### PR TITLE
fix(orch): enforce max amount of queued tasks

### DIFF
--- a/packages/scheduler/lib/models/tasks.integration.test.ts
+++ b/packages/scheduler/lib/models/tasks.integration.test.ts
@@ -9,6 +9,22 @@ import { taskStates } from '../types.js';
 import type { Task, TaskState } from '../types.js';
 import type { knex } from 'knex';
 
+const props = {
+    name: 'Test Task',
+    payload: { foo: 'bar' },
+    groupKey: nanoid(),
+    groupMaxConcurrency: 0,
+    retryMax: 3,
+    retryCount: 1,
+    startsAfter: new Date(),
+    createdToStartedTimeoutSecs: 10,
+    startedToCompletedTimeoutSecs: 20,
+    heartbeatTimeoutSecs: 5,
+    scheduleId: null,
+    retryKey: '00000000-0000-0000-0000-000000000000',
+    ownerKey: 'ownerA'
+};
+
 describe('Task', () => {
     const dbClient = getTestDbClient();
     const db = dbClient.db;
@@ -21,21 +37,6 @@ describe('Task', () => {
     });
 
     it('should be successfully created', async () => {
-        const props = {
-            name: 'Test Task',
-            payload: { foo: 'bar' },
-            groupKey: nanoid(),
-            groupMaxConcurrency: 0,
-            retryMax: 3,
-            retryCount: 1,
-            startsAfter: new Date(),
-            createdToStartedTimeoutSecs: 10,
-            startedToCompletedTimeoutSecs: 20,
-            heartbeatTimeoutSecs: 5,
-            scheduleId: null,
-            retryKey: '00000000-0000-0000-0000-000000000000',
-            ownerKey: 'ownerA'
-        };
         const task = (await tasks.create(db, props)).unwrap();
         expect(task).toMatchObject({
             id: expect.any(String),
@@ -58,6 +59,16 @@ describe('Task', () => {
             retryKey: props.retryKey,
             ownerKey: props.ownerKey
         });
+    });
+    it('should fail to create if more than cap', async () => {
+        const groupTaskCap = 1;
+        // first task should be created successfully
+        const t1 = await tasks.create(db, { ...props, name: 'Not capped' }, { groupTaskCap });
+        expect(t1.isOk()).toBe(true);
+
+        // second task with the same group key should fail
+        const t2 = await tasks.create(db, { ...props, name: 'Capped' }, { groupTaskCap });
+        expect(t2.isErr()).toBe(true);
     });
     it('should have their heartbeat updated', async () => {
         const t = await startTask(db);

--- a/packages/scheduler/lib/models/tasks.ts
+++ b/packages/scheduler/lib/models/tasks.ts
@@ -4,6 +4,7 @@ import { Err, Ok, stringToHash, stringifyError } from '@nangohq/utils';
 
 import { taskStates } from '../types.js';
 import { SCHEDULES_TABLE } from './schedules.js';
+import { envs } from '../env.js';
 
 import type { Task, TaskNonTerminalState, TaskState, TaskTerminalState } from '../types.js';
 import type { Result } from '@nangohq/utils';
@@ -120,13 +121,18 @@ export const DbTask = {
     }
 };
 
-export async function create(db: knex.Knex, taskProps: TaskProps): Promise<Result<Task>> {
+export async function create(
+    db: knex.Knex,
+    taskProps: TaskProps,
+    opts: { groupTaskCap: number } = { groupTaskCap: envs.ORCHESTRATOR_TASK_CREATED_PER_GROUP_COUNT_MAX }
+): Promise<Result<Task>> {
     const now = new Date();
+    const state = 'CREATED';
     const newTask: Task = {
         ...taskProps,
         id: uuidv7(),
+        state,
         createdAt: now,
-        state: 'CREATED',
         lastStateTransitionAt: now,
         lastHeartbeatAt: now,
         terminated: false,
@@ -135,6 +141,13 @@ export async function create(db: knex.Knex, taskProps: TaskProps): Promise<Resul
         retryKey: taskProps.retryKey || uuidv4()
     };
     try {
+        // safeguard to prevent creating an unbounded number of tasks for the same group
+        // Note: check and insertion are not atomic so creating more tasks than the limit is still possible but this is a safeguard, not a strict limit
+        const [{ count }] = await db.from(TASKS_TABLE).where({ state, group_key: taskProps.groupKey }).count();
+        if (Number(count) >= opts.groupTaskCap) {
+            return Err(new Error(`Error creating task '${taskProps.name}': already ${opts.groupTaskCap} ${state} tasks for group key '${taskProps.groupKey}'`));
+        }
+
         const inserted = await db.from<DBTask>(TASKS_TABLE).insert(DbTask.to(newTask)).returning('*');
         if (!inserted?.[0]) {
             return Err(new Error(`Error: no task '${taskProps.name}' created`));

--- a/packages/utils/lib/environment/parse.ts
+++ b/packages/utils/lib/environment/parse.ts
@@ -80,6 +80,7 @@ export const ENVS = z.object({
     ORCHESTRATOR_CLEANING_OLDER_THAN_DAYS: z.coerce.number().optional().default(5),
     ORCHESTRATOR_SCHEDULING_TICK_INTERVAL_MS: z.coerce.number().optional().default(100),
     ORCHESTRATOR_TASK_CREATED_EVENT_DEBOUNCE_MS: z.coerce.number().optional().default(100),
+    ORCHESTRATOR_TASK_CREATED_PER_GROUP_COUNT_MAX: z.coerce.number().optional().default(10_000),
     ORCHESTRATOR_DB_SSL: z.stringbool().optional().default(false),
 
     // Jobs


### PR DESCRIPTION
Enforcing an upper bound limit of tasks in CREATED tasks for a given group in order to protect the orchestrator from a sudden surge of tasks creation. 
We assume that if the cap is reached something else is going wrong and that tasks cannot be dequeued and processed fast enough. Hence discarding the tasks instead of cascading failures.
This is only a safeguard mechanism, not a strict limit.

<!-- Describe the problem and your solution --> 

<!-- Issue ticket number and link (if applicable) -->

<!-- Testing instructions (skip if just adding/editing providers) -->


<!-- Summary by @propel-code-bot -->

---

The safeguard is configurable via an environment variable and is enforced during `tasks.create`, returning an error when the per-group `CREATED` task cap is reached.

---
*This summary was automatically generated by @propel-code-bot*