### PR TITLE
feat(webhooks): thread `ingressRequestId` through webhook handler chain (NAN-5338)

### DIFF
--- a/packages/server/lib/controllers/webhook/environmentUuid/postWebhook.ts
+++ b/packages/server/lib/controllers/webhook/environmentUuid/postWebhook.ts
@@ -1,3 +1,5 @@
+import { randomUUID } from 'node:crypto';
+
 import tracer from 'dd-trace';
 import * as z from 'zod';
 
@@ -94,6 +96,9 @@ export const postWebhook = asyncWrapper<PostPublicWebhook>(async (req, res) => {
 
             const query = Object.keys(queryFiltered).length > 0 ? queryFiltered : undefined;
 
+            const ingressRequestId = randomUUID();
+            span.setTag('nango.ingressRequestId', ingressRequestId);
+
             const response = await routeWebhook({
                 environment,
                 account,
@@ -103,7 +108,8 @@ export const postWebhook = asyncWrapper<PostPublicWebhook>(async (req, res) => {
                 body: req.body,
                 rawBody: req.rawBody!,
                 ...(query !== undefined ? { query } : {}),
-                logContextGetter
+                logContextGetter,
+                ingressRequestId
             });
 
             if (!response) {

--- a/packages/server/lib/webhook/gmail-webhook-routing.unit.test.ts
+++ b/packages/server/lib/webhook/gmail-webhook-routing.unit.test.ts
@@ -19,7 +19,8 @@ describe('gmailWebhookRouting', () => {
             environment: seeders.getTestEnvironment(),
             plan: seeders.getTestPlan(),
             integration,
-            logContextGetter
+            logContextGetter,
+            ingressRequestId: 'test-ingress-request-id'
         });
         nangoMock.executeScriptForWebhooks = mock;
 
@@ -58,7 +59,8 @@ describe('gmailWebhookRouting', () => {
             environment: seeders.getTestEnvironment(),
             plan: seeders.getTestPlan(),
             integration,
-            logContextGetter
+            logContextGetter,
+            ingressRequestId: 'test-ingress-request-id'
         });
         nangoMock.executeScriptForWebhooks = mock;
 

--- a/packages/server/lib/webhook/google-calendar-webhook-routing.unit.test.ts
+++ b/packages/server/lib/webhook/google-calendar-webhook-routing.unit.test.ts
@@ -26,7 +26,8 @@ describe('googleCalendarWebhookRouting', () => {
             environment: seeders.getTestEnvironment(),
             plan: seeders.getTestPlan(),
             integration,
-            logContextGetter
+            logContextGetter,
+            ingressRequestId: 'test-ingress-request-id'
         });
         nangoMock.executeScriptForWebhooks = mock;
 
@@ -81,7 +82,8 @@ describe('googleCalendarWebhookRouting', () => {
             environment: seeders.getTestEnvironment(),
             plan: seeders.getTestPlan(),
             integration,
-            logContextGetter
+            logContextGetter,
+            ingressRequestId: 'test-ingress-request-id'
         });
         nangoMock.executeScriptForWebhooks = mock;
 
@@ -111,7 +113,8 @@ describe('googleCalendarWebhookRouting', () => {
             environment: seeders.getTestEnvironment(),
             plan: seeders.getTestPlan(),
             integration,
-            logContextGetter
+            logContextGetter,
+            ingressRequestId: 'test-ingress-request-id'
         });
         nangoMock.executeScriptForWebhooks = mock;
 

--- a/packages/server/lib/webhook/google-webhook-routing.unit.test.ts
+++ b/packages/server/lib/webhook/google-webhook-routing.unit.test.ts
@@ -20,7 +20,8 @@ describe('googleWebhookRouting', () => {
             environment: seeders.getTestEnvironment(),
             plan: seeders.getTestPlan(),
             integration,
-            logContextGetter
+            logContextGetter,
+            ingressRequestId: 'test-ingress-request-id'
         });
         nangoMock.executeScriptForWebhooks = mock;
 
@@ -51,7 +52,8 @@ describe('googleWebhookRouting', () => {
             environment: seeders.getTestEnvironment(),
             plan: seeders.getTestPlan(),
             integration,
-            logContextGetter
+            logContextGetter,
+            ingressRequestId: 'test-ingress-request-id'
         });
         nangoMock.executeScriptForWebhooks = mock;
 
@@ -69,7 +71,8 @@ describe('googleWebhookRouting', () => {
             environment: seeders.getTestEnvironment(),
             plan: seeders.getTestPlan(),
             integration,
-            logContextGetter
+            logContextGetter,
+            ingressRequestId: 'test-ingress-request-id'
         });
         nangoMock.executeScriptForWebhooks = mock;
 

--- a/packages/server/lib/webhook/hubspot-webhook-routing.unit.test.ts
+++ b/packages/server/lib/webhook/hubspot-webhook-routing.unit.test.ts
@@ -29,7 +29,8 @@ describe('Webhook route unit tests', () => {
             environment: seeders.getTestEnvironment(),
             plan: seeders.getTestPlan(),
             integration,
-            logContextGetter
+            logContextGetter,
+            ingressRequestId: 'test-ingress-request-id'
         });
         nangoMock.executeScriptForWebhooks = mock;
 
@@ -127,7 +128,8 @@ describe('Webhook route unit tests', () => {
             environment: seeders.getTestEnvironment(),
             plan: seeders.getTestPlan(),
             integration,
-            logContextGetter: logContextGetter
+            logContextGetter: logContextGetter,
+            ingressRequestId: 'test-ingress-request-id'
         });
         nangoMock.executeScriptForWebhooks = mock;
 

--- a/packages/server/lib/webhook/internal-nango.ts
+++ b/packages/server/lib/webhook/internal-nango.ts
@@ -15,6 +15,7 @@ export class InternalNango {
     readonly plan?: DBPlan | undefined;
     readonly integration: DBIntegrationDecrypted;
     readonly logContextGetter: LogContextGetter;
+    readonly ingressRequestId: string;
 
     constructor(opts: {
         team: DBTeam;
@@ -22,12 +23,14 @@ export class InternalNango {
         plan?: DBPlan | undefined;
         integration: DBIntegrationDecrypted;
         logContextGetter: LogContextGetter;
+        ingressRequestId: string;
     }) {
         this.team = opts.team;
         this.environment = opts.environment;
         this.plan = opts.plan;
         this.integration = opts.integration;
         this.logContextGetter = opts.logContextGetter;
+        this.ingressRequestId = opts.ingressRequestId;
     }
 
     async getWebhooks() {

--- a/packages/server/lib/webhook/webhook.manager.ts
+++ b/packages/server/lib/webhook/webhook.manager.ts
@@ -29,7 +29,8 @@ export async function routeWebhook({
     body,
     rawBody,
     query,
-    logContextGetter
+    logContextGetter,
+    ingressRequestId
 }: {
     environment: DBEnvironment;
     account: DBTeam;
@@ -40,6 +41,7 @@ export async function routeWebhook({
     rawBody: string;
     query?: Record<string, string>;
     logContextGetter: LogContextGetter;
+    ingressRequestId: string;
 }): Promise<WebhookResponse> {
     // Check if both body and headers are empty
     const hasBody = body && (typeof body === 'object' ? Object.keys(body).length > 0 : true);
@@ -74,7 +76,8 @@ export async function routeWebhook({
         environment,
         plan,
         integration,
-        logContextGetter
+        logContextGetter,
+        ingressRequestId
     });
 
     const result: Result<WebhookResponse> = await tracer.trace(`webhook.route.${integration.provider}`, async () => {


### PR DESCRIPTION
Generates a server-side UUID at the top of postWebhook and carries it through `routeWebhook` into `InternalNango` as a constructor field. No behavioral change yet, the ID is consumed by the upcoming dispatch-queue publisher (`NAN-5340`) to build deterministic taskNames when no de-dupe key is available. It is also used to dedupe SQS redelivery.

<!-- Describe the problem and your solution --> 

<!-- Issue ticket number and link (if applicable) -->

<!-- Testing instructions (skip if just adding/editing providers) -->

