### PR TITLE
feat: redact connection credentials instead of deleting them

### DIFF
--- a/packages/server/lib/authz/authz.integration.test.ts
+++ b/packages/server/lib/authz/authz.integration.test.ts
@@ -347,7 +347,7 @@ describe('authz integration', () => {
 
             expect(res.res.status).toBe(200);
             const connection = (res.json as any).data.connection;
-            expect(connection.credentials).toEqual({});
+            expect(connection.credentials).toEqual({ type: 'API_KEY', apiKey: 'REDACTED' });
         });
 
         it('should strip secret_key from prod environment response', async () => {

--- a/packages/server/lib/formatters/connection.ts
+++ b/packages/server/lib/formatters/connection.ts
@@ -42,7 +42,7 @@ export function connectionFullToApi(connection: DBConnectionDecrypted, options?:
         connection_id: connection.connection_id,
         provider_config_key: connection.provider_config_key,
         connection_config: connection.connection_config,
-        credentials: options?.includeCredentials ? connection.credentials : ({} as DBConnectionDecrypted['credentials']),
+        credentials: options?.includeCredentials ? connection.credentials : redactCredentials(connection.credentials),
         metadata: connection.metadata,
         tags: connection.tags,
         last_fetched_at: connection.last_fetched_at ? String(connection.last_fetched_at) : null,
@@ -110,4 +110,31 @@ export function connectionFullToPublicApi({
             : null,
         credentials: data.credentials
     };
+}
+
+const NON_SENSITIVE_KEYS = new Set(['type', 'expires_at']);
+
+function redactValue(value: unknown): unknown {
+    if (value === null || value === undefined) {
+        return value;
+    }
+    if (Array.isArray(value)) {
+        return value.map(redactValue);
+    }
+    if (typeof value === 'object') {
+        return redactObject(value as Record<string, unknown>);
+    }
+    return 'REDACTED';
+}
+
+function redactObject(obj: Record<string, unknown>): Record<string, unknown> {
+    const result: Record<string, unknown> = {};
+    for (const [key, value] of Object.entries(obj)) {
+        result[key] = NON_SENSITIVE_KEYS.has(key) ? value : redactValue(value);
+    }
+    return result;
+}
+
+function redactCredentials(credentials: DBConnectionDecrypted['credentials']): DBConnectionDecrypted['credentials'] {
+    return redactObject(credentials as Record<string, unknown>) as DBConnectionDecrypted['credentials'];
 }

--- a/packages/server/lib/formatters/connection.ts
+++ b/packages/server/lib/formatters/connection.ts
@@ -135,6 +135,6 @@ function redactObject(obj: Record<string, unknown>): Record<string, unknown> {
     return result;
 }
 
-function redactCredentials(credentials: DBConnectionDecrypted['credentials']): DBConnectionDecrypted['credentials'] {
+export function redactCredentials(credentials: DBConnectionDecrypted['credentials']): DBConnectionDecrypted['credentials'] {
     return redactObject(credentials as Record<string, unknown>) as DBConnectionDecrypted['credentials'];
 }

--- a/packages/server/lib/formatters/connection.unit.test.ts
+++ b/packages/server/lib/formatters/connection.unit.test.ts
@@ -1,0 +1,117 @@
+import { describe, expect, it } from 'vitest';
+
+import { redactCredentials } from './connection.js';
+
+describe('redactCredentials', () => {
+    it('keeps type and redacts secret fields for ApiKeyCredentials', () => {
+        const result = redactCredentials({ type: 'API_KEY', apiKey: 'secret-key' });
+        expect(result).toEqual({ type: 'API_KEY', apiKey: 'REDACTED' });
+    });
+
+    it('keeps type and redacts secret fields for BasicApiCredentials', () => {
+        const result = redactCredentials({ type: 'BASIC', username: 'user', password: 'pass' });
+        expect(result).toEqual({ type: 'BASIC', username: 'REDACTED', password: 'REDACTED' });
+    });
+
+    it('keeps type and expires_at, redacts tokens and raw for OAuth2Credentials', () => {
+        const expiresAt = new Date('2025-01-01');
+        const result = redactCredentials({
+            type: 'OAUTH2',
+            access_token: 'at',
+            refresh_token: 'rt',
+            expires_at: expiresAt,
+            raw: { access_token: 'at', expires_in: 3600 }
+        });
+        expect(result).toEqual({
+            type: 'OAUTH2',
+            access_token: 'REDACTED',
+            refresh_token: 'REDACTED',
+            expires_at: expiresAt,
+            raw: { access_token: 'REDACTED', expires_in: 'REDACTED' }
+        });
+    });
+
+    it('redacts nested config_override for OAuth2ClientCredentials', () => {
+        const result = redactCredentials({
+            type: 'OAUTH2_CC',
+            token: 'tok',
+            client_id: 'cid',
+            client_secret: 'csecret',
+            client_certificate: 'cert',
+            raw: {}
+        });
+        expect(result).toEqual({
+            type: 'OAUTH2_CC',
+            token: 'REDACTED',
+            client_id: 'REDACTED',
+            client_secret: 'REDACTED',
+            client_certificate: 'REDACTED',
+            raw: {}
+        });
+    });
+
+    it('redacts TbaCredentials including nested config_override', () => {
+        const result = redactCredentials({
+            type: 'TBA',
+            token_id: 'tid',
+            token_secret: 'tsecret',
+            config_override: { client_id: 'cid', client_secret: 'csecret' }
+        });
+        expect(result).toEqual({
+            type: 'TBA',
+            token_id: 'REDACTED',
+            token_secret: 'REDACTED',
+            config_override: { client_id: 'REDACTED', client_secret: 'REDACTED' }
+        });
+    });
+
+    it('redacts deeply nested objects for CombinedOauth2AppCredentials', () => {
+        const expiresAt = new Date('2025-01-01');
+        const result = redactCredentials({
+            type: 'CUSTOM',
+            app: { type: 'APP', access_token: 'at', raw: { token: 'raw_token' } },
+            user: { type: 'OAUTH2', access_token: 'uat', expires_at: expiresAt, raw: {} },
+            raw: {}
+        });
+        expect(result).toEqual({
+            type: 'CUSTOM',
+            app: { type: 'APP', access_token: 'REDACTED', raw: { token: 'REDACTED' } },
+            user: { type: 'OAUTH2', access_token: 'REDACTED', expires_at: expiresAt, raw: {} },
+            raw: {}
+        });
+    });
+
+    it('passes through null and undefined values', () => {
+        const result = redactCredentials({
+            type: 'OAUTH2',
+            access_token: 'at',
+            refresh_token: undefined,
+            expires_at: undefined,
+            raw: { scope: null }
+        });
+        expect(result).toMatchObject({
+            type: 'OAUTH2',
+            access_token: 'REDACTED',
+            refresh_token: undefined,
+            raw: { scope: null }
+        });
+    });
+
+    it('handles arrays inside raw', () => {
+        const result = redactCredentials({
+            type: 'OAUTH2',
+            access_token: 'at',
+            raw: { scopes: ['read', 'write'] }
+        });
+        expect(result).toEqual({
+            type: 'OAUTH2',
+            access_token: 'REDACTED',
+            raw: { scopes: ['REDACTED', 'REDACTED'] }
+        });
+    });
+
+    it('handles empty UnauthCredentials', () => {
+        const result = redactCredentials({} as any);
+        expect(result).toEqual({});
+    });
+});

--- a/packages/webapp/src/pages/Connection/components/AuthCredentials/JwtCredentials.tsx
+++ b/packages/webapp/src/pages/Connection/components/AuthCredentials/JwtCredentials.tsx
@@ -1,5 +1,6 @@
 import { RefreshCwIcon } from 'lucide-react';
 
+import { PermissionGate } from '@/components-v2/PermissionGate';
 import { SecretInput } from '@/components-v2/SecretInput';
 import { Button } from '@/components-v2/ui/button';
 import { Label } from '@/components-v2/ui/label';
@@ -23,10 +24,14 @@ export const JwtCredentialsComponent: React.FC<{
                     <Label htmlFor="token">Token</Label>
                     <div className="flex gap-2 items-center">
                         <SecretInput id="token" value={credentials.token} disabled copy canRead={canRead} />
-                        <Button variant="secondary" size="sm" className="h-full" onClick={forceRefresh} loading={isRefreshing}>
-                            <RefreshCwIcon />
-                            Refresh
-                        </Button>
+                        <PermissionGate condition={canRead} asChild>
+                            {(allowed) => (
+                                <Button variant="secondary" size="sm" className="h-full" onClick={forceRefresh} loading={isRefreshing} disabled={!allowed}>
+                                    <RefreshCwIcon />
+                                    Refresh
+                                </Button>
+                            )}
+                        </PermissionGate>
                     </div>
                 </div>
             )}

--- a/packages/webapp/src/pages/Connection/components/AuthCredentials/OAuth2ClientCredentials.tsx
+++ b/packages/webapp/src/pages/Connection/components/AuthCredentials/OAuth2ClientCredentials.tsx
@@ -1,5 +1,6 @@
 import { RefreshCwIcon } from 'lucide-react';
 
+import { PermissionGate } from '@/components-v2/PermissionGate';
 import { SecretInput } from '@/components-v2/SecretInput';
 import { Button } from '@/components-v2/ui/button';
 import { Label } from '@/components-v2/ui/label';
@@ -21,10 +22,14 @@ export const OAuth2ClientCredentialsComponent: React.FC<{
                 <Label htmlFor="token">Token</Label>
                 <div className="flex gap-2 items-center">
                     <SecretInput id="token" value={credentials.token} disabled copy canRead={canRead} />
-                    <Button variant="secondary" size="sm" className="h-full" onClick={forceRefresh} loading={isRefreshing}>
-                        <RefreshCwIcon />
-                        Refresh
-                    </Button>
+                    <PermissionGate condition={canRead} asChild>
+                        {(allowed) => (
+                            <Button variant="secondary" size="sm" className="h-full" onClick={forceRefresh} loading={isRefreshing} disabled={!allowed}>
+                                <RefreshCwIcon />
+                                Refresh
+                            </Button>
+                        )}
+                    </PermissionGate>
                 </div>
             </div>
 

--- a/packages/webapp/src/pages/Connection/components/AuthCredentials/OAuth2Credentials.tsx
+++ b/packages/webapp/src/pages/Connection/components/AuthCredentials/OAuth2Credentials.tsx
@@ -1,5 +1,6 @@
 import { RefreshCwIcon } from 'lucide-react';
 
+import { PermissionGate } from '@/components-v2/PermissionGate';
 import { SecretInput } from '@/components-v2/SecretInput';
 import { Button } from '@/components-v2/ui/button';
 import { Label } from '@/components-v2/ui/label';
@@ -22,10 +23,14 @@ export const OAuth2CredentialsComponent: React.FC<{
                 <div className="flex gap-2 items-center">
                     <SecretInput id="access_token" value={credentials.access_token} disabled copy canRead={canRead} />
                     {credentials.refresh_token && (
-                        <Button variant="secondary" size="sm" className="h-full" onClick={forceRefresh} loading={isRefreshing}>
-                            <RefreshCwIcon />
-                            Refresh
-                        </Button>
+                        <PermissionGate condition={canRead} asChild>
+                            {(allowed) => (
+                                <Button variant="secondary" size="sm" className="h-full" onClick={forceRefresh} loading={isRefreshing} disabled={!allowed}>
+                                    <RefreshCwIcon />
+                                    Refresh
+                                </Button>
+                            )}
+                        </PermissionGate>
                     )}
                 </div>
             </div>

--- a/packages/webapp/src/pages/Connection/components/AuthCredentials/SignatureCredentials.tsx
+++ b/packages/webapp/src/pages/Connection/components/AuthCredentials/SignatureCredentials.tsx
@@ -1,5 +1,6 @@
 import { RefreshCwIcon } from 'lucide-react';
 
+import { PermissionGate } from '@/components-v2/PermissionGate';
 import { SecretInput } from '@/components-v2/SecretInput';
 import { Button } from '@/components-v2/ui/button';
 import { Label } from '@/components-v2/ui/label';
@@ -32,10 +33,14 @@ export const SignatureCredentialsComponent: React.FC<{
                     <Label htmlFor="token">Token</Label>
                     <div className="flex gap-2 items-center">
                         <SecretInput id="token" value={credentials.token} disabled copy canRead={canRead} />
-                        <Button variant="secondary" size="sm" className="h-full" onClick={forceRefresh} loading={isRefreshing}>
-                            <RefreshCwIcon />
-                            Refresh
-                        </Button>
+                        <PermissionGate condition={canRead} asChild>
+                            {(allowed) => (
+                                <Button variant="secondary" size="sm" className="h-full" onClick={forceRefresh} loading={isRefreshing} disabled={!allowed}>
+                                    <RefreshCwIcon />
+                                    Refresh
+                                </Button>
+                            )}
+                        </PermissionGate>
                     </div>
                 </div>
             )}

--- a/packages/webapp/src/pages/Connection/components/AuthCredentials/TwoStepCredentials.tsx
+++ b/packages/webapp/src/pages/Connection/components/AuthCredentials/TwoStepCredentials.tsx
@@ -1,5 +1,6 @@
 import { RefreshCwIcon } from 'lucide-react';
 
+import { PermissionGate } from '@/components-v2/PermissionGate';
 import { SecretInput } from '@/components-v2/SecretInput';
 import { Button } from '@/components-v2/ui/button';
 import { Label } from '@/components-v2/ui/label';
@@ -23,10 +24,14 @@ export const TwoStepCredentialsComponent: React.FC<{
                     <Label htmlFor="token">Token</Label>
                     <div className="flex gap-2 items-center">
                         <SecretInput id="token" value={credentials.token} disabled copy canRead={canRead} />
-                        <Button variant="secondary" size="sm" className="h-full" onClick={forceRefresh} loading={isRefreshing}>
-                            <RefreshCwIcon />
-                            Refresh
-                        </Button>
+                        <PermissionGate condition={canRead} asChild>
+                            {(allowed) => (
+                                <Button variant="secondary" size="sm" className="h-full" onClick={forceRefresh} loading={isRefreshing} disabled={!allowed}>
+                                    <RefreshCwIcon />
+                                    Refresh
+                                </Button>
+                            )}
+                        </PermissionGate>
                     </div>
                 </div>
             )}

--- a/packages/webapp/src/pages/Connection/components/AuthTab.tsx
+++ b/packages/webapp/src/pages/Connection/components/AuthTab.tsx
@@ -19,7 +19,7 @@ export const AuthTab = ({ connectionData, providerConfigKey }: { connectionData:
 
     return (
         <div className="flex w-full gap-11 justify-between">
-            <div className="flex flex-col gap-8 max-w-2xl">
+            <div className="flex flex-col gap-8 w-full max-w-2xl">
                 {errorLog && (
                     <Alert variant="error">
                         <Info />


### PR DESCRIPTION
Went with a simple solution, curious on your thoughts.
Just recursively replace credentials values, regardless of which type it is. This way we don't need custom logic for each. Simple "NON_SENSITIVE_KEYS" to keep necessary `type` and any other non-sensitive key.

UI side of this was done already, so now that the UI knows which fields to render, this is what you get when you don't have the necessary permissions:
<img width="907" height="801" alt="image" src="https://github.com/user-attachments/assets/37fbcd15-c5db-4c7c-b503-8acf3749721d" />
<img width="723" height="243" alt="image" src="https://github.com/user-attachments/assets/ae732384-c4cb-4d65-9d99-b73d4006240c" />

<!-- Summary by @propel-code-bot -->

---

This PR also formalizes the behavior change so restricted responses preserve credential object shape with masked values rather than returning empty objects, and it aligns the UI by enforcing read-permission gating on credential refresh interactions. Together, these updates improve consistency for consumers while strengthening least-privilege handling across server responses and credential-management views.

---
*This summary was automatically generated by @propel-code-bot*