### PR TITLE
feat(database): add role column to users/invitations and is_production to environments

### DIFF
--- a/packages/database/lib/migrations/20260313120000_add_role_to_users.cjs
+++ b/packages/database/lib/migrations/20260313120000_add_role_to_users.cjs
@@ -1,0 +1,21 @@
+exports.config = { transaction: false };
+
+/**
+ * @param {import('knex').Knex} knex
+ */
+exports.up = async function (knex) {
+    await knex.raw(`
+        ALTER TABLE _nango_users
+        ADD COLUMN IF NOT EXISTS role VARCHAR(50) NOT NULL DEFAULT 'administrator'
+    `);
+};
+
+/**
+ * @param {import('knex').Knex} knex
+ */
+exports.down = async function (knex) {
+    await knex.raw(`
+        ALTER TABLE _nango_users
+        DROP COLUMN IF EXISTS role
+    `);
+};

--- a/packages/database/lib/migrations/20260313120000_add_role_to_users.cjs
+++ b/packages/database/lib/migrations/20260313120000_add_role_to_users.cjs
@@ -8,14 +8,11 @@ exports.up = async function (knex) {
         ALTER TABLE _nango_users
         ADD COLUMN IF NOT EXISTS role VARCHAR(50) NOT NULL DEFAULT 'administrator'
     `);
-};
 
-/**
- * @param {import('knex').Knex} knex
- */
-exports.down = async function (knex) {
     await knex.raw(`
         ALTER TABLE _nango_users
-        DROP COLUMN IF EXISTS role
+        ADD CONSTRAINT check_users_role CHECK (role IN ('administrator', 'production_support', 'development_full_access'))
     `);
 };
+
+exports.down = function () {};

--- a/packages/database/lib/migrations/20260313120000_add_role_to_users.cjs
+++ b/packages/database/lib/migrations/20260313120000_add_role_to_users.cjs
@@ -7,11 +7,7 @@ exports.up = async function (knex) {
     await knex.raw(`
         ALTER TABLE _nango_users
         ADD COLUMN IF NOT EXISTS role VARCHAR(50) NOT NULL DEFAULT 'administrator'
-    `);
-
-    await knex.raw(`
-        ALTER TABLE _nango_users
-        ADD CONSTRAINT check_users_role CHECK (role IN ('administrator', 'production_support', 'development_full_access'))
+        CONSTRAINT check_users_role CHECK (role IN ('administrator', 'production_support', 'development_full_access'))
     `);
 };
 

--- a/packages/database/lib/migrations/20260313120001_add_role_to_invitations.cjs
+++ b/packages/database/lib/migrations/20260313120001_add_role_to_invitations.cjs
@@ -8,14 +8,11 @@ exports.up = async function (knex) {
         ALTER TABLE _nango_invited_users
         ADD COLUMN IF NOT EXISTS role VARCHAR(50) NOT NULL DEFAULT 'administrator'
     `);
-};
 
-/**
- * @param {import('knex').Knex} knex
- */
-exports.down = async function (knex) {
     await knex.raw(`
         ALTER TABLE _nango_invited_users
-        DROP COLUMN IF EXISTS role
+        ADD CONSTRAINT check_invited_users_role CHECK (role IN ('administrator', 'production_support', 'development_full_access'))
     `);
 };
+
+exports.down = function () {};

--- a/packages/database/lib/migrations/20260313120001_add_role_to_invitations.cjs
+++ b/packages/database/lib/migrations/20260313120001_add_role_to_invitations.cjs
@@ -1,0 +1,21 @@
+exports.config = { transaction: false };
+
+/**
+ * @param {import('knex').Knex} knex
+ */
+exports.up = async function (knex) {
+    await knex.raw(`
+        ALTER TABLE _nango_invited_users
+        ADD COLUMN IF NOT EXISTS role VARCHAR(50) NOT NULL DEFAULT 'administrator'
+    `);
+};
+
+/**
+ * @param {import('knex').Knex} knex
+ */
+exports.down = async function (knex) {
+    await knex.raw(`
+        ALTER TABLE _nango_invited_users
+        DROP COLUMN IF EXISTS role
+    `);
+};

