### PR TITLE
docs: restore contextual copy button

### DIFF
--- a/docs/docs.json
+++ b/docs/docs.json
@@ -27,6 +27,15 @@
     "href": "https://www.nango.dev"
   },
   "favicon": "/favicon.png",
+  "contextual": {
+    "options": [
+      "copy",
+      "cursor",
+      "vscode",
+      "chatgpt",
+      "claude"
+    ]
+  },
   "seo": {
     "indexing": "all",
     "metatags": {
@@ -38,6 +47,7 @@
     "links": [
       {
         "type": "github",
+        "label": "GitHub",
         "href": "https://github.com/NangoHQ/nango"
       },
       {


### PR DESCRIPTION
## Summary

- Restores the `contextual.options` block (`copy`, `cursor`, `vscode`, `chatgpt`, `claude`) that was accidentally removed during the navigation structure revamp
- Also adds the missing required `label` field on the GitHub navbar link (was causing a validation error)

## Test plan

- [ ] Verify the copy button appears at the top of docs pages at https://docs.nango.dev

🤖 Generated with [Claude Code](https://claude.com/claude-code)