### PR TITLE
docs: Dev update - deprecation notice for `schema.ts` and `schema.json`

### DIFF
--- a/docs/updates/dev.mdx
+++ b/docs/updates/dev.mdx
@@ -49,13 +49,15 @@ description: "Updates and breaking changes for developers."
 
   **If you use `schema.json` for JSON Schema:**
 
-  Use a library like [`zod-to-json-schema`](https://github.com/StefanTerdell/zod-to-json-schema) to generate JSON Schema from your Zod models directly.
+  JSON schemas are now available per sync/action inside `.nango/nango.json` via the `json_schema` property. This replaces the top-level `schema.json` (which had naming conflicts when models across integrations shared the same name).
+
+  If you need to generate JSON Schema programmatically, Zod v4 supports this natively with [`z.toJSONSchema()`](https://zod.dev/json-schema?id=ztojsonschema):
 
   ```ts
-  import { zodToJsonSchema } from 'zod-to-json-schema';
+  import { z } from 'zod';
   import { issueSchema } from './nango-integrations/github/syncs/fetchIssues';
 
-  const jsonSchema = zodToJsonSchema(issueSchema, 'GithubIssue');
+  const jsonSchema = z.toJSONSchema(issueSchema);
   ```
 
   See the [data validation guide](/implementation-guides/platform/functions/data-validation) for more details on working with Zod schemas in Nango.

--- a/docs/updates/dev.mdx
+++ b/docs/updates/dev.mdx
@@ -24,12 +24,20 @@ description: "Updates and breaking changes for developers."
 
   ### 💡 What should I do?
 
-  **If you use `schema.ts` for types:**
+  #### If you use `schema.ts` for types:
 
   Export the types directly from your sync/action files using `z.infer`, then import them in your application code.
 
-  {/* 📌 Suggested: code snippet showing before/after — importing from `.nango/schema` vs. exporting `z.infer` type from a sync file and importing it in app code */}
+  **Before:**
+  ```ts
+  import type { GithubIssue } from './nango-integrations/.nango/schema';
+  import Nango from '@nangohq/node';
 
+  const nango = new Nango({ secretKey: '...' });
+  const issues = await nango.listRecords<GithubIssue>({ ... });
+  ```
+
+  **After:**
   1. In your sync/action file, export the inferred type:
 
   ```ts
@@ -45,9 +53,9 @@ description: "Updates and breaking changes for developers."
   const issues = await nango.listRecords<GithubIssue>({ ... });
   ```
 
-  Note: if your types are already defined with `z.infer` but not exported, you only need to add the `export` keyword.
+  Note: If your types are already defined with `z.infer` but not exported, you only need to add the `export` keyword.
 
-  **If you use `schema.json` for JSON Schema:**
+  #### If you use `schema.json` for JSON Schema:
 
   JSON schemas are now available per sync/action inside `.nango/nango.json` via the `json_schema` property. This replaces the top-level `schema.json` (which had naming conflicts when models across integrations shared the same name).
 

--- a/docs/updates/dev.mdx
+++ b/docs/updates/dev.mdx
@@ -4,6 +4,65 @@ sidebarTitle: "Dev Updates"
 description: "Updates and breaking changes for developers."
 ---
 
+<Update label="March 16, 2026">
+  ## Deprecation of `schema.ts` and `schema.json` generation
+
+  ### ✨ What's changing
+
+  Running `nango compile` or `nango deploy` currently generates three files under `.nango/`: `schema.ts`, `schema.json`, and `nango.json`.
+
+  We will stop generating `schema.ts` and `schema.json`. The `nango.json` file remains unchanged.
+
+  ### 🗓️ Timeline
+
+  - **April 16, 2026**: `schema.ts` and `schema.json` will no longer be generated.
+
+  ### 🧐 Am I impacted?
+
+  - If you import TypeScript types from `.nango/schema.ts` in your application code (e.g., to type SDK calls like `nango.listRecords<MyModel>(...)`)
+  - If you consume `.nango/schema.json` for runtime data validation or code generation
+
+  ### 💡 What should I do?
+
+  **If you use `schema.ts` for types:**
+
+  Export the types directly from your sync/action files using `z.infer`, then import them in your application code.
+
+  {/* 📌 Suggested: code snippet showing before/after — importing from `.nango/schema` vs. exporting `z.infer` type from a sync file and importing it in app code */}
+
+  1. In your sync/action file, export the inferred type:
+
+  ```ts
+  // In: github/syncs/fetchIssues.ts
+  export type GithubIssue = z.infer<typeof issueSchema>;
+  ```
+
+  2. Import it in your application code:
+
+  ```ts
+  import type { GithubIssue } from './nango-integrations/github/syncs/fetchIssues';
+
+  const issues = await nango.listRecords<GithubIssue>({ ... });
+  ```
+
+  Note: if your types are already defined with `z.infer` but not exported, you only need to add the `export` keyword.
+
+  **If you use `schema.json` for JSON Schema:**
+
+  Use a library like [`zod-to-json-schema`](https://github.com/StefanTerdell/zod-to-json-schema) to generate JSON Schema from your Zod models directly.
+
+  ```ts
+  import { zodToJsonSchema } from 'zod-to-json-schema';
+  import { issueSchema } from './nango-integrations/github/syncs/fetchIssues';
+
+  const jsonSchema = zodToJsonSchema(issueSchema, 'GithubIssue');
+  ```
+
+  See the [data validation guide](/implementation-guides/platform/functions/data-validation) for more details on working with Zod schemas in Nango.
+
+  ---
+</Update>
+
 <Update label="February 5, 2026">
   ## Better incremental syncing with checkpoints
 


### PR DESCRIPTION
### Summary

Adds a dev update entry announcing the deprecation of `.nango/schema.ts` and `.nango/schema.json` file generation from `nango compile` / `nango deploy`. Removal date: April 16, 2026.

### What's in the update

- **What's changing**: `schema.ts` and `schema.json` will no longer be generated. `nango.json` is unchanged.
- **`schema.ts` migration**: Export types from sync/action files using `z.infer` instead of importing from `.nango/schema`
- **`schema.json` migration**: Use `json_schema` property in `nango.json` (now scoped per sync/action), or generate programmatically via Zod v4's `z.toJSONSchema()`
- Links to the data validation guide for details

For: NAN-5030/announce-schema-files-deprecation

### TBD:
I mentioned the upcoming change date as April 16, 2026. Please let me know if its different.

###  Branch preview link:
https://nango-nan-5030-announce-schema-files-deprecation.mintlify.app/updates/dev

<!-- Summary by @propel-code-bot -->

---

The update is added as a new developer update entry in the documentation file.

---
*This summary was automatically generated by @propel-code-bot*