### PR TITLE
feat(server): add internal agent sandbox API

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -110,12 +110,24 @@ NANGO_PUBLIC_CONNECT_URL=http://localhost:3009
 NANGO_CONNECT_UI_PORT=3009
 FLAG_SERVE_CONNECT_UI=true
 
+# ---- Agent and remote function sandboxes
+AGENT_RUNTIME=local
+# OPENCODE_API_KEY=<opencode key>
+
+# E2B staging
+# AGENT_RUNTIME=e2b
+# E2B_SANDBOX_AGENT_TEMPLATE=agent-workspace:staging
+# E2B_SANDBOX_COMPILER_TEMPLATE=blank-workspace:staging
+# E2B_API_KEY=<e2b key>
+
+# E2B production
+# AGENT_RUNTIME=e2b
+# E2B_SANDBOX_AGENT_TEMPLATE=agent-workspace:production
+# E2B_SANDBOX_COMPILER_TEMPLATE=blank-workspace:production
+# E2B_API_KEY=<e2b key>
+
 # ---- Role-based authorization (optional)
 # FLAG_AUTH_ROLES_ENABLED=false
-
-# ---- E2B sandboxes for remote functions
-# E2B_API_KEY=<E2B-API-KEY>
-# E2B_SANDBOX_COMPILER_TEMPLATE=blank-workspace:staging
 
 # ---- AWS
 # AWS_ACCESS_KEY_ID=<ACCESS-KEY-ID>

--- a/README.md
+++ b/README.md
@@ -109,6 +109,18 @@ console.log(connection.credentials);
 
 Embed the [Auth](https://nango.dev/docs/implementation-guides/platform/auth/implement-api-auth) flow in your product, make requests with the [Proxy](https://nango.dev/docs/guides/primitives/proxy), or build custom integrations with [Functions](https://nango.dev/docs/guides/primitives/functions).
 
+## Local sandbox quickstart
+
+```bash
+export AGENT_RUNTIME=local
+
+# Build the local sandbox images in https://github.com/NangoHQ/agent-sandboxes
+npm run docker:build:agent
+npm run docker:build:blank
+```
+
+Start Nango normally after that. Agent sessions, compile, and dryrun will spawn local Docker sandboxes on demand.
+
 ## Why Nango?
 
 **AI-generated, human-controlled code.**

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -39,6 +39,11 @@ services:
             - NANGO_DASHBOARD_USERNAME
             - NANGO_DASHBOARD_PASSWORD
             - LOG_LEVEL=${LOG_LEVEL:-info}
+            - AGENT_RUNTIME=${AGENT_RUNTIME:-local}
+            - E2B_API_KEY
+            - E2B_SANDBOX_AGENT_TEMPLATE
+            - E2B_SANDBOX_COMPILER_TEMPLATE
+            - OPENCODE_API_KEY
             - NANGO_SERVER_WEBSOCKETS_PATH
             - NANGO_LOGS_ENABLED=${NANGO_LOGS_ENABLED:-false}
             - NANGO_LOGS_ES_URL=${NANGO_LOGS_ES_URL:-http://nango-elasticsearch:9200}

--- a/package-lock.json
+++ b/package-lock.json
@@ -5081,6 +5081,15 @@
                 "node": ">= 8"
             }
         },
