### PR TITLE
fix: soft delete syncs when disabled

### DIFF
--- a/packages/server/lib/controllers/v1/flows/id/patchDisable.ts
+++ b/packages/server/lib/controllers/v1/flows/id/patchDisable.ts
@@ -62,7 +62,7 @@ export const patchFlowDisable = asyncWrapper<PatchFlowDisable>(async (req, res) 
     await errorNotificationService.sync.clearBySyncConfig({ sync_config_id: valParams.data.id });
 
     if (updated > 0) {
-        await syncManager.pauseSchedules({ syncConfigId: valParams.data.id, environmentId: environment.id, orchestrator });
+        await syncManager.pauseSyncs({ syncConfigId: valParams.data.id, environmentId: environment.id, orchestrator });
         res.status(200).send({ data: { success: true } });
     } else {
         res.status(400).send({ data: { success: false } });

--- a/packages/server/lib/crons/trial.ts
+++ b/packages/server/lib/crons/trial.ts
@@ -106,7 +106,7 @@ export async function exec(): Promise<void> {
                     const updated = await disableScriptConfig({ id: sync.id, environmentId: sync.environment_id });
                     await errorNotificationService.sync.clearBySyncConfig({ sync_config_id: sync.id });
                     if (updated > 0) {
-                        await syncManager.pauseSchedules({ syncConfigId: sync.id, environmentId: sync.environment_id, orchestrator });
+                        await syncManager.pauseSyncs({ syncConfigId: sync.id, environmentId: sync.environment_id, orchestrator });
                     }
                 }
             }

--- a/packages/shared/lib/services/sync/manager.service.ts
+++ b/packages/shared/lib/services/sync/manager.service.ts
@@ -4,7 +4,15 @@ import { getCheckpointKey, getLogger, stringifyError } from '@nangohq/utils';
 import connectionService from '../connection.service.js';
 import { deleteSyncConfig, deleteSyncFilesForConfig, getSyncConfig, getSyncConfigByParams } from './config/config.service.js';
 import { getLatestSyncJob } from './job.service.js';
-import { createSync, getSync, getSyncsByConnectionId, getSyncsByProviderConfigKey, getSyncsBySyncConfigId, softDeleteSync } from './sync.service.js';
+import {
+    createSync,
+    getSync,
+    getSyncsByConnectionId,
+    getSyncsByProviderConfigKey,
+    getSyncsBySyncConfigId,
+    softDeleteSync,
+    undeleteSync
+} from './sync.service.js';
 import { SyncJobsType, SyncStatus } from '../../models/Sync.js';
 import { NangoError } from '../../utils/error.js';
 import accountService from '../account.service.js';
@@ -93,11 +101,13 @@ export class SyncManagerService {
                 continue;
             }
 
-            const existingSync = await getSync({ connectionId, name: syncName, variant: syncVariant });
-            if (existingSync) {
-                await orchestrator.unpauseSync({ syncId: existingSync.id, environmentId: nangoConnection.environment_id });
+            // Resume soft-deleted syncs if needed
+            const existing = await undeleteSync({ connectionId, name: syncName, variant: syncVariant });
+            if (existing.isOk()) {
+                await orchestrator.unpauseSync({ syncId: existing.value.id, environmentId: nangoConnection.environment_id });
                 continue;
             }
+            // If the sync doesn't exist, create it and schedule it
             const sync = await createSync({ connectionId, syncConfig, variant: syncVariant });
             if (sync) {
                 await orchestrator.scheduleSync({
@@ -146,11 +156,13 @@ export class SyncManagerService {
                 if (!syncConfig) {
                     continue;
                 }
-                const existingSync = await getSync({ connectionId: connection.id, name: syncName, variant: syncVariant });
-                if (existingSync) {
-                    await orchestrator.unpauseSync({ syncId: existingSync.id, environmentId: connection.environment_id });
+                // Resume soft-deleted syncs if needed
+                const existing = await undeleteSync({ connectionId: connection.id, name: syncName, variant: syncVariant });
+                if (existing.isOk()) {
+                    await orchestrator.unpauseSync({ syncId: existing.value.id, environmentId: connection.environment_id });
                     continue;
                 }
+                // If the sync doesn't exist, create it and schedule it
                 const sync = await createSync({ connectionId: connection.id, syncConfig, variant: syncVariant });
                 if (sync) {
                     await orchestrator.scheduleSync({
@@ -497,7 +509,7 @@ export class SyncManagerService {
             });
         }
     }
-    public async pauseSchedules({
+    public async pauseSyncs({
         syncConfigId,
         environmentId,
         orchestrator
@@ -508,9 +520,13 @@ export class SyncManagerService {
     }): Promise<void> {
         const syncs = await getSyncsBySyncConfigId(environmentId, syncConfigId);
         for (const sync of syncs) {
-            const res = await orchestrator.pauseSync({ syncId: sync.id, environmentId });
-            if (res.isErr()) {
-                logger.error('Failed to delete schedule for sync', { syncId: sync.id, error: res.error });
+            const deletingSync = await softDeleteSync(sync.id);
+            if (deletingSync.isErr()) {
+                logger.error('Failed to soft delete sync', { syncId: sync.id });
+            }
+            const pausingSchedule = await orchestrator.pauseSync({ syncId: sync.id, environmentId });
+            if (pausingSchedule.isErr()) {
+                logger.error('Failed to delete schedule for sync', { syncId: sync.id, error: pausingSchedule.error });
             }
         }
     }

--- a/packages/shared/lib/services/sync/sync.service.ts
+++ b/packages/shared/lib/services/sync/sync.service.ts
@@ -334,9 +334,57 @@ export const verifyOwnership = async (nangoConnectionId: number, environment_id:
     return true;
 };
 
-export const softDeleteSync = async (syncId: string): Promise<string> => {
-    await schema().from<Sync>(TABLE).where({ id: syncId, deleted: false }).update({ deleted: true, deleted_at: new Date() });
-    return syncId;
+export const softDeleteSync = async (syncId: string): Promise<Result<string>> => {
+    try {
+        await schema().from<Sync>(TABLE).where({ id: syncId, deleted: false }).update({ deleted: true, deleted_at: new Date() });
+        return Ok(syncId);
+    } catch (err) {
+        return Err(new Error(`Failed to soft delete sync with id ${syncId}: ${stringifyError(err)}`));
+    }
+};
+
+export const undeleteSync = async ({ connectionId, name, variant }: { connectionId: number; name: string; variant: string }): Promise<Result<Sync>> => {
+    try {
+        // Return existing non-deleted sync if one exists
+        const [existing] = await db.knex.from<Sync>(TABLE).where({
+            nango_connection_id: connectionId,
+            name,
+            variant,
+            deleted: false
+        });
+
+        if (existing) {
+            return Ok(existing);
+        }
+
+        // Undelete the most recently deleted one
+        const [res] = await db.knex
+            .from<Sync>(TABLE)
+            .where(
+                'id',
+                '=',
+                db.knex
+                    .from(TABLE)
+                    .select('id')
+                    .where({
+                        nango_connection_id: connectionId,
+                        name,
+                        variant,
+                        deleted: true
+                    })
+                    .orderBy('deleted_at', 'desc')
+                    .limit(1)
+            )
+            .update({ deleted: false, deleted_at: null })
+            .returning('*');
+
+        if (res) {
+            return Ok(res);
+        }
+        return Err(new Error(`No sync to undelete for connection ${connectionId} with name ${name} and variant ${variant}`));
+    } catch (err) {
+        return Err(new Error(`Failed to undelete sync for connection ${connectionId} with name ${name} and variant ${variant}: ${stringifyError(err)}`));
+    }
 };
 
 export const findSyncByConnections = async (connectionIds: number[], sync_name: string): Promise<Sync[]> => {


### PR DESCRIPTION
When a sync is being disabled we currently only pause the schedule without touching the sync entry, which make it look like the sync is still active.
In next PR I will run a migration to soft-delete all existing syncs where sync config is disabled, as well as updating the cleanup background job to hard delete syncs and their records after a small delay

<!-- Describe the problem and your solution --> 

<!-- Issue ticket number and link (if applicable) -->

<!-- Testing instructions (skip if just adding/editing providers) -->

