### PR TITLE
fix(api): import a connection endpoint doesnt set metadata

### DIFF
--- a/docs/docs.json
+++ b/docs/docs.json
@@ -48,7 +48,6 @@
       {
         "label": "GitHub",
         "type": "github",
-        "label": "GitHub",
         "href": "https://github.com/NangoHQ/nango"
       },
       {

--- a/docs/spec.yaml
+++ b/docs/spec.yaml
@@ -822,8 +822,8 @@ paths:
                     $ref: '#/components/responses/BadRequest'
 
         post:
-            summary: Add a connection
-            description: Adds a connection for which you already have credentials.
+            summary: Upsert a connection
+            description: Upserts a connection for which you already have credentials.
             requestBody:
                 required: true
                 content:

--- a/packages/shared/lib/services/connection.service.integration.test.ts
+++ b/packages/shared/lib/services/connection.service.integration.test.ts
@@ -9,6 +9,7 @@ import { createEnvironmentSeed } from '../seeders/environment.seeder.js';
 import { errorNotificationService } from './notification/error.service.js';
 import { createSyncSeeds } from '../seeders/sync.seeder.js';
 
+import type { Config as ProviderConfig } from '../models/Provider.js';
 import type { Metadata } from '@nangohq/types';
 
 describe('Connection service integration tests', () => {
@@ -99,6 +100,47 @@ describe('Connection service integration tests', () => {
             const matchedConnectionIds = (matches || []).map((c) => c.connection_id);
             expect(matchedConnectionIds).toEqual(expect.arrayContaining([scalar.connection_id, array.connection_id]));
             expect(matchedConnectionIds).not.toContain(otherIntegration.connection_id);
+        });
+    });
+
+    describe('upsertAuthConnection', () => {
+        it('on conflict merge should persist metadata from the payload, not copy connection_config into metadata', async () => {
+            const env = await createEnvironmentSeed();
+            const config = (await createConfigSeed(env, `openai-md-${Math.random().toString(36).slice(2, 10)}`, 'openai')) as ProviderConfig;
+            const connectionId = `conn-md-${Math.random().toString(36).slice(2, 10)}`;
+            const credentials = { type: 'API_KEY' as const, apiKey: 'sk-test-import-key' };
+
+            await connectionService.upsertAuthConnection({
+                connectionId,
+                providerConfigKey: config.unique_key,
+                credentials,
+                connectionConfig: { onlyInConfig: 'config-value' },
+                metadata: { restletEndpoint: 'https://example.com/rest' },
+                config,
+                environment: env
+            });
+
+            const first = await connectionService.getConnection(connectionId, config.unique_key, env.id);
+            expect(first.success).toBe(true);
+            expect(first.response!.metadata).toEqual({ restletEndpoint: 'https://example.com/rest' });
+            expect((first.response!.connection_config as Record<string, string>)['onlyInConfig']).toBe('config-value');
+
+            await connectionService.upsertAuthConnection({
+                connectionId,
+                providerConfigKey: config.unique_key,
+                credentials,
+                connectionConfig: { onlyInConfig: 'updated', extraConfig: 'y' },
+                metadata: { otherKey: 42 },
+                config,
+                environment: env
+            });
+
+            const second = await connectionService.getConnection(connectionId, config.unique_key, env.id);
+            expect(second.success).toBe(true);
+            expect(second.response!.metadata).toEqual({ otherKey: 42 });
+            expect(second.response!.metadata).not.toHaveProperty('onlyInConfig');
+            expect((second.response!.connection_config as Record<string, unknown>)['onlyInConfig']).toBe('updated');
+            expect((second.response!.connection_config as Record<string, unknown>)['extraConfig']).toBe('y');
         });
     });
 

--- a/packages/shared/lib/services/connection.service.ts
+++ b/packages/shared/lib/services/connection.service.ts
@@ -231,7 +231,7 @@ class ConnectionService {
                     credentials_tag: encryptedConnection.credentials_tag,
                     connection_config: encryptedConnection.connection_config,
                     environment_id: encryptedConnection.environment_id,
-                    metadata: encryptedConnection.connection_config,
+                    metadata: encryptedConnection.metadata,
                     credentials_expires_at: encryptedConnection.credentials_expires_at,
                     last_refresh_success: encryptedConnection.last_refresh_success,
                     last_refresh_failure: encryptedConnection.last_refresh_failure,


### PR DESCRIPTION
<!-- Describe the problem and your solution --> 
- POST /connections was not properly passing metadata through 
- Docs didn't indicate this endpoint was an upsert

<!-- Issue ticket number and link (if applicable) -->
[NAN-5380: Import a connection endpoint doesn't set metadata](https://linear.app/nango/issue/NAN-5380/import-a-connection-endpoint-doesnt-set-metadata)

<!-- Testing instructions (skip if just adding/editing providers) -->
Send a request to the endpoint with metadata
