### PR TITLE
feat(clickhouse): add support for connections and records metrics

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -37916,6 +37916,7 @@
                 "@nangohq/utils": "file:../utils",
                 "dd-trace": "5.52.0",
                 "node-cron": "3.0.2",
+                "uuidv7": "0.6.3",
                 "zod": "4.0.5"
             },
             "devDependencies": {

--- a/packages/metering/lib/crons/usage.ts
+++ b/packages/metering/lib/crons/usage.ts
@@ -1,16 +1,19 @@
 import tracer from 'dd-trace';
 import * as cron from 'node-cron';
+import { uuidv7 } from 'uuidv7';
 
 import { billing as usageBilling } from '@nangohq/billing';
 import { getLocking } from '@nangohq/kvstore';
 import { records } from '@nangohq/records';
 import { connectionService } from '@nangohq/shared';
+import { Clickhouse } from '@nangohq/usage';
 import { flagHasUsage, getLogger, metrics } from '@nangohq/utils';
 
 import { envs } from '../env.js';
 
 import type { Lock } from '@nangohq/kvstore';
 import type { RecordsBillingEvent } from '@nangohq/types';
+import type { ClickhouseRawUsageEvent } from '@nangohq/usage';
 
 const logger = getLogger('cron.exportUsage');
 const cronMinutes = envs.CRON_EXPORT_USAGE_MINUTES;
@@ -44,11 +47,14 @@ export async function exec(): Promise<void> {
             return;
         }
 
+        const clickhouse = new Clickhouse();
+
         try {
             // TODO: get rid of billing exports which are legacy events
             await billing.exportBillableConnections();
             await observability.exportConnectionsMetrics();
             await observability.exportRecordsMetrics();
+            await usage.exportMetrics(clickhouse);
             logger.info(`✅ done`);
         } catch (err) {
             logger.error('Failed to export usage metrics', err);
@@ -57,9 +63,97 @@ export async function exec(): Promise<void> {
             }
             // only releasing the lock on error
             // and letting it expires otherwise so no other execution can occur until the next cron
+        } finally {
+            await clickhouse.shutdown();
         }
     });
 }
+
+const usage = {
+    exportMetrics: async (clickhouse: Clickhouse): Promise<void> => {
+        await tracer.trace<Promise<void>>('nango.cron.exportUsage.metrics', async (span) => {
+            try {
+                const now = new Date();
+                // Note: connectionsPerAccount is held in memory for the duration of the entire function execution
+                // While unbounded the number of account/environment/integration combinations is expected to be manageable
+                const connectionsPerAccount = new Map<string, { accountId: number; environmentId: number; integrationId: string; count: number }>();
+                for await (const page of connectionService.paginateConnections({ batchSize: 10_000 })) {
+                    if (page.isErr()) {
+                        throw page.error;
+                    }
+                    const connectionsMap = new Map(page.value.map((c) => [c.connection.id, c]));
+                    for (const { account, environment, connection } of page.value) {
+                        const key = `${account.id}:${environment.id}:${connection.provider_config_key}`;
+                        const existing = connectionsPerAccount.get(key);
+                        if (existing) {
+                            existing.count += 1;
+                        } else {
+                            connectionsPerAccount.set(key, {
+                                accountId: account.id,
+                                environmentId: environment.id,
+                                integrationId: connection.provider_config_key,
+                                count: 1
+                            });
+                        }
+                    }
+
+                    const connectionIds = page.value.map((c) => c.connection.id);
+                    for await (const recordCounts of records.paginateCounts({ connectionIds })) {
+                        if (recordCounts.isErr()) {
+                            throw recordCounts.error;
+                        }
+                        for (const recordCount of recordCounts.value) {
+                            const connection = connectionsMap.get(recordCount.connection_id);
+                            if (connection) {
+                                const res = clickhouse.addRaw([
+                                    {
+                                        ts: now.getTime(),
+                                        idempotency_key: uuidv7(),
+                                        type: 'usage.records',
+                                        value: recordCount.count,
+                                        account_id: connection.account.id,
+                                        attributes: {
+                                            environmentId: connection.environment.id,
+                                            integrationId: connection.connection.provider_config_key,
+                                            connectionId: connection.connection.connection_id,
+                                            model: recordCount.model
+                                        }
+                                    }
+                                ]);
+                                if (res.isErr()) {
+                                    throw res.error;
+                                }
+                            }
+                        }
+                    }
+                }
+
+                const events: ClickhouseRawUsageEvent[] = Array.from(connectionsPerAccount.values()).map(
+                    ({ accountId, environmentId, integrationId, count }) => {
+                        return {
+                            ts: now.getTime(),
+                            idempotency_key: uuidv7(),
+                            type: 'usage.connections',
+                            value: count,
+                            account_id: accountId,
+                            attributes: {
+                                environmentId,
+                                integrationId
+                            }
+                        };
+                    }
+                );
+                const res = clickhouse.addRaw(events);
+                if (res.isErr()) {
+                    throw res.error;
+                }
+            } catch (err) {
+                span.setTag('error', err);
+                logger.error('Failed to export connections metrics to clickhouse', err);
+            }
+        });
+    }
+};
 
 const observability = {
     exportConnectionsMetrics: async (): Promise<void> => {
@@ -81,7 +175,7 @@ const observability = {
                             }
                         }
                     ]);
