### PR TITLE
fix: gate auto-idling trial behavior on auto_idle

### DIFF
--- a/packages/server/lib/controllers/v1/flows/id/patchEnable.integration.test.ts
+++ b/packages/server/lib/controllers/v1/flows/id/patchEnable.integration.test.ts
@@ -1,0 +1,65 @@
+import { afterAll, beforeAll, describe, expect, it, vi } from 'vitest';
+
+import { getSyncConfigRaw, remoteFileService, seeders, updatePlan } from '@nangohq/shared';
+
+import db from '../../../../../../database/lib/index.js';
+import { isSuccess, runServer } from '../../../../utils/tests.js';
+
+let api: Awaited<ReturnType<typeof runServer>>;
+
+const deployEndpoint = '/api/v1/flows/pre-built/deploy';
+
+describe('PATCH /api/v1/flows/:id/enable', () => {
+    beforeAll(async () => {
+        api = await runServer();
+    });
+    afterAll(() => {
+        api.server.close();
+    });
+
+    it('should allow re-enabling a flow for non-auto-idling plans with stale expired trial fields', async () => {
+        vi.spyOn(remoteFileService, 'copy').mockResolvedValue('_LOCAL_FILE_');
+        const { env, plan, secret } = await seeders.seedAccountEnvAndUser();
+        const integration = await seeders.createConfigSeed(env, 'airtable-enable', 'airtable');
+        await updatePlan(db.knex, {
+            id: plan.id,
+            name: 'starter-v2',
+            auto_idle: false,
+            trial_start_at: new Date(Date.now() - 2 * 86400 * 1000),
+            trial_end_at: new Date(Date.now() - 86400 * 1000),
+            trial_end_notified_at: new Date(Date.now() - 12 * 3600 * 1000),
+            trial_extension_count: 3,
+            trial_expired: true
+        });
+
+        const deployRes = await api.fetch(deployEndpoint, {
+            method: 'POST',
+            query: { env: 'dev' },
+            token: secret.secret,
+            body: { provider: 'airtable', providerConfigKey: 'airtable-enable', scriptName: 'tables', type: 'sync' }
+        });
+
+        isSuccess(deployRes.json);
+        expect(deployRes.res.status).toBe(201);
+
+        const sync = await getSyncConfigRaw({ environmentId: env.id, config_id: integration.id!, name: 'tables', isAction: false });
+        expect(sync).not.toBeNull();
+
+        await db.knex.from('_nango_sync_configs').where({ id: sync!.id }).update({ enabled: false });
+
+        const res = await api.fetch(`/api/v1/flows/${sync!.id}/enable` as '/api/v1/flows/:id/enable', {
+            method: 'PATCH',
+            params: { id: sync!.id },
+            query: { env: 'dev' },
+            token: secret.secret,
+            body: { provider: 'airtable', providerConfigKey: 'airtable-enable', scriptName: 'tables', type: 'sync' }
+        });
+
+        isSuccess(res.json);
+        expect(res.res.status).toBe(200);
+        expect(res.json).toStrictEqual({ data: { success: true } });
+
+        const reenabled = await db.knex.from('_nango_sync_configs').where({ id: sync!.id }).first('enabled');
+        expect(reenabled?.enabled).toBe(true);
+    });
+});

--- a/packages/server/lib/controllers/v1/flows/id/patchEnable.ts
+++ b/packages/server/lib/controllers/v1/flows/id/patchEnable.ts
@@ -48,7 +48,7 @@ export const patchFlowEnable = asyncWrapper<PatchFlowEnable>(async (req, res) =>
         return;
     }
 
