### PR TITLE
docs: revamp APIs & integrations tab and contribute/request API page

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -6,7 +6,7 @@ For contributions, please [submit an issue](https://github.com/NangoHQ/nango/iss
 
 # Contributing
 
-You can run Nango locally with Docker and contribute an API ([step-by-step guide](https://nango.dev/docs/implementation-guides/platform/auth/contribute-new-api)).
+You can run Nango locally with Docker and contribute an API ([step-by-step guide](https://nango.dev/docs/integrations/contribute-or-request-api)).
 
 ## Develop locally
 

--- a/README.md
+++ b/README.md
@@ -132,7 +132,7 @@ Nango is available under the [Elastic License](https://github.com/NangoHQ/nango/
 
 ## Contributing
 
-We welcome contributions — anyone can [add support for a new API](https://nango.dev/docs/implementation-guides/platform/auth/contribute-new-api).
+We welcome contributions — anyone can [add support for a new API](https://nango.dev/docs/integrations/contribute-or-request-api).
 
 Thank you to all contributors ❤️
 

--- a/docs/docs.json
+++ b/docs/docs.json
@@ -48,7 +48,6 @@
       {
         "label": "GitHub",
         "type": "github",
-        "label": "GitHub",
         "href": "https://github.com/NangoHQ/nango"
       },
       {
@@ -138,8 +137,7 @@
                       "implementation-guides/platform/auth/configure-integration",
                       "implementation-guides/platform/auth/share-connect-link",
                       "implementation-guides/platform/auth/connection-tags",
-                      "implementation-guides/platform/auth/customize-connect-ui",
-                      "implementation-guides/platform/auth/contribute-new-api"
+                      "implementation-guides/platform/auth/customize-connect-ui"
                     ]
                   }
                 ]
@@ -382,10 +380,16 @@
         "icon": "plug",
         "groups": [
           {
-            "group": "700+ APIs & Integrations",
+            "group": "Overview",
             "pages": [
               "integrations/overview",
               "reference/api-configuration",
+              "integrations/contribute-or-request-api"
+            ]
+          },
+          {
+            "group": "700+ APIs & Integrations",
+            "pages": [
               "integrations/all/1password-scim",
               "api-integrations/3cx",
               "api-integrations/8x8",

--- a/docs/docs.json
+++ b/docs/docs.json
@@ -107,6 +107,10 @@
     {
       "source": "/implementation-guides/platform/open-telemetry-export",
       "destination": "/guides/platform/observability#opentelemetry-export"
+    },
+    {
+      "source": "/implementation-guides/platform/auth/contribute-new-api",
+      "destination": "/integrations/contribute-or-request-api"
     }
   ],
   "navigation": {

--- a/docs/integrations/all/private-api-basic.mdx
+++ b/docs/integrations/all/private-api-basic.mdx
@@ -16,7 +16,7 @@ import PreBuiltUseCases from "/snippets/generated/private-api-basic/PreBuiltUseC
 - **Limited functionality**: Private API (Basic Auth) is limited to just storing credentials. Because it's generic, it does not have a base URL and many advanced Nango features are not available for it.
 - **Base URL required**: Since Private API (Basic Auth) is generic, depending on how you intend to use it (within integrations or making direct proxy calls), you must override the base URL. You cannot rely on a predefined base URL like other integrations.
 - **Recommended use cases only**: The only recommended use case for private API integrations is to store credentials for internal/customer-specific APIs that cannot be added to the Nango catalog.
-- **For all other use cases**: We recommend [contributing the API to Nango](/implementation-guides/platform/auth/contribute-new-api) or requesting it be added by us.
+- **For all other use cases**: We recommend [contributing the API to Nango](/integrations/contribute-or-request-api) or requesting it be added by us.
 
 ## Setup guide
 

--- a/docs/integrations/all/private-api-bearer.mdx
+++ b/docs/integrations/all/private-api-bearer.mdx
@@ -16,7 +16,7 @@ import PreBuiltUseCases from "/snippets/generated/private-api-bearer/PreBuiltUse
 - **Limited functionality**: Private API (Bearer Auth) is limited to just storing API keys. Because it's generic, it does not have a base URL and many advanced Nango features are not available for it.
 - **Base URL required**: Since Private API (Bearer Auth) is generic, depending on how you intend to use it (within integrations or making direct proxy calls), you must override the base URL. You cannot rely on a predefined base URL like other integrations.
 - **Recommended use cases only**: The only recommended use case for private API integrations is to store credentials for internal/customer-specific APIs that cannot be added to the Nango catalog.
-- **For all other use cases**: We recommend [contributing the API to Nango](/implementation-guides/platform/auth/contribute-new-api) or requesting it be added by us.
+- **For all other use cases**: We recommend [contributing the API to Nango](/integrations/contribute-or-request-api) or requesting it be added by us.
 
 ## Setup guide
 

--- a/docs/integrations/contribute-or-request-api.mdx
+++ b/docs/integrations/contribute-or-request-api.mdx
@@ -10,7 +10,7 @@ The easiest way to add a new API is to request it from the Nango team.
 
 If you have a shared Slack channel with Nango, send your request there. Otherwise, post in the `#request-a-new-api` channel of the [community](https://nango.dev/slack).
 
-We add APIs in days for all plans, based on the SLAs on our [pricing page](https://www.nango.dev/pricing).
+We'll deliver them according to the SLAs on our [pricing page](https://www.nango.dev/pricing).
 
 ## Option 2: Contribute a new API yourself
 

--- a/docs/integrations/contribute-or-request-api.mdx
+++ b/docs/integrations/contribute-or-request-api.mdx
@@ -1,26 +1,28 @@
 ---
-title: 'Contribute support for a new API'
-sidebarTitle: 'Contribute a new API'
-description: 'Guide on how to add support for a new API to Nango'
+title: 'Contribute or request an API'
+sidebarTitle: 'Contribute or request an API'
+description: 'Add support for a new API to Nango'
 ---
 
-## Pre-requisites
+## Option 1: Request a new API (most popular)
+
+The easiest way to add a new API is to request it from the Nango team.
+
+If you have a shared Slack channel with Nango, send your request there. Otherwise, post in the `#request-a-new-api` channel of the [community](https://nango.dev/slack).
+
+We add APIs in days for all plans, based on the SLAs on our [pricing page](https://www.nango.dev/pricing).
+
+## Option 2: Contribute a new API yourself
+
+To contribute a new API, follow the steps below and check out past [PRs](https://github.com/NangoHQ/nango/pulls?q=is%3Apr+is%3Aclosed) starting with `feat(integrations)` for examples.
+
+### Pre-requisites
 
 - You have access to a test account for the API
 - The API is publicly accessible
 - The API is of type HTTP or SOAP
 
-Nango support all authorization types (OAuth, API key, basic), including custom ones.
-
-## Option 1: Ask Nango to add support for a new API
-
-The simplest way to add a new API is to ask us in the [community](https://nango.dev/slack) on the `#request-a-new-api` channel.
-
-We prioritize requests by plan. Free users can expect support for new APIs in 5-10 business days, Enterprise customers \<48h
-
-## Option 2: Contribute a new API yourself
-
-To contribute a new API, follow the steps below and check out past [PRs](https://github.com/NangoHQ/nango/pulls?q=is%3Apr+is%3Aclosed) starting with `feat(integrations)` for examples.
+Nango supports all authorization types (OAuth, API key, basic), including custom ones.
 
 ### Add an API configuration
 
@@ -63,7 +65,7 @@ If all goes well, you should see your new connection in the _Connections_ tab. C
 
 Add a `<api>.mdx` file (e.g. `github.mdx`) for your API to the `docs/integrations/all` folder. Check out [other examples](/integrations) to fill out the content of the documentation page.
 
-Reference the page in the `docs/mint.json` file in the `Supported APIs` group in alphabetical order.
+Reference the page in the `docs/docs.json` file in the `700+ APIs & Integrations` group in alphabetical order.
 
 ### Submit a pull request
 

--- a/docs/integrations/overview.mdx
+++ b/docs/integrations/overview.mdx
@@ -11,7 +11,7 @@ Nango is the leading provider of **API access for AI agents & apps**. It is desi
 <Card title="All APIs & integrations" icon="list" href="https://www.nango.dev/api-integrations">
 700+ APIs & thousands of integrations.
 </Card>
-<Card title="Request or contribute a new API" icon="circle-question" href="/implementation-guides/platform/auth/contribute-new-api">
+<Card title="Request or contribute a new API" icon="circle-question" href="/integrations/contribute-or-request-api">
 We deliver them in &lt;48h.
 </Card>
 <Card title="Build custom integrations" icon="heart" href="/implementation-guides/platform/functions/customize-template">

--- a/docs/reference/api-configuration.mdx
+++ b/docs/reference/api-configuration.mdx
@@ -1,7 +1,6 @@
 ---
 title: 'API configuration (`providers.yaml`)'
 sidebarTitle: 'API configuration'
-icon: 'network-wired'
 ---
 
 API configurations are listed in the `providers.yaml` file, located in the [Nango GitHub repository](https://github.com/NangoHQ/nango/blob/master/packages/providers/providers.yaml).


### PR DESCRIPTION
## Summary

- **APIs & Integrations tab** now has 2 groups: an "Overview" group (Overview, API configuration, Contribute or request an API) and the existing "700+ APIs & Integrations" group for individual API pages
- **Contribute a new API** page renamed to **Contribute or request an API**, moved to `integrations/` and updated to lead with requesting (most popular), referencing shared Slack channel or `#request-a-new-api` community channel; SLA details now link to the pricing page instead of being duplicated inline
- **API configuration** nav entry no longer has an icon (inconsistent with other nav items)
- Fixed pre-existing duplicate `"label"` key in `docs.json`

## Test plan

- [ ] Navigate to APIs & Integrations tab — verify 2 groups in sidebar
- [ ] Click "Contribute or request an API" — verify page renders with updated content and pricing page link
- [ ] Click "API configuration" — verify no icon next to nav label
- [ ] Verify old `/implementation-guides/platform/auth/contribute-new-api` redirects or is gone

🤖 Generated with [Claude Code](https://claude.com/claude-code)