### PR TITLE
feat: add `code_source` to `sync_config` (migration)

### DIFF
--- a/packages/database/lib/migrations/20260417120000_sync_config_code_source.cjs
+++ b/packages/database/lib/migrations/20260417120000_sync_config_code_source.cjs
@@ -1,0 +1,33 @@
+exports.config = { transaction: false };
+
+/**
+ * @param {import('knex').Knex} knex
+ */
+exports.up = async function (knex) {
+    // Create enum type
+    await knex.raw(`DO $$
+        BEGIN
+            CREATE TYPE sync_config_code_source AS ENUM (
+                'nango',
+                'repo'
+            );
+        EXCEPTION
+            WHEN duplicate_object THEN
+                NULL;
+        END
+        $$`);
+    // Add column
+    await knex.raw(`ALTER TABLE _nango_sync_configs ADD COLUMN IF NOT EXISTS code_source sync_config_code_source NOT NULL DEFAULT 'repo'`);
+    // Backfill
+    await knex.raw(`UPDATE _nango_sync_configs SET code_source = 'nango' WHERE pre_built = true OR is_public = true`);
+    // Drop default value
+    await knex.raw(`ALTER TABLE _nango_sync_configs ALTER COLUMN code_source DROP DEFAULT`);
+};
+
+/**
+ * @param {import('knex').Knex} knex
+ */
+exports.down = async function (knex) {
+    await knex.raw(`ALTER TABLE _nango_sync_configs DROP COLUMN IF EXISTS code_source`);
+    await knex.raw(`DROP TYPE IF EXISTS sync_config_code_source`);
+};

--- a/packages/types/lib/flow/index.ts
+++ b/packages/types/lib/flow/index.ts
@@ -1,6 +1,6 @@
 import type { LegacySyncModelSchema, NangoConfigMetadata } from '../deploy/incomingFlow.js';
 import type { NangoModel, NangoSyncEndpointV2, ScriptTypeLiteral, SyncTypeLiteral } from '../nangoYaml/index.js';
-import type { Feature } from '../syncConfigs/db.js';
+import type { CodeSource, Feature } from '../syncConfigs/db.js';
 import type { JSONSchema7 } from 'json-schema';
 
 // TODO: Split by type
@@ -18,6 +18,7 @@ export interface NangoSyncConfig {
     endpoints: NangoSyncEndpointV2[];
     is_public?: boolean | null;
     pre_built?: boolean | null;
+    code_source?: CodeSource | null;
     version?: string | null;
     last_deployed?: string | null;
     id?: number;

--- a/packages/types/lib/syncConfigs/db.ts
+++ b/packages/types/lib/syncConfigs/db.ts
@@ -5,6 +5,8 @@ import type { JSONSchema7 } from 'json-schema';
 
 export type Feature = 'checkpoints';
 
+export type CodeSource = 'nango' | 'repo';
+
 export interface DBSyncConfig extends TimestampsAndDeleted {
     id: number;
     sync_name: string;
@@ -22,6 +24,7 @@ export interface DBSyncConfig extends TimestampsAndDeleted {
     attributes: object;
     pre_built: boolean;
     is_public: boolean;
+    code_source: CodeSource;
     metadata: NangoConfigMetadata;
     input: string | null;
     /** @deprecated **/


### PR DESCRIPTION
Aimed to replace `is_public` and `pre_built`, which are booleans used interchangeably (if you know the reason for `is_public` let me know, but as far as I've seen they always have the same value). This PR is just the migration, usage coming in next one.