### PR TITLE
refactor(nan-5088): use customer API key in dashboard, support managed env var keys

### DIFF
--- a/packages/server/lib/controllers/v1/environment/getEnvironment.ts
+++ b/packages/server/lib/controllers/v1/environment/getEnvironment.ts
@@ -31,21 +31,11 @@ export const getEnvironment = asyncWrapper<GetEnvironment>(async (req, res) => {
 
     if (!isCloud) {
         environment.websockets_path = getWebsocketsPath();
-        if (process.env[`NANGO_SECRET_KEY_${environment.name.toUpperCase()}`]) {
-            environment.secret_key = process.env[`NANGO_SECRET_KEY_${environment.name.toUpperCase()}`] as string;
-            environment.secret_key_rotatable = false;
-        }
 
         if (process.env[`NANGO_PUBLIC_KEY_${environment.name.toUpperCase()}`]) {
             environment.public_key = process.env[`NANGO_PUBLIC_KEY_${environment.name.toUpperCase()}`] as string;
             environment.public_key_rotatable = false;
         }
-    }
-
-    // Remove secret key if user doesn't have permission to read production secrets
-    if (!(await canReadProdSecret(res.locals, environment))) {
-        delete (environment as any).secret_key;
-        delete (environment as any).pending_secret_key;
     }
 
     environment.callback_url = await environmentService.getOauthCallbackUrl(environment.id);

--- a/packages/server/lib/controllers/v1/environment/getEnvironment.ts
+++ b/packages/server/lib/controllers/v1/environment/getEnvironment.ts
@@ -98,7 +98,8 @@ export const getEnvironment = asyncWrapper<GetEnvironment>(async (req, res) => {
             name: account.name,
             email: user.email,
             slack_notifications_channel,
-            webhook_signing_key: webhookSigningKey
+            webhook_signing_key: webhookSigningKey,
+            managed_secret_key: !isCloud ? (process.env[`NANGO_SECRET_KEY_${environment.name.toUpperCase()}`] ?? null) : null
         }
     });
 });

--- a/packages/server/lib/formatters/environment.ts
+++ b/packages/server/lib/formatters/environment.ts
@@ -7,7 +7,16 @@ export function environmentToApi(env: DBEnvironment): ApiEnvironment {
     // Normally, none of them should be present. However, if any of them were, it would be bad.
     // Until we're sure they don't exist anywhere anymore, we filter them out explicitly.
     /* eslint-disable @typescript-eslint/no-dynamic-delete */
-    const props = ['secret_key_iv', 'secret_key_tag', 'secret_key_hashed', 'pending_secret_key_iv', 'pending_secret_key_tag', 'pending_public_key'];
+    const props = [
+        'secret_key',
+        'pending_secret_key',
+        'secret_key_iv',
+        'secret_key_tag',
+        'secret_key_hashed',
+        'pending_secret_key_iv',
+        'pending_secret_key_tag',
+        'pending_public_key'
+    ];
     for (const prop of props) {
         delete (env as any)[prop];
     }

--- a/packages/types/lib/environment/api/index.ts
+++ b/packages/types/lib/environment/api/index.ts
@@ -40,6 +40,7 @@ export type GetEnvironment = Endpoint<{
             email: string;
             slack_notifications_channel: string | null;
             webhook_signing_key: string | null;
+            managed_secret_key: string | null;
         };
     };
 }>;

--- a/packages/webapp/src/pages/Environment/Settings/ApiKeys.tsx
+++ b/packages/webapp/src/pages/Environment/Settings/ApiKeys.tsx
@@ -429,6 +429,40 @@ const DeleteApiKeyButton: React.FC<{ displayName: string; onDelete: () => void }
     );
 };
 
