### PR TITLE
docs: add stop listening on connection deletion and real-time sync concept for gmail and google calendar webhooks

### DIFF
--- a/docs/api-integrations/google-calendar/webhooks.mdx
+++ b/docs/api-integrations/google-calendar/webhooks.mdx
@@ -27,6 +27,55 @@ Copy the webhook URL from your Google Calendar integration page in the Nango das
 
 Create a notification channel for the calendar you want to watch by sending a `POST` request to the appropriate `watch` endpoint. See the [API reference](https://developers.google.com/workspace/calendar/api/guides/push#create-notification-channels) for the exact URI.
 
+You can automate creating the channel for new connections with a [post-connection-creation script](/implementation-guides/use-cases/implement-event-handler):
+
+```typescript
+import { createOnEvent, ProxyConfiguration } from 'nango';
+import { randomUUID } from 'crypto';
+import z from 'zod';
+
+export default createOnEvent({
+    event: 'post-connection-creation',
+    description: 'Create a Google Calendar notification channel for events on the primary calendar',
+    metadata: z.object({
+        googleCalendarChannelId: z.string().optional(),
+        googleCalendarResourceId: z.string().optional(),
+    }),
+    exec: async (nango) => {
+        const calResponse = await nango.get({
+            baseUrlOverride: 'https://www.googleapis.com/calendar',
+            endpoint: '/v3/users/me/calendarList/primary' 
+        });
+
+        const calendarEmail = calResponse.data.id; 
+        const channelId = randomUUID();
+        const expiration = Date.now() + 7 * 24 * 60 * 60 * 1000; // 7 days in ms
+        const webhookUrl = await nango.getWebhookURL();
+
+        const config: ProxyConfiguration = {
+            baseUrlOverride: 'https://www.googleapis.com/calendar',
+            endpoint: `/v3/calendars/${encodeURIComponent(calendarEmail)}/events/watch`,
+            data: {
+                id: channelId,
+                type: 'webhook',
+                // Webhook URL can be found on https://app.nango.dev/dev/integrations/google-calendar (your integration settings page)
+                address: webhookUrl,
+                expiration: expiration,
+            },
+        };
+
+        const response = await nango.post(config);
+
+        // Store channel info so it can be used to stop notifications later (step 4)
+        await nango.updateMetadata({
+            googleCalendarChannelId: channelId,
+            googleCalendarResourceId: response.data.resourceId,
+        });
+    }
+});
+```
+
+You can also do this manually:
 Example: watch the **events** collection on a calendar:
 
 ```bash
@@ -36,7 +85,7 @@ curl -X POST "https://www.googleapis.com/calendar/v3/calendars/<CALENDAR_ID>/eve
   -d '{
     "id": "01234567-89ab-cdef-0123456789ab",
     "type": "web_hook",
-    "address": "https://api.nango.dev/webhook/...",
+    "address": "<REPLACE_WITH_NANGO_WEBHOOK_URL>",
     "expiration": 1426325213000
   }'
 ```
@@ -49,36 +98,6 @@ Replace:
 - **id** — A unique string (e.g. UUID) identifying this channel; max 64 characters. It is echoed in `X-Goog-Channel-ID` on every notification.
 - **expiration** — (Optional) Unix timestamp in **milliseconds** when the channel should stop sending notifications. If omitted, Google applies a default; channels must be renewed before they expire.
 
-You can automate creating the channel for new connections with a [post-connection-creation script](/implementation-guides/use-cases/implement-event-handler):
-
-```typescript
-import { createOnEvent, ProxyConfiguration } from 'nango';
-import { randomUUID } from 'crypto';
-
-export default createOnEvent({
-    event: 'post-connection-creation',
-    description: 'Create a Google Calendar notification channel for events on the primary calendar',
-    exec: async (nango) => {
-        const channelId = randomUUID();
-        const expiration = Date.now() + 7 * 24 * 60 * 60 * 1000; // 7 days in ms
-
-        const config: ProxyConfiguration = {
-            baseUrlOverride: 'https://www.googleapis.com/calendar',
-            endpoint: '/v3/calendars/primary/events/watch',
-            data: {
-                id: channelId,
-                type: 'web_hook',
-                address: 'https://api.nango.dev/webhook/...',
-                expiration,
-            },
-        };
-
-        const response = await nango.post(config);
-        await nango.log(response.data);
-    }
-});
-```
-
 ### 3. Renew the notification channel
 
 Google does **not** renew channels automatically. When a channel is close to its expiration, you must create a new channel by calling the `watch` endpoint again with a **new** unique `id`. See [Renew notification channels](https://developers.google.com/workspace/calendar/api/guides/push#renew-notification-channels).
@@ -88,36 +107,93 @@ You can use a Nango sync with a suitable frequency (e.g. every few days) to rene
 ```typescript
 import { createSync, ProxyConfiguration } from 'nango';
 import { randomUUID } from 'crypto';
-import { Empty } from '../../models.js';
+import z from 'zod';
 
 export default createSync({
     description: 'Renew the Google Calendar events watch channel before it expires',
-    models: { Empty },
-    endpoints: [{ method: 'POST', path: '/v3/calendars/primary/events/watch' }],
+    models: {},
+    metadata: z.object({
+        googleCalendarChannelId: z.string().optional(),
+        googleCalendarResourceId: z.string().optional(),
+    }),
+    endpoints: [{ method: 'GET', path: '/google-calendar/watch-renewal' }],
     syncType: 'full',
-    frequency: '5d',
+    frequency: '1d',
     exec: async (nango) => {
+        const calResponse = await nango.get({
+            baseUrlOverride: 'https://www.googleapis.com/calendar',
+            endpoint: '/v3/users/me/calendarList/primary' 
+        });
+
+        const calendarEmail = calResponse.data.id; // This will be "user@company.com"
         const channelId = randomUUID();
-        const expiration = Date.now() + 7 * 24 * 60 * 60 * 1000; // 7 days
+        const expiration = Date.now() + 7 * 24 * 60 * 60 * 1000; // 7 days in ms
+        const webhookUrl = await nango.getWebhookURL();
 
         const config: ProxyConfiguration = {
             baseUrlOverride: 'https://www.googleapis.com/calendar',
-            endpoint: '/v3/calendars/primary/events/watch',
+            endpoint: `/v3/calendars/${encodeURIComponent(calendarEmail)}/events/watch`,
             data: {
                 id: channelId,
-                type: 'web_hook',
-                address: 'https://api.nango.dev/webhook/...',
-                expiration,
+                type: 'webhook',
+                // Webhook URL can be found on https://app.nango.dev/dev/integrations/google-calendar (your integration settings page)
+                address: webhookUrl,
+                expiration: expiration,
             },
         };
 
         const response = await nango.post(config);
-        await nango.log(response.data);
+
+        // Update stored channel info for use in stop notifications (step 4)
+        await nango.updateMetadata({
+            googleCalendarChannelId: channelId,
+            googleCalendarResourceId: response.data.resourceId,
+        });
     }
 });
 ```
 
-### 4. Handle forwarded webhooks
+### 4. Stop notifications on connection deletion
+
+If a connection is deleted in Nango but the channel remains active, Google may continue sending notifications until the channel expires. To stop notifications immediately for a deleted connection, call `channels.stop` before deletion.
+
+You can automate this with a `pre-connection-deletion` lifecycle event. This uses the `googleCalendarChannelId` and `googleCalendarResourceId` stored in metadata during channel creation (step 2) and renewal (step 3):
+
+```typescript
+import { createOnEvent, ProxyConfiguration } from 'nango';
+
+export default createOnEvent({
+    event: 'pre-connection-deletion',
+    description: 'Stop Google Calendar notification channel before connection deletion',
+    exec: async (nango) => {
+        const metadata = await nango.getMetadata();
+        const channelId = metadata['googleCalendarChannelId'];
+        const resourceId = metadata['googleCalendarResourceId'];
+
+        if (!channelId || !resourceId) {
+            return;
+        }
+
+        const config: ProxyConfiguration = {
+            baseUrlOverride: 'https://www.googleapis.com/calendar',
+            endpoint: '/v3/channels/stop',
+            data: {
+                id: channelId,
+                resourceId
+            }
+        };
+
+        try {
+            await nango.post(config);
+        } catch (err) {
+            // Avoid blocking connection deletion if stop fails.
+            await nango.log(`Failed to stop Calendar channel: ${String(err)}`);
+        }
+    }
+});
+```
+
+### 5. Handle forwarded webhooks
 
 When a Calendar notification arrives, Nango matches it to the correct connection and forwards it to your system. Notification messages have **no body**; Google sends only HTTP headers. Nango forwards those headers in the payload. Example structure:
 
@@ -137,12 +213,12 @@ When a Calendar notification arrives, Nango matches it to the correct connection
 }
 ```
 
-Relevant headers (see [Google’s documentation](https://developers.google.com/workspace/calendar/api/guides/push#interpret-the-notification-message-format)):
+Relevant headers (see [Google's documentation](https://developers.google.com/workspace/calendar/api/guides/push#interpret-the-notification-message-format)):
 
 | Header | Description |
 |--------|-------------|
 | `x-goog-resource-state` | `sync` = channel created; `exists` = resource changed (create/update/delete). |
-| `x-goog-resource-uri` | The watched resource (e.g. which calendar’s events). |
+| `x-goog-resource-uri` | The watched resource (e.g. which calendar's events). |
 | `x-goog-channel-id` | The channel `id` you sent when creating the channel. |
 | `x-goog-message-number` | Incrementing message number for this channel. |
 
@@ -199,60 +275,6 @@ To do this in bulk, iterate over the [list connections](/reference/api/connectio
 <Warning>
 If Nango cannot match the incoming webhook to a connection (because it can't find a matching hash/email in `connection_config` or `metadata`), the webhook will still be received but won't include a `connectionId` in the forwarded payload.
 </Warning>
-
-## Stop notifications
-
-If a connection is deleted in Nango but the channel remains active, Google may continue sending notifications until the channel expires. To stop notifications immediately for a deleted connection, call `channels.stop` before deletion.
-
-You can automate this with a `pre-connection-deletion` lifecycle event (this expects `googleCalendarChannelId` and `googleCalendarResourceId` to be present in connection metadata):
-
-```typescript
-import { createOnEvent, ProxyConfiguration } from 'nango';
-
-export default createOnEvent({
-    event: 'pre-connection-deletion',
-    description: 'Stop Google Calendar notification channel before connection deletion',
-    exec: async (nango) => {
-        const metadata = await nango.getMetadata();
-        const channelId = metadata['googleCalendarChannelId'];
-        const resourceId = metadata['googleCalendarResourceId'];
-
-        if (!channelId || !resourceId) {
-            return;
-        }
-
-        const config: ProxyConfiguration = {
-            baseUrlOverride: 'https://www.googleapis.com/calendar',
-            endpoint: '/v3/channels/stop',
-            data: {
-                id: channelId,
-                resourceId
-            }
-        };
-
-        try {
-            await nango.post(config);
-        } catch (err) {
-            // Avoid blocking connection deletion if stop fails.
-            await nango.log(`Failed to stop Calendar channel: ${String(err)}`);
-        }
-    }
-});
-```
-
-To stop receiving notifications before the channel expires, call the [channels.stop](https://developers.google.com/workspace/calendar/api/guides/push#stop-notifications) method with the channel `id` and `resourceId` returned when you created the channel:
-
-```bash
-curl -X POST "https://www.googleapis.com/calendar/v3/channels/stop" \
-  -H "Authorization: Bearer <AUTH_TOKEN>" \
-  -H "Content-Type: application/json" \
-  -d '{
-    "id": "01234567-89ab-cdef-0123456789ab",
-    "resourceId": "o3hgv1538sdjfh"
-  }'
-```
-
-Channels must be stopped by the same client that created them.
 
 ## Rollback strategy
 

--- a/docs/api-integrations/google-calendar/webhooks.mdx
+++ b/docs/api-integrations/google-calendar/webhooks.mdx
@@ -162,6 +162,12 @@ curl -X POST "https://api.nango.dev/sync/trigger" \
 
 With webhooks driving real-time updates, you can run syncs less often (e.g. `1d` or `1h`) as a safety net for missed notifications.
 
+<Note>
+If you prefer Nango to automatically run a sync when the webhook arrives (instead of forwarding it to your app), you can enable webhook processing in a sync script using `webhookSubscriptions` and `onWebhook`. For Google Calendar, subscribe to `'*'` and use the forwarded headers (e.g. `x-goog-resource-state`, `x-goog-resource-uri`) to decide what to fetch.
+
+See: [Real-time syncs](/implementation-guides/use-cases/syncs/realtime-syncs)
+</Note>
+
 ## Connection matching
 
 Nango matches the incoming request to a connection using the calendar identifier (email) extracted from `X-Goog-Resource-URI` (e.g. `.../calendars/user@example.com/events...`). The lookup order is:
@@ -174,7 +180,7 @@ For **new connections** (created after 2026-03-11), no action is needed. Nango a
 
 For **existing connections** created before this feature was available, you have two options:
 
-- **Re-authorize** the connection so Nango's post-connection hook runs and persists the email address automatically
+- **Re-authorize** the connection so Nango's post-connection hook runs and persists the email hash automatically
 - **Set the metadata manually** via the API:
 
 ```bash
