### PR TITLE
feat(feature-flags): add unleash openfeature client

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -44,6 +44,7 @@ COPY packages/billing/package.json ./packages/billing/package.json
 COPY packages/pubsub/package.json ./packages/pubsub/package.json
 COPY packages/usage/package.json ./packages/usage/package.json
 COPY packages/email/package.json ./packages/email/package.json
+COPY packages/feature-flags/package.json ./packages/feature-flags/package.json
 COPY packages/metering/package.json ./packages/metering/package.json
 COPY package*.json  ./
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -46,6 +46,7 @@ COPY packages/billing/package.json ./packages/billing/package.json
 COPY packages/pubsub/package.json ./packages/pubsub/package.json
 COPY packages/usage/package.json ./packages/usage/package.json
 COPY packages/email/package.json ./packages/email/package.json
+COPY packages/feature-flags/package.json ./packages/feature-flags/package.json
 COPY packages/metering/package.json ./packages/metering/package.json
 COPY package*.json  ./
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -4999,6 +4999,10 @@
             "resolved": "packages/email",
             "link": true
         },
+        "node_modules/@nangohq/feature-flags": {
+            "resolved": "packages/feature-flags",
+            "link": true
+        },
         "node_modules/@nangohq/fleet": {
             "resolved": "packages/fleet",
             "link": true
@@ -5148,6 +5152,40 @@
             },
             "engines": {
                 "node": ">= 8"
+            }
+        },
+        "node_modules/@npmcli/agent": {
+            "version": "2.2.2",
+            "resolved": "https://registry.npmjs.org/@npmcli/agent/-/agent-2.2.2.tgz",
+            "integrity": "sha512-OrcNPXdpSl9UX7qPVRWbmWMCSXrcDa2M9DvrbOTj7ao1S4PlqVFYv9/yLKMkrJKZ/V5A/kDBC690or307i26Og==",
+            "license": "ISC",
+            "dependencies": {
+                "agent-base": "^7.1.0",
+                "http-proxy-agent": "^7.0.0",
+                "https-proxy-agent": "^7.0.1",
+                "lru-cache": "^10.0.1",
+                "socks-proxy-agent": "^8.0.3"
+            },
+            "engines": {
+                "node": "^16.14.0 || >=18.0.0"
+            }
+        },
+        "node_modules/@npmcli/agent/node_modules/lru-cache": {
+            "version": "10.4.3",
+            "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-10.4.3.tgz",
+            "integrity": "sha512-JNAzZcXrCt42VGLuYz0zfAzDfAvJWW6AfYlDBQyDV5DClI2m5sAmK+OIO7s59XfsRsWHp02jAJrRadPRGTt6SQ==",
+            "license": "ISC"
+        },
+        "node_modules/@npmcli/fs": {
+            "version": "3.1.1",
+            "resolved": "https://registry.npmjs.org/@npmcli/fs/-/fs-3.1.1.tgz",
+            "integrity": "sha512-q9CRWjpHCMIh5sVyefoD1cA7PkvILqCZsnSOEUUivORLjxCO/Irmue2DprETiNgEqktDBZaM1Bi+jrarx1XdCg==",
+            "license": "ISC",
+            "dependencies": {
+                "semver": "^7.3.5"
+            },
+            "engines": {
+                "node": "^14.17.0 || ^16.13.0 || >=18.0.0"
             }
         },
         "node_modules/@opencode-ai/sdk": {
@@ -18195,6 +18233,28 @@
                 "node": ">= 8.0.0"
             }
         },
+        "node_modules/aggregate-error": {
+            "version": "3.1.0",
+            "resolved": "https://registry.npmjs.org/aggregate-error/-/aggregate-error-3.1.0.tgz",
+            "integrity": "sha512-4I7Td01quW/RpocfNayFdFVk1qSuoh0E7JrbRJ16nH01HhKFQ88INq9Sd+nd72zqRySlr9BmDA8xlEJ6vJMrYA==",
+            "license": "MIT",
+            "dependencies": {
+                "clean-stack": "^2.0.0",
+                "indent-string": "^4.0.0"
+            },
+            "engines": {
+                "node": ">=8"
+            }
+        },
+        "node_modules/aggregate-error/node_modules/indent-string": {
+            "version": "4.0.0",
+            "resolved": "https://registry.npmjs.org/indent-string/-/indent-string-4.0.0.tgz",
+            "integrity": "sha512-EdDDZu4A2OyIK7Lr/2zG+w5jmbuk1DVBnEwREQvBzspBJkCEbRa8GxU1lghYcaGJCnRWibjDXlq779X1/y5xwg==",
+            "license": "MIT",
+            "engines": {
+                "node": ">=8"
+            }
+        },
         "node_modules/ajv": {
             "version": "6.14.0",
             "resolved": "https://registry.npmjs.org/ajv/-/ajv-6.14.0.tgz",
@@ -19841,6 +19901,180 @@
                 "node": ">=8"
             }
         },
+        "node_modules/cacache": {
+            "version": "18.0.4",
+            "resolved": "https://registry.npmjs.org/cacache/-/cacache-18.0.4.tgz",
+            "integrity": "sha512-B+L5iIa9mgcjLbliir2th36yEwPftrzteHYujzsx3dFP/31GCHcIeS8f5MGd80odLOjaOvSpU3EEAmRQptkxLQ==",
+            "license": "ISC",
+            "dependencies": {
+                "@npmcli/fs": "^3.1.0",
+                "fs-minipass": "^3.0.0",
+                "glob": "^10.2.2",
+                "lru-cache": "^10.0.1",
+                "minipass": "^7.0.3",
+                "minipass-collect": "^2.0.1",
+                "minipass-flush": "^1.0.5",
+                "minipass-pipeline": "^1.2.4",
+                "p-map": "^4.0.0",
+                "ssri": "^10.0.0",
+                "tar": "^6.1.11",
+                "unique-filename": "^3.0.0"
+            },
+            "engines": {
+                "node": "^16.14.0 || >=18.0.0"
+            }
+        },
+        "node_modules/cacache/node_modules/brace-expansion": {
+            "version": "2.1.0",
+            "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.1.0.tgz",
+            "integrity": "sha512-TN1kCZAgdgweJhWWpgKYrQaMNHcDULHkWwQIspdtjV4Y5aurRdZpjAqn6yX3FPqTA9ngHCc4hJxMAMgGfve85w==",
+            "license": "MIT",
+            "dependencies": {
+                "balanced-match": "^1.0.0"
+            }
+        },
+        "node_modules/cacache/node_modules/chownr": {
+            "version": "2.0.0",
+            "resolved": "https://registry.npmjs.org/chownr/-/chownr-2.0.0.tgz",
+            "integrity": "sha512-bIomtDF5KGpdogkLd9VspvFzk9KfpyyGlS8YFVZl7TGPBHL5snIOnxeshwVgPteQ9b4Eydl+pVbIyE1DcvCWgQ==",
+            "license": "ISC",
+            "engines": {
+                "node": ">=10"
+            }
+        },
+        "node_modules/cacache/node_modules/glob": {
+            "version": "10.5.0",
+            "resolved": "https://registry.npmjs.org/glob/-/glob-10.5.0.tgz",
+            "integrity": "sha512-DfXN8DfhJ7NH3Oe7cFmu3NCu1wKbkReJ8TorzSAFbSKrlNaQSKfIzqYqVY8zlbs2NLBbWpRiU52GX2PbaBVNkg==",
+            "deprecated": "Old versions of glob are not supported, and contain widely publicized security vulnerabilities, which have been fixed in the current version. Please update. Support for old versions may be purchased (at exorbitant rates) by contacting i@izs.me",
+            "license": "ISC",
+            "dependencies": {
+                "foreground-child": "^3.1.0",
+                "jackspeak": "^3.1.2",
+                "minimatch": "^9.0.4",
+                "minipass": "^7.1.2",
+                "package-json-from-dist": "^1.0.0",
+                "path-scurry": "^1.11.1"
+            },
+            "bin": {
+                "glob": "dist/esm/bin.mjs"
+            },
+            "funding": {
+                "url": "https://github.com/sponsors/isaacs"
+            }
+        },
+        "node_modules/cacache/node_modules/jackspeak": {
+            "version": "3.4.3",
+            "resolved": "https://registry.npmjs.org/jackspeak/-/jackspeak-3.4.3.tgz",
+            "integrity": "sha512-OGlZQpz2yfahA/Rd1Y8Cd9SIEsqvXkLVoSw/cgwhnhFMDbsQFeZYoJJ7bIZBS9BcamUW96asq/npPWugM+RQBw==",
+            "license": "BlueOak-1.0.0",
+            "dependencies": {
+                "@isaacs/cliui": "^8.0.2"
+            },
+            "funding": {
+                "url": "https://github.com/sponsors/isaacs"
+            },
+            "optionalDependencies": {
+                "@pkgjs/parseargs": "^0.11.0"
+            }
+        },
+        "node_modules/cacache/node_modules/lru-cache": {
+            "version": "10.4.3",
+            "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-10.4.3.tgz",
+            "integrity": "sha512-JNAzZcXrCt42VGLuYz0zfAzDfAvJWW6AfYlDBQyDV5DClI2m5sAmK+OIO7s59XfsRsWHp02jAJrRadPRGTt6SQ==",
+            "license": "ISC"
+        },
+        "node_modules/cacache/node_modules/minimatch": {
+            "version": "9.0.9",
+            "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-9.0.9.tgz",
+            "integrity": "sha512-OBwBN9AL4dqmETlpS2zasx+vTeWclWzkblfZk7KTA5j3jeOONz/tRCnZomUyvNg83wL5Zv9Ss6HMJXAgL8R2Yg==",
+            "license": "ISC",
+            "dependencies": {
+                "brace-expansion": "^2.0.2"
+            },
+            "engines": {
+                "node": ">=16 || 14 >=14.17"
+            },
+            "funding": {
+                "url": "https://github.com/sponsors/isaacs"
+            }
+        },
+        "node_modules/cacache/node_modules/minizlib": {
+            "version": "2.1.2",
+            "resolved": "https://registry.npmjs.org/minizlib/-/minizlib-2.1.2.tgz",
+            "integrity": "sha512-bAxsR8BVfj60DWXHE3u30oHzfl4G7khkSuPW+qvpd7jFRHm7dLxOjUk1EHACJ/hxLY8phGJ0YhYHZo7jil7Qdg==",
+            "license": "MIT",
+            "dependencies": {
+                "minipass": "^3.0.0",
+                "yallist": "^4.0.0"
+            },
+            "engines": {
+                "node": ">= 8"
+            }
+        },
+        "node_modules/cacache/node_modules/minizlib/node_modules/minipass": {
+            "version": "3.3.6",
+            "resolved": "https://registry.npmjs.org/minipass/-/minipass-3.3.6.tgz",
+            "integrity": "sha512-DxiNidxSEK+tHG6zOIklvNOwm3hvCrbUrdtzY74U6HKTJxvIDfOUL5W5P2Ghd3DTkhhKPYGqeNUIh5qcM4YBfw==",
+            "license": "ISC",
+            "dependencies": {
+                "yallist": "^4.0.0"
+            },
+            "engines": {
+                "node": ">=8"
+            }
+        },
+        "node_modules/cacache/node_modules/tar": {
+            "version": "6.2.1",
+            "resolved": "https://registry.npmjs.org/tar/-/tar-6.2.1.tgz",
+            "integrity": "sha512-DZ4yORTwrbTj/7MZYq2w+/ZFdI6OZ/f9SFHR+71gIVUZhOQPHzVCLpvRnPgyaMpfWxxk/4ONva3GQSyNIKRv6A==",
+            "deprecated": "Old versions of tar are not supported, and contain widely publicized security vulnerabilities, which have been fixed in the current version. Please update. Support for old versions may be purchased (at exorbitant rates) by contacting i@izs.me",
+            "license": "ISC",
+            "dependencies": {
+                "chownr": "^2.0.0",
+                "fs-minipass": "^2.0.0",
+                "minipass": "^5.0.0",
+                "minizlib": "^2.1.1",
+                "mkdirp": "^1.0.3",
+                "yallist": "^4.0.0"
+            },
+            "engines": {
+                "node": ">=10"
+            }
+        },
+        "node_modules/cacache/node_modules/tar/node_modules/fs-minipass": {
+            "version": "2.1.0",
+            "resolved": "https://registry.npmjs.org/fs-minipass/-/fs-minipass-2.1.0.tgz",
+            "integrity": "sha512-V/JgOLFCS+R6Vcq0slCuaeWEdNC3ouDlJMNIsacH2VtALiu9mV4LPrHc5cDl8k5aw6J8jwgWWpiTo5RYhmIzvg==",
+            "license": "ISC",
+            "dependencies": {
+                "minipass": "^3.0.0"
+            },
+            "engines": {
+                "node": ">= 8"
+            }
+        },
+        "node_modules/cacache/node_modules/tar/node_modules/fs-minipass/node_modules/minipass": {
+            "version": "3.3.6",
+            "resolved": "https://registry.npmjs.org/minipass/-/minipass-3.3.6.tgz",
+            "integrity": "sha512-DxiNidxSEK+tHG6zOIklvNOwm3hvCrbUrdtzY74U6HKTJxvIDfOUL5W5P2Ghd3DTkhhKPYGqeNUIh5qcM4YBfw==",
+            "license": "ISC",
+            "dependencies": {
+                "yallist": "^4.0.0"
+            },
+            "engines": {
+                "node": ">=8"
+            }
+        },
+        "node_modules/cacache/node_modules/tar/node_modules/minipass": {
+            "version": "5.0.0",
+            "resolved": "https://registry.npmjs.org/minipass/-/minipass-5.0.0.tgz",
+            "integrity": "sha512-3FnjYuehv9k6ovOEbyOswadCDPX1piCfhV8ncmYtHOjuPwylVWsghTLo7rabjC3Rx5xD4HDx8Wm1xnMF7S5qFQ==",
+            "license": "ISC",
+            "engines": {
+                "node": ">=8"
+            }
+        },
         "node_modules/call-bind": {
             "version": "1.0.8",
             "resolved": "https://registry.npmjs.org/call-bind/-/call-bind-1.0.8.tgz",
@@ -20142,6 +20376,15 @@
             "dev": true,
             "engines": {
                 "node": ">=0.8.0"
+            }
+        },
+        "node_modules/clean-stack": {
+            "version": "2.2.0",
+            "resolved": "https://registry.npmjs.org/clean-stack/-/clean-stack-2.2.0.tgz",
+            "integrity": "sha512-4diC9HaTE+KRAMWhDhrGOECgWZxoevMc5TlkObMqNSsVU62PYzXZ/SMTjzyGAFF1YusgxGcSWTEXBhp0CPwQ1A==",
+            "license": "MIT",
+            "engines": {
+                "node": ">=6"
             }
         },
         "node_modules/cli-boxes": {
@@ -22336,6 +22579,29 @@
                 "node": ">= 0.8"
             }
         },
+        "node_modules/encoding": {
+            "version": "0.1.13",
+            "resolved": "https://registry.npmjs.org/encoding/-/encoding-0.1.13.tgz",
+            "integrity": "sha512-ETBauow1T35Y/WZMkio9jiM0Z5xjHHmJ4XmjZOq1l/dXz3lr2sRn87nJy20RupqSh1F2m3HHPSp8ShIPQJrJ3A==",
+            "license": "MIT",
+            "optional": true,
+            "dependencies": {
+                "iconv-lite": "^0.6.2"
+            }
+        },
+        "node_modules/encoding/node_modules/iconv-lite": {
+            "version": "0.6.3",
+            "resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.6.3.tgz",
+            "integrity": "sha512-4fCk79wshMdzMp2rH06qWrJE4iolqLhCUH+OiuIgU++RB0+94NlDL81atO7GX55uUKueo0txHNtvEyI6D7WdMw==",
+            "license": "MIT",
+            "optional": true,
+            "dependencies": {
+                "safer-buffer": ">= 2.1.2 < 3.0.0"
+            },
+            "engines": {
+                "node": ">=0.10.0"
+            }
+        },
         "node_modules/end-of-stream": {
             "version": "1.4.4",
             "license": "MIT",
@@ -24460,6 +24726,18 @@
                 "node": ">=14.14"
             }
         },
+        "node_modules/fs-minipass": {
+            "version": "3.0.3",
+            "resolved": "https://registry.npmjs.org/fs-minipass/-/fs-minipass-3.0.3.tgz",
+            "integrity": "sha512-XUBA9XClHbnJWSfBzjkm6RvPsyg3sryZt06BEQoXcF7EK/xpGaQYJgQKDJSUH5SGZ76Y7pFx1QBnXz09rU5Fbw==",
+            "license": "ISC",
+            "dependencies": {
+                "minipass": "^7.0.3"
+            },
+            "engines": {
+                "node": "^14.17.0 || ^16.13.0 || >=18.0.0"
+            }
+        },
         "node_modules/fs.realpath": {
             "version": "1.0.0",
             "license": "ISC"
@@ -25359,6 +25637,12 @@
                 "url": "https://github.com/fb55/entities?sponsor=1"
             }
         },
+        "node_modules/http-cache-semantics": {
+            "version": "4.2.0",
+            "resolved": "https://registry.npmjs.org/http-cache-semantics/-/http-cache-semantics-4.2.0.tgz",
+            "integrity": "sha512-dTxcvPXqPvXBQpq5dUr6mEMJX4oIEFv6bwom3FDwKRDsuIjjJGANqhBuoAn9c1RQJIdAKav33ED65E2ys+87QQ==",
+            "license": "BSD-2-Clause"
+        },
         "node_modules/http-errors": {
             "version": "2.0.1",
             "resolved": "https://registry.npmjs.org/http-errors/-/http-errors-2.0.1.tgz",
@@ -25940,6 +26224,12 @@
             "funding": {
                 "url": "https://github.com/sponsors/sindresorhus"
             }
+        },
+        "node_modules/is-lambda": {
+            "version": "1.0.1",
+            "resolved": "https://registry.npmjs.org/is-lambda/-/is-lambda-1.0.1.tgz",
+            "integrity": "sha512-z7CMFGNrENq5iFB9Bqo64Xk6Y9sg+epq1myIcdHaGnbMTYOxvzsEtdYqQUylB7LxfkvgrrjP32T6Ywciio9UIQ==",
+            "license": "MIT"
         },
         "node_modules/is-map": {
             "version": "2.0.3",
@@ -26795,6 +27085,15 @@
         "node_modules/kuler": {
             "version": "2.0.0",
             "license": "MIT"
+        },
+        "node_modules/launchdarkly-eventsource": {
+            "version": "2.0.3",
+            "resolved": "https://registry.npmjs.org/launchdarkly-eventsource/-/launchdarkly-eventsource-2.0.3.tgz",
+            "integrity": "sha512-VhFjppK7jXlcEKaS7bxdoibB5j01NKyeDR7a8XfssdDGNWCTsbF0/5IExSmPi44eDncPhkoPNxlSZhEZvrbD5w==",
+            "license": "MIT",
+            "engines": {
+                "node": ">=0.12.0"
+            }
         },
         "node_modules/lazystream": {
             "version": "1.0.1",
@@ -27797,6 +28096,38 @@
             "version": "1.3.6",
             "license": "ISC"
         },
+        "node_modules/make-fetch-happen": {
+            "version": "13.0.1",
+            "resolved": "https://registry.npmjs.org/make-fetch-happen/-/make-fetch-happen-13.0.1.tgz",
+            "integrity": "sha512-cKTUFc/rbKUd/9meOvgrpJ2WrNzymt6jfRDdwg5UCnVzv9dTpEj9JS5m3wtziXVCjluIXyL8pcaukYqezIzZQA==",
+            "license": "ISC",
+            "dependencies": {
+                "@npmcli/agent": "^2.0.0",
+                "cacache": "^18.0.0",
+                "http-cache-semantics": "^4.1.1",
+                "is-lambda": "^1.0.1",
+                "minipass": "^7.0.2",
+                "minipass-fetch": "^3.0.0",
+                "minipass-flush": "^1.0.5",
+                "minipass-pipeline": "^1.2.4",
+                "negotiator": "^0.6.3",
+                "proc-log": "^4.2.0",
+                "promise-retry": "^2.0.1",
+                "ssri": "^10.0.0"
+            },
+            "engines": {
+                "node": "^16.14.0 || >=18.0.0"
+            }
+        },
+        "node_modules/make-fetch-happen/node_modules/proc-log": {
+            "version": "4.2.0",
+            "resolved": "https://registry.npmjs.org/proc-log/-/proc-log-4.2.0.tgz",
+            "integrity": "sha512-g8+OnU/L2v+wyiVK+D5fA34J7EH8jZ8DDlvwhRCMxmMj7UCBvxiO1mGeN+36JXIKF4zevU4kRBd8lVgG9vLelA==",
+            "license": "ISC",
+            "engines": {
+                "node": "^14.17.0 || ^16.13.0 || >=18.0.0"
+            }
+        },
         "node_modules/mark.js": {
             "version": "8.11.1",
             "resolved": "https://registry.npmjs.org/mark.js/-/mark.js-8.11.1.tgz",
@@ -27999,6 +28330,132 @@
                 "node": ">=16 || 14 >=14.17"
             }
         },
