### PR TITLE
investigation: dead tuples snowball in batch delete loops

### DIFF
--- a/dead_tuples_investigation/01_setup.sql
+++ b/dead_tuples_investigation/01_setup.sql
@@ -1,0 +1,40 @@
+-- Setup: create table, indexes, insert data, reset stats
+DROP TABLE IF EXISTS test_records;
+
+CREATE TABLE test_records (
+    id uuid NOT NULL DEFAULT gen_random_uuid(),
+    external_id varchar(255) NOT NULL,
+    connection_id integer NOT NULL,
+    model varchar(255) NOT NULL,
+    data_hash varchar(255) NOT NULL,
+    deleted_at timestamptz,
+    updated_at timestamptz NOT NULL DEFAULT NOW(),
+    sync_job_id integer NOT NULL,
+    json jsonb DEFAULT '{"some": "data", "padding": "abcdefghijklmnopqrstuvwxyz0123456789"}'::jsonb,
+    PRIMARY KEY (id)
+);
+
+CREATE INDEX idx_test_records_main ON test_records(connection_id, model, updated_at, id);
+CREATE UNIQUE INDEX idx_test_records_unique ON test_records(connection_id, model, external_id);
+
+-- Index with id as KEY column (not INCLUDE) to support cursor-based scanning
+CREATE INDEX idx_test_records_outdated ON test_records(connection_id, model, sync_job_id, id)
+    WHERE deleted_at IS NULL;
+
+-- Disable autovacuum so dead tuples accumulate (simulates vacuum lag under load)
+ALTER TABLE test_records SET (autovacuum_enabled = false);
+
+-- Insert 500K rows: 10 connections x 50K rows each, all with sync_job_id=1
+INSERT INTO test_records (external_id, connection_id, model, data_hash, sync_job_id)
+SELECT 'ext_' || i, conn_id, 'contacts', md5(i::text), 1
+FROM generate_series(1, 50000) AS i,
+     generate_series(1, 10) AS conn_id;
+
+-- Reset stats
+SELECT pg_stat_reset();
+SELECT pg_sleep(2);
+
+SELECT 'BEFORE' as phase, tup_returned, tup_fetched
+FROM pg_stat_database WHERE datname = current_database();
+
+\echo 'Setup complete: 500K rows, 10 connections, autovacuum disabled'

--- a/dead_tuples_investigation/01_setup_with_vacuum.sql
+++ b/dead_tuples_investigation/01_setup_with_vacuum.sql
@@ -1,0 +1,42 @@
+-- Setup: same as 01_setup.sql but with autovacuum ENABLED (default)
+DROP TABLE IF EXISTS test_records;
+
+CREATE TABLE test_records (
+    id uuid NOT NULL DEFAULT gen_random_uuid(),
+    external_id varchar(255) NOT NULL,
+    connection_id integer NOT NULL,
+    model varchar(255) NOT NULL,
+    data_hash varchar(255) NOT NULL,
+    deleted_at timestamptz,
+    updated_at timestamptz NOT NULL DEFAULT NOW(),
+    sync_job_id integer NOT NULL,
+    json jsonb DEFAULT '{"some": "data", "padding": "abcdefghijklmnopqrstuvwxyz0123456789"}'::jsonb,
+    PRIMARY KEY (id)
+);
+
+CREATE INDEX idx_test_records_main ON test_records(connection_id, model, updated_at, id);
+CREATE UNIQUE INDEX idx_test_records_unique ON test_records(connection_id, model, external_id);
+
+-- Index with id as KEY column (not INCLUDE) to support cursor-based scanning
+CREATE INDEX idx_test_records_outdated ON test_records(connection_id, model, sync_job_id, id)
+    WHERE deleted_at IS NULL;
+
+-- autovacuum ENABLED (default) — vacuum may run between batches
+
+-- Insert 500K rows: 10 connections x 50K rows each, all with sync_job_id=1
+INSERT INTO test_records (external_id, connection_id, model, data_hash, sync_job_id)
+SELECT 'ext_' || i, conn_id, 'contacts', md5(i::text), 1
+FROM generate_series(1, 50000) AS i,
+     generate_series(1, 10) AS conn_id;
+
+-- Vacuum + analyze to set visibility map (simulates steady-state)
+VACUUM ANALYZE test_records;
+
+-- Reset stats
+SELECT pg_stat_reset();
+SELECT pg_sleep(2);
+
+SELECT 'BEFORE' as phase, tup_returned, tup_fetched
+FROM pg_stat_database WHERE datname = current_database();
+
+\echo 'Setup complete: 500K rows, 10 connections, autovacuum ENABLED'

