### PR TITLE
fix(webapp): long wait time after Sign in

### DIFF
--- a/packages/webapp/src/App.tsx
+++ b/packages/webapp/src/App.tsx
@@ -9,6 +9,7 @@ import { SWRConfig } from 'swr';
 
 import { PrivateRoute } from './components/PrivateRoute';
 import { useMeta } from './hooks/useMeta';
+import { useUser } from './hooks/useUser';
 import { EmailVerified } from './pages/Account/EmailVerified';
 import ForgotPassword from './pages/Account/ForgotPassword';
 import { InviteSignup } from './pages/Account/InviteSignup';
@@ -286,7 +287,9 @@ const App = () => {
     const signout = useSignout();
     const setShowGettingStarted = useStore((state) => state.setShowGettingStarted);
     const [_, setLastEnvironment] = useLocalStorage(LocalStorageKeys.LastEnvironment);
-    const { meta } = useMeta();
+    const { user } = useUser();
+    const { data: metaData } = useMeta(!!user);
+    const meta = metaData?.data;
 
     useEffect(() => {
         setShowGettingStarted(env === 'dev' && globalEnv.features.gettingStarted);

--- a/packages/webapp/src/components-v2/AppSidebar/CreateEnvironmentDialog.tsx
+++ b/packages/webapp/src/components-v2/AppSidebar/CreateEnvironmentDialog.tsx
@@ -37,7 +37,7 @@ export const CreateEnvironmentDialog: React.FC<CreateEnvironmentDialogProps> = (
 
     const { toast } = useToast();
     const navigate = useNavigate();
-    const { mutate: mutateMeta } = useMeta();
+    const { refetch: refetchMeta } = useMeta();
 
     const [loading, setLoading] = useState(false);
 
@@ -58,7 +58,7 @@ export const CreateEnvironmentDialog: React.FC<CreateEnvironmentDialogProps> = (
             navigate(`/${res.json.data.name}`);
             onOpenChange(false);
             form.reset();
-            void mutateMeta();
+            void refetchMeta();
         }
 
         setLoading(false);

--- a/packages/webapp/src/components-v2/AppSidebar/EnvironmentDropdown.tsx
+++ b/packages/webapp/src/components-v2/AppSidebar/EnvironmentDropdown.tsx
@@ -18,7 +18,8 @@ export const EnvironmentDropdown: React.FC = () => {
     const setEnv = useStore((state) => state.setEnv);
     const envs = useStore((state) => state.envs);
     const environment = useEnvironment(env);
-    const { meta } = useMeta();
+    const { data: metaData } = useMeta();
+    const meta = metaData?.data;
     const [environmentDialogOpen, setEnvironmentDialogOpen] = useState(false);
 
     const navigate = useNavigate();

--- a/packages/webapp/src/components-v2/AppSidebar/ProfileDropdown.tsx
+++ b/packages/webapp/src/components-v2/AppSidebar/ProfileDropdown.tsx
@@ -14,7 +14,8 @@ import { useSignout } from '@/utils/user';
 export const ProfileDropdown: React.FC = () => {
     const env = useStore((state) => state.env);
 
-    const { meta } = useMeta();
+    const { data: metaData } = useMeta();
+    const meta = metaData?.data;
     const navigate = useNavigate();
     const signout = useSignout();
     const { user } = useUser();

--- a/packages/webapp/src/components-v2/AppSidebar/index.tsx
+++ b/packages/webapp/src/components-v2/AppSidebar/index.tsx
@@ -33,7 +33,8 @@ interface SidebarItem {
 
 export const AppSidebar: React.FC = () => {
     const env = useStore((state) => state.env);
-    const { meta, mutate: mutateMeta } = useMeta();
+    const { data: metaData, refetch: refetchMeta } = useMeta();
+    const meta = metaData?.data;
     const showGettingStarted = useStore((state) => state.showGettingStarted);
     const { plan } = useEnvironment(env);
 
@@ -46,7 +47,7 @@ export const AppSidebar: React.FC = () => {
                 await apiPatchUser({
                     gettingStartedClosed: true
                 });
-                void mutateMeta();
+                void refetchMeta();
             }
         };
 
@@ -58,7 +59,7 @@ export const AppSidebar: React.FC = () => {
             { title: 'Metrics', url: `/${env}`, icon: AreaChart },
             { title: 'Environment settings', url: `/${env}/environment-settings`, icon: Settings2 }
         ].filter((item) => item !== null);
-    }, [env, meta, mutateMeta, showGettingStarted]);
+    }, [env, meta, refetchMeta, showGettingStarted]);
 
     const showUsageCard = useMemo(() => {
         if (!plan) return false;

--- a/packages/webapp/src/components/PrivateRoute.tsx
+++ b/packages/webapp/src/components/PrivateRoute.tsx
@@ -79,15 +79,15 @@ export const PrivateRoute: React.FC = () => {
         }
     }, [user, environmentAndAccount, meta, identify]);
 
+    if (userError || metaError) {
+        return <Navigate to="/signin" replace />;
+    }
     if (loadingUser || loadingMeta || !ready) {
         return null;
     }
 
     if (notFoundEnv) {
         return <PageNotFound />;
-    }
-    if (userError || metaError) {
-        return <Navigate to="/signin" replace />;
     }
 
     return <Outlet />;

--- a/packages/webapp/src/components/PrivateRoute.tsx
+++ b/packages/webapp/src/components/PrivateRoute.tsx
@@ -9,10 +9,11 @@ import { useStore } from '../store';
 import { useAnalyticsIdentify } from '../utils/analytics';
 
 export const PrivateRoute: React.FC = () => {
-    const { meta, error, loading: loadingMeta } = useMeta();
+    const { user, loading: loadingUser, error: userError } = useUser();
+    const { data, error: metaError, isLoading: loadingMeta } = useMeta(!!user);
+    const meta = data?.data;
     const [notFoundEnv, setNotFoundEnv] = useState(false);
     const [ready, setReady] = useState(false);
-    const { user, loading: loadingUser } = useUser(Boolean(meta && ready && !notFoundEnv));
     const identify = useAnalyticsIdentify();
 
     const env = useStore((state) => state.env);
@@ -23,7 +24,7 @@ export const PrivateRoute: React.FC = () => {
     const { environmentAndAccount } = useEnvironment(env);
 
     useEffect(() => {
-        if (!meta || error) {
+        if (!meta || metaError) {
             return;
         }
 
@@ -31,10 +32,10 @@ export const PrivateRoute: React.FC = () => {
         setBaseUrl(meta.baseUrl);
         setDebugMode(meta.debugMode);
         // eslint-disable-next-line react-hooks/exhaustive-deps
-    }, [meta, error]);
+    }, [meta, metaError]);
 
     useEffect(() => {
-        if (!meta || error) {
+        if (!meta || metaError) {
             return;
         }
 
@@ -70,7 +71,7 @@ export const PrivateRoute: React.FC = () => {
 
         // it's ready when datastore and path are finally reconciliated
         setReady(true);
-    }, [meta, loadingMeta, env, error, setEnv]);
+    }, [meta, loadingMeta, env, metaError, setEnv]);
 
     useEffect(() => {
         if (user && environmentAndAccount && meta && !meta.debugMode) {
@@ -78,14 +79,14 @@ export const PrivateRoute: React.FC = () => {
         }
     }, [user, environmentAndAccount, meta, identify]);
 
-    if (loadingMeta || !ready || loadingUser) {
+    if (loadingUser || loadingMeta || !ready) {
         return null;
     }
 
     if (notFoundEnv) {
         return <PageNotFound />;
     }
-    if (error) {
+    if (userError || metaError) {
         return <Navigate to="/signin" replace />;
     }
 

--- a/packages/webapp/src/hooks/useMeta.tsx
+++ b/packages/webapp/src/hooks/useMeta.tsx
@@ -1,19 +1,26 @@
-import useSWR from 'swr';
+import { useQuery } from '@tanstack/react-query';
 
-import { swrFetcher } from '../utils/api';
+import { APIError, apiFetch } from '../utils/api';
 
-import type { SWRError } from '../utils/api';
 import type { GetMeta } from '@nangohq/types';
 
-export function useMeta() {
-    const { data, error, mutate } = useSWR<GetMeta['Success'], SWRError<GetMeta['Errors']>>('/api/v1/meta', swrFetcher);
+export const metaQueryKey = ['meta'] as const;
 
-    const loading = !data && !error;
+export function useMeta(enabled: boolean = true) {
+    return useQuery<GetMeta['Success'], APIError>({
+        enabled,
+        queryKey: metaQueryKey,
+        queryFn: async (): Promise<GetMeta['Success']> => {
+            const res = await apiFetch('/api/v1/meta', {
+                method: 'GET'
+            });
 
-    return {
-        loading,
-        error,
-        meta: data?.data,
-        mutate
-    };
+            const json = (await res.json()) as GetMeta['Reply'];
+            if (!res.ok || 'error' in json) {
+                throw new APIError({ res, json });
+            }
+
+            return json;
+        }
+    });
 }

--- a/packages/webapp/src/hooks/useUser.tsx
+++ b/packages/webapp/src/hooks/useUser.tsx
@@ -1,21 +1,34 @@
-import useSWR from 'swr';
+import { useQuery } from '@tanstack/react-query';
 
-import { apiFetch, swrFetcher } from '../utils/api';
+import { APIError, apiFetch } from '../utils/api';
 
-import type { SWRError } from '../utils/api';
 import type { GetUser, PatchUser } from '@nangohq/types';
-import type { SWRConfiguration } from 'swr';
 
-export function useUser(enabled: boolean = true, options?: SWRConfiguration) {
-    const { data, error, mutate, isLoading } = useSWR<GetUser['Success'], SWRError<GetUser['Errors']>>(enabled ? '/api/v1/user' : null, swrFetcher, options);
+export const userQueryKey = ['user'] as const;
 
-    const loading = !data && !error && isLoading;
+export function useUser(enabled: boolean = true) {
+    const query = useQuery<GetUser['Success'], APIError>({
+        enabled,
+        queryKey: userQueryKey,
+        queryFn: async (): Promise<GetUser['Success']> => {
+            const res = await apiFetch('/api/v1/user', {
+                method: 'GET'
+            });
+
+            const json = (await res.json()) as GetUser['Reply'];
+            if (!res.ok || 'error' in json) {
+                throw new APIError({ res, json });
+            }
+
+            return json;
+        }
+    });
 
     return {
-        loading,
-        error: error?.json,
-        user: data?.data,
-        mutate
+        loading: query.isLoading,
+        error: query.error?.json,
+        user: query.data?.data,
+        mutate: query.refetch
     };
 }
 

--- a/packages/webapp/src/pages/Account/InviteSignup.tsx
+++ b/packages/webapp/src/pages/Account/InviteSignup.tsx
@@ -18,7 +18,7 @@ export const InviteSignup: React.FC = () => {
     const navigate = useNavigate();
     const signout = useSignout();
 
-    const { user: isLogged } = useUser(true);
+    const { user: isLogged } = useUser();
     const { data: inviteResponse, error: inviteError, isPending: _isInvitePending } = useInvite(token);
     const [loadingDecline, setLoadingDecline] = useState(false);
     const [loadingAccept, setLoadingAccept] = useState(false);

--- a/packages/webapp/src/pages/Account/InviteSignup.tsx
+++ b/packages/webapp/src/pages/Account/InviteSignup.tsx
@@ -18,7 +18,7 @@ export const InviteSignup: React.FC = () => {
     const navigate = useNavigate();
     const signout = useSignout();
 
-    const { user: isLogged } = useUser(true, { onError: () => null });
+    const { user: isLogged } = useUser(true);
     const { data: inviteResponse, error: inviteError, isPending: _isInvitePending } = useInvite(token);
     const [loadingDecline, setLoadingDecline] = useState(false);
     const [loadingAccept, setLoadingAccept] = useState(false);

--- a/packages/webapp/src/pages/Environment/Settings/General.tsx
+++ b/packages/webapp/src/pages/Environment/Settings/General.tsx
@@ -18,7 +18,7 @@ export const General: React.FC = () => {
 
     const env = useStore((state) => state.env);
     const setEnv = useStore((state) => state.setEnv);
-    const { mutate: mutateMeta } = useMeta();
+    const { refetch: refetchMeta } = useMeta();
 
     const [showDeleteAlert, setShowDeleteAlert] = useState(false);
     const { toast } = useToast();
@@ -29,7 +29,7 @@ export const General: React.FC = () => {
             setShowDeleteAlert(false);
             // We have to start by changing the url, otherwise PrivateRoute will revert the env based on it.
             navigate(`/${PROD_ENVIRONMENT_NAME}/environment-settings`);
-            await mutateMeta();
+            await refetchMeta();
             setEnv(PROD_ENVIRONMENT_NAME);
         } else {
             toast({
@@ -49,7 +49,7 @@ export const General: React.FC = () => {
                     onSuccess={async (newName) => {
                         // We have to start by changing the url, otherwise PrivateRoute will revert the env based on it.
                         navigate(`/${newName}/environment-settings`);
-                        await mutateMeta();
+                        await refetchMeta();
                         setEnv(newName);
                     }}
                     blocked={env === PROD_ENVIRONMENT_NAME}

--- a/packages/webapp/src/pages/Homepage/Show.tsx
+++ b/packages/webapp/src/pages/Homepage/Show.tsx
@@ -8,7 +8,8 @@ import DashboardLayout from '../../layout/DashboardLayout';
 import { globalEnv } from '../../utils/env';
 
 export const Homepage: React.FC = () => {
-    const { meta } = useMeta();
+    const { data: metaData } = useMeta();
+    const meta = metaData?.data;
     const { user: me } = useUser();
 
     if (!me || !meta) {

--- a/packages/webapp/src/pages/Root.tsx
+++ b/packages/webapp/src/pages/Root.tsx
@@ -3,6 +3,7 @@ import { useLocation, useNavigate } from 'react-router-dom';
 
 import { PROD_ENVIRONMENT_NAME } from '../constants';
 import { useMeta } from '../hooks/useMeta';
+import { useUser } from '../hooks/useUser';
 import { useStore } from '../store';
 
 export const Root: React.FC = () => {
@@ -11,10 +12,19 @@ export const Root: React.FC = () => {
 
     const showGettingStarted = useStore((state) => state.showGettingStarted);
     const env = useStore((state) => state.env);
-    const { meta } = useMeta();
+    const { user, loading: isLoadingUser, error: userError } = useUser();
+    const { data: metaData } = useMeta(!!user);
+    const meta = metaData?.data;
     const hasDev = meta?.environments.some((e) => e.name === 'dev');
 
     useEffect(() => {
+        if (isLoadingUser) {
+            return;
+        }
+        if (userError || !user) {
+            navigate('/signin');
+            return;
+        }
         if (!meta) {
             return;
         }
@@ -39,7 +49,7 @@ export const Root: React.FC = () => {
         }
 
         navigate(`/${env}/`);
-    }, [meta, location, env, navigate, showGettingStarted]);
+    }, [isLoadingUser, userError, user, meta, hasDev, location, env, navigate, showGettingStarted]);
 
     return null;
 };

--- a/packages/webapp/src/pages/User/Settings.tsx
+++ b/packages/webapp/src/pages/User/Settings.tsx
@@ -2,7 +2,6 @@ import { Pencil1Icon } from '@radix-ui/react-icons';
 import { useRef, useState } from 'react';
 import { Helmet } from 'react-helmet';
 
-import { ErrorPageComponent } from '../../components/ErrorComponent';
 import { Skeleton } from '../../components/ui/Skeleton';
 import { Tooltip, TooltipContent, TooltipTrigger } from '../../components/ui/Tooltip';
 import { Button } from '../../components/ui/button/Button';
@@ -10,6 +9,7 @@ import { Input } from '../../components/ui/input/Input';
 import { useToast } from '../../hooks/useToast';
 import { apiPatchUser, useUser } from '../../hooks/useUser';
 import DashboardLayout from '../../layout/DashboardLayout';
+import { CriticalErrorAlert } from '@/components-v2/CriticalErrorAlert';
 
 export const UserSettings: React.FC = () => {
     const { toast } = useToast();
@@ -47,7 +47,7 @@ export const UserSettings: React.FC = () => {
     }
 
     if (error) {
-        return <ErrorPageComponent title="Profile Settings" error={error} />;
+        return <CriticalErrorAlert message="Failed to load profile settings" />;
     }
 
     if (!user) {


### PR DESCRIPTION
After signing in, an empty screen would be displayed for several seconds at random. When inspecting the network tab, it lined up with a call to `/meta`. Essentially, it was tied to the refetchInterval of swr, which is 15 secs. So depending on what chunk of that window you were on, it would take up to 15 secs. 

In general, the way we detect being logged in was a bit messed up, so I'm changing it by:
- Migrating `useMeta` and `useUser` to tanstack query
- Using `useUser` as the way to check if we have a valid session
- Only enable `useMeta` in `Root.tsx` and `PrivateRoute.tsx` if we have a valid user. Otherwise redirect to `/signin`

Signing in is now instant as it should be.

<!-- Summary by @propel-code-bot -->

---

This PR addresses the intermittent blank screen after sign-in by changing session detection and fetch timing. It migrates `useMeta` and `useUser` from `swr` to `@tanstack/react-query`, then uses `useUser` as the session source of truth and only enables `useMeta` when a user is present in `Root` and `PrivateRoute`.

---
*This summary was automatically generated by @propel-code-bot*