### PR TITLE
perf(records): create records_data table

### DIFF
--- a/packages/records/lib/db/migrations/20260327160200_create_data_table.ts
+++ b/packages/records/lib/db/migrations/20260327160200_create_data_table.ts
@@ -1,0 +1,30 @@
+import type { Knex } from 'knex';
+
+const TABLE = 'records_data';
+const PARTITION_COUNT = 256;
+
+export async function up(knex: Knex): Promise<void> {
+    await knex.transaction(async (trx) => {
+        // Moving the records data to a separate table
+        // New table is partitioned by connection_id and model to match the records table
+        // This allows us to stop writing blob data in the records table and only write data when hash has changed
+        await trx.raw(`
+            CREATE TABLE IF NOT EXISTS "${TABLE}" (
+                id uuid NOT NULL,
+                connection_id integer NOT NULL,
+                model character varying(255) NOT NULL,
+                data jsonb NOT NULL,
+                PRIMARY KEY (connection_id, model, id)
+            ) PARTITION BY HASH (connection_id, model)
+        `);
+        for (let i = 0; i < PARTITION_COUNT; i++) {
+            await trx.raw(`
+                CREATE TABLE IF NOT EXISTS "${TABLE}_p${i}" PARTITION OF "${TABLE}"
+                FOR VALUES WITH (MODULUS ${PARTITION_COUNT}, REMAINDER ${i});
+            `);
+        }
+        await trx.raw(`ALTER TABLE records ALTER COLUMN json DROP NOT NULL`);
+    });
+}
+
+export async function down(): Promise<void> {}


### PR DESCRIPTION
Migration to prepare the move of records payload to a separate table in order to avoid having to always write the payload of unchanged records (60% of the volume of upserted records). 
This is just the migration. Refactoring of the records package is coming in next PR

<!-- Describe the problem and your solution --> 

<!-- Issue ticket number and link (if applicable) -->

<!-- Testing instructions (skip if just adding/editing providers) -->


<!-- Summary by @propel-code-bot -->

---

This migration adds a new `records_data` table partitioned by `connection_id` and `model` and makes `records.json` nullable to enable moving payloads out of the primary table in a later refactor.

---
*This summary was automatically generated by @propel-code-bot*