### PR TITLE
feat(proxy): add a flag in the proxyConfig to enable forwarding header on redirect

### DIFF
--- a/packages/cli/lib/services/__snapshots__/model.service.unit.test.ts.snap
+++ b/packages/cli/lib/services/__snapshots__/model.service.unit.test.ts.snap
@@ -105,7 +105,7 @@ export interface ProxyConfiguration {
     retryHeader?: RetryHeaderConfig;
     responseType?: 'arraybuffer' | 'blob' | 'document' | 'json' | 'text' | 'stream' | undefined;
     retryOn?: number[] | null;
-    enableHeaderForwarding?: boolean;
+    forwardHeadersOnRedirect?: boolean;
 }
 export interface AuthModes {
     OAuth1: 'OAUTH1';

--- a/packages/cli/lib/services/__snapshots__/model.service.unit.test.ts.snap
+++ b/packages/cli/lib/services/__snapshots__/model.service.unit.test.ts.snap
@@ -105,6 +105,7 @@ export interface ProxyConfiguration {
     retryHeader?: RetryHeaderConfig;
     responseType?: 'arraybuffer' | 'blob' | 'document' | 'json' | 'text' | 'stream' | undefined;
     retryOn?: number[] | null;
+    disableHeaderForwarding?: boolean;
 }
 export interface AuthModes {
     OAuth1: 'OAUTH1';

--- a/packages/cli/lib/services/__snapshots__/model.service.unit.test.ts.snap
+++ b/packages/cli/lib/services/__snapshots__/model.service.unit.test.ts.snap
@@ -105,7 +105,7 @@ export interface ProxyConfiguration {
     retryHeader?: RetryHeaderConfig;
     responseType?: 'arraybuffer' | 'blob' | 'document' | 'json' | 'text' | 'stream' | undefined;
     retryOn?: number[] | null;
-    disableHeaderForwarding?: boolean;
+    enableHeaderForwarding?: boolean;
 }
 export interface AuthModes {
     OAuth1: 'OAUTH1';

--- a/packages/cli/lib/services/response-collector.service.ts
+++ b/packages/cli/lib/services/response-collector.service.ts
@@ -63,7 +63,7 @@ export const FILTER_HEADERS: string[] = [
     'accept',
     'base-url-override',
     'retry-on',
-    'disable-header-forwarding'
+    'enable-header-forwarding'
 ];
 
 export function isAxiosDefaultContentTypeForMockIdentity(headerKey: string, headerValue: unknown): boolean {

--- a/packages/cli/lib/services/response-collector.service.ts
+++ b/packages/cli/lib/services/response-collector.service.ts
@@ -62,7 +62,8 @@ export const FILTER_HEADERS: string[] = [
     'content-length',
     'accept',
     'base-url-override',
-    'retry-on'
+    'retry-on',
+    'disable-header-forwarding'
 ];
 
 export function isAxiosDefaultContentTypeForMockIdentity(headerKey: string, headerValue: unknown): boolean {

--- a/packages/cli/lib/services/response-collector.service.ts
+++ b/packages/cli/lib/services/response-collector.service.ts
@@ -63,7 +63,7 @@ export const FILTER_HEADERS: string[] = [
     'accept',
     'base-url-override',
     'retry-on',
-    'enable-header-forwarding'
+    'forward-headers-on-redirect'
 ];
 
 export function isAxiosDefaultContentTypeForMockIdentity(headerKey: string, headerValue: unknown): boolean {

--- a/packages/node-client/lib/index.ts
+++ b/packages/node-client/lib/index.ts
@@ -1090,7 +1090,17 @@ export class Nango {
 
         validateProxyConfiguration(config);
 
-        const { providerConfigKey, connectionId, method, retries, headers: customHeaders, baseUrlOverride, decompress, retryOn } = config;
+        const {
+            providerConfigKey,
+            connectionId,
+            method,
+            retries,
+            headers: customHeaders,
+            baseUrlOverride,
+            decompress,
+            retryOn,
+            disableHeaderForwarding
+        } = config;
 
         let url = `${this.serverUrl}/proxy${config.endpoint[0] === '/' ? '' : '/'}${config.endpoint}`;
 
@@ -1124,6 +1134,10 @@ export class Nango {
 
         if (retryOn) {
             headers['Retry-On'] = retryOn.join(',');
+        }
+
+        if (disableHeaderForwarding) {
+            headers['Disable-Header-Forwarding'] = true;
         }
 
         const options: AxiosRequestConfig = {

--- a/packages/node-client/lib/index.ts
+++ b/packages/node-client/lib/index.ts
@@ -1137,7 +1137,7 @@ export class Nango {
         }
 
         if (enableHeaderForwarding !== undefined) {
-            headers['Enable-Header-Forwarding'] = enableHeaderForwarding;
+            headers['Enable-Header-Forwarding'] = String(enableHeaderForwarding);
         }
 
         const options: AxiosRequestConfig = {

--- a/packages/node-client/lib/index.ts
+++ b/packages/node-client/lib/index.ts
@@ -1099,7 +1099,7 @@ export class Nango {
             baseUrlOverride,
             decompress,
             retryOn,
-            disableHeaderForwarding
+            enableHeaderForwarding
         } = config;
 
         let url = `${this.serverUrl}/proxy${config.endpoint[0] === '/' ? '' : '/'}${config.endpoint}`;
@@ -1136,8 +1136,8 @@ export class Nango {
             headers['Retry-On'] = retryOn.join(',');
         }
 
-        if (disableHeaderForwarding) {
-            headers['Disable-Header-Forwarding'] = true;
+        if (enableHeaderForwarding) {
+            headers['Enable-Header-Forwarding'] = true;
         }
 
         const options: AxiosRequestConfig = {

--- a/packages/node-client/lib/index.ts
+++ b/packages/node-client/lib/index.ts
@@ -1136,8 +1136,8 @@ export class Nango {
             headers['Retry-On'] = retryOn.join(',');
         }
 
-        if (enableHeaderForwarding) {
-            headers['Enable-Header-Forwarding'] = true;
+        if (enableHeaderForwarding !== undefined) {
+            headers['Enable-Header-Forwarding'] = enableHeaderForwarding;
         }
 
         const options: AxiosRequestConfig = {

--- a/packages/node-client/lib/index.ts
+++ b/packages/node-client/lib/index.ts
@@ -1099,7 +1099,7 @@ export class Nango {
             baseUrlOverride,
             decompress,
             retryOn,
-            enableHeaderForwarding
+            forwardHeadersOnRedirect
         } = config;
 
         let url = `${this.serverUrl}/proxy${config.endpoint[0] === '/' ? '' : '/'}${config.endpoint}`;
@@ -1136,8 +1136,8 @@ export class Nango {
             headers['Retry-On'] = retryOn.join(',');
         }
 
-        if (enableHeaderForwarding !== undefined) {
-            headers['Enable-Header-Forwarding'] = String(enableHeaderForwarding);
+        if (forwardHeadersOnRedirect !== undefined) {
+            headers['Forward-Headers-On-Redirect'] = forwardHeadersOnRedirect;
         }
 
         const options: AxiosRequestConfig = {

--- a/packages/providers/providers.yaml
+++ b/packages/providers/providers.yaml
@@ -4482,6 +4482,7 @@ dayforce:
     body_format: form
     proxy:
         base_url: https://${connectionConfig.clientHostname}/api || https://www.dayforcehcm.com/api
+        enable_header_forwarding: true
     token_url: https://${connectionConfig.identityHostname}/connect/token || https://dfid.dayforcehcm.com/connect/token
     token_params:
         grant_type: password

--- a/packages/providers/providers.yaml
+++ b/packages/providers/providers.yaml
@@ -4482,7 +4482,7 @@ dayforce:
     body_format: form
     proxy:
         base_url: https://${connectionConfig.clientHostname}/api || https://www.dayforcehcm.com/api
-        enable_header_forwarding: true
+        forward_headers_on_redirect: true
     token_url: https://${connectionConfig.identityHostname}/connect/token || https://dfid.dayforcehcm.com/connect/token
     token_params:
         grant_type: password

--- a/packages/runner-sdk/models.d.ts
+++ b/packages/runner-sdk/models.d.ts
@@ -62,7 +62,7 @@ export interface ProxyConfiguration {
     retryHeader?: RetryHeaderConfig;
     responseType?: 'arraybuffer' | 'blob' | 'document' | 'json' | 'text' | 'stream' | undefined;
     retryOn?: number[] | null;
-    enableHeaderForwarding?: boolean;
+    forwardHeadersOnRedirect?: boolean;
 }
 export interface AuthModes {
     OAuth1: 'OAUTH1';

--- a/packages/runner-sdk/models.d.ts
+++ b/packages/runner-sdk/models.d.ts
@@ -62,7 +62,7 @@ export interface ProxyConfiguration {
     retryHeader?: RetryHeaderConfig;
     responseType?: 'arraybuffer' | 'blob' | 'document' | 'json' | 'text' | 'stream' | undefined;
     retryOn?: number[] | null;
-    disableHeaderForwarding?: boolean;
+    enableHeaderForwarding?: boolean;
 }
 export interface AuthModes {
     OAuth1: 'OAUTH1';

--- a/packages/runner-sdk/models.d.ts
+++ b/packages/runner-sdk/models.d.ts
@@ -62,6 +62,7 @@ export interface ProxyConfiguration {
     retryHeader?: RetryHeaderConfig;
     responseType?: 'arraybuffer' | 'blob' | 'document' | 'json' | 'text' | 'stream' | undefined;
     retryOn?: number[] | null;
+    disableHeaderForwarding?: boolean;
 }
 export interface AuthModes {
     OAuth1: 'OAUTH1';

--- a/packages/runner/lib/sdk/sdk.unit.test.ts
+++ b/packages/runner/lib/sdk/sdk.unit.test.ts
@@ -186,8 +186,7 @@ describe('Pagination', () => {
                 headers: {
                     authorization: 'Bearer token',
                     'user-agent': expect.any(String)
-                },
-                beforeRedirect: expect.any(Function)
+                }
             })
         );
     });
@@ -221,8 +220,7 @@ describe('Pagination', () => {
                 headers: {
                     authorization: 'Bearer token',
                     'user-agent': expect.any(String)
-                },
-                beforeRedirect: expect.any(Function)
+                }
             })
         );
     });
@@ -356,8 +354,7 @@ describe('Pagination', () => {
             expect.objectContaining({
                 method: 'GET',
                 url: 'https://api.github.com/issues',
-                headers: { authorization: 'Bearer token', 'user-agent': expect.any(String) },
-                beforeRedirect: expect.any(Function)
+                headers: { authorization: 'Bearer token', 'user-agent': expect.any(String) }
             })
         );
         expect(spy).toHaveBeenNthCalledWith(
@@ -365,8 +362,7 @@ describe('Pagination', () => {
             expect.objectContaining({
                 method: 'GET',
                 url: 'https://api.github.com/issues?page=2',
-                headers: { authorization: 'Bearer token', 'user-agent': expect.any(String) },
-                beforeRedirect: expect.any(Function)
+                headers: { authorization: 'Bearer token', 'user-agent': expect.any(String) }
             })
         );
         expect(spy).toHaveBeenNthCalledWith(
@@ -374,8 +370,7 @@ describe('Pagination', () => {
             expect.objectContaining({
                 method: 'GET',
                 url: 'https://api.github.com/issues?page=3',
-                headers: { authorization: 'Bearer token', 'user-agent': expect.any(String) },
-                beforeRedirect: expect.any(Function)
+                headers: { authorization: 'Bearer token', 'user-agent': expect.any(String) }
             })
         );
         expect(spy).toHaveBeenCalledTimes(3);

--- a/packages/server/lib/controllers/proxy/allProxy.ts
+++ b/packages/server/lib/controllers/proxy/allProxy.ts
@@ -47,7 +47,8 @@ const schemaHeaders = z.object({
         .string()
         .regex(/^\d+(,\d+)*$/)
         .optional(),
-    'enable-header-forwarding': z.enum(['true', 'false']).default('false'),
+    // TODO: change default to 'false' after removing the metric in utils.ts
+    'forward-headers-on-redirect': z.enum(['true', 'false']).default('true'),
     'nango-activity-log-id': z.string().max(255).optional(),
     'nango-is-sync': z.enum(['true', 'false']).optional(),
     'nango-is-dry-run': z.enum(['true', 'false']).optional()
@@ -72,7 +73,7 @@ export const allPublicProxy = asyncWrapper<AllPublicProxy>(async (req, res, next
     const baseUrlOverride = parsedHeaders['base-url-override'];
     const decompress = parsedHeaders['decompress'] === 'true';
     const retryOn = parsedHeaders['retry-on'] ? parsedHeaders['retry-on'].split(',').map(Number) : null;
-    const enableHeaderForwarding = parsedHeaders['enable-header-forwarding'] === 'true';
+    const forwardHeadersOnRedirect = parsedHeaders['forward-headers-on-redirect'] === 'true';
     const existingActivityLogId = parsedHeaders['nango-activity-log-id'];
     const isSync = parsedHeaders['nango-is-sync'] === 'true';
     const isDryRun = parsedHeaders['nango-is-dry-run'] === 'true';
@@ -190,7 +191,7 @@ export const allPublicProxy = asyncWrapper<AllPublicProxy>(async (req, res, next
                     method,
                     retryOn,
                     responseType: 'stream',
-                    enableHeaderForwarding
+                    forwardHeadersOnRedirect
                 },
                 internalConfig
             }).unwrap(),

--- a/packages/server/lib/controllers/proxy/allProxy.ts
+++ b/packages/server/lib/controllers/proxy/allProxy.ts
@@ -47,6 +47,7 @@ const schemaHeaders = z.object({
         .string()
         .regex(/^\d+(,\d+)*$/)
         .optional(),
+    'disable-header-forwarding': z.enum(['true', 'false']).optional(),
     'nango-activity-log-id': z.string().max(255).optional(),
     'nango-is-sync': z.enum(['true', 'false']).optional(),
     'nango-is-dry-run': z.enum(['true', 'false']).optional()
@@ -71,6 +72,7 @@ export const allPublicProxy = asyncWrapper<AllPublicProxy>(async (req, res, next
     const baseUrlOverride = parsedHeaders['base-url-override'];
     const decompress = parsedHeaders['decompress'] === 'true';
     const retryOn = parsedHeaders['retry-on'] ? parsedHeaders['retry-on'].split(',').map(Number) : null;
+    const disableHeaderForwarding = parsedHeaders['disable-header-forwarding'] === 'true';
     const existingActivityLogId = parsedHeaders['nango-activity-log-id'];
     const isSync = parsedHeaders['nango-is-sync'] === 'true';
     const isDryRun = parsedHeaders['nango-is-dry-run'] === 'true';
@@ -187,7 +189,8 @@ export const allPublicProxy = asyncWrapper<AllPublicProxy>(async (req, res, next
                     decompress,
                     method,
                     retryOn,
-                    responseType: 'stream'
+                    responseType: 'stream',
+                    disableHeaderForwarding
                 },
                 internalConfig
             }).unwrap(),

--- a/packages/server/lib/controllers/proxy/allProxy.ts
+++ b/packages/server/lib/controllers/proxy/allProxy.ts
@@ -47,7 +47,7 @@ const schemaHeaders = z.object({
         .string()
         .regex(/^\d+(,\d+)*$/)
         .optional(),
-    'enable-header-forwarding': z.enum(['true', 'false']).optional(),
+    'enable-header-forwarding': z.enum(['true', 'false']).default('false'),
     'nango-activity-log-id': z.string().max(255).optional(),
     'nango-is-sync': z.enum(['true', 'false']).optional(),
     'nango-is-dry-run': z.enum(['true', 'false']).optional()
@@ -72,7 +72,7 @@ export const allPublicProxy = asyncWrapper<AllPublicProxy>(async (req, res, next
     const baseUrlOverride = parsedHeaders['base-url-override'];
     const decompress = parsedHeaders['decompress'] === 'true';
     const retryOn = parsedHeaders['retry-on'] ? parsedHeaders['retry-on'].split(',').map(Number) : null;
-    const enableHeaderForwarding = parsedHeaders['enable-header-forwarding'] ? parsedHeaders['enable-header-forwarding'] === 'true' : undefined;
+    const enableHeaderForwarding = parsedHeaders['enable-header-forwarding'] === 'true';
     const existingActivityLogId = parsedHeaders['nango-activity-log-id'];
     const isSync = parsedHeaders['nango-is-sync'] === 'true';
     const isDryRun = parsedHeaders['nango-is-dry-run'] === 'true';
@@ -190,7 +190,7 @@ export const allPublicProxy = asyncWrapper<AllPublicProxy>(async (req, res, next
                     method,
                     retryOn,
                     responseType: 'stream',
-                    ...(enableHeaderForwarding !== undefined ? { enableHeaderForwarding } : {})
+                    enableHeaderForwarding
                 },
                 internalConfig
             }).unwrap(),

--- a/packages/server/lib/controllers/proxy/allProxy.ts
+++ b/packages/server/lib/controllers/proxy/allProxy.ts
@@ -47,7 +47,7 @@ const schemaHeaders = z.object({
         .string()
         .regex(/^\d+(,\d+)*$/)
         .optional(),
-    'disable-header-forwarding': z.enum(['true', 'false']).optional(),
+    'enable-header-forwarding': z.enum(['true', 'false']).optional(),
     'nango-activity-log-id': z.string().max(255).optional(),
     'nango-is-sync': z.enum(['true', 'false']).optional(),
     'nango-is-dry-run': z.enum(['true', 'false']).optional()
@@ -72,7 +72,7 @@ export const allPublicProxy = asyncWrapper<AllPublicProxy>(async (req, res, next
     const baseUrlOverride = parsedHeaders['base-url-override'];
     const decompress = parsedHeaders['decompress'] === 'true';
     const retryOn = parsedHeaders['retry-on'] ? parsedHeaders['retry-on'].split(',').map(Number) : null;
-    const disableHeaderForwarding = parsedHeaders['disable-header-forwarding'] === 'true';
+    const enableHeaderForwarding = parsedHeaders['enable-header-forwarding'] === 'true';
     const existingActivityLogId = parsedHeaders['nango-activity-log-id'];
     const isSync = parsedHeaders['nango-is-sync'] === 'true';
     const isDryRun = parsedHeaders['nango-is-dry-run'] === 'true';
@@ -190,7 +190,7 @@ export const allPublicProxy = asyncWrapper<AllPublicProxy>(async (req, res, next
                     method,
                     retryOn,
                     responseType: 'stream',
-                    disableHeaderForwarding
+                    enableHeaderForwarding
                 },
                 internalConfig
             }).unwrap(),

--- a/packages/server/lib/controllers/proxy/allProxy.ts
+++ b/packages/server/lib/controllers/proxy/allProxy.ts
@@ -72,7 +72,7 @@ export const allPublicProxy = asyncWrapper<AllPublicProxy>(async (req, res, next
     const baseUrlOverride = parsedHeaders['base-url-override'];
     const decompress = parsedHeaders['decompress'] === 'true';
     const retryOn = parsedHeaders['retry-on'] ? parsedHeaders['retry-on'].split(',').map(Number) : null;
-    const enableHeaderForwarding = parsedHeaders['enable-header-forwarding'] === 'true';
+    const enableHeaderForwarding = parsedHeaders['enable-header-forwarding'] ? parsedHeaders['enable-header-forwarding'] === 'true' : undefined;
     const existingActivityLogId = parsedHeaders['nango-activity-log-id'];
     const isSync = parsedHeaders['nango-is-sync'] === 'true';
     const isDryRun = parsedHeaders['nango-is-dry-run'] === 'true';
@@ -190,7 +190,7 @@ export const allPublicProxy = asyncWrapper<AllPublicProxy>(async (req, res, next
                     method,
                     retryOn,
                     responseType: 'stream',
-                    enableHeaderForwarding
+                    ...(enableHeaderForwarding !== undefined ? { enableHeaderForwarding } : {})
                 },
                 internalConfig
             }).unwrap(),

--- a/packages/shared/lib/services/proxy/utils.ts
+++ b/packages/shared/lib/services/proxy/utils.ts
@@ -74,7 +74,9 @@ export function getAxiosConfiguration({
         headers
     };
 
-    const shouldForward = proxyConfig.enableHeaderForwarding ?? proxyConfig.provider.proxy?.enable_header_forwarding;
+    // Provider config takes precedence so integrations like Dayforce can enforce header forwarding
+    // regardless of what the caller passes. Falls back to the caller's header (default: false).
+    const shouldForward = proxyConfig.provider.proxy?.enable_header_forwarding ?? proxyConfig.enableHeaderForwarding;
     if (shouldForward) {
         axiosConfig.beforeRedirect = (options: Record<string, any>) => {
             // keep all headers from the original nango request, especially authorization as its dropped with axios follow-redirects
@@ -209,7 +211,7 @@ export function getProxyConfiguration({
         params: externalConfig.params as Record<string, string>, // TODO: fix this
         responseType: externalConfig.responseType,
         retryOn: retryOn && Array.isArray(retryOn) ? retryOn.map(Number) : null,
-        ...(enableHeaderForwarding !== undefined ? { enableHeaderForwarding } : {})
+        enableHeaderForwarding: enableHeaderForwarding ?? false
     };
 
     return Ok(configBody);

--- a/packages/shared/lib/services/proxy/utils.ts
+++ b/packages/shared/lib/services/proxy/utils.ts
@@ -74,7 +74,8 @@ export function getAxiosConfiguration({
         headers
     };
 
-    if (proxyConfig.enableHeaderForwarding || proxyConfig.provider.proxy?.enable_header_forwarding) {
+    const shouldForward = proxyConfig.enableHeaderForwarding ?? proxyConfig.provider.proxy?.enable_header_forwarding;
+    if (shouldForward) {
         axiosConfig.beforeRedirect = (options: Record<string, any>) => {
             // keep all headers from the original nango request, especially authorization as its dropped with axios follow-redirects
             Object.keys(headers).forEach((key) => {
@@ -142,7 +143,7 @@ export function getProxyConfiguration({
     externalConfig: ApplicationConstructedProxyConfiguration | UserProvidedProxyConfiguration;
     internalConfig: InternalProxyConfiguration;
 }): Result<ApplicationConstructedProxyConfiguration, ProxyError> {
-    const { endpoint: passedEndpoint, providerConfigKey, method, retries, headers, baseUrlOverride, retryOn, enableHeaderForwarding = false } = externalConfig;
+    const { endpoint: passedEndpoint, providerConfigKey, method, retries, headers, baseUrlOverride, retryOn, enableHeaderForwarding } = externalConfig;
     const { providerName } = internalConfig;
     let data = externalConfig.data;
 
@@ -208,7 +209,7 @@ export function getProxyConfiguration({
         params: externalConfig.params as Record<string, string>, // TODO: fix this
         responseType: externalConfig.responseType,
         retryOn: retryOn && Array.isArray(retryOn) ? retryOn.map(Number) : null,
-        enableHeaderForwarding
+        ...(enableHeaderForwarding !== undefined ? { enableHeaderForwarding } : {})
     };
 
     return Ok(configBody);

--- a/packages/shared/lib/services/proxy/utils.ts
+++ b/packages/shared/lib/services/proxy/utils.ts
@@ -4,7 +4,7 @@ import * as crypto from 'node:crypto';
 import FormData from 'form-data';
 import OAuth from 'oauth-1.0a';
 
-import { Err, Ok, SIGNATURE_METHOD } from '@nangohq/utils';
+import { Err, Ok, SIGNATURE_METHOD, metrics } from '@nangohq/utils';
 
 import {
     connectionCopyWithParsedConnectionConfig,
@@ -74,19 +74,19 @@ export function getAxiosConfiguration({
         headers
     };
 
-    // Provider config takes precedence so integrations like Dayforce can enforce header forwarding
-    // regardless of what the caller passes. Falls back to the caller's header (default: false).
-    const shouldForward = proxyConfig.provider.proxy?.enable_header_forwarding ?? proxyConfig.enableHeaderForwarding;
-    if (shouldForward) {
-        axiosConfig.beforeRedirect = (options: Record<string, any>) => {
+    // TODO: change default to false after removing the metric below
+    const shouldForward = proxyConfig.forwardHeadersOnRedirect ?? proxyConfig.provider.proxy?.forward_headers_on_redirect ?? true;
+    axiosConfig.beforeRedirect = (options: Record<string, any>) => {
+        metrics.increment(metrics.Types.PROXY_REDIRECT, 1, { provider: proxyConfig.providerName, forwardHeadersOnRedirect: String(shouldForward) });
+        if (shouldForward) {
             // keep all headers from the original nango request, especially authorization as its dropped with axios follow-redirects
             Object.keys(headers).forEach((key) => {
                 if (headers[key]) {
                     options['headers'][key] = headers[key];
                 }
             });
-        };
-    }
+        }
+    };
 
     if (proxyConfig.responseType) {
         axiosConfig.responseType = proxyConfig.responseType;
@@ -145,7 +145,7 @@ export function getProxyConfiguration({
     externalConfig: ApplicationConstructedProxyConfiguration | UserProvidedProxyConfiguration;
     internalConfig: InternalProxyConfiguration;
 }): Result<ApplicationConstructedProxyConfiguration, ProxyError> {
-    const { endpoint: passedEndpoint, providerConfigKey, method, retries, headers, baseUrlOverride, retryOn, enableHeaderForwarding } = externalConfig;
+    const { endpoint: passedEndpoint, providerConfigKey, method, retries, headers, baseUrlOverride, retryOn, forwardHeadersOnRedirect } = externalConfig;
     const { providerName } = internalConfig;
     let data = externalConfig.data;
 
@@ -211,7 +211,7 @@ export function getProxyConfiguration({
         params: externalConfig.params as Record<string, string>, // TODO: fix this
         responseType: externalConfig.responseType,
         retryOn: retryOn && Array.isArray(retryOn) ? retryOn.map(Number) : null,
-        enableHeaderForwarding: enableHeaderForwarding ?? false
+        ...(forwardHeadersOnRedirect !== undefined ? { forwardHeadersOnRedirect } : {})
     };
 
     return Ok(configBody);

--- a/packages/shared/lib/services/proxy/utils.ts
+++ b/packages/shared/lib/services/proxy/utils.ts
@@ -74,7 +74,7 @@ export function getAxiosConfiguration({
         headers
     };
 
-    if (!proxyConfig.disableHeaderForwarding) {
+    if (proxyConfig.enableHeaderForwarding || proxyConfig.provider.proxy?.enable_header_forwarding) {
         axiosConfig.beforeRedirect = (options: Record<string, any>) => {
             // keep all headers from the original nango request, especially authorization as its dropped with axios follow-redirects
             Object.keys(headers).forEach((key) => {
@@ -142,7 +142,7 @@ export function getProxyConfiguration({
     externalConfig: ApplicationConstructedProxyConfiguration | UserProvidedProxyConfiguration;
     internalConfig: InternalProxyConfiguration;
 }): Result<ApplicationConstructedProxyConfiguration, ProxyError> {
-    const { endpoint: passedEndpoint, providerConfigKey, method, retries, headers, baseUrlOverride, retryOn, disableHeaderForwarding = false } = externalConfig;
+    const { endpoint: passedEndpoint, providerConfigKey, method, retries, headers, baseUrlOverride, retryOn, enableHeaderForwarding = false } = externalConfig;
     const { providerName } = internalConfig;
     let data = externalConfig.data;
 
@@ -208,7 +208,7 @@ export function getProxyConfiguration({
         params: externalConfig.params as Record<string, string>, // TODO: fix this
         responseType: externalConfig.responseType,
         retryOn: retryOn && Array.isArray(retryOn) ? retryOn.map(Number) : null,
-        disableHeaderForwarding
+        enableHeaderForwarding
     };
 
     return Ok(configBody);

--- a/packages/shared/lib/services/proxy/utils.ts
+++ b/packages/shared/lib/services/proxy/utils.ts
@@ -77,7 +77,7 @@ export function getAxiosConfiguration({
     // TODO: change default to false after removing the metric below
     const shouldForward = proxyConfig.forwardHeadersOnRedirect ?? proxyConfig.provider.proxy?.forward_headers_on_redirect ?? true;
     axiosConfig.beforeRedirect = (options: Record<string, any>) => {
-        metrics.increment(metrics.Types.PROXY_REDIRECT, 1, { provider: proxyConfig.providerName, forwardHeadersOnRedirect: String(shouldForward) });
+        metrics.increment(metrics.Types.PROXY_REDIRECT, 1, { provider: proxyConfig.providerName });
         if (shouldForward) {
             // keep all headers from the original nango request, especially authorization as its dropped with axios follow-redirects
             Object.keys(headers).forEach((key) => {

--- a/packages/shared/lib/services/proxy/utils.ts
+++ b/packages/shared/lib/services/proxy/utils.ts
@@ -71,16 +71,19 @@ export function getAxiosConfiguration({
     const axiosConfig: AxiosRequestConfig = {
         method: proxyConfig.method,
         url,
-        headers,
-        beforeRedirect: (options: Record<string, any>) => {
+        headers
+    };
+
+    if (!proxyConfig.disableHeaderForwarding) {
+        axiosConfig.beforeRedirect = (options: Record<string, any>) => {
             // keep all headers from the original nango request, especially authorization as its dropped with axios follow-redirects
             Object.keys(headers).forEach((key) => {
                 if (headers[key]) {
                     options['headers'][key] = headers[key];
                 }
             });
-        }
-    };
+        };
+    }
 
     if (proxyConfig.responseType) {
         axiosConfig.responseType = proxyConfig.responseType;
@@ -139,7 +142,7 @@ export function getProxyConfiguration({
     externalConfig: ApplicationConstructedProxyConfiguration | UserProvidedProxyConfiguration;
     internalConfig: InternalProxyConfiguration;
 }): Result<ApplicationConstructedProxyConfiguration, ProxyError> {
-    const { endpoint: passedEndpoint, providerConfigKey, method, retries, headers, baseUrlOverride, retryOn } = externalConfig;
+    const { endpoint: passedEndpoint, providerConfigKey, method, retries, headers, baseUrlOverride, retryOn, disableHeaderForwarding = false } = externalConfig;
     const { providerName } = internalConfig;
     let data = externalConfig.data;
 
@@ -204,7 +207,8 @@ export function getProxyConfiguration({
         decompress: externalConfig.decompress === 'true' || externalConfig.decompress === true,
         params: externalConfig.params as Record<string, string>, // TODO: fix this
         responseType: externalConfig.responseType,
-        retryOn: retryOn && Array.isArray(retryOn) ? retryOn.map(Number) : null
+        retryOn: retryOn && Array.isArray(retryOn) ? retryOn.map(Number) : null,
+        disableHeaderForwarding
     };
 
     return Ok(configBody);

--- a/packages/shared/lib/services/proxy/utils.unit.test.ts
+++ b/packages/shared/lib/services/proxy/utils.unit.test.ts
@@ -979,7 +979,7 @@ describe('buildProxyURL', () => {
 });
 
 describe('getAxiosConfiguration', () => {
-    it('should not set beforeRedirect by default', () => {
+    it('should set beforeRedirect by default (headers are forwarded on redirect by default)', () => {
         const config = getDefaultProxy({
             provider: {
                 auth_mode: 'API_KEY',
@@ -992,16 +992,16 @@ describe('getAxiosConfiguration', () => {
             connection: getTestConnection({ credentials: { type: 'API_KEY', apiKey: 'secret' } })
         });
 
-        expect(axiosConfig.beforeRedirect).toBeUndefined();
+        expect(axiosConfig.beforeRedirect).toBeDefined();
     });
 
-    it('should set beforeRedirect when enableHeaderForwarding is true', () => {
+    it('should set beforeRedirect when forwardHeadersOnRedirect is false (to track metric)', () => {
         const config = getDefaultProxy({
             provider: {
                 auth_mode: 'API_KEY',
                 proxy: { base_url: 'https://api.example.com' }
             },
-            enableHeaderForwarding: true
+            forwardHeadersOnRedirect: false
         });
 
         const axiosConfig = getAxiosConfiguration({

--- a/packages/shared/lib/services/proxy/utils.unit.test.ts
+++ b/packages/shared/lib/services/proxy/utils.unit.test.ts
@@ -979,7 +979,7 @@ describe('buildProxyURL', () => {
 });
 
 describe('getAxiosConfiguration', () => {
-    it('should set beforeRedirect by default', () => {
+    it('should not set beforeRedirect by default', () => {
         const config = getDefaultProxy({
             provider: {
                 auth_mode: 'API_KEY',
@@ -992,16 +992,16 @@ describe('getAxiosConfiguration', () => {
             connection: getTestConnection({ credentials: { type: 'API_KEY', apiKey: 'secret' } })
         });
 
-        expect(axiosConfig.beforeRedirect).toBeDefined();
+        expect(axiosConfig.beforeRedirect).toBeUndefined();
     });
 
-    it('should not set beforeRedirect when disableHeaderForwarding is true', () => {
+    it('should set beforeRedirect when enableHeaderForwarding is true', () => {
         const config = getDefaultProxy({
             provider: {
                 auth_mode: 'API_KEY',
                 proxy: { base_url: 'https://api.example.com' }
             },
-            disableHeaderForwarding: true
+            enableHeaderForwarding: true
         });
 
         const axiosConfig = getAxiosConfiguration({
@@ -1009,7 +1009,7 @@ describe('getAxiosConfiguration', () => {
             connection: getTestConnection({ credentials: { type: 'API_KEY', apiKey: 'secret' } })
         });
 
-        expect(axiosConfig.beforeRedirect).toBeUndefined();
+        expect(axiosConfig.beforeRedirect).toBeDefined();
     });
 });
 

--- a/packages/shared/lib/services/proxy/utils.unit.test.ts
+++ b/packages/shared/lib/services/proxy/utils.unit.test.ts
@@ -1,6 +1,6 @@
 import { describe, expect, it } from 'vitest';
 
-import { ProxyError, buildProxyHeaders, buildProxyURL, getProxyConfiguration } from './utils.js';
+import { ProxyError, buildProxyHeaders, buildProxyURL, getAxiosConfiguration, getProxyConfiguration } from './utils.js';
 import { getDefaultProxy } from './utils.test.js';
 import { getTestConnection } from '../../seeders/connection.seeder.js';
 
@@ -975,6 +975,41 @@ describe('buildProxyURL', () => {
         });
 
         expect(url).toBe('https://my-secret-key.example.com/api/test');
+    });
+});
+
+describe('getAxiosConfiguration', () => {
+    it('should set beforeRedirect by default', () => {
+        const config = getDefaultProxy({
+            provider: {
+                auth_mode: 'API_KEY',
+                proxy: { base_url: 'https://api.example.com' }
+            }
+        });
+
+        const axiosConfig = getAxiosConfiguration({
+            proxyConfig: config,
+            connection: getTestConnection({ credentials: { type: 'API_KEY', apiKey: 'secret' } })
+        });
+
+        expect(axiosConfig.beforeRedirect).toBeDefined();
+    });
+
+    it('should not set beforeRedirect when disableHeaderForwarding is true', () => {
+        const config = getDefaultProxy({
+            provider: {
+                auth_mode: 'API_KEY',
+                proxy: { base_url: 'https://api.example.com' }
+            },
+            disableHeaderForwarding: true
+        });
+
+        const axiosConfig = getAxiosConfiguration({
+            proxyConfig: config,
+            connection: getTestConnection({ credentials: { type: 'API_KEY', apiKey: 'secret' } })
+        });
+
+        expect(axiosConfig.beforeRedirect).toBeUndefined();
     });
 });
 

--- a/packages/types/lib/providers/provider.ts
+++ b/packages/types/lib/providers/provider.ts
@@ -50,6 +50,7 @@ export interface BaseProvider {
         query?: Record<string, string>;
         retry?: RetryHeaderConfig;
         decompress?: boolean;
+        enable_header_forwarding?: boolean;
         paginate?: LinkPagination | CursorPagination | OffsetPagination;
         verification?: {
             method: EndpointMethod;

--- a/packages/types/lib/providers/provider.ts
+++ b/packages/types/lib/providers/provider.ts
@@ -50,7 +50,7 @@ export interface BaseProvider {
         query?: Record<string, string>;
         retry?: RetryHeaderConfig;
         decompress?: boolean;
-        enable_header_forwarding?: boolean;
+        forward_headers_on_redirect?: boolean;
         paginate?: LinkPagination | CursorPagination | OffsetPagination;
         verification?: {
             method: EndpointMethod;

--- a/packages/types/lib/proxy/api.ts
+++ b/packages/types/lib/proxy/api.ts
@@ -28,7 +28,7 @@ export interface BaseProxyConfiguration {
     responseType?: ResponseType | undefined;
     retryHeader?: RetryHeaderConfig;
     retryOn?: number[] | null;
-    enableHeaderForwarding?: boolean;
+    forwardHeadersOnRedirect?: boolean;
 }
 
 export interface UserProvidedProxyConfiguration extends BaseProxyConfiguration {

--- a/packages/types/lib/proxy/api.ts
+++ b/packages/types/lib/proxy/api.ts
@@ -28,7 +28,7 @@ export interface BaseProxyConfiguration {
     responseType?: ResponseType | undefined;
     retryHeader?: RetryHeaderConfig;
     retryOn?: number[] | null;
-    disableHeaderForwarding?: boolean;
+    enableHeaderForwarding?: boolean;
 }
 
 export interface UserProvidedProxyConfiguration extends BaseProxyConfiguration {

--- a/packages/types/lib/proxy/api.ts
+++ b/packages/types/lib/proxy/api.ts
@@ -28,6 +28,7 @@ export interface BaseProxyConfiguration {
     responseType?: ResponseType | undefined;
     retryHeader?: RetryHeaderConfig;
     retryOn?: number[] | null;
+    disableHeaderForwarding?: boolean;
 }
 
 export interface UserProvidedProxyConfiguration extends BaseProxyConfiguration {

--- a/packages/types/lib/proxy/http.api.ts
+++ b/packages/types/lib/proxy/http.api.ts
@@ -13,7 +13,7 @@ export type AllPublicProxy = Endpoint<{
         'base-url-override'?: string | undefined;
         decompress?: string | undefined;
         'retry-on'?: string | undefined;
-        'enable-header-forwarding'?: string | undefined;
+        'forward-headers-on-redirect'?: string | undefined;
         'nango-activity-log-id'?: string | undefined;
         'nango-is-sync'?: string | undefined;
         'nango-is-dry-run'?: string | undefined;

--- a/packages/types/lib/proxy/http.api.ts
+++ b/packages/types/lib/proxy/http.api.ts
@@ -13,7 +13,7 @@ export type AllPublicProxy = Endpoint<{
         'base-url-override'?: string | undefined;
         decompress?: string | undefined;
         'retry-on'?: string | undefined;
-        'disable-header-forwarding'?: string | undefined;
+        'enable-header-forwarding'?: string | undefined;
         'nango-activity-log-id'?: string | undefined;
         'nango-is-sync'?: string | undefined;
         'nango-is-dry-run'?: string | undefined;

--- a/packages/types/lib/proxy/http.api.ts
+++ b/packages/types/lib/proxy/http.api.ts
@@ -13,6 +13,7 @@ export type AllPublicProxy = Endpoint<{
         'base-url-override'?: string | undefined;
         decompress?: string | undefined;
         'retry-on'?: string | undefined;
+        'disable-header-forwarding'?: string | undefined;
         'nango-activity-log-id'?: string | undefined;
         'nango-is-sync'?: string | undefined;
         'nango-is-dry-run'?: string | undefined;

--- a/packages/utils/lib/telemetry/metrics.ts
+++ b/packages/utils/lib/telemetry/metrics.ts
@@ -39,6 +39,7 @@ export enum Types {
     PROXY_FAILURE = 'nango.server.proxy.failure',
     PROXY_INCOMING_PAYLOAD_SIZE_BYTES = 'nango.server.proxy.incoming.payloadSizeBytes',
     PROXY_OUTGOING_PAYLOAD_SIZE_BYTES = 'nango.server.proxy.outgoing.payloadSizeBytes',
+    PROXY_REDIRECT = 'nango.server.proxy.redirect',
 
     CRON_REFRESH_CONNECTIONS = 'nango.server.cron.refreshConnections',
     CRON_REFRESH_CONNECTIONS_FAILED = 'nango.server.cron.refreshConnections.failed',

--- a/scripts/validation/providers/schema.json
+++ b/scripts/validation/providers/schema.json
@@ -217,7 +217,7 @@
                         "decompress": {
                             "type": "boolean"
                         },
-                        "enable_header_forwarding": {
+                        "forward_headers_on_redirect": {
                             "type": "boolean"
                         },
                         "headers": {

--- a/scripts/validation/providers/schema.json
+++ b/scripts/validation/providers/schema.json
@@ -217,6 +217,9 @@
                         "decompress": {
                             "type": "boolean"
                         },
+                        "enable_header_forwarding": {
+                            "type": "boolean"
+                        },
                         "headers": {
                             "type": "object",
                             "additionalProperties": false,


### PR DESCRIPTION
## Describe the problem and your solution

- This feature was originally added to support dayforce, which required authorization headers to be forwarded during redirects. We now provide a flag in `proxyConfig` that allows customers to disable header forwarding for redirects.

- Use case: In hibob, when users request file downloads, the API returns a HiBob download URL that issues a HTTP redirect to an amazon s3 signed url. Passing the Authorization header to this redirected URL results in an error, as signed urls are pre-authorized and do not accept additional authorization headers.

<!-- Issue ticket number and link (if applicable) -->

<!-- Testing instructions (skip if just adding/editing providers) -->


<!-- Summary by @propel-code-bot -->

---

**Add `forwardHeadersOnRedirect` proxy flag with metrics and provider support**

This PR adds a configurable `forwardHeadersOnRedirect` option to proxy configuration, allowing callers to disable forwarding headers when `axios` follows redirects while preserving the existing default behavior. The flag is wired through public proxy headers, internal proxy configuration construction, `axios` setup, and type definitions, with a new `PROXY_REDIRECT` metric emitted on redirects.

Provider schema validation and provider configs are extended to support a provider-level default (`forward_headers_on_redirect`), and SDK/CLI surfaces are updated to send/ignore the new header. Unit tests and snapshots are adjusted to reflect the new configuration flow and `axios` behavior.

---
*This summary was automatically generated by @propel-code-bot*