### PR TITLE
fix(logger): replace logger.warn with logger.warning for syslog

### DIFF
--- a/packages/scheduler/lib/daemons/scheduling/scheduling.daemon.ts
+++ b/packages/scheduler/lib/daemons/scheduling/scheduling.daemon.ts
@@ -77,7 +77,7 @@ export class SchedulingDaemon extends SchedulerDaemon {
                                     throw new Error(`Failed to schedule tasks: ${stringifyError(createRes.error)}`);
                                 }
                                 if (createRes.value.cappedGroupKeys.length > 0) {
-                                    logger.warn(`Capped scheduling tasks for group keys: ${createRes.value.cappedGroupKeys.join(', ')}`);
+                                    logger.warning(`Capped scheduling tasks for group keys: ${createRes.value.cappedGroupKeys.join(', ')}`);
                                 }
                                 const scheduleUpdates = [];
                                 const scheduledTasks = [];

--- a/packages/scheduler/lib/daemons/scheduling/scheduling.daemon.ts
+++ b/packages/scheduler/lib/daemons/scheduling/scheduling.daemon.ts
@@ -108,6 +108,7 @@ export class SchedulingDaemon extends SchedulerDaemon {
                 }
             } catch (err) {
                 logger.error(err);
+                throw err;
             }
         });
     }

--- a/packages/server/lib/controllers/proxy/allProxy.ts
+++ b/packages/server/lib/controllers/proxy/allProxy.ts
@@ -217,7 +217,7 @@ export const allPublicProxy = asyncWrapper<AllPublicProxy>(async (req, res, next
                                       } catch {
                                           redirectHostForLog = 'unparseable';
                                       }
-                                      logger.warn('Proxy redirect to denylisted host blocked', {
+                                      logger.warning('Proxy redirect to denylisted host blocked', {
                                           accountId: account.id,
                                           providerConfigKey: parsedHeaders['provider-config-key'],
                                           connectionId: parsedHeaders['connection-id'],


### PR DESCRIPTION
## Describe the problem and your solution

- replace `logger.warn` with `logger.warning` for syslog

<!-- Issue ticket number and link (if applicable) -->

<!-- Testing instructions (skip if just adding/editing providers) -->

