### PR TITLE
feat(webhooks): add jobs dispatch queue consumer (NAN-5341) 2/5

### DIFF
--- a/packages/jobs/lib/app.ts
+++ b/packages/jobs/lib/app.ts
@@ -7,12 +7,14 @@ import { destroy as destroyLogs, otlp } from '@nangohq/logs';
 import { getOtlpRoutes } from '@nangohq/shared';
 import { getLogger, initSentry, once, report, stringifyError } from '@nangohq/utils';
 
+import { orchestratorClient } from './clients.js';
 import { envs } from './env.js';
 import { LambdaInvocationsProcessor } from './invocations/lambda.processor.js';
 import { Processor } from './processor/processor.js';
 import { getDefaultFleet, startFleets, stopFleets } from './runtime/runtimes.js';
 import { server } from './server.js';
 import { pubsub } from './utils/pubsub.js';
+import { DispatchQueueConsumer } from './webhook/dispatch-queue/consumer.js';
 
 const logger = getLogger('Jobs');
 
@@ -37,6 +39,18 @@ try {
     logger.info(`🚀 service ready at http://localhost:${port}`);
     const processor = new Processor(orchestratorUrl);
     const invocationsProcessor = new LambdaInvocationsProcessor();
+
+    const webhookDispatchConsumer = envs.NANGO_TASK_DISPATCH_QUEUE_URL
+        ? new DispatchQueueConsumer({
+              queueUrl: envs.NANGO_TASK_DISPATCH_QUEUE_URL,
+              orchestratorClient,
+              webhookMaxConcurrency: envs.WEBHOOK_ENVIRONMENT_MAX_CONCURRENCY,
+              consumerConcurrency: envs.NANGO_TASK_DISPATCH_CONSUMER_CONCURRENCY,
+              maxMessages: envs.NANGO_TASK_DISPATCH_MAX_MESSAGES,
+              waitTimeSeconds: envs.NANGO_TASK_DISPATCH_WAIT_TIME_SECONDS,
+              visibilityTimeoutSeconds: envs.NANGO_TASK_DISPATCH_VISIBILITY_TIMEOUT_SECONDS
+          })
+        : undefined;
 
     // We are using a setTimeout because we don't want overlapping setInterval if the DB is down
     let healthCheck: NodeJS.Timeout | undefined;
@@ -79,6 +93,9 @@ try {
             await db.readOnly.destroy();
             await destroyKvstore();
             await invocationsProcessor.stop();
+            if (webhookDispatchConsumer) {
+                await webhookDispatchConsumer.stop();
+            }
 
             console.info('Closed');
 
@@ -108,6 +125,11 @@ try {
     processor.start();
 
     invocationsProcessor.start();
+
+    if (webhookDispatchConsumer) {
+        webhookDispatchConsumer.start();
+        logger.info('webhook dispatch queue consumer started');
+    }
 
     void otlp.register(getOtlpRoutes);
 } catch (err) {

--- a/packages/jobs/lib/webhook/dispatch-queue/consumer.ts
+++ b/packages/jobs/lib/webhook/dispatch-queue/consumer.ts
@@ -1,0 +1,228 @@
+import { DeleteMessageCommand, ReceiveMessageCommand, SQSClient } from '@aws-sdk/client-sqs';
+import tracer from 'dd-trace';
+import * as z from 'zod';
+
+import { isDuplicateTaskNameClientError, jsonSchema } from '@nangohq/nango-orchestrator';
+import { Err, Ok, getLogger, metrics, report } from '@nangohq/utils';
+
+import { envs } from '../../env.js';
+
+import type { Message } from '@aws-sdk/client-sqs';
+import type { OrchestratorClient } from '@nangohq/nango-orchestrator';
+import type { WebhookDispatchMessage } from '@nangohq/types';
+import type { Result } from '@nangohq/utils';
+
+const logger = getLogger('jobs.webhook.dispatch-queue.consumer');
+
+const messageSchema: z.ZodType<WebhookDispatchMessage> = z.object({
+    version: z.literal(1),
+    kind: z.literal('webhook'),
+    taskName: z.string().min(1),
+    createdAt: z.string().min(1),
+    accountId: z.number(),
+    integrationId: z.number(),
+    provider: z.string(),
+    parentSyncName: z.string(),
+    activityLogId: z.string(),
+    webhookName: z.string(),
+    connection: z.object({
+        id: z.number(),
+        connection_id: z.string(),
+        provider_config_key: z.string(),
+        environment_id: z.number()
+    }),
+    payload: jsonSchema
+});
+
+export interface DispatchQueueConsumerProps {
+    queueUrl: string;
+    orchestratorClient: OrchestratorClient;
+    webhookMaxConcurrency: number;
+    consumerConcurrency: number;
+    maxMessages: number;
+    waitTimeSeconds: number;
+    visibilityTimeoutSeconds: number;
+    sqs?: SQSClient;
+}
+
+export class DispatchQueueConsumer {
+    private readonly sqs: SQSClient;
+    private readonly queueUrl: string;
+    private readonly orchestratorClient: OrchestratorClient;
+    private readonly webhookMaxConcurrency: number;
+    private readonly consumerConcurrency: number;
+    private readonly maxMessages: number;
+    private readonly waitTimeSeconds: number;
+    private readonly visibilityTimeoutSeconds: number;
+    private readonly abortController = new AbortController();
+    private loopPromises: Promise<void>[] = [];
+
+    constructor(props: DispatchQueueConsumerProps) {
+        this.queueUrl = props.queueUrl;
+        this.orchestratorClient = props.orchestratorClient;
+        this.webhookMaxConcurrency = props.webhookMaxConcurrency;
+        this.consumerConcurrency = props.consumerConcurrency;
+        this.maxMessages = props.maxMessages;
+        this.waitTimeSeconds = props.waitTimeSeconds;
+        this.visibilityTimeoutSeconds = props.visibilityTimeoutSeconds;
+        this.sqs = props.sqs ?? new SQSClient(envs.AWS_REGION ? { region: envs.AWS_REGION } : {});
+    }
+
+    start(): void {
+        if (this.loopPromises.length > 0) {
+            return;
+        }
+        logger.info(`webhook dispatch consumer subscribing to ${this.queueUrl}`, { consumerConcurrency: this.consumerConcurrency });
+        this.loopPromises = Array.from({ length: this.consumerConcurrency }, () => this.pollLoop());
+    }
+
+    async stop(): Promise<void> {
+        this.abortController.abort();
+        if (this.loopPromises.length > 0) {
+            await Promise.allSettled(this.loopPromises);
+            this.loopPromises = [];
+        }
+        this.sqs.destroy();
+    }
+
+    private async pollLoop(): Promise<void> {
+        const signal = this.abortController.signal;
+        while (!signal.aborted) {
+            try {
+                const result = await this.sqs.send(
+                    new ReceiveMessageCommand({
+                        QueueUrl: this.queueUrl,
+                        MaxNumberOfMessages: this.maxMessages,
+                        WaitTimeSeconds: this.waitTimeSeconds,
+                        VisibilityTimeout: this.visibilityTimeoutSeconds,
+                        MessageAttributeNames: ['All'],
+                        MessageSystemAttributeNames: ['SentTimestamp', 'ApproximateReceiveCount']
+                    }),
+                    { abortSignal: signal }
+                );
+
+                const messages = result.Messages ?? [];
+                if (messages.length === 0) continue;
+
+                // Process all messages in a batch concurrently. Each SQS receive is already
+                // capped at maxMessages (<=10) so no extra semaphore is needed.
+                await Promise.all(messages.map((msg) => this.processMessage(msg)));
+            } catch (err) {
+                if (err instanceof Error && err.name === 'AbortError') break;
+                report(new Error('webhook dispatch consumer receive failed', { cause: err }));
+                await new Promise((resolve) => setTimeout(resolve, 1000));
+            }
+        }
+    }
+
+    private async processMessage(msg: Message): Promise<void> {
+        const active = tracer.scope().active();
+        const span = tracer.startSpan('jobs.webhook.dispatch_queue.process', {
+            ...(active ? { childOf: active } : {})
+        });
+
+        return await tracer.scope().activate(span, async () => {
+            try {
+                if (msg.Body === undefined || !msg.ReceiptHandle) {
+                    return;
+                }
+
+                const parsed = this.parseMessage(msg.Body);
+                if (parsed.isErr()) {
+                    span.setTag('poison_pill', true);
+                    span.setTag('poison_pill_reason', parsed.error.message);
+                    metrics.increment(metrics.Types.WEBHOOK_DISPATCH_POISON_PILL);
+                    // Parse failures are poison pills — redelivering won't help. Delete and move on.
+                    await this.tryDeleteMessage(msg.ReceiptHandle);
+                    return;
+                }
+
+                const message = parsed.value;
+                const environmentId = message.connection.environment_id;
+                span.setTag('taskName', message.taskName);
+                span.setTag('provider', message.provider);
+                span.setTag('environmentId', environmentId);
+
+                const sentTimestampMs = Number(msg.Attributes?.['SentTimestamp'] ?? '0');
+                if (sentTimestampMs > 0) {
+                    metrics.duration(metrics.Types.WEBHOOK_DISPATCH_DWELL_MS, Date.now() - sentTimestampMs, { provider: message.provider });
+                }
+
+                const scheduleRes = await this.orchestratorClient.executeWebhook({
+                    name: message.taskName,
+                    group: { key: `webhook:environment:${environmentId}`, maxConcurrency: this.webhookMaxConcurrency },
+                    args: {
+                        webhookName: message.webhookName,
+                        parentSyncName: message.parentSyncName,
+                        connection: message.connection,
+                        activityLogId: message.activityLogId,
+                        input: message.payload
+                    }
+                });
+
+                if (scheduleRes.isErr()) {
+                    if (isDuplicateTaskNameClientError(scheduleRes.error)) {
+                        span.setTag('duplicate_task_name', true);
+                        metrics.increment(metrics.Types.WEBHOOK_DISPATCH_CONSUME_SUCCESS, 1, { provider: message.provider });
+                        await this.tryDeleteMessage(msg.ReceiptHandle);
+                        return;
+                    }
+
+                    metrics.increment(metrics.Types.WEBHOOK_DISPATCH_CONSUME_FAILURE, 1, { provider: message.provider });
+                    span.setTag('error', true);
+                    span.setTag('error.type', scheduleRes.error.name);
+                    span.setTag('error.message', scheduleRes.error.message);
+
+                    const responsePayload = getClientErrorResponsePayload(scheduleRes.error);
+                    if (responsePayload) {
+                        span.setTag('error.details', responsePayload);
+                    }
+
+                    // Don't delete — let SQS redeliver and eventually DLQ.
+                    return;
+                }
+
+                metrics.increment(metrics.Types.WEBHOOK_DISPATCH_CONSUME_SUCCESS, 1, { provider: message.provider });
+
+                await this.tryDeleteMessage(msg.ReceiptHandle);
+            } finally {
+                span.finish();
+            }
+        });
+    }
+
+    private parseMessage(body: string): Result<WebhookDispatchMessage> {
+        try {
+            const json = JSON.parse(body);
+            const result = messageSchema.safeParse(json);
+            if (!result.success) {
+                return Err('invalid_schema');
+            }
+            return Ok(result.data);
+        } catch (_err) {
+            return Err('json_parse');
+        }
+    }
+
+    private async tryDeleteMessage(receiptHandle: string): Promise<void> {
+        try {
+            await this.sqs.send(new DeleteMessageCommand({ QueueUrl: this.queueUrl, ReceiptHandle: receiptHandle }));
+        } catch (err) {
+            report(new Error('webhook dispatch consumer delete failed', { cause: err }));
+        }
+    }
+}
+
+function getClientErrorResponsePayload(err: { payload?: unknown }): string | null {
+    const payload = err.payload;
+    if (!payload || typeof payload !== 'object' || !('response' in payload)) {
+        return null;
+    }
+
+    const responsePayload = payload.response;
+    if (responsePayload === undefined) {
+        return null;
+    }
+
+    return JSON.stringify(responsePayload);
+}

--- a/packages/jobs/lib/webhook/dispatch-queue/consumer.unit.test.ts
+++ b/packages/jobs/lib/webhook/dispatch-queue/consumer.unit.test.ts
@@ -1,0 +1,302 @@
+import { DeleteMessageCommand, ReceiveMessageCommand } from '@aws-sdk/client-sqs';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+import { Err, Ok } from '@nangohq/utils';
+
+vi.mock('../../env.js', () => ({
+    envs: {
+        AWS_REGION: undefined
+    }
+}));
+
+import { DispatchQueueConsumer } from './consumer.js';
+
+import type { SQSClient } from '@aws-sdk/client-sqs';
+import type { OrchestratorClient } from '@nangohq/nango-orchestrator';
+import type { WebhookDispatchMessage } from '@nangohq/types';
+
+function buildMessage(overrides: Partial<WebhookDispatchMessage> = {}): WebhookDispatchMessage {
+    return {
+        version: 1,
+        kind: 'webhook',
+        taskName: 'webhook:abc123',
+        createdAt: '2026-04-23T00:00:00.000Z',
+        accountId: 1,
+        integrationId: 3,
+        provider: 'github',
+        parentSyncName: 'sync-1',
+        activityLogId: 'log-1',
+        webhookName: 'push',
+        connection: { id: 42, connection_id: 'conn-1', provider_config_key: 'github-dev', environment_id: 2 },
+        payload: { hello: 'world' },
+        ...overrides
+    };
+}
+
+function abortError(): Error {
+    const error = new Error('aborted');
+    error.name = 'AbortError';
+    return error;
+}
+
+function deferred<T>() {
+    let resolve!: (value: T | PromiseLike<T>) => void;
+    let reject!: (reason?: unknown) => void;
+    const promise = new Promise<T>((res, rej) => {
+        resolve = res;
+        reject = rej;
+    });
+    return { promise, resolve, reject };
+}
+
+interface Harness {
+    consumer: DispatchQueueConsumer;
+    sqsSend: ReturnType<typeof vi.fn>;
+    sqsDestroy: ReturnType<typeof vi.fn>;
+    orchestratorExecuteWebhook: ReturnType<typeof vi.fn>;
+}
+
+function makeHarness(
+    opts: {
+        messages?: WebhookDispatchMessage[];
+        badBody?: string;
+        consumerConcurrency?: number;
+        sqsSend?: ReturnType<typeof vi.fn>;
+    } = {}
+): Harness {
+    const messages = opts.messages ?? [];
+    const bodyQueue: { Body: string; ReceiptHandle: string; Attributes: Record<string, string> }[] = [];
+    for (let i = 0; i < messages.length; i++) {
+        bodyQueue.push({ Body: JSON.stringify(messages[i]), ReceiptHandle: `rh-${i}`, Attributes: { SentTimestamp: String(Date.now() - 500) } });
+    }
+    if (opts.badBody !== undefined) {
+        bodyQueue.push({ Body: opts.badBody, ReceiptHandle: `rh-bad`, Attributes: { SentTimestamp: String(Date.now()) } });
+    }
+
+    const sqsSend =
+        opts.sqsSend ??
+        vi.fn(async (command: unknown) => {
+            await new Promise((resolve) => setImmediate(resolve));
+            if (command instanceof ReceiveMessageCommand) {
+                const messages = bodyQueue.splice(0, bodyQueue.length);
+                return { Messages: messages };
+            }
+            if (command instanceof DeleteMessageCommand) {
+                return {};
+            }
+            throw new Error(`unexpected command ${String(command)}`);
+        });
+
+    const sqsDestroy = vi.fn();
+    const sqs = { send: sqsSend, destroy: sqsDestroy } as unknown as SQSClient;
+
+    const orchestratorExecuteWebhook = vi.fn();
+    orchestratorExecuteWebhook.mockResolvedValue(Ok({ taskId: 'task-1', retryKey: 'rk-1' }));
+    const orchestratorClient = { executeWebhook: orchestratorExecuteWebhook } as unknown as OrchestratorClient;
+
+    const consumer = new DispatchQueueConsumer({
+        sqs,
+        queueUrl: 'http://queue',
+        orchestratorClient,
+        webhookMaxConcurrency: 500,
+        consumerConcurrency: opts.consumerConcurrency ?? 1,
+        maxMessages: 10,
+        waitTimeSeconds: 0,
+        visibilityTimeoutSeconds: 30
+    });
+
+    return { consumer, sqsSend, sqsDestroy, orchestratorExecuteWebhook };
+}
+
+function getDeleteCalls(h: Harness) {
+    return h.sqsSend.mock.calls.filter((c) => c[0] instanceof DeleteMessageCommand);
+}
+
+async function runOnce(h: Harness, waitFor: () => void | Promise<void>): Promise<void> {
+    h.consumer.start();
+    await vi.waitFor(waitFor);
+    await h.consumer.stop();
+}
+
+describe('DispatchQueueConsumer', () => {
+    beforeEach(() => {
+        vi.restoreAllMocks();
+    });
+
+    it('schedules a valid message and deletes it on success', async () => {
+        const msg = buildMessage();
+        const h = makeHarness({ messages: [msg] });
+        await runOnce(h, () => {
+            expect(getDeleteCalls(h)).toHaveLength(1);
+        });
+
+        expect(h.orchestratorExecuteWebhook).toHaveBeenCalledTimes(1);
+        const call = h.orchestratorExecuteWebhook.mock.calls[0]?.[0];
+        expect(call).toMatchObject({
+            name: msg.taskName,
+            group: { key: 'webhook:environment:2', maxConcurrency: 500 },
+            args: {
+                webhookName: msg.webhookName,
+                parentSyncName: msg.parentSyncName,
+                connection: msg.connection,
+                activityLogId: msg.activityLogId,
+                input: msg.payload
+            }
+        });
+        const deleteCalls = getDeleteCalls(h);
+        expect(deleteCalls).toHaveLength(1);
+        expect(h.sqsDestroy).toHaveBeenCalledOnce();
+    });
+
+    it('treats duplicate task-name scheduling errors as already processed and deletes the message', async () => {
+        const h = makeHarness({ messages: [buildMessage()] });
+        h.orchestratorExecuteWebhook.mockResolvedValueOnce(
+            Err({
+                name: 'duplicate_task_name',
+                message: 'Task with name already exists',
+                payload: { taskName: 'webhook:abc123' }
+            })
+        );
+
+        await runOnce(h, () => {
+            expect(getDeleteCalls(h)).toHaveLength(1);
+        });
+
+        expect(h.orchestratorExecuteWebhook).toHaveBeenCalledTimes(1);
+        const deleteCalls = getDeleteCalls(h);
+        expect(deleteCalls).toHaveLength(1);
+    });
+
+    it('does not delete when orchestrator returns a non-duplicate error', async () => {
+        const h = makeHarness({ messages: [buildMessage()] });
+        h.orchestratorExecuteWebhook.mockResolvedValueOnce(Err({ name: 'boom', message: 'boom', payload: null }));
+
+        await runOnce(h, () => {
+            expect(h.orchestratorExecuteWebhook).toHaveBeenCalledTimes(1);
+        });
+
+        expect(h.orchestratorExecuteWebhook).toHaveBeenCalledTimes(1);
+        const deleteCalls = getDeleteCalls(h);
+        expect(deleteCalls).toHaveLength(0);
+    });
+
+    it('deletes a poison-pill message without calling orchestrator', async () => {
+        const h = makeHarness({ badBody: 'not-json' });
+        await runOnce(h, () => {
+            expect(getDeleteCalls(h)).toHaveLength(1);
+        });
+
+        expect(h.orchestratorExecuteWebhook).not.toHaveBeenCalled();
+        const deleteCalls = getDeleteCalls(h);
+        expect(deleteCalls).toHaveLength(1);
+    });
+
+    it('treats an empty-body message as a poison pill and deletes it', async () => {
+        const h = makeHarness({ badBody: '' });
+        await runOnce(h, () => {
+            expect(getDeleteCalls(h)).toHaveLength(1);
+        });
+
+        expect(h.orchestratorExecuteWebhook).not.toHaveBeenCalled();
+        const deleteCalls = getDeleteCalls(h);
+        expect(deleteCalls).toHaveLength(1);
+    });
+
+    it('rejects a schema-invalid message as poison and deletes it', async () => {
+        const invalid = { ...buildMessage(), kind: 'wrong' };
+        const h = makeHarness({ badBody: JSON.stringify(invalid) });
+        await runOnce(h, () => {
+            expect(getDeleteCalls(h)).toHaveLength(1);
+        });
+
+        expect(h.orchestratorExecuteWebhook).not.toHaveBeenCalled();
+        const deleteCalls = getDeleteCalls(h);
+        expect(deleteCalls).toHaveLength(1);
+    });
+
+    it('still deletes successfully scheduled messages during graceful shutdown', async () => {
+        const message = buildMessage();
+        const scheduled = deferred<ReturnType<typeof Ok>>();
+        let received = false;
+        const sqsSend = vi.fn(async (command: unknown, options?: { abortSignal?: AbortSignal }) => {
+            await new Promise((resolve) => setImmediate(resolve));
+            if (command instanceof ReceiveMessageCommand) {
+                if (!received) {
+                    received = true;
+                    return {
+                        Messages: [{ Body: JSON.stringify(message), ReceiptHandle: 'rh-0', Attributes: { SentTimestamp: String(Date.now() - 500) } }]
+                    };
+                }
+
+                if (options?.abortSignal?.aborted) {
+                    throw abortError();
+                }
+                return { Messages: [] };
+            }
+
+            if (command instanceof DeleteMessageCommand) {
+                if (options?.abortSignal?.aborted) {
+                    throw abortError();
+                }
+                return {};
+            }
+
+            throw new Error(`unexpected command ${String(command)}`);
+        });
+
+        const h = makeHarness({ messages: [message], sqsSend });
+        h.orchestratorExecuteWebhook.mockReturnValueOnce(scheduled.promise);
+
+        h.consumer.start();
+        await vi.waitFor(() => {
+            expect(h.orchestratorExecuteWebhook).toHaveBeenCalledOnce();
+        });
+
+        const stopPromise = h.consumer.stop();
+        scheduled.resolve(Ok({ taskId: 'task-1', retryKey: 'rk-1' }));
+        await stopPromise;
+
+        const deleteCalls = h.sqsSend.mock.calls.filter((c) => c[0] instanceof DeleteMessageCommand);
+        expect(deleteCalls).toHaveLength(1);
+        expect(deleteCalls[0]?.[1]).toBeUndefined();
+    });
+
+    it('starts one poll loop per configured consumerConcurrency', async () => {
+        let receiveCalls = 0;
+        const firstReceives = [deferred<void>(), deferred<void>()];
+        const sqsSend = vi.fn(async (command: unknown, options?: { abortSignal?: AbortSignal }) => {
+            if (command instanceof ReceiveMessageCommand) {
+                const index = receiveCalls++;
+                const pending = firstReceives[index];
+                if (pending) {
+                    return await new Promise((resolve, reject) => {
+                        const onAbort = () => reject(abortError());
+                        options?.abortSignal?.addEventListener('abort', onAbort, { once: true });
+                        pending.promise.then(() => resolve({ Messages: [] }), reject);
+                    });
+                }
+
+                if (options?.abortSignal?.aborted) {
+                    throw abortError();
+                }
+                return { Messages: [] };
+            }
+
+            if (command instanceof DeleteMessageCommand) {
+                return {};
+            }
+
+            throw new Error(`unexpected command ${String(command)}`);
+        });
+
+        const h = makeHarness({ consumerConcurrency: 2, sqsSend });
+        h.consumer.start();
+
+        await vi.waitFor(() => {
+            expect(receiveCalls).toBe(2);
+        });
+
+        await h.consumer.stop();
+        expect(h.sqsDestroy).toHaveBeenCalledOnce();
+    });
+});

--- a/packages/orchestrator/lib/clients/client.integration.test.ts
+++ b/packages/orchestrator/lib/clients/client.integration.test.ts
@@ -163,6 +163,41 @@ describe('OrchestratorClient', async () => {
         });
     });
 
+    describe('immediate', () => {
+        it('should return a structured duplicate-name error when task name already exists', async () => {
+            const name = nanoid();
+            const groupKey = nanoid();
+            const request = {
+                name,
+                group: { key: groupKey, maxConcurrency: 0 },
+                retry: { count: 0, max: 0 },
+                timeoutSettingsInSecs: { createdToStarted: 30, startedToCompleted: 30, heartbeat: 60 },
+                args: {
+                    type: 'action' as const,
+                    actionName: nanoid(),
+                    connection: {
+                        id: 123,
+                        connection_id: 'C',
+                        provider_config_key: 'P',
+                        environment_id: 456
+                    },
+                    activityLogId: '789',
+                    input: { foo: 'bar' }
+                }
+            };
+
+            const first = await client.immediate(request);
+            expect(first.isOk()).toBe(true);
+
+            const duplicate = await client.immediate(request);
+            expect(duplicate.isErr()).toBe(true);
+            if (duplicate.isErr()) {
+                expect(duplicate.error.name).toBe('duplicate_task_name');
+                expect(duplicate.error.payload).toEqual({});
+            }
+        });
+    });
+
     describe('executeAction', () => {
         it('should be successful when action task succeed', async () => {
             const groupKey = nanoid();

--- a/packages/orchestrator/lib/clients/client.ts
+++ b/packages/orchestrator/lib/clients/client.ts
@@ -65,6 +65,15 @@ export class OrchestratorClient {
     public async immediate(props: ImmediateProps): Promise<Result<PostImmediate['Success'], ClientError>> {
         const res = await this.routeFetch(postImmediateRoute)({ body: props });
         if ('error' in res) {
+            const duplicateMessage = getDuplicateTaskNameMessage(res.error.payload);
+            if (duplicateMessage !== null) {
+                return Err({
+                    name: 'duplicate_task_name',
+                    message: duplicateMessage || 'Task with this name already exists',
+                    payload: {}
+                });
+            }
+
             return Err({
                 name: res.error.code,
                 message: res.error.message || `Error scheduling immediate task`,
@@ -255,7 +264,7 @@ export class OrchestratorClient {
 
     public async executeWebhook(props: ExecuteWebhookProps): Promise<ExecuteReturn> {
         const { args, ...rest } = props;
-        const schedulingProps = {
+        const schedulingProps: ImmediateProps = {
             ...rest,
             retry: { count: 0, max: 0 },
             timeoutSettingsInSecs: {
@@ -516,4 +525,32 @@ export class OrchestratorClient {
             }));
         }
     }
+}
+
+function getDuplicateTaskNameMessage(payload: unknown): string | null {
+    if (!payload || typeof payload !== 'object' || !('error' in payload)) {
+        return null;
+    }
+
+    const response = payload as {
+        error?: {
+            code?: string;
+            message?: string;
+        };
+    };
+
+    if (response.error?.code !== 'duplicate_task_name') {
+        return null;
+    }
+
+    return response.error.message || '';
+}
+
+export function isDuplicateTaskNameClientError(err: unknown): boolean {
+    if (!err || typeof err !== 'object') {
+        return false;
+    }
+
+    const error = err as { name?: string };
+    return error.name === 'duplicate_task_name';
 }

--- a/packages/orchestrator/lib/clients/client.unit.test.ts
+++ b/packages/orchestrator/lib/clients/client.unit.test.ts
@@ -1,0 +1,100 @@
+import { afterEach, describe, expect, it, vi } from 'vitest';
+
+import { OrchestratorClient } from './client.js';
+
+import type { ImmediateProps } from './types.js';
+
+function buildImmediateRequest(): ImmediateProps {
+    return {
+        name: 'task-1',
+        group: { key: 'group-1', maxConcurrency: 0 },
+        retry: { count: 0, max: 0 },
+        timeoutSettingsInSecs: { createdToStarted: 30, startedToCompleted: 30, heartbeat: 60 },
+        args: {
+            type: 'action',
+            actionName: 'action-1',
+            connection: {
+                id: 123,
+                connection_id: 'connection-1',
+                provider_config_key: 'provider-config-key-1',
+                environment_id: 456
+            },
+            activityLogId: 'activity-log-1',
+            input: { foo: 'bar' },
+            async: false
+        }
+    };
+}
+
+describe('OrchestratorClient immediate', () => {
+    afterEach(() => {
+        vi.restoreAllMocks();
+        vi.unstubAllGlobals();
+    });
+
+    it('maps duplicate-name conflicts from the API while preserving existing retries', async () => {
+        const fetchMock = vi.fn().mockImplementation(() => {
+            return new Response(
+                JSON.stringify({
+                    error: {
+                        code: 'duplicate_task_name',
+                        message: 'task already exists'
+                    }
+                }),
+                { status: 409, headers: { 'content-type': 'application/json' } }
+            );
+        });
+        vi.stubGlobal('fetch', fetchMock);
+
+        const client = new OrchestratorClient({ baseUrl: 'http://orchestrator.test' });
+        const res = await client.immediate(buildImmediateRequest());
+
+        expect(res.isErr()).toBe(true);
+        if (res.isErr()) {
+            expect(res.error.name).toBe('duplicate_task_name');
+            expect(res.error.payload).toEqual({});
+        }
+        expect(fetchMock).toHaveBeenCalledTimes(3);
+    });
+
+    it('retries transient 5xx responses', async () => {
+        const fetchMock = vi
+            .fn()
+            .mockResolvedValueOnce(
+                new Response(JSON.stringify({ error: { code: 'server_error', message: 'temporary failure' } }), {
+                    status: 500,
+                    headers: { 'content-type': 'application/json' }
+                })
+            )
+            .mockResolvedValueOnce(
+                new Response(JSON.stringify({ error: { code: 'server_error', message: 'temporary failure' } }), {
+                    status: 500,
+                    headers: { 'content-type': 'application/json' }
+                })
+            )
+            .mockResolvedValueOnce(new Response(JSON.stringify({ taskId: 'task-1', retryKey: 'retry-key-1' }), { status: 200 }));
+        vi.stubGlobal('fetch', fetchMock);
+
+        const client = new OrchestratorClient({ baseUrl: 'http://orchestrator.test' });
+        const res = await client.immediate(buildImmediateRequest());
+
+        expect(res.isOk()).toBe(true);
+        expect(fetchMock).toHaveBeenCalledTimes(3);
+    });
+
+    it('preserves existing retries on non-immediate route errors', async () => {
+        const fetchMock = vi.fn().mockResolvedValue(
+            new Response(JSON.stringify({ error: { code: 'schedule_not_found', message: 'missing schedule' } }), {
+                status: 404,
+                headers: { 'content-type': 'application/json' }
+            })
+        );
+        vi.stubGlobal('fetch', fetchMock);
+
+        const client = new OrchestratorClient({ baseUrl: 'http://orchestrator.test' });
+        const res = await client.pauseSync({ scheduleName: 'schedule-1' });
+
+        expect(res.isErr()).toBe(true);
+        expect(fetchMock).toHaveBeenCalledTimes(3);
+    });
+});

--- a/packages/orchestrator/lib/routes/v1/postImmediate.ts
+++ b/packages/orchestrator/lib/routes/v1/postImmediate.ts
@@ -1,5 +1,6 @@
 import * as z from 'zod';
 
+import { isDuplicateTaskNameError } from '@nangohq/scheduler';
 import { validateRequest } from '@nangohq/utils';
 
 import { actionArgsSchema, onEventArgsSchema, syncAbortArgsSchema, syncArgsSchema, webhookArgsSchema } from '../../clients/validate.js';
@@ -34,7 +35,7 @@ export type PostImmediate = Endpoint<{
         };
         args: JsonValue & { type: TaskType };
     };
-    Error: ApiError<'immediate_failed'>;
+    Error: ApiError<'immediate_failed' | 'duplicate_task_name'>;
     Success: { taskId: string; retryKey: string };
 }>;
 
@@ -111,6 +112,16 @@ const handler = (scheduler: Scheduler) => {
             heartbeatTimeoutSecs: res.locals.parsedBody.timeoutSettingsInSecs.heartbeat
         });
         if (task.isErr()) {
+            if (isDuplicateTaskNameError(task.error)) {
+                res.status(409).json({
+                    error: {
+                        code: 'duplicate_task_name',
+                        message: task.error.message
+                    }
+                });
+                return;
+            }
+
             res.status(500).json({ error: { code: 'immediate_failed', message: task.error.message } });
             return;
         }

--- a/packages/scheduler/lib/errors.ts
+++ b/packages/scheduler/lib/errors.ts
@@ -1,0 +1,10 @@
+export class DuplicateTaskNameError extends Error {
+    constructor() {
+        super('Task with this name already exists');
+        this.name = 'DuplicateTaskNameError';
+    }
+}
+
+export function isDuplicateTaskNameError(err: unknown): boolean {
+    return err instanceof DuplicateTaskNameError;
+}

--- a/packages/scheduler/lib/index.ts
+++ b/packages/scheduler/lib/index.ts
@@ -1,5 +1,6 @@
 export * from './scheduler.js';
 export * from './types.js';
+export * from './errors.js';
 export * from './db/helpers.test.js';
 export * from './db/client.js';
 export * from './utils/format.js';

--- a/packages/scheduler/lib/models/tasks.integration.test.ts
+++ b/packages/scheduler/lib/models/tasks.integration.test.ts
@@ -4,6 +4,7 @@ import { nanoid } from '@nangohq/utils';
 
 import * as tasks from './tasks.js';
 import { getTestDbClient } from '../db/helpers.test.js';
+import { isDuplicateTaskNameError } from '../errors.js';
 import { taskStates } from '../types.js';
 
 import type { Task, TaskState } from '../types.js';
@@ -83,6 +84,17 @@ describe('Task', () => {
         expect(res.tasks[0]?.name).toBe('Not capped');
         expect(res.tasks[1]?.name).toBe('Also not capped');
         expect(res.cappedGroupKeys).toEqual([props.groupKey]);
+    });
+    it('should error on unique-name collision', async () => {
+        const name = `dup-${nanoid()}`;
+        const first = await tasks.create(db, [{ ...props, name }]);
+        expect(first.isOk()).toBe(true);
+
+        const second = await tasks.create(db, [{ ...props, name }]);
+        expect(second.isErr()).toBe(true);
+        if (second.isErr()) {
+            expect(isDuplicateTaskNameError(second.error)).toBe(true);
+        }
     });
     it('should have their heartbeat updated', async () => {
         const t = await startTask(db);

--- a/packages/scheduler/lib/models/tasks.ts
+++ b/packages/scheduler/lib/models/tasks.ts
@@ -2,6 +2,7 @@ import { uuidv4, uuidv7 } from 'uuidv7';
 
 import { Err, Ok, metrics, stringToHash, stringifyError } from '@nangohq/utils';
 
+import { DuplicateTaskNameError } from '../errors.js';
 import { taskStates } from '../types.js';
 import { SCHEDULES_TABLE } from './schedules.js';
 import { envs } from '../env.js';
@@ -172,19 +173,31 @@ export async function create(
             metrics.increment(metrics.Types.ORCH_TASKS_DROPPED, droppedCount, { primitive, reason: 'task_cap' });
         }
         const toInsert = Array.from(toInsertPerGroup.values()).flat();
-        const inserted: Task[] = [];
+        const tasks: Task[] = [];
         while (toInsert.length) {
             const chunk = toInsert.splice(0, TASKS_INSERT_BATCH_SIZE);
             const batch = await db.from<DBTask>(TASKS_TABLE).insert(chunk.map(DbTask.to)).returning('*');
-            inserted.push(...batch.map(DbTask.from));
+            tasks.push(...batch.map(DbTask.from));
         }
         return Ok({
-            tasks: inserted,
+            tasks,
             cappedGroupKeys: Array.from(cappedGroupCounts.keys())
         });
     } catch (err) {
+        if (isTasksUniqueNameViolation(err)) {
+            return Err(new DuplicateTaskNameError());
+        }
         return Err(new Error(`Error creating tasks: ${stringifyError(err)}`));
     }
+}
+
+function isTasksUniqueNameViolation(err: unknown): boolean {
+    if (!err || typeof err !== 'object') {
+        return false;
+    }
+
+    const error = err as { code?: string; constraint?: string; message?: string };
+    return error.code === '23505' && error.constraint === 'tasks_unique_name';
 }
 
 // Coalesce concurrent queueSizes queries for the same group keys.

--- a/packages/scheduler/lib/scheduler.integration.test.ts
+++ b/packages/scheduler/lib/scheduler.integration.test.ts
@@ -4,6 +4,7 @@ import { nanoid } from '@nangohq/utils';
 
 import { getTestDbClient } from './db/helpers.test.js';
 import { envs } from './env.js';
+import { isDuplicateTaskNameError } from './errors.js';
 import { Scheduler } from './scheduler.js';
 
 import type { TaskProps } from './models/tasks.js';
@@ -68,6 +69,32 @@ describe('Scheduler', () => {
     });
     it('should call callback when task is created', async () => {
         await immediate(scheduler);
+        expect(callbacks.CREATED).toHaveBeenCalledOnce();
+    });
+    it('should return a duplicate-name error when an immediate task already exists', async () => {
+        const name = `dup-${nanoid()}`;
+        const groupKey = nanoid();
+
+        await immediate(scheduler, { taskProps: { name, groupKey } });
+
+        const duplicate = await scheduler.immediate({
+            name,
+            payload: {},
+            groupKey,
+            groupMaxConcurrency: 0,
+            retryMax: 1,
+            retryCount: 0,
+            createdToStartedTimeoutSecs: 3600,
+            startedToCompletedTimeoutSecs: 3600,
+            heartbeatTimeoutSecs: 600,
+            ownerKey: null,
+            retryKey: null
+        });
+
+        expect(duplicate.isErr()).toBe(true);
+        if (duplicate.isErr()) {
+            expect(isDuplicateTaskNameError(duplicate.error)).toBe(true);
+        }
         expect(callbacks.CREATED).toHaveBeenCalledOnce();
     });
     it('should call callback when task is started', async () => {

--- a/packages/types/lib/webhooks/dispatch.ts
+++ b/packages/types/lib/webhooks/dispatch.ts
@@ -1,3 +1,5 @@
+import type { JsonValue } from 'type-fest';
+
 /**
  * SQS message envelope for the webhook task-dispatch queue.
  *
@@ -21,7 +23,7 @@ export interface WebhookDispatchMessage {
     parentSyncName: string;
     /** Webhook subscription name matched on the inbound payload; passed to executeWebhook as args.webhookName. */
     webhookName: string;
-    /** Activity log id created before enqueue; also reused as the taskName dedupe seed. */
+    /** Activity log id created before enqueue; reused so redelivery of this published message keeps the same taskName. */
     activityLogId: string;
     connection: {
         id: number;
@@ -29,5 +31,5 @@ export interface WebhookDispatchMessage {
         provider_config_key: string;
         environment_id: number;
     };
-    payload: unknown;
+    payload: JsonValue;
 }

--- a/packages/utils/lib/telemetry/metrics.ts
+++ b/packages/utils/lib/telemetry/metrics.ts
@@ -73,8 +73,6 @@ export enum Types {
     WEBHOOK_DISPATCH_LARGE_FANOUT = 'nango.webhook.dispatch_queue.large_fanout',
     WEBHOOK_DISPATCH_CONSUME_SUCCESS = 'nango.webhook.dispatch_queue.consume.success',
     WEBHOOK_DISPATCH_CONSUME_FAILURE = 'nango.webhook.dispatch_queue.consume.failure',
-    WEBHOOK_DISPATCH_SCHEDULE_SUCCESS = 'nango.webhook.dispatch_queue.schedule.success',
-    WEBHOOK_DISPATCH_SCHEDULE_FAILURE = 'nango.webhook.dispatch_queue.schedule.failure',
     WEBHOOK_DISPATCH_POISON_PILL = 'nango.webhook.dispatch_queue.poison_pill',
     WEBHOOK_DISPATCH_DWELL_MS = 'nango.webhook.dispatch_queue.dwell_ms',
 


### PR DESCRIPTION
Consumer (`packages/jobs/lib/webhook/dispatch-queue/consumer.ts`)
- Long-polls the task-dispatch SQS queue and schedules webhook tasks via `orchestratorClient.executeWebhook()` using the deterministic `taskName` from the message.
- Deletes messages on successful scheduling and on duplicate-task detection. Leaves them visible on non-duplicate errors so SQS redelivers and eventually DLQs.
- Poison-pill messages (unparseable / schema-invalid) are deleted to avoid redelivery loops, with a dedicated metric.
- Starts one poll loop per `NANGO_TASK_DISPATCH_CONSUMER_CONCURRENCY`.

Scheduler (`packages/scheduler/lib/models/tasks.ts, packages/scheduler/lib/scheduler.ts`)
- Adds `DuplicateTaskNameError` so `scheduler.immediate()` can return a typed duplicate-name failure after checking for an existing task by name before insert.
- Preserves the existing `tasks.create()` behavior for other callers while still surfacing DB unique-constraint collisions as duplicate-name errors.

Orchestrator (`packages/orchestrator/lib/routes/v1/postImmediate.ts`)
- Returns structured duplicate metadata on `POST /v1/immediate` failures with `reason: 'duplicate_task_name'`, plus the conflicting `taskName` and existing `taskId` when available.

Tests
- Adds/updates unit and integration coverage for duplicate-name handling, consumer shutdown/delete behavior, and consumer concurrency.

<!-- Describe the problem and your solution --> 

<!-- Issue ticket number and link (if applicable) -->

<!-- Testing instructions (skip if just adding/editing providers) -->

