### PR TITLE
fix(sync): initiate syncs for OAuth1

### DIFF
--- a/packages/server/lib/controllers/oauth.controller.ts
+++ b/packages/server/lib/controllers/oauth.controller.ts
@@ -2239,8 +2239,7 @@ class OAuthController {
                     connectionId: updatedConnection.connection.id,
                     connectionName: updatedConnection.connection.connection_id
                 });
-                // syncs not support for oauth1
-                const initiateSync = false;
+                const initiateSync = true;
                 const runPostConnectionScript = true;
                 void connectionCreatedHook(
                     {


### PR DESCRIPTION
## Describe the problem and your solution

- Enable initiation of syncs for OAuth 1. This is now supported after the following [changes](https://github.com/NangoHQ/nango/pull/5109/changes).


<!-- Issue ticket number and link (if applicable) -->

<!-- Testing instructions (skip if just adding/editing providers) -->

