### PR TITLE
fix(query): `deleteOutdatedRecords` transaction handling

### DIFF
--- a/packages/records/lib/models/records.ts
+++ b/packages/records/lib/models/records.ts
@@ -891,7 +891,7 @@ export async function deleteOutdatedRecords({
     connectionId,
     model,
     generation,
-    batchSize = 5000
+    batchSize = 1000
 }: {
     environmentId: number;
     connectionId: number;
@@ -906,67 +906,89 @@ export async function deleteOutdatedRecords({
     });
     let partition: string | undefined = undefined;
     try {
-        const now = db.fn.now(6);
-        return await db.transaction(async (trx) => {
-            const deletedIds: string[] = [];
-            let hasMore = true;
-            while (hasMore) {
-                const res: { external_id: string; size_bytes: number; partition: string }[] = await trx
-                    .from<FormattedRecord>(RECORDS_TABLE)
-                    .whereIn('id', function (sub) {
-                        sub.select('id')
-                            .from(RECORDS_TABLE)
+        const deletedIds: string[] = [];
+        let hasMore = true;
+        while (hasMore) {
+            const batchResult = await retry(
+                () => {
+                    return db.transaction(async (trx) => {
+                        const now = trx.fn.now(6);
+                        // Lock to prevent concurrent modifications with upserts and deletes
+                        await trx.raw(`SELECT pg_advisory_xact_lock(?) as lock_records_outdated`, [newLockId(connectionId, model)]);
+
+                        const res: { external_id: string; size_bytes: number; partition: string }[] = await trx
+                            .from<FormattedRecord>(RECORDS_TABLE)
+                            .whereIn('id', function (sub) {
+                                sub.select('id')
+                                    .from(RECORDS_TABLE)
+                                    .where({
+                                        connection_id: connectionId,
+                                        model,
+                                        deleted_at: null
+                                        // NOTE: not emptying the record payload so we don't introduce a breaking change
+                                    })
+                                    .where('sync_job_id', '<', generation)
+                                    .limit(batchSize);
+                            })
+                            .update({
+                                deleted_at: now,
+                                updated_at: now,
+                                sync_job_id: generation
+                            })
+                            // records table is partitioned by connection_id and model
+                            // to avoid table scan, we must always filter by connection_id and model
                             .where({
                                 connection_id: connectionId,
-                                model,
-                                deleted_at: null
-                                // NOTE: not emptying the record payload so we don't introduce a breaking change
+                                model
                             })
-                            .where('sync_job_id', '<', generation)
-                            .limit(batchSize);
-                    })
-                    .update({
-                        deleted_at: now,
-                        updated_at: now,
-                        sync_job_id: generation
-                    })
-                    // records table is partitioned by connection_id and model
-                    // to avoid table scan, we must always filter by connection_id and model
-                    .where({
-                        connection_id: connectionId,
-                        model
-                    })
-                    .returning(['external_id', trx.raw('pg_column_size(json) as size_bytes'), trx.raw('tableoid::regclass as partition')]);
+                            .returning(['external_id', trx.raw('pg_column_size(json) as size_bytes'), trx.raw('tableoid::regclass as partition')]);
 
-                if (res.length < batchSize) {
-                    hasMore = false;
-                }
+                        // update records count and size
+                        const deleted = res.length;
+                        const sizeInBytes = res.reduce((acc, r) => acc + r.size_bytes, 0);
+                        if (deleted > 0) {
+                            await incrCount(trx, {
+                                connectionId,
+                                environmentId,
+                                model,
+                                delta: -deleted,
+                                deltaSizeInBytes: -sizeInBytes
+                            });
+                        }
 
-                if (!partition && res[0]?.partition) {
-                    partition = res[0].partition;
-                }
-
-                deletedIds.push(...res.map((r) => r.external_id));
-
-                // update records count and size
-                const deleted = res.length;
-                const sizeInBytes = res.reduce((acc, r) => acc + r.size_bytes, 0);
-                if (deleted > 0) {
-                    await incrCount(trx, {
-                        connectionId,
-                        environmentId,
-                        model,
-                        delta: -deleted,
-                        deltaSizeInBytes: -sizeInBytes
+                        return res;
                     });
+                },
+                // Retry if deadlock detected
+                // https://www.postgresql.org/docs/current/mvcc-serialization-failure-handling.html
+                {
+                    maxAttempts: 3,
+                    delayMs: 500,
+                    retryOnError: (err) => {
+                        if ('code' in err) {
+                            const errorCode = (err as { code: string }).code;
+                            return errorCode === '40P01'; // deadlock_detected
+                        }
+                        return false;
+                    }
                 }
+            );
+
+            if (batchResult.length < batchSize) {
+                hasMore = false;
             }
 
-            if (partition) {
-                span.setTag('nango.partition', partition);
+            if (!partition && batchResult[0]?.partition) {
+                partition = batchResult[0].partition;
             }
-            return Ok(deletedIds);
-        });
+
+            deletedIds.push(...batchResult.map((r) => r.external_id));
+        }
+
+        if (partition) {
+            span.setTag('nango.partition', partition);
+        }
+        return Ok(deletedIds);
     } catch (err) {
         const e = new Error(`Failed to mark previous generation records as deleted for connection ${connectionId}, model ${model}, generation ${generation}`, {
             cause: err

--- a/packages/records/lib/models/records.ts
+++ b/packages/records/lib/models/records.ts
@@ -905,8 +905,8 @@ export async function deleteOutdatedRecords({
         tags: { 'nango.connectionId': connectionId, 'nango.model': model }
     });
     let partition: string | undefined = undefined;
+    const deletedIds: string[] = [];
     try {
-        const deletedIds: string[] = [];
         let hasMore = true;
         while (hasMore) {
             const batchResult = await retry(
@@ -925,7 +925,6 @@ export async function deleteOutdatedRecords({
                                         connection_id: connectionId,
                                         model,
                                         deleted_at: null
-                                        // NOTE: not emptying the record payload so we don't introduce a breaking change
                                     })
                                     .where('sync_job_id', '<', generation)
                                     .limit(batchSize);
@@ -994,6 +993,10 @@ export async function deleteOutdatedRecords({
             cause: err
         });
         span.setTag('error', err);
+        if (deletedIds.length > 0) {
+            logger.error(`${e.message}. Partial progress: ${deletedIds.length} records deleted before failure.`);
+            return Ok(deletedIds);
+        }
         return Err(e);
     } finally {
         span.finish();

--- a/packages/records/lib/models/records.ts
+++ b/packages/records/lib/models/records.ts
@@ -905,8 +905,8 @@ export async function deleteOutdatedRecords({
         tags: { 'nango.connectionId': connectionId, 'nango.model': model }
     });
     let partition: string | undefined = undefined;
-    const deletedIds: string[] = [];
     try {
+        const deletedIds: string[] = [];
         let hasMore = true;
         while (hasMore) {
             const batchResult = await retry(
@@ -964,7 +964,7 @@ export async function deleteOutdatedRecords({
                     maxAttempts: 3,
                     delayMs: 500,
                     retryOnError: (err) => {
-                        if ('code' in err) {
+                        if (err !== null && typeof err === 'object' && 'code' in err) {
                             const errorCode = (err as { code: string }).code;
                             return errorCode === '40P01'; // deadlock_detected
                         }
@@ -992,11 +992,7 @@ export async function deleteOutdatedRecords({
         const e = new Error(`Failed to mark previous generation records as deleted for connection ${connectionId}, model ${model}, generation ${generation}`, {
             cause: err
         });
-        span.setTag('error', err);
-        if (deletedIds.length > 0) {
-            logger.error(`${e.message}. Partial progress: ${deletedIds.length} records deleted before failure.`);
-            return Ok(deletedIds);
-        }
+        span.setTag('error', e);
         return Err(e);
     } finally {
         span.finish();

--- a/packages/records/lib/models/records.ts
+++ b/packages/records/lib/models/records.ts
@@ -908,6 +908,12 @@ export async function deleteOutdatedRecords({
     try {
         const deletedIds: string[] = [];
         let hasMore = true;
+        // NOTE: deletion is intentionally not atomic. Each batch is its own transaction so that
+        // long-running deletes (e.g. millions of records) don't hold a single DB connection and
+        // row locks for the entire duration, which was causing timeouts and stalling other queries.
+        // The tradeoff is that a failure mid-way leaves the dataset in a partially deleted state.
+        // This is acceptable because: (1) the sync fails and the user is notified, (2) the next
+        // sync run will call deleteOutdatedRecords again and clean up whatever was missed.
         while (hasMore) {
             const batchResult = await retry(
                 () => {


### PR DESCRIPTION
## Fix `deleteOutdatedRecords` transaction handling

Fixes NAN-5045

### Problem

We've been seeing a major increase in persist errors ("Failed to save record" / "Failed to delete record") rooted in DB timeouts, with spikes correlating to high DB stress (CPU >85%, block read times 10-20min, IO:DataFileRead wait events).

The main culprit identified via Datadog APM is the `DELETE .../outdated` endpoint (`deleteOutdatedRecords`): **57.8k requests, 4.43s p95 latency spiking to 24s, 0.4% error rate**

The issue is structural:

1. **Single transaction wrapping all batches**: for a large customer with 100k outdated records, that's 20 batches of 5000 rows all within one transaction. The DB connection is held for the entire 4-24s duration, and all index updates (4 indexes per row) generate sustained IO/WAL pressure that competes with normal sync operations.
2. **Large batch size (5000)** — amplifies all of the above per batch.

Other things to consider:
1. **No advisory lock**: both `upsert()` and `deleteRecords()` acquire `pg_advisory_xact_lock`, this function did not. As we are just removing old records, Im not sure if this is necessary tbh
2. **No deadlock retry**: copied `upsert()` which retries on PostgreSQL deadlock errors (`40P01`), a deadlock here would fail the entire operation (once again, not critical and not something I've seen happen but it would fail the sync)

### Fix

**`packages/records/lib/models/records.ts` `deleteOutdatedRecords`:**

- Move the transaction inside the batch loop: each batch of records is now its own independent transaction that acquires the lock, updates rows, updates counts, and commits. This releases the DB connection and all locks between batches, allowing other queries to interleave naturally.
- Add `pg_advisory_xact_lock` using the same `newLockId(connectionId, model)` as `upsert()` and `deleteRecords()`, ensuring clean serialization.
- Add deadlock retry (3 attempts, 500ms delay) matching the `upsert()` pattern.
- Reduce default batch size from 5000 to 1000.

<!-- Summary by @propel-code-bot -->

---

This PR updates `deleteOutdatedRecords` to process each batch in its own transaction, reducing long-lived locks and connection usage during large deletions. It also adds per-batch advisory locking and deadlock retry handling while lowering the default batch size.

---
*This summary was automatically generated by @propel-code-bot*