### PR TITLE
fix(lambda): add integrationConfig to nangoPropsSchema

### DIFF
--- a/packages/lambda-runner/lib/schemas.ts
+++ b/packages/lambda-runner/lib/schemas.ts
@@ -83,6 +83,12 @@ export const nangoPropsSchema = z.object({
             killAfterMs: z.number(),
             interruptAfterMs: z.number()
         })
+        .optional(),
+    integrationConfig: z
+        .object({
+            oauth_client_id: z.string().nullable(),
+            oauth_client_secret: z.string().nullable()
+        })
         .optional()
 });
 


### PR DESCRIPTION
## Describe the problem and your solution

- Zod's `z.object()`  was striping unknown keys by default, so the `integrationConfig` set in [here](https://github.com/NangoHQ/nango/blob/2313bc5c5df7ff763de90aed29df7326fb31c16a/packages/jobs/lib/execution/action.ts#L157) was silently dropped when the lambda parsed its event payload.

<!-- Issue ticket number and link (if applicable) -->

<!-- Testing instructions (skip if just adding/editing providers) -->

