### PR TITLE
feat(providers): add HaloPSA webhook support

### DIFF
--- a/docs/api-integrations/halo-psa.mdx
+++ b/docs/api-integrations/halo-psa.mdx
@@ -66,11 +66,13 @@ Connect to Halo PSA with Nango and see data flow in 2 minutes.
 Nango-maintained guides for common use cases.
 
 - [How do I link my account?](/api-integrations/halo-psa/connect): Connect your Halo PSA account using the Connect UI
+- [How do I set up webhooks?](/api-integrations/halo-psa/webhooks): Send Halo PSA Standard Webhooks to Nango
 
 Official docs:
 - [Halo API Documentation](https://haloacademy.halopsa.com/apidoc/)
 - [Creating API Applications](https://usehalo.com/halopsa/guides/1823)
 - [Connecting Through the API](https://usehalo.com/halopsa/guides/929)
+- [Halo Webhook Integration](https://halopsa.com/guides/article/?kbid=838)
 
 ## Pre-built syncs & actions for Halo PSA
 

--- a/docs/api-integrations/halo-psa/webhooks.mdx
+++ b/docs/api-integrations/halo-psa/webhooks.mdx
@@ -1,0 +1,154 @@
+---
+title: 'How to setup webhooks with Halo PSA on Nango'
+sidebarTitle: 'Webhooks'
+description: 'Learn how to send Halo PSA Standard Webhooks to Nango'
+---
+
+This guide shows you how to receive Halo PSA Standard Webhooks in Nango using [Halo's webhook configuration](https://halopsa.com/guides/article/?kbid=838).
+
+## How it works
+
+Halo lets administrators create Standard Webhooks from **Configuration** > **Integrations** > **Webhooks**. Nango receives those POST requests, matches them to the connection ID you provide, and then forwards the original Halo payload to your app or runs matching sync `onWebhook` handlers.
+
+## Setup
+
+### 1. Get the Nango webhook URL
+
+Open your Halo PSA integration in the Nango dashboard and copy the **Webhook URL**.
+
+Append the Nango connection ID and a webhook type:
+
+```text
+<NANGO_WEBHOOK_URL>?connectionId=<CONNECTION_ID>&webhookType=ticket.updated
+```
+
+`webhookType` can be any subscription name you want to handle in Nango, such as `ticket.created`, `ticket.updated`, or `halo-psa`.
+
+<Note>
+You can also put these values in the Halo JSON payload instead of the URL. Use `connectionId` and `type`, or use the nested shape `nango.connectionId` and `nango.webhookType`.
+</Note>
+
+### 2. Configure a webhook secret in Nango
+
+In the Nango dashboard, open your Halo PSA integration settings and set a **Webhook Secret**.
+
+Use the same value as the Basic Auth password in Halo.
+
+<Note>
+If you leave the Nango webhook secret empty, Nango accepts Halo webhooks without checking Basic Auth. We recommend setting a secret for production.
+</Note>
+
+### 3. Create a Standard Webhook in Halo
+
+In Halo PSA:
+
+1. Go to **Configuration** > **Integrations** > **Webhooks**.
+2. Create a new webhook.
+3. Set **Webhook Type** to **Standard Webhook**.
+4. Set **Method** to **POST**.
+5. Set **Content Type** to **application/json**.
+6. Set **Payload URL** to the URL from step 1.
+7. Set **Authentication** to **Basic Auth**.
+8. Set the Basic Auth username to `nango`.
+9. Set the Basic Auth password to the Nango webhook secret from step 2.
+10. Enable the webhook.
+
+### 4. Add Halo events
+
+Add the Halo events that should call the webhook, such as ticket-created or ticket-updated events.
+
+If one Halo webhook has several events, they all use the same `webhookType` from the URL. Create separate Halo webhooks if you want Nango to receive different subscription names.
+
+### 5. Choose the payload
+
+The Halo payload can contain any JSON your sync or app needs. If you did not put connection and type in the URL, include them in the JSON:
+
+```json
+{
+  "connectionId": "<CONNECTION_ID>",
+  "type": "ticket.updated",
+  "ticket": {
+    "id": 123,
+    "summary": "Example ticket payload from your Halo webhook template"
+  }
+}
+```
+
+When Nango calls an `onWebhook` handler, it adds normalized routing details under `payload.nango`:
+
+```json
+{
+  "ticket": {
+    "id": 123
+  },
+  "nango": {
+    "connectionId": "<CONNECTION_ID>",
+    "webhookType": "ticket.updated"
+  }
+}
+```
+
+If Halo sends a batched JSON array, Nango calls `onWebhook` with:
+
+```json
+{
+  "events": [
+    { "ticket": { "id": 123 } },
+    { "ticket": { "id": 456 } }
+  ],
+  "nango": {
+    "connectionId": "<CONNECTION_ID>",
+    "webhookType": "ticket.updated"
+  }
+}
+```
+
+Forwarded webhooks keep the original Halo payload.
+
+### 6. Handle the webhook in a sync
+
+Add the same `webhookType` to `webhookSubscriptions`:
+
+```typescript
+import { createSync } from 'nango';
+import { z } from 'zod';
+
+export default createSync({
+    description: 'Keep Halo PSA tickets up to date',
+    models: {
+        Ticket: z.object({
+            id: z.number(),
+            summary: z.string().optional()
+        })
+    },
+    frequency: '1h',
+    exec: async (nango) => {
+        // Keep polling as a safety net for missed or delayed webhooks.
+    },
+    webhookSubscriptions: ['ticket.updated'],
+    onWebhook: async (nango, payload) => {
+        await nango.log(`Received ${payload.nango.webhookType} from Halo PSA`);
+
+        // Use identifiers from your Halo payload to fetch and persist the changed records.
+    }
+});
+```
+
+## Connection matching
+
+Halo webhooks are configurable and do not include a Nango connection ID by default. Nango requires one of these values:
+
+1. URL query parameter: `connectionId=<CONNECTION_ID>`
+2. JSON payload field: `"connectionId": "<CONNECTION_ID>"`
+3. JSON payload field: `"connection_id": "<CONNECTION_ID>"`
+4. JSON payload field: `"nango": {"connectionId": "<CONNECTION_ID>"}`
+
+If Nango cannot find the connection ID, it returns a `400` response and does not run sync webhook handlers.
+
+## Rollback strategy
+
+Disable or delete the Standard Webhook in Halo. This stops Halo from sending events to Nango immediately.
+
+<Tip>Need help getting started? Get help in the [community](https://nango.dev/slack).</Tip>
+
+---

--- a/docs/snippets/generated/halo-psa/PreBuiltTooling.mdx
+++ b/docs/snippets/generated/halo-psa/PreBuiltTooling.mdx
@@ -17,7 +17,7 @@
 | API unification | ✅ |
 | 2-way sync | ✅ |
 | Webhooks from Nango on data modifications | ✅ |
-| Real-time webhooks from 3rd-party API | 🚫 (time to contribute: &lt;48h) |
+| Real-time webhooks from 3rd-party API | ✅ |
 | Proxy requests | ✅ |
 </Accordion>
 <Accordion title="✅ Observability & data quality">

--- a/packages/providers/providers.yaml
+++ b/packages/providers/providers.yaml
@@ -8448,6 +8448,11 @@ halo-psa:
     scope_separator: ' '
     token_params:
         grant_type: client_credentials
+    webhook_routing_script: haloPsaWebhookRouting
+    webhook_user_defined_secret: true
+    webhook_allowed_query_params:
+        - connectionId
+        - webhookType
     proxy:
         base_url: https://${connectionConfig.hostname}/api
     docs: https://nango.dev/docs/api-integrations/halo-psa

--- a/packages/server/lib/webhook/halo-psa-webhook-routing.ts
+++ b/packages/server/lib/webhook/halo-psa-webhook-routing.ts
@@ -1,0 +1,93 @@
+import { NangoError } from '@nangohq/shared';
+import { Err, Ok } from '@nangohq/utils';
+
+import type { WebhookHandler } from './types.js';
+
+interface HaloPsaWebhookPayload {
+    type?: string;
+    webhookType?: string;
+    event?: string;
+    connectionId?: string;
+    connection_id?: string;
+    nango?: {
+        connectionId?: string;
+        webhookType?: string;
+    };
+    [key: string]: any;
+}
+
+type HaloPsaWebhookBody = HaloPsaWebhookPayload | HaloPsaWebhookPayload[];
+
+function firstString(...values: unknown[]): string | undefined {
+    for (const value of values) {
+        if (typeof value === 'string' && value.length > 0) {
+            return value;
+        }
+    }
+
+    return undefined;
+}
+
+function validateBasicAuthorization(header: string | undefined, webhookSecret: string): boolean {
+    if (!header?.startsWith('Basic ')) {
+        return false;
+    }
+
+    try {
+        const credentials = Buffer.from(header.substring('Basic '.length), 'base64').toString('utf8');
+        const separator = credentials.indexOf(':');
+
+        if (separator < 0) {
+            return false;
+        }
+
+        const password = credentials.substring(separator + 1);
+        return password === webhookSecret;
+    } catch {
+        return false;
+    }
+}
+
+const route: WebhookHandler<HaloPsaWebhookBody> = async (nango, headers, body, _rawBody, query) => {
+    const webhookSecret = nango.integration.custom?.['webhookSecret'];
+
+    if (webhookSecret && !validateBasicAuthorization(headers['authorization'], webhookSecret)) {
+        return Err(new NangoError('webhook_invalid_signature'));
+    }
+
+    const bodyObject = Array.isArray(body) ? undefined : body;
+    const connectionId = firstString(query?.['connectionId'], bodyObject?.nango?.connectionId, bodyObject?.connectionId, bodyObject?.connection_id);
+
+    if (!connectionId) {
+        return Err(new NangoError('webhook_invalid_payload', { reason: 'Missing HaloPSA webhook connectionId' }));
+    }
+
+    const webhookType =
+        firstString(query?.['webhookType'], bodyObject?.nango?.webhookType, bodyObject?.webhookType, bodyObject?.type, bodyObject?.event) || 'halo-psa';
+    const nangoPayload = { ...bodyObject?.nango, connectionId, webhookType };
+    const scriptBody = Array.isArray(body)
+        ? {
+              events: body,
+              nango: nangoPayload
+          }
+        : {
+              ...body,
+              nango: nangoPayload
+          };
+
+    const response = await nango.executeScriptForWebhooks({
+        body: scriptBody,
+        webhookTypeValue: webhookType,
+        connectionIdentifierValue: connectionId,
+        propName: 'connectionId'
+    });
+
+    return Ok({
+        content: { status: 'success' },
+        statusCode: 200,
+        connectionIds: response?.connectionIds || [],
+        toForward: body
+    });
+};
+
+export default route;

--- a/packages/server/lib/webhook/halo-psa-webhook-routing.unit.test.ts
+++ b/packages/server/lib/webhook/halo-psa-webhook-routing.unit.test.ts
@@ -1,0 +1,134 @@
+import { describe, expect, it, vi } from 'vitest';
+
+import { logContextGetter } from '@nangohq/logs';
+import { seeders } from '@nangohq/shared';
+import { getTestConfig } from '@nangohq/shared/lib/seeders/config.seeder.js';
+
+import * as HaloPsaWebhookRouting from './halo-psa-webhook-routing.js';
+import { InternalNango } from './internal-nango.js';
+
+function getNangoMock({ webhookSecret }: { webhookSecret?: string } = {}) {
+    const integration = getTestConfig({
+        provider: 'halo-psa',
+        custom: webhookSecret ? { webhookSecret } : {}
+    });
+
+    const mock = vi.fn().mockResolvedValue({ connectionIds: ['halo-connection'], connectionMetadata: {} });
+    const nangoMock = new InternalNango({
+        team: seeders.getTestTeam(),
+        environment: seeders.getTestEnvironment(),
+        plan: seeders.getTestPlan(),
+        integration,
+        logContextGetter
+    });
+    nangoMock.executeScriptForWebhooks = mock;
+
+    return { mock, nangoMock };
+}
+
+function basicAuth(password: string) {
+    return `Basic ${Buffer.from(`nango:${password}`).toString('base64')}`;
+}
+
+describe('haloPsaWebhookRouting', () => {
+    it('routes a standard Halo webhook using connectionId and webhookType query params', async () => {
+        const { mock, nangoMock } = getNangoMock();
+        const body = {
+            ticket: { id: 123, summary: 'Printer on fire' },
+            action: { id: 456, outcome: 'New Ticket Logged' }
+        };
+
+        const result = await HaloPsaWebhookRouting.default(nangoMock, {}, body, JSON.stringify(body), {
+            connectionId: 'halo-connection',
+            webhookType: 'ticket.created'
+        });
+
+        expect(result.isOk()).toBe(true);
+        expect(mock).toHaveBeenCalledOnce();
+        expect(mock).toHaveBeenCalledWith({
+            body: {
+                ...body,
+                nango: {
+                    connectionId: 'halo-connection',
+                    webhookType: 'ticket.created'
+                }
+            },
+            webhookTypeValue: 'ticket.created',
+            connectionIdentifierValue: 'halo-connection',
+            propName: 'connectionId'
+        });
+    });
+
+    it('routes a custom Halo payload using body fields', async () => {
+        const { mock, nangoMock } = getNangoMock();
+        const body = {
+            connectionId: 'body-connection',
+            type: 'ticket.updated',
+            ticketId: 123
+        };
+
+        const result = await HaloPsaWebhookRouting.default(nangoMock, {}, body, JSON.stringify(body));
+
+        expect(result.isOk()).toBe(true);
+        expect(mock).toHaveBeenCalledOnce();
+        expect(mock).toHaveBeenCalledWith(
+            expect.objectContaining({
+                webhookTypeValue: 'ticket.updated',
+                connectionIdentifierValue: 'body-connection'
+            })
+        );
+    });
+
+    it('wraps batched Halo events for onWebhook scripts', async () => {
+        const { mock, nangoMock } = getNangoMock();
+        const body = [{ ticket: { id: 123 } }, { ticket: { id: 456 } }];
+
+        const result = await HaloPsaWebhookRouting.default(nangoMock, {}, body, JSON.stringify(body), {
+            connectionId: 'halo-connection',
+            webhookType: 'ticket.batch'
+        });
+
+        expect(result.isOk()).toBe(true);
+        expect(mock).toHaveBeenCalledWith(
+            expect.objectContaining({
+                body: {
+                    events: body,
+                    nango: {
+                        connectionId: 'halo-connection',
+                        webhookType: 'ticket.batch'
+                    }
+                }
+            })
+        );
+    });
+
+    it('rejects Halo webhooks that do not identify a Nango connection', async () => {
+        const { mock, nangoMock } = getNangoMock();
+        const body = { ticketId: 123 };
+
+        const result = await HaloPsaWebhookRouting.default(nangoMock, {}, body, JSON.stringify(body));
+
+        expect(result.isErr()).toBe(true);
+        expect(mock).not.toHaveBeenCalled();
+    });
+
+    it('accepts Halo Basic Auth when the password matches the configured webhook secret', async () => {
+        const { mock, nangoMock } = getNangoMock({ webhookSecret: 'secret-from-nango' });
+        const body = { connectionId: 'halo-connection', type: 'ticket.created' };
+
+        const result = await HaloPsaWebhookRouting.default(nangoMock, { authorization: basicAuth('secret-from-nango') }, body, JSON.stringify(body));
+
+        expect(result.isOk()).toBe(true);
+        expect(mock).toHaveBeenCalledOnce();
+    });
+
+    it('rejects Halo Basic Auth when a webhook secret is configured but the password does not match', async () => {
+        const { mock, nangoMock } = getNangoMock({ webhookSecret: 'secret-from-nango' });
+        const body = { connectionId: 'halo-connection', type: 'ticket.created' };
+
+        const result = await HaloPsaWebhookRouting.default(nangoMock, { authorization: basicAuth('wrong-secret') }, body, JSON.stringify(body));
+
+        expect(result.isErr()).toBe(true);
+        expect(mock).not.toHaveBeenCalled();
+    });
+});

--- a/packages/server/lib/webhook/index.ts
+++ b/packages/server/lib/webhook/index.ts
@@ -30,4 +30,5 @@ export { default as sellsyWebhookRouting } from './sellsy-webhook-routing.js';
 export { default as fathomWebhookRouting } from './fathom-webhook-routing.js';
 export { default as calComWebhookRouting } from './cal-com-webhook-routing.js';
 export { default as streakWebhookRouting } from './streak-webhook-routing.js';
+export { default as haloPsaWebhookRouting } from './halo-psa-webhook-routing.js';
 export type * from './types.js';


### PR DESCRIPTION
## Summary

Adds webhook routing support for the Halo PSA provider, enabling Nango to receive Halo Standard Webhooks and dispatch them to sync `onWebhook` handlers.

- **Routing**: Routes by `connectionId` supplied via an allowed query param or JSON body fields (`nango.connectionId`, `connectionId`, `connection_id`). Halo Standard Webhooks do not include a Nango connection identifier by default, so the admin-configured webhook URL or payload provides it.
- **Webhook type**: Uses `webhookType` from the query/body, falls back to `type`, `event`, or `halo-psa`, and matches that value against sync `webhookSubscriptions`.
- **Validation**: Returns 400 if no connection ID is provided.
- **Authentication**: Supports optional Basic Auth password validation against the integration webhook secret.
- **Payload handling**: Preserves the original Halo payload for forwarding, injects normalized routing details under `payload.nango` for sync handlers, and wraps batched JSON arrays as `{ events, nango }`.

### Files changed

- `packages/providers/providers.yaml` — Added Halo PSA webhook routing, user-defined webhook secret, and allowed routing query params
- `packages/server/lib/webhook/halo-psa-webhook-routing.ts` — Webhook routing handler
- `packages/server/lib/webhook/index.ts` — Exported handler
- `packages/server/lib/webhook/halo-psa-webhook-routing.unit.test.ts` — Unit tests for routing, batching, missing connection IDs, and Basic Auth
- `docs/api-integrations/halo-psa/webhooks.mdx` — Halo PSA webhook setup guide
- `docs/api-integrations/halo-psa.mdx` — Linked the webhook guide and Halo webhook docs
- `docs/snippets/generated/halo-psa/PreBuiltTooling.mdx` — Marked third-party webhook support as available

## Test plan

- [x] Unit tests pass (`npm run test:unit -- packages/server/lib/webhook/halo-psa-webhook-routing.unit.test.ts`) — 6 tests
- [x] Provider validation passes (`npm run test:providers`)
- [x] TypeScript build passes (`npm run ts-build`)
- [x] Diff whitespace check passes (`git diff --check HEAD~1..HEAD`)
- [x] Manual end-to-end HaloPSA test passes: real Halo Standard Webhook delivered through a public tunnel to local Nango, Basic Auth rejection/acceptance verified, sync `onWebhook` executed, and a `HaloWebhookEvent` record was saved