+        "node_modules/minipass-collect": {
+            "version": "2.0.1",
+            "resolved": "https://registry.npmjs.org/minipass-collect/-/minipass-collect-2.0.1.tgz",
+            "integrity": "sha512-D7V8PO9oaz7PWGLbCACuI1qEOsq7UKfLotx/C0Aet43fCUB/wfQ7DYeq2oR/svFJGYDHPr38SHATeaj/ZoKHKw==",
+            "license": "ISC",
+            "dependencies": {
+                "minipass": "^7.0.3"
+            },
+            "engines": {
+                "node": ">=16 || 14 >=14.17"
+            }
+        },
+        "node_modules/minipass-fetch": {
+            "version": "3.0.5",
+            "resolved": "https://registry.npmjs.org/minipass-fetch/-/minipass-fetch-3.0.5.tgz",
+            "integrity": "sha512-2N8elDQAtSnFV0Dk7gt15KHsS0Fyz6CbYZ360h0WTYV1Ty46li3rAXVOQj1THMNLdmrD9Vt5pBPtWtVkpwGBqg==",
+            "license": "MIT",
+            "dependencies": {
+                "minipass": "^7.0.3",
+                "minipass-sized": "^1.0.3",
+                "minizlib": "^2.1.2"
+            },
+            "engines": {
+                "node": "^14.17.0 || ^16.13.0 || >=18.0.0"
+            },
+            "optionalDependencies": {
+                "encoding": "^0.1.13"
+            }
+        },
+        "node_modules/minipass-fetch/node_modules/minizlib": {
+            "version": "2.1.2",
+            "resolved": "https://registry.npmjs.org/minizlib/-/minizlib-2.1.2.tgz",
+            "integrity": "sha512-bAxsR8BVfj60DWXHE3u30oHzfl4G7khkSuPW+qvpd7jFRHm7dLxOjUk1EHACJ/hxLY8phGJ0YhYHZo7jil7Qdg==",
+            "license": "MIT",
+            "dependencies": {
+                "minipass": "^3.0.0",
+                "yallist": "^4.0.0"
+            },
+            "engines": {
+                "node": ">= 8"
+            }
+        },
+        "node_modules/minipass-fetch/node_modules/minizlib/node_modules/minipass": {
+            "version": "3.3.6",
+            "resolved": "https://registry.npmjs.org/minipass/-/minipass-3.3.6.tgz",
+            "integrity": "sha512-DxiNidxSEK+tHG6zOIklvNOwm3hvCrbUrdtzY74U6HKTJxvIDfOUL5W5P2Ghd3DTkhhKPYGqeNUIh5qcM4YBfw==",
+            "license": "ISC",
+            "dependencies": {
+                "yallist": "^4.0.0"
+            },
+            "engines": {
+                "node": ">=8"
+            }
+        },
+        "node_modules/minipass-flush": {
+            "version": "1.0.7",
+            "resolved": "https://registry.npmjs.org/minipass-flush/-/minipass-flush-1.0.7.tgz",
+            "integrity": "sha512-TbqTz9cUwWyHS2Dy89P3ocAGUGxKjjLuR9z8w4WUTGAVgEj17/4nhgo2Du56i0Fm3Pm30g4iA8Lcqctc76jCzA==",
+            "license": "BlueOak-1.0.0",
+            "dependencies": {
+                "minipass": "^3.0.0"
+            },
+            "engines": {
+                "node": ">= 8"
+            }
+        },
+        "node_modules/minipass-flush/node_modules/minipass": {
+            "version": "3.3.6",
+            "resolved": "https://registry.npmjs.org/minipass/-/minipass-3.3.6.tgz",
+            "integrity": "sha512-DxiNidxSEK+tHG6zOIklvNOwm3hvCrbUrdtzY74U6HKTJxvIDfOUL5W5P2Ghd3DTkhhKPYGqeNUIh5qcM4YBfw==",
+            "license": "ISC",
+            "dependencies": {
+                "yallist": "^4.0.0"
+            },
+            "engines": {
+                "node": ">=8"
+            }
+        },
+        "node_modules/minipass-pipeline": {
+            "version": "1.2.4",
+            "resolved": "https://registry.npmjs.org/minipass-pipeline/-/minipass-pipeline-1.2.4.tgz",
+            "integrity": "sha512-xuIq7cIOt09RPRJ19gdi4b+RiNvDFYe5JH+ggNvBqGqpQXcru3PcRmOZuHBKWK1Txf9+cQ+HMVN4d6z46LZP7A==",
+            "license": "ISC",
+            "dependencies": {
+                "minipass": "^3.0.0"
+            },
+            "engines": {
+                "node": ">=8"
+            }
+        },
+        "node_modules/minipass-pipeline/node_modules/minipass": {
+            "version": "3.3.6",
+            "resolved": "https://registry.npmjs.org/minipass/-/minipass-3.3.6.tgz",
+            "integrity": "sha512-DxiNidxSEK+tHG6zOIklvNOwm3hvCrbUrdtzY74U6HKTJxvIDfOUL5W5P2Ghd3DTkhhKPYGqeNUIh5qcM4YBfw==",
+            "license": "ISC",
+            "dependencies": {
+                "yallist": "^4.0.0"
+            },
+            "engines": {
+                "node": ">=8"
+            }
+        },
+        "node_modules/minipass-sized": {
+            "version": "1.0.3",
+            "resolved": "https://registry.npmjs.org/minipass-sized/-/minipass-sized-1.0.3.tgz",
+            "integrity": "sha512-MbkQQ2CTiBMlA2Dm/5cY+9SWFEN8pzzOXi6rlM5Xxq0Yqbda5ZQy9sU75a673FE9ZK0Zsbr6Y5iP6u9nktfg2g==",
+            "license": "ISC",
+            "dependencies": {
+                "minipass": "^3.0.0"
+            },
+            "engines": {
+                "node": ">=8"
+            }
+        },
+        "node_modules/minipass-sized/node_modules/minipass": {
+            "version": "3.3.6",
+            "resolved": "https://registry.npmjs.org/minipass/-/minipass-3.3.6.tgz",
+            "integrity": "sha512-DxiNidxSEK+tHG6zOIklvNOwm3hvCrbUrdtzY74U6HKTJxvIDfOUL5W5P2Ghd3DTkhhKPYGqeNUIh5qcM4YBfw==",
+            "license": "ISC",
+            "dependencies": {
+                "yallist": "^4.0.0"
+            },
+            "engines": {
+                "node": ">=8"
+            }
+        },
         "node_modules/minizlib": {
             "version": "3.1.0",
             "resolved": "https://registry.npmjs.org/minizlib/-/minizlib-3.1.0.tgz",
@@ -28135,6 +28592,15 @@
             "funding": {
                 "type": "opencollective",
                 "url": "https://opencollective.com/express"
+            }
+        },
+        "node_modules/murmurhash3js": {
+            "version": "3.0.1",
+            "resolved": "https://registry.npmjs.org/murmurhash3js/-/murmurhash3js-3.0.1.tgz",
+            "integrity": "sha512-KL8QYUaxq7kUbcl0Yto51rMcYt7E/4N4BG3/c96Iqw1PQrTRspu8Cpx4TZ4Nunib1d4bEkIH3gjCYlP2RLBdow==",
+            "license": "MIT",
+            "engines": {
+                "node": ">=0.10.0"
             }
         },
         "node_modules/mute-stream": {
@@ -29071,6 +29537,21 @@
             "license": "MIT",
             "dependencies": {
                 "p-limit": "^3.0.2"
+            },
+            "engines": {
+                "node": ">=10"
+            },
+            "funding": {
+                "url": "https://github.com/sponsors/sindresorhus"
+            }
+        },
+        "node_modules/p-map": {
+            "version": "4.0.0",
+            "resolved": "https://registry.npmjs.org/p-map/-/p-map-4.0.0.tgz",
+            "integrity": "sha512-/bjOqmgETBYB5BoEeGVea8dmvHb2m9GLy1E9W43yeyfP6QQCZGFNa+XRceJEuDB6zqr+gKpIAmlLebMpykw/MQ==",
+            "license": "MIT",
+            "dependencies": {
+                "aggregate-error": "^3.0.0"
             },
             "engines": {
                 "node": ">=10"
@@ -33078,6 +33559,18 @@
                 "nan": "^2.23.0"
             }
         },
+        "node_modules/ssri": {
+            "version": "10.0.6",
+            "resolved": "https://registry.npmjs.org/ssri/-/ssri-10.0.6.tgz",
+            "integrity": "sha512-MGrFH9Z4NP9Iyhqn16sDtBpRRNJ0Y2hNa6D65h736fVSaPCHr4DM4sWUNvVaSuC+0OBGhwsrydQwmgfg5LncqQ==",
+            "license": "ISC",
+            "dependencies": {
+                "minipass": "^7.0.3"
+            },
+            "engines": {
+                "node": "^14.17.0 || ^16.13.0 || >=18.0.0"
+            }
+        },
         "node_modules/stack-generator": {
             "version": "2.0.10",
             "resolved": "https://registry.npmjs.org/stack-generator/-/stack-generator-2.0.10.tgz",
@@ -35095,12 +35588,61 @@
                 "url": "https://github.com/sponsors/sindresorhus"
             }
         },
+        "node_modules/unique-filename": {
+            "version": "3.0.0",
+            "resolved": "https://registry.npmjs.org/unique-filename/-/unique-filename-3.0.0.tgz",
+            "integrity": "sha512-afXhuC55wkAmZ0P18QsVE6kp8JaxrEokN2HGIoIVv2ijHQd419H0+6EigAFcIzXeMIkcIkNBpB3L/DXB3cTS/g==",
+            "license": "ISC",
+            "dependencies": {
+                "unique-slug": "^4.0.0"
+            },
+            "engines": {
+                "node": "^14.17.0 || ^16.13.0 || >=18.0.0"
+            }
+        },
+        "node_modules/unique-slug": {
+            "version": "4.0.0",
+            "resolved": "https://registry.npmjs.org/unique-slug/-/unique-slug-4.0.0.tgz",
+            "integrity": "sha512-WrcA6AyEfqDX5bWige/4NQfPZMtASNVxdmWR76WESYQVAACSgWcR6e9i0mofqqBxYFtL4oAxPIptY73/0YE1DQ==",
+            "license": "ISC",
+            "dependencies": {
+                "imurmurhash": "^0.1.4"
+            },
+            "engines": {
+                "node": "^14.17.0 || ^16.13.0 || >=18.0.0"
+            }
+        },
         "node_modules/universalify": {
             "version": "2.0.0",
             "license": "MIT",
             "engines": {
                 "node": ">= 10.0.0"
             }
+        },
+        "node_modules/unleash-client": {
+            "version": "6.6.0",
+            "resolved": "https://registry.npmjs.org/unleash-client/-/unleash-client-6.6.0.tgz",
+            "integrity": "sha512-xsxWobHY83d5n80aGVQVTXOVdxRw9vZxsXUeys5oucYRMzW3ymiy+QY0QBEWDORq0AffsP2suF5uj2M6On2qGw==",
+            "license": "Apache-2.0",
+            "dependencies": {
+                "http-proxy-agent": "^7.0.2",
+                "https-proxy-agent": "^7.0.5",
+                "ip-address": "^9.0.5",
+                "launchdarkly-eventsource": "2.0.3",
+                "make-fetch-happen": "^13.0.1",
+                "murmurhash3js": "^3.0.1",
+                "proxy-from-env": "^1.1.0",
+                "semver": "^7.6.2"
+            },
+            "engines": {
+                "node": ">=16"
+            }
+        },
+        "node_modules/unleash-client/node_modules/proxy-from-env": {
+            "version": "1.1.0",
+            "resolved": "https://registry.npmjs.org/proxy-from-env/-/proxy-from-env-1.1.0.tgz",
+            "integrity": "sha512-D+zkORCbA9f1tdWRK0RaCR3GPv50cMxcrz4X8k5LTSUD1Dkw47mKJEZQNunItRTkWwgtaUSo1RVFRIG9ZXiFYg==",
+            "license": "MIT"
         },
         "node_modules/unpipe": {
             "version": "1.0.0",
@@ -37449,6 +37991,18 @@
                 "utf-8-validate": {
                     "optional": true
                 }
+            }
+        },
+        "packages/feature-flags": {
+            "name": "@nangohq/feature-flags",
+            "version": "1.0.0",
+            "dependencies": {
+                "@nangohq/utils": "file:../utils",
+                "@openfeature/server-sdk": "~1.18.0",
+                "unleash-client": "6.6.0"
+            },
+            "devDependencies": {
+                "vitest": "3.2.4"
             }
         },
         "packages/fleet": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -5199,8 +5199,7 @@
             "version": "1.9.1",
             "resolved": "https://registry.npmjs.org/@openfeature/core/-/core-1.9.1.tgz",
             "integrity": "sha512-YySPtH4s/rKKnHRU0xyFGrqMU8XA+OIPNWDrlEFxE6DCVWCIrxE5YpiB94YD2jMFn6SSdA0cwQ8vLkCkl8lm8A==",
-            "license": "Apache-2.0",
-            "peer": true
+            "license": "Apache-2.0"
         },
         "node_modules/@openfeature/server-sdk": {
             "version": "1.18.0",
@@ -37998,7 +37997,8 @@
             "version": "1.0.0",
             "dependencies": {
                 "@nangohq/utils": "file:../utils",
-                "@openfeature/server-sdk": "~1.18.0",
+                "@openfeature/core": "1.9.1",
+                "@openfeature/server-sdk": "1.18.0",
                 "unleash-client": "6.6.0"
             },
             "devDependencies": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -38732,6 +38732,7 @@
                 "unleash-client": "6.6.0"
             },
             "devDependencies": {
+                "rimraf": "6.1.3",
                 "vitest": "3.2.4"
             }
         },

--- a/package-lock.json
+++ b/package-lock.json
@@ -6289,6 +6289,7 @@
             "dev": true,
             "license": "MIT"
         },
+<<<<<<< HEAD
         "node_modules/@opensearch-project/opensearch": {
             "version": "2.13.0",
             "resolved": "https://registry.npmjs.org/@opensearch-project/opensearch/-/opensearch-2.13.0.tgz",
@@ -6319,6 +6320,26 @@
             "integrity": "sha512-6aU+Rwsezw7VR8/nyvKTx8QpWH9FrcYiXXlqC4z5d5XQBDRqtbfsRjnwGyqbi3gddNtWHuEk9OANUotL26qKUw==",
             "license": "BSD-3-Clause"
         },
+=======
+        "node_modules/@openfeature/core": {
+            "version": "1.9.1",
+            "resolved": "https://registry.npmjs.org/@openfeature/core/-/core-1.9.1.tgz",
+            "integrity": "sha512-YySPtH4s/rKKnHRU0xyFGrqMU8XA+OIPNWDrlEFxE6DCVWCIrxE5YpiB94YD2jMFn6SSdA0cwQ8vLkCkl8lm8A==",
+            "license": "Apache-2.0"
+        },
+        "node_modules/@openfeature/server-sdk": {
+            "version": "1.18.0",
+            "resolved": "https://registry.npmjs.org/@openfeature/server-sdk/-/server-sdk-1.18.0.tgz",
+            "integrity": "sha512-uP8nqEGBS58s3iWXx6d8vnJ6ZVt3DACJL4PWADOAuwIS4xXpID91783e9f6zQ0i1ijQpj3yx+3ZuCB2LfQMUMA==",
+            "license": "Apache-2.0",
+            "engines": {
+                "node": ">=18"
+            },
+            "peerDependencies": {
+                "@openfeature/core": "^1.7.0"
+            }
+        },
+>>>>>>> 92f51237d (Pin openfeature versions and add core as dependency)
         "node_modules/@opentelemetry/api": {
             "version": "1.9.1",
             "resolved": "https://registry.npmjs.org/@opentelemetry/api/-/api-1.9.1.tgz",
@@ -38626,7 +38647,8 @@
             "version": "1.0.0",
             "dependencies": {
                 "@nangohq/utils": "file:../utils",
-                "@openfeature/server-sdk": "~1.18.0",
+                "@openfeature/core": "1.9.1",
+                "@openfeature/server-sdk": "1.18.0",
                 "unleash-client": "6.6.0"
             },
             "devDependencies": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -25831,6 +25831,12 @@
                 "entities": "^4.5.0"
             }
         },
+        "node_modules/http-cache-semantics": {
+            "version": "4.2.0",
+            "resolved": "https://registry.npmjs.org/http-cache-semantics/-/http-cache-semantics-4.2.0.tgz",
+            "integrity": "sha512-dTxcvPXqPvXBQpq5dUr6mEMJX4oIEFv6bwom3FDwKRDsuIjjJGANqhBuoAn9c1RQJIdAKav33ED65E2ys+87QQ==",
+            "license": "BSD-2-Clause"
+        },
         "node_modules/http-errors": {
             "version": "2.0.1",
             "resolved": "https://registry.npmjs.org/http-errors/-/http-errors-2.0.1.tgz",
@@ -38729,6 +38735,7 @@
                 "@nangohq/utils": "file:../utils",
                 "@openfeature/core": "1.9.1",
                 "@openfeature/server-sdk": "1.18.0",
+                "http-cache-semantics": "4.2.0",
                 "unleash-client": "6.6.0"
             },
             "devDependencies": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -6050,6 +6050,10 @@
             "resolved": "packages/email",
             "link": true
         },
+        "node_modules/@nangohq/feature-flags": {
+            "resolved": "packages/feature-flags",
+            "link": true
+        },
         "node_modules/@nangohq/fleet": {
             "resolved": "packages/fleet",
             "link": true
@@ -6242,6 +6246,40 @@
             },
             "engines": {
                 "node": ">= 8"
+            }
+        },
+        "node_modules/@npmcli/agent": {
+            "version": "2.2.2",
+            "resolved": "https://registry.npmjs.org/@npmcli/agent/-/agent-2.2.2.tgz",
+            "integrity": "sha512-OrcNPXdpSl9UX7qPVRWbmWMCSXrcDa2M9DvrbOTj7ao1S4PlqVFYv9/yLKMkrJKZ/V5A/kDBC690or307i26Og==",
+            "license": "ISC",
+            "dependencies": {
+                "agent-base": "^7.1.0",
+                "http-proxy-agent": "^7.0.0",
+                "https-proxy-agent": "^7.0.1",
+                "lru-cache": "^10.0.1",
+                "socks-proxy-agent": "^8.0.3"
+            },
+            "engines": {
+                "node": "^16.14.0 || >=18.0.0"
+            }
+        },
+        "node_modules/@npmcli/agent/node_modules/lru-cache": {
+            "version": "10.4.3",
+            "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-10.4.3.tgz",
+            "integrity": "sha512-JNAzZcXrCt42VGLuYz0zfAzDfAvJWW6AfYlDBQyDV5DClI2m5sAmK+OIO7s59XfsRsWHp02jAJrRadPRGTt6SQ==",
+            "license": "ISC"
+        },
+        "node_modules/@npmcli/fs": {
+            "version": "3.1.1",
+            "resolved": "https://registry.npmjs.org/@npmcli/fs/-/fs-3.1.1.tgz",
+            "integrity": "sha512-q9CRWjpHCMIh5sVyefoD1cA7PkvILqCZsnSOEUUivORLjxCO/Irmue2DprETiNgEqktDBZaM1Bi+jrarx1XdCg==",
+            "license": "ISC",
+            "dependencies": {
+                "semver": "^7.3.5"
+            },
+            "engines": {
+                "node": "^14.17.0 || ^16.13.0 || >=18.0.0"
             }
         },
         "node_modules/@opencode-ai/sdk": {
@@ -18515,6 +18553,28 @@
                 "node": ">= 8.0.0"
             }
         },
