### PR TITLE
fix: local and E2B sandbox startup paths

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -108,6 +108,23 @@ NANGO_PUBLIC_CONNECT_URL=http://localhost:3009
 NANGO_CONNECT_UI_PORT=3009
 FLAG_SERVE_CONNECT_UI=true
 
+# ---- Agent sandboxes
+AGENT_RUNTIME=local
+LOCAL_AGENT_IMAGE=agent-sandboxes/agent-workspace:local
+LOCAL_COMPILER_IMAGE=agent-sandboxes/blank-workspace:local
+
+# E2B staging
+# AGENT_RUNTIME=e2b
+# SANDBOX_AGENT_TEMPLATE=agent-workspace:staging
+# SANDBOX_COMPILER_TEMPLATE=blank-workspace:staging
+# E2B_API_KEY=<e2b key>
+
+# E2B production
+# AGENT_RUNTIME=e2b
+# SANDBOX_AGENT_TEMPLATE=agent-workspace:production
+# SANDBOX_COMPILER_TEMPLATE=blank-workspace:production
+# E2B_API_KEY=<e2b key>
+
 # ---- Role-based authorization (optional)
 # FLAG_AUTH_ROLES_ENABLED=false
 

--- a/.env.example
+++ b/.env.example
@@ -110,8 +110,6 @@ FLAG_SERVE_CONNECT_UI=true
 
 # ---- Agent sandboxes
 AGENT_RUNTIME=local
-LOCAL_AGENT_IMAGE=agent-sandboxes/agent-workspace:local
-LOCAL_COMPILER_IMAGE=agent-sandboxes/blank-workspace:local
 
 # E2B staging
 # AGENT_RUNTIME=e2b

