### PR TITLE
fix(webapp): NAN-4720: prevent spaces on connection tags

### DIFF
--- a/packages/webapp/src/components-v2/KeyValueInput.tsx
+++ b/packages/webapp/src/components-v2/KeyValueInput.tsx
@@ -75,8 +75,8 @@ export const KeyValueInput: React.FC<KeyValueInputProps> = ({
     const onUpdate = (field: 'key' | 'value', value: string, index: number) => {
         setPairs((prev) => {
             const copy = prev.map((p) => ({ ...p }));
-            copy[index][field] = value;
-            if (copy.length === index + 1 && value !== '') {
+            copy[index][field] = field === 'key' ? value.replace(/\s/g, '') : value;
+            if (copy.length === index + 1 && copy[index][field] !== '') {
                 copy.push({ id: generateId(), key: '', value: '' });
             }
             return copy;


### PR DESCRIPTION
<!-- Describe the problem and your solution --> 
Prevent inputting spaces into connection tags and env variable names
<!-- Issue ticket number and link (if applicable) -->

<!-- Testing instructions (skip if just adding/editing providers) -->


<!-- Summary by @propel-code-bot -->

---

**Prevent whitespace in `KeyValueInput` keys**

This PR updates `KeyValueInput` to strip whitespace from key fields on update, preventing spaces in connection tags and environment variable names. It also uses the sanitized key value when determining whether to append a new empty row.

---
*This summary was automatically generated by @propel-code-bot*