### PR TITLE
fix(providers): remove verification script from aws-multi-service

### DIFF
--- a/packages/providers/providers.yaml
+++ b/packages/providers/providers.yaml
@@ -2067,7 +2067,6 @@ aws-multi-service:
         retry:
             at:
                 - 'x-ratelimit-reset'
-    credentials_verification_script: awsIamCredentialsVerification
     docs: https://nango.dev/docs/api-integrations/aws-multi-service
     docs_connect: https://nango.dev/docs/api-integrations/aws-multi-service/connect
     credentials:


### PR DESCRIPTION
## Describe the problem and your solution
- The `aws-multi-service` provider is intended for narrowly scoped iam credentials limited to specific AWS services and regions. Because credential validation can fail for valid service-specific configurations, we are removing this verification step to avoid incorrectly rejecting supported setups.

<!-- Issue ticket number and link (if applicable) -->

<!-- Testing instructions (skip if just adding/editing providers) -->

