### PR TITLE
fix(webapp): narrow provider search to name fields only

### DIFF
--- a/packages/webapp/src/pages/Integrations/CreateList.tsx
+++ b/packages/webapp/src/pages/Integrations/CreateList.tsx
@@ -45,12 +45,10 @@ export const CreateIntegrationList = () => {
 
         return new Fuse(initialProviders, {
             keys: [
-                { name: 'displayName', weight: 0.3 },
-                { name: 'name', weight: 0.3 },
-                { name: 'authMode', weight: 0.2 },
-                { name: 'categories', weight: 0.2 }
+                { name: 'displayName', weight: 0.6 },
+                { name: 'name', weight: 0.4 }
             ],
-            threshold: 0.4, // 0.0 = exact match, 1.0 = match anything. 0.4 is a good balance
+            threshold: 0.3,
             includeScore: true,
             minMatchCharLength: 1,
             ignoreLocation: true, // Search anywhere in the string


### PR DESCRIPTION
## Describe the problem and your solution

- Fuse.js was matching category tags (e.g. "marketing") against search terms like "heymarket", causing unrelated providers to appear.

<!-- Issue ticket number and link (if applicable) -->

<!-- Testing instructions (skip if just adding/editing providers) -->


<!-- Summary by @propel-code-bot -->

---

**Narrow provider search to name fields in `CreateList`**

This PR adjusts Fuse.js configuration in `packages/webapp/src/pages/Integrations/CreateList.tsx` to search only `displayName` and `name`, removing `authMode` and `categories` from matching. It also tweaks weights and lowers the `threshold` to reduce unrelated provider matches.

---
*This summary was automatically generated by @propel-code-bot*