### PR TITLE
feat(webapp): add copy button for API keys in list view

### DIFF
--- a/packages/webapp/src/pages/Environment/Settings/ApiKeys.tsx
+++ b/packages/webapp/src/pages/Environment/Settings/ApiKeys.tsx
@@ -203,7 +203,7 @@ const ScopeSelector: React.FC<ScopeSelectorProps> = ({ selectedScopes, onChange,
                                                             type="checkbox"
                                                             checked={isScopeSelected(item.credentials, selectedScopes)}
                                                             disabled={disabled || wildcardSelected}
-                                                            onChange={() => onChange(toggleCredentialFn(item.value, item.credentials, selectedScopes))}
+                                                            onChange={() => onChange(toggleCredentialFn(item.value, item.credentials!, selectedScopes))}
                                                             className="accent-brand shrink-0"
                                                         />
                                                         <span

--- a/packages/webapp/src/pages/Environment/Settings/ApiKeys.tsx
+++ b/packages/webapp/src/pages/Environment/Settings/ApiKeys.tsx
@@ -203,7 +203,7 @@ const ScopeSelector: React.FC<ScopeSelectorProps> = ({ selectedScopes, onChange,
                                                             type="checkbox"
                                                             checked={isScopeSelected(item.credentials, selectedScopes)}
                                                             disabled={disabled || wildcardSelected}
-                                                            onChange={() => onChange(toggleCredentialFn(item.value, item.credentials!, selectedScopes))}
+                                                            onChange={() => onChange(toggleCredentialFn(item.value, item.credentials, selectedScopes))}
                                                             className="accent-brand shrink-0"
                                                         />
                                                         <span
@@ -550,6 +550,9 @@ export const ApiKeys: React.FC = () => {
                                     </TableCell>
                                     <TableCell>
                                         <div className="flex items-center gap-1">
+                                            <PermissionGate condition={canReadSecret}>
+                                                {(allowed) => <CopyButton text={key.secret} disabled={!allowed} />}
+                                            </PermissionGate>
                                             <Button
                                                 variant="ghost"
                                                 size="icon"

--- a/packages/webapp/src/pages/Environment/Settings/ApiKeys.tsx
+++ b/packages/webapp/src/pages/Environment/Settings/ApiKeys.tsx
@@ -477,6 +477,7 @@ export const ApiKeys: React.FC = () => {
     const isProd = envData?.environmentAndAccount?.environment?.is_production || false;
     const canReadSecret = can(permissions.canReadProdSecretKey) || !isProd;
     const canManageKeys = can(permissions.canWriteProdEnvironmentKeys) || !isProd;
+    const showActions = canReadSecret || canManageKeys;
     const managedSecretKey = envData?.environmentAndAccount?.managed_secret_key ?? null;
 
     const apiKeys = data?.data ?? [];
@@ -526,7 +527,7 @@ export const ApiKeys: React.FC = () => {
                                 <TableHead>Scopes</TableHead>
                                 <TableHead>Created</TableHead>
                                 <TableHead>Last used</TableHead>
-                                <TableHead>Action</TableHead>
+                                {showActions && <TableHead>Action</TableHead>}
                             </TableRow>
                         </TableHeader>
                         <TableBody>
@@ -548,22 +549,26 @@ export const ApiKeys: React.FC = () => {
                                             {formatRelativeTime(key.last_used_at)}
                                         </span>
                                     </TableCell>
-                                    <TableCell>
-                                        <div className="flex items-center gap-1">
-                                            <PermissionGate condition={canReadSecret}>
-                                                {(allowed) => <CopyButton text={key.secret} disabled={!allowed} />}
-                                            </PermissionGate>
-                                            <Button
-                                                variant="ghost"
-                                                size="icon"
-                                                onClick={() => setSelectedKeyId(key.id)}
-                                                className="text-text-tertiary hover:text-text-primary"
-                                            >
-                                                <IconEdit stroke={1} size={16} />
-                                            </Button>
-                                            {canManageKeys && <DeleteApiKeyButton displayName={key.display_name} onDelete={() => void handleDelete(key.id)} />}
-                                        </div>
-                                    </TableCell>
+                                    {showActions && (
+                                        <TableCell>
+                                            <div className="flex items-center gap-1">
+                                                {canReadSecret && <CopyButton text={key.secret} />}
+                                                {canManageKeys && (
+                                                    <Button
+                                                        variant="ghost"
+                                                        size="icon"
+                                                        onClick={() => setSelectedKeyId(key.id)}
+                                                        className="text-text-tertiary hover:text-text-primary"
+                                                    >
+                                                        <IconEdit stroke={1} size={16} />
+                                                    </Button>
+                                                )}
+                                                {canManageKeys && (
+                                                    <DeleteApiKeyButton displayName={key.display_name} onDelete={() => void handleDelete(key.id)} />
+                                                )}
+                                            </div>
+                                        </TableCell>
+                                    )}
                                 </TableRow>
                             ))}
                         </TableBody>

--- a/packages/webapp/src/pages/Environment/Settings/ApiKeys.tsx
+++ b/packages/webapp/src/pages/Environment/Settings/ApiKeys.tsx
@@ -477,7 +477,7 @@ export const ApiKeys: React.FC = () => {
     const isProd = envData?.environmentAndAccount?.environment?.is_production || false;
     const canReadSecret = can(permissions.canReadProdSecretKey) || !isProd;
     const canManageKeys = can(permissions.canWriteProdEnvironmentKeys) || !isProd;
-    const showActions = canReadSecret || canManageKeys;
+    const canMakeActions = canReadSecret || canManageKeys;
     const managedSecretKey = envData?.environmentAndAccount?.managed_secret_key ?? null;
 
     const apiKeys = data?.data ?? [];
@@ -527,7 +527,7 @@ export const ApiKeys: React.FC = () => {
                                 <TableHead>Scopes</TableHead>
                                 <TableHead>Created</TableHead>
                                 <TableHead>Last used</TableHead>
-                                {showActions && <TableHead>Action</TableHead>}
+                                {canMakeActions && <TableHead>Action</TableHead>}
                             </TableRow>
                         </TableHeader>
                         <TableBody>
@@ -549,7 +549,7 @@ export const ApiKeys: React.FC = () => {
                                             {formatRelativeTime(key.last_used_at)}
                                         </span>
                                     </TableCell>
-                                    {showActions && (
+                                    {canMakeActions && (
                                         <TableCell>
                                             <div className="flex items-center gap-1">
                                                 {canReadSecret && <CopyButton text={key.secret} />}


### PR DESCRIPTION
Linear issue: [NAN-5367](https://linear.app/nango/issue/NAN-5367/implement-api-key-copy-action-in-list-view)

## Summary

Adds a copy button directly in the API keys list view so users no longer need to open the edit flow to access a key.

For support roles in production environments, the entire Actions column (copy, edit, delete) is now hidden. Previously the copy button was shown-but-disabled, the edit button was always visible (but led to a read-only view), and delete was hidden — inconsistent and confusing.

## Testing

Open [API Keys settings on dev](http://localhost:3000/dev/environment-settings#api-keys).

- [x] A copy icon appears in the Action column for each key, to the left of the edit and delete icons
- [x] Clicking the copy icon copies the key to clipboard (icon briefly changes to a checkmark)
- [x] Switch to a production environment as a support role — the entire Actions column is hidden (no copy, edit, or delete icons)

## Screenshots / vids

Admin view (dev environment):

https://github.com/user-attachments/assets/a2a5965c-5544-43d5-85e9-dbd439241a89

<!-- drag screenshot here -->

Support role (prod env)

<img width="1916" height="961" alt="image" src="https://github.com/user-attachments/assets/40548ac4-6fc2-4870-be52-c03bac2be4e0" />
