### PR TITLE
docs: add Support tab linking to Slack community

### DIFF
--- a/docs/docs.json
+++ b/docs/docs.json
@@ -48,7 +48,6 @@
       {
         "label": "GitHub",
         "type": "github",
-        "label": "GitHub",
         "href": "https://github.com/NangoHQ/nango"
       },
       {
@@ -1165,6 +1164,11 @@
             ]
           }
         ]
+      },
+      {
+        "tab": "Support",
+        "icon": "slack",
+        "href": "https://nango.dev/slack"
       }
     ]
   },


### PR DESCRIPTION
## Summary
- Adds a "Support" tab in the docs top navigation with a Slack icon, linking to https://nango.dev/slack
- Fixes a pre-existing duplicate `"label"` key in the GitHub navbar entry

## Test plan
- [ ] Verify the Support tab appears in the top nav alongside Changelog
- [ ] Confirm clicking it opens nango.dev/slack

🤖 Generated with [Claude Code](https://claude.com/claude-code)