-    if (plan && plan.trial_end_at && plan.trial_end_at.getTime() < Date.now()) {
+    if (plan && plan.auto_idle && plan.trial_end_at && plan.trial_end_at.getTime() < Date.now()) {
         res.status(400).send({ error: { code: 'plan_limit', message: "Can't enable more scripts, upgrade or extend your auto idling period" } });
         return;
     }

--- a/packages/server/lib/controllers/v1/flows/preBuilt/postDeploy.integration.test.ts
+++ b/packages/server/lib/controllers/v1/flows/preBuilt/postDeploy.integration.test.ts
@@ -1,7 +1,8 @@
 import { afterAll, beforeAll, describe, expect, it, vi } from 'vitest';
 
-import { getSyncConfigRaw, remoteFileService, seeders } from '@nangohq/shared';
+import { getSyncConfigRaw, remoteFileService, seeders, updatePlan } from '@nangohq/shared';
 
+import db from '../../../../../../database/lib/index.js';
 import { isError, isSuccess, runServer, shouldBeProtected } from '../../../../utils/tests.js';
 
 let api: Awaited<ReturnType<typeof runServer>>;
@@ -164,5 +165,34 @@ describe(`POST ${endpoint}`, () => {
             version: '1.0.0',
             webhook_subscriptions: null
         });
+    });
+
+    it('should ignore stale expired trial fields for non-auto-idling plans', async () => {
+        vi.spyOn(remoteFileService, 'copy').mockResolvedValue('_LOCAL_FILE_');
+        const { env, plan, secret } = await seeders.seedAccountEnvAndUser();
+        const integration = await seeders.createConfigSeed(env, 'airtable-paid', 'airtable');
+        await updatePlan(db.knex, {
+            id: plan.id,
+            name: 'starter-v2',
+            auto_idle: false,
+            trial_start_at: new Date(Date.now() - 2 * 86400 * 1000),
+            trial_end_at: new Date(Date.now() - 86400 * 1000),
+            trial_end_notified_at: new Date(Date.now() - 12 * 3600 * 1000),
+            trial_extension_count: 3,
+            trial_expired: true
+        });
+
+        const res = await api.fetch(endpoint, {
+            method: 'POST',
+            query: { env: 'dev' },
+            token: secret.secret,
+            body: { provider: 'airtable', providerConfigKey: 'airtable-paid', scriptName: 'tables', type: 'sync' }
+        });
+
+        isSuccess(res.json);
+        expect(res.res.status).toBe(201);
+
+        const sync = await getSyncConfigRaw({ environmentId: env.id, config_id: integration.id!, name: 'tables', isAction: false });
+        expect(sync?.enabled).toBe(true);
     });
 });

--- a/packages/server/lib/controllers/v1/flows/preBuilt/postDeploy.ts
+++ b/packages/server/lib/controllers/v1/flows/preBuilt/postDeploy.ts
@@ -49,7 +49,7 @@ export const postPreBuiltDeploy = asyncWrapper<PostPreBuiltDeploy>(async (req, r
         return;
     }
 
-    if (plan && plan.trial_end_at && plan.trial_end_at.getTime() < Date.now()) {
+    if (plan && plan.auto_idle && plan.trial_end_at && plan.trial_end_at.getTime() < Date.now()) {
         res.status(400).send({ error: { code: 'plan_limit', message: "Can't enable more script, upgrade or extend your trial period" } });
         return;
     }

--- a/packages/server/lib/controllers/v1/plans/trial/postPlanExtendTrial.integration.test.ts
+++ b/packages/server/lib/controllers/v1/plans/trial/postPlanExtendTrial.integration.test.ts
@@ -74,4 +74,27 @@ describe(`POST ${route}`, () => {
         const newPlan = (await getPlan(db.knex, { accountId: plan.account_id })).unwrap();
         expect(newPlan.trial_end_at?.getTime()).toBeGreaterThan(endDate.getTime());
     });
+
+    it('should reject extending trial when auto idling is disabled even if trial fields are still set', async () => {
+        const { plan, secret } = await seeders.seedAccountEnvAndUser();
+
+        const endDate = new Date(Date.now() + TRIAL_DURATION);
+        await updatePlan(db.knex, {
+            id: plan.id,
+            auto_idle: false,
+            trial_start_at: new Date(),
+            trial_end_at: endDate
+        });
+
+        const res = await api.fetch(route, {
+            method: 'POST',
+            query: { env: 'dev' },
+            token: secret.secret
+        });
+
+        expect(res.res.status).toBe(400);
+        expect(res.json).toStrictEqual({
+            error: { code: 'conflict', message: 'No active trial' }
+        });
+    });
 });

