### PR TITLE
feat(webapp): add environment toggle to production

### DIFF
--- a/packages/webapp/src/pages/Environment/Settings/General.tsx
+++ b/packages/webapp/src/pages/Environment/Settings/General.tsx
@@ -12,7 +12,10 @@ import { useDeleteEnvironment, useEnvironment, usePatchEnvironment } from '../..
 import { useMeta } from '../../../hooks/useMeta';
 import { useStore } from '../../../store';
 import { EditableInput } from '@/components-v2/EditableInput';
+import { InfoTooltip } from '@/components-v2/InfoTooltip';
 import { Alert, AlertDescription } from '@/components-v2/ui/alert';
+import { Switch } from '@/components-v2/ui/switch';
+import { useConfirmDialog } from '@/hooks/useConfirmDialog';
 import { usePermissions } from '@/hooks/usePermissions';
 import { useToast } from '@/hooks/useToast';
 import { APIError } from '@/utils/api';
@@ -23,16 +26,17 @@ export const General: React.FC = () => {
     const env = useStore((state) => state.env);
     const setEnv = useStore((state) => state.setEnv);
     const { toast } = useToast();
+    const { confirm, DialogComponent } = useConfirmDialog();
 
     const { refetch: refetchMeta } = useMeta();
     const { data } = useEnvironment(env);
     const environmentAndAccount = data?.environmentAndAccount;
+    const environment = environmentAndAccount?.environment;
     const { mutateAsync: patchEnvironmentAsync } = usePatchEnvironment(env);
     const { mutateAsync: deleteEnvironmentAsync } = useDeleteEnvironment(env);
 
-    const isProdEnv = environmentAndAccount?.environment.is_production || false;
     const { can } = usePermissions();
-    const canEditEnvironment = !isProdEnv || can(permissions.canWriteProdEnvironment);
+    const canEditEnvironment = !environment?.is_production || can(permissions.canWriteProdEnvironment);
 
     const [showDeleteAlert, setShowDeleteAlert] = useState(false);
 
@@ -95,6 +99,36 @@ export const General: React.FC = () => {
                     )}
                 </div>
             </SettingsGroup>
+
+            <SettingsGroup
+                label={
+                    <div className="flex items-center gap-2">
+                        <span>Production environment</span>
+                        <InfoTooltip icon={<Info />}>Production environments are only accessible to administrators and support roles.</InfoTooltip>
+                    </div>
+                }
+            >
+                <Switch
+                    checked={environment?.is_production}
+                    onCheckedChange={(checked) =>
+                        confirm({
+                            title: checked ? 'Upgrade to production environment' : 'Downgrade to non-production environment',
+                            description: 'This impacts which team members have access to this environment.',
+                            onConfirm: async () => {
+                                await patchEnvironmentAsync({ is_production: checked });
+                                await refetchMeta();
+                                toast({
+                                    title: `Successfully ${checked ? 'upgraded' : 'downgraded'} to ${checked ? 'production' : 'non-production'} environment`,
+                                    variant: 'success'
+                                });
+                            },
+                            confirmButtonText: checked ? 'Upgrade' : 'Downgrade',
+                            confirmVariant: 'destructive'
+                        })
+                    }
+                />
+            </SettingsGroup>
+
             <SettingsGroup label="Environment suppression" className="items-center">
                 <div>
                     <DeleteButton
@@ -106,6 +140,8 @@ export const General: React.FC = () => {
                     />
                 </div>
             </SettingsGroup>
+
+            {DialogComponent}
         </SettingsContent>
     );
 };

--- a/packages/webapp/src/pages/Environment/Settings/General.tsx
+++ b/packages/webapp/src/pages/Environment/Settings/General.tsx
@@ -13,6 +13,7 @@ import { useMeta } from '../../../hooks/useMeta';
 import { useStore } from '../../../store';
 import { EditableInput } from '@/components-v2/EditableInput';
 import { InfoTooltip } from '@/components-v2/InfoTooltip';
+import { PermissionGate } from '@/components-v2/PermissionGate';
 import { Alert, AlertDescription } from '@/components-v2/ui/alert';
 import { Switch } from '@/components-v2/ui/switch';
 import { useConfirmDialog } from '@/hooks/useConfirmDialog';
@@ -37,6 +38,7 @@ export const General: React.FC = () => {
 
     const { can } = usePermissions();
     const canEditEnvironment = !environment?.is_production || can(permissions.canWriteProdEnvironment);
+    const canToggleIsProduction = can(permissions.canToggleIsProduction);
 
     const [showDeleteAlert, setShowDeleteAlert] = useState(false);
 
@@ -108,25 +110,30 @@ export const General: React.FC = () => {
                     </div>
                 }
             >
-                <Switch
-                    checked={environment?.is_production}
-                    onCheckedChange={(checked) =>
-                        confirm({
-                            title: checked ? 'Upgrade to production environment' : 'Downgrade to non-production environment',
-                            description: 'This impacts which team members have access to this environment.',
-                            onConfirm: async () => {
-                                await patchEnvironmentAsync({ is_production: checked });
-                                await refetchMeta();
-                                toast({
-                                    title: `Successfully ${checked ? 'upgraded' : 'downgraded'} to ${checked ? 'production' : 'non-production'} environment`,
-                                    variant: 'success'
-                                });
-                            },
-                            confirmButtonText: checked ? 'Upgrade' : 'Downgrade',
-                            confirmVariant: 'destructive'
-                        })
-                    }
-                />
+                <PermissionGate condition={canToggleIsProduction}>
+                    {(allowed) => (
+                        <Switch
+                            disabled={!allowed}
+                            checked={environment?.is_production}
+                            onCheckedChange={(checked) =>
+                                confirm({
+                                    title: checked ? 'Upgrade to production environment' : 'Downgrade to non-production environment',
+                                    description: 'This impacts which team members have access to this environment.',
+                                    onConfirm: async () => {
+                                        await patchEnvironmentAsync({ is_production: checked });
+                                        await refetchMeta();
+                                        toast({
+                                            title: `Successfully ${checked ? 'upgraded' : 'downgraded'} to ${checked ? 'production' : 'non-production'} environment`,
+                                            variant: 'success'
+                                        });
+                                    },
+                                    confirmButtonText: checked ? 'Upgrade' : 'Downgrade',
+                                    confirmVariant: 'destructive'
+                                })
+                            }
+                        />
+                    )}
+                </PermissionGate>
             </SettingsGroup>
 
             <SettingsGroup label="Environment suppression" className="items-center">


### PR DESCRIPTION
<img width="1215" height="460" alt="image" src="https://github.com/user-attachments/assets/ce38cea1-4a39-4763-808e-6cb27ab7d9d2" />
<img width="1214" height="512" alt="image" src="https://github.com/user-attachments/assets/10f1045c-4d1d-45fe-ba4c-bfb346479235" />

<!-- Summary by @propel-code-bot -->

---

**Add production environment toggle with confirmation and permission gating**

This PR adds a new production environment toggle to the environment settings UI. It introduces a permission-gated `Switch` with a confirmation dialog that updates `is_production`, refreshes metadata, and shows a success toast after upgrade/downgrade.

---
*This summary was automatically generated by @propel-code-bot*