### PR TITLE
feat(webhooks): add webhook support for ms client credentials

### DIFF
--- a/packages/providers/providers.yaml
+++ b/packages/providers/providers.yaml
@@ -10068,6 +10068,8 @@ microsoft-oauth2-cc:
         base_url: https://graph.microsoft.com
     webhook_routing_script: microsoftClientCredentialsWebhookRouting
     webhook_user_defined_secret: true
+    webhook_allowed_query_params:
+        - validationToken
     docs: https://nango.dev/docs/integrations/all/microsoft-oauth2-cc
     docs_connect: https://nango.dev/docs/integrations/all/microsoft-oauth2-cc/connect
     connection_config:

--- a/packages/providers/providers.yaml
+++ b/packages/providers/providers.yaml
@@ -10066,6 +10066,8 @@ microsoft-oauth2-cc:
         grant_type: client_credentials
     proxy:
         base_url: https://graph.microsoft.com
+    webhook_routing_script: microsoftClientCredentialsWebhookRouting
+    webhook_user_defined_secret: true
     docs: https://nango.dev/docs/integrations/all/microsoft-oauth2-cc
     docs_connect: https://nango.dev/docs/integrations/all/microsoft-oauth2-cc/connect
     connection_config:

--- a/packages/server/lib/controllers/webhook/environmentUuid/postWebhook.ts
+++ b/packages/server/lib/controllers/webhook/environmentUuid/postWebhook.ts
@@ -3,7 +3,7 @@ import * as z from 'zod';
 
 import db from '@nangohq/database';
 import { logContextGetter } from '@nangohq/logs';
-import { accountService, configService, getPlan } from '@nangohq/shared';
+import { accountService, configService, getPlan, getProvider } from '@nangohq/shared';
 import { flagHasPlan, metrics, zodErrorToHTTP } from '@nangohq/utils';
 
 import { providerConfigKeySchema } from '../../../helpers/validation.js';
@@ -12,15 +12,6 @@ import { featureFlags } from '../../../utils/utils.js';
 import { routeWebhook } from '../../../webhook/webhook.manager.js';
 
 import type { DBPlan, PostPublicWebhook } from '@nangohq/types';
