### PR TITLE
feat(webhooks): store emailAddress on Gmail/Calendar connection config for webhook routing

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -34475,6 +34475,7 @@
             "version": "1.0.0",
             "license": "SEE LICENSE IN LICENSE FILE IN GIT REPOSITORY",
             "dependencies": {
+                "@nangohq/kvstore": "file:../kvstore",
                 "@nangohq/node": "file:../node-client",
                 "@nangohq/providers": "file:../providers",
                 "@nangohq/runner-sdk": "file:../runner-sdk",

--- a/package-lock.json
+++ b/package-lock.json
@@ -34475,7 +34475,6 @@
             "version": "1.0.0",
             "license": "SEE LICENSE IN LICENSE FILE IN GIT REPOSITORY",
             "dependencies": {
-                "@nangohq/kvstore": "file:../kvstore",
                 "@nangohq/node": "file:../node-client",
                 "@nangohq/providers": "file:../providers",
                 "@nangohq/runner-sdk": "file:../runner-sdk",

--- a/packages/providers/providers.yaml
+++ b/packages/providers/providers.yaml
@@ -7132,6 +7132,7 @@ google-calendar:
                 - '401'
                 - '429'
     webhook_routing_script: googleCalendarWebhookRouting
+    post_connection_script: googleCalendarPostConnection
     docs: https://nango.dev/docs/api-integrations/google-calendar
     setup_guide_url: https://nango.dev/docs/api-integrations/google-calendar/how-to-register-your-own-google-calendar-api-oauth-app
 
@@ -7163,6 +7164,7 @@ google-mail:
     proxy:
         base_url: https://gmail.googleapis.com
     webhook_routing_script: gmailWebhookRouting
+    post_connection_script: googleMailPostConnection
     docs: https://nango.dev/docs/api-integrations/google-mail
     setup_guide_url: https://nango.dev/docs/api-integrations/google-mail/how-to-register-your-own-gmail-api-oauth-app
 

--- a/packages/server/lib/hooks/connection/index.ts
+++ b/packages/server/lib/hooks/connection/index.ts
@@ -1,4 +1,6 @@
 export { default as githubAppOauthPostConnection } from './providers/github-app-oauth/post-connection.js';
+export { default as googleMailPostConnection } from './providers/google-mail/post-connection.js';
+export { default as googleCalendarPostConnection } from './providers/google-calendar/post-connection.js';
 export { default as hubspotPostConnection } from './providers/hubspot/post-connection.js';
 export { default as hubspotPreConnectionDeletion } from './providers/hubspot/pre-connection-deletion.js';
 export { default as intercomPreConnectionDeletion } from './providers/intercom/pre-connection-deletion.js';

--- a/packages/server/lib/hooks/connection/providers/google-calendar/post-connection.ts
+++ b/packages/server/lib/hooks/connection/providers/google-calendar/post-connection.ts
@@ -1,0 +1,23 @@
+import axios from 'axios';
+
+import type { InternalNango as Nango } from '../../internal-nango.js';
+
+interface CalendarListEntry {
+    id?: string;
+}
+
+export default async function execute(nango: Nango) {
+    const connection = await nango.getConnection();
+
+    const response = await nango.proxy<CalendarListEntry>({
+        endpoint: '/calendar/v3/users/me/calendarList/primary',
+        providerConfigKey: connection.provider_config_key
+    });
+
+    if (axios.isAxiosError(response) || !response?.data?.id) {
+        return;
+    }
+
+    // For a user's primary calendar, the calendar id is the user's email address.
+    await nango.updateConnectionConfig({ emailAddress: response.data.id });
+}

--- a/packages/server/lib/hooks/connection/providers/google-mail/post-connection.ts
+++ b/packages/server/lib/hooks/connection/providers/google-mail/post-connection.ts
@@ -1,0 +1,22 @@
+import axios from 'axios';
+
+import type { InternalNango as Nango } from '../../internal-nango.js';
+
+interface GmailProfileResponse {
+    emailAddress?: string;
+}
+
+export default async function execute(nango: Nango) {
+    const connection = await nango.getConnection();
+
+    const response = await nango.proxy<GmailProfileResponse>({
+        endpoint: '/gmail/v1/users/me/profile',
+        providerConfigKey: connection.provider_config_key
+    });
+
+    if (axios.isAxiosError(response) || !response?.data?.emailAddress) {
+        return;
+    }
+
+    await nango.updateConnectionConfig({ emailAddress: response.data.emailAddress });
+}

--- a/packages/server/lib/webhook/gmail-webhook-routing.ts
+++ b/packages/server/lib/webhook/gmail-webhook-routing.ts
@@ -107,17 +107,35 @@ const route: WebhookHandler = async (nango, headers, body) => {
     }
     const editedBodyWithCatchAll = { ...body, type: '*', emailAddress: decodedBody?.emailAddress };
 
-    const response = await nango.executeScriptForWebhooks({
+    let response = await nango.executeScriptForWebhooks({
         body: editedBodyWithCatchAll,
         webhookType: 'type',
         connectionIdentifier: 'emailAddress',
-        propName: 'metadata.emailAddress'
+        propName: 'emailAddress'
     });
+
+    if (response.connectionIds.length === 0) {
+        response = await nango.executeScriptForWebhooks({
+            body: editedBodyWithCatchAll,
+            webhookType: 'type',
+            connectionIdentifier: 'emailAddress',
+            propName: 'metadata.emailAddress'
+        });
+
+        if (response.connectionIds.length === 0) {
+            response = await nango.executeScriptForWebhooks({
+                body: editedBodyWithCatchAll,
+                webhookType: 'type',
+                connectionIdentifier: 'emailAddress',
+                propName: 'metadata.email'
+            });
+        }
+    }
 
     return Ok({
         content: { status: 'success' },
         statusCode: 200,
-        connectionIds: response?.connectionIds || [],
+        connectionIds: response.connectionIds,
         toForward: body
     });
 };

--- a/packages/server/lib/webhook/gmail-webhook-routing.unit.test.ts
+++ b/packages/server/lib/webhook/gmail-webhook-routing.unit.test.ts
@@ -1,0 +1,69 @@
+import { describe, expect, it, vi } from 'vitest';
+
+import { logContextGetter } from '@nangohq/logs';
+import { seeders } from '@nangohq/shared';
+import { getTestConfig } from '@nangohq/shared/lib/seeders/config.seeder.js';
+
+import * as GmailWebhookRouting from './gmail-webhook-routing.js';
+import { InternalNango } from './internal-nango.js';
+
+describe('gmailWebhookRouting', () => {
+    it('routes by connection_config.emailAddress first', async () => {
+        const integration = getTestConfig({ provider: 'google-mail' });
+
+        const mock = vi.fn().mockResolvedValue({ connectionIds: ['conn-1'], connectionMetadata: {} });
+
+        const nangoMock = new InternalNango({
+            team: seeders.getTestTeam(),
+            environment: seeders.getTestEnvironment(),
+            plan: seeders.getTestPlan(),
+            integration,
+            logContextGetter
+        });
+        nangoMock.executeScriptForWebhooks = mock;
+
+        const payload = { emailAddress: 'user@example.com', historyId: '1' };
+        const body = { message: { data: Buffer.from(JSON.stringify(payload)).toString('base64') } };
+
+        await GmailWebhookRouting.default(nangoMock as unknown as InternalNango, {}, body as any, '');
+
+        expect(mock).toHaveBeenCalledTimes(1);
+        expect(mock).toHaveBeenCalledWith(
+            expect.objectContaining({
+                propName: 'emailAddress',
+                webhookType: 'type',
+                connectionIdentifier: 'emailAddress',
+                body: expect.objectContaining({ type: '*', emailAddress: 'user@example.com' })
+            })
+        );
+    });
+
+    it('falls back to metadata.emailAddress then metadata.email', async () => {
+        const integration = getTestConfig({ provider: 'google-mail' });
+
+        const mock = vi
+            .fn()
+            .mockResolvedValueOnce({ connectionIds: [], connectionMetadata: {} })
+            .mockResolvedValueOnce({ connectionIds: [], connectionMetadata: {} })
+            .mockResolvedValueOnce({ connectionIds: ['conn-2'], connectionMetadata: {} });
+
+        const nangoMock = new InternalNango({
+            team: seeders.getTestTeam(),
+            environment: seeders.getTestEnvironment(),
+            plan: seeders.getTestPlan(),
+            integration,
+            logContextGetter
+        });
+        nangoMock.executeScriptForWebhooks = mock;
+
+        const payload = { emailAddress: 'user@example.com', historyId: '1' };
+        const body = { message: { data: Buffer.from(JSON.stringify(payload)).toString('base64') } };
+
+        await GmailWebhookRouting.default(nangoMock as unknown as InternalNango, {}, body as any, '');
+
+        expect(mock).toHaveBeenCalledTimes(3);
+        expect(mock).toHaveBeenNthCalledWith(1, expect.objectContaining({ propName: 'emailAddress' }));
+        expect(mock).toHaveBeenNthCalledWith(2, expect.objectContaining({ propName: 'metadata.emailAddress' }));
+        expect(mock).toHaveBeenNthCalledWith(3, expect.objectContaining({ propName: 'metadata.email' }));
+    });
+});

--- a/packages/server/lib/webhook/google-calendar-webhook-routing.ts
+++ b/packages/server/lib/webhook/google-calendar-webhook-routing.ts
@@ -18,17 +18,32 @@ const route: WebhookHandler = async (nango, headers, body) => {
         }
     }
 
-    const response = await nango.executeScriptForWebhooks({
+    const baseArgs = {
         body,
         ...(headers['x-goog-resource-state'] && { webhookTypeValue: headers['x-goog-resource-state'] }),
-        ...(emailAddress && { connectionIdentifierValue: emailAddress }),
-        propName: 'metadata.emailAddress'
-    });
+        ...(emailAddress && { connectionIdentifierValue: emailAddress })
+    };
+
+    let response = await nango.executeScriptForWebhooks({ ...baseArgs, propName: 'emailAddress' });
+
+    if (response.connectionIds.length === 0) {
+        response = await nango.executeScriptForWebhooks({
+            ...baseArgs,
+            propName: 'metadata.emailAddress'
+        });
+
+        if (response.connectionIds.length === 0) {
+            response = await nango.executeScriptForWebhooks({
+                ...baseArgs,
+                propName: 'metadata.email'
+            });
+        }
+    }
 
     return Ok({
         content: { status: 'success' },
         statusCode: 200,
-        connectionIds: response?.connectionIds || [],
+        connectionIds: response.connectionIds,
         toForward: headers
     });
 };

--- a/packages/server/lib/webhook/google-calendar-webhook-routing.unit.test.ts
+++ b/packages/server/lib/webhook/google-calendar-webhook-routing.unit.test.ts
@@ -1,0 +1,39 @@
+import { describe, expect, it, vi } from 'vitest';
+
+import { logContextGetter } from '@nangohq/logs';
+import { seeders } from '@nangohq/shared';
+import { getTestConfig } from '@nangohq/shared/lib/seeders/config.seeder.js';
+
+import * as GoogleCalendarWebhookRouting from './google-calendar-webhook-routing.js';
+import { InternalNango } from './internal-nango.js';
+
+describe('googleCalendarWebhookRouting', () => {
+    it('routes by connection_config.emailAddress first and falls back to metadata', async () => {
+        const integration = getTestConfig({ provider: 'google-calendar' });
+
+        const mock = vi
+            .fn()
+            .mockResolvedValueOnce({ connectionIds: [], connectionMetadata: {} })
+            .mockResolvedValueOnce({ connectionIds: ['conn-1'], connectionMetadata: {} });
+
+        const nangoMock = new InternalNango({
+            team: seeders.getTestTeam(),
+            environment: seeders.getTestEnvironment(),
+            plan: seeders.getTestPlan(),
+            integration,
+            logContextGetter
+        });
+        nangoMock.executeScriptForWebhooks = mock;
+
+        const headers = {
+            'x-goog-resource-uri': 'https://www.googleapis.com/calendar/v3/calendars/user%40example.com/events?alt=json',
+            'x-goog-resource-state': 'exists'
+        };
+
+        await GoogleCalendarWebhookRouting.default(nangoMock as unknown as InternalNango, headers as any, {}, '');
+
+        expect(mock).toHaveBeenCalledTimes(2);
+        expect(mock).toHaveBeenNthCalledWith(1, expect.objectContaining({ propName: 'emailAddress', connectionIdentifierValue: 'user@example.com' }));
+        expect(mock).toHaveBeenNthCalledWith(2, expect.objectContaining({ propName: 'metadata.emailAddress', connectionIdentifierValue: 'user@example.com' }));
+    });
+});

--- a/packages/server/lib/webhook/internal-nango.ts
+++ b/packages/server/lib/webhook/internal-nango.ts
@@ -77,7 +77,8 @@ export class InternalNango {
             connections = await connectionService.findConnectionsByConnectionConfigValue(
                 propName || connectionIdentifier || '',
                 identifierValue,
-                this.environment.id
+                this.environment.id,
+                this.integration.id
             );
         }
 

--- a/packages/shared/lib/services/connection.service.integration.test.ts
+++ b/packages/shared/lib/services/connection.service.integration.test.ts
@@ -74,6 +74,34 @@ describe('Connection service integration tests', () => {
         });
     });
 
