### PR TITLE
chore: batch insert tasks

### DIFF
--- a/packages/orchestrator/lib/clients/processor.integration.test.ts
+++ b/packages/orchestrator/lib/clients/processor.integration.test.ts
@@ -46,7 +46,7 @@ describe('OrchestratorProcessor', () => {
             n: 10,
             waitUntil: (task) => task.state === 'STARTED'
         });
-    });
+    }, 60_000);
     it('should process tasks and mark them as failed if processing failed', async () => {
         await processN({
             handler: vi.fn((): Promise<Result<void>> => Promise.resolve(Err('Failed'))),
@@ -54,7 +54,7 @@ describe('OrchestratorProcessor', () => {
             n: 10,
             waitUntil: (task) => task.state === 'FAILED'
         });
-    });
+    }, 60_000);
 });
 
 async function processN({
@@ -81,15 +81,16 @@ async function processN({
         await immediateTask({ groupKey });
     }
 
-    let processed = false;
-    const start = Date.now();
-    const timeout = 1_000;
-    while (!processed) {
-        await setTimeout(100);
-        const tasks = (await scheduler.searchTasks({ groupKey })).unwrap();
-        processed = tasks.length == n && tasks.every(waitUntil);
-        if (!processed && Date.now() - start > timeout) {
-            throw new Error(`Timeout: expected ${n} tasks to be processed, but tasks are still in states: ${tasks.map((task) => task.state).join(', ')}`);
+    let tasks: Task[] = [];
+    let success = false;
+
+    while (!success) {
+        tasks = (await scheduler.searchTasks({ groupKey })).unwrap();
+
+        if (tasks.length === n && tasks.every(waitUntil)) {
+            success = true;
+        } else {
+            await setTimeout(100);
         }
     }
 

--- a/packages/scheduler/lib/daemons/scheduling/scheduling.daemon.ts
+++ b/packages/scheduler/lib/daemons/scheduling/scheduling.daemon.ts
@@ -56,7 +56,7 @@ export class SchedulingDaemon extends SchedulerDaemon {
                         if (getDueSchedules.isErr()) {
                             throw new Error(`Failed to get due schedules: ${stringifyError(getDueSchedules.error)}`);
                         } else {
-                            await tracer.trace('scheduler.scheduling.tasks_creation', async () => {
+                            await tracer.trace('scheduler.scheduling.tasks_creation', async (span) => {
                                 const now = new Date();
                                 const taskProps = getDueSchedules.value.map((schedule) => ({
                                     scheduleId: schedule.id,
@@ -94,6 +94,10 @@ export class SchedulingDaemon extends SchedulerDaemon {
                                 if (scheduleRes.isErr()) {
                                     logger.error(`Error updating schedules with last scheduled task: ${stringifyError(scheduleRes.error)}`);
                                 }
+
+                                span.addTags({
+                                    'scheduling.scheduled': scheduledTasks.length
+                                });
 
                                 // Notify the listeners about the scheduled tasks
                                 scheduledTasks.forEach((task) => this.onScheduling(task));

--- a/packages/scheduler/lib/daemons/scheduling/scheduling.daemon.ts
+++ b/packages/scheduler/lib/daemons/scheduling/scheduling.daemon.ts
@@ -76,13 +76,12 @@ export class SchedulingDaemon extends SchedulerDaemon {
                                 if (createRes.isErr()) {
                                     throw new Error(`Failed to schedule tasks: ${stringifyError(createRes.error)}`);
                                 }
-                                const skipped = taskProps.length - createRes.value.length;
-                                if (skipped > 0) {
-                                    logger.warn(`${skipped} task(s) were not scheduled.`);
+                                if (createRes.value.cappedGroupKeys.length > 0) {
+                                    logger.warn(`Capped scheduling tasks for group keys: ${createRes.value.cappedGroupKeys.join(', ')}`);
                                 }
                                 const scheduleUpdates = [];
                                 const scheduledTasks = [];
-                                for (const task of createRes.value) {
+                                for (const task of createRes.value.tasks) {
                                     if (task.scheduleId) {
                                         scheduleUpdates.push({ id: task.scheduleId, taskId: task.id, taskState: task.state });
                                     }

--- a/packages/scheduler/lib/daemons/scheduling/scheduling.daemon.ts
+++ b/packages/scheduler/lib/daemons/scheduling/scheduling.daemon.ts
@@ -58,37 +58,35 @@ export class SchedulingDaemon extends SchedulerDaemon {
                         } else {
                             await tracer.trace('scheduler.scheduling.tasks_creation', async () => {
                                 const now = new Date();
-                                const createTasks = getDueSchedules.value.map((schedule) =>
-                                    tasks.create(trx, {
-                                        scheduleId: schedule.id,
-                                        startsAfter: now,
-                                        name: `${schedule.name}:${now.toISOString()}`,
-                                        payload: schedule.payload,
-                                        groupKey: schedule.groupKey,
-                                        groupMaxConcurrency: envs.SYNC_ENVIRONMENT_MAX_CONCURRENCY,
-                                        retryCount: 0,
-                                        retryMax: schedule.retryMax,
-                                        createdToStartedTimeoutSecs: schedule.createdToStartedTimeoutSecs,
-                                        startedToCompletedTimeoutSecs: schedule.startedToCompletedTimeoutSecs,
-                                        heartbeatTimeoutSecs: schedule.heartbeatTimeoutSecs,
-                                        ownerKey: null
-                                    })
-                                );
-                                const res = await Promise.allSettled(createTasks);
+                                const taskProps = getDueSchedules.value.map((schedule) => ({
+                                    scheduleId: schedule.id,
+                                    startsAfter: now,
+                                    name: `${schedule.name}:${now.toISOString()}`,
+                                    payload: schedule.payload,
+                                    groupKey: schedule.groupKey,
+                                    groupMaxConcurrency: envs.SYNC_ENVIRONMENT_MAX_CONCURRENCY,
+                                    retryCount: 0,
+                                    retryMax: schedule.retryMax,
+                                    createdToStartedTimeoutSecs: schedule.createdToStartedTimeoutSecs,
+                                    startedToCompletedTimeoutSecs: schedule.startedToCompletedTimeoutSecs,
+                                    heartbeatTimeoutSecs: schedule.heartbeatTimeoutSecs,
+                                    ownerKey: null
+                                }));
+                                const createRes = await tasks.create(trx, taskProps);
+                                if (createRes.isErr()) {
+                                    throw new Error(`Failed to schedule tasks: ${stringifyError(createRes.error)}`);
+                                }
+                                const skipped = taskProps.length - createRes.value.length;
+                                if (skipped > 0) {
+                                    logger.warn(`${skipped} task(s) were not scheduled.`);
+                                }
                                 const scheduleUpdates = [];
                                 const scheduledTasks = [];
-                                for (const taskRes of res) {
-                                    if (taskRes.status === 'rejected') {
-                                        logger.error(`Failed to schedule task: ${taskRes.reason}`);
-                                    } else if (taskRes.value.isErr()) {
-                                        logger.error(`Failed to schedule task: ${stringifyError(taskRes.value.error)}`);
-                                    } else {
-                                        const task = taskRes.value.value;
-                                        if (task.scheduleId) {
-                                            scheduleUpdates.push({ id: task.scheduleId, taskId: task.id, taskState: task.state });
-                                        }
-                                        scheduledTasks.push(task);
+                                for (const task of createRes.value) {
+                                    if (task.scheduleId) {
+                                        scheduleUpdates.push({ id: task.scheduleId, taskId: task.id, taskState: task.state });
                                     }
+                                    scheduledTasks.push(task);
                                 }
 
                                 // Update the last scheduled task for each schedule

--- a/packages/scheduler/lib/models/tasks.integration.test.ts
+++ b/packages/scheduler/lib/models/tasks.integration.test.ts
@@ -37,8 +37,8 @@ describe('Task', () => {
     });
 
     it('should be successfully created', async () => {
-        const [task] = (await tasks.create(db, [props])).unwrap();
-        expect(task).toMatchObject({
+        const res = (await tasks.create(db, [props])).unwrap();
+        expect(res.tasks[0]).toMatchObject({
             id: expect.any(String),
             name: props.name,
             payload: props.payload,
@@ -61,10 +61,10 @@ describe('Task', () => {
         });
     });
     it('should create multiple tasks', async () => {
-        const n = 1500;
+        const n = 5;
         const taskProps = Array.from({ length: n }, (_, i) => ({ ...props, name: `n=${i}` }));
         const res = (await tasks.create(db, taskProps)).unwrap();
-        expect(res).toHaveLength(n);
+        expect(res.tasks).toHaveLength(n);
     });
     it('should not create tasks exceeding the cap', async () => {
         const groupTaskCap = 1;
@@ -79,9 +79,10 @@ describe('Task', () => {
                 { groupTaskCap }
             )
         ).unwrap();
-        expect(res).toHaveLength(2);
-        expect(res[0]?.name).toBe('Not capped');
-        expect(res[1]?.name).toBe('Also not capped');
+        expect(res.tasks).toHaveLength(2);
+        expect(res.tasks[0]?.name).toBe('Not capped');
+        expect(res.tasks[1]?.name).toBe('Also not capped');
+        expect(res.cappedGroupKeys).toEqual([props.groupKey]);
     });
     it('should have their heartbeat updated', async () => {
         const t = await startTask(db);
@@ -338,7 +339,7 @@ async function createTask(db: knex.Knex, props?: Partial<tasks.TaskProps>): Prom
     if (res.isErr()) {
         throw new Error(`Failed to create task: ${res.error.message}`);
     }
-    const task = res.value[0];
+    const task = res.value.tasks[0];
     if (!task) {
         throw new Error('No task created');
     }

--- a/packages/scheduler/lib/models/tasks.integration.test.ts
+++ b/packages/scheduler/lib/models/tasks.integration.test.ts
@@ -37,7 +37,7 @@ describe('Task', () => {
     });
 
     it('should be successfully created', async () => {
-        const task = (await tasks.create(db, props)).unwrap();
+        const [task] = (await tasks.create(db, [props])).unwrap();
         expect(task).toMatchObject({
             id: expect.any(String),
             name: props.name,
@@ -60,15 +60,28 @@ describe('Task', () => {
             ownerKey: props.ownerKey
         });
     });
-    it('should fail to create if more than cap', async () => {
+    it('should create multiple tasks', async () => {
+        const n = 1500;
+        const taskProps = Array.from({ length: n }, (_, i) => ({ ...props, name: `n=${i}` }));
+        const res = (await tasks.create(db, taskProps)).unwrap();
+        expect(res).toHaveLength(n);
+    });
+    it('should not create tasks exceeding the cap', async () => {
         const groupTaskCap = 1;
-        // first task should be created successfully
-        const t1 = await tasks.create(db, { ...props, name: 'Not capped' }, { groupTaskCap });
-        expect(t1.isOk()).toBe(true);
-
-        // second task with the same group key should fail
-        const t2 = await tasks.create(db, { ...props, name: 'Capped' }, { groupTaskCap });
-        expect(t2.isErr()).toBe(true);
+        const res = (
+            await tasks.create(
+                db,
+                [
+                    { ...props, name: 'Not capped' },
+                    { ...props, name: 'Capped' },
+                    { ...props, groupKey: nanoid(), name: 'Also not capped' }
+                ],
+                { groupTaskCap }
+            )
+        ).unwrap();
+        expect(res).toHaveLength(2);
+        expect(res[0]?.name).toBe('Not capped');
+        expect(res[1]?.name).toBe('Also not capped');
     });
     it('should have their heartbeat updated', async () => {
         const t = await startTask(db);
@@ -305,25 +318,31 @@ async function createTaskWithState(db: knex.Knex, state: TaskState): Promise<Tas
 
 async function createTask(db: knex.Knex, props?: Partial<tasks.TaskProps>): Promise<Task> {
     const now = new Date();
-    const task = await tasks.create(db, {
-        name: props?.name || nanoid(),
-        payload: props?.payload || {},
-        groupKey: props?.groupKey || nanoid(),
-        groupMaxConcurrency: props?.groupMaxConcurrency || 0,
-        retryMax: props?.retryMax || 3,
-        retryCount: props?.retryCount || 1,
-        startsAfter: props?.startsAfter || now,
-        createdToStartedTimeoutSecs: props?.createdToStartedTimeoutSecs || 10,
-        startedToCompletedTimeoutSecs: props?.startedToCompletedTimeoutSecs || 20,
-        heartbeatTimeoutSecs: props?.heartbeatTimeoutSecs || 5,
-        scheduleId: props?.scheduleId || null,
-        retryKey: props?.retryKey || null,
-        ownerKey: props?.ownerKey || null
-    });
-    if (task.isErr()) {
-        throw new Error(`Failed to create task: ${task.error.message}`);
+    const res = await tasks.create(db, [
+        {
+            name: props?.name || nanoid(),
+            payload: props?.payload || {},
+            groupKey: props?.groupKey || nanoid(),
+            groupMaxConcurrency: props?.groupMaxConcurrency || 0,
+            retryMax: props?.retryMax || 3,
+            retryCount: props?.retryCount || 1,
+            startsAfter: props?.startsAfter || now,
+            createdToStartedTimeoutSecs: props?.createdToStartedTimeoutSecs || 10,
+            startedToCompletedTimeoutSecs: props?.startedToCompletedTimeoutSecs || 20,
+            heartbeatTimeoutSecs: props?.heartbeatTimeoutSecs || 5,
+            scheduleId: props?.scheduleId || null,
+            retryKey: props?.retryKey || null,
+            ownerKey: props?.ownerKey || null
+        }
+    ]);
+    if (res.isErr()) {
+        throw new Error(`Failed to create task: ${res.error.message}`);
     }
-    return task.unwrap();
+    const task = res.value[0];
+    if (!task) {
+        throw new Error('No task created');
+    }
+    return task;
 }
 
 async function startTask(db: knex.Knex, props?: Partial<tasks.TaskProps>): Promise<Task> {

--- a/packages/scheduler/lib/models/tasks.integration.test.ts
+++ b/packages/scheduler/lib/models/tasks.integration.test.ts
@@ -61,7 +61,7 @@ describe('Task', () => {
         });
     });
     it('should create multiple tasks', async () => {
-        const n = 5;
+        const n = 1200;
         const taskProps = Array.from({ length: n }, (_, i) => ({ ...props, name: `n=${i}` }));
         const res = (await tasks.create(db, taskProps)).unwrap();
         expect(res.tasks).toHaveLength(n);

--- a/packages/scheduler/lib/models/tasks.ts
+++ b/packages/scheduler/lib/models/tasks.ts
@@ -134,7 +134,7 @@ export async function create(
         // safeguard to prevent creating an unbounded number of tasks for the same group
         // Note: check and insertion are not atomic so creating more tasks than the limit is still possible but this is a safeguard, not a strict limit
         const groupKeys = [...new Set(taskProps.map((p) => p.groupKey))];
-        const sizes = await queueSizes(db, groupKeys);
+        const sizes = await queueSizes(db, { groupKeys });
         if (sizes.isErr()) {
             return Err(sizes.error);
         }
@@ -173,15 +173,13 @@ export async function create(
     }
 }
 
-export async function queueSizes(db: knex.Knex, groupKeys: string[]): Promise<Result<Map<string, number>>> {
+export async function queueSizes(db: knex.Knex, opts: { groupKeys?: string[] | undefined }): Promise<Result<Map<string, number>>> {
     try {
-        const rows = await db
-            .from(TASKS_TABLE)
-            .select('group_key as groupKey')
-            .count('id as count')
-            .where('state', 'CREATED')
-            .whereIn('group_key', groupKeys)
-            .groupBy('group_key');
+        const q = db.from(TASKS_TABLE).select('group_key as groupKey').count('id as count').where('state', 'CREATED').groupBy('group_key');
+        if (opts.groupKeys && opts.groupKeys.length > 0) {
+            q.whereIn('group_key', opts.groupKeys);
+        }
+        const rows = await q;
         return Ok(new Map(rows.map((r) => [r.groupKey as string, Number(r.count)])));
     } catch (err) {
         return Err(new Error(`Error fetching queue sizes: ${stringifyError(err)}`));

--- a/packages/scheduler/lib/models/tasks.ts
+++ b/packages/scheduler/lib/models/tasks.ts
@@ -12,6 +12,7 @@ import type knex from 'knex';
 import type { JsonValue, SetOptional } from 'type-fest';
 
 export const TASKS_TABLE = 'tasks';
+const TASKS_INSERT_BATCH_SIZE = 1000;
 
 export type TaskProps = SetOptional<
     Omit<Task, 'id' | 'createdAt' | 'state' | 'lastStateTransitionAt' | 'lastHeartbeatAt' | 'output' | 'terminated'>,
@@ -123,38 +124,67 @@ export const DbTask = {
 
 export async function create(
     db: knex.Knex,
-    taskProps: TaskProps,
+    taskProps: TaskProps[],
     opts: { groupTaskCap: number } = { groupTaskCap: envs.ORCHESTRATOR_TASK_CREATED_PER_GROUP_COUNT_MAX }
-): Promise<Result<Task>> {
-    const now = new Date();
-    const state = 'CREATED';
-    const newTask: Task = {
-        ...taskProps,
-        id: uuidv7(),
-        state,
-        createdAt: now,
-        lastStateTransitionAt: now,
-        lastHeartbeatAt: now,
-        terminated: false,
-        output: null,
-        scheduleId: taskProps.scheduleId,
-        retryKey: taskProps.retryKey || uuidv4()
-    };
+): Promise<Result<Task[]>> {
+    if (taskProps.length === 0) {
+        return Ok([]);
+    }
     try {
         // safeguard to prevent creating an unbounded number of tasks for the same group
         // Note: check and insertion are not atomic so creating more tasks than the limit is still possible but this is a safeguard, not a strict limit
-        const [{ count }] = await db.from(TASKS_TABLE).where({ state, group_key: taskProps.groupKey }).count();
-        if (Number(count) >= opts.groupTaskCap) {
-            return Err(new Error(`Error creating task '${taskProps.name}': already ${opts.groupTaskCap} ${state} tasks for group key '${taskProps.groupKey}'`));
+        const groupKeys = [...new Set(taskProps.map((p) => p.groupKey))];
+        const sizes = await queueSizes(db, groupKeys);
+        if (sizes.isErr()) {
+            return Err(sizes.error);
         }
 
-        const inserted = await db.from<DBTask>(TASKS_TABLE).insert(DbTask.to(newTask)).returning('*');
-        if (!inserted?.[0]) {
-            return Err(new Error(`Error: no task '${taskProps.name}' created`));
+        const now = new Date();
+        const toInsertPerGroup = new Map<string, Task[]>();
+        for (const props of taskProps) {
+            if (!toInsertPerGroup.has(props.groupKey)) {
+                toInsertPerGroup.set(props.groupKey, []);
+            }
+            const group = toInsertPerGroup.get(props.groupKey)!;
+            if (group.length < opts.groupTaskCap - (sizes.value.get(props.groupKey) ?? 0)) {
+                group.push({
+                    ...props,
+                    id: uuidv7(),
+                    state: 'CREATED',
+                    createdAt: now,
+                    lastStateTransitionAt: now,
+                    lastHeartbeatAt: now,
+                    terminated: false,
+                    output: null,
+                    retryKey: props.retryKey || uuidv4()
+                });
+            }
         }
-        return Ok(DbTask.from(inserted[0]));
+        const toInsert = Array.from(toInsertPerGroup.values()).flat();
+        const inserted: Task[] = [];
+        while (toInsert.length) {
+            const chunk = toInsert.splice(0, TASKS_INSERT_BATCH_SIZE);
+            const batch = await db.from<DBTask>(TASKS_TABLE).insert(chunk.map(DbTask.to)).returning('*');
+            inserted.push(...batch.map(DbTask.from));
+        }
+        return Ok(inserted);
     } catch (err) {
-        return Err(new Error(`Error creating task '${taskProps.name}': ${stringifyError(err)}`));
+        return Err(new Error(`Error creating tasks: ${stringifyError(err)}`));
+    }
+}
+
+export async function queueSizes(db: knex.Knex, groupKeys: string[]): Promise<Result<Map<string, number>>> {
+    try {
+        const rows = await db
+            .from(TASKS_TABLE)
+            .select('group_key as groupKey')
+            .count('id as count')
+            .where('state', 'CREATED')
+            .whereIn('group_key', groupKeys)
+            .groupBy('group_key');
+        return Ok(new Map(rows.map((r) => [r.groupKey as string, Number(r.count)])));
+    } catch (err) {
+        return Err(new Error(`Error fetching queue sizes: ${stringifyError(err)}`));
     }
 }
 

--- a/packages/scheduler/lib/models/tasks.ts
+++ b/packages/scheduler/lib/models/tasks.ts
@@ -126,9 +126,9 @@ export async function create(
     db: knex.Knex,
     taskProps: TaskProps[],
     opts: { groupTaskCap: number } = { groupTaskCap: envs.ORCHESTRATOR_TASK_CREATED_PER_GROUP_COUNT_MAX }
-): Promise<Result<Task[]>> {
+): Promise<Result<{ tasks: Task[]; cappedGroupKeys: string[] }>> {
     if (taskProps.length === 0) {
-        return Ok([]);
+        return Ok({ tasks: [], cappedGroupKeys: [] });
     }
     try {
         // safeguard to prevent creating an unbounded number of tasks for the same group
@@ -141,6 +141,7 @@ export async function create(
 
         const now = new Date();
         const toInsertPerGroup = new Map<string, Task[]>();
+        const cappedGroupKeys = new Set<string>();
         for (const props of taskProps) {
             if (!toInsertPerGroup.has(props.groupKey)) {
                 toInsertPerGroup.set(props.groupKey, []);
@@ -158,6 +159,8 @@ export async function create(
                     output: null,
                     retryKey: props.retryKey || uuidv4()
                 });
+            } else {
+                cappedGroupKeys.add(props.groupKey);
             }
         }
         const toInsert = Array.from(toInsertPerGroup.values()).flat();
@@ -167,7 +170,10 @@ export async function create(
             const batch = await db.from<DBTask>(TASKS_TABLE).insert(chunk.map(DbTask.to)).returning('*');
             inserted.push(...batch.map(DbTask.from));
         }
-        return Ok(inserted);
+        return Ok({
+            tasks: inserted,
+            cappedGroupKeys: Array.from(cappedGroupKeys)
+        });
     } catch (err) {
         return Err(new Error(`Error creating tasks: ${stringifyError(err)}`));
     }

--- a/packages/scheduler/lib/scheduler.ts
+++ b/packages/scheduler/lib/scheduler.ts
@@ -201,7 +201,7 @@ export class Scheduler {
             if (created.isErr()) {
                 return Err(created.error);
             }
-            const task = created.value[0];
+            const task = created.value.tasks[0];
             if (!task) {
                 return Err(`Failed to create task '${taskProps.name}'`);
             }

--- a/packages/scheduler/lib/scheduler.ts
+++ b/packages/scheduler/lib/scheduler.ts
@@ -197,18 +197,22 @@ export class Scheduler {
                 };
             }
 
-            const created = await tasks.create(trx, taskProps);
-            if (created.isOk()) {
-                const task = created.value;
-                if (task.scheduleId) {
-                    const scheduleRes = await schedules.setLastScheduledTask(trx, [{ id: task.scheduleId, taskId: task.id, taskState: task.state }]);
-                    if (scheduleRes.isErr()) {
-                        return Err(`Error updating last scheduled task for schedule '${task.scheduleId}': ${stringifyError(scheduleRes.error)}`);
-                    }
-                }
-                this.onCallbacks[task.state](task);
+            const created = await tasks.create(trx, [taskProps]);
+            if (created.isErr()) {
+                return Err(created.error);
             }
-            return created;
+            const task = created.value[0];
+            if (!task) {
+                return Err(`Failed to create task '${taskProps.name}'`);
+            }
+            if (task.scheduleId) {
+                const scheduleRes = await schedules.setLastScheduledTask(trx, [{ id: task.scheduleId, taskId: task.id, taskState: task.state }]);
+                if (scheduleRes.isErr()) {
+                    return Err(`Error updating last scheduled task for schedule '${task.scheduleId}': ${stringifyError(scheduleRes.error)}`);
+                }
+            }
+            this.onCallbacks[task.state](task);
+            return Ok(task);
         });
     }
 


### PR DESCRIPTION
Optimizing orchestrator to create tasks in batch. Useful when the scheduling daemon needs to create hundreds of tasks.


<!-- Summary by @propel-code-bot -->

---

**Batch task creation with capped group tracking and scheduler updates**

This PR updates task creation to use a batch API for the scheduler and scheduler daemon, enabling bulk inserts with per-group caps and returning both created tasks and capped group keys. The scheduling flow now builds an array of task properties, calls the batch `tasks.create` API, logs capped group keys, and records the scheduled count via trace tags.

---
*This summary was automatically generated by @propel-code-bot*