### PR TITLE
feat(webapp): RBAC UI

### DIFF
--- a/packages/webapp/src/App.tsx
+++ b/packages/webapp/src/App.tsx
@@ -7,6 +7,7 @@ import { useLocalStorage } from 'react-use';
 import { Toaster } from 'sonner';
 import { SWRConfig } from 'swr';
 
+import { PermissionRoute } from './components/PermissionRoute';
 import { PrivateRoute } from './components/PrivateRoute';
 import { useMeta } from './hooks/useMeta';
 import { useUser } from './hooks/useUser';
@@ -207,14 +208,19 @@ const router = sentryCreateBrowserRouter([
                         handle: { breadcrumb: 'Team settings' } as BreadcrumbHandle
                     },
                     {
-                        path: 'team/billing',
-                        element: <TeamBilling />,
-                        handle: { breadcrumb: 'Billing' } as BreadcrumbHandle
-                    },
-                    {
                         path: 'user-settings',
                         element: <UserSettings />,
                         handle: { breadcrumb: 'User settings' } as BreadcrumbHandle
+                    },
+                    {
+                        element: <PermissionRoute action="*" scope="global" resource="billing" />,
+                        children: [
+                            {
+                                path: 'team/billing',
+                                element: <TeamBilling />,
+                                handle: { breadcrumb: 'Team billing' } as BreadcrumbHandle
+                            }
+                        ]
                     }
                 ]
             }

--- a/packages/webapp/src/components-v2/AppSidebar/EnvironmentDropdown.tsx
+++ b/packages/webapp/src/components-v2/AppSidebar/EnvironmentDropdown.tsx
@@ -12,6 +12,7 @@ import { Tooltip, TooltipContent, TooltipTrigger } from '../ui/tooltip.js';
 import { LogoInverted } from '@/assets/LogoInverted';
 import { useEnvironment } from '@/hooks/useEnvironment';
 import { useMeta } from '@/hooks/useMeta';
