### PR TITLE
fix: do not chunk autodelete deletion

### DIFF
--- a/packages/persist/lib/daemons/autodeleting.daemon.ts
+++ b/packages/persist/lib/daemons/autodeleting.daemon.ts
@@ -53,8 +53,7 @@ export function autoDeletingDaemon(): Awaited<ReturnType<typeof cancellableDaemo
                         environmentId: candidate.value.environmentId,
                         connectionId: candidate.value.connectionId,
                         model: candidate.value.model,
-                        mode: 'hard',
-                        limit: envs.PERSIST_AUTO_DELETING_LIMIT
+                        mode: 'hard'
                     });
                     if (res.isErr()) {
                         span?.addTags({ error: res.error.message });


### PR DESCRIPTION
candidate connection/model for autodeletion are selected randomly among entries where updated_at is older than 60 days. Then if the sync is stale a chunk of records is deleted. However the deletion itself modify the updated_at to now, which means that the same connection/model won't be selected again as a candidate for another 60 days. 
This commit addresses this issue by deleting all the records at once, instead of a single chunk (`deleteRecords` is itself paginated). It means a deletion operation can take a long time for models with tons of records but the process happens in the background.

Other options have been considered:
- not updating the `updated_at` attributes when autodeleting. It would require to add an additional parameter and special case to the `deleteRecords` function Not only it would be harder to understand/track records updates but it could be misused
- not selecting candidate based on `updated_at < 60 days`. Even though the number of models isn't huge (less than 200_000) it would take a lot of queries to find actual candidate for autodeletion

<!-- Describe the problem and your solution --> 

<!-- Issue ticket number and link (if applicable) -->

<!-- Testing instructions (skip if just adding/editing providers) -->