--- a/packages/server/lib/controllers/v1/plans/trial/postPlanExtendTrial.ts
+++ b/packages/server/lib/controllers/v1/plans/trial/postPlanExtendTrial.ts
@@ -25,7 +25,7 @@ export const postPlanExtendTrial = asyncWrapper<PostPlanExtendTrial>(async (req,
         return;
     }
 
-    if (!plan || !plan.trial_start_at || !plan.trial_end_at || plan.name !== 'free') {
+    if (!plan || !plan.auto_idle || !plan.trial_start_at || !plan.trial_end_at || plan.name !== 'free') {
         res.status(400).send({ error: { code: 'conflict', message: 'No active trial' } });
         return;
     }

--- a/packages/shared/lib/services/plans/plans.ts
+++ b/packages/shared/lib/services/plans/plans.ts
@@ -128,19 +128,6 @@ export async function getExpiredTrials(db: Knex): Promise<DBPlan[]> {
         .where('plans.auto_idle', true);
 }
 
-export function resetTrialStateOnPlanChange(): Pick<
-    DBPlan,
-    'trial_start_at' | 'trial_end_at' | 'trial_end_notified_at' | 'trial_extension_count' | 'trial_expired'
-> {
-    return {
-        trial_start_at: null,
-        trial_end_at: null,
-        trial_end_notified_at: null,
-        trial_extension_count: 0,
-        trial_expired: null
-    };
-}
-
 export async function handlePlanChanged(
     db: Knex,
     team: DBTeam,
@@ -178,7 +165,15 @@ export async function handlePlanChanged(
         orb_future_plan_at: null,
         ...(orbCustomerId ? { orb_customer_id: orbCustomerId } : {}),
         ...(isCurrentFree && isNewPaid ? { orb_subscribed_at: new Date() } : {}),
-        ...resetTrialStateOnPlanChange(),
+        ...(currentPlan.value.auto_idle && mergedFlags.auto_idle === false
+            ? {
+                  trial_start_at: null,
+                  trial_end_at: null,
+                  trial_end_notified_at: null,
+                  trial_extension_count: 0,
+                  trial_expired: null
+              }
+            : {}),
         ...mergedFlags
     });
 

--- a/packages/shared/lib/services/plans/plans.ts
+++ b/packages/shared/lib/services/plans/plans.ts
@@ -111,7 +111,8 @@ export async function getTrialsApproachingExpiration(db: Knex, { daysLeft }: { d
             .select<DBPlan[]>('plans.*')
             .join('_nango_accounts', '_nango_accounts.id', 'plans.account_id')
             .where('trial_end_at', '<=', dateThreshold.toISOString())
-            .whereNull('trial_end_notified_at');
+            .whereNull('trial_end_notified_at')
+            .where('plans.auto_idle', true);
         return Ok(res);
     } catch (err) {
         return Err(new Error('failed_to_get_trials', { cause: err }));
@@ -123,7 +124,21 @@ export async function getExpiredTrials(db: Knex): Promise<DBPlan[]> {
         .from('plans')
         .select<DBPlan[]>('*')
         .where('plans.trial_end_at', '<=', db.raw('NOW()'))
-        .where((b) => b.where('plans.trial_expired', false).orWhereNull('plans.trial_expired'));
+        .where((b) => b.where('plans.trial_expired', false).orWhereNull('plans.trial_expired'))
+        .where('plans.auto_idle', true);
+}
+
+export function resetTrialStateOnPlanChange(): Pick<
+    DBPlan,
+    'trial_start_at' | 'trial_end_at' | 'trial_end_notified_at' | 'trial_extension_count' | 'trial_expired'
+> {
+    return {
+        trial_start_at: null,
+        trial_end_at: null,
+        trial_end_notified_at: null,
+        trial_extension_count: 0,
+        trial_expired: null
+    };
 }
 
 export async function handlePlanChanged(
@@ -163,6 +178,7 @@ export async function handlePlanChanged(
         orb_future_plan_at: null,
         ...(orbCustomerId ? { orb_customer_id: orbCustomerId } : {}),
         ...(isCurrentFree && isNewPaid ? { orb_subscribed_at: new Date() } : {}),
+        ...resetTrialStateOnPlanChange(),
         ...mergedFlags
     });
 

--- a/packages/shared/lib/services/plans/plans.unit.test.ts
+++ b/packages/shared/lib/services/plans/plans.unit.test.ts
@@ -1,7 +1,7 @@
 import { describe, expect, it } from 'vitest';
 
 import { getPlanDefinition } from './definitions.js';
-import { mergeFlags } from './plans.js';
+import { mergeFlags, resetTrialStateOnPlanChange } from './plans.js';
 
 import type { DBPlan, PlanDefinition } from '@nangohq/types';
 
@@ -71,6 +71,18 @@ describe('mergeFlags', () => {
                 // auto_idle: new plan more generous default (false)
                 // can_disable_connect_ui_watermark: new plan more generous default (true)
             });
+        });
+    });
+});
+
+describe('resetTrialStateOnPlanChange', () => {
+    it('should clear persisted trial state when a plan changes', () => {
+        expect(resetTrialStateOnPlanChange()).toStrictEqual({
+            trial_start_at: null,
+            trial_end_at: null,
+            trial_end_notified_at: null,
+            trial_extension_count: 0,
+            trial_expired: null
         });
     });
 });

