### PR TITLE
fix(auth): attach WorkOS error details to DD span in SSO callback

### DIFF
--- a/packages/server/lib/controllers/v1/account/managed/getCallback.ts
+++ b/packages/server/lib/controllers/v1/account/managed/getCallback.ts
@@ -1,3 +1,4 @@
+import tracer from 'dd-trace';
 import * as z from 'zod';
 
 import db from '@nangohq/database';
@@ -59,6 +60,18 @@ export const getManagedCallback = asyncWrapper<GetManagedCallback>(async (req, r
         if (isInvalidGrant) {
             res.redirect(`${basePublicUrl}/signin?error=sso_session_expired`);
             return;
+        }
+
+        const workosErr = err as { rawData?: { code?: string; message?: string }; requestID?: string };
+        const span = tracer.scope().active();
+        if (span) {
+            if (workosErr.requestID) {
+                span.setTag('workos.request_id', workosErr.requestID);
+            }
+            if (workosErr.rawData) {
+                span.setTag('workos.error_code', workosErr.rawData.code);
+                span.setTag('workos.error_message', workosErr.rawData.message);
+            }
         }
         throw err;
     }


### PR DESCRIPTION
Add workos.request_id, workos.error_code and workos.error_message as span tags when authenticateWithCode fails, so we can see the full error context in Datadog APM traces without leaking sensitive data.

Also this allows us to provide any request id to Workos for pin point errors on their side

<!-- Describe the problem and your solution --> 

<!-- Issue ticket number and link (if applicable) -->

<!-- Testing instructions (skip if just adding/editing providers) -->


<!-- Summary by @propel-code-bot -->

---

This also applies the tagging on the active Datadog span within the managed SSO callback when authenticateWithCode fails.

---
*This summary was automatically generated by @propel-code-bot*