### PR TITLE
feat(webapp): RBAC UI feedback (low hanging)

### DIFF
--- a/packages/webapp/src/App.tsx
+++ b/packages/webapp/src/App.tsx
@@ -7,7 +7,6 @@ import { useLocalStorage } from 'react-use';
 import { Toaster } from 'sonner';
 import { SWRConfig } from 'swr';
 
-import { PermissionRoute } from './components/PermissionRoute';
 import { PrivateRoute } from './components/PrivateRoute';
 import { useMeta } from './hooks/useMeta';
 import { useUser } from './hooks/useUser';
@@ -213,14 +212,9 @@ const router = sentryCreateBrowserRouter([
                         handle: { breadcrumb: 'User settings' } as BreadcrumbHandle
                     },
                     {
-                        element: <PermissionRoute action="*" scope="global" resource="billing" />,
-                        children: [
-                            {
-                                path: 'team/billing',
-                                element: <TeamBilling />,
-                                handle: { breadcrumb: 'Team billing' } as BreadcrumbHandle
-                            }
-                        ]
+                        path: 'team/billing',
+                        element: <TeamBilling />,
+                        handle: { breadcrumb: 'Team billing' } as BreadcrumbHandle
                     }
                 ]
             }

--- a/packages/webapp/src/components-v2/AppSidebar/EnvironmentDropdown.tsx
+++ b/packages/webapp/src/components-v2/AppSidebar/EnvironmentDropdown.tsx
@@ -8,6 +8,7 @@ import { StyledLink } from '../StyledLink.js';
 import { CreateEnvironmentDialog } from './CreateEnvironmentDialog.js';
 import { ConditionalTooltip } from '../ConditionalTooltip.js';
 import { PermissionGate } from '../PermissionGate.js';
+import { Badge } from '../ui/badge.js';
 import { Button } from '../ui/button.js';
 import { DropdownMenu, DropdownMenuContent, DropdownMenuItem, DropdownMenuTrigger } from '../ui/dropdown-menu.js';
 import { SidebarMenu, SidebarMenuItem } from '../ui/sidebar.js';
@@ -89,13 +90,16 @@ export const EnvironmentDropdown: React.FC = () => {
                                             disabled={!allowed}
                                             onSelect={() => onSelect(environment.name)}
                                             data-active={env === environment.name}
-                                            className="flex flex-row items-center gap-2 cursor-pointer data-[active=true]:text-text-primary"
+                                            className="flex flex-row items-center justify-between gap-2 cursor-pointer data-[active=true]:text-text-primary"
                                         >
-                                            <Check
-                                                className="w-5 h-5 opacity-0 data-[active=true]:opacity-100 data-[active=true]:text-text-primary"
-                                                data-active={env === environment.name}
-                                            />
-                                            <span>{environment.name}</span>
+                                            <div className="flex flex-row items-center gap-2 ">
+                                                <Check
+                                                    className="w-5 h-5 opacity-0 data-[active=true]:opacity-100 data-[active=true]:text-text-primary"
+                                                    data-active={env === environment.name}
+                                                />
+                                                <span>{environment.name}</span>
+                                            </div>
+                                            {environment.is_production && <Badge className="-uppercase">Prod</Badge>}
                                         </DropdownMenuItem>
                                     )}
                                 </PermissionGate>

--- a/packages/webapp/src/components-v2/AppSidebar/ProfileDropdown.tsx
+++ b/packages/webapp/src/components-v2/AppSidebar/ProfileDropdown.tsx
@@ -2,12 +2,9 @@ import { ChevronsUpDown, CreditCard, LogOut, Sparkle, UserRoundCog, Users } from
 import { useMemo } from 'react';
 import { useNavigate } from 'react-router-dom';
 
-import { permissions } from '@nangohq/authz';
-
 import { DropdownMenu, DropdownMenuContent, DropdownMenuItem, DropdownMenuTrigger } from '../ui/dropdown-menu';
 import { SidebarMenu, SidebarMenuItem } from '../ui/sidebar';
 import { useMeta } from '@/hooks/useMeta';
-import { usePermissions } from '@/hooks/usePermissions';
 import { useUser } from '@/hooks/useUser';
 import { useStore } from '@/store';
 import { toAcronym } from '@/utils/avatar';
