### PR TITLE
feat(permissions): NAN-2184 implements team/invite role managment

### DIFF
--- a/packages/server/lib/authz/authz.integration.test.ts
+++ b/packages/server/lib/authz/authz.integration.test.ts
@@ -171,6 +171,67 @@ describe('authz integration', () => {
             expect(res.res.status).toBe(403);
         });
 
+        it('should deny DELETE invite', async () => {
+            const { account } = await seedAccountWithProdEnv();
+            const supportUser = await createUserWithRole(account.id, 'production_support');
+            const session = await authenticateUser(api, supportUser);
+
+            const res = await api.fetch('/api/v1/invite', {
+                method: 'DELETE',
+                query: { env: 'dev' },
+                body: { email: 'test@example.com' },
+                session
+            });
+
+            expect(res.res.status).toBe(403);
+        });
+
+        it('should deny PUT team', async () => {
+            const { account } = await seedAccountWithProdEnv();
+            const supportUser = await createUserWithRole(account.id, 'production_support');
+            const session = await authenticateUser(api, supportUser);
+
+            const res = await api.fetch('/api/v1/team', {
+                method: 'PUT',
+                query: { env: 'dev' },
+                body: { name: 'New Name' },
+                session
+            });
+
+            expect(res.res.status).toBe(403);
+        });
+
+        it('should deny DELETE team/users/:id', async () => {
+            const { account } = await seedAccountWithProdEnv();
+            const supportUser = await createUserWithRole(account.id, 'production_support');
+            const session = await authenticateUser(api, supportUser);
+
+            const res = await api.fetch('/api/v1/team/users/:id', {
+                method: 'DELETE',
+                query: { env: 'dev' },
+                params: { id: 9999 },
+                session
+            });
+
+            expect(res.res.status).toBe(403);
+        });
+
+        it('should deny PATCH team/users/:id', async () => {
+            const { account } = await seedAccountWithProdEnv();
+            const supportUser = await createUserWithRole(account.id, 'production_support');
+            const session = await authenticateUser(api, supportUser);
+
+            const res = await api.fetch('/api/v1/team/users/:id', {
+                method: 'PATCH',
+                query: { env: 'dev' },
+                params: { id: 9999 },
+                body: { role: 'production_support' },
+                session
+            });
+
+            expect(res.res.status).toBe(403);
+        });
+
         it('should allow GET prod integrations (read access)', async () => {
             const { account } = await seedAccountWithProdEnv();
             const supportUser = await createUserWithRole(account.id, 'production_support');
@@ -417,6 +478,67 @@ describe('authz integration', () => {
                 method: 'POST',
                 query: { env: 'dev' },
                 body: { emails: ['test@example.com'] },
+                session
+            });
+
+            expect(res.res.status).toBe(403);
+        });
+
+        it('should deny DELETE invite', async () => {
+            const { account } = await seedAccountWithProdEnv();
+            const devUser = await createUserWithRole(account.id, 'development_full_access');
+            const session = await authenticateUser(api, devUser);
+
+            const res = await api.fetch('/api/v1/invite', {
+                method: 'DELETE',
+                query: { env: 'dev' },
+                body: { email: 'test@example.com' },
+                session
+            });
+
+            expect(res.res.status).toBe(403);
+        });
+
+        it('should deny PUT team', async () => {
+            const { account } = await seedAccountWithProdEnv();
+            const devUser = await createUserWithRole(account.id, 'development_full_access');
+            const session = await authenticateUser(api, devUser);
+
+            const res = await api.fetch('/api/v1/team', {
+                method: 'PUT',
+                query: { env: 'dev' },
+                body: { name: 'New Name' },
+                session
+            });
+
+            expect(res.res.status).toBe(403);
+        });
+
+        it('should deny DELETE team/users/:id', async () => {
+            const { account } = await seedAccountWithProdEnv();
+            const devUser = await createUserWithRole(account.id, 'development_full_access');
+            const session = await authenticateUser(api, devUser);
+
+            const res = await api.fetch('/api/v1/team/users/:id', {
+                method: 'DELETE',
+                query: { env: 'dev' },
+                params: { id: 9999 },
+                session
+            });
+
+            expect(res.res.status).toBe(403);
+        });
+
+        it('should deny PATCH team/users/:id', async () => {
+            const { account } = await seedAccountWithProdEnv();
+            const devUser = await createUserWithRole(account.id, 'development_full_access');
+            const session = await authenticateUser(api, devUser);
+
+            const res = await api.fetch('/api/v1/team/users/:id', {
+                method: 'PATCH',
+                query: { env: 'dev' },
+                params: { id: 9999 },
+                body: { role: 'production_support' },
                 session
             });
 

--- a/packages/server/lib/authz/deny-map.ts
+++ b/packages/server/lib/authz/deny-map.ts
@@ -5,6 +5,7 @@ import type { Role } from '@nangohq/types';
 
 const ADMIN_ONLY: Permission[] = [
     p.canManageTeam,
+    p.canUpdateTeamMember,
     p.canRemoveTeamMember,
     p.canInviteMember,
     p.canCancelInvitation,

--- a/packages/server/lib/authz/permissions.ts
+++ b/packages/server/lib/authz/permissions.ts
@@ -3,6 +3,7 @@ import type { Permission } from './types.js';
 export const permissions = {
     // team management (global scope)
     canManageTeam: { action: 'update', resource: 'team', scope: 'global' },
+    canUpdateTeamMember: { action: 'update', resource: 'team_member', scope: 'global' },
     canRemoveTeamMember: { action: 'delete', resource: 'team_member', scope: 'global' },
     canInviteMember: { action: 'create', resource: 'invite', scope: 'global' },
     canCancelInvitation: { action: 'delete', resource: 'invite', scope: 'global' },

--- a/packages/server/lib/controllers/v1/invite/acceptInvite.ts
+++ b/packages/server/lib/controllers/v1/invite/acceptInvite.ts
@@ -37,7 +37,7 @@ export const acceptInvite = asyncWrapper<AcceptInvite>(async (req, res) => {
     }
 
     await acceptInvitation(data.id);
-    const updated = await userService.update({ id: user.id, account_id: invitation.account_id });
+    const updated = await userService.update({ id: user.id, account_id: invitation.account_id, role: invitation.role });
     if (!updated) {
         res.status(500).send({ error: { code: 'server_error', message: 'failed to update user team' } });
         return;

--- a/packages/server/lib/controllers/v1/invite/deleteInvite.integration.test.ts
+++ b/packages/server/lib/controllers/v1/invite/deleteInvite.integration.test.ts
@@ -57,7 +57,7 @@ describe(`DELETE ${route}`, () => {
         const { account, user, secret } = await seeders.seedAccountEnvAndUser();
 
         const email = 'foo@example.com';
-        await inviteEmail({ email, name: email, accountId: account.id, invitedByUserId: user.id, trx: db.knex });
+        await inviteEmail({ email, name: email, accountId: account.id, invitedByUserId: user.id, role: 'administrator', trx: db.knex });
 
         const listBefore = await api.fetch('/api/v1/team', { method: 'GET', query: { env: 'dev' }, token: secret.secret });
         isSuccess(listBefore.json);

--- a/packages/server/lib/controllers/v1/invite/postInvite.integration.test.ts
+++ b/packages/server/lib/controllers/v1/invite/postInvite.integration.test.ts
@@ -1,8 +1,11 @@
 import { afterAll, beforeAll, describe, expect, it } from 'vitest';
 
+import db from '@nangohq/database';
 import { seeders } from '@nangohq/shared';
 
 import { authenticateUser, isSuccess, runServer, shouldBeProtected, shouldRequireQueryEnv } from '../../../utils/tests.js';
+
+import type { DBInvitation } from '@nangohq/types';
 
 const route = '/api/v1/invite';
 let api: Awaited<ReturnType<typeof runServer>>;
@@ -70,5 +73,28 @@ describe(`POST ${route}`, () => {
                 invited: ['foo@example.com']
             }
         });
+    });
+
+    it('should invite a user with a specific role', async () => {
+        const { account, user } = await seeders.seedAccountEnvAndUser();
+        const session = await authenticateUser(api, user);
+
+        const email = 'role-test@example.com';
+        const res = await api.fetch(route, {
+            method: 'POST',
+            query: { env: 'dev' },
+            body: { emails: [email], role: 'production_support' },
+            session
+        });
+
+        expect(res.res.status).toBe(200);
+        isSuccess(res.json);
+
+        const invitation = await db.knex
+            .select('*')
+            .from<DBInvitation>('_nango_invited_users')
+            .where({ email, account_id: account.id, accepted: false })
+            .first();
+        expect(invitation?.role).toBe('production_support');
     });
 });

--- a/packages/server/lib/controllers/v1/invite/postInvite.ts
+++ b/packages/server/lib/controllers/v1/invite/postInvite.ts
@@ -2,8 +2,9 @@ import * as z from 'zod';
 
 import db from '@nangohq/database';
 import { expirePreviousInvitations, inviteEmail, userService } from '@nangohq/shared';
-import { requireEmptyQuery, zodErrorToHTTP } from '@nangohq/utils';
+import { requireEmptyQuery, roles, zodErrorToHTTP } from '@nangohq/utils';
 
+import { envs } from '../../../env.js';
 import { sendInviteEmail } from '../../../helpers/email.js';
 import { asyncWrapper } from '../../../utils/asyncWrapper.js';
 
@@ -12,7 +13,7 @@ import type { PostInvite } from '@nangohq/types';
 const validation = z
     .object({
         emails: z.array(z.string().min(3).max(255).email()),
-        role: z.enum(['administrator', 'production_support', 'development_full_access']).optional()
+        role: z.enum(roles).optional()
     })
     .strict();
 
@@ -44,7 +45,7 @@ export const postInvite = asyncWrapper<PostInvite>(async (req, res) => {
         const invitation = await db.knex.transaction(async (trx) => {
             await expirePreviousInvitations({ email, accountId: account.id, trx });
 
-            return await inviteEmail({ email, name: email, accountId: account.id, invitedByUserId: user.id, ...(body.role && { role: body.role }), trx });
+            return await inviteEmail({ email, name: email, accountId: account.id, invitedByUserId: user.id, role: body.role ?? envs.DEFAULT_USER_ROLE, trx });
         });
         if (!invitation) {
             res.status(500).json({

--- a/packages/server/lib/controllers/v1/invite/postInvite.ts
+++ b/packages/server/lib/controllers/v1/invite/postInvite.ts
@@ -11,7 +11,8 @@ import type { PostInvite } from '@nangohq/types';
 
 const validation = z
     .object({
-        emails: z.array(z.string().min(3).max(255).email())
+        emails: z.array(z.string().min(3).max(255).email()),
+        role: z.enum(['administrator', 'production_support', 'development_full_access']).optional()
     })
     .strict();
 
@@ -31,7 +32,7 @@ export const postInvite = asyncWrapper<PostInvite>(async (req, res) => {
     }
 
     const { account, user } = res.locals;
-    const body: PostInvite['Body'] = val.data;
+    const body = val.data;
 
     const invited: string[] = [];
     for (const email of body.emails) {
@@ -43,7 +44,7 @@ export const postInvite = asyncWrapper<PostInvite>(async (req, res) => {
         const invitation = await db.knex.transaction(async (trx) => {
             await expirePreviousInvitations({ email, accountId: account.id, trx });
 
-            return await inviteEmail({ email, name: email, accountId: account.id, invitedByUserId: user.id, trx });
+            return await inviteEmail({ email, name: email, accountId: account.id, invitedByUserId: user.id, ...(body.role && { role: body.role }), trx });
         });
         if (!invitation) {
             res.status(500).json({

--- a/packages/server/lib/controllers/v1/team/users/patchTeamUser.integration.test.ts
+++ b/packages/server/lib/controllers/v1/team/users/patchTeamUser.integration.test.ts
@@ -1,0 +1,110 @@
+import { afterAll, beforeAll, describe, expect, it } from 'vitest';
+
+import { seeders, userService } from '@nangohq/shared';
+
+import { authenticateUser, isSuccess, runServer, shouldBeProtected, shouldRequireQueryEnv } from '../../../../utils/tests.js';
+
+const route = '/api/v1/team/users/:id';
+let api: Awaited<ReturnType<typeof runServer>>;
+
+describe(`PATCH ${route}`, () => {
+    beforeAll(async () => {
+        api = await runServer();
+    });
+    afterAll(() => {
+        api.server.close();
+    });
+
+    it('should be protected', async () => {
+        const res = await api.fetch(route, {
+            method: 'PATCH',
+            query: { env: 'dev' },
+            params: { id: 1 },
+            body: { role: 'production_support' }
+        });
+
+        shouldBeProtected(res);
+    });
+
+    it('should enforce env query params', async () => {
+        const { secret } = await seeders.seedAccountEnvAndUser();
+        const res = await api.fetch(route, {
+            method: 'PATCH',
+            token: secret.secret,
+            params: { id: 1 },
+            body: { role: 'production_support' },
+            // @ts-expect-error missing query on purpose
+            query: {}
+        });
+
+        shouldRequireQueryEnv(res);
+    });
+
+    it('should validate body', async () => {
+        const { secret } = await seeders.seedAccountEnvAndUser();
+        const res = await api.fetch(route, {
+            method: 'PATCH',
+            query: { env: 'dev' },
+            token: secret.secret,
+            params: { id: 1 },
+            // @ts-expect-error invalid role on purpose
+            body: { role: 'invalid_role' }
+        });
+
+        expect(res.res.status).toBe(400);
+        expect((res.json as any).error.code).toBe('invalid_body');
+    });
+
+    it('should change a user role', async () => {
+        const { account, user } = await seeders.seedAccountEnvAndUser();
+        const targetUser = await seeders.seedUser(account.id);
+        const session = await authenticateUser(api, user);
+
+        const res = await api.fetch(route, {
+            method: 'PATCH',
+            query: { env: 'dev' },
+            params: { id: targetUser.id },
+            body: { role: 'production_support' },
+            session
+        });
+
+        expect(res.res.status).toBe(200);
+        isSuccess(res.json);
+
+        const updated = await userService.getUserById(targetUser.id);
+        expect(updated?.role).toBe('production_support');
+    });
+
+    it('should prevent self-demotion', async () => {
+        const { user } = await seeders.seedAccountEnvAndUser();
+        const session = await authenticateUser(api, user);
+
+        const res = await api.fetch(route, {
+            method: 'PATCH',
+            query: { env: 'dev' },
+            params: { id: user.id },
+            body: { role: 'production_support' },
+            session
+        });
+
+        expect(res.res.status).toBe(400);
+        expect((res.json as any).error.code).toBe('forbidden_self_demotion');
+    });
+
+    it('should return user_not_found for user in different account', async () => {
+        const { user } = await seeders.seedAccountEnvAndUser();
+        const { user: otherUser } = await seeders.seedAccountEnvAndUser();
+        const session = await authenticateUser(api, user);
+
+        const res = await api.fetch(route, {
+            method: 'PATCH',
+            query: { env: 'dev' },
+            params: { id: otherUser.id },
+            body: { role: 'production_support' },
+            session
+        });
+
+        expect(res.res.status).toBe(400);
+        expect((res.json as any).error.code).toBe('user_not_found');
+    });
+});

--- a/packages/server/lib/controllers/v1/team/users/patchTeamUser.ts
+++ b/packages/server/lib/controllers/v1/team/users/patchTeamUser.ts
@@ -1,0 +1,72 @@
+import * as z from 'zod';
+
+import { userService } from '@nangohq/shared';
+import { requireEmptyQuery, zodErrorToHTTP } from '@nangohq/utils';
+
+import { asyncWrapper } from '../../../../utils/asyncWrapper.js';
+
+import type { PatchTeamUser } from '@nangohq/types';
+
+const VALID_ROLES = ['administrator', 'production_support', 'development_full_access'] as const;
+
+const paramValidation = z
+    .object({
+        id: z.coerce.number()
+    })
+    .strict();
+
+const bodyValidation = z
+    .object({
+        role: z.enum(VALID_ROLES)
+    })
+    .strict();
+
+export const patchTeamUser = asyncWrapper<PatchTeamUser>(async (req, res) => {
+    const emptyQuery = requireEmptyQuery(req, { withEnv: true });
+    if (emptyQuery) {
+        res.status(400).send({ error: { code: 'invalid_query_params', errors: zodErrorToHTTP(emptyQuery.error) } });
+        return;
+    }
+
+    const paramVal = paramValidation.safeParse(req.params);
+    if (!paramVal.success) {
+        res.status(400).send({ error: { code: 'invalid_uri_params', errors: zodErrorToHTTP(paramVal.error) } });
+        return;
+    }
+
+    const bodyVal = bodyValidation.safeParse(req.body);
+    if (!bodyVal.success) {
+        res.status(400).send({ error: { code: 'invalid_body', errors: zodErrorToHTTP(bodyVal.error) } });
+        return;
+    }
+
+    const { account } = res.locals;
+    const params: PatchTeamUser['Params'] = paramVal.data;
+    const body: PatchTeamUser['Body'] = bodyVal.data;
+
+    const user = await userService.getUserById(params.id);
+    if (!user || user.account_id !== account.id) {
+        res.status(400).send({ error: { code: 'user_not_found' } });
+        return;
+    }
+
+    // Prevent demoting the last administrator
+    if (user.role === 'administrator' && body.role !== 'administrator') {
+        const admins = await userService.getUsersByAccountId(account.id);
+        const adminCount = admins.filter((u) => u.role === 'administrator').length;
+        if (adminCount <= 1) {
+            res.status(400).send({ error: { code: 'forbidden_last_admin', message: 'Cannot change the role of the last administrator' } });
+            return;
+        }
+    }
+
+    const updated = await userService.update({ id: user.id, role: body.role });
+    if (!updated) {
+        res.status(500).send({ error: { code: 'server_error', message: 'Failed to update user role' } });
+        return;
+    }
+
+    res.status(200).send({
+        data: { success: true }
+    });
+});

--- a/packages/server/lib/controllers/v1/team/users/patchTeamUser.ts
+++ b/packages/server/lib/controllers/v1/team/users/patchTeamUser.ts
@@ -1,13 +1,11 @@
 import * as z from 'zod';
 
 import { userService } from '@nangohq/shared';
-import { requireEmptyQuery, zodErrorToHTTP } from '@nangohq/utils';
+import { requireEmptyQuery, roles, zodErrorToHTTP } from '@nangohq/utils';
 
 import { asyncWrapper } from '../../../../utils/asyncWrapper.js';
 
 import type { PatchTeamUser } from '@nangohq/types';
-
-const VALID_ROLES = ['administrator', 'production_support', 'development_full_access'] as const;
 
 const paramValidation = z
     .object({
@@ -17,7 +15,7 @@ const paramValidation = z
 
 const bodyValidation = z
     .object({
-        role: z.enum(VALID_ROLES)
+        role: z.enum(roles)
     })
     .strict();
 
@@ -40,7 +38,7 @@ export const patchTeamUser = asyncWrapper<PatchTeamUser>(async (req, res) => {
         return;
     }
 
-    const { account } = res.locals;
+    const { account, user: me } = res.locals;
     const params: PatchTeamUser['Params'] = paramVal.data;
     const body: PatchTeamUser['Body'] = bodyVal.data;
 
@@ -50,14 +48,11 @@ export const patchTeamUser = asyncWrapper<PatchTeamUser>(async (req, res) => {
         return;
     }
 
-    // Prevent demoting the last administrator
-    if (user.role === 'administrator' && body.role !== 'administrator') {
-        const admins = await userService.getUsersByAccountId(account.id);
-        const adminCount = admins.filter((u) => u.role === 'administrator').length;
-        if (adminCount <= 1) {
-            res.status(400).send({ error: { code: 'forbidden_last_admin', message: 'Cannot change the role of the last administrator' } });
-            return;
-        }
+    // Prevent self-demotion — since only admins can change roles,
+    // blocking self-change guarantees at least one admin remains.
+    if (user.id === me.id) {
+        res.status(400).send({ error: { code: 'forbidden_self_demotion', message: 'You cannot change your own role' } });
+        return;
     }
 
     const updated = await userService.update({ id: user.id, role: body.role });

--- a/packages/server/lib/routes.private.ts
+++ b/packages/server/lib/routes.private.ts
@@ -85,6 +85,7 @@ import { postStripeWebhooks } from './controllers/v1/stripe/postWebhooks.js';
 import { getTeam } from './controllers/v1/team/getTeam.js';
 import { putTeam } from './controllers/v1/team/putTeam.js';
 import { deleteTeamUser } from './controllers/v1/team/users/deleteTeamUser.js';
+import { patchTeamUser } from './controllers/v1/team/users/patchTeamUser.js';
 import { getUser } from './controllers/v1/user/getUser.js';
 import { putUserPassword } from './controllers/v1/user/password/putPassword.js';
 import { patchUser } from './controllers/v1/user/patchUser.js';
@@ -163,6 +164,7 @@ web.route('/account/onboarding/hear-about-us').post(webAuth, postOnboardingHearA
 web.route('/team').get(webAuth, getTeam);
 web.route('/team').put(webAuth, can(p.canManageTeam), putTeam);
 web.route('/team/users/:id').delete(webAuth, can(p.canRemoveTeamMember), deleteTeamUser);
+web.route('/team/users/:id').patch(webAuth, can(p.canUpdateTeamMember), patchTeamUser);
 
 // Invitations
 web.route('/invite').post(webAuth, can(p.canInviteMember), postInvite);

--- a/packages/shared/lib/services/invitations.ts
+++ b/packages/shared/lib/services/invitations.ts
@@ -28,14 +28,14 @@ export async function inviteEmail({
     name,
     accountId,
     invitedByUserId,
-    role = 'administrator',
+    role,
     trx
 }: {
     email: string;
     name: string;
     accountId: number;
     invitedByUserId: number;
-    role?: DBInvitation['role'];
+    role: DBInvitation['role'];
     trx: Knex;
 }) {
     const token = uuid.v4();

--- a/packages/types/lib/api.endpoints.ts
+++ b/packages/types/lib/api.endpoints.ts
@@ -78,7 +78,7 @@ import type {
     PostSharedCredentialsProvider
 } from './sharedCredentials/api.js';
 import type { GetPublicSyncStatus, PostPublicSyncPause, PostPublicSyncStart, PostPublicTrigger, PutPublicSyncConnectionFrequency } from './sync/api.js';
-import type { DeleteTeamUser, GetTeam, PutTeam } from './team/api.js';
+import type { DeleteTeamUser, GetTeam, PatchTeamUser, PutTeam } from './team/api.js';
 import type { GetUser, PatchUser } from './user/api.js';
 import type { PostPublicWebhook } from './webhooks/http.api.js';
 
@@ -142,6 +142,7 @@ export type PrivateApiEndpoints =
     | PostInvite
     | DeleteInvite
     | DeleteTeamUser
+    | PatchTeamUser
     | PostInsights
     | PostForgotPassword
     | PutResetPassword

--- a/packages/types/lib/invitations/api.ts
+++ b/packages/types/lib/invitations/api.ts
@@ -1,12 +1,13 @@
 import type { ApiError, Endpoint } from '../api.js';
 import type { ApiInvitation, ApiTeam } from '../team/api.js';
 import type { ApiUser } from '../user/api.js';
+import type { Role } from '../user/db.js';
 
 export type PostInvite = Endpoint<{
     Method: 'POST';
     Path: '/api/v1/invite';
     Querystring: { env: string };
-    Body: { emails: string[] };
+    Body: { emails: string[]; role?: Role };
     Success: {
         data: { invited: string[] };
     };

--- a/packages/types/lib/team/api.ts
+++ b/packages/types/lib/team/api.ts
@@ -49,7 +49,7 @@ export type PatchTeamUser = Endpoint<{
     Querystring: { env: string };
     Params: { id: number };
     Body: { role: Role };
-    Error: ApiError<'user_not_found'> | ApiError<'forbidden_last_admin'>;
+    Error: ApiError<'user_not_found'> | ApiError<'forbidden_self_demotion'>;
     Success: {
         data: { success: true };
     };

--- a/packages/types/lib/team/api.ts
+++ b/packages/types/lib/team/api.ts
@@ -2,6 +2,7 @@ import type { ApiError, ApiTimestamps, Endpoint } from '../api.js';
 import type { DBTeam } from './db.js';
 import type { DBInvitation } from '../invitations/db.js';
 import type { ApiUser } from '../user/api.js';
+import type { Role } from '../user/db.js';
 import type { Merge } from 'type-fest';
 
 export type GetTeam = Endpoint<{
@@ -37,6 +38,18 @@ export type DeleteTeamUser = Endpoint<{
     Querystring: { env: string };
     Params: { id: number };
     Error: ApiError<'user_not_found'> | ApiError<'forbidden_self_delete'>;
+    Success: {
+        data: { success: true };
+    };
+}>;
+
+export type PatchTeamUser = Endpoint<{
+    Method: 'PATCH';
+    Path: '/api/v1/team/users/:id';
+    Querystring: { env: string };
+    Params: { id: number };
+    Body: { role: Role };
+    Error: ApiError<'user_not_found'> | ApiError<'forbidden_last_admin'>;
     Success: {
         data: { success: true };
     };

--- a/packages/utils/lib/environment/parse.ts
+++ b/packages/utils/lib/environment/parse.ts
@@ -1,5 +1,7 @@
 import * as z from 'zod';
 
+import { roles } from '../roles.js';
+
 export const ENVS = z.object({
     // Node ecosystem
     NODE_ENV: z.enum(['production', 'staging', 'development', 'test']).default('development'), // TODO: a better name would be NANGO_ENV
@@ -17,7 +19,7 @@ export const ENVS = z.object({
     NANGO_DASHBOARD_PASSWORD: z.string().optional(),
     LOCAL_NANGO_USER_ID: z.coerce.number().optional(),
     AUTH_ALLOW_SIGNUP: z.stringbool().optional().default(true),
-    DEFAULT_USER_ROLE: z.enum(['administrator', 'production_support', 'development_full_access']).optional().default('administrator'),
+    DEFAULT_USER_ROLE: z.enum(roles).optional().default('administrator'),
 
     // API
     NANGO_PORT: z.coerce.number().optional().default(3003), // Sync those two ports?

--- a/packages/utils/lib/index.ts
+++ b/packages/utils/lib/index.ts
@@ -1,3 +1,4 @@
+export * from './roles.js';
 export * from './environment/constants.js';
 export * from './environment/detection.js';
 export * from './environment/parse.js';

--- a/packages/utils/lib/roles.ts
+++ b/packages/utils/lib/roles.ts
@@ -1,0 +1,3 @@
+import type { Role } from '@nangohq/types';
+
+export const roles = ['administrator', 'production_support', 'development_full_access'] as const satisfies readonly Role[];


### PR DESCRIPTION
This PR implements some of the leftovers that were missing for RBAC adding all required backend changes for implementing  the team/invite role management.
<!-- Describe the problem and your solution --> 

<!-- Issue ticket number and link (if applicable) -->

<!-- Testing instructions (skip if just adding/editing providers) -->


<!-- Summary by @propel-code-bot -->

---

**Add team role management and role-aware invitations**

This PR introduces backend support for team role management and role-aware invitations. It adds a new `PATCH /api/v1/team/users/:id` endpoint for updating user roles with validation and self-demotion protection, and extends invitation creation to accept an optional role that is persisted and applied when the invite is accepted.

It also centralizes role definitions via a shared `roles` constant, updates permissions/deny maps to include team member updates, wires the new route, and adds integration/authz tests covering role updates, invite roles, and access restrictions for non-admin roles.

---
*This summary was automatically generated by @propel-code-bot*