-                    // TODO: ingest into clickhouse
+
                     metrics.gauge(metrics.Types.CONNECTIONS_COUNT, count, { accountId });
                 }
             } catch (err) {

--- a/packages/metering/package.json
+++ b/packages/metering/package.json
@@ -24,6 +24,7 @@
         "@nangohq/utils": "file:../utils",
         "dd-trace": "5.52.0",
         "node-cron": "3.0.2",
+        "uuidv7": "0.6.3",
         "zod": "4.0.5"
     },
     "devDependencies": {

--- a/packages/records/lib/models/records.ts
+++ b/packages/records/lib/models/records.ts
@@ -1207,8 +1207,10 @@ export async function getCountsByModel({
 
 export async function* paginateCounts({
     environmentIds,
+    connectionIds,
     batchSize = 1000
 }: {
+    connectionIds?: number[];
     environmentIds?: number[];
     batchSize?: number;
 } = {}): AsyncGenerator<Result<RecordCount[]>> {
@@ -1223,6 +1225,10 @@ export async function* paginateCounts({
 
             if (environmentIds && environmentIds.length > 0) {
                 query = query.whereIn('environment_id', environmentIds);
+            }
+
+            if (connectionIds && connectionIds.length > 0) {
+                query = query.whereIn('connection_id', connectionIds);
             }
 
             const results = await query;

--- a/packages/usage/lib/clickhouse/clickhouse.integration.test.ts
+++ b/packages/usage/lib/clickhouse/clickhouse.integration.test.ts
@@ -4,7 +4,7 @@ import { Clickhouse } from './clickhouse.js';
 import { clickhouseClient } from './config.js';
 import { migrate } from './migrate.js';
 
-import type { UsageEvent } from '@nangohq/types';
+import type { ClickhouseRawUsageEvent } from './clickhouse.js';
 
 describe('Clickhouse', () => {
     const database = `usage_test`;
@@ -28,52 +28,67 @@ describe('Clickhouse', () => {
 
         beforeAll(async () => {
             await cleanup();
-            clickhouse.add([
+            clickhouse.addRaw([
                 // proxy
-                ...genEventsN({ n: 10, day: dayFromNow(), type: 'usage.proxy', accountId, properties: { success: true } }),
-                ...genEventsN({ n: 11, day: dayFromNow(1), type: 'usage.proxy', accountId, properties: { success: true } }),
-                ...genEventsN({ n: 1, day: dayFromNow(2), type: 'usage.proxy', accountId, properties: { success: true } }),
-                ...genEventsN({ n: 12, day: dayFromNow(2), type: 'usage.proxy', accountId, properties: { success: false } }), // same day but success: false
-                ...genEventsN({ n: 10, day: dayFromNow(2), type: 'usage.proxy', accountId: 999 }), // different account
-                ...genEventsN({ n: 10, day: dayFromNow(-1), type: 'usage.proxy', accountId }), // out of timeframe
+                ...genEventsN({ n: 10, date: dayFromNow(), type: 'usage.proxy', accountId, attributes: { success: true } }),
+                ...genEventsN({ n: 11, date: dayFromNow(1), type: 'usage.proxy', accountId, attributes: { success: true } }),
+                ...genEventsN({ n: 1, date: dayFromNow(2), type: 'usage.proxy', accountId, attributes: { success: true } }),
+                ...genEventsN({ n: 12, date: dayFromNow(2), type: 'usage.proxy', accountId, attributes: { success: false } }), // same day but success: false
+                ...genEventsN({ n: 10, date: dayFromNow(2), type: 'usage.proxy', accountId: 999 }), // different account
+                ...genEventsN({ n: 10, date: dayFromNow(-1), type: 'usage.proxy', accountId }), // out of timeframe
                 // functions
                 ...genEventsN({
                     n: 1,
-                    day: dayFromNow(),
+                    date: dayFromNow(),
                     type: 'usage.function_executions',
                     accountId,
-                    properties: { type: 'sync', telemetryBag: { durationMs: 10, customLogs: 10, proxyCalls: 10, memoryGb: 3 } }
+                    attributes: { type: 'sync', telemetryBag: { durationMs: 10, customLogs: 10, proxyCalls: 10, memoryGb: 3 } }
                 }),
                 ...genEventsN({
                     n: 1,
-                    day: dayFromNow(1),
+                    date: dayFromNow(1),
                     type: 'usage.function_executions',
                     accountId,
-                    properties: { type: 'sync', telemetryBag: { durationMs: 1000, customLogs: 100, proxyCalls: 100, memoryGb: 3 } }
+                    attributes: { type: 'sync', telemetryBag: { durationMs: 1000, customLogs: 100, proxyCalls: 100, memoryGb: 3 } }
                 }),
                 ...genEventsN({
                     n: 1,
-                    day: dayFromNow(1),
+                    date: dayFromNow(1),
                     type: 'usage.function_executions',
                     accountId,
-                    properties: { type: 'webhook', telemetryBag: { durationMs: 100, customLogs: 10, proxyCalls: 10, memoryGb: 2 } }
+                    attributes: { type: 'webhook', telemetryBag: { durationMs: 100, customLogs: 10, proxyCalls: 10, memoryGb: 2 } }
                 }),
                 ...genEventsN({
                     n: 1,
-                    day: dayFromNow(1),
+                    date: dayFromNow(1),
                     type: 'usage.function_executions',
                     accountId,
-                    properties: { type: 'action', telemetryBag: { durationMs: 100, customLogs: 10, proxyCalls: 10, memoryGb: 0.5 } }
+                    attributes: { type: 'action', telemetryBag: { durationMs: 100, customLogs: 10, proxyCalls: 10, memoryGb: 0.5 } }
                 }),
                 // webhook_forwards
-                ...genEventsN({ n: 3, day: dayFromNow(), type: 'usage.webhook_forward', accountId, properties: { success: true } }),
-                ...genEventsN({ n: 3, day: dayFromNow(), type: 'usage.webhook_forward', accountId, properties: { success: false } }),
-                ...genEventsN({ n: 3, day: dayFromNow(1), type: 'usage.webhook_forward', accountId, properties: { success: true } })
+                ...genEventsN({ n: 3, date: dayFromNow(), type: 'usage.webhook_forward', accountId, attributes: { success: true } }),
+                ...genEventsN({ n: 3, date: dayFromNow(), type: 'usage.webhook_forward', accountId, attributes: { success: false } }),
+                ...genEventsN({ n: 3, date: dayFromNow(1), type: 'usage.webhook_forward', accountId, attributes: { success: true } }),
+                // connections
+                // day 0: average is 70
+                genEvent({ date: dayFromNow(0), type: 'usage.connections', accountId, value: 50 }),
+                genEvent({ date: dayFromNow(0), type: 'usage.connections', accountId, value: 60 }),
+                genEvent({ date: dayFromNow(0), type: 'usage.connections', accountId, value: 100 }),
+                // day 1: average is 10
+                genEvent({ date: dayFromNow(1), type: 'usage.connections', accountId, value: 20 }),
+                genEvent({ date: dayFromNow(1), type: 'usage.connections', accountId, value: 10 }),
+                genEvent({ date: dayFromNow(1), type: 'usage.connections', accountId, value: 0 }),
+                // records
+                genEvent({ date: dayFromNow(0), type: 'usage.records', accountId, value: 1000, attributes: { integrationId: 'a' } }),
+                genEvent({ date: dayFromNow(0), type: 'usage.records', accountId, value: 1100, attributes: { integrationId: 'a' } }),
+                genEvent({ date: dayFromNow(0), type: 'usage.records', accountId, value: 500, attributes: { integrationId: 'b' } }),
+                genEvent({ date: dayFromNow(1), type: 'usage.records', accountId, value: 1100, attributes: { integrationId: 'a' } }),
+                genEvent({ date: dayFromNow(1), type: 'usage.records', accountId, value: 500, attributes: { integrationId: 'b' } })
             ]);
             await clickhouse.flush(); // force flush to make sure all events are ingested before we query
         });
         describe('with no granularity', () => {
-            it('for a single metric', async () => {
+            it('for a periodic metric', async () => {
                 const res = await clickhouse.getUsage({
                     accountId,
                     metrics: { proxy: { dimension: 'none' } },
@@ -93,6 +108,32 @@ describe('Clickhouse', () => {
                             ],
                             total: 34,
                             view_mode: 'periodic'
+                        }
+                    }
+                };
+                expect(res.unwrap()).toStrictEqual(expected);
+            });
+            it('for a cumulative metric', async () => {
+                const res = await clickhouse.getUsage({
+                    accountId,
+                    metrics: { connections: { dimension: 'none' } },
+                    granularity: 'none',
+                    timeframe: { start, end }
+                });
+                const expected = {
+                    accountId: accountId,
+                    granularity: 'none',
+                    metrics: {
+                        connections: {
+                            series: [
+                                {
+                                    // (day0=70 + day1=10) / 7 days = 11
+                                    dataPoints: [{ timeframe: { start, end }, quantity: 11 }],
+                                    total: 11
+                                }
+                            ],
+                            total: 11,
+                            view_mode: 'cumulative'
                         }
                     }
                 };
@@ -204,8 +245,8 @@ describe('Clickhouse', () => {
                         function_logs: { dimension: 'none' },
                         function_compute_gbms: { dimension: 'none' },
                         webhook_forwards: { dimension: 'none' },
-                        records: { dimension: 'connection_id' },
-                        connections: { dimension: 'integration_id' }
+                        connections: { dimension: 'none' },
+                        records: { dimension: 'integration_id' }
                     },
                     granularity: 'day',
                     timeframe: { start, end }
@@ -303,11 +344,46 @@ describe('Clickhouse', () => {
                             ],
                             total: 9,
                             view_mode: 'periodic'
-                        }
-
-                        // TODO:
+                        },
                         // connections
+                        connections: {
+                            series: [
+                                {
+                                    dataPoints: [
+                                        { timeframe: { start: dayFromNow(), end: dayFromNow(1) }, quantity: 70 },
+                                        { timeframe: { start: dayFromNow(1), end: dayFromNow(2) }, quantity: 10 }
+                                    ],
+                                    total: 11
+                                }
+                            ],
+                            total: 11,
+                            view_mode: 'cumulative'
+                        },
                         // records
+                        records: {
+                            series: [
+                                {
+                                    dimension: 'integration_id',
+                                    dimensionValue: 'a',
+                                    dataPoints: [
+                                        { timeframe: { start: dayFromNow(), end: dayFromNow(1) }, quantity: 1050 },
+                                        { timeframe: { start: dayFromNow(1), end: dayFromNow(2) }, quantity: 1100 }
+                                    ],
+                                    total: 307
+                                },
+                                {
+                                    dimension: 'integration_id',
+                                    dimensionValue: 'b',
+                                    dataPoints: [
+                                        { timeframe: { start: dayFromNow(), end: dayFromNow(1) }, quantity: 500 },
+                                        { timeframe: { start: dayFromNow(1), end: dayFromNow(2) }, quantity: 500 }
+                                    ],
+                                    total: 143
+                                }
+                            ],
+                            total: 450,
+                            view_mode: 'cumulative'
+                        }
                     }
                 };
                 expect(res.unwrap()).toStrictEqual(expected);
@@ -324,42 +400,44 @@ function dayFromNow(dayOffset = 0): Date {
 }
 
 const rnd = {
-    datetime: (d: Date) => {
-        return new Date(d.getTime() + Math.floor(Math.random() * 24 * 60 * 60 * 1000));
-    },
-    number: () => Math.floor(Math.random() * 1000),
-    string: () => Math.random().toString(36).substring(6)
+    number: (exclusiveMax: number = 1000) => Math.floor(Math.random() * exclusiveMax),
+    string: () => Math.random().toString(36).substring(6),
+    time(date: Date): Date {
+        date.setHours(rnd.number(24), rnd.number(60), rnd.number(60), 0);
+        return date;
+    }
 };
 
 function genEventsN({
     n,
-    day,
+    date,
     type,
     accountId,
-    properties = {}
+    attributes = {}
 }: {
     n: number;
-    day: Date;
-    type: UsageEvent['type'];
-    accountId: UsageEvent['payload']['properties']['accountId'];
-    properties?: Partial<UsageEvent['payload']['properties']>;
-}): UsageEvent[] {
-    return Array.from({ length: n }).map((_) => genEvent({ day, type, accountId, properties }));
+    date: Date;
+    type: ClickhouseRawUsageEvent['type'];
+    accountId: ClickhouseRawUsageEvent['account_id'];
+    attributes?: Partial<ClickhouseRawUsageEvent['attributes']>;
+}): ClickhouseRawUsageEvent[] {
+    return Array.from({ length: n }).map((_) => genEvent({ date, type, accountId, attributes }));
 }
 
 function genEvent({
-    day,
+    date,
     type,
     accountId,
-    properties
+    value = 1,
+    attributes = {}
 }: {
-    day: Date;
-    type: UsageEvent['type'];
-    accountId: UsageEvent['payload']['properties']['accountId'];
-    properties: Partial<UsageEvent['payload']['properties']>;
-}): UsageEvent {
-    const baseProperties = {
-        accountId,
+    date: Date;
+    type: ClickhouseRawUsageEvent['type'];
+    accountId: ClickhouseRawUsageEvent['account_id'];
+    value?: number;
+    attributes?: Partial<ClickhouseRawUsageEvent['attributes']>;
+}): ClickhouseRawUsageEvent {
+    const baseAttributes = {
         environmentId: 1,
         environmentName: 'test',
         integrationId: 'test',
@@ -368,123 +446,84 @@ function genEvent({
     switch (type) {
         case 'usage.proxy':
             return {
-                createdAt: rnd.datetime(day),
-                subject: 'usage',
+                ts: date.getTime(),
                 type,
-                idempotencyKey: rnd.string(),
-                payload: {
-                    value: 1,
-                    properties: {
-                        success: true,
-                        ...baseProperties,
-                        ...properties
-                    }
+                idempotency_key: rnd.string(),
+                account_id: accountId,
+                value,
+                attributes: {
+                    success: true,
+                    ...baseAttributes,
+                    ...attributes
                 }
             };
 
         case 'usage.function_executions':
             return {
-                createdAt: rnd.datetime(day),
-                subject: 'usage',
+                ts: date.getTime(),
                 type,
-                idempotencyKey: rnd.string(),
-                payload: {
-                    value: 1,
-                    properties: {
-                        ...baseProperties,
-                        type: 'sync',
-                        functionName: 'test',
-                        telemetryBag: {
-                            durationMs: 1,
-                            customLogs: 1,
-                            proxyCalls: 1,
-                            memoryGb: 1
-                        },
-                        runtime: 'lambda',
-                        success: true,
-                        ...properties
-                    }
+                idempotency_key: rnd.string(),
+                account_id: accountId,
+                value,
+                attributes: {
+                    ...baseAttributes,
+                    type: 'sync',
+                    functionName: 'test',
+                    telemetryBag: {
+                        durationMs: 1,
+                        customLogs: 1,
+                        proxyCalls: 1,
+                        memoryGb: 1
+                    },
+                    runtime: 'lambda',
+                    success: true,
+                    ...attributes
                 }
             };
 
         case 'usage.webhook_forward':
             return {
-                createdAt: rnd.datetime(day),
-                subject: 'usage',
+                ts: date.getTime(),
                 type,
-                idempotencyKey: rnd.string(),
-                payload: {
-                    value: 1,
-                    properties: {
-                        ...baseProperties,
-                        success: true,
-                        ...properties
-                    }
+                idempotency_key: rnd.string(),
+                account_id: accountId,
+
+                value,
+                attributes: {
+                    ...baseAttributes,
+                    success: true,
+                    ...attributes
                 }
             };
 
         case 'usage.records':
             return {
-                createdAt: rnd.datetime(day),
-                subject: 'usage',
+                ts: date.getTime(),
                 type,
-                idempotencyKey: rnd.string(),
-                payload: {
-                    value: 1,
-                    properties: {
-                        ...baseProperties,
-                        syncId: rnd.string(),
-                        model: 'test',
-                        ...properties
-                    }
+                idempotency_key: rnd.string(),
+                account_id: accountId,
+                value,
+                attributes: {
+                    ...baseAttributes,
+                    model: 'test',
+                    ...attributes
                 }
             };
 
         case 'usage.connections':
             return {
-                createdAt: rnd.datetime(day),
-                subject: 'usage',
+                ts: date.getTime(),
                 type,
-                idempotencyKey: rnd.string(),
-                payload: {
-                    value: 1,
-                    properties: {
-                        ...baseProperties,
-                        ...properties
-                    }
+                idempotency_key: rnd.string(),
+                account_id: accountId,
+                value,
+                attributes: {
+                    ...baseAttributes,
+                    ...attributes
                 }
             };
 
-        case 'usage.actions':
-            return {
-                createdAt: rnd.datetime(day),
-                subject: 'usage',
-                type,
-                idempotencyKey: rnd.string(),
-                payload: {
-                    value: 1,
-                    properties: {
-                        ...baseProperties,
-                        actionName: 'test',
-                        ...properties
-                    }
-                }
-            };
-
-        case 'usage.monthly_active_records':
-            return {
-                createdAt: rnd.datetime(day),
-                subject: 'usage',
-                type,
-                idempotencyKey: rnd.string(),
-                payload: {
-                    value: 1,
-                    properties: {
-                        ...baseProperties,
-                        model: 'test',
-                        syncId: 'test'
-                    }
-                }
-            };
+        default:
+            throw new Error(`Unsupported event type ${type}`);
     }
 }

--- a/packages/usage/lib/clickhouse/clickhouse.query.ts
+++ b/packages/usage/lib/clickhouse/clickhouse.query.ts
@@ -92,9 +92,9 @@ export function tableForMetric(metric: UsageMetric): string {
         case 'webhook_forwards':
             return `daily_webhook_forwards`;
         case 'records':
+            return `daily_records`;
         case 'connections':
-            // not implemented yet
-            return '';
+            return `daily_connections`;
     }
 }
 
@@ -110,7 +110,6 @@ export function quantityForMetric(metric: UsageMetric): string {
             return `SUM(duration_ms * memory_gb)`;
         case 'records':
         case 'connections':
-            // not implemented yet
-            return '';
+            return `avgMerge(value)`;
     }
 }

--- a/packages/usage/lib/clickhouse/clickhouse.query.ts
+++ b/packages/usage/lib/clickhouse/clickhouse.query.ts
@@ -1,19 +1,19 @@
 import type { UsageEvent, UsageMetric } from '@nangohq/types';
 
 interface GetUsageQueryMetricDimensions<TDimension extends string = 'none'> {
-    dimension: 'none' | 'environment_id' | 'integration_id' | 'connection_id' | TDimension;
+    dimension: 'none' | 'environment_id' | 'integration_id' | TDimension;
 }
 
 type ValidateMetrics<T extends Record<UsageMetric, unknown> & Record<Exclude<keyof T, UsageMetric>, never>> = T;
 
 type GetUsageQueryMetrics = ValidateMetrics<{
     connections: GetUsageQueryMetricDimensions;
-    records: GetUsageQueryMetricDimensions<'model'>;
-    proxy: GetUsageQueryMetricDimensions<'success'>;
-    webhook_forwards: GetUsageQueryMetricDimensions<'success'>;
-    function_executions: GetUsageQueryMetricDimensions<'function_name' | 'function_type' | 'success'>;
-    function_logs: GetUsageQueryMetricDimensions<'function_name' | 'function_type' | 'success'>;
-    function_compute_gbms: GetUsageQueryMetricDimensions<'function_name' | 'function_type' | 'success'>;
+    records: GetUsageQueryMetricDimensions<'connection_id' | 'model'>;
+    proxy: GetUsageQueryMetricDimensions<'connection_id' | 'success'>;
+    webhook_forwards: GetUsageQueryMetricDimensions<'connection_id' | 'success'>;
+    function_executions: GetUsageQueryMetricDimensions<'connection_id' | 'function_name' | 'function_type' | 'success'>;
+    function_logs: GetUsageQueryMetricDimensions<'connection_id' | 'function_name' | 'function_type' | 'success'>;
+    function_compute_gbms: GetUsageQueryMetricDimensions<'connection_id' | 'function_name' | 'function_type' | 'success'>;
 }>;
 export interface GetUsageQuery {
     accountId: UsageEvent['payload']['properties']['accountId'];

--- a/packages/usage/lib/clickhouse/clickhouse.ts
+++ b/packages/usage/lib/clickhouse/clickhouse.ts
@@ -6,10 +6,23 @@ import { logger } from '../logger.js';
 import { granularityGroupBy, granularityOrderBy, quantityForMetric, startSelect, tableForMetric } from './clickhouse.query.js';
 
 import type { GetUsageQuery, GetUsageResult, GetUsageResultSeries } from './clickhouse.query.js';
-import type { UsageEvent, UsageMetric } from '@nangohq/types';
+import type { UsageActionsEvent, UsageConnectionsEvent, UsageEvent, UsageFunctionExecutionsEvent, UsageMetric, UsageRecordsEvent } from '@nangohq/types';
 import type { Result } from '@nangohq/utils';
 
 const envs = parseEnvs(ENVS);
+
+// Exclude accountId, which is already a top-level column, and environmentName which is not needed for usage metrics
+type UsageAttrs<E extends { payload: { properties: object } }, K extends string = never> = Omit<
+    E['payload']['properties'],
+    'accountId' | 'environmentName' | K
+>;
+
+type ClickhouseRawUsageEventAttrs =
+    | UsageAttrs<UsageFunctionExecutionsEvent>
+    | UsageAttrs<UsageConnectionsEvent, 'connectionId'>
+    | UsageAttrs<UsageActionsEvent>
+    | UsageAttrs<UsageEvent>
+    | UsageAttrs<UsageRecordsEvent, 'syncId'>;
 
 export interface ClickhouseRawUsageEvent {
     ts: number; // Unix timestamp in milliseconds, matches DateTime64(3)
@@ -17,7 +30,7 @@ export interface ClickhouseRawUsageEvent {
     type: UsageEvent['type'];
     value: UsageEvent['payload']['value'];
     account_id: UsageEvent['payload']['properties']['accountId'];
-    attributes: Omit<UsageEvent['payload']['properties'], 'accountId'>;
+    attributes: ClickhouseRawUsageEventAttrs;
 }
 
 export class Clickhouse {
@@ -57,11 +70,18 @@ export class Clickhouse {
         if (!this.batcher) {
             return Ok(undefined);
         }
-        const rows = events.flatMap((event) => {
-            const row = toRow(event);
-            return row && row.value > 0 ? [row] : [];
+        const raws = events.flatMap((event) => {
+            const raw = toRaw(event);
+            return raw ? [raw] : [];
         });
-        return this.batcher.add(...rows);
+        return this.batcher.add(...raws);
+    }
+
+    addRaw(events: ClickhouseRawUsageEvent[]): Result<void> {
+        if (!this.batcher) {
+            return Ok(undefined);
+        }
+        return this.batcher.add(...events);
     }
 
     flush(): Promise<Result<void>> {
@@ -113,9 +133,62 @@ export class Clickhouse {
                         };
                     }
                     case 'records':
-                    case 'connections':
-                        // not implemented yet
-                        return undefined;
+                    case 'connections': {
+                        // Gauge metrics (ie: snapshot emitted at interval)
+                        // Quantity is considered to be the average of all snapshots for a given day
+                        // Two-level query to correctly aggregate across sub-groups:
+                        //   inner: avgMerge accross all dimensions ORDER BY key
+                        //   outer: SUM per requested dimension: avg(A)+avg(B) = avg(A+B)
+                        const innerGroupBy = (() => {
+                            switch (metric) {
+                                case 'records':
+                                    return `account_id, day, environment_id, integration_id, connection_id, model`;
+                                case 'connections':
+                                    return `account_id, day, environment_id, integration_id`;
+                            }
+                        })();
+                        const startDate = query.timeframe.start.toISOString().split('T')[0];
+                        const endDate = query.timeframe.end.toISOString().split('T')[0];
+                        const quantityExpr = (() => {
+                            switch (query.granularity) {
+                                case 'none':
+                                    return `ROUND(SUM(avg_val) / dateDiff('day', toDate('${startDate}'), toDate('${endDate}')))`;
+                                case 'day':
+                                    return `ROUND(SUM(avg_val))`;
+                            }
+                        })();
+                        const sql = `
+                            SELECT
+                                ${quantityExpr} AS quantity,
+                                ${startSelect(query)}
+                                ${dimensionSelect} AS dimension
+                            FROM (
+                                SELECT
+                                    avgMerge(value) AS avg_val,
+                                    ${innerGroupBy}
+                                FROM ${this.database}.${tableForMetric(metric)}
+                                WHERE account_id = ${query.accountId}
+                                AND day >= toDate('${startDate}')
+                                AND day < toDate('${endDate}')
+                                GROUP BY ${innerGroupBy}
+                            )
+                            GROUP BY account_id ${granularityGroupBy(query)} ${dimensionGroupBy}
+                            ORDER BY account_id ${granularityOrderBy(query)} ${dimensionOrderBy}
+                        `;
+                        const res = await this.client?.query({ query: sql, format: 'JSONEachRow' });
+                        return {
+                            accountId: query.accountId,
+                            metric,
+                            dimension,
+                            rows: (await res?.json()) as {
+                                quantity: number;
+                                start: string;
+                                end: string;
+                                dimension: string;
+                            }[],
+                            viewMode: 'cumulative' as const
+                        };
+                    }
                 }
             });
             const results = await Promise.allSettled(qs);
@@ -145,12 +218,21 @@ export class Clickhouse {
                         });
                     }
 
+                    const shouldProrate = viewMode === 'cumulative' && query.granularity === 'day';
+                    const timeframeDays = shouldProrate ? (query.timeframe.end.getTime() - query.timeframe.start.getTime()) / (1000 * 60 * 60 * 24) : 1;
+
                     // sort series by dimension value for consistent ordering
                     const series = Object.entries(seriesMap)
                         .sort(([a], [b]) => a.localeCompare(b))
-                        .map(([, value]) => value);
+                        .map(([, value]) => {
+                            if (shouldProrate) {
+                                value.total = Math.round(value.total / timeframeDays);
+                            }
+                            return value;
+                        });
 
-                    const total = rows.reduce((sum, row) => sum + row.quantity, 0);
+                    const seriesTotal = rows.reduce((sum, row) => sum + row.quantity, 0);
+                    const total = shouldProrate ? Math.round(seriesTotal / timeframeDays) : seriesTotal;
 
                     usage.metrics[metric] = {
                         series,
@@ -180,7 +262,7 @@ export class Clickhouse {
     }
 }
 
-function toRow(event: UsageEvent): ClickhouseRawUsageEvent | null {
+function toRaw(event: UsageEvent): ClickhouseRawUsageEvent | null {
     switch (event.type) {
         case 'usage.monthly_active_records':
         case 'usage.actions':

--- a/packages/usage/lib/clickhouse/clickhouse.ts
+++ b/packages/usage/lib/clickhouse/clickhouse.ts
@@ -152,7 +152,7 @@ export class Clickhouse {
                         const quantityExpr = (() => {
                             switch (query.granularity) {
                                 case 'none':
-                                    return `ROUND(SUM(avg_val) / dateDiff('day', toDate('${startDate}'), toDate('${endDate}')))`;
+                                    return `ROUND(SUM(avg_val) / GREATEST(1, dateDiff('day', toDate('${startDate}'), toDate('${endDate}'))))`;
                                 case 'day':
                                     return `ROUND(SUM(avg_val))`;
                             }
@@ -219,7 +219,9 @@ export class Clickhouse {
                     }
 
                     const shouldProrate = viewMode === 'cumulative' && query.granularity === 'day';
-                    const timeframeDays = shouldProrate ? (query.timeframe.end.getTime() - query.timeframe.start.getTime()) / (1000 * 60 * 60 * 24) : 1;
+                    const timeframeDays = shouldProrate
+                        ? Math.max(1, (query.timeframe.end.getTime() - query.timeframe.start.getTime()) / (1000 * 60 * 60 * 24))
+                        : 1;
 
                     // sort series by dimension value for consistent ordering
                     const series = Object.entries(seriesMap)

--- a/packages/usage/lib/clickhouse/migrations/20260416000006_create_daily_records.ts
+++ b/packages/usage/lib/clickhouse/migrations/20260416000006_create_daily_records.ts
@@ -1,0 +1,33 @@
+export const sql = [
+    `
+    CREATE TABLE IF NOT EXISTS {database:Identifier}.daily_records
+    (
+        day              Date,
+        account_id       Int64,
+        environment_id   Int64,
+        integration_id   LowCardinality(String),
+        connection_id    String,
+        model            LowCardinality(String),
+        value            AggregateFunction(avg, Int64)
+    )
+    ENGINE = AggregatingMergeTree()
+    PARTITION BY toYYYYMM(day)
+    ORDER BY (account_id, day, environment_id, integration_id, connection_id, model)
+    TTL day + INTERVAL 24 MONTH
+    `,
+    `
+    CREATE MATERIALIZED VIEW IF NOT EXISTS {database:Identifier}.daily_records_mv
+    TO {database:Identifier}.daily_records AS
+    SELECT
+        toDate(ts)                          AS day,
+        account_id,
+        attributes.environmentId::Int64     AS environment_id,
+        attributes.integrationId::String    AS integration_id,
+        attributes.connectionId::String     AS connection_id,
+        attributes.model::String            AS model,
+        avgState(value::Int64)              AS value
+    FROM {database:Identifier}.raw_events
+    WHERE type = 'usage.records'
+    GROUP BY day, account_id, environment_id, integration_id, connection_id, model
+    `
+];

--- a/packages/usage/lib/clickhouse/migrations/20260416000007_create_daily_connections.ts
+++ b/packages/usage/lib/clickhouse/migrations/20260416000007_create_daily_connections.ts
@@ -1,0 +1,29 @@
+export const sql = [
+    `
+    CREATE TABLE IF NOT EXISTS {database:Identifier}.daily_connections
+    (
+        day              Date,
+        account_id       Int64,
+        environment_id   Int64,
+        integration_id   LowCardinality(String),
+        value            AggregateFunction(avg, Int64)
+    )
+    ENGINE = AggregatingMergeTree()
+    PARTITION BY toYYYYMM(day)
+    ORDER BY (account_id, day, environment_id, integration_id)
+    TTL day + INTERVAL 24 MONTH
+    `,
+    `
+    CREATE MATERIALIZED VIEW IF NOT EXISTS {database:Identifier}.daily_connections_mv
+    TO {database:Identifier}.daily_connections AS
+    SELECT
+        toDate(ts)                          AS day,
+        account_id,
+        attributes.environmentId::Int64     AS environment_id,
+        attributes.integrationId::String    AS integration_id,
+        avgState(value::Int64)              AS value
+    FROM {database:Identifier}.raw_events
+    WHERE type = 'usage.connections'
+    GROUP BY day, account_id, environment_id, integration_id
+    `
+];

--- a/packages/usage/lib/index.ts
+++ b/packages/usage/lib/index.ts
@@ -6,6 +6,7 @@ import type { IUsageTracker } from './usage.js';
 
 export type { IUsageTracker as Usage } from './usage.js';
 export { Capping } from './capping.js';
+export type { ClickhouseRawUsageEvent } from './clickhouse/clickhouse.js';
 export { Clickhouse } from './clickhouse/clickhouse.js';
 export { migrate } from './clickhouse/migrate.js';
 


### PR DESCRIPTION
- ingest connections and records snapshot data
- add materialized views for records and connections metrics
- add support for records and connections metric in clickhouse querying

Note: records and connections metrics are calculated the same way we do with Orb today, averaging all the ingested value across a day (assuming the ingestion interval is regular, given all ingested value the same weight)

<!-- Describe the problem and your solution --> 

<!-- Issue ticket number and link (if applicable) -->

<!-- Testing instructions (skip if just adding/editing providers) -->

