### PR TITLE
feat: ingest usage events to clickhouse

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -118,3 +118,6 @@ FLAG_SERVE_CONNECT_UI=true
 # ---- Orb (optional)
 # ORB_API_KEY=<ORB-API-KEY>
 # ORB_WEBHOOKS_SECRET=<ORB-WEBHOOKS-SECRET>
+
+# ---- Clickhouse (optional)
+# CLICKHOUSE_URL=http://default:@localhost:8123

--- a/dev/docker-compose.dev.yaml
+++ b/dev/docker-compose.dev.yaml
@@ -54,9 +54,42 @@ services:
         networks:
             - nango
 
+    clickhouse:
+        container_name: clickhouse
+        image: clickhouse/clickhouse-server:26.3.3
+        ports:
+            - '8123:8123' # HTTP port
+            - '9000:9000' # Native client port
+        environment:
+            - CLICKHOUSE_USER=default
+            - CLICKHOUSE_PASSWORD=
+        volumes:
+            - clickhouse_data:/usr/share/clickhouse/data
+        configs:
+            - source: clickhouse_users
+              target: /etc/clickhouse-server/users.d/default-user.xml
+
 networks:
     nango:
 
 volumes:
     elasticsearch-data1:
         driver: local
+    clickhouse_data:
+
+configs:
+    clickhouse_users:
+        content: |
+            <clickhouse>
+                <users>
+                    <default>
+                        <password></password>
+                        <networks>
+                            <ip>::/0</ip>
+                            <ip>0.0.0.0/0</ip>
+                        </networks>
+                        <profile>default</profile>
+                        <quota>default</quota>
+                    </default>
+                </users>
+            </clickhouse>

--- a/package-lock.json
+++ b/package-lock.json
@@ -2551,6 +2551,24 @@
             "version": "2.1.0",
             "license": "MIT"
         },
+        "node_modules/@clickhouse/client": {
+            "version": "1.18.2",
+            "resolved": "https://registry.npmjs.org/@clickhouse/client/-/client-1.18.2.tgz",
+            "integrity": "sha512-fuquQswRSHWM6D079ZeuGqkMOsqtcUPL06UdTnowmoeeYjVrqisfVmvnw8pc3OeKS4kVb91oygb/MfLDiMs0TQ==",
+            "license": "Apache-2.0",
+            "dependencies": {
+                "@clickhouse/client-common": "1.18.2"
+            },
+            "engines": {
+                "node": ">=16"
+            }
+        },
+        "node_modules/@clickhouse/client-common": {
+            "version": "1.18.2",
+            "resolved": "https://registry.npmjs.org/@clickhouse/client-common/-/client-common-1.18.2.tgz",
+            "integrity": "sha512-J0SG6q9V31ydxonglpj9xhNRsUxCsF71iEZ784yldqMYwsHixj/9xHFDgBDX3DuMiDx/kPDfXnf+pimp08wIBA==",
+            "license": "Apache-2.0"
+        },
         "node_modules/@colors/colors": {
             "version": "1.6.0",
             "license": "MIT",
@@ -35208,6 +35226,7 @@
             "version": "1.0.0",
             "license": "SEE LICENSE IN LICENSE FILE IN GIT REPOSITORY",
             "dependencies": {
+                "@clickhouse/client": "1.18.2",
                 "@nangohq/billing": "file:../billing",
                 "@nangohq/database": "file:../database",
                 "@nangohq/email": "file:../email",

--- a/packages/billing/lib/billing.ts
+++ b/packages/billing/lib/billing.ts
@@ -44,15 +44,10 @@ export class Billing {
     }
 
     async shutdown(): Promise<Result<void>> {
-        if (!this.batcher) {
-            return Ok(undefined);
+        if (this.batcher) {
+            return this.batcher.shutdown();
         }
-        const res = await this.batcher.shutdown();
-        if (res.isErr()) {
-            logger.error(`Shutdown failure: ${res.error}`);
-        }
-        logger.info(`Successful shutdown`);
-        return res;
+        return Ok(undefined);
     }
 
     add(events: BillingEvent[]): Result<void> {

--- a/packages/jobs/lib/execution/action.ts
+++ b/packages/jobs/lib/execution/action.ts
@@ -314,7 +314,7 @@ export async function handleActionSuccess({
                 functionName: nangoProps.syncConfig.sync_name,
                 success: true,
                 telemetryBag,
-                functionRuntime
+                runtime: functionRuntime
             }
         }
     });
@@ -500,7 +500,7 @@ function onFailure({
                     type: 'action',
                     success: false,
                     telemetryBag,
-                    functionRuntime
+                    runtime: functionRuntime
                 }
             }
         });

--- a/packages/jobs/lib/execution/onEvent.ts
+++ b/packages/jobs/lib/execution/onEvent.ts
@@ -222,7 +222,7 @@ export async function handleOnEventSuccess({
                 type: 'on-event',
                 success: true,
                 telemetryBag,
-                functionRuntime
+                runtime: functionRuntime
             }
         }
     });
@@ -331,7 +331,7 @@ function onFailure({
                     type: 'on-event',
                     success: false,
                     telemetryBag,
-                    functionRuntime
+                    runtime: functionRuntime
                 }
             }
         });

--- a/packages/jobs/lib/execution/sync.ts
+++ b/packages/jobs/lib/execution/sync.ts
@@ -587,7 +587,7 @@ export async function handleSyncSuccess({
                     success: true,
                     frequencyMs,
                     telemetryBag,
-                    functionRuntime
+                    runtime: functionRuntime
                 }
             }
         });
@@ -1008,7 +1008,7 @@ async function onFailure({
                     type: 'sync',
                     success: false,
                     telemetryBag,
-                    functionRuntime
+                    runtime: functionRuntime
                 }
             }
         });

--- a/packages/jobs/lib/execution/webhook.ts
+++ b/packages/jobs/lib/execution/webhook.ts
@@ -346,7 +346,7 @@ export async function handleWebhookSuccess({
                 functionName: nangoProps.syncConfig.sync_name,
                 success: true,
                 telemetryBag,
-                functionRuntime
+                runtime: functionRuntime
             }
         }
     });
