### PR TITLE
docs: remove slack webhook docs from navbar

### DIFF
--- a/docs/docs.json
+++ b/docs/docs.json
@@ -1018,7 +1018,6 @@
               "api-integrations/simpro/connect",
               "api-integrations/slab",
               "api-integrations/slack",
-              "api-integrations/slack/webhooks",
               "api-integrations/slack-mcp",
               "api-integrations/tally",
               "api-integrations/telegram",


### PR DESCRIPTION
## Describe the problem and your solution

- remove slack webhook docs from navbar

<!-- Issue ticket number and link (if applicable) -->

<!-- Testing instructions (skip if just adding/editing providers) -->

