### PR TITLE
feat(webapp): migrate environment requests to tanstack query

### DIFF
--- a/packages/webapp/src/components-v2/AppSidebar/CreateEnvironmentDialog.tsx
+++ b/packages/webapp/src/components-v2/AppSidebar/CreateEnvironmentDialog.tsx
@@ -1,6 +1,5 @@
 import { zodResolver } from '@hookform/resolvers/zod';
 import { Loader } from 'lucide-react';
-import { useState } from 'react';
 import { useForm } from 'react-hook-form';
 import { useNavigate } from 'react-router-dom';
 import z from 'zod';
@@ -9,9 +8,9 @@ import { Button } from '../ui/button';
 import { Dialog, DialogClose, DialogContent, DialogFooter, DialogHeader, DialogTitle } from '../ui/dialog';
 import { Form, FormControl, FormDescription, FormField, FormItem, FormMessage } from '../ui/form';
 import { Input } from '../ui/input';
-import { apiPostEnvironment } from '@/hooks/useEnvironment';
-import { useMeta } from '@/hooks/useMeta';
+import { usePostEnvironment } from '@/hooks/useEnvironment';
 import { useToast } from '@/hooks/useToast';
+import { APIError } from '@/utils/api';
 
 interface CreateEnvironmentDialogProps {
     open: boolean;
@@ -37,31 +36,28 @@ export const CreateEnvironmentDialog: React.FC<CreateEnvironmentDialogProps> = (
 
     const { toast } = useToast();
     const navigate = useNavigate();
-    const { refetch: refetchMeta } = useMeta();
-
-    const [loading, setLoading] = useState(false);
+    const { mutateAsync: postEnvironmentAsync, isPending } = usePostEnvironment();
 
     async function onSubmit(data: EnvironmentForm) {
-        setLoading(true);
-
-        const res = await apiPostEnvironment({ name: data.name });
-        if ('error' in res.json) {
-            const err = res.json.error;
-            if (err.code === 'invalid_body') {
-                form.setError('name', { message: 'Invalid environment name' });
-            } else if (['conflict', 'feature_disabled', 'resource_capped'].includes(err.code)) {
-                toast({ title: err.message, variant: 'error' });
+        try {
+            const res = await postEnvironmentAsync({ name: data.name });
+            navigate(`/${res.data.name}`);
+            onOpenChange(false);
+            form.reset();
+        } catch (err) {
+            if (err instanceof APIError && 'error' in err.json) {
+                const apiErr = err.json.error;
+                if (apiErr.code === 'invalid_body') {
+                    form.setError('name', { message: 'Invalid environment name' });
+                } else if (['conflict', 'feature_disabled', 'resource_capped'].includes(apiErr.code)) {
+                    toast({ title: apiErr.message, variant: 'error' });
+                } else {
+                    toast({ title: 'Failed to create environment', variant: 'error' });
+                }
             } else {
                 toast({ title: 'Failed to create environment', variant: 'error' });
             }
-        } else {
-            navigate(`/${res.json.data.name}`);
-            onOpenChange(false);
-            form.reset();
-            void refetchMeta();
         }
-
-        setLoading(false);
     }
 
     return (
@@ -89,8 +85,8 @@ export const CreateEnvironmentDialog: React.FC<CreateEnvironmentDialogProps> = (
                             <DialogClose asChild>
                                 <Button variant="secondary">Cancel</Button>
                             </DialogClose>
-                            <Button variant="primary" type="submit" disabled={loading}>
-                                {loading && <Loader className="animate-spin h-full w-full" />}
+                            <Button variant="primary" type="submit" disabled={isPending}>
+                                {isPending && <Loader className="animate-spin h-full w-full" />}
                                 Create Environment
                             </Button>
                         </DialogFooter>

--- a/packages/webapp/src/components-v2/AppSidebar/EnvironmentDropdown.tsx
+++ b/packages/webapp/src/components-v2/AppSidebar/EnvironmentDropdown.tsx
@@ -17,7 +17,8 @@ export const EnvironmentDropdown: React.FC = () => {
     const env = useStore((state) => state.env);
     const setEnv = useStore((state) => state.setEnv);
     const envs = useStore((state) => state.envs);
-    const environment = useEnvironment(env);
+    const { data: environmentData } = useEnvironment(env);
+    const environment = { plan: environmentData?.plan };
     const { data: metaData } = useMeta();
     const meta = metaData?.data;
     const [environmentDialogOpen, setEnvironmentDialogOpen] = useState(false);

--- a/packages/webapp/src/components-v2/AppSidebar/index.tsx
+++ b/packages/webapp/src/components-v2/AppSidebar/index.tsx
@@ -36,7 +36,8 @@ export const AppSidebar: React.FC = () => {
     const { data: metaData, refetch: refetchMeta } = useMeta();
     const meta = metaData?.data;
     const showGettingStarted = useStore((state) => state.showGettingStarted);
-    const { plan } = useEnvironment(env);
+    const { data: environmentData } = useEnvironment(env);
+    const plan = environmentData?.plan;
 
     const items = useMemo<SidebarItem[]>(() => {
         const gettingStarted = {

--- a/packages/webapp/src/components/PrivateRoute.tsx
+++ b/packages/webapp/src/components/PrivateRoute.tsx
@@ -21,7 +21,8 @@ export const PrivateRoute: React.FC = () => {
     const setBaseUrl = useStore((state) => state.setBaseUrl);
     const setDebugMode = useStore((state) => state.setDebugMode);
     const setEnv = useStore((state) => state.setEnv);
-    const { environmentAndAccount } = useEnvironment(env);
+    const { data: environmentData } = useEnvironment(env);
+    const environmentAndAccount = environmentData?.environmentAndAccount;
 
     useEffect(() => {
         if (!meta || metaError) {

--- a/packages/webapp/src/hooks/useEnvironment.tsx
+++ b/packages/webapp/src/hooks/useEnvironment.tsx
@@ -112,6 +112,66 @@ export function usePostEnvironment() {
     });
 }
 
+export function useRotateKey(env: string) {
+    const queryClient = useQueryClient();
+    return useMutation<undefined, APIError>({
+        mutationFn: async () => {
+            const res = await apiFetch(`/api/v1/environment/rotate-key?env=${env}`, {
+                method: 'POST',
+                body: JSON.stringify({ type: 'secret' })
+            });
+
+            if (!res.ok) {
+                const json = (await res.json()) as Record<string, unknown>;
+                throw new APIError({ res, json });
+            }
+        },
+        onSuccess: async () => {
+            await queryClient.invalidateQueries({ queryKey: environmentQueryKey(env) });
+        }
+    });
+}
+
+export function useRevertKey(env: string) {
+    const queryClient = useQueryClient();
+    return useMutation<undefined, APIError>({
+        mutationFn: async () => {
+            const res = await apiFetch(`/api/v1/environment/revert-key?env=${env}`, {
+                method: 'POST',
+                body: JSON.stringify({ type: 'secret' })
+            });
+
+            if (!res.ok) {
+                const json = (await res.json()) as Record<string, unknown>;
+                throw new APIError({ res, json });
+            }
+        },
+        onSuccess: async () => {
+            await queryClient.invalidateQueries({ queryKey: environmentQueryKey(env) });
+        }
+    });
+}
+
+export function useActivateKey(env: string) {
+    const queryClient = useQueryClient();
+    return useMutation<undefined, APIError>({
+        mutationFn: async () => {
+            const res = await apiFetch(`/api/v1/environment/activate-key?env=${env}`, {
+                method: 'POST',
+                body: JSON.stringify({ type: 'secret' })
+            });
+
+            if (!res.ok) {
+                const json = (await res.json()) as Record<string, unknown>;
+                throw new APIError({ res, json });
+            }
+        },
+        onSuccess: async () => {
+            await queryClient.invalidateQueries({ queryKey: environmentQueryKey(env) });
+        }
+    });
+}
+
 export function useDeleteEnvironment(env: string) {
     const queryClient = useQueryClient();
     return useMutation<undefined, APIError>({

--- a/packages/webapp/src/hooks/useEnvironment.tsx
+++ b/packages/webapp/src/hooks/useEnvironment.tsx
@@ -1,77 +1,132 @@
-import useSWR from 'swr';
+import { useMutation, useQuery, useQueryClient } from '@tanstack/react-query';
 
-import { apiFetch, swrFetcher } from '../utils/api';
+import { metaQueryKey } from './useMeta';
+import { APIError, apiFetch } from '../utils/api';
 
 import type { GetEnvironment, PatchEnvironment, PatchWebhook, PostEnvironment, PostEnvironmentVariables } from '@nangohq/types';
 
+export const environmentQueryKey = (env: string) => [env, 'environment'] as const;
+
 export function useEnvironment(env: string) {
-    const { data, error, mutate } = useSWR<GetEnvironment['Success'], GetEnvironment['Errors']>(`/api/v1/environments/current?env=${env}`, swrFetcher);
+    return useQuery<GetEnvironment['Success'], APIError>({
+        enabled: Boolean(env),
+        queryKey: environmentQueryKey(env),
+        queryFn: async (): Promise<GetEnvironment['Success']> => {
+            const res = await apiFetch(`/api/v1/environments/current?env=${env}`);
 
-    const loading = !data && !error;
+            const json = (await res.json()) as GetEnvironment['Reply'];
+            if (!res.ok || 'error' in json) {
+                throw new APIError({ res, json });
+            }
 
-    return {
-        loading,
-        error,
-        environmentAndAccount: data?.environmentAndAccount,
-        plan: data?.plan,
-        mutate
-    };
+            return json;
+        }
+    });
 }
 
-export async function apiPostEnvironment(body: PostEnvironment['Body']) {
-    const res = await apiFetch('/api/v1/environments', {
-        method: 'POST',
-        body: JSON.stringify(body)
-    });
+export function usePatchEnvironment(env: string) {
+    const queryClient = useQueryClient();
+    return useMutation<PatchEnvironment['Success'], APIError, PatchEnvironment['Body']>({
+        mutationFn: async (body) => {
+            const res = await apiFetch(`/api/v1/environments?env=${env}`, {
+                method: 'PATCH',
+                body: JSON.stringify(body)
+            });
 
-    return {
-        res,
-        json: (await res.json()) as PostEnvironment['Reply']
-    };
+            const json = (await res.json()) as PatchEnvironment['Reply'];
+            if (!res.ok || 'error' in json) {
+                throw new APIError({ res, json });
+            }
+
+            return json;
+        },
+        onSuccess: async () => {
+            await queryClient.invalidateQueries({ queryKey: environmentQueryKey(env) });
+        }
+    });
 }
 
-export async function apiPatchEnvironment(env: string, body: PatchEnvironment['Body']) {
-    const res = await apiFetch(`/api/v1/environments?env=${env}`, {
-        method: 'PATCH',
-        body: JSON.stringify(body)
-    });
+export function usePatchWebhook(env: string) {
+    const queryClient = useQueryClient();
+    return useMutation<PatchWebhook['Success'], APIError, PatchWebhook['Body']>({
+        mutationFn: async (body) => {
+            const res = await apiFetch(`/api/v1/environments/webhook?env=${env}`, {
+                method: 'PATCH',
+                body: JSON.stringify(body)
+            });
 
-    return {
-        res,
-        json: (await res.json()) as PatchEnvironment['Reply']
-    };
+            const json = (await res.json()) as PatchWebhook['Reply'];
+            if (!res.ok || 'error' in json) {
+                throw new APIError({ res, json });
+            }
+
+            return json;
+        },
+        onSuccess: async () => {
+            await queryClient.invalidateQueries({ queryKey: environmentQueryKey(env) });
+        }
+    });
 }
 
-export async function apiPatchWebhook(env: string, body: PatchWebhook['Body']) {
-    const res = await apiFetch(`/api/v1/environments/webhook?env=${env}`, {
-        method: 'PATCH',
-        body: JSON.stringify(body)
-    });
+export function usePostVariables(env: string) {
+    const queryClient = useQueryClient();
+    return useMutation<PostEnvironmentVariables['Success'], APIError, PostEnvironmentVariables['Body']>({
+        mutationFn: async (body) => {
+            const res = await apiFetch(`/api/v1/environments/variables?env=${env}`, {
+                method: 'POST',
+                body: JSON.stringify(body)
+            });
 
-    return {
-        res,
-        json: (await res.json()) as PostEnvironment['Reply']
-    };
+            const json = (await res.json()) as PostEnvironmentVariables['Reply'];
+            if (!res.ok || 'error' in json) {
+                throw new APIError({ res, json });
+            }
+
+            return json;
+        },
+        onSuccess: async () => {
+            await queryClient.invalidateQueries({ queryKey: environmentQueryKey(env) });
+        }
+    });
 }
 
-export async function apiPostVariables(env: string, body: PostEnvironmentVariables['Body']) {
-    const res = await apiFetch(`/api/v1/environments/variables?env=${env}`, {
-        method: 'POST',
-        body: JSON.stringify(body)
-    });
+export function usePostEnvironment() {
+    const queryClient = useQueryClient();
+    return useMutation<PostEnvironment['Success'], APIError, PostEnvironment['Body']>({
+        mutationFn: async (body) => {
+            const res = await apiFetch('/api/v1/environments', {
+                method: 'POST',
+                body: JSON.stringify(body)
+            });
 
-    return {
-        res,
-        json: (await res.json()) as PostEnvironmentVariables['Reply']
-    };
+            const json = (await res.json()) as PostEnvironment['Reply'];
+            if (!res.ok || 'error' in json) {
+                throw new APIError({ res, json });
+            }
+
+            return json;
+        },
+        onSuccess: async () => {
+            await queryClient.invalidateQueries({ queryKey: metaQueryKey });
+        }
+    });
 }
 
-export async function apiDeleteEnvironment(env: string) {
-    const res = await apiFetch(`/api/v1/environments?env=${env}`, {
-        method: 'DELETE'
-    });
+export function useDeleteEnvironment(env: string) {
+    const queryClient = useQueryClient();
+    return useMutation<undefined, APIError>({
+        mutationFn: async () => {
+            const res = await apiFetch(`/api/v1/environments?env=${env}`, {
+                method: 'DELETE'
+            });
 
-    return {
-        res
-    };
+            if (!res.ok) {
+                const json = (await res.json()) as Record<string, unknown>;
+                throw new APIError({ res, json });
+            }
+        },
+        onSuccess: async () => {
+            await queryClient.invalidateQueries({ queryKey: metaQueryKey });
+        }
+    });
 }

--- a/packages/webapp/src/pages/Connection/CreateLegacy.tsx
+++ b/packages/webapp/src/pages/Connection/CreateLegacy.tsx
@@ -68,7 +68,8 @@ export const ConnectionCreateLegacy: React.FC = () => {
     const analyticsTrack = useAnalyticsTrack();
     const getHmacAPI = useGetHmacAPI(env);
     const providerConfigKey = useSearchParam('providerConfigKey');
-    const { environmentAndAccount } = useEnvironment(env);
+    const { data } = useEnvironment(env);
+    const environmentAndAccount = data?.environmentAndAccount;
 
     useEffect(() => {
         setLoaded(false);

--- a/packages/webapp/src/pages/Connection/components/CreateConnectionSelector.tsx
+++ b/packages/webapp/src/pages/Connection/components/CreateConnectionSelector.tsx
@@ -64,7 +64,8 @@ export const CreateConnectionSelector: React.FC<CreateConnectionSelectorProps> =
     const analyticsTrack = useAnalyticsTrack();
 
     const env = useStore((state) => state.env);
-    const { environmentAndAccount } = useEnvironment(env);
+    const { data } = useEnvironment(env);
+    const environmentAndAccount = data?.environmentAndAccount;
     const { data: listIntegrationData, isLoading: listIntegrationPending } = useListIntegrations(env);
 
     const connectUI = useRef<ConnectUI>();

--- a/packages/webapp/src/pages/Environment/Settings/Backend.tsx
+++ b/packages/webapp/src/pages/Environment/Settings/Backend.tsx
@@ -1,5 +1,4 @@
 import { IconExternalLink, IconKey } from '@tabler/icons-react';
-import { useState } from 'react';
 import { Link } from 'react-router-dom';
 
 import { EditableInput } from './components/EditableInput';
@@ -7,10 +6,10 @@ import SettingsContent from './components/SettingsContent';
 import SettingsGroup from './components/SettingsGroup';
 import { Dialog, DialogClose, DialogContent, DialogDescription, DialogFooter, DialogTitle, DialogTrigger } from '../../../components/ui/Dialog';
 import SecretInput from '../../../components/ui/input/SecretInput';
-import { useEnvironment, usePatchEnvironment } from '../../../hooks/useEnvironment';
+import { useActivateKey, useEnvironment, usePatchEnvironment, useRevertKey, useRotateKey } from '../../../hooks/useEnvironment';
 import { useToast } from '../../../hooks/useToast';
 import { useStore } from '../../../store';
-import { APIError, apiFetch } from '../../../utils/api';
+import { APIError } from '../../../utils/api';
 import { StyledLink } from '@/components-v2/StyledLink';
 import { Alert, AlertDescription } from '@/components-v2/ui/alert';
 import { Button } from '@/components-v2/ui/button';
@@ -19,58 +18,35 @@ export const BackendSettings: React.FC = () => {
     const { toast } = useToast();
 
     const env = useStore((state) => state.env);
-    const { data, refetch } = useEnvironment(env);
+    const { data } = useEnvironment(env);
     const environmentAndAccount = data?.environmentAndAccount;
     const { mutateAsync: patchEnvironmentAsync } = usePatchEnvironment(env);
-
-    const [loading, setLoading] = useState(false);
+    const { mutateAsync: rotateKeyAsync, isPending: isRotating } = useRotateKey(env);
+    const { mutateAsync: revertKeyAsync, isPending: isReverting } = useRevertKey(env);
+    const { mutateAsync: activateKeyAsync, isPending: isActivating } = useActivateKey(env);
 
     const onGenerate = async () => {
-        setLoading(true);
-        const res = await apiFetch(`/api/v1/environment/rotate-key?env=${env}`, {
-            method: 'POST',
-            body: JSON.stringify({ type: 'secret' })
-        });
-        setLoading(false);
-
-        if (res.status !== 200) {
+        try {
+            await rotateKeyAsync();
+        } catch {
             toast({ title: `There was an issue when generating a new secret`, variant: 'error' });
-            return;
         }
-
-        void refetch();
     };
 
     const onRevert = async () => {
-        setLoading(true);
-        const res = await apiFetch(`/api/v1/environment/revert-key?env=${env}`, {
-            method: 'POST',
-            body: JSON.stringify({ type: 'secret' })
-        });
-        setLoading(false);
-
-        if (res.status !== 200) {
+        try {
+            await revertKeyAsync();
+        } catch {
             toast({ title: `There was an issue when reverting the secret`, variant: 'error' });
-            return;
         }
-
-        void refetch();
     };
 
     const onRotate = async () => {
-        setLoading(true);
-        const res = await apiFetch(`/api/v1/environment/activate-key?env=${env}`, {
-            method: 'POST',
-            body: JSON.stringify({ type: 'secret' })
-        });
-        setLoading(false);
-
-        if (res.status !== 200) {
+        try {
+            await activateKeyAsync();
+        } catch {
             toast({ title: `There was an issue when rotating the secret`, variant: 'error' });
-            return;
         }
-
-        void refetch();
     };
 
     if (!environmentAndAccount) {
@@ -101,7 +77,7 @@ export const BackendSettings: React.FC = () => {
                     </div>
                     {!hasNewSecretKey && (
                         <div className="flex justify-start">
-                            <Button variant={'secondary'} onClick={onGenerate} loading={loading}>
+                            <Button variant={'secondary'} onClick={onGenerate} loading={isRotating}>
                                 <>
                                     <IconKey stroke={1} size={18} />
                                     Generate new secret key
@@ -149,7 +125,7 @@ export const BackendSettings: React.FC = () => {
                                         <DialogClose asChild>
                                             <Button variant="tertiary">Dismiss</Button>
                                         </DialogClose>
-                                        <Button variant="destructive" onClick={onRevert} loading={loading}>
+                                        <Button variant="destructive" onClick={onRevert} loading={isReverting}>
                                             Cancel
                                         </Button>
                                     </DialogFooter>
@@ -170,7 +146,7 @@ export const BackendSettings: React.FC = () => {
                                         <DialogClose asChild>
                                             <Button variant={'tertiary'}>Dismiss</Button>
                                         </DialogClose>
-                                        <Button variant="destructive" onClick={onRotate} loading={loading}>
+                                        <Button variant="destructive" onClick={onRotate} loading={isActivating}>
                                             Confirm key rotation
                                         </Button>
                                     </DialogFooter>

--- a/packages/webapp/src/pages/Environment/Settings/Backend.tsx
+++ b/packages/webapp/src/pages/Environment/Settings/Backend.tsx
@@ -7,10 +7,10 @@ import SettingsContent from './components/SettingsContent';
 import SettingsGroup from './components/SettingsGroup';
 import { Dialog, DialogClose, DialogContent, DialogDescription, DialogFooter, DialogTitle, DialogTrigger } from '../../../components/ui/Dialog';
 import SecretInput from '../../../components/ui/input/SecretInput';
-import { apiPatchEnvironment, useEnvironment } from '../../../hooks/useEnvironment';
+import { useEnvironment, usePatchEnvironment } from '../../../hooks/useEnvironment';
 import { useToast } from '../../../hooks/useToast';
 import { useStore } from '../../../store';
-import { apiFetch } from '../../../utils/api';
+import { APIError, apiFetch } from '../../../utils/api';
 import { StyledLink } from '@/components-v2/StyledLink';
 import { Alert, AlertDescription } from '@/components-v2/ui/alert';
 import { Button } from '@/components-v2/ui/button';
@@ -19,7 +19,9 @@ export const BackendSettings: React.FC = () => {
     const { toast } = useToast();
 
     const env = useStore((state) => state.env);
-    const { environmentAndAccount, mutate } = useEnvironment(env);
+    const { data, refetch } = useEnvironment(env);
+    const environmentAndAccount = data?.environmentAndAccount;
+    const { mutateAsync: patchEnvironmentAsync } = usePatchEnvironment(env);
 
     const [loading, setLoading] = useState(false);
 
@@ -36,7 +38,7 @@ export const BackendSettings: React.FC = () => {
             return;
         }
 
-        void mutate();
+        void refetch();
     };
 
     const onRevert = async () => {
@@ -52,7 +54,7 @@ export const BackendSettings: React.FC = () => {
             return;
         }
 
-        void mutate();
+        void refetch();
     };
 
     const onRotate = async () => {
@@ -68,7 +70,7 @@ export const BackendSettings: React.FC = () => {
             return;
         }
 
-        void mutate();
+        void refetch();
     };
 
     if (!environmentAndAccount) {
@@ -216,8 +218,16 @@ export const BackendSettings: React.FC = () => {
                             </AlertDescription>
                         </Alert>
                     }
-                    apiCall={(value) => apiPatchEnvironment(env, { callback_url: value })}
-                    onSuccess={() => void mutate()}
+                    apiCall={async (value) => {
+                        try {
+                            const res = await patchEnvironmentAsync({ callback_url: value });
+                            return { json: res };
+                        } catch (err) {
+                            if (err instanceof APIError) return { json: err.json };
+                            throw err;
+                        }
+                    }}
+                    onSuccess={() => {}}
                 />
             </SettingsGroup>
         </SettingsContent>

--- a/packages/webapp/src/pages/Environment/Settings/ConnectUISettings/components/ConnectUIPreview.tsx
+++ b/packages/webapp/src/pages/Environment/Settings/ConnectUISettings/components/ConnectUIPreview.tsx
@@ -17,7 +17,8 @@ export interface ConnectUIPreviewRef {
 
 export const ConnectUIPreview = forwardRef<ConnectUIPreviewRef, { className?: string }>(({ className }, ref) => {
     const env = useStore((state) => state.env);
-    const { environmentAndAccount } = useEnvironment(env);
+    const { data } = useEnvironment(env);
+    const environmentAndAccount = data?.environmentAndAccount;
 
     const connectUIContainer = useRef<HTMLDivElement>(null);
     const connectUIIframe = useRef<HTMLIFrameElement>();

--- a/packages/webapp/src/pages/Environment/Settings/ConnectUISettings/index.tsx
+++ b/packages/webapp/src/pages/Environment/Settings/ConnectUISettings/index.tsx
@@ -112,15 +112,16 @@ const WatermarkToggle: React.FC<{ disabled: boolean; form: any }> = ({ disabled,
 export const ConnectUISettings = () => {
     const toast = useToast();
     const env = useStore((state) => state.env);
-    const environment = useEnvironment(env);
+    const { data: environmentData } = useEnvironment(env);
+    const plan = environmentData?.plan;
 
     const { data: connectUISettings } = useConnectUISettings(env);
     const { mutate: updateConnectUISettings, isPending: isUpdatingConnectUISettings } = useUpdateConnectUISettings(env);
     const connectUIPreviewRef = useRef<ConnectUIPreviewRef>(null);
 
-    const noPlanAvailable = !globalEnv.features.plan || !environment.plan;
-    const canCustomizeTheme = noPlanAvailable ? globalEnv.isHosted || globalEnv.isEnterprise : environment.plan!.can_customize_connect_ui_theme;
-    const canDisableWatermark = noPlanAvailable ? globalEnv.isHosted || globalEnv.isEnterprise : environment.plan!.can_disable_connect_ui_watermark;
+    const noPlanAvailable = !globalEnv.features.plan || !plan;
+    const canCustomizeTheme = noPlanAvailable ? globalEnv.isHosted || globalEnv.isEnterprise : (plan?.can_customize_connect_ui_theme ?? false);
+    const canDisableWatermark = noPlanAvailable ? globalEnv.isHosted || globalEnv.isEnterprise : (plan?.can_disable_connect_ui_watermark ?? false);
 
     const form = useForm({
         defaultValues: connectUISettings?.data,

--- a/packages/webapp/src/pages/Environment/Settings/Deprecated.tsx
+++ b/packages/webapp/src/pages/Environment/Settings/Deprecated.tsx
@@ -7,32 +7,31 @@ import SettingsContent from './components/SettingsContent';
 import SettingsGroup from './components/SettingsGroup';
 import Spinner from '../../../components/ui/Spinner';
 import SecretInput from '../../../components/ui/input/SecretInput';
-import { apiPatchEnvironment, useEnvironment } from '../../../hooks/useEnvironment';
+import { useEnvironment, usePatchEnvironment } from '../../../hooks/useEnvironment';
 import { useToast } from '../../../hooks/useToast';
 import { useStore } from '../../../store';
+import { APIError } from '../../../utils/api';
 import { Switch } from '@/components-v2/ui/switch';
 
 export const DeprecatedSettings: React.FC = () => {
     const { toast } = useToast();
 
     const env = useStore((state) => state.env);
-    const { environmentAndAccount, mutate } = useEnvironment(env);
+    const { data } = useEnvironment(env);
+    const environmentAndAccount = data?.environmentAndAccount;
+    const { mutateAsync: patchEnvironmentAsync } = usePatchEnvironment(env);
 
     const [loading, setLoading] = useState(false);
 
     const onHmacEnabled = async (isChecked: boolean) => {
         setLoading(true);
-        const res = await apiPatchEnvironment(env, {
-            hmac_enabled: isChecked
-        });
-        setLoading(false);
-
-        if ('error' in res.json) {
+        try {
+            await patchEnvironmentAsync({ hmac_enabled: isChecked });
+        } catch {
             toast({ title: 'There was an issue updating the HMAC', variant: 'error' });
-            return;
+        } finally {
+            setLoading(false);
         }
-
-        void mutate();
     };
 
     if (!environmentAndAccount) {
@@ -102,8 +101,16 @@ export const DeprecatedSettings: React.FC = () => {
                         subTitle
                         secret
                         originalValue={environmentAndAccount.environment.hmac_key || ''}
-                        apiCall={(value) => apiPatchEnvironment(env, { hmac_key: value })}
-                        onSuccess={() => void mutate()}
+                        apiCall={async (value) => {
+                            try {
+                                const res = await patchEnvironmentAsync({ hmac_key: value });
+                                return { json: res };
+                            } catch (err) {
+                                if (err instanceof APIError) return { json: err.json };
+                                throw err;
+                            }
+                        }}
+                        onSuccess={() => {}}
                     />
                 </div>
             </SettingsGroup>

--- a/packages/webapp/src/pages/Environment/Settings/Functions.tsx
+++ b/packages/webapp/src/pages/Environment/Settings/Functions.tsx
@@ -3,9 +3,10 @@ import { useState } from 'react';
 import { Link } from 'react-router-dom';
 
 import SettingsContent from './components/SettingsContent';
-import { apiPostVariables, useEnvironment } from '../../../hooks/useEnvironment';
+import { useEnvironment, usePostVariables } from '../../../hooks/useEnvironment';
 import { useToast } from '../../../hooks/useToast';
 import { useStore } from '../../../store';
+import { APIError } from '../../../utils/api';
 import { KeyValueInput } from '@/components-v2/KeyValueInput';
 import { Button } from '@/components-v2/ui/button';
 
@@ -14,10 +15,11 @@ import type { ApiEnvironmentVariable } from '@nangohq/types';
 export const Functions: React.FC = () => {
     const { toast } = useToast();
     const env = useStore((state) => state.env);
-    const { environmentAndAccount, mutate } = useEnvironment(env);
+    const { data } = useEnvironment(env);
+    const environmentAndAccount = data?.environmentAndAccount;
+    const { mutateAsync: postVariablesAsync, isPending } = usePostVariables(env);
 
     const [edit, setEdit] = useState(false);
-    const [loading, setLoading] = useState(false);
     const [vars, setVars] = useState<Record<string, string>>(() => {
         if (environmentAndAccount && environmentAndAccount.env_variables.length > 0) {
             return environmentAndAccount.env_variables.reduce<Record<string, string>>((acc, curr) => {
@@ -30,33 +32,24 @@ export const Functions: React.FC = () => {
     const [errors, setErrors] = useState<{ index: number; key: 'name' | 'value'; error: string }[]>([]);
 
     const onSave = async () => {
-        setLoading(true);
         const variables: ApiEnvironmentVariable[] = Object.entries(vars).map(([name, value]) => ({ name, value }));
-        const res = await apiPostVariables(env, {
-            variables
-        });
-
-        setLoading(false);
-
-        if ('error' in res.json) {
+        try {
+            await postVariablesAsync({ variables });
+            setEdit(false);
+            setErrors([]);
+        } catch (err) {
             toast({ title: 'There was an issue updating the environment variables', variant: 'error' });
-            if (res.json.error.code === 'invalid_body' && res.json.error.errors) {
+            if (err instanceof APIError && 'error' in err.json && err.json.error.code === 'invalid_body' && err.json.error.errors) {
                 setErrors(
-                    res.json.error.errors.map((err) => {
-                        if (err.path[0] !== 'variables') {
+                    err.json.error.errors.map((e: any) => {
+                        if (e.path[0] !== 'variables') {
                             return null as any;
                         }
-                        return { index: err.path[1], key: err.path[2], error: err.message };
+                        return { index: e.path[1], key: e.path[2], error: e.message };
                     })
                 );
             }
-            return;
         }
-
-        void mutate();
-
-        setEdit(false);
-        setErrors([]);
     };
 
     const onCancel = () => {
@@ -93,7 +86,7 @@ export const Functions: React.FC = () => {
                             onChange={setVars}
                             placeholderKey="MY_ENV_VAR"
                             placeholderValue="value"
-                            disabled={!edit || loading}
+                            disabled={!edit || isPending}
                             isSecret={true}
                             alwaysShowEmptyRow={edit}
                         />
@@ -118,7 +111,7 @@ export const Functions: React.FC = () => {
                                 <Button variant="tertiary" onClick={onCancel}>
                                     Cancel
                                 </Button>
-                                <Button variant="primary" onClick={onSave} disabled={loading}>
+                                <Button variant="primary" onClick={onSave} disabled={isPending}>
                                     Save
                                 </Button>
                             </>

--- a/packages/webapp/src/pages/Environment/Settings/General.tsx
+++ b/packages/webapp/src/pages/Environment/Settings/General.tsx
@@ -50,7 +50,7 @@ export const General: React.FC = () => {
                     apiCall={async (name) => {
                         try {
                             const res = await patchEnvironmentAsync({ name });
-                            return { json: res.data };
+                            return { json: res };
                         } catch (err) {
                             if (err instanceof APIError) {
                                 return { json: err.json };

--- a/packages/webapp/src/pages/Environment/Settings/General.tsx
+++ b/packages/webapp/src/pages/Environment/Settings/General.tsx
@@ -6,12 +6,13 @@ import { EditableInput } from './components/EditableInput';
 import SettingsContent from './components/SettingsContent';
 import SettingsGroup from './components/SettingsGroup';
 import { PROD_ENVIRONMENT_NAME } from '../../../constants';
-import { apiDeleteEnvironment, apiPatchEnvironment } from '../../../hooks/useEnvironment';
+import { useDeleteEnvironment, usePatchEnvironment } from '../../../hooks/useEnvironment';
 import { useMeta } from '../../../hooks/useMeta';
 import { useStore } from '../../../store';
 import { AlertDescription } from '@/components/ui/Alert';
 import { Alert } from '@/components-v2/ui/alert';
 import { useToast } from '@/hooks/useToast';
+import { APIError } from '@/utils/api';
 
 export const General: React.FC = () => {
     const navigate = useNavigate();
@@ -19,19 +20,20 @@ export const General: React.FC = () => {
     const env = useStore((state) => state.env);
     const setEnv = useStore((state) => state.setEnv);
     const { refetch: refetchMeta } = useMeta();
+    const { mutateAsync: patchEnvironmentAsync } = usePatchEnvironment(env);
+    const { mutateAsync: deleteEnvironmentAsync } = useDeleteEnvironment(env);
 
     const [showDeleteAlert, setShowDeleteAlert] = useState(false);
     const { toast } = useToast();
 
     const handleDelete = async () => {
-        const { res } = await apiDeleteEnvironment(env);
-        if (res.status >= 200 && res.status < 300) {
+        try {
+            await deleteEnvironmentAsync();
             setShowDeleteAlert(false);
-            // We have to start by changing the url, otherwise PrivateRoute will revert the env based on it.
             navigate(`/${PROD_ENVIRONMENT_NAME}/environment-settings`);
             await refetchMeta();
             setEnv(PROD_ENVIRONMENT_NAME);
-        } else {
+        } catch {
             toast({
                 title: 'Failed to delete environment',
                 variant: 'error'
@@ -45,7 +47,17 @@ export const General: React.FC = () => {
                 <EditableInput
                     name="environmentName"
                     originalValue={env}
-                    apiCall={(name) => apiPatchEnvironment(env, { name })}
+                    apiCall={async (name) => {
+                        try {
+                            const res = await patchEnvironmentAsync({ name });
+                            return { json: res.data };
+                        } catch (err) {
+                            if (err instanceof APIError) {
+                                return { json: err.json };
+                            }
+                            throw err;
+                        }
+                    }}
                     onSuccess={async (newName) => {
                         // We have to start by changing the url, otherwise PrivateRoute will revert the env based on it.
                         navigate(`/${newName}/environment-settings`);

--- a/packages/webapp/src/pages/Environment/Settings/Notifications.tsx
+++ b/packages/webapp/src/pages/Environment/Settings/Notifications.tsx
@@ -5,12 +5,15 @@ import { EditableInput } from './components/EditableInput';
 import SettingsContent from './components/SettingsContent';
 import SettingsGroup from './components/SettingsGroup';
 import { WebhookCheckboxes } from './components/WebhookCheckboxes';
-import { apiPatchWebhook, useEnvironment } from '../../../hooks/useEnvironment';
+import { useEnvironment, usePatchWebhook } from '../../../hooks/useEnvironment';
 import { useStore } from '../../../store';
+import { APIError } from '../../../utils/api';
 
 export const Notifications: React.FC = () => {
     const env = useStore((state) => state.env);
-    const { environmentAndAccount, mutate } = useEnvironment(env);
+    const { data } = useEnvironment(env);
+    const environmentAndAccount = data?.environmentAndAccount;
+    const { mutateAsync: patchWebhookAsync } = usePatchWebhook(env);
 
     if (!environmentAndAccount) {
         return null;
@@ -39,8 +42,16 @@ export const Notifications: React.FC = () => {
                         placeholder="https://example.com/webhooks_from_nango"
                         subTitle={true}
                         originalValue={environmentAndAccount.webhook_settings.primary_url || ''}
-                        apiCall={(value) => apiPatchWebhook(env, { primary_url: value })}
-                        onSuccess={() => void mutate()}
+                        apiCall={async (value) => {
+                            try {
+                                const res = await patchWebhookAsync({ primary_url: value });
+                                return { json: res };
+                            } catch (err) {
+                                if (err instanceof APIError) return { json: err.json };
+                                throw err;
+                            }
+                        }}
+                        onSuccess={() => {}}
                     />
                     <EditableInput
                         name="secondary_url"
@@ -48,15 +59,23 @@ export const Notifications: React.FC = () => {
                         placeholder="https://example.com/webhooks_from_nango"
                         subTitle={true}
                         originalValue={environmentAndAccount.webhook_settings.secondary_url || ''}
-                        apiCall={(value) => apiPatchWebhook(env, { secondary_url: value })}
-                        onSuccess={() => void mutate()}
+                        apiCall={async (value) => {
+                            try {
+                                const res = await patchWebhookAsync({ secondary_url: value });
+                                return { json: res };
+                            } catch (err) {
+                                if (err instanceof APIError) return { json: err.json };
+                                throw err;
+                            }
+                        }}
+                        onSuccess={() => {}}
                     />
                 </div>
             </SettingsGroup>
             <SettingsGroup label="Subscriptions">
                 <div className="flex flex-col gap-7">
                     <div>
-                        <WebhookCheckboxes env={env} checkboxState={environmentAndAccount.webhook_settings} mutate={mutate} />
+                        <WebhookCheckboxes env={env} checkboxState={environmentAndAccount.webhook_settings} />
                     </div>
                 </div>
             </SettingsGroup>

--- a/packages/webapp/src/pages/Environment/Settings/Show.tsx
+++ b/packages/webapp/src/pages/Environment/Settings/Show.tsx
@@ -31,7 +31,8 @@ export const EnvironmentSettings: React.FC = () => {
     const env = useStore((state) => state.env);
     const { team } = useTeam(env);
 
-    const { environmentAndAccount } = useEnvironment(env);
+    const { data } = useEnvironment(env);
+    const environmentAndAccount = data?.environmentAndAccount;
     const [activeTab, setActiveTab] = useHashNavigation('general');
 
     if (!environmentAndAccount || !team) {

--- a/packages/webapp/src/pages/Environment/Settings/SlackAlerts.tsx
+++ b/packages/webapp/src/pages/Environment/Settings/SlackAlerts.tsx
@@ -8,12 +8,14 @@ import { globalEnv } from '../../../utils/env';
 import { connectSlack } from '../../../utils/slack-connection';
 import { SlackIcon } from '@/assets/SlackIcon';
 import { Button } from '@/components-v2/ui/button';
-import { apiPatchEnvironment, useEnvironment } from '@/hooks/useEnvironment';
+import { useEnvironment, usePatchEnvironment } from '@/hooks/useEnvironment';
 import { useStore } from '@/store';
 
 export const SlackAlertsSettings: React.FC = () => {
     const env = useStore((state) => state.env);
-    const { environmentAndAccount, mutate } = useEnvironment(env);
+    const { data } = useEnvironment(env);
+    const { mutateAsync: patchEnvironmentAsync } = usePatchEnvironment(env);
+    const environmentAndAccount = data?.environmentAndAccount;
     const [slackIsConnecting, setSlackIsConnecting] = useState(false);
     const { toast } = useToast();
 
@@ -25,7 +27,6 @@ export const SlackAlertsSettings: React.FC = () => {
     const slackConnect = async () => {
         setSlackIsConnecting(true);
         const onFinish = () => {
-            void mutate();
             setSlackIsConnecting(false);
         };
 
@@ -52,13 +53,11 @@ export const SlackAlertsSettings: React.FC = () => {
             return;
         }
 
-        const resPatch = await apiPatchEnvironment(env, { slack_notifications: false });
-        if ('error' in resPatch.json) {
+        try {
+            await patchEnvironmentAsync({ slack_notifications: false });
+        } catch {
             toast({ title: 'There was a problem when disconnecting Slack', variant: 'error' });
-            return;
         }
-
-        void mutate();
     };
 
     return (

--- a/packages/webapp/src/pages/Environment/Settings/SlackAlerts.tsx
+++ b/packages/webapp/src/pages/Environment/Settings/SlackAlerts.tsx
@@ -13,7 +13,7 @@ import { useStore } from '@/store';
 
 export const SlackAlertsSettings: React.FC = () => {
     const env = useStore((state) => state.env);
-    const { data } = useEnvironment(env);
+    const { data, refetch: refetchEnvironment } = useEnvironment(env);
     const { mutateAsync: patchEnvironmentAsync } = usePatchEnvironment(env);
     const environmentAndAccount = data?.environmentAndAccount;
     const [slackIsConnecting, setSlackIsConnecting] = useState(false);
@@ -28,6 +28,7 @@ export const SlackAlertsSettings: React.FC = () => {
         setSlackIsConnecting(true);
         const onFinish = () => {
             setSlackIsConnecting(false);
+            void refetchEnvironment();
         };
 
         const onFailure = () => {

--- a/packages/webapp/src/pages/Environment/Settings/Telemetry.tsx
+++ b/packages/webapp/src/pages/Environment/Settings/Telemetry.tsx
@@ -7,16 +7,19 @@ import SettingsContent from './components/SettingsContent';
 import SettingsGroup from './components/SettingsGroup';
 import { Input } from '../../../components/ui/input/Input';
 import SecretInput from '../../../components/ui/input/SecretInput';
-import { apiPatchEnvironment, useEnvironment } from '../../../hooks/useEnvironment';
+import { useEnvironment, usePatchEnvironment } from '../../../hooks/useEnvironment';
 import { useToast } from '../../../hooks/useToast';
 import { useStore } from '../../../store';
+import { APIError } from '../../../utils/api';
 import { cn } from '../../../utils/utils';
 import { Button } from '@/components-v2/ui/button';
 
 export const Telemetry: React.FC = () => {
     const env = useStore((state) => state.env);
     const { toast } = useToast();
-    const { environmentAndAccount, mutate } = useEnvironment(env);
+    const { data } = useEnvironment(env);
+    const environmentAndAccount = data?.environmentAndAccount;
+    const { mutateAsync: patchEnvironmentAsync } = usePatchEnvironment(env);
 
     const [loading, setLoading] = useState(false);
     const [editHeaders, setEditHeaders] = useState(false);
@@ -48,31 +51,26 @@ export const Telemetry: React.FC = () => {
 
     const onSaveHeaders = async () => {
         setLoading(true);
-        const res = await apiPatchEnvironment(env, {
-            otlp_headers: headers.filter((v) => v.name !== '' || v.value !== '')
-        });
-        setLoading(false);
-
-        if ('error' in res.json) {
+        try {
+            await patchEnvironmentAsync({ otlp_headers: headers.filter((v) => v.name !== '' || v.value !== '') });
+            setEditHeaders(false);
+            setHeaders((prev) => (prev.length > 1 ? prev.filter((v) => v.name !== '' || v.value !== '') : prev));
+            setErrors([]);
+        } catch (err) {
             toast({ title: 'There was an issue updating the OTLP Headers', variant: 'error' });
-            if (res.json.error.code === 'invalid_body' && res.json.error.errors) {
+            if (err instanceof APIError && 'error' in err.json && err.json.error.code === 'invalid_body' && err.json.error.errors) {
                 setErrors(
-                    res.json.error.errors.map((err) => {
-                        if (err.path[0] !== 'otlp_headers') {
+                    err.json.error.errors.map((e: any) => {
+                        if (e.path[0] !== 'otlp_headers') {
                             return null as any;
                         }
-                        return { index: err.path[1], key: err.path[2], error: err.message };
+                        return { index: e.path[1], key: e.path[2], error: e.message };
                     })
                 );
             }
-            return;
+        } finally {
+            setLoading(false);
         }
-
-        void mutate();
-
-        setEditHeaders(false);
-        setHeaders((prev) => (prev.length > 1 ? prev.filter((v) => v.name !== '' || v.value !== '') : prev));
-        setErrors([]);
     };
 
     const onRemove = (index: number) => {
@@ -123,8 +121,16 @@ export const Telemetry: React.FC = () => {
                         title="Endpoint"
                         subTitle
                         originalValue={environmentAndAccount?.environment.otlp_settings?.endpoint || ''}
-                        apiCall={(value) => apiPatchEnvironment(env, { otlp_endpoint: value })}
-                        onSuccess={() => void mutate()}
+                        apiCall={async (value) => {
+                            try {
+                                const res = await patchEnvironmentAsync({ otlp_endpoint: value });
+                                return { json: res };
+                            } catch (err) {
+                                if (err instanceof APIError) return { json: err.json };
+                                throw err;
+                            }
+                        }}
+                        onSuccess={() => {}}
                         placeholder="https://my.otlp.commector:4318"
                     />
                     <fieldset className="flex flex-col gap-4">

--- a/packages/webapp/src/pages/Environment/Settings/components/WebhookCheckboxes.tsx
+++ b/packages/webapp/src/pages/Environment/Settings/components/WebhookCheckboxes.tsx
@@ -1,8 +1,8 @@
 import { useState } from 'react';
 
-import Spinner from '../../../../components/ui/Spinner';
-import { apiPatchWebhook } from '../../../../hooks/useEnvironment';
+import { usePatchWebhook } from '../../../../hooks/useEnvironment';
 import { useToast } from '../../../../hooks/useToast';
+import Spinner from '@/components/ui/Spinner';
 import { Switch } from '@/components-v2/ui/switch';
 
 import type { ApiWebhooks } from '@nangohq/types';
@@ -43,12 +43,12 @@ const checkboxesConfig: CheckboxConfig[] = [
 
 interface CheckboxFormProps {
     env: string;
-    mutate: () => void;
     checkboxState: ApiWebhooks;
 }
 
-export const WebhookCheckboxes: React.FC<CheckboxFormProps> = ({ env, checkboxState, mutate }) => {
+export const WebhookCheckboxes: React.FC<CheckboxFormProps> = ({ env, checkboxState }) => {
     const { toast } = useToast();
+    const { mutateAsync: patchWebhookAsync } = usePatchWebhook(env);
 
     const [loading, setLoading] = useState<string | false>();
 
@@ -58,22 +58,20 @@ export const WebhookCheckboxes: React.FC<CheckboxFormProps> = ({ env, checkboxSt
         }
 
         setLoading(name);
-        const res = await apiPatchWebhook(env, {
-            on_auth_creation: checkboxState['on_auth_creation'],
-            on_auth_refresh_error: checkboxState['on_auth_refresh_error'],
-            on_sync_completion_always: checkboxState['on_sync_completion_always'],
-            on_sync_error: checkboxState['on_sync_error'],
-            on_async_action_completion: checkboxState['on_async_action_completion'],
-            [name]: checked
-        });
-        setLoading(false);
-
-        if ('error' in res.json) {
+        try {
+            await patchWebhookAsync({
+                on_auth_creation: checkboxState['on_auth_creation'],
+                on_auth_refresh_error: checkboxState['on_auth_refresh_error'],
+                on_sync_completion_always: checkboxState['on_sync_completion_always'],
+                on_sync_error: checkboxState['on_sync_error'],
+                on_async_action_completion: checkboxState['on_async_action_completion'],
+                [name]: checked
+            });
+        } catch {
             toast({ title: 'There was an issue updating the webhook settings', variant: 'error' });
-            return;
+        } finally {
+            setLoading(false);
         }
-
-        mutate();
     };
 
     return (

--- a/packages/webapp/src/pages/GettingStarted/FirstStep.tsx
+++ b/packages/webapp/src/pages/GettingStarted/FirstStep.tsx
@@ -28,7 +28,8 @@ interface FirstStepProps {
 
 export const FirstStep: React.FC<FirstStepProps> = ({ connection, integration, onConnectClicked, onConnected, onDisconnected }) => {
     const env = useStore((state) => state.env);
-    const { environmentAndAccount } = useEnvironment(env);
+    const { data } = useEnvironment(env);
+    const environmentAndAccount = data?.environmentAndAccount;
     const { user } = useUser();
 
     const { toast } = useToast();

--- a/packages/webapp/src/pages/GettingStarted/SecondStep.tsx
+++ b/packages/webapp/src/pages/GettingStarted/SecondStep.tsx
@@ -49,7 +49,8 @@ export const SecondStep: React.FC<SecondStepProps> = ({ connectionId, providerCo
     const { toast } = useToast();
 
     const env = useStore((state) => state.env);
-    const { environmentAndAccount } = useEnvironment(env);
+    const { data } = useEnvironment(env);
+    const environmentAndAccount = data?.environmentAndAccount;
 
     const [isExecuting, setIsExecuting] = useState(false);
     const [isTooltipOpen, setIsTooltipOpen] = useState(false);

--- a/packages/webapp/src/pages/Integrations/components/AutoIdlingBanner.tsx
+++ b/packages/webapp/src/pages/Integrations/components/AutoIdlingBanner.tsx
@@ -11,7 +11,8 @@ export const AutoIdlingBanner: React.FC = () => {
     const { toast } = useToast();
 
     const env = useStore((state) => state.env);
-    const { plan, mutate: mutateEnv } = useEnvironment(env);
+    const { data: environmentData, refetch: refetchEnv } = useEnvironment(env);
+    const plan = environmentData?.plan;
     const { isTrial, isTrialOver, daysRemaining } = useTrial(plan);
 
     const [trialLoading, setTrialLoading] = useState(false);
@@ -26,7 +27,7 @@ export const AutoIdlingBanner: React.FC = () => {
             return;
         }
 
-        void mutateEnv();
+        void refetchEnv();
 
         toast({ title: 'Auto idling was extended successfully!', variant: 'success' });
     };

--- a/packages/webapp/src/pages/Integrations/components/FunctionSwitch.tsx
+++ b/packages/webapp/src/pages/Integrations/components/FunctionSwitch.tsx
@@ -16,7 +16,8 @@ export const FunctionSwitch: React.FC<{
 }> = ({ flow, integration }) => {
     const { toast } = useToast();
     const env = useStore((state) => state.env);
-    const { plan, mutate: mutateEnv } = useEnvironment(env);
+    const { data: environmentData, refetch: refetchEnv } = useEnvironment(env);
+    const plan = environmentData?.plan;
     const { confirm, DialogComponent } = useConfirmDialog();
 
     const { mutateAsync: enableFlow, isPending: isEnablePending } = useFlowEnable(env, integration.unique_key);
@@ -81,7 +82,7 @@ export const FunctionSwitch: React.FC<{
             }
             toast({ title: `Enabled successfully`, variant: 'success' });
             if (plan && plan.auto_idle && !plan.trial_end_at) {
-                void mutateEnv();
+                void refetchEnv();
             }
         } catch (err) {
             if (err instanceof APIError) {

--- a/packages/webapp/src/pages/Integrations/providerConfigKey/Show.tsx
+++ b/packages/webapp/src/pages/Integrations/providerConfigKey/Show.tsx
@@ -22,7 +22,8 @@ export const ShowIntegration: React.FC = () => {
     const env = useStore((state) => state.env);
     const [activeTab, setActiveTab] = usePathNavigation(`/${env}/integrations/${providerConfigKey}`, 'functions');
 
-    const { environmentAndAccount, loading: loadingEnvironment, error: environmentError } = useEnvironment(env);
+    const { data: environmentData, isLoading: loadingEnvironment, error: environmentError } = useEnvironment(env);
+    const environmentAndAccount = environmentData?.environmentAndAccount;
     const { data, isLoading: loadingIntegration, error: integrationError } = useGetIntegration(env, providerConfigKey!);
     const integration = data?.data;
 

--- a/packages/webapp/src/pages/Team/Billing/components/Plans.tsx
+++ b/packages/webapp/src/pages/Team/Billing/components/Plans.tsx
@@ -24,7 +24,8 @@ import type { PlanDefinition, StripePaymentMethod } from '@nangohq/types';
 export const Plans: React.FC = () => {
     const env = useStore((state) => state.env);
 
-    const { plan: currentPlan } = useEnvironment(env);
+    const { data: environmentData } = useEnvironment(env);
+    const currentPlan = environmentData?.plan;
     const { data: plansList } = useApiGetPlans(env);
     const { data: paymentMethods } = useStripePaymentMethods(env);
 

--- a/packages/webapp/src/pages/Team/Billing/components/Usage.tsx
+++ b/packages/webapp/src/pages/Team/Billing/components/Usage.tsx
@@ -15,7 +15,8 @@ interface UsageProps {
 
 export const Usage: React.FC<UsageProps> = ({ selectedMonth }) => {
     const env = useStore((state) => state.env);
-    const { plan } = useEnvironment(env);
+    const { data: environmentData } = useEnvironment(env);
+    const plan = environmentData?.plan;
 
     // Calculate timeframe for the selected month
     const timeframe = useMemo(() => {

--- a/packages/webapp/src/utils/slack-connection.ts
+++ b/packages/webapp/src/utils/slack-connection.ts
@@ -1,6 +1,6 @@
 import Nango from '@nangohq/frontend';
 
-import { apiFetch } from './api';
+import { APIError, apiFetch } from './api.js';
 
 export const connectSlack = async ({
     accountUUID,
@@ -40,7 +40,10 @@ export const connectSlack = async ({
             detectClosedAuthWindow: true
         })
         .then(async () => {
-            await apiFetch(`/api/v1/environments?env=${env}`, { method: 'PATCH', body: JSON.stringify({ slack_notifications: true }) });
+            const res = await apiFetch(`/api/v1/environments?env=${env}`, { method: 'PATCH', body: JSON.stringify({ slack_notifications: true }) });
+            if (!res.ok) {
+                throw new APIError({ res, json: res.json() });
+            }
             onFinish();
         })
         .catch((err: unknown) => {

--- a/packages/webapp/src/utils/slack-connection.ts
+++ b/packages/webapp/src/utils/slack-connection.ts
@@ -42,7 +42,7 @@ export const connectSlack = async ({
         .then(async () => {
             const res = await apiFetch(`/api/v1/environments?env=${env}`, { method: 'PATCH', body: JSON.stringify({ slack_notifications: true }) });
             if (!res.ok) {
-                throw new APIError({ res, json: res.json() });
+                throw new APIError({ res, json: await res.json() });
             }
             onFinish();
         })

--- a/packages/webapp/src/utils/slack-connection.tsx
+++ b/packages/webapp/src/utils/slack-connection.tsx
@@ -1,7 +1,6 @@
 import Nango from '@nangohq/frontend';
 
 import { apiFetch } from './api';
-import { apiPatchEnvironment } from '../hooks/useEnvironment';
 
 export const connectSlack = async ({
     accountUUID,
@@ -41,7 +40,7 @@ export const connectSlack = async ({
             detectClosedAuthWindow: true
         })
         .then(async () => {
-            await apiPatchEnvironment(env, { slack_notifications: true });
+            await apiFetch(`/api/v1/environments?env=${env}`, { method: 'PATCH', body: JSON.stringify({ slack_notifications: true }) });
             onFinish();
         })
         .catch((err: unknown) => {


### PR DESCRIPTION
Migrating the hooks in `useEnvironment.tsx` to use tanstack query. Mutations invalidate the cache for `useEnvironment`, so we also remove a lot of the manual refetches

<!-- Summary by @propel-code-bot -->

---

This also replaces the prior SWR/imperative environment helpers with standardized TanStack Query keys and APIError handling, and updates environment-related pages and components to consume query and mutation state, including Slack connection handling that now patches notifications with explicit error checks and refetches.

---
*This summary was automatically generated by @propel-code-bot*