### PR TITLE
feat(webhooks): add jobs dispatch queue consumer + scheduler idempotent create (NAN-5341)

### DIFF
--- a/packages/jobs/lib/app.ts
+++ b/packages/jobs/lib/app.ts
@@ -7,12 +7,14 @@ import { destroy as destroyLogs, otlp } from '@nangohq/logs';
 import { getOtlpRoutes } from '@nangohq/shared';
 import { getLogger, initSentry, once, report, stringifyError } from '@nangohq/utils';
 
+import { orchestratorClient } from './clients.js';
 import { envs } from './env.js';
 import { LambdaInvocationsProcessor } from './invocations/lambda.processor.js';
 import { Processor } from './processor/processor.js';
 import { getDefaultFleet, startFleets, stopFleets } from './runtime/runtimes.js';
 import { server } from './server.js';
 import { pubsub } from './utils/pubsub.js';
+import { DispatchQueueConsumer } from './webhook/dispatch-queue/consumer.js';
 
 const logger = getLogger('Jobs');
 
@@ -37,6 +39,17 @@ try {
     logger.info(`🚀 service ready at http://localhost:${port}`);
     const processor = new Processor(orchestratorUrl);
     const invocationsProcessor = new LambdaInvocationsProcessor();
+
+    const dispatchConsumer = envs.NANGO_TASK_DISPATCH_QUEUE_URL
+        ? new DispatchQueueConsumer({
+              queueUrl: envs.NANGO_TASK_DISPATCH_QUEUE_URL,
+              orchestratorClient,
+              webhookMaxConcurrency: envs.WEBHOOK_ENVIRONMENT_MAX_CONCURRENCY,
+              maxMessages: envs.NANGO_TASK_DISPATCH_MAX_MESSAGES,
+              waitTimeSeconds: envs.NANGO_TASK_DISPATCH_WAIT_TIME_SECONDS,
+              visibilityTimeoutSeconds: envs.NANGO_TASK_DISPATCH_VISIBILITY_TIMEOUT_SECONDS
+          })
+        : undefined;
 
     // We are using a setTimeout because we don't want overlapping setInterval if the DB is down
     let healthCheck: NodeJS.Timeout | undefined;
@@ -79,6 +92,9 @@ try {
             await db.readOnly.destroy();
             await destroyKvstore();
             await invocationsProcessor.stop();
+            if (dispatchConsumer) {
+                await dispatchConsumer.stop();
+            }
 
             console.info('Closed');
 
@@ -108,6 +124,11 @@ try {
     processor.start();
 
     invocationsProcessor.start();
+
+    if (dispatchConsumer) {
+        dispatchConsumer.start();
+        logger.info('webhook dispatch queue consumer started');
+    }
 
     void otlp.register(getOtlpRoutes);
 } catch (err) {

--- a/packages/jobs/lib/webhook/dispatch-queue/consumer.ts
+++ b/packages/jobs/lib/webhook/dispatch-queue/consumer.ts
@@ -1,0 +1,187 @@
+import { DeleteMessageCommand, ReceiveMessageCommand, SQSClient } from '@aws-sdk/client-sqs';
+import * as z from 'zod';
+
+import { getLogger, metrics, report } from '@nangohq/utils';
+
+import type { Message } from '@aws-sdk/client-sqs';
+import type { OrchestratorClient } from '@nangohq/nango-orchestrator';
+import type { WebhookDispatchMessage } from '@nangohq/types';
+
+const logger = getLogger('jobs.webhook.dispatch-queue.consumer');
+
+const getRegion = (): string => {
+    const env = typeof process !== 'undefined' ? process.env['LAMBDA_REGION'] : undefined;
+    return env ?? 'us-west-2';
+};
+
+const messageSchema: z.ZodType<WebhookDispatchMessage> = z.object({
+    version: z.literal(1),
+    kind: z.literal('webhook'),
+    taskName: z.string().min(1),
+    createdAt: z.string().min(1),
+    ingressRequestId: z.string().min(1),
+    accountId: z.number(),
+    environmentId: z.number(),
+    integrationId: z.number(),
+    provider: z.string(),
+    providerConfigKey: z.string(),
+    parentSyncName: z.string(),
+    activityLogId: z.string(),
+    webhookName: z.string(),
+    connection: z.object({
+        id: z.number(),
+        connection_id: z.string(),
+        provider_config_key: z.string(),
+        environment_id: z.number()
+    }),
+    payload: z.unknown()
+});
+
+export interface DispatchQueueConsumerProps {
+    queueUrl: string;
+    orchestratorClient: OrchestratorClient;
+    webhookMaxConcurrency: number;
+    maxMessages: number;
+    waitTimeSeconds: number;
+    visibilityTimeoutSeconds: number;
+    sqs?: SQSClient;
+}
+
+export class DispatchQueueConsumer {
+    private readonly sqs: SQSClient;
+    private readonly queueUrl: string;
+    private readonly orchestratorClient: OrchestratorClient;
+    private readonly webhookMaxConcurrency: number;
+    private readonly maxMessages: number;
+    private readonly waitTimeSeconds: number;
+    private readonly visibilityTimeoutSeconds: number;
+    private readonly abortController = new AbortController();
+    private loopPromise: Promise<void> | undefined;
+
+    constructor(props: DispatchQueueConsumerProps) {
+        this.queueUrl = props.queueUrl;
+        this.orchestratorClient = props.orchestratorClient;
+        this.webhookMaxConcurrency = props.webhookMaxConcurrency;
+        this.maxMessages = props.maxMessages;
+        this.waitTimeSeconds = props.waitTimeSeconds;
+        this.visibilityTimeoutSeconds = props.visibilityTimeoutSeconds;
+        this.sqs = props.sqs ?? new SQSClient({ region: getRegion() });
+    }
+
+    start(): void {
+        if (this.loopPromise) {
+            return;
+        }
+        logger.info(`webhook dispatch consumer subscribing to ${this.queueUrl}`);
+        this.loopPromise = this.pollLoop();
+    }
+
+    async stop(): Promise<void> {
+        this.abortController.abort();
+        if (this.loopPromise) {
+            await this.loopPromise;
+        }
+        this.sqs.destroy();
+    }
+
+    private async pollLoop(): Promise<void> {
+        const signal = this.abortController.signal;
+        while (!signal.aborted) {
+            try {
+                const result = await this.sqs.send(
+                    new ReceiveMessageCommand({
+                        QueueUrl: this.queueUrl,
+                        MaxNumberOfMessages: this.maxMessages,
+                        WaitTimeSeconds: this.waitTimeSeconds,
+                        VisibilityTimeout: this.visibilityTimeoutSeconds,
+                        MessageAttributeNames: ['All'],
+                        MessageSystemAttributeNames: ['SentTimestamp', 'ApproximateReceiveCount']
+                    }),
+                    { abortSignal: signal }
+                );
+
+                const messages = result.Messages ?? [];
+                if (messages.length === 0) continue;
+
+                // Process all messages in a batch concurrently. Each SQS receive is already
+                // capped at maxMessages (<=10) so no extra semaphore is needed.
+                await Promise.all(messages.map((msg) => this.processMessage(msg)));
+            } catch (err) {
+                if (err instanceof Error && err.name === 'AbortError') break;
+                report(new Error('webhook dispatch consumer receive failed', { cause: err }));
+                await new Promise((resolve) => setTimeout(resolve, 1000));
+            }
+        }
+    }
+
+    private async processMessage(msg: Message): Promise<void> {
+        if (!msg.Body || !msg.ReceiptHandle) return;
+
+        const parsed = this.parseMessage(msg.Body);
+        if (!parsed) {
+            metrics.increment(metrics.Types.WEBHOOK_DISPATCH_POISON_PILL);
+            // Parse failures are poison pills — redelivering won't help. Delete and move on.
+            await this.tryDeleteMessage(msg.ReceiptHandle);
+            return;
+        }
+        const message = parsed;
+
+        const sentTimestampMs = Number(msg.Attributes?.['SentTimestamp'] ?? '0');
+        if (sentTimestampMs > 0) {
+            metrics.duration(metrics.Types.WEBHOOK_DISPATCH_DWELL_MS, Date.now() - sentTimestampMs, { provider: message.provider });
+        }
+
+        const scheduleRes = await this.orchestratorClient.immediate({
+            name: message.taskName,
+            group: { key: `webhook:environment:${message.environmentId}`, maxConcurrency: this.webhookMaxConcurrency },
+            retry: { count: 0, max: 0 },
+            timeoutSettingsInSecs: { createdToStarted: 5 * 60, startedToCompleted: 60 * 60, heartbeat: 5 * 60 },
+            args: {
+                type: 'webhook',
+                webhookName: message.webhookName,
+                parentSyncName: message.parentSyncName,
+                connection: message.connection,
+                activityLogId: message.activityLogId,
+                input: (message.payload ?? null) as never
+            }
+        });
+
+        if (scheduleRes.isErr()) {
+            metrics.increment(metrics.Types.WEBHOOK_DISPATCH_SCHEDULE_FAILURE, 1, { provider: message.provider });
+            metrics.increment(metrics.Types.WEBHOOK_DISPATCH_CONSUME_FAILURE, 1, { provider: message.provider });
+            logger.error(`failed to schedule webhook task ${message.taskName}`, { error: scheduleRes.error });
+            // Don't delete — let SQS redeliver and eventually DLQ.
+            return;
+        }
+
+        metrics.increment(metrics.Types.WEBHOOK_DISPATCH_SCHEDULE_SUCCESS, 1, { provider: message.provider });
+        metrics.increment(metrics.Types.WEBHOOK_DISPATCH_CONSUME_SUCCESS, 1, { provider: message.provider });
+
+        await this.tryDeleteMessage(msg.ReceiptHandle);
+    }
+
+    private parseMessage(body: string): WebhookDispatchMessage | null {
+        try {
+            const json = JSON.parse(body);
+            const result = messageSchema.safeParse(json);
+            if (!result.success) {
+                logger.error('webhook dispatch consumer received invalid message', { issues: result.error.issues });
+                return null;
+            }
+            return result.data;
+        } catch (err) {
+            logger.error('webhook dispatch consumer could not JSON.parse body', { error: err });
+            return null;
+        }
+    }
+
+    private async tryDeleteMessage(receiptHandle: string): Promise<void> {
+        try {
+            await this.sqs.send(new DeleteMessageCommand({ QueueUrl: this.queueUrl, ReceiptHandle: receiptHandle }), {
+                abortSignal: this.abortController.signal
+            });
+        } catch (err) {
+            report(new Error('webhook dispatch consumer delete failed', { cause: err }));
+        }
+    }
+}

--- a/packages/jobs/lib/webhook/dispatch-queue/consumer.unit.test.ts
+++ b/packages/jobs/lib/webhook/dispatch-queue/consumer.unit.test.ts
@@ -1,0 +1,151 @@
+import { DeleteMessageCommand, ReceiveMessageCommand } from '@aws-sdk/client-sqs';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+import { Err, Ok } from '@nangohq/utils';
+
+import { DispatchQueueConsumer } from './consumer.js';
+
+import type { SQSClient } from '@aws-sdk/client-sqs';
+import type { OrchestratorClient } from '@nangohq/nango-orchestrator';
+import type { WebhookDispatchMessage } from '@nangohq/types';
+
+function buildMessage(overrides: Partial<WebhookDispatchMessage> = {}): WebhookDispatchMessage {
+    return {
+        version: 1,
+        kind: 'webhook',
+        taskName: 'webhook:abc123',
+        createdAt: '2026-04-23T00:00:00.000Z',
+        ingressRequestId: 'req-1',
+        accountId: 1,
+        environmentId: 2,
+        integrationId: 3,
+        provider: 'github',
+        providerConfigKey: 'github-dev',
+        parentSyncName: 'sync-1',
+        activityLogId: 'log-1',
+        webhookName: 'push',
+        connection: { id: 42, connection_id: 'conn-1', provider_config_key: 'github-dev', environment_id: 2 },
+        payload: { hello: 'world' },
+        ...overrides
+    };
+}
+
+interface Harness {
+    consumer: DispatchQueueConsumer;
+    sqsSend: ReturnType<typeof vi.fn>;
+    orchestratorClient: OrchestratorClient;
+    orchestratorImmediate: ReturnType<typeof vi.fn>;
+}
+
+function makeHarness(opts: { messages?: WebhookDispatchMessage[]; badBody?: string }): Harness {
+    const messages = opts.messages ?? [];
+    const bodyQueue: { Body: string; ReceiptHandle: string; Attributes: Record<string, string> }[] = [];
+    for (let i = 0; i < messages.length; i++) {
+        bodyQueue.push({ Body: JSON.stringify(messages[i]), ReceiptHandle: `rh-${i}`, Attributes: { SentTimestamp: String(Date.now() - 500) } });
+    }
+    if (opts.badBody !== undefined) {
+        bodyQueue.push({ Body: opts.badBody, ReceiptHandle: `rh-bad`, Attributes: { SentTimestamp: String(Date.now()) } });
+    }
+
+    const sqsSend = vi.fn();
+    let firstReceive = true;
+    sqsSend.mockImplementation(async (command: unknown) => {
+        // Yield a macrotask so the loop doesn't monopolize the event loop after stop() sets abort.
+        await new Promise((resolve) => setImmediate(resolve));
+        if (command instanceof ReceiveMessageCommand) {
+            if (firstReceive) {
+                firstReceive = false;
+                return { Messages: bodyQueue };
+            }
+            return { Messages: [] };
+        }
+        if (command instanceof DeleteMessageCommand) {
+            return {};
+        }
+        throw new Error(`unexpected command ${String(command)}`);
+    });
+
+    const sqs = { send: sqsSend, destroy: vi.fn() } as unknown as SQSClient;
+
+    const orchestratorImmediate = vi.fn();
+    orchestratorImmediate.mockResolvedValue(Ok({ taskId: 'task-1', retryKey: 'rk-1' }));
+    const orchestratorClient = { immediate: orchestratorImmediate } as unknown as OrchestratorClient;
+
+    const consumer = new DispatchQueueConsumer({
+        sqs,
+        queueUrl: 'http://queue',
+        orchestratorClient,
+        webhookMaxConcurrency: 500,
+        maxMessages: 10,
+        waitTimeSeconds: 0,
+        visibilityTimeoutSeconds: 30
+    });
+
+    return { consumer, sqsSend, orchestratorClient, orchestratorImmediate };
+}
+
+async function runOnce(h: Harness): Promise<void> {
+    h.consumer.start();
+    // Let the loop process one receive tick.
+    await new Promise((resolve) => setTimeout(resolve, 20));
+    await h.consumer.stop();
+}
+
+describe('DispatchQueueConsumer', () => {
+    beforeEach(() => {
+        vi.restoreAllMocks();
+    });
+
+    it('schedules a valid message and deletes it on success', async () => {
+        const msg = buildMessage();
+        const h = makeHarness({ messages: [msg] });
+        await runOnce(h);
+
+        expect(h.orchestratorImmediate).toHaveBeenCalledTimes(1);
+        const call = h.orchestratorImmediate.mock.calls[0]?.[0];
+        expect(call).toMatchObject({
+            name: msg.taskName,
+            group: { key: 'webhook:environment:2', maxConcurrency: 500 },
+            args: {
+                type: 'webhook',
+                webhookName: msg.webhookName,
+                parentSyncName: msg.parentSyncName,
+                connection: msg.connection,
+                activityLogId: msg.activityLogId,
+                input: msg.payload
+            }
+        });
+        const deleteCalls = h.sqsSend.mock.calls.filter((c) => c[0] instanceof DeleteMessageCommand);
+        expect(deleteCalls).toHaveLength(1);
+    });
+
+    it('does not delete when orchestrator returns an error', async () => {
+        const h = makeHarness({ messages: [buildMessage()] });
+        h.orchestratorImmediate.mockResolvedValueOnce(Err({ name: 'boom', message: 'boom', payload: null }));
+
+        await runOnce(h);
+
+        expect(h.orchestratorImmediate).toHaveBeenCalledTimes(1);
+        const deleteCalls = h.sqsSend.mock.calls.filter((c) => c[0] instanceof DeleteMessageCommand);
+        expect(deleteCalls).toHaveLength(0);
+    });
+
+    it('deletes a poison-pill message without calling orchestrator', async () => {
+        const h = makeHarness({ badBody: 'not-json' });
+        await runOnce(h);
+
+        expect(h.orchestratorImmediate).not.toHaveBeenCalled();
+        const deleteCalls = h.sqsSend.mock.calls.filter((c) => c[0] instanceof DeleteMessageCommand);
+        expect(deleteCalls).toHaveLength(1);
+    });
+
+    it('rejects a schema-invalid message as poison and deletes it', async () => {
+        const invalid = { ...buildMessage(), kind: 'wrong' };
+        const h = makeHarness({ badBody: JSON.stringify(invalid) });
+        await runOnce(h);
+
+        expect(h.orchestratorImmediate).not.toHaveBeenCalled();
+        const deleteCalls = h.sqsSend.mock.calls.filter((c) => c[0] instanceof DeleteMessageCommand);
+        expect(deleteCalls).toHaveLength(1);
+    });
+});

--- a/packages/scheduler/lib/models/tasks.integration.test.ts
+++ b/packages/scheduler/lib/models/tasks.integration.test.ts
@@ -84,6 +84,37 @@ describe('Task', () => {
         expect(res.tasks[1]?.name).toBe('Also not capped');
         expect(res.cappedGroupKeys).toEqual([props.groupKey]);
     });
+    it('should return the existing task on unique-name collision instead of erroring', async () => {
+        const name = `dup-${nanoid()}`;
+        const first = (await tasks.create(db, [{ ...props, name }])).unwrap();
+        expect(first.tasks).toHaveLength(1);
+        expect(first.newlyInsertedTaskIds.size).toBe(1);
+        const originalId = first.tasks[0]!.id;
+
+        const second = (await tasks.create(db, [{ ...props, name }])).unwrap();
+        expect(second.tasks).toHaveLength(1);
+        expect(second.tasks[0]!.id).toBe(originalId);
+        expect(second.newlyInsertedTaskIds.size).toBe(0);
+    });
+    it('should handle a mixed batch where some names already exist', async () => {
+        const existingName = `dup-${nanoid()}`;
+        const newName = `new-${nanoid()}`;
+        const first = (await tasks.create(db, [{ ...props, name: existingName }])).unwrap();
+        const existingId = first.tasks[0]!.id;
+
+        const mixed = (
+            await tasks.create(db, [
+                { ...props, name: existingName },
+                { ...props, name: newName }
+            ])
+        ).unwrap();
+        expect(mixed.tasks).toHaveLength(2);
+        const byName = new Map(mixed.tasks.map((t) => [t.name, t]));
+        expect(byName.get(existingName)!.id).toBe(existingId);
+        expect(byName.get(newName)!.id).not.toBe(existingId);
+        expect(mixed.newlyInsertedTaskIds.has(byName.get(newName)!.id)).toBe(true);
+        expect(mixed.newlyInsertedTaskIds.has(existingId)).toBe(false);
+    });
     it('should have their heartbeat updated', async () => {
         const t = await startTask(db);
         await new Promise((resolve) => void setTimeout(resolve, 20));

--- a/packages/scheduler/lib/models/tasks.ts
+++ b/packages/scheduler/lib/models/tasks.ts
@@ -126,9 +126,9 @@ export async function create(
     db: knex.Knex,
     taskProps: TaskProps[],
     opts: { groupTaskCap: number } = { groupTaskCap: envs.ORCHESTRATOR_TASK_CREATED_PER_GROUP_COUNT_MAX }
-): Promise<Result<{ tasks: Task[]; cappedGroupKeys: string[] }>> {
+): Promise<Result<{ tasks: Task[]; newlyInsertedTaskIds: Set<string>; cappedGroupKeys: string[] }>> {
     if (taskProps.length === 0) {
-        return Ok({ tasks: [], cappedGroupKeys: [] });
+        return Ok({ tasks: [], newlyInsertedTaskIds: new Set(), cappedGroupKeys: [] });
     }
     try {
         // safeguard to prevent creating an unbounded number of tasks for the same group
@@ -172,14 +172,32 @@ export async function create(
             metrics.increment(metrics.Types.ORCH_TASKS_DROPPED, droppedCount, { primitive, reason: 'task_cap' });
         }
         const toInsert = Array.from(toInsertPerGroup.values()).flat();
-        const inserted: Task[] = [];
+        const tasks: Task[] = [];
+        const newlyInsertedTaskIds = new Set<string>();
         while (toInsert.length) {
             const chunk = toInsert.splice(0, TASKS_INSERT_BATCH_SIZE);
-            const batch = await db.from<DBTask>(TASKS_TABLE).insert(chunk.map(DbTask.to)).returning('*');
-            inserted.push(...batch.map(DbTask.from));
+            // Idempotent insert: on unique-name conflict, return the existing row instead of erroring.
+            // Lets callers (e.g., webhook dispatch consumer) treat re-delivery of the same task name
+            // as a no-op instead of a hard error.
+            const batch = await db.from<DBTask>(TASKS_TABLE).insert(chunk.map(DbTask.to)).onConflict('name').ignore().returning('*');
+            const insertedNames = new Set<string>();
+            for (const dbt of batch) {
+                const t = DbTask.from(dbt);
+                tasks.push(t);
+                insertedNames.add(t.name);
+                newlyInsertedTaskIds.add(t.id);
+            }
+            const missingNames = chunk.map((t) => t.name).filter((n) => !insertedNames.has(n));
+            if (missingNames.length > 0) {
+                const existing = await db.from<DBTask>(TASKS_TABLE).whereIn('name', missingNames).select<DBTask[]>('*');
+                for (const dbt of existing) {
+                    tasks.push(DbTask.from(dbt));
+                }
+            }
         }
         return Ok({
-            tasks: inserted,
+            tasks,
+            newlyInsertedTaskIds,
             cappedGroupKeys: Array.from(cappedGroupCounts.keys())
         });
     } catch (err) {

--- a/packages/scheduler/lib/scheduler.ts
+++ b/packages/scheduler/lib/scheduler.ts
@@ -210,13 +210,19 @@ export class Scheduler {
             if (!task) {
                 return Err(`Failed to create task '${taskProps.name}'`);
             }
-            if (task.scheduleId) {
+            const wasNewlyInserted = created.value.newlyInsertedTaskIds.has(task.id);
+            if (wasNewlyInserted && task.scheduleId) {
                 const scheduleRes = await schedules.setLastScheduledTask(trx, [{ id: task.scheduleId, taskId: task.id, taskState: task.state }]);
                 if (scheduleRes.isErr()) {
                     return Err(`Error updating last scheduled task for schedule '${task.scheduleId}': ${stringifyError(scheduleRes.error)}`);
                 }
             }
-            this.onCallbacks[task.state](task);
+            // Only fire the CREATED callback for genuinely new tasks.
+            // On a name collision we return the pre-existing task so the caller sees
+            // an idempotent success, but the callback already fired at original insert time.
+            if (wasNewlyInserted) {
+                this.onCallbacks[task.state](task);
+            }
             return Ok(task);
         });
     }

--- a/packages/server/lib/webhook/dispatch-queue/publisher.unit.test.ts
+++ b/packages/server/lib/webhook/dispatch-queue/publisher.unit.test.ts
@@ -52,7 +52,7 @@ function buildMessage(overrides: Partial<WebhookDispatchMessage> = {}): WebhookD
         providerConfigKey: 'github-dev',
         parentSyncName: 'sync-1',
         activityLogId: 'log-1',
-        webhookName: 'sync-1',
+        webhookName: 'push',
         connection: { id: 42, connection_id: 'conn-1', provider_config_key: 'github-dev', environment_id: 2 },
         payload: { hello: 'world' },
         ...overrides

--- a/packages/types/lib/webhooks/dispatch.ts
+++ b/packages/types/lib/webhooks/dispatch.ts
@@ -28,6 +28,9 @@ export interface WebhookDispatchMessage {
     provider: string;
     providerConfigKey: string;
     parentSyncName: string;
+    /** Log context id created by the server before publishing; threaded through to the webhook runner. */
+    activityLogId: string;
+    webhookName: string;
     connection: {
         id: number;
         connection_id: string;


### PR DESCRIPTION
Consumer (packages/jobs/lib/webhook/dispatch-queue/consumer.ts)
- Long-polls the task-dispatch SQS queue and schedules webhook tasks via `orchestratorClient.immediate()` using `taskName` from the message as the idempotency key.
- Deletes messages on Ok; leaves them visible on Err so SQS redelivers and eventually DLQs.
- Poison-pill messages (unparseable / schema-invalid) are deleted to avoid redelivery loops, with a dedicated metric.
- Wired into `packages/jobs/lib/app.ts` behind `NANGO_TASK_DISPATCH_QUEUE_URL` a no-op when the env var is absent.

Scheduler (`packages/scheduler/lib/models/tasks.ts`)
- `tasks.create` is now idempotent on unique-name conflict. Uses `onConflict('name').ignore()` and fetches the pre-existing row when a collision is detected, returning it in the result so the caller sees an idempotent success instead of a generic DB error.
- New return field `newlyInsertedTaskIds: Set<string>` so callers like scheduler.immediate() can distinguish genuinely new tasks from re-returned existing ones and avoid firing the onCreated callback twice.

WebhookDispatchMessage (packages/types/lib/webhooks/dispatch.ts)
- Adds activityLogId and webhookName fields, threaded from the server to the webhook runner via the consumer.

<!-- Describe the problem and your solution --> 

<!-- Issue ticket number and link (if applicable) -->

<!-- Testing instructions (skip if just adding/editing providers) -->