--- a/README.md
+++ b/README.md
@@ -113,11 +113,9 @@ Embed the [Auth](https://nango.dev/docs/implementation-guides/platform/auth/impl
 
 ```bash
 export AGENT_RUNTIME=local
-export LOCAL_AGENT_IMAGE=agent-sandboxes/agent-workspace:local
-export LOCAL_COMPILER_IMAGE=agent-sandboxes/blank-workspace:local
 
-docker pull "$LOCAL_AGENT_IMAGE"
-docker pull "$LOCAL_COMPILER_IMAGE"
+docker pull agent-sandboxes/agent-workspace:local
+docker pull agent-sandboxes/blank-workspace:local
 ```
 
 Start Nango normally after that. Agent sessions, compile, and dryrun will spawn local Docker sandboxes on demand.

--- a/README.md
+++ b/README.md
@@ -114,8 +114,9 @@ Embed the [Auth](https://nango.dev/docs/implementation-guides/platform/auth/impl
 ```bash
 export AGENT_RUNTIME=local
 
-docker pull agent-sandboxes/agent-workspace:local
-docker pull agent-sandboxes/blank-workspace:local
+# Build the local sandbox images in https://github.com/NangoHQ/agent-sandboxes
+npm run docker:build:agent
+npm run docker:build:blank
 ```
 
 Start Nango normally after that. Agent sessions, compile, and dryrun will spawn local Docker sandboxes on demand.

--- a/README.md
+++ b/README.md
@@ -109,6 +109,19 @@ console.log(connection.credentials);
 
 Embed the [Auth](https://nango.dev/docs/implementation-guides/platform/auth/implement-api-auth) flow in your product, make requests with the [Proxy](https://nango.dev/docs/guides/primitives/proxy), or build custom integrations with [Functions](https://nango.dev/docs/guides/primitives/functions).
 
+## Local sandbox quickstart
+
+```bash
+export AGENT_RUNTIME=local
+export LOCAL_AGENT_IMAGE=agent-sandboxes/agent-workspace:local
+export LOCAL_COMPILER_IMAGE=agent-sandboxes/blank-workspace:local
+
+docker pull "$LOCAL_AGENT_IMAGE"
+docker pull "$LOCAL_COMPILER_IMAGE"
+```
+
+Start Nango normally after that. Agent sessions, compile, and dryrun will spawn local Docker sandboxes on demand.
+
 ## Why Nango?
 
 **AI-generated, human-controlled code.**

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -40,8 +40,6 @@ services:
             - NANGO_DASHBOARD_PASSWORD
             - LOG_LEVEL=${LOG_LEVEL:-info}
             - AGENT_RUNTIME=${AGENT_RUNTIME:-local}
-            - LOCAL_AGENT_IMAGE=${LOCAL_AGENT_IMAGE:-agent-sandboxes/agent-workspace:local}
-            - LOCAL_COMPILER_IMAGE=${LOCAL_COMPILER_IMAGE:-agent-sandboxes/blank-workspace:local}
             - E2B_API_KEY
             - SANDBOX_AGENT_TEMPLATE
             - SANDBOX_COMPILER_TEMPLATE

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -39,6 +39,12 @@ services:
             - NANGO_DASHBOARD_USERNAME
             - NANGO_DASHBOARD_PASSWORD
             - LOG_LEVEL=${LOG_LEVEL:-info}
+            - AGENT_RUNTIME=${AGENT_RUNTIME:-local}
+            - LOCAL_AGENT_IMAGE=${LOCAL_AGENT_IMAGE:-agent-sandboxes/agent-workspace:local}
+            - LOCAL_COMPILER_IMAGE=${LOCAL_COMPILER_IMAGE:-agent-sandboxes/blank-workspace:local}
+            - E2B_API_KEY
+            - SANDBOX_AGENT_TEMPLATE
+            - SANDBOX_COMPILER_TEMPLATE
             - NANGO_SERVER_WEBSOCKETS_PATH
             - NANGO_LOGS_ENABLED=${NANGO_LOGS_ENABLED:-false}
             - NANGO_LOGS_ES_URL=${NANGO_LOGS_ES_URL:-http://nango-elasticsearch:9200}

--- a/packages/server/lib/controllers/functions/deploy/postDeploy.ts
+++ b/packages/server/lib/controllers/functions/deploy/postDeploy.ts
@@ -70,6 +70,7 @@ export const postRemoteFunctionDeploy = asyncWrapper<PostRemoteFunctionDeploy>(a
         function_name: body.function_name,
         function_type: body.function_type,
         code: body.code,
+        environment_name: environment.name,
         nango_secret_key: defaultSecret.value.secret,
         nango_host: getApiUrl()
     });

--- a/packages/server/lib/controllers/functions/dryrun/postDryrun.ts
+++ b/packages/server/lib/controllers/functions/dryrun/postDryrun.ts
@@ -64,6 +64,7 @@ export const postRemoteFunctionDryrun = asyncWrapper<PostRemoteFunctionDryrun>(a
         function_name: body.function_name,
         function_type: body.function_type,
         code: body.code,
+        environment_name: environment.name,
         connection_id: body.connection_id,
         nango_secret_key: defaultSecret.value.secret,
         nango_host: getApiUrl(),

--- a/packages/server/lib/services/e2b/agent-sandbox.service.ts
+++ b/packages/server/lib/services/e2b/agent-sandbox.service.ts
@@ -14,11 +14,12 @@ const logger = getLogger('e2b-agent-sandbox');
 const opencodePort = 4096;
 export const agentSandboxTimeoutMs = 10 * 60 * 1000; // 10 minutes per spec
 const timeoutRefreshThrottleMs = 60 * 1000;
-const agentTemplate = process.env['SANDBOX_AGENT_TEMPLATE'] || 'nango-opencode-agent';
+const agentTemplate = 'agent-workspace:staging';
 
 export async function createAgentSandbox(sessionId: string, payload: AgentSessionPayload, onProgress?: (message: string) => void): Promise<AgentRuntimeHandle> {
-    if (!process.env['SANDBOX_API_KEY']) {
-        throw new Error('SANDBOX_API_KEY is required for the E2B agent runtime');
+    const apiKey = process.env['E2B_API_KEY'];
+    if (!apiKey) {
+        throw new Error('E2B_API_KEY is required for the E2B agent runtime');
     }
 
     const resolvedPayload: AgentSessionResolvedPayload = resolvePayload(payload);
@@ -28,9 +29,10 @@ export async function createAgentSandbox(sessionId: string, payload: AgentSessio
         allowInternetAccess: true,
         metadata: { purpose: 'nango-agent', sessionId, createdBy: 'nango-server' },
         network: { allowPublicTraffic: true },
-        apiKey: process.env['SANDBOX_API_KEY']
+        apiKey
     });
 
+    // This assumes the template does not auto-start OpenCode; Nango owns config injection and process startup.
     await sandbox.files.write(`${agentProjectPath}/opencode.json`, JSON.stringify(createRuntimeConfig(), null, 2));
 
     const accessToken = sandbox.trafficAccessToken;

--- a/packages/server/lib/services/local/agent-sandbox.service.ts
+++ b/packages/server/lib/services/local/agent-sandbox.service.ts
@@ -14,7 +14,7 @@ const execFileAsync = promisify(execFile);
 const logger = getLogger('local-agent-sandbox');
 
 const opencodePort = 4096;
-export const localAgentImageName = process.env['LOCAL_AGENT_IMAGE'] || 'nango-local-agent';
+export const localAgentImageName = process.env['LOCAL_AGENT_IMAGE'] || 'agent-sandboxes/agent-workspace:local';
 
 export async function createLocalAgentSandbox(
     sessionId: string,
@@ -35,7 +35,9 @@ export async function createLocalAgentSandbox(
         `${hostPort}:${opencodePort}`,
         '-e',
         `OPENCODE_API_KEY=${process.env['OPENCODE_API_KEY'] ?? ''}`,
-        localAgentImageName
+        localAgentImageName,
+        'sleep',
+        'infinity'
     ]);
 
     await writeFileToContainer(containerName, `${agentProjectPath}/opencode.json`, JSON.stringify(createRuntimeConfig(), null, 2));

--- a/packages/server/lib/services/local/agent-sandbox.service.ts
+++ b/packages/server/lib/services/local/agent-sandbox.service.ts
@@ -14,7 +14,7 @@ const execFileAsync = promisify(execFile);
 const logger = getLogger('local-agent-sandbox');
 
 const opencodePort = 4096;
-export const localAgentImageName = process.env['LOCAL_AGENT_IMAGE'] || 'agent-sandboxes/agent-workspace:local';
+export const localAgentImageName = 'agent-sandboxes/agent-workspace:local';
 
 export async function createLocalAgentSandbox(
     sessionId: string,

--- a/packages/server/lib/services/local/compiler-client.ts
+++ b/packages/server/lib/services/local/compiler-client.ts
@@ -1,15 +1,16 @@
 import { execFile, spawn } from 'node:child_process';
 import { randomUUID } from 'node:crypto';
+import path from 'node:path';
 import { promisify } from 'node:util';
 
 import { agentProjectPath } from '../agent/agent-runtime.js';
-import { CompilerError, buildFlowConfig, buildIndexTs, buildNangoYaml, getFilePaths } from '../remote-function/compiler-client.js';
+import { CompilerError, buildFlowConfig, buildIndexTs, getFilePaths } from '../remote-function/compiler-client.js';
 
 import type { CompileRequest, CompileResult } from '../remote-function/compiler-client.js';
 
 const execFileAsync = promisify(execFile);
 
-const localCompilerImage = process.env['LOCAL_COMPILER_IMAGE'] || 'nango-local-compiler';
+const localCompilerImage = process.env['LOCAL_COMPILER_IMAGE'] || 'agent-sandboxes/blank-workspace:local';
 const compilerTimeoutMs = 3 * 60 * 1000;
 
 export async function invokeLocalCompiler(request: CompileRequest): Promise<CompileResult> {
@@ -24,7 +25,6 @@ export async function invokeLocalCompiler(request: CompileRequest): Promise<Comp
 
         await writeContainerFile(containerName, `${agentProjectPath}/${tsFilePath}`, request.code);
         await writeContainerFile(containerName, `${agentProjectPath}/index.ts`, buildIndexTs(request));
-        await writeContainerFile(containerName, `${agentProjectPath}/nango.yaml`, buildNangoYaml(request));
 
         try {
             await execFileAsync('docker', ['exec', '-w', agentProjectPath, '-e', 'NO_COLOR=1', containerName, 'nango', 'compile'], {
@@ -34,12 +34,12 @@ export async function invokeLocalCompiler(request: CompileRequest): Promise<Comp
             throw new CompilerError(err instanceof Error ? err.message : String(err), 'compilation');
         }
 
-        const [bundledJs, yamlContent] = await Promise.all([
+        const [bundledJs, nangoJson] = await Promise.all([
             readContainerFile(containerName, `${agentProjectPath}/${cjsFilePath}`),
-            readContainerFile(containerName, `${agentProjectPath}/nango.yaml`)
+            readContainerFile(containerName, path.join(agentProjectPath, '.nango', 'nango.json'))
         ]);
 
-        const flow = await buildFlowConfig(yamlContent, request, bundledJs);
+        const flow = buildFlowConfig(nangoJson, request, bundledJs);
         return {
             bundledJs,
             bundleSizeBytes: Buffer.byteLength(bundledJs, 'utf8'),

--- a/packages/server/lib/services/local/compiler-client.ts
+++ b/packages/server/lib/services/local/compiler-client.ts
@@ -10,7 +10,7 @@ import type { CompileRequest, CompileResult } from '../remote-function/compiler-
 
 const execFileAsync = promisify(execFile);
 
-const localCompilerImage = process.env['LOCAL_COMPILER_IMAGE'] || 'agent-sandboxes/blank-workspace:local';
+const localCompilerImage = 'agent-sandboxes/blank-workspace:local';
 const compilerTimeoutMs = 3 * 60 * 1000;
 
 export async function invokeLocalCompiler(request: CompileRequest): Promise<CompileResult> {

--- a/packages/server/lib/services/local/deploy-client.ts
+++ b/packages/server/lib/services/local/deploy-client.ts
@@ -3,13 +3,13 @@ import { randomUUID } from 'node:crypto';
 import { promisify } from 'node:util';
 
 import { agentProjectPath } from '../agent/agent-runtime.js';
-import { buildIndexTs, buildNangoYaml, getFilePaths } from '../remote-function/compiler-client.js';
+import { buildIndexTs, getFilePaths } from '../remote-function/compiler-client.js';
 
 import type { DeployRequest, DeployResult } from '../remote-function/deploy-client.js';
 
 const execFileAsync = promisify(execFile);
 
-const localCompilerImage = process.env['LOCAL_COMPILER_IMAGE'] || 'nango-local-compiler';
+const localCompilerImage = process.env['LOCAL_COMPILER_IMAGE'] || 'agent-sandboxes/blank-workspace:local';
 const deployTimeoutMs = 5 * 60 * 1000;
 
 export async function invokeLocalDeploy(request: DeployRequest): Promise<DeployResult> {
@@ -46,7 +46,6 @@ export async function invokeLocalDeploy(request: DeployRequest): Promise<DeployR
 
         await writeContainerFile(containerName, `${agentProjectPath}/${tsFilePath}`, request.code);
         await writeContainerFile(containerName, `${agentProjectPath}/index.ts`, buildIndexTs(request));
-        await writeContainerFile(containerName, `${agentProjectPath}/nango.yaml`, buildNangoYaml(request));
 
         const cmd = buildDeployCommand(request);
 
@@ -68,7 +67,7 @@ export async function invokeLocalDeploy(request: DeployRequest): Promise<DeployR
 
 function buildDeployCommand(request: DeployRequest): string {
     const typeFlag = request.function_type === 'action' ? `--action ${request.function_name}` : `--sync ${request.function_name}`;
-    return `nango deploy ${typeFlag} --auto-confirm --allow-destructive`;
+    return `nango deploy ${request.environment_name} ${typeFlag} --auto-confirm --allow-destructive --no-interactive`;
 }
 
 async function writeContainerFile(containerName: string, filePath: string, content: string): Promise<void> {

--- a/packages/server/lib/services/local/deploy-client.ts
+++ b/packages/server/lib/services/local/deploy-client.ts
@@ -9,7 +9,7 @@ import type { DeployRequest, DeployResult } from '../remote-function/deploy-clie
 
 const execFileAsync = promisify(execFile);
 
-const localCompilerImage = process.env['LOCAL_COMPILER_IMAGE'] || 'agent-sandboxes/blank-workspace:local';
+const localCompilerImage = 'agent-sandboxes/blank-workspace:local';
 const deployTimeoutMs = 5 * 60 * 1000;
 
 export async function invokeLocalDeploy(request: DeployRequest): Promise<DeployResult> {

--- a/packages/server/lib/services/local/dryrun-client.ts
+++ b/packages/server/lib/services/local/dryrun-client.ts
@@ -9,7 +9,7 @@ import type { DryrunRequest, DryrunResult } from '../remote-function/dryrun-clie
 
 const execFileAsync = promisify(execFile);
 
-const localCompilerImage = process.env['LOCAL_COMPILER_IMAGE'] || 'agent-sandboxes/blank-workspace:local';
+const localCompilerImage = 'agent-sandboxes/blank-workspace:local';
 const compileTimeoutMs = 3 * 60 * 1000;
 const dryrunTimeoutMs = 5 * 60 * 1000;
 

--- a/packages/server/lib/services/local/dryrun-client.ts
+++ b/packages/server/lib/services/local/dryrun-client.ts
@@ -3,13 +3,13 @@ import { randomUUID } from 'node:crypto';
 import { promisify } from 'node:util';
 
 import { agentProjectPath } from '../agent/agent-runtime.js';
-import { buildIndexTs, buildNangoYaml, getFilePaths } from '../remote-function/compiler-client.js';
+import { buildIndexTs, getFilePaths } from '../remote-function/compiler-client.js';
 
 import type { DryrunRequest, DryrunResult } from '../remote-function/dryrun-client.js';
 
 const execFileAsync = promisify(execFile);
 
-const localCompilerImage = process.env['LOCAL_COMPILER_IMAGE'] || 'nango-local-compiler';
+const localCompilerImage = process.env['LOCAL_COMPILER_IMAGE'] || 'agent-sandboxes/blank-workspace:local';
 const compileTimeoutMs = 3 * 60 * 1000;
 const dryrunTimeoutMs = 5 * 60 * 1000;
 
@@ -46,7 +46,6 @@ export async function invokeLocalDryrun(request: DryrunRequest): Promise<DryrunR
 
         await writeContainerFile(containerName, `${agentProjectPath}/${tsFilePath}`, request.code);
         await writeContainerFile(containerName, `${agentProjectPath}/index.ts`, buildIndexTs(request));
-        await writeContainerFile(containerName, `${agentProjectPath}/nango.yaml`, buildNangoYaml(request));
 
         // Compile first
         try {
@@ -87,7 +86,16 @@ export async function invokeLocalDryrun(request: DryrunRequest): Promise<DryrunR
 }
 
 function buildDryrunCommand(request: DryrunRequest): string {
-    const parts = ['nango', 'dryrun', request.function_name, request.connection_id, `--integration-id ${request.integration_id}`, '--auto-confirm'];
+    const parts = [
+        'nango',
+        'dryrun',
+        request.function_name,
+        request.connection_id,
+        `--environment ${request.environment_name}`,
+        `--integration-id ${request.integration_id}`,
+        '--auto-confirm',
+        '--no-interactive'
+    ];
 
     if (request.input !== undefined) {
         parts.push('--input @/tmp/nango-dryrun-input.json');

--- a/packages/server/lib/services/remote-function/compiler-client.ts
+++ b/packages/server/lib/services/remote-function/compiler-client.ts
@@ -1,17 +1,14 @@
 import { randomUUID } from 'node:crypto';
-import { mkdir, rm, writeFile } from 'node:fs/promises';
-import { tmpdir } from 'node:os';
 import path from 'node:path';
 
 import { CommandExitError, Sandbox } from 'e2b';
 
-import { loadNangoYaml } from '@nangohq/nango-yaml';
 import { isLocal } from '@nangohq/utils';
 
 import { agentProjectPath } from '../agent/agent-runtime.js';
 import { invokeLocalCompiler } from '../local/compiler-client.js';
 
-import type { CLIDeployFlowConfig, ParsedNangoAction, ParsedNangoSync } from '@nangohq/types';
+import type { CLIDeployFlowConfig, FlowsZeroJson, ParsedNangoAction, ParsedNangoSync } from '@nangohq/types';
 
 export interface CompileRequest {
     integration_id: string;
@@ -40,21 +37,24 @@ export class CompilerError extends Error {
 }
 
 const compilerTimeoutMs = 3 * 60 * 1000;
+const compilerTemplate = 'blank-workspace:staging';
 
 export async function invokeCompiler(request: CompileRequest): Promise<CompileResult> {
     if (isLocal) {
         return invokeLocalCompiler(request);
     }
 
-    if (!process.env['SANDBOX_API_KEY']) {
-        throw new Error('SANDBOX_API_KEY is required for the E2B compiler runtime');
+    const apiKey = process.env['E2B_API_KEY'];
+    if (!apiKey) {
+        throw new Error('E2B_API_KEY is required for the E2B compiler runtime');
     }
 
-    const sandbox = await Sandbox.create(process.env['SANDBOX_COMPILER_TEMPLATE'] || 'nango-sf-compiler', {
+    const sandbox = await Sandbox.create(compilerTemplate, {
         timeoutMs: compilerTimeoutMs,
         allowInternetAccess: true,
         metadata: { purpose: 'nango-compiler', requestId: randomUUID() },
-        network: { allowPublicTraffic: true }
+        network: { allowPublicTraffic: true },
+        apiKey
     });
 
     try {
@@ -62,7 +62,6 @@ export async function invokeCompiler(request: CompileRequest): Promise<CompileRe
 
         await sandbox.files.write(path.join(agentProjectPath, tsFilePath), request.code);
         await sandbox.files.write(path.join(agentProjectPath, 'index.ts'), buildIndexTs(request));
-        await sandbox.files.write(path.join(agentProjectPath, 'nango.yaml'), buildNangoYaml(request));
 
         try {
             await sandbox.commands.run('nango compile', {
@@ -77,13 +76,13 @@ export async function invokeCompiler(request: CompileRequest): Promise<CompileRe
             throw err;
         }
 
-        const [bundledJs, yamlContent] = await Promise.all([
+        const [bundledJs, nangoJson] = await Promise.all([
             sandbox.files.read(path.join(agentProjectPath, cjsFilePath)),
-            sandbox.files.read(path.join(agentProjectPath, 'nango.yaml'))
+            sandbox.files.read(path.join(agentProjectPath, '.nango', 'nango.json'))
         ]);
 
         const bundledJsStr = String(bundledJs);
-        const flow = await buildFlowConfig(String(yamlContent), request, bundledJsStr);
+        const flow = buildFlowConfig(String(nangoJson), request, bundledJsStr);
         return {
             bundledJs: bundledJsStr,
             bundleSizeBytes: Buffer.byteLength(bundledJsStr, 'utf8'),
@@ -116,40 +115,17 @@ export function buildIndexTs(request: Pick<CompileRequest, 'integration_id' | 'f
 }
 
 /**
- * Minimal nango.yaml so that `nango compile` has a valid project definition.
- * The agent is expected to have written a more complete yaml; this is a fallback
- * for cases where the compile endpoint is called without one in the sandbox.
+ * Parse .nango/nango.json content (from sandbox) and build the CLIDeployFlowConfig the deploy endpoint needs.
  */
-export function buildNangoYaml(request: Pick<CompileRequest, 'integration_id' | 'function_name' | 'function_type'>): string {
-    if (request.function_type === 'action') {
-        return `integrations:\n  - providerConfigKey: ${request.integration_id}\n    actions:\n      - name: ${request.function_name}\n`;
-    }
-    return `integrations:\n  - providerConfigKey: ${request.integration_id}\n    syncs:\n      - name: ${request.function_name}\n        runs: every 30min\n`;
-}
+export function buildFlowConfig(nangoJsonContent: string, request: CompileRequest, bundledJs: string): CLIDeployFlowConfig {
+    const integrations = JSON.parse(nangoJsonContent) as FlowsZeroJson;
+    const integration = integrations.find((i) => i.providerConfigKey === request.integration_id);
+    const scriptDef =
+        request.function_type === 'action'
+            ? integration?.actions.find((a) => a.name === request.function_name)
+            : integration?.syncs.find((s) => s.name === request.function_name);
 
-/**
- * Parse nango.yaml content (from sandbox) and build the CLIDeployFlowConfig the deploy endpoint needs.
- * Writes to a temp dir so loadNangoYaml can read it from disk.
- */
-export async function buildFlowConfig(yamlContent: string, request: CompileRequest, bundledJs: string): Promise<CLIDeployFlowConfig> {
-    const tempDir = path.join(tmpdir(), `nango-compile-${randomUUID()}`);
-    try {
-        await mkdir(tempDir, { recursive: true });
-        await writeFile(path.join(tempDir, 'nango.yaml'), yamlContent, 'utf8');
-
-        const parser = loadNangoYaml({ fullPath: tempDir });
-        parser.parse();
-
-        const integration = parser.parsed?.integrations.find((i) => i.providerConfigKey === request.integration_id);
-        const scriptDef =
-            request.function_type === 'action'
-                ? integration?.actions.find((a) => a.name === request.function_name)
-                : integration?.syncs.find((s) => s.name === request.function_name);
-
-        return buildFlowFromDef(scriptDef, request, bundledJs);
-    } finally {
-        await rm(tempDir, { recursive: true, force: true });
-    }
+    return buildFlowFromDef(scriptDef, request, bundledJs);
 }
 
 export function buildFlowFromDef(scriptDef: ParsedNangoSync | ParsedNangoAction | undefined, request: CompileRequest, bundledJs: string): CLIDeployFlowConfig {

--- a/packages/server/lib/services/remote-function/compiler-client.unit.test.ts
+++ b/packages/server/lib/services/remote-function/compiler-client.unit.test.ts
@@ -1,0 +1,115 @@
+import { describe, expect, it } from 'vitest';
+
+import { buildFlowConfig } from './compiler-client.js';
+
+import type { FlowsZeroJson } from '@nangohq/types';
+
+describe('buildFlowConfig', () => {
+    it('builds an action flow from zero-yaml nango.json output', () => {
+        const flows: FlowsZeroJson = [
+            {
+                providerConfigKey: 'github',
+                sdkVersion: '0.0.0',
+                actions: [
+                    {
+                        name: 'smokeTest',
+                        type: 'action',
+                        description: 'Smoke test action',
+                        input: 'SmokeInput',
+                        output: ['SmokeOutput'],
+                        endpoint: { method: 'POST', path: '/smoke', group: 'Smoke' },
+                        scopes: [],
+                        usedModels: ['SmokeInput', 'SmokeOutput'],
+                        version: '1.0.0',
+                        json_schema: { definitions: {} },
+                        features: []
+                    }
+                ],
+                syncs: [],
+                onEventScripts: {
+                    'post-connection-creation': [],
+                    'pre-connection-deletion': [],
+                    'validate-connection': []
+                }
+            }
+        ];
+
+        const flow = buildFlowConfig(
+            JSON.stringify(flows),
+            {
+                integration_id: 'github',
+                function_name: 'smokeTest',
+                function_type: 'action',
+                code: ''
+            },
+            'module.exports = {};'
+        );
+
+        expect(flow).toMatchObject({
+            type: 'action',
+            syncName: 'smokeTest',
+            providerConfigKey: 'github',
+            input: 'SmokeInput',
+            models: ['SmokeOutput'],
+            endpoints: [{ method: 'POST', path: '/smoke', group: 'Smoke' }]
+        });
+    });
+
+    it('builds a sync flow from zero-yaml nango.json output', () => {
+        const flows: FlowsZeroJson = [
+            {
+                providerConfigKey: 'github',
+                sdkVersion: '0.0.0',
+                actions: [],
+                syncs: [
+                    {
+                        name: 'syncIssues',
+                        type: 'sync',
+                        description: 'Sync issues',
+                        endpoints: [{ method: 'GET', path: '/issues', group: 'Issues' }],
+                        sync_type: 'incremental',
+                        track_deletes: true,
+                        auto_start: false,
+                        runs: 'every 30min',
+                        scopes: [],
+                        input: null,
+                        output: ['Issue'],
+                        usedModels: ['Issue'],
+                        webhookSubscriptions: ['issues'],
+                        version: '1.0.0',
+                        json_schema: { definitions: {} },
+                        features: []
+                    }
+                ],
+                onEventScripts: {
+                    'post-connection-creation': [],
+                    'pre-connection-deletion': [],
+                    'validate-connection': []
+                }
+            }
+        ];
+
+        const flow = buildFlowConfig(
+            JSON.stringify(flows),
+            {
+                integration_id: 'github',
+                function_name: 'syncIssues',
+                function_type: 'sync',
+                code: ''
+            },
+            'module.exports = {};'
+        );
+
+        expect(flow).toMatchObject({
+            type: 'sync',
+            syncName: 'syncIssues',
+            providerConfigKey: 'github',
+            models: ['Issue'],
+            runs: 'every 30min',
+            track_deletes: true,
+            auto_start: false,
+            endpoints: [{ method: 'GET', path: '/issues', group: 'Issues' }],
+            webhookSubscriptions: ['issues']
+        });
+    });
+});

--- a/packages/server/lib/services/remote-function/deploy-client.ts
+++ b/packages/server/lib/services/remote-function/deploy-client.ts
@@ -4,7 +4,7 @@ import { CommandExitError, Sandbox } from 'e2b';
 
 import { isLocal } from '@nangohq/utils';
 
-import { buildIndexTs, buildNangoYaml, getFilePaths } from './compiler-client.js';
+import { buildIndexTs, getFilePaths } from './compiler-client.js';
 import { agentProjectPath } from '../agent/agent-runtime.js';
 import { invokeLocalDeploy } from '../local/deploy-client.js';
 
@@ -13,6 +13,7 @@ export interface DeployRequest {
     function_name: string;
     function_type: 'action' | 'sync';
     code: string;
+    environment_name: string;
     nango_secret_key: string;
     nango_host: string;
 }
@@ -22,21 +23,24 @@ export interface DeployResult {
 }
 
 const deployTimeoutMs = 5 * 60 * 1000;
+const compilerTemplate = 'blank-workspace:staging';
 
 export async function invokeDeploy(request: DeployRequest): Promise<DeployResult> {
     if (isLocal) {
         return invokeLocalDeploy(request);
     }
 
-    if (!process.env['SANDBOX_API_KEY']) {
-        throw new Error('SANDBOX_API_KEY is required for the E2B deploy runtime');
+    const apiKey = process.env['E2B_API_KEY'];
+    if (!apiKey) {
+        throw new Error('E2B_API_KEY is required for the E2B deploy runtime');
     }
 
-    const sandbox = await Sandbox.create(process.env['SANDBOX_COMPILER_TEMPLATE'] || 'nango-sf-compiler', {
+    const sandbox = await Sandbox.create(compilerTemplate, {
         timeoutMs: deployTimeoutMs,
         allowInternetAccess: true,
         metadata: { purpose: 'nango-deploy', requestId: randomUUID() },
-        network: { allowPublicTraffic: true }
+        network: { allowPublicTraffic: true },
+        apiKey
     });
 
     try {
@@ -44,7 +48,6 @@ export async function invokeDeploy(request: DeployRequest): Promise<DeployResult
 
         await sandbox.files.write(`${agentProjectPath}/${tsFilePath}`, request.code);
         await sandbox.files.write(`${agentProjectPath}/index.ts`, buildIndexTs(request));
-        await sandbox.files.write(`${agentProjectPath}/nango.yaml`, buildNangoYaml(request));
 
         const cmd = buildDeployCommand(request);
         const envs = {
@@ -78,5 +81,5 @@ export async function invokeDeploy(request: DeployRequest): Promise<DeployResult
 
 function buildDeployCommand(request: DeployRequest): string {
     const typeFlag = request.function_type === 'action' ? `--action ${request.function_name}` : `--sync ${request.function_name}`;
-    return `nango deploy ${typeFlag} --auto-confirm --allow-destructive`;
+    return `nango deploy ${request.environment_name} ${typeFlag} --auto-confirm --allow-destructive --no-interactive`;
 }

--- a/packages/server/lib/services/remote-function/dryrun-client.ts
+++ b/packages/server/lib/services/remote-function/dryrun-client.ts
@@ -4,7 +4,7 @@ import { CommandExitError, Sandbox } from 'e2b';
 
 import { isLocal } from '@nangohq/utils';
 
-import { buildIndexTs, buildNangoYaml, getFilePaths } from './compiler-client.js';
+import { buildIndexTs, getFilePaths } from './compiler-client.js';
 import { agentProjectPath } from '../agent/agent-runtime.js';
 import { invokeLocalDryrun } from '../local/dryrun-client.js';
 
@@ -13,6 +13,7 @@ export interface DryrunRequest {
     function_name: string;
     function_type: 'action' | 'sync';
     code: string;
+    environment_name: string;
     connection_id: string;
     nango_secret_key: string;
     nango_host: string;
@@ -28,21 +29,24 @@ export interface DryrunResult {
 
 const compileTimeoutMs = 3 * 60 * 1000;
 const dryrunTimeoutMs = 5 * 60 * 1000;
+const compilerTemplate = 'blank-workspace:staging';
 
 export async function invokeDryrun(request: DryrunRequest): Promise<DryrunResult> {
     if (isLocal) {
         return invokeLocalDryrun(request);
     }
 
-    if (!process.env['SANDBOX_API_KEY']) {
-        throw new Error('SANDBOX_API_KEY is required for the E2B dryrun runtime');
+    const apiKey = process.env['E2B_API_KEY'];
+    if (!apiKey) {
+        throw new Error('E2B_API_KEY is required for the E2B dryrun runtime');
     }
 
-    const sandbox = await Sandbox.create(process.env['SANDBOX_COMPILER_TEMPLATE'] || 'nango-sf-compiler', {
+    const sandbox = await Sandbox.create(compilerTemplate, {
         timeoutMs: dryrunTimeoutMs,
         allowInternetAccess: true,
         metadata: { purpose: 'nango-dryrun', requestId: randomUUID() },
-        network: { allowPublicTraffic: true }
+        network: { allowPublicTraffic: true },
+        apiKey
     });
 
     try {
@@ -50,7 +54,6 @@ export async function invokeDryrun(request: DryrunRequest): Promise<DryrunResult
 
         await sandbox.files.write(`${agentProjectPath}/${tsFilePath}`, request.code);
         await sandbox.files.write(`${agentProjectPath}/index.ts`, buildIndexTs(request));
-        await sandbox.files.write(`${agentProjectPath}/nango.yaml`, buildNangoYaml(request));
 
         // Compile first
         try {
@@ -107,7 +110,16 @@ export async function invokeDryrun(request: DryrunRequest): Promise<DryrunResult
 }
 
 function buildDryrunCommand(request: DryrunRequest): string {
-    const parts = ['nango', 'dryrun', request.function_name, request.connection_id, `--integration-id ${request.integration_id}`, '--auto-confirm'];
+    const parts = [
+        'nango',
+        'dryrun',
+        request.function_name,
+        request.connection_id,
+        `--environment ${request.environment_name}`,
+        `--integration-id ${request.integration_id}`,
+        '--auto-confirm',
+        '--no-interactive'
+    ];
 
     if (request.input !== undefined) {
         parts.push('--input @/tmp/nango-dryrun-input.json');

--- a/packages/utils/lib/environment/parse.ts
+++ b/packages/utils/lib/environment/parse.ts
@@ -509,8 +509,6 @@ export const ENVS = z.object({
     SANDBOX_COMPILER_TEMPLATE: z.string().optional(),
     SANDBOX_AGENT_TEMPLATE: z.string().optional(),
     AGENT_RUNTIME: z.enum(['e2b', 'local']).optional().default('local'),
-    LOCAL_AGENT_IMAGE: z.string().optional().default('agent-sandboxes/agent-workspace:local'),
-    LOCAL_COMPILER_IMAGE: z.string().optional().default('agent-sandboxes/blank-workspace:local'),
 
     // ----- Others
     SERVER_RUN_MODE: z.enum(['DOCKERIZED', '']).optional(),

--- a/packages/utils/lib/environment/parse.ts
+++ b/packages/utils/lib/environment/parse.ts
@@ -505,12 +505,12 @@ export const ENVS = z.object({
     NANGO_WEBHOOK_CIRCUIT_BREAKER_AUTO_RESET_SECS: z.coerce.number().optional().default(3600),
 
     // ----- Agent Builder
-    SANDBOX_API_KEY: z.string().optional(),
-    SANDBOX_COMPILER_TEMPLATE: z.string().optional().default('nango-sf-compiler'),
-    SANDBOX_AGENT_TEMPLATE: z.string().optional().default('nango-opencode-agent'),
+    E2B_API_KEY: z.string().optional(),
+    SANDBOX_COMPILER_TEMPLATE: z.string().optional(),
+    SANDBOX_AGENT_TEMPLATE: z.string().optional(),
     AGENT_RUNTIME: z.enum(['e2b', 'local']).optional().default('local'),
-    LOCAL_AGENT_IMAGE: z.string().optional().default('nango-local-agent'),
-    LOCAL_COMPILER_IMAGE: z.string().optional().default('nango-local-compiler'),
+    LOCAL_AGENT_IMAGE: z.string().optional().default('agent-sandboxes/agent-workspace:local'),
+    LOCAL_COMPILER_IMAGE: z.string().optional().default('agent-sandboxes/blank-workspace:local'),
 
     // ----- Others
     SERVER_RUN_MODE: z.enum(['DOCKERIZED', '']).optional(),

--- a/packages/utils/lib/environment/parse.unit.test.ts
+++ b/packages/utils/lib/environment/parse.unit.test.ts
@@ -19,6 +19,18 @@ describe('parse', () => {
         expect(res).toMatchObject({ NANGO_DB_SSL: false, NANGO_PERSIST_PORT: 3007 });
     });
 
+    it('should use the new local sandbox image defaults without defaulting E2B templates', () => {
+        const res = parseEnvs(ENVS, {});
+
+        expect(res).toMatchObject({
+            AGENT_RUNTIME: 'local',
+            LOCAL_AGENT_IMAGE: 'agent-sandboxes/agent-workspace:local',
+            LOCAL_COMPILER_IMAGE: 'agent-sandboxes/blank-workspace:local'
+        });
+        expect(res.SANDBOX_AGENT_TEMPLATE).toBeUndefined();
+        expect(res.SANDBOX_COMPILER_TEMPLATE).toBeUndefined();
+    });
+
     it('should coerce boolean and number', () => {
         const res = parseEnvs(ENVS, { NANGO_DB_SSL: 'true', NANGO_LOGS_ENABLED: 'false', NANGO_PERSIST_PORT: '3008' });
         expect(res).toMatchObject({ NANGO_DB_SSL: true, NANGO_PERSIST_PORT: 3008, NANGO_LOGS_ENABLED: false, NANGO_CLOUD: false, NANGO_CACHE_ENV_KEYS: false });

--- a/packages/utils/lib/environment/parse.unit.test.ts
+++ b/packages/utils/lib/environment/parse.unit.test.ts
@@ -19,13 +19,11 @@ describe('parse', () => {
         expect(res).toMatchObject({ NANGO_DB_SSL: false, NANGO_PERSIST_PORT: 3007 });
     });
 
-    it('should use the new local sandbox image defaults without defaulting E2B templates', () => {
+    it('should default to local runtime without defaulting sandbox templates', () => {
         const res = parseEnvs(ENVS, {});
 
         expect(res).toMatchObject({
-            AGENT_RUNTIME: 'local',
-            LOCAL_AGENT_IMAGE: 'agent-sandboxes/agent-workspace:local',
-            LOCAL_COMPILER_IMAGE: 'agent-sandboxes/blank-workspace:local'
+            AGENT_RUNTIME: 'local'
         });
         expect(res.SANDBOX_AGENT_TEMPLATE).toBeUndefined();
         expect(res.SANDBOX_COMPILER_TEMPLATE).toBeUndefined();


### PR DESCRIPTION
<!-- Describe the problem and your solution -->
Fix sandbox startup and runtime wiring for the new local Docker and E2B stack. Local agent sandboxes now keep the container alive explicitly, local compile/dryrun/deploy use the new sandbox images and Zero-YAML artifacts, and E2B agent/compiler/dryrun/deploy now use `E2B_API_KEY` with the current staging template names hardcoded. This also updates env parsing/examples and adds a minimal README quickstart for spawning local sandbox images.

<!-- Issue ticket number and link (if applicable) -->

<!-- Testing instructions (skip if just adding/editing providers) -->
`npm run test:unit -- packages/utils/lib/environment/parse.unit.test.ts packages/server/lib/services/remote-function/compiler-client.unit.test.ts`
`npm run ts-build`
Manual: local agent start, local compile, local dryrun, E2B agent spawn, E2B blank-workspace spawn

<!-- Summary by @propel-code-bot -->

---

In addition to the stack migration, this change also standardizes runtime execution behavior by making deploy/dryrun invocation semantics more deterministic across environments and tying execution explicitly to selected environment context. It further formalizes the operational shift to the new artifact-driven flow model, which improves consistency of compile outputs but also increases dependency on correct artifact presence and runtime configuration alignment.

---
*This summary was automatically generated by @propel-code-bot*