### PR TITLE
feat(server): track missing OAuth state cookies to assess CSRF fix re-enablement impact

### DIFF
--- a/packages/server/lib/controllers/oauth.controller.ts
+++ b/packages/server/lib/controllers/oauth.controller.ts
@@ -1180,10 +1180,7 @@ class OAuthController {
 
             if (req.cookies[`oauth2-${session.id}`] !== '1') {
                 metrics.increment(metrics.Types.AUTH_CALLBACK_STATE_COOKIE_MISSING, 1, {
-                    provider: config.provider,
-                    integration: config.unique_key,
-                    account_id: account.id,
-                    auth_mode: session.authMode
+                    account_id: account.id
                 });
             }
 

--- a/packages/server/lib/controllers/oauth.controller.ts
+++ b/packages/server/lib/controllers/oauth.controller.ts
@@ -296,7 +296,16 @@ class OAuthController {
                 await this.mcpOauth2Request({ provider: provider as ProviderMcpOAUTH2, config, session, req, res, connectionConfig, callbackUrl, logCtx });
                 return;
             } else if (provider.auth_mode === 'MCP_OAUTH2_GENERIC') {
-                await this.mcpGenericRequest({ provider: provider as ProviderMcpOAuth2Generic, config, session, res, connectionConfig, callbackUrl, logCtx });
+                await this.mcpGenericRequest({
+                    provider: provider as ProviderMcpOAuth2Generic,
+                    config,
+                    session,
+                    req,
+                    res,
+                    connectionConfig,
+                    callbackUrl,
+                    logCtx
+                });
                 return;
             } else if (provider.auth_mode === 'OAUTH1') {
                 await this.oauth1Request(provider, config, session, res, callbackUrl, logCtx);
@@ -957,6 +966,7 @@ class OAuthController {
     private async mcpGenericRequest({
         config,
         session,
+        req,
         res,
         connectionConfig,
         callbackUrl,
@@ -965,6 +975,7 @@ class OAuthController {
         provider: ProviderMcpOAuth2Generic;
         config: ProviderConfig;
         session: OAuthSession;
+        req: Request;
         res: Response;
         connectionConfig: Record<string, string>;
         callbackUrl: string;
@@ -1048,6 +1059,12 @@ class OAuthController {
                 scopes: scopes || ''
             });
 
+            res.cookie(`oauth2-${session.id}`, '1', {
+                maxAge: 60 * 60 * 1000,
+                secure: req.secure,
+                httpOnly: true,
+                sameSite: req.secure ? 'none' : 'lax'
+            });
             res.redirect(authResult.authorizationUrl.href);
         } catch (err) {
             const prettyError = stringifyError(err, { pretty: true });
@@ -1178,9 +1195,16 @@ class OAuthController {
             const config = (await configService.getProviderConfig(session.providerConfigKey, session.environmentId))!;
             await logCtx.enrichOperation({ integrationId: config.id!, integrationName: config.unique_key, providerName: config.provider });
 
-            if (req.cookies[`oauth2-${session.id}`] !== '1') {
+            if (
+                (session.authMode === 'OAUTH2' ||
+                    session.authMode === 'CUSTOM' ||
+                    session.authMode === 'MCP_OAUTH2' ||
+                    session.authMode === 'MCP_OAUTH2_GENERIC') &&
+                req.cookies[`oauth2-${session.id}`] !== '1'
+            ) {
                 metrics.increment(metrics.Types.AUTH_CALLBACK_STATE_COOKIE_MISSING, 1, {
-                    account_id: account.id
+                    account_id: account.id,
+                    auth_mode: session.authMode
                 });
             }
 

--- a/packages/server/lib/controllers/oauth.controller.ts
+++ b/packages/server/lib/controllers/oauth.controller.ts
@@ -280,6 +280,7 @@ class OAuthController {
                     provider: provider as ProviderOAuth2,
                     providerConfig: config,
                     session,
+                    req,
                     res,
                     connectionConfig,
                     authorizationParams,
@@ -289,10 +290,10 @@ class OAuthController {
                 });
                 return;
             } else if (provider.auth_mode === 'APP' || provider.auth_mode === 'CUSTOM') {
-                await this.appRequest(provider, config, session, res, authorizationParams, logCtx);
+                await this.appRequest(provider, config, session, req, res, authorizationParams, logCtx);
                 return;
             } else if (provider.auth_mode === 'MCP_OAUTH2') {
-                await this.mcpOauth2Request({ provider: provider as ProviderMcpOAUTH2, config, session, res, connectionConfig, callbackUrl, logCtx });
+                await this.mcpOauth2Request({ provider: provider as ProviderMcpOAUTH2, config, session, req, res, connectionConfig, callbackUrl, logCtx });
                 return;
             } else if (provider.auth_mode === 'MCP_OAUTH2_GENERIC') {
                 await this.mcpGenericRequest({ provider: provider as ProviderMcpOAuth2Generic, config, session, res, connectionConfig, callbackUrl, logCtx });
@@ -599,6 +600,7 @@ class OAuthController {
         provider,
         providerConfig,
         session,
+        req,
         res,
         connectionConfig,
         authorizationParams,
@@ -609,6 +611,7 @@ class OAuthController {
         provider: ProviderOAuth2;
         providerConfig: ProviderConfig;
         session: OAuthSession;
+        req: Request;
         res: Response;
         connectionConfig: Record<string, string>;
         authorizationParams: Record<string, string | undefined>;
@@ -734,6 +737,13 @@ class OAuthController {
                     scopes: providerConfig.oauth_scopes ? providerConfig.oauth_scopes.split(',').join(provider.scope_separator || ' ') : ''
                 });
 
+                res.cookie(`oauth2-${session.id}`, '1', {
+                    maxAge: 60 * 60 * 1000,
+                    secure: req.secure,
+                    httpOnly: true,
+                    sameSite: req.secure ? 'none' : 'lax'
+                });
+
                 res.redirect(authorizationUri);
             } else {
                 const grantType = provider.token_params.grant_type;
@@ -765,6 +775,7 @@ class OAuthController {
         provider: Provider,
         providerConfig: ProviderConfig,
         session: OAuthSession,
+        req: Request,
         res: Response,
         authorizationParams: Record<string, string | undefined>,
         logCtx: LogContext
@@ -804,6 +815,13 @@ class OAuthController {
             const authorizationUri = `${appUrl}?${params.toString()}`;
 
             void logCtx.info('Redirecting', { authorizationUri, providerConfigKey, connectionId, connectionConfig });
+
+            res.cookie(`oauth2-${session.id}`, '1', {
+                maxAge: 60 * 60 * 1000,
+                secure: req.secure,
+                httpOnly: true,
+                sameSite: req.secure ? 'none' : 'lax'
+            });
 
             res.redirect(authorizationUri);
         } catch (err) {
@@ -847,6 +865,7 @@ class OAuthController {
         provider,
         config,
         session,
+        req,
         res,
         connectionConfig,
         callbackUrl,
@@ -855,6 +874,7 @@ class OAuthController {
         provider: ProviderMcpOAUTH2;
         config: ProviderConfig;
         session: OAuthSession;
+        req: Request;
         res: Response;
         connectionConfig: Record<string, string>;
         callbackUrl: string;
@@ -914,6 +934,13 @@ class OAuthController {
                 connectionConfig,
                 grantType: provider.token_params?.['grant_type'] as string,
                 scopes: config.oauth_scopes ? config.oauth_scopes.split(',').join(provider.scope_separator || ' ') : ''
+            });
+
+            res.cookie(`oauth2-${session.id}`, '1', {
+                maxAge: 60 * 60 * 1000,
+                secure: req.secure,
+                httpOnly: true,
+                sameSite: req.secure ? 'none' : 'lax'
             });
 
             res.redirect(authorizationUri);
@@ -1150,6 +1177,15 @@ class OAuthController {
 
             const config = (await configService.getProviderConfig(session.providerConfigKey, session.environmentId))!;
             await logCtx.enrichOperation({ integrationId: config.id!, integrationName: config.unique_key, providerName: config.provider });
+
+            if (req.cookies[`oauth2-${session.id}`] !== '1') {
+                metrics.increment(metrics.Types.AUTH_CALLBACK_STATE_COOKIE_MISSING, 1, {
+                    provider: config.provider,
+                    integration: config.unique_key,
+                    account_id: account.id,
+                    auth_mode: session.authMode
+                });
+            }
 
             if (session.authMode === 'OAUTH2' || session.authMode === 'CUSTOM' || session.authMode === 'MCP_OAUTH2') {
                 await this.oauth2Callback(provider as ProviderOAuth2, config, session, req, res, environment, account, logCtx);

--- a/packages/server/lib/routes.public.ts
+++ b/packages/server/lib/routes.public.ts
@@ -1,4 +1,5 @@
 import bodyParser from 'body-parser';
+import cookieParser from 'cookie-parser';
 import cors from 'cors';
 import express from 'express';
 import multer from 'multer';
@@ -124,7 +125,7 @@ publicAPI.options('/', publicAPICorsHandler); // Pre-flight
 publicAPI.use('/connect/telemetry', publicAPITelemetryCors);
 
 // API routes (Public key auth).
-publicAPI.route('/oauth/callback').get(oauthController.oauthCallback.bind(oauthController));
+publicAPI.route('/oauth/callback').get(cookieParser(), oauthController.oauthCallback.bind(oauthController));
 publicAPI.route('/app-auth/connect').get(appAuthController.connect.bind(appAuthController));
 
 publicAPI.use('/oauth', jsonContentTypeMiddleware);

--- a/packages/utils/lib/telemetry/metrics.ts
+++ b/packages/utils/lib/telemetry/metrics.ts
@@ -98,7 +98,9 @@ export enum Types {
 
     USAGE_IS_CAPPED = 'nango.capping.isCapped',
 
-    PUBSUB_PUBLISH = 'nango.pubsub.publish'
+    PUBSUB_PUBLISH = 'nango.pubsub.publish',
+
+    AUTH_CALLBACK_STATE_COOKIE_MISSING = 'nango.server.auth.callback.state_cookie.missing'
 }
 
 type Dimensions = Record<string, string | number> | undefined;


### PR DESCRIPTION
## Problem
We shipped OAuth2 callback state cookie validation as a CSRF fix (#5366, #5488, #5491) but had to revert it (#5493) because some customers' connectors proxy the OAuth redirect and silently drop cookies, breaking their auth flow.

Before re-enabling the hard validation, we need visibility into how many customers and which integrations would actually fail the check.

## Solution
Re-add the state cookie (set on OAuth request, checked on callback) but in observation-only mode (the check never blocks the flow). When the expected cookie is absent at callback time, we emit a `nango.server.auth.callback.state_cookie.missing` metric tagged with `account_id` and `auth_mode`

This covers all OAuth2 callbacks

NAN-5134

<!-- Summary by @propel-code-bot -->

---

In addition to restoring observation-only state-cookie checks, this change standardizes that behavior across the relevant OAuth callback variants and adds the callback cookie-parsing/telemetry plumbing needed to reliably measure missing-cookie occurrences before any strict enforcement is reintroduced.

---
*This summary was automatically generated by @propel-code-bot*