### PR TITLE
fix(sync): improve error handling and operation logging for sync commands

### DIFF
--- a/packages/server/lib/controllers/sync/postSyncPause.ts
+++ b/packages/server/lib/controllers/sync/postSyncPause.ts
@@ -2,7 +2,7 @@ import * as z from 'zod';
 
 import { logContextGetter } from '@nangohq/logs';
 import { records as recordsService } from '@nangohq/records';
-import { SyncCommand, normalizedSyncParams, syncManager } from '@nangohq/shared';
+import { SyncCommand, errorManager, normalizedSyncParams, syncManager } from '@nangohq/shared';
 import { zodErrorToHTTP } from '@nangohq/utils';
 
 import { connectionIdSchema, providerConfigKeySchema } from '../../helpers/validation.js';
@@ -51,7 +51,7 @@ export const postPublicSyncPause = asyncWrapper<PostPublicSyncPause>(async (req,
         initiator: 'API call'
     });
     if (!resSyncCommand.success) {
-        res.status(500).send({ error: { code: 'server_error', message: 'failed to pause syncs', errors: [resSyncCommand.error!] } });
+        errorManager.errResFromNangoErr(res, resSyncCommand.error);
         return;
     }
 

--- a/packages/server/lib/controllers/sync/postSyncStart.ts
+++ b/packages/server/lib/controllers/sync/postSyncStart.ts
@@ -2,7 +2,7 @@ import * as z from 'zod';
 
 import { logContextGetter } from '@nangohq/logs';
 import { records as recordsService } from '@nangohq/records';
-import { SyncCommand, normalizedSyncParams, syncManager } from '@nangohq/shared';
+import { SyncCommand, errorManager, normalizedSyncParams, syncManager } from '@nangohq/shared';
 import { zodErrorToHTTP } from '@nangohq/utils';
 
 import { connectionIdSchema, providerConfigKeySchema } from '../../helpers/validation.js';
@@ -51,7 +51,7 @@ export const postPublicSyncStart = asyncWrapper<PostPublicSyncStart>(async (req,
         initiator: 'API call'
     });
     if (!resSyncCommand.success) {
-        res.status(500).send({ error: { code: 'server_error', message: 'failed to start syncs', errors: [resSyncCommand.error!] } });
+        errorManager.errResFromNangoErr(res, resSyncCommand.error);
         return;
     }
 

