### PR TITLE
refactor(nan-5088): remove legacy key rotation code

### DIFF
--- a/packages/server/lib/controllers/environment.controller.ts
+++ b/packages/server/lib/controllers/environment.controller.ts
@@ -69,53 +69,6 @@ class EnvironmentController {
             next(err);
         }
     }
-
-    async rotateKey(req: Request, res: Response<any, Required<RequestLocals>>, next: NextFunction) {
-        try {
-            if (!req.body.type) {
-                res.status(400).send({ error: 'The type of key to rotate is required' });
-                return;
-            }
-
-            const { environment } = res.locals;
-
-            const newKey = await environmentService.rotateKey(environment.id, req.body.type);
-            res.status(200).send({ key: newKey });
-        } catch (err) {
-            next(err);
-        }
-    }
-
-    async revertKey(req: Request, res: Response<any, Required<RequestLocals>>, next: NextFunction) {
-        try {
-            if (!req.body.type) {
-                res.status(400).send({ error: 'The type of key to rotate is required' });
-                return;
-            }
-
-            const { environment } = res.locals;
-
-            const newKey = await environmentService.revertKey(environment.id, req.body.type);
-            res.status(200).send({ key: newKey });
-        } catch (err) {
-            next(err);
-        }
-    }
-
-    async activateKey(req: Request, res: Response<any, Required<RequestLocals>>, next: NextFunction) {
-        try {
-            if (!req.body.type) {
-                res.status(400).send({ error: 'The type of key to activate is required' });
-                return;
-            }
-            const { environment } = res.locals;
-
-            await environmentService.activateKey(environment.id, req.body.type);
-            res.status(200).send();
-        } catch (err) {
-            next(err);
-        }
-    }
 }
 
 export default new EnvironmentController();

