### PR TITLE
feat: resume sync immediately when interrupted gracefully

### DIFF
--- a/packages/jobs/lib/execution/operations/handler.ts
+++ b/packages/jobs/lib/execution/operations/handler.ts
@@ -54,8 +54,8 @@ export async function handleError({
     functionRuntime: FunctionRuntime;
     checkpoints: CheckpointRange;
 }): Promise<void> {
+    // If the function was aborted, we do nothing as the function's state has already been updated
     if (error.type === 'script_aborted') {
-        // do nothing, the script was aborted and its state already updated
         logger.info(`Script was aborted. Ignoring output.`, {
             taskId,
             syncId: nangoProps.syncId,
@@ -63,6 +63,12 @@ export async function handleError({
             providerConfigKey: nangoProps.providerConfigKey,
             connectionId: nangoProps.connectionId
         });
+        return;
+    }
+
+    // if sync was interrupted gracefully, we consider it a success
+    if (nangoProps.scriptType === 'sync' && error.type === 'execution_interrupted') {
+        await handleSyncSuccess({ taskId, nangoProps, telemetryBag, functionRuntime, checkpoints, interrupted: true });
         return;
     }
 

--- a/packages/jobs/lib/execution/sync.ts
+++ b/packages/jobs/lib/execution/sync.ts
@@ -209,7 +209,7 @@ export async function startSync(task: TaskSync, startScriptFn = startScript): Pr
                 ? {
                       lifecycle: {
                           interruptAfterMs: envs.LAMBDA_EXECUTION_TIMEOUT_SECS * envs.LAMBDA_EXECUTION_INTERRUPT_AFTER_MULTIPLIER * 1000,
-                          killAfterMs: envs.LAMBDA_EXECUTION_TIMEOUT_SECS * envs.LAMBDA_EXECUTION_KILL_AFTER_MULTIPLER * 1000
+                          killAfterMs: envs.LAMBDA_EXECUTION_TIMEOUT_SECS * envs.LAMBDA_EXECUTION_KILL_AFTER_MULTIPLIER * 1000
                       }
                   }
                 : {}) // non-lambda runtimes do not need interrupting/resuming long-running executions

--- a/packages/jobs/lib/execution/sync.ts
+++ b/packages/jobs/lib/execution/sync.ts
@@ -261,13 +261,15 @@ export async function handleSyncSuccess({
     nangoProps,
     telemetryBag,
     functionRuntime,
-    checkpoints
+    checkpoints,
+    interrupted = false
 }: {
     taskId: string;
     nangoProps: NangoProps;
     telemetryBag: TelemetryBag;
     functionRuntime: FunctionRuntime;
     checkpoints: CheckpointRange;
+    interrupted?: boolean;
 }): Promise<void> {
     const logCtx = logContextGetter.get({ id: nangoProps.activityLogId, accountId: nangoProps.team.id });
     logCtx.attachSpan(
@@ -486,7 +488,8 @@ export async function handleSyncSuccess({
         await logCtx.enrichOperation({
             meta: {
                 ...syncPayload,
-                checkpoints
+                checkpoints,
+                interrupted
             }
         });
 
@@ -494,7 +497,8 @@ export async function handleSyncSuccess({
             `${nangoProps.syncConfig.sync_type ? nangoProps.syncConfig.sync_type.replace(/^./, (c) => c.toUpperCase()) : 'The '} sync '${nangoProps.syncConfig.sync_name}' completed successfully`,
             {
                 ...syncPayload,
-                checkpoints
+                checkpoints,
+                interrupted
             }
         );
 
@@ -506,7 +510,11 @@ export async function handleSyncSuccess({
         if (nangoProps.syncJobId) {
             await updateSyncJobStatus(nangoProps.syncJobId, SyncStatus.SUCCESS);
         }
-        await setTaskSuccess({ taskId, output: null });
+        await setTaskSuccess({
+            taskId,
+            output: null,
+            ...(interrupted ? { nextExecutionInMs: 0 } : {}) // if the sync was interrupted, we trigger next execution immediately
+        });
 
         void slackService.removeFailingConnection({
             connection,

--- a/packages/jobs/lib/execution/sync.ts
+++ b/packages/jobs/lib/execution/sync.ts
@@ -31,6 +31,7 @@ import { Err, Ok, getFrequencyMs, tagTraceUser } from '@nangohq/utils';
 import { sendSync as sendSyncWebhook } from '@nangohq/webhooks';
 
 import { bigQueryClient, orchestratorClient, slackService } from '../clients.js';
+import { envs } from '../env.js';
 import { logger } from '../logger.js';
 import { capping } from '../utils/capping.js';
 import { abortTaskWithId } from './operations/abort.js';
@@ -203,7 +204,15 @@ export async function startSync(task: TaskSync, startScriptFn = startScript): Pr
             integrationConfig: {
                 oauth_client_id: providerConfig.oauth_client_id,
                 oauth_client_secret: providerConfig.oauth_client_secret
-            }
+            },
+            ...(plan?.sync_function_runtime === 'lambda'
+                ? {
+                      lifecycle: {
+                          interruptAfterMs: envs.LAMBDA_EXECUTION_TIMEOUT_SECS * envs.LAMBDA_EXECUTION_INTERRUPT_AFTER_MULTIPLIER * 1000,
+                          killAfterMs: envs.LAMBDA_EXECUTION_TIMEOUT_SECS * envs.LAMBDA_EXECUTION_KILL_AFTER_MULTIPLER * 1000
+                      }
+                  }
+                : {}) // non-lambda runtimes do not need interrupting/resuming long-running executions
         };
 
         const runtimeContext: RuntimeContext = {

--- a/packages/utils/lib/environment/parse.ts
+++ b/packages/utils/lib/environment/parse.ts
@@ -417,7 +417,7 @@ export const ENVS = z.object({
     LAMBDA_CREATE_TIMEOUT_SECS: z.coerce.number().optional().default(120),
     LAMBDA_EXECUTION_TIMEOUT_SECS: z.coerce.number().optional().default(900),
     LAMBDA_EXECUTION_INTERRUPT_AFTER_MULTIPLIER: z.coerce.number().optional().default(0.8), // interrupt execution after 80% of the timeout, to leave time for checkpointing and graceful shutdown
-    LAMBDA_EXECUTION_KILL_AFTER_MULTIPLER: z.coerce.number().optional().default(0.95), // force kill the lambda after 95% of the timeout, to allow for runner-controlled shutdown
+    LAMBDA_EXECUTION_KILL_AFTER_MULTIPLIER: z.coerce.number().optional().default(0.95), // force kill the lambda after 95% of the timeout, to allow for runner-controlled shutdown
     LAMBDA_FUNCTION_ALIAS: z.string().optional().default('latest'),
     LAMBDA_PROVISIONED_CONCURRENCY: z.coerce.number().optional().default(1),
     LAMBDA_PROVISIONED_CONCURRENCY_SCALING_TARGET: z.coerce.number().optional().default(0.7),

--- a/packages/utils/lib/environment/parse.ts
+++ b/packages/utils/lib/environment/parse.ts
@@ -416,6 +416,8 @@ export const ENVS = z.object({
     LAMBDA_ARCHITECTURE: z.enum(['arm64', 'x86_64']).optional().default('arm64'),
     LAMBDA_CREATE_TIMEOUT_SECS: z.coerce.number().optional().default(120),
     LAMBDA_EXECUTION_TIMEOUT_SECS: z.coerce.number().optional().default(900),
+    LAMBDA_EXECUTION_INTERRUPT_AFTER_MULTIPLIER: z.coerce.number().optional().default(0.8), // interrupt execution after 80% of the timeout, to leave time for checkpointing and graceful shutdown
+    LAMBDA_EXECUTION_KILL_AFTER_MULTIPLER: z.coerce.number().optional().default(0.95), // force kill the lambda after 95% of the timeout, to allow for runner-controlled shutdown
     LAMBDA_FUNCTION_ALIAS: z.string().optional().default('latest'),
     LAMBDA_PROVISIONED_CONCURRENCY: z.coerce.number().optional().default(1),
     LAMBDA_PROVISIONED_CONCURRENCY_SCALING_TARGET: z.coerce.number().optional().default(0.7),


### PR DESCRIPTION
- Treats the "execution interrupted" error for sync (aka: interrupted after checkpointing) as a success and trigger next execution asap.
- Set function lifecycle timeouts when running in Lambda

<!-- Describe the problem and your solution --> 

<!-- Issue ticket number and link (if applicable) -->

<!-- Testing instructions (skip if just adding/editing providers) -->


<!-- Summary by @propel-code-bot -->

---

It also routes this interrupted-success path through the sync success handler with an explicit interrupted flag, enriches logs with that state, and passes the lifecycle timeout configuration into the Lambda runtime properties.

---
*This summary was automatically generated by @propel-code-bot*