### PR TITLE
feat(orchestrator): Add dropped task metric for capped groups

### DIFF
--- a/packages/scheduler/lib/models/tasks.ts
+++ b/packages/scheduler/lib/models/tasks.ts
@@ -1,6 +1,6 @@
 import { uuidv4, uuidv7 } from 'uuidv7';
 
-import { Err, Ok, stringToHash, stringifyError } from '@nangohq/utils';
+import { Err, Ok, metrics, stringToHash, stringifyError } from '@nangohq/utils';
 
 import { taskStates } from '../types.js';
 import { SCHEDULES_TABLE } from './schedules.js';
@@ -141,7 +141,7 @@ export async function create(
 
         const now = new Date();
         const toInsertPerGroup = new Map<string, Task[]>();
-        const cappedGroupKeys = new Set<string>();
+        const cappedGroupCounts = new Map<string, number>();
         for (const props of taskProps) {
             if (!toInsertPerGroup.has(props.groupKey)) {
                 toInsertPerGroup.set(props.groupKey, []);
@@ -160,8 +160,16 @@ export async function create(
                     retryKey: props.retryKey || uuidv4()
                 });
             } else {
-                cappedGroupKeys.add(props.groupKey);
+                cappedGroupCounts.set(props.groupKey, (cappedGroupCounts.get(props.groupKey) ?? 0) + 1);
             }
+        }
+        const droppedCountPerPrimitive = new Map<string, number>();
+        for (const [groupKey, droppedCount] of cappedGroupCounts.entries()) {
+            const primitive = groupKey.split(':')[0] || 'unknown';
+            droppedCountPerPrimitive.set(primitive, (droppedCountPerPrimitive.get(primitive) ?? 0) + droppedCount);
+        }
+        for (const [primitive, droppedCount] of droppedCountPerPrimitive.entries()) {
+            metrics.increment(metrics.Types.ORCH_TASKS_DROPPED, droppedCount, { primitive, reason: 'task_cap' });
         }
         const toInsert = Array.from(toInsertPerGroup.values()).flat();
         const inserted: Task[] = [];
@@ -172,7 +180,7 @@ export async function create(
         }
         return Ok({
             tasks: inserted,
-            cappedGroupKeys: Array.from(cappedGroupKeys)
+            cappedGroupKeys: Array.from(cappedGroupCounts.keys())
         });
     } catch (err) {
         return Err(new Error(`Error creating tasks: ${stringifyError(err)}`));

--- a/packages/utils/lib/telemetry/metrics.ts
+++ b/packages/utils/lib/telemetry/metrics.ts
@@ -66,6 +66,7 @@ export enum Types {
     WEBHOOK_INCOMING_PAYLOAD_SIZE_BYTES = 'nango.webhook.incoming.payloadSizeBytes',
 
     ORCH_TASKS_CREATED = 'nango.orch.tasks.created',
+    ORCH_TASKS_DROPPED = 'nango.orch.tasks.dropped',
     ORCH_TASKS_STARTED = 'nango.orch.tasks.started',
     ORCH_TASKS_SUCCEEDED = 'nango.orch.tasks.succeeded',
     ORCH_TASKS_FAILED = 'nango.orch.tasks.failed',


### PR DESCRIPTION
Adds a new metric for knowing when we are silently dropping tasks. This can be useful during incidents.
<!-- Describe the problem and your solution --> 

<!-- Issue ticket number and link (if applicable) -->

<!-- Testing instructions (skip if just adding/editing providers) -->

