### PR TITLE
feat: only run checkpointed syncs on lambda

### DIFF
--- a/packages/jobs/lib/execution/action.ts
+++ b/packages/jobs/lib/execution/action.ts
@@ -161,7 +161,8 @@ export async function startAction(task: TaskAction): Promise<Result<void>> {
         };
 
         const routingContext: RoutingContext = {
-            plan: plan
+            plan: plan,
+            features: syncConfig.features
         };
 
         const res = await startScript({

--- a/packages/jobs/lib/execution/onEvent.ts
+++ b/packages/jobs/lib/execution/onEvent.ts
@@ -131,7 +131,8 @@ export async function startOnEvent(task: TaskOnEvent): Promise<Result<void>> {
         };
 
         const routingContext: RoutingContext = {
-            plan: plan
+            plan: plan,
+            features: []
         };
 
         const res = await startScript({

--- a/packages/jobs/lib/execution/sync.ts
+++ b/packages/jobs/lib/execution/sync.ts
@@ -216,7 +216,8 @@ export async function startSync(task: TaskSync, startScriptFn = startScript): Pr
         };
 
         const routingContext: RoutingContext = {
-            plan: plan
+            plan: plan,
+            features: syncConfig.features
         };
 
         if (task.debug) {

--- a/packages/jobs/lib/execution/webhook.ts
+++ b/packages/jobs/lib/execution/webhook.ts
@@ -170,7 +170,8 @@ export async function startWebhook(task: TaskWebhook): Promise<Result<void>> {
         };
 
         const routingContext: RoutingContext = {
-            plan: plan
+            plan: plan,
+            features: []
         };
 
         const res = await startScript({

--- a/packages/jobs/lib/runtime/runtimes.rules.ts
+++ b/packages/jobs/lib/runtime/runtimes.rules.ts
@@ -24,6 +24,11 @@ export async function getFleetId({
     const runtime = runtimeSelectors[nangoProps.scriptType](routingContext.plan);
     switch (runtime) {
         case 'lambda':
+            // syncs that are not checkpointed are still run on runner fleet
+            // making sure that only syncs that can be safely interrupted/resumed are run on lambda fleet
+            if (nangoProps.scriptType === 'sync' && !routingContext.features.includes('checkpoints')) {
+                return Promise.resolve(Ok(envs.RUNNER_FLEET_ID));
+            }
             return Promise.resolve(Ok(envs.RUNNER_LAMBDA_FLEET_ID));
         default:
             return Promise.resolve(Ok(envs.RUNNER_FLEET_ID));

--- a/packages/jobs/lib/utils/lambda.unit.test.ts
+++ b/packages/jobs/lib/utils/lambda.unit.test.ts
@@ -39,7 +39,8 @@ describe('getRoutingId', () => {
 
     it('uses fleet_node_routing_override when provided in routingContext.plan', () => {
         const routingContext: RoutingContext = {
-            plan: { fleet_node_routing_override: 'custom-override' } as RoutingContext['plan']
+            plan: { fleet_node_routing_override: 'custom-override' } as RoutingContext['plan'],
+            features: []
         };
         const result = getRoutingId({
             nangoProps: minimalNangoProps(),
@@ -56,14 +57,15 @@ describe('getRoutingId', () => {
     it('uses LAMBDA_DEFAULT_PREFIX when routingContext.plan is null', () => {
         const result = getRoutingId({
             nangoProps: minimalNangoProps(),
-            routingContext: { plan: null }
+            routingContext: { plan: null, features: [] }
         });
         expect(result).toBe('default-prefix-S');
     });
 
     it('uses LAMBDA_DEFAULT_PREFIX when plan.fleet_node_routing_override is null', () => {
         const routingContext: RoutingContext = {
-            plan: { fleet_node_routing_override: null } as RoutingContext['plan']
+            plan: { fleet_node_routing_override: null } as RoutingContext['plan'],
+            features: []
         };
         const result = getRoutingId({
             nangoProps: minimalNangoProps(),

--- a/packages/types/lib/runner/index.ts
+++ b/packages/types/lib/runner/index.ts
@@ -1,6 +1,7 @@
 import type { TelemetryBag } from './sdk.js';
 import type { CheckpointRange } from '../checkpoint/types.js';
 import type { DBPlan } from '../plans/db.js';
+import type { Feature } from '../syncConfigs/db.js';
 
 export interface RunnerOutputError {
     type: string;
@@ -27,4 +28,5 @@ export interface RunnerFlags {
 
 export interface RoutingContext {
     plan: DBPlan | null;
+    features: Feature[];
 }


### PR DESCRIPTION
Adding a runtime routing rule to check for the features used by a function and only route a sync if it is using checkpoints in order to ensure long running execution can be safely interrupted and resumed.

I am planning to ramp up slowly one account at a time, until we gain enough confidence to route all checkpointed syncs to lambda.

Note: features are populated at deploy time, so we need to wait for customers to upgrade the CLI and deploy in order to make full use of it. So ramping up isn't gonna be immediate.


<!-- Describe the problem and your solution --> 

<!-- Issue ticket number and link (if applicable) -->

<!-- Testing instructions (skip if just adding/editing providers) -->


<!-- Summary by @propel-code-bot -->

---

It also ensures non-checkpointed syncs remain on the runner fleet even when the plan runtime is lambda, and broadens the routing context to carry feature data across execution paths.

---
*This summary was automatically generated by @propel-code-bot*