### PR TITLE
feat: add `has_rbac` feature flag

### DIFF
--- a/packages/database/lib/migrations/20260413155700_plans_add_has_rbac.cjs
+++ b/packages/database/lib/migrations/20260413155700_plans_add_has_rbac.cjs
@@ -1,0 +1,25 @@
+exports.config = { transaction: false };
+
+/**
+ * @param {import('knex').Knex} knex
+ */
+exports.up = async function (knex) {
+    await knex.raw(`ALTER TABLE "plans" ADD COLUMN IF NOT EXISTS "has_rbac" bool NOT NULL DEFAULT 'false'`);
+    // Backfill growth+ plans, while grandfathering accounts that already use RBAC.
+    await knex.raw(`
+        UPDATE "plans" AS p
+        SET "has_rbac" = true
+        WHERE p."name" IN ('growth', 'growth-v2', 'enterprise')
+            OR EXISTS (
+                SELECT 1
+                FROM "_nango_users" AS u
+                WHERE u."account_id" = p."account_id"
+                    AND u."role" <> 'administrator'
+            )
+    `);
+};
+
+/**
+ * @param {import('knex').Knex} knex
+ */
+exports.down = async function () {};

--- a/packages/shared/lib/seeders/plan.seeder.ts
+++ b/packages/shared/lib/seeders/plan.seeder.ts
@@ -33,6 +33,7 @@ export function getTestPlan(override?: Partial<DBPlan>): DBPlan {
         auto_idle: true,
         has_webhooks_script: false,
         has_webhooks_forward: false,
+        has_rbac: false,
         can_override_docs_connect_url: false,
         can_customize_connect_ui_theme: false,
         can_disable_connect_ui_watermark: false,

--- a/packages/shared/lib/services/plans/definitions.ts
+++ b/packages/shared/lib/services/plans/definitions.ts
@@ -249,7 +249,7 @@ export const scaleLegacyPlan: PlanDefinition = {
         trial_expired: null,
         has_webhooks_script: true,
         has_webhooks_forward: true,
-        has_rbac: true,
+        has_rbac: false,
         can_override_docs_connect_url: false,
         can_customize_connect_ui_theme: false,
         can_disable_connect_ui_watermark: false
@@ -287,7 +287,7 @@ export const growthLegacyPlan: PlanDefinition = {
         trial_expired: null,
         has_webhooks_script: true,
         has_webhooks_forward: true,
-        has_rbac: true,
+        has_rbac: false,
         can_override_docs_connect_url: false,
         can_customize_connect_ui_theme: true,
         can_disable_connect_ui_watermark: true

--- a/packages/shared/lib/services/plans/definitions.ts
+++ b/packages/shared/lib/services/plans/definitions.ts
@@ -25,6 +25,7 @@ export const freePlan: PlanDefinition = {
         monthly_active_records_max: 5000,
         has_webhooks_script: true,
         has_webhooks_forward: true,
+        has_rbac: false,
         can_override_docs_connect_url: false,
         can_customize_connect_ui_theme: false,
         can_disable_connect_ui_watermark: false,
@@ -66,6 +67,7 @@ export const starterV1Plan: PlanDefinition = {
         trial_expired: null,
         has_webhooks_script: false,
         has_webhooks_forward: false,
+        has_rbac: false,
         can_override_docs_connect_url: false,
         can_customize_connect_ui_theme: false,
         can_disable_connect_ui_watermark: false
@@ -104,6 +106,7 @@ export const growthV1Plan: PlanDefinition = {
         trial_expired: null,
         has_webhooks_script: true,
         has_webhooks_forward: true,
+        has_rbac: true,
         can_override_docs_connect_url: false,
         can_customize_connect_ui_theme: true,
         can_disable_connect_ui_watermark: true
@@ -169,6 +172,7 @@ export const enterprisePlan: PlanDefinition = {
         trial_expired: null,
         has_webhooks_script: true,
         has_webhooks_forward: true,
+        has_rbac: true,
         can_override_docs_connect_url: false,
         can_customize_connect_ui_theme: true,
         can_disable_connect_ui_watermark: true
@@ -207,6 +211,7 @@ export const starterLegacyPlan: PlanDefinition = {
         trial_expired: null,
         has_webhooks_script: true,
         has_webhooks_forward: true,
+        has_rbac: false,
         can_override_docs_connect_url: false,
         can_customize_connect_ui_theme: false,
         can_disable_connect_ui_watermark: false
@@ -244,6 +249,7 @@ export const scaleLegacyPlan: PlanDefinition = {
         trial_expired: null,
         has_webhooks_script: true,
         has_webhooks_forward: true,
+        has_rbac: true,
         can_override_docs_connect_url: false,
         can_customize_connect_ui_theme: false,
         can_disable_connect_ui_watermark: false
@@ -281,6 +287,7 @@ export const growthLegacyPlan: PlanDefinition = {
         trial_expired: null,
         has_webhooks_script: true,
         has_webhooks_forward: true,
+        has_rbac: true,
         can_override_docs_connect_url: false,
         can_customize_connect_ui_theme: true,
         can_disable_connect_ui_watermark: true

--- a/packages/shared/lib/services/plans/plans.ts
+++ b/packages/shared/lib/services/plans/plans.ts
@@ -226,6 +226,7 @@ export function mergeFlags({ currentPlan, newPlanDefinition }: { currentPlan: DB
             case 'has_otel':
             case 'has_webhooks_script':
             case 'has_webhooks_forward':
+            case 'has_rbac':
             case 'can_disable_connect_ui_watermark':
             case 'can_override_docs_connect_url':
             case 'can_customize_connect_ui_theme': {

--- a/packages/shared/lib/services/plans/plans.unit.test.ts
+++ b/packages/shared/lib/services/plans/plans.unit.test.ts
@@ -103,6 +103,7 @@ function makePlan({ code, flagOverrides }: { code: DBPlan['name']; flagOverrides
         has_otel: false,
         has_webhooks_forward: false,
         has_webhooks_script: false,
+        has_rbac: false,
         can_customize_connect_ui_theme: false,
         can_override_docs_connect_url: false,
         can_disable_connect_ui_watermark: false,

--- a/packages/shared/lib/services/plans/plans.unit.test.ts
+++ b/packages/shared/lib/services/plans/plans.unit.test.ts
@@ -6,6 +6,18 @@ import { mergeFlags } from './plans.js';
 import type { DBPlan, PlanDefinition } from '@nangohq/types';
 
 describe('mergeFlags', () => {
+    it('should only enable RBAC by default on growth, growth-v2, and enterprise', () => {
+        expect(getPlanDefinition('free')?.flags.has_rbac).toBe(false);
+        expect(getPlanDefinition('starter')?.flags.has_rbac).toBe(false);
+        expect(getPlanDefinition('starter-v2')?.flags.has_rbac).toBe(false);
+        expect(getPlanDefinition('starter-legacy')?.flags.has_rbac).toBe(false);
+        expect(getPlanDefinition('scale-legacy')?.flags.has_rbac).toBe(false);
+        expect(getPlanDefinition('growth-legacy')?.flags.has_rbac).toBe(false);
+        expect(getPlanDefinition('growth')?.flags.has_rbac).toBe(true);
+        expect(getPlanDefinition('growth-v2')?.flags.has_rbac).toBe(true);
+        expect(getPlanDefinition('enterprise')?.flags.has_rbac).toBe(true);
+    });
+
     describe('when downgrading', () => {
         it('should reset all flags to new plan default values, including overrides', () => {
             const currentPlan = makePlan({

--- a/packages/types/lib/plans/db.ts
+++ b/packages/types/lib/plans/db.ts
@@ -127,6 +127,13 @@ export interface DBPlan extends Timestamps {
     has_webhooks_forward: boolean;
 
     /**
+     * Enable role-based access control (non-administrator roles)
+     * When false, all users/invites must be 'administrator'
+     * @default false
+     */
+    has_rbac: boolean;
+
+    /**
      * Enable or disable the ability to override the docs connect url from the connect session
      * @default false
      */


### PR DESCRIPTION
Migration to add `has_rbac` feature flag to `plans` and backfill values, along with necessary changes to plan definitions so that plan changes apply the correct values.

> [!NOTE]
>  The flag is not used anywhere yet