@@ -547,7 +547,7 @@ async function onFailure({
                     functionName: syncName,
                     success: false,
                     telemetryBag,
-                    functionRuntime
+                    runtime: functionRuntime
                 }
             }
         });

--- a/packages/metering/lib/app.ts
+++ b/packages/metering/lib/app.ts
@@ -3,7 +3,7 @@ import * as cron from 'node-cron';
 
 import { billing } from '@nangohq/billing';
 import { DefaultTransport } from '@nangohq/pubsub';
-import { getUsageTracker } from '@nangohq/usage';
+import { ClickhouseIngestion, getUsageTracker, migrate as migrateUsage } from '@nangohq/usage';
 import { initSentry, once, report } from '@nangohq/utils';
 
 import { exportUsageCron } from './crons/usage.js';
@@ -33,15 +33,23 @@ try {
         process.exit(1);
     }
 
+    // Usage migrations
+    const usageMigration = await migrateUsage();
+    if (usageMigration.isErr()) {
+        logger.error('Usage migration failed', usageMigration.error);
+        process.exit(1);
+    }
+
     // Usage
+    const clickhouse = new ClickhouseIngestion();
     const usageTracker = await getUsageTracker(envs.NANGO_REDIS_URL);
 
     // Usage processor
-    const usageProc = new UsageProcessor(pubsubTransport, usageTracker);
+    const usageProc = new UsageProcessor({ transport: pubsubTransport, usageTracker, clickhouse });
     usageProc.start();
 
     // Team processor
-    const teamProc = new TeamProcessor(pubsubTransport);
+    const teamProc = new TeamProcessor({ transport: pubsubTransport });
     teamProc.start();
 
     // Crons
@@ -53,7 +61,14 @@ try {
         if (disconnect.isErr()) {
             logger.error('Error disconnecting from ActiveMQ', disconnect.error);
         }
-        await billing.shutdown();
+        const billingShutdown = await billing.shutdown();
+        if (billingShutdown.isErr()) {
+            logger.error('Error shutting down billing', billingShutdown.error);
+        }
+        const clickhouseShutdown = await clickhouse.shutdown();
+        if (clickhouseShutdown.isErr()) {
+            logger.error('Error shutting down Clickhouse ingestion', clickhouseShutdown.error);
+        }
         cron.getTasks().forEach((task) => task.stop());
         process.exit();
     });

--- a/packages/metering/lib/crons/usage.ts
+++ b/packages/metering/lib/crons/usage.ts
@@ -81,6 +81,7 @@ const observability = {
                             }
                         }
                     ]);
