### PR TITLE
fix(connect-ui): restore client secret field for providers that use OAUTH2_CC and define custom credentials

### DIFF
--- a/packages/connect-ui/src/views/Go.tsx
+++ b/packages/connect-ui/src/views/Go.tsx
@@ -149,10 +149,7 @@ export const Go: React.FC = () => {
             if ((name === 'client_certificate' || name === 'client_private_key') && provider.require_client_certificate !== true) {
                 continue;
             }
-            if (
-                name === 'client_secret' &&
-                (provider.token_request_auth_method === 'private_key_jwt' || (provider.credentials && !('client_secret' in provider.credentials)))
-            ) {
+            if (name === 'client_secret' && provider.token_request_auth_method === 'private_key_jwt') {
                 baseForm.shape['client_secret'] = z.string().optional();
                 continue;
             }


### PR DESCRIPTION
## Describe the problem and your solution

-  restore client secret field for providers that use OAUTH2_CC and define custom credentials i.e `adp`

<!-- Issue ticket number and link (if applicable) -->

<!-- Testing instructions (skip if just adding/editing providers) -->


<!-- Summary by @propel-code-bot -->

---

This also clarifies that the form logic only makes `client_secret` optional for `private_key_jwt` providers, restoring the field for custom-credential `OAUTH2_CC` providers rather than hiding it when custom credentials omit `client_secret`.

---
*This summary was automatically generated by @propel-code-bot*