### PR TITLE
chore(runner): clear records before sync execution cache 3/4

### DIFF
--- a/packages/runner/lib/exec.ts
+++ b/packages/runner/lib/exec.ts
@@ -228,6 +228,7 @@ export async function exec({
             }
 
             // Sync
+            await (nango as NangoSyncRunner).clearRecordsIfNeeded();
             if (isZeroYaml) {
                 const payload = def;
                 if (payload.type !== 'sync') {

--- a/packages/runner/lib/sdk/sdk.ts
+++ b/packages/runner/lib/sdk/sdk.ts
@@ -614,6 +614,47 @@ export class NangoSyncRunner extends NangoSyncBase<never, never, ZodCheckpoint> 
         return res.value;
     }
 
+    public async clearRecordsIfNeeded(): Promise<void> {
+        if (!this.emptyCache) {
+            return;
+        }
+        for (const model of this.syncConfig?.models || []) {
+            await this.sendLogToPersist({
+                type: 'log',
+                level: 'info',
+                source: 'internal',
+                message: `Clearing records for model ${model}...`,
+                createdAt: new Date().toISOString(),
+                meta: { model }
+            });
+            let hasMore = true;
+            let deletedCount = 0;
+            while (hasMore) {
+                this.throwIfAbortedOrKilled();
+                const res = await this.persistClient.deleteHardAllRecords({
+                    model: this.modelFullName(model),
+                    environmentId: this.environmentId,
+                    nangoConnectionId: this.nangoConnectionId!,
+                    syncId: this.syncId!,
+                    syncJobId: this.syncJobId!
+                });
+                if (res.isErr()) {
+                    throw res.error;
+                }
+                deletedCount += res.value.deletedCount;
+                hasMore = res.value.hasMore;
+            }
+            await this.sendLogToPersist({
+                type: 'log',
+                level: 'info',
+                source: 'internal',
+                message: `Cleared ${deletedCount} records for model ${model}.`,
+                createdAt: new Date().toISOString(),
+                meta: { model }
+            });
+        }
+    }
+
     private async fetchRecordsPage<T extends Record<string, any>>(
         model: string,
         options?: {

--- a/packages/shared/lib/clients/orchestrator.ts
+++ b/packages/shared/lib/clients/orchestrator.ts
@@ -575,10 +575,13 @@ export class Orchestrator {
                         return Err(deletedCheckpoints.error);
                     }
 
-                    // TODO: remove block once the records deletion is handled as part of the sync execution
+                    // TODO:
+                    // - remove block once the records deletion is handled as part of the sync execution
+                    // - pass the delete_records flag as part of the executeSync extra options
                     if (delete_records) {
                         const syncConfig = await getSyncConfigBySyncId(syncId);
-                        for (let model of syncConfig?.models || []) {
+                        const models = syncConfig?.models || [];
+                        for (let model of models) {
                             if (syncVariant !== 'base') {
                                 model = `${model}::${syncVariant}`;
                             }
@@ -591,7 +594,7 @@ export class Orchestrator {
                         }
                     }
 
-                    res = await this.client.executeSync({ scheduleName, extra: { emptyCache: delete_records || false } });
+                    res = await this.client.executeSync({ scheduleName, extra: { emptyCache: false } });
                     break;
                 }
             }


### PR DESCRIPTION
Add logic before executing the sync function code to clear records in `emptyCache = true`
