### PR TITLE
fix(lambda): use node.provisionedConcurrency as the max for the auto-scaling

### DIFF
--- a/packages/jobs/lib/runner/lambda.ts
+++ b/packages/jobs/lib/runner/lambda.ts
@@ -130,13 +130,15 @@ class Lambda {
                     );
                 }
                 const resourceId = `function:${pvResult.FunctionName}:${envs.LAMBDA_FUNCTION_ALIAS}`;
+                const minCapacity = envs.LAMBDA_MINIMUM_PROVISIONED_CONCURRENCY;
+                const maxCapacity = Math.max(minCapacity, node.provisionedConcurrency || envs.LAMBDA_MAXIMUM_PROVISIONED_CONCURRENCY);
                 await applicationAutoScalingClient.send(
                     new RegisterScalableTargetCommand({
                         ServiceNamespace: 'lambda',
                         ScalableDimension: 'lambda:function:ProvisionedConcurrency',
                         ResourceId: resourceId,
-                        MinCapacity: envs.LAMBDA_MINIMUM_PROVISIONED_CONCURRENCY,
-                        MaxCapacity: node.provisionedConcurrency || envs.LAMBDA_MAXIMUM_PROVISIONED_CONCURRENCY
+                        MinCapacity: minCapacity,
+                        MaxCapacity: maxCapacity
                     })
                 );
                 await applicationAutoScalingClient.send(

--- a/packages/jobs/lib/runner/lambda.ts
+++ b/packages/jobs/lib/runner/lambda.ts
@@ -135,8 +135,8 @@ class Lambda {
                         ServiceNamespace: 'lambda',
                         ScalableDimension: 'lambda:function:ProvisionedConcurrency',
                         ResourceId: resourceId,
-                        MinCapacity: node.provisionedConcurrency || envs.LAMBDA_PROVISIONED_CONCURRENCY,
-                        MaxCapacity: (node.provisionedConcurrency || envs.LAMBDA_PROVISIONED_CONCURRENCY) * 10
+                        MinCapacity: envs.LAMBDA_MINIMUM_PROVISIONED_CONCURRENCY,
+                        MaxCapacity: node.provisionedConcurrency || envs.LAMBDA_MAXIMUM_PROVISIONED_CONCURRENCY
                     })
                 );
                 await applicationAutoScalingClient.send(
@@ -236,7 +236,7 @@ export const lambdaNodeProvider: NodeProvider = {
         isProfilingEnabled: false,
         idleMaxDurationMs: 0,
         executionTimeoutSecs: envs.LAMBDA_EXECUTION_TIMEOUT_SECS,
-        provisionedConcurrency: envs.LAMBDA_PROVISIONED_CONCURRENCY,
+        provisionedConcurrency: envs.LAMBDA_MAXIMUM_PROVISIONED_CONCURRENCY,
         replicas: 1
     },
     start: async (node: Node) => {

--- a/packages/utils/lib/environment/parse.ts
+++ b/packages/utils/lib/environment/parse.ts
@@ -424,7 +424,8 @@ export const ENVS = z.object({
     LAMBDA_EXECUTION_INTERRUPT_AFTER_MULTIPLIER: z.coerce.number().optional().default(0.8), // interrupt execution after 80% of the timeout, to leave time for checkpointing and graceful shutdown
     LAMBDA_EXECUTION_KILL_AFTER_MULTIPLIER: z.coerce.number().optional().default(0.95), // force kill the lambda after 95% of the timeout, to allow for runner-controlled shutdown
     LAMBDA_FUNCTION_ALIAS: z.string().optional().default('latest'),
-    LAMBDA_PROVISIONED_CONCURRENCY: z.coerce.number().optional().default(1),
+    LAMBDA_MINIMUM_PROVISIONED_CONCURRENCY: z.coerce.number().optional().default(1),
+    LAMBDA_MAXIMUM_PROVISIONED_CONCURRENCY: z.coerce.number().optional().default(50),
     LAMBDA_PROVISIONED_CONCURRENCY_SCALING_TARGET: z.coerce.number().optional().default(0.7),
     LAMBDA_FAILURE_DESTINATION: z.string().optional(),
     LAMBDA_PAYLOADS_BUCKET_NAME: z.string().optional(),


### PR DESCRIPTION
We currently use the configured concurrency as the minimum and then use a multiplier (10) to determine the max. This PR changes that to use the configured concurrency as the maximum and use an env var for the minimum. This is easier to configure and reason about.

<!-- Summary by @propel-code-bot -->

---

It also introduces a safeguard to ensure the maximum is never below the minimum and aligns the default node configuration to use the new maximum concurrency env var.

---
*This summary was automatically generated by @propel-code-bot*