+        "node_modules/aggregate-error": {
+            "version": "3.1.0",
+            "resolved": "https://registry.npmjs.org/aggregate-error/-/aggregate-error-3.1.0.tgz",
+            "integrity": "sha512-4I7Td01quW/RpocfNayFdFVk1qSuoh0E7JrbRJ16nH01HhKFQ88INq9Sd+nd72zqRySlr9BmDA8xlEJ6vJMrYA==",
+            "license": "MIT",
+            "dependencies": {
+                "clean-stack": "^2.0.0",
+                "indent-string": "^4.0.0"
+            },
+            "engines": {
+                "node": ">=8"
+            }
+        },
+        "node_modules/aggregate-error/node_modules/indent-string": {
+            "version": "4.0.0",
+            "resolved": "https://registry.npmjs.org/indent-string/-/indent-string-4.0.0.tgz",
+            "integrity": "sha512-EdDDZu4A2OyIK7Lr/2zG+w5jmbuk1DVBnEwREQvBzspBJkCEbRa8GxU1lghYcaGJCnRWibjDXlq779X1/y5xwg==",
+            "license": "MIT",
+            "engines": {
+                "node": ">=8"
+            }
+        },
         "node_modules/ajv": {
             "version": "6.15.0",
             "resolved": "https://registry.npmjs.org/ajv/-/ajv-6.15.0.tgz",
@@ -20128,6 +20188,180 @@
                 "node": ">=8"
             }
         },
+        "node_modules/cacache": {
+            "version": "18.0.4",
+            "resolved": "https://registry.npmjs.org/cacache/-/cacache-18.0.4.tgz",
+            "integrity": "sha512-B+L5iIa9mgcjLbliir2th36yEwPftrzteHYujzsx3dFP/31GCHcIeS8f5MGd80odLOjaOvSpU3EEAmRQptkxLQ==",
+            "license": "ISC",
+            "dependencies": {
+                "@npmcli/fs": "^3.1.0",
+                "fs-minipass": "^3.0.0",
+                "glob": "^10.2.2",
+                "lru-cache": "^10.0.1",
+                "minipass": "^7.0.3",
+                "minipass-collect": "^2.0.1",
+                "minipass-flush": "^1.0.5",
+                "minipass-pipeline": "^1.2.4",
+                "p-map": "^4.0.0",
+                "ssri": "^10.0.0",
+                "tar": "^6.1.11",
+                "unique-filename": "^3.0.0"
+            },
+            "engines": {
+                "node": "^16.14.0 || >=18.0.0"
+            }
+        },
+        "node_modules/cacache/node_modules/brace-expansion": {
+            "version": "2.1.0",
+            "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.1.0.tgz",
+            "integrity": "sha512-TN1kCZAgdgweJhWWpgKYrQaMNHcDULHkWwQIspdtjV4Y5aurRdZpjAqn6yX3FPqTA9ngHCc4hJxMAMgGfve85w==",
+            "license": "MIT",
+            "dependencies": {
+                "balanced-match": "^1.0.0"
+            }
+        },
+        "node_modules/cacache/node_modules/chownr": {
+            "version": "2.0.0",
+            "resolved": "https://registry.npmjs.org/chownr/-/chownr-2.0.0.tgz",
+            "integrity": "sha512-bIomtDF5KGpdogkLd9VspvFzk9KfpyyGlS8YFVZl7TGPBHL5snIOnxeshwVgPteQ9b4Eydl+pVbIyE1DcvCWgQ==",
+            "license": "ISC",
+            "engines": {
+                "node": ">=10"
+            }
+        },
+        "node_modules/cacache/node_modules/glob": {
+            "version": "10.5.0",
+            "resolved": "https://registry.npmjs.org/glob/-/glob-10.5.0.tgz",
+            "integrity": "sha512-DfXN8DfhJ7NH3Oe7cFmu3NCu1wKbkReJ8TorzSAFbSKrlNaQSKfIzqYqVY8zlbs2NLBbWpRiU52GX2PbaBVNkg==",
+            "deprecated": "Old versions of glob are not supported, and contain widely publicized security vulnerabilities, which have been fixed in the current version. Please update. Support for old versions may be purchased (at exorbitant rates) by contacting i@izs.me",
+            "license": "ISC",
+            "dependencies": {
+                "foreground-child": "^3.1.0",
+                "jackspeak": "^3.1.2",
+                "minimatch": "^9.0.4",
+                "minipass": "^7.1.2",
+                "package-json-from-dist": "^1.0.0",
+                "path-scurry": "^1.11.1"
+            },
+            "bin": {
+                "glob": "dist/esm/bin.mjs"
+            },
+            "funding": {
+                "url": "https://github.com/sponsors/isaacs"
+            }
+        },
+        "node_modules/cacache/node_modules/jackspeak": {
+            "version": "3.4.3",
+            "resolved": "https://registry.npmjs.org/jackspeak/-/jackspeak-3.4.3.tgz",
+            "integrity": "sha512-OGlZQpz2yfahA/Rd1Y8Cd9SIEsqvXkLVoSw/cgwhnhFMDbsQFeZYoJJ7bIZBS9BcamUW96asq/npPWugM+RQBw==",
+            "license": "BlueOak-1.0.0",
+            "dependencies": {
+                "@isaacs/cliui": "^8.0.2"
+            },
+            "funding": {
+                "url": "https://github.com/sponsors/isaacs"
+            },
+            "optionalDependencies": {
+                "@pkgjs/parseargs": "^0.11.0"
+            }
+        },
+        "node_modules/cacache/node_modules/lru-cache": {
+            "version": "10.4.3",
+            "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-10.4.3.tgz",
+            "integrity": "sha512-JNAzZcXrCt42VGLuYz0zfAzDfAvJWW6AfYlDBQyDV5DClI2m5sAmK+OIO7s59XfsRsWHp02jAJrRadPRGTt6SQ==",
+            "license": "ISC"
+        },
+        "node_modules/cacache/node_modules/minimatch": {
+            "version": "9.0.9",
+            "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-9.0.9.tgz",
+            "integrity": "sha512-OBwBN9AL4dqmETlpS2zasx+vTeWclWzkblfZk7KTA5j3jeOONz/tRCnZomUyvNg83wL5Zv9Ss6HMJXAgL8R2Yg==",
+            "license": "ISC",
+            "dependencies": {
+                "brace-expansion": "^2.0.2"
+            },
+            "engines": {
+                "node": ">=16 || 14 >=14.17"
+            },
+            "funding": {
+                "url": "https://github.com/sponsors/isaacs"
+            }
+        },
+        "node_modules/cacache/node_modules/minizlib": {
+            "version": "2.1.2",
+            "resolved": "https://registry.npmjs.org/minizlib/-/minizlib-2.1.2.tgz",
+            "integrity": "sha512-bAxsR8BVfj60DWXHE3u30oHzfl4G7khkSuPW+qvpd7jFRHm7dLxOjUk1EHACJ/hxLY8phGJ0YhYHZo7jil7Qdg==",
+            "license": "MIT",
+            "dependencies": {
+                "minipass": "^3.0.0",
+                "yallist": "^4.0.0"
+            },
+            "engines": {
+                "node": ">= 8"
+            }
+        },
+        "node_modules/cacache/node_modules/minizlib/node_modules/minipass": {
+            "version": "3.3.6",
+            "resolved": "https://registry.npmjs.org/minipass/-/minipass-3.3.6.tgz",
+            "integrity": "sha512-DxiNidxSEK+tHG6zOIklvNOwm3hvCrbUrdtzY74U6HKTJxvIDfOUL5W5P2Ghd3DTkhhKPYGqeNUIh5qcM4YBfw==",
+            "license": "ISC",
+            "dependencies": {
+                "yallist": "^4.0.0"
+            },
+            "engines": {
+                "node": ">=8"
+            }
+        },
+        "node_modules/cacache/node_modules/tar": {
+            "version": "6.2.1",
+            "resolved": "https://registry.npmjs.org/tar/-/tar-6.2.1.tgz",
+            "integrity": "sha512-DZ4yORTwrbTj/7MZYq2w+/ZFdI6OZ/f9SFHR+71gIVUZhOQPHzVCLpvRnPgyaMpfWxxk/4ONva3GQSyNIKRv6A==",
+            "deprecated": "Old versions of tar are not supported, and contain widely publicized security vulnerabilities, which have been fixed in the current version. Please update. Support for old versions may be purchased (at exorbitant rates) by contacting i@izs.me",
+            "license": "ISC",
+            "dependencies": {
+                "chownr": "^2.0.0",
+                "fs-minipass": "^2.0.0",
+                "minipass": "^5.0.0",
+                "minizlib": "^2.1.1",
+                "mkdirp": "^1.0.3",
+                "yallist": "^4.0.0"
+            },
+            "engines": {
+                "node": ">=10"
+            }
+        },
+        "node_modules/cacache/node_modules/tar/node_modules/fs-minipass": {
+            "version": "2.1.0",
+            "resolved": "https://registry.npmjs.org/fs-minipass/-/fs-minipass-2.1.0.tgz",
+            "integrity": "sha512-V/JgOLFCS+R6Vcq0slCuaeWEdNC3ouDlJMNIsacH2VtALiu9mV4LPrHc5cDl8k5aw6J8jwgWWpiTo5RYhmIzvg==",
+            "license": "ISC",
+            "dependencies": {
+                "minipass": "^3.0.0"
+            },
+            "engines": {
+                "node": ">= 8"
+            }
+        },
+        "node_modules/cacache/node_modules/tar/node_modules/fs-minipass/node_modules/minipass": {
+            "version": "3.3.6",
+            "resolved": "https://registry.npmjs.org/minipass/-/minipass-3.3.6.tgz",
+            "integrity": "sha512-DxiNidxSEK+tHG6zOIklvNOwm3hvCrbUrdtzY74U6HKTJxvIDfOUL5W5P2Ghd3DTkhhKPYGqeNUIh5qcM4YBfw==",
+            "license": "ISC",
+            "dependencies": {
+                "yallist": "^4.0.0"
+            },
+            "engines": {
+                "node": ">=8"
+            }
+        },
+        "node_modules/cacache/node_modules/tar/node_modules/minipass": {
+            "version": "5.0.0",
+            "resolved": "https://registry.npmjs.org/minipass/-/minipass-5.0.0.tgz",
+            "integrity": "sha512-3FnjYuehv9k6ovOEbyOswadCDPX1piCfhV8ncmYtHOjuPwylVWsghTLo7rabjC3Rx5xD4HDx8Wm1xnMF7S5qFQ==",
+            "license": "ISC",
+            "engines": {
+                "node": ">=8"
+            }
+        },
         "node_modules/call-bind": {
             "version": "1.0.8",
             "resolved": "https://registry.npmjs.org/call-bind/-/call-bind-1.0.8.tgz",
@@ -20419,6 +20653,15 @@
             "dev": true,
             "engines": {
                 "node": ">=0.8.0"
+            }
+        },
+        "node_modules/clean-stack": {
+            "version": "2.2.0",
+            "resolved": "https://registry.npmjs.org/clean-stack/-/clean-stack-2.2.0.tgz",
+            "integrity": "sha512-4diC9HaTE+KRAMWhDhrGOECgWZxoevMc5TlkObMqNSsVU62PYzXZ/SMTjzyGAFF1YusgxGcSWTEXBhp0CPwQ1A==",
+            "license": "MIT",
+            "engines": {
+                "node": ">=6"
             }
         },
         "node_modules/cli-boxes": {
@@ -22477,6 +22720,29 @@
             "integrity": "sha512-Q0n9HRi4m6JuGIV1eFlmvJB7ZEVxu93IrMyiMsGC0lrMJMWzRgx6WGquyfQgZVb31vhGgXnfmPNNXmxnOkRBrg==",
             "engines": {
                 "node": ">= 0.8"
+            }
+        },
+        "node_modules/encoding": {
+            "version": "0.1.13",
+            "resolved": "https://registry.npmjs.org/encoding/-/encoding-0.1.13.tgz",
+            "integrity": "sha512-ETBauow1T35Y/WZMkio9jiM0Z5xjHHmJ4XmjZOq1l/dXz3lr2sRn87nJy20RupqSh1F2m3HHPSp8ShIPQJrJ3A==",
+            "license": "MIT",
+            "optional": true,
+            "dependencies": {
+                "iconv-lite": "^0.6.2"
+            }
+        },
+        "node_modules/encoding/node_modules/iconv-lite": {
+            "version": "0.6.3",
+            "resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.6.3.tgz",
+            "integrity": "sha512-4fCk79wshMdzMp2rH06qWrJE4iolqLhCUH+OiuIgU++RB0+94NlDL81atO7GX55uUKueo0txHNtvEyI6D7WdMw==",
+            "license": "MIT",
+            "optional": true,
+            "dependencies": {
+                "safer-buffer": ">= 2.1.2 < 3.0.0"
+            },
+            "engines": {
+                "node": ">=0.10.0"
             }
         },
         "node_modules/end-of-stream": {
@@ -24662,6 +24928,18 @@
                 "node": ">=14.14"
             }
         },
+        "node_modules/fs-minipass": {
+            "version": "3.0.3",
+            "resolved": "https://registry.npmjs.org/fs-minipass/-/fs-minipass-3.0.3.tgz",
+            "integrity": "sha512-XUBA9XClHbnJWSfBzjkm6RvPsyg3sryZt06BEQoXcF7EK/xpGaQYJgQKDJSUH5SGZ76Y7pFx1QBnXz09rU5Fbw==",
+            "license": "ISC",
+            "dependencies": {
+                "minipass": "^7.0.3"
+            },
+            "engines": {
+                "node": "^14.17.0 || ^16.13.0 || >=18.0.0"
+            }
+        },
         "node_modules/fs.realpath": {
             "version": "1.0.0",
             "license": "ISC"
@@ -26141,6 +26419,12 @@
                 "url": "https://github.com/sponsors/sindresorhus"
             }
         },
+        "node_modules/is-lambda": {
+            "version": "1.0.1",
+            "resolved": "https://registry.npmjs.org/is-lambda/-/is-lambda-1.0.1.tgz",
+            "integrity": "sha512-z7CMFGNrENq5iFB9Bqo64Xk6Y9sg+epq1myIcdHaGnbMTYOxvzsEtdYqQUylB7LxfkvgrrjP32T6Ywciio9UIQ==",
+            "license": "MIT"
+        },
         "node_modules/is-map": {
             "version": "2.0.3",
             "resolved": "https://registry.npmjs.org/is-map/-/is-map-2.0.3.tgz",
@@ -27052,6 +27336,15 @@
         "node_modules/kuler": {
             "version": "2.0.0",
             "license": "MIT"
+        },
+        "node_modules/launchdarkly-eventsource": {
+            "version": "2.0.3",
+            "resolved": "https://registry.npmjs.org/launchdarkly-eventsource/-/launchdarkly-eventsource-2.0.3.tgz",
+            "integrity": "sha512-VhFjppK7jXlcEKaS7bxdoibB5j01NKyeDR7a8XfssdDGNWCTsbF0/5IExSmPi44eDncPhkoPNxlSZhEZvrbD5w==",
+            "license": "MIT",
+            "engines": {
+                "node": ">=0.12.0"
+            }
         },
         "node_modules/lazystream": {
             "version": "1.0.1",
@@ -28083,6 +28376,38 @@
             "version": "1.3.6",
             "license": "ISC"
         },
+        "node_modules/make-fetch-happen": {
+            "version": "13.0.1",
+            "resolved": "https://registry.npmjs.org/make-fetch-happen/-/make-fetch-happen-13.0.1.tgz",
+            "integrity": "sha512-cKTUFc/rbKUd/9meOvgrpJ2WrNzymt6jfRDdwg5UCnVzv9dTpEj9JS5m3wtziXVCjluIXyL8pcaukYqezIzZQA==",
+            "license": "ISC",
+            "dependencies": {
+                "@npmcli/agent": "^2.0.0",
+                "cacache": "^18.0.0",
+                "http-cache-semantics": "^4.1.1",
+                "is-lambda": "^1.0.1",
+                "minipass": "^7.0.2",
+                "minipass-fetch": "^3.0.0",
+                "minipass-flush": "^1.0.5",
+                "minipass-pipeline": "^1.2.4",
+                "negotiator": "^0.6.3",
+                "proc-log": "^4.2.0",
+                "promise-retry": "^2.0.1",
+                "ssri": "^10.0.0"
+            },
+            "engines": {
+                "node": "^16.14.0 || >=18.0.0"
+            }
+        },
+        "node_modules/make-fetch-happen/node_modules/proc-log": {
+            "version": "4.2.0",
+            "resolved": "https://registry.npmjs.org/proc-log/-/proc-log-4.2.0.tgz",
+            "integrity": "sha512-g8+OnU/L2v+wyiVK+D5fA34J7EH8jZ8DDlvwhRCMxmMj7UCBvxiO1mGeN+36JXIKF4zevU4kRBd8lVgG9vLelA==",
+            "license": "ISC",
+            "engines": {
+                "node": "^14.17.0 || ^16.13.0 || >=18.0.0"
+            }
+        },
         "node_modules/mark.js": {
             "version": "8.11.1",
             "resolved": "https://registry.npmjs.org/mark.js/-/mark.js-8.11.1.tgz",
@@ -28293,6 +28618,132 @@
                 "node": ">=16 || 14 >=14.17"
             }
         },
