### PR TITLE
fix: don't html-encode team name in invite email subject

### DIFF
--- a/packages/server/lib/helpers/email.ts
+++ b/packages/server/lib/helpers/email.ts
@@ -54,7 +54,7 @@ export async function sendInviteEmail({
     const emailClient = EmailClient.getInstance();
     await emailClient.send(
         email,
-        `You're Invited! Join "${he.encode(account.name)}" on Nango`,
+        `You're Invited! Join "${account.name}" on Nango`,
         `<p>Hi,</p>
 
 <p>${he.encode(user.name)} invites you to join "${he.encode(account.name)}" on Nango.</p>


### PR DESCRIPTION
## Describe the problem and your solution

- Avoid html-encoding the team name in the invite email subject. Currently, invite emails for teams with special characters in their names (e.g. Acme & Co) were displaying Acme &amp; Co in the subject line.

<!-- Issue ticket number and link (if applicable) -->

<!-- Testing instructions (skip if just adding/editing providers) -->