-
-/**
- * Names of query parameters that are forwarded to webhook routing.
- * Only these parameters are forwarded; all others are ignored for security reasons.
- * By default, query parameters are not passed through: some providers send
- * unverifiable parameters, which are ignored to maintain security,
- * since they generally cannot be included in webhook signatures.
- */
-const ALLOWED_WEBHOOK_QUERY_PARAMS = ['validationToken'];
 
 const paramValidation = z
     .object({
@@ -89,7 +80,13 @@ export const postWebhook = asyncWrapper<PostPublicWebhook>(async (req, res) => {
 
             metrics.increment(metrics.Types.WEBHOOK_INCOMING_RECEIVED);
 
-            const queryFiltered = ALLOWED_WEBHOOK_QUERY_PARAMS.reduce<Record<string, string>>((acc, name) => {
+            const provider = getProvider(integration.provider);
+
+            // Query params are blocked by default — providers may include unverifiable params
+            // that can't be covered by webhook signatures. Only params explicitly listed in
+            // `webhook_allowed_query_params` (provider config) are forwarded.
+            const allowedQueryParams = provider?.webhook_allowed_query_params ?? [];
+            const queryFiltered = allowedQueryParams.reduce<Record<string, string>>((acc, name) => {
                 const v = req.query[name];
                 if (v) acc[name] = typeof v === 'string' ? v : String(v);
                 return acc;

--- a/packages/server/lib/controllers/webhook/environmentUuid/postWebhook.ts
+++ b/packages/server/lib/controllers/webhook/environmentUuid/postWebhook.ts
@@ -13,6 +13,15 @@ import { routeWebhook } from '../../../webhook/webhook.manager.js';
 
 import type { DBPlan, PostPublicWebhook } from '@nangohq/types';
 
+/**
+ * Names of query parameters that are forwarded to webhook routing.
+ * Only these parameters are forwarded; all others are ignored for security reasons.
+ * By default, query parameters are not passed through: some providers send
+ * unverifiable parameters, which are ignored to maintain security,
+ * since they generally cannot be included in webhook signatures.
+ */
+const ALLOWED_WEBHOOK_QUERY_PARAMS = ['validationToken'];
+
 const paramValidation = z
     .object({
         environmentUuid: z.string().uuid(),
@@ -80,10 +89,14 @@ export const postWebhook = asyncWrapper<PostPublicWebhook>(async (req, res) => {
 
             metrics.increment(metrics.Types.WEBHOOK_INCOMING_RECEIVED);
 
-            // Note that we do not pass on query parameters!
-            // Some providers send unverifiable query parameters
-            // we ignore them for security reasons, as they generally
-            // cannot be included in the webhook signatures.
+            const queryFiltered = ALLOWED_WEBHOOK_QUERY_PARAMS.reduce<Record<string, string>>((acc, name) => {
+                const v = req.query[name];
+                if (v) acc[name] = typeof v === 'string' ? v : String(v);
+                return acc;
+            }, {});
+
+            const query = Object.keys(queryFiltered).length > 0 ? queryFiltered : undefined;
+
             const response = await routeWebhook({
                 environment,
                 account,
@@ -92,6 +105,7 @@ export const postWebhook = asyncWrapper<PostPublicWebhook>(async (req, res) => {
                 headers,
                 body: req.body,
                 rawBody: req.rawBody!,
+                ...(query !== undefined ? { query } : {}),
                 logContextGetter
             });
 

--- a/packages/server/lib/webhook/index.ts
+++ b/packages/server/lib/webhook/index.ts
@@ -7,6 +7,7 @@ export { default as salesforceWebhookRouting } from './salesforce-webhook-routin
 export { default as slackWebhookRouting } from './slack-webhook-routing.js';
 export { default as checkrPartnerWebhookRouting } from './checkr-partner-webhook-routing.js';
 export { default as microsoftTeamsWebhookRouting } from './microsoft-teams-webhook-routing.js';
+export { default as microsoftClientCredentialsWebhookRouting } from './microsoft-client-credentials-webhook-routing.js';
 export { default as unauthenticatedWebhookRouting } from './unauthenticated-webhook-routing.js';
 export { default as airtableWebhookRouting } from './airtable-webhook-routing.js';
 export { default as calendlyWebhookRouting } from './calendly-webhook-routing.js';

--- a/packages/server/lib/webhook/microsoft-client-credentials-webhook-routing.ts
+++ b/packages/server/lib/webhook/microsoft-client-credentials-webhook-routing.ts
@@ -1,0 +1,65 @@
+import { Err, Ok } from '@nangohq/utils';
+
+import type { WebhookHandler } from './types.js';
+
+interface MicrosoftNotification {
+    tenantId?: string;
+    changeType?: string;
+    lifecycleEvent?: string;
+    clientState?: string | null;
+    resourceData?: Record<string, string>;
+    resource?: string;
+    subscriptionExpirationDateTime?: string;
+    subscriptionId?: string;
+}
+
+interface MicrosoftNotificationPayload {
+    value?: MicrosoftNotification[];
+}
+
+const route: WebhookHandler<MicrosoftNotificationPayload> = async (nango, _headers, body, _rawBody, query) => {
+    const payload = body;
+
+    // Microsoft Graph sends validationToken in query for subscription (first call) validation
+    const validationToken = query && typeof query['validationToken'] === 'string' ? query['validationToken'] : null;
+
+    if (validationToken) {
+        return Ok({ content: validationToken, statusCode: 200 });
+    }
+
+    const notifications = payload.value;
+    if (!Array.isArray(notifications) || notifications.length === 0) {
+        return Ok({ content: { status: 'success' }, statusCode: 200 });
+    }
+
+    const expectedClientState = nango.integration.custom?.['webhookSecret'];
+    const validNotifications = expectedClientState ? notifications.filter((n) => n.clientState === expectedClientState) : notifications;
+
+    if (validNotifications.length === 0) {
+        return Err('webhook_invalid_client_state');
+    }
+
+    const connectionIds = new Set<string>();
+
+    for (const notification of validNotifications) {
+        const response = await nango.executeScriptForWebhooks({
+            body: notification,
+            webhookType: 'changeType',
+            connectionIdentifier: 'tenantId',
+            propName: 'tenantId'
+        });
+
+        for (const connectionId of response?.connectionIds || []) {
+            connectionIds.add(connectionId);
+        }
+    }
+
+    return Ok({
+        content: { status: 'success' },
+        statusCode: 200,
+        connectionIds: Array.from(connectionIds),
+        toForward: payload
+    });
+};
+
+export default route;

--- a/packages/server/lib/webhook/microsoft-client-credentials-webhook-routing.ts
+++ b/packages/server/lib/webhook/microsoft-client-credentials-webhook-routing.ts
@@ -1,3 +1,4 @@
+import { NangoError } from '@nangohq/shared';
 import { Err, Ok } from '@nangohq/utils';
 
 import type { WebhookHandler } from './types.js';
@@ -36,7 +37,7 @@ const route: WebhookHandler<MicrosoftNotificationPayload> = async (nango, _heade
     const validNotifications = expectedClientState ? notifications.filter((n) => n.clientState === expectedClientState) : notifications;
 
     if (validNotifications.length === 0) {
-        return Err('webhook_invalid_client_state');
+        return Err(new NangoError('webhook_invalid_signature'));
     }
 
     const connectionIds = new Set<string>();
@@ -58,7 +59,7 @@ const route: WebhookHandler<MicrosoftNotificationPayload> = async (nango, _heade
         content: { status: 'success' },
         statusCode: 200,
         connectionIds: Array.from(connectionIds),
-        toForward: payload
+        toForward: { value: validNotifications }
     });
 };
 

--- a/packages/server/lib/webhook/types.ts
+++ b/packages/server/lib/webhook/types.ts
@@ -5,7 +5,8 @@ export type WebhookHandler<T = any> = (
     internalNango: InternalNango,
     headers: Record<string, string>,
     body: T,
-    rawBody: string
+    rawBody: string,
+    query?: Record<string, string>
 ) => Promise<Result<WebhookResponse>>;
 
 export interface WebhookResponseOnly {

--- a/packages/server/lib/webhook/webhook.manager.ts
+++ b/packages/server/lib/webhook/webhook.manager.ts
@@ -28,6 +28,7 @@ export async function routeWebhook({
     plan,
     body,
     rawBody,
+    query,
     logContextGetter
 }: {
     environment: DBEnvironment;
@@ -37,6 +38,7 @@ export async function routeWebhook({
     headers: Record<string, any>;
     body: any;
     rawBody: string;
+    query?: Record<string, string>;
     logContextGetter: LogContextGetter;
 }): Promise<WebhookResponse> {
     // Check if both body and headers are empty
@@ -77,7 +79,7 @@ export async function routeWebhook({
 
     const result: Result<WebhookResponse> = await tracer.trace(`webhook.route.${integration.provider}`, async () => {
         try {
-            const handlerResult = await handler(internalNango, headers, body, rawBody);
+            const handlerResult = await handler(internalNango, headers, body, rawBody, query);
             return handlerResult;
         } catch (err) {
             logger.error(`error processing incoming webhook for ${integration.unique_key} - `, err);

--- a/packages/types/lib/providers/provider.ts
+++ b/packages/types/lib/providers/provider.ts
@@ -80,6 +80,7 @@ export interface BaseProvider {
     token_expiration_buffer?: number; // In seconds.
     webhook_routing_script?: string;
     webhook_user_defined_secret?: boolean;
+    webhook_allowed_query_params?: string[];
     post_connection_script?: string;
     pre_connection_deletion_script?: string;
     credentials_verification_script?: string;

--- a/scripts/validation/providers/schema.json
+++ b/scripts/validation/providers/schema.json
@@ -604,6 +604,12 @@
                 "authorization_url_fragment": {
                     "type": "string"
                 },
+                "webhook_allowed_query_params": {
+                    "type": "array",
+                    "items": {
+                        "type": "string"
+                    }
+                },
                 "connection_config": {
                     "type": "object",
                     "additionalProperties": false,


### PR DESCRIPTION
## Describe the problem and your solution

- add webhook support for ms client credentials

<!-- Issue ticket number and link (if applicable) -->

<!-- Testing instructions (skip if just adding/editing providers) -->


<!-- Summary by @propel-code-bot -->

---

**Add Microsoft client-credentials webhook routing with allowlisted query params**

This PR introduces a new webhook routing handler for Microsoft client credentials, including handling `validationToken` subscription validation, filtering notifications by `clientState`, and forwarding only validated notifications. It also threads optional query parameters through the webhook controller, manager, and handler signature with a per-provider allowlist to preserve the default deny posture.

Provider metadata and validation schema are updated to support `webhook_allowed_query_params`, and the Microsoft OAuth2 client-credentials provider is configured to use the new routing script, allow user-defined secrets, and allowlist `validationToken`.

---
*This summary was automatically generated by @propel-code-bot*