### PR TITLE
chore: pass emptyCache to runner when triggering full sync with empty cache 4/4

### DIFF
--- a/packages/server/lib/controllers/sync.controller.ts
+++ b/packages/server/lib/controllers/sync.controller.ts
@@ -133,7 +133,6 @@ class SyncController {
                 command,
                 environmentId: environment.id,
                 logCtx,
-                recordsService,
                 initiator: 'UI',
                 delete_records
             });

--- a/packages/server/lib/controllers/sync/postSyncPause.ts
+++ b/packages/server/lib/controllers/sync/postSyncPause.ts
@@ -1,7 +1,6 @@
 import * as z from 'zod';
 
 import { logContextGetter } from '@nangohq/logs';
-import { records as recordsService } from '@nangohq/records';
 import { SyncCommand, errorManager, normalizedSyncParams, syncManager } from '@nangohq/shared';
 import { zodErrorToHTTP } from '@nangohq/utils';
 
@@ -40,7 +39,6 @@ export const postPublicSyncPause = asyncWrapper<PostPublicSyncPause>(async (req,
     const { environment } = res.locals;
 
     const resSyncCommand = await syncManager.runSyncCommand({
-        recordsService,
         orchestrator,
         environment,
         providerConfigKey: body.provider_config_key,

--- a/packages/server/lib/controllers/sync/postSyncStart.ts
+++ b/packages/server/lib/controllers/sync/postSyncStart.ts
@@ -1,7 +1,6 @@
 import * as z from 'zod';
 
 import { logContextGetter } from '@nangohq/logs';
-import { records as recordsService } from '@nangohq/records';
 import { SyncCommand, errorManager, normalizedSyncParams, syncManager } from '@nangohq/shared';
 import { zodErrorToHTTP } from '@nangohq/utils';
 
@@ -40,7 +39,6 @@ export const postPublicSyncStart = asyncWrapper<PostPublicSyncStart>(async (req,
     const { environment } = res.locals;
 
     const resSyncCommand = await syncManager.runSyncCommand({
-        recordsService,
         orchestrator,
         environment,
         providerConfigKey: body.provider_config_key,

--- a/packages/server/lib/controllers/sync/postTrigger.ts
+++ b/packages/server/lib/controllers/sync/postTrigger.ts
@@ -1,7 +1,6 @@
 import * as z from 'zod';
 
 import { logContextGetter } from '@nangohq/logs';
-import { records as recordsService } from '@nangohq/records';
 import { SyncCommand, errorManager, syncManager } from '@nangohq/shared';
 import { requireEmptyQuery, zodErrorToHTTP } from '@nangohq/utils';
 
@@ -97,7 +96,6 @@ export const postPublicTrigger = asyncWrapper<PostPublicTrigger>(async (req, res
     }
 
     const { success, error } = await syncManager.runSyncCommand({
-        recordsService,
         orchestrator,
         environment,
         providerConfigKey,

--- a/packages/server/lib/controllers/v1/trigger/postTriggerFunction.ts
+++ b/packages/server/lib/controllers/v1/trigger/postTriggerFunction.ts
@@ -2,7 +2,6 @@ import tracer from 'dd-trace';
 import * as z from 'zod';
 
 import { logContextGetter } from '@nangohq/logs';
-import { records as recordsService } from '@nangohq/records';
 import { SyncCommand, errorManager, syncManager } from '@nangohq/shared';
 import { getHeaders, metrics, redactHeaders, zodErrorToHTTP } from '@nangohq/utils';
 
@@ -79,7 +78,6 @@ export const postTriggerFunction = asyncWrapper<PostInternalTriggerFunction>(asy
         const syncIdentifiers = normalizeSyncParams([function_name]);
 
         const { success, error } = await syncManager.runSyncCommand({
-            recordsService,
             orchestrator,
             environment: environment,
             providerConfigKey: provider_config_key,

--- a/packages/shared/lib/clients/orchestrator.ts
+++ b/packages/shared/lib/clients/orchestrator.ts
@@ -9,7 +9,7 @@ import { hardDeleteCheckpoints } from '../index.js';
 import { LogActionEnum } from '../models/Telemetry.js';
 import { SyncCommand, SyncStatus } from '../models/index.js';
 import accountService from '../services/account.service.js';
-import { getSyncConfigBySyncId, getSyncConfigRaw } from '../services/sync/config/config.service.js';
+import { getSyncConfigRaw } from '../services/sync/config/config.service.js';
 import { isSyncJobRunning, updateSyncJobStatus } from '../services/sync/job.service.js';
 import { clearLastSyncDate } from '../services/sync/sync.service.js';
 import { NangoError, deserializeNangoError } from '../utils/error.js';
@@ -519,7 +519,6 @@ export class Orchestrator {
         command,
         environmentId,
         logCtx,
-        recordsService,
         initiator,
         delete_records
     }: {
@@ -530,7 +529,6 @@ export class Orchestrator {
         command: SyncCommand;
         environmentId: number;
         logCtx: LogContext;
-        recordsService: RecordsServiceInterface;
         initiator: string;
         delete_records?: boolean | undefined;
     }): Promise<Result<void>> {
@@ -575,26 +573,7 @@ export class Orchestrator {
                         return Err(deletedCheckpoints.error);
                     }
 
-                    // TODO:
-                    // - remove block once the records deletion is handled as part of the sync execution
-                    // - pass the delete_records flag as part of the executeSync extra options
-                    if (delete_records) {
-                        const syncConfig = await getSyncConfigBySyncId(syncId);
-                        const models = syncConfig?.models || [];
-                        for (let model of models) {
-                            if (syncVariant !== 'base') {
-                                model = `${model}::${syncVariant}`;
-                            }
-                            const deletion = await recordsService.deleteRecords({ environmentId, connectionId, model, mode: 'hard' });
-                            if (deletion.isErr()) {
-                                void logCtx.error(`Records for model ${model} failed to be deleted`, { error: deletion.error });
-                                return Err(deletion.error);
-                            }
-                            void logCtx.info(`Records for model ${model} were deleted successfully`, deletion.value);
-                        }
-                    }
-
-                    res = await this.client.executeSync({ scheduleName, extra: { emptyCache: false } });
+                    res = await this.client.executeSync({ scheduleName, extra: { emptyCache: delete_records || false } });
                     break;
                 }
             }

--- a/packages/shared/lib/services/sync/manager.service.ts
+++ b/packages/shared/lib/services/sync/manager.service.ts
@@ -261,7 +261,6 @@ export class SyncManagerService {
     }
 
     public async runSyncCommand({
-        recordsService,
         orchestrator,
         environment,
         providerConfigKey,
@@ -272,7 +271,6 @@ export class SyncManagerService {
         initiator,
         deleteRecords
     }: {
-        recordsService: RecordsServiceInterface;
         orchestrator: Orchestrator;
         environment: DBEnvironment;
         providerConfigKey: string;
@@ -335,7 +333,6 @@ export class SyncManagerService {
                     command,
                     environmentId: environment.id,
                     logCtx,
-                    recordsService,
                     initiator,
                     delete_records: deleteRecords
                 });
@@ -369,7 +366,6 @@ export class SyncManagerService {
                     command,
                     environmentId: environment.id,
                     logCtx,
-                    recordsService,
                     initiator,
                     delete_records: deleteRecords
                 });


### PR DESCRIPTION
Removing old logic to clear cache that was happening outside of the sync execution and passing the correct value to emptyCache
<!-- Describe the problem and your solution --> 

<!-- Issue ticket number and link (if applicable) -->

<!-- Testing instructions (skip if just adding/editing providers) -->

