### PR TITLE
fix(webapp): incorrect error message for incorrect login credentials

### DIFF
--- a/packages/webapp/src/hooks/useAuth.tsx
+++ b/packages/webapp/src/hooks/useAuth.tsx
@@ -21,8 +21,11 @@ export function useSigninAPI() {
               json: PostSignin['Success'];
           }
         | {
-              status: 401 | 400;
+              status: 400;
               json: PostSignin['Errors'];
+          }
+        | {
+              status: 401;
           },
         APIError,
         { email: string; password: string }
@@ -40,10 +43,16 @@ export function useSigninAPI() {
                 };
             }
 
-            if (res.status === 401 || res.status === 400) {
+            if (res.status === 400) {
                 return {
                     status: res.status,
                     json: (await res.json()) as PostSignin['Errors']
+                };
+            }
+
+            if (res.status === 401) {
+                return {
+                    status: res.status
                 };
             }
 


### PR DESCRIPTION
I noticed that mistyping the email/password would show "Issue logging in. Please try again." instead of "Invalid email or password.". It would also not do the expected behavior: clear password field and focus it. 
Turns out that the 401 response is coming from `passport`, and it doesn't follow our APIError format. So the json-deserialization would throw and lead to the generic error message. I'm simply changing this to handle the 401 separately and skipping json-deserialization entirely for 401s. We don't display backend error messages here anyway, so nothing changes for the consumers of this hook.

Before when inserting invalid credentials:
<img width="508" height="613" alt="image" src="https://github.com/user-attachments/assets/131a4e24-7d0e-4b79-b7c4-bcb0a0485793" />

After fix:
<img width="512" height="617" alt="image" src="https://github.com/user-attachments/assets/756fe100-dafc-4990-ac04-4dc37ca74de6" />


