### PR TITLE
fix(webapp): correct RBAC docs link anchor fragment

### DIFF
--- a/packages/webapp/src/pages/Team/components/AddTeamMemberButton.tsx
+++ b/packages/webapp/src/pages/Team/components/AddTeamMemberButton.tsx
@@ -106,7 +106,7 @@ export const AddTeamMemberButton = () => {
                         </form>
                     </Form>
 
-                    <StyledLink to="https://docs.nango.dev/guides/platform/security#team-&-roles" type="external" icon>
+                    <StyledLink to="https://docs.nango.dev/guides/platform/security#teams-and-roles" type="external" icon>
                         Learn more about roles and permissions
                     </StyledLink>
                 </div>

--- a/packages/webapp/src/pages/Team/components/AddTeamMemberButton.tsx
+++ b/packages/webapp/src/pages/Team/components/AddTeamMemberButton.tsx
@@ -106,7 +106,7 @@ export const AddTeamMemberButton = () => {
                         </form>
                     </Form>
 
-                    <StyledLink to="https://docs.nango.dev/guides/platform/security#teams-and-roles" type="external" icon>
+                    <StyledLink to="https://docs.nango.dev/guides/platform/security#team-and-roles" type="external" icon>
                         Learn more about roles and permissions
                     </StyledLink>
                 </div>

--- a/packages/webapp/src/pages/Team/components/TeamMembers.tsx
+++ b/packages/webapp/src/pages/Team/components/TeamMembers.tsx
@@ -55,7 +55,7 @@ const EditRoleDialog: React.FC<{ user: ApiUser; onClose: () => void }> = ({ user
                         <Input type="email" value={user.email} disabled className="flex-1" />
                         <RoleSelect value={role} onChange={setRole} />
                     </div>
-                    <StyledLink to="https://docs.nango.dev/guides/platform/security#teams-and-roles" type="external" icon>
+                    <StyledLink to="https://docs.nango.dev/guides/platform/security#team-and-roles" type="external" icon>
                         Learn more about roles and permissions
                     </StyledLink>
                 </div>
@@ -125,7 +125,7 @@ export const TeamMembers: React.FC = () => {
                         <TableHead>
                             <div className="inline-flex items-center gap-0.5">
                                 <span>Role</span>
-                                <ButtonLink to="https://docs.nango.dev/guides/platform/security#teams-and-roles" size="icon" variant="ghost" target="_blank">
+                                <ButtonLink to="https://docs.nango.dev/guides/platform/security#team-and-roles" size="icon" variant="ghost" target="_blank">
                                     <ExternalLink className="size-3" />
                                 </ButtonLink>
                             </div>

--- a/packages/webapp/src/pages/Team/components/TeamMembers.tsx
+++ b/packages/webapp/src/pages/Team/components/TeamMembers.tsx
@@ -55,7 +55,7 @@ const EditRoleDialog: React.FC<{ user: ApiUser; onClose: () => void }> = ({ user
                         <Input type="email" value={user.email} disabled className="flex-1" />
                         <RoleSelect value={role} onChange={setRole} />
                     </div>
-                    <StyledLink to="https://docs.nango.dev/guides/platform/security#team-&-roles" type="external" icon>
+                    <StyledLink to="https://docs.nango.dev/guides/platform/security#teams-and-roles" type="external" icon>
                         Learn more about roles and permissions
                     </StyledLink>
                 </div>
@@ -125,7 +125,7 @@ export const TeamMembers: React.FC = () => {
                         <TableHead>
                             <div className="inline-flex items-center gap-0.5">
                                 <span>Role</span>
-                                <ButtonLink to="https://docs.nango.dev/guides/platform/security#team-&-roles" size="icon" variant="ghost" target="_blank">
+                                <ButtonLink to="https://docs.nango.dev/guides/platform/security#teams-and-roles" size="icon" variant="ghost" target="_blank">
                                     <ExternalLink className="size-3" />
                                 </ButtonLink>
                             </div>


### PR DESCRIPTION
## Summary
- Fix broken anchor links to the RBAC docs: `#team-&-roles` → `#teams-and-roles`
- Updated in `TeamMembers.tsx` (2 occurrences) and `AddTeamMemberButton.tsx` (1 occurrence)

Fixes NAN-5230

## Test plan
- [ ] Click the "Learn more about roles and permissions" link in the Team settings page and verify it scrolls to the correct section
- [ ] Click the external link icon next to "Role" in the team members table header and verify the same

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- Summary by @propel-code-bot -->

---

This is a narrowly scoped documentation-link correction in the Team UI that aligns all affected links with the actual RBAC docs anchor and keeps behavior consistent across entry points. The change is limited to URL target literals and does not alter business logic, permissions handling, state management, or API interactions.

---
*This summary was automatically generated by @propel-code-bot*