### PR TITLE
feat: add integrations quickstart endpoint

### DIFF
--- a/docs/spec.yaml
+++ b/docs/spec.yaml
@@ -126,9 +126,7 @@ paths:
                                     - data
                                 properties:
                                     data:
-                                        type: array
-                                        items:
-                                            $ref: '#/components/schemas/Integration'
+                                        $ref: '#/components/schemas/Integration'
                 '400':
                     $ref: '#/components/responses/BadRequest'
                 '401':

--- a/docs/spec.yaml
+++ b/docs/spec.yaml
@@ -133,6 +133,50 @@ paths:
                     $ref: '#/components/responses/BadRequest'
                 '401':
                     $ref: '#/components/responses/Unauthorized'
+    /integrations/quickstart:
+        post:
+            summary: Create a quickstart integration
+            description: Create an integration using a Nango-provided developer app for providers that require a developer app.
+            requestBody:
+                required: true
+                content:
+                    application/json:
+                        schema:
+                            type: object
+                            required:
+                                - unique_key
+                                - provider
+                            properties:
+                                unique_key:
+                                    type: string
+                                    description: A unique integration ID, which you will use in the other API calls to reference this integration.
+                                provider:
+                                    type: string
+                                    description: The provider unique name.
+                                display_name:
+                                    type: string
+                                    description: The integration display name.
+                                forward_webhooks:
+                                    type: boolean
+                                    description: Whether to forward webhooks for this integration.
+            responses:
+                '200':
+                    description: Successfully created an integration
+                    content:
+                        application/json:
+                            schema:
+                                type: object
+                                required:
+                                    - data
+                                properties:
+                                    data:
+                                        type: array
+                                        items:
+                                            $ref: '#/components/schemas/Integration'
+                '400':
+                    $ref: '#/components/responses/BadRequest'
+                '401':
+                    $ref: '#/components/responses/Unauthorized'
     /integrations/{uniqueKey}:
         get:
             summary: Get an integration

