### PR TITLE
fix(auto-approve): add trusted author

### DIFF
--- a/.github/workflows/auto-approve-docs.yml
+++ b/.github/workflows/auto-approve-docs.yml
@@ -10,15 +10,48 @@ permissions:
 jobs:
     auto-approve:
         runs-on: ubuntu-latest
-        # Only run for trusted authors, blocks external contributors
-        if: >-
-            contains(fromJSON('["OWNER","MEMBER","COLLABORATOR","CONTRIBUTOR"]'),
-            github.event.pull_request.author_association)
         steps:
+            - name: Check if trusted author
+              id: trust_check
+              uses: actions/github-script@v7
+              with:
+                  script: |
+                      const login = context.payload.pull_request.user.login;
+                      const type = context.payload.pull_request.user.type;
+                      const org = context.repo.owner;
+
+                      // Trusted app
+                      if (type === 'Bot' && login === 'mintlify[bot]') return true;
+
+                      // Collaborators (write and admin)
+                      try {
+                        const { data } = await github.rest.repos.getCollaboratorPermissionLevel({
+                          owner: org,
+                          repo: context.repo.repo,
+                          username: login,
+                        });
+                        if (['write', 'admin'].includes(data.permission)) return true;
+                      } catch (err) { if (err.status !== 404) throw err; }
+
+                      // Engineers team
+                      try {
+                        const { data: teamMembership } = await github.rest.teams.getMembershipForUserInOrg({
+                          org,
+                          team_slug: 'engineers',
+                          username: login,
+                        });
+                        if (teamMembership.state === 'active') return true;
+                      } catch (err) { if (err.status !== 404) throw err; }
+
+                      return false;
+                  result-encoding: string
+
             - name: Checkout
+              if: steps.trust_check.outputs.result == 'true'
               uses: actions/checkout@v4
 
             - name: Check changed paths
+              if: steps.trust_check.outputs.result == 'true'
               uses: dorny/paths-filter@v4
               id: filter
               with:
@@ -29,6 +62,7 @@ jobs:
                           - '!docs/**'
 
             - name: Generate GitHub App token
+              if: steps.trust_check.outputs.result == 'true'
               id: app-token
               uses: actions/create-github-app-token@v1
               with:
@@ -36,7 +70,7 @@ jobs:
                   private-key: ${{ secrets.GH_APP_PUSHER_PRIVATE_KEY }}
 
             - name: Approve PR
-              if: steps.filter.outputs.non_docs == 'false'
+              if: steps.trust_check.outputs.result == 'true' && steps.filter.outputs.non_docs == 'false'
               uses: hmarr/auto-approve-action@v4
               with:
                   github-token: ${{ steps.app-token.outputs.token }}

--- a/.github/workflows/auto-approve-docs.yml
+++ b/.github/workflows/auto-approve-docs.yml
@@ -12,7 +12,7 @@ jobs:
         runs-on: ubuntu-latest
         # Only run for trusted authors, blocks external contributors
         if: >-
-            contains(fromJSON('["OWNER","MEMBER","COLLABORATOR"]'),
+            contains(fromJSON('["OWNER","MEMBER","COLLABORATOR","CONTRIBUTOR"]'),
             github.event.pull_request.author_association)
         steps:
             - name: Checkout

--- a/.github/workflows/auto-approve-docs.yml
+++ b/.github/workflows/auto-approve-docs.yml
@@ -21,16 +21,22 @@ jobs:
                       const org = context.repo.owner;
 
                       // Trusted app
-                      if (type === 'Bot' && login === 'mintlify[bot]') return true;
+                      if (type === 'Bot' && login === 'mintlify[bot]') {
+                        console.log(`Trusted: bot ${login}`);
+                        return true;
+                      }
 
                       // Collaborators (write and admin)
                       try {
                         const { data } = await github.rest.repos.getCollaboratorPermissionLevel({
-                          owner: org,
+                          owner: context.repo.owner,
                           repo: context.repo.repo,
                           username: login,
                         });
-                        if (['write', 'admin'].includes(data.permission)) return true;
+                        if (['write', 'admin'].includes(data.permission)) {
+                          console.log(`Trusted: collaborator ${login} (${data.permission})`);
+                          return true;
+                        }
                       } catch (err) { if (err.status !== 404) throw err; }
 
                       // Engineers team
@@ -40,9 +46,13 @@ jobs:
                           team_slug: 'engineers',
                           username: login,
                         });
-                        if (teamMembership.state === 'active') return true;
+                        if (teamMembership.state === 'active') {
+                          console.log(`Trusted: engineers team member ${login}`);
+                          return true;
+                        }
                       } catch (err) { if (err.status !== 404) throw err; }
 
+                      console.log(`Not trusted: ${login}`);
                       return false;
                   result-encoding: string
 


### PR DESCRIPTION
<!-- Summary by @propel-code-bot -->

**Harden docs auto-approval workflow with explicit trusted-author checks**

This PR updates `.github/workflows/auto-approve-docs.yml` to replace a broad job-level `author_association` gate with an explicit trust evaluation step using `actions/github-script@v7`. Trust is now determined by runtime checks: `mintlify[bot]`, repository collaborator permission level (`write` or `admin`), or active membership in the `engineers` team.

It also gates downstream steps (`Checkout`, `dorny/paths-filter`, token generation, and approval) on `steps.trust_check.outputs.result == 'true'`, and keeps auto-approval constrained to docs-only changes via `steps.filter.outputs.non_docs == 'false'`. The workflow includes improved logging for trusted/untrusted decisions and updates error handling to rethrow non-`404` API failures.

---
*This summary was automatically generated by @propel-code-bot*