### PR TITLE
fix(lambda): added test-invocation schema

### DIFF
--- a/packages/jobs/lib/runner/lambda.ts
+++ b/packages/jobs/lib/runner/lambda.ts
@@ -10,6 +10,7 @@ import {
     CreateAliasCommand,
     CreateFunctionCommand,
     DeleteFunctionCommand,
+    InvokeCommand,
     LambdaClient,
     PublishVersionCommand,
     PutFunctionEventInvokeConfigCommand,
@@ -156,6 +157,22 @@ class Lambda {
                         }
                     })
                 );
+                const command = new InvokeCommand({
+                    FunctionName: aResult.AliasArn,
+                    Payload: JSON.stringify({
+                        type: 'readiness_check'
+                    }),
+                    InvocationType: 'RequestResponse'
+                });
+                const response = await lambdaClient.send(command);
+                if (response.FunctionError) {
+                    logger.error(`Error invoking readiness check function ${aResult.AliasArn}`, response.FunctionError);
+                    return;
+                }
+                if (response.StatusCode !== 200) {
+                    logger.error(`Readiness check function ${aResult.AliasArn} returned status code ${response.StatusCode}`, response);
+                    return;
+                }
                 const fleetId = node.fleetId || envs.RUNNER_LAMBDA_FLEET_ID;
                 const result = await registerWithFleet(fleetId, {
                     nodeId: node.id,

--- a/packages/lambda-runner/lib/index.ts
+++ b/packages/lambda-runner/lib/index.ts
@@ -7,12 +7,12 @@ import { KVLocks, abortCheckIntervalMs, exec, heartbeatIntervalMs, jobsClient } 
 import { loadProviders } from '@nangohq/shared';
 import { getLogger } from '@nangohq/utils';
 
-import { requestSchema } from './schemas.js';
+import { lambdaInvocationSchema } from './schemas.js';
 
+import type { LambdaInvocation, ReadinessCheckRequest, TaskRequest } from './schemas.js';
 import type { Lock, Locking } from '@nangohq/kvstore';
 import type { NangoProps } from '@nangohq/types';
 import type { Context } from 'aws-lambda';
-import type * as zod from 'zod';
 
 const logger = getLogger('lambda-function-runner');
 const s3 = new S3Client();
@@ -52,7 +52,11 @@ function getNangoHost() {
     return process.env['NANGO_HOST'] || 'http://server.internal.nango';
 }
 
-async function getCode(request: zod.infer<typeof requestSchema>): Promise<string> {
+function isReadinessCheckRequest(request: LambdaInvocation): request is ReadinessCheckRequest {
+    return 'type' in request && request.type === 'readiness_check';
+}
+
+async function getCode(request: TaskRequest): Promise<string> {
     if ('code' in request && request.code) {
         return request.code;
     }
@@ -70,7 +74,7 @@ async function getCode(request: zod.infer<typeof requestSchema>): Promise<string
     return '';
 }
 
-async function deleteCodeParams(request: zod.infer<typeof requestSchema>): Promise<void> {
+async function deleteCodeParams(request: TaskRequest): Promise<void> {
     try {
         if ('codeParamsRef' in request && request.codeParamsRef) {
             await s3.send(
@@ -86,7 +90,7 @@ async function deleteCodeParams(request: zod.infer<typeof requestSchema>): Promi
     }
 }
 
-async function getCodeParams(request: zod.infer<typeof requestSchema>): Promise<object> {
+async function getCodeParams(request: TaskRequest): Promise<object> {
     if ('codeParams' in request && request.codeParams) {
         return request.codeParams;
     }
@@ -105,9 +109,15 @@ async function getCodeParams(request: zod.infer<typeof requestSchema>): Promise<
     return {};
 }
 
-export const handler = async (event: zod.infer<typeof requestSchema>, context: Context) => {
+export const handler = async (event: unknown, context: Context): Promise<{ ok: true } | void> => {
     context.callbackWaitsForEmptyEventLoop = false;
-    const request = requestSchema.parse(event);
+    const parsedRequest = lambdaInvocationSchema.parse(event);
+    if (isReadinessCheckRequest(parsedRequest)) {
+        logger.info('Readiness check invocation received');
+        return { ok: true };
+    }
+    const request: TaskRequest = parsedRequest;
+
     const nangoProps = { ...(request.nangoProps as unknown as NangoProps) };
     const locking = await getLocking('customer');
     const gate = new Gate(locking);

--- a/packages/lambda-runner/lib/index.ts
+++ b/packages/lambda-runner/lib/index.ts
@@ -9,7 +9,7 @@ import { getLogger } from '@nangohq/utils';
 
 import { lambdaInvocationSchema } from './schemas.js';
 
-import type { LambdaInvocation, ReadinessCheckRequest, TaskRequest } from './schemas.js';
+import type { FunctionExecutionRequest, LambdaInvocation, ReadinessCheckRequest } from './schemas.js';
 import type { Lock, Locking } from '@nangohq/kvstore';
 import type { NangoProps } from '@nangohq/types';
 import type { Context } from 'aws-lambda';
@@ -56,7 +56,7 @@ function isReadinessCheckRequest(request: LambdaInvocation): request is Readines
     return 'type' in request && request.type === 'readiness_check';
 }
 
-async function getCode(request: TaskRequest): Promise<string> {
+async function getCode(request: FunctionExecutionRequest): Promise<string> {
     if ('code' in request && request.code) {
         return request.code;
     }
@@ -74,7 +74,7 @@ async function getCode(request: TaskRequest): Promise<string> {
     return '';
 }
 
-async function deleteCodeParams(request: TaskRequest): Promise<void> {
+async function deleteCodeParams(request: FunctionExecutionRequest): Promise<void> {
     try {
         if ('codeParamsRef' in request && request.codeParamsRef) {
             await s3.send(
@@ -90,7 +90,7 @@ async function deleteCodeParams(request: TaskRequest): Promise<void> {
     }
 }
 
-async function getCodeParams(request: TaskRequest): Promise<object> {
+async function getCodeParams(request: FunctionExecutionRequest): Promise<object> {
     if ('codeParams' in request && request.codeParams) {
         return request.codeParams;
     }
@@ -116,7 +116,7 @@ export const handler = async (event: unknown, context: Context): Promise<{ ok: t
         logger.info('Readiness check invocation received');
         return { ok: true };
     }
-    const request: TaskRequest = parsedRequest;
+    const request: FunctionExecutionRequest = parsedRequest;
 
     const nangoProps = { ...(request.nangoProps as unknown as NangoProps) };
     const locking = await getLocking('customer');

--- a/packages/lambda-runner/lib/schemas.ts
+++ b/packages/lambda-runner/lib/schemas.ts
@@ -104,7 +104,7 @@ const refCodeSchema = z.object({
     codeParamsRef: s3RefSchema.optional()
 });
 
-export const requestSchema = z
+export const functionExecutionSchema = z
     .object({
         taskId: z.string(),
         nangoProps: nangoPropsSchema
@@ -115,8 +115,8 @@ export const readinessCheckSchema = z.object({
     type: z.literal('readiness_check')
 });
 
-export const lambdaInvocationSchema = z.union([requestSchema, readinessCheckSchema]);
+export const lambdaInvocationSchema = z.union([functionExecutionSchema, readinessCheckSchema]);
 
-export type TaskRequest = z.infer<typeof requestSchema>;
+export type FunctionExecutionRequest = z.infer<typeof functionExecutionSchema>;
 export type ReadinessCheckRequest = z.infer<typeof readinessCheckSchema>;
 export type LambdaInvocation = z.infer<typeof lambdaInvocationSchema>;

--- a/packages/lambda-runner/lib/schemas.ts
+++ b/packages/lambda-runner/lib/schemas.ts
@@ -110,3 +110,13 @@ export const requestSchema = z
         nangoProps: nangoPropsSchema
     })
     .and(z.union([inlineCodeSchema, refCodeSchema]));
+
+export const readinessCheckSchema = z.object({
+    type: z.literal('readiness_check')
+});
+
+export const lambdaInvocationSchema = z.union([requestSchema, readinessCheckSchema]);
+
+export type TaskRequest = z.infer<typeof requestSchema>;
+export type ReadinessCheckRequest = z.infer<typeof readinessCheckSchema>;
+export type LambdaInvocation = z.infer<typeof lambdaInvocationSchema>;


### PR DESCRIPTION
<!-- Describe the problem and your solution --> 

<!-- Issue ticket number and link (if applicable) -->

<!-- Testing instructions (skip if just adding/editing providers) -->


<!-- Summary by @propel-code-bot -->

---

**Add Lambda readiness-check invocation schema and handling**

This PR introduces a readiness-check invocation type for the Lambda runner by expanding the schema to include a `readiness_check` request and updating the handler to short-circuit these events with an `{ ok: true }` response. It also adds a readiness-check invocation after alias creation in the Lambda job runner to validate new functions before registering them with the fleet.

---
*This summary was automatically generated by @propel-code-bot*