### PR TITLE
fix(lambda): node routing overrides

### DIFF
--- a/packages/database/lib/migrations/20260316194000_add_node_routing_override.cjs
+++ b/packages/database/lib/migrations/20260316194000_add_node_routing_override.cjs
@@ -6,7 +6,7 @@ exports.config = { transaction: true };
 exports.up = async function (knex) {
     await knex.raw(`
         ALTER TABLE plans
-        ADD COLUMN IF NOT EXISTS node_routing_override varchar(255) DEFAULT NULL;
+        ADD COLUMN IF NOT EXISTS fleet_node_routing_override varchar(255) DEFAULT NULL;
     `);
 };
 

--- a/packages/database/lib/migrations/20260316194000_add_node_routing_override.cjs
+++ b/packages/database/lib/migrations/20260316194000_add_node_routing_override.cjs
@@ -1,0 +1,13 @@
+exports.config = { transaction: true };
+
+/**
+ * @param {import('knex').Knex} knex
+ */
+exports.up = async function (knex) {
+    await knex.raw(`
+        ALTER TABLE plans
+        ADD COLUMN IF NOT EXISTS node_routing_override varchar(255) DEFAULT NULL;
+    `);
+};
+
+exports.down = async function () {};

--- a/packages/jobs/lib/execution/action.ts
+++ b/packages/jobs/lib/execution/action.ts
@@ -36,7 +36,7 @@ import type {
     DBTeam,
     FunctionRuntime,
     NangoProps,
-    RuntimeContext,
+    RoutingContext,
     SdkLogger,
     TelemetryBag
 } from '@nangohq/types';
@@ -160,14 +160,14 @@ export async function startAction(task: TaskAction): Promise<Result<void>> {
             }
         };
 
