### PR TITLE
feat(webhooks): add dispatch queue publisher (NAN-5339) 1/5

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -36496,6 +36496,7 @@
             "version": "1.0.0",
             "license": "SEE LICENSE IN LICENSE FILE IN GIT REPOSITORY",
             "dependencies": {
+                "@aws-sdk/client-sqs": "3.993.0",
                 "@modelcontextprotocol/sdk": "1.26.0",
                 "@nangohq/authz": "file:../authz",
                 "@nangohq/billing": "file:../billing",

--- a/packages/server/lib/webhook/dispatch-queue/publisher.ts
+++ b/packages/server/lib/webhook/dispatch-queue/publisher.ts
@@ -1,0 +1,173 @@
+import { SendMessageBatchCommand } from '@aws-sdk/client-sqs';
+import tracer from 'dd-trace';
+
+import { metrics } from '@nangohq/utils';
+
+import { runWithConcurrencyLimit } from '../runWithConcurrencyLimit.js';
+
+import type { SQSClient, SendMessageBatchCommandOutput, SendMessageBatchRequestEntry } from '@aws-sdk/client-sqs';
+import type { WebhookDispatchMessage } from '@nangohq/types';
+
+const SQS_BATCH_MAX_ENTRIES = 10;
+const DEFAULT_PUBLISH_CONCURRENCY = 10;
+
+export interface DispatchQueuePublisherProps {
+    sqs: SQSClient;
+    queueUrl: string;
+    /** Max entries per SQS SendMessageBatch request. AWS caps this at 10. */
+    batchSize?: number;
+    /** Max concurrent SQS SendMessageBatch requests. Defaults to 10. */
+    publishConcurrency?: number;
+}
+
+export interface PublishResult {
+    enqueued: number;
+    failed: number;
+}
+
+interface BatchPublishResult extends PublishResult {
+    retriedEntries: number;
+}
+
+export class DispatchQueuePublisher {
+    private readonly sqs: SQSClient;
+    private readonly queueUrl: string;
+    private readonly batchSize: number;
+    private readonly publishConcurrency: number;
+
+    constructor(props: DispatchQueuePublisherProps) {
+        this.sqs = props.sqs;
+        this.queueUrl = props.queueUrl;
+        const configuredBatchSize = props.batchSize ?? SQS_BATCH_MAX_ENTRIES;
+        if (configuredBatchSize < 1) {
+            throw new RangeError(`batchSize must be > 0`);
+        }
+        this.batchSize = Math.min(configuredBatchSize, SQS_BATCH_MAX_ENTRIES);
+
+        const configuredPublishConcurrency = props.publishConcurrency ?? DEFAULT_PUBLISH_CONCURRENCY;
+        if (configuredPublishConcurrency < 1) {
+            throw new RangeError(`publishConcurrency must be > 0`);
+        }
+        this.publishConcurrency = configuredPublishConcurrency;
+    }
+
+    /**
+     * Publish a list of dispatch messages in batches. Batches are fired in parallel up to
+     * `publishConcurrency`; failed entries within a batch are retried once inline. Any
+     * entries still failing after the retry are counted as `failed`. Regular SQS send
+     * failures and partial failures are returned in the counts instead of throwing so the
+     * caller can treat them as a metric/trace concern, not an HTTP 500 (provider retries
+     * are worse).
+     */
+    async publish(messages: WebhookDispatchMessage[], messageGroupId: string): Promise<PublishResult> {
+        if (messages.length === 0) {
+            return { enqueued: 0, failed: 0 };
+        }
+
+        const activeSpan = tracer.scope().active();
+        const firstMessage = messages[0]!;
+        const batches = chunk(messages, this.batchSize);
+        const span = tracer.startSpan('webhook.dispatch.publish', {
+            ...(activeSpan ? { childOf: activeSpan } : {}),
+            tags: {
+                'nango.accountId': firstMessage.accountId,
+                'nango.environmentId': firstMessage.connection.environment_id,
+                'nango.integrationId': firstMessage.integrationId,
+                'nango.provider': firstMessage.provider,
+                'nango.providerConfigKey': firstMessage.connection.provider_config_key,
+                'nango.messageCount': messages.length,
+                'nango.batchCount': batches.length
+            }
+        });
+
+        return await tracer.scope().activate(span, async () => {
+            try {
+                const results = await runWithConcurrencyLimit(batches, this.publishConcurrency, async (batch) => {
+                    return await this.sendBatch(batch, messageGroupId);
+                });
+
+                const enqueued = results.reduce((sum, r) => sum + r.enqueued, 0);
+                const failed = results.reduce((sum, r) => sum + r.failed, 0);
+                const retriedEntries = results.reduce((sum, r) => sum + r.retriedEntries, 0);
+                const retriedBatches = results.filter((r) => r.retriedEntries > 0).length;
+
+                span.setTag('nango.enqueued', enqueued);
+                span.setTag('nango.failed', failed);
+                span.setTag('nango.retriedEntries', retriedEntries);
+                span.setTag('nango.retriedBatches', retriedBatches);
+
+                const provider = firstMessage.provider;
+
+                if (enqueued > 0) {
+                    metrics.increment(metrics.Types.WEBHOOK_DISPATCH_PUBLISH_SUCCESS, enqueued, { provider });
+                }
+                if (failed > 0) {
+                    const error = new Error(`Failed to enqueue ${failed} webhook dispatch message${failed === 1 ? '' : 's'}`);
+                    span.setTag('error', error);
+                    span.setTag('nango.partialFailure', true);
+
+                    metrics.increment(metrics.Types.WEBHOOK_DISPATCH_PUBLISH_FAILURE, failed, { provider });
+                }
+
+                return { enqueued, failed };
+            } catch (err) {
+                span.setTag('error', err);
+                throw err;
+            } finally {
+                span.finish();
+            }
+        });
+    }
+
+    private async sendBatch(batch: WebhookDispatchMessage[], messageGroupId: string): Promise<BatchPublishResult> {
+        const entries = batch.map((message, idx) => toEntry(message, idx, messageGroupId));
+
+        const first = await this.trySend(entries);
+        const failedIndices = first.failedIds.map((id) => entryIdToIndex(id));
+        if (failedIndices.length === 0) {
+            return { enqueued: batch.length, failed: 0, retriedEntries: 0 };
+        }
+
+        const retryEntries = failedIndices.map((i) => entries[i]).filter((e): e is SendMessageBatchRequestEntry => e !== undefined);
+        const second = await this.trySend(retryEntries);
+
+        const enqueued = batch.length - second.failedIds.length;
+        return { enqueued, failed: second.failedIds.length, retriedEntries: failedIndices.length };
+    }
+
+    private async trySend(entries: SendMessageBatchRequestEntry[]): Promise<{ failedIds: string[] }> {
+        if (entries.length === 0) return { failedIds: [] };
+        try {
+            const response: SendMessageBatchCommandOutput = await this.sqs.send(new SendMessageBatchCommand({ QueueUrl: this.queueUrl, Entries: entries }));
+            const failedIds = (response.Failed ?? []).map((f) => f.Id).filter((id): id is string => typeof id === 'string');
+            return { failedIds };
+        } catch (err) {
+            tracer.scope().active()?.setTag('sqs.send.error', err);
+            return { failedIds: entries.map((e) => e.Id!).filter((id): id is string => typeof id === 'string') };
+        }
+    }
+}
+
+function toEntry(message: WebhookDispatchMessage, index: number, messageGroupId: string): SendMessageBatchRequestEntry {
+    return {
+        Id: indexToEntryId(index),
+        MessageBody: JSON.stringify(message),
+        MessageGroupId: messageGroupId
+    };
+}
+
+function indexToEntryId(index: number): string {
+    return `m${index}`;
+}
+
+function entryIdToIndex(id: string): number {
+    return Number.parseInt(id.slice(1), 10);
+}
+
+function chunk<T>(items: T[], size: number): T[][] {
+    const chunks: T[][] = [];
+    for (let i = 0; i < items.length; i += size) {
+        chunks.push(items.slice(i, i + size));
+    }
+    return chunks;
+}

--- a/packages/server/lib/webhook/dispatch-queue/publisher.unit.test.ts
+++ b/packages/server/lib/webhook/dispatch-queue/publisher.unit.test.ts
@@ -1,0 +1,263 @@
+import { SendMessageBatchCommand } from '@aws-sdk/client-sqs';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+const tracerMocks = vi.hoisted(() => {
+    const span = {
+        setTag: vi.fn().mockReturnThis(),
+        finish: vi.fn()
+    };
+    const activeSpan = {
+        traceId: 'active-trace',
+        setTag: vi.fn().mockReturnThis()
+    };
+
+    return {
+        activeSpan,
+        active: vi.fn(() => activeSpan),
+        activate: vi.fn(async (_span, callback: () => Promise<unknown>) => await callback()),
+        startSpan: vi.fn(() => span),
+        span,
+        dogstatsd: {
+            increment: vi.fn(),
+            decrement: vi.fn(),
+            gauge: vi.fn(),
+            histogram: vi.fn(),
+            distribution: vi.fn()
+        }
+    };
+});
+
+vi.mock('dd-trace', () => {
+    return {
+        default: {
+            scope: () => ({ active: tracerMocks.active, activate: tracerMocks.activate }),
+            startSpan: tracerMocks.startSpan,
+            dogstatsd: tracerMocks.dogstatsd
+        }
+    };
+});
+
+import { DispatchQueuePublisher } from './publisher.js';
+
+import type { SQSClient, SendMessageBatchCommandOutput } from '@aws-sdk/client-sqs';
+import type { WebhookDispatchMessage } from '@nangohq/types';
+
+function buildMessage(overrides: Partial<WebhookDispatchMessage> = {}): WebhookDispatchMessage {
+    return {
+        version: 1,
+        kind: 'webhook',
+        taskName: 'webhook:abc123',
+        createdAt: '2026-04-23T00:00:00.000Z',
+        accountId: 1,
+        integrationId: 3,
+        provider: 'github',
+        parentSyncName: 'sync-1',
+        activityLogId: 'log-1',
+        webhookName: 'sync-1',
+        connection: { id: 42, connection_id: 'conn-1', provider_config_key: 'github-dev', environment_id: 2 },
+        payload: { hello: 'world' },
+        ...overrides
+    };
+}
+
+function makeSqsMock(
+    responder: (command: SendMessageBatchCommand, callIndex: number) => SendMessageBatchCommandOutput | Promise<SendMessageBatchCommandOutput>
+): { sqs: SQSClient; send: ReturnType<typeof vi.fn> } {
+    const send = vi.fn();
+    let callIndex = 0;
+    send.mockImplementation(async (command: unknown) => {
+        if (!(command instanceof SendMessageBatchCommand)) {
+            throw new Error(`Unexpected command: ${String(command)}`);
+        }
+        return await responder(command, callIndex++);
+    });
+    return { sqs: { send } as unknown as SQSClient, send };
+}
+
+function successfulBatchResponse(command: SendMessageBatchCommand): SendMessageBatchCommandOutput {
+    return {
+        $metadata: {},
+        Successful: (command.input.Entries ?? []).map((e) => ({ Id: e.Id!, MessageId: 'x', MD5OfMessageBody: 'x' })),
+        Failed: []
+    };
+}
+
+function deferred<T>() {
+    let resolve!: (value: T | PromiseLike<T>) => void;
+    let reject!: (reason?: unknown) => void;
+    const promise = new Promise<T>((res, rej) => {
+        resolve = res;
+        reject = rej;
+    });
+    return { promise, resolve, reject };
+}
+
+describe('DispatchQueuePublisher', () => {
+    beforeEach(() => {
+        vi.restoreAllMocks();
+        tracerMocks.active.mockClear();
+        tracerMocks.activate.mockClear();
+        tracerMocks.startSpan.mockClear();
+        tracerMocks.span.setTag.mockClear();
+        tracerMocks.span.finish.mockClear();
+        tracerMocks.activeSpan.setTag.mockClear();
+        tracerMocks.dogstatsd.increment.mockClear();
+        tracerMocks.dogstatsd.decrement.mockClear();
+        tracerMocks.dogstatsd.gauge.mockClear();
+        tracerMocks.dogstatsd.histogram.mockClear();
+        tracerMocks.dogstatsd.distribution.mockClear();
+    });
+
+    it('throws on invalid batchSize', () => {
+        const { sqs } = makeSqsMock(() => ({ $metadata: {}, Successful: [], Failed: [] }));
+        expect(() => new DispatchQueuePublisher({ sqs, queueUrl: 'http://q', batchSize: 0 })).toThrow('batchSize must be > 0');
+        expect(() => new DispatchQueuePublisher({ sqs, queueUrl: 'http://q', batchSize: -1 })).toThrow('batchSize must be > 0');
+    });
+
+    it('throws on invalid publishConcurrency', () => {
+        const { sqs } = makeSqsMock(() => ({ $metadata: {}, Successful: [], Failed: [] }));
+        expect(() => new DispatchQueuePublisher({ sqs, queueUrl: 'http://q', publishConcurrency: 0 })).toThrow('publishConcurrency must be > 0');
+    });
+
+    it('returns {enqueued:0,failed:0} for empty input', async () => {
+        const { sqs, send } = makeSqsMock(() => ({ $metadata: {}, Successful: [], Failed: [] }));
+        const publisher = new DispatchQueuePublisher({ sqs, queueUrl: 'http://q' });
+        const res = await publisher.publish([], 'account:1:env:2');
+        expect(res).toEqual({ enqueued: 0, failed: 0 });
+        expect(send.mock.calls).toHaveLength(0);
+    });
+
+    it('chunks into batches of <=10 for a 25-message input', async () => {
+        const { sqs, send } = makeSqsMock((cmd) => successfulBatchResponse(cmd));
+        const publisher = new DispatchQueuePublisher({ sqs, queueUrl: 'http://q' });
+        const messages = Array.from({ length: 25 }, () => buildMessage());
+        const res = await publisher.publish(messages, 'account:1:env:2');
+        expect(res).toEqual({ enqueued: 25, failed: 0 });
+        expect(send.mock.calls).toHaveLength(3);
+        const entryCounts = send.mock.calls.map((call) => (call[0] as SendMessageBatchCommand).input.Entries?.length);
+        expect(entryCounts).toEqual([10, 10, 5]);
+        expect(tracerMocks.startSpan).toHaveBeenCalledWith('webhook.dispatch.publish', {
+            childOf: expect.objectContaining({ traceId: 'active-trace' }),
+            tags: expect.objectContaining({
+                'nango.accountId': 1,
+                'nango.environmentId': 2,
+                'nango.integrationId': 3,
+                'nango.provider': 'github',
+                'nango.providerConfigKey': 'github-dev',
+                'nango.messageCount': 25,
+                'nango.batchCount': 3
+            })
+        });
+        expect(tracerMocks.activate).toHaveBeenCalledWith(tracerMocks.span, expect.any(Function));
+        expect(tracerMocks.span.setTag).toHaveBeenCalledWith('nango.enqueued', 25);
+        expect(tracerMocks.span.setTag).toHaveBeenCalledWith('nango.failed', 0);
+        expect(tracerMocks.span.setTag).toHaveBeenCalledWith('nango.retriedEntries', 0);
+        expect(tracerMocks.span.setTag).toHaveBeenCalledWith('nango.retriedBatches', 0);
+        expect(tracerMocks.dogstatsd.increment).toHaveBeenCalledTimes(1);
+        expect(tracerMocks.dogstatsd.increment).toHaveBeenCalledWith('nango.webhook.dispatch_queue.publish.success', 25, { provider: 'github' });
+        expect(tracerMocks.span.finish).toHaveBeenCalledTimes(1);
+    });
+
+    it('sets MessageGroupId on every entry', async () => {
+        const groupId = 'account:7:env:9';
+        const seen: string[] = [];
+        const { sqs } = makeSqsMock((cmd) => {
+            for (const entry of cmd.input.Entries ?? []) {
+                if (entry.MessageGroupId) seen.push(entry.MessageGroupId);
+            }
+            return successfulBatchResponse(cmd);
+        });
+        const publisher = new DispatchQueuePublisher({ sqs, queueUrl: 'http://q' });
+        await publisher.publish([buildMessage(), buildMessage()], groupId);
+        expect(seen).toEqual([groupId, groupId]);
+    });
+
+    it('limits concurrent batch publishes to publishConcurrency', async () => {
+        const responses = Array.from({ length: 4 }, () => deferred<SendMessageBatchCommandOutput>());
+        let inFlight = 0;
+        let maxInFlight = 0;
+
+        const { sqs, send } = makeSqsMock((_, call) => {
+            inFlight += 1;
+            maxInFlight = Math.max(maxInFlight, inFlight);
+            return responses[call]!.promise.finally(() => {
+                inFlight -= 1;
+            });
+        });
+
+        const publisher = new DispatchQueuePublisher({ sqs, queueUrl: 'http://q', batchSize: 1, publishConcurrency: 2 });
+        const publishPromise = publisher.publish(
+            Array.from({ length: 4 }, () => buildMessage()),
+            'account:1:env:2'
+        );
+
+        await vi.waitFor(() => {
+            expect(send.mock.calls).toHaveLength(2);
+        });
+        expect(maxInFlight).toBe(2);
+
+        responses[0]!.resolve(successfulBatchResponse(send.mock.calls[0]![0] as SendMessageBatchCommand));
+        responses[1]!.resolve(successfulBatchResponse(send.mock.calls[1]![0] as SendMessageBatchCommand));
+
+        await vi.waitFor(() => {
+            expect(send.mock.calls).toHaveLength(4);
+        });
+        expect(maxInFlight).toBe(2);
+
+        responses[2]!.resolve(successfulBatchResponse(send.mock.calls[2]![0] as SendMessageBatchCommand));
+        responses[3]!.resolve(successfulBatchResponse(send.mock.calls[3]![0] as SendMessageBatchCommand));
+
+        await expect(publishPromise).resolves.toEqual({ enqueued: 4, failed: 0 });
+    });
+
+    it('retries failed entries once and reports remaining failures', async () => {
+        const responses: SendMessageBatchCommandOutput[] = [
+            {
+                $metadata: {},
+                Successful: [{ Id: 'm0', MessageId: 'ok', MD5OfMessageBody: 'x' }],
+                Failed: [
+                    { Id: 'm1', SenderFault: false, Code: 'InternalError', Message: 'boom' },
+                    { Id: 'm2', SenderFault: false, Code: 'InternalError', Message: 'boom' }
+                ]
+            },
+            // second call is the retry of m1, m2 — only m1 recovers
+            {
+                $metadata: {},
+                Successful: [{ Id: 'm1', MessageId: 'ok', MD5OfMessageBody: 'x' }],
+                Failed: [{ Id: 'm2', SenderFault: false, Code: 'InternalError', Message: 'still broken' }]
+            }
+        ];
+        const { sqs, send } = makeSqsMock((_n, call) => responses[call]!);
+        const publisher = new DispatchQueuePublisher({ sqs, queueUrl: 'http://q' });
+        const res = await publisher.publish([buildMessage(), buildMessage(), buildMessage()], 'account:1:env:2');
+        expect(res).toEqual({ enqueued: 2, failed: 1 });
+        expect(send.mock.calls).toHaveLength(2);
+        expect(tracerMocks.span.setTag).toHaveBeenCalledWith('nango.enqueued', 2);
+        expect(tracerMocks.span.setTag).toHaveBeenCalledWith('nango.failed', 1);
+        expect(tracerMocks.span.setTag).toHaveBeenCalledWith('nango.retriedEntries', 2);
+        expect(tracerMocks.span.setTag).toHaveBeenCalledWith('nango.retriedBatches', 1);
+        expect(tracerMocks.span.setTag).toHaveBeenCalledWith('nango.partialFailure', true);
+        expect(tracerMocks.span.setTag).toHaveBeenCalledWith('error', expect.any(Error));
+        expect(tracerMocks.dogstatsd.increment).toHaveBeenCalledTimes(2);
+        expect(tracerMocks.dogstatsd.increment).toHaveBeenCalledWith('nango.webhook.dispatch_queue.publish.success', 2, { provider: 'github' });
+        expect(tracerMocks.dogstatsd.increment).toHaveBeenCalledWith('nango.webhook.dispatch_queue.publish.failure', 1, { provider: 'github' });
+        expect(tracerMocks.span.finish).toHaveBeenCalledTimes(1);
+    });
+
+    it('treats an SDK throw as all-entries-failed and still retries', async () => {
+        let call = 0;
+        const { sqs, send } = makeSqsMock(() => {
+            call++;
+            if (call === 1) throw new Error('network');
+            return { $metadata: {}, Successful: [{ Id: 'm0', MessageId: 'ok', MD5OfMessageBody: 'x' }], Failed: [] };
+        });
+        const publisher = new DispatchQueuePublisher({ sqs, queueUrl: 'http://q' });
+        const res = await publisher.publish([buildMessage()], 'account:1:env:2');
+        expect(res).toEqual({ enqueued: 1, failed: 0 });
+        expect(send.mock.calls).toHaveLength(2);
+        expect(tracerMocks.span.setTag).toHaveBeenCalledWith('nango.retriedEntries', 1);
+        expect(tracerMocks.span.setTag).toHaveBeenCalledWith('nango.retriedBatches', 1);
+        expect(tracerMocks.span.setTag.mock.calls.filter(([tag]) => tag === 'error')).toHaveLength(0);
+        expect(tracerMocks.activeSpan.setTag).toHaveBeenCalledWith('sqs.send.error', expect.any(Error));
+    });
+});

--- a/packages/server/lib/webhook/runWithConcurrencyLimit.ts
+++ b/packages/server/lib/webhook/runWithConcurrencyLimit.ts
@@ -1,0 +1,20 @@
+export async function runWithConcurrencyLimit<T, R>(items: T[], concurrency: number, worker: (item: T, index: number) => Promise<R>): Promise<R[]> {
+    const results: R[] = new Array(items.length);
+    const workerCount = Math.min(concurrency, items.length);
+    let nextIndex = 0;
+
+    await Promise.all(
+        Array.from({ length: workerCount }, async () => {
+            while (true) {
+                const index = nextIndex++;
+                if (index >= items.length) {
+                    return;
+                }
+
+                results[index] = await worker(items[index]!, index);
+            }
+        })
+    );
+
+    return results;
+}

--- a/packages/server/package.json
+++ b/packages/server/package.json
@@ -19,6 +19,7 @@
     },
     "license": "SEE LICENSE IN LICENSE FILE IN GIT REPOSITORY",
     "dependencies": {
+        "@aws-sdk/client-sqs": "3.993.0",
         "@modelcontextprotocol/sdk": "1.26.0",
         "@nangohq/authz": "file:../authz",
         "@nangohq/usage": "file:../usage",

--- a/packages/types/lib/index.ts
+++ b/packages/types/lib/index.ts
@@ -80,6 +80,7 @@ export type * from './environment/api/otlp.js';
 export type * from './environment/variable/index.js';
 export type * from './environment/variable/api.js';
 export type * from './webhooks/api.js';
+export type * from './webhooks/dispatch.js';
 export type * from './webhooks/http.api.js';
 export type * from './flow/http.api.js';
 export type * from './flow/index.js';

--- a/packages/types/lib/webhooks/dispatch.ts
+++ b/packages/types/lib/webhooks/dispatch.ts
@@ -1,0 +1,33 @@
+/**
+ * SQS message envelope for the webhook task-dispatch queue.
+ *
+ * The server produces one of these per (syncConfig × webhook subscription × connection)
+ * triple resulting from an inbound provider webhook. The jobs consumer parses these and
+ * calls the orchestrator to schedule the actual webhook task using `taskName` as the
+ * idempotency key.
+ */
+export interface WebhookDispatchMessage {
+    version: 1;
+    kind: 'webhook';
+    /**
+     * Deterministic scheduler task name; used by the orchestrator as the
+     * idempotency key so duplicate SQS deliveries resolve to the same task.
+     */
+    taskName: string;
+    createdAt: string;
+    accountId: number;
+    integrationId: number;
+    provider: string;
+    parentSyncName: string;
+    /** Webhook subscription name matched on the inbound payload; passed to executeWebhook as args.webhookName. */
+    webhookName: string;
+    /** Activity log id created before enqueue; also reused as the taskName dedupe seed. */
+    activityLogId: string;
+    connection: {
+        id: number;
+        connection_id: string;
+        provider_config_key: string;
+        environment_id: number;
+    };
+    payload: unknown;
+}

--- a/packages/utils/lib/environment/parse.ts
+++ b/packages/utils/lib/environment/parse.ts
@@ -549,7 +549,7 @@ export const ENVS = z.object({
     NANGO_TASK_DISPATCH_VISIBILITY_TIMEOUT_SECONDS: z.coerce.number().min(0).max(43200).optional().default(30),
     NANGO_TASK_DISPATCH_CONSUMER_CONCURRENCY: z.coerce.number().min(1).optional().default(50),
     NANGO_TASK_DISPATCH_PUBLISH_BATCH_SIZE: z.coerce.number().min(1).max(10).optional().default(10),
-    NANGO_TASK_DISPATCH_PUBLISH_CONCURRENCY: z.coerce.number().min(1).optional().default(5),
+    NANGO_TASK_DISPATCH_PUBLISH_CONCURRENCY: z.coerce.number().min(1).optional().default(10),
 
     // E2B sandboxes
     E2B_API_KEY: z.string().optional(),

--- a/packages/utils/lib/environment/parse.unit.test.ts
+++ b/packages/utils/lib/environment/parse.unit.test.ts
@@ -200,7 +200,7 @@ describe('parse', () => {
                 NANGO_TASK_DISPATCH_VISIBILITY_TIMEOUT_SECONDS: 30,
                 NANGO_TASK_DISPATCH_CONSUMER_CONCURRENCY: 50,
                 NANGO_TASK_DISPATCH_PUBLISH_BATCH_SIZE: 10,
-                NANGO_TASK_DISPATCH_PUBLISH_CONCURRENCY: 5
+                NANGO_TASK_DISPATCH_PUBLISH_CONCURRENCY: 10
             });
             expect(res.NANGO_TASK_DISPATCH_QUEUE_URL).toBeUndefined();
             expect(res.NANGO_TASK_DISPATCH_DLQ_URL).toBeUndefined();

--- a/packages/utils/lib/telemetry/metrics.ts
+++ b/packages/utils/lib/telemetry/metrics.ts
@@ -68,6 +68,16 @@ export enum Types {
     WEBHOOK_ASYNC_ACTION_FAILED = 'nango.webhook.async_action.failed',
     WEBHOOK_INCOMING_PAYLOAD_SIZE_BYTES = 'nango.webhook.incoming.payloadSizeBytes',
 
+    WEBHOOK_DISPATCH_PUBLISH_SUCCESS = 'nango.webhook.dispatch_queue.publish.success',
+    WEBHOOK_DISPATCH_PUBLISH_FAILURE = 'nango.webhook.dispatch_queue.publish.failure',
+    WEBHOOK_DISPATCH_LARGE_FANOUT = 'nango.webhook.dispatch_queue.large_fanout',
+    WEBHOOK_DISPATCH_CONSUME_SUCCESS = 'nango.webhook.dispatch_queue.consume.success',
+    WEBHOOK_DISPATCH_CONSUME_FAILURE = 'nango.webhook.dispatch_queue.consume.failure',
+    WEBHOOK_DISPATCH_SCHEDULE_SUCCESS = 'nango.webhook.dispatch_queue.schedule.success',
+    WEBHOOK_DISPATCH_SCHEDULE_FAILURE = 'nango.webhook.dispatch_queue.schedule.failure',
+    WEBHOOK_DISPATCH_POISON_PILL = 'nango.webhook.dispatch_queue.poison_pill',
+    WEBHOOK_DISPATCH_DWELL_MS = 'nango.webhook.dispatch_queue.dwell_ms',
+
     ORCH_TASKS_CREATED = 'nango.orch.tasks.created',
     ORCH_TASKS_DROPPED = 'nango.orch.tasks.dropped',
     ORCH_TASKS_STARTED = 'nango.orch.tasks.started',


### PR DESCRIPTION
- WebhookDispatchMessage shared type in `@nangohq/types`
- DispatchQueuePublisher in server package: batched SendMessageBatch, parallel batches, one inline retry for failed entries, partial-failure emits metric + log
- New WEBHOOK_DISPATCH_* metric types in `@nangohq/utils`
- Adds `@aws-sdk/client-sqs` depedency to server

No call sites yet, wired up in NAN-5340.

<!-- Describe the problem and your solution --> 

<!-- Issue ticket number and link (if applicable) -->

<!-- Testing instructions (skip if just adding/editing providers) -->

