### PR TITLE
fix(webhooks): bypass SQS for oversize dispatch payloads 4/5

### DIFF
--- a/packages/server/lib/webhook/dispatch-queue/publisher.ts
+++ b/packages/server/lib/webhook/dispatch-queue/publisher.ts
@@ -10,6 +10,7 @@ import type { WebhookDispatchMessage } from '@nangohq/types';
 
 const SQS_BATCH_MAX_ENTRIES = 10;
 const DEFAULT_PUBLISH_CONCURRENCY = 10;
+export const SQS_BATCH_MAX_BYTES = 1_048_576;
 
 export interface DispatchQueuePublisherProps {
     sqs: SQSClient;
@@ -24,6 +25,11 @@ export interface PublishResult {
     enqueued: number;
     failed: number;
     failedActivityLogIds: string[];
+}
+
+export interface PreparedDispatchMessage {
+    message: WebhookDispatchMessage;
+    byteSize: number;
 }
 
 interface BatchPublishResult extends PublishResult {
@@ -60,13 +66,13 @@ export class DispatchQueuePublisher {
      * caller can treat them as a metric/trace concern, not an HTTP 500 (provider retries
      * are worse).
      */
-    async publish(messages: WebhookDispatchMessage[], messageGroupId: string): Promise<PublishResult> {
+    async publish(messages: PreparedDispatchMessage[], messageGroupId: string): Promise<PublishResult> {
         if (messages.length === 0) {
             return { enqueued: 0, failed: 0, failedActivityLogIds: [] };
         }
 
         const activeSpan = tracer.scope().active();
-        const firstMessage = messages[0]!;
+        const firstMessage = messages[0]!.message;
         const batches = chunk(messages, this.batchSize);
         const span = tracer.startSpan('webhook.dispatch.publish', {
             ...(activeSpan ? { childOf: activeSpan } : {}),
@@ -121,7 +127,7 @@ export class DispatchQueuePublisher {
         });
     }
 
-    private async sendBatch(batch: WebhookDispatchMessage[], messageGroupId: string): Promise<BatchPublishResult> {
+    private async sendBatch(batch: PreparedDispatchMessage[], messageGroupId: string): Promise<BatchPublishResult> {
         const entries = batch.map((message, idx) => toEntry(message, idx, messageGroupId));
 
         const first = await this.trySend(entries);
@@ -158,7 +164,7 @@ export class DispatchQueuePublisher {
                     return [];
                 }
 
-                const activityLogId = batch[index]?.activityLogId;
+                const activityLogId = batch[index]?.message.activityLogId;
                 return activityLogId ? [activityLogId] : [];
             }),
             retriedEntries: failedIndices.length
@@ -178,10 +184,10 @@ export class DispatchQueuePublisher {
     }
 }
 
-function toEntry(message: WebhookDispatchMessage, index: number, messageGroupId: string): SendMessageBatchRequestEntry {
+function toEntry(message: PreparedDispatchMessage, index: number, messageGroupId: string): SendMessageBatchRequestEntry {
     return {
         Id: indexToEntryId(index),
-        MessageBody: JSON.stringify(message),
+        MessageBody: JSON.stringify(message.message),
         MessageGroupId: messageGroupId
     };
 }
@@ -199,10 +205,28 @@ function entryIdToIndex(id: string): number | null {
     return Number.isNaN(index) ? null : index;
 }
 
-function chunk<T>(items: T[], size: number): T[][] {
-    const chunks: T[][] = [];
-    for (let i = 0; i < items.length; i += size) {
-        chunks.push(items.slice(i, i + size));
+function chunk(items: PreparedDispatchMessage[], size: number): PreparedDispatchMessage[][] {
+    const chunks: PreparedDispatchMessage[][] = [];
+    let currentChunk: PreparedDispatchMessage[] = [];
+    let currentChunkBytes = 0;
+
+    for (const item of items) {
+        const exceedsBatchSize = currentChunk.length >= size;
+        const exceedsBatchBytes = currentChunkBytes + item.byteSize > SQS_BATCH_MAX_BYTES;
+
+        if (currentChunk.length > 0 && (exceedsBatchSize || exceedsBatchBytes)) {
+            chunks.push(currentChunk);
+            currentChunk = [];
+            currentChunkBytes = 0;
+        }
+
+        currentChunk.push(item);
+        currentChunkBytes += item.byteSize;
     }
+
+    if (currentChunk.length > 0) {
+        chunks.push(currentChunk);
+    }
+
     return chunks;
 }

--- a/packages/server/lib/webhook/dispatch-queue/publisher.unit.test.ts
+++ b/packages/server/lib/webhook/dispatch-queue/publisher.unit.test.ts
@@ -27,6 +27,10 @@ const tracerMocks = vi.hoisted(() => {
     };
 });
 
+const utilsMocks = vi.hoisted(() => ({
+    report: vi.fn()
+}));
+
 vi.mock('dd-trace', () => {
     return {
         default: {
@@ -37,8 +41,29 @@ vi.mock('dd-trace', () => {
     };
 });
 
+vi.mock('@nangohq/utils', async (importOriginal) => {
+    const actual = await importOriginal();
+
+    if (!actual || typeof actual !== 'object') {
+        throw new Error('Invalid @nangohq/utils mock');
+    }
+
+    return {
+        ...actual,
+        report: utilsMocks.report,
+        metrics: {
+            Types: {
+                WEBHOOK_DISPATCH_PUBLISH_SUCCESS: 'nango.webhook.dispatch_queue.publish.success',
+                WEBHOOK_DISPATCH_PUBLISH_FAILURE: 'nango.webhook.dispatch_queue.publish.failure'
+            },
+            increment: tracerMocks.dogstatsd.increment
+        }
+    };
+});
+
 import { DispatchQueuePublisher } from './publisher.js';
 
+import type { PreparedDispatchMessage } from './publisher.js';
 import type { SQSClient, SendMessageBatchCommandOutput } from '@aws-sdk/client-sqs';
 import type { WebhookDispatchMessage } from '@nangohq/types';
 
@@ -57,6 +82,21 @@ function buildMessage(overrides: Partial<WebhookDispatchMessage> = {}): WebhookD
         connection: { id: 42, connection_id: 'conn-1', provider_config_key: 'github-dev', environment_id: 2 },
         payload: { hello: 'world' },
         ...overrides
+    };
+}
+
+function buildPreparedMessage({
+    messageOverrides,
+    byteSize
+}: {
+    messageOverrides?: Partial<WebhookDispatchMessage>;
+    byteSize?: number;
+} = {}): PreparedDispatchMessage {
+    const message = buildMessage(messageOverrides);
+
+    return {
+        message,
+        byteSize: byteSize ?? Buffer.byteLength(JSON.stringify(message), 'utf8')
     };
 }
 
@@ -95,6 +135,7 @@ function deferred<T>() {
 describe('DispatchQueuePublisher', () => {
     beforeEach(() => {
         vi.restoreAllMocks();
+        utilsMocks.report.mockClear();
         tracerMocks.active.mockClear();
         tracerMocks.activate.mockClear();
         tracerMocks.startSpan.mockClear();
@@ -130,7 +171,7 @@ describe('DispatchQueuePublisher', () => {
     it('chunks into batches of <=10 for a 25-message input', async () => {
         const { sqs, send } = makeSqsMock((cmd) => successfulBatchResponse(cmd));
         const publisher = new DispatchQueuePublisher({ sqs, queueUrl: 'http://q' });
-        const messages = Array.from({ length: 25 }, () => buildMessage());
+        const messages = Array.from({ length: 25 }, () => buildPreparedMessage());
         const res = await publisher.publish(messages, 'account:1:env:2');
         expect(res).toEqual({ enqueued: 25, failed: 0, failedActivityLogIds: [] });
         expect(send.mock.calls).toHaveLength(3);
@@ -161,15 +202,36 @@ describe('DispatchQueuePublisher', () => {
     it('sets MessageGroupId on every entry', async () => {
         const groupId = 'account:7:env:9';
         const seen: string[] = [];
+        const bodies: string[] = [];
         const { sqs } = makeSqsMock((cmd) => {
             for (const entry of cmd.input.Entries ?? []) {
                 if (entry.MessageGroupId) seen.push(entry.MessageGroupId);
+                if (entry.MessageBody) bodies.push(entry.MessageBody);
             }
             return successfulBatchResponse(cmd);
         });
         const publisher = new DispatchQueuePublisher({ sqs, queueUrl: 'http://q' });
-        await publisher.publish([buildMessage(), buildMessage()], groupId);
+        const first = buildPreparedMessage();
+        const second = buildPreparedMessage({ messageOverrides: { activityLogId: 'log-2' } });
+
+        await publisher.publish([first, second], groupId);
         expect(seen).toEqual([groupId, groupId]);
+        expect(bodies).toEqual([JSON.stringify(first.message), JSON.stringify(second.message)]);
+    });
+
+    it('splits batches when cumulative bytes exceed the SQS request limit', async () => {
+        const { sqs, send } = makeSqsMock((cmd) => successfulBatchResponse(cmd));
+        const publisher = new DispatchQueuePublisher({ sqs, queueUrl: 'http://q' });
+
+        const res = await publisher.publish(
+            [buildPreparedMessage({ byteSize: 600_000 }), buildPreparedMessage({ byteSize: 300_000 }), buildPreparedMessage({ byteSize: 300_000 })],
+            'account:1:env:2'
+        );
+
+        expect(res).toEqual({ enqueued: 3, failed: 0, failedActivityLogIds: [] });
+        expect(send.mock.calls).toHaveLength(2);
+        const entryCounts = send.mock.calls.map((call) => (call[0] as SendMessageBatchCommand).input.Entries?.length);
+        expect(entryCounts).toEqual([2, 1]);
     });
 
     it('limits concurrent batch publishes to publishConcurrency', async () => {
@@ -187,7 +249,7 @@ describe('DispatchQueuePublisher', () => {
 
         const publisher = new DispatchQueuePublisher({ sqs, queueUrl: 'http://q', batchSize: 1, publishConcurrency: 2 });
         const publishPromise = publisher.publish(
-            Array.from({ length: 4 }, () => buildMessage()),
+            Array.from({ length: 4 }, () => buildPreparedMessage()),
             'account:1:env:2'
         );
 
@@ -230,7 +292,11 @@ describe('DispatchQueuePublisher', () => {
         const { sqs, send } = makeSqsMock((_n, call) => responses[call]!);
         const publisher = new DispatchQueuePublisher({ sqs, queueUrl: 'http://q' });
         const res = await publisher.publish(
-            [buildMessage(), buildMessage({ activityLogId: 'log-2' }), buildMessage({ activityLogId: 'log-3' })],
+            [
+                buildPreparedMessage(),
+                buildPreparedMessage({ messageOverrides: { activityLogId: 'log-2' } }),
+                buildPreparedMessage({ messageOverrides: { activityLogId: 'log-3' } })
+            ],
             'account:1:env:2'
         );
         expect(res).toEqual({ enqueued: 2, failed: 1, failedActivityLogIds: ['log-3'] });
@@ -255,7 +321,7 @@ describe('DispatchQueuePublisher', () => {
             return { $metadata: {}, Successful: [{ Id: 'm0', MessageId: 'ok', MD5OfMessageBody: 'x' }], Failed: [] };
         });
         const publisher = new DispatchQueuePublisher({ sqs, queueUrl: 'http://q' });
-        const res = await publisher.publish([buildMessage()], 'account:1:env:2');
+        const res = await publisher.publish([buildPreparedMessage()], 'account:1:env:2');
         expect(res).toEqual({ enqueued: 1, failed: 0, failedActivityLogIds: [] });
         expect(send.mock.calls).toHaveLength(2);
         expect(tracerMocks.span.setTag).toHaveBeenCalledWith('nango.retriedEntries', 1);
@@ -282,7 +348,7 @@ describe('DispatchQueuePublisher', () => {
         });
         const publisher = new DispatchQueuePublisher({ sqs, queueUrl: 'http://q' });
 
-        const res = await publisher.publish([buildMessage()], 'account:1:env:2');
+        const res = await publisher.publish([buildPreparedMessage()], 'account:1:env:2');
 
         expect(res).toEqual({ enqueued: 0, failed: 1, failedActivityLogIds: [] });
     });

--- a/packages/server/lib/webhook/internal-nango.ts
+++ b/packages/server/lib/webhook/internal-nango.ts
@@ -10,11 +10,21 @@ import { envs } from '../env.js';
 import { runWithConcurrencyLimit } from './runWithConcurrencyLimit.js';
 import { getOrchestrator } from '../utils/utils.js';
 import { dispatchQueuePublisher } from './dispatch-queue/client.js';
+import { SQS_BATCH_MAX_BYTES } from './dispatch-queue/publisher.js';
 
-import type { DispatchQueuePublisher } from './dispatch-queue/publisher.js';
-import type { LogContextGetter } from '@nangohq/logs';
-import type { Config } from '@nangohq/shared';
-import type { ConnectionInternal, DBConnectionDecrypted, DBEnvironment, DBIntegrationDecrypted, DBPlan, DBSyncConfig, DBTeam, Metadata } from '@nangohq/types';
+import type { DispatchQueuePublisher, PreparedDispatchMessage } from './dispatch-queue/publisher.js';
+import type { LogContext, LogContextGetter } from '@nangohq/logs';
+import type {
+    ConnectionInternal,
+    DBConnectionDecrypted,
+    DBEnvironment,
+    DBIntegrationDecrypted,
+    DBPlan,
+    DBSyncConfig,
+    DBTeam,
+    Metadata,
+    WebhookDispatchMessage
+} from '@nangohq/types';
 
 const LARGE_FANOUT_THRESHOLD = 200;
 const LOG_CONTEXT_CREATE_CONCURRENCY = 25;
@@ -26,27 +36,23 @@ interface MatchedExecution {
 }
 
 interface QueuedExecution {
+    syncConfig: DBSyncConfig;
+    webhook: string;
+    connection: DBConnectionDecrypted | ConnectionInternal;
     kind: 'queued';
     logCtx: Awaited<ReturnType<LogContextGetter['create']>>;
-    message: {
-        version: 1;
-        kind: 'webhook';
-        taskName: string;
-        createdAt: string;
-        accountId: number;
-        integrationId: number;
-        provider: string;
-        parentSyncName: string;
-        activityLogId: string;
-        webhookName: string;
-        connection: {
-            id: number;
-            connection_id: string;
-            provider_config_key: string;
-            environment_id: number;
-        };
-        payload: Record<string, any>;
-    };
+    preparedMessage: PreparedDispatchMessage;
+}
+
+interface OrchestratorExecution {
+    syncConfig: DBSyncConfig;
+    webhook: string;
+    connection: DBConnectionDecrypted | ConnectionInternal;
+    logCtx: LogContext;
+}
+
+interface FailedOrchestratorExecution extends OrchestratorExecution {
+    error: unknown;
 }
 
 interface FailedQueuedExecution extends MatchedExecution {
@@ -206,50 +212,83 @@ export class InternalNango {
         type: string | undefined;
         webhookHeaderValue: string | undefined;
     }): Promise<void> {
-        const orchestrator = getOrchestrator();
-        let scheduledCount = 0;
+        const executions: OrchestratorExecution[] = [];
 
-        try {
-            for (const syncConfig of syncConfigsWithWebhooks) {
-                const { webhook_subscriptions } = syncConfig;
-                if (!webhook_subscriptions) {
-                    continue;
+        for (const syncConfig of syncConfigsWithWebhooks) {
+            const { webhook_subscriptions } = syncConfig;
+            if (!webhook_subscriptions) {
+                continue;
+            }
+
+            let triggered = false;
+
+            for (const webhook of webhook_subscriptions) {
+                if (triggered) {
+                    break;
                 }
 
-                let triggered = false;
-
-                for (const webhook of webhook_subscriptions) {
-                    if (triggered) {
-                        break;
-                    }
-
-                    if (type === webhook || webhookHeaderValue === webhook || webhook === '*') {
-                        for (const connection of connections) {
-                            await orchestrator.triggerWebhook({
+                if (type === webhook || webhookHeaderValue === webhook || webhook === '*') {
+                    for (const connection of connections) {
+                        const logCtx = await this.logContextGetter.create(
+                            { operation: { type: 'webhook', action: 'incoming' }, expiresAt: new Date(Date.now() + 15 * 60 * 1000).toISOString() },
+                            {
                                 account: this.team,
                                 environment: this.environment,
-                                integration: this.integration as Config,
-                                connection,
-                                webhookName: webhook,
-                                syncConfig,
-                                input: body,
-                                maxConcurrency: envs.WEBHOOK_ENVIRONMENT_MAX_CONCURRENCY,
-                                logContextGetter: this.logContextGetter
-                            });
-                            scheduledCount += 1;
-                        }
+                                integration: { id: this.integration.id!, name: this.integration.unique_key, provider: this.integration.provider },
+                                connection: { id: connection.id, name: connection.connection_id },
+                                syncConfig: { id: syncConfig.id, name: syncConfig.sync_name }
+                            }
+                        );
+                        logCtx.attachSpan(new OtlpSpan(logCtx.operation));
+                        executions.push({ syncConfig, webhook, connection, logCtx });
+                    }
 
-                        triggered = true;
-                        if (webhook === '*') {
-                            // Only trigger once since it will match all webhooks
-                            break;
-                        }
+                    triggered = true;
+                    if (webhook === '*') {
+                        // Only trigger once since it will match all webhooks
+                        break;
                     }
                 }
             }
-        } finally {
-            metrics.increment(metrics.Types.WEBHOOK_DIRECT_TRIGGER_SUCCESS, scheduledCount, { provider: this.integration.provider });
         }
+
+        const dispatchResult = await this.dispatchExecutionsViaOrchestrator(executions, body);
+        metrics.increment(metrics.Types.WEBHOOK_DIRECT_TRIGGER_SUCCESS, dispatchResult.succeededCount, { provider: this.integration.provider });
+    }
+
+    private async dispatchExecutionsViaOrchestrator(
+        executions: OrchestratorExecution[],
+        body: Record<string, any>
+    ): Promise<{ succeededCount: number; failedExecutions: FailedOrchestratorExecution[] }> {
+        const orchestrator = getOrchestrator();
+        let succeededCount = 0;
+        const failedExecutions: FailedOrchestratorExecution[] = [];
+
+        for (const execution of executions) {
+            const { syncConfig, webhook, connection, logCtx } = execution;
+
+            try {
+                const result = await orchestrator.triggerWebhook({
+                    connection,
+                    webhookName: webhook,
+                    syncConfig,
+                    input: body,
+                    maxConcurrency: envs.WEBHOOK_ENVIRONMENT_MAX_CONCURRENCY,
+                    logCtx
+                });
+
+                if (result.isErr()) {
+                    failedExecutions.push({ ...execution, error: result.error });
+                    continue;
+                }
+
+                succeededCount += 1;
+            } catch (err) {
+                failedExecutions.push({ ...execution, error: err });
+            }
+        }
+
+        return { succeededCount, failedExecutions };
     }
 
     private async dispatchViaQueue({
@@ -310,34 +349,44 @@ export class InternalNango {
                     );
                     logCtx.attachSpan(new OtlpSpan(logCtx.operation));
 
+                    const message: WebhookDispatchMessage = {
+                        version: 1,
+                        kind: 'webhook',
+                        taskName: computeTaskName({
+                            environmentId: this.environment.id,
+                            providerConfigKey: this.integration.unique_key,
+                            parentSyncName: syncConfig.sync_name,
+                            connectionId: connection.id,
+                            activityLogId: logCtx.id
+                        }),
+                        createdAt: new Date().toISOString(),
+                        accountId: this.team.id,
+                        integrationId: this.integration.id!,
+                        provider: this.integration.provider,
+                        parentSyncName: syncConfig.sync_name,
+                        activityLogId: logCtx.id,
+                        webhookName: webhook,
+                        connection: {
+                            id: connection.id,
+                            connection_id: connection.connection_id,
+                            provider_config_key: connection.provider_config_key,
+                            environment_id: connection.environment_id
+                        },
+                        payload: body
+                    };
+                    const serializedBody = JSON.stringify(message);
+                    const preparedMessage: PreparedDispatchMessage = {
+                        message,
+                        byteSize: Buffer.byteLength(serializedBody, 'utf8')
+                    };
+
                     return {
                         kind: 'queued' as const,
                         logCtx,
-                        message: {
-                            version: 1 as const,
-                            kind: 'webhook' as const,
-                            taskName: computeTaskName({
-                                environmentId: this.environment.id,
-                                providerConfigKey: this.integration.unique_key,
-                                parentSyncName: syncConfig.sync_name,
-                                connectionId: connection.id,
-                                activityLogId: logCtx.id
-                            }),
-                            createdAt: new Date().toISOString(),
-                            accountId: this.team.id,
-                            integrationId: this.integration.id!,
-                            provider: this.integration.provider,
-                            parentSyncName: syncConfig.sync_name,
-                            activityLogId: logCtx.id,
-                            webhookName: webhook,
-                            connection: {
-                                id: connection.id,
-                                connection_id: connection.connection_id,
-                                provider_config_key: connection.provider_config_key,
-                                environment_id: connection.environment_id
-                            },
-                            payload: body
-                        }
+                        syncConfig,
+                        webhook,
+                        connection,
+                        preparedMessage
                     };
                 } catch (err) {
                     if (logCtx) {
@@ -386,8 +435,6 @@ export class InternalNango {
             return;
         }
 
-        const messages = queuedExecutions.map(({ message }) => message);
-
         if (matchedExecutions.length > LARGE_FANOUT_THRESHOLD) {
             metrics.increment(metrics.Types.WEBHOOK_DISPATCH_LARGE_FANOUT, 1, {
                 provider: this.integration.provider,
@@ -396,34 +443,83 @@ export class InternalNango {
             });
         }
 
-        const messageGroupId = `account:${this.team.id}:env:${this.environment.id}`;
-        const publishResult = await publisher.publish(messages, messageGroupId);
-        const failedActivityLogIds = new Set(publishResult.failedActivityLogIds);
-        const unmappedFailureCount = publishResult.failed - failedActivityLogIds.size;
+        const queueEligibleExecutions = queuedExecutions.filter(({ preparedMessage }) => preparedMessage.byteSize <= SQS_BATCH_MAX_BYTES);
+        const oversizedExecutions = queuedExecutions.filter(({ preparedMessage }) => preparedMessage.byteSize > SQS_BATCH_MAX_BYTES);
 
-        for (const { message, logCtx } of queuedExecutions) {
-            if (!failedActivityLogIds.has(message.activityLogId) && unmappedFailureCount === 0) {
-                void logCtx.info('The webhook was successfully queued for execution', {
+        let unmappedFailureCount = 0;
+
+        if (queueEligibleExecutions.length > 0) {
+            const messageGroupId = `account:${this.team.id}:env:${this.environment.id}`;
+            const publishResult = await publisher.publish(
+                queueEligibleExecutions.map(({ preparedMessage }) => preparedMessage),
+                messageGroupId
+            );
+            const failedActivityLogIds = new Set(publishResult.failedActivityLogIds);
+            unmappedFailureCount = publishResult.failed - failedActivityLogIds.size;
+
+            for (const {
+                preparedMessage: { message },
+                logCtx
+            } of queueEligibleExecutions) {
+                if (!failedActivityLogIds.has(message.activityLogId) && unmappedFailureCount === 0) {
+                    void logCtx.info('The webhook was successfully queued for execution', {
+                        action: message.webhookName,
+                        connection: message.connection.connection_id,
+                        integration: message.connection.provider_config_key
+                    });
+                    continue;
+                }
+
+                const error = new NangoError('webhook_failure', {
+                    error: 'The webhook could not be queued for execution',
+                    taskName: message.taskName
+                });
+
+                await logCtx.error('The webhook failed to queue for execution', {
+                    error,
+                    webhook: message.webhookName,
+                    connection: message.connection.connection_id,
+                    integration: message.connection.provider_config_key
+                });
+                await logCtx.enrichOperation({ error });
+                await logCtx.failed();
+            }
+        }
+
+        if (oversizedExecutions.length > 0) {
+            metrics.increment(metrics.Types.WEBHOOK_DISPATCH_BYPASS_OVERSIZE, oversizedExecutions.length, {
+                provider: this.integration.provider,
+                accountId: this.team.id,
+                environmentId: this.environment.id
+            });
+
+            for (const {
+                preparedMessage: { message },
+                logCtx
+            } of oversizedExecutions) {
+                void logCtx.warn('The webhook payload exceeds the queue size limit and will be dispatched directly', {
                     action: message.webhookName,
                     connection: message.connection.connection_id,
                     integration: message.connection.provider_config_key
                 });
-                continue;
             }
 
-            const error = new NangoError('webhook_failure', {
-                error: 'The webhook could not be queued for execution',
-                taskName: message.taskName
-            });
+            const dispatchResult = await this.dispatchExecutionsViaOrchestrator(oversizedExecutions, body);
 
-            await logCtx.error('The webhook failed to queue for execution', {
-                error,
-                webhook: message.webhookName,
-                connection: message.connection.connection_id,
-                integration: message.connection.provider_config_key
-            });
-            await logCtx.enrichOperation({ error });
-            await logCtx.failed();
+            for (const { error, syncConfig, webhook, connection } of dispatchResult.failedExecutions) {
+                report(error, {
+                    context: 'oversized webhook direct dispatch failed',
+                    provider: this.integration.provider,
+                    accountId: this.team.id,
+                    environmentId: this.environment.id,
+                    syncConfigId: syncConfig.id,
+                    syncName: syncConfig.sync_name,
+                    webhook,
+                    connectionId: connection.id,
+                    connection: connection.connection_id,
+                    integration: connection.provider_config_key
+                });
+            }
         }
 
         if (unmappedFailureCount > 0) {

--- a/packages/server/lib/webhook/internal-nango.unit.test.ts
+++ b/packages/server/lib/webhook/internal-nango.unit.test.ts
@@ -21,17 +21,28 @@ vi.mock('../utils/utils.js', () => ({ getOrchestrator: () => ({ triggerWebhook: 
 vi.mock('@nangohq/utils', async (importOriginal) => {
     const actual = await importOriginal();
 
+    if (!actual || typeof actual !== 'object' || !('metrics' in actual)) {
+        throw new Error('Invalid @nangohq/utils mock: missing metrics export');
+    }
+
+    const { metrics } = actual;
+    if (!metrics || typeof metrics !== 'object' || !('Types' in metrics) || !metrics.Types || typeof metrics.Types !== 'object') {
+        throw new Error('Invalid @nangohq/utils mock: missing metrics.Types export');
+    }
+
     return {
         ...(actual as object),
+        report: mocks.report,
         metrics: {
-            ...(actual as any).metrics,
+            ...metrics,
             Types: {
+                ...metrics.Types,
                 WEBHOOK_DIRECT_TRIGGER_SUCCESS: 'nango.webhook.direct_trigger.success',
-                WEBHOOK_DISPATCH_LARGE_FANOUT: 'nango.webhook.dispatch_queue.large_fanout'
+                WEBHOOK_DISPATCH_LARGE_FANOUT: 'nango.webhook.dispatch_queue.large_fanout',
+                WEBHOOK_DISPATCH_BYPASS_OVERSIZE: 'nango.webhook.dispatch_queue.bypass_oversize'
             },
             increment: mocks.increment
-        },
-        report: mocks.report
+        }
     };
 });
 vi.mock('@nangohq/shared', () => {
@@ -62,6 +73,7 @@ function createLogCtx(id: string) {
         operation: { id },
         attachSpan: vi.fn(),
         info: vi.fn().mockResolvedValue(true),
+        warn: vi.fn().mockResolvedValue(true),
         error: vi.fn().mockResolvedValue(true),
         enrichOperation: vi.fn().mockResolvedValue(undefined),
         failed: vi.fn().mockResolvedValue(undefined)
@@ -114,7 +126,7 @@ describe('InternalNango queue dispatch', () => {
             { id: 12, connection_id: 'conn-2', provider_config_key: 'github-dev', environment_id: 2, metadata: null }
         ]);
         mocks.getSyncConfigsByConfigIdForWebhook.mockResolvedValue([{ id: 21, sync_name: 'sync-1', webhook_subscriptions: ['push'] }]);
-        mocks.triggerWebhook.mockResolvedValue(undefined);
+        mocks.triggerWebhook.mockResolvedValue({ isErr: () => false });
     });
 
     it('logs queued successes and marks failed publishes as failed operations', async () => {
@@ -151,15 +163,37 @@ describe('InternalNango queue dispatch', () => {
         const publisher = { publish: vi.fn() };
         mocks.dispatchQueueClient.dispatchQueuePublisher = publisher;
 
-        const { nango, logContextGetter } = makeInternalNango([]);
+        const logCtx1 = createLogCtx('log-1');
+        const logCtx2 = createLogCtx('log-2');
+        const { nango, logContextGetter } = makeInternalNango([logCtx1, logCtx2]);
 
         const result = await nango.executeScriptForWebhooks({ body: { event: 'x' }, webhookTypeValue: 'push' });
 
         expect(result.connectionIds).toEqual(['conn-1', 'conn-2']);
         expect(mocks.triggerWebhook).toHaveBeenCalledTimes(2);
-        expect(logContextGetter.create).not.toHaveBeenCalled();
+        expect(logContextGetter.create).toHaveBeenCalledTimes(2);
         expect(publisher.publish).not.toHaveBeenCalled();
         expect(mocks.increment).toHaveBeenCalledWith('nango.webhook.direct_trigger.success', 2, { provider: 'github' });
+    });
+
+    it('continues direct orchestrator dispatch when one execution fails', async () => {
+        mocks.envs.WEBHOOK_INGRESS_USE_DISPATCH_QUEUE = false;
+        const publisher = { publish: vi.fn() };
+        mocks.dispatchQueueClient.dispatchQueuePublisher = publisher;
+        mocks.triggerWebhook
+            .mockResolvedValueOnce({ isErr: () => false })
+            .mockResolvedValueOnce({ isErr: () => true, error: new Error('orchestrator unavailable') });
+
+        const logCtx1 = createLogCtx('log-1');
+        const logCtx2 = createLogCtx('log-2');
+        const { nango } = makeInternalNango([logCtx1, logCtx2]);
+
+        const result = await nango.executeScriptForWebhooks({ body: { event: 'x' }, webhookTypeValue: 'push' });
+
+        expect(result.connectionIds).toEqual(['conn-1', 'conn-2']);
+        expect(mocks.triggerWebhook).toHaveBeenCalledTimes(2);
+        expect(publisher.publish).not.toHaveBeenCalled();
+        expect(mocks.increment).toHaveBeenCalledWith('nango.webhook.direct_trigger.success', 1, { provider: 'github' });
     });
 
     it('creates log contexts concurrently before publishing queue messages', async () => {
@@ -220,9 +254,11 @@ describe('InternalNango queue dispatch', () => {
         expect(publisher.publish).toHaveBeenCalledWith(
             [
                 expect.objectContaining({
-                    activityLogId: 'log-2',
-                    webhookName: 'push',
-                    connection: expect.objectContaining({ connection_id: 'conn-2' })
+                    message: expect.objectContaining({
+                        activityLogId: 'log-2',
+                        webhookName: 'push',
+                        connection: expect.objectContaining({ connection_id: 'conn-2' })
+                    })
                 })
             ],
             'account:1:env:2'
@@ -265,8 +301,10 @@ describe('InternalNango queue dispatch', () => {
         expect(publisher.publish).toHaveBeenCalledWith(
             [
                 expect.objectContaining({
-                    activityLogId: 'log-2',
-                    connection: expect.objectContaining({ connection_id: 'conn-2' })
+                    message: expect.objectContaining({
+                        activityLogId: 'log-2',
+                        connection: expect.objectContaining({ connection_id: 'conn-2' })
+                    })
                 })
             ],
             'account:1:env:2'
@@ -307,5 +345,76 @@ describe('InternalNango queue dispatch', () => {
             accountId: 1,
             environmentId: 2
         });
+    });
+
+    it('dispatches oversized messages directly to the orchestrator and emits a metric', async () => {
+        const publisher = { publish: vi.fn() };
+        mocks.dispatchQueueClient.dispatchQueuePublisher = publisher;
+
+        const logCtx1 = createLogCtx('log-1');
+        const logCtx2 = createLogCtx('log-2');
+        const { nango } = makeInternalNango([logCtx1, logCtx2]);
+
+        const result = await nango.executeScriptForWebhooks({ body: { payload: 'x'.repeat(1_100_000) }, webhookTypeValue: 'push' });
+
+        expect(result.connectionIds).toEqual(['conn-1', 'conn-2']);
+        expect(publisher.publish).not.toHaveBeenCalled();
+        expect(mocks.triggerWebhook).toHaveBeenCalledTimes(2);
+        expect(mocks.increment).toHaveBeenCalledWith('nango.webhook.dispatch_queue.bypass_oversize', 2, {
+            provider: 'github',
+            accountId: 1,
+            environmentId: 2
+        });
+        expect(logCtx1.warn).toHaveBeenCalledWith(
+            'The webhook payload exceeds the queue size limit and will be dispatched directly',
+            expect.objectContaining({ connection: 'conn-1' })
+        );
+        expect(logCtx2.warn).toHaveBeenCalledWith(
+            'The webhook payload exceeds the queue size limit and will be dispatched directly',
+            expect.objectContaining({ connection: 'conn-2' })
+        );
+    });
+
+    it('reports but does not rethrow when oversized direct dispatch fails', async () => {
+        const publisher = {
+            publish: vi.fn().mockResolvedValue({ enqueued: 1, failed: 0, failedActivityLogIds: [] })
+        };
+        mocks.dispatchQueueClient.dispatchQueuePublisher = publisher;
+        // triggerWebhook returns Err (never rejects) — logCtx.error/failed handled internally by triggerWebhook
+        mocks.triggerWebhook.mockResolvedValue({ isErr: () => true, error: new Error('orchestrator unavailable') });
+
+        // Single connection with a body large enough to exceed 1 MiB → goes to oversize path
+        const logCtx1 = createLogCtx('log-1');
+
+        mocks.getConnectionsByEnvironmentAndConfig.mockResolvedValue([
+            { id: 11, connection_id: 'conn-1', provider_config_key: 'github-dev', environment_id: 2, metadata: null }
+        ]);
+        const { nango } = makeInternalNango([logCtx1]);
+
+        await expect(nango.executeScriptForWebhooks({ body: { payload: 'x'.repeat(1_100_000) }, webhookTypeValue: 'push' })).resolves.not.toThrow();
+
+        expect(publisher.publish).not.toHaveBeenCalled();
+        expect(mocks.triggerWebhook).toHaveBeenCalledTimes(1);
+        expect(mocks.report).toHaveBeenCalledWith(expect.any(Error), expect.objectContaining({ context: 'oversized webhook direct dispatch failed' }));
+    });
+
+    it('only reports for the failing connection when oversize dispatch partially succeeds', async () => {
+        const publisher = { publish: vi.fn() };
+        mocks.dispatchQueueClient.dispatchQueuePublisher = publisher;
+        // First call succeeds, second call returns Err — logCtx handling is triggerWebhook's responsibility
+        mocks.triggerWebhook
+            .mockResolvedValueOnce({ isErr: () => false })
+            .mockResolvedValueOnce({ isErr: () => true, error: new Error('orchestrator unavailable') });
+
+        const logCtx1 = createLogCtx('log-1');
+        const logCtx2 = createLogCtx('log-2');
+        const { nango } = makeInternalNango([logCtx1, logCtx2]);
+
+        await expect(nango.executeScriptForWebhooks({ body: { payload: 'x'.repeat(1_100_000) }, webhookTypeValue: 'push' })).resolves.not.toThrow();
+
+        expect(mocks.triggerWebhook).toHaveBeenCalledTimes(2);
+        // Only the failing connection triggers a report; the successful one does not
+        expect(mocks.report).toHaveBeenCalledTimes(1);
+        expect(mocks.report).toHaveBeenCalledWith(expect.any(Error), expect.objectContaining({ context: 'oversized webhook direct dispatch failed' }));
     });
 });

--- a/packages/shared/lib/clients/orchestrator.ts
+++ b/packages/shared/lib/clients/orchestrator.ts
@@ -3,7 +3,6 @@ import ms from 'ms';
 import { v4 as uuid } from 'uuid';
 
 import db from '@nangohq/database';
-import { OtlpSpan } from '@nangohq/logs';
 import { Err, Ok, errorToObject, getCheckpointKey, getFrequencyMs, stringifyError } from '@nangohq/utils';
 
 import { hardDeleteCheckpoints } from '../index.js';
@@ -33,16 +32,7 @@ import type {
     VoidReturn
 } from '@nangohq/nango-orchestrator';
 import type { RecordCount } from '@nangohq/records';
-import type {
-    AsyncActionResponse,
-    ConnectionInternal,
-    ConnectionJobs,
-    DBConnection,
-    DBConnectionDecrypted,
-    DBEnvironment,
-    DBSyncConfig,
-    DBTeam
-} from '@nangohq/types';
+import type { AsyncActionResponse, ConnectionInternal, ConnectionJobs, DBConnection, DBConnectionDecrypted, DBSyncConfig } from '@nangohq/types';
 import type { Result } from '@nangohq/utils';
 import type { JsonValue } from 'type-fest';
 
@@ -234,25 +224,19 @@ export class Orchestrator {
     }
 
     async triggerWebhook<T = unknown>({
-        account,
-        environment,
-        integration,
         connection,
         webhookName,
         syncConfig,
         input,
         maxConcurrency,
-        logContextGetter
+        logCtx
     }: {
-        account: DBTeam;
-        environment: DBEnvironment;
-        integration: ProviderConfig;
         connection: ConnectionJobs;
         webhookName: string;
         syncConfig: DBSyncConfig;
         input: object;
         maxConcurrency: number;
-        logContextGetter: LogContextGetter;
+        logCtx: LogContext;
     }): Promise<Result<T, NangoError>> {
         const activeSpan = tracer.scope().active();
         const spanTags = {
@@ -267,17 +251,6 @@ export class Orchestrator {
             tags: spanTags,
             ...(activeSpan ? { childOf: activeSpan } : {})
         });
-        const logCtx = await logContextGetter.create(
-            { operation: { type: 'webhook', action: 'incoming' }, expiresAt: new Date(Date.now() + 15 * 60 * 1000).toISOString() },
-            {
-                account,
-                environment,
-                integration: { id: integration.id!, name: integration.unique_key, provider: integration.provider },
-                connection: { id: connection.id, name: connection.connection_id },
-                syncConfig: { id: syncConfig.id, name: syncConfig.sync_name }
-            }
-        );
-        logCtx.attachSpan(new OtlpSpan(logCtx.operation));
 
         try {
             let parsedInput = null;

--- a/packages/utils/lib/telemetry/metrics.ts
+++ b/packages/utils/lib/telemetry/metrics.ts
@@ -71,6 +71,7 @@ export enum Types {
 
     WEBHOOK_DISPATCH_PUBLISH_SUCCESS = 'nango.webhook.dispatch_queue.publish.success',
     WEBHOOK_DISPATCH_PUBLISH_FAILURE = 'nango.webhook.dispatch_queue.publish.failure',
+    WEBHOOK_DISPATCH_BYPASS_OVERSIZE = 'nango.webhook.dispatch_queue.bypass_oversize',
     WEBHOOK_DISPATCH_LARGE_FANOUT = 'nango.webhook.dispatch_queue.large_fanout',
     WEBHOOK_DISPATCH_CONSUME_SUCCESS = 'nango.webhook.dispatch_queue.consume.success',
     WEBHOOK_DISPATCH_CONSUME_FAILURE = 'nango.webhook.dispatch_queue.consume.failure',


### PR DESCRIPTION
Keep large-but-valid webhook messages on the dispatch queue while routing payloads above the 1 MiB SQS limit straight to the orchestrator so they are still delivered.
