### PR TITLE
fix(sdk): Add checkpoint methods to mock classes

### DIFF
--- a/packages/cli/lib/testMocks/utils.ts
+++ b/packages/cli/lib/testMocks/utils.ts
@@ -10,7 +10,15 @@ import { PaginationService } from '@nangohq/runner-sdk';
 
 import { FILTER_HEADERS as FILTER_HEADERS_UNIFIED, isAxiosDefaultContentTypeForMockIdentity } from '../services/response-collector.service.js';
 
-import type { CursorPagination, LinkPagination, OffsetCalculationMethod, OffsetPagination, Pagination, UserProvidedProxyConfiguration } from '@nangohq/types';
+import type {
+    Checkpoint,
+    CursorPagination,
+    LinkPagination,
+    OffsetCalculationMethod,
+    OffsetPagination,
+    Pagination,
+    UserProvidedProxyConfiguration
+} from '@nangohq/types';
 import type { AxiosResponse } from 'axios';
 
 interface FixtureProvider {
@@ -1123,14 +1131,36 @@ class NangoActionMock {
 }
 class NangoSyncMock extends NangoActionMock {
     lastSyncDate = null;
+    private checkpoint: Checkpoint | null = null;
 
     batchSave: ReturnType<typeof vi.fn>;
     batchDelete: ReturnType<typeof vi.fn>;
+    getCheckpoint: ReturnType<typeof vi.fn>;
+    saveCheckpoint: ReturnType<typeof vi.fn>;
+    clearCheckpoint: ReturnType<typeof vi.fn>;
 
     constructor({ dirname, name, Model }: { dirname: string; name: string; Model: string }) {
         super({ dirname, name, Model });
         this.batchSave = vi.fn();
         this.batchDelete = vi.fn();
+        this.getCheckpoint = vi.fn(this.getCheckpointData.bind(this));
+        this.saveCheckpoint = vi.fn(this.saveCheckpointData.bind(this));
+        this.clearCheckpoint = vi.fn(this.clearCheckpointData.bind(this));
+    }
+
+    // eslint-disable-next-line @typescript-eslint/require-await
+    private async getCheckpointData() {
+        return this.checkpoint;
+    }
+
+    // eslint-disable-next-line @typescript-eslint/require-await
+    private async saveCheckpointData(checkpoint: Checkpoint) {
+        this.checkpoint = checkpoint;
+    }
+
+    // eslint-disable-next-line @typescript-eslint/require-await
+    private async clearCheckpointData() {
+        this.checkpoint = null;
     }
 }
 

--- a/packages/cli/lib/testMocks/utils.unified.unit.cli-test.ts
+++ b/packages/cli/lib/testMocks/utils.unified.unit.cli-test.ts
@@ -4,7 +4,7 @@ import path from 'node:path';
 
 import { describe, expect, it } from 'vitest';
 
-import { NangoActionMock } from './utils.js';
+import { NangoActionMock, NangoSyncMock } from './utils.js';
 
 async function withMigrateMocksEnv<T>(value: string | undefined, fn: () => Promise<T>): Promise<T> {
     const previous = process.env['MIGRATE_MOCKS'];
@@ -326,5 +326,30 @@ describe('UnifiedFixtureProvider matching behavior', () => {
         expect(noParams.data).toEqual({ ok: true });
 
         await expect(nangoMock.get({ endpoint: '/foo', params: { q: '1' } })).rejects.toThrow('No mock found for GET foo');
+    });
+});
+
+describe('NangoSyncMock checkpoint behavior', () => {
+    it('stores and clears checkpoints in memory', async () => {
+        const testsDir = await createTestDir('nango-sync-checkpoint-');
+        const nangoMock = new NangoSyncMock({
+            dirname: testsDir,
+            name: 'checkpoint',
+            Model: 'CheckpointModel'
+        });
+
+        expect(await nangoMock.getCheckpoint()).toBeNull();
+
+        const checkpoint = {
+            cursor: 'next-page',
+            page: 2,
+            done: false
+        };
+
+        await nangoMock.saveCheckpoint(checkpoint);
+        expect(await nangoMock.getCheckpoint()).toEqual(checkpoint);
+
+        await nangoMock.clearCheckpoint();
+        expect(await nangoMock.getCheckpoint()).toBeNull();
     });
 });


### PR DESCRIPTION
<!-- Describe the problem and your solution --> 

<!-- Issue ticket number and link (if applicable) -->

<!-- Testing instructions (skip if just adding/editing providers) -->


<!-- Summary by @propel-code-bot -->

---

**Add checkpoint support to `NangoSyncMock` with tests**

This PR adds in-memory checkpoint handling to the `NangoSyncMock` test helper and introduces a unit test validating save/get/clear behavior. It also updates imports and types to include the new `Checkpoint` type and uses the new mock in the unified mocks test file.

---
*This summary was automatically generated by @propel-code-bot*