### PR TITLE
feat(webhooks): Rate limit webhook ingress in shadow mode

### DIFF
--- a/packages/server/lib/controllers/webhook/environmentUuid/postWebhook.ts
+++ b/packages/server/lib/controllers/webhook/environmentUuid/postWebhook.ts
@@ -49,7 +49,7 @@ export const postWebhook = asyncWrapper<PostPublicWebhook>(async (req, res) => {
             span.setTag('nango.environmentUUID', environmentUuid);
             span.setTag('nango.providerConfigKey', providerConfigKey);
 
-            metrics.increment(metrics.Types.WEBHOOK_INCOMING_PAYLOAD_SIZE_BYTES, req.rawBody ? Buffer.byteLength(req.rawBody) : 0, { accountId: account.id });
+            metrics.duration(metrics.Types.WEBHOOK_INCOMING_PAYLOAD_SIZE_BYTES, req.rawBody ? Buffer.byteLength(req.rawBody) : 0, { accountId: account.id });
 
             const isDisabledForThisAccount = await featureFlags.isSet('disable-external-webhooks', { distinctId: account.uuid });
             if (isDisabledForThisAccount) {

--- a/packages/server/lib/controllers/webhook/environmentUuid/postWebhook.ts
+++ b/packages/server/lib/controllers/webhook/environmentUuid/postWebhook.ts
@@ -78,7 +78,10 @@ export const postWebhook = asyncWrapper<PostPublicWebhook>(async (req, res) => {
                 return;
             }
 
-            metrics.increment(metrics.Types.WEBHOOK_INCOMING_RECEIVED);
+            metrics.increment(metrics.Types.WEBHOOK_INCOMING_RECEIVED, 1, {
+                accountId: account.id,
+                provider: integration.provider
+            });
 
             const provider = getProvider(integration.provider);
 

--- a/packages/server/lib/middleware/ratelimit.middleware.ts
+++ b/packages/server/lib/middleware/ratelimit.middleware.ts
@@ -1,12 +1,12 @@
 import path from 'node:path';
 
 import { RateLimiterMemory, RateLimiterRedis, RateLimiterRes } from 'rate-limiter-flexible';
-import { createClient } from 'redis';
 
 import { getRedisUrl } from '@nangohq/shared';
 import { flagHasAPIRateLimit, flagHasPlan, getLogger } from '@nangohq/utils';
 
 import { envs } from '../env.js';
+import { createRateLimiterRedisClient } from '../utils/rateLimiterRedisClient.js';
 
 import type { RequestLocals } from '../utils/express.js';
 import type { DBPlan } from '@nangohq/types';
@@ -45,22 +45,7 @@ async function getRateLimiter(size: DBPlan['api_rate_limit_size']) {
     const url = getRedisUrl();
     let limiter: RateLimiterAbstract;
     if (url) {
-        const isExternal = url.startsWith('rediss://');
-        const socket = isExternal
-            ? {
-                  reconnectStrategy: (retries: number) => Math.min(retries * 200, 2000),
-                  connectTimeout: 10_000,
-                  tls: true,
-                  servername: new URL(url).hostname,
-                  keepAlive: 60_000
-              }
-            : {};
-        const redisClient = await createClient({
-            url: url,
-            disableOfflineQueue: true,
-            pingInterval: 30_000,
-            socket
-        }).connect();
+        const redisClient = await createRateLimiterRedisClient(url);
         redisClient.on('error', (err) => {
             logger.error(`Redis (rate-limiter) error: ${err}`);
         });

--- a/packages/server/lib/middleware/webhook-ingress-ratelimit.middleware.ts
+++ b/packages/server/lib/middleware/webhook-ingress-ratelimit.middleware.ts
@@ -120,7 +120,11 @@ async function buildLimiter(): Promise<RateLimiterAbstract> {
 
 function getDefaultLimiter(): Promise<RateLimiterAbstract> {
     if (!limiterPromise) {
-        limiterPromise = buildLimiter();
+        limiterPromise = buildLimiter().catch((err: unknown) => {
+            // Don't cache the rejection — let the next request retry the build
+            limiterPromise = null;
+            throw err;
+        });
     }
     return limiterPromise;
 }

--- a/packages/server/lib/middleware/webhook-ingress-ratelimit.middleware.ts
+++ b/packages/server/lib/middleware/webhook-ingress-ratelimit.middleware.ts
@@ -1,0 +1,132 @@
+import { RateLimiterMemory, RateLimiterRedis, RateLimiterRes } from 'rate-limiter-flexible';
+import { createClient } from 'redis';
+
+import { getRedisUrl } from '@nangohq/shared';
+import { getLogger, metrics } from '@nangohq/utils';
+
+import { envs } from '../env.js';
+
+import type { RequestHandler } from 'express';
+import type { RateLimiterAbstract } from 'rate-limiter-flexible';
+
+const logger = getLogger('WebhookIngressRateLimit');
+
+const UUID_V4 = /^[0-9a-f]{8}-[0-9a-f]{4}-4[0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$/i;
+
+interface Deps {
+    limit: number;
+    enforce: boolean;
+    getLimiter: () => Promise<RateLimiterAbstract>;
+}
+
+export function createWebhookIngressRateLimit(deps: Deps): RequestHandler {
+    return async (req, res, next) => {
+        if (deps.limit <= 0) {
+            next();
+            return;
+        }
+
+        const environmentUuid = req.params['environmentUuid'];
+        const providerConfigKey = req.params['providerConfigKey'];
+
+        if (!environmentUuid || !providerConfigKey || !UUID_V4.test(environmentUuid)) {
+            next();
+            return;
+        }
+
+        const envUuid = environmentUuid.toLowerCase();
+
+        try {
+            const limiter = await deps.getLimiter();
+            const key = `${envUuid}:${providerConfigKey}`;
+
+            try {
+                await limiter.consume(key, 1);
+                next();
+                return;
+            } catch (err) {
+                if (err instanceof RateLimiterRes) {
+                    const retryAfterSeconds = Math.max(1, Math.ceil(err.msBeforeNext / 1000));
+
+                    logger.warning('Webhook ingress rate limit breached', {
+                        environmentUuid: envUuid,
+                        providerConfigKey,
+                        retryAfterSeconds,
+                        enforced: deps.enforce
+                    });
+                    metrics.increment(metrics.Types.WEBHOOK_INCOMING_RATE_LIMITED, 1, {
+                        enforced: deps.enforce ? 'true' : 'false'
+                    });
+
+                    if (deps.enforce) {
+                        res.setHeader('Retry-After', retryAfterSeconds);
+                        res.status(429).send({ error: { code: 'too_many_request' } });
+                        return;
+                    }
+
+                    next();
+                    return;
+                }
+
+                logger.error('Failed to consume webhook ingress rate limit', { error: err });
+                next();
+                return;
+            }
+        } catch (err) {
+            logger.error('Unexpected error in webhook ingress rate limit middleware', { error: err });
+            next();
+        }
+    };
+}
+
+let limiterPromise: Promise<RateLimiterAbstract> | null = null;
+
+async function buildLimiter(): Promise<RateLimiterAbstract> {
+    const opts = {
+        keyPrefix: 'webhook-ingress',
+        points: envs.NANGO_WEBHOOK_INGRESS_RATE_LIMIT_PER_MIN,
+        duration: 60,
+        blockDuration: 0
+    };
+
+    const url = getRedisUrl();
+    if (!url) {
+        return new RateLimiterMemory(opts);
+    }
+
+    const isExternal = url.startsWith('rediss://');
+    const socket = isExternal
+        ? {
+              reconnectStrategy: (retries: number) => Math.min(retries * 200, 2000),
+              connectTimeout: 10_000,
+              tls: true,
+              servername: new URL(url).hostname,
+              keepAlive: 60_000
+          }
+        : {};
+
+    const redisClient = await createClient({
+        url,
+        disableOfflineQueue: true,
+        pingInterval: 30_000,
+        socket
+    }).connect();
+    redisClient.on('error', (err) => {
+        logger.error(`Redis (webhook-ingress rate-limiter) error: ${err}`);
+    });
+
+    return new RateLimiterRedis({ storeClient: redisClient, ...opts });
+}
+
+function getDefaultLimiter(): Promise<RateLimiterAbstract> {
+    if (!limiterPromise) {
+        limiterPromise = buildLimiter();
+    }
+    return limiterPromise;
+}
+
+export const webhookIngressRateLimit: RequestHandler = createWebhookIngressRateLimit({
+    limit: envs.NANGO_WEBHOOK_INGRESS_RATE_LIMIT_PER_MIN,
+    enforce: envs.NANGO_WEBHOOK_INGRESS_RATE_LIMIT_ENFORCE,
+    getLimiter: getDefaultLimiter
+});

--- a/packages/server/lib/middleware/webhook-ingress-ratelimit.middleware.ts
+++ b/packages/server/lib/middleware/webhook-ingress-ratelimit.middleware.ts
@@ -1,10 +1,10 @@
 import { RateLimiterMemory, RateLimiterRedis, RateLimiterRes } from 'rate-limiter-flexible';
-import { createClient } from 'redis';
 
 import { getRedisUrl } from '@nangohq/shared';
 import { getLogger, metrics } from '@nangohq/utils';
 
 import { envs } from '../env.js';
+import { createRateLimiterRedisClient } from '../utils/rateLimiterRedisClient.js';
 
 import type { RequestHandler } from 'express';
 import type { RateLimiterAbstract } from 'rate-limiter-flexible';
@@ -36,12 +36,20 @@ export function createWebhookIngressRateLimit(deps: Deps): RequestHandler {
 
         const envUuid = environmentUuid.toLowerCase();
 
+        function setXRateLimitHeaders(rateLimiterRes: RateLimiterRes) {
+            const resetEpoch = Math.floor(new Date(Date.now() + rateLimiterRes.msBeforeNext).getTime() / 1000);
+            res.setHeader('X-RateLimit-Limit', deps.limit);
+            res.setHeader('X-RateLimit-Remaining', rateLimiterRes.remainingPoints);
+            res.setHeader('X-RateLimit-Reset', resetEpoch);
+        }
+
         try {
             const limiter = await deps.getLimiter();
             const key = `${envUuid}:${providerConfigKey}`;
 
             try {
-                await limiter.consume(key, 1);
+                const resConsume = await limiter.consume(key, 1);
+                setXRateLimitHeaders(resConsume);
                 next();
                 return;
             } catch (err) {
@@ -57,6 +65,8 @@ export function createWebhookIngressRateLimit(deps: Deps): RequestHandler {
                     metrics.increment(metrics.Types.WEBHOOK_INCOMING_RATE_LIMITED, 1, {
                         enforced: deps.enforce ? 'true' : 'false'
                     });
+
+                    setXRateLimitHeaders(err);
 
                     if (deps.enforce) {
                         res.setHeader('Retry-After', retryAfterSeconds);
@@ -94,23 +104,7 @@ async function buildLimiter(): Promise<RateLimiterAbstract> {
         return new RateLimiterMemory(opts);
     }
 
-    const isExternal = url.startsWith('rediss://');
-    const socket = isExternal
-        ? {
-              reconnectStrategy: (retries: number) => Math.min(retries * 200, 2000),
-              connectTimeout: 10_000,
-              tls: true,
-              servername: new URL(url).hostname,
-              keepAlive: 60_000
-          }
-        : {};
-
-    const redisClient = await createClient({
-        url,
-        disableOfflineQueue: true,
-        pingInterval: 30_000,
-        socket
-    }).connect();
+    const redisClient = await createRateLimiterRedisClient(url);
     redisClient.on('error', (err) => {
         logger.error(`Redis (webhook-ingress rate-limiter) error: ${err}`);
     });

--- a/packages/server/lib/middleware/webhook-ingress-ratelimit.middleware.unit.test.ts
+++ b/packages/server/lib/middleware/webhook-ingress-ratelimit.middleware.unit.test.ts
@@ -1,0 +1,221 @@
+import { RateLimiterMemory } from 'rate-limiter-flexible';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+import { createWebhookIngressRateLimit } from './webhook-ingress-ratelimit.middleware.js';
+
+import type { NextFunction, Request, Response } from 'express';
+import type { RateLimiterAbstract } from 'rate-limiter-flexible';
+
+const VALID_UUID = '11111111-1111-4111-8111-111111111111';
+const ANOTHER_UUID = '22222222-2222-4222-8222-222222222222';
+
+function makeReq(params: Record<string, string | undefined>): Request {
+    return { params } as unknown as Request;
+}
+
+function makeRes() {
+    const headers: Record<string, unknown> = {};
+    let statusCode: number | undefined;
+    let body: unknown;
+    const res = {
+        setHeader: (name: string, value: unknown) => {
+            headers[name] = value;
+            return res;
+        },
+        status: (code: number) => {
+            statusCode = code;
+            return res;
+        },
+        send: (payload: unknown) => {
+            body = payload;
+            return res;
+        }
+    };
+    return {
+        res: res as unknown as Response,
+        getHeaders: () => headers,
+        getStatusCode: () => statusCode,
+        getBody: () => body
+    };
+}
+
+function makeLimiter(points: number): RateLimiterAbstract {
+    return new RateLimiterMemory({
+        keyPrefix: 'test-webhook-ingress',
+        points,
+        duration: 60,
+        blockDuration: 0
+    });
+}
+
+describe('webhookIngressRateLimit middleware', () => {
+    let next: NextFunction;
+
+    beforeEach(() => {
+        next = vi.fn();
+    });
+
+    it('passes through when limit is 0 (disabled)', async () => {
+        const getLimiter = vi.fn();
+        const middleware = createWebhookIngressRateLimit({ limit: 0, enforce: true, getLimiter });
+        const { res } = makeRes();
+
+        await middleware(makeReq({ environmentUuid: VALID_UUID, providerConfigKey: 'github' }), res, next);
+
+        expect(next).toHaveBeenCalledOnce();
+        expect(getLimiter).not.toHaveBeenCalled();
+    });
+
+    it('passes through when environmentUuid is not a UUID v4', async () => {
+        const getLimiter = vi.fn();
+        const middleware = createWebhookIngressRateLimit({ limit: 5, enforce: true, getLimiter });
+        const { res } = makeRes();
+
+        await middleware(makeReq({ environmentUuid: 'not-a-uuid', providerConfigKey: 'github' }), res, next);
+
+        expect(next).toHaveBeenCalledOnce();
+        expect(getLimiter).not.toHaveBeenCalled();
+    });
+
+    it('passes through when providerConfigKey is missing', async () => {
+        const getLimiter = vi.fn();
+        const middleware = createWebhookIngressRateLimit({ limit: 5, enforce: true, getLimiter });
+        const { res } = makeRes();
+
+        await middleware(makeReq({ environmentUuid: VALID_UUID, providerConfigKey: undefined }), res, next);
+
+        expect(next).toHaveBeenCalledOnce();
+        expect(getLimiter).not.toHaveBeenCalled();
+    });
+
+    it('allows requests within the limit and breaches on N+1', async () => {
+        const limiter = makeLimiter(2);
+        const middleware = createWebhookIngressRateLimit({
+            limit: 2,
+            enforce: false,
+            getLimiter: () => Promise.resolve(limiter)
+        });
+
+        for (let i = 0; i < 2; i++) {
+            const { res } = makeRes();
+            const localNext = vi.fn();
+            await middleware(makeReq({ environmentUuid: VALID_UUID, providerConfigKey: 'github' }), res, localNext);
+            expect(localNext).toHaveBeenCalledOnce();
+        }
+
+        // 3rd request — over the limit
+        const { res, getStatusCode } = makeRes();
+        const localNext = vi.fn();
+        await middleware(makeReq({ environmentUuid: VALID_UUID, providerConfigKey: 'github' }), res, localNext);
+        // shadow mode by default — falls through
+        expect(localNext).toHaveBeenCalledOnce();
+        expect(getStatusCode()).toBeUndefined();
+    });
+
+    it('different keys do not share a budget', async () => {
+        const limiter = makeLimiter(1);
+        const middleware = createWebhookIngressRateLimit({
+            limit: 1,
+            enforce: false,
+            getLimiter: () => Promise.resolve(limiter)
+        });
+
+        // First key consumes its single point
+        let { res } = makeRes();
+        let localNext = vi.fn();
+        await middleware(makeReq({ environmentUuid: VALID_UUID, providerConfigKey: 'github' }), res, localNext);
+        expect(localNext).toHaveBeenCalledOnce();
+
+        // Different env uuid, same provider config — independent budget
+        ({ res } = makeRes());
+        localNext = vi.fn();
+        await middleware(makeReq({ environmentUuid: ANOTHER_UUID, providerConfigKey: 'github' }), res, localNext);
+        expect(localNext).toHaveBeenCalledOnce();
+
+        // Same env uuid, different provider config — independent budget
+        ({ res } = makeRes());
+        localNext = vi.fn();
+        await middleware(makeReq({ environmentUuid: VALID_UUID, providerConfigKey: 'slack' }), res, localNext);
+        expect(localNext).toHaveBeenCalledOnce();
+    });
+
+    it('shadow mode: breach is observed but request continues', async () => {
+        const limiter = makeLimiter(1);
+        const middleware = createWebhookIngressRateLimit({
+            limit: 1,
+            enforce: false,
+            getLimiter: () => Promise.resolve(limiter)
+        });
+
+        // consume the only point
+        const { res } = makeRes();
+        await middleware(makeReq({ environmentUuid: VALID_UUID, providerConfigKey: 'github' }), res, vi.fn());
+
+        // breach
+        const second = makeRes();
+        const localNext = vi.fn();
+        await middleware(makeReq({ environmentUuid: VALID_UUID, providerConfigKey: 'github' }), second.res, localNext);
+
+        expect(localNext).toHaveBeenCalledOnce();
+        expect(second.getStatusCode()).toBeUndefined();
+        expect(second.getHeaders()['Retry-After']).toBeUndefined();
+    });
+
+    it('enforce mode: breach returns 429 with Retry-After and does not call next', async () => {
+        const limiter = makeLimiter(1);
+        const middleware = createWebhookIngressRateLimit({
+            limit: 1,
+            enforce: true,
+            getLimiter: () => Promise.resolve(limiter)
+        });
+
+        // consume the only point
+        await middleware(makeReq({ environmentUuid: VALID_UUID, providerConfigKey: 'github' }), makeRes().res, vi.fn());
+
+        // breach
+        const { res, getStatusCode, getHeaders, getBody } = makeRes();
+        const localNext = vi.fn();
+        await middleware(makeReq({ environmentUuid: VALID_UUID, providerConfigKey: 'github' }), res, localNext);
+
+        expect(localNext).not.toHaveBeenCalled();
+        expect(getStatusCode()).toBe(429);
+        expect(getHeaders()['Retry-After']).toBeGreaterThanOrEqual(1);
+        expect(getBody()).toEqual({ error: { code: 'too_many_request' } });
+    });
+
+    it('fails open when the limiter throws an unexpected error', async () => {
+        const brokenLimiter = {
+            consume: vi.fn(() => Promise.reject(new Error('redis unreachable')))
+        } as unknown as RateLimiterAbstract;
+        const middleware = createWebhookIngressRateLimit({
+            limit: 5,
+            enforce: true,
+            getLimiter: () => Promise.resolve(brokenLimiter)
+        });
+        const { res, getStatusCode } = makeRes();
+        const localNext = vi.fn();
+
+        await middleware(makeReq({ environmentUuid: VALID_UUID, providerConfigKey: 'github' }), res, localNext);
+
+        expect(localNext).toHaveBeenCalledOnce();
+        expect(getStatusCode()).toBeUndefined();
+    });
+
+    it('lowercases the environment uuid before keying', async () => {
+        const limiter = makeLimiter(1);
+        const middleware = createWebhookIngressRateLimit({
+            limit: 1,
+            enforce: true,
+            getLimiter: () => Promise.resolve(limiter)
+        });
+
+        // consume with lowercase
+        await middleware(makeReq({ environmentUuid: VALID_UUID, providerConfigKey: 'github' }), makeRes().res, vi.fn());
+
+        // same uuid in uppercase should hit the same bucket
+        const { res, getStatusCode } = makeRes();
+        await middleware(makeReq({ environmentUuid: VALID_UUID.toUpperCase(), providerConfigKey: 'github' }), res, vi.fn());
+
+        expect(getStatusCode()).toBe(429);
+    });
+});

--- a/packages/server/lib/routes.public.ts
+++ b/packages/server/lib/routes.public.ts
@@ -70,6 +70,7 @@ import { connectionCapping } from './middleware/connection-capping.middleware.js
 import { jsonContentTypeMiddleware } from './middleware/json.middleware.js';
 import { rateLimiterMiddleware } from './middleware/ratelimit.middleware.js';
 import { withAnyScope, withScope } from './middleware/scope.middleware.js';
+import { webhookIngressRateLimit } from './middleware/webhook-ingress-ratelimit.middleware.js';
 import { isBinaryContentType } from './utils/utils.js';
 
 import type { DBPlan } from '@nangohq/types';
@@ -163,7 +164,7 @@ publicAPI.route('/auth/bill/:providerConfigKey').post(connectSessionOrPublicAuth
 publicAPI.route('/auth/signature/:providerConfigKey').post(connectSessionOrPublicAuth, postPublicSignatureAuthorization);
 publicAPI.route('/auth/unauthenticated/:providerConfigKey').post(connectSessionOrPublicAuth, postPublicUnauthenticated);
 
-publicAPI.route('/webhook/:environmentUuid/:providerConfigKey').post(postWebhook);
+publicAPI.route('/webhook/:environmentUuid/:providerConfigKey').post(webhookIngressRateLimit, postWebhook);
 
 publicAPI.use('/providers', jsonContentTypeMiddleware);
 publicAPI.route('/providers').get(connectSessionOrApiAuth, acceptLanguageMiddleware, getPublicProviders);

--- a/packages/server/lib/utils/rateLimiterRedisClient.ts
+++ b/packages/server/lib/utils/rateLimiterRedisClient.ts
@@ -1,0 +1,21 @@
+import { createClient } from 'redis';
+
+export async function createRateLimiterRedisClient(url: string): Promise<ReturnType<typeof createClient>> {
+    const isExternal = url.startsWith('rediss://');
+    const socket = isExternal
+        ? {
+              reconnectStrategy: (retries: number) => Math.min(retries * 200, 2000),
+              connectTimeout: 10_000,
+              tls: true,
+              servername: new URL(url).hostname,
+              keepAlive: 60_000
+          }
+        : {};
+
+    return createClient({
+        url,
+        disableOfflineQueue: true,
+        pingInterval: 30_000,
+        socket
+    }).connect();
+}

--- a/packages/utils/lib/environment/parse.ts
+++ b/packages/utils/lib/environment/parse.ts
@@ -538,6 +538,8 @@ export const ENVS = z.object({
 
     // WEBHOOK INGRESS
     WEBHOOK_INGRESS_USE_DISPATCH_QUEUE: z.stringbool().optional().default(false),
+    NANGO_WEBHOOK_INGRESS_RATE_LIMIT_PER_MIN: z.coerce.number().min(0).optional().default(4000),
+    NANGO_WEBHOOK_INGRESS_RATE_LIMIT_ENFORCE: z.stringbool().optional().default(false),
 
     // TASK DISPATCH QUEUE
     NANGO_TASK_DISPATCH_QUEUE_URL: z.url().optional(),

--- a/packages/utils/lib/environment/parse.unit.test.ts
+++ b/packages/utils/lib/environment/parse.unit.test.ts
@@ -156,6 +156,41 @@ describe('parse', () => {
         });
     });
 
+    describe('NANGO_WEBHOOK_INGRESS_RATE_LIMIT_PER_MIN', () => {
+        it('should default to 4000', () => {
+            const res = parseEnvs(ENVS, {});
+            expect(res.NANGO_WEBHOOK_INGRESS_RATE_LIMIT_PER_MIN).toBe(4000);
+        });
+
+        it('should accept 0 (disabled)', () => {
+            const res = parseEnvs(ENVS, { NANGO_WEBHOOK_INGRESS_RATE_LIMIT_PER_MIN: '0' });
+            expect(res.NANGO_WEBHOOK_INGRESS_RATE_LIMIT_PER_MIN).toBe(0);
+        });
+
+        it('should accept positive overrides', () => {
+            const res = parseEnvs(ENVS, { NANGO_WEBHOOK_INGRESS_RATE_LIMIT_PER_MIN: '120' });
+            expect(res.NANGO_WEBHOOK_INGRESS_RATE_LIMIT_PER_MIN).toBe(120);
+        });
+
+        it('should reject negatives', () => {
+            expect(() => {
+                parseEnvs(ENVS, { NANGO_WEBHOOK_INGRESS_RATE_LIMIT_PER_MIN: '-1' });
+            }).toThrowError();
+        });
+    });
+
+    describe('NANGO_WEBHOOK_INGRESS_RATE_LIMIT_ENFORCE', () => {
+        it('should default to false', () => {
+            const res = parseEnvs(ENVS, {});
+            expect(res.NANGO_WEBHOOK_INGRESS_RATE_LIMIT_ENFORCE).toBe(false);
+        });
+
+        it('should coerce "true"/"false" strings', () => {
+            expect(parseEnvs(ENVS, { NANGO_WEBHOOK_INGRESS_RATE_LIMIT_ENFORCE: 'true' }).NANGO_WEBHOOK_INGRESS_RATE_LIMIT_ENFORCE).toBe(true);
+            expect(parseEnvs(ENVS, { NANGO_WEBHOOK_INGRESS_RATE_LIMIT_ENFORCE: 'false' }).NANGO_WEBHOOK_INGRESS_RATE_LIMIT_ENFORCE).toBe(false);
+        });
+    });
+
     describe('NANGO_TASK_DISPATCH_*', () => {
         it('should apply defaults when task-dispatch vars are absent', () => {
             const res = parseEnvs(ENVS, {});

--- a/packages/utils/lib/telemetry/metrics.ts
+++ b/packages/utils/lib/telemetry/metrics.ts
@@ -59,6 +59,7 @@ export enum Types {
     FUNCTION_EXECUTIONS = 'nango.jobs.function.executions',
 
     WEBHOOK_INCOMING_RECEIVED = 'nango.webhook.incoming.received',
+    WEBHOOK_INCOMING_RATE_LIMITED = 'nango.webhook.incoming.rateLimited',
     WEBHOOK_INCOMING_FORWARDED_SUCCESS = 'nango.webhook.incoming.forwarded.success',
     WEBHOOK_INCOMING_FORWARDED_FAILED = 'nango.webhook.incoming.forwarded.failed',
     WEBHOOK_OUTGOING_SUCCESS = 'nango.webhook.outgoing.success',


### PR DESCRIPTION
Adds a middleware that rate-limits `POST /webhook/:environmentUuid/:providerConfigKey` using `rate-limiter-flexible`, keyed on `(environmentUuid, providerConfigKey)`.

**Shipped in shadow mode**: breaches log a warning and emit `nango.webhook.incoming.rateLimited{enforced:false}` but do not return `429`. Per-environment bypass via `webhook-ingress-rate-limit-bypass`.

Default 4000/min per `(env, providerConfigKey)`, tunable via `NANGO_WEBHOOK_INGRESS_RATE_LIMIT_PER_MIN` (0 disables entirely).

Also adds `accountId` + `provider` dimensions to `WEBHOOK_INCOMING_RECEIVED` so unsampled per-key ingress data is available to size the limit before turning enforcement on.
