### PR TITLE
docs: fix outdated import limitation and MCP URL (NAN-5358)

### DIFF
--- a/docs/implementation-guides/platform/functions/leverage-ai-agents.mdx
+++ b/docs/implementation-guides/platform/functions/leverage-ai-agents.mdx
@@ -6,7 +6,7 @@ description: 'Guide on how to use AI to build custom integrations on Nango.'
 
 <Tip>
     **Quickstart:**
-    1. Use Nango's documentation MCP: /mcp
+    1. Use Nango's documentation MCP: https://nango.dev/docs/mcp
     2. Install the function builder skill: `npx skills add NangoHQ/skills`
 </Tip>
 

--- a/docs/reference/functions.mdx
+++ b/docs/reference/functions.mdx
@@ -432,9 +432,7 @@ No parameters.
 
 ## Trigger action
 
-Integration functions currently do not support importing files, which limits the ability to share code between integration functions.
-
-As a temporary workaround, you can call action functions from other integration functions with:
+You can call action functions from other integration functions with:
 
 ```js
 await nango.triggerAction('<ACTION-NAME>', { 'custom_key1': 'custom_value1' });


### PR DESCRIPTION
## Summary
- Remove stale text in `docs/reference/functions.mdx` that incorrectly stated integration functions don't support importing files (they do now) — the `triggerAction` section no longer describes this as a workaround
- Fix the MCP URL in `docs/implementation-guides/platform/functions/leverage-ai-agents.mdx` from `/mcp` to `https://nango.dev/docs/mcp`

Fixes: https://linear.app/nango/issue/NAN-5358/docs-fixes

🤖 Generated with [Claude Code](https://claude.com/claude-code)