### PR TITLE
chore: add account dimension to getRecords.size metric

### DIFF
--- a/packages/server/lib/controllers/records/getRecords.ts
+++ b/packages/server/lib/controllers/records/getRecords.ts
@@ -54,7 +54,7 @@ export const getPublicRecords = asyncWrapper<GetPublicRecords>(async (req, res) 
         return;
     }
 
-    const { environment } = res.locals;
+    const { environment, account } = res.locals;
     const headers: GetPublicRecords['Headers'] = valHeaders.data;
     const query: GetPublicRecords['Querystring'] = valQuery.data;
 
@@ -88,10 +88,10 @@ export const getPublicRecords = asyncWrapper<GetPublicRecords>(async (req, res) 
     });
 
     try {
-        metrics.increment(metrics.Types.GET_RECORDS_COUNT, result.value.records.length);
+        metrics.increment(metrics.Types.GET_RECORDS_COUNT, result.value.records.length, { accountId: account.id });
         // using the response content-length header as the records size metric in order to avoid stringifying the response body
         const responseSize = parseInt(res.get('content-length') || '0');
-        metrics.increment(metrics.Types.GET_RECORDS_SIZE_IN_BYTES, responseSize);
+        metrics.increment(metrics.Types.GET_RECORDS_SIZE_IN_BYTES, responseSize, { accountId: account.id });
     } catch {
         // ignore errors
     }


### PR DESCRIPTION
We have the accountId dimension for records writes but not reads. I would like to be able to correlate both for a given customer

<!-- Summary by @propel-code-bot -->

---

**Add `accountId` metric dimension to `getRecords` read metrics**

This PR updates `packages/server/lib/controllers/records/getRecords.ts` to include account-level metric tagging for read operations. It now pulls `account` from `res.locals` and passes `{ accountId: account.id }` as metric tags when incrementing both `metrics.Types.GET_RECORDS_COUNT` and `metrics.Types.GET_RECORDS_SIZE_IN_BYTES`.

The change aligns read-side observability with existing write-side account dimensions, enabling per-customer correlation of records read volume and payload size. Scope is minimal (single file, 3 additions / 3 deletions) and does not alter request validation, record retrieval logic, or response payload shape.

---
*This summary was automatically generated by @propel-code-bot*