### PR TITLE
feat(proxy): resolve `accessToken` in custom headers for OAUTH2_CC

### DIFF
--- a/packages/shared/lib/services/proxy/utils.ts
+++ b/packages/shared/lib/services/proxy/utils.ts
@@ -519,6 +519,8 @@ export function buildProxyHeaders({
                     headers[key] = interpolateIfNeeded(value, { accessToken: connection.credentials.access_token });
                     break;
                 }
+                case 'JWT':
+                case 'OAUTH2_CC':
                 case 'SIGNATURE': {
                     headers[key] = interpolateIfNeeded(value, { accessToken: connection.credentials.token || '' });
                     break;
@@ -530,10 +532,6 @@ export function buildProxyHeaders({
                         ...stableReplacers,
                         ...baseReplacers
                     });
-                    break;
-                }
-                case 'JWT': {
-                    headers[key] = interpolateIfNeeded(value, { accessToken: connection.credentials.token || '' });
                     break;
                 }
                 default:


### PR DESCRIPTION
## Describe the problem and your solution

- resolve `accessToken` in custom headers for OAUTH2_CC, fixes `shopify-cc` provider.

<!-- Issue ticket number and link (if applicable) -->

<!-- Testing instructions (skip if just adding/editing providers) -->

