### PR TITLE
fix(runner-lambda): return checkpoints

### DIFF
--- a/packages/lambda-runner/lib/index.ts
+++ b/packages/lambda-runner/lib/index.ts
@@ -101,12 +101,15 @@ export const handler = async (event: zod.infer<typeof requestSchema>, context: C
         };
         const execRes = await exec(payload);
         const telemetryBag = execRes.isErr() ? execRes.error.telemetryBag : execRes.value.telemetryBag;
+        const checkpoints = execRes.isErr() ? execRes.error.checkpoints : execRes.value.checkpoints;
         telemetryBag.durationMs = Date.now() - startTime;
         await jobsClient.putTask({
             taskId: request.taskId,
             nangoProps: request.nangoProps as unknown as NangoProps,
-            ...(execRes.isErr() ? { error: execRes.error.toJSON(), telemetryBag } : { output: execRes.value.output as any, telemetryBag }),
-            functionRuntime: 'lambda'
+            functionRuntime: 'lambda',
+            telemetryBag,
+            checkpoints,
+            ...(execRes.isErr() ? { error: execRes.error.toJSON() } : { output: execRes.value.output as any })
         });
     } catch (err: any) {
         await jobsClient.putTask({


### PR DESCRIPTION
I forgot to update `lambda-runner` so it also returns the checkpoints info. It is a bit annoying to have duplicated code

<!-- Summary by @propel-code-bot -->

---

**Return checkpoints from `lambda-runner` task results**

This PR updates the lambda runner to include checkpoint data in task results sent to the jobs service. The change aligns the lambda path with existing execution result metadata, adding `checkpoints` alongside `telemetryBag` and outputs/errors.

---
*This summary was automatically generated by @propel-code-bot*