### PR TITLE
fix: improve error message on records lock timeout

### DIFF
--- a/packages/persist/lib/records.ts
+++ b/packages/persist/lib/records.ts
@@ -97,7 +97,7 @@ export async function persistRecords({
     });
 
     if (formatting.isErr()) {
-        void logCtx.error('There was an issue with the batch', { error: formatting.error, persistType });
+        void logCtx.error('Failed to persist records', { error: formatting.error, persistType });
         const err = new Error(`Failed to ${persistType} records ${activityLogId}`);
 
         span.setTag('error', err).finish();
@@ -229,11 +229,9 @@ export async function persistRecords({
 
         return Ok(persistResult.value.nextMerging);
     } else {
-        const content = `There was an issue with the batch ${persistType}. ${stringifyError(persistResult.error)}`;
+        void logCtx.error('Failed to persist records', { error: persistResult.error, persistType });
 
-        void logCtx.error('There was an issue with the batch', { error: persistResult.error, persistType });
-
-        errorManager.report(content, {
+        errorManager.report(`There was an issue with the batch${persistType}. ${stringifyError(persistResult.error)}`, {
             environmentId: environment.id,
             source: ErrorSourceEnum.CUSTOMER,
             operation: LogActionEnum.SYNC,

--- a/packages/records/lib/models/records.ts
+++ b/packages/records/lib/models/records.ts
@@ -31,6 +31,16 @@ dayjs.extend(utc);
 
 const BATCH_SIZE = envs.RECORDS_BATCH_SIZE;
 
+class LockError extends Error {}
+
+async function acquireAdvisoryLock(trx: Knex.Transaction, { name, connectionId, model }: { name: string; connectionId: number; model: string }): Promise<void> {
+    try {
+        await trx.raw(`SELECT pg_advisory_xact_lock(?) as ${name}`, [newLockId(connectionId, model)]);
+    } catch {
+        throw new LockError(`Failed to acquire lock for model ${model} (connection ${connectionId}). Another operation may be in progress. Please retry.`);
+    }
+}
+
 interface UpsertedMetadata {
     partition: string;
     external_id: string;
@@ -332,7 +342,7 @@ export async function upsert({
             () => {
                 return db.transaction(async (trx) => {
                     // Lock to prevent concurrent upserts
-                    await trx.raw(`SELECT pg_advisory_xact_lock(?) as lock_records_${softDelete ? 'delete' : 'upsert'}`, [newLockId(connectionId, model)]);
+                    await acquireAdvisoryLock(trx, { name: `lock_records_${softDelete ? 'delete' : 'upsert'}`, connectionId, model });
 
                     const summary: UpsertSummary = {
                         addedKeys: [],
@@ -557,9 +567,11 @@ export async function upsert({
             }
         );
     } catch (err: any) {
-        let errorMessage = `Failed to upsert records to table ${RECORDS_TABLE}.\n`;
-        errorMessage += `Model: ${model}, Nango Connection ID: ${connectionId}.\n`;
-        errorMessage += `Attempted to insert/update/delete: ${recordsWithoutDuplicates.length} records\n`;
+        if (err instanceof LockError) {
+            span.setTag('error', err);
+            return Err(err);
+        }
+        let errorMessage = `Failed to upsert ${recordsWithoutDuplicates.length} records. (connectionId: ${connectionId}, model: ${model})\n`;
 
         if ('code' in err) {
             const errorCode = (err as { code: string }).code;
@@ -616,7 +628,8 @@ export async function update({
         const activatedKeys: string[] = [];
         await db.transaction(async (trx) => {
             // Lock to prevent concurrent updates
-            await trx.raw(`SELECT pg_advisory_xact_lock(?) as lock_records_update`, [newLockId(connectionId, model)]);
+            await acquireAdvisoryLock(trx, { name: 'lock_records_update', connectionId, model });
+
             let deltaSizeInBytes = 0;
             for (let i = 0; i < recordsWithoutDuplicates.length; i += BATCH_SIZE) {
                 const chunk = recordsWithoutDuplicates.slice(i, i + BATCH_SIZE);
@@ -781,9 +794,11 @@ export async function update({
             unchangedKeys: []
         });
     } catch (err: any) {
-        let errorMessage = `Failed to update records to table ${RECORDS_TABLE}.\n`;
-        errorMessage += `Model: ${model}, Nango Connection ID: ${connectionId}.\n`;
-        errorMessage += `Attempted to update: ${recordsWithoutDuplicates.length} records\n`;
+        if (err instanceof LockError) {
+            span.setTag('error', err);
+            return Err(err);
+        }
+        let errorMessage = `Failed to update ${recordsWithoutDuplicates.length} records. (connectionId: ${connectionId}, model: ${model})\n`;
 
         if ('code' in err) errorMessage += `Error code: ${(err as { code: string }).code}.\n`;
         if ('detail' in err) errorMessage += `Detail: ${(err as { detail: string }).detail}.\n`;
@@ -863,7 +878,7 @@ export async function deleteRecords({
             const now = trx.fn.now(6);
             // Lock to prevent concurrent deletions (skip lock if dry run)
             if (!dryRun) {
-                await trx.raw(`SELECT pg_advisory_xact_lock(?) as lock_records_delete`, [newLockId(connectionId, model)]);
+                await acquireAdvisoryLock(trx, { name: 'lock_records_delete', connectionId, model });
             }
 
             do {
@@ -1000,6 +1015,10 @@ export async function deleteRecords({
 
         return Ok({ count: totalRecords, lastCursor });
     } catch (err) {
+        if (err instanceof LockError) {
+            span.setTag('error', err);
+            return Err(err);
+        }
         span.setTag('error', err);
         return Err(new Error(`Failed to delete records connection ${connectionId}, model ${model}`, { cause: err }));
     } finally {
@@ -1042,7 +1061,7 @@ export async function deleteOutdatedRecords({
                 () => {
                     return db.transaction(async (trx) => {
                         // Lock to prevent concurrent modifications with upserts and deletes
-                        await trx.raw(`SELECT pg_advisory_xact_lock(?) as lock_records_outdated`, [newLockId(connectionId, model)]);
+                        await acquireAdvisoryLock(trx, { name: 'lock_records_outdated', connectionId, model });
 
                         const res: {
                             id: string;
@@ -1139,6 +1158,10 @@ export async function deleteOutdatedRecords({
         }
         return Ok(deletedIds);
     } catch (err) {
+        if (err instanceof LockError) {
+            span.setTag('error', err);
+            return Err(err);
+        }
         const e = new Error(`Failed to mark previous generation records as deleted for connection ${connectionId}, model ${model}, generation ${generation}`, {
             cause: err
         });
@@ -1402,7 +1425,7 @@ async function getRecordsToUpdate({
         .whereNotIn([`${RECORDS_TABLE}.external_id`, `${RECORDS_TABLE}.data_hash`], keysWithHash);
 }
 
-function newLockId(connectionId: number, model: string): bigint {
+export function newLockId(connectionId: number, model: string): bigint {
     // convert modelHash to unsigned 32-bit integer to ensure
     // negative hash values don't cause sign extension problems
     // when combined with connectionId in the bitwise OR operation


### PR DESCRIPTION
Improve error message reported to user when records lock acquisition times out. (For example, if deletion of records is ongoing and upsert lock acquisition times out)

<img width="836" height="502" alt="Screenshot 2026-04-03 at 11 21 09" src="https://github.com/user-attachments/assets/09f06947-2881-4412-a3f9-3485c9679071" />

<!-- Summary by @propel-code-bot -->

---

**Improve `records` lock-timeout error propagation and user-facing messaging**

This PR standardizes how advisory lock acquisition failures are handled in the `records` model layer and ensures those failures surface as a specific, user-readable error instead of being wrapped in generic persistence errors. A new `LockError` path was introduced around `pg_advisory_xact_lock` usage and then explicitly propagated through `upsert`, `update`, `deleteRecords`, and `deleteOutdatedRecords` catch blocks.

In the persist layer, logging text was normalized to `Failed to persist records`, and failure reporting now includes the propagated lock error content so timeout/lock contention scenarios (e.g., concurrent delete/upsert) produce clearer feedback. The PR is focused on error clarity and handling behavior rather than functional record-processing changes.

---
*This summary was automatically generated by @propel-code-bot*