### PR TITLE
fix(clickhouse): compute_gbms to be calculated in mv

### DIFF
--- a/packages/usage/lib/clickhouse/clickhouse.query.ts
+++ b/packages/usage/lib/clickhouse/clickhouse.query.ts
@@ -107,7 +107,7 @@ export function quantityForMetric(metric: UsageMetric): string {
         case 'function_logs':
             return `SUM(custom_logs)`;
         case 'function_compute_gbms':
-            return `SUM(duration_ms * memory_gb)`;
+            return `SUM(compute_gbms)`;
         case 'records':
         case 'connections':
             // not implemented yet

--- a/packages/usage/lib/clickhouse/migrations/20260407000003_create_daily_function_executions.ts
+++ b/packages/usage/lib/clickhouse/migrations/20260407000003_create_daily_function_executions.ts
@@ -13,11 +13,11 @@ export const sql = [
         runtime          LowCardinality(String),
         value            Int64,
         duration_ms      UInt64,
-        memory_gb        Float64,
+        compute_gbms     Float64,
         custom_logs      UInt64,
         proxy_calls      UInt64
     )
-    ENGINE = SummingMergeTree((value, duration_ms, memory_gb, custom_logs, proxy_calls))
+    ENGINE = SummingMergeTree((value, duration_ms, compute_gbms, custom_logs, proxy_calls))
     PARTITION BY toYYYYMM(day)
     ORDER BY (account_id, day, environment_id, integration_id, connection_id, function_type, function_name, success, runtime)
     TTL day + INTERVAL 24 MONTH
@@ -37,7 +37,7 @@ export const sql = [
         attributes.runtime::String                                              AS runtime,
         sum(value)                                                              AS value,
         sum(coalesce(attributes.telemetryBag.durationMs::Nullable(UInt64), 0))  AS duration_ms,
-        sum(coalesce(attributes.telemetryBag.memoryGb::Nullable(Float64), 0.0))    AS memory_gb,
+        sum(coalesce(attributes.telemetryBag.durationMs::Nullable(UInt64), 0) * coalesce(attributes.telemetryBag.memoryGb::Nullable(Float64), 0.0)) AS compute_gbms,
         sum(coalesce(attributes.telemetryBag.customLogs::Nullable(UInt64), 0))  AS custom_logs,
         sum(coalesce(attributes.telemetryBag.proxyCalls::Nullable(UInt64), 0))  AS proxy_calls
     FROM {database:Identifier}.raw_events


### PR DESCRIPTION
compute_gbms was wrongly calculated because memory_gb was summed instead of being part of the aggregation group_by. Fixing this issue as well as pre-calculating compute_gbms

<!-- Describe the problem and your solution --> 

<!-- Issue ticket number and link (if applicable) -->

<!-- Testing instructions (skip if just adding/editing providers) -->

