### PR TITLE
chore: hard delete syncs and associated data after 1 day

### DIFF
--- a/packages/database/lib/migrations/20260429212200_fix_disabled_syncs.cjs
+++ b/packages/database/lib/migrations/20260429212200_fix_disabled_syncs.cjs
@@ -1,0 +1,22 @@
+/**
+ * @param {import('knex').Knex} knex
+ */
+exports.up = async function (knex) {
+    // fix: soft-delete syncs when sync config is disabled or doesn't exist anymore
+    await knex.raw(`
+        UPDATE _nango_syncs s
+        SET deleted = true,
+            deleted_at = CURRENT_TIMESTAMP
+        WHERE s.deleted = false
+        AND NOT EXISTS (
+            SELECT 1 FROM _nango_sync_configs sc
+            WHERE sc.id = s.sync_config_id
+            AND sc.deleted = false
+            AND sc.enabled = true
+        );
+    `);
+};
+
+exports.down = async function () {};
+
+exports.config = { transaction: true };

--- a/packages/server/lib/controllers/v1/flows/id/patchDisable.ts
+++ b/packages/server/lib/controllers/v1/flows/id/patchDisable.ts
@@ -62,7 +62,7 @@ export const patchFlowDisable = asyncWrapper<PatchFlowDisable>(async (req, res) 
     await errorNotificationService.sync.clearBySyncConfig({ sync_config_id: valParams.data.id });
 
     if (updated > 0) {
-        await syncManager.pauseSchedules({ syncConfigId: valParams.data.id, environmentId: environment.id, orchestrator });
+        await syncManager.pauseSyncs({ syncConfigId: valParams.data.id, environmentId: environment.id, orchestrator });
         res.status(200).send({ data: { success: true } });
     } else {
         res.status(400).send({ data: { success: false } });

--- a/packages/server/lib/crons/delete/deleteSyncData.ts
+++ b/packages/server/lib/crons/delete/deleteSyncData.ts
@@ -8,7 +8,7 @@ import type { BatchDeleteSharedOptions } from './batchDelete.js';
 import type { Sync } from '@nangohq/shared';
 import type { ActiveLog, DBSyncConfig } from '@nangohq/types';
 
-export async function deleteSyncData(sync: Sync, syncConfig: DBSyncConfig, opts: BatchDeleteSharedOptions) {
+export async function deleteSyncData(sync: Sync, syncConfig: DBSyncConfig | null, opts: BatchDeleteSharedOptions) {
     const { logger, deadline, limit } = opts;
     logger.info('Deleting sync...', sync.id, sync.name);
 
@@ -35,29 +35,30 @@ export async function deleteSyncData(sync: Sync, syncConfig: DBSyncConfig, opts:
         }
     });
 
-    for (const model of syncConfig.models) {
-        // delete records for each model
-        await batchDelete({
-            name: 'records < sync',
-            deadline,
-            limit,
-            logger,
-            deleteFn: async () => {
-                const res = await records.deleteRecords({
-                    connectionId: sync.nango_connection_id,
-                    environmentId: syncConfig.environment_id,
-                    model,
-                    mode: 'hard',
-                    batchSize: limit
-                });
-                if (res.isOk() && res.value.count) {
-                    logger.info('deleted', res.value.count, 'records for model', model);
-                    return res.value.count;
-                }
+    if (syncConfig) {
+        for (const model of syncConfig.models) {
+            await batchDelete({
+                name: 'records < sync',
+                deadline,
+                limit,
+                logger,
+                deleteFn: async () => {
+                    const res = await records.deleteRecords({
+                        connectionId: sync.nango_connection_id,
+                        environmentId: syncConfig.environment_id,
+                        model,
+                        mode: 'hard',
+                        batchSize: limit
+                    });
+                    if (res.isOk() && res.value.count) {
+                        logger.info('deleted', res.value.count, 'records for model', model);
+                        return res.value.count;
+                    }
 
-                return 0;
-            }
-        });
+                    return 0;
+                }
+            });
+        }
     }
 
     // delete sync

--- a/packages/server/lib/crons/deleteOldData.ts
+++ b/packages/server/lib/crons/deleteOldData.ts
@@ -4,7 +4,15 @@ import * as cron from 'node-cron';
 import db from '@nangohq/database';
 import { deleteExpiredPrivateKeys } from '@nangohq/keystore';
 import { getLocking } from '@nangohq/kvstore';
-import { configService, connectionService, deleteExpiredInvitations, deleteJobsByDate, environmentService, getSoftDeletedSyncConfig } from '@nangohq/shared';
+import {
+    configService,
+    connectionService,
+    deleteExpiredInvitations,
+    deleteJobsByDate,
+    environmentService,
+    getSoftDeletedSyncConfig,
+    getSoftDeletedSyncs
+} from '@nangohq/shared';
 import { getLogger, metrics, report } from '@nangohq/utils';
 
 import { envs } from '../env.js';
@@ -15,6 +23,7 @@ import { deleteConnectionData } from './delete/deleteConnectionData.js';
 import { deleteEnvironmentData } from './delete/deleteEnvironmentData.js';
 import { deleteProviderConfigData } from './delete/deleteProviderConfigData.js';
 import { deleteSyncConfigData } from './delete/deleteSyncConfigData.js';
+import { deleteSyncData } from './delete/deleteSyncData.js';
 
 import type { BatchDeleteSharedOptions } from './delete/batchDelete.js';
 import type { Lock } from '@nangohq/kvstore';
@@ -30,6 +39,7 @@ const deleteConnectionSessionOlderThan = envs.CRON_DELETE_OLD_CONNECT_SESSION_MA
 const deletePrivateKeysOlderThan = envs.CRON_DELETE_OLD_PRIVATE_KEYS_MAX_DAYS;
 const deleteOauthSessionOlderThan = envs.CRON_DELETE_OLD_OAUTH_SESSION_MAX_DAYS;
 const deleteInvitationsOlderThan = envs.CRON_DELETE_OLD_INVITATIONS_MAX_DAYS;
+const deleteSyncsOlderThan = envs.CRON_DELETE_OLD_SYNCS_MAX_DAYS;
 const deleteConfigsOlderThan = envs.CRON_DELETE_OLD_CONFIGS_MAX_DAYS;
 const deleteSyncConfigsOlderThan = envs.CRON_DELETE_OLD_SYNC_CONFIGS_MAX_DAYS;
 const deleteConnectionsOlderThan = envs.CRON_DELETE_OLD_CONNECTIONS_MAX_DAYS;
@@ -115,6 +125,23 @@ export async function exec(): Promise<void> {
             ...opts,
             name: 'invitations',
             deleteFn: async () => await deleteExpiredInvitations({ limit, olderThan: deleteInvitationsOlderThan })
+        });
+
+        // Delete syncs and all associated data
+        await batchDelete({
+            ...opts,
+            name: 'sync',
+            deleteFn: async () => {
+                const syncs = await getSoftDeletedSyncs({ limit, olderThan: deleteSyncsOlderThan });
+                if (syncs.isErr()) {
+                    throw syncs.error;
+                }
+                for (const { sync, syncConfig } of syncs.value) {
+                    await deleteSyncData(sync, syncConfig, opts);
+                }
+
+                return syncs.value.length;
+            }
         });
 
         // Delete integrations and all associated data

--- a/packages/server/lib/crons/trial.ts
+++ b/packages/server/lib/crons/trial.ts
@@ -106,7 +106,7 @@ export async function exec(): Promise<void> {
                     const updated = await disableScriptConfig({ id: sync.id, environmentId: sync.environment_id });
                     await errorNotificationService.sync.clearBySyncConfig({ sync_config_id: sync.id });
                     if (updated > 0) {
-                        await syncManager.pauseSchedules({ syncConfigId: sync.id, environmentId: sync.environment_id, orchestrator });
+                        await syncManager.pauseSyncs({ syncConfigId: sync.id, environmentId: sync.environment_id, orchestrator });
                     }
                 }
             }

--- a/packages/shared/lib/services/sync/manager.service.ts
+++ b/packages/shared/lib/services/sync/manager.service.ts
@@ -4,7 +4,15 @@ import { getCheckpointKey, getLogger, stringifyError } from '@nangohq/utils';
 import connectionService from '../connection.service.js';
 import { deleteSyncConfig, deleteSyncFilesForConfig, getSyncConfig, getSyncConfigByParams } from './config/config.service.js';
 import { getLatestSyncJob } from './job.service.js';
-import { createSync, getSync, getSyncsByConnectionId, getSyncsByProviderConfigKey, getSyncsBySyncConfigId, softDeleteSync } from './sync.service.js';
+import {
+    createSync,
+    getSync,
+    getSyncsByConnectionId,
+    getSyncsByProviderConfigKey,
+    getSyncsBySyncConfigId,
+    softDeleteSync,
+    undeleteSync
+} from './sync.service.js';
 import { SyncJobsType, SyncStatus } from '../../models/Sync.js';
 import { NangoError } from '../../utils/error.js';
 import accountService from '../account.service.js';
@@ -93,11 +101,13 @@ export class SyncManagerService {
                 continue;
             }
 
-            const existingSync = await getSync({ connectionId, name: syncName, variant: syncVariant });
-            if (existingSync) {
-                await orchestrator.unpauseSync({ syncId: existingSync.id, environmentId: nangoConnection.environment_id });
+            // Resume soft-deleted syncs if needed
+            const existing = await undeleteSync({ connectionId, name: syncName, variant: syncVariant });
+            if (existing.isOk()) {
+                await orchestrator.unpauseSync({ syncId: existing.value.id, environmentId: nangoConnection.environment_id });
                 continue;
             }
+            // If the sync doesn't exist, create it and schedule it
             const sync = await createSync({ connectionId, syncConfig, variant: syncVariant });
             if (sync) {
                 await orchestrator.scheduleSync({
@@ -146,11 +156,13 @@ export class SyncManagerService {
                 if (!syncConfig) {
                     continue;
                 }
-                const existingSync = await getSync({ connectionId: connection.id, name: syncName, variant: syncVariant });
-                if (existingSync) {
-                    await orchestrator.unpauseSync({ syncId: existingSync.id, environmentId: connection.environment_id });
+                // Resume soft-deleted syncs if needed
+                const existing = await undeleteSync({ connectionId: connection.id, name: syncName, variant: syncVariant });
+                if (existing.isOk()) {
+                    await orchestrator.unpauseSync({ syncId: existing.value.id, environmentId: connection.environment_id });
                     continue;
                 }
+                // If the sync doesn't exist, create it and schedule it
                 const sync = await createSync({ connectionId: connection.id, syncConfig, variant: syncVariant });
                 if (sync) {
                     await orchestrator.scheduleSync({
@@ -497,7 +509,7 @@ export class SyncManagerService {
             });
         }
     }
-    public async pauseSchedules({
+    public async pauseSyncs({
         syncConfigId,
         environmentId,
         orchestrator
@@ -508,9 +520,13 @@ export class SyncManagerService {
     }): Promise<void> {
         const syncs = await getSyncsBySyncConfigId(environmentId, syncConfigId);
         for (const sync of syncs) {
-            const res = await orchestrator.pauseSync({ syncId: sync.id, environmentId });
-            if (res.isErr()) {
-                logger.error('Failed to delete schedule for sync', { syncId: sync.id, error: res.error });
+            const deletingSync = await softDeleteSync(sync.id);
+            if (deletingSync.isErr()) {
+                logger.error('Failed to soft delete sync', { syncId: sync.id });
+            }
+            const pausingSchedule = await orchestrator.pauseSync({ syncId: sync.id, environmentId });
+            if (pausingSchedule.isErr()) {
+                logger.error('Failed to delete schedule for sync', { syncId: sync.id, error: pausingSchedule.error });
             }
         }
     }

--- a/packages/shared/lib/services/sync/sync.service.ts
+++ b/packages/shared/lib/services/sync/sync.service.ts
@@ -639,6 +639,33 @@ export async function hardDeleteSync(id: string) {
     await db.knex.from<Sync>('_nango_syncs').where({ id }).delete();
 }
 
+export async function getSoftDeletedSyncs({
+    limit,
+    olderThan
+}: {
+    limit: number;
+    olderThan: number;
+}): Promise<Result<{ sync: Sync; syncConfig: DBSyncConfig | null }[]>> {
+    try {
+        const dateThreshold = new Date();
+        dateThreshold.setDate(dateThreshold.getDate() - olderThan);
+
+        const res = await db.knex
+            .select<
+                { sync: Sync; syncConfig: DBSyncConfig | null }[]
+            >(db.knex.raw('row_to_json(_nango_syncs.*) as sync'), db.knex.raw('CASE WHEN _nango_sync_configs.id IS NULL THEN NULL ELSE row_to_json(_nango_sync_configs.*) END as "syncConfig"'))
+            .from<Sync>('_nango_syncs')
+            .leftJoin('_nango_sync_configs', '_nango_sync_configs.id', '_nango_syncs.sync_config_id')
+            .where('_nango_syncs.deleted', true)
+            .andWhere('_nango_syncs.deleted_at', '<=', dateThreshold.toISOString())
+            .limit(limit);
+
+        return Ok(res);
+    } catch (err) {
+        return Err(new Error(`Failed to get soft deleted syncs: ${stringifyError(err)}`));
+    }
+}
+
 export function normalizedSyncParams(syncs: (string | { name: string; variant: string })[]): Result<{ syncName: string; syncVariant: string }[]> {
     if (!syncs) {
         return Err('Missing sync names');

--- a/packages/shared/lib/services/sync/sync.service.ts
+++ b/packages/shared/lib/services/sync/sync.service.ts
@@ -334,9 +334,57 @@ export const verifyOwnership = async (nangoConnectionId: number, environment_id:
     return true;
 };
 
-export const softDeleteSync = async (syncId: string): Promise<string> => {
-    await schema().from<Sync>(TABLE).where({ id: syncId, deleted: false }).update({ deleted: true, deleted_at: new Date() });
-    return syncId;
+export const softDeleteSync = async (syncId: string): Promise<Result<string>> => {
+    try {
+        await schema().from<Sync>(TABLE).where({ id: syncId, deleted: false }).update({ deleted: true, deleted_at: new Date() });
+        return Ok(syncId);
+    } catch (err) {
+        return Err(new Error(`Failed to soft delete sync with id ${syncId}: ${stringifyError(err)}`));
+    }
+};
+
+export const undeleteSync = async ({ connectionId, name, variant }: { connectionId: number; name: string; variant: string }): Promise<Result<Sync>> => {
+    try {
+        // Return existing non-deleted sync if one exists
+        const [existing] = await db.knex.from<Sync>(TABLE).where({
+            nango_connection_id: connectionId,
+            name,
+            variant,
+            deleted: false
+        });
+
+        if (existing) {
+            return Ok(existing);
+        }
+
+        // Undelete the most recently deleted one
+        const [res] = await db.knex
+            .from<Sync>(TABLE)
+            .where(
+                'id',
+                '=',
+                db.knex
+                    .from(TABLE)
+                    .select('id')
+                    .where({
+                        nango_connection_id: connectionId,
+                        name,
+                        variant,
+                        deleted: true
+                    })
+                    .orderBy('deleted_at', 'desc')
+                    .limit(1)
+            )
+            .update({ deleted: false, deleted_at: null })
+            .returning('*');
+
+        if (res) {
+            return Ok(res);
+        }
+        return Err(new Error(`No sync to undelete for connection ${connectionId} with name ${name} and variant ${variant}`));
+    } catch (err) {
+        return Err(new Error(`Failed to undelete sync for connection ${connectionId} with name ${name} and variant ${variant}: ${stringifyError(err)}`));
+    }
 };
 
 export const findSyncByConnections = async (connectionIds: number[], sync_name: string): Promise<Sync[]> => {

--- a/packages/utils/lib/environment/parse.ts
+++ b/packages/utils/lib/environment/parse.ts
@@ -72,6 +72,7 @@ export const ENVS = z.object({
     CRON_DELETE_OLD_PRIVATE_KEYS_MAX_DAYS: z.coerce.number().optional().default(31),
     CRON_DELETE_OLD_OAUTH_SESSION_MAX_DAYS: z.coerce.number().optional().default(2),
     CRON_DELETE_OLD_INVITATIONS_MAX_DAYS: z.coerce.number().optional().default(2),
+    CRON_DELETE_OLD_SYNCS_MAX_DAYS: z.coerce.number().optional().default(1),
     CRON_DELETE_OLD_CONFIGS_MAX_DAYS: z.coerce.number().optional().default(31),
     CRON_DELETE_OLD_SYNC_CONFIGS_MAX_DAYS: z.coerce.number().optional().default(31),
     CRON_DELETE_OLD_CONNECTIONS_MAX_DAYS: z.coerce.number().optional().default(31),


### PR DESCRIPTION
follow-up of https://github.com/NangoHQ/nango/pull/5989

- migration to soft-delete existing syncs when sync config is disabled (or non existing)
- hard delete syncs and associated data after 1 day. We currently don't delete syncs and its associated records when a sync config is disabled, causing the records to be billed. With this commit syncs (and records) will be hard deleted after one day as part of the old delete cron job so it is not done inline and prevent deleting data in case of misclick 
