### PR TITLE
fix: build lambda on arm64 github runner

### DIFF
--- a/.github/workflows/deploy.yaml
+++ b/.github/workflows/deploy.yaml
@@ -207,7 +207,7 @@ jobs:
                     --data "{ \"image\": \"nangohq/nango:${{ github.sha }}\", \"imageType\":\"docker\" }"
     deploy_lambda:
         if: inputs.service == 'lambda' && inputs.stage != 'replit'
-        runs-on: ubuntu-latest
+        runs-on: ubuntu-24.04-arm
         permissions:
             id-token: write
             contents: read
@@ -215,8 +215,6 @@ jobs:
         steps:
             - name: Checkout
               uses: actions/checkout@v4
-            - name: Set up QEMU
-              uses: docker/setup-qemu-action@v3
             - name: Set up Docker Buildx
               uses: docker/setup-buildx-action@v3
             - name: Configure aws credentials


### PR DESCRIPTION
building runner-lambda for arm64 architecture on a amd64 runner is super slow since it is using QEMU emulation.
Ensuring the github runner uses arm arch OS

much better: https://github.com/NangoHQ/nango/actions/runs/22924327696/job/66530698225

<!-- Describe the problem and your solution --> 

<!-- Issue ticket number and link (if applicable) -->

<!-- Testing instructions (skip if just adding/editing providers) -->


<!-- Summary by @propel-code-bot -->

---

This updates the `deploy_lambda` workflow to run on a native ARM runner, eliminating the need for QEMU emulation and speeding up ARM64 image builds.

---
*This summary was automatically generated by @propel-code-bot*