### PR TITLE
fix(nan-5324): make logger reject invalid level method names

### DIFF
--- a/packages/server/lib/controllers/v1/account/managed/postVerification.ts
+++ b/packages/server/lib/controllers/v1/account/managed/postVerification.ts
@@ -72,7 +72,7 @@ export const postManagedEmailVerification = asyncWrapper<PostManagedEmailVerific
             throw err;
         }
 
-        logger.warn('Failed to authenticate WorkOS email verification code', {
+        logger.warning('Failed to authenticate WorkOS email verification code', {
             code: workosErr.rawData?.code
         });
         res.status(400).send({

--- a/packages/server/lib/crons/delete/batchDelete.ts
+++ b/packages/server/lib/crons/delete/batchDelete.ts
@@ -1,13 +1,13 @@
 import { setTimeout } from 'node:timers/promises';
 
-import type { Logger } from '@nangohq/types';
+import type { StrictLogger } from '@nangohq/utils';
 
 export interface BatchDeleteOptions {
     name: string;
     deleteFn: () => Promise<number>;
     deadline: Date;
     limit: number;
-    logger: Logger;
+    logger: StrictLogger;
 }
 
 export type BatchDeleteSharedOptions = Omit<BatchDeleteOptions, 'name' | 'deleteFn'>;

--- a/packages/utils/lib/logger.ts
+++ b/packages/utils/lib/logger.ts
@@ -5,7 +5,20 @@ import winston from 'winston';
 
 import { isCloud, isEnterprise, isTest } from './environment/detection.js';
 
-import type { Logform, Logger } from 'winston';
+import type { LeveledLogMethod, Logform } from 'winston';
+
+// Methods exposed by the logger. Restricted to the syslog levels actually used in the codebase
+// so callers can only invoke level methods that exist at runtime — guards against the INC-99 class
+// of bug where `logger.warn(...)` compiled (winston's Logger has a `[key: string]: any` index
+// signature) but threw at runtime because the syslog level is `warning`, not `warn`. Add other
+// syslog levels (`emerg`, `alert`, `crit`, `notice`) here intentionally if a real need arises.
+export interface StrictLogger {
+    error: LeveledLogMethod;
+    warning: LeveledLogMethod;
+    info: LeveledLogMethod;
+    debug: LeveledLogMethod;
+    close: () => void;
+}
 
 const SPLAT = Symbol.for('splat');
 const level = process.env['LOG_LEVEL'] ? process.env['LOG_LEVEL'] : isTest ? 'error' : 'info';
@@ -58,6 +71,6 @@ const defaultLogger = winston.createLogger({
     transports: [new winston.transports.Console({ level })]
 });
 
-export function getLogger(service?: string): Logger {
-    return defaultLogger.child({ service });
+export function getLogger(service?: string): StrictLogger {
+    return defaultLogger.child({ service }) as unknown as StrictLogger;
 }


### PR DESCRIPTION
## Summary

- Wraps winston's `Logger` in a `StrictLogger` interface that exposes only the level methods actually used in the codebase (`error`, `warning`, `info`, `debug`) plus `close`. Winston's own `Logger` has a `[key: string]: any` index signature, which is what let `logger.warn(...)` compile in INC-99 and then throw at runtime because the syslog level is `warning`, not `warn`. Other syslog levels (`emerg`, `alert`, `crit`, `notice`) can be added intentionally if a real need arises.
- Fixes one latent `logger.warn(...)` call in `postVerification.ts` that would have thrown the next time WorkOS email verification failed — the same bug pattern that turned INC-99 into a self-amplifying recovery failure.

Refs: [NAN-5324](https://linear.app/nango/issue/NAN-5324/fix-logger-not-to-accept-any-function-name) (parent: [INC-99](https://linear.app/nango/issue/INC-99/2026-04-12-0656-utc-actions-and-syncs-stopped-working))

## Test plan

- [x] CI build passes (the strict interface only reports a TS error if a level method outside the allowed set is invoked).
- [x] `grep -rn "logger\.\(warn\|trace\|fatal\|silly\|verbose\)\b" packages --include="*.ts"` returns no matches outside the comment in `logger.ts`.
- [x] Locally, drop in a `logger.warn(...)` somewhere and confirm `tsc` rejects it with `Property 'warn' does not exist on type 'StrictLogger'`.

```bash
packages/server/lib/controllers/v1/account/managed/postVerification.ts:75:16 - error TS2339: Property 'warn' does not exist on type 'StrictLogger'.

75         logger.warn('Failed to authenticate WorkOS email verification code', {
                  ~~~~


Found 1 error.
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)