### PR TITLE
perf(records): avoid pg_column_size on unchanged records during upsert

### DIFF
--- a/packages/records/lib/models/records.ts
+++ b/packages/records/lib/models/records.ts
@@ -32,11 +32,12 @@ dayjs.extend(utc);
 const BATCH_SIZE = envs.RECORDS_BATCH_SIZE;
 
 interface UpsertResult {
+    partition: string;
     external_id: string;
     id: string;
     last_modified_at: string;
     previous_last_modified_at: string | null;
-    delta_size_bytes: number;
+    previous_size_bytes: number;
     status: 'inserted' | 'changed' | 'undeleted' | 'deleted' | 'unchanged';
 }
 
@@ -340,38 +341,37 @@ export async function upsert({
                         const chunk = recordsWithoutDuplicates.slice(i, i + BATCH_SIZE);
                         const encryptedRecords = encryptRecords(chunk);
 
-                        // we need to know which records were updated, deleted, undeleted or unchanged
-                        // we achieve this by comparing the records data_hash and deleted_at fields before and after the update
-                        const externalIds = chunk.map((r) => r.external_id);
                         const res = await trx
+                            .with(
+                                'incoming',
+                                trx.raw(
+                                    `SELECT * FROM (VALUES ${chunk.map(() => '(?, ?)').join(', ')}) AS t(external_id, data_hash)`,
+                                    chunk.flatMap((r) => [r.external_id, r.data_hash])
+                                )
+                            )
                             .with('existing', (qb) => {
                                 qb.select(
-                                    'external_id',
-                                    'data_hash',
-                                    'deleted_at',
-                                    'updated_at',
-                                    trx.raw('pg_column_size(json) as size_bytes'),
-                                    trx.raw('tableoid::regclass as partition')
+                                    `${RECORDS_TABLE}.external_id`,
+                                    `${RECORDS_TABLE}.deleted_at`,
+                                    `${RECORDS_TABLE}.updated_at`,
+                                    trx.raw(`
+                                        CASE
+                                            WHEN incoming.data_hash IS DISTINCT FROM ${RECORDS_TABLE}.data_hash THEN pg_column_size(json)
+                                            ELSE 0
+                                        END as previous_size_bytes
+                                    `),
+                                    trx.raw(`incoming.data_hash IS DISTINCT FROM ${RECORDS_TABLE}.data_hash as has_changed`)
                                 )
                                     .from(RECORDS_TABLE)
                                     .where({
                                         connection_id: connectionId,
                                         model
                                     })
-                                    .whereIn('external_id', externalIds);
+                                    .join('incoming', 'incoming.external_id', `${RECORDS_TABLE}.external_id`);
                             })
                             .with('upsert', (qb) => {
                                 qb.insert(encryptedRecords)
                                     .into(RECORDS_TABLE)
-                                    .returning([
-                                        'id',
-                                        'external_id',
-                                        'data_hash',
-                                        'deleted_at',
-                                        'updated_at',
-                                        trx.raw('pg_column_size(json) as size_bytes'),
-                                        trx.raw('tableoid::regclass as partition')
-                                    ])
                                     .onConflict(['connection_id', 'external_id', 'model'])
                                     .merge({
                                         json: trx.raw(
@@ -382,7 +382,8 @@ export async function upsert({
                                         sync_job_id: trx.raw(`EXCLUDED.sync_job_id`),
                                         deleted_at: trx.raw(`EXCLUDED.deleted_at`),
                                         ...(softDelete ? { updated_at: trx.raw(`EXCLUDED.updated_at`) } : {})
-                                    });
+                                    })
+                                    .returning(['id', 'external_id', 'updated_at', 'deleted_at', trx.raw('tableoid::regclass as partition')]);
                                 if (merging.strategy === 'ignore_if_modified_after_cursor' && merging.cursor) {
                                     const cursor = Cursor.from(merging.cursor);
                                     if (cursor) {
@@ -390,13 +391,13 @@ export async function upsert({
                                     }
                                 }
                             })
-                            .select<(UpsertResult & { partition: string })[]>(
+                            .select<UpsertResult[]>(
                                 trx.raw(`
-                                    coalesce(upsert.partition, existing.partition) as partition,
+                                    upsert.partition as partition,
                                     upsert.id as id,
                                     upsert.external_id as external_id,
                                     to_json(upsert.updated_at) as last_modified_at,
-                                    upsert.size_bytes - COALESCE(existing.size_bytes, 0) as delta_size_bytes,
+                                    COALESCE(existing.previous_size_bytes, 0) as previous_size_bytes,
                                     CASE
                                       WHEN existing.updated_at IS NULL THEN NULL
                                       ELSE to_json(existing.updated_at)
@@ -407,17 +408,35 @@ export async function upsert({
                                             CASE
                                                 WHEN existing.deleted_at IS NOT NULL AND upsert.deleted_at IS NULL THEN 'undeleted'
                                                 WHEN existing.deleted_at IS NULL AND upsert.deleted_at IS NOT NULL THEN 'deleted'
-                                                WHEN existing.data_hash <> upsert.data_hash THEN 'changed'
+                                                WHEN existing.has_changed THEN 'changed'
                                                 ELSE 'unchanged'
                                             END
                                     END as status`)
                             )
                             .from('upsert')
-                            .leftJoin('existing', 'upsert.external_id', 'existing.external_id')
+                            .leftJoin('existing', 'existing.external_id', 'upsert.external_id')
                             .orderBy([
                                 { column: 'upsert.updated_at', order: 'asc' },
                                 { column: 'upsert.id', order: 'asc' }
                             ]);
+
+                        // Fetch post-upsert json sizes for inserted/changed records to compute delta_size_bytes.
+                        // BUT only for records that have actually changed (based on data_hash comparison)
+                        // to avoid unnecessary pg_column_size calls since they can be costly on large json payloads.
+                        // This must be a separate query since data-modifying CTEs use snapshot isolation.
+                        // Returning the delta from 'upsert' would be possible with Postgres17 since it supports old/new syntax but we are currently using Postgres16.
+                        const toSize = res.filter((r) => r.status === 'inserted' || r.status === 'changed').map((r) => r.external_id);
+                        const newSize = new Map<string, number>();
+                        if (toSize.length > 0) {
+                            const sizeRows = await trx
+                                .select<{ external_id: string; size_bytes: number }[]>('external_id', trx.raw('pg_column_size(json) as size_bytes'))
+                                .from(RECORDS_TABLE)
+                                .where({ connection_id: connectionId, model })
+                                .whereIn('external_id', toSize);
+                            for (const row of sizeRows) {
+                                newSize.set(row.external_id, row.size_bytes);
+                            }
+                        }
 
                         // Billing:
                         // A record is billed only once per month. ie:
@@ -463,7 +482,9 @@ export async function upsert({
                                 };
                             }
                         }
-                        deltaSizeInBytes += res.reduce((acc, r) => acc + r.delta_size_bytes, 0);
+                        deltaSizeInBytes += res.reduce((acc, r) => {
+                            return acc + (newSize.get(r.external_id) ?? 0) - r.previous_size_bytes;
+                        }, 0);
 
                         // all records for the same connection/model are in the same partition
                         if (!partition && res[0]?.partition) {


### PR DESCRIPTION
Since #5700, json is no longer overwritten when the data_hash is identical. 
However, pg_column_size(json) was still being computed for all records in both the existing and upsert CTEs, including unchanged records where the delta is always 0.

The fix pre-computes has_changed in CTE query so that previous_size_bytes is only computed for records whose json actually changed. Post-upsert sizes are then fetched in a separate query limited to inserted/changed records only. A separate query is required because we don't want to use pg_column_size in upsert CTE RETURNING clause where it would be applied to all rows. We cannot get the new size after the upsert CTE because of PG snapshot isolation. This will be avoidable with Postgres 17's RETURNING OLD/NEW syntax.

<!-- Describe the problem and your solution --> 

<!-- Issue ticket number and link (if applicable) -->

<!-- Testing instructions (skip if just adding/editing providers) -->


<!-- Summary by @propel-code-bot -->

---

It also recalculates deltaSizeInBytes based on the newly fetched size map for inserted or changed records.

---
*This summary was automatically generated by @propel-code-bot*