### PR TITLE
fix(auth): Sign up with Google from invite creates new account

### DIFF
--- a/packages/webapp/src/pages/Account/components/SignupForm.tsx
+++ b/packages/webapp/src/pages/Account/components/SignupForm.tsx
@@ -173,7 +173,7 @@ export const SignupForm: React.FC<{ invitation?: ApiInvitation; token?: string }
                             <div className="border-t-[0.5px] border-border-strong w-full"></div>
                         </div>
 
-                        <GoogleButton text="Sign up with Google" setServerErrorMessage={setServerErrorMessage} />
+                        <GoogleButton text="Sign up with Google" setServerErrorMessage={setServerErrorMessage} token={token} />
                     </div>
                 )}
 


### PR DESCRIPTION
<!-- Describe the problem and your solution --> 
Right now the invite flow is broken for SSO sign up
1. User X invites User Y
2. User Y selects link and is taken to sign up where they can either:
  a. Sign up with email/password -> Selecting this will add them to the account they were invited to
  b. Sign up with Google -> Selecting this will add them to a net new account they no longer have access to

We just need to pass the invite token so sign up with Google also adds them to the existing account from the invite

<!-- Issue ticket number and link (if applicable) -->
[NAN-5279: Sign up with Google from invite creates new account](https://linear.app/nango/issue/NAN-5279/sign-up-with-google-from-invite-creates-new-account)

<!-- Testing instructions (skip if just adding/editing providers) -->
1. Set up .env for testing hosted auth locally:

# Hosted Auth Configuration
FLAG_MANAGED_AUTH_ENABLED=true
WORKOS_API_KEY=GET_FROM_AWS
WORKOS_CLIENT_ID=GET_FROM_AWS

2. Send invite to your email
3. Click link and sign up with Google

