### PR TITLE
fix: hash emails on connection config for gmail and google calendar

### DIFF
--- a/docs/api-integrations/google-mail/webhooks.mdx
+++ b/docs/api-integrations/google-mail/webhooks.mdx
@@ -16,7 +16,7 @@ Gmail uses Google Cloud Pub/Sub to deliver push notifications. The flow is:
 4. The Pub/Sub subscription pushes it to Nango
 5. Nango matches the notification to the correct connection and forwards it to your app
 
-Nango automatically identifies which connection a webhook belongs to using the `emailAddress` from the notification payload. For new connections, Nango persists the user's email address automatically at connection time — no manual setup required.
+Nango automatically identifies which connection a webhook belongs to using the `emailAddress` from the notification payload. For new connections, Nango persists a hash of the user's email (`connection_config.emailAddressHash`) automatically at connection time, no manual setup required.
 
 ## Setup
 
@@ -170,14 +170,14 @@ With webhooks triggering syncs in real time, you can reduce your sync frequency 
 
 Nango uses the `emailAddress` from the webhook payload to find the matching connection. The lookup order is:
 
-1. `connection_config.emailAddress` — automatically set by Nango for connections created after 2026-03-11
-2. `metadata.emailAddress` — legacy fallback
+1. `connection_config.emailAddressHash` — automatically set by Nango for new connections
+2. `metadata.emailAddress` — fallback
 
-For **new connections** (created after 2026-03-11), no action is needed. Nango automatically persists the email address at connection time.
+For **new connections**, no action is needed. Nango automatically persists the email hash at connection time.
 
 For **existing connections** created before this feature was available, you have two options:
 
