### PR TITLE
fix(providers): correct Conta Azul scope separator

### DIFF
--- a/packages/providers/providers.yaml
+++ b/packages/providers/providers.yaml
@@ -4143,7 +4143,7 @@ conta-azul:
         grant_type: authorization_code
     refresh_params:
         grant_type: refresh_token
-    scope_separator: '+'
+    scope_separator: ' '
     proxy:
         base_url: https://api-v2.contaazul.com
     disable_pkce: true


### PR DESCRIPTION
## Summary

- Fix the Conta Azul provider `scope_separator` from `+` to a space character (` `)
- The `+` separator caused scopes to be encoded as `%2B` in the authorization URL, which Conta Azul rejects
- The confusion arose because `+` is a valid encoding for spaces in `application/x-www-form-urlencoded` contexts (e.g. HTML form submissions), but OAuth authorization URLs use standard percent-encoding where spaces must be `%20`, not `%2B`

<!-- Summary by @propel-code-bot -->

---

This PR updates the Conta Azul provider configuration to use a space character as the `scope_separator` instead of `+`. This aligns scope encoding with standard OAuth URL percent-encoding so scopes are separated by `%20` rather than `%2B`.

---
*This summary was automatically generated by @propel-code-bot*