### PR TITLE
fix(webapp): embed auth link in getting started

### DIFF
--- a/packages/webapp/src/pages/GettingStarted/Show.tsx
+++ b/packages/webapp/src/pages/GettingStarted/Show.tsx
@@ -135,7 +135,7 @@ export const GettingStarted: React.FC = () => {
 
                     <div className="flex flex-col gap-5">
                         <DocCard
-                            to="https://nango.dev/docs/getting-started/quickstart/embed-in-your-app"
+                            to="https://nango.dev/docs/implementation-guides/platform/auth/implement-api-auth"
                             icon={CodeXml}
                             title="Embed in your app"
                             description="Let your users authorize 3rd-party APIs seamlessly."


### PR DESCRIPTION
<!-- Summary by @propel-code-bot -->

**Fix Getting Started embed auth documentation link**

This PR updates the documentation link for the “Embed in your app” card in the Getting Started page. The change replaces the previous quickstart URL with the new implementation guide path.

---
*This summary was automatically generated by @propel-code-bot*