### PR TITLE
feat: add cache hit rate metric for secret key hash cache

### DIFF
--- a/packages/shared/lib/services/account.service.ts
+++ b/packages/shared/lib/services/account.service.ts
@@ -286,7 +286,10 @@ class AccountService {
             // Hashing is slow by design so it's very slow to recompute this hash all the time
             // We keep the hash in-memory to not compromise on security if the db leak
             hash = hashLocalCache.get(opts.secretKey);
-            if (!hash) {
+            if (hash) {
+                metrics.increment(metrics.Types.AUTH_SECRET_KEY_HASH_CACHE, 1, { result: 'hit' });
+            } else {
+                metrics.increment(metrics.Types.AUTH_SECRET_KEY_HASH_CACHE, 1, { result: 'miss' });
                 const hashed = await secretService.hashSecret(opts.secretKey);
                 if (hashed.isErr()) {
                     throw hashed.error;

--- a/packages/utils/lib/telemetry/metrics.ts
+++ b/packages/utils/lib/telemetry/metrics.ts
@@ -5,6 +5,7 @@ export enum Types {
 
     ACTION_INCOMING_PAYLOAD_SIZE_BYTES = 'nango.action.incoming.payloadSizeBytes',
 
+    AUTH_SECRET_KEY_HASH_CACHE = 'nango.auth.secretKeyHashCache',
     AUTH_GET_ENV_BY_CONNECT_SESSION = 'nango.auth.getEnvByConnectSession',
     AUTH_GET_ENV_BY_SECRET_KEY = 'nango.auth.getEnvBySecretKey',
     AUTH_GET_ENV_BY_CONNECT_SESSION_OR_SECRET_KEY = 'nango.auth.getEnvByConnectSessionOrSecretKey',


### PR DESCRIPTION
Track hit/miss ratio of the in-memory PBKDF2 hash cache used during secret key authentication. The cache avoids expensive rehashing on every request — this metric helps monitor its effectiveness.

<!-- Describe the problem and your solution --> 

<!-- Issue ticket number and link (if applicable) -->

<!-- Testing instructions (skip if just adding/editing providers) -->

