### PR TITLE
fix(refreshToken): return Redis error on lock timeout during token refresh

### DIFF
--- a/packages/kvstore/lib/Locking.ts
+++ b/packages/kvstore/lib/Locking.ts
@@ -6,6 +6,18 @@ export interface Lock {
     readonly key: string;
 }
 
+export class LockTimeoutError extends Error {
+    public readonly key: string;
+    public readonly timeoutMs: number;
+
+    constructor(key: string, timeoutMs: number) {
+        super(`Acquiring lock for key: ${key} timed out after ${timeoutMs}ms`);
+        this.name = this.constructor.name;
+        this.key = key;
+        this.timeoutMs = timeoutMs;
+    }
+}
+
 export class Locking {
     private store: KVStore;
 
@@ -30,7 +42,7 @@ export class Locking {
                 await new Promise((resolve) => setTimeout(resolve, 50));
             }
         }
-        throw new Error(`Acquiring lock for key: ${key} timed out after ${acquisitionTimeoutMs}ms`);
+        throw new LockTimeoutError(key, acquisitionTimeoutMs);
     }
 
     public async acquire(key: string, ttlMs: number): Promise<Lock> {

--- a/packages/kvstore/lib/index.ts
+++ b/packages/kvstore/lib/index.ts
@@ -13,7 +13,7 @@ export { InMemoryKVStore } from './InMemoryStore.js';
 export { FeatureFlags } from './FeatureFlags.js';
 export { RedisKVStore } from './RedisStore.js';
 export type { KVStore } from './KVStore.js';
-export { type Lock, Locking } from './Locking.js';
+export { type Lock, LockTimeoutError, Locking } from './Locking.js';
 
 type KvBoundary = 'system' | 'customer';
 

--- a/packages/shared/lib/services/connections/credentials/refresh.ts
+++ b/packages/shared/lib/services/connections/credentials/refresh.ts
@@ -519,7 +519,10 @@ export async function refreshCredentialsIfNeeded({
                 credentials: newCredentials as RefreshableCredentials
             });
         } catch (err) {
-            const error = new NangoError('refresh_token_external_error', { message: err instanceof Error ? err.message : 'unknown error' });
+            const isLockTimeout = err instanceof Error && err.message.startsWith('Acquiring lock for key:');
+            const error = new NangoError(isLockTimeout ? 'refresh_token_lock_timeout' : 'refresh_token_external_error', {
+                message: err instanceof Error ? err.message : 'unknown error'
+            });
 
             return Err(error);
         } finally {

--- a/packages/shared/lib/services/connections/credentials/refresh.ts
+++ b/packages/shared/lib/services/connections/credentials/refresh.ts
@@ -1,6 +1,6 @@
 import tracer from 'dd-trace';
 
-import { getLocking } from '@nangohq/kvstore';
+import { LockTimeoutError, getLocking } from '@nangohq/kvstore';
 import { getProvider } from '@nangohq/providers';
 import { Err, FixedSizeMap, Ok, getLogger, metrics } from '@nangohq/utils';
 
@@ -519,8 +519,7 @@ export async function refreshCredentialsIfNeeded({
                 credentials: newCredentials as RefreshableCredentials
             });
         } catch (err) {
-            const isLockTimeout = err instanceof Error && err.message.startsWith('Acquiring lock for key:');
-            const error = new NangoError(isLockTimeout ? 'refresh_token_lock_timeout' : 'refresh_token_external_error', {
+            const error = new NangoError(err instanceof LockTimeoutError ? 'refresh_token_lock_timeout' : 'refresh_token_external_error', {
                 message: err instanceof Error ? err.message : 'unknown error'
             });
 

--- a/packages/shared/lib/services/connections/credentials/refresh.unit.test.ts
+++ b/packages/shared/lib/services/connections/credentials/refresh.unit.test.ts
@@ -1,6 +1,7 @@
 import { afterEach, describe, expect, it, vi } from 'vitest';
 
 import * as kvstoreModule from '@nangohq/kvstore';
+import { LockTimeoutError } from '@nangohq/kvstore';
 
 import { refreshCredentialsIfNeeded, shouldRefreshCredentials } from './refresh.js';
 import { getTestConnection } from '../../../seeders/connection.seeder.js';
@@ -183,7 +184,7 @@ describe('refreshCredentialsIfNeeded', () => {
         } as any);
 
         vi.spyOn(kvstoreModule, 'getLocking').mockResolvedValue({
-            tryAcquire: vi.fn().mockRejectedValue(new Error('Acquiring lock for key: lock:refresh:42:airtable:test-conn timed out after 12000ms')),
+            tryAcquire: vi.fn().mockRejectedValue(new LockTimeoutError('lock:refresh:42:airtable:test-conn', 12000)),
             release: vi.fn().mockResolvedValue(undefined)
         } as any);
 

--- a/packages/shared/lib/services/connections/credentials/refresh.unit.test.ts
+++ b/packages/shared/lib/services/connections/credentials/refresh.unit.test.ts
@@ -1,7 +1,10 @@
-import { describe, expect, it } from 'vitest';
+import { afterEach, describe, expect, it, vi } from 'vitest';
 
-import { shouldRefreshCredentials } from './refresh.js';
+import * as kvstoreModule from '@nangohq/kvstore';
+
+import { refreshCredentialsIfNeeded, shouldRefreshCredentials } from './refresh.js';
 import { getTestConnection } from '../../../seeders/connection.seeder.js';
+import connectionService from '../../connection.service.js';
 import { REFRESH_MARGIN_MS } from '../utils.js';
 
 import type { Config } from '../../../models/index.js';
@@ -151,5 +154,53 @@ describe('shouldRefreshCredentials', () => {
 
             expect(res).toStrictEqual({ should: false, reason: 'no_expires_at' });
         });
+    });
+});
+
+describe('refreshCredentialsIfNeeded', () => {
+    afterEach(() => {
+        vi.restoreAllMocks();
+    });
+
+    it('should return refresh_token_lock_timeout (503) when Redis lock times out, not refresh_token_external_error (400)', async () => {
+        const connection = getTestConnection({
+            connection_id: 'test-conn',
+            environment_id: 42,
+            provider_config_key: 'airtable',
+            credentials: {
+                type: 'OAUTH2',
+                access_token: 'old_token',
+                refresh_token: 'old_refresh',
+                expires_at: new Date(Date.now() - 1000),
+                raw: {}
+            }
+        });
+
+        vi.spyOn(connectionService, 'getConnection').mockResolvedValue({
+            success: true,
+            error: null,
+            response: connection
+        } as any);
+
+        vi.spyOn(kvstoreModule, 'getLocking').mockResolvedValue({
+            tryAcquire: vi.fn().mockRejectedValue(new Error('Acquiring lock for key: lock:refresh:42:airtable:test-conn timed out after 12000ms')),
+            release: vi.fn().mockResolvedValue(undefined)
+        } as any);
+
+        const res = await refreshCredentialsIfNeeded({
+            connectionId: 'test-conn',
+            environmentId: 42,
+            environment_id: 42,
+            providerConfig: { unique_key: 'airtable', provider: 'airtable' } as Config,
+            provider: { auth_mode: 'OAUTH2', token_expiration_buffer: 0 } as ProviderOAuth2,
+            instantRefresh: false,
+            logCtx: { debug: vi.fn(), info: vi.fn(), warn: vi.fn(), error: vi.fn() } as any
+        });
+
+        expect(res.isErr()).toBe(true);
+        if (res.isErr()) {
+            expect(res.error.type).toBe('refresh_token_lock_timeout');
+            expect(res.error.status).toBe(503);
+        }
     });
 });

