### PR TITLE
fix(cli): ignore axios default urlencoded Content-Type in unified mocks

### DIFF
--- a/packages/cli/lib/services/response-collector.service.ts
+++ b/packages/cli/lib/services/response-collector.service.ts
@@ -65,6 +65,15 @@ export const FILTER_HEADERS: string[] = [
     'retry-on'
 ];
 
+export function isAxiosDefaultContentTypeForMockIdentity(headerKey: string, headerValue: unknown): boolean {
+    if (headerKey.toLowerCase() !== 'content-type') {
+        return false;
+    }
+
+    const normalizedValue = String(headerValue).toLowerCase();
+    return normalizedValue === 'application/json' || normalizedValue === 'undefined' || normalizedValue.startsWith('application/x-www-form-urlencoded');
+}
+
 export class ResponseCollector {
     private apiCalls: CachedRequest[] = [];
     private connectionInfo?: { connectionId: string; provider: string };
@@ -245,8 +254,10 @@ export class ResponseCollector {
                     // Skip filtered
                     if (FILTER_HEADERS.includes(lowerKey)) return false;
 
-                    // Skip application/json
-                    if (lowerKey === 'content-type' && (value.toLowerCase() === 'application/json' || value === 'undefined')) return false;
+                    // Skip default content-types injected by axios.
+                    if (isAxiosDefaultContentTypeForMockIdentity(lowerKey, value)) {
+                        return false;
+                    }
 
                     return true;
                 });

--- a/packages/cli/lib/testMocks/utils.ts
+++ b/packages/cli/lib/testMocks/utils.ts
@@ -8,7 +8,7 @@ import { vi } from 'vitest';
 import { getProvider } from '@nangohq/providers';
 import { PaginationService } from '@nangohq/runner-sdk';
 
-import { FILTER_HEADERS as FILTER_HEADERS_UNIFIED } from '../services/response-collector.service.js';
+import { FILTER_HEADERS as FILTER_HEADERS_UNIFIED, isAxiosDefaultContentTypeForMockIdentity } from '../services/response-collector.service.js';
 
 import type { CursorPagination, LinkPagination, OffsetCalculationMethod, OffsetPagination, Pagination, UserProvidedProxyConfiguration } from '@nangohq/types';
 import type { AxiosResponse } from 'axios';
@@ -427,22 +427,42 @@ class UnifiedFixtureProvider implements FixtureProvider {
                         }
                     }
 
