### PR TITLE
feat(server): add remote function public API

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -113,6 +113,10 @@ FLAG_SERVE_CONNECT_UI=true
 # ---- Role-based authorization (optional)
 # FLAG_AUTH_ROLES_ENABLED=false
 
+# ---- E2B sandboxes for remote functions
+# E2B_API_KEY=<E2B-API-KEY>
+# E2B_SANDBOX_COMPILER_TEMPLATE=blank-workspace:staging
+
 # ---- AWS
 # AWS_ACCESS_KEY_ID=<ACCESS-KEY-ID>
 # AWS_SECRET_ACCESS_KEY=<SECRET-ACCESS-KEY>

--- a/package-lock.json
+++ b/package-lock.json
@@ -2551,6 +2551,12 @@
             "version": "2.1.0",
             "license": "MIT"
         },
+        "node_modules/@bufbuild/protobuf": {
+            "version": "2.11.0",
+            "resolved": "https://registry.npmjs.org/@bufbuild/protobuf/-/protobuf-2.11.0.tgz",
+            "integrity": "sha512-sBXGT13cpmPR5BMgHE6UEEfEaShh5Ror6rfN3yEK5si7QVrtZg8LEPQb0VVhiLRUslD2yLnXtnRzG035J/mZXQ==",
+            "license": "(Apache-2.0 AND BSD-3-Clause)"
+        },
         "node_modules/@clickhouse/client": {
             "version": "1.18.2",
             "resolved": "https://registry.npmjs.org/@clickhouse/client/-/client-1.18.2.tgz",
@@ -2574,6 +2580,25 @@
             "license": "MIT",
             "engines": {
                 "node": ">=0.1.90"
+            }
+        },
+        "node_modules/@connectrpc/connect": {
+            "version": "2.0.0-rc.3",
+            "resolved": "https://registry.npmjs.org/@connectrpc/connect/-/connect-2.0.0-rc.3.tgz",
+            "integrity": "sha512-ARBt64yEyKbanyRETTjcjJuHr2YXorzQo0etyS5+P6oSeW8xEuzajA9g+zDnMcj1hlX2dQE93foIWQGfpru7gQ==",
+            "license": "Apache-2.0",
+            "peerDependencies": {
+                "@bufbuild/protobuf": "^2.2.0"
+            }
+        },
+        "node_modules/@connectrpc/connect-web": {
+            "version": "2.0.0-rc.3",
+            "resolved": "https://registry.npmjs.org/@connectrpc/connect-web/-/connect-web-2.0.0-rc.3.tgz",
+            "integrity": "sha512-w88P8Lsn5CCsA7MFRl2e6oLY4J/5toiNtJns/YJrlyQaWOy3RO8pDgkz+iIkG98RPMhj2thuBvsd3Cn4DKKCkw==",
+            "license": "Apache-2.0",
+            "peerDependencies": {
+                "@bufbuild/protobuf": "^2.2.0",
+                "@connectrpc/connect": "2.0.0-rc.3"
             }
         },
         "node_modules/@cspotcode/source-map-support": {
@@ -4404,6 +4429,18 @@
             },
             "funding": {
                 "url": "https://github.com/chalk/wrap-ansi?sponsor=1"
+            }
+        },
+        "node_modules/@isaacs/fs-minipass": {
+            "version": "4.0.1",
+            "resolved": "https://registry.npmjs.org/@isaacs/fs-minipass/-/fs-minipass-4.0.1.tgz",
+            "integrity": "sha512-wgm9Ehl2jpeqP3zw/7mo3kRHFp5MEDhqAdwy1fTGkHAwnkGOVsgpvQhL8B5n1qlb01jV3n/bI0ZfZp5lWA1k4w==",
+            "license": "ISC",
+            "dependencies": {
+                "minipass": "^7.0.4"
+            },
+            "engines": {
+                "node": ">=18.0.0"
             }
         },
         "node_modules/@isaacs/ttlcache": {
@@ -17954,6 +17991,12 @@
             "version": "1.0.1",
             "license": "MIT"
         },
+        "node_modules/compare-versions": {
+            "version": "6.1.1",
+            "resolved": "https://registry.npmjs.org/compare-versions/-/compare-versions-6.1.1.tgz",
+            "integrity": "sha512-4hm4VPpIecmlg59CHXnRDnqGplJFrbLG4aFEl5vl6cK1u76ws3LLvX7ikFnTDl5vo39sjWD6AaDPYodJp/NNHg==",
+            "license": "MIT"
+        },
         "node_modules/compress-commons": {
             "version": "6.0.2",
             "resolved": "https://registry.npmjs.org/compress-commons/-/compress-commons-6.0.2.tgz",
@@ -19290,6 +19333,19 @@
                 "node": ">= 8.0"
             }
         },
+        "node_modules/dockerfile-ast": {
+            "version": "0.7.1",
+            "resolved": "https://registry.npmjs.org/dockerfile-ast/-/dockerfile-ast-0.7.1.tgz",
+            "integrity": "sha512-oX/A4I0EhSkGqrFv0YuvPkBUSYp1XiY8O8zAKc8Djglx8ocz+JfOr8gP0ryRMC2myqvDLagmnZaU9ot1vG2ijw==",
+            "license": "MIT",
+            "dependencies": {
+                "vscode-languageserver-textdocument": "^1.0.8",
+                "vscode-languageserver-types": "^3.17.3"
+            },
+            "engines": {
+                "node": "*"
+            }
+        },
         "node_modules/dockerode": {
             "version": "4.0.9",
             "resolved": "https://registry.npmjs.org/dockerode/-/dockerode-4.0.9.tgz",
@@ -19561,6 +19617,112 @@
                 "inherits": "^2.0.3",
                 "readable-stream": "^3.1.1",
                 "stream-shift": "^1.0.2"
+            }
+        },
+        "node_modules/e2b": {
+            "version": "2.18.0",
+            "resolved": "https://registry.npmjs.org/e2b/-/e2b-2.18.0.tgz",
+            "integrity": "sha512-umWvNhKx3dWUfzcLPLO5Ep1qB5cTLuJlAlnxfKVUnOwx3yaO+H1PaAE2fihT4etEu3BNs3pHvdwa1VM+uMxe0w==",
+            "license": "MIT",
+            "dependencies": {
+                "@bufbuild/protobuf": "^2.6.2",
+                "@connectrpc/connect": "2.0.0-rc.3",
+                "@connectrpc/connect-web": "2.0.0-rc.3",
+                "chalk": "^5.3.0",
+                "compare-versions": "^6.1.0",
+                "dockerfile-ast": "^0.7.1",
+                "glob": "^11.1.0",
+                "openapi-fetch": "^0.14.1",
+                "platform": "^1.3.6",
+                "tar": "^7.5.11"
+            },
+            "engines": {
+                "node": ">=20"
+            }
+        },
+        "node_modules/e2b/node_modules/balanced-match": {
+            "version": "4.0.4",
+            "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-4.0.4.tgz",
+            "integrity": "sha512-BLrgEcRTwX2o6gGxGOCNyMvGSp35YofuYzw9h1IMTRmKqttAZZVU67bdb9Pr2vUHA8+j3i2tJfjO6C6+4myGTA==",
+            "license": "MIT",
+            "engines": {
+                "node": "18 || 20 || >=22"
+            }
+        },
+        "node_modules/e2b/node_modules/brace-expansion": {
+            "version": "5.0.5",
+            "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.5.tgz",
+            "integrity": "sha512-VZznLgtwhn+Mact9tfiwx64fA9erHH/MCXEUfB/0bX/6Fz6ny5EGTXYltMocqg4xFAQZtnO3DHWWXi8RiuN7cQ==",
+            "license": "MIT",
+            "dependencies": {
+                "balanced-match": "^4.0.2"
+            },
+            "engines": {
+                "node": "18 || 20 || >=22"
+            }
+        },
+        "node_modules/e2b/node_modules/glob": {
+            "version": "11.1.0",
+            "resolved": "https://registry.npmjs.org/glob/-/glob-11.1.0.tgz",
+            "integrity": "sha512-vuNwKSaKiqm7g0THUBu2x7ckSs3XJLXE+2ssL7/MfTGPLLcrJQ/4Uq1CjPTtO5cCIiRxqvN6Twy1qOwhL0Xjcw==",
+            "deprecated": "Old versions of glob are not supported, and contain widely publicized security vulnerabilities, which have been fixed in the current version. Please update. Support for old versions may be purchased (at exorbitant rates) by contacting i@izs.me",
+            "license": "BlueOak-1.0.0",
+            "dependencies": {
+                "foreground-child": "^3.3.1",
+                "jackspeak": "^4.1.1",
+                "minimatch": "^10.1.1",
+                "minipass": "^7.1.2",
+                "package-json-from-dist": "^1.0.0",
+                "path-scurry": "^2.0.0"
+            },
+            "bin": {
+                "glob": "dist/esm/bin.mjs"
+            },
+            "engines": {
+                "node": "20 || >=22"
+            },
+            "funding": {
+                "url": "https://github.com/sponsors/isaacs"
+            }
+        },
+        "node_modules/e2b/node_modules/lru-cache": {
+            "version": "11.3.3",
+            "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-11.3.3.tgz",
+            "integrity": "sha512-JvNw9Y81y33E+BEYPr0U7omo+U9AySnsMsEiXgwT6yqd31VQWTLNQqmT4ou5eqPFUrTfIDFta2wKhB1hyohtAQ==",
+            "license": "BlueOak-1.0.0",
+            "engines": {
+                "node": "20 || >=22"
+            }
+        },
+        "node_modules/e2b/node_modules/minimatch": {
+            "version": "10.2.5",
+            "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-10.2.5.tgz",
+            "integrity": "sha512-MULkVLfKGYDFYejP07QOurDLLQpcjk7Fw+7jXS2R2czRQzR56yHRveU5NDJEOviH+hETZKSkIk5c+T23GjFUMg==",
+            "license": "BlueOak-1.0.0",
+            "dependencies": {
+                "brace-expansion": "^5.0.5"
+            },
+            "engines": {
+                "node": "18 || 20 || >=22"
+            },
+            "funding": {
+                "url": "https://github.com/sponsors/isaacs"
+            }
+        },
+        "node_modules/e2b/node_modules/path-scurry": {
+            "version": "2.0.2",
+            "resolved": "https://registry.npmjs.org/path-scurry/-/path-scurry-2.0.2.tgz",
+            "integrity": "sha512-3O/iVVsJAPsOnpwWIeD+d6z/7PmqApyQePUtCndjatj/9I5LylHvt5qluFaBT3I5h3r1ejfR056c+FCv+NnNXg==",
+            "license": "BlueOak-1.0.0",
+            "dependencies": {
+                "lru-cache": "^11.0.0",
+                "minipass": "^7.1.2"
+            },
+            "engines": {
+                "node": "18 || 20 || >=22"
+            },
+            "funding": {
+                "url": "https://github.com/sponsors/isaacs"
             }
         },
         "node_modules/eastasianwidth": {
@@ -24197,6 +24359,7 @@
             "os": [
                 "android"
             ],
+            "peer": true,
             "engines": {
                 "node": ">= 12.0.0"
             },
@@ -24218,6 +24381,7 @@
             "os": [
                 "darwin"
             ],
+            "peer": true,
             "engines": {
                 "node": ">= 12.0.0"
             },
@@ -24239,6 +24403,7 @@
             "os": [
                 "darwin"
             ],
+            "peer": true,
             "engines": {
                 "node": ">= 12.0.0"
             },
@@ -24260,6 +24425,7 @@
             "os": [
                 "freebsd"
             ],
+            "peer": true,
             "engines": {
                 "node": ">= 12.0.0"
             },
@@ -24281,6 +24447,7 @@
             "os": [
                 "linux"
             ],
+            "peer": true,
             "engines": {
                 "node": ">= 12.0.0"
             },
@@ -24302,6 +24469,7 @@
             "os": [
                 "linux"
             ],
+            "peer": true,
             "engines": {
                 "node": ">= 12.0.0"
             },
@@ -24323,6 +24491,7 @@
             "os": [
                 "linux"
             ],
+            "peer": true,
             "engines": {
                 "node": ">= 12.0.0"
             },
@@ -24344,6 +24513,7 @@
             "os": [
                 "linux"
             ],
+            "peer": true,
             "engines": {
                 "node": ">= 12.0.0"
             },
@@ -24365,6 +24535,7 @@
             "os": [
                 "linux"
             ],
+            "peer": true,
             "engines": {
                 "node": ">= 12.0.0"
             },
@@ -24386,6 +24557,7 @@
             "os": [
                 "win32"
             ],
+            "peer": true,
             "engines": {
                 "node": ">= 12.0.0"
             },
@@ -24407,6 +24579,7 @@
             "os": [
                 "win32"
             ],
+            "peer": true,
             "engines": {
                 "node": ">= 12.0.0"
             },
@@ -25297,6 +25470,18 @@
                 "node": ">=16 || 14 >=14.17"
             }
         },
+        "node_modules/minizlib": {
+            "version": "3.1.0",
+            "resolved": "https://registry.npmjs.org/minizlib/-/minizlib-3.1.0.tgz",
+            "integrity": "sha512-KZxYo1BUkWD2TVFLr0MQoM8vUUigWD3LlD83a/75BqC+4qE0Hb1Vo5v1FgcfaNXvfXzr+5EhQ6ing/CaBijTlw==",
+            "license": "MIT",
+            "dependencies": {
+                "minipass": "^7.1.2"
+            },
+            "engines": {
+                "node": ">= 18"
+            }
+        },
         "node_modules/mitt": {
             "version": "3.0.1",
             "resolved": "https://registry.npmjs.org/mitt/-/mitt-3.0.1.tgz",
@@ -26138,6 +26323,15 @@
                 "url": "https://github.com/sponsors/sindresorhus"
             }
         },
+        "node_modules/openapi-fetch": {
+            "version": "0.14.1",
+            "resolved": "https://registry.npmjs.org/openapi-fetch/-/openapi-fetch-0.14.1.tgz",
+            "integrity": "sha512-l7RarRHxlEZYjMLd/PR0slfMVse2/vvIAGm75/F7J6MlQ8/b9uUQmUF2kCPrQhJqMXSxmYWObVgeYXbFYzZR+A==",
+            "license": "MIT",
+            "dependencies": {
+                "openapi-typescript-helpers": "^0.0.15"
+            }
+        },
         "node_modules/openapi-sampler": {
             "version": "1.7.0",
             "resolved": "https://registry.npmjs.org/openapi-sampler/-/openapi-sampler-1.7.0.tgz",
@@ -26156,6 +26350,12 @@
             "integrity": "sha512-N4YtSYJqghVu4iek2ZUvcN/0aqH1kRDuNqzcycDxhOUpg7GdvLa2F3DgS6yBNhInhv2r/6I0Flkn7CqL8+nIcw==",
             "dev": true,
             "peer": true
+        },
+        "node_modules/openapi-typescript-helpers": {
+            "version": "0.0.15",
+            "resolved": "https://registry.npmjs.org/openapi-typescript-helpers/-/openapi-typescript-helpers-0.0.15.tgz",
+            "integrity": "sha512-opyTPaunsklCBpTK8JGef6mfPhLSnyy5a0IN9vKtx3+4aExf+KxEqYwIy3hqkedXIB97u357uLMJsOnm3GVjsw==",
+            "license": "MIT"
         },
         "node_modules/openid-client": {
             "version": "6.6.2",
@@ -26814,6 +27014,12 @@
                 "mlly": "^1.7.4",
                 "pathe": "^2.0.1"
             }
+        },
+        "node_modules/platform": {
+            "version": "1.3.6",
+            "resolved": "https://registry.npmjs.org/platform/-/platform-1.3.6.tgz",
+            "integrity": "sha512-fnWVljUchTro6RiCFvCXBbNhJc2NijN7oIQxbwsyL0buWJPG85v81ehlHI9fXrJsMNgTofEoWIQeClKpgxFLrg==",
+            "license": "MIT"
         },
         "node_modules/pluralize": {
             "version": "8.0.0",
@@ -30332,6 +30538,22 @@
                 "url": "https://opencollective.com/webpack"
             }
         },
