### PR TITLE
feat(cli): Clear mocks in generated sync tests

### DIFF
--- a/packages/cli/lib/services/test.service.unit.cli-test.ts
+++ b/packages/cli/lib/services/test.service.unit.cli-test.ts
@@ -462,7 +462,7 @@ describe('generateSyncTest', () => {
         const content = await fs.readFile(outputPath, 'utf8');
 
         // Check imports
-        expect(content).toContain("import { vi, expect, it, describe } from 'vitest'");
+        expect(content).toContain("import { afterEach, vi, expect, it, describe } from 'vitest'");
         expect(content).toContain("import createSync from '../syncs/fetch-issues.js'");
 
         // Check describe block
@@ -472,6 +472,13 @@ describe('generateSyncTest', () => {
         expect(content).toContain('dirname: __dirname,');
         expect(content).toContain('name: "fetch-issues"');
         expect(content).toContain('Model: "GithubIssue"');
+        expect(content).toContain('const createTestContext = () => {');
+        expect(content).toContain('afterEach(() => {');
+        expect(content).toContain('vi.clearAllMocks();');
+        expect(content).toContain('vi.restoreAllMocks();');
+        expect(content).toContain("const batchDeleteSpy = vi.spyOn(nangoMock, 'batchDelete');");
+        expect(content).toContain('const spiedData = batchDeleteSpy.mock.calls.flatMap(call => {');
+        expect(content).toContain('expect(spied).toStrictEqual(batchDeleteData);');
 
         // Check test cases exist
         expect(content).toContain("it('should get, map correctly the data and batchSave the result'");

--- a/packages/cli/lib/templates/sync-test-template.ejs
+++ b/packages/cli/lib/templates/sync-test-template.ejs
@@ -1,18 +1,31 @@
-import { vi, expect, it, describe } from 'vitest';
+import { afterEach, vi, expect, it, describe } from 'vitest';
 
 import createSync from '../syncs/<%= syncName %>.js';
 
 describe('<%= integration %> <%= syncName %> tests', () => {
-  const nangoMock = new global.vitest.NangoSyncMock({ 
+  const models = '<%= modelName %>'.split(',');
+
+  const createTestContext = () => {
+    const nangoMock = new global.vitest.NangoSyncMock({
       dirname: __dirname,
       name: "<%= syncName %>",
       Model: "<%= modelName %>"
+    });
+
+    return {
+      nangoMock,
+      batchSaveSpy: vi.spyOn(nangoMock, 'batchSave')
+    };
+  };
+
+  afterEach(() => {
+    vi.clearAllMocks();
+    vi.restoreAllMocks();
   });
 
-  const models = '<%= modelName %>'.split(',');
-  const batchSaveSpy = vi.spyOn(nangoMock, 'batchSave');
-
   it('should get, map correctly the data and batchSave the result', async () => {
+    const { nangoMock, batchSaveSpy } = createTestContext();
+
     await createSync.exec(nangoMock);
 
     for (const model of models) {
@@ -26,6 +39,9 @@ describe('<%= integration %> <%= syncName %> tests', () => {
         return [];
       });
 
+      // Normalize spy-captured args into plain JSON so they compare cleanly
+      // with fixture data loaded from `*.test.json`. 
+      // Removes things like prototypes, undefined values and other non-serializable data.
       const spied = JSON.parse(JSON.stringify(spiedData));
 
       expect(spied).toStrictEqual(expectedBatchSaveData);
@@ -33,13 +49,29 @@ describe('<%= integration %> <%= syncName %> tests', () => {
   });
 
   it('should get, map correctly the data and batchDelete the result', async () => {
-      await createSync.exec(nangoMock);
+    const { nangoMock } = createTestContext();
+    const batchDeleteSpy = vi.spyOn(nangoMock, 'batchDelete');
 
-      for (const model of models) {
-          const batchDeleteData = await nangoMock.getBatchDeleteData(model);
-          if (batchDeleteData && batchDeleteData.length > 0) {
-              expect(nangoMock.batchDelete).toHaveBeenCalledWith(batchDeleteData, model);
+    await createSync.exec(nangoMock);
+
+    for (const model of models) {
+      const batchDeleteData = await nangoMock.getBatchDeleteData(model);
+      if (batchDeleteData && batchDeleteData.length > 0) {
+        const spiedData = batchDeleteSpy.mock.calls.flatMap(call => {
+          if (call[1] === model) {
+            return call[0];
           }
+
+          return [];
+        });
+
+        // Normalize spy-captured args into plain JSON so they compare cleanly
+        // with fixture data loaded from `*.test.json`.
+        // Removes things like prototypes, undefined values and other non-serializable data.
+        const spied = JSON.parse(JSON.stringify(spiedData));
+
+        expect(spied).toStrictEqual(batchDeleteData);
       }
+    }
   });
 });


### PR DESCRIPTION
<!-- Describe the problem and your solution --> 

<!-- Issue ticket number and link (if applicable) -->

<!-- Testing instructions (skip if just adding/editing providers) -->


<!-- Summary by @propel-code-bot -->

---

**Improve generated sync test template mock isolation**

Updates the sync test template to create a fresh `NangoSyncMock` per test, add `afterEach` cleanup for `vitest` mocks, and add clearer spy normalization for batch save/delete comparisons. Adjusts unit test expectations in `packages/cli/lib/services/test.service.unit.cli-test.ts` to match the new template output.

---
*This summary was automatically generated by @propel-code-bot*