### PR TITLE
feat(webapp): gate auto-idling banner with PermissionGate

### DIFF
--- a/packages/webapp/src/pages/Integrations/components/AutoIdlingBanner.tsx
+++ b/packages/webapp/src/pages/Integrations/components/AutoIdlingBanner.tsx
@@ -1,11 +1,15 @@
 import { Clock, Loader2, TriangleAlert } from 'lucide-react';
 import { useState } from 'react';
 
+import { permissions } from '@nangohq/authz';
+
 import { useEnvironment } from '../../../hooks/useEnvironment';
 import { apiPostPlanExtendTrial, useTrial } from '../../../hooks/usePlan';
 import { useToast } from '../../../hooks/useToast';
 import { useStore } from '../../../store';
+import { PermissionGate } from '@/components-v2/PermissionGate';
 import { Alert, AlertActions, AlertButton, AlertButtonLink, AlertDescription, AlertTitle } from '@/components-v2/ui/alert';
+import { usePermissions } from '@/hooks/usePermissions';
 
 export const AutoIdlingBanner: React.FC = () => {
     const { toast } = useToast();
@@ -14,6 +18,9 @@ export const AutoIdlingBanner: React.FC = () => {
     const { data: environmentData, refetch: refetchEnv } = useEnvironment(env);
     const plan = environmentData?.plan;
     const { isTrial, isTrialOver, daysRemaining } = useTrial(plan);
+
+    const { can } = usePermissions();
+    const canExtendTrial = can(permissions.canChangePlan);
 
     const [trialLoading, setTrialLoading] = useState(false);
 
@@ -43,11 +50,15 @@ export const AutoIdlingBanner: React.FC = () => {
                 <AlertTitle>Functions paused</AlertTitle>
                 <AlertDescription>Functions are paused every 2 weeks on the free plan.</AlertDescription>
                 <AlertActions>
-                    <AlertButton variant={'warning-secondary'} onClick={onClickExtend} disabled={trialLoading}>
-                        {trialLoading && <Loader2 className="size-4 animate-spin" />}
-                        Restart
-                    </AlertButton>
-                    <AlertButtonLink variant={'warning'} to={`/${env}/team/billing`}>
+                    <PermissionGate condition={canExtendTrial}>
+                        {(allowed) => (
+                            <AlertButton variant={'warning-secondary'} onClick={onClickExtend} disabled={trialLoading || !allowed}>
+                                {trialLoading && <Loader2 className="animate-spin" />}
+                                Restart
+                            </AlertButton>
+                        )}
+                    </PermissionGate>
+                    <AlertButtonLink variant={'warning'} to={`/${env}/team/billing#plans`}>
                         Upgrade
                     </AlertButtonLink>
                 </AlertActions>
@@ -61,11 +72,15 @@ export const AutoIdlingBanner: React.FC = () => {
             <AlertTitle>Functions will pause in {daysRemaining} days</AlertTitle>
             <AlertDescription>Functions are paused every 2 weeks on the free plan.</AlertDescription>
             <AlertActions>
-                <AlertButton variant={'info-secondary'} onClick={onClickExtend} disabled={trialLoading}>
-                    {trialLoading && <Loader2 className="size-4 animate-spin" />}
-                    Extend
-                </AlertButton>
-                <AlertButtonLink variant={'info'} to={`/${env}/team/billing`}>
+                <PermissionGate condition={canExtendTrial}>
+                    {(allowed) => (
+                        <AlertButton variant={'info-secondary'} onClick={onClickExtend} disabled={trialLoading || !allowed}>
+                            {trialLoading && <Loader2 className="animate-spin" />}
+                            Extend
+                        </AlertButton>
+                    )}
+                </PermissionGate>
+                <AlertButtonLink variant={'info'} to={`/${env}/team/billing#plans`}>
                     Upgrade
                 </AlertButtonLink>
             </AlertActions>


### PR DESCRIPTION
Wrap Restart/Extend buttons in the `AutoIdlingBanner` with `PermissionGate` using the `canChangePlan` permission (same as the backend `POST /plans/trial/extension` route). Unauthorized roles see the buttons disabled with a tooltip. Also updates Upgrade links to anchor to `#plans`.

<!-- Issue ticket number and link (if applicable) -->

<!-- Testing instructions (skip if just adding/editing providers) -->
- Log in as a role without `canChangePlan` permission and verify the Restart/Extend buttons are disabled with a tooltip
- Log in as an admin and verify buttons work as before
- Verify Upgrade links navigate to the billing page `#plans` anchor