+        "node_modules/tar": {
+            "version": "7.5.13",
+            "resolved": "https://registry.npmjs.org/tar/-/tar-7.5.13.tgz",
+            "integrity": "sha512-tOG/7GyXpFevhXVh8jOPJrmtRpOTsYqUIkVdVooZYJS/z8WhfQUX8RJILmeuJNinGAMSu1veBr4asSHFt5/hng==",
+            "license": "BlueOak-1.0.0",
+            "dependencies": {
+                "@isaacs/fs-minipass": "^4.0.0",
+                "chownr": "^3.0.0",
+                "minipass": "^7.1.2",
+                "minizlib": "^3.1.0",
+                "yallist": "^5.0.0"
+            },
+            "engines": {
+                "node": ">=18"
+            }
+        },
         "node_modules/tar-fs": {
             "version": "3.1.1",
             "resolved": "https://registry.npmjs.org/tar-fs/-/tar-fs-3.1.1.tgz",
@@ -30355,6 +30577,24 @@
                 "b4a": "^1.6.4",
                 "fast-fifo": "^1.2.0",
                 "streamx": "^2.15.0"
+            }
+        },
+        "node_modules/tar/node_modules/chownr": {
+            "version": "3.0.0",
+            "resolved": "https://registry.npmjs.org/chownr/-/chownr-3.0.0.tgz",
+            "integrity": "sha512-+IxzY9BZOQd/XuYPRmrvEVjF/nqj5kgT4kEq7VofrDoM1MxoRjEWkrCC3EtLi59TVawxTAn+orJwFQcrqEN1+g==",
+            "license": "BlueOak-1.0.0",
+            "engines": {
+                "node": ">=18"
+            }
+        },
+        "node_modules/tar/node_modules/yallist": {
+            "version": "5.0.0",
+            "resolved": "https://registry.npmjs.org/yallist/-/yallist-5.0.0.tgz",
+            "integrity": "sha512-YgvUTfwqyc7UXVMrB+SImsVYSmTS8X/tSrtdNZMImM+n7+QTriRXyXim0mBrTXNeqzVF0KWGgHPeiyViFFrNDw==",
+            "license": "BlueOak-1.0.0",
+            "engines": {
+                "node": ">=18"
             }
         },
         "node_modules/tarn": {
@@ -32586,6 +32826,18 @@
             "funding": {
                 "url": "https://github.com/sponsors/jonschlinkert"
             }
+        },
+        "node_modules/vscode-languageserver-textdocument": {
+            "version": "1.0.12",
+            "resolved": "https://registry.npmjs.org/vscode-languageserver-textdocument/-/vscode-languageserver-textdocument-1.0.12.tgz",
+            "integrity": "sha512-cxWNPesCnQCcMPeenjKKsOCKQZ/L6Tv19DTRIGuLWe32lyzWhihGVJ/rcckZXJxfdKCFvRLS3fpBIsV/ZGX4zA==",
+            "license": "MIT"
+        },
+        "node_modules/vscode-languageserver-types": {
+            "version": "3.17.5",
+            "resolved": "https://registry.npmjs.org/vscode-languageserver-types/-/vscode-languageserver-types-3.17.5.tgz",
+            "integrity": "sha512-Ld1VelNuX9pdF39h2Hgaeb5hEZM2Z3jUrrMgWQAu82jMtZp7p3vJT3BzToKtZI7NgQssZje5o0zryOrhQvzQAg==",
+            "license": "MIT"
         },
         "node_modules/vscode-uri": {
             "version": "3.1.0",
@@ -34935,6 +35187,7 @@
                 "cors": "2.8.5",
                 "dd-trace": "5.52.0",
                 "dotenv": "16.5.0",
+                "e2b": "2.18.0",
                 "exponential-backoff": "3.1.1",
                 "express": "5.1.0",
                 "express-session": "1.18.2",

--- a/packages/database/lib/migrations/20260416140000_add_remote_functions_flag_to_plans.cjs
+++ b/packages/database/lib/migrations/20260416140000_add_remote_functions_flag_to_plans.cjs
@@ -1,0 +1,19 @@
+/**
+ * @param {import('knex').Knex} knex
+ */
+exports.up = async function (knex) {
+    await knex.schema.alterTable('plans', (table) => {
+        table.boolean('remote_functions').notNullable().defaultTo(false);
+    });
+};
+
+/**
+ * @param {import('knex').Knex} knex
+ */
+exports.down = async function (knex) {
+    await knex.schema.alterTable('plans', (table) => {
+        table.dropColumn('remote_functions');
+    });
+};
+
+exports.config = { transaction: true };

--- a/packages/server/lib/controllers/functions/compile/postCompile.ts
+++ b/packages/server/lib/controllers/functions/compile/postCompile.ts
@@ -49,7 +49,6 @@ export const postRemoteFunctionCompile = asyncWrapper<PostRemoteFunctionCompile>
     } catch (err) {
         sendStepError({
             res,
-            step: 'compilation',
             error: err,
             ...(err instanceof RemoteFunctionError ? {} : { status: 500 })
         });

--- a/packages/server/lib/controllers/functions/compile/postCompile.ts
+++ b/packages/server/lib/controllers/functions/compile/postCompile.ts
@@ -1,8 +1,8 @@
 import { configService } from '@nangohq/shared';
 import { requireEmptyQuery, zodErrorToHTTP } from '@nangohq/utils';
 
-import { CompilerError, invokeCompiler } from '../../../services/remote-function/compiler-client.js';
-import { sendStepError } from '../../../services/remote-function/helpers.js';
+import { invokeCompiler } from '../../../services/remote-function/compiler-client.js';
+import { RemoteFunctionError, sendStepError } from '../../../services/remote-function/helpers.js';
 import { asyncWrapper } from '../../../utils/asyncWrapper.js';
 import { remoteFunctionCompileBodySchema } from '../validation.js';
 
@@ -51,7 +51,7 @@ export const postRemoteFunctionCompile = asyncWrapper<PostRemoteFunctionCompile>
             res,
             step: 'compilation',
             error: err,
-            status: err instanceof CompilerError ? 400 : 500
+            ...(err instanceof RemoteFunctionError ? {} : { status: 500 })
         });
     }
 });

--- a/packages/server/lib/controllers/functions/compile/postCompile.ts
+++ b/packages/server/lib/controllers/functions/compile/postCompile.ts
@@ -1,0 +1,57 @@
+import { configService } from '@nangohq/shared';
+import { requireEmptyQuery, zodErrorToHTTP } from '@nangohq/utils';
+
+import { CompilerError, invokeCompiler } from '../../../services/remote-function/compiler-client.js';
+import { sendStepError } from '../../../services/remote-function/helpers.js';
+import { asyncWrapper } from '../../../utils/asyncWrapper.js';
+import { remoteFunctionCompileBodySchema } from '../validation.js';
+
+import type { PostRemoteFunctionCompile } from '@nangohq/types';
+
+export const postRemoteFunctionCompile = asyncWrapper<PostRemoteFunctionCompile>(async (req, res) => {
+    const emptyQuery = requireEmptyQuery(req);
+    if (emptyQuery) {
+        res.status(400).send({ error: { code: 'invalid_query_params', errors: zodErrorToHTTP(emptyQuery.error) } });
+        return;
+    }
+
+    const valBody = remoteFunctionCompileBodySchema.safeParse(req.body);
+    if (!valBody.success) {
+        res.status(400).send({ error: { code: 'invalid_body', errors: zodErrorToHTTP(valBody.error) } });
+        return;
+    }
+
+    const body = valBody.data;
+    const { environment } = res.locals;
+
+    const providerConfig = await configService.getProviderConfig(body.integration_id, environment.id);
+    if (!providerConfig) {
+        res.status(404).send({ error: { code: 'integration_not_found', message: `Integration '${body.integration_id}' was not found` } });
+        return;
+    }
+
+    try {
+        const result = await invokeCompiler({
+            integration_id: body.integration_id,
+            function_name: body.function_name,
+            function_type: body.function_type,
+            code: body.code
+        });
+
+        res.status(200).send({
+            integration_id: body.integration_id,
+            function_name: body.function_name,
+            function_type: body.function_type,
+            bundle_size_bytes: result.bundleSizeBytes,
+            bundled_js: result.bundledJs,
+            compiled_at: new Date().toISOString()
+        });
+    } catch (err) {
+        sendStepError({
+            res,
+            step: 'compilation',
+            error: err,
+            status: err instanceof CompilerError ? 400 : 500
+        });
+    }
+});

--- a/packages/server/lib/controllers/functions/deploy/postDeploy.ts
+++ b/packages/server/lib/controllers/functions/deploy/postDeploy.ts
@@ -1,0 +1,76 @@
+import db from '@nangohq/database';
+import { configService, getApiUrl, getSyncConfigRaw, secretService } from '@nangohq/shared';
+import { requireEmptyQuery, zodErrorToHTTP } from '@nangohq/utils';
+
+import { invokeDeploy } from '../../../services/remote-function/deploy-client.js';
+import { sendStepError } from '../../../services/remote-function/helpers.js';
+import { asyncWrapper } from '../../../utils/asyncWrapper.js';
+import { remoteFunctionDeployBodySchema } from '../validation.js';
+
+import type { PostRemoteFunctionDeploy } from '@nangohq/types';
+
+export const postRemoteFunctionDeploy = asyncWrapper<PostRemoteFunctionDeploy>(async (req, res) => {
+    const emptyQuery = requireEmptyQuery(req);
+    if (emptyQuery) {
+        res.status(400).send({ error: { code: 'invalid_query_params', errors: zodErrorToHTTP(emptyQuery.error) } });
+        return;
+    }
+
+    const valBody = remoteFunctionDeployBodySchema.safeParse(req.body);
+    if (!valBody.success) {
+        res.status(400).send({ error: { code: 'invalid_body', errors: zodErrorToHTTP(valBody.error) } });
+        return;
+    }
+
+    const body = valBody.data;
+    const { environment } = res.locals;
+
+    const providerConfig = await configService.getProviderConfig(body.integration_id, environment.id);
+    if (!providerConfig || !providerConfig.id) {
+        res.status(404).send({ error: { code: 'integration_not_found', message: `Integration '${body.integration_id}' was not found` } });
+        return;
+    }
+
+    const existingSyncConfig = await getSyncConfigRaw({
+        environmentId: environment.id,
+        config_id: providerConfig.id,
+        name: body.function_name,
+        isAction: body.function_type === 'action'
+    });
+    if (existingSyncConfig && (existingSyncConfig.is_public || existingSyncConfig.pre_built)) {
+        res.status(400).send({
+            error: {
+                code: 'invalid_request',
+                message: `Cannot overwrite pre-built function '${body.function_name}'`
+            }
+        });
+        return;
+    }
+
+    const defaultSecret = await secretService.getDefaultSecretForEnv(db.readOnly, environment.id);
+    if (defaultSecret.isErr()) {
+        sendStepError({ res, step: 'deployment', status: 500, error: defaultSecret.error });
+        return;
+    }
+
+    try {
+        const result = await invokeDeploy({
+            integration_id: body.integration_id,
+            function_name: body.function_name,
+            function_type: body.function_type,
+            code: body.code,
+            environment_name: environment.name,
+            nango_secret_key: defaultSecret.value.secret,
+            nango_host: getApiUrl()
+        });
+
+        res.status(200).send({
+            integration_id: body.integration_id,
+            function_name: body.function_name,
+            function_type: body.function_type,
+            output: result.output
+        });
+    } catch (err) {
+        sendStepError({ res, step: 'deployment', status: 500, error: err });
+    }
+});

--- a/packages/server/lib/controllers/functions/deploy/postDeploy.ts
+++ b/packages/server/lib/controllers/functions/deploy/postDeploy.ts
@@ -3,7 +3,7 @@ import { configService, getApiUrl, getSyncConfigRaw, secretService } from '@nang
 import { requireEmptyQuery, zodErrorToHTTP } from '@nangohq/utils';
 
 import { invokeDeploy } from '../../../services/remote-function/deploy-client.js';
-import { sendStepError } from '../../../services/remote-function/helpers.js';
+import { RemoteFunctionError, sendStepError } from '../../../services/remote-function/helpers.js';
 import { asyncWrapper } from '../../../utils/asyncWrapper.js';
 import { remoteFunctionDeployBodySchema } from '../validation.js';
 
@@ -71,6 +71,6 @@ export const postRemoteFunctionDeploy = asyncWrapper<PostRemoteFunctionDeploy>(a
             output: result.output
         });
     } catch (err) {
-        sendStepError({ res, step: 'deployment', status: 500, error: err });
+        sendStepError({ res, step: 'deployment', error: err, ...(err instanceof RemoteFunctionError ? {} : { status: 500 }) });
     }
 });

--- a/packages/server/lib/controllers/functions/deploy/postDeploy.ts
+++ b/packages/server/lib/controllers/functions/deploy/postDeploy.ts
@@ -49,7 +49,7 @@ export const postRemoteFunctionDeploy = asyncWrapper<PostRemoteFunctionDeploy>(a
 
     const defaultSecret = await secretService.getDefaultSecretForEnv(db.readOnly, environment.id);
     if (defaultSecret.isErr()) {
-        sendStepError({ res, step: 'deployment', status: 500, error: defaultSecret.error });
+        sendStepError({ res, status: 500, error: defaultSecret.error });
         return;
     }
 
@@ -71,6 +71,6 @@ export const postRemoteFunctionDeploy = asyncWrapper<PostRemoteFunctionDeploy>(a
             output: result.output
         });
     } catch (err) {
-        sendStepError({ res, step: 'deployment', error: err, ...(err instanceof RemoteFunctionError ? {} : { status: 500 }) });
+        sendStepError({ res, error: err, ...(err instanceof RemoteFunctionError ? {} : { status: 500 }) });
     }
 });

--- a/packages/server/lib/controllers/functions/dryrun/postDryrun.ts
+++ b/packages/server/lib/controllers/functions/dryrun/postDryrun.ts
@@ -3,7 +3,7 @@ import { connectionService, getApiUrl, secretService } from '@nangohq/shared';
 import { requireEmptyQuery, zodErrorToHTTP } from '@nangohq/utils';
 
 import { invokeDryrun } from '../../../services/remote-function/dryrun-client.js';
-import { sendStepError } from '../../../services/remote-function/helpers.js';
+import { RemoteFunctionError, sendStepError } from '../../../services/remote-function/helpers.js';
 import { asyncWrapper } from '../../../utils/asyncWrapper.js';
 import { remoteFunctionDryrunBodySchema } from '../validation.js';
 
@@ -71,6 +71,6 @@ export const postRemoteFunctionDryrun = asyncWrapper<PostRemoteFunctionDryrun>(a
             output: result.output
         });
     } catch (err) {
-        sendStepError({ res, step: 'execution', status: 500, error: err });
+        sendStepError({ res, step: 'execution', error: err, ...(err instanceof RemoteFunctionError ? {} : { status: 500 }) });
     }
 });

--- a/packages/server/lib/controllers/functions/dryrun/postDryrun.ts
+++ b/packages/server/lib/controllers/functions/dryrun/postDryrun.ts
@@ -29,7 +29,6 @@ export const postRemoteFunctionDryrun = asyncWrapper<PostRemoteFunctionDryrun>(a
     if (!connectionResult.success || !connectionResult.response) {
         sendStepError({
             res,
-            step: 'lookup',
             status: 404,
             error: { type: 'connection_not_found', message: `Connection '${body.connection_id}' was not found for integration '${body.integration_id}'` }
         });
@@ -38,7 +37,7 @@ export const postRemoteFunctionDryrun = asyncWrapper<PostRemoteFunctionDryrun>(a
 
     const defaultSecret = await secretService.getDefaultSecretForEnv(db.readOnly, environment.id);
     if (defaultSecret.isErr()) {
-        sendStepError({ res, step: 'lookup', status: 500, error: defaultSecret.error });
+        sendStepError({ res, status: 500, error: defaultSecret.error });
         return;
     }
 
@@ -71,6 +70,6 @@ export const postRemoteFunctionDryrun = asyncWrapper<PostRemoteFunctionDryrun>(a
             output: result.output
         });
     } catch (err) {
-        sendStepError({ res, step: 'execution', error: err, ...(err instanceof RemoteFunctionError ? {} : { status: 500 }) });
+        sendStepError({ res, error: err, ...(err instanceof RemoteFunctionError ? {} : { status: 500 }) });
     }
 });

--- a/packages/server/lib/controllers/functions/dryrun/postDryrun.ts
+++ b/packages/server/lib/controllers/functions/dryrun/postDryrun.ts
@@ -1,0 +1,76 @@
+import db from '@nangohq/database';
+import { connectionService, getApiUrl, secretService } from '@nangohq/shared';
+import { requireEmptyQuery, zodErrorToHTTP } from '@nangohq/utils';
+
+import { invokeDryrun } from '../../../services/remote-function/dryrun-client.js';
+import { sendStepError } from '../../../services/remote-function/helpers.js';
+import { asyncWrapper } from '../../../utils/asyncWrapper.js';
+import { remoteFunctionDryrunBodySchema } from '../validation.js';
+
+import type { PostRemoteFunctionDryrun } from '@nangohq/types';
+
+export const postRemoteFunctionDryrun = asyncWrapper<PostRemoteFunctionDryrun>(async (req, res) => {
+    const emptyQuery = requireEmptyQuery(req);
+    if (emptyQuery) {
+        res.status(400).send({ error: { code: 'invalid_query_params', errors: zodErrorToHTTP(emptyQuery.error) } });
+        return;
+    }
+
+    const valBody = remoteFunctionDryrunBodySchema.safeParse(req.body);
+    if (!valBody.success) {
+        res.status(400).send({ error: { code: 'invalid_body', errors: zodErrorToHTTP(valBody.error) } });
+        return;
+    }
+
+    const body = valBody.data;
+    const { environment } = res.locals;
+
+    const connectionResult = await connectionService.getConnection(body.connection_id, body.integration_id, environment.id);
+    if (!connectionResult.success || !connectionResult.response) {
+        sendStepError({
+            res,
+            step: 'lookup',
+            status: 404,
+            error: { type: 'connection_not_found', message: `Connection '${body.connection_id}' was not found for integration '${body.integration_id}'` }
+        });
+        return;
+    }
+
+    const defaultSecret = await secretService.getDefaultSecretForEnv(db.readOnly, environment.id);
+    if (defaultSecret.isErr()) {
+        sendStepError({ res, step: 'lookup', status: 500, error: defaultSecret.error });
+        return;
+    }
+
+    const startedAt = new Date();
+
+    try {
+        const result = await invokeDryrun({
+            integration_id: body.integration_id,
+            function_name: body.function_name,
+            function_type: body.function_type,
+            code: body.code,
+            environment_name: environment.name,
+            connection_id: body.connection_id,
+            nango_secret_key: defaultSecret.value.secret,
+            nango_host: getApiUrl(),
+            ...(body.input !== undefined ? { input: body.input } : {}),
+            ...(body.metadata ? { metadata: body.metadata } : {}),
+            ...(body.checkpoint ? { checkpoint: body.checkpoint } : {}),
+            ...(body.last_sync_date ? { last_sync_date: body.last_sync_date } : {})
+        });
+
+        const durationMs = Date.now() - startedAt.getTime();
+
+        res.status(200).send({
+            integration_id: body.integration_id,
+            function_name: body.function_name,
+            function_type: body.function_type,
+            execution_timeout_at: new Date(startedAt.getTime() + 5 * 60 * 1000).toISOString(),
+            duration_ms: durationMs,
+            output: result.output
+        });
+    } catch (err) {
+        sendStepError({ res, step: 'execution', status: 500, error: err });
+    }
+});