+    describe('findConnectionsByMetadataValue', () => {
+        it('should match scalar values and set-like values (arrays)', async () => {
+            const env = await createEnvironmentSeed();
+
+            const integrationA = await createConfigSeed(env, 'google-calendar-a', 'google-calendar');
+            const integrationB = await createConfigSeed(env, 'google-calendar-b', 'google-calendar');
+
+            const scalar = await createConnectionSeed({ env, provider: integrationA.unique_key, metadata: { email: 'user@example.com' } });
+            const array = await createConnectionSeed({
+                env,
+                provider: integrationA.unique_key,
+                metadata: { email: ['user@example.com', 'other@example.com'] }
+            });
+            const otherIntegration = await createConnectionSeed({ env, provider: integrationB.unique_key, metadata: { email: 'user@example.com' } });
+
+            const matches = await connectionService.findConnectionsByMetadataValue({
+                metadataProperty: 'email',
+                payloadIdentifier: 'user@example.com',
+                configId: integrationA.id,
+                environmentId: env.id
+            });
+
+            const matchedConnectionIds = (matches || []).map((c) => c.connection_id);
+            expect(matchedConnectionIds).toEqual(expect.arrayContaining([scalar.connection_id, array.connection_id]));
+            expect(matchedConnectionIds).not.toContain(otherIntegration.connection_id);
+        });
+    });
+
     describe('listConnections', () => {
         it('should return all connections', async () => {
             const env = await createEnvironmentSeed();

--- a/packages/shared/lib/services/connection.service.ts
+++ b/packages/shared/lib/services/connection.service.ts
@@ -645,18 +645,28 @@ class ConnectionService {
         return newConfig;
     }
 
-    public async findConnectionsByConnectionConfigValue(key: string, value: string, environmentId: number): Promise<DBConnectionDecrypted[] | null> {
+    public async findConnectionsByConnectionConfigValue(
+        key: string,
+        value: string,
+        environmentId: number,
+        configId?: number
+    ): Promise<DBConnectionDecrypted[] | null> {
         const result = await db.knex
             .from<DBConnection>(`_nango_connections`)
             .select('*')
             .where({ environment_id: environmentId })
+            .modify((query) => {
+                if (typeof configId === 'number') {
+                    query.andWhere({ config_id: configId });
+                }
+            })
             .whereRaw(`connection_config->>:key = :value AND deleted = false`, { key, value });
 
         if (!result || result.length == 0) {
             return null;
         }
 
-        return result.map((connection) => encryptionManager.decryptConnection(connection));
+        return result.map((connection: DBConnection) => encryptionManager.decryptConnection(connection));
     }
 
     public async findConnectionsByMetadataValue({
@@ -678,8 +688,9 @@ class ConnectionService {
             .from<DBConnection>(`_nango_connections`)
             .select('*')
             .where({ environment_id: environmentId, config_id: configId })
-            // escape the question mark so it doesn't try to bind it as a parameter
-            .where(db.knex.raw(`metadata->? \\? ?`, [metadataProperty, payloadIdentifier]))
+            // Match both scalar values (metadata.key === value) and set-like values (metadata.key contains value).
+            // We escape the question mark so it doesn't try to bind it as a parameter.
+            .where(db.knex.raw(`(metadata->>? = ? OR metadata->? \\? ?)`, [metadataProperty, payloadIdentifier, metadataProperty, payloadIdentifier]))
             .andWhere('deleted', false);
 
         if (!result || result.length == 0) {


### PR DESCRIPTION
<!-- Describe the problem and your solution --> 
- Add `google-mail` + `google-calendar` post-connection hooks to persist `connection_config.emailAddress`
- Route `Gmail` + `Google Calendar` webhooks by `connection_config.emailAddress` first, fallback to `metadata.emailAddress` then `metadata.email` for migration

<!-- Issue ticket number and link (if applicable) -->
NAN-4969
<!-- Testing instructions (skip if just adding/editing providers) -->


<!-- Summary by @propel-code-bot -->

---

It also scopes connection config lookups by integration, broadens metadata matching to handle both scalar and array values, and adds unit and integration tests to cover the routing and metadata query behavior.

---
*This summary was automatically generated by @propel-code-bot*