### PR TITLE
fix(test): use isError type guard in apiKeys integration tests

### DIFF
--- a/packages/server/lib/controllers/v1/environment/apiKeys.integration.test.ts
+++ b/packages/server/lib/controllers/v1/environment/apiKeys.integration.test.ts
@@ -3,7 +3,7 @@ import { afterAll, beforeAll, describe, expect, it } from 'vitest';
 import db from '@nangohq/database';
 import { seeders } from '@nangohq/shared';
 
-import { authenticateUser, isSuccess, runServer, shouldBeProtected } from '../../../utils/tests.js';
+import { authenticateUser, isError, isSuccess, runServer, shouldBeProtected } from '../../../utils/tests.js';
 
 let api: Awaited<ReturnType<typeof runServer>>;
 
@@ -127,7 +127,8 @@ describe('API Keys endpoints', () => {
             });
 
             expect(res.res.status).toBe(400);
-            expect((res.json as any).error.code).toBe('resource_capped');
+            isError(res.json);
+            expect(res.json.error.code).toBe('resource_capped');
         });
     });
 
@@ -199,6 +200,7 @@ describe('API Keys endpoints', () => {
             );
 
             expect(patchRes.res.status).toBe(404);
+            isError(patchRes.json);
             expect(patchRes.json.error.code).toBe('not_found');
         });
     });
@@ -304,6 +306,7 @@ describe('API Keys endpoints', () => {
             );
 
             expect(deleteRes.res.status).toBe(404);
+            isError(deleteRes.json);
             expect(deleteRes.json.error.code).toBe('not_found');
         });
     });


### PR DESCRIPTION
## Describe the problem and your solution 

- use isError type guard in apiKeys integration tests

<!-- Issue ticket number and link (if applicable) -->

<!-- Testing instructions (skip if just adding/editing providers) -->

