### PR TITLE
feat: add variants_per_sync_max to plan

### DIFF
--- a/packages/database/lib/migrations/20260311120000_plans_add_variants_per_sync_max.cjs
+++ b/packages/database/lib/migrations/20260311120000_plans_add_variants_per_sync_max.cjs
@@ -1,0 +1,13 @@
+exports.config = { transaction: true };
+
+/**
+ * @param {import('knex').Knex} knex
+ */
+exports.up = async function (knex) {
+    await knex.raw(`
+        ALTER TABLE plans
+        ADD COLUMN IF NOT EXISTS variants_per_sync_max integer NOT NULL DEFAULT 100;
+    `);
+};
+
+exports.down = async function () {};

--- a/packages/server/lib/controllers/sync/postSyncVariant.ts
+++ b/packages/server/lib/controllers/sync/postSyncVariant.ts
@@ -49,11 +49,6 @@ export const postSyncVariant = asyncWrapper<PostSyncVariant>(async (req, res) =>
     const params: PostSyncVariant['Params'] = parsedParams.data;
     const { environment, plan } = res.locals;
 
-    if (plan && !plan.has_sync_variants) {
-        res.status(400).send({ error: { code: 'feature_disabled', message: 'Creating sync variant is only available for paying customer' } });
-        return;
-    }
-
     if (params.variant.toLowerCase() === 'base') {
         res.status(400).send({ error: { code: 'invalid_variant', message: `Variant name "${params.variant}" is protected.` } });
         return;
@@ -70,9 +65,10 @@ export const postSyncVariant = asyncWrapper<PostSyncVariant>(async (req, res) =>
         return;
     }
 
-    const maxSyncsPerConnection = envs.MAX_SYNCS_PER_CONNECTION;
-    if (syncs.length > maxSyncsPerConnection) {
-        res.status(400).send({ error: { code: 'resource_capped', message: `Maximum number of syncs per connection (${maxSyncsPerConnection}) reached` } });
+    const maxVariantsPerSync = plan?.variants_per_sync_max ?? envs.MAX_SYNCS_PER_CONNECTION;
+    const variantsForSync = syncs.filter((s) => s.name === params.name);
+    if (variantsForSync.length >= maxVariantsPerSync) {
+        res.status(400).send({ error: { code: 'resource_capped', message: `Maximum number of variants per sync (${maxVariantsPerSync}) reached` } });
         return;
     }
 

--- a/packages/shared/lib/seeders/plan.seeder.ts
+++ b/packages/shared/lib/seeders/plan.seeder.ts
@@ -28,7 +28,6 @@ export function getTestPlan(override?: Partial<DBPlan>): DBPlan {
         function_logs_max: 10000,
         monthly_actions_max: 10000,
         monthly_active_records_max: 5000,
-        has_sync_variants: false,
         has_otel: false,
         api_rate_limit_size: 'm',
         auto_idle: true,
@@ -44,6 +43,7 @@ export function getTestPlan(override?: Partial<DBPlan>): DBPlan {
         webhook_function_runtime: 'runner',
         on_event_function_runtime: 'runner',
         has_records_autopruning: true,
+        variants_per_sync_max: 100,
         ...override
     };
 }

--- a/packages/shared/lib/services/plans/definitions.ts
+++ b/packages/shared/lib/services/plans/definitions.ts
@@ -12,7 +12,7 @@ export const freePlan: PlanDefinition = {
         api_rate_limit_size: 'm',
         environments_max: 2,
         has_otel: false,
-        has_sync_variants: false,
+
         connections_max: 10,
         records_max: 100_000,
         proxy_max: 100_000,
@@ -47,7 +47,7 @@ export const starterV1Plan: PlanDefinition = {
         api_rate_limit_size: 'l',
         environments_max: 3,
         has_otel: false,
-        has_sync_variants: false,
+
         sync_frequency_secs_min: 3600,
         connections_max: null,
         records_max: null,
@@ -85,7 +85,7 @@ export const growthV1Plan: PlanDefinition = {
         api_rate_limit_size: 'xl',
         environments_max: 10,
         has_otel: true,
-        has_sync_variants: true,
+
         sync_frequency_secs_min: 30,
         auto_idle: false,
         connections_max: null,
@@ -121,7 +121,7 @@ export const starterV2Plan: PlanDefinition = {
     flags: {
         ...starterV1Plan.flags,
         sync_frequency_secs_min: 30,
-        has_sync_variants: true,
+
         has_webhooks_script: true,
         has_webhooks_forward: true
     }
@@ -150,7 +150,7 @@ export const enterprisePlan: PlanDefinition = {
         api_rate_limit_size: '2xl',
         environments_max: 10,
         has_otel: true,
-        has_sync_variants: true,
+
         sync_frequency_secs_min: 30,
         connections_max: null,
         records_max: null,
@@ -188,7 +188,7 @@ export const starterLegacyPlan: PlanDefinition = {
         api_rate_limit_size: 'l',
         environments_max: 3,
         has_otel: false,
-        has_sync_variants: true,
+
         sync_frequency_secs_min: 30,
         connections_max: null,
         records_max: null,
@@ -225,7 +225,7 @@ export const scaleLegacyPlan: PlanDefinition = {
         api_rate_limit_size: 'l',
         environments_max: 3,
         has_otel: false,
-        has_sync_variants: true,
+
         sync_frequency_secs_min: 30,
         connections_max: null,
         records_max: null,
@@ -262,7 +262,7 @@ export const growthLegacyPlan: PlanDefinition = {
         api_rate_limit_size: 'l',
         environments_max: 3,
         has_otel: false,
-        has_sync_variants: true,
+
         sync_frequency_secs_min: 30,
         connections_max: null,
         records_max: null,

--- a/packages/shared/lib/services/plans/plans.ts
+++ b/packages/shared/lib/services/plans/plans.ts
@@ -221,7 +221,6 @@ export function mergeFlags({ currentPlan, newPlanDefinition }: { currentPlan: DB
             }
             // BOOLEAN FLAGS - keep override if true
             case 'has_otel':
-            case 'has_sync_variants':
             case 'has_webhooks_script':
             case 'has_webhooks_forward':
             case 'can_disable_connect_ui_watermark':
@@ -248,7 +247,8 @@ export function mergeFlags({ currentPlan, newPlanDefinition }: { currentPlan: DB
                 break;
             }
             // NUMBER FLAGS - keep override if higher
-            case 'environments_max': {
+            case 'environments_max':
+            case 'variants_per_sync_max': {
                 const currentValue = currentPlan[key];
                 const newValue = newPlanDefinition.flags[key] || 0;
                 if (currentValue > newValue) {

--- a/packages/shared/lib/services/plans/plans.unit.test.ts
+++ b/packages/shared/lib/services/plans/plans.unit.test.ts
@@ -100,7 +100,6 @@ function makePlan({ code, flagOverrides }: { code: DBPlan['name']; flagOverrides
         monthly_active_records_max: null,
         sync_frequency_secs_min: 3600,
         auto_idle: false,
-        has_sync_variants: false,
         has_otel: false,
         has_webhooks_forward: false,
         has_webhooks_script: false,
@@ -120,6 +119,7 @@ function makePlan({ code, flagOverrides }: { code: DBPlan['name']; flagOverrides
         webhook_function_runtime: 'runner',
         on_event_function_runtime: 'runner',
         has_records_autopruning: true,
+        variants_per_sync_max: 100,
         ...defaultPlanDefinition,
         ...flagOverrides
     };

--- a/packages/types/lib/plans/db.ts
+++ b/packages/types/lib/plans/db.ts
@@ -97,12 +97,6 @@ export interface DBPlan extends Timestamps {
     sync_frequency_secs_min: number;
 
     /**
-     * Enable or disabled sync variant
-     * @default false
-     */
-    has_sync_variants: boolean;
-
-    /**
      * Enable or disabled open telemetry export
      * @default false
      */
@@ -179,4 +173,10 @@ export interface DBPlan extends Timestamps {
      * @default true
      */
     has_records_autopruning: boolean;
+
+    /**
+     * Limit the number of variants per sync
+     * @default 100
+     */
+    variants_per_sync_max: number;
 }


### PR DESCRIPTION
so we can bump the number of allowed variants per customer. 
The commit also get rid of `has_sync_variants` that can now be controlled by setting `variants_per_sync_max` to 0 in order to disable the feature. Note: we recently agree to open variants to all customers not just paying ones (ie: all get 100/sync by default)
Migration to remove the has_sync_variants column will be done in followup PR

<!-- Describe the problem and your solution --> 

<!-- Issue ticket number and link (if applicable) -->

<!-- Testing instructions (skip if just adding/editing providers) -->


<!-- Summary by @propel-code-bot -->

---

**Add `variants_per_sync_max` plan flag and enforce per-sync variant limits**

This PR introduces a new `variants_per_sync_max` plan flag, adds a database column with a default of 100, and uses it to cap variants per sync in the `postSyncVariant` controller. It also removes the legacy `has_sync_variants` checks and references, relying on `variants_per_sync_max` (including `0` to disable) instead.

---
*This summary was automatically generated by @propel-code-bot*