### PR TITLE
docs: product chnagelog update for Playground

### DIFF
--- a/docs/updates/product.mdx
+++ b/docs/updates/product.mdx
@@ -4,6 +4,23 @@ sidebarTitle: "Product Updates"
 description: "Product updates and improvements."
 ---
 
+<Update label="April 14, 2026">
+  ## Playground
+
+  We added a Playground to the Nango dashboard. You can now trigger [actions](/guides/primitives/functions#actions) and [syncs](/guides/primitives/functions#syncs) directly from the Nango dashboard. Pick an integration, connection, and function, fill in the inputs, and hit Run!
+
+  {/* 📸 Suggested: GIF showing the full flow — open Playground from the header, select integration/connection/function, fill inputs, run, view result, then click through to logs */}
+
+  ![Playground](/images/changelog/playground.gif)
+
+  - **Enabled functions only:** The function dropdown shows only functions that are enabled for the selected integration.
+  - **Input validation:** Required fields are validated before execution. Missing inputs are flagged immediately without triggering a run.
+  - **Inline results and errors:** Execution results, timing, and error codes (e.g., invalid credentials) are displayed directly in the panel.
+  - **Jump to logs:** Navigate to the filtered [logs](/guides/platform/logging) view for any execution directly from the result.
+  - **Permission-gated:** Playground access in production environments respects your team's [roles](/guides/platform/security#team-and-roles).
+</Update>
+---
+
 <Update label="March 27, 2026">
   <AccordionGroup>
     <Accordion icon="webhook" title="34 new APIs in March">

--- a/docs/updates/product.mdx
+++ b/docs/updates/product.mdx
@@ -9,8 +9,6 @@ description: "Product updates and improvements."
 
   We added a Playground to the Nango dashboard. You can now trigger [actions](/implementation-guides/use-cases/actions/implement-an-action#implement-an-action) and [syncs](/implementation-guides/use-cases/syncs/implement-a-sync#implement-a-sync) directly from the Nango dashboard. Pick an integration, connection, and function, fill in the inputs, and hit Run!
 
-  {/* 📸 Suggested: GIF showing the full flow — open Playground from the header, select integration/connection/function, fill inputs, run, view result, then click through to logs */}
-
   ![Playground](/images/changelog/playground.gif)
 
   - ***Enabled* functions only:** The function dropdown shows only functions that are enabled for the selected integration.

--- a/docs/updates/product.mdx
+++ b/docs/updates/product.mdx
@@ -13,7 +13,7 @@ description: "Product updates and improvements."
 
   ![Playground](/images/changelog/playground.gif)
 
-  - **Enabled functions only:** The function dropdown shows only functions that are enabled for the selected integration.
+  - ***Enabled* functions only:** The function dropdown shows only functions that are enabled for the selected integration.
   - **Input validation:** Required fields are validated before execution. Missing inputs are flagged immediately without triggering a run.
   - **Inline results and errors:** Execution results, timing, and error codes (e.g., invalid credentials) are displayed directly in the panel.
   - **Jump to logs:** Navigate to the filtered [logs](/guides/platform/observability#observability) view for any execution directly from the result.

--- a/docs/updates/product.mdx
+++ b/docs/updates/product.mdx
@@ -7,7 +7,7 @@ description: "Product updates and improvements."
 <Update label="April 14, 2026">
   ## Playground
 
-  We added a Playground to the Nango dashboard. You can now trigger [actions](/guides/primitives/functions#actions) and [syncs](/guides/primitives/functions#syncs) directly from the Nango dashboard. Pick an integration, connection, and function, fill in the inputs, and hit Run!
+  We added a Playground to the Nango dashboard. You can now trigger [actions](/implementation-guides/use-cases/actions/implement-an-action#implement-an-action) and [syncs](/implementation-guides/use-cases/syncs/implement-a-sync#implement-a-sync) directly from the Nango dashboard. Pick an integration, connection, and function, fill in the inputs, and hit Run!
 
   {/* 📸 Suggested: GIF showing the full flow — open Playground from the header, select integration/connection/function, fill inputs, run, view result, then click through to logs */}
 
@@ -16,7 +16,7 @@ description: "Product updates and improvements."
   - **Enabled functions only:** The function dropdown shows only functions that are enabled for the selected integration.
   - **Input validation:** Required fields are validated before execution. Missing inputs are flagged immediately without triggering a run.
   - **Inline results and errors:** Execution results, timing, and error codes (e.g., invalid credentials) are displayed directly in the panel.
-  - **Jump to logs:** Navigate to the filtered [logs](/guides/platform/logging) view for any execution directly from the result.
+  - **Jump to logs:** Navigate to the filtered [logs](/guides/platform/observability#observability) view for any execution directly from the result.
   - **Permission-gated:** Playground access in production environments respects your team's [roles](/guides/platform/security#team-and-roles).
 </Update>
 ---


### PR DESCRIPTION
For: https://linear.app/nango/issue/CON-49/playground-release-notes-update
Preview Link: https://nango-con-49-playground-release-notes-update.mintlify.app/getting-started/intro-to-nango

## Summary
- Add April 14, 2026 changelog entry for the new Playground feature
- Covers: integration/connection/function selection, input validation, inline results, log navigation, and RBAC gating

## Test plan
- [x] Verify the changelog renders correctly on the docs site
- [x] Confirm doc links resolve: `/guides/primitives/functions#actions`, `/guides/primitives/functions#syncs`, `/guides/platform/logging`, `/guides/platform/security#team-and-roles`