+import { permissions } from '@/hooks/usePermissions.js';
 import { useStore } from '@/store';
 
 export const EnvironmentDropdown: React.FC = () => {
@@ -72,11 +73,7 @@ export const EnvironmentDropdown: React.FC = () => {
                     <DropdownMenuContent align="start" side="bottom" className="w-50 max-h-96 flex flex-col gap-2">
                         <div className="flex flex-col">
                             {meta?.environments.map((environment) => (
-                                <PermissionGate
-                                    key={environment.name}
-                                    bypass={!environment.is_production}
-                                    permission={{ action: 'read', resource: 'environment', scope: 'production' }}
-                                >
+                                <PermissionGate key={environment.name} bypass={!environment.is_production} permission={permissions.canAccessProdEnvironment}>
                                     {(allowed) => (
                                         <DropdownMenuItem
                                             disabled={!allowed}
@@ -94,7 +91,7 @@ export const EnvironmentDropdown: React.FC = () => {
                                 </PermissionGate>
                             ))}
                         </div>
-                        <PermissionGate permission={{ action: 'create', resource: 'environment', scope: 'global' }}>
+                        <PermissionGate permission={permissions.canCreateEnvironment}>
                             {(allowed) =>
                                 allowed ? (
                                     <Tooltip delayDuration={0}>

--- a/packages/webapp/src/components-v2/AppSidebar/EnvironmentDropdown.tsx
+++ b/packages/webapp/src/components-v2/AppSidebar/EnvironmentDropdown.tsx
@@ -4,15 +4,15 @@ import { useNavigate } from 'react-router-dom';
 
 import { StyledLink } from '../StyledLink.js';
 import { CreateEnvironmentDialog } from './CreateEnvironmentDialog.js';
+import { ConditionalTooltip } from '../ConditionalTooltip.js';
 import { PermissionGate } from '../PermissionGate.js';
 import { Button } from '../ui/button.js';
 import { DropdownMenu, DropdownMenuContent, DropdownMenuItem, DropdownMenuTrigger } from '../ui/dropdown-menu.js';
 import { SidebarMenu, SidebarMenuItem } from '../ui/sidebar.js';
-import { Tooltip, TooltipContent, TooltipTrigger } from '../ui/tooltip.js';
 import { LogoInverted } from '@/assets/LogoInverted';
 import { useEnvironment } from '@/hooks/useEnvironment';
 import { useMeta } from '@/hooks/useMeta';
-import { permissions } from '@/hooks/usePermissions.js';
+import { permissions, usePermissions } from '@/hooks/usePermissions.js';
 import { useStore } from '@/store';
 
 export const EnvironmentDropdown: React.FC = () => {
@@ -24,6 +24,9 @@ export const EnvironmentDropdown: React.FC = () => {
     const { data: metaData } = useMeta();
     const meta = metaData?.data;
     const [environmentDialogOpen, setEnvironmentDialogOpen] = useState(false);
+
+    const { can } = usePermissions();
+    const canCreateEnvironment = can(permissions.canCreateEnvironment);
 
     const navigate = useNavigate();
 
@@ -73,7 +76,12 @@ export const EnvironmentDropdown: React.FC = () => {
                     <DropdownMenuContent align="start" side="bottom" className="w-50 max-h-96 flex flex-col gap-2">
                         <div className="flex flex-col">
                             {meta?.environments.map((environment) => (
-                                <PermissionGate key={environment.name} bypass={!environment.is_production} permission={permissions.canAccessProdEnvironment}>
+                                <PermissionGate
+                                    key={environment.name}
+                                    condition={can(permissions.canAccessProdEnvironment) || !environment.is_production}
+                                    message="Your role does not have access to production environments."
+                                    tooltipSide="right"
+                                >
                                     {(allowed) => (
                                         <DropdownMenuItem
                                             disabled={!allowed}
@@ -91,45 +99,28 @@ export const EnvironmentDropdown: React.FC = () => {
                                 </PermissionGate>
                             ))}
                         </div>
-                        <PermissionGate permission={permissions.canCreateEnvironment}>
-                            {(allowed) =>
-                                allowed ? (
-                                    <Tooltip delayDuration={0}>
-                                        <TooltipTrigger asChild>
-                                            <span tabIndex={0} className="w-full">
-                                                <Button
-                                                    disabled={!!isMaxEnvironmentsReached}
-                                                    variant="primary"
-                                                    onClick={() => {
-                                                        // Managed control because Dialogs within DropdownMenus behave weirdly
-                                                        setEnvironmentDialogOpen(true);
-                                                    }}
-                                                    className="w-full"
-                                                >
-                                                    {!!isMaxEnvironmentsReached && <Lock className="size-4" />}
-                                                    Create Environment
-                                                </Button>
-                                            </span>
-                                        </TooltipTrigger>
-                                        {isMaxEnvironmentsReached && allowed && (
-                                            <TooltipContent side="right" align="center">
-                                                Max number of environments reached.{' '}
-                                                {environment?.plan?.name.includes('legacy') ? (
-                                                    <>Contact Nango to add more</>
-                                                ) : (
-                                                    <>
-                                                        <StyledLink to={`/${env}/team/billing`} className="text-s">
-                                                            Upgrade
-                                                        </StyledLink>{' '}
-                                                        to add more
-                                                    </>
-                                                )}
-                                            </TooltipContent>
-                                        )}
-                                    </Tooltip>
-                                ) : (
+                        <PermissionGate condition={canCreateEnvironment} tooltipSide="right">
+                            {(allowed) => (
+                                <ConditionalTooltip
+                                    condition={!!isMaxEnvironmentsReached}
+                                    content={
+                                        <>
+                                            Max number of environments reached.{' '}
+                                            {environment?.plan?.name.includes('legacy') ? (
+                                                <>Contact Nango to add more</>
+                                            ) : (
+                                                <>
+                                                    <StyledLink to={`/${env}/team/billing`} className="text-s">
+                                                        Upgrade
+                                                    </StyledLink>{' '}
+                                                    to add more
+                                                </>
+                                            )}
+                                        </>
+                                    }
+                                >
                                     <Button
-                                        disabled
+                                        disabled={!!isMaxEnvironmentsReached || !allowed}
                                         variant="primary"
                                         onClick={() => {
                                             // Managed control because Dialogs within DropdownMenus behave weirdly
@@ -137,11 +128,11 @@ export const EnvironmentDropdown: React.FC = () => {
                                         }}
                                         className="w-full"
                                     >
-                                        <Lock className="size-4" />
+                                        {!!isMaxEnvironmentsReached && <Lock />}
                                         Create Environment
                                     </Button>
-                                )
-                            }
+                                </ConditionalTooltip>
+                            )}
                         </PermissionGate>
                     </DropdownMenuContent>
                 </DropdownMenu>

--- a/packages/webapp/src/components-v2/AppSidebar/EnvironmentDropdown.tsx
+++ b/packages/webapp/src/components-v2/AppSidebar/EnvironmentDropdown.tsx
@@ -4,6 +4,7 @@ import { useNavigate } from 'react-router-dom';
 
 import { StyledLink } from '../StyledLink.js';
 import { CreateEnvironmentDialog } from './CreateEnvironmentDialog.js';
+import { PermissionGate } from '../PermissionGate.js';
 import { Button } from '../ui/button.js';
 import { DropdownMenu, DropdownMenuContent, DropdownMenuItem, DropdownMenuTrigger } from '../ui/dropdown-menu.js';
 import { SidebarMenu, SidebarMenuItem } from '../ui/sidebar.js';
@@ -71,53 +72,80 @@ export const EnvironmentDropdown: React.FC = () => {
                     <DropdownMenuContent align="start" side="bottom" className="w-50 max-h-96 flex flex-col gap-2">
                         <div className="flex flex-col">
                             {meta?.environments.map((environment) => (
-                                <DropdownMenuItem
+                                <PermissionGate
                                     key={environment.name}
-                                    onSelect={() => onSelect(environment.name)}
-                                    data-active={env === environment.name}
-                                    className="flex flex-row items-center gap-2 cursor-pointer data-[active=true]:text-text-primary"
+                                    bypass={!environment.is_production}
+                                    permission={{ action: 'read', resource: 'environment', scope: 'production' }}
                                 >
-                                    <Check
-                                        className="w-5 h-5 opacity-0 data-[active=true]:opacity-100 data-[active=true]:text-text-primary"
-                                        data-active={env === environment.name}
-                                    />
-                                    <span>{environment.name}</span>
-                                </DropdownMenuItem>
+                                    {(allowed) => (
+                                        <DropdownMenuItem
+                                            disabled={!allowed}
+                                            onSelect={() => onSelect(environment.name)}
+                                            data-active={env === environment.name}
+                                            className="flex flex-row items-center gap-2 cursor-pointer data-[active=true]:text-text-primary"
+                                        >
+                                            <Check
+                                                className="w-5 h-5 opacity-0 data-[active=true]:opacity-100 data-[active=true]:text-text-primary"
+                                                data-active={env === environment.name}
+                                            />
+                                            <span>{environment.name}</span>
+                                        </DropdownMenuItem>
+                                    )}
+                                </PermissionGate>
                             ))}
                         </div>
-                        <Tooltip delayDuration={0}>
-                            <TooltipTrigger asChild>
-                                <span tabIndex={0} className="w-full">
+                        <PermissionGate permission={{ action: 'create', resource: 'environment', scope: 'global' }}>
+                            {(allowed) =>
+                                allowed ? (
+                                    <Tooltip delayDuration={0}>
+                                        <TooltipTrigger asChild>
+                                            <span tabIndex={0} className="w-full">
+                                                <Button
+                                                    disabled={!!isMaxEnvironmentsReached}
+                                                    variant="primary"
+                                                    onClick={() => {
+                                                        // Managed control because Dialogs within DropdownMenus behave weirdly
+                                                        setEnvironmentDialogOpen(true);
+                                                    }}
+                                                    className="w-full"
+                                                >
+                                                    {!!isMaxEnvironmentsReached && <Lock className="size-4" />}
+                                                    Create Environment
+                                                </Button>
+                                            </span>
+                                        </TooltipTrigger>
+                                        {isMaxEnvironmentsReached && allowed && (
+                                            <TooltipContent side="right" align="center">
+                                                Max number of environments reached.{' '}
+                                                {environment?.plan?.name.includes('legacy') ? (
+                                                    <>Contact Nango to add more</>
+                                                ) : (
+                                                    <>
+                                                        <StyledLink to={`/${env}/team/billing`} className="text-s">
+                                                            Upgrade
+                                                        </StyledLink>{' '}
+                                                        to add more
+                                                    </>
+                                                )}
+                                            </TooltipContent>
+                                        )}
+                                    </Tooltip>
+                                ) : (
                                     <Button
+                                        disabled
                                         variant="primary"
                                         onClick={() => {
                                             // Managed control because Dialogs within DropdownMenus behave weirdly
                                             setEnvironmentDialogOpen(true);
                                         }}
-                                        disabled={!!isMaxEnvironmentsReached}
                                         className="w-full"
                                     >
-                                        {!!isMaxEnvironmentsReached && <Lock className="size-4" />}
+                                        <Lock className="size-4" />
                                         Create Environment
                                     </Button>
-                                </span>
-                            </TooltipTrigger>
-                            {isMaxEnvironmentsReached && (
-                                <TooltipContent side="right" align="center">
-                                    Max number of environments reached.{' '}
-                                    {environment?.plan?.name.includes('legacy') ? (
-                                        <>Contact Nango to add more</>
-                                    ) : (
-                                        <>
-                                            <StyledLink to={`/${env}/team/billing`} className="text-s">
-                                                Upgrade
-                                            </StyledLink>{' '}
-                                            to add more
-                                        </>
-                                    )}
-                                </TooltipContent>
-                            )}
-                        </Tooltip>
+                                )
+                            }
+                        </PermissionGate>
                     </DropdownMenuContent>
                 </DropdownMenu>
                 <CreateEnvironmentDialog open={environmentDialogOpen} onOpenChange={setEnvironmentDialogOpen} />

--- a/packages/webapp/src/components-v2/AppSidebar/EnvironmentDropdown.tsx
+++ b/packages/webapp/src/components-v2/AppSidebar/EnvironmentDropdown.tsx
@@ -2,6 +2,8 @@ import { Check, ChevronsUpDown, Lock } from 'lucide-react';
 import React, { useState } from 'react';
 import { useNavigate } from 'react-router-dom';
 
+import { permissions } from '@nangohq/authz';
+
 import { StyledLink } from '../StyledLink.js';
 import { CreateEnvironmentDialog } from './CreateEnvironmentDialog.js';
 import { ConditionalTooltip } from '../ConditionalTooltip.js';
@@ -12,7 +14,7 @@ import { SidebarMenu, SidebarMenuItem } from '../ui/sidebar.js';
 import { LogoInverted } from '@/assets/LogoInverted';
 import { useEnvironment } from '@/hooks/useEnvironment';
 import { useMeta } from '@/hooks/useMeta';
-import { permissions, usePermissions } from '@/hooks/usePermissions.js';
+import { usePermissions } from '@/hooks/usePermissions.js';
 import { useStore } from '@/store';
 
 export const EnvironmentDropdown: React.FC = () => {

--- a/packages/webapp/src/components-v2/AppSidebar/ProfileDropdown.tsx
+++ b/packages/webapp/src/components-v2/AppSidebar/ProfileDropdown.tsx
@@ -25,7 +25,7 @@ export const ProfileDropdown: React.FC = () => {
     const showGettingStarted = useStore((state) => state.showGettingStarted);
 
     const { can } = usePermissions();
-    const canManageBilling = can(permissions.canManageTeam);
+    const canManageBilling = can(permissions.canManageBilling);
 
     const items = useMemo(() => {
         const list = [

--- a/packages/webapp/src/components-v2/AppSidebar/ProfileDropdown.tsx
+++ b/packages/webapp/src/components-v2/AppSidebar/ProfileDropdown.tsx
@@ -2,10 +2,12 @@ import { ChevronsUpDown, CreditCard, LogOut, Sparkle, UserRoundCog, Users } from
 import { useMemo } from 'react';
 import { useNavigate } from 'react-router-dom';
 
+import { permissions } from '@nangohq/authz';
+
 import { DropdownMenu, DropdownMenuContent, DropdownMenuItem, DropdownMenuTrigger } from '../ui/dropdown-menu';
 import { SidebarMenu, SidebarMenuItem } from '../ui/sidebar';
 import { useMeta } from '@/hooks/useMeta';
-import { permissions, usePermissions } from '@/hooks/usePermissions';
+import { usePermissions } from '@/hooks/usePermissions';
 import { useUser } from '@/hooks/useUser';
 import { useStore } from '@/store';
 import { toAcronym } from '@/utils/avatar';

--- a/packages/webapp/src/components-v2/AppSidebar/ProfileDropdown.tsx
+++ b/packages/webapp/src/components-v2/AppSidebar/ProfileDropdown.tsx
@@ -5,6 +5,7 @@ import { useNavigate } from 'react-router-dom';
 import { DropdownMenu, DropdownMenuContent, DropdownMenuItem, DropdownMenuTrigger } from '../ui/dropdown-menu';
 import { SidebarMenu, SidebarMenuItem } from '../ui/sidebar';
 import { useMeta } from '@/hooks/useMeta';
+import { permissions, usePermissions } from '@/hooks/usePermissions';
 import { useUser } from '@/hooks/useUser';
 import { useStore } from '@/store';
 import { toAcronym } from '@/utils/avatar';
@@ -20,6 +21,9 @@ export const ProfileDropdown: React.FC = () => {
     const signout = useSignout();
     const { user } = useUser();
     const showGettingStarted = useStore((state) => state.showGettingStarted);
+
+    const { can } = usePermissions();
+    const canManageBilling = can(permissions.canManageTeam);
 
     const items = useMemo(() => {
         const list = [
@@ -43,7 +47,7 @@ export const ProfileDropdown: React.FC = () => {
             });
         }
 
-        if (globalEnv.features.plan) {
+        if (globalEnv.features.plan && canManageBilling) {
             list.push({
                 label: 'Billing & usage',
                 icon: CreditCard,

--- a/packages/webapp/src/components-v2/AppSidebar/UsageCard.tsx
+++ b/packages/webapp/src/components-v2/AppSidebar/UsageCard.tsx
@@ -1,10 +1,12 @@
 import { Link } from 'react-router-dom';
 
+import { permissions } from '@nangohq/authz';
+
 import { Skeleton } from '../../components/ui/Skeleton.js';
 import { useApiGetUsage } from '../../hooks/usePlan.js';
 import { useStore } from '../../store.js';
 import { cn } from '../../utils/utils.js';
-import { permissions, usePermissions } from '@/hooks/usePermissions.js';
+import { usePermissions } from '@/hooks/usePermissions.js';
 
 const numberFormatter = Intl.NumberFormat('en-US', { maximumFractionDigits: 0 });
 /**

--- a/packages/webapp/src/components-v2/AppSidebar/UsageCard.tsx
+++ b/packages/webapp/src/components-v2/AppSidebar/UsageCard.tsx
@@ -4,6 +4,7 @@ import { Skeleton } from '../../components/ui/Skeleton.js';
 import { useApiGetUsage } from '../../hooks/usePlan.js';
 import { useStore } from '../../store.js';
 import { cn } from '../../utils/utils.js';
+import { permissions, usePermissions } from '@/hooks/usePermissions.js';
 
 const numberFormatter = Intl.NumberFormat('en-US', { maximumFractionDigits: 0 });
 /**
@@ -50,27 +51,35 @@ export default function UsageCard() {
     const env = useStore((state) => state.env);
     const { data: usage, isLoading } = useApiGetUsage(env);
 
+    const { can } = usePermissions();
+    const canManageBilling = can(permissions.canManageBilling);
+
+    const content = isLoading ? (
+        <>
+            <Skeleton className="h-[24px]" />
+            <Skeleton className="h-[24px]" />
+            <Skeleton className="h-[24px]" />
+        </>
+    ) : (
+        Object.entries(usage?.data ?? {}).map(([metric, usage]) => (
+            <div key={metric} className="flex flex-row justify-between items-center">
+                <span className="text-text-primary font-medium">{usage.label}</span>
+                <div>
+                    <UsageBadge usage={usage.usage} limit={usage.limit} />
+                </div>
+            </div>
+        ))
+    );
+
+    const baseClassName = 'flex flex-col gap-4.5 px-3 py-3.5 text-xs rounded-sm bg-bg-surface border-[0.5px] border-border-muted';
+
+    if (!canManageBilling) {
+        return <div className={baseClassName}>{content}</div>;
+    }
+
     return (
-        <Link
-            to={`/${env}/team/billing#usage`}
-            className="flex flex-col gap-4.5 px-3 py-3.5 text-xs rounded-sm bg-bg-surface border-[0.5px] border-border-muted cursor-pointer transition-colors hover:bg-bg-elevated hover:border-transparent"
-        >
-            {isLoading ? (
-                <>
-                    <Skeleton className="h-[24px]" />
-                    <Skeleton className="h-[24px]" />
-                    <Skeleton className="h-[24px]" />
-                </>
-            ) : (
-                Object.entries(usage?.data ?? {}).map(([metric, usage]) => (
-                    <div key={metric} className="flex flex-row justify-between items-center">
-                        <span className="text-text-primary font-medium">{usage.label}</span>
-                        <div>
-                            <UsageBadge usage={usage.usage} limit={usage.limit} />
-                        </div>
-                    </div>
-                ))
-            )}
+        <Link to={`/${env}/team/billing#usage`} className={cn(baseClassName, 'cursor-pointer transition-colors hover:bg-bg-elevated hover:border-transparent')}>
+            {content}
         </Link>
     );
 }

--- a/packages/webapp/src/components-v2/ConditionalTooltip.tsx
+++ b/packages/webapp/src/components-v2/ConditionalTooltip.tsx
@@ -1,0 +1,43 @@
+import { createContext, useContext } from 'react';
+
+import { Tooltip, TooltipContent, TooltipTrigger } from './ui/tooltip';
+
+import type * as TooltipPrimitive from '@radix-ui/react-tooltip';
+
+const TooltipSuppressedContext = createContext(false);
+
+interface ConditionalTooltipProps {
+    condition?: boolean;
+    children: React.ReactNode;
+    content: React.ReactNode;
+    asChild?: boolean;
+    side?: 'left' | 'right' | 'top' | 'bottom';
+}
+
+/**
+ * Only renders the tooltip wrapper when the condition is true. Useful for nesting tooltips.
+ * When rendered, suppresses any nested ConditionalTooltip so only the outermost active tooltip shows.
+ */
+export const ConditionalTooltip: React.FC<ConditionalTooltipProps & React.ComponentProps<typeof TooltipPrimitive.Root>> = ({
+    condition,
+    content,
+    asChild,
+    side = 'bottom',
+    children,
+    ...props
+}) => {
+    const suppressed = useContext(TooltipSuppressedContext);
+
+    if (!condition || suppressed) {
+        return children;
+    }
+
+    return (
+        <TooltipSuppressedContext.Provider value={true}>
+            <Tooltip {...props}>
+                <TooltipTrigger asChild={asChild}>{children}</TooltipTrigger>
+                <TooltipContent side={side}>{content}</TooltipContent>
+            </Tooltip>
+        </TooltipSuppressedContext.Provider>
+    );
+};

--- a/packages/webapp/src/components-v2/CopyButton.tsx
+++ b/packages/webapp/src/components-v2/CopyButton.tsx
@@ -4,7 +4,7 @@ import { useEffect, useState } from 'react';
 import { Button } from './ui/button';
 import { cn } from '@/utils/utils';
 
-export const CopyButton: React.FC<{ text: string }> = ({ text }) => {
+export const CopyButton: React.FC<{ text: string; disabled?: boolean }> = ({ text, disabled }) => {
     const [copied, setCopied] = useState(false);
     const [hasInteracted, setHasInteracted] = useState(false);
 
@@ -29,7 +29,7 @@ export const CopyButton: React.FC<{ text: string }> = ({ text }) => {
     const animationClass = hasInteracted ? 'animate-in zoom-in-45' : '';
 
     return (
-        <Button data-copied={copied} variant="ghost" size="icon" onClick={copyToClipboard} className="group">
+        <Button disabled={disabled} data-copied={copied} variant="ghost" size="icon" onClick={copyToClipboard} className="group">
             <Check className={cn('size-3.5 hidden group-data-[copied=true]:inline', animationClass)} />
             <Copy className={cn('size-3.5 inline group-data-[copied=true]:hidden', animationClass)} />
         </Button>

--- a/packages/webapp/src/components-v2/EditableInput.tsx
+++ b/packages/webapp/src/components-v2/EditableInput.tsx
@@ -1,11 +1,10 @@
-import { TooltipTrigger } from '@radix-ui/react-tooltip';
 import { Check, Edit, Loader2, X } from 'lucide-react';
 import { useEffect, useRef, useState } from 'react';
 
+import { ConditionalTooltip } from './ConditionalTooltip';
 import { CopyButton } from './CopyButton';
 import { PermissionCondition } from './PermissionGate';
 import { InputGroup, InputGroupAddon, InputGroupButton, InputGroupInput, InputGroupTextarea } from './ui/input-group';
-import { Tooltip, TooltipContent } from './ui/tooltip';
 
 export interface EditableInputProps {
     id?: string;
@@ -146,18 +145,15 @@ export const EditableInput: React.FC<EditableInputProps> = ({
                     </InputGroupAddon>
                 ) : !editing ? (
                     <>
-                        <PermissionCondition condition={canEdit} tooltipSide="bottom">
-                            {(allowed) => (
-                                <Tooltip>
-                                    <TooltipTrigger>
-                                        <InputGroupButton disabled={!!disabled || !allowed} onClick={onEditClicked} size="icon-sm">
-                                            <Edit />
-                                        </InputGroupButton>
-                                    </TooltipTrigger>
-                                    {typeof disabled === 'string' && <TooltipContent side="bottom">{disabled}</TooltipContent>}
-                                </Tooltip>
-                            )}
-                        </PermissionCondition>
+                        <ConditionalTooltip condition={!!disabled && typeof disabled === 'string'} content={disabled} side="bottom">
+                            <PermissionCondition condition={canEdit} tooltipSide="bottom">
+                                {(allowed) => (
+                                    <InputGroupButton disabled={!!disabled || !allowed} onClick={onEditClicked} size="icon-sm">
+                                        <Edit />
+                                    </InputGroupButton>
+                                )}
+                            </PermissionCondition>
+                        </ConditionalTooltip>
                         <InputGroupAddon align="inline-end">
                             <PermissionCondition condition={canRead || !secret} tooltipSide="bottom">
                                 {(allowed) => <CopyButton disabled={!allowed} text={value} />}

--- a/packages/webapp/src/components-v2/EditableInput.tsx
+++ b/packages/webapp/src/components-v2/EditableInput.tsx
@@ -3,6 +3,7 @@ import { Check, Edit, Loader2, X } from 'lucide-react';
 import { useEffect, useRef, useState } from 'react';
 
 import { CopyButton } from './CopyButton';
+import { PermissionCondition } from './PermissionGate';
 import { InputGroup, InputGroupAddon, InputGroupButton, InputGroupInput, InputGroupTextarea } from './ui/input-group';
 import { Tooltip, TooltipContent } from './ui/tooltip';
 
@@ -18,6 +19,8 @@ export interface EditableInputProps {
     onValidationChange?: (error: string | null) => void; // Called when validation state changes
     hintText?: string; // Hint text to display when editing (shown when no error, or as fallback)
     disabled?: boolean | string;
+    canEdit?: boolean; // Permission to edit
+    canRead?: boolean; // Permission to read
 }
 
 export const EditableInput: React.FC<EditableInputProps> = ({
@@ -31,7 +34,9 @@ export const EditableInput: React.FC<EditableInputProps> = ({
     validate,
     onValidationChange,
     hintText,
-    disabled
+    disabled,
+    canEdit = true,
+    canRead = true
 }) => {
     const [editing, setEditing] = useState(false);
     const [referenceValue, setReferenceValue] = useState(initialValue);
@@ -141,16 +146,22 @@ export const EditableInput: React.FC<EditableInputProps> = ({
                     </InputGroupAddon>
                 ) : !editing ? (
                     <>
-                        <Tooltip>
-                            <TooltipTrigger>
-                                <InputGroupButton disabled={!!disabled} onClick={onEditClicked} size="icon-sm">
-                                    <Edit />
-                                </InputGroupButton>
-                            </TooltipTrigger>
-                            {typeof disabled === 'string' && <TooltipContent side="bottom">{disabled}</TooltipContent>}
-                        </Tooltip>
+                        <PermissionCondition condition={canEdit} tooltipSide="bottom">
+                            {(allowed) => (
+                                <Tooltip>
+                                    <TooltipTrigger>
+                                        <InputGroupButton disabled={!!disabled || !allowed} onClick={onEditClicked} size="icon-sm">
+                                            <Edit />
+                                        </InputGroupButton>
+                                    </TooltipTrigger>
+                                    {typeof disabled === 'string' && <TooltipContent side="bottom">{disabled}</TooltipContent>}
+                                </Tooltip>
+                            )}
+                        </PermissionCondition>
                         <InputGroupAddon align="inline-end">
-                            <CopyButton text={value} />
+                            <PermissionCondition condition={canRead || !secret} tooltipSide="bottom">
+                                {(allowed) => <CopyButton disabled={!allowed} text={value} />}
+                            </PermissionCondition>
                         </InputGroupAddon>
                     </>
                 ) : (

--- a/packages/webapp/src/components-v2/EditableInput.tsx
+++ b/packages/webapp/src/components-v2/EditableInput.tsx
@@ -3,7 +3,7 @@ import { useEffect, useRef, useState } from 'react';
 
 import { ConditionalTooltip } from './ConditionalTooltip';
 import { CopyButton } from './CopyButton';
-import { PermissionCondition } from './PermissionGate';
+import { PermissionGate } from './PermissionGate';
 import { InputGroup, InputGroupAddon, InputGroupButton, InputGroupInput, InputGroupTextarea } from './ui/input-group';
 
 export interface EditableInputProps {
@@ -146,18 +146,18 @@ export const EditableInput: React.FC<EditableInputProps> = ({
                 ) : !editing ? (
                     <>
                         <ConditionalTooltip condition={!!disabled && typeof disabled === 'string'} content={disabled} side="bottom">
-                            <PermissionCondition condition={canEdit} tooltipSide="bottom">
+                            <PermissionGate condition={canEdit} tooltipSide="bottom">
                                 {(allowed) => (
                                     <InputGroupButton disabled={!!disabled || !allowed} onClick={onEditClicked} size="icon-sm">
                                         <Edit />
                                     </InputGroupButton>
                                 )}
-                            </PermissionCondition>
+                            </PermissionGate>
                         </ConditionalTooltip>
                         <InputGroupAddon align="inline-end">
-                            <PermissionCondition condition={canRead || !secret} tooltipSide="bottom">
+                            <PermissionGate condition={canRead || !secret} tooltipSide="bottom">
                                 {(allowed) => <CopyButton disabled={!allowed} text={value} />}
-                            </PermissionCondition>
+                            </PermissionGate>
                         </InputGroupAddon>
                     </>
                 ) : (

--- a/packages/webapp/src/components-v2/PermissionGate.tsx
+++ b/packages/webapp/src/components-v2/PermissionGate.tsx
@@ -9,22 +9,36 @@ interface PermissionGateProps {
     bypass?: boolean;
     permission?: { action: Action; scope: Scope; resource: string };
     children: (allowed: boolean) => React.ReactNode;
+    asChild?: boolean;
     tooltipSide?: 'top' | 'right' | 'bottom' | 'left';
 }
 
-export const PermissionGate: React.FC<PermissionGateProps> = ({ permission, children, bypass = false, tooltipSide = 'right' }) => {
+export const PermissionGate: React.FC<PermissionGateProps> = ({ permission, children, bypass = false, tooltipSide = 'right', asChild = false }) => {
     const { can } = usePermissions();
-    if (!permission || bypass) {
+
+    return (
+        <PermissionCondition asChild={asChild} condition={bypass || (permission ? can(permission) : true)} tooltipSide={tooltipSide}>
+            {children}
+        </PermissionCondition>
+    );
+};
+
+interface PermissionConditionProps {
+    condition?: boolean;
+    children: (allowed: boolean) => React.ReactNode;
+    asChild?: boolean;
+    tooltipSide?: 'top' | 'right' | 'bottom' | 'left';
+}
+
+export const PermissionCondition = ({ condition, children, asChild, tooltipSide = 'right' }: PermissionConditionProps) => {
+    if (condition) {
         return <>{children(true)}</>;
     }
 
-    const { action, scope, resource } = permission;
-    const allowed = can(action, scope, resource);
-
     return (
         <Tooltip delayDuration={0}>
-            <TooltipTrigger asChild>{children(allowed)}</TooltipTrigger>
-            {!allowed && <TooltipContent side={tooltipSide}>This action is not permitted for your role.</TooltipContent>}
+            <TooltipTrigger asChild={asChild}>{children(false)}</TooltipTrigger>
+            {!condition && <TooltipContent side={tooltipSide}>This action is not permitted for your role.</TooltipContent>}
         </Tooltip>
     );
 };

--- a/packages/webapp/src/components-v2/PermissionGate.tsx
+++ b/packages/webapp/src/components-v2/PermissionGate.tsx
@@ -1,36 +1,22 @@
 import { ConditionalTooltip } from './ConditionalTooltip';
-import { usePermissions } from '@/hooks/usePermissions';
-
-import type { Action, Scope } from '@/hooks/usePermissions';
 
 interface PermissionGateProps {
-    bypass?: boolean;
-    permission?: { action: Action; scope: Scope; resource: string };
-    children: (allowed: boolean) => React.ReactNode;
-    asChild?: boolean;
-    tooltipSide?: 'top' | 'right' | 'bottom' | 'left';
-}
-
-export const PermissionGate: React.FC<PermissionGateProps> = ({ permission, children, bypass = false, tooltipSide = 'right', asChild = false }) => {
-    const { can } = usePermissions();
-
-    return (
-        <PermissionCondition asChild={asChild} condition={bypass || (permission ? can(permission) : true)} tooltipSide={tooltipSide}>
-            {children}
-        </PermissionCondition>
-    );
-};
-
-interface PermissionConditionProps {
     condition: boolean;
+    message?: string;
     children: (allowed: boolean) => React.ReactNode;
     asChild?: boolean;
     tooltipSide?: 'top' | 'right' | 'bottom' | 'left';
 }
 
-export const PermissionCondition = ({ condition, children, asChild, tooltipSide = 'bottom' }: PermissionConditionProps) => {
+export const PermissionGate = ({
+    condition,
+    message = 'This action is not permitted for your role.',
+    children,
+    asChild,
+    tooltipSide = 'bottom'
+}: PermissionGateProps) => {
     return (
-        <ConditionalTooltip condition={!condition} content="This action is not permitted for your role." asChild={asChild} side={tooltipSide} delayDuration={0}>
+        <ConditionalTooltip condition={!condition} content={message} asChild={asChild} side={tooltipSide} delayDuration={0}>
             {children(condition)}
         </ConditionalTooltip>
     );

--- a/packages/webapp/src/components-v2/PermissionGate.tsx
+++ b/packages/webapp/src/components-v2/PermissionGate.tsx
@@ -1,6 +1,4 @@
-import { TooltipTrigger } from '@radix-ui/react-tooltip';
-
-import { Tooltip, TooltipContent } from './ui/tooltip';
+import { ConditionalTooltip } from './ConditionalTooltip';
 import { usePermissions } from '@/hooks/usePermissions';
 
 import type { Action, Scope } from '@/hooks/usePermissions';
@@ -24,21 +22,16 @@ export const PermissionGate: React.FC<PermissionGateProps> = ({ permission, chil
 };
 
 interface PermissionConditionProps {
-    condition?: boolean;
+    condition: boolean;
     children: (allowed: boolean) => React.ReactNode;
     asChild?: boolean;
     tooltipSide?: 'top' | 'right' | 'bottom' | 'left';
 }
 
-export const PermissionCondition = ({ condition, children, asChild, tooltipSide = 'right' }: PermissionConditionProps) => {
-    if (condition) {
-        return <>{children(true)}</>;
-    }
-
+export const PermissionCondition = ({ condition, children, asChild, tooltipSide = 'bottom' }: PermissionConditionProps) => {
     return (
-        <Tooltip delayDuration={0}>
-            <TooltipTrigger asChild={asChild}>{children(false)}</TooltipTrigger>
-            {!condition && <TooltipContent side={tooltipSide}>This action is not permitted for your role.</TooltipContent>}
-        </Tooltip>
+        <ConditionalTooltip condition={!condition} content="This action is not permitted for your role." asChild={asChild} side={tooltipSide} delayDuration={0}>
+            {children(condition)}
+        </ConditionalTooltip>
     );
 };

--- a/packages/webapp/src/components-v2/PermissionGate.tsx
+++ b/packages/webapp/src/components-v2/PermissionGate.tsx
@@ -1,0 +1,28 @@
+import { TooltipTrigger } from '@radix-ui/react-tooltip';
+
+import { Tooltip, TooltipContent } from './ui/tooltip';
+import { usePermissions } from '@/hooks/usePermissions';
+
+import type { Action, Scope } from '@/hooks/usePermissions';
+
+interface PermissionGateProps {
+    permission?: { action: Action; scope: Scope; resource: string };
+    children: (allowed: boolean) => React.ReactNode;
+}
+
+export const PermissionGate: React.FC<PermissionGateProps> = ({ permission, children }) => {
+    const { can } = usePermissions();
+    if (!permission) {
+        return <>{children(true)}</>;
+    }
+
+    const { action, scope, resource } = permission;
+    const allowed = can(action, scope, resource);
+
+    return (
+        <Tooltip>
+            <TooltipTrigger asChild>{children(allowed)}</TooltipTrigger>
+            {!allowed && <TooltipContent>This action is not permitted for your role.</TooltipContent>}
+        </Tooltip>
+    );
+};

--- a/packages/webapp/src/components-v2/PermissionGate.tsx
+++ b/packages/webapp/src/components-v2/PermissionGate.tsx
@@ -6,13 +6,15 @@ import { usePermissions } from '@/hooks/usePermissions';
 import type { Action, Scope } from '@/hooks/usePermissions';
 
 interface PermissionGateProps {
+    bypass?: boolean;
     permission?: { action: Action; scope: Scope; resource: string };
     children: (allowed: boolean) => React.ReactNode;
+    tooltipSide?: 'top' | 'right' | 'bottom' | 'left';
 }
 
-export const PermissionGate: React.FC<PermissionGateProps> = ({ permission, children }) => {
+export const PermissionGate: React.FC<PermissionGateProps> = ({ permission, children, bypass = false, tooltipSide = 'right' }) => {
     const { can } = usePermissions();
-    if (!permission) {
+    if (!permission || bypass) {
         return <>{children(true)}</>;
     }
 
@@ -20,9 +22,9 @@ export const PermissionGate: React.FC<PermissionGateProps> = ({ permission, chil
     const allowed = can(action, scope, resource);
 
     return (
-        <Tooltip>
+        <Tooltip delayDuration={0}>
             <TooltipTrigger asChild>{children(allowed)}</TooltipTrigger>
-            {!allowed && <TooltipContent>This action is not permitted for your role.</TooltipContent>}
+            {!allowed && <TooltipContent side={tooltipSide}>This action is not permitted for your role.</TooltipContent>}
         </Tooltip>
     );
 };

--- a/packages/webapp/src/components-v2/SecretInput.tsx
+++ b/packages/webapp/src/components-v2/SecretInput.tsx
@@ -3,7 +3,7 @@ import { EyeIcon } from 'lucide-react';
 import { useCallback, useState } from 'react';
 
 import { CopyButton } from './CopyButton';
-import { PermissionCondition } from './PermissionGate';
+import { PermissionGate } from './PermissionGate';
 import { Button } from './ui/button';
 import { InputGroup, InputGroupAddon, InputGroupInput } from './ui/input-group';
 
@@ -23,13 +23,13 @@ export const SecretInput: React.FC<SecretInputProps> = ({ copy, canRead = true, 
         <InputGroup>
             <InputGroupInput {...props} value={value} defaultValue={defaultValue} type={isSecretVisible ? 'text' : 'password'} />
             <InputGroupAddon align="inline-end">
-                <PermissionCondition condition={canRead}>
+                <PermissionGate condition={canRead}>
                     {(allowed) => (
                         <Button disabled={!allowed} type="button" variant="ghost" size="icon" onClick={toggleSecretVisibility}>
                             {isSecretVisible ? <EyeIcon /> : <EyeSlashIcon />}
                         </Button>
                     )}
-                </PermissionCondition>
+                </PermissionGate>
                 {copy && <CopyButton text={textToCopy} />}
             </InputGroupAddon>
         </InputGroup>

--- a/packages/webapp/src/components-v2/SecretInput.tsx
+++ b/packages/webapp/src/components-v2/SecretInput.tsx
@@ -3,14 +3,16 @@ import { EyeIcon } from 'lucide-react';
 import { useCallback, useState } from 'react';
 
 import { CopyButton } from './CopyButton';
+import { PermissionCondition } from './PermissionGate';
 import { Button } from './ui/button';
 import { InputGroup, InputGroupAddon, InputGroupInput } from './ui/input-group';
 
 interface SecretInputProps extends React.ComponentProps<'input'> {
     copy?: boolean;
+    canRead?: boolean;
 }
 
-export const SecretInput: React.FC<SecretInputProps> = ({ copy, value, defaultValue, ...props }) => {
+export const SecretInput: React.FC<SecretInputProps> = ({ copy, canRead = true, value, defaultValue, ...props }) => {
     const [isSecretVisible, setIsSecretVisible] = useState(false);
 
     const toggleSecretVisibility = useCallback(() => setIsSecretVisible(!isSecretVisible), [isSecretVisible]);
@@ -21,9 +23,13 @@ export const SecretInput: React.FC<SecretInputProps> = ({ copy, value, defaultVa
         <InputGroup>
             <InputGroupInput {...props} value={value} defaultValue={defaultValue} type={isSecretVisible ? 'text' : 'password'} />
             <InputGroupAddon align="inline-end">
-                <Button type="button" variant="ghost" size="icon" onClick={toggleSecretVisibility}>
-                    {isSecretVisible ? <EyeIcon /> : <EyeSlashIcon />}
-                </Button>
+                <PermissionCondition condition={canRead}>
+                    {(allowed) => (
+                        <Button disabled={!allowed} type="button" variant="ghost" size="icon" onClick={toggleSecretVisibility}>
+                            {isSecretVisible ? <EyeIcon /> : <EyeSlashIcon />}
+                        </Button>
+                    )}
+                </PermissionCondition>
                 {copy && <CopyButton text={textToCopy} />}
             </InputGroupAddon>
         </InputGroup>

--- a/packages/webapp/src/components-v2/SecretInput.tsx
+++ b/packages/webapp/src/components-v2/SecretInput.tsx
@@ -21,7 +21,7 @@ export const SecretInput: React.FC<SecretInputProps> = ({ copy, canRead = true, 
 
     return (
         <InputGroup>
-            <InputGroupInput {...props} disabled value={value} defaultValue={defaultValue} type={isSecretVisible ? 'text' : 'password'} />
+            <InputGroupInput {...props} value={value} defaultValue={defaultValue} type={isSecretVisible ? 'text' : 'password'} />
             <InputGroupAddon align="inline-end">
                 <PermissionGate condition={canRead}>
                     {(allowed) => (

--- a/packages/webapp/src/components-v2/SecretInput.tsx
+++ b/packages/webapp/src/components-v2/SecretInput.tsx
@@ -21,7 +21,7 @@ export const SecretInput: React.FC<SecretInputProps> = ({ copy, canRead = true, 
 
     return (
         <InputGroup>
-            <InputGroupInput {...props} value={value} defaultValue={defaultValue} type={isSecretVisible ? 'text' : 'password'} />
+            <InputGroupInput {...props} disabled value={value} defaultValue={defaultValue} type={isSecretVisible ? 'text' : 'password'} />
             <InputGroupAddon align="inline-end">
                 <PermissionGate condition={canRead}>
                     {(allowed) => (
@@ -30,7 +30,7 @@ export const SecretInput: React.FC<SecretInputProps> = ({ copy, canRead = true, 
                         </Button>
                     )}
                 </PermissionGate>
-                {copy && <CopyButton text={textToCopy} />}
+                {copy && <PermissionGate condition={canRead}>{(allowed) => <CopyButton text={textToCopy} disabled={!allowed} />}</PermissionGate>}
             </InputGroupAddon>
         </InputGroup>
     );

--- a/packages/webapp/src/components-v2/ui/button.tsx
+++ b/packages/webapp/src/components-v2/ui/button.tsx
@@ -65,7 +65,20 @@ const Button = React.forwardRef<
 });
 Button.displayName = 'Button';
 
-function ButtonLink({ className, variant, size, ...props }: LinkProps & VariantProps<typeof buttonVariants>) {
+type ButtonLinkProps = LinkProps &
+    VariantProps<typeof buttonVariants> & {
+        disabled?: boolean;
+    };
+
+function ButtonLink({ className, variant, size, disabled, ...props }: ButtonLinkProps) {
+    // react-router-dom links don't support disabled state
+    if (disabled) {
+        return (
+            <Button variant={variant} size={size} className={className} disabled>
+                {props.children}
+            </Button>
+        );
+    }
     return <Link data-slot="button" className={cn(buttonVariants({ variant, size, className }))} {...props} />;
 }
 

--- a/packages/webapp/src/components-v2/ui/tooltip.tsx
+++ b/packages/webapp/src/components-v2/ui/tooltip.tsx
@@ -23,7 +23,7 @@ function TooltipTrigger({ ...props }: React.ComponentProps<typeof TooltipPrimiti
 }
 
 const tooltipContentVariants = cva(
-    'text-text-secondary animate-in fade-in-0 zoom-in-95 data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=closed]:zoom-out-95 data-[side=bottom]:slide-in-from-top-2 data-[side=left]:slide-in-from-right-2 data-[side=right]:slide-in-from-left-2 data-[side=top]:slide-in-from-bottom-2 z-50 w-fit origin-(--radix-tooltip-content-transform-origin) rounded-md px-3 py-1.5 text-s leading-4 text-balance',
+    'text-text-secondary animate-in fade-in-0 zoom-in-95 shadow-md data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=closed]:zoom-out-95 data-[side=bottom]:slide-in-from-top-2 data-[side=left]:slide-in-from-right-2 data-[side=right]:slide-in-from-left-2 data-[side=top]:slide-in-from-bottom-2 z-50 w-fit origin-(--radix-tooltip-content-transform-origin) rounded-md px-3 py-1.5 text-s leading-4 text-balance',
     {
         variants: {
             variant: {

--- a/packages/webapp/src/components/PermissionRoute.tsx
+++ b/packages/webapp/src/components/PermissionRoute.tsx
@@ -4,7 +4,7 @@ import { usePermissions } from '../hooks/usePermissions';
 import { useUser } from '../hooks/useUser';
 import { useStore } from '../store';
 
-import type { Permission } from '../hooks/usePermissions';
+import type { Permission } from '@nangohq/types';
 
 export const PermissionRoute: React.FC<Permission> = (permission) => {
     const { can } = usePermissions();

--- a/packages/webapp/src/components/PermissionRoute.tsx
+++ b/packages/webapp/src/components/PermissionRoute.tsx
@@ -1,0 +1,15 @@
+import { Navigate, Outlet } from 'react-router-dom';
+
+import { usePermissions } from '../hooks/usePermissions';
+import { useUser } from '../hooks/useUser';
+import { useStore } from '../store';
+
+export const PermissionRoute: React.FC<{ action: string; scope: string; resource: string }> = ({ action, scope, resource }) => {
+    const { can } = usePermissions();
+    const { loading } = useUser();
+    const env = useStore((state) => state.env);
+
+    if (loading) return null;
+    if (!can(action as any, scope as any, resource)) return <Navigate to={`/${env}`} replace />;
+    return <Outlet />;
+};

--- a/packages/webapp/src/components/PermissionRoute.tsx
+++ b/packages/webapp/src/components/PermissionRoute.tsx
@@ -4,12 +4,14 @@ import { usePermissions } from '../hooks/usePermissions';
 import { useUser } from '../hooks/useUser';
 import { useStore } from '../store';
 
-export const PermissionRoute: React.FC<{ action: string; scope: string; resource: string }> = ({ action, scope, resource }) => {
+import type { Permission } from '../hooks/usePermissions';
+
+export const PermissionRoute: React.FC<Permission> = (permission) => {
     const { can } = usePermissions();
     const { loading } = useUser();
     const env = useStore((state) => state.env);
 
     if (loading) return null;
-    if (!can(action as any, scope as any, resource)) return <Navigate to={`/${env}`} replace />;
+    if (!can(permission)) return <Navigate to={`/${env}`} replace />;
     return <Outlet />;
 };

--- a/packages/webapp/src/components/PrivateRoute.tsx
+++ b/packages/webapp/src/components/PrivateRoute.tsx
@@ -1,9 +1,11 @@
 import { useEffect, useState } from 'react';
-import { Navigate, Outlet } from 'react-router-dom';
+import { Navigate, Outlet, useLocation } from 'react-router-dom';
 
 import { useEnvironment } from '../hooks/useEnvironment';
 import { useMeta } from '../hooks/useMeta';
+import { permissions, usePermissions } from '../hooks/usePermissions';
 import { useUser } from '../hooks/useUser';
+import PageEnvironmentUnauthorized from '../pages/PageEnvironmentUnauthorized';
 import PageNotFound from '../pages/PageNotFound';
 import { useStore } from '../store';
 import { useAnalyticsIdentify } from '../utils/analytics';
@@ -13,8 +15,11 @@ export const PrivateRoute: React.FC = () => {
     const { data, error: metaError, isLoading: loadingMeta } = useMeta(!!user);
     const meta = data?.data;
     const [notFoundEnv, setNotFoundEnv] = useState(false);
+    const [unauthorizedEnv, setUnauthorizedEnv] = useState(false);
     const [ready, setReady] = useState(false);
     const identify = useAnalyticsIdentify();
+    const { can } = usePermissions();
+    const location = useLocation();
 
     const env = useStore((state) => state.env);
     const setStoredEnvs = useStore((state) => state.setEnvs);
@@ -67,12 +72,21 @@ export const PrivateRoute: React.FC = () => {
 
             setNotFoundEnv(true);
         } else {
-            setEnv(currentEnv);
+            const matchedEnv = meta.environments.find(({ name }) => name === currentEnv);
+            if (matchedEnv?.is_production && !can(permissions.canAccessProdEnvironment)) {
+                // User navigated directly to a production env they don't have access to
+                const fallback = meta.environments.find(({ name, is_production }) => name !== currentEnv && !is_production);
+                setEnv(fallback ? fallback.name : meta.environments[0].name);
+                setUnauthorizedEnv(true);
+            } else {
+                setEnv(currentEnv);
+                setUnauthorizedEnv(false);
+            }
         }
 
         // it's ready when datastore and path are finally reconciliated
         setReady(true);
-    }, [meta, loadingMeta, env, metaError, setEnv]);
+    }, [meta, loadingMeta, env, metaError, setEnv, can, location.pathname]);
 
     useEffect(() => {
         if (user && environmentAndAccount && meta && !meta.debugMode) {
@@ -89,6 +103,10 @@ export const PrivateRoute: React.FC = () => {
 
     if (notFoundEnv) {
         return <PageNotFound />;
+    }
+
+    if (unauthorizedEnv) {
+        return <PageEnvironmentUnauthorized />;
     }
 
     return <Outlet />;

--- a/packages/webapp/src/components/PrivateRoute.tsx
+++ b/packages/webapp/src/components/PrivateRoute.tsx
@@ -1,9 +1,11 @@
 import { useEffect, useState } from 'react';
 import { Navigate, Outlet, useLocation } from 'react-router-dom';
 
+import { permissions } from '@nangohq/authz';
+
 import { useEnvironment } from '../hooks/useEnvironment';
 import { useMeta } from '../hooks/useMeta';
-import { permissions, usePermissions } from '../hooks/usePermissions';
+import { usePermissions } from '../hooks/usePermissions';
 import { useUser } from '../hooks/useUser';
 import PageEnvironmentUnauthorized from '../pages/PageEnvironmentUnauthorized';
 import PageNotFound from '../pages/PageNotFound';

--- a/packages/webapp/src/hooks/usePermissions.tsx
+++ b/packages/webapp/src/hooks/usePermissions.tsx
@@ -2,8 +2,8 @@ import { useUser } from './useUser';
 
 import type { AllowedPermissions } from '@nangohq/types';
 
-type Action = 'create' | 'read' | 'update' | 'delete' | '*';
-type Scope = 'production' | 'non-production' | 'global';
+export type Action = 'create' | 'read' | 'update' | 'delete' | '*';
+export type Scope = 'production' | 'non-production' | 'global';
 
 export function usePermissions(): { can: (action: Action, scope: Scope, resource: string) => boolean; permissions: AllowedPermissions } {
     const { user } = useUser();

--- a/packages/webapp/src/hooks/usePermissions.tsx
+++ b/packages/webapp/src/hooks/usePermissions.tsx
@@ -1,0 +1,15 @@
+import { useUser } from './useUser';
+
+import type { AllowedPermissions } from '@nangohq/types';
+
+type Action = 'create' | 'read' | 'update' | 'delete' | '*';
+type Scope = 'production' | 'non-production' | 'global';
+
+export function usePermissions(): { can: (action: Action, scope: Scope, resource: string) => boolean; permissions: AllowedPermissions } {
+    const { user } = useUser();
+    const permissions = user?.permissions ?? {};
+    return {
+        permissions,
+        can: (action: Action, scope: Scope, resource: string) => permissions[resource]?.[scope]?.includes(action) ?? false
+    };
+}

--- a/packages/webapp/src/hooks/usePermissions.tsx
+++ b/packages/webapp/src/hooks/usePermissions.tsx
@@ -6,7 +6,7 @@ import type { AllowedPermissions } from '@nangohq/types';
 export type Action = 'create' | 'read' | 'update' | 'delete' | '*';
 export type Scope = 'production' | 'non-production' | 'global';
 
-interface Permission {
+export interface Permission {
     action: Action;
     resource: string;
     scope: Scope;
@@ -43,11 +43,11 @@ export const permissions = {
     canReadProdConnectionCredentials: { action: 'read', resource: 'connection_credential', scope: 'production' }
 } as const satisfies Record<string, Permission>;
 
-export function usePermissions(): { can: (action: Action, scope: Scope, resource: string) => boolean; permissions: AllowedPermissions } {
+export function usePermissions(): { can: (permission: Permission) => boolean; permissions: AllowedPermissions } {
     const { user } = useUser();
     const permissions = user?.permissions ?? {};
     return {
         permissions,
-        can: (action: Action, scope: Scope, resource: string) => permissions[resource]?.[scope]?.includes(action) ?? false
+        can: (permission: Permission) => permissions[permission.resource]?.[permission.scope]?.includes(permission.action) ?? false
     };
 }

--- a/packages/webapp/src/hooks/usePermissions.tsx
+++ b/packages/webapp/src/hooks/usePermissions.tsx
@@ -2,8 +2,46 @@ import { useUser } from './useUser';
 
 import type { AllowedPermissions } from '@nangohq/types';
 
+// TODO: Temporary while the types aren't shared
 export type Action = 'create' | 'read' | 'update' | 'delete' | '*';
 export type Scope = 'production' | 'non-production' | 'global';
+
+interface Permission {
+    action: Action;
+    resource: string;
+    scope: Scope;
+}
+
+export const permissions = {
+    // team management (global scope)
+    canManageTeam: { action: 'update', resource: 'team', scope: 'global' },
+    canUpdateTeamMember: { action: 'update', resource: 'team_member', scope: 'global' },
+    canRemoveTeamMember: { action: 'delete', resource: 'team_member', scope: 'global' },
+    canInviteMember: { action: 'create', resource: 'invite', scope: 'global' },
+    canCancelInvitation: { action: 'delete', resource: 'invite', scope: 'global' },
+    canManageConnectUI: { action: 'update', resource: 'connect_ui_settings', scope: 'global' },
+    canManageBilling: { action: '*', resource: 'billing', scope: 'global' },
+    canChangePlan: { action: 'update', resource: 'plan', scope: 'global' },
+    canToggleIsProduction: { action: 'update', resource: 'environment_production_flag', scope: 'global' },
+    canCreateEnvironment: { action: 'create', resource: 'environment', scope: 'global' },
+
+    // production environment access
+    canAccessProdEnvironment: { action: 'read', resource: 'environment', scope: 'production' },
+    canWriteProdIntegrations: { action: 'update', resource: 'integration', scope: 'production' },
+    canDeleteProdIntegrations: { action: 'delete', resource: 'integration', scope: 'production' },
+    canWriteProdConnections: { action: 'update', resource: 'connection', scope: 'production' },
+    canDeleteProdConnections: { action: 'delete', resource: 'connection', scope: 'production' },
+    canWriteProdFlows: { action: 'update', resource: 'flow', scope: 'production' },
+    canWriteProdEnvironment: { action: 'update', resource: 'environment', scope: 'production' },
+    canWriteProdEnvironmentKeys: { action: 'update', resource: 'environment_key', scope: 'production' },
+    canWriteProdEnvironmentVariables: { action: 'update', resource: 'environment_variable', scope: 'production' },
+    canWriteProdWebhooks: { action: 'update', resource: 'webhook', scope: 'production' },
+    canDeleteProdEnvironment: { action: 'delete', resource: 'environment', scope: 'production' },
+
+    // production secrets/credentials
+    canReadProdSecretKey: { action: 'read', resource: 'secret_key', scope: 'production' },
+    canReadProdConnectionCredentials: { action: 'read', resource: 'connection_credential', scope: 'production' }
+} as const satisfies Record<string, Permission>;
 
 export function usePermissions(): { can: (action: Action, scope: Scope, resource: string) => boolean; permissions: AllowedPermissions } {
     const { user } = useUser();

--- a/packages/webapp/src/hooks/usePermissions.tsx
+++ b/packages/webapp/src/hooks/usePermissions.tsx
@@ -1,47 +1,6 @@
 import { useUser } from './useUser';
 
-import type { AllowedPermissions } from '@nangohq/types';
-
-// TODO: Temporary while the types aren't shared
-export type Action = 'create' | 'read' | 'update' | 'delete' | '*';
-export type Scope = 'production' | 'non-production' | 'global';
-
-export interface Permission {
-    action: Action;
-    resource: string;
-    scope: Scope;
-}
-
-export const permissions = {
-    // team management (global scope)
-    canManageTeam: { action: 'update', resource: 'team', scope: 'global' },
-    canUpdateTeamMember: { action: 'update', resource: 'team_member', scope: 'global' },
-    canRemoveTeamMember: { action: 'delete', resource: 'team_member', scope: 'global' },
-    canInviteMember: { action: 'create', resource: 'invite', scope: 'global' },
-    canCancelInvitation: { action: 'delete', resource: 'invite', scope: 'global' },
-    canManageConnectUI: { action: 'update', resource: 'connect_ui_settings', scope: 'global' },
-    canManageBilling: { action: '*', resource: 'billing', scope: 'global' },
-    canChangePlan: { action: 'update', resource: 'plan', scope: 'global' },
-    canToggleIsProduction: { action: 'update', resource: 'environment_production_flag', scope: 'global' },
-    canCreateEnvironment: { action: 'create', resource: 'environment', scope: 'global' },
-
-    // production environment access
-    canAccessProdEnvironment: { action: 'read', resource: 'environment', scope: 'production' },
-    canWriteProdIntegrations: { action: 'update', resource: 'integration', scope: 'production' },
-    canDeleteProdIntegrations: { action: 'delete', resource: 'integration', scope: 'production' },
-    canWriteProdConnections: { action: 'update', resource: 'connection', scope: 'production' },
-    canDeleteProdConnections: { action: 'delete', resource: 'connection', scope: 'production' },
-    canWriteProdFlows: { action: 'update', resource: 'flow', scope: 'production' },
-    canWriteProdEnvironment: { action: 'update', resource: 'environment', scope: 'production' },
-    canWriteProdEnvironmentKeys: { action: 'update', resource: 'environment_key', scope: 'production' },
-    canWriteProdEnvironmentVariables: { action: 'update', resource: 'environment_variable', scope: 'production' },
-    canWriteProdWebhooks: { action: 'update', resource: 'webhook', scope: 'production' },
-    canDeleteProdEnvironment: { action: 'delete', resource: 'environment', scope: 'production' },
-
-    // production secrets/credentials
-    canReadProdSecretKey: { action: 'read', resource: 'secret_key', scope: 'production' },
-    canReadProdConnectionCredentials: { action: 'read', resource: 'connection_credential', scope: 'production' }
-} as const satisfies Record<string, Permission>;
+import type { AllowedPermissions, Permission } from '@nangohq/types';
 
 export function usePermissions(): { can: (permission: Permission) => boolean; permissions: AllowedPermissions } {
     const { user } = useUser();

--- a/packages/webapp/src/pages/Connection/List.tsx
+++ b/packages/webapp/src/pages/Connection/List.tsx
@@ -12,6 +12,7 @@ import { Avatar } from '@/components-v2/Avatar';
 import { CopyButton } from '@/components-v2/CopyButton';
 import { IntegrationLogo } from '@/components-v2/IntegrationLogo';
 import { MultiSelect } from '@/components-v2/MultiSelect';
+import { PermissionGate } from '@/components-v2/PermissionGate';
 import { StatusCircleWithIcon } from '@/components-v2/StatusCircleWithIcon';
 import { StyledLink } from '@/components-v2/StyledLink';
 import { Button, ButtonLink } from '@/components-v2/ui/button';
@@ -19,7 +20,9 @@ import { InputGroup, InputGroupAddon, InputGroupInput } from '@/components-v2/ui
 import { Skeleton } from '@/components-v2/ui/skeleton';
 import { Table, TableBody, TableCell, TableHead, TableHeader, TableRow } from '@/components-v2/ui/table';
 import { useConnections } from '@/hooks/useConnections';
+import { useEnvironment } from '@/hooks/useEnvironment';
 import { useListIntegrations } from '@/hooks/useIntegration';
+import { permissions, usePermissions } from '@/hooks/usePermissions';
 import DashboardLayout from '@/layout/DashboardLayout';
 import { useStore } from '@/store';
 import { getConnectionDisplayName, getEndUserEmail } from '@/utils/endUser';
@@ -142,6 +145,12 @@ const columns: ColumnDef<ApiConnectionSimple>[] = [
 
 export const ConnectionList = () => {
     const env = useStore((state) => state.env);
+    const { data: environmentData } = useEnvironment(env);
+    const environment = environmentData?.environmentAndAccount?.environment;
+
+    const { can } = usePermissions();
+    const canCreateTestConnection = can(permissions.canWriteProdConnections) || !environment?.is_production;
+
     const navigate = useNavigate();
 
     const [search, setSearch] = useQueryState('search', parseSearch);
@@ -221,9 +230,13 @@ export const ConnectionList = () => {
                 <div className="flex items-center justify-between">
                     <h2 className="text-title-subsection text-text-primary">Connections</h2>
                     {(hasConnections || hasFiltered) && (
-                        <ButtonLink to={`/${env}/connections/create`} size="lg">
-                            Add Test Connection
-                        </ButtonLink>
+                        <PermissionGate condition={canCreateTestConnection}>
+                            {(allowed) => (
+                                <ButtonLink to={`/${env}/connections/create`} size="lg" disabled={!allowed}>
+                                    Add test connection
+                                </ButtonLink>
+                            )}
+                        </PermissionGate>
                     )}
                 </div>
 

--- a/packages/webapp/src/pages/Connection/List.tsx
+++ b/packages/webapp/src/pages/Connection/List.tsx
@@ -6,6 +6,8 @@ import { Helmet } from 'react-helmet';
 import { useNavigate } from 'react-router-dom';
 import { useDebounce } from 'react-use';
 
+import { permissions } from '@nangohq/authz';
+
 import { ConnectionCount } from './components/ConnectionCount';
 import { ErrorPageComponent } from '@/components/ErrorComponent';
 import { Avatar } from '@/components-v2/Avatar';
@@ -22,7 +24,7 @@ import { Table, TableBody, TableCell, TableHead, TableHeader, TableRow } from '@
 import { useConnections } from '@/hooks/useConnections';
 import { useEnvironment } from '@/hooks/useEnvironment';
 import { useListIntegrations } from '@/hooks/useIntegration';
-import { permissions, usePermissions } from '@/hooks/usePermissions';
+import { usePermissions } from '@/hooks/usePermissions';
 import DashboardLayout from '@/layout/DashboardLayout';
 import { useStore } from '@/store';
 import { getConnectionDisplayName, getEndUserEmail } from '@/utils/endUser';

--- a/packages/webapp/src/pages/Connection/components/AuthCredentials/ApiKeyCredentials.tsx
+++ b/packages/webapp/src/pages/Connection/components/AuthCredentials/ApiKeyCredentials.tsx
@@ -5,12 +5,13 @@ import type { ApiKeyCredentials } from '@nangohq/types';
 
 export const ApiKeyCredentialsComponent: React.FC<{
     credentials: ApiKeyCredentials;
-}> = ({ credentials }) => {
+    canRead: boolean;
+}> = ({ credentials, canRead }) => {
     return (
         <>
             <div className="flex flex-col gap-2">
                 <Label htmlFor="api_key">API key</Label>
-                <SecretInput id="api_key" value={credentials.apiKey} disabled copy />
+                <SecretInput id="api_key" value={credentials.apiKey} disabled copy canRead={canRead} />
             </div>
         </>
     );

--- a/packages/webapp/src/pages/Connection/components/AuthCredentials/AppCredentials.tsx
+++ b/packages/webapp/src/pages/Connection/components/AuthCredentials/AppCredentials.tsx
@@ -5,18 +5,19 @@ import type { AppCredentials } from '@nangohq/types';
 
 export const AppCredentialsComponent: React.FC<{
     credentials: AppCredentials;
-}> = ({ credentials }) => {
+    canRead: boolean;
+}> = ({ credentials, canRead }) => {
     return (
         <>
             <div className="flex flex-col gap-2">
                 <Label htmlFor="access_token">Access token</Label>
-                <SecretInput id="access_token" value={credentials.access_token} disabled copy />
+                <SecretInput id="access_token" value={credentials.access_token} disabled copy canRead={canRead} />
             </div>
 
             {credentials.jwtToken && (
                 <div className="flex flex-col gap-2">
                     <Label htmlFor="jwt_token">JWT token</Label>
-                    <SecretInput id="jwt_token" value={credentials.jwtToken} disabled copy />
+                    <SecretInput id="jwt_token" value={credentials.jwtToken} disabled copy canRead={canRead} />
                 </div>
             )}
         </>

--- a/packages/webapp/src/pages/Connection/components/AuthCredentials/AppStoreCredentials.tsx
+++ b/packages/webapp/src/pages/Connection/components/AuthCredentials/AppStoreCredentials.tsx
@@ -5,17 +5,18 @@ import type { AppStoreCredentials } from '@nangohq/types';
 
 export const AppStoreCredentialsComponent: React.FC<{
     credentials: AppStoreCredentials;
-}> = ({ credentials }) => {
+    canRead: boolean;
+}> = ({ credentials, canRead }) => {
     return (
         <>
             <div className="flex flex-col gap-2">
                 <Label htmlFor="access_token">Access token</Label>
-                <SecretInput id="access_token" value={credentials.access_token} disabled copy />
+                <SecretInput id="access_token" value={credentials.access_token} disabled copy canRead={canRead} />
             </div>
 
             <div className="flex flex-col gap-2">
                 <Label htmlFor="private_key">Private key</Label>
-                <SecretInput id="private_key" value={credentials.private_key} disabled copy />
+                <SecretInput id="private_key" value={credentials.private_key} disabled copy canRead={canRead} />
             </div>
         </>
     );

--- a/packages/webapp/src/pages/Connection/components/AuthCredentials/AuthCredentials.tsx
+++ b/packages/webapp/src/pages/Connection/components/AuthCredentials/AuthCredentials.tsx
@@ -11,6 +11,9 @@ import { OAuth2CredentialsComponent } from './OAuth2Credentials';
 import { SignatureCredentialsComponent } from './SignatureCredentials';
 import { TbaCredentialsComponent } from './TbaCredentials';
 import { TwoStepCredentialsComponent } from './TwoStepCredentials';
+import { useEnvironment } from '@/hooks/useEnvironment';
+import { permissions, usePermissions } from '@/hooks/usePermissions';
+import { useStore } from '@/store';
 
 import type { ApiConnectionFull, BasicApiCredentials } from '@nangohq/types';
 
@@ -22,37 +25,76 @@ interface AuthCredentialsProps {
 export const AuthCredentials: React.FC<AuthCredentialsProps> = ({ connection, providerConfigKey }) => {
     const { credentials } = connection;
 
+    const env = useStore((state) => state.env);
+    const { data } = useEnvironment(env);
+    const environment = data?.environmentAndAccount?.environment;
+
+    const { can } = usePermissions();
+    const canReadConnectionCredentials = can(permissions.canReadProdConnectionCredentials) || !environment?.is_production;
+
     return (
         <>
             {credentials.type === 'OAUTH2' && (
-                <OAuth2CredentialsComponent credentials={credentials} connection={connection} providerConfigKey={providerConfigKey} />
+                <OAuth2CredentialsComponent
+                    credentials={credentials}
+                    connection={connection}
+                    providerConfigKey={providerConfigKey}
+                    canRead={canReadConnectionCredentials}
+                />
             )}
-            {credentials.type === 'OAUTH1' && <OAuth1CredentialsComponent credentials={credentials} />}
+            {credentials.type === 'OAUTH1' && <OAuth1CredentialsComponent credentials={credentials} canRead={canReadConnectionCredentials} />}
             {credentials.type === 'OAUTH2_CC' && (
-                <OAuth2ClientCredentialsComponent credentials={credentials} connection={connection} providerConfigKey={providerConfigKey} />
+                <OAuth2ClientCredentialsComponent
+                    credentials={credentials}
+                    connection={connection}
+                    providerConfigKey={providerConfigKey}
+                    canRead={canReadConnectionCredentials}
+                />
             )}
 
             {/* Could be InstallPlugin */}
             {credentials.type === 'BASIC' && 'username' in credentials && 'password' in credentials && (
-                <BasicCredentialsComponent credentials={credentials as BasicApiCredentials} />
+                <BasicCredentialsComponent credentials={credentials as BasicApiCredentials} canRead={canReadConnectionCredentials} />
             )}
 
-            {credentials.type === 'API_KEY' && <ApiKeyCredentialsComponent credentials={credentials} />}
-            {credentials.type === 'APP' && <AppCredentialsComponent credentials={credentials} />}
-            {credentials.type === 'APP_STORE' && <AppStoreCredentialsComponent credentials={credentials} />}
-            {credentials.type === 'TBA' && <TbaCredentialsComponent credentials={credentials} />}
-            {credentials.type === 'JWT' && <JwtCredentialsComponent credentials={credentials} connection={connection} providerConfigKey={providerConfigKey} />}
-            {credentials.type === 'BILL' && <BillCredentialsComponent credentials={credentials} />}
+            {credentials.type === 'API_KEY' && <ApiKeyCredentialsComponent credentials={credentials} canRead={canReadConnectionCredentials} />}
+            {credentials.type === 'APP' && <AppCredentialsComponent credentials={credentials} canRead={canReadConnectionCredentials} />}
+            {credentials.type === 'APP_STORE' && <AppStoreCredentialsComponent credentials={credentials} canRead={canReadConnectionCredentials} />}
+            {credentials.type === 'TBA' && <TbaCredentialsComponent credentials={credentials} canRead={canReadConnectionCredentials} />}
+            {credentials.type === 'JWT' && (
+                <JwtCredentialsComponent
+                    credentials={credentials}
+                    connection={connection}
+                    providerConfigKey={providerConfigKey}
+                    canRead={canReadConnectionCredentials}
+                />
+            )}
+            {credentials.type === 'BILL' && <BillCredentialsComponent credentials={credentials} canRead={canReadConnectionCredentials} />}
             {credentials.type === 'TWO_STEP' && (
-                <TwoStepCredentialsComponent credentials={credentials} connection={connection} providerConfigKey={providerConfigKey} />
+                <TwoStepCredentialsComponent
+                    credentials={credentials}
+                    connection={connection}
+                    providerConfigKey={providerConfigKey}
+                    canRead={canReadConnectionCredentials}
+                />
             )}
             {credentials.type === 'SIGNATURE' && (
-                <SignatureCredentialsComponent credentials={credentials} connection={connection} providerConfigKey={providerConfigKey} />
+                <SignatureCredentialsComponent
+                    credentials={credentials}
+                    connection={connection}
+                    providerConfigKey={providerConfigKey}
+                    canRead={canReadConnectionCredentials}
+                />
             )}
 
             {/* Custom and CombinedOauth2AppCredentials */}
             {credentials.type === 'CUSTOM' && (
-                <CustomCredentialsComponent credentials={credentials} connection={connection} providerConfigKey={providerConfigKey} />
+                <CustomCredentialsComponent
+                    credentials={credentials}
+                    connection={connection}
+                    providerConfigKey={providerConfigKey}
+                    canRead={canReadConnectionCredentials}
+                />
             )}
         </>
     );

--- a/packages/webapp/src/pages/Connection/components/AuthCredentials/AuthCredentials.tsx
+++ b/packages/webapp/src/pages/Connection/components/AuthCredentials/AuthCredentials.tsx
@@ -1,3 +1,5 @@
+import { permissions } from '@nangohq/authz';
+
 import { ApiKeyCredentialsComponent } from './ApiKeyCredentials';
 import { AppCredentialsComponent } from './AppCredentials';
 import { AppStoreCredentialsComponent } from './AppStoreCredentials';
@@ -12,7 +14,7 @@ import { SignatureCredentialsComponent } from './SignatureCredentials';
 import { TbaCredentialsComponent } from './TbaCredentials';
 import { TwoStepCredentialsComponent } from './TwoStepCredentials';
 import { useEnvironment } from '@/hooks/useEnvironment';
-import { permissions, usePermissions } from '@/hooks/usePermissions';
+import { usePermissions } from '@/hooks/usePermissions';
 import { useStore } from '@/store';
 
 import type { ApiConnectionFull, BasicApiCredentials } from '@nangohq/types';

--- a/packages/webapp/src/pages/Connection/components/AuthCredentials/BasicCredentials.tsx
+++ b/packages/webapp/src/pages/Connection/components/AuthCredentials/BasicCredentials.tsx
@@ -5,17 +5,18 @@ import type { BasicApiCredentials } from '@nangohq/types';
 
 export const BasicCredentialsComponent: React.FC<{
     credentials: BasicApiCredentials;
-}> = ({ credentials }) => {
+    canRead: boolean;
+}> = ({ credentials, canRead }) => {
     return (
         <>
             <div className="flex flex-col gap-2">
                 <Label htmlFor="username">Username</Label>
-                <SecretInput id="username" value={credentials.username} disabled copy />
+                <SecretInput id="username" value={credentials.username} disabled copy canRead={canRead} />
             </div>
 
             <div className="flex flex-col gap-2">
                 <Label htmlFor="password">Password</Label>
-                <SecretInput id="password" value={credentials.password} disabled copy />
+                <SecretInput id="password" value={credentials.password} disabled copy canRead={canRead} />
             </div>
         </>
     );

--- a/packages/webapp/src/pages/Connection/components/AuthCredentials/BillCredentials.tsx
+++ b/packages/webapp/src/pages/Connection/components/AuthCredentials/BillCredentials.tsx
@@ -5,40 +5,41 @@ import type { BillCredentials } from '@nangohq/types';
 
 export const BillCredentialsComponent: React.FC<{
     credentials: BillCredentials;
-}> = ({ credentials }) => {
+    canRead: boolean;
+}> = ({ credentials, canRead }) => {
     return (
         <>
             <div className="flex flex-col gap-2">
                 <Label htmlFor="username">Username</Label>
-                <SecretInput id="username" value={credentials.username} disabled copy />
+                <SecretInput id="username" value={credentials.username} disabled copy canRead={canRead} />
             </div>
 
             <div className="flex flex-col gap-2">
                 <Label htmlFor="password">Password</Label>
-                <SecretInput id="password" value={credentials.password} disabled copy />
+                <SecretInput id="password" value={credentials.password} disabled copy canRead={canRead} />
             </div>
 
             <div className="flex flex-col gap-2">
                 <Label htmlFor="organization_id">Organization ID</Label>
-                <SecretInput id="organization_id" value={credentials.organization_id} disabled copy />
+                <SecretInput id="organization_id" value={credentials.organization_id} disabled copy canRead={canRead} />
             </div>
 
             <div className="flex flex-col gap-2">
                 <Label htmlFor="dev_key">Dev key</Label>
-                <SecretInput id="dev_key" value={credentials.dev_key} disabled copy />
+                <SecretInput id="dev_key" value={credentials.dev_key} disabled copy canRead={canRead} />
             </div>
 
             {credentials.session_id && (
                 <div className="flex flex-col gap-2">
                     <Label htmlFor="session_id">Session ID</Label>
-                    <SecretInput id="session_id" value={credentials.session_id} disabled copy />
+                    <SecretInput id="session_id" value={credentials.session_id} disabled copy canRead={canRead} />
                 </div>
             )}
 
             {credentials.user_id && (
                 <div className="flex flex-col gap-2">
                     <Label htmlFor="user_id">User ID</Label>
-                    <SecretInput id="user_id" value={credentials.user_id} disabled copy />
+                    <SecretInput id="user_id" value={credentials.user_id} disabled copy canRead={canRead} />
                 </div>
             )}
         </>

--- a/packages/webapp/src/pages/Connection/components/AuthCredentials/CustomCredentials.tsx
+++ b/packages/webapp/src/pages/Connection/components/AuthCredentials/CustomCredentials.tsx
@@ -7,12 +7,13 @@ export const CustomCredentialsComponent: React.FC<{
     connection: ApiConnectionFull;
     credentials: CustomCredentials | CombinedOauth2AppCredentials;
     providerConfigKey: string;
-}> = ({ connection, credentials, providerConfigKey }) => {
+    canRead: boolean;
+}> = ({ connection, credentials, providerConfigKey, canRead }) => {
     return (
         <>
-            {'app' in credentials && credentials.app && <AppCredentialsComponent credentials={credentials.app} />}
+            {'app' in credentials && credentials.app && <AppCredentialsComponent credentials={credentials.app} canRead={canRead} />}
             {'user' in credentials && credentials.user && (
-                <OAuth2CredentialsComponent connection={connection} credentials={credentials.user} providerConfigKey={providerConfigKey} />
+                <OAuth2CredentialsComponent connection={connection} credentials={credentials.user} providerConfigKey={providerConfigKey} canRead={canRead} />
             )}
         </>
     );

--- a/packages/webapp/src/pages/Connection/components/AuthCredentials/JwtCredentials.tsx
+++ b/packages/webapp/src/pages/Connection/components/AuthCredentials/JwtCredentials.tsx
@@ -12,7 +12,8 @@ export const JwtCredentialsComponent: React.FC<{
     credentials: JwtCredentials;
     connection: ApiConnectionFull;
     providerConfigKey: string;
-}> = ({ credentials, connection, providerConfigKey }) => {
+    canRead: boolean;
+}> = ({ credentials, connection, providerConfigKey, canRead }) => {
     const { forceRefresh, isRefreshing } = useRefreshConnectionWithToast(connection, providerConfigKey);
 
     return (
@@ -21,7 +22,7 @@ export const JwtCredentialsComponent: React.FC<{
                 <div className="flex flex-col gap-2">
                     <Label htmlFor="token">Token</Label>
                     <div className="flex gap-2 items-center">
-                        <SecretInput id="token" value={credentials.token} disabled copy />
+                        <SecretInput id="token" value={credentials.token} disabled copy canRead={canRead} />
                         <Button variant="secondary" size="sm" className="h-full" onClick={forceRefresh} loading={isRefreshing}>
                             <RefreshCwIcon />
                             Refresh
@@ -45,6 +46,7 @@ export const JwtCredentialsComponent: React.FC<{
                         }
                         disabled
                         copy
+                        canRead={canRead}
                     />
                 </div>
             )}
@@ -60,7 +62,7 @@ export const JwtCredentialsComponent: React.FC<{
                 return (
                     <div className="flex flex-col gap-2" key={key}>
                         <Label htmlFor={key}>{label}</Label>
-                        <SecretInput id={key} value={value} disabled copy />
+                        <SecretInput id={key} value={value} disabled copy canRead={canRead} />
                     </div>
                 );
             })}

--- a/packages/webapp/src/pages/Connection/components/AuthCredentials/OAuth1Credentials.tsx
+++ b/packages/webapp/src/pages/Connection/components/AuthCredentials/OAuth1Credentials.tsx
@@ -5,17 +5,18 @@ import type { OAuth1Credentials } from '@nangohq/types';
 
 export const OAuth1CredentialsComponent: React.FC<{
     credentials: OAuth1Credentials;
-}> = ({ credentials }) => {
+    canRead: boolean;
+}> = ({ credentials, canRead }) => {
     return (
         <>
             <div className="flex flex-col gap-2">
                 <Label htmlFor="oauth_token">OAuth token</Label>
-                <SecretInput id="oauth_token" value={credentials.oauth_token} disabled copy />
+                <SecretInput id="oauth_token" value={credentials.oauth_token} disabled copy canRead={canRead} />
             </div>
 
             <div className="flex flex-col gap-2">
                 <Label htmlFor="oauth_token_secret">OAuth token secret</Label>
-                <SecretInput id="oauth_token_secret" value={credentials.oauth_token_secret} disabled copy />
+                <SecretInput id="oauth_token_secret" value={credentials.oauth_token_secret} disabled copy canRead={canRead} />
             </div>
         </>
     );

--- a/packages/webapp/src/pages/Connection/components/AuthCredentials/OAuth2ClientCredentials.tsx
+++ b/packages/webapp/src/pages/Connection/components/AuthCredentials/OAuth2ClientCredentials.tsx
@@ -11,7 +11,8 @@ export const OAuth2ClientCredentialsComponent: React.FC<{
     credentials: OAuth2ClientCredentials;
     connection: ApiConnectionFull;
     providerConfigKey: string;
-}> = ({ credentials, connection, providerConfigKey }) => {
+    canRead: boolean;
+}> = ({ credentials, connection, providerConfigKey, canRead }) => {
     const { forceRefresh, isRefreshing } = useRefreshConnectionWithToast(connection, providerConfigKey);
 
     return (
@@ -19,7 +20,7 @@ export const OAuth2ClientCredentialsComponent: React.FC<{
             <div className="flex flex-col gap-2">
                 <Label htmlFor="token">Token</Label>
                 <div className="flex gap-2 items-center">
-                    <SecretInput id="token" value={credentials.token} disabled copy />
+                    <SecretInput id="token" value={credentials.token} disabled copy canRead={canRead} />
                     <Button variant="secondary" size="sm" className="h-full" onClick={forceRefresh} loading={isRefreshing}>
                         <RefreshCwIcon />
                         Refresh
@@ -29,25 +30,25 @@ export const OAuth2ClientCredentialsComponent: React.FC<{
 
             <div className="flex flex-col gap-2">
                 <Label htmlFor="client_id">Client ID</Label>
-                <SecretInput id="client_id" value={credentials.client_id} disabled copy />
+                <SecretInput id="client_id" value={credentials.client_id} disabled copy canRead={canRead} />
             </div>
 
             <div className="flex flex-col gap-2">
                 <Label htmlFor="client_secret">Client secret</Label>
-                <SecretInput id="client_secret" value={credentials.client_secret} disabled copy />
+                <SecretInput id="client_secret" value={credentials.client_secret} disabled copy canRead={canRead} />
             </div>
 
             {credentials.client_certificate && (
                 <div className="flex flex-col gap-2">
                     <Label htmlFor="client_certificate">Client certificate</Label>
-                    <SecretInput id="client_certificate" value={credentials.client_certificate} disabled copy />
+                    <SecretInput id="client_certificate" value={credentials.client_certificate} disabled copy canRead={canRead} />
                 </div>
             )}
 
             {credentials.client_private_key && (
                 <div className="flex flex-col gap-2">
                     <Label htmlFor="client_private_key">Client private Key</Label>
-                    <SecretInput id="client_private_key" value={credentials.client_private_key} disabled copy />
+                    <SecretInput id="client_private_key" value={credentials.client_private_key} disabled copy canRead={canRead} />
                 </div>
             )}
         </>

--- a/packages/webapp/src/pages/Connection/components/AuthCredentials/OAuth2Credentials.tsx
+++ b/packages/webapp/src/pages/Connection/components/AuthCredentials/OAuth2Credentials.tsx
@@ -8,10 +8,11 @@ import { useRefreshConnectionWithToast } from '@/hooks/useRefreshConnectionWithT
 import type { ApiConnectionFull, OAuth2Credentials } from '@nangohq/types';
 
 export const OAuth2CredentialsComponent: React.FC<{
-    connection: ApiConnectionFull;
     credentials: OAuth2Credentials;
+    connection: ApiConnectionFull;
     providerConfigKey: string;
-}> = ({ connection, credentials, providerConfigKey }) => {
+    canRead: boolean;
+}> = ({ credentials, connection, providerConfigKey, canRead }) => {
     const { forceRefresh, isRefreshing } = useRefreshConnectionWithToast(connection, providerConfigKey);
 
     return (
@@ -19,7 +20,7 @@ export const OAuth2CredentialsComponent: React.FC<{
             <div className="flex flex-col gap-2">
                 <Label htmlFor="access_token">Access token</Label>
                 <div className="flex gap-2 items-center">
-                    <SecretInput id="access_token" value={credentials.access_token} disabled copy />
+                    <SecretInput id="access_token" value={credentials.access_token} disabled copy canRead={canRead} />
                     {credentials.refresh_token && (
                         <Button variant="secondary" size="sm" className="h-full" onClick={forceRefresh} loading={isRefreshing}>
                             <RefreshCwIcon />
@@ -32,7 +33,7 @@ export const OAuth2CredentialsComponent: React.FC<{
             {credentials.refresh_token && (
                 <div className="flex flex-col gap-2">
                     <Label htmlFor="refresh_token">Refresh token</Label>
-                    <SecretInput id="refresh_token" value={credentials.refresh_token} disabled copy />
+                    <SecretInput id="refresh_token" value={credentials.refresh_token} disabled copy canRead={canRead} />
                 </div>
             )}
 
@@ -41,14 +42,14 @@ export const OAuth2CredentialsComponent: React.FC<{
                     {credentials.config_override.client_id && (
                         <div className="flex flex-col gap-2">
                             <Label htmlFor="client_id_override">Client ID override</Label>
-                            <SecretInput id="client_id_override" value={credentials.config_override.client_id} disabled copy />
+                            <SecretInput id="client_id_override" value={credentials.config_override.client_id} disabled copy canRead={canRead} />
                         </div>
                     )}
 
                     {credentials.config_override.client_secret && (
                         <div className="flex flex-col gap-2">
                             <Label htmlFor="client_secret_override">Client secret override</Label>
-                            <SecretInput id="client_secret_override" value={credentials.config_override.client_secret} disabled copy />
+                            <SecretInput id="client_secret_override" value={credentials.config_override.client_secret} disabled copy canRead={canRead} />
                         </div>
                     )}
                 </>

--- a/packages/webapp/src/pages/Connection/components/AuthCredentials/SignatureCredentials.tsx
+++ b/packages/webapp/src/pages/Connection/components/AuthCredentials/SignatureCredentials.tsx
@@ -11,26 +11,27 @@ export const SignatureCredentialsComponent: React.FC<{
     credentials: SignatureCredentials;
     connection: ApiConnectionFull;
     providerConfigKey: string;
-}> = ({ credentials, connection, providerConfigKey }) => {
+    canRead: boolean;
+}> = ({ credentials, connection, providerConfigKey, canRead }) => {
     const { forceRefresh, isRefreshing } = useRefreshConnectionWithToast(connection, providerConfigKey);
 
     return (
         <>
             <div className="flex flex-col gap-2">
                 <Label htmlFor="username">Username</Label>
-                <SecretInput id="username" value={credentials.username} disabled copy />
+                <SecretInput id="username" value={credentials.username} disabled copy canRead={canRead} />
             </div>
 
             <div className="flex flex-col gap-2">
                 <Label htmlFor="password">Password</Label>
-                <SecretInput id="password" value={credentials.password} disabled copy />
+                <SecretInput id="password" value={credentials.password} disabled copy canRead={canRead} />
             </div>
 
             {credentials.token && (
                 <div className="flex flex-col gap-2">
                     <Label htmlFor="token">Token</Label>
                     <div className="flex gap-2 items-center">
-                        <SecretInput id="token" value={credentials.token} disabled copy />
+                        <SecretInput id="token" value={credentials.token} disabled copy canRead={canRead} />
                         <Button variant="secondary" size="sm" className="h-full" onClick={forceRefresh} loading={isRefreshing}>
                             <RefreshCwIcon />
                             Refresh

--- a/packages/webapp/src/pages/Connection/components/AuthCredentials/TbaCredentials.tsx
+++ b/packages/webapp/src/pages/Connection/components/AuthCredentials/TbaCredentials.tsx
@@ -5,17 +5,18 @@ import type { TbaCredentials } from '@nangohq/types';
 
 export const TbaCredentialsComponent: React.FC<{
     credentials: TbaCredentials;
-}> = ({ credentials }) => {
+    canRead: boolean;
+}> = ({ credentials, canRead }) => {
     return (
         <>
             <div className="flex flex-col gap-2">
                 <Label htmlFor="token_id">Token ID</Label>
-                <SecretInput id="token_id" value={credentials.token_id} disabled copy />
+                <SecretInput id="token_id" value={credentials.token_id} disabled copy canRead={canRead} />
             </div>
 
             <div className="flex flex-col gap-2">
                 <Label htmlFor="token_secret">Token secret</Label>
-                <SecretInput id="token_secret" value={credentials.token_secret} disabled copy />
+                <SecretInput id="token_secret" value={credentials.token_secret} disabled copy canRead={canRead} />
             </div>
 
             {credentials.config_override && (
@@ -23,14 +24,14 @@ export const TbaCredentialsComponent: React.FC<{
                     {credentials.config_override.client_id && (
                         <div className="flex flex-col gap-2">
                             <Label htmlFor="client_id_override">Client ID override</Label>
-                            <SecretInput id="client_id_override" value={credentials.config_override.client_id} disabled copy />
+                            <SecretInput id="client_id_override" value={credentials.config_override.client_id} disabled copy canRead={canRead} />
                         </div>
                     )}
 
                     {credentials.config_override.client_secret && (
                         <div className="flex flex-col gap-2">
                             <Label htmlFor="client_secret_override">Client secret override</Label>
-                            <SecretInput id="client_secret_override" value={credentials.config_override.client_secret} disabled copy />
+                            <SecretInput id="client_secret_override" value={credentials.config_override.client_secret} disabled copy canRead={canRead} />
                         </div>
                     )}
                 </>

--- a/packages/webapp/src/pages/Connection/components/AuthCredentials/TwoStepCredentials.tsx
+++ b/packages/webapp/src/pages/Connection/components/AuthCredentials/TwoStepCredentials.tsx
@@ -12,7 +12,8 @@ export const TwoStepCredentialsComponent: React.FC<{
     credentials: TwoStepCredentials;
     connection: ApiConnectionFull;
     providerConfigKey: string;
-}> = ({ credentials, connection, providerConfigKey }) => {
+    canRead: boolean;
+}> = ({ credentials, connection, providerConfigKey, canRead }) => {
     const { forceRefresh, isRefreshing } = useRefreshConnectionWithToast(connection, providerConfigKey);
 
     return (
@@ -21,7 +22,7 @@ export const TwoStepCredentialsComponent: React.FC<{
                 <div className="flex flex-col gap-2">
                     <Label htmlFor="token">Token</Label>
                     <div className="flex gap-2 items-center">
-                        <SecretInput id="token" value={credentials.token} disabled copy />
+                        <SecretInput id="token" value={credentials.token} disabled copy canRead={canRead} />
                         <Button variant="secondary" size="sm" className="h-full" onClick={forceRefresh} loading={isRefreshing}>
                             <RefreshCwIcon />
                             Refresh
@@ -33,7 +34,7 @@ export const TwoStepCredentialsComponent: React.FC<{
             {credentials.refresh_token && (
                 <div className="flex flex-col gap-2">
                     <Label htmlFor="refresh_token">Refresh token</Label>
-                    <SecretInput id="refresh_token" value={credentials.refresh_token} disabled copy />
+                    <SecretInput id="refresh_token" value={credentials.refresh_token} disabled copy canRead={canRead} />
                 </div>
             )}
 
@@ -48,7 +49,7 @@ export const TwoStepCredentialsComponent: React.FC<{
                 return (
                     <div className="flex flex-col gap-2" key={key}>
                         <Label htmlFor={key}>{label}</Label>
-                        <SecretInput id={key} value={value} disabled copy />
+                        <SecretInput id={key} value={value} disabled copy canRead={canRead} />
                     </div>
                 );
             })}

--- a/packages/webapp/src/pages/Connection/components/AuthTab.tsx
+++ b/packages/webapp/src/pages/Connection/components/AuthTab.tsx
@@ -13,6 +13,7 @@ import type { GetConnection } from '@nangohq/types';
 
 export const AuthTab = ({ connectionData, providerConfigKey }: { connectionData: GetConnection['Success']['data']; providerConfigKey: string }) => {
     const env = useStore((state) => state.env);
+
     const { connection, errorLog } = connectionData;
     const { credentials } = connection;
 

--- a/packages/webapp/src/pages/Connection/components/CreateConnectionSelector.tsx
+++ b/packages/webapp/src/pages/Connection/components/CreateConnectionSelector.tsx
@@ -21,7 +21,9 @@ import { useAnalyticsTrack } from '../../../utils/analytics';
 import { globalEnv } from '../../../utils/env';
 import { formatDateToPreciseUSFormat } from '../../../utils/utils';
 import { InfoTooltip } from '@/components-v2/InfoTooltip';
+import { PermissionGate } from '@/components-v2/PermissionGate';
 import { Card, CardContent, CardDescription, CardHeader, CardTitle } from '@/components-v2/ui/card';
+import { permissions, usePermissions } from '@/hooks/usePermissions';
 
 import type { AuthResult, ConnectUI, OnConnectEvent } from '@nangohq/frontend';
 import type { ApiIntegrationList } from '@nangohq/types';
@@ -66,7 +68,11 @@ export const CreateConnectionSelector: React.FC<CreateConnectionSelectorProps> =
     const env = useStore((state) => state.env);
     const { data } = useEnvironment(env);
     const environmentAndAccount = data?.environmentAndAccount;
+    const environment = environmentAndAccount?.environment;
     const { data: listIntegrationData, isLoading: listIntegrationPending } = useListIntegrations(env);
+
+    const { can } = usePermissions();
+    const canCreateTestConnection = can(permissions.canWriteProdConnections) || !environment?.is_production;
 
     const connectUI = useRef<ConnectUI>();
     const hasConnected = useRef<AuthResult | undefined>();
@@ -292,9 +298,17 @@ export const CreateConnectionSelector: React.FC<CreateConnectionSelectorProps> =
                         <Tooltip>
                             <TooltipTrigger asChild>
                                 <span className="inline-block" tabIndex={0}>
-                                    <Button onClick={onClickConnectUI} size="lg" disabled={usageCapReached || integrationHasMissingFields || !isFormValid}>
-                                        Authorize
-                                    </Button>
+                                    <PermissionGate condition={canCreateTestConnection}>
+                                        {(allowed) => (
+                                            <Button
+                                                onClick={onClickConnectUI}
+                                                size="lg"
+                                                disabled={usageCapReached || integrationHasMissingFields || !isFormValid || !allowed}
+                                            >
+                                                Authorize
+                                            </Button>
+                                        )}
+                                    </PermissionGate>
                                 </span>
                             </TooltipTrigger>
                             {tooltipContent && <TooltipContent side="bottom">{tooltipContent}</TooltipContent>}
@@ -304,16 +318,20 @@ export const CreateConnectionSelector: React.FC<CreateConnectionSelectorProps> =
                         <Tooltip>
                             <TooltipTrigger asChild>
                                 <span className="inline-block" tabIndex={0}>
-                                    <Button
-                                        onClick={onClickShareConnectionLink}
-                                        size="lg"
-                                        variant="secondary"
-                                        loading={isShareLinkLoading}
-                                        disabled={usageCapReached || integrationHasMissingFields || !isFormValid}
-                                    >
-                                        <Link2 />
-                                        Share connect link
-                                    </Button>
+                                    <PermissionGate condition={canCreateTestConnection}>
+                                        {(allowed) => (
+                                            <Button
+                                                onClick={onClickShareConnectionLink}
+                                                size="lg"
+                                                variant="secondary"
+                                                loading={isShareLinkLoading}
+                                                disabled={usageCapReached || integrationHasMissingFields || !isFormValid || !allowed}
+                                            >
+                                                <Link2 />
+                                                Share connect link
+                                            </Button>
+                                        )}
+                                    </PermissionGate>
                                 </span>
                             </TooltipTrigger>
                             {tooltipContent && <TooltipContent side="bottom">{tooltipContent}</TooltipContent>}

--- a/packages/webapp/src/pages/Connection/components/CreateConnectionSelector.tsx
+++ b/packages/webapp/src/pages/Connection/components/CreateConnectionSelector.tsx
@@ -5,6 +5,7 @@ import { Link, useNavigate } from 'react-router-dom';
 import { useSearchParam, useUnmount } from 'react-use';
 import { useSWRConfig } from 'swr';
 
+import { permissions } from '@nangohq/authz';
 import Nango from '@nangohq/frontend';
 
 import { IntegrationDropdown } from './IntegrationDropdown';
@@ -23,7 +24,7 @@ import { formatDateToPreciseUSFormat } from '../../../utils/utils';
 import { InfoTooltip } from '@/components-v2/InfoTooltip';
 import { PermissionGate } from '@/components-v2/PermissionGate';
 import { Card, CardContent, CardDescription, CardHeader, CardTitle } from '@/components-v2/ui/card';
-import { permissions, usePermissions } from '@/hooks/usePermissions';
+import { usePermissions } from '@/hooks/usePermissions';
 
 import type { AuthResult, ConnectUI, OnConnectEvent } from '@nangohq/frontend';
 import type { ApiIntegrationList } from '@nangohq/types';

--- a/packages/webapp/src/pages/Connection/components/SettingsTab.tsx
+++ b/packages/webapp/src/pages/Connection/components/SettingsTab.tsx
@@ -1,13 +1,15 @@
 import { Trash2 } from 'lucide-react';
 import { useNavigate } from 'react-router-dom';
 
+import { permissions } from '@nangohq/authz';
+
 import { ConnectionSideInfo } from './ConnectionSideInfo';
 import { PermissionGate } from '@/components-v2/PermissionGate';
 import { Button } from '@/components-v2/ui/button';
 import { useConfirmDialog } from '@/hooks/useConfirmDialog';
 import { useDeleteConnection } from '@/hooks/useConnections';
 import { useEnvironment } from '@/hooks/useEnvironment';
-import { permissions, usePermissions } from '@/hooks/usePermissions';
+import { usePermissions } from '@/hooks/usePermissions';
 import { useToast } from '@/hooks/useToast';
 import { useStore } from '@/store';
 

--- a/packages/webapp/src/pages/Connection/components/SettingsTab.tsx
+++ b/packages/webapp/src/pages/Connection/components/SettingsTab.tsx
@@ -2,9 +2,12 @@ import { Trash2 } from 'lucide-react';
 import { useNavigate } from 'react-router-dom';
 
 import { ConnectionSideInfo } from './ConnectionSideInfo';
+import { PermissionGate } from '@/components-v2/PermissionGate';
 import { Button } from '@/components-v2/ui/button';
 import { useConfirmDialog } from '@/hooks/useConfirmDialog';
 import { useDeleteConnection } from '@/hooks/useConnections';
+import { useEnvironment } from '@/hooks/useEnvironment';
+import { permissions, usePermissions } from '@/hooks/usePermissions';
 import { useToast } from '@/hooks/useToast';
 import { useStore } from '@/store';
 
@@ -16,6 +19,10 @@ export const SettingsTab: React.FC<{ connectionData: GetConnection['Success']['d
 }) => {
     const env = useStore((state) => state.env);
     const { connection } = connectionData;
+    const { data } = useEnvironment(env);
+    const environment = data?.environmentAndAccount?.environment;
+    const { can } = usePermissions();
+    const canDeleteConnection = can(permissions.canDeleteProdConnections) || !environment?.is_production;
     const navigate = useNavigate();
 
     const { toast } = useToast();
@@ -40,23 +47,28 @@ export const SettingsTab: React.FC<{ connectionData: GetConnection['Success']['d
             <div className="flex justify-between items-start gap-11">
                 <div className="w-full flex items-center justify-between">
                     <span className="text-body-medium-semi text-text-primary">Connection deletion</span>
-                    <Button
-                        variant="destructive"
-                        size="lg"
-                        loading={isDeletingConnection}
-                        onClick={() =>
-                            confirm({
-                                title: 'Delete connection?',
-                                description: 'All credentials & synced data associated with this connection will be deleted.',
-                                confirmButtonText: 'Delete connection',
-                                confirmVariant: 'destructive',
-                                onConfirm: onDelete
-                            })
-                        }
-                    >
-                        <Trash2 />
-                        Delete connection
-                    </Button>
+                    <PermissionGate condition={canDeleteConnection} asChild>
+                        {(allowed) => (
+                            <Button
+                                variant="destructive"
+                                size="lg"
+                                loading={isDeletingConnection}
+                                disabled={!allowed}
+                                onClick={() =>
+                                    confirm({
+                                        title: 'Delete connection?',
+                                        description: 'All credentials & synced data associated with this connection will be deleted.',
+                                        confirmButtonText: 'Delete connection',
+                                        confirmVariant: 'destructive',
+                                        onConfirm: onDelete
+                                    })
+                                }
+                            >
+                                <Trash2 />
+                                Delete connection
+                            </Button>
+                        )}
+                    </PermissionGate>
                 </div>
 
                 <ConnectionSideInfo connectionData={connectionData} />

--- a/packages/webapp/src/pages/Environment/Settings/Backend.tsx
+++ b/packages/webapp/src/pages/Environment/Settings/Backend.tsx
@@ -3,6 +3,8 @@ import { Info } from 'lucide-react';
 import { useState } from 'react';
 import { Link } from 'react-router-dom';
 
+import { permissions } from '@nangohq/authz';
+
 import SettingsContent from './components/SettingsContent';
 import SettingsGroup from './components/SettingsGroup';
 import { useActivateKey, useEnvironment, usePatchEnvironment, useRevertKey, useRotateKey } from '../../../hooks/useEnvironment';
@@ -15,7 +17,7 @@ import { StyledLink } from '@/components-v2/StyledLink';
 import { Alert, AlertDescription } from '@/components-v2/ui/alert';
 import { Button } from '@/components-v2/ui/button';
 import { useConfirmDialog } from '@/hooks/useConfirmDialog';
-import { permissions, usePermissions } from '@/hooks/usePermissions';
+import { usePermissions } from '@/hooks/usePermissions';
 import { APIError } from '@/utils/api';
 
 export const BackendSettings: React.FC = () => {

--- a/packages/webapp/src/pages/Environment/Settings/Backend.tsx
+++ b/packages/webapp/src/pages/Environment/Settings/Backend.tsx
@@ -9,7 +9,7 @@ import { useActivateKey, useEnvironment, usePatchEnvironment, useRevertKey, useR
 import { useToast } from '../../../hooks/useToast';
 import { useStore } from '../../../store';
 import { EditableInput } from '@/components-v2/EditableInput';
-import { PermissionCondition } from '@/components-v2/PermissionGate';
+import { PermissionGate } from '@/components-v2/PermissionGate';
 import { SecretInput } from '@/components-v2/SecretInput';
 import { StyledLink } from '@/components-v2/StyledLink';
 import { Alert, AlertDescription } from '@/components-v2/ui/alert';
@@ -30,6 +30,7 @@ export const BackendSettings: React.FC = () => {
     const { mutateAsync: activateKeyAsync, isPending: isActivating } = useActivateKey(env);
 
     const isProdEnv = environmentAndAccount?.environment.is_production || false;
+
     const { can } = usePermissions();
     const canReadSecretKey = can(permissions.canReadProdSecretKey) || !isProdEnv;
     const canGenerateNewSecretKey = canReadSecretKey;
@@ -89,16 +90,14 @@ export const BackendSettings: React.FC = () => {
                     </div>
                     {!hasNewSecretKey && (
                         <div className="flex justify-start">
-                            <PermissionCondition condition={canGenerateNewSecretKey}>
+                            <PermissionGate condition={canGenerateNewSecretKey}>
                                 {(allowed) => (
                                     <Button disabled={!allowed} variant={'secondary'} onClick={onGenerate} loading={isRotating}>
-                                        <>
-                                            <IconKey stroke={1} size={18} />
-                                            Generate new secret key
-                                        </>
+                                        <IconKey stroke={1} size={18} />
+                                        Generate new secret key
                                     </Button>
                                 )}
-                            </PermissionCondition>
+                            </PermissionGate>
                         </div>
                     )}
                     {hasNewSecretKey && (

--- a/packages/webapp/src/pages/Environment/Settings/Backend.tsx
+++ b/packages/webapp/src/pages/Environment/Settings/Backend.tsx
@@ -35,7 +35,7 @@ export const BackendSettings: React.FC = () => {
 
     const { can } = usePermissions();
     const canReadSecretKey = can(permissions.canReadProdSecretKey) || !isProdEnv;
-    const canGenerateNewSecretKey = canReadSecretKey;
+    const canGenerateNewSecretKey = can(permissions.canWriteProdEnvironmentKeys) || !isProdEnv;
     const canEditEnv = can(permissions.canWriteProdEnvironment) || !isProdEnv;
 
     const { confirm, DialogComponent } = useConfirmDialog();

--- a/packages/webapp/src/pages/Environment/Settings/Backend.tsx
+++ b/packages/webapp/src/pages/Environment/Settings/Backend.tsx
@@ -9,11 +9,13 @@ import { useActivateKey, useEnvironment, usePatchEnvironment, useRevertKey, useR
 import { useToast } from '../../../hooks/useToast';
 import { useStore } from '../../../store';
 import { EditableInput } from '@/components-v2/EditableInput';
+import { PermissionCondition } from '@/components-v2/PermissionGate';
 import { SecretInput } from '@/components-v2/SecretInput';
 import { StyledLink } from '@/components-v2/StyledLink';
 import { Alert, AlertDescription } from '@/components-v2/ui/alert';
 import { Button } from '@/components-v2/ui/button';
 import { useConfirmDialog } from '@/hooks/useConfirmDialog';
+import { permissions, usePermissions } from '@/hooks/usePermissions';
 import { APIError } from '@/utils/api';
 
 export const BackendSettings: React.FC = () => {
@@ -26,6 +28,11 @@ export const BackendSettings: React.FC = () => {
     const { mutateAsync: rotateKeyAsync, isPending: isRotating } = useRotateKey(env);
     const { mutateAsync: revertKeyAsync, isPending: isReverting } = useRevertKey(env);
     const { mutateAsync: activateKeyAsync, isPending: isActivating } = useActivateKey(env);
+
+    const isProdEnv = environmentAndAccount?.environment.is_production || false;
+    const { can } = usePermissions();
+    const canReadSecretKey = can(permissions.canReadProdSecretKey) || !isProdEnv;
+    const canGenerateNewSecretKey = canReadSecretKey;
 
     const { confirm, DialogComponent } = useConfirmDialog();
 
@@ -71,17 +78,26 @@ export const BackendSettings: React.FC = () => {
                             </label>
                         )}
                         <div className="flex gap-2">
-                            <SecretInput copy name="secretKey" value={environmentAndAccount.environment.secret_key} />
+                            <SecretInput
+                                name="secretKey"
+                                value={environmentAndAccount.environment.secret_key}
+                                copy={canReadSecretKey}
+                                canRead={canReadSecretKey}
+                            />
                         </div>
                     </div>
                     {!hasNewSecretKey && (
                         <div className="flex justify-start">
-                            <Button variant={'secondary'} onClick={onGenerate} loading={isRotating}>
-                                <>
-                                    <IconKey stroke={1} size={18} />
-                                    Generate new secret key
-                                </>
-                            </Button>
+                            <PermissionCondition condition={canGenerateNewSecretKey}>
+                                {(allowed) => (
+                                    <Button disabled={!allowed} variant={'secondary'} onClick={onGenerate} loading={isRotating}>
+                                        <>
+                                            <IconKey stroke={1} size={18} />
+                                            Generate new secret key
+                                        </>
+                                    </Button>
+                                )}
+                            </PermissionCondition>
                         </div>
                     )}
                     {hasNewSecretKey && (
@@ -89,7 +105,12 @@ export const BackendSettings: React.FC = () => {
                             <label htmlFor="secretKey" className="text-sm">
                                 New secret
                             </label>
-                            <SecretInput copy name="pendingSecretKey" value={environmentAndAccount.environment.pending_secret_key!} />
+                            <SecretInput
+                                name="pendingSecretKey"
+                                value={environmentAndAccount.environment.pending_secret_key!}
+                                copy={canReadSecretKey}
+                                canRead={canReadSecretKey}
+                            />
                         </div>
                     )}
                     {hasNewSecretKey && (

--- a/packages/webapp/src/pages/Environment/Settings/Backend.tsx
+++ b/packages/webapp/src/pages/Environment/Settings/Backend.tsx
@@ -33,6 +33,7 @@ export const BackendSettings: React.FC = () => {
     const { can } = usePermissions();
     const canReadSecretKey = can(permissions.canReadProdSecretKey) || !isProdEnv;
     const canGenerateNewSecretKey = canReadSecretKey;
+    const canEditEnv = can(permissions.canWriteProdEnvironment) || !isProdEnv;
 
     const { confirm, DialogComponent } = useConfirmDialog();
 
@@ -199,6 +200,7 @@ export const BackendSettings: React.FC = () => {
                                 throw err;
                             }
                         }}
+                        canEdit={canEditEnv}
                     />
                     {isEditingCallbackUrl && (
                         <Alert variant="info">

--- a/packages/webapp/src/pages/Environment/Settings/Backend.tsx
+++ b/packages/webapp/src/pages/Environment/Settings/Backend.tsx
@@ -85,6 +85,7 @@ export const BackendSettings: React.FC = () => {
                                 value={environmentAndAccount.environment.secret_key}
                                 copy={canReadSecretKey}
                                 canRead={canReadSecretKey}
+                                disabled
                             />
                         </div>
                     </div>
@@ -110,6 +111,7 @@ export const BackendSettings: React.FC = () => {
                                 value={environmentAndAccount.environment.pending_secret_key!}
                                 copy={canReadSecretKey}
                                 canRead={canReadSecretKey}
+                                disabled
                             />
                         </div>
                     )}

--- a/packages/webapp/src/pages/Environment/Settings/ConnectUISettings/index.tsx
+++ b/packages/webapp/src/pages/Environment/Settings/ConnectUISettings/index.tsx
@@ -6,6 +6,7 @@ import { ConnectUIPreview } from './components/ConnectUIPreview';
 import SettingsContent from '../components/SettingsContent';
 import { ColorInput } from '@/components-v2/ColorInput';
 import { InfoTooltip } from '@/components-v2/InfoTooltip';
+import { PermissionGate } from '@/components-v2/PermissionGate';
 import { StyledLink } from '@/components-v2/StyledLink';
 import { Button, ButtonLink } from '@/components-v2/ui/button';
 import { Select, SelectContent, SelectItem, SelectTrigger, SelectValue } from '@/components-v2/ui/select';
@@ -13,6 +14,7 @@ import { Switch } from '@/components-v2/ui/switch';
 import { Tooltip, TooltipContent, TooltipTrigger } from '@/components-v2/ui/tooltip';
 import { useConnectUISettings, useUpdateConnectUISettings } from '@/hooks/useConnectUISettings';
 import { useEnvironment } from '@/hooks/useEnvironment';
+import { permissions, usePermissions } from '@/hooks/usePermissions';
 import { useToast } from '@/hooks/useToast';
 import { useStore } from '@/store';
 import { globalEnv } from '@/utils/env';
@@ -112,6 +114,9 @@ export const ConnectUISettings = () => {
     const { data: environmentData } = useEnvironment(env);
     const plan = environmentData?.plan;
 
+    const { can } = usePermissions();
+    const canManageConnectUI = can(permissions.canManageConnectUI);
+
     const { data: connectUISettings } = useConnectUISettings(env);
     const { mutate: updateConnectUISettings, isPending: isUpdatingConnectUISettings } = useUpdateConnectUISettings(env);
     const connectUIPreviewRef = useRef<ConnectUIPreviewRef>(null);
@@ -198,16 +203,20 @@ export const ConnectUISettings = () => {
 
                         <form.Subscribe selector={(state) => [state.canSubmit, state.isDirty, state.isSubmitting]}>
                             {([canSubmit, isDirty]) => (
-                                <Button
-                                    type="submit"
-                                    variant="primary"
-                                    size="sm"
-                                    className="self-start"
-                                    disabled={!canSubmit || !isDirty}
-                                    loading={isUpdatingConnectUISettings}
-                                >
-                                    Save
-                                </Button>
+                                <PermissionGate asChild condition={canManageConnectUI}>
+                                    {(allowed) => (
+                                        <Button
+                                            type="submit"
+                                            variant="primary"
+                                            size="sm"
+                                            className="self-start"
+                                            disabled={!canSubmit || !isDirty || !allowed}
+                                            loading={isUpdatingConnectUISettings}
+                                        >
+                                            Save
+                                        </Button>
+                                    )}
+                                </PermissionGate>
                             )}
                         </form.Subscribe>
 

--- a/packages/webapp/src/pages/Environment/Settings/ConnectUISettings/index.tsx
+++ b/packages/webapp/src/pages/Environment/Settings/ConnectUISettings/index.tsx
@@ -2,6 +2,8 @@ import { useForm } from '@tanstack/react-form';
 import { Info, Lock } from 'lucide-react';
 import React, { useRef } from 'react';
 
+import { permissions } from '@nangohq/authz';
+
 import { ConnectUIPreview } from './components/ConnectUIPreview';
 import SettingsContent from '../components/SettingsContent';
 import { ColorInput } from '@/components-v2/ColorInput';
@@ -14,7 +16,7 @@ import { Switch } from '@/components-v2/ui/switch';
 import { Tooltip, TooltipContent, TooltipTrigger } from '@/components-v2/ui/tooltip';
 import { useConnectUISettings, useUpdateConnectUISettings } from '@/hooks/useConnectUISettings';
 import { useEnvironment } from '@/hooks/useEnvironment';
-import { permissions, usePermissions } from '@/hooks/usePermissions';
+import { usePermissions } from '@/hooks/usePermissions';
 import { useToast } from '@/hooks/useToast';
 import { useStore } from '@/store';
 import { globalEnv } from '@/utils/env';

--- a/packages/webapp/src/pages/Environment/Settings/Deprecated.tsx
+++ b/packages/webapp/src/pages/Environment/Settings/Deprecated.tsx
@@ -8,10 +8,12 @@ import { useEnvironment, usePatchEnvironment } from '../../../hooks/useEnvironme
 import { useToast } from '../../../hooks/useToast';
 import { useStore } from '../../../store';
 import { EditableInput } from '@/components-v2/EditableInput';
+import { PermissionGate } from '@/components-v2/PermissionGate';
 import { SecretInput } from '@/components-v2/SecretInput';
 import { ButtonLink } from '@/components-v2/ui/button';
 import { Label } from '@/components-v2/ui/label';
 import { Switch } from '@/components-v2/ui/switch';
+import { permissions, usePermissions } from '@/hooks/usePermissions';
 
 export const DeprecatedSettings: React.FC = () => {
     const { toast } = useToast();
@@ -19,7 +21,12 @@ export const DeprecatedSettings: React.FC = () => {
     const env = useStore((state) => state.env);
     const { data } = useEnvironment(env);
     const environmentAndAccount = data?.environmentAndAccount;
+    const environment = environmentAndAccount?.environment;
     const { mutateAsync: patchEnvironmentAsync } = usePatchEnvironment(env);
+
+    const { can } = usePermissions();
+    const canReadEnvironmentKey = can(permissions.canReadProdSecretKey) || !environment?.is_production;
+    const canEditEnvironment = can(permissions.canWriteProdEnvironment) || !environment?.is_production;
 
     const [loading, setLoading] = useState(false);
 
@@ -56,7 +63,7 @@ export const DeprecatedSettings: React.FC = () => {
                 }
             >
                 <fieldset className="flex flex-col gap-4">
-                    <SecretInput copy name="publicKey" value={environmentAndAccount.environment.public_key} />
+                    <SecretInput copy name="publicKey" value={environmentAndAccount.environment.public_key} canRead={canReadEnvironmentKey} />
                 </fieldset>
             </SettingsGroup>
             <SettingsGroup
@@ -81,11 +88,16 @@ export const DeprecatedSettings: React.FC = () => {
                         </label>
                         <div className="flex gap-2 items-center">
                             {loading && <Spinner size={1} />}
-                            <Switch
-                                name="hmac_enabled"
-                                checked={environmentAndAccount.environment.hmac_enabled}
-                                onCheckedChange={(checked) => onHmacEnabled(!!checked)}
-                            />
+                            <PermissionGate condition={canEditEnvironment}>
+                                {(allowed) => (
+                                    <Switch
+                                        name="hmac_enabled"
+                                        checked={environmentAndAccount.environment.hmac_enabled}
+                                        onCheckedChange={(checked) => onHmacEnabled(!!checked)}
+                                        disabled={!allowed}
+                                    />
+                                )}
+                            </PermissionGate>
                         </div>
                     </div>
 
@@ -105,6 +117,7 @@ export const DeprecatedSettings: React.FC = () => {
                                     throw err;
                                 }
                             }}
+                            canEdit={canEditEnvironment}
                         />
                     </div>
                 </div>

--- a/packages/webapp/src/pages/Environment/Settings/Deprecated.tsx
+++ b/packages/webapp/src/pages/Environment/Settings/Deprecated.tsx
@@ -1,6 +1,8 @@
 import { ExternalLink } from 'lucide-react';
 import { useState } from 'react';
 
+import { permissions } from '@nangohq/authz';
+
 import SettingsContent from './components/SettingsContent';
 import SettingsGroup from './components/SettingsGroup';
 import Spinner from '../../../components/ui/Spinner';
@@ -13,7 +15,7 @@ import { SecretInput } from '@/components-v2/SecretInput';
 import { ButtonLink } from '@/components-v2/ui/button';
 import { Label } from '@/components-v2/ui/label';
 import { Switch } from '@/components-v2/ui/switch';
-import { permissions, usePermissions } from '@/hooks/usePermissions';
+import { usePermissions } from '@/hooks/usePermissions';
 
 export const DeprecatedSettings: React.FC = () => {
     const { toast } = useToast();

--- a/packages/webapp/src/pages/Environment/Settings/Deprecated.tsx
+++ b/packages/webapp/src/pages/Environment/Settings/Deprecated.tsx
@@ -63,7 +63,7 @@ export const DeprecatedSettings: React.FC = () => {
                 }
             >
                 <fieldset className="flex flex-col gap-4">
-                    <SecretInput copy name="publicKey" value={environmentAndAccount.environment.public_key} canRead={canReadEnvironmentKey} />
+                    <SecretInput copy name="publicKey" value={environmentAndAccount.environment.public_key} canRead={canReadEnvironmentKey} disabled />
                 </fieldset>
             </SettingsGroup>
             <SettingsGroup

--- a/packages/webapp/src/pages/Environment/Settings/Functions.tsx
+++ b/packages/webapp/src/pages/Environment/Settings/Functions.tsx
@@ -7,7 +7,9 @@ import { useToast } from '../../../hooks/useToast';
 import { useStore } from '../../../store';
 import { APIError } from '../../../utils/api';
 import { KeyValueInput } from '@/components-v2/KeyValueInput';
+import { PermissionGate } from '@/components-v2/PermissionGate';
 import { Button, ButtonLink } from '@/components-v2/ui/button';
+import { permissions, usePermissions } from '@/hooks/usePermissions';
 
 import type { ApiEnvironmentVariable } from '@nangohq/types';
 
@@ -16,7 +18,11 @@ export const Functions: React.FC = () => {
     const env = useStore((state) => state.env);
     const { data } = useEnvironment(env);
     const environmentAndAccount = data?.environmentAndAccount;
+    const environment = environmentAndAccount?.environment;
     const { mutateAsync: postVariablesAsync, isPending } = usePostVariables(env);
+
+    const { can } = usePermissions();
+    const canEditEnvironmentVars = can(permissions.canWriteProdEnvironmentVariables) || !environment?.is_production;
 
     const [edit, setEdit] = useState(false);
     const [vars, setVars] = useState<Record<string, string>>(() => {
@@ -101,9 +107,13 @@ export const Functions: React.FC = () => {
                     </fieldset>
                     <div className="flex justify-start gap-2">
                         {!edit && (
-                            <Button variant="secondary" onClick={() => setEdit(true)}>
-                                Edit
-                            </Button>
+                            <PermissionGate asChild condition={canEditEnvironmentVars}>
+                                {(allowed) => (
+                                    <Button variant="secondary" onClick={() => setEdit(true)} disabled={!allowed}>
+                                        Edit
+                                    </Button>
+                                )}
+                            </PermissionGate>
                         )}
                         {edit && (
                             <>

--- a/packages/webapp/src/pages/Environment/Settings/Functions.tsx
+++ b/packages/webapp/src/pages/Environment/Settings/Functions.tsx
@@ -1,6 +1,8 @@
 import { ExternalLink } from 'lucide-react';
 import { useState } from 'react';
 
+import { permissions } from '@nangohq/authz';
+
 import SettingsContent from './components/SettingsContent';
 import { useEnvironment, usePostVariables } from '../../../hooks/useEnvironment';
 import { useToast } from '../../../hooks/useToast';
@@ -9,7 +11,7 @@ import { APIError } from '../../../utils/api';
 import { KeyValueInput } from '@/components-v2/KeyValueInput';
 import { PermissionGate } from '@/components-v2/PermissionGate';
 import { Button, ButtonLink } from '@/components-v2/ui/button';
-import { permissions, usePermissions } from '@/hooks/usePermissions';
+import { usePermissions } from '@/hooks/usePermissions';
 
 import type { ApiEnvironmentVariable } from '@nangohq/types';
 

--- a/packages/webapp/src/pages/Environment/Settings/General.tsx
+++ b/packages/webapp/src/pages/Environment/Settings/General.tsx
@@ -2,6 +2,8 @@ import { Info } from 'lucide-react';
 import { useState } from 'react';
 import { useNavigate } from 'react-router-dom';
 
+import { permissions } from '@nangohq/authz';
+
 import { DeleteButton } from './components/DeleteButton';
 import SettingsContent from './components/SettingsContent';
 import SettingsGroup from './components/SettingsGroup';
@@ -11,7 +13,7 @@ import { useMeta } from '../../../hooks/useMeta';
 import { useStore } from '../../../store';
 import { EditableInput } from '@/components-v2/EditableInput';
 import { Alert, AlertDescription } from '@/components-v2/ui/alert';
-import { permissions, usePermissions } from '@/hooks/usePermissions';
+import { usePermissions } from '@/hooks/usePermissions';
 import { useToast } from '@/hooks/useToast';
 import { APIError } from '@/utils/api';
 

--- a/packages/webapp/src/pages/Environment/Settings/General.tsx
+++ b/packages/webapp/src/pages/Environment/Settings/General.tsx
@@ -6,11 +6,12 @@ import { DeleteButton } from './components/DeleteButton';
 import SettingsContent from './components/SettingsContent';
 import SettingsGroup from './components/SettingsGroup';
 import { PROD_ENVIRONMENT_NAME } from '../../../constants';
-import { useDeleteEnvironment, usePatchEnvironment } from '../../../hooks/useEnvironment';
+import { useDeleteEnvironment, useEnvironment, usePatchEnvironment } from '../../../hooks/useEnvironment';
 import { useMeta } from '../../../hooks/useMeta';
 import { useStore } from '../../../store';
 import { EditableInput } from '@/components-v2/EditableInput';
 import { Alert, AlertDescription } from '@/components-v2/ui/alert';
+import { permissions, usePermissions } from '@/hooks/usePermissions';
 import { useToast } from '@/hooks/useToast';
 import { APIError } from '@/utils/api';
 
@@ -22,8 +23,14 @@ export const General: React.FC = () => {
     const { toast } = useToast();
 
     const { refetch: refetchMeta } = useMeta();
+    const { data } = useEnvironment(env);
+    const environmentAndAccount = data?.environmentAndAccount;
     const { mutateAsync: patchEnvironmentAsync } = usePatchEnvironment(env);
     const { mutateAsync: deleteEnvironmentAsync } = useDeleteEnvironment(env);
+
+    const isProdEnv = environmentAndAccount?.environment.is_production || false;
+    const { can } = usePermissions();
+    const canEditEnvironment = !isProdEnv || can(permissions.canWriteProdEnvironment);
 
     const [showDeleteAlert, setShowDeleteAlert] = useState(false);
 
@@ -67,6 +74,7 @@ export const General: React.FC = () => {
                         }}
                         disabled={env === PROD_ENVIRONMENT_NAME ? `You cannot rename the ${PROD_ENVIRONMENT_NAME} environment` : false}
                         hintText="Must be lowercase letters, numbers, underscores and/or dashes."
+                        canEdit={canEditEnvironment}
                     />
 
                     {env !== PROD_ENVIRONMENT_NAME && (

--- a/packages/webapp/src/pages/Environment/Settings/SlackAlerts.tsx
+++ b/packages/webapp/src/pages/Environment/Settings/SlackAlerts.tsx
@@ -7,8 +7,10 @@ import { apiFetch } from '../../../utils/api';
 import { globalEnv } from '../../../utils/env';
 import { connectSlack } from '../../../utils/slack-connection';
 import { SlackIcon } from '@/assets/SlackIcon';
+import { PermissionGate } from '@/components-v2/PermissionGate';
 import { Button } from '@/components-v2/ui/button';
 import { useEnvironment, usePatchEnvironment } from '@/hooks/useEnvironment';
+import { permissions, usePermissions } from '@/hooks/usePermissions';
 import { useStore } from '@/store';
 
 export const SlackAlertsSettings: React.FC = () => {
@@ -16,8 +18,12 @@ export const SlackAlertsSettings: React.FC = () => {
     const { data, refetch: refetchEnvironment } = useEnvironment(env);
     const { mutateAsync: patchEnvironmentAsync } = usePatchEnvironment(env);
     const environmentAndAccount = data?.environmentAndAccount;
+    const environment = environmentAndAccount?.environment;
     const [slackIsConnecting, setSlackIsConnecting] = useState(false);
     const { toast } = useToast();
+
+    const { can } = usePermissions();
+    const canEditEnvironment = can(permissions.canWriteProdEnvironment) || !environment?.is_production;
 
     if (!environmentAndAccount) {
         return null;
@@ -65,15 +71,19 @@ export const SlackAlertsSettings: React.FC = () => {
         <SettingsContent title="Slack alerts">
             <SettingsGroup label="Slack alerts" className="items-center">
                 <div className="flex justify-end">
-                    <Button
-                        className="px-4"
-                        disabled={slackIsConnecting}
-                        variant={isConnected ? 'tertiary' : 'primary'}
-                        onClick={isConnected ? slackDisconnect : slackConnect}
-                    >
-                        <SlackIcon className="w-5 h-5" />
-                        {isConnected ? `Disconnect from Slack` : 'Connect to Slack'}
-                    </Button>
+                    <PermissionGate asChild condition={canEditEnvironment}>
+                        {(allowed) => (
+                            <Button
+                                className="px-4"
+                                disabled={slackIsConnecting || !allowed}
+                                variant={isConnected ? 'tertiary' : 'primary'}
+                                onClick={isConnected ? slackDisconnect : slackConnect}
+                            >
+                                <SlackIcon className="w-5 h-5" />
+                                {isConnected ? `Disconnect from Slack` : 'Connect to Slack'}
+                            </Button>
+                        )}
+                    </PermissionGate>
                 </div>
             </SettingsGroup>
         </SettingsContent>

--- a/packages/webapp/src/pages/Environment/Settings/SlackAlerts.tsx
+++ b/packages/webapp/src/pages/Environment/Settings/SlackAlerts.tsx
@@ -1,5 +1,7 @@
 import { useState } from 'react';
 
+import { permissions } from '@nangohq/authz';
+
 import SettingsContent from './components/SettingsContent';
 import SettingsGroup from './components/SettingsGroup';
 import { useToast } from '../../../hooks/useToast';
@@ -10,7 +12,7 @@ import { SlackIcon } from '@/assets/SlackIcon';
 import { PermissionGate } from '@/components-v2/PermissionGate';
 import { Button } from '@/components-v2/ui/button';
 import { useEnvironment, usePatchEnvironment } from '@/hooks/useEnvironment';
-import { permissions, usePermissions } from '@/hooks/usePermissions';
+import { usePermissions } from '@/hooks/usePermissions';
 import { useStore } from '@/store';
 
 export const SlackAlertsSettings: React.FC = () => {

--- a/packages/webapp/src/pages/Environment/Settings/Telemetry.tsx
+++ b/packages/webapp/src/pages/Environment/Settings/Telemetry.tsx
@@ -1,6 +1,8 @@
 import { ExternalLink } from 'lucide-react';
 import { useEffect, useState } from 'react';
 
+import { permissions } from '@nangohq/authz';
+
 import SettingsContent from './components/SettingsContent';
 import SettingsGroup from './components/SettingsGroup';
 import { useEnvironment, usePatchEnvironment } from '../../../hooks/useEnvironment';
@@ -12,7 +14,7 @@ import { KeyValueInput } from '@/components-v2/KeyValueInput';
 import { PermissionGate } from '@/components-v2/PermissionGate';
 import { Button, ButtonLink } from '@/components-v2/ui/button';
 import { Label } from '@/components-v2/ui/label';
-import { permissions, usePermissions } from '@/hooks/usePermissions';
+import { usePermissions } from '@/hooks/usePermissions';
 
 export const Telemetry: React.FC = () => {
     const env = useStore((state) => state.env);

--- a/packages/webapp/src/pages/Environment/Settings/Telemetry.tsx
+++ b/packages/webapp/src/pages/Environment/Settings/Telemetry.tsx
@@ -9,15 +9,21 @@ import { useStore } from '../../../store';
 import { APIError } from '../../../utils/api';
 import { EditableInput } from '@/components-v2/EditableInput';
 import { KeyValueInput } from '@/components-v2/KeyValueInput';
+import { PermissionGate } from '@/components-v2/PermissionGate';
 import { Button, ButtonLink } from '@/components-v2/ui/button';
 import { Label } from '@/components-v2/ui/label';
+import { permissions, usePermissions } from '@/hooks/usePermissions';
 
 export const Telemetry: React.FC = () => {
     const env = useStore((state) => state.env);
     const { toast } = useToast();
     const { data } = useEnvironment(env);
     const environmentAndAccount = data?.environmentAndAccount;
+    const environment = environmentAndAccount?.environment;
     const { mutateAsync: patchEnvironmentAsync } = usePatchEnvironment(env);
+
+    const { can } = usePermissions();
+    const canEditEnvironment = can(permissions.canWriteProdEnvironment) || !environment?.is_production;
 
     const [loading, setLoading] = useState(false);
     const [editHeaders, setEditHeaders] = useState(false);
@@ -104,6 +110,7 @@ export const Telemetry: React.FC = () => {
                                 }
                             }}
                             placeholder="https://my.otlp.commector:4318"
+                            canEdit={canEditEnvironment}
                         />
                     </div>
                     <fieldset className="flex flex-col gap-4">
@@ -132,9 +139,13 @@ export const Telemetry: React.FC = () => {
                         </div>
                         <div className="flex justify-start gap-3 mt-1.5">
                             {!editHeaders && (
-                                <Button variant={'secondary'} onClick={() => setEditHeaders(true)}>
-                                    Edit
-                                </Button>
+                                <PermissionGate asChild condition={canEditEnvironment}>
+                                    {(allowed) => (
+                                        <Button variant={'secondary'} onClick={() => setEditHeaders(true)} disabled={!allowed}>
+                                            Edit
+                                        </Button>
+                                    )}
+                                </PermissionGate>
                             )}
                             {editHeaders && (
                                 <>

--- a/packages/webapp/src/pages/Environment/Settings/Webhooks.tsx
+++ b/packages/webapp/src/pages/Environment/Settings/Webhooks.tsx
@@ -8,6 +8,7 @@ import { useStore } from '../../../store.js';
 import { EditableInput } from '@/components-v2/EditableInput.js';
 import { ButtonLink } from '@/components-v2/ui/button.js';
 import { Label } from '@/components-v2/ui/label.js';
+import { permissions, usePermissions } from '@/hooks/usePermissions.js';
 import { useToast } from '@/hooks/useToast.js';
 import { validateUrl } from '@/pages/Integrations/utils.js';
 
@@ -19,6 +20,10 @@ export const Webhooks: React.FC = () => {
     const { mutateAsync: patchWebhookAsync } = usePatchWebhook(env);
     const { data } = useEnvironment(env);
     const environmentAndAccount = data?.environmentAndAccount;
+    const environment = environmentAndAccount?.environment;
+
+    const { can } = usePermissions();
+    const canEditEnvironment = can(permissions.canWriteProdEnvironment) || !environment?.is_production;
 
     const onSave = async (body: PatchWebhook['Body']) => {
         try {
@@ -55,6 +60,7 @@ export const Webhooks: React.FC = () => {
                             initialValue={environmentAndAccount.webhook_settings.primary_url || ''}
                             onSave={(value) => onSave({ primary_url: value })}
                             validate={validateUrl}
+                            canEdit={canEditEnvironment}
                         />
                     </div>
                     <div className="flex flex-col gap-2">
@@ -65,6 +71,7 @@ export const Webhooks: React.FC = () => {
                             initialValue={environmentAndAccount.webhook_settings.secondary_url || ''}
                             onSave={(value) => onSave({ secondary_url: value })}
                             validate={validateUrl}
+                            canEdit={canEditEnvironment}
                         />
                     </div>
                 </div>

--- a/packages/webapp/src/pages/Environment/Settings/Webhooks.tsx
+++ b/packages/webapp/src/pages/Environment/Settings/Webhooks.tsx
@@ -23,7 +23,7 @@ export const Webhooks: React.FC = () => {
     const environment = environmentAndAccount?.environment;
 
     const { can } = usePermissions();
-    const canEditEnvironment = can(permissions.canWriteProdEnvironment) || !environment?.is_production;
+    const canWriteWebhooks = can(permissions.canWriteProdWebhooks) || !environment?.is_production;
 
     const onSave = async (body: PatchWebhook['Body']) => {
         try {
@@ -60,7 +60,7 @@ export const Webhooks: React.FC = () => {
                             initialValue={environmentAndAccount.webhook_settings.primary_url || ''}
                             onSave={(value) => onSave({ primary_url: value })}
                             validate={validateUrl}
-                            canEdit={canEditEnvironment}
+                            canEdit={canWriteWebhooks}
                         />
                     </div>
                     <div className="flex flex-col gap-2">
@@ -71,7 +71,7 @@ export const Webhooks: React.FC = () => {
                             initialValue={environmentAndAccount.webhook_settings.secondary_url || ''}
                             onSave={(value) => onSave({ secondary_url: value })}
                             validate={validateUrl}
-                            canEdit={canEditEnvironment}
+                            canEdit={canWriteWebhooks}
                         />
                     </div>
                 </div>

--- a/packages/webapp/src/pages/Environment/Settings/Webhooks.tsx
+++ b/packages/webapp/src/pages/Environment/Settings/Webhooks.tsx
@@ -1,5 +1,7 @@
 import { ExternalLink } from 'lucide-react';
 
+import { permissions } from '@nangohq/authz';
+
 import SettingsContent from './components/SettingsContent.js';
 import SettingsGroup from './components/SettingsGroup.js';
 import { WebhookCheckboxes } from './components/WebhookCheckboxes.js';
@@ -8,7 +10,7 @@ import { useStore } from '../../../store.js';
 import { EditableInput } from '@/components-v2/EditableInput.js';
 import { ButtonLink } from '@/components-v2/ui/button.js';
 import { Label } from '@/components-v2/ui/label.js';
-import { permissions, usePermissions } from '@/hooks/usePermissions.js';
+import { usePermissions } from '@/hooks/usePermissions.js';
 import { useToast } from '@/hooks/useToast.js';
 import { validateUrl } from '@/pages/Integrations/utils.js';
 

--- a/packages/webapp/src/pages/Environment/Settings/components/DeleteButton.tsx
+++ b/packages/webapp/src/pages/Environment/Settings/components/DeleteButton.tsx
@@ -1,11 +1,13 @@
 import { IconTrash } from '@tabler/icons-react';
 
+import { permissions } from '@nangohq/authz';
+
 import { ConditionalTooltip } from '@/components-v2/ConditionalTooltip';
 import { DestructiveActionModal } from '@/components-v2/DestructiveActionModal';
 import { PermissionGate } from '@/components-v2/PermissionGate';
 import { Button } from '@/components-v2/ui/button';
 import { useEnvironment } from '@/hooks/useEnvironment';
-import { permissions, usePermissions } from '@/hooks/usePermissions';
+import { usePermissions } from '@/hooks/usePermissions';
 
 interface DeleteButtonProps {
     environmentName: string;

--- a/packages/webapp/src/pages/Environment/Settings/components/DeleteButton.tsx
+++ b/packages/webapp/src/pages/Environment/Settings/components/DeleteButton.tsx
@@ -2,7 +2,7 @@ import { IconTrash } from '@tabler/icons-react';
 
 import { ConditionalTooltip } from '@/components-v2/ConditionalTooltip';
 import { DestructiveActionModal } from '@/components-v2/DestructiveActionModal';
-import { PermissionCondition } from '@/components-v2/PermissionGate';
+import { PermissionGate } from '@/components-v2/PermissionGate';
 import { Button } from '@/components-v2/ui/button';
 import { useEnvironment } from '@/hooks/useEnvironment';
 import { permissions, usePermissions } from '@/hooks/usePermissions';
@@ -24,14 +24,14 @@ export const DeleteButton: React.FC<DeleteButtonProps> = ({ environmentName, onD
 
     const trigger = (
         <ConditionalTooltip condition={typeof disabled === 'string'} content={disabled}>
-            <PermissionCondition condition={canDeleteEnvironment}>
+            <PermissionGate condition={canDeleteEnvironment}>
                 {(allowed) => (
                     <Button variant="destructive" disabled={!!disabled || !allowed}>
                         <IconTrash stroke={1} size={18} />
                         <span>Delete environment</span>
                     </Button>
                 )}
-            </PermissionCondition>
+            </PermissionGate>
         </ConditionalTooltip>
     );
 

--- a/packages/webapp/src/pages/Environment/Settings/components/DeleteButton.tsx
+++ b/packages/webapp/src/pages/Environment/Settings/components/DeleteButton.tsx
@@ -1,8 +1,11 @@
 import { IconTrash } from '@tabler/icons-react';
 
+import { ConditionalTooltip } from '@/components-v2/ConditionalTooltip';
 import { DestructiveActionModal } from '@/components-v2/DestructiveActionModal';
+import { PermissionCondition } from '@/components-v2/PermissionGate';
 import { Button } from '@/components-v2/ui/button';
-import { Tooltip, TooltipContent, TooltipTrigger } from '@/components-v2/ui/tooltip';
+import { useEnvironment } from '@/hooks/useEnvironment';
+import { permissions, usePermissions } from '@/hooks/usePermissions';
 
 interface DeleteButtonProps {
     environmentName: string;
@@ -13,16 +16,23 @@ interface DeleteButtonProps {
 }
 
 export const DeleteButton: React.FC<DeleteButtonProps> = ({ environmentName, onDelete, open, onOpenChange, disabled }) => {
+    const { data } = useEnvironment(environmentName);
+    const environmentAndAccount = data?.environmentAndAccount;
+    const isProdEnv = environmentAndAccount?.environment.is_production;
+    const { can } = usePermissions();
+    const canDeleteEnvironment = !isProdEnv || can(permissions.canDeleteProdEnvironment);
+
     const trigger = (
-        <Tooltip>
-            <TooltipTrigger>
-                <Button variant="destructive" disabled={!!disabled}>
-                    <IconTrash stroke={1} size={18} />
-                    <span>Delete environment</span>
-                </Button>
-            </TooltipTrigger>
-            {typeof disabled === 'string' && <TooltipContent>{disabled}</TooltipContent>}
-        </Tooltip>
+        <ConditionalTooltip condition={typeof disabled === 'string'} content={disabled}>
+            <PermissionCondition condition={canDeleteEnvironment}>
+                {(allowed) => (
+                    <Button variant="destructive" disabled={!!disabled || !allowed}>
+                        <IconTrash stroke={1} size={18} />
+                        <span>Delete environment</span>
+                    </Button>
+                )}
+            </PermissionCondition>
+        </ConditionalTooltip>
     );
 
     return (

--- a/packages/webapp/src/pages/Environment/Settings/components/WebhookCheckboxes.tsx
+++ b/packages/webapp/src/pages/Environment/Settings/components/WebhookCheckboxes.tsx
@@ -1,11 +1,13 @@
 import { Loader2 } from 'lucide-react';
 import { useState } from 'react';
 
+import { permissions } from '@nangohq/authz';
+
 import { useEnvironment, usePatchWebhook } from '../../../../hooks/useEnvironment';
 import { useToast } from '../../../../hooks/useToast';
 import { PermissionGate } from '@/components-v2/PermissionGate';
 import { Switch } from '@/components-v2/ui/switch';
-import { permissions, usePermissions } from '@/hooks/usePermissions';
+import { usePermissions } from '@/hooks/usePermissions';
 
 import type { ApiWebhooks } from '@nangohq/types';
 

--- a/packages/webapp/src/pages/Environment/Settings/components/WebhookCheckboxes.tsx
+++ b/packages/webapp/src/pages/Environment/Settings/components/WebhookCheckboxes.tsx
@@ -1,9 +1,11 @@
 import { Loader2 } from 'lucide-react';
 import { useState } from 'react';
 
-import { usePatchWebhook } from '../../../../hooks/useEnvironment';
+import { useEnvironment, usePatchWebhook } from '../../../../hooks/useEnvironment';
 import { useToast } from '../../../../hooks/useToast';
+import { PermissionGate } from '@/components-v2/PermissionGate';
 import { Switch } from '@/components-v2/ui/switch';
+import { permissions, usePermissions } from '@/hooks/usePermissions';
 
 import type { ApiWebhooks } from '@nangohq/types';
 
@@ -50,6 +52,13 @@ export const WebhookCheckboxes: React.FC<CheckboxFormProps> = ({ env, checkboxSt
     const { toast } = useToast();
     const { mutateAsync: patchWebhookAsync } = usePatchWebhook(env);
 
+    const { data } = useEnvironment(env);
+    const environmentAndAccount = data?.environmentAndAccount;
+    const environment = environmentAndAccount?.environment;
+
+    const { can } = usePermissions();
+    const canEditEnvironment = can(permissions.canWriteProdEnvironment) || !environment?.is_production;
+
     const [loading, setLoading] = useState<string | false>();
 
     const handleCheckboxChange = async (name: string, checked: boolean) => {
@@ -84,11 +93,16 @@ export const WebhookCheckboxes: React.FC<CheckboxFormProps> = ({ env, checkboxSt
 
                     <div className="flex gap-2 items-center">
                         {loading === stateKey && <Loader2 className="size-4 animate-spin" />}
-                        <Switch
-                            name="hmac_enabled"
-                            checked={checkboxState[stateKey] as boolean}
-                            onCheckedChange={(checked) => handleCheckboxChange(stateKey, Boolean(checked))}
-                        />
+                        <PermissionGate condition={canEditEnvironment}>
+                            {(allowed) => (
+                                <Switch
+                                    name="hmac_enabled"
+                                    checked={checkboxState[stateKey] as boolean}
+                                    onCheckedChange={(checked) => handleCheckboxChange(stateKey, Boolean(checked))}
+                                    disabled={!allowed}
+                                />
+                            )}
+                        </PermissionGate>
                     </div>
                 </div>
             ))}

--- a/packages/webapp/src/pages/Integrations/Show.tsx
+++ b/packages/webapp/src/pages/Integrations/Show.tsx
@@ -27,8 +27,8 @@ export const IntegrationsList = () => {
     const navigate = useNavigate();
 
     const env = useStore((state) => state.env);
-    const { environmentAndAccount } = useEnvironment(env);
-    const { environment } = environmentAndAccount || {};
+    const { data: environmentData } = useEnvironment(env);
+    const { environment } = environmentData?.environmentAndAccount || {};
     const { data, isPending, error } = useListIntegrations(env);
     const [integrations, setIntegrations] = useState<ApiIntegrationList[] | null>(null);
 

--- a/packages/webapp/src/pages/Integrations/Show.tsx
+++ b/packages/webapp/src/pages/Integrations/Show.tsx
@@ -5,6 +5,8 @@ import { useCallback, useEffect, useMemo, useState } from 'react';
 import { Helmet } from 'react-helmet';
 import { useNavigate } from 'react-router-dom';
 
+import { permissions } from '@nangohq/authz';
+
 import { AuthBadge } from './components/AuthBadge';
 import { AutoIdlingBanner } from './components/AutoIdlingBanner';
 import { ErrorPageComponent } from '@/components/ErrorComponent';
@@ -17,7 +19,7 @@ import { Skeleton } from '@/components-v2/ui/skeleton';
 import { Table, TableBody, TableCell, TableHead, TableHeader, TableRow } from '@/components-v2/ui/table';
 import { useEnvironment } from '@/hooks/useEnvironment';
 import { useListIntegrations } from '@/hooks/useIntegration';
-import { permissions, usePermissions } from '@/hooks/usePermissions';
+import { usePermissions } from '@/hooks/usePermissions';
 import DashboardLayout from '@/layout/DashboardLayout';
 import { useStore } from '@/store';
 

--- a/packages/webapp/src/pages/Integrations/Show.tsx
+++ b/packages/webapp/src/pages/Integrations/Show.tsx
@@ -105,7 +105,7 @@ export const IntegrationsList = () => {
             </Helmet>
             <header className="flex justify-between items-center">
                 <h2 className="text-text-primary text-title-subsection">Integrations</h2>
-                <PermissionGate asChild condition={canWriteIntegration}>
+                <PermissionGate condition={canWriteIntegration}>
                     {(allowed) => (
                         <ButtonLink disabled={!allowed} to={`/${env}/integrations/create`} size="lg">
                             Set up new integration

--- a/packages/webapp/src/pages/Integrations/Show.tsx
+++ b/packages/webapp/src/pages/Integrations/Show.tsx
@@ -17,7 +17,7 @@ import { Skeleton } from '@/components-v2/ui/skeleton';
 import { Table, TableBody, TableCell, TableHead, TableHeader, TableRow } from '@/components-v2/ui/table';
 import { useEnvironment } from '@/hooks/useEnvironment';
 import { useListIntegrations } from '@/hooks/useIntegration';
-import { permissions } from '@/hooks/usePermissions';
+import { permissions, usePermissions } from '@/hooks/usePermissions';
 import DashboardLayout from '@/layout/DashboardLayout';
 import { useStore } from '@/store';
 
@@ -31,6 +31,9 @@ export const IntegrationsList = () => {
     const { environment } = environmentData?.environmentAndAccount || {};
     const { data, isPending, error } = useListIntegrations(env);
     const [integrations, setIntegrations] = useState<ApiIntegrationList[] | null>(null);
+
+    const { can } = usePermissions();
+    const canWriteIntegration = can(permissions.canWriteProdIntegrations) || !environment?.is_production;
 
     const initialIntegrations = useMemo(() => {
         return data?.data ?? null;
@@ -102,7 +105,7 @@ export const IntegrationsList = () => {
             </Helmet>
             <header className="flex justify-between items-center">
                 <h2 className="text-text-primary text-title-subsection">Integrations</h2>
-                <PermissionGate permission={permissions.canWriteProdIntegrations} bypass={!environment?.is_production}>
+                <PermissionGate asChild condition={canWriteIntegration}>
                     {(allowed) => (
                         <ButtonLink disabled={!allowed} to={`/${env}/integrations/create`} size="lg">
                             Set up new integration
@@ -133,7 +136,7 @@ export const IntegrationsList = () => {
                 <div className="flex flex-col gap-5 p-20 items-center justify-center bg-bg-elevated rounded">
                     <h3 className="text-title-body text-text-primary">No available integrations</h3>
                     <p className="text-text-secondary text-body-medium-regular">You don’t have any integrations set up yet with Nango.</p>
-                    <PermissionGate asChild permission={permissions.canWriteProdIntegrations} bypass={!environment?.is_production}>
+                    <PermissionGate asChild condition={canWriteIntegration}>
                         {(allowed) => (
                             <ButtonLink disabled={!allowed} to={`/${env}/integrations/create`} size="lg">
                                 Set up new integration
@@ -147,7 +150,7 @@ export const IntegrationsList = () => {
                 <div className="flex flex-col gap-5 p-20 items-center justify-center bg-bg-elevated rounded">
                     <h3 className="text-title-body text-text-primary">No integrations found</h3>
                     <p className="text-text-secondary text-body-medium-regular">Could not find any integrations matching your search.</p>
-                    <PermissionGate permission={permissions.canWriteProdIntegrations} bypass={!environment?.is_production}>
+                    <PermissionGate condition={canWriteIntegration}>
                         {(allowed) => (
                             <ButtonLink disabled={!allowed} to={`/${env}/integrations/create`} size="lg">
                                 Set up new integration

--- a/packages/webapp/src/pages/Integrations/Show.tsx
+++ b/packages/webapp/src/pages/Integrations/Show.tsx
@@ -10,11 +10,14 @@ import { AutoIdlingBanner } from './components/AutoIdlingBanner';
 import { ErrorPageComponent } from '@/components/ErrorComponent';
 import { CopyButton } from '@/components-v2/CopyButton';
 import { IntegrationLogo } from '@/components-v2/IntegrationLogo';
+import { PermissionGate } from '@/components-v2/PermissionGate';
 import { ButtonLink } from '@/components-v2/ui/button';
 import { InputGroup, InputGroupAddon, InputGroupInput } from '@/components-v2/ui/input-group';
 import { Skeleton } from '@/components-v2/ui/skeleton';
 import { Table, TableBody, TableCell, TableHead, TableHeader, TableRow } from '@/components-v2/ui/table';
+import { useEnvironment } from '@/hooks/useEnvironment';
 import { useListIntegrations } from '@/hooks/useIntegration';
+import { permissions } from '@/hooks/usePermissions';
 import DashboardLayout from '@/layout/DashboardLayout';
 import { useStore } from '@/store';
 
@@ -24,6 +27,8 @@ export const IntegrationsList = () => {
     const navigate = useNavigate();
 
     const env = useStore((state) => state.env);
+    const { environmentAndAccount } = useEnvironment(env);
+    const { environment } = environmentAndAccount || {};
     const { data, isPending, error } = useListIntegrations(env);
     const [integrations, setIntegrations] = useState<ApiIntegrationList[] | null>(null);
 
@@ -97,9 +102,13 @@ export const IntegrationsList = () => {
             </Helmet>
             <header className="flex justify-between items-center">
                 <h2 className="text-text-primary text-title-subsection">Integrations</h2>
-                <ButtonLink to={`/${env}/integrations/create`} size="lg">
-                    Set up new integration
-                </ButtonLink>
+                <PermissionGate permission={permissions.canWriteProdIntegrations} bypass={!environment?.is_production}>
+                    {(allowed) => (
+                        <ButtonLink disabled={!allowed} to={`/${env}/integrations/create`} size="lg">
+                            Set up new integration
+                        </ButtonLink>
+                    )}
+                </PermissionGate>
             </header>
 
             <InputGroup className="bg-bg-subtle">
@@ -124,9 +133,13 @@ export const IntegrationsList = () => {
                 <div className="flex flex-col gap-5 p-20 items-center justify-center bg-bg-elevated rounded">
                     <h3 className="text-title-body text-text-primary">No available integrations</h3>
                     <p className="text-text-secondary text-body-medium-regular">You don’t have any integrations set up yet with Nango.</p>
-                    <ButtonLink to={`/${env}/integrations/create`} size="lg">
-                        Set up new integration
-                    </ButtonLink>
+                    <PermissionGate asChild permission={permissions.canWriteProdIntegrations} bypass={!environment?.is_production}>
+                        {(allowed) => (
+                            <ButtonLink disabled={!allowed} to={`/${env}/integrations/create`} size="lg">
+                                Set up new integration
+                            </ButtonLink>
+                        )}
+                    </PermissionGate>
                 </div>
             )}
 
@@ -134,9 +147,13 @@ export const IntegrationsList = () => {
                 <div className="flex flex-col gap-5 p-20 items-center justify-center bg-bg-elevated rounded">
                     <h3 className="text-title-body text-text-primary">No integrations found</h3>
                     <p className="text-text-secondary text-body-medium-regular">Could not find any integrations matching your search.</p>
-                    <ButtonLink to={`/${env}/integrations/create`} size="lg">
-                        Set up new integration
-                    </ButtonLink>
+                    <PermissionGate permission={permissions.canWriteProdIntegrations} bypass={!environment?.is_production}>
+                        {(allowed) => (
+                            <ButtonLink disabled={!allowed} to={`/${env}/integrations/create`} size="lg">
+                                Set up new integration
+                            </ButtonLink>
+                        )}
+                    </PermissionGate>
                 </div>
             )}
 

--- a/packages/webapp/src/pages/Integrations/components/FunctionSwitch.tsx
+++ b/packages/webapp/src/pages/Integrations/components/FunctionSwitch.tsx
@@ -5,8 +5,10 @@ import { useFlowDisable, useFlowEnable, usePreBuiltDeployFlow } from '../../../h
 import { useToast } from '../../../hooks/useToast.js';
 import { useStore } from '../../../store.js';
 import { APIError } from '../../../utils/api.js';
+import { PermissionGate } from '@/components-v2/PermissionGate';
 import { Switch } from '@/components-v2/ui/switch';
 import { useConfirmDialog } from '@/hooks/useConfirmDialog';
+import { permissions, usePermissions } from '@/hooks/usePermissions';
 
 import type { ApiError, ApiIntegration, NangoSyncConfig } from '@nangohq/types';
 
@@ -18,6 +20,11 @@ export const FunctionSwitch: React.FC<{
     const env = useStore((state) => state.env);
     const { data: environmentData, refetch: refetchEnv } = useEnvironment(env);
     const plan = environmentData?.plan;
+    const environment = environmentData?.environmentAndAccount?.environment;
+
+    const { can } = usePermissions();
+    const canWriteFlows = can(permissions.canWriteProdFlows) || !environment?.is_production;
+
     const { confirm, DialogComponent } = useConfirmDialog();
 
     const { mutateAsync: enableFlow, isPending: isEnablePending } = useFlowEnable(env, integration.unique_key);
@@ -124,16 +131,20 @@ export const FunctionSwitch: React.FC<{
                 e.stopPropagation();
             }}
         >
-            <Switch
-                name="script"
-                checked={flow.enabled === true}
-                className="cursor-pointer"
-                disabled={loading}
-                onClick={(e) => {
-                    e.preventDefault();
-                    toggleSync();
-                }}
-            />
+            <PermissionGate condition={canWriteFlows}>
+                {(allowed) => (
+                    <Switch
+                        name="script"
+                        checked={flow.enabled === true}
+                        className="cursor-pointer"
+                        disabled={loading || !allowed}
+                        onClick={(e) => {
+                            e.preventDefault();
+                            toggleSync();
+                        }}
+                    />
+                )}
+            </PermissionGate>
             {flow.type === 'action' && loading && <Loader2 className="animate-spin size-4" />}
             {DialogComponent}
         </div>

--- a/packages/webapp/src/pages/Integrations/components/FunctionSwitch.tsx
+++ b/packages/webapp/src/pages/Integrations/components/FunctionSwitch.tsx
@@ -1,5 +1,7 @@
 import { Loader2 } from 'lucide-react';
 
+import { permissions } from '@nangohq/authz';
+
 import { useEnvironment } from '../../../hooks/useEnvironment.js';
 import { useFlowDisable, useFlowEnable, usePreBuiltDeployFlow } from '../../../hooks/useFlow.js';
 import { useToast } from '../../../hooks/useToast.js';
@@ -8,7 +10,7 @@ import { APIError } from '../../../utils/api.js';
 import { PermissionGate } from '@/components-v2/PermissionGate';
 import { Switch } from '@/components-v2/ui/switch';
 import { useConfirmDialog } from '@/hooks/useConfirmDialog';
-import { permissions, usePermissions } from '@/hooks/usePermissions';
+import { usePermissions } from '@/hooks/usePermissions';
 
 import type { ApiError, ApiIntegration, NangoSyncConfig } from '@nangohq/types';
 

--- a/packages/webapp/src/pages/Integrations/providerConfigKey/Settings/components/GeneralSettings.tsx
+++ b/packages/webapp/src/pages/Integrations/providerConfigKey/Settings/components/GeneralSettings.tsx
@@ -11,6 +11,7 @@ import { Label } from '@/components-v2/ui/label';
 import { Switch } from '@/components-v2/ui/switch';
 import { useConfirmDialog } from '@/hooks/useConfirmDialog';
 import { usePatchIntegration } from '@/hooks/useIntegration';
+import { permissions, usePermissions } from '@/hooks/usePermissions';
 import { useToast } from '@/hooks/useToast';
 import { validateNotEmpty } from '@/pages/Integrations/utils';
 import { useStore } from '@/store';
@@ -26,6 +27,9 @@ export const GeneralSettings: React.FC<{ data: GetIntegration['Success']['data']
     const navigate = useNavigate();
     const { confirm, DialogComponent } = useConfirmDialog();
     const { mutateAsync: patchIntegration } = usePatchIntegration(env, integration.unique_key);
+
+    const { can } = usePermissions();
+    const canEdit = !environment.is_production || can(permissions.canWriteProdIntegrations);
 
     const [isEditingIntegrationId, setIsEditingIntegrationId] = useState(false);
 
@@ -78,6 +82,7 @@ export const GeneralSettings: React.FC<{ data: GetIntegration['Success']['data']
                     initialValue={integration.display_name || template.display_name}
                     onSave={(value) => onSave({ displayName: value })}
                     validate={validateNotEmpty}
+                    canEdit={canEdit}
                 />
             </div>
 
@@ -100,6 +105,7 @@ export const GeneralSettings: React.FC<{ data: GetIntegration['Success']['data']
                         await onSave({ integrationId: value });
                         navigate(`/${env}/integrations/${value}/settings`);
                     }}
+                    canEdit={canEdit}
                 />
                 {isEditingIntegrationId && (
                     <Alert variant="info">
@@ -155,7 +161,13 @@ export const GeneralSettings: React.FC<{ data: GetIntegration['Success']['data']
                                 <Label htmlFor="incoming_webhook_secret">Webhook Secret</Label>
                                 <InfoTooltip>Obtain the Webhook Secret from on the developer portal of the Integration Provider</InfoTooltip>
                             </div>
-                            <EditableInput secret initialValue={integration.custom?.webhookSecret || ''} onSave={(value) => onSave({ webhookSecret: value })} />
+                            <EditableInput
+                                secret
+                                initialValue={integration.custom?.webhookSecret || ''}
+                                onSave={(value) => onSave({ webhookSecret: value })}
+                                canEdit={canEdit}
+                                canRead={canEdit}
+                            />
                         </div>
                     )}
                 </>

--- a/packages/webapp/src/pages/Integrations/providerConfigKey/Settings/components/GeneralSettings.tsx
+++ b/packages/webapp/src/pages/Integrations/providerConfigKey/Settings/components/GeneralSettings.tsx
@@ -2,6 +2,8 @@ import { AlertTriangle, Info } from 'lucide-react';
 import { useState } from 'react';
 import { useNavigate } from 'react-router-dom';
 
+import { permissions } from '@nangohq/authz';
+
 import { CopyButton } from '@/components-v2/CopyButton';
 import { EditableInput } from '@/components-v2/EditableInput';
 import { InfoTooltip } from '@/components-v2/InfoTooltip';
@@ -11,7 +13,7 @@ import { Label } from '@/components-v2/ui/label';
 import { Switch } from '@/components-v2/ui/switch';
 import { useConfirmDialog } from '@/hooks/useConfirmDialog';
 import { usePatchIntegration } from '@/hooks/useIntegration';
-import { permissions, usePermissions } from '@/hooks/usePermissions';
+import { usePermissions } from '@/hooks/usePermissions';
 import { useToast } from '@/hooks/useToast';
 import { validateNotEmpty } from '@/pages/Integrations/utils';
 import { useStore } from '@/store';

--- a/packages/webapp/src/pages/Integrations/providerConfigKey/Settings/components/OAuthSettings.tsx
+++ b/packages/webapp/src/pages/Integrations/providerConfigKey/Settings/components/OAuthSettings.tsx
@@ -9,6 +9,7 @@ import { InputGroup, InputGroupAddon, InputGroupInput } from '@/components-v2/ui
 import { Label } from '@/components-v2/ui/label';
 import { useConfirmDialog } from '@/hooks/useConfirmDialog';
 import { usePatchIntegration } from '@/hooks/useIntegration';
+import { permissions, usePermissions } from '@/hooks/usePermissions';
 import { useToast } from '@/hooks/useToast';
 import { NangoProvidedInput } from '@/pages/Integrations/components/NangoProvidedInput';
 import { validateNotEmpty } from '@/pages/Integrations/utils';
@@ -24,6 +25,10 @@ export const OAuthSettings: React.FC<{ data: GetIntegration['Success']['data']; 
     const env = useStore((state) => state.env);
     const { toast } = useToast();
     const { confirm, DialogComponent } = useConfirmDialog();
+
+    const { can } = usePermissions();
+    const canEdit = !environment.is_production || can(permissions.canWriteProdIntegrations);
+
     const { mutateAsync: patchIntegration } = usePatchIntegration(env, integration.unique_key);
     const [isEditingClientId, setIsEditingClientId] = useState(false);
 
@@ -113,6 +118,9 @@ export const OAuthSettings: React.FC<{ data: GetIntegration['Success']['data']; 
                             onSave={handleClientIdSave}
                             onEditingChange={setIsEditingClientId}
                             validate={validateNotEmpty}
+                            canEdit={canEdit}
+                            canRead={canEdit}
+                            secret={!canEdit}
                         />
                         {isEditingClientId && hasExistingClientId && (
                             <Alert variant="warning">
@@ -137,6 +145,8 @@ export const OAuthSettings: React.FC<{ data: GetIntegration['Success']['data']; 
                         initialValue={integration.oauth_client_secret || ''}
                         onSave={(value) => onSave({ clientSecret: value })}
                         validate={validateNotEmpty}
+                        canEdit={canEdit}
+                        canRead={canEdit}
                     />
                 )}
             </div>

--- a/packages/webapp/src/pages/Integrations/providerConfigKey/Settings/components/OAuthSettings.tsx
+++ b/packages/webapp/src/pages/Integrations/providerConfigKey/Settings/components/OAuthSettings.tsx
@@ -1,6 +1,8 @@
 import { AlertTriangle } from 'lucide-react';
 import { useState } from 'react';
 
+import { permissions } from '@nangohq/authz';
+
 import { CopyButton } from '@/components-v2/CopyButton';
 import { EditableInput } from '@/components-v2/EditableInput';
 import { ScopesInput } from '@/components-v2/ScopesInput';
@@ -9,7 +11,7 @@ import { InputGroup, InputGroupAddon, InputGroupInput } from '@/components-v2/ui
 import { Label } from '@/components-v2/ui/label';
 import { useConfirmDialog } from '@/hooks/useConfirmDialog';
 import { usePatchIntegration } from '@/hooks/useIntegration';
-import { permissions, usePermissions } from '@/hooks/usePermissions';
+import { usePermissions } from '@/hooks/usePermissions';
 import { useToast } from '@/hooks/useToast';
 import { NangoProvidedInput } from '@/pages/Integrations/components/NangoProvidedInput';
 import { validateNotEmpty } from '@/pages/Integrations/utils';

--- a/packages/webapp/src/pages/PageEnvironmentUnauthorized.tsx
+++ b/packages/webapp/src/pages/PageEnvironmentUnauthorized.tsx
@@ -1,0 +1,23 @@
+import { Link } from 'react-router-dom';
+
+import DefaultLayout from '../layout/DefaultLayout';
+import { useStore } from '../store';
+
+export default function PageEnvironmentUnauthorized() {
+    const env = useStore((state) => state.env);
+
+    return (
+        <DefaultLayout>
+            <div className="mx-auto max-w-7xl px-6 py-32 text-center sm:py-40 lg:px-8">
+                <p className="text-base font-semibold leading-8 text-white">403</p>
+                <h1 className="mt-4 text-3xl font-bold tracking-tight text-white sm:text-5xl">Access denied</h1>
+                <p className="mt-4 text-base text-white/70 sm:mt-6">Your role does not have access to this environment.</p>
+                <div className="mt-10 flex justify-center">
+                    <Link to={`/${env}`} className="text-sm font-semibold leading-7 text-white">
+                        <span aria-hidden="true">&larr;</span> Back to home
+                    </Link>
+                </div>
+            </div>
+        </DefaultLayout>
+    );
+}

--- a/scripts/validation/providers/validate.ts
+++ b/scripts/validation/providers/validate.ts
@@ -3,7 +3,6 @@ import path from 'node:path';
 import { fileURLToPath } from 'node:url';
 
 import Ajv from 'ajv';
-// eslint-disable-next-line import/order
 import chalk from 'chalk';
 import { dump, load } from 'js-yaml';
 


### PR DESCRIPTION
This adds RBAC gates to buttons/switches/pages. It still doesn't add role management or anything new.
The way to test it currently is to manually update your role in the database to one of:
- `administrator` -> full access
- `production_support` -> full access to dev envs, read access to non-sensitive prod data
- `development_full_access` -> full access to dev envs, zero access to prod

For the most part, this is disabling and adding a tooltip to specific components.
I've created a `ConditionalTooltip` component, which is a convenient way wrapping something in a tooltip given a condition, and it also handles nested tooltips (eg: you need a button to be disabled on 2 different situations, but show 2 different tooltips for each condition, but not both at the same time. This is well handled by `ConditionalTooltip`).
And to go further, `PermissionGate` is a wrapper around the `ConditionalTooltip` that adds the default message to the displayed tooltip, and also gives you a handle to use to disable the inner component, whatever that is. Example usage:
```tsx
<PermissionGate condition={canDeleteEnvironment}> {/** Conditionally wraps with the default "you can't do this" tooltip */}
  {(allowed) => // Handle to use to disable inner components and what not
    <Button disabled={!allowed} onClick={deleteEnv}>
      Delete environment
    </Button>
  }
</PermissionGate>
```

<!-- Summary by @propel-code-bot -->

---

It also adds a centralized permissions hook and a route-level guard to enforce access beyond UI controls, extends credential/secret displays with read/edit gating, introduces an unauthorized environment page, and adjusts shared UI primitives to support permission-aware disabled behavior across the app.

---
*This summary was automatically generated by @propel-code-bot*