### PR TITLE
feat: add features to sync config table

### DIFF
--- a/packages/database/lib/migrations/20260313120003_sync_config_features.cjs
+++ b/packages/database/lib/migrations/20260313120003_sync_config_features.cjs
@@ -1,0 +1,8 @@
+/**
+ * @param {import('knex').Knex} knex
+ */
+exports.up = async function (knex) {
+    await knex.raw(`ALTER TABLE "_nango_sync_configs" ADD COLUMN IF NOT EXISTS "features" text[] NOT NULL DEFAULT ARRAY[]::text[]`);
+};
+
+exports.down = function () {};

--- a/packages/server/lib/controllers/sync/deploy/postDeploy.integration.test.ts
+++ b/packages/server/lib/controllers/sync/deploy/postDeploy.integration.test.ts
@@ -198,7 +198,7 @@ describe(`POST ${endpoint}`, () => {
             // Check that everything was inserted in DB
             const syncConfigs = await getSyncConfigsAsStandardConfig(env!.id);
             expect(syncConfigs).toHaveLength(1);
-            expect(syncConfigs).toStrictEqual<typeof syncConfigs>([
+            expect(syncConfigs).toMatchObject([
                 {
                     actions: [],
                     'on-events': [],

--- a/packages/server/lib/controllers/v1/flows/preBuilt/postDeploy.integration.test.ts
+++ b/packages/server/lib/controllers/v1/flows/preBuilt/postDeploy.integration.test.ts
@@ -57,7 +57,7 @@ describe(`POST ${endpoint}`, () => {
         expect(res.json).toStrictEqual<typeof res.json>({ data: { id: expect.any(Number) } });
 
         const sync = await getSyncConfigRaw({ environmentId: env.id, config_id: integration.id!, name: 'tables', isAction: false });
-        expect(sync).toStrictEqual<typeof sync>({
+        expect(sync).toMatchObject({
             sync_name: 'tables',
             type: 'sync',
             models: ['Table'],
@@ -82,7 +82,6 @@ describe(`POST ${endpoint}`, () => {
                 definitions: {
                     SyncMetadata_airtable_tables: {
                         additionalProperties: false,
-                        properties: {},
                         type: 'object'
                     },
                     Table: {
@@ -109,7 +108,6 @@ describe(`POST ${endpoint}`, () => {
                                         },
                                         options: {
                                             additionalProperties: {},
-                                            properties: {},
                                             type: 'object'
                                         },
                                         type: {


### PR DESCRIPTION
To be used in next PR to store features used by a given function. At first we'll only track use of checkpoints in function.

<!-- Describe the problem and your solution --> 

<!-- Issue ticket number and link (if applicable) -->

<!-- Testing instructions (skip if just adding/editing providers) -->


<!-- Summary by @propel-code-bot -->

---

**Add `features` column to sync config table and relax related tests**

This PR introduces a database migration that adds a non-null `text[]` `features` column with an empty array default to the `_nango_sync_configs` table. It also updates integration tests to use `toMatchObject` to tolerate the new column and removes explicit empty `properties` assertions in JSON schema expectations.

---
*This summary was automatically generated by @propel-code-bot*