### PR TITLE
chore: enable records autodelete

### DIFF
--- a/packages/persist/lib/daemons/autodeleting.daemon.ts
+++ b/packages/persist/lib/daemons/autodeleting.daemon.ts
@@ -19,8 +19,7 @@ export function autoDeletingDaemon(): Awaited<ReturnType<typeof cancellableDaemo
     return cancellableDaemon({
         tickIntervalMs: envs.PERSIST_AUTO_DELETING_INTERVAL_MS,
         tick: async (): Promise<void> => {
-            const dryRun = true; // TODO: removed after grace period given to customer (March 8th 2026)
-            return tracer.trace('nango.persist.daemon.autodeleting', { tags: { dryRun } }, async (span) => {
+            return tracer.trace('nango.persist.daemon.autodeleting', async (span) => {
                 try {
                     const candidate = await records.autoDeletingCandidate({ staleAfterMs: envs.PERSIST_AUTO_DELETING_STALE_AFTER_MS });
                     if (candidate.isErr()) {
@@ -55,8 +54,7 @@ export function autoDeletingDaemon(): Awaited<ReturnType<typeof cancellableDaemo
                         connectionId: candidate.value.connectionId,
                         model: candidate.value.model,
                         mode: 'hard',
-                        limit: envs.PERSIST_AUTO_DELETING_LIMIT,
-                        dryRun
+                        limit: envs.PERSIST_AUTO_DELETING_LIMIT
                     });
                     if (res.isErr()) {
                         span?.addTags({ error: res.error.message });


### PR DESCRIPTION
records autodelete automatically deletes records from sync that have not be run in the last 60 days.
We are passed the 60 days grace period since the announcement of the feature, hence enabling it by removing the dryrun option.

<!-- Describe the problem and your solution --> 

<!-- Issue ticket number and link (if applicable) -->

<!-- Testing instructions (skip if just adding/editing providers) -->


<!-- Summary by @propel-code-bot -->

---

**Enable auto-deleting records by removing dry-run mode**

This PR removes the dry-run flag from the auto-deleting daemon so it performs real deletions after the 60-day grace period. The tracing call is simplified to omit the `dryRun` tag, and the delete operation no longer passes `dryRun`.

---
*This summary was automatically generated by @propel-code-bot*