### PR TITLE
feat: detect features in CLI and pass to /deploy endpoint  

### DIFF
--- a/packages/cli/fixtures/zero/cases/features.none.ts
+++ b/packages/cli/fixtures/zero/cases/features.none.ts
@@ -1,0 +1,20 @@
+import { createSync } from 'nango';
+import * as z from 'zod';
+
+const issueSchema = z.object({
+    id: z.string()
+});
+
+export default createSync({
+    description: 'example',
+    version: '1.0.0',
+    endpoints: [{ method: 'GET', path: '/example', group: 'Issues' }],
+    frequency: 'every hour',
+    syncType: 'full',
+    models: {
+        GithubIssue: issueSchema
+    },
+    exec: async (nango) => {
+        await nango.get({ endpoint: `/nangohq/nango/issues?${from}` });
+    }
+});

--- a/packages/cli/fixtures/zero/cases/features.none.ts
+++ b/packages/cli/fixtures/zero/cases/features.none.ts
@@ -15,6 +15,6 @@ export default createSync({
         GithubIssue: issueSchema
     },
     exec: async (nango) => {
-        await nango.get({ endpoint: `/nangohq/nango/issues?${from}` });
+        await nango.get({ endpoint: `/nangohq/nango/issues` });
     }
 });

--- a/packages/cli/fixtures/zero/cases/features.ts
+++ b/packages/cli/fixtures/zero/cases/features.ts
@@ -19,7 +19,7 @@ export default createSync({
     }),
     exec: async (nango) => {
         const checkpoint = await nango.getCheckpoint();
-        const from = checkpoint ? `from=checkpoint.lastSyncedIssueId` : '';
+        const from = checkpoint ? `from=${checkpoint.lastSyncedIssueId}` : '';
         await nango.get({ endpoint: `/nangohq/nango/issues?${from}` });
         await nango.saveCheckpoint({ lastSyncedIssueId: '123' });
     }

--- a/packages/cli/fixtures/zero/cases/features.ts
+++ b/packages/cli/fixtures/zero/cases/features.ts
@@ -1,0 +1,26 @@
+import { createSync } from 'nango';
+import * as z from 'zod';
+
+const issueSchema = z.object({
+    id: z.string()
+});
+
+export default createSync({
+    description: 'example',
+    version: '1.0.0',
+    endpoints: [{ method: 'GET', path: '/example', group: 'Issues' }],
+    frequency: 'every hour',
+    syncType: 'full',
+    models: {
+        GithubIssue: issueSchema
+    },
+    checkpoint: z.object({
+        lastSyncedIssueId: z.string()
+    }),
+    exec: async (nango) => {
+        const checkpoint = await nango.getCheckpoint();
+        const from = checkpoint ? `from=checkpoint.lastSyncedIssueId` : '';
+        await nango.get({ endpoint: `/nangohq/nango/issues?${from}` });
+        await nango.saveCheckpoint({ lastSyncedIssueId: '123' });
+    }
+});

--- a/packages/cli/lib/services/__snapshots__/config.service.unit.test.ts.snap
+++ b/packages/cli/lib/services/__snapshots__/config.service.unit.test.ts.snap
@@ -163,6 +163,7 @@ exports[`load > should parse a nango.yaml file that is version 2 as expected 1`]
             "method": "GET",
             "path": "/ticketing/tickets/{GithubCreateIssueInput:id}",
           },
+          "features": [],
           "input": null,
           "name": "github-get-issue",
           "output": [
@@ -183,6 +184,7 @@ exports[`load > should parse a nango.yaml file that is version 2 as expected 1`]
             "method": "POST",
             "path": "/ticketing/tickets",
           },
+          "features": [],
           "input": "GithubCreateIssueInput",
           "name": "github-create-issue",
           "output": [
@@ -205,6 +207,7 @@ exports[`load > should parse a nango.yaml file that is version 2 as expected 1`]
             "method": "DELETE",
             "path": "/ticketing/tickets/{GithubIssue:id}",
           },
+          "features": [],
           "input": null,
           "name": "github-delete-issue",
           "output": [
@@ -236,6 +239,7 @@ exports[`load > should parse a nango.yaml file that is version 2 as expected 1`]
               "path": "/ticketing/tickets",
             },
           ],
+          "features": [],
           "input": null,
           "name": "github-issue-example",
           "output": [
@@ -265,6 +269,7 @@ exports[`load > should parse a nango.yaml file that is version 2 as expected 1`]
               "path": "/ticketing/tickets-two",
             },
           ],
