### PR TITLE
docs: normalize page titles to sentence case

### DIFF
--- a/docs/docs.json
+++ b/docs/docs.json
@@ -140,7 +140,7 @@
         "icon": "book-open",
         "groups": [
           {
-            "group": "Getting Started",
+            "group": "Getting started",
             "pages": [
               "getting-started/intro-to-nango",
               "getting-started/quickstart"
@@ -172,7 +172,7 @@
                 ]
               },
               {
-                "group": "Use Cases",
+                "group": "Use cases",
                 "expanded": false,
                 "pages": [
                   {

--- a/docs/guides/platform/free-self-hosting/configuration.mdx
+++ b/docs/guides/platform/free-self-hosting/configuration.mdx
@@ -1,5 +1,5 @@
 ---
-title: 'Free self-hosting - Configuration'
+title: 'Free self-hosting - configuration'
 sidebarTitle: 'Configuration'
 description: 'Instructions & configuration options for self-hosting Nango.'
 ---

--- a/docs/implementation-guides/platform/auth/customize-connect-ui.mdx
+++ b/docs/implementation-guides/platform/auth/customize-connect-ui.mdx
@@ -1,5 +1,5 @@
 ---
-title: 'API Auth with a custom UI'
+title: 'API auth with a custom UI'
 sidebarTitle: 'Customize Connect UI'
 description: 'Guide to letting your users authorize an external API from your application, with your own UI.'
 ---

--- a/docs/reference/api-keys.mdx
+++ b/docs/reference/api-keys.mdx
@@ -1,10 +1,10 @@
 ---
-title: "API Keys"
-sidebarTitle: "API Keys"
+title: "API keys"
+sidebarTitle: "API keys"
 description: "Manage API keys with scoped permissions for your Nango environments."
 ---
 
-# API Keys
+# API keys
 
 API keys allow programmatic access to your Nango environment. Each environment can have multiple API keys with different permissions, enabling you to follow the principle of least privilege.
 

--- a/docs/reference/api/connection/set-metadata-legacy.mdx
+++ b/docs/reference/api/connection/set-metadata-legacy.mdx
@@ -1,5 +1,5 @@
 ---
-title: 'Set connection metadata (Deprecated)'
+title: 'Set connection metadata (deprecated)'
 openapi: 'POST /connection/{connectionId}/metadata'
 ---
 

--- a/docs/reference/api/connection/update-metadata-legacy.mdx
+++ b/docs/reference/api/connection/update-metadata-legacy.mdx
@@ -1,5 +1,5 @@
 ---
-title: 'Edit connection metadata (Deprecated)'
+title: 'Edit connection metadata (deprecated)'
 openapi: 'PATCH /connection/{connectionId}/metadata'
 ---
 

--- a/docs/reference/api/sync/environment-variables.mdx
+++ b/docs/reference/api/sync/environment-variables.mdx
@@ -1,5 +1,5 @@
 ---
-title: 'Get Environment Variables'
+title: 'Get environment variables'
 openapi: 'GET /environment-variables'
 ---
 

--- a/docs/updates/dev.mdx
+++ b/docs/updates/dev.mdx
@@ -1,6 +1,6 @@
 ---
-title: "Dev Updates"
-sidebarTitle: "Dev Updates"
+title: "Dev updates"
+sidebarTitle: "Dev updates"
 description: "Updates and breaking changes for developers."
 ---
 

--- a/docs/updates/product.mdx
+++ b/docs/updates/product.mdx
@@ -1,6 +1,6 @@
 ---
-title: "Product Updates"
-sidebarTitle: "Product Updates"
+title: "Product updates"
+sidebarTitle: "Product updates"
 description: "Product updates and improvements."
 ---
 


### PR DESCRIPTION
## Summary

- Standardizes all doc page titles and nav group labels to sentence case (first word capitalized, plus acronyms/proper nouns like API, SDK, MCP, etc.)
- Changes nav groups: "Getting Started" → "Getting started", "Use Cases" → "Use cases"
- Fixes title frontmatter in 8 pages: `API Keys`, `Get Environment Variables`, `(Deprecated)` casing, `Dev/Product Updates`, `Free self-hosting - Configuration`, `API Auth with a custom UI`

## Test plan

- [ ] Run `mintlify broken-links` from `docs/` — no anchors changed so links should be clean
- [ ] Confirm nav labels and page headers render correctly in Mintlify preview

🤖 Generated with [Claude Code](https://claude.com/claude-code)