### PR TITLE
fix(webapp): allow for scopes to be defined when creating an oauth2_cc integration

### DIFF
--- a/packages/server/lib/controllers/v1/integrations/providerConfigKey/patchIntegration.ts
+++ b/packages/server/lib/controllers/v1/integrations/providerConfigKey/patchIntegration.ts
@@ -81,7 +81,11 @@ export const patchIntegration = asyncWrapper<PatchIntegration>(async (req, res) 
             return;
         }
 
-        if (body.authType === 'OAUTH1' || body.authType === 'OAUTH2' || body.authType === 'TBA') {
+        if (body.authType === 'OAUTH2_CC') {
+            if (body.scopes !== undefined) {
+                integration.oauth_scopes = body.scopes || '';
+            }
+        } else if (body.authType === 'OAUTH1' || body.authType === 'OAUTH2' || body.authType === 'TBA') {
             if (body.clientId !== undefined) {
                 integration.oauth_client_id = body.clientId;
             }

--- a/packages/server/lib/controllers/v1/integrations/validation.ts
+++ b/packages/server/lib/controllers/v1/integrations/validation.ts
@@ -69,11 +69,19 @@ export const integrationAuthTypeInstallPluginSchema = z
     })
     .strict();
 
+export const integrationAuthTypeOAuth2CCSchema = z
+    .object({
+        authType: z.enum(['OAUTH2_CC']),
+        scopes: scopesSchema
+    })
+    .strict();
+
 // Discriminated union for all auth types
 export const integrationAuthTypeSchema = z.discriminatedUnion(
     'authType',
     [
         integrationAuthTypeOAuthSchema,
+        integrationAuthTypeOAuth2CCSchema,
         integrationAuthTypeAppSchema,
         integrationAuthTypeCustomSchema,
         integrationAuthTypeMcpOAuth2Schema,

--- a/packages/types/lib/integration/api.ts
+++ b/packages/types/lib/integration/api.ts
@@ -112,6 +112,11 @@ export interface OAuthAuthBody {
     scopes?: string | undefined;
 }
 
+export interface OAuth2CCAuthBody {
+    authType: Extract<AuthModeType, 'OAUTH2_CC'>;
+    scopes?: string | undefined;
+}
+
 export interface AppAuthBody {
     authType: Extract<AuthModeType, 'APP'>;
     appId?: string | undefined;
@@ -149,7 +154,14 @@ export interface InstallPluginAuthBody {
     password?: string | undefined;
 }
 
-export type IntegrationAuthBody = OAuthAuthBody | AppAuthBody | CustomAuthBody | MCPOAuth2AuthBody | MCPOAuth2GenericAuthBody | InstallPluginAuthBody;
+export type IntegrationAuthBody =
+    | OAuthAuthBody
+    | OAuth2CCAuthBody
+    | AppAuthBody
+    | CustomAuthBody
+    | MCPOAuth2AuthBody
+    | MCPOAuth2GenericAuthBody
+    | InstallPluginAuthBody;
 
 export type PostIntegration = Endpoint<{
     Method: 'POST';

--- a/packages/webapp/src/components-v2/ScopesInput.tsx
+++ b/packages/webapp/src/components-v2/ScopesInput.tsx
@@ -47,6 +47,12 @@ export const ScopesInput: React.FC<ScopesInputProps> = ({ scopesString, onChange
         const newScopes = unique([...scopes, ...scopesToAdd]);
         const countDifference = newScopes.length - scopes.length;
 
+        if (countDifference === 0) {
+            setInputValue('');
+            setLoading(false);
+            return;
+        }
+
         try {
             await onChange?.(newScopes.join(','), countDifference);
             setScopes(newScopes);

--- a/packages/webapp/src/pages/Integrations/providerConfigKey/Settings/components/AuthSpecificSettings.tsx
+++ b/packages/webapp/src/pages/Integrations/providerConfigKey/Settings/components/AuthSpecificSettings.tsx
@@ -3,6 +3,7 @@ import { CustomAuthSettings } from './CustomAuthSettings';
 import { InstallPluginSettings } from './InstallPluginSettings';
 import { McpGenericSettings } from './McpGenericSettings';
 import { McpOAuthSettings } from './McpOAuthSettings';
+import { OAuth2CCSettings } from './OAuth2CCSettings';
 import { OAuthSettings } from './OAuthSettings';
 
 import type { ApiEnvironment, GetIntegration } from '@nangohq/types';
@@ -13,9 +14,11 @@ export const AuthSpecificSettings: React.FC<{ data: GetIntegration['Success']['d
     switch (authMode) {
         case 'OAUTH1':
         case 'OAUTH2':
-        case 'OAUTH2_CC':
         case 'TBA':
             return <OAuthSettings data={data} environment={environment} />;
+
+        case 'OAUTH2_CC':
+            return <OAuth2CCSettings data={data} environment={environment} />;
 
         case 'APP':
             return <AppAuthSettings data={data} environment={environment} />;

--- a/packages/webapp/src/pages/Integrations/providerConfigKey/Settings/components/AuthSpecificSettings.tsx
+++ b/packages/webapp/src/pages/Integrations/providerConfigKey/Settings/components/AuthSpecificSettings.tsx
@@ -13,6 +13,7 @@ export const AuthSpecificSettings: React.FC<{ data: GetIntegration['Success']['d
     switch (authMode) {
         case 'OAUTH1':
         case 'OAUTH2':
+        case 'OAUTH2_CC':
         case 'TBA':
             return <OAuthSettings data={data} environment={environment} />;
 

--- a/packages/webapp/src/pages/Integrations/providerConfigKey/Settings/components/OAuth2CCSettings.tsx
+++ b/packages/webapp/src/pages/Integrations/providerConfigKey/Settings/components/OAuth2CCSettings.tsx
@@ -1,0 +1,56 @@
+import { permissions } from '@nangohq/authz';
+
+import { ScopesInput } from '@/components-v2/ScopesInput';
+import { Label } from '@/components-v2/ui/label';
+import { usePatchIntegration } from '@/hooks/useIntegration';
+import { usePermissions } from '@/hooks/usePermissions';
+import { useToast } from '@/hooks/useToast';
+import { useStore } from '@/store';
+
+import type { ApiEnvironment, GetIntegration } from '@nangohq/types';
+
+export const OAuth2CCSettings: React.FC<{ data: GetIntegration['Success']['data']; environment: ApiEnvironment }> = ({
+    data: { integration, template },
+    environment
+}) => {
+    const env = useStore((state) => state.env);
+    const { toast } = useToast();
+    const { mutateAsync: patchIntegration } = usePatchIntegration(env, integration.unique_key);
+
+    const { can } = usePermissions();
+    const canEdit = !environment.is_production || can(permissions.canWriteProdIntegrations);
+
+    const isSharedCredentials = Boolean(integration.shared_credentials_id);
+
+    const handleScopesChange = async (scopes: string, countDifference: number) => {
+        try {
+            await patchIntegration({
+                authType: template.auth_mode as Extract<typeof template.auth_mode, 'OAUTH2_CC'>,
+                scopes
+            });
+            if (countDifference > 0) {
+                const plural = countDifference > 1 ? 'scopes' : 'scope';
+                toast({ title: `Added ${countDifference} new ${plural}`, variant: 'success' });
+            } else {
+                toast({ title: `Scope successfully removed`, variant: 'success' });
+            }
+        } catch (err) {
+            toast({ title: 'Failed to update scopes', variant: 'error' });
+            throw err;
+        }
+    };
+
+    return (
+        <div className="flex flex-col gap-10">
+            <div className="flex flex-col gap-2">
+                <Label htmlFor="scopes">Scopes</Label>
+                <ScopesInput
+                    scopesString={integration.oauth_scopes || ''}
+                    onChange={handleScopesChange}
+                    isSharedCredentials={isSharedCredentials}
+                    readOnly={!canEdit}
+                />
+            </div>
+        </div>
+    );
+};

--- a/packages/webapp/src/pages/Integrations/providerConfigKey/Settings/components/OAuthSettings.tsx
+++ b/packages/webapp/src/pages/Integrations/providerConfigKey/Settings/components/OAuthSettings.tsx
@@ -41,7 +41,7 @@ export const OAuthSettings: React.FC<{ data: GetIntegration['Success']['data']; 
     const onSave = async (field: Partial<PatchIntegration['Body']>, supressToast = false) => {
         try {
             await patchIntegration({
-                authType: template.auth_mode as Extract<typeof template.auth_mode, 'OAUTH1' | 'OAUTH2' | 'TBA'>,
+                authType: template.auth_mode as Extract<typeof template.auth_mode, 'OAUTH1' | 'OAUTH2' | 'OAUTH2_CC' | 'TBA'>,
                 ...field
             });
             if (!supressToast) {
@@ -97,61 +97,68 @@ export const OAuthSettings: React.FC<{ data: GetIntegration['Success']['data']; 
 
     return (
         <div className="flex flex-col gap-10">
-            {/* Callback URL */}
-            <div className="flex flex-col gap-2">
-                <Label htmlFor="callback_url">Callback URL</Label>
-                <InputGroup>
-                    <InputGroupInput disabled value={callbackUrl} />
-                    <InputGroupAddon align="inline-end">
-                        <CopyButton text={callbackUrl} />
-                    </InputGroupAddon>
-                </InputGroup>
-            </div>
+            {/* Callback URL (not applicable for OAUTH2_CC) */}
+            {template.auth_mode !== 'OAUTH2_CC' && (
+                <div className="flex flex-col gap-2">
+                    <Label htmlFor="callback_url">Callback URL</Label>
+                    <InputGroup>
+                        <InputGroupInput disabled value={callbackUrl} />
+                        <InputGroupAddon align="inline-end">
+                            <CopyButton text={callbackUrl} />
+                        </InputGroupAddon>
+                    </InputGroup>
+                </div>
+            )}
 
-            {/* Client ID */}
-            <div className="flex flex-col gap-2">
-                <Label htmlFor="client_id">Client ID</Label>
-                {isSharedCredentials ? (
-                    <NangoProvidedInput fakeValueSize={24} />
-                ) : (
-                    <>
-                        <EditableInput
-                            initialValue={integration.oauth_client_id || ''}
-                            onSave={handleClientIdSave}
-                            onEditingChange={setIsEditingClientId}
-                            validate={validateNotEmpty}
-                            canEdit={canEdit}
-                            canRead={canEdit}
-                            secret={!canEdit}
-                        />
-                        {isEditingClientId && hasExistingClientId && (
-                            <Alert variant="warning">
-                                <AlertTriangle />
-                                <AlertDescription>
-                                    Updating the Client ID will invalidate token refreshes for all existing connections for this integration.
-                                </AlertDescription>
-                            </Alert>
+            {/* Client ID and Client Secret (not applicable for OAUTH2_CC) */}
+            {template.auth_mode !== 'OAUTH2_CC' && (
+                <>
+                    {/* Client ID */}
+                    <div className="flex flex-col gap-2">
+                        <Label htmlFor="client_id">Client ID</Label>
+                        {isSharedCredentials ? (
+                            <NangoProvidedInput fakeValueSize={24} />
+                        ) : (
+                            <>
+                                <EditableInput
+                                    initialValue={integration.oauth_client_id || ''}
+                                    onSave={handleClientIdSave}
+                                    onEditingChange={setIsEditingClientId}
+                                    validate={validateNotEmpty}
+                                    canEdit={canEdit}
+                                    canRead={canEdit}
+                                    secret={!canEdit}
+                                />
+                                {isEditingClientId && hasExistingClientId && (
+                                    <Alert variant="warning">
+                                        <AlertTriangle />
+                                        <AlertDescription>
+                                            Updating the Client ID will invalidate token refreshes for all existing connections for this integration.
+                                        </AlertDescription>
+                                    </Alert>
+                                )}
+                            </>
                         )}
-                    </>
-                )}
-            </div>
+                    </div>
 
-            {/* Client Secret */}
-            <div className="flex flex-col gap-2">
-                <Label htmlFor="client_secret">Client Secret</Label>
-                {isSharedCredentials ? (
-                    <NangoProvidedInput fakeValueSize={48} />
-                ) : (
-                    <EditableInput
-                        secret
-                        initialValue={integration.oauth_client_secret || ''}
-                        onSave={(value) => onSave({ clientSecret: value })}
-                        validate={validateNotEmpty}
-                        canEdit={canEdit}
-                        canRead={canEdit}
-                    />
-                )}
-            </div>
+                    {/* Client Secret */}
+                    <div className="flex flex-col gap-2">
+                        <Label htmlFor="client_secret">Client Secret</Label>
+                        {isSharedCredentials ? (
+                            <NangoProvidedInput fakeValueSize={48} />
+                        ) : (
+                            <EditableInput
+                                secret
+                                initialValue={integration.oauth_client_secret || ''}
+                                onSave={(value) => onSave({ clientSecret: value })}
+                                validate={validateNotEmpty}
+                                canEdit={canEdit}
+                                canRead={canEdit}
+                            />
+                        )}
+                    </div>
+                </>
+            )}
 
             {/* Scopes */}
             {template.auth_mode !== 'TBA' && template.installation !== 'outbound' && (

--- a/packages/webapp/src/pages/Integrations/providerConfigKey/Settings/components/OAuthSettings.tsx
+++ b/packages/webapp/src/pages/Integrations/providerConfigKey/Settings/components/OAuthSettings.tsx
@@ -41,7 +41,7 @@ export const OAuthSettings: React.FC<{ data: GetIntegration['Success']['data']; 
     const onSave = async (field: Partial<PatchIntegration['Body']>, supressToast = false) => {
         try {
             await patchIntegration({
-                authType: template.auth_mode as Extract<typeof template.auth_mode, 'OAUTH1' | 'OAUTH2' | 'OAUTH2_CC' | 'TBA'>,
+                authType: template.auth_mode as Extract<typeof template.auth_mode, 'OAUTH1' | 'OAUTH2' | 'TBA'>,
                 ...field
             });
             if (!supressToast) {
@@ -97,74 +97,72 @@ export const OAuthSettings: React.FC<{ data: GetIntegration['Success']['data']; 
 
     return (
         <div className="flex flex-col gap-10">
-            {/* Callback URL (not applicable for OAUTH2_CC) */}
-            {template.auth_mode !== 'OAUTH2_CC' && (
-                <div className="flex flex-col gap-2">
-                    <Label htmlFor="callback_url">Callback URL</Label>
-                    <InputGroup>
-                        <InputGroupInput disabled value={callbackUrl} />
-                        <InputGroupAddon align="inline-end">
-                            <CopyButton text={callbackUrl} />
-                        </InputGroupAddon>
-                    </InputGroup>
-                </div>
-            )}
+            {/* Callback URL */}
+            <div className="flex flex-col gap-2">
+                <Label htmlFor="callback_url">Callback URL</Label>
+                <InputGroup>
+                    <InputGroupInput disabled value={callbackUrl} />
+                    <InputGroupAddon align="inline-end">
+                        <CopyButton text={callbackUrl} />
+                    </InputGroupAddon>
+                </InputGroup>
+            </div>
 
-            {/* Client ID and Client Secret (not applicable for OAUTH2_CC) */}
-            {template.auth_mode !== 'OAUTH2_CC' && (
-                <>
-                    {/* Client ID */}
-                    <div className="flex flex-col gap-2">
-                        <Label htmlFor="client_id">Client ID</Label>
-                        {isSharedCredentials ? (
-                            <NangoProvidedInput fakeValueSize={24} />
-                        ) : (
-                            <>
-                                <EditableInput
-                                    initialValue={integration.oauth_client_id || ''}
-                                    onSave={handleClientIdSave}
-                                    onEditingChange={setIsEditingClientId}
-                                    validate={validateNotEmpty}
-                                    canEdit={canEdit}
-                                    canRead={canEdit}
-                                    secret={!canEdit}
-                                />
-                                {isEditingClientId && hasExistingClientId && (
-                                    <Alert variant="warning">
-                                        <AlertTriangle />
-                                        <AlertDescription>
-                                            Updating the Client ID will invalidate token refreshes for all existing connections for this integration.
-                                        </AlertDescription>
-                                    </Alert>
-                                )}
-                            </>
+            {/* Client ID */}
+            <div className="flex flex-col gap-2">
+                <Label htmlFor="client_id">Client ID</Label>
+                {isSharedCredentials ? (
+                    <NangoProvidedInput fakeValueSize={24} />
+                ) : (
+                    <>
+                        <EditableInput
+                            initialValue={integration.oauth_client_id || ''}
+                            onSave={handleClientIdSave}
+                            onEditingChange={setIsEditingClientId}
+                            validate={validateNotEmpty}
+                            canEdit={canEdit}
+                            canRead={canEdit}
+                            secret={!canEdit}
+                        />
+                        {isEditingClientId && hasExistingClientId && (
+                            <Alert variant="warning">
+                                <AlertTriangle />
+                                <AlertDescription>
+                                    Updating the Client ID will invalidate token refreshes for all existing connections for this integration.
+                                </AlertDescription>
+                            </Alert>
                         )}
-                    </div>
+                    </>
+                )}
+            </div>
 
-                    {/* Client Secret */}
-                    <div className="flex flex-col gap-2">
-                        <Label htmlFor="client_secret">Client Secret</Label>
-                        {isSharedCredentials ? (
-                            <NangoProvidedInput fakeValueSize={48} />
-                        ) : (
-                            <EditableInput
-                                secret
-                                initialValue={integration.oauth_client_secret || ''}
-                                onSave={(value) => onSave({ clientSecret: value })}
-                                validate={validateNotEmpty}
-                                canEdit={canEdit}
-                                canRead={canEdit}
-                            />
-                        )}
-                    </div>
-                </>
-            )}
+            {/* Client Secret */}
+            <div className="flex flex-col gap-2">
+                <Label htmlFor="client_secret">Client Secret</Label>
+                {isSharedCredentials ? (
+                    <NangoProvidedInput fakeValueSize={48} />
+                ) : (
+                    <EditableInput
+                        secret
+                        initialValue={integration.oauth_client_secret || ''}
+                        onSave={(value) => onSave({ clientSecret: value })}
+                        validate={validateNotEmpty}
+                        canEdit={canEdit}
+                        canRead={canEdit}
+                    />
+                )}
+            </div>
 
             {/* Scopes */}
             {template.auth_mode !== 'TBA' && template.installation !== 'outbound' && (
                 <div className="flex flex-col gap-2">
                     <Label htmlFor="scopes">Scopes</Label>
-                    <ScopesInput scopesString={integration.oauth_scopes || ''} onChange={handleScopesChange} isSharedCredentials={isSharedCredentials} />
+                    <ScopesInput
+                        scopesString={integration.oauth_scopes || ''}
+                        onChange={handleScopesChange}
+                        isSharedCredentials={isSharedCredentials}
+                        readOnly={!canEdit}
+                    />
                 </div>
             )}
 


### PR DESCRIPTION
## Describe the problem and your solution

- Allow scopes to be defined when creating an `oauth2_cc` integration. This enables customers to specify scopes at the [integration](https://github.com/NangoHQ/nango/blob/master/packages/server/lib/controllers/oauth.controller.ts#L448) level, rather than only when creating a connect session.

<!-- Issue ticket number and link (if applicable) -->

<!-- Testing instructions (skip if just adding/editing providers) -->


<!-- Summary by @propel-code-bot -->

---

**Add `OAUTH2_CC` scope configuration in integration settings and API**

This PR adds support for defining `OAUTH2_CC` scopes at the integration level across the web UI, server validation, and API types. It introduces a dedicated `OAuth2CCSettings` component with a `ScopesInput` control that persists scopes via PATCH, and wires this component into the auth-specific settings routing.

---
*This summary was automatically generated by @propel-code-bot*