### PR TITLE
feat(webhooks): switch internal-nango to publish via dispatch queue (NAN-5340)

### DIFF
--- a/packages/jobs/lib/webhook/dispatch-queue/consumer.ts
+++ b/packages/jobs/lib/webhook/dispatch-queue/consumer.ts
@@ -154,7 +154,7 @@ export class DispatchQueueConsumer {
 
                 const scheduleRes = await this.orchestratorClient.immediate({
                     name: message.taskName,
-                    group: { key: `webhook:environment:${environmentId}`, maxConcurrency: this.webhookMaxConcurrency },
+                    group: { key: `webhook:environment:${message.environmentId}`, maxConcurrency: this.webhookMaxConcurrency },
                     ...webhookTaskSchedulingSettings,
                     args: {
                         type: 'webhook',

--- a/packages/jobs/lib/webhook/dispatch-queue/consumer.ts
+++ b/packages/jobs/lib/webhook/dispatch-queue/consumer.ts
@@ -2,8 +2,10 @@ import { DeleteMessageCommand, ReceiveMessageCommand, SQSClient } from '@aws-sdk
 import tracer from 'dd-trace';
 import * as z from 'zod';
 
-import { jsonSchema, webhookTaskSchedulingSettings } from '@nangohq/nango-orchestrator';
+import { isDuplicateTaskNameClientError, jsonSchema, webhookTaskSchedulingSettings } from '@nangohq/nango-orchestrator';
 import { getLogger, metrics, report } from '@nangohq/utils';
+
+import { envs } from '../../env.js';
 
 import type { Message } from '@aws-sdk/client-sqs';
 import type { OrchestratorClient } from '@nangohq/nango-orchestrator';
@@ -13,10 +15,7 @@ const logger = getLogger('jobs.webhook.dispatch-queue.consumer');
 
 type ParseMessageResult = { success: true; message: WebhookDispatchMessage } | { success: false; reason: 'invalid_schema' | 'json_parse' };
 
-const getRegion = (): string => {
-    const env = typeof process !== 'undefined' ? process.env['LAMBDA_REGION'] : undefined;
-    return env ?? 'us-west-2';
-};
+const getRegion = (): string => envs.AWS_SQS_REGION ?? 'us-west-2';
 
 const messageSchema: z.ZodType<WebhookDispatchMessage> = z.object({
     version: z.literal(1),
@@ -127,7 +126,7 @@ export class DispatchQueueConsumer {
 
         return await tracer.scope().activate(span, async () => {
             try {
-                if (!msg.Body || !msg.ReceiptHandle) {
+                if (msg.Body === undefined || !msg.ReceiptHandle) {
                     return;
                 }
 
@@ -154,7 +153,7 @@ export class DispatchQueueConsumer {
 
                 const scheduleRes = await this.orchestratorClient.immediate({
                     name: message.taskName,
-                    group: { key: `webhook:environment:${message.environmentId}`, maxConcurrency: this.webhookMaxConcurrency },
+                    group: { key: `webhook:environment:${environmentId}`, maxConcurrency: this.webhookMaxConcurrency },
                     ...webhookTaskSchedulingSettings,
                     args: {
                         type: 'webhook',
@@ -167,7 +166,7 @@ export class DispatchQueueConsumer {
                 });
 
                 if (scheduleRes.isErr()) {
-                    if (isDuplicateTaskNameSchedulingError(scheduleRes.error, message.taskName)) {
+                    if (isDuplicateTaskNameClientError(scheduleRes.error, message.taskName)) {
                         span.setTag('duplicate_task_name', true);
                         metrics.increment(metrics.Types.WEBHOOK_DISPATCH_CONSUME_SUCCESS, 1, { provider: message.provider });
                         await this.tryDeleteMessage(msg.ReceiptHandle);
@@ -217,34 +216,6 @@ export class DispatchQueueConsumer {
             report(new Error('webhook dispatch consumer delete failed', { cause: err }));
         }
     }
-}
-
-function isDuplicateTaskNameSchedulingError(err: unknown, taskName: string): boolean {
-    if (!err || typeof err !== 'object') {
-        return false;
-    }
-
-    const error = err as {
-        name?: string;
-        payload?: {
-            response?: {
-                error?: {
-                    code?: string;
-                    payload?: {
-                        reason?: string;
-                        taskName?: string;
-                    };
-                };
-            };
-        };
-    };
-
-    return (
-        error.name === 'fetch_failed' &&
-        error.payload?.response?.error?.code === 'immediate_failed' &&
-        error.payload.response.error.payload?.reason === 'duplicate_task_name' &&
-        error.payload.response.error.payload?.taskName === taskName
-    );
 }
 
 function getClientErrorResponsePayload(err: { payload?: unknown }): string | null {

--- a/packages/jobs/lib/webhook/dispatch-queue/consumer.unit.test.ts
+++ b/packages/jobs/lib/webhook/dispatch-queue/consumer.unit.test.ts
@@ -3,6 +3,12 @@ import { beforeEach, describe, expect, it, vi } from 'vitest';
 
 import { Err, Ok } from '@nangohq/utils';
 
+vi.mock('../../env.js', () => ({
+    envs: {
+        AWS_SQS_REGION: undefined
+    }
+}));
+
 import { DispatchQueueConsumer } from './consumer.js';
 
 import type { SQSClient } from '@aws-sdk/client-sqs';
@@ -147,19 +153,9 @@ describe('DispatchQueueConsumer', () => {
         const h = makeHarness({ messages: [buildMessage()] });
         h.orchestratorImmediate.mockResolvedValueOnce(
             Err({
-                name: 'fetch_failed',
+                name: 'duplicate_task_name',
                 message: 'Task with name already exists',
-                payload: {
-                    response: {
-                        error: {
-                            code: 'immediate_failed',
-                            payload: {
-                                reason: 'duplicate_task_name',
-                                taskName: 'webhook:abc123'
-                            }
-                        }
-                    }
-                }
+                payload: { taskName: 'webhook:abc123' }
             })
         );
 
@@ -187,6 +183,17 @@ describe('DispatchQueueConsumer', () => {
 
     it('deletes a poison-pill message without calling orchestrator', async () => {
         const h = makeHarness({ badBody: 'not-json' });
+        await runOnce(h, () => {
+            expect(getDeleteCalls(h)).toHaveLength(1);
+        });
+
+        expect(h.orchestratorImmediate).not.toHaveBeenCalled();
+        const deleteCalls = getDeleteCalls(h);
+        expect(deleteCalls).toHaveLength(1);
+    });
+
+    it('treats an empty-body message as a poison pill and deletes it', async () => {
+        const h = makeHarness({ badBody: '' });
         await runOnce(h, () => {
             expect(getDeleteCalls(h)).toHaveLength(1);
         });

--- a/packages/orchestrator/lib/clients/client.integration.test.ts
+++ b/packages/orchestrator/lib/clients/client.integration.test.ts
@@ -192,13 +192,8 @@ describe('OrchestratorClient', async () => {
             const duplicate = await client.immediate(request);
             expect(duplicate.isErr()).toBe(true);
             if (duplicate.isErr()) {
-                expect(duplicate.error.name).toBe('fetch_failed');
-                const response = (duplicate.error.payload as { response?: { error?: { code?: string; payload?: unknown } } } | null)?.response;
-                expect(response?.error?.code).toBe('immediate_failed');
-                expect(response?.error?.payload).toMatchObject({
-                    reason: 'duplicate_task_name',
-                    taskName: name
-                });
+                expect(duplicate.error.name).toBe('duplicate_task_name');
+                expect(duplicate.error.payload).toMatchObject({ taskName: name });
             }
         });
     });

--- a/packages/orchestrator/lib/clients/client.ts
+++ b/packages/orchestrator/lib/clients/client.ts
@@ -48,6 +48,10 @@ function getRouteFetchStatusCode(message: string | undefined): number | null {
 }
 
 function shouldRetryRouteFetchResult(res: unknown): boolean {
+    // routeFetch wraps non-2xx responses as fetch_failed results, so retry policy has to
+    // look through that wrapper. Deterministic application errors like duplicate task-name
+    // conflicts should not be retried, while transport/no-status failures and transient
+    // HTTP responses still should.
     if (!res || typeof res !== 'object' || !('error' in res)) {
         return false;
     }
@@ -91,15 +95,32 @@ export class OrchestratorClient {
             const retryConfig: RetryConfig<E['Reply']> = config?.retryConfig || {
                 maxAttempts: 3,
                 delayMs: 50,
-                retryIf: (res) => shouldRetryRouteFetchResult(res)
+                retryIf: (res) => 'error' in res
             };
             return retry(fetch, retryConfig);
         };
     }
 
     public async immediate(props: ImmediateProps): Promise<Result<PostImmediate['Success'], ClientError>> {
-        const res = await this.routeFetch(postImmediateRoute)({ body: props });
+        const res = await this.routeFetch(postImmediateRoute, {
+            retryConfig: {
+                maxAttempts: 3,
+                delayMs: 50,
+                retryIf: (reply) => shouldRetryRouteFetchResult(reply)
+            }
+        })({ body: props });
         if ('error' in res) {
+            const duplicatePayload = getDuplicateTaskNamePayload(res.error.payload);
+            if (duplicatePayload !== null) {
+                const taskName = typeof duplicatePayload['taskName'] === 'string' ? duplicatePayload['taskName'] : undefined;
+                return Err({
+                    name: 'duplicate_task_name',
+                    message: taskName ? `Task with name '${taskName}' already exists` : 'Task with this name already exists',
+                    payload: duplicatePayload,
+                    additional_properties: { response: res.error.payload as JsonValue }
+                });
+            }
+
             return Err({
                 name: res.error.code,
                 message: res.error.message || `Error scheduling immediate task`,
@@ -546,4 +567,32 @@ export class OrchestratorClient {
             }));
         }
     }
+}
+
+function getDuplicateTaskNamePayload(payload: unknown): Record<string, JsonValue> | null {
+    if (!payload || typeof payload !== 'object' || !('error' in payload)) {
+        return null;
+    }
+
+    const response = payload as {
+        error?: {
+            code?: string;
+            payload?: { reason?: string; taskName?: string };
+        };
+    };
+
+    if (response.error?.code !== 'immediate_failed' || response.error.payload?.reason !== 'duplicate_task_name') {
+        return null;
+    }
+
+    return response.error.payload.taskName ? { taskName: response.error.payload.taskName } : {};
+}
+
+export function isDuplicateTaskNameClientError(err: unknown, taskName?: string): boolean {
+    if (!err || typeof err !== 'object') {
+        return false;
+    }
+
+    const error = err as { name?: string; payload?: { taskName?: string } };
+    return error.name === 'duplicate_task_name' && (taskName === undefined || error.payload?.taskName === taskName);
 }

--- a/packages/orchestrator/lib/clients/client.unit.test.ts
+++ b/packages/orchestrator/lib/clients/client.unit.test.ts
@@ -51,6 +51,10 @@ describe('OrchestratorClient retry policy', () => {
         const res = await client.immediate(buildImmediateRequest());
 
         expect(res.isErr()).toBe(true);
+        if (res.isErr()) {
+            expect(res.error.name).toBe('duplicate_task_name');
+            expect(res.error.payload).toEqual({ taskName: 'task-1' });
+        }
         expect(fetchMock).toHaveBeenCalledTimes(1);
     });
 

--- a/packages/server/lib/webhook/dispatch-queue/client.ts
+++ b/packages/server/lib/webhook/dispatch-queue/client.ts
@@ -1,0 +1,31 @@
+import { SQSClient } from '@aws-sdk/client-sqs';
+
+import { DispatchQueuePublisher } from './publisher.js';
+import { envs } from '../../env.js';
+
+const getRegion = (): string => envs.AWS_SQS_REGION ?? 'us-west-2';
+
+let cached: DispatchQueuePublisher | null | undefined;
+
+/**
+ * Returns the singleton DispatchQueuePublisher, or null when `NANGO_TASK_DISPATCH_QUEUE_URL`
+ * is unset (self-hosted / local dev). Callers must check for null before use.
+ */
+export function getDispatchQueuePublisher(): DispatchQueuePublisher | null {
+    if (cached !== undefined) return cached;
+    const url = envs.NANGO_TASK_DISPATCH_QUEUE_URL;
+    if (!url) {
+        cached = null;
+        return cached;
+    }
+    if (new URL(url).pathname.endsWith('.fifo')) {
+        throw new Error('Webhook dispatch queue must be a Standard SQS queue; FIFO queues would serialize environment traffic.');
+    }
+    cached = new DispatchQueuePublisher({
+        sqs: new SQSClient({ region: getRegion() }),
+        queueUrl: url,
+        batchSize: envs.NANGO_TASK_DISPATCH_PUBLISH_BATCH_SIZE,
+        publishConcurrency: envs.NANGO_TASK_DISPATCH_PUBLISH_CONCURRENCY
+    });
+    return cached;
+}

--- a/packages/server/lib/webhook/dispatch-queue/client.unit.test.ts
+++ b/packages/server/lib/webhook/dispatch-queue/client.unit.test.ts
@@ -1,0 +1,41 @@
+import { afterEach, describe, expect, it, vi } from 'vitest';
+
+describe('getDispatchQueuePublisher', () => {
+    afterEach(() => {
+        vi.resetModules();
+        vi.unmock('../../env.js');
+    });
+
+    it('wires batch size and publish concurrency from envs', async () => {
+        vi.doMock('../../env.js', () => ({
+            envs: {
+                AWS_SQS_REGION: 'eu-west-1',
+                NANGO_TASK_DISPATCH_QUEUE_URL: 'https://sqs.us-west-2.amazonaws.com/123456789012/nango-task-dispatch-development',
+                NANGO_TASK_DISPATCH_PUBLISH_BATCH_SIZE: 8,
+                NANGO_TASK_DISPATCH_PUBLISH_CONCURRENCY: 3
+            }
+        }));
+
+        const { getDispatchQueuePublisher } = await import('./client.js');
+        const publisher = getDispatchQueuePublisher() as any;
+
+        expect(publisher).not.toBeNull();
+        expect(publisher.batchSize).toBe(8);
+        expect(publisher.publishConcurrency).toBe(3);
+    });
+
+    it('rejects fifo queue urls', async () => {
+        vi.doMock('../../env.js', () => ({
+            envs: {
+                AWS_SQS_REGION: 'eu-west-1',
+                NANGO_TASK_DISPATCH_QUEUE_URL: 'https://sqs.us-west-2.amazonaws.com/123456789012/nango-task-dispatch-development.fifo',
+                NANGO_TASK_DISPATCH_PUBLISH_BATCH_SIZE: 10,
+                NANGO_TASK_DISPATCH_PUBLISH_CONCURRENCY: 2
+            }
+        }));
+
+        const { getDispatchQueuePublisher } = await import('./client.js');
+
+        expect(() => getDispatchQueuePublisher()).toThrow('Webhook dispatch queue must be a Standard SQS queue');
+    });
+});

--- a/packages/server/lib/webhook/dispatch-queue/publisher.ts
+++ b/packages/server/lib/webhook/dispatch-queue/publisher.ts
@@ -1,7 +1,7 @@
 import { SendMessageBatchCommand } from '@aws-sdk/client-sqs';
 import tracer from 'dd-trace';
 
-import { metrics } from '@nangohq/utils';
+import { metrics, report } from '@nangohq/utils';
 
 import type { SQSClient, SendMessageBatchCommandOutput, SendMessageBatchRequestEntry } from '@aws-sdk/client-sqs';
 import type { WebhookDispatchMessage } from '@nangohq/types';
@@ -20,6 +20,7 @@ export interface DispatchQueuePublisherProps {
 export interface PublishResult {
     enqueued: number;
     failed: number;
+    failedActivityLogIds: string[];
 }
 
 interface BatchPublishResult extends PublishResult {
@@ -58,7 +59,7 @@ export class DispatchQueuePublisher {
      */
     async publish(messages: WebhookDispatchMessage[], messageGroupId: string): Promise<PublishResult> {
         if (messages.length === 0) {
-            return { enqueued: 0, failed: 0 };
+            return { enqueued: 0, failed: 0, failedActivityLogIds: [] };
         }
 
         const activeSpan = tracer.scope().active();
@@ -85,6 +86,7 @@ export class DispatchQueuePublisher {
 
                 const enqueued = results.reduce((sum, r) => sum + r.enqueued, 0);
                 const failed = results.reduce((sum, r) => sum + r.failed, 0);
+                const failedActivityLogIds = results.flatMap((r) => r.failedActivityLogIds);
                 const retriedEntries = results.reduce((sum, r) => sum + r.retriedEntries, 0);
                 const retriedBatches = results.filter((r) => r.retriedEntries > 0).length;
 
@@ -106,7 +108,7 @@ export class DispatchQueuePublisher {
                     metrics.increment(metrics.Types.WEBHOOK_DISPATCH_PUBLISH_FAILURE, failed, { provider });
                 }
 
-                return { enqueued, failed };
+                return { enqueued, failed, failedActivityLogIds };
             } catch (err) {
                 span.setTag('error', err);
                 throw err;
@@ -120,16 +122,44 @@ export class DispatchQueuePublisher {
         const entries = batch.map((message, idx) => toEntry(message, idx, messageGroupId));
 
         const first = await this.trySend(entries);
-        const failedIndices = first.failedIds.map((id) => entryIdToIndex(id));
+        const failedIndices = first.failedIds.flatMap((id) => {
+            const index = entryIdToIndex(id);
+            if (index === null) {
+                report(new Error('webhook_dispatch_invalid_failed_entry_id'), { entryId: id });
+                return [];
+            }
+
+            return [index];
+        });
+        const invalidFailedCount = first.failedIds.length - failedIndices.length;
         if (failedIndices.length === 0) {
-            return { enqueued: batch.length, failed: 0, retriedEntries: 0 };
+            return {
+                enqueued: batch.length - invalidFailedCount,
+                failed: invalidFailedCount,
+                failedActivityLogIds: [],
+                retriedEntries: 0
+            };
         }
 
         const retryEntries = failedIndices.map((i) => entries[i]).filter((e): e is SendMessageBatchRequestEntry => e !== undefined);
         const second = await this.trySend(retryEntries);
 
-        const enqueued = batch.length - second.failedIds.length;
-        return { enqueued, failed: second.failedIds.length, retriedEntries: failedIndices.length };
+        const enqueued = batch.length - invalidFailedCount - second.failedIds.length;
+        return {
+            enqueued,
+            failed: invalidFailedCount + second.failedIds.length,
+            failedActivityLogIds: second.failedIds.flatMap((id) => {
+                const index = entryIdToIndex(id);
+                if (index === null) {
+                    report(new Error('webhook_dispatch_invalid_failed_entry_id'), { entryId: id });
+                    return [];
+                }
+
+                const activityLogId = batch[index]?.activityLogId;
+                return activityLogId ? [activityLogId] : [];
+            }),
+            retriedEntries: failedIndices.length
+        };
     }
 
     private async trySend(entries: SendMessageBatchRequestEntry[]): Promise<{ failedIds: string[] }> {
@@ -157,8 +187,13 @@ function indexToEntryId(index: number): string {
     return `m${index}`;
 }
 
-function entryIdToIndex(id: string): number {
-    return Number.parseInt(id.slice(1), 10);
+function entryIdToIndex(id: string): number | null {
+    if (!id.startsWith('m')) {
+        return null;
+    }
+
+    const index = Number.parseInt(id.slice(1), 10);
+    return Number.isNaN(index) ? null : index;
 }
 
 function chunk<T>(items: T[], size: number): T[][] {

--- a/packages/server/lib/webhook/dispatch-queue/publisher.unit.test.ts
+++ b/packages/server/lib/webhook/dispatch-queue/publisher.unit.test.ts
@@ -123,7 +123,7 @@ describe('DispatchQueuePublisher', () => {
         const { sqs, send } = makeSqsMock(() => ({ $metadata: {}, Successful: [], Failed: [] }));
         const publisher = new DispatchQueuePublisher({ sqs, queueUrl: 'http://q' });
         const res = await publisher.publish([], 'account:1:env:2');
-        expect(res).toEqual({ enqueued: 0, failed: 0 });
+        expect(res).toEqual({ enqueued: 0, failed: 0, failedActivityLogIds: [] });
         expect(send.mock.calls).toHaveLength(0);
     });
 
@@ -132,7 +132,7 @@ describe('DispatchQueuePublisher', () => {
         const publisher = new DispatchQueuePublisher({ sqs, queueUrl: 'http://q' });
         const messages = Array.from({ length: 25 }, () => buildMessage());
         const res = await publisher.publish(messages, 'account:1:env:2');
-        expect(res).toEqual({ enqueued: 25, failed: 0 });
+        expect(res).toEqual({ enqueued: 25, failed: 0, failedActivityLogIds: [] });
         expect(send.mock.calls).toHaveLength(3);
         const entryCounts = send.mock.calls.map((call) => (call[0] as SendMessageBatchCommand).input.Entries?.length);
         expect(entryCounts).toEqual([10, 10, 5]);
@@ -207,7 +207,7 @@ describe('DispatchQueuePublisher', () => {
         responses[2]!.resolve(successfulBatchResponse(send.mock.calls[2]![0] as SendMessageBatchCommand));
         responses[3]!.resolve(successfulBatchResponse(send.mock.calls[3]![0] as SendMessageBatchCommand));
 
-        await expect(publishPromise).resolves.toEqual({ enqueued: 4, failed: 0 });
+        await expect(publishPromise).resolves.toEqual({ enqueued: 4, failed: 0, failedActivityLogIds: [] });
     });
 
     it('retries failed entries once and reports remaining failures', async () => {
@@ -229,8 +229,11 @@ describe('DispatchQueuePublisher', () => {
         ];
         const { sqs, send } = makeSqsMock((_n, call) => responses[call]!);
         const publisher = new DispatchQueuePublisher({ sqs, queueUrl: 'http://q' });
-        const res = await publisher.publish([buildMessage(), buildMessage(), buildMessage()], 'account:1:env:2');
-        expect(res).toEqual({ enqueued: 2, failed: 1 });
+        const res = await publisher.publish(
+            [buildMessage(), buildMessage({ activityLogId: 'log-2' }), buildMessage({ activityLogId: 'log-3' })],
+            'account:1:env:2'
+        );
+        expect(res).toEqual({ enqueued: 2, failed: 1, failedActivityLogIds: ['log-3'] });
         expect(send.mock.calls).toHaveLength(2);
         expect(tracerMocks.span.setTag).toHaveBeenCalledWith('nango.enqueued', 2);
         expect(tracerMocks.span.setTag).toHaveBeenCalledWith('nango.failed', 1);
@@ -253,11 +256,34 @@ describe('DispatchQueuePublisher', () => {
         });
         const publisher = new DispatchQueuePublisher({ sqs, queueUrl: 'http://q' });
         const res = await publisher.publish([buildMessage()], 'account:1:env:2');
-        expect(res).toEqual({ enqueued: 1, failed: 0 });
+        expect(res).toEqual({ enqueued: 1, failed: 0, failedActivityLogIds: [] });
         expect(send.mock.calls).toHaveLength(2);
         expect(tracerMocks.span.setTag).toHaveBeenCalledWith('nango.retriedEntries', 1);
         expect(tracerMocks.span.setTag).toHaveBeenCalledWith('nango.retriedBatches', 1);
         expect(tracerMocks.span.setTag.mock.calls.filter(([tag]) => tag === 'error')).toHaveLength(0);
         expect(tracerMocks.activeSpan.setTag).toHaveBeenCalledWith('sqs.send.error', expect.any(Error));
+    });
+
+    it('reports malformed failed entry ids without crashing retries', async () => {
+        const { sqs } = makeSqsMock((_n, call) => {
+            if (call === 0) {
+                return {
+                    $metadata: {},
+                    Successful: [],
+                    Failed: [{ Id: 'bogus', SenderFault: false, Code: 'InternalError', Message: 'boom' }]
+                };
+            }
+
+            return {
+                $metadata: {},
+                Successful: [],
+                Failed: [{ Id: 'bogus', SenderFault: false, Code: 'InternalError', Message: 'still boom' }]
+            };
+        });
+        const publisher = new DispatchQueuePublisher({ sqs, queueUrl: 'http://q' });
+
+        const res = await publisher.publish([buildMessage()], 'account:1:env:2');
+
+        expect(res).toEqual({ enqueued: 0, failed: 1, failedActivityLogIds: [] });
     });
 });

--- a/packages/server/lib/webhook/internal-nango.ts
+++ b/packages/server/lib/webhook/internal-nango.ts
@@ -1,13 +1,48 @@
+import { createHash } from 'node:crypto';
+
 import get from 'lodash-es/get.js';
 
-import { connectionService, getSyncConfigsByConfigIdForWebhook } from '@nangohq/shared';
+import { OtlpSpan } from '@nangohq/logs';
+import { NangoError, connectionService, getSyncConfigsByConfigIdForWebhook } from '@nangohq/shared';
+import { metrics } from '@nangohq/utils';
 
 import { envs } from '../env.js';
 import { getOrchestrator } from '../utils/utils.js';
+import { getDispatchQueuePublisher } from './dispatch-queue/client.js';
 
+import type { DispatchQueuePublisher } from './dispatch-queue/publisher.js';
 import type { LogContextGetter } from '@nangohq/logs';
 import type { Config } from '@nangohq/shared';
-import type { ConnectionInternal, DBConnectionDecrypted, DBEnvironment, DBIntegrationDecrypted, DBPlan, DBTeam, Metadata } from '@nangohq/types';
+import type {
+    ConnectionInternal,
+    DBConnectionDecrypted,
+    DBEnvironment,
+    DBIntegrationDecrypted,
+    DBPlan,
+    DBSyncConfig,
+    DBTeam,
+    Metadata,
+    WebhookDispatchMessage
+} from '@nangohq/types';
+
+const LARGE_FANOUT_THRESHOLD = 200;
+
+function computeTaskName({
+    environmentId,
+    providerConfigKey,
+    parentSyncName,
+    connectionId,
+    activityLogId
+}: {
+    environmentId: number;
+    providerConfigKey: string;
+    parentSyncName: string;
+    connectionId: number;
+    activityLogId: string;
+}): string {
+    const hash = createHash('sha256').update(`${environmentId}:${providerConfigKey}:${parentSyncName}:${connectionId}:${activityLogId}`).digest('hex');
+    return `webhook:${hash.slice(0, 32)}`;
+}
 
 export class InternalNango {
     readonly team: DBTeam;
@@ -108,21 +143,51 @@ export class InternalNango {
         // use webhookTypeValue if provided (direct value from headers), otherwise extract from body
         const type = webhookTypeValue || (webhookType ? get(body, webhookType) : undefined);
 
+        const publisher = envs.WEBHOOK_INGRESS_USE_DISPATCH_QUEUE ? getDispatchQueuePublisher() : null;
+
+        if (publisher) {
+            await this.dispatchViaQueue({
+                publisher,
+                connections,
+                syncConfigsWithWebhooks,
+                body,
+                type,
+                webhookHeaderValue
+            });
+        } else {
+            await this.dispatchViaOrchestrator({ connections, syncConfigsWithWebhooks, body, type, webhookHeaderValue });
+        }
+
+        const connectionMetadata = connections.reduce<Record<string, Metadata | null>>((acc, connection) => {
+            acc[connection.connection_id] = 'metadata' in connection ? connection.metadata : null;
+            return acc;
+        }, {});
+
+        return { connectionIds: connections.map((connection) => connection.connection_id), connectionMetadata };
+    }
+
+    private async dispatchViaOrchestrator({
+        connections,
+        syncConfigsWithWebhooks,
+        body,
+        type,
+        webhookHeaderValue
+    }: {
+        connections: (DBConnectionDecrypted | ConnectionInternal)[];
+        syncConfigsWithWebhooks: DBSyncConfig[];
+        body: Record<string, any>;
+        type: string | undefined;
+        webhookHeaderValue: string | undefined;
+    }): Promise<void> {
         const orchestrator = getOrchestrator();
 
         for (const syncConfig of syncConfigsWithWebhooks) {
             const { webhook_subscriptions } = syncConfig;
-
-            if (!webhook_subscriptions) {
-                continue;
-            }
+            if (!webhook_subscriptions) continue;
 
             let triggered = false;
-
             for (const webhook of webhook_subscriptions) {
-                if (triggered) {
-                    break;
-                }
+                if (triggered) break;
 
                 if (type === webhook || webhookHeaderValue === webhook || webhook === '*') {
                     for (const connection of connections) {
@@ -140,20 +205,124 @@ export class InternalNango {
                     }
 
                     triggered = true;
+                    if (webhook === '*') break;
+                }
+            }
+        }
+    }
 
-                    if (webhook === '*') {
-                        // Only trigger once since it will match all webhooks
-                        break;
+    private async dispatchViaQueue({
+        publisher,
+        connections,
+        syncConfigsWithWebhooks,
+        body,
+        type,
+        webhookHeaderValue
+    }: {
+        publisher: DispatchQueuePublisher;
+        connections: (DBConnectionDecrypted | ConnectionInternal)[];
+        syncConfigsWithWebhooks: DBSyncConfig[];
+        body: Record<string, any>;
+        type: string | undefined;
+        webhookHeaderValue: string | undefined;
+    }): Promise<void> {
+        const queuedExecutions: { message: WebhookDispatchMessage; logCtx: Awaited<ReturnType<LogContextGetter['create']>> }[] = [];
+
+        for (const syncConfig of syncConfigsWithWebhooks) {
+            const { webhook_subscriptions } = syncConfig;
+            if (!webhook_subscriptions) continue;
+
+            let matched = false;
+            for (const webhook of webhook_subscriptions) {
+                if (matched) break;
+
+                if (type === webhook || webhookHeaderValue === webhook || webhook === '*') {
+                    for (const connection of connections) {
+                        // Create a log context per (syncConfig × connection × webhook) triple before publishing
+                        // so the runner picks up the same activityLogId it would have in the direct-schedule path.
+                        const logCtx = await this.logContextGetter.create(
+                            { operation: { type: 'webhook', action: 'incoming' }, expiresAt: new Date(Date.now() + 15 * 60 * 1000).toISOString() },
+                            {
+                                account: this.team,
+                                environment: this.environment,
+                                integration: { id: this.integration.id!, name: this.integration.unique_key, provider: this.integration.provider },
+                                connection: { id: connection.id, name: connection.connection_id },
+                                syncConfig: { id: syncConfig.id, name: syncConfig.sync_name }
+                            }
+                        );
+                        logCtx.attachSpan(new OtlpSpan(logCtx.operation));
+
+                        queuedExecutions.push({
+                            logCtx,
+                            message: {
+                                version: 1,
+                                kind: 'webhook',
+                                taskName: computeTaskName({
+                                    environmentId: this.environment.id,
+                                    providerConfigKey: this.integration.unique_key,
+                                    parentSyncName: syncConfig.sync_name,
+                                    connectionId: connection.id,
+                                    activityLogId: logCtx.id
+                                }),
+                                createdAt: new Date().toISOString(),
+                                accountId: this.team.id,
+                                integrationId: this.integration.id!,
+                                provider: this.integration.provider,
+                                parentSyncName: syncConfig.sync_name,
+                                activityLogId: logCtx.id,
+                                webhookName: webhook,
+                                connection: {
+                                    id: connection.id,
+                                    connection_id: connection.connection_id,
+                                    provider_config_key: connection.provider_config_key,
+                                    environment_id: connection.environment_id
+                                },
+                                payload: body
+                            }
+                        });
                     }
+
+                    matched = true;
+                    if (webhook === '*') break;
                 }
             }
         }
 
-        const connectionMetadata = connections.reduce<Record<string, Metadata | null>>((acc, connection) => {
-            acc[connection.connection_id] = 'metadata' in connection ? connection.metadata : null;
-            return acc;
-        }, {});
+        if (queuedExecutions.length === 0) return;
 
-        return { connectionIds: connections.map((connection) => connection.connection_id), connectionMetadata };
+        const messages = queuedExecutions.map(({ message }) => message);
+
+        if (messages.length > LARGE_FANOUT_THRESHOLD) {
+            metrics.increment(metrics.Types.WEBHOOK_DISPATCH_LARGE_FANOUT, 1, { provider: this.integration.provider });
+        }
+
+        const messageGroupId = `account:${this.team.id}:env:${this.environment.id}`;
+        const publishResult = await publisher.publish(messages, messageGroupId);
+        const failedActivityLogIds = new Set(publishResult.failedActivityLogIds);
+
+        for (const { message, logCtx } of queuedExecutions) {
+            if (!failedActivityLogIds.has(message.activityLogId)) {
+                void logCtx.info('The webhook was successfully queued for execution', {
+                    action: message.webhookName,
+                    connection: message.connection.connection_id,
+                    integration: message.connection.provider_config_key
+                });
+                continue;
+            }
+
+            const error = new NangoError('webhook_failure', {
+                error: 'The webhook could not be queued for execution',
+                taskName: message.taskName
+            });
+
+            await logCtx.error('The webhook failed to queue for execution', {
+                error,
+                webhook: message.webhookName,
+                connection: message.connection.connection_id,
+                integration: message.connection.provider_config_key
+            });
+            await logCtx.enrichOperation({ error });
+            await logCtx.failed();
+        }
     }
 }

--- a/packages/server/lib/webhook/internal-nango.unit.test.ts
+++ b/packages/server/lib/webhook/internal-nango.unit.test.ts
@@ -1,0 +1,132 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+const mocks = vi.hoisted(() => {
+    return {
+        envs: {
+            WEBHOOK_INGRESS_USE_DISPATCH_QUEUE: true,
+            WEBHOOK_ENVIRONMENT_MAX_CONCURRENCY: 7
+        },
+        getDispatchQueuePublisher: vi.fn(),
+        triggerWebhook: vi.fn(),
+        getConnectionsByEnvironmentAndConfig: vi.fn(),
+        getSyncConfigsByConfigIdForWebhook: vi.fn()
+    };
+});
+
+vi.mock('../env.js', () => ({ envs: mocks.envs }));
+vi.mock('./dispatch-queue/client.js', () => ({ getDispatchQueuePublisher: mocks.getDispatchQueuePublisher }));
+vi.mock('../utils/utils.js', () => ({ getOrchestrator: () => ({ triggerWebhook: mocks.triggerWebhook }) }));
+vi.mock('@nangohq/shared', () => {
+    class NangoError extends Error {
+        public payload: Record<string, unknown>;
+
+        constructor(type: string, payload: Record<string, unknown>) {
+            super(type);
+            this.name = type;
+            this.payload = payload;
+        }
+    }
+
+    return {
+        NangoError,
+        connectionService: {
+            getConnectionsByEnvironmentAndConfig: mocks.getConnectionsByEnvironmentAndConfig
+        },
+        getSyncConfigsByConfigIdForWebhook: mocks.getSyncConfigsByConfigIdForWebhook
+    };
+});
+
+import { InternalNango } from './internal-nango.js';
+
+function createLogCtx(id: string) {
+    return {
+        id,
+        operation: { id },
+        attachSpan: vi.fn(),
+        info: vi.fn().mockResolvedValue(true),
+        error: vi.fn().mockResolvedValue(true),
+        enrichOperation: vi.fn().mockResolvedValue(undefined),
+        failed: vi.fn().mockResolvedValue(undefined)
+    };
+}
+
+function makeInternalNango(logContexts: ReturnType<typeof createLogCtx>[]) {
+    const logContextGetter = {
+        create: vi.fn().mockImplementation(() => {
+            const next = logContexts.shift();
+            if (!next) {
+                throw new Error('Missing log context');
+            }
+            return next;
+        })
+    } as any;
+
+    return {
+        nango: new InternalNango({
+            team: { id: 1 } as any,
+            environment: { id: 2 } as any,
+            plan: undefined,
+            integration: { id: 3, unique_key: 'github-dev', provider: 'github' } as any,
+            logContextGetter
+        }),
+        logContextGetter
+    };
+}
+
+describe('InternalNango queue dispatch', () => {
+    beforeEach(() => {
+        vi.clearAllMocks();
+        mocks.envs.WEBHOOK_INGRESS_USE_DISPATCH_QUEUE = true;
+        mocks.getConnectionsByEnvironmentAndConfig.mockResolvedValue([
+            { id: 11, connection_id: 'conn-1', provider_config_key: 'github-dev', environment_id: 2, metadata: null },
+            { id: 12, connection_id: 'conn-2', provider_config_key: 'github-dev', environment_id: 2, metadata: null }
+        ]);
+        mocks.getSyncConfigsByConfigIdForWebhook.mockResolvedValue([{ id: 21, sync_name: 'sync-1', webhook_subscriptions: ['push'] }]);
+        mocks.triggerWebhook.mockResolvedValue(undefined);
+    });
+
+    it('logs queued successes and marks failed publishes as failed operations', async () => {
+        const publisher = {
+            publish: vi.fn().mockResolvedValue({ enqueued: 1, failed: 1, failedActivityLogIds: ['log-2'] })
+        };
+        mocks.getDispatchQueuePublisher.mockReturnValue(publisher);
+
+        const logCtx1 = createLogCtx('log-1');
+        const logCtx2 = createLogCtx('log-2');
+        const { nango } = makeInternalNango([logCtx1, logCtx2]);
+
+        const result = await nango.executeScriptForWebhooks({ body: { event: 'x' }, webhookTypeValue: 'push' });
+
+        expect(result.connectionIds).toEqual(['conn-1', 'conn-2']);
+        expect(publisher.publish).toHaveBeenCalledTimes(1);
+        expect(logCtx1.info).toHaveBeenCalledWith('The webhook was successfully queued for execution', {
+            action: 'push',
+            connection: 'conn-1',
+            integration: 'github-dev'
+        });
+        expect(logCtx2.error).toHaveBeenCalledWith('The webhook failed to queue for execution', {
+            error: expect.any(Error),
+            webhook: 'push',
+            connection: 'conn-2',
+            integration: 'github-dev'
+        });
+        expect(logCtx2.enrichOperation).toHaveBeenCalledWith({ error: expect.any(Error) });
+        expect(logCtx2.failed).toHaveBeenCalledOnce();
+    });
+
+    it('falls back to direct orchestrator dispatch when the feature flag is off', async () => {
+        mocks.envs.WEBHOOK_INGRESS_USE_DISPATCH_QUEUE = false;
+        const publisher = { publish: vi.fn() };
+        mocks.getDispatchQueuePublisher.mockReturnValue(publisher);
+
+        const { nango, logContextGetter } = makeInternalNango([]);
+
+        const result = await nango.executeScriptForWebhooks({ body: { event: 'x' }, webhookTypeValue: 'push' });
+
+        expect(result.connectionIds).toEqual(['conn-1', 'conn-2']);
+        expect(mocks.getDispatchQueuePublisher).not.toHaveBeenCalled();
+        expect(mocks.triggerWebhook).toHaveBeenCalledTimes(2);
+        expect(logContextGetter.create).not.toHaveBeenCalled();
+        expect(publisher.publish).not.toHaveBeenCalled();
+    });
+});

--- a/packages/types/lib/webhooks/dispatch.ts
+++ b/packages/types/lib/webhooks/dispatch.ts
@@ -23,7 +23,7 @@ export interface WebhookDispatchMessage {
     parentSyncName: string;
     /** Webhook subscription name matched on the inbound payload; passed to executeWebhook as args.webhookName. */
     webhookName: string;
-    /** Activity log id created before enqueue; also reused as the taskName dedupe seed. */
+    /** Activity log id created before enqueue; reused so redelivery of this published message keeps the same taskName. */
     activityLogId: string;
     connection: {
         id: number;

--- a/packages/utils/lib/environment/parse.ts
+++ b/packages/utils/lib/environment/parse.ts
@@ -540,6 +540,7 @@ export const ENVS = z.object({
     WEBHOOK_INGRESS_USE_DISPATCH_QUEUE: z.stringbool().optional().default(false),
 
     // TASK DISPATCH QUEUE
+    AWS_SQS_REGION: z.string().min(1).optional(),
     NANGO_TASK_DISPATCH_QUEUE_URL: z.url().optional(),
     NANGO_TASK_DISPATCH_DLQ_URL: z.url().optional(),
     NANGO_TASK_DISPATCH_MAX_MESSAGES: z.coerce.number().min(1).max(10).optional().default(10),

--- a/packages/utils/lib/environment/parse.unit.test.ts
+++ b/packages/utils/lib/environment/parse.unit.test.ts
@@ -167,8 +167,14 @@ describe('parse', () => {
                 NANGO_TASK_DISPATCH_PUBLISH_BATCH_SIZE: 10,
                 NANGO_TASK_DISPATCH_PUBLISH_CONCURRENCY: 10
             });
+            expect(res.AWS_SQS_REGION).toBeUndefined();
             expect(res.NANGO_TASK_DISPATCH_QUEUE_URL).toBeUndefined();
             expect(res.NANGO_TASK_DISPATCH_DLQ_URL).toBeUndefined();
+        });
+
+        it('should accept AWS_SQS_REGION when provided', () => {
+            const res = parseEnvs(ENVS, { AWS_SQS_REGION: 'eu-west-1' });
+            expect(res.AWS_SQS_REGION).toBe('eu-west-1');
         });
 
         it('should accept valid SQS URLs for queue and DLQ', () => {


### PR DESCRIPTION
Behind `WEBHOOK_INGRESS_USE_DISPATCH_QUEUE` (default off), replace the nested-loop `orchestrator.triggerWebhook()` calls in `InternalNango.executeScriptForWebhooks()` with:

- one `WebhookDispatchMessage` per (syncConfig × subscription × connection)
  triple
- `MessageGroupId` = `account:<accountId>:env:<environmentId>` for fair
  queueing
- one `SendMessageBatch`-driven publish call per request

`connectionIds` are still returned so `forwardWebhook` keeps working.

Large fan-out (>200 messages) emits `WEBHOOK_DISPATCH_LARGE_FANOUT` for tracking.

A singleton `DispatchQueuePublisher` is cached in `dispatch-queue/client.ts` and gated on `NANGO_TASK_DISPATCH_QUEUE_URL` being set.