### PR TITLE
feat(webapp): Playground contextual buttons

### DIFF
--- a/packages/webapp/src/components-v2/Playground/index.tsx
+++ b/packages/webapp/src/components-v2/Playground/index.tsx
@@ -9,6 +9,7 @@ import { PlaygroundResult } from './PlaygroundResult';
 import { PlaygroundSelectors } from './PlaygroundSelectors';
 import { getInputFields } from './types';
 import { usePlayground } from './usePlayground';
+import { ConditionalTooltip } from '../ConditionalTooltip';
 import { PermissionGate } from '../PermissionGate';
 import { Button } from '../ui/button';
 import { Sheet, SheetContent } from '../ui/sheet';
@@ -81,7 +82,8 @@ export const Playground: React.FC = () => {
     const clearInputError = useCallback((name: string) => clearPlaygroundInputError(name), [clearPlaygroundInputError]);
 
     const playgroundConnection = usePlaygroundStore((s) => s.connection);
-    const canRun = Boolean(playgroundIntegration && playgroundConnection && playgroundFunctionName && playgroundFunctionType);
+    const isFunctionDisabled = Boolean(playgroundFunction && playgroundFunction.enabled === false);
+    const canRun = Boolean(playgroundIntegration && playgroundConnection && playgroundFunctionName && playgroundFunctionType) && !isFunctionDisabled;
     const isSync = playgroundFunctionType === 'sync';
     const showInputs = Boolean(playgroundFunction && (isSync || inputFields.length > 0));
 
@@ -156,23 +158,27 @@ export const Playground: React.FC = () => {
                                             )}
                                         </>
                                     ) : result ? (
-                                        <PermissionGate condition={canUsePlayground} message="Your role does not have permission to use the playground.">
-                                            {(allowed) => (
-                                                <Button variant="primary" size="sm" onClick={handleRun} disabled={!canRun || !allowed}>
-                                                    <RotateCcw />
-                                                    Run again
-                                                </Button>
-                                            )}
-                                        </PermissionGate>
+                                        <ConditionalTooltip condition={isFunctionDisabled} content="Enable this function to run it from the Playground.">
+                                            <PermissionGate condition={canUsePlayground} message="Your role does not have permission to use the playground.">
+                                                {(allowed) => (
+                                                    <Button variant="primary" size="sm" onClick={handleRun} disabled={!canRun || !allowed}>
+                                                        <RotateCcw />
+                                                        Run again
+                                                    </Button>
+                                                )}
+                                            </PermissionGate>
+                                        </ConditionalTooltip>
                                     ) : (
-                                        <PermissionGate condition={canUsePlayground} message="Your role does not have permission to use the playground.">
-                                            {(allowed) => (
-                                                <Button variant="primary" size="sm" onClick={handleRun} disabled={!canRun || !allowed}>
-                                                    <Play />
-                                                    Run
-                                                </Button>
-                                            )}
-                                        </PermissionGate>
+                                        <ConditionalTooltip condition={isFunctionDisabled} content="Enable this function to run it from the Playground.">
+                                            <PermissionGate condition={canUsePlayground} message="Your role does not have permission to use the playground.">
+                                                {(allowed) => (
+                                                    <Button variant="primary" size="sm" onClick={handleRun} disabled={!canRun || !allowed}>
+                                                        <Play />
+                                                        Run
+                                                    </Button>
+                                                )}
+                                            </PermissionGate>
+                                        </ConditionalTooltip>
                                     )}
                                 </div>
                             </div>

