### PR TITLE
fix: docs only PR should skip code related gh actions

### DIFF
--- a/.github/workflows/build-image.yaml
+++ b/.github/workflows/build-image.yaml
@@ -15,9 +15,10 @@ jobs:
             should_skip: ${{ steps.check.outputs.should_skip }}
         steps:
             - uses: actions/checkout@v4
-            - uses: dorny/paths-filter@v3
+            - uses: dorny/paths-filter@v4
               id: filter
               with:
+                  predicate-quantifier: 'every'
                   filters: |
                       docs_only:
                           - 'docs/**'

--- a/.github/workflows/cli-verification.yaml
+++ b/.github/workflows/cli-verification.yaml
@@ -19,9 +19,10 @@ jobs:
             should_skip: ${{ steps.check.outputs.should_skip }}
         steps:
             - uses: actions/checkout@v4
-            - uses: dorny/paths-filter@v3
+            - uses: dorny/paths-filter@v4
               id: filter
               with:
+                  predicate-quantifier: 'every'
                   filters: |
                       docs_only:
                           - 'docs/**'

--- a/.github/workflows/docker.yaml
+++ b/.github/workflows/docker.yaml
@@ -19,9 +19,10 @@ jobs:
             should_skip: ${{ steps.check.outputs.should_skip }}
         steps:
             - uses: actions/checkout@v4
-            - uses: dorny/paths-filter@v3
+            - uses: dorny/paths-filter@v4
               id: filter
               with:
+                  predicate-quantifier: 'every'
                   filters: |
                       docs_only:
                           - 'docs/**'

--- a/.github/workflows/lint.yaml
+++ b/.github/workflows/lint.yaml
@@ -15,9 +15,10 @@ jobs:
             should_skip: ${{ steps.check.outputs.should_skip }}
         steps:
             - uses: actions/checkout@v4
-            - uses: dorny/paths-filter@v3
+            - uses: dorny/paths-filter@v4
               id: filter
               with:
+                  predicate-quantifier: 'every'
                   filters: |
                       docs_only:
                           - 'docs/**'

--- a/.github/workflows/tests-clients.yaml
+++ b/.github/workflows/tests-clients.yaml
@@ -15,9 +15,10 @@ jobs:
             should_skip: ${{ steps.check.outputs.should_skip }}
         steps:
             - uses: actions/checkout@v4
-            - uses: dorny/paths-filter@v3
+            - uses: dorny/paths-filter@v4
               id: filter
               with:
+                  predicate-quantifier: 'every'
                   filters: |
                       docs_only:
                           - 'docs/**'

--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -19,9 +19,10 @@ jobs:
             should_skip: ${{ steps.check.outputs.should_skip }}
         steps:
             - uses: actions/checkout@v4
-            - uses: dorny/paths-filter@v3
+            - uses: dorny/paths-filter@v4
               id: filter
               with:
+                  predicate-quantifier: 'every'
                   filters: |
                       docs_only:
                           - 'docs/**'

--- a/.github/workflows/validation.yaml
+++ b/.github/workflows/validation.yaml
@@ -19,9 +19,10 @@ jobs:
             should_skip: ${{ steps.check.outputs.should_skip }}
         steps:
             - uses: actions/checkout@v4
-            - uses: dorny/paths-filter@v3
+            - uses: dorny/paths-filter@v4
               id: filter
               with:
+                  predicate-quantifier: 'some'
                   filters: |
                       docs:
                           - 'docs/**'


### PR DESCRIPTION
looks like the behavior of the `paths-filter` actions has changed when specifying more than one path. Bumping to v4 with explicit `predicate-quantifier: 'every'` to bring back the expected behavior and skip code related actions when PR is only modifying docs


<!-- Summary by @propel-code-bot -->

---

This update applies the filter-semantics fix consistently across CI workflows, while preserving expected execution behavior for non-PR contexts such as `merge_group` and direct pushes to `master`. It also distinguishes docs detection logic where needed so documentation-triggered validation behavior remains correct, not just docs-only skipping for code workflows.

---
*This summary was automatically generated by @propel-code-bot*