### PR TITLE
fix(records): do not overwrite json if hash is identical

### DIFF
--- a/packages/records/lib/models/records.integration.test.ts
+++ b/packages/records/lib/models/records.integration.test.ts
@@ -8,6 +8,7 @@ import { db } from '../db/client.js';
 import { migrate } from '../db/migrate.js';
 import { formatRecords } from '../helpers/format.js';
 import * as Records from '../models/records.js';
+import { decryptRecordData } from '../utils/encryption.js';
 
 import type { FormattedRecord, UnencryptedRecordData, UpsertSummary } from '../types.js';
 import type { MergingStrategy, Result } from '@nangohq/types';
@@ -104,11 +105,14 @@ describe('Records service', () => {
         expect(stats[model]?.count).toBe(4);
         expect(stats[model]?.size_bytes).toBe(556);
 
-        const after = await db.select<FormattedRecord[]>('*').from('nango_records.records').where({ connection_id: connectionId, model });
-        expect(after.find((r) => r.external_id === '1')?.sync_job_id).toBe(2);
-        expect(after.find((r) => r.external_id === '2')?.sync_job_id).toBe(2);
-        expect(after.find((r) => r.external_id === '3')?.sync_job_id).toBe(1);
-        expect(after.find((r) => r.external_id === '4')?.sync_job_id).toBe(1);
+        await expect(fromDb(connectionId, model, '1')).resolves.toMatchObject({ external_id: '1', sync_job_id: 2, decrypted: { id: '1', name: 'John Doe' } });
+        await expect(fromDb(connectionId, model, '2')).resolves.toMatchObject({
+            external_id: '2',
+            sync_job_id: 2,
+            decrypted: { id: '2', name: 'Jane Much Longer Name Doe' }
+        });
+        await expect(fromDb(connectionId, model, '3')).resolves.toMatchObject({ external_id: '3', sync_job_id: 1, decrypted: { id: '3', name: 'Max Doe' } });
+        await expect(fromDb(connectionId, model, '4')).resolves.toMatchObject({ external_id: '4', sync_job_id: 1, decrypted: { id: '4', name: 'Mike Doe' } });
 
         const updated = await updateRecords({ records: [{ id: '1', name: 'Maurice Doe' }], connectionId, environmentId, model, syncId, syncJobId: 3 });
         expect(updated).toStrictEqual({
@@ -165,11 +169,26 @@ describe('Records service', () => {
                     nextMerging: { strategy: 'override' }
                 });
 
-                const after = await db.select<FormattedRecord[]>('*').from('nango_records.records').where({ connection_id: connectionId, model });
-                expect(after.find((r) => r.external_id === '1')?.sync_job_id).toBe(2);
-                expect(after.find((r) => r.external_id === '2')?.sync_job_id).toBe(2);
-                expect(after.find((r) => r.external_id === '3')?.sync_job_id).toBe(1);
-                expect(after.find((r) => r.external_id === '4')?.sync_job_id).toBe(1);
+                await expect(fromDb(connectionId, model, '1')).resolves.toMatchObject({
+                    external_id: '1',
+                    sync_job_id: 2,
+                    decrypted: { id: '1', name: 'John Doe' }
+                });
+                await expect(fromDb(connectionId, model, '2')).resolves.toMatchObject({
+                    external_id: '2',
+                    sync_job_id: 2,
+                    decrypted: { id: '2', name: 'Jane Moe' }
+                });
+                await expect(fromDb(connectionId, model, '3')).resolves.toMatchObject({
+                    external_id: '3',
+                    sync_job_id: 1,
+                    decrypted: { id: '3', name: 'Max Doe' }
+                });
+                await expect(fromDb(connectionId, model, '4')).resolves.toMatchObject({
+                    external_id: '4',
+                    sync_job_id: 1,
+                    decrypted: { id: '4', name: 'Mike Doe' }
+                });
             });
             it('when strategy = ignore_if_modified_after_cursor', async () => {
                 const connectionId = rnd.number();
@@ -1723,6 +1742,25 @@ async function updateRecords({
         throw new Error(`Failed to update records: ${updateRes.error.message}`);
     }
     return updateRes.value;
+}
+async function fromDb(
+    connectionId: number,
+    model: string,
+    externalId: string
+): Promise<{ external_id: string; sync_job_id: number; decrypted: UnencryptedRecordData }> {
+    const row = await db
+        .select<FormattedRecord[]>('*')
+        .from('nango_records.records')
+        .where({ connection_id: connectionId, model, external_id: externalId })
+        .first();
+    if (!row) {
+        throw new Error(`Record with external_id ${externalId} not found`);
+    }
+    return {
+        external_id: row.external_id,
+        sync_job_id: row.sync_job_id,
+        decrypted: await decryptRecordData(row)
+    };
 }
 
 const rnd = {

--- a/packages/records/lib/models/records.ts
+++ b/packages/records/lib/models/records.ts
@@ -36,8 +36,7 @@ interface UpsertResult {
     id: string;
     last_modified_at: string;
     previous_last_modified_at: string | null;
-    size_bytes: number;
-    previous_size_bytes: number | null;
+    delta_size_bytes: number;
     status: 'inserted' | 'changed' | 'undeleted' | 'deleted' | 'unchanged';
 }
 
@@ -374,7 +373,16 @@ export async function upsert({
                                         trx.raw('tableoid::regclass as partition')
                                     ])
                                     .onConflict(['connection_id', 'external_id', 'model'])
-                                    .merge();
+                                    .merge({
+                                        json: trx.raw(
+                                            `CASE WHEN ${RECORDS_TABLE}.data_hash IS NOT DISTINCT FROM EXCLUDED.data_hash THEN ${RECORDS_TABLE}.json ELSE EXCLUDED.json END`
+                                        ),
+                                        data_hash: trx.raw(`EXCLUDED.data_hash`),
+                                        sync_id: trx.raw(`EXCLUDED.sync_id`),
+                                        sync_job_id: trx.raw(`EXCLUDED.sync_job_id`),
+                                        deleted_at: trx.raw(`EXCLUDED.deleted_at`),
+                                        ...(softDelete ? { updated_at: trx.raw(`EXCLUDED.updated_at`) } : {})
+                                    });
                                 if (merging.strategy === 'ignore_if_modified_after_cursor' && merging.cursor) {
                                     const cursor = Cursor.from(merging.cursor);
                                     if (cursor) {
@@ -388,8 +396,7 @@ export async function upsert({
                                     upsert.id as id,
                                     upsert.external_id as external_id,
                                     to_json(upsert.updated_at) as last_modified_at,
-                                    upsert.size_bytes as size_bytes,
-                                    existing.size_bytes as previous_size_bytes,
+                                    upsert.size_bytes - COALESCE(existing.size_bytes, 0) as delta_size_bytes,
                                     CASE
                                       WHEN existing.updated_at IS NULL THEN NULL
                                       ELSE to_json(existing.updated_at)
@@ -456,7 +463,7 @@ export async function upsert({
                                 };
                             }
                         }
-                        deltaSizeInBytes += res.reduce((acc, r) => acc + (r.size_bytes - (r.previous_size_bytes || 0)), 0);
+                        deltaSizeInBytes += res.reduce((acc, r) => acc + r.delta_size_bytes, 0);
 
                         // all records for the same connection/model are in the same partition
                         if (!partition && res[0]?.partition) {


### PR DESCRIPTION
pg is smart enough to only copy the toast pointer when updating a toasted value with the old tuple data

ex:
```
EXPLAIN (ANALYSE, BUFFERS) INSERT INTO toast_test (id, small_col, big_col)
VALUES (1, 'b', repeat('x', 100000))
ON CONFLICT (id)
DO UPDATE SET
    big_col   = toast_test.big_col -- old data
;

Insert on toast_test  (cost=0.00..0.01 rows=0 width=0) (actual time=0.803..0.810 rows=0 loops=1)
  ...
  Buffers: shared hit=4 dirtied=1
  ...
```

vs updating with the new identical data

```
EXPLAIN (ANALYSE, BUFFERS) INSERT INTO toast_test (id, small_col, big_col)
VALUES (1, 'a', repeat('x', 100000))
ON CONFLICT (id)
DO UPDATE SET
    big_col   = EXCLUDED.big_col; -- new value
;   
Insert on toast_test  (cost=0.00..0.01 rows=0 width=0) (actual time=2.173..2.174 rows=0 loops=1)
  ...
  Buffers: shared hit=264 dirtied=13
  ...

```

Note: we cannot prevent the creation of a new tuple for each record because column like sync_job_id are always updated. This commit is only an optimization that doesn't require to change the design of Nango records features

<!-- Describe the problem and your solution --> 

<!-- Issue ticket number and link (if applicable) -->

<!-- Testing instructions (skip if just adding/editing providers) -->


<!-- Summary by @propel-code-bot -->

---

**Skip JSON overwrite on identical record hashes and update size delta tracking**

This PR adjusts `records` upsert behavior to avoid rewriting `json` when the incoming `data_hash` matches the stored value, reducing unnecessary TOAST writes. It also changes upsert result handling to compute and propagate `delta_size_bytes` for size accounting, and updates integration tests to assert decrypted payloads from the database via a new helper.

---
*This summary was automatically generated by @propel-code-bot*