--- a/packages/server/lib/controllers/functions/remote-function.integration.test.ts
+++ b/packages/server/lib/controllers/functions/remote-function.integration.test.ts
@@ -1,0 +1,121 @@
+import { afterAll, beforeAll, describe, expect, it } from 'vitest';
+
+import { seeders } from '@nangohq/shared';
+
+import { isError, runServer, shouldBeProtected } from '../../utils/tests.js';
+
+let api: Awaited<ReturnType<typeof runServer>>;
+
+describe('remote-function public API', () => {
+    beforeAll(async () => {
+        api = await runServer();
+    });
+
+    afterAll(() => {
+        api.server.close();
+    });
+
+    it('protects POST /remote-function/compile', async () => {
+        const res = await api.fetch('/remote-function/compile', {
+            method: 'POST',
+            body: {
+                integration_id: 'github',
+                function_name: 'syncIssues',
+                function_type: 'sync',
+                code: 'export default {}'
+            }
+        });
+
+        shouldBeProtected(res);
+    });
+
+    it('rejects unsafe function names on POST /remote-function/compile', async () => {
+        const { secret } = await seeders.seedAccountEnvAndUser();
+
+        const res = await api.fetch('/remote-function/compile', {
+            method: 'POST',
+            token: secret.secret,
+            body: {
+                integration_id: 'github',
+                function_name: 'bad/name',
+                function_type: 'sync',
+                code: 'export default {}'
+            }
+        });
+
+        isError(res.json);
+        expect(res.res.status).toBe(400);
+        expect(res.json.error.code).toBe('invalid_body');
+    });
+
+    it('returns integration_not_found on POST /remote-function/compile', async () => {
+        const { secret } = await seeders.seedAccountEnvAndUser();
+
+        const res = await api.fetch('/remote-function/compile', {
+            method: 'POST',
+            token: secret.secret,
+            body: {
+                integration_id: 'github',
+                function_name: 'syncIssues',
+                function_type: 'sync',
+                code: 'export default {}'
+            }
+        });
+
+        expect(res.res.status).toBe(404);
+        expect(res.json).toStrictEqual({
+            error: {
+                code: 'integration_not_found',
+                message: "Integration 'github' was not found"
+            }
+        });
+    });
+
+    it('returns connection_not_found on POST /remote-function/dryrun', async () => {
+        const { env, secret } = await seeders.seedAccountEnvAndUser();
+        await seeders.createConfigSeed(env, 'github', 'github');
+
+        const res = await api.fetch('/remote-function/dryrun', {
+            method: 'POST',
+            token: secret.secret,
+            body: {
+                integration_id: 'github',
+                function_name: 'syncIssues',
+                function_type: 'sync',
+                code: 'export default {}',
+                connection_id: 'missing-connection'
+            }
+        });
+
+        expect(res.res.status).toBe(404);
+        expect(res.json).toStrictEqual({
+            error: {
+                code: 'connection_not_found',
+                message: "Connection 'missing-connection' was not found for integration 'github'"
+            }
+        });
+    });
+
+    it('returns integration_not_found on POST /remote-function/deploy', async () => {
+        const { secret } = await seeders.seedAccountEnvAndUser();
+
+        const res = await api.fetch('/remote-function/deploy', {
+            method: 'POST',
+            token: secret.secret,
+            body: {
+                integration_id: 'github',
+                function_name: 'syncIssues',
+                function_type: 'sync',
+                code: 'export default {}'
+            }
+        });
+
+        expect(res.res.status).toBe(404);
+        expect(res.json).toStrictEqual({
+            error: {
+                code: 'integration_not_found',
+                message: "Integration 'github' was not found"
+            }
+        });
+    });
+});

--- a/packages/server/lib/controllers/functions/remote-function.integration.test.ts
+++ b/packages/server/lib/controllers/functions/remote-function.integration.test.ts
@@ -7,7 +7,6 @@ import { isError, runServer, shouldBeProtected } from '../../utils/tests.js';
 
 let api: Awaited<ReturnType<typeof runServer>>;
 const originalNodeEnv = envs.NODE_ENV;
