### PR TITLE
feat(runner-sdk): deprecate `endpoints` in functions

### DIFF
--- a/docs/implementation-guides/platform/migrations/migrate-to-zero-yaml.mdx
+++ b/docs/implementation-guides/platform/migrations/migrate-to-zero-yaml.mdx
@@ -30,7 +30,6 @@ const issueSchema = z.object({
 
 const sync = createSync({
     description: 'Fetches GitHub issues',
-    endpoints: [{ method: 'GET', path: '/issues', group: 'Issues' }],
     frequency: 'every hour',
     models: { GithubIssue: issueSchema },
     exec: async (nango) => {
@@ -126,7 +125,6 @@ models:
 const sync = createSync({
     description: 'Fetches GitHub issues',
     frequency: 'every hour',
-    endpoints: [{ method: 'GET', path: '/issues', group: 'Issues' }],
     models: { GithubIssue: issueSchema }
 });
 ```
@@ -189,7 +187,6 @@ const issueSchema = z.object({
 const sync = createSync({
     description: 'Fetches GitHub issues',
     frequency: 'every hour',
-    endpoints: [{ method: 'GET', path: '/issues', group: 'Issues' }],
     models: { GithubIssue: issueSchema },
     exec: async (nango) => {
         // Your existing sync logic here
@@ -221,7 +218,6 @@ const inputSchema = z.object({
 
 const action = createAction({
     description: 'Create a GitHub issue',
-    endpoint: { method: 'POST', path: '/issues', group: 'Issues' },
     input: inputSchema,
     output: z.void(),
     exec: async (nango, input) => {

--- a/docs/implementation-guides/use-cases/actions/implement-an-action.mdx
+++ b/docs/implementation-guides/use-cases/actions/implement-an-action.mdx
@@ -91,7 +91,6 @@ const MyObject = z.object({
 export default createAction({
     description: `<Description of your action>`,
     version: '1.0.0', // Version, increment it when you release a new version
-    endpoints: [{ method: 'GET', path: '/<integration>/<object-name>', group: '<Group>' }],
     input: z.void(),
     output: MyObject,
     exec: async (nango) => {

--- a/docs/implementation-guides/use-cases/syncs/implement-a-sync.mdx
+++ b/docs/implementation-guides/use-cases/syncs/implement-a-sync.mdx
@@ -125,7 +125,6 @@ const MyObject = z.object({
 export default createSync({
     description: `<Description of your sync>`,
     version: '1.0.0', // Version, increment it when you release a new version
-    endpoints: [{ method: 'GET', path: '/<integration>/<object-name>', group: '<Group>' }],
     frequency: 'every hour', // Default sync interval
     autoStart: true, // Should the sync start immediately when a new connection is created?
     trackDeletes: true, // detect deletes? See separate implementation guide
@@ -175,7 +174,6 @@ const SalesforceContact = z.object({
 export default createSync({
   description: `Fetches contacts from Salesforce`,
   version: '1.0.0',
-  endpoints: [{ method: 'GET', path: '/salesforce/contacts', group: 'Contacts' }],
   frequency: 'every hour',
   autoStart: true,
   // Define checkpoint schema to track sync progress

--- a/docs/implementation-guides/use-cases/unified-apis.mdx
+++ b/docs/implementation-guides/use-cases/unified-apis.mdx
@@ -73,9 +73,9 @@ export const UserUnified = z.object({
 });
 ```
 
-### 2. Define your unified endpoints
+### 2. Implement your unified actions
 
-In your script's configuration, standardize the configuration of endpoints across APIs for consistency: use the same method, path, and parameters across APIs.
+Implement the same action for each API you want to unify, using the same input and output models for consistency.
 
 <CodeGroup>
 ```ts jira/create-user.ts
@@ -83,11 +83,6 @@ import { createAction } from 'nango';
 import { UserUnified } from './models.js';
 
 export default createAction({
-  endpoint: {
-    method: 'POST',
-    path: '/users',
-    group: 'Users',
-  },
   input: UserUnified,
   output: UserUnified,
   exec: async (nango, input) => {
@@ -101,11 +96,6 @@ import { createAction } from 'nango';
 import { UserUnified } from './models.js';
 
 export default createAction({
-  endpoint: {
-    method: 'POST',
-    path: '/users',
-    group: 'Users',
-  },
   input: UserUnified,
   output: UserUnified,
   exec: async (nango, input) => {

--- a/docs/reference/functions.mdx
+++ b/docs/reference/functions.mdx
@@ -18,7 +18,6 @@ description: "Full reference of the SDK available in Nango Functions."
     export default createSync({
       description: `Fetches the Github issues from all a user's repositories.`,
       version: '1.0.0',
-      endpoints: [{ method: 'GET', path: '/example/github/issues', group: 'Issues' }],
       frequency: 'every hour',
       autoStart: true,
       metadata: z.void(),
@@ -57,8 +56,6 @@ description: "Full reference of the SDK available in Nango Functions."
     export default createAction({
       description: `Create an issue in GitHub`,
       version: '1.0.0',
-      endpoint: { method: 'POST', path: '/example/github/issues', group: 'Issues' },
-
       input: GithubCreateIssueInput,
       output: GithubCreateIssueResult,
 
@@ -89,22 +86,6 @@ Read more about [integration functions](/guides/primitives/functions) to underst
 
 <ResponseField name="description" type="string" required>
   The description of the sync.
-</ResponseField>
-
-<ResponseField name="endpoints" type="object[]" required>
-  The endpoints of the sync.
-  You can call this endpoint to fetch records synced by the sync.
-  You need one endpoint per model.
-
-  ```ts
-  endpoints: [{ method: 'GET', path: '/github/issues' }],
-  ```
-
-  Which you can then call like this:
-
-  ```ts
-  const res = await fetch('https://api.nango.dev/github/issues');
-  ```
 </ResponseField>
 
 <ResponseField name="exec" type="function" required>
@@ -199,21 +180,17 @@ Read more about [integration functions](/guides/primitives/functions) to underst
   ```
 </ResponseField>
 
+<ResponseField name="endpoints" type="object[]" optional deprecated>
+  [DEPRECATED] Use the [`GET /records`](api/sync/records-list) API endpoint to fetch records.
+</ResponseField>
+
 ### `createAction`
 
 <ResponseField name="description" type="string" required>
   The description of the sync.
 </ResponseField>
 
-<ResponseField name="endpoint" type="object" required>
-  The endpoints of the sync.
-  You can call this endpoint to fetch records synced by the sync.
-  You need one endpoint per model.
 
-  ```ts
-  endpoint: { method: 'POST', path: '/github/issues' },
-  ```
-</ResponseField>
 
 <ResponseField name="exec" type="function" required>
   The function that will be called when the action is triggered.
@@ -261,6 +238,10 @@ Read more about [integration functions](/guides/primitives/functions) to underst
   ```ts
   scopes: ['read:user', 'write:user'],
   ```
+</ResponseField>
+
+<ResponseField name="endpoint" type="object" optional deprecated>
+  [DEPRECATED] Use the [`POST /action/trigger`](/reference/api/action/trigger) API endpoint to trigger actions.
 </ResponseField>
 
 ### `createOnEvent`

--- a/docs/reference/functions.mdx
+++ b/docs/reference/functions.mdx
@@ -181,7 +181,7 @@ Read more about [integration functions](/guides/primitives/functions) to underst
 </ResponseField>
 
 <ResponseField name="endpoints" type="object[]" optional deprecated>
-  [DEPRECATED] Use the [`GET /records`](api/sync/records-list) API endpoint to fetch records.
+  [DEPRECATED] Use the [`GET /records`](/reference/api/sync/records-list) API endpoint to fetch records.
 </ResponseField>
 
 ### `createAction`

--- a/packages/cli/lib/zeroYaml/definitions.ts
+++ b/packages/cli/lib/zeroYaml/definitions.ts
@@ -147,20 +147,22 @@ export function parseSync({
     if (interval instanceof Error) {
         return Err(new InvalidIntervalDefinitionError(filePath, ['createSync', 'frequency']));
     }
-    if (Object.keys(params.models).length !== params.endpoints.length) {
+    if (params.endpoints && Object.keys(params.models).length !== params.endpoints.length) {
         return Err(new EndpointMismatchDefinitionError(filePath, ['createSync', 'endpoints']));
     }
     if (params.syncType === 'incremental' && params.trackDeletes) {
         return Err(new TrackDeletesDefinitionError(filePath, ['createSync', 'trackDeletes']));
     }
 
-    const seen = new Set();
-    for (const endpoint of params.endpoints) {
-        const key = `${endpoint.method} ${endpoint.path}`;
-        if (seen.has(key)) {
-            return Err(new DuplicateEndpointDefinitionError(key, filePath, ['createSync', 'endpoints']));
+    if (params.endpoints) {
+        const seen = new Set();
+        for (const endpoint of params.endpoints) {
+            const key = `${endpoint.method} ${endpoint.path}`;
+            if (seen.has(key)) {
+                return Err(new DuplicateEndpointDefinitionError(key, filePath, ['createSync', 'endpoints']));
+            }
+            seen.add(key);
         }
-        seen.add(key);
     }
 
     for (const modelName of Object.keys(params.models)) {
@@ -182,7 +184,7 @@ export function parseSync({
         type: 'sync',
         description: params.description,
         auto_start: params.autoStart === true,
-        endpoints: params.endpoints,
+        endpoints: params.endpoints ?? [],
         input: metadataModelName,
         name: basename,
         output: outputNames,
@@ -223,7 +225,7 @@ export function parseAction({
     return {
         type: 'action' as const,
         description: params.description,
-        endpoint: params.endpoint,
+        endpoint: params.endpoint ?? null,
         input: inputName,
         name: basename,
         output: [outputName],

--- a/packages/cli/lib/zeroYaml/definitions.unit.test.ts
+++ b/packages/cli/lib/zeroYaml/definitions.unit.test.ts
@@ -38,6 +38,23 @@ const actionParams = {
 };
 
 describe('parseSync', () => {
+    it('should return the parsed sync without endpoints', () => {
+        const { endpoints, ...syncParamsWithoutEndpoints } = syncParams;
+        const res = parseSync({
+            filePath: './fetchIssues.ts',
+            params: syncParamsWithoutEndpoints,
+            basename: 'fetchIssues',
+            basenameClean: 'fetchIssues',
+            integrationIdClean: 'github'
+        });
+
+        expect(res.unwrap()).toMatchObject({
+            type: 'sync',
+            name: 'fetchIssues',
+            endpoints: []
+        });
+    });
+
     it('should return the parsed sync', () => {
         const res = parseSync({
             filePath: './fetchIssues.ts',
@@ -103,6 +120,22 @@ describe('buildNangoModelsForSync', () => {
 });
 
 describe('parseAction', () => {
+    it('should return the parsed action without endpoint', () => {
+        const { endpoint, ...actionParamsWithoutEndpoint } = actionParams;
+        const action = parseAction({
+            params: actionParamsWithoutEndpoint,
+            basename: 'createIssue',
+            basenameClean: 'createIssue',
+            integrationIdClean: 'github'
+        });
+
+        expect(action).toMatchObject({
+            type: 'action',
+            name: 'createIssue',
+            endpoint: null
+        });
+    });
+
     it('should return the parsed action', () => {
         const action = parseAction({
             params: actionParams,

--- a/packages/runner-sdk/lib/scripts.ts
+++ b/packages/runner-sdk/lib/scripts.ts
@@ -37,6 +37,7 @@ export interface CreateSyncProps<TModels extends Record<string, ZodModel>, TMeta
      * You can call this endpoint to fetch records synced by the sync.
      * You need one endpoint per model.
      *
+     * @deprecated Endpoints are no longer required. This field will be removed in a future version.
      * @example
      * ```ts
      * endpoints: [{ method: 'GET', path: '/github/issues' }],
@@ -45,7 +46,7 @@ export interface CreateSyncProps<TModels extends Record<string, ZodModel>, TMeta
      * const res = await fetch('https://api.nango.dev/github/issues');
      * ```
      */
-    endpoints: NangoSyncEndpointV2[];
+    endpoints?: NangoSyncEndpointV2[];
 
     /**
      * The frequency of the sync.
@@ -225,6 +226,7 @@ export interface CreateActionProps<
      * The endpoint of the action.
      * You can call this endpoint to trigger the action.
      *
+     * @deprecated Endpoints are no longer required. This field will be removed in a future version.
      * @example
      * ```ts
      * endpoint: { method: 'POST', path: '/github/issues' },
@@ -238,7 +240,7 @@ export interface CreateActionProps<
      * });
      * ```
      */
-    endpoint: NangoSyncEndpointV2;
+    endpoint?: NangoSyncEndpointV2;
 
     /**
      * The input required by the action when triggering it.

--- a/packages/runner-sdk/lib/scripts.unit.test.ts
+++ b/packages/runner-sdk/lib/scripts.unit.test.ts
@@ -63,6 +63,28 @@ describe('scripts', () => {
             });
         });
 
+        it('should create a sync without endpoints', () => {
+            const sync = createSync({
+                description: 'Fetch issues from GitHub',
+                frequency: 'every hour',
+                models: {
+                    issue: z.object({ id: z.string() })
+                },
+                exec: async (nango) => {
+                    await nango.log('Hello, world!');
+                }
+            });
+
+            expect(sync).toStrictEqual({
+                description: 'Fetch issues from GitHub',
+                frequency: 'every hour',
+                type: 'sync',
+                models: expect.any(Object),
+                exec: expect.any(Function)
+            });
+            expect(sync.endpoints).toBeUndefined();
+        });
+
         it('should correctly infer the type of the nango object when no models are provided', () => {
             createSync({
                 description: 'Fetch issues from GitHub',
@@ -88,6 +110,27 @@ describe('scripts', () => {
     });
 
     describe('createAction', () => {
+        it('should create an action without endpoint', () => {
+            const action = createAction({
+                description: 'Create a new issue in GitHub',
+                input: z.object({ title: z.string() }),
+                output: z.object({ issueId: z.string() }),
+                exec: async (nango, input) => {
+                    await nango.log('Hello, world!', input);
+                    return { issueId: '123' };
+                }
+            });
+
+            expect(action).toStrictEqual({
+                description: 'Create a new issue in GitHub',
+                input: expect.any(Object),
+                output: expect.any(Object),
+                type: 'action',
+                exec: expect.any(Function)
+            });
+            expect(action.endpoint).toBeUndefined();
+        });
+
         it('should create an action', () => {
             const action = createAction({
                 description: 'Create a new issue in GitHub',

--- a/packages/server/lib/controllers/v1/getV1.ts
+++ b/packages/server/lib/controllers/v1/getV1.ts
@@ -15,12 +15,16 @@ const schemaHeaders = z.object({
     'connection-id': connectionIdSchema
 });
 
+/** @deprecated Use POST /action/trigger to trigger actions and GET /records to fetch sync records instead. */
 export const allPublicV1 = asyncWrapper<GetPublicV1>(async (req, res, next) => {
     const valHeaders = schemaHeaders.safeParse(req.headers);
     if (!valHeaders.success) {
         res.status(400).send({ error: { code: 'invalid_headers', errors: zodErrorToHTTP(valHeaders.error) } });
         return;
     }
+
+    res.setHeader('Deprecation', 'true');
+    res.setHeader('Sunset', 'true');
 
     // Can have query params and body depending on if it's an action or a model
 

--- a/packages/server/lib/controllers/v1/getV1.ts
+++ b/packages/server/lib/controllers/v1/getV1.ts
@@ -23,9 +23,6 @@ export const allPublicV1 = asyncWrapper<GetPublicV1>(async (req, res, next) => {
         return;
     }
 
-    res.setHeader('Deprecation', 'true');
-    res.setHeader('Sunset', 'true');
-
     // Can have query params and body depending on if it's an action or a model
 
     const { environment } = res.locals;

--- a/packages/types/lib/action/api.ts
+++ b/packages/types/lib/action/api.ts
@@ -33,6 +33,7 @@ export type PostPublicTriggerAction = Endpoint<{
     Success: any;
 }>;
 
+/** @deprecated Use POST /action/trigger to trigger actions and GET /records to fetch sync records instead. */
 export type GetPublicV1 = Endpoint<{
     Method: 'GET';
     Path: `/v1/:path`;


### PR DESCRIPTION
Deprecates `endpoints` in `createSync` and `endpoint` in `createAction`. Updates docs accordingly.

<!-- Summary by @propel-code-bot -->

---

**Deprecate `endpoints`/`endpoint` in runner SDK and align CLI parsing and docs**

This PR makes `endpoints` in `createSync` and `endpoint` in `createAction` optional and marked deprecated in the runner SDK types, with supporting updates to CLI parsing and validation to accept missing values. It also updates multiple documentation guides and references to remove or deprecate endpoint usage, and adds tests to confirm behavior when these fields are omitted.

---
*This summary was automatically generated by @propel-code-bot*