### PR TITLE
feat: env settings badge redesign

### DIFF
--- a/packages/webapp/src/components-v2/AppSidebar/EnvironmentDropdown.tsx
+++ b/packages/webapp/src/components-v2/AppSidebar/EnvironmentDropdown.tsx
@@ -99,7 +99,7 @@ export const EnvironmentDropdown: React.FC = () => {
                                                 />
                                                 <span>{environment.name}</span>
                                             </div>
-                                            {environment.is_production && <Badge className="-uppercase">Prod</Badge>}
+                                            {environment.is_production && <Badge>Prod</Badge>}
                                         </DropdownMenuItem>
                                     )}
                                 </PermissionGate>

--- a/packages/webapp/src/components-v2/CodeBlock.tsx
+++ b/packages/webapp/src/components-v2/CodeBlock.tsx
@@ -52,7 +52,7 @@ export const CodeBlock: React.FC<CodeBlockProps> = ({ title, code, language, ico
                 <span className="text-text-tertiary text-s">{title}</span>
                 <div className="flex gap-2 items-center">
                     {displayLanguage && (
-                        <Badge variant="gray">
+                        <Badge variant="gray" className="uppercase">
                             {icon && icon}
                             {displayLanguage}
                         </Badge>

--- a/packages/webapp/src/components-v2/ScopesInput.tsx
+++ b/packages/webapp/src/components-v2/ScopesInput.tsx
@@ -79,7 +79,9 @@ export const ScopesInput: React.FC<ScopesInputProps> = ({ scopesString, onChange
                     {loading ? (
                         <Loader2 className="animate-spin" />
                     ) : isSharedCredentials ? (
-                        <Badge variant="gray">Nango provided</Badge>
+                        <Badge variant="gray" className="uppercase">
+                            Nango provided
+                        </Badge>
                     ) : (
                         !readOnly && (
                             <Button variant="ghost" size="icon" onClick={() => onSubmit()}>

--- a/packages/webapp/src/components-v2/ui/badge.tsx
+++ b/packages/webapp/src/components-v2/ui/badge.tsx
@@ -11,8 +11,9 @@ const badgeVariants = cva(
     {
         variants: {
             variant: {
-                brand: 'bg-bg-accent text-text-brand',
                 gray: 'bg-badge-bg-gray text-badge-fg-gray',
+                secondary: 'bg-bg-subtle text-text-secondary border border-border-muted',
+                brand: 'bg-bg-accent text-text-brand',
                 mint: 'bg-badge-bg-mint text-badge-fg-mint',
                 pink: 'bg-badge-bg-pink text-badge-fg-pink',
                 yellow: 'bg-badge-bg-yellow text-badge-fg-yellow',

--- a/packages/webapp/src/components-v2/ui/badge.tsx
+++ b/packages/webapp/src/components-v2/ui/badge.tsx
@@ -7,7 +7,7 @@ import { cn } from '@/utils/utils';
 import type { VariantProps } from 'class-variance-authority';
 
 const badgeVariants = cva(
-    'inline-flex items-center justify-center uppercase rounded px-2 py-0.5 w-fit whitespace-nowrap shrink-0 [&>svg]:size-3.5 gap-1 [&>svg]:pointer-events-none',
+    'inline-flex items-center justify-center rounded px-2 py-0.5 w-fit whitespace-nowrap shrink-0 [&>svg]:size-3.5 gap-1 [&>svg]:pointer-events-none',
     {
         variants: {
             variant: {

--- a/packages/webapp/src/pages/Connection/components/SyncsTab.tsx
+++ b/packages/webapp/src/pages/Connection/components/SyncsTab.tsx
@@ -155,7 +155,7 @@ const SyncRow = ({ sync, connection, provider }: { sync: SyncResponse; connectio
                             <Tooltip>
                                 <TooltipTrigger>
                                     {/* TODO: Replace badge */}
-                                    <Badge variant="gray" size="xs" className="-uppercase">
+                                    <Badge variant="gray" size="xs">
                                         {truncateMiddle(sync.variant)}
                                     </Badge>
                                 </TooltipTrigger>

--- a/packages/webapp/src/pages/Environment/Settings/Show.tsx
+++ b/packages/webapp/src/pages/Environment/Settings/Show.tsx
@@ -64,7 +64,7 @@ export const EnvironmentSettings: React.FC = () => {
 
             <div className="flex flex-col gap-2.5">
                 <h2 className="text-title-subsection text-text-primary">Environment settings</h2>
-                <div className="flex gap-2 5">
+                <div className="flex gap-2.5">
                     <span className="text-heading-sm text-text-secondary">{env}</span>
                     {isProd && (
                         <Badge variant="secondary" className="text-heading-sm text-text-secondary">

--- a/packages/webapp/src/pages/Environment/Settings/Show.tsx
+++ b/packages/webapp/src/pages/Environment/Settings/Show.tsx
@@ -22,8 +22,7 @@ import type { ReactNode } from 'react';
 const EnvironmentSettingsContent: React.FC<{ value: string; children: ReactNode }> = ({ value, children }) => {
     return (
         <NavigationContent value={value} className="h-fit flex w-full">
-            <div className="flex-1"></div>
-            <div className="max-w-[900px] min-w-[715px] w-full">{children}</div>
+            <div className="w-full">{children}</div>
         </NavigationContent>
     );
 };
@@ -34,6 +33,7 @@ export const EnvironmentSettings: React.FC = () => {
 
     const { data } = useEnvironment(env);
     const environmentAndAccount = data?.environmentAndAccount;
+    const isProd = environmentAndAccount?.environment?.is_production || false;
     const [activeTab, setActiveTab] = useHashNavigation('general');
 
     if (!environmentAndAccount || !team) {
@@ -57,21 +57,25 @@ export const EnvironmentSettings: React.FC = () => {
     const canSeeDeprecatedAuthorization = new Date(team.account.created_at) <= new Date('2025-08-25');
 
     return (
-        <DashboardLayout fullWidth className="flex-col justify-center">
+        <DashboardLayout fullWidth className="flex flex-col gap-8">
             <Helmet>
                 <title>Environment Settings - Nango</title>
             </Helmet>
 
-            <div className="flex mb-8 justify-center">
-                <div className="flex text-left text-3xl tracking-tight text-white w-[1153px] gap-2.5">
-                    <h2 className="font-semibold">Environment Settings</h2>
-                    <Badge size="custom" className="px-3.5 text-title-group">
-                        {env}
-                    </Badge>
+            <div className="flex flex-col gap-2.5">
+                <h2 className="text-title-subsection text-text-primary">Environment settings</h2>
+                <div className="flex gap-2 5">
+                    <span className="text-heading-sm text-text-secondary">{env}</span>
+                    {isProd && (
+                        <Badge variant="secondary" className="text-heading-sm text-text-secondary">
+                            Prod
+                        </Badge>
+                    )}
                 </div>
             </div>
+
             <div className="flex h-fit justify-center" key={env}>
-                <Navigation value={activeTab} onValueChange={setActiveTab} className="max-w-[1153px] mx-auto">
+                <Navigation value={activeTab} onValueChange={setActiveTab}>
                     <NavigationList className="w-[209px]">
                         <NavigationTrigger value="general">General</NavigationTrigger>
                         <NavigationTrigger value="backend">Backend</NavigationTrigger>

--- a/packages/webapp/src/pages/Integrations/Create.tsx
+++ b/packages/webapp/src/pages/Integrations/Create.tsx
@@ -84,9 +84,13 @@ export const CreateIntegration = () => {
                                 <span className="text-text-primary text-body-medium-semi">{provider.displayName}</span>
                             </div>
                             <div className="flex flex-wrap gap-3 gap-y-2">
-                                {provider.authMode !== 'NONE' && <Badge variant="brand">{getDisplayName(provider.authMode)}</Badge>}
+                                {provider.authMode !== 'NONE' && (
+                                    <Badge variant="brand" className="uppercase">
+                                        {getDisplayName(provider.authMode)}
+                                    </Badge>
+                                )}
                                 {provider.categories?.map((category) => (
-                                    <Badge key={category} variant="ghost">
+                                    <Badge key={category} variant="ghost" className="uppercase">
                                         {category}
                                     </Badge>
                                 ))}

--- a/packages/webapp/src/pages/Integrations/CreateList.tsx
+++ b/packages/webapp/src/pages/Integrations/CreateList.tsx
@@ -203,7 +203,7 @@ const Provider = ({
             <div className="inline-flex gap-1.5 items-center justify-end">
                 <AuthBadge authMode={provider.authMode} />
                 {provider.categories?.map((category) => (
-                    <Badge key={category} variant="ghost">
+                    <Badge key={category} variant="ghost" className="uppercase">
                         {category}
                     </Badge>
                 ))}

--- a/packages/webapp/src/pages/Integrations/components/NangoProvidedInput.tsx
+++ b/packages/webapp/src/pages/Integrations/components/NangoProvidedInput.tsx
@@ -6,7 +6,9 @@ export const NangoProvidedInput: React.FC<React.ComponentProps<'input'> & { fake
         <InputGroup>
             <InputGroupInput disabled value={'•'.repeat(fakeValueSize)} {...props} />
             <InputGroupAddon align="inline-end">
-                <Badge variant="gray">Nango provided</Badge>
+                <Badge variant="gray" className="uppercase">
+                    Nango provided
+                </Badge>
             </InputGroupAddon>
         </InputGroup>
     );

--- a/packages/webapp/src/pages/Integrations/providerConfigKey/Functions/Tab.tsx
+++ b/packages/webapp/src/pages/Integrations/providerConfigKey/Functions/Tab.tsx
@@ -141,12 +141,12 @@ const GroupedFunctionsTable: React.FC<{
                                 </TableCell>
                                 <TableCell>
                                     {func.pre_built ? (
-                                        <Badge variant="gray">
+                                        <Badge variant="gray" className="uppercase">
                                             <Box />
                                             Template
                                         </Badge>
                                     ) : (
-                                        <Badge variant="gray">
+                                        <Badge variant="gray" className="uppercase">
                                             <Code /> Custom
                                         </Badge>
                                     )}

--- a/packages/webapp/src/pages/Team/components/TeamMembers.tsx
+++ b/packages/webapp/src/pages/Team/components/TeamMembers.tsx
@@ -218,9 +218,5 @@ export const RoleBadge: React.FC<{ role: Role }> = ({ role }) => {
         }
     }, [role]);
 
-    return (
-        <Badge variant="ghost" className="-uppercase">
-            {roleLabel}
-        </Badge>
-    );
+    return <Badge variant="ghost">{roleLabel}</Badge>;
 };


### PR DESCRIPTION
Updating Environment settings header design and fixing some inconsistencies while at it. Made sizing the same as other screens.

<img width="1511" height="808" alt="image" src="https://github.com/user-attachments/assets/574640ee-3d86-4b33-80b8-a8fc91f0c618" />

<!-- Summary by @propel-code-bot -->

---

It also aligns badge appearance and casing across the webapp, including the production badge display, to match styling on other screens.

---
*This summary was automatically generated by @propel-code-bot*