### PR TITLE
fix: show mintlify broken-links output when error

### DIFF
--- a/.github/workflows/validation.yaml
+++ b/.github/workflows/validation.yaml
@@ -81,7 +81,9 @@ jobs:
               run: |
                   npm install -g mintlify
                   cd docs
-                  if ! mintlify broken-links | grep -q "no broken links found"; then
-                    echo "Broken links found in documentation"
+                  broken_links_outpout=$(mintlify broken-links 2>&1)
+                  if ! echo "$broken_links_outpout" | grep -q "no broken links found"; then
+                    echo "Broken links found in documentation:"
+                    echo "$broken_links_outpout"
                     exit 1
                   fi

--- a/.github/workflows/validation.yaml
+++ b/.github/workflows/validation.yaml
@@ -81,9 +81,9 @@ jobs:
               run: |
                   npm install -g mintlify
                   cd docs
-                  broken_links_outpout=$(mintlify broken-links 2>&1)
-                  if ! echo "$broken_links_outpout" | grep -q "no broken links found"; then
+                  broken_links_output=$(mintlify broken-links 2>&1)
+                  if ! echo "$broken_links_output" | grep -q "no broken links found"; then
                     echo "Broken links found in documentation:"
-                    echo "$broken_links_outpout"
+                    echo "$broken_links_output"
                     exit 1
                   fi

--- a/.github/workflows/validation.yaml
+++ b/.github/workflows/validation.yaml
@@ -81,9 +81,8 @@ jobs:
               run: |
                   npm install -g mintlify
                   cd docs
-                  broken_links_output=$(mintlify broken-links 2>&1)
+                  broken_links_output=$(mintlify broken-links 2>&1) || true
                   if ! echo "$broken_links_output" | grep -q "no broken links found"; then
-                    echo "Broken links found in documentation:"
                     echo "$broken_links_output"
                     exit 1
                   fi


### PR DESCRIPTION
Showing `mintlify broken-links` output in case of error to help debugging
