### PR TITLE
fix(webhooks): use headers instead of the request body for webhookscript executions in g-calendar

### DIFF
--- a/packages/server/lib/webhook/google-calendar-webhook-routing.ts
+++ b/packages/server/lib/webhook/google-calendar-webhook-routing.ts
@@ -4,7 +4,7 @@ import { hashEmailAddress } from '../utils/pii.js';
 
 import type { WebhookHandler } from './types.js';
 
-const route: WebhookHandler = async (nango, headers, body) => {
+const route: WebhookHandler = async (nango, headers) => {
     // https://developers.google.com/workspace/calendar/api/guides/push
     // we will need to just forward the headers since the body is empty
 
@@ -21,7 +21,7 @@ const route: WebhookHandler = async (nango, headers, body) => {
     }
 
     const baseArgs = {
-        body,
+        body: headers,
         ...(headers['x-goog-resource-state'] && { webhookTypeValue: headers['x-goog-resource-state'] })
     };
 


### PR DESCRIPTION
## Describe the problem and your solution

- Use headers instead of the request body for webhookscript executions in g-calendar, since the body is empty and this is also what we forward.

<!-- Issue ticket number and link (if applicable) -->

<!-- Testing instructions (skip if just adding/editing providers) -->


<!-- Summary by @propel-code-bot -->

---

It also removes the unused body parameter from the webhook handler signature to align with the new header-based payload behavior.

---
*This summary was automatically generated by @propel-code-bot*