### PR TITLE
docs: Add free vs. paid self-hosted table

### DIFF
--- a/docs/guides/platform/free-self-hosting/configuration.mdx
+++ b/docs/guides/platform/free-self-hosting/configuration.mdx
@@ -20,7 +20,7 @@ description: 'Instructions & configuration options for self-hosting Nango.'
 | SAML SSO | No | Yes |
 | Support SLA | No | Yes |
 
-For more details see our [pricing page for Nango Cloud](https://nango.dev/pricing) or [schedule a call](https://nango.dev/demo) to discuss the [Enterprise self-hosted](guides/platform/self-hosting) version.
+For more details see our [pricing page for Nango Cloud](https://nango.dev/pricing) or [schedule a call](https://nango.dev/demo) to discuss the [Enterprise self-hosted](/guides/platform/self-hosting) version.
 
 
 ## Server URL, Callback URL & Custom Domains[](#custom-urls 'Direct link to Server URL, Callback URL & Custom Domains')

--- a/docs/guides/platform/free-self-hosting/configuration.mdx
+++ b/docs/guides/platform/free-self-hosting/configuration.mdx
@@ -4,6 +4,25 @@ sidebarTitle: 'Configuration'
 description: 'Instructions & configuration options for self-hosting Nango.'
 ---
 
+## Free self-hosted vs. Enterprise self-hosted feature availability
+
+| Feature | Free self-hosted | Enterprise self-hosted / Nango Cloud |
+| --- | --- | --- |
+| Auth | Yes | Yes |
+| Proxy | Yes | Yes |
+| Observability | Auth + proxy only | Full |
+| OpenTelemetry (OTel) export | No | Yes |
+| Functions (syncs, actions, triggers) | No | Yes |
+| Webhooks | No | Yes |
+| MCP server | No | Yes |
+| Customize auth branding | No | Yes |
+| Role-based permissions | No | Yes |
+| SAML SSO | No | Yes |
+| Support SLA | No | Yes |
+
+For more details see our [pricing page for Nango Cloud](https://nango.dev/pricing) or [schedule a call](https://nango.dev/demo) to discuss the [Enterprise self-hosted](guides/platform/self-hosting) version.
+
+
 ## Server URL, Callback URL & Custom Domains[](#custom-urls 'Direct link to Server URL, Callback URL & Custom Domains')
 
 Add server environment variables for the instance URL and port (in the `.env`


### PR DESCRIPTION
<!-- Summary by @propel-code-bot -->

**Add free vs. enterprise self-hosted comparison table to configuration docs**

This PR updates documentation by inserting a comparison table of feature availability between free self-hosted and enterprise self-hosted/Nango Cloud options at the top of the configuration guide. It also adds links to pricing and demo resources near the new table.

---
*This summary was automatically generated by @propel-code-bot*