### PR TITLE
feat(webhooks): switch internal-nango to publish via dispatch queue (NAN-5340) 3/5

### DIFF
--- a/packages/server/lib/webhook/dispatch-queue/client.ts
+++ b/packages/server/lib/webhook/dispatch-queue/client.ts
@@ -1,0 +1,26 @@
+import { SQSClient } from '@aws-sdk/client-sqs';
+
+import { DispatchQueuePublisher } from './publisher.js';
+import { envs } from '../../env.js';
+
+function buildPublisher(): DispatchQueuePublisher | null {
+    const url = envs.NANGO_TASK_DISPATCH_QUEUE_URL;
+    if (!url) {
+        return null;
+    }
+    if (new URL(url).pathname.replace(/\/$/, '').endsWith('.fifo')) {
+        throw new Error('Webhook dispatch queue must be a Standard SQS queue; FIFO queues would serialize environment traffic.');
+    }
+    return new DispatchQueuePublisher({
+        sqs: new SQSClient(envs.AWS_REGION ? { region: envs.AWS_REGION } : {}),
+        queueUrl: url,
+        batchSize: envs.NANGO_TASK_DISPATCH_PUBLISH_BATCH_SIZE,
+        publishConcurrency: envs.NANGO_TASK_DISPATCH_PUBLISH_CONCURRENCY
+    });
+}
+
+/**
+ * Singleton DispatchQueuePublisher, or null when `NANGO_TASK_DISPATCH_QUEUE_URL`
+ * is unset (self-hosted / local dev). Callers must check for null before use.
+ */
+export const dispatchQueuePublisher: DispatchQueuePublisher | null = buildPublisher();

--- a/packages/server/lib/webhook/dispatch-queue/client.unit.test.ts
+++ b/packages/server/lib/webhook/dispatch-queue/client.unit.test.ts
@@ -1,0 +1,52 @@
+import { afterEach, describe, expect, it, vi } from 'vitest';
+
+describe('dispatchQueuePublisher', () => {
+    afterEach(() => {
+        vi.resetModules();
+        vi.unmock('../../env.js');
+    });
+
+    it('wires batch size and publish concurrency from envs', async () => {
+        vi.doMock('../../env.js', () => ({
+            envs: {
+                AWS_REGION: 'eu-west-1',
+                NANGO_TASK_DISPATCH_QUEUE_URL: 'https://sqs.us-west-2.amazonaws.com/123456789012/nango-task-dispatch-development',
+                NANGO_TASK_DISPATCH_PUBLISH_BATCH_SIZE: 8,
+                NANGO_TASK_DISPATCH_PUBLISH_CONCURRENCY: 3
+            }
+        }));
+
+        const { dispatchQueuePublisher } = await import('./client.js');
+        const publisher = dispatchQueuePublisher as any;
+
+        expect(publisher).not.toBeNull();
+        expect(publisher.batchSize).toBe(8);
+        expect(publisher.publishConcurrency).toBe(3);
+    });
+
+    it('rejects fifo queue urls', async () => {
+        vi.doMock('../../env.js', () => ({
+            envs: {
+                AWS_REGION: 'eu-west-1',
+                NANGO_TASK_DISPATCH_QUEUE_URL: 'https://sqs.us-west-2.amazonaws.com/123456789012/nango-task-dispatch-development.fifo',
+                NANGO_TASK_DISPATCH_PUBLISH_BATCH_SIZE: 10,
+                NANGO_TASK_DISPATCH_PUBLISH_CONCURRENCY: 2
+            }
+        }));
+
+        await expect(import('./client.js')).rejects.toThrow('Webhook dispatch queue must be a Standard SQS queue');
+    });
+
+    it('rejects fifo queue urls with trailing slash', async () => {
+        vi.doMock('../../env.js', () => ({
+            envs: {
+                AWS_REGION: 'eu-west-1',
+                NANGO_TASK_DISPATCH_QUEUE_URL: 'https://sqs.us-west-2.amazonaws.com/123456789012/nango-task-dispatch-development.fifo/',
+                NANGO_TASK_DISPATCH_PUBLISH_BATCH_SIZE: 10,
+                NANGO_TASK_DISPATCH_PUBLISH_CONCURRENCY: 2
+            }
+        }));
+
+        await expect(import('./client.js')).rejects.toThrow('Webhook dispatch queue must be a Standard SQS queue');
+    });
+});

--- a/packages/server/lib/webhook/dispatch-queue/publisher.ts
+++ b/packages/server/lib/webhook/dispatch-queue/publisher.ts
@@ -1,7 +1,7 @@
 import { SendMessageBatchCommand } from '@aws-sdk/client-sqs';
 import tracer from 'dd-trace';
 
-import { metrics } from '@nangohq/utils';
+import { metrics, report } from '@nangohq/utils';
 
 import { runWithConcurrencyLimit } from '../runWithConcurrencyLimit.js';
 
