### PR TITLE
chore: track functions concurrency in metrics

### DIFF
--- a/packages/jobs/lib/execution/operations/handler.ts
+++ b/packages/jobs/lib/execution/operations/handler.ts
@@ -3,26 +3,35 @@ import { handleActionError, handleActionSuccess } from '../action.js';
 import { handleOnEventError, handleOnEventSuccess } from '../onEvent.js';
 import { handleSyncError, handleSyncSuccess } from '../sync.js';
 import { handleWebhookError, handleWebhookSuccess } from '../webhook.js';
+import { concurrencyMonitor } from './monitor.js';
 import { toNangoError } from './utils/errors.js';
 
 import type { CheckpointRange, FunctionRuntime, NangoProps, RunnerOutputError, TelemetryBag } from '@nangohq/types';
 import type { JsonValue } from 'type-fest';
 
-export async function handleSuccess({
-    taskId,
-    nangoProps,
-    output,
-    telemetryBag,
-    functionRuntime,
-    checkpoints
-}: {
+interface Payload {
     taskId: string;
     nangoProps: NangoProps;
-    output: JsonValue;
     telemetryBag: TelemetryBag;
     functionRuntime: FunctionRuntime;
     checkpoints: CheckpointRange;
-}): Promise<void> {
+}
+type SuccessPayload = Payload & { output: JsonValue };
+type ErrorPayload = Payload & { error: RunnerOutputError };
+
+export async function handle(payload: SuccessPayload | ErrorPayload): Promise<void> {
+    try {
+        if ('error' in payload) {
+            await handleError(payload);
+        } else {
+            await handleSuccess(payload);
+        }
+    } finally {
+        concurrencyMonitor.end({ type: payload.nangoProps.scriptType, accountId: payload.nangoProps.team.id });
+    }
+}
+
+async function handleSuccess({ taskId, nangoProps, output, telemetryBag, functionRuntime, checkpoints }: SuccessPayload): Promise<void> {
     switch (nangoProps.scriptType) {
         case 'action':
             await handleActionSuccess({ taskId, nangoProps, output, telemetryBag, functionRuntime, checkpoints });
@@ -39,21 +48,7 @@ export async function handleSuccess({
     }
 }
 
-export async function handleError({
-    taskId,
-    nangoProps,
-    error,
-    telemetryBag,
-    functionRuntime,
-    checkpoints
-}: {
-    taskId: string;
-    nangoProps: NangoProps;
-    error: RunnerOutputError;
-    telemetryBag: TelemetryBag;
-    functionRuntime: FunctionRuntime;
-    checkpoints: CheckpointRange;
-}): Promise<void> {
+async function handleError({ taskId, nangoProps, error, telemetryBag, functionRuntime, checkpoints }: ErrorPayload): Promise<void> {
     // If the function was aborted, we do nothing as the function's state has already been updated
     if (error.type === 'script_aborted') {
         logger.info(`Script was aborted. Ignoring output.`, {

--- a/packages/jobs/lib/execution/operations/monitor.ts
+++ b/packages/jobs/lib/execution/operations/monitor.ts
@@ -1,0 +1,10 @@
+import { metrics } from '@nangohq/utils';
+
+export const concurrencyMonitor = {
+    start(dimensions: { type: string; accountId: number }): void {
+        metrics.increment(metrics.Types.FUNCTION_EXECUTIONS_CONCURRENCY, 1, dimensions);
+    },
+    end(dimensions: { type: string; accountId: number }): void {
+        metrics.decrement(metrics.Types.FUNCTION_EXECUTIONS_CONCURRENCY, 1, dimensions);
+    }
+};

--- a/packages/jobs/lib/execution/operations/start.ts
+++ b/packages/jobs/lib/execution/operations/start.ts
@@ -3,6 +3,7 @@ import tracer from 'dd-trace';
 import { connectionService, localFileService, remoteFileService } from '@nangohq/shared';
 import { Err, Ok, integrationFilesAreRemote, isCloud, stringifyError } from '@nangohq/utils';
 
+import { concurrencyMonitor } from './monitor.js';
 import { getRuntimeAdapter } from '../../runtime/runtimes.js';
 
 import type { LogContext } from '@nangohq/logs';
@@ -66,6 +67,7 @@ export async function startScript({
         }
 
         await connectionService.trackExecution(nangoProps.nangoConnectionId);
+        concurrencyMonitor.start({ type: nangoProps.scriptType, accountId: nangoProps.team.id });
         return Ok(undefined);
     } catch (err) {
         span.setTag('error', err);

--- a/packages/jobs/lib/invocations/lambda.processor.ts
+++ b/packages/jobs/lib/invocations/lambda.processor.ts
@@ -3,7 +3,7 @@ import { z } from 'zod';
 import { envs } from '../env.js';
 import { NoopEventListener } from '../events/noop.listener.js';
 import { SqsEventListener } from '../events/sqs.listener.js';
-import { handleError } from '../execution/operations/handler.js';
+import { handle } from '../execution/operations/handler.js';
 import { nangoPropsSchema } from '../schemas/nango-props.js';
 
 import type { EventListener, QueueMessage } from '../events/listener.js';
@@ -56,7 +56,7 @@ export class LambdaInvocationsProcessor {
 
         if (parsedMessage.responseContext.functionError === 'Unhandled') {
             const errorMessage = parsedMessage.responsePayload.errorMessage;
-            await handleError({
+            await handle({
                 taskId: parsedMessage.requestPayload.taskId,
                 nangoProps: parsedMessage.requestPayload.nangoProps as unknown as NangoProps,
                 error: {

--- a/packages/jobs/lib/invocations/lambda.processor.unit.test.ts
+++ b/packages/jobs/lib/invocations/lambda.processor.unit.test.ts
@@ -12,7 +12,7 @@ vi.mock('../events/sqs.listener.js', () => ({
 }));
 
 vi.mock('../execution/operations/handler.js', () => ({
-    handleError: vi.fn().mockResolvedValue(undefined)
+    handle: vi.fn().mockResolvedValue(undefined)
 }));
 
 let mockLambdaFailureDestination: string | undefined = 'https://sqs.us-west-2.amazonaws.com/123456789/lambda-failures';
@@ -23,7 +23,7 @@ vi.mock('../env.js', () => ({
 }));
 
 import { LambdaInvocationsProcessor } from './lambda.processor.js';
-import { handleError } from '../execution/operations/handler.js';
+import { handle } from '../execution/operations/handler.js';
 
 function minimalNangoProps() {
     return {
@@ -116,7 +116,7 @@ describe('LambdaInvocationsProcessor', () => {
         expect(mockListen).toHaveBeenCalledWith('https://sqs.us-west-2.amazonaws.com/123456789/lambda-failures', expect.any(Function));
     });
 
-    it('should process Unhandled failure and call handleError with function_runtime_other for generic error message', async () => {
+    it('should process Unhandled failure and call handle with function_runtime_other for generic error message', async () => {
         let onMessage: (message: { body: string }) => Promise<void> = undefined!;
         mockListen.mockImplementation((_queue: string, cb: (m: { body: string }) => Promise<void>) => {
             onMessage = cb;
@@ -129,8 +129,8 @@ describe('LambdaInvocationsProcessor', () => {
         const message = failureMessage({ errorMessage: 'Random error' });
         await onMessage(message);
 
-        expect(handleError).toHaveBeenCalledTimes(1);
-        expect(handleError).toHaveBeenCalledWith(
+        expect(handle).toHaveBeenCalledTimes(1);
+        expect(handle).toHaveBeenCalledWith(
             expect.objectContaining({
                 taskId: 'task-123',
                 error: expect.objectContaining({
@@ -155,7 +155,7 @@ describe('LambdaInvocationsProcessor', () => {
 
         await onMessage(failureMessage({ errorMessage: 'Process exited with signal: killed' }));
 
-        expect(handleError).toHaveBeenCalledWith(
+        expect(handle).toHaveBeenCalledWith(
             expect.objectContaining({
                 error: expect.objectContaining({
                     type: 'function_runtime_out_of_memory',
@@ -176,7 +176,7 @@ describe('LambdaInvocationsProcessor', () => {
 
         await onMessage(failureMessage({ errorMessage: 'Task timed out after 30.00 seconds' }));
 
-        expect(handleError).toHaveBeenCalledWith(
+        expect(handle).toHaveBeenCalledWith(
             expect.objectContaining({
                 error: expect.objectContaining({
                     type: 'function_runtime_timed_out',
@@ -186,7 +186,7 @@ describe('LambdaInvocationsProcessor', () => {
         );
     });
 
-    it('should not call handleError when functionError is not Unhandled', async () => {
+    it('should not call handle when functionError is not Unhandled', async () => {
         let onMessage: (message: { body: string }) => Promise<void> = undefined!;
         mockListen.mockImplementation((_queue: string, cb: (m: { body: string }) => Promise<void>) => {
             onMessage = cb;
@@ -197,7 +197,7 @@ describe('LambdaInvocationsProcessor', () => {
 
         await onMessage(failureMessage({ functionError: 'Handled', statusCode: 400, errorMessage: 'Validation failed', taskId: 'task-456' }));
 
-        expect(handleError).not.toHaveBeenCalled();
+        expect(handle).not.toHaveBeenCalled();
     });
 
     it('should not call listen when LAMBDA_FAILURE_DESTINATION is not set', async () => {

--- a/packages/jobs/lib/routes/tasks/putTask.ts
+++ b/packages/jobs/lib/routes/tasks/putTask.ts
@@ -2,7 +2,7 @@ import * as z from 'zod';
 
 import { validateRequest } from '@nangohq/utils';
 
-import { handleError, handleSuccess } from '../../execution/operations/handler.js';
+import { handle } from '../../execution/operations/handler.js';
 import { nangoPropsSchema } from '../../schemas/nango-props.js';
 
 import type { PutTask } from '@nangohq/types';
@@ -46,25 +46,14 @@ const handler = async (_req: EndpointRequest, res: EndpointResponse<PutTask>) =>
         res.status(400).json({ error: { code: 'put_task_failed', message: 'missing nangoProps' } });
         return;
     }
-    if (error) {
-        await handleError({
-            taskId,
-            nangoProps,
-            error,
-            telemetryBag,
-            functionRuntime,
-            checkpoints: checkpoints || null
-        });
-    } else {
-        await handleSuccess({
-            taskId,
-            nangoProps,
-            output: output || null,
-            telemetryBag,
-            functionRuntime,
-            checkpoints: checkpoints || null
-        });
-    }
+    await handle({
+        taskId,
+        nangoProps,
+        telemetryBag,
+        functionRuntime,
+        checkpoints: checkpoints || null,
+        ...(error ? { error } : { output: output || null })
+    });
     res.status(204).send();
     return;
 };

--- a/packages/utils/lib/telemetry/metrics.ts
+++ b/packages/utils/lib/telemetry/metrics.ts
@@ -53,6 +53,7 @@ export enum Types {
     RUNNER_MEMORY_USAGE = 'nango.runner.memoryUsage',
 
     FUNCTION_EXECUTIONS = 'nango.jobs.function.executions',
+    FUNCTION_EXECUTIONS_CONCURRENCY = 'nango.jobs.function.executions.concurrency',
 
     WEBHOOK_INCOMING_RECEIVED = 'nango.webhook.incoming.received',
     WEBHOOK_INCOMING_FORWARDED_SUCCESS = 'nango.webhook.incoming.forwarded.success',


### PR DESCRIPTION
We want to be able to track functions concurrency per accounts/types.


<!-- Summary by @propel-code-bot -->

---

**Add function concurrency metric tracking and unify handler flow**

This PR introduces a new function concurrency metric and wires it into the job execution lifecycle. It adds a `concurrencyMonitor` helper, increments on `startScript()` and decrements in a unified `handle()` path to ensure decrement happens for both success and error handling.

It also refactors task handling to use a single `handle()` entry point, updates lambda failure processing to call this unified handler, and adjusts unit tests accordingly.

---
*This summary was automatically generated by @propel-code-bot*