### PR TITLE
fix(webapp): allow clearing webhook urls in settings

### DIFF
--- a/packages/webapp/src/pages/Environment/Settings/Webhooks.tsx
+++ b/packages/webapp/src/pages/Environment/Settings/Webhooks.tsx
@@ -61,7 +61,7 @@ export const Webhooks: React.FC = () => {
                             placeholder="https://example.com/webhooks_from_nango"
                             initialValue={environmentAndAccount.webhook_settings.primary_url || ''}
                             onSave={(value) => onSave({ primary_url: value })}
-                            validate={validateUrl}
+                            validate={(value) => validateUrl(value, true)}
                             canEdit={canWriteWebhooks}
                         />
                     </div>
@@ -72,7 +72,7 @@ export const Webhooks: React.FC = () => {
                             placeholder="https://example.com/webhooks_from_nango"
                             initialValue={environmentAndAccount.webhook_settings.secondary_url || ''}
                             onSave={(value) => onSave({ secondary_url: value })}
-                            validate={validateUrl}
+                            validate={(value) => validateUrl(value, true)}
                             canEdit={canWriteWebhooks}
                         />
                     </div>

--- a/packages/webapp/src/pages/Integrations/utils.ts
+++ b/packages/webapp/src/pages/Integrations/utils.ts
@@ -27,7 +27,10 @@ export function getDisplayName(authMode: AuthModeType): string {
     return displayNames[authMode] || authMode.replaceAll('_', ' ').toUpperCase();
 }
 
-export function validateUrl(value: string): string | null {
+export function validateUrl(value: string, allowEmpty = false): string | null {
+    if (allowEmpty && value === '') {
+        return null;
+    }
     const message = 'Must be a valid URL (e.g., https://example.com)';
     try {
         // The URL constructor will throw if the URL is invalid.


### PR DESCRIPTION
## Describe the problem and your solution

- allow clearing webhook urls in settings

<!-- Issue ticket number and link (if applicable) -->

<!-- Testing instructions (skip if just adding/editing providers) -->


<!-- Summary by @propel-code-bot -->

---

**Allow Empty Webhook URL Values in Webapp Settings Validation**

This PR updates webhook URL validation in the web app so users can clear `primary` and `secondary` webhook URL fields in environment settings. Previously, `validateUrl` always required a valid `http`/`https` URL, which blocked saving empty values.

The shared `validateUrl` helper now accepts an optional `allowEmpty` flag and returns valid when the input is an empty string and that flag is enabled. `Webhooks` settings now call `validateUrl(value, true)` for both URL inputs, aligning behavior with the PR intent to allow clearing saved webhook URLs.

---
*This summary was automatically generated by @propel-code-bot*