### PR TITLE
feat(webflow-sync): add force update flag and monthly scheduled run

### DIFF
--- a/.github/workflows/webflow-sync.yaml
+++ b/.github/workflows/webflow-sync.yaml
@@ -9,6 +9,14 @@ on:
             - docs/integrations/all/*.md
             - packages/shared/flows.yaml
     workflow_dispatch:
+        inputs:
+            force_update:
+                description: 'Force update all providers regardless of changes'
+                required: false
+                default: 'false'
+                type: boolean
+    schedule:
+        - cron: '0 0 1 * *'
 
 concurrency:
     group: webflow-sync
@@ -31,3 +39,4 @@ jobs:
             - run: npx tsx scripts/webflow-api-sync.ts
               env:
                   WEBFLOW_CMS_API_TOKEN: ${{ secrets.WEBFLOW_CMS_API_TOKEN }}
+                  FORCE_UPDATE: ${{ github.event_name == 'schedule' || inputs.force_update == 'true' }}

--- a/scripts/webflow-api-sync.ts
+++ b/scripts/webflow-api-sync.ts
@@ -27,6 +27,8 @@ if (process.env['DRYRUN']) {
     dryRun = true;
 }
 
+const forceUpdate = process.env['FORCE_UPDATE'] === 'true';
+
 const webflow = new WebflowClient({ accessToken: process.env['WEBFLOW_CMS_API_TOKEN'] });
 
 const providersPath = 'packages/providers/providers.yaml';
@@ -162,7 +164,7 @@ for (const [slug, provider] of Object.entries(neededProviders)) {
             }
         };
 
-        if (!util.isDeepStrictEqual(previous, update)) {
+        if (forceUpdate || !util.isDeepStrictEqual(previous, update)) {
             // always update logo, just in case
             (update.fieldData as any).logo = logo;
 


### PR DESCRIPTION
## Describe the problem and your solution

- Add a force update flag and a monthly scheduled run to ensure any providers added in the past but missing from the docs are listed.

<!-- Issue ticket number and link (if applicable) -->

<!-- Testing instructions (skip if just adding/editing providers) -->


<!-- Summary by @propel-code-bot -->

---

**Add manual force update input and monthly schedule to Webflow sync**

This PR updates the Webflow sync workflow to support a manual `force_update` input and a monthly scheduled run, enabling periodic full refreshes. It also wires a `FORCE_UPDATE` environment variable into `scripts/webflow-api-sync.ts` to bypass diff checks when forced.

---
*This summary was automatically generated by @propel-code-bot*