### PR TITLE
chore(usage): add clickhouse materialized views for metrics

### DIFF
--- a/packages/usage/lib/clickhouse/migrate.ts
+++ b/packages/usage/lib/clickhouse/migrate.ts
@@ -46,9 +46,11 @@ export async function migrate({ database }: { database: string } = { database: u
         });
 
         for (const migration of migrations) {
-            const { sql } = (await import(path.join(migrationsDir, migration))) as { sql: string };
+            const { sql } = (await import(path.join(migrationsDir, migration))) as { sql: string[] };
             logger.info(`Clickhouse migration: applying ${migration}`);
-            await client.command({ query: sql });
+            for (const statement of sql) {
+                await client.command({ query: statement });
+            }
             await client.insert({ table: migrationTable, values: [{ name: migration }], format: 'JSONEachRow' });
         }
         logger.info(`Clickhouse migration: ${migrations.length > 0 ? `applied ${migrations.length} migration(s)` : `no migrations`}`);

--- a/packages/usage/lib/clickhouse/migrations/20260406174100_create_raw_usage_events.ts
+++ b/packages/usage/lib/clickhouse/migrations/20260406174100_create_raw_usage_events.ts
@@ -1,4 +1,5 @@
-export const sql = `
+export const sql = [
+    `
     CREATE TABLE IF NOT EXISTS usage.raw_events
     (
         ts               DateTime64(3),
@@ -12,4 +13,5 @@ export const sql = `
     PARTITION BY toYYYYMM(ts)
     ORDER BY (account_id, type, idempotency_key)
     TTL toDateTime(ts) + INTERVAL 90 DAY
-`;
+    `
+];

--- a/packages/usage/lib/clickhouse/migrations/20260407000001_create_daily_mar.ts
+++ b/packages/usage/lib/clickhouse/migrations/20260407000001_create_daily_mar.ts
@@ -5,7 +5,6 @@ export const sql = [
         day              Date,
         account_id       Int64,
         environment_id   Int64,
-        environment_name LowCardinality(String),
         integration_id   LowCardinality(String),
         connection_id    String,
         sync_id          String,
@@ -14,7 +13,8 @@ export const sql = [
     )
     ENGINE = SummingMergeTree(value)
     PARTITION BY toYYYYMM(day)
-    ORDER BY (account_id, environment_id, integration_id, connection_id, sync_id, model, day)
+    ORDER BY (account_id, day, environment_id, integration_id, connection_id, sync_id, model)
+    TTL day + INTERVAL 24 MONTH
     `,
     `
     CREATE MATERIALIZED VIEW IF NOT EXISTS usage.daily_mar_mv
@@ -23,7 +23,6 @@ export const sql = [
         toDate(ts)                          AS day,
         account_id,
         attributes.environmentId::Int64     AS environment_id,
-        attributes.environmentName::String  AS environment_name,
         attributes.integrationId::String    AS integration_id,
         attributes.connectionId::String     AS connection_id,
         attributes.syncId::String           AS sync_id,
@@ -31,6 +30,6 @@ export const sql = [
         sum(value)                          AS value
     FROM usage.raw_events
     WHERE type = 'usage.monthly_active_records'
-    GROUP BY day, account_id, environment_id, environment_name, integration_id, connection_id, sync_id, model
+    GROUP BY day, account_id, environment_id, integration_id, connection_id, sync_id, model
     `
 ];

--- a/packages/usage/lib/clickhouse/migrations/20260407000001_create_daily_mar.ts
+++ b/packages/usage/lib/clickhouse/migrations/20260407000001_create_daily_mar.ts
@@ -1,0 +1,36 @@
+export const sql = [
+    `
+    CREATE TABLE IF NOT EXISTS usage.daily_mar
+    (
+        day              Date,
+        account_id       Int64,
+        environment_id   Int64,
+        environment_name LowCardinality(String),
+        integration_id   LowCardinality(String),
+        connection_id    String,
+        sync_id          String,
+        model            LowCardinality(String),
+        value            Int64
+    )
+    ENGINE = SummingMergeTree(value)
+    PARTITION BY toYYYYMM(day)
+    ORDER BY (account_id, environment_id, integration_id, connection_id, sync_id, model, day)
+    `,
+    `
+    CREATE MATERIALIZED VIEW IF NOT EXISTS usage.daily_mar_mv
+    TO usage.daily_mar AS
+    SELECT
+        toDate(ts)                          AS day,
+        account_id,
+        attributes.environmentId::Int64     AS environment_id,
+        attributes.environmentName::String  AS environment_name,
+        attributes.integrationId::String    AS integration_id,
+        attributes.connectionId::String     AS connection_id,
+        attributes.syncId::String           AS sync_id,
+        attributes.model::String            AS model,
+        sum(value)                          AS value
+    FROM usage.raw_events
+    WHERE type = 'usage.monthly_active_records'
+    GROUP BY day, account_id, environment_id, environment_name, integration_id, connection_id, sync_id, model
+    `
+];