+        "node_modules/minipass-collect": {
+            "version": "2.0.1",
+            "resolved": "https://registry.npmjs.org/minipass-collect/-/minipass-collect-2.0.1.tgz",
+            "integrity": "sha512-D7V8PO9oaz7PWGLbCACuI1qEOsq7UKfLotx/C0Aet43fCUB/wfQ7DYeq2oR/svFJGYDHPr38SHATeaj/ZoKHKw==",
+            "license": "ISC",
+            "dependencies": {
+                "minipass": "^7.0.3"
+            },
+            "engines": {
+                "node": ">=16 || 14 >=14.17"
+            }
+        },
+        "node_modules/minipass-fetch": {
+            "version": "3.0.5",
+            "resolved": "https://registry.npmjs.org/minipass-fetch/-/minipass-fetch-3.0.5.tgz",
+            "integrity": "sha512-2N8elDQAtSnFV0Dk7gt15KHsS0Fyz6CbYZ360h0WTYV1Ty46li3rAXVOQj1THMNLdmrD9Vt5pBPtWtVkpwGBqg==",
+            "license": "MIT",
+            "dependencies": {
+                "minipass": "^7.0.3",
+                "minipass-sized": "^1.0.3",
+                "minizlib": "^2.1.2"
+            },
+            "engines": {
+                "node": "^14.17.0 || ^16.13.0 || >=18.0.0"
+            },
+            "optionalDependencies": {
+                "encoding": "^0.1.13"
+            }
+        },
+        "node_modules/minipass-fetch/node_modules/minizlib": {
+            "version": "2.1.2",
+            "resolved": "https://registry.npmjs.org/minizlib/-/minizlib-2.1.2.tgz",
+            "integrity": "sha512-bAxsR8BVfj60DWXHE3u30oHzfl4G7khkSuPW+qvpd7jFRHm7dLxOjUk1EHACJ/hxLY8phGJ0YhYHZo7jil7Qdg==",
+            "license": "MIT",
+            "dependencies": {
+                "minipass": "^3.0.0",
+                "yallist": "^4.0.0"
+            },
+            "engines": {
+                "node": ">= 8"
+            }
+        },
+        "node_modules/minipass-fetch/node_modules/minizlib/node_modules/minipass": {
+            "version": "3.3.6",
+            "resolved": "https://registry.npmjs.org/minipass/-/minipass-3.3.6.tgz",
+            "integrity": "sha512-DxiNidxSEK+tHG6zOIklvNOwm3hvCrbUrdtzY74U6HKTJxvIDfOUL5W5P2Ghd3DTkhhKPYGqeNUIh5qcM4YBfw==",
+            "license": "ISC",
+            "dependencies": {
+                "yallist": "^4.0.0"
+            },
+            "engines": {
+                "node": ">=8"
+            }
+        },
+        "node_modules/minipass-flush": {
+            "version": "1.0.7",
+            "resolved": "https://registry.npmjs.org/minipass-flush/-/minipass-flush-1.0.7.tgz",
+            "integrity": "sha512-TbqTz9cUwWyHS2Dy89P3ocAGUGxKjjLuR9z8w4WUTGAVgEj17/4nhgo2Du56i0Fm3Pm30g4iA8Lcqctc76jCzA==",
+            "license": "BlueOak-1.0.0",
+            "dependencies": {
+                "minipass": "^3.0.0"
+            },
+            "engines": {
+                "node": ">= 8"
+            }
+        },
+        "node_modules/minipass-flush/node_modules/minipass": {
+            "version": "3.3.6",
+            "resolved": "https://registry.npmjs.org/minipass/-/minipass-3.3.6.tgz",
+            "integrity": "sha512-DxiNidxSEK+tHG6zOIklvNOwm3hvCrbUrdtzY74U6HKTJxvIDfOUL5W5P2Ghd3DTkhhKPYGqeNUIh5qcM4YBfw==",
+            "license": "ISC",
+            "dependencies": {
+                "yallist": "^4.0.0"
+            },
+            "engines": {
+                "node": ">=8"
+            }
+        },
+        "node_modules/minipass-pipeline": {
+            "version": "1.2.4",
+            "resolved": "https://registry.npmjs.org/minipass-pipeline/-/minipass-pipeline-1.2.4.tgz",
+            "integrity": "sha512-xuIq7cIOt09RPRJ19gdi4b+RiNvDFYe5JH+ggNvBqGqpQXcru3PcRmOZuHBKWK1Txf9+cQ+HMVN4d6z46LZP7A==",
+            "license": "ISC",
+            "dependencies": {
+                "minipass": "^3.0.0"
+            },
+            "engines": {
+                "node": ">=8"
+            }
+        },
+        "node_modules/minipass-pipeline/node_modules/minipass": {
+            "version": "3.3.6",
+            "resolved": "https://registry.npmjs.org/minipass/-/minipass-3.3.6.tgz",
+            "integrity": "sha512-DxiNidxSEK+tHG6zOIklvNOwm3hvCrbUrdtzY74U6HKTJxvIDfOUL5W5P2Ghd3DTkhhKPYGqeNUIh5qcM4YBfw==",
+            "license": "ISC",
+            "dependencies": {
+                "yallist": "^4.0.0"
+            },
+            "engines": {
+                "node": ">=8"
+            }
+        },
+        "node_modules/minipass-sized": {
+            "version": "1.0.3",
+            "resolved": "https://registry.npmjs.org/minipass-sized/-/minipass-sized-1.0.3.tgz",
+            "integrity": "sha512-MbkQQ2CTiBMlA2Dm/5cY+9SWFEN8pzzOXi6rlM5Xxq0Yqbda5ZQy9sU75a673FE9ZK0Zsbr6Y5iP6u9nktfg2g==",
+            "license": "ISC",
+            "dependencies": {
+                "minipass": "^3.0.0"
+            },
+            "engines": {
+                "node": ">=8"
+            }
+        },
+        "node_modules/minipass-sized/node_modules/minipass": {
+            "version": "3.3.6",
+            "resolved": "https://registry.npmjs.org/minipass/-/minipass-3.3.6.tgz",
+            "integrity": "sha512-DxiNidxSEK+tHG6zOIklvNOwm3hvCrbUrdtzY74U6HKTJxvIDfOUL5W5P2Ghd3DTkhhKPYGqeNUIh5qcM4YBfw==",
+            "license": "ISC",
+            "dependencies": {
+                "yallist": "^4.0.0"
+            },
+            "engines": {
+                "node": ">=8"
+            }
+        },
         "node_modules/minizlib": {
             "version": "3.1.0",
             "resolved": "https://registry.npmjs.org/minizlib/-/minizlib-3.1.0.tgz",
@@ -28438,6 +28889,15 @@
             "funding": {
                 "type": "opencollective",
                 "url": "https://opencollective.com/express"
+            }
+        },
+        "node_modules/murmurhash3js": {
+            "version": "3.0.1",
+            "resolved": "https://registry.npmjs.org/murmurhash3js/-/murmurhash3js-3.0.1.tgz",
+            "integrity": "sha512-KL8QYUaxq7kUbcl0Yto51rMcYt7E/4N4BG3/c96Iqw1PQrTRspu8Cpx4TZ4Nunib1d4bEkIH3gjCYlP2RLBdow==",
+            "license": "MIT",
+            "engines": {
+                "node": ">=0.10.0"
             }
         },
         "node_modules/mute-stream": {
@@ -29502,6 +29962,21 @@
             "license": "MIT",
             "dependencies": {
                 "p-limit": "^3.0.2"
+            },
+            "engines": {
+                "node": ">=10"
+            },
+            "funding": {
+                "url": "https://github.com/sponsors/sindresorhus"
+            }
+        },
+        "node_modules/p-map": {
+            "version": "4.0.0",
+            "resolved": "https://registry.npmjs.org/p-map/-/p-map-4.0.0.tgz",
+            "integrity": "sha512-/bjOqmgETBYB5BoEeGVea8dmvHb2m9GLy1E9W43yeyfP6QQCZGFNa+XRceJEuDB6zqr+gKpIAmlLebMpykw/MQ==",
+            "license": "MIT",
+            "dependencies": {
+                "aggregate-error": "^3.0.0"
             },
             "engines": {
                 "node": ">=10"
@@ -33299,6 +33774,18 @@
                 "nan": "^2.23.0"
             }
         },
+        "node_modules/ssri": {
+            "version": "10.0.6",
+            "resolved": "https://registry.npmjs.org/ssri/-/ssri-10.0.6.tgz",
+            "integrity": "sha512-MGrFH9Z4NP9Iyhqn16sDtBpRRNJ0Y2hNa6D65h736fVSaPCHr4DM4sWUNvVaSuC+0OBGhwsrydQwmgfg5LncqQ==",
+            "license": "ISC",
+            "dependencies": {
+                "minipass": "^7.0.3"
+            },
+            "engines": {
+                "node": "^14.17.0 || ^16.13.0 || >=18.0.0"
+            }
+        },
         "node_modules/stack-generator": {
             "version": "2.0.10",
             "resolved": "https://registry.npmjs.org/stack-generator/-/stack-generator-2.0.10.tgz",
@@ -35369,12 +35856,61 @@
                 "url": "https://github.com/sponsors/sindresorhus"
             }
         },
+        "node_modules/unique-filename": {
+            "version": "3.0.0",
+            "resolved": "https://registry.npmjs.org/unique-filename/-/unique-filename-3.0.0.tgz",
+            "integrity": "sha512-afXhuC55wkAmZ0P18QsVE6kp8JaxrEokN2HGIoIVv2ijHQd419H0+6EigAFcIzXeMIkcIkNBpB3L/DXB3cTS/g==",
+            "license": "ISC",
+            "dependencies": {
+                "unique-slug": "^4.0.0"
+            },
+            "engines": {
+                "node": "^14.17.0 || ^16.13.0 || >=18.0.0"
+            }
+        },
+        "node_modules/unique-slug": {
+            "version": "4.0.0",
+            "resolved": "https://registry.npmjs.org/unique-slug/-/unique-slug-4.0.0.tgz",
+            "integrity": "sha512-WrcA6AyEfqDX5bWige/4NQfPZMtASNVxdmWR76WESYQVAACSgWcR6e9i0mofqqBxYFtL4oAxPIptY73/0YE1DQ==",
+            "license": "ISC",
+            "dependencies": {
+                "imurmurhash": "^0.1.4"
+            },
+            "engines": {
+                "node": "^14.17.0 || ^16.13.0 || >=18.0.0"
+            }
+        },
         "node_modules/universalify": {
             "version": "2.0.0",
             "license": "MIT",
             "engines": {
                 "node": ">= 10.0.0"
             }
+        },
+        "node_modules/unleash-client": {
+            "version": "6.6.0",
+            "resolved": "https://registry.npmjs.org/unleash-client/-/unleash-client-6.6.0.tgz",
+            "integrity": "sha512-xsxWobHY83d5n80aGVQVTXOVdxRw9vZxsXUeys5oucYRMzW3ymiy+QY0QBEWDORq0AffsP2suF5uj2M6On2qGw==",
+            "license": "Apache-2.0",
+            "dependencies": {
+                "http-proxy-agent": "^7.0.2",
+                "https-proxy-agent": "^7.0.5",
+                "ip-address": "^9.0.5",
+                "launchdarkly-eventsource": "2.0.3",
+                "make-fetch-happen": "^13.0.1",
+                "murmurhash3js": "^3.0.1",
+                "proxy-from-env": "^1.1.0",
+                "semver": "^7.6.2"
+            },
+            "engines": {
+                "node": ">=16"
+            }
+        },
+        "node_modules/unleash-client/node_modules/proxy-from-env": {
+            "version": "1.1.0",
+            "resolved": "https://registry.npmjs.org/proxy-from-env/-/proxy-from-env-1.1.0.tgz",
+            "integrity": "sha512-D+zkORCbA9f1tdWRK0RaCR3GPv50cMxcrz4X8k5LTSUD1Dkw47mKJEZQNunItRTkWwgtaUSo1RVFRIG9ZXiFYg==",
+            "license": "MIT"
         },
         "node_modules/unpipe": {
             "version": "1.0.0",
@@ -38062,6 +38598,42 @@
                 "uuid": "dist/bin/uuid"
             }
         },
+<<<<<<< HEAD
+=======
+        "packages/email/node_modules/ws": {
+            "version": "8.18.3",
+            "resolved": "https://registry.npmjs.org/ws/-/ws-8.18.3.tgz",
+            "integrity": "sha512-PEIGCY5tSlUt50cqyMXfCzX+oOPqN0vuGqWzbcJ2xvnkzkq46oOpz7dQaTDBdfICb4N14+GARUDw2XV2N4tvzg==",
+            "license": "MIT",
+            "engines": {
+                "node": ">=10.0.0"
+            },
+            "peerDependencies": {
+                "bufferutil": "^4.0.1",
+                "utf-8-validate": ">=5.0.2"
+            },
+            "peerDependenciesMeta": {
+                "bufferutil": {
+                    "optional": true
+                },
+                "utf-8-validate": {
+                    "optional": true
+                }
+            }
+        },
+        "packages/feature-flags": {
+            "name": "@nangohq/feature-flags",
+            "version": "1.0.0",
+            "dependencies": {
+                "@nangohq/utils": "file:../utils",
+                "@openfeature/server-sdk": "~1.18.0",
+                "unleash-client": "6.6.0"
+            },
+            "devDependencies": {
+                "vitest": "3.2.4"
+            }
+        },
+>>>>>>> aee0c7151 (feat(feature-flags): add unleash openfeature client)
         "packages/fleet": {
             "name": "@nangohq/fleet",
             "version": "1.0.0",

--- a/package-lock.json
+++ b/package-lock.json
@@ -6289,7 +6289,24 @@
             "dev": true,
             "license": "MIT"
         },
-<<<<<<< HEAD
+        "node_modules/@openfeature/core": {
+            "version": "1.9.1",
+            "resolved": "https://registry.npmjs.org/@openfeature/core/-/core-1.9.1.tgz",
+            "integrity": "sha512-YySPtH4s/rKKnHRU0xyFGrqMU8XA+OIPNWDrlEFxE6DCVWCIrxE5YpiB94YD2jMFn6SSdA0cwQ8vLkCkl8lm8A==",
+            "license": "Apache-2.0"
+        },
+        "node_modules/@openfeature/server-sdk": {
+            "version": "1.18.0",
+            "resolved": "https://registry.npmjs.org/@openfeature/server-sdk/-/server-sdk-1.18.0.tgz",
+            "integrity": "sha512-uP8nqEGBS58s3iWXx6d8vnJ6ZVt3DACJL4PWADOAuwIS4xXpID91783e9f6zQ0i1ijQpj3yx+3ZuCB2LfQMUMA==",
+            "license": "Apache-2.0",
+            "engines": {
+                "node": ">=18"
+            },
+            "peerDependencies": {
+                "@openfeature/core": "^1.7.0"
+            }
+        },
         "node_modules/@opensearch-project/opensearch": {
             "version": "2.13.0",
             "resolved": "https://registry.npmjs.org/@opensearch-project/opensearch/-/opensearch-2.13.0.tgz",
@@ -6320,26 +6337,6 @@
             "integrity": "sha512-6aU+Rwsezw7VR8/nyvKTx8QpWH9FrcYiXXlqC4z5d5XQBDRqtbfsRjnwGyqbi3gddNtWHuEk9OANUotL26qKUw==",
             "license": "BSD-3-Clause"
         },
-=======
-        "node_modules/@openfeature/core": {
-            "version": "1.9.1",
-            "resolved": "https://registry.npmjs.org/@openfeature/core/-/core-1.9.1.tgz",
-            "integrity": "sha512-YySPtH4s/rKKnHRU0xyFGrqMU8XA+OIPNWDrlEFxE6DCVWCIrxE5YpiB94YD2jMFn6SSdA0cwQ8vLkCkl8lm8A==",
-            "license": "Apache-2.0"
-        },
-        "node_modules/@openfeature/server-sdk": {
-            "version": "1.18.0",
-            "resolved": "https://registry.npmjs.org/@openfeature/server-sdk/-/server-sdk-1.18.0.tgz",
-            "integrity": "sha512-uP8nqEGBS58s3iWXx6d8vnJ6ZVt3DACJL4PWADOAuwIS4xXpID91783e9f6zQ0i1ijQpj3yx+3ZuCB2LfQMUMA==",
-            "license": "Apache-2.0",
-            "engines": {
-                "node": ">=18"
-            },
-            "peerDependencies": {
-                "@openfeature/core": "^1.7.0"
-            }
-        },
->>>>>>> 92f51237d (Pin openfeature versions and add core as dependency)
         "node_modules/@opentelemetry/api": {
             "version": "1.9.1",
             "resolved": "https://registry.npmjs.org/@opentelemetry/api/-/api-1.9.1.tgz",
@@ -34238,6 +34235,26 @@
                 "url": "https://github.com/sponsors/sindresorhus"
             }
         },
+        "node_modules/strip-literal": {
+            "version": "3.1.0",
+            "resolved": "https://registry.npmjs.org/strip-literal/-/strip-literal-3.1.0.tgz",
+            "integrity": "sha512-8r3mkIM/2+PpjHoOtiAW8Rg3jJLHaV7xPwG+YRGrv6FP0wwk/toTpATxWYOW0BKdWwl82VT2tFYi5DlROa0Mxg==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "js-tokens": "^9.0.1"
+            },
+            "funding": {
+                "url": "https://github.com/sponsors/antfu"
+            }
+        },
+        "node_modules/strip-literal/node_modules/js-tokens": {
+            "version": "9.0.1",
+            "resolved": "https://registry.npmjs.org/js-tokens/-/js-tokens-9.0.1.tgz",
+            "integrity": "sha512-mxa9E9ITFOt0ban3j6L5MpjwegGz6lBQmM1IJkWeBZGcMxto50+eWdjC/52xDbS2vy0k7vIMK0Fe2wfL9OQSpQ==",
+            "dev": true,
+            "license": "MIT"
+        },
         "node_modules/stripe": {
             "version": "18.2.1",
             "resolved": "https://registry.npmjs.org/stripe/-/stripe-18.2.1.tgz",
@@ -35040,6 +35057,16 @@
             },
             "funding": {
                 "url": "https://github.com/sponsors/SuperchupuDev"
+            }
+        },
+        "node_modules/tinypool": {
+            "version": "1.1.1",
+            "resolved": "https://registry.npmjs.org/tinypool/-/tinypool-1.1.1.tgz",
+            "integrity": "sha512-Zba82s87IFq9A9XmjiX5uZA/ARWDrB03OHlq+Vw1fSdt0I+4/Kutwy8BP4Y/y/aORMo61FQ0vIb5j44vSo5Pkg==",
+            "dev": true,
+            "license": "MIT",
+            "engines": {
+                "node": "^18.0.0 || >=20.0.0"
             }
         },
         "node_modules/tinyrainbow": {
@@ -36346,6 +36373,61 @@
                     "optional": true
                 }
             }
+        },
+        "node_modules/vite-node": {
+            "version": "3.2.4",
+            "resolved": "https://registry.npmjs.org/vite-node/-/vite-node-3.2.4.tgz",
+            "integrity": "sha512-EbKSKh+bh1E1IFxeO0pg1n4dvoOTt0UDiXMd/qn++r98+jPO1xtJilvXldeuQ8giIB5IkpjCgMleHMNEsGH6pg==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "cac": "^6.7.14",
+                "debug": "^4.4.1",
+                "es-module-lexer": "^1.7.0",
+                "pathe": "^2.0.3",
+                "vite": "^5.0.0 || ^6.0.0 || ^7.0.0-0"
+            },
+            "bin": {
+                "vite-node": "vite-node.mjs"
+            },
+            "engines": {
+                "node": "^18.0.0 || ^20.0.0 || >=22.0.0"
+            },
+            "funding": {
+                "url": "https://opencollective.com/vitest"
+            }
+        },
+        "node_modules/vite-node/node_modules/debug": {
+            "version": "4.4.3",
+            "resolved": "https://registry.npmjs.org/debug/-/debug-4.4.3.tgz",
+            "integrity": "sha512-RGwwWnwQvkVfavKVt22FGLw+xYSdzARwm0ru6DhTVA3umU5hZc28V3kO4stgYryrTlLpuvgI9GiijltAjNbcqA==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "ms": "^2.1.3"
+            },
+            "engines": {
+                "node": ">=6.0"
+            },
+            "peerDependenciesMeta": {
+                "supports-color": {
+                    "optional": true
+                }
+            }
+        },
+        "node_modules/vite-node/node_modules/es-module-lexer": {
+            "version": "1.7.0",
+            "resolved": "https://registry.npmjs.org/es-module-lexer/-/es-module-lexer-1.7.0.tgz",
+            "integrity": "sha512-jEQoCwk8hyb2AZziIOLhDqpm5+2ww5uIE6lkO/6jcOCusfk6LhMHpXXfBLXTZ7Ydyt0j4VoUQv6uGNYbdW+kBA==",
+            "dev": true,
+            "license": "MIT"
+        },
+        "node_modules/vite-node/node_modules/ms": {
+            "version": "2.1.3",
+            "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.3.tgz",
+            "integrity": "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==",
+            "dev": true,
+            "license": "MIT"
         },
         "node_modules/vite-plugin-checker": {
             "version": "0.9.3",
@@ -38619,8 +38701,6 @@
                 "uuid": "dist/bin/uuid"
             }
         },
-<<<<<<< HEAD
-=======
         "packages/email/node_modules/ws": {
             "version": "8.18.3",
             "resolved": "https://registry.npmjs.org/ws/-/ws-8.18.3.tgz",
@@ -38655,7 +38735,168 @@
                 "vitest": "3.2.4"
             }
         },
