### PR TITLE
fix(webapp): SignIn autoComplete

### DIFF
--- a/packages/webapp/src/components-v2/ui/input.tsx
+++ b/packages/webapp/src/components-v2/ui/input.tsx
@@ -2,7 +2,8 @@ import * as React from 'react';
 
 import { cn } from '@/utils/utils';
 
-const Input = React.forwardRef<HTMLInputElement, React.ComponentProps<'input'>>(({ className, type, ...props }, ref) => {
+const Input = React.forwardRef<HTMLInputElement, React.ComponentProps<'input'>>(({ className, type, autoComplete, ...props }, ref) => {
+    const blockPasswordManager = !autoComplete || autoComplete === 'off';
     return (
         <input
             ref={ref}
@@ -15,10 +16,8 @@ const Input = React.forwardRef<HTMLInputElement, React.ComponentProps<'input'>>(
                 'aria-invalid:focus-error aria-invalid:border-feedback-error-border',
                 className
             )}
-            autoComplete="off"
-            data-1p-ignore
-            data-lpignore="true"
-            data-protonpass-ignore="true"
+            autoComplete={autoComplete ?? 'off'}
+            {...(blockPasswordManager ? { 'data-1p-ignore': true, 'data-lpignore': 'true', 'data-protonpass-ignore': 'true' } : {})}
             {...props}
         />
     );

--- a/packages/webapp/src/pages/Account/Signin.tsx
+++ b/packages/webapp/src/pages/Account/Signin.tsx
@@ -130,7 +130,7 @@ export const Signin: React.FC = () => {
                                     <FormItem>
                                         <FormControl>
                                             <InputGroup className="h-11">
-                                                <InputGroupInput placeholder="Email" {...field} aria-invalid={!!fieldState.error} />
+                                                <InputGroupInput placeholder="Email" autoComplete="email" {...field} aria-invalid={!!fieldState.error} />
                                             </InputGroup>
                                         </FormControl>
                                         <FormMessage />

--- a/packages/webapp/src/pages/Account/components/SignupForm.tsx
+++ b/packages/webapp/src/pages/Account/components/SignupForm.tsx
@@ -127,7 +127,7 @@ export const SignupForm: React.FC<{ invitation?: ApiInvitation; token?: string }
                                 <FormItem>
                                     <FormControl>
                                         <InputGroup className="h-11">
-                                            <InputGroupInput placeholder="Name" {...field} aria-invalid={!!fieldState.error} />
+                                            <InputGroupInput placeholder="Name" autoComplete="name" {...field} aria-invalid={!!fieldState.error} />
                                         </InputGroup>
                                     </FormControl>
                                     <FormMessage />
@@ -141,7 +141,13 @@ export const SignupForm: React.FC<{ invitation?: ApiInvitation; token?: string }
                                 <FormItem>
                                     <FormControl>
                                         <InputGroup className="h-11">
-                                            <InputGroupInput disabled={!!invitation?.email} placeholder="Email" {...field} aria-invalid={!!fieldState.error} />
+                                            <InputGroupInput
+                                                disabled={!!invitation?.email}
+                                                placeholder="Email"
+                                                autoComplete="email"
+                                                {...field}
+                                                aria-invalid={!!fieldState.error}
+                                            />
                                         </InputGroup>
                                     </FormControl>
                                     <FormMessage />


### PR DESCRIPTION
<!-- Summary by @propel-code-bot -->

**Fix autocomplete handling for account inputs**

This PR updates the shared `Input` component to honor the `autoComplete` prop while only blocking password managers when autocomplete is unset or explicitly off. It also sets appropriate `autoComplete` values for name and email fields in signup and signin forms to improve browser autofill behavior.

---
*This summary was automatically generated by @propel-code-bot*