+          "features": [],
           "input": null,
           "name": "github-issue-example-two",
           "output": [
@@ -296,6 +301,7 @@ exports[`load > should parse a nango.yaml file that is version 2 as expected 1`]
               "path": "/ticketing/pr",
             },
           ],
+          "features": [],
           "input": null,
           "name": "github-multiple-models",
           "output": [

--- a/packages/cli/lib/services/dryrun.service.ts
+++ b/packages/cli/lib/services/dryrun.service.ts
@@ -321,6 +321,7 @@ export class DryRunService {
                 metadata: {},
                 pre_built: false,
                 sdk_version: null,
+                features: [],
                 sync_type: lastSyncDate ? 'incremental' : 'full',
                 version: '0.0.1'
             };

--- a/packages/cli/lib/zeroYaml/compile.ts
+++ b/packages/cli/lib/zeroYaml/compile.ts
@@ -16,7 +16,7 @@ import { Spinner } from '../utils/spinner.js';
 import { printDebug } from '../utils.js';
 
 // import type { BabelErrorType } from './constants.js';
-import type { Result } from '@nangohq/types';
+import type { Feature, Result } from '@nangohq/types';
 
 /**
  * This function is used to compile the code in the integration.
@@ -406,6 +406,29 @@ export function tsToJsPath(filePath: string) {
     return filePath.replace(/^\.\//, '').replaceAll(/[/\\]/g, '_').replace('.js', '.cjs');
 }
 
+/**
+ * Detects which features are used in a function
+ */
+export async function detectFeatures({ entryPoint }: { entryPoint: string }): Promise<Result<Feature[]>> {
+    try {
+        const source = await fs.promises.readFile(entryPoint, 'utf8');
+        const { plugin, bag } = nangoPlugin({ entryPoint });
+        await babel.transformAsync(source, {
+            filename: entryPoint,
+            plugins: [plugin],
+            parserOpts: { sourceType: 'module', plugins: ['typescript'] },
+            generatorOpts: { decoratorsBeforeExport: true }
+        });
+        const features: Feature[] = [];
+        if (bag.checkpointsLines.length > 0) {
+            features.push('checkpoints');
+        }
+        return Ok(features);
+    } catch (err) {
+        return Err(new Error('failed_to_detect_features', { cause: err }));
+    }
+}
+
 type AugmentedExport = babel.types.ExportNamedDeclaration & { __transformedByRemoveCreateWrappers?: boolean };
 type AugmentedExportDefault = babel.types.ExportDefaultDeclaration & { __transformedByRemoveCreateWrappers?: boolean };
 
@@ -422,12 +445,14 @@ function nangoPlugin({ entryPoint }: { entryPoint: string }) {
     const setMergingStrategyLines: number[] = [];
     const deleteRecordsFromPreviousExecutionsLines: number[] = [];
     const trackDeletesByModel = new Map<string, { startLines: number[]; endLines: number[] }>();
+    const checkpointsLines: number[] = [];
     const bag = {
         proxyLines,
         batchingRecordsLines,
         setMergingStrategyLines,
         deleteRecordsFromPreviousExecutionsLines,
-        trackDeletesByModel
+        trackDeletesByModel,
+        checkpointsLines
     };
 
     const normalizedEntryPoint = path.resolve(entryPoint);
@@ -583,6 +608,10 @@ function nangoPlugin({ entryPoint }: { entryPoint: string }) {
                                     }
                                 }
                             }
+                        }
+
+                        if (['getCheckpoint', 'saveCheckpoint', 'clearCheckpoint'].includes(callee.property.name)) {
+                            checkpointsLines.push(lineNumber);
                         }
                     },
 

--- a/packages/cli/lib/zeroYaml/compile.ts
+++ b/packages/cli/lib/zeroYaml/compile.ts
@@ -407,13 +407,13 @@ export function tsToJsPath(filePath: string) {
 }
 
 /**
- * Detects which features are used in a function
+ * Detects which features are used in function code
  */
