### PR TITLE
fix(proxy): add deny list for base url override in proxy

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -40,6 +40,8 @@ WORKER_PORT=3004
 # - Configure server full URL (current value is the default for running Nango locally).
 #
 NANGO_SERVER_URL=http://localhost:3003
+# JSON array of hostnames or URLs; blocks matching Base-Url-Override targets (SSRF hardening). Restart the server after changing this value.
+# NANGO_PROXY_BASE_URL_OVERRIDE_DENYLIST='["169.254.169.254","metadata.google.internal","localhost"]'
 NANGO_PUBLIC_SERVER_URL=http://localhost:3000
 CSP_REPORT_ONLY=false
 # FLAG_AUTH_ENABLED=false

--- a/packages/server/lib/controllers/proxy/allProxy.integration.test.ts
+++ b/packages/server/lib/controllers/proxy/allProxy.integration.test.ts
@@ -1,8 +1,7 @@
-import { afterAll, afterEach, beforeAll, beforeEach, describe, expect, it } from 'vitest';
+import { afterAll, beforeAll, describe, expect, it } from 'vitest';
 
 import { seeders } from '@nangohq/shared';
 
-import { envs } from '../../env.js';
 import { isError, isSuccess, runServer, shouldBeProtected } from '../../utils/tests.js';
 
 const route = '/proxy/:anyPath';
@@ -102,46 +101,5 @@ describe(`GET ${route}`, () => {
         });
 
         isSuccess(res.json);
-    });
-
-    describe('base-url-override denylist', () => {
-        let previousDenylist: string[];
-
-        beforeAll(() => {
-            previousDenylist = [...envs.NANGO_PROXY_BASE_URL_OVERRIDE_DENYLIST];
-        });
-
-        beforeEach(() => {
-            envs.NANGO_PROXY_BASE_URL_OVERRIDE_DENYLIST = ['169.254.169.254'];
-        });
-
-        afterEach(() => {
-            envs.NANGO_PROXY_BASE_URL_OVERRIDE_DENYLIST = [...previousDenylist];
-        });
-
-        it('should reject a denied base-url-override', async () => {
-            const { env, secret } = await seeders.seedAccountEnvAndUser();
-            const integration = await seeders.createConfigSeed(env, 'github', 'github');
-            const connection = await seeders.createConnectionSeed({ env, config_id: integration.id!, provider: 'github' });
-            const res = await api.fetch(route, {
-                method: 'GET',
-                token: secret.secret,
-                params: { anyPath: 'latest/meta-data/' },
-                headers: {
-                    'connection-id': connection.connection_id,
-                    'provider-config-key': integration.unique_key,
-                    'base-url-override': 'http://169.254.169.254'
-                }
-            });
-
-            expect(res.res.status).toBe(400);
-            isError(res.json);
-            expect(res.json).toStrictEqual({
-                error: {
-                    code: 'base_url_override_not_allowed',
-                    message: 'This base URL override is not allowed by server configuration.'
-                }
-            });
-        });
     });
 });

--- a/packages/server/lib/controllers/proxy/allProxy.integration.test.ts
+++ b/packages/server/lib/controllers/proxy/allProxy.integration.test.ts
@@ -1,7 +1,8 @@
-import { afterAll, beforeAll, describe, expect, it } from 'vitest';
+import { afterAll, afterEach, beforeAll, beforeEach, describe, expect, it } from 'vitest';
 
 import { seeders } from '@nangohq/shared';
 
+import { envs } from '../../env.js';
 import { isError, isSuccess, runServer, shouldBeProtected } from '../../utils/tests.js';
 
 const route = '/proxy/:anyPath';
@@ -101,5 +102,46 @@ describe(`GET ${route}`, () => {
         });
 
         isSuccess(res.json);
+    });
+
+    describe('base-url-override denylist', () => {
+        let previousDenylist: string[];
+
+        beforeAll(() => {
+            previousDenylist = [...envs.NANGO_PROXY_BASE_URL_OVERRIDE_DENYLIST];
+        });
+
+        beforeEach(() => {
+            envs.NANGO_PROXY_BASE_URL_OVERRIDE_DENYLIST = ['169.254.169.254'];
+        });
+
+        afterEach(() => {
+            envs.NANGO_PROXY_BASE_URL_OVERRIDE_DENYLIST = [...previousDenylist];
+        });
+
+        it('should reject a denied base-url-override', async () => {
+            const { env, secret } = await seeders.seedAccountEnvAndUser();
+            const integration = await seeders.createConfigSeed(env, 'github', 'github');
+            const connection = await seeders.createConnectionSeed({ env, config_id: integration.id!, provider: 'github' });
+            const res = await api.fetch(route, {
+                method: 'GET',
+                token: secret.secret,
+                params: { anyPath: 'latest/meta-data/' },
+                headers: {
+                    'connection-id': connection.connection_id,
+                    'provider-config-key': integration.unique_key,
+                    'base-url-override': 'http://169.254.169.254'
+                }
+            });
+
+            expect(res.res.status).toBe(400);
+            isError(res.json);
+            expect(res.json).toStrictEqual({
+                error: {
+                    code: 'base_url_override_not_allowed',
+                    message: 'This base URL override is not allowed by server configuration.'
+                }
+            });
+        });
     });
 });

--- a/packages/server/lib/controllers/proxy/allProxy.integration.test.ts
+++ b/packages/server/lib/controllers/proxy/allProxy.integration.test.ts
@@ -78,6 +78,31 @@ describe(`GET ${route}`, () => {
         });
     });
 
