### PR TITLE
feat(sanity-sync): add more logs to sanity sync

### DIFF
--- a/.github/workflows/sanity-sync.yaml
+++ b/.github/workflows/sanity-sync.yaml
@@ -55,5 +55,5 @@ jobs:
                   SANITY_TOKEN: ${{ secrets.SANITY_TOKEN }}
                   SANITY_PROJECT_ID: ${{ vars.SANITY_PROJECT_ID }}
                   SANITY_DATASET: ${{ vars.SANITY_DATASET }}
-                  FORCE_UPDATE: ${{ github.event_name == 'schedule' || inputs.force_update == 'true' }}
-                  DRYRUN: ${{ inputs.dry_run == 'true' }}
+                  FORCE_UPDATE: ${{ github.event_name == 'schedule' || inputs.force_update }}
+                  DRYRUN: ${{ inputs.dry_run }}

--- a/scripts/sanity-api-sync.ts
+++ b/scripts/sanity-api-sync.ts
@@ -30,11 +30,13 @@ if (!process.env['SANITY_DATASET']) {
     throw new Error('Missing SANITY_DATASET');
 }
 
-const dryRun = !!process.env['DRYRUN'];
-const forceUpdate = !!process.env['FORCE_UPDATE'];
+const dryRun = process.env['DRYRUN'] === 'true';
+const forceUpdate = process.env['FORCE_UPDATE'] === 'true';
 const projectId = process.env['SANITY_PROJECT_ID'];
 const dataset = process.env['SANITY_DATASET'];
 const token = process.env['SANITY_TOKEN'];
+
+console.log(`Config: dryRun=${dryRun}, forceUpdate=${forceUpdate}`);
 
 const sanity = createClient({ projectId, dataset, token, apiVersion, useCdn: false });
 
@@ -120,12 +122,14 @@ async function buildDocument(slug: string, provider: Provider): Promise<SanityDo
     let logoAssetRef: string | undefined;
     if (logoBuffer) {
         if (!dryRun) {
+            console.log(`Uploading logo for ${slug}...`);
             const asset = await sanity.assets.upload('image', logoBuffer, {
                 filename: `${slug}.svg`,
                 contentType: 'image/svg+xml',
                 source: { id: slug, name: slug }
             });
             logoAssetRef = asset._id;
+            console.log(`Uploaded logo for ${slug}: ${logoAssetRef}`);
         } else {
             logoAssetRef = existing?.logo?.asset?._ref;
         }
@@ -153,6 +157,7 @@ if (forceUpdate) {
     const documents: SanityDoc[] = [];
 
     for (const [slug, provider] of Object.entries(neededProviders)) {
+        console.log(`Processing ${slug}...`);
         const doc = await buildDocument(slug, provider);
         documents.push(doc);
 
@@ -187,25 +192,23 @@ if (forceUpdate) {
     }
 } else {
     for (const [slug, provider] of Object.entries(neededProviders)) {
-        const doc = await buildDocument(slug, provider);
         const existing = existingBySlug[slug];
 
-        const existingCategoryRefs = new Set((existing?.category || []).map((c: { _ref: string }) => c._ref));
-        const newCategoryRefs = new Set(doc.category.map((c) => c._ref));
-        const categoriesUnchanged = existingCategoryRefs.size === newCategoryRefs.size && [...newCategoryRefs].every((ref) => existingCategoryRefs.has(ref));
-
         if (existing) {
-            const unchanged =
-                existing.name === doc.name &&
-                existing.documentationLink === doc.documentationLink &&
-                existing.logo?.asset?._ref === doc.logo?.asset?._ref &&
-                categoriesUnchanged;
+            const newCategoryRefs = new Set((provider.categories || []).filter((cat) => categoriesBySlug[cat]).map((cat) => categoriesBySlug[cat]!));
+            const existingCategoryRefs = new Set((existing.category || []).map((c: { _ref: string }) => c._ref));
+            const categoriesUnchanged =
+                existingCategoryRefs.size === newCategoryRefs.size && [...newCategoryRefs].every((ref) => existingCategoryRefs.has(ref));
+
+            const unchanged = existing.name === provider.display_name && existing.documentationLink === provider.docs && categoriesUnchanged;
 
             if (unchanged) {
                 skipped++;
                 continue;
             }
         }
+
+        const doc = await buildDocument(slug, provider);
 
         if (!dryRun) {
             await sanity.createOrReplace(doc);


### PR DESCRIPTION
## Describe the problem and your solution

- add more logs to sanity sync
- Fix logo uploads on every run by ensuring unchanged providers are skipped earlier in the flow. Moved the change check before `buildDocument` so logos are only uploaded when updates are needed.

<!-- Issue ticket number and link (if applicable) -->

<!-- Testing instructions (skip if just adding/editing providers) -->


<!-- Summary by @propel-code-bot -->

---

**Improve `sanity-sync` observability and tighten env flag handling**

This PR updates `scripts/sanity-api-sync.ts` and `.github/workflows/sanity-sync.yaml` to improve runtime visibility and make boolean flag behavior more explicit. It adds targeted logs for configuration, per-provider processing, and logo upload progress, while changing `DRYRUN`/`FORCE_UPDATE` parsing to strict `'true'` checks.

It also optimizes non-force-update flow by checking whether provider data changed before building/uploading a full Sanity document, and adjusts unchanged detection to compare against provider source fields and category refs. Overall scope is small and localized, with no new feature surface beyond improved sync behavior clarity.

---
*This summary was automatically generated by @propel-code-bot*