+// ── Managed secret key (env var) ────────────────────────────────────
+
+const ManagedSecretKeyView: React.FC<{ secretKey: string; env: string }> = ({ secretKey, env }) => {
+    const [revealed, setRevealed] = useState(false);
+    const masked = `····${secretKey.slice(-4)}`;
+
+    return (
+        <SettingsContent title="API Keys">
+            <div className="flex flex-col gap-4 py-4">
+                <div className="text-body-small-regular text-text-secondary">
+                    This key is managed via the <code className="text-text-primary">NANGO_SECRET_KEY_{env.toUpperCase()}</code> environment variable.
+                </div>
+                <div>
+                    <label className="text-body-small-semi text-text-primary block mb-1.5">Secret Key</label>
+                    <div className="relative">
+                        <Input value={revealed ? secretKey : masked} disabled className="font-mono bg-bg-surface text-text-tertiary pr-20" />
+                        <div className="absolute right-2 top-1/2 -translate-y-1/2 flex items-center gap-1">
+                            <Button
+                                variant="ghost"
+                                size="icon"
+                                onClick={() => setRevealed((r) => !r)}
+                                className="text-text-tertiary hover:text-text-primary h-7 w-7"
+                            >
+                                {revealed ? <IconEyeOff stroke={1} size={16} /> : <IconEye stroke={1} size={16} />}
+                            </Button>
+                            <CopyButton text={secretKey} />
+                        </div>
+                    </div>
+                </div>
+            </div>
+        </SettingsContent>
+    );
+};
+
 // ── Main component ──────────────────────────────────────────────────
 
 export const ApiKeys: React.FC = () => {
@@ -463,14 +497,7 @@ export const ApiKeys: React.FC = () => {
     };
 
     if (managedSecretKey) {
-        return (
-            <SettingsContent title="API Keys">
-                <div className="text-body-small-regular text-text-secondary py-4">
-                    API keys are managed via the <code className="text-text-primary">NANGO_SECRET_KEY_{env.toUpperCase()}</code> environment variable and cannot
-                    be modified from the dashboard.
-                </div>
-            </SettingsContent>
-        );
+        return <ManagedSecretKeyView secretKey={managedSecretKey} env={env} />;
     }
 
     if (selectedKey) {

--- a/packages/webapp/src/pages/Environment/Settings/ApiKeys.tsx
+++ b/packages/webapp/src/pages/Environment/Settings/ApiKeys.tsx
@@ -443,6 +443,7 @@ export const ApiKeys: React.FC = () => {
     const isProd = envData?.environmentAndAccount?.environment?.is_production || false;
     const canReadSecret = can(permissions.canReadProdSecretKey) || !isProd;
     const canManageKeys = can(permissions.canWriteProdEnvironmentKeys) || !isProd;
+    const managedSecretKey = envData?.environmentAndAccount?.managed_secret_key ?? null;
 
     const apiKeys = data?.data ?? [];
     const selectedKey = selectedKeyId !== null ? apiKeys.find((k) => k.id === selectedKeyId) : null;
@@ -460,6 +461,17 @@ export const ApiKeys: React.FC = () => {
             }
         }
     };
+
+    if (managedSecretKey) {
+        return (
+            <SettingsContent title="API Keys">
+                <div className="text-body-small-regular text-text-secondary py-4">
+                    API keys are managed via the <code className="text-text-primary">NANGO_SECRET_KEY_{env.toUpperCase()}</code> environment variable and cannot
+                    be modified from the dashboard.
+                </div>
+            </SettingsContent>
+        );
+    }
 
     if (selectedKey) {
         return <KeyConfig apiKey={selectedKey} env={env} onBack={() => setSelectedKeyId(null)} canReadSecret={canReadSecret} canManageKeys={canManageKeys} />;

--- a/packages/webapp/src/pages/GettingStarted/SecondStep.tsx
+++ b/packages/webapp/src/pages/GettingStarted/SecondStep.tsx
@@ -3,7 +3,7 @@ import { CodeXml, Loader } from 'lucide-react';
 import { useMemo, useState } from 'react';
 
 import { MultiLanguageCodeBlock } from '../../components-v2/MultiLanguageCodeBlock';
-import { useEnvironment } from '../../hooks/useEnvironment';
+import { useApiKeys } from '../../hooks/useApiKeys';
 import { useToast } from '../../hooks/useToast';
 import { useStore } from '../../store';
 import { publicApiFetch } from '../../utils/api';
@@ -49,8 +49,8 @@ export const SecondStep: React.FC<SecondStepProps> = ({ connectionId, providerCo
     const { toast } = useToast();
 
     const env = useStore((state) => state.env);
-    const { data } = useEnvironment(env);
-    const environmentAndAccount = data?.environmentAndAccount;
+    const { data: apiKeysData } = useApiKeys(env);
+    const defaultApiKey = apiKeysData?.data?.[0];
 
     const [isExecuting, setIsExecuting] = useState(false);
     const [isTooltipOpen, setIsTooltipOpen] = useState(false);
@@ -64,7 +64,7 @@ export const SecondStep: React.FC<SecondStepProps> = ({ connectionId, providerCo
     }, [connectionId, providerConfigKey]);
 
     const onExecute = async () => {
-        if (!connectionId || !providerConfigKey || !environmentAndAccount) {
+        if (!connectionId || !providerConfigKey || !defaultApiKey) {
             return;
         }
 
@@ -75,7 +75,7 @@ export const SecondStep: React.FC<SecondStepProps> = ({ connectionId, providerCo
                 {
                     connectionId: connectionId,
                     providerConfigKey: providerConfigKey,
-                    secretKey: environmentAndAccount?.environment.secret_key
+                    secretKey: defaultApiKey.secret
                 },
                 {
                     method: 'PUT'

--- a/packages/webapp/src/pages/GettingStarted/SecondStep.tsx
+++ b/packages/webapp/src/pages/GettingStarted/SecondStep.tsx
@@ -4,6 +4,7 @@ import { useMemo, useState } from 'react';
 
 import { MultiLanguageCodeBlock } from '../../components-v2/MultiLanguageCodeBlock';
 import { useApiKeys } from '../../hooks/useApiKeys';
+import { useEnvironment } from '../../hooks/useEnvironment';
 import { useToast } from '../../hooks/useToast';
 import { useStore } from '../../store';
 import { publicApiFetch } from '../../utils/api';
@@ -49,8 +50,11 @@ export const SecondStep: React.FC<SecondStepProps> = ({ connectionId, providerCo
     const { toast } = useToast();
 
     const env = useStore((state) => state.env);
+    const { data: envData } = useEnvironment(env);
+    const managedSecretKey = envData?.environmentAndAccount?.managed_secret_key ?? null;
     const { data: apiKeysData } = useApiKeys(env);
     const defaultApiKey = apiKeysData?.data?.find((key) => key.display_name === 'Default - Full access') ?? apiKeysData?.data?.[0];
+    const secretKey = managedSecretKey ?? defaultApiKey?.secret;
 
     const [isExecuting, setIsExecuting] = useState(false);
     const [isTooltipOpen, setIsTooltipOpen] = useState(false);
@@ -64,7 +68,7 @@ export const SecondStep: React.FC<SecondStepProps> = ({ connectionId, providerCo
     }, [connectionId, providerConfigKey]);
 
     const onExecute = async () => {
-        if (!connectionId || !providerConfigKey || !defaultApiKey) {
+        if (!connectionId || !providerConfigKey || !secretKey) {
             return;
         }
 
@@ -75,7 +79,7 @@ export const SecondStep: React.FC<SecondStepProps> = ({ connectionId, providerCo
                 {
                     connectionId: connectionId,
                     providerConfigKey: providerConfigKey,
-                    secretKey: defaultApiKey.secret
+                    secretKey: secretKey
                 },
                 {
                     method: 'PUT'

--- a/packages/webapp/src/pages/GettingStarted/SecondStep.tsx
+++ b/packages/webapp/src/pages/GettingStarted/SecondStep.tsx
@@ -50,7 +50,7 @@ export const SecondStep: React.FC<SecondStepProps> = ({ connectionId, providerCo
 
     const env = useStore((state) => state.env);
     const { data: apiKeysData } = useApiKeys(env);
-    const defaultApiKey = apiKeysData?.data?.[0];
+    const defaultApiKey = apiKeysData?.data?.find((key) => key.display_name === 'Default - Full access') ?? apiKeysData?.data?.[0];
 
     const [isExecuting, setIsExecuting] = useState(false);
     const [isTooltipOpen, setIsTooltipOpen] = useState(false);


### PR DESCRIPTION
## Summary
- **Getting Started page**: Switch code snippets from `environment.secret_key` (api_secrets) to the default customer API key via `useApiKeys` hook
- **getEnvironment API**: Remove `secret_key` and `pending_secret_key` from the response — no longer needed by the dashboard

Example of how the list keys look like when the API key comes from envrionment

<img width="1499" height="630" alt="Screenshot 2026-04-24 at 16 50 14" src="https://github.com/user-attachments/assets/a04fc95a-f31c-4813-9ab1-e6fd288d0778" />


## Test plan
- [x] Build passes
- [ ] Verify Getting Started page shows the correct API key in code snippets

🤖 Generated with [Claude Code](https://claude.com/claude-code)