### PR TITLE
fix: cache decrypted webhook signing key per environment

### DIFF
--- a/packages/jobs/lib/execution/action.ts
+++ b/packages/jobs/lib/execution/action.ts
@@ -545,7 +545,7 @@ async function sendWebhookIfNeeded({
             throw webhookSigningKey.error;
         }
         await sendAsyncActionWebhook({
-            secret: webhookSigningKey.value.secret,
+            secret: webhookSigningKey.value,
             connectionId: connectionId,
             providerConfigKey: providerConfigKey,
             payload: {

--- a/packages/jobs/lib/execution/sync.ts
+++ b/packages/jobs/lib/execution/sync.ts
@@ -345,7 +345,7 @@ export async function handleSyncSuccess({
         const webhookSigningSecret = webhookSettings
             ? await customerKeyService.getWebhookSigningKeyForEnv(db.knex, nangoProps.environmentId).then((r) => {
                   if (r.isErr()) throw r.error;
-                  return r.value.secret;
+                  return r.value;
               })
             : null;
         for (const model of nangoProps.syncConfig.models || []) {
@@ -944,7 +944,7 @@ async function onFailure({
                         syncVariant,
                         connection: connection,
                         environment: environment,
-                        secret: webhookSigningKey.value.secret,
+                        secret: webhookSigningKey.value,
                         webhookSettings,
                         model: models.join(','),
                         success: false,

--- a/packages/jobs/lib/execution/webhook.ts
+++ b/packages/jobs/lib/execution/webhook.ts
@@ -307,7 +307,7 @@ export async function handleWebhookSuccess({
                             provider_config_key: nangoProps.providerConfigKey
                         },
                         environment: environment,
-                        secret: webhookSigningKey.value.secret,
+                        secret: webhookSigningKey.value,
                         webhookSettings,
                         syncConfig: nangoProps.syncConfig,
                         syncVariant: nangoProps.syncVariant || 'base',
@@ -483,7 +483,7 @@ async function onFailure({
                         const res = await sendSyncWebhook({
                             account: team,
                             environment,
-                            secret: webhookSigningKey.value.secret,
+                            secret: webhookSigningKey.value,
                             connection: connection,
                             webhookSettings,
                             syncConfig,

--- a/packages/server/lib/controllers/v1/environment/getEnvironment.ts
+++ b/packages/server/lib/controllers/v1/environment/getEnvironment.ts
@@ -67,7 +67,7 @@ export const getEnvironment = asyncWrapper<GetEnvironment>(async (req, res) => {
     if (await canReadProdSecret(res.locals, environment)) {
         const signingKeyResult = await customerKeyService.getWebhookSigningKeyForEnv(db.knex, environment.id);
         if (signingKeyResult.isOk()) {
-            webhookSigningKey = signingKeyResult.value.secret;
+            webhookSigningKey = signingKeyResult.value;
         }
     }
 

--- a/packages/server/lib/hooks/hooks.ts
+++ b/packages/server/lib/hooks/hooks.ts
@@ -159,7 +159,7 @@ export const connectionCreated = async (
         void sendAuthWebhook({
             connection,
             environment,
-            secret: webhookSigningKey.value.secret,
+            secret: webhookSigningKey.value,
             webhookSettings,
             auth_mode,
             endUser,
@@ -205,7 +205,7 @@ export const connectionCreationFailed = async (
             void sendAuthWebhook({
                 connection,
                 environment,
-                secret: webhookSigningKey.value.secret,
+                secret: webhookSigningKey.value,
                 webhookSettings,
                 auth_mode,
                 success: false,
@@ -288,7 +288,7 @@ export const connectionRefreshFailed = async ({
         void sendAuthWebhook({
             connection,
             environment,
-            secret: webhookSigningKey.value.secret,
+            secret: webhookSigningKey.value,
             webhookSettings,
             auth_mode: provider.auth_mode,
             operation: 'refresh',

--- a/packages/server/lib/webhook/webhook.manager.ts
+++ b/packages/server/lib/webhook/webhook.manager.ts
@@ -114,7 +114,7 @@ export async function routeWebhook({
         const webhookSigningSecret = webhookSettings
             ? await customerKeyService.getWebhookSigningKeyForEnv(db.knex, environment.id).then((r) => {
                   if (r.isErr()) throw r.error;
-                  return r.value.secret;
+                  return r.value;
               })
             : '';
 

--- a/packages/shared/lib/services/customerKey.service.ts
+++ b/packages/shared/lib/services/customerKey.service.ts
@@ -10,6 +10,8 @@ import type { Knex } from 'knex';
 
 const CUSTOMER_KEYS_TABLE = 'customer_keys';
 const CUSTOMER_KEYS_RELATIONS_TABLE = 'customer_keys_relations';
+// Cache decrypted webhook signing key per environment. No eviction needed since rotation is not supported yet.
+const webhookSigningKeyCache = new Map<number, string>();
 // Internal safety limit — not a product constraint, just prevents unbounded key creation.
 // Can be raised without migration if needed.
 export const MAX_API_KEYS_PER_ENV = 50;
@@ -182,6 +184,11 @@ class CustomerKeyService {
     }
 
     public async getWebhookSigningKeyForEnv(trx: Knex, envId: number): Promise<Result<DBCustomerKey>> {
+        const cached = webhookSigningKeyCache.get(envId);
+        if (cached) {
+            return Ok({ secret: cached } as DBCustomerKey);
+        }
+
         try {
             const row = await trx<DBCustomerKey>(CUSTOMER_KEYS_TABLE)
                 .select(`${CUSTOMER_KEYS_TABLE}.*`)
@@ -197,6 +204,7 @@ class CustomerKeyService {
             }
 
             const decrypted = encryptionManager.decryptAPISecret(row as Parameters<typeof encryptionManager.decryptAPISecret>[0]) as DBCustomerKey;
+            webhookSigningKeyCache.set(envId, decrypted.secret);
             return Ok(decrypted);
         } catch (err) {
             return Err(err);

--- a/packages/shared/lib/services/customerKey.service.ts
+++ b/packages/shared/lib/services/customerKey.service.ts
@@ -183,10 +183,10 @@ class CustomerKeyService {
         }
     }
 
-    public async getWebhookSigningKeyForEnv(trx: Knex, envId: number): Promise<Result<DBCustomerKey>> {
+    public async getWebhookSigningKeyForEnv(trx: Knex, envId: number): Promise<Result<string>> {
         const cached = webhookSigningKeyCache.get(envId);
         if (cached) {
-            return Ok({ secret: cached } as DBCustomerKey);
+            return Ok(cached);
         }
 
         try {
@@ -205,7 +205,7 @@ class CustomerKeyService {
 
             const decrypted = encryptionManager.decryptAPISecret(row as Parameters<typeof encryptionManager.decryptAPISecret>[0]) as DBCustomerKey;
             webhookSigningKeyCache.set(envId, decrypted.secret);
-            return Ok(decrypted);
+            return Ok(decrypted.secret);
         } catch (err) {
             return Err(err);
         }


### PR DESCRIPTION
## Summary
- Cache the decrypted webhook signing key in memory per environment ID
- First call per environment hits DB + decryption, all subsequent calls are a map lookup
- No eviction — cache lives forever since webhook signing key rotation is not supported yet

## Test plan
- [x] Build passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)