### PR TITLE
fix: Fix not being able to see some templates

### DIFF
--- a/packages/server/lib/controllers/v1/integrations/providerConfigKey/flows/getFlows.integration.test.ts
+++ b/packages/server/lib/controllers/v1/integrations/providerConfigKey/flows/getFlows.integration.test.ts
@@ -1,6 +1,6 @@
-import { afterAll, beforeAll, describe, expect, it } from 'vitest';
+import { afterAll, beforeAll, describe, expect, it, vi } from 'vitest';
 
-import { seeders } from '@nangohq/shared';
+import { flowService, seeders } from '@nangohq/shared';
 
 import { isError, isSuccess, runServer, shouldBeProtected, shouldRequireQueryEnv } from '../../../../../utils/tests.js';
 
@@ -123,5 +123,77 @@ describe(`GET ${route}`, () => {
         // Should not dedup the sync with the same endpoint path
         const scriptListFile = res.json.data.flows.find((value) => value.name === 'list-files');
         expect(scriptListFile).not.toBeUndefined();
+    });
+
+    it('should keep renamed templates visible when an older sync with the same model name exists', async () => {
+        const getAllAvailableFlowsAsStandardConfigSpy = vi.spyOn(flowService, 'getAllAvailableFlowsAsStandardConfig').mockReturnValue([
+            {
+                providerConfigKey: 'hubspot',
+                actions: [],
+                syncs: [
+                    seeders.getTestStdSyncConfig({
+                        name: 'sync-users',
+                        type: 'sync',
+                        returns: ['User'],
+                        description: 'Sync provisioned users',
+                        auto_start: true,
+                        sync_type: 'full',
+                        version: '1.0.0',
+                        enabled: false,
+                        is_public: true,
+                        pre_built: true,
+                        endpoints: [{ group: 'Users', method: 'GET', path: '/syncs/sync-users' }],
+                        runs: 'every hour'
+                    })
+                ],
+                ['on-events']: []
+            }
+        ]);
+
+        try {
+            const { env, secret } = await seeders.seedAccountEnvAndUser();
+            const config = await seeders.createConfigSeed(env, 'hubspot', 'hubspot');
+            const connection = await seeders.createConnectionSeed({ env, provider: 'hubspot' });
+
+            await seeders.createSyncSeeds({
+                connectionId: connection.id,
+                environment_id: env.id,
+                nango_config_id: config.id!,
+                sync_name: 'users',
+                type: 'sync',
+                models: ['User'],
+                endpoints: [{ group: 'Users', method: 'GET', path: '/users' }]
+            });
+
+            const res = await api.fetch(route, {
+                method: 'GET',
+                query: { env: 'dev' },
+                params: { providerConfigKey: 'hubspot' },
+                token: secret.secret
+            });
+
+            expect(res.res.status).toBe(200);
+            isSuccess(res.json);
+
+            const oldFlow = res.json.data.flows.find((value) => value.name === 'users');
+            const newTemplate = res.json.data.flows.find((value) => value.name === 'sync-users');
+
+            expect(oldFlow).toMatchObject({
+                name: 'users',
+                returns: ['User'],
+                type: 'sync'
+            });
+            expect(newTemplate).not.toBeUndefined();
+            expect(newTemplate).toMatchObject({
+                enabled: false,
+                is_public: true,
+                name: 'sync-users',
+                pre_built: true,
+                returns: ['User'],
+                type: 'sync'
+            });
+        } finally {
+            getAllAvailableFlowsAsStandardConfigSpy.mockRestore();
+        }
     });
 });

--- a/packages/server/lib/controllers/v1/integrations/providerConfigKey/flows/getFlows.ts
+++ b/packages/server/lib/controllers/v1/integrations/providerConfigKey/flows/getFlows.ts
@@ -70,13 +70,8 @@ function containsSameEndpoint(flowA: NangoSyncConfig, flowB: NangoSyncConfig) {
 }
 
 function hasSimilarFlow(templateFlow: NangoSyncConfig, list: NangoSyncConfig[]): NangoSyncConfig | false {
-    const modelsName = new Set<string>(templateFlow.returns.map((model) => model));
-
     for (const flow of list) {
         if (flow.type === templateFlow.type && flow.name === templateFlow.name) {
-            return flow;
-        }
-        if (flow.type === 'sync' && templateFlow.type === 'sync' && flow.returns.find((model) => modelsName.has(model))) {
             return flow;
         }
         if (containsSameEndpoint(flow, templateFlow)) {


### PR DESCRIPTION
<!-- Describe the problem and your solution --> 
Robin noticed that when he had a `hubspot/users` sync previously deployed (and disabled now), the new `hubspot/sync-users` template wasn't even available to turn on. This was the case for a few other syncs too.

The reason for that is we are filtering templates that sync models with the same name as any other previously deployed sync. Since syncs can't influence models from other syncs, this doesn't seem to make sense.
<!-- Issue ticket number and link (if applicable) -->

<!-- Testing instructions (skip if just adding/editing providers) -->


<!-- Summary by @propel-code-bot -->

---

This PR updates flow template deduplication so templates are no longer filtered out solely due to sharing model names with previously deployed syncs, and adds an integration test to ensure renamed templates remain visible when legacy syncs exist.

---
*This summary was automatically generated by @propel-code-bot*