-export async function detectFeatures({ entryPoint }: { entryPoint: string }): Promise<Result<Feature[]>> {
+export function detectFeatures({ entryPoint }: { entryPoint: string }): Result<Feature[]> {
     try {
-        const source = await fs.promises.readFile(entryPoint, 'utf8');
+        const source = fs.readFileSync(entryPoint, { encoding: 'utf8' });
         const { plugin, bag } = nangoPlugin({ entryPoint });
-        await babel.transformAsync(source, {
+        babel.transformSync(source, {
             filename: entryPoint,
             plugins: [plugin],
             parserOpts: { sourceType: 'module', plugins: ['typescript'] },

--- a/packages/cli/lib/zeroYaml/compile.unit.cli-test.ts
+++ b/packages/cli/lib/zeroYaml/compile.unit.cli-test.ts
@@ -69,16 +69,16 @@ describe('edge cases', () => {
 });
 
 describe('detectFeatures', () => {
-    it('should fail if entrypoint does not exists', async () => {
-        const res = await detectFeatures({ entryPoint: path.join(fixturesPath, 'does/not/exist.ts') });
+    it('should fail if entrypoint does not exists', () => {
+        const res = detectFeatures({ entryPoint: path.join(fixturesPath, 'does/not/exist.ts') });
         expect(res.isErr()).toBe(true);
     });
-    it('should detect features', async () => {
-        const features = (await detectFeatures({ entryPoint: path.join(fixturesPath, 'zero/cases/features.ts') })).unwrap();
+    it('should detect features', () => {
+        const features = detectFeatures({ entryPoint: path.join(fixturesPath, 'zero/cases/features.ts') }).unwrap();
         expect(features).toEqual(['checkpoints']);
     });
-    it('should not detect features if none', async () => {
-        const features = (await detectFeatures({ entryPoint: path.join(fixturesPath, 'zero/cases/features.none.ts') })).unwrap();
+    it('should not detect features if none', () => {
+        const features = detectFeatures({ entryPoint: path.join(fixturesPath, 'zero/cases/features.none.ts') }).unwrap();
         expect(features).toEqual([]);
     });
 });

--- a/packages/cli/lib/zeroYaml/compile.unit.cli-test.ts
+++ b/packages/cli/lib/zeroYaml/compile.unit.cli-test.ts
@@ -5,7 +5,7 @@ import { promisify } from 'node:util';
 
 import { assert, describe, expect, it } from 'vitest';
 
-import { bundleFile, compileAllFunctions } from './compile.js';
+import { bundleFile, compileAllFunctions, detectFeatures } from './compile.js';
 import { CompileError } from './utils.js';
 import { copyDirectoryAndContents, fixturesPath, getTestDirectory } from '../tests/helpers.js';
 
@@ -65,5 +65,20 @@ describe('edge cases', () => {
         assert(result.error instanceof CompileError, 'Should be an error');
 
         expect(result.error.toText().replaceAll('\\', '/')).toMatchSnapshot();
+    });
+});
+
+describe('detectFeatures', () => {
+    it('should fail if entrypoint does not exists', async () => {
+        const res = await detectFeatures({ entryPoint: path.join(fixturesPath, 'does/not/exist.ts') });
+        expect(res.isErr()).toBe(true);
+    });
+    it('should detect features', async () => {
+        const features = (await detectFeatures({ entryPoint: path.join(fixturesPath, 'zero/cases/features.ts') })).unwrap();
+        expect(features).toEqual(['checkpoints']);
+    });
+    it('should not detect features if none', async () => {
+        const features = (await detectFeatures({ entryPoint: path.join(fixturesPath, 'zero/cases/features.none.ts') })).unwrap();
+        expect(features).toEqual([]);
     });
 });

--- a/packages/cli/lib/zeroYaml/definitions.ts
+++ b/packages/cli/lib/zeroYaml/definitions.ts
@@ -3,7 +3,7 @@ import { pathToFileURL } from 'url';
 
 import { getInterval } from '@nangohq/nango-yaml';
 
-import { getEntryPoints, readIndexContent, tsToJsPath } from './compile.js';
+import { detectFeatures, getEntryPoints, readIndexContent, tsToJsPath } from './compile.js';
 import { buildJsonSchemaDefinitionsFromZodModels } from './json-schema.js';
 import {
     DuplicateEndpointDefinitionError,
@@ -90,7 +90,7 @@ export async function parseIntegrationDefinitions({ fullPath, debug }: { fullPat
                 break;
             }
             case 'action': {
-                const action = parseAction({ params: script, integrationIdClean, basename, basenameClean });
+                const action = parseAction({ filePath: realPath, params: script, integrationIdClean, basename, basenameClean });
                 integration.actions.push(action);
 
                 const models = buildNangoModelsForAction(script, integrationIdClean, basenameClean);
@@ -180,6 +180,8 @@ export function parseSync({
     const outputNames = Object.keys(params.models);
     const jsonSchema = buildJsonSchemaDefinitionsFromZodModels(allZodModels);
 
+    const features = detectFeatures({ entryPoint: filePath });
+
     const sync: ParsedNangoSync = {
         type: 'sync',
         description: params.description,
@@ -195,18 +197,21 @@ export function parseSync({
         usedModels: Object.keys(allZodModels),
         version: params.version || '',
         webhookSubscriptions: params.webhookSubscriptions || [],
-        json_schema: jsonSchema
+        json_schema: jsonSchema,
+        features: features.isOk() ? features.value : [] // silently ignore features detection error as it is only used internally and we don't want it to block the parsing
     };
 
     return Ok(sync);
 }
 
 export function parseAction({
+    filePath,
     params,
     integrationIdClean,
     basename,
     basenameClean
 }: {
+    filePath: string;
     params: CreateActionResponse<z.ZodTypeAny, z.ZodTypeAny, ZodMetadata, ZodCheckpoint>;
     integrationIdClean: string;
     basename: string;
@@ -222,6 +227,8 @@ export function parseAction({
 
     const jsonSchema = buildJsonSchemaDefinitionsFromZodModels(allZodModels);
 
+    const features = detectFeatures({ entryPoint: filePath });
+
     return {
         type: 'action' as const,
         description: params.description,
@@ -232,7 +239,8 @@ export function parseAction({
         scopes: params.scopes || [],
         usedModels: [inputName, outputName],
         version: params.version || '',
-        json_schema: jsonSchema
+        json_schema: jsonSchema,
+        features: features.isOk() ? features.value : [] // silently ignore features detection error as it is only used internally and we don't want it to block the parsing
     };
 }
 

--- a/packages/cli/lib/zeroYaml/definitions.unit.test.ts
+++ b/packages/cli/lib/zeroYaml/definitions.unit.test.ts
@@ -123,6 +123,7 @@ describe('parseAction', () => {
     it('should return the parsed action without endpoint', () => {
         const { endpoint, ...actionParamsWithoutEndpoint } = actionParams;
         const action = parseAction({
+            filePath: './createIssue.ts',
             params: actionParamsWithoutEndpoint,
             basename: 'createIssue',
             basenameClean: 'createIssue',
@@ -138,6 +139,7 @@ describe('parseAction', () => {
 
     it('should return the parsed action', () => {
         const action = parseAction({
+            filePath: './createIssue.ts',
             params: actionParams,
             basename: 'createIssue',
             basenameClean: 'createIssue',

--- a/packages/cli/lib/zeroYaml/deploy.ts
+++ b/packages/cli/lib/zeroYaml/deploy.ts
@@ -224,7 +224,7 @@ async function createDeployConfirmationPackage({
                     endpoints: sync.endpoints,
                     webhookSubscriptions: sync.webhookSubscriptions,
                     models_json_schema: sync.json_schema,
-                    features: features.isErr() ? [] : features.value
+                    features: sync.features
                 };
 
                 postData.push(body);
@@ -263,7 +263,7 @@ async function createDeployConfirmationPackage({
                     endpoints: action.endpoint ? [action.endpoint] : [],
                     track_deletes: false,
                     models_json_schema: action.json_schema,
-                    features: features.isErr() ? [] : features.value
+                    features: action.features
                 };
 
                 postData.push(body);

--- a/packages/cli/lib/zeroYaml/deploy.ts
+++ b/packages/cli/lib/zeroYaml/deploy.ts
@@ -223,7 +223,8 @@ async function createDeployConfirmationPackage({
                     fileBody: files,
                     endpoints: sync.endpoints,
                     webhookSubscriptions: sync.webhookSubscriptions,
-                    models_json_schema: sync.json_schema
+                    models_json_schema: sync.json_schema,
+                    features: features.isErr() ? [] : features.value
                 };
 
                 postData.push(body);
@@ -261,7 +262,8 @@ async function createDeployConfirmationPackage({
                     fileBody: files,
                     endpoints: action.endpoint ? [action.endpoint] : [],
                     track_deletes: false,
-                    models_json_schema: action.json_schema
+                    models_json_schema: action.json_schema,
+                    features: features.isErr() ? [] : features.value
                 };
 
                 postData.push(body);

--- a/packages/database/lib/migrations/20260313120003_sync_config_features.cjs
+++ b/packages/database/lib/migrations/20260313120003_sync_config_features.cjs
@@ -1,0 +1,8 @@
+/**
+ * @param {import('knex').Knex} knex
+ */
+exports.up = async function (knex) {
+    await knex.raw(`ALTER TABLE "_nango_sync_configs" ADD COLUMN IF NOT EXISTS "features" text[] NOT NULL DEFAULT ARRAY[]::text[]`);
+};
+
+exports.down = function () {};

--- a/packages/jobs/lib/execution/onEvent.ts
+++ b/packages/jobs/lib/execution/onEvent.ts
@@ -96,6 +96,7 @@ export async function startOnEvent(task: TaskOnEvent): Promise<Result<void>> {
             pre_built: false,
             sync_type: null,
             sdk_version: task.sdkVersion,
+            features: [],
             created_at: new Date(),
             updated_at: new Date()
         };

--- a/packages/jobs/lib/runtime/lambda.adapter.unit.test.ts
+++ b/packages/jobs/lib/runtime/lambda.adapter.unit.test.ts
@@ -82,7 +82,8 @@ function minimalNangoProps(overrides: { environmentId?: number } = {}) {
             input: null,
             sync_type: null,
             metadata: {},
-            sdk_version: null
+            sdk_version: null,
+            features: []
         },
         activityLogId: 'log-1',
         secretKey: 'sk',

--- a/packages/jobs/lib/schemas/nango-props.ts
+++ b/packages/jobs/lib/schemas/nango-props.ts
@@ -2,6 +2,8 @@ import { z } from 'zod';
 
 import { operationIdRegex } from '@nangohq/logs';
 
+import type { Feature } from '@nangohq/types';
+
 export const nangoPropsSchema = z.looseObject({
     scriptType: z.enum(['action', 'webhook', 'sync', 'on-event']),
     connectionId: z.string().min(1),
@@ -40,7 +42,8 @@ export const nangoPropsSchema = z.looseObject({
         input: z.string().nullable(),
         sync_type: z.enum(['full', 'incremental']).nullable(),
         metadata: z.record(z.string(), z.any()),
-        sdk_version: z.string().nullable()
+        sdk_version: z.string().nullable(),
+        features: z.array(z.enum(['checkpoints'] satisfies Feature[])).default([])
         // TODO: fix this missing fields
         // deleted: z.boolean().optional(),
         // deleted_at: z.coerce.date().optional().nullable(),

--- a/packages/nango-yaml/lib/parser.v2.ts
+++ b/packages/nango-yaml/lib/parser.v2.ts
@@ -139,7 +139,8 @@ export class NangoYamlParserV2 extends NangoYamlParser {
                 output: modelOutput.map((m) => m.name),
                 scopes: this.getScopes(sync),
                 endpoints,
-                webhookSubscriptions
+                webhookSubscriptions,
+                features: [] // not supporting features detection in Nango YAML
             };
 
             parsedSyncs.push(parsedSync);
@@ -183,7 +184,8 @@ export class NangoYamlParserV2 extends NangoYamlParser {
                 input: modelInput?.name || null,
                 output: modelOutput && modelOutput.length > 0 ? modelOutput.map((m) => m.name) : null,
                 usedModels: Array.from(modelNames),
-                endpoint
+                endpoint,
+                features: [] // not supporting features detection in Nango YAML
             };
 
             parsedActions.push(parsedAction);

--- a/packages/nango-yaml/lib/parser.v2.unit.test.ts
+++ b/packages/nango-yaml/lib/parser.v2.unit.test.ts
@@ -44,7 +44,8 @@ describe('parse', () => {
                             type: 'sync',
                             usedModels: ['GithubIssue'],
                             webhookSubscriptions: [],
-                            version: ''
+                            version: '',
+                            features: []
                         }
                     ],
                     onEventScripts: { 'post-connection-creation': [], 'pre-connection-deletion': [], 'validate-connection': [] },
@@ -58,7 +59,8 @@ describe('parse', () => {
                             scopes: [],
                             type: 'action',
                             usedModels: ['GithubIssue', 'Anonymous_provider_action_createIssue_input'],
-                            version: ''
+                            version: '',
+                            features: []
                         }
                     ]
                 }
@@ -106,7 +108,8 @@ describe('parse', () => {
                             scopes: [],
                             type: 'action',
                             usedModels: ['Start', 'Middle', 'End'],
-                            version: ''
+                            version: '',
+                            features: []
                         }
                     ]
                 }
@@ -150,7 +153,8 @@ describe('parse', () => {
                             type: 'sync',
                             usedModels: ['Anonymous_provider_sync_top_output', 'Anonymous_provider_sync_top_input'],
                             webhookSubscriptions: [],
-                            version: ''
+                            version: '',
+                            features: []
                         }
                     ],
                     onEventScripts: { 'post-connection-creation': [], 'pre-connection-deletion': [], 'validate-connection': [] },

--- a/packages/server/lib/controllers/scripts/config/getScriptsConfigOpenAI.unit.test.ts
+++ b/packages/server/lib/controllers/scripts/config/getScriptsConfigOpenAI.unit.test.ts
@@ -22,7 +22,8 @@ describe('transformToOpenAIFunctions', () => {
                             properties: {},
                             required: []
                         },
-                        sdk_version: '0.0.0'
+                        sdk_version: '0.0.0',
+                        features: []
                     } as NangoSyncConfig
                 ],
                 actions: [],
@@ -71,7 +72,8 @@ describe('transformToOpenAIFunctions', () => {
                                 }
                             }
                         },
-                        sdk_version: '0.0.0'
+                        sdk_version: '0.0.0',
+                        features: []
                     } as NangoSyncConfig
                 ],
                 'on-events': []

--- a/packages/server/lib/controllers/sync/deploy/postDeploy.integration.test.ts
+++ b/packages/server/lib/controllers/sync/deploy/postDeploy.integration.test.ts
@@ -226,6 +226,7 @@ describe(`POST ${endpoint}`, () => {
                             type: 'sync',
                             version: '1',
                             webhookSubscriptions: [],
+                            features: [],
                             json_schema: {
                                 definitions: {
                                     Input: { type: 'object', properties: { id: { type: 'number' } }, required: ['id'], additionalProperties: false },

--- a/packages/server/lib/controllers/sync/deploy/validation.ts
+++ b/packages/server/lib/controllers/sync/deploy/validation.ts
@@ -2,7 +2,7 @@ import * as z from 'zod';
 
 import { frequencySchema, providerConfigKeySchema, syncNameSchema } from '../../../helpers/validation.js';
 
-import type { NangoModelField, OnEventType } from '@nangohq/types';
+import type { Feature, NangoModelField, OnEventType } from '@nangohq/types';
 
 const fileBody = z.object({ js: z.string(), ts: z.string() }).strict();
 const jsonSchema = z
@@ -86,7 +86,8 @@ export const flowConfig = z
             .object({
                 definitions: z.record(z.string(), z.looseObject({}))
             })
-            .optional()
+            .optional(),
+        features: z.array(z.enum(['checkpoints'] satisfies Feature[])).default([])
     })
     .refine(
         (data) => {

--- a/packages/server/lib/controllers/v1/flows/preBuilt/postDeploy.integration.test.ts
+++ b/packages/server/lib/controllers/v1/flows/preBuilt/postDeploy.integration.test.ts
@@ -164,8 +164,7 @@ describe(`POST ${endpoint}`, () => {
             track_deletes: false,
             updated_at: expect.any(Date),
             version: '1.0.0',
-            webhook_subscriptions: null,
-            features: []
+            webhook_subscriptions: null
         });
     });
 });

--- a/packages/server/lib/controllers/v1/flows/preBuilt/postDeploy.integration.test.ts
+++ b/packages/server/lib/controllers/v1/flows/preBuilt/postDeploy.integration.test.ts
@@ -159,11 +159,13 @@ describe(`POST ${endpoint}`, () => {
             pre_built: true,
             runs: 'every day',
             sdk_version: expect.any(String),
+            features: expect.any(Array),
             sync_type: 'full',
             track_deletes: false,
             updated_at: expect.any(Date),
             version: '1.0.0',
-            webhook_subscriptions: null
+            webhook_subscriptions: null,
+            features: []
         });
     });
 });

--- a/packages/shared/lib/seeders/syncConfig.seeder.ts
+++ b/packages/shared/lib/seeders/syncConfig.seeder.ts
@@ -9,6 +9,7 @@ export function getTestStdSyncConfig(data?: Partial<NangoSyncConfig>): NangoSync
         returns: [],
         json_schema: {},
         sdk_version: '1.0.0',
+        features: [],
         ...data
     };
 }

--- a/packages/shared/lib/services/deploy/template.ts
+++ b/packages/shared/lib/services/deploy/template.ts
@@ -119,7 +119,7 @@ export async function deployTemplate({
         webhook_subscriptions: null,
         models_json_schema: template.json_schema,
         sdk_version: template.sdk_version,
-        features: [],
+        features: template.features,
         updated_at: new Date(),
         sync_type: 'sync_type' in template ? template.sync_type : null
     };
@@ -252,7 +252,7 @@ export async function upgradeTemplate({
         track_deletes: template.track_deletes === true,
         models: template.returns,
         sdk_version: template.sdk_version,
-        features: [],
+        features: template.features,
         models_json_schema: template.json_schema,
         input: template.input || null,
         runs: template.type === 'sync' ? template.runs! : null

--- a/packages/shared/lib/services/deploy/template.ts
+++ b/packages/shared/lib/services/deploy/template.ts
@@ -119,6 +119,7 @@ export async function deployTemplate({
         webhook_subscriptions: null,
         models_json_schema: template.json_schema,
         sdk_version: template.sdk_version,
+        features: [],
         updated_at: new Date(),
         sync_type: 'sync_type' in template ? template.sync_type : null
     };
@@ -251,6 +252,7 @@ export async function upgradeTemplate({
         track_deletes: template.track_deletes === true,
         models: template.returns,
         sdk_version: template.sdk_version,
+        features: [],
         models_json_schema: template.json_schema,
         input: template.input || null,
         runs: template.type === 'sync' ? template.runs! : null

--- a/packages/shared/lib/services/flow.service.ts
+++ b/packages/shared/lib/services/flow.service.ts
@@ -55,7 +55,8 @@ class FlowService {
                     webhookSubscriptions: [],
                     json_schema: jsonSchema,
                     metadata: { description: item.description, scopes: item.scopes },
-                    sdk_version: `${integration.sdkVersion}-zero`
+                    sdk_version: `${integration.sdkVersion}-zero`,
+                    features: item.features || []
                 });
             }
             for (const item of integration.actions) {
@@ -86,7 +87,8 @@ class FlowService {
                     webhookSubscriptions: [],
                     json_schema: jsonSchema,
                     metadata: { description: item.description, scopes: item.scopes },
-                    sdk_version: `${integration.sdkVersion}-zero`
+                    sdk_version: `${integration.sdkVersion}-zero`,
+                    features: item.features || []
                 });
             }
 

--- a/packages/shared/lib/services/sync/config/config.service.ts
+++ b/packages/shared/lib/services/sync/config/config.service.ts
@@ -52,7 +52,8 @@ function convertSyncConfigToStandardConfig(syncConfigs: ExtendedSyncConfig[]): S
             json_schema: syncConfig.models_json_schema || null,
             sdk_version: syncConfig.sdk_version,
             // Temporary regression
-            models: syncConfig.model_schema ?? modelsFromJsonSchema(syncConfig.models_json_schema)
+            models: syncConfig.model_schema ?? modelsFromJsonSchema(syncConfig.models_json_schema),
+            features: syncConfig.features
         };
 
         if (syncConfig.type === 'sync') {

--- a/packages/shared/lib/services/sync/config/deploy.service.ts
+++ b/packages/shared/lib/services/sync/config/deploy.service.ts
@@ -368,6 +368,7 @@ async function compileDeployInfo({
                 model_schema: null,
                 models_json_schema,
                 sdk_version: sdkVersion || null,
+                features: flow.features || [],
                 created_at: new Date(),
                 updated_at: new Date()
             }

--- a/packages/shared/lib/services/sync/config/deploy.service.unit.test.ts
+++ b/packages/shared/lib/services/sync/config/deploy.service.unit.test.ts
@@ -171,6 +171,7 @@ describe('Sync config create', () => {
                     sync_type: 'full',
                     models_json_schema: null,
                     sdk_version: null,
+                    features: [],
                     created_at: new Date(),
                     updated_at: new Date()
                 }
@@ -202,6 +203,7 @@ describe('Sync config create', () => {
                 sync_type: 'full',
                 models_json_schema: null,
                 sdk_version: null,
+                features: [],
                 created_at: new Date(),
                 updated_at: new Date()
             });
@@ -232,6 +234,7 @@ describe('Sync config create', () => {
                 sync_type: 'full',
                 models_json_schema: null,
                 sdk_version: null,
+                features: [],
                 created_at: new Date(),
                 updated_at: new Date()
             });

--- a/packages/types/lib/deploy/incomingFlow.ts
+++ b/packages/types/lib/deploy/incomingFlow.ts
@@ -1,5 +1,6 @@
 import type { NangoSyncEndpointOld, NangoSyncEndpointV2, ScriptTypeLiteral, SyncTypeLiteral } from '../nangoYaml/index.js';
 import type { OnEventType } from '../scripts/on-events/api.js';
+import type { Feature } from '../syncConfigs/db.js';
 import type { JSONSchema7 } from 'json-schema';
 import type { Merge } from 'type-fest';
 
@@ -91,6 +92,7 @@ export interface CLIDeployFlowConfig {
     webhookSubscriptions?: string[] | undefined;
     // TODO: make non-optional when nango-yaml and `schema.ts` are fully removed
     models_json_schema?: JSONSchema7 | undefined;
+    features?: Feature[] | undefined;
 }
 
 /**

--- a/packages/types/lib/flow/index.ts
+++ b/packages/types/lib/flow/index.ts
@@ -1,5 +1,6 @@
 import type { LegacySyncModelSchema, NangoConfigMetadata } from '../deploy/incomingFlow.js';
 import type { NangoModel, NangoSyncEndpointV2, ScriptTypeLiteral, SyncTypeLiteral } from '../nangoYaml/index.js';
+import type { Feature } from '../syncConfigs/db.js';
 import type { JSONSchema7 } from 'json-schema';
 
 // TODO: Split by type
@@ -30,6 +31,7 @@ export interface NangoSyncConfig {
     sdk_version: string | null;
     // Temporary regression
     models?: NangoModel[] | LegacySyncModelSchema[] | undefined;
+    features: Feature[];
 }
 
 export interface StandardNangoConfig {

--- a/packages/types/lib/nangoYaml/index.ts
+++ b/packages/types/lib/nangoYaml/index.ts
@@ -1,4 +1,5 @@
 import type { OnEventType } from '../scripts/on-events/api.js';
+import type { Feature } from '../syncConfigs/db.js';
 import type { JSONSchema7 } from 'json-schema';
 
 export type HTTP_METHOD = 'GET' | 'POST' | 'PATCH' | 'PUT' | 'DELETE';
@@ -119,6 +120,7 @@ export interface ParsedNangoSync {
     version: string;
     // TODO: make non-optional when nango-yaml is fully removed
     json_schema?: JSONSchema7 | undefined;
+    features?: Feature[] | undefined;
 }
 
 export interface ParsedNangoAction {
@@ -133,6 +135,7 @@ export interface ParsedNangoAction {
     version: string;
     // TODO: make non-optional when nango-yaml is fully removed
     json_schema?: JSONSchema7 | undefined;
+    features?: Feature[] | undefined;
 }
 
 export type LayoutMode = 'root' | 'nested';

--- a/packages/types/lib/syncConfigs/db.ts
+++ b/packages/types/lib/syncConfigs/db.ts
@@ -3,6 +3,8 @@ import type { LegacySyncModelSchema, NangoConfigMetadata } from '../deploy/incom
 import type { NangoModel, ScriptTypeLiteral, SyncTypeLiteral } from '../nangoYaml/index.js';
 import type { JSONSchema7 } from 'json-schema';
 
+export type Feature = 'checkpoints';
+
 export interface DBSyncConfig extends TimestampsAndDeleted {
     id: number;
     sync_name: string;
@@ -28,5 +30,6 @@ export interface DBSyncConfig extends TimestampsAndDeleted {
     enabled: boolean;
     models_json_schema: JSONSchema7 | null;
     sdk_version: string | null;
+    features: Feature[];
 }
 export type DBSyncConfigInsert = Omit<DBSyncConfig, 'id'>;

--- a/packages/webhooks/lib/sync.unit.test.ts
+++ b/packages/webhooks/lib/sync.unit.test.ts
@@ -69,6 +69,7 @@ const syncConfig: DBSyncConfig = {
     enabled: true,
     models_json_schema: null,
     sdk_version: null,
+    features: [],
     created_at: new Date(),
     updated_at: new Date()
 };


### PR DESCRIPTION
For now we only detect the use of checkpoints in function code. 

This information will then be used to dynamically dispatch checkpointed syncs to Lambda

Notes:
- built-in templates are supported yet (aka: no features detected for them)
- nango YAML is not supported

<!-- Summary by @propel-code-bot -->

---

**Add CLI feature detection and persist `features` through deploy pipeline**

This PR introduces feature detection in the CLI build pipeline (currently tracking checkpoint usage) and propagates a new `features` array through parsed definitions, deploy payloads, and persisted sync configs. It adds database support for storing features, updates shared types and validation to include the field, and ensures templates and YAML parsing default to empty feature lists where detection is not supported.

Tests and fixtures are updated to cover feature detection and to include `features` in expected configs, sync configs, and webhook/job contexts, ensuring the new field is consistently handled across services.

---
*This summary was automatically generated by @propel-code-bot*