### PR TITLE
fix(webapp): improve error feedback on plan upgrade flows

### DIFF
--- a/packages/webapp/src/hooks/usePlan.tsx
+++ b/packages/webapp/src/hooks/usePlan.tsx
@@ -1,4 +1,4 @@
-import { useQuery } from '@tanstack/react-query';
+import { useMutation, useQuery } from '@tanstack/react-query';
 import { useMemo } from 'react';
 
 import { APIError, apiFetch } from '../utils/api';
@@ -104,14 +104,20 @@ export function useTrial(plan?: ApiPlan | null): { isTrial: boolean; isTrialOver
     return res;
 }
 
-export async function apiPostPlanChange(env: string, body: PostPlanChange['Body']) {
-    const res = await apiFetch(`/api/v1/plans/change?env=${env}`, {
-        method: 'POST',
-        body: JSON.stringify(body)
-    });
+export function useApiPostPlanChange(env: string) {
+    return useMutation<PostPlanChange['Success'], APIError, PostPlanChange['Body']>({
+        mutationFn: async (body): Promise<PostPlanChange['Success']> => {
+            const res = await apiFetch(`/api/v1/plans/change?env=${env}`, {
+                method: 'POST',
+                body: JSON.stringify(body)
+            });
 
-    return {
-        res,
-        json: (await res.json()) as PostPlanChange['Reply']
-    };
+            const json = (await res.json()) as PostPlanChange['Reply'];
+            if (res.status !== 200 || 'error' in json) {
+                throw new APIError({ res, json });
+            }
+
+            return json;
+        }
+    });
 }

--- a/packages/webapp/src/pages/Team/Billing/components/Plans.tsx
+++ b/packages/webapp/src/pages/Team/Billing/components/Plans.tsx
@@ -1,6 +1,5 @@
 import { Info, Loader } from 'lucide-react';
 import { useCallback, useEffect, useMemo, useRef, useState } from 'react';
-import { mutate } from 'swr';
 
 import { permissions } from '@nangohq/authz';
 
@@ -14,15 +13,16 @@ import { Alert, AlertDescription } from '@/components-v2/ui/alert.js';
 import { Button, ButtonLink } from '@/components-v2/ui/button';
 import { Dialog } from '@/components-v2/ui/dialog.js';
 import { Table, TableBody, TableCell, TableRow } from '@/components-v2/ui/table';
-import { useEnvironment } from '@/hooks/useEnvironment';
+import { environmentQueryKey, useEnvironment } from '@/hooks/useEnvironment';
 import { usePermissions } from '@/hooks/usePermissions.js';
-import { apiGetCurrentPlan, apiPostPlanChange, useApiGetPlans } from '@/hooks/usePlan';
+import { apiGetCurrentPlan, useApiGetPlans, useApiPostPlanChange } from '@/hooks/usePlan';
 import { useStripePaymentMethods } from '@/hooks/useStripe.js';
 import { useToast } from '@/hooks/useToast.js';
 import { queryClient, useStore } from '@/store';
 import { stripePromise } from '@/utils/stripe.js';
 
 import type { PlanDefinitionList } from '../types.js';
+import type { StripeError } from '@/utils/stripe.js';
 import type { PlanDefinition, StripePaymentMethod } from '@nangohq/types';
 
 export const Plans: React.FC = () => {
@@ -178,15 +178,21 @@ const PlanRow: React.FC<{ planDefinition: PlanDefinitionList; activePlan?: PlanD
 
         if (isDowngrade && plan.canChange) {
             return (
-                <PlanChangeDialog selectedPlan={planDefinition} activePlan={activePlan}>
+                <>
                     <PermissionGate asChild condition={canChangePlan}>
                         {(allowed) => (
-                            <Button variant="destructive" className="w-27" disabled={!allowed}>
+                            <Button onClick={() => setPlanChangeDialogOpen(true)} variant="destructive" className="w-27" disabled={!allowed}>
                                 Downgrade
                             </Button>
                         )}
                     </PermissionGate>
-                </PlanChangeDialog>
+                    <PlanChangeDialog
+                        open={planChangeDialogOpen}
+                        onOpenChange={setPlanChangeDialogOpen}
+                        selectedPlan={planDefinition}
+                        activePlan={activePlan}
+                    />
+                </>
             );
         }
 
@@ -230,15 +236,37 @@ const PlanChangeDialog: React.FC<{
             if (!isControlled) {
                 setInternalOpen(value);
             }
+            if (!value) {
+                setError(null);
+            }
             onOpenChange?.(value);
         },
         [isControlled, onOpenChange]
     );
 
+    const { mutateAsync: postPlanChange } = useApiPostPlanChange(env);
+
     const [loading, setLoading] = useState(false);
     const [longWait, setLongWait] = useState(false);
+    const [error, setError] = useState<string | null>(null);
 
     const refInterval = useRef<NodeJS.Timeout>();
+
+    /**
+     * Extracts a `card_error` from the Stripe error or fallback to `defaultError`.
+     *
+     * @param error - The `StripeError` object returned from `confirmCardPayment`
+     * @param defaultError - Fallback message when the error type is not user-actionable
+     * @returns `card_error` message if present, otherwise the `defaultError`
+     */
+    const getStripeCardErrorOrDefault = (error: StripeError, defaultError: string = 'An error occurred while validating your payment.') => {
+        switch (error.type) {
+            case 'card_error':
+                return error.message ?? defaultError;
+            default:
+                return defaultError;
+        }
+    };
 
     const onUpgrade = async () => {
         if (!selectedPlan?.plan.code) {
@@ -247,22 +275,29 @@ const PlanChangeDialog: React.FC<{
 
         setLoading(true);
         setLongWait(false);
+        setError(null);
 
-        const res = await apiPostPlanChange(env, { orbId: selectedPlan.plan.code });
-        if ('error' in res.json) {
+        let json: Awaited<ReturnType<typeof postPlanChange>>;
+        try {
+            json = await postPlanChange({ orbId: selectedPlan.plan.code });
+        } catch {
             setLoading(false);
-            toast({ title: 'Failed to upgrade, an error occurred', variant: 'error' });
+            setError('An error occurred. Please try again.');
             return;
         }
 
-        if ('paymentIntent' in res.json.data) {
-            res.json.data.paymentIntent;
+        if ('paymentIntent' in json.data) {
             const stripe = await stripePromise;
-            const result = await stripe!.confirmCardPayment(res.json.data.paymentIntent.client_secret);
+            if (!stripe) {
+                setLoading(false);
+                setError('Payment processor failed to load. Please refresh the page and try again.');
+                return;
+            }
 
+            const result = await stripe.confirmCardPayment(json.data.paymentIntent.client_secret);
             if (result.error) {
-                console.error({ error: result.error });
-                toast({ title: 'An error occurred while validating your payment', variant: 'error' });
+                setLoading(false);
+                setError(getStripeCardErrorOrDefault(result.error));
                 return;
             } else if (result.paymentIntent.status === 'succeeded') {
                 console.log('payment success', result);
@@ -283,8 +318,7 @@ const PlanChangeDialog: React.FC<{
 
             await Promise.all([
                 queryClient.invalidateQueries({ exact: false, queryKey: ['plans'], type: 'all' }),
-                queryClient.refetchQueries({ exact: false, queryKey: ['plans'], type: 'all' }),
-                mutate((key) => typeof key === 'string' && key.startsWith(`/api/v1/environments`))
+                queryClient.invalidateQueries({ queryKey: environmentQueryKey(env) })
             ]);
 
             setLongWait(false);
@@ -300,10 +334,13 @@ const PlanChangeDialog: React.FC<{
         }
 
         setLoading(true);
-        const res = await apiPostPlanChange(env, { orbId: selectedPlan.plan.code });
-        if ('error' in res.json) {
+        setError(null);
+
+        try {
+            await postPlanChange({ orbId: selectedPlan.plan.code });
+        } catch {
             setLoading(false);
-            toast({ title: 'Failed to downgrade, an error occurred', variant: 'error' });
+            setError('An error occurred. Please try again.');
             return;
         }
 
@@ -321,8 +358,7 @@ const PlanChangeDialog: React.FC<{
 
             await Promise.all([
                 queryClient.invalidateQueries({ exact: false, queryKey: ['plans'], type: 'all' }),
-                queryClient.refetchQueries({ exact: false, queryKey: ['plans'], type: 'all' }),
-                mutate((key) => typeof key === 'string' && key.startsWith(`/api/v1/environments`))
+                queryClient.invalidateQueries({ queryKey: environmentQueryKey(env) })
             ]);
 
             setLongWait(false);
@@ -368,6 +404,11 @@ const PlanChangeDialog: React.FC<{
                         <p className="text-s text-text-tertiary text-right">{selectedPlan.isUpgrade ? 'Payment is processing...' : 'Downgrading...'}</p>
                     )}
                 </div>
+                {error && (
+                    <Alert variant="error">
+                        <AlertDescription>{error}</AlertDescription>
+                    </Alert>
+                )}
                 <DialogFooter>
                     <DialogClose asChild>
                         <Button variant="secondary">Cancel</Button>

--- a/packages/webapp/src/utils/stripe.ts
+++ b/packages/webapp/src/utils/stripe.ts
@@ -2,5 +2,8 @@ import { loadStripe } from '@stripe/stripe-js';
 
 import { globalEnv } from './env';
 
+import type { StripeError } from '@stripe/stripe-js';
+
 const stripePublishableKey = globalEnv.publicStripeKey;
 export const stripePromise = loadStripe(stripePublishableKey);
+export type { StripeError };


### PR DESCRIPTION
<!-- Describe the problem and your solution -->
Customers faced with errors during attempts to upgrade their plan would receive generic, transient error messages, making it harder for them to pinpoint the root cause of the failure.

- Fixed load animation getting stuck on upgrade-plan failures.
- Improved error messages displayed to users on upgrade-plan failures: the errors are no longer transient (via toast), but are rather inlined with the <Alert> component.

<!-- Issue ticket number and link (if applicable) -->

<!-- Testing instructions (skip if just adding/editing providers) --> Register a valid card as a payment method, but set it up to fail when upgrading the plan (e.g. due to lack of funds/limits). The error should now be visible within the upgrade form and the source (if card-related) should be clear.


<!-- Summary by @propel-code-bot -->

---

In addition to improving inline error visibility and fixing stuck loading states, this PR also standardizes plan-change request handling and post-success data refresh behavior across billing flows, improves dialog error lifecycle handling across retries/close-reopen interactions, and strengthens failure handling around payment initialization so users receive safe, consistent feedback during both upgrade and downgrade attempts.

---
*This summary was automatically generated by @propel-code-bot*