### PR TITLE
feat(nan-5088): API key permissions with scoped customer keys

### DIFF
--- a/docs/docs.json
+++ b/docs/docs.json
@@ -1001,6 +1001,7 @@
                 "group": "HTTP API",
                 "icon": "cloud",
                 "pages": [
+                  "reference/api-keys",
                   "reference/api/authentication",
                   "reference/api/rate-limits",
                   {

--- a/docs/getting-started/quickstart.mdx
+++ b/docs/getting-started/quickstart.mdx
@@ -22,7 +22,7 @@ description: 'Authorize any API in minutes'
         ```typescript
         import { Nango } from '@nangohq/node';
 
-        const nango = new Nango({ secretKey: '<NANGO-SECRET-KEY>' }); // Find in your Environment Settings
+        const nango = new Nango({ secretKey: '<NANGO-SECRET-KEY>' }); // Find in Environment Settings > API Keys
 
         const connection = await nango.getConnection(
             '<INTEGRATION-ID>', // Find in your Integrations
@@ -36,11 +36,11 @@ description: 'Authorize any API in minutes'
         <Tab title="cURL">
 
         ```bash
-        # <NANGO-SECRET-KEY>: Find in your Environment Settings
+        # <NANGO-API-KEY>: Find in Environment Settings > API Keys
         # <INTEGRATION-ID>: Find in your Integrations
         # <CONNECTION-ID>: Find in your Connections
         curl -X GET \
-        -H 'Authorization: Bearer <NANGO-SECRET-KEY>' \
+        -H 'Authorization: Bearer <NANGO-API-KEY>' \
         'https://api.nango.dev/connection/<CONNECTION-ID>?provider_config_key=<INTEGRATION-ID>'
         ```
 

--- a/docs/getting-started/sample-app.mdx
+++ b/docs/getting-started/sample-app.mdx
@@ -109,7 +109,7 @@ The sample app uses Slack, Google Drive, OneDrive for Business, and OneDrive Per
     nvm use
     npm i
     ```
-    - Copy your Nango Secret Key, found in [Environment Settings](https://app.nango.dev/dev/environment-settings?source=sample-app).
+    - Copy your Nango Secret Key, found in [Environment Settings > API Keys](https://app.nango.dev/dev/environment-settings#api-keys?source=sample-app).
     - Create a file to store environment variables and fill in the Nango Secret Key:
     ```sh
     cp .env.example .env

--- a/docs/guides/platform/security.mdx
+++ b/docs/guides/platform/security.mdx
@@ -350,6 +350,12 @@ To minimize disruption:
 
 We will make reasonable efforts to communicate breaking changes in advance.
 
+## API Key Scoping
+
+Nango supports scoped API keys, allowing you to follow the principle of least privilege when granting programmatic access to your environments. Each API key can be restricted to specific operations — for example, a CI/CD pipeline key that can only deploy, or a backend service key that can read connections but not manage integrations.
+
+For details on available scopes, advised profiles, and key management, see the [API Keys reference](/reference/api-keys).
+
 <Tip>
 **Questions about security?** Please reach out in the [Slack community](https://nango.dev/slack) or contact security@nango.dev.
 </Tip>

--- a/docs/implementation-guides/platform/auth/connection-tags.mdx
+++ b/docs/implementation-guides/platform/auth/connection-tags.mdx
@@ -49,7 +49,7 @@ When requesting a new Connect session token from Nango, pass a `tags` object:
     ```ts
     import { Nango } from '@nangohq/node';
     
-    const nango = new Nango({ secretKey: process.env['<NANGO-SECRET-KEY>'] });
+    const nango = new Nango({ secretKey: process.env['<NANGO-API-KEY>'] });
     
     api.post('/sessionToken', async (req, res) => {
       const { data } = await nango.createConnectSession({
@@ -69,7 +69,7 @@ When requesting a new Connect session token from Nango, pass a `tags` object:
     ```bash
     curl --request POST \
       --url https://api.nango.dev/connect/sessions \
-      --header 'Authorization: Bearer <NANGO-SECRET-KEY>' \
+      --header 'Authorization: Bearer <NANGO-API-KEY>' \
       --header 'Content-Type: application/json' \
       --data '{
         "tags": {
@@ -115,7 +115,7 @@ Nango also stores these tags on the connection itself.
     ```ts
     import { Nango } from '@nangohq/node';
     
-    const nango = new Nango({ secretKey: '<NANGO-SECRET-KEY>' });
+    const nango = new Nango({ secretKey: '<NANGO-API-KEY>' });
     const connection = await nango.getConnection('<INTEGRATION-ID>', '<CONNECTION-ID>');
 
     console.log(connection.tags);
@@ -125,7 +125,7 @@ Nango also stores these tags on the connection itself.
     ```bash
     curl --request GET \
       --url 'https://api.nango.dev/connections/<CONNECTION-ID>?provider_config_key=<INTEGRATION-ID>' \
-      --header 'Authorization: Bearer <NANGO-SECRET-KEY>' \
+      --header 'Authorization: Bearer <NANGO-API-KEY>' \
       --header 'Content-Type: application/json' \
     ```
   </Tab>
@@ -140,7 +140,7 @@ You can filter connections by tags when listing connections:
     ```ts
     import { Nango } from '@nangohq/node';
 
-    const nango = new Nango({ secretKey: '<NANGO-SECRET-KEY>' });
+    const nango = new Nango({ secretKey: '<NANGO-API-KEY>' });
 
     const { connections } = await nango.listConnections({
       tags: {
@@ -158,7 +158,7 @@ You can filter connections by tags when listing connections:
     ```bash
     curl --request GET \
       --url 'https://api.nango.dev/connections?tags[end_user_id]=<END-USER-ID>&tags[end_user_email]=<END-USER-EMAIL>&tags[organization_id]=<ORGANIZATION-ID>' \
-      --header 'Authorization: Bearer <NANGO-SECRET-KEY>' \
+      --header 'Authorization: Bearer <NANGO-API-KEY>' \
       --header 'Content-Type: application/json'
     ```
   </Tab>
@@ -198,7 +198,7 @@ If you need to update tags after a connection is created, patch the connection:
     ```ts
     import { Nango } from '@nangohq/node';
 
-    const nango = new Nango({ secretKey: '<NANGO-SECRET-KEY>' });
+    const nango = new Nango({ secretKey: '<NANGO-API-KEY>' });
 
     await nango.patchConnection(
       {
@@ -220,7 +220,7 @@ If you need to update tags after a connection is created, patch the connection:
     ```bash
     curl --request PATCH \
       --url 'https://api.nango.dev/connections/<CONNECTION-ID>?provider_config_key=<INTEGRATION-ID>' \
-      --header 'Authorization: Bearer <NANGO-SECRET-KEY>' \
+      --header 'Authorization: Bearer <NANGO-API-KEY>' \
       --header 'Content-Type: application/json' \
       --data '{
         "tags": {

--- a/docs/implementation-guides/platform/auth/implement-api-auth.mdx
+++ b/docs/implementation-guides/platform/auth/implement-api-auth.mdx
@@ -23,14 +23,16 @@ description: "Guide to letting your users authorize an external API from your ap
 
 In **your backend**, set up an API endpoint that your frontend will call before each authorization attempt to retrieve a session token from Nango.
 
-Here's an example of how your backend can retrieve a session token from Nango ([API](/reference/api/connect/sessions/create) / [Node SDK](/reference/sdks/node#create-a-connect-session) references):
+Here's an example of how your backend can retrieve a session token from Nango ([API](/reference/api/connect/sessions/create) / [Node SDK](/reference/sdks/node#create-a-connect-session) references).
+
+You'll need an [API key](/reference/api-keys) with the `environment:connect_sessions:write` scope. You can find your API keys in **Environment Settings > API Keys** in the Nango UI.
 
 <Tabs>
   <Tab title="Node">
     ```ts
     import { Nango } from '@nangohq/node';
     
-    const nango = new Nango({ secretKey: process.env['<NANGO-SECRET-KEY>'] });
+    const nango = new Nango({ secretKey: process.env['<NANGO-API-KEY>'] });
     
     api.post('/sessionToken', async (req, res) => {
       // Ask Nango for a secure token
@@ -52,7 +54,7 @@ Here's an example of how your backend can retrieve a session token from Nango ([
     ```bash
     curl --request POST \
       --url https://api.nango.dev/connect/sessions \
-      --header 'Authorization: Bearer <NANGO-SECRET-KEY>' \
+      --header 'Authorization: Bearer <NANGO-API-KEY>' \
       --header 'Content-Type: application/json' \
       --data '{
         "tags": {
@@ -231,7 +233,7 @@ Before displaying integration settings, check if the connection is still valid u
 ```ts
 import { Nango } from '@nangohq/node';
 
-const nango = new Nango({ secretKey: process.env['<NANGO-SECRET-KEY>'] });
+const nango = new Nango({ secretKey: process.env['<NANGO-API-KEY>'] });
 
 // Check connection status
 try {
@@ -252,7 +254,7 @@ try {
 ```bash
 curl --request GET \
   --url https://api.nango.dev/connection/<CONNECTION-ID>?provider_config_key=<INTEGRATION-ID> \
-  --header 'Authorization: Bearer <NANGO-SECRET-KEY>'
+  --header 'Authorization: Bearer <NANGO-API-KEY>'
 ```
 
 </Tab>
@@ -284,7 +286,7 @@ The flow is very similar to the flow for new connections:
 ```ts
 import { Nango } from '@nangohq/node';
 
-const nango = new Nango({ secretKey: process.env['<NANGO-SECRET-KEY>'] });
+const nango = new Nango({ secretKey: process.env['<NANGO-API-KEY>'] });
 
 api.post('/sessionToken', async (req, res) => {
   // Ask Nango for a secure token to reconnect
@@ -304,7 +306,7 @@ api.post('/sessionToken', async (req, res) => {
 ```bash
 curl --request POST \
   --url https://api.nango.dev/connect/sessions/reconnect \
-  --header 'Authorization: Bearer <NANGO-SECRET-KEY>' \
+  --header 'Authorization: Bearer <NANGO-API-KEY>' \
   --header 'Content-Type: application/json' \
   --data '{
     "connection_id": "<CONNECTION-ID>",

--- a/docs/implementation-guides/platform/auth/share-connect-link.mdx
+++ b/docs/implementation-guides/platform/auth/share-connect-link.mdx
@@ -15,7 +15,7 @@ Create a connect session and return the `connect_link` to your frontend or inter
     ```ts
     import { Nango } from '@nangohq/node';
 
-    const nango = new Nango({ secretKey: process.env['<NANGO-SECRET-KEY>'] });
+    const nango = new Nango({ secretKey: process.env['<NANGO-API-KEY>'] });
 
     api.post('/connectLink', async (req, res) => {
       const { data } = await nango.createConnectSession({
@@ -38,7 +38,7 @@ Create a connect session and return the `connect_link` to your frontend or inter
     ```bash
     curl --request POST \
       --url https://api.nango.dev/connect/sessions \
-      --header 'Authorization: Bearer <NANGO-SECRET-KEY>' \
+      --header 'Authorization: Bearer <NANGO-API-KEY>' \
       --header 'Content-Type: application/json' \
       --data '{
         "tags": {

--- a/docs/implementation-guides/platform/common-issues.mdx
+++ b/docs/implementation-guides/platform/common-issues.mdx
@@ -100,7 +100,7 @@ Indications of the error:
 
 1. Confirm the environment and secret key
    - The `secretKey` in the API or SDK is specific to the environment. Make sure you pass the key that corresponds to the environment you are using (e.g., dev vs prod).
-   - Open [Environment Settings](https://app.nango.dev/dev/environment-settings) and verify the key matches.
+   - Open [Environment Settings > API Keys](https://app.nango.dev/dev/environment-settings#api-keys) and verify the key matches.
 
 2. Verify the Integration ID (aka `providerConfigKey`)
    - Go to [Integrations](https://app.nango.dev/dev/integrations), open the integration, and copy the `Integration ID` exactly.

--- a/docs/implementation-guides/platform/functions/functions-setup.mdx
+++ b/docs/implementation-guides/platform/functions/functions-setup.mdx
@@ -52,7 +52,7 @@ NANGO_SECRET_KEY_PROD='<PROD-SECRET-KEY>'
 NANGO_SECRET_KEY_DEV='<DEV-SECRET-KEY>'
 ```
 
-Get your secret keys from the **Environment Settings** tab (toggle between the `Production` and `Development` environment in the left nav bar).
+Get your secret keys from **Environment Settings > API Keys** (toggle between the `Production` and `Development` environment in the left nav bar).
 
 <Note>
   You can rename environments in the Nango UI under _Environment Settings_. 

--- a/docs/implementation-guides/platform/migrations/migrate-from-end-user.mdx
+++ b/docs/implementation-guides/platform/migrations/migrate-from-end-user.mdx
@@ -39,7 +39,7 @@ Add a `tags` object when creating a Connect session token in your backend:
     ```ts
     import { Nango } from '@nangohq/node';
 
-    const nango = new Nango({ secretKey: process.env['<NANGO-SECRET-KEY>'] });
+    const nango = new Nango({ secretKey: process.env['<NANGO-API-KEY>'] });
 
     const { data } = await nango.createConnectSession({
       // Recommended
@@ -57,7 +57,7 @@ Add a `tags` object when creating a Connect session token in your backend:
     ```bash
     curl --request POST \
       --url https://api.nango.dev/connect/sessions \
-      --header 'Authorization: Bearer <NANGO-SECRET-KEY>' \
+      --header 'Authorization: Bearer <NANGO-API-KEY>' \
       --header 'Content-Type: application/json' \
       --data '{
         "tags": {

--- a/docs/implementation-guides/platform/migrations/migrate-from-public-key.mdx
+++ b/docs/implementation-guides/platform/migrations/migrate-from-public-key.mdx
@@ -61,7 +61,7 @@ This will also be used to attribute webhooks to the correct end user.
   ```ts
   import { Nango } from '@nangohq/node';
 
-const nango = new Nango({ secretKey: process.env['<NANGO-SECRET-KEY>'] });
+const nango = new Nango({ secretKey: process.env['<NANGO-API-KEY>'] });
  await nango.patchConnection({
      connectionId: '<CONNECTION-ID>',
      provider_config_key: '<INTEGRATION-ID>',
@@ -77,7 +77,7 @@ const nango = new Nango({ secretKey: process.env['<NANGO-SECRET-KEY>'] });
   <Tab title="cURL">
 ```bash
 curl -X PATCH https://api.nango.dev/v1/connections/<CONNECTION-ID> \
--H "Authorization: Bearer <NANGO-SECRET-KEY>" \
+-H "Authorization: Bearer <NANGO-API-KEY>" \
 -H "Content-Type: application/json" \
  -d '{
      "tags": {

--- a/docs/implementation-guides/platform/proxy/implement-requests-proxy.mdx
+++ b/docs/implementation-guides/platform/proxy/implement-requests-proxy.mdx
@@ -46,7 +46,7 @@ You can use the proxy with the [Node SDK](/reference/sdks/node#proxy-get-request
     <Tab title="cURL">
         ```bash
         curl -X POST -H 'Content-Type: application/json' \
-        -H 'Authorization: Bearer <NANGO-SECRET-KEY>' \
+        -H 'Authorization: Bearer <NANGO-API-KEY>' \
         -H 'Provider-Config-Key: <INTEGRATION-ID>' \
         -H 'Connection-Id: <CONNECTION-ID>' \
         -d '{"colorId: "blue"}' \

--- a/docs/implementation-guides/platform/webhooks-from-nango.mdx
+++ b/docs/implementation-guides/platform/webhooks-from-nango.mdx
@@ -39,7 +39,7 @@ To test webhooks locally, use a webhook forwarding service like [ngrok](https://
 
 Validate webhooks from Nango by looking at the `X-Nango-Hmac-Sha256` header.
 
-It's an HMAC-SHA256 hash of the webhook payload, using the secret key found in the _Environment Settings_ in the Nango UI.
+It's an HMAC-SHA256 hash of the webhook payload, using the webhook signing key found in **Environment Settings > Webhooks > Signing key** in the Nango UI.
 
 <Warning>
 Nango webhook requests include an `X-Nango-Hmac-Sha256` header for secure verification. A legacy `X-Nango-Signature` header (using plain SHA-256) is also sent for backwards compatibility but should not be used. If you're currently using `X-Nango-Signature`, migrate to `X-Nango-Hmac-Sha256` for improved security.

--- a/docs/implementation-guides/use-cases/syncs/records-cache.mdx
+++ b/docs/implementation-guides/use-cases/syncs/records-cache.mdx
@@ -106,7 +106,7 @@ You must persist the cursor on your side for each combination of **connection** 
 ```ts
 import { Nango } from '@nangohq/node';
 
-const nango = new Nango({ secretKey: '<NANGO-SECRET-KEY>' });
+const nango = new Nango({ secretKey: '<NANGO-API-KEY>' });
 
 // Fetch only records that changed since your last cursor
 const result = await nango.listRecords({
@@ -128,7 +128,7 @@ if (result.records.length > 0) {
 <Tab title="cURL">
 ```bash
 curl -G https://api.nango.dev/records \
-  --header 'Authorization: Bearer <NANGO-SECRET-KEY>' \
+  --header 'Authorization: Bearer <NANGO-API-KEY>' \
   --header 'Provider-Config-Key: <INTEGRATION-ID>' \
   --header 'Connection-Id: <CONNECTION-ID>' \
   --data-urlencode 'model=Contact' \

--- a/docs/implementation-guides/use-cases/syncs/sync-partitioning.mdx
+++ b/docs/implementation-guides/use-cases/syncs/sync-partitioning.mdx
@@ -49,7 +49,7 @@ To create a sync variant, use the Nango API or SDK. The variant must have a uniq
     ```bash
     curl --request POST \
       --url https://api.nango.dev/sync/sync-orders/variant/high-value-orders \
-      --header 'Authorization: Bearer <NANGO-SECRET-KEY>' \
+      --header 'Authorization: Bearer <NANGO-API-KEY>' \
       --header 'Content-Type: application/json' \
       --data '{
         "provider_config_key": "my-integration",
@@ -104,7 +104,7 @@ Use the variant query parameter when retrieving records from the Nango API.
     ```bash
     curl --request GET \
       --url "https://api.nango.dev/records?model=Order&variant=high-value-orders" \
-      --header 'Authorization: Bearer <NANGO-SECRET-KEY>'
+      --header 'Authorization: Bearer <NANGO-API-KEY>'
     ```
   </Tab>
 </Tabs>
@@ -138,7 +138,7 @@ Storing metadata:
     ```bash
     curl --request POST \
       --url https://api.nango.dev/metadata \
-      --header 'Authorization: Bearer <NANGO-SECRET-KEY>' \
+      --header 'Authorization: Bearer <NANGO-API-KEY>' \
       --header 'Content-Type: application/json' \
       --data '{
         "connection_id": "customer-123",

--- a/docs/reference/api-keys.mdx
+++ b/docs/reference/api-keys.mdx
@@ -1,0 +1,196 @@
+---
+title: "API Keys"
+sidebarTitle: "API Keys"
+description: "Manage API keys with scoped permissions for your Nango environments."
+---
+
+# API Keys
+
+API keys allow programmatic access to your Nango environment. Each environment can have multiple API keys with different permissions, enabling you to follow the principle of least privilege.
+
+## Managing API Keys
+
+API keys are managed in the Nango UI under **Environment Settings > API Keys**.
+
+Each environment comes with a **Default - Full access** key that grants access to all API endpoints. You can create additional keys with restricted scopes for specific use cases.
+
+### Creating a Key
+
+1. Go to **Environment Settings > API Keys**
+2. Click **Create API Key**
+3. Enter a display name (e.g., "CI Deploy Key", "Backend service")
+4. Choose **Full access** or **Custom** permissions — custom lets you pick individual scopes
+5. The key is created immediately and can be revealed and copied from the key list
+
+### Rotating a Key
+
+To rotate a key:
+1. Create a new key with the same scopes
+2. Update your application to use the new key
+3. Monitor the **Last used** column on the old key to confirm it's no longer in use
+4. Delete the old key
+
+### Using a Key
+
+Pass the API key as a Bearer token in the `Authorization` header:
+
+<Tabs>
+  <Tab title="Node SDK">
+    ```ts
+    import { Nango } from '@nangohq/node';
+
+    const nango = new Nango({ secretKey: '<YOUR-API-KEY>' });
+    ```
+  </Tab>
+  <Tab title="cURL">
+    ```bash
+    curl --request GET \
+      --url https://api.nango.dev/connections \
+      --header 'Authorization: Bearer <YOUR-API-KEY>'
+    ```
+  </Tab>
+</Tabs>
+
+## Scopes
+
+Scopes control what an API key can access. When creating a key with **Custom** permissions, you select which scopes to grant. A key without a specific scope will receive a `403 Forbidden` response when trying to access a protected endpoint.
+
+### Credential Scopes
+
+Some resources (Integrations and Connections) have sensitive credential data. Access to this data is controlled by dedicated `_credentials` scopes:
+
+- `list` / `read` — returns the resource **without** sensitive credentials
+- `list_credentials` / `read_credentials` — returns the resource **with** credentials (access tokens, client secrets, etc.)
+
+The `_credentials` scopes are supersets — selecting `read_credentials` automatically includes `read` access. You don't need to select both.
+
+| Resource | Without credentials | With credentials |
+|----------|-------------------|-----------------|
+| **Connections** | Connection metadata, tags, status | + access/refresh tokens |
+| **Integrations** | Provider, display name, config | + client ID and client secret |
+
+## Advised Profiles
+
+Common scope combinations for typical use cases:
+
+### Auth (Connect UI)
+
+For backends that create connect sessions for the auth flow:
+
+| Scope |
+|-------|
+| `environment:connect_sessions:write` |
+
+### CI/CD Deploy
+
+For CI/CD pipelines deploying syncs and actions to production:
+
+| Scope |
+|-------|
+| `environment:deploy` |
+
+### Backend Service
+
+For backend services that consume data, trigger actions, and proxy requests:
+
+| Scope |
+|-------|
+| `environment:connections:read` |
+| `environment:records:read` |
+| `environment:actions:execute` |
+| `environment:syncs:execute` |
+| `environment:proxy` |
+
+Add `environment:connections:read_credentials` if the service needs access to connection tokens.
+
+<Tip>
+For extra security, avoid when possible granting `environment:connections:list` to backend services. Without it, connection IDs act as connection-specific secrets — a leaked API key alone won't let an attacker enumerate and access customer data.
+</Tip>
+
+### Local Development
+
+For local development, use a **Full access** key. This is the default key created for each environment.
+
+## CLI
+
+The Nango CLI uses the `NANGO_SECRET_KEY_<ENV>` environment variable for authentication. Set it to an API key with the required scopes:
+
+| CLI Command | Required Scope |
+|-------------|---------------|
+| `nango deploy` | `environment:deploy` |
+| `nango dryrun` | `environment:connections:read_credentials` + `environment:integrations:read` + `environment:proxy` |
+
+The **Default - Full access** key that comes with each environment already has all required scopes for both deploying and dry-running. For production CI/CD pipelines, consider creating a dedicated key with only the `environment:deploy` scope to follow the principle of least privilege.
+
+## All Available Scopes
+
+### Integrations
+
+| Scope | Description |
+|-------|-------------|
+| `environment:integrations:list` | List integrations (no credentials) |
+| `environment:integrations:list_credentials` | List integrations with client credentials |
+| `environment:integrations:read` | Read a single integration (no credentials) |
+| `environment:integrations:read_credentials` | Read a single integration with client credentials |
+| `environment:integrations:write` | Create, update, delete integrations |
+
+### Connections
+
+| Scope | Description |
+|-------|-------------|
+| `environment:connections:list` | List connections (no credentials) |
+| `environment:connections:list_credentials` | List connections with access/refresh tokens |
+| `environment:connections:read` | Read a single connection (no credentials) |
+| `environment:connections:read_credentials` | Read a single connection with access/refresh tokens |
+| `environment:connections:write` | Create, update, delete connections and metadata |
+
+### Connect Sessions
+
+| Scope | Description |
+|-------|-------------|
+| `environment:connect_sessions:write` | Create and reconnect sessions for the Connect UI auth flow |
+
+### Syncs
+
+| Scope | Description |
+|-------|-------------|
+| `environment:syncs:read` | Read sync status |
+| `environment:syncs:execute` | Trigger, pause, start syncs |
+| `environment:syncs:manage` | Update sync frequency, create/delete sync variants |
+
+### Deploy
+
+| Scope | Description |
+|-------|-------------|
+| `environment:deploy` | Deploy syncs and actions via CLI or API |
+
+### Records
+
+| Scope | Description |
+|-------|-------------|
+| `environment:records:read` | Read synced records |
+| `environment:records:write` | Prune records |
+
+### Actions
+
+| Scope | Description |
+|-------|-------------|
+| `environment:actions:execute` | Trigger actions and read action results |
+
+### Proxy
+
+| Scope | Description |
+|-------|-------------|
+| `environment:proxy` | Send proxy requests to external APIs through Nango |
+
+### Config
+
+| Scope | Description |
+|-------|-------------|
+| `environment:config:read` | Read environment variables and scripts config |
+
+### MCP
+
+| Scope | Description |
+|-------|-------------|
+| `environment:mcp` | Access the MCP endpoint |

--- a/docs/reference/api/action/trigger.mdx
+++ b/docs/reference/api/action/trigger.mdx
@@ -2,3 +2,7 @@
 title: 'Trigger an action'
 openapi: 'POST /action/trigger'
 ---
+
+<Info>
+  Requires an API key with the `environment:actions:execute` scope. [Learn more about API key scopes](/reference/api-keys#scopes).
+</Info>

--- a/docs/reference/api/authentication.mdx
+++ b/docs/reference/api/authentication.mdx
@@ -2,8 +2,10 @@
 title: 'Authentication'
 ---
 
-Use the Nango Secret Key available in your [Environment Settings](https://app.nango.dev/environment-settings) as Bearer token in the `Authorization` header:
+Use an [API key](/reference/api-keys) as a Bearer token in the `Authorization` header. API keys are managed in **Environment Settings > API Keys** in the Nango UI.
 
 ```
-Authorization: Bearer {nango-secret-key}
+Authorization: Bearer <NANGO-API-KEY>
 ```
+
+Each API key has [scopes](/reference/api-keys#scopes) that control which endpoints it can access. A key without the required scope will receive a `403 Forbidden` response.

--- a/docs/reference/api/connect/sessions/create.mdx
+++ b/docs/reference/api/connect/sessions/create.mdx
@@ -3,6 +3,10 @@ title: 'Create a connect session'
 openapi: 'POST /connect/sessions'
 ---
 
+<Info>
+  Requires an API key with the `environment:connect_sessions:write` scope. [Learn more about API key scopes](/reference/api-keys#scopes).
+</Info>
+
 Creates a short-lived connect session (30m).
 The returned token can be used for instance to create connections through Connect UI.
 

--- a/docs/reference/api/connect/sessions/reconnect.mdx
+++ b/docs/reference/api/connect/sessions/reconnect.mdx
@@ -3,3 +3,6 @@ title: 'Create a re-connect session'
 openapi: 'POST /connect/sessions/reconnect'
 ---
 
+<Info>
+  Requires an API key with the `environment:connect_sessions:write` scope. [Learn more about API key scopes](/reference/api-keys#scopes).
+</Info>

--- a/docs/reference/api/connection/delete.mdx
+++ b/docs/reference/api/connection/delete.mdx
@@ -2,3 +2,7 @@
 title: 'Delete a connection (deprecated)'
 openapi: 'DELETE /connection/{connectionId}'
 ---
+
+<Info>
+  Requires an API key with the `environment:connections:write` scope. [Learn more about API key scopes](/reference/api-keys#scopes).
+</Info>

--- a/docs/reference/api/connection/get.mdx
+++ b/docs/reference/api/connection/get.mdx
@@ -4,6 +4,10 @@ openapi: 'GET /connection/{connectionId}'
 ---
 
 <Info>
+  Requires an API key with one of: `environment:connections:read` or `environment:connections:read_credentials`. [Learn more about API key scopes](/reference/api-keys#scopes).
+</Info>
+
+<Info>
 
 The response content depends on the API authentication type (e.g: OAuth 2, OAuth 1, API key, etc.).
 

--- a/docs/reference/api/connection/list.mdx
+++ b/docs/reference/api/connection/list.mdx
@@ -3,6 +3,10 @@ title: 'List connections (deprecated)'
 openapi: 'GET /connection'
 ---
 
+<Info>
+  Requires an API key with one of: `environment:connections:list` or `environment:connections:list_credentials`. [Learn more about API key scopes](/reference/api-keys#scopes).
+</Info>
+
 <ResponseExample>
   ```json Example Response
 {

--- a/docs/reference/api/connection/post.mdx
+++ b/docs/reference/api/connection/post.mdx
@@ -2,6 +2,11 @@
 title: 'Import a connection (deprecated)'
 openapi: 'POST /connection'
 ---
+
+<Info>
+  Requires an API key with the `environment:connections:write` scope. [Learn more about API key scopes](/reference/api-keys#scopes).
+</Info>
+
 ## When to use
 
 Use this API endpoint to import existing access tokens into Nango. It is mostly meant for one-off bulk imports when onboarding Nango.

--- a/docs/reference/api/connection/set-metadata-legacy.mdx
+++ b/docs/reference/api/connection/set-metadata-legacy.mdx
@@ -3,6 +3,10 @@ title: 'Set connection metadata (Deprecated)'
 openapi: 'POST /connection/{connectionId}/metadata'
 ---
 
+<Info>
+  Requires an API key with the `environment:connections:write` scope. [Learn more about API key scopes](/reference/api-keys#scopes).
+</Info>
+
 ## Set _connection metadata_
 
 Nango uses the request body as the new metadata (it must be a JSON object). Note that this overrides any existing metadata.

--- a/docs/reference/api/connection/set-metadata.mdx
+++ b/docs/reference/api/connection/set-metadata.mdx
@@ -3,6 +3,10 @@ title: 'Set connection metadata (deprecated)'
 openapi: 'POST /connection/metadata'
 ---
 
+<Info>
+  Requires an API key with the `environment:connections:write` scope. [Learn more about API key scopes](/reference/api-keys#scopes).
+</Info>
+
 ## Set _connection metadata_
 
 Nango uses the request body as the new metadata (it must be a JSON object). Note that this overrides any existing metadata. The connection_id must be passed in the body as well. Note that the connection_id can be a single string or an array of strings.

--- a/docs/reference/api/connection/update-metadata-legacy.mdx
+++ b/docs/reference/api/connection/update-metadata-legacy.mdx
@@ -3,6 +3,10 @@ title: 'Edit connection metadata (Deprecated)'
 openapi: 'PATCH /connection/{connectionId}/metadata'
 ---
 
+<Info>
+  Requires an API key with the `environment:connections:write` scope. [Learn more about API key scopes](/reference/api-keys#scopes).
+</Info>
+
 ## Update _connection metadata_
 
 Nango uses the request body as the new metadata (it must be a JSON object).

--- a/docs/reference/api/connection/update-metadata.mdx
+++ b/docs/reference/api/connection/update-metadata.mdx
@@ -3,6 +3,10 @@ title: 'Edit connection metadata (deprecated)'
 openapi: 'PATCH /connection/metadata'
 ---
 
+<Info>
+  Requires an API key with the `environment:connections:write` scope. [Learn more about API key scopes](/reference/api-keys#scopes).
+</Info>
+
 ## Update _connection metadata_
 
 Nango uses the request body as the new metadata (it must be a JSON object). Note that this overrides specified properties, not the entire metadata. The connection_id must be passed in the body as well. Note that the connection_id can be a single string or an array of strings.

--- a/docs/reference/api/connections/delete.mdx
+++ b/docs/reference/api/connections/delete.mdx
@@ -2,3 +2,7 @@
 title: 'Delete a connection'
 openapi: 'DELETE /connections/{connectionId}'
 ---
+
+<Info>
+  Requires an API key with the `environment:connections:write` scope. [Learn more about API key scopes](/reference/api-keys#scopes).
+</Info>

--- a/docs/reference/api/connections/get.mdx
+++ b/docs/reference/api/connections/get.mdx
@@ -4,6 +4,10 @@ openapi: 'GET /connections/{connectionId}'
 ---
 
 <Info>
+  Requires an API key with one of: `environment:connections:read` or `environment:connections:read_credentials`. [Learn more about API key scopes](/reference/api-keys#scopes).
+</Info>
+
+<Info>
 
 The response content depends on the API authentication type (e.g: OAuth 2, OAuth 1, API key, etc.).
 

--- a/docs/reference/api/connections/list.mdx
+++ b/docs/reference/api/connections/list.mdx
@@ -3,6 +3,10 @@ title: 'List connections'
 openapi: 'GET /connections'
 ---
 
+<Info>
+  Requires an API key with one of: `environment:connections:list` or `environment:connections:list_credentials`. [Learn more about API key scopes](/reference/api-keys#scopes).
+</Info>
+
 <ResponseExample>
   ```json Example Response
 {

--- a/docs/reference/api/connections/patch.mdx
+++ b/docs/reference/api/connections/patch.mdx
@@ -2,3 +2,7 @@
 title: 'Patch a connection'
 openapi: 'PATCH /connections/{connectionId}'
 ---
+
+<Info>
+  Requires an API key with the `environment:connections:write` scope. [Learn more about API key scopes](/reference/api-keys#scopes).
+</Info>

--- a/docs/reference/api/connections/post.mdx
+++ b/docs/reference/api/connections/post.mdx
@@ -2,6 +2,11 @@
 title: 'Import a connection'
 openapi: 'POST /connections'
 ---
+
+<Info>
+  Requires an API key with the `environment:connections:write` scope. [Learn more about API key scopes](/reference/api-keys#scopes).
+</Info>
+
 ## When to use
 
 Use this API endpoint to import existing access tokens into Nango. It is mostly meant for one-off bulk imports when onboarding Nango.

--- a/docs/reference/api/connections/set-metadata.mdx
+++ b/docs/reference/api/connections/set-metadata.mdx
@@ -3,6 +3,10 @@ title: 'Set connection metadata'
 openapi: 'POST /connections/metadata'
 ---
 
+<Info>
+  Requires an API key with the `environment:connections:write` scope. [Learn more about API key scopes](/reference/api-keys#scopes).
+</Info>
+
 ## Set _connection metadata_
 
 Nango uses the request body as the new metadata (it must be a JSON object). Note that this overrides any existing metadata. The connection_id must be passed in the body as well. Note that the connection_id can be a single string or an array of strings.

--- a/docs/reference/api/connections/update-metadata.mdx
+++ b/docs/reference/api/connections/update-metadata.mdx
@@ -3,6 +3,10 @@ title: 'Edit connection metadata'
 openapi: 'PATCH /connections/metadata'
 ---
 
+<Info>
+  Requires an API key with the `environment:connections:write` scope. [Learn more about API key scopes](/reference/api-keys#scopes).
+</Info>
+
 ## Update _connection metadata_
 
 Nango uses the request body as the new metadata (it must be a JSON object). Note that this overrides specified properties, not the entire metadata. The connection_id must be passed in the body as well. Note that the connection_id can be a single string or an array of strings.

--- a/docs/reference/api/integration/create.mdx
+++ b/docs/reference/api/integration/create.mdx
@@ -3,6 +3,10 @@ title: 'Create an integration'
 openapi: 'POST /integrations'
 ---
 
+<Info>
+  Requires an API key with the `environment:integrations:write` scope. [Learn more about API key scopes](/reference/api-keys#scopes).
+</Info>
+
 <ResponseExample>
 ```json Example Response
 {

--- a/docs/reference/api/integration/delete.mdx
+++ b/docs/reference/api/integration/delete.mdx
@@ -2,3 +2,7 @@
 title: 'Delete an integration'
 openapi: 'DELETE /integrations/{uniqueKey}'
 ---
+
+<Info>
+  Requires an API key with the `environment:integrations:write` scope. [Learn more about API key scopes](/reference/api-keys#scopes).
+</Info>

--- a/docs/reference/api/integration/get.mdx
+++ b/docs/reference/api/integration/get.mdx
@@ -3,6 +3,10 @@ title: 'Get an integration'
 openapi: 'GET /integrations/{uniqueKey}'
 ---
 
+<Info>
+  Requires an API key with one of: `environment:integrations:read` or `environment:integrations:read_credentials`. [Learn more about API key scopes](/reference/api-keys#scopes).
+</Info>
+
 <ResponseExample>
 ```json Example Response
 {

--- a/docs/reference/api/integration/list.mdx
+++ b/docs/reference/api/integration/list.mdx
@@ -3,6 +3,10 @@ title: 'List all integrations'
 openapi: 'GET /integrations'
 ---
 
+<Info>
+  Requires an API key with one of: `environment:integrations:list` or `environment:integrations:list_credentials`. [Learn more about API key scopes](/reference/api-keys#scopes).
+</Info>
+
 <RequestExample>
 
 ```ts Node Client

--- a/docs/reference/api/integration/update.mdx
+++ b/docs/reference/api/integration/update.mdx
@@ -3,3 +3,6 @@ title: 'Update an integration'
 openapi: 'PATCH /integrations/{uniqueKey}'
 ---
 
+<Info>
+  Requires an API key with the `environment:integrations:write` scope. [Learn more about API key scopes](/reference/api-keys#scopes).
+</Info>

--- a/docs/reference/api/proxy/delete.mdx
+++ b/docs/reference/api/proxy/delete.mdx
@@ -4,6 +4,10 @@ sidebarTitle: 'Proxy - DELETE requests'
 openapi: 'DELETE /proxy/{anyPath}'
 ---
 
+<Info>
+  Requires an API key with the `environment:proxy` scope. [Learn more about API key scopes](/reference/api-keys#scopes).
+</Info>
+
 ### API request
 
 The path, query params, and headers you send to the Proxy are all passed on to the external API, except for the configuration headers mentioned here:

--- a/docs/reference/api/proxy/get.mdx
+++ b/docs/reference/api/proxy/get.mdx
@@ -4,6 +4,10 @@ sidebarTitle: 'Proxy  - GET requests'
 openapi: 'GET /proxy/{anyPath}'
 ---
 
+<Info>
+  Requires an API key with the `environment:proxy` scope. [Learn more about API key scopes](/reference/api-keys#scopes).
+</Info>
+
 ### API request
 
 The path, query params, and headers you send to the Proxy are all passed on to the external API, except for the configuration headers mentioned here:

--- a/docs/reference/api/proxy/patch.mdx
+++ b/docs/reference/api/proxy/patch.mdx
@@ -4,6 +4,10 @@ sidebarTitle: 'Proxy - PATCH requests'
 openapi: 'PATCH /proxy/{anyPath}'
 ---
 
+<Info>
+  Requires an API key with the `environment:proxy` scope. [Learn more about API key scopes](/reference/api-keys#scopes).
+</Info>
+
 ### API request
 
 The path, query params, and headers you send to the Proxy are all passed on to the external API, except for the configuration headers mentioned here:

--- a/docs/reference/api/proxy/post.mdx
+++ b/docs/reference/api/proxy/post.mdx
@@ -4,6 +4,10 @@ sidebarTitle: 'Proxy - POST requests'
 openapi: 'POST /proxy/{anyPath}'
 ---
 
+<Info>
+  Requires an API key with the `environment:proxy` scope. [Learn more about API key scopes](/reference/api-keys#scopes).
+</Info>
+
 ### API request
 
 The path, query params, and headers you send to the Proxy are all passed on to the external API, except for the configuration headers mentioned here:

--- a/docs/reference/api/proxy/put.mdx
+++ b/docs/reference/api/proxy/put.mdx
@@ -4,6 +4,10 @@ sidebarTitle: 'Proxy - PUT requests'
 openapi: 'PUT /proxy/{anyPath}'
 ---
 
+<Info>
+  Requires an API key with the `environment:proxy` scope. [Learn more about API key scopes](/reference/api-keys#scopes).
+</Info>
+
 ### API request
 
 The path, query params, and headers you send to the Proxy are all passed on to the external API, except for the configuration headers mentioned here:

--- a/docs/reference/api/scripts/config.mdx
+++ b/docs/reference/api/scripts/config.mdx
@@ -3,6 +3,10 @@ title: 'Get integration functions config'
 openapi: 'GET /scripts/config'
 ---
 
+<Info>
+  Requires an API key with the `environment:config:read` scope. [Learn more about API key scopes](/reference/api-keys#scopes).
+</Info>
+
 The `/scripts/config` endpoint returns the configuration for all integration functions. There are two variants of this endpoint:
 
 1. `/scripts/config?format=nango` - Returns the standard configuration format

--- a/docs/reference/api/sync/create-variant.mdx
+++ b/docs/reference/api/sync/create-variant.mdx
@@ -4,6 +4,10 @@ sidebarTitle: 'Create variant'
 openapi: 'POST /sync/{name}/variant/{variant}'
 ---
 
+<Info>
+  Requires an API key with the `environment:syncs:manage` scope. [Learn more about API key scopes](/reference/api-keys#scopes).
+</Info>
+
 ## Creating a sync variant
 
 Sync variants allow you to create different configurations of the same sync for a specific connection. This is useful when you need to sync the same data with different settings or filters.

--- a/docs/reference/api/sync/delete-variant.mdx
+++ b/docs/reference/api/sync/delete-variant.mdx
@@ -3,3 +3,7 @@ title: 'Delete sync variant'
 sidebarTitle: 'Delete variant'
 openapi: 'DELETE /sync/{name}/variant/{variant}'
 ---
+
+<Info>
+  Requires an API key with the `environment:syncs:manage` scope. [Learn more about API key scopes](/reference/api-keys#scopes).
+</Info>

--- a/docs/reference/api/sync/environment-variables.mdx
+++ b/docs/reference/api/sync/environment-variables.mdx
@@ -3,3 +3,6 @@ title: 'Get Environment Variables'
 openapi: 'GET /environment-variables'
 ---
 
+<Info>
+  Requires an API key with the `environment:config:read` scope. [Learn more about API key scopes](/reference/api-keys#scopes).
+</Info>

--- a/docs/reference/api/sync/pause.mdx
+++ b/docs/reference/api/sync/pause.mdx
@@ -2,3 +2,7 @@
 title: 'Pause sync(s)'
 openapi: 'POST /sync/pause'
 ---
+
+<Info>
+  Requires an API key with the `environment:syncs:execute` scope. [Learn more about API key scopes](/reference/api-keys#scopes).
+</Info>

--- a/docs/reference/api/sync/prune-records.mdx
+++ b/docs/reference/api/sync/prune-records.mdx
@@ -4,6 +4,10 @@ sidebarTitle: 'Prune records'
 openapi: 'PATCH /records/prune'
 ---
 
+<Info>
+  Requires an API key with the `environment:records:write` scope. [Learn more about API key scopes](/reference/api-keys#scopes).
+</Info>
+
 Prunes synced records for a given connection and model using cursor-based pagination.
 
 ## What is pruning?

--- a/docs/reference/api/sync/records-list.mdx
+++ b/docs/reference/api/sync/records-list.mdx
@@ -4,6 +4,10 @@ sidebarTitle: 'Get records'
 openapi: 'GET /records'
 ---
 
+<Info>
+  Requires an API key with the `environment:records:read` scope. [Learn more about API key scopes](/reference/api-keys#scopes).
+</Info>
+
 ## Receive webhooks on data updates
 
 Receive webhooks from Nango when new records are available. Follow our [implement a sync guide](/implementation-guides/use-cases/syncs/implement-a-sync).

--- a/docs/reference/api/sync/start.mdx
+++ b/docs/reference/api/sync/start.mdx
@@ -2,3 +2,7 @@
 title: 'Start sync(s)'
 openapi: 'POST /sync/start'
 ---
+
+<Info>
+  Requires an API key with the `environment:syncs:execute` scope. [Learn more about API key scopes](/reference/api-keys#scopes).
+</Info>

--- a/docs/reference/api/sync/status.mdx
+++ b/docs/reference/api/sync/status.mdx
@@ -3,5 +3,9 @@ title: 'Sync status'
 openapi: 'GET /sync/status'
 ---
 
+<Info>
+  Requires an API key with the `environment:syncs:read` scope. [Learn more about API key scopes](/reference/api-keys#scopes).
+</Info>
+
 The response includes the current `checkpoint` for each sync, which tracks how far the sync has progressed. Learn more about [checkpoints](/implementation-guides/use-cases/syncs/checkpoints).
 

--- a/docs/reference/api/sync/trigger.mdx
+++ b/docs/reference/api/sync/trigger.mdx
@@ -2,6 +2,11 @@
 title: 'Trigger sync(s)'
 openapi: 'POST /sync/trigger'
 ---
+
+<Info>
+  Requires an API key with the `environment:syncs:execute` scope. [Learn more about API key scopes](/reference/api-keys#scopes).
+</Info>
+
 ## Triggering one-off syncs
 
 This is especially useful if you e.g. changed the metadata for the connection and now want to re-import data.

--- a/docs/reference/api/sync/update-connection-frequency.mdx
+++ b/docs/reference/api/sync/update-connection-frequency.mdx
@@ -2,3 +2,7 @@
 title: 'Override sync connection frequency'
 openapi: 'PUT /sync/update-connection-frequency'
 ---
+
+<Info>
+  Requires an API key with the `environment:syncs:manage` scope. [Learn more about API key scopes](/reference/api-keys#scopes).
+</Info>

--- a/docs/reference/cli.mdx
+++ b/docs/reference/cli.mdx
@@ -36,7 +36,7 @@ NANGO_SECRET_KEY_PROD='<prod-secret-key>'
 NANGO_SECRET_KEY_DEV='<dev-secret-key>'
 ```
 
-Get your `prod` and `dev` secret keys from the [Environment Settings tab](https://app.nango.dev/environment-settings) (toggle between the `prod` and `dev` environment in the left nav bar).
+Get your `prod` and `dev` secret keys from [Environment Settings > API Keys](https://app.nango.dev/environment-settings#api-keys) (toggle between the `prod` and `dev` environment in the left nav bar).
 
 <Info>
 For self-hosting, set the `NANGO_HOSTPORT` env variable to `http://localhost:3003` (for local development) or your instance's URL.
@@ -119,7 +119,7 @@ Environment variables:
 ```bash
 # Recommendation: in a ".env" file in ./nango-integrations.
 
-# Authenticates the CLI (get the keys in the dashboard's Environment Settings).
+# Authenticates the CLI (get the keys in the dashboard's Environment Settings > API Keys).
 NANGO_SECRET_KEY_DEV=xxxx-xxx-xxxx
 NANGO_SECRET_KEY_PROD=xxxx-xxx-xxxx
 

--- a/packages/database/lib/migrations/20260420120000_create_customer_keys.cjs
+++ b/packages/database/lib/migrations/20260420120000_create_customer_keys.cjs
@@ -1,0 +1,70 @@
+exports.config = { transaction: false };
+
+/**
+ * @param {import('knex').Knex} knex
+ */
+exports.up = async function (knex) {
+    await knex.raw(`
+        CREATE TABLE IF NOT EXISTS customer_keys (
+            id              SERIAL PRIMARY KEY,
+            account_id      INTEGER NOT NULL REFERENCES _nango_accounts(id) ON DELETE CASCADE,
+            key_type        VARCHAR(50) NOT NULL
+                            CONSTRAINT check_customer_keys_key_type CHECK (key_type IN ('api', 'webhook_signing')),
+            display_name    VARCHAR(255) NOT NULL,
+            scopes          TEXT[],
+            secret          VARCHAR(255) NOT NULL,
+            iv              VARCHAR(255) NOT NULL DEFAULT '',
+            tag             VARCHAR(255) NOT NULL DEFAULT '',
+            hashed          VARCHAR(255) NOT NULL,
+            last_used_at    TIMESTAMPTZ,
+            created_at      TIMESTAMPTZ NOT NULL DEFAULT CURRENT_TIMESTAMP,
+            updated_at      TIMESTAMPTZ NOT NULL DEFAULT CURRENT_TIMESTAMP,
+            deleted_at      TIMESTAMPTZ
+        );
+
+        -- Auth lookup by hash — unique per key_type to prevent ambiguous key resolution
+        CREATE UNIQUE INDEX IF NOT EXISTS idx_customer_keys_hashed_key_type
+            ON customer_keys (hashed, key_type);
+
+        -- Narrows key listing to account + type (avoids full table scan on future account-level queries)
+        CREATE INDEX IF NOT EXISTS idx_customer_keys_account_key_type
+            ON customer_keys (account_id, key_type);
+
+        CREATE TABLE IF NOT EXISTS customer_keys_relations (
+            customer_key_id INTEGER NOT NULL REFERENCES customer_keys(id) ON DELETE CASCADE,
+            entity_type     VARCHAR(50) NOT NULL
+                            CONSTRAINT check_customer_keys_relations_entity_type CHECK (entity_type IN ('environment', 'account')),
+            entity_id       INTEGER NOT NULL,
+            UNIQUE (customer_key_id, entity_type, entity_id)
+        );
+
+        -- Supports reverse lookups (entity → keys) used by the cleanup trigger on environment delete
+        CREATE INDEX IF NOT EXISTS idx_customer_keys_relations_entity
+            ON customer_keys_relations (entity_type, entity_id);
+
+        CREATE OR REPLACE FUNCTION cleanup_customer_key_relations()
+        RETURNS TRIGGER AS $$
+        BEGIN
+            DELETE FROM customer_keys
+            WHERE id IN (
+                SELECT customer_key_id FROM customer_keys_relations
+                WHERE entity_type = TG_ARGV[0] AND entity_id = OLD.id
+            );
+            RETURN OLD;
+        END;
+        $$ LANGUAGE plpgsql;
+
+        DO $$
+        BEGIN
+            IF NOT EXISTS (
+                SELECT 1 FROM pg_trigger WHERE tgname = 'trg_env_delete_customer_key_relations'
+            ) THEN
+                CREATE TRIGGER trg_env_delete_customer_key_relations
+                    BEFORE DELETE ON _nango_environments
+                    FOR EACH ROW EXECUTE FUNCTION cleanup_customer_key_relations('environment');
+            END IF;
+        END $$;
+    `);
+};
+
+exports.down = function () {};

--- a/packages/database/lib/migrations/20260420120001_backfill_customer_keys.cjs
+++ b/packages/database/lib/migrations/20260420120001_backfill_customer_keys.cjs
@@ -1,0 +1,79 @@
+exports.config = { transaction: false };
+
+/**
+ * @param {import('knex').Knex} knex
+ */
+exports.up = async function (knex) {
+    // ON CONFLICT DO NOTHING: environments created between Step 2 (dual-read code deployed)
+    // and this migration already have keys in customer_keys via createEnvironment.
+    // The backfill skips those to avoid unique constraint violations.
+    await knex.raw(`
+        BEGIN;
+
+        INSERT INTO customer_keys (account_id, key_type, display_name, scopes, secret, iv, tag, hashed, created_at, updated_at)
+            SELECT
+                e.account_id,
+                'api'                            AS key_type,
+                'Default - Full access'          AS display_name,
+                '{environment:*}'::text[]        AS scopes,
+                s.secret,
+                s.iv,
+                s.tag,
+                s.hashed,
+                s.created_at,
+                s.updated_at
+            FROM api_secrets s
+            JOIN _nango_environments e ON e.id = s.environment_id
+            WHERE s.is_default = true
+        ON CONFLICT DO NOTHING;
+
+        INSERT INTO customer_keys_relations (customer_key_id, entity_type, entity_id)
+            SELECT
+                ck.id                AS customer_key_id,
+                'environment'        AS entity_type,
+                s.environment_id     AS entity_id
+            FROM api_secrets s
+            JOIN _nango_environments e ON e.id = s.environment_id
+            JOIN customer_keys ck
+                ON  ck.hashed = s.hashed
+                AND ck.account_id = e.account_id
+                AND ck.key_type = 'api'
+            WHERE s.is_default = true
+        ON CONFLICT DO NOTHING;
+
+        INSERT INTO customer_keys (account_id, key_type, display_name, scopes, secret, iv, tag, hashed, created_at, updated_at)
+            SELECT
+                e.account_id,
+                'webhook_signing'                AS key_type,
+                'Webhook signing'                AS display_name,
+                NULL                             AS scopes,
+                s.secret,
+                s.iv,
+                s.tag,
+                s.hashed,
+                s.created_at,
+                s.updated_at
+            FROM api_secrets s
+            JOIN _nango_environments e ON e.id = s.environment_id
+            WHERE s.is_default = true
+        ON CONFLICT DO NOTHING;
+
+        INSERT INTO customer_keys_relations (customer_key_id, entity_type, entity_id)
+            SELECT
+                ck.id                AS customer_key_id,
+                'environment'        AS entity_type,
+                s.environment_id     AS entity_id
+            FROM api_secrets s
+            JOIN _nango_environments e ON e.id = s.environment_id
+            JOIN customer_keys ck
+                ON  ck.hashed = s.hashed
+                AND ck.account_id = e.account_id
+                AND ck.key_type = 'webhook_signing'
+            WHERE s.is_default = true
+        ON CONFLICT DO NOTHING;
+
+        COMMIT;
+    `);
+};
+
+exports.down = function () {};

--- a/packages/jobs/lib/execution/action.ts
+++ b/packages/jobs/lib/execution/action.ts
@@ -126,7 +126,7 @@ export async function startAction(task: TaskAction): Promise<Result<void>> {
             sdkLogger = await environmentService.getSdkLogger(environment.id);
         }
 
-        const defaultSecret = await secretService.getDefaultSecretForEnv(db.readOnly, environment.id);
+        const defaultSecret = await secretService.getInternalSecretForEnv(db.readOnly, environment.id);
         if (defaultSecret.isErr()) {
             return Err(defaultSecret.error);
         }

--- a/packages/jobs/lib/execution/onEvent.ts
+++ b/packages/jobs/lib/execution/onEvent.ts
@@ -101,7 +101,7 @@ export async function startOnEvent(task: TaskOnEvent): Promise<Result<void>> {
             updated_at: new Date()
         };
 
-        const defaultSecret = await secretService.getDefaultSecretForEnv(db.readOnly, environment.id);
+        const defaultSecret = await secretService.getInternalSecretForEnv(db.readOnly, environment.id);
         if (defaultSecret.isErr()) {
             return Err(defaultSecret.error);
         }

--- a/packages/jobs/lib/execution/sync.ts
+++ b/packages/jobs/lib/execution/sync.ts
@@ -168,7 +168,7 @@ export async function startSync(task: TaskSync, startScriptFn = startScript): Pr
             sdkLogger = await environmentService.getSdkLogger(environment.id);
         }
 
-        const defaultSecret = await secretService.getDefaultSecretForEnv(db.readOnly, environment.id);
+        const defaultSecret = await secretService.getInternalSecretForEnv(db.readOnly, environment.id);
         if (defaultSecret.isErr()) {
             throw defaultSecret.error;
         }
@@ -926,7 +926,7 @@ async function onFailure({
         if (team && environment && syncConfig && providerConfig) {
             void tracer.scope().activate(span, async () => {
                 try {
-                    const defaultSecret = await secretService.getDefaultSecretForEnv(db.readOnly, environment.id);
+                    const defaultSecret = await secretService.getInternalSecretForEnv(db.readOnly, environment.id);
                     if (defaultSecret.isErr()) {
                         throw defaultSecret.error;
                     }

--- a/packages/jobs/lib/execution/webhook.ts
+++ b/packages/jobs/lib/execution/webhook.ts
@@ -137,7 +137,7 @@ export async function startWebhook(task: TaskWebhook): Promise<Result<void>> {
             sdkLogger = await environmentService.getSdkLogger(environment.id);
         }
 
-        const defaultSecret = await secretService.getDefaultSecretForEnv(db.readOnly, environment.id);
+        const defaultSecret = await secretService.getInternalSecretForEnv(db.readOnly, environment.id);
         if (defaultSecret.isErr()) {
             return Err(defaultSecret.error);
         }
@@ -278,7 +278,7 @@ export async function handleWebhookSuccess({
     const environment = accountAndEnv.environment;
 
     if (environment) {
-        const defaultSecret = await secretService.getDefaultSecretForEnv(db.readOnly, environment.id);
+        const defaultSecret = await secretService.getInternalSecretForEnv(db.readOnly, environment.id);
         if (defaultSecret.isErr()) {
             throw defaultSecret.error;
         }
@@ -474,7 +474,7 @@ async function onFailure({
             if (team && environment && syncConfig && providerConfig) {
                 void tracer.scope().activate(span, async () => {
                     try {
-                        const defaultSecret = await secretService.getDefaultSecretForEnv(db.readOnly, environment.id);
+                        const defaultSecret = await secretService.getInternalSecretForEnv(db.readOnly, environment.id);
                         if (defaultSecret.isErr()) {
                             throw defaultSecret.error;
                         }

--- a/packages/persist/lib/middleware/auth.middleware.ts
+++ b/packages/persist/lib/middleware/auth.middleware.ts
@@ -34,7 +34,7 @@ export const authMiddleware = async (req: Request, res: Response<any, AuthLocals
 
     try {
         const accountContext = await tracer.trace('persist.middleware.auth.getAccountAndEnvironmentBySecretKey', async () => {
-            return await accountService.getAccountContextBySecretKey(secret);
+            return await accountService.getAccountContextByInternalSecretKey(secret);
         });
         if (!accountContext) {
             res.status(401).json({ error: { code: 'unauthorized', message: `Unauthorized: Account not found` } });

--- a/packages/persist/lib/server.integration.test.ts
+++ b/packages/persist/lib/server.integration.test.ts
@@ -50,7 +50,7 @@ describe('Persist API', () => {
         seed = await initDb();
         server.listen(port);
 
-        vi.spyOn(accountService, 'getAccountContextBySecretKey').mockImplementation((secretKey) => {
+        vi.spyOn(accountService, 'getAccountContextByInternalSecretKey').mockImplementation((secretKey) => {
             if (secretKey === mockSecretKey) {
                 return Promise.resolve({
                     account: seed.account,
@@ -616,7 +616,7 @@ const initDb = async () => {
     const now = new Date();
     const env = await environmentService.createEnvironment(db.knex, { accountId: 0, name: 'testEnv' });
     if (!env) throw new Error('Environment not created');
-    const secret = (await secretService.getDefaultSecretForEnv(db.knex, env.id)).unwrap();
+    const secret = (await secretService.getInternalSecretForEnv(db.knex, env.id)).unwrap();
 
     const plan = (await createPlan(db.knex, { account_id: 0, name: 'free' })).unwrap();
 
@@ -710,6 +710,11 @@ const initDb = async () => {
 
 const clearDb = async () => {
     await db.knex.raw(`DROP SCHEMA nango CASCADE`);
+    await db.knex.raw(`CREATE SCHEMA nango`);
+    // The keystore migration tracker is in the 'migrations' schema and survives the drop.
+    // Clear it so migrateKeystore re-runs and recreates private_keys in the new nango schema.
+    await db.knex.raw(`DELETE FROM migrations.migrations_keystore_lock`).catch(() => {});
+    await db.knex.raw(`DELETE FROM migrations.migrations_keystore`).catch(() => {});
 };
 
 const insertRecords = async (seed: testSeed, model: string, toInsert: UnencryptedRecordData[]) => {

--- a/packages/server/lib/authz/resolve.ts
+++ b/packages/server/lib/authz/resolve.ts
@@ -16,6 +16,14 @@ export async function resolve(locals: { user?: { role: Role } }, permission: Per
     return evaluator.evaluate(user.role, permission);
 }
 
+/**
+ * Check if the current user can read production secrets for the given environment.
+ * Non-production environments always allow reading secrets.
+ */
+export async function canReadProdSecret(locals: { user?: { role: Role } }, environment: { is_production: boolean }): Promise<boolean> {
+    return !environment.is_production || (await resolve(locals, permissions.canReadProdSecretKey));
+}
+
 export async function buildPermissions(role: Role): Promise<AllowedPermissions> {
     const result: AllowedPermissions = {};
     for (const perm of Object.values(permissions)) {

--- a/packages/server/lib/controllers/config.controller.ts
+++ b/packages/server/lib/controllers/config.controller.ts
@@ -11,6 +11,8 @@ import {
 } from '@nangohq/shared';
 import { report } from '@nangohq/utils';
 
+import { hasScope } from '../middleware/scope.middleware.js';
+
 import type { RequestLocals } from '../utils/express.js';
 import type { Integration as ProviderIntegration, IntegrationWithCreds } from '@nangohq/shared';
 import type { NextFunction, Request, Response } from 'express';
@@ -105,6 +107,10 @@ class ConfigController {
             }
 
             let configRes: ProviderIntegration | IntegrationWithCreds;
+            if (includeCreds && !hasScope({ grantedScopes: res.locals['apiKeyScopes'], requiredScope: 'environment:integrations:read_credentials' })) {
+                res.status(403).json({ error: { code: 'forbidden', message: 'Insufficient scope. Required: environment:integrations:read_credentials' } });
+                return;
+            }
             if (includeCreds) {
                 const connections = await connectionService.getConnectionsByEnvironmentAndConfig(environmentId, providerConfigKey);
                 const connection_count = connections.length;

--- a/packages/server/lib/controllers/connection/connectionId/getConnection.ts
+++ b/packages/server/lib/controllers/connection/connectionId/getConnection.ts
@@ -7,6 +7,7 @@ import { Err, Ok, metrics, zodErrorToHTTP } from '@nangohq/utils';
 import { connectionFullToPublicApi } from '../../../formatters/connection.js';
 import { connectionIdSchema, providerConfigKeySchema } from '../../../helpers/validation.js';
 import { connectionRefreshFailed as connectionRefreshFailedHook, connectionRefreshSuccess as connectionRefreshSuccessHook } from '../../../hooks/hooks.js';
+import { hasScope } from '../../../middleware/scope.middleware.js';
 import { asyncWrapper } from '../../../utils/asyncWrapper.js';
 
 import type { AllAuthCredentials, ApiPublicConnectionFull, GetPublicConnection, Result } from '@nangohq/types';
@@ -70,7 +71,7 @@ export const getPublicConnection = asyncWrapper<GetPublicConnection>(async (req,
         return;
     }
 
-    const getApiPublicConnection = async (credentials: AllAuthCredentials = {}): Promise<Result<ApiPublicConnectionFull>> => {
+    const getApiPublicConnection = async (credentials: AllAuthCredentials = {}, includeCredentials = true): Promise<Result<ApiPublicConnectionFull>> => {
         // We are using listConnections because it has everything we need, but this is a bit wrong
         const finalConnections = await connectionService.listConnections({ environmentId: environment.id, connectionId, integrationIds: [providerConfigKey] });
         if (finalConnections.length !== 1 || !finalConnections[0]) {
@@ -85,7 +86,8 @@ export const getPublicConnection = asyncWrapper<GetPublicConnection>(async (req,
                 },
                 activeLog: finalConnections[0].active_logs,
                 endUser: finalConnections[0].end_user,
-                provider: finalConnections[0].provider
+                provider: finalConnections[0].provider,
+                includeCredentials
             })
         );
     };
@@ -132,7 +134,11 @@ export const getPublicConnection = asyncWrapper<GetPublicConnection>(async (req,
         }
     }
 
-    const response = await getApiPublicConnection(connection.credentials);
+    const includeCredentials = hasScope({
+        grantedScopes: res.locals['apiKeyScopes'] as string[] | undefined,
+        requiredScope: 'environment:connections:read_credentials'
+    });
+    const response = await getApiPublicConnection(connection.credentials, includeCredentials);
     if (response.isErr()) {
         res.status(500).send({ error: { code: 'server_error', message: response.error.message } });
         return;

--- a/packages/server/lib/controllers/connection/postConnection.ts
+++ b/packages/server/lib/controllers/connection/postConnection.ts
@@ -461,6 +461,12 @@ export const postPublicConnection = asyncWrapper<PostPublicConnection>(async (re
     await logCtx.success();
 
     res.status(201).send(
-        connectionFullToPublicApi({ data: connection, provider: providerName, activeLog: [], endUser: endUser ? EndUserMapper.to(endUser) : null })
+        connectionFullToPublicApi({
+            data: connection,
+            provider: providerName,
+            activeLog: [],
+            endUser: endUser ? EndUserMapper.to(endUser) : null,
+            includeCredentials: true
+        })
     );
 });

--- a/packages/server/lib/controllers/functions/deploy/postDeploy.ts
+++ b/packages/server/lib/controllers/functions/deploy/postDeploy.ts
@@ -49,7 +49,7 @@ export const postRemoteFunctionDeploy = asyncWrapper<PostRemoteFunctionDeploy>(a
         return;
     }
 
-    const defaultSecret = await secretService.getDefaultSecretForEnv(db.readOnly, environment.id);
+    const defaultSecret = await secretService.getInternalSecretForEnv(db.readOnly, environment.id);
     if (defaultSecret.isErr()) {
         sendStepError({ res, status: 500, error: defaultSecret.error });
         return;

--- a/packages/server/lib/controllers/functions/dryrun/postDryrun.ts
+++ b/packages/server/lib/controllers/functions/dryrun/postDryrun.ts
@@ -37,7 +37,7 @@ export const postRemoteFunctionDryrun = asyncWrapper<PostRemoteFunctionDryrun>(a
         return;
     }
 
-    const defaultSecret = await secretService.getDefaultSecretForEnv(db.readOnly, environment.id);
+    const defaultSecret = await secretService.getInternalSecretForEnv(db.readOnly, environment.id);
     if (defaultSecret.isErr()) {
         sendStepError({ res, status: 500, error: defaultSecret.error });
         return;

--- a/packages/server/lib/controllers/integrations/uniqueKey/getIntegration.ts
+++ b/packages/server/lib/controllers/integrations/uniqueKey/getIntegration.ts
@@ -5,6 +5,7 @@ import { zodErrorToHTTP } from '@nangohq/utils';
 
 import { integrationToPublicApi } from '../../../formatters/integration.js';
 import { providerConfigKeySchema } from '../../../helpers/validation.js';
+import { hasScope } from '../../../middleware/scope.middleware.js';
 import { asyncWrapper } from '../../../utils/asyncWrapper.js';
 
 import type { ApiPublicIntegrationInclude, GetPublicIntegration } from '@nangohq/types';
@@ -65,7 +66,10 @@ export const getPublicIntegration = asyncWrapper<GetPublicIntegration>(async (re
     if (queryInclude.has('webhook')) {
         include.webhook_url = provider.webhook_routing_script ? `${getGlobalWebhookReceiveUrl()}/${environment.uuid}/${integration.provider}` : null;
     }
-    if (queryInclude.has('credentials')) {
+    if (
+        queryInclude.has('credentials') &&
+        hasScope({ grantedScopes: res.locals['apiKeyScopes'] as string[] | undefined, requiredScope: 'environment:integrations:read_credentials' })
+    ) {
         if (provider.auth_mode === 'OAUTH1' || provider.auth_mode === 'OAUTH2' || provider.auth_mode === 'TBA') {
             include.credentials = {
                 type: provider.auth_mode,

--- a/packages/server/lib/controllers/v1/environment/apiKeys.integration.test.ts
+++ b/packages/server/lib/controllers/v1/environment/apiKeys.integration.test.ts
@@ -1,0 +1,571 @@
+import { afterAll, beforeAll, describe, expect, it } from 'vitest';
+
+import db from '@nangohq/database';
+import { seeders } from '@nangohq/shared';
+
+import { authenticateUser, isSuccess, runServer, shouldBeProtected } from '../../../utils/tests.js';
+
+let api: Awaited<ReturnType<typeof runServer>>;
+
+describe('API Keys endpoints', () => {
+    beforeAll(async () => {
+        api = await runServer();
+    });
+
+    afterAll(() => {
+        api.server.close();
+    });
+
+    describe('GET /api/v1/environment/api-keys', () => {
+        it('should be protected', async () => {
+            // @ts-expect-error query params are required
+            const res = await api.fetch('/api/v1/environment/api-keys', { method: 'GET', query: { env: 'dev' } });
+            shouldBeProtected(res);
+        });
+
+        it('should list api keys for environment', async () => {
+            const { env, user } = await seeders.seedAccountEnvAndUser();
+            const session = await authenticateUser(api, user);
+
+            const res = await api.fetch('/api/v1/environment/api-keys', {
+                method: 'GET',
+                // @ts-expect-error query params are required
+                query: { env: env.name },
+                session
+            });
+
+            expect(res.res.status).toBe(200);
+            isSuccess(res.json);
+            expect(res.json.data).toBeInstanceOf(Array);
+            expect(res.json.data.length).toBeGreaterThanOrEqual(1);
+            expect(res.json.data[0]).toMatchObject({
+                id: expect.any(Number),
+                display_name: expect.any(String),
+                scopes: expect.any(Array),
+                secret: expect.any(String),
+                created_at: expect.any(String)
+            });
+        });
+    });
+
+    describe('POST /api/v1/environment/api-keys', () => {
+        it('should create an api key with scopes', async () => {
+            const { env, user } = await seeders.seedAccountEnvAndUser();
+            const session = await authenticateUser(api, user);
+
+            const res = await api.fetch('/api/v1/environment/api-keys', {
+                method: 'POST',
+                // @ts-expect-error query params are required
+                query: { env: env.name },
+                body: { display_name: 'CI Deploy Key', scopes: ['environment:deploy'] },
+                session
+            });
+
+            expect(res.res.status).toBe(200);
+            isSuccess(res.json);
+            expect(res.json.data).toMatchObject({
+                id: expect.any(Number),
+                display_name: 'CI Deploy Key',
+                scopes: ['environment:deploy'],
+                secret: expect.any(String),
+                created_at: expect.any(String)
+            });
+        });
+
+        it('should default to environment:* scopes', async () => {
+            const { env, user } = await seeders.seedAccountEnvAndUser();
+            const session = await authenticateUser(api, user);
+
+            const res = await api.fetch('/api/v1/environment/api-keys', {
+                method: 'POST',
+                // @ts-expect-error query params are required
+                query: { env: env.name },
+                body: { display_name: 'Full access key' },
+                session
+            });
+
+            expect(res.res.status).toBe(200);
+            isSuccess(res.json);
+            expect(res.json.data.scopes).toEqual(['environment:*']);
+        });
+
+        it('should enforce max keys per environment limit', async () => {
+            const { env, user, account } = await seeders.seedAccountEnvAndUser();
+            const session = await authenticateUser(api, user);
+
+            // Insert keys directly to approach the limit without 50 HTTP calls
+            // The env already has 1 default key from seeding, so insert 49 more
+            for (let i = 0; i < 49; i++) {
+                const hashed = `fake-hash-${env.id}-${i}`;
+                const [key] = await db
+                    .knex('customer_keys')
+                    .insert({
+                        account_id: account.id,
+                        key_type: 'api',
+                        display_name: `bulk-key-${i}`,
+                        scopes: ['environment:*'],
+                        secret: `fake-secret-${i}`,
+                        iv: '',
+                        tag: '',
+                        hashed
+                    })
+                    .returning('id');
+                await db.knex('customer_keys_relations').insert({
+                    customer_key_id: key!.id,
+                    entity_type: 'environment',
+                    entity_id: env.id
+                });
+            }
+
+            // Now at 50 keys — next create should fail
+            const res = await api.fetch('/api/v1/environment/api-keys', {
+                method: 'POST',
+                // @ts-expect-error query params are required
+                query: { env: env.name },
+                body: { display_name: 'One too many' },
+                session
+            });
+
+            expect(res.res.status).toBe(400);
+            expect((res.json as any).error.code).toBe('resource_capped');
+        });
+    });
+
+    describe('PATCH /api/v1/environment/api-keys/:keyId', () => {
+        it('should update scopes', async () => {
+            const { env, user } = await seeders.seedAccountEnvAndUser();
+            const session = await authenticateUser(api, user);
+
+            // Create a key first
+            const createRes = await api.fetch('/api/v1/environment/api-keys', {
+                method: 'POST',
+                // @ts-expect-error query params are required
+                query: { env: env.name },
+                body: { display_name: 'To update', scopes: ['environment:deploy'] },
+                session
+            });
+            isSuccess(createRes.json);
+            const keyId = createRes.json.data.id;
+
+            // Update scopes
+            const patchRes = await api.fetch(
+                `/api/v1/environment/api-keys/${keyId}` as any,
+                {
+                    method: 'PATCH',
+                    query: { env: env.name },
+                    body: { scopes: ['environment:connections:read', 'environment:records:read'] } as any,
+                    session
+                } as any
+            );
+
+            expect(patchRes.res.status).toBe(200);
+            expect(patchRes.json).toEqual({ success: true });
+
+            // Verify scopes were updated
+            const listRes = await api.fetch('/api/v1/environment/api-keys', {
+                method: 'GET',
+                // @ts-expect-error query params are required
+                query: { env: env.name },
+                session
+            });
+            isSuccess(listRes.json);
+            const updated = listRes.json.data.find((k: any) => k.id === keyId);
+            expect(updated!.scopes).toEqual(['environment:connections:read', 'environment:records:read']);
+        });
+
+        it('should return not_found when patching a key from another environment', async () => {
+            const { env: envA, user } = await seeders.seedAccountEnvAndUser();
+            const envB = await seeders.createEnvironmentSeed(envA.account_id, 'other-env');
+            const session = await authenticateUser(api, user);
+
+            const createRes = await api.fetch('/api/v1/environment/api-keys', {
+                method: 'POST',
+                // @ts-expect-error query params are required
+                query: { env: envA.name },
+                body: { display_name: 'Foreign key', scopes: ['environment:deploy'] },
+                session
+            });
+            isSuccess(createRes.json);
+            const keyId = createRes.json.data.id;
+
+            const patchRes = await api.fetch(
+                `/api/v1/environment/api-keys/${keyId}` as any,
+                {
+                    method: 'PATCH',
+                    query: { env: envB.name },
+                    body: { scopes: ['environment:connections:read'] } as any,
+                    session
+                } as any
+            );
+
+            expect(patchRes.res.status).toBe(404);
+            expect(patchRes.json.error.code).toBe('not_found');
+        });
+    });
+
+    describe('DELETE /api/v1/environment/api-keys/:keyId', () => {
+        it('should soft-delete an api key', async () => {
+            const { env, user } = await seeders.seedAccountEnvAndUser();
+            const session = await authenticateUser(api, user);
+
+            // Create a key
+            const createRes = await api.fetch('/api/v1/environment/api-keys', {
+                method: 'POST',
+                // @ts-expect-error query params are required
+                query: { env: env.name },
+                body: { display_name: 'To delete' },
+                session
+            });
+            isSuccess(createRes.json);
+            const keyId = createRes.json.data.id;
+
+            // Delete it
+            const deleteRes = await api.fetch(
+                `/api/v1/environment/api-keys/${keyId}` as any,
+                {
+                    method: 'DELETE',
+                    query: { env: env.name },
+                    session
+                } as any
+            );
+
+            expect(deleteRes.res.status).toBe(200);
+            expect(deleteRes.json).toEqual({ success: true });
+
+            // Verify it's gone from the list
+            const listRes = await api.fetch('/api/v1/environment/api-keys', {
+                method: 'GET',
+                // @ts-expect-error query params are required
+                query: { env: env.name },
+                session
+            });
+            isSuccess(listRes.json);
+            const deleted = listRes.json.data.find((k: any) => k.id === keyId);
+            expect(deleted).toBeUndefined();
+        });
+
+        it('should reject auth with deleted key', async () => {
+            const { env, user } = await seeders.seedAccountEnvAndUser();
+            const session = await authenticateUser(api, user);
+
+            // Create and get the secret
+            const createRes = await api.fetch('/api/v1/environment/api-keys', {
+                method: 'POST',
+                // @ts-expect-error query params are required
+                query: { env: env.name },
+                body: { display_name: 'To delete and test auth' },
+                session
+            });
+            isSuccess(createRes.json);
+            const keyId = createRes.json.data.id;
+            const secret = createRes.json.data.secret;
+
+            // Key should authenticate
+            const authRes1 = await api.fetch('/integrations', { method: 'GET', token: secret });
+            expect(authRes1.res.status).toBe(200);
+
+            // Delete the key
+            await api.fetch(
+                `/api/v1/environment/api-keys/${keyId}` as any,
+                {
+                    method: 'DELETE',
+                    query: { env: env.name },
+                    session
+                } as any
+            );
+
+            // Key should no longer authenticate
+            const authRes2 = await api.fetch('/integrations', { method: 'GET', token: secret });
+            expect(authRes2.res.status).toBe(401);
+        });
+
+        it('should return not_found when deleting a key from another environment', async () => {
+            const { env: envA, user } = await seeders.seedAccountEnvAndUser();
+            const envB = await seeders.createEnvironmentSeed(envA.account_id, 'other-env-delete');
+            const session = await authenticateUser(api, user);
+
+            const createRes = await api.fetch('/api/v1/environment/api-keys', {
+                method: 'POST',
+                // @ts-expect-error query params are required
+                query: { env: envA.name },
+                body: { display_name: 'Foreign delete key' },
+                session
+            });
+            isSuccess(createRes.json);
+            const keyId = createRes.json.data.id;
+
+            const deleteRes = await api.fetch(
+                `/api/v1/environment/api-keys/${keyId}` as any,
+                {
+                    method: 'DELETE',
+                    query: { env: envB.name },
+                    session
+                } as any
+            );
+
+            expect(deleteRes.res.status).toBe(404);
+            expect(deleteRes.json.error.code).toBe('not_found');
+        });
+    });
+
+    describe('scope enforcement', () => {
+        it('should allow access with matching scope', async () => {
+            const { env, user } = await seeders.seedAccountEnvAndUser();
+            const session = await authenticateUser(api, user);
+
+            const createRes = await api.fetch('/api/v1/environment/api-keys', {
+                method: 'POST',
+                // @ts-expect-error query params are required
+                query: { env: env.name },
+                body: { display_name: 'Integrations only', scopes: ['environment:integrations:list'] },
+                session
+            });
+            isSuccess(createRes.json);
+
+            const res = await api.fetch('/integrations', { method: 'GET', token: createRes.json.data.secret });
+            expect(res.res.status).toBe(200);
+        });
+
+        it('should deny access with missing scope', async () => {
+            const { env, user } = await seeders.seedAccountEnvAndUser();
+            const session = await authenticateUser(api, user);
+
+            const createRes = await api.fetch('/api/v1/environment/api-keys', {
+                method: 'POST',
+                // @ts-expect-error query params are required
+                query: { env: env.name },
+                body: { display_name: 'Connections only', scopes: ['environment:connections:read'] },
+                session
+            });
+            isSuccess(createRes.json);
+
+            const res = await api.fetch('/integrations', { method: 'GET', token: createRes.json.data.secret });
+            expect(res.res.status).toBe(403);
+        });
+
+        it('should allow wildcard scope', async () => {
+            const { env, user } = await seeders.seedAccountEnvAndUser();
+            const session = await authenticateUser(api, user);
+
+            const createRes = await api.fetch('/api/v1/environment/api-keys', {
+                method: 'POST',
+                // @ts-expect-error query params are required
+                query: { env: env.name },
+                body: { display_name: 'Full access', scopes: ['environment:*'] },
+                session
+            });
+            isSuccess(createRes.json);
+
+            const res = await api.fetch('/integrations', { method: 'GET', token: createRes.json.data.secret });
+            expect(res.res.status).toBe(200);
+        });
+
+        it('should allow legacy api_secrets key with environment:* scope semantics', async () => {
+            const { secret } = await seeders.seedAccountEnvAndUser();
+            // Legacy key from api_secrets resolves to explicit environment:* semantics
+            const res = await api.fetch('/integrations', { method: 'GET', token: secret.secret });
+            expect(res.res.status).toBe(200);
+        });
+    });
+
+    describe('RBAC', () => {
+        it('should deny production_support from creating keys on prod', async () => {
+            const { env, user } = await seeders.seedAccountEnvAndUser();
+            await db.knex('_nango_environments').where({ id: env.id }).update({ is_production: true });
+            await db.knex('_nango_users').where({ id: user.id }).update({ role: 'production_support' });
+
+            const session = await authenticateUser(api, user);
+            const res = await api.fetch('/api/v1/environment/api-keys', {
+                method: 'POST',
+                // @ts-expect-error query params are required
+                query: { env: env.name },
+                body: { display_name: 'Should fail' },
+                session
+            });
+
+            expect(res.res.status).toBe(403);
+        });
+
+        it('should allow production_support to list keys on prod but mask secrets', async () => {
+            const { env, user } = await seeders.seedAccountEnvAndUser();
+            await db.knex('_nango_environments').where({ id: env.id }).update({ is_production: true });
+            await db.knex('_nango_users').where({ id: user.id }).update({ role: 'production_support' });
+
+            const session = await authenticateUser(api, user);
+            const res = await api.fetch('/api/v1/environment/api-keys', {
+                method: 'GET',
+                // @ts-expect-error query params are required
+                query: { env: env.name },
+                session
+            });
+
+            expect(res.res.status).toBe(200);
+            isSuccess(res.json);
+            expect(res.json.data.length).toBeGreaterThanOrEqual(1);
+            // Secret should be masked: ****<last4>
+            for (const key of res.json.data) {
+                expect(key.secret).toMatch(/^\*{4}.{4}$/);
+            }
+        });
+
+        it('should deny production_support from updating scopes on prod', async () => {
+            const { env, user } = await seeders.seedAccountEnvAndUser();
+            await db.knex('_nango_environments').where({ id: env.id }).update({ is_production: true });
+
+            // Get the default key id
+            const keys = await db
+                .knex('customer_keys')
+                .select('customer_keys.id')
+                .join('customer_keys_relations', 'customer_keys_relations.customer_key_id', 'customer_keys.id')
+                .where({ 'customer_keys_relations.entity_type': 'environment', 'customer_keys_relations.entity_id': env.id, 'customer_keys.key_type': 'api' })
+                .whereNull('customer_keys.deleted_at');
+            const keyId = keys[0]!.id;
+
+            await db.knex('_nango_users').where({ id: user.id }).update({ role: 'production_support' });
+
+            const session = await authenticateUser(api, user);
+            const res = await api.fetch(
+                `/api/v1/environment/api-keys/${keyId}` as any,
+                {
+                    method: 'PATCH',
+                    query: { env: env.name },
+                    body: { scopes: ['environment:connections:read'] } as any,
+                    session
+                } as any
+            );
+
+            expect(res.res.status).toBe(403);
+        });
+
+        it('should deny production_support from deleting keys on prod', async () => {
+            const { env, user } = await seeders.seedAccountEnvAndUser();
+            await db.knex('_nango_environments').where({ id: env.id }).update({ is_production: true });
+
+            const keys = await db
+                .knex('customer_keys')
+                .select('customer_keys.id')
+                .join('customer_keys_relations', 'customer_keys_relations.customer_key_id', 'customer_keys.id')
+                .where({ 'customer_keys_relations.entity_type': 'environment', 'customer_keys_relations.entity_id': env.id, 'customer_keys.key_type': 'api' })
+                .whereNull('customer_keys.deleted_at');
+            const keyId = keys[0]!.id;
+
+            await db.knex('_nango_users').where({ id: user.id }).update({ role: 'production_support' });
+
+            const session = await authenticateUser(api, user);
+            const res = await api.fetch(
+                `/api/v1/environment/api-keys/${keyId}` as any,
+                {
+                    method: 'DELETE',
+                    query: { env: env.name },
+                    session
+                } as any
+            );
+
+            expect(res.res.status).toBe(403);
+        });
+
+        it('should allow admin full access on prod', async () => {
+            const { env, user } = await seeders.seedAccountEnvAndUser();
+            await db.knex('_nango_environments').where({ id: env.id }).update({ is_production: true });
+            // user is already administrator by default
+
+            const session = await authenticateUser(api, user);
+
+            // Create
+            const createRes = await api.fetch('/api/v1/environment/api-keys', {
+                method: 'POST',
+                // @ts-expect-error query params are required
+                query: { env: env.name },
+                body: { display_name: 'Admin prod key', scopes: ['environment:deploy'] },
+                session
+            });
+            expect(createRes.res.status).toBe(200);
+            isSuccess(createRes.json);
+            const keyId = createRes.json.data.id;
+            // Secret should NOT be masked for admin
+            expect(createRes.json.data.secret).not.toMatch(/^\*{4}/);
+
+            // List — secrets should be visible
+            const listRes = await api.fetch('/api/v1/environment/api-keys', {
+                method: 'GET',
+                // @ts-expect-error query params are required
+                query: { env: env.name },
+                session
+            });
+            expect(listRes.res.status).toBe(200);
+            isSuccess(listRes.json);
+            const adminKey = listRes.json.data.find((k: any) => k.id === keyId);
+            expect(adminKey!.secret).not.toMatch(/^\*{4}/);
+
+            // Update scopes
+            const patchRes = await api.fetch(
+                `/api/v1/environment/api-keys/${keyId}` as any,
+                {
+                    method: 'PATCH',
+                    query: { env: env.name },
+                    body: { scopes: ['environment:connections:read'] } as any,
+                    session
+                } as any
+            );
+            expect(patchRes.res.status).toBe(200);
+
+            // Delete
+            const deleteRes = await api.fetch(
+                `/api/v1/environment/api-keys/${keyId}` as any,
+                {
+                    method: 'DELETE',
+                    query: { env: env.name },
+                    session
+                } as any
+            );
+            expect(deleteRes.res.status).toBe(200);
+        });
+
+        it('should allow all roles full access on non-prod', async () => {
+            const { env, user } = await seeders.seedAccountEnvAndUser();
+            // env is non-prod by default
+            await db.knex('_nango_users').where({ id: user.id }).update({ role: 'production_support' });
+
+            const session = await authenticateUser(api, user);
+
+            // Create — should work on non-prod even for support role
+            const createRes = await api.fetch('/api/v1/environment/api-keys', {
+                method: 'POST',
+                // @ts-expect-error query params are required
+                query: { env: env.name },
+                body: { display_name: 'Support non-prod key' },
+                session
+            });
+            expect(createRes.res.status).toBe(200);
+            isSuccess(createRes.json);
+
+            // Secret should be visible on non-prod
+            expect(createRes.json.data.secret).not.toMatch(/^\*{4}/);
+
+            // List — secrets visible
+            const listRes = await api.fetch('/api/v1/environment/api-keys', {
+                method: 'GET',
+                // @ts-expect-error query params are required
+                query: { env: env.name },
+                session
+            });
+            expect(listRes.res.status).toBe(200);
+            isSuccess(listRes.json);
+            for (const key of listRes.json.data) {
+                expect(key.secret).not.toMatch(/^\*{4}/);
+            }
+
+            // Delete — should work
+            const keyId = createRes.json.data.id;
+            const deleteRes = await api.fetch(
+                `/api/v1/environment/api-keys/${keyId}` as any,
+                {
+                    method: 'DELETE',
+                    query: { env: env.name },
+                    session
+                } as any
+            );
+            expect(deleteRes.res.status).toBe(200);
+        });
+    });
+});

--- a/packages/server/lib/controllers/v1/environment/createApiKey.ts
+++ b/packages/server/lib/controllers/v1/environment/createApiKey.ts
@@ -1,0 +1,63 @@
+import * as z from 'zod';
+
+import db from '@nangohq/database';
+import { customerKeyService } from '@nangohq/shared';
+import { apiKeyScopes, requireEmptyQuery, zodErrorToHTTP } from '@nangohq/utils';
+
+import { asyncWrapper } from '../../../utils/asyncWrapper.js';
+
+import type { ApiKeyScope, CreateApiKey } from '@nangohq/types';
+
+const validationBody = z
+    .object({
+        display_name: z.string().min(1).max(255),
+        scopes: z.array(z.enum(apiKeyScopes)).nonempty('At least one scope is required when scopes are provided').optional()
+    })
+    .strict();
+
+export const createApiKey = asyncWrapper<CreateApiKey>(async (req, res) => {
+    const emptyQuery = requireEmptyQuery(req, { withEnv: true });
+    if (emptyQuery) {
+        res.status(400).send({ error: { code: 'invalid_query_params', errors: zodErrorToHTTP(emptyQuery.error) } });
+        return;
+    }
+
+    const valBody = validationBody.safeParse(req.body);
+    if (!valBody.success) {
+        res.status(400).send({ error: { code: 'invalid_body', errors: zodErrorToHTTP(valBody.error) } });
+        return;
+    }
+
+    const { environment, account } = res.locals;
+    const { display_name: displayName, scopes } = valBody.data;
+
+    const result = await customerKeyService.createApiKey(db.knex, {
+        accountId: account.id,
+        environmentId: environment.id,
+        displayName,
+        scopes: scopes ?? ['environment:*']
+    });
+
+    if (result.isErr()) {
+        const { type: errType = '', message: errMsg = '' } = result.error as { type?: string; message?: string };
+        if (errType === 'duplicate_api_key' || errMsg.includes('duplicate_api_key')) {
+            res.status(409).send({ error: { code: 'conflict', message: 'A key with this name already exists' } });
+        } else if (errType === 'resource_capped' || errMsg.includes('resource_capped')) {
+            res.status(400).send({ error: { code: 'resource_capped', message: 'Maximum number of API keys per environment reached' } });
+        } else {
+            res.status(500).send({ error: { code: 'server_error', message: 'Failed to create API key' } });
+        }
+        return;
+    }
+
+    const key = result.value;
+    res.status(200).send({
+        data: {
+            id: key.id,
+            display_name: key.display_name,
+            scopes: (key.scopes ?? []) as ApiKeyScope[],
+            secret: key.secret,
+            created_at: key.created_at.toISOString()
+        }
+    });
+});

--- a/packages/server/lib/controllers/v1/environment/deleteApiKey.ts
+++ b/packages/server/lib/controllers/v1/environment/deleteApiKey.ts
@@ -1,0 +1,39 @@
+import * as z from 'zod';
+
+import db from '@nangohq/database';
+import { customerKeyService } from '@nangohq/shared';
+import { requireEmptyQuery, zodErrorToHTTP } from '@nangohq/utils';
+
+import { asyncWrapper } from '../../../utils/asyncWrapper.js';
+
+import type { DeleteApiKey } from '@nangohq/types';
+
+const validationParams = z.object({
+    keyId: z.coerce.number().int().positive()
+});
+
+export const deleteApiKey = asyncWrapper<DeleteApiKey>(async (req, res) => {
+    const emptyQuery = requireEmptyQuery(req, { withEnv: true });
+    if (emptyQuery) {
+        res.status(400).send({ error: { code: 'invalid_query_params', errors: zodErrorToHTTP(emptyQuery.error) } });
+        return;
+    }
+
+    const valParams = validationParams.safeParse(req.params);
+    if (!valParams.success) {
+        res.status(400).send({ error: { code: 'invalid_query_params', errors: zodErrorToHTTP(valParams.error) } });
+        return;
+    }
+
+    const { keyId } = valParams.data;
+
+    const { environment } = res.locals;
+
+    const result = await customerKeyService.deleteCustomerKey(db.knex, keyId, environment.id);
+    if (result.isErr()) {
+        res.status(404).send({ error: { code: 'not_found', message: 'API key not found' } });
+        return;
+    }
+
+    res.status(200).send({ success: true });
+});

--- a/packages/server/lib/controllers/v1/environment/deleteEnvironment.integration.test.ts
+++ b/packages/server/lib/controllers/v1/environment/deleteEnvironment.integration.test.ts
@@ -38,7 +38,7 @@ describe(`DELETE ${endpoint}`, () => {
             throw new Error('Failed to create prod environment');
         }
 
-        const prodSecret = (await secretService.getDefaultSecretForEnv(db.knex, prodEnv.id)).unwrap();
+        const prodSecret = (await secretService.getInternalSecretForEnv(db.knex, prodEnv.id)).unwrap();
 
         const res = await api.fetch(endpoint, {
             method: 'DELETE',
@@ -64,7 +64,7 @@ describe(`DELETE ${endpoint}`, () => {
             throw new Error('Failed to create test environment');
         }
 
-        const testSecret = (await secretService.getDefaultSecretForEnv(db.knex, testEnv.id)).unwrap();
+        const testSecret = (await secretService.getInternalSecretForEnv(db.knex, testEnv.id)).unwrap();
 
         const res = await api.fetch(endpoint, {
             method: 'DELETE',
@@ -88,7 +88,7 @@ describe(`DELETE ${endpoint}`, () => {
             throw new Error('Failed to create test environment');
         }
 
-        const testSecret = (await secretService.getDefaultSecretForEnv(db.knex, testEnv.id)).unwrap();
+        const testSecret = (await secretService.getInternalSecretForEnv(db.knex, testEnv.id)).unwrap();
 
         // Create a provider config for this environment
         const providerName = 'github';

--- a/packages/server/lib/controllers/v1/environment/getEnvironment.integration.test.ts
+++ b/packages/server/lib/controllers/v1/environment/getEnvironment.integration.test.ts
@@ -61,6 +61,28 @@ describe(`GET ${route}`, () => {
                 slack_notifications_channel: ''
             }
         });
+        // NAN-5088: webhook signing key should be present
+        expect(res.json.environmentAndAccount.webhook_signing_key).toBeTruthy();
+    });
+
+    it('should redact webhook_signing_key for production_support on prod environment', async () => {
+        const { env, user } = await seeders.seedAccountEnvAndUser();
+        // Make it a production environment
+        await db.knex('_nango_environments').where({ id: env.id }).update({ is_production: true });
+        // Change user role to production_support
+        await db.knex('_nango_users').where({ id: user.id }).update({ role: 'production_support' });
+
+        const session = await authenticateUser(api, user);
+        const res = await api.fetch(route, {
+            method: 'GET',
+            // @ts-expect-error query params are required
+            query: { env: env.name },
+            session
+        });
+
+        expect(res.res.status).toBe(200);
+        isSuccess(res.json);
+        expect(res.json.environmentAndAccount.webhook_signing_key).toBeNull();
     });
 
     describe('slack_notifications_channel', () => {

--- a/packages/server/lib/controllers/v1/environment/getEnvironment.ts
+++ b/packages/server/lib/controllers/v1/environment/getEnvironment.ts
@@ -1,7 +1,8 @@
-import { permissions } from '@nangohq/authz';
+import db from '@nangohq/database';
 import {
     accountService,
     connectionService,
+    customerKeyService,
     environmentService,
     externalWebhookService,
     generateSlackConnectionId,
@@ -10,7 +11,7 @@ import {
 } from '@nangohq/shared';
 import { isCloud, requireEmptyQuery, zodErrorToHTTP } from '@nangohq/utils';
 
-import { resolve } from '../../../authz/resolve.js';
+import { canReadProdSecret } from '../../../authz/resolve.js';
 import { envs } from '../../../env.js';
 import { environmentToApi } from '../../../formatters/environment.js';
 import { planToApi } from '../../../formatters/plan.js';
@@ -42,7 +43,7 @@ export const getEnvironment = asyncWrapper<GetEnvironment>(async (req, res) => {
     }
 
     // Remove secret key if user doesn't have permission to read production secrets
-    if (environment.is_production && !(await resolve(res.locals, permissions.canReadProdSecretKey))) {
+    if (!(await canReadProdSecret(res.locals, environment))) {
         delete (environment as any).secret_key;
         delete (environment as any).pending_secret_key;
     }
@@ -72,6 +73,14 @@ export const getEnvironment = asyncWrapper<GetEnvironment>(async (req, res) => {
 
     const webhookSettings = await externalWebhookService.get(environment.id);
 
+    let webhookSigningKey: string | null = null;
+    if (await canReadProdSecret(res.locals, environment)) {
+        const signingKeyResult = await customerKeyService.getWebhookSigningKeyForEnv(db.knex, environment.id);
+        if (signingKeyResult.isOk()) {
+            webhookSigningKey = signingKeyResult.value.secret;
+        }
+    }
+
     res.status(200).send({
         plan: plan ? planToApi(plan) : null,
         environmentAndAccount: {
@@ -98,7 +107,8 @@ export const getEnvironment = asyncWrapper<GetEnvironment>(async (req, res) => {
             uuid: account.uuid,
             name: account.name,
             email: user.email,
-            slack_notifications_channel
+            slack_notifications_channel,
+            webhook_signing_key: webhookSigningKey
         }
     });
 });

--- a/packages/server/lib/controllers/v1/environment/getEnvironments.integration.test.ts
+++ b/packages/server/lib/controllers/v1/environment/getEnvironments.integration.test.ts
@@ -28,7 +28,7 @@ describe(`GET ${route}`, () => {
         const env = await seeders.createEnvironmentSeed(account.id, 'test');
         await seeders.createEnvironmentSeed(account.id, 'prod');
 
-        const secret = (await secretService.getDefaultSecretForEnv(db.knex, env.id)).unwrap();
+        const secret = (await secretService.getInternalSecretForEnv(db.knex, env.id)).unwrap();
 
         const res = await api.fetch(route, {
             method: 'GET',

--- a/packages/server/lib/controllers/v1/environment/listApiKeys.ts
+++ b/packages/server/lib/controllers/v1/environment/listApiKeys.ts
@@ -1,0 +1,41 @@
+import db from '@nangohq/database';
+import { customerKeyService } from '@nangohq/shared';
+import { requireEmptyQuery, zodErrorToHTTP } from '@nangohq/utils';
+
+import { canReadProdSecret } from '../../../authz/resolve.js';
+import { asyncWrapper } from '../../../utils/asyncWrapper.js';
+
+import type { ApiKeyScope, ListApiKeys } from '@nangohq/types';
+
+export const listApiKeys = asyncWrapper<ListApiKeys>(async (req, res) => {
+    const emptyQuery = requireEmptyQuery(req, { withEnv: true });
+    if (emptyQuery) {
+        res.status(400).send({ error: { code: 'invalid_query_params', errors: zodErrorToHTTP(emptyQuery.error) } });
+        return;
+    }
+
+    const { environment } = res.locals;
+
+    const canReadSecret = await canReadProdSecret(res.locals, environment);
+
+    const keysResult = await customerKeyService.getApiKeysByEnv(db.knex, environment.id);
+    if (keysResult.isErr()) {
+        res.status(500).send({ error: { code: 'server_error', message: 'Failed to retrieve API keys' } });
+        return;
+    }
+
+    const data = keysResult.value.map((key) => {
+        const secret = canReadSecret ? key.secret : `****${key.secret.slice(-4)}`;
+        return {
+            id: key.id,
+            display_name: key.display_name,
+            scopes: (key.scopes ?? []) as ApiKeyScope[],
+            secret,
+            last_used_at: key.last_used_at ? key.last_used_at.toISOString() : null,
+            created_at: key.created_at.toISOString(),
+            updated_at: key.updated_at.toISOString()
+        };
+    });
+
+    res.status(200).send({ data });
+});

--- a/packages/server/lib/controllers/v1/environment/patchApiKey.ts
+++ b/packages/server/lib/controllers/v1/environment/patchApiKey.ts
@@ -1,0 +1,60 @@
+import * as z from 'zod';
+
+import db from '@nangohq/database';
+import { customerKeyService } from '@nangohq/shared';
+import { apiKeyScopes, zodErrorToHTTP } from '@nangohq/utils';
+
+import { asyncWrapper } from '../../../utils/asyncWrapper.js';
+
+import type { PatchApiKey } from '@nangohq/types';
+
+const validationParams = z.object({
+    keyId: z.coerce.number().int().positive()
+});
+
+const validationBody = z
+    .object({
+        scopes: z.array(z.enum(apiKeyScopes)).min(1).optional(),
+        display_name: z.string().min(1).max(255).optional()
+    })
+    .refine((data) => data.scopes || data.display_name, { message: 'At least one of scopes or display_name is required' });
+
+export const patchApiKey = asyncWrapper<PatchApiKey>(async (req, res) => {
+    const valParams = validationParams.safeParse(req.params);
+    if (!valParams.success) {
+        res.status(400).send({ error: { code: 'invalid_body', errors: zodErrorToHTTP(valParams.error) } });
+        return;
+    }
+
+    const { keyId } = valParams.data;
+    const { environment, account } = res.locals;
+
+    const parsed = validationBody.safeParse(req.body);
+    if (!parsed.success) {
+        res.status(400).send({ error: { code: 'invalid_body', errors: zodErrorToHTTP(parsed.error) } });
+        return;
+    }
+
+    if (parsed.data.display_name) {
+        const result = await customerKeyService.renameApiKey(db.knex, keyId, parsed.data.display_name, environment.id, account.id);
+        if (result.isErr()) {
+            const { type: errType = '', message: errMsg = '' } = result.error as { type?: string; message?: string };
+            if (errType === 'duplicate_api_key' || errMsg.includes('duplicate_api_key')) {
+                res.status(409).send({ error: { code: 'conflict', message: 'A key with this name already exists' } });
+            } else {
+                res.status(404).send({ error: { code: 'not_found', message: 'API key not found' } });
+            }
+            return;
+        }
+    }
+
+    if (parsed.data.scopes) {
+        const result = await customerKeyService.updateApiKeyScopes(db.knex, keyId, parsed.data.scopes, environment.id);
+        if (result.isErr()) {
+            res.status(404).send({ error: { code: 'not_found', message: 'API key not found' } });
+            return;
+        }
+    }
+
+    res.status(200).send({ success: true });
+});

--- a/packages/server/lib/controllers/v1/environment/scopeEnforcement.integration.test.ts
+++ b/packages/server/lib/controllers/v1/environment/scopeEnforcement.integration.test.ts
@@ -1,0 +1,619 @@
+import { afterAll, beforeAll, describe, expect, it } from 'vitest';
+
+import { seeders } from '@nangohq/shared';
+
+import { authenticateUser, isSuccess, runServer } from '../../../utils/tests.js';
+
+import type { ApiKeyScope } from '@nangohq/types';
+
+let api: Awaited<ReturnType<typeof runServer>>;
+
+/**
+ * NAN-5088: Scope enforcement tests.
+ *
+ * For each public API route group, verify that:
+ * 1. A key WITH the required scope passes (not 403)
+ * 2. A key WITHOUT the required scope is denied (403)
+ *
+ * We use a "wrong" scope (one that doesn't match) to test denial.
+ * We don't validate the full response — just that scope enforcement is wired.
+ * The actual status may be 200, 400, 404, etc. depending on the endpoint's validation,
+ * but it must NOT be 403 when the correct scope is present.
+ */
+
+const WRONG_SCOPE = 'environment:mcp'; // unlikely to match any route except /mcp
+
+async function createKeyWithScopes(scopes: ApiKeyScope[]): Promise<string> {
+    const result = await createKeyWithScopesAndEnv(scopes);
+    return result.secret;
+}
+
+async function createKeyWithScopesAndEnv(scopes: ApiKeyScope[]) {
+    const { env, user } = await seeders.seedAccountEnvAndUser();
+    const session = await authenticateUser(api, user);
+    const res = await api.fetch('/api/v1/environment/api-keys', {
+        method: 'POST',
+        // @ts-expect-error query params are required
+        query: { env: env.name },
+        body: { display_name: 'test', scopes },
+        session
+    });
+    isSuccess(res.json);
+    return { secret: res.json.data.secret, env };
+}
+
+describe('Scope enforcement on public API routes', () => {
+    beforeAll(async () => {
+        api = await runServer();
+    });
+
+    afterAll(() => {
+        api.server.close();
+    });
+
+    // ── Integrations ────────────────────────────────────────────────
+
+    describe('GET /integrations', () => {
+        it('should allow with integrations:list scope', async () => {
+            const token = await createKeyWithScopes(['environment:integrations:list']);
+            const res = await api.fetch('/integrations', { method: 'GET', token } as any);
+            expect(res.res.status).not.toBe(403);
+        });
+
+        it('should deny without integrations scope', async () => {
+            const token = await createKeyWithScopes([WRONG_SCOPE]);
+            const res = await api.fetch('/integrations', { method: 'GET', token } as any);
+            expect(res.res.status).toBe(403);
+        });
+    });
+
+    describe('POST /integrations', () => {
+        it('should allow with integrations:write scope', async () => {
+            const token = await createKeyWithScopes(['environment:integrations:write']);
+            const res = await api.fetch('/integrations', { method: 'POST', token, body: {} } as any);
+            expect(res.res.status).not.toBe(403);
+        });
+
+        it('should deny without integrations:write scope', async () => {
+            const token = await createKeyWithScopes([WRONG_SCOPE]);
+            const res = await api.fetch('/integrations', { method: 'POST', token, body: {} } as any);
+            expect(res.res.status).toBe(403);
+        });
+    });
+
+    describe('GET /integrations/:uniqueKey', () => {
+        it('should allow with integrations:read scope', async () => {
+            const token = await createKeyWithScopes(['environment:integrations:read']);
+            const res = await api.fetch('/integrations/:uniqueKey' as any, { method: 'GET', token, params: { uniqueKey: 'nonexistent' } } as any);
+            expect(res.res.status).not.toBe(403);
+        });
+
+        it('should deny without integrations:read scope', async () => {
+            const token = await createKeyWithScopes([WRONG_SCOPE]);
+            const res = await api.fetch('/integrations/:uniqueKey' as any, { method: 'GET', token, params: { uniqueKey: 'nonexistent' } } as any);
+            expect(res.res.status).toBe(403);
+        });
+    });
+
+    describe('DELETE /integrations/:uniqueKey', () => {
+        it('should allow with integrations:write scope', async () => {
+            const token = await createKeyWithScopes(['environment:integrations:write']);
+            const res = await api.fetch('/integrations/:uniqueKey' as any, { method: 'DELETE', token, params: { uniqueKey: 'nonexistent' } } as any);
+            expect(res.res.status).not.toBe(403);
+        });
+
+        it('should deny without integrations:write scope', async () => {
+            const token = await createKeyWithScopes([WRONG_SCOPE]);
+            const res = await api.fetch('/integrations/:uniqueKey' as any, { method: 'DELETE', token, params: { uniqueKey: 'nonexistent' } } as any);
+            expect(res.res.status).toBe(403);
+        });
+    });
+
+    // ── Connections ──────────────────────────────────────────────────
+
+    describe('GET /connections', () => {
+        it('should allow with connections:list scope', async () => {
+            const token = await createKeyWithScopes(['environment:connections:list']);
+            const res = await api.fetch('/connections', { method: 'GET', token } as any);
+            expect(res.res.status).not.toBe(403);
+        });
+
+        it('should deny without connections scope', async () => {
+            const token = await createKeyWithScopes([WRONG_SCOPE]);
+            const res = await api.fetch('/connections', { method: 'GET', token } as any);
+            expect(res.res.status).toBe(403);
+        });
+    });
+
+    describe('GET /connections/:connectionId', () => {
+        it('should allow with connections:read scope', async () => {
+            const token = await createKeyWithScopes(['environment:connections:read']);
+            const res = await api.fetch('/connections/:connectionId' as any, { method: 'GET', token, params: { connectionId: 'nonexistent' } } as any);
+            expect(res.res.status).not.toBe(403);
+        });
+
+        it('should deny without connections:read scope', async () => {
+            const token = await createKeyWithScopes([WRONG_SCOPE]);
+            const res = await api.fetch('/connections/:connectionId' as any, { method: 'GET', token, params: { connectionId: 'nonexistent' } } as any);
+            expect(res.res.status).toBe(403);
+        });
+    });
+
+    describe('DELETE /connections/:connectionId', () => {
+        it('should allow with connections:write scope', async () => {
+            const token = await createKeyWithScopes(['environment:connections:write']);
+            const res = await api.fetch('/connections/:connectionId' as any, { method: 'DELETE', token, params: { connectionId: 'nonexistent' } } as any);
+            expect(res.res.status).not.toBe(403);
+        });
+
+        it('should deny without connections:write scope', async () => {
+            const token = await createKeyWithScopes([WRONG_SCOPE]);
+            const res = await api.fetch('/connections/:connectionId' as any, { method: 'DELETE', token, params: { connectionId: 'nonexistent' } } as any);
+            expect(res.res.status).toBe(403);
+        });
+    });
+
+    // ── Connect Sessions ────────────────────────────────────────────
+
+    describe('POST /connect/sessions', () => {
+        it('should allow with connect_sessions:write scope', async () => {
+            const token = await createKeyWithScopes(['environment:connect_sessions:write']);
+            const res = await api.fetch('/connect/sessions', { method: 'POST', token, body: {} } as any);
+            expect(res.res.status).not.toBe(403);
+        });
+
+        it('should deny without connect_sessions:write scope', async () => {
+            const token = await createKeyWithScopes([WRONG_SCOPE]);
+            const res = await api.fetch('/connect/sessions', { method: 'POST', token, body: {} } as any);
+            expect(res.res.status).toBe(403);
+        });
+    });
+
+    // ── Deploy ───────────────────────────────────────────────────────
+
+    describe('POST /sync/deploy', () => {
+        it('should allow with deploy scope', async () => {
+            const token = await createKeyWithScopes(['environment:deploy']);
+            const res = await api.fetch('/sync/deploy' as any, { method: 'POST', token, body: {}, headers: {} } as any);
+            expect(res.res.status).not.toBe(403);
+        });
+
+        it('should deny without deploy scope', async () => {
+            const token = await createKeyWithScopes([WRONG_SCOPE]);
+            const res = await api.fetch('/sync/deploy' as any, { method: 'POST', token, body: {}, headers: {} } as any);
+            expect(res.res.status).toBe(403);
+        });
+    });
+
+    // ── Records ──────────────────────────────────────────────────────
+
+    describe('GET /records', () => {
+        it('should allow with records:read scope', async () => {
+            const token = await createKeyWithScopes(['environment:records:read']);
+            const res = await api.fetch('/records' as any, { method: 'GET', token, query: { model: 'test' } } as any);
+            expect(res.res.status).not.toBe(403);
+        });
+
+        it('should deny without records:read scope', async () => {
+            const token = await createKeyWithScopes([WRONG_SCOPE]);
+            const res = await api.fetch('/records' as any, { method: 'GET', token, query: { model: 'test' } } as any);
+            expect(res.res.status).toBe(403);
+        });
+    });
+
+    // ── Syncs ────────────────────────────────────────────────────────
+
+    describe('POST /sync/trigger', () => {
+        it('should allow with syncs:execute scope', async () => {
+            const token = await createKeyWithScopes(['environment:syncs:execute']);
+            const res = await api.fetch('/sync/trigger' as any, { method: 'POST', token, body: {}, headers: {} } as any);
+            expect(res.res.status).not.toBe(403);
+        });
+
+        it('should deny without syncs:execute scope', async () => {
+            const token = await createKeyWithScopes([WRONG_SCOPE]);
+            const res = await api.fetch('/sync/trigger' as any, { method: 'POST', token, body: {}, headers: {} } as any);
+            expect(res.res.status).toBe(403);
+        });
+    });
+
+    describe('GET /sync/status', () => {
+        it('should allow with syncs:read scope', async () => {
+            const token = await createKeyWithScopes(['environment:syncs:read']);
+            const res = await api.fetch('/sync/status' as any, { method: 'GET', token, query: { syncs: 'test', provider_config_key: 'test' } } as any);
+            expect(res.res.status).not.toBe(403);
+        });
+
+        it('should deny without syncs:read scope', async () => {
+            const token = await createKeyWithScopes([WRONG_SCOPE]);
+            const res = await api.fetch('/sync/status' as any, { method: 'GET', token, query: { syncs: 'test', provider_config_key: 'test' } } as any);
+            expect(res.res.status).toBe(403);
+        });
+    });
+
+    // ── Actions ──────────────────────────────────────────────────────
+
+    describe('POST /action/trigger', () => {
+        it('should allow with actions:execute scope', async () => {
+            const token = await createKeyWithScopes(['environment:actions:execute']);
+            const res = await api.fetch(
+                '/action/trigger' as any,
+                { method: 'POST', token, body: { action_name: 'test', input: {} }, headers: { 'provider-config-key': 'test', 'connection-id': 'test' } } as any
+            );
+            expect(res.res.status).not.toBe(403);
+        });
+
+        it('should deny without actions:execute scope', async () => {
+            const token = await createKeyWithScopes([WRONG_SCOPE]);
+            const res = await api.fetch(
+                '/action/trigger' as any,
+                { method: 'POST', token, body: { action_name: 'test', input: {} }, headers: { 'provider-config-key': 'test', 'connection-id': 'test' } } as any
+            );
+            expect(res.res.status).toBe(403);
+        });
+    });
+
+    // ── V1 passthrough (deprecated) ───────────────────────────────────
+    // These tests need real connections and sync configs because the scope check
+    // happens after the connection lookup and action/model resolution.
+
+    describe('POST /v1/* (action via legacy passthrough)', () => {
+        it('should allow with actions:execute scope', async () => {
+            const { secret, env } = await createKeyWithScopesAndEnv(['environment:actions:execute']);
+            const config = await seeders.createConfigSeed(env, 'github', 'github');
+            const conn = await seeders.createConnectionSeed({ env, provider: 'github', connectionId: 'v1-action-allow' });
+            await seeders.createSyncSeeds({
+                connectionId: conn.id,
+                environment_id: env.id,
+                nango_config_id: config.id!,
+                sync_name: 'my-action',
+                type: 'action',
+                endpoints: [{ method: 'POST', path: '/my-action' }]
+            });
+            const res = await api.fetch(
+                '/v1/my-action' as any,
+                {
+                    method: 'POST',
+                    token: secret,
+                    body: {},
+                    headers: { 'provider-config-key': 'github', 'connection-id': 'v1-action-allow' }
+                } as any
+            );
+            expect(res.res.status).not.toBe(403);
+        });
+
+        it('should deny without actions:execute scope', async () => {
+            const { secret, env } = await createKeyWithScopesAndEnv([WRONG_SCOPE]);
+            const config = await seeders.createConfigSeed(env, 'github', 'github');
+            const conn = await seeders.createConnectionSeed({ env, provider: 'github', connectionId: 'v1-action-deny' });
+            await seeders.createSyncSeeds({
+                connectionId: conn.id,
+                environment_id: env.id,
+                nango_config_id: config.id!,
+                sync_name: 'my-action',
+                type: 'action',
+                endpoints: [{ method: 'POST', path: '/my-action' }]
+            });
+            const res = await api.fetch(
+                '/v1/my-action' as any,
+                {
+                    method: 'POST',
+                    token: secret,
+                    body: {},
+                    headers: { 'provider-config-key': 'github', 'connection-id': 'v1-action-deny' }
+                } as any
+            );
+            expect(res.res.status).toBe(403);
+        });
+    });
+
+    describe('GET /v1/* (records via legacy passthrough)', () => {
+        it('should allow with records:read scope', async () => {
+            const { secret, env } = await createKeyWithScopesAndEnv(['environment:records:read']);
+            const config = await seeders.createConfigSeed(env, 'github', 'github');
+            const conn = await seeders.createConnectionSeed({ env, provider: 'github', connectionId: 'v1-records-allow' });
+            await seeders.createSyncSeeds({
+                connectionId: conn.id,
+                environment_id: env.id,
+                nango_config_id: config.id!,
+                sync_name: 'my-sync',
+                type: 'sync',
+                models: ['MyModel'],
+                endpoints: [{ method: 'GET', path: '/my-model', model: 'MyModel' }]
+            });
+            const res = await api.fetch(
+                '/v1/my-model' as any,
+                {
+                    method: 'GET',
+                    token: secret,
+                    headers: { 'provider-config-key': 'github', 'connection-id': 'v1-records-allow' }
+                } as any
+            );
+            expect(res.res.status).not.toBe(403);
+        });
+
+        it('should deny without records:read scope', async () => {
+            const { secret, env } = await createKeyWithScopesAndEnv([WRONG_SCOPE]);
+            const config = await seeders.createConfigSeed(env, 'github', 'github');
+            const conn = await seeders.createConnectionSeed({ env, provider: 'github', connectionId: 'v1-records-deny' });
+            await seeders.createSyncSeeds({
+                connectionId: conn.id,
+                environment_id: env.id,
+                nango_config_id: config.id!,
+                sync_name: 'my-sync',
+                type: 'sync',
+                models: ['MyModel'],
+                endpoints: [{ method: 'GET', path: '/my-model', model: 'MyModel' }]
+            });
+            const res = await api.fetch(
+                '/v1/my-model' as any,
+                {
+                    method: 'GET',
+                    token: secret,
+                    headers: { 'provider-config-key': 'github', 'connection-id': 'v1-records-deny' }
+                } as any
+            );
+            expect(res.res.status).toBe(403);
+        });
+    });
+
+    // ── Proxy ────────────────────────────────────────────────────────
+
+    describe('GET /proxy/*', () => {
+        it('should allow with proxy scope', async () => {
+            const token = await createKeyWithScopes(['environment:proxy']);
+            const res = await api.fetch('/proxy/:anyPath' as any, { method: 'GET', token, params: { anyPath: 'test' } } as any);
+            expect(res.res.status).not.toBe(403);
+        });
+
+        it('should deny without proxy scope', async () => {
+            const token = await createKeyWithScopes([WRONG_SCOPE]);
+            const res = await api.fetch('/proxy/:anyPath' as any, { method: 'GET', token, params: { anyPath: 'test' } } as any);
+            expect(res.res.status).toBe(403);
+        });
+    });
+
+    // ── Config ───────────────────────────────────────────────────────
+
+    describe('GET /environment-variables', () => {
+        it('should allow with config:read scope', async () => {
+            const token = await createKeyWithScopes(['environment:config:read']);
+            const res = await api.fetch('/environment-variables' as any, { method: 'GET', token } as any);
+            expect(res.res.status).not.toBe(403);
+        });
+
+        it('should deny without config:read scope', async () => {
+            const token = await createKeyWithScopes([WRONG_SCOPE]);
+            const res = await api.fetch('/environment-variables' as any, { method: 'GET', token } as any);
+            expect(res.res.status).toBe(403);
+        });
+    });
+
+    describe('GET /scripts/config', () => {
+        it('should allow with config:read scope', async () => {
+            const token = await createKeyWithScopes(['environment:config:read']);
+            const res = await api.fetch('/scripts/config', { method: 'GET', token } as any);
+            expect(res.res.status).not.toBe(403);
+        });
+
+        it('should deny without config:read scope', async () => {
+            const token = await createKeyWithScopes([WRONG_SCOPE]);
+            const res = await api.fetch('/scripts/config', { method: 'GET', token } as any);
+            expect(res.res.status).toBe(403);
+        });
+    });
+
+    // ── MCP ──────────────────────────────────────────────────────────
+
+    describe('POST /mcp', () => {
+        it('should allow with mcp scope', async () => {
+            const token = await createKeyWithScopes(['environment:mcp']);
+            const res = await api.fetch('/mcp' as any, { method: 'POST', token, body: {} } as any);
+            expect(res.res.status).not.toBe(403);
+        });
+
+        it('should deny without mcp scope', async () => {
+            const token = await createKeyWithScopes(['environment:deploy']);
+            const res = await api.fetch('/mcp' as any, { method: 'POST', token, body: {} } as any);
+            expect(res.res.status).toBe(403);
+        });
+    });
+
+    // ── Wildcard ─────────────────────────────────────────────────────
+
+    describe('wildcard scope', () => {
+        it('environment:* should grant access to all routes', async () => {
+            const token = await createKeyWithScopes(['environment:*']);
+
+            const routes: { path: string; method: string; extra?: Record<string, unknown> }[] = [
+                { path: '/integrations', method: 'GET' },
+                { path: '/connections', method: 'GET' },
+                { path: '/scripts/config', method: 'GET' }
+            ];
+
+            for (const route of routes) {
+                const res = await api.fetch(route.path as any, { method: route.method, token, ...route.extra } as any);
+                expect(res.res.status).not.toBe(403);
+            }
+        });
+
+        it('environment:integrations:* should grant access to all integration routes', async () => {
+            const token = await createKeyWithScopes(['environment:integrations:*']);
+
+            // Should work
+            const listRes = await api.fetch('/integrations', { method: 'GET', token } as any);
+            expect(listRes.res.status).not.toBe(403);
+
+            // Should not work for connections
+            const connRes = await api.fetch('/connections', { method: 'GET', token } as any);
+            expect(connRes.res.status).toBe(403);
+        });
+    });
+
+    // ── Credential stripping ─────────────────────────────────────────
+
+    describe('credential stripping based on scope', () => {
+        it('GET /connections/:id with read scope should strip credentials', async () => {
+            const { env, user } = await seeders.seedAccountEnvAndUser();
+            await seeders.createConfigSeed(env, 'github', 'github');
+            await seeders.createConnectionSeed({
+                env,
+                provider: 'github',
+                connectionId: 'test-conn',
+                rawCredentials: { type: 'OAUTH2', access_token: 'secret-token-123', raw: {} } as any
+            });
+
+            const session = await authenticateUser(api, user);
+
+            // Create key with read only (no credentials)
+            const readKey = await api.fetch('/api/v1/environment/api-keys', {
+                method: 'POST',
+                // @ts-expect-error query params
+                query: { env: env.name },
+                body: { display_name: 'read-only', scopes: ['environment:connections:read'] },
+                session
+            });
+            isSuccess(readKey.json);
+
+            const res = await api.fetch(
+                '/connections/:connectionId' as any,
+                {
+                    method: 'GET',
+                    token: readKey.json.data.secret,
+                    params: { connectionId: 'test-conn' },
+                    query: { provider_config_key: 'github' }
+                } as any
+            );
+
+            expect(res.res.status).toBe(200);
+            // Credentials should be empty/stripped
+            expect(res.json.credentials).toEqual({});
+        });
+
+        it('GET /connections/:id with read_credentials scope should include credentials', async () => {
+            const { env, user } = await seeders.seedAccountEnvAndUser();
+            await seeders.createConfigSeed(env, 'github', 'github');
+            await seeders.createConnectionSeed({
+                env,
+                provider: 'github',
+                connectionId: 'test-conn-creds',
+                rawCredentials: { type: 'OAUTH2', access_token: 'secret-token-456', raw: {} } as any
+            });
+
+            const session = await authenticateUser(api, user);
+
+            // Create key with read_credentials
+            const credKey = await api.fetch('/api/v1/environment/api-keys', {
+                method: 'POST',
+                // @ts-expect-error query params
+                query: { env: env.name },
+                body: { display_name: 'with-creds', scopes: ['environment:connections:read_credentials'] },
+                session
+            });
+            isSuccess(credKey.json);
+
+            const res = await api.fetch(
+                '/connections/:connectionId' as any,
+                {
+                    method: 'GET',
+                    token: credKey.json.data.secret,
+                    params: { connectionId: 'test-conn-creds' },
+                    query: { provider_config_key: 'github' }
+                } as any
+            );
+
+            expect(res.res.status).toBe(200);
+            // Credentials should be present
+            expect(res.json.credentials).toBeDefined();
+            expect(res.json.credentials.access_token).toBeTruthy();
+        });
+
+        it('GET /integrations/:key?include=credentials with read scope should not include credentials', async () => {
+            const { env, user } = await seeders.seedAccountEnvAndUser();
+            await seeders.createConfigSeed(env, 'github', 'github');
+
+            const session = await authenticateUser(api, user);
+
+            // Create key with read only
+            const readKey = await api.fetch('/api/v1/environment/api-keys', {
+                method: 'POST',
+                // @ts-expect-error query params
+                query: { env: env.name },
+                body: { display_name: 'int-read', scopes: ['environment:integrations:read'] },
+                session
+            });
+            isSuccess(readKey.json);
+
+            const res = await api.fetch(
+                '/integrations/:uniqueKey' as any,
+                {
+                    method: 'GET',
+                    token: readKey.json.data.secret,
+                    params: { uniqueKey: 'github' },
+                    query: { include: 'credentials' }
+                } as any
+            );
+
+            expect(res.res.status).toBe(200);
+            // Credentials should NOT be included (scope doesn't allow it)
+            expect(res.json.data.credentials).toBeUndefined();
+        });
+
+        it('GET /integrations/:key?include=credentials with read_credentials scope should include credentials', async () => {
+            const { env, user } = await seeders.seedAccountEnvAndUser();
+            await seeders.createConfigSeed(env, 'github', 'github');
+
+            const session = await authenticateUser(api, user);
+
+            // Create key with read_credentials
+            const credKey = await api.fetch('/api/v1/environment/api-keys', {
+                method: 'POST',
+                // @ts-expect-error query params
+                query: { env: env.name },
+                body: { display_name: 'int-creds', scopes: ['environment:integrations:read_credentials'] },
+                session
+            });
+            isSuccess(credKey.json);
+
+            const res = await api.fetch(
+                '/integrations/:uniqueKey' as any,
+                {
+                    method: 'GET',
+                    token: credKey.json.data.secret,
+                    params: { uniqueKey: 'github' },
+                    query: { include: 'credentials' }
+                } as any
+            );
+
+            expect(res.res.status).toBe(200);
+            // Credentials should be included
+            expect(res.json.data.credentials).toBeDefined();
+        });
+
+        it('legacy api_secrets key should include credentials (backward compatible)', async () => {
+            const { env, secret } = await seeders.seedAccountEnvAndUser();
+            await seeders.createConfigSeed(env, 'github', 'github');
+            await seeders.createConnectionSeed({
+                env,
+                provider: 'github',
+                connectionId: 'test-conn-legacy',
+                rawCredentials: { type: 'OAUTH2', access_token: 'legacy-token', raw: {} } as any
+            });
+
+            const res = await api.fetch(
+                '/connections/:connectionId' as any,
+                {
+                    method: 'GET',
+                    token: secret.secret,
+                    params: { connectionId: 'test-conn-legacy' },
+                    query: { provider_config_key: 'github' }
+                } as any
+            );
+
+            expect(res.res.status).toBe(200);
+            // Legacy keys have no scope restriction — credentials included
+            expect(res.json.credentials).toBeDefined();
+            expect(res.json.credentials.access_token).toBeTruthy();
+        });
+    });
+});

--- a/packages/server/lib/controllers/v1/getV1.ts
+++ b/packages/server/lib/controllers/v1/getV1.ts
@@ -4,6 +4,7 @@ import { connectionService, getActionOrModelByEndpoint } from '@nangohq/shared';
 import { baseUrl, zodErrorToHTTP } from '@nangohq/utils';
 
 import { connectionIdSchema, providerConfigKeySchema } from '../../helpers/validation.js';
+import { hasScope } from '../../middleware/scope.middleware.js';
 import { asyncWrapper } from '../../utils/asyncWrapper.js';
 import { postPublicTriggerAction } from '../action/postTriggerAction.js';
 import { getPublicRecords } from '../records/getRecords.js';
@@ -40,12 +41,20 @@ export const allPublicV1 = asyncWrapper<GetPublicV1>(async (req, res, next) => {
 
     const { action, model } = await getActionOrModelByEndpoint(connection, req.method as HTTP_METHOD, path);
     if (action) {
+        if (!hasScope({ grantedScopes: res.locals['apiKeyScopes'], requiredScope: 'environment:actions:execute' })) {
+            res.status(403).json({ error: { code: 'forbidden', message: 'Insufficient scope. Required: environment:actions:execute' } });
+            return;
+        }
         const input = req.body || req.params[1];
         req.body = {};
         req.body['action_name'] = action;
         req.body['input'] = input;
         await postPublicTriggerAction(req, res, next);
     } else if (model) {
+        if (!hasScope({ grantedScopes: res.locals['apiKeyScopes'], requiredScope: 'environment:records:read' })) {
+            res.status(403).json({ error: { code: 'forbidden', message: 'Insufficient scope. Required: environment:records:read' } });
+            return;
+        }
         Object.defineProperty(req, 'query', { ...Object.getOwnPropertyDescriptor(req, 'query'), value: req.query, writable: true });
         req.query['model'] = model;
         await getPublicRecords(req, res, next);

--- a/packages/server/lib/formatters/connection.ts
+++ b/packages/server/lib/formatters/connection.ts
@@ -87,12 +87,14 @@ export function connectionFullToPublicApi({
     data,
     provider,
     activeLog,
-    endUser
+    endUser,
+    includeCredentials
 }: {
     data: (DBConnectionDecrypted | DBConnectionAsJSONRow) & { credentials: DBConnectionDecrypted['credentials'] };
     provider: string;
     activeLog: { type: string; log_id: string }[];
     endUser: DBEndUser | null;
+    includeCredentials: boolean;
 }): ApiPublicConnectionFull {
     return {
         id: data.id,
@@ -111,7 +113,7 @@ export function connectionFullToPublicApi({
                 ? data.last_fetched_at.toISOString()
                 : String(data.last_fetched_at)
             : null,
-        credentials: data.credentials
+        credentials: includeCredentials ? data.credentials : ({} as DBConnectionDecrypted['credentials'])
     };
 }
 

--- a/packages/server/lib/hooks/hooks.ts
+++ b/packages/server/lib/hooks/hooks.ts
@@ -150,7 +150,7 @@ export const connectionCreated = async (
 
     const webhookSettings = await externalWebhookService.get(environment.id);
 
-    const defaultSecret = await secretService.getDefaultSecretForEnv(db.readOnly, environment.id);
+    const defaultSecret = await secretService.getInternalSecretForEnv(db.readOnly, environment.id);
     if (defaultSecret.isErr()) {
         throw defaultSecret.error;
     }
@@ -194,7 +194,7 @@ export const connectionCreationFailed = async (
     if (error) {
         const webhookSettings = await externalWebhookService.get(environment.id);
 
-        const defaultSecret = await secretService.getDefaultSecretForEnv(db.readOnly, environment.id);
+        const defaultSecret = await secretService.getInternalSecretForEnv(db.readOnly, environment.id);
         if (defaultSecret.isErr()) {
             throw defaultSecret.error;
         }
@@ -275,7 +275,7 @@ export const connectionRefreshFailed = async ({
 
     const webhookSettings = await externalWebhookService.get(environment.id);
 
-    const defaultSecret = await secretService.getDefaultSecretForEnv(db.readOnly, environment.id);
+    const defaultSecret = await secretService.getInternalSecretForEnv(db.readOnly, environment.id);
     if (defaultSecret.isErr()) {
         throw defaultSecret.error;
     }

--- a/packages/server/lib/middleware/access.middleware.ts
+++ b/packages/server/lib/middleware/access.middleware.ts
@@ -47,6 +47,11 @@ export class AccessMiddleware {
             environment: DBEnvironment;
             secret: DBAPISecret;
             plan: DBPlan | null;
+            auth?: {
+                source: 'customer_key' | 'api_secret';
+                scopes?: string[];
+                apiKeyId?: number;
+            };
         }>
     > {
         if (!keyRegex.test(secret)) {
@@ -86,6 +91,29 @@ export class AccessMiddleware {
                 return;
             }
 
+            const isScript = req.get('Nango-Is-Script') === 'true';
+
+            if (isScript) {
+                // Runner/script traffic — validate against api_secrets only (no customer_keys lookup).
+                // This prevents customer scope restrictions from breaking runner execution.
+                const accountContext = await accountService.getAccountContextByInternalSecretKey(secret);
+                if (!accountContext) {
+                    errorManager.errRes(res, 'unknown_account');
+                    return;
+                }
+                res.locals['authType'] = 'secretKey';
+                res.locals['account'] = accountContext.account;
+                res.locals['environment'] = accountContext.environment;
+                res.locals['plan'] = accountContext.plan;
+                res.locals['apiKeyScopes'] = ['environment:*'];
+                metrics.increment(metrics.Types.AUTH_GET_ENV_BY_SECRET_KEY_SOURCE, 1, {
+                    auth_source: 'internal_script'
+                });
+                tagTraceUser(accountContext);
+                next();
+                return;
+            }
+
             const result = await this.validateSecretKey(secret);
             if (result.isErr()) {
                 errorManager.errRes(res, result.error.message);
@@ -96,6 +124,12 @@ export class AccessMiddleware {
             res.locals['account'] = result.value.account;
             res.locals['environment'] = result.value.environment;
             res.locals['plan'] = result.value.plan;
+            if (result.value.auth?.scopes) {
+                res.locals['apiKeyScopes'] = result.value.auth.scopes;
+            }
+            metrics.increment(metrics.Types.AUTH_GET_ENV_BY_SECRET_KEY_SOURCE, 1, {
+                auth_source: result.value.auth?.source ?? 'env_var'
+            });
             tagTraceUser(result.value);
             next();
         } catch (err) {
@@ -359,12 +393,16 @@ export class AccessMiddleware {
                     errorManager.errRes(res, secretKeyResult.error.message);
                     return;
                 }
-
                 res.locals['authType'] = 'secretKey';
                 res.locals['account'] = secretKeyResult.value.account;
                 res.locals['environment'] = secretKeyResult.value.environment;
                 res.locals['plan'] = secretKeyResult.value.plan;
-
+                if (secretKeyResult.value.auth?.scopes) {
+                    res.locals['apiKeyScopes'] = secretKeyResult.value.auth.scopes;
+                }
+                metrics.increment(metrics.Types.AUTH_GET_ENV_BY_SECRET_KEY_SOURCE, 1, {
+                    auth_source: secretKeyResult.value.auth?.source ?? 'env_var'
+                });
                 tagTraceUser(secretKeyResult.value);
             } else {
                 res.locals['authType'] = 'connectSession';
@@ -372,6 +410,7 @@ export class AccessMiddleware {
                 res.locals['environment'] = connectSessionResult.value.environment;
                 res.locals['connectSession'] = connectSessionResult.value.connectSession;
                 res.locals['endUser'] = connectSessionResult.value.endUser;
+                res.locals['apiKeyScopes'] = ['environment:integrations:list', 'environment:integrations:list_credentials'];
                 res.locals['plan'] = connectSessionResult.value.plan;
                 tagTraceUser(connectSessionResult.value);
             }

--- a/packages/server/lib/middleware/scope.middleware.ts
+++ b/packages/server/lib/middleware/scope.middleware.ts
@@ -1,0 +1,48 @@
+import type { RequestLocals } from '../utils/express.js';
+import type { ApiKeyScope } from '@nangohq/types';
+import type { NextFunction, Request, Response } from 'express';
+
+export function hasScope({ grantedScopes, requiredScope }: { grantedScopes: string[] | undefined; requiredScope: ApiKeyScope }): boolean {
+    if (!grantedScopes) {
+        return false;
+    }
+
+    for (const s of grantedScopes) {
+        if (s === requiredScope) {
+            return true;
+        }
+        if (s.endsWith(':*') && requiredScope.startsWith(s.slice(0, -1))) {
+            return true;
+        }
+    }
+
+    return false;
+}
+
+export function withScope(requiredScope: ApiKeyScope) {
+    return function (_req: Request, res: Response<unknown, RequestLocals>, next: NextFunction): void {
+        const scopes = res.locals['apiKeyScopes'];
+
+        if (hasScope({ grantedScopes: scopes, requiredScope })) {
+            next();
+            return;
+        }
+
+        res.status(403).json({ error: { code: 'forbidden', message: `Insufficient scope. Required: ${requiredScope}` } });
+    };
+}
+
+export function withAnyScope(...requiredScopes: ApiKeyScope[]) {
+    return function (_req: Request, res: Response<unknown, RequestLocals>, next: NextFunction): void {
+        const scopes = res.locals['apiKeyScopes'];
+
+        for (const scope of requiredScopes) {
+            if (hasScope({ grantedScopes: scopes, requiredScope: scope })) {
+                next();
+                return;
+            }
+        }
+
+        res.status(403).json({ error: { code: 'forbidden', message: `Insufficient scope. Required one of: ${requiredScopes.join(' or ')}` } });
+    };
+}

--- a/packages/server/lib/middleware/scope.middleware.unit.test.ts
+++ b/packages/server/lib/middleware/scope.middleware.unit.test.ts
@@ -1,0 +1,54 @@
+import { describe, expect, it } from 'vitest';
+
+import { hasScope } from './scope.middleware.js';
+
+import type { ApiKeyScope } from '@nangohq/types';
+
+describe('hasScope', () => {
+    it('returns false when grantedScopes is undefined', () => {
+        expect(hasScope({ grantedScopes: undefined, requiredScope: 'environment:deploy' })).toBe(false);
+    });
+
+    it('exact match', () => {
+        expect(hasScope({ grantedScopes: ['environment:deploy'], requiredScope: 'environment:deploy' })).toBe(true);
+    });
+
+    it('no match', () => {
+        expect(hasScope({ grantedScopes: ['environment:deploy'], requiredScope: 'environment:proxy' })).toBe(false);
+    });
+
+    it('empty scopes returns false', () => {
+        expect(hasScope({ grantedScopes: [], requiredScope: 'environment:deploy' })).toBe(false);
+    });
+
+    it('environment:* matches any environment scope', () => {
+        expect(hasScope({ grantedScopes: ['environment:*'], requiredScope: 'environment:deploy' })).toBe(true);
+        expect(hasScope({ grantedScopes: ['environment:*'], requiredScope: 'environment:integrations:list' })).toBe(true);
+        expect(hasScope({ grantedScopes: ['environment:*'], requiredScope: 'environment:connections:read_credentials' })).toBe(true);
+    });
+
+    it('group wildcard matches scopes within the group', () => {
+        expect(hasScope({ grantedScopes: ['environment:integrations:*'], requiredScope: 'environment:integrations:list' })).toBe(true);
+        expect(hasScope({ grantedScopes: ['environment:integrations:*'], requiredScope: 'environment:integrations:write' })).toBe(true);
+        expect(hasScope({ grantedScopes: ['environment:integrations:*'], requiredScope: 'environment:integrations:read_credentials' })).toBe(true);
+    });
+
+    it('group wildcard does not match other groups', () => {
+        expect(hasScope({ grantedScopes: ['environment:integrations:*'], requiredScope: 'environment:connections:list' })).toBe(false);
+        expect(hasScope({ grantedScopes: ['environment:integrations:*'], requiredScope: 'environment:deploy' })).toBe(false);
+    });
+
+    it('multiple granted scopes — any match is sufficient', () => {
+        expect(hasScope({ grantedScopes: ['environment:deploy', 'environment:proxy'], requiredScope: 'environment:proxy' })).toBe(true);
+    });
+
+    it('wildcard does not match across prefixes', () => {
+        // Cast to ApiKeyScope: account-level scopes are not yet supported, but we verify
+        // that environment:* doesn't accidentally match them
+        expect(hasScope({ grantedScopes: ['environment:*'], requiredScope: 'account:environments:create' as ApiKeyScope })).toBe(false);
+    });
+
+    it('credential scope does not grant non-credential access', () => {
+        expect(hasScope({ grantedScopes: ['environment:connections:read_credentials'], requiredScope: 'environment:connections:write' })).toBe(false);
+    });
+});

--- a/packages/server/lib/routes.private.ts
+++ b/packages/server/lib/routes.private.ts
@@ -40,9 +40,13 @@ import { getConnection as getConnectionWeb } from './controllers/v1/connections/
 import { getConnectionRefresh } from './controllers/v1/connections/connectionId/postRefresh.js';
 import { getConnections } from './controllers/v1/connections/getConnections.js';
 import { getConnectionsCount } from './controllers/v1/connections/getConnectionsCount.js';
+import { createApiKey } from './controllers/v1/environment/createApiKey.js';
+import { deleteApiKey } from './controllers/v1/environment/deleteApiKey.js';
 import { deleteEnvironment } from './controllers/v1/environment/deleteEnvironment.js';
 import { getEnvironment } from './controllers/v1/environment/getEnvironment.js';
 import { getEnvironments } from './controllers/v1/environment/getEnvironments.js';
+import { listApiKeys } from './controllers/v1/environment/listApiKeys.js';
+import { patchApiKey } from './controllers/v1/environment/patchApiKey.js';
 import { patchEnvironment } from './controllers/v1/environment/patchEnvironment.js';
 import { postEnvironment } from './controllers/v1/environment/postEnvironment.js';
 import { postEnvironmentVariables } from './controllers/v1/environment/variables/postVariables.js';
@@ -199,22 +203,17 @@ web.route('/environments/current').get(webAuth, can({ action: 'read', resource: 
 web.route('/environments/webhook').patch(webAuth, can({ action: 'update', resource: 'webhook', scopedBy: envScope }), patchWebhook);
 web.route('/environments/variables').post(webAuth, can({ action: 'update', resource: 'environment_variable', scopedBy: envScope }), postEnvironmentVariables);
 
+// API Key management
+web.route('/environment/api-keys').get(webAuth, can({ action: 'read', resource: 'environment_key', scopedBy: envScope }), listApiKeys);
+web.route('/environment/api-keys').post(webAuth, can({ action: 'update', resource: 'environment_key', scopedBy: envScope }), createApiKey);
+web.route('/environment/api-keys/:keyId').patch(webAuth, can({ action: 'update', resource: 'environment_key', scopedBy: envScope }), patchApiKey);
+web.route('/environment/api-keys/:keyId').delete(webAuth, can({ action: 'update', resource: 'environment_key', scopedBy: envScope }), deleteApiKey);
+
 web.route('/environment/hmac').get(webAuth, environmentController.getHmacDigest.bind(environmentController));
-web.route('/environment/rotate-key').post(
-    webAuth,
-    can({ action: 'update', resource: 'environment_key', scopedBy: envScope }),
-    environmentController.rotateKey.bind(environmentController)
-);
-web.route('/environment/revert-key').post(
-    webAuth,
-    can({ action: 'update', resource: 'environment_key', scopedBy: envScope }),
-    environmentController.revertKey.bind(environmentController)
-);
-web.route('/environment/activate-key').post(
-    webAuth,
-    can({ action: 'update', resource: 'environment_key', scopedBy: envScope }),
-    environmentController.activateKey.bind(environmentController)
-);
+// Legacy key rotation endpoints — disabled, replaced by customer_keys API (NAN-5088)
+// web.route('/environment/rotate-key').post(webAuth, can(...), environmentController.rotateKey)
+// web.route('/environment/revert-key').post(webAuth, can(...), environmentController.revertKey)
+// web.route('/environment/activate-key').post(webAuth, can(...), environmentController.activateKey)
 web.route('/environment/admin-auth').get(webAuth, environmentController.getAdminAuthInfo.bind(environmentController));
 
 // Connect

--- a/packages/server/lib/routes.public.ts
+++ b/packages/server/lib/routes.public.ts
@@ -69,6 +69,7 @@ import { cliMaxVersion, cliMinVersion } from './middleware/cliVersionCheck.js';
 import { connectionCapping } from './middleware/connection-capping.middleware.js';
 import { jsonContentTypeMiddleware } from './middleware/json.middleware.js';
 import { rateLimiterMiddleware } from './middleware/ratelimit.middleware.js';
+import { withAnyScope, withScope } from './middleware/scope.middleware.js';
 import { isBinaryContentType } from './utils/utils.js';
 
 import type { DBPlan } from '@nangohq/types';
@@ -169,78 +170,108 @@ publicAPI.route('/providers').get(connectSessionOrApiAuth, acceptLanguageMiddlew
 publicAPI.route('/providers/:provider').get(connectSessionOrApiAuth, acceptLanguageMiddleware, getPublicProvider);
 
 // @deprecated rollbacked for one customer, to delete asap
-publicAPI.route('/config/:providerConfigKey').get(apiAuth, configController.getProviderConfig.bind(configController));
+publicAPI
+    .route('/config/:providerConfigKey')
+    .get(
+        apiAuth,
+        withAnyScope('environment:integrations:read', 'environment:integrations:read_credentials'),
+        configController.getProviderConfig.bind(configController)
+    );
 
+// Integrations
 publicAPI.use('/integrations', jsonContentTypeMiddleware);
-publicAPI.route('/integrations').get(connectSessionOrApiAuth, getPublicListIntegrations);
-publicAPI.route('/integrations').post(apiAuth, postPublicIntegration);
-publicAPI.route('/integrations/:uniqueKey').patch(apiAuth, patchPublicIntegration);
-publicAPI.route('/integrations/:uniqueKey').get(apiAuth, getPublicIntegration);
-publicAPI.route('/integrations/:uniqueKey').delete(apiAuth, deletePublicIntegration);
+publicAPI
+    .route('/integrations')
+    .get(connectSessionOrApiAuth, withAnyScope('environment:integrations:list', 'environment:integrations:list_credentials'), getPublicListIntegrations);
+publicAPI.route('/integrations').post(apiAuth, withScope('environment:integrations:write'), postPublicIntegration);
+publicAPI.route('/integrations/:uniqueKey').patch(apiAuth, withScope('environment:integrations:write'), patchPublicIntegration);
+publicAPI
+    .route('/integrations/:uniqueKey')
+    .get(apiAuth, withAnyScope('environment:integrations:read', 'environment:integrations:read_credentials'), getPublicIntegration);
+publicAPI.route('/integrations/:uniqueKey').delete(apiAuth, withScope('environment:integrations:write'), deletePublicIntegration);
 
-// @deprecated
+// @deprecated connections
 publicAPI.use('/connection', jsonContentTypeMiddleware);
 // @deprecated
-publicAPI.route('/connection/:connectionId').get(apiAuth, getPublicConnection);
+publicAPI
+    .route('/connection/:connectionId')
+    .get(apiAuth, withAnyScope('environment:connections:read', 'environment:connections:read_credentials'), getPublicConnection);
 // @deprecated
-publicAPI.route('/connection').get(apiAuth, getPublicConnections);
+publicAPI.route('/connection').get(apiAuth, withAnyScope('environment:connections:list', 'environment:connections:list_credentials'), getPublicConnections);
 // @deprecated
-publicAPI.route('/connection/:connectionId').delete(apiAuth, deletePublicConnection);
+publicAPI.route('/connection/:connectionId').delete(apiAuth, withScope('environment:connections:write'), deletePublicConnection);
 // @deprecated
-publicAPI.route('/connection/:connectionId/metadata').post(apiAuth, connectionController.setMetadataLegacy.bind(connectionController));
+publicAPI
+    .route('/connection/:connectionId/metadata')
+    .post(apiAuth, withScope('environment:connections:write'), connectionController.setMetadataLegacy.bind(connectionController));
 // @deprecated
-publicAPI.route('/connection/:connectionId/metadata').patch(apiAuth, connectionController.updateMetadataLegacy.bind(connectionController));
+publicAPI
+    .route('/connection/:connectionId/metadata')
+    .patch(apiAuth, withScope('environment:connections:write'), connectionController.updateMetadataLegacy.bind(connectionController));
 // @deprecated
-publicAPI.route('/connection/metadata').post(apiAuth, postPublicMetadata);
+publicAPI.route('/connection/metadata').post(apiAuth, withScope('environment:connections:write'), postPublicMetadata);
 // @deprecated
-publicAPI.route('/connection/metadata').patch(apiAuth, patchPublicMetadata);
+publicAPI.route('/connection/metadata').patch(apiAuth, withScope('environment:connections:write'), patchPublicMetadata);
 // @deprecated
-publicAPI.route('/connection').post(apiAuth, connectionController.createConnection.bind(connectionController));
+publicAPI.route('/connection').post(apiAuth, withScope('environment:connections:write'), connectionController.createConnection.bind(connectionController));
 
+// Connections
 publicAPI.use('/connections', jsonContentTypeMiddleware);
-publicAPI.route('/connections').post(apiAuth, postPublicConnection);
-publicAPI.route('/connections').get(apiAuth, getPublicConnections);
-publicAPI.route('/connections/metadata').post(apiAuth, postPublicMetadata);
-publicAPI.route('/connections/metadata').patch(apiAuth, patchPublicMetadata);
-publicAPI.route('/connections/:connectionId').get(apiAuth, getPublicConnection);
-publicAPI.route('/connections/:connectionId').patch(apiAuth, patchPublicConnection);
-publicAPI.route('/connections/:connectionId').delete(apiAuth, deletePublicConnection);
+publicAPI.route('/connections').post(apiAuth, withScope('environment:connections:write'), postPublicConnection);
+publicAPI.route('/connections').get(apiAuth, withAnyScope('environment:connections:list', 'environment:connections:list_credentials'), getPublicConnections);
+publicAPI.route('/connections/metadata').post(apiAuth, withScope('environment:connections:write'), postPublicMetadata);
+publicAPI.route('/connections/metadata').patch(apiAuth, withScope('environment:connections:write'), patchPublicMetadata);
+publicAPI
+    .route('/connections/:connectionId')
+    .get(apiAuth, withAnyScope('environment:connections:read', 'environment:connections:read_credentials'), getPublicConnection);
+publicAPI.route('/connections/:connectionId').patch(apiAuth, withScope('environment:connections:write'), patchPublicConnection);
+publicAPI.route('/connections/:connectionId').delete(apiAuth, withScope('environment:connections:write'), deletePublicConnection);
 
+// Config
 publicAPI.use('/environment-variables', jsonContentTypeMiddleware);
-publicAPI.route('/environment-variables').get(apiAuth, getPublicEnvironmentVariables);
+publicAPI.route('/environment-variables').get(apiAuth, withScope('environment:config:read'), getPublicEnvironmentVariables);
 
+// Deploy
 publicAPI.use('/sync', jsonContentTypeMiddleware);
-publicAPI.route('/sync/deploy').post(apiAuth, cliMinVersion('0.39.25'), postDeploy);
-publicAPI.route('/sync/deploy/confirmation').post(apiAuth, cliMinVersion('0.39.25'), postDeployConfirmation);
-publicAPI.route('/sync/deploy/internal').post(apiAuth, postDeployInternal);
-publicAPI.route('/sync/update-connection-frequency').put(apiAuth, putSyncConnectionFrequency);
+publicAPI.route('/sync/deploy').post(apiAuth, withScope('environment:deploy'), cliMinVersion('0.39.25'), postDeploy);
+publicAPI.route('/sync/deploy/confirmation').post(apiAuth, withScope('environment:deploy'), cliMinVersion('0.39.25'), postDeployConfirmation);
+publicAPI.route('/sync/deploy/internal').post(apiAuth, withScope('environment:deploy'), postDeployInternal);
 
+// Syncs
+publicAPI.route('/sync/update-connection-frequency').put(apiAuth, withScope('environment:syncs:manage'), putSyncConnectionFrequency);
+
+// Records
 publicAPI.use('/records', jsonContentTypeMiddleware);
-publicAPI.route('/records').get(apiAuth, getPublicRecords);
-publicAPI.route('/records/prune').patch(apiAuth, patchPublicPruneRecords);
+publicAPI.route('/records').get(apiAuth, withScope('environment:records:read'), getPublicRecords);
+publicAPI.route('/records/prune').patch(apiAuth, withScope('environment:records:write'), patchPublicPruneRecords);
 
+// Syncs (continued)
 publicAPI.use('/sync', jsonContentTypeMiddleware);
-publicAPI.route('/sync/trigger').post(apiAuth, postPublicTrigger);
-publicAPI.route('/sync/pause').post(apiAuth, postPublicSyncPause);
-publicAPI.route('/sync/start').post(apiAuth, postPublicSyncStart);
-publicAPI.route('/sync/status').get(apiAuth, getPublicSyncStatus);
-publicAPI.route('/sync/:name/variant/:variant').post(apiAuth, postSyncVariant);
-publicAPI.route('/sync/:name/variant/:variant').delete(apiAuth, deleteSyncVariant);
+publicAPI.route('/sync/trigger').post(apiAuth, withScope('environment:syncs:execute'), postPublicTrigger);
+publicAPI.route('/sync/pause').post(apiAuth, withScope('environment:syncs:execute'), postPublicSyncPause);
+publicAPI.route('/sync/start').post(apiAuth, withScope('environment:syncs:execute'), postPublicSyncStart);
+publicAPI.route('/sync/status').get(apiAuth, withScope('environment:syncs:read'), getPublicSyncStatus);
+publicAPI.route('/sync/:name/variant/:variant').post(apiAuth, withScope('environment:syncs:manage'), postSyncVariant);
+publicAPI.route('/sync/:name/variant/:variant').delete(apiAuth, withScope('environment:syncs:manage'), deleteSyncVariant);
 
+// MCP
 publicAPI.use('/mcp', jsonContentTypeMiddleware);
-publicAPI.route('/mcp').post(apiAuth, postMcp);
-publicAPI.route('/mcp').get(apiAuth, getMcp);
+publicAPI.route('/mcp').post(apiAuth, withScope('environment:mcp'), postMcp);
+publicAPI.route('/mcp').get(apiAuth, withScope('environment:mcp'), getMcp);
 
+// Scripts config
 publicAPI.use('/scripts', jsonContentTypeMiddleware);
-publicAPI.route('/scripts/config').get(apiAuth, getPublicScriptsConfig);
+publicAPI.route('/scripts/config').get(apiAuth, withScope('environment:config:read'), getPublicScriptsConfig);
 
+// Actions
 publicAPI.use('/action', jsonContentTypeMiddleware);
-publicAPI.route('/action/trigger').post(apiAuth, postPublicTriggerAction); //TODO: to deprecate
-publicAPI.route('/action/:id').get(apiAuth, getAsyncActionResult);
+publicAPI.route('/action/trigger').post(apiAuth, withScope('environment:actions:execute'), postPublicTriggerAction); //TODO: to deprecate
+publicAPI.route('/action/:id').get(apiAuth, withScope('environment:actions:execute'), getAsyncActionResult);
 
+// Connect sessions
 publicAPI.use('/connect', jsonContentTypeMiddleware);
-publicAPI.route('/connect/sessions').post(apiAuth, connectionCapping, postConnectSessions);
-publicAPI.route('/connect/sessions/reconnect').post(apiAuth, postConnectSessionsReconnect);
+publicAPI.route('/connect/sessions').post(apiAuth, withScope('environment:connect_sessions:write'), connectionCapping, postConnectSessions);
+publicAPI.route('/connect/sessions/reconnect').post(apiAuth, withScope('environment:connect_sessions:write'), postConnectSessionsReconnect);
 publicAPI.route('/connect/session').get(connectSessionAuth, getConnectSession);
 publicAPI.route('/connect/session').delete(connectSessionAuth, deleteConnectSession);
 publicAPI.route('/connect/telemetry').post(connectSessionAuthBody, postConnectTelemetry);
@@ -250,7 +281,9 @@ publicAPI.route('/remote-function/compile').post(remoteFunctionAuth, postRemoteF
 publicAPI.route('/remote-function/dryrun').post(remoteFunctionAuth, postRemoteFunctionDryrun);
 publicAPI.route('/remote-function/deploy').post(remoteFunctionAuth, postRemoteFunctionDeploy);
 
+// V1 passthrough (deprecated) — scope checks are inline in allPublicV1 after action/model resolution
 publicAPI.use('/v1', jsonContentTypeMiddleware);
 publicAPI.route('/v1/*splat').all(apiAuth, allPublicV1);
 
-publicAPI.route('/proxy/*splat').all(apiAuth, upload.any(), allPublicProxy);
+// Proxy
+publicAPI.route('/proxy/*splat').all(apiAuth, withScope('environment:proxy'), upload.any(), allPublicProxy);

--- a/packages/server/lib/utils/express.ts
+++ b/packages/server/lib/utils/express.ts
@@ -31,4 +31,5 @@ export interface RequestLocals {
     plan?: DBPlan | null;
     lang?: string;
     secret?: DBAPISecret;
+    apiKeyScopes?: string[];
 }

--- a/packages/server/lib/webhook/webhook.manager.ts
+++ b/packages/server/lib/webhook/webhook.manager.ts
@@ -111,7 +111,7 @@ export async function routeWebhook({
 
         const webhookSettings = await externalWebhookService.get(environment.id);
 
-        const defaultSecret = await secretService.getDefaultSecretForEnv(db.readOnly, environment.id);
+        const defaultSecret = await secretService.getInternalSecretForEnv(db.readOnly, environment.id);
         if (defaultSecret.isErr()) {
             throw defaultSecret.error;
         }

--- a/packages/shared/lib/index.ts
+++ b/packages/shared/lib/index.ts
@@ -4,6 +4,7 @@ import * as seeders from './seeders/index.js';
 import accountService from './services/account.service.js';
 import configService from './services/config.service.js';
 import connectionService from './services/connection.service.js';
+import customerKeyService from './services/customerKey.service.js';
 import environmentService from './services/environment.service.js';
 import * as externalWebhookService from './services/external-webhook.service.js';
 import localFileService from './services/file/local.service.js';
@@ -67,6 +68,7 @@ export {
     accountService,
     configService,
     connectionService,
+    customerKeyService,
     encryptionManager,
     environmentService,
     errorManager,

--- a/packages/shared/lib/seeders/global.seeder.ts
+++ b/packages/shared/lib/seeders/global.seeder.ts
@@ -11,7 +11,7 @@ import type { DBAPISecret, DBEnvironment, DBPlan, DBTeam, DBUser } from '@nangoh
 export async function seedAccountEnvAndUser(): Promise<{ account: DBTeam; env: DBEnvironment; secret: DBAPISecret; user: DBUser; plan: DBPlan }> {
     const account = await createAccount();
     const env = await createEnvironmentSeed(account.id, 'dev');
-    const secret = (await secretService.getDefaultSecretForEnv(db.knex, env.id)).unwrap();
+    const secret = (await secretService.getInternalSecretForEnv(db.knex, env.id)).unwrap();
     const plan = (await createPlan(db.knex, { account_id: account.id, name: 'free' })).unwrap();
     const user = await seedUser(account.id);
     return { account, env, secret, user, plan };

--- a/packages/shared/lib/seeders/sync.seeder.ts
+++ b/packages/shared/lib/seeders/sync.seeder.ts
@@ -12,7 +12,7 @@ export async function createSyncSeeds({
     ...syncData
 }: SetRequired<Partial<DBSyncConfig>, 'environment_id' | 'nango_config_id' | 'sync_name'> & {
     connectionId: number;
-    endpoints?: NangoSyncEndpointV2[];
+    endpoints?: (NangoSyncEndpointV2 & { model?: string })[];
 }): Promise<{
     syncConfig: DBSyncConfig;
     sync: Sync;
@@ -54,6 +54,7 @@ export async function createSyncSeeds({
                 return {
                     method: endpoint.method,
                     path: endpoint.path,
+                    model: endpoint.model || null,
                     group_name: endpoint.group || null,
                     sync_config_id: syncConfig.id
                 };

--- a/packages/shared/lib/services/account.service.integration.test.ts
+++ b/packages/shared/lib/services/account.service.integration.test.ts
@@ -48,7 +48,7 @@ describe('Account service', () => {
         const account = await createTestAccount();
         const environment = await environmentService.createEnvironment(db.knex, { accountId: account.id, name: uuid() });
         const plan = (await plans.createPlan(db.knex, { account_id: account.id, name: 'free' })).unwrap();
-        const secret = (await secretService.getDefaultSecretForEnv(db.knex, environment!.id)).unwrap();
+        const secret = (await secretService.getInternalSecretForEnv(db.knex, environment!.id)).unwrap();
 
         const bySecretKey = await accountService.getAccountContext({ secretKey: environment!.secret_key });
 
@@ -72,15 +72,152 @@ describe('Account service', () => {
                 ...secret,
                 created_at: expect.toBeIsoDateTimezone(),
                 updated_at: expect.toBeIsoDateTimezone()
+            },
+            auth: {
+                source: 'customer_key',
+                scopes: ['environment:*'],
+                apiKeyId: expect.any(Number)
             }
         });
+    });
+
+    it('should retrieve account context by legacy secretKey when customer key is missing', async () => {
+        const account = await createTestAccount();
+        const environment = await environmentService.createEnvironment(db.knex, { accountId: account.id, name: uuid() });
+        const plan = (await plans.createPlan(db.knex, { account_id: account.id, name: 'free' })).unwrap();
+        const secret = (await secretService.getInternalSecretForEnv(db.knex, environment!.id)).unwrap();
+
+        await db.knex('customer_keys_relations').where({ entity_type: 'environment', entity_id: environment!.id }).delete();
+        await db.knex('customer_keys').where({ account_id: account.id, key_type: 'api' }).delete();
+
+        const bySecretKey = await accountService.getAccountContext({ secretKey: environment!.secret_key });
+
+        expect(bySecretKey).toStrictEqual({
+            account: {
+                ...account,
+                created_at: expect.toBeIsoDateTimezone(),
+                updated_at: expect.toBeIsoDateTimezone()
+            },
+            environment: {
+                ...environment,
+                created_at: expect.toBeIsoDateTimezone(),
+                updated_at: expect.toBeIsoDateTimezone()
+            },
+            plan: {
+                ...plan,
+                created_at: expect.toBeIsoDateTimezone(),
+                updated_at: expect.toBeIsoDateTimezone()
+            },
+            secret: {
+                ...secret,
+                created_at: expect.toBeIsoDateTimezone(),
+                updated_at: expect.toBeIsoDateTimezone()
+            },
+            auth: {
+                source: 'api_secret',
+                scopes: ['environment:*']
+            }
+        });
+    });
+
+    it('should prefer customer key scopes when both tables match the same secret', async () => {
+        const account = await createTestAccount();
+        const environment = await environmentService.createEnvironment(db.knex, { accountId: account.id, name: uuid() });
+        await plans.createPlan(db.knex, { account_id: account.id, name: 'free' });
+
+        await db
+            .knex('customer_keys')
+            .update({ scopes: ['environment:deploy'] })
+            .where({ account_id: account.id, key_type: 'api' })
+            .whereNull('deleted_at');
+
+        const bySecretKey = await accountService.getAccountContext({ secretKey: environment!.secret_key });
+
+        expect(bySecretKey?.auth).toStrictEqual({
+            source: 'customer_key',
+            scopes: ['environment:deploy'],
+            apiKeyId: expect.any(Number)
+        });
+    });
+
+    it('should fall back to legacy secret when matching customer key is soft-deleted', async () => {
+        const account = await createTestAccount();
+        const environment = await environmentService.createEnvironment(db.knex, { accountId: account.id, name: uuid() });
+        await plans.createPlan(db.knex, { account_id: account.id, name: 'free' });
+
+        await db.knex('customer_keys').update({ deleted_at: new Date() }).where({ account_id: account.id, key_type: 'api' });
+
+        const bySecretKey = await accountService.getAccountContext({ secretKey: environment!.secret_key });
+
+        expect(bySecretKey?.auth).toStrictEqual({
+            source: 'api_secret',
+            scopes: ['environment:*']
+        });
+    });
+
+    it('should fall back to legacy secret when matching customer key relation is not environment-scoped', async () => {
+        const account = await createTestAccount();
+        const environment = await environmentService.createEnvironment(db.knex, { accountId: account.id, name: uuid() });
+        await plans.createPlan(db.knex, { account_id: account.id, name: 'free' });
+
+        const apiKey = await db.knex('customer_keys').select('id').where({ account_id: account.id, key_type: 'api' }).whereNull('deleted_at').first();
+
+        expect(apiKey).toBeDefined();
+
+        await db.knex('customer_keys_relations').where({ customer_key_id: apiKey!.id }).delete();
+        await db.knex('customer_keys_relations').insert({
+            customer_key_id: apiKey!.id,
+            entity_type: 'account',
+            entity_id: account.id
+        });
+
+        const bySecretKey = await accountService.getAccountContext({ secretKey: environment!.secret_key });
+
+        expect(bySecretKey?.auth).toStrictEqual({
+            source: 'api_secret',
+            scopes: ['environment:*']
+        });
+    });
+
+    it('should return null when secretKey does not match either table', async () => {
+        const bySecretKey = await accountService.getAccountContext({ secretKey: uuid() });
+
+        expect(bySecretKey).toBeNull();
+    });
+
+    it('should debounce customer key last_used_at updates when resolving by secretKey', async () => {
+        const account = await createTestAccount();
+        const environment = await environmentService.createEnvironment(db.knex, { accountId: account.id, name: uuid() });
+        await plans.createPlan(db.knex, { account_id: account.id, name: 'free' });
+
+        const initial = await accountService.getAccountContext({ secretKey: environment!.secret_key });
+        expect(initial?.auth?.source).toBe('customer_key');
+        const apiKeyId = initial?.auth?.apiKeyId;
+        expect(apiKeyId).toBeDefined();
+
+        const firstLastUsedAt = (await db.knex('customer_keys').select('last_used_at').where({ id: apiKeyId! }).first())?.last_used_at;
+        expect(firstLastUsedAt).toBeTruthy();
+
+        const recentTimestamp = new Date(Date.now() - 5 * 1000);
+        await db.knex('customer_keys').where({ id: apiKeyId! }).update({ last_used_at: recentTimestamp });
+
+        await accountService.getAccountContext({ secretKey: environment!.secret_key });
+        const secondLastUsedAt = (await db.knex('customer_keys').select('last_used_at').where({ id: apiKeyId! }).first())?.last_used_at;
+        expect(new Date(secondLastUsedAt).toISOString()).toBe(recentTimestamp.toISOString());
+
+        const staleTimestamp = new Date(Date.now() - 2 * 60 * 1000);
+        await db.knex('customer_keys').where({ id: apiKeyId! }).update({ last_used_at: staleTimestamp });
+
+        await accountService.getAccountContext({ secretKey: environment!.secret_key });
+        const thirdLastUsedAt = (await db.knex('customer_keys').select('last_used_at').where({ id: apiKeyId! }).first())?.last_used_at;
+        expect(new Date(thirdLastUsedAt).getTime()).toBeGreaterThan(staleTimestamp.getTime());
     });
 
     it('should retrieve account context by publicKey', async () => {
         const account = await createTestAccount();
         const environment = await environmentService.createEnvironment(db.knex, { accountId: account.id, name: uuid() });
         const plan = (await plans.createPlan(db.knex, { account_id: account.id, name: 'free' })).unwrap();
-        const secret = (await secretService.getDefaultSecretForEnv(db.knex, environment!.id)).unwrap();
+        const secret = (await secretService.getInternalSecretForEnv(db.knex, environment!.id)).unwrap();
 
         const byPublicKey = await accountService.getAccountContext({ publicKey: environment!.public_key });
 
@@ -112,7 +249,7 @@ describe('Account service', () => {
         const account = await createTestAccount();
         const environment = await environmentService.createEnvironment(db.knex, { accountId: account.id, name: uuid() });
         const plan = (await plans.createPlan(db.knex, { account_id: account.id, name: 'free' })).unwrap();
-        const secret = (await secretService.getDefaultSecretForEnv(db.knex, environment!.id)).unwrap();
+        const secret = (await secretService.getInternalSecretForEnv(db.knex, environment!.id)).unwrap();
 
         const byUuid = await accountService.getAccountContext({ environmentUuid: environment!.uuid });
 
@@ -144,7 +281,7 @@ describe('Account service', () => {
         const account = await createTestAccount();
         const environment = await environmentService.createEnvironment(db.knex, { accountId: account.id, name: uuid() });
         const plan = (await plans.createPlan(db.knex, { account_id: account.id, name: 'free' })).unwrap();
-        const secret = (await secretService.getDefaultSecretForEnv(db.knex, environment!.id)).unwrap();
+        const secret = (await secretService.getInternalSecretForEnv(db.knex, environment!.id)).unwrap();
 
         const byAccountUuid = await accountService.getAccountContext({ accountUuid: account.uuid, envName: environment!.name });
 
@@ -176,7 +313,7 @@ describe('Account service', () => {
         const account = await createTestAccount();
         const environment = await environmentService.createEnvironment(db.knex, { accountId: account.id, name: uuid() });
         const plan = (await plans.createPlan(db.knex, { account_id: account.id, name: 'free' })).unwrap();
-        const secret = (await secretService.getDefaultSecretForEnv(db.knex, environment!.id)).unwrap();
+        const secret = (await secretService.getInternalSecretForEnv(db.knex, environment!.id)).unwrap();
 
         const byAccountId = await accountService.getAccountContext({ accountId: account.id, envName: environment!.name });
 
@@ -208,7 +345,7 @@ describe('Account service', () => {
         const account = await createTestAccount();
         const environment = await environmentService.createEnvironment(db.knex, { accountId: account.id, name: uuid() });
         const plan = (await plans.createPlan(db.knex, { account_id: account.id, name: 'free' })).unwrap();
-        const secret = (await secretService.getDefaultSecretForEnv(db.knex, environment!.id)).unwrap();
+        const secret = (await secretService.getInternalSecretForEnv(db.knex, environment!.id)).unwrap();
 
         const byEnvironmentId = await accountService.getAccountContext({ environmentId: environment!.id });
 

--- a/packages/shared/lib/services/account.service.ts
+++ b/packages/shared/lib/services/account.service.ts
@@ -536,9 +536,16 @@ class AccountService {
      * environment's internal secret key. Avoids polluting customer_keys.last_used_at.
      */
     private async getAccountContextByInternalSecret(secretKey: string): Promise<AccountContext | null> {
-        const hashed = await secretService.hashSecret(secretKey);
-        if (hashed.isErr()) {
-            throw hashed.error;
+        let hash = hashLocalCache.get(secretKey);
+        if (hash) {
+            metrics.increment(metrics.Types.AUTH_SECRET_KEY_HASH_CACHE, 1, { result: 'hit' });
+        } else {
+            metrics.increment(metrics.Types.AUTH_SECRET_KEY_HASH_CACHE, 1, { result: 'miss' });
+            const hashed = await secretService.hashSecret(secretKey);
+            if (hashed.isErr()) {
+                throw hashed.error;
+            }
+            hash = hashed.value;
         }
 
         const row = await db.readOnly
@@ -565,7 +572,7 @@ class AccountService {
                 j.on('pending_secret.environment_id', '_nango_environments.id').andOn('pending_secret.is_default', db.knex.raw('false'))
             )
             .leftJoin('plans', 'plans.account_id', '_nango_accounts.id')
-            .where('api_secrets.hashed', hashed.value)
+            .where('api_secrets.hashed', hash)
             .where('api_secrets.is_default', true)
             .where('_nango_environments.deleted', false)
             .first();
@@ -573,6 +580,9 @@ class AccountService {
         if (!row) {
             return null;
         }
+
+        // Store only successful lookups to avoid polluting the cache
+        hashLocalCache.set(secretKey, hash);
 
         const defaultSecret = encryptionManager.decryptAPISecret(row.default_secret);
         const pendingKey = row.pending_secret ? encryptionManager.decryptAPISecret(row.pending_secret) : null;

--- a/packages/shared/lib/services/account.service.ts
+++ b/packages/shared/lib/services/account.service.ts
@@ -15,6 +15,18 @@ import type { DBAPISecret, DBEnvironment, DBPlan, DBTeam } from '@nangohq/types'
 
 const hashLocalCache = new FixedSizeMap<string, string>(10_000);
 
+interface AccountContext {
+    account: DBTeam;
+    environment: DBEnvironment;
+    secret: DBAPISecret;
+    plan: DBPlan | null;
+    auth?: {
+        source: 'customer_key' | 'api_secret';
+        scopes?: string[];
+        apiKeyId?: number;
+    };
+}
+
 const freeEmailDomains = new Set([
     'gmail.com',
     'duck.com',
@@ -181,9 +193,7 @@ class AccountService {
         return result || null;
     }
 
-    async getAccountContextBySecretKey(
-        secretKey: string
-    ): Promise<{ account: DBTeam; environment: DBEnvironment; secret: DBAPISecret; plan: DBPlan | null } | null> {
+    async getAccountContextBySecretKey(secretKey: string): Promise<AccountContext | null> {
         if (!isCloud) {
             const environmentVariables = Object.keys(process.env).filter((key) => key.startsWith('NANGO_SECRET_KEY_'));
             if (environmentVariables.length > 0) {
@@ -206,7 +216,19 @@ class AccountService {
                         return null;
                     }
 
-                    return this.getAccountContext({ accountId: env.account_id, envName });
+                    const accountContext = await this.getAccountContext({ accountId: env.account_id, envName });
+
+                    if (!accountContext) {
+                        return null;
+                    }
+
+                    return {
+                        ...accountContext,
+                        auth: {
+                            source: 'api_secret',
+                            scopes: ['environment:*']
+                        }
+                    };
                 }
             }
         }
@@ -214,9 +236,40 @@ class AccountService {
         return this.getAccountContext({ secretKey });
     }
 
-    async getAccountContextByPublicKey(
-        publicKey: string
-    ): Promise<{ account: DBTeam; environment: DBEnvironment; secret: DBAPISecret; plan: DBPlan | null } | null> {
+    /**
+     * Resolve account context using only api_secrets (no customer_keys lookup).
+     * Used by internal services (persist) that authenticate with the
+     * environment's internal secret key. Avoids polluting customer_keys.last_used_at.
+     */
+    async getAccountContextByInternalSecretKey(secretKey: string): Promise<AccountContext | null> {
+        if (!isCloud) {
+            const environmentVariables = Object.keys(process.env).filter((key) => key.startsWith('NANGO_SECRET_KEY_'));
+            for (const environmentVariable of environmentVariables) {
+                const envSecretKey = process.env[environmentVariable] as string;
+                if (envSecretKey !== secretKey) {
+                    continue;
+                }
+                const envName = environmentVariable.replace('NANGO_SECRET_KEY_', '').toLowerCase();
+                const env = await db.knex
+                    .select<Pick<DBEnvironment, 'account_id'>>('account_id')
+                    .from<DBEnvironment>('_nango_environments')
+                    .where({ name: envName, deleted: false })
+                    .first();
+                if (!env) {
+                    return null;
+                }
+                const accountContext = await this.getAccountContext({ accountId: env.account_id, envName });
+                if (!accountContext) {
+                    return null;
+                }
+                return accountContext;
+            }
+        }
+
+        return this.getAccountContext({ internalSecretKey: secretKey });
+    }
+
+    async getAccountContextByPublicKey(publicKey: string): Promise<AccountContext | null> {
         if (!isCloud) {
             const environmentVariables = Object.keys(process.env).filter((key) => key.startsWith('NANGO_PUBLIC_KEY_'));
             if (environmentVariables.length > 0) {
@@ -250,11 +303,19 @@ class AccountService {
         opts:
             | { publicKey: string }
             | { secretKey: string }
+            | { internalSecretKey: string }
             | { accountId: number; envName: string }
             | { environmentId: number }
             | { environmentUuid: string }
             | { accountUuid: string; envName: string }
-    ): Promise<{ account: DBTeam; environment: DBEnvironment; secret: DBAPISecret; plan: DBPlan | null } | null> {
+    ): Promise<AccountContext | null> {
+        if ('secretKey' in opts) {
+            return this.getAccountContextByAnySecret(opts.secretKey);
+        }
+        if ('internalSecretKey' in opts) {
+            return this.getAccountContextByInternalSecret(opts.internalSecretKey);
+        }
+
         const q = db.readOnly
             .select<{
                 account: DBTeam;
@@ -281,23 +342,7 @@ class AccountService {
             .where('_nango_environments.deleted', false)
             .first();
 
-        let hash: string | undefined;
-        if ('secretKey' in opts) {
-            // Hashing is slow by design so it's very slow to recompute this hash all the time
-            // We keep the hash in-memory to not compromise on security if the db leak
-            hash = hashLocalCache.get(opts.secretKey);
-            if (hash) {
-                metrics.increment(metrics.Types.AUTH_SECRET_KEY_HASH_CACHE, 1, { result: 'hit' });
-            } else {
-                metrics.increment(metrics.Types.AUTH_SECRET_KEY_HASH_CACHE, 1, { result: 'miss' });
-                const hashed = await secretService.hashSecret(opts.secretKey);
-                if (hashed.isErr()) {
-                    throw hashed.error;
-                }
-                hash = hashed.value;
-            }
-            q.where('default_secret.hashed', hash);
-        } else if ('publicKey' in opts) {
+        if ('publicKey' in opts) {
             q.where('_nango_environments.public_key', opts.publicKey);
         } else if ('environmentUuid' in opts) {
             q.where('_nango_environments.uuid', opts.environmentUuid);
@@ -314,11 +359,6 @@ class AccountService {
         const res = await q;
         if (!res) {
             return null;
-        }
-
-        if (hash && 'secretKey' in opts) {
-            // store only successful attempt to not pollute the memory
-            hashLocalCache.set(opts.secretKey, hash);
         }
 
         const defaultSecret = encryptionManager.decryptAPISecret(res.default_secret);
@@ -349,6 +389,218 @@ class AccountService {
                       trial_end_notified_at: res.plan.trial_end_notified_at ? new Date(res.plan.trial_end_notified_at) : res.plan.trial_end_notified_at,
                       orb_subscribed_at: res.plan.orb_subscribed_at ? new Date(res.plan.orb_subscribed_at) : res.plan.orb_subscribed_at,
                       orb_future_plan_at: res.plan.orb_future_plan_at ? new Date(res.plan.orb_future_plan_at) : res.plan.orb_future_plan_at
+                  }
+                : null,
+            secret: defaultSecret
+        };
+    }
+
+    private async getAccountContextByAnySecret(secretKey: string): Promise<AccountContext | null> {
+        const cachedHash = hashLocalCache.get(secretKey);
+        let hash: string;
+        if (!cachedHash) {
+            const hashed = await secretService.hashSecret(secretKey);
+            if (hashed.isErr()) {
+                throw hashed.error;
+            }
+            hash = hashed.value;
+        } else {
+            hash = cachedHash;
+        }
+
+        // This query debounces last_used_at in the same statement, so it must run on the primary.
+        // If we later introduce real read replicas for auth lookups, split this into:
+        // 1. read auth context from replica, 2. best-effort debounced update on primary.
+        const {
+            rows: [row]
+        } = await db.knex.raw<{
+            rows: {
+                account: DBTeam;
+                environment: DBEnvironment;
+                plan: DBPlan | null;
+                default_secret: DBAPISecret;
+                pending_secret: DBAPISecret | null;
+                auth_source: 'customer_key' | 'api_secret';
+                auth_scopes: string[] | null;
+                auth_api_key_id: number | null;
+            }[];
+        }>(
+            `
+                WITH matched_customer_key AS (
+                    SELECT ck.id, ckr.entity_id AS environment_id, ck.scopes
+                    FROM customer_keys ck
+                    JOIN customer_keys_relations ckr ON ckr.customer_key_id = ck.id
+                    WHERE ck.hashed = ?
+                      AND ck.key_type = 'api'
+                      AND ck.deleted_at IS NULL
+                      AND ckr.entity_type = 'environment'
+                    LIMIT 1
+                ),
+                updated_customer_key AS (
+                    UPDATE customer_keys ck
+                    SET last_used_at = NOW()
+                    FROM matched_customer_key mck
+                    WHERE ck.id = mck.id
+                      AND (ck.last_used_at IS NULL OR ck.last_used_at < NOW() - INTERVAL '1 minute')
+                    RETURNING ck.id
+                ),
+                matched_auth AS (
+                    SELECT
+                        mck.environment_id,
+                        'customer_key'::text AS auth_source,
+                        mck.scopes AS auth_scopes,
+                        mck.id AS auth_api_key_id
+                    FROM matched_customer_key mck
+                    UNION ALL
+                    SELECT
+                        legacy.environment_id,
+                        'api_secret'::text AS auth_source,
+                        NULL::text[] AS auth_scopes,
+                        NULL::integer AS auth_api_key_id
+                    FROM api_secrets legacy
+                    WHERE legacy.hashed = ?
+                      AND legacy.is_default = true
+                      AND NOT EXISTS (SELECT 1 FROM matched_customer_key)
+                )
+                SELECT
+                    row_to_json(_nango_environments.*) AS environment,
+                    row_to_json(_nango_accounts.*) AS account,
+                    row_to_json(plans.*) AS plan,
+                    row_to_json(default_secret.*) AS default_secret,
+                    row_to_json(pending_secret.*) AS pending_secret,
+                    matched_auth.auth_source,
+                    matched_auth.auth_scopes,
+                    matched_auth.auth_api_key_id
+                FROM matched_auth
+                JOIN _nango_environments ON _nango_environments.id = matched_auth.environment_id
+                JOIN _nango_accounts ON _nango_accounts.id = _nango_environments.account_id
+                JOIN api_secrets AS default_secret
+                    ON default_secret.environment_id = _nango_environments.id
+                   AND default_secret.is_default = true
+                LEFT JOIN api_secrets AS pending_secret
+                    ON pending_secret.environment_id = _nango_environments.id
+                   AND pending_secret.is_default = false
+                LEFT JOIN plans ON plans.account_id = _nango_accounts.id
+                WHERE _nango_environments.deleted = false
+                LIMIT 1;
+            `,
+            [hash, hash]
+        );
+        if (!row) {
+            return null;
+        }
+
+        hashLocalCache.set(secretKey, hash);
+
+        const defaultSecret = encryptionManager.decryptAPISecret(row.default_secret);
+        const pendingKey = row.pending_secret ? encryptionManager.decryptAPISecret(row.pending_secret) : null;
+
+        return {
+            account: {
+                ...row.account,
+                created_at: new Date(row.account.created_at),
+                updated_at: new Date(row.account.updated_at)
+            },
+            environment: {
+                ...row.environment,
+                secret_key: defaultSecret.secret,
+                pending_secret_key: pendingKey?.secret || null,
+                created_at: new Date(row.environment.created_at),
+                updated_at: new Date(row.environment.updated_at),
+                deleted_at: row.environment.deleted_at ? new Date(row.environment.deleted_at) : row.environment.deleted_at
+            },
+            plan: row.plan
+                ? {
+                      ...row.plan,
+                      created_at: new Date(row.plan.created_at),
+                      updated_at: new Date(row.plan.updated_at),
+                      trial_start_at: row.plan.trial_start_at ? new Date(row.plan.trial_start_at) : row.plan.trial_start_at,
+                      trial_end_at: row.plan.trial_end_at ? new Date(row.plan.trial_end_at) : row.plan.trial_end_at,
+                      trial_end_notified_at: row.plan.trial_end_notified_at ? new Date(row.plan.trial_end_notified_at) : row.plan.trial_end_notified_at,
+                      orb_subscribed_at: row.plan.orb_subscribed_at ? new Date(row.plan.orb_subscribed_at) : row.plan.orb_subscribed_at,
+                      orb_future_plan_at: row.plan.orb_future_plan_at ? new Date(row.plan.orb_future_plan_at) : row.plan.orb_future_plan_at
+                  }
+                : null,
+            secret: defaultSecret,
+            auth: {
+                source: row.auth_source,
+                scopes: row.auth_source === 'api_secret' ? ['environment:*'] : (row.auth_scopes ?? []),
+                ...(row.auth_api_key_id ? { apiKeyId: row.auth_api_key_id } : {})
+            }
+        };
+    }
+
+    /**
+     * Resolve account context using only api_secrets (no customer_keys lookup).
+     * Used by internal services (persist, runners) that authenticate with the
+     * environment's internal secret key. Avoids polluting customer_keys.last_used_at.
+     */
+    private async getAccountContextByInternalSecret(secretKey: string): Promise<AccountContext | null> {
+        const hashed = await secretService.hashSecret(secretKey);
+        if (hashed.isErr()) {
+            throw hashed.error;
+        }
+
+        const row = await db.readOnly
+            .select<{
+                account: DBTeam;
+                environment: DBEnvironment;
+                plan: DBPlan | null;
+                default_secret: DBAPISecret;
+                pending_secret: DBAPISecret | null;
+            }>(
+                db.knex.raw('row_to_json(_nango_environments.*) as environment'),
+                db.knex.raw('row_to_json(_nango_accounts.*) as account'),
+                db.knex.raw('row_to_json(plans.*) as plan'),
+                db.knex.raw('row_to_json(default_secret.*) as default_secret'),
+                db.knex.raw('row_to_json(pending_secret.*) as pending_secret')
+            )
+            .from<DBAPISecret>('api_secrets')
+            .join('_nango_environments', '_nango_environments.id', 'api_secrets.environment_id')
+            .join('_nango_accounts', '_nango_accounts.id', '_nango_environments.account_id')
+            .join({ default_secret: 'api_secrets' }, (j) =>
+                j.on('default_secret.environment_id', '_nango_environments.id').andOn('default_secret.is_default', db.knex.raw('true'))
+            )
+            .leftJoin({ pending_secret: 'api_secrets' }, (j) =>
+                j.on('pending_secret.environment_id', '_nango_environments.id').andOn('pending_secret.is_default', db.knex.raw('false'))
+            )
+            .leftJoin('plans', 'plans.account_id', '_nango_accounts.id')
+            .where('api_secrets.hashed', hashed.value)
+            .where('api_secrets.is_default', true)
+            .where('_nango_environments.deleted', false)
+            .first();
+
+        if (!row) {
+            return null;
+        }
+
+        const defaultSecret = encryptionManager.decryptAPISecret(row.default_secret);
+        const pendingKey = row.pending_secret ? encryptionManager.decryptAPISecret(row.pending_secret) : null;
+
+        return {
+            account: {
+                ...row.account,
+                created_at: new Date(row.account.created_at),
+                updated_at: new Date(row.account.updated_at)
+            },
+            environment: {
+                ...row.environment,
+                secret_key: defaultSecret.secret,
+                pending_secret_key: pendingKey?.secret || null,
+                created_at: new Date(row.environment.created_at),
+                updated_at: new Date(row.environment.updated_at),
+                deleted_at: row.environment.deleted_at ? new Date(row.environment.deleted_at) : row.environment.deleted_at
+            },
+            plan: row.plan
+                ? {
+                      ...row.plan,
+                      created_at: new Date(row.plan.created_at),
+                      updated_at: new Date(row.plan.updated_at),
+                      trial_start_at: row.plan.trial_start_at ? new Date(row.plan.trial_start_at) : row.plan.trial_start_at,
+                      trial_end_at: row.plan.trial_end_at ? new Date(row.plan.trial_end_at) : row.plan.trial_end_at,
+                      trial_end_notified_at: row.plan.trial_end_notified_at ? new Date(row.plan.trial_end_notified_at) : row.plan.trial_end_notified_at,
+                      orb_subscribed_at: row.plan.orb_subscribed_at ? new Date(row.plan.orb_subscribed_at) : row.plan.orb_subscribed_at,
+                      orb_future_plan_at: row.plan.orb_future_plan_at ? new Date(row.plan.orb_future_plan_at) : row.plan.orb_future_plan_at
                   }
                 : null,
             secret: defaultSecret

--- a/packages/shared/lib/services/customerKey.service.ts
+++ b/packages/shared/lib/services/customerKey.service.ts
@@ -1,0 +1,315 @@
+import * as uuid from 'uuid';
+
+import { Err, Ok, stringToHash } from '@nangohq/utils';
+
+import encryptionManager, { pbkdf2 } from '../utils/encryption.manager.js';
+import { NangoError } from '../utils/error.js';
+
+import type { DBCustomerKey, DBCustomerKeyRelation, Result } from '@nangohq/types';
+import type { Knex } from 'knex';
+
+const CUSTOMER_KEYS_TABLE = 'customer_keys';
+const CUSTOMER_KEYS_RELATIONS_TABLE = 'customer_keys_relations';
+// Internal safety limit — not a product constraint, just prevents unbounded key creation.
+// Can be raised without migration if needed.
+export const MAX_API_KEYS_PER_ENV = 50;
+
+class CustomerKeyService {
+    private async acquireNameLock(trx: Knex, accountId: number, keyType: string): Promise<void> {
+        const lockKey = stringToHash(`customer_key_name:${accountId}:${keyType}`);
+        await trx.raw(`SELECT pg_advisory_xact_lock(?) as "lock_customer_key_name_${keyType}"`, [lockKey]);
+    }
+    public async createApiKey(
+        trx: Knex,
+        {
+            accountId,
+            environmentId,
+            displayName,
+            scopes = ['environment:*'],
+            secret: providedSecret
+        }: {
+            accountId: number;
+            environmentId: number;
+            displayName: string;
+            scopes?: string[];
+            secret?: string;
+        }
+    ): Promise<Result<DBCustomerKey>> {
+        try {
+            const plainText = providedSecret ?? uuid.v4();
+
+            const hashed = await this.hashSecret(plainText);
+            if (hashed.isErr()) {
+                throw hashed.error;
+            }
+
+            const created = await trx.transaction(async (innerTrx) => {
+                await this.acquireNameLock(innerTrx, accountId, 'api');
+
+                // Check name uniqueness within the environment
+                const existing = await innerTrx<DBCustomerKey>(CUSTOMER_KEYS_TABLE)
+                    .select(`${CUSTOMER_KEYS_TABLE}.id`)
+                    .join(CUSTOMER_KEYS_RELATIONS_TABLE, `${CUSTOMER_KEYS_RELATIONS_TABLE}.customer_key_id`, `${CUSTOMER_KEYS_TABLE}.id`)
+                    .where(`${CUSTOMER_KEYS_TABLE}.key_type`, 'api')
+                    .where(`${CUSTOMER_KEYS_TABLE}.display_name`, displayName)
+                    .where(`${CUSTOMER_KEYS_RELATIONS_TABLE}.entity_type`, 'environment')
+                    .where(`${CUSTOMER_KEYS_RELATIONS_TABLE}.entity_id`, environmentId)
+                    .whereNull(`${CUSTOMER_KEYS_TABLE}.deleted_at`)
+                    .first();
+
+                if (existing) {
+                    throw new NangoError('duplicate_api_key', { display_name: displayName });
+                }
+
+                // Check max keys per environment
+                const count = await innerTrx<DBCustomerKey>(CUSTOMER_KEYS_TABLE)
+                    .join(CUSTOMER_KEYS_RELATIONS_TABLE, `${CUSTOMER_KEYS_RELATIONS_TABLE}.customer_key_id`, `${CUSTOMER_KEYS_TABLE}.id`)
+                    .where(`${CUSTOMER_KEYS_TABLE}.key_type`, 'api')
+                    .where(`${CUSTOMER_KEYS_RELATIONS_TABLE}.entity_type`, 'environment')
+                    .where(`${CUSTOMER_KEYS_RELATIONS_TABLE}.entity_id`, environmentId)
+                    .whereNull(`${CUSTOMER_KEYS_TABLE}.deleted_at`)
+                    .count('* as total')
+                    .first();
+                if (count && Number(count['total']) >= MAX_API_KEYS_PER_ENV) {
+                    throw new NangoError('resource_capped', { max: MAX_API_KEYS_PER_ENV });
+                }
+
+                const customerKey = {
+                    account_id: accountId,
+                    key_type: 'api' as const,
+                    display_name: displayName,
+                    scopes,
+                    secret: plainText,
+                    iv: '',
+                    tag: '',
+                    hashed: hashed.value,
+                    last_used_at: null,
+                    deleted_at: null
+                } satisfies Partial<DBCustomerKey>;
+
+                const encrypted = encryptionManager.encryptAPISecret(
+                    customerKey as Parameters<typeof encryptionManager.encryptAPISecret>[0]
+                ) as typeof customerKey;
+
+                const [row] = await innerTrx<DBCustomerKey>(CUSTOMER_KEYS_TABLE).insert(encrypted).returning('*');
+                if (!row) {
+                    throw new NangoError('impossible_condition');
+                }
+
+                await innerTrx<DBCustomerKeyRelation>(CUSTOMER_KEYS_RELATIONS_TABLE).insert({
+                    customer_key_id: row.id,
+                    entity_type: 'environment',
+                    entity_id: environmentId
+                });
+
+                return row;
+            });
+
+            created.secret = plainText; // Callers expect unencrypted secret.
+            return Ok(created);
+        } catch (err) {
+            return Err(err);
+        }
+    }
+
+    public async createWebhookSigningKey(
+        trx: Knex,
+        {
+            accountId,
+            environmentId,
+            secret: providedSecret
+        }: {
+            accountId: number;
+            environmentId: number;
+            secret?: string;
+        }
+    ): Promise<Result<DBCustomerKey>> {
+        try {
+            const plainText = providedSecret ?? uuid.v4();
+
+            const hashed = await this.hashSecret(plainText);
+            if (hashed.isErr()) {
+                throw hashed.error;
+            }
+
+            const customerKey = {
+                account_id: accountId,
+                key_type: 'webhook_signing' as const,
+                display_name: 'Webhook signing',
+                scopes: null,
+                secret: plainText,
+                iv: '',
+                tag: '',
+                hashed: hashed.value,
+                last_used_at: null,
+                deleted_at: null
+            } satisfies Partial<DBCustomerKey>;
+
+            const encrypted = encryptionManager.encryptAPISecret(customerKey as Parameters<typeof encryptionManager.encryptAPISecret>[0]) as typeof customerKey;
+
+            const [created] = await trx<DBCustomerKey>(CUSTOMER_KEYS_TABLE).insert(encrypted).returning('*');
+            if (!created) {
+                throw new NangoError('impossible_condition');
+            }
+
+            await trx<DBCustomerKeyRelation>(CUSTOMER_KEYS_RELATIONS_TABLE).insert({
+                customer_key_id: created.id,
+                entity_type: 'environment',
+                entity_id: environmentId
+            });
+
+            created.secret = plainText; // Callers expect unencrypted secret.
+            return Ok(created);
+        } catch (err) {
+            return Err(err);
+        }
+    }
+
+    public async getApiKeysByEnv(trx: Knex, envId: number): Promise<Result<DBCustomerKey[]>> {
+        try {
+            const rows = await trx<DBCustomerKey>(CUSTOMER_KEYS_TABLE)
+                .select(`${CUSTOMER_KEYS_TABLE}.*`)
+                .join(CUSTOMER_KEYS_RELATIONS_TABLE, `${CUSTOMER_KEYS_RELATIONS_TABLE}.customer_key_id`, `${CUSTOMER_KEYS_TABLE}.id`)
+                .where(`${CUSTOMER_KEYS_RELATIONS_TABLE}.entity_type`, 'environment')
+                .where(`${CUSTOMER_KEYS_RELATIONS_TABLE}.entity_id`, envId)
+                .where(`${CUSTOMER_KEYS_TABLE}.key_type`, 'api')
+                .whereNull(`${CUSTOMER_KEYS_TABLE}.deleted_at`)
+                .orderBy(`${CUSTOMER_KEYS_TABLE}.display_name`, 'asc');
+
+            const decrypted = rows.map(
+                (row) => encryptionManager.decryptAPISecret(row as Parameters<typeof encryptionManager.decryptAPISecret>[0]) as DBCustomerKey
+            );
+            return Ok(decrypted);
+        } catch (err) {
+            return Err(err);
+        }
+    }
+
+    public async getWebhookSigningKeyForEnv(trx: Knex, envId: number): Promise<Result<DBCustomerKey>> {
+        try {
+            const row = await trx<DBCustomerKey>(CUSTOMER_KEYS_TABLE)
+                .select(`${CUSTOMER_KEYS_TABLE}.*`)
+                .join(CUSTOMER_KEYS_RELATIONS_TABLE, `${CUSTOMER_KEYS_RELATIONS_TABLE}.customer_key_id`, `${CUSTOMER_KEYS_TABLE}.id`)
+                .where(`${CUSTOMER_KEYS_TABLE}.key_type`, 'webhook_signing')
+                .where(`${CUSTOMER_KEYS_RELATIONS_TABLE}.entity_type`, 'environment')
+                .where(`${CUSTOMER_KEYS_RELATIONS_TABLE}.entity_id`, envId)
+                .whereNull(`${CUSTOMER_KEYS_TABLE}.deleted_at`)
+                .first();
+
+            if (!row) {
+                throw new NangoError('no_webhook_signing_key', { environment_id: envId });
+            }
+
+            const decrypted = encryptionManager.decryptAPISecret(row as Parameters<typeof encryptionManager.decryptAPISecret>[0]) as DBCustomerKey;
+            return Ok(decrypted);
+        } catch (err) {
+            return Err(err);
+        }
+    }
+
+    public async renameApiKey(trx: Knex, keyId: number, displayName: string, envId: number, accountId: number): Promise<Result<void>> {
+        try {
+            await trx.transaction(async (innerTrx) => {
+                await this.acquireNameLock(innerTrx, accountId, 'api');
+
+                // Check uniqueness: no other API key in the same environment should have this name
+                const existing = await innerTrx<DBCustomerKey>(CUSTOMER_KEYS_TABLE)
+                    .select(`${CUSTOMER_KEYS_TABLE}.id`)
+                    .join(CUSTOMER_KEYS_RELATIONS_TABLE, `${CUSTOMER_KEYS_RELATIONS_TABLE}.customer_key_id`, `${CUSTOMER_KEYS_TABLE}.id`)
+                    .where(`${CUSTOMER_KEYS_TABLE}.key_type`, 'api')
+                    .where(`${CUSTOMER_KEYS_TABLE}.display_name`, displayName)
+                    .where(`${CUSTOMER_KEYS_RELATIONS_TABLE}.entity_type`, 'environment')
+                    .where(`${CUSTOMER_KEYS_RELATIONS_TABLE}.entity_id`, envId)
+                    .whereNull(`${CUSTOMER_KEYS_TABLE}.deleted_at`)
+                    .whereNot(`${CUSTOMER_KEYS_TABLE}.id`, keyId)
+                    .first();
+
+                if (existing) {
+                    throw new NangoError('duplicate_api_key', { display_name: displayName });
+                }
+
+                const updated = await innerTrx<DBCustomerKey>(CUSTOMER_KEYS_TABLE)
+                    .where(`${CUSTOMER_KEYS_TABLE}.id`, keyId)
+                    .where(`${CUSTOMER_KEYS_TABLE}.key_type`, 'api')
+                    .whereNull(`${CUSTOMER_KEYS_TABLE}.deleted_at`)
+                    .whereExists(function () {
+                        void this.select(innerTrx.raw('1'))
+                            .from(CUSTOMER_KEYS_RELATIONS_TABLE)
+                            .whereRaw(`${CUSTOMER_KEYS_RELATIONS_TABLE}.customer_key_id = ${CUSTOMER_KEYS_TABLE}.id`)
+                            .whereRaw(`${CUSTOMER_KEYS_RELATIONS_TABLE}.entity_type = ?`, ['environment'])
+                            .whereRaw(`${CUSTOMER_KEYS_RELATIONS_TABLE}.entity_id = ?`, [envId]);
+                    })
+                    .update({ display_name: displayName, updated_at: innerTrx.fn.now() as unknown as Date });
+                if (updated === 0) {
+                    throw new NangoError('no_such_api_secret', { id: keyId });
+                }
+            });
+            return Ok();
+        } catch (err) {
+            return Err(err);
+        }
+    }
+
+    public async updateApiKeyScopes(trx: Knex, keyId: number, scopes: string[], envId: number): Promise<Result<void>> {
+        try {
+            const updated = await trx<DBCustomerKey>(CUSTOMER_KEYS_TABLE)
+                .where(`${CUSTOMER_KEYS_TABLE}.id`, keyId)
+                .where(`${CUSTOMER_KEYS_TABLE}.key_type`, 'api')
+                .whereNull(`${CUSTOMER_KEYS_TABLE}.deleted_at`)
+                .whereExists(function () {
+                    void this.select(trx.raw('1'))
+                        .from(CUSTOMER_KEYS_RELATIONS_TABLE)
+                        .whereRaw(`${CUSTOMER_KEYS_RELATIONS_TABLE}.customer_key_id = ${CUSTOMER_KEYS_TABLE}.id`)
+                        .whereRaw(`${CUSTOMER_KEYS_RELATIONS_TABLE}.entity_type = ?`, ['environment'])
+                        .whereRaw(`${CUSTOMER_KEYS_RELATIONS_TABLE}.entity_id = ?`, [envId]);
+                })
+                .update({ scopes, updated_at: trx.fn.now() as unknown as Date });
+            if (updated === 0) {
+                return Err(new NangoError('no_such_api_secret', { id: keyId }));
+            }
+            return Ok();
+        } catch (err) {
+            return Err(err);
+        }
+    }
+
+    public async deleteCustomerKey(trx: Knex, keyId: number, envId: number): Promise<Result<void>> {
+        try {
+            const updated = await trx<DBCustomerKey>(CUSTOMER_KEYS_TABLE)
+                .where(`${CUSTOMER_KEYS_TABLE}.id`, keyId)
+                .where(`${CUSTOMER_KEYS_TABLE}.key_type`, 'api')
+                .whereNull(`${CUSTOMER_KEYS_TABLE}.deleted_at`)
+                .whereExists(function () {
+                    void this.select(trx.raw('1'))
+                        .from(CUSTOMER_KEYS_RELATIONS_TABLE)
+                        .whereRaw(`${CUSTOMER_KEYS_RELATIONS_TABLE}.customer_key_id = ${CUSTOMER_KEYS_TABLE}.id`)
+                        .whereRaw(`${CUSTOMER_KEYS_RELATIONS_TABLE}.entity_type = ?`, ['environment'])
+                        .whereRaw(`${CUSTOMER_KEYS_RELATIONS_TABLE}.entity_id = ?`, [envId]);
+                })
+                .update({
+                    deleted_at: trx.fn.now() as unknown as Date
+                });
+            if (updated === 0) {
+                return Err(new NangoError('no_such_api_secret', { id: keyId }));
+            }
+            return Ok();
+        } catch (err) {
+            return Err(err);
+        }
+    }
+
+    private async hashSecret(plainText: string): Promise<Result<string>> {
+        try {
+            if (!encryptionManager.shouldEncrypt()) {
+                return Ok(plainText);
+            }
+            const key = encryptionManager.getKey();
+            const hash = (await pbkdf2(plainText, key, 310000, 32, 'sha256')).toString('base64');
+            return Ok(hash);
+        } catch (err) {
+            return Err(err);
+        }
+    }
+}
+
+export default new CustomerKeyService();

--- a/packages/shared/lib/services/environment.service.integration.test.ts
+++ b/packages/shared/lib/services/environment.service.integration.test.ts
@@ -60,7 +60,7 @@ describe('Environment service', () => {
         expect(env.secret_key).toBeUUID();
         expect(env.pending_secret_key).toBeNull();
 
-        const secret = (await secretService.getDefaultSecretForEnv(db.knex, env.id)).unwrap();
+        const secret = (await secretService.getInternalSecretForEnv(db.knex, env.id)).unwrap();
         expect(secret.is_default).toBe(true);
         expect(secret.secret).toEqual(env.secret_key);
 
@@ -71,7 +71,7 @@ describe('Environment service', () => {
         expect(env2.secret_key).toEqual(env.secret_key);
         expect(env2.pending_secret_key).toBeUUID();
 
-        const secret2 = (await secretService.getDefaultSecretForEnv(db.knex, env.id)).unwrap();
+        const secret2 = (await secretService.getInternalSecretForEnv(db.knex, env.id)).unwrap();
         expect(secret2).toEqual(secret);
 
         // Activate
@@ -81,7 +81,7 @@ describe('Environment service', () => {
         expect(env3.secret_key).toBeUUID();
         expect(env3.pending_secret_key).toBeNull();
 
-        const secret3 = (await secretService.getDefaultSecretForEnv(db.knex, env.id)).unwrap();
+        const secret3 = (await secretService.getInternalSecretForEnv(db.knex, env.id)).unwrap();
         expect(secret3).not.toEqual(secret2);
         expect(secret3.is_default).toBe(true);
         expect(secret3.secret).toEqual(env3.secret_key);

--- a/packages/shared/lib/services/environment.service.ts
+++ b/packages/shared/lib/services/environment.service.ts
@@ -5,6 +5,7 @@ import db from '@nangohq/database';
 
 import { PROD_ENVIRONMENT_NAME } from '../constants.js';
 import { configService, externalWebhookService, getGlobalOAuthCallbackUrl } from '../index.js';
+import customerKeyService from './customerKey.service.js';
 import secretService from './secret.service.js';
 import { LogActionEnum } from '../models/Telemetry.js';
 import encryptionManager from '../utils/encryption.manager.js';
@@ -91,7 +92,7 @@ class EnvironmentService {
                 trx.rollback();
                 return null;
             }
-            // Invariant: Every environment always has one default key.
+            // Invariant: Every environment always has one default key (used by runners for persist auth).
             const created = await secretService.createSecret(trx, {
                 environmentId: environment.id,
                 displayName: 'default',
@@ -103,6 +104,26 @@ class EnvironmentService {
             const secret = created.value;
             environment.secret_key = secret.secret;
             environment.pending_secret_key = null;
+
+            const apiKey = await customerKeyService.createApiKey(trx, {
+                accountId: accountId,
+                environmentId: environment.id,
+                displayName: 'Default - Full access',
+                secret: secret.secret
+            });
+            if (apiKey.isErr()) {
+                throw apiKey.error;
+            }
+
+            const webhookKey = await customerKeyService.createWebhookSigningKey(trx, {
+                accountId: accountId,
+                environmentId: environment.id,
+                secret: secret.secret
+            });
+            if (webhookKey.isErr()) {
+                throw webhookKey.error;
+            }
+
             return environment;
         });
     }
@@ -298,7 +319,7 @@ class EnvironmentService {
                 environment_id: environment.id,
                 is_default: false
             });
-            return secretService.getDefaultSecretForEnv(trx, envId);
+            return secretService.getInternalSecretForEnv(trx, envId);
         });
         if (defaultSecret === null) {
             return null;

--- a/packages/shared/lib/services/secret.service.integration.test.ts
+++ b/packages/shared/lib/services/secret.service.integration.test.ts
@@ -22,8 +22,8 @@ describe('Secret service', () => {
 
     it('creates a default secret for each environment', async () => {
         const env = await newEnv();
-        // Note: getDefaultSecretForEnv will throw if no default secret exists.
-        (await secretService.getDefaultSecretForEnv(db.knex, env.id)).unwrap();
+        // Note: getInternalSecretForEnv will throw if no default secret exists.
+        (await secretService.getInternalSecretForEnv(db.knex, env.id)).unwrap();
     });
 
     it('refuses to create two default secrets', async () => {
@@ -55,7 +55,7 @@ describe('Secret service', () => {
             })
         ).unwrap();
         (await secretService.markDefault(db.knex, secret.id)).unwrap();
-        const newDefault = (await secretService.getDefaultSecretForEnv(db.knex, env.id)).unwrap();
+        const newDefault = (await secretService.getInternalSecretForEnv(db.knex, env.id)).unwrap();
         expect(newDefault.id).toEqual(secret.id);
     });
 

--- a/packages/shared/lib/services/secret.service.ts
+++ b/packages/shared/lib/services/secret.service.ts
@@ -11,7 +11,7 @@ import type { Knex } from 'knex';
 const API_SECRETS_TABLE = 'api_secrets';
 
 class SecretService {
-    public async getDefaultSecretForEnv(trx: Knex, envId: number): Promise<Result<DBAPISecret>> {
+    public async getInternalSecretForEnv(trx: Knex, envId: number): Promise<Result<DBAPISecret>> {
         try {
             const [secret] = await trx<DBAPISecret>(API_SECRETS_TABLE).select('*').where({
                 environment_id: envId,

--- a/packages/shared/lib/utils/encryption.manager.integration.test.ts
+++ b/packages/shared/lib/utils/encryption.manager.integration.test.ts
@@ -69,7 +69,7 @@ describe('encryption', () => {
             const { env } = await seedAccountEnvAndUser();
             expect(env.secret_key).toBeUUID();
 
-            const defaultSecret = (await secretService.getDefaultSecretForEnv(db.knex, env.id)).unwrap();
+            const defaultSecret = (await secretService.getInternalSecretForEnv(db.knex, env.id)).unwrap();
             expect(defaultSecret.secret).toBeUUID();
             expect(defaultSecret.secret).toEqual(env.secret_key);
             expect(defaultSecret.iv).toEqual('');
@@ -83,7 +83,7 @@ describe('encryption', () => {
             const envAfterEnc = (await environmentService.getById(env.id))!;
             expect(envAfterEnc.secret_key).toEqual(env.secret_key);
 
-            const defaultSecretAfterEnc = (await secretService.getDefaultSecretForEnv(db.knex, env.id)).unwrap();
+            const defaultSecretAfterEnc = (await secretService.getInternalSecretForEnv(db.knex, env.id)).unwrap();
             expect(defaultSecretAfterEnc.secret).toBeUUID();
             expect(defaultSecretAfterEnc.secret).toEqual(env.secret_key);
         });

--- a/packages/shared/lib/utils/encryption.manager.ts
+++ b/packages/shared/lib/utils/encryption.manager.ts
@@ -8,7 +8,7 @@ import { isConnectionJsonRow } from '../services/connections/utils.js';
 import secretService from '../services/secret.service.js';
 
 import type { Config as ProviderConfig } from '../models/Provider.js';
-import type { DBAPISecret, DBConfig, DBConnection, DBConnectionAsJSONRow, DBConnectionDecrypted, DBEnvironmentVariable } from '@nangohq/types';
+import type { DBAPISecret, DBConfig, DBConnection, DBConnectionAsJSONRow, DBConnectionDecrypted, DBCustomerKey, DBEnvironmentVariable } from '@nangohq/types';
 
 const logger = getLogger('Encryption.Manager');
 
@@ -279,6 +279,21 @@ export class EncryptionManager extends Encryption {
             environmentVariable.value_tag = authTag;
 
             await db.knex.from<DBEnvironmentVariable>(`_nango_environment_variables`).where({ id: environmentVariable.id }).update(environmentVariable);
+        }
+
+        const customerKeys = await db.knex.select('*').from<DBCustomerKey>('customer_keys');
+        for (const key of customerKeys) {
+            if (key.iv && key.tag) {
+                continue;
+            }
+            const encrypted = this.encryptAPISecret(key);
+            const hashed = await secretService.hashSecret(key.secret);
+            if (hashed.isErr()) {
+                throw hashed.error;
+            }
+            encrypted.hashed = hashed.value;
+            encrypted.updated_at = new Date();
+            await db.knex<DBCustomerKey>('customer_keys').where({ id: key.id }).update(encrypted);
         }
 
         logger.info('🔐✅ Encryption of database complete!');

--- a/packages/types/lib/api-keys/scopes.ts
+++ b/packages/types/lib/api-keys/scopes.ts
@@ -1,0 +1,44 @@
+export const API_KEY_SCOPES = [
+    'environment:*',
+    // Integrations
+    'environment:integrations:list',
+    'environment:integrations:list_credentials',
+    'environment:integrations:read',
+    'environment:integrations:read_credentials',
+    'environment:integrations:write',
+    'environment:integrations:*',
+    // Connections
+    'environment:connections:list',
+    'environment:connections:list_credentials',
+    'environment:connections:read',
+    'environment:connections:read_credentials',
+    'environment:connections:write',
+    'environment:connections:*',
+    // Connect Sessions
+    'environment:connect_sessions:write',
+    // Syncs
+    'environment:syncs:read',
+    'environment:syncs:execute',
+    'environment:syncs:manage',
+    'environment:syncs:*',
+    // Deploy
+    'environment:deploy',
+    // Records
+    'environment:records:read',
+    'environment:records:write',
+    'environment:records:*',
+    // Actions
+    'environment:actions:execute',
+    'environment:actions:*',
+    // Proxy
+    'environment:proxy',
+    // Config
+    'environment:config:read',
+    'environment:config:*',
+    // MCP
+    'environment:mcp'
+] as const;
+
+export type ApiKeyScope = (typeof API_KEY_SCOPES)[number];
+
+export const ALL_SCOPES: string[] = [...API_KEY_SCOPES];

--- a/packages/types/lib/api.endpoints.ts
+++ b/packages/types/lib/api.endpoints.ts
@@ -48,7 +48,17 @@ import type {
 } from './connection/api/get.js';
 import type { SetMetadata, UpdateMetadata } from './connection/api/metadata.js';
 import type { PostDeploy, PostDeployConfirmation, PostDeployInternal } from './deploy/api.js';
-import type { DeleteEnvironment, GetEnvironment, GetEnvironments, PatchEnvironment, PostEnvironment } from './environment/api/index.js';
+import type {
+    CreateApiKey,
+    DeleteApiKey,
+    DeleteEnvironment,
+    GetEnvironment,
+    GetEnvironments,
+    ListApiKeys,
+    PatchApiKey,
+    PatchEnvironment,
+    PostEnvironment
+} from './environment/api/index.js';
 import type { PatchWebhook } from './environment/api/webhook.js';
 import type { PostEnvironmentVariables } from './environment/variable/api.js';
 import type { PatchFlowDisable, PatchFlowEnable, PatchFlowFrequency, PostPreBuiltDeploy, PutUpgradePreBuiltFlow } from './flow/http.api.js';
@@ -185,6 +195,10 @@ export type PrivateApiEndpoints =
     | DeleteEnvironment
     | GetEnvironments
     | GetEnvironment
+    | ListApiKeys
+    | CreateApiKey
+    | DeleteApiKey
+    | PatchApiKey
     | PatchWebhook
     | PostEnvironmentVariables
     | PostImpersonate

--- a/packages/types/lib/environment/api/index.ts
+++ b/packages/types/lib/environment/api/index.ts
@@ -1,3 +1,4 @@
+import type { ApiKeyScope } from '../../api-keys/scopes.js';
 import type { ApiError, ApiTimestamps, Endpoint } from '../../api.js';
 import type { ApiPlan } from '../../plans/http.api.js';
 import type { DBEnvironment, DBExternalWebhook } from '../db.js';
@@ -38,6 +39,7 @@ export type GetEnvironment = Endpoint<{
             name: string;
             email: string;
             slack_notifications_channel: string | null;
+            webhook_signing_key: string | null;
         };
     };
 }>;
@@ -72,4 +74,57 @@ export type GetPublicEnvironmentVariables = Endpoint<{
     Method: 'GET';
     Path: '/api/v1/environment-variables';
     Success: { name: string; value: string }[];
+}>;
+
+export type ListApiKeys = Endpoint<{
+    Method: 'GET';
+    Path: '/api/v1/environment/api-keys';
+    Success: {
+        data: {
+            id: number;
+            display_name: string;
+            scopes: ApiKeyScope[];
+            secret: string;
+            last_used_at: string | null;
+            created_at: string;
+        }[];
+    };
+}>;
+
+export type CreateApiKey = Endpoint<{
+    Method: 'POST';
+    Path: '/api/v1/environment/api-keys';
+    Body: {
+        display_name: string;
+        scopes?: ApiKeyScope[];
+    };
+    Success: {
+        data: {
+            id: number;
+            display_name: string;
+            scopes: ApiKeyScope[];
+            secret: string;
+            created_at: string;
+        };
+    };
+    Error: ApiError<'conflict' | 'resource_capped'>;
+}>;
+
+export type DeleteApiKey = Endpoint<{
+    Method: 'DELETE';
+    Path: '/api/v1/environment/api-keys/:keyId';
+    Params: { keyId: number };
+    Success: { success: true };
+}>;
+
+export type PatchApiKey = Endpoint<{
+    Method: 'PATCH';
+    Path: '/api/v1/environment/api-keys/:keyId';
+    Params: { keyId: number };
+    Body: {
+        scopes?: ApiKeyScope[];
+        display_name?: string;
+    };
+    Success: { success: true };
+    Error: ApiError<'conflict' | 'not_found'>;
 }>;

--- a/packages/types/lib/environment/db.ts
+++ b/packages/types/lib/environment/db.ts
@@ -78,3 +78,27 @@ export interface DBAPISecret extends Timestamps {
     hashed: string;
     is_default: boolean;
 }
+
+export type CustomerKeyType = 'api' | 'webhook_signing';
+
+export interface DBCustomerKey extends Timestamps {
+    id: number;
+    account_id: number;
+    key_type: CustomerKeyType;
+    display_name: string;
+    scopes: string[] | null;
+    secret: string;
+    iv: string;
+    tag: string;
+    hashed: string;
+    last_used_at: Date | null;
+    deleted_at: Date | null;
+}
+
+export type CustomerKeyEntityType = 'environment' | 'account';
+
+export interface DBCustomerKeyRelation {
+    customer_key_id: number;
+    entity_type: CustomerKeyEntityType;
+    entity_id: number;
+}

--- a/packages/types/lib/index.ts
+++ b/packages/types/lib/index.ts
@@ -72,6 +72,8 @@ export type * from './dbConfig/db.js';
 export type * from './nangoYaml/index.js';
 
 export type * from './environment/db.js';
+export { ALL_SCOPES, API_KEY_SCOPES } from './api-keys/scopes.js';
+export type { ApiKeyScope } from './api-keys/scopes.js';
 export type * from './environment/api/index.js';
 export type * from './environment/api/webhook.js';
 export type * from './environment/api/otlp.js';

--- a/packages/utils/lib/api-key-scopes.ts
+++ b/packages/utils/lib/api-key-scopes.ts
@@ -1,0 +1,42 @@
+import type { ApiKeyScope } from '@nangohq/types';
+
+export const apiKeyScopes = [
+    'environment:*',
+    // Integrations
+    'environment:integrations:list',
+    'environment:integrations:list_credentials',
+    'environment:integrations:read',
+    'environment:integrations:read_credentials',
+    'environment:integrations:write',
+    'environment:integrations:*',
+    // Connections
+    'environment:connections:list',
+    'environment:connections:list_credentials',
+    'environment:connections:read',
+    'environment:connections:read_credentials',
+    'environment:connections:write',
+    'environment:connections:*',
+    // Connect Sessions
+    'environment:connect_sessions:write',
+    // Syncs
+    'environment:syncs:read',
+    'environment:syncs:execute',
+    'environment:syncs:manage',
+    'environment:syncs:*',
+    // Deploy
+    'environment:deploy',
+    // Records
+    'environment:records:read',
+    'environment:records:write',
+    'environment:records:*',
+    // Actions
+    'environment:actions:execute',
+    'environment:actions:*',
+    // Proxy
+    'environment:proxy',
+    // Config
+    'environment:config:read',
+    'environment:config:*',
+    // MCP
+    'environment:mcp'
+] as const satisfies readonly ApiKeyScope[];

--- a/packages/utils/lib/index.ts
+++ b/packages/utils/lib/index.ts
@@ -1,4 +1,5 @@
 export * from './roles.js';
+export * from './api-key-scopes.js';
 export * from './environment/constants.js';
 export * from './environment/detection.js';
 export * from './environment/parse.js';

--- a/packages/utils/lib/telemetry/metrics.ts
+++ b/packages/utils/lib/telemetry/metrics.ts
@@ -8,6 +8,7 @@ export enum Types {
     AUTH_SECRET_KEY_HASH_CACHE = 'nango.auth.secretKeyHashCache',
     AUTH_GET_ENV_BY_CONNECT_SESSION = 'nango.auth.getEnvByConnectSession',
     AUTH_GET_ENV_BY_SECRET_KEY = 'nango.auth.getEnvBySecretKey',
+    AUTH_GET_ENV_BY_SECRET_KEY_SOURCE = 'nango.auth.getEnvBySecretKey.source',
     AUTH_GET_ENV_BY_CONNECT_SESSION_OR_SECRET_KEY = 'nango.auth.getEnvByConnectSessionOrSecretKey',
     AUTH_GET_ENV_BY_CONNECT_SESSION_OR_PUBLIC_KEY = 'nango.auth.getEnvByConnectSessionOrPublicKey',
     AUTH_WITH_PUBLIC_KEY = 'nango.auth.withPublicKey',

--- a/packages/webapp/src/components-v2/DestructiveActionModal.tsx
+++ b/packages/webapp/src/components-v2/DestructiveActionModal.tsx
@@ -35,16 +35,16 @@ export const DestructiveActionModal: React.FC<DestructiveActionModalProps> = ({
     return (
         <Dialog open={open} onOpenChange={onOpenChange}>
             {trigger && <DialogTrigger>{trigger}</DialogTrigger>}
-            <DialogContent>
+            <DialogContent className="gap-6">
                 <DialogTitle>{title}</DialogTitle>
-                <DialogDescription>{description}</DialogDescription>
+                <DialogDescription className="-mt-3">{description}</DialogDescription>
 
-                <div className="mt-4 flex flex-col gap-4">
+                <div className="flex flex-col gap-2">
                     <p className="text-sm text-white break-words">{inputLabel}</p>
                     <Input value={confirmText} onChange={(e) => setConfirmText(e.target.value)} placeholder="Enter confirmation text" className="w-full" />
                 </div>
 
-                <DialogFooter className="mt-4">
+                <DialogFooter>
                     <DialogClose asChild>
                         <Button variant="secondary">{cancelButtonText}</Button>
                     </DialogClose>

--- a/packages/webapp/src/hooks/useApiKeys.tsx
+++ b/packages/webapp/src/hooks/useApiKeys.tsx
@@ -1,0 +1,97 @@
+import { useMutation, useQuery, useQueryClient } from '@tanstack/react-query';
+
+import { APIError, apiFetch } from '../utils/api';
+
+export interface ApiKeyListItem {
+    id: number;
+    display_name: string;
+    scopes: string[];
+    secret: string;
+    last_used_at: string | null;
+    created_at: string;
+    updated_at: string;
+}
+
+export const apiKeysQueryKey = (env: string) => [env, 'api-keys'] as const;
+
+export function useApiKeys(env: string) {
+    return useQuery<{ data: ApiKeyListItem[] }, APIError>({
+        enabled: Boolean(env),
+        queryKey: apiKeysQueryKey(env),
+        queryFn: async (): Promise<{ data: ApiKeyListItem[] }> => {
+            const res = await apiFetch(`/api/v1/environment/api-keys?env=${env}`);
+
+            const json = (await res.json()) as { data: ApiKeyListItem[] } | { error: unknown };
+            if (!res.ok || 'error' in json) {
+                throw new APIError({ res, json: json as Record<string, unknown> });
+            }
+
+            return json as { data: ApiKeyListItem[] };
+        }
+    });
+}
+
+export function useCreateApiKey(env: string) {
+    const queryClient = useQueryClient();
+    return useMutation<{ data: ApiKeyListItem }, APIError, { display_name: string; scopes?: string[] }>({
+        mutationFn: async (body) => {
+            const res = await apiFetch(`/api/v1/environment/api-keys?env=${env}`, {
+                method: 'POST',
+                body: JSON.stringify(body)
+            });
+
+            const json = (await res.json()) as { data: ApiKeyListItem } | { error: unknown };
+            if (!res.ok || 'error' in json) {
+                throw new APIError({ res, json: json as Record<string, unknown> });
+            }
+
+            return json as { data: ApiKeyListItem };
+        },
+        onSuccess: async () => {
+            await queryClient.invalidateQueries({ queryKey: apiKeysQueryKey(env) });
+        }
+    });
+}
+
+export function useUpdateApiKey(env: string) {
+    const queryClient = useQueryClient();
+    return useMutation<undefined, APIError, { keyId: number; scopes?: string[]; display_name?: string }>({
+        mutationFn: async ({ keyId, ...body }) => {
+            const res = await apiFetch(`/api/v1/environment/api-keys/${keyId}?env=${env}`, {
+                method: 'PATCH',
+                body: JSON.stringify(body)
+            });
+
+            if (!res.ok) {
+                const json = (await res.json()) as Record<string, unknown>;
+                throw new APIError({ res, json });
+            }
+
+            return undefined;
+        },
+        onSuccess: async () => {
+            await queryClient.invalidateQueries({ queryKey: apiKeysQueryKey(env) });
+        }
+    });
+}
+
+export function useDeleteApiKey(env: string) {
+    const queryClient = useQueryClient();
+    return useMutation<undefined, APIError, number>({
+        mutationFn: async (keyId) => {
+            const res = await apiFetch(`/api/v1/environment/api-keys/${keyId}?env=${env}`, {
+                method: 'DELETE'
+            });
+
+            if (!res.ok) {
+                const json = (await res.json()) as Record<string, unknown>;
+                throw new APIError({ res, json });
+            }
+
+            return undefined;
+        },
+        onSuccess: async () => {
+            await queryClient.invalidateQueries({ queryKey: apiKeysQueryKey(env) });
+        }
+    });
+}

--- a/packages/webapp/src/pages/Environment/Settings/ApiKeys.tsx
+++ b/packages/webapp/src/pages/Environment/Settings/ApiKeys.tsx
@@ -1,0 +1,533 @@
+import { IconEdit, IconExternalLink, IconEye, IconEyeOff, IconKey, IconTrash } from '@tabler/icons-react';
+import { useState } from 'react';
+
+import { permissions } from '@nangohq/authz';
+
+import SettingsContent from './components/SettingsContent';
+import {
+    SCOPE_GROUPS,
+    allGroupScopes,
+    groupWildcard,
+    isScopeSelected,
+    toggleCredential as toggleCredentialFn,
+    toggleGroup as toggleGroupFn,
+    toggleScope as toggleScopeFn
+} from './scope-logic';
+import { useApiKeys, useCreateApiKey, useDeleteApiKey, useUpdateApiKey } from '../../../hooks/useApiKeys';
+import { useEnvironment } from '../../../hooks/useEnvironment';
+import { useToast } from '../../../hooks/useToast';
+import { useStore } from '../../../store';
+import { CopyButton } from '@/components-v2/CopyButton';
+import { DestructiveActionModal } from '@/components-v2/DestructiveActionModal';
+import { PermissionGate } from '@/components-v2/PermissionGate';
+import { Button } from '@/components-v2/ui/button';
+import { Dialog, DialogContent, DialogFooter, DialogHeader, DialogTitle, DialogTrigger } from '@/components-v2/ui/dialog';
+import { Input } from '@/components-v2/ui/input';
+import { Select, SelectContent, SelectItem, SelectTrigger, SelectValue } from '@/components-v2/ui/select';
+import { Table, TableBody, TableCell, TableHead, TableHeader, TableRow } from '@/components-v2/ui/table';
+import { usePermissions } from '@/hooks/usePermissions';
+import { APIError } from '@/utils/api';
+
+import type { ScopeGroup } from './scope-logic';
+import type { ApiKeyListItem } from '../../../hooks/useApiKeys';
+
+function formatRelativeTime(dateStr: string | null): string {
+    if (!dateStr) return 'Never';
+    const now = Date.now();
+    const then = new Date(dateStr).getTime();
+    const diffMs = now - then;
+    const seconds = Math.floor(diffMs / 1000);
+    const minutes = Math.floor(seconds / 60);
+    const hours = Math.floor(minutes / 60);
+    const days = Math.floor(hours / 24);
+    const weeks = Math.floor(days / 7);
+    const months = Math.floor(days / 30);
+
+    if (seconds < 60) return 'Just now';
+    if (minutes < 60) return `${minutes}m ago`;
+    if (hours < 24) return `${hours}h ago`;
+    if (days < 7) return `${days}d ago`;
+    if (days < 30) return `${weeks}w ago`;
+    return `${months}mo ago`;
+}
+
+function formatFullDate(dateStr: string | null): string {
+    if (!dateStr) return 'Never';
+    return new Date(dateStr).toLocaleString('en-US', { year: 'numeric', month: 'short', day: 'numeric', hour: 'numeric', minute: '2-digit' });
+}
+
+function countSelectedScopes(scopes: string[]): number {
+    if (scopes.includes('environment:*')) {
+        return SCOPE_GROUPS.reduce((acc, g) => acc + allGroupScopes(g).length, 0);
+    }
+    let count = 0;
+    for (const scope of scopes) {
+        if (scope.endsWith(':*')) {
+            const prefix = scope.slice(0, -1);
+            count += SCOPE_GROUPS.reduce((acc, g) => acc + allGroupScopes(g).filter((s) => s.startsWith(prefix)).length, 0);
+        } else {
+            count++;
+        }
+    }
+    return count;
+}
+
+// ── Scope selector with dropdown + collapsible groups ───────────────
+
+interface ScopeSelectorProps {
+    selectedScopes: string[];
+    onChange: (scopes: string[]) => void;
+    disabled?: boolean;
+    hideLabel?: boolean;
+}
+
+const ScopeSelector: React.FC<ScopeSelectorProps> = ({ selectedScopes, onChange, disabled, hideLabel }) => {
+    const hasFullAccess = selectedScopes.includes('environment:*');
+    const isCustom = !hasFullAccess && selectedScopes.length > 0;
+    const permissionMode = hasFullAccess && !isCustom ? 'full' : 'custom';
+
+    const isGroupWildcardSelected = (group: ScopeGroup) => {
+        const wc = groupWildcard(group);
+        return wc ? selectedScopes.includes(wc) : false;
+    };
+
+    const isGroupAllSelected = (group: ScopeGroup) => {
+        const all = allGroupScopes(group);
+        return isGroupWildcardSelected(group) || all.every((s) => selectedScopes.includes(s));
+    };
+
+    const hasAnyChildSelected = (group: ScopeGroup) => allGroupScopes(group).some((s) => selectedScopes.includes(s));
+
+    const countGroupTotal = (group: ScopeGroup): number => {
+        return group.items.reduce((acc, item) => acc + (item.credentials ? 2 : 1), 0);
+    };
+
+    const countGroupSelected = (group: ScopeGroup): number => {
+        if (isGroupWildcardSelected(group)) return countGroupTotal(group);
+        return group.items.reduce((acc, item) => {
+            const baseSelected = isScopeSelected(item.value, selectedScopes) || (!!item.credentials && isScopeSelected(item.credentials, selectedScopes));
+            const credSelected = !!item.credentials && isScopeSelected(item.credentials, selectedScopes);
+            return acc + (baseSelected ? 1 : 0) + (credSelected ? 1 : 0);
+        }, 0);
+    };
+
+    return (
+        <div className="flex flex-col gap-3">
+            <div className="flex flex-col gap-1.5">
+                {!hideLabel && (
+                    <div className="flex items-center gap-1.5">
+                        <label className="text-body-medium-semi text-text-primary">Permission</label>
+                        <a
+                            href="https://nango.dev/docs/reference/api-keys#scopes"
+                            target="_blank"
+                            rel="noopener noreferrer"
+                            className="text-text-tertiary hover:text-text-primary"
+                        >
+                            <IconExternalLink stroke={1} size={14} />
+                        </a>
+                    </div>
+                )}
+                <Select
+                    value={permissionMode}
+                    onValueChange={(v) => {
+                        if (v === 'full') {
+                            onChange(['environment:*']);
+                        } else {
+                            onChange([]);
+                        }
+                    }}
+                    disabled={disabled}
+                >
+                    <SelectTrigger className="w-full">
+                        <SelectValue />
+                    </SelectTrigger>
+                    <SelectContent>
+                        <SelectItem value="full">Full access</SelectItem>
+                        <SelectItem value="custom">Custom</SelectItem>
+                    </SelectContent>
+                </Select>
+            </div>
+            {permissionMode === 'custom' && (
+                <div className="flex flex-col gap-1.5">
+                    <label className="text-body-medium-semi text-text-primary">
+                        Selected scopes<span className="text-feedback-error-fg">*</span>
+                    </label>
+                    <div className="max-h-[320px] overflow-y-auto flex flex-col px-1">
+                        {SCOPE_GROUPS.map((group) => {
+                            const groupSelected = isGroupAllSelected(group);
+                            const wildcardSelected = isGroupWildcardSelected(group);
+
+                            return (
+                                <div key={group.group} className="flex flex-col border-b border-border-muted last:border-b-0">
+                                    <div className="flex items-center gap-2 py-2">
+                                        <label className="flex items-center gap-2 cursor-pointer flex-1">
+                                            <input
+                                                type="checkbox"
+                                                checked={groupSelected}
+                                                disabled={disabled}
+                                                ref={(el) => {
+                                                    if (el) el.indeterminate = !groupSelected && hasAnyChildSelected(group);
+                                                }}
+                                                onChange={() => onChange(toggleGroupFn(group, selectedScopes))}
+                                                className="accent-brand shrink-0"
+                                            />
+                                            <span className="text-body-small-semi text-text-primary">{group.group}</span>
+                                        </label>
+                                        <span className="text-body-small-regular text-text-tertiary">
+                                            {countGroupSelected(group)}/{countGroupTotal(group)}
+                                        </span>
+                                    </div>
+                                    <div className="flex flex-col pb-2">
+                                        {group.items.map((item) => (
+                                            <div key={item.value} className="flex flex-col">
+                                                <label className="flex items-center gap-2 pl-7 cursor-pointer py-1">
+                                                    <input
+                                                        type="checkbox"
+                                                        checked={
+                                                            isScopeSelected(item.value, selectedScopes) ||
+                                                            (!!item.credentials && isScopeSelected(item.credentials, selectedScopes))
+                                                        }
+                                                        disabled={disabled || wildcardSelected}
+                                                        onChange={() => onChange(toggleScopeFn(item.value, item.credentials, selectedScopes))}
+                                                        className="accent-brand shrink-0"
+                                                    />
+                                                    <span
+                                                        className={`text-body-small-regular ${wildcardSelected ? 'text-text-tertiary' : 'text-text-primary'}`}
+                                                    >
+                                                        {item.label}
+                                                    </span>
+                                                </label>
+                                                {item.credentials && (
+                                                    <label className="flex items-center gap-2 pl-7 cursor-pointer py-1">
+                                                        <input
+                                                            type="checkbox"
+                                                            checked={isScopeSelected(item.credentials, selectedScopes)}
+                                                            disabled={disabled || wildcardSelected}
+                                                            onChange={() => onChange(toggleCredentialFn(item.value, item.credentials!, selectedScopes))}
+                                                            className="accent-brand shrink-0"
+                                                        />
+                                                        <span
+                                                            className={`text-body-small-regular ${wildcardSelected ? 'text-text-tertiary' : 'text-text-primary'}`}
+                                                        >
+                                                            {item.label}:with_credentials
+                                                        </span>
+                                                    </label>
+                                                )}
+                                            </div>
+                                        ))}
+                                    </div>
+                                </div>
+                            );
+                        })}
+                    </div>
+                    {selectedScopes.length === 0 && <p className="text-body-small-regular text-feedback-error-fg">Select at least one scope to continue</p>}
+                </div>
+            )}
+        </div>
+    );
+};
+
+// ── Create dialog ───────────────────────────────────────────────────
+
+interface CreateApiKeyDialogProps {
+    env: string;
+    onCreated: () => void;
+    disabled?: boolean;
+}
+
+const CreateApiKeyDialog: React.FC<CreateApiKeyDialogProps> = ({ env, onCreated, disabled }) => {
+    const [open, setOpen] = useState(false);
+    const [displayName, setDisplayName] = useState('');
+    const [selectedScopes, setSelectedScopes] = useState<string[]>(['environment:*']);
+    const { toast } = useToast();
+    const { mutateAsync: createApiKey, isPending } = useCreateApiKey(env);
+
+    const hasNoScopes = selectedScopes.length === 0;
+
+    const handleCreate = async () => {
+        if (!displayName.trim()) {
+            toast({ title: 'Display name is required', variant: 'error' });
+            return;
+        }
+        if (hasNoScopes) {
+            toast({ title: 'Select at least one scope or choose Full access', variant: 'error' });
+            return;
+        }
+        try {
+            await createApiKey({
+                display_name: displayName.trim(),
+                scopes: selectedScopes
+            });
+            setOpen(false);
+            setDisplayName('');
+            setSelectedScopes(['environment:*']);
+            toast({ title: 'API Key successfully created.', variant: 'success' });
+            onCreated();
+        } catch (err) {
+            if (err instanceof APIError) {
+                toast({ title: (err.json as any)?.error?.message ?? 'Failed to create API key', variant: 'error' });
+            } else {
+                toast({ title: 'Failed to create API key', variant: 'error' });
+            }
+        }
+    };
+
+    return (
+        <Dialog open={open} onOpenChange={setOpen}>
+            <DialogTrigger asChild>
+                <Button variant="primary" disabled={disabled}>
+                    <IconKey stroke={1} size={16} />
+                    Create new API key
+                </Button>
+            </DialogTrigger>
+            <DialogContent className="max-w-lg max-h-[85vh] overflow-y-auto">
+                <DialogHeader>
+                    <DialogTitle>Create API Key</DialogTitle>
+                </DialogHeader>
+                <div className="flex flex-col gap-4">
+                    <div className="flex flex-col gap-2">
+                        <label htmlFor="api-key-name" className="text-body-medium-semi text-text-primary">
+                            Display name<span className="text-feedback-error-fg">*</span>
+                        </label>
+                        <Input id="api-key-name" placeholder="e.g. Production backend" value={displayName} onChange={(e) => setDisplayName(e.target.value)} />
+                    </div>
+                    <ScopeSelector selectedScopes={selectedScopes} onChange={setSelectedScopes} />
+                </div>
+                <DialogFooter>
+                    <Button variant="tertiary" onClick={() => setOpen(false)}>
+                        Cancel
+                    </Button>
+                    <Button onClick={handleCreate} loading={isPending} disabled={hasNoScopes}>
+                        Create API Key
+                    </Button>
+                </DialogFooter>
+            </DialogContent>
+        </Dialog>
+    );
+};
+
+// ── Key configuration page ──────────────────────────────────────────
+
+interface KeyConfigProps {
+    apiKey: ApiKeyListItem;
+    env: string;
+    onBack: () => void;
+    canReadSecret: boolean;
+    canManageKeys: boolean;
+}
+
+const KeyConfig: React.FC<KeyConfigProps> = ({ apiKey, env, onBack, canReadSecret, canManageKeys }) => {
+    const [editedScopes, setEditedScopes] = useState<string[]>(apiKey.scopes);
+    const [editedName, setEditedName] = useState<string>(apiKey.display_name);
+    const [secretRevealed, setSecretRevealed] = useState(false);
+    const { mutateAsync: updateApiKey, isPending } = useUpdateApiKey(env);
+    const { toast } = useToast();
+
+    const scopesChanged = JSON.stringify(editedScopes.slice().sort()) !== JSON.stringify(apiKey.scopes.slice().sort());
+    const nameChanged = editedName.trim() !== apiKey.display_name;
+    const hasChanges = scopesChanged || nameChanged;
+    const hasNoScopes = editedScopes.length === 0;
+
+    const masked = `····${apiKey.secret.slice(-4)}`;
+
+    const handleSave = async () => {
+        if (hasNoScopes) {
+            toast({ title: 'Select at least one scope or choose Full access', variant: 'error' });
+            return;
+        }
+        try {
+            const updates: { keyId: number; scopes?: string[]; display_name?: string } = { keyId: apiKey.id };
+            if (scopesChanged) {
+                updates.scopes = editedScopes;
+            }
+            if (nameChanged) {
+                updates.display_name = editedName.trim();
+            }
+            await updateApiKey(updates);
+            toast({ title: 'API Key successfully updated.', variant: 'success' });
+        } catch (err) {
+            if (err instanceof APIError) {
+                toast({ title: (err.json as any)?.error?.message ?? 'Failed to update API key', variant: 'error' });
+            } else {
+                toast({ title: 'Failed to update API key', variant: 'error' });
+            }
+        }
+    };
+
+    return (
+        <SettingsContent title="Key configuration">
+            <div className="flex flex-col gap-6">
+                <div className="grid grid-cols-[200px_1fr] items-center gap-y-6">
+                    <label className="text-body-medium-semi text-text-secondary">Name</label>
+                    {canManageKeys ? (
+                        <Input value={editedName} onChange={(e) => setEditedName(e.target.value)} />
+                    ) : (
+                        <span className="text-body-medium-regular text-text-primary">{apiKey.display_name}</span>
+                    )}
+
+                    <label className="text-body-medium-semi text-text-secondary">Secret</label>
+                    <div className="relative">
+                        <Input
+                            value={secretRevealed && canReadSecret ? apiKey.secret : masked}
+                            disabled
+                            className="font-mono bg-bg-surface text-text-tertiary pr-20"
+                        />
+                        {canReadSecret && (
+                            <div className="absolute right-2 top-1/2 -translate-y-1/2 flex items-center gap-1">
+                                <Button
+                                    variant="ghost"
+                                    size="icon"
+                                    onClick={() => setSecretRevealed((r) => !r)}
+                                    className="text-text-tertiary hover:text-text-primary h-7 w-7"
+                                >
+                                    {secretRevealed ? <IconEyeOff stroke={1} size={16} /> : <IconEye stroke={1} size={16} />}
+                                </Button>
+                                <CopyButton text={apiKey.secret} />
+                            </div>
+                        )}
+                    </div>
+                </div>
+
+                <ScopeSelector selectedScopes={editedScopes} onChange={setEditedScopes} disabled={!canManageKeys} />
+
+                {canManageKeys && (
+                    <div className="flex gap-2 pt-2">
+                        <Button variant="tertiary" onClick={onBack}>
+                            Cancel
+                        </Button>
+                        <Button onClick={handleSave} loading={isPending} disabled={!hasChanges || hasNoScopes}>
+                            Save
+                        </Button>
+                    </div>
+                )}
+            </div>
+        </SettingsContent>
+    );
+};
+
+// ── Delete button with self-managed open state ─────────────────────
+
+const DeleteApiKeyButton: React.FC<{ displayName: string; onDelete: () => void }> = ({ displayName, onDelete }) => {
+    const [open, setOpen] = useState(false);
+
+    return (
+        <DestructiveActionModal
+            title="Delete API Key"
+            description={`This action is irreversible. Any services using the key "${displayName}" will lose access immediately.`}
+            inputLabel="To confirm, type the key name below:"
+            confirmationKeyword={displayName}
+            confirmButtonText="Delete API Key"
+            trigger={
+                <Button variant="ghost" size="icon" className="text-text-tertiary hover:text-feedback-error-fg">
+                    <IconTrash stroke={1} size={16} />
+                </Button>
+            }
+            onConfirm={onDelete}
+            open={open}
+            onOpenChange={setOpen}
+        />
+    );
+};
+
+// ── Main component ──────────────────────────────────────────────────
+
+export const ApiKeys: React.FC = () => {
+    const env = useStore((state) => state.env);
+    const { data, isLoading } = useApiKeys(env);
+    const { data: envData } = useEnvironment(env);
+    const { mutateAsync: deleteApiKey } = useDeleteApiKey(env);
+    const { toast } = useToast();
+    const [selectedKeyId, setSelectedKeyId] = useState<number | null>(null);
+
+    const { can } = usePermissions();
+    const isProd = envData?.environmentAndAccount?.environment?.is_production || false;
+    const canReadSecret = can(permissions.canReadProdSecretKey) || !isProd;
+    const canManageKeys = can(permissions.canWriteProdEnvironmentKeys) || !isProd;
+
+    const apiKeys = data?.data ?? [];
+    const selectedKey = selectedKeyId !== null ? apiKeys.find((k) => k.id === selectedKeyId) : null;
+
+    const handleDelete = async (keyId: number) => {
+        try {
+            await deleteApiKey(keyId);
+            setSelectedKeyId(null);
+            toast({ title: 'API key deleted', variant: 'success' });
+        } catch (err) {
+            if (err instanceof APIError) {
+                toast({ title: (err.json as any)?.error?.message ?? 'Failed to delete API key', variant: 'error' });
+            } else {
+                toast({ title: 'Failed to delete API key', variant: 'error' });
+            }
+        }
+    };
+
+    if (selectedKey) {
+        return <KeyConfig apiKey={selectedKey} env={env} onBack={() => setSelectedKeyId(null)} canReadSecret={canReadSecret} canManageKeys={canManageKeys} />;
+    }
+
+    return (
+        <SettingsContent
+            title="API Keys"
+            action={
+                <PermissionGate condition={canManageKeys}>
+                    {(allowed) => <CreateApiKeyDialog env={env} onCreated={() => void 0} disabled={!allowed} />}
+                </PermissionGate>
+            }
+        >
+            {isLoading ? (
+                <div className="text-body-small-regular text-text-tertiary py-4">Loading API keys...</div>
+            ) : apiKeys.length === 0 ? (
+                <div className="text-body-small-regular text-text-tertiary py-4">No API keys yet. Create one to get started.</div>
+            ) : (
+                <div className="[&_[data-slot=table-container]]:border-0 [&_[data-slot=table-container]]:rounded-none">
+                    <Table>
+                        <TableHeader>
+                            <TableRow>
+                                <TableHead>Name</TableHead>
+                                <TableHead>Scopes</TableHead>
+                                <TableHead>Created</TableHead>
+                                <TableHead>Last used</TableHead>
+                                <TableHead>Action</TableHead>
+                            </TableRow>
+                        </TableHeader>
+                        <TableBody>
+                            {apiKeys.map((key) => (
+                                <TableRow key={key.id}>
+                                    <TableCell>
+                                        <span className="text-body-small-semi text-text-primary">{key.display_name}</span>
+                                    </TableCell>
+                                    <TableCell>
+                                        <span className="text-body-small-regular text-text-secondary">{countSelectedScopes(key.scopes)}</span>
+                                    </TableCell>
+                                    <TableCell>
+                                        <span className="text-text-secondary cursor-default" title={formatFullDate(key.created_at)}>
+                                            {formatRelativeTime(key.created_at)}
+                                        </span>
+                                    </TableCell>
+                                    <TableCell>
+                                        <span className="text-text-secondary cursor-default" title={formatFullDate(key.last_used_at)}>
+                                            {formatRelativeTime(key.last_used_at)}
+                                        </span>
+                                    </TableCell>
+                                    <TableCell>
+                                        <div className="flex items-center gap-1">
+                                            <Button
+                                                variant="ghost"
+                                                size="icon"
+                                                onClick={() => setSelectedKeyId(key.id)}
+                                                className="text-text-tertiary hover:text-text-primary"
+                                            >
+                                                <IconEdit stroke={1} size={16} />
+                                            </Button>
+                                            {canManageKeys && <DeleteApiKeyButton displayName={key.display_name} onDelete={() => void handleDelete(key.id)} />}
+                                        </div>
+                                    </TableCell>
+                                </TableRow>
+                            ))}
+                        </TableBody>
+                    </Table>
+                </div>
+            )}
+        </SettingsContent>
+    );
+};

--- a/packages/webapp/src/pages/Environment/Settings/Backend.tsx
+++ b/packages/webapp/src/pages/Environment/Settings/Backend.tsx
@@ -1,4 +1,4 @@
-import { IconExternalLink, IconKey } from '@tabler/icons-react';
+import { IconExternalLink } from '@tabler/icons-react';
 import { Info } from 'lucide-react';
 import { useState } from 'react';
 import { Link } from 'react-router-dom';
@@ -7,16 +7,12 @@ import { permissions } from '@nangohq/authz';
 
 import SettingsContent from './components/SettingsContent';
 import SettingsGroup from './components/SettingsGroup';
-import { useActivateKey, useEnvironment, usePatchEnvironment, useRevertKey, useRotateKey } from '../../../hooks/useEnvironment';
+import { useEnvironment, usePatchEnvironment } from '../../../hooks/useEnvironment';
 import { useToast } from '../../../hooks/useToast';
 import { useStore } from '../../../store';
 import { EditableInput } from '@/components-v2/EditableInput';
-import { PermissionGate } from '@/components-v2/PermissionGate';
-import { SecretInput } from '@/components-v2/SecretInput';
 import { StyledLink } from '@/components-v2/StyledLink';
 import { Alert, AlertDescription } from '@/components-v2/ui/alert';
-import { Button } from '@/components-v2/ui/button';
-import { useConfirmDialog } from '@/hooks/useConfirmDialog';
 import { usePermissions } from '@/hooks/usePermissions';
 import { APIError } from '@/utils/api';
 
@@ -27,146 +23,20 @@ export const BackendSettings: React.FC = () => {
     const { data } = useEnvironment(env);
     const environmentAndAccount = data?.environmentAndAccount;
     const { mutateAsync: patchEnvironmentAsync } = usePatchEnvironment(env);
-    const { mutateAsync: rotateKeyAsync, isPending: isRotating } = useRotateKey(env);
-    const { mutateAsync: revertKeyAsync, isPending: isReverting } = useRevertKey(env);
-    const { mutateAsync: activateKeyAsync, isPending: isActivating } = useActivateKey(env);
 
     const isProdEnv = environmentAndAccount?.environment.is_production || false;
 
     const { can } = usePermissions();
-    const canReadSecretKey = can(permissions.canReadProdSecretKey) || !isProdEnv;
-    const canGenerateNewSecretKey = can(permissions.canWriteProdEnvironmentKeys) || !isProdEnv;
     const canEditEnv = can(permissions.canWriteProdEnvironment) || !isProdEnv;
 
-    const { confirm, DialogComponent } = useConfirmDialog();
-
     const [isEditingCallbackUrl, setIsEditingCallbackUrl] = useState(false);
-
-    const onGenerate = async () => {
-        try {
-            await rotateKeyAsync();
-        } catch {
-            toast({ title: `There was an issue when generating a new secret`, variant: 'error' });
-        }
-    };
-
-    const onRevert = async () => {
-        try {
-            await revertKeyAsync();
-        } catch {
-            toast({ title: `There was an issue when reverting the secret`, variant: 'error' });
-        }
-    };
-
-    const onRotate = async () => {
-        try {
-            await activateKeyAsync();
-        } catch {
-            toast({ title: `There was an issue when rotating the secret`, variant: 'error' });
-        }
-    };
 
     if (!environmentAndAccount) {
         return null;
     }
 
-    const hasNewSecretKey = environmentAndAccount.environment.pending_secret_key;
     return (
         <SettingsContent title="Backend">
-            <SettingsGroup label="Secret key">
-                <fieldset className="flex flex-col gap-3.5">
-                    <div className="flex flex-col gap-2">
-                        {hasNewSecretKey && (
-                            <label htmlFor="secretKey" className="text-sm">
-                                Current secret
-                            </label>
-                        )}
-                        <div className="flex gap-2">
-                            <SecretInput
-                                name="secretKey"
-                                value={environmentAndAccount.environment.secret_key}
-                                copy={canReadSecretKey}
-                                canRead={canReadSecretKey}
-                                disabled
-                            />
-                        </div>
-                    </div>
-                    {!hasNewSecretKey && (
-                        <div className="flex justify-start">
-                            <PermissionGate condition={canGenerateNewSecretKey}>
-                                {(allowed) => (
-                                    <Button disabled={!allowed} variant={'secondary'} onClick={onGenerate} loading={isRotating}>
-                                        <IconKey stroke={1} size={18} />
-                                        Generate new secret key
-                                    </Button>
-                                )}
-                            </PermissionGate>
-                        </div>
-                    )}
-                    {hasNewSecretKey && (
-                        <div className="flex flex-col gap-2">
-                            <label htmlFor="secretKey" className="text-sm">
-                                New secret
-                            </label>
-                            <SecretInput
-                                name="pendingSecretKey"
-                                value={environmentAndAccount.environment.pending_secret_key!}
-                                copy={canReadSecretKey}
-                                canRead={canReadSecretKey}
-                                disabled
-                            />
-                        </div>
-                    )}
-                    {hasNewSecretKey && (
-                        <Alert variant="info">
-                            <AlertDescription>
-                                The current secret is still active, the new secret is not. Confirm key rotation to activate new secret and deactivate current
-                                secret.
-                            </AlertDescription>
-                        </Alert>
-                    )}
-
-                    {hasNewSecretKey && (
-                        <div className="flex gap-3 justify-start">
-                            <Button
-                                onClick={() =>
-                                    confirm({
-                                        title: 'Cancel key rotation?',
-                                        description:
-                                            'The new key will be deactivated. Only do this when the old key is used in production. This is not reversible.',
-                                        cancelButtonText: 'Dismiss',
-                                        confirmButtonText: 'Cancel key rotation',
-                                        confirmVariant: 'destructive',
-                                        onConfirm: onRevert
-                                    })
-                                }
-                                variant={'tertiary'}
-                                loading={isReverting}
-                            >
-                                Cancel key rotation
-                            </Button>
-
-                            <Button
-                                onClick={() =>
-                                    confirm({
-                                        title: 'Confirm key rotation?',
-                                        description:
-                                            'The old key will be deactivated. Only do this when the new key is used in production. This is not reversible.',
-                                        cancelButtonText: 'Dismiss',
-                                        confirmButtonText: 'Confirm key rotation',
-                                        confirmVariant: 'destructive',
-                                        onConfirm: onRotate
-                                    })
-                                }
-                                variant={'primary'}
-                                loading={isActivating}
-                            >
-                                Confirm key rotation
-                            </Button>
-                        </div>
-                    )}
-                </fieldset>
-            </SettingsGroup>
             <SettingsGroup
                 label={
                     <>
@@ -226,7 +96,6 @@ export const BackendSettings: React.FC = () => {
                     )}
                 </div>
             </SettingsGroup>
-            {DialogComponent}
         </SettingsContent>
     );
 };

--- a/packages/webapp/src/pages/Environment/Settings/Show.tsx
+++ b/packages/webapp/src/pages/Environment/Settings/Show.tsx
@@ -1,5 +1,7 @@
+import { useState } from 'react';
 import { Helmet } from 'react-helmet';
 
+import { ApiKeys } from './ApiKeys';
 import { BackendSettings } from './Backend';
 import { ConnectUISettings } from './ConnectUISettings';
 import { DeprecatedSettings } from './Deprecated';
@@ -35,6 +37,7 @@ export const EnvironmentSettings: React.FC = () => {
     const environmentAndAccount = data?.environmentAndAccount;
     const isProd = environmentAndAccount?.environment?.is_production || false;
     const [activeTab, setActiveTab] = useHashNavigation('general');
+    const [apiKeysResetKey, setApiKeysResetKey] = useState(0);
 
     if (!environmentAndAccount || !team) {
         return (
@@ -78,6 +81,9 @@ export const EnvironmentSettings: React.FC = () => {
                 <Navigation value={activeTab} onValueChange={setActiveTab}>
                     <NavigationList className="w-[209px]">
                         <NavigationTrigger value="general">General</NavigationTrigger>
+                        <NavigationTrigger value="api-keys" onClick={() => setApiKeysResetKey((k) => k + 1)}>
+                            API Keys
+                        </NavigationTrigger>
                         <NavigationTrigger value="backend">Backend</NavigationTrigger>
                         <NavigationTrigger value="connect-ui">Connect UI</NavigationTrigger>
                         <NavigationTrigger value="webhooks">Webhooks</NavigationTrigger>
@@ -88,6 +94,9 @@ export const EnvironmentSettings: React.FC = () => {
                     </NavigationList>
                     <EnvironmentSettingsContent value={'general'}>
                         <General />
+                    </EnvironmentSettingsContent>
+                    <EnvironmentSettingsContent value={'api-keys'}>
+                        <ApiKeys key={apiKeysResetKey} />
                     </EnvironmentSettingsContent>
                     <EnvironmentSettingsContent value={'backend'}>
                         <BackendSettings />

--- a/packages/webapp/src/pages/Environment/Settings/Webhooks.tsx
+++ b/packages/webapp/src/pages/Environment/Settings/Webhooks.tsx
@@ -8,6 +8,7 @@ import { WebhookCheckboxes } from './components/WebhookCheckboxes.js';
 import { useEnvironment, usePatchWebhook } from '../../../hooks/useEnvironment.js';
 import { useStore } from '../../../store.js';
 import { EditableInput } from '@/components-v2/EditableInput.js';
+import { SecretInput } from '@/components-v2/SecretInput.js';
 import { ButtonLink } from '@/components-v2/ui/button.js';
 import { Label } from '@/components-v2/ui/label.js';
 import { usePermissions } from '@/hooks/usePermissions.js';
@@ -26,6 +27,7 @@ export const Webhooks: React.FC = () => {
 
     const { can } = usePermissions();
     const canWriteWebhooks = can(permissions.canWriteProdWebhooks) || !environment?.is_production;
+    const canReadSigningKey = can(permissions.canReadProdSecretKey) || !environment?.is_production;
 
     const onSave = async (body: PatchWebhook['Body']) => {
         try {
@@ -76,6 +78,22 @@ export const Webhooks: React.FC = () => {
                             canEdit={canWriteWebhooks}
                         />
                     </div>
+                </div>
+            </SettingsGroup>
+            <SettingsGroup label="Signing key">
+                <div className="flex flex-col gap-2">
+                    <p className="text-body-small-regular text-text-secondary">
+                        Use this key to verify that webhook payloads are from Nango.{' '}
+                        <a
+                            href="https://nango.dev/docs/implementation-guides/platform/webhooks-from-nango#verifying-webhooks-from-nango"
+                            target="_blank"
+                            rel="noopener noreferrer"
+                            className="text-text-brand hover:underline"
+                        >
+                            Learn more
+                        </a>
+                    </p>
+                    <SecretInput value={environmentAndAccount.webhook_signing_key ?? ''} copy={canReadSigningKey} canRead={canReadSigningKey} readOnly />
                 </div>
             </SettingsGroup>
             <SettingsGroup label="Subscriptions">

--- a/packages/webapp/src/pages/Environment/Settings/components/SettingsContent.tsx
+++ b/packages/webapp/src/pages/Environment/Settings/components/SettingsContent.tsx
@@ -1,8 +1,9 @@
-const SettingsContent: React.FC<{ title: string; children: React.ReactNode }> = ({ title, children }) => {
+const SettingsContent: React.FC<{ title: string; action?: React.ReactNode; children: React.ReactNode }> = ({ title, action, children }) => {
     return (
         <div className="text-text-primary flex flex-col rounded-sm border-2 border-border-disabled h-full">
-            <div className="text-body-large-semi bg-bg-elevated h-10 flex items-center p-6">
+            <div className="text-body-large-semi bg-bg-elevated h-10 flex items-center justify-between p-6">
                 <h2>{title}</h2>
+                {action}
             </div>
             <div className="flex flex-col gap-9 w-full px-6 flex-1 py-9">{children}</div>
         </div>

--- a/packages/webapp/src/pages/Environment/Settings/scope-logic.ts
+++ b/packages/webapp/src/pages/Environment/Settings/scope-logic.ts
@@ -1,0 +1,145 @@
+import type { ApiKeyScope } from '@nangohq/types';
+
+export interface ScopeItem {
+    value: ApiKeyScope;
+    label: string;
+    credentials?: ApiKeyScope;
+}
+
+export interface ScopeGroup {
+    group: string;
+    items: ScopeItem[];
+}
+
+export const SCOPE_GROUPS: ScopeGroup[] = [
+    {
+        group: 'Integrations',
+        items: [
+            { value: 'environment:integrations:list', label: 'list', credentials: 'environment:integrations:list_credentials' },
+            { value: 'environment:integrations:read', label: 'read', credentials: 'environment:integrations:read_credentials' },
+            { value: 'environment:integrations:write', label: 'write' }
+        ]
+    },
+    {
+        group: 'Connections',
+        items: [
+            { value: 'environment:connections:list', label: 'list', credentials: 'environment:connections:list_credentials' },
+            { value: 'environment:connections:read', label: 'read', credentials: 'environment:connections:read_credentials' },
+            { value: 'environment:connections:write', label: 'write' }
+        ]
+    },
+    { group: 'Connect Sessions', items: [{ value: 'environment:connect_sessions:write', label: 'write' }] },
+    {
+        group: 'Syncs',
+        items: [
+            { value: 'environment:syncs:read', label: 'read' },
+            { value: 'environment:syncs:execute', label: 'execute' },
+            { value: 'environment:syncs:manage', label: 'manage' }
+        ]
+    },
+    { group: 'Deploy', items: [{ value: 'environment:deploy', label: 'deploy' }] },
+    {
+        group: 'Records',
+        items: [
+            { value: 'environment:records:read', label: 'read' },
+            { value: 'environment:records:write', label: 'write' }
+        ]
+    },
+    { group: 'Actions', items: [{ value: 'environment:actions:execute', label: 'execute' }] },
+    { group: 'Proxy', items: [{ value: 'environment:proxy', label: 'proxy' }] },
+    { group: 'Config', items: [{ value: 'environment:config:read', label: 'read' }] },
+    { group: 'MCP', items: [{ value: 'environment:mcp', label: 'mcp' }] }
+];
+
+export function allGroupScopes(group: ScopeGroup): string[] {
+    return group.items.flatMap((item) => (item.credentials ? [item.value, item.credentials] : [item.value]));
+}
+
+export const ALL_INDIVIDUAL_SCOPES = SCOPE_GROUPS.flatMap((g) => allGroupScopes(g));
+
+export function expandScopes(scopes: string[]): string[] {
+    const expanded = new Set<string>();
+    for (const scope of scopes) {
+        if (scope === 'environment:*') {
+            return ALL_INDIVIDUAL_SCOPES;
+        }
+        if (scope.endsWith(':*')) {
+            const prefix = scope.slice(0, -1);
+            for (const s of ALL_INDIVIDUAL_SCOPES) {
+                if (s.startsWith(prefix)) {
+                    expanded.add(s);
+                }
+            }
+        } else {
+            expanded.add(scope);
+        }
+    }
+    return Array.from(expanded);
+}
+
+export function groupWildcard(group: ScopeGroup): string | null {
+    const allScopes = allGroupScopes(group);
+    const parts = group.items[0].value.split(':');
+    if (parts.length < 3 || allScopes.length <= 1) {
+        return null;
+    }
+    return parts.slice(0, -1).join(':') + ':*';
+}
+
+export function isScopeSelected(scope: string, selectedScopes: string[]): boolean {
+    if (selectedScopes.includes(scope)) return true;
+    return selectedScopes.some((s) => s.endsWith(':*') && scope.startsWith(s.slice(0, -1)));
+}
+
+export function toggleScope(scope: string, credentialChild: string | undefined, selectedScopes: string[]): string[] {
+    const isSelected = isScopeSelected(scope, selectedScopes) || (!!credentialChild && isScopeSelected(credentialChild, selectedScopes));
+    if (isSelected) {
+        const matchingWildcard = selectedScopes.find((s) => s.endsWith(':*') && s !== scope && scope.startsWith(s.slice(0, -1)));
+        if (matchingWildcard) {
+            const expanded = ALL_INDIVIDUAL_SCOPES.filter((s) => s.startsWith(matchingWildcard.slice(0, -1)));
+            const without = expanded.filter((s) => s !== scope && s !== credentialChild);
+            const rest = selectedScopes.filter((s) => s !== matchingWildcard);
+            return [...rest, ...without];
+        } else {
+            return selectedScopes.filter((s) => s !== scope && s !== credentialChild);
+        }
+    } else {
+        return [...selectedScopes, scope];
+    }
+}
+
+export function toggleCredential(parent: string, credential: string, selectedScopes: string[]): string[] {
+    const isSelected = isScopeSelected(credential, selectedScopes);
+    if (isSelected) {
+        const matchingWildcard = selectedScopes.find((s) => s.endsWith(':*') && s !== credential && credential.startsWith(s.slice(0, -1)));
+        if (matchingWildcard) {
+            const expanded = ALL_INDIVIDUAL_SCOPES.filter((s) => s.startsWith(matchingWildcard.slice(0, -1)));
+            const without = expanded.filter((s) => s !== credential);
+            const rest = selectedScopes.filter((s) => s !== matchingWildcard);
+            return [...rest, ...without];
+        } else {
+            return [...selectedScopes.filter((s) => s !== credential), ...(selectedScopes.includes(parent) ? [] : [parent])];
+        }
+    } else {
+        return [...selectedScopes.filter((s) => s !== parent), credential];
+    }
+}
+
+export function toggleGroup(group: ScopeGroup, selectedScopes: string[]): string[] {
+    if (selectedScopes.includes('environment:*')) return selectedScopes;
+    const wc = groupWildcard(group);
+    const all = allGroupScopes(group);
+    if (wc && selectedScopes.includes(wc)) {
+        return selectedScopes.filter((s) => s !== wc);
+    } else if (wc) {
+        const cleaned = selectedScopes.filter((s) => !all.includes(s));
+        return [...cleaned, wc];
+    } else {
+        const allSelected = all.every((s) => selectedScopes.includes(s));
+        if (allSelected) {
+            return selectedScopes.filter((s) => !all.includes(s));
+        } else {
+            return Array.from(new Set([...selectedScopes, ...all]));
+        }
+    }
+}

--- a/packages/webapp/src/pages/Environment/Settings/scope-logic.unit.test.ts
+++ b/packages/webapp/src/pages/Environment/Settings/scope-logic.unit.test.ts
@@ -1,0 +1,252 @@
+import { describe, expect, it } from 'vitest';
+
+import {
+    ALL_INDIVIDUAL_SCOPES,
+    SCOPE_GROUPS,
+    allGroupScopes,
+    expandScopes,
+    groupWildcard,
+    isScopeSelected,
+    toggleCredential,
+    toggleGroup,
+    toggleScope
+} from './scope-logic';
+
+describe('isScopeSelected', () => {
+    it('exact match', () => {
+        expect(isScopeSelected('environment:deploy', ['environment:deploy'])).toBe(true);
+    });
+
+    it('no match', () => {
+        expect(isScopeSelected('environment:proxy', ['environment:deploy'])).toBe(false);
+    });
+
+    it('wildcard environment:* matches any scope', () => {
+        expect(isScopeSelected('environment:integrations:list', ['environment:*'])).toBe(true);
+        expect(isScopeSelected('environment:deploy', ['environment:*'])).toBe(true);
+    });
+
+    it('group wildcard matches scopes in group', () => {
+        expect(isScopeSelected('environment:integrations:list', ['environment:integrations:*'])).toBe(true);
+        expect(isScopeSelected('environment:integrations:write', ['environment:integrations:*'])).toBe(true);
+    });
+
+    it('group wildcard does not match other groups', () => {
+        expect(isScopeSelected('environment:connections:list', ['environment:integrations:*'])).toBe(false);
+    });
+
+    it('empty scopes returns false', () => {
+        expect(isScopeSelected('environment:deploy', [])).toBe(false);
+    });
+});
+
+describe('expandScopes', () => {
+    it('environment:* expands to all individual scopes', () => {
+        const expanded = expandScopes(['environment:*']);
+        expect(expanded).toEqual(ALL_INDIVIDUAL_SCOPES);
+        expect(expanded.length).toBe(21);
+    });
+
+    it('group wildcard expands to group scopes', () => {
+        const expanded = expandScopes(['environment:integrations:*']);
+        expect(expanded).toEqual([
+            'environment:integrations:list',
+            'environment:integrations:list_credentials',
+            'environment:integrations:read',
+            'environment:integrations:read_credentials',
+            'environment:integrations:write'
+        ]);
+    });
+
+    it('individual scope stays as-is', () => {
+        expect(expandScopes(['environment:deploy'])).toEqual(['environment:deploy']);
+    });
+
+    it('mixed wildcards and individual scopes', () => {
+        const expanded = expandScopes(['environment:integrations:*', 'environment:deploy']);
+        expect(expanded).toContain('environment:integrations:list');
+        expect(expanded).toContain('environment:integrations:write');
+        expect(expanded).toContain('environment:deploy');
+        expect(expanded).not.toContain('environment:connections:list');
+    });
+});
+
+describe('groupWildcard', () => {
+    it('returns wildcard for multi-scope groups with 3+ segments', () => {
+        const integrations = SCOPE_GROUPS.find((g) => g.group === 'Integrations')!;
+        expect(groupWildcard(integrations)).toBe('environment:integrations:*');
+    });
+
+    it('returns null for single-scope 2-segment groups (Deploy)', () => {
+        const deploy = SCOPE_GROUPS.find((g) => g.group === 'Deploy')!;
+        expect(groupWildcard(deploy)).toBeNull();
+    });
+
+    it('returns null for single-scope groups (Proxy, MCP)', () => {
+        const proxy = SCOPE_GROUPS.find((g) => g.group === 'Proxy')!;
+        expect(groupWildcard(proxy)).toBeNull();
+
+        const mcp = SCOPE_GROUPS.find((g) => g.group === 'MCP')!;
+        expect(groupWildcard(mcp)).toBeNull();
+    });
+
+    it('returns wildcard for Syncs (multiple items, 3 segments)', () => {
+        const syncs = SCOPE_GROUPS.find((g) => g.group === 'Syncs')!;
+        expect(groupWildcard(syncs)).toBe('environment:syncs:*');
+    });
+});
+
+describe('toggleScope', () => {
+    it('adds scope when not selected', () => {
+        const result = toggleScope('environment:deploy', undefined, []);
+        expect(result).toEqual(['environment:deploy']);
+    });
+
+    it('removes scope when selected', () => {
+        const result = toggleScope('environment:deploy', undefined, ['environment:deploy']);
+        expect(result).toEqual([]);
+    });
+
+    it('removes scope and its credential child', () => {
+        const result = toggleScope('environment:integrations:list', 'environment:integrations:list_credentials', [
+            'environment:integrations:list',
+            'environment:integrations:list_credentials'
+        ]);
+        expect(result).not.toContain('environment:integrations:list');
+        expect(result).not.toContain('environment:integrations:list_credentials');
+    });
+
+    it('unchecking parent when only credential is stored removes credential', () => {
+        const result = toggleScope('environment:integrations:list', 'environment:integrations:list_credentials', ['environment:integrations:list_credentials']);
+        expect(result).not.toContain('environment:integrations:list');
+        expect(result).not.toContain('environment:integrations:list_credentials');
+    });
+
+    it('expands wildcard when unchecking a scope selected via wildcard', () => {
+        const result = toggleScope('environment:integrations:list', 'environment:integrations:list_credentials', ['environment:integrations:*']);
+        expect(result).not.toContain('environment:integrations:*');
+        expect(result).not.toContain('environment:integrations:list');
+        expect(result).not.toContain('environment:integrations:list_credentials');
+        expect(result).toContain('environment:integrations:read');
+        expect(result).toContain('environment:integrations:read_credentials');
+        expect(result).toContain('environment:integrations:write');
+    });
+
+    it('preserves other scopes when removing', () => {
+        const result = toggleScope('environment:deploy', undefined, ['environment:deploy', 'environment:proxy']);
+        expect(result).toEqual(['environment:proxy']);
+    });
+});
+
+describe('toggleCredential', () => {
+    it('checking credentials replaces parent (superset)', () => {
+        const result = toggleCredential('environment:integrations:list', 'environment:integrations:list_credentials', ['environment:integrations:list']);
+        expect(result).toContain('environment:integrations:list_credentials');
+        expect(result).not.toContain('environment:integrations:list');
+    });
+
+    it('checking credentials when parent not selected stores only credential', () => {
+        const result = toggleCredential('environment:integrations:list', 'environment:integrations:list_credentials', []);
+        expect(result).toEqual(['environment:integrations:list_credentials']);
+        expect(result).not.toContain('environment:integrations:list');
+    });
+
+    it('unchecking credentials downgrades to parent', () => {
+        const result = toggleCredential('environment:integrations:list', 'environment:integrations:list_credentials', [
+            'environment:integrations:list_credentials'
+        ]);
+        expect(result).toContain('environment:integrations:list');
+        expect(result).not.toContain('environment:integrations:list_credentials');
+    });
+
+    it('never stores both parent and credential (no redundancy)', () => {
+        // Check credential when parent exists
+        const result1 = toggleCredential('environment:integrations:list', 'environment:integrations:list_credentials', ['environment:integrations:list']);
+        const hasBoth1 = result1.includes('environment:integrations:list') && result1.includes('environment:integrations:list_credentials');
+        expect(hasBoth1).toBe(false);
+
+        // Check credential when nothing exists
+        const result2 = toggleCredential('environment:integrations:list', 'environment:integrations:list_credentials', []);
+        const hasBoth2 = result2.includes('environment:integrations:list') && result2.includes('environment:integrations:list_credentials');
+        expect(hasBoth2).toBe(false);
+    });
+
+    it('unchecking credential from wildcard expands and removes only the credential', () => {
+        const result = toggleCredential('environment:integrations:list', 'environment:integrations:list_credentials', ['environment:integrations:*']);
+        expect(result).not.toContain('environment:integrations:*');
+        expect(result).not.toContain('environment:integrations:list_credentials');
+        expect(result).toContain('environment:integrations:list');
+        expect(result).toContain('environment:integrations:read');
+        expect(result).toContain('environment:integrations:read_credentials');
+        expect(result).toContain('environment:integrations:write');
+    });
+
+    it('preserves other scopes', () => {
+        const result = toggleCredential('environment:integrations:list', 'environment:integrations:list_credentials', [
+            'environment:integrations:list',
+            'environment:deploy'
+        ]);
+        expect(result).toContain('environment:integrations:list_credentials');
+        expect(result).toContain('environment:deploy');
+    });
+});
+
+describe('toggleGroup', () => {
+    const integrations = SCOPE_GROUPS.find((g) => g.group === 'Integrations')!;
+    const deploy = SCOPE_GROUPS.find((g) => g.group === 'Deploy')!;
+
+    it('checking multi-scope group stores wildcard', () => {
+        const result = toggleGroup(integrations, []);
+        expect(result).toEqual(['environment:integrations:*']);
+    });
+
+    it('unchecking wildcard group removes wildcard', () => {
+        const result = toggleGroup(integrations, ['environment:integrations:*']);
+        expect(result).not.toContain('environment:integrations:*');
+    });
+
+    it('checking single-scope group stores individual scope', () => {
+        const result = toggleGroup(deploy, []);
+        expect(result).toContain('environment:deploy');
+        expect(result).not.toContain('environment:*');
+    });
+
+    it('unchecking single-scope group removes individual scope', () => {
+        const result = toggleGroup(deploy, ['environment:deploy']);
+        expect(result).not.toContain('environment:deploy');
+    });
+
+    it('does nothing when full access is set', () => {
+        const result = toggleGroup(integrations, ['environment:*']);
+        expect(result).toEqual(['environment:*']);
+    });
+
+    it('checking group removes individual scopes and stores wildcard', () => {
+        const result = toggleGroup(integrations, ['environment:integrations:list', 'environment:integrations:write']);
+        expect(result).toEqual(['environment:integrations:*']);
+        expect(result).not.toContain('environment:integrations:list');
+        expect(result).not.toContain('environment:integrations:write');
+    });
+
+    it('preserves other scopes when toggling group', () => {
+        const result = toggleGroup(integrations, ['environment:deploy']);
+        expect(result).toContain('environment:integrations:*');
+        expect(result).toContain('environment:deploy');
+    });
+});
+
+describe('allGroupScopes', () => {
+    it('includes credential scopes', () => {
+        const integrations = SCOPE_GROUPS.find((g) => g.group === 'Integrations')!;
+        const scopes = allGroupScopes(integrations);
+        expect(scopes).toContain('environment:integrations:list');
+        expect(scopes).toContain('environment:integrations:list_credentials');
+        expect(scopes).toHaveLength(5);
+    });
+
+    it('groups without credentials have no extra scopes', () => {
+        const syncs = SCOPE_GROUPS.find((g) => g.group === 'Syncs')!;
+        const scopes = allGroupScopes(syncs);
+        expect(scopes).toEqual(['environment:syncs:read', 'environment:syncs:execute', 'environment:syncs:manage']);
+    });
+});


### PR DESCRIPTION
Version 2 of the original branch https://github.com/NangoHQ/nango/pull/5822 for implementing the new API Key system, where we have added the fix for keep caching all hashed secret keys, also the internal ones (see this [commit](https://github.com/NangoHQ/nango/pull/5911/changes/883d3a90c608399c7069ff5dbf1800b0ba931967))
<!-- Describe the problem and your solution --> 

<!-- Issue ticket number and link (if applicable) -->

<!-- Testing instructions (skip if just adding/editing providers) -->

