### PR TITLE
fix(oauth): resolve flat dot-notation keys in token url interpolation

### DIFF
--- a/packages/shared/lib/utils/utils.ts
+++ b/packages/shared/lib/utils/utils.ts
@@ -291,7 +291,11 @@ export function interpolateStringFromObject(str: string, replacers: Record<strin
         if (b === 'endpoint') {
             return (replacers['endpoint'] as string | undefined) ?? '';
         }
-        const r = b.split('.').reduce((o: Record<string, any>, i: string) => o[i], replacers);
+        const r =
+            b
+                .split('.')
+                .reduce((o: Record<string, any> | undefined, i: string) => (o != null ? o[i] : undefined), replacers as Record<string, any> | undefined) ??
+            replacers[b];
         return typeof r === 'string' || typeof r === 'number' ? (r as string) : a;
     });
     return interpolated;

--- a/packages/shared/lib/utils/utils.ts
+++ b/packages/shared/lib/utils/utils.ts
@@ -291,6 +291,8 @@ export function interpolateStringFromObject(str: string, replacers: Record<strin
         if (b === 'endpoint') {
             return (replacers['endpoint'] as string | undefined) ?? '';
         }
+        // try dot-notation path first, fall back to a flat key lookup
+        // for callers that pass top-level keys containing literal dots in their name.
         const r =
             b
                 .split('.')

--- a/packages/shared/lib/utils/utils.unit.test.ts
+++ b/packages/shared/lib/utils/utils.unit.test.ts
@@ -353,9 +353,9 @@ describe('interpolateStringFromObject', () => {
     });
 
     it('resolves flat dot-notation keys (e.g. from webhook_response_metadata)', () => {
-        // getConnectionMetadata extracts dot-notation keys from the webhook payload and stores them
+        // getConnectionMetadata extracts dot-notation keys from the payload and stores them
         // as flat keys with a literal dot in the name, e.g.: webhook_response_metadata: ['installation.uuid']
-        // The template url ${connectionConfig.installation.uuid} needs to resolve
+        // The template url ${connectionConfig.installation.uuid} (token or authorization) needs to resolve
         // 'installation.uuid' as a flat key lookup when nested traversal finds nothing.
         const replacers = { 'installation.uuid': 'a87e0eb2-4fb3-4965-9580-6f5bb9ccc5de' };
         const input = 'https://sentry.io/api/0/sentry-app-installations/${installation.uuid}/authorizations/';

--- a/packages/shared/lib/utils/utils.unit.test.ts
+++ b/packages/shared/lib/utils/utils.unit.test.ts
@@ -351,6 +351,31 @@ describe('interpolateStringFromObject', () => {
         const output = utils.interpolateStringFromObject(input, {});
         expect(output).toBe('Path: ');
     });
+
+    it('resolves flat dot-notation keys (e.g. from webhook_response_metadata)', () => {
+        // getConnectionMetadata extracts dot-notation keys from the webhook payload and stores them
+        // as flat keys with a literal dot in the name, e.g.: webhook_response_metadata: ['installation.uuid']
+        // The template url ${connectionConfig.installation.uuid} needs to resolve
+        // 'installation.uuid' as a flat key lookup when nested traversal finds nothing.
+        const replacers = { 'installation.uuid': 'a87e0eb2-4fb3-4965-9580-6f5bb9ccc5de' };
+        const input = 'https://sentry.io/api/0/sentry-app-installations/${installation.uuid}/authorizations/';
+        const output = utils.interpolateStringFromObject(input, replacers);
+        expect(output).toBe('https://sentry.io/api/0/sentry-app-installations/a87e0eb2-4fb3-4965-9580-6f5bb9ccc5de/authorizations/');
+    });
+
+    it('prefers nested traversal over flat key when both exist', () => {
+        const replacers = {
+            'installation.uuid': 'flat-value',
+            installation: { uuid: 'nested-value' }
+        };
+        const output = utils.interpolateStringFromObject('${installation.uuid}', replacers);
+        expect(output).toBe('nested-value');
+    });
+
+    it('leaves placeholder unchanged when key is missing entirely', () => {
+        const output = utils.interpolateStringFromObject('${missing.key}', {});
+        expect(output).toBe('${missing.key}');
+    });
 });
 
 describe('interpolateObjectValues', () => {


### PR DESCRIPTION
## Describe the problem and your solution

- Resolve flat dot-notation keys in token url interpolation. This change relates to the Sentry public installation flow, which uses webhooks for token exchange. The installation UUID is stored in the connection config as `{ "installation.uuid": string }` and is required to generate the token URL `${connectionConfig.installation.uuid}`.


<!-- Issue ticket number and link (if applicable) -->

<!-- Testing instructions (skip if just adding/editing providers) -->


<!-- Summary by @propel-code-bot -->

---

It also adds unit tests to cover flat-key interpolation, precedence between nested and flat keys, and missing-key behavior.

---
*This summary was automatically generated by @propel-code-bot*