### PR TITLE
chore: move authz types to shared package

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -4805,6 +4805,10 @@
             "resolved": "packages/account-usage",
             "link": true
         },
+        "node_modules/@nangohq/authz": {
+            "resolved": "packages/authz",
+            "link": true
+        },
         "node_modules/@nangohq/billing": {
             "resolved": "packages/billing",
             "link": true
@@ -24020,6 +24024,7 @@
             "os": [
                 "android"
             ],
+            "peer": true,
             "engines": {
                 "node": ">= 12.0.0"
             },
@@ -24041,6 +24046,7 @@
             "os": [
                 "darwin"
             ],
+            "peer": true,
             "engines": {
                 "node": ">= 12.0.0"
             },
@@ -24062,6 +24068,7 @@
             "os": [
                 "darwin"
             ],
+            "peer": true,
             "engines": {
                 "node": ">= 12.0.0"
             },
@@ -24083,6 +24090,7 @@
             "os": [
                 "freebsd"
             ],
+            "peer": true,
             "engines": {
                 "node": ">= 12.0.0"
             },
@@ -24104,6 +24112,7 @@
             "os": [
                 "linux"
             ],
+            "peer": true,
             "engines": {
                 "node": ">= 12.0.0"
             },
@@ -24125,6 +24134,7 @@
             "os": [
                 "linux"
             ],
+            "peer": true,
             "engines": {
                 "node": ">= 12.0.0"
             },
@@ -24146,6 +24156,7 @@
             "os": [
                 "linux"
             ],
+            "peer": true,
             "engines": {
                 "node": ">= 12.0.0"
             },
@@ -24167,6 +24178,7 @@
             "os": [
                 "linux"
             ],
+            "peer": true,
             "engines": {
                 "node": ">= 12.0.0"
             },
@@ -24188,6 +24200,7 @@
             "os": [
                 "linux"
             ],
+            "peer": true,
             "engines": {
                 "node": ">= 12.0.0"
             },
@@ -24209,6 +24222,7 @@
             "os": [
                 "win32"
             ],
+            "peer": true,
             "engines": {
                 "node": ">= 12.0.0"
             },
@@ -24230,6 +24244,7 @@
             "os": [
                 "win32"
             ],
+            "peer": true,
             "engines": {
                 "node": ">= 12.0.0"
             },
@@ -33171,6 +33186,14 @@
                 "url": "https://github.com/sponsors/colinhacks"
             }
         },
