### PR TITLE
docs: rename function builder skill references

### DIFF
--- a/docs/implementation-guides/platform/functions/leverage-ai-agents.mdx
+++ b/docs/implementation-guides/platform/functions/leverage-ai-agents.mdx
@@ -28,7 +28,7 @@ Install Nango's skill pack into your development environment:
 npx skills add NangoHQ/skills
 ```
 
-This adds `nango-function-builder`, which includes guidance for building both [Actions](/implementation-guides/use-cases/actions/implement-an-action) and [Syncs](/implementation-guides/use-cases/syncs/implement-a-sync).
+This adds `building-nango-functions-locally`, which includes guidance for building both [Actions](/implementation-guides/use-cases/actions/implement-an-action) and [Syncs](/implementation-guides/use-cases/syncs/implement-a-sync).
 
 <Note>
 If your coding agent is already running, restart it after installing the skill so it can load the new instructions.
@@ -36,7 +36,7 @@ If your coding agent is already running, restart it after installing the skill s
 
 ## Use it with your coding agent
 
-The `nango-function-builder` skill is loaded automatically when using popular coding agents/tools (Claude Code, Cursor, Gemini CLI, Codex CLI, VS Code with Copilot, Opencode, and more).
+The `building-nango-functions-locally` skill is loaded automatically when using popular coding agents/tools (Claude Code, Cursor, Gemini CLI, Codex CLI, VS Code with Copilot, Opencode, and more).
 
 Tell your agent what you want to build. You can start with a simple prompt to build an [Action](/implementation-guides/use-cases/actions/implement-an-action):
 


### PR DESCRIPTION
<!-- Describe the problem and your solution -->
Updates the Function AI Builder docs to reference `building-nango-functions-locally` instead of `nango-function-builder`, so the page matches the current skill name.

<!-- Issue ticket number and link (if applicable) -->

<!-- Testing instructions (skip if just adding/editing providers) -->
Not run; docs-only change.
