### PR TITLE
docs: replace full links with relative links in docs

### DIFF
--- a/docs/api-integrations/servicenow-oauth2-cc.mdx
+++ b/docs/api-integrations/servicenow-oauth2-cc.mdx
@@ -76,7 +76,7 @@ Official docs: [ServiceNow REST API Documentation](https://developer.servicenow.
 
 _No pre-built syncs or actions available yet._
 
-<Tip>Not seeing the integration you need? [Build your own](https://nango.dev/docs/guides/primitives/functions) independently.</Tip>
+<Tip>Not seeing the integration you need? [Build your own](/guides/primitives/functions) independently.</Tip>
 
 ---
 

--- a/docs/guides/platform/self-hosting.mdx
+++ b/docs/guides/platform/self-hosting.mdx
@@ -69,7 +69,7 @@ Customers should **pin their CLI version to the `application-version`** specifie
 
 You can find the latest version by checking the [`managed-manifest.json`](https://github.com/NangoHQ/nango/blob/master/managed-manifest.json).
 
-See the full [changelog](https://nango.dev/docs/updates) for details on each release.
+See the full [changelog](/updates) for details on each release.
 
 ## Cloud provider support
 

--- a/docs/implementation-guides/platform/functions/leverage-ai-agents.mdx
+++ b/docs/implementation-guides/platform/functions/leverage-ai-agents.mdx
@@ -6,7 +6,7 @@ description: 'Guide on how to use AI to build custom integrations on Nango.'
 
 <Tip>
     **Quickstart:**
-    1. Use Nango's documentation MCP: https://nango.dev/docs/mcp
+    1. Use Nango's documentation MCP: /mcp
     2. Install the function builder skill: `npx skills add NangoHQ/skills`
 </Tip>
 

--- a/docs/implementation-guides/use-cases/tool-calling/anthropic-sdk.mdx
+++ b/docs/implementation-guides/use-cases/tool-calling/anthropic-sdk.mdx
@@ -11,7 +11,7 @@ npm i @anthropic-ai/sdk @nangohq/node
 ```
 
 <Tip>
-This example uses the Node SDK, a lightweight wrapper over Nango’s REST API. The same flow works in any language by using the [API reference](https://nango.dev/docs/reference/api/authentication).
+This example uses the Node SDK, a lightweight wrapper over Nango’s REST API. The same flow works in any language by using the [API reference](/reference/api/authentication).
 </Tip>
 
 **Requirements:** 

--- a/docs/implementation-guides/use-cases/tool-calling/any-llm.mdx
+++ b/docs/implementation-guides/use-cases/tool-calling/any-llm.mdx
@@ -11,7 +11,7 @@ npm i @nangohq/node
 ```
 
 <Tip>
-This example uses the Node SDK, a lightweight wrapper over Nango’s REST API. The same flow works in any language by using the [API reference](https://nango.dev/docs/reference/api/authentication).
+This example uses the Node SDK, a lightweight wrapper over Nango’s REST API. The same flow works in any language by using the [API reference](/reference/api/authentication).
 </Tip>
 
 **Requirements:** 

--- a/docs/implementation-guides/use-cases/tool-calling/google-sdk.mdx
+++ b/docs/implementation-guides/use-cases/tool-calling/google-sdk.mdx
@@ -11,7 +11,7 @@ npm i ai @google/genai @nangohq/node
 ```
 
 <Tip>
-This example uses the Node SDK, a lightweight wrapper over Nango’s REST API. The same flow works in any language by using the [API reference](https://nango.dev/docs/reference/api/authentication).
+This example uses the Node SDK, a lightweight wrapper over Nango’s REST API. The same flow works in any language by using the [API reference](/reference/api/authentication).
 </Tip>
 
 **Requirements:** 

--- a/docs/implementation-guides/use-cases/tool-calling/langchain-sdk.mdx
+++ b/docs/implementation-guides/use-cases/tool-calling/langchain-sdk.mdx
@@ -11,7 +11,7 @@ npm i ai langchain @langchain/core/tools @nangohq/node zod
 ```
 
 <Tip>
-This example uses the Node SDK, a lightweight wrapper over Nango’s REST API. The same flow works in any language by using the [API reference](https://nango.dev/docs/reference/api/authentication).
+This example uses the Node SDK, a lightweight wrapper over Nango’s REST API. The same flow works in any language by using the [API reference](/reference/api/authentication).
 </Tip>
 
 **Requirements:** 

--- a/docs/implementation-guides/use-cases/tool-calling/llamaindex-sdk.mdx
+++ b/docs/implementation-guides/use-cases/tool-calling/llamaindex-sdk.mdx
@@ -11,7 +11,7 @@ npm i llamaindex @llamaindex/openai @nangohq/node
 ```
 
 <Tip>
-This example uses the Node SDK, a lightweight wrapper over Nango’s REST API. The same flow works in any language by using the [API reference](https://nango.dev/docs/reference/api/authentication).
+This example uses the Node SDK, a lightweight wrapper over Nango’s REST API. The same flow works in any language by using the [API reference](/reference/api/authentication).
 </Tip>
 
 **Requirements:** 

--- a/docs/implementation-guides/use-cases/tool-calling/mastra-sdk.mdx
+++ b/docs/implementation-guides/use-cases/tool-calling/mastra-sdk.mdx
@@ -11,7 +11,7 @@ npm i @mastra/core @nangohq/node
 ```
 
 <Tip>
-This example uses the Node SDK, a lightweight wrapper over Nango’s REST API. The same flow works in any language by using the [API reference](https://nango.dev/docs/reference/api/authentication).
+This example uses the Node SDK, a lightweight wrapper over Nango’s REST API. The same flow works in any language by using the [API reference](/reference/api/authentication).
 </Tip>
 
 **Requirements:** 

--- a/docs/implementation-guides/use-cases/tool-calling/openai-agents-sdk.mdx
+++ b/docs/implementation-guides/use-cases/tool-calling/openai-agents-sdk.mdx
@@ -11,7 +11,7 @@ npm i ai @openai/agents @nangohq/node
 ```
 
 <Tip>
-This example uses the Node SDK, a lightweight wrapper over Nango’s REST API. The same flow works in any language by using the [API reference](https://nango.dev/docs/reference/api/authentication).
+This example uses the Node SDK, a lightweight wrapper over Nango’s REST API. The same flow works in any language by using the [API reference](/reference/api/authentication).
 </Tip>
 
 **Requirements:** 

--- a/docs/implementation-guides/use-cases/tool-calling/openai-sdk.mdx
+++ b/docs/implementation-guides/use-cases/tool-calling/openai-sdk.mdx
@@ -11,7 +11,7 @@ npm i openai @nangohq/node
 ```
 
 <Tip>
-This example uses the Node SDK, a lightweight wrapper over Nango’s REST API. The same flow works in any language by using the [API reference](https://nango.dev/docs/reference/api/authentication).
+This example uses the Node SDK, a lightweight wrapper over Nango’s REST API. The same flow works in any language by using the [API reference](/reference/api/authentication).
 </Tip>
 
 **Requirements:** 

--- a/docs/implementation-guides/use-cases/tool-calling/vercel-sdk.mdx
+++ b/docs/implementation-guides/use-cases/tool-calling/vercel-sdk.mdx
@@ -11,7 +11,7 @@ npm i ai @ai-sdk/openai @nangohq/node
 ```
 
 <Tip>
-This example uses the Node SDK, a lightweight wrapper over Nango’s REST API. The same flow works in any language by using the [API reference](https://nango.dev/docs/reference/api/authentication).
+This example uses the Node SDK, a lightweight wrapper over Nango’s REST API. The same flow works in any language by using the [API reference](/reference/api/authentication).
 </Tip>
 
 **Requirements:** 

--- a/docs/integrations/all/microsoft-excel.mdx
+++ b/docs/integrations/all/microsoft-excel.mdx
@@ -54,7 +54,7 @@ import UsefulLinks from "/snippets/microsoft-shared/useful-links.mdx"
         Or fetch credentials dynamically via the [Node SDK](/reference/sdks/node#get-a-connection-with-credentials) or [API](/reference/api/connection/get).
 
         <Note>
-         The `{fileId}` in the URL is the unique identifier for the Excel file in OneDrive/SharePoint. You can obtain this ID by first making a Nango [proxy](https://nango.dev/docs/reference/api/proxy/get) call to `/v1.0/me/drive/root/children` to list files and retrieve their IDs. Then, use the ID of the desired workbook to access its worksheets.
+         The `{fileId}` in the URL is the unique identifier for the Excel file in OneDrive/SharePoint. You can obtain this ID by first making a Nango [proxy](/reference/api/proxy/get) call to `/v1.0/me/drive/root/children` to list files and retrieve their IDs. Then, use the ID of the desired workbook to access its worksheets.
          </Note>
 
       </Step>

--- a/docs/integrations/all/roller.mdx
+++ b/docs/integrations/all/roller.mdx
@@ -53,11 +53,11 @@ await nango.openConnectUI({ sessionToken: connectSessionToken });
 
 ## Useful links
 
-- **Auth0 (Client Credentials) — example**: https://nango.dev/docs/integrations/all/auth0-cc
-- **Frontend SDK (Connect UI API)**: https://nango.dev/docs/reference/sdks/frontend
-- **Quickstart: Embed in your app (connect session token)**: https://nango.dev/docs/implementation-guides/platform/auth/implement-api-auth
-- **Authorize in your app (default UI)**: https://nango.dev/docs/guides/api-authorization/authorize-in-your-app-default-ui
-- **Proxy requests** (server-side calls through Nango): https://nango.dev/docs/guides/proxy-requests
+- **Auth0 (Client Credentials) — example**: /integrations/all/auth0-cc
+- **Frontend SDK (Connect UI API)**: /reference/sdks/frontend
+- **Quickstart: Embed in your app (connect session token)**: /implementation-guides/platform/auth/implement-api-auth
+- **Authorize in your app (default UI)**: /guides/api-authorization/authorize-in-your-app-default-ui
+- **Proxy requests** (server-side calls through Nango): /guides/proxy-requests
 
 ---
 

--- a/docs/snippets/builder-io-public/PreBuiltUseCases.mdx
+++ b/docs/snippets/builder-io-public/PreBuiltUseCases.mdx
@@ -1,3 +1,3 @@
 _No pre-built syncs or actions available yet._
 
-<Tip>Not seeing the integration you need? [Build your own](https://nango.dev/docs/guides/primitives/functions) independently.</Tip>
+<Tip>Not seeing the integration you need? [Build your own](/guides/primitives/functions) independently.</Tip>

--- a/docs/snippets/canva-scim/PreBuiltUseCases.mdx
+++ b/docs/snippets/canva-scim/PreBuiltUseCases.mdx
@@ -1,3 +1,3 @@
 _No pre-built syncs or actions available yet._
 
-<Tip>Not seeing the integration you need? [Build your own](https://nango.dev/docs/guides/primitives/functions) independently.</Tip>
+<Tip>Not seeing the integration you need? [Build your own](/guides/primitives/functions) independently.</Tip>

--- a/docs/snippets/generated/1password-scim/PreBuiltUseCases.mdx
+++ b/docs/snippets/generated/1password-scim/PreBuiltUseCases.mdx
@@ -1,3 +1,3 @@
 _No pre-built syncs or actions available yet._
 
-<Tip>Not seeing the integration you need? [Build your own](https://nango.dev/docs/guides/primitives/functions) independently.</Tip>
+<Tip>Not seeing the integration you need? [Build your own](/guides/primitives/functions) independently.</Tip>

--- a/docs/snippets/generated/3cx/PreBuiltUseCases.mdx
+++ b/docs/snippets/generated/3cx/PreBuiltUseCases.mdx
@@ -1,3 +1,3 @@
 _No pre-built syncs or actions available yet._
 
-<Tip>Not seeing the integration you need? [Build your own](https://nango.dev/docs/guides/primitives/functions) independently.</Tip>
+<Tip>Not seeing the integration you need? [Build your own](/guides/primitives/functions) independently.</Tip>

--- a/docs/snippets/generated/8x8/PreBuiltUseCases.mdx
+++ b/docs/snippets/generated/8x8/PreBuiltUseCases.mdx
@@ -1,3 +1,3 @@
 _No pre-built syncs or actions available yet._
 
-<Tip>Not seeing the integration you need? [Build your own](https://nango.dev/docs/guides/primitives/functions) independently.</Tip>
+<Tip>Not seeing the integration you need? [Build your own](/guides/primitives/functions) independently.</Tip>

--- a/docs/snippets/generated/accelo/PreBuiltUseCases.mdx
+++ b/docs/snippets/generated/accelo/PreBuiltUseCases.mdx
@@ -1,3 +1,3 @@
 _No pre-built syncs or actions available yet._
 
-<Tip>Not seeing the integration you need? [Build your own](https://nango.dev/docs/guides/primitives/functions) independently.</Tip>
+<Tip>Not seeing the integration you need? [Build your own](/guides/primitives/functions) independently.</Tip>

--- a/docs/snippets/generated/active-campaign/PreBuiltUseCases.mdx
+++ b/docs/snippets/generated/active-campaign/PreBuiltUseCases.mdx
@@ -1,3 +1,3 @@
 _No pre-built syncs or actions available yet._
 
-<Tip>Not seeing the integration you need? [Build your own](https://nango.dev/docs/guides/primitives/functions) independently.</Tip>
+<Tip>Not seeing the integration you need? [Build your own](/guides/primitives/functions) independently.</Tip>

--- a/docs/snippets/generated/acuity-scheduling/PreBuiltUseCases.mdx
+++ b/docs/snippets/generated/acuity-scheduling/PreBuiltUseCases.mdx
@@ -1,3 +1,3 @@
 _No pre-built syncs or actions available yet._
 
-<Tip>Not seeing the integration you need? [Build your own](https://nango.dev/docs/guides/primitives/functions) independently.</Tip>
+<Tip>Not seeing the integration you need? [Build your own](/guides/primitives/functions) independently.</Tip>

--- a/docs/snippets/generated/addepar-basic/PreBuiltUseCases.mdx
+++ b/docs/snippets/generated/addepar-basic/PreBuiltUseCases.mdx
@@ -1,3 +1,3 @@
 _No pre-built syncs or actions available yet._
 
-<Tip>Not seeing the integration you need? [Build your own](https://nango.dev/docs/guides/primitives/functions) independently.</Tip>
+<Tip>Not seeing the integration you need? [Build your own](/guides/primitives/functions) independently.</Tip>

--- a/docs/snippets/generated/addepar/PreBuiltUseCases.mdx
+++ b/docs/snippets/generated/addepar/PreBuiltUseCases.mdx
@@ -1,3 +1,3 @@
 _No pre-built syncs or actions available yet._
 
-<Tip>Not seeing the integration you need? [Build your own](https://nango.dev/docs/guides/primitives/functions) independently.</Tip>
+<Tip>Not seeing the integration you need? [Build your own](/guides/primitives/functions) independently.</Tip>

--- a/docs/snippets/generated/adobe-commerce/PreBuiltUseCases.mdx
+++ b/docs/snippets/generated/adobe-commerce/PreBuiltUseCases.mdx
@@ -1,3 +1,3 @@
 _No pre-built syncs or actions available yet._
 
-<Tip>Not seeing the integration you need? [Build your own](https://nango.dev/docs/guides/primitives/functions) independently.</Tip>
+<Tip>Not seeing the integration you need? [Build your own](/guides/primitives/functions) independently.</Tip>

--- a/docs/snippets/generated/adobe-umapi/PreBuiltUseCases.mdx
+++ b/docs/snippets/generated/adobe-umapi/PreBuiltUseCases.mdx
@@ -1,3 +1,3 @@
 _No pre-built syncs or actions available yet._
 
-<Tip>Not seeing the integration you need? [Build your own](https://nango.dev/docs/guides/primitives/functions) independently.</Tip>
+<Tip>Not seeing the integration you need? [Build your own](/guides/primitives/functions) independently.</Tip>

--- a/docs/snippets/generated/adobe-workfront/PreBuiltUseCases.mdx
+++ b/docs/snippets/generated/adobe-workfront/PreBuiltUseCases.mdx
@@ -1,3 +1,3 @@
 _No pre-built syncs or actions available yet._
 
-<Tip>Not seeing the integration you need? [Build your own](https://nango.dev/docs/guides/primitives/functions) independently.</Tip>
+<Tip>Not seeing the integration you need? [Build your own](/guides/primitives/functions) independently.</Tip>

--- a/docs/snippets/generated/adobe/PreBuiltUseCases.mdx
+++ b/docs/snippets/generated/adobe/PreBuiltUseCases.mdx
@@ -1,3 +1,3 @@
 _No pre-built syncs or actions available yet._
 
-<Tip>Not seeing the integration you need? [Build your own](https://nango.dev/docs/guides/primitives/functions) independently.</Tip>
+<Tip>Not seeing the integration you need? [Build your own](/guides/primitives/functions) independently.</Tip>

--- a/docs/snippets/generated/adp-lyric/PreBuiltUseCases.mdx
+++ b/docs/snippets/generated/adp-lyric/PreBuiltUseCases.mdx
@@ -1,3 +1,3 @@
 _No pre-built syncs or actions available yet._
 
-<Tip>Not seeing the integration you need? [Build your own](https://nango.dev/docs/guides/primitives/functions) independently.</Tip>
+<Tip>Not seeing the integration you need? [Build your own](/guides/primitives/functions) independently.</Tip>

--- a/docs/snippets/generated/adp-run/PreBuiltUseCases.mdx
+++ b/docs/snippets/generated/adp-run/PreBuiltUseCases.mdx
@@ -1,3 +1,3 @@
 _No pre-built syncs or actions available yet._
 
-<Tip>Not seeing the integration you need? [Build your own](https://nango.dev/docs/guides/primitives/functions) independently.</Tip>
+<Tip>Not seeing the integration you need? [Build your own](/guides/primitives/functions) independently.</Tip>

--- a/docs/snippets/generated/adp-workforce-now-next-gen/PreBuiltUseCases.mdx
+++ b/docs/snippets/generated/adp-workforce-now-next-gen/PreBuiltUseCases.mdx
@@ -1,3 +1,3 @@
 _No pre-built syncs or actions available yet._
 
-<Tip>Not seeing the integration you need? [Build your own](https://nango.dev/docs/guides/primitives/functions) independently.</Tip>
+<Tip>Not seeing the integration you need? [Build your own](/guides/primitives/functions) independently.</Tip>

--- a/docs/snippets/generated/adp-workforce-now/PreBuiltUseCases.mdx
+++ b/docs/snippets/generated/adp-workforce-now/PreBuiltUseCases.mdx
@@ -1,3 +1,3 @@
 _No pre-built syncs or actions available yet._
 
-<Tip>Not seeing the integration you need? [Build your own](https://nango.dev/docs/guides/primitives/functions) independently.</Tip>
+<Tip>Not seeing the integration you need? [Build your own](/guides/primitives/functions) independently.</Tip>

--- a/docs/snippets/generated/adyen/PreBuiltUseCases.mdx
+++ b/docs/snippets/generated/adyen/PreBuiltUseCases.mdx
@@ -1,3 +1,3 @@
 _No pre-built syncs or actions available yet._
 
-<Tip>Not seeing the integration you need? [Build your own](https://nango.dev/docs/guides/primitives/functions) independently.</Tip>
+<Tip>Not seeing the integration you need? [Build your own](/guides/primitives/functions) independently.</Tip>

--- a/docs/snippets/generated/affinity-v2/PreBuiltUseCases.mdx
+++ b/docs/snippets/generated/affinity-v2/PreBuiltUseCases.mdx
@@ -1,3 +1,3 @@
 _No pre-built syncs or actions available yet._
 
-<Tip>Not seeing the integration you need? [Build your own](https://nango.dev/docs/guides/primitives/functions) independently.</Tip>
+<Tip>Not seeing the integration you need? [Build your own](/guides/primitives/functions) independently.</Tip>

--- a/docs/snippets/generated/affinity/PreBuiltUseCases.mdx
+++ b/docs/snippets/generated/affinity/PreBuiltUseCases.mdx
@@ -1,3 +1,3 @@
 _No pre-built syncs or actions available yet._
 
-<Tip>Not seeing the integration you need? [Build your own](https://nango.dev/docs/guides/primitives/functions) independently.</Tip>
+<Tip>Not seeing the integration you need? [Build your own](/guides/primitives/functions) independently.</Tip>

--- a/docs/snippets/generated/aimfox-oauth/PreBuiltUseCases.mdx
+++ b/docs/snippets/generated/aimfox-oauth/PreBuiltUseCases.mdx
@@ -1,3 +1,3 @@
 _No pre-built syncs or actions available yet._
 
-<Tip>Not seeing the integration you need? [Build your own](https://nango.dev/docs/guides/primitives/functions) independently.</Tip>
+<Tip>Not seeing the integration you need? [Build your own](/guides/primitives/functions) independently.</Tip>

--- a/docs/snippets/generated/aimfox/PreBuiltUseCases.mdx
+++ b/docs/snippets/generated/aimfox/PreBuiltUseCases.mdx
@@ -1,3 +1,3 @@
 _No pre-built syncs or actions available yet._
 
-<Tip>Not seeing the integration you need? [Build your own](https://nango.dev/docs/guides/primitives/functions) independently.</Tip>
+<Tip>Not seeing the integration you need? [Build your own](/guides/primitives/functions) independently.</Tip>

--- a/docs/snippets/generated/aircall-basic/PreBuiltUseCases.mdx
+++ b/docs/snippets/generated/aircall-basic/PreBuiltUseCases.mdx
@@ -1,3 +1,3 @@
 _No pre-built syncs or actions available yet._
 
-<Tip>Not seeing the integration you need? [Build your own](https://nango.dev/docs/guides/primitives/functions) independently.</Tip>
+<Tip>Not seeing the integration you need? [Build your own](/guides/primitives/functions) independently.</Tip>

--- a/docs/snippets/generated/amazon-selling-partner-beta/PreBuiltUseCases.mdx
+++ b/docs/snippets/generated/amazon-selling-partner-beta/PreBuiltUseCases.mdx
@@ -1,3 +1,3 @@
 _No pre-built syncs or actions available yet._
 
-<Tip>Not seeing the integration you need? [Build your own](https://nango.dev/docs/guides/primitives/functions) independently.</Tip>
+<Tip>Not seeing the integration you need? [Build your own](/guides/primitives/functions) independently.</Tip>

--- a/docs/snippets/generated/amazon-selling-partner/PreBuiltUseCases.mdx
+++ b/docs/snippets/generated/amazon-selling-partner/PreBuiltUseCases.mdx
@@ -1,3 +1,3 @@
 _No pre-built syncs or actions available yet._
 
-<Tip>Not seeing the integration you need? [Build your own](https://nango.dev/docs/guides/primitives/functions) independently.</Tip>
+<Tip>Not seeing the integration you need? [Build your own](/guides/primitives/functions) independently.</Tip>

--- a/docs/snippets/generated/amazon/PreBuiltUseCases.mdx
+++ b/docs/snippets/generated/amazon/PreBuiltUseCases.mdx
@@ -1,3 +1,3 @@
 _No pre-built syncs or actions available yet._
 
-<Tip>Not seeing the integration you need? [Build your own](https://nango.dev/docs/guides/primitives/functions) independently.</Tip>
+<Tip>Not seeing the integration you need? [Build your own](/guides/primitives/functions) independently.</Tip>

--- a/docs/snippets/generated/amplitude-mcp/PreBuiltUseCases.mdx
+++ b/docs/snippets/generated/amplitude-mcp/PreBuiltUseCases.mdx
@@ -1,3 +1,3 @@
 _No pre-built syncs or actions available yet._
 
-<Tip>Not seeing the integration you need? [Build your own](https://nango.dev/docs/guides/primitives/functions) independently.</Tip>
+<Tip>Not seeing the integration you need? [Build your own](/guides/primitives/functions) independently.</Tip>

--- a/docs/snippets/generated/amplitude/PreBuiltUseCases.mdx
+++ b/docs/snippets/generated/amplitude/PreBuiltUseCases.mdx
@@ -1,3 +1,3 @@
 _No pre-built syncs or actions available yet._
 
-<Tip>Not seeing the integration you need? [Build your own](https://nango.dev/docs/guides/primitives/functions) independently.</Tip>
+<Tip>Not seeing the integration you need? [Build your own](/guides/primitives/functions) independently.</Tip>

--- a/docs/snippets/generated/anthropic-admin/PreBuiltUseCases.mdx
+++ b/docs/snippets/generated/anthropic-admin/PreBuiltUseCases.mdx
@@ -1,3 +1,3 @@
 _No pre-built syncs or actions available yet._
 
-<Tip>Not seeing the integration you need? [Build your own](https://nango.dev/docs/guides/primitives/functions) independently.</Tip>
+<Tip>Not seeing the integration you need? [Build your own](/guides/primitives/functions) independently.</Tip>

--- a/docs/snippets/generated/anthropic/PreBuiltUseCases.mdx
+++ b/docs/snippets/generated/anthropic/PreBuiltUseCases.mdx
@@ -1,3 +1,3 @@
 _No pre-built syncs or actions available yet._
 
-<Tip>Not seeing the integration you need? [Build your own](https://nango.dev/docs/guides/primitives/functions) independently.</Tip>
+<Tip>Not seeing the integration you need? [Build your own](/guides/primitives/functions) independently.</Tip>

--- a/docs/snippets/generated/apaleo/PreBuiltUseCases.mdx
+++ b/docs/snippets/generated/apaleo/PreBuiltUseCases.mdx
@@ -1,3 +1,3 @@
 _No pre-built syncs or actions available yet._
 
-<Tip>Not seeing the integration you need? [Build your own](https://nango.dev/docs/guides/primitives/functions) independently.</Tip>
+<Tip>Not seeing the integration you need? [Build your own](/guides/primitives/functions) independently.</Tip>

--- a/docs/snippets/generated/apify/PreBuiltUseCases.mdx
+++ b/docs/snippets/generated/apify/PreBuiltUseCases.mdx
@@ -1,3 +1,3 @@
 _No pre-built syncs or actions available yet._
 
-<Tip>Not seeing the integration you need? [Build your own](https://nango.dev/docs/guides/primitives/functions) independently.</Tip>
+<Tip>Not seeing the integration you need? [Build your own](/guides/primitives/functions) independently.</Tip>

--- a/docs/snippets/generated/apollo-oauth/PreBuiltUseCases.mdx
+++ b/docs/snippets/generated/apollo-oauth/PreBuiltUseCases.mdx
@@ -1,3 +1,3 @@
 _No pre-built syncs or actions available yet._
 
-<Tip>Not seeing the integration you need? [Build your own](https://nango.dev/docs/guides/primitives/functions) independently.</Tip>
+<Tip>Not seeing the integration you need? [Build your own](/guides/primitives/functions) independently.</Tip>

--- a/docs/snippets/generated/apollo/PreBuiltUseCases.mdx
+++ b/docs/snippets/generated/apollo/PreBuiltUseCases.mdx
@@ -1,3 +1,3 @@
 _No pre-built syncs or actions available yet._
 
-<Tip>Not seeing the integration you need? [Build your own](https://nango.dev/docs/guides/primitives/functions) independently.</Tip>
+<Tip>Not seeing the integration you need? [Build your own](/guides/primitives/functions) independently.</Tip>

--- a/docs/snippets/generated/apple-app-store/PreBuiltUseCases.mdx
+++ b/docs/snippets/generated/apple-app-store/PreBuiltUseCases.mdx
@@ -1,3 +1,3 @@
 _No pre-built syncs or actions available yet._
 
-<Tip>Not seeing the integration you need? [Build your own](https://nango.dev/docs/guides/primitives/functions) independently.</Tip>
+<Tip>Not seeing the integration you need? [Build your own](/guides/primitives/functions) independently.</Tip>

--- a/docs/snippets/generated/appstle-subscriptions/PreBuiltUseCases.mdx
+++ b/docs/snippets/generated/appstle-subscriptions/PreBuiltUseCases.mdx
@@ -1,3 +1,3 @@
 _No pre-built syncs or actions available yet._
 
-<Tip>Not seeing the integration you need? [Build your own](https://nango.dev/docs/guides/primitives/functions) independently.</Tip>
+<Tip>Not seeing the integration you need? [Build your own](/guides/primitives/functions) independently.</Tip>

--- a/docs/snippets/generated/asana-mcp/PreBuiltUseCases.mdx
+++ b/docs/snippets/generated/asana-mcp/PreBuiltUseCases.mdx
@@ -1,3 +1,3 @@
 _No pre-built syncs or actions available yet._
 
-<Tip>Not seeing the integration you need? [Build your own](https://nango.dev/docs/guides/primitives/functions) independently.</Tip>
+<Tip>Not seeing the integration you need? [Build your own](/guides/primitives/functions) independently.</Tip>

--- a/docs/snippets/generated/asana-scim/PreBuiltUseCases.mdx
+++ b/docs/snippets/generated/asana-scim/PreBuiltUseCases.mdx
@@ -1,3 +1,3 @@
 _No pre-built syncs or actions available yet._
 
-<Tip>Not seeing the integration you need? [Build your own](https://nango.dev/docs/guides/primitives/functions) independently.</Tip>
+<Tip>Not seeing the integration you need? [Build your own](/guides/primitives/functions) independently.</Tip>

--- a/docs/snippets/generated/atlas-so/PreBuiltUseCases.mdx
+++ b/docs/snippets/generated/atlas-so/PreBuiltUseCases.mdx
@@ -1,3 +1,3 @@
 _No pre-built syncs or actions available yet._
 
-<Tip>Not seeing the integration you need? [Build your own](https://nango.dev/docs/guides/primitives/functions) independently.</Tip>
+<Tip>Not seeing the integration you need? [Build your own](/guides/primitives/functions) independently.</Tip>

--- a/docs/snippets/generated/atlassian-admin/PreBuiltUseCases.mdx
+++ b/docs/snippets/generated/atlassian-admin/PreBuiltUseCases.mdx
@@ -1,3 +1,3 @@
 _No pre-built syncs or actions available yet._
 
-<Tip>Not seeing the integration you need? [Build your own](https://nango.dev/docs/guides/primitives/functions) independently.</Tip>
+<Tip>Not seeing the integration you need? [Build your own](/guides/primitives/functions) independently.</Tip>

--- a/docs/snippets/generated/atlassian-government-cloud/PreBuiltUseCases.mdx
+++ b/docs/snippets/generated/atlassian-government-cloud/PreBuiltUseCases.mdx
@@ -1,3 +1,3 @@
 _No pre-built syncs or actions available yet._
 
-<Tip>Not seeing the integration you need? [Build your own](https://nango.dev/docs/guides/primitives/functions) independently.</Tip>
+<Tip>Not seeing the integration you need? [Build your own](/guides/primitives/functions) independently.</Tip>

--- a/docs/snippets/generated/atlassian-service-account-api-token/PreBuiltUseCases.mdx
+++ b/docs/snippets/generated/atlassian-service-account-api-token/PreBuiltUseCases.mdx
@@ -1,3 +1,3 @@
 _No pre-built syncs or actions available yet._
 
-<Tip>Not seeing the integration you need? [Build your own](https://nango.dev/docs/guides/primitives/functions) independently.</Tip>
+<Tip>Not seeing the integration you need? [Build your own](/guides/primitives/functions) independently.</Tip>

--- a/docs/snippets/generated/atlassian-service-account-oauth2/PreBuiltUseCases.mdx
+++ b/docs/snippets/generated/atlassian-service-account-oauth2/PreBuiltUseCases.mdx
@@ -1,3 +1,3 @@
 _No pre-built syncs or actions available yet._
 
-<Tip>Not seeing the integration you need? [Build your own](https://nango.dev/docs/guides/primitives/functions) independently.</Tip>
+<Tip>Not seeing the integration you need? [Build your own](/guides/primitives/functions) independently.</Tip>

--- a/docs/snippets/generated/atlassian/PreBuiltUseCases.mdx
+++ b/docs/snippets/generated/atlassian/PreBuiltUseCases.mdx
@@ -1,3 +1,3 @@
 _No pre-built syncs or actions available yet._
 
-<Tip>Not seeing the integration you need? [Build your own](https://nango.dev/docs/guides/primitives/functions) independently.</Tip>
+<Tip>Not seeing the integration you need? [Build your own](/guides/primitives/functions) independently.</Tip>

--- a/docs/snippets/generated/attention/PreBuiltUseCases.mdx
+++ b/docs/snippets/generated/attention/PreBuiltUseCases.mdx
@@ -1,3 +1,3 @@
 _No pre-built syncs or actions available yet._
 
-<Tip>Not seeing the integration you need? [Build your own](https://nango.dev/docs/guides/primitives/functions) independently.</Tip>
+<Tip>Not seeing the integration you need? [Build your own](/guides/primitives/functions) independently.</Tip>

--- a/docs/snippets/generated/auth0-cc/PreBuiltUseCases.mdx
+++ b/docs/snippets/generated/auth0-cc/PreBuiltUseCases.mdx
@@ -1,3 +1,3 @@
 _No pre-built syncs or actions available yet._
 
-<Tip>Not seeing the integration you need? [Build your own](https://nango.dev/docs/guides/primitives/functions) independently.</Tip>
+<Tip>Not seeing the integration you need? [Build your own](/guides/primitives/functions) independently.</Tip>

--- a/docs/snippets/generated/auth0/PreBuiltUseCases.mdx
+++ b/docs/snippets/generated/auth0/PreBuiltUseCases.mdx
@@ -1,3 +1,3 @@
 _No pre-built syncs or actions available yet._
 
-<Tip>Not seeing the integration you need? [Build your own](https://nango.dev/docs/guides/primitives/functions) independently.</Tip>
+<Tip>Not seeing the integration you need? [Build your own](/guides/primitives/functions) independently.</Tip>

--- a/docs/snippets/generated/autodesk/PreBuiltUseCases.mdx
+++ b/docs/snippets/generated/autodesk/PreBuiltUseCases.mdx
@@ -1,3 +1,3 @@
 _No pre-built syncs or actions available yet._
 
-<Tip>Not seeing the integration you need? [Build your own](https://nango.dev/docs/guides/primitives/functions) independently.</Tip>
+<Tip>Not seeing the integration you need? [Build your own](/guides/primitives/functions) independently.</Tip>

--- a/docs/snippets/generated/autotask/PreBuiltUseCases.mdx
+++ b/docs/snippets/generated/autotask/PreBuiltUseCases.mdx
@@ -1,3 +1,3 @@
 _No pre-built syncs or actions available yet._
 
-<Tip>Not seeing the integration you need? [Build your own](https://nango.dev/docs/guides/primitives/functions) independently.</Tip>
+<Tip>Not seeing the integration you need? [Build your own](/guides/primitives/functions) independently.</Tip>

--- a/docs/snippets/generated/auvik/PreBuiltUseCases.mdx
+++ b/docs/snippets/generated/auvik/PreBuiltUseCases.mdx
@@ -1,3 +1,3 @@
 _No pre-built syncs or actions available yet._
 
-<Tip>Not seeing the integration you need? [Build your own](https://nango.dev/docs/guides/primitives/functions) independently.</Tip>
+<Tip>Not seeing the integration you need? [Build your own](/guides/primitives/functions) independently.</Tip>

--- a/docs/snippets/generated/availity/PreBuiltUseCases.mdx
+++ b/docs/snippets/generated/availity/PreBuiltUseCases.mdx
@@ -1,3 +1,3 @@
 _No pre-built syncs or actions available yet._
 
-<Tip>Not seeing the integration you need? [Build your own](https://nango.dev/docs/guides/primitives/functions) independently.</Tip>
+<Tip>Not seeing the integration you need? [Build your own](/guides/primitives/functions) independently.</Tip>

--- a/docs/snippets/generated/avanan/PreBuiltUseCases.mdx
+++ b/docs/snippets/generated/avanan/PreBuiltUseCases.mdx
@@ -1,3 +1,3 @@
 _No pre-built syncs or actions available yet._
 
-<Tip>Not seeing the integration you need? [Build your own](https://nango.dev/docs/guides/primitives/functions) independently.</Tip>
+<Tip>Not seeing the integration you need? [Build your own](/guides/primitives/functions) independently.</Tip>

--- a/docs/snippets/generated/avoma/PreBuiltUseCases.mdx
+++ b/docs/snippets/generated/avoma/PreBuiltUseCases.mdx
@@ -1,3 +1,3 @@
 _No pre-built syncs or actions available yet._
 
-<Tip>Not seeing the integration you need? [Build your own](https://nango.dev/docs/guides/primitives/functions) independently.</Tip>
+<Tip>Not seeing the integration you need? [Build your own](/guides/primitives/functions) independently.</Tip>

--- a/docs/snippets/generated/aws-scim/PreBuiltUseCases.mdx
+++ b/docs/snippets/generated/aws-scim/PreBuiltUseCases.mdx
@@ -1,3 +1,3 @@
 _No pre-built syncs or actions available yet._
 
-<Tip>Not seeing the integration you need? [Build your own](https://nango.dev/docs/guides/primitives/functions) independently.</Tip>
+<Tip>Not seeing the integration you need? [Build your own](/guides/primitives/functions) independently.</Tip>

--- a/docs/snippets/generated/aws/PreBuiltUseCases.mdx
+++ b/docs/snippets/generated/aws/PreBuiltUseCases.mdx
@@ -1,3 +1,3 @@
 _No pre-built syncs or actions available yet._
 
-<Tip>Not seeing the integration you need? [Build your own](https://nango.dev/docs/guides/primitives/functions) independently.</Tip>
+<Tip>Not seeing the integration you need? [Build your own](/guides/primitives/functions) independently.</Tip>

--- a/docs/snippets/generated/axiom/PreBuiltUseCases.mdx
+++ b/docs/snippets/generated/axiom/PreBuiltUseCases.mdx
@@ -1,3 +1,3 @@
 _No pre-built syncs or actions available yet._
 
-<Tip>Not seeing the integration you need? [Build your own](https://nango.dev/docs/guides/primitives/functions) independently.</Tip>
+<Tip>Not seeing the integration you need? [Build your own](/guides/primitives/functions) independently.</Tip>

--- a/docs/snippets/generated/azure-blob-storage/PreBuiltUseCases.mdx
+++ b/docs/snippets/generated/azure-blob-storage/PreBuiltUseCases.mdx
@@ -1,3 +1,3 @@
 _No pre-built syncs or actions available yet._
 
-<Tip>Not seeing the integration you need? [Build your own](https://nango.dev/docs/guides/primitives/functions) independently.</Tip>
+<Tip>Not seeing the integration you need? [Build your own](/guides/primitives/functions) independently.</Tip>

--- a/docs/snippets/generated/azure-devops/PreBuiltUseCases.mdx
+++ b/docs/snippets/generated/azure-devops/PreBuiltUseCases.mdx
@@ -1,3 +1,3 @@
 _No pre-built syncs or actions available yet._
 
-<Tip>Not seeing the integration you need? [Build your own](https://nango.dev/docs/guides/primitives/functions) independently.</Tip>
+<Tip>Not seeing the integration you need? [Build your own](/guides/primitives/functions) independently.</Tip>

--- a/docs/snippets/generated/bamboohr/PreBuiltUseCases.mdx
+++ b/docs/snippets/generated/bamboohr/PreBuiltUseCases.mdx
@@ -1,3 +1,3 @@
 _No pre-built syncs or actions available yet._
 
-<Tip>Not seeing the integration you need? [Build your own](https://nango.dev/docs/guides/primitives/functions) independently.</Tip>
+<Tip>Not seeing the integration you need? [Build your own](/guides/primitives/functions) independently.</Tip>

--- a/docs/snippets/generated/battlenet/PreBuiltUseCases.mdx
+++ b/docs/snippets/generated/battlenet/PreBuiltUseCases.mdx
@@ -1,3 +1,3 @@
 _No pre-built syncs or actions available yet._
 
-<Tip>Not seeing the integration you need? [Build your own](https://nango.dev/docs/guides/primitives/functions) independently.</Tip>
+<Tip>Not seeing the integration you need? [Build your own](/guides/primitives/functions) independently.</Tip>

--- a/docs/snippets/generated/beehiiv/PreBuiltUseCases.mdx
+++ b/docs/snippets/generated/beehiiv/PreBuiltUseCases.mdx
@@ -1,3 +1,3 @@
 _No pre-built syncs or actions available yet._
 
-<Tip>Not seeing the integration you need? [Build your own](https://nango.dev/docs/guides/primitives/functions) independently.</Tip>
+<Tip>Not seeing the integration you need? [Build your own](/guides/primitives/functions) independently.</Tip>

--- a/docs/snippets/generated/bettercontact/PreBuiltUseCases.mdx
+++ b/docs/snippets/generated/bettercontact/PreBuiltUseCases.mdx
@@ -1,3 +1,3 @@
 _No pre-built syncs or actions available yet._
 
-<Tip>Not seeing the integration you need? [Build your own](https://nango.dev/docs/guides/primitives/functions) independently.</Tip>
+<Tip>Not seeing the integration you need? [Build your own](/guides/primitives/functions) independently.</Tip>

--- a/docs/snippets/generated/bigcommerce/PreBuiltUseCases.mdx
+++ b/docs/snippets/generated/bigcommerce/PreBuiltUseCases.mdx
@@ -1,3 +1,3 @@
 _No pre-built syncs or actions available yet._
 
-<Tip>Not seeing the integration you need? [Build your own](https://nango.dev/docs/guides/primitives/functions) independently.</Tip>
+<Tip>Not seeing the integration you need? [Build your own](/guides/primitives/functions) independently.</Tip>

--- a/docs/snippets/generated/bird/PreBuiltUseCases.mdx
+++ b/docs/snippets/generated/bird/PreBuiltUseCases.mdx
@@ -1,3 +1,3 @@
 _No pre-built syncs or actions available yet._
 
-<Tip>Not seeing the integration you need? [Build your own](https://nango.dev/docs/guides/primitives/functions) independently.</Tip>
+<Tip>Not seeing the integration you need? [Build your own](/guides/primitives/functions) independently.</Tip>

--- a/docs/snippets/generated/bitbucket/PreBuiltUseCases.mdx
+++ b/docs/snippets/generated/bitbucket/PreBuiltUseCases.mdx
@@ -1,3 +1,3 @@
 _No pre-built syncs or actions available yet._
 
-<Tip>Not seeing the integration you need? [Build your own](https://nango.dev/docs/guides/primitives/functions) independently.</Tip>
+<Tip>Not seeing the integration you need? [Build your own](/guides/primitives/functions) independently.</Tip>

--- a/docs/snippets/generated/bitly/PreBuiltUseCases.mdx
+++ b/docs/snippets/generated/bitly/PreBuiltUseCases.mdx
@@ -1,3 +1,3 @@
 _No pre-built syncs or actions available yet._
 
-<Tip>Not seeing the integration you need? [Build your own](https://nango.dev/docs/guides/primitives/functions) independently.</Tip>
+<Tip>Not seeing the integration you need? [Build your own](/guides/primitives/functions) independently.</Tip>

--- a/docs/snippets/generated/blackbaud-basic/PreBuiltUseCases.mdx
+++ b/docs/snippets/generated/blackbaud-basic/PreBuiltUseCases.mdx
@@ -1,3 +1,3 @@
 _No pre-built syncs or actions available yet._
 
-<Tip>Not seeing the integration you need? [Build your own](https://nango.dev/docs/guides/primitives/functions) independently.</Tip>
+<Tip>Not seeing the integration you need? [Build your own](/guides/primitives/functions) independently.</Tip>

--- a/docs/snippets/generated/blackbaud/PreBuiltUseCases.mdx
+++ b/docs/snippets/generated/blackbaud/PreBuiltUseCases.mdx
@@ -1,3 +1,3 @@
 _No pre-built syncs or actions available yet._
 
-<Tip>Not seeing the integration you need? [Build your own](https://nango.dev/docs/guides/primitives/functions) independently.</Tip>
+<Tip>Not seeing the integration you need? [Build your own](/guides/primitives/functions) independently.</Tip>

--- a/docs/snippets/generated/blandai/PreBuiltUseCases.mdx
+++ b/docs/snippets/generated/blandai/PreBuiltUseCases.mdx
@@ -1,3 +1,3 @@
 _No pre-built syncs or actions available yet._
 
-<Tip>Not seeing the integration you need? [Build your own](https://nango.dev/docs/guides/primitives/functions) independently.</Tip>
+<Tip>Not seeing the integration you need? [Build your own](/guides/primitives/functions) independently.</Tip>

--- a/docs/snippets/generated/boldsign/PreBuiltUseCases.mdx
+++ b/docs/snippets/generated/boldsign/PreBuiltUseCases.mdx
@@ -1,3 +1,3 @@
 _No pre-built syncs or actions available yet._
 
-<Tip>Not seeing the integration you need? [Build your own](https://nango.dev/docs/guides/primitives/functions) independently.</Tip>
+<Tip>Not seeing the integration you need? [Build your own](/guides/primitives/functions) independently.</Tip>

--- a/docs/snippets/generated/booking-com/PreBuiltUseCases.mdx
+++ b/docs/snippets/generated/booking-com/PreBuiltUseCases.mdx
@@ -1,3 +1,3 @@
 _No pre-built syncs or actions available yet._
 
-<Tip>Not seeing the integration you need? [Build your own](https://nango.dev/docs/guides/primitives/functions) independently.</Tip>
+<Tip>Not seeing the integration you need? [Build your own](/guides/primitives/functions) independently.</Tip>

--- a/docs/snippets/generated/braintree-sandbox/PreBuiltUseCases.mdx
+++ b/docs/snippets/generated/braintree-sandbox/PreBuiltUseCases.mdx
@@ -1,3 +1,3 @@
 _No pre-built syncs or actions available yet._
 
-<Tip>Not seeing the integration you need? [Build your own](https://nango.dev/docs/guides/primitives/functions) independently.</Tip>
+<Tip>Not seeing the integration you need? [Build your own](/guides/primitives/functions) independently.</Tip>

--- a/docs/snippets/generated/braintree/PreBuiltUseCases.mdx
+++ b/docs/snippets/generated/braintree/PreBuiltUseCases.mdx
@@ -1,3 +1,3 @@
 _No pre-built syncs or actions available yet._
 
-<Tip>Not seeing the integration you need? [Build your own](https://nango.dev/docs/guides/primitives/functions) independently.</Tip>
+<Tip>Not seeing the integration you need? [Build your own](/guides/primitives/functions) independently.</Tip>

--- a/docs/snippets/generated/braze/PreBuiltUseCases.mdx
+++ b/docs/snippets/generated/braze/PreBuiltUseCases.mdx
@@ -1,3 +1,3 @@
 _No pre-built syncs or actions available yet._
 
-<Tip>Not seeing the integration you need? [Build your own](https://nango.dev/docs/guides/primitives/functions) independently.</Tip>
+<Tip>Not seeing the integration you need? [Build your own](/guides/primitives/functions) independently.</Tip>

--- a/docs/snippets/generated/breezy-hr/PreBuiltUseCases.mdx
+++ b/docs/snippets/generated/breezy-hr/PreBuiltUseCases.mdx
@@ -1,3 +1,3 @@
 _No pre-built syncs or actions available yet._
 
-<Tip>Not seeing the integration you need? [Build your own](https://nango.dev/docs/guides/primitives/functions) independently.</Tip>
+<Tip>Not seeing the integration you need? [Build your own](/guides/primitives/functions) independently.</Tip>

--- a/docs/snippets/generated/brevo-api-key/PreBuiltUseCases.mdx
+++ b/docs/snippets/generated/brevo-api-key/PreBuiltUseCases.mdx
@@ -1,3 +1,3 @@
 _No pre-built syncs or actions available yet._
 
-<Tip>Not seeing the integration you need? [Build your own](https://nango.dev/docs/guides/primitives/functions) independently.</Tip>
+<Tip>Not seeing the integration you need? [Build your own](/guides/primitives/functions) independently.</Tip>

--- a/docs/snippets/generated/brex-api-key/PreBuiltUseCases.mdx
+++ b/docs/snippets/generated/brex-api-key/PreBuiltUseCases.mdx
@@ -1,3 +1,3 @@
 _No pre-built syncs or actions available yet._
 
-<Tip>Not seeing the integration you need? [Build your own](https://nango.dev/docs/guides/primitives/functions) independently.</Tip>
+<Tip>Not seeing the integration you need? [Build your own](/guides/primitives/functions) independently.</Tip>

--- a/docs/snippets/generated/brex-staging/PreBuiltUseCases.mdx
+++ b/docs/snippets/generated/brex-staging/PreBuiltUseCases.mdx
@@ -1,3 +1,3 @@
 _No pre-built syncs or actions available yet._
 
-<Tip>Not seeing the integration you need? [Build your own](https://nango.dev/docs/guides/primitives/functions) independently.</Tip>
+<Tip>Not seeing the integration you need? [Build your own](/guides/primitives/functions) independently.</Tip>

--- a/docs/snippets/generated/brex/PreBuiltUseCases.mdx
+++ b/docs/snippets/generated/brex/PreBuiltUseCases.mdx
@@ -1,3 +1,3 @@
 _No pre-built syncs or actions available yet._
 
-<Tip>Not seeing the integration you need? [Build your own](https://nango.dev/docs/guides/primitives/functions) independently.</Tip>
+<Tip>Not seeing the integration you need? [Build your own](/guides/primitives/functions) independently.</Tip>

--- a/docs/snippets/generated/builder-io-private/PreBuiltUseCases.mdx
+++ b/docs/snippets/generated/builder-io-private/PreBuiltUseCases.mdx
@@ -1,3 +1,3 @@
 _No pre-built syncs or actions available yet._
 
-<Tip>Not seeing the integration you need? [Build your own](https://nango.dev/docs/guides/primitives/functions) independently.</Tip>
+<Tip>Not seeing the integration you need? [Build your own](/guides/primitives/functions) independently.</Tip>

--- a/docs/snippets/generated/builder-io-public/PreBuiltUseCases.mdx
+++ b/docs/snippets/generated/builder-io-public/PreBuiltUseCases.mdx
@@ -1,3 +1,3 @@
 _No pre-built syncs or actions available yet._
 
-<Tip>Not seeing the integration you need? [Build your own](https://nango.dev/docs/guides/primitives/functions) independently.</Tip>
+<Tip>Not seeing the integration you need? [Build your own](/guides/primitives/functions) independently.</Tip>

--- a/docs/snippets/generated/buildium/PreBuiltUseCases.mdx
+++ b/docs/snippets/generated/buildium/PreBuiltUseCases.mdx
@@ -1,3 +1,3 @@
 _No pre-built syncs or actions available yet._
 
-<Tip>Not seeing the integration you need? [Build your own](https://nango.dev/docs/guides/primitives/functions) independently.</Tip>
+<Tip>Not seeing the integration you need? [Build your own](/guides/primitives/functions) independently.</Tip>

--- a/docs/snippets/generated/builtwith/PreBuiltUseCases.mdx
+++ b/docs/snippets/generated/builtwith/PreBuiltUseCases.mdx
@@ -1,3 +1,3 @@
 _No pre-built syncs or actions available yet._
 
-<Tip>Not seeing the integration you need? [Build your own](https://nango.dev/docs/guides/primitives/functions) independently.</Tip>
+<Tip>Not seeing the integration you need? [Build your own](/guides/primitives/functions) independently.</Tip>

--- a/docs/snippets/generated/bullhorn/PreBuiltUseCases.mdx
+++ b/docs/snippets/generated/bullhorn/PreBuiltUseCases.mdx
@@ -1,3 +1,3 @@
 _No pre-built syncs or actions available yet._
 
-<Tip>Not seeing the integration you need? [Build your own](https://nango.dev/docs/guides/primitives/functions) independently.</Tip>
+<Tip>Not seeing the integration you need? [Build your own](/guides/primitives/functions) independently.</Tip>

--- a/docs/snippets/generated/cal-com-oauth/PreBuiltUseCases.mdx
+++ b/docs/snippets/generated/cal-com-oauth/PreBuiltUseCases.mdx
@@ -1,3 +1,3 @@
 _No pre-built syncs or actions available yet._
 
-<Tip>Not seeing the integration you need? [Build your own](https://nango.dev/docs/guides/primitives/functions) independently.</Tip>
+<Tip>Not seeing the integration you need? [Build your own](/guides/primitives/functions) independently.</Tip>

--- a/docs/snippets/generated/cal-com-v1/PreBuiltUseCases.mdx
+++ b/docs/snippets/generated/cal-com-v1/PreBuiltUseCases.mdx
@@ -1,3 +1,3 @@
 _No pre-built syncs or actions available yet._
 
-<Tip>Not seeing the integration you need? [Build your own](https://nango.dev/docs/guides/primitives/functions) independently.</Tip>
+<Tip>Not seeing the integration you need? [Build your own](/guides/primitives/functions) independently.</Tip>

--- a/docs/snippets/generated/callrail/PreBuiltUseCases.mdx
+++ b/docs/snippets/generated/callrail/PreBuiltUseCases.mdx
@@ -1,3 +1,3 @@
 _No pre-built syncs or actions available yet._
 
-<Tip>Not seeing the integration you need? [Build your own](https://nango.dev/docs/guides/primitives/functions) independently.</Tip>
+<Tip>Not seeing the integration you need? [Build your own](/guides/primitives/functions) independently.</Tip>

--- a/docs/snippets/generated/candis/PreBuiltUseCases.mdx
+++ b/docs/snippets/generated/candis/PreBuiltUseCases.mdx
@@ -1,3 +1,3 @@
 _No pre-built syncs or actions available yet._
 
-<Tip>Not seeing the integration you need? [Build your own](https://nango.dev/docs/guides/primitives/functions) independently.</Tip>
+<Tip>Not seeing the integration you need? [Build your own](/guides/primitives/functions) independently.</Tip>

--- a/docs/snippets/generated/canny/PreBuiltUseCases.mdx
+++ b/docs/snippets/generated/canny/PreBuiltUseCases.mdx
@@ -1,3 +1,3 @@
 _No pre-built syncs or actions available yet._
 
-<Tip>Not seeing the integration you need? [Build your own](https://nango.dev/docs/guides/primitives/functions) independently.</Tip>
+<Tip>Not seeing the integration you need? [Build your own](/guides/primitives/functions) independently.</Tip>

--- a/docs/snippets/generated/canva-scim/PreBuiltUseCases.mdx
+++ b/docs/snippets/generated/canva-scim/PreBuiltUseCases.mdx
@@ -1,3 +1,3 @@
 _No pre-built syncs or actions available yet._
 
-<Tip>Not seeing the integration you need? [Build your own](https://nango.dev/docs/guides/primitives/functions) independently.</Tip>
+<Tip>Not seeing the integration you need? [Build your own](/guides/primitives/functions) independently.</Tip>

--- a/docs/snippets/generated/canva/PreBuiltUseCases.mdx
+++ b/docs/snippets/generated/canva/PreBuiltUseCases.mdx
@@ -1,3 +1,3 @@
 _No pre-built syncs or actions available yet._
 
-<Tip>Not seeing the integration you need? [Build your own](https://nango.dev/docs/guides/primitives/functions) independently.</Tip>
+<Tip>Not seeing the integration you need? [Build your own](/guides/primitives/functions) independently.</Tip>

--- a/docs/snippets/generated/canvas-lms/PreBuiltUseCases.mdx
+++ b/docs/snippets/generated/canvas-lms/PreBuiltUseCases.mdx
@@ -1,3 +1,3 @@
 _No pre-built syncs or actions available yet._
 
-<Tip>Not seeing the integration you need? [Build your own](https://nango.dev/docs/guides/primitives/functions) independently.</Tip>
+<Tip>Not seeing the integration you need? [Build your own](/guides/primitives/functions) independently.</Tip>

--- a/docs/snippets/generated/certn-partner/PreBuiltUseCases.mdx
+++ b/docs/snippets/generated/certn-partner/PreBuiltUseCases.mdx
@@ -1,3 +1,3 @@
 _No pre-built syncs or actions available yet._
 
-<Tip>Not seeing the integration you need? [Build your own](https://nango.dev/docs/guides/primitives/functions) independently.</Tip>
+<Tip>Not seeing the integration you need? [Build your own](/guides/primitives/functions) independently.</Tip>

--- a/docs/snippets/generated/certn/PreBuiltUseCases.mdx
+++ b/docs/snippets/generated/certn/PreBuiltUseCases.mdx
@@ -1,3 +1,3 @@
 _No pre-built syncs or actions available yet._
 
-<Tip>Not seeing the integration you need? [Build your own](https://nango.dev/docs/guides/primitives/functions) independently.</Tip>
+<Tip>Not seeing the integration you need? [Build your own](/guides/primitives/functions) independently.</Tip>

--- a/docs/snippets/generated/chargebee/PreBuiltUseCases.mdx
+++ b/docs/snippets/generated/chargebee/PreBuiltUseCases.mdx
@@ -1,3 +1,3 @@
 _No pre-built syncs or actions available yet._
 
-<Tip>Not seeing the integration you need? [Build your own](https://nango.dev/docs/guides/primitives/functions) independently.</Tip>
+<Tip>Not seeing the integration you need? [Build your own](/guides/primitives/functions) independently.</Tip>

--- a/docs/snippets/generated/chattermill/PreBuiltUseCases.mdx
+++ b/docs/snippets/generated/chattermill/PreBuiltUseCases.mdx
@@ -1,3 +1,3 @@
 _No pre-built syncs or actions available yet._
 
-<Tip>Not seeing the integration you need? [Build your own](https://nango.dev/docs/guides/primitives/functions) independently.</Tip>
+<Tip>Not seeing the integration you need? [Build your own](/guides/primitives/functions) independently.</Tip>

--- a/docs/snippets/generated/check/PreBuiltUseCases.mdx
+++ b/docs/snippets/generated/check/PreBuiltUseCases.mdx
@@ -1,3 +1,3 @@
 _No pre-built syncs or actions available yet._
 
-<Tip>Not seeing the integration you need? [Build your own](https://nango.dev/docs/guides/primitives/functions) independently.</Tip>
+<Tip>Not seeing the integration you need? [Build your own](/guides/primitives/functions) independently.</Tip>

--- a/docs/snippets/generated/checkhq/PreBuiltUseCases.mdx
+++ b/docs/snippets/generated/checkhq/PreBuiltUseCases.mdx
@@ -1,3 +1,3 @@
 _No pre-built syncs or actions available yet._
 
-<Tip>Not seeing the integration you need? [Build your own](https://nango.dev/docs/guides/primitives/functions) independently.</Tip>
+<Tip>Not seeing the integration you need? [Build your own](/guides/primitives/functions) independently.</Tip>

--- a/docs/snippets/generated/checkout-com-sandbox/PreBuiltUseCases.mdx
+++ b/docs/snippets/generated/checkout-com-sandbox/PreBuiltUseCases.mdx
@@ -1,3 +1,3 @@
 _No pre-built syncs or actions available yet._
 
-<Tip>Not seeing the integration you need? [Build your own](https://nango.dev/docs/guides/primitives/functions) independently.</Tip>
+<Tip>Not seeing the integration you need? [Build your own](/guides/primitives/functions) independently.</Tip>

--- a/docs/snippets/generated/checkout-com/PreBuiltUseCases.mdx
+++ b/docs/snippets/generated/checkout-com/PreBuiltUseCases.mdx
@@ -1,3 +1,3 @@
 _No pre-built syncs or actions available yet._
 
-<Tip>Not seeing the integration you need? [Build your own](https://nango.dev/docs/guides/primitives/functions) independently.</Tip>
+<Tip>Not seeing the integration you need? [Build your own](/guides/primitives/functions) independently.</Tip>

--- a/docs/snippets/generated/chorus/PreBuiltUseCases.mdx
+++ b/docs/snippets/generated/chorus/PreBuiltUseCases.mdx
@@ -1,3 +1,3 @@
 _No pre-built syncs or actions available yet._
 
-<Tip>Not seeing the integration you need? [Build your own](https://nango.dev/docs/guides/primitives/functions) independently.</Tip>
+<Tip>Not seeing the integration you need? [Build your own](/guides/primitives/functions) independently.</Tip>

--- a/docs/snippets/generated/circle-so/PreBuiltUseCases.mdx
+++ b/docs/snippets/generated/circle-so/PreBuiltUseCases.mdx
@@ -1,3 +1,3 @@
 _No pre-built syncs or actions available yet._
 
-<Tip>Not seeing the integration you need? [Build your own](https://nango.dev/docs/guides/primitives/functions) independently.</Tip>
+<Tip>Not seeing the integration you need? [Build your own](/guides/primitives/functions) independently.</Tip>

--- a/docs/snippets/generated/circleback-mcp/PreBuiltUseCases.mdx
+++ b/docs/snippets/generated/circleback-mcp/PreBuiltUseCases.mdx
@@ -1,3 +1,3 @@
 _No pre-built syncs or actions available yet._
 
-<Tip>Not seeing the integration you need? [Build your own](https://nango.dev/docs/guides/primitives/functions) independently.</Tip>
+<Tip>Not seeing the integration you need? [Build your own](/guides/primitives/functions) independently.</Tip>

--- a/docs/snippets/generated/clerk/PreBuiltUseCases.mdx
+++ b/docs/snippets/generated/clerk/PreBuiltUseCases.mdx
@@ -1,3 +1,3 @@
 _No pre-built syncs or actions available yet._
 
-<Tip>Not seeing the integration you need? [Build your own](https://nango.dev/docs/guides/primitives/functions) independently.</Tip>
+<Tip>Not seeing the integration you need? [Build your own](/guides/primitives/functions) independently.</Tip>

--- a/docs/snippets/generated/cleverreach/PreBuiltUseCases.mdx
+++ b/docs/snippets/generated/cleverreach/PreBuiltUseCases.mdx
@@ -1,3 +1,3 @@
 _No pre-built syncs or actions available yet._
 
-<Tip>Not seeing the integration you need? [Build your own](https://nango.dev/docs/guides/primitives/functions) independently.</Tip>
+<Tip>Not seeing the integration you need? [Build your own](/guides/primitives/functions) independently.</Tip>

--- a/docs/snippets/generated/clickup/PreBuiltUseCases.mdx
+++ b/docs/snippets/generated/clickup/PreBuiltUseCases.mdx
@@ -1,3 +1,3 @@
 _No pre-built syncs or actions available yet._
 
-<Tip>Not seeing the integration you need? [Build your own](https://nango.dev/docs/guides/primitives/functions) independently.</Tip>
+<Tip>Not seeing the integration you need? [Build your own](/guides/primitives/functions) independently.</Tip>

--- a/docs/snippets/generated/close/PreBuiltUseCases.mdx
+++ b/docs/snippets/generated/close/PreBuiltUseCases.mdx
@@ -1,3 +1,3 @@
 _No pre-built syncs or actions available yet._
 
-<Tip>Not seeing the integration you need? [Build your own](https://nango.dev/docs/guides/primitives/functions) independently.</Tip>
+<Tip>Not seeing the integration you need? [Build your own](/guides/primitives/functions) independently.</Tip>

--- a/docs/snippets/generated/cloudbeds/PreBuiltUseCases.mdx
+++ b/docs/snippets/generated/cloudbeds/PreBuiltUseCases.mdx
@@ -1,3 +1,3 @@
 _No pre-built syncs or actions available yet._
 
-<Tip>Not seeing the integration you need? [Build your own](https://nango.dev/docs/guides/primitives/functions) independently.</Tip>
+<Tip>Not seeing the integration you need? [Build your own](/guides/primitives/functions) independently.</Tip>

--- a/docs/snippets/generated/cloudentity/PreBuiltUseCases.mdx
+++ b/docs/snippets/generated/cloudentity/PreBuiltUseCases.mdx
@@ -1,3 +1,3 @@
 _No pre-built syncs or actions available yet._
 
-<Tip>Not seeing the integration you need? [Build your own](https://nango.dev/docs/guides/primitives/functions) independently.</Tip>
+<Tip>Not seeing the integration you need? [Build your own](/guides/primitives/functions) independently.</Tip>

--- a/docs/snippets/generated/cloudflare/PreBuiltUseCases.mdx
+++ b/docs/snippets/generated/cloudflare/PreBuiltUseCases.mdx
@@ -1,3 +1,3 @@
 _No pre-built syncs or actions available yet._
 
-<Tip>Not seeing the integration you need? [Build your own](https://nango.dev/docs/guides/primitives/functions) independently.</Tip>
+<Tip>Not seeing the integration you need? [Build your own](/guides/primitives/functions) independently.</Tip>

--- a/docs/snippets/generated/cloudtalk/PreBuiltUseCases.mdx
+++ b/docs/snippets/generated/cloudtalk/PreBuiltUseCases.mdx
@@ -1,3 +1,3 @@
 _No pre-built syncs or actions available yet._
 
-<Tip>Not seeing the integration you need? [Build your own](https://nango.dev/docs/guides/primitives/functions) independently.</Tip>
+<Tip>Not seeing the integration you need? [Build your own](/guides/primitives/functions) independently.</Tip>

--- a/docs/snippets/generated/coda/PreBuiltUseCases.mdx
+++ b/docs/snippets/generated/coda/PreBuiltUseCases.mdx
@@ -1,3 +1,3 @@
 _No pre-built syncs or actions available yet._
 
-<Tip>Not seeing the integration you need? [Build your own](https://nango.dev/docs/guides/primitives/functions) independently.</Tip>
+<Tip>Not seeing the integration you need? [Build your own](/guides/primitives/functions) independently.</Tip>

--- a/docs/snippets/generated/codeclimate/PreBuiltUseCases.mdx
+++ b/docs/snippets/generated/codeclimate/PreBuiltUseCases.mdx
@@ -1,3 +1,3 @@
 _No pre-built syncs or actions available yet._
 
-<Tip>Not seeing the integration you need? [Build your own](https://nango.dev/docs/guides/primitives/functions) independently.</Tip>
+<Tip>Not seeing the integration you need? [Build your own](/guides/primitives/functions) independently.</Tip>

--- a/docs/snippets/generated/codegen/PreBuiltUseCases.mdx
+++ b/docs/snippets/generated/codegen/PreBuiltUseCases.mdx
@@ -1,3 +1,3 @@
 _No pre-built syncs or actions available yet._
 
-<Tip>Not seeing the integration you need? [Build your own](https://nango.dev/docs/guides/primitives/functions) independently.</Tip>
+<Tip>Not seeing the integration you need? [Build your own](/guides/primitives/functions) independently.</Tip>

--- a/docs/snippets/generated/commercetools/PreBuiltUseCases.mdx
+++ b/docs/snippets/generated/commercetools/PreBuiltUseCases.mdx
@@ -1,3 +1,3 @@
 _No pre-built syncs or actions available yet._
 
-<Tip>Not seeing the integration you need? [Build your own](https://nango.dev/docs/guides/primitives/functions) independently.</Tip>
+<Tip>Not seeing the integration you need? [Build your own](/guides/primitives/functions) independently.</Tip>

--- a/docs/snippets/generated/companycam/PreBuiltUseCases.mdx
+++ b/docs/snippets/generated/companycam/PreBuiltUseCases.mdx
@@ -1,3 +1,3 @@
 _No pre-built syncs or actions available yet._
 
-<Tip>Not seeing the integration you need? [Build your own](https://nango.dev/docs/guides/primitives/functions) independently.</Tip>
+<Tip>Not seeing the integration you need? [Build your own](/guides/primitives/functions) independently.</Tip>

--- a/docs/snippets/generated/conductorone/PreBuiltUseCases.mdx
+++ b/docs/snippets/generated/conductorone/PreBuiltUseCases.mdx
@@ -1,3 +1,3 @@
 _No pre-built syncs or actions available yet._
 
-<Tip>Not seeing the integration you need? [Build your own](https://nango.dev/docs/guides/primitives/functions) independently.</Tip>
+<Tip>Not seeing the integration you need? [Build your own](/guides/primitives/functions) independently.</Tip>

--- a/docs/snippets/generated/confluence-basic/PreBuiltUseCases.mdx
+++ b/docs/snippets/generated/confluence-basic/PreBuiltUseCases.mdx
@@ -1,3 +1,3 @@
 _No pre-built syncs or actions available yet._
 
-<Tip>Not seeing the integration you need? [Build your own](https://nango.dev/docs/guides/primitives/functions) independently.</Tip>
+<Tip>Not seeing the integration you need? [Build your own](/guides/primitives/functions) independently.</Tip>

--- a/docs/snippets/generated/confluence-data-center/PreBuiltUseCases.mdx
+++ b/docs/snippets/generated/confluence-data-center/PreBuiltUseCases.mdx
@@ -1,3 +1,3 @@
 _No pre-built syncs or actions available yet._
 
-<Tip>Not seeing the integration you need? [Build your own](https://nango.dev/docs/guides/primitives/functions) independently.</Tip>
+<Tip>Not seeing the integration you need? [Build your own](/guides/primitives/functions) independently.</Tip>

--- a/docs/snippets/generated/connectwise-psa-staging/PreBuiltUseCases.mdx
+++ b/docs/snippets/generated/connectwise-psa-staging/PreBuiltUseCases.mdx
@@ -1,3 +1,3 @@
 _No pre-built syncs or actions available yet._
 
-<Tip>Not seeing the integration you need? [Build your own](https://nango.dev/docs/guides/primitives/functions) independently.</Tip>
+<Tip>Not seeing the integration you need? [Build your own](/guides/primitives/functions) independently.</Tip>

--- a/docs/snippets/generated/connectwise-psa/PreBuiltUseCases.mdx
+++ b/docs/snippets/generated/connectwise-psa/PreBuiltUseCases.mdx
@@ -1,3 +1,3 @@
 _No pre-built syncs or actions available yet._
 
-<Tip>Not seeing the integration you need? [Build your own](https://nango.dev/docs/guides/primitives/functions) independently.</Tip>
+<Tip>Not seeing the integration you need? [Build your own](/guides/primitives/functions) independently.</Tip>

--- a/docs/snippets/generated/connectwise-rmm/PreBuiltUseCases.mdx
+++ b/docs/snippets/generated/connectwise-rmm/PreBuiltUseCases.mdx
@@ -1,3 +1,3 @@
 _No pre-built syncs or actions available yet._
 
-<Tip>Not seeing the integration you need? [Build your own](https://nango.dev/docs/guides/primitives/functions) independently.</Tip>
+<Tip>Not seeing the integration you need? [Build your own](/guides/primitives/functions) independently.</Tip>

--- a/docs/snippets/generated/constant-contact/PreBuiltUseCases.mdx
+++ b/docs/snippets/generated/constant-contact/PreBuiltUseCases.mdx
@@ -1,3 +1,3 @@
 _No pre-built syncs or actions available yet._
 
-<Tip>Not seeing the integration you need? [Build your own](https://nango.dev/docs/guides/primitives/functions) independently.</Tip>
+<Tip>Not seeing the integration you need? [Build your own](/guides/primitives/functions) independently.</Tip>

--- a/docs/snippets/generated/contactout/PreBuiltUseCases.mdx
+++ b/docs/snippets/generated/contactout/PreBuiltUseCases.mdx
@@ -1,3 +1,3 @@
 _No pre-built syncs or actions available yet._
 
-<Tip>Not seeing the integration you need? [Build your own](https://nango.dev/docs/guides/primitives/functions) independently.</Tip>
+<Tip>Not seeing the integration you need? [Build your own](/guides/primitives/functions) independently.</Tip>

--- a/docs/snippets/generated/contentful/PreBuiltUseCases.mdx
+++ b/docs/snippets/generated/contentful/PreBuiltUseCases.mdx
@@ -1,3 +1,3 @@
 _No pre-built syncs or actions available yet._
 
-<Tip>Not seeing the integration you need? [Build your own](https://nango.dev/docs/guides/primitives/functions) independently.</Tip>
+<Tip>Not seeing the integration you need? [Build your own](/guides/primitives/functions) independently.</Tip>

--- a/docs/snippets/generated/contentstack/PreBuiltUseCases.mdx
+++ b/docs/snippets/generated/contentstack/PreBuiltUseCases.mdx
@@ -1,3 +1,3 @@
 _No pre-built syncs or actions available yet._
 
-<Tip>Not seeing the integration you need? [Build your own](https://nango.dev/docs/guides/primitives/functions) independently.</Tip>
+<Tip>Not seeing the integration you need? [Build your own](/guides/primitives/functions) independently.</Tip>

--- a/docs/snippets/generated/copper-api-key/PreBuiltUseCases.mdx
+++ b/docs/snippets/generated/copper-api-key/PreBuiltUseCases.mdx
@@ -1,3 +1,3 @@
 _No pre-built syncs or actions available yet._
 
-<Tip>Not seeing the integration you need? [Build your own](https://nango.dev/docs/guides/primitives/functions) independently.</Tip>
+<Tip>Not seeing the integration you need? [Build your own](/guides/primitives/functions) independently.</Tip>

--- a/docs/snippets/generated/copper/PreBuiltUseCases.mdx
+++ b/docs/snippets/generated/copper/PreBuiltUseCases.mdx
@@ -1,3 +1,3 @@
 _No pre-built syncs or actions available yet._
 
-<Tip>Not seeing the integration you need? [Build your own](https://nango.dev/docs/guides/primitives/functions) independently.</Tip>
+<Tip>Not seeing the integration you need? [Build your own](/guides/primitives/functions) independently.</Tip>

--- a/docs/snippets/generated/coros-sandbox/PreBuiltUseCases.mdx
+++ b/docs/snippets/generated/coros-sandbox/PreBuiltUseCases.mdx
@@ -1,3 +1,3 @@
 _No pre-built syncs or actions available yet._
 
-<Tip>Not seeing the integration you need? [Build your own](https://nango.dev/docs/guides/primitives/functions) independently.</Tip>
+<Tip>Not seeing the integration you need? [Build your own](/guides/primitives/functions) independently.</Tip>

--- a/docs/snippets/generated/coros/PreBuiltUseCases.mdx
+++ b/docs/snippets/generated/coros/PreBuiltUseCases.mdx
@@ -1,3 +1,3 @@
 _No pre-built syncs or actions available yet._
 
-<Tip>Not seeing the integration you need? [Build your own](https://nango.dev/docs/guides/primitives/functions) independently.</Tip>
+<Tip>Not seeing the integration you need? [Build your own](/guides/primitives/functions) independently.</Tip>

--- a/docs/snippets/generated/coupa-compass/PreBuiltUseCases.mdx
+++ b/docs/snippets/generated/coupa-compass/PreBuiltUseCases.mdx
@@ -1,3 +1,3 @@
 _No pre-built syncs or actions available yet._
 
-<Tip>Not seeing the integration you need? [Build your own](https://nango.dev/docs/guides/primitives/functions) independently.</Tip>
+<Tip>Not seeing the integration you need? [Build your own](/guides/primitives/functions) independently.</Tip>

--- a/docs/snippets/generated/crisp-plugin-install/PreBuiltUseCases.mdx
+++ b/docs/snippets/generated/crisp-plugin-install/PreBuiltUseCases.mdx
@@ -1,3 +1,3 @@
 _No pre-built syncs or actions available yet._
 
-<Tip>Not seeing the integration you need? [Build your own](https://nango.dev/docs/guides/primitives/functions) independently.</Tip>
+<Tip>Not seeing the integration you need? [Build your own](/guides/primitives/functions) independently.</Tip>

--- a/docs/snippets/generated/crisp/PreBuiltUseCases.mdx
+++ b/docs/snippets/generated/crisp/PreBuiltUseCases.mdx
@@ -1,3 +1,3 @@
 _No pre-built syncs or actions available yet._
 
-<Tip>Not seeing the integration you need? [Build your own](https://nango.dev/docs/guides/primitives/functions) independently.</Tip>
+<Tip>Not seeing the integration you need? [Build your own](/guides/primitives/functions) independently.</Tip>

--- a/docs/snippets/generated/crowdstrike/PreBuiltUseCases.mdx
+++ b/docs/snippets/generated/crowdstrike/PreBuiltUseCases.mdx
@@ -1,3 +1,3 @@
 _No pre-built syncs or actions available yet._
 
-<Tip>Not seeing the integration you need? [Build your own](https://nango.dev/docs/guides/primitives/functions) independently.</Tip>
+<Tip>Not seeing the integration you need? [Build your own](/guides/primitives/functions) independently.</Tip>

--- a/docs/snippets/generated/cursor-admin/PreBuiltUseCases.mdx
+++ b/docs/snippets/generated/cursor-admin/PreBuiltUseCases.mdx
@@ -1,3 +1,3 @@
 _No pre-built syncs or actions available yet._
 
-<Tip>Not seeing the integration you need? [Build your own](https://nango.dev/docs/guides/primitives/functions) independently.</Tip>
+<Tip>Not seeing the integration you need? [Build your own](/guides/primitives/functions) independently.</Tip>

--- a/docs/snippets/generated/cursor/PreBuiltUseCases.mdx
+++ b/docs/snippets/generated/cursor/PreBuiltUseCases.mdx
@@ -1,3 +1,3 @@
 _No pre-built syncs or actions available yet._
 
-<Tip>Not seeing the integration you need? [Build your own](https://nango.dev/docs/guides/primitives/functions) independently.</Tip>
+<Tip>Not seeing the integration you need? [Build your own](/guides/primitives/functions) independently.</Tip>

--- a/docs/snippets/generated/cyberimpact/PreBuiltUseCases.mdx
+++ b/docs/snippets/generated/cyberimpact/PreBuiltUseCases.mdx
@@ -1,3 +1,3 @@
 _No pre-built syncs or actions available yet._
 
-<Tip>Not seeing the integration you need? [Build your own](https://nango.dev/docs/guides/primitives/functions) independently.</Tip>
+<Tip>Not seeing the integration you need? [Build your own](/guides/primitives/functions) independently.</Tip>

--- a/docs/snippets/generated/databricks-account/PreBuiltUseCases.mdx
+++ b/docs/snippets/generated/databricks-account/PreBuiltUseCases.mdx
@@ -1,3 +1,3 @@
 _No pre-built syncs or actions available yet._
 
-<Tip>Not seeing the integration you need? [Build your own](https://nango.dev/docs/guides/primitives/functions) independently.</Tip>
+<Tip>Not seeing the integration you need? [Build your own](/guides/primitives/functions) independently.</Tip>

--- a/docs/snippets/generated/datacandy/PreBuiltUseCases.mdx
+++ b/docs/snippets/generated/datacandy/PreBuiltUseCases.mdx
@@ -1,3 +1,3 @@
 _No pre-built syncs or actions available yet._
 
-<Tip>Not seeing the integration you need? [Build your own](https://nango.dev/docs/guides/primitives/functions) independently.</Tip>
+<Tip>Not seeing the integration you need? [Build your own](/guides/primitives/functions) independently.</Tip>

--- a/docs/snippets/generated/datev/PreBuiltUseCases.mdx
+++ b/docs/snippets/generated/datev/PreBuiltUseCases.mdx
@@ -1,3 +1,3 @@
 _No pre-built syncs or actions available yet._
 
-<Tip>Not seeing the integration you need? [Build your own](https://nango.dev/docs/guides/primitives/functions) independently.</Tip>
+<Tip>Not seeing the integration you need? [Build your own](/guides/primitives/functions) independently.</Tip>

--- a/docs/snippets/generated/datto-rmm-password-grant/PreBuiltUseCases.mdx
+++ b/docs/snippets/generated/datto-rmm-password-grant/PreBuiltUseCases.mdx
@@ -1,3 +1,3 @@
 _No pre-built syncs or actions available yet._
 
-<Tip>Not seeing the integration you need? [Build your own](https://nango.dev/docs/guides/primitives/functions) independently.</Tip>
+<Tip>Not seeing the integration you need? [Build your own](/guides/primitives/functions) independently.</Tip>

--- a/docs/snippets/generated/datto-rmm/PreBuiltUseCases.mdx
+++ b/docs/snippets/generated/datto-rmm/PreBuiltUseCases.mdx
@@ -1,3 +1,3 @@
 _No pre-built syncs or actions available yet._
 
-<Tip>Not seeing the integration you need? [Build your own](https://nango.dev/docs/guides/primitives/functions) independently.</Tip>
+<Tip>Not seeing the integration you need? [Build your own](/guides/primitives/functions) independently.</Tip>

--- a/docs/snippets/generated/dayforce/PreBuiltUseCases.mdx
+++ b/docs/snippets/generated/dayforce/PreBuiltUseCases.mdx
@@ -1,3 +1,3 @@
 _No pre-built syncs or actions available yet._
 
-<Tip>Not seeing the integration you need? [Build your own](https://nango.dev/docs/guides/primitives/functions) independently.</Tip>
+<Tip>Not seeing the integration you need? [Build your own](/guides/primitives/functions) independently.</Tip>

--- a/docs/snippets/generated/deel-sandbox/PreBuiltUseCases.mdx
+++ b/docs/snippets/generated/deel-sandbox/PreBuiltUseCases.mdx
@@ -1,3 +1,3 @@
 _No pre-built syncs or actions available yet._
 
-<Tip>Not seeing the integration you need? [Build your own](https://nango.dev/docs/guides/primitives/functions) independently.</Tip>
+<Tip>Not seeing the integration you need? [Build your own](/guides/primitives/functions) independently.</Tip>

--- a/docs/snippets/generated/deel/PreBuiltUseCases.mdx
+++ b/docs/snippets/generated/deel/PreBuiltUseCases.mdx
@@ -1,3 +1,3 @@
 _No pre-built syncs or actions available yet._
 
-<Tip>Not seeing the integration you need? [Build your own](https://nango.dev/docs/guides/primitives/functions) independently.</Tip>
+<Tip>Not seeing the integration you need? [Build your own](/guides/primitives/functions) independently.</Tip>

--- a/docs/snippets/generated/demodesk/PreBuiltUseCases.mdx
+++ b/docs/snippets/generated/demodesk/PreBuiltUseCases.mdx
@@ -1,3 +1,3 @@
 _No pre-built syncs or actions available yet._
 
-<Tip>Not seeing the integration you need? [Build your own](https://nango.dev/docs/guides/primitives/functions) independently.</Tip>
+<Tip>Not seeing the integration you need? [Build your own](/guides/primitives/functions) independently.</Tip>

--- a/docs/snippets/generated/devin/PreBuiltUseCases.mdx
+++ b/docs/snippets/generated/devin/PreBuiltUseCases.mdx
@@ -1,3 +1,3 @@
 _No pre-built syncs or actions available yet._
 
-<Tip>Not seeing the integration you need? [Build your own](https://nango.dev/docs/guides/primitives/functions) independently.</Tip>
+<Tip>Not seeing the integration you need? [Build your own](/guides/primitives/functions) independently.</Tip>

--- a/docs/snippets/generated/digitalocean/PreBuiltUseCases.mdx
+++ b/docs/snippets/generated/digitalocean/PreBuiltUseCases.mdx
@@ -1,3 +1,3 @@
 _No pre-built syncs or actions available yet._
 
-<Tip>Not seeing the integration you need? [Build your own](https://nango.dev/docs/guides/primitives/functions) independently.</Tip>
+<Tip>Not seeing the integration you need? [Build your own](/guides/primitives/functions) independently.</Tip>

--- a/docs/snippets/generated/discord/PreBuiltUseCases.mdx
+++ b/docs/snippets/generated/discord/PreBuiltUseCases.mdx
@@ -1,3 +1,3 @@
 _No pre-built syncs or actions available yet._
 
-<Tip>Not seeing the integration you need? [Build your own](https://nango.dev/docs/guides/primitives/functions) independently.</Tip>
+<Tip>Not seeing the integration you need? [Build your own](/guides/primitives/functions) independently.</Tip>

--- a/docs/snippets/generated/dixa/PreBuiltUseCases.mdx
+++ b/docs/snippets/generated/dixa/PreBuiltUseCases.mdx
@@ -1,3 +1,3 @@
 _No pre-built syncs or actions available yet._
 
-<Tip>Not seeing the integration you need? [Build your own](https://nango.dev/docs/guides/primitives/functions) independently.</Tip>
+<Tip>Not seeing the integration you need? [Build your own](/guides/primitives/functions) independently.</Tip>

--- a/docs/snippets/generated/document360/PreBuiltUseCases.mdx
+++ b/docs/snippets/generated/document360/PreBuiltUseCases.mdx
@@ -1,3 +1,3 @@
 _No pre-built syncs or actions available yet._
 
-<Tip>Not seeing the integration you need? [Build your own](https://nango.dev/docs/guides/primitives/functions) independently.</Tip>
+<Tip>Not seeing the integration you need? [Build your own](/guides/primitives/functions) independently.</Tip>

--- a/docs/snippets/generated/docuware/PreBuiltUseCases.mdx
+++ b/docs/snippets/generated/docuware/PreBuiltUseCases.mdx
@@ -1,3 +1,3 @@
 _No pre-built syncs or actions available yet._
 
-<Tip>Not seeing the integration you need? [Build your own](https://nango.dev/docs/guides/primitives/functions) independently.</Tip>
+<Tip>Not seeing the integration you need? [Build your own](/guides/primitives/functions) independently.</Tip>

--- a/docs/snippets/generated/domo/PreBuiltUseCases.mdx
+++ b/docs/snippets/generated/domo/PreBuiltUseCases.mdx
@@ -1,3 +1,3 @@
 _No pre-built syncs or actions available yet._
 
-<Tip>Not seeing the integration you need? [Build your own](https://nango.dev/docs/guides/primitives/functions) independently.</Tip>
+<Tip>Not seeing the integration you need? [Build your own](/guides/primitives/functions) independently.</Tip>

--- a/docs/snippets/generated/drata/PreBuiltUseCases.mdx
+++ b/docs/snippets/generated/drata/PreBuiltUseCases.mdx
@@ -1,3 +1,3 @@
 _No pre-built syncs or actions available yet._
 
-<Tip>Not seeing the integration you need? [Build your own](https://nango.dev/docs/guides/primitives/functions) independently.</Tip>
+<Tip>Not seeing the integration you need? [Build your own](/guides/primitives/functions) independently.</Tip>

--- a/docs/snippets/generated/drchrono/PreBuiltUseCases.mdx
+++ b/docs/snippets/generated/drchrono/PreBuiltUseCases.mdx
@@ -1,3 +1,3 @@
 _No pre-built syncs or actions available yet._
 
-<Tip>Not seeing the integration you need? [Build your own](https://nango.dev/docs/guides/primitives/functions) independently.</Tip>
+<Tip>Not seeing the integration you need? [Build your own](/guides/primitives/functions) independently.</Tip>

--- a/docs/snippets/generated/dropbox-sign/PreBuiltUseCases.mdx
+++ b/docs/snippets/generated/dropbox-sign/PreBuiltUseCases.mdx
@@ -1,3 +1,3 @@
 _No pre-built syncs or actions available yet._
 
-<Tip>Not seeing the integration you need? [Build your own](https://nango.dev/docs/guides/primitives/functions) independently.</Tip>
+<Tip>Not seeing the integration you need? [Build your own](/guides/primitives/functions) independently.</Tip>

--- a/docs/snippets/generated/drupal/PreBuiltUseCases.mdx
+++ b/docs/snippets/generated/drupal/PreBuiltUseCases.mdx
@@ -1,3 +1,3 @@
 _No pre-built syncs or actions available yet._
 
-<Tip>Not seeing the integration you need? [Build your own](https://nango.dev/docs/guides/primitives/functions) independently.</Tip>
+<Tip>Not seeing the integration you need? [Build your own](/guides/primitives/functions) independently.</Tip>

--- a/docs/snippets/generated/e-conomic/PreBuiltUseCases.mdx
+++ b/docs/snippets/generated/e-conomic/PreBuiltUseCases.mdx
@@ -1,3 +1,3 @@
 _No pre-built syncs or actions available yet._
 
-<Tip>Not seeing the integration you need? [Build your own](https://nango.dev/docs/guides/primitives/functions) independently.</Tip>
+<Tip>Not seeing the integration you need? [Build your own](/guides/primitives/functions) independently.</Tip>

--- a/docs/snippets/generated/ebay-sandbox/PreBuiltUseCases.mdx
+++ b/docs/snippets/generated/ebay-sandbox/PreBuiltUseCases.mdx
@@ -1,3 +1,3 @@
 _No pre-built syncs or actions available yet._
 
-<Tip>Not seeing the integration you need? [Build your own](https://nango.dev/docs/guides/primitives/functions) independently.</Tip>
+<Tip>Not seeing the integration you need? [Build your own](/guides/primitives/functions) independently.</Tip>

--- a/docs/snippets/generated/ebay/PreBuiltUseCases.mdx
+++ b/docs/snippets/generated/ebay/PreBuiltUseCases.mdx
@@ -1,3 +1,3 @@
 _No pre-built syncs or actions available yet._
 
-<Tip>Not seeing the integration you need? [Build your own](https://nango.dev/docs/guides/primitives/functions) independently.</Tip>
+<Tip>Not seeing the integration you need? [Build your own](/guides/primitives/functions) independently.</Tip>

--- a/docs/snippets/generated/ecu360-production/PreBuiltUseCases.mdx
+++ b/docs/snippets/generated/ecu360-production/PreBuiltUseCases.mdx
@@ -1,3 +1,3 @@
 _No pre-built syncs or actions available yet._
 
-<Tip>Not seeing the integration you need? [Build your own](https://nango.dev/docs/guides/primitives/functions) independently.</Tip>
+<Tip>Not seeing the integration you need? [Build your own](/guides/primitives/functions) independently.</Tip>

--- a/docs/snippets/generated/ecu360/PreBuiltUseCases.mdx
+++ b/docs/snippets/generated/ecu360/PreBuiltUseCases.mdx
@@ -1,3 +1,3 @@
 _No pre-built syncs or actions available yet._
 
-<Tip>Not seeing the integration you need? [Build your own](https://nango.dev/docs/guides/primitives/functions) independently.</Tip>
+<Tip>Not seeing the integration you need? [Build your own](/guides/primitives/functions) independently.</Tip>

--- a/docs/snippets/generated/egnyte/PreBuiltUseCases.mdx
+++ b/docs/snippets/generated/egnyte/PreBuiltUseCases.mdx
@@ -1,3 +1,3 @@
 _No pre-built syncs or actions available yet._
 
-<Tip>Not seeing the integration you need? [Build your own](https://nango.dev/docs/guides/primitives/functions) independently.</Tip>
+<Tip>Not seeing the integration you need? [Build your own](/guides/primitives/functions) independently.</Tip>

--- a/docs/snippets/generated/elevenlabs/PreBuiltUseCases.mdx
+++ b/docs/snippets/generated/elevenlabs/PreBuiltUseCases.mdx
@@ -1,3 +1,3 @@
 _No pre-built syncs or actions available yet._
 
-<Tip>Not seeing the integration you need? [Build your own](https://nango.dev/docs/guides/primitives/functions) independently.</Tip>
+<Tip>Not seeing the integration you need? [Build your own](/guides/primitives/functions) independently.</Tip>

--- a/docs/snippets/generated/elevio/PreBuiltUseCases.mdx
+++ b/docs/snippets/generated/elevio/PreBuiltUseCases.mdx
@@ -1,3 +1,3 @@
 _No pre-built syncs or actions available yet._
 
-<Tip>Not seeing the integration you need? [Build your own](https://nango.dev/docs/guides/primitives/functions) independently.</Tip>
+<Tip>Not seeing the integration you need? [Build your own](/guides/primitives/functions) independently.</Tip>

--- a/docs/snippets/generated/emarsys-oauth/PreBuiltUseCases.mdx
+++ b/docs/snippets/generated/emarsys-oauth/PreBuiltUseCases.mdx
@@ -1,3 +1,3 @@
 _No pre-built syncs or actions available yet._
 
-<Tip>Not seeing the integration you need? [Build your own](https://nango.dev/docs/guides/primitives/functions) independently.</Tip>
+<Tip>Not seeing the integration you need? [Build your own](/guides/primitives/functions) independently.</Tip>

--- a/docs/snippets/generated/emarsys/PreBuiltUseCases.mdx
+++ b/docs/snippets/generated/emarsys/PreBuiltUseCases.mdx
@@ -1,3 +1,3 @@
 _No pre-built syncs or actions available yet._
 
-<Tip>Not seeing the integration you need? [Build your own](https://nango.dev/docs/guides/primitives/functions) independently.</Tip>
+<Tip>Not seeing the integration you need? [Build your own](/guides/primitives/functions) independently.</Tip>

--- a/docs/snippets/generated/employment-hero/PreBuiltUseCases.mdx
+++ b/docs/snippets/generated/employment-hero/PreBuiltUseCases.mdx
@@ -1,3 +1,3 @@
 _No pre-built syncs or actions available yet._
 
-<Tip>Not seeing the integration you need? [Build your own](https://nango.dev/docs/guides/primitives/functions) independently.</Tip>
+<Tip>Not seeing the integration you need? [Build your own](/guides/primitives/functions) independently.</Tip>

--- a/docs/snippets/generated/entrata/PreBuiltUseCases.mdx
+++ b/docs/snippets/generated/entrata/PreBuiltUseCases.mdx
@@ -1,3 +1,3 @@
 _No pre-built syncs or actions available yet._
 
-<Tip>Not seeing the integration you need? [Build your own](https://nango.dev/docs/guides/primitives/functions) independently.</Tip>
+<Tip>Not seeing the integration you need? [Build your own](/guides/primitives/functions) independently.</Tip>

--- a/docs/snippets/generated/envoy/PreBuiltUseCases.mdx
+++ b/docs/snippets/generated/envoy/PreBuiltUseCases.mdx
@@ -1,3 +1,3 @@
 _No pre-built syncs or actions available yet._
 
-<Tip>Not seeing the integration you need? [Build your own](https://nango.dev/docs/guides/primitives/functions) independently.</Tip>
+<Tip>Not seeing the integration you need? [Build your own](/guides/primitives/functions) independently.</Tip>

--- a/docs/snippets/generated/epic-games/PreBuiltUseCases.mdx
+++ b/docs/snippets/generated/epic-games/PreBuiltUseCases.mdx
@@ -1,3 +1,3 @@
 _No pre-built syncs or actions available yet._
 
-<Tip>Not seeing the integration you need? [Build your own](https://nango.dev/docs/guides/primitives/functions) independently.</Tip>
+<Tip>Not seeing the integration you need? [Build your own](/guides/primitives/functions) independently.</Tip>

--- a/docs/snippets/generated/eventbrite/PreBuiltUseCases.mdx
+++ b/docs/snippets/generated/eventbrite/PreBuiltUseCases.mdx
@@ -1,3 +1,3 @@
 _No pre-built syncs or actions available yet._
 
-<Tip>Not seeing the integration you need? [Build your own](https://nango.dev/docs/guides/primitives/functions) independently.</Tip>
+<Tip>Not seeing the integration you need? [Build your own](/guides/primitives/functions) independently.</Tip>

--- a/docs/snippets/generated/exa/PreBuiltUseCases.mdx
+++ b/docs/snippets/generated/exa/PreBuiltUseCases.mdx
@@ -1,3 +1,3 @@
 _No pre-built syncs or actions available yet._
 
-<Tip>Not seeing the integration you need? [Build your own](https://nango.dev/docs/guides/primitives/functions) independently.</Tip>
+<Tip>Not seeing the integration you need? [Build your own](/guides/primitives/functions) independently.</Tip>

--- a/docs/snippets/generated/exist/PreBuiltUseCases.mdx
+++ b/docs/snippets/generated/exist/PreBuiltUseCases.mdx
@@ -1,3 +1,3 @@
 _No pre-built syncs or actions available yet._
 
-<Tip>Not seeing the integration you need? [Build your own](https://nango.dev/docs/guides/primitives/functions) independently.</Tip>
+<Tip>Not seeing the integration you need? [Build your own](/guides/primitives/functions) independently.</Tip>

--- a/docs/snippets/generated/facebook/PreBuiltUseCases.mdx
+++ b/docs/snippets/generated/facebook/PreBuiltUseCases.mdx
@@ -1,3 +1,3 @@
 _No pre-built syncs or actions available yet._
 
-<Tip>Not seeing the integration you need? [Build your own](https://nango.dev/docs/guides/primitives/functions) independently.</Tip>
+<Tip>Not seeing the integration you need? [Build your own](/guides/primitives/functions) independently.</Tip>

--- a/docs/snippets/generated/factorial/PreBuiltUseCases.mdx
+++ b/docs/snippets/generated/factorial/PreBuiltUseCases.mdx
@@ -1,3 +1,3 @@
 _No pre-built syncs or actions available yet._
 
-<Tip>Not seeing the integration you need? [Build your own](https://nango.dev/docs/guides/primitives/functions) independently.</Tip>
+<Tip>Not seeing the integration you need? [Build your own](/guides/primitives/functions) independently.</Tip>

--- a/docs/snippets/generated/fairing/PreBuiltUseCases.mdx
+++ b/docs/snippets/generated/fairing/PreBuiltUseCases.mdx
@@ -1,3 +1,3 @@
 _No pre-built syncs or actions available yet._
 
-<Tip>Not seeing the integration you need? [Build your own](https://nango.dev/docs/guides/primitives/functions) independently.</Tip>
+<Tip>Not seeing the integration you need? [Build your own](/guides/primitives/functions) independently.</Tip>

--- a/docs/snippets/generated/falai/PreBuiltUseCases.mdx
+++ b/docs/snippets/generated/falai/PreBuiltUseCases.mdx
@@ -1,3 +1,3 @@
 _No pre-built syncs or actions available yet._
 
-<Tip>Not seeing the integration you need? [Build your own](https://nango.dev/docs/guides/primitives/functions) independently.</Tip>
+<Tip>Not seeing the integration you need? [Build your own](/guides/primitives/functions) independently.</Tip>

--- a/docs/snippets/generated/fanvue/PreBuiltUseCases.mdx
+++ b/docs/snippets/generated/fanvue/PreBuiltUseCases.mdx
@@ -1,3 +1,3 @@
 _No pre-built syncs or actions available yet._
 
-<Tip>Not seeing the integration you need? [Build your own](https://nango.dev/docs/guides/primitives/functions) independently.</Tip>
+<Tip>Not seeing the integration you need? [Build your own](/guides/primitives/functions) independently.</Tip>

--- a/docs/snippets/generated/fathom-oauth/PreBuiltUseCases.mdx
+++ b/docs/snippets/generated/fathom-oauth/PreBuiltUseCases.mdx
@@ -1,3 +1,3 @@
 _No pre-built syncs or actions available yet._
 
-<Tip>Not seeing the integration you need? [Build your own](https://nango.dev/docs/guides/primitives/functions) independently.</Tip>
+<Tip>Not seeing the integration you need? [Build your own](/guides/primitives/functions) independently.</Tip>

--- a/docs/snippets/generated/fathom/PreBuiltUseCases.mdx
+++ b/docs/snippets/generated/fathom/PreBuiltUseCases.mdx
@@ -1,3 +1,3 @@
 _No pre-built syncs or actions available yet._
 
-<Tip>Not seeing the integration you need? [Build your own](https://nango.dev/docs/guides/primitives/functions) independently.</Tip>
+<Tip>Not seeing the integration you need? [Build your own](/guides/primitives/functions) independently.</Tip>

--- a/docs/snippets/generated/fellow/PreBuiltUseCases.mdx
+++ b/docs/snippets/generated/fellow/PreBuiltUseCases.mdx
@@ -1,3 +1,3 @@
 _No pre-built syncs or actions available yet._
 
-<Tip>Not seeing the integration you need? [Build your own](https://nango.dev/docs/guides/primitives/functions) independently.</Tip>
+<Tip>Not seeing the integration you need? [Build your own](/guides/primitives/functions) independently.</Tip>

--- a/docs/snippets/generated/fiber-ai/PreBuiltUseCases.mdx
+++ b/docs/snippets/generated/fiber-ai/PreBuiltUseCases.mdx
@@ -1,3 +1,3 @@
 _No pre-built syncs or actions available yet._
 
-<Tip>Not seeing the integration you need? [Build your own](https://nango.dev/docs/guides/primitives/functions) independently.</Tip>
+<Tip>Not seeing the integration you need? [Build your own](/guides/primitives/functions) independently.</Tip>

--- a/docs/snippets/generated/figjam/PreBuiltUseCases.mdx
+++ b/docs/snippets/generated/figjam/PreBuiltUseCases.mdx
@@ -1,3 +1,3 @@
 _No pre-built syncs or actions available yet._
 
-<Tip>Not seeing the integration you need? [Build your own](https://nango.dev/docs/guides/primitives/functions) independently.</Tip>
+<Tip>Not seeing the integration you need? [Build your own](/guides/primitives/functions) independently.</Tip>

--- a/docs/snippets/generated/figma-scim/PreBuiltUseCases.mdx
+++ b/docs/snippets/generated/figma-scim/PreBuiltUseCases.mdx
@@ -1,3 +1,3 @@
 _No pre-built syncs or actions available yet._
 
-<Tip>Not seeing the integration you need? [Build your own](https://nango.dev/docs/guides/primitives/functions) independently.</Tip>
+<Tip>Not seeing the integration you need? [Build your own](/guides/primitives/functions) independently.</Tip>

--- a/docs/snippets/generated/figma/PreBuiltUseCases.mdx
+++ b/docs/snippets/generated/figma/PreBuiltUseCases.mdx
@@ -1,3 +1,3 @@
 _No pre-built syncs or actions available yet._
 
-<Tip>Not seeing the integration you need? [Build your own](https://nango.dev/docs/guides/primitives/functions) independently.</Tip>
+<Tip>Not seeing the integration you need? [Build your own](/guides/primitives/functions) independently.</Tip>

--- a/docs/snippets/generated/fillout-api-key/PreBuiltUseCases.mdx
+++ b/docs/snippets/generated/fillout-api-key/PreBuiltUseCases.mdx
@@ -1,3 +1,3 @@
 _No pre-built syncs or actions available yet._
 
-<Tip>Not seeing the integration you need? [Build your own](https://nango.dev/docs/guides/primitives/functions) independently.</Tip>
+<Tip>Not seeing the integration you need? [Build your own](/guides/primitives/functions) independently.</Tip>

--- a/docs/snippets/generated/fillout/PreBuiltUseCases.mdx
+++ b/docs/snippets/generated/fillout/PreBuiltUseCases.mdx
@@ -1,3 +1,3 @@
 _No pre-built syncs or actions available yet._
 
-<Tip>Not seeing the integration you need? [Build your own](https://nango.dev/docs/guides/primitives/functions) independently.</Tip>
+<Tip>Not seeing the integration you need? [Build your own](/guides/primitives/functions) independently.</Tip>

--- a/docs/snippets/generated/findymail/PreBuiltUseCases.mdx
+++ b/docs/snippets/generated/findymail/PreBuiltUseCases.mdx
@@ -1,3 +1,3 @@
 _No pre-built syncs or actions available yet._
 
-<Tip>Not seeing the integration you need? [Build your own](https://nango.dev/docs/guides/primitives/functions) independently.</Tip>
+<Tip>Not seeing the integration you need? [Build your own](/guides/primitives/functions) independently.</Tip>

--- a/docs/snippets/generated/firefish/PreBuiltUseCases.mdx
+++ b/docs/snippets/generated/firefish/PreBuiltUseCases.mdx
@@ -1,3 +1,3 @@
 _No pre-built syncs or actions available yet._
 
-<Tip>Not seeing the integration you need? [Build your own](https://nango.dev/docs/guides/primitives/functions) independently.</Tip>
+<Tip>Not seeing the integration you need? [Build your own](/guides/primitives/functions) independently.</Tip>

--- a/docs/snippets/generated/firstbase/PreBuiltUseCases.mdx
+++ b/docs/snippets/generated/firstbase/PreBuiltUseCases.mdx
@@ -1,3 +1,3 @@
 _No pre-built syncs or actions available yet._
 
-<Tip>Not seeing the integration you need? [Build your own](https://nango.dev/docs/guides/primitives/functions) independently.</Tip>
+<Tip>Not seeing the integration you need? [Build your own](/guides/primitives/functions) independently.</Tip>

--- a/docs/snippets/generated/fiserv-api-key/PreBuiltUseCases.mdx
+++ b/docs/snippets/generated/fiserv-api-key/PreBuiltUseCases.mdx
@@ -1,3 +1,3 @@
 _No pre-built syncs or actions available yet._
 
-<Tip>Not seeing the integration you need? [Build your own](https://nango.dev/docs/guides/primitives/functions) independently.</Tip>
+<Tip>Not seeing the integration you need? [Build your own](/guides/primitives/functions) independently.</Tip>

--- a/docs/snippets/generated/fiserv/PreBuiltUseCases.mdx
+++ b/docs/snippets/generated/fiserv/PreBuiltUseCases.mdx
@@ -1,3 +1,3 @@
 _No pre-built syncs or actions available yet._
 
-<Tip>Not seeing the integration you need? [Build your own](https://nango.dev/docs/guides/primitives/functions) independently.</Tip>
+<Tip>Not seeing the integration you need? [Build your own](/guides/primitives/functions) independently.</Tip>

--- a/docs/snippets/generated/fitbit/PreBuiltUseCases.mdx
+++ b/docs/snippets/generated/fitbit/PreBuiltUseCases.mdx
@@ -1,3 +1,3 @@
 _No pre-built syncs or actions available yet._
 
-<Tip>Not seeing the integration you need? [Build your own](https://nango.dev/docs/guides/primitives/functions) independently.</Tip>
+<Tip>Not seeing the integration you need? [Build your own](/guides/primitives/functions) independently.</Tip>

--- a/docs/snippets/generated/float/PreBuiltUseCases.mdx
+++ b/docs/snippets/generated/float/PreBuiltUseCases.mdx
@@ -1,3 +1,3 @@
 _No pre-built syncs or actions available yet._
 
-<Tip>Not seeing the integration you need? [Build your own](https://nango.dev/docs/guides/primitives/functions) independently.</Tip>
+<Tip>Not seeing the integration you need? [Build your own](/guides/primitives/functions) independently.</Tip>

--- a/docs/snippets/generated/folk/PreBuiltUseCases.mdx
+++ b/docs/snippets/generated/folk/PreBuiltUseCases.mdx
@@ -1,3 +1,3 @@
 _No pre-built syncs or actions available yet._
 
-<Tip>Not seeing the integration you need? [Build your own](https://nango.dev/docs/guides/primitives/functions) independently.</Tip>
+<Tip>Not seeing the integration you need? [Build your own](/guides/primitives/functions) independently.</Tip>

--- a/docs/snippets/generated/fortnox/PreBuiltUseCases.mdx
+++ b/docs/snippets/generated/fortnox/PreBuiltUseCases.mdx
@@ -1,3 +1,3 @@
 _No pre-built syncs or actions available yet._
 
-<Tip>Not seeing the integration you need? [Build your own](https://nango.dev/docs/guides/primitives/functions) independently.</Tip>
+<Tip>Not seeing the integration you need? [Build your own](/guides/primitives/functions) independently.</Tip>

--- a/docs/snippets/generated/freeagent-sandbox/PreBuiltUseCases.mdx
+++ b/docs/snippets/generated/freeagent-sandbox/PreBuiltUseCases.mdx
@@ -1,3 +1,3 @@
 _No pre-built syncs or actions available yet._
 
-<Tip>Not seeing the integration you need? [Build your own](https://nango.dev/docs/guides/primitives/functions) independently.</Tip>
+<Tip>Not seeing the integration you need? [Build your own](/guides/primitives/functions) independently.</Tip>

--- a/docs/snippets/generated/freeagent/PreBuiltUseCases.mdx
+++ b/docs/snippets/generated/freeagent/PreBuiltUseCases.mdx
@@ -1,3 +1,3 @@
 _No pre-built syncs or actions available yet._
 
-<Tip>Not seeing the integration you need? [Build your own](https://nango.dev/docs/guides/primitives/functions) independently.</Tip>
+<Tip>Not seeing the integration you need? [Build your own](/guides/primitives/functions) independently.</Tip>

--- a/docs/snippets/generated/freshbooks/PreBuiltUseCases.mdx
+++ b/docs/snippets/generated/freshbooks/PreBuiltUseCases.mdx
@@ -1,3 +1,3 @@
 _No pre-built syncs or actions available yet._
 
-<Tip>Not seeing the integration you need? [Build your own](https://nango.dev/docs/guides/primitives/functions) independently.</Tip>
+<Tip>Not seeing the integration you need? [Build your own](/guides/primitives/functions) independently.</Tip>

--- a/docs/snippets/generated/freshsales/PreBuiltUseCases.mdx
+++ b/docs/snippets/generated/freshsales/PreBuiltUseCases.mdx
@@ -1,3 +1,3 @@
 _No pre-built syncs or actions available yet._
 
-<Tip>Not seeing the integration you need? [Build your own](https://nango.dev/docs/guides/primitives/functions) independently.</Tip>
+<Tip>Not seeing the integration you need? [Build your own](/guides/primitives/functions) independently.</Tip>

--- a/docs/snippets/generated/freshservice/PreBuiltUseCases.mdx
+++ b/docs/snippets/generated/freshservice/PreBuiltUseCases.mdx
@@ -1,3 +1,3 @@
 _No pre-built syncs or actions available yet._
 
-<Tip>Not seeing the integration you need? [Build your own](https://nango.dev/docs/guides/primitives/functions) independently.</Tip>
+<Tip>Not seeing the integration you need? [Build your own](/guides/primitives/functions) independently.</Tip>

--- a/docs/snippets/generated/freshteam/PreBuiltUseCases.mdx
+++ b/docs/snippets/generated/freshteam/PreBuiltUseCases.mdx
@@ -1,3 +1,3 @@
 _No pre-built syncs or actions available yet._
 
-<Tip>Not seeing the integration you need? [Build your own](https://nango.dev/docs/guides/primitives/functions) independently.</Tip>
+<Tip>Not seeing the integration you need? [Build your own](/guides/primitives/functions) independently.</Tip>

--- a/docs/snippets/generated/fullenrich/PreBuiltUseCases.mdx
+++ b/docs/snippets/generated/fullenrich/PreBuiltUseCases.mdx
@@ -1,3 +1,3 @@
 _No pre-built syncs or actions available yet._
 
-<Tip>Not seeing the integration you need? [Build your own](https://nango.dev/docs/guides/primitives/functions) independently.</Tip>
+<Tip>Not seeing the integration you need? [Build your own](/guides/primitives/functions) independently.</Tip>

--- a/docs/snippets/generated/gainsight-cc/PreBuiltUseCases.mdx
+++ b/docs/snippets/generated/gainsight-cc/PreBuiltUseCases.mdx
@@ -1,3 +1,3 @@
 _No pre-built syncs or actions available yet._
 
-<Tip>Not seeing the integration you need? [Build your own](https://nango.dev/docs/guides/primitives/functions) independently.</Tip>
+<Tip>Not seeing the integration you need? [Build your own](/guides/primitives/functions) independently.</Tip>

--- a/docs/snippets/generated/gamma/PreBuiltUseCases.mdx
+++ b/docs/snippets/generated/gamma/PreBuiltUseCases.mdx
@@ -1,3 +1,3 @@
 _No pre-built syncs or actions available yet._
 
-<Tip>Not seeing the integration you need? [Build your own](https://nango.dev/docs/guides/primitives/functions) independently.</Tip>
+<Tip>Not seeing the integration you need? [Build your own](/guides/primitives/functions) independently.</Tip>

--- a/docs/snippets/generated/garmin/PreBuiltUseCases.mdx
+++ b/docs/snippets/generated/garmin/PreBuiltUseCases.mdx
@@ -1,3 +1,3 @@
 _No pre-built syncs or actions available yet._
 
-<Tip>Not seeing the integration you need? [Build your own](https://nango.dev/docs/guides/primitives/functions) independently.</Tip>
+<Tip>Not seeing the integration you need? [Build your own](/guides/primitives/functions) independently.</Tip>

--- a/docs/snippets/generated/gebruder-weiss/PreBuiltUseCases.mdx
+++ b/docs/snippets/generated/gebruder-weiss/PreBuiltUseCases.mdx
@@ -1,3 +1,3 @@
 _No pre-built syncs or actions available yet._
 
-<Tip>Not seeing the integration you need? [Build your own](https://nango.dev/docs/guides/primitives/functions) independently.</Tip>
+<Tip>Not seeing the integration you need? [Build your own](/guides/primitives/functions) independently.</Tip>

--- a/docs/snippets/generated/gemini/PreBuiltUseCases.mdx
+++ b/docs/snippets/generated/gemini/PreBuiltUseCases.mdx
@@ -1,3 +1,3 @@
 _No pre-built syncs or actions available yet._
 
-<Tip>Not seeing the integration you need? [Build your own](https://nango.dev/docs/guides/primitives/functions) independently.</Tip>
+<Tip>Not seeing the integration you need? [Build your own](/guides/primitives/functions) independently.</Tip>

--- a/docs/snippets/generated/gerrit/PreBuiltUseCases.mdx
+++ b/docs/snippets/generated/gerrit/PreBuiltUseCases.mdx
@@ -1,3 +1,3 @@
 _No pre-built syncs or actions available yet._
 
-<Tip>Not seeing the integration you need? [Build your own](https://nango.dev/docs/guides/primitives/functions) independently.</Tip>
+<Tip>Not seeing the integration you need? [Build your own](/guides/primitives/functions) independently.</Tip>

--- a/docs/snippets/generated/ghost-admin/PreBuiltUseCases.mdx
+++ b/docs/snippets/generated/ghost-admin/PreBuiltUseCases.mdx
@@ -1,3 +1,3 @@
 _No pre-built syncs or actions available yet._
 
-<Tip>Not seeing the integration you need? [Build your own](https://nango.dev/docs/guides/primitives/functions) independently.</Tip>
+<Tip>Not seeing the integration you need? [Build your own](/guides/primitives/functions) independently.</Tip>

--- a/docs/snippets/generated/ghost-content/PreBuiltUseCases.mdx
+++ b/docs/snippets/generated/ghost-content/PreBuiltUseCases.mdx
@@ -1,3 +1,3 @@
 _No pre-built syncs or actions available yet._
 
-<Tip>Not seeing the integration you need? [Build your own](https://nango.dev/docs/guides/primitives/functions) independently.</Tip>
+<Tip>Not seeing the integration you need? [Build your own](/guides/primitives/functions) independently.</Tip>

--- a/docs/snippets/generated/github-pat/PreBuiltUseCases.mdx
+++ b/docs/snippets/generated/github-pat/PreBuiltUseCases.mdx
@@ -1,3 +1,3 @@
 _No pre-built syncs or actions available yet._
 
-<Tip>Not seeing the integration you need? [Build your own](https://nango.dev/docs/guides/primitives/functions) independently.</Tip>
+<Tip>Not seeing the integration you need? [Build your own](/guides/primitives/functions) independently.</Tip>

--- a/docs/snippets/generated/gitlab-pat/PreBuiltUseCases.mdx
+++ b/docs/snippets/generated/gitlab-pat/PreBuiltUseCases.mdx
@@ -1,3 +1,3 @@
 _No pre-built syncs or actions available yet._
 
-<Tip>Not seeing the integration you need? [Build your own](https://nango.dev/docs/guides/primitives/functions) independently.</Tip>
+<Tip>Not seeing the integration you need? [Build your own](/guides/primitives/functions) independently.</Tip>

--- a/docs/snippets/generated/gitlab/PreBuiltUseCases.mdx
+++ b/docs/snippets/generated/gitlab/PreBuiltUseCases.mdx
@@ -1,3 +1,3 @@
 _No pre-built syncs or actions available yet._
 
-<Tip>Not seeing the integration you need? [Build your own](https://nango.dev/docs/guides/primitives/functions) independently.</Tip>
+<Tip>Not seeing the integration you need? [Build your own](/guides/primitives/functions) independently.</Tip>

--- a/docs/snippets/generated/glyphic/PreBuiltUseCases.mdx
+++ b/docs/snippets/generated/glyphic/PreBuiltUseCases.mdx
@@ -1,3 +1,3 @@
 _No pre-built syncs or actions available yet._
 
-<Tip>Not seeing the integration you need? [Build your own](https://nango.dev/docs/guides/primitives/functions) independently.</Tip>
+<Tip>Not seeing the integration you need? [Build your own](/guides/primitives/functions) independently.</Tip>

--- a/docs/snippets/generated/google-ads/PreBuiltUseCases.mdx
+++ b/docs/snippets/generated/google-ads/PreBuiltUseCases.mdx
@@ -1,3 +1,3 @@
 _No pre-built syncs or actions available yet._
 
-<Tip>Not seeing the integration you need? [Build your own](https://nango.dev/docs/guides/primitives/functions) independently.</Tip>
+<Tip>Not seeing the integration you need? [Build your own](/guides/primitives/functions) independently.</Tip>

--- a/docs/snippets/generated/google-analytics/PreBuiltUseCases.mdx
+++ b/docs/snippets/generated/google-analytics/PreBuiltUseCases.mdx
@@ -1,3 +1,3 @@
 _No pre-built syncs or actions available yet._
 
-<Tip>Not seeing the integration you need? [Build your own](https://nango.dev/docs/guides/primitives/functions) independently.</Tip>
+<Tip>Not seeing the integration you need? [Build your own](/guides/primitives/functions) independently.</Tip>

--- a/docs/snippets/generated/google-bigquery/PreBuiltUseCases.mdx
+++ b/docs/snippets/generated/google-bigquery/PreBuiltUseCases.mdx
@@ -1,3 +1,3 @@
 _No pre-built syncs or actions available yet._
 
-<Tip>Not seeing the integration you need? [Build your own](https://nango.dev/docs/guides/primitives/functions) independently.</Tip>
+<Tip>Not seeing the integration you need? [Build your own](/guides/primitives/functions) independently.</Tip>

--- a/docs/snippets/generated/google-chat/PreBuiltUseCases.mdx
+++ b/docs/snippets/generated/google-chat/PreBuiltUseCases.mdx
@@ -1,3 +1,3 @@
 _No pre-built syncs or actions available yet._
 
-<Tip>Not seeing the integration you need? [Build your own](https://nango.dev/docs/guides/primitives/functions) independently.</Tip>
+<Tip>Not seeing the integration you need? [Build your own](/guides/primitives/functions) independently.</Tip>

--- a/docs/snippets/generated/google-cloud-storage/PreBuiltUseCases.mdx
+++ b/docs/snippets/generated/google-cloud-storage/PreBuiltUseCases.mdx
@@ -1,3 +1,3 @@
 _No pre-built syncs or actions available yet._
 
-<Tip>Not seeing the integration you need? [Build your own](https://nango.dev/docs/guides/primitives/functions) independently.</Tip>
+<Tip>Not seeing the integration you need? [Build your own](/guides/primitives/functions) independently.</Tip>

--- a/docs/snippets/generated/google-docs/PreBuiltUseCases.mdx
+++ b/docs/snippets/generated/google-docs/PreBuiltUseCases.mdx
@@ -1,3 +1,3 @@
 _No pre-built syncs or actions available yet._
 
-<Tip>Not seeing the integration you need? [Build your own](https://nango.dev/docs/guides/primitives/functions) independently.</Tip>
+<Tip>Not seeing the integration you need? [Build your own](/guides/primitives/functions) independently.</Tip>

--- a/docs/snippets/generated/google-forms/PreBuiltUseCases.mdx
+++ b/docs/snippets/generated/google-forms/PreBuiltUseCases.mdx
@@ -1,3 +1,3 @@
 _No pre-built syncs or actions available yet._
 
-<Tip>Not seeing the integration you need? [Build your own](https://nango.dev/docs/guides/primitives/functions) independently.</Tip>
+<Tip>Not seeing the integration you need? [Build your own](/guides/primitives/functions) independently.</Tip>

--- a/docs/snippets/generated/google-gemini/PreBuiltUseCases.mdx
+++ b/docs/snippets/generated/google-gemini/PreBuiltUseCases.mdx
@@ -1,3 +1,3 @@
 _No pre-built syncs or actions available yet._
 
-<Tip>Not seeing the integration you need? [Build your own](https://nango.dev/docs/guides/primitives/functions) independently.</Tip>
+<Tip>Not seeing the integration you need? [Build your own](/guides/primitives/functions) independently.</Tip>

--- a/docs/snippets/generated/google-meet/PreBuiltUseCases.mdx
+++ b/docs/snippets/generated/google-meet/PreBuiltUseCases.mdx
@@ -1,3 +1,3 @@
 _No pre-built syncs or actions available yet._
 
-<Tip>Not seeing the integration you need? [Build your own](https://nango.dev/docs/guides/primitives/functions) independently.</Tip>
+<Tip>Not seeing the integration you need? [Build your own](/guides/primitives/functions) independently.</Tip>

--- a/docs/snippets/generated/google-play/PreBuiltUseCases.mdx
+++ b/docs/snippets/generated/google-play/PreBuiltUseCases.mdx
@@ -1,3 +1,3 @@
 _No pre-built syncs or actions available yet._
 
-<Tip>Not seeing the integration you need? [Build your own](https://nango.dev/docs/guides/primitives/functions) independently.</Tip>
+<Tip>Not seeing the integration you need? [Build your own](/guides/primitives/functions) independently.</Tip>

--- a/docs/snippets/generated/google-search-console/PreBuiltUseCases.mdx
+++ b/docs/snippets/generated/google-search-console/PreBuiltUseCases.mdx
@@ -1,3 +1,3 @@
 _No pre-built syncs or actions available yet._
 
-<Tip>Not seeing the integration you need? [Build your own](https://nango.dev/docs/guides/primitives/functions) independently.</Tip>
+<Tip>Not seeing the integration you need? [Build your own](/guides/primitives/functions) independently.</Tip>

--- a/docs/snippets/generated/google-service-account/PreBuiltUseCases.mdx
+++ b/docs/snippets/generated/google-service-account/PreBuiltUseCases.mdx
@@ -1,3 +1,3 @@
 _No pre-built syncs or actions available yet._
 
-<Tip>Not seeing the integration you need? [Build your own](https://nango.dev/docs/guides/primitives/functions) independently.</Tip>
+<Tip>Not seeing the integration you need? [Build your own](/guides/primitives/functions) independently.</Tip>

--- a/docs/snippets/generated/google-slides/PreBuiltUseCases.mdx
+++ b/docs/snippets/generated/google-slides/PreBuiltUseCases.mdx
@@ -1,3 +1,3 @@
 _No pre-built syncs or actions available yet._
 
-<Tip>Not seeing the integration you need? [Build your own](https://nango.dev/docs/guides/primitives/functions) independently.</Tip>
+<Tip>Not seeing the integration you need? [Build your own](/guides/primitives/functions) independently.</Tip>

--- a/docs/snippets/generated/google-tasks/PreBuiltUseCases.mdx
+++ b/docs/snippets/generated/google-tasks/PreBuiltUseCases.mdx
@@ -1,3 +1,3 @@
 _No pre-built syncs or actions available yet._
 
-<Tip>Not seeing the integration you need? [Build your own](https://nango.dev/docs/guides/primitives/functions) independently.</Tip>
+<Tip>Not seeing the integration you need? [Build your own](/guides/primitives/functions) independently.</Tip>

--- a/docs/snippets/generated/google-workspace-admin/PreBuiltUseCases.mdx
+++ b/docs/snippets/generated/google-workspace-admin/PreBuiltUseCases.mdx
@@ -1,3 +1,3 @@
 _No pre-built syncs or actions available yet._
 
-<Tip>Not seeing the integration you need? [Build your own](https://nango.dev/docs/guides/primitives/functions) independently.</Tip>
+<Tip>Not seeing the integration you need? [Build your own](/guides/primitives/functions) independently.</Tip>

--- a/docs/snippets/generated/grafana/PreBuiltUseCases.mdx
+++ b/docs/snippets/generated/grafana/PreBuiltUseCases.mdx
@@ -1,3 +1,3 @@
 _No pre-built syncs or actions available yet._
 
-<Tip>Not seeing the integration you need? [Build your own](https://nango.dev/docs/guides/primitives/functions) independently.</Tip>
+<Tip>Not seeing the integration you need? [Build your own](/guides/primitives/functions) independently.</Tip>

--- a/docs/snippets/generated/grain-api-key/PreBuiltUseCases.mdx
+++ b/docs/snippets/generated/grain-api-key/PreBuiltUseCases.mdx
@@ -1,3 +1,3 @@
 _No pre-built syncs or actions available yet._
 
-<Tip>Not seeing the integration you need? [Build your own](https://nango.dev/docs/guides/primitives/functions) independently.</Tip>
+<Tip>Not seeing the integration you need? [Build your own](/guides/primitives/functions) independently.</Tip>

--- a/docs/snippets/generated/grain/PreBuiltUseCases.mdx
+++ b/docs/snippets/generated/grain/PreBuiltUseCases.mdx
@@ -1,3 +1,3 @@
 _No pre-built syncs or actions available yet._
 
-<Tip>Not seeing the integration you need? [Build your own](https://nango.dev/docs/guides/primitives/functions) independently.</Tip>
+<Tip>Not seeing the integration you need? [Build your own](/guides/primitives/functions) independently.</Tip>

--- a/docs/snippets/generated/grammarly-scim/PreBuiltUseCases.mdx
+++ b/docs/snippets/generated/grammarly-scim/PreBuiltUseCases.mdx
@@ -1,3 +1,3 @@
 _No pre-built syncs or actions available yet._
 
-<Tip>Not seeing the integration you need? [Build your own](https://nango.dev/docs/guides/primitives/functions) independently.</Tip>
+<Tip>Not seeing the integration you need? [Build your own](/guides/primitives/functions) independently.</Tip>

--- a/docs/snippets/generated/granola-mcp/PreBuiltUseCases.mdx
+++ b/docs/snippets/generated/granola-mcp/PreBuiltUseCases.mdx
@@ -1,3 +1,3 @@
 _No pre-built syncs or actions available yet._
 
-<Tip>Not seeing the integration you need? [Build your own](https://nango.dev/docs/guides/primitives/functions) independently.</Tip>
+<Tip>Not seeing the integration you need? [Build your own](/guides/primitives/functions) independently.</Tip>

--- a/docs/snippets/generated/granola/PreBuiltUseCases.mdx
+++ b/docs/snippets/generated/granola/PreBuiltUseCases.mdx
@@ -1,3 +1,3 @@
 _No pre-built syncs or actions available yet._
 
-<Tip>Not seeing the integration you need? [Build your own](https://nango.dev/docs/guides/primitives/functions) independently.</Tip>
+<Tip>Not seeing the integration you need? [Build your own](/guides/primitives/functions) independently.</Tip>

--- a/docs/snippets/generated/greenhouse-assessment/PreBuiltUseCases.mdx
+++ b/docs/snippets/generated/greenhouse-assessment/PreBuiltUseCases.mdx
@@ -1,3 +1,3 @@
 _No pre-built syncs or actions available yet._
 
-<Tip>Not seeing the integration you need? [Build your own](https://nango.dev/docs/guides/primitives/functions) independently.</Tip>
+<Tip>Not seeing the integration you need? [Build your own](/guides/primitives/functions) independently.</Tip>

--- a/docs/snippets/generated/greenhouse-harvest-oauth2-cc/PreBuiltUseCases.mdx
+++ b/docs/snippets/generated/greenhouse-harvest-oauth2-cc/PreBuiltUseCases.mdx
@@ -1,3 +1,3 @@
 _No pre-built syncs or actions available yet._
 
-<Tip>Not seeing the integration you need? [Build your own](https://nango.dev/docs/guides/primitives/functions) independently.</Tip>
+<Tip>Not seeing the integration you need? [Build your own](/guides/primitives/functions) independently.</Tip>

--- a/docs/snippets/generated/greenhouse-harvest-partner/PreBuiltUseCases.mdx
+++ b/docs/snippets/generated/greenhouse-harvest-partner/PreBuiltUseCases.mdx
@@ -1,3 +1,3 @@
 _No pre-built syncs or actions available yet._
 
-<Tip>Not seeing the integration you need? [Build your own](https://nango.dev/docs/guides/primitives/functions) independently.</Tip>
+<Tip>Not seeing the integration you need? [Build your own](/guides/primitives/functions) independently.</Tip>

--- a/docs/snippets/generated/greenhouse-harvest/PreBuiltUseCases.mdx
+++ b/docs/snippets/generated/greenhouse-harvest/PreBuiltUseCases.mdx
@@ -1,3 +1,3 @@
 _No pre-built syncs or actions available yet._
 
-<Tip>Not seeing the integration you need? [Build your own](https://nango.dev/docs/guides/primitives/functions) independently.</Tip>
+<Tip>Not seeing the integration you need? [Build your own](/guides/primitives/functions) independently.</Tip>

--- a/docs/snippets/generated/greenhouse-ingestion/PreBuiltUseCases.mdx
+++ b/docs/snippets/generated/greenhouse-ingestion/PreBuiltUseCases.mdx
@@ -1,3 +1,3 @@
 _No pre-built syncs or actions available yet._
 
-<Tip>Not seeing the integration you need? [Build your own](https://nango.dev/docs/guides/primitives/functions) independently.</Tip>
+<Tip>Not seeing the integration you need? [Build your own](/guides/primitives/functions) independently.</Tip>

--- a/docs/snippets/generated/greenhouse-job-board/PreBuiltUseCases.mdx
+++ b/docs/snippets/generated/greenhouse-job-board/PreBuiltUseCases.mdx
@@ -1,3 +1,3 @@
 _No pre-built syncs or actions available yet._
 
-<Tip>Not seeing the integration you need? [Build your own](https://nango.dev/docs/guides/primitives/functions) independently.</Tip>
+<Tip>Not seeing the integration you need? [Build your own](/guides/primitives/functions) independently.</Tip>

--- a/docs/snippets/generated/greenhouse-onboarding/PreBuiltUseCases.mdx
+++ b/docs/snippets/generated/greenhouse-onboarding/PreBuiltUseCases.mdx
@@ -1,3 +1,3 @@
 _No pre-built syncs or actions available yet._
 
-<Tip>Not seeing the integration you need? [Build your own](https://nango.dev/docs/guides/primitives/functions) independently.</Tip>
+<Tip>Not seeing the integration you need? [Build your own](/guides/primitives/functions) independently.</Tip>

--- a/docs/snippets/generated/grist/PreBuiltUseCases.mdx
+++ b/docs/snippets/generated/grist/PreBuiltUseCases.mdx
@@ -1,3 +1,3 @@
 _No pre-built syncs or actions available yet._
 
-<Tip>Not seeing the integration you need? [Build your own](https://nango.dev/docs/guides/primitives/functions) independently.</Tip>
+<Tip>Not seeing the integration you need? [Build your own](/guides/primitives/functions) independently.</Tip>

--- a/docs/snippets/generated/gumroad/PreBuiltUseCases.mdx
+++ b/docs/snippets/generated/gumroad/PreBuiltUseCases.mdx
@@ -1,3 +1,3 @@
 _No pre-built syncs or actions available yet._
 
-<Tip>Not seeing the integration you need? [Build your own](https://nango.dev/docs/guides/primitives/functions) independently.</Tip>
+<Tip>Not seeing the integration you need? [Build your own](/guides/primitives/functions) independently.</Tip>

--- a/docs/snippets/generated/guru-scim/PreBuiltUseCases.mdx
+++ b/docs/snippets/generated/guru-scim/PreBuiltUseCases.mdx
@@ -1,3 +1,3 @@
 _No pre-built syncs or actions available yet._
 
-<Tip>Not seeing the integration you need? [Build your own](https://nango.dev/docs/guides/primitives/functions) independently.</Tip>
+<Tip>Not seeing the integration you need? [Build your own](/guides/primitives/functions) independently.</Tip>

--- a/docs/snippets/generated/guru/PreBuiltUseCases.mdx
+++ b/docs/snippets/generated/guru/PreBuiltUseCases.mdx
@@ -1,3 +1,3 @@
 _No pre-built syncs or actions available yet._
 
-<Tip>Not seeing the integration you need? [Build your own](https://nango.dev/docs/guides/primitives/functions) independently.</Tip>
+<Tip>Not seeing the integration you need? [Build your own](/guides/primitives/functions) independently.</Tip>

--- a/docs/snippets/generated/health-gorilla/PreBuiltUseCases.mdx
+++ b/docs/snippets/generated/health-gorilla/PreBuiltUseCases.mdx
@@ -1,3 +1,3 @@
 _No pre-built syncs or actions available yet._
 
-<Tip>Not seeing the integration you need? [Build your own](https://nango.dev/docs/guides/primitives/functions) independently.</Tip>
+<Tip>Not seeing the integration you need? [Build your own](/guides/primitives/functions) independently.</Tip>

--- a/docs/snippets/generated/heap/PreBuiltUseCases.mdx
+++ b/docs/snippets/generated/heap/PreBuiltUseCases.mdx
@@ -1,3 +1,3 @@
 _No pre-built syncs or actions available yet._
 
-<Tip>Not seeing the integration you need? [Build your own](https://nango.dev/docs/guides/primitives/functions) independently.</Tip>
+<Tip>Not seeing the integration you need? [Build your own](/guides/primitives/functions) independently.</Tip>

--- a/docs/snippets/generated/helpscout-docs/PreBuiltUseCases.mdx
+++ b/docs/snippets/generated/helpscout-docs/PreBuiltUseCases.mdx
@@ -1,3 +1,3 @@
 _No pre-built syncs or actions available yet._
 
-<Tip>Not seeing the integration you need? [Build your own](https://nango.dev/docs/guides/primitives/functions) independently.</Tip>
+<Tip>Not seeing the integration you need? [Build your own](/guides/primitives/functions) independently.</Tip>

--- a/docs/snippets/generated/helpscout-mailbox/PreBuiltUseCases.mdx
+++ b/docs/snippets/generated/helpscout-mailbox/PreBuiltUseCases.mdx
@@ -1,3 +1,3 @@
 _No pre-built syncs or actions available yet._
 
-<Tip>Not seeing the integration you need? [Build your own](https://nango.dev/docs/guides/primitives/functions) independently.</Tip>
+<Tip>Not seeing the integration you need? [Build your own](/guides/primitives/functions) independently.</Tip>

--- a/docs/snippets/generated/heygen/PreBuiltUseCases.mdx
+++ b/docs/snippets/generated/heygen/PreBuiltUseCases.mdx
@@ -1,3 +1,3 @@
 _No pre-built syncs or actions available yet._
 
-<Tip>Not seeing the integration you need? [Build your own](https://nango.dev/docs/guides/primitives/functions) independently.</Tip>
+<Tip>Not seeing the integration you need? [Build your own](/guides/primitives/functions) independently.</Tip>

--- a/docs/snippets/generated/heyreach/PreBuiltUseCases.mdx
+++ b/docs/snippets/generated/heyreach/PreBuiltUseCases.mdx
@@ -1,3 +1,3 @@
 _No pre-built syncs or actions available yet._
 
-<Tip>Not seeing the integration you need? [Build your own](https://nango.dev/docs/guides/primitives/functions) independently.</Tip>
+<Tip>Not seeing the integration you need? [Build your own](/guides/primitives/functions) independently.</Tip>

--- a/docs/snippets/generated/highlevel-white-label/PreBuiltUseCases.mdx
+++ b/docs/snippets/generated/highlevel-white-label/PreBuiltUseCases.mdx
@@ -1,3 +1,3 @@
 _No pre-built syncs or actions available yet._
 
-<Tip>Not seeing the integration you need? [Build your own](https://nango.dev/docs/guides/primitives/functions) independently.</Tip>
+<Tip>Not seeing the integration you need? [Build your own](/guides/primitives/functions) independently.</Tip>

--- a/docs/snippets/generated/highlevel/PreBuiltUseCases.mdx
+++ b/docs/snippets/generated/highlevel/PreBuiltUseCases.mdx
@@ -1,3 +1,3 @@
 _No pre-built syncs or actions available yet._
 
-<Tip>Not seeing the integration you need? [Build your own](https://nango.dev/docs/guides/primitives/functions) independently.</Tip>
+<Tip>Not seeing the integration you need? [Build your own](/guides/primitives/functions) independently.</Tip>

--- a/docs/snippets/generated/holded/PreBuiltUseCases.mdx
+++ b/docs/snippets/generated/holded/PreBuiltUseCases.mdx
@@ -1,3 +1,3 @@
 _No pre-built syncs or actions available yet._
 
-<Tip>Not seeing the integration you need? [Build your own](https://nango.dev/docs/guides/primitives/functions) independently.</Tip>
+<Tip>Not seeing the integration you need? [Build your own](/guides/primitives/functions) independently.</Tip>

--- a/docs/snippets/generated/hover/PreBuiltUseCases.mdx
+++ b/docs/snippets/generated/hover/PreBuiltUseCases.mdx
@@ -1,3 +1,3 @@
 _No pre-built syncs or actions available yet._
 
-<Tip>Not seeing the integration you need? [Build your own](https://nango.dev/docs/guides/primitives/functions) independently.</Tip>
+<Tip>Not seeing the integration you need? [Build your own](/guides/primitives/functions) independently.</Tip>

--- a/docs/snippets/generated/hubspot-mcp/PreBuiltUseCases.mdx
+++ b/docs/snippets/generated/hubspot-mcp/PreBuiltUseCases.mdx
@@ -1,3 +1,3 @@
 _No pre-built syncs or actions available yet._
 
-<Tip>Not seeing the integration you need? [Build your own](https://nango.dev/docs/guides/primitives/functions) independently.</Tip>
+<Tip>Not seeing the integration you need? [Build your own](/guides/primitives/functions) independently.</Tip>

--- a/docs/snippets/generated/icypeas/PreBuiltUseCases.mdx
+++ b/docs/snippets/generated/icypeas/PreBuiltUseCases.mdx
@@ -1,3 +1,3 @@
 _No pre-built syncs or actions available yet._
 
-<Tip>Not seeing the integration you need? [Build your own](https://nango.dev/docs/guides/primitives/functions) independently.</Tip>
+<Tip>Not seeing the integration you need? [Build your own](/guides/primitives/functions) independently.</Tip>

--- a/docs/snippets/generated/incident-io/PreBuiltUseCases.mdx
+++ b/docs/snippets/generated/incident-io/PreBuiltUseCases.mdx
@@ -1,3 +1,3 @@
 _No pre-built syncs or actions available yet._
 
-<Tip>Not seeing the integration you need? [Build your own](https://nango.dev/docs/guides/primitives/functions) independently.</Tip>
+<Tip>Not seeing the integration you need? [Build your own](/guides/primitives/functions) independently.</Tip>

--- a/docs/snippets/generated/insightly/PreBuiltUseCases.mdx
+++ b/docs/snippets/generated/insightly/PreBuiltUseCases.mdx
@@ -1,3 +1,3 @@
 _No pre-built syncs or actions available yet._
 
-<Tip>Not seeing the integration you need? [Build your own](https://nango.dev/docs/guides/primitives/functions) independently.</Tip>
+<Tip>Not seeing the integration you need? [Build your own](/guides/primitives/functions) independently.</Tip>

--- a/docs/snippets/generated/instagram/PreBuiltUseCases.mdx
+++ b/docs/snippets/generated/instagram/PreBuiltUseCases.mdx
@@ -1,3 +1,3 @@
 _No pre-built syncs or actions available yet._
 
-<Tip>Not seeing the integration you need? [Build your own](https://nango.dev/docs/guides/primitives/functions) independently.</Tip>
+<Tip>Not seeing the integration you need? [Build your own](/guides/primitives/functions) independently.</Tip>

--- a/docs/snippets/generated/intuit/PreBuiltUseCases.mdx
+++ b/docs/snippets/generated/intuit/PreBuiltUseCases.mdx
@@ -1,3 +1,3 @@
 _No pre-built syncs or actions available yet._
 
-<Tip>Not seeing the integration you need? [Build your own](https://nango.dev/docs/guides/primitives/functions) independently.</Tip>
+<Tip>Not seeing the integration you need? [Build your own](/guides/primitives/functions) independently.</Tip>

--- a/docs/snippets/generated/ironclad/PreBuiltUseCases.mdx
+++ b/docs/snippets/generated/ironclad/PreBuiltUseCases.mdx
@@ -1,3 +1,3 @@
 _No pre-built syncs or actions available yet._
 
-<Tip>Not seeing the integration you need? [Build your own](https://nango.dev/docs/guides/primitives/functions) independently.</Tip>
+<Tip>Not seeing the integration you need? [Build your own](/guides/primitives/functions) independently.</Tip>

--- a/docs/snippets/generated/itglue/PreBuiltUseCases.mdx
+++ b/docs/snippets/generated/itglue/PreBuiltUseCases.mdx
@@ -1,3 +1,3 @@
 _No pre-built syncs or actions available yet._
 
-<Tip>Not seeing the integration you need? [Build your own](https://nango.dev/docs/guides/primitives/functions) independently.</Tip>
+<Tip>Not seeing the integration you need? [Build your own](/guides/primitives/functions) independently.</Tip>

--- a/docs/snippets/generated/jamf-basic/PreBuiltUseCases.mdx
+++ b/docs/snippets/generated/jamf-basic/PreBuiltUseCases.mdx
@@ -1,3 +1,3 @@
 _No pre-built syncs or actions available yet._
 
-<Tip>Not seeing the integration you need? [Build your own](https://nango.dev/docs/guides/primitives/functions) independently.</Tip>
+<Tip>Not seeing the integration you need? [Build your own](/guides/primitives/functions) independently.</Tip>

--- a/docs/snippets/generated/jamf/PreBuiltUseCases.mdx
+++ b/docs/snippets/generated/jamf/PreBuiltUseCases.mdx
@@ -1,3 +1,3 @@
 _No pre-built syncs or actions available yet._
 
-<Tip>Not seeing the integration you need? [Build your own](https://nango.dev/docs/guides/primitives/functions) independently.</Tip>
+<Tip>Not seeing the integration you need? [Build your own](/guides/primitives/functions) independently.</Tip>

--- a/docs/snippets/generated/jazzhr/PreBuiltUseCases.mdx
+++ b/docs/snippets/generated/jazzhr/PreBuiltUseCases.mdx
@@ -1,3 +1,3 @@
 _No pre-built syncs or actions available yet._
 
-<Tip>Not seeing the integration you need? [Build your own](https://nango.dev/docs/guides/primitives/functions) independently.</Tip>
+<Tip>Not seeing the integration you need? [Build your own](/guides/primitives/functions) independently.</Tip>

--- a/docs/snippets/generated/jira-data-center-api-key/PreBuiltUseCases.mdx
+++ b/docs/snippets/generated/jira-data-center-api-key/PreBuiltUseCases.mdx
@@ -1,3 +1,3 @@
 _No pre-built syncs or actions available yet._
 
-<Tip>Not seeing the integration you need? [Build your own](https://nango.dev/docs/guides/primitives/functions) independently.</Tip>
+<Tip>Not seeing the integration you need? [Build your own](/guides/primitives/functions) independently.</Tip>

--- a/docs/snippets/generated/jira-data-center-basic/PreBuiltUseCases.mdx
+++ b/docs/snippets/generated/jira-data-center-basic/PreBuiltUseCases.mdx
@@ -1,3 +1,3 @@
 _No pre-built syncs or actions available yet._
 
-<Tip>Not seeing the integration you need? [Build your own](https://nango.dev/docs/guides/primitives/functions) independently.</Tip>
+<Tip>Not seeing the integration you need? [Build your own](/guides/primitives/functions) independently.</Tip>

--- a/docs/snippets/generated/jira-data-center/PreBuiltUseCases.mdx
+++ b/docs/snippets/generated/jira-data-center/PreBuiltUseCases.mdx
@@ -1,3 +1,3 @@
 _No pre-built syncs or actions available yet._
 
-<Tip>Not seeing the integration you need? [Build your own](https://nango.dev/docs/guides/primitives/functions) independently.</Tip>
+<Tip>Not seeing the integration you need? [Build your own](/guides/primitives/functions) independently.</Tip>

--- a/docs/snippets/generated/jobadder/PreBuiltUseCases.mdx
+++ b/docs/snippets/generated/jobadder/PreBuiltUseCases.mdx
@@ -1,3 +1,3 @@
 _No pre-built syncs or actions available yet._
 
-<Tip>Not seeing the integration you need? [Build your own](https://nango.dev/docs/guides/primitives/functions) independently.</Tip>
+<Tip>Not seeing the integration you need? [Build your own](/guides/primitives/functions) independently.</Tip>

--- a/docs/snippets/generated/jobber/PreBuiltUseCases.mdx
+++ b/docs/snippets/generated/jobber/PreBuiltUseCases.mdx
@@ -1,3 +1,3 @@
 _No pre-built syncs or actions available yet._
 
-<Tip>Not seeing the integration you need? [Build your own](https://nango.dev/docs/guides/primitives/functions) independently.</Tip>
+<Tip>Not seeing the integration you need? [Build your own](/guides/primitives/functions) independently.</Tip>

--- a/docs/snippets/generated/jobdiva/PreBuiltUseCases.mdx
+++ b/docs/snippets/generated/jobdiva/PreBuiltUseCases.mdx
@@ -1,3 +1,3 @@
 _No pre-built syncs or actions available yet._
 
-<Tip>Not seeing the integration you need? [Build your own](https://nango.dev/docs/guides/primitives/functions) independently.</Tip>
+<Tip>Not seeing the integration you need? [Build your own](/guides/primitives/functions) independently.</Tip>

--- a/docs/snippets/generated/jobvite/PreBuiltUseCases.mdx
+++ b/docs/snippets/generated/jobvite/PreBuiltUseCases.mdx
@@ -1,3 +1,3 @@
 _No pre-built syncs or actions available yet._
 
-<Tip>Not seeing the integration you need? [Build your own](https://nango.dev/docs/guides/primitives/functions) independently.</Tip>
+<Tip>Not seeing the integration you need? [Build your own](/guides/primitives/functions) independently.</Tip>

--- a/docs/snippets/generated/jotform/PreBuiltUseCases.mdx
+++ b/docs/snippets/generated/jotform/PreBuiltUseCases.mdx
@@ -1,3 +1,3 @@
 _No pre-built syncs or actions available yet._
 
-<Tip>Not seeing the integration you need? [Build your own](https://nango.dev/docs/guides/primitives/functions) independently.</Tip>
+<Tip>Not seeing the integration you need? [Build your own](/guides/primitives/functions) independently.</Tip>

--- a/docs/snippets/generated/jumpcloud/PreBuiltUseCases.mdx
+++ b/docs/snippets/generated/jumpcloud/PreBuiltUseCases.mdx
@@ -1,3 +1,3 @@
 _No pre-built syncs or actions available yet._
 
-<Tip>Not seeing the integration you need? [Build your own](https://nango.dev/docs/guides/primitives/functions) independently.</Tip>
+<Tip>Not seeing the integration you need? [Build your own](/guides/primitives/functions) independently.</Tip>

--- a/docs/snippets/generated/juniper-mist/PreBuiltUseCases.mdx
+++ b/docs/snippets/generated/juniper-mist/PreBuiltUseCases.mdx
@@ -1,3 +1,3 @@
 _No pre-built syncs or actions available yet._
 
-<Tip>Not seeing the integration you need? [Build your own](https://nango.dev/docs/guides/primitives/functions) independently.</Tip>
+<Tip>Not seeing the integration you need? [Build your own](/guides/primitives/functions) independently.</Tip>

--- a/docs/snippets/generated/justworks/PreBuiltUseCases.mdx
+++ b/docs/snippets/generated/justworks/PreBuiltUseCases.mdx
@@ -1,3 +1,3 @@
 _No pre-built syncs or actions available yet._
 
-<Tip>Not seeing the integration you need? [Build your own](https://nango.dev/docs/guides/primitives/functions) independently.</Tip>
+<Tip>Not seeing the integration you need? [Build your own](/guides/primitives/functions) independently.</Tip>

--- a/docs/snippets/generated/kandji/PreBuiltUseCases.mdx
+++ b/docs/snippets/generated/kandji/PreBuiltUseCases.mdx
@@ -1,3 +1,3 @@
 _No pre-built syncs or actions available yet._
 
-<Tip>Not seeing the integration you need? [Build your own](https://nango.dev/docs/guides/primitives/functions) independently.</Tip>
+<Tip>Not seeing the integration you need? [Build your own](/guides/primitives/functions) independently.</Tip>

--- a/docs/snippets/generated/keap/PreBuiltUseCases.mdx
+++ b/docs/snippets/generated/keap/PreBuiltUseCases.mdx
@@ -1,3 +1,3 @@
 _No pre-built syncs or actions available yet._
 
-<Tip>Not seeing the integration you need? [Build your own](https://nango.dev/docs/guides/primitives/functions) independently.</Tip>
+<Tip>Not seeing the integration you need? [Build your own](/guides/primitives/functions) independently.</Tip>

--- a/docs/snippets/generated/kintone-user-api/PreBuiltUseCases.mdx
+++ b/docs/snippets/generated/kintone-user-api/PreBuiltUseCases.mdx
@@ -1,3 +1,3 @@
 _No pre-built syncs or actions available yet._
 
-<Tip>Not seeing the integration you need? [Build your own](https://nango.dev/docs/guides/primitives/functions) independently.</Tip>
+<Tip>Not seeing the integration you need? [Build your own](/guides/primitives/functions) independently.</Tip>

--- a/docs/snippets/generated/kintone/PreBuiltUseCases.mdx
+++ b/docs/snippets/generated/kintone/PreBuiltUseCases.mdx
@@ -1,3 +1,3 @@
 _No pre-built syncs or actions available yet._
 
-<Tip>Not seeing the integration you need? [Build your own](https://nango.dev/docs/guides/primitives/functions) independently.</Tip>
+<Tip>Not seeing the integration you need? [Build your own](/guides/primitives/functions) independently.</Tip>

--- a/docs/snippets/generated/klaviyo-oauth/PreBuiltUseCases.mdx
+++ b/docs/snippets/generated/klaviyo-oauth/PreBuiltUseCases.mdx
@@ -1,3 +1,3 @@
 _No pre-built syncs or actions available yet._
 
-<Tip>Not seeing the integration you need? [Build your own](https://nango.dev/docs/guides/primitives/functions) independently.</Tip>
+<Tip>Not seeing the integration you need? [Build your own](/guides/primitives/functions) independently.</Tip>

--- a/docs/snippets/generated/klaviyo/PreBuiltUseCases.mdx
+++ b/docs/snippets/generated/klaviyo/PreBuiltUseCases.mdx
@@ -1,3 +1,3 @@
 _No pre-built syncs or actions available yet._
 
-<Tip>Not seeing the integration you need? [Build your own](https://nango.dev/docs/guides/primitives/functions) independently.</Tip>
+<Tip>Not seeing the integration you need? [Build your own](/guides/primitives/functions) independently.</Tip>

--- a/docs/snippets/generated/klicktipp/PreBuiltUseCases.mdx
+++ b/docs/snippets/generated/klicktipp/PreBuiltUseCases.mdx
@@ -1,3 +1,3 @@
 _No pre-built syncs or actions available yet._
 
-<Tip>Not seeing the integration you need? [Build your own](https://nango.dev/docs/guides/primitives/functions) independently.</Tip>
+<Tip>Not seeing the integration you need? [Build your own](/guides/primitives/functions) independently.</Tip>

--- a/docs/snippets/generated/klipfolio/PreBuiltUseCases.mdx
+++ b/docs/snippets/generated/klipfolio/PreBuiltUseCases.mdx
@@ -1,3 +1,3 @@
 _No pre-built syncs or actions available yet._
 
-<Tip>Not seeing the integration you need? [Build your own](https://nango.dev/docs/guides/primitives/functions) independently.</Tip>
+<Tip>Not seeing the integration you need? [Build your own](/guides/primitives/functions) independently.</Tip>

--- a/docs/snippets/generated/knowbe4/PreBuiltUseCases.mdx
+++ b/docs/snippets/generated/knowbe4/PreBuiltUseCases.mdx
@@ -1,3 +1,3 @@
 _No pre-built syncs or actions available yet._
 
-<Tip>Not seeing the integration you need? [Build your own](https://nango.dev/docs/guides/primitives/functions) independently.</Tip>
+<Tip>Not seeing the integration you need? [Build your own](/guides/primitives/functions) independently.</Tip>

--- a/docs/snippets/generated/lagrowthmachine/PreBuiltUseCases.mdx
+++ b/docs/snippets/generated/lagrowthmachine/PreBuiltUseCases.mdx
@@ -1,3 +1,3 @@
 _No pre-built syncs or actions available yet._
 
-<Tip>Not seeing the integration you need? [Build your own](https://nango.dev/docs/guides/primitives/functions) independently.</Tip>
+<Tip>Not seeing the integration you need? [Build your own](/guides/primitives/functions) independently.</Tip>

--- a/docs/snippets/generated/leadmagic/PreBuiltUseCases.mdx
+++ b/docs/snippets/generated/leadmagic/PreBuiltUseCases.mdx
@@ -1,3 +1,3 @@
 _No pre-built syncs or actions available yet._
 
-<Tip>Not seeing the integration you need? [Build your own](https://nango.dev/docs/guides/primitives/functions) independently.</Tip>
+<Tip>Not seeing the integration you need? [Build your own](/guides/primitives/functions) independently.</Tip>

--- a/docs/snippets/generated/lemlist/PreBuiltUseCases.mdx
+++ b/docs/snippets/generated/lemlist/PreBuiltUseCases.mdx
@@ -1,3 +1,3 @@
 _No pre-built syncs or actions available yet._
 
-<Tip>Not seeing the integration you need? [Build your own](https://nango.dev/docs/guides/primitives/functions) independently.</Tip>
+<Tip>Not seeing the integration you need? [Build your own](/guides/primitives/functions) independently.</Tip>

--- a/docs/snippets/generated/lessonly/PreBuiltUseCases.mdx
+++ b/docs/snippets/generated/lessonly/PreBuiltUseCases.mdx
@@ -1,3 +1,3 @@
 _No pre-built syncs or actions available yet._
 
-<Tip>Not seeing the integration you need? [Build your own](https://nango.dev/docs/guides/primitives/functions) independently.</Tip>
+<Tip>Not seeing the integration you need? [Build your own](/guides/primitives/functions) independently.</Tip>

--- a/docs/snippets/generated/linkhut/PreBuiltUseCases.mdx
+++ b/docs/snippets/generated/linkhut/PreBuiltUseCases.mdx
@@ -1,3 +1,3 @@
 _No pre-built syncs or actions available yet._
 
-<Tip>Not seeing the integration you need? [Build your own](https://nango.dev/docs/guides/primitives/functions) independently.</Tip>
+<Tip>Not seeing the integration you need? [Build your own](/guides/primitives/functions) independently.</Tip>

--- a/docs/snippets/generated/listmonk/PreBuiltUseCases.mdx
+++ b/docs/snippets/generated/listmonk/PreBuiltUseCases.mdx
@@ -1,3 +1,3 @@
 _No pre-built syncs or actions available yet._
 
-<Tip>Not seeing the integration you need? [Build your own](https://nango.dev/docs/guides/primitives/functions) independently.</Tip>
+<Tip>Not seeing the integration you need? [Build your own](/guides/primitives/functions) independently.</Tip>

--- a/docs/snippets/generated/looker/PreBuiltUseCases.mdx
+++ b/docs/snippets/generated/looker/PreBuiltUseCases.mdx
@@ -1,3 +1,3 @@
 _No pre-built syncs or actions available yet._
 
-<Tip>Not seeing the integration you need? [Build your own](https://nango.dev/docs/guides/primitives/functions) independently.</Tip>
+<Tip>Not seeing the integration you need? [Build your own](/guides/primitives/functions) independently.</Tip>

--- a/docs/snippets/generated/loom-scim/PreBuiltUseCases.mdx
+++ b/docs/snippets/generated/loom-scim/PreBuiltUseCases.mdx
@@ -1,3 +1,3 @@
 _No pre-built syncs or actions available yet._
 
-<Tip>Not seeing the integration you need? [Build your own](https://nango.dev/docs/guides/primitives/functions) independently.</Tip>
+<Tip>Not seeing the integration you need? [Build your own](/guides/primitives/functions) independently.</Tip>

--- a/docs/snippets/generated/loop-returns/PreBuiltUseCases.mdx
+++ b/docs/snippets/generated/loop-returns/PreBuiltUseCases.mdx
@@ -1,3 +1,3 @@
 _No pre-built syncs or actions available yet._
 
-<Tip>Not seeing the integration you need? [Build your own](https://nango.dev/docs/guides/primitives/functions) independently.</Tip>
+<Tip>Not seeing the integration you need? [Build your own](/guides/primitives/functions) independently.</Tip>

--- a/docs/snippets/generated/loops-so/PreBuiltUseCases.mdx
+++ b/docs/snippets/generated/loops-so/PreBuiltUseCases.mdx
@@ -1,3 +1,3 @@
 _No pre-built syncs or actions available yet._
 
-<Tip>Not seeing the integration you need? [Build your own](https://nango.dev/docs/guides/primitives/functions) independently.</Tip>
+<Tip>Not seeing the integration you need? [Build your own](/guides/primitives/functions) independently.</Tip>

--- a/docs/snippets/generated/lucid-scim/PreBuiltUseCases.mdx
+++ b/docs/snippets/generated/lucid-scim/PreBuiltUseCases.mdx
@@ -1,3 +1,3 @@
 _No pre-built syncs or actions available yet._
 
-<Tip>Not seeing the integration you need? [Build your own](https://nango.dev/docs/guides/primitives/functions) independently.</Tip>
+<Tip>Not seeing the integration you need? [Build your own](/guides/primitives/functions) independently.</Tip>

--- a/docs/snippets/generated/lumos/PreBuiltUseCases.mdx
+++ b/docs/snippets/generated/lumos/PreBuiltUseCases.mdx
@@ -1,3 +1,3 @@
 _No pre-built syncs or actions available yet._
 
-<Tip>Not seeing the integration you need? [Build your own](https://nango.dev/docs/guides/primitives/functions) independently.</Tip>
+<Tip>Not seeing the integration you need? [Build your own](/guides/primitives/functions) independently.</Tip>

--- a/docs/snippets/generated/mailchimp/PreBuiltUseCases.mdx
+++ b/docs/snippets/generated/mailchimp/PreBuiltUseCases.mdx
@@ -1,3 +1,3 @@
 _No pre-built syncs or actions available yet._
 
-<Tip>Not seeing the integration you need? [Build your own](https://nango.dev/docs/guides/primitives/functions) independently.</Tip>
+<Tip>Not seeing the integration you need? [Build your own](/guides/primitives/functions) independently.</Tip>

--- a/docs/snippets/generated/mailgun/PreBuiltUseCases.mdx
+++ b/docs/snippets/generated/mailgun/PreBuiltUseCases.mdx
@@ -1,3 +1,3 @@
 _No pre-built syncs or actions available yet._
 
-<Tip>Not seeing the integration you need? [Build your own](https://nango.dev/docs/guides/primitives/functions) independently.</Tip>
+<Tip>Not seeing the integration you need? [Build your own](/guides/primitives/functions) independently.</Tip>

--- a/docs/snippets/generated/mailjet/PreBuiltUseCases.mdx
+++ b/docs/snippets/generated/mailjet/PreBuiltUseCases.mdx
@@ -1,3 +1,3 @@
 _No pre-built syncs or actions available yet._
 
-<Tip>Not seeing the integration you need? [Build your own](https://nango.dev/docs/guides/primitives/functions) independently.</Tip>
+<Tip>Not seeing the integration you need? [Build your own](/guides/primitives/functions) independently.</Tip>

--- a/docs/snippets/generated/make/PreBuiltUseCases.mdx
+++ b/docs/snippets/generated/make/PreBuiltUseCases.mdx
@@ -1,3 +1,3 @@
 _No pre-built syncs or actions available yet._
 
-<Tip>Not seeing the integration you need? [Build your own](https://nango.dev/docs/guides/primitives/functions) independently.</Tip>
+<Tip>Not seeing the integration you need? [Build your own](/guides/primitives/functions) independently.</Tip>

--- a/docs/snippets/generated/malwarebytes/PreBuiltUseCases.mdx
+++ b/docs/snippets/generated/malwarebytes/PreBuiltUseCases.mdx
@@ -1,3 +1,3 @@
 _No pre-built syncs or actions available yet._
 
-<Tip>Not seeing the integration you need? [Build your own](https://nango.dev/docs/guides/primitives/functions) independently.</Tip>
+<Tip>Not seeing the integration you need? [Build your own](/guides/primitives/functions) independently.</Tip>

--- a/docs/snippets/generated/manatal/PreBuiltUseCases.mdx
+++ b/docs/snippets/generated/manatal/PreBuiltUseCases.mdx
@@ -1,3 +1,3 @@
 _No pre-built syncs or actions available yet._
 
-<Tip>Not seeing the integration you need? [Build your own](https://nango.dev/docs/guides/primitives/functions) independently.</Tip>
+<Tip>Not seeing the integration you need? [Build your own](/guides/primitives/functions) independently.</Tip>

--- a/docs/snippets/generated/marketo/PreBuiltUseCases.mdx
+++ b/docs/snippets/generated/marketo/PreBuiltUseCases.mdx
@@ -1,3 +1,3 @@
 _No pre-built syncs or actions available yet._
 
-<Tip>Not seeing the integration you need? [Build your own](https://nango.dev/docs/guides/primitives/functions) independently.</Tip>
+<Tip>Not seeing the integration you need? [Build your own](/guides/primitives/functions) independently.</Tip>

--- a/docs/snippets/generated/maximizer-on-premise/PreBuiltUseCases.mdx
+++ b/docs/snippets/generated/maximizer-on-premise/PreBuiltUseCases.mdx
@@ -1,3 +1,3 @@
 _No pre-built syncs or actions available yet._
 
-<Tip>Not seeing the integration you need? [Build your own](https://nango.dev/docs/guides/primitives/functions) independently.</Tip>
+<Tip>Not seeing the integration you need? [Build your own](/guides/primitives/functions) independently.</Tip>

--- a/docs/snippets/generated/maximizer/PreBuiltUseCases.mdx
+++ b/docs/snippets/generated/maximizer/PreBuiltUseCases.mdx
@@ -1,3 +1,3 @@
 _No pre-built syncs or actions available yet._
 
-<Tip>Not seeing the integration you need? [Build your own](https://nango.dev/docs/guides/primitives/functions) independently.</Tip>
+<Tip>Not seeing the integration you need? [Build your own](/guides/primitives/functions) independently.</Tip>

--- a/docs/snippets/generated/mcp-generic/PreBuiltUseCases.mdx
+++ b/docs/snippets/generated/mcp-generic/PreBuiltUseCases.mdx
@@ -1,3 +1,3 @@
 _No pre-built syncs or actions available yet._
 
-<Tip>Not seeing the integration you need? [Build your own](https://nango.dev/docs/guides/primitives/functions) independently.</Tip>
+<Tip>Not seeing the integration you need? [Build your own](/guides/primitives/functions) independently.</Tip>

--- a/docs/snippets/generated/medallia/PreBuiltUseCases.mdx
+++ b/docs/snippets/generated/medallia/PreBuiltUseCases.mdx
@@ -1,3 +1,3 @@
 _No pre-built syncs or actions available yet._
 
-<Tip>Not seeing the integration you need? [Build your own](https://nango.dev/docs/guides/primitives/functions) independently.</Tip>
+<Tip>Not seeing the integration you need? [Build your own](/guides/primitives/functions) independently.</Tip>

--- a/docs/snippets/generated/mercury/PreBuiltUseCases.mdx
+++ b/docs/snippets/generated/mercury/PreBuiltUseCases.mdx
@@ -1,3 +1,3 @@
 _No pre-built syncs or actions available yet._
 
-<Tip>Not seeing the integration you need? [Build your own](https://nango.dev/docs/guides/primitives/functions) independently.</Tip>
+<Tip>Not seeing the integration you need? [Build your own](/guides/primitives/functions) independently.</Tip>

--- a/docs/snippets/generated/meta-marketing-api/PreBuiltUseCases.mdx
+++ b/docs/snippets/generated/meta-marketing-api/PreBuiltUseCases.mdx
@@ -1,3 +1,3 @@
 _No pre-built syncs or actions available yet._
 
-<Tip>Not seeing the integration you need? [Build your own](https://nango.dev/docs/guides/primitives/functions) independently.</Tip>
+<Tip>Not seeing the integration you need? [Build your own](/guides/primitives/functions) independently.</Tip>

--- a/docs/snippets/generated/microsoft-admin/PreBuiltUseCases.mdx
+++ b/docs/snippets/generated/microsoft-admin/PreBuiltUseCases.mdx
@@ -1,3 +1,3 @@
 _No pre-built syncs or actions available yet._
 
-<Tip>Not seeing the integration you need? [Build your own](https://nango.dev/docs/guides/primitives/functions) independently.</Tip>
+<Tip>Not seeing the integration you need? [Build your own](/guides/primitives/functions) independently.</Tip>

--- a/docs/snippets/generated/microsoft-ads/PreBuiltUseCases.mdx
+++ b/docs/snippets/generated/microsoft-ads/PreBuiltUseCases.mdx
@@ -1,3 +1,3 @@
 _No pre-built syncs or actions available yet._
 
-<Tip>Not seeing the integration you need? [Build your own](https://nango.dev/docs/guides/primitives/functions) independently.</Tip>
+<Tip>Not seeing the integration you need? [Build your own](/guides/primitives/functions) independently.</Tip>

--- a/docs/snippets/generated/microsoft-business-central/PreBuiltUseCases.mdx
+++ b/docs/snippets/generated/microsoft-business-central/PreBuiltUseCases.mdx
@@ -1,3 +1,3 @@
 _No pre-built syncs or actions available yet._
 
-<Tip>Not seeing the integration you need? [Build your own](https://nango.dev/docs/guides/primitives/functions) independently.</Tip>
+<Tip>Not seeing the integration you need? [Build your own](/guides/primitives/functions) independently.</Tip>

--- a/docs/snippets/generated/microsoft-entra-id/PreBuiltUseCases.mdx
+++ b/docs/snippets/generated/microsoft-entra-id/PreBuiltUseCases.mdx
@@ -1,3 +1,3 @@
 _No pre-built syncs or actions available yet._
 
-<Tip>Not seeing the integration you need? [Build your own](https://nango.dev/docs/guides/primitives/functions) independently.</Tip>
+<Tip>Not seeing the integration you need? [Build your own](/guides/primitives/functions) independently.</Tip>

--- a/docs/snippets/generated/microsoft-excel/PreBuiltUseCases.mdx
+++ b/docs/snippets/generated/microsoft-excel/PreBuiltUseCases.mdx
@@ -1,3 +1,3 @@
 _No pre-built syncs or actions available yet._
 
-<Tip>Not seeing the integration you need? [Build your own](https://nango.dev/docs/guides/primitives/functions) independently.</Tip>
+<Tip>Not seeing the integration you need? [Build your own](/guides/primitives/functions) independently.</Tip>

--- a/docs/snippets/generated/microsoft-oauth2-cc/PreBuiltUseCases.mdx
+++ b/docs/snippets/generated/microsoft-oauth2-cc/PreBuiltUseCases.mdx
@@ -1,3 +1,3 @@
 _No pre-built syncs or actions available yet._
 
-<Tip>Not seeing the integration you need? [Build your own](https://nango.dev/docs/guides/primitives/functions) independently.</Tip>
+<Tip>Not seeing the integration you need? [Build your own](/guides/primitives/functions) independently.</Tip>

--- a/docs/snippets/generated/microsoft-planner/PreBuiltUseCases.mdx
+++ b/docs/snippets/generated/microsoft-planner/PreBuiltUseCases.mdx
@@ -1,3 +1,3 @@
 _No pre-built syncs or actions available yet._
 
-<Tip>Not seeing the integration you need? [Build your own](https://nango.dev/docs/guides/primitives/functions) independently.</Tip>
+<Tip>Not seeing the integration you need? [Build your own](/guides/primitives/functions) independently.</Tip>

--- a/docs/snippets/generated/microsoft-power-bi/PreBuiltUseCases.mdx
+++ b/docs/snippets/generated/microsoft-power-bi/PreBuiltUseCases.mdx
@@ -1,3 +1,3 @@
 _No pre-built syncs or actions available yet._
 
-<Tip>Not seeing the integration you need? [Build your own](https://nango.dev/docs/guides/primitives/functions) independently.</Tip>
+<Tip>Not seeing the integration you need? [Build your own](/guides/primitives/functions) independently.</Tip>

--- a/docs/snippets/generated/microsoft-teams-bot/PreBuiltUseCases.mdx
+++ b/docs/snippets/generated/microsoft-teams-bot/PreBuiltUseCases.mdx
@@ -1,3 +1,3 @@
 _No pre-built syncs or actions available yet._
 
-<Tip>Not seeing the integration you need? [Build your own](https://nango.dev/docs/guides/primitives/functions) independently.</Tip>
+<Tip>Not seeing the integration you need? [Build your own](/guides/primitives/functions) independently.</Tip>

--- a/docs/snippets/generated/microsoft-tenant-specific/PreBuiltUseCases.mdx
+++ b/docs/snippets/generated/microsoft-tenant-specific/PreBuiltUseCases.mdx
@@ -1,3 +1,3 @@
 _No pre-built syncs or actions available yet._
 
-<Tip>Not seeing the integration you need? [Build your own](https://nango.dev/docs/guides/primitives/functions) independently.</Tip>
+<Tip>Not seeing the integration you need? [Build your own](/guides/primitives/functions) independently.</Tip>

--- a/docs/snippets/generated/microsoft/PreBuiltUseCases.mdx
+++ b/docs/snippets/generated/microsoft/PreBuiltUseCases.mdx
@@ -1,3 +1,3 @@
 _No pre-built syncs or actions available yet._
 
-<Tip>Not seeing the integration you need? [Build your own](https://nango.dev/docs/guides/primitives/functions) independently.</Tip>
+<Tip>Not seeing the integration you need? [Build your own](/guides/primitives/functions) independently.</Tip>

--- a/docs/snippets/generated/mimecast/PreBuiltUseCases.mdx
+++ b/docs/snippets/generated/mimecast/PreBuiltUseCases.mdx
@@ -1,3 +1,3 @@
 _No pre-built syncs or actions available yet._
 
-<Tip>Not seeing the integration you need? [Build your own](https://nango.dev/docs/guides/primitives/functions) independently.</Tip>
+<Tip>Not seeing the integration you need? [Build your own](/guides/primitives/functions) independently.</Tip>

--- a/docs/snippets/generated/mindbody/PreBuiltUseCases.mdx
+++ b/docs/snippets/generated/mindbody/PreBuiltUseCases.mdx
@@ -1,3 +1,3 @@
 _No pre-built syncs or actions available yet._
 
-<Tip>Not seeing the integration you need? [Build your own](https://nango.dev/docs/guides/primitives/functions) independently.</Tip>
+<Tip>Not seeing the integration you need? [Build your own](/guides/primitives/functions) independently.</Tip>

--- a/docs/snippets/generated/minimax/PreBuiltUseCases.mdx
+++ b/docs/snippets/generated/minimax/PreBuiltUseCases.mdx
@@ -1,3 +1,3 @@
 _No pre-built syncs or actions available yet._
 
-<Tip>Not seeing the integration you need? [Build your own](https://nango.dev/docs/guides/primitives/functions) independently.</Tip>
+<Tip>Not seeing the integration you need? [Build your own](/guides/primitives/functions) independently.</Tip>

--- a/docs/snippets/generated/mip-cloud/PreBuiltUseCases.mdx
+++ b/docs/snippets/generated/mip-cloud/PreBuiltUseCases.mdx
@@ -1,3 +1,3 @@
 _No pre-built syncs or actions available yet._
 
-<Tip>Not seeing the integration you need? [Build your own](https://nango.dev/docs/guides/primitives/functions) independently.</Tip>
+<Tip>Not seeing the integration you need? [Build your own](/guides/primitives/functions) independently.</Tip>

--- a/docs/snippets/generated/mip-on-premise/PreBuiltUseCases.mdx
+++ b/docs/snippets/generated/mip-on-premise/PreBuiltUseCases.mdx
@@ -1,3 +1,3 @@
 _No pre-built syncs or actions available yet._
 
-<Tip>Not seeing the integration you need? [Build your own](https://nango.dev/docs/guides/primitives/functions) independently.</Tip>
+<Tip>Not seeing the integration you need? [Build your own](/guides/primitives/functions) independently.</Tip>

--- a/docs/snippets/generated/mip-on-premises/PreBuiltUseCases.mdx
+++ b/docs/snippets/generated/mip-on-premises/PreBuiltUseCases.mdx
@@ -1,3 +1,3 @@
 _No pre-built syncs or actions available yet._
 
-<Tip>Not seeing the integration you need? [Build your own](https://nango.dev/docs/guides/primitives/functions) independently.</Tip>
+<Tip>Not seeing the integration you need? [Build your own](/guides/primitives/functions) independently.</Tip>

--- a/docs/snippets/generated/mip/PreBuiltUseCases.mdx
+++ b/docs/snippets/generated/mip/PreBuiltUseCases.mdx
@@ -1,3 +1,3 @@
 _No pre-built syncs or actions available yet._
 
-<Tip>Not seeing the integration you need? [Build your own](https://nango.dev/docs/guides/primitives/functions) independently.</Tip>
+<Tip>Not seeing the integration you need? [Build your own](/guides/primitives/functions) independently.</Tip>

--- a/docs/snippets/generated/miro-scim/PreBuiltUseCases.mdx
+++ b/docs/snippets/generated/miro-scim/PreBuiltUseCases.mdx
@@ -1,3 +1,3 @@
 _No pre-built syncs or actions available yet._
 
-<Tip>Not seeing the integration you need? [Build your own](https://nango.dev/docs/guides/primitives/functions) independently.</Tip>
+<Tip>Not seeing the integration you need? [Build your own](/guides/primitives/functions) independently.</Tip>

--- a/docs/snippets/generated/miro/PreBuiltUseCases.mdx
+++ b/docs/snippets/generated/miro/PreBuiltUseCases.mdx
@@ -1,3 +1,3 @@
 _No pre-built syncs or actions available yet._
 
-<Tip>Not seeing the integration you need? [Build your own](https://nango.dev/docs/guides/primitives/functions) independently.</Tip>
+<Tip>Not seeing the integration you need? [Build your own](/guides/primitives/functions) independently.</Tip>

--- a/docs/snippets/generated/missive/PreBuiltUseCases.mdx
+++ b/docs/snippets/generated/missive/PreBuiltUseCases.mdx
@@ -1,3 +1,3 @@
 _No pre-built syncs or actions available yet._
 
-<Tip>Not seeing the integration you need? [Build your own](https://nango.dev/docs/guides/primitives/functions) independently.</Tip>
+<Tip>Not seeing the integration you need? [Build your own](/guides/primitives/functions) independently.</Tip>

--- a/docs/snippets/generated/mixpanel/PreBuiltUseCases.mdx
+++ b/docs/snippets/generated/mixpanel/PreBuiltUseCases.mdx
@@ -1,3 +1,3 @@
 _No pre-built syncs or actions available yet._
 
-<Tip>Not seeing the integration you need? [Build your own](https://nango.dev/docs/guides/primitives/functions) independently.</Tip>
+<Tip>Not seeing the integration you need? [Build your own](/guides/primitives/functions) independently.</Tip>

--- a/docs/snippets/generated/modmed/PreBuiltUseCases.mdx
+++ b/docs/snippets/generated/modmed/PreBuiltUseCases.mdx
@@ -1,3 +1,3 @@
 _No pre-built syncs or actions available yet._
 
-<Tip>Not seeing the integration you need? [Build your own](https://nango.dev/docs/guides/primitives/functions) independently.</Tip>
+<Tip>Not seeing the integration you need? [Build your own](/guides/primitives/functions) independently.</Tip>

--- a/docs/snippets/generated/mollie/PreBuiltUseCases.mdx
+++ b/docs/snippets/generated/mollie/PreBuiltUseCases.mdx
@@ -1,3 +1,3 @@
 _No pre-built syncs or actions available yet._
 
-<Tip>Not seeing the integration you need? [Build your own](https://nango.dev/docs/guides/primitives/functions) independently.</Tip>
+<Tip>Not seeing the integration you need? [Build your own](/guides/primitives/functions) independently.</Tip>

--- a/docs/snippets/generated/momentum-io/PreBuiltUseCases.mdx
+++ b/docs/snippets/generated/momentum-io/PreBuiltUseCases.mdx
@@ -1,3 +1,3 @@
 _No pre-built syncs or actions available yet._
 
-<Tip>Not seeing the integration you need? [Build your own](https://nango.dev/docs/guides/primitives/functions) independently.</Tip>
+<Tip>Not seeing the integration you need? [Build your own](/guides/primitives/functions) independently.</Tip>

--- a/docs/snippets/generated/monday/PreBuiltUseCases.mdx
+++ b/docs/snippets/generated/monday/PreBuiltUseCases.mdx
@@ -1,3 +1,3 @@
 _No pre-built syncs or actions available yet._
 
-<Tip>Not seeing the integration you need? [Build your own](https://nango.dev/docs/guides/primitives/functions) independently.</Tip>
+<Tip>Not seeing the integration you need? [Build your own](/guides/primitives/functions) independently.</Tip>

--- a/docs/snippets/generated/mural/PreBuiltUseCases.mdx
+++ b/docs/snippets/generated/mural/PreBuiltUseCases.mdx
@@ -1,3 +1,3 @@
 _No pre-built syncs or actions available yet._
 
-<Tip>Not seeing the integration you need? [Build your own](https://nango.dev/docs/guides/primitives/functions) independently.</Tip>
+<Tip>Not seeing the integration you need? [Build your own](/guides/primitives/functions) independently.</Tip>

--- a/docs/snippets/generated/namely/PreBuiltUseCases.mdx
+++ b/docs/snippets/generated/namely/PreBuiltUseCases.mdx
@@ -1,3 +1,3 @@
 _No pre-built syncs or actions available yet._
 
-<Tip>Not seeing the integration you need? [Build your own](https://nango.dev/docs/guides/primitives/functions) independently.</Tip>
+<Tip>Not seeing the integration you need? [Build your own](/guides/primitives/functions) independently.</Tip>

--- a/docs/snippets/generated/nationbuilder/PreBuiltUseCases.mdx
+++ b/docs/snippets/generated/nationbuilder/PreBuiltUseCases.mdx
@@ -1,3 +1,3 @@
 _No pre-built syncs or actions available yet._
 
-<Tip>Not seeing the integration you need? [Build your own](https://nango.dev/docs/guides/primitives/functions) independently.</Tip>
+<Tip>Not seeing the integration you need? [Build your own](/guides/primitives/functions) independently.</Tip>

--- a/docs/snippets/generated/nerdio/PreBuiltUseCases.mdx
+++ b/docs/snippets/generated/nerdio/PreBuiltUseCases.mdx
@@ -1,3 +1,3 @@
 _No pre-built syncs or actions available yet._
 
-<Tip>Not seeing the integration you need? [Build your own](https://nango.dev/docs/guides/primitives/functions) independently.</Tip>
+<Tip>Not seeing the integration you need? [Build your own](/guides/primitives/functions) independently.</Tip>

--- a/docs/snippets/generated/netsuite/PreBuiltUseCases.mdx
+++ b/docs/snippets/generated/netsuite/PreBuiltUseCases.mdx
@@ -1,3 +1,3 @@
 _No pre-built syncs or actions available yet._
 
-<Tip>Not seeing the integration you need? [Build your own](https://nango.dev/docs/guides/primitives/functions) independently.</Tip>
+<Tip>Not seeing the integration you need? [Build your own](/guides/primitives/functions) independently.</Tip>

--- a/docs/snippets/generated/ninjaone-rmm-oauth2/PreBuiltUseCases.mdx
+++ b/docs/snippets/generated/ninjaone-rmm-oauth2/PreBuiltUseCases.mdx
@@ -1,3 +1,3 @@
 _No pre-built syncs or actions available yet._
 
-<Tip>Not seeing the integration you need? [Build your own](https://nango.dev/docs/guides/primitives/functions) independently.</Tip>
+<Tip>Not seeing the integration you need? [Build your own](/guides/primitives/functions) independently.</Tip>

--- a/docs/snippets/generated/ninjaone-rmm/PreBuiltUseCases.mdx
+++ b/docs/snippets/generated/ninjaone-rmm/PreBuiltUseCases.mdx
@@ -1,3 +1,3 @@
 _No pre-built syncs or actions available yet._
 
-<Tip>Not seeing the integration you need? [Build your own](https://nango.dev/docs/guides/primitives/functions) independently.</Tip>
+<Tip>Not seeing the integration you need? [Build your own](/guides/primitives/functions) independently.</Tip>

--- a/docs/snippets/generated/nocrm/PreBuiltUseCases.mdx
+++ b/docs/snippets/generated/nocrm/PreBuiltUseCases.mdx
@@ -1,3 +1,3 @@
 _No pre-built syncs or actions available yet._
 
-<Tip>Not seeing the integration you need? [Build your own](https://nango.dev/docs/guides/primitives/functions) independently.</Tip>
+<Tip>Not seeing the integration you need? [Build your own](/guides/primitives/functions) independently.</Tip>

--- a/docs/snippets/generated/notion-scim/PreBuiltUseCases.mdx
+++ b/docs/snippets/generated/notion-scim/PreBuiltUseCases.mdx
@@ -1,3 +1,3 @@
 _No pre-built syncs or actions available yet._
 
-<Tip>Not seeing the integration you need? [Build your own](https://nango.dev/docs/guides/primitives/functions) independently.</Tip>
+<Tip>Not seeing the integration you need? [Build your own](/guides/primitives/functions) independently.</Tip>

--- a/docs/snippets/generated/nyne-ai/PreBuiltUseCases.mdx
+++ b/docs/snippets/generated/nyne-ai/PreBuiltUseCases.mdx
@@ -1,3 +1,3 @@
 _No pre-built syncs or actions available yet._
 
-<Tip>Not seeing the integration you need? [Build your own](https://nango.dev/docs/guides/primitives/functions) independently.</Tip>
+<Tip>Not seeing the integration you need? [Build your own](/guides/primitives/functions) independently.</Tip>

--- a/docs/snippets/generated/odoo-cc/PreBuiltUseCases.mdx
+++ b/docs/snippets/generated/odoo-cc/PreBuiltUseCases.mdx
@@ -1,3 +1,3 @@
 _No pre-built syncs or actions available yet._
 
-<Tip>Not seeing the integration you need? [Build your own](https://nango.dev/docs/guides/primitives/functions) independently.</Tip>
+<Tip>Not seeing the integration you need? [Build your own](/guides/primitives/functions) independently.</Tip>

--- a/docs/snippets/generated/odoo/PreBuiltUseCases.mdx
+++ b/docs/snippets/generated/odoo/PreBuiltUseCases.mdx
@@ -1,3 +1,3 @@
 _No pre-built syncs or actions available yet._
 
-<Tip>Not seeing the integration you need? [Build your own](https://nango.dev/docs/guides/primitives/functions) independently.</Tip>
+<Tip>Not seeing the integration you need? [Build your own](/guides/primitives/functions) independently.</Tip>

--- a/docs/snippets/generated/okta-cc/PreBuiltUseCases.mdx
+++ b/docs/snippets/generated/okta-cc/PreBuiltUseCases.mdx
@@ -1,3 +1,3 @@
 _No pre-built syncs or actions available yet._
 
-<Tip>Not seeing the integration you need? [Build your own](https://nango.dev/docs/guides/primitives/functions) independently.</Tip>
+<Tip>Not seeing the integration you need? [Build your own](/guides/primitives/functions) independently.</Tip>

--- a/docs/snippets/generated/one-note/PreBuiltUseCases.mdx
+++ b/docs/snippets/generated/one-note/PreBuiltUseCases.mdx
@@ -1,3 +1,3 @@
 _No pre-built syncs or actions available yet._
 
-<Tip>Not seeing the integration you need? [Build your own](https://nango.dev/docs/guides/primitives/functions) independently.</Tip>
+<Tip>Not seeing the integration you need? [Build your own](/guides/primitives/functions) independently.</Tip>

--- a/docs/snippets/generated/onelogin/PreBuiltUseCases.mdx
+++ b/docs/snippets/generated/onelogin/PreBuiltUseCases.mdx
@@ -1,3 +1,3 @@
 _No pre-built syncs or actions available yet._
 
-<Tip>Not seeing the integration you need? [Build your own](https://nango.dev/docs/guides/primitives/functions) independently.</Tip>
+<Tip>Not seeing the integration you need? [Build your own](/guides/primitives/functions) independently.</Tip>

--- a/docs/snippets/generated/onlogist/PreBuiltUseCases.mdx
+++ b/docs/snippets/generated/onlogist/PreBuiltUseCases.mdx
@@ -1,3 +1,3 @@
 _No pre-built syncs or actions available yet._
 
-<Tip>Not seeing the integration you need? [Build your own](https://nango.dev/docs/guides/primitives/functions) independently.</Tip>
+<Tip>Not seeing the integration you need? [Build your own](/guides/primitives/functions) independently.</Tip>

--- a/docs/snippets/generated/oomnitza/PreBuiltUseCases.mdx
+++ b/docs/snippets/generated/oomnitza/PreBuiltUseCases.mdx
@@ -1,3 +1,3 @@
 _No pre-built syncs or actions available yet._
 
-<Tip>Not seeing the integration you need? [Build your own](https://nango.dev/docs/guides/primitives/functions) independently.</Tip>
+<Tip>Not seeing the integration you need? [Build your own](/guides/primitives/functions) independently.</Tip>

--- a/docs/snippets/generated/open-hands/PreBuiltUseCases.mdx
+++ b/docs/snippets/generated/open-hands/PreBuiltUseCases.mdx
@@ -1,3 +1,3 @@
 _No pre-built syncs or actions available yet._
 
-<Tip>Not seeing the integration you need? [Build your own](https://nango.dev/docs/guides/primitives/functions) independently.</Tip>
+<Tip>Not seeing the integration you need? [Build your own](/guides/primitives/functions) independently.</Tip>

--- a/docs/snippets/generated/openai-admin/PreBuiltUseCases.mdx
+++ b/docs/snippets/generated/openai-admin/PreBuiltUseCases.mdx
@@ -1,3 +1,3 @@
 _No pre-built syncs or actions available yet._
 
-<Tip>Not seeing the integration you need? [Build your own](https://nango.dev/docs/guides/primitives/functions) independently.</Tip>
+<Tip>Not seeing the integration you need? [Build your own](/guides/primitives/functions) independently.</Tip>

--- a/docs/snippets/generated/openai/PreBuiltUseCases.mdx
+++ b/docs/snippets/generated/openai/PreBuiltUseCases.mdx
@@ -1,3 +1,3 @@
 _No pre-built syncs or actions available yet._
 
-<Tip>Not seeing the integration you need? [Build your own](https://nango.dev/docs/guides/primitives/functions) independently.</Tip>
+<Tip>Not seeing the integration you need? [Build your own](/guides/primitives/functions) independently.</Tip>

--- a/docs/snippets/generated/oracle-cloud-identity/PreBuiltUseCases.mdx
+++ b/docs/snippets/generated/oracle-cloud-identity/PreBuiltUseCases.mdx
@@ -1,3 +1,3 @@
 _No pre-built syncs or actions available yet._
 
-<Tip>Not seeing the integration you need? [Build your own](https://nango.dev/docs/guides/primitives/functions) independently.</Tip>
+<Tip>Not seeing the integration you need? [Build your own](/guides/primitives/functions) independently.</Tip>

--- a/docs/snippets/generated/ordinal/PreBuiltUseCases.mdx
+++ b/docs/snippets/generated/ordinal/PreBuiltUseCases.mdx
@@ -1,3 +1,3 @@
 _No pre-built syncs or actions available yet._
 
-<Tip>Not seeing the integration you need? [Build your own](https://nango.dev/docs/guides/primitives/functions) independently.</Tip>
+<Tip>Not seeing the integration you need? [Build your own](/guides/primitives/functions) independently.</Tip>

--- a/docs/snippets/generated/ory/PreBuiltUseCases.mdx
+++ b/docs/snippets/generated/ory/PreBuiltUseCases.mdx
@@ -1,3 +1,3 @@
 _No pre-built syncs or actions available yet._
 
-<Tip>Not seeing the integration you need? [Build your own](https://nango.dev/docs/guides/primitives/functions) independently.</Tip>
+<Tip>Not seeing the integration you need? [Build your own](/guides/primitives/functions) independently.</Tip>

--- a/docs/snippets/generated/osu/PreBuiltUseCases.mdx
+++ b/docs/snippets/generated/osu/PreBuiltUseCases.mdx
@@ -1,3 +1,3 @@
 _No pre-built syncs or actions available yet._
 
-<Tip>Not seeing the integration you need? [Build your own](https://nango.dev/docs/guides/primitives/functions) independently.</Tip>
+<Tip>Not seeing the integration you need? [Build your own](/guides/primitives/functions) independently.</Tip>

--- a/docs/snippets/generated/oura/PreBuiltUseCases.mdx
+++ b/docs/snippets/generated/oura/PreBuiltUseCases.mdx
@@ -1,3 +1,3 @@
 _No pre-built syncs or actions available yet._
 
-<Tip>Not seeing the integration you need? [Build your own](https://nango.dev/docs/guides/primitives/functions) independently.</Tip>
+<Tip>Not seeing the integration you need? [Build your own](/guides/primitives/functions) independently.</Tip>

--- a/docs/snippets/generated/outreach/PreBuiltUseCases.mdx
+++ b/docs/snippets/generated/outreach/PreBuiltUseCases.mdx
@@ -1,3 +1,3 @@
 _No pre-built syncs or actions available yet._
 
-<Tip>Not seeing the integration you need? [Build your own](https://nango.dev/docs/guides/primitives/functions) independently.</Tip>
+<Tip>Not seeing the integration you need? [Build your own](/guides/primitives/functions) independently.</Tip>

--- a/docs/snippets/generated/pagerduty/PreBuiltUseCases.mdx
+++ b/docs/snippets/generated/pagerduty/PreBuiltUseCases.mdx
@@ -1,3 +1,3 @@
 _No pre-built syncs or actions available yet._
 
-<Tip>Not seeing the integration you need? [Build your own](https://nango.dev/docs/guides/primitives/functions) independently.</Tip>
+<Tip>Not seeing the integration you need? [Build your own](/guides/primitives/functions) independently.</Tip>

--- a/docs/snippets/generated/pandadoc-api-key/PreBuiltUseCases.mdx
+++ b/docs/snippets/generated/pandadoc-api-key/PreBuiltUseCases.mdx
@@ -1,3 +1,3 @@
 _No pre-built syncs or actions available yet._
 
-<Tip>Not seeing the integration you need? [Build your own](https://nango.dev/docs/guides/primitives/functions) independently.</Tip>
+<Tip>Not seeing the integration you need? [Build your own](/guides/primitives/functions) independently.</Tip>

--- a/docs/snippets/generated/pandadoc/PreBuiltUseCases.mdx
+++ b/docs/snippets/generated/pandadoc/PreBuiltUseCases.mdx
@@ -1,3 +1,3 @@
 _No pre-built syncs or actions available yet._
 
-<Tip>Not seeing the integration you need? [Build your own](https://nango.dev/docs/guides/primitives/functions) independently.</Tip>
+<Tip>Not seeing the integration you need? [Build your own](/guides/primitives/functions) independently.</Tip>

--- a/docs/snippets/generated/passportal/PreBuiltUseCases.mdx
+++ b/docs/snippets/generated/passportal/PreBuiltUseCases.mdx
@@ -1,3 +1,3 @@
 _No pre-built syncs or actions available yet._
 
-<Tip>Not seeing the integration you need? [Build your own](https://nango.dev/docs/guides/primitives/functions) independently.</Tip>
+<Tip>Not seeing the integration you need? [Build your own](/guides/primitives/functions) independently.</Tip>

--- a/docs/snippets/generated/pax8/PreBuiltUseCases.mdx
+++ b/docs/snippets/generated/pax8/PreBuiltUseCases.mdx
@@ -1,3 +1,3 @@
 _No pre-built syncs or actions available yet._
 
-<Tip>Not seeing the integration you need? [Build your own](https://nango.dev/docs/guides/primitives/functions) independently.</Tip>
+<Tip>Not seeing the integration you need? [Build your own](/guides/primitives/functions) independently.</Tip>

--- a/docs/snippets/generated/paychex/PreBuiltUseCases.mdx
+++ b/docs/snippets/generated/paychex/PreBuiltUseCases.mdx
@@ -1,3 +1,3 @@
 _No pre-built syncs or actions available yet._
 
-<Tip>Not seeing the integration you need? [Build your own](https://nango.dev/docs/guides/primitives/functions) independently.</Tip>
+<Tip>Not seeing the integration you need? [Build your own](/guides/primitives/functions) independently.</Tip>

--- a/docs/snippets/generated/paycor-sandbox/PreBuiltUseCases.mdx
+++ b/docs/snippets/generated/paycor-sandbox/PreBuiltUseCases.mdx
@@ -1,3 +1,3 @@
 _No pre-built syncs or actions available yet._
 
-<Tip>Not seeing the integration you need? [Build your own](https://nango.dev/docs/guides/primitives/functions) independently.</Tip>
+<Tip>Not seeing the integration you need? [Build your own](/guides/primitives/functions) independently.</Tip>

--- a/docs/snippets/generated/paycor/PreBuiltUseCases.mdx
+++ b/docs/snippets/generated/paycor/PreBuiltUseCases.mdx
@@ -1,3 +1,3 @@
 _No pre-built syncs or actions available yet._
 
-<Tip>Not seeing the integration you need? [Build your own](https://nango.dev/docs/guides/primitives/functions) independently.</Tip>
+<Tip>Not seeing the integration you need? [Build your own](/guides/primitives/functions) independently.</Tip>

--- a/docs/snippets/generated/payfit/PreBuiltUseCases.mdx
+++ b/docs/snippets/generated/payfit/PreBuiltUseCases.mdx
@@ -1,3 +1,3 @@
 _No pre-built syncs or actions available yet._
 
-<Tip>Not seeing the integration you need? [Build your own](https://nango.dev/docs/guides/primitives/functions) independently.</Tip>
+<Tip>Not seeing the integration you need? [Build your own](/guides/primitives/functions) independently.</Tip>

--- a/docs/snippets/generated/paylocity-nextgen/PreBuiltUseCases.mdx
+++ b/docs/snippets/generated/paylocity-nextgen/PreBuiltUseCases.mdx
@@ -1,3 +1,3 @@
 _No pre-built syncs or actions available yet._
 
-<Tip>Not seeing the integration you need? [Build your own](https://nango.dev/docs/guides/primitives/functions) independently.</Tip>
+<Tip>Not seeing the integration you need? [Build your own](/guides/primitives/functions) independently.</Tip>

--- a/docs/snippets/generated/paypal-sandbox/PreBuiltUseCases.mdx
+++ b/docs/snippets/generated/paypal-sandbox/PreBuiltUseCases.mdx
@@ -1,3 +1,3 @@
 _No pre-built syncs or actions available yet._
 
-<Tip>Not seeing the integration you need? [Build your own](https://nango.dev/docs/guides/primitives/functions) independently.</Tip>
+<Tip>Not seeing the integration you need? [Build your own](/guides/primitives/functions) independently.</Tip>

--- a/docs/snippets/generated/paypal/PreBuiltUseCases.mdx
+++ b/docs/snippets/generated/paypal/PreBuiltUseCases.mdx
@@ -1,3 +1,3 @@
 _No pre-built syncs or actions available yet._
 
-<Tip>Not seeing the integration you need? [Build your own](https://nango.dev/docs/guides/primitives/functions) independently.</Tip>
+<Tip>Not seeing the integration you need? [Build your own](/guides/primitives/functions) independently.</Tip>

--- a/docs/snippets/generated/pendo/PreBuiltUseCases.mdx
+++ b/docs/snippets/generated/pendo/PreBuiltUseCases.mdx
@@ -1,3 +1,3 @@
 _No pre-built syncs or actions available yet._
 
-<Tip>Not seeing the integration you need? [Build your own](https://nango.dev/docs/guides/primitives/functions) independently.</Tip>
+<Tip>Not seeing the integration you need? [Build your own](/guides/primitives/functions) independently.</Tip>

--- a/docs/snippets/generated/pennylane-company-api/PreBuiltUseCases.mdx
+++ b/docs/snippets/generated/pennylane-company-api/PreBuiltUseCases.mdx
@@ -1,3 +1,3 @@
 _No pre-built syncs or actions available yet._
 
-<Tip>Not seeing the integration you need? [Build your own](https://nango.dev/docs/guides/primitives/functions) independently.</Tip>
+<Tip>Not seeing the integration you need? [Build your own](/guides/primitives/functions) independently.</Tip>

--- a/docs/snippets/generated/peopledatalabs/PreBuiltUseCases.mdx
+++ b/docs/snippets/generated/peopledatalabs/PreBuiltUseCases.mdx
@@ -1,3 +1,3 @@
 _No pre-built syncs or actions available yet._
 
-<Tip>Not seeing the integration you need? [Build your own](https://nango.dev/docs/guides/primitives/functions) independently.</Tip>
+<Tip>Not seeing the integration you need? [Build your own](/guides/primitives/functions) independently.</Tip>

--- a/docs/snippets/generated/perdoo/PreBuiltUseCases.mdx
+++ b/docs/snippets/generated/perdoo/PreBuiltUseCases.mdx
@@ -1,3 +1,3 @@
 _No pre-built syncs or actions available yet._
 
-<Tip>Not seeing the integration you need? [Build your own](https://nango.dev/docs/guides/primitives/functions) independently.</Tip>
+<Tip>Not seeing the integration you need? [Build your own](/guides/primitives/functions) independently.</Tip>

--- a/docs/snippets/generated/perplexity/PreBuiltUseCases.mdx
+++ b/docs/snippets/generated/perplexity/PreBuiltUseCases.mdx
@@ -1,3 +1,3 @@
 _No pre-built syncs or actions available yet._
 
-<Tip>Not seeing the integration you need? [Build your own](https://nango.dev/docs/guides/primitives/functions) independently.</Tip>
+<Tip>Not seeing the integration you need? [Build your own](/guides/primitives/functions) independently.</Tip>

--- a/docs/snippets/generated/personio-recruiting/PreBuiltUseCases.mdx
+++ b/docs/snippets/generated/personio-recruiting/PreBuiltUseCases.mdx
@@ -1,3 +1,3 @@
 _No pre-built syncs or actions available yet._
 
-<Tip>Not seeing the integration you need? [Build your own](https://nango.dev/docs/guides/primitives/functions) independently.</Tip>
+<Tip>Not seeing the integration you need? [Build your own](/guides/primitives/functions) independently.</Tip>

--- a/docs/snippets/generated/personio-v2/PreBuiltUseCases.mdx
+++ b/docs/snippets/generated/personio-v2/PreBuiltUseCases.mdx
@@ -1,3 +1,3 @@
 _No pre-built syncs or actions available yet._
 
-<Tip>Not seeing the integration you need? [Build your own](https://nango.dev/docs/guides/primitives/functions) independently.</Tip>
+<Tip>Not seeing the integration you need? [Build your own](/guides/primitives/functions) independently.</Tip>

--- a/docs/snippets/generated/personio/PreBuiltUseCases.mdx
+++ b/docs/snippets/generated/personio/PreBuiltUseCases.mdx
@@ -1,3 +1,3 @@
 _No pre-built syncs or actions available yet._
 
-<Tip>Not seeing the integration you need? [Build your own](https://nango.dev/docs/guides/primitives/functions) independently.</Tip>
+<Tip>Not seeing the integration you need? [Build your own](/guides/primitives/functions) independently.</Tip>

--- a/docs/snippets/generated/pingboard/PreBuiltUseCases.mdx
+++ b/docs/snippets/generated/pingboard/PreBuiltUseCases.mdx
@@ -1,3 +1,3 @@
 _No pre-built syncs or actions available yet._
 
-<Tip>Not seeing the integration you need? [Build your own](https://nango.dev/docs/guides/primitives/functions) independently.</Tip>
+<Tip>Not seeing the integration you need? [Build your own](/guides/primitives/functions) independently.</Tip>

--- a/docs/snippets/generated/pingone-cc/PreBuiltUseCases.mdx
+++ b/docs/snippets/generated/pingone-cc/PreBuiltUseCases.mdx
@@ -1,3 +1,3 @@
 _No pre-built syncs or actions available yet._
 
-<Tip>Not seeing the integration you need? [Build your own](https://nango.dev/docs/guides/primitives/functions) independently.</Tip>
+<Tip>Not seeing the integration you need? [Build your own](/guides/primitives/functions) independently.</Tip>

--- a/docs/snippets/generated/pingone/PreBuiltUseCases.mdx
+++ b/docs/snippets/generated/pingone/PreBuiltUseCases.mdx
@@ -1,3 +1,3 @@
 _No pre-built syncs or actions available yet._
 
-<Tip>Not seeing the integration you need? [Build your own](https://nango.dev/docs/guides/primitives/functions) independently.</Tip>
+<Tip>Not seeing the integration you need? [Build your own](/guides/primitives/functions) independently.</Tip>

--- a/docs/snippets/generated/pinterest/PreBuiltUseCases.mdx
+++ b/docs/snippets/generated/pinterest/PreBuiltUseCases.mdx
@@ -1,3 +1,3 @@
 _No pre-built syncs or actions available yet._
 
-<Tip>Not seeing the integration you need? [Build your own](https://nango.dev/docs/guides/primitives/functions) independently.</Tip>
+<Tip>Not seeing the integration you need? [Build your own](/guides/primitives/functions) independently.</Tip>

--- a/docs/snippets/generated/pipedream-oauth2-cc/PreBuiltUseCases.mdx
+++ b/docs/snippets/generated/pipedream-oauth2-cc/PreBuiltUseCases.mdx
@@ -1,3 +1,3 @@
 _No pre-built syncs or actions available yet._
 
-<Tip>Not seeing the integration you need? [Build your own](https://nango.dev/docs/guides/primitives/functions) independently.</Tip>
+<Tip>Not seeing the integration you need? [Build your own](/guides/primitives/functions) independently.</Tip>

--- a/docs/snippets/generated/pipedream/PreBuiltUseCases.mdx
+++ b/docs/snippets/generated/pipedream/PreBuiltUseCases.mdx
@@ -1,3 +1,3 @@
 _No pre-built syncs or actions available yet._
 
-<Tip>Not seeing the integration you need? [Build your own](https://nango.dev/docs/guides/primitives/functions) independently.</Tip>
+<Tip>Not seeing the integration you need? [Build your own](/guides/primitives/functions) independently.</Tip>

--- a/docs/snippets/generated/pivotaltracker/PreBuiltUseCases.mdx
+++ b/docs/snippets/generated/pivotaltracker/PreBuiltUseCases.mdx
@@ -1,3 +1,3 @@
 _No pre-built syncs or actions available yet._
 
-<Tip>Not seeing the integration you need? [Build your own](https://nango.dev/docs/guides/primitives/functions) independently.</Tip>
+<Tip>Not seeing the integration you need? [Build your own](/guides/primitives/functions) independently.</Tip>

--- a/docs/snippets/generated/plain/PreBuiltUseCases.mdx
+++ b/docs/snippets/generated/plain/PreBuiltUseCases.mdx
@@ -1,3 +1,3 @@
 _No pre-built syncs or actions available yet._
 
-<Tip>Not seeing the integration you need? [Build your own](https://nango.dev/docs/guides/primitives/functions) independently.</Tip>
+<Tip>Not seeing the integration you need? [Build your own](/guides/primitives/functions) independently.</Tip>

--- a/docs/snippets/generated/podium/PreBuiltUseCases.mdx
+++ b/docs/snippets/generated/podium/PreBuiltUseCases.mdx
@@ -1,3 +1,3 @@
 _No pre-built syncs or actions available yet._
 
-<Tip>Not seeing the integration you need? [Build your own](https://nango.dev/docs/guides/primitives/functions) independently.</Tip>
+<Tip>Not seeing the integration you need? [Build your own](/guides/primitives/functions) independently.</Tip>

--- a/docs/snippets/generated/posthog/PreBuiltUseCases.mdx
+++ b/docs/snippets/generated/posthog/PreBuiltUseCases.mdx
@@ -1,3 +1,3 @@
 _No pre-built syncs or actions available yet._
 
-<Tip>Not seeing the integration you need? [Build your own](https://nango.dev/docs/guides/primitives/functions) independently.</Tip>
+<Tip>Not seeing the integration you need? [Build your own](/guides/primitives/functions) independently.</Tip>

--- a/docs/snippets/generated/practicefusion/PreBuiltUseCases.mdx
+++ b/docs/snippets/generated/practicefusion/PreBuiltUseCases.mdx
@@ -1,3 +1,3 @@
 _No pre-built syncs or actions available yet._
 
-<Tip>Not seeing the integration you need? [Build your own](https://nango.dev/docs/guides/primitives/functions) independently.</Tip>
+<Tip>Not seeing the integration you need? [Build your own](/guides/primitives/functions) independently.</Tip>

--- a/docs/snippets/generated/precisefp/PreBuiltUseCases.mdx
+++ b/docs/snippets/generated/precisefp/PreBuiltUseCases.mdx
@@ -1,3 +1,3 @@
 _No pre-built syncs or actions available yet._
 
-<Tip>Not seeing the integration you need? [Build your own](https://nango.dev/docs/guides/primitives/functions) independently.</Tip>
+<Tip>Not seeing the integration you need? [Build your own](/guides/primitives/functions) independently.</Tip>

--- a/docs/snippets/generated/printful/PreBuiltUseCases.mdx
+++ b/docs/snippets/generated/printful/PreBuiltUseCases.mdx
@@ -1,3 +1,3 @@
 _No pre-built syncs or actions available yet._
 
-<Tip>Not seeing the integration you need? [Build your own](https://nango.dev/docs/guides/primitives/functions) independently.</Tip>
+<Tip>Not seeing the integration you need? [Build your own](/guides/primitives/functions) independently.</Tip>

--- a/docs/snippets/generated/private-api-basic/PreBuiltUseCases.mdx
+++ b/docs/snippets/generated/private-api-basic/PreBuiltUseCases.mdx
@@ -1,3 +1,3 @@
 _No pre-built syncs or actions available yet._
 
-<Tip>Not seeing the integration you need? [Build your own](https://nango.dev/docs/guides/primitives/functions) independently.</Tip>
+<Tip>Not seeing the integration you need? [Build your own](/guides/primitives/functions) independently.</Tip>

--- a/docs/snippets/generated/private-api-bearer/PreBuiltUseCases.mdx
+++ b/docs/snippets/generated/private-api-bearer/PreBuiltUseCases.mdx
@@ -1,3 +1,3 @@
 _No pre-built syncs or actions available yet._
 
-<Tip>Not seeing the integration you need? [Build your own](https://nango.dev/docs/guides/primitives/functions) independently.</Tip>
+<Tip>Not seeing the integration you need? [Build your own](/guides/primitives/functions) independently.</Tip>

--- a/docs/snippets/generated/prive/PreBuiltUseCases.mdx
+++ b/docs/snippets/generated/prive/PreBuiltUseCases.mdx
@@ -1,3 +1,3 @@
 _No pre-built syncs or actions available yet._
 
-<Tip>Not seeing the integration you need? [Build your own](https://nango.dev/docs/guides/primitives/functions) independently.</Tip>
+<Tip>Not seeing the integration you need? [Build your own](/guides/primitives/functions) independently.</Tip>

--- a/docs/snippets/generated/procore/PreBuiltUseCases.mdx
+++ b/docs/snippets/generated/procore/PreBuiltUseCases.mdx
@@ -1,3 +1,3 @@
 _No pre-built syncs or actions available yet._
 
-<Tip>Not seeing the integration you need? [Build your own](https://nango.dev/docs/guides/primitives/functions) independently.</Tip>
+<Tip>Not seeing the integration you need? [Build your own](/guides/primitives/functions) independently.</Tip>

--- a/docs/snippets/generated/productboard/PreBuiltUseCases.mdx
+++ b/docs/snippets/generated/productboard/PreBuiltUseCases.mdx
@@ -1,3 +1,3 @@
 _No pre-built syncs or actions available yet._
 
-<Tip>Not seeing the integration you need? [Build your own](https://nango.dev/docs/guides/primitives/functions) independently.</Tip>
+<Tip>Not seeing the integration you need? [Build your own](/guides/primitives/functions) independently.</Tip>

--- a/docs/snippets/generated/prospeo/PreBuiltUseCases.mdx
+++ b/docs/snippets/generated/prospeo/PreBuiltUseCases.mdx
@@ -1,3 +1,3 @@
 _No pre-built syncs or actions available yet._
 
-<Tip>Not seeing the integration you need? [Build your own](https://nango.dev/docs/guides/primitives/functions) independently.</Tip>
+<Tip>Not seeing the integration you need? [Build your own](/guides/primitives/functions) independently.</Tip>

--- a/docs/snippets/generated/provenexpert/PreBuiltUseCases.mdx
+++ b/docs/snippets/generated/provenexpert/PreBuiltUseCases.mdx
@@ -1,3 +1,3 @@
 _No pre-built syncs or actions available yet._
 
-<Tip>Not seeing the integration you need? [Build your own](https://nango.dev/docs/guides/primitives/functions) independently.</Tip>
+<Tip>Not seeing the integration you need? [Build your own](/guides/primitives/functions) independently.</Tip>

--- a/docs/snippets/generated/pylon/PreBuiltUseCases.mdx
+++ b/docs/snippets/generated/pylon/PreBuiltUseCases.mdx
@@ -1,3 +1,3 @@
 _No pre-built syncs or actions available yet._
 
-<Tip>Not seeing the integration you need? [Build your own](https://nango.dev/docs/guides/primitives/functions) independently.</Tip>
+<Tip>Not seeing the integration you need? [Build your own](/guides/primitives/functions) independently.</Tip>

--- a/docs/snippets/generated/qualtrics/PreBuiltUseCases.mdx
+++ b/docs/snippets/generated/qualtrics/PreBuiltUseCases.mdx
@@ -1,3 +1,3 @@
 _No pre-built syncs or actions available yet._
 
-<Tip>Not seeing the integration you need? [Build your own](https://nango.dev/docs/guides/primitives/functions) independently.</Tip>
+<Tip>Not seeing the integration you need? [Build your own](/guides/primitives/functions) independently.</Tip>

--- a/docs/snippets/generated/quentn/PreBuiltUseCases.mdx
+++ b/docs/snippets/generated/quentn/PreBuiltUseCases.mdx
@@ -1,3 +1,3 @@
 _No pre-built syncs or actions available yet._
 
-<Tip>Not seeing the integration you need? [Build your own](https://nango.dev/docs/guides/primitives/functions) independently.</Tip>
+<Tip>Not seeing the integration you need? [Build your own](/guides/primitives/functions) independently.</Tip>

--- a/docs/snippets/generated/quickbase/PreBuiltUseCases.mdx
+++ b/docs/snippets/generated/quickbase/PreBuiltUseCases.mdx
@@ -1,3 +1,3 @@
 _No pre-built syncs or actions available yet._
 
-<Tip>Not seeing the integration you need? [Build your own](https://nango.dev/docs/guides/primitives/functions) independently.</Tip>
+<Tip>Not seeing the integration you need? [Build your own](/guides/primitives/functions) independently.</Tip>

--- a/docs/snippets/generated/ragieai/PreBuiltUseCases.mdx
+++ b/docs/snippets/generated/ragieai/PreBuiltUseCases.mdx
@@ -1,3 +1,3 @@
 _No pre-built syncs or actions available yet._
 
-<Tip>Not seeing the integration you need? [Build your own](https://nango.dev/docs/guides/primitives/functions) independently.</Tip>
+<Tip>Not seeing the integration you need? [Build your own](/guides/primitives/functions) independently.</Tip>

--- a/docs/snippets/generated/rapidapi/PreBuiltUseCases.mdx
+++ b/docs/snippets/generated/rapidapi/PreBuiltUseCases.mdx
@@ -1,3 +1,3 @@
 _No pre-built syncs or actions available yet._
 
-<Tip>Not seeing the integration you need? [Build your own](https://nango.dev/docs/guides/primitives/functions) independently.</Tip>
+<Tip>Not seeing the integration you need? [Build your own](/guides/primitives/functions) independently.</Tip>

--- a/docs/snippets/generated/razorpay/PreBuiltUseCases.mdx
+++ b/docs/snippets/generated/razorpay/PreBuiltUseCases.mdx
@@ -1,3 +1,3 @@
 _No pre-built syncs or actions available yet._
 
-<Tip>Not seeing the integration you need? [Build your own](https://nango.dev/docs/guides/primitives/functions) independently.</Tip>
+<Tip>Not seeing the integration you need? [Build your own](/guides/primitives/functions) independently.</Tip>

--- a/docs/snippets/generated/readwise-reader/PreBuiltUseCases.mdx
+++ b/docs/snippets/generated/readwise-reader/PreBuiltUseCases.mdx
@@ -1,3 +1,3 @@
 _No pre-built syncs or actions available yet._
 
-<Tip>Not seeing the integration you need? [Build your own](https://nango.dev/docs/guides/primitives/functions) independently.</Tip>
+<Tip>Not seeing the integration you need? [Build your own](/guides/primitives/functions) independently.</Tip>

--- a/docs/snippets/generated/readwise/PreBuiltUseCases.mdx
+++ b/docs/snippets/generated/readwise/PreBuiltUseCases.mdx
@@ -1,3 +1,3 @@
 _No pre-built syncs or actions available yet._
 
-<Tip>Not seeing the integration you need? [Build your own](https://nango.dev/docs/guides/primitives/functions) independently.</Tip>
+<Tip>Not seeing the integration you need? [Build your own](/guides/primitives/functions) independently.</Tip>

--- a/docs/snippets/generated/reapit/PreBuiltUseCases.mdx
+++ b/docs/snippets/generated/reapit/PreBuiltUseCases.mdx
@@ -1,3 +1,3 @@
 _No pre-built syncs or actions available yet._
 
-<Tip>Not seeing the integration you need? [Build your own](https://nango.dev/docs/guides/primitives/functions) independently.</Tip>
+<Tip>Not seeing the integration you need? [Build your own](/guides/primitives/functions) independently.</Tip>

--- a/docs/snippets/generated/recall-ai/PreBuiltUseCases.mdx
+++ b/docs/snippets/generated/recall-ai/PreBuiltUseCases.mdx
@@ -1,3 +1,3 @@
 _No pre-built syncs or actions available yet._
 
-<Tip>Not seeing the integration you need? [Build your own](https://nango.dev/docs/guides/primitives/functions) independently.</Tip>
+<Tip>Not seeing the integration you need? [Build your own](/guides/primitives/functions) independently.</Tip>

--- a/docs/snippets/generated/recruitcrm/PreBuiltUseCases.mdx
+++ b/docs/snippets/generated/recruitcrm/PreBuiltUseCases.mdx
@@ -1,3 +1,3 @@
 _No pre-built syncs or actions available yet._
 
-<Tip>Not seeing the integration you need? [Build your own](https://nango.dev/docs/guides/primitives/functions) independently.</Tip>
+<Tip>Not seeing the integration you need? [Build your own](/guides/primitives/functions) independently.</Tip>

--- a/docs/snippets/generated/recruitee/PreBuiltUseCases.mdx
+++ b/docs/snippets/generated/recruitee/PreBuiltUseCases.mdx
@@ -1,3 +1,3 @@
 _No pre-built syncs or actions available yet._
 
-<Tip>Not seeing the integration you need? [Build your own](https://nango.dev/docs/guides/primitives/functions) independently.</Tip>
+<Tip>Not seeing the integration you need? [Build your own](/guides/primitives/functions) independently.</Tip>

--- a/docs/snippets/generated/reddit/PreBuiltUseCases.mdx
+++ b/docs/snippets/generated/reddit/PreBuiltUseCases.mdx
@@ -1,3 +1,3 @@
 _No pre-built syncs or actions available yet._
 
-<Tip>Not seeing the integration you need? [Build your own](https://nango.dev/docs/guides/primitives/functions) independently.</Tip>
+<Tip>Not seeing the integration you need? [Build your own](/guides/primitives/functions) independently.</Tip>

--- a/docs/snippets/generated/redtail-crm-sandbox/PreBuiltUseCases.mdx
+++ b/docs/snippets/generated/redtail-crm-sandbox/PreBuiltUseCases.mdx
@@ -1,3 +1,3 @@
 _No pre-built syncs or actions available yet._
 
-<Tip>Not seeing the integration you need? [Build your own](https://nango.dev/docs/guides/primitives/functions) independently.</Tip>
+<Tip>Not seeing the integration you need? [Build your own](/guides/primitives/functions) independently.</Tip>

--- a/docs/snippets/generated/refiner/PreBuiltUseCases.mdx
+++ b/docs/snippets/generated/refiner/PreBuiltUseCases.mdx
@@ -1,3 +1,3 @@
 _No pre-built syncs or actions available yet._
 
-<Tip>Not seeing the integration you need? [Build your own](https://nango.dev/docs/guides/primitives/functions) independently.</Tip>
+<Tip>Not seeing the integration you need? [Build your own](/guides/primitives/functions) independently.</Tip>

--- a/docs/snippets/generated/replicate/PreBuiltUseCases.mdx
+++ b/docs/snippets/generated/replicate/PreBuiltUseCases.mdx
@@ -1,3 +1,3 @@
 _No pre-built syncs or actions available yet._
 
-<Tip>Not seeing the integration you need? [Build your own](https://nango.dev/docs/guides/primitives/functions) independently.</Tip>
+<Tip>Not seeing the integration you need? [Build your own](/guides/primitives/functions) independently.</Tip>

--- a/docs/snippets/generated/researchdesk/PreBuiltUseCases.mdx
+++ b/docs/snippets/generated/researchdesk/PreBuiltUseCases.mdx
@@ -1,3 +1,3 @@
 _No pre-built syncs or actions available yet._
 
-<Tip>Not seeing the integration you need? [Build your own](https://nango.dev/docs/guides/primitives/functions) independently.</Tip>
+<Tip>Not seeing the integration you need? [Build your own](/guides/primitives/functions) independently.</Tip>

--- a/docs/snippets/generated/resend/PreBuiltUseCases.mdx
+++ b/docs/snippets/generated/resend/PreBuiltUseCases.mdx
@@ -1,3 +1,3 @@
 _No pre-built syncs or actions available yet._
 
-<Tip>Not seeing the integration you need? [Build your own](https://nango.dev/docs/guides/primitives/functions) independently.</Tip>
+<Tip>Not seeing the integration you need? [Build your own](/guides/primitives/functions) independently.</Tip>

--- a/docs/snippets/generated/retell-ai/PreBuiltUseCases.mdx
+++ b/docs/snippets/generated/retell-ai/PreBuiltUseCases.mdx
@@ -1,3 +1,3 @@
 _No pre-built syncs or actions available yet._
 
-<Tip>Not seeing the integration you need? [Build your own](https://nango.dev/docs/guides/primitives/functions) independently.</Tip>
+<Tip>Not seeing the integration you need? [Build your own](/guides/primitives/functions) independently.</Tip>

--- a/docs/snippets/generated/rippling-shop-app/PreBuiltUseCases.mdx
+++ b/docs/snippets/generated/rippling-shop-app/PreBuiltUseCases.mdx
@@ -1,3 +1,3 @@
 _No pre-built syncs or actions available yet._
 
-<Tip>Not seeing the integration you need? [Build your own](https://nango.dev/docs/guides/primitives/functions) independently.</Tip>
+<Tip>Not seeing the integration you need? [Build your own](/guides/primitives/functions) independently.</Tip>

--- a/docs/snippets/generated/rippling/PreBuiltUseCases.mdx
+++ b/docs/snippets/generated/rippling/PreBuiltUseCases.mdx
@@ -1,3 +1,3 @@
 _No pre-built syncs or actions available yet._
 
-<Tip>Not seeing the integration you need? [Build your own](https://nango.dev/docs/guides/primitives/functions) independently.</Tip>
+<Tip>Not seeing the integration you need? [Build your own](/guides/primitives/functions) independently.</Tip>

--- a/docs/snippets/generated/roam-scim/PreBuiltUseCases.mdx
+++ b/docs/snippets/generated/roam-scim/PreBuiltUseCases.mdx
@@ -1,3 +1,3 @@
 _No pre-built syncs or actions available yet._
 
-<Tip>Not seeing the integration you need? [Build your own](https://nango.dev/docs/guides/primitives/functions) independently.</Tip>
+<Tip>Not seeing the integration you need? [Build your own](/guides/primitives/functions) independently.</Tip>

--- a/docs/snippets/generated/rock-gym-pro/PreBuiltUseCases.mdx
+++ b/docs/snippets/generated/rock-gym-pro/PreBuiltUseCases.mdx
@@ -1,3 +1,3 @@
 _No pre-built syncs or actions available yet._
 
-<Tip>Not seeing the integration you need? [Build your own](https://nango.dev/docs/guides/primitives/functions) independently.</Tip>
+<Tip>Not seeing the integration you need? [Build your own](/guides/primitives/functions) independently.</Tip>

--- a/docs/snippets/generated/rocketlane/PreBuiltUseCases.mdx
+++ b/docs/snippets/generated/rocketlane/PreBuiltUseCases.mdx
@@ -1,3 +1,3 @@
 _No pre-built syncs or actions available yet._
 
-<Tip>Not seeing the integration you need? [Build your own](https://nango.dev/docs/guides/primitives/functions) independently.</Tip>
+<Tip>Not seeing the integration you need? [Build your own](/guides/primitives/functions) independently.</Tip>

--- a/docs/snippets/generated/roller/PreBuiltUseCases.mdx
+++ b/docs/snippets/generated/roller/PreBuiltUseCases.mdx
@@ -1,3 +1,3 @@
 _No pre-built syncs or actions available yet._
 
-<Tip>Not seeing the integration you need? [Build your own](https://nango.dev/docs/guides/primitives/functions) independently.</Tip>
+<Tip>Not seeing the integration you need? [Build your own](/guides/primitives/functions) independently.</Tip>

--- a/docs/snippets/generated/rootly/PreBuiltUseCases.mdx
+++ b/docs/snippets/generated/rootly/PreBuiltUseCases.mdx
@@ -1,3 +1,3 @@
 _No pre-built syncs or actions available yet._
 
-<Tip>Not seeing the integration you need? [Build your own](https://nango.dev/docs/guides/primitives/functions) independently.</Tip>
+<Tip>Not seeing the integration you need? [Build your own](/guides/primitives/functions) independently.</Tip>

--- a/docs/snippets/generated/sage-hr/PreBuiltUseCases.mdx
+++ b/docs/snippets/generated/sage-hr/PreBuiltUseCases.mdx
@@ -1,3 +1,3 @@
 _No pre-built syncs or actions available yet._
 
-<Tip>Not seeing the integration you need? [Build your own](https://nango.dev/docs/guides/primitives/functions) independently.</Tip>
+<Tip>Not seeing the integration you need? [Build your own](/guides/primitives/functions) independently.</Tip>

--- a/docs/snippets/generated/sage-intacct/PreBuiltUseCases.mdx
+++ b/docs/snippets/generated/sage-intacct/PreBuiltUseCases.mdx
@@ -1,3 +1,3 @@
 _No pre-built syncs or actions available yet._
 
-<Tip>Not seeing the integration you need? [Build your own](https://nango.dev/docs/guides/primitives/functions) independently.</Tip>
+<Tip>Not seeing the integration you need? [Build your own](/guides/primitives/functions) independently.</Tip>

--- a/docs/snippets/generated/sage-people/PreBuiltUseCases.mdx
+++ b/docs/snippets/generated/sage-people/PreBuiltUseCases.mdx
@@ -1,3 +1,3 @@
 _No pre-built syncs or actions available yet._
 
-<Tip>Not seeing the integration you need? [Build your own](https://nango.dev/docs/guides/primitives/functions) independently.</Tip>
+<Tip>Not seeing the integration you need? [Build your own](/guides/primitives/functions) independently.</Tip>

--- a/docs/snippets/generated/sage/PreBuiltUseCases.mdx
+++ b/docs/snippets/generated/sage/PreBuiltUseCases.mdx
@@ -1,3 +1,3 @@
 _No pre-built syncs or actions available yet._
 
-<Tip>Not seeing the integration you need? [Build your own](https://nango.dev/docs/guides/primitives/functions) independently.</Tip>
+<Tip>Not seeing the integration you need? [Build your own](/guides/primitives/functions) independently.</Tip>

--- a/docs/snippets/generated/salesforce-cdp/PreBuiltUseCases.mdx
+++ b/docs/snippets/generated/salesforce-cdp/PreBuiltUseCases.mdx
@@ -1,3 +1,3 @@
 _No pre-built syncs or actions available yet._
 
-<Tip>Not seeing the integration you need? [Build your own](https://nango.dev/docs/guides/primitives/functions) independently.</Tip>
+<Tip>Not seeing the integration you need? [Build your own](/guides/primitives/functions) independently.</Tip>

--- a/docs/snippets/generated/salesforce-experience-cloud/PreBuiltUseCases.mdx
+++ b/docs/snippets/generated/salesforce-experience-cloud/PreBuiltUseCases.mdx
@@ -1,3 +1,3 @@
 _No pre-built syncs or actions available yet._
 
-<Tip>Not seeing the integration you need? [Build your own](https://nango.dev/docs/guides/primitives/functions) independently.</Tip>
+<Tip>Not seeing the integration you need? [Build your own](/guides/primitives/functions) independently.</Tip>

--- a/docs/snippets/generated/salesforce-jwt/PreBuiltUseCases.mdx
+++ b/docs/snippets/generated/salesforce-jwt/PreBuiltUseCases.mdx
@@ -1,3 +1,3 @@
 _No pre-built syncs or actions available yet._
 
-<Tip>Not seeing the integration you need? [Build your own](https://nango.dev/docs/guides/primitives/functions) independently.</Tip>
+<Tip>Not seeing the integration you need? [Build your own](/guides/primitives/functions) independently.</Tip>

--- a/docs/snippets/generated/salesloft/PreBuiltUseCases.mdx
+++ b/docs/snippets/generated/salesloft/PreBuiltUseCases.mdx
@@ -1,3 +1,3 @@
 _No pre-built syncs or actions available yet._
 
-<Tip>Not seeing the integration you need? [Build your own](https://nango.dev/docs/guides/primitives/functions) independently.</Tip>
+<Tip>Not seeing the integration you need? [Build your own](/guides/primitives/functions) independently.</Tip>

--- a/docs/snippets/generated/salesmsg-oauth2/PreBuiltUseCases.mdx
+++ b/docs/snippets/generated/salesmsg-oauth2/PreBuiltUseCases.mdx
@@ -1,3 +1,3 @@
 _No pre-built syncs or actions available yet._
 
-<Tip>Not seeing the integration you need? [Build your own](https://nango.dev/docs/guides/primitives/functions) independently.</Tip>
+<Tip>Not seeing the integration you need? [Build your own](/guides/primitives/functions) independently.</Tip>

--- a/docs/snippets/generated/salesmsg/PreBuiltUseCases.mdx
+++ b/docs/snippets/generated/salesmsg/PreBuiltUseCases.mdx
@@ -1,3 +1,3 @@
 _No pre-built syncs or actions available yet._
 
-<Tip>Not seeing the integration you need? [Build your own](https://nango.dev/docs/guides/primitives/functions) independently.</Tip>
+<Tip>Not seeing the integration you need? [Build your own](/guides/primitives/functions) independently.</Tip>

--- a/docs/snippets/generated/sap-business-one/PreBuiltUseCases.mdx
+++ b/docs/snippets/generated/sap-business-one/PreBuiltUseCases.mdx
@@ -1,3 +1,3 @@
 _No pre-built syncs or actions available yet._
 
-<Tip>Not seeing the integration you need? [Build your own](https://nango.dev/docs/guides/primitives/functions) independently.</Tip>
+<Tip>Not seeing the integration you need? [Build your own](/guides/primitives/functions) independently.</Tip>

--- a/docs/snippets/generated/sap-concur/PreBuiltUseCases.mdx
+++ b/docs/snippets/generated/sap-concur/PreBuiltUseCases.mdx
@@ -1,3 +1,3 @@
 _No pre-built syncs or actions available yet._
 
-<Tip>Not seeing the integration you need? [Build your own](https://nango.dev/docs/guides/primitives/functions) independently.</Tip>
+<Tip>Not seeing the integration you need? [Build your own](/guides/primitives/functions) independently.</Tip>

--- a/docs/snippets/generated/sap-fieldglass/PreBuiltUseCases.mdx
+++ b/docs/snippets/generated/sap-fieldglass/PreBuiltUseCases.mdx
@@ -1,3 +1,3 @@
 _No pre-built syncs or actions available yet._
 
-<Tip>Not seeing the integration you need? [Build your own](https://nango.dev/docs/guides/primitives/functions) independently.</Tip>
+<Tip>Not seeing the integration you need? [Build your own](/guides/primitives/functions) independently.</Tip>

--- a/docs/snippets/generated/sap-odata-basic/PreBuiltUseCases.mdx
+++ b/docs/snippets/generated/sap-odata-basic/PreBuiltUseCases.mdx
@@ -1,3 +1,3 @@
 _No pre-built syncs or actions available yet._
 
-<Tip>Not seeing the integration you need? [Build your own](https://nango.dev/docs/guides/primitives/functions) independently.</Tip>
+<Tip>Not seeing the integration you need? [Build your own](/guides/primitives/functions) independently.</Tip>

--- a/docs/snippets/generated/sap-odata-oauth2-cc/PreBuiltUseCases.mdx
+++ b/docs/snippets/generated/sap-odata-oauth2-cc/PreBuiltUseCases.mdx
@@ -1,3 +1,3 @@
 _No pre-built syncs or actions available yet._
 
-<Tip>Not seeing the integration you need? [Build your own](https://nango.dev/docs/guides/primitives/functions) independently.</Tip>
+<Tip>Not seeing the integration you need? [Build your own](/guides/primitives/functions) independently.</Tip>

--- a/docs/snippets/generated/schwab/PreBuiltUseCases.mdx
+++ b/docs/snippets/generated/schwab/PreBuiltUseCases.mdx
@@ -1,3 +1,3 @@
 _No pre-built syncs or actions available yet._
 
-<Tip>Not seeing the integration you need? [Build your own](https://nango.dev/docs/guides/primitives/functions) independently.</Tip>
+<Tip>Not seeing the integration you need? [Build your own](/guides/primitives/functions) independently.</Tip>

--- a/docs/snippets/generated/scrapedo/PreBuiltUseCases.mdx
+++ b/docs/snippets/generated/scrapedo/PreBuiltUseCases.mdx
@@ -1,3 +1,3 @@
 _No pre-built syncs or actions available yet._
 
-<Tip>Not seeing the integration you need? [Build your own](https://nango.dev/docs/guides/primitives/functions) independently.</Tip>
+<Tip>Not seeing the integration you need? [Build your own](/guides/primitives/functions) independently.</Tip>

--- a/docs/snippets/generated/sedna-basic/PreBuiltUseCases.mdx
+++ b/docs/snippets/generated/sedna-basic/PreBuiltUseCases.mdx
@@ -1,3 +1,3 @@
 _No pre-built syncs or actions available yet._
 
-<Tip>Not seeing the integration you need? [Build your own](https://nango.dev/docs/guides/primitives/functions) independently.</Tip>
+<Tip>Not seeing the integration you need? [Build your own](/guides/primitives/functions) independently.</Tip>

--- a/docs/snippets/generated/sedna/PreBuiltUseCases.mdx
+++ b/docs/snippets/generated/sedna/PreBuiltUseCases.mdx
@@ -1,3 +1,3 @@
 _No pre-built syncs or actions available yet._
 
-<Tip>Not seeing the integration you need? [Build your own](https://nango.dev/docs/guides/primitives/functions) independently.</Tip>
+<Tip>Not seeing the integration you need? [Build your own](/guides/primitives/functions) independently.</Tip>

--- a/docs/snippets/generated/segment/PreBuiltUseCases.mdx
+++ b/docs/snippets/generated/segment/PreBuiltUseCases.mdx
@@ -1,3 +1,3 @@
 _No pre-built syncs or actions available yet._
 
-<Tip>Not seeing the integration you need? [Build your own](https://nango.dev/docs/guides/primitives/functions) independently.</Tip>
+<Tip>Not seeing the integration you need? [Build your own](/guides/primitives/functions) independently.</Tip>

--- a/docs/snippets/generated/sellercloud/PreBuiltUseCases.mdx
+++ b/docs/snippets/generated/sellercloud/PreBuiltUseCases.mdx
@@ -1,3 +1,3 @@
 _No pre-built syncs or actions available yet._
 
-<Tip>Not seeing the integration you need? [Build your own](https://nango.dev/docs/guides/primitives/functions) independently.</Tip>
+<Tip>Not seeing the integration you need? [Build your own](/guides/primitives/functions) independently.</Tip>

--- a/docs/snippets/generated/sellsy-oauth2-cc/PreBuiltUseCases.mdx
+++ b/docs/snippets/generated/sellsy-oauth2-cc/PreBuiltUseCases.mdx
@@ -1,3 +1,3 @@
 _No pre-built syncs or actions available yet._
 
-<Tip>Not seeing the integration you need? [Build your own](https://nango.dev/docs/guides/primitives/functions) independently.</Tip>
+<Tip>Not seeing the integration you need? [Build your own](/guides/primitives/functions) independently.</Tip>

--- a/docs/snippets/generated/sellsy/PreBuiltUseCases.mdx
+++ b/docs/snippets/generated/sellsy/PreBuiltUseCases.mdx
@@ -1,3 +1,3 @@
 _No pre-built syncs or actions available yet._
 
-<Tip>Not seeing the integration you need? [Build your own](https://nango.dev/docs/guides/primitives/functions) independently.</Tip>
+<Tip>Not seeing the integration you need? [Build your own](/guides/primitives/functions) independently.</Tip>

--- a/docs/snippets/generated/semrush/PreBuiltUseCases.mdx
+++ b/docs/snippets/generated/semrush/PreBuiltUseCases.mdx
@@ -1,3 +1,3 @@
 _No pre-built syncs or actions available yet._
 
-<Tip>Not seeing the integration you need? [Build your own](https://nango.dev/docs/guides/primitives/functions) independently.</Tip>
+<Tip>Not seeing the integration you need? [Build your own](/guides/primitives/functions) independently.</Tip>

--- a/docs/snippets/generated/sendgrid/PreBuiltUseCases.mdx
+++ b/docs/snippets/generated/sendgrid/PreBuiltUseCases.mdx
@@ -1,3 +1,3 @@
 _No pre-built syncs or actions available yet._
 
-<Tip>Not seeing the integration you need? [Build your own](https://nango.dev/docs/guides/primitives/functions) independently.</Tip>
+<Tip>Not seeing the integration you need? [Build your own](/guides/primitives/functions) independently.</Tip>

--- a/docs/snippets/generated/sentry-oauth/PreBuiltUseCases.mdx
+++ b/docs/snippets/generated/sentry-oauth/PreBuiltUseCases.mdx
@@ -1,3 +1,3 @@
 _No pre-built syncs or actions available yet._
 
-<Tip>Not seeing the integration you need? [Build your own](https://nango.dev/docs/guides/primitives/functions) independently.</Tip>
+<Tip>Not seeing the integration you need? [Build your own](/guides/primitives/functions) independently.</Tip>

--- a/docs/snippets/generated/sentry/PreBuiltUseCases.mdx
+++ b/docs/snippets/generated/sentry/PreBuiltUseCases.mdx
@@ -1,3 +1,3 @@
 _No pre-built syncs or actions available yet._
 
-<Tip>Not seeing the integration you need? [Build your own](https://nango.dev/docs/guides/primitives/functions) independently.</Tip>
+<Tip>Not seeing the integration you need? [Build your own](/guides/primitives/functions) independently.</Tip>

--- a/docs/snippets/generated/servicem8/PreBuiltUseCases.mdx
+++ b/docs/snippets/generated/servicem8/PreBuiltUseCases.mdx
@@ -1,3 +1,3 @@
 _No pre-built syncs or actions available yet._
 
-<Tip>Not seeing the integration you need? [Build your own](https://nango.dev/docs/guides/primitives/functions) independently.</Tip>
+<Tip>Not seeing the integration you need? [Build your own](/guides/primitives/functions) independently.</Tip>

--- a/docs/snippets/generated/servicenow-oauth2-cc/PreBuiltUseCases.mdx
+++ b/docs/snippets/generated/servicenow-oauth2-cc/PreBuiltUseCases.mdx
@@ -1,3 +1,3 @@
 _No pre-built syncs or actions available yet._
 
-<Tip>Not seeing the integration you need? [Build your own](https://nango.dev/docs/guides/primitives/functions) independently.</Tip>
+<Tip>Not seeing the integration you need? [Build your own](/guides/primitives/functions) independently.</Tip>

--- a/docs/snippets/generated/servicenow/PreBuiltUseCases.mdx
+++ b/docs/snippets/generated/servicenow/PreBuiltUseCases.mdx
@@ -1,3 +1,3 @@
 _No pre-built syncs or actions available yet._
 
-<Tip>Not seeing the integration you need? [Build your own](https://nango.dev/docs/guides/primitives/functions) independently.</Tip>
+<Tip>Not seeing the integration you need? [Build your own](/guides/primitives/functions) independently.</Tip>

--- a/docs/snippets/generated/setmore/PreBuiltUseCases.mdx
+++ b/docs/snippets/generated/setmore/PreBuiltUseCases.mdx
@@ -1,3 +1,3 @@
 _No pre-built syncs or actions available yet._
 
-<Tip>Not seeing the integration you need? [Build your own](https://nango.dev/docs/guides/primitives/functions) independently.</Tip>
+<Tip>Not seeing the integration you need? [Build your own](/guides/primitives/functions) independently.</Tip>

--- a/docs/snippets/generated/sharepoint-online-oauth2-cc/PreBuiltUseCases.mdx
+++ b/docs/snippets/generated/sharepoint-online-oauth2-cc/PreBuiltUseCases.mdx
@@ -1,3 +1,3 @@
 _No pre-built syncs or actions available yet._
 
-<Tip>Not seeing the integration you need? [Build your own](https://nango.dev/docs/guides/primitives/functions) independently.</Tip>
+<Tip>Not seeing the integration you need? [Build your own](/guides/primitives/functions) independently.</Tip>

--- a/docs/snippets/generated/sharepoint-online-v1/PreBuiltUseCases.mdx
+++ b/docs/snippets/generated/sharepoint-online-v1/PreBuiltUseCases.mdx
@@ -1,3 +1,3 @@
 _No pre-built syncs or actions available yet._
 
-<Tip>Not seeing the integration you need? [Build your own](https://nango.dev/docs/guides/primitives/functions) independently.</Tip>
+<Tip>Not seeing the integration you need? [Build your own](/guides/primitives/functions) independently.</Tip>

--- a/docs/snippets/generated/shipstation-v2/PreBuiltUseCases.mdx
+++ b/docs/snippets/generated/shipstation-v2/PreBuiltUseCases.mdx
@@ -1,3 +1,3 @@
 _No pre-built syncs or actions available yet._
 
-<Tip>Not seeing the integration you need? [Build your own](https://nango.dev/docs/guides/primitives/functions) independently.</Tip>
+<Tip>Not seeing the integration you need? [Build your own](/guides/primitives/functions) independently.</Tip>

--- a/docs/snippets/generated/shipstation/PreBuiltUseCases.mdx
+++ b/docs/snippets/generated/shipstation/PreBuiltUseCases.mdx
@@ -1,3 +1,3 @@
 _No pre-built syncs or actions available yet._
 
-<Tip>Not seeing the integration you need? [Build your own](https://nango.dev/docs/guides/primitives/functions) independently.</Tip>
+<Tip>Not seeing the integration you need? [Build your own](/guides/primitives/functions) independently.</Tip>

--- a/docs/snippets/generated/shopify-api-key/PreBuiltUseCases.mdx
+++ b/docs/snippets/generated/shopify-api-key/PreBuiltUseCases.mdx
@@ -1,3 +1,3 @@
 _No pre-built syncs or actions available yet._
 
-<Tip>Not seeing the integration you need? [Build your own](https://nango.dev/docs/guides/primitives/functions) independently.</Tip>
+<Tip>Not seeing the integration you need? [Build your own](/guides/primitives/functions) independently.</Tip>

--- a/docs/snippets/generated/shopify-partner/PreBuiltUseCases.mdx
+++ b/docs/snippets/generated/shopify-partner/PreBuiltUseCases.mdx
@@ -1,3 +1,3 @@
 _No pre-built syncs or actions available yet._
 
-<Tip>Not seeing the integration you need? [Build your own](https://nango.dev/docs/guides/primitives/functions) independently.</Tip>
+<Tip>Not seeing the integration you need? [Build your own](/guides/primitives/functions) independently.</Tip>

--- a/docs/snippets/generated/shopify-scim/PreBuiltUseCases.mdx
+++ b/docs/snippets/generated/shopify-scim/PreBuiltUseCases.mdx
@@ -1,3 +1,3 @@
 _No pre-built syncs or actions available yet._
 
-<Tip>Not seeing the integration you need? [Build your own](https://nango.dev/docs/guides/primitives/functions) independently.</Tip>
+<Tip>Not seeing the integration you need? [Build your own](/guides/primitives/functions) independently.</Tip>

--- a/docs/snippets/generated/shortcut/PreBuiltUseCases.mdx
+++ b/docs/snippets/generated/shortcut/PreBuiltUseCases.mdx
@@ -1,3 +1,3 @@
 _No pre-built syncs or actions available yet._
 
-<Tip>Not seeing the integration you need? [Build your own](https://nango.dev/docs/guides/primitives/functions) independently.</Tip>
+<Tip>Not seeing the integration you need? [Build your own](/guides/primitives/functions) independently.</Tip>

--- a/docs/snippets/generated/signnow-sandbox/PreBuiltUseCases.mdx
+++ b/docs/snippets/generated/signnow-sandbox/PreBuiltUseCases.mdx
@@ -1,3 +1,3 @@
 _No pre-built syncs or actions available yet._
 
-<Tip>Not seeing the integration you need? [Build your own](https://nango.dev/docs/guides/primitives/functions) independently.</Tip>
+<Tip>Not seeing the integration you need? [Build your own](/guides/primitives/functions) independently.</Tip>

--- a/docs/snippets/generated/signnow/PreBuiltUseCases.mdx
+++ b/docs/snippets/generated/signnow/PreBuiltUseCases.mdx
@@ -1,3 +1,3 @@
 _No pre-built syncs or actions available yet._
 
-<Tip>Not seeing the integration you need? [Build your own](https://nango.dev/docs/guides/primitives/functions) independently.</Tip>
+<Tip>Not seeing the integration you need? [Build your own](/guides/primitives/functions) independently.</Tip>

--- a/docs/snippets/generated/skio/PreBuiltUseCases.mdx
+++ b/docs/snippets/generated/skio/PreBuiltUseCases.mdx
@@ -1,3 +1,3 @@
 _No pre-built syncs or actions available yet._
 
-<Tip>Not seeing the integration you need? [Build your own](https://nango.dev/docs/guides/primitives/functions) independently.</Tip>
+<Tip>Not seeing the integration you need? [Build your own](/guides/primitives/functions) independently.</Tip>

--- a/docs/snippets/generated/slab/PreBuiltUseCases.mdx
+++ b/docs/snippets/generated/slab/PreBuiltUseCases.mdx
@@ -1,3 +1,3 @@
 _No pre-built syncs or actions available yet._
 
-<Tip>Not seeing the integration you need? [Build your own](https://nango.dev/docs/guides/primitives/functions) independently.</Tip>
+<Tip>Not seeing the integration you need? [Build your own](/guides/primitives/functions) independently.</Tip>

--- a/docs/snippets/generated/smartlead-ai/PreBuiltUseCases.mdx
+++ b/docs/snippets/generated/smartlead-ai/PreBuiltUseCases.mdx
@@ -1,3 +1,3 @@
 _No pre-built syncs or actions available yet._
 
-<Tip>Not seeing the integration you need? [Build your own](https://nango.dev/docs/guides/primitives/functions) independently.</Tip>
+<Tip>Not seeing the integration you need? [Build your own](/guides/primitives/functions) independently.</Tip>

--- a/docs/snippets/generated/smartrecruiters-api-key/PreBuiltUseCases.mdx
+++ b/docs/snippets/generated/smartrecruiters-api-key/PreBuiltUseCases.mdx
@@ -1,3 +1,3 @@
 _No pre-built syncs or actions available yet._
 
-<Tip>Not seeing the integration you need? [Build your own](https://nango.dev/docs/guides/primitives/functions) independently.</Tip>
+<Tip>Not seeing the integration you need? [Build your own](/guides/primitives/functions) independently.</Tip>

--- a/docs/snippets/generated/smugmug/PreBuiltUseCases.mdx
+++ b/docs/snippets/generated/smugmug/PreBuiltUseCases.mdx
@@ -1,3 +1,3 @@
 _No pre-built syncs or actions available yet._
 
-<Tip>Not seeing the integration you need? [Build your own](https://nango.dev/docs/guides/primitives/functions) independently.</Tip>
+<Tip>Not seeing the integration you need? [Build your own](/guides/primitives/functions) independently.</Tip>

--- a/docs/snippets/generated/snapchat/PreBuiltUseCases.mdx
+++ b/docs/snippets/generated/snapchat/PreBuiltUseCases.mdx
@@ -1,3 +1,3 @@
 _No pre-built syncs or actions available yet._
 
-<Tip>Not seeing the integration you need? [Build your own](https://nango.dev/docs/guides/primitives/functions) independently.</Tip>
+<Tip>Not seeing the integration you need? [Build your own](/guides/primitives/functions) independently.</Tip>

--- a/docs/snippets/generated/snipe-it/PreBuiltUseCases.mdx
+++ b/docs/snippets/generated/snipe-it/PreBuiltUseCases.mdx
@@ -1,3 +1,3 @@
 _No pre-built syncs or actions available yet._
 
-<Tip>Not seeing the integration you need? [Build your own](https://nango.dev/docs/guides/primitives/functions) independently.</Tip>
+<Tip>Not seeing the integration you need? [Build your own](/guides/primitives/functions) independently.</Tip>

--- a/docs/snippets/generated/snowflake-jwt/PreBuiltUseCases.mdx
+++ b/docs/snippets/generated/snowflake-jwt/PreBuiltUseCases.mdx
@@ -1,3 +1,3 @@
 _No pre-built syncs or actions available yet._
 
-<Tip>Not seeing the integration you need? [Build your own](https://nango.dev/docs/guides/primitives/functions) independently.</Tip>
+<Tip>Not seeing the integration you need? [Build your own](/guides/primitives/functions) independently.</Tip>

--- a/docs/snippets/generated/snowflake/PreBuiltUseCases.mdx
+++ b/docs/snippets/generated/snowflake/PreBuiltUseCases.mdx
@@ -1,3 +1,3 @@
 _No pre-built syncs or actions available yet._
 
-<Tip>Not seeing the integration you need? [Build your own](https://nango.dev/docs/guides/primitives/functions) independently.</Tip>
+<Tip>Not seeing the integration you need? [Build your own](/guides/primitives/functions) independently.</Tip>

--- a/docs/snippets/generated/sophos-central/PreBuiltUseCases.mdx
+++ b/docs/snippets/generated/sophos-central/PreBuiltUseCases.mdx
@@ -1,3 +1,3 @@
 _No pre-built syncs or actions available yet._
 
-<Tip>Not seeing the integration you need? [Build your own](https://nango.dev/docs/guides/primitives/functions) independently.</Tip>
+<Tip>Not seeing the integration you need? [Build your own](/guides/primitives/functions) independently.</Tip>

--- a/docs/snippets/generated/splitwise/PreBuiltUseCases.mdx
+++ b/docs/snippets/generated/splitwise/PreBuiltUseCases.mdx
@@ -1,3 +1,3 @@
 _No pre-built syncs or actions available yet._
 
-<Tip>Not seeing the integration you need? [Build your own](https://nango.dev/docs/guides/primitives/functions) independently.</Tip>
+<Tip>Not seeing the integration you need? [Build your own](/guides/primitives/functions) independently.</Tip>

--- a/docs/snippets/generated/spotify-oauth-cc/PreBuiltUseCases.mdx
+++ b/docs/snippets/generated/spotify-oauth-cc/PreBuiltUseCases.mdx
@@ -1,3 +1,3 @@
 _No pre-built syncs or actions available yet._
 
-<Tip>Not seeing the integration you need? [Build your own](https://nango.dev/docs/guides/primitives/functions) independently.</Tip>
+<Tip>Not seeing the integration you need? [Build your own](/guides/primitives/functions) independently.</Tip>

--- a/docs/snippets/generated/spotify-oauth2-cc/PreBuiltUseCases.mdx
+++ b/docs/snippets/generated/spotify-oauth2-cc/PreBuiltUseCases.mdx
@@ -1,3 +1,3 @@
 _No pre-built syncs or actions available yet._
 
-<Tip>Not seeing the integration you need? [Build your own](https://nango.dev/docs/guides/primitives/functions) independently.</Tip>
+<Tip>Not seeing the integration you need? [Build your own](/guides/primitives/functions) independently.</Tip>

--- a/docs/snippets/generated/spotify/PreBuiltUseCases.mdx
+++ b/docs/snippets/generated/spotify/PreBuiltUseCases.mdx
@@ -1,3 +1,3 @@
 _No pre-built syncs or actions available yet._
 
-<Tip>Not seeing the integration you need? [Build your own](https://nango.dev/docs/guides/primitives/functions) independently.</Tip>
+<Tip>Not seeing the integration you need? [Build your own](/guides/primitives/functions) independently.</Tip>

--- a/docs/snippets/generated/squarespace/PreBuiltUseCases.mdx
+++ b/docs/snippets/generated/squarespace/PreBuiltUseCases.mdx
@@ -1,3 +1,3 @@
 _No pre-built syncs or actions available yet._
 
-<Tip>Not seeing the integration you need? [Build your own](https://nango.dev/docs/guides/primitives/functions) independently.</Tip>
+<Tip>Not seeing the integration you need? [Build your own](/guides/primitives/functions) independently.</Tip>

--- a/docs/snippets/generated/squareup-sandbox/PreBuiltUseCases.mdx
+++ b/docs/snippets/generated/squareup-sandbox/PreBuiltUseCases.mdx
@@ -1,3 +1,3 @@
 _No pre-built syncs or actions available yet._
 
-<Tip>Not seeing the integration you need? [Build your own](https://nango.dev/docs/guides/primitives/functions) independently.</Tip>
+<Tip>Not seeing the integration you need? [Build your own](/guides/primitives/functions) independently.</Tip>

--- a/docs/snippets/generated/squareup/PreBuiltUseCases.mdx
+++ b/docs/snippets/generated/squareup/PreBuiltUseCases.mdx
@@ -1,3 +1,3 @@
 _No pre-built syncs or actions available yet._
 
-<Tip>Not seeing the integration you need? [Build your own](https://nango.dev/docs/guides/primitives/functions) independently.</Tip>
+<Tip>Not seeing the integration you need? [Build your own](/guides/primitives/functions) independently.</Tip>

--- a/docs/snippets/generated/stackexchange/PreBuiltUseCases.mdx
+++ b/docs/snippets/generated/stackexchange/PreBuiltUseCases.mdx
@@ -1,3 +1,3 @@
 _No pre-built syncs or actions available yet._
 
-<Tip>Not seeing the integration you need? [Build your own](https://nango.dev/docs/guides/primitives/functions) independently.</Tip>
+<Tip>Not seeing the integration you need? [Build your own](/guides/primitives/functions) independently.</Tip>

--- a/docs/snippets/generated/statista/PreBuiltUseCases.mdx
+++ b/docs/snippets/generated/statista/PreBuiltUseCases.mdx
@@ -1,3 +1,3 @@
 _No pre-built syncs or actions available yet._
 
-<Tip>Not seeing the integration you need? [Build your own](https://nango.dev/docs/guides/primitives/functions) independently.</Tip>
+<Tip>Not seeing the integration you need? [Build your own](/guides/primitives/functions) independently.</Tip>

--- a/docs/snippets/generated/strava-web/PreBuiltUseCases.mdx
+++ b/docs/snippets/generated/strava-web/PreBuiltUseCases.mdx
@@ -1,3 +1,3 @@
 _No pre-built syncs or actions available yet._
 
-<Tip>Not seeing the integration you need? [Build your own](https://nango.dev/docs/guides/primitives/functions) independently.</Tip>
+<Tip>Not seeing the integration you need? [Build your own](/guides/primitives/functions) independently.</Tip>

--- a/docs/snippets/generated/strava/PreBuiltUseCases.mdx
+++ b/docs/snippets/generated/strava/PreBuiltUseCases.mdx
@@ -1,3 +1,3 @@
 _No pre-built syncs or actions available yet._
 
-<Tip>Not seeing the integration you need? [Build your own](https://nango.dev/docs/guides/primitives/functions) independently.</Tip>
+<Tip>Not seeing the integration you need? [Build your own](/guides/primitives/functions) independently.</Tip>

--- a/docs/snippets/generated/streak/PreBuiltUseCases.mdx
+++ b/docs/snippets/generated/streak/PreBuiltUseCases.mdx
@@ -1,3 +1,3 @@
 _No pre-built syncs or actions available yet._
 
-<Tip>Not seeing the integration you need? [Build your own](https://nango.dev/docs/guides/primitives/functions) independently.</Tip>
+<Tip>Not seeing the integration you need? [Build your own](/guides/primitives/functions) independently.</Tip>

--- a/docs/snippets/generated/stripe-api-key/PreBuiltUseCases.mdx
+++ b/docs/snippets/generated/stripe-api-key/PreBuiltUseCases.mdx
@@ -1,3 +1,3 @@
 _No pre-built syncs or actions available yet._
 
-<Tip>Not seeing the integration you need? [Build your own](https://nango.dev/docs/guides/primitives/functions) independently.</Tip>
+<Tip>Not seeing the integration you need? [Build your own](/guides/primitives/functions) independently.</Tip>

--- a/docs/snippets/generated/stripe-express/PreBuiltUseCases.mdx
+++ b/docs/snippets/generated/stripe-express/PreBuiltUseCases.mdx
@@ -1,3 +1,3 @@
 _No pre-built syncs or actions available yet._
 
-<Tip>Not seeing the integration you need? [Build your own](https://nango.dev/docs/guides/primitives/functions) independently.</Tip>
+<Tip>Not seeing the integration you need? [Build your own](/guides/primitives/functions) independently.</Tip>

--- a/docs/snippets/generated/stripe/PreBuiltUseCases.mdx
+++ b/docs/snippets/generated/stripe/PreBuiltUseCases.mdx
@@ -1,3 +1,3 @@
 _No pre-built syncs or actions available yet._
 
-<Tip>Not seeing the integration you need? [Build your own](https://nango.dev/docs/guides/primitives/functions) independently.</Tip>
+<Tip>Not seeing the integration you need? [Build your own](/guides/primitives/functions) independently.</Tip>

--- a/docs/snippets/generated/supabase-mcp-project/PreBuiltUseCases.mdx
+++ b/docs/snippets/generated/supabase-mcp-project/PreBuiltUseCases.mdx
@@ -1,3 +1,3 @@
 _No pre-built syncs or actions available yet._
 
-<Tip>Not seeing the integration you need? [Build your own](https://nango.dev/docs/guides/primitives/functions) independently.</Tip>
+<Tip>Not seeing the integration you need? [Build your own](/guides/primitives/functions) independently.</Tip>

--- a/docs/snippets/generated/supabase-mcp/PreBuiltUseCases.mdx
+++ b/docs/snippets/generated/supabase-mcp/PreBuiltUseCases.mdx
@@ -1,3 +1,3 @@
 _No pre-built syncs or actions available yet._
 
-<Tip>Not seeing the integration you need? [Build your own](https://nango.dev/docs/guides/primitives/functions) independently.</Tip>
+<Tip>Not seeing the integration you need? [Build your own](/guides/primitives/functions) independently.</Tip>

--- a/docs/snippets/generated/supabase/PreBuiltUseCases.mdx
+++ b/docs/snippets/generated/supabase/PreBuiltUseCases.mdx
@@ -1,3 +1,3 @@
 _No pre-built syncs or actions available yet._
 
-<Tip>Not seeing the integration you need? [Build your own](https://nango.dev/docs/guides/primitives/functions) independently.</Tip>
+<Tip>Not seeing the integration you need? [Build your own](/guides/primitives/functions) independently.</Tip>

--- a/docs/snippets/generated/survey-monkey/PreBuiltUseCases.mdx
+++ b/docs/snippets/generated/survey-monkey/PreBuiltUseCases.mdx
@@ -1,3 +1,3 @@
 _No pre-built syncs or actions available yet._
 
-<Tip>Not seeing the integration you need? [Build your own](https://nango.dev/docs/guides/primitives/functions) independently.</Tip>
+<Tip>Not seeing the integration you need? [Build your own](/guides/primitives/functions) independently.</Tip>

--- a/docs/snippets/generated/tableau/PreBuiltUseCases.mdx
+++ b/docs/snippets/generated/tableau/PreBuiltUseCases.mdx
@@ -1,3 +1,3 @@
 _No pre-built syncs or actions available yet._
 
-<Tip>Not seeing the integration you need? [Build your own](https://nango.dev/docs/guides/primitives/functions) independently.</Tip>
+<Tip>Not seeing the integration you need? [Build your own](/guides/primitives/functions) independently.</Tip>

--- a/docs/snippets/generated/tailscale-api-key/PreBuiltUseCases.mdx
+++ b/docs/snippets/generated/tailscale-api-key/PreBuiltUseCases.mdx
@@ -1,3 +1,3 @@
 _No pre-built syncs or actions available yet._
 
-<Tip>Not seeing the integration you need? [Build your own](https://nango.dev/docs/guides/primitives/functions) independently.</Tip>
+<Tip>Not seeing the integration you need? [Build your own](/guides/primitives/functions) independently.</Tip>

--- a/docs/snippets/generated/tailscale/PreBuiltUseCases.mdx
+++ b/docs/snippets/generated/tailscale/PreBuiltUseCases.mdx
@@ -1,3 +1,3 @@
 _No pre-built syncs or actions available yet._
 
-<Tip>Not seeing the integration you need? [Build your own](https://nango.dev/docs/guides/primitives/functions) independently.</Tip>
+<Tip>Not seeing the integration you need? [Build your own](/guides/primitives/functions) independently.</Tip>

--- a/docs/snippets/generated/tally/PreBuiltUseCases.mdx
+++ b/docs/snippets/generated/tally/PreBuiltUseCases.mdx
@@ -1,3 +1,3 @@
 _No pre-built syncs or actions available yet._
 
-<Tip>Not seeing the integration you need? [Build your own](https://nango.dev/docs/guides/primitives/functions) independently.</Tip>
+<Tip>Not seeing the integration you need? [Build your own](/guides/primitives/functions) independently.</Tip>

--- a/docs/snippets/generated/tapclicks/PreBuiltUseCases.mdx
+++ b/docs/snippets/generated/tapclicks/PreBuiltUseCases.mdx
@@ -1,3 +1,3 @@
 _No pre-built syncs or actions available yet._
 
-<Tip>Not seeing the integration you need? [Build your own](https://nango.dev/docs/guides/primitives/functions) independently.</Tip>
+<Tip>Not seeing the integration you need? [Build your own](/guides/primitives/functions) independently.</Tip>

--- a/docs/snippets/generated/teamleader/PreBuiltUseCases.mdx
+++ b/docs/snippets/generated/teamleader/PreBuiltUseCases.mdx
@@ -1,3 +1,3 @@
 _No pre-built syncs or actions available yet._
 
-<Tip>Not seeing the integration you need? [Build your own](https://nango.dev/docs/guides/primitives/functions) independently.</Tip>
+<Tip>Not seeing the integration you need? [Build your own](/guides/primitives/functions) independently.</Tip>

--- a/docs/snippets/generated/teamwork/PreBuiltUseCases.mdx
+++ b/docs/snippets/generated/teamwork/PreBuiltUseCases.mdx
@@ -1,3 +1,3 @@
 _No pre-built syncs or actions available yet._
 
-<Tip>Not seeing the integration you need? [Build your own](https://nango.dev/docs/guides/primitives/functions) independently.</Tip>
+<Tip>Not seeing the integration you need? [Build your own](/guides/primitives/functions) independently.</Tip>

--- a/docs/snippets/generated/telegram/PreBuiltUseCases.mdx
+++ b/docs/snippets/generated/telegram/PreBuiltUseCases.mdx
@@ -1,3 +1,3 @@
 _No pre-built syncs or actions available yet._
 
-<Tip>Not seeing the integration you need? [Build your own](https://nango.dev/docs/guides/primitives/functions) independently.</Tip>
+<Tip>Not seeing the integration you need? [Build your own](/guides/primitives/functions) independently.</Tip>

--- a/docs/snippets/generated/terraform/PreBuiltUseCases.mdx
+++ b/docs/snippets/generated/terraform/PreBuiltUseCases.mdx
@@ -1,3 +1,3 @@
 _No pre-built syncs or actions available yet._
 
-<Tip>Not seeing the integration you need? [Build your own](https://nango.dev/docs/guides/primitives/functions) independently.</Tip>
+<Tip>Not seeing the integration you need? [Build your own](/guides/primitives/functions) independently.</Tip>

--- a/docs/snippets/generated/thrivecart-api-key/PreBuiltUseCases.mdx
+++ b/docs/snippets/generated/thrivecart-api-key/PreBuiltUseCases.mdx
@@ -1,3 +1,3 @@
 _No pre-built syncs or actions available yet._
 
-<Tip>Not seeing the integration you need? [Build your own](https://nango.dev/docs/guides/primitives/functions) independently.</Tip>
+<Tip>Not seeing the integration you need? [Build your own](/guides/primitives/functions) independently.</Tip>

--- a/docs/snippets/generated/thrivecart-oauth/PreBuiltUseCases.mdx
+++ b/docs/snippets/generated/thrivecart-oauth/PreBuiltUseCases.mdx
@@ -1,3 +1,3 @@
 _No pre-built syncs or actions available yet._
 
-<Tip>Not seeing the integration you need? [Build your own](https://nango.dev/docs/guides/primitives/functions) independently.</Tip>
+<Tip>Not seeing the integration you need? [Build your own](/guides/primitives/functions) independently.</Tip>

--- a/docs/snippets/generated/ticktick/PreBuiltUseCases.mdx
+++ b/docs/snippets/generated/ticktick/PreBuiltUseCases.mdx
@@ -1,3 +1,3 @@
 _No pre-built syncs or actions available yet._
 
-<Tip>Not seeing the integration you need? [Build your own](https://nango.dev/docs/guides/primitives/functions) independently.</Tip>
+<Tip>Not seeing the integration you need? [Build your own](/guides/primitives/functions) independently.</Tip>

--- a/docs/snippets/generated/tiktok-accounts/PreBuiltUseCases.mdx
+++ b/docs/snippets/generated/tiktok-accounts/PreBuiltUseCases.mdx
@@ -1,3 +1,3 @@
 _No pre-built syncs or actions available yet._
 
-<Tip>Not seeing the integration you need? [Build your own](https://nango.dev/docs/guides/primitives/functions) independently.</Tip>
+<Tip>Not seeing the integration you need? [Build your own](/guides/primitives/functions) independently.</Tip>

--- a/docs/snippets/generated/tiktok-ads/PreBuiltUseCases.mdx
+++ b/docs/snippets/generated/tiktok-ads/PreBuiltUseCases.mdx
@@ -1,3 +1,3 @@
 _No pre-built syncs or actions available yet._
 
-<Tip>Not seeing the integration you need? [Build your own](https://nango.dev/docs/guides/primitives/functions) independently.</Tip>
+<Tip>Not seeing the integration you need? [Build your own](/guides/primitives/functions) independently.</Tip>

--- a/docs/snippets/generated/tiktok-personal/PreBuiltUseCases.mdx
+++ b/docs/snippets/generated/tiktok-personal/PreBuiltUseCases.mdx
@@ -1,3 +1,3 @@
 _No pre-built syncs or actions available yet._
 
-<Tip>Not seeing the integration you need? [Build your own](https://nango.dev/docs/guides/primitives/functions) independently.</Tip>
+<Tip>Not seeing the integration you need? [Build your own](/guides/primitives/functions) independently.</Tip>

--- a/docs/snippets/generated/tiktok/PreBuiltUseCases.mdx
+++ b/docs/snippets/generated/tiktok/PreBuiltUseCases.mdx
@@ -1,3 +1,3 @@
 _No pre-built syncs or actions available yet._
 
-<Tip>Not seeing the integration you need? [Build your own](https://nango.dev/docs/guides/primitives/functions) independently.</Tip>
+<Tip>Not seeing the integration you need? [Build your own](/guides/primitives/functions) independently.</Tip>

--- a/docs/snippets/generated/timely/PreBuiltUseCases.mdx
+++ b/docs/snippets/generated/timely/PreBuiltUseCases.mdx
@@ -1,3 +1,3 @@
 _No pre-built syncs or actions available yet._
 
-<Tip>Not seeing the integration you need? [Build your own](https://nango.dev/docs/guides/primitives/functions) independently.</Tip>
+<Tip>Not seeing the integration you need? [Build your own](/guides/primitives/functions) independently.</Tip>

--- a/docs/snippets/generated/timify/PreBuiltUseCases.mdx
+++ b/docs/snippets/generated/timify/PreBuiltUseCases.mdx
@@ -1,3 +1,3 @@
 _No pre-built syncs or actions available yet._
 
-<Tip>Not seeing the integration you need? [Build your own](https://nango.dev/docs/guides/primitives/functions) independently.</Tip>
+<Tip>Not seeing the integration you need? [Build your own](/guides/primitives/functions) independently.</Tip>

--- a/docs/snippets/generated/tldv/PreBuiltUseCases.mdx
+++ b/docs/snippets/generated/tldv/PreBuiltUseCases.mdx
@@ -1,3 +1,3 @@
 _No pre-built syncs or actions available yet._
 
-<Tip>Not seeing the integration you need? [Build your own](https://nango.dev/docs/guides/primitives/functions) independently.</Tip>
+<Tip>Not seeing the integration you need? [Build your own](/guides/primitives/functions) independently.</Tip>

--- a/docs/snippets/generated/todoist/PreBuiltUseCases.mdx
+++ b/docs/snippets/generated/todoist/PreBuiltUseCases.mdx
@@ -1,3 +1,3 @@
 _No pre-built syncs or actions available yet._
 
-<Tip>Not seeing the integration you need? [Build your own](https://nango.dev/docs/guides/primitives/functions) independently.</Tip>
+<Tip>Not seeing the integration you need? [Build your own](/guides/primitives/functions) independently.</Tip>

--- a/docs/snippets/generated/torii/PreBuiltUseCases.mdx
+++ b/docs/snippets/generated/torii/PreBuiltUseCases.mdx
@@ -1,3 +1,3 @@
 _No pre-built syncs or actions available yet._
 
-<Tip>Not seeing the integration you need? [Build your own](https://nango.dev/docs/guides/primitives/functions) independently.</Tip>
+<Tip>Not seeing the integration you need? [Build your own](/guides/primitives/functions) independently.</Tip>

--- a/docs/snippets/generated/totango/PreBuiltUseCases.mdx
+++ b/docs/snippets/generated/totango/PreBuiltUseCases.mdx
@@ -1,3 +1,3 @@
 _No pre-built syncs or actions available yet._
 
-<Tip>Not seeing the integration you need? [Build your own](https://nango.dev/docs/guides/primitives/functions) independently.</Tip>
+<Tip>Not seeing the integration you need? [Build your own](/guides/primitives/functions) independently.</Tip>

--- a/docs/snippets/generated/trafft/PreBuiltUseCases.mdx
+++ b/docs/snippets/generated/trafft/PreBuiltUseCases.mdx
@@ -1,3 +1,3 @@
 _No pre-built syncs or actions available yet._
 
-<Tip>Not seeing the integration you need? [Build your own](https://nango.dev/docs/guides/primitives/functions) independently.</Tip>
+<Tip>Not seeing the integration you need? [Build your own](/guides/primitives/functions) independently.</Tip>

--- a/docs/snippets/generated/trakstar-hire/PreBuiltUseCases.mdx
+++ b/docs/snippets/generated/trakstar-hire/PreBuiltUseCases.mdx
@@ -1,3 +1,3 @@
 _No pre-built syncs or actions available yet._
 
-<Tip>Not seeing the integration you need? [Build your own](https://nango.dev/docs/guides/primitives/functions) independently.</Tip>
+<Tip>Not seeing the integration you need? [Build your own](/guides/primitives/functions) independently.</Tip>

--- a/docs/snippets/generated/trello-scim/PreBuiltUseCases.mdx
+++ b/docs/snippets/generated/trello-scim/PreBuiltUseCases.mdx
@@ -1,3 +1,3 @@
 _No pre-built syncs or actions available yet._
 
-<Tip>Not seeing the integration you need? [Build your own](https://nango.dev/docs/guides/primitives/functions) independently.</Tip>
+<Tip>Not seeing the integration you need? [Build your own](/guides/primitives/functions) independently.</Tip>

--- a/docs/snippets/generated/trello/PreBuiltUseCases.mdx
+++ b/docs/snippets/generated/trello/PreBuiltUseCases.mdx
@@ -1,3 +1,3 @@
 _No pre-built syncs or actions available yet._
 
-<Tip>Not seeing the integration you need? [Build your own](https://nango.dev/docs/guides/primitives/functions) independently.</Tip>
+<Tip>Not seeing the integration you need? [Build your own](/guides/primitives/functions) independently.</Tip>

--- a/docs/snippets/generated/tremendous-sandbox/PreBuiltUseCases.mdx
+++ b/docs/snippets/generated/tremendous-sandbox/PreBuiltUseCases.mdx
@@ -1,3 +1,3 @@
 _No pre-built syncs or actions available yet._
 
-<Tip>Not seeing the integration you need? [Build your own](https://nango.dev/docs/guides/primitives/functions) independently.</Tip>
+<Tip>Not seeing the integration you need? [Build your own](/guides/primitives/functions) independently.</Tip>

--- a/docs/snippets/generated/tremendous/PreBuiltUseCases.mdx
+++ b/docs/snippets/generated/tremendous/PreBuiltUseCases.mdx
@@ -1,3 +1,3 @@
 _No pre-built syncs or actions available yet._
 
-<Tip>Not seeing the integration you need? [Build your own](https://nango.dev/docs/guides/primitives/functions) independently.</Tip>
+<Tip>Not seeing the integration you need? [Build your own](/guides/primitives/functions) independently.</Tip>

--- a/docs/snippets/generated/trigify-io-mcp/PreBuiltUseCases.mdx
+++ b/docs/snippets/generated/trigify-io-mcp/PreBuiltUseCases.mdx
@@ -1,3 +1,3 @@
 _No pre-built syncs or actions available yet._
 
-<Tip>Not seeing the integration you need? [Build your own](https://nango.dev/docs/guides/primitives/functions) independently.</Tip>
+<Tip>Not seeing the integration you need? [Build your own](/guides/primitives/functions) independently.</Tip>

--- a/docs/snippets/generated/triple-whale/PreBuiltUseCases.mdx
+++ b/docs/snippets/generated/triple-whale/PreBuiltUseCases.mdx
@@ -1,3 +1,3 @@
 _No pre-built syncs or actions available yet._
 
-<Tip>Not seeing the integration you need? [Build your own](https://nango.dev/docs/guides/primitives/functions) independently.</Tip>
+<Tip>Not seeing the integration you need? [Build your own](/guides/primitives/functions) independently.</Tip>

--- a/docs/snippets/generated/tsheetsteam/PreBuiltUseCases.mdx
+++ b/docs/snippets/generated/tsheetsteam/PreBuiltUseCases.mdx
@@ -1,3 +1,3 @@
 _No pre-built syncs or actions available yet._
 
-<Tip>Not seeing the integration you need? [Build your own](https://nango.dev/docs/guides/primitives/functions) independently.</Tip>
+<Tip>Not seeing the integration you need? [Build your own](/guides/primitives/functions) independently.</Tip>

--- a/docs/snippets/generated/tumblr/PreBuiltUseCases.mdx
+++ b/docs/snippets/generated/tumblr/PreBuiltUseCases.mdx
@@ -1,3 +1,3 @@
 _No pre-built syncs or actions available yet._
 
-<Tip>Not seeing the integration you need? [Build your own](https://nango.dev/docs/guides/primitives/functions) independently.</Tip>
+<Tip>Not seeing the integration you need? [Build your own](/guides/primitives/functions) independently.</Tip>

--- a/docs/snippets/generated/twenty-crm-self-hosted/PreBuiltUseCases.mdx
+++ b/docs/snippets/generated/twenty-crm-self-hosted/PreBuiltUseCases.mdx
@@ -1,3 +1,3 @@
 _No pre-built syncs or actions available yet._
 
-<Tip>Not seeing the integration you need? [Build your own](https://nango.dev/docs/guides/primitives/functions) independently.</Tip>
+<Tip>Not seeing the integration you need? [Build your own](/guides/primitives/functions) independently.</Tip>

--- a/docs/snippets/generated/twenty-crm/PreBuiltUseCases.mdx
+++ b/docs/snippets/generated/twenty-crm/PreBuiltUseCases.mdx
@@ -1,3 +1,3 @@
 _No pre-built syncs or actions available yet._
 
-<Tip>Not seeing the integration you need? [Build your own](https://nango.dev/docs/guides/primitives/functions) independently.</Tip>
+<Tip>Not seeing the integration you need? [Build your own](/guides/primitives/functions) independently.</Tip>

--- a/docs/snippets/generated/twilio/PreBuiltUseCases.mdx
+++ b/docs/snippets/generated/twilio/PreBuiltUseCases.mdx
@@ -1,3 +1,3 @@
 _No pre-built syncs or actions available yet._
 
-<Tip>Not seeing the integration you need? [Build your own](https://nango.dev/docs/guides/primitives/functions) independently.</Tip>
+<Tip>Not seeing the integration you need? [Build your own](/guides/primitives/functions) independently.</Tip>

--- a/docs/snippets/generated/twinfield/PreBuiltUseCases.mdx
+++ b/docs/snippets/generated/twinfield/PreBuiltUseCases.mdx
@@ -1,3 +1,3 @@
 _No pre-built syncs or actions available yet._
 
-<Tip>Not seeing the integration you need? [Build your own](https://nango.dev/docs/guides/primitives/functions) independently.</Tip>
+<Tip>Not seeing the integration you need? [Build your own](/guides/primitives/functions) independently.</Tip>

--- a/docs/snippets/generated/twitch/PreBuiltUseCases.mdx
+++ b/docs/snippets/generated/twitch/PreBuiltUseCases.mdx
@@ -1,3 +1,3 @@
 _No pre-built syncs or actions available yet._
 
-<Tip>Not seeing the integration you need? [Build your own](https://nango.dev/docs/guides/primitives/functions) independently.</Tip>
+<Tip>Not seeing the integration you need? [Build your own](/guides/primitives/functions) independently.</Tip>

--- a/docs/snippets/generated/twitter-oauth2-cc/PreBuiltUseCases.mdx
+++ b/docs/snippets/generated/twitter-oauth2-cc/PreBuiltUseCases.mdx
@@ -1,3 +1,3 @@
 _No pre-built syncs or actions available yet._
 
-<Tip>Not seeing the integration you need? [Build your own](https://nango.dev/docs/guides/primitives/functions) independently.</Tip>
+<Tip>Not seeing the integration you need? [Build your own](/guides/primitives/functions) independently.</Tip>

--- a/docs/snippets/generated/twitter-v2/PreBuiltUseCases.mdx
+++ b/docs/snippets/generated/twitter-v2/PreBuiltUseCases.mdx
@@ -1,3 +1,3 @@
 _No pre-built syncs or actions available yet._
 
-<Tip>Not seeing the integration you need? [Build your own](https://nango.dev/docs/guides/primitives/functions) independently.</Tip>
+<Tip>Not seeing the integration you need? [Build your own](/guides/primitives/functions) independently.</Tip>

--- a/docs/snippets/generated/twitter/PreBuiltUseCases.mdx
+++ b/docs/snippets/generated/twitter/PreBuiltUseCases.mdx
@@ -1,3 +1,3 @@
 _No pre-built syncs or actions available yet._
 
-<Tip>Not seeing the integration you need? [Build your own](https://nango.dev/docs/guides/primitives/functions) independently.</Tip>
+<Tip>Not seeing the integration you need? [Build your own](/guides/primitives/functions) independently.</Tip>

--- a/docs/snippets/generated/typeform/PreBuiltUseCases.mdx
+++ b/docs/snippets/generated/typeform/PreBuiltUseCases.mdx
@@ -1,3 +1,3 @@
 _No pre-built syncs or actions available yet._
 
-<Tip>Not seeing the integration you need? [Build your own](https://nango.dev/docs/guides/primitives/functions) independently.</Tip>
+<Tip>Not seeing the integration you need? [Build your own](/guides/primitives/functions) independently.</Tip>

--- a/docs/snippets/generated/typefully-v2/PreBuiltUseCases.mdx
+++ b/docs/snippets/generated/typefully-v2/PreBuiltUseCases.mdx
@@ -1,3 +1,3 @@
 _No pre-built syncs or actions available yet._
 
-<Tip>Not seeing the integration you need? [Build your own](https://nango.dev/docs/guides/primitives/functions) independently.</Tip>
+<Tip>Not seeing the integration you need? [Build your own](/guides/primitives/functions) independently.</Tip>

--- a/docs/snippets/generated/typefully/PreBuiltUseCases.mdx
+++ b/docs/snippets/generated/typefully/PreBuiltUseCases.mdx
@@ -1,3 +1,3 @@
 _No pre-built syncs or actions available yet._
 
-<Tip>Not seeing the integration you need? [Build your own](https://nango.dev/docs/guides/primitives/functions) independently.</Tip>
+<Tip>Not seeing the integration you need? [Build your own](/guides/primitives/functions) independently.</Tip>

--- a/docs/snippets/generated/uber/PreBuiltUseCases.mdx
+++ b/docs/snippets/generated/uber/PreBuiltUseCases.mdx
@@ -1,3 +1,3 @@
 _No pre-built syncs or actions available yet._
 
-<Tip>Not seeing the integration you need? [Build your own](https://nango.dev/docs/guides/primitives/functions) independently.</Tip>
+<Tip>Not seeing the integration you need? [Build your own](/guides/primitives/functions) independently.</Tip>

--- a/docs/snippets/generated/ukg-pro-cc/PreBuiltUseCases.mdx
+++ b/docs/snippets/generated/ukg-pro-cc/PreBuiltUseCases.mdx
@@ -1,3 +1,3 @@
 _No pre-built syncs or actions available yet._
 
-<Tip>Not seeing the integration you need? [Build your own](https://nango.dev/docs/guides/primitives/functions) independently.</Tip>
+<Tip>Not seeing the integration you need? [Build your own](/guides/primitives/functions) independently.</Tip>

--- a/docs/snippets/generated/ukg-pro-wfm/PreBuiltUseCases.mdx
+++ b/docs/snippets/generated/ukg-pro-wfm/PreBuiltUseCases.mdx
@@ -1,3 +1,3 @@
 _No pre-built syncs or actions available yet._
 
-<Tip>Not seeing the integration you need? [Build your own](https://nango.dev/docs/guides/primitives/functions) independently.</Tip>
+<Tip>Not seeing the integration you need? [Build your own](/guides/primitives/functions) independently.</Tip>

--- a/docs/snippets/generated/unauthenticated/PreBuiltUseCases.mdx
+++ b/docs/snippets/generated/unauthenticated/PreBuiltUseCases.mdx
@@ -1,3 +1,3 @@
 _No pre-built syncs or actions available yet._
 
-<Tip>Not seeing the integration you need? [Build your own](https://nango.dev/docs/guides/primitives/functions) independently.</Tip>
+<Tip>Not seeing the integration you need? [Build your own](/guides/primitives/functions) independently.</Tip>

--- a/docs/snippets/generated/unipile/PreBuiltUseCases.mdx
+++ b/docs/snippets/generated/unipile/PreBuiltUseCases.mdx
@@ -1,3 +1,3 @@
 _No pre-built syncs or actions available yet._
 
-<Tip>Not seeing the integration you need? [Build your own](https://nango.dev/docs/guides/primitives/functions) independently.</Tip>
+<Tip>Not seeing the integration you need? [Build your own](/guides/primitives/functions) independently.</Tip>

--- a/docs/snippets/generated/upsales/PreBuiltUseCases.mdx
+++ b/docs/snippets/generated/upsales/PreBuiltUseCases.mdx
@@ -1,3 +1,3 @@
 _No pre-built syncs or actions available yet._
 
-<Tip>Not seeing the integration you need? [Build your own](https://nango.dev/docs/guides/primitives/functions) independently.</Tip>
+<Tip>Not seeing the integration you need? [Build your own](/guides/primitives/functions) independently.</Tip>

--- a/docs/snippets/generated/valley-api-key/PreBuiltUseCases.mdx
+++ b/docs/snippets/generated/valley-api-key/PreBuiltUseCases.mdx
@@ -1,3 +1,3 @@
 _No pre-built syncs or actions available yet._
 
-<Tip>Not seeing the integration you need? [Build your own](https://nango.dev/docs/guides/primitives/functions) independently.</Tip>
+<Tip>Not seeing the integration you need? [Build your own](/guides/primitives/functions) independently.</Tip>

--- a/docs/snippets/generated/valley/PreBuiltUseCases.mdx
+++ b/docs/snippets/generated/valley/PreBuiltUseCases.mdx
@@ -1,3 +1,3 @@
 _No pre-built syncs or actions available yet._
 
-<Tip>Not seeing the integration you need? [Build your own](https://nango.dev/docs/guides/primitives/functions) independently.</Tip>
+<Tip>Not seeing the integration you need? [Build your own](/guides/primitives/functions) independently.</Tip>

--- a/docs/snippets/generated/vanta/PreBuiltUseCases.mdx
+++ b/docs/snippets/generated/vanta/PreBuiltUseCases.mdx
@@ -1,3 +1,3 @@
 _No pre-built syncs or actions available yet._
 
-<Tip>Not seeing the integration you need? [Build your own](https://nango.dev/docs/guides/primitives/functions) independently.</Tip>
+<Tip>Not seeing the integration you need? [Build your own](/guides/primitives/functions) independently.</Tip>

--- a/docs/snippets/generated/veeva-vault/PreBuiltUseCases.mdx
+++ b/docs/snippets/generated/veeva-vault/PreBuiltUseCases.mdx
@@ -1,3 +1,3 @@
 _No pre-built syncs or actions available yet._
 
-<Tip>Not seeing the integration you need? [Build your own](https://nango.dev/docs/guides/primitives/functions) independently.</Tip>
+<Tip>Not seeing the integration you need? [Build your own](/guides/primitives/functions) independently.</Tip>

--- a/docs/snippets/generated/vercel/PreBuiltUseCases.mdx
+++ b/docs/snippets/generated/vercel/PreBuiltUseCases.mdx
@@ -1,3 +1,3 @@
 _No pre-built syncs or actions available yet._
 
-<Tip>Not seeing the integration you need? [Build your own](https://nango.dev/docs/guides/primitives/functions) independently.</Tip>
+<Tip>Not seeing the integration you need? [Build your own](/guides/primitives/functions) independently.</Tip>

--- a/docs/snippets/generated/vimeo-basic/PreBuiltUseCases.mdx
+++ b/docs/snippets/generated/vimeo-basic/PreBuiltUseCases.mdx
@@ -1,3 +1,3 @@
 _No pre-built syncs or actions available yet._
 
-<Tip>Not seeing the integration you need? [Build your own](https://nango.dev/docs/guides/primitives/functions) independently.</Tip>
+<Tip>Not seeing the integration you need? [Build your own](/guides/primitives/functions) independently.</Tip>

--- a/docs/snippets/generated/vimeo/PreBuiltUseCases.mdx
+++ b/docs/snippets/generated/vimeo/PreBuiltUseCases.mdx
@@ -1,3 +1,3 @@
 _No pre-built syncs or actions available yet._
 
-<Tip>Not seeing the integration you need? [Build your own](https://nango.dev/docs/guides/primitives/functions) independently.</Tip>
+<Tip>Not seeing the integration you need? [Build your own](/guides/primitives/functions) independently.</Tip>

--- a/docs/snippets/generated/wakatime/PreBuiltUseCases.mdx
+++ b/docs/snippets/generated/wakatime/PreBuiltUseCases.mdx
@@ -1,3 +1,3 @@
 _No pre-built syncs or actions available yet._
 
-<Tip>Not seeing the integration you need? [Build your own](https://nango.dev/docs/guides/primitives/functions) independently.</Tip>
+<Tip>Not seeing the integration you need? [Build your own](/guides/primitives/functions) independently.</Tip>

--- a/docs/snippets/generated/wave-accounting/PreBuiltUseCases.mdx
+++ b/docs/snippets/generated/wave-accounting/PreBuiltUseCases.mdx
@@ -1,3 +1,3 @@
 _No pre-built syncs or actions available yet._
 
-<Tip>Not seeing the integration you need? [Build your own](https://nango.dev/docs/guides/primitives/functions) independently.</Tip>
+<Tip>Not seeing the integration you need? [Build your own](/guides/primitives/functions) independently.</Tip>

--- a/docs/snippets/generated/wealthbox/PreBuiltUseCases.mdx
+++ b/docs/snippets/generated/wealthbox/PreBuiltUseCases.mdx
@@ -1,3 +1,3 @@
 _No pre-built syncs or actions available yet._
 
-<Tip>Not seeing the integration you need? [Build your own](https://nango.dev/docs/guides/primitives/functions) independently.</Tip>
+<Tip>Not seeing the integration you need? [Build your own](/guides/primitives/functions) independently.</Tip>

--- a/docs/snippets/generated/webex/PreBuiltUseCases.mdx
+++ b/docs/snippets/generated/webex/PreBuiltUseCases.mdx
@@ -1,3 +1,3 @@
 _No pre-built syncs or actions available yet._
 
-<Tip>Not seeing the integration you need? [Build your own](https://nango.dev/docs/guides/primitives/functions) independently.</Tip>
+<Tip>Not seeing the integration you need? [Build your own](/guides/primitives/functions) independently.</Tip>

--- a/docs/snippets/generated/webflow/PreBuiltUseCases.mdx
+++ b/docs/snippets/generated/webflow/PreBuiltUseCases.mdx
@@ -1,3 +1,3 @@
 _No pre-built syncs or actions available yet._
 
-<Tip>Not seeing the integration you need? [Build your own](https://nango.dev/docs/guides/primitives/functions) independently.</Tip>
+<Tip>Not seeing the integration you need? [Build your own](/guides/primitives/functions) independently.</Tip>

--- a/docs/snippets/generated/webinarjam/PreBuiltUseCases.mdx
+++ b/docs/snippets/generated/webinarjam/PreBuiltUseCases.mdx
@@ -1,3 +1,3 @@
 _No pre-built syncs or actions available yet._
 
-<Tip>Not seeing the integration you need? [Build your own](https://nango.dev/docs/guides/primitives/functions) independently.</Tip>
+<Tip>Not seeing the integration you need? [Build your own](/guides/primitives/functions) independently.</Tip>

--- a/docs/snippets/generated/whatsapp-business/PreBuiltUseCases.mdx
+++ b/docs/snippets/generated/whatsapp-business/PreBuiltUseCases.mdx
@@ -1,3 +1,3 @@
 _No pre-built syncs or actions available yet._
 
-<Tip>Not seeing the integration you need? [Build your own](https://nango.dev/docs/guides/primitives/functions) independently.</Tip>
+<Tip>Not seeing the integration you need? [Build your own](/guides/primitives/functions) independently.</Tip>

--- a/docs/snippets/generated/whoop/PreBuiltUseCases.mdx
+++ b/docs/snippets/generated/whoop/PreBuiltUseCases.mdx
@@ -1,3 +1,3 @@
 _No pre-built syncs or actions available yet._
 
-<Tip>Not seeing the integration you need? [Build your own](https://nango.dev/docs/guides/primitives/functions) independently.</Tip>
+<Tip>Not seeing the integration you need? [Build your own](/guides/primitives/functions) independently.</Tip>

--- a/docs/snippets/generated/wise-api-key/PreBuiltUseCases.mdx
+++ b/docs/snippets/generated/wise-api-key/PreBuiltUseCases.mdx
@@ -1,3 +1,3 @@
 _No pre-built syncs or actions available yet._
 
-<Tip>Not seeing the integration you need? [Build your own](https://nango.dev/docs/guides/primitives/functions) independently.</Tip>
+<Tip>Not seeing the integration you need? [Build your own](/guides/primitives/functions) independently.</Tip>

--- a/docs/snippets/generated/wiseagent/PreBuiltUseCases.mdx
+++ b/docs/snippets/generated/wiseagent/PreBuiltUseCases.mdx
@@ -1,3 +1,3 @@
 _No pre-built syncs or actions available yet._
 
-<Tip>Not seeing the integration you need? [Build your own](https://nango.dev/docs/guides/primitives/functions) independently.</Tip>
+<Tip>Not seeing the integration you need? [Build your own](/guides/primitives/functions) independently.</Tip>

--- a/docs/snippets/generated/wiza/PreBuiltUseCases.mdx
+++ b/docs/snippets/generated/wiza/PreBuiltUseCases.mdx
@@ -1,3 +1,3 @@
 _No pre-built syncs or actions available yet._
 
-<Tip>Not seeing the integration you need? [Build your own](https://nango.dev/docs/guides/primitives/functions) independently.</Tip>
+<Tip>Not seeing the integration you need? [Build your own](/guides/primitives/functions) independently.</Tip>

--- a/docs/snippets/generated/wordpress/PreBuiltUseCases.mdx
+++ b/docs/snippets/generated/wordpress/PreBuiltUseCases.mdx
@@ -1,3 +1,3 @@
 _No pre-built syncs or actions available yet._
 
-<Tip>Not seeing the integration you need? [Build your own](https://nango.dev/docs/guides/primitives/functions) independently.</Tip>
+<Tip>Not seeing the integration you need? [Build your own](/guides/primitives/functions) independently.</Tip>

--- a/docs/snippets/generated/workable-oauth/PreBuiltUseCases.mdx
+++ b/docs/snippets/generated/workable-oauth/PreBuiltUseCases.mdx
@@ -1,3 +1,3 @@
 _No pre-built syncs or actions available yet._
 
-<Tip>Not seeing the integration you need? [Build your own](https://nango.dev/docs/guides/primitives/functions) independently.</Tip>
+<Tip>Not seeing the integration you need? [Build your own](/guides/primitives/functions) independently.</Tip>

--- a/docs/snippets/generated/workday-oauth/PreBuiltUseCases.mdx
+++ b/docs/snippets/generated/workday-oauth/PreBuiltUseCases.mdx
@@ -1,3 +1,3 @@
 _No pre-built syncs or actions available yet._
 
-<Tip>Not seeing the integration you need? [Build your own](https://nango.dev/docs/guides/primitives/functions) independently.</Tip>
+<Tip>Not seeing the integration you need? [Build your own](/guides/primitives/functions) independently.</Tip>

--- a/docs/snippets/generated/workday-refresh-token/PreBuiltUseCases.mdx
+++ b/docs/snippets/generated/workday-refresh-token/PreBuiltUseCases.mdx
@@ -1,3 +1,3 @@
 _No pre-built syncs or actions available yet._
 
-<Tip>Not seeing the integration you need? [Build your own](https://nango.dev/docs/guides/primitives/functions) independently.</Tip>
+<Tip>Not seeing the integration you need? [Build your own](/guides/primitives/functions) independently.</Tip>

--- a/docs/snippets/generated/workos/PreBuiltUseCases.mdx
+++ b/docs/snippets/generated/workos/PreBuiltUseCases.mdx
@@ -1,3 +1,3 @@
 _No pre-built syncs or actions available yet._
 
-<Tip>Not seeing the integration you need? [Build your own](https://nango.dev/docs/guides/primitives/functions) independently.</Tip>
+<Tip>Not seeing the integration you need? [Build your own](/guides/primitives/functions) independently.</Tip>

--- a/docs/snippets/generated/wrike/PreBuiltUseCases.mdx
+++ b/docs/snippets/generated/wrike/PreBuiltUseCases.mdx
@@ -1,3 +1,3 @@
 _No pre-built syncs or actions available yet._
 
-<Tip>Not seeing the integration you need? [Build your own](https://nango.dev/docs/guides/primitives/functions) independently.</Tip>
+<Tip>Not seeing the integration you need? [Build your own](/guides/primitives/functions) independently.</Tip>

--- a/docs/snippets/generated/xai/PreBuiltUseCases.mdx
+++ b/docs/snippets/generated/xai/PreBuiltUseCases.mdx
@@ -1,3 +1,3 @@
 _No pre-built syncs or actions available yet._
 
-<Tip>Not seeing the integration you need? [Build your own](https://nango.dev/docs/guides/primitives/functions) independently.</Tip>
+<Tip>Not seeing the integration you need? [Build your own](/guides/primitives/functions) independently.</Tip>

--- a/docs/snippets/generated/xero-oauth2-cc/PreBuiltUseCases.mdx
+++ b/docs/snippets/generated/xero-oauth2-cc/PreBuiltUseCases.mdx
@@ -1,3 +1,3 @@
 _No pre-built syncs or actions available yet._
 
-<Tip>Not seeing the integration you need? [Build your own](https://nango.dev/docs/guides/primitives/functions) independently.</Tip>
+<Tip>Not seeing the integration you need? [Build your own](/guides/primitives/functions) independently.</Tip>

--- a/docs/snippets/generated/yahoo/PreBuiltUseCases.mdx
+++ b/docs/snippets/generated/yahoo/PreBuiltUseCases.mdx
@@ -1,3 +1,3 @@
 _No pre-built syncs or actions available yet._
 
-<Tip>Not seeing the integration you need? [Build your own](https://nango.dev/docs/guides/primitives/functions) independently.</Tip>
+<Tip>Not seeing the integration you need? [Build your own](/guides/primitives/functions) independently.</Tip>

--- a/docs/snippets/generated/yandex/PreBuiltUseCases.mdx
+++ b/docs/snippets/generated/yandex/PreBuiltUseCases.mdx
@@ -1,3 +1,3 @@
 _No pre-built syncs or actions available yet._
 
-<Tip>Not seeing the integration you need? [Build your own](https://nango.dev/docs/guides/primitives/functions) independently.</Tip>
+<Tip>Not seeing the integration you need? [Build your own](/guides/primitives/functions) independently.</Tip>

--- a/docs/snippets/generated/yotpo/PreBuiltUseCases.mdx
+++ b/docs/snippets/generated/yotpo/PreBuiltUseCases.mdx
@@ -1,3 +1,3 @@
 _No pre-built syncs or actions available yet._
 
-<Tip>Not seeing the integration you need? [Build your own](https://nango.dev/docs/guides/primitives/functions) independently.</Tip>
+<Tip>Not seeing the integration you need? [Build your own](/guides/primitives/functions) independently.</Tip>

--- a/docs/snippets/generated/youtube/PreBuiltUseCases.mdx
+++ b/docs/snippets/generated/youtube/PreBuiltUseCases.mdx
@@ -1,3 +1,3 @@
 _No pre-built syncs or actions available yet._
 
-<Tip>Not seeing the integration you need? [Build your own](https://nango.dev/docs/guides/primitives/functions) independently.</Tip>
+<Tip>Not seeing the integration you need? [Build your own](/guides/primitives/functions) independently.</Tip>

--- a/docs/snippets/generated/zapier-nla/PreBuiltUseCases.mdx
+++ b/docs/snippets/generated/zapier-nla/PreBuiltUseCases.mdx
@@ -1,3 +1,3 @@
 _No pre-built syncs or actions available yet._
 
-<Tip>Not seeing the integration you need? [Build your own](https://nango.dev/docs/guides/primitives/functions) independently.</Tip>
+<Tip>Not seeing the integration you need? [Build your own](/guides/primitives/functions) independently.</Tip>

--- a/docs/snippets/generated/zapier-scim/PreBuiltUseCases.mdx
+++ b/docs/snippets/generated/zapier-scim/PreBuiltUseCases.mdx
@@ -1,3 +1,3 @@
 _No pre-built syncs or actions available yet._
 
-<Tip>Not seeing the integration you need? [Build your own](https://nango.dev/docs/guides/primitives/functions) independently.</Tip>
+<Tip>Not seeing the integration you need? [Build your own](/guides/primitives/functions) independently.</Tip>

--- a/docs/snippets/generated/zapier/PreBuiltUseCases.mdx
+++ b/docs/snippets/generated/zapier/PreBuiltUseCases.mdx
@@ -1,3 +1,3 @@
 _No pre-built syncs or actions available yet._
 
-<Tip>Not seeing the integration you need? [Build your own](https://nango.dev/docs/guides/primitives/functions) independently.</Tip>
+<Tip>Not seeing the integration you need? [Build your own](/guides/primitives/functions) independently.</Tip>

--- a/docs/snippets/generated/zendesk-sell/PreBuiltUseCases.mdx
+++ b/docs/snippets/generated/zendesk-sell/PreBuiltUseCases.mdx
@@ -1,3 +1,3 @@
 _No pre-built syncs or actions available yet._
 
-<Tip>Not seeing the integration you need? [Build your own](https://nango.dev/docs/guides/primitives/functions) independently.</Tip>
+<Tip>Not seeing the integration you need? [Build your own](/guides/primitives/functions) independently.</Tip>

--- a/docs/snippets/generated/zenefits/PreBuiltUseCases.mdx
+++ b/docs/snippets/generated/zenefits/PreBuiltUseCases.mdx
@@ -1,3 +1,3 @@
 _No pre-built syncs or actions available yet._
 
-<Tip>Not seeing the integration you need? [Build your own](https://nango.dev/docs/guides/primitives/functions) independently.</Tip>
+<Tip>Not seeing the integration you need? [Build your own](/guides/primitives/functions) independently.</Tip>

--- a/docs/snippets/generated/zoho-bigin/PreBuiltUseCases.mdx
+++ b/docs/snippets/generated/zoho-bigin/PreBuiltUseCases.mdx
@@ -1,3 +1,3 @@
 _No pre-built syncs or actions available yet._
 
-<Tip>Not seeing the integration you need? [Build your own](https://nango.dev/docs/guides/primitives/functions) independently.</Tip>
+<Tip>Not seeing the integration you need? [Build your own](/guides/primitives/functions) independently.</Tip>

--- a/docs/snippets/generated/zoho-books/PreBuiltUseCases.mdx
+++ b/docs/snippets/generated/zoho-books/PreBuiltUseCases.mdx
@@ -1,3 +1,3 @@
 _No pre-built syncs or actions available yet._
 
-<Tip>Not seeing the integration you need? [Build your own](https://nango.dev/docs/guides/primitives/functions) independently.</Tip>
+<Tip>Not seeing the integration you need? [Build your own](/guides/primitives/functions) independently.</Tip>

--- a/docs/snippets/generated/zoho-calendar/PreBuiltUseCases.mdx
+++ b/docs/snippets/generated/zoho-calendar/PreBuiltUseCases.mdx
@@ -1,3 +1,3 @@
 _No pre-built syncs or actions available yet._
 
-<Tip>Not seeing the integration you need? [Build your own](https://nango.dev/docs/guides/primitives/functions) independently.</Tip>
+<Tip>Not seeing the integration you need? [Build your own](/guides/primitives/functions) independently.</Tip>

--- a/docs/snippets/generated/zoho-desk/PreBuiltUseCases.mdx
+++ b/docs/snippets/generated/zoho-desk/PreBuiltUseCases.mdx
@@ -1,3 +1,3 @@
 _No pre-built syncs or actions available yet._
 
-<Tip>Not seeing the integration you need? [Build your own](https://nango.dev/docs/guides/primitives/functions) independently.</Tip>
+<Tip>Not seeing the integration you need? [Build your own](/guides/primitives/functions) independently.</Tip>

--- a/docs/snippets/generated/zoho-inventory/PreBuiltUseCases.mdx
+++ b/docs/snippets/generated/zoho-inventory/PreBuiltUseCases.mdx
@@ -1,3 +1,3 @@
 _No pre-built syncs or actions available yet._
 
-<Tip>Not seeing the integration you need? [Build your own](https://nango.dev/docs/guides/primitives/functions) independently.</Tip>
+<Tip>Not seeing the integration you need? [Build your own](/guides/primitives/functions) independently.</Tip>

--- a/docs/snippets/generated/zoho-invoice/PreBuiltUseCases.mdx
+++ b/docs/snippets/generated/zoho-invoice/PreBuiltUseCases.mdx
@@ -1,3 +1,3 @@
 _No pre-built syncs or actions available yet._
 
-<Tip>Not seeing the integration you need? [Build your own](https://nango.dev/docs/guides/primitives/functions) independently.</Tip>
+<Tip>Not seeing the integration you need? [Build your own](/guides/primitives/functions) independently.</Tip>

--- a/docs/snippets/generated/zoho-people/PreBuiltUseCases.mdx
+++ b/docs/snippets/generated/zoho-people/PreBuiltUseCases.mdx
@@ -1,3 +1,3 @@
 _No pre-built syncs or actions available yet._
 
-<Tip>Not seeing the integration you need? [Build your own](https://nango.dev/docs/guides/primitives/functions) independently.</Tip>
+<Tip>Not seeing the integration you need? [Build your own](/guides/primitives/functions) independently.</Tip>

--- a/docs/snippets/generated/zoho-recruit/PreBuiltUseCases.mdx
+++ b/docs/snippets/generated/zoho-recruit/PreBuiltUseCases.mdx
@@ -1,3 +1,3 @@
 _No pre-built syncs or actions available yet._
 
-<Tip>Not seeing the integration you need? [Build your own](https://nango.dev/docs/guides/primitives/functions) independently.</Tip>
+<Tip>Not seeing the integration you need? [Build your own](/guides/primitives/functions) independently.</Tip>

--- a/docs/snippets/generated/zoho/PreBuiltUseCases.mdx
+++ b/docs/snippets/generated/zoho/PreBuiltUseCases.mdx
@@ -1,3 +1,3 @@
 _No pre-built syncs or actions available yet._
 
-<Tip>Not seeing the integration you need? [Build your own](https://nango.dev/docs/guides/primitives/functions) independently.</Tip>
+<Tip>Not seeing the integration you need? [Build your own](/guides/primitives/functions) independently.</Tip>

--- a/docs/snippets/generated/zoominfo/PreBuiltUseCases.mdx
+++ b/docs/snippets/generated/zoominfo/PreBuiltUseCases.mdx
@@ -1,3 +1,3 @@
 _No pre-built syncs or actions available yet._
 
-<Tip>Not seeing the integration you need? [Build your own](https://nango.dev/docs/guides/primitives/functions) independently.</Tip>
+<Tip>Not seeing the integration you need? [Build your own](/guides/primitives/functions) independently.</Tip>

--- a/docs/snippets/generated/zuora/PreBuiltUseCases.mdx
+++ b/docs/snippets/generated/zuora/PreBuiltUseCases.mdx
@@ -1,3 +1,3 @@
 _No pre-built syncs or actions available yet._
 
-<Tip>Not seeing the integration you need? [Build your own](https://nango.dev/docs/guides/primitives/functions) independently.</Tip>
+<Tip>Not seeing the integration you need? [Build your own](/guides/primitives/functions) independently.</Tip>

--- a/docs/updates/dev.mdx
+++ b/docs/updates/dev.mdx
@@ -354,5 +354,5 @@ description: "Updates and breaking changes for developers."
 
   ### 💡 What should I do?
 
-  - Follow migration guide -\> https://nango.dev/docs/guides/custom-integrations/migrate-to-zero-yaml
+  - Follow migration guide -\> /guides/custom-integrations/migrate-to-zero-yaml
 </Update>

--- a/docs/updates/product.mdx
+++ b/docs/updates/product.mdx
@@ -175,7 +175,7 @@ description: "Product updates and improvements."
 
   This auth mode bypasses the interactive OAuth consent screen, which enterprise customers often prefer for easier onboarding and stronger governance.
 
-  See the [Salesforce JWT documentation](https://nango.dev/docs/api-integrations/salesforce-jwt) for the setup guide and implementation snippets.
+  See the [Salesforce JWT documentation](/api-integrations/salesforce-jwt) for the setup guide and implementation snippets.
 
   ## Shareable Connect UI links
 
@@ -400,7 +400,7 @@ description: "Product updates and improvements."
   </AccordionGroup>
   ## CLI interactive mode
 
-  The Nango CLI now supports an [interactive mode](https://nango.dev/docs/reference/cli#interactive-mode) that prompts for missing arguments. For example, run `nango create` without specifying the function type, integration, or name, and the CLI will ask for them. Interactive mode is on by default in interactive terminal sessions.
+  The Nango CLI now supports an [interactive mode](/reference/cli#interactive-mode) that prompts for missing arguments. For example, run `nango create` without specifying the function type, integration, or name, and the CLI will ask for them. Interactive mode is on by default in interactive terminal sessions.
 
   ![Nango_CLI_interactive_mode](/images/changelog/nango-cli-interactive-mode.png)
 
@@ -889,8 +889,8 @@ description: "Product updates and improvements."
 
   What’s new:
 
-  - [**Introspection endpoint**](https://nango.dev/docs/reference/api/scripts/config): List available actions programmatically, exportable as OpenAI tools
-  - [**Action trigger endpoint**](https://nango.dev/docs/reference/api/action/trigger): Run actions reliably via the API
+  - [**Introspection endpoint**](/reference/api/scripts/config): List available actions programmatically, exportable as OpenAI tools
+  - [**Action trigger endpoint**](/reference/api/action/trigger): Run actions reliably via the API
   - [**Integrated authorization**](/guides/primitives/auth): Use Nango’s pre-built UI to securely prompt users for access
 
   This makes it easier to build AI agents that can reliably interact with 700+ APIs.

--- a/scripts/docs-gen-snippets.ts
+++ b/scripts/docs-gen-snippets.ts
@@ -200,7 +200,7 @@ ${endpoints
 function emptyUseCases() {
     return `_No pre-built syncs or actions available yet._
 
-<Tip>Not seeing the integration you need? [Build your own](https://nango.dev/docs/guides/primitives/functions) independently.</Tip>`;
+<Tip>Not seeing the integration you need? [Build your own](/guides/primitives/functions) independently.</Tip>`;
 }
 
 interface Endpoint {


### PR DESCRIPTION
## Describe the problem and your solution

- replace full links with relative links in docs

<!-- Issue ticket number and link (if applicable) -->

<!-- Testing instructions (skip if just adding/editing providers) -->


<!-- Summary by @propel-code-bot -->

---

**Convert documentation links from absolute to relative paths**

This PR updates documentation to use root-relative links instead of absolute `https://nango.dev/...` URLs across generated snippets, integration guides, implementation guides, and update pages. It also adjusts the snippet generation script to emit relative links for empty use-case tips, ensuring future generated content follows the same pattern.

Overall, the change standardizes internal linking throughout the docs and reduces dependence on a fixed domain, while requiring validation that the docs site base path supports root-relative links.

---
*This summary was automatically generated by @propel-code-bot*