### PR TITLE
feat(webhook): discard webhook messages from the queue if they are old 5/5

### DIFF
--- a/packages/jobs/lib/app.ts
+++ b/packages/jobs/lib/app.ts
@@ -48,7 +48,8 @@ try {
               consumerConcurrency: envs.NANGO_TASK_DISPATCH_CONSUMER_CONCURRENCY,
               maxMessages: envs.NANGO_TASK_DISPATCH_MAX_MESSAGES,
               waitTimeSeconds: envs.NANGO_TASK_DISPATCH_WAIT_TIME_SECONDS,
-              visibilityTimeoutSeconds: envs.NANGO_TASK_DISPATCH_VISIBILITY_TIMEOUT_SECONDS
+              visibilityTimeoutSeconds: envs.NANGO_TASK_DISPATCH_VISIBILITY_TIMEOUT_SECONDS,
+              maxAgeMs: envs.NANGO_TASK_DISPATCH_MAX_AGE_SECONDS * 1000
           })
         : undefined;
 

--- a/packages/jobs/lib/webhook/dispatch-queue/consumer.ts
+++ b/packages/jobs/lib/webhook/dispatch-queue/consumer.ts
@@ -2,6 +2,7 @@ import { DeleteMessageCommand, ReceiveMessageCommand, SQSClient } from '@aws-sdk
 import tracer from 'dd-trace';
 import * as z from 'zod';
 
+import { logContextGetter } from '@nangohq/logs';
 import { isDuplicateTaskNameClientError, jsonSchema } from '@nangohq/nango-orchestrator';
 import { Err, Ok, getLogger, metrics, report } from '@nangohq/utils';
 
@@ -42,6 +43,7 @@ export interface DispatchQueueConsumerProps {
     maxMessages: number;
     waitTimeSeconds: number;
     visibilityTimeoutSeconds: number;
+    maxAgeMs: number;
     sqs?: SQSClient;
 }
 
