### PR TITLE
feat(webhook): fan-out unauthenticated routing by metadata.stress_test

### DIFF
--- a/packages/server/lib/webhook/unauthenticated-webhook-routing.ts
+++ b/packages/server/lib/webhook/unauthenticated-webhook-routing.ts
@@ -4,14 +4,18 @@ import type { WebhookHandler } from './types.js';
 
 const route: WebhookHandler = async (nango, _headers, body) => {
     /**
-     * Only accepted format
-     * { type: '__STRING__', connectionId: '__STRING__', ... }
+     * Fan-out routing: dispatches to all connections whose metadata contains
+     * { stress_test: <value> } matching the `stress_test` field in the webhook body.
+     * To target specific connections, set metadata.stress_test on those connections
+     * and include the same value in the webhook payload.
+     *
+     * Example payload: { type: '...', stress_test: 'true', ... }
      */
     const response = await nango.executeScriptForWebhooks({
         body,
         webhookType: 'type',
-        connectionIdentifier: 'connectionId',
-        propName: 'connectionId'
+        connectionIdentifier: 'stress_test',
+        propName: 'metadata.stress_test'
     });
     return Ok({
         content: { status: 'success' },


### PR DESCRIPTION
Routes to all connections tagged with metadata.stress_test matching the value in the webhook body, instead of routing by connectionId. Allows scoped load-test fan-out without affecting other connections.

<!-- Describe the problem and your solution --> 

<!-- Issue ticket number and link (if applicable) -->

<!-- Testing instructions (skip if just adding/editing providers) -->