--- a/packages/database/lib/migrations/20260313120001_add_role_to_invitations.cjs
+++ b/packages/database/lib/migrations/20260313120001_add_role_to_invitations.cjs
@@ -7,11 +7,7 @@ exports.up = async function (knex) {
     await knex.raw(`
         ALTER TABLE _nango_invited_users
         ADD COLUMN IF NOT EXISTS role VARCHAR(50) NOT NULL DEFAULT 'administrator'
-    `);
-
-    await knex.raw(`
-        ALTER TABLE _nango_invited_users
-        ADD CONSTRAINT check_invited_users_role CHECK (role IN ('administrator', 'production_support', 'development_full_access'))
+        CONSTRAINT check_invited_users_role CHECK (role IN ('administrator', 'production_support', 'development_full_access'))
     `);
 };
 

--- a/packages/database/lib/migrations/20260313120002_add_is_production_to_environments.cjs
+++ b/packages/database/lib/migrations/20260313120002_add_is_production_to_environments.cjs
@@ -1,0 +1,21 @@
+exports.config = { transaction: false };
+
+/**
+ * @param {import('knex').Knex} knex
+ */
+exports.up = async function (knex) {
+    await knex.raw(`
+        ALTER TABLE _nango_environments
+        ADD COLUMN IF NOT EXISTS is_production BOOLEAN NOT NULL DEFAULT false
+    `);
+};
+
+/**
+ * @param {import('knex').Knex} knex
+ */
+exports.down = async function (knex) {
+    await knex.raw(`
+        ALTER TABLE _nango_environments
+        DROP COLUMN IF EXISTS is_production
+    `);
+};

--- a/packages/database/lib/migrations/20260313120002_add_is_production_to_environments.cjs
+++ b/packages/database/lib/migrations/20260313120002_add_is_production_to_environments.cjs
@@ -10,12 +10,4 @@ exports.up = async function (knex) {
     `);
 };
 
-/**
- * @param {import('knex').Knex} knex
- */
-exports.down = async function (knex) {
-    await knex.raw(`
-        ALTER TABLE _nango_environments
-        DROP COLUMN IF EXISTS is_production
-    `);
-};
+exports.down = function () {};

--- a/packages/shared/lib/services/environment.service.integration.test.ts
+++ b/packages/shared/lib/services/environment.service.integration.test.ts
@@ -29,6 +29,7 @@ describe('Environment service', () => {
             hmac_enabled: false,
             hmac_key: null,
             id: expect.any(Number),
+            is_production: false,
             name: envName,
             pending_public_key: null,
             pending_secret_key: null,


### PR DESCRIPTION
Add schema migrations for the permissions system (NAN-2184):
- Add `role` column (VARCHAR(50), default 'administrator') to _nango_users
- Add `role` column (VARCHAR(50), default 'administrator') to _nango_invited_users
- Add `is_production` column (BOOLEAN, default false) to _nango_environments

We will doing first this migration which should be a `noop` from the point of view of our application, once this one is in place we will follow up with the following changes

- [PR](https://github.com/NangoHQ/nango/pull/5631) for add logic in our app for tagging all new created `prod` environments as `is_production` as `True`
- [PR](https://github.com/NangoHQ/nango/pull/5632) for adding a new migration for updating all existing `prod` environments as `is_production`  as `True`

This will allow us to not have any dat race and keeping the all proper `prod` environments tagged as they should be

After that we will proceed with more PRs for supporting the RBAC system

<!-- Describe the problem and your solution --> 

<!-- Issue ticket number and link (if applicable) -->

<!-- Testing instructions (skip if just adding/editing providers) -->


<!-- Summary by @propel-code-bot -->

---

It also updates the environment service integration test expectations to include the new default value for `is_production`.

---
*This summary was automatically generated by @propel-code-bot*