### PR TITLE
feat: new free accounts default to lambda runtime for syncs

### DIFF
--- a/docs/implementation-guides/use-cases/syncs/checkpoints.mdx
+++ b/docs/implementation-guides/use-cases/syncs/checkpoints.mdx
@@ -19,9 +19,26 @@ Checkpoints solve this by tracking how far your sync has progressed. The benefit
 - **Lower costs** — Less compute time on Nango, fewer API calls against the external API's rate limits, and lower bandwidth consumption.
 - **Higher freshness** — Faster syncs mean you can run them more frequently, keeping your data closer to real-time.
 
+# Function interruption and resumption
+
+By default, functions have a capped execution duration. When a function reaches the limit, Nango interrupts it gracefully and schedules the next execution to start immediately.
+
+Checkpoints are what make this seamless: the next execution should call `getCheckpoint()` and resumes from where the previous one stopped. **Without checkpoints, each execution starts from scratch**, meaning any function that takes longer than the execution cap will loop indefinitely without ever completing.
+
+<Warning>
+If your sync processes a large dataset, you must call `saveCheckpoint()` after every `batchSave`. A sync without checkpoints that exceeds the execution duration will restart from the beginning on every run and never finish.
+</Warning>
+
+The interrupt-and-resume flow:
+
+1. Sync runs, processes records, saves a checkpoint after each page.
+2. Nango interrupts the sync gracefully when the execution cap is reached (ie: after the current `saveCheckpoint()` call completes).
+3. The next execution starts immediately, calls `getCheckpoint()`, and continues from that point.
+4. This repeats until the sync finishes naturally.
+
 # How checkpoints work
 
-A checkpoint is a small payload — defined by a schema you control — that your sync saves after processing each batch of data. On the next execution, the sync reads the checkpoint to know where it left off.
+A checkpoint is a small payload, defined by a schema you control,  that your sync saves after processing each batch of data. On the next execution, the sync reads the checkpoint to know where it left off.
 
 The typical flow is:
 

--- a/docs/implementation-guides/use-cases/syncs/checkpoints.mdx
+++ b/docs/implementation-guides/use-cases/syncs/checkpoints.mdx
@@ -21,7 +21,7 @@ Checkpoints solve this by tracking how far your sync has progressed. The benefit
 
 # Function interruption and resumption
 
-By default, functions have a capped execution duration. When a function reaches the limit, Nango interrupts it gracefully and schedules the next execution to start immediately.
+Nango reserves the right to cap the duration of a function execution. When an execution reaches the limit, Nango interrupts it gracefully and schedules the next execution to start immediately.
 
 Checkpoints are what make this seamless: the next execution should call `getCheckpoint()` and resumes from where the previous one stopped. **Without checkpoints, each execution starts from scratch**, meaning any function that takes longer than the execution cap will loop indefinitely without ever completing.
 

--- a/packages/shared/lib/services/plans/definitions.ts
+++ b/packages/shared/lib/services/plans/definitions.ts
@@ -29,8 +29,10 @@ export const freePlan: PlanDefinition = {
         can_override_docs_connect_url: false,
         can_customize_connect_ui_theme: false,
         can_disable_connect_ui_watermark: false,
+        sync_function_runtime: 'lambda',
         action_function_runtime: 'lambda',
-        webhook_function_runtime: 'lambda'
+        webhook_function_runtime: 'lambda',
+        on_event_function_runtime: 'lambda'
     }
 };
 


### PR DESCRIPTION
first stage of the migration: new free accounts sync runtime defaults to `lambda`. 
No changes for existing customers (paying or not)

<!-- Summary by @propel-code-bot -->

---

It also updates the free plan defaults for on‑event function runtimes to `lambda` and expands the checkpoints documentation to explain interruption/resumption behavior and required checkpoint usage to avoid restart loops.

---
*This summary was automatically generated by @propel-code-bot*