### PR TITLE
fix(fleet): fix node config override checks

### DIFF
--- a/packages/fleet/lib/models/node_config_overrides.ts
+++ b/packages/fleet/lib/models/node_config_overrides.ts
@@ -97,6 +97,8 @@ export async function upsert(
             ...(props.isProfilingEnabled !== undefined ? { is_profiling_enabled: props.isProfilingEnabled } : {}),
             ...(props.idleMaxDurationMs !== undefined ? { idle_max_duration_ms: props.idleMaxDurationMs } : {}),
             ...(props.replicas !== undefined ? { replicas: props.replicas } : {}),
+            ...(props.executionTimeoutSecs !== undefined ? { execution_timeout_secs: props.executionTimeoutSecs } : {}),
+            ...(props.provisionedConcurrency !== undefined ? { provisioned_concurrency: props.provisionedConcurrency } : {}),
             updated_at: now
         };
 

--- a/packages/fleet/lib/supervisor/supervisor.ts
+++ b/packages/fleet/lib/supervisor/supervisor.ts
@@ -212,10 +212,10 @@ export class Supervisor {
                     if (configOverride.replicas !== null && configOverride.replicas !== node.replicas) {
                         return true;
                     }
-                    if (configOverride.executionTimeoutSecs && configOverride.executionTimeoutSecs !== node.executionTimeoutSecs) {
+                    if (configOverride.executionTimeoutSecs !== null && configOverride.executionTimeoutSecs !== node.executionTimeoutSecs) {
                         return true;
                     }
-                    if (configOverride.provisionedConcurrency && configOverride.provisionedConcurrency !== node.provisionedConcurrency) {
+                    if (configOverride.provisionedConcurrency !== null && configOverride.provisionedConcurrency !== node.provisionedConcurrency) {
                         return true;
                     }
                     return false;

--- a/packages/fleet/lib/supervisor/supervisor.ts
+++ b/packages/fleet/lib/supervisor/supervisor.ts
@@ -212,6 +212,12 @@ export class Supervisor {
                     if (configOverride.replicas !== null && configOverride.replicas !== node.replicas) {
                         return true;
                     }
+                    if (configOverride.executionTimeoutSecs && configOverride.executionTimeoutSecs !== node.executionTimeoutSecs) {
+                        return true;
+                    }
+                    if (configOverride.provisionedConcurrency && configOverride.provisionedConcurrency !== node.provisionedConcurrency) {
+                        return true;
+                    }
                     return false;
                 };
                 plan.push(


### PR DESCRIPTION
<!-- Describe the problem and your solution --> 

<!-- Issue ticket number and link (if applicable) -->

<!-- Testing instructions (skip if just adding/editing providers) -->


<!-- Summary by @propel-code-bot -->

---

**Fix node config override comparisons and persistence**

This PR updates fleet node config override handling to include `executionTimeoutSecs` and `provisionedConcurrency` in outdated-node detection and in override upsert updates. The changes ensure these override fields are compared explicitly and persisted when overrides change.

---
*This summary was automatically generated by @propel-code-bot*