### PR TITLE
feat: add ability to download deployed functions in debug mode

### DIFF
--- a/packages/server/lib/controllers/flow.controller.ts
+++ b/packages/server/lib/controllers/flow.controller.ts
@@ -1,67 +1,9 @@
-import { configService, flowService, getSyncConfigById, getSyncConfigsAsStandardConfig, remoteFileService } from '@nangohq/shared';
+import { configService, flowService, getSyncConfigsAsStandardConfig } from '@nangohq/shared';
 
 import type { RequestLocals } from '../utils/express.js';
-import type { ScriptTypeLiteral } from '@nangohq/types';
 import type { NextFunction, Request, Response } from 'express';
 
-interface FlowDownloadBody {
-    id?: number;
-    name: string;
-    provider: string;
-    is_public: boolean;
-    providerConfigKey: string;
-    flowType: string;
-}
-
 class FlowController {
-    public async downloadFlow(req: Request, res: Response<any, Required<RequestLocals>>, next: NextFunction) {
-        try {
-            const environmentId = res.locals['environment'].id;
-
-            const body: FlowDownloadBody = req.body as FlowDownloadBody;
-
-            if (!body) {
-                res.status(400).send('Missing body');
-                return;
-            }
-
-            const { id, name, provider, is_public, providerConfigKey, flowType } = body;
-
-            if (!name || !provider || typeof is_public === 'undefined') {
-                res.status(400).send('Missing required fields');
-                return;
-            }
-
-            if (!id && is_public) {
-                const flow = flowService.getFlowByIntegrationAndName({ provider, type: flowType as ScriptTypeLiteral, scriptName: name });
-                if (!flow) {
-                    res.status(400).send({ error: { code: 'invalid_query' } });
-                    return;
-                }
-                await remoteFileService.zipAndSendPublicFiles({ res, scriptName: name, providerPath: provider, flowType });
-                return;
-            } else {
-                // it has an id, so it's either a public template that is active, or a private template
-                // either way, we need to fetch it from the users directory in s3
-                const syncConfig = await getSyncConfigById(environmentId, id as number);
-                if (!syncConfig) {
-                    res.status(400).send('Invalid file reference');
-                    return;
-                }
-
-                await remoteFileService.zipAndSendFiles({
-                    res,
-                    scriptName: name,
-                    syncConfig,
-                    providerConfigKey
-                });
-                return;
-            }
-        } catch (err) {
-            next(err);
-        }
-    }
-
     public async getFlow(req: Request, res: Response<any, Required<RequestLocals>>, next: NextFunction) {
         try {
             const environment = res.locals['environment'];

--- a/packages/server/lib/controllers/v1/flow/getDownload.ts
+++ b/packages/server/lib/controllers/v1/flow/getDownload.ts
@@ -5,7 +5,7 @@ import { requireEmptyQuery, zodErrorToHTTP } from '@nangohq/utils';
 
 import { asyncWrapper } from '../../../utils/asyncWrapper.js';
 
-import type { PostFlowDownload } from '@nangohq/types';
+import type { GetFlowDownload } from '@nangohq/types';
 
 export const validationParams = z
     .object({
@@ -13,7 +13,7 @@ export const validationParams = z
     })
     .strict();
 
-export const postFlowDownload = asyncWrapper<PostFlowDownload>(async (req, res) => {
+export const getFlowDownload = asyncWrapper<GetFlowDownload>(async (req, res) => {
     const emptyQuery = requireEmptyQuery(req, { withEnv: true });
     if (emptyQuery) {
         res.status(400).send({ error: { code: 'invalid_query_params', errors: zodErrorToHTTP(emptyQuery.error) } });

--- a/packages/server/lib/controllers/v1/flow/postDownload.ts
+++ b/packages/server/lib/controllers/v1/flow/postDownload.ts
@@ -1,57 +1,47 @@
 import * as z from 'zod';
 
-import { flowService, getSyncConfigById, remoteFileService } from '@nangohq/shared';
+import { configService, getSyncConfigById, remoteFileService } from '@nangohq/shared';
 import { requireEmptyQuery, zodErrorToHTTP } from '@nangohq/utils';
 
-import { providerConfigKeySchema, providerSchema, scriptNameSchema } from '../../../helpers/validation.js';
 import { asyncWrapper } from '../../../utils/asyncWrapper.js';
-import { flowConfig } from '../../sync/deploy/validation.js';
 
 import type { PostFlowDownload } from '@nangohq/types';
 
-const validation = z
+export const validationParams = z
     .object({
-        id: z.number().optional(),
-        name: scriptNameSchema,
-        provider: providerSchema,
-        is_public: z.boolean(),
-        providerConfigKey: providerConfigKeySchema,
-        flowType: flowConfig.shape.type
+        id: z.coerce.number().positive()
     })
     .strict();
 
 export const postFlowDownload = asyncWrapper<PostFlowDownload>(async (req, res) => {
-    const emptyQuery = requireEmptyQuery(req);
+    const emptyQuery = requireEmptyQuery(req, { withEnv: true });
     if (emptyQuery) {
         res.status(400).send({ error: { code: 'invalid_query_params', errors: zodErrorToHTTP(emptyQuery.error) } });
         return;
     }
 
-    const val = validation.safeParse(req.body);
-    if (!val.success) {
-        res.status(400).send({ error: { code: 'invalid_body', errors: zodErrorToHTTP(val.error) } });
+    const valParams = validationParams.safeParse(req.params);
+    if (!valParams.success) {
+        res.status(400).send({
+            error: { code: 'invalid_uri_params', errors: zodErrorToHTTP(valParams.error) }
+        });
         return;
     }
 
-    const body: PostFlowDownload['Body'] = val.data;
     const { environment } = res.locals;
-    const { id, name, provider, is_public, providerConfigKey, flowType } = body;
+    const { id } = valParams.data;
 
-    if (!id && is_public) {
-        const flow = flowService.getFlowByIntegrationAndName({ provider, type: flowType, scriptName: name });
-        if (!flow) {
-            res.status(400).send({ error: { code: 'invalid_query' } });
-            return;
-        }
-        await remoteFileService.zipAndSendPublicFiles({ res, scriptName: name, providerPath: provider, flowType });
-        return;
-    }
-
-    const syncConfig = await getSyncConfigById(environment.id, id as number);
+    const syncConfig = await getSyncConfigById(environment.id, id);
     if (!syncConfig) {
-        res.status(400).send({ error: { code: 'invalid_file_reference' } });
+        res.status(400).send({ error: { code: 'not_found' } });
         return;
     }
 
-    await remoteFileService.zipAndSendFiles({ res, scriptName: name, syncConfig, providerConfigKey });
+    const providerConfigKey = await configService.getProviderConfigKeyById(environment.id, syncConfig.nango_config_id);
+    if (!providerConfigKey) {
+        res.status(400).send({ error: { code: 'not_found' } });
+        return;
+    }
+
+    await remoteFileService.zipAndSendFlow({ res, syncConfig, providerConfigKey });
 });

--- a/packages/server/lib/controllers/v1/flow/postDownload.ts
+++ b/packages/server/lib/controllers/v1/flow/postDownload.ts
@@ -1,0 +1,57 @@
+import * as z from 'zod';
+
+import { flowService, getSyncConfigById, remoteFileService } from '@nangohq/shared';
+import { requireEmptyQuery, zodErrorToHTTP } from '@nangohq/utils';
+
+import { providerConfigKeySchema, providerSchema, scriptNameSchema } from '../../../helpers/validation.js';
+import { asyncWrapper } from '../../../utils/asyncWrapper.js';
+import { flowConfig } from '../../sync/deploy/validation.js';
+
+import type { PostFlowDownload } from '@nangohq/types';
+
+const validation = z
+    .object({
+        id: z.number().optional(),
+        name: scriptNameSchema,
+        provider: providerSchema,
+        is_public: z.boolean(),
+        providerConfigKey: providerConfigKeySchema,
+        flowType: flowConfig.shape.type
+    })
+    .strict();
+
+export const postFlowDownload = asyncWrapper<PostFlowDownload>(async (req, res) => {
+    const emptyQuery = requireEmptyQuery(req);
+    if (emptyQuery) {
+        res.status(400).send({ error: { code: 'invalid_query_params', errors: zodErrorToHTTP(emptyQuery.error) } });
+        return;
+    }
+
+    const val = validation.safeParse(req.body);
+    if (!val.success) {
+        res.status(400).send({ error: { code: 'invalid_body', errors: zodErrorToHTTP(val.error) } });
+        return;
+    }
+
+    const body: PostFlowDownload['Body'] = val.data;
+    const { environment } = res.locals;
+    const { id, name, provider, is_public, providerConfigKey, flowType } = body;
+
+    if (!id && is_public) {
+        const flow = flowService.getFlowByIntegrationAndName({ provider, type: flowType, scriptName: name });
+        if (!flow) {
+            res.status(400).send({ error: { code: 'invalid_query' } });
+            return;
+        }
+        await remoteFileService.zipAndSendPublicFiles({ res, scriptName: name, providerPath: provider, flowType });
+        return;
+    }
+
+    const syncConfig = await getSyncConfigById(environment.id, id as number);
+    if (!syncConfig) {
+        res.status(400).send({ error: { code: 'invalid_file_reference' } });
+        return;
+    }
+
+    await remoteFileService.zipAndSendFiles({ res, scriptName: name, syncConfig, providerConfigKey });
+});

--- a/packages/server/lib/controllers/v1/flow/postDownload.ts
+++ b/packages/server/lib/controllers/v1/flow/postDownload.ts
@@ -29,15 +29,21 @@ export const postFlowDownload = asyncWrapper<PostFlowDownload>(async (req, res) 
     }
 
     const { environment } = res.locals;
-    const { id } = valParams.data;
+    const { id: syncConfigId } = valParams.data;
 
-    const syncConfig = await getSyncConfigById(environment.id, id);
+    const syncConfig = await getSyncConfigById(environment.id, syncConfigId);
     if (!syncConfig) {
         res.status(400).send({ error: { code: 'not_found' } });
         return;
     }
 
-    const providerConfigKey = await configService.getProviderConfigKeyById(environment.id, syncConfig.nango_config_id);
+    const providerConfigKeyResult = await configService.getProviderConfigKeyById(environment.id, syncConfig.nango_config_id);
+    if (providerConfigKeyResult.isErr()) {
+        res.status(500).send({ error: { code: 'failed_to_download_flow' } });
+        return;
+    }
+
+    const providerConfigKey = providerConfigKeyResult.value;
     if (!providerConfigKey) {
         res.status(400).send({ error: { code: 'not_found' } });
         return;

--- a/packages/server/lib/routes.private.ts
+++ b/packages/server/lib/routes.private.ts
@@ -248,10 +248,10 @@ web.route('/sync/command').post(
 );
 web.route('/flows/pre-built/deploy').post(webAuth, can({ action: 'update', resource: 'flow', scopedBy: envScope }), postPreBuiltDeploy);
 web.route('/flows/pre-built/upgrade').put(webAuth, can({ action: 'update', resource: 'flow', scopedBy: envScope }), putUpgradePreBuilt);
-web.route('/flow/download').post(webAuth, flowController.downloadFlow.bind(flowController));
 web.route('/flows/:id/disable').patch(webAuth, can({ action: 'update', resource: 'flow', scopedBy: envScope }), patchFlowDisable);
 web.route('/flows/:id/enable').patch(webAuth, can({ action: 'update', resource: 'flow', scopedBy: envScope }), patchFlowEnable);
 web.route('/flows/:id/frequency').patch(webAuth, can({ action: 'update', resource: 'flow', scopedBy: envScope }), patchFlowFrequency);
+web.route('/flows/:id/download').post(webAuth, postFlowDownload);
 web.route('/flow/:flowName').get(webAuth, flowController.getFlow.bind(syncController));
 
 // Getting Started

--- a/packages/server/lib/routes.private.ts
+++ b/packages/server/lib/routes.private.ts
@@ -45,6 +45,7 @@ import { patchEnvironment } from './controllers/v1/environment/patchEnvironment.
 import { postEnvironment } from './controllers/v1/environment/postEnvironment.js';
 import { postEnvironmentVariables } from './controllers/v1/environment/variables/postVariables.js';
 import { patchWebhook } from './controllers/v1/environment/webhook/patchWebhook.js';
+import { postFlowDownload } from './controllers/v1/flow/postDownload.js';
 import { patchFlowDisable } from './controllers/v1/flows/id/patchDisable.js';
 import { patchFlowEnable } from './controllers/v1/flows/id/patchEnable.js';
 import { patchFlowFrequency } from './controllers/v1/flows/id/patchFrequency.js';

--- a/packages/server/lib/routes.private.ts
+++ b/packages/server/lib/routes.private.ts
@@ -251,7 +251,7 @@ web.route('/flows/pre-built/upgrade').put(webAuth, can({ action: 'update', resou
 web.route('/flows/:id/disable').patch(webAuth, can({ action: 'update', resource: 'flow', scopedBy: envScope }), patchFlowDisable);
 web.route('/flows/:id/enable').patch(webAuth, can({ action: 'update', resource: 'flow', scopedBy: envScope }), patchFlowEnable);
 web.route('/flows/:id/frequency').patch(webAuth, can({ action: 'update', resource: 'flow', scopedBy: envScope }), patchFlowFrequency);
-web.route('/flows/:id/download').get(webAuth, getFlowDownload);
+web.route('/flows/:id/download').get(webAuth, can({ action: 'read', resource: 'flow', scopedBy: envScope }), getFlowDownload);
 web.route('/flow/:flowName').get(webAuth, flowController.getFlow.bind(syncController));
 
 // Getting Started

--- a/packages/server/lib/routes.private.ts
+++ b/packages/server/lib/routes.private.ts
@@ -45,7 +45,7 @@ import { patchEnvironment } from './controllers/v1/environment/patchEnvironment.
 import { postEnvironment } from './controllers/v1/environment/postEnvironment.js';
 import { postEnvironmentVariables } from './controllers/v1/environment/variables/postVariables.js';
 import { patchWebhook } from './controllers/v1/environment/webhook/patchWebhook.js';
-import { postFlowDownload } from './controllers/v1/flow/postDownload.js';
+import { getFlowDownload } from './controllers/v1/flow/getDownload.js';
 import { patchFlowDisable } from './controllers/v1/flows/id/patchDisable.js';
 import { patchFlowEnable } from './controllers/v1/flows/id/patchEnable.js';
 import { patchFlowFrequency } from './controllers/v1/flows/id/patchFrequency.js';
@@ -251,7 +251,7 @@ web.route('/flows/pre-built/upgrade').put(webAuth, can({ action: 'update', resou
 web.route('/flows/:id/disable').patch(webAuth, can({ action: 'update', resource: 'flow', scopedBy: envScope }), patchFlowDisable);
 web.route('/flows/:id/enable').patch(webAuth, can({ action: 'update', resource: 'flow', scopedBy: envScope }), patchFlowEnable);
 web.route('/flows/:id/frequency').patch(webAuth, can({ action: 'update', resource: 'flow', scopedBy: envScope }), patchFlowFrequency);
-web.route('/flows/:id/download').post(webAuth, postFlowDownload);
+web.route('/flows/:id/download').get(webAuth, getFlowDownload);
 web.route('/flow/:flowName').get(webAuth, flowController.getFlow.bind(syncController));
 
 // Getting Started

--- a/packages/shared/lib/services/config.service.ts
+++ b/packages/shared/lib/services/config.service.ts
@@ -1,5 +1,5 @@
 import db from '@nangohq/database';
-import { isCloud, nanoid } from '@nangohq/utils';
+import { Err, Ok, isCloud, nanoid } from '@nangohq/utils';
 
 import { getProvider } from './providers.js';
 import { gettingStartedService } from '../index.js';
@@ -11,7 +11,16 @@ import { NangoError } from '../utils/error.js';
 import type { Orchestrator } from '../clients/orchestrator.js';
 import type { Config as ProviderConfig } from '../models/Provider.js';
 import type { Knex } from '@nangohq/database';
-import type { AuthModeType, DBConnection, DBCreateIntegration, DBIntegrationCrypted, IntegrationConfig, Provider, SharedCredentials } from '@nangohq/types';
+import type {
+    AuthModeType,
+    DBConnection,
+    DBCreateIntegration,
+    DBIntegrationCrypted,
+    IntegrationConfig,
+    Provider,
+    Result,
+    SharedCredentials
+} from '@nangohq/types';
 
 interface ValidationRule {
     field: keyof ProviderConfig | 'app_id' | 'private_key';
@@ -34,14 +43,18 @@ class ConfigService {
         return result.id;
     }
 
-    async getProviderConfigKeyById(environment_id: number, id: number): Promise<string | null> {
-        const result = await db.knex.select('unique_key').from<ProviderConfig>(`_nango_configs`).where({ id, environment_id, deleted: false }).first();
+    async getProviderConfigKeyById(environment_id: number, id: number): Promise<Result<string | null>> {
+        try {
+            const result = await db.knex.select('unique_key').from<ProviderConfig>(`_nango_configs`).where({ id, environment_id, deleted: false }).first();
 
-        if (!result) {
-            return null;
+            if (!result) {
+                return Ok(null);
+            }
+
+            return Ok(result.unique_key);
+        } catch (err) {
+            return Err(new Error('failed_to_get_provider_config', { cause: err }));
         }
-
-        return result.unique_key;
     }
 
     async getProviderConfig(providerConfigKey: string, environment_id: number, trx = db.readOnly): Promise<ProviderConfig | null> {

--- a/packages/shared/lib/services/config.service.ts
+++ b/packages/shared/lib/services/config.service.ts
@@ -3,10 +3,10 @@ import { isCloud, nanoid } from '@nangohq/utils';
 
 import { getProvider } from './providers.js';
 import { gettingStartedService } from '../index.js';
-import encryptionManager from '../utils/encryption.manager.js';
-import { NangoError } from '../utils/error.js';
 import syncManager from './sync/manager.service.js';
 import { deleteByConfigId as deleteSyncConfigByConfigId, deleteSyncFilesForConfig } from '../services/sync/config/config.service.js';
+import encryptionManager from '../utils/encryption.manager.js';
+import { NangoError } from '../utils/error.js';
 
 import type { Orchestrator } from '../clients/orchestrator.js';
 import type { Config as ProviderConfig } from '../models/Provider.js';
@@ -32,6 +32,16 @@ class ConfigService {
         }
 
         return result.id;
+    }
+
+    async getProviderConfigKeyById(environment_id: number, id: number): Promise<string | null> {
+        const result = await db.knex.select('unique_key').from<ProviderConfig>(`_nango_configs`).where({ id, environment_id, deleted: false }).first();
+
+        if (!result) {
+            return null;
+        }
+
+        return result.unique_key;
     }
 
     async getProviderConfig(providerConfigKey: string, environment_id: number, trx = db.readOnly): Promise<ProviderConfig | null> {

--- a/packages/shared/lib/services/file/local.service.ts
+++ b/packages/shared/lib/services/file/local.service.ts
@@ -116,6 +116,13 @@ class LocalFileService {
 
         const scriptName = syncConfig.sync_name;
 
+        const jsFilePath = this.resolveIntegrationFile({ scriptType: 'sync', syncConfig, providerConfigKey });
+        if (!jsFilePath) {
+            errorManager.errResFromNangoErr(res, new NangoError('integration_file_not_found'));
+            return;
+        }
+        files.push(jsFilePath);
+
         const tsFilePath = this.resolveTsFile({ scriptName, providerConfigKey, syncConfig });
         if (!tsFilePath) {
             errorManager.errResFromNangoErr(res, new NangoError('integration_file_not_found'));

--- a/packages/shared/lib/services/file/local.service.ts
+++ b/packages/shared/lib/services/file/local.service.ts
@@ -102,17 +102,7 @@ class LocalFileService {
      * @desc grab the files locally from the integrations path, zip and send
      * the archive
      */
-    public async zipAndSendFiles({
-        res,
-        scriptName,
-        providerConfigKey,
-        syncConfig
-    }: {
-        res: Response;
-        scriptName: string;
-        providerConfigKey: string;
-        syncConfig: DBSyncConfig;
-    }) {
+    public async zipAndSendFlow({ res, syncConfig, providerConfigKey }: { res: Response; syncConfig: DBSyncConfig; providerConfigKey: string }) {
         const files: string[] = [];
         if (!syncConfig.sdk_version?.includes('-zero')) {
             const yamlPath = path.resolve(basePath, nangoConfigFile);
@@ -123,6 +113,8 @@ class LocalFileService {
             }
             files.push(yamlPath);
         }
+
+        const scriptName = syncConfig.sync_name;
 
         const tsFilePath = this.resolveTsFile({ scriptName, providerConfigKey, syncConfig });
         if (!tsFilePath) {

--- a/packages/shared/lib/services/file/remote.service.ts
+++ b/packages/shared/lib/services/file/remote.service.ts
@@ -254,8 +254,16 @@ class RemoteFileService {
 
             const scriptName = syncConfig.sync_name;
 
-            const integrationFileLocation = syncConfig.file_location.split('/').slice(0, -1).join('/');
-            const { success: tsSuccess, error: tsError, response: tsFile } = await this.getStream(`${integrationFileLocation}/${scriptName}.ts`);
+            const jsFileLocation = syncConfig.file_location;
+            const { success: jsSuccess, error: jsError, response: jsFile } = await this.getStream(jsFileLocation);
+            if (!jsSuccess || jsFile === null) {
+                errorManager.errResFromNangoErr(res, jsError);
+                return;
+            }
+            files.push({ name: `${scriptName}.js`, content: jsFile });
+
+            const tsFileLocation = syncConfig.file_location.split('/').slice(0, -1).join('/');
+            const { success: tsSuccess, error: tsError, response: tsFile } = await this.getStream(`${tsFileLocation}/${scriptName}.ts`);
             if (!tsSuccess || tsFile === null) {
                 errorManager.errResFromNangoErr(res, tsError);
                 return;

--- a/packages/shared/lib/services/file/remote.service.ts
+++ b/packages/shared/lib/services/file/remote.service.ts
@@ -237,19 +237,9 @@ class RemoteFileService {
         await this.zipAndSend({ res, files });
     }
 
-    async zipAndSendFiles({
-        res,
-        scriptName,
-        providerConfigKey,
-        syncConfig
-    }: {
-        res: Response;
-        scriptName: string;
-        providerConfigKey: string;
-        syncConfig: DBSyncConfig;
-    }): Promise<void> {
+    async zipAndSendFlow({ res, syncConfig, providerConfigKey }: { res: Response; syncConfig: DBSyncConfig; providerConfigKey: string }): Promise<void> {
         if (!isCloud && !this.useS3) {
-            return localFileService.zipAndSendFiles({ res, scriptName, providerConfigKey, syncConfig });
+            return localFileService.zipAndSendFlow({ res, syncConfig, providerConfigKey });
         } else {
             const files: { name: string; content: Readable }[] = [];
             if (!syncConfig.sdk_version?.includes('-zero')) {
@@ -261,6 +251,8 @@ class RemoteFileService {
                 }
                 files.push({ name: 'nango.yaml', content: resGet.response });
             }
+
+            const scriptName = syncConfig.sync_name;
 
             const integrationFileLocation = syncConfig.file_location.split('/').slice(0, -1).join('/');
             const { success: tsSuccess, error: tsError, response: tsFile } = await this.getStream(`${integrationFileLocation}/${scriptName}.ts`);

--- a/packages/types/lib/flow/http.api.ts
+++ b/packages/types/lib/flow/http.api.ts
@@ -96,8 +96,8 @@ export type PatchFlowFrequency = Endpoint<{
     };
 }>;
 
-export type PostFlowDownload = Endpoint<{
-    Method: 'POST';
+export type GetFlowDownload = Endpoint<{
+    Method: 'GET';
     Path: '/api/v1/flows/:id/download';
     Querystring: { env: string };
     Params: { id: number };

--- a/packages/types/lib/flow/http.api.ts
+++ b/packages/types/lib/flow/http.api.ts
@@ -95,3 +95,18 @@ export type PatchFlowFrequency = Endpoint<{
         };
     };
 }>;
+
+export type PostFlowDownload = Endpoint<{
+    Method: 'POST';
+    Path: '/flow/download';
+    Body: {
+        id?: number | undefined;
+        name: string;
+        provider: string;
+        is_public: boolean;
+        providerConfigKey: string;
+        flowType: ScriptTypeLiteral;
+    };
+    Error: ApiError<'invalid_query'> | ApiError<'invalid_file_reference'>;
+    Success: never;
+}>;

--- a/packages/types/lib/flow/http.api.ts
+++ b/packages/types/lib/flow/http.api.ts
@@ -102,4 +102,5 @@ export type PostFlowDownload = Endpoint<{
     Querystring: { env: string };
     Params: { id: number };
     Success: never;
+    Error: ApiError<'failed_to_download_flow'>;
 }>;

--- a/packages/types/lib/flow/http.api.ts
+++ b/packages/types/lib/flow/http.api.ts
@@ -98,15 +98,8 @@ export type PatchFlowFrequency = Endpoint<{
 
 export type PostFlowDownload = Endpoint<{
     Method: 'POST';
-    Path: '/flow/download';
-    Body: {
-        id?: number | undefined;
-        name: string;
-        provider: string;
-        is_public: boolean;
-        providerConfigKey: string;
-        flowType: ScriptTypeLiteral;
-    };
-    Error: ApiError<'invalid_query'> | ApiError<'invalid_file_reference'>;
+    Path: '/api/v1/flows/:id/download';
+    Querystring: { env: string };
+    Params: { id: number };
     Success: never;
 }>;

--- a/packages/webapp/src/hooks/useFlow.tsx
+++ b/packages/webapp/src/hooks/useFlow.tsx
@@ -2,7 +2,7 @@ import { useMutation, useQueryClient } from '@tanstack/react-query';
 
 import { APIError, apiFetch } from '../utils/api';
 
-import type { PatchFlowDisable, PatchFlowEnable, PatchFlowFrequency, PostPreBuiltDeploy, PutUpgradePreBuiltFlow } from '@nangohq/types';
+import type { PatchFlowDisable, PatchFlowEnable, PatchFlowFrequency, PostFlowDownload, PostPreBuiltDeploy, PutUpgradePreBuiltFlow } from '@nangohq/types';
 
 export function usePreBuiltDeployFlow(env: string, integrationId: string) {
     const queryClient = useQueryClient();
@@ -86,4 +86,23 @@ export async function apiFlowUpdateFrequency(env: string, params: PatchFlowFrequ
         res,
         json: (await res.json()) as PatchFlowFrequency['Reply']
     };
+}
+
+export async function apiFlowDownload(env: string, params: PostFlowDownload['Params'], flowName = 'flow') {
+    const res = await apiFetch(`/api/v1/flows/${params.id}/download?env=${env}`, {
+        method: 'POST'
+    });
+    if (!res.ok) {
+        const json = (await res.json()) as PostFlowDownload['Errors'];
+        throw new APIError({ res, json });
+    }
+    const blob = await res.blob();
+    const url = URL.createObjectURL(blob);
+    const a = document.createElement('a');
+    a.href = url;
+    a.download = `${flowName}.zip`;
+    document.body.appendChild(a);
+    a.click();
+    document.body.removeChild(a);
+    URL.revokeObjectURL(url);
 }

--- a/packages/webapp/src/hooks/useFlow.tsx
+++ b/packages/webapp/src/hooks/useFlow.tsx
@@ -2,7 +2,7 @@ import { useMutation, useQueryClient } from '@tanstack/react-query';
 
 import { APIError, apiFetch } from '../utils/api';
 
-import type { PatchFlowDisable, PatchFlowEnable, PatchFlowFrequency, PostFlowDownload, PostPreBuiltDeploy, PutUpgradePreBuiltFlow } from '@nangohq/types';
+import type { GetFlowDownload, PatchFlowDisable, PatchFlowEnable, PatchFlowFrequency, PostPreBuiltDeploy, PutUpgradePreBuiltFlow } from '@nangohq/types';
 
 export function usePreBuiltDeployFlow(env: string, integrationId: string) {
     const queryClient = useQueryClient();
@@ -88,12 +88,12 @@ export async function apiFlowUpdateFrequency(env: string, params: PatchFlowFrequ
     };
 }
 
-export async function apiFlowDownload(env: string, params: PostFlowDownload['Params'], flowName = 'flow') {
+export async function apiFlowDownload(env: string, params: GetFlowDownload['Params'], flowName = 'flow') {
     const res = await apiFetch(`/api/v1/flows/${params.id}/download?env=${env}`, {
-        method: 'POST'
+        method: 'GET'
     });
     if (!res.ok) {
-        const json = (await res.json()) as PostFlowDownload['Errors'];
+        const json = (await res.json()) as GetFlowDownload['Errors'];
         throw new APIError({ res, json });
     }
     const blob = await res.blob();

--- a/packages/webapp/src/pages/Integrations/providerConfigKey/Functions/One.tsx
+++ b/packages/webapp/src/pages/Integrations/providerConfigKey/Functions/One.tsx
@@ -22,14 +22,17 @@ import { INTEGRATION_TEMPLATES_GITHUB_URL } from '@/constants';
 import { apiFlowDownload } from '@/hooks/useFlow';
 import { useHashNavigation } from '@/hooks/useHashNavigation';
 import { useGetIntegration, useGetIntegrationFlows } from '@/hooks/useIntegration';
+import { useToast } from '@/hooks/useToast';
 import DashboardLayout from '@/layout/DashboardLayout';
 import PageNotFound from '@/pages/PageNotFound';
 import { useStore } from '@/store';
+import { APIError } from '@/utils/api';
 
 import type { JSONSchema7 } from 'json-schema';
 
 export const FunctionsOne: React.FC = () => {
     const { providerConfigKey, functionName } = useParams();
+    const { toast } = useToast();
 
     const env = useStore((state) => state.env);
     const debugMode = useStore((state) => state.debugMode);
@@ -79,8 +82,21 @@ export const FunctionsOne: React.FC = () => {
         if (!func || !func.enabled || !func.id) {
             return;
         }
-        await apiFlowDownload(env, { id: func.id }, func.name);
-    }, [func, env]);
+        try {
+            await apiFlowDownload(env, { id: func.id }, func.name);
+            toast({
+                title: 'Downloading function code',
+                variant: 'success'
+            });
+        } catch (err) {
+            const errorCode = err instanceof APIError ? err.json?.error?.code : undefined;
+            toast({
+                title: 'Failed to download function code',
+                description: errorCode ? `Error code: ${errorCode}` : undefined,
+                variant: 'error'
+            });
+        }
+    }, [func, env, toast]);
 
     if (isLoading) {
         return (

--- a/packages/webapp/src/pages/Integrations/providerConfigKey/Functions/One.tsx
+++ b/packages/webapp/src/pages/Integrations/providerConfigKey/Functions/One.tsx
@@ -1,5 +1,5 @@
-import { ExternalLink, Info } from 'lucide-react';
-import { useMemo } from 'react';
+import { Download, ExternalLink, Info } from 'lucide-react';
+import { useCallback, useMemo } from 'react';
 import { Helmet } from 'react-helmet';
 import { Link, useParams } from 'react-router-dom';
 
@@ -16,9 +16,10 @@ import { Navigation, NavigationContent, NavigationList, NavigationTrigger } from
 import { StyledLink } from '@/components-v2/StyledLink';
 import { Tabs, TabsContent, TabsList, TabsTrigger } from '@/components-v2/Tabs';
 import { Alert, AlertDescription } from '@/components-v2/ui/alert';
-import { ButtonLink } from '@/components-v2/ui/button';
+import { Button, ButtonLink } from '@/components-v2/ui/button';
 import { Skeleton } from '@/components-v2/ui/skeleton';
 import { INTEGRATION_TEMPLATES_GITHUB_URL } from '@/constants';
+import { apiFlowDownload } from '@/hooks/useFlow';
 import { useHashNavigation } from '@/hooks/useHashNavigation';
 import { useGetIntegration, useGetIntegrationFlows } from '@/hooks/useIntegration';
 import DashboardLayout from '@/layout/DashboardLayout';
@@ -31,6 +32,7 @@ export const FunctionsOne: React.FC = () => {
     const { providerConfigKey, functionName } = useParams();
 
     const env = useStore((state) => state.env);
+    const debugMode = useStore((state) => state.debugMode);
     const { data: integrationResponse, isLoading: integrationLoading } = useGetIntegration(env, providerConfigKey!);
     const integrationData = integrationResponse?.data;
     const { data: flowsResponse, isLoading: flowsLoading } = useGetIntegrationFlows(env, providerConfigKey!);
@@ -72,6 +74,13 @@ export const FunctionsOne: React.FC = () => {
     const [activeTab, setActiveTab] = useHashNavigation(outputSchemas && outputSchemas.length > 0 && !inputSchema ? 'output' : 'input');
 
     const isLoading = integrationLoading || flowsLoading;
+
+    const downloadCode = useCallback(async () => {
+        if (!func || !func.enabled || !func.id) {
+            return;
+        }
+        await apiFlowDownload(env, { id: func.id }, func.name);
+    }, [func, env]);
 
     if (isLoading) {
         return (
@@ -127,7 +136,14 @@ export const FunctionsOne: React.FC = () => {
                                 <CopyButton text={func.name} />
                             </div>
                         </div>
-                        <FunctionSwitch flow={func} integration={integrationData.integration} />
+                        <div className="inline-flex items-center gap-2">
+                            {func.enabled && debugMode && (
+                                <Button onClick={downloadCode} variant="ghost" size="icon">
+                                    <Download />
+                                </Button>
+                            )}
+                            <FunctionSwitch flow={func} integration={integrationData.integration} />
+                        </div>
                     </div>
 
                     <span className="text-text-secondary text-body-medium-medium">{func.description}</span>


### PR DESCRIPTION
- Migrates old download endpoint to new format.
- Changes route and simplifies parameters.
- It only works for deployed functions
- Conditionally render download icon besides toggle switch when in debug mode (when impersonating, and function is deployed).
- It downloads the typescript file, not the bundled js.

<img width="1091" height="366" alt="image" src="https://github.com/user-attachments/assets/cbadca56-847f-42e7-9389-2caf5224d047" />

<!-- Summary by @propel-code-bot -->

---

It introduces a new v1 GET handler that validates parameters and resolves the provider config key before zipping artifacts, and adds a download button with client-side helper and basic toast feedback.

---
*This summary was automatically generated by @propel-code-bot*