### PR TITLE
feat(webhook): add calcom connection-id to query param

### DIFF
--- a/docs/api-integrations/cal-com-oauth/webhook.mdx
+++ b/docs/api-integrations/cal-com-oauth/webhook.mdx
@@ -10,7 +10,7 @@ This guide shows you how to receive real-time Cal.com webhooks in Nango. Cal.com
 
 1. You call the Cal.com webhooks API to register a subscription, passing your Nango webhook URL and a `payloadTemplate` that embeds the Nango connection ID as a static field.
 2. When an event occurs, Cal.com sends a signed POST request to Nango with an `x-cal-signature-256` header.
-3. Nango verifies the signature and reads `nangoConnectionId` from the payload to identify the connection.
+3. Nango verifies the signature and resolves `nangoConnectionId` — first from the `?nangoConnectionId=` query parameter on the webhook URL, then from the `nangoConnectionId` field in the payload body.
 4. Nango routes the event to that connection's webhook script and forwards the full payload to your app.
 
 ## Setup
@@ -91,7 +91,12 @@ Replace:
 - **&lt;YOUR-WEBHOOK-SECRET&gt;** — the webhook secret configured on your Cal.com (OAuth) integration in Nango
 
 <Note>
-  The `nangoConnectionId` field in the payload template is a **static string** — it is the same for every event sent by this subscription. Each Cal.com user/connection needs its own subscription with its own `nangoConnectionId`.
+  There are two ways to pass `nangoConnectionId` to Nango:
+
+  - **Query parameter:** append `?nangoConnectionId=<CONNECTION-ID>` to the Nango webhook URL you register as `subscriberUrl`. This avoids embedding the ID in the payload template entirely.
+  - **Payload body (fallback):** include a `"nangoConnectionId":"<CONNECTION-ID>"` field in the `payloadTemplate`, as shown above.
+
+  Either way, each Cal.com user/connection needs its own subscription so the correct connection ID is passed for every event.
 </Note>
 
 For the full list of available triggers, see the [Cal.com webhook documentation](https://cal.com/docs/developing/guides/automation/webhooks).

--- a/docs/api-integrations/cal-com-v2/webhook.mdx
+++ b/docs/api-integrations/cal-com-v2/webhook.mdx
@@ -10,7 +10,7 @@ This guide shows you how to receive real-time Cal.com webhooks in Nango. Cal.com
 
 1. You call the Cal.com webhooks API to register a subscription, passing your Nango webhook URL and a `payloadTemplate` that embeds the Nango connection ID as a static field.
 2. When an event occurs, Cal.com sends a signed POST request to Nango with an `x-cal-signature-256` header.
-3. Nango verifies the signature and reads `nangoConnectionId` from the payload to identify the connection.
+3. Nango verifies the signature and resolves `nangoConnectionId` — first from the `?nangoConnectionId=` query parameter on the webhook URL, then from the `nangoConnectionId` field in the payload body.
 4. Nango routes the event to that connection's webhook script and forwards the full payload to your app.
 
 ## Setup
@@ -91,7 +91,12 @@ Replace:
 - **&lt;YOUR-WEBHOOK-SECRET&gt;** — the webhook secret configured on your Cal.com (v2) integration in Nango
 
 <Note>
-  The `nangoConnectionId` field in the payload template is a **static string** — it is the same for every event sent by this subscription. Each Cal.com user/connection needs its own subscription with its own `nangoConnectionId`.
+  There are two ways to pass `nangoConnectionId` to Nango:
+
+  - **Query parameter:** append `?nangoConnectionId=<CONNECTION-ID>` to the Nango webhook URL you register as `subscriberUrl`. This avoids embedding the ID in the payload template entirely.
+  - **Payload body (fallback):** include a `"nangoConnectionId":"<CONNECTION-ID>"` field in the `payloadTemplate`, as shown above.
+
+  Either way, each Cal.com user/connection needs its own subscription so the correct connection ID is passed for every event.
 </Note>
 
 For the full list of available triggers, see the [Cal.com webhook documentation](https://cal.com/docs/developing/guides/automation/webhooks).

--- a/packages/providers/providers.yaml
+++ b/packages/providers/providers.yaml
@@ -3071,6 +3071,8 @@ cal-com-v2:
                 - /me
     webhook_routing_script: calComWebhookRouting
     webhook_user_defined_secret: true
+    webhook_allowed_query_params:
+        - nangoConnectionId
     docs: https://nango.dev/docs/api-integrations/cal-com-v2
     docs_connect: https://nango.dev/docs/api-integrations/cal-com-v2/connect
     credentials:
@@ -3102,6 +3104,8 @@ cal-com-oauth:
                 - 'x-ratelimit-reset'
     webhook_routing_script: calComWebhookRouting
     webhook_user_defined_secret: true
+    webhook_allowed_query_params:
+        - nangoConnectionId
     docs: https://nango.dev/docs/api-integrations/cal-com-oauth
     setup_guide_url: https://nango.dev/docs/api-integrations/cal-com-oauth/how-to-register-your-own-cal-com-oauth-app
 

--- a/packages/server/lib/webhook/cal-com-webhook-routing.ts
+++ b/packages/server/lib/webhook/cal-com-webhook-routing.ts
@@ -18,7 +18,7 @@ function validateCalComSignature(secret: string, headerSignature: string, rawBod
     return crypto.timingSafeEqual(expectedBuffer, receivedBuffer);
 }
 
-const route: WebhookHandler = async (nango, headers, body, rawBody) => {
+const route: WebhookHandler = async (nango, headers, body, rawBody, query) => {
     // https://cal.com/docs/developing/guides/automation/webhooks#verifying-the-authenticity-of-the-received-payload
     const signatureHeader = headers['x-cal-signature-256'];
     const webhookSecret = nango.integration.custom?.['webhookSecret'];
@@ -33,7 +33,7 @@ const route: WebhookHandler = async (nango, headers, body, rawBody) => {
         }
     }
 
-    const connectionIdentifierValue = body.nangoConnectionId;
+    const connectionIdentifierValue = query?.['nangoConnectionId'] ?? body.nangoConnectionId;
 
     if (!connectionIdentifierValue) {
         return Err(new NangoError('webhook_missing_connection_id'));


### PR DESCRIPTION
## Describe the problem and your solution

- Allow `cal.com` connectionId to be specified via a query parameter.

<!-- Issue ticket number and link (if applicable) -->

<!-- Testing instructions (skip if just adding/editing providers) -->