--- a/packages/usage/lib/clickhouse/migrations/20260407000002_create_daily_actions.ts
+++ b/packages/usage/lib/clickhouse/migrations/20260407000002_create_daily_actions.ts
@@ -1,0 +1,33 @@
+export const sql = [
+    `
+    CREATE TABLE IF NOT EXISTS usage.daily_actions
+    (
+        day              Date,
+        account_id       Int64,
+        environment_id   Int64,
+        integration_id   LowCardinality(String),
+        connection_id    String,
+        action_name      String,
+        value            Int64
+    )
+    ENGINE = SummingMergeTree(value)
+    PARTITION BY toYYYYMM(day)
+    ORDER BY (account_id, day, environment_id, integration_id, connection_id, action_name)
+    TTL day + INTERVAL 24 MONTH
+    `,
+    `
+    CREATE MATERIALIZED VIEW IF NOT EXISTS usage.daily_actions_mv
+    TO usage.daily_actions AS
+    SELECT
+        toDate(ts)                          AS day,
+        account_id,
+        attributes.environmentId::Int64     AS environment_id,
+        attributes.integrationId::String    AS integration_id,
+        attributes.connectionId::String     AS connection_id,
+        attributes.actionName::String       AS action_name,
+        sum(value)                          AS value
+    FROM usage.raw_events
+    WHERE type = 'usage.actions'
+    GROUP BY day, account_id, environment_id, integration_id, connection_id, action_name
+    `
+];

