### PR TITLE
chore: drop plan has_sync_variants

### DIFF
--- a/packages/database/lib/migrations/20260311130000_plans_drop_has_sync_variants.cjs
+++ b/packages/database/lib/migrations/20260311130000_plans_drop_has_sync_variants.cjs
@@ -1,0 +1,13 @@
+exports.config = { transaction: true };
+
+/**
+ * @param {import('knex').Knex} knex
+ */
+exports.up = async function (knex) {
+    await knex.raw(`
+        ALTER TABLE plans
+        DROP COLUMN IF EXISTS has_sync_variants;
+    `);
+};
+
+exports.down = async function () {};


### PR DESCRIPTION
its usage was remove in #5607

<!-- Describe the problem and your solution --> 

<!-- Issue ticket number and link (if applicable) -->

<!-- Testing instructions (skip if just adding/editing providers) -->


<!-- Summary by @propel-code-bot -->

---

**Drop `plans.has_sync_variants` column via migration**

This PR adds a single Knex migration that drops the `has_sync_variants` column from the `plans` table. The migration runs inside a transaction and leaves the `down` migration empty, aligning with the stated intent to remove a previously unused field.

---
*This summary was automatically generated by @propel-code-bot*