+        "node_modules/@opencode-ai/sdk": {
+            "version": "1.4.3",
+            "resolved": "https://registry.npmjs.org/@opencode-ai/sdk/-/sdk-1.4.3.tgz",
+            "integrity": "sha512-X0CAVbwoGAjTY2iecpWkx2B+GAa2jSaQKYpJ+xILopeF/OGKZUN15mjqci+L7cEuwLHV5wk3x2TStUOVCa5p0A==",
+            "license": "MIT",
+            "dependencies": {
+                "cross-spawn": "7.0.6"
+            }
+        },
         "node_modules/@openfeature/core": {
             "version": "1.9.1",
             "resolved": "https://registry.npmjs.org/@openfeature/core/-/core-1.9.1.tgz",
@@ -35179,6 +35188,7 @@
                 "@nangohq/usage": "file:../usage",
                 "@nangohq/utils": "file:../utils",
                 "@nangohq/webhooks": "file:../webhooks",
+                "@opencode-ai/sdk": "^1.3.13",
                 "@workos-inc/node": "6.2.0",
                 "axios": "1.13.5",
                 "body-parser": "2.2.1",

--- a/packages/server/lib/controllers/v1/agent/session/sessionToken/getEvents.ts
+++ b/packages/server/lib/controllers/v1/agent/session/sessionToken/getEvents.ts
@@ -1,0 +1,66 @@
+import { z } from 'zod';
+
+import { requireEmptyQuery, zodErrorToHTTP } from '@nangohq/utils';
+
+import { getSessionByToken, subscribeToSession } from '../../../../../services/agent/agent-session.service.js';
+import { asyncWrapper } from '../../../../../utils/asyncWrapper.js';
+
+import type { GetAgentSessionEvents } from '@nangohq/types';
+
+const paramsSchema = z
+    .object({
+        sessionToken: z.string().min(1)
+    })
+    .strict();
+
+const heartbeatIntervalMs = 15_000;
+
+export const getAgentSessionEvents = asyncWrapper<GetAgentSessionEvents>(async (req, res) => {
+    const emptyQuery = requireEmptyQuery(req);
+    if (emptyQuery) {
+        res.status(400).send({ error: { code: 'invalid_query_params', errors: zodErrorToHTTP(emptyQuery.error) } });
+        return;
+    }
+
+    const valParams = paramsSchema.safeParse(req.params);
+    if (!valParams.success) {
+        res.status(400).send({ error: { code: 'invalid_uri_params', errors: zodErrorToHTTP(valParams.error) } });
+        return;
+    }
+
+    const { sessionToken } = valParams.data;
+    const { environment } = res.locals;
+
+    const session = await getSessionByToken(sessionToken, environment.id);
+    if (!session) {
+        res.status(404).send({ error: { code: 'not_found', message: 'Session not found or access denied' } });
+        return;
+    }
+
+    res.setHeader('Content-Type', 'text/event-stream');
+    res.setHeader('Cache-Control', 'no-cache');
+    res.setHeader('Connection', 'keep-alive');
+    res.flushHeaders();
+
+    const write = (event: string, data: unknown): void => {
+        res.write(`event: ${event}\ndata: ${JSON.stringify(data)}\n\n`);
+    };
+
+    const { backlog, unsubscribe } = subscribeToSession(session, (browserEvent) => {
+        write(browserEvent.event, browserEvent.data);
+    });
+
+    // Flush backlog to catch up any missed events
+    for (const e of backlog) {
+        write(e.event, e.data);
+    }
+
+    const heartbeat = setInterval(() => {
+        res.write(': heartbeat\n\n');
+    }, heartbeatIntervalMs);
+
+    req.on('close', () => {
+        clearInterval(heartbeat);
+        unsubscribe();
+    });
+});

--- a/packages/server/lib/controllers/v1/agent/session/sessionToken/postAnswer.ts
+++ b/packages/server/lib/controllers/v1/agent/session/sessionToken/postAnswer.ts
@@ -1,0 +1,64 @@
+import { z } from 'zod';
+
+import { requireEmptyQuery, zodErrorToHTTP } from '@nangohq/utils';
+
+import { answerSession, getSessionByToken } from '../../../../../services/agent/agent-session.service.js';
+import { asyncWrapper } from '../../../../../utils/asyncWrapper.js';
+
+import type { PostAgentSessionAnswer } from '@nangohq/types';
+
+const paramsSchema = z
+    .object({
+        sessionToken: z.string().min(1)
+    })
+    .strict();
+
+const bodySchema = z
+    .object({
+        question_id: z.string().min(1),
+        response: z.string().min(1)
+    })
+    .strict();
+
+export const postAgentSessionAnswer = asyncWrapper<PostAgentSessionAnswer>(async (req, res) => {
+    const emptyQuery = requireEmptyQuery(req);
+    if (emptyQuery) {
+        res.status(400).send({ error: { code: 'invalid_query_params', errors: zodErrorToHTTP(emptyQuery.error) } });
+        return;
+    }
+
+    const valParams = paramsSchema.safeParse(req.params);
+    if (!valParams.success) {
+        res.status(400).send({ error: { code: 'invalid_uri_params', errors: zodErrorToHTTP(valParams.error) } });
+        return;
+    }
+
+    const valBody = bodySchema.safeParse(req.body);
+    if (!valBody.success) {
+        res.status(400).send({ error: { code: 'invalid_body', errors: zodErrorToHTTP(valBody.error) } });
+        return;
+    }
+
+    const { sessionToken } = valParams.data;
+    const body = valBody.data;
+    const { environment } = res.locals;
+
+    const session = await getSessionByToken(sessionToken, environment.id);
+    if (!session) {
+        res.status(404).send({ error: { code: 'not_found', message: 'Session not found or access denied' } });
+        return;
+    }
+
+    try {
+        await answerSession(session, body);
+    } catch (err) {
+        const message = err instanceof Error ? err.message : String(err);
+        res.status(400).send({ error: { code: 'invalid_request', message } });
+        return;
+    }
+
+    res.status(200).send({
+        success: true,
+        accepted_at: new Date().toISOString()
+    });
+});

--- a/packages/server/lib/controllers/v1/agent/session/start/postStart.ts
+++ b/packages/server/lib/controllers/v1/agent/session/start/postStart.ts
@@ -1,0 +1,54 @@
+import { z } from 'zod';
+
+import { configService } from '@nangohq/shared';
+import { requireEmptyQuery, zodErrorToHTTP } from '@nangohq/utils';
+
+import { connectionIdSchema, providerConfigKeySchema } from '../../../../../helpers/validation.js';
+import { createAgentSession } from '../../../../../services/agent/agent-session.service.js';
+import { asyncWrapper } from '../../../../../utils/asyncWrapper.js';
+
+import type { PostAgentSessionStart } from '@nangohq/types';
+
+const bodySchema = z
+    .object({
+        prompt: z.string().min(1),
+        integration_id: providerConfigKeySchema.refine((value) => value !== '.' && value !== '..', {
+            message: 'Integration id cannot be "." or ".."'
+        }),
+        connection_id: connectionIdSchema.optional()
+    })
+    .strict();
+
+export const postAgentSessionStart = asyncWrapper<PostAgentSessionStart>(async (req, res) => {
+    const emptyQuery = requireEmptyQuery(req);
+    if (emptyQuery) {
+        res.status(400).send({ error: { code: 'invalid_query_params', errors: zodErrorToHTTP(emptyQuery.error) } });
+        return;
+    }
+
+    const valBody = bodySchema.safeParse(req.body);
+    if (!valBody.success) {
+        res.status(400).send({ error: { code: 'invalid_body', errors: zodErrorToHTTP(valBody.error) } });
+        return;
+    }
+
+    const body = valBody.data;
+    const { environment } = res.locals;
+
+    const providerConfig = await configService.getProviderConfig(body.integration_id, environment.id);
+    if (!providerConfig) {
+        res.status(404).send({ error: { code: 'not_found', message: `Integration '${body.integration_id}' was not found` } });
+        return;
+    }
+
+    const { token, executionTimeoutAt } = await createAgentSession(environment.id, {
+        prompt: body.prompt,
+        integration_id: body.integration_id,
+        ...(body.connection_id ? { connection_id: body.connection_id } : {})
+    });
+
+    res.status(201).send({
+        session_token: token,
+        execution_timeout_at: executionTimeoutAt.toISOString()
+    });
+});

--- a/packages/server/lib/routes.private.ts
+++ b/packages/server/lib/routes.private.ts
@@ -29,6 +29,9 @@ import { postForgotPassword } from './controllers/v1/account/postForgotPassword.
 import { postLogout } from './controllers/v1/account/postLogout.js';
 import { putResetPassword } from './controllers/v1/account/putResetPassword.js';
 import { postImpersonate } from './controllers/v1/admin/impersonate/postImpersonate.js';
+import { getAgentSessionEvents } from './controllers/v1/agent/session/sessionToken/getEvents.js';
+import { postAgentSessionAnswer } from './controllers/v1/agent/session/sessionToken/postAnswer.js';
+import { postAgentSessionStart } from './controllers/v1/agent/session/start/postStart.js';
 import { postInternalConnectSessions } from './controllers/v1/connect/sessions/postConnectSessions.js';
 import { getConnectUISettings } from './controllers/v1/connectUISettings/getConnectUISettings.js';
 import { putConnectUISettings } from './controllers/v1/connectUISettings/putConnectUISettings.js';
@@ -281,6 +284,11 @@ if (flagHasUsage) {
 }
 
 web.route('/admin/impersonate').post(webAuth, postImpersonate);
+
+// Agent Builder
+web.route('/agent/session/start').post(webAuth, can({ action: 'update', resource: 'integration', scopedBy: envScope }), postAgentSessionStart);
+web.route('/agent/session/:sessionToken/events').get(webAuth, can({ action: 'update', resource: 'integration', scopedBy: envScope }), getAgentSessionEvents);
+web.route('/agent/session/:sessionToken/answer').post(webAuth, can({ action: 'update', resource: 'integration', scopedBy: envScope }), postAgentSessionAnswer);
 
 // Hosted signin
 if (!isCloud && !isEnterprise) {

--- a/packages/server/lib/services/agent/agent-runtime.ts
+++ b/packages/server/lib/services/agent/agent-runtime.ts
@@ -1,0 +1,66 @@
+import type { OpencodeClient } from '@opencode-ai/sdk/v2';
+
+export const agentProjectPath = '/home/user/nango-integrations';
+
+export const AGENT_MODEL = { providerID: 'opencode', modelID: 'kimi-k2.5', full: 'opencode/kimi-k2.5' } as const;
+
+export interface AgentSessionPayload {
+    prompt: string;
+    integration_id: string;
+    connection_id?: string;
+}
+
+export interface AgentSessionResolvedPayload extends AgentSessionPayload {
+    nango_base_url: string;
+}
+
+export function resolvePayload(payload: AgentSessionPayload): AgentSessionResolvedPayload {
+    const serverUrl = process.env['NANGO_SERVER_URL'];
+    return {
+        ...payload,
+        nango_base_url: serverUrl ?? 'https://api.nango.dev'
+    };
+}
+
+export interface AgentRuntimeHandle {
+    client: OpencodeClient;
+    baseUrl: string;
+    accessToken: string | undefined;
+    sandboxId: string;
+    serverPid: number;
+    resolvedPayload: AgentSessionResolvedPayload;
+    /** E2B: extend sandbox lifetime. Omitted for local Docker. */
+    refreshTimeout?: (timeoutMs: number) => Promise<void>;
+    destroy(): Promise<void>;
+}
+
+export function createRuntimeConfig(): Record<string, unknown> {
+    const apiKey = process.env['OPENCODE_API_KEY'];
+    return {
+        model: AGENT_MODEL.full,
+        small_model: AGENT_MODEL.full,
+        enabled_providers: [AGENT_MODEL.providerID],
+        permission: {
+            '*': 'allow',
+            external_directory: { '/**': 'allow' }
+        },
+        ...(apiKey ? { provider: { [AGENT_MODEL.providerID]: { options: { apiKey } } } } : {})
+    };
+}
+
+export function createAgentPrompt(payload: AgentSessionResolvedPayload): string {
+    const { prompt, integration_id, connection_id, nango_base_url } = payload;
+    const context: Record<string, unknown> = { integration_id, nango_base_url };
+    if (connection_id) {
+        context['connection_id'] = connection_id;
+    }
+    return `${prompt}\n\nYou are working inside a prepared Nango project at ${agentProjectPath}. Use the installed skill named nango-remote-function-builder from .agents/skills when relevant.\n\nContext:\n${JSON.stringify(context, null, 2)}`;
+}
+
+export function createAnswerPrompt(answer: string): string {
+    return `User response: ${answer}\n\nContinue from the current session state.`;
+}
+
+export function createSessionTitle(payload: AgentSessionResolvedPayload): string {
+    return `Build ${payload.integration_id}`;
+}

--- a/packages/server/lib/services/agent/agent-runtime.unit.test.ts
+++ b/packages/server/lib/services/agent/agent-runtime.unit.test.ts
@@ -1,0 +1,105 @@
+import { afterEach, describe, expect, it, vi } from 'vitest';
+
+import {
+    AGENT_MODEL,
+    agentProjectPath,
+    createAgentPrompt,
+    createAnswerPrompt,
+    createRuntimeConfig,
+    createSessionTitle,
+    resolvePayload
+} from './agent-runtime.js';
+
+describe('agent runtime helpers', () => {
+    afterEach(() => {
+        vi.unstubAllEnvs();
+    });
+
+    it('resolves payloads with the production API base URL by default', () => {
+        expect(
+            resolvePayload({
+                prompt: 'Build a sync',
+                integration_id: 'github'
+            })
+        ).toStrictEqual({
+            prompt: 'Build a sync',
+            integration_id: 'github',
+            nango_base_url: 'https://api.nango.dev'
+        });
+    });
+
+    it('resolves payloads with NANGO_SERVER_URL when configured', () => {
+        vi.stubEnv('NANGO_SERVER_URL', 'http://localhost:3003');
+
+        expect(
+            resolvePayload({
+                prompt: 'Build an action',
+                integration_id: 'github',
+                connection_id: 'conn_1'
+            })
+        ).toStrictEqual({
+            prompt: 'Build an action',
+            integration_id: 'github',
+            connection_id: 'conn_1',
+            nango_base_url: 'http://localhost:3003'
+        });
+    });
+
+    it('builds OpenCode runtime config without provider credentials by default', () => {
+        expect(createRuntimeConfig()).toStrictEqual({
+            model: AGENT_MODEL.full,
+            small_model: AGENT_MODEL.full,
+            enabled_providers: [AGENT_MODEL.providerID],
+            permission: {
+                '*': 'allow',
+                external_directory: { '/**': 'allow' }
+            }
+        });
+    });
+
+    it('injects OpenCode API credentials when configured', () => {
+        vi.stubEnv('OPENCODE_API_KEY', 'sk-test');
+
+        expect(createRuntimeConfig()).toStrictEqual({
+            model: AGENT_MODEL.full,
+            small_model: AGENT_MODEL.full,
+            enabled_providers: [AGENT_MODEL.providerID],
+            permission: {
+                '*': 'allow',
+                external_directory: { '/**': 'allow' }
+            },
+            provider: {
+                [AGENT_MODEL.providerID]: {
+                    options: { apiKey: 'sk-test' }
+                }
+            }
+        });
+    });
+
+    it('builds the initial agent prompt with workspace and task context', () => {
+        const prompt = createAgentPrompt({
+            prompt: 'Build a GitHub issue sync',
+            integration_id: 'github',
+            connection_id: 'conn_1',
+            nango_base_url: 'http://localhost:3003'
+        });
+
+        expect(prompt).toContain('Build a GitHub issue sync');
+        expect(prompt).toContain(agentProjectPath);
+        expect(prompt).toContain('nango-remote-function-builder');
+        expect(prompt).toContain('"integration_id": "github"');
+        expect(prompt).toContain('"connection_id": "conn_1"');
+        expect(prompt).toContain('"nango_base_url": "http://localhost:3003"');
+    });
+
+    it('builds answer prompts and session titles', () => {
+        expect(createAnswerPrompt('Use the REST API')).toBe('User response: Use the REST API\n\nContinue from the current session state.');
+        expect(
+            createSessionTitle({
+                prompt: 'Build it',
+                integration_id: 'github',
+                nango_base_url: 'https://api.nango.dev'
+            })
+        ).toBe('Build github');
+    });
+});

--- a/packages/server/lib/services/agent/agent-session.service.ts
+++ b/packages/server/lib/services/agent/agent-session.service.ts
@@ -1,0 +1,477 @@
+import { randomBytes, randomUUID } from 'node:crypto';
+import { EventEmitter } from 'node:events';
+
+import { getKVStore } from '@nangohq/kvstore';
+import { getLogger } from '@nangohq/utils';
+
+import { AGENT_MODEL, createAgentPrompt, createAnswerPrompt, createSessionTitle } from './agent-runtime.js';
+import { agentSandboxTimeoutMs, createAgentSandbox, refreshAgentSandboxTimeout, shouldRefreshAgentSandboxTimeout } from '../e2b/agent-sandbox.service.js';
+import { createLocalAgentSandbox } from '../local/agent-sandbox.service.js';
+
+import type { AgentRuntimeHandle, AgentSessionPayload } from './agent-runtime.js';
+import type { GlobalEvent, Message, PermissionRequest, QuestionRequest } from '@opencode-ai/sdk/v2';
+
+const logger = getLogger('agent-session-service');
+
+const sessionTtlMs = 30 * 60 * 1000; // 30 min per spec
+const idleSessionCleanupDelayMs = 5 * 60 * 1000;
+const errorSessionCleanupDelayMs = 15_000;
+
+function sessionKey(token: string): string {
+    return `agent:session:${token}`;
+}
+
+function generateSessionToken(): string {
+    return `agt_${randomBytes(32).toString('hex')}`;
+}
+
+interface AgentBrowserEvent {
+    id: number;
+    event: string;
+    data: Record<string, unknown>;
+}
+
+interface AgentSessionRecord {
+    sid: string;
+    token: string;
+    environmentId: number;
+    sandbox: AgentRuntimeHandle | null;
+    opencodeSessionId: string | null;
+    emitter: EventEmitter;
+    backlog: AgentBrowserEvent[];
+    nextEventId: number;
+    pendingPermissions: Map<string, PermissionRequest>;
+    pendingQuestionRequests: Map<string, QuestionRequest>;
+    messageRoles: Map<string, Message['role']>;
+    messageTexts: Map<string, string>;
+    pendingQuestion: { id: string; message: string } | null;
+    cleanupTimer: NodeJS.Timeout | null;
+    lastSandboxRefreshAt: number;
+}
+
+// In-memory store keyed by internal sid
+const sessions = new Map<string, AgentSessionRecord>();
+
+function createSandbox(sessionId: string, payload: AgentSessionPayload, onProgress: (message: string) => void): Promise<AgentRuntimeHandle> {
+    if ((process.env['AGENT_RUNTIME'] || 'local') === 'local') {
+        return createLocalAgentSandbox(sessionId, payload, onProgress);
+    }
+    return createAgentSandbox(sessionId, payload, onProgress);
+}
+
+export interface CreateSessionResult {
+    token: string;
+    executionTimeoutAt: Date;
+}
+
+export async function createAgentSession(environmentId: number, payload: AgentSessionPayload): Promise<CreateSessionResult> {
+    const token = generateSessionToken();
+    const sid = randomUUID();
+
+    // Store token to {sid, environmentId} in Redis with TTL
+    const kv = await getKVStore();
+    await kv.set(sessionKey(token), JSON.stringify({ sid, environmentId }), { ttlMs: sessionTtlMs });
+
+    const record: AgentSessionRecord = {
+        sid,
+        token,
+        environmentId,
+        sandbox: null,
+        opencodeSessionId: null,
+        emitter: new EventEmitter(),
+        backlog: [],
+        nextEventId: 1,
+        pendingPermissions: new Map(),
+        pendingQuestionRequests: new Map(),
+        messageRoles: new Map(),
+        messageTexts: new Map(),
+        pendingQuestion: null,
+        cleanupTimer: null,
+        lastSandboxRefreshAt: 0
+    };
+
+    sessions.set(sid, record);
+    void setupSession(record, payload);
+
+    return {
+        token,
+        executionTimeoutAt: new Date(Date.now() + agentSandboxTimeoutMs)
+    };
+}
+
+/**
+ * Validate a session token and return the session record.
+ * Returns null if the token is not found, expired, or the environment doesn't match.
+ */
+export async function getSessionByToken(token: string, environmentId: number): Promise<AgentSessionRecord | null> {
+    const kv = await getKVStore();
+    const raw = await kv.get(sessionKey(token));
+    if (!raw) {
+        return null;
+    }
+
+    let entry: { sid: string; environmentId: number };
+    try {
+        entry = JSON.parse(raw) as { sid: string; environmentId: number };
+    } catch {
+        return null;
+    }
+
+    if (entry.environmentId !== environmentId) {
+        return null;
+    }
+
+    const record = sessions.get(entry.sid) || null;
+
+    // Refresh TTL on activity
+    if (record) {
+        await kv.set(sessionKey(token), raw, { ttlMs: sessionTtlMs });
+    }
+
+    return record;
+}
+
+export function subscribeToSession(
+    record: AgentSessionRecord,
+    listener: (event: AgentBrowserEvent) => void
+): { backlog: AgentBrowserEvent[]; unsubscribe: () => void } {
+    record.emitter.on('event', listener);
+    return {
+        backlog: [...record.backlog],
+        unsubscribe: () => record.emitter.off('event', listener)
+    };
+}
+
+export async function answerSession(
+    record: AgentSessionRecord,
+    answer: { question_id: string; response: string }
+): Promise<{ ok: true; kind: 'message' | 'permission' }> {
+    if (!record.sandbox || !record.opencodeSessionId) {
+        throw new Error('Agent session is still initializing');
+    }
+
+    const { question_id, response } = answer;
+
+    // Permission decision
+    const permissionId = resolvePermissionId(record, question_id);
+    if (permissionId) {
+        const reply = response as 'once' | 'always' | 'reject';
+        await record.sandbox.client.permission.reply({ requestID: permissionId, reply });
+        record.pendingPermissions.delete(permissionId);
+        emit(record, 'agent.permission.submitted', { sid: record.sid, permissionId, response });
+        return { ok: true, kind: 'permission' };
+    }
+
+    // Question answer (v2: client.question.reply / reject)
+    const questionReq = record.pendingQuestionRequests.get(question_id);
+    if (questionReq) {
+        record.pendingQuestionRequests.delete(question_id);
+        record.pendingQuestion = null;
+        clearCleanup(record);
+        touchSandbox(record, true);
+
+        if (response === 'reject') {
+            await record.sandbox.client.question.reject({ requestID: question_id });
+        } else {
+            if (!response.trim()) {
+                throw new Error('Response cannot be empty');
+            }
+            // answers is Array<QuestionAnswer>, one per QuestionInfo in the request
+            const answers = questionReq.questions.map(() => [response.trim()]);
+            await record.sandbox.client.question.reply({ requestID: question_id, answers });
+        }
+        emit(record, 'agent.answer.accepted', { sid: record.sid });
+        return { ok: true, kind: 'message' };
+    }
+
+    // Fallback: free-form message to session (no pending question or permission matched)
+    if (!response.trim()) {
+        throw new Error('Response cannot be empty');
+    }
+
+    record.pendingQuestion = null;
+    clearCleanup(record);
+    touchSandbox(record, true);
+
+    await record.sandbox.client.session.promptAsync({
+        sessionID: record.opencodeSessionId,
+        model: { providerID: AGENT_MODEL.providerID, modelID: AGENT_MODEL.modelID },
+        parts: [{ type: 'text', text: createAnswerPrompt(response.trim()) }]
+    });
+    emit(record, 'agent.answer.accepted', { sid: record.sid });
+    return { ok: true, kind: 'message' };
+}
+
+// -------
+// Internal session lifecycle
+// -------
+
+async function setupSession(record: AgentSessionRecord, payload: AgentSessionPayload): Promise<void> {
+    const { sid } = record;
+
+    try {
+        emitLifecycle(record, 'workspace.creating', 'Spinning up workspace...');
+
+        const sandbox = await createSandbox(sid, payload, (message) => {
+            emitLifecycle(record, 'workspace.progress', message);
+        });
+
+        record.sandbox = sandbox;
+        record.lastSandboxRefreshAt = Date.now();
+
+        emitLifecycle(record, 'workspace.ready', 'Workspace ready');
+        emitLifecycle(record, 'agent.starting', 'Starting agent...');
+
+        const created = await sandbox.client.session.create({ title: createSessionTitle(sandbox.resolvedPayload) });
+        const session = created.data;
+        if (!session) {
+            throw new Error('OpenCode did not return a session');
+        }
+
+        record.opencodeSessionId = session.id;
+
+        await startEventPump(record);
+
+        emit(record, 'agent.session.started', {
+            sid,
+            sandboxId: sandbox.sandboxId,
+            sessionId: session.id,
+            previewUrl: sandbox.baseUrl
+        });
+
+        emitLifecycle(record, 'agent.ready', 'Agent ready, sending task...');
+
+        await sandbox.client.session.promptAsync({
+            sessionID: session.id,
+            model: { providerID: AGENT_MODEL.providerID, modelID: AGENT_MODEL.modelID },
+            parts: [{ type: 'text', text: createAgentPrompt(sandbox.resolvedPayload) }]
+        });
+
+        emit(record, 'agent.prompt.accepted', { sid, sessionId: session.id });
+    } catch (err) {
+        logger.error('Failed to set up agent session', { sid, error: err });
+        if (record.sandbox) {
+            await record.sandbox.destroy();
+        }
+        emit(record, 'agent.error', {
+            sid,
+            message: err instanceof Error ? err.message : String(err)
+        });
+        sessions.delete(sid);
+    }
+}
+
+async function startEventPump(record: AgentSessionRecord): Promise<void> {
+    if (!record.sandbox) {
+        return;
+    }
+    const subscription = await record.sandbox.client.global.event();
+    void (async () => {
+        try {
+            for await (const event of subscription.stream) {
+                handleOpenCodeEvent(record, event);
+            }
+        } catch (err) {
+            logger.error('OpenCode event stream failed', { sid: record.sid, error: err });
+            emit(record, 'agent.error', {
+                sid: record.sid,
+                message: err instanceof Error ? err.message : String(err)
+            });
+        }
+    })();
+}
+
+function handleOpenCodeEvent(record: AgentSessionRecord, globalEvent: GlobalEvent): void {
+    const event = globalEvent.payload;
+    const sessionId = record.opencodeSessionId;
+    if (!sessionId) {
+        return;
+    }
+
+    touchSandbox(record);
+
+    switch (event.type) {
+        case 'message.part.delta': {
+            const { sessionID, messageID, field, delta } = event.properties;
+            if (sessionID !== sessionId || field !== 'text') {
+                return;
+            }
+            const role = record.messageRoles.get(messageID);
+            if (role && role !== 'assistant') {
+                return;
+            }
+            emit(record, 'agent.delta', { sid: record.sid, sessionId, messageId: messageID, delta });
+            return;
+        }
+        case 'message.part.updated': {
+            const part = event.properties.part;
+            if (part.sessionID !== sessionId || part.type !== 'tool') {
+                return;
+            }
+            emit(record, 'agent.tool.updated', {
+                sid: record.sid,
+                sessionId,
+                messageId: part.messageID,
+                tool: part.tool,
+                state: part.state
+            });
+            return;
+        }
+        case 'message.updated': {
+            const info = event.properties.info;
+            if (info.sessionID !== sessionId) {
+                return;
+            }
+            record.messageRoles.set(info.id, info.role);
+            emit(record, 'agent.message.updated', { sid: record.sid, sessionId, message: info });
+            return;
+        }
+        case 'question.asked': {
+            const req = event.properties;
+            if (req.sessionID !== sessionId) {
+                return;
+            }
+            record.pendingQuestionRequests.set(req.id, req);
+            const firstQuestion = req.questions[0];
+            if (firstQuestion) {
+                record.pendingQuestion = { id: req.id, message: firstQuestion.question };
+                const options = firstQuestion.options?.map((o) => o.label) ?? [];
+                emit(record, 'agent.question', {
+                    sid: record.sid,
+                    sessionId,
+                    questionId: req.id,
+                    message: firstQuestion.question,
+                    ...(options.length > 0 ? { options } : {})
+                });
+                clearCleanup(record);
+            }
+            return;
+        }
+        case 'permission.asked': {
+            const permission = event.properties;
+            if (permission.sessionID !== sessionId) {
+                return;
+            }
+            record.pendingPermissions.set(permission.id, permission);
+            emit(record, 'agent.permission.requested', { sid: record.sid, sessionId, permission });
+            return;
+        }
+        case 'permission.replied': {
+            if (event.properties.sessionID !== sessionId) {
+                return;
+            }
+            record.pendingPermissions.delete(event.properties.requestID);
+            emit(record, 'agent.permission.replied', {
+                sid: record.sid,
+                sessionId,
+                permissionId: event.properties.requestID,
+                response: event.properties.reply
+            });
+            return;
+        }
+        case 'session.status': {
+            if (event.properties.sessionID !== sessionId) {
+                return;
+            }
+            emit(record, 'agent.session.status', { sid: record.sid, sessionId, status: event.properties.status });
+            return;
+        }
+        case 'session.idle': {
+            if (event.properties.sessionID !== sessionId) {
+                return;
+            }
+
+            // If there's already a pending question (from the `question` tool), don't schedule cleanup
+            if (record.pendingQuestion) {
+                return;
+            }
+
+            emit(record, 'agent.session.idle', { sid: record.sid, sessionId });
+            scheduleCleanup(record, 'idle');
+            return;
+        }
+        case 'session.error': {
+            if (event.properties.sessionID && event.properties.sessionID !== sessionId) {
+                return;
+            }
+            emit(record, 'agent.error', { sid: record.sid, sessionId, error: event.properties.error });
+            scheduleCleanup(record, 'error');
+            return;
+        }
+        default:
+            return;
+    }
+}
+
+function emitLifecycle(record: AgentSessionRecord, stage: string, message: string): void {
+    emit(record, 'agent.lifecycle', { sid: record.sid, stage, message });
+}
+
+function emit(record: AgentSessionRecord, event: string, data: Record<string, unknown>): void {
+    const payload: AgentBrowserEvent = { id: record.nextEventId, event, data };
+    record.nextEventId += 1;
+    record.backlog.push(payload);
+    if (record.backlog.length > 200) {
+        record.backlog.shift();
+    }
+    record.emitter.emit('event', payload);
+}
+
+function clearCleanup(record: AgentSessionRecord): void {
+    if (record.cleanupTimer) {
+        clearTimeout(record.cleanupTimer);
+        record.cleanupTimer = null;
+    }
+}
+
+function scheduleCleanup(record: AgentSessionRecord, reason: 'idle' | 'error'): void {
+    if (record.pendingQuestion || record.pendingPermissions.size > 0 || record.cleanupTimer) {
+        return;
+    }
+
+    touchSandbox(record, true);
+
+    record.cleanupTimer = setTimeout(
+        () => {
+            void cleanupSession(record.sid, reason);
+        },
+        reason === 'idle' ? idleSessionCleanupDelayMs : errorSessionCleanupDelayMs
+    );
+}
+
+async function cleanupSession(sid: string, reason: 'idle' | 'error'): Promise<void> {
+    const record = sessions.get(sid);
+    if (!record) {
+        return;
+    }
+
+    clearCleanup(record);
+    sessions.delete(sid);
+
+    if (record.sandbox) {
+        await record.sandbox.destroy();
+        logger.info('Cleaned up agent sandbox', { sid, sandboxId: record.sandbox.sandboxId, reason });
+    }
+}
+
+function touchSandbox(record: AgentSessionRecord, force: boolean = false): void {
+    if (!record.sandbox) {
+        return;
+    }
+    const now = Date.now();
+    if (!force && !shouldRefreshAgentSandboxTimeout(record.lastSandboxRefreshAt, now)) {
+        return;
+    }
+    record.lastSandboxRefreshAt = now;
+    void refreshAgentSandboxTimeout(record.sandbox, agentSandboxTimeoutMs);
+}
+
+function resolvePermissionId(record: AgentSessionRecord, questionId: string): string | null {
+    if (record.pendingPermissions.has(questionId)) {
+        return questionId;
+    }
+    if (record.pendingPermissions.size === 1 && !record.pendingQuestionRequests.has(questionId)) {
+        return [...record.pendingPermissions.keys()][0] as string;
+    }
+    return null;
+}

--- a/packages/server/lib/services/e2b/agent-sandbox.service.ts
+++ b/packages/server/lib/services/e2b/agent-sandbox.service.ts
@@ -1,0 +1,121 @@
+import { createOpencodeClient } from '@opencode-ai/sdk/v2';
+import { Sandbox } from 'e2b';
+
+import { getLogger } from '@nangohq/utils';
+
+import { envs } from '../../env.js';
+import { AGENT_MODEL, agentProjectPath, createAgentPrompt, createRuntimeConfig, resolvePayload } from '../agent/agent-runtime.js';
+
+import type { AgentRuntimeHandle, AgentSessionPayload, AgentSessionResolvedPayload } from '../agent/agent-runtime.js';
+
+export type { AgentRuntimeHandle };
+
+const logger = getLogger('e2b-agent-sandbox');
+
+const opencodePort = 4096;
+export const agentSandboxTimeoutMs = 10 * 60 * 1000; // 10 minutes per spec
+const timeoutRefreshThrottleMs = 60 * 1000;
+const agentTemplate = envs.E2B_SANDBOX_AGENT_TEMPLATE;
+
+export async function createAgentSandbox(sessionId: string, payload: AgentSessionPayload, onProgress?: (message: string) => void): Promise<AgentRuntimeHandle> {
+    const apiKey = envs.E2B_API_KEY;
+    if (!apiKey) {
+        throw new Error('E2B_API_KEY is required for the E2B agent runtime');
+    }
+
+    const resolvedPayload: AgentSessionResolvedPayload = resolvePayload(payload);
+    onProgress?.('Creating sandbox...');
+    const sandbox = await Sandbox.create(agentTemplate, {
+        timeoutMs: agentSandboxTimeoutMs,
+        allowInternetAccess: true,
+        metadata: { purpose: 'nango-agent', sessionId, createdBy: 'nango-server' },
+        network: { allowPublicTraffic: true },
+        apiKey
+    });
+
+    try {
+        // This assumes the template does not auto-start OpenCode; Nango owns config injection and process startup.
+        await sandbox.files.write(`${agentProjectPath}/opencode.json`, JSON.stringify(createRuntimeConfig(), null, 2));
+
+        const accessToken = sandbox.trafficAccessToken;
+        const baseUrl = `https://${sandbox.getHost(opencodePort)}`;
+        onProgress?.('Starting OpenCode server...');
+        const serverHandle = await sandbox.commands.run(`opencode serve --hostname 0.0.0.0 --port ${opencodePort}`, {
+            cwd: agentProjectPath,
+            envs: { OPENCODE_API_KEY: process.env['OPENCODE_API_KEY'] ?? '' },
+            background: true,
+            timeoutMs: 0
+        });
+
+        const client = createOpencodeClient({
+            baseUrl,
+            directory: agentProjectPath,
+            headers: accessToken ? { 'e2b-traffic-access-token': accessToken } : undefined,
+            fetch: async (input, init) => {
+                if (!accessToken) {
+                    return fetch(input, init);
+                }
+                const merged = new Headers(input instanceof Request ? input.headers : init?.headers);
+                merged.set('e2b-traffic-access-token', accessToken);
+                const reqInit = { ...init, headers: merged };
+                return fetch(input instanceof Request ? new Request(input, reqInit) : input, reqInit);
+            }
+        });
+
+        await waitForOpenCodeServer(baseUrl, accessToken, serverHandle);
+
+        return {
+            client,
+            baseUrl,
+            accessToken,
+            sandboxId: sandbox.sandboxId,
+            serverPid: serverHandle.pid,
+            resolvedPayload,
+            refreshTimeout: async (timeoutMs: number) => {
+                await sandbox.setTimeout(timeoutMs).catch((err: unknown) => {
+                    logger.warn('Failed to refresh E2B agent sandbox timeout', { error: err, sandboxId: sandbox.sandboxId, timeoutMs });
+                });
+            },
+            destroy: async () => {
+                await sandbox.kill().catch((err: unknown) => {
+                    logger.warn('Failed to kill E2B agent sandbox', { error: err });
+                });
+            }
+        };
+    } catch (err) {
+        await sandbox.kill().catch((killErr: unknown) => {
+            logger.warn('Failed to kill E2B agent sandbox after startup failure', { error: killErr, sandboxId: sandbox.sandboxId });
+        });
+        throw err;
+    }
+}
+
+export async function refreshAgentSandboxTimeout(handle: AgentRuntimeHandle, timeoutMs: number = agentSandboxTimeoutMs): Promise<void> {
+    await handle.refreshTimeout?.(timeoutMs);
+}
+
+export function shouldRefreshAgentSandboxTimeout(lastRefreshAt: number, now: number = Date.now()): boolean {
+    return now - lastRefreshAt >= timeoutRefreshThrottleMs;
+}
+
+async function waitForOpenCodeServer(baseUrl: string, accessToken: string | undefined, serverHandle: { stdout: string; stderr: string }): Promise<void> {
+    const maxAttempts = 40;
+    for (let attempt = 0; attempt < maxAttempts; attempt += 1) {
+        try {
+            const init = accessToken ? { headers: { 'e2b-traffic-access-token': accessToken } } : {};
+            const response = await fetch(`${baseUrl}/global/health`, init);
+            if (response.ok) {
+                return;
+            }
+        } catch {
+            // retry
+        }
+        await new Promise((resolve) => setTimeout(resolve, 1500));
+    }
+
+    const logs = [serverHandle.stdout, serverHandle.stderr].filter(Boolean).join('\n');
+    throw new Error(`Timed out waiting for OpenCode server to start in E2B sandbox${logs ? `: ${logs}` : ''}`);
+}
+
+// Re-exported for use in session service
+export { AGENT_MODEL, createAgentPrompt };

--- a/packages/server/lib/services/e2b/agent-sandbox.unit.test.ts
+++ b/packages/server/lib/services/e2b/agent-sandbox.unit.test.ts
@@ -1,0 +1,13 @@
+import { describe, expect, it } from 'vitest';
+
+import { shouldRefreshAgentSandboxTimeout } from './agent-sandbox.service.js';
+
+describe('agent sandbox timeout refresh throttle', () => {
+    it('does not refresh before the throttle window elapses', () => {
+        expect(shouldRefreshAgentSandboxTimeout(1_000, 60_999)).toBe(false);
+    });
+
+    it('refreshes once the throttle window elapses', () => {
+        expect(shouldRefreshAgentSandboxTimeout(1_000, 61_000)).toBe(true);
+    });
+});

--- a/packages/server/lib/services/local/agent-sandbox.service.ts
+++ b/packages/server/lib/services/local/agent-sandbox.service.ts
@@ -1,0 +1,131 @@
+import { createServer } from 'node:net';
+
+import { createOpencodeClient } from '@opencode-ai/sdk/v2';
+
+import { getLogger } from '@nangohq/utils';
+
+import { execDockerFileAsync, rewriteDockerHostForLocalhost, writeContainerFile } from './docker.js';
+import { agentProjectPath, createRuntimeConfig, resolvePayload } from '../agent/agent-runtime.js';
+
+import type { AgentRuntimeHandle, AgentSessionPayload, AgentSessionResolvedPayload } from '../agent/agent-runtime.js';
+
+const logger = getLogger('local-agent-sandbox');
+
+const opencodePort = 4096;
+export const localAgentImageName = 'agent-sandboxes/agent-workspace:local';
+
+export async function createLocalAgentSandbox(
+    sessionId: string,
+    payload: AgentSessionPayload,
+    onProgress?: (message: string) => void
+): Promise<AgentRuntimeHandle> {
+    const resolvedPayload: AgentSessionResolvedPayload = rewriteLocalhostUrl(resolvePayload(payload));
+    const hostPort = await findFreePort();
+    const containerName = `nango-agent-${sessionId.slice(0, 8)}`;
+
+    onProgress?.('Starting container...');
+    await execDockerFileAsync(
+        'docker',
+        [
+            'run',
+            '-d',
+            '--name',
+            containerName,
+            '-p',
+            `${hostPort}:${opencodePort}`,
+            '-e',
+            `OPENCODE_API_KEY=${process.env['OPENCODE_API_KEY'] ?? ''}`,
+            '--add-host',
+            'host.docker.internal:host-gateway',
+            localAgentImageName,
+            'sleep',
+            'infinity'
+        ],
+        { timeout: 10_000 }
+    );
+
+    try {
+        await writeContainerFile(containerName, `${agentProjectPath}/opencode.json`, JSON.stringify(createRuntimeConfig(), null, 2));
+
+        onProgress?.('Starting OpenCode server...');
+        await execDockerFileAsync('docker', [
+            'exec',
+            '-d',
+            '-w',
+            agentProjectPath,
+            containerName,
+            'bash',
+            '-c',
+            `opencode serve --hostname 0.0.0.0 --port ${opencodePort} > /tmp/opencode.log 2>&1`
+        ]);
+
+        const baseUrl = `http://localhost:${hostPort}`;
+        const client = createOpencodeClient({ baseUrl, directory: agentProjectPath });
+
+        await waitForOpenCodeServer(baseUrl, containerName);
+
+        return {
+            client,
+            baseUrl,
+            accessToken: undefined,
+            sandboxId: containerName,
+            serverPid: 0,
+            resolvedPayload,
+            destroy: async () => {
+                await execDockerFileAsync('docker', ['rm', '-f', containerName]).catch((err: unknown) => {
+                    logger.warn('Failed to remove local agent container', { containerName, error: err });
+                });
+            }
+        };
+    } catch (err) {
+        await execDockerFileAsync('docker', ['rm', '-f', containerName]).catch((removeErr: unknown) => {
+            logger.warn('Failed to remove local agent container after startup failure', { containerName, error: removeErr });
+        });
+        throw err;
+    }
+}
+
+async function waitForOpenCodeServer(baseUrl: string, containerName: string): Promise<void> {
+    const maxAttempts = 40;
+    for (let attempt = 0; attempt < maxAttempts; attempt += 1) {
+        try {
+            const response = await fetch(`${baseUrl}/global/health`);
+            if (response.ok) {
+                return;
+            }
+        } catch {
+            // retry
+        }
+        await new Promise((resolve) => setTimeout(resolve, 1500));
+    }
+
+    const logs = await execDockerFileAsync('docker', ['exec', containerName, 'cat', '/tmp/opencode.log'])
+        .then((r) => r.stdout)
+        .catch(() => '');
+    throw new Error(`Timed out waiting for OpenCode server to start in local container${logs ? `: ${logs}` : ''}`);
+}
+
+// Inside Docker, localhost/127.0.0.1 refers to the container itself, update to use host.docker.internal
+function rewriteLocalhostUrl(payload: AgentSessionResolvedPayload): AgentSessionResolvedPayload {
+    return {
+        ...payload,
+        nango_base_url: rewriteDockerHostForLocalhost(payload.nango_base_url)
+    };
+}
+
+function findFreePort(): Promise<number> {
+    return new Promise((resolve, reject) => {
+        const server = createServer();
+        server.listen(0, '127.0.0.1', () => {
+            const addr = server.address();
+            server.close(() => {
+                if (addr && typeof addr === 'object') {
+                    resolve(addr.port);
+                } else {
+                    reject(new Error('Failed to find a free port'));
+                }
+            });
+        });
+        server.on('error', reject);
+    });
+}

--- a/packages/server/package.json
+++ b/packages/server/package.json
@@ -32,6 +32,7 @@
         "@nangohq/nango-orchestrator": "file:../orchestrator",
         "@nangohq/nango-yaml": "file:../nango-yaml",
         "@nangohq/providers": "file:.../providers",
+        "@opencode-ai/sdk": "^1.3.13",
         "@nangohq/records": "file:../records",
         "@nangohq/shared": "file:../shared",
         "@nangohq/utils": "file:../utils",

--- a/packages/types/lib/agent/api.ts
+++ b/packages/types/lib/agent/api.ts
@@ -1,0 +1,64 @@
+import type { ApiError, Endpoint } from '../api.js';
+
+export type PostAgentSessionStart = Endpoint<{
+    Method: 'POST';
+    Path: '/api/v1/agent/session/start';
+    Body: {
+        prompt: string;
+        integration_id: string;
+        connection_id?: string | undefined;
+    };
+    Error: ApiError<'invalid_request'> | ApiError<'server_error'>;
+    Success: {
+        session_token: string;
+        execution_timeout_at: string;
+    };
+}>;
+
+export type GetAgentSessionEvents = Endpoint<{
+    Method: 'GET';
+    Path: '/api/v1/agent/session/:sessionToken/events';
+    Params: { sessionToken: string };
+    Error: ApiError<'not_found'> | ApiError<'server_error'>;
+    // SSE streams events indefinitely; no structured JSON success body
+    Success: never;
+}>;
+
+export type PostAgentSessionAnswer = Endpoint<{
+    Method: 'POST';
+    Path: '/api/v1/agent/session/:sessionToken/answer';
+    Params: { sessionToken: string };
+    Body: {
+        question_id: string;
+        /** For regular questions: any string. For permissions: "once" | "always" | "reject" */
+        response: string;
+    };
+    Error: ApiError<'invalid_request'> | ApiError<'not_found'> | ApiError<'server_error'>;
+    Success: {
+        success: true;
+        accepted_at: string;
+    };
+}>;
+
+export type AgentEventData = Record<string, unknown>;
+
+export type AgentEventName =
+    | 'agent.lifecycle'
+    | 'agent.session.started'
+    | 'agent.prompt.accepted'
+    | 'agent.delta'
+    | 'agent.tool.updated'
+    | 'agent.message.updated'
+    | 'agent.question'
+    | 'agent.permission.requested'
+    | 'agent.permission.submitted'
+    | 'agent.permission.replied'
+    | 'agent.answer.accepted'
+    | 'agent.session.status'
+    | 'agent.session.idle'
+    | 'agent.error';
+
+export interface AgentSseEvent {
+    event: AgentEventName;
+    data: AgentEventData;
+}

--- a/packages/types/lib/api.endpoints.ts
+++ b/packages/types/lib/api.endpoints.ts
@@ -11,6 +11,7 @@ import type {
 } from './account/api.js';
 import type { GetAsyncActionResult, GetPublicV1, PostPublicTriggerAction } from './action/api.js';
 import type { PostImpersonate } from './admin/http.api.js';
+import type { GetAgentSessionEvents, PostAgentSessionAnswer, PostAgentSessionStart } from './agent/api.js';
 import type { EndpointMethod } from './api.js';
 import type {
     PostPublicApiKeyAuthorization,
@@ -192,7 +193,10 @@ export type PrivateApiEndpoints =
     | GetConnectUISettings
     | PutConnectUISettings
     | GetProviders
-    | GetProvider;
+    | GetProvider
+    | PostAgentSessionStart
+    | GetAgentSessionEvents
+    | PostAgentSessionAnswer;
 
 export type APIEndpoints = PrivateApiEndpoints | PublicApiEndpoints;
 

--- a/packages/types/lib/index.ts
+++ b/packages/types/lib/index.ts
@@ -95,6 +95,7 @@ export type * from './checkpoint/types.js';
 export type * from './checkpoint/db.js';
 
 export type * from './mcp/api.js';
+export type * from './agent/api.js';
 export type * from './functions/api.js';
 
 export type * from './lambda/index.js';

--- a/packages/utils/lib/environment/parse.ts
+++ b/packages/utils/lib/environment/parse.ts
@@ -537,6 +537,11 @@ export const ENVS = z.object({
     // E2B sandboxes
     E2B_API_KEY: z.string().optional(),
     E2B_SANDBOX_COMPILER_TEMPLATE: z.string().min(1).default('blank-workspace:staging'),
+    E2B_SANDBOX_AGENT_TEMPLATE: z.string().min(1).default('agent-workspace:staging'),
+
+    // Agent Builder
+    AGENT_RUNTIME: z.enum(['e2b', 'local']).optional().default('local'),
+    OPENCODE_API_KEY: z.string().optional(),
 
     // ----- Others
     SERVER_RUN_MODE: z.enum(['DOCKERIZED', '']).optional(),

--- a/packages/utils/lib/environment/parse.unit.test.ts
+++ b/packages/utils/lib/environment/parse.unit.test.ts
@@ -24,6 +24,19 @@ describe('parse', () => {
         expect(res.E2B_SANDBOX_COMPILER_TEMPLATE).toBe('blank-workspace:dev');
     });
 
+    it('should parse the sandbox agent template', () => {
+        const res = parseEnvs(ENVS, { E2B_SANDBOX_AGENT_TEMPLATE: 'agent-workspace:dev' });
+        expect(res.E2B_SANDBOX_AGENT_TEMPLATE).toBe('agent-workspace:dev');
+    });
+
+    it('should default to local agent runtime and sandbox templates', () => {
+        const res = parseEnvs(ENVS, {});
+
+        expect(res).toMatchObject({ AGENT_RUNTIME: 'local' });
+        expect(res.E2B_SANDBOX_AGENT_TEMPLATE).toBe('agent-workspace:staging');
+        expect(res.E2B_SANDBOX_COMPILER_TEMPLATE).toBe('blank-workspace:staging');
+    });
+
     it('should coerce boolean and number', () => {
         const res = parseEnvs(ENVS, { NANGO_DB_SSL: 'true', NANGO_LOGS_ENABLED: 'false', NANGO_PERSIST_PORT: '3008' });
         expect(res).toMatchObject({ NANGO_DB_SSL: true, NANGO_PERSIST_PORT: 3008, NANGO_LOGS_ENABLED: false, NANGO_CLOUD: false, NANGO_CACHE_ENV_KEYS: false });


### PR DESCRIPTION
<!-- Describe the problem and your solution -->
Adds the PR 2 internal agent session API on top of #5836, including private session start/events/answer endpoints, OpenCode session orchestration, and local/E2B sandbox startup. It also wires agent API types, sandbox environment configuration/docs, and the OpenCode SDK dependency while preserving the public remote-function API from the base PR.

<!-- Issue ticket number and link (if applicable) -->
Stacked on #5836.

<!-- Testing instructions (skip if just adding/editing providers) -->
- npm run ts-build
- npm run test:unit -- packages/server/lib/services/agent/agent-runtime.unit.test.ts packages/server/lib/services/e2b/agent-sandbox.unit.test.ts packages/utils/lib/environment/parse.unit.test.ts packages/server/lib/services/remote-function/compiler-client.unit.test.ts packages/server/lib/services/remote-function/shell.unit.test.ts
- npx eslint packages/server/lib/controllers/v1/agent/session/start/postStart.ts packages/server/lib/controllers/v1/agent/session/sessionToken/getEvents.ts packages/server/lib/controllers/v1/agent/session/sessionToken/postAnswer.ts packages/server/lib/services/agent/agent-runtime.ts packages/server/lib/services/agent/agent-session.service.ts packages/server/lib/services/agent/agent-runtime.unit.test.ts packages/server/lib/services/e2b/agent-sandbox.service.ts packages/server/lib/services/e2b/agent-sandbox.unit.test.ts packages/server/lib/services/local/agent-sandbox.service.ts packages/server/lib/services/remote-function/runtime.ts packages/types/lib/agent/api.ts packages/types/lib/api.endpoints.ts packages/types/lib/index.ts packages/utils/lib/environment/parse.ts packages/utils/lib/environment/parse.unit.test.ts