-const originalAdminUUID = envs.NANGO_ADMIN_UUID;
 
 describe('remote-function public API', () => {
     beforeAll(async () => {
@@ -20,7 +19,6 @@ describe('remote-function public API', () => {
 
     afterEach(() => {
         envs.NODE_ENV = originalNodeEnv;
-        envs.NANGO_ADMIN_UUID = originalAdminUUID;
     });
 
     it('protects POST /remote-function/compile', async () => {
@@ -79,36 +77,10 @@ describe('remote-function public API', () => {
         });
     });
 
-    it('rejects non-admin org secret keys in production', async () => {
+    it('allows valid secret keys in production', async () => {
         envs.NODE_ENV = 'production';
-        envs.NANGO_ADMIN_UUID = 'e1e8fee9-a459-46fe-9e82-15c93dae2406';
 
         const { secret } = await seeders.seedAccountEnvAndUser();
-
-        const res = await api.fetch('/remote-function/compile', {
-            method: 'POST',
-            token: secret.secret,
-            body: {
-                integration_id: 'github',
-                function_name: 'syncIssues',
-                function_type: 'sync',
-                code: 'export default {}'
-            }
-        });
-
-        expect(res.res.status).toBe(401);
-        expect(res.json).toStrictEqual({
-            error: {
-                code: 'unauthorized',
-                message: 'Unauthorized'
-            }
-        });
-    });
-
-    it('allows admin org secret keys in production', async () => {
-        envs.NODE_ENV = 'production';
-        const { account, secret } = await seeders.seedAccountEnvAndUser();
-        envs.NANGO_ADMIN_UUID = account.uuid;
 
         const res = await api.fetch('/remote-function/compile', {
             method: 'POST',

--- a/packages/server/lib/controllers/functions/remote-function.integration.test.ts
+++ b/packages/server/lib/controllers/functions/remote-function.integration.test.ts
@@ -1,10 +1,13 @@
-import { afterAll, beforeAll, describe, expect, it } from 'vitest';
+import { afterAll, afterEach, beforeAll, describe, expect, it } from 'vitest';
 
 import { seeders } from '@nangohq/shared';
 
+import { envs } from '../../env.js';
 import { isError, runServer, shouldBeProtected } from '../../utils/tests.js';
 
 let api: Awaited<ReturnType<typeof runServer>>;
+const originalNodeEnv = envs.NODE_ENV;
+const originalAdminUUID = envs.NANGO_ADMIN_UUID;
 
 describe('remote-function public API', () => {
     beforeAll(async () => {
@@ -13,6 +16,11 @@ describe('remote-function public API', () => {
 
     afterAll(() => {
         api.server.close();
+    });
+
+    afterEach(() => {
+        envs.NODE_ENV = originalNodeEnv;
+        envs.NANGO_ADMIN_UUID = originalAdminUUID;
     });
 
     it('protects POST /remote-function/compile', async () => {
@@ -50,6 +58,57 @@ describe('remote-function public API', () => {
 
     it('returns integration_not_found on POST /remote-function/compile', async () => {
         const { secret } = await seeders.seedAccountEnvAndUser();
+
+        const res = await api.fetch('/remote-function/compile', {
+            method: 'POST',
+            token: secret.secret,
+            body: {
+                integration_id: 'github',
+                function_name: 'syncIssues',
+                function_type: 'sync',
+                code: 'export default {}'
+            }
+        });
+
+        expect(res.res.status).toBe(404);
+        expect(res.json).toStrictEqual({
+            error: {
+                code: 'integration_not_found',
+                message: "Integration 'github' was not found"
+            }
+        });
+    });
+
+    it('rejects non-admin org secret keys in production', async () => {
+        envs.NODE_ENV = 'production';
+        envs.NANGO_ADMIN_UUID = 'e1e8fee9-a459-46fe-9e82-15c93dae2406';
+
+        const { secret } = await seeders.seedAccountEnvAndUser();
+
+        const res = await api.fetch('/remote-function/compile', {
+            method: 'POST',
+            token: secret.secret,
+            body: {
+                integration_id: 'github',
+                function_name: 'syncIssues',
+                function_type: 'sync',
+                code: 'export default {}'
+            }
+        });
+
+        expect(res.res.status).toBe(401);
+        expect(res.json).toStrictEqual({
+            error: {
+                code: 'unauthorized',
+                message: 'Unauthorized'
+            }
+        });
+    });
+
+    it('allows admin org secret keys in production', async () => {
+        envs.NODE_ENV = 'production';
+        const { account, secret } = await seeders.seedAccountEnvAndUser();
+        envs.NANGO_ADMIN_UUID = account.uuid;
 
         const res = await api.fetch('/remote-function/compile', {
             method: 'POST',

--- a/packages/server/lib/controllers/functions/remote-function.integration.test.ts
+++ b/packages/server/lib/controllers/functions/remote-function.integration.test.ts
@@ -1,5 +1,6 @@
 import { afterAll, afterEach, beforeAll, describe, expect, it } from 'vitest';
 
+import db from '@nangohq/database';
 import { seeders } from '@nangohq/shared';
 
 import { envs } from '../../env.js';
@@ -7,6 +8,12 @@ import { isError, runServer, shouldBeProtected } from '../../utils/tests.js';
 
 let api: Awaited<ReturnType<typeof runServer>>;
 const originalNodeEnv = envs.NODE_ENV;
+
+async function seedAccountWithRemoteFunctions() {
+    const seed = await seeders.seedAccountEnvAndUser();
+    await db.knex('plans').where('id', seed.plan.id).update({ remote_functions: true });
+    return seed;
+}
 
 describe('remote-function public API', () => {
     beforeAll(async () => {
@@ -35,8 +42,31 @@ describe('remote-function public API', () => {
         shouldBeProtected(res);
     });
 
-    it('rejects unsafe function names on POST /remote-function/compile', async () => {
+    it('rejects valid secret keys without remote functions plan flag', async () => {
         const { secret } = await seeders.seedAccountEnvAndUser();
+
+        const res = await api.fetch('/remote-function/compile', {
+            method: 'POST',
+            token: secret.secret,
+            body: {
+                integration_id: 'github',
+                function_name: 'syncIssues',
+                function_type: 'sync',
+                code: 'export default {}'
+            }
+        });
+
+        expect(res.res.status).toBe(403);
+        expect(res.json).toStrictEqual({
+            error: {
+                code: 'forbidden',
+                message: 'Remote functions are not enabled for this account'
+            }
+        });
+    });
+
+    it('rejects unsafe function names on POST /remote-function/compile', async () => {
+        const { secret } = await seedAccountWithRemoteFunctions();
 
         const res = await api.fetch('/remote-function/compile', {
             method: 'POST',
@@ -55,7 +85,7 @@ describe('remote-function public API', () => {
     });
 
     it('returns integration_not_found on POST /remote-function/compile', async () => {
-        const { secret } = await seeders.seedAccountEnvAndUser();
+        const { secret } = await seedAccountWithRemoteFunctions();
 
         const res = await api.fetch('/remote-function/compile', {
             method: 'POST',
@@ -80,7 +110,7 @@ describe('remote-function public API', () => {
     it('allows valid secret keys in production', async () => {
         envs.NODE_ENV = 'production';
 
-        const { secret } = await seeders.seedAccountEnvAndUser();
+        const { secret } = await seedAccountWithRemoteFunctions();
 
         const res = await api.fetch('/remote-function/compile', {
             method: 'POST',
@@ -103,7 +133,7 @@ describe('remote-function public API', () => {
     });
 
     it('returns connection_not_found on POST /remote-function/dryrun', async () => {
-        const { env, secret } = await seeders.seedAccountEnvAndUser();
+        const { env, secret } = await seedAccountWithRemoteFunctions();
         await seeders.createConfigSeed(env, 'github', 'github');
 
         const res = await api.fetch('/remote-function/dryrun', {
@@ -128,7 +158,7 @@ describe('remote-function public API', () => {
     });
 
     it('returns integration_not_found on POST /remote-function/deploy', async () => {
-        const { secret } = await seeders.seedAccountEnvAndUser();
+        const { secret } = await seedAccountWithRemoteFunctions();
 
         const res = await api.fetch('/remote-function/deploy', {
             method: 'POST',

--- a/packages/server/lib/controllers/functions/validation.ts
+++ b/packages/server/lib/controllers/functions/validation.ts
@@ -1,0 +1,30 @@
+import { z } from 'zod';
+
+import { connectionIdSchema, providerConfigKeySchema, syncNameSchema } from '../../helpers/validation.js';
+
+const integrationIdSchema = providerConfigKeySchema.refine((value) => value !== '.' && value !== '..', {
+    message: 'Integration id cannot be "." or ".."'
+});
+
+const remoteFunctionBaseBodySchema = z
+    .object({
+        integration_id: integrationIdSchema,
+        function_name: syncNameSchema,
+        function_type: z.enum(['action', 'sync']),
+        code: z.string().min(1)
+    })
+    .strict();
+
+export const remoteFunctionCompileBodySchema = remoteFunctionBaseBodySchema;
+
+export const remoteFunctionDeployBodySchema = remoteFunctionBaseBodySchema;
+
+export const remoteFunctionDryrunBodySchema = remoteFunctionBaseBodySchema
+    .extend({
+        connection_id: connectionIdSchema,
+        input: z.unknown().optional(),
+        metadata: z.record(z.string(), z.unknown()).optional(),
+        checkpoint: z.record(z.string(), z.unknown()).optional(),
+        last_sync_date: z.string().datetime().optional()
+    })
+    .strict();

--- a/packages/server/lib/routes.public.ts
+++ b/packages/server/lib/routes.public.ts
@@ -34,6 +34,9 @@ import { getPublicConnections } from './controllers/connection/getConnections.js
 import { postPublicConnection } from './controllers/connection/postConnection.js';
 import connectionController from './controllers/connection.controller.js';
 import { getPublicEnvironmentVariables } from './controllers/environment/getVariables.js';
+import { postRemoteFunctionCompile } from './controllers/functions/compile/postCompile.js';
+import { postRemoteFunctionDeploy } from './controllers/functions/deploy/postDeploy.js';
+import { postRemoteFunctionDryrun } from './controllers/functions/dryrun/postDryrun.js';
 import { getPublicListIntegrations } from './controllers/integrations/getListIntegrations.js';
 import { postPublicIntegration } from './controllers/integrations/postIntegration.js';
 import { deletePublicIntegration } from './controllers/integrations/uniqueKey/deleteIntegration.js';
@@ -227,6 +230,11 @@ publicAPI.route('/connect/sessions/reconnect').post(apiAuth, postConnectSessions
 publicAPI.route('/connect/session').get(connectSessionAuth, getConnectSession);
 publicAPI.route('/connect/session').delete(connectSessionAuth, deleteConnectSession);
 publicAPI.route('/connect/telemetry').post(connectSessionAuthBody, postConnectTelemetry);
+
+publicAPI.use('/remote-function', jsonContentTypeMiddleware);
+publicAPI.route('/remote-function/compile').post(apiAuth, postRemoteFunctionCompile);
+publicAPI.route('/remote-function/dryrun').post(apiAuth, postRemoteFunctionDryrun);
+publicAPI.route('/remote-function/deploy').post(apiAuth, postRemoteFunctionDeploy);
 
 publicAPI.use('/v1', jsonContentTypeMiddleware);
 publicAPI.route('/v1/*splat').all(apiAuth, allPublicV1);

--- a/packages/server/lib/routes.public.ts
+++ b/packages/server/lib/routes.public.ts
@@ -4,7 +4,7 @@ import cors from 'cors';
 import express from 'express';
 import multer from 'multer';
 
-import { connectUrl, flagEnforceCLIVersion } from '@nangohq/utils';
+import { connectUrl, flagEnforceCLIVersion, flagHasPlan } from '@nangohq/utils';
 
 import { getAsyncActionResult } from './controllers/action/getAsyncActionResult.js';
 import { postPublicTriggerAction } from './controllers/action/postTriggerAction.js';
@@ -71,6 +71,7 @@ import { jsonContentTypeMiddleware } from './middleware/json.middleware.js';
 import { rateLimiterMiddleware } from './middleware/ratelimit.middleware.js';
 import { isBinaryContentType } from './utils/utils.js';
 
+import type { DBPlan } from '@nangohq/types';
 import type { Request, RequestHandler } from 'express';
 
 const apiAuth: RequestHandler[] = [authMiddleware.secretKeyAuth.bind(authMiddleware), rateLimiterMiddleware];
@@ -79,6 +80,19 @@ const connectSessionAuthBody: RequestHandler[] = [authMiddleware.connectSessionA
 const connectSessionOrApiAuth: RequestHandler[] = [authMiddleware.connectSessionOrSecretKeyAuth.bind(authMiddleware), rateLimiterMiddleware];
 
 const connectSessionOrPublicAuth: RequestHandler[] = [authMiddleware.connectSessionOrPublicKeyAuth.bind(authMiddleware), rateLimiterMiddleware];
+const remoteFunctionAuth: RequestHandler[] = [
+    ...apiAuth,
+    (_req, res, next) => {
+        const plan = res.locals['plan'] as DBPlan | null | undefined;
+
+        if (flagHasPlan && !plan?.remote_functions) {
+            res.status(403).send({ error: { code: 'forbidden', message: 'Remote functions are not enabled for this account' } });
+            return;
+        }
+
+        next();
+    }
+];
 
 export const publicAPI = express.Router();
 
@@ -232,9 +246,9 @@ publicAPI.route('/connect/session').delete(connectSessionAuth, deleteConnectSess
 publicAPI.route('/connect/telemetry').post(connectSessionAuthBody, postConnectTelemetry);
 
 publicAPI.use('/remote-function', jsonContentTypeMiddleware);
-publicAPI.route('/remote-function/compile').post(apiAuth, postRemoteFunctionCompile);
-publicAPI.route('/remote-function/dryrun').post(apiAuth, postRemoteFunctionDryrun);
-publicAPI.route('/remote-function/deploy').post(apiAuth, postRemoteFunctionDeploy);
+publicAPI.route('/remote-function/compile').post(remoteFunctionAuth, postRemoteFunctionCompile);
+publicAPI.route('/remote-function/dryrun').post(remoteFunctionAuth, postRemoteFunctionDryrun);
+publicAPI.route('/remote-function/deploy').post(remoteFunctionAuth, postRemoteFunctionDeploy);
 
 publicAPI.use('/v1', jsonContentTypeMiddleware);
 publicAPI.route('/v1/*splat').all(apiAuth, allPublicV1);

--- a/packages/server/lib/routes.public.ts
+++ b/packages/server/lib/routes.public.ts
@@ -71,7 +71,6 @@ import { jsonContentTypeMiddleware } from './middleware/json.middleware.js';
 import { rateLimiterMiddleware } from './middleware/ratelimit.middleware.js';
 import { isBinaryContentType } from './utils/utils.js';
 
-import type { RequestLocals } from './utils/express.js';
 import type { Request, RequestHandler } from 'express';
 
 const apiAuth: RequestHandler[] = [authMiddleware.secretKeyAuth.bind(authMiddleware), rateLimiterMiddleware];
@@ -80,19 +79,6 @@ const connectSessionAuthBody: RequestHandler[] = [authMiddleware.connectSessionA
 const connectSessionOrApiAuth: RequestHandler[] = [authMiddleware.connectSessionOrSecretKeyAuth.bind(authMiddleware), rateLimiterMiddleware];
 
 const connectSessionOrPublicAuth: RequestHandler[] = [authMiddleware.connectSessionOrPublicKeyAuth.bind(authMiddleware), rateLimiterMiddleware];
-const remoteFunctionAuth: RequestHandler[] = [
-    ...apiAuth,
-    (_req, res, next) => {
-        const account = res.locals['account'] as RequestLocals['account'] | undefined;
-
-        if (envs.NODE_ENV === 'production' && account?.uuid !== envs.NANGO_ADMIN_UUID) {
-            res.status(401).send({ error: { code: 'unauthorized', message: 'Unauthorized' } });
-            return;
-        }
-
-        next();
-    }
-];
 
 export const publicAPI = express.Router();
 
@@ -246,9 +232,9 @@ publicAPI.route('/connect/session').delete(connectSessionAuth, deleteConnectSess
 publicAPI.route('/connect/telemetry').post(connectSessionAuthBody, postConnectTelemetry);
 
 publicAPI.use('/remote-function', jsonContentTypeMiddleware);
-publicAPI.route('/remote-function/compile').post(remoteFunctionAuth, postRemoteFunctionCompile);
-publicAPI.route('/remote-function/dryrun').post(remoteFunctionAuth, postRemoteFunctionDryrun);
-publicAPI.route('/remote-function/deploy').post(remoteFunctionAuth, postRemoteFunctionDeploy);
+publicAPI.route('/remote-function/compile').post(apiAuth, postRemoteFunctionCompile);
+publicAPI.route('/remote-function/dryrun').post(apiAuth, postRemoteFunctionDryrun);
+publicAPI.route('/remote-function/deploy').post(apiAuth, postRemoteFunctionDeploy);
 
 publicAPI.use('/v1', jsonContentTypeMiddleware);
 publicAPI.route('/v1/*splat').all(apiAuth, allPublicV1);

--- a/packages/server/lib/routes.public.ts
+++ b/packages/server/lib/routes.public.ts
@@ -231,10 +231,12 @@ publicAPI.route('/connect/session').get(connectSessionAuth, getConnectSession);
 publicAPI.route('/connect/session').delete(connectSessionAuth, deleteConnectSession);
 publicAPI.route('/connect/telemetry').post(connectSessionAuthBody, postConnectTelemetry);
 
-publicAPI.use('/remote-function', jsonContentTypeMiddleware);
-publicAPI.route('/remote-function/compile').post(apiAuth, postRemoteFunctionCompile);
-publicAPI.route('/remote-function/dryrun').post(apiAuth, postRemoteFunctionDryrun);
-publicAPI.route('/remote-function/deploy').post(apiAuth, postRemoteFunctionDeploy);
+if (envs.NODE_ENV !== 'production') {
+    publicAPI.use('/remote-function', jsonContentTypeMiddleware);
+    publicAPI.route('/remote-function/compile').post(apiAuth, postRemoteFunctionCompile);
+    publicAPI.route('/remote-function/dryrun').post(apiAuth, postRemoteFunctionDryrun);
+    publicAPI.route('/remote-function/deploy').post(apiAuth, postRemoteFunctionDeploy);
+}
 
 publicAPI.use('/v1', jsonContentTypeMiddleware);
 publicAPI.route('/v1/*splat').all(apiAuth, allPublicV1);

--- a/packages/server/lib/routes.public.ts
+++ b/packages/server/lib/routes.public.ts
@@ -71,6 +71,7 @@ import { jsonContentTypeMiddleware } from './middleware/json.middleware.js';
 import { rateLimiterMiddleware } from './middleware/ratelimit.middleware.js';
 import { isBinaryContentType } from './utils/utils.js';
 
+import type { RequestLocals } from './utils/express.js';
 import type { Request, RequestHandler } from 'express';
 
 const apiAuth: RequestHandler[] = [authMiddleware.secretKeyAuth.bind(authMiddleware), rateLimiterMiddleware];
@@ -79,6 +80,19 @@ const connectSessionAuthBody: RequestHandler[] = [authMiddleware.connectSessionA
 const connectSessionOrApiAuth: RequestHandler[] = [authMiddleware.connectSessionOrSecretKeyAuth.bind(authMiddleware), rateLimiterMiddleware];
 
 const connectSessionOrPublicAuth: RequestHandler[] = [authMiddleware.connectSessionOrPublicKeyAuth.bind(authMiddleware), rateLimiterMiddleware];
+const remoteFunctionAuth: RequestHandler[] = [
+    ...apiAuth,
+    (_req, res, next) => {
+        const account = res.locals['account'] as RequestLocals['account'] | undefined;
+
+        if (envs.NODE_ENV === 'production' && account?.uuid !== envs.NANGO_ADMIN_UUID) {
+            res.status(401).send({ error: { code: 'unauthorized', message: 'Unauthorized' } });
+            return;
+        }
+
+        next();
+    }
+];
 
 export const publicAPI = express.Router();
 
@@ -231,12 +245,10 @@ publicAPI.route('/connect/session').get(connectSessionAuth, getConnectSession);
 publicAPI.route('/connect/session').delete(connectSessionAuth, deleteConnectSession);
 publicAPI.route('/connect/telemetry').post(connectSessionAuthBody, postConnectTelemetry);
 
-if (envs.NODE_ENV !== 'production') {
-    publicAPI.use('/remote-function', jsonContentTypeMiddleware);
-    publicAPI.route('/remote-function/compile').post(apiAuth, postRemoteFunctionCompile);
-    publicAPI.route('/remote-function/dryrun').post(apiAuth, postRemoteFunctionDryrun);
-    publicAPI.route('/remote-function/deploy').post(apiAuth, postRemoteFunctionDeploy);
-}
+publicAPI.use('/remote-function', jsonContentTypeMiddleware);
+publicAPI.route('/remote-function/compile').post(remoteFunctionAuth, postRemoteFunctionCompile);
+publicAPI.route('/remote-function/dryrun').post(remoteFunctionAuth, postRemoteFunctionDryrun);
+publicAPI.route('/remote-function/deploy').post(remoteFunctionAuth, postRemoteFunctionDeploy);
 
 publicAPI.use('/v1', jsonContentTypeMiddleware);
 publicAPI.route('/v1/*splat').all(apiAuth, allPublicV1);

--- a/packages/server/lib/services/local/compiler-client.ts
+++ b/packages/server/lib/services/local/compiler-client.ts
@@ -2,17 +2,23 @@ import { randomUUID } from 'node:crypto';
 
 import { execDockerFileAsync, getExecErrorOutput, readContainerFile, writeContainerFile } from './docker.js';
 import { CompilerError, buildIndexTs, getFilePaths } from '../remote-function/compiler-client.js';
-import { remoteFunctionLocalImage, remoteFunctionProjectPath } from '../remote-function/runtime.js';
+import {
+    remoteFunctionCompileTimeoutMs,
+    remoteFunctionCompilerSandboxTimeoutMs,
+    remoteFunctionLocalImage,
+    remoteFunctionProjectPath
+} from '../remote-function/runtime.js';
 
 import type { CompileRequest, CompileResult } from '../remote-function/compiler-client.js';
-
-const compilerTimeoutMs = 3 * 60 * 1000;
 
 export async function invokeLocalCompiler(request: CompileRequest): Promise<CompileResult> {
     const containerName = `nango-compiler-${randomUUID().slice(0, 8)}`;
 
     try {
-        await execDockerFileAsync(['run', '-d', '--name', containerName, remoteFunctionLocalImage, 'sleep', '300'], { timeout: 10_000 });
+        await execDockerFileAsync(
+            ['run', '-d', '--name', containerName, remoteFunctionLocalImage, 'sleep', String(Math.ceil(remoteFunctionCompilerSandboxTimeoutMs / 1000))],
+            { timeout: 10_000 }
+        );
 
         const { tsFilePath, cjsFilePath } = getFilePaths(request);
 
@@ -21,7 +27,7 @@ export async function invokeLocalCompiler(request: CompileRequest): Promise<Comp
 
         try {
             await execDockerFileAsync(['exec', '-w', remoteFunctionProjectPath, '-e', 'NO_COLOR=1', containerName, 'nango', 'compile'], {
-                timeout: compilerTimeoutMs
+                timeout: remoteFunctionCompileTimeoutMs
             });
         } catch (err) {
             throw new CompilerError(getExecErrorOutput(err), 'compilation');

--- a/packages/server/lib/services/local/compiler-client.ts
+++ b/packages/server/lib/services/local/compiler-client.ts
@@ -1,0 +1,39 @@
+import { randomUUID } from 'node:crypto';
+
+import { execDockerFileAsync, getExecErrorOutput, readContainerFile, writeContainerFile } from './docker.js';
+import { CompilerError, buildIndexTs, getFilePaths } from '../remote-function/compiler-client.js';
+import { remoteFunctionLocalImage, remoteFunctionProjectPath } from '../remote-function/runtime.js';
+
+import type { CompileRequest, CompileResult } from '../remote-function/compiler-client.js';
+
+const compilerTimeoutMs = 3 * 60 * 1000;
+
+export async function invokeLocalCompiler(request: CompileRequest): Promise<CompileResult> {
+    const containerName = `nango-compiler-${randomUUID().slice(0, 8)}`;
+
+    try {
+        await execDockerFileAsync('docker', ['run', '-d', '--name', containerName, remoteFunctionLocalImage, 'sleep', '300'], { timeout: 10_000 });
+
+        const { tsFilePath, cjsFilePath } = getFilePaths(request);
+
+        await writeContainerFile(containerName, `${remoteFunctionProjectPath}/${tsFilePath}`, request.code);
+        await writeContainerFile(containerName, `${remoteFunctionProjectPath}/index.ts`, buildIndexTs(request));
+
+        try {
+            await execDockerFileAsync('docker', ['exec', '-w', remoteFunctionProjectPath, '-e', 'NO_COLOR=1', containerName, 'nango', 'compile'], {
+                timeout: compilerTimeoutMs
+            });
+        } catch (err) {
+            throw new CompilerError(getExecErrorOutput(err), 'compilation');
+        }
+
+        const bundledJs = await readContainerFile(containerName, `${remoteFunctionProjectPath}/${cjsFilePath}`);
+
+        return {
+            bundledJs,
+            bundleSizeBytes: Buffer.byteLength(bundledJs, 'utf8')
+        };
+    } finally {
+        await execDockerFileAsync('docker', ['rm', '-f', containerName]).catch(() => {});
+    }
+}

--- a/packages/server/lib/services/local/compiler-client.ts
+++ b/packages/server/lib/services/local/compiler-client.ts
@@ -12,7 +12,7 @@ export async function invokeLocalCompiler(request: CompileRequest): Promise<Comp
     const containerName = `nango-compiler-${randomUUID().slice(0, 8)}`;
 
     try {
-        await execDockerFileAsync('docker', ['run', '-d', '--name', containerName, remoteFunctionLocalImage, 'sleep', '300'], { timeout: 10_000 });
+        await execDockerFileAsync(['run', '-d', '--name', containerName, remoteFunctionLocalImage, 'sleep', '300'], { timeout: 10_000 });
 
         const { tsFilePath, cjsFilePath } = getFilePaths(request);
 
@@ -20,7 +20,7 @@ export async function invokeLocalCompiler(request: CompileRequest): Promise<Comp
         await writeContainerFile(containerName, `${remoteFunctionProjectPath}/index.ts`, buildIndexTs(request));
 
         try {
-            await execDockerFileAsync('docker', ['exec', '-w', remoteFunctionProjectPath, '-e', 'NO_COLOR=1', containerName, 'nango', 'compile'], {
+            await execDockerFileAsync(['exec', '-w', remoteFunctionProjectPath, '-e', 'NO_COLOR=1', containerName, 'nango', 'compile'], {
                 timeout: compilerTimeoutMs
             });
         } catch (err) {
@@ -34,6 +34,6 @@ export async function invokeLocalCompiler(request: CompileRequest): Promise<Comp
             bundleSizeBytes: Buffer.byteLength(bundledJs, 'utf8')
         };
     } finally {
-        await execDockerFileAsync('docker', ['rm', '-f', containerName]).catch(() => {});
+        await execDockerFileAsync(['rm', '-f', containerName]).catch(() => {});
     }
 }

--- a/packages/server/lib/services/local/deploy-client.ts
+++ b/packages/server/lib/services/local/deploy-client.ts
@@ -1,0 +1,59 @@
+import { randomUUID } from 'node:crypto';
+
+import { execDockerFileAsync, getExecErrorOutput, rewriteDockerHostForLocalhost, writeContainerFile } from './docker.js';
+import { buildDeployArgs } from '../remote-function/command-builders.js';
+import { buildIndexTs, getFilePaths } from '../remote-function/compiler-client.js';
+import { remoteFunctionLocalImage, remoteFunctionProjectPath } from '../remote-function/runtime.js';
+
+import type { DeployRequest, DeployResult } from '../remote-function/deploy-client.js';
+
+const deployTimeoutMs = 5 * 60 * 1000;
+
+export async function invokeLocalDeploy(request: DeployRequest): Promise<DeployResult> {
+    const containerName = `nango-deploy-${randomUUID().slice(0, 8)}`;
+    const nangoHost = rewriteDockerHostForLocalhost(request.nango_host);
+
+    try {
+        await execDockerFileAsync(
+            'docker',
+            [
+                'run',
+                '-d',
+                '--name',
+                containerName,
+                '-e',
+                `NANGO_SECRET_KEY=${request.nango_secret_key}`,
+                '-e',
+                `NANGO_HOSTPORT=${nangoHost}`,
+                '-e',
+                'NO_COLOR=1',
+                '-e',
+                'NANGO_DEPLOY_AUTO_CONFIRM=true',
+                '--add-host',
+                'host.docker.internal:host-gateway',
+                remoteFunctionLocalImage,
+                'sleep',
+                '300'
+            ],
+            { timeout: 10_000 }
+        );
+
+        const { tsFilePath } = getFilePaths(request);
+
+        await writeContainerFile(containerName, `${remoteFunctionProjectPath}/${tsFilePath}`, request.code);
+        await writeContainerFile(containerName, `${remoteFunctionProjectPath}/index.ts`, buildIndexTs(request));
+
+        try {
+            const { stdout, stderr } = await execDockerFileAsync(
+                'docker',
+                ['exec', '-w', remoteFunctionProjectPath, containerName, 'nango', ...buildDeployArgs(request)],
+                { timeout: deployTimeoutMs }
+            );
+            return { output: stdout || stderr };
+        } catch (err) {
+            return { output: getExecErrorOutput(err) };
+        }
+    } finally {
+        await execDockerFileAsync('docker', ['rm', '-f', containerName]).catch(() => {});
+    }
+}

--- a/packages/server/lib/services/local/deploy-client.ts
+++ b/packages/server/lib/services/local/deploy-client.ts
@@ -4,11 +4,14 @@ import { execDockerFileAsync, getExecErrorOutput, isExecTimeoutError, rewriteDoc
 import { buildDeployArgs } from '../remote-function/command-builders.js';
 import { buildIndexTs, getFilePaths } from '../remote-function/compiler-client.js';
 import { RemoteFunctionError } from '../remote-function/helpers.js';
-import { remoteFunctionLocalImage, remoteFunctionProjectPath } from '../remote-function/runtime.js';
+import {
+    remoteFunctionDeploySandboxTimeoutMs,
+    remoteFunctionDeployTimeoutMs,
+    remoteFunctionLocalImage,
+    remoteFunctionProjectPath
+} from '../remote-function/runtime.js';
 
 import type { DeployRequest, DeployResult } from '../remote-function/deploy-client.js';
-
-const deployTimeoutMs = 5 * 60 * 1000;
 
 export async function invokeLocalDeploy(request: DeployRequest): Promise<DeployResult> {
     const containerName = `nango-deploy-${randomUUID().slice(0, 8)}`;
@@ -33,7 +36,7 @@ export async function invokeLocalDeploy(request: DeployRequest): Promise<DeployR
                 'host.docker.internal:host-gateway',
                 remoteFunctionLocalImage,
                 'sleep',
-                '300'
+                String(Math.ceil(remoteFunctionDeploySandboxTimeoutMs / 1000))
             ],
             { timeout: 10_000 }
         );
@@ -46,7 +49,7 @@ export async function invokeLocalDeploy(request: DeployRequest): Promise<DeployR
         try {
             const { stdout, stderr } = await execDockerFileAsync(
                 ['exec', '-w', remoteFunctionProjectPath, containerName, 'nango', ...buildDeployArgs(request)],
-                { timeout: deployTimeoutMs }
+                { timeout: remoteFunctionDeployTimeoutMs }
             );
             return { output: stdout || stderr };
         } catch (err) {

--- a/packages/server/lib/services/local/deploy-client.ts
+++ b/packages/server/lib/services/local/deploy-client.ts
@@ -1,8 +1,9 @@
 import { randomUUID } from 'node:crypto';
 
-import { execDockerFileAsync, getExecErrorOutput, rewriteDockerHostForLocalhost, writeContainerFile } from './docker.js';
+import { execDockerFileAsync, getExecErrorOutput, isExecTimeoutError, rewriteDockerHostForLocalhost, writeContainerFile } from './docker.js';
 import { buildDeployArgs } from '../remote-function/command-builders.js';
 import { buildIndexTs, getFilePaths } from '../remote-function/compiler-client.js';
+import { RemoteFunctionError } from '../remote-function/helpers.js';
 import { remoteFunctionLocalImage, remoteFunctionProjectPath } from '../remote-function/runtime.js';
 
 import type { DeployRequest, DeployResult } from '../remote-function/deploy-client.js';
@@ -15,7 +16,6 @@ export async function invokeLocalDeploy(request: DeployRequest): Promise<DeployR
 
     try {
         await execDockerFileAsync(
-            'docker',
             [
                 'run',
                 '-d',
@@ -45,15 +45,18 @@ export async function invokeLocalDeploy(request: DeployRequest): Promise<DeployR
 
         try {
             const { stdout, stderr } = await execDockerFileAsync(
-                'docker',
                 ['exec', '-w', remoteFunctionProjectPath, containerName, 'nango', ...buildDeployArgs(request)],
                 { timeout: deployTimeoutMs }
             );
             return { output: stdout || stderr };
         } catch (err) {
-            return { output: getExecErrorOutput(err) };
+            throw new RemoteFunctionError({
+                code: isExecTimeoutError(err) ? 'timeout' : 'deployment_error',
+                message: isExecTimeoutError(err) ? 'Deployment timed out' : getExecErrorOutput(err),
+                status: isExecTimeoutError(err) ? 504 : 400
+            });
         }
     } finally {
-        await execDockerFileAsync('docker', ['rm', '-f', containerName]).catch(() => {});
+        await execDockerFileAsync(['rm', '-f', containerName]).catch(() => {});
     }
 }

--- a/packages/server/lib/services/local/docker.ts
+++ b/packages/server/lib/services/local/docker.ts
@@ -2,7 +2,14 @@ import { execFile, spawn } from 'node:child_process';
 import path from 'node:path';
 import { promisify } from 'node:util';
 
-export const execDockerFileAsync = promisify(execFile);
+import type { ExecFileOptions } from 'node:child_process';
+
+const execFileAsync = promisify(execFile);
+
+export async function execDockerFileAsync(args: string[], options?: ExecFileOptions): Promise<{ stdout: string; stderr: string }> {
+    const { stdout, stderr } = await execFileAsync('docker', args, options);
+    return { stdout: String(stdout), stderr: String(stderr) };
+}
 
 export function rewriteDockerHostForLocalhost(nangoHost: string): string {
     return nangoHost.replace(/https?:\/\/(localhost|127\.0\.0\.1)(:\d+)?/, (_, _host, port) => `http://host.docker.internal${port ?? ''}`);
@@ -25,9 +32,23 @@ export function getExecErrorOutput(error: unknown): string {
     return String(error);
 }
 
+export function isExecTimeoutError(error: unknown): boolean {
+    if (error && typeof error === 'object') {
+        const err = error as Record<string, unknown>;
+        if (err['killed'] === true || err['code'] === 'ETIMEDOUT') {
+            return true;
+        }
+        if (typeof err['message'] === 'string' && /timed out|timeout/i.test(err['message'])) {
+            return true;
+        }
+    }
+
+    return false;
+}
+
 export async function writeContainerFile(containerName: string, filePath: string, content: string): Promise<void> {
     const dir = path.posix.dirname(filePath);
-    await execDockerFileAsync('docker', ['exec', containerName, 'mkdir', '-p', dir]);
+    await execDockerFileAsync(['exec', containerName, 'mkdir', '-p', dir]);
 
     await new Promise<void>((resolve, reject) => {
         const proc = spawn('docker', ['exec', '-i', containerName, 'tee', filePath], {
@@ -42,6 +63,6 @@ export async function writeContainerFile(containerName: string, filePath: string
 }
 
 export async function readContainerFile(containerName: string, filePath: string): Promise<string> {
-    const { stdout } = await execDockerFileAsync('docker', ['exec', containerName, 'cat', filePath]);
+    const { stdout } = await execDockerFileAsync(['exec', containerName, 'cat', filePath]);
     return stdout;
 }

--- a/packages/server/lib/services/local/docker.ts
+++ b/packages/server/lib/services/local/docker.ts
@@ -1,0 +1,47 @@
+import { execFile, spawn } from 'node:child_process';
+import path from 'node:path';
+import { promisify } from 'node:util';
+
+export const execDockerFileAsync = promisify(execFile);
+
+export function rewriteDockerHostForLocalhost(nangoHost: string): string {
+    return nangoHost.replace(/https?:\/\/(localhost|127\.0\.0\.1)(:\d+)?/, (_, _host, port) => `http://host.docker.internal${port ?? ''}`);
+}
+
+export function getExecErrorOutput(error: unknown): string {
+    if (error && typeof error === 'object') {
+        const err = error as Record<string, unknown>;
+        if (typeof err['stderr'] === 'string' && err['stderr']) {
+            return err['stderr'];
+        }
+        if (typeof err['stdout'] === 'string' && err['stdout']) {
+            return err['stdout'];
+        }
+        if (typeof err['message'] === 'string' && err['message']) {
+            return err['message'];
+        }
+    }
+
+    return String(error);
+}
+
+export async function writeContainerFile(containerName: string, filePath: string, content: string): Promise<void> {
+    const dir = path.posix.dirname(filePath);
+    await execDockerFileAsync('docker', ['exec', containerName, 'mkdir', '-p', dir]);
+
+    await new Promise<void>((resolve, reject) => {
+        const proc = spawn('docker', ['exec', '-i', containerName, 'tee', filePath], {
+            stdio: ['pipe', 'ignore', 'pipe']
+        });
+
+        proc.stdin.write(content);
+        proc.stdin.end();
+        proc.on('close', (code) => (code === 0 ? resolve() : reject(new Error(`docker exec write exited with code ${code}`))));
+        proc.on('error', reject);
+    });
+}
+
+export async function readContainerFile(containerName: string, filePath: string): Promise<string> {
+    const { stdout } = await execDockerFileAsync('docker', ['exec', containerName, 'cat', filePath]);
+    return stdout;
+}

--- a/packages/server/lib/services/local/dryrun-client.ts
+++ b/packages/server/lib/services/local/dryrun-client.ts
@@ -1,8 +1,9 @@
 import { randomUUID } from 'node:crypto';
 
-import { execDockerFileAsync, getExecErrorOutput, rewriteDockerHostForLocalhost, writeContainerFile } from './docker.js';
+import { execDockerFileAsync, getExecErrorOutput, isExecTimeoutError, rewriteDockerHostForLocalhost, writeContainerFile } from './docker.js';
 import { buildDryrunArgs } from '../remote-function/command-builders.js';
 import { buildIndexTs, getFilePaths } from '../remote-function/compiler-client.js';
+import { RemoteFunctionError } from '../remote-function/helpers.js';
 import { remoteFunctionLocalImage, remoteFunctionProjectPath } from '../remote-function/runtime.js';
 
 import type { DryrunRequest, DryrunResult } from '../remote-function/dryrun-client.js';
@@ -16,7 +17,6 @@ export async function invokeLocalDryrun(request: DryrunRequest): Promise<DryrunR
 
     try {
         await execDockerFileAsync(
-            'docker',
             [
                 'run',
                 '-d',
@@ -43,11 +43,15 @@ export async function invokeLocalDryrun(request: DryrunRequest): Promise<DryrunR
         await writeContainerFile(containerName, `${remoteFunctionProjectPath}/index.ts`, buildIndexTs(request));
 
         try {
-            await execDockerFileAsync('docker', ['exec', '-w', remoteFunctionProjectPath, '-e', 'NO_COLOR=1', containerName, 'nango', 'compile'], {
+            await execDockerFileAsync(['exec', '-w', remoteFunctionProjectPath, '-e', 'NO_COLOR=1', containerName, 'nango', 'compile'], {
                 timeout: compileTimeoutMs
             });
         } catch (err) {
-            return { output: getExecErrorOutput(err) };
+            throw new RemoteFunctionError({
+                code: isExecTimeoutError(err) ? 'timeout' : 'compilation_error',
+                message: isExecTimeoutError(err) ? 'Compilation timed out' : getExecErrorOutput(err),
+                status: isExecTimeoutError(err) ? 504 : 400
+            });
         }
 
         if (request.input !== undefined) {
@@ -62,15 +66,18 @@ export async function invokeLocalDryrun(request: DryrunRequest): Promise<DryrunR
 
         try {
             const { stdout, stderr } = await execDockerFileAsync(
-                'docker',
                 ['exec', '-w', remoteFunctionProjectPath, containerName, 'nango', ...buildDryrunArgs(request)],
                 { timeout: dryrunTimeoutMs }
             );
             return { output: stdout || stderr };
         } catch (err) {
-            return { output: getExecErrorOutput(err) };
+            throw new RemoteFunctionError({
+                code: isExecTimeoutError(err) ? 'timeout' : 'dryrun_error',
+                message: isExecTimeoutError(err) ? 'Dry run timed out' : getExecErrorOutput(err),
+                status: isExecTimeoutError(err) ? 504 : 400
+            });
         }
     } finally {
-        await execDockerFileAsync('docker', ['rm', '-f', containerName]).catch(() => {});
+        await execDockerFileAsync(['rm', '-f', containerName]).catch(() => {});
     }
 }

--- a/packages/server/lib/services/local/dryrun-client.ts
+++ b/packages/server/lib/services/local/dryrun-client.ts
@@ -1,0 +1,76 @@
+import { randomUUID } from 'node:crypto';
+
+import { execDockerFileAsync, getExecErrorOutput, rewriteDockerHostForLocalhost, writeContainerFile } from './docker.js';
+import { buildDryrunArgs } from '../remote-function/command-builders.js';
+import { buildIndexTs, getFilePaths } from '../remote-function/compiler-client.js';
+import { remoteFunctionLocalImage, remoteFunctionProjectPath } from '../remote-function/runtime.js';
+
+import type { DryrunRequest, DryrunResult } from '../remote-function/dryrun-client.js';
+
+const compileTimeoutMs = 3 * 60 * 1000;
+const dryrunTimeoutMs = 5 * 60 * 1000;
+
+export async function invokeLocalDryrun(request: DryrunRequest): Promise<DryrunResult> {
+    const containerName = `nango-dryrun-${randomUUID().slice(0, 8)}`;
+    const nangoHost = rewriteDockerHostForLocalhost(request.nango_host);
+
+    try {
+        await execDockerFileAsync(
+            'docker',
+            [
+                'run',
+                '-d',
+                '--name',
+                containerName,
+                '-e',
+                `NANGO_SECRET_KEY=${request.nango_secret_key}`,
+                '-e',
+                `NANGO_HOSTPORT=${nangoHost}`,
+                '-e',
+                'NO_COLOR=1',
+                '--add-host',
+                'host.docker.internal:host-gateway',
+                remoteFunctionLocalImage,
+                'sleep',
+                '300'
+            ],
+            { timeout: 10_000 }
+        );
+
+        const { tsFilePath } = getFilePaths(request);
+
+        await writeContainerFile(containerName, `${remoteFunctionProjectPath}/${tsFilePath}`, request.code);
+        await writeContainerFile(containerName, `${remoteFunctionProjectPath}/index.ts`, buildIndexTs(request));
+
+        try {
+            await execDockerFileAsync('docker', ['exec', '-w', remoteFunctionProjectPath, '-e', 'NO_COLOR=1', containerName, 'nango', 'compile'], {
+                timeout: compileTimeoutMs
+            });
+        } catch (err) {
+            return { output: getExecErrorOutput(err) };
+        }
+
+        if (request.input !== undefined) {
+            await writeContainerFile(containerName, '/tmp/nango-dryrun-input.json', JSON.stringify(request.input));
+        }
+        if (request.metadata) {
+            await writeContainerFile(containerName, '/tmp/nango-dryrun-metadata.json', JSON.stringify(request.metadata));
+        }
+        if (request.checkpoint) {
+            await writeContainerFile(containerName, '/tmp/nango-dryrun-checkpoint.json', JSON.stringify(request.checkpoint));
+        }
+
+        try {
+            const { stdout, stderr } = await execDockerFileAsync(
+                'docker',
+                ['exec', '-w', remoteFunctionProjectPath, containerName, 'nango', ...buildDryrunArgs(request)],
+                { timeout: dryrunTimeoutMs }
+            );
+            return { output: stdout || stderr };
+        } catch (err) {
+            return { output: getExecErrorOutput(err) };
+        }
+    } finally {
+        await execDockerFileAsync('docker', ['rm', '-f', containerName]).catch(() => {});
+    }
+}

--- a/packages/server/lib/services/local/dryrun-client.ts
+++ b/packages/server/lib/services/local/dryrun-client.ts
@@ -4,12 +4,15 @@ import { execDockerFileAsync, getExecErrorOutput, isExecTimeoutError, rewriteDoc
 import { buildDryrunArgs } from '../remote-function/command-builders.js';
 import { buildIndexTs, getFilePaths } from '../remote-function/compiler-client.js';
 import { RemoteFunctionError } from '../remote-function/helpers.js';
-import { remoteFunctionLocalImage, remoteFunctionProjectPath } from '../remote-function/runtime.js';
+import {
+    remoteFunctionCompileTimeoutMs,
+    remoteFunctionDryrunSandboxTimeoutMs,
+    remoteFunctionDryrunTimeoutMs,
+    remoteFunctionLocalImage,
+    remoteFunctionProjectPath
+} from '../remote-function/runtime.js';
 
 import type { DryrunRequest, DryrunResult } from '../remote-function/dryrun-client.js';
-
-const compileTimeoutMs = 3 * 60 * 1000;
-const dryrunTimeoutMs = 5 * 60 * 1000;
 
 export async function invokeLocalDryrun(request: DryrunRequest): Promise<DryrunResult> {
     const containerName = `nango-dryrun-${randomUUID().slice(0, 8)}`;
@@ -32,7 +35,7 @@ export async function invokeLocalDryrun(request: DryrunRequest): Promise<DryrunR
                 'host.docker.internal:host-gateway',
                 remoteFunctionLocalImage,
                 'sleep',
-                '300'
+                String(Math.ceil(remoteFunctionDryrunSandboxTimeoutMs / 1000))
             ],
             { timeout: 10_000 }
         );
@@ -44,7 +47,7 @@ export async function invokeLocalDryrun(request: DryrunRequest): Promise<DryrunR
 
         try {
             await execDockerFileAsync(['exec', '-w', remoteFunctionProjectPath, '-e', 'NO_COLOR=1', containerName, 'nango', 'compile'], {
-                timeout: compileTimeoutMs
+                timeout: remoteFunctionCompileTimeoutMs
             });
         } catch (err) {
             throw new RemoteFunctionError({
@@ -67,7 +70,7 @@ export async function invokeLocalDryrun(request: DryrunRequest): Promise<DryrunR
         try {
             const { stdout, stderr } = await execDockerFileAsync(
                 ['exec', '-w', remoteFunctionProjectPath, containerName, 'nango', ...buildDryrunArgs(request)],
-                { timeout: dryrunTimeoutMs }
+                { timeout: remoteFunctionDryrunTimeoutMs }
             );
             return { output: stdout || stderr };
         } catch (err) {

--- a/packages/server/lib/services/remote-function/command-builders.ts
+++ b/packages/server/lib/services/remote-function/command-builders.ts
@@ -34,6 +34,8 @@ export function buildDeployArgs(request: DeployRequest): string[] {
     return [
         'deploy',
         request.environment_name,
+        '--integration',
+        request.integration_id,
         request.function_type === 'action' ? '--action' : '--sync',
         request.function_name,
         '--auto-confirm',

--- a/packages/server/lib/services/remote-function/command-builders.ts
+++ b/packages/server/lib/services/remote-function/command-builders.ts
@@ -1,0 +1,43 @@
+import type { DeployRequest } from './deploy-client.js';
+import type { DryrunRequest } from './dryrun-client.js';
+
+export function buildDryrunArgs(request: DryrunRequest): string[] {
+    const args = [
+        'dryrun',
+        request.function_name,
+        request.connection_id,
+        '--environment',
+        request.environment_name,
+        '--integration-id',
+        request.integration_id,
+        '--auto-confirm',
+        '--no-interactive'
+    ];
+
+    if (request.input !== undefined) {
+        args.push('--input', '@/tmp/nango-dryrun-input.json');
+    }
+    if (request.metadata) {
+        args.push('--metadata', '@/tmp/nango-dryrun-metadata.json');
+    }
+    if (request.checkpoint) {
+        args.push('--checkpoint', '@/tmp/nango-dryrun-checkpoint.json');
+    }
+    if (request.last_sync_date) {
+        args.push('--lastSyncDate', request.last_sync_date);
+    }
+
+    return args;
+}
+
+export function buildDeployArgs(request: DeployRequest): string[] {
+    return [
+        'deploy',
+        request.environment_name,
+        request.function_type === 'action' ? '--action' : '--sync',
+        request.function_name,
+        '--auto-confirm',
+        '--allow-destructive',
+        '--no-interactive'
+    ];
+}

--- a/packages/server/lib/services/remote-function/command-builders.unit.test.ts
+++ b/packages/server/lib/services/remote-function/command-builders.unit.test.ts
@@ -1,0 +1,34 @@
+import { describe, expect, it } from 'vitest';
+
+import { buildDeployArgs, buildDryrunArgs } from './command-builders.js';
+
+describe('remote function command builders', () => {
+    it('scopes deploy to the requested integration', () => {
+        expect(
+            buildDeployArgs({
+                integration_id: 'github',
+                function_name: 'syncIssues',
+                function_type: 'sync',
+                code: 'export default {}',
+                environment_name: 'dev',
+                nango_secret_key: 'nango-secret',
+                nango_host: 'https://api.example.test'
+            })
+        ).toStrictEqual(['deploy', 'dev', '--integration', 'github', '--sync', 'syncIssues', '--auto-confirm', '--allow-destructive', '--no-interactive']);
+    });
+
+    it('scopes dry-run to the requested integration', () => {
+        expect(
+            buildDryrunArgs({
+                integration_id: 'github',
+                function_name: 'createIssue',
+                function_type: 'action',
+                code: 'export default {}',
+                environment_name: 'dev',
+                connection_id: 'conn-1',
+                nango_secret_key: 'nango-secret',
+                nango_host: 'https://api.example.test'
+            })
+        ).toContain('--integration-id');
+    });
+});

--- a/packages/server/lib/services/remote-function/compiler-client.ts
+++ b/packages/server/lib/services/remote-function/compiler-client.ts
@@ -1,10 +1,11 @@
 import { randomUUID } from 'node:crypto';
 import path from 'node:path';
 
-import { CommandExitError, Sandbox } from 'e2b';
+import { CommandExitError, Sandbox, TimeoutError } from 'e2b';
 
 import { isLocal } from '@nangohq/utils';
 
+import { RemoteFunctionError } from './helpers.js';
 import { remoteFunctionCompilerTemplate, remoteFunctionProjectPath } from './runtime.js';
 import { invokeLocalCompiler } from '../local/compiler-client.js';
 
@@ -20,11 +21,11 @@ export interface CompileResult {
     bundleSizeBytes: number;
 }
 
-export class CompilerError extends Error {
+export class CompilerError extends RemoteFunctionError {
     public readonly step: 'validation' | 'compilation';
 
     constructor(message: string, step: 'validation' | 'compilation', remoteStack?: string) {
-        super(message);
+        super({ code: step === 'validation' ? 'validation_error' : 'compilation_error', message, status: 400 });
         this.name = 'CompilerError';
         this.step = step;
         if (remoteStack !== undefined) {
@@ -68,6 +69,9 @@ export async function invokeCompiler(request: CompileRequest): Promise<CompileRe
         } catch (err) {
             if (err instanceof CommandExitError) {
                 throw new CompilerError(err.stderr || err.stdout || 'Compilation failed', 'compilation');
+            }
+            if (err instanceof TimeoutError) {
+                throw new RemoteFunctionError({ code: 'timeout', message: 'Compilation timed out', status: 504 });
             }
             throw err;
         }

--- a/packages/server/lib/services/remote-function/compiler-client.ts
+++ b/packages/server/lib/services/remote-function/compiler-client.ts
@@ -6,7 +6,12 @@ import { CommandExitError, Sandbox, TimeoutError } from 'e2b';
 import { isLocal } from '@nangohq/utils';
 
 import { RemoteFunctionError } from './helpers.js';
-import { remoteFunctionCompilerTemplate, remoteFunctionProjectPath } from './runtime.js';
+import {
+    remoteFunctionCompileTimeoutMs,
+    remoteFunctionCompilerSandboxTimeoutMs,
+    remoteFunctionCompilerTemplate,
+    remoteFunctionProjectPath
+} from './runtime.js';
 import { invokeLocalCompiler } from '../local/compiler-client.js';
 
 export interface CompileRequest {
@@ -34,8 +39,6 @@ export class CompilerError extends RemoteFunctionError {
     }
 }
 
-const compilerTimeoutMs = 3 * 60 * 1000;
-
 export async function invokeCompiler(request: CompileRequest): Promise<CompileResult> {
     if (isLocal) {
         return invokeLocalCompiler(request);
@@ -47,7 +50,7 @@ export async function invokeCompiler(request: CompileRequest): Promise<CompileRe
     }
 
     const sandbox = await Sandbox.create(remoteFunctionCompilerTemplate, {
-        timeoutMs: compilerTimeoutMs,
+        timeoutMs: remoteFunctionCompilerSandboxTimeoutMs,
         allowInternetAccess: true,
         metadata: { purpose: 'nango-compiler', requestId: randomUUID() },
         network: { allowPublicTraffic: true },
@@ -63,7 +66,7 @@ export async function invokeCompiler(request: CompileRequest): Promise<CompileRe
         try {
             await sandbox.commands.run('nango compile', {
                 cwd: remoteFunctionProjectPath,
-                timeoutMs: compilerTimeoutMs,
+                timeoutMs: remoteFunctionCompileTimeoutMs,
                 envs: { NO_COLOR: '1' }
             });
         } catch (err) {

--- a/packages/server/lib/services/remote-function/compiler-client.ts
+++ b/packages/server/lib/services/remote-function/compiler-client.ts
@@ -1,0 +1,99 @@
+import { randomUUID } from 'node:crypto';
+import path from 'node:path';
+
+import { CommandExitError, Sandbox } from 'e2b';
+
+import { isLocal } from '@nangohq/utils';
+
+import { remoteFunctionCompilerTemplate, remoteFunctionProjectPath } from './runtime.js';
+import { invokeLocalCompiler } from '../local/compiler-client.js';
+
+export interface CompileRequest {
+    integration_id: string;
+    function_name: string;
+    function_type: 'action' | 'sync';
+    code: string;
+}
+
+export interface CompileResult {
+    bundledJs: string;
+    bundleSizeBytes: number;
+}
+
+export class CompilerError extends Error {
+    public readonly step: 'validation' | 'compilation';
+
+    constructor(message: string, step: 'validation' | 'compilation', remoteStack?: string) {
+        super(message);
+        this.name = 'CompilerError';
+        this.step = step;
+        if (remoteStack !== undefined) {
+            this.stack = remoteStack;
+        }
+    }
+}
+
+const compilerTimeoutMs = 3 * 60 * 1000;
+
+export async function invokeCompiler(request: CompileRequest): Promise<CompileResult> {
+    if (isLocal) {
+        return invokeLocalCompiler(request);
+    }
+
+    const apiKey = process.env['E2B_API_KEY'];
+    if (!apiKey) {
+        throw new Error('E2B_API_KEY is required for the E2B compiler runtime');
+    }
+
+    const sandbox = await Sandbox.create(remoteFunctionCompilerTemplate, {
+        timeoutMs: compilerTimeoutMs,
+        allowInternetAccess: true,
+        metadata: { purpose: 'nango-compiler', requestId: randomUUID() },
+        network: { allowPublicTraffic: true },
+        apiKey
+    });
+
+    try {
+        const { tsFilePath, cjsFilePath } = getFilePaths(request);
+
+        await sandbox.files.write(path.join(remoteFunctionProjectPath, tsFilePath), request.code);
+        await sandbox.files.write(path.join(remoteFunctionProjectPath, 'index.ts'), buildIndexTs(request));
+
+        try {
+            await sandbox.commands.run('nango compile', {
+                cwd: remoteFunctionProjectPath,
+                timeoutMs: compilerTimeoutMs,
+                envs: { NO_COLOR: '1' }
+            });
+        } catch (err) {
+            if (err instanceof CommandExitError) {
+                throw new CompilerError(err.stderr || err.stdout || 'Compilation failed', 'compilation');
+            }
+            throw err;
+        }
+
+        const bundledJs = String(await sandbox.files.read(path.join(remoteFunctionProjectPath, cjsFilePath)));
+
+        return {
+            bundledJs,
+            bundleSizeBytes: Buffer.byteLength(bundledJs, 'utf8')
+        };
+    } finally {
+        await sandbox.kill().catch(() => {});
+    }
+}
+
+export function getFilePaths(request: Pick<CompileRequest, 'integration_id' | 'function_name' | 'function_type'>): {
+    tsFilePath: string;
+    cjsFilePath: string;
+} {
+    const folder = request.function_type === 'action' ? 'actions' : 'syncs';
+    const tsFilePath = `${request.integration_id}/${folder}/${request.function_name}.ts`;
+    const cjsFilePath = `build/${request.integration_id}_${folder}_${request.function_name}.cjs`;
+    return { tsFilePath, cjsFilePath };
+}
+
+export function buildIndexTs(request: Pick<CompileRequest, 'integration_id' | 'function_name' | 'function_type'>): string {
+    const folder = request.function_type === 'action' ? 'actions' : 'syncs';
+    return `import './${request.integration_id}/${folder}/${request.function_name}.js';\n`;
+}

--- a/packages/server/lib/services/remote-function/compiler-client.unit.test.ts
+++ b/packages/server/lib/services/remote-function/compiler-client.unit.test.ts
@@ -1,0 +1,41 @@
+import { describe, expect, it } from 'vitest';
+
+import { buildIndexTs, getFilePaths } from './compiler-client.js';
+
+describe('remote function compiler client helpers', () => {
+    it('builds action file paths', () => {
+        expect(
+            getFilePaths({
+                integration_id: 'github',
+                function_name: 'smokeTest',
+                function_type: 'action'
+            })
+        ).toStrictEqual({
+            tsFilePath: 'github/actions/smokeTest.ts',
+            cjsFilePath: 'build/github_actions_smokeTest.cjs'
+        });
+    });
+
+    it('builds sync file paths', () => {
+        expect(
+            getFilePaths({
+                integration_id: 'github',
+                function_name: 'syncIssues',
+                function_type: 'sync'
+            })
+        ).toStrictEqual({
+            tsFilePath: 'github/syncs/syncIssues.ts',
+            cjsFilePath: 'build/github_syncs_syncIssues.cjs'
+        });
+    });
+
+    it('builds the single-entry index file', () => {
+        expect(
+            buildIndexTs({
+                integration_id: 'github',
+                function_name: 'syncIssues',
+                function_type: 'sync'
+            })
+        ).toBe("import './github/syncs/syncIssues.js';\n");
+    });
+});

--- a/packages/server/lib/services/remote-function/deploy-client.ts
+++ b/packages/server/lib/services/remote-function/deploy-client.ts
@@ -7,7 +7,7 @@ import { isLocal } from '@nangohq/utils';
 import { buildDeployArgs } from './command-builders.js';
 import { buildIndexTs, getFilePaths } from './compiler-client.js';
 import { RemoteFunctionError } from './helpers.js';
-import { remoteFunctionCompilerTemplate, remoteFunctionProjectPath } from './runtime.js';
+import { remoteFunctionCompilerTemplate, remoteFunctionDeploySandboxTimeoutMs, remoteFunctionDeployTimeoutMs, remoteFunctionProjectPath } from './runtime.js';
 import { buildShellCommand } from './shell.js';
 import { invokeLocalDeploy } from '../local/deploy-client.js';
 
@@ -25,8 +25,6 @@ export interface DeployResult {
     output: string;
 }
 
-const deployTimeoutMs = 5 * 60 * 1000;
-
 export async function invokeDeploy(request: DeployRequest): Promise<DeployResult> {
     if (isLocal) {
         return invokeLocalDeploy(request);
@@ -38,7 +36,7 @@ export async function invokeDeploy(request: DeployRequest): Promise<DeployResult
     }
 
     const sandbox = await Sandbox.create(remoteFunctionCompilerTemplate, {
-        timeoutMs: deployTimeoutMs,
+        timeoutMs: remoteFunctionDeploySandboxTimeoutMs,
         allowInternetAccess: true,
         metadata: { purpose: 'nango-deploy', requestId: randomUUID() },
         network: { allowPublicTraffic: true },
@@ -62,7 +60,7 @@ export async function invokeDeploy(request: DeployRequest): Promise<DeployResult
         try {
             const result = await sandbox.commands.run(command, {
                 cwd: remoteFunctionProjectPath,
-                timeoutMs: deployTimeoutMs,
+                timeoutMs: remoteFunctionDeployTimeoutMs,
                 envs
             });
             return { output: result.stdout };

--- a/packages/server/lib/services/remote-function/deploy-client.ts
+++ b/packages/server/lib/services/remote-function/deploy-client.ts
@@ -1,0 +1,77 @@
+import { randomUUID } from 'node:crypto';
+
+import { CommandExitError, Sandbox } from 'e2b';
+
+import { isLocal } from '@nangohq/utils';
+
+import { buildDeployArgs } from './command-builders.js';
+import { buildIndexTs, getFilePaths } from './compiler-client.js';
+import { remoteFunctionCompilerTemplate, remoteFunctionProjectPath } from './runtime.js';
+import { buildShellCommand } from './shell.js';
+import { invokeLocalDeploy } from '../local/deploy-client.js';
+
+export interface DeployRequest {
+    integration_id: string;
+    function_name: string;
+    function_type: 'action' | 'sync';
+    code: string;
+    environment_name: string;
+    nango_secret_key: string;
+    nango_host: string;
+}
+
+export interface DeployResult {
+    output: string;
+}
+
+const deployTimeoutMs = 5 * 60 * 1000;
+
+export async function invokeDeploy(request: DeployRequest): Promise<DeployResult> {
+    if (isLocal) {
+        return invokeLocalDeploy(request);
+    }
+
+    const apiKey = process.env['E2B_API_KEY'];
+    if (!apiKey) {
+        throw new Error('E2B_API_KEY is required for the E2B deploy runtime');
+    }
+
+    const sandbox = await Sandbox.create(remoteFunctionCompilerTemplate, {
+        timeoutMs: deployTimeoutMs,
+        allowInternetAccess: true,
+        metadata: { purpose: 'nango-deploy', requestId: randomUUID() },
+        network: { allowPublicTraffic: true },
+        apiKey
+    });
+
+    try {
+        const { tsFilePath } = getFilePaths(request);
+
+        await sandbox.files.write(`${remoteFunctionProjectPath}/${tsFilePath}`, request.code);
+        await sandbox.files.write(`${remoteFunctionProjectPath}/index.ts`, buildIndexTs(request));
+
+        const envs = {
+            NO_COLOR: '1',
+            NANGO_SECRET_KEY: request.nango_secret_key,
+            NANGO_HOSTPORT: request.nango_host,
+            NANGO_DEPLOY_AUTO_CONFIRM: 'true'
+        };
+        const command = buildShellCommand(['nango', ...buildDeployArgs(request)]);
+
+        try {
+            const result = await sandbox.commands.run(command, {
+                cwd: remoteFunctionProjectPath,
+                timeoutMs: deployTimeoutMs,
+                envs
+            });
+            return { output: result.stdout };
+        } catch (err) {
+            if (err instanceof CommandExitError) {
+                return { output: err.stdout || err.stderr || JSON.stringify(err) };
+            }
+            throw err;
+        }
+    } finally {
+        await sandbox.kill().catch(() => {});
+    }
+}

--- a/packages/server/lib/services/remote-function/deploy-client.ts
+++ b/packages/server/lib/services/remote-function/deploy-client.ts
@@ -1,11 +1,12 @@
 import { randomUUID } from 'node:crypto';
 
-import { CommandExitError, Sandbox } from 'e2b';
+import { CommandExitError, Sandbox, TimeoutError } from 'e2b';
 
 import { isLocal } from '@nangohq/utils';
 
 import { buildDeployArgs } from './command-builders.js';
 import { buildIndexTs, getFilePaths } from './compiler-client.js';
+import { RemoteFunctionError } from './helpers.js';
 import { remoteFunctionCompilerTemplate, remoteFunctionProjectPath } from './runtime.js';
 import { buildShellCommand } from './shell.js';
 import { invokeLocalDeploy } from '../local/deploy-client.js';
@@ -67,7 +68,10 @@ export async function invokeDeploy(request: DeployRequest): Promise<DeployResult
             return { output: result.stdout };
         } catch (err) {
             if (err instanceof CommandExitError) {
-                return { output: err.stdout || err.stderr || JSON.stringify(err) };
+                throw new RemoteFunctionError({ code: 'deployment_error', message: err.stdout || err.stderr || JSON.stringify(err), status: 400 });
+            }
+            if (err instanceof TimeoutError) {
+                throw new RemoteFunctionError({ code: 'timeout', message: 'Deployment timed out', status: 504 });
             }
             throw err;
         }

--- a/packages/server/lib/services/remote-function/dryrun-client.ts
+++ b/packages/server/lib/services/remote-function/dryrun-client.ts
@@ -7,7 +7,13 @@ import { isLocal } from '@nangohq/utils';
 import { buildDryrunArgs } from './command-builders.js';
 import { buildIndexTs, getFilePaths } from './compiler-client.js';
 import { RemoteFunctionError } from './helpers.js';
-import { remoteFunctionCompilerTemplate, remoteFunctionProjectPath } from './runtime.js';
+import {
+    remoteFunctionCompileTimeoutMs,
+    remoteFunctionCompilerTemplate,
+    remoteFunctionDryrunSandboxTimeoutMs,
+    remoteFunctionDryrunTimeoutMs,
+    remoteFunctionProjectPath
+} from './runtime.js';
 import { buildShellCommand } from './shell.js';
 import { invokeLocalDryrun } from '../local/dryrun-client.js';
 
@@ -30,9 +36,6 @@ export interface DryrunResult {
     output: string;
 }
 
-const compileTimeoutMs = 3 * 60 * 1000;
-const dryrunTimeoutMs = 5 * 60 * 1000;
-
 export async function invokeDryrun(request: DryrunRequest): Promise<DryrunResult> {
     if (isLocal) {
         return invokeLocalDryrun(request);
@@ -44,7 +47,7 @@ export async function invokeDryrun(request: DryrunRequest): Promise<DryrunResult
     }
 
     const sandbox = await Sandbox.create(remoteFunctionCompilerTemplate, {
-        timeoutMs: dryrunTimeoutMs,
+        timeoutMs: remoteFunctionDryrunSandboxTimeoutMs,
         allowInternetAccess: true,
         metadata: { purpose: 'nango-dryrun', requestId: randomUUID() },
         network: { allowPublicTraffic: true },
@@ -60,7 +63,7 @@ export async function invokeDryrun(request: DryrunRequest): Promise<DryrunResult
         try {
             await sandbox.commands.run('nango compile', {
                 cwd: remoteFunctionProjectPath,
-                timeoutMs: compileTimeoutMs,
+                timeoutMs: remoteFunctionCompileTimeoutMs,
                 envs: { NO_COLOR: '1' }
             });
         } catch (err) {
@@ -93,7 +96,7 @@ export async function invokeDryrun(request: DryrunRequest): Promise<DryrunResult
         try {
             const result = await sandbox.commands.run(command, {
                 cwd: remoteFunctionProjectPath,
-                timeoutMs: dryrunTimeoutMs,
+                timeoutMs: remoteFunctionDryrunTimeoutMs,
                 envs
             });
             return { output: result.stdout };

--- a/packages/server/lib/services/remote-function/dryrun-client.ts
+++ b/packages/server/lib/services/remote-function/dryrun-client.ts
@@ -1,11 +1,12 @@
 import { randomUUID } from 'node:crypto';
 
-import { CommandExitError, Sandbox } from 'e2b';
+import { CommandExitError, Sandbox, TimeoutError } from 'e2b';
 
 import { isLocal } from '@nangohq/utils';
 
 import { buildDryrunArgs } from './command-builders.js';
 import { buildIndexTs, getFilePaths } from './compiler-client.js';
+import { RemoteFunctionError } from './helpers.js';
 import { remoteFunctionCompilerTemplate, remoteFunctionProjectPath } from './runtime.js';
 import { buildShellCommand } from './shell.js';
 import { invokeLocalDryrun } from '../local/dryrun-client.js';
@@ -64,7 +65,10 @@ export async function invokeDryrun(request: DryrunRequest): Promise<DryrunResult
             });
         } catch (err) {
             if (err instanceof CommandExitError) {
-                return { output: err.stderr || err.stdout || 'Compilation failed' };
+                throw new RemoteFunctionError({ code: 'compilation_error', message: err.stderr || err.stdout || 'Compilation failed', status: 400 });
+            }
+            if (err instanceof TimeoutError) {
+                throw new RemoteFunctionError({ code: 'timeout', message: 'Compilation timed out', status: 504 });
             }
             throw err;
         }
@@ -95,7 +99,10 @@ export async function invokeDryrun(request: DryrunRequest): Promise<DryrunResult
             return { output: result.stdout };
         } catch (err) {
             if (err instanceof CommandExitError) {
-                return { output: err.stdout || err.stderr || JSON.stringify(err) };
+                throw new RemoteFunctionError({ code: 'dryrun_error', message: err.stdout || err.stderr || JSON.stringify(err), status: 400 });
+            }
+            if (err instanceof TimeoutError) {
+                throw new RemoteFunctionError({ code: 'timeout', message: 'Dry run timed out', status: 504 });
             }
             throw err;
         }

--- a/packages/server/lib/services/remote-function/dryrun-client.ts
+++ b/packages/server/lib/services/remote-function/dryrun-client.ts
@@ -1,0 +1,105 @@
+import { randomUUID } from 'node:crypto';
+
+import { CommandExitError, Sandbox } from 'e2b';
+
+import { isLocal } from '@nangohq/utils';
+
+import { buildDryrunArgs } from './command-builders.js';
+import { buildIndexTs, getFilePaths } from './compiler-client.js';
+import { remoteFunctionCompilerTemplate, remoteFunctionProjectPath } from './runtime.js';
+import { buildShellCommand } from './shell.js';
+import { invokeLocalDryrun } from '../local/dryrun-client.js';
+
+export interface DryrunRequest {
+    integration_id: string;
+    function_name: string;
+    function_type: 'action' | 'sync';
+    code: string;
+    environment_name: string;
+    connection_id: string;
+    nango_secret_key: string;
+    nango_host: string;
+    input?: unknown;
+    metadata?: Record<string, unknown>;
+    checkpoint?: Record<string, unknown>;
+    last_sync_date?: string;
+}
+
+export interface DryrunResult {
+    output: string;
+}
+
+const compileTimeoutMs = 3 * 60 * 1000;
+const dryrunTimeoutMs = 5 * 60 * 1000;
+
+export async function invokeDryrun(request: DryrunRequest): Promise<DryrunResult> {
+    if (isLocal) {
+        return invokeLocalDryrun(request);
+    }
+
+    const apiKey = process.env['E2B_API_KEY'];
+    if (!apiKey) {
+        throw new Error('E2B_API_KEY is required for the E2B dryrun runtime');
+    }
+
+    const sandbox = await Sandbox.create(remoteFunctionCompilerTemplate, {
+        timeoutMs: dryrunTimeoutMs,
+        allowInternetAccess: true,
+        metadata: { purpose: 'nango-dryrun', requestId: randomUUID() },
+        network: { allowPublicTraffic: true },
+        apiKey
+    });
+
+    try {
+        const { tsFilePath } = getFilePaths(request);
+
+        await sandbox.files.write(`${remoteFunctionProjectPath}/${tsFilePath}`, request.code);
+        await sandbox.files.write(`${remoteFunctionProjectPath}/index.ts`, buildIndexTs(request));
+
+        try {
+            await sandbox.commands.run('nango compile', {
+                cwd: remoteFunctionProjectPath,
+                timeoutMs: compileTimeoutMs,
+                envs: { NO_COLOR: '1' }
+            });
+        } catch (err) {
+            if (err instanceof CommandExitError) {
+                return { output: err.stderr || err.stdout || 'Compilation failed' };
+            }
+            throw err;
+        }
+
+        if (request.input !== undefined) {
+            await sandbox.files.write('/tmp/nango-dryrun-input.json', JSON.stringify(request.input));
+        }
+        if (request.metadata) {
+            await sandbox.files.write('/tmp/nango-dryrun-metadata.json', JSON.stringify(request.metadata));
+        }
+        if (request.checkpoint) {
+            await sandbox.files.write('/tmp/nango-dryrun-checkpoint.json', JSON.stringify(request.checkpoint));
+        }
+
+        const envs = {
+            NO_COLOR: '1',
+            NANGO_SECRET_KEY: request.nango_secret_key,
+            NANGO_HOSTPORT: request.nango_host
+        };
+        const command = buildShellCommand(['nango', ...buildDryrunArgs(request)]);
+
+        try {
+            const result = await sandbox.commands.run(command, {
+                cwd: remoteFunctionProjectPath,
+                timeoutMs: dryrunTimeoutMs,
+                envs
+            });
+            return { output: result.stdout };
+        } catch (err) {
+            if (err instanceof CommandExitError) {
+                return { output: err.stdout || err.stderr || JSON.stringify(err) };
+            }
+            throw err;
+        }
+    } finally {
+        await sandbox.kill().catch(() => {});
+    }
+}

--- a/packages/server/lib/services/remote-function/helpers.ts
+++ b/packages/server/lib/services/remote-function/helpers.ts
@@ -1,0 +1,43 @@
+import { stringifyError } from '@nangohq/utils';
+
+import type { FunctionErrorCode } from '@nangohq/types';
+import type { Response } from 'express';
+
+export type RemoteFunctionStep = 'compilation' | 'deployment' | 'lookup' | 'execution';
+
+export function sendStepError({ res, step: _step, error, status }: { res: Response; step: RemoteFunctionStep; error: unknown; status?: number }): void {
+    const normalized = normalizeError(error);
+
+    res.status(status ?? normalized.status ?? 500).send({
+        error: {
+            code: (normalized.code ?? 'server_error') as FunctionErrorCode,
+            message: normalized.message,
+            ...(normalized.payload !== undefined ? { payload: normalized.payload } : {})
+        }
+    });
+}
+
+function normalizeError(error: unknown): {
+    message: string;
+    code?: string;
+    payload?: unknown;
+    status?: number;
+} {
+    if (error && typeof error === 'object') {
+        const err = error as Record<string, unknown>;
+        const message = typeof err['message'] === 'string' ? sanitizeMessage(err['message']) : sanitizeMessage(stringifyError(error));
+        const code = typeof err['type'] === 'string' ? err['type'] : typeof err['code'] === 'string' ? err['code'] : undefined;
+        const payload = 'payload' in err ? err['payload'] : undefined;
+        const status = typeof err['status'] === 'number' ? err['status'] : undefined;
+        return { message, ...(code ? { code } : {}), ...(payload !== undefined ? { payload } : {}), ...(status ? { status } : {}) };
+    }
+    return { message: sanitizeMessage(stringifyError(error)) };
+}
+
+function sanitizeMessage(message: string): string {
+    return message
+        .replace(/\/[^\s"']+\/[^\s"']*/g, '<path>')
+        .replace(/https?:\/\/(localhost|127\.0\.0\.1|10\.\d+\.\d+\.\d+|192\.168\.\d+\.\d+)(:\d+)?[^\s]*/g, '<internal-url>')
+        .replace(/\b[A-Z][A-Z0-9_]{4,}\b/g, (match) => (process.env[match] !== undefined ? '<env>' : match))
+        .slice(0, 500);
+}

--- a/packages/server/lib/services/remote-function/helpers.ts
+++ b/packages/server/lib/services/remote-function/helpers.ts
@@ -5,8 +5,6 @@ import { remoteFunctionProjectPath } from './runtime.js';
 import type { FunctionErrorCode } from '@nangohq/types';
 import type { Response } from 'express';
 
-export type RemoteFunctionStep = 'compilation' | 'deployment' | 'lookup' | 'execution';
-
 /**
  * Runtime allow-list for error codes exposed by the remote-function API.
  * normalizeError receives arbitrary Error-like objects, so internal codes
@@ -40,7 +38,7 @@ export class RemoteFunctionError extends Error {
     }
 }
 
-export function sendStepError({ res, step: _step, error, status }: { res: Response; step: RemoteFunctionStep; error: unknown; status?: number }): void {
+export function sendStepError({ res, error, status }: { res: Response; error: unknown; status?: number }): void {
     const normalized = normalizeError(error);
 
     res.status(status ?? normalized.status ?? 500).send({

--- a/packages/server/lib/services/remote-function/helpers.ts
+++ b/packages/server/lib/services/remote-function/helpers.ts
@@ -1,9 +1,44 @@
 import { stringifyError } from '@nangohq/utils';
 
+import { remoteFunctionProjectPath } from './runtime.js';
+
 import type { FunctionErrorCode } from '@nangohq/types';
 import type { Response } from 'express';
 
 export type RemoteFunctionStep = 'compilation' | 'deployment' | 'lookup' | 'execution';
+
+/**
+ * Runtime allow-list for error codes exposed by the remote-function API.
+ * normalizeError receives arbitrary Error-like objects, so internal codes
+ * such as ENOENT should not be returned as public API error codes.
+ */
+const functionErrorCodes = new Set<string>([
+    'invalid_request',
+    'integration_not_found',
+    'compilation_error',
+    'dryrun_error',
+    'deployment_error',
+    'connection_not_found',
+    'function_disabled',
+    'timeout',
+    'validation_error'
+] satisfies FunctionErrorCode[]);
+
+export class RemoteFunctionError extends Error {
+    public readonly code: FunctionErrorCode;
+    public readonly status: number;
+    public readonly payload?: unknown;
+
+    constructor({ code, message, status, payload }: { code: FunctionErrorCode; message: string; status: number; payload?: unknown }) {
+        super(message);
+        this.name = 'RemoteFunctionError';
+        this.code = code;
+        this.status = status;
+        if (payload !== undefined) {
+            this.payload = payload;
+        }
+    }
+}
 
 export function sendStepError({ res, step: _step, error, status }: { res: Response; step: RemoteFunctionStep; error: unknown; status?: number }): void {
     const normalized = normalizeError(error);
@@ -26,7 +61,8 @@ function normalizeError(error: unknown): {
     if (error && typeof error === 'object') {
         const err = error as Record<string, unknown>;
         const message = typeof err['message'] === 'string' ? sanitizeMessage(err['message']) : sanitizeMessage(stringifyError(error));
-        const code = typeof err['type'] === 'string' ? err['type'] : typeof err['code'] === 'string' ? err['code'] : undefined;
+        const rawCode = typeof err['type'] === 'string' ? err['type'] : typeof err['code'] === 'string' ? err['code'] : undefined;
+        const code = rawCode && functionErrorCodes.has(rawCode) ? rawCode : undefined;
         const payload = 'payload' in err ? err['payload'] : undefined;
         const status = typeof err['status'] === 'number' ? err['status'] : undefined;
         return { message, ...(code ? { code } : {}), ...(payload !== undefined ? { payload } : {}), ...(status ? { status } : {}) };
@@ -35,9 +71,36 @@ function normalizeError(error: unknown): {
 }
 
 function sanitizeMessage(message: string): string {
-    return message
-        .replace(/\/[^\s"']+\/[^\s"']*/g, '<path>')
-        .replace(/https?:\/\/(localhost|127\.0\.0\.1|10\.\d+\.\d+\.\d+|192\.168\.\d+\.\d+)(:\d+)?[^\s]*/g, '<internal-url>')
+    const urlReplacements: string[] = [];
+    const messageWithUrlPlaceholders = message.replace(/https?:\/\/[^\s"']+/g, (match) => {
+        const replacementKey = urlReplacements.length;
+        urlReplacements.push(removeUrlOrigin(match));
+        return `__REMOTE_FUNCTION_URL_${replacementKey}__`;
+    });
+
+    return messageWithUrlPlaceholders
+        .replace(/\/[^\s"']+/g, redactAbsolutePath)
+        .replace(/__REMOTE_FUNCTION_URL_(\d+)__/g, (_, index: string) => urlReplacements[Number(index)] ?? '<url>')
         .replace(/\b[A-Z][A-Z0-9_]{4,}\b/g, (match) => (process.env[match] !== undefined ? '<env>' : match))
         .slice(0, 500);
+}
+
+function removeUrlOrigin(value: string): string {
+    try {
+        const url = new URL(value);
+        return `${url.pathname}${url.search}${url.hash}`;
+    } catch {
+        return '<url>';
+    }
+}
+
+function redactAbsolutePath(value: string): string {
+    if (value === remoteFunctionProjectPath) {
+        return '.';
+    }
+    if (value.startsWith(`${remoteFunctionProjectPath}/`)) {
+        return value.slice(remoteFunctionProjectPath.length + 1);
+    }
+
+    return '<path>';
 }

--- a/packages/server/lib/services/remote-function/helpers.unit.test.ts
+++ b/packages/server/lib/services/remote-function/helpers.unit.test.ts
@@ -1,0 +1,67 @@
+import { describe, expect, it, vi } from 'vitest';
+
+import { RemoteFunctionError, sendStepError } from './helpers.js';
+
+import type { Response } from 'express';
+
+function mockResponse() {
+    const status = vi.fn().mockReturnThis();
+    const send = vi.fn();
+    const res = { status, send } as unknown as Response;
+
+    return { res, status, send };
+}
+
+describe('remote function helpers', () => {
+    it('sends structured remote function errors with their status and code', () => {
+        const { res, status, send } = mockResponse();
+
+        sendStepError({
+            res,
+            step: 'deployment',
+            error: new RemoteFunctionError({ code: 'deployment_error', message: 'Deploy failed', status: 400 })
+        });
+
+        expect(status).toHaveBeenCalledWith(400);
+        expect(send).toHaveBeenCalledWith({ error: { code: 'deployment_error', message: 'Deploy failed' } });
+    });
+
+    it('does not expose arbitrary error codes as function API codes', () => {
+        const { res, status, send } = mockResponse();
+
+        sendStepError({
+            res,
+            step: 'execution',
+            error: Object.assign(new Error('Docker is unavailable'), { code: 'ENOENT' })
+        });
+
+        expect(status).toHaveBeenCalledWith(500);
+        expect(send).toHaveBeenCalledWith({ error: { code: 'server_error', message: 'Docker is unavailable' } });
+    });
+
+    it('removes url origins while preserving route context', () => {
+        const { res, send } = mockResponse();
+
+        sendStepError({
+            res,
+            step: 'execution',
+            error: new Error('Fetch failed http://localhost:3003/sync/deploy?env=dev')
+        });
+
+        expect(send).toHaveBeenCalledWith({ error: { code: 'server_error', message: 'Fetch failed /sync/deploy?env=dev' } });
+    });
+
+    it('keeps sandbox project paths relative and redacts other absolute paths', () => {
+        const { res, send } = mockResponse();
+
+        sendStepError({
+            res,
+            step: 'compilation',
+            error: new Error('Failed at /home/user/nango-integrations/github/syncs/foo.ts:12:3 while reading /tmp/nango-dryrun-input.json')
+        });
+
+        expect(send).toHaveBeenCalledWith({
+            error: { code: 'server_error', message: 'Failed at github/syncs/foo.ts:12:3 while reading <path>' }
+        });
+    });
+});

--- a/packages/server/lib/services/remote-function/helpers.unit.test.ts
+++ b/packages/server/lib/services/remote-function/helpers.unit.test.ts
@@ -18,7 +18,6 @@ describe('remote function helpers', () => {
 
         sendStepError({
             res,
-            step: 'deployment',
             error: new RemoteFunctionError({ code: 'deployment_error', message: 'Deploy failed', status: 400 })
         });
 
@@ -31,7 +30,6 @@ describe('remote function helpers', () => {
 
         sendStepError({
             res,
-            step: 'execution',
             error: Object.assign(new Error('Docker is unavailable'), { code: 'ENOENT' })
         });
 
@@ -44,7 +42,6 @@ describe('remote function helpers', () => {
 
         sendStepError({
             res,
-            step: 'execution',
             error: new Error('Fetch failed http://localhost:3003/sync/deploy?env=dev')
         });
 
@@ -56,7 +53,6 @@ describe('remote function helpers', () => {
 
         sendStepError({
             res,
-            step: 'compilation',
             error: new Error('Failed at /home/user/nango-integrations/github/syncs/foo.ts:12:3 while reading /tmp/nango-dryrun-input.json')
         });
 

--- a/packages/server/lib/services/remote-function/runtime.ts
+++ b/packages/server/lib/services/remote-function/runtime.ts
@@ -1,0 +1,3 @@
+export const remoteFunctionProjectPath = '/home/user/nango-integrations';
+export const remoteFunctionCompilerTemplate = 'blank-workspace:staging';
+export const remoteFunctionLocalImage = 'agent-sandboxes/blank-workspace:local';

--- a/packages/server/lib/services/remote-function/runtime.ts
+++ b/packages/server/lib/services/remote-function/runtime.ts
@@ -1,3 +1,5 @@
+import { envs } from '../../env.js';
+
 export const remoteFunctionProjectPath = '/home/user/nango-integrations';
-export const remoteFunctionCompilerTemplate = 'blank-workspace:staging';
+export const remoteFunctionCompilerTemplate = envs.E2B_SANDBOX_COMPILER_TEMPLATE;
 export const remoteFunctionLocalImage = 'agent-sandboxes/blank-workspace:local';

--- a/packages/server/lib/services/remote-function/runtime.ts
+++ b/packages/server/lib/services/remote-function/runtime.ts
@@ -3,3 +3,13 @@ import { envs } from '../../env.js';
 export const remoteFunctionProjectPath = '/home/user/nango-integrations';
 export const remoteFunctionCompilerTemplate = envs.E2B_SANDBOX_COMPILER_TEMPLATE;
 export const remoteFunctionLocalImage = 'agent-sandboxes/blank-workspace:local';
+
+export const remoteFunctionCompileTimeoutMs = 3 * 60 * 1000;
+export const remoteFunctionDeployTimeoutMs = 5 * 60 * 1000;
+export const remoteFunctionDryrunTimeoutMs = 5 * 60 * 1000;
+
+const remoteFunctionSandboxTimeoutBufferMs = 30 * 1000;
+
+export const remoteFunctionCompilerSandboxTimeoutMs = remoteFunctionCompileTimeoutMs + remoteFunctionSandboxTimeoutBufferMs;
+export const remoteFunctionDeploySandboxTimeoutMs = remoteFunctionDeployTimeoutMs + remoteFunctionSandboxTimeoutBufferMs;
+export const remoteFunctionDryrunSandboxTimeoutMs = remoteFunctionCompileTimeoutMs + remoteFunctionDryrunTimeoutMs + remoteFunctionSandboxTimeoutBufferMs;

--- a/packages/server/lib/services/remote-function/shell.ts
+++ b/packages/server/lib/services/remote-function/shell.ts
@@ -1,0 +1,7 @@
+export function quoteShellArg(value: string): string {
+    return `'${value.replace(/'/g, `'"'"'`)}'`;
+}
+
+export function buildShellCommand(args: string[]): string {
+    return args.map(quoteShellArg).join(' ');
+}

--- a/packages/server/lib/services/remote-function/shell.unit.test.ts
+++ b/packages/server/lib/services/remote-function/shell.unit.test.ts
@@ -1,0 +1,13 @@
+import { describe, expect, it } from 'vitest';
+
+import { buildShellCommand, quoteShellArg } from './shell.js';
+
+describe('remote function shell helpers', () => {
+    it('quotes single quotes safely', () => {
+        expect(quoteShellArg("a'b")).toBe(`'a'"'"'b'`);
+    });
+
+    it('quotes all command arguments', () => {
+        expect(buildShellCommand(['nango', 'dryrun', 'sync; rm -rf /'])).toBe(`'nango' 'dryrun' 'sync; rm -rf /'`);
+    });
+});

--- a/packages/server/package.json
+++ b/packages/server/package.json
@@ -45,6 +45,7 @@
         "cors": "2.8.5",
         "dd-trace": "5.52.0",
         "dotenv": "16.5.0",
+        "e2b": "2.18.0",
         "exponential-backoff": "3.1.1",
         "express": "5.1.0",
         "express-session": "1.18.2",

--- a/packages/shared/lib/seeders/plan.seeder.ts
+++ b/packages/shared/lib/seeders/plan.seeder.ts
@@ -36,6 +36,7 @@ export function getTestPlan(override?: Partial<DBPlan>): DBPlan {
         can_override_docs_connect_url: false,
         can_customize_connect_ui_theme: false,
         can_disable_connect_ui_watermark: false,
+        remote_functions: false,
         created_at: new Date(),
         updated_at: new Date(),
         sync_function_runtime: 'runner',

--- a/packages/shared/lib/services/plans/definitions.ts
+++ b/packages/shared/lib/services/plans/definitions.ts
@@ -28,6 +28,7 @@ export const freePlan: PlanDefinition = {
         can_override_docs_connect_url: false,
         can_customize_connect_ui_theme: false,
         can_disable_connect_ui_watermark: false,
+        remote_functions: false,
         sync_function_runtime: 'lambda',
         action_function_runtime: 'lambda',
         webhook_function_runtime: 'lambda',
@@ -68,7 +69,8 @@ export const starterV1Plan: PlanDefinition = {
         has_webhooks_forward: false,
         can_override_docs_connect_url: false,
         can_customize_connect_ui_theme: false,
-        can_disable_connect_ui_watermark: false
+        can_disable_connect_ui_watermark: false,
+        remote_functions: false
     }
 };
 
@@ -106,7 +108,8 @@ export const growthV1Plan: PlanDefinition = {
         has_webhooks_forward: true,
         can_override_docs_connect_url: false,
         can_customize_connect_ui_theme: true,
-        can_disable_connect_ui_watermark: true
+        can_disable_connect_ui_watermark: true,
+        remote_functions: false
     }
 };
 
@@ -171,7 +174,8 @@ export const enterprisePlan: PlanDefinition = {
         has_webhooks_forward: true,
         can_override_docs_connect_url: false,
         can_customize_connect_ui_theme: true,
-        can_disable_connect_ui_watermark: true
+        can_disable_connect_ui_watermark: true,
+        remote_functions: false
     }
 };
 
@@ -209,7 +213,8 @@ export const starterLegacyPlan: PlanDefinition = {
         has_webhooks_forward: true,
         can_override_docs_connect_url: false,
         can_customize_connect_ui_theme: false,
-        can_disable_connect_ui_watermark: false
+        can_disable_connect_ui_watermark: false,
+        remote_functions: false
     }
 };
 
@@ -246,7 +251,8 @@ export const scaleLegacyPlan: PlanDefinition = {
         has_webhooks_forward: true,
         can_override_docs_connect_url: false,
         can_customize_connect_ui_theme: false,
-        can_disable_connect_ui_watermark: false
+        can_disable_connect_ui_watermark: false,
+        remote_functions: false
     }
 };
 
@@ -283,7 +289,8 @@ export const growthLegacyPlan: PlanDefinition = {
         has_webhooks_forward: true,
         can_override_docs_connect_url: false,
         can_customize_connect_ui_theme: true,
-        can_disable_connect_ui_watermark: true
+        can_disable_connect_ui_watermark: true,
+        remote_functions: false
     }
 };
 

--- a/packages/shared/lib/services/plans/plans.ts
+++ b/packages/shared/lib/services/plans/plans.ts
@@ -228,7 +228,8 @@ export function mergeFlags({ currentPlan, newPlanDefinition }: { currentPlan: DB
             case 'has_webhooks_forward':
             case 'can_disable_connect_ui_watermark':
             case 'can_override_docs_connect_url':
-            case 'can_customize_connect_ui_theme': {
+            case 'can_customize_connect_ui_theme':
+            case 'remote_functions': {
                 overrides[key] = currentPlan[key] ? true : newPlanDefinition.flags[key];
                 break;
             }

--- a/packages/shared/lib/services/plans/plans.unit.test.ts
+++ b/packages/shared/lib/services/plans/plans.unit.test.ts
@@ -106,6 +106,7 @@ function makePlan({ code, flagOverrides }: { code: DBPlan['name']; flagOverrides
         can_customize_connect_ui_theme: false,
         can_override_docs_connect_url: false,
         can_disable_connect_ui_watermark: false,
+        remote_functions: false,
         environments_max: 2,
         connections_max: null,
         records_max: null,

--- a/packages/types/lib/api.endpoints.ts
+++ b/packages/types/lib/api.endpoints.ts
@@ -50,6 +50,7 @@ import type { DeleteEnvironment, GetEnvironment, GetEnvironments, PatchEnvironme
 import type { PatchWebhook } from './environment/api/webhook.js';
 import type { PostEnvironmentVariables } from './environment/variable/api.js';
 import type { PatchFlowDisable, PatchFlowEnable, PatchFlowFrequency, PostPreBuiltDeploy, PutUpgradePreBuiltFlow } from './flow/http.api.js';
+import type { PostRemoteFunctionCompile, PostRemoteFunctionDeploy, PostRemoteFunctionDryrun } from './functions/api.js';
 import type { GetGettingStarted, PatchGettingStarted } from './gettingStarted/api.js';
 import type {
     DeleteIntegration,
@@ -127,6 +128,9 @@ export type PublicApiEndpoints =
     | GetPublicSyncStatus
     | GetPublicV1
     | PostPublicTriggerAction
+    | PostRemoteFunctionCompile
+    | PostRemoteFunctionDryrun
+    | PostRemoteFunctionDeploy
     | AllPublicProxy;
 
 export type PrivateApiEndpoints =

--- a/packages/types/lib/functions/api.ts
+++ b/packages/types/lib/functions/api.ts
@@ -1,0 +1,90 @@
+import type { ApiError, Endpoint } from '../api.js';
+
+export type FunctionType = 'action' | 'sync';
+
+export type FunctionErrorCode =
+    | 'invalid_request'
+    | 'integration_not_found'
+    | 'compilation_error'
+    | 'dryrun_error'
+    | 'deployment_error'
+    | 'connection_not_found'
+    | 'function_disabled'
+    | 'timeout'
+    | 'validation_error';
+
+export interface ProxyCall {
+    method: string;
+    endpoint: string;
+    status: number;
+    request: {
+        params?: Record<string, unknown>;
+        headers?: Record<string, unknown>;
+        data?: unknown;
+    };
+    response: unknown;
+    headers: Record<string, unknown>;
+}
+
+export type PostRemoteFunctionCompile = Endpoint<{
+    Method: 'POST';
+    Path: '/remote-function/compile';
+    Body: {
+        integration_id: string;
+        function_name: string;
+        function_type: FunctionType;
+        code: string;
+    };
+    Error: ApiError<FunctionErrorCode>;
+    Success: {
+        integration_id: string;
+        function_name: string;
+        function_type: FunctionType;
+        bundle_size_bytes: number;
+        bundled_js: string;
+        compiled_at: string;
+    };
+}>;
+
+export type PostRemoteFunctionDryrun = Endpoint<{
+    Method: 'POST';
+    Path: '/remote-function/dryrun';
+    Body: {
+        integration_id: string;
+        function_name: string;
+        function_type: FunctionType;
+        code: string;
+        connection_id: string;
+        input?: unknown;
+        metadata?: Record<string, unknown> | undefined;
+        checkpoint?: Record<string, unknown> | undefined;
+        last_sync_date?: string | undefined;
+    };
+    Error: ApiError<FunctionErrorCode>;
+    Success: {
+        integration_id: string;
+        function_name: string;
+        function_type: FunctionType;
+        execution_timeout_at: string;
+        duration_ms: number;
+        output: string;
+    };
+}>;
+
+export type PostRemoteFunctionDeploy = Endpoint<{
+    Method: 'POST';
+    Path: '/remote-function/deploy';
+    Body: {
+        integration_id: string;
+        function_name: string;
+        function_type: FunctionType;
+        code: string;
+    };
+    Error: ApiError<FunctionErrorCode>;
+    Success: {
+        integration_id: string;
+        function_name: string;
+        function_type: FunctionType;
+        output: string;
+    };
+}>;

--- a/packages/types/lib/index.ts
+++ b/packages/types/lib/index.ts
@@ -95,6 +95,7 @@ export type * from './checkpoint/types.js';
 export type * from './checkpoint/db.js';
 
 export type * from './mcp/api.js';
+export type * from './functions/api.js';
 
 export type * from './lambda/index.js';
 export type * from './authz/types.js';

--- a/packages/types/lib/plans/db.ts
+++ b/packages/types/lib/plans/db.ts
@@ -145,6 +145,12 @@ export interface DBPlan extends Timestamps {
     can_disable_connect_ui_watermark: boolean;
 
     /**
+     * Enable or disable remote function compile, dry-run, and deploy endpoints
+     * @default false
+     */
+    remote_functions: boolean;
+
+    /**
      * Sync Function Runtime
      * @default "runner"
      */

--- a/packages/utils/lib/environment/parse.ts
+++ b/packages/utils/lib/environment/parse.ts
@@ -534,6 +534,10 @@ export const ENVS = z.object({
     NANGO_WEBHOOK_CIRCUIT_BREAKER_COOLDOWN_DURATION_SECS: z.coerce.number().optional().default(60),
     NANGO_WEBHOOK_CIRCUIT_BREAKER_AUTO_RESET_SECS: z.coerce.number().optional().default(3600),
 
+    // E2B sandboxes
+    E2B_API_KEY: z.string().optional(),
+    E2B_SANDBOX_COMPILER_TEMPLATE: z.string().min(1).default('blank-workspace:staging'),
+
     // ----- Others
     SERVER_RUN_MODE: z.enum(['DOCKERIZED', '']).optional(),
     NANGO_CLOUD: z.stringbool().optional().default(false),

--- a/packages/utils/lib/environment/parse.unit.test.ts
+++ b/packages/utils/lib/environment/parse.unit.test.ts
@@ -19,6 +19,11 @@ describe('parse', () => {
         expect(res).toMatchObject({ NANGO_DB_SSL: false, NANGO_PERSIST_PORT: 3007 });
     });
 
+    it('should parse the sandbox compiler template', () => {
+        const res = parseEnvs(ENVS, { E2B_SANDBOX_COMPILER_TEMPLATE: 'blank-workspace:dev' });
+        expect(res.E2B_SANDBOX_COMPILER_TEMPLATE).toBe('blank-workspace:dev');
+    });
+
     it('should coerce boolean and number', () => {
         const res = parseEnvs(ENVS, { NANGO_DB_SSL: 'true', NANGO_LOGS_ENABLED: 'false', NANGO_PERSIST_PORT: '3008' });
         expect(res).toMatchObject({ NANGO_DB_SSL: true, NANGO_PERSIST_PORT: 3008, NANGO_LOGS_ENABLED: false, NANGO_CLOUD: false, NANGO_CACHE_ENV_KEYS: false });


### PR DESCRIPTION
<!-- Describe the problem and your solution -->
Adds public /remote-function/compile, /remote-function/dryrun, and /remote-function/deploy endpoints with request validation, endpoint types, and E2B/local runtime clients for running Nango function code.
This intentionally keeps the broader agent-session/internal sandbox prompting APIs and UI work out of this PR.

<!-- Issue ticket number and link (if applicable) -->
N/A

<!-- Testing instructions (skip if just adding/editing providers) -->
- npm run ts-build
- npm run test:unit -- packages/server/lib/services/remote-function/compiler-client.unit.test.ts packages/server/lib/services/remote-function/shell.unit.test.ts
- npm run test:integration -- packages/server/lib/controllers/functions/remote-function.integration.test.ts