### PR TITLE
fix: mark upgrade invoices as paid instead of always crediting balance

### DIFF
--- a/packages/billing/lib/clients/orb/client.ts
+++ b/packages/billing/lib/clients/orb/client.ts
@@ -279,7 +279,7 @@ export class OrbClient implements BillingClient {
         }
     }
 
-    async applyPendingChanges(opts: { pendingChangeId: string; paymentExternalId?: string }): Promise<Result<BillingSubscription>> {
+    async applyPendingChanges(opts: { pendingChangeId: string; paymentExternalId?: string; amountCollected?: string }): Promise<Result<BillingSubscription>> {
         try {
             // We apply the pending change and mark invoices as paid directly.
             // Using mark_as_paid instead of previously_collected_amount avoids
@@ -288,7 +288,8 @@ export class OrbClient implements BillingClient {
             const res = await this.orbSDK.subscriptionChanges.apply(opts.pendingChangeId, {
                 description: 'Initial payment on subscription',
                 mark_as_paid: true,
-                payment_external_id: opts.paymentExternalId ?? null
+                payment_external_id: opts.paymentExternalId ?? null,
+                payment_notes: opts.amountCollected ? `Stripe collected: $${opts.amountCollected}` : null
             });
             if (!res.subscription) {
                 return Err(new Error('failed_to_apply_pending_changes', { cause: 'no subscription' }));

--- a/packages/billing/lib/clients/orb/client.ts
+++ b/packages/billing/lib/clients/orb/client.ts
@@ -279,18 +279,16 @@ export class OrbClient implements BillingClient {
         }
     }
 
-    async applyPendingChanges(opts: { pendingChangeId: string; paymentExternalId?: string; amountCollected?: string }): Promise<Result<BillingSubscription>> {
+    async applyPendingChanges(opts: { pendingChangeId: string; amountCollected: string; paymentExternalId: string }): Promise<Result<BillingSubscription>> {
         try {
-            // We apply the pending change and mark invoices as paid directly.
-            // Using mark_as_paid instead of previously_collected_amount avoids
-            // creating a customer balance credit, which would cause invoices to
-            // net to zero (full amount charged + full amount discounted).
             const res = await this.orbSDK.subscriptionChanges.apply(opts.pendingChangeId, {
                 description: 'Initial payment on subscription',
                 mark_as_paid: true,
-                payment_external_id: opts.paymentExternalId ?? null,
-                payment_notes: opts.amountCollected ? `Stripe collected: $${opts.amountCollected}` : null
+                previously_collected_amount: opts.amountCollected,
+                payment_external_id: opts.paymentExternalId,
+                payment_notes: `Stripe collected: $${opts.amountCollected}`
             });
+
             if (!res.subscription) {
                 return Err(new Error('failed_to_apply_pending_changes', { cause: 'no subscription' }));
             }

--- a/packages/billing/lib/clients/orb/client.ts
+++ b/packages/billing/lib/clients/orb/client.ts
@@ -279,12 +279,16 @@ export class OrbClient implements BillingClient {
         }
     }
 
-    async applyPendingChanges(opts: { pendingChangeId: string; amount: string }): Promise<Result<BillingSubscription>> {
+    async applyPendingChanges(opts: { pendingChangeId: string; paymentExternalId?: string }): Promise<Result<BillingSubscription>> {
         try {
-            // We apply the pending change to confirm the card
+            // We apply the pending change and mark invoices as paid directly.
+            // Using mark_as_paid instead of previously_collected_amount avoids
+            // creating a customer balance credit, which would cause invoices to
+            // net to zero (full amount charged + full amount discounted).
             const res = await this.orbSDK.subscriptionChanges.apply(opts.pendingChangeId, {
                 description: 'Initial payment on subscription',
-                previously_collected_amount: opts.amount
+                mark_as_paid: true,
+                payment_external_id: opts.paymentExternalId ?? null
             });
             if (!res.subscription) {
                 return Err(new Error('failed_to_apply_pending_changes', { cause: 'no subscription' }));

--- a/packages/server/lib/controllers/v1/stripe/postWebhooks.ts
+++ b/packages/server/lib/controllers/v1/stripe/postWebhooks.ts
@@ -171,7 +171,7 @@ async function handleWebhook(event: Stripe.Event, stripe: Stripe): Promise<Resul
             // Finally, we apply the pending change to confirm the card and the plan
             const resApply = await billing.client.applyPendingChanges({
                 pendingChangeId: sub.pendingChangeId,
-                amount: (data.amount / 100).toFixed(2)
+                paymentExternalId: data.id
             });
             if (resApply.isErr()) {
                 return Err(resApply.error);

--- a/packages/server/lib/controllers/v1/stripe/postWebhooks.ts
+++ b/packages/server/lib/controllers/v1/stripe/postWebhooks.ts
@@ -171,7 +171,8 @@ async function handleWebhook(event: Stripe.Event, stripe: Stripe): Promise<Resul
             // Finally, we apply the pending change to confirm the card and the plan
             const resApply = await billing.client.applyPendingChanges({
                 pendingChangeId: sub.pendingChangeId,
-                paymentExternalId: data.id
+                paymentExternalId: data.id,
+                amountCollected: (data.amount / 100).toFixed(2)
             });
             if (resApply.isErr()) {
                 return Err(resApply.error);

--- a/packages/types/lib/billing/types.ts
+++ b/packages/types/lib/billing/types.ts
@@ -16,9 +16,9 @@ export interface BillingClient {
     applyPendingChanges: (opts: {
         pendingChangeId: string;
         /**
-         * format: dollar.cent = 0.00
+         * Stripe PaymentIntent ID, used to cross-reference the payment in Orb.
          */
-        amount: string;
+        paymentExternalId?: string;
     }) => Promise<Result<BillingSubscription>>;
     cancelPendingChanges: (opts: { pendingChangeId: string }) => Promise<Result<void>>;
     verifyWebhookSignature(body: string, headers: Record<string, unknown>, secret: string): Result<true>;

--- a/packages/types/lib/billing/types.ts
+++ b/packages/types/lib/billing/types.ts
@@ -18,12 +18,14 @@ export interface BillingClient {
         /**
          * Stripe PaymentIntent ID, used to cross-reference the payment in Orb.
          */
-        paymentExternalId?: string;
+        paymentExternalId: string;
         /**
-         * Amount collected via Stripe in dollars (e.g. "25.00"), stored as a
-         * note on the Orb invoice for audit purposes.
+         * Amount collected via Stripe in dollars (e.g. "25.00"). Orb uses this
+         * to credit the customer the difference vs. the actual invoice amount,
+         * so overcharges (e.g. when falling back to the base fee) are corrected
+         * automatically. No credit is issued if the amounts match exactly.
          */
-        amountCollected?: string;
+        amountCollected: string;
     }) => Promise<Result<BillingSubscription>>;
     cancelPendingChanges: (opts: { pendingChangeId: string }) => Promise<Result<void>>;
     verifyWebhookSignature(body: string, headers: Record<string, unknown>, secret: string): Result<true>;

--- a/packages/types/lib/billing/types.ts
+++ b/packages/types/lib/billing/types.ts
@@ -19,6 +19,11 @@ export interface BillingClient {
          * Stripe PaymentIntent ID, used to cross-reference the payment in Orb.
          */
         paymentExternalId?: string;
+        /**
+         * Amount collected via Stripe in dollars (e.g. "25.00"), stored as a
+         * note on the Orb invoice for audit purposes.
+         */
+        amountCollected?: string;
     }) => Promise<Result<BillingSubscription>>;
     cancelPendingChanges: (opts: { pendingChangeId: string }) => Promise<Result<void>>;
     verifyWebhookSignature(body: string, headers: Record<string, unknown>, secret: string): Result<true>;


### PR DESCRIPTION
<!-- Describe the problem and your solution --> 
When applying a pending plan change, always pass both `mark_as_paid: true`
and `previously_collected_amount` to Orb. This fixes base-fee invoice amounts
netting to zero and causes Orb to automatically credit the customer the 
difference if we charged the base fee fallback instead of the exact pro-rated 
invoice amount — and is a no-op when the amounts match.

<!-- Issue ticket number and link (if applicable) -->

<!-- Testing instructions (skip if just adding/editing providers) -->