### PR TITLE
refactor(nan-5088): remove dual lookup, unify auth paths

### DIFF
--- a/packages/persist/lib/middleware/auth.middleware.ts
+++ b/packages/persist/lib/middleware/auth.middleware.ts
@@ -33,8 +33,8 @@ export const authMiddleware = async (req: Request, res: Response<any, AuthLocals
     }
 
     try {
-        const accountContext = await tracer.trace('persist.middleware.auth.getAccountAndEnvironmentBySecretKey', async () => {
-            return await accountService.getAccountContextByInternalSecretKey(secret);
+        const accountContext = await tracer.trace('persist.middleware.auth.getAccountContextByApiKey', async () => {
+            return await accountService.getAccountContextByApiKey({ internalSecretKey: secret });
         });
         if (!accountContext) {
             res.status(401).json({ error: { code: 'unauthorized', message: `Unauthorized: Account not found` } });

--- a/packages/persist/lib/server.integration.test.ts
+++ b/packages/persist/lib/server.integration.test.ts
@@ -50,8 +50,9 @@ describe('Persist API', () => {
         seed = await initDb();
         server.listen(port);
 
-        vi.spyOn(accountService, 'getAccountContextByInternalSecretKey').mockImplementation((secretKey) => {
-            if (secretKey === mockSecretKey) {
+        vi.spyOn(accountService, 'getAccountContextByApiKey').mockImplementation((opts) => {
+            const key = 'internalSecretKey' in opts ? opts.internalSecretKey : 'secretKey' in opts ? opts.secretKey : '';
+            if (key === mockSecretKey) {
                 return Promise.resolve({
                     account: seed.account,
                     environment: seed.env,

--- a/packages/server/lib/controllers/v1/environment/scopeEnforcement.integration.test.ts
+++ b/packages/server/lib/controllers/v1/environment/scopeEnforcement.integration.test.ts
@@ -590,30 +590,57 @@ describe('Scope enforcement on public API routes', () => {
             expect(res.json.data.credentials).toBeDefined();
         });
 
-        it('legacy api_secrets key should include credentials (backward compatible)', async () => {
+        it('api_secrets key with Nango-Is-Script header should include credentials (internal key path)', async () => {
             const { env, secret } = await seeders.seedAccountEnvAndUser();
             await seeders.createConfigSeed(env, 'github', 'github');
             await seeders.createConnectionSeed({
                 env,
                 provider: 'github',
-                connectionId: 'test-conn-legacy',
-                rawCredentials: { type: 'OAUTH2', access_token: 'legacy-token', raw: {} } as any
+                connectionId: 'test-conn-internal',
+                rawCredentials: { type: 'OAUTH2', access_token: 'internal-token', raw: {} } as any
             });
 
-            const res = await api.fetch(
-                '/connections/:connectionId' as any,
-                {
-                    method: 'GET',
-                    token: secret.secret,
-                    params: { connectionId: 'test-conn-legacy' },
-                    query: { provider_config_key: 'github' }
-                } as any
-            );
+            const res = await fetch(`${api.url}/connections/test-conn-internal?provider_config_key=github`, {
+                method: 'GET',
+                headers: {
+                    Authorization: `Bearer ${secret.secret}`,
+                    'Nango-Is-Script': 'true'
+                }
+            });
+            const json = await res.json();
 
-            expect(res.res.status).toBe(200);
-            // Legacy keys have no scope restriction — credentials included
-            expect(res.json.credentials).toBeDefined();
-            expect(res.json.credentials.access_token).toBeTruthy();
+            expect(res.status).toBe(200);
+            // Internal keys get environment:* scopes — credentials included
+            expect(json.credentials).toBeDefined();
+            expect(json.credentials.access_token).toBeTruthy();
+        });
+    });
+
+    // ── Internal script key (Nango-Is-Script header) ────────────────
+
+    describe('internal script key access', () => {
+        it('should allow access to scoped routes with Nango-Is-Script header', async () => {
+            const { secret } = await seeders.seedAccountEnvAndUser();
+
+            // Use raw fetch to send custom Nango-Is-Script header
+            const routes = ['/integrations', '/connections', '/scripts/config'];
+
+            for (const path of routes) {
+                const res = await fetch(`${api.url}${path}`, {
+                    method: 'GET',
+                    headers: {
+                        Authorization: `Bearer ${secret.secret}`,
+                        'Nango-Is-Script': 'true'
+                    }
+                });
+                expect(res.status).toBe(200);
+            }
+        });
+
+        it('should deny access without Nango-Is-Script header when using restricted customer key', async () => {
+            const token = await createKeyWithScopes([WRONG_SCOPE]);
+            const res = await api.fetch('/integrations', { method: 'GET', token } as any);
+            expect(res.res.status).toBe(403);
         });
     });
 });

--- a/packages/server/lib/controllers/v1/environment/scopeEnforcement.integration.test.ts
+++ b/packages/server/lib/controllers/v1/environment/scopeEnforcement.integration.test.ts
@@ -623,18 +623,14 @@ describe('Scope enforcement on public API routes', () => {
             const { secret } = await seeders.seedAccountEnvAndUser();
 
             // Use raw fetch to send custom Nango-Is-Script header
-            const routes = ['/integrations', '/connections', '/scripts/config'];
-
-            for (const path of routes) {
-                const res = await fetch(`${api.url}${path}`, {
-                    method: 'GET',
-                    headers: {
-                        Authorization: `Bearer ${secret.secret}`,
-                        'Nango-Is-Script': 'true'
-                    }
-                });
-                expect(res.status).toBe(200);
-            }
+            const res = await fetch(`${api.url}/integrations`, {
+                method: 'GET',
+                headers: {
+                    Authorization: `Bearer ${secret.secret}`,
+                    'Nango-Is-Script': 'true'
+                }
+            });
+            expect(res.status).toBe(200);
         });
 
         it('should deny access without Nango-Is-Script header when using restricted customer key', async () => {

--- a/packages/server/lib/middleware/access.middleware.ts
+++ b/packages/server/lib/middleware/access.middleware.ts
@@ -51,7 +51,7 @@ export class AccessMiddleware {
             secret: DBAPISecret;
             plan: DBPlan | null;
             auth?: {
-                source: string;
+                source: 'customer_key' | 'api_secret' | 'env_var';
                 scopes?: string[];
                 apiKeyId?: number;
             };

--- a/packages/server/lib/middleware/access.middleware.ts
+++ b/packages/server/lib/middleware/access.middleware.ts
@@ -69,7 +69,7 @@ export class AccessMiddleware {
             return Err('plan_not_found');
         }
 
-        return Ok(accountContext);
+        return Ok({ ...accountContext });
     }
 
     async secretKeyAuth(req: Request, res: Response<any, RequestLocals>, next: NextFunction) {

--- a/packages/server/lib/middleware/access.middleware.ts
+++ b/packages/server/lib/middleware/access.middleware.ts
@@ -60,9 +60,7 @@ export class AccessMiddleware {
         if (!keyRegex.test(secret)) {
             return Err('invalid_secret_key_format');
         }
-        const accountContext = await accountService.getAccountContextByApiKey(
-            opts.isScript ? { internalSecretKey: secret } : { secretKey: secret }
-        );
+        const accountContext = await accountService.getAccountContextByApiKey(opts.isScript ? { internalSecretKey: secret } : { secretKey: secret });
         if (!accountContext) {
             return Err('unknown_account');
         }

--- a/packages/server/lib/middleware/access.middleware.ts
+++ b/packages/server/lib/middleware/access.middleware.ts
@@ -41,14 +41,17 @@ const ignoreEnvPaths = [
 ];
 
 export class AccessMiddleware {
-    private async validateSecretKey(secret: string): Promise<
+    private async validateApiKey(
+        secret: string,
+        opts: { isScript: boolean }
+    ): Promise<
         Result<{
             account: DBTeam;
             environment: DBEnvironment;
             secret: DBAPISecret;
             plan: DBPlan | null;
             auth?: {
-                source: 'customer_key' | 'api_secret';
+                source: string;
                 scopes?: string[];
                 apiKeyId?: number;
             };
@@ -57,7 +60,9 @@ export class AccessMiddleware {
         if (!keyRegex.test(secret)) {
             return Err('invalid_secret_key_format');
         }
-        const accountContext = await accountService.getAccountContextBySecretKey(secret);
+        const accountContext = await accountService.getAccountContextByApiKey(
+            opts.isScript ? { internalSecretKey: secret } : { secretKey: secret }
+        );
         if (!accountContext) {
             return Err('unknown_account');
         }
@@ -66,7 +71,7 @@ export class AccessMiddleware {
             return Err('plan_not_found');
         }
 
-        return Ok({ ...accountContext });
+        return Ok(accountContext);
     }
 
     async secretKeyAuth(req: Request, res: Response<any, RequestLocals>, next: NextFunction) {
@@ -93,28 +98,7 @@ export class AccessMiddleware {
 
             const isScript = req.get('Nango-Is-Script') === 'true';
 
-            if (isScript) {
-                // Runner/script traffic — validate against api_secrets only (no customer_keys lookup).
-                // This prevents customer scope restrictions from breaking runner execution.
-                const accountContext = await accountService.getAccountContextByInternalSecretKey(secret);
-                if (!accountContext) {
-                    errorManager.errRes(res, 'unknown_account');
-                    return;
-                }
-                res.locals['authType'] = 'secretKey';
-                res.locals['account'] = accountContext.account;
-                res.locals['environment'] = accountContext.environment;
-                res.locals['plan'] = accountContext.plan;
-                res.locals['apiKeyScopes'] = ['environment:*'];
-                metrics.increment(metrics.Types.AUTH_GET_ENV_BY_SECRET_KEY_SOURCE, 1, {
-                    auth_source: 'internal_script'
-                });
-                tagTraceUser(accountContext);
-                next();
-                return;
-            }
-
-            const result = await this.validateSecretKey(secret);
+            const result = await this.validateApiKey(secret, { isScript });
             if (result.isErr()) {
                 errorManager.errRes(res, result.error.message);
                 return;
@@ -128,7 +112,7 @@ export class AccessMiddleware {
                 res.locals['apiKeyScopes'] = result.value.auth.scopes;
             }
             metrics.increment(metrics.Types.AUTH_GET_ENV_BY_SECRET_KEY_SOURCE, 1, {
-                auth_source: result.value.auth?.source ?? 'env_var'
+                auth_source: isScript ? 'internal_script' : (result.value.auth?.source ?? 'env_var')
             });
             tagTraceUser(result.value);
             next();
@@ -388,22 +372,22 @@ export class AccessMiddleware {
                     return;
                 }
 
-                const secretKeyResult = await this.validateSecretKey(token);
-                if (secretKeyResult.isErr()) {
-                    errorManager.errRes(res, secretKeyResult.error.message);
+                const apiKeyResult = await this.validateApiKey(token, { isScript: false });
+                if (apiKeyResult.isErr()) {
+                    errorManager.errRes(res, apiKeyResult.error.message);
                     return;
                 }
                 res.locals['authType'] = 'secretKey';
-                res.locals['account'] = secretKeyResult.value.account;
-                res.locals['environment'] = secretKeyResult.value.environment;
-                res.locals['plan'] = secretKeyResult.value.plan;
-                if (secretKeyResult.value.auth?.scopes) {
-                    res.locals['apiKeyScopes'] = secretKeyResult.value.auth.scopes;
+                res.locals['account'] = apiKeyResult.value.account;
+                res.locals['environment'] = apiKeyResult.value.environment;
+                res.locals['plan'] = apiKeyResult.value.plan;
+                if (apiKeyResult.value.auth?.scopes) {
+                    res.locals['apiKeyScopes'] = apiKeyResult.value.auth.scopes;
                 }
                 metrics.increment(metrics.Types.AUTH_GET_ENV_BY_SECRET_KEY_SOURCE, 1, {
-                    auth_source: secretKeyResult.value.auth?.source ?? 'env_var'
+                    auth_source: apiKeyResult.value.auth?.source ?? 'env_var'
                 });
-                tagTraceUser(secretKeyResult.value);
+                tagTraceUser(apiKeyResult.value);
             } else {
                 res.locals['authType'] = 'connectSession';
                 res.locals['account'] = connectSessionResult.value.account;
@@ -532,7 +516,7 @@ export class AccessMiddleware {
                 return;
             }
 
-            const result = await this.validateSecretKey(secret);
+            const result = await this.validateApiKey(secret, { isScript: false });
             if (result.isErr()) {
                 errorManager.errRes(res, result.error.message);
                 return;

--- a/packages/shared/lib/services/account.service.integration.test.ts
+++ b/packages/shared/lib/services/account.service.integration.test.ts
@@ -181,6 +181,42 @@ describe('Account service', () => {
         expect(new Date(thirdLastUsedAt).getTime()).toBeGreaterThan(staleTimestamp.getTime());
     });
 
+    it('should return environment:* scopes for internalSecretKey (api_secret path)', async () => {
+        const account = await createTestAccount();
+        const environment = await environmentService.createEnvironment(db.knex, { accountId: account.id, name: uuid() });
+        await plans.createPlan(db.knex, { account_id: account.id, name: 'free' });
+        const secret = (await secretService.getInternalSecretForEnv(db.knex, environment!.id)).unwrap();
+
+        const result = await accountService.getAccountContextByApiKey({ internalSecretKey: secret.secret });
+
+        expect(result?.auth).toStrictEqual({
+            source: 'api_secret',
+            scopes: ['environment:*']
+        });
+    });
+
+    it('should return environment:* scopes for env var key (env_var path)', async () => {
+        const account = await createTestAccount();
+        const envName = uuid();
+        await environmentService.createEnvironment(db.knex, { accountId: account.id, name: envName });
+        await plans.createPlan(db.knex, { account_id: account.id, name: 'free' });
+
+        const envVarName = `NANGO_SECRET_KEY_${envName.toUpperCase()}`;
+        const envVarKey = `nango_secret_key_${uuid()}`;
+        process.env[envVarName] = envVarKey;
+        try {
+            const result = await accountService.getAccountContextByApiKey({ secretKey: envVarKey });
+
+            expect(result?.auth).toStrictEqual({
+                source: 'env_var',
+                scopes: ['environment:*']
+            });
+        } finally {
+            // eslint-disable-next-line @typescript-eslint/no-dynamic-delete
+            delete process.env[envVarName];
+        }
+    });
+
     it('should retrieve account context by publicKey', async () => {
         const account = await createTestAccount();
         const environment = await environmentService.createEnvironment(db.knex, { accountId: account.id, name: uuid() });

--- a/packages/shared/lib/services/account.service.integration.test.ts
+++ b/packages/shared/lib/services/account.service.integration.test.ts
@@ -81,43 +81,17 @@ describe('Account service', () => {
         });
     });
 
-    it('should retrieve account context by legacy secretKey when customer key is missing', async () => {
+    it('should return null when customer key is missing (no fallback to api_secrets)', async () => {
         const account = await createTestAccount();
         const environment = await environmentService.createEnvironment(db.knex, { accountId: account.id, name: uuid() });
-        const plan = (await plans.createPlan(db.knex, { account_id: account.id, name: 'free' })).unwrap();
-        const secret = (await secretService.getInternalSecretForEnv(db.knex, environment!.id)).unwrap();
+        await plans.createPlan(db.knex, { account_id: account.id, name: 'free' });
 
         await db.knex('customer_keys_relations').where({ entity_type: 'environment', entity_id: environment!.id }).delete();
         await db.knex('customer_keys').where({ account_id: account.id, key_type: 'api' }).delete();
 
         const bySecretKey = await accountService.getAccountContext({ secretKey: environment!.secret_key });
 
-        expect(bySecretKey).toStrictEqual({
-            account: {
-                ...account,
-                created_at: expect.toBeIsoDateTimezone(),
-                updated_at: expect.toBeIsoDateTimezone()
-            },
-            environment: {
-                ...environment,
-                created_at: expect.toBeIsoDateTimezone(),
-                updated_at: expect.toBeIsoDateTimezone()
-            },
-            plan: {
-                ...plan,
-                created_at: expect.toBeIsoDateTimezone(),
-                updated_at: expect.toBeIsoDateTimezone()
-            },
-            secret: {
-                ...secret,
-                created_at: expect.toBeIsoDateTimezone(),
-                updated_at: expect.toBeIsoDateTimezone()
-            },
-            auth: {
-                source: 'api_secret',
-                scopes: ['environment:*']
-            }
-        });
+        expect(bySecretKey).toBeNull();
     });
 
     it('should prefer customer key scopes when both tables match the same secret', async () => {
@@ -140,7 +114,7 @@ describe('Account service', () => {
         });
     });
 
-    it('should fall back to legacy secret when matching customer key is soft-deleted', async () => {
+    it('should return null when matching customer key is soft-deleted (no fallback to api_secrets)', async () => {
         const account = await createTestAccount();
         const environment = await environmentService.createEnvironment(db.knex, { accountId: account.id, name: uuid() });
         await plans.createPlan(db.knex, { account_id: account.id, name: 'free' });
@@ -149,13 +123,10 @@ describe('Account service', () => {
 
         const bySecretKey = await accountService.getAccountContext({ secretKey: environment!.secret_key });
 
-        expect(bySecretKey?.auth).toStrictEqual({
-            source: 'api_secret',
-            scopes: ['environment:*']
-        });
+        expect(bySecretKey).toBeNull();
     });
 
-    it('should fall back to legacy secret when matching customer key relation is not environment-scoped', async () => {
+    it('should return null when matching customer key relation is not environment-scoped (no fallback to api_secrets)', async () => {
         const account = await createTestAccount();
         const environment = await environmentService.createEnvironment(db.knex, { accountId: account.id, name: uuid() });
         await plans.createPlan(db.knex, { account_id: account.id, name: 'free' });
@@ -173,10 +144,7 @@ describe('Account service', () => {
 
         const bySecretKey = await accountService.getAccountContext({ secretKey: environment!.secret_key });
 
-        expect(bySecretKey?.auth).toStrictEqual({
-            source: 'api_secret',
-            scopes: ['environment:*']
-        });
+        expect(bySecretKey).toBeNull();
     });
 
     it('should return null when secretKey does not match either table', async () => {

--- a/packages/shared/lib/services/account.service.ts
+++ b/packages/shared/lib/services/account.service.ts
@@ -21,7 +21,7 @@ interface AccountContext {
     secret: DBAPISecret;
     plan: DBPlan | null;
     auth?: {
-        source: 'customer_key' | 'api_secret';
+        source: 'customer_key' | 'api_secret' | 'env_var';
         scopes?: string[];
         apiKeyId?: number;
     };
@@ -193,60 +193,14 @@ class AccountService {
         return result || null;
     }
 
-    async getAccountContextBySecretKey(secretKey: string): Promise<AccountContext | null> {
+    async getAccountContextByApiKey(opts: { secretKey: string } | { internalSecretKey: string }): Promise<AccountContext | null> {
+        const key = 'secretKey' in opts ? opts.secretKey : opts.internalSecretKey;
+
         if (!isCloud) {
-            const environmentVariables = Object.keys(process.env).filter((key) => key.startsWith('NANGO_SECRET_KEY_'));
-            if (environmentVariables.length > 0) {
-                for (const environmentVariable of environmentVariables) {
-                    const envSecretKey = process.env[environmentVariable] as string;
-
-                    if (envSecretKey !== secretKey) {
-                        continue;
-                    }
-
-                    const envName = environmentVariable.replace('NANGO_SECRET_KEY_', '').toLowerCase();
-                    // This key is set dynamically and does not exist in database
-                    const env = await db.knex
-                        .select<Pick<DBEnvironment, 'account_id'>>('account_id')
-                        .from<DBEnvironment>('_nango_environments')
-                        .where({ name: envName, deleted: false })
-                        .first();
-
-                    if (!env) {
-                        return null;
-                    }
-
-                    const accountContext = await this.getAccountContext({ accountId: env.account_id, envName });
-
-                    if (!accountContext) {
-                        return null;
-                    }
-
-                    return {
-                        ...accountContext,
-                        auth: {
-                            source: 'api_secret',
-                            scopes: ['environment:*']
-                        }
-                    };
-                }
-            }
-        }
-
-        return this.getAccountContext({ secretKey });
-    }
-
-    /**
-     * Resolve account context using only api_secrets (no customer_keys lookup).
-     * Used by internal services (persist) that authenticate with the
-     * environment's internal secret key. Avoids polluting customer_keys.last_used_at.
-     */
-    async getAccountContextByInternalSecretKey(secretKey: string): Promise<AccountContext | null> {
-        if (!isCloud) {
-            const environmentVariables = Object.keys(process.env).filter((key) => key.startsWith('NANGO_SECRET_KEY_'));
+            const environmentVariables = Object.keys(process.env).filter((k) => k.startsWith('NANGO_SECRET_KEY_'));
             for (const environmentVariable of environmentVariables) {
                 const envSecretKey = process.env[environmentVariable] as string;
-                if (envSecretKey !== secretKey) {
+                if (envSecretKey !== key) {
                     continue;
                 }
                 const envName = environmentVariable.replace('NANGO_SECRET_KEY_', '').toLowerCase();
@@ -262,11 +216,17 @@ class AccountService {
                 if (!accountContext) {
                     return null;
                 }
-                return accountContext;
+                return {
+                    ...accountContext,
+                    auth: {
+                        source: 'env_var' as const,
+                        scopes: ['environment:*']
+                    }
+                };
             }
         }
 
-        return this.getAccountContext({ internalSecretKey: secretKey });
+        return this.getAccountContext(opts);
     }
 
     async getAccountContextByPublicKey(publicKey: string): Promise<AccountContext | null> {
@@ -310,7 +270,7 @@ class AccountService {
             | { accountUuid: string; envName: string }
     ): Promise<AccountContext | null> {
         if ('secretKey' in opts) {
-            return this.getAccountContextByAnySecret(opts.secretKey);
+            return this.getAccountContextByCustomerKey(opts.secretKey);
         }
         if ('internalSecretKey' in opts) {
             return this.getAccountContextByInternalSecret(opts.internalSecretKey);
@@ -395,7 +355,7 @@ class AccountService {
         };
     }
 
-    private async getAccountContextByAnySecret(secretKey: string): Promise<AccountContext | null> {
+    private async getAccountContextByCustomerKey(secretKey: string): Promise<AccountContext | null> {
         const cachedHash = hashLocalCache.get(secretKey);
         let hash: string;
         if (!cachedHash) {
@@ -420,9 +380,8 @@ class AccountService {
                 plan: DBPlan | null;
                 default_secret: DBAPISecret;
                 pending_secret: DBAPISecret | null;
-                auth_source: 'customer_key' | 'api_secret';
                 auth_scopes: string[] | null;
-                auth_api_key_id: number | null;
+                auth_api_key_id: number;
             }[];
         }>(
             `
@@ -443,24 +402,6 @@ class AccountService {
                     WHERE ck.id = mck.id
                       AND (ck.last_used_at IS NULL OR ck.last_used_at < NOW() - INTERVAL '1 minute')
                     RETURNING ck.id
-                ),
-                matched_auth AS (
-                    SELECT
-                        mck.environment_id,
-                        'customer_key'::text AS auth_source,
-                        mck.scopes AS auth_scopes,
-                        mck.id AS auth_api_key_id
-                    FROM matched_customer_key mck
-                    UNION ALL
-                    SELECT
-                        legacy.environment_id,
-                        'api_secret'::text AS auth_source,
-                        NULL::text[] AS auth_scopes,
-                        NULL::integer AS auth_api_key_id
-                    FROM api_secrets legacy
-                    WHERE legacy.hashed = ?
-                      AND legacy.is_default = true
-                      AND NOT EXISTS (SELECT 1 FROM matched_customer_key)
                 )
                 SELECT
                     row_to_json(_nango_environments.*) AS environment,
@@ -468,11 +409,10 @@ class AccountService {
                     row_to_json(plans.*) AS plan,
                     row_to_json(default_secret.*) AS default_secret,
                     row_to_json(pending_secret.*) AS pending_secret,
-                    matched_auth.auth_source,
-                    matched_auth.auth_scopes,
-                    matched_auth.auth_api_key_id
-                FROM matched_auth
-                JOIN _nango_environments ON _nango_environments.id = matched_auth.environment_id
+                    matched_customer_key.scopes AS auth_scopes,
+                    matched_customer_key.id AS auth_api_key_id
+                FROM matched_customer_key
+                JOIN _nango_environments ON _nango_environments.id = matched_customer_key.environment_id
                 JOIN _nango_accounts ON _nango_accounts.id = _nango_environments.account_id
                 JOIN api_secrets AS default_secret
                     ON default_secret.environment_id = _nango_environments.id
@@ -484,7 +424,7 @@ class AccountService {
                 WHERE _nango_environments.deleted = false
                 LIMIT 1;
             `,
-            [hash, hash]
+            [hash]
         );
         if (!row) {
             return null;
@@ -523,9 +463,9 @@ class AccountService {
                 : null,
             secret: defaultSecret,
             auth: {
-                source: row.auth_source,
-                scopes: row.auth_source === 'api_secret' ? ['environment:*'] : (row.auth_scopes ?? []),
-                ...(row.auth_api_key_id ? { apiKeyId: row.auth_api_key_id } : {})
+                source: 'customer_key' as const,
+                scopes: row.auth_scopes ?? [],
+                apiKeyId: row.auth_api_key_id
             }
         };
     }
@@ -613,7 +553,11 @@ class AccountService {
                       orb_future_plan_at: row.plan.orb_future_plan_at ? new Date(row.plan.orb_future_plan_at) : row.plan.orb_future_plan_at
                   }
                 : null,
-            secret: defaultSecret
+            secret: defaultSecret,
+            auth: {
+                source: 'api_secret' as const,
+                scopes: ['environment:*']
+            }
         };
     }
 }

--- a/packages/shared/lib/services/account.service.ts
+++ b/packages/shared/lib/services/account.service.ts
@@ -355,18 +355,22 @@ class AccountService {
         };
     }
 
-    private async getAccountContextByCustomerKey(secretKey: string): Promise<AccountContext | null> {
-        const cachedHash = hashLocalCache.get(secretKey);
-        let hash: string;
-        if (!cachedHash) {
-            const hashed = await secretService.hashSecret(secretKey);
-            if (hashed.isErr()) {
-                throw hashed.error;
-            }
-            hash = hashed.value;
-        } else {
-            hash = cachedHash;
+    private async hashSecretWithCache(secretKey: string): Promise<string> {
+        const cached = hashLocalCache.get(secretKey);
+        if (cached) {
+            metrics.increment(metrics.Types.AUTH_SECRET_KEY_HASH_CACHE, 1, { result: 'hit' });
+            return cached;
         }
+        metrics.increment(metrics.Types.AUTH_SECRET_KEY_HASH_CACHE, 1, { result: 'miss' });
+        const hashed = await secretService.hashSecret(secretKey);
+        if (hashed.isErr()) {
+            throw hashed.error;
+        }
+        return hashed.value;
+    }
+
+    private async getAccountContextByCustomerKey(secretKey: string): Promise<AccountContext | null> {
+        const hash = await this.hashSecretWithCache(secretKey);
 
         // This query debounces last_used_at in the same statement, so it must run on the primary.
         // If we later introduce real read replicas for auth lookups, split this into:
@@ -476,17 +480,7 @@ class AccountService {
      * environment's internal secret key. Avoids polluting customer_keys.last_used_at.
      */
     private async getAccountContextByInternalSecret(secretKey: string): Promise<AccountContext | null> {
-        let hash = hashLocalCache.get(secretKey);
-        if (hash) {
-            metrics.increment(metrics.Types.AUTH_SECRET_KEY_HASH_CACHE, 1, { result: 'hit' });
-        } else {
-            metrics.increment(metrics.Types.AUTH_SECRET_KEY_HASH_CACHE, 1, { result: 'miss' });
-            const hashed = await secretService.hashSecret(secretKey);
-            if (hashed.isErr()) {
-                throw hashed.error;
-            }
-            hash = hashed.value;
-        }
+        const hash = await this.hashSecretWithCache(secretKey);
 
         const row = await db.readOnly
             .select<{


### PR DESCRIPTION
## Why
- We are not having a single public API request which goes through the fallback, we did this solely for catching up data races during the migration. See [DD](https://us3.datadoghq.com/s/e94cfb60-2611-11ee-93ab-da7ad0900003/bie-tcr-qui) panel for this
- We can now remove the dual lookup

## Summary
- **Remove dual lookup**: `getAccountContextByCustomerKey` now only queries `customer_keys` (removed UNION ALL fallback to `api_secrets`). Customer API auth resolves exclusively through `customer_keys`.
- **Unify `validateApiKey`**: Single method in `access.middleware.ts` replaces the separate `isScript` branch and `validateSecretKey`, routing to `getAccountContextByApiKey({ secretKey | internalSecretKey })`.
- **Inject auth on internal keys**: `getAccountContextByInternalSecret` now returns `auth: { source: 'api_secret', scopes: ['environment:*'] }` — scopes are injected at the data layer rather than relying on middleware to check `isScript`.
- **Add `env_var` auth source**: Env-var-based keys return `auth: { source: 'env_var', scopes: ['environment:*'] }`.
- **Update tests**: Fallback tests updated to expect `null` (no dual lookup). Added internal script key tests using `Nango-Is-Script` header.

## Test plan
- [x] All 537 server integration tests pass (70 files)
- [x] All 22 persist integration tests pass
- [x] All 14 account service integration tests pass (including updated fallback tests)
- [x] Scope enforcement tests (47 tests) pass — including internal key access tests

🤖 Generated with [Claude Code](https://claude.com/claude-code)