### PR TITLE
feat: expose checkpoints in sync completion webhooks

### DIFF
--- a/packages/jobs/lib/execution/sync.ts
+++ b/packages/jobs/lib/execution/sync.ts
@@ -464,7 +464,8 @@ export async function handleSyncSuccess({
                                     updated,
                                     deleted
                                 },
-                                operation: lastSyncDate ? SyncJobsType.INCREMENTAL : SyncJobsType.FULL
+                                operation: lastSyncDate ? SyncJobsType.INCREMENTAL : SyncJobsType.FULL,
+                                checkpoints
                             });
 
                             if (res.isErr()) {
@@ -942,7 +943,8 @@ async function onFailure({
                             ...(error.additional_properties ? { additional_properties: error.additional_properties } : {})
                         },
                         now: lastSyncDate,
-                        operation: lastSyncDate ? SyncJobsType.INCREMENTAL : SyncJobsType.FULL
+                        operation: lastSyncDate ? SyncJobsType.INCREMENTAL : SyncJobsType.FULL,
+                        checkpoints
                     });
 
                     if (res.isErr()) {

--- a/packages/jobs/lib/execution/webhook.ts
+++ b/packages/jobs/lib/execution/webhook.ts
@@ -315,7 +315,8 @@ export async function handleWebhookSuccess({
                         now: nangoProps.startedAt,
                         success: true,
                         responseResults: syncJob.result?.[model] || { added: 0, updated: 0, deleted: 0 },
-                        operation: 'WEBHOOK'
+                        operation: 'WEBHOOK',
+                        checkpoints
                     });
 
                     if (res.isErr()) {
@@ -494,7 +495,8 @@ async function onFailure({
                                 description: error.message
                             },
                             now: new Date(),
-                            operation: 'WEBHOOK'
+                            operation: 'WEBHOOK',
+                            checkpoints
                         });
 
                         if (res.isErr()) {

--- a/packages/types/lib/webhooks/api.ts
+++ b/packages/types/lib/webhooks/api.ts
@@ -1,6 +1,7 @@
 import type { AsyncActionResponse } from '../action/api.js';
 import type { ErrorPayload, SyncErrorPayload } from '../api.js';
 import type { AuthModeType, AuthOperationType } from '../auth/api.js';
+import type { CheckpointRange } from '../checkpoint/types.js';
 import type { SyncResult } from '../sync/index.js';
 
 export type WebhookTypes = 'sync' | 'auth' | 'forward' | 'async_action';
@@ -21,6 +22,7 @@ export interface NangoSyncWebhookBodyBase extends NangoWebhookBase {
     syncName: string;
     syncVariant: string;
     model: string;
+    checkpoints?: CheckpointRange | undefined;
     /** @deprecated **/
     syncType: 'INCREMENTAL' | 'INITIAL' | 'WEBHOOK';
 }

--- a/packages/webhooks/lib/sync.ts
+++ b/packages/webhooks/lib/sync.ts
@@ -7,6 +7,7 @@ import { Ok, metrics } from '@nangohq/utils';
 import { deliver, shouldSend } from './utils.js';
 
 import type {
+    CheckpointRange,
     ConnectionJobs,
     DBAPISecret,
     DBEnvironment,
@@ -38,7 +39,8 @@ export const sendSync = async ({
     responseResults,
     success,
     operation,
-    error
+    error,
+    checkpoints
 }: {
     connection: ConnectionJobs;
     environment: Pick<DBEnvironment, 'id' | 'name'>;
@@ -54,6 +56,7 @@ export const sendSync = async ({
     error?: SyncErrorPayload;
     responseResults?: SyncResult;
     success: boolean;
+    checkpoints?: CheckpointRange | undefined;
 } & ({ success: true; responseResults: SyncResult } | { success: false; error: SyncErrorPayload })): Promise<Result<void>> => {
     if (!webhookSettings) {
         return Ok(undefined);
@@ -87,7 +90,8 @@ export const sendSync = async ({
         /** @deprecated.
         For backward compatibility reason we are sending the syncType as INITIAL instead of FULL
         **/
-        syncType: operation === 'FULL' ? 'INITIAL' : operation
+        syncType: operation === 'FULL' ? 'INITIAL' : operation,
+        ...(checkpoints ? { checkpoints } : {})
     };
     let finalBody: NangoSyncWebhookBody;
 


### PR DESCRIPTION
Adding checkpoints to the sync completion webhook. We were showing the checkpoints in the operation logs but it can be useful for customer to have access to this info in the webhook payload

ex:
```
{
  "checkpoints": {
    "from": {
      "isoDate": "2026-03-25T17:12:16.111Z"
    },
    "to": {
      "isoDate": "2026-03-25T19:42:55.597Z"
    }
  },
  "connectionId": "unauth",
  "from": "nango",
  "model": "TaxItem",
  "modifiedAfter": "2026-03-25T19:42:49.717Z",
  "providerConfigKey": "unauthenticated",
  "queryTimeStamp": "2026-03-25T19:42:49.717Z",
  "responseResults": {
    "added": 1,
    "deleted": 1,
    "updated": 5
  },
  "success": true,
  "syncName": "syncA",
  "syncType": "INCREMENTAL",
  "syncVariant": "base",
  "type": "sync"
}
```

<!-- Summary by @propel-code-bot -->

---

This also updates the webhook sender and sync/webhook execution flow to pass checkpoints when available, keeping backward compatibility by only including the field when defined.

---
*This summary was automatically generated by @propel-code-bot*