-- **Re-authorize** the connection so Nango's post-connection hook runs and persists the email address automatically
+- **Re-authorize** the connection so Nango's post-connection hook runs and persists the email hash automatically
 - **Set the metadata manually** via the API:
 
 ```bash
@@ -194,7 +194,7 @@ curl -X PATCH "https://api.nango.dev/connection/metadata" \
 To do this in bulk, iterate over the [list connections](/reference/api/connection/list) response and [update the metadata](/reference/api/connection/update-metadata) for each one.
 
 <Warning>
-If Nango cannot match the incoming webhook to a connection (because neither `connection_config` nor `metadata` contains the email address), the webhook will still be received but won't include a `connectionId` in the forwarded payload.
+If Nango cannot match the incoming webhook to a connection (because it can't find a matching hash/email in `connection_config` or `metadata`), the webhook will still be received but won't include a `connectionId` in the forwarded payload.
 </Warning>
 
 ## Rollback strategy

--- a/docs/api-integrations/google-mail/webhooks.mdx
+++ b/docs/api-integrations/google-mail/webhooks.mdx
@@ -16,7 +16,7 @@ Gmail uses Google Cloud Pub/Sub to deliver push notifications. The flow is:
 4. The Pub/Sub subscription pushes it to Nango
 5. Nango matches the notification to the correct connection and forwards it to your app
 
-Nango automatically identifies which connection a webhook belongs to using the `emailAddress` from the notification payload. For new connections, Nango persists a hash of the user's email (`connection_config.emailAddressHash`) automatically at connection time, no manual setup required.
+Nango automatically identifies which connection a webhook belongs to using the `emailAddress` from the notification payload. For new connections, Nango persists only a hash of the user's email (`connection_config.emailAddressHash`) automatically at connection time — no manual setup required.
 
 ## Setup
 
@@ -168,12 +168,13 @@ With webhooks triggering syncs in real time, you can reduce your sync frequency 
 
 ## Connection matching
 
-Nango uses the `emailAddress` from the webhook payload to find the matching connection. The lookup order is:
+Nango uses the `emailAddress` from the webhook payload to find the matching connection (by hashing it internally). The lookup order is:
 
-1. `connection_config.emailAddressHash` — automatically set by Nango for new connections
-2. `metadata.emailAddress` — fallback
+1. `connection_config.emailAddressHash` — automatically set by Nango for new connections (created after 2026-03-11)
+2. `metadata.emailAddress` — fallback (customer-controlled)
+3. `metadata.email` — fallback (customer-controlled)
 
-For **new connections**, no action is needed. Nango automatically persists the email hash at connection time.
+For **new connections** (created after 2026-03-11), no action is needed. Nango automatically persists the email hash at connection time.
 
 For **existing connections** created before this feature was available, you have two options:
 

--- a/packages/server/lib/hooks/connection/providers/google-calendar/post-connection.ts
+++ b/packages/server/lib/hooks/connection/providers/google-calendar/post-connection.ts
@@ -1,5 +1,7 @@
 import axios from 'axios';
 
+import { hashEmailAddress } from '../../../../utils/pii.js';
+
 import type { InternalNango as Nango } from '../../internal-nango.js';
 
 interface CalendarListEntry {
@@ -19,5 +21,5 @@ export default async function execute(nango: Nango) {
     }
 
     // For a user's primary calendar, the calendar id is the user's email address.
-    await nango.updateConnectionConfig({ emailAddress: response.data.id });
+    await nango.updateConnectionConfig({ emailAddressHash: hashEmailAddress(response.data.id) });
 }

--- a/packages/server/lib/hooks/connection/providers/google-mail/post-connection.ts
+++ b/packages/server/lib/hooks/connection/providers/google-mail/post-connection.ts
@@ -1,5 +1,7 @@
 import axios from 'axios';
 
+import { hashEmailAddress } from '../../../../utils/pii.js';
+
 import type { InternalNango as Nango } from '../../internal-nango.js';
 
 interface GmailProfileResponse {
@@ -18,5 +20,5 @@ export default async function execute(nango: Nango) {
         return;
     }
 
-    await nango.updateConnectionConfig({ emailAddress: response.data.emailAddress });
+    await nango.updateConnectionConfig({ emailAddressHash: hashEmailAddress(response.data.emailAddress) });
 }

--- a/packages/server/lib/utils/pii.ts
+++ b/packages/server/lib/utils/pii.ts
@@ -1,0 +1,18 @@
+import crypto from 'node:crypto';
+
+const EMAIL_ADDRESS_HASH_CONTEXT = 'nango.emailAddressHash.v1';
+
+export function normalizeEmailAddress(emailAddress: string): string {
+    return emailAddress.trim().toLowerCase();
+}
+
+/**
+ * Pseudonymize an email address for storage/comparison.
+ *
+ * This is done to avoid storing raw email addresses.
+ */
+export function hashEmailAddress(emailAddress: string): string {
+    const normalized = normalizeEmailAddress(emailAddress);
+    const payload = `${EMAIL_ADDRESS_HASH_CONTEXT}:${normalized}`;
+    return crypto.createHash('sha256').update(payload, 'utf8').digest('hex');
+}

--- a/packages/server/lib/webhook/gmail-webhook-routing.ts
+++ b/packages/server/lib/webhook/gmail-webhook-routing.ts
@@ -4,6 +4,7 @@ import { NangoError, environmentService, getGlobalWebhookReceiveUrl } from '@nan
 import { Err, Ok, getLogger, report } from '@nangohq/utils';
 
 import { getGoogleJWKS } from './cache.js';
+import { hashEmailAddress } from '../utils/pii.js';
 
 import type { WebhookHandler } from './types.js';
 import type { IntegrationConfig } from '@nangohq/types';
@@ -105,13 +106,19 @@ const route: WebhookHandler = async (nango, headers, body) => {
         logger.error('Failed to parse webhook body:', err);
         return Err(new NangoError('webhook_invalid_body'));
     }
-    const editedBodyWithCatchAll = { ...body, type: '*', emailAddress: decodedBody?.emailAddress };
+    const emailAddress = decodedBody?.emailAddress;
+    const editedBodyWithCatchAll = {
+        ...body,
+        type: '*',
+        emailAddress,
+        emailAddressHash: emailAddress ? hashEmailAddress(emailAddress) : undefined
+    };
 
     let response = await nango.executeScriptForWebhooks({
         body: editedBodyWithCatchAll,
         webhookType: 'type',
-        connectionIdentifier: 'emailAddress',
-        propName: 'emailAddress'
+        connectionIdentifier: 'emailAddressHash',
+        propName: 'emailAddressHash'
     });
 
     if (response.connectionIds.length === 0) {

--- a/packages/server/lib/webhook/gmail-webhook-routing.unit.test.ts
+++ b/packages/server/lib/webhook/gmail-webhook-routing.unit.test.ts
@@ -6,9 +6,10 @@ import { getTestConfig } from '@nangohq/shared/lib/seeders/config.seeder.js';
 
 import * as GmailWebhookRouting from './gmail-webhook-routing.js';
 import { InternalNango } from './internal-nango.js';
+import { hashEmailAddress } from '../utils/pii.js';
 
 describe('gmailWebhookRouting', () => {
-    it('routes by connection_config.emailAddress first', async () => {
+    it('routes by connection_config.emailAddressHash first', async () => {
         const integration = getTestConfig({ provider: 'google-mail' });
 
         const mock = vi.fn().mockResolvedValue({ connectionIds: ['conn-1'], connectionMetadata: {} });
@@ -30,19 +31,24 @@ describe('gmailWebhookRouting', () => {
         expect(mock).toHaveBeenCalledTimes(1);
         expect(mock).toHaveBeenCalledWith(
             expect.objectContaining({
-                propName: 'emailAddress',
+                propName: 'emailAddressHash',
                 webhookType: 'type',
-                connectionIdentifier: 'emailAddress',
-                body: expect.objectContaining({ type: '*', emailAddress: 'user@example.com' })
+                connectionIdentifier: 'emailAddressHash',
+                body: expect.objectContaining({
+                    type: '*',
+                    emailAddress: 'user@example.com',
+                    emailAddressHash: hashEmailAddress('user@example.com')
+                })
             })
         );
     });
 
-    it('falls back to metadata.emailAddress then metadata.email', async () => {
+    it('falls back to legacy config then metadata', async () => {
         const integration = getTestConfig({ provider: 'google-mail' });
 
         const mock = vi
             .fn()
+            .mockResolvedValueOnce({ connectionIds: [], connectionMetadata: {} })
             .mockResolvedValueOnce({ connectionIds: [], connectionMetadata: {} })
             .mockResolvedValueOnce({ connectionIds: [], connectionMetadata: {} })
             .mockResolvedValueOnce({ connectionIds: ['conn-2'], connectionMetadata: {} });
@@ -62,7 +68,7 @@ describe('gmailWebhookRouting', () => {
         await GmailWebhookRouting.default(nangoMock as unknown as InternalNango, {}, body as any, '');
 
         expect(mock).toHaveBeenCalledTimes(3);
-        expect(mock).toHaveBeenNthCalledWith(1, expect.objectContaining({ propName: 'emailAddress' }));
+        expect(mock).toHaveBeenNthCalledWith(1, expect.objectContaining({ propName: 'emailAddressHash' }));
         expect(mock).toHaveBeenNthCalledWith(2, expect.objectContaining({ propName: 'metadata.emailAddress' }));
         expect(mock).toHaveBeenNthCalledWith(3, expect.objectContaining({ propName: 'metadata.email' }));
     });

--- a/packages/server/lib/webhook/google-calendar-webhook-routing.ts
+++ b/packages/server/lib/webhook/google-calendar-webhook-routing.ts
@@ -1,5 +1,7 @@
 import { Ok } from '@nangohq/utils';
 
+import { hashEmailAddress } from '../utils/pii.js';
+
 import type { WebhookHandler } from './types.js';
 
 const route: WebhookHandler = async (nango, headers, body) => {
@@ -20,21 +22,31 @@ const route: WebhookHandler = async (nango, headers, body) => {
 
     const baseArgs = {
         body,
-        ...(headers['x-goog-resource-state'] && { webhookTypeValue: headers['x-goog-resource-state'] }),
-        ...(emailAddress && { connectionIdentifierValue: emailAddress })
+        ...(headers['x-goog-resource-state'] && { webhookTypeValue: headers['x-goog-resource-state'] })
     };
 
-    let response = await nango.executeScriptForWebhooks({ ...baseArgs, propName: 'emailAddress' });
+    const emailAddressHash = emailAddress ? hashEmailAddress(emailAddress) : undefined;
+
+    let response = await nango.executeScriptForWebhooks({
+        ...baseArgs,
+        connectionIdentifier: 'emailAddressHash',
+        ...(emailAddressHash && { connectionIdentifierValue: emailAddressHash }),
+        propName: 'emailAddressHash'
+    });
 
     if (response.connectionIds.length === 0) {
         response = await nango.executeScriptForWebhooks({
             ...baseArgs,
+            connectionIdentifier: 'emailAddress',
+            ...(emailAddress && { connectionIdentifierValue: emailAddress }),
             propName: 'metadata.emailAddress'
         });
 
         if (response.connectionIds.length === 0) {
             response = await nango.executeScriptForWebhooks({
                 ...baseArgs,
+                connectionIdentifier: 'emailAddress',
+                ...(emailAddress && { connectionIdentifierValue: emailAddress }),
                 propName: 'metadata.email'
             });
         }

--- a/packages/server/lib/webhook/google-calendar-webhook-routing.unit.test.ts
+++ b/packages/server/lib/webhook/google-calendar-webhook-routing.unit.test.ts
@@ -6,13 +6,15 @@ import { getTestConfig } from '@nangohq/shared/lib/seeders/config.seeder.js';
 
 import * as GoogleCalendarWebhookRouting from './google-calendar-webhook-routing.js';
 import { InternalNango } from './internal-nango.js';
+import { hashEmailAddress } from '../utils/pii.js';
 
 describe('googleCalendarWebhookRouting', () => {
-    it('routes by connection_config.emailAddress first and falls back to metadata', async () => {
+    it('routes by connection_config.emailAddressHash first then falls back', async () => {
         const integration = getTestConfig({ provider: 'google-calendar' });
 
         const mock = vi
             .fn()
+            .mockResolvedValueOnce({ connectionIds: [], connectionMetadata: {} })
             .mockResolvedValueOnce({ connectionIds: [], connectionMetadata: {} })
             .mockResolvedValueOnce({ connectionIds: ['conn-1'], connectionMetadata: {} });
 
@@ -32,8 +34,30 @@ describe('googleCalendarWebhookRouting', () => {
 
         await GoogleCalendarWebhookRouting.default(nangoMock as unknown as InternalNango, headers as any, {}, '');
 
-        expect(mock).toHaveBeenCalledTimes(2);
-        expect(mock).toHaveBeenNthCalledWith(1, expect.objectContaining({ propName: 'emailAddress', connectionIdentifierValue: 'user@example.com' }));
-        expect(mock).toHaveBeenNthCalledWith(2, expect.objectContaining({ propName: 'metadata.emailAddress', connectionIdentifierValue: 'user@example.com' }));
+        expect(mock).toHaveBeenCalledTimes(3);
+        expect(mock).toHaveBeenNthCalledWith(
+            1,
+            expect.objectContaining({
+                propName: 'emailAddressHash',
+                connectionIdentifier: 'emailAddressHash',
+                connectionIdentifierValue: hashEmailAddress('user@example.com')
+            })
+        );
+        expect(mock).toHaveBeenNthCalledWith(
+            2,
+            expect.objectContaining({
+                propName: 'metadata.emailAddress',
+                connectionIdentifier: 'emailAddress',
+                connectionIdentifierValue: 'user@example.com'
+            })
+        );
+        expect(mock).toHaveBeenNthCalledWith(
+            3,
+            expect.objectContaining({
+                propName: 'metadata.email',
+                connectionIdentifier: 'emailAddress',
+                connectionIdentifierValue: 'user@example.com'
+            })
+        );
     });
 });


### PR DESCRIPTION
<!-- Describe the problem and your solution --> 
- `google-mail` + `google-calendar` post-connection hooks now persist `connection_config.emailAddressHash` so we no longer store raw email in config.
- `Gmail` + `Google Calendar` webhook routing now matches connections by `connection_config.emailAddressHash` first, then falls back to customer-supplied `metadata.emailAddress` / `metadata.email` for backwards compatibility during migration.
- Hashing is deterministic: `sha256("nango.emailAddressHash.v1:" + lower(trim(email)))`, shared between hooks + webhook routing to keep routing stable without storing PII. This simplifies the migration (hmac based hashing would require us to introduce a new secret)
- Unit tests cover routing order/fallbacks

<!-- Issue ticket number and link (if applicable) -->
NAN-4969
<!-- Testing instructions (skip if just adding/editing providers) -->


<!-- Summary by @propel-code-bot -->

---

The Gmail webhook documentation was also updated to describe hash-based matching and provide migration guidance.

---
*This summary was automatically generated by @propel-code-bot*