+                    // TODO: ingest into clickhouse
                     metrics.gauge(metrics.Types.CONNECTIONS_COUNT, count, { accountId });
                 }
             } catch (err) {
@@ -155,6 +156,8 @@ const observability = {
                 if (toBilling.isErr()) {
                     logger.error(`Failed to ingest record billing events`);
                 }
+
+                // TODO ingest into clickhouse
 
                 // send to datadog
                 for (const {

--- a/packages/metering/lib/processors/team.ts
+++ b/packages/metering/lib/processors/team.ts
@@ -6,13 +6,14 @@ import { Err, Ok, report, stringifyError } from '@nangohq/utils';
 
 import { logger } from '../utils.js';
 
-import type { TeamUpdatedEvent, Transport } from '@nangohq/pubsub';
+import type { Transport } from '@nangohq/pubsub';
+import type { TeamUpdatedEvent } from '@nangohq/types';
 import type { Result } from '@nangohq/utils';
 
 export class TeamProcessor {
     private subscriber: Subscriber;
 
-    constructor(transport: Transport) {
+    constructor({ transport }: { transport: Transport }) {
         this.subscriber = new Subscriber(transport);
     }
 

--- a/packages/metering/lib/processors/usage.ts
+++ b/packages/metering/lib/processors/usage.ts
@@ -5,8 +5,9 @@ import { Err, Ok, metrics, report, stringifyError } from '@nangohq/utils';
 
 import { logger } from '../utils.js';
 
-import type { Transport, UsageEvent } from '@nangohq/pubsub';
-import type { Usage } from '@nangohq/usage';
+import type { Transport } from '@nangohq/pubsub';
+import type { UsageEvent } from '@nangohq/types';
+import type { ClickhouseIngestion, Usage } from '@nangohq/usage';
 import type { Result } from '@nangohq/utils';
 
 const DAY_IN_MS = 24 * 60 * 60 * 1000;
@@ -14,10 +15,12 @@ const DAY_IN_MS = 24 * 60 * 60 * 1000;
 export class UsageProcessor {
     private subscriber: Subscriber;
     private usageTracker: Usage;
+    private clickhouse: ClickhouseIngestion;
 
-    constructor(transport: Transport, usageTracker: Usage) {
+    constructor({ transport, usageTracker, clickhouse }: { transport: Transport; usageTracker: Usage; clickhouse: ClickhouseIngestion }) {
         this.subscriber = new Subscriber(transport);
         this.usageTracker = usageTracker;
+        this.clickhouse = clickhouse;
     }
 
     public start(): void {
@@ -51,6 +54,8 @@ export class UsageProcessor {
                     const mar = event.payload.value;
                     metrics.increment(metrics.Types.BILLED_RECORDS_COUNT, mar, { accountId });
 
+                    this.clickhouse.add([event]);
+
                     return billing.add([
                         {
                             type: 'monthly_active_records',
@@ -82,6 +87,9 @@ export class UsageProcessor {
                 }
                 case 'usage.actions': {
                     const { accountId, environmentId, environmentName, integrationId, actionName } = event.payload.properties;
+
+                    this.clickhouse.add([event]);
+
                     return billing.add([
                         {
                             type: 'billable_actions',
@@ -127,7 +135,7 @@ export class UsageProcessor {
                         telemetryBag,
                         frequencyMs,
                         success,
-                        functionRuntime = 'runner'
+                        runtime = 'runner'
                     } = event.payload.properties;
                     const compute = telemetryBag ? telemetryBag.durationMs * telemetryBag.memoryGb : 0;
                     const customLogs = telemetryBag?.customLogs ?? 0;
@@ -157,6 +165,9 @@ export class UsageProcessor {
                     if (incrLogs.isErr()) {
                         logger.error(`Failed to increment logs for account ${accountId}: ${incrLogs.error}`);
                     }
+
+                    // Clickhouse
+                    this.clickhouse.add([event]);
 
                     // Billing
                     billing.add([
@@ -209,7 +220,7 @@ export class UsageProcessor {
                         success: String(success),
                         accountId,
                         frequencyBucket,
-                        functionRuntime
+                        functionRuntime: runtime
                     });
                     return Ok(undefined);
                 }
@@ -221,6 +232,8 @@ export class UsageProcessor {
                         metric: 'proxy',
                         delta: event.payload.value
                     });
+                    // Clickhouse
+                    this.clickhouse.add([event]);
                     // Billing
                     billing.add([
                         {
@@ -252,6 +265,8 @@ export class UsageProcessor {
                     if (incrWebhook.isErr()) {
                         logger.error(`Failed to increment webhook_forwards for account ${accountId}: ${incrWebhook.error}`);
                     }
+                    // Clickhouse
+                    this.clickhouse.add([event]);
                     // Billing
                     billing.add([
                         {

--- a/packages/pubsub/lib/index.ts
+++ b/packages/pubsub/lib/index.ts
@@ -1,5 +1,4 @@
 export type * from './transport/transport.js';
-export type * from './event.js';
 export * from './publisher.js';
 export * from './subscriber.js';
 export * from './transport/default.js';

--- a/packages/pubsub/lib/publisher.ts
+++ b/packages/pubsub/lib/publisher.ts
@@ -2,8 +2,8 @@ import { v4 as uuidv4 } from 'uuid';
 
 import { metrics } from '@nangohq/utils';
 
-import type { Event } from './event.js';
 import type { Transport } from './transport/transport.js';
+import type { Event } from '@nangohq/types';
 import type { Result } from '@nangohq/utils';
 import type { SetOptional } from 'type-fest';
 

--- a/packages/pubsub/lib/subscriber.ts
+++ b/packages/pubsub/lib/subscriber.ts
@@ -1,5 +1,5 @@
-import type { Event } from './event.js';
 import type { SubscribeProps, Transport } from './transport/transport.js';
+import type { Event } from '@nangohq/types';
 
 export class Subscriber {
     private transport: Transport;

--- a/packages/pubsub/lib/transport/activemq.integration.test.ts
+++ b/packages/pubsub/lib/transport/activemq.integration.test.ts
@@ -2,7 +2,7 @@ import { afterEach, assert, beforeEach, describe, expect, it, vi } from 'vitest'
 
 import { ActiveMQ } from './activemq.js';
 
-import type { Event } from '../event.js';
+import type { Event } from '@nangohq/types';
 
 describe('ActiveMQ Transport', () => {
     it('should connect successfully', async () => {

--- a/packages/pubsub/lib/transport/activemq.ts
+++ b/packages/pubsub/lib/transport/activemq.ts
@@ -9,7 +9,7 @@ import { envs } from '../env.js';
 import { serde } from '../utils/serde.js';
 
 import type { SubscribeProps, Transport } from './transport.js';
-import type { Event } from '../event.js';
+import type { Event } from '@nangohq/types';
 import type { Result } from '@nangohq/utils';
 import type { StompConfig, StompSubscription } from '@stomp/stompjs';
 

--- a/packages/pubsub/lib/transport/default.ts
+++ b/packages/pubsub/lib/transport/default.ts
@@ -6,8 +6,8 @@ import { NoOpTransport } from './noop.js';
 import { SnsSqs } from './sns-sqs.js';
 import { envs } from '../env.js';
 
-import type { Event } from '../event.js';
 import type { SubscribeProps, Transport } from './transport.js';
+import type { Event } from '@nangohq/types';
 import type { Result } from '@nangohq/utils';
 
 export class DefaultTransport implements Transport {

--- a/packages/pubsub/lib/transport/migration.ts
+++ b/packages/pubsub/lib/transport/migration.ts
@@ -1,7 +1,7 @@
 import { Err, Ok } from '@nangohq/utils';
 
-import type { Event } from '../event.js';
 import type { SubscribeProps, Transport } from './transport.js';
+import type { Event } from '@nangohq/types';
 import type { Result } from '@nangohq/utils';
 
 export class MigrationTransportError extends Error {

--- a/packages/pubsub/lib/transport/migration.unit.test.ts
+++ b/packages/pubsub/lib/transport/migration.unit.test.ts
@@ -5,8 +5,8 @@ import { Err, Ok } from '@nangohq/utils';
 import { Migration } from './migration.js';
 
 import type { MigrationTransportError } from './migration.js';
-import type { Event } from '../event.js';
 import type { Transport } from './transport.js';
+import type { Event } from '@nangohq/types';
 
 function mockTransport(partial?: Partial<Transport>): Transport {
     return {

--- a/packages/pubsub/lib/transport/sns-sqs.ts
+++ b/packages/pubsub/lib/transport/sns-sqs.ts
@@ -8,7 +8,7 @@ import { envs } from '../env.js';
 import { serde } from '../utils/serde.js';
 
 import type { SubscribeProps, Transport } from './transport.js';
-import type { Event } from '../event.js';
+import type { Event } from '@nangohq/types';
 import type { Result } from '@nangohq/utils';
 
 const logger = getLogger('pubsub.sns-sqs');

--- a/packages/pubsub/lib/transport/sns-sqs.unit.test.ts
+++ b/packages/pubsub/lib/transport/sns-sqs.unit.test.ts
@@ -7,9 +7,9 @@ import { report } from '@nangohq/utils';
 import { SnsSqs } from './sns-sqs.js';
 import { serde } from '../utils/serde.js';
 
-import type { Event } from '../event.js';
 import type { SNSClient } from '@aws-sdk/client-sns';
 import type { SQSClient } from '@aws-sdk/client-sqs';
+import type { Event } from '@nangohq/types';
 
 vi.mock('@nangohq/utils', async (importOriginal) => {
     const actual = await importOriginal();

--- a/packages/pubsub/lib/transport/transport.ts
+++ b/packages/pubsub/lib/transport/transport.ts
@@ -1,4 +1,4 @@
-import type { Event } from '../event.js';
+import type { Event } from '@nangohq/types';
 import type { Result } from '@nangohq/utils';
 
 // TODO: add support for subscriber ack/nack

--- a/packages/pubsub/tsconfig.json
+++ b/packages/pubsub/tsconfig.json
@@ -4,6 +4,6 @@
         "rootDir": "lib",
         "outDir": "dist"
     },
-    "references": [{ "path": "../utils" }],
+    "references": [{ "path": "../utils" }, { "path": "../types" }],
     "include": ["lib/**/*", "../utils/lib/vitest.d.ts"]
 }

--- a/packages/types/lib/index.ts
+++ b/packages/types/lib/index.ts
@@ -98,3 +98,5 @@ export type * from './mcp/api.js';
 
 export type * from './lambda/index.js';
 export type * from './authz/types.js';
+
+export type * from './pubsub/events.js';

--- a/packages/types/lib/pubsub/events.ts
+++ b/packages/types/lib/pubsub/events.ts
@@ -1,4 +1,6 @@
-import type { DBTeam, DBUser, FunctionRuntime } from '@nangohq/types';
+import type { FunctionRuntime } from '../runner/sdk.js';
+import type { DBTeam } from '../team/db.js';
+import type { DBUser } from '../user/db.js';
 
 type Serializable = string | number | boolean | Date | null | undefined | Serializable[] | { [key: string]: Serializable };
 
@@ -46,7 +48,6 @@ interface UsageEventBase<TType extends string, TPayload extends Serializable> ex
             environmentName: string;
             integrationId: string;
             connectionId: string;
-            functionRuntime?: FunctionRuntime | undefined;
         };
     };
 }
@@ -98,6 +99,7 @@ export type UsageFunctionExecutionsEvent = UsageEventBase<
             type: 'sync' | 'action' | 'webhook' | 'on-event';
             success: boolean;
             functionName: string;
+            runtime: FunctionRuntime | undefined;
             telemetryBag:
                 | {
                       durationMs: number;

--- a/packages/usage/lib/clickhouse/batcher.ts
+++ b/packages/usage/lib/clickhouse/batcher.ts
@@ -90,6 +90,7 @@ export class Batcher<T> {
             const batchToRetry = batch.filter((item) => item.retries < this.maxProcessingRetry).map((item) => ({ ...item, retries: item.retries + 1 }));
             const dropped = batch.length - batchToRetry.length;
             if (dropped > 0) {
+                // TODO: push metric
                 logger.error(`Clickhouse batcher: dropping ${dropped} items after exhausting retries.`);
             }
             this.queue.unshift(...batchToRetry);

--- a/packages/usage/lib/clickhouse/batcher.ts
+++ b/packages/usage/lib/clickhouse/batcher.ts
@@ -1,6 +1,6 @@
 import { Err, Ok } from '@nangohq/utils';
 
-import { logger } from './logger.js';
+import { logger } from '../logger.js';
 
 import type { Result } from '@nangohq/utils';
 
@@ -11,7 +11,6 @@ interface Item<T> {
 
 export class Batcher<T> {
     private readonly process: (events: T[]) => Promise<void>;
-    private readonly grouping: Grouping<T> | undefined;
     private readonly maxBatchSize: number;
     private readonly flushInterval: number;
     private queue: Item<T>[];
@@ -22,14 +21,12 @@ export class Batcher<T> {
 
     constructor(options: {
         process: (events: T[]) => Promise<void>;
-        grouping?: Grouping<T>;
         flushIntervalMs?: number;
         maxBatchSize: number;
         maxQueueSize?: number;
         maxProcessingRetry?: number;
     }) {
         this.process = options.process;
-        this.grouping = options.grouping;
         this.maxBatchSize = options.maxBatchSize;
         this.maxQueueSize = options.maxQueueSize ?? Infinity;
         this.flushInterval = options.flushIntervalMs ?? 0;
@@ -38,10 +35,13 @@ export class Batcher<T> {
         this.isFlushing = false;
 
         this.timer = this.flushInterval > 0 ? setInterval(() => this.flush(), this.flushInterval) : null;
+        this.timer?.unref();
     }
 
     public add(...t: T[]): Result<void> {
-        // Discard items if over maxQueueSize
+        if (t.length === 0) {
+            return Ok(undefined);
+        }
         let discarded = 0;
         if (this.queue.length + t.length > this.maxQueueSize) {
             const remaining = this.maxQueueSize - this.queue.length;
@@ -50,41 +50,20 @@ export class Batcher<T> {
         }
 
         if (discarded > 0) {
-            logger.error(`Billing batcher queue full. Discarding ${discarded} items.`);
-            // TODO: add metric + alert
+            logger.error(`Clickhouse batcher queue full. Discarding ${discarded} items.`);
         }
 
         this.queue.push(...t.map((item) => ({ item, retries: 0 })));
 
-        // Auto-flush if batch size threshold is reached
         if (this.queue.length >= this.maxBatchSize) {
             void this.flush();
         }
 
         if (discarded > 0) {
-            return Err(new Error(`Batcher is full. ${discarded} items are being discarded.`));
+            return Err(new Error(`Clickhouse batcher is full. ${discarded} items are being discarded.`));
         }
 
         return Ok(undefined);
-    }
-
-    private aggregateItems(items: Item<T>[]): Item<T>[] {
-        if (!this.grouping) {
-            return items;
-        }
-
-        const aggregated = new Map<string, Item<T>>();
-        for (const item of items) {
-            const key = this.grouping.groupingKey(item.item);
-            const existing = aggregated.get(key);
-            if (existing) {
-                const mergedItem = this.grouping.aggregate(existing.item, item.item);
-                aggregated.set(key, { item: mergedItem, retries: Math.min(existing.retries, item.retries) });
-            } else {
-                aggregated.set(key, item);
-            }
-        }
-        return Array.from(aggregated.values());
     }
 
     public async flush(): Promise<Result<void>> {
@@ -99,26 +78,19 @@ export class Batcher<T> {
         this.isFlushing = true;
 
         const batch = this.queue.splice(0, Math.min(this.queue.length, this.maxBatchSize));
-        const aggregated = this.aggregateItems(batch);
-
-        if (batch.length !== aggregated.length) {
-            logger.info(`Aggregated ${batch.length} items into ${aggregated.length} items`);
-        }
 
         try {
-            await this.process(aggregated.map((data) => data.item));
+            await this.process(batch.map((data) => data.item));
 
             if (this.queue.length >= this.maxBatchSize) {
                 setImmediate(() => this.flush());
             }
             return Ok(undefined);
         } catch (err) {
-            // Put failed items back at the front of the queue
-            // unless they have been retried too many times
-            const batchToRetry = aggregated.filter((item) => item.retries < this.maxProcessingRetry).map((item) => ({ ...item, retries: item.retries + 1 }));
+            const batchToRetry = batch.filter((item) => item.retries < this.maxProcessingRetry).map((item) => ({ ...item, retries: item.retries + 1 }));
             const dropped = batch.length - batchToRetry.length;
             if (dropped > 0) {
-                logger.error(`Batcher: dropping ${dropped} items after exhausting retries.`);
+                logger.error(`Clickhouse batcher: dropping ${dropped} items after exhausting retries.`);
             }
             this.queue.unshift(...batchToRetry);
 
@@ -136,33 +108,24 @@ export class Batcher<T> {
 
         const start = Date.now();
         while (true) {
-            // check if we are over the timeout
             if (Date.now() - start > timeoutMs) {
-                return Err(new Error('Batcher shutdown timed out'));
+                if (this.queue.length > 0) {
+                    logger.error(`Clickhouse batcher shutdown timed out. Dropping ${this.queue.length} items.`);
+                }
+                return Err(new Error('Clickhouse batcher shutdown timed out'));
             }
-            // processing is in progress, wait and loop again
             if (this.isFlushing) {
                 await new Promise((resolve) => setTimeout(resolve, 100));
                 continue;
             }
-
-            // queue is empty, we are done
             if (this.queue.length === 0) {
                 break;
             }
-
             const res = await this.flush();
-
             if (res.isErr()) {
                 return res;
             }
         }
         return Ok(undefined);
     }
-}
-
-// A grouping and aggregation strategy for items of type T
-export interface Grouping<T> {
-    groupingKey: (t: T) => string;
-    aggregate: (t1: T, t2: T) => T;
 }

--- a/packages/usage/lib/clickhouse/batcher.unit.test.ts
+++ b/packages/usage/lib/clickhouse/batcher.unit.test.ts
@@ -1,0 +1,246 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+
+import { Batcher } from './batcher.js';
+
+describe('Batcher', () => {
+    let mockProcess: ReturnType<typeof vi.fn>;
+
+    beforeEach(() => {
+        mockProcess = vi.fn().mockResolvedValue(undefined);
+        vi.useFakeTimers();
+    });
+
+    afterEach(() => {
+        vi.clearAllTimers();
+        vi.useRealTimers();
+        vi.restoreAllMocks();
+    });
+
+    describe('add', () => {
+        it('should add an item to the queue', () => {
+            const batcher = new Batcher({ process: mockProcess, maxBatchSize: 3 });
+            const res = batcher.add('item1');
+            expect(res.isOk()).toBe(true);
+            expect(batcher['queue']).toEqual([{ item: 'item1', retries: 0 }]);
+        });
+
+        it('should return Err if queue is full', () => {
+            const batcher = new Batcher({
+                process: () => {
+                    throw new Error('items are not sent');
+                },
+                maxBatchSize: 1,
+                maxQueueSize: 1
+            });
+            const res = batcher.add('item1', 'item2');
+            expect(res.isErr()).toBe(true);
+            if (res.isErr()) {
+                expect(res.error.message).toContain('batcher is full. 1 items are being discarded.');
+            }
+            expect(batcher['queue'].length).toBe(1);
+        });
+
+        it('should auto-flush when maxBatchSize is reached', () => {
+            const batcher = new Batcher({ process: mockProcess, maxBatchSize: 2 });
+            const flushSpy = vi.spyOn(batcher, 'flush');
+
+            batcher.add('item1');
+            expect(flushSpy).not.toHaveBeenCalled();
+            expect(batcher['queue'].length).toBe(1);
+
+            batcher.add('item2'); // Reaches batch size
+            expect(flushSpy).toHaveBeenCalledTimes(1);
+
+            expect(mockProcess).toHaveBeenCalledWith(['item1', 'item2']);
+            expect(batcher['queue'].length).toBe(0);
+        });
+    });
+
+    describe('flush', () => {
+        it('should do nothing if already processing', async () => {
+            const batcher = new Batcher({ process: mockProcess, maxBatchSize: 3 });
+            batcher.add('item1');
+            batcher['isFlushing'] = true; // Simulate processing state
+            const res = await batcher.flush();
+            expect(res.isOk()).toBe(true);
+            expect(mockProcess).not.toHaveBeenCalled();
+        });
+
+        it('should do nothing if queue is empty', async () => {
+            const batcher = new Batcher({ process: mockProcess, maxBatchSize: 3 });
+            const res = await batcher.flush();
+            expect(res.isOk()).toBe(true);
+            expect(mockProcess).not.toHaveBeenCalled();
+        });
+
+        it('should process all items when queue <= maxBatchSize', async () => {
+            const batcher = new Batcher({ process: mockProcess, maxBatchSize: 3 });
+            batcher.add('item1');
+            const res = await batcher.flush();
+            expect(res.isOk()).toBe(true);
+            expect(mockProcess).toHaveBeenCalledTimes(1);
+            expect(mockProcess).toHaveBeenCalledWith(['item1']);
+            expect(batcher['queue'].length).toBe(0);
+        });
+
+        it('should process maxBatchSize items when queue > maxBatchSize', async () => {
+            const batcher = new Batcher({ process: mockProcess, maxBatchSize: 3 });
+            batcher.add('item1', 'item2', 'item3', 'item4');
+            const res = await batcher.flush();
+            expect(res.isOk()).toBe(true);
+            expect(mockProcess).toHaveBeenCalledTimes(1);
+            expect(mockProcess).toHaveBeenCalledWith(['item1', 'item2', 'item3']);
+            expect(batcher['queue'].length).toBe(1);
+        });
+
+        it('should handle processing failure and retry items successfully', async () => {
+            let attempt = 0;
+            // eslint-disable-next-line @typescript-eslint/require-await
+            const processFn = vi.fn(async () => {
+                attempt++;
+                if (attempt === 1) {
+                    throw new Error('Simulated processing failure');
+                } else {
+                    return;
+                }
+            });
+
+            const batcher = new Batcher({
+                process: processFn,
+                maxBatchSize: 2,
+                maxProcessingRetry: 1
+            });
+
+            batcher.add('item1');
+            batcher.add('item2');
+
+            await Promise.resolve(); // Allow the auto-flush to complete
+
+            expect(batcher['queue'].length).toBe(2);
+            expect(batcher['queue'][0]).toEqual({ item: 'item1', retries: 1 });
+            expect(batcher['queue'][1]).toEqual({ item: 'item2', retries: 1 });
+
+            // retrying to flush
+            const res = await batcher.flush();
+            expect(res.isOk()).toBe(true);
+            expect(processFn).toHaveBeenCalledTimes(2);
+            expect(processFn).toHaveBeenLastCalledWith(['item1', 'item2']);
+            expect(batcher['queue']).toEqual([]);
+        });
+
+        it('should discard items after maxProcessingRetry attempts', () => {
+            const processFn = vi.fn(() => {
+                throw new Error('Simulated processing failure');
+            });
+
+            const batcher = new Batcher({
+                process: processFn,
+                maxBatchSize: 2,
+                maxProcessingRetry: 0
+            });
+
+            batcher.add('item1');
+            batcher.add('item2'); // This should trigger an auto-flush
+
+            expect(batcher['queue'].length).toBe(0);
+        });
+    });
+
+    describe('interval flushing', () => {
+        it('should flush periodically based on flushInterval', async () => {
+            const flushInterval = 100;
+            const batcher = new Batcher({ process: mockProcess, maxBatchSize: 5, flushIntervalMs: flushInterval });
+            const flushSpy = vi.spyOn(batcher, 'flush');
+
+            batcher.add('item1');
+            expect(flushSpy).not.toHaveBeenCalled();
+
+            // Interval not yet reached
+            vi.advanceTimersByTime(flushInterval / 2);
+            expect(flushSpy).not.toHaveBeenCalled();
+
+            // Interval reached
+            vi.advanceTimersByTime(flushInterval / 2);
+            expect(flushSpy).toHaveBeenCalledTimes(1);
+            expect(mockProcess).toHaveBeenCalledWith(['item1']);
+
+            // Add more items to meet batchSize for a subsequent interval flush
+            batcher.add('item2');
+            batcher.add('item3');
+            batcher.add('item4');
+            batcher.add('item5');
+            await Promise.resolve(); // allow auto-flush to complete
+            vi.advanceTimersByTime(flushInterval);
+
+            expect(mockProcess).toHaveBeenCalledWith(['item2', 'item3', 'item4', 'item5']);
+            expect(batcher['queue'].length).toBe(0);
+            mockProcess.mockClear();
+            flushSpy.mockClear();
+        });
+    });
+
+    describe('shutdown', () => {
+        it('should clear the timer', async () => {
+            const clearIntervalSpy = vi.spyOn(global, 'clearInterval');
+            const batcher = new Batcher({ process: mockProcess, maxBatchSize: 3, flushIntervalMs: 1_000 });
+            expect(batcher['timer']).not.toBeNull();
+
+            await batcher.shutdown();
+            expect(clearIntervalSpy).toHaveBeenCalledTimes(1);
+            expect(batcher['timer']).toBeNull();
+            clearIntervalSpy.mockRestore();
+        });
+        it('should process remaining items in the queue', async () => {
+            const batcher = new Batcher({ process: mockProcess, maxBatchSize: 5 });
+            batcher.add('item1');
+            batcher.add('item2');
+
+            const res = await batcher.shutdown();
+            expect(res.isOk()).toBe(true);
+            expect(mockProcess).toHaveBeenCalledTimes(1);
+            expect(mockProcess).toHaveBeenCalledWith(['item1', 'item2']);
+            expect(batcher['queue']).toEqual([]);
+        });
+
+        it('should return Err if processing fails during shutdown flush', async () => {
+            const shutdownError = new Error('Shutdown process fail');
+            mockProcess.mockRejectedValueOnce(shutdownError);
+            const batcher = new Batcher({ process: mockProcess, maxBatchSize: 5 });
+            batcher.add('item1');
+
+            const res = await batcher.shutdown();
+            expect(res.isErr()).toBe(true);
+            if (res.isErr()) {
+                expect(res.error.message).toBe('Batcher failed to process batch');
+                expect(res.error.cause).toBe(shutdownError);
+            }
+            expect(batcher['queue'].length).toBe(1);
+            expect(batcher['queue'][0]?.retries).toBe(1);
+        });
+
+        it('should return successfully when queue is empty and not processing', async () => {
+            const batcher = new Batcher({ process: mockProcess, maxBatchSize: 1, flushIntervalMs: 0 });
+            const res = await batcher.shutdown();
+            expect(res.isOk()).toBe(true);
+            expect(mockProcess).not.toHaveBeenCalled();
+        });
+        it('should return error from shutdown if a forced flush fails and items are discarded (max retries)', async () => {
+            const batcher = new Batcher({ process: mockProcess, maxBatchSize: 10, maxProcessingRetry: 0 });
+            batcher.add('item1');
+
+            const processError = new Error('Processing failed');
+            mockProcess.mockRejectedValueOnce(processError);
+
+            const res = await batcher.shutdown({ timeoutMs: 100 });
+
+            expect(res.isErr()).toBe(true);
+            if (res.isErr()) {
+                expect(res.error.message).toBe('Batcher failed to process batch');
+                expect(res.error.cause).toBe(processError);
+            }
+            expect(mockProcess).toHaveBeenCalledTimes(1);
+            expect(mockProcess).toHaveBeenCalledWith(['item1']);
+            expect(batcher['queue']).toEqual([]);
+        });
+    });
+});

--- a/packages/usage/lib/clickhouse/config.ts
+++ b/packages/usage/lib/clickhouse/config.ts
@@ -1,0 +1,19 @@
+import { createClient } from '@clickhouse/client';
+
+import { ENVS, parseEnvs } from '@nangohq/utils';
+
+import type { ClickHouseClient } from '@clickhouse/client';
+
+const envs = parseEnvs(ENVS);
+
+export const database = 'usage';
+
+export function clickhouseClient(opts?: { database: string }): ClickHouseClient | null {
+    if (!envs.CLICKHOUSE_URL) {
+        return null;
+    }
+    return createClient({
+        url: envs.CLICKHOUSE_URL,
+        ...(opts?.database ? { database: opts.database } : {})
+    });
+}

--- a/packages/usage/lib/clickhouse/migrate.ts
+++ b/packages/usage/lib/clickhouse/migrate.ts
@@ -1,0 +1,61 @@
+import fs from 'node:fs/promises';
+import path from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+import { Err, Ok, stringifyError } from '@nangohq/utils';
+
+import { logger } from '../logger.js';
+import { clickhouseClient, database as usageDatabase } from './config.js';
+
+import type { Result } from '@nangohq/utils';
+
+const migrationsDir = path.join(fileURLToPath(import.meta.url), '..', 'migrations');
+
+export async function migrate({ database }: { database: string } = { database: usageDatabase }): Promise<Result<void>> {
+    const client = clickhouseClient();
+    if (!client) {
+        logger.info('Clickhouse migration: config not set, skipping migration');
+        return Ok(undefined);
+    }
+
+    const migrationTable = `${database}.migrations`;
+    try {
+        await client.command({ query: `CREATE DATABASE IF NOT EXISTS ${database}` });
+        await client.command({
+            query: `
+                CREATE TABLE IF NOT EXISTS ${migrationTable}
+                (
+                    name        String,
+                    created_at  DateTime64(3) DEFAULT now64()
+                )
+                ENGINE = ReplacingMergeTree()
+                ORDER BY name
+            `
+        });
+
+        const result = await client.query({ query: `SELECT name FROM ${migrationTable} FINAL`, format: 'JSONEachRow' });
+        const rows = await result.json<{ name: string }>();
+        const applied = new Set(rows.map((r) => r.name));
+
+        const migrations = (await fs.readdir(migrationsDir)).sort().flatMap((f) => {
+            if (f.endsWith('.js')) {
+                const name = path.basename(f);
+                return applied.has(name) ? [] : [name];
+            }
+            return [];
+        });
+
+        for (const migration of migrations) {
+            const { sql } = (await import(path.join(migrationsDir, migration))) as { sql: string };
+            logger.info(`Clickhouse migration: applying ${migration}`);
+            await client.command({ query: sql });
+            await client.insert({ table: migrationTable, values: [{ name: migration }], format: 'JSONEachRow' });
+        }
+        logger.info(`Clickhouse migration: ${migrations.length > 0 ? `applied ${migrations.length} migration(s)` : `no migrations`}`);
+        return Ok(undefined);
+    } catch (err) {
+        return Err(`Clickhouse migration failed: ${stringifyError(err)}`);
+    } finally {
+        await client.close();
+    }
+}

--- a/packages/usage/lib/clickhouse/migrations/20260406174100_create_raw_usage_events.ts
+++ b/packages/usage/lib/clickhouse/migrations/20260406174100_create_raw_usage_events.ts
@@ -1,0 +1,15 @@
+export const sql = `
+    CREATE TABLE IF NOT EXISTS usage.raw_events
+    (
+        ts               DateTime64(3),
+        idempotency_key  String,
+        type             LowCardinality(String),
+        account_id       Int64,
+        value            Float64,
+        attributes       JSON
+    )
+    ENGINE = ReplacingMergeTree()
+    PARTITION BY toYYYYMM(ts)
+    ORDER BY (account_id, type, idempotency_key)
+    TTL toDateTime(ts) + INTERVAL 90 DAY
+`;

--- a/packages/usage/lib/clickhouse/usage.ts
+++ b/packages/usage/lib/clickhouse/usage.ts
@@ -1,0 +1,97 @@
+import { ENVS, Err, Ok, parseEnvs, stringifyError } from '@nangohq/utils';
+
+import { Batcher } from './batcher.js';
+import { clickhouseClient, database as usageDatabase } from './config.js';
+import { logger } from '../logger.js';
+
+import type { UsageEvent } from '@nangohq/types';
+import type { Result } from '@nangohq/utils';
+
+const envs = parseEnvs(ENVS);
+
+export interface ClickhouseUsageEvent {
+    ts: number; // Unix timestamp in milliseconds, matches DateTime64(3)
+    idempotency_key: UsageEvent['idempotencyKey'];
+    type: UsageEvent['type'];
+    value: UsageEvent['payload']['value'];
+    account_id: UsageEvent['payload']['properties']['accountId'];
+    attributes: Omit<UsageEvent['payload']['properties'], 'accountId'>;
+}
+
+export class ClickhouseIngestion {
+    private batcher: Batcher<ClickhouseUsageEvent> | null = null;
+    private client: ReturnType<typeof clickhouseClient> = null;
+
+    constructor(opts: { database: string } = { database: usageDatabase }) {
+        const client = clickhouseClient(opts);
+        if (!client) {
+            return;
+        }
+
+        this.client = client;
+        this.batcher = new Batcher({
+            process: async (events) => {
+                try {
+                    await client.insert({
+                        table: 'raw_events',
+                        values: events,
+                        format: 'JSONEachRow'
+                    });
+                } catch (err) {
+                    logger.error(`Failed to insert usage events into Clickhouse: ${stringifyError(err)}`);
+                    throw err;
+                }
+            },
+            maxBatchSize: envs.CLICKHOUSE_USAGE_INGEST_BATCH_SIZE,
+            flushIntervalMs: envs.CLICKHOUSE_USAGE_INGEST_BATCH_INTERVAL_MS,
+            maxQueueSize: envs.CLICKHOUSE_USAGE_INGEST_MAX_QUEUE_SIZE
+        });
+    }
+
+    add(events: UsageEvent[]): Result<void> {
+        if (!this.batcher) {
+            return Ok(undefined);
+        }
+        const rows = events.flatMap((event) => {
+            const row = toRow(event);
+            return row && row.value > 0 ? [row] : [];
+        });
+        return this.batcher.add(...rows);
+    }
+
+    async shutdown(): Promise<Result<void>> {
+        const res = this.batcher ? await this.batcher.shutdown() : Ok(undefined);
+
+        try {
+            await this.client?.close();
+        } catch (err) {
+            return Err(new Error('Failed to close Clickhouse client', { cause: err }));
+        }
+
+        return res;
+    }
+}
+
+function toRow(event: UsageEvent): ClickhouseUsageEvent | null {
+    switch (event.type) {
+        case 'usage.monthly_active_records':
+        case 'usage.actions':
+        case 'usage.function_executions':
+        case 'usage.proxy':
+        case 'usage.webhook_forward': {
+            const { accountId, ...properties } = event.payload.properties;
+            return {
+                ts: event.createdAt.getTime(),
+                idempotency_key: event.idempotencyKey,
+                type: event.type,
+                account_id: accountId,
+                value: event.payload.value,
+                attributes: properties
+            };
+        }
+        case 'usage.records':
+        case 'usage.connections':
+            // Not ingested into Clickhouse via events
+            return null;
+    }
+}

--- a/packages/usage/lib/index.ts
+++ b/packages/usage/lib/index.ts
@@ -6,6 +6,8 @@ import type { IUsageTracker } from './usage.js';
 
 export type { IUsageTracker as Usage } from './usage.js';
 export { Capping } from './capping.js';
+export { ClickhouseIngestion } from './clickhouse/usage.js';
+export { migrate } from './clickhouse/migrate.js';
 
 export async function getUsageTracker(redisUrl: string | undefined): Promise<IUsageTracker> {
     if (redisUrl) {

--- a/packages/usage/lib/logger.ts
+++ b/packages/usage/lib/logger.ts
@@ -1,3 +1,3 @@
 import { getLogger } from '@nangohq/utils';
 
-export const logger = getLogger('AccountUsage');
+export const logger = getLogger('usage');

--- a/packages/usage/package.json
+++ b/packages/usage/package.json
@@ -13,6 +13,7 @@
         "directory": "packages/usage"
     },
     "dependencies": {
+        "@clickhouse/client": "1.18.2",
         "@nangohq/billing": "file:../billing",
         "@nangohq/database": "file:../database",
         "@nangohq/email": "file:../email",

--- a/packages/utils/lib/environment/parse.ts
+++ b/packages/utils/lib/environment/parse.ts
@@ -244,6 +244,12 @@ export const ENVS = z.object({
     BILLING_INGEST_MAX_QUEUE_SIZE: z.coerce.number().optional().default(100_000),
     BILLING_INGEST_MAX_RETRY: z.coerce.number().optional().default(3),
 
+    // ClickHouse
+    CLICKHOUSE_URL: z.string().optional(),
+    CLICKHOUSE_USAGE_INGEST_BATCH_SIZE: z.coerce.number().optional().default(10_000),
+    CLICKHOUSE_USAGE_INGEST_BATCH_INTERVAL_MS: z.coerce.number().optional().default(5_000),
+    CLICKHOUSE_USAGE_INGEST_MAX_QUEUE_SIZE: z.coerce.number().optional().default(500_000),
+
     // Usage
     USAGE_CAPPING_ENABLED: z.stringbool().optional().default(false),
     USAGE_REVALIDATE_AFTER_MS: z.coerce.number().optional().default(3_600_000), // 1 hour


### PR DESCRIPTION
This commit introduce clickhouse and ingest usage events to raw table 
It doesn't ingest connections or records usage because they are not event-based and I haven't figure out how I am gonna model those metrics yet.
CLICKHOUSE_URL isn't set in staging/prod. Until then code is noop 
Next steps will be creating materialized views for the metrics.

<!-- Describe the problem and your solution --> 

<!-- Issue ticket number and link (if applicable) -->

<!-- Testing instructions (skip if just adding/editing providers) -->


<!-- Summary by @propel-code-bot -->

---

This PR also establishes the foundational ingestion pipeline around ClickHouse by integrating migration and ingestion lifecycle handling into the metering flow and introducing buffered event processing so event-based analytics can be captured reliably without disrupting existing billing and usage-tracking paths. It formalizes the initial event-oriented ingestion scope as a staged rollout toward downstream metric modeling, while keeping behavior safely disabled in environments where ClickHouse is not configured.

---
*This summary was automatically generated by @propel-code-bot*