--- a/packages/shared/lib/services/sync/manager.service.ts
+++ b/packages/shared/lib/services/sync/manager.service.ts
@@ -272,27 +272,30 @@ export class SyncManagerService {
         deleteRecords?: boolean;
     }): Promise<ServiceResponse<boolean>> {
         const provider = await configService.getProviderConfig(providerConfigKey, environment.id); // Todo: pass provider as argument as it's most likely already loaded
-        if (!provider) {
+        if (!provider || !provider.id) {
             return { success: false, error: new NangoError('unknown_provider_config'), response: false };
         }
 
         const account = (await accountService.getAccountFromEnvironment(environment.id))!; // Todo: pass account as argument as it's most likely already loaded
 
-        const logCtx = await logContextGetter.create(
-            { operation: { type: 'sync', action: syncCommandToOperation[command] } },
-            { account, environment, integration: { id: provider.id!, name: provider.unique_key, provider: provider.provider } }
-        );
+        let logCtx: Awaited<ReturnType<LogContextGetter['create']>>;
 
         if (connectionId) {
             const { success, error, response: connection } = await connectionService.getConnection(connectionId, providerConfigKey, environment.id);
 
             if (!success || !connection) {
-                void logCtx.error(error?.message || 'Connection not found', { error });
-                await logCtx.failed();
                 return { success: false, error, response: false };
             }
 
-            await logCtx.enrichOperation({ connectionId: connection.id, connectionName: connection.connection_id });
+            logCtx = await logContextGetter.create(
+                { operation: { type: 'sync', action: syncCommandToOperation[command] } },
+                {
+                    account,
+                    environment,
+                    integration: { id: provider.id, name: provider.unique_key, provider: provider.provider },
+                    connection: { id: connection.id, name: connection.connection_id }
+                }
+            );
 
             let syncs = syncIdentifiers;
 
@@ -307,7 +310,7 @@ export class SyncManagerService {
             for (const { syncName, syncVariant } of syncs) {
                 const sync = await getSync({ connectionId: connection.id, name: syncName, variant: syncVariant });
                 if (!sync) {
-                    void logCtx.error(`Sync "${syncName}" doesn't exist.`);
+                    void logCtx.error(`Sync "${syncName}" (variant: "${syncVariant}") doesn't exist.`);
                     await logCtx.failed();
                     return { success: false, error: new NangoError('no_syncs_found'), response: false };
                 }
@@ -326,11 +329,16 @@ export class SyncManagerService {
                 });
             }
         } else {
+            logCtx = await logContextGetter.create(
+                { operation: { type: 'sync', action: syncCommandToOperation[command] } },
+                { account, environment, integration: { id: provider.id, name: provider.unique_key, provider: provider.provider } }
+            );
+
             const syncs = await getSyncsByProviderConfigKey({ environmentId: environment.id, providerConfigKey, filter: syncIdentifiers });
 
             if (!syncs || syncs.length === 0) {
                 const error = new NangoError('no_syncs_found');
-                void logCtx.error('No syncs found for the provided params', { error });
+                void logCtx.error('No syncs found', { syncIdentifiers });
                 await logCtx.failed();
                 return { success: false, error, response: false };
             }

--- a/packages/shared/lib/services/sync/manager.service.ts
+++ b/packages/shared/lib/services/sync/manager.service.ts
@@ -272,19 +272,27 @@ export class SyncManagerService {
         deleteRecords?: boolean;
     }): Promise<ServiceResponse<boolean>> {
         const provider = await configService.getProviderConfig(providerConfigKey, environment.id); // Todo: pass provider as argument as it's most likely already loaded
+        if (!provider) {
+            return { success: false, error: new NangoError('unknown_provider_config'), response: false };
+        }
+
         const account = (await accountService.getAccountFromEnvironment(environment.id))!; // Todo: pass account as argument as it's most likely already loaded
 
         const logCtx = await logContextGetter.create(
             { operation: { type: 'sync', action: syncCommandToOperation[command] } },
-            { account, environment, integration: { id: provider!.id!, name: provider!.unique_key, provider: provider!.provider } }
+            { account, environment, integration: { id: provider.id!, name: provider.unique_key, provider: provider.provider } }
         );
 
         if (connectionId) {
             const { success, error, response: connection } = await connectionService.getConnection(connectionId, providerConfigKey, environment.id);
 
             if (!success || !connection) {
+                void logCtx.error(error?.message || 'Connection not found', { error });
+                await logCtx.failed();
                 return { success: false, error, response: false };
             }
+
+            await logCtx.enrichOperation({ connectionId: connection.id, connectionName: connection.connection_id });
 
             let syncs = syncIdentifiers;
 
@@ -299,7 +307,9 @@ export class SyncManagerService {
             for (const { syncName, syncVariant } of syncs) {
                 const sync = await getSync({ connectionId: connection.id, name: syncName, variant: syncVariant });
                 if (!sync) {
-                    throw new Error(`Sync "${syncName}" doesn't exists.`); // Todo: return this error instead of throwing
+                    void logCtx.error(`Sync "${syncName}" doesn't exist.`);
+                    await logCtx.failed();
+                    return { success: false, error: new NangoError('no_syncs_found'), response: false };
                 }
 
                 await orchestrator.runSyncCommand({
@@ -320,7 +330,8 @@ export class SyncManagerService {
 
             if (!syncs || syncs.length === 0) {
                 const error = new NangoError('no_syncs_found');
-
+                void logCtx.error('No syncs found for the provided params', { error });
+                await logCtx.failed();
                 return { success: false, error, response: false };
             }
 

--- a/packages/types/lib/sync/api.ts
+++ b/packages/types/lib/sync/api.ts
@@ -19,7 +19,7 @@ export type PostPublicTrigger = Endpoint<{
         'connection-id'?: string | undefined;
     };
     Success: { success: boolean };
-    Error: ApiError<'missing_provider_config_key'>;
+    Error: ApiError<'missing_provider_config_key' | 'unknown_provider_config' | 'unknown_connection' | 'no_syncs_found'>;
 }>;
 
 export type PostSyncVariant = Endpoint<{
@@ -77,6 +77,7 @@ export type PostPublicSyncPause = Endpoint<{
         connection_id?: string | undefined;
     };
     Success: { success: boolean };
+    Error: ApiError<'no_syncs_found' | 'unknown_connection' | 'unknown_provider_config'>;
 }>;
 
 export type PostPublicSyncStart = Endpoint<{
@@ -88,6 +89,7 @@ export type PostPublicSyncStart = Endpoint<{
         connection_id?: string | undefined;
     };
     Success: { success: boolean };
+    Error: ApiError<'no_syncs_found' | 'unknown_connection' | 'unknown_provider_config'>;
 }>;
 
 export type GetPublicSyncStatus = Endpoint<{


### PR DESCRIPTION
## Describe the problem and your solution

**Fix some few issues with the various sync commands**
- Silent crash on unknown integration
- ConnectionId missing from operation details in the nango logs
- Incomplete error types 
- Swallowed error codes that returned `server_error` instead of forwarding the actual typed error
- Operation log contexts were never closed in error paths, leaving them stuck in a running state


<!-- Issue ticket number and link (if applicable) -->

<!-- Testing instructions (skip if just adding/editing providers) -->


<!-- Summary by @propel-code-bot -->

---

It also formalizes typed error responses via the shared error handler and updates the sync API typings to align with the new error behavior.

---
*This summary was automatically generated by @propel-code-bot*