### PR TITLE
fix(connections): preserve tags on reconnect when no tags are provided

### DIFF
--- a/packages/shared/lib/services/connection.service.integration.test.ts
+++ b/packages/shared/lib/services/connection.service.integration.test.ts
@@ -348,6 +348,46 @@ describe('Connection service integration tests', () => {
         });
     });
 
+    describe('upsertAuthConnection', () => {
+        it('should preserve existing tags when called with empty tags (reconnect without tags)', async () => {
+            const env = await createEnvironmentSeed();
+            const config = await createConfigSeed(env, 'github', 'github');
+
+            const connection = await createConnectionSeed({ env, provider: 'github', tags: { connection_type: 'pull' } });
+
+            const [result] = await connectionService.upsertAuthConnection({
+                connectionId: connection.connection_id,
+                providerConfigKey: 'github',
+                credentials: { type: 'API_KEY', apiKey: 'new-token' },
+                config,
+                environment: env,
+                tags: {}
+            });
+
+            const updated = await connectionService.getConnectionById(result!.connection.id);
+            expect(updated?.tags).toStrictEqual({ connection_type: 'pull' });
+        });
+
+        it('should update tags when new non-empty tags are provided', async () => {
+            const env = await createEnvironmentSeed();
+            const config = await createConfigSeed(env, 'github', 'github');
+
+            const connection = await createConnectionSeed({ env, provider: 'github', tags: { connection_type: 'pull' } });
+
+            const [result] = await connectionService.upsertAuthConnection({
+                connectionId: connection.connection_id,
+                providerConfigKey: 'github',
+                credentials: { type: 'API_KEY', apiKey: 'new-token' },
+                config,
+                environment: env,
+                tags: { connection_type: 'push' }
+            });
+
+            const updated = await connectionService.getConnectionById(result!.connection.id);
+            expect(updated?.tags).toStrictEqual({ connection_type: 'push' });
+        });
+    });
+
     describe('paginate', () => {
         it('should paginate through connections', async () => {
             const env = await createEnvironmentSeed();

--- a/packages/shared/lib/services/connection.service.ts
+++ b/packages/shared/lib/services/connection.service.ts
@@ -69,6 +69,7 @@ import type {
     DBEndUser,
     DBEnvironment,
     DBTeam,
+    IntegrationConfig,
     JwtCredentials,
     MaybePromise,
     Metadata,
@@ -188,7 +189,7 @@ class ConnectionService {
         providerConfigKey: string;
         credentials: TwoStepCredentials | TbaCredentials | JwtCredentials | ApiKeyCredentials | BasicApiCredentials | BillCredentials | SignatureCredentials;
         connectionConfig?: ConnectionConfig;
-        config: ProviderConfig;
+        config: IntegrationConfig;
         metadata?: Metadata | null;
         environment: DBEnvironment;
         tags?: Tags | undefined;
@@ -215,7 +216,7 @@ class ConnectionService {
                 refresh_exhausted: false,
                 deleted: false,
                 deleted_at: null,
-                tags: tags ?? exists?.tags ?? {}
+                tags: tags && Object.keys(tags).length > 0 ? tags : (exists?.tags ?? {})
             });
 
             const [connection] = await db.knex


### PR DESCRIPTION
## Describe the problem and your solution

- preserve tags on reconnect when no tags are provided

<!-- Issue ticket number and link (if applicable) -->

<!-- Testing instructions (skip if just adding/editing providers) -->


<!-- Summary by @propel-code-bot -->

---

**Fix reconnect tag preservation in `upsertAuthConnection`**

This PR updates `upsertAuthConnection` to preserve existing connection tags when reconnecting with empty `tags`, while still replacing tags when non-empty values are provided. It also adds integration tests to validate both behaviors.

---
*This summary was automatically generated by @propel-code-bot*