-        const runtimeContext: RuntimeContext = {
+        const routingContext: RoutingContext = {
             plan: plan
         };
 
         const res = await startScript({
             taskId: task.id,
             nangoProps,
-            runtimeContext,
+            routingContext,
             logCtx: logCtx,
             input: task.input
         });

--- a/packages/jobs/lib/execution/onEvent.ts
+++ b/packages/jobs/lib/execution/onEvent.ts
@@ -12,7 +12,7 @@ import { pubsub } from '../utils/pubsub.js';
 
 import type { TaskOnEvent } from '@nangohq/nango-orchestrator';
 import type { Config } from '@nangohq/shared';
-import type { ConnectionJobs, DBEnvironment, DBSyncConfig, DBTeam, FunctionRuntime, NangoProps, RuntimeContext, SdkLogger, TelemetryBag } from '@nangohq/types';
+import type { ConnectionJobs, DBEnvironment, DBSyncConfig, DBTeam, FunctionRuntime, NangoProps, RoutingContext, SdkLogger, TelemetryBag } from '@nangohq/types';
 import type { Result } from '@nangohq/utils';
 
 export async function startOnEvent(task: TaskOnEvent): Promise<Result<void>> {
@@ -129,14 +129,14 @@ export async function startOnEvent(task: TaskOnEvent): Promise<Result<void>> {
             heartbeatTimeoutSecs: task.heartbeatTimeoutSecs
         };
 
-        const runtimeContext: RuntimeContext = {
+        const routingContext: RoutingContext = {
             plan: plan
         };
 
         const res = await startScript({
             taskId: task.id,
             nangoProps,
-            runtimeContext,
+            routingContext,
             logCtx: logCtx
         });
 

--- a/packages/jobs/lib/execution/operations/start.ts
+++ b/packages/jobs/lib/execution/operations/start.ts
@@ -59,7 +59,8 @@ export async function startScript({
             taskId,
             nangoProps,
             code: script,
-            codeParams: (input as object) || {}
+            codeParams: (input as object) || {},
+            runtimeContext
         });
 
         if (res.isErr()) {

--- a/packages/jobs/lib/execution/operations/start.ts
+++ b/packages/jobs/lib/execution/operations/start.ts
@@ -7,20 +7,20 @@ import { concurrencyMonitor } from './monitor.js';
 import { getRuntimeAdapter } from '../../runtime/runtimes.js';
 
 import type { LogContext } from '@nangohq/logs';
-import type { NangoProps, RuntimeContext } from '@nangohq/types';
+import type { NangoProps, RoutingContext } from '@nangohq/types';
 import type { Result } from '@nangohq/utils';
 import type { JsonValue } from 'type-fest';
 
 export async function startScript({
     taskId,
     nangoProps,
-    runtimeContext,
+    routingContext,
     input,
     logCtx
 }: {
     taskId: string;
     nangoProps: NangoProps;
-    runtimeContext: RuntimeContext;
+    routingContext: RoutingContext;
     input?: JsonValue | undefined;
     logCtx: LogContext;
 }): Promise<Result<void>> {
@@ -51,7 +51,7 @@ export async function startScript({
             throw new Error(`No team provided (instead ${nangoProps.team})`);
         }
 
-        const runtimeAdapter = await getRuntimeAdapter({ nangoProps, runtimeContext });
+        const runtimeAdapter = await getRuntimeAdapter({ nangoProps, routingContext });
         if (runtimeAdapter.isErr()) {
             throw runtimeAdapter.error;
         }
@@ -60,7 +60,7 @@ export async function startScript({
             nangoProps,
             code: script,
             codeParams: (input as object) || {},
-            runtimeContext
+            routingContext
         });
 
         if (res.isErr()) {

--- a/packages/jobs/lib/execution/sync.ts
+++ b/packages/jobs/lib/execution/sync.ts
@@ -51,7 +51,7 @@ import type {
     DBTeam,
     FunctionRuntime,
     NangoProps,
-    RuntimeContext,
+    RoutingContext,
     SdkLogger,
     SyncResult,
     SyncTypeLiteral,
@@ -215,7 +215,7 @@ export async function startSync(task: TaskSync, startScriptFn = startScript): Pr
                 : {}) // non-lambda runtimes do not need interrupting/resuming long-running executions
         };
 
-        const runtimeContext: RuntimeContext = {
+        const routingContext: RoutingContext = {
             plan: plan
         };
 
@@ -226,7 +226,7 @@ export async function startSync(task: TaskSync, startScriptFn = startScript): Pr
         const res = await startScriptFn({
             taskId: task.id,
             nangoProps,
-            runtimeContext,
+            routingContext,
             logCtx: logCtx
         });
 

--- a/packages/jobs/lib/execution/webhook.ts
+++ b/packages/jobs/lib/execution/webhook.ts
@@ -38,7 +38,7 @@ import type {
     DBTeam,
     FunctionRuntime,
     NangoProps,
-    RuntimeContext,
+    RoutingContext,
     SdkLogger,
     TelemetryBag
 } from '@nangohq/types';
@@ -169,14 +169,14 @@ export async function startWebhook(task: TaskWebhook): Promise<Result<void>> {
             heartbeatTimeoutSecs: task.heartbeatTimeoutSecs
         };
 
-        const runtimeContext: RuntimeContext = {
+        const routingContext: RoutingContext = {
             plan: plan
         };
 
         const res = await startScript({
             taskId: task.id,
             nangoProps,
-            runtimeContext,
+            routingContext,
             logCtx: logCtx,
             input: task.input
         });

--- a/packages/jobs/lib/runner/lambda.ts
+++ b/packages/jobs/lib/runner/lambda.ts
@@ -219,7 +219,7 @@ export const lambdaNodeProvider: NodeProvider = {
     defaultNodeConfig: {
         cpuMilli: 500,
         memoryMb: 512,
-        storageMb: 10240,
+        storageMb: 512,
         isTracingEnabled: false,
         isProfilingEnabled: false,
         idleMaxDurationMs: 0,

--- a/packages/jobs/lib/runner/lambda.ts
+++ b/packages/jobs/lib/runner/lambda.ts
@@ -20,7 +20,6 @@ import { Err, Ok, getLogger } from '@nangohq/utils';
 
 import { envs } from '../env.js';
 import { registerWithFleet } from '../runtime/runtimes.js';
-import { getSizeFromRoutingId } from '../utils/lambda.js';
 
 import type { Environment } from '@aws-sdk/client-lambda';
 import type { Node, NodeProvider } from '@nangohq/fleet';
@@ -33,10 +32,6 @@ const applicationAutoScalingClient = new ApplicationAutoScalingClient();
 
 export function getFunctionName(node: Node): string {
     return `${node.routingId}-${node.id}`;
-}
-
-function getSize(node: Node): number {
-    return getSizeFromRoutingId(node.routingId);
 }
 
 export function getFunctionQualifier(node: Node): string {
@@ -72,8 +67,11 @@ class Lambda {
                     },
                     PackageType: 'Image',
                     Architectures: [envs.LAMBDA_ARCHITECTURE],
-                    MemorySize: getSize(node),
-                    Timeout: node.executionTimeoutSecs || envs.LAMBDA_EXECUTION_TIMEOUT_SECS,
+                    MemorySize: Math.min(10240, node.memoryMb), //max 10GB allowed by Lambda
+                    EphemeralStorage: {
+                        Size: Math.min(10240, node.storageMb) //max 10GB allowed by Lambda
+                    },
+                    Timeout: Math.min(900, node.executionTimeoutSecs || envs.LAMBDA_EXECUTION_TIMEOUT_SECS), //max 15 minutes allowed by Lambda
                     Environment: this.getEnvironmentVariables(node),
                     VpcConfig: {
                         SubnetIds: envs.LAMBDA_SUBNET_IDS,
@@ -209,7 +207,7 @@ class Lambda {
     }
 
     async verifyUrl(_url: string): Promise<Result<void>> {
-        const regex = /^arn:aws:lambda:.*:function:nango-runner-function-\d+-[a-f0-9-]+:.*$/;
+        const regex = /^arn:aws:lambda:.*:function:.*/;
         if (!regex.test(_url)) {
             return Err('Invalid URL');
         }
@@ -221,12 +219,12 @@ export const lambdaNodeProvider: NodeProvider = {
     defaultNodeConfig: {
         cpuMilli: 500,
         memoryMb: 512,
-        storageMb: 20000,
+        storageMb: 10240,
         isTracingEnabled: false,
         isProfilingEnabled: false,
         idleMaxDurationMs: 0,
-        executionTimeoutSecs: 900,
-        provisionedConcurrency: 1,
+        executionTimeoutSecs: envs.LAMBDA_EXECUTION_TIMEOUT_SECS,
+        provisionedConcurrency: envs.LAMBDA_PROVISIONED_CONCURRENCY,
         replicas: 1
     },
     start: async (node: Node) => {

--- a/packages/jobs/lib/runner/lambda.ts
+++ b/packages/jobs/lib/runner/lambda.ts
@@ -123,8 +123,8 @@ class Lambda {
                         ServiceNamespace: 'lambda',
                         ScalableDimension: 'lambda:function:ProvisionedConcurrency',
                         ResourceId: resourceId,
-                        MinCapacity: node.provisionedConcurrency || envs.LAMBDA_PROVISIONED_CONCURRENCY,
-                        MaxCapacity: (node.provisionedConcurrency || envs.LAMBDA_PROVISIONED_CONCURRENCY) * 10
+                        MinCapacity: node.provisionedConcurrency || envs.LAMBDA_DEFAULT_PROVISIONED_CONCURRENCY,
+                        MaxCapacity: (node.provisionedConcurrency || envs.LAMBDA_DEFAULT_PROVISIONED_CONCURRENCY) * 10
                     })
                 );
                 await applicationAutoScalingClient.send(
@@ -224,7 +224,7 @@ export const lambdaNodeProvider: NodeProvider = {
         isProfilingEnabled: false,
         idleMaxDurationMs: 0,
         executionTimeoutSecs: envs.LAMBDA_EXECUTION_TIMEOUT_SECS,
-        provisionedConcurrency: envs.LAMBDA_PROVISIONED_CONCURRENCY,
+        provisionedConcurrency: envs.LAMBDA_DEFAULT_PROVISIONED_CONCURRENCY,
         replicas: 1
     },
     start: async (node: Node) => {

--- a/packages/jobs/lib/runner/lambda.ts
+++ b/packages/jobs/lib/runner/lambda.ts
@@ -123,8 +123,8 @@ class Lambda {
                         ServiceNamespace: 'lambda',
                         ScalableDimension: 'lambda:function:ProvisionedConcurrency',
                         ResourceId: resourceId,
-                        MinCapacity: node.provisionedConcurrency || envs.LAMBDA_DEFAULT_PROVISIONED_CONCURRENCY,
-                        MaxCapacity: (node.provisionedConcurrency || envs.LAMBDA_DEFAULT_PROVISIONED_CONCURRENCY) * 10
+                        MinCapacity: node.provisionedConcurrency || envs.LAMBDA_PROVISIONED_CONCURRENCY,
+                        MaxCapacity: (node.provisionedConcurrency || envs.LAMBDA_PROVISIONED_CONCURRENCY) * 10
                     })
                 );
                 await applicationAutoScalingClient.send(
@@ -224,7 +224,7 @@ export const lambdaNodeProvider: NodeProvider = {
         isProfilingEnabled: false,
         idleMaxDurationMs: 0,
         executionTimeoutSecs: envs.LAMBDA_EXECUTION_TIMEOUT_SECS,
-        provisionedConcurrency: envs.LAMBDA_DEFAULT_PROVISIONED_CONCURRENCY,
+        provisionedConcurrency: envs.LAMBDA_PROVISIONED_CONCURRENCY,
         replicas: 1
     },
     start: async (node: Node) => {

--- a/packages/jobs/lib/runner/lambda.ts
+++ b/packages/jobs/lib/runner/lambda.ts
@@ -218,8 +218,8 @@ class Lambda {
 export const lambdaNodeProvider: NodeProvider = {
     defaultNodeConfig: {
         cpuMilli: 500,
-        memoryMb: 512,
-        storageMb: 512,
+        memoryMb: envs.LAMBDA_DEFAULT_MEMORY_MB,
+        storageMb: envs.LAMBDA_DEFAULT_STORAGE_MB,
         isTracingEnabled: false,
         isProfilingEnabled: false,
         idleMaxDurationMs: 0,

--- a/packages/jobs/lib/runtime/adapter.ts
+++ b/packages/jobs/lib/runtime/adapter.ts
@@ -1,7 +1,13 @@
-import type { NangoProps } from '@nangohq/types';
+import type { NangoProps, RuntimeContext } from '@nangohq/types';
 import type { Result } from '@nangohq/utils';
 
 export interface RuntimeAdapter {
-    invoke(params: { taskId: string; nangoProps: NangoProps; code: string; codeParams: object }): Promise<Result<boolean>>;
+    invoke(params: {
+        taskId: string;
+        nangoProps: NangoProps;
+        code: string;
+        codeParams: object;
+        runtimeContext?: RuntimeContext | undefined;
+    }): Promise<Result<boolean>>;
     cancel(params: { taskId: string; nangoProps: NangoProps }): Promise<Result<boolean>>;
 }

--- a/packages/jobs/lib/runtime/adapter.ts
+++ b/packages/jobs/lib/runtime/adapter.ts
@@ -1,4 +1,4 @@
-import type { NangoProps, RuntimeContext } from '@nangohq/types';
+import type { NangoProps, RoutingContext } from '@nangohq/types';
 import type { Result } from '@nangohq/utils';
 
 export interface RuntimeAdapter {
@@ -7,7 +7,7 @@ export interface RuntimeAdapter {
         nangoProps: NangoProps;
         code: string;
         codeParams: object;
-        runtimeContext?: RuntimeContext | undefined;
+        routingContext?: RoutingContext | undefined;
     }): Promise<Result<boolean>>;
     cancel(params: { taskId: string; nangoProps: NangoProps }): Promise<Result<boolean>>;
 }

--- a/packages/jobs/lib/runtime/lambda.adapter.ts
+++ b/packages/jobs/lib/runtime/lambda.adapter.ts
@@ -12,7 +12,7 @@ import { getRoutingId } from '../utils/lambda.js';
 
 import type { RuntimeAdapter } from './adapter.js';
 import type { Fleet } from '@nangohq/fleet';
-import type { NangoProps, Result } from '@nangohq/types';
+import type { NangoProps, Result, RuntimeContext } from '@nangohq/types';
 
 const logger = getLogger('LambdaRuntimeAdapter');
 
@@ -34,8 +34,8 @@ interface S3ObjectRef {
 export class LambdaRuntimeAdapter implements RuntimeAdapter {
     constructor(private readonly fleet: Fleet) {}
 
-    private async getFunction(nangoProps: NangoProps): Promise<LambdaFunction> {
-        const routingId = getRoutingId(nangoProps);
+    private async getFunction(params: { nangoProps: NangoProps; runtimeContext?: RuntimeContext | undefined }): Promise<LambdaFunction> {
+        const routingId = getRoutingId(params);
         const node = await this.fleet.getRunningNode(routingId);
         if (node.isErr()) {
             throw new Error(`Failed to get running node for routing id '${routingId}'`, { cause: node.error });
@@ -165,9 +165,15 @@ export class LambdaRuntimeAdapter implements RuntimeAdapter {
         }
     }
 
-    async invoke(params: { taskId: string; nangoProps: NangoProps; code: string; codeParams: object }): Promise<Result<boolean>> {
+    async invoke(params: {
+        taskId: string;
+        nangoProps: NangoProps;
+        code: string;
+        codeParams: object;
+        runtimeContext?: RuntimeContext | undefined;
+    }): Promise<Result<boolean>> {
         try {
-            const func = await this.getFunction(params.nangoProps);
+            const func = await this.getFunction({ nangoProps: params.nangoProps, runtimeContext: params.runtimeContext });
 
             const payload = await this.preparePayload(params);
             if (payload.isErr()) {

--- a/packages/jobs/lib/runtime/lambda.adapter.ts
+++ b/packages/jobs/lib/runtime/lambda.adapter.ts
@@ -12,7 +12,7 @@ import { getRoutingId } from '../utils/lambda.js';
 
 import type { RuntimeAdapter } from './adapter.js';
 import type { Fleet } from '@nangohq/fleet';
-import type { NangoProps, Result, RuntimeContext } from '@nangohq/types';
+import type { NangoProps, Result, RoutingContext } from '@nangohq/types';
 
 const logger = getLogger('LambdaRuntimeAdapter');
 
@@ -34,7 +34,7 @@ interface S3ObjectRef {
 export class LambdaRuntimeAdapter implements RuntimeAdapter {
     constructor(private readonly fleet: Fleet) {}
 
-    private async getFunction(params: { nangoProps: NangoProps; runtimeContext?: RuntimeContext | undefined }): Promise<LambdaFunction> {
+    private async getFunction(params: { nangoProps: NangoProps; routingContext?: RoutingContext | undefined }): Promise<LambdaFunction> {
         const routingId = getRoutingId(params);
         const node = await this.fleet.getRunningNode(routingId);
         if (node.isErr()) {
@@ -170,10 +170,10 @@ export class LambdaRuntimeAdapter implements RuntimeAdapter {
         nangoProps: NangoProps;
         code: string;
         codeParams: object;
-        runtimeContext?: RuntimeContext | undefined;
+        routingContext?: RoutingContext | undefined;
     }): Promise<Result<boolean>> {
         try {
-            const func = await this.getFunction({ nangoProps: params.nangoProps, runtimeContext: params.runtimeContext });
+            const func = await this.getFunction({ nangoProps: params.nangoProps, routingContext: params.routingContext });
 
             const payload = await this.preparePayload(params);
             if (payload.isErr()) {

--- a/packages/jobs/lib/runtime/runtimes.rules.ts
+++ b/packages/jobs/lib/runtime/runtimes.rules.ts
@@ -2,7 +2,7 @@ import { Ok } from '@nangohq/utils';
 
 import { envs } from '../env.js';
 
-import type { DBPlan, NangoProps, Result, RuntimeContext } from '@nangohq/types';
+import type { DBPlan, NangoProps, Result, RoutingContext } from '@nangohq/types';
 
 const runtimeSelectors = {
     sync: (plan: DBPlan) => plan.sync_function_runtime,
@@ -13,15 +13,15 @@ const runtimeSelectors = {
 
 export async function getFleetId({
     nangoProps,
-    runtimeContext
+    routingContext
 }: {
     nangoProps: NangoProps;
-    runtimeContext: RuntimeContext;
+    routingContext: RoutingContext;
 }): Promise<Result<string | undefined>> {
-    if (!runtimeContext.plan) {
+    if (!routingContext.plan) {
         return Promise.resolve(Ok(envs.RUNNER_FLEET_ID));
     }
-    const runtime = runtimeSelectors[nangoProps.scriptType](runtimeContext.plan);
+    const runtime = runtimeSelectors[nangoProps.scriptType](routingContext.plan);
     switch (runtime) {
         case 'lambda':
             return Promise.resolve(Ok(envs.RUNNER_LAMBDA_FLEET_ID));

--- a/packages/jobs/lib/runtime/runtimes.ts
+++ b/packages/jobs/lib/runtime/runtimes.ts
@@ -10,7 +10,7 @@ import { runnersFleet } from '../runner/fleet.js';
 import { lambdaNodeProvider } from '../runner/lambda.js';
 
 import type { RuntimeAdapter } from './adapter.js';
-import type { NangoProps, RuntimeContext } from '@nangohq/types';
+import type { NangoProps, RoutingContext } from '@nangohq/types';
 import type { Result } from '@nangohq/utils';
 
 interface Runtime {
@@ -39,7 +39,7 @@ export function getDefaultFleet(): Fleet {
     return runnersFleet;
 }
 
-export async function getRuntimeAdapter(params: { nangoProps: NangoProps; runtimeContext: RuntimeContext }): Promise<Result<RuntimeAdapter>> {
+export async function getRuntimeAdapter(params: { nangoProps: NangoProps; routingContext: RoutingContext }): Promise<Result<RuntimeAdapter>> {
     const result = await getFleetId(params);
     if (result.isErr()) {
         logger.error('Error while getting fleet id for runtime', result.error);

--- a/packages/jobs/lib/utils/lambda.ts
+++ b/packages/jobs/lib/utils/lambda.ts
@@ -1,20 +1,23 @@
 import { envs } from '../env.js';
 
-import type { NangoProps } from '@nangohq/types';
+import type { NangoProps, RuntimeContext } from '@nangohq/types';
 
 export function getSizeFromProps(_nangoProps: NangoProps): number {
     //based on available props return a memory size compatible with lambda - will use rules for this
     return envs.LAMBDA_DEFAULT_SIZE;
 }
 
-export function getSizeFromRoutingId(name: string): number {
-    const parts = name.split('-');
-    const size = Number.parseInt((parts.length && parts[parts.length - 1]) || '');
-    if (Number.isNaN(size)) return envs.LAMBDA_DEFAULT_SIZE;
-    return size;
+export function getRoutingId(params: { nangoProps: NangoProps; runtimeContext?: RuntimeContext | undefined }): string {
+    const size = getSizeFromProps(params.nangoProps);
+    const tshirtSize = getTShirtSize(size);
+    const prefix = params.runtimeContext?.plan?.node_routing_override || envs.LAMBDA_PREFIX;
+    return `${prefix}-${tshirtSize}`;
 }
 
-export function getRoutingId(nangoProps: NangoProps): string {
-    const size = getSizeFromProps(nangoProps);
-    return `nango-runner-function-${size}`;
+function getTShirtSize(size: number): string {
+    if (size <= 1024) return 'S';
+    if (size <= 2048) return 'M';
+    if (size <= 4096) return 'L';
+    if (size <= 8192) return 'XL';
+    return 'XXL';
 }

--- a/packages/jobs/lib/utils/lambda.ts
+++ b/packages/jobs/lib/utils/lambda.ts
@@ -3,12 +3,14 @@ import { envs } from '../env.js';
 import type { NangoProps, RoutingContext } from '@nangohq/types';
 
 export function getRoutingId(params: { nangoProps: NangoProps; routingContext?: RoutingContext | undefined }): string {
-    const tshirtSize = getTShirtSize(params.nangoProps);
+    const tshirtSize = getTShirtSize(params);
     const prefix = params.routingContext?.plan?.fleet_node_routing_override || envs.LAMBDA_DEFAULT_PREFIX;
     return `${prefix}-${tshirtSize}`;
 }
 
-function getTShirtSize(_nangoProps: NangoProps): string {
+function getTShirtSize(_params: { nangoProps: NangoProps; routingContext?: RoutingContext | undefined }): string {
+    //t-shirt size will be retrieved from nangoProps or routingContext as specified by the customer
+    //for now, we will just use the default memory size
     const memoryMb = envs.LAMBDA_DEFAULT_MEMORY_MB;
     if (memoryMb < 1024) return 'S';
     if (memoryMb < 2048) return 'M';

--- a/packages/jobs/lib/utils/lambda.ts
+++ b/packages/jobs/lib/utils/lambda.ts
@@ -4,7 +4,7 @@ import type { NangoProps, RuntimeContext } from '@nangohq/types';
 
 export function getSizeFromProps(_nangoProps: NangoProps): number {
     //based on available props return a memory size compatible with lambda - will use rules for this
-    return envs.LAMBDA_DEFAULT_SIZE;
+    return envs.LAMBDA_DEFAULT_MEMORY_MB;
 }
 
 export function getRoutingId(params: { nangoProps: NangoProps; runtimeContext?: RuntimeContext | undefined }): string {

--- a/packages/jobs/lib/utils/lambda.ts
+++ b/packages/jobs/lib/utils/lambda.ts
@@ -1,23 +1,18 @@
 import { envs } from '../env.js';
 
-import type { NangoProps, RuntimeContext } from '@nangohq/types';
+import type { NangoProps, RoutingContext } from '@nangohq/types';
 
-export function getSizeFromProps(_nangoProps: NangoProps): number {
-    //based on available props return a memory size compatible with lambda - will use rules for this
-    return envs.LAMBDA_DEFAULT_MEMORY_MB;
-}
-
-export function getRoutingId(params: { nangoProps: NangoProps; runtimeContext?: RuntimeContext | undefined }): string {
-    const size = getSizeFromProps(params.nangoProps);
-    const tshirtSize = getTShirtSize(size);
-    const prefix = params.runtimeContext?.plan?.node_routing_override || envs.LAMBDA_PREFIX;
+export function getRoutingId(params: { nangoProps: NangoProps; routingContext?: RoutingContext | undefined }): string {
+    const tshirtSize = getTShirtSize(params.nangoProps);
+    const prefix = params.routingContext?.plan?.node_routing_override || envs.LAMBDA_DEFAULT_PREFIX;
     return `${prefix}-${tshirtSize}`;
 }
 
-function getTShirtSize(size: number): string {
-    if (size <= 1024) return 'S';
-    if (size <= 2048) return 'M';
-    if (size <= 4096) return 'L';
-    if (size <= 8192) return 'XL';
+function getTShirtSize(_nangoProps: NangoProps): string {
+    const memoryMb = envs.LAMBDA_DEFAULT_MEMORY_MB;
+    if (memoryMb < 1024) return 'S';
+    if (memoryMb < 2048) return 'M';
+    if (memoryMb < 4096) return 'L';
+    if (memoryMb < 8192) return 'XL';
     return 'XXL';
 }

--- a/packages/jobs/lib/utils/lambda.ts
+++ b/packages/jobs/lib/utils/lambda.ts
@@ -4,7 +4,7 @@ import type { NangoProps, RoutingContext } from '@nangohq/types';
 
 export function getRoutingId(params: { nangoProps: NangoProps; routingContext?: RoutingContext | undefined }): string {
     const tshirtSize = getTShirtSize(params.nangoProps);
-    const prefix = params.routingContext?.plan?.node_routing_override || envs.LAMBDA_DEFAULT_PREFIX;
+    const prefix = params.routingContext?.plan?.fleet_node_routing_override || envs.LAMBDA_DEFAULT_PREFIX;
     return `${prefix}-${tshirtSize}`;
 }
 

--- a/packages/jobs/lib/utils/lambda.unit.test.ts
+++ b/packages/jobs/lib/utils/lambda.unit.test.ts
@@ -37,9 +37,9 @@ describe('getRoutingId', () => {
         mockEnvs.LAMBDA_DEFAULT_MEMORY_MB = 512;
     });
 
-    it('uses node_routing_override when provided in routingContext.plan', () => {
+    it('uses fleet_node_routing_override when provided in routingContext.plan', () => {
         const routingContext: RoutingContext = {
-            plan: { node_routing_override: 'custom-override' } as RoutingContext['plan']
+            plan: { fleet_node_routing_override: 'custom-override' } as RoutingContext['plan']
         };
         const result = getRoutingId({
             nangoProps: minimalNangoProps(),
@@ -61,9 +61,9 @@ describe('getRoutingId', () => {
         expect(result).toBe('default-prefix-S');
     });
 
-    it('uses LAMBDA_DEFAULT_PREFIX when plan.node_routing_override is null', () => {
+    it('uses LAMBDA_DEFAULT_PREFIX when plan.fleet_node_routing_override is null', () => {
         const routingContext: RoutingContext = {
-            plan: { node_routing_override: null } as RoutingContext['plan']
+            plan: { fleet_node_routing_override: null } as RoutingContext['plan']
         };
         const result = getRoutingId({
             nangoProps: minimalNangoProps(),

--- a/packages/jobs/lib/utils/lambda.unit.test.ts
+++ b/packages/jobs/lib/utils/lambda.unit.test.ts
@@ -1,0 +1,74 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+const mockEnvs = vi.hoisted(() => ({
+    LAMBDA_DEFAULT_PREFIX: 'default-prefix',
+    LAMBDA_DEFAULT_MEMORY_MB: 512
+}));
+
+vi.mock('../env.js', () => ({
+    get envs() {
+        return mockEnvs;
+    }
+}));
+
+import { getRoutingId } from './lambda.js';
+
+import type { NangoProps, RoutingContext } from '@nangohq/types';
+
+function minimalNangoProps(): NangoProps {
+    return {
+        logger: { level: 'info' as const },
+        scriptType: 'sync' as const,
+        connectionId: 'conn-1',
+        nangoConnectionId: 1,
+        environmentId: 1,
+        environmentName: 'dev',
+        providerConfigKey: 'google',
+        provider: 'google',
+        team: { id: 1, name: 'team' },
+        syncId: 'sync-1',
+        syncConfig: {} as NangoProps['syncConfig']
+    } as unknown as NangoProps;
+}
+
+describe('getRoutingId', () => {
+    beforeEach(() => {
+        mockEnvs.LAMBDA_DEFAULT_PREFIX = 'default-prefix';
+        mockEnvs.LAMBDA_DEFAULT_MEMORY_MB = 512;
+    });
+
+    it('uses node_routing_override when provided in routingContext.plan', () => {
+        const routingContext: RoutingContext = {
+            plan: { node_routing_override: 'custom-override' } as RoutingContext['plan']
+        };
+        const result = getRoutingId({
+            nangoProps: minimalNangoProps(),
+            routingContext
+        });
+        expect(result).toBe('custom-override-S');
+    });
+
+    it('uses LAMBDA_DEFAULT_PREFIX when routingContext is undefined', () => {
+        const result = getRoutingId({ nangoProps: minimalNangoProps() });
+        expect(result).toBe('default-prefix-S');
+    });
+
+    it('uses LAMBDA_DEFAULT_PREFIX when routingContext.plan is null', () => {
+        const result = getRoutingId({
+            nangoProps: minimalNangoProps(),
+            routingContext: { plan: null }
+        });
+        expect(result).toBe('default-prefix-S');
+    });
+
+    it('uses LAMBDA_DEFAULT_PREFIX when plan.node_routing_override is null', () => {
+        const routingContext: RoutingContext = {
+            plan: { node_routing_override: null } as RoutingContext['plan']
+        };
+        const result = getRoutingId({
+            nangoProps: minimalNangoProps(),
+            routingContext
+        });
+        expect(result).toBe('default-prefix-S');
+    });
+});

--- a/packages/shared/lib/seeders/plan.seeder.ts
+++ b/packages/shared/lib/seeders/plan.seeder.ts
@@ -44,6 +44,7 @@ export function getTestPlan(override?: Partial<DBPlan>): DBPlan {
         on_event_function_runtime: 'runner',
         has_records_autopruning: true,
         variants_per_sync_max: 100,
+        node_routing_override: null,
         ...override
     };
 }

--- a/packages/shared/lib/seeders/plan.seeder.ts
+++ b/packages/shared/lib/seeders/plan.seeder.ts
@@ -44,7 +44,7 @@ export function getTestPlan(override?: Partial<DBPlan>): DBPlan {
         on_event_function_runtime: 'runner',
         has_records_autopruning: true,
         variants_per_sync_max: 100,
-        node_routing_override: null,
+        fleet_node_routing_override: null,
         ...override
     };
 }

--- a/packages/shared/lib/services/plans/definitions.ts
+++ b/packages/shared/lib/services/plans/definitions.ts
@@ -31,7 +31,8 @@ export const freePlan: PlanDefinition = {
         sync_function_runtime: 'lambda',
         action_function_runtime: 'lambda',
         webhook_function_runtime: 'lambda',
-        on_event_function_runtime: 'lambda'
+        on_event_function_runtime: 'lambda',
+        node_routing_override: null
     }
 };
 

--- a/packages/shared/lib/services/plans/definitions.ts
+++ b/packages/shared/lib/services/plans/definitions.ts
@@ -31,8 +31,7 @@ export const freePlan: PlanDefinition = {
         sync_function_runtime: 'lambda',
         action_function_runtime: 'lambda',
         webhook_function_runtime: 'lambda',
-        on_event_function_runtime: 'lambda',
-        node_routing_override: null
+        on_event_function_runtime: 'lambda'
     }
 };
 

--- a/packages/shared/lib/services/plans/plans.ts
+++ b/packages/shared/lib/services/plans/plans.ts
@@ -291,6 +291,10 @@ export function mergeFlags({ currentPlan, newPlanDefinition }: { currentPlan: DB
                 }
                 break;
             }
+            case 'node_routing_override': {
+                overrides[key] = currentPlan[key] !== newPlanDefinition.flags[key] ? newPlanDefinition.flags[key] : currentPlan[key];
+                break;
+            }
             default:
                 ((_exhaustiveCheck: never) => {
                     throw new Error(`Unhandled plan flag key in mergeFlags: ${key}`);

--- a/packages/shared/lib/services/plans/plans.ts
+++ b/packages/shared/lib/services/plans/plans.ts
@@ -210,6 +210,7 @@ export function mergeFlags({ currentPlan, newPlanDefinition }: { currentPlan: DB
             case 'trial_extension_count':
             case 'trial_end_notified_at':
             case 'trial_expired':
+            case 'node_routing_override':
             case 'created_at':
             case 'updated_at':
                 break;
@@ -289,10 +290,6 @@ export function mergeFlags({ currentPlan, newPlanDefinition }: { currentPlan: DB
                 if (currentIndex > newIndex) {
                     overrides[key] = currentPlan[key];
                 }
-                break;
-            }
-            case 'node_routing_override': {
-                overrides[key] = currentPlan[key] !== newPlanDefinition.flags[key] ? newPlanDefinition.flags[key] : currentPlan[key];
                 break;
             }
             default:

--- a/packages/shared/lib/services/plans/plans.ts
+++ b/packages/shared/lib/services/plans/plans.ts
@@ -210,7 +210,7 @@ export function mergeFlags({ currentPlan, newPlanDefinition }: { currentPlan: DB
             case 'trial_extension_count':
             case 'trial_end_notified_at':
             case 'trial_expired':
-            case 'node_routing_override':
+            case 'fleet_node_routing_override':
             case 'created_at':
             case 'updated_at':
                 break;

--- a/packages/shared/lib/services/plans/plans.unit.test.ts
+++ b/packages/shared/lib/services/plans/plans.unit.test.ts
@@ -120,7 +120,7 @@ function makePlan({ code, flagOverrides }: { code: DBPlan['name']; flagOverrides
         on_event_function_runtime: 'runner',
         has_records_autopruning: true,
         variants_per_sync_max: 100,
-        node_routing_override: null,
+        fleet_node_routing_override: null,
         ...defaultPlanDefinition,
         ...flagOverrides
     };

--- a/packages/shared/lib/services/plans/plans.unit.test.ts
+++ b/packages/shared/lib/services/plans/plans.unit.test.ts
@@ -120,6 +120,7 @@ function makePlan({ code, flagOverrides }: { code: DBPlan['name']; flagOverrides
         on_event_function_runtime: 'runner',
         has_records_autopruning: true,
         variants_per_sync_max: 100,
+        node_routing_override: null,
         ...defaultPlanDefinition,
         ...flagOverrides
     };

--- a/packages/types/lib/plans/db.ts
+++ b/packages/types/lib/plans/db.ts
@@ -179,4 +179,10 @@ export interface DBPlan extends Timestamps {
      * @default 100
      */
     variants_per_sync_max: number;
+
+    /**
+     * Override the prefix for the function routing
+     * @default null
+     */
+    node_routing_override: string | null;
 }

--- a/packages/types/lib/plans/db.ts
+++ b/packages/types/lib/plans/db.ts
@@ -184,5 +184,5 @@ export interface DBPlan extends Timestamps {
      * Override the prefix for the function routing
      * @default null
      */
-    node_routing_override: string | null;
+    fleet_node_routing_override: string | null;
 }

--- a/packages/types/lib/runner/index.ts
+++ b/packages/types/lib/runner/index.ts
@@ -25,6 +25,6 @@ export interface RunnerFlags {
     validateSyncMetadata: boolean;
 }
 
-export interface RuntimeContext {
+export interface RoutingContext {
     plan: DBPlan | null;
 }

--- a/packages/utils/lib/environment/parse.ts
+++ b/packages/utils/lib/environment/parse.ts
@@ -382,7 +382,7 @@ export const ENVS = z.object({
 
     // Lambda
     LAMBDA_ENABLED: z.stringbool().optional().default(false),
-    LAMBDA_PREFIX: z.string().optional().default('nango-function'),
+    LAMBDA_DEFAULT_PREFIX: z.string().optional().default('nango-runner-function'),
     LAMBDA_ECR_REGISTRY: z.string().optional(),
     LAMBDA_RUNTIME: z.enum(['nodejs22.x', 'nodejs24.x']).optional().default('nodejs22.x'),
     LAMBDA_EXECUTION_ROLE_ARN: z.string().optional(),

--- a/packages/utils/lib/environment/parse.ts
+++ b/packages/utils/lib/environment/parse.ts
@@ -383,7 +383,6 @@ export const ENVS = z.object({
     // Lambda
     LAMBDA_ENABLED: z.stringbool().optional().default(false),
     LAMBDA_PREFIX: z.string().optional().default('nango-function'),
-    LAMBDA_DEFAULT_SIZE: z.coerce.number().default(512),
     LAMBDA_ECR_REGISTRY: z.string().optional(),
     LAMBDA_RUNTIME: z.enum(['nodejs22.x', 'nodejs24.x']).optional().default('nodejs22.x'),
     LAMBDA_EXECUTION_ROLE_ARN: z.string().optional(),
@@ -417,6 +416,8 @@ export const ENVS = z.object({
     LAMBDA_ARCHITECTURE: z.enum(['arm64', 'x86_64']).optional().default('arm64'),
     LAMBDA_CREATE_TIMEOUT_SECS: z.coerce.number().optional().default(120),
     LAMBDA_EXECUTION_TIMEOUT_SECS: z.coerce.number().optional().default(900),
+    LAMBDA_DEFAULT_MEMORY_MB: z.coerce.number().optional().default(512),
+    LAMBDA_DEFAULT_STORAGE_MB: z.coerce.number().optional().default(512),
     LAMBDA_EXECUTION_INTERRUPT_AFTER_MULTIPLIER: z.coerce.number().optional().default(0.8), // interrupt execution after 80% of the timeout, to leave time for checkpointing and graceful shutdown
     LAMBDA_EXECUTION_KILL_AFTER_MULTIPLIER: z.coerce.number().optional().default(0.95), // force kill the lambda after 95% of the timeout, to allow for runner-controlled shutdown
     LAMBDA_FUNCTION_ALIAS: z.string().optional().default('latest'),

--- a/packages/utils/lib/environment/parse.ts
+++ b/packages/utils/lib/environment/parse.ts
@@ -421,7 +421,7 @@ export const ENVS = z.object({
     LAMBDA_EXECUTION_INTERRUPT_AFTER_MULTIPLIER: z.coerce.number().optional().default(0.8), // interrupt execution after 80% of the timeout, to leave time for checkpointing and graceful shutdown
     LAMBDA_EXECUTION_KILL_AFTER_MULTIPLIER: z.coerce.number().optional().default(0.95), // force kill the lambda after 95% of the timeout, to allow for runner-controlled shutdown
     LAMBDA_FUNCTION_ALIAS: z.string().optional().default('latest'),
-    LAMBDA_DEFAULT_PROVISIONED_CONCURRENCY: z.coerce.number().optional().default(1),
+    LAMBDA_PROVISIONED_CONCURRENCY: z.coerce.number().optional().default(1),
     LAMBDA_PROVISIONED_CONCURRENCY_SCALING_TARGET: z.coerce.number().optional().default(0.7),
     LAMBDA_FAILURE_DESTINATION: z.string().optional(),
     LAMBDA_PAYLOADS_BUCKET_NAME: z.string().optional(),

--- a/packages/utils/lib/environment/parse.ts
+++ b/packages/utils/lib/environment/parse.ts
@@ -421,7 +421,7 @@ export const ENVS = z.object({
     LAMBDA_EXECUTION_INTERRUPT_AFTER_MULTIPLIER: z.coerce.number().optional().default(0.8), // interrupt execution after 80% of the timeout, to leave time for checkpointing and graceful shutdown
     LAMBDA_EXECUTION_KILL_AFTER_MULTIPLIER: z.coerce.number().optional().default(0.95), // force kill the lambda after 95% of the timeout, to allow for runner-controlled shutdown
     LAMBDA_FUNCTION_ALIAS: z.string().optional().default('latest'),
-    LAMBDA_PROVISIONED_CONCURRENCY: z.coerce.number().optional().default(1),
+    LAMBDA_DEFAULT_PROVISIONED_CONCURRENCY: z.coerce.number().optional().default(1),
     LAMBDA_PROVISIONED_CONCURRENCY_SCALING_TARGET: z.coerce.number().optional().default(0.7),
     LAMBDA_FAILURE_DESTINATION: z.string().optional(),
     LAMBDA_PAYLOADS_BUCKET_NAME: z.string().optional(),

--- a/packages/utils/lib/environment/parse.ts
+++ b/packages/utils/lib/environment/parse.ts
@@ -382,6 +382,7 @@ export const ENVS = z.object({
 
     // Lambda
     LAMBDA_ENABLED: z.stringbool().optional().default(false),
+    LAMBDA_PREFIX: z.string().optional().default('nango-function'),
     LAMBDA_DEFAULT_SIZE: z.coerce.number().default(512),
     LAMBDA_ECR_REGISTRY: z.string().optional(),
     LAMBDA_RUNTIME: z.enum(['nodejs22.x', 'nodejs24.x']).optional().default('nodejs22.x'),


### PR DESCRIPTION
<!-- Describe the problem and your solution --> 

<!-- Issue ticket number and link (if applicable) -->

<!-- Testing instructions (skip if just adding/editing providers) -->


<!-- Summary by @propel-code-bot -->

---

**Add plan-level Lambda routing overrides and routing context propagation**

This PR introduces plan-scoped Lambda routing overrides by adding a `fleet_node_routing_override` column on `plans` and propagating a new `RoutingContext` through job execution, runtime selection, and Lambda invocation. Routing IDs now use a configurable prefix plus a t‑shirt size derived from `LAMBDA_DEFAULT_MEMORY_MB`.

It also moves Lambda defaults to environment-driven values, enforces AWS resource caps when creating Lambda functions, relaxes Lambda ARN validation to support custom prefixes, and updates plan typing, seed data, and unit tests to cover the new routing behavior.

---
*This summary was automatically generated by @propel-code-bot*