+    it('should return 400 base_url_override_not_allowed when base-url-override host is denylisted', async () => {
+        const { env, secret } = await seeders.seedAccountEnvAndUser();
+        const integration = await seeders.createConfigSeed(env, 'github', 'github');
+        const connection = await seeders.createConnectionSeed({ env, config_id: integration.id!, provider: 'github' });
+        const res = await api.fetch(route, {
+            method: 'GET',
+            token: secret.secret,
+            params: { anyPath: 'users/octocat' },
+            headers: {
+                'connection-id': connection.connection_id,
+                'provider-config-key': integration.unique_key,
+                'base-url-override': 'https://denylisted-proxy-test.invalid'
+            }
+        });
+
+        isError(res.json);
+        expect(res.res.status).toBe(400);
+        expect(res.json).toStrictEqual({
+            error: {
+                code: 'base_url_override_not_allowed',
+                message: 'This base URL override is not allowed by server configuration.'
+            }
+        });
+    });
+
     it('should use all the headers', async () => {
         const { env, secret } = await seeders.seedAccountEnvAndUser();
         const integration = await seeders.createConfigSeed(env, 'github', 'github');

--- a/packages/server/lib/controllers/proxy/allProxy.ts
+++ b/packages/server/lib/controllers/proxy/allProxy.ts
@@ -39,7 +39,6 @@ const MEMOIZED_CONNECTION_TTL = 60000;
 
 const logger = getLogger('Proxy.Controller');
 
-/** Parsed once at module load; `envs` comes from `process.env` at process start (restart to change denylist). */
 const baseUrlOverrideDenylist = normalizeDenylist(envs.NANGO_PROXY_BASE_URL_OVERRIDE_DENYLIST);
 
 const schemaHeaders = z.object({
@@ -66,8 +65,23 @@ export const allPublicProxy = asyncWrapper<AllPublicProxy>(async (req, res, next
         return;
     }
     const parsedHeaders = valHeaders.data satisfies AllPublicProxy['Headers'];
+    const { environment, account, plan } = res.locals;
+
     const baseUrlOverride = parsedHeaders['base-url-override'];
     if (baseUrlOverride && isBaseUrlOverrideDenied(baseUrlOverride, baseUrlOverrideDenylist)) {
+        metrics.increment(metrics.Types.PROXY_BASE_URL_OVERRIDE_DENIED, 1, { accountId: account.id });
+        let overrideHostForLog: string;
+        try {
+            overrideHostForLog = new URL(baseUrlOverride).hostname;
+        } catch {
+            overrideHostForLog = 'unparseable';
+        }
+        logger.warn('Proxy base-url-override denied by denylist', {
+            accountId: account.id,
+            providerConfigKey: parsedHeaders['provider-config-key'],
+            connectionId: parsedHeaders['connection-id'],
+            overrideHost: overrideHostForLog
+        });
         res.status(400).send({
             error: {
                 code: 'base_url_override_not_allowed',
@@ -76,8 +90,6 @@ export const allPublicProxy = asyncWrapper<AllPublicProxy>(async (req, res, next
         });
         return;
     }
-
-    const { environment, account, plan } = res.locals;
 
     metrics.increment(metrics.Types.PROXY_INCOMING_PAYLOAD_SIZE_BYTES, req.rawBody ? Buffer.byteLength(req.rawBody) : 0, { accountId: account.id });
 

--- a/packages/server/lib/controllers/proxy/allProxy.ts
+++ b/packages/server/lib/controllers/proxy/allProxy.ts
@@ -17,7 +17,7 @@ import {
 } from '@nangohq/shared';
 import { getHeaders, getLogger, metrics, redactHeaders, zodErrorToHTTP } from '@nangohq/utils';
 
-import { isBaseUrlOverrideDenied } from './baseUrlOverrideDenylist.js';
+import { isBaseUrlOverrideDenied, normalizeDenylist } from './baseUrlOverrideDenylist.js';
 import { envs } from '../../env.js';
 import { connectionIdSchema, providerConfigKeySchema } from '../../helpers/validation.js';
 import { connectionRefreshFailed, connectionRefreshSuccess } from '../../hooks/hooks.js';
@@ -38,6 +38,8 @@ type ForwardedHeaders = Record<string, string>;
 const MEMOIZED_CONNECTION_TTL = 60000;
 
 const logger = getLogger('Proxy.Controller');
+
+const baseUrlOverrideDenylist = normalizeDenylist(envs.NANGO_PROXY_BASE_URL_OVERRIDE_DENYLIST);
 
 const schemaHeaders = z.object({
     'provider-config-key': providerConfigKeySchema,
@@ -64,7 +66,7 @@ export const allPublicProxy = asyncWrapper<AllPublicProxy>(async (req, res, next
     }
     const parsedHeaders = valHeaders.data satisfies AllPublicProxy['Headers'];
     const baseUrlOverride = parsedHeaders['base-url-override'];
-    if (baseUrlOverride && isBaseUrlOverrideDenied(baseUrlOverride, envs.NANGO_PROXY_BASE_URL_OVERRIDE_DENYLIST)) {
+    if (baseUrlOverride && isBaseUrlOverrideDenied(baseUrlOverride, baseUrlOverrideDenylist)) {
         res.status(400).send({
             error: {
                 code: 'base_url_override_not_allowed',

--- a/packages/server/lib/controllers/proxy/allProxy.ts
+++ b/packages/server/lib/controllers/proxy/allProxy.ts
@@ -218,7 +218,29 @@ export const allPublicProxy = asyncWrapper<AllPublicProxy>(async (req, res, next
                     method,
                     retryOn,
                     responseType: 'stream',
-                    forwardHeadersOnRedirect
+                    forwardHeadersOnRedirect,
+                    ...(baseUrlOverrideDenylist.size > 0
+                        ? {
+                              validateProxyRedirectUrl: (absoluteUrl: string) => {
+                                  if (isBaseUrlOverrideDenied(absoluteUrl, baseUrlOverrideDenylist)) {
+                                      metrics.increment(metrics.Types.PROXY_BASE_URL_OVERRIDE_DENIED, 1, { accountId: account.id });
+                                      let redirectHostForLog: string;
+                                      try {
+                                          redirectHostForLog = new URL(absoluteUrl).hostname;
+                                      } catch {
+                                          redirectHostForLog = 'unparseable';
+                                      }
+                                      logger.warn('Proxy redirect to denylisted host blocked', {
+                                          accountId: account.id,
+                                          providerConfigKey: parsedHeaders['provider-config-key'],
+                                          connectionId: parsedHeaders['connection-id'],
+                                          redirectHost: redirectHostForLog
+                                      });
+                                      throw new ProxyError('proxy_redirect_to_denied_host', 'This redirect target is not allowed by server configuration.');
+                                  }
+                              }
+                          }
+                        : {})
                 },
                 internalConfig
             }).unwrap(),
@@ -397,6 +419,23 @@ export async function handleResponse({ res, responseStream, logCtx }: { res: Res
     });
 }
 
+function proxyErrorFromErrorChain(error: unknown): ProxyError | null {
+    let current: unknown = error;
+    const seen = new Set<unknown>();
+    while (current && typeof current === 'object' && !seen.has(current)) {
+        seen.add(current);
+        if (current instanceof ProxyError) {
+            return current;
+        }
+        if ('cause' in current && (current as { cause?: unknown }).cause !== undefined) {
+            current = (current as { cause: unknown }).cause;
+        } else {
+            break;
+        }
+    }
+    return null;
+}
+
 export function handleErrorResponse({
     res,
     error,
@@ -408,6 +447,18 @@ export function handleErrorResponse({
     requestConfig?: AxiosRequestConfig | undefined;
     logCtx: LogContext;
 }) {
+    const proxyErr = proxyErrorFromErrorChain(error);
+    if (proxyErr?.code === 'proxy_redirect_to_denied_host') {
+        void logCtx.error('Proxy redirect denied by denylist', { error: proxyErr });
+        res.status(400).send({
+            error: {
+                code: 'base_url_override_not_allowed',
+                message: 'This base URL override is not allowed by server configuration.'
+            }
+        });
+        return;
+    }
+
     if (!isAxiosError(error)) {
         if (error instanceof ProxyError) {
             void logCtx.error('Unknown error', { error });

--- a/packages/server/lib/controllers/proxy/allProxy.ts
+++ b/packages/server/lib/controllers/proxy/allProxy.ts
@@ -17,6 +17,8 @@ import {
 } from '@nangohq/shared';
 import { getHeaders, getLogger, metrics, redactHeaders, zodErrorToHTTP } from '@nangohq/utils';
 
+import { isBaseUrlOverrideDenied } from './baseUrlOverrideDenylist.js';
+import { envs } from '../../env.js';
 import { connectionIdSchema, providerConfigKeySchema } from '../../helpers/validation.js';
 import { connectionRefreshFailed, connectionRefreshSuccess } from '../../hooks/hooks.js';
 import { pubsub } from '../../pubsub.js';
@@ -60,17 +62,27 @@ export const allPublicProxy = asyncWrapper<AllPublicProxy>(async (req, res, next
         res.status(400).send({ error: { code: 'invalid_headers', errors: zodErrorToHTTP(valHeaders.error) } });
         return;
     }
+    const parsedHeaders = valHeaders.data satisfies AllPublicProxy['Headers'];
+    const baseUrlOverride = parsedHeaders['base-url-override'];
+    if (baseUrlOverride && isBaseUrlOverrideDenied(baseUrlOverride, envs.NANGO_PROXY_BASE_URL_OVERRIDE_DENYLIST)) {
+        res.status(400).send({
+            error: {
+                code: 'base_url_override_not_allowed',
+                message: 'This base URL override is not allowed by server configuration.'
+            }
+        });
+        return;
+    }
+
     const { environment, account, plan } = res.locals;
 
     metrics.increment(metrics.Types.PROXY_INCOMING_PAYLOAD_SIZE_BYTES, req.rawBody ? Buffer.byteLength(req.rawBody) : 0, { accountId: account.id });
 
     let logCtx: LogContext | undefined;
-    const parsedHeaders = valHeaders.data satisfies AllPublicProxy['Headers'];
 
     const connectionId = parsedHeaders['connection-id'];
     const providerConfigKey = parsedHeaders['provider-config-key'];
     const retries = parsedHeaders['retries'];
-    const baseUrlOverride = parsedHeaders['base-url-override'];
     const decompress = parsedHeaders['decompress'] === 'true';
     const retryOn = parsedHeaders['retry-on'] ? parsedHeaders['retry-on'].split(',').map(Number) : null;
     const forwardHeadersOnRedirect = parsedHeaders['forward-headers-on-redirect'] === 'true';

--- a/packages/server/lib/controllers/proxy/allProxy.ts
+++ b/packages/server/lib/controllers/proxy/allProxy.ts
@@ -69,19 +69,6 @@ export const allPublicProxy = asyncWrapper<AllPublicProxy>(async (req, res, next
 
     const baseUrlOverride = parsedHeaders['base-url-override'];
     if (baseUrlOverride && isBaseUrlOverrideDenied(baseUrlOverride, baseUrlOverrideDenylist)) {
-        metrics.increment(metrics.Types.PROXY_BASE_URL_OVERRIDE_DENIED, 1, { accountId: account.id });
-        let overrideHostForLog: string;
-        try {
-            overrideHostForLog = new URL(baseUrlOverride).hostname;
-        } catch {
-            overrideHostForLog = 'unparseable';
-        }
-        logger.warn('Proxy base-url-override denied by denylist', {
-            accountId: account.id,
-            providerConfigKey: parsedHeaders['provider-config-key'],
-            connectionId: parsedHeaders['connection-id'],
-            overrideHost: overrideHostForLog
-        });
         res.status(400).send({
             error: {
                 code: 'base_url_override_not_allowed',

--- a/packages/server/lib/controllers/proxy/allProxy.ts
+++ b/packages/server/lib/controllers/proxy/allProxy.ts
@@ -39,6 +39,7 @@ const MEMOIZED_CONNECTION_TTL = 60000;
 
 const logger = getLogger('Proxy.Controller');
 
+/** Parsed once at module load; `envs` comes from `process.env` at process start (restart to change denylist). */
 const baseUrlOverrideDenylist = normalizeDenylist(envs.NANGO_PROXY_BASE_URL_OVERRIDE_DENYLIST);
 
 const schemaHeaders = z.object({

--- a/packages/server/lib/controllers/proxy/allProxy.unit.test.ts
+++ b/packages/server/lib/controllers/proxy/allProxy.unit.test.ts
@@ -211,6 +211,28 @@ describe('handleErrorResponse', () => {
         expect(mockLogCtx.error).toHaveBeenCalledWith('Unknown error', { error: err });
     });
 
+    it('should return 400 base_url_override_not_allowed when error chain contains proxy_redirect_to_denied_host', () => {
+        const res = {
+            status: vi.fn().mockReturnThis(),
+            send: vi.fn(),
+            set: vi.fn().mockReturnThis(),
+            writeHead: vi.fn()
+        } as unknown as Response;
+        const err = new Error('Axios redirect aborted');
+        err.cause = new ProxyError('proxy_redirect_to_denied_host', 'blocked');
+
+        handleErrorResponse({ res, error: err, logCtx: mockLogCtx });
+
+        expect(res.status).toHaveBeenCalledWith(400);
+        expect(res.send).toHaveBeenCalledWith({
+            error: {
+                code: 'base_url_override_not_allowed',
+                message: 'This base URL override is not allowed by server configuration.'
+            }
+        });
+        expect(mockLogCtx.error).toHaveBeenCalledWith('Proxy redirect denied by denylist', { error: err.cause });
+    });
+
     it('should return upstream status and send errorObject when Axios error has no response.data', () => {
         const res = {
             status: vi.fn().mockReturnThis(),

--- a/packages/server/lib/controllers/proxy/baseUrlOverrideDenylist.ts
+++ b/packages/server/lib/controllers/proxy/baseUrlOverrideDenylist.ts
@@ -48,11 +48,15 @@ export function normalizeDenylist(denylist: string[]): string[] {
 }
 
 export function isBaseUrlOverrideDenied(overrideUrl: string, denylist: string[]): boolean {
+    if (denylist.length === 0) {
+        return false;
+    }
     let hostname: string;
     try {
         hostname = canonicalizeHostnameForDenylist(new URL(overrideUrl).hostname);
     } catch {
-        return false;
+        // Fail closed when a denylist is configured but the override URL cannot be parsed (defense in depth vs. z.url()).
+        return true;
     }
     return denylist.includes(hostname);
 }

--- a/packages/server/lib/controllers/proxy/baseUrlOverrideDenylist.ts
+++ b/packages/server/lib/controllers/proxy/baseUrlOverrideDenylist.ts
@@ -37,6 +37,5 @@ export function isBaseUrlOverrideDenied(overrideUrl: string, denylist: string[])
     } catch {
         return false;
     }
-    const denied = normalizeDenylist(denylist);
-    return denied.includes(hostname);
+    return denylist.includes(hostname);
 }

--- a/packages/server/lib/controllers/proxy/baseUrlOverrideDenylist.ts
+++ b/packages/server/lib/controllers/proxy/baseUrlOverrideDenylist.ts
@@ -34,21 +34,12 @@ export function normalizeDenylistHost(entry: string): string {
     return canonicalizeHostnameForDenylist(host);
 }
 
-export function normalizeDenylist(denylist: string[]): string[] {
-    const out: string[] = [];
-    const seen = new Set<string>();
-    for (const e of denylist) {
-        const h = normalizeDenylistHost(e);
-        if (h && !seen.has(h)) {
-            seen.add(h);
-            out.push(h);
-        }
-    }
-    return out;
+export function normalizeDenylist(denylist: string[]): Set<string> {
+    return new Set(denylist.map(normalizeDenylistHost).filter(Boolean));
 }
 
-export function isBaseUrlOverrideDenied(overrideUrl: string, denylist: string[]): boolean {
-    if (denylist.length === 0) {
+export function isBaseUrlOverrideDenied(overrideUrl: string, denylist: Set<string>): boolean {
+    if (denylist.size === 0) {
         return false;
     }
     let hostname: string;
@@ -58,5 +49,5 @@ export function isBaseUrlOverrideDenied(overrideUrl: string, denylist: string[])
         // Fail closed when a denylist is configured but the override URL cannot be parsed (defense in depth vs. z.url()).
         return true;
     }
-    return denylist.includes(hostname);
+    return denylist.has(hostname);
 }

--- a/packages/server/lib/controllers/proxy/baseUrlOverrideDenylist.ts
+++ b/packages/server/lib/controllers/proxy/baseUrlOverrideDenylist.ts
@@ -1,5 +1,11 @@
 /**
  * Hostname form used for denylist matching: lowercase, no bracketed IPv6 wrapper, no trailing FQDN dot.
+ *
+ * Note: {@link https://url.spec.whatwg.org/ WHATWG URL} already normalizes IPv4 hostnames to dotted
+ * decimal (`127.0.0.1`) for octal, hexadecimal, and 32-bit integer spellings. That applies to
+ * `new URL(overrideUrl).hostname` in {@link isBaseUrlOverrideDenied}. Bare denylist entries are
+ * passed through `new URL('http://…')` in {@link normalizeDenylistHost} so they use the same IPv4
+ * rules. IPv6 literals must be bracketed when using bare form (`[::1]`), matching URL parsing.
  */
 export function canonicalizeHostnameForDenylist(host: string): string {
     let h = host.trim().toLowerCase();
@@ -14,7 +20,8 @@ export function canonicalizeHostnameForDenylist(host: string): string {
 
 /**
  * Normalize a denylist entry to a lowercase hostname for comparison.
- * Accepts bare hostnames/IPs or full URLs (uses URL.hostname when `://` is present).
+ * Accepts full URLs (`://` present), or bare hostnames / `host:port` / IPv4 literals — bare forms are
+ * parsed with `new URL('http://…')` so IPv4 uses the same normalization as {@link isBaseUrlOverrideDenied}.
  */
 export function normalizeDenylistHost(entry: string): string {
     const trimmed = entry.trim();
@@ -29,7 +36,11 @@ export function normalizeDenylistHost(entry: string): string {
             host = trimmed;
         }
     } else {
-        host = trimmed;
+        try {
+            host = new URL(`http://${trimmed}`).hostname;
+        } catch {
+            host = trimmed;
+        }
     }
     return canonicalizeHostnameForDenylist(host);
 }

--- a/packages/server/lib/controllers/proxy/baseUrlOverrideDenylist.ts
+++ b/packages/server/lib/controllers/proxy/baseUrlOverrideDenylist.ts
@@ -45,7 +45,10 @@ export function normalizeDenylistHost(entry: string): string {
     return canonicalizeHostnameForDenylist(host);
 }
 
-export function normalizeDenylist(denylist: string[]): Set<string> {
+export function normalizeDenylist(denylist: string[] | undefined): Set<string> {
+    if (!denylist?.length) {
+        return new Set();
+    }
     return new Set(denylist.map(normalizeDenylistHost).filter(Boolean));
 }
 

--- a/packages/server/lib/controllers/proxy/baseUrlOverrideDenylist.ts
+++ b/packages/server/lib/controllers/proxy/baseUrlOverrideDenylist.ts
@@ -1,4 +1,18 @@
 /**
+ * Hostname form used for denylist matching: lowercase, no bracketed IPv6 wrapper, no trailing FQDN dot.
+ */
+export function canonicalizeHostnameForDenylist(host: string): string {
+    let h = host.trim().toLowerCase();
+    if (h.startsWith('[') && h.endsWith(']')) {
+        h = h.slice(1, -1);
+    }
+    while (h.endsWith('.')) {
+        h = h.slice(0, -1);
+    }
+    return h;
+}
+
+/**
  * Normalize a denylist entry to a lowercase hostname for comparison.
  * Accepts bare hostnames/IPs or full URLs (uses URL.hostname when `://` is present).
  */
@@ -7,14 +21,17 @@ export function normalizeDenylistHost(entry: string): string {
     if (!trimmed) {
         return '';
     }
+    let host: string;
     if (trimmed.includes('://')) {
         try {
-            return new URL(trimmed).hostname.toLowerCase();
+            host = new URL(trimmed).hostname;
         } catch {
-            return trimmed.toLowerCase();
+            host = trimmed;
         }
+    } else {
+        host = trimmed;
     }
-    return trimmed.toLowerCase();
+    return canonicalizeHostnameForDenylist(host);
 }
 
 export function normalizeDenylist(denylist: string[]): string[] {
@@ -33,7 +50,7 @@ export function normalizeDenylist(denylist: string[]): string[] {
 export function isBaseUrlOverrideDenied(overrideUrl: string, denylist: string[]): boolean {
     let hostname: string;
     try {
-        hostname = new URL(overrideUrl).hostname.toLowerCase();
+        hostname = canonicalizeHostnameForDenylist(new URL(overrideUrl).hostname);
     } catch {
         return false;
     }

--- a/packages/server/lib/controllers/proxy/baseUrlOverrideDenylist.ts
+++ b/packages/server/lib/controllers/proxy/baseUrlOverrideDenylist.ts
@@ -1,0 +1,42 @@
+/**
+ * Normalize a denylist entry to a lowercase hostname for comparison.
+ * Accepts bare hostnames/IPs or full URLs (uses URL.hostname when `://` is present).
+ */
+export function normalizeDenylistHost(entry: string): string {
+    const trimmed = entry.trim();
+    if (!trimmed) {
+        return '';
+    }
+    if (trimmed.includes('://')) {
+        try {
+            return new URL(trimmed).hostname.toLowerCase();
+        } catch {
+            return trimmed.toLowerCase();
+        }
+    }
+    return trimmed.toLowerCase();
+}
+
+export function normalizeDenylist(denylist: string[]): string[] {
+    const out: string[] = [];
+    const seen = new Set<string>();
+    for (const e of denylist) {
+        const h = normalizeDenylistHost(e);
+        if (h && !seen.has(h)) {
+            seen.add(h);
+            out.push(h);
+        }
+    }
+    return out;
+}
+
+export function isBaseUrlOverrideDenied(overrideUrl: string, denylist: string[]): boolean {
+    let hostname: string;
+    try {
+        hostname = new URL(overrideUrl).hostname.toLowerCase();
+    } catch {
+        return false;
+    }
+    const denied = normalizeDenylist(denylist);
+    return denied.includes(hostname);
+}

--- a/packages/server/lib/controllers/proxy/baseUrlOverrideDenylist.unit.test.ts
+++ b/packages/server/lib/controllers/proxy/baseUrlOverrideDenylist.unit.test.ts
@@ -31,10 +31,6 @@ describe('isBaseUrlOverrideDenied', () => {
         expect(isBaseUrlOverrideDenied('http://169.254.169.254/foo', ['169.254.169.254'])).toBe(true);
     });
 
-    it('matches URL-form deny entry', () => {
-        expect(isBaseUrlOverrideDenied('http://169.254.169.254/', ['http://169.254.169.254'])).toBe(true);
-    });
-
     it('returns false when host not listed', () => {
         expect(isBaseUrlOverrideDenied('https://api.github.com', ['169.254.169.254'])).toBe(false);
     });

--- a/packages/server/lib/controllers/proxy/baseUrlOverrideDenylist.unit.test.ts
+++ b/packages/server/lib/controllers/proxy/baseUrlOverrideDenylist.unit.test.ts
@@ -44,6 +44,11 @@ describe('normalizeDenylist', () => {
     it('dedupes', () => {
         expect(normalizeDenylist(['localhost', 'LOCALHOST', 'http://localhost/'])).toEqual(new Set(['localhost']));
     });
+
+    it('returns empty set when input is undefined or empty', () => {
+        expect(normalizeDenylist(undefined)).toEqual(new Set());
+        expect(normalizeDenylist([])).toEqual(new Set());
+    });
 });
 
 describe('isBaseUrlOverrideDenied', () => {

--- a/packages/server/lib/controllers/proxy/baseUrlOverrideDenylist.unit.test.ts
+++ b/packages/server/lib/controllers/proxy/baseUrlOverrideDenylist.unit.test.ts
@@ -70,4 +70,8 @@ describe('isBaseUrlOverrideDenied', () => {
         const list = normalizeDenylist(['http://[::1]/']);
         expect(isBaseUrlOverrideDenied('http://[::1]/path', list)).toBe(true);
     });
+
+    it('fails closed when URL cannot be parsed and denylist is non-empty', () => {
+        expect(isBaseUrlOverrideDenied('http://', ['localhost'])).toBe(true);
+    });
 });

--- a/packages/server/lib/controllers/proxy/baseUrlOverrideDenylist.unit.test.ts
+++ b/packages/server/lib/controllers/proxy/baseUrlOverrideDenylist.unit.test.ts
@@ -36,25 +36,25 @@ describe('normalizeDenylistHost', () => {
 
 describe('normalizeDenylist', () => {
     it('dedupes', () => {
-        expect(normalizeDenylist(['localhost', 'LOCALHOST', 'http://localhost/'])).toEqual(['localhost']);
+        expect(normalizeDenylist(['localhost', 'LOCALHOST', 'http://localhost/'])).toEqual(new Set(['localhost']));
     });
 });
 
 describe('isBaseUrlOverrideDenied', () => {
     it('returns false when denylist empty', () => {
-        expect(isBaseUrlOverrideDenied('http://169.254.169.254/', [])).toBe(false);
+        expect(isBaseUrlOverrideDenied('http://169.254.169.254/', new Set())).toBe(false);
     });
 
     it('returns true on exact hostname match', () => {
-        expect(isBaseUrlOverrideDenied('http://169.254.169.254/foo', ['169.254.169.254'])).toBe(true);
+        expect(isBaseUrlOverrideDenied('http://169.254.169.254/foo', new Set(['169.254.169.254']))).toBe(true);
     });
 
     it('returns false when host not listed', () => {
-        expect(isBaseUrlOverrideDenied('https://api.github.com', ['169.254.169.254'])).toBe(false);
+        expect(isBaseUrlOverrideDenied('https://api.github.com', new Set(['169.254.169.254']))).toBe(false);
     });
 
     it('is case-insensitive', () => {
-        expect(isBaseUrlOverrideDenied('http://LOCALHOST:8080/', ['localhost'])).toBe(true);
+        expect(isBaseUrlOverrideDenied('http://LOCALHOST:8080/', new Set(['localhost']))).toBe(true);
     });
 
     it('matches when override uses trailing-dot hostname and denylist lists bare host', () => {
@@ -72,6 +72,6 @@ describe('isBaseUrlOverrideDenied', () => {
     });
 
     it('fails closed when URL cannot be parsed and denylist is non-empty', () => {
-        expect(isBaseUrlOverrideDenied('http://', ['localhost'])).toBe(true);
+        expect(isBaseUrlOverrideDenied('http://', new Set(['localhost']))).toBe(true);
     });
 });

--- a/packages/server/lib/controllers/proxy/baseUrlOverrideDenylist.unit.test.ts
+++ b/packages/server/lib/controllers/proxy/baseUrlOverrideDenylist.unit.test.ts
@@ -1,0 +1,45 @@
+import { describe, expect, it } from 'vitest';
+
+import { isBaseUrlOverrideDenied, normalizeDenylist, normalizeDenylistHost } from './baseUrlOverrideDenylist.js';
+
+describe('normalizeDenylistHost', () => {
+    it('lowercases bare hostname', () => {
+        expect(normalizeDenylistHost('LOCALHOST')).toBe('localhost');
+    });
+
+    it('extracts hostname from URL', () => {
+        expect(normalizeDenylistHost('http://169.254.169.254/path')).toBe('169.254.169.254');
+    });
+
+    it('returns empty for whitespace-only', () => {
+        expect(normalizeDenylistHost('  ')).toBe('');
+    });
+});
+
+describe('normalizeDenylist', () => {
+    it('dedupes', () => {
+        expect(normalizeDenylist(['localhost', 'LOCALHOST', 'http://localhost/'])).toEqual(['localhost']);
+    });
+});
+
+describe('isBaseUrlOverrideDenied', () => {
+    it('returns false when denylist empty', () => {
+        expect(isBaseUrlOverrideDenied('http://169.254.169.254/', [])).toBe(false);
+    });
+
+    it('returns true on exact hostname match', () => {
+        expect(isBaseUrlOverrideDenied('http://169.254.169.254/foo', ['169.254.169.254'])).toBe(true);
+    });
+
+    it('matches URL-form deny entry', () => {
+        expect(isBaseUrlOverrideDenied('http://169.254.169.254/', ['http://169.254.169.254'])).toBe(true);
+    });
+
+    it('returns false when host not listed', () => {
+        expect(isBaseUrlOverrideDenied('https://api.github.com', ['169.254.169.254'])).toBe(false);
+    });
+
+    it('is case-insensitive', () => {
+        expect(isBaseUrlOverrideDenied('http://LOCALHOST:8080/', ['localhost'])).toBe(true);
+    });
+});

--- a/packages/server/lib/controllers/proxy/baseUrlOverrideDenylist.unit.test.ts
+++ b/packages/server/lib/controllers/proxy/baseUrlOverrideDenylist.unit.test.ts
@@ -32,6 +32,12 @@ describe('normalizeDenylistHost', () => {
     it('returns empty for whitespace-only', () => {
         expect(normalizeDenylistHost('  ')).toBe('');
     });
+
+    it('normalizes bare IPv4 alternate spellings like URL (integer, octal, hex)', () => {
+        expect(normalizeDenylistHost('2852039166')).toBe('169.254.169.254');
+        expect(normalizeDenylistHost('0177.0.0.1')).toBe('127.0.0.1');
+        expect(normalizeDenylistHost('0x7f.0.0.1')).toBe('127.0.0.1');
+    });
 });
 
 describe('normalizeDenylist', () => {
@@ -47,6 +53,10 @@ describe('isBaseUrlOverrideDenied', () => {
 
     it('returns true on exact hostname match', () => {
         expect(isBaseUrlOverrideDenied('http://169.254.169.254/foo', new Set(['169.254.169.254']))).toBe(true);
+    });
+
+    it('matches when denylist uses bare IPv4 integer and override uses dotted decimal', () => {
+        expect(isBaseUrlOverrideDenied('http://169.254.169.254/', normalizeDenylist(['2852039166']))).toBe(true);
     });
 
     it('returns false when host not listed', () => {

--- a/packages/server/lib/controllers/proxy/baseUrlOverrideDenylist.unit.test.ts
+++ b/packages/server/lib/controllers/proxy/baseUrlOverrideDenylist.unit.test.ts
@@ -1,6 +1,16 @@
 import { describe, expect, it } from 'vitest';
 
-import { isBaseUrlOverrideDenied, normalizeDenylist, normalizeDenylistHost } from './baseUrlOverrideDenylist.js';
+import { canonicalizeHostnameForDenylist, isBaseUrlOverrideDenied, normalizeDenylist, normalizeDenylistHost } from './baseUrlOverrideDenylist.js';
+
+describe('canonicalizeHostnameForDenylist', () => {
+    it('strips trailing FQDN dot', () => {
+        expect(canonicalizeHostnameForDenylist('localhost.')).toBe('localhost');
+    });
+
+    it('strips bracketed IPv6', () => {
+        expect(canonicalizeHostnameForDenylist('[::1]')).toBe('::1');
+    });
+});
 
 describe('normalizeDenylistHost', () => {
     it('lowercases bare hostname', () => {
@@ -9,6 +19,14 @@ describe('normalizeDenylistHost', () => {
 
     it('extracts hostname from URL', () => {
         expect(normalizeDenylistHost('http://169.254.169.254/path')).toBe('169.254.169.254');
+    });
+
+    it('canonicalizes trailing dot in URL hostname', () => {
+        expect(normalizeDenylistHost('http://localhost./path')).toBe('localhost');
+    });
+
+    it('normalizes bracketed IPv6 denylist entry to match URL hostname', () => {
+        expect(normalizeDenylistHost('[::1]')).toBe('::1');
     });
 
     it('returns empty for whitespace-only', () => {
@@ -37,5 +55,19 @@ describe('isBaseUrlOverrideDenied', () => {
 
     it('is case-insensitive', () => {
         expect(isBaseUrlOverrideDenied('http://LOCALHOST:8080/', ['localhost'])).toBe(true);
+    });
+
+    it('matches when override uses trailing-dot hostname and denylist lists bare host', () => {
+        expect(isBaseUrlOverrideDenied('http://localhost./', normalizeDenylist(['localhost']))).toBe(true);
+    });
+
+    it('matches IPv6 when denylist uses bracketed literal', () => {
+        const list = normalizeDenylist(['[::1]']);
+        expect(isBaseUrlOverrideDenied('http://[::1]/', list)).toBe(true);
+    });
+
+    it('matches URL-form deny entry with bracketed IPv6', () => {
+        const list = normalizeDenylist(['http://[::1]/']);
+        expect(isBaseUrlOverrideDenied('http://[::1]/path', list)).toBe(true);
     });
 });

--- a/packages/shared/lib/services/proxy/utils.ts
+++ b/packages/shared/lib/services/proxy/utils.ts
@@ -37,7 +37,8 @@ type ProxyErrorCode =
     | 'invalid_query_params'
     | 'unknown_error'
     | 'failed_to_get_connection'
-    | 'invalid_certificate_or_key_format';
+    | 'invalid_certificate_or_key_format'
+    | 'proxy_redirect_to_denied_host';
 
 export interface RetryReason {
     retry: boolean;
@@ -55,6 +56,28 @@ export class ProxyError extends Error {
 
 const methodDataAllowed = ['POST', 'PUT', 'PATCH', 'DELETE'];
 const providedHeaders: Lowercase<string>[] = ['user-agent'];
+
+/**
+ * Absolute URL for the upcoming redirect request, from Node `follow-redirects` options
+ * (after `spreadUrlObject`, `href` is set).
+ */
+export function absoluteUrlFromRedirectRequestOptions(options: Record<string, unknown>): string | null {
+    if (typeof options['href'] === 'string' && options['href'].length > 0) {
+        return options['href'];
+    }
+    const protocol = typeof options['protocol'] === 'string' ? options['protocol'] : '';
+    const host =
+        typeof options['host'] === 'string'
+            ? options['host']
+            : typeof options['hostname'] === 'string'
+              ? `${options['hostname']}${typeof options['port'] === 'number' && options['port'] ? `:${options['port']}` : ''}`
+              : '';
+    const path = typeof options['path'] === 'string' ? options['path'] : '/';
+    if (!protocol || !host) {
+        return null;
+    }
+    return `${protocol}//${host}${path.startsWith('/') ? path : `/${path}`}`;
+}
 
 export function getAxiosConfiguration({
     proxyConfig,
@@ -77,6 +100,12 @@ export function getAxiosConfiguration({
     // TODO: change default to false after removing the metric below
     const shouldForward = proxyConfig.forwardHeadersOnRedirect ?? proxyConfig.provider.proxy?.forward_headers_on_redirect ?? true;
     axiosConfig.beforeRedirect = (options: Record<string, any>) => {
+        if (proxyConfig.validateProxyRedirectUrl) {
+            const absolute = absoluteUrlFromRedirectRequestOptions(options);
+            if (absolute) {
+                proxyConfig.validateProxyRedirectUrl(absolute);
+            }
+        }
         metrics.increment(metrics.Types.PROXY_REDIRECT, 1, { provider: proxyConfig.providerName });
         if (shouldForward) {
             // keep all headers from the original nango request, especially authorization as its dropped with axios follow-redirects
@@ -145,7 +174,17 @@ export function getProxyConfiguration({
     externalConfig: ApplicationConstructedProxyConfiguration | UserProvidedProxyConfiguration;
     internalConfig: InternalProxyConfiguration;
 }): Result<ApplicationConstructedProxyConfiguration, ProxyError> {
-    const { endpoint: passedEndpoint, providerConfigKey, method, retries, headers, baseUrlOverride, retryOn, forwardHeadersOnRedirect } = externalConfig;
+    const {
+        endpoint: passedEndpoint,
+        providerConfigKey,
+        method,
+        retries,
+        headers,
+        baseUrlOverride,
+        retryOn,
+        forwardHeadersOnRedirect,
+        validateProxyRedirectUrl
+    } = externalConfig;
     const { providerName } = internalConfig;
     let data = externalConfig.data;
 
@@ -211,7 +250,8 @@ export function getProxyConfiguration({
         params: externalConfig.params as Record<string, string>, // TODO: fix this
         responseType: externalConfig.responseType,
         retryOn: retryOn && Array.isArray(retryOn) ? retryOn.map(Number) : null,
-        ...(forwardHeadersOnRedirect !== undefined ? { forwardHeadersOnRedirect } : {})
+        ...(forwardHeadersOnRedirect !== undefined ? { forwardHeadersOnRedirect } : {}),
+        ...(validateProxyRedirectUrl !== undefined ? { validateProxyRedirectUrl } : {})
     };
 
     return Ok(configBody);

--- a/packages/shared/lib/services/proxy/utils.unit.test.ts
+++ b/packages/shared/lib/services/proxy/utils.unit.test.ts
@@ -1,6 +1,6 @@
 import { describe, expect, it } from 'vitest';
 
-import { ProxyError, buildProxyHeaders, buildProxyURL, getAxiosConfiguration, getProxyConfiguration } from './utils.js';
+import { ProxyError, absoluteUrlFromRedirectRequestOptions, buildProxyHeaders, buildProxyURL, getAxiosConfiguration, getProxyConfiguration } from './utils.js';
 import { getDefaultProxy } from './utils.test.js';
 import { getTestConnection } from '../../seeders/connection.seeder.js';
 
@@ -1091,6 +1091,65 @@ describe('getAxiosConfiguration', () => {
 
         expect(axiosConfig.beforeRedirect).toBeDefined();
     });
+
+    it('invokes validateProxyRedirectUrl with redirect href before other beforeRedirect work', () => {
+        const seen: string[] = [];
+        const config = getDefaultProxy({
+            provider: {
+                auth_mode: 'API_KEY',
+                proxy: { base_url: 'https://api.example.com' }
+            },
+            validateProxyRedirectUrl: (absoluteUrl) => {
+                seen.push(absoluteUrl);
+            }
+        });
+
+        const axiosConfig = getAxiosConfiguration({
+            proxyConfig: config,
+            connection: getTestConnection({ credentials: { type: 'API_KEY', apiKey: 'secret' } })
+        });
+
+        const redirectDetails = { headers: {} as Record<string, string>, statusCode: 302 };
+        axiosConfig.beforeRedirect!({ href: 'https://redirect.example/next', headers: {} }, redirectDetails);
+
+        expect(seen).toEqual(['https://redirect.example/next']);
+    });
+
+    it('propagates throw from validateProxyRedirectUrl', () => {
+        const config = getDefaultProxy({
+            provider: {
+                auth_mode: 'API_KEY',
+                proxy: { base_url: 'https://api.example.com' }
+            },
+            validateProxyRedirectUrl: () => {
+                throw new ProxyError('proxy_redirect_to_denied_host', 'blocked');
+            }
+        });
+
+        const axiosConfig = getAxiosConfiguration({
+            proxyConfig: config,
+            connection: getTestConnection({ credentials: { type: 'API_KEY', apiKey: 'secret' } })
+        });
+
+        const redirectDetails = { headers: {} as Record<string, string>, statusCode: 302 };
+        expect(() => axiosConfig.beforeRedirect!({ href: 'https://redirect.example/next', headers: {} }, redirectDetails)).toThrow(ProxyError);
+    });
+});
+
+describe('absoluteUrlFromRedirectRequestOptions', () => {
+    it('returns href when present', () => {
+        expect(absoluteUrlFromRedirectRequestOptions({ href: 'https://a.example/path' })).toBe('https://a.example/path');
+    });
+
+    it('composes from protocol host path when href missing', () => {
+        expect(
+            absoluteUrlFromRedirectRequestOptions({
+                protocol: 'https:',
+                host: 'api.example.com',
+                path: '/p?q=1'
+            })
+        ).toBe('https://api.example.com/p?q=1');
+    });
 });
 
 describe('getProxyConfiguration', () => {
@@ -1200,5 +1259,28 @@ describe('getProxyConfiguration', () => {
             params: { foo: 'bar' },
             responseType: 'blob'
         });
+    });
+
+    it('passes through validateProxyRedirectUrl', () => {
+        const validateProxyRedirectUrl = (url: string): void => {
+            void url;
+        };
+        const externalConfig: UserProvidedProxyConfiguration = {
+            method: 'GET',
+            providerConfigKey: 'provider-config-key-1',
+            endpoint: '/api/test',
+            baseUrlOverride: 'https://api.github.com.override',
+            validateProxyRedirectUrl
+        };
+        const internalConfig: InternalProxyConfiguration = {
+            providerName: 'github'
+        };
+
+        const res = getProxyConfiguration({ externalConfig, internalConfig });
+        if (res.isErr()) {
+            throw res.error;
+        }
+
+        expect(res.value.validateProxyRedirectUrl).toBe(validateProxyRedirectUrl);
     });
 });

--- a/packages/types/lib/proxy/api.ts
+++ b/packages/types/lib/proxy/api.ts
@@ -29,6 +29,11 @@ export interface BaseProxyConfiguration {
     retryHeader?: RetryHeaderConfig;
     retryOn?: number[] | null;
     forwardHeadersOnRedirect?: boolean;
+    /**
+     * If set, called with the absolute URL of each HTTP redirect before Axios follows it.
+     * Implementations may throw (e.g. shared `ProxyError`) to abort the redirect.
+     */
+    validateProxyRedirectUrl?: (absoluteRedirectUrl: string) => void;
 }
 
 export interface UserProvidedProxyConfiguration extends BaseProxyConfiguration {

--- a/packages/utils/lib/environment/parse.ts
+++ b/packages/utils/lib/environment/parse.ts
@@ -32,6 +32,30 @@ export const ENVS = z.object({
     NANGO_ADMIN_INVITE_TOKEN: z.string().optional(),
     NANGO_SERVER_PUBLIC_BODY_LIMIT: z.string().optional().default('75mb'),
     SERVER_SHUTDOWN_DELAY_MS: z.coerce.number().optional().default(0),
+    NANGO_PROXY_BASE_URL_OVERRIDE_DENYLIST: z
+        .string()
+        .transform((s, ctx) => {
+            if (s.trim() === '') {
+                return [];
+            }
+            try {
+                const parsed = JSON.parse(s);
+                if (!Array.isArray(parsed) || !parsed.every((item: unknown) => typeof item === 'string')) {
+                    ctx.addIssue(`NANGO_PROXY_BASE_URL_OVERRIDE_DENYLIST must be a JSON array of strings`);
+                    return z.NEVER;
+                }
+                return parsed;
+            } catch {
+                ctx.addIssue(`NANGO_PROXY_BASE_URL_OVERRIDE_DENYLIST must be a valid JSON array of strings`);
+                return z.NEVER;
+            }
+        })
+        .pipe(
+            z.array(z.string()).transform((arr) => {
+                return arr.map((e) => e.trim()).filter((e) => e.length > 0);
+            })
+        )
+        .default([]),
 
     // Connect
     NANGO_PUBLIC_CONNECT_URL: z.url().optional(),

--- a/packages/utils/lib/environment/parse.unit.test.ts
+++ b/packages/utils/lib/environment/parse.unit.test.ts
@@ -114,4 +114,28 @@ describe('parse', () => {
             ]
         });
     });
+
+    it('should default NANGO_PROXY_BASE_URL_OVERRIDE_DENYLIST to empty array', () => {
+        const res = parseEnvs(ENVS, {});
+        expect(res.NANGO_PROXY_BASE_URL_OVERRIDE_DENYLIST).toEqual([]);
+    });
+
+    it('should parse NANGO_PROXY_BASE_URL_OVERRIDE_DENYLIST JSON array and trim entries', () => {
+        const res = parseEnvs(ENVS, {
+            NANGO_PROXY_BASE_URL_OVERRIDE_DENYLIST: JSON.stringify([' 169.254.169.254 ', 'localhost', ''])
+        });
+        expect(res.NANGO_PROXY_BASE_URL_OVERRIDE_DENYLIST).toEqual(['169.254.169.254', 'localhost']);
+    });
+
+    it('should throw on invalid NANGO_PROXY_BASE_URL_OVERRIDE_DENYLIST JSON', () => {
+        expect(() => {
+            parseEnvs(ENVS, { NANGO_PROXY_BASE_URL_OVERRIDE_DENYLIST: 'not-json' });
+        }).toThrow('NANGO_PROXY_BASE_URL_OVERRIDE_DENYLIST');
+    });
+
+    it('should throw when NANGO_PROXY_BASE_URL_OVERRIDE_DENYLIST is not a string array', () => {
+        expect(() => {
+            parseEnvs(ENVS, { NANGO_PROXY_BASE_URL_OVERRIDE_DENYLIST: JSON.stringify([1, 2]) });
+        }).toThrow('NANGO_PROXY_BASE_URL_OVERRIDE_DENYLIST');
+    });
 });

--- a/packages/utils/lib/telemetry/metrics.ts
+++ b/packages/utils/lib/telemetry/metrics.ts
@@ -40,6 +40,7 @@ export enum Types {
     PROXY_INCOMING_PAYLOAD_SIZE_BYTES = 'nango.server.proxy.incoming.payloadSizeBytes',
     PROXY_OUTGOING_PAYLOAD_SIZE_BYTES = 'nango.server.proxy.outgoing.payloadSizeBytes',
     PROXY_REDIRECT = 'nango.server.proxy.redirect',
+    PROXY_BASE_URL_OVERRIDE_DENIED = 'nango.server.proxy.baseUrlOverrideDenied',
 
     CRON_REFRESH_CONNECTIONS = 'nango.server.cron.refreshConnections',
     CRON_REFRESH_CONNECTIONS_FAILED = 'nango.server.cron.refreshConnections.failed',

--- a/vite.integration.config.ts
+++ b/vite.integration.config.ts
@@ -19,7 +19,9 @@ export default defineConfig({
             ORCHESTRATOR_SERVICE_URL: 'http://orchestrator',
             RUNNER_NODE_ID: '1',
             FLAG_API_RATE_LIMIT_ENABLED: 'false',
-            FLAG_AUTH_ROLES_ENABLED: 'true'
+            FLAG_AUTH_ROLES_ENABLED: 'true',
+            // Used by allProxy.integration.test.ts denylist case; must be set before server modules load
+            NANGO_PROXY_BASE_URL_OVERRIDE_DENYLIST: JSON.stringify(['denylisted-proxy-test.invalid'])
         },
         fileParallelism: false,
         pool: 'forks',


### PR DESCRIPTION
<!-- Describe the problem and your solution --> 

<!-- Issue ticket number and link (if applicable) -->

<!-- Testing instructions (skip if just adding/editing providers) -->


<!-- Summary by @propel-code-bot -->

---

**Enforce `base-url-override` Denylist in Proxy With Redirect Validation and Normalization**

This PR adds server-side enforcement to block disallowed proxy `base-url-override` targets using a new environment variable, `NANGO_PROXY_BASE_URL_OVERRIDE_DENYLIST`. It introduces robust hostname normalization for denylist matching (case-insensitive hostnames, trailing dots, bracketed IPv6 handling, and URL/bare-entry normalization), applies checks early in `allPublicProxy`, and returns `400` with `error.code` `base_url_override_not_allowed` when blocked.

It also closes a redirect-based bypass by validating redirect destinations via `validateProxyRedirectUrl` in proxy request configuration, wiring this through shared proxy config/types, and surfacing denied redirects as the same `400` response. The PR adds observability with a new metric and warning logs, expands env parsing and docs for denylist configuration, and includes targeted unit tests for normalization, deny behavior, redirect validation, and error-chain handling.

---
*This summary was automatically generated by @propel-code-bot*