### PR TITLE
fix(runner): pass redis url

### DIFF
--- a/packages/jobs/lib/runner/kubernetes.ts
+++ b/packages/jobs/lib/runner/kubernetes.ts
@@ -425,7 +425,12 @@ class Kubernetes {
             { name: 'JOBS_SERVICE_URL', value: getJobsUrl() },
             { name: 'PROVIDERS_URL', value: getProvidersUrl() },
             { name: 'PROVIDERS_RELOAD_INTERVAL', value: envs.PROVIDERS_RELOAD_INTERVAL.toString() },
-            ...(node.replicas > 1 ? [{ name: 'RUNNER_CONFLICT_RESOLUTION_MODE', value: 'REDIS' }] : [])
+            ...(node.replicas > 1
+                ? [
+                      { name: 'RUNNER_CONFLICT_RESOLUTION_MODE', value: 'REDIS' },
+                      { name: 'NANGO_CUSTOMER_REDIS_URL', value: envs.NANGO_CUSTOMER_REDIS_URL || envs.NANGO_REDIS_URL || '' }
+                  ]
+                : [])
         ];
     }
 


### PR DESCRIPTION
<!-- Describe the problem and your solution --> 

<!-- Issue ticket number and link (if applicable) -->

<!-- Testing instructions (skip if just adding/editing providers) -->


<!-- Summary by @propel-code-bot -->

---

**Pass Redis URL to multi-replica runner deployments**

This PR updates the Kubernetes runner deployment to include a Redis URL environment variable when running with multiple replicas. The change extends the existing conflict resolution configuration so the runner can resolve conflicts using a provided Redis endpoint.

---
*This summary was automatically generated by @propel-code-bot*