### PR TITLE
fix(autodelete): don't filter out entries with count=0

### DIFF
--- a/packages/records/lib/models/records.ts
+++ b/packages/records/lib/models/records.ts
@@ -1182,7 +1182,6 @@ export async function autoDeletingCandidate({ staleAfterMs }: { staleAfterMs: nu
             .from(RECORD_COUNTS_TABLE)
             .select<RecordCount[]>('*')
             .whereRaw(`updated_at < NOW() - INTERVAL '${staleAfterMs} milliseconds'`)
-            .where('count', '>', 0)
             .orderByRaw('RANDOM()')
             .limit(1);
 


### PR DESCRIPTION
Take into account entries in the records_count table that have `count = 0` when selecting candidates for records autodelete so the entry is cleaned up. Right now those entries are kept in the db.

<!-- Describe the problem and your solution --> 

<!-- Issue ticket number and link (if applicable) -->

<!-- Testing instructions (skip if just adding/editing providers) -->


<!-- Summary by @propel-code-bot -->

---

This PR removes the filter that excluded `record_counts` rows where `count` equals 0 when selecting auto-delete candidates. This ensures stale count entries with zero records are eligible for cleanup.

---
*This summary was automatically generated by @propel-code-bot*