### PR TITLE
feat(permissions): NAN-2184 expose authRoles feature flag to frontend

### DIFF
--- a/packages/server/lib/controllers/v1/getEnvJs.ts
+++ b/packages/server/lib/controllers/v1/getEnvJs.ts
@@ -8,6 +8,7 @@ import {
     flagHasPlan,
     flagHasScripts,
     flagHasSlack,
+    flags,
     isCloud,
     isEnterprise,
     isHosted
@@ -40,7 +41,8 @@ export const getEnvJs = asyncWrapper<any, any>((_, res) => {
             managedAuth: flagHasManagedAuth,
             gettingStarted: true,
             slack: flagHasSlack,
-            plan: flagHasPlan
+            plan: flagHasPlan,
+            authRoles: flags.hasAuthRoles
         }
     };
     res.setHeader('content-type', 'text/javascript');

--- a/packages/types/lib/web/env.ts
+++ b/packages/types/lib/web/env.ts
@@ -21,5 +21,6 @@ export interface WindowEnv {
         gettingStarted: boolean;
         slack: boolean;
         plan: boolean;
+        authRoles: boolean;
     };
 }


### PR DESCRIPTION
Add authRoles to WindowEnv.features so the frontend can check whether the role-based authorization system is enabled via globalEnv.features.authRoles.

<!-- Describe the problem and your solution --> 

<!-- Issue ticket number and link (if applicable) -->

<!-- Testing instructions (skip if just adding/editing providers) -->


<!-- Summary by @propel-code-bot -->

---

It also updates the WindowEnv type to include the new features.authRoles boolean in the server-generated window._env payload.

---
*This summary was automatically generated by @propel-code-bot*