--- a/packages/server/lib/routes.private.ts
+++ b/packages/server/lib/routes.private.ts
@@ -210,10 +210,6 @@ web.route('/environment/api-keys/:keyId').patch(webAuth, can({ action: 'update',
 web.route('/environment/api-keys/:keyId').delete(webAuth, can({ action: 'update', resource: 'environment_key', scopedBy: envScope }), deleteApiKey);
 
 web.route('/environment/hmac').get(webAuth, environmentController.getHmacDigest.bind(environmentController));
-// Legacy key rotation endpoints — disabled, replaced by customer_keys API (NAN-5088)
-// web.route('/environment/rotate-key').post(webAuth, can(...), environmentController.rotateKey)
-// web.route('/environment/revert-key').post(webAuth, can(...), environmentController.revertKey)
-// web.route('/environment/activate-key').post(webAuth, can(...), environmentController.activateKey)
 web.route('/environment/admin-auth').get(webAuth, environmentController.getAdminAuthInfo.bind(environmentController));
 
 // Connect

--- a/packages/shared/lib/services/environment.service.integration.test.ts
+++ b/packages/shared/lib/services/environment.service.integration.test.ts
@@ -4,7 +4,6 @@ import { beforeAll, describe, expect, it } from 'vitest';
 import db, { multipleMigrations } from '@nangohq/database';
 
 import environmentService from './environment.service.js';
-import secretService from './secret.service.js';
 import { createAccount } from '../seeders/account.seeder.js';
 import { createEnvironmentSeed } from '../seeders/environment.seeder.js';
 
@@ -52,39 +51,6 @@ describe('Environment service', () => {
         });
 
         expect(env.secret_key).toBeUUID();
-    });
-
-    it('should rotate secretKey', async () => {
-        const account = await createAccount();
-        const env = (await environmentService.createEnvironment(db.knex, { accountId: account.id, name: uuid() }))!;
-        expect(env.secret_key).toBeUUID();
-        expect(env.pending_secret_key).toBeNull();
-
-        const secret = (await secretService.getInternalSecretForEnv(db.knex, env.id)).unwrap();
-        expect(secret.is_default).toBe(true);
-        expect(secret.secret).toEqual(env.secret_key);
-
-        // Rotate
-        await environmentService.rotateSecretKey(env.id);
-
-        const env2 = (await environmentService.getById(env.id))!;
-        expect(env2.secret_key).toEqual(env.secret_key);
-        expect(env2.pending_secret_key).toBeUUID();
-
-        const secret2 = (await secretService.getInternalSecretForEnv(db.knex, env.id)).unwrap();
-        expect(secret2).toEqual(secret);
-
-        // Activate
-        await environmentService.activateSecretKey(env.id);
-
-        const env3 = (await environmentService.getById(env.id))!;
-        expect(env3.secret_key).toBeUUID();
-        expect(env3.pending_secret_key).toBeNull();
-
-        const secret3 = (await secretService.getInternalSecretForEnv(db.knex, env.id)).unwrap();
-        expect(secret3).not.toEqual(secret2);
-        expect(secret3.is_default).toBe(true);
-        expect(secret3.secret).toEqual(env3.secret_key);
     });
 
     it('should set is_production = true when name is prod', async () => {

--- a/packages/shared/lib/services/environment.service.ts
+++ b/packages/shared/lib/services/environment.service.ts
@@ -1,4 +1,3 @@
-import * as uuid from 'uuid';
 import * as z from 'zod';
 
 import db from '@nangohq/database';
@@ -13,7 +12,7 @@ import errorManager, { ErrorSourceEnum } from '../utils/error.manager.js';
 
 import type { Orchestrator } from '../index.js';
 import type { Knex } from '@nangohq/database';
-import type { DBAPISecret, DBEnvironment, DBEnvironmentVariable, SdkLogger } from '@nangohq/types';
+import type { DBEnvironment, DBEnvironmentVariable, SdkLogger } from '@nangohq/types';
 
 const TABLE = '_nango_environments';
 
@@ -234,155 +233,6 @@ class EnvironmentService {
         }
 
         return results;
-    }
-
-    async rotateKey(id: number, type: string): Promise<string | null> {
-        if (type === 'secret') {
-            return this.rotateSecretKey(id);
-        }
-
-        if (type === 'public') {
-            return this.rotatePublicKey(id);
-        }
-
-        return null;
-    }
-
-    async revertKey(id: number, type: string): Promise<string | null> {
-        if (type === 'secret') {
-            return this.revertSecretKey(id);
-        }
-
-        if (type === 'public') {
-            return this.revertPublicKey(id);
-        }
-
-        return null;
-    }
-
-    async activateKey(id: number, type: string): Promise<boolean> {
-        if (type === 'secret') {
-            return this.activateSecretKey(id);
-        }
-
-        if (type === 'public') {
-            return this.activatePublicKey(id);
-        }
-
-        return false;
-    }
-
-    async rotateSecretKey(envId: number): Promise<string | null> {
-        const created = await db.knex.transaction(async (trx) => {
-            const environment = await this.getByIdWithoutSecrets(trx, envId);
-            if (!environment) {
-                trx.rollback();
-                return null;
-            }
-            // Note: For now, we enforce the invariant that only one non-default API secret
-            // can exist at a time: the 'pending' secret, during rotation.
-            await trx<DBAPISecret>('api_secrets').delete().where({
-                environment_id: environment.id,
-                is_default: false
-            });
-            return secretService.createSecret(trx, {
-                environmentId: environment.id,
-                displayName: `rotated-${new Date().toISOString()}`,
-                isDefault: false
-            });
-        });
-        if (created === null) {
-            return null;
-        }
-        if (created.isErr()) {
-            throw created.error;
-        }
-        return created.value.secret;
-    }
-
-    async rotatePublicKey(id: number): Promise<string | null> {
-        const pending_public_key = uuid.v4();
-
-        await db.knex.from<DBEnvironment>(TABLE).where({ id }).update({ pending_public_key });
-
-        return pending_public_key;
-    }
-
-    async revertSecretKey(envId: number): Promise<string | null> {
-        const defaultSecret = await db.knex.transaction(async (trx) => {
-            const environment = await this.getByIdWithoutSecrets(trx, envId);
-            if (!environment) {
-                trx.rollback();
-                return null;
-            }
-            await trx<DBAPISecret>('api_secrets').delete().where({
-                environment_id: environment.id,
-                is_default: false
-            });
-            return secretService.getInternalSecretForEnv(trx, envId);
-        });
-        if (defaultSecret === null) {
-            return null;
-        }
-        if (defaultSecret.isErr()) {
-            throw defaultSecret.error;
-        }
-        return defaultSecret.value.secret;
-    }
-
-    async revertPublicKey(id: number): Promise<string | null> {
-        const environment = await this.getById(id);
-
-        if (!environment) {
-            return null;
-        }
-
-        await db.knex.from<DBEnvironment>(TABLE).where({ id }).update({ pending_public_key: null });
-
-        return environment.public_key;
-    }
-
-    async activateSecretKey(envId: number): Promise<boolean> {
-        return await db.knex.transaction(async (trx) => {
-            const environment = await this.getByIdWithoutSecrets(trx, envId);
-            if (!environment) {
-                trx.rollback();
-                return false;
-            }
-            // Note: For now, only one non-default secret can exist: the 'pending' secret.
-            const [secret] = await trx<DBAPISecret>('api_secrets').select('*').where({
-                environment_id: environment.id,
-                is_default: false
-            });
-            if (!secret) {
-                trx.rollback();
-                return false;
-            }
-            await secretService.markDefault(trx, secret.id);
-            await trx<DBAPISecret>('api_secrets').delete().where({
-                environment_id: environment.id,
-                is_default: false
-            });
-            return true;
-        });
-    }
-
-    async activatePublicKey(id: number): Promise<boolean> {
-        const environment = await this.getById(id);
-
-        if (!environment) {
-            return false;
-        }
-
-        await db.knex
-            .from<DBEnvironment>(TABLE)
-            .where({ id })
-            .update({
-                public_key: environment.pending_public_key as string,
-                pending_public_key: null
-            });
-
-        return true;
     }
 
     async getOauthCallbackUrl(environmentId?: number): Promise<string> {

--- a/packages/webapp/src/hooks/useEnvironment.tsx
+++ b/packages/webapp/src/hooks/useEnvironment.tsx
@@ -112,66 +112,6 @@ export function usePostEnvironment() {
     });
 }
 
-export function useRotateKey(env: string) {
-    const queryClient = useQueryClient();
-    return useMutation<undefined, APIError>({
-        mutationFn: async () => {
-            const res = await apiFetch(`/api/v1/environment/rotate-key?env=${env}`, {
-                method: 'POST',
-                body: JSON.stringify({ type: 'secret' })
-            });
-
-            if (!res.ok) {
-                const json = (await res.json()) as Record<string, unknown>;
-                throw new APIError({ res, json });
-            }
-        },
-        onSuccess: async () => {
-            await queryClient.invalidateQueries({ queryKey: environmentQueryKey(env) });
-        }
-    });
-}
-
-export function useRevertKey(env: string) {
-    const queryClient = useQueryClient();
-    return useMutation<undefined, APIError>({
-        mutationFn: async () => {
-            const res = await apiFetch(`/api/v1/environment/revert-key?env=${env}`, {
-                method: 'POST',
-                body: JSON.stringify({ type: 'secret' })
-            });
-
-            if (!res.ok) {
-                const json = (await res.json()) as Record<string, unknown>;
-                throw new APIError({ res, json });
-            }
-        },
-        onSuccess: async () => {
-            await queryClient.invalidateQueries({ queryKey: environmentQueryKey(env) });
-        }
-    });
-}
-
-export function useActivateKey(env: string) {
-    const queryClient = useQueryClient();
-    return useMutation<undefined, APIError>({
-        mutationFn: async () => {
-            const res = await apiFetch(`/api/v1/environment/activate-key?env=${env}`, {
-                method: 'POST',
-                body: JSON.stringify({ type: 'secret' })
-            });
-
-            if (!res.ok) {
-                const json = (await res.json()) as Record<string, unknown>;
-                throw new APIError({ res, json });
-            }
-        },
-        onSuccess: async () => {
-            await queryClient.invalidateQueries({ queryKey: environmentQueryKey(env) });
-        }
-    });
-}
-
 export function useDeleteEnvironment(env: string) {
     const queryClient = useQueryClient();
     return useMutation<undefined, APIError>({


### PR DESCRIPTION
## Summary
- Remove `rotateKey`, `revertKey`, `activateKey` from environment controller
- Remove `rotateSecretKey`, `activateSecretKey`, `rotateKey`, `revertKey`, `activateKey`, `rotatePublicKey`, `revertSecretKey`, `revertPublicKey`, `activatePublicKey` from environment service
- Remove commented-out routes in `routes.private.ts`
- Remove `useRotateKey`, `useRevertKey`, `useActivateKey` hooks from webapp
- Remove `should rotate secretKey` integration test

These endpoints were already disabled (routes commented out) and are replaced by the customer_keys API key management.

## Test plan
- [x] Build passes
- [x] No remaining references to removed methods

🤖 Generated with [Claude Code](https://claude.com/claude-code)