### PR TITLE
fix(lambda): catch error when loading providers

### DIFF
--- a/packages/lambda-runner/lib/index.ts
+++ b/packages/lambda-runner/lib/index.ts
@@ -155,7 +155,11 @@ export const handler = async (event: zod.infer<typeof requestSchema>, context: C
         if (code === '') {
             throw new Error('No code found');
         }
-        await loadProviders();
+        try {
+            await loadProviders();
+        } catch (err) {
+            logger.error('Error loading providers', { error: err });
+        }
         const payload = {
             nangoProps: { ...nangoProps, host: getNangoHost() },
             code,


### PR DESCRIPTION
<!-- Describe the problem and your solution --> 

<!-- Issue ticket number and link (if applicable) -->

<!-- Testing instructions (skip if just adding/editing providers) -->


<!-- Summary by @propel-code-bot -->

---

**Handle `loadProviders` errors in lambda runner**

This PR wraps `loadProviders()` in a try/catch to prevent provider-loading failures from aborting the lambda execution. Errors are now logged via `logger.error` while allowing the function to continue building the payload.

---
*This summary was automatically generated by @propel-code-bot*