-                    const mockHeaderCount = mock.request.headers ? Object.keys(mock.request.headers).length : 0;
-                    const requestHeaderCount = identity.requestIdentity.headers.length;
+                    const normalizeHeaderEntries = (entries: [string, unknown][]): Map<string, string> => {
+                        const normalized = new Map<string, string>();
 
-                    // Headers must match exactly (same count and same values)
-                    if (mockHeaderCount !== requestHeaderCount) {
+                        for (const [rawKey, rawValue] of entries) {
+                            const key = String(rawKey).toLowerCase();
+                            const value = String(rawValue);
+
+                            // Axios injects this content-type for POST/PUT/PATCH requests.
+                            // Treat it as optional to avoid unified mock identity mismatches.
+                            if (key === 'content-type' && isAxiosDefaultUrlEncodedContentType(value)) {
+                                continue;
+                            }
+
+                            if (!normalized.has(key)) {
+                                normalized.set(key, value);
+                            }
+                        }
+
+                        return normalized;
+                    };
+
+                    const mockHeaders = normalizeHeaderEntries(Object.entries(mock.request.headers || {}));
+                    const requestHeaders = normalizeHeaderEntries(identity.requestIdentity.headers);
+
+                    // Headers must match exactly (same keys and same values) after normalization.
+                    if (mockHeaders.size !== requestHeaders.size) {
                         return false;
                     }
 
-                    if (mock.request.headers) {
-                        for (const [key, value] of Object.entries(mock.request.headers)) {
-                            const actualHeader = identity.requestIdentity.headers.find(([k]) => k.toLowerCase() === key.toLowerCase());
-                            if (!actualHeader || String(actualHeader[1]) !== String(value)) {
-                                return false;
-                            }
+                    for (const [key, value] of mockHeaders.entries()) {
+                        const actualValue = requestHeaders.get(key);
+                        if (actualValue === undefined || String(actualValue) !== String(value)) {
+                            return false;
                         }
                     }
+
                     if (mock.request.data !== undefined) {
                         const expectedDataIdentity = computeDataIdentity({ data: mock.request.data } as UserProvidedProxyConfiguration);
                         if (expectedDataIdentity !== identity.requestIdentity.data) {
@@ -1260,9 +1280,8 @@ function normalizeHeadersForUnifiedIdentity(headers: UserProvidedProxyConfigurat
         }
 
         const value = String(rawValue);
-
         // Match ResponseCollector behavior for axios defaults.
-        if (lowerKey === 'content-type' && (value.toLowerCase() === 'application/json' || value === 'undefined')) {
+        if (isAxiosDefaultContentTypeForMockIdentity(lowerKey, value)) {
             continue;
         }
 
@@ -1271,6 +1290,10 @@ function normalizeHeadersForUnifiedIdentity(headers: UserProvidedProxyConfigurat
 
     sortEntries(filtered);
     return filtered;
+}
+
+function isAxiosDefaultUrlEncodedContentType(value: unknown): boolean {
+    return String(value).toLowerCase().startsWith('application/x-www-form-urlencoded');
 }
 
 function sortEntries(entries: [string, unknown][]): [string, unknown][] {

--- a/packages/cli/lib/testMocks/utils.unified.unit.cli-test.ts
+++ b/packages/cli/lib/testMocks/utils.unified.unit.cli-test.ts
@@ -259,6 +259,44 @@ describe('UnifiedFixtureProvider matching behavior', () => {
         expect(response.data).toEqual({ ok: true });
     });
 
+    it('ignores axios default application/x-www-form-urlencoded content-type when matching', async () => {
+        const testsDir = await createTestDir('nango-unified-ignore-form-content-type-');
+        await fs.writeFile(
+            path.join(testsDir, 'ignore-form-content-type.test.json'),
+            JSON.stringify(
+                {
+                    api: {
+                        post: {
+                            foo: [
+                                {
+                                    request: {
+                                        headers: {
+                                            'Content-Type': 'application/x-www-form-urlencoded'
+                                        }
+                                    },
+                                    response: { ok: true },
+                                    hash: ''
+                                }
+                            ]
+                        }
+                    }
+                },
+                null,
+                2
+            )
+        );
+
+        const nangoMock = new NangoActionMock({
+            dirname: testsDir,
+            name: 'ignore-form-content-type',
+            Model: 'IgnoreFormContentTypeModel'
+        });
+
+        // Deliberately omit headers; axios would inject this header at runtime.
+        const response = await nangoMock.post({ endpoint: '/foo' });
+        expect(response.data).toEqual({ ok: true });
+    });
+
     it('only applies single-mock fallback when request has no params', async () => {
         const testsDir = await createTestDir('nango-unified-fallback-');
         await fs.writeFile(


### PR DESCRIPTION
Axios injects Content-Type: application/x-www-form-urlencoded for body-less POST/PUT/PATCH requests. Unified mock recording hashes the actual axios request config, but test playback hashes the user-provided proxy config (which often omits this header), causing requestIdentityHash mismatches and strict header matching failures ("No mock found ...").

Treat the urlencoded content-type as an ignorable axios default in both recording (ResponseCollector) and unified identity normalization, and relax unified request-header matching to consider it optional.

Backwards compatibility: existing .test.json fixtures that already include the urlencoded content-type (and hashes computed with it) still match via request matching, while new recordings omit the header so identities stay stable.

Add a regression test covering the body-less POST scenario.

<!-- Describe the problem and your solution --> 

<!-- Issue ticket number and link (if applicable) -->

<!-- Testing instructions (skip if just adding/editing providers) -->


<!-- Summary by @propel-code-bot -->

---

This also introduces a shared helper to consistently detect axios default content types so recording, identity normalization, and header matching stay aligned.

---
*This summary was automatically generated by @propel-code-bot*