@@ -54,6 +56,7 @@ export class DispatchQueueConsumer {
     private readonly maxMessages: number;
     private readonly waitTimeSeconds: number;
     private readonly visibilityTimeoutSeconds: number;
+    private readonly maxAgeMs: number;
     private readonly abortController = new AbortController();
     private loopPromises: Promise<void>[] = [];
 
@@ -65,6 +68,7 @@ export class DispatchQueueConsumer {
         this.maxMessages = props.maxMessages;
         this.waitTimeSeconds = props.waitTimeSeconds;
         this.visibilityTimeoutSeconds = props.visibilityTimeoutSeconds;
+        this.maxAgeMs = props.maxAgeMs;
         this.sqs = props.sqs ?? new SQSClient(envs.AWS_REGION ? { region: envs.AWS_REGION } : {});
     }
 
@@ -145,7 +149,17 @@ export class DispatchQueueConsumer {
 
                 const sentTimestampMs = Number(msg.Attributes?.['SentTimestamp'] ?? '0');
                 if (sentTimestampMs > 0) {
-                    metrics.duration(metrics.Types.WEBHOOK_DISPATCH_DWELL_MS, Date.now() - sentTimestampMs, { provider: message.provider });
+                    const dwellMs = Date.now() - sentTimestampMs;
+                    metrics.duration(metrics.Types.WEBHOOK_DISPATCH_DWELL_MS, dwellMs, { provider: message.provider });
+
+                    if (this.maxAgeMs > 0 && dwellMs > this.maxAgeMs) {
+                        span.setTag('stale', true);
+                        metrics.increment(metrics.Types.WEBHOOK_DISPATCH_STALE, 1, { accountId: message.accountId });
+                        const logCtx = logContextGetter.get({ id: message.activityLogId, accountId: message.accountId });
+                        await logCtx.warn('Webhook was discarded: it spent too long in the queue and was not processed.', { dwell_ms: dwellMs });
+                        await this.tryDeleteMessage(msg.ReceiptHandle);
+                        return;
+                    }
                 }
 
                 const scheduleRes = await this.orchestratorClient.executeWebhook({

--- a/packages/jobs/lib/webhook/dispatch-queue/consumer.unit.test.ts
+++ b/packages/jobs/lib/webhook/dispatch-queue/consumer.unit.test.ts
@@ -61,6 +61,7 @@ function makeHarness(
         messages?: WebhookDispatchMessage[];
         badBody?: string;
         consumerConcurrency?: number;
+        maxAgeMs?: number;
         sqsSend?: ReturnType<typeof vi.fn>;
     } = {}
 ): Harness {
@@ -102,7 +103,8 @@ function makeHarness(
         consumerConcurrency: opts.consumerConcurrency ?? 1,
         maxMessages: 10,
         waitTimeSeconds: 0,
-        visibilityTimeoutSeconds: 30
+        visibilityTimeoutSeconds: 30,
+        maxAgeMs: opts.maxAgeMs ?? 0
     });
 
     return { consumer, sqsSend, sqsDestroy, orchestratorExecuteWebhook };
@@ -259,6 +261,17 @@ describe('DispatchQueueConsumer', () => {
         const deleteCalls = h.sqsSend.mock.calls.filter((c) => c[0] instanceof DeleteMessageCommand);
         expect(deleteCalls).toHaveLength(1);
         expect(deleteCalls[0]?.[1]).toBeUndefined();
+    });
+
+    it('deletes a stale message without calling orchestrator', async () => {
+        const h = makeHarness({ messages: [buildMessage()], maxAgeMs: 100 });
+        // SentTimestamp in makeHarness is Date.now() - 500, which exceeds maxAgeMs of 100ms
+        await runOnce(h, () => {
+            expect(getDeleteCalls(h)).toHaveLength(1);
+        });
+
+        expect(h.orchestratorExecuteWebhook).not.toHaveBeenCalled();
+        expect(getDeleteCalls(h)).toHaveLength(1);
     });
 
     it('starts one poll loop per configured consumerConcurrency', async () => {

--- a/packages/server/lib/webhook/internal-nango.unit.test.ts
+++ b/packages/server/lib/webhook/internal-nango.unit.test.ts
@@ -127,7 +127,7 @@ describe('InternalNango queue dispatch', () => {
             { id: 12, connection_id: 'conn-2', provider_config_key: 'github-dev', environment_id: 2, metadata: null }
         ]);
         mocks.getSyncConfigsByConfigIdForWebhook.mockResolvedValue([{ id: 21, sync_name: 'sync-1', webhook_subscriptions: ['push'] }]);
-        mocks.triggerWebhook.mockResolvedValue(undefined);
+        mocks.triggerWebhook.mockResolvedValue({ isErr: () => false });
     });
 
     it('logs queued successes and marks failed publishes as failed operations', async () => {

--- a/packages/server/lib/webhook/internal-nango.unit.test.ts
+++ b/packages/server/lib/webhook/internal-nango.unit.test.ts
@@ -10,6 +10,7 @@ const mocks = vi.hoisted(() => {
         triggerWebhook: vi.fn(),
         increment: vi.fn(),
         report: vi.fn(),
+        metricsIncrement: vi.fn(),
         getConnectionsByEnvironmentAndConfig: vi.fn(),
         getSyncConfigsByConfigIdForWebhook: vi.fn()
     };
@@ -126,7 +127,7 @@ describe('InternalNango queue dispatch', () => {
             { id: 12, connection_id: 'conn-2', provider_config_key: 'github-dev', environment_id: 2, metadata: null }
         ]);
         mocks.getSyncConfigsByConfigIdForWebhook.mockResolvedValue([{ id: 21, sync_name: 'sync-1', webhook_subscriptions: ['push'] }]);
-        mocks.triggerWebhook.mockResolvedValue({ isErr: () => false });
+        mocks.triggerWebhook.mockResolvedValue(undefined);
     });
 
     it('logs queued successes and marks failed publishes as failed operations', async () => {

--- a/packages/utils/lib/environment/parse.ts
+++ b/packages/utils/lib/environment/parse.ts
@@ -550,6 +550,7 @@ export const ENVS = z.object({
     NANGO_TASK_DISPATCH_CONSUMER_CONCURRENCY: z.coerce.number().min(1).optional().default(50),
     NANGO_TASK_DISPATCH_PUBLISH_BATCH_SIZE: z.coerce.number().min(1).max(10).optional().default(10),
     NANGO_TASK_DISPATCH_PUBLISH_CONCURRENCY: z.coerce.number().min(1).optional().default(10),
+    NANGO_TASK_DISPATCH_MAX_AGE_SECONDS: z.coerce.number().min(0).optional().default(7200),
 
     // E2B sandboxes
     E2B_API_KEY: z.string().optional(),

--- a/packages/utils/lib/telemetry/metrics.ts
+++ b/packages/utils/lib/telemetry/metrics.ts
@@ -76,6 +76,7 @@ export enum Types {
     WEBHOOK_DISPATCH_CONSUME_SUCCESS = 'nango.webhook.dispatch_queue.consume.success',
     WEBHOOK_DISPATCH_CONSUME_FAILURE = 'nango.webhook.dispatch_queue.consume.failure',
     WEBHOOK_DISPATCH_POISON_PILL = 'nango.webhook.dispatch_queue.poison_pill',
+    WEBHOOK_DISPATCH_STALE = 'nango.webhook.dispatch_queue.stale',
     WEBHOOK_DISPATCH_DWELL_MS = 'nango.webhook.dispatch_queue.dwell_ms',
 
     ORCH_TASKS_CREATED = 'nango.orch.tasks.created',


### PR DESCRIPTION
Webhook SQS messages older than 2 hours are now discarded at consumption time rather than being scheduled into the orchestrator.

When a message is received, its dwell time (already computed for the existing `dwell_ms` metric) is compared against a configurable max age. Messages that exceed it are deleted from the queue, emits `nango.webhook.dispatch_queue.stale` metric tagged by provider. Setting `NANGO_TASK_DISPATCH_MAX_AGE_SECONDS=0` disables the check.

New env var: `NANGO_TASK_DISPATCH_MAX_AGE_SECONDS` (default: 7200)

<!-- Describe the problem and your solution --> 

<!-- Issue ticket number and link (if applicable) -->
NAN-5416
<!-- Testing instructions (skip if just adding/editing providers) -->