--- a/dead_tuples_investigation/02_worker_no_cursor.sql
+++ b/dead_tuples_investigation/02_worker_no_cursor.sql
@@ -1,0 +1,43 @@
+-- Worker WITHOUT cursor: scans from beginning of index each batch
+-- Simulates current deleteOutdatedRecords behavior
+-- Pass connection_id via: psql -v conn_id=1
+
+-- Batch 1
+UPDATE test_records SET deleted_at = NOW(), updated_at = NOW(), sync_job_id = 2
+WHERE id IN (SELECT id FROM test_records WHERE connection_id = :conn_id AND model = 'contacts' AND deleted_at IS NULL AND sync_job_id < 2 LIMIT 5000);
+
+-- Batch 2
+UPDATE test_records SET deleted_at = NOW(), updated_at = NOW(), sync_job_id = 2
+WHERE id IN (SELECT id FROM test_records WHERE connection_id = :conn_id AND model = 'contacts' AND deleted_at IS NULL AND sync_job_id < 2 LIMIT 5000);
+
+-- Batch 3
+UPDATE test_records SET deleted_at = NOW(), updated_at = NOW(), sync_job_id = 2
+WHERE id IN (SELECT id FROM test_records WHERE connection_id = :conn_id AND model = 'contacts' AND deleted_at IS NULL AND sync_job_id < 2 LIMIT 5000);
+
+-- Batch 4
+UPDATE test_records SET deleted_at = NOW(), updated_at = NOW(), sync_job_id = 2
+WHERE id IN (SELECT id FROM test_records WHERE connection_id = :conn_id AND model = 'contacts' AND deleted_at IS NULL AND sync_job_id < 2 LIMIT 5000);
+
+-- Batch 5
+UPDATE test_records SET deleted_at = NOW(), updated_at = NOW(), sync_job_id = 2
+WHERE id IN (SELECT id FROM test_records WHERE connection_id = :conn_id AND model = 'contacts' AND deleted_at IS NULL AND sync_job_id < 2 LIMIT 5000);
+
+-- Batch 6
+UPDATE test_records SET deleted_at = NOW(), updated_at = NOW(), sync_job_id = 2
+WHERE id IN (SELECT id FROM test_records WHERE connection_id = :conn_id AND model = 'contacts' AND deleted_at IS NULL AND sync_job_id < 2 LIMIT 5000);
+
+-- Batch 7
+UPDATE test_records SET deleted_at = NOW(), updated_at = NOW(), sync_job_id = 2
+WHERE id IN (SELECT id FROM test_records WHERE connection_id = :conn_id AND model = 'contacts' AND deleted_at IS NULL AND sync_job_id < 2 LIMIT 5000);
+
+-- Batch 8
+UPDATE test_records SET deleted_at = NOW(), updated_at = NOW(), sync_job_id = 2
+WHERE id IN (SELECT id FROM test_records WHERE connection_id = :conn_id AND model = 'contacts' AND deleted_at IS NULL AND sync_job_id < 2 LIMIT 5000);
+
+-- Batch 9
+UPDATE test_records SET deleted_at = NOW(), updated_at = NOW(), sync_job_id = 2
+WHERE id IN (SELECT id FROM test_records WHERE connection_id = :conn_id AND model = 'contacts' AND deleted_at IS NULL AND sync_job_id < 2 LIMIT 5000);
+
+-- Batch 10
+UPDATE test_records SET deleted_at = NOW(), updated_at = NOW(), sync_job_id = 2
+WHERE id IN (SELECT id FROM test_records WHERE connection_id = :conn_id AND model = 'contacts' AND deleted_at IS NULL AND sync_job_id < 2 LIMIT 5000);

--- a/dead_tuples_investigation/03_collect_stats.sql
+++ b/dead_tuples_investigation/03_collect_stats.sql
@@ -1,0 +1,20 @@
+-- Collect stats after test run
+SELECT pg_stat_force_next_flush();
+SELECT pg_sleep(2);
+
+\echo '=== Database-level stats ==='
+SELECT tup_returned, tup_fetched,
+       round(tup_returned::numeric / nullif(tup_fetched, 0), 2) as ratio
+FROM pg_stat_database WHERE datname = current_database();
+
+\echo '=== Table-level stats ==='
+SELECT seq_tup_read, idx_tup_fetch, n_dead_tup, n_live_tup
+FROM pg_stat_user_tables WHERE relname = 'test_records';
+
+\echo '=== Index-level stats ==='
+SELECT indexrelname,
+       idx_tup_read,
+       idx_tup_fetch,
+       round(idx_tup_read::numeric / nullif(idx_tup_fetch, 0), 2) as ratio
+FROM pg_stat_user_indexes WHERE relname = 'test_records'
+ORDER BY indexrelname;

