### PR TITLE
feat(integrations): add support for slack mcp

### DIFF
--- a/docs/api-integrations/slack-mcp.mdx
+++ b/docs/api-integrations/slack-mcp.mdx
@@ -1,0 +1,105 @@
+---
+title: 'Slack (MCP)'
+sidebarTitle: 'Slack (MCP)'
+description: 'Connect AI tools to Slack via the Model Context Protocol (MCP)'
+---
+
+## 🚀 Quickstart
+
+Connect to the Slack MCP server with Nango and call MCP tools in minutes. Slack MCP uses OAuth 2.0 with **static client registration**.
+
+<Steps>
+    <Step title="Create the integration">
+    In Nango ([free signup](https://app.nango.dev)), go to [Integrations](https://app.nango.dev/dev/integrations) -> _Configure New Integration_ -> _Slack (MCP)_.
+    </Step>
+    <Step title="Authorize Slack">
+    Go to [Connections](https://app.nango.dev/dev/connections) -> _Add Test Connection_ -> _Authorize_, then log in to Slack and approve the requested scopes. Later, you'll let your users do the same directly from your app.
+    </Step>
+    <Step title="Call a Slack MCP tool">
+    Make your first MCP request (initialize handshake). Replace the placeholders below with your [secret key](https://app.nango.dev/dev/environment-settings), [integration ID](https://app.nango.dev/dev/integrations), and [connection ID](https://app.nango.dev/dev/connections):
+    <Tabs>
+        <Tab title="cURL">
+
+            ```bash
+            curl "https://api.nango.dev/v2/mcp" \
+              -X POST \
+              -H "Authorization: Bearer <NANGO-SECRET-KEY>" \
+              -H "Provider-Config-Key: <INTEGRATION-ID>" \
+              -H "Connection-Id: <CONNECTION-ID>" \
+              -H "Content-Type: application/json" \
+              -d '{
+                "jsonrpc": "2.0",
+                "id": 1,
+                "method": "initialize",
+                "params": {
+                    "protocolVersion": "2025-06-18",
+                    "capabilities": {},
+                    "clientInfo": {
+                        "name": "nango-client",
+                        "version": "1.0.0"
+                    }
+                }
+            }'
+            ```
+
+        </Tab>
+
+        <Tab title="Node">
+
+        Install Nango's backend SDK with `npm i @nangohq/node`. Then run:
+
+        ```typescript
+        import { Nango } from '@nangohq/node';
+
+        const nango = new Nango({ secretKey: '<NANGO-SECRET-KEY>' });
+
+        const res = await nango.post({
+            endpoint: '/v2/mcp',
+            providerConfigKey: '<INTEGRATION-ID>',
+            connectionId: '<CONNECTION-ID>',
+            body: {
+                jsonrpc: '2.0',
+                id: 1,
+                method: 'initialize',
+                params: {
+                    protocolVersion: '2025-06-18',
+                    capabilities: {},
+                    clientInfo: {
+                        name: 'nango-client',
+                        version: '1.0.0'
+                    }
+                }
+            }
+        });
+
+        console.log(res.data);
+        ```
+        </Tab>
+
+    </Tabs>
+    ✅ You're connected! Check the [Logs](https://app.nango.dev/dev/logs) tab in Nango to inspect requests.
+    </Step>
+
+    <Step title="Implement Nango in your app">
+        Follow our [Auth implementation guide](/implementation-guides/platform/auth/implement-api-auth) to integrate Nango in your app.
+
+        To obtain your own production credentials, follow the setup guide linked below.
+    </Step>
+</Steps>
+
+## 📚 Slack (MCP) Integration Guides
+
+- [How to register your own Slack MCP OAuth app](/api-integrations/slack-mcp/how-to-register-your-own-slack-mcp-oauth-app)  
+  Create or reuse a Slack app and configure it for MCP (user tokens, redirect URL, scopes).
+
+Official docs: [Slack MCP server](https://slack.com/help/articles/17388188499099-Use-the-Slack-MCP-server) · [Slack API OAuth](https://api.slack.com/authentication/oauth-v2)
+
+## 🧩 Pre-built syncs & actions for Slack (MCP)
+
+Enable them in your dashboard. [Extend and customize](/implementation-guides/platform/functions/customize-template) to fit your needs.
+
+import PreBuiltUseCases from "/snippets/generated/slack-mcp/PreBuiltUseCases.mdx"
+
+<PreBuiltUseCases />
+
+---

--- a/docs/api-integrations/slack-mcp/how-to-register-your-own-slack-mcp-oauth-app.mdx
+++ b/docs/api-integrations/slack-mcp/how-to-register-your-own-slack-mcp-oauth-app.mdx
@@ -9,12 +9,12 @@ This guide shows you how to create or reuse a Slack app and configure it for the
 <Steps>
   <Step title="Create or open a Slack app">
     1. Go to the [Slack API](https://api.slack.com/apps) and sign in or join the [Slack Developer Program](https://api.slack.com/developer-program).
-    2. Click **Create New App** (or open an existing app you want to reuse for MCP).
+    2. Click **Create New App** (or open an existing app you want to reuse for MCP and skip the app creation step).
     3. Choose **From scratch**, set an app name and workspace, then click **Create App**.
   </Step>
   <Step title="Enable the Slack MCP server">
-    1. In the left sidebar, open **App Home** (or go to `https://api.slack.com/apps/<your-app-id>/app-assistant`).
-    2. Scroll to the **Slack MCP server** section and toggle it on.
+    1. In the left sidebar, open **Agents & AI Apps** (or go to `https://api.slack.com/apps/<your-app-id>/app-assistant`).
+    2. Scroll to the **Model Context Protocol** section and toggle it on.
     3. Save changes.
   </Step>
   <Step title="Set redirect URL and user token scopes">

--- a/docs/api-integrations/slack-mcp/how-to-register-your-own-slack-mcp-oauth-app.mdx
+++ b/docs/api-integrations/slack-mcp/how-to-register-your-own-slack-mcp-oauth-app.mdx
@@ -1,0 +1,37 @@
+---
+title: 'How to register your own Slack MCP OAuth app'
+sidebarTitle: 'Slack MCP Setup'
+description: 'Configure a Slack app for MCP (user tokens) and connect it to Nango'
+---
+
+This guide shows you how to create or reuse a Slack app and configure it for the **Slack MCP server**. Slack MCP uses **user tokens** (OAuth v2 user flow). You can use the same Slack app as for the regular [Slack integration](/api-integrations/slack); add the redirect URL and **User Token Scopes** required for MCP. Only **directory-published** or **internal** Slack apps may use MCP; unlisted apps are not supported.
+
+<Steps>
+  <Step title="Create or open a Slack app">
+    1. Go to the [Slack API](https://api.slack.com/apps) and sign in or join the [Slack Developer Program](https://api.slack.com/developer-program).
+    2. Click **Create New App** (or open an existing app you want to reuse for MCP).
+    3. Choose **From scratch**, set an app name and workspace, then click **Create App**.
+  </Step>
+  <Step title="Enable the Slack MCP server">
+    1. In the left sidebar, open **App Home** (or go to `https://api.slack.com/apps/<your-app-id>/app-assistant`).
+    2. Scroll to the **Slack MCP server** section and toggle it on.
+    3. Save changes.
+  </Step>
+  <Step title="Set redirect URL and user token scopes">
+    1. In the left sidebar, open **OAuth & Permissions**.
+    2. Under **Redirect URLs**, add: `https://api.nango.dev/oauth/callback`.
+    3. Under **Scopes**, find **User Token Scopes** and add the scopes your MCP use case needs.
+    4. Save changes.
+  </Step>
+  <Step title="Copy credentials">
+    1. Open the **Basic Information** tab.
+    2. Copy your **Client ID** and **Client Secret**. You will enter these when configuring the Slack (MCP) integration in Nango.
+  </Step>
+  <Step title="Next">
+    Follow the [_Quickstart_](/getting-started/quickstart).
+  </Step>
+</Steps>
+
+For more on Slack MCP and OAuth, see [Slack MCP server](https://docs.slack.dev/ai/slack-mcp-server).
+
+---

--- a/docs/docs.json
+++ b/docs/docs.json
@@ -792,6 +792,7 @@
               "integrations/all/skio",
               "api-integrations/slab",
               "api-integrations/slack",
+              "api-integrations/slack-mcp",
               "api-integrations/tally",
               "api-integrations/telegram",
               "api-integrations/timify",

--- a/docs/snippets/generated/slack-mcp/PreBuiltTooling.mdx
+++ b/docs/snippets/generated/slack-mcp/PreBuiltTooling.mdx
@@ -1,0 +1,41 @@
+## Pre-built tooling
+<AccordionGroup>
+<Accordion title="✅ Authorization">
+| Tools | Status |
+| - | - |
+| Pre-built authorization (MCP OAuth2) | ✅ |
+| Auth parameters validation | ✅ |
+| Pre-built authorization UI | ✅ |
+| Custom authorization UI | ✅ |
+| End-user authorization guide | 🚫 |
+| Expired credentials detection | ✅ |
+</Accordion>
+<Accordion title="✅ Read & write data">
+| Tools | Status |
+| - | - |
+| Pre-built integrations | 🚫 (time to contribute: &lt;48h) |
+| API unification | ✅ |
+| 2-way sync | ✅ |
+| Webhooks from Nango on data modifications | ✅ |
+| Real-time webhooks from 3rd-party API | 🚫 (time to contribute: &lt;48h) |
+| Proxy requests | ✅ |
+</Accordion>
+<Accordion title="✅ Observability & data quality">
+| Tools | Status |
+| - | - |
+| HTTP request logging | ✅ |
+| End-to-end type safety | ✅ |
+| Data runtime validation | ✅ |
+| OpenTelemetry export | ✅ |
+| Slack alerts on errors | ✅ |
+| Integration status API | ✅ |
+</Accordion>
+<Accordion title="✅ Customization">
+| Tools | Status |
+| - | - |
+| Create or customize use-cases | ✅ |
+| Pre-configured pagination | 🚫 (time to contribute: &lt;48h) |
+| Pre-configured rate-limit handling | 🚫 (time to contribute: &lt;48h) |
+| Per-customer configurations | ✅ |
+</Accordion>
+</AccordionGroup>

--- a/docs/snippets/generated/slack-mcp/PreBuiltUseCases.mdx
+++ b/docs/snippets/generated/slack-mcp/PreBuiltUseCases.mdx
@@ -1,0 +1,3 @@
+_No pre-built syncs or actions available yet._
+
+<Tip>Not seeing the integration you need? [Build your own](https://nango.dev/docs/guides/primitives/functions) independently.</Tip>

--- a/packages/providers/providers.yaml
+++ b/packages/providers/providers.yaml
@@ -15302,6 +15302,30 @@ slack:
     docs: https://nango.dev/docs/api-integrations/slack
     setup_guide_url: https://nango.dev/docs/api-integrations/slack/how-to-register-your-own-slack-api-oauth-app
 
+slack-mcp:
+    display_name: Slack (MCP)
+    categories:
+        - popular
+        - productivity
+        - communication
+        - mcp
+    auth_mode: MCP_OAUTH2
+    client_registration: static
+    authorization_url: https://slack.com/oauth/v2_user/authorize
+    token_url: https://slack.com/api/oauth.v2.user.access
+    scope_separator: ','
+    alternate_access_token_response_path: authed_user.access_token
+    authorization_params:
+        response_type: code
+    token_params:
+        grant_type: authorization_code
+    proxy:
+        base_url: https://mcp.slack.com
+        headers:
+            accept: application/json,text/event-stream
+    docs: https://nango.dev/docs/api-integrations/slack-mcp
+    setup_guide_url: https://nango.dev/docs/api-integrations/slack-mcp/how-to-register-your-own-slack-mcp-oauth-app
+
 smartlead-ai:
     display_name: Smartlead.ai
     categories:

--- a/packages/webapp/public/images/template-logos/slack-mcp.svg
+++ b/packages/webapp/public/images/template-logos/slack-mcp.svg
@@ -1,0 +1,1 @@
+slack.svg


### PR DESCRIPTION
<!-- Describe the problem and your solution --> 

<!-- Issue ticket number and link (if applicable) -->

<!-- Testing instructions (skip if just adding/editing providers) -->


<!-- Summary by @propel-code-bot -->

---

**Add Slack MCP integration configuration and documentation**

This PR adds a new Slack MCP integration by defining a `slack-mcp` provider entry in `packages/providers/providers.yaml` with MCP OAuth2 settings, proxy base URL, and docs/setup guide links. It also introduces new documentation pages and snippets for Slack MCP, adds the integration to `docs/docs.json` navigation, and includes a logo asset for the template list.

---
*This summary was automatically generated by @propel-code-bot*