### PR TITLE
feat(server): add client IP tags to Datadog traces

### DIFF
--- a/packages/server/lib/tracer.ts
+++ b/packages/server/lib/tracer.ts
@@ -2,6 +2,8 @@ import tracer from 'dd-trace';
 
 tracer.init({
     service: 'nango',
+    clientIpEnabled: true,
+    clientIpHeader: 'x-forwarded-for',
     samplingRules: [
         { service: 'server-net', sampleRate: 0.01, name: '*' },
         { service: 'nango-elasticsearch', sampleRate: 0.1, name: '*' },
@@ -16,6 +18,7 @@ tracer.use('elasticsearch', {
 });
 tracer.use('express');
 tracer.use('http', {
+    headers: ['x-forwarded-for'],
     blocklist: ['/health', '/favicon.ico', '/logo-dark.svg', '/logo-text.svg', /^\/static\//, /^\/images\//, '/manifest.json']
 });
 tracer.use('net', {


### PR DESCRIPTION
<!-- Describe the problem and your solution -->
Adds Datadog client IP extraction from `X-Forwarded-For` for server traces and captures the raw `X-Forwarded-For` request header for trace inspection.

<!-- Issue ticket number and link (if applicable) -->
NAN-4843: https://linear.app/nango/issue/NAN-4843/create-sampling-rules-for-control-plane-api-actions

<!-- Testing instructions (skip if just adding/editing providers) -->