### PR TITLE
feat(lambda): isolation

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -534,6 +534,56 @@
                 "node": ">=14.0.0"
             }
         },
+        "node_modules/@aws-sdk/client-application-auto-scaling": {
+            "version": "3.993.0",
+            "resolved": "https://registry.npmjs.org/@aws-sdk/client-application-auto-scaling/-/client-application-auto-scaling-3.993.0.tgz",
+            "integrity": "sha512-vbFDZez35h4OW+acPwnQ1wsNm3nEddpL91/URX0ZoShAs697SxKW6LjaAYxdCAOvGBUtI+bch6zyPBhLLIOacQ==",
+            "license": "Apache-2.0",
+            "dependencies": {
+                "@aws-crypto/sha256-browser": "5.2.0",
+                "@aws-crypto/sha256-js": "5.2.0",
+                "@aws-sdk/core": "^3.973.11",
+                "@aws-sdk/credential-provider-node": "^3.972.10",
+                "@aws-sdk/middleware-host-header": "^3.972.3",
+                "@aws-sdk/middleware-logger": "^3.972.3",
+                "@aws-sdk/middleware-recursion-detection": "^3.972.3",
+                "@aws-sdk/middleware-user-agent": "^3.972.11",
+                "@aws-sdk/region-config-resolver": "^3.972.3",
+                "@aws-sdk/types": "^3.973.1",
+                "@aws-sdk/util-endpoints": "3.993.0",
+                "@aws-sdk/util-user-agent-browser": "^3.972.3",
+                "@aws-sdk/util-user-agent-node": "^3.972.9",
+                "@smithy/config-resolver": "^4.4.6",
+                "@smithy/core": "^3.23.2",
+                "@smithy/fetch-http-handler": "^5.3.9",
+                "@smithy/hash-node": "^4.2.8",
+                "@smithy/invalid-dependency": "^4.2.8",
+                "@smithy/middleware-content-length": "^4.2.8",
+                "@smithy/middleware-endpoint": "^4.4.16",
+                "@smithy/middleware-retry": "^4.4.33",
+                "@smithy/middleware-serde": "^4.2.9",
+                "@smithy/middleware-stack": "^4.2.8",
+                "@smithy/node-config-provider": "^4.3.8",
+                "@smithy/node-http-handler": "^4.4.10",
+                "@smithy/protocol-http": "^5.3.8",
+                "@smithy/smithy-client": "^4.11.5",
+                "@smithy/types": "^4.12.0",
+                "@smithy/url-parser": "^4.2.8",
+                "@smithy/util-base64": "^4.3.0",
+                "@smithy/util-body-length-browser": "^4.2.0",
+                "@smithy/util-body-length-node": "^4.2.1",
+                "@smithy/util-defaults-mode-browser": "^4.3.32",
+                "@smithy/util-defaults-mode-node": "^4.2.35",
+                "@smithy/util-endpoints": "^3.2.8",
+                "@smithy/util-middleware": "^4.2.8",
+                "@smithy/util-retry": "^4.2.8",
+                "@smithy/util-utf8": "^4.2.0",
+                "tslib": "^2.6.2"
+            },
+            "engines": {
+                "node": ">=20.0.0"
+            }
+        },
         "node_modules/@aws-sdk/client-ecr": {
             "version": "3.993.0",
             "resolved": "https://registry.npmjs.org/@aws-sdk/client-ecr/-/client-ecr-3.993.0.tgz",
@@ -577,6 +627,61 @@
                 "@smithy/util-endpoints": "^3.2.8",
                 "@smithy/util-middleware": "^4.2.8",
                 "@smithy/util-retry": "^4.2.8",
+                "@smithy/util-utf8": "^4.2.0",
+                "@smithy/util-waiter": "^4.2.8",
+                "tslib": "^2.6.2"
+            },
+            "engines": {
+                "node": ">=20.0.0"
+            }
+        },
+        "node_modules/@aws-sdk/client-lambda": {
+            "version": "3.993.0",
+            "resolved": "https://registry.npmjs.org/@aws-sdk/client-lambda/-/client-lambda-3.993.0.tgz",
+            "integrity": "sha512-bXUuyTeNjMEyzVdXnYUJFcRXr6NQJjQte3EqnixUkUDZcqbyL3lXQS3cQSUuzmSaQrUDiTqIvbGrQiKv2wTXpQ==",
+            "license": "Apache-2.0",
+            "dependencies": {
+                "@aws-crypto/sha256-browser": "5.2.0",
+                "@aws-crypto/sha256-js": "5.2.0",
+                "@aws-sdk/core": "^3.973.11",
+                "@aws-sdk/credential-provider-node": "^3.972.10",
+                "@aws-sdk/middleware-host-header": "^3.972.3",
+                "@aws-sdk/middleware-logger": "^3.972.3",
+                "@aws-sdk/middleware-recursion-detection": "^3.972.3",
+                "@aws-sdk/middleware-user-agent": "^3.972.11",
+                "@aws-sdk/region-config-resolver": "^3.972.3",
+                "@aws-sdk/types": "^3.973.1",
+                "@aws-sdk/util-endpoints": "3.993.0",
+                "@aws-sdk/util-user-agent-browser": "^3.972.3",
+                "@aws-sdk/util-user-agent-node": "^3.972.9",
+                "@smithy/config-resolver": "^4.4.6",
+                "@smithy/core": "^3.23.2",
+                "@smithy/eventstream-serde-browser": "^4.2.8",
+                "@smithy/eventstream-serde-config-resolver": "^4.3.8",
+                "@smithy/eventstream-serde-node": "^4.2.8",
+                "@smithy/fetch-http-handler": "^5.3.9",
+                "@smithy/hash-node": "^4.2.8",
+                "@smithy/invalid-dependency": "^4.2.8",
+                "@smithy/middleware-content-length": "^4.2.8",
+                "@smithy/middleware-endpoint": "^4.4.16",
+                "@smithy/middleware-retry": "^4.4.33",
+                "@smithy/middleware-serde": "^4.2.9",
+                "@smithy/middleware-stack": "^4.2.8",
+                "@smithy/node-config-provider": "^4.3.8",
+                "@smithy/node-http-handler": "^4.4.10",
+                "@smithy/protocol-http": "^5.3.8",
+                "@smithy/smithy-client": "^4.11.5",
+                "@smithy/types": "^4.12.0",
+                "@smithy/url-parser": "^4.2.8",
+                "@smithy/util-base64": "^4.3.0",
+                "@smithy/util-body-length-browser": "^4.2.0",
+                "@smithy/util-body-length-node": "^4.2.1",
+                "@smithy/util-defaults-mode-browser": "^4.3.32",
+                "@smithy/util-defaults-mode-node": "^4.2.35",
+                "@smithy/util-endpoints": "^3.2.8",
+                "@smithy/util-middleware": "^4.2.8",
+                "@smithy/util-retry": "^4.2.8",
+                "@smithy/util-stream": "^4.5.12",
                 "@smithy/util-utf8": "^4.2.0",
                 "@smithy/util-waiter": "^4.2.8",
                 "tslib": "^2.6.2"
@@ -751,264 +856,6 @@
             },
             "engines": {
                 "node": ">=20.0.0"
-            }
-        },
-        "node_modules/@aws-sdk/client-sso": {
-            "version": "3.932.0",
-            "resolved": "https://registry.npmjs.org/@aws-sdk/client-sso/-/client-sso-3.932.0.tgz",
-            "integrity": "sha512-XHqHa5iv2OQsKoM2tUQXs7EAyryploC00Wg0XSFra/KAKqyGizUb5XxXsGlyqhebB29Wqur+zwiRwNmejmN0+Q==",
-            "license": "Apache-2.0",
-            "dependencies": {
-                "@aws-crypto/sha256-browser": "5.2.0",
-                "@aws-crypto/sha256-js": "5.2.0",
-                "@aws-sdk/core": "3.932.0",
-                "@aws-sdk/middleware-host-header": "3.930.0",
-                "@aws-sdk/middleware-logger": "3.930.0",
-                "@aws-sdk/middleware-recursion-detection": "3.930.0",
-                "@aws-sdk/middleware-user-agent": "3.932.0",
-                "@aws-sdk/region-config-resolver": "3.930.0",
-                "@aws-sdk/types": "3.930.0",
-                "@aws-sdk/util-endpoints": "3.930.0",
-                "@aws-sdk/util-user-agent-browser": "3.930.0",
-                "@aws-sdk/util-user-agent-node": "3.932.0",
-                "@smithy/config-resolver": "^4.4.3",
-                "@smithy/core": "^3.18.2",
-                "@smithy/fetch-http-handler": "^5.3.6",
-                "@smithy/hash-node": "^4.2.5",
-                "@smithy/invalid-dependency": "^4.2.5",
-                "@smithy/middleware-content-length": "^4.2.5",
-                "@smithy/middleware-endpoint": "^4.3.9",
-                "@smithy/middleware-retry": "^4.4.9",
-                "@smithy/middleware-serde": "^4.2.5",
-                "@smithy/middleware-stack": "^4.2.5",
-                "@smithy/node-config-provider": "^4.3.5",
-                "@smithy/node-http-handler": "^4.4.5",
-                "@smithy/protocol-http": "^5.3.5",
-                "@smithy/smithy-client": "^4.9.5",
-                "@smithy/types": "^4.9.0",
-                "@smithy/url-parser": "^4.2.5",
-                "@smithy/util-base64": "^4.3.0",
-                "@smithy/util-body-length-browser": "^4.2.0",
-                "@smithy/util-body-length-node": "^4.2.1",
-                "@smithy/util-defaults-mode-browser": "^4.3.8",
-                "@smithy/util-defaults-mode-node": "^4.2.11",
-                "@smithy/util-endpoints": "^3.2.5",
-                "@smithy/util-middleware": "^4.2.5",
-                "@smithy/util-retry": "^4.2.5",
-                "@smithy/util-utf8": "^4.2.0",
-                "tslib": "^2.6.2"
-            },
-            "engines": {
-                "node": ">=18.0.0"
-            }
-        },
-        "node_modules/@aws-sdk/client-sso/node_modules/@aws-sdk/core": {
-            "version": "3.932.0",
-            "resolved": "https://registry.npmjs.org/@aws-sdk/core/-/core-3.932.0.tgz",
-            "integrity": "sha512-AS8gypYQCbNojwgjvZGkJocC2CoEICDx9ZJ15ILsv+MlcCVLtUJSRSx3VzJOUY2EEIaGLRrPNlIqyn/9/fySvA==",
-            "license": "Apache-2.0",
-            "dependencies": {
-                "@aws-sdk/types": "3.930.0",
-                "@aws-sdk/xml-builder": "3.930.0",
-                "@smithy/core": "^3.18.2",
-                "@smithy/node-config-provider": "^4.3.5",
-                "@smithy/property-provider": "^4.2.5",
-                "@smithy/protocol-http": "^5.3.5",
-                "@smithy/signature-v4": "^5.3.5",
-                "@smithy/smithy-client": "^4.9.5",
-                "@smithy/types": "^4.9.0",
-                "@smithy/util-base64": "^4.3.0",
-                "@smithy/util-middleware": "^4.2.5",
-                "@smithy/util-utf8": "^4.2.0",
-                "tslib": "^2.6.2"
-            },
-            "engines": {
-                "node": ">=18.0.0"
-            }
-        },
-        "node_modules/@aws-sdk/client-sso/node_modules/@aws-sdk/middleware-host-header": {
-            "version": "3.930.0",
-            "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-host-header/-/middleware-host-header-3.930.0.tgz",
-            "integrity": "sha512-x30jmm3TLu7b/b+67nMyoV0NlbnCVT5DI57yDrhXAPCtdgM1KtdLWt45UcHpKOm1JsaIkmYRh2WYu7Anx4MG0g==",
-            "license": "Apache-2.0",
-            "dependencies": {
-                "@aws-sdk/types": "3.930.0",
-                "@smithy/protocol-http": "^5.3.5",
-                "@smithy/types": "^4.9.0",
-                "tslib": "^2.6.2"
-            },
-            "engines": {
-                "node": ">=18.0.0"
-            }
-        },
-        "node_modules/@aws-sdk/client-sso/node_modules/@aws-sdk/middleware-logger": {
-            "version": "3.930.0",
-            "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-logger/-/middleware-logger-3.930.0.tgz",
-            "integrity": "sha512-vh4JBWzMCBW8wREvAwoSqB2geKsZwSHTa0nSt0OMOLp2PdTYIZDi0ZiVMmpfnjcx9XbS6aSluLv9sKx4RrG46A==",
-            "license": "Apache-2.0",
-            "dependencies": {
-                "@aws-sdk/types": "3.930.0",
-                "@smithy/types": "^4.9.0",
-                "tslib": "^2.6.2"
-            },
-            "engines": {
-                "node": ">=18.0.0"
-            }
-        },
-        "node_modules/@aws-sdk/client-sso/node_modules/@aws-sdk/middleware-recursion-detection": {
-            "version": "3.930.0",
-            "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-recursion-detection/-/middleware-recursion-detection-3.930.0.tgz",
-            "integrity": "sha512-gv0sekNpa2MBsIhm2cjP3nmYSfI4nscx/+K9u9ybrWZBWUIC4kL2sV++bFjjUz4QxUIlvKByow3/a9ARQyCu7Q==",
-            "license": "Apache-2.0",
-            "dependencies": {
-                "@aws-sdk/types": "3.930.0",
-                "@aws/lambda-invoke-store": "^0.1.1",
-                "@smithy/protocol-http": "^5.3.5",
-                "@smithy/types": "^4.9.0",
-                "tslib": "^2.6.2"
-            },
-            "engines": {
-                "node": ">=18.0.0"
-            }
-        },
-        "node_modules/@aws-sdk/client-sso/node_modules/@aws-sdk/middleware-user-agent": {
-            "version": "3.932.0",
-            "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-user-agent/-/middleware-user-agent-3.932.0.tgz",
-            "integrity": "sha512-9BGTbJyA/4PTdwQWE9hAFIJGpsYkyEW20WON3i15aDqo5oRZwZmqaVageOD57YYqG8JDJjvcwKyDdR4cc38dvg==",
-            "license": "Apache-2.0",
-            "dependencies": {
-                "@aws-sdk/core": "3.932.0",
-                "@aws-sdk/types": "3.930.0",
-                "@aws-sdk/util-endpoints": "3.930.0",
-                "@smithy/core": "^3.18.2",
-                "@smithy/protocol-http": "^5.3.5",
-                "@smithy/types": "^4.9.0",
-                "tslib": "^2.6.2"
-            },
-            "engines": {
-                "node": ">=18.0.0"
-            }
-        },
-        "node_modules/@aws-sdk/client-sso/node_modules/@aws-sdk/region-config-resolver": {
-            "version": "3.930.0",
-            "resolved": "https://registry.npmjs.org/@aws-sdk/region-config-resolver/-/region-config-resolver-3.930.0.tgz",
-            "integrity": "sha512-KL2JZqH6aYeQssu1g1KuWsReupdfOoxD6f1as2VC+rdwYFUu4LfzMsFfXnBvvQWWqQ7rZHWOw1T+o5gJmg7Dzw==",
-            "license": "Apache-2.0",
-            "dependencies": {
-                "@aws-sdk/types": "3.930.0",
-                "@smithy/config-resolver": "^4.4.3",
-                "@smithy/node-config-provider": "^4.3.5",
-                "@smithy/types": "^4.9.0",
-                "tslib": "^2.6.2"
-            },
-            "engines": {
-                "node": ">=18.0.0"
-            }
-        },
-        "node_modules/@aws-sdk/client-sso/node_modules/@aws-sdk/types": {
-            "version": "3.930.0",
-            "resolved": "https://registry.npmjs.org/@aws-sdk/types/-/types-3.930.0.tgz",
-            "integrity": "sha512-we/vaAgwlEFW7IeftmCLlLMw+6hFs3DzZPJw7lVHbj/5HJ0bz9gndxEsS2lQoeJ1zhiiLqAqvXxmM43s0MBg0A==",
-            "license": "Apache-2.0",
-            "dependencies": {
-                "@smithy/types": "^4.9.0",
-                "tslib": "^2.6.2"
-            },
-            "engines": {
-                "node": ">=18.0.0"
-            }
-        },
-        "node_modules/@aws-sdk/client-sso/node_modules/@aws-sdk/util-endpoints": {
-            "version": "3.930.0",
-            "resolved": "https://registry.npmjs.org/@aws-sdk/util-endpoints/-/util-endpoints-3.930.0.tgz",
-            "integrity": "sha512-M2oEKBzzNAYr136RRc6uqw3aWlwCxqTP1Lawps9E1d2abRPvl1p1ztQmmXp1Ak4rv8eByIZ+yQyKQ3zPdRG5dw==",
-            "license": "Apache-2.0",
-            "dependencies": {
-                "@aws-sdk/types": "3.930.0",
-                "@smithy/types": "^4.9.0",
-                "@smithy/url-parser": "^4.2.5",
-                "@smithy/util-endpoints": "^3.2.5",
-                "tslib": "^2.6.2"
-            },
-            "engines": {
-                "node": ">=18.0.0"
-            }
-        },
-        "node_modules/@aws-sdk/client-sso/node_modules/@aws-sdk/util-user-agent-browser": {
-            "version": "3.930.0",
-            "resolved": "https://registry.npmjs.org/@aws-sdk/util-user-agent-browser/-/util-user-agent-browser-3.930.0.tgz",
-            "integrity": "sha512-q6lCRm6UAe+e1LguM5E4EqM9brQlDem4XDcQ87NzEvlTW6GzmNCO0w1jS0XgCFXQHjDxjdlNFX+5sRbHijwklg==",
-            "license": "Apache-2.0",
-            "dependencies": {
-                "@aws-sdk/types": "3.930.0",
-                "@smithy/types": "^4.9.0",
-                "bowser": "^2.11.0",
-                "tslib": "^2.6.2"
-            }
-        },
-        "node_modules/@aws-sdk/client-sso/node_modules/@aws-sdk/util-user-agent-node": {
-            "version": "3.932.0",
-            "resolved": "https://registry.npmjs.org/@aws-sdk/util-user-agent-node/-/util-user-agent-node-3.932.0.tgz",
-            "integrity": "sha512-/kC6cscHrZL74TrZtgiIL5jJNbVsw9duGGPurmaVgoCbP7NnxyaSWEurbNV3VPNPhNE3bV3g4Ci+odq+AlsYQg==",
-            "license": "Apache-2.0",
-            "dependencies": {
-                "@aws-sdk/middleware-user-agent": "3.932.0",
-                "@aws-sdk/types": "3.930.0",
-                "@smithy/node-config-provider": "^4.3.5",
-                "@smithy/types": "^4.9.0",
-                "tslib": "^2.6.2"
-            },
-            "engines": {
-                "node": ">=18.0.0"
-            },
-            "peerDependencies": {
-                "aws-crt": ">=1.0.0"
-            },
-            "peerDependenciesMeta": {
-                "aws-crt": {
-                    "optional": true
-                }
-            }
-        },
-        "node_modules/@aws-sdk/client-sso/node_modules/@aws-sdk/xml-builder": {
-            "version": "3.930.0",
-            "resolved": "https://registry.npmjs.org/@aws-sdk/xml-builder/-/xml-builder-3.930.0.tgz",
-            "integrity": "sha512-YIfkD17GocxdmlUVc3ia52QhcWuRIUJonbF8A2CYfcWNV3HzvAqpcPeC0bYUhkK+8e8YO1ARnLKZQE0TlwzorA==",
-            "license": "Apache-2.0",
-            "dependencies": {
-                "@smithy/types": "^4.9.0",
-                "fast-xml-parser": "5.2.5",
-                "tslib": "^2.6.2"
-            },
-            "engines": {
-                "node": ">=18.0.0"
-            }
-        },
-        "node_modules/@aws-sdk/client-sso/node_modules/@aws/lambda-invoke-store": {
-            "version": "0.1.1",
-            "resolved": "https://registry.npmjs.org/@aws/lambda-invoke-store/-/lambda-invoke-store-0.1.1.tgz",
-            "integrity": "sha512-RcLam17LdlbSOSp9VxmUu1eI6Mwxp+OwhD2QhiSNmNCzoDb0EeUXTD2n/WbcnrAYMGlmf05th6QYq23VqvJqpA==",
-            "license": "Apache-2.0",
-            "engines": {
-                "node": ">=18.0.0"
-            }
-        },
-        "node_modules/@aws-sdk/client-sso/node_modules/fast-xml-parser": {
-            "version": "5.2.5",
-            "resolved": "https://registry.npmjs.org/fast-xml-parser/-/fast-xml-parser-5.2.5.tgz",
-            "integrity": "sha512-pfX9uG9Ki0yekDHx2SiuRIyFdyAr1kMIMitPvb0YBo8SUfKvia7w7FIyd/l6av85pFYRhZscS75MwMnbvY+hcQ==",
-            "funding": [
-                {
-                    "type": "github",
-                    "url": "https://github.com/sponsors/NaturalIntelligence"
-                }
-            ],
-            "license": "MIT",
-            "dependencies": {
-                "strnum": "^2.1.0"
-            },
-            "bin": {
-                "fxparser": "src/cli/cli.js"
             }
         },
         "node_modules/@aws-sdk/core": {
@@ -27039,6 +26886,237 @@
                 "lightningcss-win32-x64-msvc": "1.31.1"
             }
         },
+        "node_modules/lightningcss-android-arm64": {
+            "version": "1.31.1",
+            "resolved": "https://registry.npmjs.org/lightningcss-android-arm64/-/lightningcss-android-arm64-1.31.1.tgz",
+            "integrity": "sha512-HXJF3x8w9nQ4jbXRiNppBCqeZPIAfUo8zE/kOEGbW5NZvGc/K7nMxbhIr+YlFlHW5mpbg/YFPdbnCh1wAXCKFg==",
+            "cpu": [
+                "arm64"
+            ],
+            "dev": true,
+            "license": "MPL-2.0",
+            "optional": true,
+            "os": [
+                "android"
+            ],
+            "engines": {
+                "node": ">= 12.0.0"
+            },
+            "funding": {
+                "type": "opencollective",
+                "url": "https://opencollective.com/parcel"
+            }
+        },
+        "node_modules/lightningcss-darwin-arm64": {
+            "version": "1.31.1",
+            "resolved": "https://registry.npmjs.org/lightningcss-darwin-arm64/-/lightningcss-darwin-arm64-1.31.1.tgz",
+            "integrity": "sha512-02uTEqf3vIfNMq3h/z2cJfcOXnQ0GRwQrkmPafhueLb2h7mqEidiCzkE4gBMEH65abHRiQvhdcQ+aP0D0g67sg==",
+            "cpu": [
+                "arm64"
+            ],
+            "dev": true,
+            "license": "MPL-2.0",
+            "optional": true,
+            "os": [
+                "darwin"
+            ],
+            "engines": {
+                "node": ">= 12.0.0"
+            },
+            "funding": {
+                "type": "opencollective",
+                "url": "https://opencollective.com/parcel"
+            }
+        },
+        "node_modules/lightningcss-darwin-x64": {
+            "version": "1.31.1",
+            "resolved": "https://registry.npmjs.org/lightningcss-darwin-x64/-/lightningcss-darwin-x64-1.31.1.tgz",
+            "integrity": "sha512-1ObhyoCY+tGxtsz1lSx5NXCj3nirk0Y0kB/g8B8DT+sSx4G9djitg9ejFnjb3gJNWo7qXH4DIy2SUHvpoFwfTA==",
+            "cpu": [
+                "x64"
+            ],
+            "dev": true,
+            "license": "MPL-2.0",
+            "optional": true,
+            "os": [
+                "darwin"
+            ],
+            "engines": {
+                "node": ">= 12.0.0"
+            },
+            "funding": {
+                "type": "opencollective",
+                "url": "https://opencollective.com/parcel"
+            }
+        },
+        "node_modules/lightningcss-freebsd-x64": {
+            "version": "1.31.1",
+            "resolved": "https://registry.npmjs.org/lightningcss-freebsd-x64/-/lightningcss-freebsd-x64-1.31.1.tgz",
+            "integrity": "sha512-1RINmQKAItO6ISxYgPwszQE1BrsVU5aB45ho6O42mu96UiZBxEXsuQ7cJW4zs4CEodPUioj/QrXW1r9pLUM74A==",
+            "cpu": [
+                "x64"
+            ],
+            "dev": true,
+            "license": "MPL-2.0",
+            "optional": true,
+            "os": [
+                "freebsd"
+            ],
+            "engines": {
+                "node": ">= 12.0.0"
+            },
+            "funding": {
+                "type": "opencollective",
+                "url": "https://opencollective.com/parcel"
+            }
+        },
+        "node_modules/lightningcss-linux-arm-gnueabihf": {
+            "version": "1.31.1",
+            "resolved": "https://registry.npmjs.org/lightningcss-linux-arm-gnueabihf/-/lightningcss-linux-arm-gnueabihf-1.31.1.tgz",
+            "integrity": "sha512-OOCm2//MZJ87CdDK62rZIu+aw9gBv4azMJuA8/KB74wmfS3lnC4yoPHm0uXZ/dvNNHmnZnB8XLAZzObeG0nS1g==",
+            "cpu": [
+                "arm"
+            ],
+            "dev": true,
+            "license": "MPL-2.0",
+            "optional": true,
+            "os": [
+                "linux"
+            ],
+            "engines": {
+                "node": ">= 12.0.0"
+            },
+            "funding": {
+                "type": "opencollective",
+                "url": "https://opencollective.com/parcel"
+            }
+        },
+        "node_modules/lightningcss-linux-arm64-gnu": {
+            "version": "1.31.1",
+            "resolved": "https://registry.npmjs.org/lightningcss-linux-arm64-gnu/-/lightningcss-linux-arm64-gnu-1.31.1.tgz",
+            "integrity": "sha512-WKyLWztD71rTnou4xAD5kQT+982wvca7E6QoLpoawZ1gP9JM0GJj4Tp5jMUh9B3AitHbRZ2/H3W5xQmdEOUlLg==",
+            "cpu": [
+                "arm64"
+            ],
+            "dev": true,
+            "license": "MPL-2.0",
+            "optional": true,
+            "os": [
+                "linux"
+            ],
+            "engines": {
+                "node": ">= 12.0.0"
+            },
+            "funding": {
+                "type": "opencollective",
+                "url": "https://opencollective.com/parcel"
+            }
+        },
+        "node_modules/lightningcss-linux-arm64-musl": {
+            "version": "1.31.1",
+            "resolved": "https://registry.npmjs.org/lightningcss-linux-arm64-musl/-/lightningcss-linux-arm64-musl-1.31.1.tgz",
+            "integrity": "sha512-mVZ7Pg2zIbe3XlNbZJdjs86YViQFoJSpc41CbVmKBPiGmC4YrfeOyz65ms2qpAobVd7WQsbW4PdsSJEMymyIMg==",
+            "cpu": [
+                "arm64"
+            ],
+            "dev": true,
+            "license": "MPL-2.0",
+            "optional": true,
+            "os": [
+                "linux"
+            ],
+            "engines": {
+                "node": ">= 12.0.0"
+            },
+            "funding": {
+                "type": "opencollective",
+                "url": "https://opencollective.com/parcel"
+            }
+        },
+        "node_modules/lightningcss-linux-x64-gnu": {
+            "version": "1.31.1",
+            "resolved": "https://registry.npmjs.org/lightningcss-linux-x64-gnu/-/lightningcss-linux-x64-gnu-1.31.1.tgz",
+            "integrity": "sha512-xGlFWRMl+0KvUhgySdIaReQdB4FNudfUTARn7q0hh/V67PVGCs3ADFjw+6++kG1RNd0zdGRlEKa+T13/tQjPMA==",
+            "cpu": [
+                "x64"
+            ],
+            "dev": true,
+            "license": "MPL-2.0",
+            "optional": true,
+            "os": [
+                "linux"
+            ],
+            "engines": {
+                "node": ">= 12.0.0"
+            },
+            "funding": {
+                "type": "opencollective",
+                "url": "https://opencollective.com/parcel"
+            }
+        },
+        "node_modules/lightningcss-linux-x64-musl": {
+            "version": "1.31.1",
+            "resolved": "https://registry.npmjs.org/lightningcss-linux-x64-musl/-/lightningcss-linux-x64-musl-1.31.1.tgz",
+            "integrity": "sha512-eowF8PrKHw9LpoZii5tdZwnBcYDxRw2rRCyvAXLi34iyeYfqCQNA9rmUM0ce62NlPhCvof1+9ivRaTY6pSKDaA==",
+            "cpu": [
+                "x64"
+            ],
+            "dev": true,
+            "license": "MPL-2.0",
+            "optional": true,
+            "os": [
+                "linux"
+            ],
+            "engines": {
+                "node": ">= 12.0.0"
+            },
+            "funding": {
+                "type": "opencollective",
+                "url": "https://opencollective.com/parcel"
+            }
+        },
+        "node_modules/lightningcss-win32-arm64-msvc": {
+            "version": "1.31.1",
+            "resolved": "https://registry.npmjs.org/lightningcss-win32-arm64-msvc/-/lightningcss-win32-arm64-msvc-1.31.1.tgz",
+            "integrity": "sha512-aJReEbSEQzx1uBlQizAOBSjcmr9dCdL3XuC/6HLXAxmtErsj2ICo5yYggg1qOODQMtnjNQv2UHb9NpOuFtYe4w==",
+            "cpu": [
+                "arm64"
+            ],
+            "dev": true,
+            "license": "MPL-2.0",
+            "optional": true,
+            "os": [
+                "win32"
+            ],
+            "engines": {
+                "node": ">= 12.0.0"
+            },
+            "funding": {
+                "type": "opencollective",
+                "url": "https://opencollective.com/parcel"
+            }
+        },
+        "node_modules/lightningcss-win32-x64-msvc": {
+            "version": "1.31.1",
+            "resolved": "https://registry.npmjs.org/lightningcss-win32-x64-msvc/-/lightningcss-win32-x64-msvc-1.31.1.tgz",
+            "integrity": "sha512-I9aiFrbd7oYHwlnQDqr1Roz+fTz61oDDJX7n9tYF9FJymH1cIN1DtKw3iYt6b8WZgEjoNwVSncwF4wx/ZedMhw==",
+            "cpu": [
+                "x64"
+            ],
+            "dev": true,
+            "license": "MPL-2.0",
+            "optional": true,
+            "os": [
+                "win32"
+            ],
+            "engines": {
+                "node": ">= 12.0.0"
+            },
+            "funding": {
+                "type": "opencollective",
+                "url": "https://opencollective.com/parcel"
+            }
+        },
         "node_modules/limiter": {
             "version": "1.1.5"
         },
@@ -37399,11 +37477,11 @@
             "name": "@nangohq/nango-jobs",
             "version": "1.0.0",
             "dependencies": {
-                "@aws-sdk/client-application-auto-scaling": "3.932.0",
-                "@aws-sdk/client-cloudwatch-logs": "3.932.0",
-                "@aws-sdk/client-lambda": "3.932.0",
-                "@aws-sdk/client-s3": "3.932.0",
-                "@aws-sdk/client-sqs": "3.932.0",
+                "@aws-sdk/client-application-auto-scaling": "3.993.0",
+                "@aws-sdk/client-cloudwatch-logs": "3.993.0",
+                "@aws-sdk/client-lambda": "3.993.0",
+                "@aws-sdk/client-s3": "3.993.0",
+                "@aws-sdk/client-sqs": "3.993.0",
                 "@kubernetes/client-node": "1.3.0",
                 "@nangohq/data-ingestion": "file:../data-ingestion",
                 "@nangohq/database": "file:../database",
@@ -37432,247 +37510,6 @@
                 "type-fest": "4.41.0",
                 "typescript": "5.8.3",
                 "vitest": "3.2.4"
-            }
-        },
-        "packages/jobs/node_modules/@aws-sdk/client-application-auto-scaling": {
-            "version": "3.932.0",
-            "resolved": "https://registry.npmjs.org/@aws-sdk/client-application-auto-scaling/-/client-application-auto-scaling-3.932.0.tgz",
-            "integrity": "sha512-Ya+tPT+055sABGIi1qQChJ63ftEGbyPCm0aKjjdPv+u7UOFuyzAgG7pk79XW6kuWNEFBl5ibdJvUBu1iPDmJyg==",
-            "license": "Apache-2.0",
-            "dependencies": {
-                "@aws-crypto/sha256-browser": "5.2.0",
-                "@aws-crypto/sha256-js": "5.2.0",
-                "@aws-sdk/core": "3.932.0",
-                "@aws-sdk/credential-provider-node": "3.932.0",
-                "@aws-sdk/middleware-host-header": "3.930.0",
-                "@aws-sdk/middleware-logger": "3.930.0",
-                "@aws-sdk/middleware-recursion-detection": "3.930.0",
-                "@aws-sdk/middleware-user-agent": "3.932.0",
-                "@aws-sdk/region-config-resolver": "3.930.0",
-                "@aws-sdk/types": "3.930.0",
-                "@aws-sdk/util-endpoints": "3.930.0",
-                "@aws-sdk/util-user-agent-browser": "3.930.0",
-                "@aws-sdk/util-user-agent-node": "3.932.0",
-                "@smithy/config-resolver": "^4.4.3",
-                "@smithy/core": "^3.18.2",
-                "@smithy/fetch-http-handler": "^5.3.6",
-                "@smithy/hash-node": "^4.2.5",
-                "@smithy/invalid-dependency": "^4.2.5",
-                "@smithy/middleware-content-length": "^4.2.5",
-                "@smithy/middleware-endpoint": "^4.3.9",
-                "@smithy/middleware-retry": "^4.4.9",
-                "@smithy/middleware-serde": "^4.2.5",
-                "@smithy/middleware-stack": "^4.2.5",
-                "@smithy/node-config-provider": "^4.3.5",
-                "@smithy/node-http-handler": "^4.4.5",
-                "@smithy/protocol-http": "^5.3.5",
-                "@smithy/smithy-client": "^4.9.5",
-                "@smithy/types": "^4.9.0",
-                "@smithy/url-parser": "^4.2.5",
-                "@smithy/util-base64": "^4.3.0",
-                "@smithy/util-body-length-browser": "^4.2.0",
-                "@smithy/util-body-length-node": "^4.2.1",
-                "@smithy/util-defaults-mode-browser": "^4.3.8",
-                "@smithy/util-defaults-mode-node": "^4.2.11",
-                "@smithy/util-endpoints": "^3.2.5",
-                "@smithy/util-middleware": "^4.2.5",
-                "@smithy/util-retry": "^4.2.5",
-                "@smithy/util-utf8": "^4.2.0",
-                "tslib": "^2.6.2"
-            },
-            "engines": {
-                "node": ">=18.0.0"
-            }
-        },
-        "packages/jobs/node_modules/@aws-sdk/client-application-auto-scaling/node_modules/@aws-sdk/core": {
-            "version": "3.932.0",
-            "resolved": "https://registry.npmjs.org/@aws-sdk/core/-/core-3.932.0.tgz",
-            "integrity": "sha512-AS8gypYQCbNojwgjvZGkJocC2CoEICDx9ZJ15ILsv+MlcCVLtUJSRSx3VzJOUY2EEIaGLRrPNlIqyn/9/fySvA==",
-            "license": "Apache-2.0",
-            "dependencies": {
-                "@aws-sdk/types": "3.930.0",
-                "@aws-sdk/xml-builder": "3.930.0",
-                "@smithy/core": "^3.18.2",
-                "@smithy/node-config-provider": "^4.3.5",
-                "@smithy/property-provider": "^4.2.5",
-                "@smithy/protocol-http": "^5.3.5",
-                "@smithy/signature-v4": "^5.3.5",
-                "@smithy/smithy-client": "^4.9.5",
-                "@smithy/types": "^4.9.0",
-                "@smithy/util-base64": "^4.3.0",
-                "@smithy/util-middleware": "^4.2.5",
-                "@smithy/util-utf8": "^4.2.0",
-                "tslib": "^2.6.2"
-            },
-            "engines": {
-                "node": ">=18.0.0"
-            }
-        },
-        "packages/jobs/node_modules/@aws-sdk/client-application-auto-scaling/node_modules/@aws-sdk/credential-provider-node": {
-            "version": "3.932.0",
-            "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-node/-/credential-provider-node-3.932.0.tgz",
-            "integrity": "sha512-SEG9t2taBT86qe3gTunfrK8BxT710GVLGepvHr+X5Pw+qW225iNRaGN0zJH+ZE/j91tcW9wOaIoWnURkhR5wIg==",
-            "license": "Apache-2.0",
-            "dependencies": {
-                "@aws-sdk/credential-provider-env": "3.932.0",
-                "@aws-sdk/credential-provider-http": "3.932.0",
-                "@aws-sdk/credential-provider-ini": "3.932.0",
-                "@aws-sdk/credential-provider-process": "3.932.0",
-                "@aws-sdk/credential-provider-sso": "3.932.0",
-                "@aws-sdk/credential-provider-web-identity": "3.932.0",
-                "@aws-sdk/types": "3.930.0",
-                "@smithy/credential-provider-imds": "^4.2.5",
-                "@smithy/property-provider": "^4.2.5",
-                "@smithy/shared-ini-file-loader": "^4.4.0",
-                "@smithy/types": "^4.9.0",
-                "tslib": "^2.6.2"
-            },
-            "engines": {
-                "node": ">=18.0.0"
-            }
-        },
-        "packages/jobs/node_modules/@aws-sdk/client-application-auto-scaling/node_modules/@aws-sdk/middleware-host-header": {
-            "version": "3.930.0",
-            "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-host-header/-/middleware-host-header-3.930.0.tgz",
-            "integrity": "sha512-x30jmm3TLu7b/b+67nMyoV0NlbnCVT5DI57yDrhXAPCtdgM1KtdLWt45UcHpKOm1JsaIkmYRh2WYu7Anx4MG0g==",
-            "license": "Apache-2.0",
-            "dependencies": {
-                "@aws-sdk/types": "3.930.0",
-                "@smithy/protocol-http": "^5.3.5",
-                "@smithy/types": "^4.9.0",
-                "tslib": "^2.6.2"
-            },
-            "engines": {
-                "node": ">=18.0.0"
-            }
-        },
-        "packages/jobs/node_modules/@aws-sdk/client-application-auto-scaling/node_modules/@aws-sdk/middleware-logger": {
-            "version": "3.930.0",
-            "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-logger/-/middleware-logger-3.930.0.tgz",
-            "integrity": "sha512-vh4JBWzMCBW8wREvAwoSqB2geKsZwSHTa0nSt0OMOLp2PdTYIZDi0ZiVMmpfnjcx9XbS6aSluLv9sKx4RrG46A==",
-            "license": "Apache-2.0",
-            "dependencies": {
-                "@aws-sdk/types": "3.930.0",
-                "@smithy/types": "^4.9.0",
-                "tslib": "^2.6.2"
-            },
-            "engines": {
-                "node": ">=18.0.0"
-            }
-        },
-        "packages/jobs/node_modules/@aws-sdk/client-application-auto-scaling/node_modules/@aws-sdk/middleware-recursion-detection": {
-            "version": "3.930.0",
-            "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-recursion-detection/-/middleware-recursion-detection-3.930.0.tgz",
-            "integrity": "sha512-gv0sekNpa2MBsIhm2cjP3nmYSfI4nscx/+K9u9ybrWZBWUIC4kL2sV++bFjjUz4QxUIlvKByow3/a9ARQyCu7Q==",
-            "license": "Apache-2.0",
-            "dependencies": {
-                "@aws-sdk/types": "3.930.0",
-                "@aws/lambda-invoke-store": "^0.1.1",
-                "@smithy/protocol-http": "^5.3.5",
-                "@smithy/types": "^4.9.0",
-                "tslib": "^2.6.2"
-            },
-            "engines": {
-                "node": ">=18.0.0"
-            }
-        },
-        "packages/jobs/node_modules/@aws-sdk/client-application-auto-scaling/node_modules/@aws-sdk/middleware-user-agent": {
-            "version": "3.932.0",
-            "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-user-agent/-/middleware-user-agent-3.932.0.tgz",
-            "integrity": "sha512-9BGTbJyA/4PTdwQWE9hAFIJGpsYkyEW20WON3i15aDqo5oRZwZmqaVageOD57YYqG8JDJjvcwKyDdR4cc38dvg==",
-            "license": "Apache-2.0",
-            "dependencies": {
-                "@aws-sdk/core": "3.932.0",
-                "@aws-sdk/types": "3.930.0",
-                "@aws-sdk/util-endpoints": "3.930.0",
-                "@smithy/core": "^3.18.2",
-                "@smithy/protocol-http": "^5.3.5",
-                "@smithy/types": "^4.9.0",
-                "tslib": "^2.6.2"
-            },
-            "engines": {
-                "node": ">=18.0.0"
-            }
-        },
-        "packages/jobs/node_modules/@aws-sdk/client-application-auto-scaling/node_modules/@aws-sdk/region-config-resolver": {
-            "version": "3.930.0",
-            "resolved": "https://registry.npmjs.org/@aws-sdk/region-config-resolver/-/region-config-resolver-3.930.0.tgz",
-            "integrity": "sha512-KL2JZqH6aYeQssu1g1KuWsReupdfOoxD6f1as2VC+rdwYFUu4LfzMsFfXnBvvQWWqQ7rZHWOw1T+o5gJmg7Dzw==",
-            "license": "Apache-2.0",
-            "dependencies": {
-                "@aws-sdk/types": "3.930.0",
-                "@smithy/config-resolver": "^4.4.3",
-                "@smithy/node-config-provider": "^4.3.5",
-                "@smithy/types": "^4.9.0",
-                "tslib": "^2.6.2"
-            },
-            "engines": {
-                "node": ">=18.0.0"
-            }
-        },
-        "packages/jobs/node_modules/@aws-sdk/client-application-auto-scaling/node_modules/@aws-sdk/types": {
-            "version": "3.930.0",
-            "resolved": "https://registry.npmjs.org/@aws-sdk/types/-/types-3.930.0.tgz",
-            "integrity": "sha512-we/vaAgwlEFW7IeftmCLlLMw+6hFs3DzZPJw7lVHbj/5HJ0bz9gndxEsS2lQoeJ1zhiiLqAqvXxmM43s0MBg0A==",
-            "license": "Apache-2.0",
-            "dependencies": {
-                "@smithy/types": "^4.9.0",
-                "tslib": "^2.6.2"
-            },
-            "engines": {
-                "node": ">=18.0.0"
-            }
-        },
-        "packages/jobs/node_modules/@aws-sdk/client-application-auto-scaling/node_modules/@aws-sdk/util-endpoints": {
-            "version": "3.930.0",
-            "resolved": "https://registry.npmjs.org/@aws-sdk/util-endpoints/-/util-endpoints-3.930.0.tgz",
-            "integrity": "sha512-M2oEKBzzNAYr136RRc6uqw3aWlwCxqTP1Lawps9E1d2abRPvl1p1ztQmmXp1Ak4rv8eByIZ+yQyKQ3zPdRG5dw==",
-            "license": "Apache-2.0",
-            "dependencies": {
-                "@aws-sdk/types": "3.930.0",
-                "@smithy/types": "^4.9.0",
-                "@smithy/url-parser": "^4.2.5",
-                "@smithy/util-endpoints": "^3.2.5",
-                "tslib": "^2.6.2"
-            },
-            "engines": {
-                "node": ">=18.0.0"
-            }
-        },
-        "packages/jobs/node_modules/@aws-sdk/client-application-auto-scaling/node_modules/@aws-sdk/util-user-agent-browser": {
-            "version": "3.930.0",
-            "resolved": "https://registry.npmjs.org/@aws-sdk/util-user-agent-browser/-/util-user-agent-browser-3.930.0.tgz",
-            "integrity": "sha512-q6lCRm6UAe+e1LguM5E4EqM9brQlDem4XDcQ87NzEvlTW6GzmNCO0w1jS0XgCFXQHjDxjdlNFX+5sRbHijwklg==",
-            "license": "Apache-2.0",
-            "dependencies": {
-                "@aws-sdk/types": "3.930.0",
-                "@smithy/types": "^4.9.0",
-                "bowser": "^2.11.0",
-                "tslib": "^2.6.2"
-            }
-        },
-        "packages/jobs/node_modules/@aws-sdk/client-application-auto-scaling/node_modules/@aws-sdk/util-user-agent-node": {
-            "version": "3.932.0",
-            "resolved": "https://registry.npmjs.org/@aws-sdk/util-user-agent-node/-/util-user-agent-node-3.932.0.tgz",
-            "integrity": "sha512-/kC6cscHrZL74TrZtgiIL5jJNbVsw9duGGPurmaVgoCbP7NnxyaSWEurbNV3VPNPhNE3bV3g4Ci+odq+AlsYQg==",
-            "license": "Apache-2.0",
-            "dependencies": {
-                "@aws-sdk/middleware-user-agent": "3.932.0",
-                "@aws-sdk/types": "3.930.0",
-                "@smithy/node-config-provider": "^4.3.5",
-                "@smithy/types": "^4.9.0",
-                "tslib": "^2.6.2"
-            },
-            "engines": {
-                "node": ">=18.0.0"
-            },
-            "peerDependencies": {
-                "aws-crt": ">=1.0.0"
-            },
-            "peerDependenciesMeta": {
-                "aws-crt": {
-                    "optional": true
-                }
             }
         },
         "packages/jobs/node_modules/@aws-sdk/client-cloudwatch-logs": {
@@ -37726,1710 +37563,6 @@
             },
             "engines": {
                 "node": ">=20.0.0"
-            }
-        },
-        "packages/jobs/node_modules/@aws-sdk/client-lambda": {
-            "version": "3.932.0",
-            "resolved": "https://registry.npmjs.org/@aws-sdk/client-lambda/-/client-lambda-3.932.0.tgz",
-            "integrity": "sha512-C7XVPe2XI8An6HgCv6RmoIp9ShdUVqcNFKzdu+HGcxCHZhqg5kvvWjfG0nJuI+CarwBUQqxYdwnBWSrZaBMuYw==",
-            "license": "Apache-2.0",
-            "dependencies": {
-                "@aws-crypto/sha256-browser": "5.2.0",
-                "@aws-crypto/sha256-js": "5.2.0",
-                "@aws-sdk/core": "3.932.0",
-                "@aws-sdk/credential-provider-node": "3.932.0",
-                "@aws-sdk/middleware-host-header": "3.930.0",
-                "@aws-sdk/middleware-logger": "3.930.0",
-                "@aws-sdk/middleware-recursion-detection": "3.930.0",
-                "@aws-sdk/middleware-user-agent": "3.932.0",
-                "@aws-sdk/region-config-resolver": "3.930.0",
-                "@aws-sdk/types": "3.930.0",
-                "@aws-sdk/util-endpoints": "3.930.0",
-                "@aws-sdk/util-user-agent-browser": "3.930.0",
-                "@aws-sdk/util-user-agent-node": "3.932.0",
-                "@smithy/config-resolver": "^4.4.3",
-                "@smithy/core": "^3.18.2",
-                "@smithy/eventstream-serde-browser": "^4.2.5",
-                "@smithy/eventstream-serde-config-resolver": "^4.3.5",
-                "@smithy/eventstream-serde-node": "^4.2.5",
-                "@smithy/fetch-http-handler": "^5.3.6",
-                "@smithy/hash-node": "^4.2.5",
-                "@smithy/invalid-dependency": "^4.2.5",
-                "@smithy/middleware-content-length": "^4.2.5",
-                "@smithy/middleware-endpoint": "^4.3.9",
-                "@smithy/middleware-retry": "^4.4.9",
-                "@smithy/middleware-serde": "^4.2.5",
-                "@smithy/middleware-stack": "^4.2.5",
-                "@smithy/node-config-provider": "^4.3.5",
-                "@smithy/node-http-handler": "^4.4.5",
-                "@smithy/protocol-http": "^5.3.5",
-                "@smithy/smithy-client": "^4.9.5",
-                "@smithy/types": "^4.9.0",
-                "@smithy/url-parser": "^4.2.5",
-                "@smithy/util-base64": "^4.3.0",
-                "@smithy/util-body-length-browser": "^4.2.0",
-                "@smithy/util-body-length-node": "^4.2.1",
-                "@smithy/util-defaults-mode-browser": "^4.3.8",
-                "@smithy/util-defaults-mode-node": "^4.2.11",
-                "@smithy/util-endpoints": "^3.2.5",
-                "@smithy/util-middleware": "^4.2.5",
-                "@smithy/util-retry": "^4.2.5",
-                "@smithy/util-stream": "^4.5.6",
-                "@smithy/util-utf8": "^4.2.0",
-                "@smithy/util-waiter": "^4.2.5",
-                "tslib": "^2.6.2"
-            },
-            "engines": {
-                "node": ">=18.0.0"
-            }
-        },
-        "packages/jobs/node_modules/@aws-sdk/client-lambda/node_modules/@aws-sdk/core": {
-            "version": "3.932.0",
-            "resolved": "https://registry.npmjs.org/@aws-sdk/core/-/core-3.932.0.tgz",
-            "integrity": "sha512-AS8gypYQCbNojwgjvZGkJocC2CoEICDx9ZJ15ILsv+MlcCVLtUJSRSx3VzJOUY2EEIaGLRrPNlIqyn/9/fySvA==",
-            "license": "Apache-2.0",
-            "dependencies": {
-                "@aws-sdk/types": "3.930.0",
-                "@aws-sdk/xml-builder": "3.930.0",
-                "@smithy/core": "^3.18.2",
-                "@smithy/node-config-provider": "^4.3.5",
-                "@smithy/property-provider": "^4.2.5",
-                "@smithy/protocol-http": "^5.3.5",
-                "@smithy/signature-v4": "^5.3.5",
-                "@smithy/smithy-client": "^4.9.5",
-                "@smithy/types": "^4.9.0",
-                "@smithy/util-base64": "^4.3.0",
-                "@smithy/util-middleware": "^4.2.5",
-                "@smithy/util-utf8": "^4.2.0",
-                "tslib": "^2.6.2"
-            },
-            "engines": {
-                "node": ">=18.0.0"
-            }
-        },
-        "packages/jobs/node_modules/@aws-sdk/client-lambda/node_modules/@aws-sdk/credential-provider-node": {
-            "version": "3.932.0",
-            "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-node/-/credential-provider-node-3.932.0.tgz",
-            "integrity": "sha512-SEG9t2taBT86qe3gTunfrK8BxT710GVLGepvHr+X5Pw+qW225iNRaGN0zJH+ZE/j91tcW9wOaIoWnURkhR5wIg==",
-            "license": "Apache-2.0",
-            "dependencies": {
-                "@aws-sdk/credential-provider-env": "3.932.0",
-                "@aws-sdk/credential-provider-http": "3.932.0",
-                "@aws-sdk/credential-provider-ini": "3.932.0",
-                "@aws-sdk/credential-provider-process": "3.932.0",
-                "@aws-sdk/credential-provider-sso": "3.932.0",
-                "@aws-sdk/credential-provider-web-identity": "3.932.0",
-                "@aws-sdk/types": "3.930.0",
-                "@smithy/credential-provider-imds": "^4.2.5",
-                "@smithy/property-provider": "^4.2.5",
-                "@smithy/shared-ini-file-loader": "^4.4.0",
-                "@smithy/types": "^4.9.0",
-                "tslib": "^2.6.2"
-            },
-            "engines": {
-                "node": ">=18.0.0"
-            }
-        },
-        "packages/jobs/node_modules/@aws-sdk/client-lambda/node_modules/@aws-sdk/middleware-host-header": {
-            "version": "3.930.0",
-            "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-host-header/-/middleware-host-header-3.930.0.tgz",
-            "integrity": "sha512-x30jmm3TLu7b/b+67nMyoV0NlbnCVT5DI57yDrhXAPCtdgM1KtdLWt45UcHpKOm1JsaIkmYRh2WYu7Anx4MG0g==",
-            "license": "Apache-2.0",
-            "dependencies": {
-                "@aws-sdk/types": "3.930.0",
-                "@smithy/protocol-http": "^5.3.5",
-                "@smithy/types": "^4.9.0",
-                "tslib": "^2.6.2"
-            },
-            "engines": {
-                "node": ">=18.0.0"
-            }
-        },
-        "packages/jobs/node_modules/@aws-sdk/client-lambda/node_modules/@aws-sdk/middleware-logger": {
-            "version": "3.930.0",
-            "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-logger/-/middleware-logger-3.930.0.tgz",
-            "integrity": "sha512-vh4JBWzMCBW8wREvAwoSqB2geKsZwSHTa0nSt0OMOLp2PdTYIZDi0ZiVMmpfnjcx9XbS6aSluLv9sKx4RrG46A==",
-            "license": "Apache-2.0",
-            "dependencies": {
-                "@aws-sdk/types": "3.930.0",
-                "@smithy/types": "^4.9.0",
-                "tslib": "^2.6.2"
-            },
-            "engines": {
-                "node": ">=18.0.0"
-            }
-        },
-        "packages/jobs/node_modules/@aws-sdk/client-lambda/node_modules/@aws-sdk/middleware-recursion-detection": {
-            "version": "3.930.0",
-            "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-recursion-detection/-/middleware-recursion-detection-3.930.0.tgz",
-            "integrity": "sha512-gv0sekNpa2MBsIhm2cjP3nmYSfI4nscx/+K9u9ybrWZBWUIC4kL2sV++bFjjUz4QxUIlvKByow3/a9ARQyCu7Q==",
-            "license": "Apache-2.0",
-            "dependencies": {
-                "@aws-sdk/types": "3.930.0",
-                "@aws/lambda-invoke-store": "^0.1.1",
-                "@smithy/protocol-http": "^5.3.5",
-                "@smithy/types": "^4.9.0",
-                "tslib": "^2.6.2"
-            },
-            "engines": {
-                "node": ">=18.0.0"
-            }
-        },
-        "packages/jobs/node_modules/@aws-sdk/client-lambda/node_modules/@aws-sdk/middleware-user-agent": {
-            "version": "3.932.0",
-            "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-user-agent/-/middleware-user-agent-3.932.0.tgz",
-            "integrity": "sha512-9BGTbJyA/4PTdwQWE9hAFIJGpsYkyEW20WON3i15aDqo5oRZwZmqaVageOD57YYqG8JDJjvcwKyDdR4cc38dvg==",
-            "license": "Apache-2.0",
-            "dependencies": {
-                "@aws-sdk/core": "3.932.0",
-                "@aws-sdk/types": "3.930.0",
-                "@aws-sdk/util-endpoints": "3.930.0",
-                "@smithy/core": "^3.18.2",
-                "@smithy/protocol-http": "^5.3.5",
-                "@smithy/types": "^4.9.0",
-                "tslib": "^2.6.2"
-            },
-            "engines": {
-                "node": ">=18.0.0"
-            }
-        },
-        "packages/jobs/node_modules/@aws-sdk/client-lambda/node_modules/@aws-sdk/region-config-resolver": {
-            "version": "3.930.0",
-            "resolved": "https://registry.npmjs.org/@aws-sdk/region-config-resolver/-/region-config-resolver-3.930.0.tgz",
-            "integrity": "sha512-KL2JZqH6aYeQssu1g1KuWsReupdfOoxD6f1as2VC+rdwYFUu4LfzMsFfXnBvvQWWqQ7rZHWOw1T+o5gJmg7Dzw==",
-            "license": "Apache-2.0",
-            "dependencies": {
-                "@aws-sdk/types": "3.930.0",
-                "@smithy/config-resolver": "^4.4.3",
-                "@smithy/node-config-provider": "^4.3.5",
-                "@smithy/types": "^4.9.0",
-                "tslib": "^2.6.2"
-            },
-            "engines": {
-                "node": ">=18.0.0"
-            }
-        },
-        "packages/jobs/node_modules/@aws-sdk/client-lambda/node_modules/@aws-sdk/types": {
-            "version": "3.930.0",
-            "resolved": "https://registry.npmjs.org/@aws-sdk/types/-/types-3.930.0.tgz",
-            "integrity": "sha512-we/vaAgwlEFW7IeftmCLlLMw+6hFs3DzZPJw7lVHbj/5HJ0bz9gndxEsS2lQoeJ1zhiiLqAqvXxmM43s0MBg0A==",
-            "license": "Apache-2.0",
-            "dependencies": {
-                "@smithy/types": "^4.9.0",
-                "tslib": "^2.6.2"
-            },
-            "engines": {
-                "node": ">=18.0.0"
-            }
-        },
-        "packages/jobs/node_modules/@aws-sdk/client-lambda/node_modules/@aws-sdk/util-endpoints": {
-            "version": "3.930.0",
-            "resolved": "https://registry.npmjs.org/@aws-sdk/util-endpoints/-/util-endpoints-3.930.0.tgz",
-            "integrity": "sha512-M2oEKBzzNAYr136RRc6uqw3aWlwCxqTP1Lawps9E1d2abRPvl1p1ztQmmXp1Ak4rv8eByIZ+yQyKQ3zPdRG5dw==",
-            "license": "Apache-2.0",
-            "dependencies": {
-                "@aws-sdk/types": "3.930.0",
-                "@smithy/types": "^4.9.0",
-                "@smithy/url-parser": "^4.2.5",
-                "@smithy/util-endpoints": "^3.2.5",
-                "tslib": "^2.6.2"
-            },
-            "engines": {
-                "node": ">=18.0.0"
-            }
-        },
-        "packages/jobs/node_modules/@aws-sdk/client-lambda/node_modules/@aws-sdk/util-user-agent-browser": {
-            "version": "3.930.0",
-            "resolved": "https://registry.npmjs.org/@aws-sdk/util-user-agent-browser/-/util-user-agent-browser-3.930.0.tgz",
-            "integrity": "sha512-q6lCRm6UAe+e1LguM5E4EqM9brQlDem4XDcQ87NzEvlTW6GzmNCO0w1jS0XgCFXQHjDxjdlNFX+5sRbHijwklg==",
-            "license": "Apache-2.0",
-            "dependencies": {
-                "@aws-sdk/types": "3.930.0",
-                "@smithy/types": "^4.9.0",
-                "bowser": "^2.11.0",
-                "tslib": "^2.6.2"
-            }
-        },
-        "packages/jobs/node_modules/@aws-sdk/client-lambda/node_modules/@aws-sdk/util-user-agent-node": {
-            "version": "3.932.0",
-            "resolved": "https://registry.npmjs.org/@aws-sdk/util-user-agent-node/-/util-user-agent-node-3.932.0.tgz",
-            "integrity": "sha512-/kC6cscHrZL74TrZtgiIL5jJNbVsw9duGGPurmaVgoCbP7NnxyaSWEurbNV3VPNPhNE3bV3g4Ci+odq+AlsYQg==",
-            "license": "Apache-2.0",
-            "dependencies": {
-                "@aws-sdk/middleware-user-agent": "3.932.0",
-                "@aws-sdk/types": "3.930.0",
-                "@smithy/node-config-provider": "^4.3.5",
-                "@smithy/types": "^4.9.0",
-                "tslib": "^2.6.2"
-            },
-            "engines": {
-                "node": ">=18.0.0"
-            },
-            "peerDependencies": {
-                "aws-crt": ">=1.0.0"
-            },
-            "peerDependenciesMeta": {
-                "aws-crt": {
-                    "optional": true
-                }
-            }
-        },
-        "packages/jobs/node_modules/@aws-sdk/client-s3": {
-            "version": "3.932.0",
-            "resolved": "https://registry.npmjs.org/@aws-sdk/client-s3/-/client-s3-3.932.0.tgz",
-            "integrity": "sha512-qrlbJ3W5QR3Gzz2S+yaItH8ZhX7vaeA4j4fDAi8+0FmsVhXOfBbomWr+JO1wk/YojZMdyLfmfYRHrJvAQsLFVw==",
-            "license": "Apache-2.0",
-            "dependencies": {
-                "@aws-crypto/sha1-browser": "5.2.0",
-                "@aws-crypto/sha256-browser": "5.2.0",
-                "@aws-crypto/sha256-js": "5.2.0",
-                "@aws-sdk/core": "3.932.0",
-                "@aws-sdk/credential-provider-node": "3.932.0",
-                "@aws-sdk/middleware-bucket-endpoint": "3.930.0",
-                "@aws-sdk/middleware-expect-continue": "3.930.0",
-                "@aws-sdk/middleware-flexible-checksums": "3.932.0",
-                "@aws-sdk/middleware-host-header": "3.930.0",
-                "@aws-sdk/middleware-location-constraint": "3.930.0",
-                "@aws-sdk/middleware-logger": "3.930.0",
-                "@aws-sdk/middleware-recursion-detection": "3.930.0",
-                "@aws-sdk/middleware-sdk-s3": "3.932.0",
-                "@aws-sdk/middleware-ssec": "3.930.0",
-                "@aws-sdk/middleware-user-agent": "3.932.0",
-                "@aws-sdk/region-config-resolver": "3.930.0",
-                "@aws-sdk/signature-v4-multi-region": "3.932.0",
-                "@aws-sdk/types": "3.930.0",
-                "@aws-sdk/util-endpoints": "3.930.0",
-                "@aws-sdk/util-user-agent-browser": "3.930.0",
-                "@aws-sdk/util-user-agent-node": "3.932.0",
-                "@smithy/config-resolver": "^4.4.3",
-                "@smithy/core": "^3.18.2",
-                "@smithy/eventstream-serde-browser": "^4.2.5",
-                "@smithy/eventstream-serde-config-resolver": "^4.3.5",
-                "@smithy/eventstream-serde-node": "^4.2.5",
-                "@smithy/fetch-http-handler": "^5.3.6",
-                "@smithy/hash-blob-browser": "^4.2.6",
-                "@smithy/hash-node": "^4.2.5",
-                "@smithy/hash-stream-node": "^4.2.5",
-                "@smithy/invalid-dependency": "^4.2.5",
-                "@smithy/md5-js": "^4.2.5",
-                "@smithy/middleware-content-length": "^4.2.5",
-                "@smithy/middleware-endpoint": "^4.3.9",
-                "@smithy/middleware-retry": "^4.4.9",
-                "@smithy/middleware-serde": "^4.2.5",
-                "@smithy/middleware-stack": "^4.2.5",
-                "@smithy/node-config-provider": "^4.3.5",
-                "@smithy/node-http-handler": "^4.4.5",
-                "@smithy/protocol-http": "^5.3.5",
-                "@smithy/smithy-client": "^4.9.5",
-                "@smithy/types": "^4.9.0",
-                "@smithy/url-parser": "^4.2.5",
-                "@smithy/util-base64": "^4.3.0",
-                "@smithy/util-body-length-browser": "^4.2.0",
-                "@smithy/util-body-length-node": "^4.2.1",
-                "@smithy/util-defaults-mode-browser": "^4.3.8",
-                "@smithy/util-defaults-mode-node": "^4.2.11",
-                "@smithy/util-endpoints": "^3.2.5",
-                "@smithy/util-middleware": "^4.2.5",
-                "@smithy/util-retry": "^4.2.5",
-                "@smithy/util-stream": "^4.5.6",
-                "@smithy/util-utf8": "^4.2.0",
-                "@smithy/util-waiter": "^4.2.5",
-                "tslib": "^2.6.2"
-            },
-            "engines": {
-                "node": ">=18.0.0"
-            }
-        },
-        "packages/jobs/node_modules/@aws-sdk/client-s3/node_modules/@aws-sdk/core": {
-            "version": "3.932.0",
-            "resolved": "https://registry.npmjs.org/@aws-sdk/core/-/core-3.932.0.tgz",
-            "integrity": "sha512-AS8gypYQCbNojwgjvZGkJocC2CoEICDx9ZJ15ILsv+MlcCVLtUJSRSx3VzJOUY2EEIaGLRrPNlIqyn/9/fySvA==",
-            "license": "Apache-2.0",
-            "dependencies": {
-                "@aws-sdk/types": "3.930.0",
-                "@aws-sdk/xml-builder": "3.930.0",
-                "@smithy/core": "^3.18.2",
-                "@smithy/node-config-provider": "^4.3.5",
-                "@smithy/property-provider": "^4.2.5",
-                "@smithy/protocol-http": "^5.3.5",
-                "@smithy/signature-v4": "^5.3.5",
-                "@smithy/smithy-client": "^4.9.5",
-                "@smithy/types": "^4.9.0",
-                "@smithy/util-base64": "^4.3.0",
-                "@smithy/util-middleware": "^4.2.5",
-                "@smithy/util-utf8": "^4.2.0",
-                "tslib": "^2.6.2"
-            },
-            "engines": {
-                "node": ">=18.0.0"
-            }
-        },
-        "packages/jobs/node_modules/@aws-sdk/client-s3/node_modules/@aws-sdk/credential-provider-node": {
-            "version": "3.932.0",
-            "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-node/-/credential-provider-node-3.932.0.tgz",
-            "integrity": "sha512-SEG9t2taBT86qe3gTunfrK8BxT710GVLGepvHr+X5Pw+qW225iNRaGN0zJH+ZE/j91tcW9wOaIoWnURkhR5wIg==",
-            "license": "Apache-2.0",
-            "dependencies": {
-                "@aws-sdk/credential-provider-env": "3.932.0",
-                "@aws-sdk/credential-provider-http": "3.932.0",
-                "@aws-sdk/credential-provider-ini": "3.932.0",
-                "@aws-sdk/credential-provider-process": "3.932.0",
-                "@aws-sdk/credential-provider-sso": "3.932.0",
-                "@aws-sdk/credential-provider-web-identity": "3.932.0",
-                "@aws-sdk/types": "3.930.0",
-                "@smithy/credential-provider-imds": "^4.2.5",
-                "@smithy/property-provider": "^4.2.5",
-                "@smithy/shared-ini-file-loader": "^4.4.0",
-                "@smithy/types": "^4.9.0",
-                "tslib": "^2.6.2"
-            },
-            "engines": {
-                "node": ">=18.0.0"
-            }
-        },
-        "packages/jobs/node_modules/@aws-sdk/client-s3/node_modules/@aws-sdk/middleware-host-header": {
-            "version": "3.930.0",
-            "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-host-header/-/middleware-host-header-3.930.0.tgz",
-            "integrity": "sha512-x30jmm3TLu7b/b+67nMyoV0NlbnCVT5DI57yDrhXAPCtdgM1KtdLWt45UcHpKOm1JsaIkmYRh2WYu7Anx4MG0g==",
-            "license": "Apache-2.0",
-            "dependencies": {
-                "@aws-sdk/types": "3.930.0",
-                "@smithy/protocol-http": "^5.3.5",
-                "@smithy/types": "^4.9.0",
-                "tslib": "^2.6.2"
-            },
-            "engines": {
-                "node": ">=18.0.0"
-            }
-        },
-        "packages/jobs/node_modules/@aws-sdk/client-s3/node_modules/@aws-sdk/middleware-logger": {
-            "version": "3.930.0",
-            "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-logger/-/middleware-logger-3.930.0.tgz",
-            "integrity": "sha512-vh4JBWzMCBW8wREvAwoSqB2geKsZwSHTa0nSt0OMOLp2PdTYIZDi0ZiVMmpfnjcx9XbS6aSluLv9sKx4RrG46A==",
-            "license": "Apache-2.0",
-            "dependencies": {
-                "@aws-sdk/types": "3.930.0",
-                "@smithy/types": "^4.9.0",
-                "tslib": "^2.6.2"
-            },
-            "engines": {
-                "node": ">=18.0.0"
-            }
-        },
-        "packages/jobs/node_modules/@aws-sdk/client-s3/node_modules/@aws-sdk/middleware-recursion-detection": {
-            "version": "3.930.0",
-            "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-recursion-detection/-/middleware-recursion-detection-3.930.0.tgz",
-            "integrity": "sha512-gv0sekNpa2MBsIhm2cjP3nmYSfI4nscx/+K9u9ybrWZBWUIC4kL2sV++bFjjUz4QxUIlvKByow3/a9ARQyCu7Q==",
-            "license": "Apache-2.0",
-            "dependencies": {
-                "@aws-sdk/types": "3.930.0",
-                "@aws/lambda-invoke-store": "^0.1.1",
-                "@smithy/protocol-http": "^5.3.5",
-                "@smithy/types": "^4.9.0",
-                "tslib": "^2.6.2"
-            },
-            "engines": {
-                "node": ">=18.0.0"
-            }
-        },
-        "packages/jobs/node_modules/@aws-sdk/client-s3/node_modules/@aws-sdk/middleware-user-agent": {
-            "version": "3.932.0",
-            "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-user-agent/-/middleware-user-agent-3.932.0.tgz",
-            "integrity": "sha512-9BGTbJyA/4PTdwQWE9hAFIJGpsYkyEW20WON3i15aDqo5oRZwZmqaVageOD57YYqG8JDJjvcwKyDdR4cc38dvg==",
-            "license": "Apache-2.0",
-            "dependencies": {
-                "@aws-sdk/core": "3.932.0",
-                "@aws-sdk/types": "3.930.0",
-                "@aws-sdk/util-endpoints": "3.930.0",
-                "@smithy/core": "^3.18.2",
-                "@smithy/protocol-http": "^5.3.5",
-                "@smithy/types": "^4.9.0",
-                "tslib": "^2.6.2"
-            },
-            "engines": {
-                "node": ">=18.0.0"
-            }
-        },
-        "packages/jobs/node_modules/@aws-sdk/client-s3/node_modules/@aws-sdk/region-config-resolver": {
-            "version": "3.930.0",
-            "resolved": "https://registry.npmjs.org/@aws-sdk/region-config-resolver/-/region-config-resolver-3.930.0.tgz",
-            "integrity": "sha512-KL2JZqH6aYeQssu1g1KuWsReupdfOoxD6f1as2VC+rdwYFUu4LfzMsFfXnBvvQWWqQ7rZHWOw1T+o5gJmg7Dzw==",
-            "license": "Apache-2.0",
-            "dependencies": {
-                "@aws-sdk/types": "3.930.0",
-                "@smithy/config-resolver": "^4.4.3",
-                "@smithy/node-config-provider": "^4.3.5",
-                "@smithy/types": "^4.9.0",
-                "tslib": "^2.6.2"
-            },
-            "engines": {
-                "node": ">=18.0.0"
-            }
-        },
-        "packages/jobs/node_modules/@aws-sdk/client-s3/node_modules/@aws-sdk/types": {
-            "version": "3.930.0",
-            "resolved": "https://registry.npmjs.org/@aws-sdk/types/-/types-3.930.0.tgz",
-            "integrity": "sha512-we/vaAgwlEFW7IeftmCLlLMw+6hFs3DzZPJw7lVHbj/5HJ0bz9gndxEsS2lQoeJ1zhiiLqAqvXxmM43s0MBg0A==",
-            "license": "Apache-2.0",
-            "dependencies": {
-                "@smithy/types": "^4.9.0",
-                "tslib": "^2.6.2"
-            },
-            "engines": {
-                "node": ">=18.0.0"
-            }
-        },
-        "packages/jobs/node_modules/@aws-sdk/client-s3/node_modules/@aws-sdk/util-endpoints": {
-            "version": "3.930.0",
-            "resolved": "https://registry.npmjs.org/@aws-sdk/util-endpoints/-/util-endpoints-3.930.0.tgz",
-            "integrity": "sha512-M2oEKBzzNAYr136RRc6uqw3aWlwCxqTP1Lawps9E1d2abRPvl1p1ztQmmXp1Ak4rv8eByIZ+yQyKQ3zPdRG5dw==",
-            "license": "Apache-2.0",
-            "dependencies": {
-                "@aws-sdk/types": "3.930.0",
-                "@smithy/types": "^4.9.0",
-                "@smithy/url-parser": "^4.2.5",
-                "@smithy/util-endpoints": "^3.2.5",
-                "tslib": "^2.6.2"
-            },
-            "engines": {
-                "node": ">=18.0.0"
-            }
-        },
-        "packages/jobs/node_modules/@aws-sdk/client-s3/node_modules/@aws-sdk/util-user-agent-browser": {
-            "version": "3.930.0",
-            "resolved": "https://registry.npmjs.org/@aws-sdk/util-user-agent-browser/-/util-user-agent-browser-3.930.0.tgz",
-            "integrity": "sha512-q6lCRm6UAe+e1LguM5E4EqM9brQlDem4XDcQ87NzEvlTW6GzmNCO0w1jS0XgCFXQHjDxjdlNFX+5sRbHijwklg==",
-            "license": "Apache-2.0",
-            "dependencies": {
-                "@aws-sdk/types": "3.930.0",
-                "@smithy/types": "^4.9.0",
-                "bowser": "^2.11.0",
-                "tslib": "^2.6.2"
-            }
-        },
-        "packages/jobs/node_modules/@aws-sdk/client-s3/node_modules/@aws-sdk/util-user-agent-node": {
-            "version": "3.932.0",
-            "resolved": "https://registry.npmjs.org/@aws-sdk/util-user-agent-node/-/util-user-agent-node-3.932.0.tgz",
-            "integrity": "sha512-/kC6cscHrZL74TrZtgiIL5jJNbVsw9duGGPurmaVgoCbP7NnxyaSWEurbNV3VPNPhNE3bV3g4Ci+odq+AlsYQg==",
-            "license": "Apache-2.0",
-            "dependencies": {
-                "@aws-sdk/middleware-user-agent": "3.932.0",
-                "@aws-sdk/types": "3.930.0",
-                "@smithy/node-config-provider": "^4.3.5",
-                "@smithy/types": "^4.9.0",
-                "tslib": "^2.6.2"
-            },
-            "engines": {
-                "node": ">=18.0.0"
-            },
-            "peerDependencies": {
-                "aws-crt": ">=1.0.0"
-            },
-            "peerDependenciesMeta": {
-                "aws-crt": {
-                    "optional": true
-                }
-            }
-        },
-        "packages/jobs/node_modules/@aws-sdk/client-sqs": {
-            "version": "3.932.0",
-            "resolved": "https://registry.npmjs.org/@aws-sdk/client-sqs/-/client-sqs-3.932.0.tgz",
-            "integrity": "sha512-Is0FzdPc9T/Pcd5LNgqQe5BdWohTGOlVQ98fTs0GF6HIEbfrczNQSBfj7PXv6eL9AuYFWola5SdZX4ucbMkAEg==",
-            "license": "Apache-2.0",
-            "dependencies": {
-                "@aws-crypto/sha256-browser": "5.2.0",
-                "@aws-crypto/sha256-js": "5.2.0",
-                "@aws-sdk/core": "3.932.0",
-                "@aws-sdk/credential-provider-node": "3.932.0",
-                "@aws-sdk/middleware-host-header": "3.930.0",
-                "@aws-sdk/middleware-logger": "3.930.0",
-                "@aws-sdk/middleware-recursion-detection": "3.930.0",
-                "@aws-sdk/middleware-sdk-sqs": "3.930.0",
-                "@aws-sdk/middleware-user-agent": "3.932.0",
-                "@aws-sdk/region-config-resolver": "3.930.0",
-                "@aws-sdk/types": "3.930.0",
-                "@aws-sdk/util-endpoints": "3.930.0",
-                "@aws-sdk/util-user-agent-browser": "3.930.0",
-                "@aws-sdk/util-user-agent-node": "3.932.0",
-                "@smithy/config-resolver": "^4.4.3",
-                "@smithy/core": "^3.18.2",
-                "@smithy/fetch-http-handler": "^5.3.6",
-                "@smithy/hash-node": "^4.2.5",
-                "@smithy/invalid-dependency": "^4.2.5",
-                "@smithy/md5-js": "^4.2.5",
-                "@smithy/middleware-content-length": "^4.2.5",
-                "@smithy/middleware-endpoint": "^4.3.9",
-                "@smithy/middleware-retry": "^4.4.9",
-                "@smithy/middleware-serde": "^4.2.5",
-                "@smithy/middleware-stack": "^4.2.5",
-                "@smithy/node-config-provider": "^4.3.5",
-                "@smithy/node-http-handler": "^4.4.5",
-                "@smithy/protocol-http": "^5.3.5",
-                "@smithy/smithy-client": "^4.9.5",
-                "@smithy/types": "^4.9.0",
-                "@smithy/url-parser": "^4.2.5",
-                "@smithy/util-base64": "^4.3.0",
-                "@smithy/util-body-length-browser": "^4.2.0",
-                "@smithy/util-body-length-node": "^4.2.1",
-                "@smithy/util-defaults-mode-browser": "^4.3.8",
-                "@smithy/util-defaults-mode-node": "^4.2.11",
-                "@smithy/util-endpoints": "^3.2.5",
-                "@smithy/util-middleware": "^4.2.5",
-                "@smithy/util-retry": "^4.2.5",
-                "@smithy/util-utf8": "^4.2.0",
-                "tslib": "^2.6.2"
-            },
-            "engines": {
-                "node": ">=18.0.0"
-            }
-        },
-        "packages/jobs/node_modules/@aws-sdk/client-sqs/node_modules/@aws-sdk/core": {
-            "version": "3.932.0",
-            "resolved": "https://registry.npmjs.org/@aws-sdk/core/-/core-3.932.0.tgz",
-            "integrity": "sha512-AS8gypYQCbNojwgjvZGkJocC2CoEICDx9ZJ15ILsv+MlcCVLtUJSRSx3VzJOUY2EEIaGLRrPNlIqyn/9/fySvA==",
-            "license": "Apache-2.0",
-            "dependencies": {
-                "@aws-sdk/types": "3.930.0",
-                "@aws-sdk/xml-builder": "3.930.0",
-                "@smithy/core": "^3.18.2",
-                "@smithy/node-config-provider": "^4.3.5",
-                "@smithy/property-provider": "^4.2.5",
-                "@smithy/protocol-http": "^5.3.5",
-                "@smithy/signature-v4": "^5.3.5",
-                "@smithy/smithy-client": "^4.9.5",
-                "@smithy/types": "^4.9.0",
-                "@smithy/util-base64": "^4.3.0",
-                "@smithy/util-middleware": "^4.2.5",
-                "@smithy/util-utf8": "^4.2.0",
-                "tslib": "^2.6.2"
-            },
-            "engines": {
-                "node": ">=18.0.0"
-            }
-        },
-        "packages/jobs/node_modules/@aws-sdk/client-sqs/node_modules/@aws-sdk/credential-provider-node": {
-            "version": "3.932.0",
-            "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-node/-/credential-provider-node-3.932.0.tgz",
-            "integrity": "sha512-SEG9t2taBT86qe3gTunfrK8BxT710GVLGepvHr+X5Pw+qW225iNRaGN0zJH+ZE/j91tcW9wOaIoWnURkhR5wIg==",
-            "license": "Apache-2.0",
-            "dependencies": {
-                "@aws-sdk/credential-provider-env": "3.932.0",
-                "@aws-sdk/credential-provider-http": "3.932.0",
-                "@aws-sdk/credential-provider-ini": "3.932.0",
-                "@aws-sdk/credential-provider-process": "3.932.0",
-                "@aws-sdk/credential-provider-sso": "3.932.0",
-                "@aws-sdk/credential-provider-web-identity": "3.932.0",
-                "@aws-sdk/types": "3.930.0",
-                "@smithy/credential-provider-imds": "^4.2.5",
-                "@smithy/property-provider": "^4.2.5",
-                "@smithy/shared-ini-file-loader": "^4.4.0",
-                "@smithy/types": "^4.9.0",
-                "tslib": "^2.6.2"
-            },
-            "engines": {
-                "node": ">=18.0.0"
-            }
-        },
-        "packages/jobs/node_modules/@aws-sdk/client-sqs/node_modules/@aws-sdk/middleware-host-header": {
-            "version": "3.930.0",
-            "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-host-header/-/middleware-host-header-3.930.0.tgz",
-            "integrity": "sha512-x30jmm3TLu7b/b+67nMyoV0NlbnCVT5DI57yDrhXAPCtdgM1KtdLWt45UcHpKOm1JsaIkmYRh2WYu7Anx4MG0g==",
-            "license": "Apache-2.0",
-            "dependencies": {
-                "@aws-sdk/types": "3.930.0",
-                "@smithy/protocol-http": "^5.3.5",
-                "@smithy/types": "^4.9.0",
-                "tslib": "^2.6.2"
-            },
-            "engines": {
-                "node": ">=18.0.0"
-            }
-        },
-        "packages/jobs/node_modules/@aws-sdk/client-sqs/node_modules/@aws-sdk/middleware-logger": {
-            "version": "3.930.0",
-            "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-logger/-/middleware-logger-3.930.0.tgz",
-            "integrity": "sha512-vh4JBWzMCBW8wREvAwoSqB2geKsZwSHTa0nSt0OMOLp2PdTYIZDi0ZiVMmpfnjcx9XbS6aSluLv9sKx4RrG46A==",
-            "license": "Apache-2.0",
-            "dependencies": {
-                "@aws-sdk/types": "3.930.0",
-                "@smithy/types": "^4.9.0",
-                "tslib": "^2.6.2"
-            },
-            "engines": {
-                "node": ">=18.0.0"
-            }
-        },
-        "packages/jobs/node_modules/@aws-sdk/client-sqs/node_modules/@aws-sdk/middleware-recursion-detection": {
-            "version": "3.930.0",
-            "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-recursion-detection/-/middleware-recursion-detection-3.930.0.tgz",
-            "integrity": "sha512-gv0sekNpa2MBsIhm2cjP3nmYSfI4nscx/+K9u9ybrWZBWUIC4kL2sV++bFjjUz4QxUIlvKByow3/a9ARQyCu7Q==",
-            "license": "Apache-2.0",
-            "dependencies": {
-                "@aws-sdk/types": "3.930.0",
-                "@aws/lambda-invoke-store": "^0.1.1",
-                "@smithy/protocol-http": "^5.3.5",
-                "@smithy/types": "^4.9.0",
-                "tslib": "^2.6.2"
-            },
-            "engines": {
-                "node": ">=18.0.0"
-            }
-        },
-        "packages/jobs/node_modules/@aws-sdk/client-sqs/node_modules/@aws-sdk/middleware-user-agent": {
-            "version": "3.932.0",
-            "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-user-agent/-/middleware-user-agent-3.932.0.tgz",
-            "integrity": "sha512-9BGTbJyA/4PTdwQWE9hAFIJGpsYkyEW20WON3i15aDqo5oRZwZmqaVageOD57YYqG8JDJjvcwKyDdR4cc38dvg==",
-            "license": "Apache-2.0",
-            "dependencies": {
-                "@aws-sdk/core": "3.932.0",
-                "@aws-sdk/types": "3.930.0",
-                "@aws-sdk/util-endpoints": "3.930.0",
-                "@smithy/core": "^3.18.2",
-                "@smithy/protocol-http": "^5.3.5",
-                "@smithy/types": "^4.9.0",
-                "tslib": "^2.6.2"
-            },
-            "engines": {
-                "node": ">=18.0.0"
-            }
-        },
-        "packages/jobs/node_modules/@aws-sdk/client-sqs/node_modules/@aws-sdk/region-config-resolver": {
-            "version": "3.930.0",
-            "resolved": "https://registry.npmjs.org/@aws-sdk/region-config-resolver/-/region-config-resolver-3.930.0.tgz",
-            "integrity": "sha512-KL2JZqH6aYeQssu1g1KuWsReupdfOoxD6f1as2VC+rdwYFUu4LfzMsFfXnBvvQWWqQ7rZHWOw1T+o5gJmg7Dzw==",
-            "license": "Apache-2.0",
-            "dependencies": {
-                "@aws-sdk/types": "3.930.0",
-                "@smithy/config-resolver": "^4.4.3",
-                "@smithy/node-config-provider": "^4.3.5",
-                "@smithy/types": "^4.9.0",
-                "tslib": "^2.6.2"
-            },
-            "engines": {
-                "node": ">=18.0.0"
-            }
-        },
-        "packages/jobs/node_modules/@aws-sdk/client-sqs/node_modules/@aws-sdk/types": {
-            "version": "3.930.0",
-            "resolved": "https://registry.npmjs.org/@aws-sdk/types/-/types-3.930.0.tgz",
-            "integrity": "sha512-we/vaAgwlEFW7IeftmCLlLMw+6hFs3DzZPJw7lVHbj/5HJ0bz9gndxEsS2lQoeJ1zhiiLqAqvXxmM43s0MBg0A==",
-            "license": "Apache-2.0",
-            "dependencies": {
-                "@smithy/types": "^4.9.0",
-                "tslib": "^2.6.2"
-            },
-            "engines": {
-                "node": ">=18.0.0"
-            }
-        },
-        "packages/jobs/node_modules/@aws-sdk/client-sqs/node_modules/@aws-sdk/util-endpoints": {
-            "version": "3.930.0",
-            "resolved": "https://registry.npmjs.org/@aws-sdk/util-endpoints/-/util-endpoints-3.930.0.tgz",
-            "integrity": "sha512-M2oEKBzzNAYr136RRc6uqw3aWlwCxqTP1Lawps9E1d2abRPvl1p1ztQmmXp1Ak4rv8eByIZ+yQyKQ3zPdRG5dw==",
-            "license": "Apache-2.0",
-            "dependencies": {
-                "@aws-sdk/types": "3.930.0",
-                "@smithy/types": "^4.9.0",
-                "@smithy/url-parser": "^4.2.5",
-                "@smithy/util-endpoints": "^3.2.5",
-                "tslib": "^2.6.2"
-            },
-            "engines": {
-                "node": ">=18.0.0"
-            }
-        },
-        "packages/jobs/node_modules/@aws-sdk/client-sqs/node_modules/@aws-sdk/util-user-agent-browser": {
-            "version": "3.930.0",
-            "resolved": "https://registry.npmjs.org/@aws-sdk/util-user-agent-browser/-/util-user-agent-browser-3.930.0.tgz",
-            "integrity": "sha512-q6lCRm6UAe+e1LguM5E4EqM9brQlDem4XDcQ87NzEvlTW6GzmNCO0w1jS0XgCFXQHjDxjdlNFX+5sRbHijwklg==",
-            "license": "Apache-2.0",
-            "dependencies": {
-                "@aws-sdk/types": "3.930.0",
-                "@smithy/types": "^4.9.0",
-                "bowser": "^2.11.0",
-                "tslib": "^2.6.2"
-            }
-        },
-        "packages/jobs/node_modules/@aws-sdk/client-sqs/node_modules/@aws-sdk/util-user-agent-node": {
-            "version": "3.932.0",
-            "resolved": "https://registry.npmjs.org/@aws-sdk/util-user-agent-node/-/util-user-agent-node-3.932.0.tgz",
-            "integrity": "sha512-/kC6cscHrZL74TrZtgiIL5jJNbVsw9duGGPurmaVgoCbP7NnxyaSWEurbNV3VPNPhNE3bV3g4Ci+odq+AlsYQg==",
-            "license": "Apache-2.0",
-            "dependencies": {
-                "@aws-sdk/middleware-user-agent": "3.932.0",
-                "@aws-sdk/types": "3.930.0",
-                "@smithy/node-config-provider": "^4.3.5",
-                "@smithy/types": "^4.9.0",
-                "tslib": "^2.6.2"
-            },
-            "engines": {
-                "node": ">=18.0.0"
-            },
-            "peerDependencies": {
-                "aws-crt": ">=1.0.0"
-            },
-            "peerDependenciesMeta": {
-                "aws-crt": {
-                    "optional": true
-                }
-            }
-        },
-        "packages/jobs/node_modules/@aws-sdk/credential-provider-env": {
-            "version": "3.932.0",
-            "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-env/-/credential-provider-env-3.932.0.tgz",
-            "integrity": "sha512-ozge/c7NdHUDyHqro6+P5oHt8wfKSUBN+olttiVfBe9Mw3wBMpPa3gQ0pZnG+gwBkKskBuip2bMR16tqYvUSEA==",
-            "license": "Apache-2.0",
-            "dependencies": {
-                "@aws-sdk/core": "3.932.0",
-                "@aws-sdk/types": "3.930.0",
-                "@smithy/property-provider": "^4.2.5",
-                "@smithy/types": "^4.9.0",
-                "tslib": "^2.6.2"
-            },
-            "engines": {
-                "node": ">=18.0.0"
-            }
-        },
-        "packages/jobs/node_modules/@aws-sdk/credential-provider-env/node_modules/@aws-sdk/core": {
-            "version": "3.932.0",
-            "resolved": "https://registry.npmjs.org/@aws-sdk/core/-/core-3.932.0.tgz",
-            "integrity": "sha512-AS8gypYQCbNojwgjvZGkJocC2CoEICDx9ZJ15ILsv+MlcCVLtUJSRSx3VzJOUY2EEIaGLRrPNlIqyn/9/fySvA==",
-            "license": "Apache-2.0",
-            "dependencies": {
-                "@aws-sdk/types": "3.930.0",
-                "@aws-sdk/xml-builder": "3.930.0",
-                "@smithy/core": "^3.18.2",
-                "@smithy/node-config-provider": "^4.3.5",
-                "@smithy/property-provider": "^4.2.5",
-                "@smithy/protocol-http": "^5.3.5",
-                "@smithy/signature-v4": "^5.3.5",
-                "@smithy/smithy-client": "^4.9.5",
-                "@smithy/types": "^4.9.0",
-                "@smithy/util-base64": "^4.3.0",
-                "@smithy/util-middleware": "^4.2.5",
-                "@smithy/util-utf8": "^4.2.0",
-                "tslib": "^2.6.2"
-            },
-            "engines": {
-                "node": ">=18.0.0"
-            }
-        },
-        "packages/jobs/node_modules/@aws-sdk/credential-provider-env/node_modules/@aws-sdk/types": {
-            "version": "3.930.0",
-            "resolved": "https://registry.npmjs.org/@aws-sdk/types/-/types-3.930.0.tgz",
-            "integrity": "sha512-we/vaAgwlEFW7IeftmCLlLMw+6hFs3DzZPJw7lVHbj/5HJ0bz9gndxEsS2lQoeJ1zhiiLqAqvXxmM43s0MBg0A==",
-            "license": "Apache-2.0",
-            "dependencies": {
-                "@smithy/types": "^4.9.0",
-                "tslib": "^2.6.2"
-            },
-            "engines": {
-                "node": ">=18.0.0"
-            }
-        },
-        "packages/jobs/node_modules/@aws-sdk/credential-provider-http": {
-            "version": "3.932.0",
-            "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-http/-/credential-provider-http-3.932.0.tgz",
-            "integrity": "sha512-b6N9Nnlg8JInQwzBkUq5spNaXssM3h3zLxGzpPrnw0nHSIWPJPTbZzA5Ca285fcDUFuKP+qf3qkuqlAjGOdWhg==",
-            "license": "Apache-2.0",
-            "dependencies": {
-                "@aws-sdk/core": "3.932.0",
-                "@aws-sdk/types": "3.930.0",
-                "@smithy/fetch-http-handler": "^5.3.6",
-                "@smithy/node-http-handler": "^4.4.5",
-                "@smithy/property-provider": "^4.2.5",
-                "@smithy/protocol-http": "^5.3.5",
-                "@smithy/smithy-client": "^4.9.5",
-                "@smithy/types": "^4.9.0",
-                "@smithy/util-stream": "^4.5.6",
-                "tslib": "^2.6.2"
-            },
-            "engines": {
-                "node": ">=18.0.0"
-            }
-        },
-        "packages/jobs/node_modules/@aws-sdk/credential-provider-http/node_modules/@aws-sdk/core": {
-            "version": "3.932.0",
-            "resolved": "https://registry.npmjs.org/@aws-sdk/core/-/core-3.932.0.tgz",
-            "integrity": "sha512-AS8gypYQCbNojwgjvZGkJocC2CoEICDx9ZJ15ILsv+MlcCVLtUJSRSx3VzJOUY2EEIaGLRrPNlIqyn/9/fySvA==",
-            "license": "Apache-2.0",
-            "dependencies": {
-                "@aws-sdk/types": "3.930.0",
-                "@aws-sdk/xml-builder": "3.930.0",
-                "@smithy/core": "^3.18.2",
-                "@smithy/node-config-provider": "^4.3.5",
-                "@smithy/property-provider": "^4.2.5",
-                "@smithy/protocol-http": "^5.3.5",
-                "@smithy/signature-v4": "^5.3.5",
-                "@smithy/smithy-client": "^4.9.5",
-                "@smithy/types": "^4.9.0",
-                "@smithy/util-base64": "^4.3.0",
-                "@smithy/util-middleware": "^4.2.5",
-                "@smithy/util-utf8": "^4.2.0",
-                "tslib": "^2.6.2"
-            },
-            "engines": {
-                "node": ">=18.0.0"
-            }
-        },
-        "packages/jobs/node_modules/@aws-sdk/credential-provider-http/node_modules/@aws-sdk/types": {
-            "version": "3.930.0",
-            "resolved": "https://registry.npmjs.org/@aws-sdk/types/-/types-3.930.0.tgz",
-            "integrity": "sha512-we/vaAgwlEFW7IeftmCLlLMw+6hFs3DzZPJw7lVHbj/5HJ0bz9gndxEsS2lQoeJ1zhiiLqAqvXxmM43s0MBg0A==",
-            "license": "Apache-2.0",
-            "dependencies": {
-                "@smithy/types": "^4.9.0",
-                "tslib": "^2.6.2"
-            },
-            "engines": {
-                "node": ">=18.0.0"
-            }
-        },
-        "packages/jobs/node_modules/@aws-sdk/credential-provider-ini": {
-            "version": "3.932.0",
-            "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-ini/-/credential-provider-ini-3.932.0.tgz",
-            "integrity": "sha512-ZBjSAXVGy7danZRHCRMJQ7sBkG1Dz39thYlvTiUaf9BKZ+8ymeiFhuTeV1OkWUBBnY0ki2dVZJvboTqfINhNxA==",
-            "license": "Apache-2.0",
-            "dependencies": {
-                "@aws-sdk/core": "3.932.0",
-                "@aws-sdk/credential-provider-env": "3.932.0",
-                "@aws-sdk/credential-provider-http": "3.932.0",
-                "@aws-sdk/credential-provider-process": "3.932.0",
-                "@aws-sdk/credential-provider-sso": "3.932.0",
-                "@aws-sdk/credential-provider-web-identity": "3.932.0",
-                "@aws-sdk/nested-clients": "3.932.0",
-                "@aws-sdk/types": "3.930.0",
-                "@smithy/credential-provider-imds": "^4.2.5",
-                "@smithy/property-provider": "^4.2.5",
-                "@smithy/shared-ini-file-loader": "^4.4.0",
-                "@smithy/types": "^4.9.0",
-                "tslib": "^2.6.2"
-            },
-            "engines": {
-                "node": ">=18.0.0"
-            }
-        },
-        "packages/jobs/node_modules/@aws-sdk/credential-provider-ini/node_modules/@aws-sdk/core": {
-            "version": "3.932.0",
-            "resolved": "https://registry.npmjs.org/@aws-sdk/core/-/core-3.932.0.tgz",
-            "integrity": "sha512-AS8gypYQCbNojwgjvZGkJocC2CoEICDx9ZJ15ILsv+MlcCVLtUJSRSx3VzJOUY2EEIaGLRrPNlIqyn/9/fySvA==",
-            "license": "Apache-2.0",
-            "dependencies": {
-                "@aws-sdk/types": "3.930.0",
-                "@aws-sdk/xml-builder": "3.930.0",
-                "@smithy/core": "^3.18.2",
-                "@smithy/node-config-provider": "^4.3.5",
-                "@smithy/property-provider": "^4.2.5",
-                "@smithy/protocol-http": "^5.3.5",
-                "@smithy/signature-v4": "^5.3.5",
-                "@smithy/smithy-client": "^4.9.5",
-                "@smithy/types": "^4.9.0",
-                "@smithy/util-base64": "^4.3.0",
-                "@smithy/util-middleware": "^4.2.5",
-                "@smithy/util-utf8": "^4.2.0",
-                "tslib": "^2.6.2"
-            },
-            "engines": {
-                "node": ">=18.0.0"
-            }
-        },
-        "packages/jobs/node_modules/@aws-sdk/credential-provider-ini/node_modules/@aws-sdk/types": {
-            "version": "3.930.0",
-            "resolved": "https://registry.npmjs.org/@aws-sdk/types/-/types-3.930.0.tgz",
-            "integrity": "sha512-we/vaAgwlEFW7IeftmCLlLMw+6hFs3DzZPJw7lVHbj/5HJ0bz9gndxEsS2lQoeJ1zhiiLqAqvXxmM43s0MBg0A==",
-            "license": "Apache-2.0",
-            "dependencies": {
-                "@smithy/types": "^4.9.0",
-                "tslib": "^2.6.2"
-            },
-            "engines": {
-                "node": ">=18.0.0"
-            }
-        },
-        "packages/jobs/node_modules/@aws-sdk/credential-provider-process": {
-            "version": "3.932.0",
-            "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-process/-/credential-provider-process-3.932.0.tgz",
-            "integrity": "sha512-BodZYKvT4p/Dkm28Ql/FhDdS1+p51bcZeMMu2TRtU8PoMDHnVDhHz27zASEKSZwmhvquxHrZHB0IGuVqjZUtSQ==",
-            "license": "Apache-2.0",
-            "dependencies": {
-                "@aws-sdk/core": "3.932.0",
-                "@aws-sdk/types": "3.930.0",
-                "@smithy/property-provider": "^4.2.5",
-                "@smithy/shared-ini-file-loader": "^4.4.0",
-                "@smithy/types": "^4.9.0",
-                "tslib": "^2.6.2"
-            },
-            "engines": {
-                "node": ">=18.0.0"
-            }
-        },
-        "packages/jobs/node_modules/@aws-sdk/credential-provider-process/node_modules/@aws-sdk/core": {
-            "version": "3.932.0",
-            "resolved": "https://registry.npmjs.org/@aws-sdk/core/-/core-3.932.0.tgz",
-            "integrity": "sha512-AS8gypYQCbNojwgjvZGkJocC2CoEICDx9ZJ15ILsv+MlcCVLtUJSRSx3VzJOUY2EEIaGLRrPNlIqyn/9/fySvA==",
-            "license": "Apache-2.0",
-            "dependencies": {
-                "@aws-sdk/types": "3.930.0",
-                "@aws-sdk/xml-builder": "3.930.0",
-                "@smithy/core": "^3.18.2",
-                "@smithy/node-config-provider": "^4.3.5",
-                "@smithy/property-provider": "^4.2.5",
-                "@smithy/protocol-http": "^5.3.5",
-                "@smithy/signature-v4": "^5.3.5",
-                "@smithy/smithy-client": "^4.9.5",
-                "@smithy/types": "^4.9.0",
-                "@smithy/util-base64": "^4.3.0",
-                "@smithy/util-middleware": "^4.2.5",
-                "@smithy/util-utf8": "^4.2.0",
-                "tslib": "^2.6.2"
-            },
-            "engines": {
-                "node": ">=18.0.0"
-            }
-        },
-        "packages/jobs/node_modules/@aws-sdk/credential-provider-process/node_modules/@aws-sdk/types": {
-            "version": "3.930.0",
-            "resolved": "https://registry.npmjs.org/@aws-sdk/types/-/types-3.930.0.tgz",
-            "integrity": "sha512-we/vaAgwlEFW7IeftmCLlLMw+6hFs3DzZPJw7lVHbj/5HJ0bz9gndxEsS2lQoeJ1zhiiLqAqvXxmM43s0MBg0A==",
-            "license": "Apache-2.0",
-            "dependencies": {
-                "@smithy/types": "^4.9.0",
-                "tslib": "^2.6.2"
-            },
-            "engines": {
-                "node": ">=18.0.0"
-            }
-        },
-        "packages/jobs/node_modules/@aws-sdk/credential-provider-sso": {
-            "version": "3.932.0",
-            "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-sso/-/credential-provider-sso-3.932.0.tgz",
-            "integrity": "sha512-XYmkv+ltBjjmPZ6AmR1ZQZkQfD0uzG61M18/Lif3HAGxyg3dmod0aWx9aL6lj9SvxAGqzscrx5j4PkgLqjZruw==",
-            "license": "Apache-2.0",
-            "dependencies": {
-                "@aws-sdk/client-sso": "3.932.0",
-                "@aws-sdk/core": "3.932.0",
-                "@aws-sdk/token-providers": "3.932.0",
-                "@aws-sdk/types": "3.930.0",
-                "@smithy/property-provider": "^4.2.5",
-                "@smithy/shared-ini-file-loader": "^4.4.0",
-                "@smithy/types": "^4.9.0",
-                "tslib": "^2.6.2"
-            },
-            "engines": {
-                "node": ">=18.0.0"
-            }
-        },
-        "packages/jobs/node_modules/@aws-sdk/credential-provider-sso/node_modules/@aws-sdk/core": {
-            "version": "3.932.0",
-            "resolved": "https://registry.npmjs.org/@aws-sdk/core/-/core-3.932.0.tgz",
-            "integrity": "sha512-AS8gypYQCbNojwgjvZGkJocC2CoEICDx9ZJ15ILsv+MlcCVLtUJSRSx3VzJOUY2EEIaGLRrPNlIqyn/9/fySvA==",
-            "license": "Apache-2.0",
-            "dependencies": {
-                "@aws-sdk/types": "3.930.0",
-                "@aws-sdk/xml-builder": "3.930.0",
-                "@smithy/core": "^3.18.2",
-                "@smithy/node-config-provider": "^4.3.5",
-                "@smithy/property-provider": "^4.2.5",
-                "@smithy/protocol-http": "^5.3.5",
-                "@smithy/signature-v4": "^5.3.5",
-                "@smithy/smithy-client": "^4.9.5",
-                "@smithy/types": "^4.9.0",
-                "@smithy/util-base64": "^4.3.0",
-                "@smithy/util-middleware": "^4.2.5",
-                "@smithy/util-utf8": "^4.2.0",
-                "tslib": "^2.6.2"
-            },
-            "engines": {
-                "node": ">=18.0.0"
-            }
-        },
-        "packages/jobs/node_modules/@aws-sdk/credential-provider-sso/node_modules/@aws-sdk/types": {
-            "version": "3.930.0",
-            "resolved": "https://registry.npmjs.org/@aws-sdk/types/-/types-3.930.0.tgz",
-            "integrity": "sha512-we/vaAgwlEFW7IeftmCLlLMw+6hFs3DzZPJw7lVHbj/5HJ0bz9gndxEsS2lQoeJ1zhiiLqAqvXxmM43s0MBg0A==",
-            "license": "Apache-2.0",
-            "dependencies": {
-                "@smithy/types": "^4.9.0",
-                "tslib": "^2.6.2"
-            },
-            "engines": {
-                "node": ">=18.0.0"
-            }
-        },
-        "packages/jobs/node_modules/@aws-sdk/credential-provider-web-identity": {
-            "version": "3.932.0",
-            "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-web-identity/-/credential-provider-web-identity-3.932.0.tgz",
-            "integrity": "sha512-Yw/hYNnC1KHuVIQF9PkLXbuKN7ljx70OSbJYDRufllQvej3kRwNcqQSnzI1M4KaObccqKaE6srg22DqpPy9p8w==",
-            "license": "Apache-2.0",
-            "dependencies": {
-                "@aws-sdk/core": "3.932.0",
-                "@aws-sdk/nested-clients": "3.932.0",
-                "@aws-sdk/types": "3.930.0",
-                "@smithy/property-provider": "^4.2.5",
-                "@smithy/shared-ini-file-loader": "^4.4.0",
-                "@smithy/types": "^4.9.0",
-                "tslib": "^2.6.2"
-            },
-            "engines": {
-                "node": ">=18.0.0"
-            }
-        },
-        "packages/jobs/node_modules/@aws-sdk/credential-provider-web-identity/node_modules/@aws-sdk/core": {
-            "version": "3.932.0",
-            "resolved": "https://registry.npmjs.org/@aws-sdk/core/-/core-3.932.0.tgz",
-            "integrity": "sha512-AS8gypYQCbNojwgjvZGkJocC2CoEICDx9ZJ15ILsv+MlcCVLtUJSRSx3VzJOUY2EEIaGLRrPNlIqyn/9/fySvA==",
-            "license": "Apache-2.0",
-            "dependencies": {
-                "@aws-sdk/types": "3.930.0",
-                "@aws-sdk/xml-builder": "3.930.0",
-                "@smithy/core": "^3.18.2",
-                "@smithy/node-config-provider": "^4.3.5",
-                "@smithy/property-provider": "^4.2.5",
-                "@smithy/protocol-http": "^5.3.5",
-                "@smithy/signature-v4": "^5.3.5",
-                "@smithy/smithy-client": "^4.9.5",
-                "@smithy/types": "^4.9.0",
-                "@smithy/util-base64": "^4.3.0",
-                "@smithy/util-middleware": "^4.2.5",
-                "@smithy/util-utf8": "^4.2.0",
-                "tslib": "^2.6.2"
-            },
-            "engines": {
-                "node": ">=18.0.0"
-            }
-        },
-        "packages/jobs/node_modules/@aws-sdk/credential-provider-web-identity/node_modules/@aws-sdk/types": {
-            "version": "3.930.0",
-            "resolved": "https://registry.npmjs.org/@aws-sdk/types/-/types-3.930.0.tgz",
-            "integrity": "sha512-we/vaAgwlEFW7IeftmCLlLMw+6hFs3DzZPJw7lVHbj/5HJ0bz9gndxEsS2lQoeJ1zhiiLqAqvXxmM43s0MBg0A==",
-            "license": "Apache-2.0",
-            "dependencies": {
-                "@smithy/types": "^4.9.0",
-                "tslib": "^2.6.2"
-            },
-            "engines": {
-                "node": ">=18.0.0"
-            }
-        },
-        "packages/jobs/node_modules/@aws-sdk/middleware-bucket-endpoint": {
-            "version": "3.930.0",
-            "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-bucket-endpoint/-/middleware-bucket-endpoint-3.930.0.tgz",
-            "integrity": "sha512-cnCLWeKPYgvV4yRYPFH6pWMdUByvu2cy2BAlfsPpvnm4RaVioztyvxmQj5PmVN5fvWs5w/2d6U7le8X9iye2sA==",
-            "license": "Apache-2.0",
-            "dependencies": {
-                "@aws-sdk/types": "3.930.0",
-                "@aws-sdk/util-arn-parser": "3.893.0",
-                "@smithy/node-config-provider": "^4.3.5",
-                "@smithy/protocol-http": "^5.3.5",
-                "@smithy/types": "^4.9.0",
-                "@smithy/util-config-provider": "^4.2.0",
-                "tslib": "^2.6.2"
-            },
-            "engines": {
-                "node": ">=18.0.0"
-            }
-        },
-        "packages/jobs/node_modules/@aws-sdk/middleware-bucket-endpoint/node_modules/@aws-sdk/types": {
-            "version": "3.930.0",
-            "resolved": "https://registry.npmjs.org/@aws-sdk/types/-/types-3.930.0.tgz",
-            "integrity": "sha512-we/vaAgwlEFW7IeftmCLlLMw+6hFs3DzZPJw7lVHbj/5HJ0bz9gndxEsS2lQoeJ1zhiiLqAqvXxmM43s0MBg0A==",
-            "license": "Apache-2.0",
-            "dependencies": {
-                "@smithy/types": "^4.9.0",
-                "tslib": "^2.6.2"
-            },
-            "engines": {
-                "node": ">=18.0.0"
-            }
-        },
-        "packages/jobs/node_modules/@aws-sdk/middleware-expect-continue": {
-            "version": "3.930.0",
-            "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-expect-continue/-/middleware-expect-continue-3.930.0.tgz",
-            "integrity": "sha512-5HEQ+JU4DrLNWeY27wKg/jeVa8Suy62ivJHOSUf6e6hZdVIMx0h/kXS1fHEQNNiLu2IzSEP/bFXsKBaW7x7s0g==",
-            "license": "Apache-2.0",
-            "dependencies": {
-                "@aws-sdk/types": "3.930.0",
-                "@smithy/protocol-http": "^5.3.5",
-                "@smithy/types": "^4.9.0",
-                "tslib": "^2.6.2"
-            },
-            "engines": {
-                "node": ">=18.0.0"
-            }
-        },
-        "packages/jobs/node_modules/@aws-sdk/middleware-expect-continue/node_modules/@aws-sdk/types": {
-            "version": "3.930.0",
-            "resolved": "https://registry.npmjs.org/@aws-sdk/types/-/types-3.930.0.tgz",
-            "integrity": "sha512-we/vaAgwlEFW7IeftmCLlLMw+6hFs3DzZPJw7lVHbj/5HJ0bz9gndxEsS2lQoeJ1zhiiLqAqvXxmM43s0MBg0A==",
-            "license": "Apache-2.0",
-            "dependencies": {
-                "@smithy/types": "^4.9.0",
-                "tslib": "^2.6.2"
-            },
-            "engines": {
-                "node": ">=18.0.0"
-            }
-        },
-        "packages/jobs/node_modules/@aws-sdk/middleware-flexible-checksums": {
-            "version": "3.932.0",
-            "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-flexible-checksums/-/middleware-flexible-checksums-3.932.0.tgz",
-            "integrity": "sha512-hyvRz/XS/0HTHp9/Ld1mKwpOi7bZu5olI42+T112rkCTbt1bewkygzEl4oflY4H7cKMamQusYoL0yBUD/QSEvA==",
-            "license": "Apache-2.0",
-            "dependencies": {
-                "@aws-crypto/crc32": "5.2.0",
-                "@aws-crypto/crc32c": "5.2.0",
-                "@aws-crypto/util": "5.2.0",
-                "@aws-sdk/core": "3.932.0",
-                "@aws-sdk/types": "3.930.0",
-                "@smithy/is-array-buffer": "^4.2.0",
-                "@smithy/node-config-provider": "^4.3.5",
-                "@smithy/protocol-http": "^5.3.5",
-                "@smithy/types": "^4.9.0",
-                "@smithy/util-middleware": "^4.2.5",
-                "@smithy/util-stream": "^4.5.6",
-                "@smithy/util-utf8": "^4.2.0",
-                "tslib": "^2.6.2"
-            },
-            "engines": {
-                "node": ">=18.0.0"
-            }
-        },
-        "packages/jobs/node_modules/@aws-sdk/middleware-flexible-checksums/node_modules/@aws-sdk/core": {
-            "version": "3.932.0",
-            "resolved": "https://registry.npmjs.org/@aws-sdk/core/-/core-3.932.0.tgz",
-            "integrity": "sha512-AS8gypYQCbNojwgjvZGkJocC2CoEICDx9ZJ15ILsv+MlcCVLtUJSRSx3VzJOUY2EEIaGLRrPNlIqyn/9/fySvA==",
-            "license": "Apache-2.0",
-            "dependencies": {
-                "@aws-sdk/types": "3.930.0",
-                "@aws-sdk/xml-builder": "3.930.0",
-                "@smithy/core": "^3.18.2",
-                "@smithy/node-config-provider": "^4.3.5",
-                "@smithy/property-provider": "^4.2.5",
-                "@smithy/protocol-http": "^5.3.5",
-                "@smithy/signature-v4": "^5.3.5",
-                "@smithy/smithy-client": "^4.9.5",
-                "@smithy/types": "^4.9.0",
-                "@smithy/util-base64": "^4.3.0",
-                "@smithy/util-middleware": "^4.2.5",
-                "@smithy/util-utf8": "^4.2.0",
-                "tslib": "^2.6.2"
-            },
-            "engines": {
-                "node": ">=18.0.0"
-            }
-        },
-        "packages/jobs/node_modules/@aws-sdk/middleware-flexible-checksums/node_modules/@aws-sdk/types": {
-            "version": "3.930.0",
-            "resolved": "https://registry.npmjs.org/@aws-sdk/types/-/types-3.930.0.tgz",
-            "integrity": "sha512-we/vaAgwlEFW7IeftmCLlLMw+6hFs3DzZPJw7lVHbj/5HJ0bz9gndxEsS2lQoeJ1zhiiLqAqvXxmM43s0MBg0A==",
-            "license": "Apache-2.0",
-            "dependencies": {
-                "@smithy/types": "^4.9.0",
-                "tslib": "^2.6.2"
-            },
-            "engines": {
-                "node": ">=18.0.0"
-            }
-        },
-        "packages/jobs/node_modules/@aws-sdk/middleware-location-constraint": {
-            "version": "3.930.0",
-            "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-location-constraint/-/middleware-location-constraint-3.930.0.tgz",
-            "integrity": "sha512-QIGNsNUdRICog+LYqmtJ03PLze6h2KCORXUs5td/hAEjVP5DMmubhtrGg1KhWyctACluUH/E/yrD14p4pRXxwA==",
-            "license": "Apache-2.0",
-            "dependencies": {
-                "@aws-sdk/types": "3.930.0",
-                "@smithy/types": "^4.9.0",
-                "tslib": "^2.6.2"
-            },
-            "engines": {
-                "node": ">=18.0.0"
-            }
-        },
-        "packages/jobs/node_modules/@aws-sdk/middleware-location-constraint/node_modules/@aws-sdk/types": {
-            "version": "3.930.0",
-            "resolved": "https://registry.npmjs.org/@aws-sdk/types/-/types-3.930.0.tgz",
-            "integrity": "sha512-we/vaAgwlEFW7IeftmCLlLMw+6hFs3DzZPJw7lVHbj/5HJ0bz9gndxEsS2lQoeJ1zhiiLqAqvXxmM43s0MBg0A==",
-            "license": "Apache-2.0",
-            "dependencies": {
-                "@smithy/types": "^4.9.0",
-                "tslib": "^2.6.2"
-            },
-            "engines": {
-                "node": ">=18.0.0"
-            }
-        },
-        "packages/jobs/node_modules/@aws-sdk/middleware-sdk-s3": {
-            "version": "3.932.0",
-            "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-sdk-s3/-/middleware-sdk-s3-3.932.0.tgz",
-            "integrity": "sha512-bYMHxqQzseaAP9Z5qLI918z5AtbAnZRRtFi3POb4FLZyreBMgCgBNaPkIhdgywnkqaydTWvbMBX4s9f4gUwlTw==",
-            "license": "Apache-2.0",
-            "dependencies": {
-                "@aws-sdk/core": "3.932.0",
-                "@aws-sdk/types": "3.930.0",
-                "@aws-sdk/util-arn-parser": "3.893.0",
-                "@smithy/core": "^3.18.2",
-                "@smithy/node-config-provider": "^4.3.5",
-                "@smithy/protocol-http": "^5.3.5",
-                "@smithy/signature-v4": "^5.3.5",
-                "@smithy/smithy-client": "^4.9.5",
-                "@smithy/types": "^4.9.0",
-                "@smithy/util-config-provider": "^4.2.0",
-                "@smithy/util-middleware": "^4.2.5",
-                "@smithy/util-stream": "^4.5.6",
-                "@smithy/util-utf8": "^4.2.0",
-                "tslib": "^2.6.2"
-            },
-            "engines": {
-                "node": ">=18.0.0"
-            }
-        },
-        "packages/jobs/node_modules/@aws-sdk/middleware-sdk-s3/node_modules/@aws-sdk/core": {
-            "version": "3.932.0",
-            "resolved": "https://registry.npmjs.org/@aws-sdk/core/-/core-3.932.0.tgz",
-            "integrity": "sha512-AS8gypYQCbNojwgjvZGkJocC2CoEICDx9ZJ15ILsv+MlcCVLtUJSRSx3VzJOUY2EEIaGLRrPNlIqyn/9/fySvA==",
-            "license": "Apache-2.0",
-            "dependencies": {
-                "@aws-sdk/types": "3.930.0",
-                "@aws-sdk/xml-builder": "3.930.0",
-                "@smithy/core": "^3.18.2",
-                "@smithy/node-config-provider": "^4.3.5",
-                "@smithy/property-provider": "^4.2.5",
-                "@smithy/protocol-http": "^5.3.5",
-                "@smithy/signature-v4": "^5.3.5",
-                "@smithy/smithy-client": "^4.9.5",
-                "@smithy/types": "^4.9.0",
-                "@smithy/util-base64": "^4.3.0",
-                "@smithy/util-middleware": "^4.2.5",
-                "@smithy/util-utf8": "^4.2.0",
-                "tslib": "^2.6.2"
-            },
-            "engines": {
-                "node": ">=18.0.0"
-            }
-        },
-        "packages/jobs/node_modules/@aws-sdk/middleware-sdk-s3/node_modules/@aws-sdk/types": {
-            "version": "3.930.0",
-            "resolved": "https://registry.npmjs.org/@aws-sdk/types/-/types-3.930.0.tgz",
-            "integrity": "sha512-we/vaAgwlEFW7IeftmCLlLMw+6hFs3DzZPJw7lVHbj/5HJ0bz9gndxEsS2lQoeJ1zhiiLqAqvXxmM43s0MBg0A==",
-            "license": "Apache-2.0",
-            "dependencies": {
-                "@smithy/types": "^4.9.0",
-                "tslib": "^2.6.2"
-            },
-            "engines": {
-                "node": ">=18.0.0"
-            }
-        },
-        "packages/jobs/node_modules/@aws-sdk/middleware-sdk-sqs": {
-            "version": "3.930.0",
-            "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-sdk-sqs/-/middleware-sdk-sqs-3.930.0.tgz",
-            "integrity": "sha512-Sk/VgUC9LTLloWUJHSLw9EkGukQHb/54rF1p9qJgJByQJLPmBd4oKiEGmKImVyUo/RN9BUPgNlNLWPUON6ySmQ==",
-            "license": "Apache-2.0",
-            "dependencies": {
-                "@aws-sdk/types": "3.930.0",
-                "@smithy/smithy-client": "^4.9.5",
-                "@smithy/types": "^4.9.0",
-                "@smithy/util-hex-encoding": "^4.2.0",
-                "@smithy/util-utf8": "^4.2.0",
-                "tslib": "^2.6.2"
-            },
-            "engines": {
-                "node": ">=18.0.0"
-            }
-        },
-        "packages/jobs/node_modules/@aws-sdk/middleware-sdk-sqs/node_modules/@aws-sdk/types": {
-            "version": "3.930.0",
-            "resolved": "https://registry.npmjs.org/@aws-sdk/types/-/types-3.930.0.tgz",
-            "integrity": "sha512-we/vaAgwlEFW7IeftmCLlLMw+6hFs3DzZPJw7lVHbj/5HJ0bz9gndxEsS2lQoeJ1zhiiLqAqvXxmM43s0MBg0A==",
-            "license": "Apache-2.0",
-            "dependencies": {
-                "@smithy/types": "^4.9.0",
-                "tslib": "^2.6.2"
-            },
-            "engines": {
-                "node": ">=18.0.0"
-            }
-        },
-        "packages/jobs/node_modules/@aws-sdk/middleware-ssec": {
-            "version": "3.930.0",
-            "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-ssec/-/middleware-ssec-3.930.0.tgz",
-            "integrity": "sha512-N2/SvodmaDS6h7CWfuapt3oJyn1T2CBz0CsDIiTDv9cSagXAVFjPdm2g4PFJqrNBeqdDIoYBnnta336HmamWHg==",
-            "license": "Apache-2.0",
-            "dependencies": {
-                "@aws-sdk/types": "3.930.0",
-                "@smithy/types": "^4.9.0",
-                "tslib": "^2.6.2"
-            },
-            "engines": {
-                "node": ">=18.0.0"
-            }
-        },
-        "packages/jobs/node_modules/@aws-sdk/middleware-ssec/node_modules/@aws-sdk/types": {
-            "version": "3.930.0",
-            "resolved": "https://registry.npmjs.org/@aws-sdk/types/-/types-3.930.0.tgz",
-            "integrity": "sha512-we/vaAgwlEFW7IeftmCLlLMw+6hFs3DzZPJw7lVHbj/5HJ0bz9gndxEsS2lQoeJ1zhiiLqAqvXxmM43s0MBg0A==",
-            "license": "Apache-2.0",
-            "dependencies": {
-                "@smithy/types": "^4.9.0",
-                "tslib": "^2.6.2"
-            },
-            "engines": {
-                "node": ">=18.0.0"
-            }
-        },
-        "packages/jobs/node_modules/@aws-sdk/nested-clients": {
-            "version": "3.932.0",
-            "resolved": "https://registry.npmjs.org/@aws-sdk/nested-clients/-/nested-clients-3.932.0.tgz",
-            "integrity": "sha512-E2ucBfiXSpxZflHTf3UFbVwao4+7v7ctAeg8SWuglc1UMqMlpwMFFgWiSONtsf0SR3+ZDoWGATyCXOfDWerJuw==",
-            "license": "Apache-2.0",
-            "dependencies": {
-                "@aws-crypto/sha256-browser": "5.2.0",
-                "@aws-crypto/sha256-js": "5.2.0",
-                "@aws-sdk/core": "3.932.0",
-                "@aws-sdk/middleware-host-header": "3.930.0",
-                "@aws-sdk/middleware-logger": "3.930.0",
-                "@aws-sdk/middleware-recursion-detection": "3.930.0",
-                "@aws-sdk/middleware-user-agent": "3.932.0",
-                "@aws-sdk/region-config-resolver": "3.930.0",
-                "@aws-sdk/types": "3.930.0",
-                "@aws-sdk/util-endpoints": "3.930.0",
-                "@aws-sdk/util-user-agent-browser": "3.930.0",
-                "@aws-sdk/util-user-agent-node": "3.932.0",
-                "@smithy/config-resolver": "^4.4.3",
-                "@smithy/core": "^3.18.2",
-                "@smithy/fetch-http-handler": "^5.3.6",
-                "@smithy/hash-node": "^4.2.5",
-                "@smithy/invalid-dependency": "^4.2.5",
-                "@smithy/middleware-content-length": "^4.2.5",
-                "@smithy/middleware-endpoint": "^4.3.9",
-                "@smithy/middleware-retry": "^4.4.9",
-                "@smithy/middleware-serde": "^4.2.5",
-                "@smithy/middleware-stack": "^4.2.5",
-                "@smithy/node-config-provider": "^4.3.5",
-                "@smithy/node-http-handler": "^4.4.5",
-                "@smithy/protocol-http": "^5.3.5",
-                "@smithy/smithy-client": "^4.9.5",
-                "@smithy/types": "^4.9.0",
-                "@smithy/url-parser": "^4.2.5",
-                "@smithy/util-base64": "^4.3.0",
-                "@smithy/util-body-length-browser": "^4.2.0",
-                "@smithy/util-body-length-node": "^4.2.1",
-                "@smithy/util-defaults-mode-browser": "^4.3.8",
-                "@smithy/util-defaults-mode-node": "^4.2.11",
-                "@smithy/util-endpoints": "^3.2.5",
-                "@smithy/util-middleware": "^4.2.5",
-                "@smithy/util-retry": "^4.2.5",
-                "@smithy/util-utf8": "^4.2.0",
-                "tslib": "^2.6.2"
-            },
-            "engines": {
-                "node": ">=18.0.0"
-            }
-        },
-        "packages/jobs/node_modules/@aws-sdk/nested-clients/node_modules/@aws-sdk/core": {
-            "version": "3.932.0",
-            "resolved": "https://registry.npmjs.org/@aws-sdk/core/-/core-3.932.0.tgz",
-            "integrity": "sha512-AS8gypYQCbNojwgjvZGkJocC2CoEICDx9ZJ15ILsv+MlcCVLtUJSRSx3VzJOUY2EEIaGLRrPNlIqyn/9/fySvA==",
-            "license": "Apache-2.0",
-            "dependencies": {
-                "@aws-sdk/types": "3.930.0",
-                "@aws-sdk/xml-builder": "3.930.0",
-                "@smithy/core": "^3.18.2",
-                "@smithy/node-config-provider": "^4.3.5",
-                "@smithy/property-provider": "^4.2.5",
-                "@smithy/protocol-http": "^5.3.5",
-                "@smithy/signature-v4": "^5.3.5",
-                "@smithy/smithy-client": "^4.9.5",
-                "@smithy/types": "^4.9.0",
-                "@smithy/util-base64": "^4.3.0",
-                "@smithy/util-middleware": "^4.2.5",
-                "@smithy/util-utf8": "^4.2.0",
-                "tslib": "^2.6.2"
-            },
-            "engines": {
-                "node": ">=18.0.0"
-            }
-        },
-        "packages/jobs/node_modules/@aws-sdk/nested-clients/node_modules/@aws-sdk/middleware-host-header": {
-            "version": "3.930.0",
-            "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-host-header/-/middleware-host-header-3.930.0.tgz",
-            "integrity": "sha512-x30jmm3TLu7b/b+67nMyoV0NlbnCVT5DI57yDrhXAPCtdgM1KtdLWt45UcHpKOm1JsaIkmYRh2WYu7Anx4MG0g==",
-            "license": "Apache-2.0",
-            "dependencies": {
-                "@aws-sdk/types": "3.930.0",
-                "@smithy/protocol-http": "^5.3.5",
-                "@smithy/types": "^4.9.0",
-                "tslib": "^2.6.2"
-            },
-            "engines": {
-                "node": ">=18.0.0"
-            }
-        },
-        "packages/jobs/node_modules/@aws-sdk/nested-clients/node_modules/@aws-sdk/middleware-logger": {
-            "version": "3.930.0",
-            "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-logger/-/middleware-logger-3.930.0.tgz",
-            "integrity": "sha512-vh4JBWzMCBW8wREvAwoSqB2geKsZwSHTa0nSt0OMOLp2PdTYIZDi0ZiVMmpfnjcx9XbS6aSluLv9sKx4RrG46A==",
-            "license": "Apache-2.0",
-            "dependencies": {
-                "@aws-sdk/types": "3.930.0",
-                "@smithy/types": "^4.9.0",
-                "tslib": "^2.6.2"
-            },
-            "engines": {
-                "node": ">=18.0.0"
-            }
-        },
-        "packages/jobs/node_modules/@aws-sdk/nested-clients/node_modules/@aws-sdk/middleware-recursion-detection": {
-            "version": "3.930.0",
-            "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-recursion-detection/-/middleware-recursion-detection-3.930.0.tgz",
-            "integrity": "sha512-gv0sekNpa2MBsIhm2cjP3nmYSfI4nscx/+K9u9ybrWZBWUIC4kL2sV++bFjjUz4QxUIlvKByow3/a9ARQyCu7Q==",
-            "license": "Apache-2.0",
-            "dependencies": {
-                "@aws-sdk/types": "3.930.0",
-                "@aws/lambda-invoke-store": "^0.1.1",
-                "@smithy/protocol-http": "^5.3.5",
-                "@smithy/types": "^4.9.0",
-                "tslib": "^2.6.2"
-            },
-            "engines": {
-                "node": ">=18.0.0"
-            }
-        },
-        "packages/jobs/node_modules/@aws-sdk/nested-clients/node_modules/@aws-sdk/middleware-user-agent": {
-            "version": "3.932.0",
-            "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-user-agent/-/middleware-user-agent-3.932.0.tgz",
-            "integrity": "sha512-9BGTbJyA/4PTdwQWE9hAFIJGpsYkyEW20WON3i15aDqo5oRZwZmqaVageOD57YYqG8JDJjvcwKyDdR4cc38dvg==",
-            "license": "Apache-2.0",
-            "dependencies": {
-                "@aws-sdk/core": "3.932.0",
-                "@aws-sdk/types": "3.930.0",
-                "@aws-sdk/util-endpoints": "3.930.0",
-                "@smithy/core": "^3.18.2",
-                "@smithy/protocol-http": "^5.3.5",
-                "@smithy/types": "^4.9.0",
-                "tslib": "^2.6.2"
-            },
-            "engines": {
-                "node": ">=18.0.0"
-            }
-        },
-        "packages/jobs/node_modules/@aws-sdk/nested-clients/node_modules/@aws-sdk/region-config-resolver": {
-            "version": "3.930.0",
-            "resolved": "https://registry.npmjs.org/@aws-sdk/region-config-resolver/-/region-config-resolver-3.930.0.tgz",
-            "integrity": "sha512-KL2JZqH6aYeQssu1g1KuWsReupdfOoxD6f1as2VC+rdwYFUu4LfzMsFfXnBvvQWWqQ7rZHWOw1T+o5gJmg7Dzw==",
-            "license": "Apache-2.0",
-            "dependencies": {
-                "@aws-sdk/types": "3.930.0",
-                "@smithy/config-resolver": "^4.4.3",
-                "@smithy/node-config-provider": "^4.3.5",
-                "@smithy/types": "^4.9.0",
-                "tslib": "^2.6.2"
-            },
-            "engines": {
-                "node": ">=18.0.0"
-            }
-        },
-        "packages/jobs/node_modules/@aws-sdk/nested-clients/node_modules/@aws-sdk/types": {
-            "version": "3.930.0",
-            "resolved": "https://registry.npmjs.org/@aws-sdk/types/-/types-3.930.0.tgz",
-            "integrity": "sha512-we/vaAgwlEFW7IeftmCLlLMw+6hFs3DzZPJw7lVHbj/5HJ0bz9gndxEsS2lQoeJ1zhiiLqAqvXxmM43s0MBg0A==",
-            "license": "Apache-2.0",
-            "dependencies": {
-                "@smithy/types": "^4.9.0",
-                "tslib": "^2.6.2"
-            },
-            "engines": {
-                "node": ">=18.0.0"
-            }
-        },
-        "packages/jobs/node_modules/@aws-sdk/nested-clients/node_modules/@aws-sdk/util-endpoints": {
-            "version": "3.930.0",
-            "resolved": "https://registry.npmjs.org/@aws-sdk/util-endpoints/-/util-endpoints-3.930.0.tgz",
-            "integrity": "sha512-M2oEKBzzNAYr136RRc6uqw3aWlwCxqTP1Lawps9E1d2abRPvl1p1ztQmmXp1Ak4rv8eByIZ+yQyKQ3zPdRG5dw==",
-            "license": "Apache-2.0",
-            "dependencies": {
-                "@aws-sdk/types": "3.930.0",
-                "@smithy/types": "^4.9.0",
-                "@smithy/url-parser": "^4.2.5",
-                "@smithy/util-endpoints": "^3.2.5",
-                "tslib": "^2.6.2"
-            },
-            "engines": {
-                "node": ">=18.0.0"
-            }
-        },
-        "packages/jobs/node_modules/@aws-sdk/nested-clients/node_modules/@aws-sdk/util-user-agent-browser": {
-            "version": "3.930.0",
-            "resolved": "https://registry.npmjs.org/@aws-sdk/util-user-agent-browser/-/util-user-agent-browser-3.930.0.tgz",
-            "integrity": "sha512-q6lCRm6UAe+e1LguM5E4EqM9brQlDem4XDcQ87NzEvlTW6GzmNCO0w1jS0XgCFXQHjDxjdlNFX+5sRbHijwklg==",
-            "license": "Apache-2.0",
-            "dependencies": {
-                "@aws-sdk/types": "3.930.0",
-                "@smithy/types": "^4.9.0",
-                "bowser": "^2.11.0",
-                "tslib": "^2.6.2"
-            }
-        },
-        "packages/jobs/node_modules/@aws-sdk/nested-clients/node_modules/@aws-sdk/util-user-agent-node": {
-            "version": "3.932.0",
-            "resolved": "https://registry.npmjs.org/@aws-sdk/util-user-agent-node/-/util-user-agent-node-3.932.0.tgz",
-            "integrity": "sha512-/kC6cscHrZL74TrZtgiIL5jJNbVsw9duGGPurmaVgoCbP7NnxyaSWEurbNV3VPNPhNE3bV3g4Ci+odq+AlsYQg==",
-            "license": "Apache-2.0",
-            "dependencies": {
-                "@aws-sdk/middleware-user-agent": "3.932.0",
-                "@aws-sdk/types": "3.930.0",
-                "@smithy/node-config-provider": "^4.3.5",
-                "@smithy/types": "^4.9.0",
-                "tslib": "^2.6.2"
-            },
-            "engines": {
-                "node": ">=18.0.0"
-            },
-            "peerDependencies": {
-                "aws-crt": ">=1.0.0"
-            },
-            "peerDependenciesMeta": {
-                "aws-crt": {
-                    "optional": true
-                }
-            }
-        },
-        "packages/jobs/node_modules/@aws-sdk/signature-v4-multi-region": {
-            "version": "3.932.0",
-            "resolved": "https://registry.npmjs.org/@aws-sdk/signature-v4-multi-region/-/signature-v4-multi-region-3.932.0.tgz",
-            "integrity": "sha512-NCIRJvoRc9246RZHIusY1+n/neeG2yGhBGdKhghmrNdM+mLLN6Ii7CKFZjx3DhxtpHMpl1HWLTMhdVrGwP2upw==",
-            "license": "Apache-2.0",
-            "dependencies": {
-                "@aws-sdk/middleware-sdk-s3": "3.932.0",
-                "@aws-sdk/types": "3.930.0",
-                "@smithy/protocol-http": "^5.3.5",
-                "@smithy/signature-v4": "^5.3.5",
-                "@smithy/types": "^4.9.0",
-                "tslib": "^2.6.2"
-            },
-            "engines": {
-                "node": ">=18.0.0"
-            }
-        },
-        "packages/jobs/node_modules/@aws-sdk/signature-v4-multi-region/node_modules/@aws-sdk/types": {
-            "version": "3.930.0",
-            "resolved": "https://registry.npmjs.org/@aws-sdk/types/-/types-3.930.0.tgz",
-            "integrity": "sha512-we/vaAgwlEFW7IeftmCLlLMw+6hFs3DzZPJw7lVHbj/5HJ0bz9gndxEsS2lQoeJ1zhiiLqAqvXxmM43s0MBg0A==",
-            "license": "Apache-2.0",
-            "dependencies": {
-                "@smithy/types": "^4.9.0",
-                "tslib": "^2.6.2"
-            },
-            "engines": {
-                "node": ">=18.0.0"
-            }
-        },
-        "packages/jobs/node_modules/@aws-sdk/token-providers": {
-            "version": "3.932.0",
-            "resolved": "https://registry.npmjs.org/@aws-sdk/token-providers/-/token-providers-3.932.0.tgz",
-            "integrity": "sha512-43u82ulVuHK4zWhcSPyuPS18l0LNHi3QJQ1YtP2MfP8bPf5a6hMYp5e3lUr9oTDEWcpwBYtOW0m1DVmoU/3veA==",
-            "license": "Apache-2.0",
-            "dependencies": {
-                "@aws-sdk/core": "3.932.0",
-                "@aws-sdk/nested-clients": "3.932.0",
-                "@aws-sdk/types": "3.930.0",
-                "@smithy/property-provider": "^4.2.5",
-                "@smithy/shared-ini-file-loader": "^4.4.0",
-                "@smithy/types": "^4.9.0",
-                "tslib": "^2.6.2"
-            },
-            "engines": {
-                "node": ">=18.0.0"
-            }
-        },
-        "packages/jobs/node_modules/@aws-sdk/token-providers/node_modules/@aws-sdk/core": {
-            "version": "3.932.0",
-            "resolved": "https://registry.npmjs.org/@aws-sdk/core/-/core-3.932.0.tgz",
-            "integrity": "sha512-AS8gypYQCbNojwgjvZGkJocC2CoEICDx9ZJ15ILsv+MlcCVLtUJSRSx3VzJOUY2EEIaGLRrPNlIqyn/9/fySvA==",
-            "license": "Apache-2.0",
-            "dependencies": {
-                "@aws-sdk/types": "3.930.0",
-                "@aws-sdk/xml-builder": "3.930.0",
-                "@smithy/core": "^3.18.2",
-                "@smithy/node-config-provider": "^4.3.5",
-                "@smithy/property-provider": "^4.2.5",
-                "@smithy/protocol-http": "^5.3.5",
-                "@smithy/signature-v4": "^5.3.5",
-                "@smithy/smithy-client": "^4.9.5",
-                "@smithy/types": "^4.9.0",
-                "@smithy/util-base64": "^4.3.0",
-                "@smithy/util-middleware": "^4.2.5",
-                "@smithy/util-utf8": "^4.2.0",
-                "tslib": "^2.6.2"
-            },
-            "engines": {
-                "node": ">=18.0.0"
-            }
-        },
-        "packages/jobs/node_modules/@aws-sdk/token-providers/node_modules/@aws-sdk/types": {
-            "version": "3.930.0",
-            "resolved": "https://registry.npmjs.org/@aws-sdk/types/-/types-3.930.0.tgz",
-            "integrity": "sha512-we/vaAgwlEFW7IeftmCLlLMw+6hFs3DzZPJw7lVHbj/5HJ0bz9gndxEsS2lQoeJ1zhiiLqAqvXxmM43s0MBg0A==",
-            "license": "Apache-2.0",
-            "dependencies": {
-                "@smithy/types": "^4.9.0",
-                "tslib": "^2.6.2"
-            },
-            "engines": {
-                "node": ">=18.0.0"
-            }
-        },
-        "packages/jobs/node_modules/@aws-sdk/util-arn-parser": {
-            "version": "3.893.0",
-            "resolved": "https://registry.npmjs.org/@aws-sdk/util-arn-parser/-/util-arn-parser-3.893.0.tgz",
-            "integrity": "sha512-u8H4f2Zsi19DGnwj5FSZzDMhytYF/bCh37vAtBsn3cNDL3YG578X5oc+wSX54pM3tOxS+NY7tvOAo52SW7koUA==",
-            "license": "Apache-2.0",
-            "dependencies": {
-                "tslib": "^2.6.2"
-            },
-            "engines": {
-                "node": ">=18.0.0"
-            }
-        },
-        "packages/jobs/node_modules/@aws-sdk/xml-builder": {
-            "version": "3.930.0",
-            "resolved": "https://registry.npmjs.org/@aws-sdk/xml-builder/-/xml-builder-3.930.0.tgz",
-            "integrity": "sha512-YIfkD17GocxdmlUVc3ia52QhcWuRIUJonbF8A2CYfcWNV3HzvAqpcPeC0bYUhkK+8e8YO1ARnLKZQE0TlwzorA==",
-            "license": "Apache-2.0",
-            "dependencies": {
-                "@smithy/types": "^4.9.0",
-                "fast-xml-parser": "5.2.5",
-                "tslib": "^2.6.2"
-            },
-            "engines": {
-                "node": ">=18.0.0"
-            }
-        },
-        "packages/jobs/node_modules/@aws/lambda-invoke-store": {
-            "version": "0.1.1",
-            "resolved": "https://registry.npmjs.org/@aws/lambda-invoke-store/-/lambda-invoke-store-0.1.1.tgz",
-            "integrity": "sha512-RcLam17LdlbSOSp9VxmUu1eI6Mwxp+OwhD2QhiSNmNCzoDb0EeUXTD2n/WbcnrAYMGlmf05th6QYq23VqvJqpA==",
-            "license": "Apache-2.0",
-            "engines": {
-                "node": ">=18.0.0"
-            }
-        },
-        "packages/jobs/node_modules/fast-xml-parser": {
-            "version": "5.2.5",
-            "resolved": "https://registry.npmjs.org/fast-xml-parser/-/fast-xml-parser-5.2.5.tgz",
-            "integrity": "sha512-pfX9uG9Ki0yekDHx2SiuRIyFdyAr1kMIMitPvb0YBo8SUfKvia7w7FIyd/l6av85pFYRhZscS75MwMnbvY+hcQ==",
-            "funding": [
-                {
-                    "type": "github",
-                    "url": "https://github.com/sponsors/NaturalIntelligence"
-                }
-            ],
-            "license": "MIT",
-            "dependencies": {
-                "strnum": "^2.1.0"
-            },
-            "bin": {
-                "fxparser": "src/cli/cli.js"
             }
         },
         "packages/jobs/node_modules/zod": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -534,56 +534,6 @@
                 "node": ">=14.0.0"
             }
         },
-        "node_modules/@aws-sdk/client-application-auto-scaling": {
-            "version": "3.993.0",
-            "resolved": "https://registry.npmjs.org/@aws-sdk/client-application-auto-scaling/-/client-application-auto-scaling-3.993.0.tgz",
-            "integrity": "sha512-vbFDZez35h4OW+acPwnQ1wsNm3nEddpL91/URX0ZoShAs697SxKW6LjaAYxdCAOvGBUtI+bch6zyPBhLLIOacQ==",
-            "license": "Apache-2.0",
-            "dependencies": {
-                "@aws-crypto/sha256-browser": "5.2.0",
-                "@aws-crypto/sha256-js": "5.2.0",
-                "@aws-sdk/core": "^3.973.11",
-                "@aws-sdk/credential-provider-node": "^3.972.10",
-                "@aws-sdk/middleware-host-header": "^3.972.3",
-                "@aws-sdk/middleware-logger": "^3.972.3",
-                "@aws-sdk/middleware-recursion-detection": "^3.972.3",
-                "@aws-sdk/middleware-user-agent": "^3.972.11",
-                "@aws-sdk/region-config-resolver": "^3.972.3",
-                "@aws-sdk/types": "^3.973.1",
-                "@aws-sdk/util-endpoints": "3.993.0",
-                "@aws-sdk/util-user-agent-browser": "^3.972.3",
-                "@aws-sdk/util-user-agent-node": "^3.972.9",
-                "@smithy/config-resolver": "^4.4.6",
-                "@smithy/core": "^3.23.2",
-                "@smithy/fetch-http-handler": "^5.3.9",
-                "@smithy/hash-node": "^4.2.8",
-                "@smithy/invalid-dependency": "^4.2.8",
-                "@smithy/middleware-content-length": "^4.2.8",
-                "@smithy/middleware-endpoint": "^4.4.16",
-                "@smithy/middleware-retry": "^4.4.33",
-                "@smithy/middleware-serde": "^4.2.9",
-                "@smithy/middleware-stack": "^4.2.8",
-                "@smithy/node-config-provider": "^4.3.8",
-                "@smithy/node-http-handler": "^4.4.10",
-                "@smithy/protocol-http": "^5.3.8",
-                "@smithy/smithy-client": "^4.11.5",
-                "@smithy/types": "^4.12.0",
-                "@smithy/url-parser": "^4.2.8",
-                "@smithy/util-base64": "^4.3.0",
-                "@smithy/util-body-length-browser": "^4.2.0",
-                "@smithy/util-body-length-node": "^4.2.1",
-                "@smithy/util-defaults-mode-browser": "^4.3.32",
-                "@smithy/util-defaults-mode-node": "^4.2.35",
-                "@smithy/util-endpoints": "^3.2.8",
-                "@smithy/util-middleware": "^4.2.8",
-                "@smithy/util-retry": "^4.2.8",
-                "@smithy/util-utf8": "^4.2.0",
-                "tslib": "^2.6.2"
-            },
-            "engines": {
-                "node": ">=20.0.0"
-            }
-        },
         "node_modules/@aws-sdk/client-ecr": {
             "version": "3.993.0",
             "resolved": "https://registry.npmjs.org/@aws-sdk/client-ecr/-/client-ecr-3.993.0.tgz",
@@ -627,61 +577,6 @@
                 "@smithy/util-endpoints": "^3.2.8",
                 "@smithy/util-middleware": "^4.2.8",
                 "@smithy/util-retry": "^4.2.8",
-                "@smithy/util-utf8": "^4.2.0",
-                "@smithy/util-waiter": "^4.2.8",
-                "tslib": "^2.6.2"
-            },
-            "engines": {
-                "node": ">=20.0.0"
-            }
-        },
-        "node_modules/@aws-sdk/client-lambda": {
-            "version": "3.993.0",
-            "resolved": "https://registry.npmjs.org/@aws-sdk/client-lambda/-/client-lambda-3.993.0.tgz",
-            "integrity": "sha512-bXUuyTeNjMEyzVdXnYUJFcRXr6NQJjQte3EqnixUkUDZcqbyL3lXQS3cQSUuzmSaQrUDiTqIvbGrQiKv2wTXpQ==",
-            "license": "Apache-2.0",
-            "dependencies": {
-                "@aws-crypto/sha256-browser": "5.2.0",
-                "@aws-crypto/sha256-js": "5.2.0",
-                "@aws-sdk/core": "^3.973.11",
-                "@aws-sdk/credential-provider-node": "^3.972.10",
-                "@aws-sdk/middleware-host-header": "^3.972.3",
-                "@aws-sdk/middleware-logger": "^3.972.3",
-                "@aws-sdk/middleware-recursion-detection": "^3.972.3",
-                "@aws-sdk/middleware-user-agent": "^3.972.11",
-                "@aws-sdk/region-config-resolver": "^3.972.3",
-                "@aws-sdk/types": "^3.973.1",
-                "@aws-sdk/util-endpoints": "3.993.0",
-                "@aws-sdk/util-user-agent-browser": "^3.972.3",
-                "@aws-sdk/util-user-agent-node": "^3.972.9",
-                "@smithy/config-resolver": "^4.4.6",
-                "@smithy/core": "^3.23.2",
-                "@smithy/eventstream-serde-browser": "^4.2.8",
-                "@smithy/eventstream-serde-config-resolver": "^4.3.8",
-                "@smithy/eventstream-serde-node": "^4.2.8",
-                "@smithy/fetch-http-handler": "^5.3.9",
-                "@smithy/hash-node": "^4.2.8",
-                "@smithy/invalid-dependency": "^4.2.8",
-                "@smithy/middleware-content-length": "^4.2.8",
-                "@smithy/middleware-endpoint": "^4.4.16",
-                "@smithy/middleware-retry": "^4.4.33",
-                "@smithy/middleware-serde": "^4.2.9",
-                "@smithy/middleware-stack": "^4.2.8",
-                "@smithy/node-config-provider": "^4.3.8",
-                "@smithy/node-http-handler": "^4.4.10",
-                "@smithy/protocol-http": "^5.3.8",
-                "@smithy/smithy-client": "^4.11.5",
-                "@smithy/types": "^4.12.0",
-                "@smithy/url-parser": "^4.2.8",
-                "@smithy/util-base64": "^4.3.0",
-                "@smithy/util-body-length-browser": "^4.2.0",
-                "@smithy/util-body-length-node": "^4.2.1",
-                "@smithy/util-defaults-mode-browser": "^4.3.32",
-                "@smithy/util-defaults-mode-node": "^4.2.35",
-                "@smithy/util-endpoints": "^3.2.8",
-                "@smithy/util-middleware": "^4.2.8",
-                "@smithy/util-retry": "^4.2.8",
-                "@smithy/util-stream": "^4.5.12",
                 "@smithy/util-utf8": "^4.2.0",
                 "@smithy/util-waiter": "^4.2.8",
                 "tslib": "^2.6.2"
@@ -856,6 +751,264 @@
             },
             "engines": {
                 "node": ">=20.0.0"
+            }
+        },
+        "node_modules/@aws-sdk/client-sso": {
+            "version": "3.932.0",
+            "resolved": "https://registry.npmjs.org/@aws-sdk/client-sso/-/client-sso-3.932.0.tgz",
+            "integrity": "sha512-XHqHa5iv2OQsKoM2tUQXs7EAyryploC00Wg0XSFra/KAKqyGizUb5XxXsGlyqhebB29Wqur+zwiRwNmejmN0+Q==",
+            "license": "Apache-2.0",
+            "dependencies": {
+                "@aws-crypto/sha256-browser": "5.2.0",
+                "@aws-crypto/sha256-js": "5.2.0",
+                "@aws-sdk/core": "3.932.0",
+                "@aws-sdk/middleware-host-header": "3.930.0",
+                "@aws-sdk/middleware-logger": "3.930.0",
+                "@aws-sdk/middleware-recursion-detection": "3.930.0",
+                "@aws-sdk/middleware-user-agent": "3.932.0",
+                "@aws-sdk/region-config-resolver": "3.930.0",
+                "@aws-sdk/types": "3.930.0",
+                "@aws-sdk/util-endpoints": "3.930.0",
+                "@aws-sdk/util-user-agent-browser": "3.930.0",
+                "@aws-sdk/util-user-agent-node": "3.932.0",
+                "@smithy/config-resolver": "^4.4.3",
+                "@smithy/core": "^3.18.2",
+                "@smithy/fetch-http-handler": "^5.3.6",
+                "@smithy/hash-node": "^4.2.5",
+                "@smithy/invalid-dependency": "^4.2.5",
+                "@smithy/middleware-content-length": "^4.2.5",
+                "@smithy/middleware-endpoint": "^4.3.9",
+                "@smithy/middleware-retry": "^4.4.9",
+                "@smithy/middleware-serde": "^4.2.5",
+                "@smithy/middleware-stack": "^4.2.5",
+                "@smithy/node-config-provider": "^4.3.5",
+                "@smithy/node-http-handler": "^4.4.5",
+                "@smithy/protocol-http": "^5.3.5",
+                "@smithy/smithy-client": "^4.9.5",
+                "@smithy/types": "^4.9.0",
+                "@smithy/url-parser": "^4.2.5",
+                "@smithy/util-base64": "^4.3.0",
+                "@smithy/util-body-length-browser": "^4.2.0",
+                "@smithy/util-body-length-node": "^4.2.1",
+                "@smithy/util-defaults-mode-browser": "^4.3.8",
+                "@smithy/util-defaults-mode-node": "^4.2.11",
+                "@smithy/util-endpoints": "^3.2.5",
+                "@smithy/util-middleware": "^4.2.5",
+                "@smithy/util-retry": "^4.2.5",
+                "@smithy/util-utf8": "^4.2.0",
+                "tslib": "^2.6.2"
+            },
+            "engines": {
+                "node": ">=18.0.0"
+            }
+        },
+        "node_modules/@aws-sdk/client-sso/node_modules/@aws-sdk/core": {
+            "version": "3.932.0",
+            "resolved": "https://registry.npmjs.org/@aws-sdk/core/-/core-3.932.0.tgz",
+            "integrity": "sha512-AS8gypYQCbNojwgjvZGkJocC2CoEICDx9ZJ15ILsv+MlcCVLtUJSRSx3VzJOUY2EEIaGLRrPNlIqyn/9/fySvA==",
+            "license": "Apache-2.0",
+            "dependencies": {
+                "@aws-sdk/types": "3.930.0",
+                "@aws-sdk/xml-builder": "3.930.0",
+                "@smithy/core": "^3.18.2",
+                "@smithy/node-config-provider": "^4.3.5",
+                "@smithy/property-provider": "^4.2.5",
+                "@smithy/protocol-http": "^5.3.5",
+                "@smithy/signature-v4": "^5.3.5",
+                "@smithy/smithy-client": "^4.9.5",
+                "@smithy/types": "^4.9.0",
+                "@smithy/util-base64": "^4.3.0",
+                "@smithy/util-middleware": "^4.2.5",
+                "@smithy/util-utf8": "^4.2.0",
+                "tslib": "^2.6.2"
+            },
+            "engines": {
+                "node": ">=18.0.0"
+            }
+        },
+        "node_modules/@aws-sdk/client-sso/node_modules/@aws-sdk/middleware-host-header": {
+            "version": "3.930.0",
+            "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-host-header/-/middleware-host-header-3.930.0.tgz",
+            "integrity": "sha512-x30jmm3TLu7b/b+67nMyoV0NlbnCVT5DI57yDrhXAPCtdgM1KtdLWt45UcHpKOm1JsaIkmYRh2WYu7Anx4MG0g==",
+            "license": "Apache-2.0",
+            "dependencies": {
+                "@aws-sdk/types": "3.930.0",
+                "@smithy/protocol-http": "^5.3.5",
+                "@smithy/types": "^4.9.0",
+                "tslib": "^2.6.2"
+            },
+            "engines": {
+                "node": ">=18.0.0"
+            }
+        },
+        "node_modules/@aws-sdk/client-sso/node_modules/@aws-sdk/middleware-logger": {
+            "version": "3.930.0",
+            "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-logger/-/middleware-logger-3.930.0.tgz",
+            "integrity": "sha512-vh4JBWzMCBW8wREvAwoSqB2geKsZwSHTa0nSt0OMOLp2PdTYIZDi0ZiVMmpfnjcx9XbS6aSluLv9sKx4RrG46A==",
+            "license": "Apache-2.0",
+            "dependencies": {
+                "@aws-sdk/types": "3.930.0",
+                "@smithy/types": "^4.9.0",
+                "tslib": "^2.6.2"
+            },
+            "engines": {
+                "node": ">=18.0.0"
+            }
+        },
+        "node_modules/@aws-sdk/client-sso/node_modules/@aws-sdk/middleware-recursion-detection": {
+            "version": "3.930.0",
+            "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-recursion-detection/-/middleware-recursion-detection-3.930.0.tgz",
+            "integrity": "sha512-gv0sekNpa2MBsIhm2cjP3nmYSfI4nscx/+K9u9ybrWZBWUIC4kL2sV++bFjjUz4QxUIlvKByow3/a9ARQyCu7Q==",
+            "license": "Apache-2.0",
+            "dependencies": {
+                "@aws-sdk/types": "3.930.0",
+                "@aws/lambda-invoke-store": "^0.1.1",
+                "@smithy/protocol-http": "^5.3.5",
+                "@smithy/types": "^4.9.0",
+                "tslib": "^2.6.2"
+            },
+            "engines": {
+                "node": ">=18.0.0"
+            }
+        },
+        "node_modules/@aws-sdk/client-sso/node_modules/@aws-sdk/middleware-user-agent": {
+            "version": "3.932.0",
+            "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-user-agent/-/middleware-user-agent-3.932.0.tgz",
+            "integrity": "sha512-9BGTbJyA/4PTdwQWE9hAFIJGpsYkyEW20WON3i15aDqo5oRZwZmqaVageOD57YYqG8JDJjvcwKyDdR4cc38dvg==",
+            "license": "Apache-2.0",
+            "dependencies": {
+                "@aws-sdk/core": "3.932.0",
+                "@aws-sdk/types": "3.930.0",
+                "@aws-sdk/util-endpoints": "3.930.0",
+                "@smithy/core": "^3.18.2",
+                "@smithy/protocol-http": "^5.3.5",
+                "@smithy/types": "^4.9.0",
+                "tslib": "^2.6.2"
+            },
+            "engines": {
+                "node": ">=18.0.0"
+            }
+        },
+        "node_modules/@aws-sdk/client-sso/node_modules/@aws-sdk/region-config-resolver": {
+            "version": "3.930.0",
+            "resolved": "https://registry.npmjs.org/@aws-sdk/region-config-resolver/-/region-config-resolver-3.930.0.tgz",
+            "integrity": "sha512-KL2JZqH6aYeQssu1g1KuWsReupdfOoxD6f1as2VC+rdwYFUu4LfzMsFfXnBvvQWWqQ7rZHWOw1T+o5gJmg7Dzw==",
+            "license": "Apache-2.0",
+            "dependencies": {
+                "@aws-sdk/types": "3.930.0",
+                "@smithy/config-resolver": "^4.4.3",
+                "@smithy/node-config-provider": "^4.3.5",
+                "@smithy/types": "^4.9.0",
+                "tslib": "^2.6.2"
+            },
+            "engines": {
+                "node": ">=18.0.0"
+            }
+        },
+        "node_modules/@aws-sdk/client-sso/node_modules/@aws-sdk/types": {
+            "version": "3.930.0",
+            "resolved": "https://registry.npmjs.org/@aws-sdk/types/-/types-3.930.0.tgz",
+            "integrity": "sha512-we/vaAgwlEFW7IeftmCLlLMw+6hFs3DzZPJw7lVHbj/5HJ0bz9gndxEsS2lQoeJ1zhiiLqAqvXxmM43s0MBg0A==",
+            "license": "Apache-2.0",
+            "dependencies": {
+                "@smithy/types": "^4.9.0",
+                "tslib": "^2.6.2"
+            },
+            "engines": {
+                "node": ">=18.0.0"
+            }
+        },
+        "node_modules/@aws-sdk/client-sso/node_modules/@aws-sdk/util-endpoints": {
+            "version": "3.930.0",
+            "resolved": "https://registry.npmjs.org/@aws-sdk/util-endpoints/-/util-endpoints-3.930.0.tgz",
+            "integrity": "sha512-M2oEKBzzNAYr136RRc6uqw3aWlwCxqTP1Lawps9E1d2abRPvl1p1ztQmmXp1Ak4rv8eByIZ+yQyKQ3zPdRG5dw==",
+            "license": "Apache-2.0",
+            "dependencies": {
+                "@aws-sdk/types": "3.930.0",
+                "@smithy/types": "^4.9.0",
+                "@smithy/url-parser": "^4.2.5",
+                "@smithy/util-endpoints": "^3.2.5",
+                "tslib": "^2.6.2"
+            },
+            "engines": {
+                "node": ">=18.0.0"
+            }
+        },
+        "node_modules/@aws-sdk/client-sso/node_modules/@aws-sdk/util-user-agent-browser": {
+            "version": "3.930.0",
+            "resolved": "https://registry.npmjs.org/@aws-sdk/util-user-agent-browser/-/util-user-agent-browser-3.930.0.tgz",
+            "integrity": "sha512-q6lCRm6UAe+e1LguM5E4EqM9brQlDem4XDcQ87NzEvlTW6GzmNCO0w1jS0XgCFXQHjDxjdlNFX+5sRbHijwklg==",
+            "license": "Apache-2.0",
+            "dependencies": {
+                "@aws-sdk/types": "3.930.0",
+                "@smithy/types": "^4.9.0",
+                "bowser": "^2.11.0",
+                "tslib": "^2.6.2"
+            }
+        },
+        "node_modules/@aws-sdk/client-sso/node_modules/@aws-sdk/util-user-agent-node": {
+            "version": "3.932.0",
+            "resolved": "https://registry.npmjs.org/@aws-sdk/util-user-agent-node/-/util-user-agent-node-3.932.0.tgz",
+            "integrity": "sha512-/kC6cscHrZL74TrZtgiIL5jJNbVsw9duGGPurmaVgoCbP7NnxyaSWEurbNV3VPNPhNE3bV3g4Ci+odq+AlsYQg==",
+            "license": "Apache-2.0",
+            "dependencies": {
+                "@aws-sdk/middleware-user-agent": "3.932.0",
+                "@aws-sdk/types": "3.930.0",
+                "@smithy/node-config-provider": "^4.3.5",
+                "@smithy/types": "^4.9.0",
+                "tslib": "^2.6.2"
+            },
+            "engines": {
+                "node": ">=18.0.0"
+            },
+            "peerDependencies": {
+                "aws-crt": ">=1.0.0"
+            },
+            "peerDependenciesMeta": {
+                "aws-crt": {
+                    "optional": true
+                }
+            }
+        },
+        "node_modules/@aws-sdk/client-sso/node_modules/@aws-sdk/xml-builder": {
+            "version": "3.930.0",
+            "resolved": "https://registry.npmjs.org/@aws-sdk/xml-builder/-/xml-builder-3.930.0.tgz",
+            "integrity": "sha512-YIfkD17GocxdmlUVc3ia52QhcWuRIUJonbF8A2CYfcWNV3HzvAqpcPeC0bYUhkK+8e8YO1ARnLKZQE0TlwzorA==",
+            "license": "Apache-2.0",
+            "dependencies": {
+                "@smithy/types": "^4.9.0",
+                "fast-xml-parser": "5.2.5",
+                "tslib": "^2.6.2"
+            },
+            "engines": {
+                "node": ">=18.0.0"
+            }
+        },
+        "node_modules/@aws-sdk/client-sso/node_modules/@aws/lambda-invoke-store": {
+            "version": "0.1.1",
+            "resolved": "https://registry.npmjs.org/@aws/lambda-invoke-store/-/lambda-invoke-store-0.1.1.tgz",
+            "integrity": "sha512-RcLam17LdlbSOSp9VxmUu1eI6Mwxp+OwhD2QhiSNmNCzoDb0EeUXTD2n/WbcnrAYMGlmf05th6QYq23VqvJqpA==",
+            "license": "Apache-2.0",
+            "engines": {
+                "node": ">=18.0.0"
+            }
+        },
+        "node_modules/@aws-sdk/client-sso/node_modules/fast-xml-parser": {
+            "version": "5.2.5",
+            "resolved": "https://registry.npmjs.org/fast-xml-parser/-/fast-xml-parser-5.2.5.tgz",
+            "integrity": "sha512-pfX9uG9Ki0yekDHx2SiuRIyFdyAr1kMIMitPvb0YBo8SUfKvia7w7FIyd/l6av85pFYRhZscS75MwMnbvY+hcQ==",
+            "funding": [
+                {
+                    "type": "github",
+                    "url": "https://github.com/sponsors/NaturalIntelligence"
+                }
+            ],
+            "license": "MIT",
+            "dependencies": {
+                "strnum": "^2.1.0"
+            },
+            "bin": {
+                "fxparser": "src/cli/cli.js"
             }
         },
         "node_modules/@aws-sdk/core": {
@@ -26886,237 +27039,6 @@
                 "lightningcss-win32-x64-msvc": "1.31.1"
             }
         },
-        "node_modules/lightningcss-android-arm64": {
-            "version": "1.31.1",
-            "resolved": "https://registry.npmjs.org/lightningcss-android-arm64/-/lightningcss-android-arm64-1.31.1.tgz",
-            "integrity": "sha512-HXJF3x8w9nQ4jbXRiNppBCqeZPIAfUo8zE/kOEGbW5NZvGc/K7nMxbhIr+YlFlHW5mpbg/YFPdbnCh1wAXCKFg==",
-            "cpu": [
-                "arm64"
-            ],
-            "dev": true,
-            "license": "MPL-2.0",
-            "optional": true,
-            "os": [
-                "android"
-            ],
-            "engines": {
-                "node": ">= 12.0.0"
-            },
-            "funding": {
-                "type": "opencollective",
-                "url": "https://opencollective.com/parcel"
-            }
-        },
-        "node_modules/lightningcss-darwin-arm64": {
-            "version": "1.31.1",
-            "resolved": "https://registry.npmjs.org/lightningcss-darwin-arm64/-/lightningcss-darwin-arm64-1.31.1.tgz",
-            "integrity": "sha512-02uTEqf3vIfNMq3h/z2cJfcOXnQ0GRwQrkmPafhueLb2h7mqEidiCzkE4gBMEH65abHRiQvhdcQ+aP0D0g67sg==",
-            "cpu": [
-                "arm64"
-            ],
-            "dev": true,
-            "license": "MPL-2.0",
-            "optional": true,
-            "os": [
-                "darwin"
-            ],
-            "engines": {
-                "node": ">= 12.0.0"
-            },
-            "funding": {
-                "type": "opencollective",
-                "url": "https://opencollective.com/parcel"
-            }
-        },
-        "node_modules/lightningcss-darwin-x64": {
-            "version": "1.31.1",
-            "resolved": "https://registry.npmjs.org/lightningcss-darwin-x64/-/lightningcss-darwin-x64-1.31.1.tgz",
-            "integrity": "sha512-1ObhyoCY+tGxtsz1lSx5NXCj3nirk0Y0kB/g8B8DT+sSx4G9djitg9ejFnjb3gJNWo7qXH4DIy2SUHvpoFwfTA==",
-            "cpu": [
-                "x64"
-            ],
-            "dev": true,
-            "license": "MPL-2.0",
-            "optional": true,
-            "os": [
-                "darwin"
-            ],
-            "engines": {
-                "node": ">= 12.0.0"
-            },
-            "funding": {
-                "type": "opencollective",
-                "url": "https://opencollective.com/parcel"
-            }
-        },
-        "node_modules/lightningcss-freebsd-x64": {
-            "version": "1.31.1",
-            "resolved": "https://registry.npmjs.org/lightningcss-freebsd-x64/-/lightningcss-freebsd-x64-1.31.1.tgz",
-            "integrity": "sha512-1RINmQKAItO6ISxYgPwszQE1BrsVU5aB45ho6O42mu96UiZBxEXsuQ7cJW4zs4CEodPUioj/QrXW1r9pLUM74A==",
-            "cpu": [
-                "x64"
-            ],
-            "dev": true,
-            "license": "MPL-2.0",
-            "optional": true,
-            "os": [
-                "freebsd"
-            ],
-            "engines": {
-                "node": ">= 12.0.0"
-            },
-            "funding": {
-                "type": "opencollective",
-                "url": "https://opencollective.com/parcel"
-            }
-        },
-        "node_modules/lightningcss-linux-arm-gnueabihf": {
-            "version": "1.31.1",
-            "resolved": "https://registry.npmjs.org/lightningcss-linux-arm-gnueabihf/-/lightningcss-linux-arm-gnueabihf-1.31.1.tgz",
-            "integrity": "sha512-OOCm2//MZJ87CdDK62rZIu+aw9gBv4azMJuA8/KB74wmfS3lnC4yoPHm0uXZ/dvNNHmnZnB8XLAZzObeG0nS1g==",
-            "cpu": [
-                "arm"
-            ],
-            "dev": true,
-            "license": "MPL-2.0",
-            "optional": true,
-            "os": [
-                "linux"
-            ],
-            "engines": {
-                "node": ">= 12.0.0"
-            },
-            "funding": {
-                "type": "opencollective",
-                "url": "https://opencollective.com/parcel"
-            }
-        },
-        "node_modules/lightningcss-linux-arm64-gnu": {
-            "version": "1.31.1",
-            "resolved": "https://registry.npmjs.org/lightningcss-linux-arm64-gnu/-/lightningcss-linux-arm64-gnu-1.31.1.tgz",
-            "integrity": "sha512-WKyLWztD71rTnou4xAD5kQT+982wvca7E6QoLpoawZ1gP9JM0GJj4Tp5jMUh9B3AitHbRZ2/H3W5xQmdEOUlLg==",
-            "cpu": [
-                "arm64"
-            ],
-            "dev": true,
-            "license": "MPL-2.0",
-            "optional": true,
-            "os": [
-                "linux"
-            ],
-            "engines": {
-                "node": ">= 12.0.0"
-            },
-            "funding": {
-                "type": "opencollective",
-                "url": "https://opencollective.com/parcel"
-            }
-        },
-        "node_modules/lightningcss-linux-arm64-musl": {
-            "version": "1.31.1",
-            "resolved": "https://registry.npmjs.org/lightningcss-linux-arm64-musl/-/lightningcss-linux-arm64-musl-1.31.1.tgz",
-            "integrity": "sha512-mVZ7Pg2zIbe3XlNbZJdjs86YViQFoJSpc41CbVmKBPiGmC4YrfeOyz65ms2qpAobVd7WQsbW4PdsSJEMymyIMg==",
-            "cpu": [
-                "arm64"
-            ],
-            "dev": true,
-            "license": "MPL-2.0",
-            "optional": true,
-            "os": [
-                "linux"
-            ],
-            "engines": {
-                "node": ">= 12.0.0"
-            },
-            "funding": {
-                "type": "opencollective",
-                "url": "https://opencollective.com/parcel"
-            }
-        },
-        "node_modules/lightningcss-linux-x64-gnu": {
-            "version": "1.31.1",
-            "resolved": "https://registry.npmjs.org/lightningcss-linux-x64-gnu/-/lightningcss-linux-x64-gnu-1.31.1.tgz",
-            "integrity": "sha512-xGlFWRMl+0KvUhgySdIaReQdB4FNudfUTARn7q0hh/V67PVGCs3ADFjw+6++kG1RNd0zdGRlEKa+T13/tQjPMA==",
-            "cpu": [
-                "x64"
-            ],
-            "dev": true,
-            "license": "MPL-2.0",
-            "optional": true,
-            "os": [
-                "linux"
-            ],
-            "engines": {
-                "node": ">= 12.0.0"
-            },
-            "funding": {
-                "type": "opencollective",
-                "url": "https://opencollective.com/parcel"
-            }
-        },
-        "node_modules/lightningcss-linux-x64-musl": {
-            "version": "1.31.1",
-            "resolved": "https://registry.npmjs.org/lightningcss-linux-x64-musl/-/lightningcss-linux-x64-musl-1.31.1.tgz",
-            "integrity": "sha512-eowF8PrKHw9LpoZii5tdZwnBcYDxRw2rRCyvAXLi34iyeYfqCQNA9rmUM0ce62NlPhCvof1+9ivRaTY6pSKDaA==",
-            "cpu": [
-                "x64"
-            ],
-            "dev": true,
-            "license": "MPL-2.0",
-            "optional": true,
-            "os": [
-                "linux"
-            ],
-            "engines": {
-                "node": ">= 12.0.0"
-            },
-            "funding": {
-                "type": "opencollective",
-                "url": "https://opencollective.com/parcel"
-            }
-        },
-        "node_modules/lightningcss-win32-arm64-msvc": {
-            "version": "1.31.1",
-            "resolved": "https://registry.npmjs.org/lightningcss-win32-arm64-msvc/-/lightningcss-win32-arm64-msvc-1.31.1.tgz",
-            "integrity": "sha512-aJReEbSEQzx1uBlQizAOBSjcmr9dCdL3XuC/6HLXAxmtErsj2ICo5yYggg1qOODQMtnjNQv2UHb9NpOuFtYe4w==",
-            "cpu": [
-                "arm64"
-            ],
-            "dev": true,
-            "license": "MPL-2.0",
-            "optional": true,
-            "os": [
-                "win32"
-            ],
-            "engines": {
-                "node": ">= 12.0.0"
-            },
-            "funding": {
-                "type": "opencollective",
-                "url": "https://opencollective.com/parcel"
-            }
-        },
-        "node_modules/lightningcss-win32-x64-msvc": {
-            "version": "1.31.1",
-            "resolved": "https://registry.npmjs.org/lightningcss-win32-x64-msvc/-/lightningcss-win32-x64-msvc-1.31.1.tgz",
-            "integrity": "sha512-I9aiFrbd7oYHwlnQDqr1Roz+fTz61oDDJX7n9tYF9FJymH1cIN1DtKw3iYt6b8WZgEjoNwVSncwF4wx/ZedMhw==",
-            "cpu": [
-                "x64"
-            ],
-            "dev": true,
-            "license": "MPL-2.0",
-            "optional": true,
-            "os": [
-                "win32"
-            ],
-            "engines": {
-                "node": ">= 12.0.0"
-            },
-            "funding": {
-                "type": "opencollective",
-                "url": "https://opencollective.com/parcel"
-            }
-        },
         "node_modules/limiter": {
             "version": "1.1.5"
         },
@@ -37477,11 +37399,11 @@
             "name": "@nangohq/nango-jobs",
             "version": "1.0.0",
             "dependencies": {
-                "@aws-sdk/client-application-auto-scaling": "3.993.0",
-                "@aws-sdk/client-cloudwatch-logs": "3.993.0",
-                "@aws-sdk/client-lambda": "3.993.0",
-                "@aws-sdk/client-s3": "3.993.0",
-                "@aws-sdk/client-sqs": "3.993.0",
+                "@aws-sdk/client-application-auto-scaling": "3.932.0",
+                "@aws-sdk/client-cloudwatch-logs": "3.932.0",
+                "@aws-sdk/client-lambda": "3.932.0",
+                "@aws-sdk/client-s3": "3.932.0",
+                "@aws-sdk/client-sqs": "3.932.0",
                 "@kubernetes/client-node": "1.3.0",
                 "@nangohq/data-ingestion": "file:../data-ingestion",
                 "@nangohq/database": "file:../database",
@@ -37510,6 +37432,247 @@
                 "type-fest": "4.41.0",
                 "typescript": "5.8.3",
                 "vitest": "3.2.4"
+            }
+        },
+        "packages/jobs/node_modules/@aws-sdk/client-application-auto-scaling": {
+            "version": "3.932.0",
+            "resolved": "https://registry.npmjs.org/@aws-sdk/client-application-auto-scaling/-/client-application-auto-scaling-3.932.0.tgz",
+            "integrity": "sha512-Ya+tPT+055sABGIi1qQChJ63ftEGbyPCm0aKjjdPv+u7UOFuyzAgG7pk79XW6kuWNEFBl5ibdJvUBu1iPDmJyg==",
+            "license": "Apache-2.0",
+            "dependencies": {
+                "@aws-crypto/sha256-browser": "5.2.0",
+                "@aws-crypto/sha256-js": "5.2.0",
+                "@aws-sdk/core": "3.932.0",
+                "@aws-sdk/credential-provider-node": "3.932.0",
+                "@aws-sdk/middleware-host-header": "3.930.0",
+                "@aws-sdk/middleware-logger": "3.930.0",
+                "@aws-sdk/middleware-recursion-detection": "3.930.0",
+                "@aws-sdk/middleware-user-agent": "3.932.0",
+                "@aws-sdk/region-config-resolver": "3.930.0",
+                "@aws-sdk/types": "3.930.0",
+                "@aws-sdk/util-endpoints": "3.930.0",
+                "@aws-sdk/util-user-agent-browser": "3.930.0",
+                "@aws-sdk/util-user-agent-node": "3.932.0",
+                "@smithy/config-resolver": "^4.4.3",
+                "@smithy/core": "^3.18.2",
+                "@smithy/fetch-http-handler": "^5.3.6",
+                "@smithy/hash-node": "^4.2.5",
+                "@smithy/invalid-dependency": "^4.2.5",
+                "@smithy/middleware-content-length": "^4.2.5",
+                "@smithy/middleware-endpoint": "^4.3.9",
+                "@smithy/middleware-retry": "^4.4.9",
+                "@smithy/middleware-serde": "^4.2.5",
+                "@smithy/middleware-stack": "^4.2.5",
+                "@smithy/node-config-provider": "^4.3.5",
+                "@smithy/node-http-handler": "^4.4.5",
+                "@smithy/protocol-http": "^5.3.5",
+                "@smithy/smithy-client": "^4.9.5",
+                "@smithy/types": "^4.9.0",
+                "@smithy/url-parser": "^4.2.5",
+                "@smithy/util-base64": "^4.3.0",
+                "@smithy/util-body-length-browser": "^4.2.0",
+                "@smithy/util-body-length-node": "^4.2.1",
+                "@smithy/util-defaults-mode-browser": "^4.3.8",
+                "@smithy/util-defaults-mode-node": "^4.2.11",
+                "@smithy/util-endpoints": "^3.2.5",
+                "@smithy/util-middleware": "^4.2.5",
+                "@smithy/util-retry": "^4.2.5",
+                "@smithy/util-utf8": "^4.2.0",
+                "tslib": "^2.6.2"
+            },
+            "engines": {
+                "node": ">=18.0.0"
+            }
+        },
+        "packages/jobs/node_modules/@aws-sdk/client-application-auto-scaling/node_modules/@aws-sdk/core": {
+            "version": "3.932.0",
+            "resolved": "https://registry.npmjs.org/@aws-sdk/core/-/core-3.932.0.tgz",
+            "integrity": "sha512-AS8gypYQCbNojwgjvZGkJocC2CoEICDx9ZJ15ILsv+MlcCVLtUJSRSx3VzJOUY2EEIaGLRrPNlIqyn/9/fySvA==",
+            "license": "Apache-2.0",
+            "dependencies": {
+                "@aws-sdk/types": "3.930.0",
+                "@aws-sdk/xml-builder": "3.930.0",
+                "@smithy/core": "^3.18.2",
+                "@smithy/node-config-provider": "^4.3.5",
+                "@smithy/property-provider": "^4.2.5",
+                "@smithy/protocol-http": "^5.3.5",
+                "@smithy/signature-v4": "^5.3.5",
+                "@smithy/smithy-client": "^4.9.5",
+                "@smithy/types": "^4.9.0",
+                "@smithy/util-base64": "^4.3.0",
+                "@smithy/util-middleware": "^4.2.5",
+                "@smithy/util-utf8": "^4.2.0",
+                "tslib": "^2.6.2"
+            },
+            "engines": {
+                "node": ">=18.0.0"
+            }
+        },
+        "packages/jobs/node_modules/@aws-sdk/client-application-auto-scaling/node_modules/@aws-sdk/credential-provider-node": {
+            "version": "3.932.0",
+            "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-node/-/credential-provider-node-3.932.0.tgz",
+            "integrity": "sha512-SEG9t2taBT86qe3gTunfrK8BxT710GVLGepvHr+X5Pw+qW225iNRaGN0zJH+ZE/j91tcW9wOaIoWnURkhR5wIg==",
+            "license": "Apache-2.0",
+            "dependencies": {
+                "@aws-sdk/credential-provider-env": "3.932.0",
+                "@aws-sdk/credential-provider-http": "3.932.0",
+                "@aws-sdk/credential-provider-ini": "3.932.0",
+                "@aws-sdk/credential-provider-process": "3.932.0",
+                "@aws-sdk/credential-provider-sso": "3.932.0",
+                "@aws-sdk/credential-provider-web-identity": "3.932.0",
+                "@aws-sdk/types": "3.930.0",
+                "@smithy/credential-provider-imds": "^4.2.5",
+                "@smithy/property-provider": "^4.2.5",
+                "@smithy/shared-ini-file-loader": "^4.4.0",
+                "@smithy/types": "^4.9.0",
+                "tslib": "^2.6.2"
+            },
+            "engines": {
+                "node": ">=18.0.0"
+            }
+        },
+        "packages/jobs/node_modules/@aws-sdk/client-application-auto-scaling/node_modules/@aws-sdk/middleware-host-header": {
+            "version": "3.930.0",
+            "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-host-header/-/middleware-host-header-3.930.0.tgz",
+            "integrity": "sha512-x30jmm3TLu7b/b+67nMyoV0NlbnCVT5DI57yDrhXAPCtdgM1KtdLWt45UcHpKOm1JsaIkmYRh2WYu7Anx4MG0g==",
+            "license": "Apache-2.0",
+            "dependencies": {
+                "@aws-sdk/types": "3.930.0",
+                "@smithy/protocol-http": "^5.3.5",
+                "@smithy/types": "^4.9.0",
+                "tslib": "^2.6.2"
+            },
+            "engines": {
+                "node": ">=18.0.0"
+            }
+        },
+        "packages/jobs/node_modules/@aws-sdk/client-application-auto-scaling/node_modules/@aws-sdk/middleware-logger": {
+            "version": "3.930.0",
+            "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-logger/-/middleware-logger-3.930.0.tgz",
+            "integrity": "sha512-vh4JBWzMCBW8wREvAwoSqB2geKsZwSHTa0nSt0OMOLp2PdTYIZDi0ZiVMmpfnjcx9XbS6aSluLv9sKx4RrG46A==",
+            "license": "Apache-2.0",
+            "dependencies": {
+                "@aws-sdk/types": "3.930.0",
+                "@smithy/types": "^4.9.0",
+                "tslib": "^2.6.2"
+            },
+            "engines": {
+                "node": ">=18.0.0"
+            }
+        },
+        "packages/jobs/node_modules/@aws-sdk/client-application-auto-scaling/node_modules/@aws-sdk/middleware-recursion-detection": {
+            "version": "3.930.0",
+            "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-recursion-detection/-/middleware-recursion-detection-3.930.0.tgz",
+            "integrity": "sha512-gv0sekNpa2MBsIhm2cjP3nmYSfI4nscx/+K9u9ybrWZBWUIC4kL2sV++bFjjUz4QxUIlvKByow3/a9ARQyCu7Q==",
+            "license": "Apache-2.0",
+            "dependencies": {
+                "@aws-sdk/types": "3.930.0",
+                "@aws/lambda-invoke-store": "^0.1.1",
+                "@smithy/protocol-http": "^5.3.5",
+                "@smithy/types": "^4.9.0",
+                "tslib": "^2.6.2"
+            },
+            "engines": {
+                "node": ">=18.0.0"
+            }
+        },
+        "packages/jobs/node_modules/@aws-sdk/client-application-auto-scaling/node_modules/@aws-sdk/middleware-user-agent": {
+            "version": "3.932.0",
+            "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-user-agent/-/middleware-user-agent-3.932.0.tgz",
+            "integrity": "sha512-9BGTbJyA/4PTdwQWE9hAFIJGpsYkyEW20WON3i15aDqo5oRZwZmqaVageOD57YYqG8JDJjvcwKyDdR4cc38dvg==",
+            "license": "Apache-2.0",
+            "dependencies": {
+                "@aws-sdk/core": "3.932.0",
+                "@aws-sdk/types": "3.930.0",
+                "@aws-sdk/util-endpoints": "3.930.0",
+                "@smithy/core": "^3.18.2",
+                "@smithy/protocol-http": "^5.3.5",
+                "@smithy/types": "^4.9.0",
+                "tslib": "^2.6.2"
+            },
+            "engines": {
+                "node": ">=18.0.0"
+            }
+        },
+        "packages/jobs/node_modules/@aws-sdk/client-application-auto-scaling/node_modules/@aws-sdk/region-config-resolver": {
+            "version": "3.930.0",
+            "resolved": "https://registry.npmjs.org/@aws-sdk/region-config-resolver/-/region-config-resolver-3.930.0.tgz",
+            "integrity": "sha512-KL2JZqH6aYeQssu1g1KuWsReupdfOoxD6f1as2VC+rdwYFUu4LfzMsFfXnBvvQWWqQ7rZHWOw1T+o5gJmg7Dzw==",
+            "license": "Apache-2.0",
+            "dependencies": {
+                "@aws-sdk/types": "3.930.0",
+                "@smithy/config-resolver": "^4.4.3",
+                "@smithy/node-config-provider": "^4.3.5",
+                "@smithy/types": "^4.9.0",
+                "tslib": "^2.6.2"
+            },
+            "engines": {
+                "node": ">=18.0.0"
+            }
+        },
+        "packages/jobs/node_modules/@aws-sdk/client-application-auto-scaling/node_modules/@aws-sdk/types": {
+            "version": "3.930.0",
+            "resolved": "https://registry.npmjs.org/@aws-sdk/types/-/types-3.930.0.tgz",
+            "integrity": "sha512-we/vaAgwlEFW7IeftmCLlLMw+6hFs3DzZPJw7lVHbj/5HJ0bz9gndxEsS2lQoeJ1zhiiLqAqvXxmM43s0MBg0A==",
+            "license": "Apache-2.0",
+            "dependencies": {
+                "@smithy/types": "^4.9.0",
+                "tslib": "^2.6.2"
+            },
+            "engines": {
+                "node": ">=18.0.0"
+            }
+        },
+        "packages/jobs/node_modules/@aws-sdk/client-application-auto-scaling/node_modules/@aws-sdk/util-endpoints": {
+            "version": "3.930.0",
+            "resolved": "https://registry.npmjs.org/@aws-sdk/util-endpoints/-/util-endpoints-3.930.0.tgz",
+            "integrity": "sha512-M2oEKBzzNAYr136RRc6uqw3aWlwCxqTP1Lawps9E1d2abRPvl1p1ztQmmXp1Ak4rv8eByIZ+yQyKQ3zPdRG5dw==",
+            "license": "Apache-2.0",
+            "dependencies": {
+                "@aws-sdk/types": "3.930.0",
+                "@smithy/types": "^4.9.0",
+                "@smithy/url-parser": "^4.2.5",
+                "@smithy/util-endpoints": "^3.2.5",
+                "tslib": "^2.6.2"
+            },
+            "engines": {
+                "node": ">=18.0.0"
+            }
+        },
+        "packages/jobs/node_modules/@aws-sdk/client-application-auto-scaling/node_modules/@aws-sdk/util-user-agent-browser": {
+            "version": "3.930.0",
+            "resolved": "https://registry.npmjs.org/@aws-sdk/util-user-agent-browser/-/util-user-agent-browser-3.930.0.tgz",
+            "integrity": "sha512-q6lCRm6UAe+e1LguM5E4EqM9brQlDem4XDcQ87NzEvlTW6GzmNCO0w1jS0XgCFXQHjDxjdlNFX+5sRbHijwklg==",
+            "license": "Apache-2.0",
+            "dependencies": {
+                "@aws-sdk/types": "3.930.0",
+                "@smithy/types": "^4.9.0",
+                "bowser": "^2.11.0",
+                "tslib": "^2.6.2"
+            }
+        },
+        "packages/jobs/node_modules/@aws-sdk/client-application-auto-scaling/node_modules/@aws-sdk/util-user-agent-node": {
+            "version": "3.932.0",
+            "resolved": "https://registry.npmjs.org/@aws-sdk/util-user-agent-node/-/util-user-agent-node-3.932.0.tgz",
+            "integrity": "sha512-/kC6cscHrZL74TrZtgiIL5jJNbVsw9duGGPurmaVgoCbP7NnxyaSWEurbNV3VPNPhNE3bV3g4Ci+odq+AlsYQg==",
+            "license": "Apache-2.0",
+            "dependencies": {
+                "@aws-sdk/middleware-user-agent": "3.932.0",
+                "@aws-sdk/types": "3.930.0",
+                "@smithy/node-config-provider": "^4.3.5",
+                "@smithy/types": "^4.9.0",
+                "tslib": "^2.6.2"
+            },
+            "engines": {
+                "node": ">=18.0.0"
+            },
+            "peerDependencies": {
+                "aws-crt": ">=1.0.0"
+            },
+            "peerDependenciesMeta": {
+                "aws-crt": {
+                    "optional": true
+                }
             }
         },
         "packages/jobs/node_modules/@aws-sdk/client-cloudwatch-logs": {
@@ -37563,6 +37726,1710 @@
             },
             "engines": {
                 "node": ">=20.0.0"
+            }
+        },
+        "packages/jobs/node_modules/@aws-sdk/client-lambda": {
+            "version": "3.932.0",
+            "resolved": "https://registry.npmjs.org/@aws-sdk/client-lambda/-/client-lambda-3.932.0.tgz",
+            "integrity": "sha512-C7XVPe2XI8An6HgCv6RmoIp9ShdUVqcNFKzdu+HGcxCHZhqg5kvvWjfG0nJuI+CarwBUQqxYdwnBWSrZaBMuYw==",
+            "license": "Apache-2.0",
+            "dependencies": {
+                "@aws-crypto/sha256-browser": "5.2.0",
+                "@aws-crypto/sha256-js": "5.2.0",
+                "@aws-sdk/core": "3.932.0",
+                "@aws-sdk/credential-provider-node": "3.932.0",
+                "@aws-sdk/middleware-host-header": "3.930.0",
+                "@aws-sdk/middleware-logger": "3.930.0",
+                "@aws-sdk/middleware-recursion-detection": "3.930.0",
+                "@aws-sdk/middleware-user-agent": "3.932.0",
+                "@aws-sdk/region-config-resolver": "3.930.0",
+                "@aws-sdk/types": "3.930.0",
+                "@aws-sdk/util-endpoints": "3.930.0",
+                "@aws-sdk/util-user-agent-browser": "3.930.0",
+                "@aws-sdk/util-user-agent-node": "3.932.0",
+                "@smithy/config-resolver": "^4.4.3",
+                "@smithy/core": "^3.18.2",
+                "@smithy/eventstream-serde-browser": "^4.2.5",
+                "@smithy/eventstream-serde-config-resolver": "^4.3.5",
+                "@smithy/eventstream-serde-node": "^4.2.5",
+                "@smithy/fetch-http-handler": "^5.3.6",
+                "@smithy/hash-node": "^4.2.5",
+                "@smithy/invalid-dependency": "^4.2.5",
+                "@smithy/middleware-content-length": "^4.2.5",
+                "@smithy/middleware-endpoint": "^4.3.9",
+                "@smithy/middleware-retry": "^4.4.9",
+                "@smithy/middleware-serde": "^4.2.5",
+                "@smithy/middleware-stack": "^4.2.5",
+                "@smithy/node-config-provider": "^4.3.5",
+                "@smithy/node-http-handler": "^4.4.5",
+                "@smithy/protocol-http": "^5.3.5",
+                "@smithy/smithy-client": "^4.9.5",
+                "@smithy/types": "^4.9.0",
+                "@smithy/url-parser": "^4.2.5",
+                "@smithy/util-base64": "^4.3.0",
+                "@smithy/util-body-length-browser": "^4.2.0",
+                "@smithy/util-body-length-node": "^4.2.1",
+                "@smithy/util-defaults-mode-browser": "^4.3.8",
+                "@smithy/util-defaults-mode-node": "^4.2.11",
+                "@smithy/util-endpoints": "^3.2.5",
+                "@smithy/util-middleware": "^4.2.5",
+                "@smithy/util-retry": "^4.2.5",
+                "@smithy/util-stream": "^4.5.6",
+                "@smithy/util-utf8": "^4.2.0",
+                "@smithy/util-waiter": "^4.2.5",
+                "tslib": "^2.6.2"
+            },
+            "engines": {
+                "node": ">=18.0.0"
+            }
+        },
+        "packages/jobs/node_modules/@aws-sdk/client-lambda/node_modules/@aws-sdk/core": {
+            "version": "3.932.0",
+            "resolved": "https://registry.npmjs.org/@aws-sdk/core/-/core-3.932.0.tgz",
+            "integrity": "sha512-AS8gypYQCbNojwgjvZGkJocC2CoEICDx9ZJ15ILsv+MlcCVLtUJSRSx3VzJOUY2EEIaGLRrPNlIqyn/9/fySvA==",
+            "license": "Apache-2.0",
+            "dependencies": {
+                "@aws-sdk/types": "3.930.0",
+                "@aws-sdk/xml-builder": "3.930.0",
+                "@smithy/core": "^3.18.2",
+                "@smithy/node-config-provider": "^4.3.5",
+                "@smithy/property-provider": "^4.2.5",
+                "@smithy/protocol-http": "^5.3.5",
+                "@smithy/signature-v4": "^5.3.5",
+                "@smithy/smithy-client": "^4.9.5",
+                "@smithy/types": "^4.9.0",
+                "@smithy/util-base64": "^4.3.0",
+                "@smithy/util-middleware": "^4.2.5",
+                "@smithy/util-utf8": "^4.2.0",
+                "tslib": "^2.6.2"
+            },
+            "engines": {
+                "node": ">=18.0.0"
+            }
+        },
+        "packages/jobs/node_modules/@aws-sdk/client-lambda/node_modules/@aws-sdk/credential-provider-node": {
+            "version": "3.932.0",
+            "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-node/-/credential-provider-node-3.932.0.tgz",
+            "integrity": "sha512-SEG9t2taBT86qe3gTunfrK8BxT710GVLGepvHr+X5Pw+qW225iNRaGN0zJH+ZE/j91tcW9wOaIoWnURkhR5wIg==",
+            "license": "Apache-2.0",
+            "dependencies": {
+                "@aws-sdk/credential-provider-env": "3.932.0",
+                "@aws-sdk/credential-provider-http": "3.932.0",
+                "@aws-sdk/credential-provider-ini": "3.932.0",
+                "@aws-sdk/credential-provider-process": "3.932.0",
+                "@aws-sdk/credential-provider-sso": "3.932.0",
+                "@aws-sdk/credential-provider-web-identity": "3.932.0",
+                "@aws-sdk/types": "3.930.0",
+                "@smithy/credential-provider-imds": "^4.2.5",
+                "@smithy/property-provider": "^4.2.5",
+                "@smithy/shared-ini-file-loader": "^4.4.0",
+                "@smithy/types": "^4.9.0",
+                "tslib": "^2.6.2"
+            },
+            "engines": {
+                "node": ">=18.0.0"
+            }
+        },
+        "packages/jobs/node_modules/@aws-sdk/client-lambda/node_modules/@aws-sdk/middleware-host-header": {
+            "version": "3.930.0",
+            "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-host-header/-/middleware-host-header-3.930.0.tgz",
+            "integrity": "sha512-x30jmm3TLu7b/b+67nMyoV0NlbnCVT5DI57yDrhXAPCtdgM1KtdLWt45UcHpKOm1JsaIkmYRh2WYu7Anx4MG0g==",
+            "license": "Apache-2.0",
+            "dependencies": {
+                "@aws-sdk/types": "3.930.0",
+                "@smithy/protocol-http": "^5.3.5",
+                "@smithy/types": "^4.9.0",
+                "tslib": "^2.6.2"
+            },
+            "engines": {
+                "node": ">=18.0.0"
+            }
+        },
+        "packages/jobs/node_modules/@aws-sdk/client-lambda/node_modules/@aws-sdk/middleware-logger": {
+            "version": "3.930.0",
+            "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-logger/-/middleware-logger-3.930.0.tgz",
+            "integrity": "sha512-vh4JBWzMCBW8wREvAwoSqB2geKsZwSHTa0nSt0OMOLp2PdTYIZDi0ZiVMmpfnjcx9XbS6aSluLv9sKx4RrG46A==",
+            "license": "Apache-2.0",
+            "dependencies": {
+                "@aws-sdk/types": "3.930.0",
+                "@smithy/types": "^4.9.0",
+                "tslib": "^2.6.2"
+            },
+            "engines": {
+                "node": ">=18.0.0"
+            }
+        },
+        "packages/jobs/node_modules/@aws-sdk/client-lambda/node_modules/@aws-sdk/middleware-recursion-detection": {
+            "version": "3.930.0",
+            "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-recursion-detection/-/middleware-recursion-detection-3.930.0.tgz",
+            "integrity": "sha512-gv0sekNpa2MBsIhm2cjP3nmYSfI4nscx/+K9u9ybrWZBWUIC4kL2sV++bFjjUz4QxUIlvKByow3/a9ARQyCu7Q==",
+            "license": "Apache-2.0",
+            "dependencies": {
+                "@aws-sdk/types": "3.930.0",
+                "@aws/lambda-invoke-store": "^0.1.1",
+                "@smithy/protocol-http": "^5.3.5",
+                "@smithy/types": "^4.9.0",
+                "tslib": "^2.6.2"
+            },
+            "engines": {
+                "node": ">=18.0.0"
+            }
+        },
+        "packages/jobs/node_modules/@aws-sdk/client-lambda/node_modules/@aws-sdk/middleware-user-agent": {
+            "version": "3.932.0",
+            "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-user-agent/-/middleware-user-agent-3.932.0.tgz",
+            "integrity": "sha512-9BGTbJyA/4PTdwQWE9hAFIJGpsYkyEW20WON3i15aDqo5oRZwZmqaVageOD57YYqG8JDJjvcwKyDdR4cc38dvg==",
+            "license": "Apache-2.0",
+            "dependencies": {
+                "@aws-sdk/core": "3.932.0",
+                "@aws-sdk/types": "3.930.0",
+                "@aws-sdk/util-endpoints": "3.930.0",
+                "@smithy/core": "^3.18.2",
+                "@smithy/protocol-http": "^5.3.5",
+                "@smithy/types": "^4.9.0",
+                "tslib": "^2.6.2"
+            },
+            "engines": {
+                "node": ">=18.0.0"
+            }
+        },
+        "packages/jobs/node_modules/@aws-sdk/client-lambda/node_modules/@aws-sdk/region-config-resolver": {
+            "version": "3.930.0",
+            "resolved": "https://registry.npmjs.org/@aws-sdk/region-config-resolver/-/region-config-resolver-3.930.0.tgz",
+            "integrity": "sha512-KL2JZqH6aYeQssu1g1KuWsReupdfOoxD6f1as2VC+rdwYFUu4LfzMsFfXnBvvQWWqQ7rZHWOw1T+o5gJmg7Dzw==",
+            "license": "Apache-2.0",
+            "dependencies": {
+                "@aws-sdk/types": "3.930.0",
+                "@smithy/config-resolver": "^4.4.3",
+                "@smithy/node-config-provider": "^4.3.5",
+                "@smithy/types": "^4.9.0",
+                "tslib": "^2.6.2"
+            },
+            "engines": {
+                "node": ">=18.0.0"
+            }
+        },
+        "packages/jobs/node_modules/@aws-sdk/client-lambda/node_modules/@aws-sdk/types": {
+            "version": "3.930.0",
+            "resolved": "https://registry.npmjs.org/@aws-sdk/types/-/types-3.930.0.tgz",
+            "integrity": "sha512-we/vaAgwlEFW7IeftmCLlLMw+6hFs3DzZPJw7lVHbj/5HJ0bz9gndxEsS2lQoeJ1zhiiLqAqvXxmM43s0MBg0A==",
+            "license": "Apache-2.0",
+            "dependencies": {
+                "@smithy/types": "^4.9.0",
+                "tslib": "^2.6.2"
+            },
+            "engines": {
+                "node": ">=18.0.0"
+            }
+        },
+        "packages/jobs/node_modules/@aws-sdk/client-lambda/node_modules/@aws-sdk/util-endpoints": {
+            "version": "3.930.0",
+            "resolved": "https://registry.npmjs.org/@aws-sdk/util-endpoints/-/util-endpoints-3.930.0.tgz",
+            "integrity": "sha512-M2oEKBzzNAYr136RRc6uqw3aWlwCxqTP1Lawps9E1d2abRPvl1p1ztQmmXp1Ak4rv8eByIZ+yQyKQ3zPdRG5dw==",
+            "license": "Apache-2.0",
+            "dependencies": {
+                "@aws-sdk/types": "3.930.0",
+                "@smithy/types": "^4.9.0",
+                "@smithy/url-parser": "^4.2.5",
+                "@smithy/util-endpoints": "^3.2.5",
+                "tslib": "^2.6.2"
+            },
+            "engines": {
+                "node": ">=18.0.0"
+            }
+        },
+        "packages/jobs/node_modules/@aws-sdk/client-lambda/node_modules/@aws-sdk/util-user-agent-browser": {
+            "version": "3.930.0",
+            "resolved": "https://registry.npmjs.org/@aws-sdk/util-user-agent-browser/-/util-user-agent-browser-3.930.0.tgz",
+            "integrity": "sha512-q6lCRm6UAe+e1LguM5E4EqM9brQlDem4XDcQ87NzEvlTW6GzmNCO0w1jS0XgCFXQHjDxjdlNFX+5sRbHijwklg==",
+            "license": "Apache-2.0",
+            "dependencies": {
+                "@aws-sdk/types": "3.930.0",
+                "@smithy/types": "^4.9.0",
+                "bowser": "^2.11.0",
+                "tslib": "^2.6.2"
+            }
+        },
+        "packages/jobs/node_modules/@aws-sdk/client-lambda/node_modules/@aws-sdk/util-user-agent-node": {
+            "version": "3.932.0",
+            "resolved": "https://registry.npmjs.org/@aws-sdk/util-user-agent-node/-/util-user-agent-node-3.932.0.tgz",
+            "integrity": "sha512-/kC6cscHrZL74TrZtgiIL5jJNbVsw9duGGPurmaVgoCbP7NnxyaSWEurbNV3VPNPhNE3bV3g4Ci+odq+AlsYQg==",
+            "license": "Apache-2.0",
+            "dependencies": {
+                "@aws-sdk/middleware-user-agent": "3.932.0",
+                "@aws-sdk/types": "3.930.0",
+                "@smithy/node-config-provider": "^4.3.5",
+                "@smithy/types": "^4.9.0",
+                "tslib": "^2.6.2"
+            },
+            "engines": {
+                "node": ">=18.0.0"
+            },
+            "peerDependencies": {
+                "aws-crt": ">=1.0.0"
+            },
+            "peerDependenciesMeta": {
+                "aws-crt": {
+                    "optional": true
+                }
+            }
+        },
+        "packages/jobs/node_modules/@aws-sdk/client-s3": {
+            "version": "3.932.0",
+            "resolved": "https://registry.npmjs.org/@aws-sdk/client-s3/-/client-s3-3.932.0.tgz",
+            "integrity": "sha512-qrlbJ3W5QR3Gzz2S+yaItH8ZhX7vaeA4j4fDAi8+0FmsVhXOfBbomWr+JO1wk/YojZMdyLfmfYRHrJvAQsLFVw==",
+            "license": "Apache-2.0",
+            "dependencies": {
+                "@aws-crypto/sha1-browser": "5.2.0",
+                "@aws-crypto/sha256-browser": "5.2.0",
+                "@aws-crypto/sha256-js": "5.2.0",
+                "@aws-sdk/core": "3.932.0",
+                "@aws-sdk/credential-provider-node": "3.932.0",
+                "@aws-sdk/middleware-bucket-endpoint": "3.930.0",
+                "@aws-sdk/middleware-expect-continue": "3.930.0",
+                "@aws-sdk/middleware-flexible-checksums": "3.932.0",
+                "@aws-sdk/middleware-host-header": "3.930.0",
+                "@aws-sdk/middleware-location-constraint": "3.930.0",
+                "@aws-sdk/middleware-logger": "3.930.0",
+                "@aws-sdk/middleware-recursion-detection": "3.930.0",
+                "@aws-sdk/middleware-sdk-s3": "3.932.0",
+                "@aws-sdk/middleware-ssec": "3.930.0",
+                "@aws-sdk/middleware-user-agent": "3.932.0",
+                "@aws-sdk/region-config-resolver": "3.930.0",
+                "@aws-sdk/signature-v4-multi-region": "3.932.0",
+                "@aws-sdk/types": "3.930.0",
+                "@aws-sdk/util-endpoints": "3.930.0",
+                "@aws-sdk/util-user-agent-browser": "3.930.0",
+                "@aws-sdk/util-user-agent-node": "3.932.0",
+                "@smithy/config-resolver": "^4.4.3",
+                "@smithy/core": "^3.18.2",
+                "@smithy/eventstream-serde-browser": "^4.2.5",
+                "@smithy/eventstream-serde-config-resolver": "^4.3.5",
+                "@smithy/eventstream-serde-node": "^4.2.5",
+                "@smithy/fetch-http-handler": "^5.3.6",
+                "@smithy/hash-blob-browser": "^4.2.6",
+                "@smithy/hash-node": "^4.2.5",
+                "@smithy/hash-stream-node": "^4.2.5",
+                "@smithy/invalid-dependency": "^4.2.5",
+                "@smithy/md5-js": "^4.2.5",
+                "@smithy/middleware-content-length": "^4.2.5",
+                "@smithy/middleware-endpoint": "^4.3.9",
+                "@smithy/middleware-retry": "^4.4.9",
+                "@smithy/middleware-serde": "^4.2.5",
+                "@smithy/middleware-stack": "^4.2.5",
+                "@smithy/node-config-provider": "^4.3.5",
+                "@smithy/node-http-handler": "^4.4.5",
+                "@smithy/protocol-http": "^5.3.5",
+                "@smithy/smithy-client": "^4.9.5",
+                "@smithy/types": "^4.9.0",
+                "@smithy/url-parser": "^4.2.5",
+                "@smithy/util-base64": "^4.3.0",
+                "@smithy/util-body-length-browser": "^4.2.0",
+                "@smithy/util-body-length-node": "^4.2.1",
+                "@smithy/util-defaults-mode-browser": "^4.3.8",
+                "@smithy/util-defaults-mode-node": "^4.2.11",
+                "@smithy/util-endpoints": "^3.2.5",
+                "@smithy/util-middleware": "^4.2.5",
+                "@smithy/util-retry": "^4.2.5",
+                "@smithy/util-stream": "^4.5.6",
+                "@smithy/util-utf8": "^4.2.0",
+                "@smithy/util-waiter": "^4.2.5",
+                "tslib": "^2.6.2"
+            },
+            "engines": {
+                "node": ">=18.0.0"
+            }
+        },
+        "packages/jobs/node_modules/@aws-sdk/client-s3/node_modules/@aws-sdk/core": {
+            "version": "3.932.0",
+            "resolved": "https://registry.npmjs.org/@aws-sdk/core/-/core-3.932.0.tgz",
+            "integrity": "sha512-AS8gypYQCbNojwgjvZGkJocC2CoEICDx9ZJ15ILsv+MlcCVLtUJSRSx3VzJOUY2EEIaGLRrPNlIqyn/9/fySvA==",
+            "license": "Apache-2.0",
+            "dependencies": {
+                "@aws-sdk/types": "3.930.0",
+                "@aws-sdk/xml-builder": "3.930.0",
+                "@smithy/core": "^3.18.2",
+                "@smithy/node-config-provider": "^4.3.5",
+                "@smithy/property-provider": "^4.2.5",
+                "@smithy/protocol-http": "^5.3.5",
+                "@smithy/signature-v4": "^5.3.5",
+                "@smithy/smithy-client": "^4.9.5",
+                "@smithy/types": "^4.9.0",
+                "@smithy/util-base64": "^4.3.0",
+                "@smithy/util-middleware": "^4.2.5",
+                "@smithy/util-utf8": "^4.2.0",
+                "tslib": "^2.6.2"
+            },
+            "engines": {
+                "node": ">=18.0.0"
+            }
+        },
+        "packages/jobs/node_modules/@aws-sdk/client-s3/node_modules/@aws-sdk/credential-provider-node": {
+            "version": "3.932.0",
+            "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-node/-/credential-provider-node-3.932.0.tgz",
+            "integrity": "sha512-SEG9t2taBT86qe3gTunfrK8BxT710GVLGepvHr+X5Pw+qW225iNRaGN0zJH+ZE/j91tcW9wOaIoWnURkhR5wIg==",
+            "license": "Apache-2.0",
+            "dependencies": {
+                "@aws-sdk/credential-provider-env": "3.932.0",
+                "@aws-sdk/credential-provider-http": "3.932.0",
+                "@aws-sdk/credential-provider-ini": "3.932.0",
+                "@aws-sdk/credential-provider-process": "3.932.0",
+                "@aws-sdk/credential-provider-sso": "3.932.0",
+                "@aws-sdk/credential-provider-web-identity": "3.932.0",
+                "@aws-sdk/types": "3.930.0",
+                "@smithy/credential-provider-imds": "^4.2.5",
+                "@smithy/property-provider": "^4.2.5",
+                "@smithy/shared-ini-file-loader": "^4.4.0",
+                "@smithy/types": "^4.9.0",
+                "tslib": "^2.6.2"
+            },
+            "engines": {
+                "node": ">=18.0.0"
+            }
+        },
+        "packages/jobs/node_modules/@aws-sdk/client-s3/node_modules/@aws-sdk/middleware-host-header": {
+            "version": "3.930.0",
+            "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-host-header/-/middleware-host-header-3.930.0.tgz",
+            "integrity": "sha512-x30jmm3TLu7b/b+67nMyoV0NlbnCVT5DI57yDrhXAPCtdgM1KtdLWt45UcHpKOm1JsaIkmYRh2WYu7Anx4MG0g==",
+            "license": "Apache-2.0",
+            "dependencies": {
+                "@aws-sdk/types": "3.930.0",
+                "@smithy/protocol-http": "^5.3.5",
+                "@smithy/types": "^4.9.0",
+                "tslib": "^2.6.2"
+            },
+            "engines": {
+                "node": ">=18.0.0"
+            }
+        },
+        "packages/jobs/node_modules/@aws-sdk/client-s3/node_modules/@aws-sdk/middleware-logger": {
+            "version": "3.930.0",
+            "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-logger/-/middleware-logger-3.930.0.tgz",
+            "integrity": "sha512-vh4JBWzMCBW8wREvAwoSqB2geKsZwSHTa0nSt0OMOLp2PdTYIZDi0ZiVMmpfnjcx9XbS6aSluLv9sKx4RrG46A==",
+            "license": "Apache-2.0",
+            "dependencies": {
+                "@aws-sdk/types": "3.930.0",
+                "@smithy/types": "^4.9.0",
+                "tslib": "^2.6.2"
+            },
+            "engines": {
+                "node": ">=18.0.0"
+            }
+        },
+        "packages/jobs/node_modules/@aws-sdk/client-s3/node_modules/@aws-sdk/middleware-recursion-detection": {
+            "version": "3.930.0",
+            "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-recursion-detection/-/middleware-recursion-detection-3.930.0.tgz",
+            "integrity": "sha512-gv0sekNpa2MBsIhm2cjP3nmYSfI4nscx/+K9u9ybrWZBWUIC4kL2sV++bFjjUz4QxUIlvKByow3/a9ARQyCu7Q==",
+            "license": "Apache-2.0",
+            "dependencies": {
+                "@aws-sdk/types": "3.930.0",
+                "@aws/lambda-invoke-store": "^0.1.1",
+                "@smithy/protocol-http": "^5.3.5",
+                "@smithy/types": "^4.9.0",
+                "tslib": "^2.6.2"
+            },
+            "engines": {
+                "node": ">=18.0.0"
+            }
+        },
+        "packages/jobs/node_modules/@aws-sdk/client-s3/node_modules/@aws-sdk/middleware-user-agent": {
+            "version": "3.932.0",
+            "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-user-agent/-/middleware-user-agent-3.932.0.tgz",
+            "integrity": "sha512-9BGTbJyA/4PTdwQWE9hAFIJGpsYkyEW20WON3i15aDqo5oRZwZmqaVageOD57YYqG8JDJjvcwKyDdR4cc38dvg==",
+            "license": "Apache-2.0",
+            "dependencies": {
+                "@aws-sdk/core": "3.932.0",
+                "@aws-sdk/types": "3.930.0",
+                "@aws-sdk/util-endpoints": "3.930.0",
+                "@smithy/core": "^3.18.2",
+                "@smithy/protocol-http": "^5.3.5",
+                "@smithy/types": "^4.9.0",
+                "tslib": "^2.6.2"
+            },
+            "engines": {
+                "node": ">=18.0.0"
+            }
+        },
+        "packages/jobs/node_modules/@aws-sdk/client-s3/node_modules/@aws-sdk/region-config-resolver": {
+            "version": "3.930.0",
+            "resolved": "https://registry.npmjs.org/@aws-sdk/region-config-resolver/-/region-config-resolver-3.930.0.tgz",
+            "integrity": "sha512-KL2JZqH6aYeQssu1g1KuWsReupdfOoxD6f1as2VC+rdwYFUu4LfzMsFfXnBvvQWWqQ7rZHWOw1T+o5gJmg7Dzw==",
+            "license": "Apache-2.0",
+            "dependencies": {
+                "@aws-sdk/types": "3.930.0",
+                "@smithy/config-resolver": "^4.4.3",
+                "@smithy/node-config-provider": "^4.3.5",
+                "@smithy/types": "^4.9.0",
+                "tslib": "^2.6.2"
+            },
+            "engines": {
+                "node": ">=18.0.0"
+            }
+        },
+        "packages/jobs/node_modules/@aws-sdk/client-s3/node_modules/@aws-sdk/types": {
+            "version": "3.930.0",
+            "resolved": "https://registry.npmjs.org/@aws-sdk/types/-/types-3.930.0.tgz",
+            "integrity": "sha512-we/vaAgwlEFW7IeftmCLlLMw+6hFs3DzZPJw7lVHbj/5HJ0bz9gndxEsS2lQoeJ1zhiiLqAqvXxmM43s0MBg0A==",
+            "license": "Apache-2.0",
+            "dependencies": {
+                "@smithy/types": "^4.9.0",
+                "tslib": "^2.6.2"
+            },
+            "engines": {
+                "node": ">=18.0.0"
+            }
+        },
+        "packages/jobs/node_modules/@aws-sdk/client-s3/node_modules/@aws-sdk/util-endpoints": {
+            "version": "3.930.0",
+            "resolved": "https://registry.npmjs.org/@aws-sdk/util-endpoints/-/util-endpoints-3.930.0.tgz",
+            "integrity": "sha512-M2oEKBzzNAYr136RRc6uqw3aWlwCxqTP1Lawps9E1d2abRPvl1p1ztQmmXp1Ak4rv8eByIZ+yQyKQ3zPdRG5dw==",
+            "license": "Apache-2.0",
+            "dependencies": {
+                "@aws-sdk/types": "3.930.0",
+                "@smithy/types": "^4.9.0",
+                "@smithy/url-parser": "^4.2.5",
+                "@smithy/util-endpoints": "^3.2.5",
+                "tslib": "^2.6.2"
+            },
+            "engines": {
+                "node": ">=18.0.0"
+            }
+        },
+        "packages/jobs/node_modules/@aws-sdk/client-s3/node_modules/@aws-sdk/util-user-agent-browser": {
+            "version": "3.930.0",
+            "resolved": "https://registry.npmjs.org/@aws-sdk/util-user-agent-browser/-/util-user-agent-browser-3.930.0.tgz",
+            "integrity": "sha512-q6lCRm6UAe+e1LguM5E4EqM9brQlDem4XDcQ87NzEvlTW6GzmNCO0w1jS0XgCFXQHjDxjdlNFX+5sRbHijwklg==",
+            "license": "Apache-2.0",
+            "dependencies": {
+                "@aws-sdk/types": "3.930.0",
+                "@smithy/types": "^4.9.0",
+                "bowser": "^2.11.0",
+                "tslib": "^2.6.2"
+            }
+        },
+        "packages/jobs/node_modules/@aws-sdk/client-s3/node_modules/@aws-sdk/util-user-agent-node": {
+            "version": "3.932.0",
+            "resolved": "https://registry.npmjs.org/@aws-sdk/util-user-agent-node/-/util-user-agent-node-3.932.0.tgz",
+            "integrity": "sha512-/kC6cscHrZL74TrZtgiIL5jJNbVsw9duGGPurmaVgoCbP7NnxyaSWEurbNV3VPNPhNE3bV3g4Ci+odq+AlsYQg==",
+            "license": "Apache-2.0",
+            "dependencies": {
+                "@aws-sdk/middleware-user-agent": "3.932.0",
+                "@aws-sdk/types": "3.930.0",
+                "@smithy/node-config-provider": "^4.3.5",
+                "@smithy/types": "^4.9.0",
+                "tslib": "^2.6.2"
+            },
+            "engines": {
+                "node": ">=18.0.0"
+            },
+            "peerDependencies": {
+                "aws-crt": ">=1.0.0"
+            },
+            "peerDependenciesMeta": {
+                "aws-crt": {
+                    "optional": true
+                }
+            }
+        },
+        "packages/jobs/node_modules/@aws-sdk/client-sqs": {
+            "version": "3.932.0",
+            "resolved": "https://registry.npmjs.org/@aws-sdk/client-sqs/-/client-sqs-3.932.0.tgz",
+            "integrity": "sha512-Is0FzdPc9T/Pcd5LNgqQe5BdWohTGOlVQ98fTs0GF6HIEbfrczNQSBfj7PXv6eL9AuYFWola5SdZX4ucbMkAEg==",
+            "license": "Apache-2.0",
+            "dependencies": {
+                "@aws-crypto/sha256-browser": "5.2.0",
+                "@aws-crypto/sha256-js": "5.2.0",
+                "@aws-sdk/core": "3.932.0",
+                "@aws-sdk/credential-provider-node": "3.932.0",
+                "@aws-sdk/middleware-host-header": "3.930.0",
+                "@aws-sdk/middleware-logger": "3.930.0",
+                "@aws-sdk/middleware-recursion-detection": "3.930.0",
+                "@aws-sdk/middleware-sdk-sqs": "3.930.0",
+                "@aws-sdk/middleware-user-agent": "3.932.0",
+                "@aws-sdk/region-config-resolver": "3.930.0",
+                "@aws-sdk/types": "3.930.0",
+                "@aws-sdk/util-endpoints": "3.930.0",
+                "@aws-sdk/util-user-agent-browser": "3.930.0",
+                "@aws-sdk/util-user-agent-node": "3.932.0",
+                "@smithy/config-resolver": "^4.4.3",
+                "@smithy/core": "^3.18.2",
+                "@smithy/fetch-http-handler": "^5.3.6",
+                "@smithy/hash-node": "^4.2.5",
+                "@smithy/invalid-dependency": "^4.2.5",
+                "@smithy/md5-js": "^4.2.5",
+                "@smithy/middleware-content-length": "^4.2.5",
+                "@smithy/middleware-endpoint": "^4.3.9",
+                "@smithy/middleware-retry": "^4.4.9",
+                "@smithy/middleware-serde": "^4.2.5",
+                "@smithy/middleware-stack": "^4.2.5",
+                "@smithy/node-config-provider": "^4.3.5",
+                "@smithy/node-http-handler": "^4.4.5",
+                "@smithy/protocol-http": "^5.3.5",
+                "@smithy/smithy-client": "^4.9.5",
+                "@smithy/types": "^4.9.0",
+                "@smithy/url-parser": "^4.2.5",
+                "@smithy/util-base64": "^4.3.0",
+                "@smithy/util-body-length-browser": "^4.2.0",
+                "@smithy/util-body-length-node": "^4.2.1",
+                "@smithy/util-defaults-mode-browser": "^4.3.8",
+                "@smithy/util-defaults-mode-node": "^4.2.11",
+                "@smithy/util-endpoints": "^3.2.5",
+                "@smithy/util-middleware": "^4.2.5",
+                "@smithy/util-retry": "^4.2.5",
+                "@smithy/util-utf8": "^4.2.0",
+                "tslib": "^2.6.2"
+            },
+            "engines": {
+                "node": ">=18.0.0"
+            }
+        },
+        "packages/jobs/node_modules/@aws-sdk/client-sqs/node_modules/@aws-sdk/core": {
+            "version": "3.932.0",
+            "resolved": "https://registry.npmjs.org/@aws-sdk/core/-/core-3.932.0.tgz",
+            "integrity": "sha512-AS8gypYQCbNojwgjvZGkJocC2CoEICDx9ZJ15ILsv+MlcCVLtUJSRSx3VzJOUY2EEIaGLRrPNlIqyn/9/fySvA==",
+            "license": "Apache-2.0",
+            "dependencies": {
+                "@aws-sdk/types": "3.930.0",
+                "@aws-sdk/xml-builder": "3.930.0",
+                "@smithy/core": "^3.18.2",
+                "@smithy/node-config-provider": "^4.3.5",
+                "@smithy/property-provider": "^4.2.5",
+                "@smithy/protocol-http": "^5.3.5",
+                "@smithy/signature-v4": "^5.3.5",
+                "@smithy/smithy-client": "^4.9.5",
+                "@smithy/types": "^4.9.0",
+                "@smithy/util-base64": "^4.3.0",
+                "@smithy/util-middleware": "^4.2.5",
+                "@smithy/util-utf8": "^4.2.0",
+                "tslib": "^2.6.2"
+            },
+            "engines": {
+                "node": ">=18.0.0"
+            }
+        },
+        "packages/jobs/node_modules/@aws-sdk/client-sqs/node_modules/@aws-sdk/credential-provider-node": {
+            "version": "3.932.0",
+            "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-node/-/credential-provider-node-3.932.0.tgz",
+            "integrity": "sha512-SEG9t2taBT86qe3gTunfrK8BxT710GVLGepvHr+X5Pw+qW225iNRaGN0zJH+ZE/j91tcW9wOaIoWnURkhR5wIg==",
+            "license": "Apache-2.0",
+            "dependencies": {
+                "@aws-sdk/credential-provider-env": "3.932.0",
+                "@aws-sdk/credential-provider-http": "3.932.0",
+                "@aws-sdk/credential-provider-ini": "3.932.0",
+                "@aws-sdk/credential-provider-process": "3.932.0",
+                "@aws-sdk/credential-provider-sso": "3.932.0",
+                "@aws-sdk/credential-provider-web-identity": "3.932.0",
+                "@aws-sdk/types": "3.930.0",
+                "@smithy/credential-provider-imds": "^4.2.5",
+                "@smithy/property-provider": "^4.2.5",
+                "@smithy/shared-ini-file-loader": "^4.4.0",
+                "@smithy/types": "^4.9.0",
+                "tslib": "^2.6.2"
+            },
+            "engines": {
+                "node": ">=18.0.0"
+            }
+        },
+        "packages/jobs/node_modules/@aws-sdk/client-sqs/node_modules/@aws-sdk/middleware-host-header": {
+            "version": "3.930.0",
+            "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-host-header/-/middleware-host-header-3.930.0.tgz",
+            "integrity": "sha512-x30jmm3TLu7b/b+67nMyoV0NlbnCVT5DI57yDrhXAPCtdgM1KtdLWt45UcHpKOm1JsaIkmYRh2WYu7Anx4MG0g==",
+            "license": "Apache-2.0",
+            "dependencies": {
+                "@aws-sdk/types": "3.930.0",
+                "@smithy/protocol-http": "^5.3.5",
+                "@smithy/types": "^4.9.0",
+                "tslib": "^2.6.2"
+            },
+            "engines": {
+                "node": ">=18.0.0"
+            }
+        },
+        "packages/jobs/node_modules/@aws-sdk/client-sqs/node_modules/@aws-sdk/middleware-logger": {
+            "version": "3.930.0",
+            "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-logger/-/middleware-logger-3.930.0.tgz",
+            "integrity": "sha512-vh4JBWzMCBW8wREvAwoSqB2geKsZwSHTa0nSt0OMOLp2PdTYIZDi0ZiVMmpfnjcx9XbS6aSluLv9sKx4RrG46A==",
+            "license": "Apache-2.0",
+            "dependencies": {
+                "@aws-sdk/types": "3.930.0",
+                "@smithy/types": "^4.9.0",
+                "tslib": "^2.6.2"
+            },
+            "engines": {
+                "node": ">=18.0.0"
+            }
+        },
+        "packages/jobs/node_modules/@aws-sdk/client-sqs/node_modules/@aws-sdk/middleware-recursion-detection": {
+            "version": "3.930.0",
+            "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-recursion-detection/-/middleware-recursion-detection-3.930.0.tgz",
+            "integrity": "sha512-gv0sekNpa2MBsIhm2cjP3nmYSfI4nscx/+K9u9ybrWZBWUIC4kL2sV++bFjjUz4QxUIlvKByow3/a9ARQyCu7Q==",
+            "license": "Apache-2.0",
+            "dependencies": {
+                "@aws-sdk/types": "3.930.0",
+                "@aws/lambda-invoke-store": "^0.1.1",
+                "@smithy/protocol-http": "^5.3.5",
+                "@smithy/types": "^4.9.0",
+                "tslib": "^2.6.2"
+            },
+            "engines": {
+                "node": ">=18.0.0"
+            }
+        },
+        "packages/jobs/node_modules/@aws-sdk/client-sqs/node_modules/@aws-sdk/middleware-user-agent": {
+            "version": "3.932.0",
+            "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-user-agent/-/middleware-user-agent-3.932.0.tgz",
+            "integrity": "sha512-9BGTbJyA/4PTdwQWE9hAFIJGpsYkyEW20WON3i15aDqo5oRZwZmqaVageOD57YYqG8JDJjvcwKyDdR4cc38dvg==",
+            "license": "Apache-2.0",
+            "dependencies": {
+                "@aws-sdk/core": "3.932.0",
+                "@aws-sdk/types": "3.930.0",
+                "@aws-sdk/util-endpoints": "3.930.0",
+                "@smithy/core": "^3.18.2",
+                "@smithy/protocol-http": "^5.3.5",
+                "@smithy/types": "^4.9.0",
+                "tslib": "^2.6.2"
+            },
+            "engines": {
+                "node": ">=18.0.0"
+            }
+        },
+        "packages/jobs/node_modules/@aws-sdk/client-sqs/node_modules/@aws-sdk/region-config-resolver": {
+            "version": "3.930.0",
+            "resolved": "https://registry.npmjs.org/@aws-sdk/region-config-resolver/-/region-config-resolver-3.930.0.tgz",
+            "integrity": "sha512-KL2JZqH6aYeQssu1g1KuWsReupdfOoxD6f1as2VC+rdwYFUu4LfzMsFfXnBvvQWWqQ7rZHWOw1T+o5gJmg7Dzw==",
+            "license": "Apache-2.0",
+            "dependencies": {
+                "@aws-sdk/types": "3.930.0",
+                "@smithy/config-resolver": "^4.4.3",
+                "@smithy/node-config-provider": "^4.3.5",
+                "@smithy/types": "^4.9.0",
+                "tslib": "^2.6.2"
+            },
+            "engines": {
+                "node": ">=18.0.0"
+            }
+        },
+        "packages/jobs/node_modules/@aws-sdk/client-sqs/node_modules/@aws-sdk/types": {
+            "version": "3.930.0",
+            "resolved": "https://registry.npmjs.org/@aws-sdk/types/-/types-3.930.0.tgz",
+            "integrity": "sha512-we/vaAgwlEFW7IeftmCLlLMw+6hFs3DzZPJw7lVHbj/5HJ0bz9gndxEsS2lQoeJ1zhiiLqAqvXxmM43s0MBg0A==",
+            "license": "Apache-2.0",
+            "dependencies": {
+                "@smithy/types": "^4.9.0",
+                "tslib": "^2.6.2"
+            },
+            "engines": {
+                "node": ">=18.0.0"
+            }
+        },
+        "packages/jobs/node_modules/@aws-sdk/client-sqs/node_modules/@aws-sdk/util-endpoints": {
+            "version": "3.930.0",
+            "resolved": "https://registry.npmjs.org/@aws-sdk/util-endpoints/-/util-endpoints-3.930.0.tgz",
+            "integrity": "sha512-M2oEKBzzNAYr136RRc6uqw3aWlwCxqTP1Lawps9E1d2abRPvl1p1ztQmmXp1Ak4rv8eByIZ+yQyKQ3zPdRG5dw==",
+            "license": "Apache-2.0",
+            "dependencies": {
+                "@aws-sdk/types": "3.930.0",
+                "@smithy/types": "^4.9.0",
+                "@smithy/url-parser": "^4.2.5",
+                "@smithy/util-endpoints": "^3.2.5",
+                "tslib": "^2.6.2"
+            },
+            "engines": {
+                "node": ">=18.0.0"
+            }
+        },
+        "packages/jobs/node_modules/@aws-sdk/client-sqs/node_modules/@aws-sdk/util-user-agent-browser": {
+            "version": "3.930.0",
+            "resolved": "https://registry.npmjs.org/@aws-sdk/util-user-agent-browser/-/util-user-agent-browser-3.930.0.tgz",
+            "integrity": "sha512-q6lCRm6UAe+e1LguM5E4EqM9brQlDem4XDcQ87NzEvlTW6GzmNCO0w1jS0XgCFXQHjDxjdlNFX+5sRbHijwklg==",
+            "license": "Apache-2.0",
+            "dependencies": {
+                "@aws-sdk/types": "3.930.0",
+                "@smithy/types": "^4.9.0",
+                "bowser": "^2.11.0",
+                "tslib": "^2.6.2"
+            }
+        },
+        "packages/jobs/node_modules/@aws-sdk/client-sqs/node_modules/@aws-sdk/util-user-agent-node": {
+            "version": "3.932.0",
+            "resolved": "https://registry.npmjs.org/@aws-sdk/util-user-agent-node/-/util-user-agent-node-3.932.0.tgz",
+            "integrity": "sha512-/kC6cscHrZL74TrZtgiIL5jJNbVsw9duGGPurmaVgoCbP7NnxyaSWEurbNV3VPNPhNE3bV3g4Ci+odq+AlsYQg==",
+            "license": "Apache-2.0",
+            "dependencies": {
+                "@aws-sdk/middleware-user-agent": "3.932.0",
+                "@aws-sdk/types": "3.930.0",
+                "@smithy/node-config-provider": "^4.3.5",
+                "@smithy/types": "^4.9.0",
+                "tslib": "^2.6.2"
+            },
+            "engines": {
+                "node": ">=18.0.0"
+            },
+            "peerDependencies": {
+                "aws-crt": ">=1.0.0"
+            },
+            "peerDependenciesMeta": {
+                "aws-crt": {
+                    "optional": true
+                }
+            }
+        },
+        "packages/jobs/node_modules/@aws-sdk/credential-provider-env": {
+            "version": "3.932.0",
+            "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-env/-/credential-provider-env-3.932.0.tgz",
+            "integrity": "sha512-ozge/c7NdHUDyHqro6+P5oHt8wfKSUBN+olttiVfBe9Mw3wBMpPa3gQ0pZnG+gwBkKskBuip2bMR16tqYvUSEA==",
+            "license": "Apache-2.0",
+            "dependencies": {
+                "@aws-sdk/core": "3.932.0",
+                "@aws-sdk/types": "3.930.0",
+                "@smithy/property-provider": "^4.2.5",
+                "@smithy/types": "^4.9.0",
+                "tslib": "^2.6.2"
+            },
+            "engines": {
+                "node": ">=18.0.0"
+            }
+        },
+        "packages/jobs/node_modules/@aws-sdk/credential-provider-env/node_modules/@aws-sdk/core": {
+            "version": "3.932.0",
+            "resolved": "https://registry.npmjs.org/@aws-sdk/core/-/core-3.932.0.tgz",
+            "integrity": "sha512-AS8gypYQCbNojwgjvZGkJocC2CoEICDx9ZJ15ILsv+MlcCVLtUJSRSx3VzJOUY2EEIaGLRrPNlIqyn/9/fySvA==",
+            "license": "Apache-2.0",
+            "dependencies": {
+                "@aws-sdk/types": "3.930.0",
+                "@aws-sdk/xml-builder": "3.930.0",
+                "@smithy/core": "^3.18.2",
+                "@smithy/node-config-provider": "^4.3.5",
+                "@smithy/property-provider": "^4.2.5",
+                "@smithy/protocol-http": "^5.3.5",
+                "@smithy/signature-v4": "^5.3.5",
+                "@smithy/smithy-client": "^4.9.5",
+                "@smithy/types": "^4.9.0",
+                "@smithy/util-base64": "^4.3.0",
+                "@smithy/util-middleware": "^4.2.5",
+                "@smithy/util-utf8": "^4.2.0",
+                "tslib": "^2.6.2"
+            },
+            "engines": {
+                "node": ">=18.0.0"
+            }
+        },
+        "packages/jobs/node_modules/@aws-sdk/credential-provider-env/node_modules/@aws-sdk/types": {
+            "version": "3.930.0",
+            "resolved": "https://registry.npmjs.org/@aws-sdk/types/-/types-3.930.0.tgz",
+            "integrity": "sha512-we/vaAgwlEFW7IeftmCLlLMw+6hFs3DzZPJw7lVHbj/5HJ0bz9gndxEsS2lQoeJ1zhiiLqAqvXxmM43s0MBg0A==",
+            "license": "Apache-2.0",
+            "dependencies": {
+                "@smithy/types": "^4.9.0",
+                "tslib": "^2.6.2"
+            },
+            "engines": {
+                "node": ">=18.0.0"
+            }
+        },
+        "packages/jobs/node_modules/@aws-sdk/credential-provider-http": {
+            "version": "3.932.0",
+            "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-http/-/credential-provider-http-3.932.0.tgz",
+            "integrity": "sha512-b6N9Nnlg8JInQwzBkUq5spNaXssM3h3zLxGzpPrnw0nHSIWPJPTbZzA5Ca285fcDUFuKP+qf3qkuqlAjGOdWhg==",
+            "license": "Apache-2.0",
+            "dependencies": {
+                "@aws-sdk/core": "3.932.0",
+                "@aws-sdk/types": "3.930.0",
+                "@smithy/fetch-http-handler": "^5.3.6",
+                "@smithy/node-http-handler": "^4.4.5",
+                "@smithy/property-provider": "^4.2.5",
+                "@smithy/protocol-http": "^5.3.5",
+                "@smithy/smithy-client": "^4.9.5",
+                "@smithy/types": "^4.9.0",
+                "@smithy/util-stream": "^4.5.6",
+                "tslib": "^2.6.2"
+            },
+            "engines": {
+                "node": ">=18.0.0"
+            }
+        },
+        "packages/jobs/node_modules/@aws-sdk/credential-provider-http/node_modules/@aws-sdk/core": {
+            "version": "3.932.0",
+            "resolved": "https://registry.npmjs.org/@aws-sdk/core/-/core-3.932.0.tgz",
+            "integrity": "sha512-AS8gypYQCbNojwgjvZGkJocC2CoEICDx9ZJ15ILsv+MlcCVLtUJSRSx3VzJOUY2EEIaGLRrPNlIqyn/9/fySvA==",
+            "license": "Apache-2.0",
+            "dependencies": {
+                "@aws-sdk/types": "3.930.0",
+                "@aws-sdk/xml-builder": "3.930.0",
+                "@smithy/core": "^3.18.2",
+                "@smithy/node-config-provider": "^4.3.5",
+                "@smithy/property-provider": "^4.2.5",
+                "@smithy/protocol-http": "^5.3.5",
+                "@smithy/signature-v4": "^5.3.5",
+                "@smithy/smithy-client": "^4.9.5",
+                "@smithy/types": "^4.9.0",
+                "@smithy/util-base64": "^4.3.0",
+                "@smithy/util-middleware": "^4.2.5",
+                "@smithy/util-utf8": "^4.2.0",
+                "tslib": "^2.6.2"
+            },
+            "engines": {
+                "node": ">=18.0.0"
+            }
+        },
+        "packages/jobs/node_modules/@aws-sdk/credential-provider-http/node_modules/@aws-sdk/types": {
+            "version": "3.930.0",
+            "resolved": "https://registry.npmjs.org/@aws-sdk/types/-/types-3.930.0.tgz",
+            "integrity": "sha512-we/vaAgwlEFW7IeftmCLlLMw+6hFs3DzZPJw7lVHbj/5HJ0bz9gndxEsS2lQoeJ1zhiiLqAqvXxmM43s0MBg0A==",
+            "license": "Apache-2.0",
+            "dependencies": {
+                "@smithy/types": "^4.9.0",
+                "tslib": "^2.6.2"
+            },
+            "engines": {
+                "node": ">=18.0.0"
+            }
+        },
+        "packages/jobs/node_modules/@aws-sdk/credential-provider-ini": {
+            "version": "3.932.0",
+            "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-ini/-/credential-provider-ini-3.932.0.tgz",
+            "integrity": "sha512-ZBjSAXVGy7danZRHCRMJQ7sBkG1Dz39thYlvTiUaf9BKZ+8ymeiFhuTeV1OkWUBBnY0ki2dVZJvboTqfINhNxA==",
+            "license": "Apache-2.0",
+            "dependencies": {
+                "@aws-sdk/core": "3.932.0",
+                "@aws-sdk/credential-provider-env": "3.932.0",
+                "@aws-sdk/credential-provider-http": "3.932.0",
+                "@aws-sdk/credential-provider-process": "3.932.0",
+                "@aws-sdk/credential-provider-sso": "3.932.0",
+                "@aws-sdk/credential-provider-web-identity": "3.932.0",
+                "@aws-sdk/nested-clients": "3.932.0",
+                "@aws-sdk/types": "3.930.0",
+                "@smithy/credential-provider-imds": "^4.2.5",
+                "@smithy/property-provider": "^4.2.5",
+                "@smithy/shared-ini-file-loader": "^4.4.0",
+                "@smithy/types": "^4.9.0",
+                "tslib": "^2.6.2"
+            },
+            "engines": {
+                "node": ">=18.0.0"
+            }
+        },
+        "packages/jobs/node_modules/@aws-sdk/credential-provider-ini/node_modules/@aws-sdk/core": {
+            "version": "3.932.0",
+            "resolved": "https://registry.npmjs.org/@aws-sdk/core/-/core-3.932.0.tgz",
+            "integrity": "sha512-AS8gypYQCbNojwgjvZGkJocC2CoEICDx9ZJ15ILsv+MlcCVLtUJSRSx3VzJOUY2EEIaGLRrPNlIqyn/9/fySvA==",
+            "license": "Apache-2.0",
+            "dependencies": {
+                "@aws-sdk/types": "3.930.0",
+                "@aws-sdk/xml-builder": "3.930.0",
+                "@smithy/core": "^3.18.2",
+                "@smithy/node-config-provider": "^4.3.5",
+                "@smithy/property-provider": "^4.2.5",
+                "@smithy/protocol-http": "^5.3.5",
+                "@smithy/signature-v4": "^5.3.5",
+                "@smithy/smithy-client": "^4.9.5",
+                "@smithy/types": "^4.9.0",
+                "@smithy/util-base64": "^4.3.0",
+                "@smithy/util-middleware": "^4.2.5",
+                "@smithy/util-utf8": "^4.2.0",
+                "tslib": "^2.6.2"
+            },
+            "engines": {
+                "node": ">=18.0.0"
+            }
+        },
+        "packages/jobs/node_modules/@aws-sdk/credential-provider-ini/node_modules/@aws-sdk/types": {
+            "version": "3.930.0",
+            "resolved": "https://registry.npmjs.org/@aws-sdk/types/-/types-3.930.0.tgz",
+            "integrity": "sha512-we/vaAgwlEFW7IeftmCLlLMw+6hFs3DzZPJw7lVHbj/5HJ0bz9gndxEsS2lQoeJ1zhiiLqAqvXxmM43s0MBg0A==",
+            "license": "Apache-2.0",
+            "dependencies": {
+                "@smithy/types": "^4.9.0",
+                "tslib": "^2.6.2"
+            },
+            "engines": {
+                "node": ">=18.0.0"
+            }
+        },
+        "packages/jobs/node_modules/@aws-sdk/credential-provider-process": {
+            "version": "3.932.0",
+            "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-process/-/credential-provider-process-3.932.0.tgz",
+            "integrity": "sha512-BodZYKvT4p/Dkm28Ql/FhDdS1+p51bcZeMMu2TRtU8PoMDHnVDhHz27zASEKSZwmhvquxHrZHB0IGuVqjZUtSQ==",
+            "license": "Apache-2.0",
+            "dependencies": {
+                "@aws-sdk/core": "3.932.0",
+                "@aws-sdk/types": "3.930.0",
+                "@smithy/property-provider": "^4.2.5",
+                "@smithy/shared-ini-file-loader": "^4.4.0",
+                "@smithy/types": "^4.9.0",
+                "tslib": "^2.6.2"
+            },
+            "engines": {
+                "node": ">=18.0.0"
+            }
+        },
+        "packages/jobs/node_modules/@aws-sdk/credential-provider-process/node_modules/@aws-sdk/core": {
+            "version": "3.932.0",
+            "resolved": "https://registry.npmjs.org/@aws-sdk/core/-/core-3.932.0.tgz",
+            "integrity": "sha512-AS8gypYQCbNojwgjvZGkJocC2CoEICDx9ZJ15ILsv+MlcCVLtUJSRSx3VzJOUY2EEIaGLRrPNlIqyn/9/fySvA==",
+            "license": "Apache-2.0",
+            "dependencies": {
+                "@aws-sdk/types": "3.930.0",
+                "@aws-sdk/xml-builder": "3.930.0",
+                "@smithy/core": "^3.18.2",
+                "@smithy/node-config-provider": "^4.3.5",
+                "@smithy/property-provider": "^4.2.5",
+                "@smithy/protocol-http": "^5.3.5",
+                "@smithy/signature-v4": "^5.3.5",
+                "@smithy/smithy-client": "^4.9.5",
+                "@smithy/types": "^4.9.0",
+                "@smithy/util-base64": "^4.3.0",
+                "@smithy/util-middleware": "^4.2.5",
+                "@smithy/util-utf8": "^4.2.0",
+                "tslib": "^2.6.2"
+            },
+            "engines": {
+                "node": ">=18.0.0"
+            }
+        },
+        "packages/jobs/node_modules/@aws-sdk/credential-provider-process/node_modules/@aws-sdk/types": {
+            "version": "3.930.0",
+            "resolved": "https://registry.npmjs.org/@aws-sdk/types/-/types-3.930.0.tgz",
+            "integrity": "sha512-we/vaAgwlEFW7IeftmCLlLMw+6hFs3DzZPJw7lVHbj/5HJ0bz9gndxEsS2lQoeJ1zhiiLqAqvXxmM43s0MBg0A==",
+            "license": "Apache-2.0",
+            "dependencies": {
+                "@smithy/types": "^4.9.0",
+                "tslib": "^2.6.2"
+            },
+            "engines": {
+                "node": ">=18.0.0"
+            }
+        },
+        "packages/jobs/node_modules/@aws-sdk/credential-provider-sso": {
+            "version": "3.932.0",
+            "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-sso/-/credential-provider-sso-3.932.0.tgz",
+            "integrity": "sha512-XYmkv+ltBjjmPZ6AmR1ZQZkQfD0uzG61M18/Lif3HAGxyg3dmod0aWx9aL6lj9SvxAGqzscrx5j4PkgLqjZruw==",
+            "license": "Apache-2.0",
+            "dependencies": {
+                "@aws-sdk/client-sso": "3.932.0",
+                "@aws-sdk/core": "3.932.0",
+                "@aws-sdk/token-providers": "3.932.0",
+                "@aws-sdk/types": "3.930.0",
+                "@smithy/property-provider": "^4.2.5",
+                "@smithy/shared-ini-file-loader": "^4.4.0",
+                "@smithy/types": "^4.9.0",
+                "tslib": "^2.6.2"
+            },
+            "engines": {
+                "node": ">=18.0.0"
+            }
+        },
+        "packages/jobs/node_modules/@aws-sdk/credential-provider-sso/node_modules/@aws-sdk/core": {
+            "version": "3.932.0",
+            "resolved": "https://registry.npmjs.org/@aws-sdk/core/-/core-3.932.0.tgz",
+            "integrity": "sha512-AS8gypYQCbNojwgjvZGkJocC2CoEICDx9ZJ15ILsv+MlcCVLtUJSRSx3VzJOUY2EEIaGLRrPNlIqyn/9/fySvA==",
+            "license": "Apache-2.0",
+            "dependencies": {
+                "@aws-sdk/types": "3.930.0",
+                "@aws-sdk/xml-builder": "3.930.0",
+                "@smithy/core": "^3.18.2",
+                "@smithy/node-config-provider": "^4.3.5",
+                "@smithy/property-provider": "^4.2.5",
+                "@smithy/protocol-http": "^5.3.5",
+                "@smithy/signature-v4": "^5.3.5",
+                "@smithy/smithy-client": "^4.9.5",
+                "@smithy/types": "^4.9.0",
+                "@smithy/util-base64": "^4.3.0",
+                "@smithy/util-middleware": "^4.2.5",
+                "@smithy/util-utf8": "^4.2.0",
+                "tslib": "^2.6.2"
+            },
+            "engines": {
+                "node": ">=18.0.0"
+            }
+        },
+        "packages/jobs/node_modules/@aws-sdk/credential-provider-sso/node_modules/@aws-sdk/types": {
+            "version": "3.930.0",
+            "resolved": "https://registry.npmjs.org/@aws-sdk/types/-/types-3.930.0.tgz",
+            "integrity": "sha512-we/vaAgwlEFW7IeftmCLlLMw+6hFs3DzZPJw7lVHbj/5HJ0bz9gndxEsS2lQoeJ1zhiiLqAqvXxmM43s0MBg0A==",
+            "license": "Apache-2.0",
+            "dependencies": {
+                "@smithy/types": "^4.9.0",
+                "tslib": "^2.6.2"
+            },
+            "engines": {
+                "node": ">=18.0.0"
+            }
+        },
+        "packages/jobs/node_modules/@aws-sdk/credential-provider-web-identity": {
+            "version": "3.932.0",
+            "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-web-identity/-/credential-provider-web-identity-3.932.0.tgz",
+            "integrity": "sha512-Yw/hYNnC1KHuVIQF9PkLXbuKN7ljx70OSbJYDRufllQvej3kRwNcqQSnzI1M4KaObccqKaE6srg22DqpPy9p8w==",
+            "license": "Apache-2.0",
+            "dependencies": {
+                "@aws-sdk/core": "3.932.0",
+                "@aws-sdk/nested-clients": "3.932.0",
+                "@aws-sdk/types": "3.930.0",
+                "@smithy/property-provider": "^4.2.5",
+                "@smithy/shared-ini-file-loader": "^4.4.0",
+                "@smithy/types": "^4.9.0",
+                "tslib": "^2.6.2"
+            },
+            "engines": {
+                "node": ">=18.0.0"
+            }
+        },
+        "packages/jobs/node_modules/@aws-sdk/credential-provider-web-identity/node_modules/@aws-sdk/core": {
+            "version": "3.932.0",
+            "resolved": "https://registry.npmjs.org/@aws-sdk/core/-/core-3.932.0.tgz",
+            "integrity": "sha512-AS8gypYQCbNojwgjvZGkJocC2CoEICDx9ZJ15ILsv+MlcCVLtUJSRSx3VzJOUY2EEIaGLRrPNlIqyn/9/fySvA==",
+            "license": "Apache-2.0",
+            "dependencies": {
+                "@aws-sdk/types": "3.930.0",
+                "@aws-sdk/xml-builder": "3.930.0",
+                "@smithy/core": "^3.18.2",
+                "@smithy/node-config-provider": "^4.3.5",
+                "@smithy/property-provider": "^4.2.5",
+                "@smithy/protocol-http": "^5.3.5",
+                "@smithy/signature-v4": "^5.3.5",
+                "@smithy/smithy-client": "^4.9.5",
+                "@smithy/types": "^4.9.0",
+                "@smithy/util-base64": "^4.3.0",
+                "@smithy/util-middleware": "^4.2.5",
+                "@smithy/util-utf8": "^4.2.0",
+                "tslib": "^2.6.2"
+            },
+            "engines": {
+                "node": ">=18.0.0"
+            }
+        },
+        "packages/jobs/node_modules/@aws-sdk/credential-provider-web-identity/node_modules/@aws-sdk/types": {
+            "version": "3.930.0",
+            "resolved": "https://registry.npmjs.org/@aws-sdk/types/-/types-3.930.0.tgz",
+            "integrity": "sha512-we/vaAgwlEFW7IeftmCLlLMw+6hFs3DzZPJw7lVHbj/5HJ0bz9gndxEsS2lQoeJ1zhiiLqAqvXxmM43s0MBg0A==",
+            "license": "Apache-2.0",
+            "dependencies": {
+                "@smithy/types": "^4.9.0",
+                "tslib": "^2.6.2"
+            },
+            "engines": {
+                "node": ">=18.0.0"
+            }
+        },
+        "packages/jobs/node_modules/@aws-sdk/middleware-bucket-endpoint": {
+            "version": "3.930.0",
+            "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-bucket-endpoint/-/middleware-bucket-endpoint-3.930.0.tgz",
+            "integrity": "sha512-cnCLWeKPYgvV4yRYPFH6pWMdUByvu2cy2BAlfsPpvnm4RaVioztyvxmQj5PmVN5fvWs5w/2d6U7le8X9iye2sA==",
+            "license": "Apache-2.0",
+            "dependencies": {
+                "@aws-sdk/types": "3.930.0",
+                "@aws-sdk/util-arn-parser": "3.893.0",
+                "@smithy/node-config-provider": "^4.3.5",
+                "@smithy/protocol-http": "^5.3.5",
+                "@smithy/types": "^4.9.0",
+                "@smithy/util-config-provider": "^4.2.0",
+                "tslib": "^2.6.2"
+            },
+            "engines": {
+                "node": ">=18.0.0"
+            }
+        },
+        "packages/jobs/node_modules/@aws-sdk/middleware-bucket-endpoint/node_modules/@aws-sdk/types": {
+            "version": "3.930.0",
+            "resolved": "https://registry.npmjs.org/@aws-sdk/types/-/types-3.930.0.tgz",
+            "integrity": "sha512-we/vaAgwlEFW7IeftmCLlLMw+6hFs3DzZPJw7lVHbj/5HJ0bz9gndxEsS2lQoeJ1zhiiLqAqvXxmM43s0MBg0A==",
+            "license": "Apache-2.0",
+            "dependencies": {
+                "@smithy/types": "^4.9.0",
+                "tslib": "^2.6.2"
+            },
+            "engines": {
+                "node": ">=18.0.0"
+            }
+        },
+        "packages/jobs/node_modules/@aws-sdk/middleware-expect-continue": {
+            "version": "3.930.0",
+            "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-expect-continue/-/middleware-expect-continue-3.930.0.tgz",
+            "integrity": "sha512-5HEQ+JU4DrLNWeY27wKg/jeVa8Suy62ivJHOSUf6e6hZdVIMx0h/kXS1fHEQNNiLu2IzSEP/bFXsKBaW7x7s0g==",
+            "license": "Apache-2.0",
+            "dependencies": {
+                "@aws-sdk/types": "3.930.0",
+                "@smithy/protocol-http": "^5.3.5",
+                "@smithy/types": "^4.9.0",
+                "tslib": "^2.6.2"
+            },
+            "engines": {
+                "node": ">=18.0.0"
+            }
+        },
+        "packages/jobs/node_modules/@aws-sdk/middleware-expect-continue/node_modules/@aws-sdk/types": {
+            "version": "3.930.0",
+            "resolved": "https://registry.npmjs.org/@aws-sdk/types/-/types-3.930.0.tgz",
+            "integrity": "sha512-we/vaAgwlEFW7IeftmCLlLMw+6hFs3DzZPJw7lVHbj/5HJ0bz9gndxEsS2lQoeJ1zhiiLqAqvXxmM43s0MBg0A==",
+            "license": "Apache-2.0",
+            "dependencies": {
+                "@smithy/types": "^4.9.0",
+                "tslib": "^2.6.2"
+            },
+            "engines": {
+                "node": ">=18.0.0"
+            }
+        },
+        "packages/jobs/node_modules/@aws-sdk/middleware-flexible-checksums": {
+            "version": "3.932.0",
+            "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-flexible-checksums/-/middleware-flexible-checksums-3.932.0.tgz",
+            "integrity": "sha512-hyvRz/XS/0HTHp9/Ld1mKwpOi7bZu5olI42+T112rkCTbt1bewkygzEl4oflY4H7cKMamQusYoL0yBUD/QSEvA==",
+            "license": "Apache-2.0",
+            "dependencies": {
+                "@aws-crypto/crc32": "5.2.0",
+                "@aws-crypto/crc32c": "5.2.0",
+                "@aws-crypto/util": "5.2.0",
+                "@aws-sdk/core": "3.932.0",
+                "@aws-sdk/types": "3.930.0",
+                "@smithy/is-array-buffer": "^4.2.0",
+                "@smithy/node-config-provider": "^4.3.5",
+                "@smithy/protocol-http": "^5.3.5",
+                "@smithy/types": "^4.9.0",
+                "@smithy/util-middleware": "^4.2.5",
+                "@smithy/util-stream": "^4.5.6",
+                "@smithy/util-utf8": "^4.2.0",
+                "tslib": "^2.6.2"
+            },
+            "engines": {
+                "node": ">=18.0.0"
+            }
+        },
+        "packages/jobs/node_modules/@aws-sdk/middleware-flexible-checksums/node_modules/@aws-sdk/core": {
+            "version": "3.932.0",
+            "resolved": "https://registry.npmjs.org/@aws-sdk/core/-/core-3.932.0.tgz",
+            "integrity": "sha512-AS8gypYQCbNojwgjvZGkJocC2CoEICDx9ZJ15ILsv+MlcCVLtUJSRSx3VzJOUY2EEIaGLRrPNlIqyn/9/fySvA==",
+            "license": "Apache-2.0",
+            "dependencies": {
+                "@aws-sdk/types": "3.930.0",
+                "@aws-sdk/xml-builder": "3.930.0",
+                "@smithy/core": "^3.18.2",
+                "@smithy/node-config-provider": "^4.3.5",
+                "@smithy/property-provider": "^4.2.5",
+                "@smithy/protocol-http": "^5.3.5",
+                "@smithy/signature-v4": "^5.3.5",
+                "@smithy/smithy-client": "^4.9.5",
+                "@smithy/types": "^4.9.0",
+                "@smithy/util-base64": "^4.3.0",
+                "@smithy/util-middleware": "^4.2.5",
+                "@smithy/util-utf8": "^4.2.0",
+                "tslib": "^2.6.2"
+            },
+            "engines": {
+                "node": ">=18.0.0"
+            }
+        },
+        "packages/jobs/node_modules/@aws-sdk/middleware-flexible-checksums/node_modules/@aws-sdk/types": {
+            "version": "3.930.0",
+            "resolved": "https://registry.npmjs.org/@aws-sdk/types/-/types-3.930.0.tgz",
+            "integrity": "sha512-we/vaAgwlEFW7IeftmCLlLMw+6hFs3DzZPJw7lVHbj/5HJ0bz9gndxEsS2lQoeJ1zhiiLqAqvXxmM43s0MBg0A==",
+            "license": "Apache-2.0",
+            "dependencies": {
+                "@smithy/types": "^4.9.0",
+                "tslib": "^2.6.2"
+            },
+            "engines": {
+                "node": ">=18.0.0"
+            }
+        },
+        "packages/jobs/node_modules/@aws-sdk/middleware-location-constraint": {
+            "version": "3.930.0",
+            "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-location-constraint/-/middleware-location-constraint-3.930.0.tgz",
+            "integrity": "sha512-QIGNsNUdRICog+LYqmtJ03PLze6h2KCORXUs5td/hAEjVP5DMmubhtrGg1KhWyctACluUH/E/yrD14p4pRXxwA==",
+            "license": "Apache-2.0",
+            "dependencies": {
+                "@aws-sdk/types": "3.930.0",
+                "@smithy/types": "^4.9.0",
+                "tslib": "^2.6.2"
+            },
+            "engines": {
+                "node": ">=18.0.0"
+            }
+        },
+        "packages/jobs/node_modules/@aws-sdk/middleware-location-constraint/node_modules/@aws-sdk/types": {
+            "version": "3.930.0",
+            "resolved": "https://registry.npmjs.org/@aws-sdk/types/-/types-3.930.0.tgz",
+            "integrity": "sha512-we/vaAgwlEFW7IeftmCLlLMw+6hFs3DzZPJw7lVHbj/5HJ0bz9gndxEsS2lQoeJ1zhiiLqAqvXxmM43s0MBg0A==",
+            "license": "Apache-2.0",
+            "dependencies": {
+                "@smithy/types": "^4.9.0",
+                "tslib": "^2.6.2"
+            },
+            "engines": {
+                "node": ">=18.0.0"
+            }
+        },
+        "packages/jobs/node_modules/@aws-sdk/middleware-sdk-s3": {
+            "version": "3.932.0",
+            "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-sdk-s3/-/middleware-sdk-s3-3.932.0.tgz",
+            "integrity": "sha512-bYMHxqQzseaAP9Z5qLI918z5AtbAnZRRtFi3POb4FLZyreBMgCgBNaPkIhdgywnkqaydTWvbMBX4s9f4gUwlTw==",
+            "license": "Apache-2.0",
+            "dependencies": {
+                "@aws-sdk/core": "3.932.0",
+                "@aws-sdk/types": "3.930.0",
+                "@aws-sdk/util-arn-parser": "3.893.0",
+                "@smithy/core": "^3.18.2",
+                "@smithy/node-config-provider": "^4.3.5",
+                "@smithy/protocol-http": "^5.3.5",
+                "@smithy/signature-v4": "^5.3.5",
+                "@smithy/smithy-client": "^4.9.5",
+                "@smithy/types": "^4.9.0",
+                "@smithy/util-config-provider": "^4.2.0",
+                "@smithy/util-middleware": "^4.2.5",
+                "@smithy/util-stream": "^4.5.6",
+                "@smithy/util-utf8": "^4.2.0",
+                "tslib": "^2.6.2"
+            },
+            "engines": {
+                "node": ">=18.0.0"
+            }
+        },
+        "packages/jobs/node_modules/@aws-sdk/middleware-sdk-s3/node_modules/@aws-sdk/core": {
+            "version": "3.932.0",
+            "resolved": "https://registry.npmjs.org/@aws-sdk/core/-/core-3.932.0.tgz",
+            "integrity": "sha512-AS8gypYQCbNojwgjvZGkJocC2CoEICDx9ZJ15ILsv+MlcCVLtUJSRSx3VzJOUY2EEIaGLRrPNlIqyn/9/fySvA==",
+            "license": "Apache-2.0",
+            "dependencies": {
+                "@aws-sdk/types": "3.930.0",
+                "@aws-sdk/xml-builder": "3.930.0",
+                "@smithy/core": "^3.18.2",
+                "@smithy/node-config-provider": "^4.3.5",
+                "@smithy/property-provider": "^4.2.5",
+                "@smithy/protocol-http": "^5.3.5",
+                "@smithy/signature-v4": "^5.3.5",
+                "@smithy/smithy-client": "^4.9.5",
+                "@smithy/types": "^4.9.0",
+                "@smithy/util-base64": "^4.3.0",
+                "@smithy/util-middleware": "^4.2.5",
+                "@smithy/util-utf8": "^4.2.0",
+                "tslib": "^2.6.2"
+            },
+            "engines": {
+                "node": ">=18.0.0"
+            }
+        },
+        "packages/jobs/node_modules/@aws-sdk/middleware-sdk-s3/node_modules/@aws-sdk/types": {
+            "version": "3.930.0",
+            "resolved": "https://registry.npmjs.org/@aws-sdk/types/-/types-3.930.0.tgz",
+            "integrity": "sha512-we/vaAgwlEFW7IeftmCLlLMw+6hFs3DzZPJw7lVHbj/5HJ0bz9gndxEsS2lQoeJ1zhiiLqAqvXxmM43s0MBg0A==",
+            "license": "Apache-2.0",
+            "dependencies": {
+                "@smithy/types": "^4.9.0",
+                "tslib": "^2.6.2"
+            },
+            "engines": {
+                "node": ">=18.0.0"
+            }
+        },
+        "packages/jobs/node_modules/@aws-sdk/middleware-sdk-sqs": {
+            "version": "3.930.0",
+            "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-sdk-sqs/-/middleware-sdk-sqs-3.930.0.tgz",
+            "integrity": "sha512-Sk/VgUC9LTLloWUJHSLw9EkGukQHb/54rF1p9qJgJByQJLPmBd4oKiEGmKImVyUo/RN9BUPgNlNLWPUON6ySmQ==",
+            "license": "Apache-2.0",
+            "dependencies": {
+                "@aws-sdk/types": "3.930.0",
+                "@smithy/smithy-client": "^4.9.5",
+                "@smithy/types": "^4.9.0",
+                "@smithy/util-hex-encoding": "^4.2.0",
+                "@smithy/util-utf8": "^4.2.0",
+                "tslib": "^2.6.2"
+            },
+            "engines": {
+                "node": ">=18.0.0"
+            }
+        },
+        "packages/jobs/node_modules/@aws-sdk/middleware-sdk-sqs/node_modules/@aws-sdk/types": {
+            "version": "3.930.0",
+            "resolved": "https://registry.npmjs.org/@aws-sdk/types/-/types-3.930.0.tgz",
+            "integrity": "sha512-we/vaAgwlEFW7IeftmCLlLMw+6hFs3DzZPJw7lVHbj/5HJ0bz9gndxEsS2lQoeJ1zhiiLqAqvXxmM43s0MBg0A==",
+            "license": "Apache-2.0",
+            "dependencies": {
+                "@smithy/types": "^4.9.0",
+                "tslib": "^2.6.2"
+            },
+            "engines": {
+                "node": ">=18.0.0"
+            }
+        },
+        "packages/jobs/node_modules/@aws-sdk/middleware-ssec": {
+            "version": "3.930.0",
+            "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-ssec/-/middleware-ssec-3.930.0.tgz",
+            "integrity": "sha512-N2/SvodmaDS6h7CWfuapt3oJyn1T2CBz0CsDIiTDv9cSagXAVFjPdm2g4PFJqrNBeqdDIoYBnnta336HmamWHg==",
+            "license": "Apache-2.0",
+            "dependencies": {
+                "@aws-sdk/types": "3.930.0",
+                "@smithy/types": "^4.9.0",
+                "tslib": "^2.6.2"
+            },
+            "engines": {
+                "node": ">=18.0.0"
+            }
+        },
+        "packages/jobs/node_modules/@aws-sdk/middleware-ssec/node_modules/@aws-sdk/types": {
+            "version": "3.930.0",
+            "resolved": "https://registry.npmjs.org/@aws-sdk/types/-/types-3.930.0.tgz",
+            "integrity": "sha512-we/vaAgwlEFW7IeftmCLlLMw+6hFs3DzZPJw7lVHbj/5HJ0bz9gndxEsS2lQoeJ1zhiiLqAqvXxmM43s0MBg0A==",
+            "license": "Apache-2.0",
+            "dependencies": {
+                "@smithy/types": "^4.9.0",
+                "tslib": "^2.6.2"
+            },
+            "engines": {
+                "node": ">=18.0.0"
+            }
+        },
+        "packages/jobs/node_modules/@aws-sdk/nested-clients": {
+            "version": "3.932.0",
+            "resolved": "https://registry.npmjs.org/@aws-sdk/nested-clients/-/nested-clients-3.932.0.tgz",
+            "integrity": "sha512-E2ucBfiXSpxZflHTf3UFbVwao4+7v7ctAeg8SWuglc1UMqMlpwMFFgWiSONtsf0SR3+ZDoWGATyCXOfDWerJuw==",
+            "license": "Apache-2.0",
+            "dependencies": {
+                "@aws-crypto/sha256-browser": "5.2.0",
+                "@aws-crypto/sha256-js": "5.2.0",
+                "@aws-sdk/core": "3.932.0",
+                "@aws-sdk/middleware-host-header": "3.930.0",
+                "@aws-sdk/middleware-logger": "3.930.0",
+                "@aws-sdk/middleware-recursion-detection": "3.930.0",
+                "@aws-sdk/middleware-user-agent": "3.932.0",
+                "@aws-sdk/region-config-resolver": "3.930.0",
+                "@aws-sdk/types": "3.930.0",
+                "@aws-sdk/util-endpoints": "3.930.0",
+                "@aws-sdk/util-user-agent-browser": "3.930.0",
+                "@aws-sdk/util-user-agent-node": "3.932.0",
+                "@smithy/config-resolver": "^4.4.3",
+                "@smithy/core": "^3.18.2",
+                "@smithy/fetch-http-handler": "^5.3.6",
+                "@smithy/hash-node": "^4.2.5",
+                "@smithy/invalid-dependency": "^4.2.5",
+                "@smithy/middleware-content-length": "^4.2.5",
+                "@smithy/middleware-endpoint": "^4.3.9",
+                "@smithy/middleware-retry": "^4.4.9",
+                "@smithy/middleware-serde": "^4.2.5",
+                "@smithy/middleware-stack": "^4.2.5",
+                "@smithy/node-config-provider": "^4.3.5",
+                "@smithy/node-http-handler": "^4.4.5",
+                "@smithy/protocol-http": "^5.3.5",
+                "@smithy/smithy-client": "^4.9.5",
+                "@smithy/types": "^4.9.0",
+                "@smithy/url-parser": "^4.2.5",
+                "@smithy/util-base64": "^4.3.0",
+                "@smithy/util-body-length-browser": "^4.2.0",
+                "@smithy/util-body-length-node": "^4.2.1",
+                "@smithy/util-defaults-mode-browser": "^4.3.8",
+                "@smithy/util-defaults-mode-node": "^4.2.11",
+                "@smithy/util-endpoints": "^3.2.5",
+                "@smithy/util-middleware": "^4.2.5",
+                "@smithy/util-retry": "^4.2.5",
+                "@smithy/util-utf8": "^4.2.0",
+                "tslib": "^2.6.2"
+            },
+            "engines": {
+                "node": ">=18.0.0"
+            }
+        },
+        "packages/jobs/node_modules/@aws-sdk/nested-clients/node_modules/@aws-sdk/core": {
+            "version": "3.932.0",
+            "resolved": "https://registry.npmjs.org/@aws-sdk/core/-/core-3.932.0.tgz",
+            "integrity": "sha512-AS8gypYQCbNojwgjvZGkJocC2CoEICDx9ZJ15ILsv+MlcCVLtUJSRSx3VzJOUY2EEIaGLRrPNlIqyn/9/fySvA==",
+            "license": "Apache-2.0",
+            "dependencies": {
+                "@aws-sdk/types": "3.930.0",
+                "@aws-sdk/xml-builder": "3.930.0",
+                "@smithy/core": "^3.18.2",
+                "@smithy/node-config-provider": "^4.3.5",
+                "@smithy/property-provider": "^4.2.5",
+                "@smithy/protocol-http": "^5.3.5",
+                "@smithy/signature-v4": "^5.3.5",
+                "@smithy/smithy-client": "^4.9.5",
+                "@smithy/types": "^4.9.0",
+                "@smithy/util-base64": "^4.3.0",
+                "@smithy/util-middleware": "^4.2.5",
+                "@smithy/util-utf8": "^4.2.0",
+                "tslib": "^2.6.2"
+            },
+            "engines": {
+                "node": ">=18.0.0"
+            }
+        },
+        "packages/jobs/node_modules/@aws-sdk/nested-clients/node_modules/@aws-sdk/middleware-host-header": {
+            "version": "3.930.0",
+            "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-host-header/-/middleware-host-header-3.930.0.tgz",
+            "integrity": "sha512-x30jmm3TLu7b/b+67nMyoV0NlbnCVT5DI57yDrhXAPCtdgM1KtdLWt45UcHpKOm1JsaIkmYRh2WYu7Anx4MG0g==",
+            "license": "Apache-2.0",
+            "dependencies": {
+                "@aws-sdk/types": "3.930.0",
+                "@smithy/protocol-http": "^5.3.5",
+                "@smithy/types": "^4.9.0",
+                "tslib": "^2.6.2"
+            },
+            "engines": {
+                "node": ">=18.0.0"
+            }
+        },
+        "packages/jobs/node_modules/@aws-sdk/nested-clients/node_modules/@aws-sdk/middleware-logger": {
+            "version": "3.930.0",
+            "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-logger/-/middleware-logger-3.930.0.tgz",
+            "integrity": "sha512-vh4JBWzMCBW8wREvAwoSqB2geKsZwSHTa0nSt0OMOLp2PdTYIZDi0ZiVMmpfnjcx9XbS6aSluLv9sKx4RrG46A==",
+            "license": "Apache-2.0",
+            "dependencies": {
+                "@aws-sdk/types": "3.930.0",
+                "@smithy/types": "^4.9.0",
+                "tslib": "^2.6.2"
+            },
+            "engines": {
+                "node": ">=18.0.0"
+            }
+        },
+        "packages/jobs/node_modules/@aws-sdk/nested-clients/node_modules/@aws-sdk/middleware-recursion-detection": {
+            "version": "3.930.0",
+            "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-recursion-detection/-/middleware-recursion-detection-3.930.0.tgz",
+            "integrity": "sha512-gv0sekNpa2MBsIhm2cjP3nmYSfI4nscx/+K9u9ybrWZBWUIC4kL2sV++bFjjUz4QxUIlvKByow3/a9ARQyCu7Q==",
+            "license": "Apache-2.0",
+            "dependencies": {
+                "@aws-sdk/types": "3.930.0",
+                "@aws/lambda-invoke-store": "^0.1.1",
+                "@smithy/protocol-http": "^5.3.5",
+                "@smithy/types": "^4.9.0",
+                "tslib": "^2.6.2"
+            },
+            "engines": {
+                "node": ">=18.0.0"
+            }
+        },
+        "packages/jobs/node_modules/@aws-sdk/nested-clients/node_modules/@aws-sdk/middleware-user-agent": {
+            "version": "3.932.0",
+            "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-user-agent/-/middleware-user-agent-3.932.0.tgz",
+            "integrity": "sha512-9BGTbJyA/4PTdwQWE9hAFIJGpsYkyEW20WON3i15aDqo5oRZwZmqaVageOD57YYqG8JDJjvcwKyDdR4cc38dvg==",
+            "license": "Apache-2.0",
+            "dependencies": {
+                "@aws-sdk/core": "3.932.0",
+                "@aws-sdk/types": "3.930.0",
+                "@aws-sdk/util-endpoints": "3.930.0",
+                "@smithy/core": "^3.18.2",
+                "@smithy/protocol-http": "^5.3.5",
+                "@smithy/types": "^4.9.0",
+                "tslib": "^2.6.2"
+            },
+            "engines": {
+                "node": ">=18.0.0"
+            }
+        },
+        "packages/jobs/node_modules/@aws-sdk/nested-clients/node_modules/@aws-sdk/region-config-resolver": {
+            "version": "3.930.0",
+            "resolved": "https://registry.npmjs.org/@aws-sdk/region-config-resolver/-/region-config-resolver-3.930.0.tgz",
+            "integrity": "sha512-KL2JZqH6aYeQssu1g1KuWsReupdfOoxD6f1as2VC+rdwYFUu4LfzMsFfXnBvvQWWqQ7rZHWOw1T+o5gJmg7Dzw==",
+            "license": "Apache-2.0",
+            "dependencies": {
+                "@aws-sdk/types": "3.930.0",
+                "@smithy/config-resolver": "^4.4.3",
+                "@smithy/node-config-provider": "^4.3.5",
+                "@smithy/types": "^4.9.0",
+                "tslib": "^2.6.2"
+            },
+            "engines": {
+                "node": ">=18.0.0"
+            }
+        },
+        "packages/jobs/node_modules/@aws-sdk/nested-clients/node_modules/@aws-sdk/types": {
+            "version": "3.930.0",
+            "resolved": "https://registry.npmjs.org/@aws-sdk/types/-/types-3.930.0.tgz",
+            "integrity": "sha512-we/vaAgwlEFW7IeftmCLlLMw+6hFs3DzZPJw7lVHbj/5HJ0bz9gndxEsS2lQoeJ1zhiiLqAqvXxmM43s0MBg0A==",
+            "license": "Apache-2.0",
+            "dependencies": {
+                "@smithy/types": "^4.9.0",
+                "tslib": "^2.6.2"
+            },
+            "engines": {
+                "node": ">=18.0.0"
+            }
+        },
+        "packages/jobs/node_modules/@aws-sdk/nested-clients/node_modules/@aws-sdk/util-endpoints": {
+            "version": "3.930.0",
+            "resolved": "https://registry.npmjs.org/@aws-sdk/util-endpoints/-/util-endpoints-3.930.0.tgz",
+            "integrity": "sha512-M2oEKBzzNAYr136RRc6uqw3aWlwCxqTP1Lawps9E1d2abRPvl1p1ztQmmXp1Ak4rv8eByIZ+yQyKQ3zPdRG5dw==",
+            "license": "Apache-2.0",
+            "dependencies": {
+                "@aws-sdk/types": "3.930.0",
+                "@smithy/types": "^4.9.0",
+                "@smithy/url-parser": "^4.2.5",
+                "@smithy/util-endpoints": "^3.2.5",
+                "tslib": "^2.6.2"
+            },
+            "engines": {
+                "node": ">=18.0.0"
+            }
+        },
+        "packages/jobs/node_modules/@aws-sdk/nested-clients/node_modules/@aws-sdk/util-user-agent-browser": {
+            "version": "3.930.0",
+            "resolved": "https://registry.npmjs.org/@aws-sdk/util-user-agent-browser/-/util-user-agent-browser-3.930.0.tgz",
+            "integrity": "sha512-q6lCRm6UAe+e1LguM5E4EqM9brQlDem4XDcQ87NzEvlTW6GzmNCO0w1jS0XgCFXQHjDxjdlNFX+5sRbHijwklg==",
+            "license": "Apache-2.0",
+            "dependencies": {
+                "@aws-sdk/types": "3.930.0",
+                "@smithy/types": "^4.9.0",
+                "bowser": "^2.11.0",
+                "tslib": "^2.6.2"
+            }
+        },
+        "packages/jobs/node_modules/@aws-sdk/nested-clients/node_modules/@aws-sdk/util-user-agent-node": {
+            "version": "3.932.0",
+            "resolved": "https://registry.npmjs.org/@aws-sdk/util-user-agent-node/-/util-user-agent-node-3.932.0.tgz",
+            "integrity": "sha512-/kC6cscHrZL74TrZtgiIL5jJNbVsw9duGGPurmaVgoCbP7NnxyaSWEurbNV3VPNPhNE3bV3g4Ci+odq+AlsYQg==",
+            "license": "Apache-2.0",
+            "dependencies": {
+                "@aws-sdk/middleware-user-agent": "3.932.0",
+                "@aws-sdk/types": "3.930.0",
+                "@smithy/node-config-provider": "^4.3.5",
+                "@smithy/types": "^4.9.0",
+                "tslib": "^2.6.2"
+            },
+            "engines": {
+                "node": ">=18.0.0"
+            },
+            "peerDependencies": {
+                "aws-crt": ">=1.0.0"
+            },
+            "peerDependenciesMeta": {
+                "aws-crt": {
+                    "optional": true
+                }
+            }
+        },
+        "packages/jobs/node_modules/@aws-sdk/signature-v4-multi-region": {
+            "version": "3.932.0",
+            "resolved": "https://registry.npmjs.org/@aws-sdk/signature-v4-multi-region/-/signature-v4-multi-region-3.932.0.tgz",
+            "integrity": "sha512-NCIRJvoRc9246RZHIusY1+n/neeG2yGhBGdKhghmrNdM+mLLN6Ii7CKFZjx3DhxtpHMpl1HWLTMhdVrGwP2upw==",
+            "license": "Apache-2.0",
+            "dependencies": {
+                "@aws-sdk/middleware-sdk-s3": "3.932.0",
+                "@aws-sdk/types": "3.930.0",
+                "@smithy/protocol-http": "^5.3.5",
+                "@smithy/signature-v4": "^5.3.5",
+                "@smithy/types": "^4.9.0",
+                "tslib": "^2.6.2"
+            },
+            "engines": {
+                "node": ">=18.0.0"
+            }
+        },
+        "packages/jobs/node_modules/@aws-sdk/signature-v4-multi-region/node_modules/@aws-sdk/types": {
+            "version": "3.930.0",
+            "resolved": "https://registry.npmjs.org/@aws-sdk/types/-/types-3.930.0.tgz",
+            "integrity": "sha512-we/vaAgwlEFW7IeftmCLlLMw+6hFs3DzZPJw7lVHbj/5HJ0bz9gndxEsS2lQoeJ1zhiiLqAqvXxmM43s0MBg0A==",
+            "license": "Apache-2.0",
+            "dependencies": {
+                "@smithy/types": "^4.9.0",
+                "tslib": "^2.6.2"
+            },
+            "engines": {
+                "node": ">=18.0.0"
+            }
+        },
+        "packages/jobs/node_modules/@aws-sdk/token-providers": {
+            "version": "3.932.0",
+            "resolved": "https://registry.npmjs.org/@aws-sdk/token-providers/-/token-providers-3.932.0.tgz",
+            "integrity": "sha512-43u82ulVuHK4zWhcSPyuPS18l0LNHi3QJQ1YtP2MfP8bPf5a6hMYp5e3lUr9oTDEWcpwBYtOW0m1DVmoU/3veA==",
+            "license": "Apache-2.0",
+            "dependencies": {
+                "@aws-sdk/core": "3.932.0",
+                "@aws-sdk/nested-clients": "3.932.0",
+                "@aws-sdk/types": "3.930.0",
+                "@smithy/property-provider": "^4.2.5",
+                "@smithy/shared-ini-file-loader": "^4.4.0",
+                "@smithy/types": "^4.9.0",
+                "tslib": "^2.6.2"
+            },
+            "engines": {
+                "node": ">=18.0.0"
+            }
+        },
+        "packages/jobs/node_modules/@aws-sdk/token-providers/node_modules/@aws-sdk/core": {
+            "version": "3.932.0",
+            "resolved": "https://registry.npmjs.org/@aws-sdk/core/-/core-3.932.0.tgz",
+            "integrity": "sha512-AS8gypYQCbNojwgjvZGkJocC2CoEICDx9ZJ15ILsv+MlcCVLtUJSRSx3VzJOUY2EEIaGLRrPNlIqyn/9/fySvA==",
+            "license": "Apache-2.0",
+            "dependencies": {
+                "@aws-sdk/types": "3.930.0",
+                "@aws-sdk/xml-builder": "3.930.0",
+                "@smithy/core": "^3.18.2",
+                "@smithy/node-config-provider": "^4.3.5",
+                "@smithy/property-provider": "^4.2.5",
+                "@smithy/protocol-http": "^5.3.5",
+                "@smithy/signature-v4": "^5.3.5",
+                "@smithy/smithy-client": "^4.9.5",
+                "@smithy/types": "^4.9.0",
+                "@smithy/util-base64": "^4.3.0",
+                "@smithy/util-middleware": "^4.2.5",
+                "@smithy/util-utf8": "^4.2.0",
+                "tslib": "^2.6.2"
+            },
+            "engines": {
+                "node": ">=18.0.0"
+            }
+        },
+        "packages/jobs/node_modules/@aws-sdk/token-providers/node_modules/@aws-sdk/types": {
+            "version": "3.930.0",
+            "resolved": "https://registry.npmjs.org/@aws-sdk/types/-/types-3.930.0.tgz",
+            "integrity": "sha512-we/vaAgwlEFW7IeftmCLlLMw+6hFs3DzZPJw7lVHbj/5HJ0bz9gndxEsS2lQoeJ1zhiiLqAqvXxmM43s0MBg0A==",
+            "license": "Apache-2.0",
+            "dependencies": {
+                "@smithy/types": "^4.9.0",
+                "tslib": "^2.6.2"
+            },
+            "engines": {
+                "node": ">=18.0.0"
+            }
+        },
+        "packages/jobs/node_modules/@aws-sdk/util-arn-parser": {
+            "version": "3.893.0",
+            "resolved": "https://registry.npmjs.org/@aws-sdk/util-arn-parser/-/util-arn-parser-3.893.0.tgz",
+            "integrity": "sha512-u8H4f2Zsi19DGnwj5FSZzDMhytYF/bCh37vAtBsn3cNDL3YG578X5oc+wSX54pM3tOxS+NY7tvOAo52SW7koUA==",
+            "license": "Apache-2.0",
+            "dependencies": {
+                "tslib": "^2.6.2"
+            },
+            "engines": {
+                "node": ">=18.0.0"
+            }
+        },
+        "packages/jobs/node_modules/@aws-sdk/xml-builder": {
+            "version": "3.930.0",
+            "resolved": "https://registry.npmjs.org/@aws-sdk/xml-builder/-/xml-builder-3.930.0.tgz",
+            "integrity": "sha512-YIfkD17GocxdmlUVc3ia52QhcWuRIUJonbF8A2CYfcWNV3HzvAqpcPeC0bYUhkK+8e8YO1ARnLKZQE0TlwzorA==",
+            "license": "Apache-2.0",
+            "dependencies": {
+                "@smithy/types": "^4.9.0",
+                "fast-xml-parser": "5.2.5",
+                "tslib": "^2.6.2"
+            },
+            "engines": {
+                "node": ">=18.0.0"
+            }
+        },
+        "packages/jobs/node_modules/@aws/lambda-invoke-store": {
+            "version": "0.1.1",
+            "resolved": "https://registry.npmjs.org/@aws/lambda-invoke-store/-/lambda-invoke-store-0.1.1.tgz",
+            "integrity": "sha512-RcLam17LdlbSOSp9VxmUu1eI6Mwxp+OwhD2QhiSNmNCzoDb0EeUXTD2n/WbcnrAYMGlmf05th6QYq23VqvJqpA==",
+            "license": "Apache-2.0",
+            "engines": {
+                "node": ">=18.0.0"
+            }
+        },
+        "packages/jobs/node_modules/fast-xml-parser": {
+            "version": "5.2.5",
+            "resolved": "https://registry.npmjs.org/fast-xml-parser/-/fast-xml-parser-5.2.5.tgz",
+            "integrity": "sha512-pfX9uG9Ki0yekDHx2SiuRIyFdyAr1kMIMitPvb0YBo8SUfKvia7w7FIyd/l6av85pFYRhZscS75MwMnbvY+hcQ==",
+            "funding": [
+                {
+                    "type": "github",
+                    "url": "https://github.com/sponsors/NaturalIntelligence"
+                }
+            ],
+            "license": "MIT",
+            "dependencies": {
+                "strnum": "^2.1.0"
+            },
+            "bin": {
+                "fxparser": "src/cli/cli.js"
             }
         },
         "packages/jobs/node_modules/zod": {

--- a/packages/database/lib/migrations/20260427120000_plans_add_tenant_isolation.cjs
+++ b/packages/database/lib/migrations/20260427120000_plans_add_tenant_isolation.cjs
@@ -1,0 +1,12 @@
+/**
+ * @param {import('knex').Knex} knex
+ */
+exports.up = async function (knex) {
+    await knex.schema.alterTable('plans', (table) => {
+        table.boolean('tenant_isolation').notNullable().defaultTo(false);
+    });
+};
+
+exports.down = async function () {};
+
+exports.config = { transaction: true };

--- a/packages/database/lib/migrations/20260427120000_plans_add_tenant_isolation.cjs
+++ b/packages/database/lib/migrations/20260427120000_plans_add_tenant_isolation.cjs
@@ -3,7 +3,7 @@
  */
 exports.up = async function (knex) {
     await knex.schema.alterTable('plans', (table) => {
-        table.boolean('tenant_isolation').notNullable().defaultTo(false);
+        table.boolean('lambda_tenant_isolation').notNullable().defaultTo(false);
     });
 };
 

--- a/packages/jobs/lib/runner/lambda.ts
+++ b/packages/jobs/lib/runner/lambda.ts
@@ -22,7 +22,7 @@ import { Err, Ok, getLogger } from '@nangohq/utils';
 
 import { envs } from '../env.js';
 import { registerWithFleet } from '../runtime/runtimes.js';
-import { getFunctionName, isTenantIsolatedRoutingId } from '../utils/lambda.js';
+import { getLambdaFunctionName, isLambdaTenantIsolationRoutingId } from '../utils/lambda.js';
 
 import type { Environment } from '@aws-sdk/client-lambda';
 import type { Node, NodeProvider } from '@nangohq/fleet';
@@ -34,6 +34,9 @@ export const logger = getLogger('Lambda');
 const lambdaClient = new LambdaClient();
 const applicationAutoScalingClient = new ApplicationAutoScalingClient();
 const cloudwatchLogsClient = new CloudWatchLogsClient();
+
+/** Synthetic tenant id for readiness checks on PER_TENANT Lambdas (see AWS tenant isolation invoke docs). */
+const READINESS_CHECK_TENANT_ID = 'nango-readiness';
 
 export function getFunctionQualifier(node: Node): string {
     //need to get the qualifier from the function url
@@ -58,7 +61,7 @@ class Lambda {
 
     async createFunction(node: Node): Promise<Result<void>> {
         setImmediate(async () => {
-            const name = getFunctionName(node);
+            const name = getLambdaFunctionName(node);
             try {
                 const logGroupName = `/aws/lambda/${name}`; //this is the default log group name for Lambda
                 const createLogGroupCommand = new CreateLogGroupCommand({
@@ -70,6 +73,7 @@ class Lambda {
                     retentionInDays: envs.LAMBDA_DEFAULT_LOG_RETENTION_DAYS
                 });
                 await cloudwatchLogsClient.send(putRetentionPolicyCommand);
+                const perTenant = isLambdaTenantIsolationRoutingId(node.routingId);
                 const createFunctionCommand = new CreateFunctionCommand({
                     FunctionName: name,
                     Role: envs.LAMBDA_EXECUTION_ROLE_ARN,
@@ -87,7 +91,12 @@ class Lambda {
                     VpcConfig: {
                         SubnetIds: envs.LAMBDA_SUBNET_IDS,
                         SecurityGroupIds: envs.LAMBDA_SECURITY_GROUP_IDS
-                    }
+                    },
+                    ...(perTenant && {
+                        TenancyConfig: {
+                            TenantIsolationMode: 'PER_TENANT'
+                        }
+                    })
                 });
                 const cfResult = await lambdaClient.send(createFunctionCommand);
                 await waitUntilFunctionActive(
@@ -128,7 +137,7 @@ class Lambda {
                         })
                     );
                 }
-                const useProvisionedConcurrency = !isTenantIsolatedRoutingId(node.routingId);
+                const useProvisionedConcurrency = !perTenant;
                 if (useProvisionedConcurrency) {
                     const resourceId = `function:${pvResult.FunctionName}:${envs.LAMBDA_FUNCTION_ALIAS}`;
                     const minCapacity = envs.LAMBDA_MINIMUM_PROVISIONED_CONCURRENCY;
@@ -164,7 +173,8 @@ class Lambda {
                 const command = new InvokeCommand({
                     FunctionName: aResult.AliasArn,
                     Payload: JSON.stringify(readinessCheckRequest),
-                    InvocationType: 'RequestResponse'
+                    InvocationType: 'RequestResponse',
+                    ...(perTenant && { TenantId: READINESS_CHECK_TENANT_ID })
                 });
                 const response = await lambdaClient.send(command);
                 if (response.FunctionError) {
@@ -214,13 +224,13 @@ class Lambda {
     }
 
     async terminateFunction(node: Node): Promise<Result<void>> {
-        const name = getFunctionName(node);
+        const name = getLambdaFunctionName(node);
         await lambdaClient.send(
             new DeleteFunctionCommand({
                 FunctionName: name
             })
         );
-        if (!isTenantIsolatedRoutingId(node.routingId)) {
+        if (!isLambdaTenantIsolationRoutingId(node.routingId)) {
             const resourceId = `function:${name}:${envs.LAMBDA_FUNCTION_ALIAS}`;
             await applicationAutoScalingClient.send(
                 new DeleteScalingPolicyCommand({

--- a/packages/jobs/lib/runner/lambda.ts
+++ b/packages/jobs/lib/runner/lambda.ts
@@ -22,6 +22,7 @@ import { Err, Ok, getLogger } from '@nangohq/utils';
 
 import { envs } from '../env.js';
 import { registerWithFleet } from '../runtime/runtimes.js';
+import { getFunctionName, isTenantIsolatedRoutingId } from '../utils/lambda.js';
 
 import type { Environment } from '@aws-sdk/client-lambda';
 import type { Node, NodeProvider } from '@nangohq/fleet';
@@ -33,10 +34,6 @@ export const logger = getLogger('Lambda');
 const lambdaClient = new LambdaClient();
 const applicationAutoScalingClient = new ApplicationAutoScalingClient();
 const cloudwatchLogsClient = new CloudWatchLogsClient();
-
-export function getFunctionName(node: Node): string {
-    return `${node.routingId}-${node.id}`;
-}
 
 export function getFunctionQualifier(node: Node): string {
     //need to get the qualifier from the function url
@@ -131,33 +128,36 @@ class Lambda {
                         })
                     );
                 }
-                const resourceId = `function:${pvResult.FunctionName}:${envs.LAMBDA_FUNCTION_ALIAS}`;
-                const minCapacity = envs.LAMBDA_MINIMUM_PROVISIONED_CONCURRENCY;
-                const maxCapacity = Math.max(minCapacity, node.provisionedConcurrency || envs.LAMBDA_MAXIMUM_PROVISIONED_CONCURRENCY);
-                await applicationAutoScalingClient.send(
-                    new RegisterScalableTargetCommand({
-                        ServiceNamespace: 'lambda',
-                        ScalableDimension: 'lambda:function:ProvisionedConcurrency',
-                        ResourceId: resourceId,
-                        MinCapacity: minCapacity,
-                        MaxCapacity: maxCapacity
-                    })
-                );
-                await applicationAutoScalingClient.send(
-                    new PutScalingPolicyCommand({
-                        ServiceNamespace: 'lambda',
-                        ScalableDimension: 'lambda:function:ProvisionedConcurrency',
-                        ResourceId: resourceId,
-                        PolicyName: `${pvResult.FunctionName}-scaling-policy`,
-                        PolicyType: 'TargetTrackingScaling',
-                        TargetTrackingScalingPolicyConfiguration: {
-                            TargetValue: envs.LAMBDA_PROVISIONED_CONCURRENCY_SCALING_TARGET,
-                            PredefinedMetricSpecification: {
-                                PredefinedMetricType: 'LambdaProvisionedConcurrencyUtilization'
+                const useProvisionedConcurrency = !isTenantIsolatedRoutingId(node.routingId);
+                if (useProvisionedConcurrency) {
+                    const resourceId = `function:${pvResult.FunctionName}:${envs.LAMBDA_FUNCTION_ALIAS}`;
+                    const minCapacity = envs.LAMBDA_MINIMUM_PROVISIONED_CONCURRENCY;
+                    const maxCapacity = Math.max(minCapacity, node.provisionedConcurrency || envs.LAMBDA_MAXIMUM_PROVISIONED_CONCURRENCY);
+                    await applicationAutoScalingClient.send(
+                        new RegisterScalableTargetCommand({
+                            ServiceNamespace: 'lambda',
+                            ScalableDimension: 'lambda:function:ProvisionedConcurrency',
+                            ResourceId: resourceId,
+                            MinCapacity: minCapacity,
+                            MaxCapacity: maxCapacity
+                        })
+                    );
+                    await applicationAutoScalingClient.send(
+                        new PutScalingPolicyCommand({
+                            ServiceNamespace: 'lambda',
+                            ScalableDimension: 'lambda:function:ProvisionedConcurrency',
+                            ResourceId: resourceId,
+                            PolicyName: `${pvResult.FunctionName}-scaling-policy`,
+                            PolicyType: 'TargetTrackingScaling',
+                            TargetTrackingScalingPolicyConfiguration: {
+                                TargetValue: envs.LAMBDA_PROVISIONED_CONCURRENCY_SCALING_TARGET,
+                                PredefinedMetricSpecification: {
+                                    PredefinedMetricType: 'LambdaProvisionedConcurrencyUtilization'
+                                }
                             }
-                        }
-                    })
-                );
+                        })
+                    );
+                }
                 const readinessCheckRequest: LambdaReadinessCheck = {
                     type: 'readiness_check'
                 };
@@ -220,22 +220,24 @@ class Lambda {
                 FunctionName: name
             })
         );
-        const resourceId = `function:${name}:${envs.LAMBDA_FUNCTION_ALIAS}`;
-        await applicationAutoScalingClient.send(
-            new DeleteScalingPolicyCommand({
-                PolicyName: `${name}-scaling-policy`,
-                ServiceNamespace: 'lambda',
-                ScalableDimension: 'lambda:function:ProvisionedConcurrency',
-                ResourceId: resourceId
-            })
-        );
-        await applicationAutoScalingClient.send(
-            new DeregisterScalableTargetCommand({
-                ServiceNamespace: 'lambda',
-                ScalableDimension: 'lambda:function:ProvisionedConcurrency',
-                ResourceId: resourceId
-            })
-        );
+        if (!isTenantIsolatedRoutingId(node.routingId)) {
+            const resourceId = `function:${name}:${envs.LAMBDA_FUNCTION_ALIAS}`;
+            await applicationAutoScalingClient.send(
+                new DeleteScalingPolicyCommand({
+                    PolicyName: `${name}-scaling-policy`,
+                    ServiceNamespace: 'lambda',
+                    ScalableDimension: 'lambda:function:ProvisionedConcurrency',
+                    ResourceId: resourceId
+                })
+            );
+            await applicationAutoScalingClient.send(
+                new DeregisterScalableTargetCommand({
+                    ServiceNamespace: 'lambda',
+                    ScalableDimension: 'lambda:function:ProvisionedConcurrency',
+                    ResourceId: resourceId
+                })
+            );
+        }
         return Ok(undefined);
     }
 

--- a/packages/jobs/lib/runtime/lambda.adapter.ts
+++ b/packages/jobs/lib/runtime/lambda.adapter.ts
@@ -184,7 +184,7 @@ export class LambdaRuntimeAdapter implements RuntimeAdapter {
                 Payload: payload.value,
                 //InvocationType is Event for async invocation, RequestResponse for sync invocation
                 InvocationType: 'Event',
-                ...(params.routingContext?.plan?.tenant_isolation && {
+                ...(params.routingContext?.plan?.lambda_tenant_isolation && {
                     TenantId: getLambdaTenantId(params.nangoProps)
                 })
             });

--- a/packages/jobs/lib/runtime/lambda.adapter.ts
+++ b/packages/jobs/lib/runtime/lambda.adapter.ts
@@ -8,7 +8,7 @@ import { Err, Ok, getLogger } from '@nangohq/utils';
 
 import { envs } from '../env.js';
 import { setAbortFlag } from '../execution/operations/abort.js';
-import { getRoutingId } from '../utils/lambda.js';
+import { getLambdaTenantId, getRoutingId } from '../utils/lambda.js';
 
 import type { RuntimeAdapter } from './adapter.js';
 import type { Fleet } from '@nangohq/fleet';
@@ -183,7 +183,10 @@ export class LambdaRuntimeAdapter implements RuntimeAdapter {
                 FunctionName: func.arn,
                 Payload: payload.value,
                 //InvocationType is Event for async invocation, RequestResponse for sync invocation
-                InvocationType: 'Event'
+                InvocationType: 'Event',
+                ...(params.routingContext?.plan?.tenant_isolation && {
+                    TenantId: getLambdaTenantId(params.nangoProps)
+                })
             });
             await client.send(command);
             return Ok(true);

--- a/packages/jobs/lib/utils/lambda.ts
+++ b/packages/jobs/lib/utils/lambda.ts
@@ -32,7 +32,7 @@ export function getRoutingId(params: { nangoProps: NangoProps; routingContext?: 
     const tshirtSize = getTShirtSize(params);
     const prefix = params.routingContext?.plan?.fleet_node_routing_override || envs.LAMBDA_DEFAULT_PREFIX;
     const base = `${prefix}-${tshirtSize}`;
-    if (params.routingContext?.plan?.tenant_isolation) {
+    if (params.routingContext?.plan?.lambda_tenant_isolation) {
         return `${base}${LAMBDA_TENANT_ISOLATION_ROUTING_SUFFIX}`;
     }
     return base;

--- a/packages/jobs/lib/utils/lambda.ts
+++ b/packages/jobs/lib/utils/lambda.ts
@@ -3,19 +3,29 @@ import { envs } from '../env.js';
 import type { Node } from '@nangohq/fleet';
 import type { NangoProps, RoutingContext } from '@nangohq/types';
 
-/** Routing ids for tenant-isolated Lambdas end with this segment (see {@link getRoutingId}). */
-export const TENANT_ISOLATED_ROUTING_SUFFIX = '-isolated';
+/**
+ * Fleet `routing_id` suffix when the plan uses dedicated Lambda tenant isolation.
+ * Matches AWS `TenancyConfig.TenantIsolationMode = PER_TENANT`; the physical function name
+ * is {@link getLambdaFunctionName} so it also ends with `-isolated` after the node id.
+ */
+export const LAMBDA_TENANT_ISOLATION_ROUTING_SUFFIX = '-isolated';
 
-export function isTenantIsolatedRoutingId(routingId: string): boolean {
-    return routingId.endsWith(TENANT_ISOLATED_ROUTING_SUFFIX);
+export function isLambdaTenantIsolationRoutingId(routingId: string): boolean {
+    return routingId.endsWith(LAMBDA_TENANT_ISOLATION_ROUTING_SUFFIX);
 }
 
-export function getFunctionName(node: Node): string {
-    if (isTenantIsolatedRoutingId(node.routingId)) {
-        const base = node.routingId.slice(0, -TENANT_ISOLATED_ROUTING_SUFFIX.length);
-        return `${base}-${node.id}${TENANT_ISOLATED_ROUTING_SUFFIX}`;
+/** AWS `FunctionName` (and log group name segment): shared pool `routingId-id`, isolated pool `base-id-isolated`. */
+export function getLambdaFunctionName(node: Node): string {
+    if (isLambdaTenantIsolationRoutingId(node.routingId)) {
+        const base = node.routingId.slice(0, -LAMBDA_TENANT_ISOLATION_ROUTING_SUFFIX.length);
+        return `${base}-${node.id}${LAMBDA_TENANT_ISOLATION_ROUTING_SUFFIX}`;
     }
     return `${node.routingId}-${node.id}`;
+}
+
+/** Stable `TenantId` for AWS Lambda invoke when the plan uses tenant-isolated functions (PER_TENANT). */
+export function getLambdaTenantId(nangoProps: NangoProps): string {
+    return `team-${nangoProps.team.id}-env-${nangoProps.environmentId}`;
 }
 
 export function getRoutingId(params: { nangoProps: NangoProps; routingContext?: RoutingContext | undefined }): string {
@@ -23,7 +33,7 @@ export function getRoutingId(params: { nangoProps: NangoProps; routingContext?: 
     const prefix = params.routingContext?.plan?.fleet_node_routing_override || envs.LAMBDA_DEFAULT_PREFIX;
     const base = `${prefix}-${tshirtSize}`;
     if (params.routingContext?.plan?.tenant_isolation) {
-        return `${base}-isolated`;
+        return `${base}${LAMBDA_TENANT_ISOLATION_ROUTING_SUFFIX}`;
     }
     return base;
 }

--- a/packages/jobs/lib/utils/lambda.ts
+++ b/packages/jobs/lib/utils/lambda.ts
@@ -1,11 +1,31 @@
 import { envs } from '../env.js';
 
+import type { Node } from '@nangohq/fleet';
 import type { NangoProps, RoutingContext } from '@nangohq/types';
+
+/** Routing ids for tenant-isolated Lambdas end with this segment (see {@link getRoutingId}). */
+export const TENANT_ISOLATED_ROUTING_SUFFIX = '-isolated';
+
+export function isTenantIsolatedRoutingId(routingId: string): boolean {
+    return routingId.endsWith(TENANT_ISOLATED_ROUTING_SUFFIX);
+}
+
+export function getFunctionName(node: Node): string {
+    if (isTenantIsolatedRoutingId(node.routingId)) {
+        const base = node.routingId.slice(0, -TENANT_ISOLATED_ROUTING_SUFFIX.length);
+        return `${base}-${node.id}${TENANT_ISOLATED_ROUTING_SUFFIX}`;
+    }
+    return `${node.routingId}-${node.id}`;
+}
 
 export function getRoutingId(params: { nangoProps: NangoProps; routingContext?: RoutingContext | undefined }): string {
     const tshirtSize = getTShirtSize(params);
     const prefix = params.routingContext?.plan?.fleet_node_routing_override || envs.LAMBDA_DEFAULT_PREFIX;
-    return `${prefix}-${tshirtSize}`;
+    const base = `${prefix}-${tshirtSize}`;
+    if (params.routingContext?.plan?.tenant_isolation) {
+        return `${base}-isolated`;
+    }
+    return base;
 }
 
 function getTShirtSize(_params: { nangoProps: NangoProps; routingContext?: RoutingContext | undefined }): string {

--- a/packages/jobs/lib/utils/lambda.ts
+++ b/packages/jobs/lib/utils/lambda.ts
@@ -25,7 +25,7 @@ export function getLambdaFunctionName(node: Node): string {
 
 /** Stable `TenantId` for AWS Lambda invoke when the plan uses tenant-isolated functions (PER_TENANT). */
 export function getLambdaTenantId(nangoProps: NangoProps): string {
-    return `team-${nangoProps.team.id}-env-${nangoProps.environmentId}`;
+    return `account-${nangoProps.team.id}-env-${nangoProps.environmentId}`;
 }
 
 export function getRoutingId(params: { nangoProps: NangoProps; routingContext?: RoutingContext | undefined }): string {

--- a/packages/jobs/lib/utils/lambda.unit.test.ts
+++ b/packages/jobs/lib/utils/lambda.unit.test.ts
@@ -11,8 +11,9 @@ vi.mock('../env.js', () => ({
     }
 }));
 
-import { getRoutingId } from './lambda.js';
+import { TENANT_ISOLATED_ROUTING_SUFFIX, getFunctionName, getRoutingId, isTenantIsolatedRoutingId } from './lambda.js';
 
+import type { Node } from '@nangohq/fleet';
 import type { NangoProps, RoutingContext } from '@nangohq/types';
 
 function minimalNangoProps(): NangoProps {
@@ -72,5 +73,73 @@ describe('getRoutingId', () => {
             routingContext
         });
         expect(result).toBe('default-prefix-S');
+    });
+
+    it('appends -isolated to routing id when plan.tenant_isolation is true', () => {
+        const routingContext: RoutingContext = {
+            plan: { fleet_node_routing_override: null, tenant_isolation: true } as unknown as RoutingContext['plan'],
+            features: []
+        };
+        const result = getRoutingId({
+            nangoProps: minimalNangoProps(),
+            routingContext
+        });
+        expect(result).toBe('default-prefix-S-isolated');
+    });
+
+    it('combines fleet_node_routing_override with tenant_isolation', () => {
+        const routingContext: RoutingContext = {
+            plan: { fleet_node_routing_override: 'custom', tenant_isolation: true } as unknown as RoutingContext['plan'],
+            features: []
+        };
+        const result = getRoutingId({
+            nangoProps: minimalNangoProps(),
+            routingContext
+        });
+        expect(result).toBe('custom-S-isolated');
+    });
+});
+
+function minimalNode(partial: Pick<Node, 'routingId' | 'id'>): Node {
+    return {
+        id: partial.id,
+        routingId: partial.routingId,
+        fleetId: 'f',
+        deploymentId: 1,
+        url: null,
+        state: 'PENDING',
+        image: 'img',
+        cpuMilli: 500,
+        memoryMb: 512,
+        storageMb: 512,
+        isTracingEnabled: false,
+        isProfilingEnabled: false,
+        idleMaxDurationMs: null,
+        executionTimeoutSecs: null,
+        provisionedConcurrency: null,
+        replicas: 1,
+        error: null,
+        createdAt: new Date(),
+        lastStateTransitionAt: new Date()
+    } as Node;
+}
+
+describe('isTenantIsolatedRoutingId', () => {
+    it('detects tenant-isolated routing ids', () => {
+        expect(isTenantIsolatedRoutingId(`prefix-M${TENANT_ISOLATED_ROUTING_SUFFIX}`)).toBe(true);
+    });
+
+    it('is false for shared pool routing ids', () => {
+        expect(isTenantIsolatedRoutingId('prefix-M')).toBe(false);
+    });
+});
+
+describe('getFunctionName', () => {
+    it('uses routingId-id for non-isolated nodes', () => {
+        expect(getFunctionName(minimalNode({ routingId: 'default-M', id: 42 }))).toBe('default-M-42');
+    });
+
+    it('uses routingBase-id-isolated for tenant-isolated routing ids', () => {
+        expect(getFunctionName(minimalNode({ routingId: 'default-M-isolated', id: 7 }))).toBe('default-M-7-isolated');
     });
 });

--- a/packages/jobs/lib/utils/lambda.unit.test.ts
+++ b/packages/jobs/lib/utils/lambda.unit.test.ts
@@ -53,7 +53,7 @@ function minimalNode(partial: Pick<Node, 'routingId' | 'id'>): Node {
         error: null,
         createdAt: new Date(),
         lastStateTransitionAt: new Date()
-    } as Node;
+    };
 }
 
 describe('getRoutingId', () => {

--- a/packages/jobs/lib/utils/lambda.unit.test.ts
+++ b/packages/jobs/lib/utils/lambda.unit.test.ts
@@ -11,7 +11,7 @@ vi.mock('../env.js', () => ({
     }
 }));
 
-import { TENANT_ISOLATED_ROUTING_SUFFIX, getFunctionName, getRoutingId, isTenantIsolatedRoutingId } from './lambda.js';
+import { LAMBDA_TENANT_ISOLATION_ROUTING_SUFFIX, getLambdaFunctionName, getLambdaTenantId, getRoutingId, isLambdaTenantIsolationRoutingId } from './lambda.js';
 
 import type { Node } from '@nangohq/fleet';
 import type { NangoProps, RoutingContext } from '@nangohq/types';
@@ -30,6 +30,30 @@ function minimalNangoProps(): NangoProps {
         syncId: 'sync-1',
         syncConfig: {} as NangoProps['syncConfig']
     } as unknown as NangoProps;
+}
+
+function minimalNode(partial: Pick<Node, 'routingId' | 'id'>): Node {
+    return {
+        id: partial.id,
+        routingId: partial.routingId,
+        fleetId: 'f',
+        deploymentId: 1,
+        url: null,
+        state: 'PENDING',
+        image: 'img',
+        cpuMilli: 500,
+        memoryMb: 512,
+        storageMb: 512,
+        isTracingEnabled: false,
+        isProfilingEnabled: false,
+        idleMaxDurationMs: null,
+        executionTimeoutSecs: null,
+        provisionedConcurrency: null,
+        replicas: 1,
+        error: null,
+        createdAt: new Date(),
+        lastStateTransitionAt: new Date()
+    } as Node;
 }
 
 describe('getRoutingId', () => {
@@ -75,7 +99,7 @@ describe('getRoutingId', () => {
         expect(result).toBe('default-prefix-S');
     });
 
-    it('appends -isolated to routing id when plan.tenant_isolation is true', () => {
+    it(`appends ${LAMBDA_TENANT_ISOLATION_ROUTING_SUFFIX} when plan.tenant_isolation is true`, () => {
         const routingContext: RoutingContext = {
             plan: { fleet_node_routing_override: null, tenant_isolation: true } as unknown as RoutingContext['plan'],
             features: []
@@ -84,7 +108,7 @@ describe('getRoutingId', () => {
             nangoProps: minimalNangoProps(),
             routingContext
         });
-        expect(result).toBe('default-prefix-S-isolated');
+        expect(result).toBe(`default-prefix-S${LAMBDA_TENANT_ISOLATION_ROUTING_SUFFIX}`);
     });
 
     it('combines fleet_node_routing_override with tenant_isolation', () => {
@@ -96,50 +120,32 @@ describe('getRoutingId', () => {
             nangoProps: minimalNangoProps(),
             routingContext
         });
-        expect(result).toBe('custom-S-isolated');
+        expect(result).toBe(`custom-S${LAMBDA_TENANT_ISOLATION_ROUTING_SUFFIX}`);
     });
 });
 
-function minimalNode(partial: Pick<Node, 'routingId' | 'id'>): Node {
-    return {
-        id: partial.id,
-        routingId: partial.routingId,
-        fleetId: 'f',
-        deploymentId: 1,
-        url: null,
-        state: 'PENDING',
-        image: 'img',
-        cpuMilli: 500,
-        memoryMb: 512,
-        storageMb: 512,
-        isTracingEnabled: false,
-        isProfilingEnabled: false,
-        idleMaxDurationMs: null,
-        executionTimeoutSecs: null,
-        provisionedConcurrency: null,
-        replicas: 1,
-        error: null,
-        createdAt: new Date(),
-        lastStateTransitionAt: new Date()
-    } as Node;
-}
-
-describe('isTenantIsolatedRoutingId', () => {
-    it('detects tenant-isolated routing ids', () => {
-        expect(isTenantIsolatedRoutingId(`prefix-M${TENANT_ISOLATED_ROUTING_SUFFIX}`)).toBe(true);
+describe('isLambdaTenantIsolationRoutingId', () => {
+    it('detects tenant-isolation fleet pool routing ids', () => {
+        expect(isLambdaTenantIsolationRoutingId(`prefix-M${LAMBDA_TENANT_ISOLATION_ROUTING_SUFFIX}`)).toBe(true);
     });
 
     it('is false for shared pool routing ids', () => {
-        expect(isTenantIsolatedRoutingId('prefix-M')).toBe(false);
+        expect(isLambdaTenantIsolationRoutingId('prefix-M')).toBe(false);
     });
 });
 
-describe('getFunctionName', () => {
-    it('uses routingId-id for non-isolated nodes', () => {
-        expect(getFunctionName(minimalNode({ routingId: 'default-M', id: 42 }))).toBe('default-M-42');
+describe('getLambdaFunctionName', () => {
+    it('uses routingId-id for shared pool', () => {
+        expect(getLambdaFunctionName(minimalNode({ routingId: 'default-M', id: 42 }))).toBe('default-M-42');
     });
 
-    it('uses routingBase-id-isolated for tenant-isolated routing ids', () => {
-        expect(getFunctionName(minimalNode({ routingId: 'default-M-isolated', id: 7 }))).toBe('default-M-7-isolated');
+    it('uses base-id-isolated for tenant-isolation pool (distinct AWS name from shared)', () => {
+        expect(getLambdaFunctionName(minimalNode({ routingId: 'default-M-isolated', id: 7 }))).toBe('default-M-7-isolated');
+    });
+});
+
+describe('getLambdaTenantId', () => {
+    it('returns team and environment scoped id', () => {
+        expect(getLambdaTenantId(minimalNangoProps())).toBe('team-1-env-1');
     });
 });

--- a/packages/jobs/lib/utils/lambda.unit.test.ts
+++ b/packages/jobs/lib/utils/lambda.unit.test.ts
@@ -146,6 +146,6 @@ describe('getLambdaFunctionName', () => {
 
 describe('getLambdaTenantId', () => {
     it('returns team and environment scoped id', () => {
-        expect(getLambdaTenantId(minimalNangoProps())).toBe('team-1-env-1');
+        expect(getLambdaTenantId(minimalNangoProps())).toBe('account-1-env-1');
     });
 });

--- a/packages/jobs/lib/utils/lambda.unit.test.ts
+++ b/packages/jobs/lib/utils/lambda.unit.test.ts
@@ -101,7 +101,7 @@ describe('getRoutingId', () => {
 
     it(`appends ${LAMBDA_TENANT_ISOLATION_ROUTING_SUFFIX} when plan.tenant_isolation is true`, () => {
         const routingContext: RoutingContext = {
-            plan: { fleet_node_routing_override: null, tenant_isolation: true } as unknown as RoutingContext['plan'],
+            plan: { fleet_node_routing_override: null, lambda_tenant_isolation: true } as unknown as RoutingContext['plan'],
             features: []
         };
         const result = getRoutingId({
@@ -113,7 +113,7 @@ describe('getRoutingId', () => {
 
     it('combines fleet_node_routing_override with tenant_isolation', () => {
         const routingContext: RoutingContext = {
-            plan: { fleet_node_routing_override: 'custom', tenant_isolation: true } as unknown as RoutingContext['plan'],
+            plan: { fleet_node_routing_override: 'custom', lambda_tenant_isolation: true } as unknown as RoutingContext['plan'],
             features: []
         };
         const result = getRoutingId({

--- a/packages/shared/lib/seeders/plan.seeder.ts
+++ b/packages/shared/lib/seeders/plan.seeder.ts
@@ -48,7 +48,7 @@ export function getTestPlan(override?: Partial<DBPlan>): DBPlan {
         has_records_autopruning: true,
         variants_per_sync_max: 100,
         fleet_node_routing_override: null,
-        tenant_isolation: false,
+        lambda_tenant_isolation: false,
         ...override
     };
 }

--- a/packages/shared/lib/seeders/plan.seeder.ts
+++ b/packages/shared/lib/seeders/plan.seeder.ts
@@ -48,6 +48,7 @@ export function getTestPlan(override?: Partial<DBPlan>): DBPlan {
         has_records_autopruning: true,
         variants_per_sync_max: 100,
         fleet_node_routing_override: null,
+        tenant_isolation: false,
         ...override
     };
 }

--- a/packages/shared/lib/services/plans/definitions.ts
+++ b/packages/shared/lib/services/plans/definitions.ts
@@ -34,7 +34,8 @@ export const freePlan: PlanDefinition = {
         action_function_runtime: 'lambda',
         webhook_function_runtime: 'lambda',
         on_event_function_runtime: 'lambda',
-        sync_lambda_checkpoint_required: false
+        sync_lambda_checkpoint_required: false,
+        tenant_isolation: false
     }
 };
 
@@ -73,7 +74,8 @@ export const starterV1Plan: PlanDefinition = {
         can_override_docs_connect_url: false,
         can_customize_connect_ui_theme: false,
         can_disable_connect_ui_watermark: false,
-        remote_functions: false
+        remote_functions: false,
+        tenant_isolation: false
     }
 };
 
@@ -113,7 +115,8 @@ export const growthV1Plan: PlanDefinition = {
         can_override_docs_connect_url: false,
         can_customize_connect_ui_theme: true,
         can_disable_connect_ui_watermark: true,
-        remote_functions: false
+        remote_functions: false,
+        tenant_isolation: false
     }
 };
 
@@ -180,7 +183,8 @@ export const enterprisePlan: PlanDefinition = {
         can_override_docs_connect_url: false,
         can_customize_connect_ui_theme: true,
         can_disable_connect_ui_watermark: true,
-        remote_functions: false
+        remote_functions: false,
+        tenant_isolation: false
     }
 };
 
@@ -220,7 +224,8 @@ export const starterLegacyPlan: PlanDefinition = {
         can_override_docs_connect_url: false,
         can_customize_connect_ui_theme: false,
         can_disable_connect_ui_watermark: false,
-        remote_functions: false
+        remote_functions: false,
+        tenant_isolation: false
     }
 };
 
@@ -259,7 +264,8 @@ export const scaleLegacyPlan: PlanDefinition = {
         can_override_docs_connect_url: false,
         can_customize_connect_ui_theme: false,
         can_disable_connect_ui_watermark: false,
-        remote_functions: false
+        remote_functions: false,
+        tenant_isolation: false
     }
 };
 
@@ -298,7 +304,8 @@ export const growthLegacyPlan: PlanDefinition = {
         can_override_docs_connect_url: false,
         can_customize_connect_ui_theme: true,
         can_disable_connect_ui_watermark: true,
-        remote_functions: false
+        remote_functions: false,
+        tenant_isolation: false
     }
 };
 

--- a/packages/shared/lib/services/plans/definitions.ts
+++ b/packages/shared/lib/services/plans/definitions.ts
@@ -35,7 +35,7 @@ export const freePlan: PlanDefinition = {
         webhook_function_runtime: 'lambda',
         on_event_function_runtime: 'lambda',
         sync_lambda_checkpoint_required: false,
-        tenant_isolation: false
+        lambda_tenant_isolation: false
     }
 };
 
@@ -75,7 +75,7 @@ export const starterV1Plan: PlanDefinition = {
         can_customize_connect_ui_theme: false,
         can_disable_connect_ui_watermark: false,
         remote_functions: false,
-        tenant_isolation: false
+        lambda_tenant_isolation: false
     }
 };
 
@@ -116,7 +116,7 @@ export const growthV1Plan: PlanDefinition = {
         can_customize_connect_ui_theme: true,
         can_disable_connect_ui_watermark: true,
         remote_functions: false,
-        tenant_isolation: false
+        lambda_tenant_isolation: false
     }
 };
 
@@ -184,7 +184,7 @@ export const enterprisePlan: PlanDefinition = {
         can_customize_connect_ui_theme: true,
         can_disable_connect_ui_watermark: true,
         remote_functions: false,
-        tenant_isolation: false
+        lambda_tenant_isolation: false
     }
 };
 
@@ -225,7 +225,7 @@ export const starterLegacyPlan: PlanDefinition = {
         can_customize_connect_ui_theme: false,
         can_disable_connect_ui_watermark: false,
         remote_functions: false,
-        tenant_isolation: false
+        lambda_tenant_isolation: false
     }
 };
 
@@ -265,7 +265,7 @@ export const scaleLegacyPlan: PlanDefinition = {
         can_customize_connect_ui_theme: false,
         can_disable_connect_ui_watermark: false,
         remote_functions: false,
-        tenant_isolation: false
+        lambda_tenant_isolation: false
     }
 };
 
@@ -305,7 +305,7 @@ export const growthLegacyPlan: PlanDefinition = {
         can_customize_connect_ui_theme: true,
         can_disable_connect_ui_watermark: true,
         remote_functions: false,
-        tenant_isolation: false
+        lambda_tenant_isolation: false
     }
 };
 

--- a/packages/shared/lib/services/plans/plans.ts
+++ b/packages/shared/lib/services/plans/plans.ts
@@ -246,6 +246,7 @@ export function mergeFlags({ currentPlan, newPlanDefinition }: { currentPlan: DB
                 break;
             }
             // BOOLEAN FLAGS - keep override if different
+            case 'tenant_isolation':
             case 'sync_lambda_checkpoint_required': {
                 overrides[key] = currentPlan[key] !== newPlanDefinition.flags[key] ? newPlanDefinition.flags[key] : currentPlan[key];
                 break;

--- a/packages/shared/lib/services/plans/plans.ts
+++ b/packages/shared/lib/services/plans/plans.ts
@@ -246,7 +246,7 @@ export function mergeFlags({ currentPlan, newPlanDefinition }: { currentPlan: DB
                 break;
             }
             // BOOLEAN FLAGS - keep override if different
-            case 'tenant_isolation':
+            case 'lambda_tenant_isolation':
             case 'sync_lambda_checkpoint_required': {
                 overrides[key] = currentPlan[key] !== newPlanDefinition.flags[key] ? newPlanDefinition.flags[key] : currentPlan[key];
                 break;

--- a/packages/shared/lib/services/plans/plans.unit.test.ts
+++ b/packages/shared/lib/services/plans/plans.unit.test.ts
@@ -136,6 +136,7 @@ function makePlan({ code, flagOverrides }: { code: DBPlan['name']; flagOverrides
         has_records_autopruning: true,
         variants_per_sync_max: 100,
         fleet_node_routing_override: null,
+        tenant_isolation: false,
         ...defaultPlanDefinition,
         ...flagOverrides
     };

--- a/packages/shared/lib/services/plans/plans.unit.test.ts
+++ b/packages/shared/lib/services/plans/plans.unit.test.ts
@@ -136,7 +136,7 @@ function makePlan({ code, flagOverrides }: { code: DBPlan['name']; flagOverrides
         has_records_autopruning: true,
         variants_per_sync_max: 100,
         fleet_node_routing_override: null,
-        tenant_isolation: false,
+        lambda_tenant_isolation: false,
         ...defaultPlanDefinition,
         ...flagOverrides
     };

--- a/packages/types/lib/plans/db.ts
+++ b/packages/types/lib/plans/db.ts
@@ -206,8 +206,8 @@ export interface DBPlan extends Timestamps {
     fleet_node_routing_override: string | null;
 
     /**
-     * Enable or tenant isolation for functions executions
+     * Enable or disable tenant isolation for functions executions
      * @default false
      */
-    tenant_isolation: boolean;
+    lambda_tenant_isolation: boolean;
 }

--- a/packages/types/lib/plans/db.ts
+++ b/packages/types/lib/plans/db.ts
@@ -206,9 +206,7 @@ export interface DBPlan extends Timestamps {
     fleet_node_routing_override: string | null;
 
     /**
-     * When true, Nango uses a dedicated fleet pool: routing ids end with `-isolated`, AWS function names are
-     * `…-{nodeId}-isolated` (distinct from the shared pool), Lambdas use `TenancyConfig.TenantIsolationMode = PER_TENANT`,
-     * and invoke sends `TenantId`. Provisioned concurrency is not configured for that pool.
+     * Enable or tenant isolation for functions executions
      * @default false
      */
     tenant_isolation: boolean;

--- a/packages/types/lib/plans/db.ts
+++ b/packages/types/lib/plans/db.ts
@@ -204,4 +204,11 @@ export interface DBPlan extends Timestamps {
      * @default null
      */
     fleet_node_routing_override: string | null;
+
+    /**
+     * When true, Lambda invocations use a dedicated routing pool and function names ending with `-isolated`.
+     * Provisioned concurrency is not applied to tenant-isolated Lambdas.
+     * @default false
+     */
+    tenant_isolation: boolean;
 }

--- a/packages/types/lib/plans/db.ts
+++ b/packages/types/lib/plans/db.ts
@@ -206,8 +206,9 @@ export interface DBPlan extends Timestamps {
     fleet_node_routing_override: string | null;
 
     /**
-     * When true, Lambda invocations use a dedicated routing pool and function names ending with `-isolated`.
-     * Provisioned concurrency is not applied to tenant-isolated Lambdas.
+     * When true, Nango uses a dedicated fleet pool: routing ids end with `-isolated`, AWS function names are
+     * `…-{nodeId}-isolated` (distinct from the shared pool), Lambdas use `TenancyConfig.TenantIsolationMode = PER_TENANT`,
+     * and invoke sends `TenantId`. Provisioned concurrency is not configured for that pool.
      * @default false
      */
     tenant_isolation: boolean;


### PR DESCRIPTION
Enable plan-gated Lambda tenant isolation (PER_TENANT)

**Summary**
- Adds a new plan attribute tenant_isolation (boolean, default false) with a DB migration.
- When enabled, routes invocations to a dedicated Lambda fleet pool (routingId suffix -isolated) and creates AWS functions with distinct names (…-{nodeId}-isolated).
- Creates isolated Lambdas with AWS TenancyConfig.TenantIsolationMode = PER_TENANT and passes TenantId on invoke as required by AWS tenant isolation.
- Disables provisioned concurrency configuration for tenant-isolated Lambda nodes (not supported/assumed incompatible).

**Key changes**
- Plans
  - Migration: plans.tenant_isolation default false
  - Types/definitions/seeding updated to include the new flag
mergeFlags treats tenant_isolation as a “sticky enable” flag on upgrade (downgrades reset to new plan defaults)
- Routing & naming
  - Tenant-isolated routing uses -isolated suffix to ensure separate fleet pools
  - AWS function naming ensures isolated and non-isolated functions never collide
- Lambda create/invoke
  - CreateFunction conditionally sets TenancyConfig for isolated pool
  - Invoke conditionally sets TenantId for isolated plan
  - Provisioned concurrency registration/cleanup is conditional (skipped for isolated pool)
