### PR TITLE
chore: auto-approve gh action for docs only PRs

### DIFF
--- a/.github/workflows/auto-approve-docs.yml
+++ b/.github/workflows/auto-approve-docs.yml
@@ -1,6 +1,6 @@
 name: Auto-Approve Docs PRs
 on:
-    pull_request_target:
+    pull_request:
         types: [opened, synchronize, reopened]
         paths:
             - 'docs/**'
@@ -10,12 +10,16 @@ permissions:
 jobs:
     auto-approve:
         runs-on: ubuntu-latest
+        # Only run for trusted authors, blocks external contributors
+        if: >-
+            contains(fromJSON('["OWNER","MEMBER","COLLABORATOR"]'),
+            github.event.pull_request.author_association)
         steps:
             - name: Checkout
               uses: actions/checkout@v4
 
             - name: Check changed paths
-              uses: dorny/paths-filter@v3
+              uses: dorny/paths-filter@v4
               id: filter
               with:
                   predicate-quantifier: 'every'
@@ -23,7 +27,6 @@ jobs:
                       non_docs:
                           - '**'
                           - '!docs/**'
-                          - '!github/**'
 
             - name: Generate GitHub App token
               id: app-token

--- a/.github/workflows/auto-approve-docs.yml
+++ b/.github/workflows/auto-approve-docs.yml
@@ -1,0 +1,40 @@
+name: Auto-Approve Docs PRs
+on:
+    pull_request_target:
+        types: [opened, synchronize, reopened]
+        paths:
+            - 'docs/**'
+permissions:
+    contents: read
+    pull-requests: write
+jobs:
+    auto-approve:
+        runs-on: ubuntu-latest
+        steps:
+            - name: Checkout
+              uses: actions/checkout@v4
+
+            - name: Check changed paths
+              uses: dorny/paths-filter@v3
+              id: filter
+              with:
+                  predicate-quantifier: 'every'
+                  filters: |
+                      non_docs:
+                          - '**'
+                          - '!docs/**'
+
+            - name: Generate GitHub App token
+              id: app-token
+              uses: actions/create-github-app-token@v1
+              with:
+                  app-id: ${{ secrets.GH_APP_PUSHER_ID }}
+                  private-key: ${{ secrets.GH_APP_PUSHER_PRIVATE_KEY }}
+
+            - name: Approve PR
+              if: steps.filter.outputs.non_docs == 'false'
+              uses: hmarr/auto-approve-action@v4
+              with:
+                  github-token: ${{ steps.app-token.outputs.token }}
+                  review-message: |
+                      ✅ Auto-approved: docs-only change.

--- a/.github/workflows/auto-approve-docs.yml
+++ b/.github/workflows/auto-approve-docs.yml
@@ -23,6 +23,7 @@ jobs:
                       non_docs:
                           - '**'
                           - '!docs/**'
+                          - '!github/**'
 
             - name: Generate GitHub App token
               id: app-token

--- a/docs/docs.json
+++ b/docs/docs.json
@@ -1075,7 +1075,8 @@
             "group": "Functions",
             "pages": [
               "reference/cli",
-              "reference/functions"
+              "reference/functions",
+              "reference/TODO"
             ]
           },
           {

--- a/docs/guides/platform/free-self-hosting/configuration.mdx
+++ b/docs/guides/platform/free-self-hosting/configuration.mdx
@@ -4,6 +4,8 @@ sidebarTitle: 'Configuration'
 description: 'Instructions & configuration options for self-hosting Nango.'
 ---
 
+# TODO
+
 ## Free self-hosted vs. Enterprise self-hosted feature availability
 
 | Feature | Free self-hosted | Enterprise self-hosted / Nango Cloud |


### PR DESCRIPTION
testing reviews requirements for docs only PRs

<!-- Summary by @propel-code-bot -->

---

**Add docs-only auto-approval workflow and placeholder docs entries**

This PR adds a GitHub Actions workflow to auto-approve documentation-only pull requests, using `dorny/paths-filter` to ensure only `docs/**` changes and `actions/create-github-app-token` with `hmarr/auto-approve-action` for approvals gated by trusted author association. It also introduces placeholder documentation updates by inserting a `# TODO` heading in the self-hosting configuration guide and adding a `reference/TODO` entry in the docs navigation.

---
*This summary was automatically generated by @propel-code-bot*