### PR TITLE
fix(vulns): fix vulns

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -3761,9 +3761,9 @@
             }
         },
         "node_modules/@hono/node-server": {
-            "version": "1.19.11",
-            "resolved": "https://registry.npmjs.org/@hono/node-server/-/node-server-1.19.11.tgz",
-            "integrity": "sha512-dr8/3zEaB+p0D2n/IUrlPF1HZm586qgJNXK1a9fhg/PzdtkK7Ksd5l312tJX2yBuALqDYBlG20QEbayqPyxn+g==",
+            "version": "1.19.13",
+            "resolved": "https://registry.npmjs.org/@hono/node-server/-/node-server-1.19.13.tgz",
+            "integrity": "sha512-TsQLe4i2gvoTtrHje625ngThGBySOgSK3Xo2XRYOdqGN1teR8+I7vchQC46uLJi8OF62YTYA3AhSpumtkhsaKQ==",
             "license": "MIT",
             "engines": {
                 "node": ">=18.14.1"
@@ -22565,9 +22565,9 @@
             "license": "MIT"
         },
         "node_modules/hono": {
-            "version": "4.12.7",
-            "resolved": "https://registry.npmjs.org/hono/-/hono-4.12.7.tgz",
-            "integrity": "sha512-jq9l1DM0zVIvsm3lv9Nw9nlJnMNPOcAtsbsgiUhWcFzPE99Gvo6yRTlszSLLYacMeQ6quHD6hMfId8crVHvexw==",
+            "version": "4.12.12",
+            "resolved": "https://registry.npmjs.org/hono/-/hono-4.12.12.tgz",
+            "integrity": "sha512-p1JfQMKaceuCbpJKAPKVqyqviZdS0eUxH9v82oWo1kb9xjQ5wA6iP3FNVAPDFlz5/p7d45lO+BpSk1tuSZMF4Q==",
             "license": "MIT",
             "engines": {
                 "node": ">=16.9.0"
@@ -24179,7 +24179,6 @@
             "os": [
                 "android"
             ],
-            "peer": true,
             "engines": {
                 "node": ">= 12.0.0"
             },
@@ -24201,7 +24200,6 @@
             "os": [
                 "darwin"
             ],
-            "peer": true,
             "engines": {
                 "node": ">= 12.0.0"
             },
@@ -24223,7 +24221,6 @@
             "os": [
                 "darwin"
             ],
-            "peer": true,
             "engines": {
                 "node": ">= 12.0.0"
             },
@@ -24245,7 +24242,6 @@
             "os": [
                 "freebsd"
             ],
-            "peer": true,
             "engines": {
                 "node": ">= 12.0.0"
             },
@@ -24267,7 +24263,6 @@
             "os": [
                 "linux"
             ],
-            "peer": true,
             "engines": {
                 "node": ">= 12.0.0"
             },
@@ -24289,7 +24284,6 @@
             "os": [
                 "linux"
             ],
-            "peer": true,
             "engines": {
                 "node": ">= 12.0.0"
             },
@@ -24311,7 +24305,6 @@
             "os": [
                 "linux"
             ],
-            "peer": true,
             "engines": {
                 "node": ">= 12.0.0"
             },
@@ -24333,7 +24326,6 @@
             "os": [
                 "linux"
             ],
-            "peer": true,
             "engines": {
                 "node": ">= 12.0.0"
             },
@@ -24355,7 +24347,6 @@
             "os": [
                 "linux"
             ],
-            "peer": true,
             "engines": {
                 "node": ">= 12.0.0"
             },
@@ -24377,7 +24368,6 @@
             "os": [
                 "win32"
             ],
-            "peer": true,
             "engines": {
                 "node": ">= 12.0.0"
             },
@@ -24399,7 +24389,6 @@
             "os": [
                 "win32"
             ],
-            "peer": true,
             "engines": {
                 "node": ">= 12.0.0"
             },
@@ -31771,9 +31760,9 @@
             }
         },
         "node_modules/vite": {
-            "version": "7.3.1",
-            "resolved": "https://registry.npmjs.org/vite/-/vite-7.3.1.tgz",
-            "integrity": "sha512-w+N7Hifpc3gRjZ63vYBXA56dvvRlNWRczTdmCBBa+CotUzAPf5b7YMdMR/8CQoeYE5LX3W4wj6RYTgonm1b9DA==",
+            "version": "7.3.2",
+            "resolved": "https://registry.npmjs.org/vite/-/vite-7.3.2.tgz",
+            "integrity": "sha512-Bby3NOsna2jsjfLVOHKes8sGwgl4TT0E6vvpYgnAYDIF/tie7MRaFthmKuHx1NSXjiTueXH3do80FMQgvEktRg==",
             "dev": true,
             "license": "MIT",
             "dependencies": {
@@ -33695,7 +33684,7 @@
                 "tailwindcss": "4.1.13",
                 "tailwindcss-animate": "1.0.7",
                 "typescript": "5.8.3",
-                "vite": "7.3.1",
+                "vite": "7.3.2",
                 "vite-plugin-svgr": "4.5.0",
                 "zod": "4.0.5",
                 "zustand": "5.0.3"
@@ -35374,7 +35363,7 @@
                 "tw-animate-css": "1.3.8",
                 "typescript": "5.8.3",
                 "vaul": "1.1.2",
-                "vite": "7.3.1",
+                "vite": "7.3.2",
                 "vite-plugin-checker": "0.9.3",
                 "vite-plugin-svgr": "4.5.0",
                 "vitest": "3.2.4",

--- a/packages/connect-ui/package.json
+++ b/packages/connect-ui/package.json
@@ -40,7 +40,7 @@
         "tailwindcss": "4.1.13",
         "tailwindcss-animate": "1.0.7",
         "typescript": "5.8.3",
-        "vite": "7.3.1",
+        "vite": "7.3.2",
         "vite-plugin-svgr": "4.5.0",
         "zod": "4.0.5",
         "zustand": "5.0.3"

--- a/packages/webapp/package.json
+++ b/packages/webapp/package.json
@@ -99,7 +99,7 @@
         "tw-animate-css": "1.3.8",
         "typescript": "5.8.3",
         "vaul": "1.1.2",
-        "vite": "7.3.1",
+        "vite": "7.3.2",
         "vite-plugin-checker": "0.9.3",
         "vite-plugin-svgr": "4.5.0",
         "vitest": "3.2.4",


### PR DESCRIPTION
<!-- Describe the problem and your solution --> 

<!-- Issue ticket number and link (if applicable) -->

<!-- Testing instructions (skip if just adding/editing providers) -->


<!-- Summary by @propel-code-bot -->

---

**Update vulnerable frontend dependencies in `webapp` and `connect-ui`**

This PR performs a targeted dependency security update by bumping `vite` from `7.3.1` to `7.3.2` in both `packages/connect-ui/package.json` and `packages/webapp/package.json`. The lockfile (`package-lock.json`) is regenerated accordingly and also reflects transitive updates, including `hono` (`4.12.7` → `4.12.12`) and `@hono/node-server` (`1.19.11` → `1.19.13`).

No application source logic is changed; all modifications are package metadata and lockfile resolution updates intended to remediate known vulnerabilities.

---
*This summary was automatically generated by @propel-code-bot*