### PR TITLE
fix(webapp): don't allow toggling `prod` environment production status

### DIFF
--- a/packages/webapp/src/pages/Environment/Settings/General.tsx
+++ b/packages/webapp/src/pages/Environment/Settings/General.tsx
@@ -11,6 +11,7 @@ import { PROD_ENVIRONMENT_NAME } from '../../../constants';
 import { useDeleteEnvironment, useEnvironment, usePatchEnvironment } from '../../../hooks/useEnvironment';
 import { useMeta } from '../../../hooks/useMeta';
 import { useStore } from '../../../store';
+import { ConditionalTooltip } from '@/components-v2/ConditionalTooltip';
 import { EditableInput } from '@/components-v2/EditableInput';
 import { PermissionGate } from '@/components-v2/PermissionGate';
 import { Alert, AlertDescription } from '@/components-v2/ui/alert';
@@ -117,34 +118,39 @@ export const General: React.FC = () => {
                     </div>
                 }
             >
-                <PermissionGate condition={canToggleIsProduction}>
-                    {(allowed) => (
-                        <Switch
-                            disabled={!allowed}
-                            checked={environment?.is_production}
-                            onCheckedChange={(checked) =>
-                                confirm({
-                                    title: checked ? 'Upgrade to production environment' : 'Downgrade to non-production environment',
-                                    description: 'This impacts which team members have access to this environment.',
-                                    onConfirm: async () => {
-                                        await patchEnvironmentAsync({ is_production: checked });
-                                        await refetchMeta();
-                                        toast({
-                                            title: `Successfully ${checked ? 'upgraded' : 'downgraded'} to ${checked ? 'production' : 'non-production'} environment`,
-                                            variant: 'success'
-                                        });
-                                    },
-                                    confirmButtonText: checked ? 'Upgrade' : 'Downgrade',
-                                    confirmVariant: 'destructive',
-                                    docs: {
-                                        title: 'Learn more',
-                                        url: 'https://docs.nango.dev/guides/platform/environments#production-environments'
-                                    }
-                                })
-                            }
-                        />
-                    )}
-                </PermissionGate>
+                <ConditionalTooltip
+                    condition={env === PROD_ENVIRONMENT_NAME}
+                    content={`You cannot change the production status of the ${PROD_ENVIRONMENT_NAME} environment`}
+                >
+                    <PermissionGate condition={canToggleIsProduction}>
+                        {(allowed) => (
+                            <Switch
+                                disabled={env === PROD_ENVIRONMENT_NAME || !allowed}
+                                checked={environment?.is_production}
+                                onCheckedChange={(checked) =>
+                                    confirm({
+                                        title: checked ? 'Upgrade to production environment' : 'Downgrade to non-production environment',
+                                        description: 'This impacts which team members have access to this environment.',
+                                        onConfirm: async () => {
+                                            await patchEnvironmentAsync({ is_production: checked });
+                                            await refetchMeta();
+                                            toast({
+                                                title: `Successfully ${checked ? 'upgraded' : 'downgraded'} to ${checked ? 'production' : 'non-production'} environment`,
+                                                variant: 'success'
+                                            });
+                                        },
+                                        confirmButtonText: checked ? 'Upgrade' : 'Downgrade',
+                                        confirmVariant: 'destructive',
+                                        docs: {
+                                            title: 'Learn more',
+                                            url: 'https://docs.nango.dev/guides/platform/environments#production-environments'
+                                        }
+                                    })
+                                }
+                            />
+                        )}
+                    </PermissionGate>
+                </ConditionalTooltip>
             </SettingsGroup>
 
             <SettingsGroup label="Environment suppression" className="items-center">


### PR DESCRIPTION
`prod` is a special environment that can't be renamed, deleted, and is always `is_production = true`. But the latter was not correctly reflected in the UI.
After change:
<img width="978" height="311" alt="image" src="https://github.com/user-attachments/assets/75fdf053-61af-4e89-a4d3-bca64ae3fb40" />

<!-- Summary by @propel-code-bot -->

---

**Disable `prod` Production Status Toggle in Environment Settings UI**

This PR fixes a UI behavior in `packages/webapp/src/pages/Environment/Settings/General.tsx` so the special `prod` environment can no longer have its production status toggled. The production switch is now explicitly disabled when `env === PROD_ENVIRONMENT_NAME`, aligning frontend behavior with the existing rule that `prod` is always production.

It also improves UX by wrapping the switch in `ConditionalTooltip` to explain why the control is disabled for `prod`. Existing permission-based gating via `PermissionGate` and toggle confirmation flow remain in place for non-`prod` environments.

---
*This summary was automatically generated by @propel-code-bot*