--- a/packages/webapp/src/components-v2/ui/tooltip.tsx
+++ b/packages/webapp/src/components-v2/ui/tooltip.tsx
@@ -23,7 +23,7 @@ function TooltipTrigger({ ...props }: React.ComponentProps<typeof TooltipPrimiti
 }
 
 const tooltipContentVariants = cva(
-    'text-text-secondary animate-in fade-in-0 zoom-in-95 shadow-md data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=closed]:zoom-out-95 data-[side=bottom]:slide-in-from-top-2 data-[side=left]:slide-in-from-right-2 data-[side=right]:slide-in-from-left-2 data-[side=top]:slide-in-from-bottom-2 z-50 w-fit origin-(--radix-tooltip-content-transform-origin) rounded-md px-3 py-1.5 text-s leading-4 text-balance',
+    'text-text-secondary animate-in fade-in-0 zoom-in-95 shadow-md data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=closed]:zoom-out-95 data-[side=bottom]:slide-in-from-top-2 data-[side=left]:slide-in-from-right-2 data-[side=right]:slide-in-from-left-2 data-[side=top]:slide-in-from-bottom-2 z-80 w-fit origin-(--radix-tooltip-content-transform-origin) rounded-md px-3 py-1.5 text-s leading-4 text-balance',
     {
         variants: {
             variant: {
@@ -37,7 +37,7 @@ const tooltipContentVariants = cva(
     }
 );
 
-const tooltipPrimitiveVariants = cva('z-50 size-2.5 translate-y-[calc(-50%_-_2px)] rotate-45 rounded-[2px]', {
+const tooltipPrimitiveVariants = cva('z-80 size-2.5 translate-y-[calc(-50%_-_2px)] rotate-45 rounded-[2px]', {
     variants: {
         variant: {
             primary: 'bg-bg-subtle fill-bg-subtle',

--- a/packages/webapp/src/pages/Connection/List.tsx
+++ b/packages/webapp/src/pages/Connection/List.tsx
@@ -176,7 +176,10 @@ export const ConnectionList = () => {
     const [debouncedSearch, setDebouncedSearch] = useState<string>('');
     const [selectedIntegrations, setSelectedIntegrations] = useQueryState('integrations', parseIntegrations);
     const [rawStatusFilters, setSelectedStatusFilters] = useQueryState('status', parseStatusFilters);
-    const selectedStatusFilters = (rawStatusFilters ?? []).filter((s): s is StatusFilterValue => validStatusFilterValues.has(s));
+    const selectedStatusFilters = useMemo(
+        () => (rawStatusFilters ?? []).filter((s): s is StatusFilterValue => validStatusFilterValues.has(s)),
+        [rawStatusFilters]
+    );
 
     useDebounce(() => setDebouncedSearch(search || ''), 300, [search]);
 
@@ -248,10 +251,11 @@ export const ConnectionList = () => {
     const showEmptyStateNoFilters = !loading && connectionCount === 0 && !hasFiltered;
     const showEmptyStateWithFilters = !loading && !isFetchingNextPage && connectionCount === 0 && hasFiltered && !hasNextPage;
 
+    const coreRowModel = useMemo(() => getCoreRowModel(), []);
     const table = useReactTable({
         data: displayedConnections,
         columns,
-        getCoreRowModel: getCoreRowModel()
+        getCoreRowModel: coreRowModel
     });
 
     const integrationsOptions = useMemo(() => {

--- a/packages/webapp/src/pages/Connection/Show.tsx
+++ b/packages/webapp/src/pages/Connection/Show.tsx
@@ -1,3 +1,4 @@
+import { ExternalLink } from 'lucide-react';
 import { Helmet } from 'react-helmet';
 import { useParams } from 'react-router-dom';
 
@@ -14,11 +15,11 @@ import { useGetIntegration } from '@/hooks/useIntegration';
 import DashboardLayout from '@/layout/DashboardLayout';
 import { useStore } from '@/store';
 import { getConnectionDisplayName, getEndUserEmail } from '@/utils/endUser';
+import { openPlaygroundWithContext } from '@/utils/playground';
 
 export const ConnectionShow = () => {
     const env = useStore((state) => state.env);
     const { connectionId, providerConfigKey } = useParams();
-
     const {
         data: connectionResponse,
         error: connectionError,
@@ -94,11 +95,26 @@ export const ConnectionShow = () => {
                     </div>
                 </div>
 
-                <Tabs value={activeTab} onValueChange={setActiveTab}>
+                <Tabs
+                    value={activeTab}
+                    onValueChange={(value) => {
+                        if (value === 'playground') {
+                            openPlaygroundWithContext({
+                                integration: integrationData.integration.unique_key,
+                                connection: connectionResponse.connection.connection_id
+                            });
+                        } else {
+                            setActiveTab(value);
+                        }
+                    }}
+                >
                     <TabsList>
                         <TabsTrigger value="auth">Auth</TabsTrigger>
                         <TabsTrigger value="syncs">Syncs</TabsTrigger>
                         <TabsTrigger value="settings">Settings</TabsTrigger>
+                        <TabsTrigger value="playground">
+                            Playground <ExternalLink className="size-4" />
+                        </TabsTrigger>
                     </TabsList>
                     <TabsContent value="auth">
                         <AuthTab connectionData={connectionResponse} providerConfigKey={integrationData.integration.unique_key} />

--- a/packages/webapp/src/pages/Integrations/providerConfigKey/Functions/One.tsx
+++ b/packages/webapp/src/pages/Integrations/providerConfigKey/Functions/One.tsx
@@ -7,6 +7,7 @@ import { CardContent, CardHeader, CardLayout, CardSubheader } from '../../compon
 import { FunctionSwitch } from '../../components/FunctionSwitch';
 import { JsonSchemaTopLevelObject } from '../../components/jsonSchema/JsonSchema';
 import { isNullSchema, isObjectWithNoProperties } from '../../components/jsonSchema/utils';
+import { ConditionalTooltip } from '@/components-v2/ConditionalTooltip';
 import { CopyButton } from '@/components-v2/CopyButton';
 import { EmptyCard } from '@/components-v2/EmptyCard';
 import { IntegrationLogo } from '@/components-v2/IntegrationLogo';
@@ -159,19 +160,22 @@ export const FunctionsOne: React.FC = () => {
                                     <Download />
                                 </Button>
                             )}
-                            <Button
-                                variant="secondary"
-                                size="sm"
-                                onClick={() => {
-                                    openPlaygroundWithContext({
-                                        integration: integrationData.integration.unique_key,
-                                        functionName: func.name,
-                                        functionType: func.type as 'action' | 'sync'
-                                    });
-                                }}
-                            >
-                                Playground <ExternalLink />
-                            </Button>
+                            <ConditionalTooltip condition={!func.enabled} content="Enable this function to use it in the Playground.">
+                                <Button
+                                    variant="secondary"
+                                    size="sm"
+                                    disabled={!func.enabled}
+                                    onClick={() => {
+                                        openPlaygroundWithContext({
+                                            integration: integrationData.integration.unique_key,
+                                            functionName: func.name,
+                                            functionType: func.type as 'action' | 'sync'
+                                        });
+                                    }}
+                                >
+                                    Playground <ExternalLink />
+                                </Button>
+                            </ConditionalTooltip>
                             <FunctionSwitch flow={func} integration={integrationData.integration} />
                         </div>
                     </div>

--- a/packages/webapp/src/pages/Integrations/providerConfigKey/Functions/One.tsx
+++ b/packages/webapp/src/pages/Integrations/providerConfigKey/Functions/One.tsx
@@ -27,6 +27,7 @@ import DashboardLayout from '@/layout/DashboardLayout';
 import PageNotFound from '@/pages/PageNotFound';
 import { useStore } from '@/store';
 import { APIError } from '@/utils/api';
+import { openPlaygroundWithContext } from '@/utils/playground';
 
 import type { JSONSchema7 } from 'json-schema';
 
@@ -158,6 +159,19 @@ export const FunctionsOne: React.FC = () => {
                                     <Download />
                                 </Button>
                             )}
+                            <Button
+                                variant="secondary"
+                                size="sm"
+                                onClick={() => {
+                                    openPlaygroundWithContext({
+                                        integration: integrationData.integration.unique_key,
+                                        functionName: func.name,
+                                        functionType: func.type as 'action' | 'sync'
+                                    });
+                                }}
+                            >
+                                Playground <ExternalLink />
+                            </Button>
                             <FunctionSwitch flow={func} integration={integrationData.integration} />
                         </div>
                     </div>

--- a/packages/webapp/src/pages/Integrations/providerConfigKey/Show.tsx
+++ b/packages/webapp/src/pages/Integrations/providerConfigKey/Show.tsx
@@ -20,6 +20,7 @@ import { usePathNavigation } from '@/hooks/usePathNavigation';
 import { usePermissions } from '@/hooks/usePermissions';
 import DashboardLayout from '@/layout/DashboardLayout';
 import { useStore } from '@/store';
+import { openPlaygroundWithContext } from '@/utils/playground';
 
 export const ShowIntegration: React.FC = () => {
     const { providerConfigKey } = useParams();
@@ -86,7 +87,16 @@ export const ShowIntegration: React.FC = () => {
                         )}
                     </PermissionGate>
                 </div>
-                <Tabs value={activeTab} onValueChange={setActiveTab}>
+                <Tabs
+                    value={activeTab}
+                    onValueChange={(value) => {
+                        if (value === 'playground') {
+                            openPlaygroundWithContext({ integration: integration.integration.unique_key });
+                        } else {
+                            setActiveTab(value);
+                        }
+                    }}
+                >
                     <TabsList>
                         <TabsTrigger value="functions">Functions</TabsTrigger>
                         <TabsTrigger value="settings">Settings</TabsTrigger>
@@ -107,6 +117,9 @@ export const ShowIntegration: React.FC = () => {
                             >
                                 Connections <ExternalLink className="size-4" />
                             </Link>
+                        </TabsTrigger>
+                        <TabsTrigger value="playground">
+                            Playground <ExternalLink className="size-4" />
                         </TabsTrigger>
                     </TabsList>
                     <TabsContent value="functions">


### PR DESCRIPTION
<!-- Describe the problem and your solution --> 
Add buttons on Connection, Integration and Sync/Action view pages to be able to open the Playground with that context.
<img width="1111" height="243" alt="Screenshot 2026-04-16 at 12 31 24 PM" src="https://github.com/user-attachments/assets/ec7f8fbb-70e8-4083-86a7-9a4d89a6f7cd" />
<img width="1113" height="280" alt="Screenshot 2026-04-16 at 12 31 09 PM" src="https://github.com/user-attachments/assets/a0b4c29d-debd-452e-8d78-5e092006cdf2" />
<img width="1108" height="352" alt="Screenshot 2026-04-16 at 12 30 55 PM" src="https://github.com/user-attachments/assets/a34ddceb-8039-493c-a139-8ba6326c79be" />

<!-- Issue ticket number and link (if applicable) -->
NAN-5079
<!-- Testing instructions (skip if just adding/editing providers) -->

