### PR TITLE
chore: Bump max string length in checkpoint

### DIFF
--- a/packages/shared/lib/services/checkpoints/checkpoints.ts
+++ b/packages/shared/lib/services/checkpoints/checkpoints.ts
@@ -9,13 +9,13 @@ import type { Knex } from 'knex';
 const TABLE = 'checkpoints';
 
 export const CHECKPOINT_KEY_MAX_LENGTH = 255;
-export const CHECKPOINT_STRING_VALUE_MAX_LENGTH = 255;
+export const CHECKPOINT_STRING_VALUE_MAX_LENGTH = 4000;
 export const CHECKPOINT_MAX_FIELDS = 16;
 
 /**
  * Zod schema for checkpoint validation.
  * - Keys: max 255 characters
- * - String values: max 255 characters
+ * - String values: max 4000 characters
  * - Date values: converted to ISO string
  * - Max 16 fields
  */

--- a/packages/shared/lib/services/checkpoints/checkpoints.unit.test.ts
+++ b/packages/shared/lib/services/checkpoints/checkpoints.unit.test.ts
@@ -90,8 +90,14 @@ describe('validateCheckpoint', () => {
             expect(result.isErr()).toBe(true);
         });
 
-        it('should fail for string value exceeding 255 characters', () => {
-            const longValue = 'a'.repeat(256);
+        it('should not fail for string value up to 4000 characters', () => {
+            const longValue = 'a'.repeat(4000);
+            const result = validateCheckpoint({ key: longValue });
+            expect(result.isErr()).toBe(false);
+        });
+
+        it('should fail for string value exceeding 4000 characters', () => {
+            const longValue = 'a'.repeat(4001);
             const result = validateCheckpoint({ key: longValue });
             expect(result.isErr()).toBe(true);
         });


### PR DESCRIPTION
<!-- Describe the problem and your solution --> 
Increase max length of strings in checkpoint object to allow for [Microsoft deltaTokens](https://learn.microsoft.com/en-us/graph/delta-query-overview#state-tokens) and similar.

[Internal thread](https://nangohq.slack.com/archives/C073P0YK5EY/p1774892131045709)

<!-- Issue ticket number and link (if applicable) -->
[NAN-5164: Levity - Bump max string length in checkpoint](https://linear.app/nango/issue/NAN-5164/levity-bump-max-string-length-in-checkpoint)

<!-- Testing instructions (skip if just adding/editing providers) -->
- Save a checkpoint with a long string

<!-- Summary by @propel-code-bot -->

---

This PR raises the checkpoint string value maximum from 255 to 4000 in the schema and updates the unit tests to validate the new length bounds.

---
*This summary was automatically generated by @propel-code-bot*