--- a/dead_tuples_investigation/04_worker_cursor.sh
+++ b/dead_tuples_investigation/04_worker_cursor.sh
@@ -1,0 +1,57 @@
+#!/bin/bash
+# Worker WITH cursor: resumes from (sync_job_id, id) of previous batch
+# Simulates proposed fix for deleteOutdatedRecords
+# Usage: bash 04_worker_cursor.sh <connection_id>
+
+CONN_ID=$1
+LAST_SYNC_JOB_ID=""
+LAST_ID=""
+
+for batch in $(seq 1 10); do
+    if [ -z "$LAST_ID" ]; then
+        # First batch: no cursor
+        RESULT=$(psql -t -A -F'|' -c "
+            WITH to_delete AS (
+                SELECT id, sync_job_id as original_sync_job_id
+                FROM test_records
+                WHERE connection_id = $CONN_ID AND model = 'contacts'
+                  AND deleted_at IS NULL AND sync_job_id < 2
+                ORDER BY sync_job_id, id
+                LIMIT 5000
+            ),
+            deleted AS (
+                UPDATE test_records SET deleted_at = NOW(), updated_at = NOW(), sync_job_id = 2
+                WHERE id IN (SELECT id FROM to_delete)
+                RETURNING id
+            )
+            SELECT original_sync_job_id, to_delete.id
+            FROM to_delete
+            ORDER BY original_sync_job_id DESC, to_delete.id DESC
+            LIMIT 1;
+        " 2>/dev/null)
+    else
+        # Subsequent batches: resume from cursor
+        RESULT=$(psql -t -A -F'|' -c "
+            WITH to_delete AS (
+                SELECT id, sync_job_id as original_sync_job_id
+                FROM test_records
+                WHERE connection_id = $CONN_ID AND model = 'contacts'
+                  AND deleted_at IS NULL AND sync_job_id < 2
+                  AND (sync_job_id, id) > ($LAST_SYNC_JOB_ID, '$LAST_ID')
+                ORDER BY sync_job_id, id
+                LIMIT 5000
+            ),
+            deleted AS (
+                UPDATE test_records SET deleted_at = NOW(), updated_at = NOW(), sync_job_id = 2
+                WHERE id IN (SELECT id FROM to_delete)
+                RETURNING id
+            )
+            SELECT original_sync_job_id, to_delete.id
+            FROM to_delete
+            ORDER BY original_sync_job_id DESC, to_delete.id DESC
+            LIMIT 1;
+        " 2>/dev/null)
+    fi
+    LAST_SYNC_JOB_ID=$(echo "$RESULT" | cut -d'|' -f1)
+    LAST_ID=$(echo "$RESULT" | cut -d'|' -f2)
+done

--- a/dead_tuples_investigation/README.md
+++ b/dead_tuples_investigation/README.md
@@ -1,0 +1,109 @@
+# Dead Tuples Snowball Investigation
+
+## Hypothesis
+
+The `deleteOutdatedRecords` function marks records as deleted in batches, using a loop that
+re-scans the partial index from the beginning on each iteration. Each batch creates dead tuples
+(the old row versions) that remain in the index until vacuum removes them. If vacuum can't keep
+up — either because it hasn't run yet between batches, or because it's overwhelmed under high
+concurrency — subsequent batches will re-scan these dead tuples over and over, wasting IO on
+entries that will never produce useful results.
+
+The `deleteRecords` function (used by the auto-deleting and auto-pruning daemons) has the same
+batch loop pattern and may suffer from the same issue.
+
+## Problem
+
+This re-scanning manifests as:
+
+This manifests as:
+- `tup_returned` (index entries scanned) growing much faster than `tup_fetched` (useful rows)
+- IO amplification under concurrency — kill flags that normally help skip dead entries get
+  evicted from the buffer cache by other sessions
+- Cascading IO saturation (`IO:DataFileRead`) that slows down all queries including upserts
+
+## How PostgreSQL stats work
+
+- **tup_returned**: incremented by `index_getnext_tid()` for every index entry the AM returns,
+  including dead tuples (before visibility check). Also incremented by `heap_getnext` for seq scans.
+- **tup_fetched**: incremented by `index_fetch_heap()` only when the tuple is **visible**.
+  Dead tuples are fetched from the heap but don't count.
+- **LP_DEAD kill flags**: when a scan discovers a dead tuple via heap fetch, it marks the index
+  entry as LP_DEAD in memory. Future scans skip it. But if the buffer page is evicted and re-read,
+  the flag is lost and the dead tuple must be re-discovered.
+
+So dead tuples inflate `tup_returned` without `tup_fetched`, and the kill flag mechanism
+breaks down under buffer cache pressure from concurrent sessions.
+
+## Proposed fix
+
+Use a cursor `(sync_job_id, id) > (last_sync_job_id, last_id)` so each batch starts where
+the previous one left off, never revisiting dead tuples. Requires the index to have `id` as
+a key column instead of INCLUDE — same storage cost (verified: both 28 MB for 500K rows).
+
+## Reproducing
+
+### Prerequisites
+- PostgreSQL 15+ running locally
+- `psql` available
+
+### Run the tests
+
+```bash
+# Set your connection details
+export PGPASSWORD=nango
+export PGHOST=localhost
+export PGPORT=5432
+export PGUSER=nango
+
+# Test 1: No cursor, vacuum disabled — single worker
+psql -f 01_setup.sql
+psql -v conn_id=1 -f 02_worker_no_cursor.sql
+psql -f 03_collect_stats.sql
+
+# Test 2: With cursor, vacuum disabled — single worker
+psql -f 01_setup.sql
+bash 04_worker_cursor.sh 1
+psql -f 03_collect_stats.sql
+
+# Test 3: No cursor, vacuum enabled — single worker
+psql -f 01_setup_with_vacuum.sql
+psql -v conn_id=1 -f 02_worker_no_cursor.sql
+psql -f 03_collect_stats.sql
+
+# Test 4: With cursor, vacuum enabled — single worker
+psql -f 01_setup_with_vacuum.sql
+bash 04_worker_cursor.sh 1
+psql -f 03_collect_stats.sql
+
+# Test 5: No cursor, vacuum disabled — 10 concurrent workers
+psql -f 01_setup.sql
+for i in $(seq 1 10); do psql -v conn_id=$i -f 02_worker_no_cursor.sql > /dev/null 2>&1 & done; wait
+psql -f 03_collect_stats.sql
+
+# Test 6: With cursor, vacuum disabled — 10 concurrent workers
+psql -f 01_setup.sql
+for i in $(seq 1 10); do bash 04_worker_cursor.sh $i & done; wait
+psql -f 03_collect_stats.sql
+```
+
+### Expected results (idx_test_records_outdated)
+
+Single worker (50K rows, 10 batches of 5K):
+
+| | No cursor | With cursor |
+|---|---|---|
+| **Vacuum OFF** | idx_tup_read=95K, idx_tup_fetch=50K, **ratio=1.90x** | idx_tup_read=50K, idx_tup_fetch=50K, **ratio=1.00x** |
+| **Vacuum ON** | idx_tup_read=95K, idx_tup_fetch=45K, **ratio=2.11x** | idx_tup_read=50K, idx_tup_fetch=45K, **ratio=1.11x** |
+
+10 concurrent workers (500K rows total):
+
+| | No cursor | With cursor |
+|---|---|---|
+| **Vacuum OFF** | idx_tup_read=1.63M, idx_tup_fetch=500K, **ratio=3.26x** | idx_tup_read=500K, idx_tup_fetch=500K, **ratio=1.00x** |
+| **Vacuum ON** | idx_tup_read=1.82M, idx_tup_fetch=449K, **ratio=4.05x** | idx_tup_read=500K, idx_tup_fetch=449K, **ratio=1.11x** |
+
+Key observations:
+- Vacuum does NOT solve the problem — the no-cursor ratio is worse with vacuum (2.11x vs 1.90x)
+- Concurrency amplifies the problem (1.90x → 3.26x) due to kill flag eviction from buffer cache
+- The cursor fix eliminates dead tuple re-scanning regardless of vacuum or concurrency


### PR DESCRIPTION
Add reproducible test suite demonstrating how deleteOutdatedRecords and deleteRecords batch loops re-scan dead index tuples when vacuum can't keep up, causing tup_returned to diverge from tup_fetched and amplifying IO under concurrency.

Includes a proposed fix using (sync_job_id, id) cursor to resume scanning from last position, eliminating dead tuple re-scanning (ratio drops from 3.26x to 1.0x with 10 concurrent workers).

<!-- Describe the problem and your solution --> 

<!-- Issue ticket number and link (if applicable) -->

<!-- Testing instructions (skip if just adding/editing providers) -->

