### PR TITLE
fix(webapp): conditionally load Stripe only when publishable key exists

### DIFF
--- a/packages/webapp/src/utils/stripe.ts
+++ b/packages/webapp/src/utils/stripe.ts
@@ -3,4 +3,4 @@ import { loadStripe } from '@stripe/stripe-js';
 import { globalEnv } from './env';
 
 const stripePublishableKey = globalEnv.publicStripeKey;
-export const stripePromise = stripePublishableKey ? loadStripe(stripePublishableKey) : null;
+export const stripePromise = stripePublishableKey ? loadStripe(stripePublishableKey) : Promise.resolve(null);

--- a/packages/webapp/src/utils/stripe.ts
+++ b/packages/webapp/src/utils/stripe.ts
@@ -3,4 +3,4 @@ import { loadStripe } from '@stripe/stripe-js';
 import { globalEnv } from './env';
 
 const stripePublishableKey = globalEnv.publicStripeKey;
-export const stripePromise = loadStripe(stripePublishableKey);
+export const stripePromise = stripePublishableKey ? loadStripe(stripePublishableKey) : null;


### PR DESCRIPTION
## Problem
The Nango dashboard renders a completely blank/black screen on self-hosted instances because stripe.js attempts to initialize with an empty string, throwing an unhandled error that kills the entire React app.

Fixes #5640

## Changes
- Modified `packages/webapp/src/utils/stripe.ts` to conditionally call `loadStripe()` only when `publicStripeKey` is truthy
- Returns `null` instead of calling `loadStripe("")` when the key is empty

## Testing
- This fix prevents the `IntegrationError: Please call Stripe() with your publishable key. You used an empty string.` error
- Self-hosted instances will now load the dashboard properly
- Cloud instances with a valid Stripe key continue to work normally

<!-- Summary by @propel-code-bot -->

---

This PR updates Stripe initialization to avoid calling `loadStripe()` with an empty publishable key. When `globalEnv.publicStripeKey` is falsy, `stripePromise` now resolves to `null`, preventing the self-hosted dashboard crash caused by Stripe's empty-key error.

---
*This summary was automatically generated by @propel-code-bot*