### PR TITLE
docs(functions): shorten pre-built functions callout

### DIFF
--- a/docs/guides/primitives/functions.mdx
+++ b/docs/guides/primitives/functions.mdx
@@ -85,7 +85,7 @@ Your application can call functions from any language or framework.
 <Tip>**Using a coding agent?** Copy the page (button top right) and paste as a prompt.</Tip>
 
 <Note>
-  To enable a pre-built function without any local setup, browse the [templates catalog](https://www.nango.dev/templates) and enable functions directly from the [Nango dashboard](https://app.nango.dev) — no CLI or code required.
+  You can enable pre-built functions directly from the dashboard, then skip to step 4.
 </Note>
 
 <Steps>


### PR DESCRIPTION
## Summary
- Shortens the callout in the Functions guide from a verbose sentence to a concise one-liner

🤖 Generated with [Claude Code](https://claude.com/claude-code)