### PR TITLE
feat(persist): add endpoint to hard delete records cache 2/4

### DIFF
--- a/packages/jobs/lib/execution/sync.integration.test.ts
+++ b/packages/jobs/lib/execution/sync.integration.test.ts
@@ -201,6 +201,7 @@ const runJob = async (
         },
         ownerKey: null,
         heartbeatTimeoutSecs: 30,
+        emptyCache: false,
         isSync: (): this is TaskSync => true,
         isWebhook: (): this is TaskWebhook => false,
         isAction: (): this is TaskAction => false,

--- a/packages/jobs/lib/execution/sync.ts
+++ b/packages/jobs/lib/execution/sync.ts
@@ -116,7 +116,7 @@ export async function startSync(task: TaskSync, startScriptFn = startScript): Pr
                 integration: { id: providerConfig.id!, name: providerConfig.unique_key, provider: providerConfig.provider },
                 connection: { id: task.connection.id, name: task.connection.connection_id },
                 syncConfig: { id: syncConfig.id, name: syncConfig.sync_name },
-                meta: { scriptVersion: syncConfig.version }
+                meta: { scriptVersion: syncConfig.version, emptyCache: task.emptyCache }
             }
         );
         logCtx.attachSpan(new OtlpSpan(logCtx.operation, startedAt));
@@ -194,6 +194,7 @@ export async function startSync(task: TaskSync, startScriptFn = startScript): Pr
             syncJobId: syncJob.id,
             attributes: syncConfig.attributes,
             track_deletes: syncConfig.track_deletes,
+            emptyCache: task.emptyCache,
             syncConfig,
             debug: task.debug || false,
             logger: sdkLogger,

