### PR TITLE
feat: classify `standalone` deploys

### DIFF
--- a/packages/cli/lib/zeroYaml/deploy.ts
+++ b/packages/cli/lib/zeroYaml/deploy.ts
@@ -105,6 +105,7 @@ export async function deploy({
         return Err('failed');
     }
 
+    const deploySource = resolveDeploySource();
     const autoconfirm = process.env['NANGO_DEPLOY_AUTO_CONFIRM'] === 'true' || options.autoConfirm;
     const confirmed = await handleConfirmation({ autoconfirm, allowDestructive: options.allowDestructive || false, confirmation });
     if (confirmed.isErr()) {
@@ -118,7 +119,7 @@ export async function deploy({
     try {
         const deployRes = await postDeploy({
             hostport,
-            body: { ...pkg, reconcile: true, debug, nangoYamlBody, sdkVersion }
+            body: { ...pkg, reconcile: true, debug, nangoYamlBody, sdkVersion, source: deploySource }
         });
         if (deployRes.isErr()) {
             spinnerDeploy.fail();
@@ -630,4 +631,9 @@ function summaryMessageColumns({ name, newItems, updatedItems, deleteItems }: { 
 }
 function shortSummaryMessage({ name, newItems, deleteItems }: { name: string; newItems: any[]; deleteItems: any[] }): string {
     return ` [${name} ${chalk.green(`+${newItems.length}`)} ${chalk.red(`-${deleteItems.length}`)}]`;
+}
+
+function resolveDeploySource(): 'standalone' | 'repo' {
+    const val = process.env['NANGO_DEPLOY_SOURCE'];
+    return val === 'standalone' ? 'standalone' : 'repo';
 }

--- a/packages/server/lib/controllers/functions/deploy/postDeploy.ts
+++ b/packages/server/lib/controllers/functions/deploy/postDeploy.ts
@@ -39,7 +39,8 @@ export const postRemoteFunctionDeploy = asyncWrapper<PostRemoteFunctionDeploy>(a
         name: body.function_name,
         isAction: body.function_type === 'action'
     });
-    if (existingSyncConfig && existingSyncConfig.source === 'catalog') {
+
+    if (existingSyncConfig && existingSyncConfig.source !== 'standalone') {
         res.status(400).send({
             error: {
                 code: 'invalid_request',

--- a/packages/server/lib/controllers/sync/deploy/postDeploy.ts
+++ b/packages/server/lib/controllers/sync/deploy/postDeploy.ts
@@ -64,7 +64,7 @@ export const postDeploy = asyncWrapper<PostDeploy>(async (req, res) => {
         logContextGetter,
         sdkVersion: body.sdkVersion,
         orchestrator,
-        source: 'repo'
+        source: body.source ?? ('repo' as const)
     });
 
     if (plan && !plan.trial_end_at && plan.auto_idle) {

--- a/packages/server/lib/controllers/sync/deploy/validation.ts
+++ b/packages/server/lib/controllers/sync/deploy/validation.ts
@@ -158,7 +158,8 @@ const commonValidation = z
         sdkVersion: z
             .string()
             .regex(/[0-9]+\.[0-9]+\.[0-9]+-(zero|yaml)/)
-            .optional()
+            .optional(),
+        source: z.enum(['standalone', 'repo']).optional()
     })
     .strict();
 

--- a/packages/server/lib/services/local/deploy-client.ts
+++ b/packages/server/lib/services/local/deploy-client.ts
@@ -33,6 +33,8 @@ export async function invokeLocalDeploy(request: DeployRequest): Promise<DeployR
                 'NO_COLOR=1',
                 '-e',
                 'NANGO_DEPLOY_AUTO_CONFIRM=true',
+                '-e',
+                'NANGO_DEPLOY_SOURCE=standalone',
                 '--add-host',
                 'host.docker.internal:host-gateway',
                 remoteFunctionLocalImage,

--- a/packages/server/lib/services/remote-function/deploy-client.ts
+++ b/packages/server/lib/services/remote-function/deploy-client.ts
@@ -54,7 +54,8 @@ export async function invokeDeploy(request: DeployRequest): Promise<DeployResult
             NO_COLOR: '1',
             NANGO_SECRET_KEY: request.nango_secret_key,
             NANGO_HOSTPORT: request.nango_host,
-            NANGO_DEPLOY_AUTO_CONFIRM: 'true'
+            NANGO_DEPLOY_AUTO_CONFIRM: 'true',
+            NANGO_DEPLOY_SOURCE: 'standalone'
         };
         const command = buildShellCommand(['nango', ...buildDeployArgs(request)]);
 

--- a/packages/types/lib/deploy/api.ts
+++ b/packages/types/lib/deploy/api.ts
@@ -2,6 +2,7 @@ import type { ApiError, Endpoint } from '../api.js';
 import type { CLIDeployFlowConfig, OnEventScriptsByProvider } from './incomingFlow.js';
 import type { SyncDeploymentResult } from './index.js';
 import type { OnEventType } from '../scripts/on-events/api.js';
+import type { FunctionSource } from '../syncConfigs/db.js';
 import type { JSONSchema7 } from 'json-schema';
 
 export type PostDeployConfirmation = Endpoint<{
@@ -33,6 +34,7 @@ export type PostDeploy = Endpoint<{
         /** @deprecated Use CLIDeployFlowConfig.models_json_schema */
         jsonSchema?: JSONSchema7 | undefined;
         sdkVersion?: string | undefined;
+        source?: FunctionSource | undefined;
     };
     Success: SyncDeploymentResult[];
 }>;


### PR DESCRIPTION
Assuming the "standalone" term I made up is accepted, classify functions deployed from the `/remote-function/deploy` endpoint as "standalone". Done by adding an optional `source` property to `postDeploy`'s body, and making so the CLI reads an optional `NANGO_DEPLOY_SOURCE` env var to send it as `standalone`. The sandbox is injected with that flag.