### PR TITLE
ci(sanity-sync): add env targeting to sanity providers sync

### DIFF
--- a/.github/workflows/sanity-sync.yaml
+++ b/.github/workflows/sanity-sync.yaml
@@ -10,6 +10,19 @@ on:
             - docs/api-integrations/*.mdx
     workflow_dispatch:
         inputs:
+            environment:
+                type: choice
+                description: 'Docs environment to sync to, defaults to prod-docs'
+                required: true
+                default: 'prod-docs'
+                options:
+                    - prod-docs
+                    - dev-docs
+            dry_run:
+                description: 'Log changes without writing to Sanity'
+                required: false
+                default: 'false'
+                type: boolean
             force_update:
                 description: 'Force update all providers regardless of changes'
                 required: false
@@ -24,6 +37,7 @@ concurrency:
 jobs:
     sanity-sync-job:
         runs-on: ubuntu-latest
+        environment: ${{ inputs.environment || 'prod-docs' }}
         steps:
             - name: Checkout
               uses: actions/checkout@v4
@@ -42,3 +56,4 @@ jobs:
                   SANITY_PROJECT_ID: ${{ vars.SANITY_PROJECT_ID }}
                   SANITY_DATASET: ${{ vars.SANITY_DATASET }}
                   FORCE_UPDATE: ${{ github.event_name == 'schedule' || inputs.force_update == 'true' }}
+                  DRYRUN: ${{ inputs.dry_run == 'true' }}


### PR DESCRIPTION
## Describe the problem and your solution

- add env targeting to sanity providers sync

<!-- Issue ticket number and link (if applicable) -->

<!-- Testing instructions (skip if just adding/editing providers) -->


<!-- Summary by @propel-code-bot -->

---

**Add environment targeting and dry-run input to Sanity sync workflow**

This PR updates the GitHub Actions workflow to allow selecting a docs environment for the Sanity sync and adds a dry-run option for manual dispatches. It also wires the selected environment into the job configuration and passes the dry-run flag to the sync script.

---
*This summary was automatically generated by @propel-code-bot*