### PR TITLE
feat(webapp): Playground contextual buttons

### DIFF
--- a/packages/webapp/src/pages/Connection/Show.tsx
+++ b/packages/webapp/src/pages/Connection/Show.tsx
@@ -1,3 +1,4 @@
+import { ExternalLink } from 'lucide-react';
 import { Helmet } from 'react-helmet';
 import { useParams } from 'react-router-dom';
 
@@ -13,11 +14,15 @@ import { useHashNavigation } from '@/hooks/useHashNavigation';
 import { useGetIntegration } from '@/hooks/useIntegration';
 import DashboardLayout from '@/layout/DashboardLayout';
 import { useStore } from '@/store';
+import { usePlaygroundStore } from '@/store/playground';
 import { getConnectionDisplayName, getEndUserEmail } from '@/utils/endUser';
 
 export const ConnectionShow = () => {
     const env = useStore((state) => state.env);
     const { connectionId, providerConfigKey } = useParams();
+    const setPlaygroundOpen = usePlaygroundStore((s) => s.setOpen);
+    const setPlaygroundIntegration = usePlaygroundStore((s) => s.setIntegration);
+    const setPlaygroundConnection = usePlaygroundStore((s) => s.setConnection);
 
     const {
         data: connectionResponse,
@@ -99,6 +104,16 @@ export const ConnectionShow = () => {
                         <TabsTrigger value="auth">Auth</TabsTrigger>
                         <TabsTrigger value="syncs">Syncs</TabsTrigger>
                         <TabsTrigger value="settings">Settings</TabsTrigger>
+                        <button
+                            onClick={() => {
+                                setPlaygroundIntegration(integrationData.integration.unique_key);
+                                setPlaygroundConnection(connectionResponse.connection.connection_id);
+                                setPlaygroundOpen(true);
+                            }}
+                            className="w-fit px-3 py-2 inline-flex items-center gap-1.5 cursor-pointer text-text-secondary !text-body-medium-medium border-b-2 border-b-transparent transition-colors hover:text-text-primary hover:border-text-tertiary"
+                        >
+                            Playground <ExternalLink className="size-4" />
+                        </button>
                     </TabsList>
                     <TabsContent value="auth">
                         <AuthTab connectionData={connectionResponse} providerConfigKey={integrationData.integration.unique_key} />

--- a/packages/webapp/src/pages/Integrations/providerConfigKey/Functions/One.tsx
+++ b/packages/webapp/src/pages/Integrations/providerConfigKey/Functions/One.tsx
@@ -26,6 +26,7 @@ import { useToast } from '@/hooks/useToast';
 import DashboardLayout from '@/layout/DashboardLayout';
 import PageNotFound from '@/pages/PageNotFound';
 import { useStore } from '@/store';
+import { usePlaygroundStore } from '@/store/playground';
 import { APIError } from '@/utils/api';
 
 import type { JSONSchema7 } from 'json-schema';
@@ -75,6 +76,10 @@ export const FunctionsOne: React.FC = () => {
     }, [func]);
 
     const [activeTab, setActiveTab] = useHashNavigation(outputSchemas && outputSchemas.length > 0 && !inputSchema ? 'output' : 'input');
+
+    const setPlaygroundOpen = usePlaygroundStore((s) => s.setOpen);
+    const setPlaygroundIntegration = usePlaygroundStore((s) => s.setIntegration);
+    const setPlaygroundFunction = usePlaygroundStore((s) => s.setFunction);
 
     const isLoading = integrationLoading || flowsLoading;
 
@@ -158,6 +163,17 @@ export const FunctionsOne: React.FC = () => {
                                     <Download />
                                 </Button>
                             )}
+                            <Button
+                                variant="secondary"
+                                size="sm"
+                                onClick={() => {
+                                    setPlaygroundIntegration(integrationData.integration.unique_key);
+                                    setPlaygroundFunction(func.name, func.type as 'action' | 'sync');
+                                    setPlaygroundOpen(true);
+                                }}
+                            >
+                                Playground <ExternalLink className="size-4" />
+                            </Button>
                             <FunctionSwitch flow={func} integration={integrationData.integration} />
                         </div>
                     </div>

--- a/packages/webapp/src/pages/Integrations/providerConfigKey/Show.tsx
+++ b/packages/webapp/src/pages/Integrations/providerConfigKey/Show.tsx
@@ -20,10 +20,13 @@ import { usePathNavigation } from '@/hooks/usePathNavigation';
 import { usePermissions } from '@/hooks/usePermissions';
 import DashboardLayout from '@/layout/DashboardLayout';
 import { useStore } from '@/store';
+import { usePlaygroundStore } from '@/store/playground';
 
 export const ShowIntegration: React.FC = () => {
     const { providerConfigKey } = useParams();
     const env = useStore((state) => state.env);
+    const setPlaygroundOpen = usePlaygroundStore((s) => s.setOpen);
+    const setPlaygroundIntegration = usePlaygroundStore((s) => s.setIntegration);
     const [activeTab, setActiveTab] = usePathNavigation(`/${env}/integrations/${providerConfigKey}`, 'functions');
 
     const { data: environmentData, isLoading: loadingEnvironment, error: environmentError } = useEnvironment(env);
@@ -108,6 +111,15 @@ export const ShowIntegration: React.FC = () => {
                                 Connections <ExternalLink className="size-4" />
                             </Link>
                         </TabsTrigger>
+                        <button
+                            onClick={() => {
+                                setPlaygroundIntegration(integration.integration.unique_key);
+                                setPlaygroundOpen(true);
+                            }}
+                            className="w-fit px-3 py-2 inline-flex items-center gap-1.5 cursor-pointer text-text-secondary !text-body-medium-medium border-b-2 border-b-transparent transition-colors hover:text-text-primary hover:border-text-tertiary"
+                        >
+                            Playground <ExternalLink className="size-4" />
+                        </button>
                     </TabsList>
                     <TabsContent value="functions">
                         <div className="flex w-full gap-11 justify-between">


### PR DESCRIPTION
<!-- Describe the problem and your solution --> 
Add contextual buttons to open the Playground:
<img width="421" height="163" alt="Screenshot 2026-04-15 at 4 55 15 PM" src="https://github.com/user-attachments/assets/44bfed2e-4dec-4666-b749-083f80997f78" />
<img width="783" height="155" alt="Screenshot 2026-04-15 at 4 55 09 PM" src="https://github.com/user-attachments/assets/7cca8133-c9f8-4e44-a40b-da34cb7f7217" />
<img width="1095" height="508" alt="Screenshot 2026-04-15 at 4 54 55 PM" src="https://github.com/user-attachments/assets/3ac95eb0-c274-4feb-87aa-38e67c4e07b4" />
<!-- Issue ticket number and link (if applicable) -->
NAN-5079

<!-- Testing instructions (skip if just adding/editing providers) -->

