### PR TITLE
fix(lambda): retrieve providers on invocation

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -33876,6 +33876,7 @@
                 "@nangohq/kvstore": "file:../kvstore",
                 "@nangohq/node": "file:../node-client",
                 "@nangohq/runner": "file:../runner",
+                "@nangohq/shared": "file:../shared",
                 "@nangohq/types": "file:../types",
                 "@nangohq/utils": "file:../utils",
                 "datadog-lambda-js": "12.130.0",

--- a/packages/lambda-runner/lib/index.ts
+++ b/packages/lambda-runner/lib/index.ts
@@ -4,6 +4,7 @@ import { DeleteObjectCommand, GetObjectCommand, S3Client } from '@aws-sdk/client
 
 import { getKVStore, getLocking } from '@nangohq/kvstore';
 import { KVLocks, abortCheckIntervalMs, exec, heartbeatIntervalMs, jobsClient } from '@nangohq/runner';
+import { loadProviders } from '@nangohq/shared';
 import { getLogger } from '@nangohq/utils';
 
 import { requestSchema } from './schemas.js';
@@ -154,6 +155,7 @@ export const handler = async (event: zod.infer<typeof requestSchema>, context: C
         if (code === '') {
             throw new Error('No code found');
         }
+        await loadProviders();
         const payload = {
             nangoProps: { ...nangoProps, host: getNangoHost() },
             code,

--- a/packages/lambda-runner/package.json
+++ b/packages/lambda-runner/package.json
@@ -20,6 +20,7 @@
         "@nangohq/kvstore": "file:../kvstore",
         "@nangohq/node": "file:../node-client",
         "@nangohq/runner": "file:../runner",
+        "@nangohq/shared": "file:../shared",
         "@nangohq/types": "file:../types",
         "@nangohq/utils": "file:../utils",
         "datadog-lambda-js": "12.130.0",

--- a/packages/lambda-runner/tsconfig.json
+++ b/packages/lambda-runner/tsconfig.json
@@ -15,6 +15,9 @@
             "path": "../utils"
         },
         {
+            "path": "../shared"
+        },
+        {
             "path": "../kvstore"
         }
     ]

--- a/packages/shared/lib/services/providers.ts
+++ b/packages/shared/lib/services/providers.ts
@@ -17,6 +17,24 @@ const envs = parseEnvs(ENVS);
 let polling = false;
 let providersHash = '';
 
+async function loadAndCacheProviders(providersUrl: string): Promise<void> {
+    const providersRaw = await fetchProvidersRaw(providersUrl);
+    providersHash = createHash('sha1').update(providersRaw).digest('hex');
+
+    updateProviderCache(JSON.parse(providersRaw) as Record<string, Provider>);
+    logger.info(`Providers loaded from url ${providersUrl} (${providersHash})`);
+}
+
+export async function loadProviders(): Promise<void> {
+    const providersUrl = envs.PROVIDERS_URL;
+
+    // fall back to standard disk loading if no URL is provided
+    if (!providersUrl) {
+        return;
+    }
+    return loadAndCacheProviders(providersUrl);
+}
+
 // Monitors for changes to providers over HTTP. Returns a function to clean up
 // the monitoring.
 export async function monitorProviders(): Promise<() => void> {
@@ -27,11 +45,7 @@ export async function monitorProviders(): Promise<() => void> {
         return () => null;
     }
 
-    const providersRaw = await fetchProvidersRaw(providersUrl);
-    providersHash = createHash('sha1').update(providersRaw).digest('hex');
-
-    updateProviderCache(JSON.parse(providersRaw) as Record<string, Provider>);
-    logger.info(`Providers loaded from url ${providersUrl} (${providersHash})`);
+    await loadAndCacheProviders(providersUrl);
 
     void pollProviders(providersUrl);
 


### PR DESCRIPTION
<!-- Describe the problem and your solution --> 

<!-- Issue ticket number and link (if applicable) -->

<!-- Testing instructions (skip if just adding/editing providers) -->


<!-- Summary by @propel-code-bot -->

---

**Ensure Lambda loads providers at invocation**

Adds a provider loading helper to `packages/shared/lib/services/providers.ts` and calls it from the Lambda runner before executing code, ensuring providers are fetched from `ENVS.PROVIDERS_URL` on each invocation. Updates `packages/lambda-runner` dependencies and TypeScript references to include `@nangohq/shared`.

---
*This summary was automatically generated by @propel-code-bot*