### PR TITLE
fix: validate jwt.decode() tenant ID before using in URL construction

### DIFF
--- a/packages/server/lib/hooks/connection/providers/microsoft-teams/post-connection.ts
+++ b/packages/server/lib/hooks/connection/providers/microsoft-teams/post-connection.ts
@@ -1,58 +1,27 @@
 import jwt from 'jsonwebtoken';
+import * as z from 'zod';
+
+import { getLogger } from '@nangohq/utils';
 
 import type { InternalNango as Nango } from '../../internal-nango.js';
 import type { OAuth2Credentials } from '@nangohq/types';
 
-interface MicrosoftDecodedToken {
-    aud: string;
-    iss: string;
-    iat: number;
-    nbf: number;
-    exp: number;
-    acct: number;
-    acr: string;
-    aio: string;
-    amr: string[];
-    app_displayname: string;
-    appid: string;
-    appidacr: string;
-    family_name: string;
-    given_name: string;
-    idtyp: string;
-    ipaddr: string;
-    name: string;
-    oid: string;
-    platf: string;
-    puid: string;
-    rh: string;
-    scp: string;
-    signin_state: string[];
-    sub: string;
-    tenant_region_scope: string;
-    tid: string;
-    unique_name: string;
-    upn: string;
-    uti: string;
-    ver: string;
-    wids: string[];
-    xms_ftd: string;
-    xms_idrel: string;
-    xms_st: {
-        sub: string;
-    };
-    xms_tcdt: number;
-}
+const logger = getLogger('post-connection:microsoft-teams');
+
+const MicrosoftTeamsJWTPayloadSchema = z.object({
+    tid: z.string()
+});
 
 export default async function execute(nango: Nango) {
     const connection = await nango.getConnection();
     const accessToken = (connection.credentials as OAuth2Credentials).access_token;
-    const decoded = jwt.decode(accessToken) as MicrosoftDecodedToken;
+    const decoded = jwt.decode(accessToken);
 
-    if (!decoded || typeof decoded !== 'object') {
+    const parsed = MicrosoftTeamsJWTPayloadSchema.safeParse(decoded);
+    if (!parsed.success) {
+        logger.info('Failed to parse decoded JWT payload. Skipping tenant_id update.');
         return;
     }
 
-    const id = decoded.tid;
-
-    await nango.updateConnectionConfig({ tenantId: id });
+    await nango.updateConnectionConfig({ tenantId: parsed.data.tid });
 }

--- a/packages/server/lib/hooks/connection/providers/one-drive/post-connection.ts
+++ b/packages/server/lib/hooks/connection/providers/one-drive/post-connection.ts
@@ -1,7 +1,7 @@
 import axios from 'axios';
 import jwt from 'jsonwebtoken';
 
-import type { MicrosoftDecodedToken, SharePointTokenResponse } from './types.js';
+import type { SharePointTokenResponse } from './types.js';
 import type { InternalNango as Nango } from '../../internal-nango.js';
 import type { OAuth2Credentials } from '@nangohq/types';
 
@@ -10,12 +10,15 @@ export default async function execute(nango: Nango) {
     const credentials = connection.credentials as OAuth2Credentials;
     const integration = await nango.getIntegration();
 
-    const decoded = jwt.decode(credentials.access_token) as MicrosoftDecodedToken;
-    if (!decoded || typeof decoded !== 'object') {
+    const decoded = jwt.decode(credentials.access_token);
+    if (!decoded || typeof decoded === 'string') {
         return;
     }
 
-    const tenantId = decoded.tid;
+    const tenantId = decoded['tid'];
+    if (!tenantId || typeof tenantId !== 'string') {
+        return;
+    }
 
     if (!integration || !integration.oauth_client_id || !integration.oauth_client_secret || !credentials.refresh_token) {
         return;

--- a/packages/server/lib/hooks/connection/providers/one-drive/post-connection.ts
+++ b/packages/server/lib/hooks/connection/providers/one-drive/post-connection.ts
@@ -1,9 +1,18 @@
 import axios from 'axios';
 import jwt from 'jsonwebtoken';
+import * as z from 'zod';
+
+import { getLogger } from '@nangohq/utils';
 
 import type { SharePointTokenResponse } from './types.js';
 import type { InternalNango as Nango } from '../../internal-nango.js';
 import type { OAuth2Credentials } from '@nangohq/types';
+
+const logger = getLogger('post-connection:one-drive');
+
+const OneDriveJWTPayloadSchema = z.object({
+    tid: z.string()
+});
 
 export default async function execute(nango: Nango) {
     const connection = await nango.getConnection();
@@ -11,14 +20,12 @@ export default async function execute(nango: Nango) {
     const integration = await nango.getIntegration();
 
     const decoded = jwt.decode(credentials.access_token);
-    if (!decoded || typeof decoded === 'string') {
+    const parsed = OneDriveJWTPayloadSchema.safeParse(decoded);
+    if (!parsed.success) {
+        logger.info('Failed to parse decoded JWT payload. Skipping tenant_id update.');
         return;
     }
-
-    const tenantId = decoded['tid'];
-    if (!tenantId || typeof tenantId !== 'string') {
-        return;
-    }
+    const tenantId = parsed.data.tid;
 
     if (!integration || !integration.oauth_client_id || !integration.oauth_client_secret || !credentials.refresh_token) {
         return;


### PR DESCRIPTION
The OneDrive post-connection hook uses `jwt.decode()` to extract the tenant ID (`tid`) from the OAuth access token, then uses it to construct SharePoint and Microsoft login URLs.
  The decoded payload was unsafely cast via `as MicrosoftDecodedToken` without runtime validation that `tid` exists. If the token lacks a `tid` claim, `tenantId` would be `undefined`,
   causing the refresh token and client secret to be sent to `https://login.microsoftonline.com/undefined/oauth2/v2.0/token`.

  **Fix:** Remove the unsafe type assertion, use `jwt.decode()`'s native return type, and add a runtime check that `tid` exists and is a string before proceeding. Returns early
  (no-op) if validation fails, consistent with the existing guard pattern in the function.

  Ref: [`jwt.decode()` does not verify signatures](https://github.com/auth0/node-jsonwebtoken#jwtdecodetoken--options)

  **Testing:** `npm run ts-build` passes. ESLint passes (verified by pre-commit hook). The change is additive — only adds a guard clause that returns early.