@@ -23,9 +20,6 @@ export const ProfileDropdown: React.FC = () => {
     const signout = useSignout();
     const { user } = useUser();
     const showGettingStarted = useStore((state) => state.showGettingStarted);
-
-    const { can } = usePermissions();
-    const canManageBilling = can(permissions.canManageBilling);
 
     const items = useMemo(() => {
         const list = [
@@ -49,7 +43,7 @@ export const ProfileDropdown: React.FC = () => {
             });
         }
 
-        if (globalEnv.features.plan && canManageBilling) {
+        if (globalEnv.features.plan) {
             list.push({
                 label: 'Billing & usage',
                 icon: CreditCard,

--- a/packages/webapp/src/components-v2/EditableInput.tsx
+++ b/packages/webapp/src/components-v2/EditableInput.tsx
@@ -100,8 +100,7 @@ export const EditableInput: React.FC<EditableInputProps> = ({
         try {
             await onSave?.(value);
             setReferenceValue(value);
-        } catch (err) {
-            console.log('onSaveClicked catch', value, referenceValue, err);
+        } catch {
             setEditing(true);
         } finally {
             setLoading(false);

--- a/packages/webapp/src/components-v2/EditableInput.tsx
+++ b/packages/webapp/src/components-v2/EditableInput.tsx
@@ -108,7 +108,7 @@ export const EditableInput: React.FC<EditableInputProps> = ({
         }
     };
 
-    const displayValue = !canRead && !value ? '•'.repeat(32) : value;
+    const displayValue = !canRead ? '•'.repeat(32) : value;
 
     return (
         <div className="flex flex-col gap-2">

--- a/packages/webapp/src/components-v2/EditableInput.tsx
+++ b/packages/webapp/src/components-v2/EditableInput.tsx
@@ -100,12 +100,15 @@ export const EditableInput: React.FC<EditableInputProps> = ({
         try {
             await onSave?.(value);
             setReferenceValue(value);
-        } catch {
+        } catch (err) {
+            console.log('onSaveClicked catch', value, referenceValue, err);
             setEditing(true);
         } finally {
             setLoading(false);
         }
     };
+
+    const displayValue = !canRead && !value ? '•'.repeat(32) : value;
 
     return (
         <div className="flex flex-col gap-2">
@@ -114,7 +117,7 @@ export const EditableInput: React.FC<EditableInputProps> = ({
                     <InputGroupTextarea
                         ref={textareaRef}
                         id={id}
-                        value={value}
+                        value={displayValue}
                         onChange={handleChange}
                         className="h-36"
                         disabled={!editing}
@@ -127,7 +130,7 @@ export const EditableInput: React.FC<EditableInputProps> = ({
                     <InputGroupInput
                         ref={inputRef}
                         id={id}
-                        value={value}
+                        value={displayValue}
                         placeholder={editing ? placeHolder : undefined}
                         onChange={handleChange}
                         type={secret && !editing ? 'password' : 'text'}

--- a/packages/webapp/src/components-v2/SecretInput.tsx
+++ b/packages/webapp/src/components-v2/SecretInput.tsx
@@ -19,9 +19,11 @@ export const SecretInput: React.FC<SecretInputProps> = ({ copy, canRead = true, 
 
     const textToCopy = (value || defaultValue)?.toString() || '';
 
+    const displayValue = !canRead && !value && !defaultValue ? '•'.repeat(32) : value;
+
     return (
         <InputGroup>
-            <InputGroupInput {...props} value={value} defaultValue={defaultValue} type={isSecretVisible ? 'text' : 'password'} />
+            <InputGroupInput {...props} value={displayValue} defaultValue={defaultValue} type={isSecretVisible ? 'text' : 'password'} />
             <InputGroupAddon align="inline-end">
                 <PermissionGate condition={canRead}>
                     {(allowed) => (

--- a/packages/webapp/src/components-v2/SecretInput.tsx
+++ b/packages/webapp/src/components-v2/SecretInput.tsx
@@ -19,11 +19,11 @@ export const SecretInput: React.FC<SecretInputProps> = ({ copy, canRead = true, 
 
     const textToCopy = (value || defaultValue)?.toString() || '';
 
-    const displayValue = !canRead && !value && !defaultValue ? '•'.repeat(32) : value;
+    const displayValue = !canRead ? '•'.repeat(32) : (value ?? defaultValue ?? '');
 
     return (
         <InputGroup>
-            <InputGroupInput {...props} value={displayValue} defaultValue={defaultValue} type={isSecretVisible ? 'text' : 'password'} />
+            <InputGroupInput {...props} value={displayValue} defaultValue={canRead ? defaultValue : undefined} type={isSecretVisible ? 'text' : 'password'} />
             <InputGroupAddon align="inline-end">
                 <PermissionGate condition={canRead}>
                     {(allowed) => (

--- a/packages/webapp/src/components-v2/ui/button.tsx
+++ b/packages/webapp/src/components-v2/ui/button.tsx
@@ -10,19 +10,19 @@ import type { VariantProps } from 'class-variance-authority';
 import type { LinkProps } from 'react-router-dom';
 
 const buttonVariants = cva(
-    "w-fit inline-flex items-center justify-center gap-2 whitespace-nowrap rounded-md !text-body-medium-medium transition-colors cursor-pointer disabled:cursor-not-allowed disabled:opacity-50 [&_svg]:pointer-events-none [&_svg:not([class*='size-'])]:size-4 shrink-0 [&_svg]:shrink-0 outline-none focus-default",
+    "w-fit inline-flex items-center justify-center gap-2 whitespace-nowrap rounded-md !text-body-medium-medium transition-colors cursor-pointer disabled:cursor-not-allowed disabled:opacity-50 aria-disabled:cursor-not-allowed aria-disabled:opacity-50 [&_svg]:pointer-events-none [&_svg:not([class*='size-'])]:size-4 shrink-0 [&_svg]:shrink-0 outline-none focus-default",
     {
         variants: {
             variant: {
                 primary:
-                    'bg-btn-primary-bg text-btn-primary-fg hover:bg-btn-primary-hover active:bg-btn-primary-press focus:bg-btn-primary-hover disabled:bg-btn-primary-disabled data-loading:bg-btn-primary-loading data-loading:opacity-100',
+                    'bg-btn-primary-bg text-btn-primary-fg hover:bg-btn-primary-hover active:bg-btn-primary-press focus:bg-btn-primary-hover disabled:bg-btn-primary-disabled data-loading:bg-btn-primary-loading data-loading:opacity-100 aria-disabled:hover:bg-btn-primary-bg aria-disabled:active:bg-btn-primary-bg',
                 destructive:
-                    'bg-btn-destructive-bg text-btn-destructive-fg hover:bg-btn-destructive-hover active:bg-btn-destructive-press focus:bg-btn-destructive-hover disabled:bg-btn-destructive-disabled data-loading:bg-btn-destructive-loading data-loading:opacity-100',
+                    'bg-btn-destructive-bg text-btn-destructive-fg hover:bg-btn-destructive-hover active:bg-btn-destructive-press focus:bg-btn-destructive-hover disabled:bg-btn-destructive-disabled data-loading:bg-btn-destructive-loading data-loading:opacity-100 aria-disabled:hover:bg-btn-destructive-bg aria-disabled:active:bg-btn-destructive-bg',
                 secondary:
-                    'bg-btn-secondary-bg text-btn-secondary-fg hover:bg-btn-secondary-hover active:bg-btn-secondary-press focus:bg-btn-secondary-hover disabled:bg-btn-secondary-disabled data-loading:bg-btn-secondary-loading data-loading:opacity-100',
+                    'bg-btn-secondary-bg text-btn-secondary-fg hover:bg-btn-secondary-hover active:bg-btn-secondary-press focus:bg-btn-secondary-hover disabled:bg-btn-secondary-disabled data-loading:bg-btn-secondary-loading data-loading:opacity-100 aria-disabled:hover:bg-btn-secondary-bg aria-disabled:active:bg-btn-secondary-bg',
                 tertiary:
-                    'bg-btn-tertiary-bg text-btn-tertiary-fg hover:bg-btn-tertiary-hover active:bg-btn-tertiary-press focus:bg-btn-tertiary-hover disabled:bg-btn-tertiary-disabled data-loading:bg-btn-tertiary-loading data-loading:opacity-100',
-                ghost: 'bg-transparent text-text-tertiary hover:text-text-primary'
+                    'bg-btn-tertiary-bg text-btn-tertiary-fg hover:bg-btn-tertiary-hover active:bg-btn-tertiary-press focus:bg-btn-tertiary-hover disabled:bg-btn-tertiary-disabled data-loading:bg-btn-tertiary-loading data-loading:opacity-100 aria-disabled:hover:bg-btn-tertiary-bg aria-disabled:active:bg-btn-tertiary-bg',
+                ghost: 'bg-transparent text-text-tertiary hover:text-text-primary aria-disabled:hover:text-text-tertiary'
             },
             size: {
                 sm: 'h-8 rounded gap-1.5 px-3 py-2',
@@ -70,16 +70,19 @@ type ButtonLinkProps = LinkProps &
         disabled?: boolean;
     };
 
-function ButtonLink({ className, variant, size, disabled, ...props }: ButtonLinkProps) {
-    // react-router-dom links don't support disabled state
-    if (disabled) {
-        return (
-            <Button variant={variant} size={size} className={className} disabled>
-                {props.children}
-            </Button>
-        );
-    }
-    return <Link data-slot="button" className={cn(buttonVariants({ variant, size, className }))} {...props} />;
-}
+const ButtonLink = React.forwardRef<HTMLAnchorElement, ButtonLinkProps>(({ className, variant, size, disabled, onClick, ...props }, ref) => {
+    return (
+        <Link
+            ref={ref}
+            data-slot="button"
+            aria-disabled={disabled || undefined}
+            tabIndex={disabled ? -1 : undefined}
+            className={cn(buttonVariants({ variant, size, className }))}
+            onClick={disabled ? (e) => e.preventDefault() : onClick}
+            {...props}
+        />
+    );
+});
+ButtonLink.displayName = 'ButtonLink';
 
 export { Button, ButtonLink, buttonVariants };

--- a/packages/webapp/src/pages/Integrations/Show.tsx
+++ b/packages/webapp/src/pages/Integrations/Show.tsx
@@ -107,7 +107,7 @@ export const IntegrationsList = () => {
             </Helmet>
             <header className="flex justify-between items-center">
                 <h2 className="text-text-primary text-title-subsection">Integrations</h2>
-                <PermissionGate condition={canWriteIntegration}>
+                <PermissionGate asChild condition={canWriteIntegration}>
                     {(allowed) => (
                         <ButtonLink disabled={!allowed} to={`/${env}/integrations/create`} size="lg">
                             Set up new integration
@@ -152,7 +152,7 @@ export const IntegrationsList = () => {
                 <div className="flex flex-col gap-5 p-20 items-center justify-center bg-bg-elevated rounded">
                     <h3 className="text-title-body text-text-primary">No integrations found</h3>
                     <p className="text-text-secondary text-body-medium-regular">Could not find any integrations matching your search.</p>
-                    <PermissionGate condition={canWriteIntegration}>
+                    <PermissionGate asChild condition={canWriteIntegration}>
                         {(allowed) => (
                             <ButtonLink disabled={!allowed} to={`/${env}/integrations/create`} size="lg">
                                 Set up new integration

--- a/packages/webapp/src/pages/Integrations/providerConfigKey/Settings/components/DeleteIntegrationButton.tsx
+++ b/packages/webapp/src/pages/Integrations/providerConfigKey/Settings/components/DeleteIntegrationButton.tsx
@@ -23,7 +23,7 @@ export const DeleteIntegrationButton: React.FC<{ env: string; integration: ApiIn
     const { data: environmentData } = useEnvironment(env);
     const environment = environmentData?.environmentAndAccount?.environment;
     const { can } = usePermissions();
-    const canDeleteIntegration = can(permissions.canWriteProdIntegrations) || !environment?.is_production;
+    const canDeleteIntegration = can(permissions.canDeleteProdIntegrations) || !environment?.is_production;
 
     const [open, setOpen] = useState(false);
     const { mutate, cache } = useSWRConfig();

--- a/packages/webapp/src/pages/Integrations/providerConfigKey/Settings/components/DeleteIntegrationButton.tsx
+++ b/packages/webapp/src/pages/Integrations/providerConfigKey/Settings/components/DeleteIntegrationButton.tsx
@@ -23,7 +23,7 @@ export const DeleteIntegrationButton: React.FC<{ env: string; integration: ApiIn
     const { data: environmentData } = useEnvironment(env);
     const environment = environmentData?.environmentAndAccount?.environment;
     const { can } = usePermissions();
-    const canDeleteIntegration = can(permissions.canDeleteProdIntegrations) || !environment?.is_production;
+    const canDeleteIntegration = environment ? can(permissions.canDeleteProdIntegrations) || !environment.is_production : false;
 
     const [open, setOpen] = useState(false);
     const { mutate, cache } = useSWRConfig();

--- a/packages/webapp/src/pages/Integrations/providerConfigKey/Settings/components/DeleteIntegrationButton.tsx
+++ b/packages/webapp/src/pages/Integrations/providerConfigKey/Settings/components/DeleteIntegrationButton.tsx
@@ -3,17 +3,28 @@ import { useState } from 'react';
 import { useNavigate } from 'react-router-dom';
 import { useSWRConfig } from 'swr';
 
+import { permissions } from '@nangohq/authz';
+
 import { clearConnectionsCache } from '../../../../../hooks/useConnections.js';
 import { useDeleteIntegration } from '../../../../../hooks/useIntegration.js';
 import { useToast } from '../../../../../hooks/useToast.js';
+import { PermissionGate } from '@/components-v2/PermissionGate.js';
 import { Button } from '@/components-v2/ui/button.js';
 import { Dialog, DialogClose, DialogContent, DialogDescription, DialogFooter, DialogTitle, DialogTrigger } from '@/components-v2/ui/dialog.js';
+import { useEnvironment } from '@/hooks/useEnvironment.js';
+import { usePermissions } from '@/hooks/usePermissions.js';
 
 import type { ApiIntegration } from '@nangohq/types';
 
 export const DeleteIntegrationButton: React.FC<{ env: string; integration: ApiIntegration; className?: string }> = ({ env, integration, className = '' }) => {
     const { toast } = useToast();
     const navigate = useNavigate();
+
+    const { data: environmentData } = useEnvironment(env);
+    const environment = environmentData?.environmentAndAccount?.environment;
+    const { can } = usePermissions();
+    const canDeleteIntegration = can(permissions.canWriteProdIntegrations) || !environment?.is_production;
+
     const [open, setOpen] = useState(false);
     const { mutate, cache } = useSWRConfig();
     const { mutateAsync: deleteIntegration, isPending } = useDeleteIntegration(env, integration.unique_key);
@@ -32,10 +43,14 @@ export const DeleteIntegrationButton: React.FC<{ env: string; integration: ApiIn
     return (
         <Dialog open={open} onOpenChange={setOpen}>
             <DialogTrigger asChild>
-                <Button variant="destructive" size="lg" loading={isPending} className={className}>
-                    <Trash2 />
-                    Delete integration
-                </Button>
+                <PermissionGate condition={canDeleteIntegration} asChild>
+                    {(allowed) => (
+                        <Button variant="destructive" size="lg" loading={isPending} className={className} disabled={!allowed}>
+                            <Trash2 />
+                            Delete integration
+                        </Button>
+                    )}
+                </PermissionGate>
             </DialogTrigger>
             <DialogContent>
                 <DialogTitle>Delete integration?</DialogTitle>

--- a/packages/webapp/src/pages/Integrations/providerConfigKey/Settings/components/GeneralSettings.tsx
+++ b/packages/webapp/src/pages/Integrations/providerConfigKey/Settings/components/GeneralSettings.tsx
@@ -7,6 +7,7 @@ import { permissions } from '@nangohq/authz';
 import { CopyButton } from '@/components-v2/CopyButton';
 import { EditableInput } from '@/components-v2/EditableInput';
 import { InfoTooltip } from '@/components-v2/InfoTooltip';
+import { PermissionGate } from '@/components-v2/PermissionGate';
 import { Alert, AlertDescription } from '@/components-v2/ui/alert';
 import { InputGroup, InputGroupAddon, InputGroupInput } from '@/components-v2/ui/input-group';
 import { Label } from '@/components-v2/ui/label';
@@ -122,7 +123,18 @@ export const GeneralSettings: React.FC<{ data: GetIntegration['Success']['data']
                 <>
                     <div className="flex gap-5 items-center">
                         <Label htmlFor="webhook_forwarding">Webhook Forwarding</Label>
-                        <Switch name="webhook_forwarding" checked={webhookForwarding} onCheckedChange={handleWebhookForwardingChange} />
+                        <PermissionGate asChild condition={canEdit}>
+                            {(allowed) => (
+                                <div className="flex items-center">
+                                    <Switch
+                                        name="webhook_forwarding"
+                                        checked={webhookForwarding}
+                                        onCheckedChange={handleWebhookForwardingChange}
+                                        disabled={!allowed}
+                                    />
+                                </div>
+                            )}
+                        </PermissionGate>
                     </div>
                     {/* Webhook URL */}
                     <div className="flex flex-col gap-2">

--- a/packages/webapp/src/pages/Integrations/providerConfigKey/Settings/components/OAuthSettings.tsx
+++ b/packages/webapp/src/pages/Integrations/providerConfigKey/Settings/components/OAuthSettings.tsx
@@ -157,7 +157,12 @@ export const OAuthSettings: React.FC<{ data: GetIntegration['Success']['data']; 
             {template.auth_mode !== 'TBA' && template.installation !== 'outbound' && (
                 <div className="flex flex-col gap-2">
                     <Label htmlFor="scopes">Scopes</Label>
-                    <ScopesInput scopesString={integration.oauth_scopes || ''} onChange={handleScopesChange} isSharedCredentials={isSharedCredentials} />
+                    <ScopesInput
+                        scopesString={integration.oauth_scopes || ''}
+                        onChange={handleScopesChange}
+                        isSharedCredentials={isSharedCredentials}
+                        readOnly={!canEdit}
+                    />
                 </div>
             )}
 

--- a/packages/webapp/src/pages/Integrations/providerConfigKey/Show.tsx
+++ b/packages/webapp/src/pages/Integrations/providerConfigKey/Show.tsx
@@ -2,18 +2,22 @@ import { ExternalLink } from 'lucide-react';
 import { Helmet } from 'react-helmet';
 import { Link, useParams } from 'react-router-dom';
 
+import { permissions } from '@nangohq/authz';
+
 import { AutoIdlingBanner } from '../components/AutoIdlingBanner';
 import { FunctionsTab } from './Functions/Tab';
 import { SettingsTab } from './Settings/Tab';
 import { IntegrationSideInfo } from './components/IntegrationSideInfo';
 import { CriticalErrorAlert } from '@/components-v2/CriticalErrorAlert';
 import { IntegrationLogo } from '@/components-v2/IntegrationLogo';
+import { PermissionGate } from '@/components-v2/PermissionGate';
 import { Tabs, TabsContent, TabsList, TabsTrigger } from '@/components-v2/Tabs';
 import { ButtonLink } from '@/components-v2/ui/button';
 import { Skeleton } from '@/components-v2/ui/skeleton';
 import { useEnvironment } from '@/hooks/useEnvironment';
 import { useGetIntegration } from '@/hooks/useIntegration';
 import { usePathNavigation } from '@/hooks/usePathNavigation';
+import { usePermissions } from '@/hooks/usePermissions';
 import DashboardLayout from '@/layout/DashboardLayout';
 import { useStore } from '@/store';
 
@@ -24,6 +28,10 @@ export const ShowIntegration: React.FC = () => {
 
     const { data: environmentData, isLoading: loadingEnvironment, error: environmentError } = useEnvironment(env);
     const environmentAndAccount = environmentData?.environmentAndAccount;
+
+    const { can } = usePermissions();
+    const canCreateTestConnection = can(permissions.canWriteProdConnections) || !environmentAndAccount?.environment.is_production;
+
     const { data, isLoading: loadingIntegration, error: integrationError } = useGetIntegration(env, providerConfigKey!);
     const integration = data?.data;
 
@@ -70,9 +78,13 @@ export const ShowIntegration: React.FC = () => {
                             {integration.integration.display_name ?? integration.template.display_name}
                         </span>
                     </div>
-                    <ButtonLink to={`/${env}/connections/create?integration_id=${integration.integration.unique_key}`} size="lg">
-                        Add test connection
-                    </ButtonLink>
+                    <PermissionGate condition={canCreateTestConnection} asChild>
+                        {(allowed) => (
+                            <ButtonLink to={`/${env}/connections/create?integration_id=${integration.integration.unique_key}`} size="lg" disabled={!allowed}>
+                                Add test connection
+                            </ButtonLink>
+                        )}
+                    </PermissionGate>
                 </div>
                 <Tabs value={activeTab} onValueChange={setActiveTab}>
                     <TabsList>

--- a/packages/webapp/src/pages/Team/Billing/Show.tsx
+++ b/packages/webapp/src/pages/Team/Billing/Show.tsx
@@ -1,4 +1,4 @@
-import { useState } from 'react';
+import { useEffect, useState } from 'react';
 import { Helmet } from 'react-helmet';
 
 import { permissions } from '@nangohq/authz';
@@ -23,6 +23,12 @@ export const TeamBilling: React.FC = () => {
 
     const { can } = usePermissions();
     const canManageBilling = can(permissions.canManageBilling);
+
+    useEffect(() => {
+        if (!canManageBilling && activeTab === 'payment-and-invoices') {
+            setActiveTab('usage');
+        }
+    }, [canManageBilling, activeTab, setActiveTab]);
 
     return (
         <DashboardLayout className="flex flex-col gap-8">

--- a/packages/webapp/src/pages/Team/Billing/Show.tsx
+++ b/packages/webapp/src/pages/Team/Billing/Show.tsx
@@ -1,13 +1,17 @@
 import { useState } from 'react';
 import { Helmet } from 'react-helmet';
 
+import { permissions } from '@nangohq/authz';
+
 import { MonthSelector } from './components/MonthSelector';
 import { Payment } from './components/Payment';
 import { Plans } from './components/Plans';
 import { Usage } from './components/Usage';
 import DashboardLayout from '../../../layout/DashboardLayout';
 import { Navigation, NavigationContent, NavigationList, NavigationTrigger } from '@/components-v2/Navigation';
+import { PermissionGate } from '@/components-v2/PermissionGate';
 import { useHashNavigation } from '@/hooks/useHashNavigation';
+import { usePermissions } from '@/hooks/usePermissions';
 
 export const TeamBilling: React.FC = () => {
     const [activeTab, setActiveTab] = useHashNavigation('usage');
@@ -16,6 +20,9 @@ export const TeamBilling: React.FC = () => {
         const now = new Date();
         return new Date(now.getUTCFullYear(), now.getUTCMonth(), 1);
     });
+
+    const { can } = usePermissions();
+    const canManageBilling = can(permissions.canManageBilling);
 
     return (
         <DashboardLayout className="flex flex-col gap-8">
@@ -34,7 +41,13 @@ export const TeamBilling: React.FC = () => {
                 <NavigationList>
                     <NavigationTrigger value={'usage'}>Usage</NavigationTrigger>
                     <NavigationTrigger value={'plans'}>Plans</NavigationTrigger>
-                    <NavigationTrigger value={'payment-and-invoices'}>Payment & Invoices</NavigationTrigger>
+                    <PermissionGate condition={canManageBilling}>
+                        {(allowed) => (
+                            <NavigationTrigger value={'payment-and-invoices'} disabled={!allowed}>
+                                Payment & Invoices
+                            </NavigationTrigger>
+                        )}
+                    </PermissionGate>
                 </NavigationList>
                 <NavigationContent value={'usage'} className="w-full flex flex-col gap-6">
                     <Usage selectedMonth={selectedMonth} />
@@ -42,9 +55,11 @@ export const TeamBilling: React.FC = () => {
                 <NavigationContent value={'plans'} className="w-full overflow-x-auto">
                     <Plans />
                 </NavigationContent>
-                <NavigationContent value={'payment-and-invoices'} className="w-full">
-                    <Payment />
-                </NavigationContent>
+                {canManageBilling && (
+                    <NavigationContent value={'payment-and-invoices'} className="w-full">
+                        <Payment />
+                    </NavigationContent>
+                )}
             </Navigation>
         </DashboardLayout>
     );

--- a/packages/webapp/src/pages/Team/Billing/components/Plans.tsx
+++ b/packages/webapp/src/pages/Team/Billing/components/Plans.tsx
@@ -2,16 +2,20 @@ import { Info, Loader } from 'lucide-react';
 import { useCallback, useEffect, useMemo, useRef, useState } from 'react';
 import { mutate } from 'swr';
 
+import { permissions } from '@nangohq/authz';
+
 import { PaymentMethodDialog } from './PaymentMethodDialog.js';
 import { Dot } from '../../../../components-v2/Dot.js';
 import { DialogClose, DialogContent, DialogDescription, DialogFooter } from '../../../../components-v2/ui/dialog.jsx';
 import { DialogHeader, DialogTitle, DialogTrigger } from '@/components/ui/Dialog.js';
+import { PermissionGate } from '@/components-v2/PermissionGate.js';
 import { StyledLink } from '@/components-v2/StyledLink.js';
 import { Alert, AlertDescription } from '@/components-v2/ui/alert.js';
 import { Button, ButtonLink } from '@/components-v2/ui/button';
 import { Dialog } from '@/components-v2/ui/dialog.js';
 import { Table, TableBody, TableCell, TableRow } from '@/components-v2/ui/table';
 import { useEnvironment } from '@/hooks/useEnvironment';
+import { usePermissions } from '@/hooks/usePermissions.js';
 import { apiGetCurrentPlan, apiPostPlanChange, useApiGetPlans } from '@/hooks/usePlan';
 import { useStripePaymentMethods } from '@/hooks/useStripe.js';
 import { useToast } from '@/hooks/useToast.js';
@@ -117,6 +121,9 @@ const PlanRow: React.FC<{ planDefinition: PlanDefinitionList; activePlan?: PlanD
 }) => {
     const { plan, active, isFuture, isDowngrade, isUpgrade } = planDefinition;
 
+    const { can } = usePermissions();
+    const canChangePlan = can(permissions.canChangePlan);
+
     const [paymentMethodDialogOpen, setPaymentMethodDialogOpen] = useState(false);
     const [planChangeDialogOpen, setPlanChangeDialogOpen] = useState(false);
 
@@ -147,9 +154,13 @@ const PlanRow: React.FC<{ planDefinition: PlanDefinitionList; activePlan?: PlanD
         if (isUpgrade && plan.canChange) {
             return (
                 <>
-                    <Button onClick={onUpgradeClicked} variant="primary" className="w-27">
-                        Upgrade
-                    </Button>
+                    <PermissionGate asChild condition={canChangePlan}>
+                        {(allowed) => (
+                            <Button onClick={onUpgradeClicked} variant="primary" className="w-27" disabled={!allowed}>
+                                Upgrade
+                            </Button>
+                        )}
+                    </PermissionGate>
                     <PaymentMethodDialog
                         open={paymentMethodDialogOpen}
                         onOpenChange={setPaymentMethodDialogOpen}
@@ -168,9 +179,13 @@ const PlanRow: React.FC<{ planDefinition: PlanDefinitionList; activePlan?: PlanD
         if (isDowngrade && plan.canChange) {
             return (
                 <PlanChangeDialog selectedPlan={planDefinition} activePlan={activePlan}>
-                    <Button variant="destructive" className="w-27">
-                        Downgrade
-                    </Button>
+                    <PermissionGate asChild condition={canChangePlan}>
+                        {(allowed) => (
+                            <Button variant="destructive" className="w-27" disabled={!allowed}>
+                                Downgrade
+                            </Button>
+                        )}
+                    </PermissionGate>
                 </PlanChangeDialog>
             );
         }

--- a/packages/webapp/src/pages/Team/components/AddTeamMemberButton.tsx
+++ b/packages/webapp/src/pages/Team/components/AddTeamMemberButton.tsx
@@ -6,28 +6,16 @@ import { z } from 'zod';
 
 import { permissions } from '@nangohq/authz';
 
+import { RoleSelect } from './RoleSelect';
 import { PermissionGate } from '@/components-v2/PermissionGate';
 import { Button } from '@/components-v2/ui/button';
 import { Dialog, DialogClose, DialogContent, DialogFooter, DialogHeader, DialogTitle, DialogTrigger } from '@/components-v2/ui/dialog';
 import { Form, FormControl, FormField, FormItem, FormMessage } from '@/components-v2/ui/form';
 import { InputGroup, InputGroupInput } from '@/components-v2/ui/input-group';
-import { Select, SelectContent, SelectItem, SelectTrigger, SelectValue } from '@/components-v2/ui/select';
 import { usePostInvite } from '@/hooks/useInvite';
 import { usePermissions } from '@/hooks/usePermissions';
 import { useToast } from '@/hooks/useToast';
 import { useStore } from '@/store';
-
-import type { Role } from '@nangohq/types';
-
-const roles: { value: Role; label: string; description: string }[] = [
-    { value: 'administrator', label: 'Full access', description: 'Full access to everything, including sensitive data.' },
-    {
-        value: 'production_support',
-        label: 'Support',
-        description: 'Full access to non-production environments. Read-only access to non-sensitive production data.'
-    },
-    { value: 'development_full_access', label: 'Contributor', description: 'Full access to non-production environments.' }
-];
 
 const inviteSchema = z.object({
     email: z.string().email('Please enter a valid email address'),
@@ -109,23 +97,7 @@ export const AddTeamMemberButton = () => {
                             <Controller
                                 control={form.control}
                                 name="role"
-                                render={({ field }) => (
-                                    <Select value={field.value} onValueChange={(value) => field.onChange(value as Role)}>
-                                        <SelectTrigger className="w-40">
-                                            <SelectValue placeholder="Select a role">{roles.find((r) => r.value === field.value)?.label}</SelectValue>
-                                        </SelectTrigger>
-                                        <SelectContent align="end" className="p-0 max-w-71">
-                                            {roles.map(({ value, label, description }) => (
-                                                <SelectItem key={value} value={value} className="h-fit p-2">
-                                                    <div className="flex flex-col gap-1">
-                                                        <span className="text-text-primary text-body-medium-regular">{label}</span>
-                                                        <p className="text-text-secondary text-body-small-regular">{description}</p>
-                                                    </div>
-                                                </SelectItem>
-                                            ))}
-                                        </SelectContent>
-                                    </Select>
-                                )}
+                                render={({ field }) => <RoleSelect value={field.value} onChange={field.onChange} />}
                             />
                         </div>
                     </form>

--- a/packages/webapp/src/pages/Team/components/RoleSelect.tsx
+++ b/packages/webapp/src/pages/Team/components/RoleSelect.tsx
@@ -1,0 +1,33 @@
+import { Select, SelectContent, SelectItem, SelectTrigger, SelectValue } from '@/components-v2/ui/select';
+
+import type { Role } from '@nangohq/types';
+
+export const roles: { value: Role; label: string; description: string }[] = [
+    { value: 'administrator', label: 'Full access', description: 'Full access to all environments.' },
+    {
+        value: 'production_support',
+        label: 'Support',
+        description: 'Read-only access of non-sensitive data in production environments.'
+    },
+    { value: 'development_full_access', label: 'Contributor', description: 'Full access to non-production environments.' }
+];
+
+export const RoleSelect: React.FC<{ value: Role; onChange: (value: Role) => void }> = ({ value, onChange }) => {
+    return (
+        <Select value={value} onValueChange={(v) => onChange(v as Role)}>
+            <SelectTrigger className="w-40">
+                <SelectValue placeholder="Select a role">{roles.find((r) => r.value === value)?.label}</SelectValue>
+            </SelectTrigger>
+            <SelectContent align="end" className="p-0 max-w-71">
+                {roles.map(({ value: v, label, description }) => (
+                    <SelectItem key={v} value={v} className="h-fit p-2">
+                        <div className="flex flex-col gap-1">
+                            <span className="text-text-primary text-body-medium-regular">{label}</span>
+                            <p className="text-text-secondary text-body-small-regular">{description}</p>
+                        </div>
+                    </SelectItem>
+                ))}
+            </SelectContent>
+        </Select>
+    );
+};

--- a/packages/webapp/src/pages/Team/components/TeamMembers.tsx
+++ b/packages/webapp/src/pages/Team/components/TeamMembers.tsx
@@ -3,6 +3,7 @@ import { useMemo, useState } from 'react';
 
 import { permissions } from '@nangohq/authz';
 
+import { RoleSelect } from './RoleSelect';
 import { useDeleteTeamUser, usePatchTeamUser, useTeam } from '../../../hooks/useTeam';
 import { useStore } from '../../../store';
 import { Dot } from '@/components-v2/Dot';
@@ -12,7 +13,6 @@ import { Button } from '@/components-v2/ui/button';
 import { Dialog, DialogClose, DialogContent, DialogFooter, DialogHeader, DialogTitle } from '@/components-v2/ui/dialog';
 import { DropdownMenu, DropdownMenuContent, DropdownMenuItem, DropdownMenuTrigger } from '@/components-v2/ui/dropdown-menu';
 import { Input } from '@/components-v2/ui/input';
-import { Select, SelectContent, SelectItem, SelectTrigger, SelectValue } from '@/components-v2/ui/select';
 import { Table, TableBody, TableCell, TableHead, TableHeader, TableRow } from '@/components-v2/ui/table';
 import { useConfirmDialog } from '@/hooks/useConfirmDialog';
 import { useDeleteInvite } from '@/hooks/useInvite';
@@ -21,16 +21,6 @@ import { useToast } from '@/hooks/useToast';
 import { useUser } from '@/hooks/useUser';
 
 import type { ApiInvitation, ApiUser, Role } from '@nangohq/types';
-
-const roles: { value: Role; label: string; description: string }[] = [
-    { value: 'administrator', label: 'Full access', description: 'Full access to everything, including sensitive data.' },
-    {
-        value: 'production_support',
-        label: 'Support',
-        description: 'Full access to non-production environments. Read-only access to non-sensitive production data.'
-    },
-    { value: 'development_full_access', label: 'Contributor', description: 'Full access to non-production environments.' }
-];
 
 const EditRoleDialog: React.FC<{ user: ApiUser; onClose: () => void }> = ({ user, onClose }) => {
     const env = useStore((state) => state.env);
@@ -60,21 +50,7 @@ const EditRoleDialog: React.FC<{ user: ApiUser; onClose: () => void }> = ({ user
                 </DialogHeader>
                 <div className="flex items-center gap-2">
                     <Input type="email" value={user.email} disabled className="flex-1" />
-                    <Select value={role} onValueChange={(value) => setRole(value as Role)}>
-                        <SelectTrigger className="w-40">
-                            <SelectValue placeholder="Select a role">{roles.find((r) => r.value === role)?.label}</SelectValue>
-                        </SelectTrigger>
-                        <SelectContent align="end" className="p-0 max-w-71">
-                            {roles.map(({ value, label, description }) => (
-                                <SelectItem key={value} value={value} className="h-fit p-2">
-                                    <div className="flex flex-col gap-1">
-                                        <span className="text-text-primary text-body-medium-regular">{label}</span>
-                                        <p className="text-text-secondary text-body-small-regular">{description}</p>
-                                    </div>
-                                </SelectItem>
-                            ))}
-                        </SelectContent>
-                    </Select>
+                    <RoleSelect value={role} onChange={setRole} />
                 </div>
                 <DialogFooter>
                     <DialogClose asChild>

--- a/packages/webapp/src/pages/Team/components/TeamMembers.tsx
+++ b/packages/webapp/src/pages/Team/components/TeamMembers.tsx
@@ -78,10 +78,11 @@ export const TeamMembers: React.FC = () => {
     const [editingUser, setEditingUser] = useState<ApiUser | null>(null);
 
     const allUsers: ((ApiUser & { is_invitation: false }) | (ApiInvitation & { is_invitation: true }))[] = useMemo(
-        () => [
-            ...(data?.data.users || []).map((u) => ({ ...u, is_invitation: false as const })),
-            ...(data?.data.invitedUsers || []).map((u) => ({ ...u, is_invitation: true as const }))
-        ],
+        () =>
+            [
+                ...(data?.data.users || []).map((u) => ({ ...u, is_invitation: false as const })),
+                ...(data?.data.invitedUsers || []).map((u) => ({ ...u, is_invitation: true as const }))
+            ].sort((a, b) => a.name.localeCompare(b.email)),
         [data]
     );
 

--- a/packages/webapp/src/pages/Team/components/TeamMembers.tsx
+++ b/packages/webapp/src/pages/Team/components/TeamMembers.tsx
@@ -82,7 +82,7 @@ export const TeamMembers: React.FC = () => {
             [
                 ...(data?.data.users || []).map((u) => ({ ...u, is_invitation: false as const })),
                 ...(data?.data.invitedUsers || []).map((u) => ({ ...u, is_invitation: true as const }))
-            ].sort((a, b) => a.name.localeCompare(b.email)),
+            ].sort((a, b) => a.email.localeCompare(b.email)),
         [data]
     );
 


### PR DESCRIPTION
Some low hanging fruits from RBAC UI feedback. There are a couple things that still require design but this is a good step forward.

<!-- Summary by @propel-code-bot -->

---

**RBAC UI feedback: shared role selection, permission gating, and masked secrets**

This PR delivers a set of RBAC-oriented UI refinements in the web app. It introduces a shared `RoleSelect` component for team role selection, adds permission-aware disabled states and gating for billing, integrations, and settings actions, and improves disabled link styling and behavior via `aria-disabled` on `ButtonLink`.

Additional tweaks include masking secret values when `canRead` is false in `SecretInput` and `EditableInput`, adding a production badge in the environment dropdown, ensuring deterministic team member ordering, and removing the billing route guard in favor of in-page permission checks.

---
*This summary was automatically generated by @propel-code-bot*