### PR TITLE
refactor(server): remove nango yaml logic from `POST /flows/pre-built/deploy`

### DIFF
--- a/packages/server/lib/controllers/scripts/config/getScriptsConfigOpenAI.unit.test.ts
+++ b/packages/server/lib/controllers/scripts/config/getScriptsConfigOpenAI.unit.test.ts
@@ -22,8 +22,7 @@ describe('transformToOpenAIFunctions', () => {
                             properties: {},
                             required: []
                         },
-                        sdk_version: '0.0.0',
-                        is_zero_yaml: false
+                        sdk_version: '0.0.0'
                     } as NangoSyncConfig
                 ],
                 actions: [],
@@ -72,8 +71,7 @@ describe('transformToOpenAIFunctions', () => {
                                 }
                             }
                         },
-                        sdk_version: '0.0.0',
-                        is_zero_yaml: false
+                        sdk_version: '0.0.0'
                     } as NangoSyncConfig
                 ],
                 'on-events': []

--- a/packages/server/lib/controllers/sync/deploy/postDeploy.integration.test.ts
+++ b/packages/server/lib/controllers/sync/deploy/postDeploy.integration.test.ts
@@ -213,7 +213,6 @@ describe(`POST ${endpoint}`, () => {
                             enabled: true,
                             endpoints: [{ method: 'GET', path: '/path', group: null }],
                             input: 'Input',
-                            is_zero_yaml: false,
                             sdk_version: expect.any(String),
                             is_public: false,
                             last_deployed: expect.toBeIsoDate(),

--- a/packages/shared/lib/seeders/syncConfig.seeder.ts
+++ b/packages/shared/lib/seeders/syncConfig.seeder.ts
@@ -8,7 +8,6 @@ export function getTestStdSyncConfig(data?: Partial<NangoSyncConfig>): NangoSync
         endpoints: [],
         returns: [],
         json_schema: {},
-        is_zero_yaml: false,
         sdk_version: '1.0.0',
         ...data
     };

--- a/packages/shared/lib/services/deploy/template.ts
+++ b/packages/shared/lib/services/deploy/template.ts
@@ -50,6 +50,12 @@ export async function deployTemplate({
         return Err(new NangoError('template_already_deployed'));
     }
 
+    if (!template.json_schema) {
+        void logCtx.error('Template missing json schema');
+        await logCtx.failed();
+        return Err(new NangoError('deploy_missing_json_schema_model'));
+    }
+
     const version = template.version || '0.0.1';
 
     void logCtx.info(`Uploading ${deployInfo.integrationId} -> ${template.name}@${version}`);

--- a/packages/shared/lib/services/deploy/template.ts
+++ b/packages/shared/lib/services/deploy/template.ts
@@ -1,6 +1,5 @@
 import db from '@nangohq/database';
-import { nangoConfigFile } from '@nangohq/nango-yaml';
-import { Err, Ok, env, filterJsonSchemaForModels } from '@nangohq/utils';
+import { Err, Ok, env } from '@nangohq/utils';
 
 import { switchActiveSyncConfig } from './utils.js';
 import { NangoError } from '../../utils/error.js';
@@ -21,7 +20,6 @@ import type {
     Result,
     SyncDeploymentResult
 } from '@nangohq/types';
-import type { JSONSchema7 } from 'json-schema';
 
 /**
  * Deploy a template from the S3 public folder, to the database and S3
@@ -56,34 +54,11 @@ export async function deployTemplate({
 
     void logCtx.info(`Uploading ${deployInfo.integrationId} -> ${template.name}@${version}`);
 
-    if (!template.is_zero_yaml) {
-        // Copy nango.yaml
-        // this is a public template so copy it from the public location
-        // We might not want to do this as it just overrides the root nango.yaml
-        // which means we overwrite any custom nango.yaml that the user has
-        const copy = await remoteFileService.copy({
-            sourcePath: `${publicRoute}/${nangoConfigFile}`,
-            destinationPath: `${remoteBasePath}/${nangoConfigFile}`,
-            destinationLocalPath: nangoConfigFile,
-            isZeroYaml: false
-        });
-        if (!copy) {
-            void logCtx.error('There was an error uploading the nango.yaml file');
-            await logCtx.failed();
-            return Err(new NangoError('failed_to_copy_yaml'));
-        }
-    }
-
     // Copy the main js file
     const copyJs = await remoteFileService.copy({
-        sourcePath: template.is_zero_yaml
-            ? `${publicRoute}/build/${deployInfo.provider}_${template.type}s_${template.name}.cjs`
-            : `${publicRoute}/dist/${template.name}-${deployInfo.provider}.js`,
+        sourcePath: `${publicRoute}/build/${deployInfo.provider}_${template.type}s_${template.name}.cjs`,
         destinationPath: `${remoteBasePathConfig}/${template.name}-v${version}.js`,
-        destinationLocalPath: template.is_zero_yaml
-            ? `build/${deployInfo.provider}-${template.type}s-${template.name}.cjs`
-            : `dist/${template.name}-${deployInfo.integrationId}.js`,
-        isZeroYaml: template.is_zero_yaml
+        destinationLocalPath: `build/${deployInfo.provider}-${template.type}s-${template.name}.cjs`
     });
     if (!copyJs) {
         void logCtx.error('There was an error uploading the main js file');
@@ -94,10 +69,9 @@ export async function deployTemplate({
 
     // Copy the typescript source file
     const copyTs = await remoteFileService.copy({
-        sourcePath: template.is_zero_yaml ? `${publicRoute}/${template.type}s/${template.name}.ts` : `${publicRoute}/${template.type}s/${template.name}.ts`,
+        sourcePath: `${publicRoute}/${template.type}s/${template.name}.ts`,
         destinationPath: `${remoteBasePathConfig}/${template.name}.ts`,
-        destinationLocalPath: `${deployInfo.integrationId}/${template.type}s/${template.name}.ts`,
-        isZeroYaml: template.is_zero_yaml
+        destinationLocalPath: `${deployInfo.integrationId}/${template.type}s/${template.name}.ts`
     });
     if (!copyTs) {
         void logCtx.error('There was an error uploading the source file');
@@ -106,31 +80,6 @@ export async function deployTemplate({
     }
 
     const modelsNames = [...template.returns, template.input].filter(Boolean) as string[];
-    // If it's a zero yaml template json schema is pre-bundled
-    // otherwise fetch it from the public folder
-    let models_json_schema: JSONSchema7 | null = null;
-    if (template.json_schema) {
-        models_json_schema = template.json_schema;
-    } else {
-        // fetch the json schema so we have type checking
-        const jsonSchemaString = await remoteFileService.getPublicTemplateJsonSchemaFile(publicRoute);
-        if (!jsonSchemaString) {
-            void logCtx.error('There was an error getting the json schema');
-            await logCtx.failed();
-            return Err(new NangoError('source_copy_error'));
-        }
-
-        if (jsonSchemaString) {
-            const jsonSchema = JSON.parse(jsonSchemaString) as JSONSchema7;
-            const result = filterJsonSchemaForModels(jsonSchema, modelsNames);
-            if (result.isErr()) {
-                void logCtx.error('There was an error parsing the json schema', { error: result.error });
-                await logCtx.failed();
-                return Err(new NangoError('deploy_missing_json_schema_model', result.error));
-            }
-            models_json_schema = result.value;
-        }
-    }
 
     const oldConfigs = await getSyncAndActionConfigsBySyncNameAndConfigId(environment.id, integration.id!, template.name);
     if (oldConfigs.length > 0) {
@@ -162,7 +111,7 @@ export async function deployTemplate({
         is_public: true,
         enabled: true,
         webhook_subscriptions: null,
-        models_json_schema,
+        models_json_schema: template.json_schema,
         sdk_version: template.sdk_version,
         updated_at: new Date(),
         sync_type: 'sync_type' in template ? template.sync_type : null
@@ -258,14 +207,9 @@ export async function upgradeTemplate({
 
     // Copy the main js file
     const copyJs = await remoteFileService.copy({
-        sourcePath: template.is_zero_yaml
-            ? `${publicRoute}/build/${provider}_${template.type}s_${template.name}.cjs`
-            : `${publicRoute}/dist/${template.name}-${provider}.js`,
+        sourcePath: `${publicRoute}/build/${provider}_${template.type}s_${template.name}.cjs`,
         destinationPath: `${remoteBasePathConfig}/${template.name}-v${template.version}.js`,
-        destinationLocalPath: template.is_zero_yaml
-            ? `build/${provider}-${template.type}s-${template.name}.cjs`
-            : `dist/${template.name}-${provider_config_key}.js`,
-        isZeroYaml: template.is_zero_yaml
+        destinationLocalPath: `build/${provider}-${template.type}s-${template.name}.cjs`
     });
     if (!copyJs) {
         void logCtx.error('There was an error uploading the main js file');
@@ -276,10 +220,9 @@ export async function upgradeTemplate({
 
     // Copy the typescript source file
     const copyTs = await remoteFileService.copy({
-        sourcePath: template.is_zero_yaml ? `${publicRoute}/${template.type}s/${template.name}.ts` : `${publicRoute}/${template.type}s/${template.name}.ts`,
+        sourcePath: `${publicRoute}/${template.type}s/${template.name}.ts`,
         destinationPath: `${remoteBasePathConfig}/${template.name}.ts`,
-        destinationLocalPath: `${provider_config_key}/${template.type}s/${template.name}.ts`,
-        isZeroYaml: template.is_zero_yaml
+        destinationLocalPath: `${provider_config_key}/${template.type}s/${template.name}.ts`
     });
     if (!copyTs) {
         void logCtx.error('There was an error uploading the source file');

--- a/packages/shared/lib/services/file/remote.service.ts
+++ b/packages/shared/lib/services/file/remote.service.ts
@@ -98,12 +98,10 @@ class RemoteFileService {
     async copy({
         sourcePath,
         destinationPath,
-        destinationLocalPath,
-        isZeroYaml
+        destinationLocalPath
     }: {
         sourcePath: string;
         destinationPath: string;
-        isZeroYaml: boolean;
         /**
          * sic
          * Destination when not uploading to S3
@@ -112,7 +110,7 @@ class RemoteFileService {
          */
         destinationLocalPath: string;
     }): Promise<string | null> {
-        const s3FilePath = `${isZeroYaml ? this.publicZeroYamlRoute : this.publicRoute}/${sourcePath}`;
+        const s3FilePath = `${this.publicZeroYamlRoute}/${sourcePath}`;
         try {
             if (isCloud) {
                 await this.client.send(

--- a/packages/shared/lib/services/flow.service.ts
+++ b/packages/shared/lib/services/flow.service.ts
@@ -55,8 +55,7 @@ class FlowService {
                     webhookSubscriptions: [],
                     json_schema: jsonSchema,
                     metadata: { description: item.description, scopes: item.scopes },
-                    sdk_version: `${integration.sdkVersion}-zero`,
-                    is_zero_yaml: true
+                    sdk_version: `${integration.sdkVersion}-zero`
                 });
             }
             for (const item of integration.actions) {
@@ -87,8 +86,7 @@ class FlowService {
                     webhookSubscriptions: [],
                     json_schema: jsonSchema,
                     metadata: { description: item.description, scopes: item.scopes },
-                    sdk_version: `${integration.sdkVersion}-zero`,
-                    is_zero_yaml: true
+                    sdk_version: `${integration.sdkVersion}-zero`
                 });
             }
 

--- a/packages/shared/lib/services/sync/config/config.service.ts
+++ b/packages/shared/lib/services/sync/config/config.service.ts
@@ -51,7 +51,6 @@ function convertSyncConfigToStandardConfig(syncConfigs: ExtendedSyncConfig[]): S
             webhookSubscriptions: syncConfig.webhook_subscriptions || [],
             json_schema: syncConfig.models_json_schema || null,
             sdk_version: syncConfig.sdk_version,
-            is_zero_yaml: syncConfig.sdk_version?.includes('zero') || false,
             // Temporary regression
             models: syncConfig.model_schema ?? modelsFromJsonSchema(syncConfig.models_json_schema)
         };

--- a/packages/types/lib/flow/index.ts
+++ b/packages/types/lib/flow/index.ts
@@ -27,7 +27,6 @@ export interface NangoSyncConfig {
     enabled?: boolean;
     json_schema: JSONSchema7 | null;
     upgrade_version?: string;
-    is_zero_yaml: boolean;
     sdk_version: string | null;
     // Temporary regression
     models?: NangoModel[] | LegacySyncModelSchema[] | undefined;


### PR DESCRIPTION
<!-- Summary by @propel-code-bot -->

**Refactor prebuilt deploy flow to drop `is_zero_yaml` handling and require template schema**

This PR removes `is_zero_yaml` branching across prebuilt template deployment and sync config handling, standardizing file copies to zero-yaml build locations. It also enforces presence of `template.json_schema` during deploy and stores it directly in sync config records without fetching schema files from public templates.

---
*This summary was automatically generated by @propel-code-bot*