--- a/packages/shared/lib/utils/error.ts
+++ b/packages/shared/lib/utils/error.ts
@@ -276,7 +276,7 @@ export class NangoError extends NangoInternalError {
 
             case 'refresh_token_lock_timeout':
                 this.status = 503;
-                this.message = `A token refresh is already in progress for this connection. Please retry.`;
+                this.message = `Could not acquire the refresh lock for this connection. Please retry.`;
                 break;
 
             case 'request_token_external_error':

--- a/packages/shared/lib/utils/error.ts
+++ b/packages/shared/lib/utils/error.ts
@@ -274,6 +274,11 @@ export class NangoError extends NangoInternalError {
                 this.message = `The external API returned an error when trying to refresh the access token. Please try again later.`;
                 break;
 
+            case 'refresh_token_lock_timeout':
+                this.status = 503;
+                this.message = `A token refresh is already in progress for this connection. Please retry.`;
+                break;
+
             case 'request_token_external_error':
                 this.status = 400;
                 this.message = `The external API returned an error when trying to request for an access token. Please try again later.`;


### PR DESCRIPTION
## Describe the problem and your solution

- Previously, any exception thrown inside `refreshCredentialsIfNeeded` was wrapped as `refresh_token_external_error` (400), including [internal Redis lock](https://github.com/NangoHQ/nango/blob/14637d0448cf8ed2d22a43d764e76b016676d265/packages/shared/lib/services/connections/credentials/refresh.ts#L426) acquisition timeouts. This caused infra failures to appear as OAuth provider errors, making it impossible for callers to distinguish the two. This change detects lock timeout errors and maps them to a new `refresh_token_lock_timeout` error type with a 503 status.

<!-- Issue ticket number and link (if applicable) -->

<!-- Testing instructions (skip if just adding/editing providers) -->


<!-- Summary by @propel-code-bot -->

---

It also introduces a typed lock-timeout error in the kvstore layer, updates NangoError metadata for the new error type, and adds a unit test to validate the lock-timeout mapping behavior.

---
*This summary was automatically generated by @propel-code-bot*