### PR TITLE
chore: add CLAUDE.md with database migration conventions

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -7,4 +7,3 @@ Main database migrations live in `packages/database/lib/migrations/` (other serv
 - **Naming**: `<YYYYMMDDHHMMSS>_<description>.cjs` (e.g. `20260420120000_create_customer_keys.cjs`)
 - **No teardown**: `exports.down` is always an empty function — we never write rollback logic
 - **Foreign keys use `ON DELETE CASCADE`**: child rows are cleaned up automatically when the parent is deleted
-- **`exports.config = { transaction: false }`**: migrations run outside a transaction by default

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -5,5 +5,5 @@
 Main database migrations live in `packages/database/lib/migrations/` (other services have their own migration directories). Before writing a new migration, read 2-3 recent ones to match the current style.
 
 - **Naming**: `<YYYYMMDDHHMMSS>_<description>.cjs` (e.g. `20260420120000_create_customer_keys.cjs`)
-- **No teardown**: `exports.down` is always an empty function — we never write rollback logic
+- **Teardown**: ask the user whether `exports.down` should include rollback logic or be left empty
 - **Foreign keys**: use `ON DELETE CASCADE` for ownership relationships (child cannot exist without parent). Use `ON DELETE SET NULL` for optional references where the child should survive parent deletion. Check existing migrations for the pattern that fits.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -6,4 +6,4 @@ Main database migrations live in `packages/database/lib/migrations/` (other serv
 
 - **Naming**: `<YYYYMMDDHHMMSS>_<description>.cjs` (e.g. `20260420120000_create_customer_keys.cjs`)
 - **No teardown**: `exports.down` is always an empty function — we never write rollback logic
-- **Foreign keys use `ON DELETE CASCADE`**: child rows are cleaned up automatically when the parent is deleted
+- **Foreign keys**: use `ON DELETE CASCADE` for ownership relationships (child cannot exist without parent). Use `ON DELETE SET NULL` for optional references where the child should survive parent deletion. Check existing migrations for the pattern that fits.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,10 @@
+# Nango
+
+## Database Migrations
+
+Main database migrations live in `packages/database/lib/migrations/` (other services have their own migration directories). Before writing a new migration, read 2-3 recent ones to match the current style.
+
+- **Naming**: `<YYYYMMDDHHMMSS>_<description>.cjs` (e.g. `20260420120000_create_customer_keys.cjs`)
+- **No teardown**: `exports.down` is always an empty function — we never write rollback logic
+- **Foreign keys use `ON DELETE CASCADE`**: child rows are cleaned up automatically when the parent is deleted
+- **`exports.config = { transaction: false }`**: migrations run outside a transaction by default


### PR DESCRIPTION
## Summary
- Adds a repo-level `CLAUDE.md` with database migration conventions (naming, no teardown, CASCADE, transaction config)
- Starting point — more sections to be added over time

## Test plan
- [ ] No code changes, documentation only

🤖 Generated with [Claude Code](https://claude.com/claude-code)