### PR TITLE
fix(runner): add Redis-based abort polling for multi-replica runners

### DIFF
--- a/packages/runner/lib/server.ts
+++ b/packages/runner/lib/server.ts
@@ -7,10 +7,10 @@ import superjson from 'superjson';
 
 import { abort } from './abort.js';
 import { jobsClient } from './clients/jobs.js';
-import { heartbeatIntervalMs } from './env.js';
+import { abortCheckIntervalMs, heartbeatIntervalMs } from './env.js';
 import { exec } from './exec.js';
 import { logger } from './logger.js';
-import { abortControllers, locks, usage } from './state.js';
+import { abortControllers, abortViaRedis, kvStore, locks, usage } from './state.js';
 
 import type { NangoProps } from '@nangohq/types';
 import type { NextFunction, Request, Response } from 'express';
@@ -73,6 +73,22 @@ function startProcedure() {
                     ? arg.input.nangoProps.heartbeatTimeoutSecs * 1000
                     : heartbeatIntervalMs * 3;
 
+                // Poll Redis for abort flag when running with multiple replicas
+                const abortPoll = abortViaRedis
+                    ? setInterval(async () => {
+                          try {
+                              const shouldAbort = await kvStore.exists(`function:${taskId}:abort`);
+                              if (shouldAbort) {
+                                  logger.info('Aborting task via Redis poll', { taskId });
+                                  abortController.abort();
+                                  clearInterval(abortPoll!);
+                              }
+                          } catch (err) {
+                              logger.error('Error checking abort flag', { taskId, error: err });
+                          }
+                      }, abortCheckIntervalMs)
+                    : null;
+
                 const heartbeat = setInterval(async () => {
                     if (lastSuccessHeartbeatAt && lastSuccessHeartbeatAt + heartbeatTimeoutMs < Date.now()) {
                         // Jobs and orchestrator will kill the task if the heartbeat is not successful for too long
@@ -109,6 +125,9 @@ function startProcedure() {
                     });
                 } finally {
                     clearInterval(heartbeat);
+                    if (abortPoll) {
+                        clearInterval(abortPoll);
+                    }
                     abortControllers.delete(taskId);
                     await usage.untrack(taskId);
                     logger.info(`Task ${taskId} completed`);

--- a/packages/runner/lib/state.ts
+++ b/packages/runner/lib/state.ts
@@ -8,17 +8,19 @@ import type { KVStore } from '@nangohq/kvstore';
 
 export const abortControllers = new Map<string, AbortController>();
 
-let conflictTracker: KVStore;
+export const abortViaRedis = envs.RUNNER_CONFLICT_RESOLUTION_MODE === 'REDIS';
 
+let kvStoreInstance: KVStore;
 if (envs.RUNNER_CONFLICT_RESOLUTION_MODE === 'REDIS') {
-    conflictTracker = await getKVStore('customer');
+    kvStoreInstance = await getKVStore('customer');
 } else {
-    conflictTracker = new InMemoryKVStore();
+    kvStoreInstance = new InMemoryKVStore();
 }
+export const kvStore = kvStoreInstance;
 export const usage = new RunnerMonitor({
     runnerId: envs.RUNNER_NODE_ID,
     conflictTracking: {
-        tracker: conflictTracker
+        tracker: kvStoreInstance
     }
 });
 export const locks = new MapLocks();


### PR DESCRIPTION
When runners have replicas > 1, pods sit behind a K8s Service that load-balances requests. The HTTP-based tRPC abort call may hit the wrong pod, leaving the task running. This adds Redis polling for the abort flag (already set by Jobs) when RUNNER_CONFLICT_RESOLUTION_MODE is REDIS, matching the existing lambda-runner pattern.

<!-- Describe the problem and your solution --> 

<!-- Issue ticket number and link (if applicable) -->

<!-- Testing instructions (skip if just adding/editing providers) -->


<!-- Summary by @propel-code-bot -->

---

It also centralizes the KV store instance and exposes flags to control abort polling in the runner server.

---
*This summary was automatically generated by @propel-code-bot*