+        "packages/authz": {
+            "name": "@nangohq/authz",
+            "version": "1.0.0",
+            "license": "SEE LICENSE IN LICENSE FILE IN GIT REPOSITORY",
+            "dependencies": {
+                "@nangohq/types": "file:../types"
+            }
+        },
         "packages/billing": {
             "name": "@nangohq/billing",
             "version": "1.0.0",
@@ -34749,6 +34772,7 @@
             "dependencies": {
                 "@modelcontextprotocol/sdk": "1.26.0",
                 "@nangohq/account-usage": "file:../account-usage",
+                "@nangohq/authz": "file:../authz",
                 "@nangohq/billing": "file:../billing",
                 "@nangohq/database": "file:../database",
                 "@nangohq/email": "file:../email",
@@ -35116,6 +35140,7 @@
                 "@hookform/resolvers": "5.2.2",
                 "@mantine/core": "7.12.1",
                 "@mantine/prism": "5.10.5",
+                "@nangohq/authz": "file:../authz",
                 "@nangohq/frontend": "0.69.46",
                 "@nangohq/types": "file:../types",
                 "@radix-ui/react-accordion": "1.2.2",

--- a/packages/authz/lib/index.ts
+++ b/packages/authz/lib/index.ts
@@ -1,0 +1,1 @@
+export * from './permissions.js';

--- a/packages/authz/lib/permissions.ts
+++ b/packages/authz/lib/permissions.ts
@@ -1,4 +1,4 @@
-import type { Permission } from './types.js';
+import type { Permission } from '@nangohq/types';
 
 export const permissions = {
     // team management (global scope)

--- a/packages/authz/package.json
+++ b/packages/authz/package.json
@@ -1,0 +1,23 @@
+{
+    "name": "@nangohq/authz",
+    "version": "1.0.0",
+    "description": "Authorization permissions for Nango",
+    "type": "module",
+    "main": "./dist/index.js",
+    "typings": "./dist/index.d.ts",
+    "private": true,
+    "scripts": {},
+    "keywords": [],
+    "repository": {
+        "type": "git",
+        "url": "git+https://github.com/NangoHQ/nango.git",
+        "directory": "packages/authz"
+    },
+    "license": "SEE LICENSE IN LICENSE FILE IN GIT REPOSITORY",
+    "dependencies": {
+        "@nangohq/types": "file:../types"
+    },
+    "files": [
+        "dist/**/*"
+    ]
+}

--- a/packages/authz/tsconfig.json
+++ b/packages/authz/tsconfig.json
@@ -1,0 +1,13 @@
+{
+    "extends": "../../tsconfig.json",
+    "compilerOptions": {
+        "rootDir": "lib",
+        "outDir": "dist"
+    },
+    "references": [
+        {
+            "path": "../types"
+        }
+    ],
+    "include": ["lib/**/*"]
+}

--- a/packages/server/lib/authz/deny-map.ts
+++ b/packages/server/lib/authz/deny-map.ts
@@ -1,7 +1,6 @@
-import { permissions as p } from './permissions.js';
+import { permissions as p } from '@nangohq/authz';
 
-import type { Permission } from './types.js';
-import type { Role } from '@nangohq/types';
+import type { Permission, Role } from '@nangohq/types';
 
 const ADMIN_ONLY: Permission[] = [
     p.canManageTeam,

--- a/packages/server/lib/authz/evaluator.ts
+++ b/packages/server/lib/authz/evaluator.ts
@@ -1,7 +1,6 @@
 import { ROLE_DENY_MAP } from './deny-map.js';
 
-import type { Action, Permission, PermissionEvaluator, Resource, Scope } from './types.js';
-import type { Role } from '@nangohq/types';
+import type { Action, Permission, PermissionEvaluator, Resource, Role, Scope } from '@nangohq/types';
 
 function matchesAction(rule: Action, actual: Action): boolean {
     return rule === '*' || rule === actual;

--- a/packages/server/lib/authz/evaluator.unit.test.ts
+++ b/packages/server/lib/authz/evaluator.unit.test.ts
@@ -2,7 +2,7 @@ import { describe, expect, it } from 'vitest';
 
 import { StaticEvaluator } from './evaluator.js';
 
-import type { Permission } from './types.js';
+import type { Permission } from '@nangohq/types';
 
 const evaluator = new StaticEvaluator();
 

--- a/packages/server/lib/authz/middleware.ts
+++ b/packages/server/lib/authz/middleware.ts
@@ -2,8 +2,8 @@ import { flags } from '@nangohq/utils';
 
 import { evaluator } from './evaluator.js';
 
-import type { Permission, Scope } from './types.js';
 import type { RequestLocals } from '../utils/express.js';
+import type { Permission, Scope } from '@nangohq/types';
 import type { RequestHandler } from 'express';
 
 export const envScope = (l: RequestLocals): Scope => (l.environment?.is_production ? 'production' : 'non-production');

--- a/packages/server/lib/authz/resolve.ts
+++ b/packages/server/lib/authz/resolve.ts
@@ -1,10 +1,9 @@
+import { permissions } from '@nangohq/authz';
 import { flags } from '@nangohq/utils';
 
 import { evaluator } from './evaluator.js';
-import { permissions } from './permissions.js';
 
-import type { Permission } from './types.js';
-import type { AllowedPermissions, Role } from '@nangohq/types';
+import type { AllowedPermissions, Permission, Role } from '@nangohq/types';
 
 /**
  * Resolve a permission for the current request.

--- a/packages/server/lib/controllers/v1/connections/connectionId/getConnection.ts
+++ b/packages/server/lib/controllers/v1/connections/connectionId/getConnection.ts
@@ -1,10 +1,10 @@
 import * as z from 'zod';
 
+import { permissions } from '@nangohq/authz';
 import { logContextGetter } from '@nangohq/logs';
 import { configService, connectionService, errorNotificationService, refreshOrTestCredentials } from '@nangohq/shared';
 import { requireEmptyBody, zodErrorToHTTP } from '@nangohq/utils';
 
-import { permissions } from '../../../../authz/permissions.js';
 import { resolve } from '../../../../authz/resolve.js';
 import { connectionFullToApi } from '../../../../formatters/connection.js';
 import { endUserToApi } from '../../../../formatters/endUser.js';

--- a/packages/server/lib/controllers/v1/environment/getEnvironment.ts
+++ b/packages/server/lib/controllers/v1/environment/getEnvironment.ts
@@ -1,3 +1,4 @@
+import { permissions } from '@nangohq/authz';
 import {
     accountService,
     connectionService,
@@ -9,7 +10,6 @@ import {
 } from '@nangohq/shared';
 import { isCloud, requireEmptyQuery, zodErrorToHTTP } from '@nangohq/utils';
 
-import { permissions } from '../../../authz/permissions.js';
 import { resolve } from '../../../authz/resolve.js';
 import { envs } from '../../../env.js';
 import { environmentToApi } from '../../../formatters/environment.js';

--- a/packages/server/lib/controllers/v1/environment/patchEnvironment.ts
+++ b/packages/server/lib/controllers/v1/environment/patchEnvironment.ts
@@ -1,9 +1,9 @@
 import * as z from 'zod';
 
+import { permissions } from '@nangohq/authz';
 import { PROD_ENVIRONMENT_NAME, environmentService } from '@nangohq/shared';
 import { flagHasPlan, requireEmptyQuery, zodErrorToHTTP } from '@nangohq/utils';
 
-import { permissions } from '../../../authz/permissions.js';
 import { resolve } from '../../../authz/resolve.js';
 import { environmentToApi } from '../../../formatters/environment.js';
 import { envSchema } from '../../../helpers/validation.js';

--- a/packages/server/lib/controllers/v1/integrations/getIntegrations.ts
+++ b/packages/server/lib/controllers/v1/integrations/getIntegrations.ts
@@ -1,7 +1,7 @@
+import { permissions } from '@nangohq/authz';
 import { configService, countSyncConfigByConfigId, getProvider } from '@nangohq/shared';
 import { requireEmptyQuery, zodErrorToHTTP } from '@nangohq/utils';
 
-import { permissions } from '../../../authz/permissions.js';
 import { resolve } from '../../../authz/resolve.js';
 import { integrationToApi } from '../../../formatters/integration.js';
 import { asyncWrapper } from '../../../utils/asyncWrapper.js';

--- a/packages/server/lib/controllers/v1/integrations/providerConfigKey/getIntegration.ts
+++ b/packages/server/lib/controllers/v1/integrations/providerConfigKey/getIntegration.ts
@@ -2,10 +2,10 @@ import crypto from 'node:crypto';
 
 import * as z from 'zod';
 
+import { permissions } from '@nangohq/authz';
 import { configService, connectionService, getGlobalWebhookReceiveUrl, getProvider } from '@nangohq/shared';
 import { requireEmptyQuery, zodErrorToHTTP } from '@nangohq/utils';
 
-import { permissions } from '../../../../authz/permissions.js';
 import { resolve } from '../../../../authz/resolve.js';
 import { integrationToApi } from '../../../../formatters/integration.js';
 import { providerConfigKeySchema } from '../../../../helpers/validation.js';

--- a/packages/server/lib/routes.private.ts
+++ b/packages/server/lib/routes.private.ts
@@ -3,10 +3,10 @@ import cors from 'cors';
 import express from 'express';
 import passport from 'passport';
 
+import { permissions as p } from '@nangohq/authz';
 import { basePublicUrl, baseUrl, flagHasAuth, flagHasManagedAuth, flagHasUsage, isBasicAuthEnabled, isCloud, isEnterprise, isTest } from '@nangohq/utils';
 
 import { can, envScope } from './authz/middleware.js';
-import { permissions as p } from './authz/permissions.js';
 import { setupAuth } from './clients/auth.client.js';
 import connectionController from './controllers/connection.controller.js';
 import environmentController from './controllers/environment.controller.js';

--- a/packages/server/package.json
+++ b/packages/server/package.json
@@ -20,6 +20,7 @@
     "license": "SEE LICENSE IN LICENSE FILE IN GIT REPOSITORY",
     "dependencies": {
         "@modelcontextprotocol/sdk": "1.26.0",
+        "@nangohq/authz": "file:../authz",
         "@nangohq/account-usage": "file:../account-usage",
         "@nangohq/billing": "file:../billing",
         "@nangohq/database": "file:../database",

--- a/packages/server/tsconfig.json
+++ b/packages/server/tsconfig.json
@@ -6,6 +6,9 @@
     },
     "references": [
         {
+            "path": "../authz"
+        },
+        {
             "path": "../database"
         },
         {

--- a/packages/types/lib/authz/types.ts
+++ b/packages/types/lib/authz/types.ts
@@ -1,4 +1,4 @@
-import type { Role } from '@nangohq/types';
+import type { Role } from '../user/db.js';
 
 export type Action = 'create' | 'read' | 'update' | 'delete' | '*';
 export type Resource =

--- a/packages/types/lib/index.ts
+++ b/packages/types/lib/index.ts
@@ -96,3 +96,5 @@ export type * from './checkpoint/types.js';
 export type * from './checkpoint/db.js';
 
 export type * from './mcp/api.js';
+
+export type * from './authz/types.js';

--- a/packages/webapp/package.json
+++ b/packages/webapp/package.json
@@ -28,6 +28,7 @@
         "@hookform/resolvers": "5.2.2",
         "@mantine/core": "7.12.1",
         "@mantine/prism": "5.10.5",
+        "@nangohq/authz": "file:../authz",
         "@nangohq/frontend": "0.69.46",
         "@nangohq/types": "file:../types",
         "@radix-ui/react-accordion": "1.2.2",


### PR DESCRIPTION
Proposal to move authz types to the types package. Moves `permissions` to a new `authz` package.

The `authz` package is very small containing only the permission definitions (for now at least).


Q: why not moving `permissions` to `shared` or `utils`?
A: because they are not imported by the frontend, for good reasons (they are heavy on backend specific stuff).

Lmk if you have better ideas.

<!-- Summary by @propel-code-bot -->

---

It also updates server imports to consume the new authz package and wires the new package into TypeScript project references and package dependencies across the server and webapp.

---
*This summary was automatically generated by @propel-code-bot*