### PR TITLE
refactor(cli): light refac on build and deploy 

### DIFF
--- a/packages/cli/lib/index.ts
+++ b/packages/cli/lib/index.ts
@@ -27,7 +27,7 @@ import { MissingArgumentError } from './utils/errors.js';
 import { getNangoRootPath, isCI, printDebug, upgradeAction } from './utils.js';
 import { checkAndSyncPackageJson } from './zeroYaml/check.js';
 import { compileAllFunctions } from './zeroYaml/compile.js';
-import { buildDefinitions } from './zeroYaml/definitions.js';
+import { parseIntegrationDefinitions } from './zeroYaml/definitions.js';
 import { deploy } from './zeroYaml/deploy.js';
 import { dev } from './zeroYaml/dev.js';
 import { initZero } from './zeroYaml/init.js';
@@ -207,7 +207,7 @@ program
 
             let integrations: string[] = [];
 
-            const definitions = await buildDefinitions({ fullPath: absolutePath, debug: debug });
+            const definitions = await parseIntegrationDefinitions({ fullPath: absolutePath, debug: debug });
             if (definitions.isOk()) {
                 integrations = definitions.value.integrations.flatMap((i) => i.providerConfigKey);
             } else {
@@ -314,7 +314,7 @@ program
             const ensure = new Ensure(interactive);
             environment = await ensure.environment(environment, debug);
 
-            const definitions = await buildDefinitions({ fullPath, debug });
+            const definitions = await parseIntegrationDefinitions({ fullPath, debug });
             if (definitions.isErr()) {
                 console.error(chalk.red('Could not build function definitions to select from.'));
                 process.exit(1);
@@ -524,7 +524,7 @@ program
             return;
         }
 
-        const def = await buildDefinitions({ fullPath, debug });
+        const def = await parseIntegrationDefinitions({ fullPath, debug });
         if (def.isErr()) {
             console.log('');
             console.log(def.error instanceof ReadableError ? def.error.toText() : chalk.red(def.error.message));

--- a/packages/cli/lib/services/dryrun.service.ts
+++ b/packages/cli/lib/services/dryrun.service.ts
@@ -28,7 +28,7 @@ import * as nangoScript from '../sdkScripts.js';
 import { displayValidationError } from '../utils/errors.js';
 import { getConfig, getConnection, parseSecretKey, printDebug, resolveHostport } from '../utils.js';
 import { NangoActionCLI, NangoSyncCLI } from './sdk.js';
-import { buildDefinitions } from '../zeroYaml/definitions.js';
+import { parseIntegrationDefinitions } from '../zeroYaml/definitions.js';
 import { ReadableError } from '../zeroYaml/utils.js';
 
 import type { GlobalOptions } from '../types.js';
@@ -149,7 +149,7 @@ export class DryRunService {
             return;
         }
 
-        const def = await buildDefinitions({ fullPath: this.fullPath, debug });
+        const def = await parseIntegrationDefinitions({ fullPath: this.fullPath, debug });
         if (def.isErr()) {
             console.log('');
             console.log(def.error instanceof ReadableError ? def.error.toText() : chalk.red(def.error.message));

--- a/packages/cli/lib/services/model.service.ts
+++ b/packages/cli/lib/services/model.service.ts
@@ -217,7 +217,17 @@ export function generateAdditionalExports({ fullPath, parsed, debug }: { fullPat
         printDebug(`Generated export ${pathJSON}`);
     }
 
-    fs.writeFileSync(path.join(exportPath, 'nango.json'), JSON.stringify(parsed.integrations, null, 2));
+    const nangoJsonPath = path.join(exportPath, 'nango.json');
+    fs.writeFileSync(nangoJsonPath, JSON.stringify(parsed.integrations, null, 2));
+    if (debug) {
+        printDebug(`Generated export ${nangoJsonPath}`);
+    }
+
+    console.log(
+        chalk.yellow(
+            '[DEPRECATION NOTICE] The generated .nango/schema.ts and .nango/schema.json files are deprecated and will stop being generated in future versions of nango. For access to function types, please export types directly from your code. You can leverage `zod.infer` to generate types from your zod schemas. See the official zod documentation: https://zod.dev/basics?id=inferring-types'
+        )
+    );
 }
 
 export function getExportToTS({ parsed }: { parsed: NangoYamlParsed }): string {

--- a/packages/cli/lib/services/model.service.ts
+++ b/packages/cli/lib/services/model.service.ts
@@ -225,7 +225,7 @@ export function generateAdditionalExports({ fullPath, parsed, debug }: { fullPat
 
     console.log(
         chalk.yellow(
-            '[DEPRECATION NOTICE] The generated .nango/schema.ts and .nango/schema.json files are deprecated and will stop being generated in future versions of nango. For access to function types, please export types directly from your code. You can leverage `zod.infer` to generate types from your zod schemas. See the official zod documentation: https://zod.dev/basics?id=inferring-types'
+            'The generated .nango/schema.ts and .nango/schema.json are deprecated and will stop being generated in future versions. For access to function types, please export types directly from your code. You can leverage `zod.infer` to generate types from your zod schemas. See the official zod documentation: https://zod.dev/basics?id=inferring-types'
         )
     );
 }

--- a/packages/cli/lib/services/model.service.ts
+++ b/packages/cli/lib/services/model.service.ts
@@ -222,12 +222,6 @@ export function generateAdditionalExports({ fullPath, parsed, debug }: { fullPat
     if (debug) {
         printDebug(`Generated export ${nangoJsonPath}`);
     }
-
-    console.log(
-        chalk.yellow(
-            'The generated .nango/schema.ts and .nango/schema.json are deprecated and will stop being generated in future versions. For access to function types, please export types directly from your code. You can leverage `zod.infer` to generate types from your zod schemas. See the official zod documentation: https://zod.dev/basics?id=inferring-types'
-        )
-    );
 }
 
 export function getExportToTS({ parsed }: { parsed: NangoYamlParsed }): string {

--- a/packages/cli/lib/services/test.service.ts
+++ b/packages/cli/lib/services/test.service.ts
@@ -12,7 +12,7 @@ import ejs from 'ejs';
 import { Spinner } from '../utils/spinner.js';
 import { detectPackageManager, printDebug } from '../utils.js';
 import { compileAllFunctions } from '../zeroYaml/compile.js';
-import { buildDefinitions } from '../zeroYaml/definitions.js';
+import { parseIntegrationDefinitions } from '../zeroYaml/definitions.js';
 
 const execAsync = promisify(exec);
 
@@ -498,7 +498,7 @@ export async function generateTests({
             return { success: false, generatedFiles: [] };
         }
 
-        const defsResult = await buildDefinitions({ fullPath: absolutePath, debug });
+        const defsResult = await parseIntegrationDefinitions({ fullPath: absolutePath, debug });
         if (defsResult.isErr()) {
             console.error(chalk.red(`Failed to build definitions: ${defsResult.error}`));
             return { success: false, generatedFiles: [] };

--- a/packages/cli/lib/zeroYaml/compile.ts
+++ b/packages/cli/lib/zeroYaml/compile.ts
@@ -8,7 +8,7 @@ import { serializeError } from 'serialize-error';
 import ts from 'typescript';
 
 import { allowedPackages, importRegex, npmPackageRegex, tsconfig, tsconfigString } from './constants.js';
-import { buildDefinitions } from './definitions.js';
+import { parseIntegrationDefinitions } from './definitions.js';
 import { CompileError, ReadableError, badExportCompilerError, fileErrorToText, tsDiagnosticToText } from './utils.js';
 import { generateAdditionalExports } from '../services/model.service.js';
 import { Err, Ok } from '../utils/result.js';

--- a/packages/cli/lib/zeroYaml/compile.ts
+++ b/packages/cli/lib/zeroYaml/compile.ts
@@ -89,8 +89,8 @@ export async function compileAllFunctions({
         spinner.succeed();
 
         // Build and export the definitions
-        spinner = spinnerFactory.start('Exporting definitions');
-        const def = await buildDefinitions({ fullPath, debug });
+        spinner = spinnerFactory.start('Generating artifacts');
+        const def = await parseIntegrationDefinitions({ fullPath, debug });
         if (def.isErr()) {
             spinner.fail(`Failed to compile definitions`);
             console.log('');

--- a/packages/cli/lib/zeroYaml/definitions.ts
+++ b/packages/cli/lib/zeroYaml/definitions.ts
@@ -24,7 +24,7 @@ import type * as z from 'zod';
 
 const allowed = ['action', 'sync', 'onEvent'];
 
-export async function buildDefinitions({ fullPath, debug }: { fullPath: string; debug: boolean }): Promise<Result<NangoYamlParsed>> {
+export async function parseIntegrationDefinitions({ fullPath, debug }: { fullPath: string; debug: boolean }): Promise<Result<NangoYamlParsed>> {
     const parsed: NangoYamlParsed = { yamlVersion: 'v2', integrations: [], models: new Map() };
 
     printDebug('Rebuilding parsed from js files', debug);

--- a/packages/cli/lib/zeroYaml/deploy.ts
+++ b/packages/cli/lib/zeroYaml/deploy.ts
@@ -137,7 +137,12 @@ export async function deploy({
     }
 }
 
-async function createPackage({
+/**
+ * Maps NangoYamlParsed (which is a list of integrations and its function definitions) into the shape expected by the API,
+ * while also loading the content of the related script files.
+ * It also supports filtering by integration, sync or action name for single deploys.
+ */
+async function createDeployConfirmationPackage({
     parsed,
     fullPath,
     debug,

--- a/packages/cli/lib/zeroYaml/deploy.ts
+++ b/packages/cli/lib/zeroYaml/deploy.ts
@@ -5,7 +5,7 @@ import chalk from 'chalk';
 import columnify from 'columnify';
 import promptly from 'promptly';
 
-import { buildDefinitions } from './definitions.js';
+import { parseIntegrationDefinitions } from './definitions.js';
 import { ReadableError } from './utils.js';
 import { Err, Ok } from '../utils/result.js';
 import { Spinner } from '../utils/spinner.js';
@@ -45,8 +45,7 @@ export async function deploy({
     let pkg: Package;
     const spinnerPackage = spinnerFactory.start('Packaging');
     try {
-        // Prepare retro-compat json
-        const def = await buildDefinitions({ fullPath, debug });
+        const def = await parseIntegrationDefinitions({ fullPath, debug });
         if (def.isErr()) {
             spinnerPackage.fail();
             console.log('');
@@ -54,8 +53,7 @@ export async function deploy({
             return Err(def.error);
         }
 
-        // Create deploy package
-        const postData = await createPackage({
+        const postData = await createDeployConfirmationPackage({
             parsed: def.value,
             fullPath,
             debug,


### PR DESCRIPTION
Some light renaming and comment that IMO makes this a bit more understandable. Ideally I would rename `NangoYamlParsed` and so on, but it still has a lot has dependents. I also went a bit further but went back on some changes. Trying to reduce risk of breaking something while still improving this a bit.

Plan on also moving some files around, but that would make the PR review confusing. Will hold off for now.

<!-- Summary by @propel-code-bot -->

---

**Rename definition parsing helper and clarify CLI packaging output**

This PR performs light refactoring across the CLI to rename `buildDefinitions` to `parseIntegrationDefinitions`, updating all call sites in deploy, compile, dry-run, test generation, and command routing. It also improves naming for deploy packaging by renaming `createPackage` to `createDeployConfirmationPackage` and adds clarifying comments.

Additionally, `generateAdditionalExports` now logs the `nango.json` export path when debug is enabled, and the generated `schema.ts` export includes a deprecation notice in its header comment.

---
*This summary was automatically generated by @propel-code-bot*