### PR TITLE
fix(runner): correct env var name for conflict resolution mode

### DIFF
--- a/packages/jobs/lib/runner/kubernetes.ts
+++ b/packages/jobs/lib/runner/kubernetes.ts
@@ -425,7 +425,7 @@ class Kubernetes {
             { name: 'JOBS_SERVICE_URL', value: getJobsUrl() },
             { name: 'PROVIDERS_URL', value: getProvidersUrl() },
             { name: 'PROVIDERS_RELOAD_INTERVAL', value: envs.PROVIDERS_RELOAD_INTERVAL.toString() },
-            ...(node.replicas > 1 ? [{ name: 'RUNNER_CONFLICT_FUNCTION_MODE', value: 'REDIS' }] : [])
+            ...(node.replicas > 1 ? [{ name: 'RUNNER_CONFLICT_RESOLUTION_MODE', value: 'REDIS' }] : [])
         ];
     }
 


### PR DESCRIPTION
<!-- Describe the problem and your solution --> 

<!-- Issue ticket number and link (if applicable) -->

<!-- Testing instructions (skip if just adding/editing providers) -->


<!-- Summary by @propel-code-bot -->

---

**Fix runner conflict resolution env var name**

This PR updates the runner Kubernetes environment variable name used for conflict resolution mode when multiple replicas are deployed. The change aligns the variable from the incorrect `RUNNER_CONFLICT_FUNCTION_MODE` to the intended `RUNNER_CONFLICT_RESOLUTION_MODE` in `packages/jobs/lib/runner/kubernetes.ts`.

---
*This summary was automatically generated by @propel-code-bot*