--- a/packages/usage/lib/clickhouse/migrations/20260407000002_create_daily_actions.ts
+++ b/packages/usage/lib/clickhouse/migrations/20260407000002_create_daily_actions.ts
@@ -5,13 +5,6 @@ export const sql = [
         day              Date,
         account_id       Int64,
         environment_id   Int64,
-<<<<<<< HEAD
-<<<<<<< HEAD
-=======
-        environment_name LowCardinality(String),
->>>>>>> d86fbb6a3 (chore(usage): add clickhouse materialized views for metrics)
-=======
->>>>>>> 32761a3e8 (fix: remove environment_name and add ttl)
         integration_id   LowCardinality(String),
         connection_id    String,
         action_name      String,
@@ -19,16 +12,8 @@ export const sql = [
     )
     ENGINE = SummingMergeTree(value)
     PARTITION BY toYYYYMM(day)
-<<<<<<< HEAD
-<<<<<<< HEAD
     ORDER BY (account_id, day, environment_id, integration_id, connection_id, action_name)
     TTL day + INTERVAL 24 MONTH
-=======
-    ORDER BY (account_id, environment_id, integration_id, connection_id, action_name, day)
->>>>>>> d86fbb6a3 (chore(usage): add clickhouse materialized views for metrics)
-=======
-    ORDER BY (account_id, day, environment_id, integration_id, connection_id, action_name)
->>>>>>> 32761a3e8 (fix: remove environment_name and add ttl)
     `,
     `
     CREATE MATERIALIZED VIEW IF NOT EXISTS usage.daily_actions_mv
@@ -37,27 +22,12 @@ export const sql = [
         toDate(ts)                          AS day,
         account_id,
         attributes.environmentId::Int64     AS environment_id,
-<<<<<<< HEAD
-<<<<<<< HEAD
-=======
-        attributes.environmentName::String  AS environment_name,
->>>>>>> d86fbb6a3 (chore(usage): add clickhouse materialized views for metrics)
-=======
->>>>>>> 32761a3e8 (fix: remove environment_name and add ttl)
         attributes.integrationId::String    AS integration_id,
         attributes.connectionId::String     AS connection_id,
         attributes.actionName::String       AS action_name,
         sum(value)                          AS value
     FROM usage.raw_events
     WHERE type = 'usage.actions'
-<<<<<<< HEAD
-<<<<<<< HEAD
     GROUP BY day, account_id, environment_id, integration_id, connection_id, action_name
-=======
-    GROUP BY day, account_id, environment_id, environment_name, integration_id, connection_id, action_name
->>>>>>> d86fbb6a3 (chore(usage): add clickhouse materialized views for metrics)
-=======
-    GROUP BY day, account_id, environment_id, integration_id, connection_id, action_name
->>>>>>> 32761a3e8 (fix: remove environment_name and add ttl)
     `
 ];

--- a/packages/usage/lib/clickhouse/migrations/20260407000002_create_daily_actions.ts
+++ b/packages/usage/lib/clickhouse/migrations/20260407000002_create_daily_actions.ts
@@ -5,6 +5,10 @@ export const sql = [
         day              Date,
         account_id       Int64,
         environment_id   Int64,
+<<<<<<< HEAD
+=======
+        environment_name LowCardinality(String),
+>>>>>>> d86fbb6a3 (chore(usage): add clickhouse materialized views for metrics)
         integration_id   LowCardinality(String),
         connection_id    String,
         action_name      String,
@@ -12,8 +16,12 @@ export const sql = [
     )
     ENGINE = SummingMergeTree(value)
     PARTITION BY toYYYYMM(day)
+<<<<<<< HEAD
     ORDER BY (account_id, day, environment_id, integration_id, connection_id, action_name)
     TTL day + INTERVAL 24 MONTH
+=======
+    ORDER BY (account_id, environment_id, integration_id, connection_id, action_name, day)
+>>>>>>> d86fbb6a3 (chore(usage): add clickhouse materialized views for metrics)
     `,
     `
     CREATE MATERIALIZED VIEW IF NOT EXISTS usage.daily_actions_mv
@@ -22,12 +30,20 @@ export const sql = [
         toDate(ts)                          AS day,
         account_id,
         attributes.environmentId::Int64     AS environment_id,
+<<<<<<< HEAD
+=======
+        attributes.environmentName::String  AS environment_name,
+>>>>>>> d86fbb6a3 (chore(usage): add clickhouse materialized views for metrics)
         attributes.integrationId::String    AS integration_id,
         attributes.connectionId::String     AS connection_id,
         attributes.actionName::String       AS action_name,
         sum(value)                          AS value
     FROM usage.raw_events
     WHERE type = 'usage.actions'
+<<<<<<< HEAD
     GROUP BY day, account_id, environment_id, integration_id, connection_id, action_name
+=======
+    GROUP BY day, account_id, environment_id, environment_name, integration_id, connection_id, action_name
+>>>>>>> d86fbb6a3 (chore(usage): add clickhouse materialized views for metrics)
     `
 ];

--- a/packages/usage/lib/clickhouse/migrations/20260407000002_create_daily_actions.ts
+++ b/packages/usage/lib/clickhouse/migrations/20260407000002_create_daily_actions.ts
@@ -6,9 +6,12 @@ export const sql = [
         account_id       Int64,
         environment_id   Int64,
 <<<<<<< HEAD
+<<<<<<< HEAD
 =======
         environment_name LowCardinality(String),
 >>>>>>> d86fbb6a3 (chore(usage): add clickhouse materialized views for metrics)
+=======
+>>>>>>> 32761a3e8 (fix: remove environment_name and add ttl)
         integration_id   LowCardinality(String),
         connection_id    String,
         action_name      String,
@@ -17,11 +20,15 @@ export const sql = [
     ENGINE = SummingMergeTree(value)
     PARTITION BY toYYYYMM(day)
 <<<<<<< HEAD
+<<<<<<< HEAD
     ORDER BY (account_id, day, environment_id, integration_id, connection_id, action_name)
     TTL day + INTERVAL 24 MONTH
 =======
     ORDER BY (account_id, environment_id, integration_id, connection_id, action_name, day)
 >>>>>>> d86fbb6a3 (chore(usage): add clickhouse materialized views for metrics)
+=======
+    ORDER BY (account_id, day, environment_id, integration_id, connection_id, action_name)
+>>>>>>> 32761a3e8 (fix: remove environment_name and add ttl)
     `,
     `
     CREATE MATERIALIZED VIEW IF NOT EXISTS usage.daily_actions_mv
@@ -31,9 +38,12 @@ export const sql = [
         account_id,
         attributes.environmentId::Int64     AS environment_id,
 <<<<<<< HEAD
+<<<<<<< HEAD
 =======
         attributes.environmentName::String  AS environment_name,
 >>>>>>> d86fbb6a3 (chore(usage): add clickhouse materialized views for metrics)
+=======
+>>>>>>> 32761a3e8 (fix: remove environment_name and add ttl)
         attributes.integrationId::String    AS integration_id,
         attributes.connectionId::String     AS connection_id,
         attributes.actionName::String       AS action_name,
@@ -41,9 +51,13 @@ export const sql = [
     FROM usage.raw_events
     WHERE type = 'usage.actions'
 <<<<<<< HEAD
+<<<<<<< HEAD
     GROUP BY day, account_id, environment_id, integration_id, connection_id, action_name
 =======
     GROUP BY day, account_id, environment_id, environment_name, integration_id, connection_id, action_name
 >>>>>>> d86fbb6a3 (chore(usage): add clickhouse materialized views for metrics)
+=======
+    GROUP BY day, account_id, environment_id, integration_id, connection_id, action_name
+>>>>>>> 32761a3e8 (fix: remove environment_name and add ttl)
     `
 ];

--- a/packages/usage/lib/clickhouse/migrations/20260407000003_create_daily_function_executions.ts
+++ b/packages/usage/lib/clickhouse/migrations/20260407000003_create_daily_function_executions.ts
@@ -1,0 +1,46 @@
+export const sql = [
+    `
+    CREATE TABLE IF NOT EXISTS usage.daily_function_executions
+    (
+        day              Date,
+        account_id       Int64,
+        environment_id   Int64,
+        environment_name LowCardinality(String),
+        integration_id   LowCardinality(String),
+        connection_id    String,
+        function_name    String,
+        function_type    LowCardinality(String),
+        success          Bool,
+        runtime          LowCardinality(String),
+        value            Int64,
+        duration_ms      UInt64,
+        custom_logs      UInt64,
+        proxy_calls      UInt64
+    )
+    ENGINE = SummingMergeTree((value, duration_ms, custom_logs, proxy_calls))
+    PARTITION BY toYYYYMM(day)
+    ORDER BY (account_id, environment_id, integration_id, connection_id, function_name, function_type, success, runtime, day)
+    `,
+    `
+    CREATE MATERIALIZED VIEW IF NOT EXISTS usage.daily_function_executions_mv
+    TO usage.daily_function_executions AS
+    SELECT
+        toDate(ts)                                                              AS day,
+        account_id,
+        attributes.environmentId::Int64                                         AS environment_id,
+        attributes.environmentName::String                                      AS environment_name,
+        attributes.integrationId::String                                        AS integration_id,
+        attributes.connectionId::String                                         AS connection_id,
+        attributes.functionName::String                                         AS function_name,
+        attributes.type::String                                                 AS function_type,
+        attributes.success::Bool                                                AS success,
+        attributes.runtime::String                                              AS runtime,
+        sum(value)                                                              AS value,
+        sum(coalesce(attributes.telemetryBag.durationMs::Nullable(UInt64), 0))  AS duration_ms,
+        sum(coalesce(attributes.telemetryBag.customLogs::Nullable(UInt64), 0))  AS custom_logs,
+        sum(coalesce(attributes.telemetryBag.proxyCalls::Nullable(UInt64), 0))  AS proxy_calls
+    FROM usage.raw_events
+    WHERE type = 'usage.function_executions'
+    GROUP BY day, account_id, environment_id, environment_name, integration_id, connection_id, function_name, function_type, success, runtime
+    `
+];

--- a/packages/usage/lib/clickhouse/migrations/20260407000003_create_daily_function_executions.ts
+++ b/packages/usage/lib/clickhouse/migrations/20260407000003_create_daily_function_executions.ts
@@ -5,7 +5,6 @@ export const sql = [
         day              Date,
         account_id       Int64,
         environment_id   Int64,
-        environment_name LowCardinality(String),
         integration_id   LowCardinality(String),
         connection_id    String,
         function_name    String,
@@ -19,7 +18,8 @@ export const sql = [
     )
     ENGINE = SummingMergeTree((value, duration_ms, custom_logs, proxy_calls))
     PARTITION BY toYYYYMM(day)
-    ORDER BY (account_id, environment_id, integration_id, connection_id, function_name, function_type, success, runtime, day)
+    ORDER BY (account_id, day, environment_id, integration_id, connection_id, function_name, function_type, success, runtime)
+    TTL day + INTERVAL 24 MONTH
     `,
     `
     CREATE MATERIALIZED VIEW IF NOT EXISTS usage.daily_function_executions_mv
@@ -28,7 +28,6 @@ export const sql = [
         toDate(ts)                                                              AS day,
         account_id,
         attributes.environmentId::Int64                                         AS environment_id,
-        attributes.environmentName::String                                      AS environment_name,
         attributes.integrationId::String                                        AS integration_id,
         attributes.connectionId::String                                         AS connection_id,
         attributes.functionName::String                                         AS function_name,
@@ -41,6 +40,6 @@ export const sql = [
         sum(coalesce(attributes.telemetryBag.proxyCalls::Nullable(UInt64), 0))  AS proxy_calls
     FROM usage.raw_events
     WHERE type = 'usage.function_executions'
-    GROUP BY day, account_id, environment_id, environment_name, integration_id, connection_id, function_name, function_type, success, runtime
+    GROUP BY day, account_id, environment_id, integration_id, connection_id, function_name, function_type, success, runtime
     `
 ];

--- a/packages/usage/lib/clickhouse/migrations/20260407000004_create_daily_proxy.ts
+++ b/packages/usage/lib/clickhouse/migrations/20260407000004_create_daily_proxy.ts
@@ -5,14 +5,14 @@ export const sql = [
         day              Date,
         account_id       Int64,
         environment_id   Int64,
-        environment_name LowCardinality(String),
         integration_id   LowCardinality(String),
         success          Bool,
         value            Int64
     )
     ENGINE = SummingMergeTree(value)
     PARTITION BY toYYYYMM(day)
-    ORDER BY (account_id, environment_id, integration_id, success, day)
+    ORDER BY (account_id, day, environment_id, integration_id, success)
+    TTL day + INTERVAL 24 MONTH
     `,
     `
     CREATE MATERIALIZED VIEW IF NOT EXISTS usage.daily_proxy_mv
@@ -21,12 +21,11 @@ export const sql = [
         toDate(ts)                          AS day,
         account_id,
         attributes.environmentId::Int64     AS environment_id,
-        attributes.environmentName::String  AS environment_name,
         attributes.integrationId::String    AS integration_id,
         attributes.success::Bool            AS success,
         sum(value)                          AS value
     FROM usage.raw_events
     WHERE type = 'usage.proxy'
-    GROUP BY day, account_id, environment_id, environment_name, integration_id, success
+    GROUP BY day, account_id, environment_id, integration_id, success
     `
 ];

--- a/packages/usage/lib/clickhouse/migrations/20260407000004_create_daily_proxy.ts
+++ b/packages/usage/lib/clickhouse/migrations/20260407000004_create_daily_proxy.ts
@@ -1,0 +1,32 @@
+export const sql = [
+    `
+    CREATE TABLE IF NOT EXISTS usage.daily_proxy
+    (
+        day              Date,
+        account_id       Int64,
+        environment_id   Int64,
+        environment_name LowCardinality(String),
+        integration_id   LowCardinality(String),
+        success          Bool,
+        value            Int64
+    )
+    ENGINE = SummingMergeTree(value)
+    PARTITION BY toYYYYMM(day)
+    ORDER BY (account_id, environment_id, integration_id, success, day)
+    `,
+    `
+    CREATE MATERIALIZED VIEW IF NOT EXISTS usage.daily_proxy_mv
+    TO usage.daily_proxy AS
+    SELECT
+        toDate(ts)                          AS day,
+        account_id,
+        attributes.environmentId::Int64     AS environment_id,
+        attributes.environmentName::String  AS environment_name,
+        attributes.integrationId::String    AS integration_id,
+        attributes.success::Bool            AS success,
+        sum(value)                          AS value
+    FROM usage.raw_events
+    WHERE type = 'usage.proxy'
+    GROUP BY day, account_id, environment_id, environment_name, integration_id, success
+    `
+];

--- a/packages/usage/lib/clickhouse/migrations/20260407000005_create_daily_webhook_forward.ts
+++ b/packages/usage/lib/clickhouse/migrations/20260407000005_create_daily_webhook_forward.ts
@@ -1,0 +1,32 @@
+export const sql = [
+    `
+    CREATE TABLE IF NOT EXISTS usage.daily_webhook_forward
+    (
+        day              Date,
+        account_id       Int64,
+        environment_id   Int64,
+        environment_name LowCardinality(String),
+        integration_id   LowCardinality(String),
+        success          Bool,
+        value            Int64
+    )
+    ENGINE = SummingMergeTree(value)
+    PARTITION BY toYYYYMM(day)
+    ORDER BY (account_id, environment_id, integration_id, success, day)
+    `,
+    `
+    CREATE MATERIALIZED VIEW IF NOT EXISTS usage.daily_webhook_forward_mv
+    TO usage.daily_webhook_forward AS
+    SELECT
+        toDate(ts)                          AS day,
+        account_id,
+        attributes.environmentId::Int64     AS environment_id,
+        attributes.environmentName::String  AS environment_name,
+        attributes.integrationId::String    AS integration_id,
+        attributes.success::Bool            AS success,
+        sum(value)                          AS value
+    FROM usage.raw_events
+    WHERE type = 'usage.webhook_forward'
+    GROUP BY day, account_id, environment_id, environment_name, integration_id, success
+    `
+];

--- a/packages/usage/lib/clickhouse/migrations/20260407000005_create_daily_webhook_forward.ts
+++ b/packages/usage/lib/clickhouse/migrations/20260407000005_create_daily_webhook_forward.ts
@@ -5,14 +5,14 @@ export const sql = [
         day              Date,
         account_id       Int64,
         environment_id   Int64,
-        environment_name LowCardinality(String),
         integration_id   LowCardinality(String),
         success          Bool,
         value            Int64
     )
     ENGINE = SummingMergeTree(value)
     PARTITION BY toYYYYMM(day)
-    ORDER BY (account_id, environment_id, integration_id, success, day)
+    ORDER BY (account_id, day, environment_id, integration_id, success)
+    TTL day + INTERVAL 24 MONTH
     `,
     `
     CREATE MATERIALIZED VIEW IF NOT EXISTS usage.daily_webhook_forward_mv
@@ -21,12 +21,11 @@ export const sql = [
         toDate(ts)                          AS day,
         account_id,
         attributes.environmentId::Int64     AS environment_id,
-        attributes.environmentName::String  AS environment_name,
         attributes.integrationId::String    AS integration_id,
         attributes.success::Bool            AS success,
         sum(value)                          AS value
     FROM usage.raw_events
     WHERE type = 'usage.webhook_forward'
-    GROUP BY day, account_id, environment_id, environment_name, integration_id, success
+    GROUP BY day, account_id, environment_id, integration_id, success
     `
 ];


### PR DESCRIPTION
Creating a materialized view for each billing metric (with daily granularity) in order to be able to quickly retrieve the aggregated values for a specific customer.

Next: querying the materialized views to get metrics per account with breakdown

<!-- Summary by @propel-code-bot -->

---

**Add daily ClickHouse materialized views for usage billing metrics**

This PR introduces five new ClickHouse migrations that create daily aggregated tables plus materialized views for billing-related usage metrics sourced from `usage.raw_events`. The new aggregates cover `usage.monthly_active_records`, `usage.actions`, `usage.function_executions`, `usage.proxy`, and `usage.webhook_forward`, enabling faster per-customer retrieval at daily granularity.

To support multi-statement migrations, the migration runner in `packages/usage/lib/clickhouse/migrate.ts` now expects `sql` as `string[]` and executes each statement in sequence. The existing raw events migration was updated from a single SQL string to an array format for compatibility.

---
*This summary was automatically generated by @propel-code-bot*