--- a/packages/shared/lib/services/plans/plans.unit.test.ts
+++ b/packages/shared/lib/services/plans/plans.unit.test.ts
@@ -1,7 +1,7 @@
 import { describe, expect, it } from 'vitest';
 
 import { getPlanDefinition } from './definitions.js';
-import { mergeFlags, resetTrialStateOnPlanChange } from './plans.js';
+import { mergeFlags } from './plans.js';
 
 import type { DBPlan, PlanDefinition } from '@nangohq/types';
 
@@ -71,18 +71,6 @@ describe('mergeFlags', () => {
                 // auto_idle: new plan more generous default (false)
                 // can_disable_connect_ui_watermark: new plan more generous default (true)
             });
-        });
-    });
-});
-
-describe('resetTrialStateOnPlanChange', () => {
-    it('should clear persisted trial state when a plan changes', () => {
-        expect(resetTrialStateOnPlanChange()).toStrictEqual({
-            trial_start_at: null,
-            trial_end_at: null,
-            trial_end_notified_at: null,
-            trial_extension_count: 0,
-            trial_expired: null
         });
     });
 });

--- a/packages/webapp/src/hooks/usePlan.tsx
+++ b/packages/webapp/src/hooks/usePlan.tsx
@@ -94,7 +94,7 @@ export function useApiGetBillingUsage(env: string, timeframe?: { start: string; 
 
 export function useTrial(plan?: ApiPlan | null): { isTrial: boolean; isTrialOver: boolean; daysRemaining: number } {
     const res = useMemo<{ isTrial: boolean; isTrialOver: boolean; daysRemaining: number }>(() => {
-        if (!plan || !plan.trial_end_at) {
+        if (!plan || !plan.auto_idle || !plan.trial_end_at) {
             return { isTrial: false, isTrialOver: false, daysRemaining: 0 };
         }
         const days = Math.floor((new Date(plan.trial_end_at).getTime() - new Date().getTime()) / (86400 * 1000));


### PR DESCRIPTION
There were cases where the `AutoIdlingBanner` would show even when the `auto_idle` was off (happens in our nango admin account, for example). I noticed that most of our checks relied on `trial_end_at` without really checking `auto_idle`, and upgrading plans didn't clear out trial dates. This PR makes it so the trial data is cleared when upgrading to paid plans, but also adds `auto_idle` checks in places where it should have impact in to support accounts that have it off and still have `auto_idle` off. This way we can still just toggle the flag from retool and have it all working.