->>>>>>> aee0c7151 (feat(feature-flags): add unleash openfeature client)
+        "packages/feature-flags/node_modules/@vitest/mocker": {
+            "version": "3.2.4",
+            "resolved": "https://registry.npmjs.org/@vitest/mocker/-/mocker-3.2.4.tgz",
+            "integrity": "sha512-46ryTE9RZO/rfDd7pEqFl7etuyzekzEhUbTW3BvmeO/BcCMEgq59BKhek3dXDWgAj4oMK6OZi+vRr1wPW6qjEQ==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "@vitest/spy": "3.2.4",
+                "estree-walker": "^3.0.3",
+                "magic-string": "^0.30.17"
+            },
+            "funding": {
+                "url": "https://opencollective.com/vitest"
+            },
+            "peerDependencies": {
+                "msw": "^2.4.9",
+                "vite": "^5.0.0 || ^6.0.0 || ^7.0.0-0"
+            },
+            "peerDependenciesMeta": {
+                "msw": {
+                    "optional": true
+                },
+                "vite": {
+                    "optional": true
+                }
+            }
+        },
+        "packages/feature-flags/node_modules/@vitest/runner": {
+            "version": "3.2.4",
+            "resolved": "https://registry.npmjs.org/@vitest/runner/-/runner-3.2.4.tgz",
+            "integrity": "sha512-oukfKT9Mk41LreEW09vt45f8wx7DordoWUZMYdY/cyAk7w5TWkTRCNZYF7sX7n2wB7jyGAl74OxgwhPgKaqDMQ==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "@vitest/utils": "3.2.4",
+                "pathe": "^2.0.3",
+                "strip-literal": "^3.0.0"
+            },
+            "funding": {
+                "url": "https://opencollective.com/vitest"
+            }
+        },
+        "packages/feature-flags/node_modules/@vitest/snapshot": {
+            "version": "3.2.4",
+            "resolved": "https://registry.npmjs.org/@vitest/snapshot/-/snapshot-3.2.4.tgz",
+            "integrity": "sha512-dEYtS7qQP2CjU27QBC5oUOxLE/v5eLkGqPE0ZKEIDGMs4vKWe7IjgLOeauHsR0D5YuuycGRO5oSRXnwnmA78fQ==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "@vitest/pretty-format": "3.2.4",
+                "magic-string": "^0.30.17",
+                "pathe": "^2.0.3"
+            },
+            "funding": {
+                "url": "https://opencollective.com/vitest"
+            }
+        },
+        "packages/feature-flags/node_modules/debug": {
+            "version": "4.4.3",
+            "resolved": "https://registry.npmjs.org/debug/-/debug-4.4.3.tgz",
+            "integrity": "sha512-RGwwWnwQvkVfavKVt22FGLw+xYSdzARwm0ru6DhTVA3umU5hZc28V3kO4stgYryrTlLpuvgI9GiijltAjNbcqA==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "ms": "^2.1.3"
+            },
+            "engines": {
+                "node": ">=6.0"
+            },
+            "peerDependenciesMeta": {
+                "supports-color": {
+                    "optional": true
+                }
+            }
+        },
+        "packages/feature-flags/node_modules/ms": {
+            "version": "2.1.3",
+            "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.3.tgz",
+            "integrity": "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==",
+            "dev": true,
+            "license": "MIT"
+        },
+        "packages/feature-flags/node_modules/std-env": {
+            "version": "3.10.0",
+            "resolved": "https://registry.npmjs.org/std-env/-/std-env-3.10.0.tgz",
+            "integrity": "sha512-5GS12FdOZNliM5mAOxFRg7Ir0pWz8MdpYm6AY6VPkGpbA7ZzmbzNcBJQ0GPvvyWgcY7QAhCgf9Uy89I03faLkg==",
+            "dev": true,
+            "license": "MIT"
+        },
+        "packages/feature-flags/node_modules/vitest": {
+            "version": "3.2.4",
+            "resolved": "https://registry.npmjs.org/vitest/-/vitest-3.2.4.tgz",
+            "integrity": "sha512-LUCP5ev3GURDysTWiP47wRRUpLKMOfPh+yKTx3kVIEiu5KOMeqzpnYNsKyOoVrULivR8tLcks4+lga33Whn90A==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "@types/chai": "^5.2.2",
+                "@vitest/expect": "3.2.4",
+                "@vitest/mocker": "3.2.4",
+                "@vitest/pretty-format": "^3.2.4",
+                "@vitest/runner": "3.2.4",
+                "@vitest/snapshot": "3.2.4",
+                "@vitest/spy": "3.2.4",
+                "@vitest/utils": "3.2.4",
+                "chai": "^5.2.0",
+                "debug": "^4.4.1",
+                "expect-type": "^1.2.1",
+                "magic-string": "^0.30.17",
+                "pathe": "^2.0.3",
+                "picomatch": "^4.0.2",
+                "std-env": "^3.9.0",
+                "tinybench": "^2.9.0",
+                "tinyexec": "^0.3.2",
+                "tinyglobby": "^0.2.14",
+                "tinypool": "^1.1.1",
+                "tinyrainbow": "^2.0.0",
+                "vite": "^5.0.0 || ^6.0.0 || ^7.0.0-0",
+                "vite-node": "3.2.4",
+                "why-is-node-running": "^2.3.0"
+            },
+            "bin": {
+                "vitest": "vitest.mjs"
+            },
+            "engines": {
+                "node": "^18.0.0 || ^20.0.0 || >=22.0.0"
+            },
+            "funding": {
+                "url": "https://opencollective.com/vitest"
+            },
+            "peerDependencies": {
+                "@edge-runtime/vm": "*",
+                "@types/debug": "^4.1.12",
+                "@types/node": "^18.0.0 || ^20.0.0 || >=22.0.0",
+                "@vitest/browser": "3.2.4",
+                "@vitest/ui": "3.2.4",
+                "happy-dom": "*",
+                "jsdom": "*"
+            },
+            "peerDependenciesMeta": {
+                "@edge-runtime/vm": {
+                    "optional": true
+                },
+                "@types/debug": {
+                    "optional": true
+                },
+                "@types/node": {
+                    "optional": true
+                },
+                "@vitest/browser": {
+                    "optional": true
+                },
+                "@vitest/ui": {
+                    "optional": true
+                },
+                "happy-dom": {
+                    "optional": true
+                },
+                "jsdom": {
+                    "optional": true
+                }
+            }
+        },
         "packages/fleet": {
             "name": "@nangohq/fleet",
             "version": "1.0.0",

--- a/packages/feature-flags/lib/client.ts
+++ b/packages/feature-flags/lib/client.ts
@@ -1,0 +1,41 @@
+import { OpenFeature } from '@openfeature/server-sdk';
+
+import { NoopProvider } from './providers/noop.js';
+
+import type { FlagContext } from './types.js';
+import type { Client, EvaluationContext, Provider } from '@openfeature/server-sdk';
+
+export interface FeatureFlagsClient {
+    isEnabled(key: string, context: FlagContext, defaultValue: boolean): Promise<boolean>;
+    destroy(): Promise<void>;
+}
+
+function toEvaluationContext(context: FlagContext): EvaluationContext {
+    const out: EvaluationContext = {};
+    for (const [key, value] of Object.entries(context)) {
+        if (value === undefined) continue;
+        out[key] = value;
+    }
+    return out;
+}
+
+const FLAG_DOMAIN = 'nango-feature-flags';
+
+export function buildFeatureFlagsClient(provider: Provider): FeatureFlagsClient {
+    OpenFeature.setProvider(FLAG_DOMAIN, provider);
+    const ofClient: Client = OpenFeature.getClient(FLAG_DOMAIN);
+
+    return {
+        async isEnabled(key, context, defaultValue) {
+            try {
+                return await ofClient.getBooleanValue(key, defaultValue, toEvaluationContext(context));
+            } catch {
+                return defaultValue;
+            }
+        },
+        async destroy() {
+            // Swap to NOOP so OpenFeature unregisters the provider and invokes its onClose internally.
+            await OpenFeature.setProviderAndWait(FLAG_DOMAIN, new NoopProvider());
+        }
+    };
+}

--- a/packages/feature-flags/lib/client.ts
+++ b/packages/feature-flags/lib/client.ts
@@ -1,9 +1,13 @@
 import { OpenFeature } from '@openfeature/server-sdk';
 
+import { getLogger } from '@nangohq/utils';
+
 import { NoopProvider } from './providers/noop.js';
 
 import type { FlagContext } from './types.js';
 import type { Client, EvaluationContext, JsonValue, Provider } from '@openfeature/server-sdk';
+
+const logger = getLogger('FeatureFlags');
 
 export interface FeatureFlagsClient {
     isEnabled(key: string, context: FlagContext, defaultValue: boolean): Promise<boolean>;
@@ -23,6 +27,11 @@ function toEvaluationContext(context: FlagContext): EvaluationContext {
     return out;
 }
 
+function fallbackOnEvaluationError<T>(key: string, defaultValue: T, err: unknown): T {
+    logger.warning('Feature flag evaluation failed, using default', { key, err });
+    return defaultValue;
+}
+
 const FLAG_DOMAIN = 'nango-feature-flags';
 
 export function buildFeatureFlagsClient(provider: Provider): FeatureFlagsClient {
@@ -33,29 +42,29 @@ export function buildFeatureFlagsClient(provider: Provider): FeatureFlagsClient 
         async isEnabled(key, context, defaultValue) {
             try {
                 return await ofClient.getBooleanValue(key, defaultValue, toEvaluationContext(context));
-            } catch {
-                return defaultValue;
+            } catch (err) {
+                return fallbackOnEvaluationError(key, defaultValue, err);
             }
         },
         async getString(key, context, defaultValue) {
             try {
                 return await ofClient.getStringValue(key, defaultValue, toEvaluationContext(context));
-            } catch {
-                return defaultValue;
+            } catch (err) {
+                return fallbackOnEvaluationError(key, defaultValue, err);
             }
         },
         async getNumber(key, context, defaultValue) {
             try {
                 return await ofClient.getNumberValue(key, defaultValue, toEvaluationContext(context));
-            } catch {
-                return defaultValue;
+            } catch (err) {
+                return fallbackOnEvaluationError(key, defaultValue, err);
             }
         },
         async getObject(key, context, defaultValue) {
             try {
                 return (await ofClient.getObjectValue(key, defaultValue, toEvaluationContext(context))) as typeof defaultValue;
-            } catch {
-                return defaultValue;
+            } catch (err) {
+                return fallbackOnEvaluationError(key, defaultValue, err);
             }
         },
         async destroy() {

--- a/packages/feature-flags/lib/client.ts
+++ b/packages/feature-flags/lib/client.ts
@@ -3,10 +3,14 @@ import { OpenFeature } from '@openfeature/server-sdk';
 import { NoopProvider } from './providers/noop.js';
 
 import type { FlagContext } from './types.js';
-import type { Client, EvaluationContext, Provider } from '@openfeature/server-sdk';
+import type { Client, EvaluationContext, JsonValue, Provider } from '@openfeature/server-sdk';
 
 export interface FeatureFlagsClient {
     isEnabled(key: string, context: FlagContext, defaultValue: boolean): Promise<boolean>;
+    // Non-boolean flags, served as Unleash variant payloads (provisioned by nango-flags).
+    getString(key: string, context: FlagContext, defaultValue: string): Promise<string>;
+    getNumber(key: string, context: FlagContext, defaultValue: number): Promise<number>;
+    getObject<T extends JsonValue>(key: string, context: FlagContext, defaultValue: T): Promise<T>;
     destroy(): Promise<void>;
 }
 
@@ -29,6 +33,27 @@ export function buildFeatureFlagsClient(provider: Provider): FeatureFlagsClient 
         async isEnabled(key, context, defaultValue) {
             try {
                 return await ofClient.getBooleanValue(key, defaultValue, toEvaluationContext(context));
+            } catch {
+                return defaultValue;
+            }
+        },
+        async getString(key, context, defaultValue) {
+            try {
+                return await ofClient.getStringValue(key, defaultValue, toEvaluationContext(context));
+            } catch {
+                return defaultValue;
+            }
+        },
+        async getNumber(key, context, defaultValue) {
+            try {
+                return await ofClient.getNumberValue(key, defaultValue, toEvaluationContext(context));
+            } catch {
+                return defaultValue;
+            }
+        },
+        async getObject(key, context, defaultValue) {
+            try {
+                return (await ofClient.getObjectValue(key, defaultValue, toEvaluationContext(context))) as typeof defaultValue;
             } catch {
                 return defaultValue;
             }

--- a/packages/feature-flags/lib/client.unit.test.ts
+++ b/packages/feature-flags/lib/client.unit.test.ts
@@ -1,0 +1,45 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+const mockLogger = vi.hoisted(() => ({
+    info: vi.fn(),
+    warning: vi.fn(),
+    error: vi.fn(),
+    debug: vi.fn()
+}));
+
+const openFeatureClient = vi.hoisted(() => ({
+    getBooleanValue: vi.fn(),
+    getStringValue: vi.fn(),
+    getNumberValue: vi.fn(),
+    getObjectValue: vi.fn()
+}));
+
+vi.mock('@nangohq/utils', () => ({
+    getLogger: vi.fn(() => mockLogger)
+}));
+
+vi.mock('@openfeature/server-sdk', () => ({
+    OpenFeature: {
+        setProvider: vi.fn(),
+        getClient: vi.fn(() => openFeatureClient),
+        setProviderAndWait: vi.fn()
+    }
+}));
+
+describe('buildFeatureFlagsClient', () => {
+    beforeEach(() => {
+        vi.clearAllMocks();
+    });
+
+    it('logs and returns the default when evaluation fails', async () => {
+        const { buildFeatureFlagsClient } = await import('./client.js');
+        const { NoopProvider } = await import('./providers/noop.js');
+        openFeatureClient.getBooleanValue.mockRejectedValue(new Error('provider down'));
+        const client = buildFeatureFlagsClient(new NoopProvider());
+        await expect(client.isEnabled('my-flag', {}, false)).resolves.toBe(false);
+        expect(mockLogger.warning).toHaveBeenCalledWith('Feature flag evaluation failed, using default', {
+            key: 'my-flag',
+            err: expect.any(Error)
+        });
+    });
+});

--- a/packages/feature-flags/lib/env.ts
+++ b/packages/feature-flags/lib/env.ts
@@ -1,0 +1,3 @@
+import { ENVS, parseEnvs } from '@nangohq/utils';
+
+export const envs = parseEnvs(ENVS);

--- a/packages/feature-flags/lib/index.ts
+++ b/packages/feature-flags/lib/index.ts
@@ -1,0 +1,60 @@
+import { buildFeatureFlagsClient } from './client.js';
+import { envs } from './env.js';
+import { NoopProvider } from './providers/noop.js';
+import { UnleashProvider } from './providers/unleash.js';
+
+import type { FeatureFlagsClient } from './client.js';
+import type { Provider } from '@openfeature/server-sdk';
+
+export type { FeatureFlagsClient } from './client.js';
+export type { FlagContext } from './types.js';
+export { FLAGS, type FlagKey } from './registry.js';
+
+let clientPromise: Promise<FeatureFlagsClient> | undefined;
+let destroyPromise: Promise<void> | undefined;
+
+export async function getFeatureFlagsClient(): Promise<FeatureFlagsClient> {
+    if (destroyPromise) await destroyPromise;
+    if (clientPromise) return clientPromise;
+    clientPromise = createClient();
+    return clientPromise;
+}
+
+export async function destroy(): Promise<void> {
+    if (destroyPromise) return destroyPromise;
+    const promise = clientPromise;
+    if (!promise) return;
+    destroyPromise = (async () => {
+        try {
+            const client = await promise;
+            await client.destroy();
+        } finally {
+            clientPromise = undefined;
+            destroyPromise = undefined;
+        }
+    })();
+    return destroyPromise;
+}
+
+async function createClient(): Promise<FeatureFlagsClient> {
+    const provider = await buildProvider();
+    return buildFeatureFlagsClient(provider);
+}
+
+async function buildProvider(): Promise<Provider> {
+    if (envs.NANGO_FLAG_PROVIDER === 'unleash') {
+        if (!envs.NANGO_UNLEASH_URL) {
+            console.warn('NANGO_FLAG_PROVIDER=unleash but NANGO_UNLEASH_URL is unset; using noop provider');
+            return new NoopProvider();
+        }
+        const provider = new UnleashProvider({
+            url: envs.NANGO_UNLEASH_URL,
+            appName: envs.NANGO_UNLEASH_APP_NAME,
+            apiToken: envs.NANGO_UNLEASH_API_TOKEN,
+            refreshIntervalMs: envs.NANGO_UNLEASH_REFRESH_INTERVAL_MS
+        });
+        await provider.initialize();
+        return provider;
+    }
+    return new NoopProvider();
+}

--- a/packages/feature-flags/lib/index.ts
+++ b/packages/feature-flags/lib/index.ts
@@ -1,3 +1,5 @@
+import { getLogger } from '@nangohq/utils';
+
 import { buildFeatureFlagsClient } from './client.js';
 import { envs } from './env.js';
 import { NoopProvider } from './providers/noop.js';
@@ -13,10 +15,13 @@ export { FLAGS, type FlagKey } from './registry.js';
 let clientPromise: Promise<FeatureFlagsClient> | undefined;
 let destroyPromise: Promise<void> | undefined;
 
+const logger = getLogger('FeatureFlags');
+
 export async function getFeatureFlagsClient(): Promise<FeatureFlagsClient> {
     if (destroyPromise) await destroyPromise;
     if (clientPromise) return clientPromise;
     clientPromise = createClient();
+    clientPromise.catch((err: unknown) => logger.error('Error creating feature flags client', err));
     return clientPromise;
 }
 
@@ -26,6 +31,7 @@ export async function destroy(): Promise<void> {
     if (!promise) return;
     destroyPromise = (async () => {
         try {
+            logger.info('Destroying feature flags client');
             const client = await promise;
             await client.destroy();
         } finally {
@@ -44,7 +50,7 @@ async function createClient(): Promise<FeatureFlagsClient> {
 async function buildProvider(): Promise<Provider> {
     if (envs.NANGO_FLAG_PROVIDER === 'unleash') {
         if (!envs.NANGO_UNLEASH_URL) {
-            console.warn('NANGO_FLAG_PROVIDER=unleash but NANGO_UNLEASH_URL is unset; using noop provider');
+            logger.warning('NANGO_FLAG_PROVIDER=unleash but NANGO_UNLEASH_URL is unset; using noop provider');
             return new NoopProvider();
         }
         const provider = new UnleashProvider({
@@ -54,7 +60,9 @@ async function buildProvider(): Promise<Provider> {
             refreshIntervalMs: envs.NANGO_UNLEASH_REFRESH_INTERVAL_MS
         });
         await provider.initialize();
+        logger.info('Unleash provider initialized');
         return provider;
     }
+    logger.info('Using noop feature-flags provider');
     return new NoopProvider();
 }

--- a/packages/feature-flags/lib/index.ts
+++ b/packages/feature-flags/lib/index.ts
@@ -14,18 +14,56 @@ export { FLAGS, type FlagKey } from './registry.js';
 
 let clientPromise: Promise<FeatureFlagsClient> | undefined;
 let destroyPromise: Promise<void> | undefined;
+let reconnectTimer: ReturnType<typeof setTimeout> | undefined;
 
 const logger = getLogger('FeatureFlags');
+
+function cancelReconnect(): void {
+    if (reconnectTimer) {
+        clearTimeout(reconnectTimer);
+        reconnectTimer = undefined;
+    }
+}
+
+function scheduleReconnect(): void {
+    if (reconnectTimer) return;
+    if (envs.NANGO_FLAG_PROVIDER !== 'unleash' || !envs.NANGO_UNLEASH_URL) return;
+
+    reconnectTimer = setTimeout(() => {
+        reconnectTimer = undefined;
+        if (clientPromise || destroyPromise) return;
+        void getFeatureFlagsClient()
+            .then(() => {
+                logger.info('Feature flags client reconnected to Unleash');
+            })
+            .catch(() => {
+                scheduleReconnect();
+            });
+    }, envs.NANGO_UNLEASH_REFRESH_INTERVAL_MS);
+    if (typeof reconnectTimer.unref === 'function') {
+        reconnectTimer.unref();
+    }
+}
 
 export async function getFeatureFlagsClient(): Promise<FeatureFlagsClient> {
     if (destroyPromise) await destroyPromise;
     if (clientPromise) return clientPromise;
-    clientPromise = createClient();
-    clientPromise.catch((err: unknown) => logger.error('Error creating feature flags client', err));
+    clientPromise = createClient()
+        .then((client) => {
+            cancelReconnect();
+            return client;
+        })
+        .catch((err: unknown) => {
+            clientPromise = undefined;
+            logger.error('Error creating feature flags client', err);
+            scheduleReconnect();
+            throw err;
+        });
     return clientPromise;
 }
 
 export async function destroy(): Promise<void> {
+    cancelReconnect();
     if (destroyPromise) return destroyPromise;
     const promise = clientPromise;
     if (!promise) return;
@@ -37,6 +75,7 @@ export async function destroy(): Promise<void> {
         } finally {
             clientPromise = undefined;
             destroyPromise = undefined;
+            cancelReconnect();
         }
     })();
     return destroyPromise;

--- a/packages/feature-flags/lib/index.ts
+++ b/packages/feature-flags/lib/index.ts
@@ -57,10 +57,15 @@ async function buildProvider(): Promise<Provider> {
             url: envs.NANGO_UNLEASH_URL,
             appName: envs.NANGO_UNLEASH_APP_NAME,
             apiToken: envs.NANGO_UNLEASH_API_TOKEN,
-            refreshIntervalMs: envs.NANGO_UNLEASH_REFRESH_INTERVAL_MS
+            refreshIntervalMs: envs.NANGO_UNLEASH_REFRESH_INTERVAL_MS,
+            initTimeoutMs: envs.NANGO_UNLEASH_INIT_TIMEOUT_MS
         });
         await provider.initialize();
-        logger.info('Unleash provider initialized');
+        if (provider.hasSynchronized()) {
+            logger.info('Unleash provider initialized');
+        } else {
+            logger.warning('Unleash provider initialized without toggle data; evaluations will use defaults until synchronized');
+        }
         return provider;
     }
     logger.info('Using noop feature-flags provider');

--- a/packages/feature-flags/lib/index.unit.test.ts
+++ b/packages/feature-flags/lib/index.unit.test.ts
@@ -1,0 +1,134 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+
+const mockEnvs = {
+    NANGO_FLAG_PROVIDER: 'noop' as 'noop' | 'unleash',
+    NANGO_UNLEASH_URL: undefined as string | undefined,
+    NANGO_UNLEASH_API_TOKEN: undefined as string | undefined,
+    NANGO_UNLEASH_APP_NAME: 'nango',
+    NANGO_UNLEASH_REFRESH_INTERVAL_MS: 30_000
+};
+
+vi.mock('./env.js', () => ({
+    envs: mockEnvs
+}));
+
+const { unleashMockState, unleashInstances } = vi.hoisted(() => ({
+    unleashMockState: {
+        readyEvent: 'synchronized' as 'synchronized' | 'error',
+        readyDelayMs: 0
+    },
+    unleashInstances: [] as { destroy: ReturnType<typeof vi.fn> }[]
+}));
+
+vi.mock('unleash-client', () => {
+    return {
+        initialize: vi.fn(() => {
+            const instance = {
+                on: vi.fn(),
+                once: vi.fn((event: string, fn: (err?: Error) => void) => {
+                    if (event !== unleashMockState.readyEvent) return;
+                    const fire = () => fn(event === 'error' ? new Error('boom') : undefined);
+                    if (unleashMockState.readyDelayMs > 0) {
+                        setTimeout(fire, unleashMockState.readyDelayMs);
+                    } else {
+                        queueMicrotask(fire);
+                    }
+                }),
+                isEnabled: vi.fn(() => true),
+                destroy: vi.fn()
+            };
+            unleashInstances.push(instance);
+            return instance;
+        })
+    };
+});
+
+describe('getFeatureFlagsClient', () => {
+    beforeEach(async () => {
+        vi.clearAllMocks();
+        mockEnvs.NANGO_FLAG_PROVIDER = 'noop';
+        mockEnvs.NANGO_UNLEASH_URL = undefined;
+        mockEnvs.NANGO_UNLEASH_API_TOKEN = undefined;
+        unleashMockState.readyEvent = 'synchronized';
+        unleashMockState.readyDelayMs = 0;
+        unleashInstances.length = 0;
+        vi.resetModules();
+        const { destroy } = await import('./index.js');
+        await destroy();
+    });
+
+    afterEach(() => {
+        vi.restoreAllMocks();
+    });
+
+    it('returns the default value with the noop provider', async () => {
+        vi.resetModules();
+        const { getFeatureFlagsClient } = await import('./index.js');
+        const client = await getFeatureFlagsClient();
+        await expect(client.isEnabled('any-flag', { 'account.uuid': 'abc' }, true)).resolves.toBe(true);
+        await expect(client.isEnabled('any-flag', { 'account.uuid': 'abc' }, false)).resolves.toBe(false);
+    });
+
+    it('falls back to noop when unleash is selected but url is missing', async () => {
+        mockEnvs.NANGO_FLAG_PROVIDER = 'unleash';
+        const warn = vi.spyOn(console, 'warn').mockImplementation(() => {});
+        vi.resetModules();
+        const { getFeatureFlagsClient } = await import('./index.js');
+        const client = await getFeatureFlagsClient();
+        await expect(client.isEnabled('any-flag', {}, true)).resolves.toBe(true);
+        expect(warn).toHaveBeenCalled();
+    });
+
+    it('uses unleash provider when configured', async () => {
+        mockEnvs.NANGO_FLAG_PROVIDER = 'unleash';
+        mockEnvs.NANGO_UNLEASH_URL = 'http://unleash.local:4242/api';
+        mockEnvs.NANGO_UNLEASH_API_TOKEN = 'token';
+        vi.resetModules();
+        const { getFeatureFlagsClient } = await import('./index.js');
+        const client = await getFeatureFlagsClient();
+        await expect(client.isEnabled('any-flag', { 'account.uuid': 'abc' }, false)).resolves.toBe(true);
+    });
+
+    it('resolves initialize() when unleash emits error before synchronized', async () => {
+        mockEnvs.NANGO_FLAG_PROVIDER = 'unleash';
+        mockEnvs.NANGO_UNLEASH_URL = 'http://unleash.local:4242/api';
+        unleashMockState.readyEvent = 'error';
+        const errSpy = vi.spyOn(console, 'error').mockImplementation(() => {});
+        vi.resetModules();
+        const { getFeatureFlagsClient } = await import('./index.js');
+        const client = await getFeatureFlagsClient();
+        await expect(client.isEnabled('any-flag', {}, false)).resolves.toBe(true);
+        errSpy.mockRestore();
+    });
+
+    it('serializes destroy() called during initialization', async () => {
+        mockEnvs.NANGO_FLAG_PROVIDER = 'unleash';
+        mockEnvs.NANGO_UNLEASH_URL = 'http://unleash.local:4242/api';
+        unleashMockState.readyDelayMs = 30;
+        vi.resetModules();
+        const { getFeatureFlagsClient, destroy } = await import('./index.js');
+        const initPromise = getFeatureFlagsClient();
+        const destroyPromise = destroy();
+        const [client] = await Promise.all([initPromise, destroyPromise]);
+        // The first instance was destroyed as part of the swap to NOOP.
+        expect(unleashInstances[0]?.destroy).toHaveBeenCalledTimes(1);
+        // After destroy, isEnabled should still resolve (now backed by NOOP -> default).
+        await expect(client.isEnabled('any-flag', {}, false)).resolves.toBe(false);
+    });
+
+    it('rebuilds a fresh provider after destroy/recreate', async () => {
+        mockEnvs.NANGO_FLAG_PROVIDER = 'unleash';
+        mockEnvs.NANGO_UNLEASH_URL = 'http://unleash.local:4242/api';
+        vi.resetModules();
+        const { getFeatureFlagsClient, destroy } = await import('./index.js');
+        const first = await getFeatureFlagsClient();
+        await destroy();
+        const second = await getFeatureFlagsClient();
+        expect(second).not.toBe(first);
+        // Two unleash instances were created (one per recreate).
+        expect(unleashInstances.length).toBe(2);
+        // The first unleash instance was torn down by the destroy/swap.
+        expect(unleashInstances[0]?.destroy).toHaveBeenCalledTimes(1);
+        await expect(second.isEnabled('any-flag', {}, false)).resolves.toBe(true);
+    });
+});

--- a/packages/feature-flags/lib/index.unit.test.ts
+++ b/packages/feature-flags/lib/index.unit.test.ts
@@ -29,7 +29,8 @@ vi.mock('@nangohq/utils', async (importOriginal) => {
 const { unleashMockState, unleashInstances } = vi.hoisted(() => ({
     unleashMockState: {
         readyEvent: 'ready' as 'ready' | 'synchronized' | 'never',
-        readyDelayMs: 0
+        readyDelayMs: 0,
+        failNextInit: 0
     },
     unleashInstances: [] as { destroy: ReturnType<typeof vi.fn>; isEnabled: ReturnType<typeof vi.fn> }[]
 }));
@@ -37,6 +38,10 @@ const { unleashMockState, unleashInstances } = vi.hoisted(() => ({
 vi.mock('unleash-client', () => {
     return {
         initialize: vi.fn(() => {
+            if (unleashMockState.failNextInit > 0) {
+                unleashMockState.failNextInit -= 1;
+                throw new Error('init failed');
+            }
             const listeners = new Map<string, Set<(err?: Error) => void>>();
             const instance = {
                 isSynchronized: vi.fn(() => false),
@@ -72,22 +77,24 @@ vi.mock('unleash-client', () => {
 });
 
 describe('getFeatureFlagsClient', () => {
-    beforeEach(async () => {
+    beforeEach(() => {
         vi.useRealTimers();
         vi.clearAllMocks();
         mockEnvs.NANGO_FLAG_PROVIDER = 'noop';
         mockEnvs.NANGO_UNLEASH_URL = undefined;
         mockEnvs.NANGO_UNLEASH_API_TOKEN = undefined;
+        mockEnvs.NANGO_UNLEASH_REFRESH_INTERVAL_MS = 30_000;
         mockEnvs.NANGO_UNLEASH_INIT_TIMEOUT_MS = 100;
         unleashMockState.readyEvent = 'ready';
         unleashMockState.readyDelayMs = 0;
+        unleashMockState.failNextInit = 0;
         unleashInstances.length = 0;
-        vi.resetModules();
-        const { destroy } = await import('./index.js');
-        await destroy();
     });
 
-    afterEach(() => {
+    afterEach(async () => {
+        const { destroy } = await import('./index.js');
+        await destroy();
+        vi.resetModules();
         vi.restoreAllMocks();
         vi.useRealTimers();
     });
@@ -181,6 +188,53 @@ describe('getFeatureFlagsClient', () => {
         expect(unleashInstances[0]?.destroy).toHaveBeenCalledTimes(1);
         // After destroy, isEnabled should still resolve (now backed by NOOP -> default).
         await expect(client.isEnabled('any-flag', {}, false)).resolves.toBe(false);
+    });
+
+    it('retries client creation after a failed initialization', async () => {
+        mockEnvs.NANGO_FLAG_PROVIDER = 'unleash';
+        mockEnvs.NANGO_UNLEASH_URL = 'http://unleash.local:4242/api';
+        unleashMockState.failNextInit = 1;
+        vi.resetModules();
+        const { getFeatureFlagsClient } = await import('./index.js');
+        await expect(getFeatureFlagsClient()).rejects.toThrow('init failed');
+        const client = await getFeatureFlagsClient();
+        await expect(client.isEnabled('any-flag', {}, false)).resolves.toBe(false);
+    });
+
+    it('reconnects to unleash in the background after a failed initialization', async () => {
+        vi.useFakeTimers();
+        mockEnvs.NANGO_FLAG_PROVIDER = 'unleash';
+        mockEnvs.NANGO_UNLEASH_URL = 'http://unleash.local:4242/api';
+        mockEnvs.NANGO_UNLEASH_REFRESH_INTERVAL_MS = 1000;
+        unleashMockState.failNextInit = 1;
+        vi.resetModules();
+        const { getFeatureFlagsClient } = await import('./index.js');
+        await expect(getFeatureFlagsClient()).rejects.toThrow('init failed');
+        expect(unleashInstances.length).toBe(0);
+
+        await vi.advanceTimersByTimeAsync(1000);
+        await Promise.resolve();
+
+        expect(unleashInstances.length).toBe(1);
+        vi.useRealTimers();
+    });
+
+    it('cancels a pending reconnect when destroy() is called after a failed initialization', async () => {
+        vi.useFakeTimers();
+        mockEnvs.NANGO_FLAG_PROVIDER = 'unleash';
+        mockEnvs.NANGO_UNLEASH_URL = 'http://unleash.local:4242/api';
+        mockEnvs.NANGO_UNLEASH_REFRESH_INTERVAL_MS = 1000;
+        unleashMockState.failNextInit = 1;
+        vi.resetModules();
+        const { getFeatureFlagsClient, destroy } = await import('./index.js');
+        await expect(getFeatureFlagsClient()).rejects.toThrow('init failed');
+
+        await destroy();
+        await vi.advanceTimersByTimeAsync(1000);
+        await Promise.resolve();
+
+        expect(unleashInstances.length).toBe(0);
+        vi.useRealTimers();
     });
 
     it('rebuilds a fresh provider after destroy/recreate', async () => {

--- a/packages/feature-flags/lib/index.unit.test.ts
+++ b/packages/feature-flags/lib/index.unit.test.ts
@@ -5,36 +5,63 @@ const mockEnvs = {
     NANGO_UNLEASH_URL: undefined as string | undefined,
     NANGO_UNLEASH_API_TOKEN: undefined as string | undefined,
     NANGO_UNLEASH_APP_NAME: 'nango',
-    NANGO_UNLEASH_REFRESH_INTERVAL_MS: 30_000
+    NANGO_UNLEASH_REFRESH_INTERVAL_MS: 30_000,
+    NANGO_UNLEASH_INIT_TIMEOUT_MS: 100
 };
 
 vi.mock('./env.js', () => ({
     envs: mockEnvs
 }));
 
+vi.mock('@nangohq/utils', async (importOriginal) => {
+    const actual = await importOriginal();
+    return {
+        ...(actual as Record<string, unknown>),
+        getLogger: vi.fn(() => ({
+            info: vi.fn(),
+            warning: vi.fn(),
+            error: vi.fn(),
+            debug: vi.fn()
+        }))
+    };
+});
+
 const { unleashMockState, unleashInstances } = vi.hoisted(() => ({
     unleashMockState: {
-        readyEvent: 'synchronized' as 'synchronized' | 'error',
+        readyEvent: 'ready' as 'ready' | 'synchronized' | 'never',
         readyDelayMs: 0
     },
-    unleashInstances: [] as { destroy: ReturnType<typeof vi.fn> }[]
+    unleashInstances: [] as { destroy: ReturnType<typeof vi.fn>; isEnabled: ReturnType<typeof vi.fn> }[]
 }));
 
 vi.mock('unleash-client', () => {
     return {
         initialize: vi.fn(() => {
+            const listeners = new Map<string, Set<(err?: Error) => void>>();
             const instance = {
-                on: vi.fn(),
+                isSynchronized: vi.fn(() => false),
+                on: vi.fn((event: string, fn: (err?: Error) => void) => {
+                    if (!listeners.has(event)) listeners.set(event, new Set());
+                    listeners.get(event)!.add(fn);
+                }),
                 once: vi.fn((event: string, fn: (err?: Error) => void) => {
-                    if (event !== unleashMockState.readyEvent) return;
-                    const fire = () => fn(event === 'error' ? new Error('boom') : undefined);
+                    const wrapper = (err?: Error) => {
+                        instance.removeListener(event, wrapper);
+                        fn(err);
+                    };
+                    instance.on(event, wrapper);
+                    if (unleashMockState.readyEvent === 'never' || event !== unleashMockState.readyEvent) return;
+                    const fire = () => wrapper(undefined);
                     if (unleashMockState.readyDelayMs > 0) {
                         setTimeout(fire, unleashMockState.readyDelayMs);
                     } else {
                         queueMicrotask(fire);
                     }
                 }),
-                isEnabled: vi.fn(() => true),
+                removeListener: vi.fn((event: string, fn: (err?: Error) => void) => {
+                    listeners.get(event)?.delete(fn);
+                }),
+                isEnabled: vi.fn((_flag: string, _ctx: unknown, defaultValue: boolean) => defaultValue),
                 getVariant: vi.fn(() => ({ name: 'v0', enabled: true, feature_enabled: true, payload: { type: 'string', value: 'new-ui' } })),
                 destroy: vi.fn()
             };
@@ -46,11 +73,13 @@ vi.mock('unleash-client', () => {
 
 describe('getFeatureFlagsClient', () => {
     beforeEach(async () => {
+        vi.useRealTimers();
         vi.clearAllMocks();
         mockEnvs.NANGO_FLAG_PROVIDER = 'noop';
         mockEnvs.NANGO_UNLEASH_URL = undefined;
         mockEnvs.NANGO_UNLEASH_API_TOKEN = undefined;
-        unleashMockState.readyEvent = 'synchronized';
+        mockEnvs.NANGO_UNLEASH_INIT_TIMEOUT_MS = 100;
+        unleashMockState.readyEvent = 'ready';
         unleashMockState.readyDelayMs = 0;
         unleashInstances.length = 0;
         vi.resetModules();
@@ -60,6 +89,7 @@ describe('getFeatureFlagsClient', () => {
 
     afterEach(() => {
         vi.restoreAllMocks();
+        vi.useRealTimers();
     });
 
     it('returns the default value with the noop provider', async () => {
@@ -85,6 +115,7 @@ describe('getFeatureFlagsClient', () => {
         vi.resetModules();
         const { getFeatureFlagsClient } = await import('./index.js');
         const client = await getFeatureFlagsClient();
+        unleashInstances[0]!.isEnabled.mockReturnValue(true);
         await expect(client.isEnabled('any-flag', { 'account.uuid': 'abc' }, false)).resolves.toBe(true);
     });
 
@@ -105,16 +136,36 @@ describe('getFeatureFlagsClient', () => {
         void getNoop;
     });
 
-    it('resolves initialize() when unleash emits error before synchronized', async () => {
+    it('waits for ready before completing init when unleash is slow to synchronize', async () => {
+        vi.useFakeTimers();
         mockEnvs.NANGO_FLAG_PROVIDER = 'unleash';
         mockEnvs.NANGO_UNLEASH_URL = 'http://unleash.local:4242/api';
-        unleashMockState.readyEvent = 'error';
-        const errSpy = vi.spyOn(console, 'error').mockImplementation(() => {});
+        unleashMockState.readyDelayMs = 50;
         vi.resetModules();
         const { getFeatureFlagsClient } = await import('./index.js');
-        const client = await getFeatureFlagsClient();
-        await expect(client.isEnabled('any-flag', {}, false)).resolves.toBe(true);
-        errSpy.mockRestore();
+        let resolved = false;
+        const initPromise = getFeatureFlagsClient().then((client) => {
+            resolved = true;
+            return client;
+        });
+        await vi.advanceTimersByTimeAsync(10);
+        expect(resolved).toBe(false);
+        await vi.advanceTimersByTimeAsync(50);
+        await initPromise;
+        expect(resolved).toBe(true);
+    });
+
+    it('completes init after timeout when unleash never synchronizes', async () => {
+        vi.useFakeTimers();
+        mockEnvs.NANGO_FLAG_PROVIDER = 'unleash';
+        mockEnvs.NANGO_UNLEASH_URL = 'http://unleash.local:4242/api';
+        unleashMockState.readyEvent = 'never';
+        vi.resetModules();
+        const { getFeatureFlagsClient } = await import('./index.js');
+        const initPromise = getFeatureFlagsClient();
+        await vi.advanceTimersByTimeAsync(100);
+        const client = await initPromise;
+        await expect(client.isEnabled('any-flag', {}, false)).resolves.toBe(false);
     });
 
     it('serializes destroy() called during initialization', async () => {
@@ -145,6 +196,7 @@ describe('getFeatureFlagsClient', () => {
         expect(unleashInstances.length).toBe(2);
         // The first unleash instance was torn down by the destroy/swap.
         expect(unleashInstances[0]?.destroy).toHaveBeenCalledTimes(1);
+        unleashInstances[1]!.isEnabled.mockReturnValue(true);
         await expect(second.isEnabled('any-flag', {}, false)).resolves.toBe(true);
     });
 });

--- a/packages/feature-flags/lib/index.unit.test.ts
+++ b/packages/feature-flags/lib/index.unit.test.ts
@@ -72,12 +72,10 @@ describe('getFeatureFlagsClient', () => {
 
     it('falls back to noop when unleash is selected but url is missing', async () => {
         mockEnvs.NANGO_FLAG_PROVIDER = 'unleash';
-        const warn = vi.spyOn(console, 'warn').mockImplementation(() => {});
         vi.resetModules();
         const { getFeatureFlagsClient } = await import('./index.js');
         const client = await getFeatureFlagsClient();
         await expect(client.isEnabled('any-flag', {}, true)).resolves.toBe(true);
-        expect(warn).toHaveBeenCalled();
     });
 
     it('uses unleash provider when configured', async () => {

--- a/packages/feature-flags/lib/index.unit.test.ts
+++ b/packages/feature-flags/lib/index.unit.test.ts
@@ -35,6 +35,7 @@ vi.mock('unleash-client', () => {
                     }
                 }),
                 isEnabled: vi.fn(() => true),
+                getVariant: vi.fn(() => ({ name: 'v0', enabled: true, feature_enabled: true, payload: { type: 'string', value: 'new-ui' } })),
                 destroy: vi.fn()
             };
             unleashInstances.push(instance);
@@ -87,6 +88,23 @@ describe('getFeatureFlagsClient', () => {
         const { getFeatureFlagsClient } = await import('./index.js');
         const client = await getFeatureFlagsClient();
         await expect(client.isEnabled('any-flag', { 'account.uuid': 'abc' }, false)).resolves.toBe(true);
+    });
+
+    it('reads non-boolean variant payloads (getString), falling back to default otherwise', async () => {
+        mockEnvs.NANGO_FLAG_PROVIDER = 'unleash';
+        mockEnvs.NANGO_UNLEASH_URL = 'http://unleash.local:4242/api';
+        vi.resetModules();
+        const { getFeatureFlagsClient } = await import('./index.js');
+        const client = await getFeatureFlagsClient();
+        await expect(client.getString('variant-flag', { 'account.id': '1239' }, 'control')).resolves.toBe('new-ui');
+        // noop provider returns the default for non-boolean reads
+        const { destroy, getFeatureFlagsClient: getNoop } = await import('./index.js');
+        await destroy();
+        mockEnvs.NANGO_FLAG_PROVIDER = 'noop';
+        vi.resetModules();
+        const noopClient = await (await import('./index.js')).getFeatureFlagsClient();
+        await expect(noopClient.getString('variant-flag', {}, 'control')).resolves.toBe('control');
+        void getNoop;
     });
 
     it('resolves initialize() when unleash emits error before synchronized', async () => {

--- a/packages/feature-flags/lib/providers/noop.ts
+++ b/packages/feature-flags/lib/providers/noop.ts
@@ -1,0 +1,35 @@
+import { ErrorCode } from '@openfeature/server-sdk';
+
+import type { EvaluationContext, JsonValue, Logger, Provider, ResolutionDetails } from '@openfeature/server-sdk';
+
+const FLAG_NOT_FOUND: ResolutionDetails<never> = {
+    value: undefined as never,
+    reason: 'ERROR',
+    errorCode: ErrorCode.FLAG_NOT_FOUND
+};
+
+export class NoopProvider implements Provider {
+    readonly metadata = { name: 'noop' };
+    readonly runsOn = 'server' as const;
+
+    resolveBooleanEvaluation(_flagKey: string, defaultValue: boolean, _context: EvaluationContext, _logger: Logger): Promise<ResolutionDetails<boolean>> {
+        return Promise.resolve({ value: defaultValue, reason: 'DEFAULT' });
+    }
+
+    resolveStringEvaluation(_flagKey: string, _defaultValue: string, _context: EvaluationContext, _logger: Logger): Promise<ResolutionDetails<string>> {
+        return Promise.resolve(FLAG_NOT_FOUND);
+    }
+
+    resolveNumberEvaluation(_flagKey: string, _defaultValue: number, _context: EvaluationContext, _logger: Logger): Promise<ResolutionDetails<number>> {
+        return Promise.resolve(FLAG_NOT_FOUND);
+    }
+
+    resolveObjectEvaluation<T extends JsonValue>(
+        _flagKey: string,
+        _defaultValue: T,
+        _context: EvaluationContext,
+        _logger: Logger
+    ): Promise<ResolutionDetails<T>> {
+        return Promise.resolve(FLAG_NOT_FOUND);
+    }
+}

--- a/packages/feature-flags/lib/providers/noop.ts
+++ b/packages/feature-flags/lib/providers/noop.ts
@@ -1,12 +1,4 @@
-import { ErrorCode } from '@openfeature/server-sdk';
-
 import type { EvaluationContext, JsonValue, Logger, Provider, ResolutionDetails } from '@openfeature/server-sdk';
-
-const FLAG_NOT_FOUND: ResolutionDetails<never> = {
-    value: undefined as never,
-    reason: 'ERROR',
-    errorCode: ErrorCode.FLAG_NOT_FOUND
-};
 
 export class NoopProvider implements Provider {
     readonly metadata = { name: 'noop' };
@@ -16,20 +8,20 @@ export class NoopProvider implements Provider {
         return Promise.resolve({ value: defaultValue, reason: 'DEFAULT' });
     }
 
-    resolveStringEvaluation(_flagKey: string, _defaultValue: string, _context: EvaluationContext, _logger: Logger): Promise<ResolutionDetails<string>> {
-        return Promise.resolve(FLAG_NOT_FOUND);
+    resolveStringEvaluation(_flagKey: string, defaultValue: string, _context: EvaluationContext, _logger: Logger): Promise<ResolutionDetails<string>> {
+        return Promise.resolve({ value: defaultValue, reason: 'DEFAULT' });
     }
 
-    resolveNumberEvaluation(_flagKey: string, _defaultValue: number, _context: EvaluationContext, _logger: Logger): Promise<ResolutionDetails<number>> {
-        return Promise.resolve(FLAG_NOT_FOUND);
+    resolveNumberEvaluation(_flagKey: string, defaultValue: number, _context: EvaluationContext, _logger: Logger): Promise<ResolutionDetails<number>> {
+        return Promise.resolve({ value: defaultValue, reason: 'DEFAULT' });
     }
 
     resolveObjectEvaluation<T extends JsonValue>(
         _flagKey: string,
-        _defaultValue: T,
+        defaultValue: T,
         _context: EvaluationContext,
         _logger: Logger
     ): Promise<ResolutionDetails<T>> {
-        return Promise.resolve(FLAG_NOT_FOUND);
+        return Promise.resolve({ value: defaultValue, reason: 'DEFAULT' });
     }
 }

--- a/packages/feature-flags/lib/providers/unleash.ts
+++ b/packages/feature-flags/lib/providers/unleash.ts
@@ -1,0 +1,125 @@
+import { ErrorCode } from '@openfeature/server-sdk';
+import { initialize } from 'unleash-client';
+
+import type { EvaluationContext, JsonValue, Logger, Provider, ResolutionDetails } from '@openfeature/server-sdk';
+import type { Context as UnleashEvaluationContext, Unleash } from 'unleash-client';
+
+const FLAG_NOT_FOUND: ResolutionDetails<never> = {
+    value: undefined as never,
+    reason: 'ERROR',
+    errorCode: ErrorCode.FLAG_NOT_FOUND
+};
+
+const KNOWN_KEYS = new Set(['userId', 'sessionId', 'remoteAddress', 'environment', 'appName', 'currentTime']);
+
+export interface UnleashProviderConfig {
+    url: string;
+    appName: string;
+    apiToken?: string | undefined;
+    refreshIntervalMs?: number | undefined;
+}
+
+function stringifyValue(value: unknown): string {
+    switch (typeof value) {
+        case 'string':
+            return value;
+        case 'number':
+        case 'boolean':
+        case 'bigint':
+            return value.toString();
+        case 'object':
+            return JSON.stringify(value);
+        default:
+            return '';
+    }
+}
+
+function toUnleashContext(context: EvaluationContext): UnleashEvaluationContext {
+    const out: UnleashEvaluationContext = {};
+    const properties: Record<string, string> = {};
+
+    for (const [key, value] of Object.entries(context)) {
+        if (value === undefined || value === null) continue;
+        const str = stringifyValue(value);
+        if (key === 'targetingKey') {
+            out.userId = str;
+        } else if (KNOWN_KEYS.has(key)) {
+            (out as unknown as Record<string, string>)[key] = str;
+        } else {
+            properties[key] = str;
+        }
+    }
+    if (Object.keys(properties).length > 0) {
+        out.properties = properties;
+    }
+    return out;
+}
+
+export class UnleashProvider implements Provider {
+    readonly metadata = { name: 'unleash' };
+    readonly runsOn = 'server' as const;
+
+    private readonly unleash: Unleash;
+    private ready = false;
+
+    constructor(config: UnleashProviderConfig) {
+        this.unleash = initialize({
+            url: config.url,
+            appName: config.appName,
+            refreshInterval: config.refreshIntervalMs ?? 30_000,
+            disableMetrics: false,
+            customHeaders: config.apiToken ? { Authorization: config.apiToken } : {}
+        });
+
+        this.unleash.on('synchronized', () => {
+            this.ready = true;
+        });
+        this.unleash.on('error', (err: Error) => {
+            console.error(`Unleash error: ${err.message}`);
+        });
+    }
+
+    async initialize(): Promise<void> {
+        if (this.ready) return;
+        await new Promise<void>((resolve) => {
+            this.unleash.once('synchronized', () => resolve());
+            this.unleash.once('error', () => resolve());
+        });
+    }
+
+    onClose(): Promise<void> {
+        this.unleash.destroy();
+        return Promise.resolve();
+    }
+
+    resolveBooleanEvaluation(flagKey: string, defaultValue: boolean, context: EvaluationContext, _logger: Logger): Promise<ResolutionDetails<boolean>> {
+        try {
+            const value = this.unleash.isEnabled(flagKey, toUnleashContext(context), defaultValue);
+            return Promise.resolve({ value, reason: 'TARGETING_MATCH' });
+        } catch (err) {
+            return Promise.resolve({
+                value: defaultValue,
+                reason: 'ERROR',
+                errorCode: ErrorCode.GENERAL,
+                errorMessage: err instanceof Error ? err.message : String(err)
+            });
+        }
+    }
+
+    resolveStringEvaluation(_flagKey: string, _defaultValue: string, _context: EvaluationContext, _logger: Logger): Promise<ResolutionDetails<string>> {
+        return Promise.resolve(FLAG_NOT_FOUND);
+    }
+
+    resolveNumberEvaluation(_flagKey: string, _defaultValue: number, _context: EvaluationContext, _logger: Logger): Promise<ResolutionDetails<number>> {
+        return Promise.resolve(FLAG_NOT_FOUND);
+    }
+
+    resolveObjectEvaluation<T extends JsonValue>(
+        _flagKey: string,
+        _defaultValue: T,
+        _context: EvaluationContext,
+        _logger: Logger
+    ): Promise<ResolutionDetails<T>> {
+        return Promise.resolve(FLAG_NOT_FOUND);
+    }
+}

--- a/packages/feature-flags/lib/providers/unleash.ts
+++ b/packages/feature-flags/lib/providers/unleash.ts
@@ -71,6 +71,7 @@ export class UnleashProvider implements Provider {
     private readonly whenReady: Promise<void>;
     private settleWhenReady: (() => void) | undefined;
     private hasToggleData = false;
+    private apiSynced = false;
 
     constructor(config: UnleashProviderConfig) {
         this.unleash = initialize({
@@ -83,6 +84,16 @@ export class UnleashProvider implements Provider {
 
         this.whenReady = this.waitForFirstContact(config.initTimeoutMs ?? DEFAULT_INIT_TIMEOUT_MS);
 
+        this.unleash.on('ready', () => {
+            this.hasToggleData = true;
+        });
+        this.unleash.on('synchronized', () => {
+            if (!this.apiSynced) {
+                logger.info('Unleash synchronized; flag evaluations now use remote toggles');
+                this.apiSynced = true;
+            }
+            this.hasToggleData = true;
+        });
         this.unleash.on('error', (err: Error) => {
             logger.error('Unleash error', err);
         });
@@ -140,17 +151,15 @@ export class UnleashProvider implements Provider {
         return Promise.resolve();
     }
 
-    private async evaluate<T>(defaultValue: T, evaluate: () => T): Promise<ResolutionDetails<T>> {
+    async resolveBooleanEvaluation(flagKey: string, defaultValue: boolean, context: EvaluationContext, _logger: Logger): Promise<ResolutionDetails<boolean>> {
         await this.whenReady;
         try {
-            return { value: evaluate(), reason: 'TARGETING_MATCH' };
+            const value = this.unleash.isEnabled(flagKey, toUnleashContext(context), defaultValue);
+            const reason = this.unleash.isSynchronized() ? 'TARGETING_MATCH' : 'DEFAULT';
+            return { value, reason };
         } catch (err) {
             return this.evaluationError(defaultValue, err);
         }
-    }
-
-    async resolveBooleanEvaluation(flagKey: string, defaultValue: boolean, context: EvaluationContext, _logger: Logger): Promise<ResolutionDetails<boolean>> {
-        return this.evaluate(defaultValue, () => this.unleash.isEnabled(flagKey, toUnleashContext(context), defaultValue));
     }
 
     // Non-boolean values are served as Unleash variant payloads (provisioned by the

--- a/packages/feature-flags/lib/providers/unleash.ts
+++ b/packages/feature-flags/lib/providers/unleash.ts
@@ -1,8 +1,14 @@
 import { ErrorCode } from '@openfeature/server-sdk';
 import { initialize } from 'unleash-client';
 
+import { getLogger } from '@nangohq/utils';
+
 import type { EvaluationContext, JsonValue, Logger, Provider, ResolutionDetails } from '@openfeature/server-sdk';
 import type { Context as UnleashEvaluationContext, Unleash } from 'unleash-client';
+
+const logger = getLogger('FeatureFlags.Unleash');
+
+const DEFAULT_INIT_TIMEOUT_MS = 10_000;
 
 const KNOWN_KEYS = new Set(['userId', 'sessionId', 'remoteAddress', 'environment', 'appName', 'currentTime']);
 
@@ -11,6 +17,7 @@ export interface UnleashProviderConfig {
     appName: string;
     apiToken?: string | undefined;
     refreshIntervalMs?: number | undefined;
+    initTimeoutMs?: number | undefined;
 }
 
 function stringifyValue(value: unknown): string {
@@ -22,6 +29,9 @@ function stringifyValue(value: unknown): string {
         case 'bigint':
             return value.toString();
         case 'object':
+            if (value instanceof Date) {
+                return value.toISOString();
+            }
             return JSON.stringify(value);
         default:
             return '';
@@ -34,6 +44,10 @@ function toUnleashContext(context: EvaluationContext): UnleashEvaluationContext 
 
     for (const [key, value] of Object.entries(context)) {
         if (value === undefined || value === null) continue;
+        if (key === 'currentTime') {
+            out.currentTime = value instanceof Date ? value : new Date(stringifyValue(value));
+            continue;
+        }
         const str = stringifyValue(value);
         if (key === 'targetingKey') {
             out.userId = str;
@@ -54,7 +68,9 @@ export class UnleashProvider implements Provider {
     readonly runsOn = 'server' as const;
 
     private readonly unleash: Unleash;
-    private ready = false;
+    private readonly whenReady: Promise<void>;
+    private settleWhenReady: (() => void) | undefined;
+    private hasToggleData = false;
 
     constructor(config: UnleashProviderConfig) {
         this.unleash = initialize({
@@ -65,39 +81,76 @@ export class UnleashProvider implements Provider {
             customHeaders: config.apiToken ? { Authorization: config.apiToken } : {}
         });
 
-        this.unleash.on('synchronized', () => {
-            this.ready = true;
-        });
+        this.whenReady = this.waitForFirstContact(config.initTimeoutMs ?? DEFAULT_INIT_TIMEOUT_MS);
+
         this.unleash.on('error', (err: Error) => {
-            console.error(`Unleash error: ${err.message}`);
+            logger.error('Unleash error', err);
+        });
+    }
+
+    hasSynchronized(): boolean {
+        return this.hasToggleData;
+    }
+
+    private waitForFirstContact(timeoutMs: number): Promise<void> {
+        if (this.unleash.isSynchronized()) {
+            this.hasToggleData = true;
+            return Promise.resolve();
+        }
+
+        return new Promise((resolve) => {
+            let settled = false;
+            const settle = (synchronized: boolean) => {
+                if (settled) return;
+                settled = true;
+                this.settleWhenReady = undefined;
+                clearTimeout(timer);
+                this.unleash.removeListener('ready', onReady);
+                this.unleash.removeListener('synchronized', onReady);
+                if (synchronized) {
+                    this.hasToggleData = true;
+                }
+                resolve();
+            };
+
+            this.settleWhenReady = () => settle(false);
+
+            const onReady = () => settle(true);
+            this.unleash.once('ready', onReady);
+            this.unleash.once('synchronized', onReady);
+
+            const timer = setTimeout(() => {
+                logger.warning('Unleash first contact timed out; flag evaluations will use defaults until synchronized');
+                settle(false);
+            }, timeoutMs);
+            if (typeof timer.unref === 'function') {
+                timer.unref();
+            }
         });
     }
 
     async initialize(): Promise<void> {
-        if (this.ready) return;
-        await new Promise<void>((resolve) => {
-            this.unleash.once('synchronized', () => resolve());
-            this.unleash.once('error', () => resolve());
-        });
+        await this.whenReady;
     }
 
+    // unleash-client destroy() is synchronous — stops polling and clears timers.
     onClose(): Promise<void> {
+        this.settleWhenReady?.();
         this.unleash.destroy();
         return Promise.resolve();
     }
 
-    resolveBooleanEvaluation(flagKey: string, defaultValue: boolean, context: EvaluationContext, _logger: Logger): Promise<ResolutionDetails<boolean>> {
+    private async evaluate<T>(defaultValue: T, evaluate: () => T): Promise<ResolutionDetails<T>> {
+        await this.whenReady;
         try {
-            const value = this.unleash.isEnabled(flagKey, toUnleashContext(context), defaultValue);
-            return Promise.resolve({ value, reason: 'TARGETING_MATCH' });
+            return { value: evaluate(), reason: 'TARGETING_MATCH' };
         } catch (err) {
-            return Promise.resolve({
-                value: defaultValue,
-                reason: 'ERROR',
-                errorCode: ErrorCode.GENERAL,
-                errorMessage: err instanceof Error ? err.message : String(err)
-            });
+            return this.evaluationError(defaultValue, err);
         }
+    }
+
+    async resolveBooleanEvaluation(flagKey: string, defaultValue: boolean, context: EvaluationContext, _logger: Logger): Promise<ResolutionDetails<boolean>> {
+        return this.evaluate(defaultValue, () => this.unleash.isEnabled(flagKey, toUnleashContext(context), defaultValue));
     }
 
     // Non-boolean values are served as Unleash variant payloads (provisioned by the
@@ -110,37 +163,47 @@ export class UnleashProvider implements Provider {
         return undefined;
     }
 
-    resolveStringEvaluation(flagKey: string, defaultValue: string, context: EvaluationContext, _logger: Logger): Promise<ResolutionDetails<string>> {
+    async resolveStringEvaluation(flagKey: string, defaultValue: string, context: EvaluationContext, _logger: Logger): Promise<ResolutionDetails<string>> {
+        await this.whenReady;
         try {
             const raw = this.payloadValue(flagKey, context);
-            if (raw === undefined) return Promise.resolve({ value: defaultValue, reason: 'DEFAULT' });
-            return Promise.resolve({ value: raw, reason: 'TARGETING_MATCH' });
+            if (raw === undefined) return { value: defaultValue, reason: 'DEFAULT' };
+            return { value: raw, reason: 'TARGETING_MATCH' };
         } catch (err) {
-            return Promise.resolve(this.evaluationError(defaultValue, err));
+            return this.evaluationError(defaultValue, err);
         }
     }
 
-    resolveNumberEvaluation(flagKey: string, defaultValue: number, context: EvaluationContext, _logger: Logger): Promise<ResolutionDetails<number>> {
+    async resolveNumberEvaluation(flagKey: string, defaultValue: number, context: EvaluationContext, _logger: Logger): Promise<ResolutionDetails<number>> {
+        await this.whenReady;
         try {
             const raw = this.payloadValue(flagKey, context);
             const num = raw === undefined ? NaN : Number(raw);
-            if (Number.isNaN(num)) return Promise.resolve({ value: defaultValue, reason: 'DEFAULT' });
-            return Promise.resolve({ value: num, reason: 'TARGETING_MATCH' });
+            if (Number.isNaN(num)) return { value: defaultValue, reason: 'DEFAULT' };
+            return { value: num, reason: 'TARGETING_MATCH' };
         } catch (err) {
-            return Promise.resolve(this.evaluationError(defaultValue, err));
+            return this.evaluationError(defaultValue, err);
         }
     }
 
-    resolveObjectEvaluation<T extends JsonValue>(flagKey: string, defaultValue: T, context: EvaluationContext, _logger: Logger): Promise<ResolutionDetails<T>> {
+    async resolveObjectEvaluation<T extends JsonValue>(
+        flagKey: string,
+        defaultValue: T,
+        context: EvaluationContext,
+        _logger: Logger
+    ): Promise<ResolutionDetails<T>> {
+        await this.whenReady;
         try {
             const raw = this.payloadValue(flagKey, context);
-            if (raw === undefined) return Promise.resolve({ value: defaultValue, reason: 'DEFAULT' });
-            return Promise.resolve({ value: JSON.parse(raw) as T, reason: 'TARGETING_MATCH' });
+            if (raw === undefined) return { value: defaultValue, reason: 'DEFAULT' };
+            return { value: JSON.parse(raw) as T, reason: 'TARGETING_MATCH' };
         } catch (err) {
-            return Promise.resolve(this.evaluationError(defaultValue, err));
+            return this.evaluationError(defaultValue, err);
         }
     }
 
+    // Return the default with reason 'ERROR'; OpenFeature applies the default and exposes error metadata.
+    // https://openfeature.dev/docs/reference/concepts/provider/
     private evaluationError<T>(defaultValue: T, err: unknown): ResolutionDetails<T> {
         return {
             value: defaultValue,

--- a/packages/feature-flags/lib/providers/unleash.ts
+++ b/packages/feature-flags/lib/providers/unleash.ts
@@ -4,12 +4,6 @@ import { initialize } from 'unleash-client';
 import type { EvaluationContext, JsonValue, Logger, Provider, ResolutionDetails } from '@openfeature/server-sdk';
 import type { Context as UnleashEvaluationContext, Unleash } from 'unleash-client';
 
-const FLAG_NOT_FOUND: ResolutionDetails<never> = {
-    value: undefined as never,
-    reason: 'ERROR',
-    errorCode: ErrorCode.FLAG_NOT_FOUND
-};
-
 const KNOWN_KEYS = new Set(['userId', 'sessionId', 'remoteAddress', 'environment', 'appName', 'currentTime']);
 
 export interface UnleashProviderConfig {
@@ -106,20 +100,53 @@ export class UnleashProvider implements Provider {
         }
     }
 
-    resolveStringEvaluation(_flagKey: string, _defaultValue: string, _context: EvaluationContext, _logger: Logger): Promise<ResolutionDetails<string>> {
-        return Promise.resolve(FLAG_NOT_FOUND);
+    // Non-boolean values are served as Unleash variant payloads (provisioned by the
+    // nango-flags repo as strategy variants). getVariant returns the payload string.
+    private payloadValue(flagKey: string, context: EvaluationContext): string | undefined {
+        const variant = this.unleash.getVariant(flagKey, toUnleashContext(context));
+        if (variant.feature_enabled && variant.payload?.value !== undefined) {
+            return variant.payload.value;
+        }
+        return undefined;
     }
 
-    resolveNumberEvaluation(_flagKey: string, _defaultValue: number, _context: EvaluationContext, _logger: Logger): Promise<ResolutionDetails<number>> {
-        return Promise.resolve(FLAG_NOT_FOUND);
+    resolveStringEvaluation(flagKey: string, defaultValue: string, context: EvaluationContext, _logger: Logger): Promise<ResolutionDetails<string>> {
+        try {
+            const raw = this.payloadValue(flagKey, context);
+            if (raw === undefined) return Promise.resolve({ value: defaultValue, reason: 'DEFAULT' });
+            return Promise.resolve({ value: raw, reason: 'TARGETING_MATCH' });
+        } catch (err) {
+            return Promise.resolve(this.evaluationError(defaultValue, err));
+        }
     }
 
-    resolveObjectEvaluation<T extends JsonValue>(
-        _flagKey: string,
-        _defaultValue: T,
-        _context: EvaluationContext,
-        _logger: Logger
-    ): Promise<ResolutionDetails<T>> {
-        return Promise.resolve(FLAG_NOT_FOUND);
+    resolveNumberEvaluation(flagKey: string, defaultValue: number, context: EvaluationContext, _logger: Logger): Promise<ResolutionDetails<number>> {
+        try {
+            const raw = this.payloadValue(flagKey, context);
+            const num = raw === undefined ? NaN : Number(raw);
+            if (Number.isNaN(num)) return Promise.resolve({ value: defaultValue, reason: 'DEFAULT' });
+            return Promise.resolve({ value: num, reason: 'TARGETING_MATCH' });
+        } catch (err) {
+            return Promise.resolve(this.evaluationError(defaultValue, err));
+        }
+    }
+
+    resolveObjectEvaluation<T extends JsonValue>(flagKey: string, defaultValue: T, context: EvaluationContext, _logger: Logger): Promise<ResolutionDetails<T>> {
+        try {
+            const raw = this.payloadValue(flagKey, context);
+            if (raw === undefined) return Promise.resolve({ value: defaultValue, reason: 'DEFAULT' });
+            return Promise.resolve({ value: JSON.parse(raw) as T, reason: 'TARGETING_MATCH' });
+        } catch (err) {
+            return Promise.resolve(this.evaluationError(defaultValue, err));
+        }
+    }
+
+    private evaluationError<T>(defaultValue: T, err: unknown): ResolutionDetails<T> {
+        return {
+            value: defaultValue,
+            reason: 'ERROR',
+            errorCode: ErrorCode.GENERAL,
+            errorMessage: err instanceof Error ? err.message : String(err)
+        };
     }
 }

--- a/packages/feature-flags/lib/providers/unleash.unit.test.ts
+++ b/packages/feature-flags/lib/providers/unleash.unit.test.ts
@@ -1,0 +1,61 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+import type { Logger } from '@openfeature/server-sdk';
+
+const unleashInstance = vi.hoisted(() => ({
+    isSynchronized: vi.fn(() => true),
+    on: vi.fn(),
+    once: vi.fn(),
+    removeListener: vi.fn(),
+    isEnabled: vi.fn(() => true),
+    getVariant: vi.fn(),
+    destroy: vi.fn()
+}));
+
+vi.mock('unleash-client', () => ({
+    initialize: vi.fn(() => unleashInstance)
+}));
+
+vi.mock('@nangohq/utils', () => ({
+    getLogger: vi.fn(() => ({
+        info: vi.fn(),
+        warning: vi.fn(),
+        error: vi.fn(),
+        debug: vi.fn()
+    }))
+}));
+
+const mockLogger = {} as Logger;
+
+describe('UnleashProvider context mapping', () => {
+    beforeEach(() => {
+        vi.clearAllMocks();
+        unleashInstance.isSynchronized.mockReturnValue(true);
+    });
+
+    it('passes currentTime as a native Date to unleash', async () => {
+        const { UnleashProvider } = await import('./unleash.js');
+        const provider = new UnleashProvider({ url: 'http://unleash.local/api', appName: 'nango' });
+        const currentTime = new Date('2024-06-01T12:00:00.000Z');
+
+        await provider.resolveBooleanEvaluation('example-flag', false, { currentTime }, mockLogger);
+
+        expect(unleashInstance.isEnabled).toHaveBeenCalledWith('example-flag', expect.objectContaining({ currentTime }), false);
+    });
+
+    it('serializes Date properties as ISO strings', async () => {
+        const { UnleashProvider } = await import('./unleash.js');
+        const provider = new UnleashProvider({ url: 'http://unleash.local/api', appName: 'nango' });
+        const rolloutAt = new Date('2024-06-01T12:00:00.000Z');
+
+        await provider.resolveBooleanEvaluation('example-flag', false, { rolloutAt }, mockLogger);
+
+        expect(unleashInstance.isEnabled).toHaveBeenCalledWith(
+            'example-flag',
+            expect.objectContaining({
+                properties: { rolloutAt: '2024-06-01T12:00:00.000Z' }
+            }),
+            false
+        );
+    });
+});

--- a/packages/feature-flags/lib/providers/unleash.unit.test.ts
+++ b/packages/feature-flags/lib/providers/unleash.unit.test.ts
@@ -2,15 +2,27 @@ import { beforeEach, describe, expect, it, vi } from 'vitest';
 
 import type { Logger } from '@openfeature/server-sdk';
 
-const unleashInstance = vi.hoisted(() => ({
-    isSynchronized: vi.fn(() => true),
-    on: vi.fn(),
-    once: vi.fn(),
-    removeListener: vi.fn(),
-    isEnabled: vi.fn(() => true),
-    getVariant: vi.fn(),
-    destroy: vi.fn()
-}));
+const unleashInstance = vi.hoisted(() => {
+    const listeners = new Map<string, Set<(err?: Error) => void>>();
+    return {
+        listeners,
+        isSynchronized: vi.fn(() => false),
+        on: vi.fn((event: string, fn: (err?: Error) => void) => {
+            if (!listeners.has(event)) listeners.set(event, new Set());
+            listeners.get(event)!.add(fn);
+        }),
+        once: vi.fn(),
+        removeListener: vi.fn((event: string, fn: (err?: Error) => void) => {
+            listeners.get(event)?.delete(fn);
+        }),
+        emit: (event: string) => {
+            listeners.get(event)?.forEach((fn) => fn());
+        },
+        isEnabled: vi.fn((_flag: string, _ctx: unknown, defaultValue: boolean) => defaultValue),
+        getVariant: vi.fn(),
+        destroy: vi.fn()
+    };
+});
 
 vi.mock('unleash-client', () => ({
     initialize: vi.fn(() => unleashInstance)
@@ -30,10 +42,12 @@ const mockLogger = {} as Logger;
 describe('UnleashProvider context mapping', () => {
     beforeEach(() => {
         vi.clearAllMocks();
-        unleashInstance.isSynchronized.mockReturnValue(true);
+        unleashInstance.listeners.clear();
+        unleashInstance.isSynchronized.mockReturnValue(false);
     });
 
     it('passes currentTime as a native Date to unleash', async () => {
+        unleashInstance.isSynchronized.mockReturnValue(true);
         const { UnleashProvider } = await import('./unleash.js');
         const provider = new UnleashProvider({ url: 'http://unleash.local/api', appName: 'nango' });
         const currentTime = new Date('2024-06-01T12:00:00.000Z');
@@ -44,6 +58,7 @@ describe('UnleashProvider context mapping', () => {
     });
 
     it('serializes Date properties as ISO strings', async () => {
+        unleashInstance.isSynchronized.mockReturnValue(true);
         const { UnleashProvider } = await import('./unleash.js');
         const provider = new UnleashProvider({ url: 'http://unleash.local/api', appName: 'nango' });
         const rolloutAt = new Date('2024-06-01T12:00:00.000Z');
@@ -57,5 +72,34 @@ describe('UnleashProvider context mapping', () => {
             }),
             false
         );
+    });
+
+    it('returns DEFAULT reason when unleash is not synchronized', async () => {
+        vi.useFakeTimers();
+        unleashInstance.isSynchronized.mockReturnValue(false);
+        const { UnleashProvider } = await import('./unleash.js');
+        const provider = new UnleashProvider({ url: 'http://unleash.local/api', appName: 'nango', initTimeoutMs: 0 });
+        await vi.advanceTimersByTimeAsync(0);
+        const result = await provider.resolveBooleanEvaluation('example-flag', false, {}, mockLogger);
+        expect(result).toEqual({ value: false, reason: 'DEFAULT' });
+        vi.useRealTimers();
+    });
+
+    it('recovers evaluations after unleash synchronizes in the background', async () => {
+        vi.useFakeTimers();
+        const { UnleashProvider } = await import('./unleash.js');
+        const provider = new UnleashProvider({ url: 'http://unleash.local/api', appName: 'nango', initTimeoutMs: 0 });
+        await vi.advanceTimersByTimeAsync(0);
+
+        const beforeSync = await provider.resolveBooleanEvaluation('example-flag', false, {}, mockLogger);
+        expect(beforeSync).toEqual({ value: false, reason: 'DEFAULT' });
+
+        unleashInstance.isSynchronized.mockReturnValue(true);
+        unleashInstance.isEnabled.mockReturnValue(true);
+        unleashInstance.emit('synchronized');
+
+        const afterSync = await provider.resolveBooleanEvaluation('example-flag', false, {}, mockLogger);
+        expect(afterSync).toEqual({ value: true, reason: 'TARGETING_MATCH' });
+        vi.useRealTimers();
     });
 });

--- a/packages/feature-flags/lib/registry.ts
+++ b/packages/feature-flags/lib/registry.ts
@@ -1,0 +1,3 @@
+export const FLAGS = {} as const;
+
+export type FlagKey = (typeof FLAGS)[keyof typeof FLAGS];

--- a/packages/feature-flags/lib/registry.ts
+++ b/packages/feature-flags/lib/registry.ts
@@ -1,3 +1,24 @@
-export const FLAGS = {} as const;
+/**
+ * Typed registry of feature flag keys evaluated by Nango code.
+ *
+ * Each value is the Unleash flag name. These keys are maintained by hand and
+ * are intentionally decoupled from the nango-flags repo (the provisioning
+ * source of truth): adding a key here does not create the flag in Unleash, and
+ * provisioning a flag there does not require a code change. When you add a flag,
+ * mirror the name in both places. An unknown / unprovisioned flag simply
+ * resolves to the default value passed to `isEnabled`, so drift is safe.
+ *
+ * Usage:
+ *   import { FLAGS } from '@nangohq/feature-flags';
+ *   await client.isEnabled(FLAGS.EXAMPLE_FLAG, { 'account.uuid': uuid }, false);
+ */
+export const FLAGS = {
+    // Reference flags; mirror flags/*.yaml in nango-flags. Safe to remove once real flags exist.
+    // Boolean — read with client.isEnabled(FLAGS.EXAMPLE_FLAG, ctx, false).
+    EXAMPLE_FLAG: 'example-flag',
+    // Non-boolean (string) — read with client.getString(FLAGS.EXAMPLE_VARIANT, ctx, 'control').
+    // Number/JSON flags use client.getNumber / client.getObject.
+    EXAMPLE_VARIANT: 'example-variant'
+} as const;
 
 export type FlagKey = (typeof FLAGS)[keyof typeof FLAGS];

--- a/packages/feature-flags/lib/types.ts
+++ b/packages/feature-flags/lib/types.ts
@@ -1,0 +1,1 @@
+export type FlagContext = Record<string, string | number | boolean | undefined>;

--- a/packages/feature-flags/lib/types.ts
+++ b/packages/feature-flags/lib/types.ts
@@ -1,1 +1,1 @@
-export type FlagContext = Record<string, string | number | boolean | undefined>;
+export type FlagContext = Record<string, string | number | boolean | Date | undefined>;

--- a/packages/feature-flags/package.json
+++ b/packages/feature-flags/package.json
@@ -1,0 +1,27 @@
+{
+    "name": "@nangohq/feature-flags",
+    "version": "1.0.0",
+    "type": "module",
+    "main": "./dist/index.js",
+    "types": "./dist/index.js",
+    "private": true,
+    "scripts": {
+        "build": "rimraf ./dist && tsc"
+    },
+    "repository": {
+        "type": "git",
+        "url": "git+https://github.com/NangoHQ/nango.git",
+        "directory": "packages/feature-flags"
+    },
+    "dependencies": {
+        "@nangohq/utils": "file:../utils",
+        "@openfeature/server-sdk": "~1.18.0",
+        "unleash-client": "6.6.0"
+    },
+    "devDependencies": {
+        "vitest": "3.2.4"
+    },
+    "files": [
+        "dist/**/*"
+    ]
+}

--- a/packages/feature-flags/package.json
+++ b/packages/feature-flags/package.json
@@ -15,7 +15,8 @@
     },
     "dependencies": {
         "@nangohq/utils": "file:../utils",
-        "@openfeature/server-sdk": "~1.18.0",
+        "@openfeature/core": "1.9.1",
+        "@openfeature/server-sdk": "1.18.0",
         "unleash-client": "6.6.0"
     },
     "devDependencies": {

--- a/packages/feature-flags/package.json
+++ b/packages/feature-flags/package.json
@@ -17,7 +17,8 @@
         "@nangohq/utils": "file:../utils",
         "@openfeature/core": "1.9.1",
         "@openfeature/server-sdk": "1.18.0",
-        "unleash-client": "6.6.0"
+        "unleash-client": "6.6.0",
+        "http-cache-semantics": "4.2.0"
     },
     "devDependencies": {
         "rimraf": "6.1.3",

--- a/packages/feature-flags/package.json
+++ b/packages/feature-flags/package.json
@@ -20,6 +20,7 @@
         "unleash-client": "6.6.0"
     },
     "devDependencies": {
+        "rimraf": "6.1.3",
         "vitest": "3.2.4"
     },
     "files": [

--- a/packages/feature-flags/tsconfig.json
+++ b/packages/feature-flags/tsconfig.json
@@ -1,0 +1,13 @@
+{
+    "extends": "../../tsconfig.json",
+    "compilerOptions": {
+        "rootDir": "lib",
+        "outDir": "dist"
+    },
+    "references": [
+        {
+            "path": "../utils"
+        }
+    ],
+    "include": ["lib/**/*", "../utils/lib/vitest.d.ts"]
+}

--- a/packages/lambda-runner/Dockerfile.lambda
+++ b/packages/lambda-runner/Dockerfile.lambda
@@ -44,6 +44,7 @@ COPY packages/billing/package.json ./packages/billing/package.json
 COPY packages/pubsub/package.json ./packages/pubsub/package.json
 COPY packages/usage/package.json ./packages/usage/package.json
 COPY packages/email/package.json ./packages/email/package.json
+COPY packages/feature-flags/package.json ./packages/feature-flags/package.json
 COPY packages/metering/package.json ./packages/metering/package.json
 COPY packages/lambda-runner/package.json ./packages/lambda-runner/package.json
 COPY package*.json  ./

--- a/packages/lambda-runner/Dockerfile.lambda
+++ b/packages/lambda-runner/Dockerfile.lambda
@@ -46,6 +46,7 @@ COPY packages/billing/package.json ./packages/billing/package.json
 COPY packages/pubsub/package.json ./packages/pubsub/package.json
 COPY packages/usage/package.json ./packages/usage/package.json
 COPY packages/email/package.json ./packages/email/package.json
+COPY packages/feature-flags/package.json ./packages/feature-flags/package.json
 COPY packages/metering/package.json ./packages/metering/package.json
 COPY packages/lambda-runner/package.json ./packages/lambda-runner/package.json
 COPY package*.json  ./

--- a/packages/utils/lib/environment/parse.ts
+++ b/packages/utils/lib/environment/parse.ts
@@ -540,6 +540,13 @@ export const ENVS = z.object({
     E2B_API_KEY: z.string().optional(),
     E2B_SANDBOX_COMPILER_TEMPLATE: z.string().min(1).default('blank-workspace:staging'),
 
+    // Feature Flags
+    NANGO_FLAG_PROVIDER: z.enum(['noop', 'unleash']).optional().default('noop'),
+    NANGO_UNLEASH_URL: z.url().optional(),
+    NANGO_UNLEASH_API_TOKEN: z.string().optional(),
+    NANGO_UNLEASH_APP_NAME: z.string().optional().default('nango'),
+    NANGO_UNLEASH_REFRESH_INTERVAL_MS: z.coerce.number().optional().default(30_000),
+
     // ----- Others
     SERVER_RUN_MODE: z.enum(['DOCKERIZED', '']).optional(),
     NANGO_CLOUD: z.stringbool().optional().default(false),

--- a/packages/utils/lib/environment/parse.ts
+++ b/packages/utils/lib/environment/parse.ts
@@ -642,6 +642,7 @@ export const ENVS = z.object({
     NANGO_UNLEASH_API_TOKEN: z.string().optional(),
     NANGO_UNLEASH_APP_NAME: z.string().optional().default('nango'),
     NANGO_UNLEASH_REFRESH_INTERVAL_MS: z.coerce.number().optional().default(30_000),
+    NANGO_UNLEASH_INIT_TIMEOUT_MS: z.coerce.number().optional().default(10_000),
 
     // ----- Others
     SERVER_RUN_MODE: z.enum(['DOCKERIZED', '']).optional(),

--- a/packages/utils/lib/environment/parse.ts
+++ b/packages/utils/lib/environment/parse.ts
@@ -636,6 +636,13 @@ export const ENVS = z.object({
     E2B_SANDBOX_METRICS_POLL_INTERVAL_MS: z.coerce.number().int().nonnegative().default(60_000),
     E2B_SANDBOX_METRICS_REQUEST_TIMEOUT_MS: z.coerce.number().int().positive().default(10_000),
 
+    // Feature Flags
+    NANGO_FLAG_PROVIDER: z.enum(['noop', 'unleash']).optional().default('noop'),
+    NANGO_UNLEASH_URL: z.url().optional(),
+    NANGO_UNLEASH_API_TOKEN: z.string().optional(),
+    NANGO_UNLEASH_APP_NAME: z.string().optional().default('nango'),
+    NANGO_UNLEASH_REFRESH_INTERVAL_MS: z.coerce.number().optional().default(30_000),
+
     // ----- Others
     SERVER_RUN_MODE: z.enum(['DOCKERIZED', '']).optional(),
     NANGO_CLOUD: z.stringbool().optional().default(false),

--- a/tsconfig.build.json
+++ b/tsconfig.build.json
@@ -20,6 +20,9 @@
             "path": "packages/kvstore"
         },
         {
+            "path": "packages/feature-flags"
+        },
+        {
             "path": "packages/logs"
         },
         {

--- a/tsconfig.build.json
+++ b/tsconfig.build.json
@@ -23,6 +23,9 @@
             "path": "packages/kms"
         },
         {
+            "path": "packages/feature-flags"
+        },
+        {
             "path": "packages/logs"
         },
         {


### PR DESCRIPTION
This PR adds `@nangohq/feature-flags`, a thin wrapper around the [OpenFeature](https://openfeature.dev/) server SDK with two providers:
- **`noop`** (default) — always returns the call-site default. Zero-config, safe to ship to any environment.
- **`unleash`** — talks to a self-hosted [Unleash](https://www.getunleash.io/) instance. Configured via env vars; only enabled where `NANGO_FLAG_PROVIDER=unleash` and `NANGO_UNLEASH_URL` are set (currently development only — see infra/env PRs).

NAN-5344