--- a/packages/lambda-runner/lib/schemas.ts
+++ b/packages/lambda-runner/lib/schemas.ts
@@ -28,6 +28,7 @@ export const nangoPropsSchema = z.object({
     nangoConnectionId: z.number(),
     syncJobId: z.number().optional(),
     track_deletes: z.boolean().optional(),
+    emptyCache: z.boolean().optional(),
     attributes: z.record(z.string(), z.any()).optional(),
     abortSignal: z.any().optional(), // AbortSignal cannot be validated
     syncConfig: z.object({

--- a/packages/orchestrator/lib/clients/client.ts
+++ b/packages/orchestrator/lib/clients/client.ts
@@ -145,7 +145,8 @@ export class OrchestratorClient {
     public async executeSync(props: ExecuteSyncProps): Promise<VoidReturn> {
         const res = await this.routeFetch(postScheduleRunRoute)({
             body: {
-                scheduleName: props.scheduleName
+                scheduleName: props.scheduleName,
+                extra: props.extra
             }
         });
         if ('error' in res) {

--- a/packages/orchestrator/lib/clients/types.ts
+++ b/packages/orchestrator/lib/clients/types.ts
@@ -16,6 +16,9 @@ interface SyncArgs {
     debug: boolean;
     connection: ConnectionJobs;
 }
+interface SyncExecutionArgs {
+    emptyCache: boolean;
+}
 interface AbortArgs {
     abortedTask: {
         id: string;
@@ -112,8 +115,8 @@ export function TaskAbort(props: TaskCommonFields & AbortArgs): TaskAbort {
     };
 }
 
-export interface TaskSync extends TaskCommon, SyncArgs {}
-export function TaskSync(props: TaskCommonFields & SyncArgs): TaskSync {
+export interface TaskSync extends TaskCommon, SyncArgs, SyncExecutionArgs {}
+export function TaskSync(props: TaskCommonFields & SyncArgs & SyncExecutionArgs): TaskSync {
     return {
         id: props.id,
         name: props.name,
@@ -130,6 +133,7 @@ export function TaskSync(props: TaskCommonFields & SyncArgs): TaskSync {
         groupMaxConcurrency: props.groupMaxConcurrency,
         ownerKey: props.ownerKey,
         heartbeatTimeoutSecs: props.heartbeatTimeoutSecs,
+        emptyCache: props.emptyCache,
         isSync: (): this is TaskSync => true,
         isWebhook: (): this is TaskWebhook => false,
         isAction: (): this is TaskAction => false,

--- a/packages/orchestrator/lib/clients/validate.ts
+++ b/packages/orchestrator/lib/clients/validate.ts
@@ -35,6 +35,7 @@ export const syncArgsSchema = z.object({
     syncName: z.string().min(1),
     syncVariant: z.string().min(1).optional().default('base'), // TODO: remove optional/default
     debug: z.boolean(),
+    emptyCache: z.boolean().default(false),
     ...commonSchemaArgsFields
 });
 
@@ -129,7 +130,8 @@ export function validateTask(task: Task): Result<OrchestratorTask> {
                 retryKey: sync.data.retryKey,
                 ownerKey: sync.data.ownerKey,
                 debug: sync.data.payload.debug,
-                heartbeatTimeoutSecs: sync.data.heartbeatTimeoutSecs
+                heartbeatTimeoutSecs: sync.data.heartbeatTimeoutSecs,
+                emptyCache: sync.data.payload.emptyCache
             })
         );
     }

--- a/packages/orchestrator/lib/routes/v1/postImmediate.ts
+++ b/packages/orchestrator/lib/routes/v1/postImmediate.ts
@@ -8,7 +8,7 @@ import type { TaskType } from '../../types.js';
 import type { Scheduler } from '@nangohq/scheduler';
 import type { ApiError, Endpoint } from '@nangohq/types';
 import type { EndpointRequest, EndpointResponse, Route, RouteHandler } from '@nangohq/utils';
-import type { JsonValue } from 'type-fest';
+import type { JsonObject } from 'type-fest';
 
 const path = '/v1/immediate';
 const method = 'POST';
@@ -32,7 +32,7 @@ export type PostImmediate = Endpoint<{
             startedToCompleted: number;
             heartbeat: number;
         };
-        args: JsonValue & { type: TaskType };
+        args: JsonObject & { type: TaskType };
     };
     Error: ApiError<'immediate_failed'>;
     Success: { taskId: string; retryKey: string };

--- a/packages/orchestrator/lib/routes/v1/postRecurring.ts
+++ b/packages/orchestrator/lib/routes/v1/postRecurring.ts
@@ -8,7 +8,7 @@ import type { TaskType } from '../../types.js';
 import type { Scheduler } from '@nangohq/scheduler';
 import type { ApiError, Endpoint } from '@nangohq/types';
 import type { EndpointRequest, EndpointResponse, Route, RouteHandler } from '@nangohq/utils';
-import type { JsonValue } from 'type-fest';
+import type { JsonObject } from 'type-fest';
 
 const path = '/v1/recurring';
 const method = 'POST';
@@ -33,7 +33,7 @@ export type PostRecurring = Endpoint<{
             startedToCompleted: number;
             heartbeat: number;
         };
-        args: JsonValue & { type: TaskType };
+        args: JsonObject & { type: TaskType };
     };
     Error: ApiError<'recurring_failed'>;
     Success: { scheduleId: string };

--- a/packages/orchestrator/lib/routes/v1/schedules/postRun.ts
+++ b/packages/orchestrator/lib/routes/v1/schedules/postRun.ts
@@ -5,6 +5,7 @@ import { validateRequest } from '@nangohq/utils';
 import type { Scheduler } from '@nangohq/scheduler';
 import type { ApiError, Endpoint } from '@nangohq/types';
 import type { EndpointRequest, EndpointResponse, Route, RouteHandler } from '@nangohq/utils';
+import type { JsonObject } from 'type-fest';
 
 const path = '/v1/schedules/run';
 const method = 'POST';
@@ -14,12 +15,13 @@ export type PostScheduleRun = Endpoint<{
     Path: typeof path;
     Body: {
         scheduleName: string;
+        extra: JsonObject;
     };
     Error: ApiError<'recurring_run_failed'>;
     Success: { scheduleId: string };
 }>;
 
-const bodySchema = z.object({ scheduleName: z.string().min(1) }).strict();
+const bodySchema = z.object({ scheduleName: z.string().min(1), extra: z.record(z.string(), z.json()).default({}) }).strict();
 
 const validate = validateRequest<PostScheduleRun>({
     parseBody: (data: any) => bodySchema.parse(data)
@@ -28,7 +30,8 @@ const validate = validateRequest<PostScheduleRun>({
 const handler = (scheduler: Scheduler) => {
     return async (_req: EndpointRequest, res: EndpointResponse<PostScheduleRun>) => {
         const schedule = await scheduler.immediate({
-            scheduleName: res.locals.parsedBody.scheduleName
+            scheduleName: res.locals.parsedBody.scheduleName,
+            extra: res.locals.parsedBody.extra
         });
         if (schedule.isErr()) {
             res.status(500).json({ error: { code: 'recurring_run_failed', message: schedule.error.message } });

--- a/packages/persist/lib/routes/environment/environmentId/connection/connectionId/sync/syncId/job/jobId/deleteHardRecords.ts
+++ b/packages/persist/lib/routes/environment/environmentId/connection/connectionId/sync/syncId/job/jobId/deleteHardRecords.ts
@@ -1,0 +1,99 @@
+import z from 'zod';
+
+import { records } from '@nangohq/records';
+import { connectionService } from '@nangohq/shared';
+import { validateRequest } from '@nangohq/utils';
+
+import { envs } from '../../../../../../../../../env.js';
+import { pubsub } from '../../../../../../../../../pubsub.js';
+
+import type { AuthLocals } from '../../../../../../../../../middleware/auth.middleware.js';
+import type { ApiError, DeleteHardAllRecordsSuccess, Endpoint } from '@nangohq/types';
+import type { EndpointRequest, EndpointResponse, Route, RouteHandler } from '@nangohq/utils';
+
+type DeleteHardRecords = Endpoint<{
+    Method: typeof method;
+    Path: typeof path;
+    Params: {
+        environmentId: number;
+        nangoConnectionId: number;
+        syncId: string;
+        syncJobId: number;
+    };
+    Body: {
+        model: string;
+    };
+    Error: ApiError<'hard_delete_records_failed'>;
+    Success: DeleteHardAllRecordsSuccess;
+}>;
+
+const path = '/environment/:environmentId/connection/:nangoConnectionId/sync/:syncId/job/:syncJobId/records/hard';
+const method = 'DELETE';
+
+const bodySchema = z
+    .object({
+        model: z.string()
+    })
+    .strict();
+const paramsSchema = z
+    .object({
+        environmentId: z.coerce.number().int().positive(),
+        nangoConnectionId: z.coerce.number().int().positive(),
+        syncId: z.string(),
+        syncJobId: z.coerce.number().int().positive()
+    })
+    .strict();
+
+const validate = validateRequest<DeleteHardRecords>({
+    parseBody: (data: unknown) => bodySchema.parse(data),
+    parseParams: (data: unknown) => paramsSchema.parse(data)
+});
+
+const handler = async (_req: EndpointRequest, res: EndpointResponse<DeleteHardRecords, AuthLocals>) => {
+    const { nangoConnectionId, environmentId, syncId } = res.locals.parsedParams;
+    const { model } = res.locals.parsedBody;
+    const { account, environment } = res.locals;
+    const limit = envs.PERSIST_HARD_DELETE_LIMIT;
+    const result = await records.deleteRecords({
+        connectionId: nangoConnectionId,
+        environmentId,
+        model,
+        mode: 'hard',
+        limit
+    });
+    if (result.isOk()) {
+        if (result.value.count > 0) {
+            const connection = await connectionService.getConnectionById(nangoConnectionId);
+            void pubsub.publisher.publish({
+                subject: 'usage',
+                type: 'usage.records',
+                payload: {
+                    value: -result.value.count,
+                    properties: {
+                        accountId: account.id,
+                        environmentId: environment.id,
+                        environmentName: environment.name,
+                        integrationId: connection?.provider_config_key || 'unknown',
+                        connectionId: connection?.connection_id || 'unknown',
+                        syncId,
+                        model
+                    }
+                }
+            });
+        }
+
+        res.status(200).json({ deletedCount: result.value.count, hasMore: result.value.count === limit });
+    } else {
+        res.status(500).json({ error: { code: 'hard_delete_records_failed', message: `Failed to hard delete records: ${result.error.message}` } });
+    }
+    return;
+};
+
+export const route: Route<DeleteHardRecords> = { path, method };
+
+export const routeHandler: RouteHandler<DeleteHardRecords, AuthLocals> = {
+    method,
+    path,
+    validate,
+    handler
+};

--- a/packages/persist/lib/server.integration.test.ts
+++ b/packages/persist/lib/server.integration.test.ts
@@ -461,6 +461,47 @@ describe('Persist API', () => {
         });
     });
 
+    describe('deleteHardRecords', () => {
+        it('should hard delete all records for a model', async () => {
+            const model = 'DeleteHardModel';
+            await insertRecords(seed, model, [
+                { id: '1', name: 'r1' },
+                { id: '2', name: 'r2' },
+                { id: '3', name: 'r3' }
+            ]);
+
+            const response = await fetch(
+                `${serverUrl}/environment/${seed.env.id}/connection/${seed.connection.id}/sync/${seed.sync.id}/job/${seed.syncJob.id}/records/hard`,
+                {
+                    method: 'DELETE',
+                    body: JSON.stringify({ model }),
+                    headers: {
+                        Authorization: `Bearer ${mockSecretKey}`,
+                        'Content-Type': 'application/json'
+                    }
+                }
+            );
+            expect(response.status).toEqual(200);
+            const body = await response.json();
+            expect(body).toMatchObject({ deletedCount: 3, hasMore: false });
+        });
+
+        it('should return 400 when model is missing', async () => {
+            const response = await fetch(
+                `${serverUrl}/environment/${seed.env.id}/connection/${seed.connection.id}/sync/${seed.sync.id}/job/${seed.syncJob.id}/records/hard`,
+                {
+                    method: 'DELETE',
+                    body: JSON.stringify({}),
+                    headers: {
+                        Authorization: `Bearer ${mockSecretKey}`,
+                        'Content-Type': 'application/json'
+                    }
+                }
+            );
+            expect(response.status).toEqual(400);
+        });
+    });
+
     describe('checkpoint', () => {
         it('should return 404 if checkpoint not found', async () => {
             const response = await fetch(`${serverUrl}/environment/${seed.env.id}/connection/${seed.connection.id}/checkpoint?key=non-existent`, {

--- a/packages/persist/lib/server.ts
+++ b/packages/persist/lib/server.ts
@@ -14,6 +14,10 @@ import { routeHandler as putCheckpointHandler } from './routes/environment/envir
 import { route as getCursorRoute, routeHandler as getCursorHandler } from './routes/environment/environmentId/connection/connectionId/getCursor.js';
 import { route as getRecordsRoute, routeHandler as getRecordsHandler } from './routes/environment/environmentId/connection/connectionId/getRecords.js';
 import {
+    route as deleteHardRecordsRoute,
+    routeHandler as deleteHardRecordsHandler
+} from './routes/environment/environmentId/connection/connectionId/sync/syncId/job/jobId/deleteHardRecords.js';
+import {
     route as deleteOutdatedRecordsRoute,
     routeHandler as deleteOutdatedRecordsHandler
 } from './routes/environment/environmentId/connection/connectionId/sync/syncId/job/jobId/deleteOutdatedRecords.js';
@@ -41,6 +45,7 @@ server.use(recordsPath, express.json({ limit: maxSizeJsonRecords }));
 server.use(getCursorRoute.path, express.json());
 server.use(getRecordsRoute.path, express.json());
 server.use(deleteOutdatedRecordsRoute.path, express.json());
+server.use(deleteHardRecordsRoute.path, express.json());
 server.use(getCheckpointRoute.path, express.json());
 
 createRoute(server, getHealthHandler);
@@ -48,6 +53,7 @@ createRoute(server, postLogHandler);
 createRoute(server, postRecordsHandler);
 createRoute(server, deleteRecordsHandler);
 createRoute(server, deleteOutdatedRecordsHandler);
+createRoute(server, deleteHardRecordsHandler);
 createRoute(server, putRecordsHandler);
 createRoute(server, getCursorHandler);
 createRoute(server, getRecordsHandler);

--- a/packages/runner-sdk/lib/sync.ts
+++ b/packages/runner-sdk/lib/sync.ts
@@ -18,6 +18,7 @@ export abstract class NangoSyncBase<
 
     lastSyncDate?: Date;
     track_deletes = false;
+    emptyCache = false;
 
     constructor(config: NangoProps) {
         super(config);
@@ -28,6 +29,10 @@ export abstract class NangoSyncBase<
 
         if (config.track_deletes) {
             this.track_deletes = config.track_deletes;
+        }
+
+        if (config.emptyCache) {
+            this.emptyCache = config.emptyCache;
         }
 
         if (config.syncVariant) {

--- a/packages/runner/lib/clients/persist.ts
+++ b/packages/runner/lib/clients/persist.ts
@@ -8,6 +8,7 @@ import { logger } from '../logger.js';
 import type {
     Checkpoint,
     CursorOffset,
+    DeleteHardAllRecordsSuccess,
     DeleteOutdatedRecordsSuccess,
     DeleteRecordsSuccess,
     GetCheckpointSuccess,
@@ -219,6 +220,30 @@ export class PersistClient {
         });
         if (res.isErr()) {
             return Err(new Error(`Failed to delete records: ${res.error.message}`));
+        }
+        return res;
+    }
+
+    public async deleteHardAllRecords({
+        environmentId,
+        nangoConnectionId,
+        syncId,
+        syncJobId,
+        model
+    }: {
+        environmentId: number;
+        nangoConnectionId: number;
+        syncId: string;
+        syncJobId: number;
+        model: string;
+    }): Promise<Result<DeleteHardAllRecordsSuccess>> {
+        const res = await this.fetch<DeleteHardAllRecordsSuccess>({
+            method: 'DELETE',
+            path: `/environment/${environmentId}/connection/${nangoConnectionId}/sync/${syncId}/job/${syncJobId}/records/hard`,
+            data: { model }
+        });
+        if (res.isErr()) {
+            return Err(new Error(`Failed to hard delete records: ${res.error.message}`));
         }
         return res;
     }

--- a/packages/scheduler/lib/models/schedules.ts
+++ b/packages/scheduler/lib/models/schedules.ts
@@ -5,7 +5,7 @@ import { Err, Ok, stringifyError } from '@nangohq/utils';
 import type { Schedule, ScheduleProps, ScheduleState, TaskState } from '../types.js';
 import type { Result } from '@nangohq/utils';
 import type knex from 'knex';
-import type { JsonValue } from 'type-fest';
+import type { JsonObject } from 'type-fest';
 
 export const SCHEDULES_TABLE = 'schedules';
 
@@ -39,7 +39,7 @@ export interface DbSchedule {
     state: ScheduleState;
     readonly starts_at: Date;
     frequency: string;
-    payload: JsonValue;
+    payload: JsonObject;
     readonly group_key: string;
     readonly retry_max: number;
     readonly created_to_started_timeout_secs: number;

--- a/packages/scheduler/lib/models/tasks.ts
+++ b/packages/scheduler/lib/models/tasks.ts
@@ -9,7 +9,7 @@ import { envs } from '../env.js';
 import type { Task, TaskNonTerminalState, TaskState, TaskTerminalState } from '../types.js';
 import type { Result } from '@nangohq/utils';
 import type knex from 'knex';
-import type { JsonValue, SetOptional } from 'type-fest';
+import type { JsonObject, JsonValue, SetOptional } from 'type-fest';
 
 export const TASKS_TABLE = 'tasks';
 const TASKS_INSERT_BATCH_SIZE = 1000;
@@ -52,7 +52,7 @@ const TaskStateTransition = {
 export interface DBTask {
     readonly id: string;
     readonly name: string;
-    readonly payload: JsonValue;
+    readonly payload: JsonObject;
     readonly group_key: string;
     readonly group_max_concurrency: number;
     readonly retry_max: number;

--- a/packages/scheduler/lib/scheduler.integration.test.ts
+++ b/packages/scheduler/lib/scheduler.integration.test.ts
@@ -259,7 +259,8 @@ async function immediate(
     let taskProps;
     if (props && 'schedule' in props) {
         taskProps = {
-            scheduleName: props.schedule.name
+            scheduleName: props.schedule.name,
+            extra: {}
         };
     } else {
         taskProps = {

--- a/packages/scheduler/lib/scheduler.ts
+++ b/packages/scheduler/lib/scheduler.ts
@@ -10,7 +10,7 @@ import * as schedules from './models/schedules.js';
 import * as tasks from './models/tasks.js';
 import { logger } from './utils/logger.js';
 
-import type { ImmediateProps, Schedule, ScheduleProps, ScheduleState, Task, TaskState } from './types.js';
+import type { FromScheduleProps, ImmediateProps, Schedule, ScheduleProps, ScheduleState, Task, TaskState } from './types.js';
 import type { Result } from '@nangohq/utils';
 import type knex from 'knex';
 import type { JsonObject, JsonValue } from 'type-fest';
@@ -154,7 +154,7 @@ export class Scheduler {
      * };
      * const scheduled = await scheduler.immediate(schedulingProps);
      */
-    public async immediate(props: ImmediateProps | { scheduleName: string }): Promise<Result<Task>> {
+    public async immediate(props: ImmediateProps | FromScheduleProps): Promise<Result<Task>> {
         return this.db.transaction(async (trx) => {
             const now = new Date();
             let taskProps: tasks.TaskProps;
@@ -182,7 +182,7 @@ export class Scheduler {
                 }
                 taskProps = {
                     name: `${schedule.name}:${uuidv7()}`,
-                    payload: schedule.payload,
+                    payload: { ...schedule.payload, ...props.extra },
                     groupKey: schedule.groupKey,
                     groupMaxConcurrency: 0,
                     retryMax: schedule.retryMax,
@@ -520,15 +520,15 @@ export class Scheduler {
         const abortType = 'abort';
 
         // no need to abort an abort task
-        const isAbortPayload = (payload: JsonValue) => {
-            return typeof payload === 'object' && payload !== null && !Array.isArray(payload) && 'type' in payload && payload['type'] === abortType;
+        const isAbortPayload = (payload: JsonObject) => {
+            return 'type' in payload && payload['type'] === abortType;
         };
         if (isAbortPayload(aborted.payload)) {
             return Err(`Task is already an abort task`);
         }
 
-        const payload: JsonValue = {
-            ...(aborted.payload as JsonObject),
+        const payload: JsonObject = {
+            ...aborted.payload,
             type: abortType,
             abortedTask: {
                 id: aborted.id,

--- a/packages/scheduler/lib/types.ts
+++ b/packages/scheduler/lib/types.ts
@@ -1,5 +1,5 @@
 import type { TaskProps } from './models/tasks.js';
-import type { JsonValue, SetOptional } from 'type-fest';
+import type { JsonObject, JsonValue, SetOptional } from 'type-fest';
 
 export const taskStates = ['CREATED', 'STARTED', 'SUCCEEDED', 'FAILED', 'EXPIRED', 'CANCELLED'] as const;
 export type TaskState = (typeof taskStates)[number];
@@ -9,7 +9,7 @@ export type TaskNonTerminalState = Exclude<TaskState, TaskTerminalState>;
 export interface Task {
     readonly id: string;
     readonly name: string;
-    readonly payload: JsonValue;
+    readonly payload: JsonObject;
     readonly groupKey: string;
     readonly groupMaxConcurrency: number;
     readonly retryMax: number;
@@ -30,6 +30,10 @@ export interface Task {
 }
 
 export type ImmediateProps = SetOptional<Omit<TaskProps, 'startsAfter' | 'scheduleId'>, 'retryKey'>;
+export interface FromScheduleProps {
+    scheduleName: string;
+    extra: JsonObject;
+}
 export type ScheduleProps = Omit<Schedule, 'id' | 'createdAt' | 'updatedAt' | 'deletedAt' | 'nextExecutionAt'>;
 
 // eslint-disable-next-line @typescript-eslint/no-unused-vars
@@ -42,7 +46,7 @@ export interface Schedule {
     readonly state: ScheduleState;
     readonly startsAt: Date;
     readonly frequencyMs: number;
-    readonly payload: JsonValue;
+    readonly payload: JsonObject;
     readonly groupKey: string;
     readonly retryMax: number;
     readonly createdToStartedTimeoutSecs: number;

--- a/packages/shared/lib/clients/orchestrator.ts
+++ b/packages/shared/lib/clients/orchestrator.ts
@@ -586,7 +586,7 @@ export class Orchestrator {
                     res = await this.client.unpauseSync({ scheduleName });
                     break;
                 case SyncCommand.RUN:
-                    res = await this.client.executeSync({ scheduleName });
+                    res = await this.client.executeSync({ scheduleName, extra: { emptyCache: false } });
                     break;
                 case SyncCommand.RUN_FULL: {
                     await cancelling(syncId);
@@ -602,6 +602,7 @@ export class Orchestrator {
                         return Err(deletedCheckpoints.error);
                     }
 
+                    // TODO: remove block once the records deletion is handled as part of the sync execution
                     if (delete_records) {
                         const syncConfig = await getSyncConfigBySyncId(syncId);
                         for (let model of syncConfig?.models || []) {
@@ -617,7 +618,7 @@ export class Orchestrator {
                         }
                     }
 
-                    res = await this.client.executeSync({ scheduleName });
+                    res = await this.client.executeSync({ scheduleName, extra: { emptyCache: delete_records || false } });
                     break;
                 }
             }

--- a/packages/types/lib/persist/api.ts
+++ b/packages/types/lib/persist/api.ts
@@ -35,6 +35,11 @@ export interface DeleteOutdatedRecordsSuccess {
     deletedKeys: string[];
 }
 
+export interface DeleteHardAllRecordsSuccess {
+    deletedCount: number;
+    hasMore: boolean;
+}
+
 export interface GetCursorSuccess {
     cursor?: string;
 }

--- a/packages/types/lib/runner/sdk.ts
+++ b/packages/types/lib/runner/sdk.ts
@@ -30,6 +30,7 @@ export interface NangoProps {
     nangoConnectionId: number;
     syncJobId?: number | undefined;
     track_deletes?: boolean;
+    emptyCache?: boolean;
     attributes?: object | undefined;
     abortSignal?: AbortSignal;
     syncConfig: DBSyncConfig;

--- a/packages/utils/lib/environment/parse.ts
+++ b/packages/utils/lib/environment/parse.ts
@@ -81,6 +81,7 @@ export const ENVS = z.object({
 
     // Persist
     PERSIST_SERVICE_URL: z.url().optional(),
+    PERSIST_HARD_DELETE_LIMIT: z.coerce.number().int().positive().optional().default(50_000),
     PERSIST_AUTO_PRUNING_INTERVAL_MS: z.coerce.number().optional().default(5_000), // set to 0 to disable
     PERSIST_AUTO_PRUNING_LIMIT: z.coerce.number().optional().default(1_000),
     PERSIST_AUTO_PRUNING_STALE_AFTER_MS: z.coerce


### PR DESCRIPTION
This endpoint will be called by the runner to empty the records cache before running a full sync from empty cache.

Up to 50_000 records are deleted per call. I picked it as an arbitrary value so it is bounded for very large dataset. Only big dataset would require more than one round-trip between runner and persist.