@@ -23,6 +23,7 @@ export interface DispatchQueuePublisherProps {
 export interface PublishResult {
     enqueued: number;
     failed: number;
+    failedActivityLogIds: string[];
 }
 
 interface BatchPublishResult extends PublishResult {
@@ -61,7 +62,7 @@ export class DispatchQueuePublisher {
      */
     async publish(messages: WebhookDispatchMessage[], messageGroupId: string): Promise<PublishResult> {
         if (messages.length === 0) {
-            return { enqueued: 0, failed: 0 };
+            return { enqueued: 0, failed: 0, failedActivityLogIds: [] };
         }
 
         const activeSpan = tracer.scope().active();
@@ -88,6 +89,7 @@ export class DispatchQueuePublisher {
 
                 const enqueued = results.reduce((sum, r) => sum + r.enqueued, 0);
                 const failed = results.reduce((sum, r) => sum + r.failed, 0);
+                const failedActivityLogIds = results.flatMap((r) => r.failedActivityLogIds);
                 const retriedEntries = results.reduce((sum, r) => sum + r.retriedEntries, 0);
                 const retriedBatches = results.filter((r) => r.retriedEntries > 0).length;
 
@@ -109,7 +111,7 @@ export class DispatchQueuePublisher {
                     metrics.increment(metrics.Types.WEBHOOK_DISPATCH_PUBLISH_FAILURE, failed, { provider });
                 }
 
-                return { enqueued, failed };
+                return { enqueued, failed, failedActivityLogIds };
             } catch (err) {
                 span.setTag('error', err);
                 throw err;
@@ -123,16 +125,44 @@ export class DispatchQueuePublisher {
         const entries = batch.map((message, idx) => toEntry(message, idx, messageGroupId));
 
         const first = await this.trySend(entries);
-        const failedIndices = first.failedIds.map((id) => entryIdToIndex(id));
+        const failedIndices = first.failedIds.flatMap((id) => {
+            const index = entryIdToIndex(id);
+            if (index === null) {
+                report(new Error('webhook_dispatch_invalid_failed_entry_id'), { entryId: id });
+                return [];
+            }
+
+            return [index];
+        });
+        const invalidFailedCount = first.failedIds.length - failedIndices.length;
         if (failedIndices.length === 0) {
-            return { enqueued: batch.length, failed: 0, retriedEntries: 0 };
+            return {
+                enqueued: batch.length - invalidFailedCount,
+                failed: invalidFailedCount,
+                failedActivityLogIds: [],
+                retriedEntries: 0
+            };
         }
 
         const retryEntries = failedIndices.map((i) => entries[i]).filter((e): e is SendMessageBatchRequestEntry => e !== undefined);
         const second = await this.trySend(retryEntries);
 
-        const enqueued = batch.length - second.failedIds.length;
-        return { enqueued, failed: second.failedIds.length, retriedEntries: failedIndices.length };
+        const enqueued = batch.length - invalidFailedCount - second.failedIds.length;
+        return {
+            enqueued,
+            failed: invalidFailedCount + second.failedIds.length,
+            failedActivityLogIds: second.failedIds.flatMap((id) => {
+                const index = entryIdToIndex(id);
+                if (index === null) {
+                    report(new Error('webhook_dispatch_invalid_failed_entry_id'), { entryId: id });
+                    return [];
+                }
+
+                const activityLogId = batch[index]?.activityLogId;
+                return activityLogId ? [activityLogId] : [];
+            }),
+            retriedEntries: failedIndices.length
+        };
     }
 
     private async trySend(entries: SendMessageBatchRequestEntry[]): Promise<{ failedIds: string[] }> {
@@ -160,8 +190,13 @@ function indexToEntryId(index: number): string {
     return `m${index}`;
 }
 
-function entryIdToIndex(id: string): number {
-    return Number.parseInt(id.slice(1), 10);
+function entryIdToIndex(id: string): number | null {
+    if (!id.startsWith('m')) {
+        return null;
+    }
+
+    const index = Number.parseInt(id.slice(1), 10);
+    return Number.isNaN(index) ? null : index;
 }
 
 function chunk<T>(items: T[], size: number): T[][] {

--- a/packages/server/lib/webhook/dispatch-queue/publisher.unit.test.ts
+++ b/packages/server/lib/webhook/dispatch-queue/publisher.unit.test.ts
@@ -123,7 +123,7 @@ describe('DispatchQueuePublisher', () => {
         const { sqs, send } = makeSqsMock(() => ({ $metadata: {}, Successful: [], Failed: [] }));
         const publisher = new DispatchQueuePublisher({ sqs, queueUrl: 'http://q' });
         const res = await publisher.publish([], 'account:1:env:2');
-        expect(res).toEqual({ enqueued: 0, failed: 0 });
+        expect(res).toEqual({ enqueued: 0, failed: 0, failedActivityLogIds: [] });
         expect(send.mock.calls).toHaveLength(0);
     });
 
@@ -132,7 +132,7 @@ describe('DispatchQueuePublisher', () => {
         const publisher = new DispatchQueuePublisher({ sqs, queueUrl: 'http://q' });
         const messages = Array.from({ length: 25 }, () => buildMessage());
         const res = await publisher.publish(messages, 'account:1:env:2');
-        expect(res).toEqual({ enqueued: 25, failed: 0 });
+        expect(res).toEqual({ enqueued: 25, failed: 0, failedActivityLogIds: [] });
         expect(send.mock.calls).toHaveLength(3);
         const entryCounts = send.mock.calls.map((call) => (call[0] as SendMessageBatchCommand).input.Entries?.length);
         expect(entryCounts).toEqual([10, 10, 5]);
@@ -207,7 +207,7 @@ describe('DispatchQueuePublisher', () => {
         responses[2]!.resolve(successfulBatchResponse(send.mock.calls[2]![0] as SendMessageBatchCommand));
         responses[3]!.resolve(successfulBatchResponse(send.mock.calls[3]![0] as SendMessageBatchCommand));
 
-        await expect(publishPromise).resolves.toEqual({ enqueued: 4, failed: 0 });
+        await expect(publishPromise).resolves.toEqual({ enqueued: 4, failed: 0, failedActivityLogIds: [] });
     });
 
     it('retries failed entries once and reports remaining failures', async () => {
@@ -229,8 +229,11 @@ describe('DispatchQueuePublisher', () => {
         ];
         const { sqs, send } = makeSqsMock((_n, call) => responses[call]!);
         const publisher = new DispatchQueuePublisher({ sqs, queueUrl: 'http://q' });
-        const res = await publisher.publish([buildMessage(), buildMessage(), buildMessage()], 'account:1:env:2');
-        expect(res).toEqual({ enqueued: 2, failed: 1 });
+        const res = await publisher.publish(
+            [buildMessage(), buildMessage({ activityLogId: 'log-2' }), buildMessage({ activityLogId: 'log-3' })],
+            'account:1:env:2'
+        );
+        expect(res).toEqual({ enqueued: 2, failed: 1, failedActivityLogIds: ['log-3'] });
         expect(send.mock.calls).toHaveLength(2);
         expect(tracerMocks.span.setTag).toHaveBeenCalledWith('nango.enqueued', 2);
         expect(tracerMocks.span.setTag).toHaveBeenCalledWith('nango.failed', 1);
@@ -253,11 +256,34 @@ describe('DispatchQueuePublisher', () => {
         });
         const publisher = new DispatchQueuePublisher({ sqs, queueUrl: 'http://q' });
         const res = await publisher.publish([buildMessage()], 'account:1:env:2');
-        expect(res).toEqual({ enqueued: 1, failed: 0 });
+        expect(res).toEqual({ enqueued: 1, failed: 0, failedActivityLogIds: [] });
         expect(send.mock.calls).toHaveLength(2);
         expect(tracerMocks.span.setTag).toHaveBeenCalledWith('nango.retriedEntries', 1);
         expect(tracerMocks.span.setTag).toHaveBeenCalledWith('nango.retriedBatches', 1);
         expect(tracerMocks.span.setTag.mock.calls.filter(([tag]) => tag === 'error')).toHaveLength(0);
         expect(tracerMocks.activeSpan.setTag).toHaveBeenCalledWith('sqs.send.error', expect.any(Error));
+    });
+
+    it('reports malformed failed entry ids without crashing retries', async () => {
+        const { sqs } = makeSqsMock((_n, call) => {
+            if (call === 0) {
+                return {
+                    $metadata: {},
+                    Successful: [],
+                    Failed: [{ Id: 'bogus', SenderFault: false, Code: 'InternalError', Message: 'boom' }]
+                };
+            }
+
+            return {
+                $metadata: {},
+                Successful: [],
+                Failed: [{ Id: 'bogus', SenderFault: false, Code: 'InternalError', Message: 'still boom' }]
+            };
+        });
+        const publisher = new DispatchQueuePublisher({ sqs, queueUrl: 'http://q' });
+
+        const res = await publisher.publish([buildMessage()], 'account:1:env:2');
+
+        expect(res).toEqual({ enqueued: 0, failed: 1, failedActivityLogIds: [] });
     });
 });

--- a/packages/server/lib/webhook/internal-nango.ts
+++ b/packages/server/lib/webhook/internal-nango.ts
@@ -335,43 +335,16 @@ export class InternalNango {
                     };
                 } catch (err) {
                     if (logCtx) {
-                        const failedLogCtx = logCtx;
                         const formattedError = err instanceof NangoError ? err : new NangoError('webhook_failure', { error: errorToObject(err) });
 
-                        for (const operation of [
-                            async () => {
-                                await failedLogCtx.error('The webhook failed during queue preparation', {
-                                    error: err,
-                                    webhook,
-                                    connection: connection.connection_id,
-                                    integration: connection.provider_config_key
-                                });
-                            },
-                            async () => {
-                                await failedLogCtx.enrichOperation({ error: formattedError });
-                            },
-                            async () => {
-                                await failedLogCtx.failed();
-                            }
-                        ]) {
-                            try {
-                                await operation();
-                            } catch (logCtxErr) {
-                                report(logCtxErr, {
-                                    error: 'The webhook queue preparation failure could not be written to the log context',
-                                    activityLogId: failedLogCtx.id,
-                                    provider: this.integration.provider,
-                                    accountId: this.team.id,
-                                    environmentId: this.environment.id,
-                                    syncConfigId: syncConfig.id,
-                                    syncName: syncConfig.sync_name,
-                                    webhook,
-                                    connectionId: connection.id,
-                                    connection: connection.connection_id,
-                                    integration: connection.provider_config_key
-                                });
-                            }
-                        }
+                        await logCtx.error('The webhook failed during queue preparation', {
+                            error: err,
+                            webhook,
+                            connection: connection.connection_id,
+                            integration: connection.provider_config_key
+                        });
+                        await logCtx.enrichOperation({ error: formattedError });
+                        await logCtx.failed();
                     }
 
                     return {

--- a/packages/server/lib/webhook/internal-nango.ts
+++ b/packages/server/lib/webhook/internal-nango.ts
@@ -207,42 +207,48 @@ export class InternalNango {
         webhookHeaderValue: string | undefined;
     }): Promise<void> {
         const orchestrator = getOrchestrator();
+        let scheduledCount = 0;
 
-        for (const syncConfig of syncConfigsWithWebhooks) {
-            const { webhook_subscriptions } = syncConfig;
-            if (!webhook_subscriptions) {
-                continue;
-            }
-
-            let triggered = false;
-
-            for (const webhook of webhook_subscriptions) {
-                if (triggered) {
-                    break;
+        try {
+            for (const syncConfig of syncConfigsWithWebhooks) {
+                const { webhook_subscriptions } = syncConfig;
+                if (!webhook_subscriptions) {
+                    continue;
                 }
 
-                if (type === webhook || webhookHeaderValue === webhook || webhook === '*') {
-                    for (const connection of connections) {
-                        await orchestrator.triggerWebhook({
-                            account: this.team,
-                            environment: this.environment,
-                            integration: this.integration as Config,
-                            connection,
-                            webhookName: webhook,
-                            syncConfig,
-                            input: body,
-                            maxConcurrency: envs.WEBHOOK_ENVIRONMENT_MAX_CONCURRENCY,
-                            logContextGetter: this.logContextGetter
-                        });
-                    }
+                let triggered = false;
 
-                    triggered = true;
-                    if (webhook === '*') {
-                        // Only trigger once since it will match all webhooks
+                for (const webhook of webhook_subscriptions) {
+                    if (triggered) {
                         break;
                     }
+
+                    if (type === webhook || webhookHeaderValue === webhook || webhook === '*') {
+                        for (const connection of connections) {
+                            await orchestrator.triggerWebhook({
+                                account: this.team,
+                                environment: this.environment,
+                                integration: this.integration as Config,
+                                connection,
+                                webhookName: webhook,
+                                syncConfig,
+                                input: body,
+                                maxConcurrency: envs.WEBHOOK_ENVIRONMENT_MAX_CONCURRENCY,
+                                logContextGetter: this.logContextGetter
+                            });
+                            scheduledCount += 1;
+                        }
+
+                        triggered = true;
+                        if (webhook === '*') {
+                            // Only trigger once since it will match all webhooks
+                            break;
+                        }
+                    }
                 }
             }
+        } finally {
+            metrics.increment(metrics.Types.WEBHOOK_DIRECT_TRIGGER_SUCCESS, scheduledCount, { provider: this.integration.provider });
         }
     }
 

--- a/packages/server/lib/webhook/internal-nango.ts
+++ b/packages/server/lib/webhook/internal-nango.ts
@@ -1,13 +1,75 @@
+import { createHash } from 'node:crypto';
+
 import get from 'lodash-es/get.js';
 
-import { connectionService, getSyncConfigsByConfigIdForWebhook } from '@nangohq/shared';
+import { OtlpSpan } from '@nangohq/logs';
+import { NangoError, connectionService, getSyncConfigsByConfigIdForWebhook } from '@nangohq/shared';
+import { errorToObject, metrics, report } from '@nangohq/utils';
 
 import { envs } from '../env.js';
+import { runWithConcurrencyLimit } from './runWithConcurrencyLimit.js';
 import { getOrchestrator } from '../utils/utils.js';
+import { dispatchQueuePublisher } from './dispatch-queue/client.js';
 
+import type { DispatchQueuePublisher } from './dispatch-queue/publisher.js';
 import type { LogContextGetter } from '@nangohq/logs';
 import type { Config } from '@nangohq/shared';
-import type { ConnectionInternal, DBConnectionDecrypted, DBEnvironment, DBIntegrationDecrypted, DBPlan, DBTeam, Metadata } from '@nangohq/types';
+import type { ConnectionInternal, DBConnectionDecrypted, DBEnvironment, DBIntegrationDecrypted, DBPlan, DBSyncConfig, DBTeam, Metadata } from '@nangohq/types';
+
+const LARGE_FANOUT_THRESHOLD = 200;
+const LOG_CONTEXT_CREATE_CONCURRENCY = 25;
+
+interface MatchedExecution {
+    syncConfig: DBSyncConfig;
+    webhook: string;
+    connection: DBConnectionDecrypted | ConnectionInternal;
+}
+
+interface QueuedExecution {
+    kind: 'queued';
+    logCtx: Awaited<ReturnType<LogContextGetter['create']>>;
+    message: {
+        version: 1;
+        kind: 'webhook';
+        taskName: string;
+        createdAt: string;
+        accountId: number;
+        integrationId: number;
+        provider: string;
+        parentSyncName: string;
+        activityLogId: string;
+        webhookName: string;
+        connection: {
+            id: number;
+            connection_id: string;
+            provider_config_key: string;
+            environment_id: number;
+        };
+        payload: Record<string, any>;
+    };
+}
+
+interface FailedQueuedExecution extends MatchedExecution {
+    kind: 'failed';
+    error: unknown;
+}
+
+function computeTaskName({
+    environmentId,
+    providerConfigKey,
+    parentSyncName,
+    connectionId,
+    activityLogId
+}: {
+    environmentId: number;
+    providerConfigKey: string;
+    parentSyncName: string;
+    connectionId: number;
+    activityLogId: string;
+}): string {
+    const hash = createHash('sha256').update(`${environmentId}:${providerConfigKey}:${parentSyncName}:${connectionId}:${activityLogId}`).digest('hex');
+    return `webhook:env:${environmentId}:connection:${connectionId}:${hash.slice(0, 32)}`;
+}
 
 export class InternalNango {
     readonly team: DBTeam;
@@ -108,11 +170,46 @@ export class InternalNango {
         // use webhookTypeValue if provided (direct value from headers), otherwise extract from body
         const type = webhookTypeValue || (webhookType ? get(body, webhookType) : undefined);
 
+        const publisher = envs.WEBHOOK_INGRESS_USE_DISPATCH_QUEUE ? dispatchQueuePublisher : null;
+
+        if (publisher) {
+            await this.dispatchViaQueue({
+                publisher,
+                connections,
+                syncConfigsWithWebhooks,
+                body,
+                type,
+                webhookHeaderValue
+            });
+        } else {
+            await this.dispatchViaOrchestrator({ connections, syncConfigsWithWebhooks, body, type, webhookHeaderValue });
+        }
+
+        const connectionMetadata = connections.reduce<Record<string, Metadata | null>>((acc, connection) => {
+            acc[connection.connection_id] = 'metadata' in connection ? connection.metadata : null;
+            return acc;
+        }, {});
+
+        return { connectionIds: connections.map((connection) => connection.connection_id), connectionMetadata };
+    }
+
+    private async dispatchViaOrchestrator({
+        connections,
+        syncConfigsWithWebhooks,
+        body,
+        type,
+        webhookHeaderValue
+    }: {
+        connections: (DBConnectionDecrypted | ConnectionInternal)[];
+        syncConfigsWithWebhooks: DBSyncConfig[];
+        body: Record<string, any>;
+        type: string | undefined;
+        webhookHeaderValue: string | undefined;
+    }): Promise<void> {
         const orchestrator = getOrchestrator();
 
         for (const syncConfig of syncConfigsWithWebhooks) {
             const { webhook_subscriptions } = syncConfig;
-
             if (!webhook_subscriptions) {
                 continue;
             }
@@ -140,7 +237,6 @@ export class InternalNango {
                     }
 
                     triggered = true;
-
                     if (webhook === '*') {
                         // Only trigger once since it will match all webhooks
                         break;
@@ -148,12 +244,215 @@ export class InternalNango {
                 }
             }
         }
+    }
 
-        const connectionMetadata = connections.reduce<Record<string, Metadata | null>>((acc, connection) => {
-            acc[connection.connection_id] = 'metadata' in connection ? connection.metadata : null;
-            return acc;
-        }, {});
+    private async dispatchViaQueue({
+        publisher,
+        connections,
+        syncConfigsWithWebhooks,
+        body,
+        type,
+        webhookHeaderValue
+    }: {
+        publisher: DispatchQueuePublisher;
+        connections: (DBConnectionDecrypted | ConnectionInternal)[];
+        syncConfigsWithWebhooks: DBSyncConfig[];
+        body: Record<string, any>;
+        type: string | undefined;
+        webhookHeaderValue: string | undefined;
+    }): Promise<void> {
+        const matchedExecutions: MatchedExecution[] = [];
 
-        return { connectionIds: connections.map((connection) => connection.connection_id), connectionMetadata };
+        for (const syncConfig of syncConfigsWithWebhooks) {
+            const { webhook_subscriptions } = syncConfig;
+            if (!webhook_subscriptions) continue;
+
+            let matched = false;
+            for (const webhook of webhook_subscriptions) {
+                if (matched) break;
+
+                if (type === webhook || webhookHeaderValue === webhook || webhook === '*') {
+                    for (const connection of connections) {
+                        matchedExecutions.push({ syncConfig, webhook, connection });
+                    }
+
+                    matched = true;
+                }
+            }
+        }
+
+        if (matchedExecutions.length === 0) return;
+
+        const queuePreparationResults = await runWithConcurrencyLimit(
+            matchedExecutions,
+            LOG_CONTEXT_CREATE_CONCURRENCY,
+            async ({ syncConfig, webhook, connection }) => {
+                let logCtx: Awaited<ReturnType<LogContextGetter['create']>> | null = null;
+
+                try {
+                    // Create a log context per (syncConfig × connection × webhook) triple before publishing
+                    // so the runner picks up the same activityLogId it would have in the direct-schedule path.
+                    logCtx = await this.logContextGetter.create(
+                        { operation: { type: 'webhook', action: 'incoming' }, expiresAt: new Date(Date.now() + 15 * 60 * 1000).toISOString() },
+                        {
+                            account: this.team,
+                            environment: this.environment,
+                            integration: { id: this.integration.id!, name: this.integration.unique_key, provider: this.integration.provider },
+                            connection: { id: connection.id, name: connection.connection_id },
+                            syncConfig: { id: syncConfig.id, name: syncConfig.sync_name }
+                        }
+                    );
+                    logCtx.attachSpan(new OtlpSpan(logCtx.operation));
+
+                    return {
+                        kind: 'queued' as const,
+                        logCtx,
+                        message: {
+                            version: 1 as const,
+                            kind: 'webhook' as const,
+                            taskName: computeTaskName({
+                                environmentId: this.environment.id,
+                                providerConfigKey: this.integration.unique_key,
+                                parentSyncName: syncConfig.sync_name,
+                                connectionId: connection.id,
+                                activityLogId: logCtx.id
+                            }),
+                            createdAt: new Date().toISOString(),
+                            accountId: this.team.id,
+                            integrationId: this.integration.id!,
+                            provider: this.integration.provider,
+                            parentSyncName: syncConfig.sync_name,
+                            activityLogId: logCtx.id,
+                            webhookName: webhook,
+                            connection: {
+                                id: connection.id,
+                                connection_id: connection.connection_id,
+                                provider_config_key: connection.provider_config_key,
+                                environment_id: connection.environment_id
+                            },
+                            payload: body
+                        }
+                    };
+                } catch (err) {
+                    if (logCtx) {
+                        const failedLogCtx = logCtx;
+                        const formattedError = err instanceof NangoError ? err : new NangoError('webhook_failure', { error: errorToObject(err) });
+
+                        for (const operation of [
+                            async () => {
+                                await failedLogCtx.error('The webhook failed during queue preparation', {
+                                    error: err,
+                                    webhook,
+                                    connection: connection.connection_id,
+                                    integration: connection.provider_config_key
+                                });
+                            },
+                            async () => {
+                                await failedLogCtx.enrichOperation({ error: formattedError });
+                            },
+                            async () => {
+                                await failedLogCtx.failed();
+                            }
+                        ]) {
+                            try {
+                                await operation();
+                            } catch (logCtxErr) {
+                                report(logCtxErr, {
+                                    error: 'The webhook queue preparation failure could not be written to the log context',
+                                    activityLogId: failedLogCtx.id,
+                                    provider: this.integration.provider,
+                                    accountId: this.team.id,
+                                    environmentId: this.environment.id,
+                                    syncConfigId: syncConfig.id,
+                                    syncName: syncConfig.sync_name,
+                                    webhook,
+                                    connectionId: connection.id,
+                                    connection: connection.connection_id,
+                                    integration: connection.provider_config_key
+                                });
+                            }
+                        }
+                    }
+
+                    return {
+                        kind: 'failed' as const,
+                        error: err,
+                        syncConfig,
+                        webhook,
+                        connection
+                    };
+                }
+            }
+        );
+
+        const queuedExecutions = queuePreparationResults.filter((result): result is QueuedExecution => result.kind === 'queued');
+        const failedQueuedExecutions = queuePreparationResults.filter((result): result is FailedQueuedExecution => result.kind === 'failed');
+
+        for (const { error, syncConfig, webhook, connection } of failedQueuedExecutions) {
+            report(error, {
+                error: 'The webhook could not be prepared for queue dispatch',
+                provider: this.integration.provider,
+                accountId: this.team.id,
+                environmentId: this.environment.id,
+                syncConfigId: syncConfig.id,
+                syncName: syncConfig.sync_name,
+                webhook,
+                connectionId: connection.id,
+                connection: connection.connection_id,
+                integration: connection.provider_config_key
+            });
+        }
+
+        if (queuedExecutions.length === 0) {
+            return;
+        }
+
+        const messages = queuedExecutions.map(({ message }) => message);
+
+        if (matchedExecutions.length > LARGE_FANOUT_THRESHOLD) {
+            metrics.increment(metrics.Types.WEBHOOK_DISPATCH_LARGE_FANOUT, 1, {
+                provider: this.integration.provider,
+                accountId: this.team.id,
+                environmentId: this.environment.id
+            });
+        }
+
+        const messageGroupId = `account:${this.team.id}:env:${this.environment.id}`;
+        const publishResult = await publisher.publish(messages, messageGroupId);
+        const failedActivityLogIds = new Set(publishResult.failedActivityLogIds);
+        const unmappedFailureCount = publishResult.failed - failedActivityLogIds.size;
+
+        for (const { message, logCtx } of queuedExecutions) {
+            if (!failedActivityLogIds.has(message.activityLogId) && unmappedFailureCount === 0) {
+                void logCtx.info('The webhook was successfully queued for execution', {
+                    action: message.webhookName,
+                    connection: message.connection.connection_id,
+                    integration: message.connection.provider_config_key
+                });
+                continue;
+            }
+
+            const error = new NangoError('webhook_failure', {
+                error: 'The webhook could not be queued for execution',
+                taskName: message.taskName
+            });
+
+            await logCtx.error('The webhook failed to queue for execution', {
+                error,
+                webhook: message.webhookName,
+                connection: message.connection.connection_id,
+                integration: message.connection.provider_config_key
+            });
+            await logCtx.enrichOperation({ error });
+            await logCtx.failed();
+        }
+
+        if (unmappedFailureCount > 0) {
+            report(new Error('webhook_dispatch_fanout_unmapped_failures'), {
+                unmappedFailureCount,
+                accountId: this.team.id,
+                environmentId: this.environment.id
+            });
+        }
     }
 }

--- a/packages/server/lib/webhook/internal-nango.unit.test.ts
+++ b/packages/server/lib/webhook/internal-nango.unit.test.ts
@@ -1,0 +1,300 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+const mocks = vi.hoisted(() => {
+    return {
+        envs: {
+            WEBHOOK_INGRESS_USE_DISPATCH_QUEUE: true,
+            WEBHOOK_ENVIRONMENT_MAX_CONCURRENCY: 7
+        },
+        dispatchQueueClient: { dispatchQueuePublisher: null as any },
+        triggerWebhook: vi.fn(),
+        report: vi.fn(),
+        getConnectionsByEnvironmentAndConfig: vi.fn(),
+        getSyncConfigsByConfigIdForWebhook: vi.fn()
+    };
+});
+
+vi.mock('../env.js', () => ({ envs: mocks.envs }));
+vi.mock('./dispatch-queue/client.js', () => mocks.dispatchQueueClient);
+vi.mock('../utils/utils.js', () => ({ getOrchestrator: () => ({ triggerWebhook: mocks.triggerWebhook }) }));
+vi.mock('@nangohq/utils', async (importOriginal) => {
+    const actual = await importOriginal();
+
+    return {
+        ...(actual as object),
+        report: mocks.report
+    };
+});
+vi.mock('@nangohq/shared', () => {
+    class NangoError extends Error {
+        public payload: Record<string, unknown>;
+
+        constructor(type: string, payload: Record<string, unknown>) {
+            super(type);
+            this.name = type;
+            this.payload = payload;
+        }
+    }
+
+    return {
+        NangoError,
+        connectionService: {
+            getConnectionsByEnvironmentAndConfig: mocks.getConnectionsByEnvironmentAndConfig
+        },
+        getSyncConfigsByConfigIdForWebhook: mocks.getSyncConfigsByConfigIdForWebhook
+    };
+});
+
+import { InternalNango } from './internal-nango.js';
+
+function createLogCtx(id: string) {
+    return {
+        id,
+        operation: { id },
+        attachSpan: vi.fn(),
+        info: vi.fn().mockResolvedValue(true),
+        error: vi.fn().mockResolvedValue(true),
+        enrichOperation: vi.fn().mockResolvedValue(undefined),
+        failed: vi.fn().mockResolvedValue(undefined)
+    };
+}
+
+function deferred<T>() {
+    let resolve!: (value: T | PromiseLike<T>) => void;
+    let reject!: (reason?: unknown) => void;
+    const promise = new Promise<T>((res, rej) => {
+        resolve = res;
+        reject = rej;
+    });
+    return { promise, resolve, reject };
+}
+
+function makeInternalNango(logContexts: ReturnType<typeof createLogCtx>[], logContextGetterOverride?: any) {
+    const logContextGetter =
+        logContextGetterOverride ??
+        ({
+            create: vi.fn().mockImplementation(() => {
+                const next = logContexts.shift();
+                if (!next) {
+                    throw new Error('Missing log context');
+                }
+                return next;
+            })
+        } as any);
+
+    return {
+        nango: new InternalNango({
+            team: { id: 1 } as any,
+            environment: { id: 2 } as any,
+            plan: undefined,
+            integration: { id: 3, unique_key: 'github-dev', provider: 'github' } as any,
+            logContextGetter
+        }),
+        logContextGetter
+    };
+}
+
+describe('InternalNango queue dispatch', () => {
+    beforeEach(() => {
+        vi.clearAllMocks();
+        mocks.envs.WEBHOOK_INGRESS_USE_DISPATCH_QUEUE = true;
+        mocks.dispatchQueueClient.dispatchQueuePublisher = null;
+        mocks.getConnectionsByEnvironmentAndConfig.mockResolvedValue([
+            { id: 11, connection_id: 'conn-1', provider_config_key: 'github-dev', environment_id: 2, metadata: null },
+            { id: 12, connection_id: 'conn-2', provider_config_key: 'github-dev', environment_id: 2, metadata: null }
+        ]);
+        mocks.getSyncConfigsByConfigIdForWebhook.mockResolvedValue([{ id: 21, sync_name: 'sync-1', webhook_subscriptions: ['push'] }]);
+        mocks.triggerWebhook.mockResolvedValue(undefined);
+    });
+
+    it('logs queued successes and marks failed publishes as failed operations', async () => {
+        const publisher = {
+            publish: vi.fn().mockResolvedValue({ enqueued: 1, failed: 1, failedActivityLogIds: ['log-2'] })
+        };
+        mocks.dispatchQueueClient.dispatchQueuePublisher = publisher;
+
+        const logCtx1 = createLogCtx('log-1');
+        const logCtx2 = createLogCtx('log-2');
+        const { nango } = makeInternalNango([logCtx1, logCtx2]);
+
+        const result = await nango.executeScriptForWebhooks({ body: { event: 'x' }, webhookTypeValue: 'push' });
+
+        expect(result.connectionIds).toEqual(['conn-1', 'conn-2']);
+        expect(publisher.publish).toHaveBeenCalledTimes(1);
+        expect(logCtx1.info).toHaveBeenCalledWith('The webhook was successfully queued for execution', {
+            action: 'push',
+            connection: 'conn-1',
+            integration: 'github-dev'
+        });
+        expect(logCtx2.error).toHaveBeenCalledWith('The webhook failed to queue for execution', {
+            error: expect.any(Error),
+            webhook: 'push',
+            connection: 'conn-2',
+            integration: 'github-dev'
+        });
+        expect(logCtx2.enrichOperation).toHaveBeenCalledWith({ error: expect.any(Error) });
+        expect(logCtx2.failed).toHaveBeenCalledOnce();
+    });
+
+    it('falls back to direct orchestrator dispatch when the feature flag is off', async () => {
+        mocks.envs.WEBHOOK_INGRESS_USE_DISPATCH_QUEUE = false;
+        const publisher = { publish: vi.fn() };
+        mocks.dispatchQueueClient.dispatchQueuePublisher = publisher;
+
+        const { nango, logContextGetter } = makeInternalNango([]);
+
+        const result = await nango.executeScriptForWebhooks({ body: { event: 'x' }, webhookTypeValue: 'push' });
+
+        expect(result.connectionIds).toEqual(['conn-1', 'conn-2']);
+        expect(mocks.triggerWebhook).toHaveBeenCalledTimes(2);
+        expect(logContextGetter.create).not.toHaveBeenCalled();
+        expect(publisher.publish).not.toHaveBeenCalled();
+    });
+
+    it('creates log contexts concurrently before publishing queue messages', async () => {
+        const publisher = {
+            publish: vi.fn().mockResolvedValue({ enqueued: 2, failed: 0, failedActivityLogIds: [] })
+        };
+        mocks.dispatchQueueClient.dispatchQueuePublisher = publisher;
+
+        const blockers = [deferred<void>(), deferred<void>()];
+        const contexts = [createLogCtx('log-1'), createLogCtx('log-2')];
+        let createIndex = 0;
+        let inFlight = 0;
+        let maxInFlight = 0;
+        const logContextGetter = {
+            create: vi.fn().mockImplementation(async () => {
+                const index = createIndex++;
+                inFlight += 1;
+                maxInFlight = Math.max(maxInFlight, inFlight);
+                await blockers[index]!.promise;
+                inFlight -= 1;
+                return contexts[index]!;
+            })
+        } as any;
+        const { nango } = makeInternalNango([], logContextGetter);
+
+        const execution = nango.executeScriptForWebhooks({ body: { event: 'x' }, webhookTypeValue: 'push' });
+
+        await vi.waitFor(() => {
+            expect(logContextGetter.create).toHaveBeenCalledTimes(2);
+        });
+        expect(maxInFlight).toBe(2);
+
+        blockers[0]!.resolve();
+        blockers[1]!.resolve();
+
+        const result = await execution;
+
+        expect(result.connectionIds).toEqual(['conn-1', 'conn-2']);
+        expect(publisher.publish).toHaveBeenCalledOnce();
+    });
+
+    it('publishes successful executions even when one log context creation fails', async () => {
+        const publisher = {
+            publish: vi.fn().mockResolvedValue({ enqueued: 1, failed: 0, failedActivityLogIds: [] })
+        };
+        mocks.dispatchQueueClient.dispatchQueuePublisher = publisher;
+
+        const logCtx = createLogCtx('log-2');
+        const logContextGetter = {
+            create: vi.fn().mockRejectedValueOnce(new Error('transient db failure')).mockResolvedValueOnce(logCtx)
+        } as any;
+        const { nango } = makeInternalNango([], logContextGetter);
+
+        const result = await nango.executeScriptForWebhooks({ body: { event: 'x' }, webhookTypeValue: 'push' });
+
+        expect(result.connectionIds).toEqual(['conn-1', 'conn-2']);
+        expect(publisher.publish).toHaveBeenCalledTimes(1);
+        expect(publisher.publish).toHaveBeenCalledWith(
+            [
+                expect.objectContaining({
+                    activityLogId: 'log-2',
+                    webhookName: 'push',
+                    connection: expect.objectContaining({ connection_id: 'conn-2' })
+                })
+            ],
+            'account:1:env:2'
+        );
+        expect(logCtx.info).toHaveBeenCalledWith('The webhook was successfully queued for execution', {
+            action: 'push',
+            connection: 'conn-2',
+            integration: 'github-dev'
+        });
+        expect(mocks.report).toHaveBeenCalledWith(expect.any(Error), {
+            error: 'The webhook could not be prepared for queue dispatch',
+            provider: 'github',
+            accountId: 1,
+            environmentId: 2,
+            syncConfigId: 21,
+            syncName: 'sync-1',
+            webhook: 'push',
+            connectionId: 11,
+            connection: 'conn-1',
+            integration: 'github-dev'
+        });
+    });
+
+    it('fails the log context when queue preparation fails after creation', async () => {
+        const publisher = {
+            publish: vi.fn().mockResolvedValue({ enqueued: 1, failed: 0, failedActivityLogIds: [] })
+        };
+        mocks.dispatchQueueClient.dispatchQueuePublisher = publisher;
+
+        const failedLogCtx = createLogCtx('log-1');
+        failedLogCtx.attachSpan.mockImplementation(() => {
+            throw new Error('attach span failed');
+        });
+        const successfulLogCtx = createLogCtx('log-2');
+        const { nango } = makeInternalNango([failedLogCtx, successfulLogCtx]);
+
+        const result = await nango.executeScriptForWebhooks({ body: { event: 'x' }, webhookTypeValue: 'push' });
+
+        expect(result.connectionIds).toEqual(['conn-1', 'conn-2']);
+        expect(publisher.publish).toHaveBeenCalledWith(
+            [
+                expect.objectContaining({
+                    activityLogId: 'log-2',
+                    connection: expect.objectContaining({ connection_id: 'conn-2' })
+                })
+            ],
+            'account:1:env:2'
+        );
+        expect(failedLogCtx.error).toHaveBeenCalledWith('The webhook failed during queue preparation', {
+            error: expect.any(Error),
+            webhook: 'push',
+            connection: 'conn-1',
+            integration: 'github-dev'
+        });
+        expect(failedLogCtx.enrichOperation).toHaveBeenCalledWith({ error: expect.any(Error) });
+        expect(failedLogCtx.failed).toHaveBeenCalledOnce();
+        expect(successfulLogCtx.info).toHaveBeenCalledWith('The webhook was successfully queued for execution', {
+            action: 'push',
+            connection: 'conn-2',
+            integration: 'github-dev'
+        });
+    });
+
+    it('marks all executions as failed and reports when publish has unmapped failures', async () => {
+        const publisher = {
+            publish: vi.fn().mockResolvedValue({ enqueued: 0, failed: 2, failedActivityLogIds: [] })
+        };
+        mocks.dispatchQueueClient.dispatchQueuePublisher = publisher;
+
+        const logCtx1 = createLogCtx('log-1');
+        const logCtx2 = createLogCtx('log-2');
+        const { nango } = makeInternalNango([logCtx1, logCtx2]);
+
+        await nango.executeScriptForWebhooks({ body: { event: 'x' }, webhookTypeValue: 'push' });
+
+        expect(logCtx1.info).not.toHaveBeenCalled();
+        expect(logCtx2.info).not.toHaveBeenCalled();
+        expect(logCtx1.failed).toHaveBeenCalledOnce();
+        expect(logCtx2.failed).toHaveBeenCalledOnce();
+        expect(mocks.report).toHaveBeenCalledWith(expect.any(Error), {
+            unmappedFailureCount: 2,
+            accountId: 1,
+            environmentId: 2
+        });
+    });
+});

--- a/packages/server/lib/webhook/internal-nango.unit.test.ts
+++ b/packages/server/lib/webhook/internal-nango.unit.test.ts
@@ -8,6 +8,7 @@ const mocks = vi.hoisted(() => {
         },
         dispatchQueueClient: { dispatchQueuePublisher: null as any },
         triggerWebhook: vi.fn(),
+        increment: vi.fn(),
         report: vi.fn(),
         getConnectionsByEnvironmentAndConfig: vi.fn(),
         getSyncConfigsByConfigIdForWebhook: vi.fn()
@@ -22,6 +23,14 @@ vi.mock('@nangohq/utils', async (importOriginal) => {
 
     return {
         ...(actual as object),
+        metrics: {
+            ...(actual as any).metrics,
+            Types: {
+                WEBHOOK_DIRECT_TRIGGER_SUCCESS: 'nango.webhook.direct_trigger.success',
+                WEBHOOK_DISPATCH_LARGE_FANOUT: 'nango.webhook.dispatch_queue.large_fanout'
+            },
+            increment: mocks.increment
+        },
         report: mocks.report
     };
 });
@@ -97,6 +106,7 @@ function makeInternalNango(logContexts: ReturnType<typeof createLogCtx>[], logCo
 describe('InternalNango queue dispatch', () => {
     beforeEach(() => {
         vi.clearAllMocks();
+        mocks.increment.mockClear();
         mocks.envs.WEBHOOK_INGRESS_USE_DISPATCH_QUEUE = true;
         mocks.dispatchQueueClient.dispatchQueuePublisher = null;
         mocks.getConnectionsByEnvironmentAndConfig.mockResolvedValue([
@@ -149,6 +159,7 @@ describe('InternalNango queue dispatch', () => {
         expect(mocks.triggerWebhook).toHaveBeenCalledTimes(2);
         expect(logContextGetter.create).not.toHaveBeenCalled();
         expect(publisher.publish).not.toHaveBeenCalled();
+        expect(mocks.increment).toHaveBeenCalledWith('nango.webhook.direct_trigger.success', 2, { provider: 'github' });
     });
 
     it('creates log contexts concurrently before publishing queue messages', async () => {

--- a/packages/utils/lib/telemetry/metrics.ts
+++ b/packages/utils/lib/telemetry/metrics.ts
@@ -67,6 +67,7 @@ export enum Types {
     WEBHOOK_ASYNC_ACTION_SUCCESS = 'nango.webhook.async_action.success',
     WEBHOOK_ASYNC_ACTION_FAILED = 'nango.webhook.async_action.failed',
     WEBHOOK_INCOMING_PAYLOAD_SIZE_BYTES = 'nango.webhook.incoming.payloadSizeBytes',
+    WEBHOOK_DIRECT_TRIGGER_SUCCESS = 'nango.webhook.direct_trigger.success',
 
     WEBHOOK_DISPATCH_PUBLISH_SUCCESS = 'nango.webhook.dispatch_queue.publish.success',
     WEBHOOK_DISPATCH_PUBLISH_FAILURE = 'nango.webhook.dispatch_queue.publish.failure',


### PR DESCRIPTION
Behind `WEBHOOK_INGRESS_USE_DISPATCH_QUEUE` (default off), routes `InternalNango.executeScriptForWebhooks()` through the SQS dispatch queue instead of calling `orchestrator.triggerWebhook()` directly. When the flag is off, `triggerWebhook()` remains the fallback path.

When enabled, each (syncConfig × subscription × connection) triple becomes one `WebhookDispatchMessage`:
- `MessageGroupId` = `account:<accountId>:env:<environmentId>` for fair queueing
- Messages are batched into `SendMessageBatch` calls (up to 10 entries or 1 MiB per batch); large fan-out issues multiple batches in parallel

`connectionIds` are still returned so `forwardWebhook` keeps working.

Large fan-out (>200 messages) emits `WEBHOOK_DISPATCH_LARGE_FANOUT` for tracking.

A singleton `DispatchQueuePublisher` is cached in `dispatch-queue/client.ts` and gated on `NANGO_TASK_DISPATCH_QUEUE_URL` being set.