@@ -191,10 +197,48 @@ curl -X PATCH "https://api.nango.dev/connection/metadata" \
 To do this in bulk, iterate over the [list connections](/reference/api/connection/list) response and [update the metadata](/reference/api/connection/update-metadata) for each one.
 
 <Warning>
-If Nango cannot match the incoming webhook to a connection (because neither `connection_config` nor `metadata` contains the email address), the webhook will still be received but won't include a `connectionId` in the forwarded payload.
+If Nango cannot match the incoming webhook to a connection (because it can't find a matching hash/email in `connection_config` or `metadata`), the webhook will still be received but won't include a `connectionId` in the forwarded payload.
 </Warning>
 
 ## Stop notifications
+
+If a connection is deleted in Nango but the channel remains active, Google may continue sending notifications until the channel expires. To stop notifications immediately for a deleted connection, call `channels.stop` before deletion.
+
+You can automate this with a `pre-connection-deletion` lifecycle event (this expects `googleCalendarChannelId` and `googleCalendarResourceId` to be present in connection metadata):
+
+```typescript
+import { createOnEvent, ProxyConfiguration } from 'nango';
+
+export default createOnEvent({
+    event: 'pre-connection-deletion',
+    description: 'Stop Google Calendar notification channel before connection deletion',
+    exec: async (nango) => {
+        const metadata = await nango.getMetadata();
+        const channelId = metadata['googleCalendarChannelId'];
+        const resourceId = metadata['googleCalendarResourceId'];
+
+        if (!channelId || !resourceId) {
+            return;
+        }
+
+        const config: ProxyConfiguration = {
+            baseUrlOverride: 'https://www.googleapis.com/calendar',
+            endpoint: '/v3/channels/stop',
+            data: {
+                id: channelId,
+                resourceId
+            }
+        };
+
+        try {
+            await nango.post(config);
+        } catch (err) {
+            // Avoid blocking connection deletion if stop fails.
+            await nango.log(`Failed to stop Calendar channel: ${String(err)}`);
+        }
+    }
+});
+```
 
 To stop receiving notifications before the channel expires, call the [channels.stop](https://developers.google.com/workspace/calendar/api/guides/push#stop-notifications) method with the channel `id` and `resourceId` returned when you created the channel:
 

--- a/docs/api-integrations/google-calendar/webhooks.mdx
+++ b/docs/api-integrations/google-calendar/webhooks.mdx
@@ -1,14 +1,14 @@
 ---
 title: 'How to setup webhooks with Google Calendar on Nango'
 sidebarTitle: 'Webhooks'
-description: 'Learn how to set up Google Calendar push notifications with notification channels and Nango'
+description: 'Learn how to set up Google Calendar webhooks with notification channels and Nango'
 ---
 
-This guide shows you how to receive real-time Google Calendar push notifications in Nango using [notification channels](https://developers.google.com/workspace/calendar/api/guides/push#create-notification-channels). Unlike Gmail, Google Calendar does **not** require Google Cloud Pub/Sub—you configure a webhook URL directly with the Calendar API.
+This guide shows you how to receive real-time Google Calendar webhooks in Nango using [notification channels](https://developers.google.com/workspace/calendar/api/guides/push#create-notification-channels). Unlike Gmail, Google Calendar does **not** require Google Cloud Pub/Sub—you configure a webhook URL directly with the Calendar API.
 
 ## How it works
 
-The Google Calendar API uses notification channels to deliver push notifications. The flow is:
+The Google Calendar API uses notification channels to deliver webhooks. The flow is:
 
 1. You call the `watch` endpoint for the Google Calendar you want to monitor, passing your Nango webhook URL as the channel `address`.
 2. Google creates a notification channel and sends an initial `sync` message to your URL.
@@ -86,7 +86,7 @@ curl -X POST "https://www.googleapis.com/calendar/v3/calendars/<CALENDAR_ID>/eve
     "id": "01234567-89ab-cdef-0123456789ab",
     "type": "web_hook",
     "address": "<REPLACE_WITH_NANGO_WEBHOOK_URL>",
-    "expiration": 1426325213000
+    "expiration": <EXPIRATION>
   }'
 ```
 
@@ -100,7 +100,7 @@ Replace:
 
 ### 3. Renew the notification channel
 
-Google does **not** renew channels automatically. When a channel is close to its expiration, you must create a new channel by calling the `watch` endpoint again with a **new** unique `id`. See [Renew notification channels](https://developers.google.com/workspace/calendar/api/guides/push#renew-notification-channels).
+Google does **not** renew channels automatically. When a channel is close to its expiration, you must create a new channel by calling the `watch` endpoint again with a **new** unique `id`. After the new channel is created successfully, stop the old channel so only one remains active. See [Renew notification channels](https://developers.google.com/workspace/calendar/api/guides/push#renew-notification-channels).
 
 You can use a Nango sync with a suitable frequency (e.g. every few days) to renew the watch before it expires:
 
@@ -120,6 +120,10 @@ export default createSync({
     syncType: 'full',
     frequency: '1d',
     exec: async (nango) => {
+        const metadata = await nango.getMetadata();
+        const oldChannelId = metadata['googleCalendarChannelId'];
+        const oldResourceId = metadata['googleCalendarResourceId'];
+
         const calResponse = await nango.get({
             baseUrlOverride: 'https://www.googleapis.com/calendar',
             endpoint: '/v3/users/me/calendarList/primary' 
@@ -143,6 +147,19 @@ export default createSync({
         };
 
         const response = await nango.post(config);
+
+        // Stop the old channel only after the new one was successful
+        if (response.status === 200 && oldChannelId && oldResourceId) {
+            try {
+                await nango.post({
+                    baseUrlOverride: 'https://www.googleapis.com/calendar',
+                    endpoint: '/v3/channels/stop',
+                    data: { id: oldChannelId, resourceId: oldResourceId },
+                });
+            } catch (err) {
+                await nango.log(`Failed to stop previous channel: ${String(err)}`, { level: 'error' });
+            }
+        }
 
         // Update stored channel info for use in stop notifications (step 4)
         await nango.updateMetadata({
@@ -187,7 +204,7 @@ export default createOnEvent({
             await nango.post(config);
         } catch (err) {
             // Avoid blocking connection deletion if stop fails.
-            await nango.log(`Failed to stop Calendar channel: ${String(err)}`);
+            await nango.log(`Failed to stop Calendar channel: ${String(err)}`, { level: 'error' });
         }
     }
 });

--- a/docs/api-integrations/google-mail/webhooks.mdx
+++ b/docs/api-integrations/google-mail/webhooks.mdx
@@ -1,10 +1,10 @@
 ---
 title: 'How to setup webhooks with Gmail on Nango'
 sidebarTitle: 'Webhooks'
-description: 'Learn how to set up Gmail push notifications with Google Pub/Sub and Nango'
+description: 'Learn how to set up Gmail webhooks with Google Pub/Sub and Nango'
 ---
 
-This guide shows you how to receive real-time Gmail push notifications in Nango using [Google Pub/Sub](https://developers.google.com/workspace/gmail/api/guides/push).
+This guide shows you how to receive real-time Gmail webhooks in Nango using [Google Pub/Sub](https://developers.google.com/workspace/gmail/api/guides/push).
 
 ## How it works
 
@@ -26,7 +26,15 @@ Create a topic in the [Google Cloud Console](https://console.cloud.google.com/cl
 
 ### 2. Grant Gmail publish rights
 
-Gmail needs permission to publish to your topic. Run this with the [gcloud CLI](https://cloud.google.com/sdk/docs/install):
+Gmail needs permission to publish to your topic. You can do this in the [Google Cloud Console](https://console.cloud.google.com/cloudpubsub/topic/list) or with the gcloud CLI.
+
+**Option A — Google Cloud Console:**
+
+1. Open [Pub/Sub Topics](https://console.cloud.google.com/cloudpubsub/topic/list) in the Google Cloud Console.
+2. Click on your topic, then go to the **Permissions** tab.
+3. Click **Add principal**. Set the principal to `gmail-api-push@system.gserviceaccount.com` and assign the **Pub/Sub Publisher** role.
+
+**Option B — gcloud CLI:**
 
 ```bash
 gcloud pubsub topics add-iam-policy-binding <TOPIC_ID> \
@@ -41,10 +49,12 @@ The **topic ID** is the short name (e.g. `my-gmail-topic`), while the **topic na
 
 ### 3. Create a push subscription
 
-Click on the default subscription for your topic (if one was created) or create a new one. Set the delivery type to **Push** and configure it as follows:
+Click on the default subscription for your topic (if one was created) or create a new one. Select *Edit* and configure it as follows:
 
-1. **Endpoint URL**: Copy the webhook URL from your Gmail integration page in the Nango dashboard, under the **Webhook URL** section.
-2. **Authentication** (recommended): Enable authentication and configure a service account for added security.
+1. **Delivery type**: Set as push
+2. **Endpoint URL**: Copy the webhook URL from your Gmail integration page in the Nango dashboard, under the **Webhook URL** section.
+3. **Authentication** (recommended): Enable authentication and configure a service account for added security.
+4. **Save the changes**
 
 ### 4. Activate the watch subscription
 
@@ -70,14 +80,14 @@ export default createOnEvent({
     event: 'post-connection-creation',
     description: 'Activate the Gmail watch webhook subscription for new connections',
     exec: async (nango) => {
-        const metadata = await nango.getMetadata();
-
         const config: ProxyConfiguration = {
             baseUrlOverride: 'https://www.googleapis.com/gmail',
             endpoint: '/v1/users/me/watch',
             data: {
                 labelIds: ['INBOX'],
-                topicName: metadata['topicName'] ?? 'projects/<PROJECT_ID>/topics/<TOPIC_ID>',
+                // Replace with your full topic name from the Pub/Sub setup (step 1)
+                // Ideally, you should set the value to be read from the Nango env variables (https://nango.dev/docs/reference/functions#environment-variables)
+                topicName: 'projects/<PROJECT_ID>/topics/<TOPIC_ID>',
                 labelFilterBehavior: 'INCLUDE',
             },
         };
@@ -93,26 +103,25 @@ Google [recommends](https://developers.google.com/workspace/gmail/api/guides/pus
 
 ```typescript
 import { createSync, ProxyConfiguration } from 'nango';
-import { Empty } from '../../models.js';
 
 export default createSync({
     description: 'Calls the watch endpoint daily to keep a Gmail webhook subscription active',
-    models: { Empty },
+    models: { Empty: z.object({}) },
     endpoints: [{
         method: 'GET',
-        path: '/watch',
+        path: '/gmail/watch-renewal',
     }],
     syncType: 'full',
     frequency: '1d',
     exec: async (nango) => {
-        const metadata = await nango.getMetadata();
-
         const config: ProxyConfiguration = {
             baseUrlOverride: 'https://www.googleapis.com/gmail',
             endpoint: '/v1/users/me/watch',
             data: {
                 labelIds: ['INBOX'],
-                topicName: metadata['topicName'] ?? 'projects/<PROJECT_ID>/topics/<TOPIC_ID>',
+                // Replace with your full topic name from the Pub/Sub setup (step 1)
+                // Ideally, you should set the value to be read from the Nango env variables (https://nango.dev/docs/reference/functions#environment-variables)
+                topicName: 'projects/<PROJECT_ID>/topics/<TOPIC_ID>',
                 labelFilterBehavior: 'INCLUDE',
             },
         };

--- a/docs/api-integrations/google-mail/webhooks.mdx
+++ b/docs/api-integrations/google-mail/webhooks.mdx
@@ -99,10 +99,11 @@ export default createOnEvent({
 
 ### 5. Renew the watch subscription daily
 
-Google [recommends](https://developers.google.com/workspace/gmail/api/guides/push#renewing_mailbox_watch) calling the `watch` endpoint at least once a day to keep the subscription active. You can use a Nango sync with a `1d` frequency for this:
+Google [recommends](https://developers.google.com/workspace/gmail/api/guides/push#renewing_mailbox_watch) calling the `watch` endpoint at least once a day to keep the subscription active. Each call replaces any existing watch for the user, so no separate cleanup is needed. You can use a Nango sync with a `1d` frequency for this:
 
 ```typescript
 import { createSync, ProxyConfiguration } from 'nango';
+import { z } from 'zod';
 
 export default createSync({
     description: 'Calls the watch endpoint daily to keep a Gmail webhook subscription active',
@@ -154,7 +155,7 @@ export default createOnEvent({
             await nango.post(config);
         } catch (err) {
             // Avoid blocking connection deletion if stop fails.
-            await nango.log(`Failed to stop Gmail watch subscription: ${String(err)}`);
+            await nango.log(`Failed to stop Gmail watch subscription: ${String(err)}`, { level: 'error' });
         }
     }
 });

--- a/docs/api-integrations/google-mail/webhooks.mdx
+++ b/docs/api-integrations/google-mail/webhooks.mdx
@@ -123,7 +123,35 @@ export default createSync({
 });
 ```
 
-### 6. Handle forwarded webhooks
+### 6. Stop the watch subscription on connection deletion
+
+If a connection is deleted in Nango but the Gmail watch remains active, Google may continue sending notifications for that mailbox until the watch expires. To stop notifications immediately for a deleted connection, call Gmail's [`users.stop`](https://developers.google.com/workspace/gmail/api/reference/rest/v1/users/stop) endpoint before deletion.
+
+You can automate this with a `pre-connection-deletion` lifecycle event:
+
+```typescript
+import { createOnEvent, ProxyConfiguration } from 'nango';
+
+export default createOnEvent({
+    event: 'pre-connection-deletion',
+    description: 'Stop Gmail watch subscription before connection deletion',
+    exec: async (nango) => {
+        const config: ProxyConfiguration = {
+            baseUrlOverride: 'https://www.googleapis.com/gmail',
+            endpoint: '/v1/users/me/stop'
+        };
+
+        try {
+            await nango.post(config);
+        } catch (err) {
+            // Avoid blocking connection deletion if stop fails.
+            await nango.log(`Failed to stop Gmail watch subscription: ${String(err)}`);
+        }
+    }
+});
+```
+
+### 7. Handle forwarded webhooks
 
 When a Gmail notification arrives, Nango matches it to the correct connection and forwards it to your system. The forwarded payload looks like this:
 
@@ -165,6 +193,12 @@ curl -X POST "https://api.nango.dev/sync/trigger" \
 ```
 
 With webhooks triggering syncs in real time, you can reduce your sync frequency to a lower value (`1d`/`1h`) just to act as a safety net for any missed webhooks.
+
+<Note>
+If you prefer Nango to automatically run a sync when the webhook arrives (instead of forwarding it to your app), you can enable webhook processing in a sync script using `webhookSubscriptions` and `onWebhook`. For Gmail, subscribe to `'*'` and decode `payload.message.data` to get `historyId`.
+
+See: [Real-time syncs](/implementation-guides/use-cases/syncs/realtime-syncs)
+</Note>
 
 ## Connection matching
 


### PR DESCRIPTION
docs: add stop listening on connection deletion and real-time sync concept for gmail and google calendar webhooks

<!-- Describe the problem and your solution --> 

<!-- Issue ticket number and link (if applicable) -->

<!-- Testing instructions (skip if just adding/editing providers) -->


<!-- Summary by @propel-code-bot -->

---

**Update Gmail and Google Calendar webhook documentation with lifecycle and real-time sync guidance**

This PR revises the Gmail and Google Calendar webhook docs to clarify setup wording, add lifecycle cleanup steps, and document real-time sync options. It introduces examples for automated channel/watch creation, renewal flows with metadata storage, and pre-connection deletion cleanup, plus notes on connection matching and webhook-driven sync behavior.

---
*This summary was automatically generated by @propel-code-bot*