--- a/packages/node-client/lib/index.ts
+++ b/packages/node-client/lib/index.ts
@@ -45,6 +45,7 @@ import type {
     PostConnectSessions,
     PostPublicConnectSessionsReconnect,
     PostPublicIntegration,
+    PostPublicQuickstartIntegration,
     PostPublicTrigger,
     PostSyncVariant,
     SignatureCredentials,
@@ -203,6 +204,12 @@ export class Nango {
 
     public async createIntegration(body: PostPublicIntegration['Body']): Promise<PostPublicIntegration['Success']> {
         const url = `${this.serverUrl}/integrations`;
+        const response = await this.http.post(url, body, { headers: this.enrichHeaders({}) });
+        return response.data;
+    }
+
+    public async createQuickstartIntegration(body: PostPublicQuickstartIntegration['Body']): Promise<PostPublicQuickstartIntegration['Success']> {
+        const url = `${this.serverUrl}/integrations/quickstart`;
         const response = await this.http.post(url, body, { headers: this.enrichHeaders({}) });
         return response.data;
     }

--- a/packages/server/lib/controllers/integrations/postIntegration.ts
+++ b/packages/server/lib/controllers/integrations/postIntegration.ts
@@ -1,6 +1,6 @@
 import * as z from 'zod';
 
-import { configService, getProvider } from '@nangohq/shared';
+import { configService, getProvider, sharedCredentialsService } from '@nangohq/shared';
 import { requireEmptyQuery, zodErrorToHTTP } from '@nangohq/utils';
 
 import { integrationToPublicApi } from '../../formatters/integration.js';
@@ -13,17 +13,22 @@ import {
 } from '../../helpers/validation.js';
 import { asyncWrapper } from '../../utils/asyncWrapper.js';
 
-import type { DBCreateIntegration, PostPublicIntegration } from '@nangohq/types';
+import type { DBCreateIntegration, PostPublicIntegration, PostPublicQuickstartIntegration } from '@nangohq/types';
 
-const validationBody = z
+const baseValidationBody = z
     .object({
         provider: providerSchema,
         unique_key: providerConfigKeySchema,
         display_name: integrationDisplayNameSchema.optional(),
-        credentials: integrationCredentialsSchema.optional(),
         forward_webhooks: integrationForwardWebhooksSchema
     })
     .strict();
+
+const validationBody = baseValidationBody.extend({
+    credentials: integrationCredentialsSchema.optional()
+});
+
+const quickstartAuthModes = new Set(['OAUTH1', 'OAUTH2']);
 
 export const postPublicIntegration = asyncWrapper<PostPublicIntegration>(async (req, res) => {
     const emptyQuery = requireEmptyQuery(req);
@@ -114,6 +119,79 @@ export const postPublicIntegration = asyncWrapper<PostPublicIntegration>(async (
             }
         }
     }
+
+    const result = await configService.createProviderConfig(newIntegration, provider);
+    if (!result) {
+        res.status(500).send({ error: { code: 'server_error', message: 'Failed to create integration' } });
+        return;
+    }
+
+    res.status(200).send({
+        data: integrationToPublicApi({ integration: result, provider })
+    });
+});
+
+export const postPublicQuickstartIntegration = asyncWrapper<PostPublicQuickstartIntegration>(async (req, res) => {
+    const emptyQuery = requireEmptyQuery(req);
+    if (emptyQuery) {
+        res.status(400).send({ error: { code: 'invalid_query_params', errors: zodErrorToHTTP(emptyQuery.error) } });
+        return;
+    }
+
+    const valBody = baseValidationBody.safeParse(req.body);
+    if (!valBody.success) {
+        res.status(400).send({ error: { code: 'invalid_body', errors: zodErrorToHTTP(valBody.error) } });
+        return;
+    }
+
+    const { environment } = res.locals;
+    const body: PostPublicQuickstartIntegration['Body'] = valBody.data;
+    const provider = getProvider(body.provider);
+    if (!provider) {
+        res.status(400).send({
+            error: { code: 'invalid_body', errors: [{ code: 'invalid_string', message: 'Invalid provider', path: ['provider'] }] }
+        });
+        return;
+    }
+
+    if (!quickstartAuthModes.has(provider.auth_mode)) {
+        res.status(400).send({
+            error: { code: 'invalid_body', message: 'Quickstart is only available for providers that require a developer app' }
+        });
+        return;
+    }
+
+    const exists = await configService.getProviderConfig(body.unique_key, environment.id);
+    if (exists) {
+        res.status(400).send({
+            error: { code: 'invalid_body', errors: [{ code: 'invalid_string', message: 'Unique key already exists', path: ['uniqueKey'] }] }
+        });
+        return;
+    }
+
+    const sharedCredentials = await sharedCredentialsService.getLatestSharedCredentialsByName(body.provider);
+    if (sharedCredentials.isErr()) {
+        res.status(500).send({ error: { code: 'server_error', message: 'Failed to load Nango-provided developer app' } });
+        return;
+    }
+
+    if (!sharedCredentials.value) {
+        res.status(400).send({
+            error: { code: 'invalid_body', message: 'No Nango-provided developer app is configured for this provider' }
+        });
+        return;
+    }
+
+    const newIntegration: DBCreateIntegration = {
+        environment_id: environment.id,
+        provider: body.provider,
+        display_name: body.display_name || null,
+        unique_key: body.unique_key,
+        custom: null,
+        missing_fields: [],
+        forward_webhooks: body.forward_webhooks ?? true,
+        shared_credentials_id: sharedCredentials.value.id
+    };
 
     const result = await configService.createProviderConfig(newIntegration, provider);
     if (!result) {

--- a/packages/server/lib/controllers/integrations/postQuickstartIntegration.integration.test.ts
+++ b/packages/server/lib/controllers/integrations/postQuickstartIntegration.integration.test.ts
@@ -80,7 +80,7 @@ describe(`POST ${endpoint}`, () => {
         const res = await api.fetch(endpoint, {
             method: 'POST',
             token: secret.secret,
-            body: { provider: 'github', unique_key: 'github-quickstart' }
+            body: { provider: 'docusign-sandbox', unique_key: 'docusign-quickstart' }
         });
 
         isError(res.json);

--- a/packages/server/lib/controllers/integrations/postQuickstartIntegration.integration.test.ts
+++ b/packages/server/lib/controllers/integrations/postQuickstartIntegration.integration.test.ts
@@ -1,0 +1,153 @@
+import { afterAll, beforeAll, describe, expect, it } from 'vitest';
+
+import { seeders } from '@nangohq/shared';
+
+import { isError, isSuccess, runServer, shouldBeProtected } from '../../utils/tests.js';
+
+let api: Awaited<ReturnType<typeof runServer>>;
+
+const endpoint = '/integrations/quickstart';
+const getEndpoint = '/integrations/:uniqueKey';
+
+describe(`POST ${endpoint}`, () => {
+    beforeAll(async () => {
+        api = await runServer();
+    });
+    afterAll(() => {
+        api.server.close();
+    });
+
+    it('should be protected', async () => {
+        const res = await api.fetch(endpoint, {
+            method: 'POST',
+            // @ts-expect-error on purpose
+            body: { provider: 'github' }
+        });
+
+        shouldBeProtected(res);
+    });
+
+    it('should reject credentials in the body', async () => {
+        const { secret } = await seeders.seedAccountEnvAndUser();
+        const res = await api.fetch(endpoint, {
+            method: 'POST',
+            token: secret.secret,
+            body: {
+                provider: 'github',
+                unique_key: 'github-quickstart',
+                credentials: {
+                    type: 'OAUTH2',
+                    client_id: 'client-id',
+                    client_secret: 'client-secret'
+                }
+            } as any
+        });
+
+        isError(res.json);
+        expect(res.json.error.code).toBe('invalid_body');
+    });
+
+    it('should validate the provider', async () => {
+        const { secret } = await seeders.seedAccountEnvAndUser();
+        const res = await api.fetch(endpoint, {
+            method: 'POST',
+            token: secret.secret,
+            body: { provider: 'invalid', unique_key: 'foobar' }
+        });
+
+        isError(res.json);
+        expect(res.json).toStrictEqual<typeof res.json>({
+            error: { code: 'invalid_body', errors: [{ code: 'invalid_string', message: 'Invalid provider', path: ['provider'] }] }
+        });
+    });
+
+    it('should reject providers that do not require a developer app', async () => {
+        const { secret } = await seeders.seedAccountEnvAndUser();
+        const res = await api.fetch(endpoint, {
+            method: 'POST',
+            token: secret.secret,
+            body: { provider: 'algolia', unique_key: 'algolia-quickstart' }
+        });
+
+        isError(res.json);
+        expect(res.json).toStrictEqual<typeof res.json>({
+            error: { code: 'invalid_body', message: 'Quickstart is only available for providers that require a developer app' }
+        });
+    });
+
+    it('should reject providers without a Nango-provided developer app', async () => {
+        const { secret } = await seeders.seedAccountEnvAndUser();
+        const res = await api.fetch(endpoint, {
+            method: 'POST',
+            token: secret.secret,
+            body: { provider: 'github', unique_key: 'github-quickstart' }
+        });
+
+        isError(res.json);
+        expect(res.json).toStrictEqual<typeof res.json>({
+            error: { code: 'invalid_body', message: 'No Nango-provided developer app is configured for this provider' }
+        });
+    });
+
+    it('should reject duplicate unique keys', async () => {
+        const { env, secret } = await seeders.seedAccountEnvAndUser();
+        await seeders.createConfigSeed(env, 'github-quickstart', 'github');
+        await seeders.createSharedCredentialsSeed('github');
+
+        const res = await api.fetch(endpoint, {
+            method: 'POST',
+            token: secret.secret,
+            body: { provider: 'github', unique_key: 'github-quickstart' }
+        });
+
+        isError(res.json);
+        expect(res.json).toStrictEqual<typeof res.json>({
+            error: { code: 'invalid_body', errors: [{ code: 'invalid_string', message: 'Unique key already exists', path: ['uniqueKey'] }] }
+        });
+    });
+
+    it('should create an integration with a Nango-provided developer app', async () => {
+        const { secret } = await seeders.seedAccountEnvAndUser();
+        await seeders.createSharedCredentialsSeed('github');
+
+        const res = await api.fetch(endpoint, {
+            method: 'POST',
+            token: secret.secret,
+            body: {
+                provider: 'github',
+                unique_key: 'github-quickstart',
+                display_name: 'GitHub Quickstart',
+                forward_webhooks: false
+            }
+        });
+
+        isSuccess(res.json);
+        expect(res.json).toStrictEqual<typeof res.json>({
+            data: {
+                created_at: expect.toBeIsoDate(),
+                display_name: 'GitHub Quickstart',
+                logo: 'http://localhost:3003/images/template-logos/github.svg',
+                provider: 'github',
+                unique_key: 'github-quickstart',
+                updated_at: expect.toBeIsoDate(),
+                forward_webhooks: false
+            }
+        });
+
+        const resGet = await api.fetch(getEndpoint, {
+            method: 'GET',
+            token: secret.secret,
+            params: { uniqueKey: 'github-quickstart' },
+            query: { include: ['credentials'] }
+        });
+
+        isSuccess(resGet.json);
+        expect(resGet.json.data.credentials).toStrictEqual({
+            type: 'OAUTH2',
+            client_id: '',
+            client_secret: '',
+            scopes: 'test',
+            webhook_secret: null
+        });
+    });
+});

--- a/packages/server/lib/controllers/v1/environment/scopeEnforcement.integration.test.ts
+++ b/packages/server/lib/controllers/v1/environment/scopeEnforcement.integration.test.ts
@@ -81,6 +81,20 @@ describe('Scope enforcement on public API routes', () => {
         });
     });
 
+    describe('POST /integrations/quickstart', () => {
+        it('should allow with integrations:write scope', async () => {
+            const token = await createKeyWithScopes(['environment:integrations:write']);
+            const res = await api.fetch('/integrations/quickstart', { method: 'POST', token, body: {} } as any);
+            expect(res.res.status).not.toBe(403);
+        });
+
+        it('should deny without integrations:write scope', async () => {
+            const token = await createKeyWithScopes([WRONG_SCOPE]);
+            const res = await api.fetch('/integrations/quickstart', { method: 'POST', token, body: {} } as any);
+            expect(res.res.status).toBe(403);
+        });
+    });
+
     describe('GET /integrations/:uniqueKey', () => {
         it('should allow with integrations:read scope', async () => {
             const token = await createKeyWithScopes(['environment:integrations:read']);

--- a/packages/server/lib/routes.public.ts
+++ b/packages/server/lib/routes.public.ts
@@ -38,7 +38,7 @@ import { postRemoteFunctionCompile } from './controllers/functions/compile/postC
 import { postRemoteFunctionDeploy } from './controllers/functions/deploy/postDeploy.js';
 import { postRemoteFunctionDryrun } from './controllers/functions/dryrun/postDryrun.js';
 import { getPublicListIntegrations } from './controllers/integrations/getListIntegrations.js';
-import { postPublicIntegration } from './controllers/integrations/postIntegration.js';
+import { postPublicIntegration, postPublicQuickstartIntegration } from './controllers/integrations/postIntegration.js';
 import { deletePublicIntegration } from './controllers/integrations/uniqueKey/deleteIntegration.js';
 import { getPublicIntegration } from './controllers/integrations/uniqueKey/getIntegration.js';
 import { patchPublicIntegration } from './controllers/integrations/uniqueKey/patchIntegration.js';
@@ -184,6 +184,7 @@ publicAPI
     .route('/integrations')
     .get(connectSessionOrApiAuth, withAnyScope('environment:integrations:list', 'environment:integrations:list_credentials'), getPublicListIntegrations);
 publicAPI.route('/integrations').post(apiAuth, withScope('environment:integrations:write'), postPublicIntegration);
+publicAPI.route('/integrations/quickstart').post(apiAuth, withScope('environment:integrations:write'), postPublicQuickstartIntegration);
 publicAPI.route('/integrations/:uniqueKey').patch(apiAuth, withScope('environment:integrations:write'), patchPublicIntegration);
 publicAPI
     .route('/integrations/:uniqueKey')

--- a/packages/shared/lib/services/shared-credentials.service.ts
+++ b/packages/shared/lib/services/shared-credentials.service.ts
@@ -4,6 +4,7 @@ import { Err, Ok, nanoid } from '@nangohq/utils';
 import configService from './config.service.js';
 import encryptionManager from '../utils/encryption.manager.js';
 
+import type { Knex } from '@nangohq/database';
 import type {
     DBSharedCredentials,
     IntegrationConfig,
@@ -14,7 +15,27 @@ import type {
     SharedCredentialsInputDto
 } from '@nangohq/types';
 
+async function getLatestSharedCredentialsRecordByName({
+    name,
+    trx = db.knex
+}: {
+    name: string;
+    trx?: Knex.Transaction | Knex;
+}): Promise<DBSharedCredentials | undefined> {
+    return await trx.select('*').from<DBSharedCredentials>('providers_shared_credentials').where('name', name).orderBy('created_at', 'desc').first();
+}
+
 class SharedCredentialsService {
+    async getLatestSharedCredentialsByName(name: string): Promise<Result<DBSharedCredentials | null>> {
+        try {
+            const sharedCredentials = await getLatestSharedCredentialsRecordByName({ name });
+
+            return Ok(sharedCredentials ?? null);
+        } catch (err) {
+            return Err(new Error('failed_to_get_shared_credentials_by_name', { cause: err }));
+        }
+    }
+
     async createPreprovisionedProvider({
         providerName,
         environment_id,
@@ -32,12 +53,10 @@ class SharedCredentialsService {
     }): Promise<Result<IntegrationConfig>> {
         try {
             const config = await db.knex.transaction(async (trx) => {
-                const sharedCredentials = await trx
-                    .select('*')
-                    .from<DBSharedCredentials>('providers_shared_credentials')
-                    .where('name', shared_credentials_name ?? providerName)
-                    .orderBy('created_at', 'desc')
-                    .first();
+                const sharedCredentials = await getLatestSharedCredentialsRecordByName({
+                    name: shared_credentials_name ?? providerName,
+                    trx
+                });
 
                 if (!sharedCredentials) {
                     throw new Error('shared_credentials_not_found');

--- a/packages/types/lib/api.endpoints.ts
+++ b/packages/types/lib/api.endpoints.ts
@@ -74,7 +74,8 @@ import type {
     PatchIntegration,
     PatchPublicIntegration,
     PostIntegration,
-    PostPublicIntegration
+    PostPublicIntegration,
+    PostPublicQuickstartIntegration
 } from './integration/api.js';
 import type { DeleteInvite, GetInvite, PostInvite } from './invitations/api.js';
 import type { GetOperation, PostInsights, SearchFilters, SearchMessages, SearchOperations } from './logs/api.js';
@@ -130,6 +131,7 @@ export type PublicApiEndpoints =
     | PostPublicConnectTelemetry
     | PutPublicSyncConnectionFrequency
     | PostPublicIntegration
+    | PostPublicQuickstartIntegration
     | PatchPublicIntegration
     | GetAsyncActionResult
     | PostPublicOauthOutboundAuthorization

--- a/packages/types/lib/integration/api.ts
+++ b/packages/types/lib/integration/api.ts
@@ -49,6 +49,20 @@ export type PostPublicIntegration = Endpoint<{
     };
 }>;
 
+export type PostPublicQuickstartIntegration = Endpoint<{
+    Method: 'POST';
+    Path: '/integrations/quickstart';
+    Body: {
+        provider: string;
+        unique_key: string;
+        display_name?: string | undefined;
+        forward_webhooks?: boolean | undefined;
+    };
+    Success: {
+        data: ApiPublicIntegration;
+    };
+}>;
+
 export type GetPublicIntegration = Endpoint<{
     Method: 'GET';
     Path: '/integrations/:uniqueKey';


### PR DESCRIPTION
<!-- Describe the problem and your solution -->
Adds a public `POST /integrations/quickstart` endpoint that mirrors `POST /integrations` but creates the integration with a Nango-provided developer app instead of accepting credentials. The change wires the endpoint through the public server routes, shared credential lookup, public API types, node client, OpenAPI spec, and integration/scope-enforcement coverage.

<!-- Issue ticket number and link (if applicable) -->


<!-- Testing instructions (skip if just adding/editing providers) -->
- `npm run test:integration -- packages/server/lib/controllers/integrations/postQuickstartIntegration.integration.test.ts`
- `npx tsc -p packages/shared/tsconfig.json --noEmit && npx tsc -p packages/server/tsconfig.json --noEmit`