### PR TITLE
fix(sanity-sync): fix envs vars always evaluating to true

### DIFF
--- a/scripts/sanity-api-sync.ts
+++ b/scripts/sanity-api-sync.ts
@@ -30,8 +30,8 @@ if (!process.env['SANITY_DATASET']) {
     throw new Error('Missing SANITY_DATASET');
 }
 
-const dryRun = !!process.env['DRYRUN'];
-const forceUpdate = !!process.env['FORCE_UPDATE'];
+const dryRun = process.env['DRYRUN'] === 'true';
+const forceUpdate = process.env['FORCE_UPDATE'] === 'true';
 const projectId = process.env['SANITY_PROJECT_ID'];
 const dataset = process.env['SANITY_DATASET'];
 const token = process.env['SANITY_TOKEN'];


### PR DESCRIPTION
<!-- Describe the problem and your solution --> 

- The !! coercion treated the string `false` (set by GitHub Actions when toggles are off) as true, making the workflow_dispatch inputs have no effect.

<!-- Issue ticket number and link (if applicable) -->

<!-- Testing instructions (skip if just adding/editing providers) -->


<!-- Summary by @propel-code-bot -->

---

This PR updates boolean flag parsing in `scripts/sanity-api-sync.ts` so runtime behavior matches GitHub Actions string-based inputs, ensuring the `DRYRUN` and `FORCE_UPDATE` toggles only enable when explicitly set to `'true'`.

---
*This summary was automatically generated by @propel-code-bot*