### PR TITLE
fix(refresh): emit credential refresh failures to stdout

### DIFF
--- a/packages/shared/lib/services/connections/credentials/refresh.ts
+++ b/packages/shared/lib/services/connections/credentials/refresh.ts
@@ -2,7 +2,7 @@ import tracer from 'dd-trace';
 
 import { getLocking } from '@nangohq/kvstore';
 import { getProvider } from '@nangohq/providers';
-import { Err, FixedSizeMap, Ok, getLogger, metrics } from '@nangohq/utils';
+import { Err, FixedSizeMap, Ok, errorToObject, getLogger, metrics } from '@nangohq/utils';
 
 import { decode as decodeJwt } from '../../../auth/jwt.js';
 import providerClient from '../../../clients/provider.client.js';
@@ -212,7 +212,7 @@ async function refreshCredentials(
         logCtx.merge(logsBuffer);
 
         metrics.increment(metrics.Types.REFRESH_CONNECTIONS_FAILED);
-        logger.error('Failed to refresh credentials', err);
+        logger.error('Failed to refresh credentials', errorToObject(err));
         void logCtx.error('Failed to refresh credentials', err);
         await logCtx.failed();
 

--- a/packages/shared/lib/services/connections/credentials/refresh.ts
+++ b/packages/shared/lib/services/connections/credentials/refresh.ts
@@ -212,6 +212,7 @@ async function refreshCredentials(
         logCtx.merge(logsBuffer);
 
         metrics.increment(metrics.Types.REFRESH_CONNECTIONS_FAILED);
+        logger.error('Failed to refresh credentials', err);
         void logCtx.error('Failed to refresh credentials', err);
         await logCtx.failed();
 


### PR DESCRIPTION
## Describe the problem and your solution

In `packages/shared/lib/services/connections/credentials/refresh.ts`, the credential refresh failure path only writes through `logCtx.error('Failed to refresh credentials', err)`, which persists to the internal Postgres logs store. The operation start is logged via `logger.info('Refreshing', ...)` (stdout), so deployments that forward container logs see the refresh begin but never the failure reason or the state transition to failed.

This change adds a `logger.error('Failed to refresh credentials', err)` call alongside the existing `logCtx.error(...)` so failure details surface in stdout — useful for log-forwarding setups — while keeping the internal logs store behavior unchanged.

### Change

```diff
 metrics.increment(metrics.Types.REFRESH_CONNECTIONS_FAILED);
+logger.error('Failed to refresh credentials', err);
 void logCtx.error('Failed to refresh credentials', err);
 await logCtx.failed();
```

The `logger` is already declared at the top of the file (`const logger = getLogger('connectionRefresh');`) and used elsewhere in this module, so no new imports are needed.
