### PR TITLE
fix(northbeam): use validation endpoint that does not have required params

### DIFF
--- a/packages/providers/providers.yaml
+++ b/packages/providers/providers.yaml
@@ -12120,7 +12120,7 @@ northbeam:
         verification:
             method: GET
             endpoints:
-                - /v2/orders
+                - /v1/exports/attribution-models
     docs: https://nango.dev/docs/api-integrations/northbeam
     docs_connect: https://nango.dev/docs/api-integrations/northbeam/connect
     connection_config:


### PR DESCRIPTION
The verification endpoint pointed at /v2/orders has required parameters that cause a 400 response. Using `/v1/exports/attribution-models` as the verification target works because there are no params necessary. 

Confirmed working, hitting the endpoint directly.

Validation endpoint docs - https://docs.northbeam.io/v2.3/reference/get_attribution-models