### PR TITLE
fix(auth): handle expired OAuth code in SSO callback gracefully

### DIFF
--- a/packages/server/lib/controllers/v1/account/managed/getCallback.ts
+++ b/packages/server/lib/controllers/v1/account/managed/getCallback.ts
@@ -45,10 +45,23 @@ export const getManagedCallback = asyncWrapper<GetManagedCallback>(async (req, r
     const workos = getWorkOSClient();
 
     // Check the request against WorkOS
-    const { user: authorizedUser, organizationId } = await workos.userManagement.authenticateWithCode({
-        clientId: process.env['WORKOS_CLIENT_ID'] || '',
-        code: query.code
-    });
+    let authorizedUser;
+    let organizationId;
+    try {
+        const authResponse = await workos.userManagement.authenticateWithCode({
+            clientId: process.env['WORKOS_CLIENT_ID'] || '',
+            code: query.code
+        });
+        authorizedUser = authResponse.user;
+        organizationId = authResponse.organizationId;
+    } catch (err) {
+        const isInvalidGrant = err instanceof Error && (err as { error?: string }).error === 'invalid_grant';
+        if (isInvalidGrant) {
+            res.redirect(`${basePublicUrl}/signin?error=sso_session_expired`);
+            return;
+        }
+        throw err;
+    }
 
     // Parse optional state that can contains invitation
     const state = parseState(query.state || '');

--- a/packages/server/lib/controllers/v1/account/managed/getCallback.ts
+++ b/packages/server/lib/controllers/v1/account/managed/getCallback.ts
@@ -49,7 +49,7 @@ export const getManagedCallback = asyncWrapper<GetManagedCallback>(async (req, r
     let organizationId;
     try {
         const authResponse = await workos.userManagement.authenticateWithCode({
-            clientId: process.env['WORKOS_CLIENT_ID'] || '',
+            clientId: envs.WORKOS_CLIENT_ID || '',
             code: query.code
         });
         authorizedUser = authResponse.user;

--- a/packages/webapp/src/pages/Account/Signin.tsx
+++ b/packages/webapp/src/pages/Account/Signin.tsx
@@ -1,9 +1,9 @@
 import { zodResolver } from '@hookform/resolvers/zod';
 import { CircleX, ExternalLink, Loader2, TriangleAlert } from 'lucide-react';
-import { useState } from 'react';
+import { useEffect, useState } from 'react';
 import { Helmet } from 'react-helmet';
 import { useForm } from 'react-hook-form';
-import { useNavigate } from 'react-router-dom';
+import { useNavigate, useSearchParams } from 'react-router-dom';
 import z from 'zod';
 
 import GoogleButton from '@/components/ui/button/Auth/Google';
@@ -34,8 +34,24 @@ export const Signin: React.FC = () => {
     const navigate = useNavigate();
     const { toast } = useToast();
 
-    const [errorMessage, setServerErrorMessage] = useState('');
+    const [searchParams, setSearchParams] = useSearchParams();
+    const ssoError = searchParams.get('error');
+
+    const [errorMessage, setServerErrorMessage] = useState(() => {
+        if (ssoError === 'sso_session_expired') {
+            return 'Your SSO session has expired. Please try again.';
+        }
+        return '';
+    });
     const [showResendEmail, setShowResendEmail] = useState(false);
+
+    // Clear the error query param so it doesn't persist on refresh
+    useEffect(() => {
+        if (ssoError) {
+            searchParams.delete('error');
+            setSearchParams(searchParams, { replace: true });
+        }
+    }, []); // eslint-disable-line react-hooks/exhaustive-deps
 
     const form = useForm<SigninFormData>({
         resolver: zodResolver(signinSchema),

--- a/packages/webapp/src/pages/Account/Signin.tsx
+++ b/packages/webapp/src/pages/Account/Signin.tsx
@@ -35,7 +35,7 @@ export const Signin: React.FC = () => {
     const { toast } = useToast();
 
     const [searchParams, setSearchParams] = useSearchParams();
-    const ssoError = searchParams.get('error');
+    const error = searchParams.get('error');
 
     const [errorMessage, setServerErrorMessage] = useState(() => {
         if (ssoError === 'sso_session_expired') {

--- a/packages/webapp/src/pages/Account/Signin.tsx
+++ b/packages/webapp/src/pages/Account/Signin.tsx
@@ -39,7 +39,7 @@ export const Signin: React.FC = () => {
 
     const [errorMessage, setServerErrorMessage] = useState(() => {
         if (ssoError === 'sso_session_expired') {
-            return 'Your SSO session has expired. Please try again.';
+            return 'Your SSO session has expired or is invalid. Please try again.';
         }
         return '';
     });

--- a/packages/webapp/src/pages/Account/Signin.tsx
+++ b/packages/webapp/src/pages/Account/Signin.tsx
@@ -38,7 +38,7 @@ export const Signin: React.FC = () => {
     const error = searchParams.get('error');
 
     const [errorMessage, setServerErrorMessage] = useState(() => {
-        if (ssoError === 'sso_session_expired') {
+        if (error === 'sso_session_expired') {
             return 'Your SSO session has expired or is invalid. Please try again.';
         }
         return '';
@@ -47,7 +47,7 @@ export const Signin: React.FC = () => {
 
     // Clear the error query param so it doesn't persist on refresh
     useEffect(() => {
-        if (ssoError) {
+        if (error) {
             searchParams.delete('error');
             setSearchParams(searchParams, { replace: true });
         }


### PR DESCRIPTION
When WorkOS returns an invalid_grant error (expired/invalid OAuth code), redirect users to the signin page with a friendly error message instead of showing raw JSON in the browser.

Example of the message that will be displayed to the user

<img width="1512" height="627" alt="Screenshot 2026-03-26 at 11 46 06" src="https://github.com/user-attachments/assets/c152761e-2424-4e10-a2bf-b05da9d53f45" />

Users that might take too long to finish the flow, we have a few, will have the chance to start over the flow.

For invalid tokens - not expired -  the expectation is that this should happen only bc of bugs at workos side, but if we have concerns on swallowing issues in that specific area we can create a specific monitor which checks that we still have a healthy number of 200s


<!-- Describe the problem and your solution --> 

<!-- Issue ticket number and link (if applicable) -->

<!-- Testing instructions (skip if just adding/editing providers) -->


<!-- Summary by @propel-code-bot -->

---

It also routes the failure through a sign-in error flag and ensures the sign-in page consumes that error parameter and clears it after display so the message does not persist on refresh.

---
*This summary was automatically generated by @propel-code-bot*