### PR TITLE
docs: add April 2026 changelog entry

### DIFF
--- a/docs/updates/changelog.mdx
+++ b/docs/updates/changelog.mdx
@@ -4,6 +4,74 @@ sidebarTitle: "Changelog"
 description: "Important developer & product updates, including deprecations & breaking changes."
 ---
 
+<Update label="May 5, 2026">
+  <AccordionGroup>
+    <Accordion icon="webhook" title="50 new APIs in April">
+      - [Apple Business Manager](/api-integrations/apple-business-manager)
+      - [AWS Inspector2](/api-integrations/aws-inspector2)
+      - [AWS Multi-Service](/api-integrations/aws-multi-service)
+      - [Bing Webmasters](/api-integrations/bing-webmasters)
+      - [Cin7 Core](/api-integrations/cin7-core)
+      - [Cisco Duo Admin API](/api-integrations/cisco-duo-admin)
+      - [ClickHouse](/api-integrations/clickhouse)
+      - [Clover](/api-integrations/clover)
+      - [Crunchbase](/api-integrations/crunchbase)
+      - [Energy Performance Certificates (Gov.UK)](/api-integrations/epc-gov-uk)
+      - [Etsy](/api-integrations/etsy)
+      - [Freepik](/api-integrations/freepik)
+      - [Getty Images](/api-integrations/getty-images)
+      - [Google Maps](/api-integrations/google-maps)
+      - [Halo PSA](/api-integrations/halo-psa)
+      - [Hex](/api-integrations/hex)
+      - [Kno Commerce](/api-integrations/kno-commerce)
+      - [Listrak](/api-integrations/listrak)
+      - [Lob](/api-integrations/lob)
+      - [Lokalise](/api-integrations/lokalise)
+      - [Looker (OAuth)](/api-integrations/looker-oauth)
+      - [Maxio](/api-integrations/maxio)
+      - [Modjo AI](/api-integrations/modjo-ai)
+      - [Northbeam](/api-integrations/northbeam)
+      - [Ocean.io](/api-integrations/ocean-io)
+      - [Orange Logic](/api-integrations/orange-logic)
+      - [Paligo](/api-integrations/paligo)
+      - [Pendo (OAuth)](/api-integrations/pendo-oauth)
+      - [Perk](/api-integrations/perk)
+      - [PostHog (OAuth)](/api-integrations/posthog-oauth)
+      - [PRTG Classic](/api-integrations/prtg-classic)
+      - [Qualia](/api-integrations/qualia)
+      - [Quipteams](/api-integrations/quipteams)
+      - [Ringover](/api-integrations/ringover)
+      - [RocketReach](/api-integrations/rocketreach)
+      - [Rydoo](/api-integrations/rydoo)
+      - [SentinelOne](/api-integrations/sentinelone)
+      - [Shopify (Client Credentials)](/api-integrations/shopify-cc)
+      - [simPRO](/api-integrations/simpro)
+      - [Stay AI](/api-integrations/stay-ai)
+      - [Stitch (MCP)](/api-integrations/stitch-mcp)
+      - [Store Leads](/api-integrations/store-leads)
+      - [Supabase (MCP OAuth)](/api-integrations/supabase-mcp-oauth)
+      - [TalentLMS](/api-integrations/talentlms)
+      - [VTEX](/api-integrations/vtex)
+      - [WeJam AI](/api-integrations/wejam)
+      - [Workday Adaptive Planning](/api-integrations/workday-adaptive-planning)
+      - [Workday Adaptive Planning (Basic Auth)](/api-integrations/workday-adaptive-planning-basic)
+      - [Workpath](/api-integrations/workpath)
+      - [Zorus](/api-integrations/zorus)
+    </Accordion>
+  </AccordionGroup>
+
+  ## New blog posts
+
+  New posts from the Nango team in April:
+
+  - [The emergence of just-in-time integrations](https://www.nango.dev/blog/just-in-time-integrations)
+  - [Introducing the Nango API integrations builder skill](https://www.nango.dev/blog/nango-api-integrations-builder-skill)
+  - [How to build a real-time Google Calendar API integration](https://www.nango.dev/blog/how-to-build-a-real-time-google-calendar-api-integration)
+  - [Best API integration platforms to use with Claude Code, Cursor, and Codex (2026)](https://www.nango.dev/blog/best-api-integration-platforms-claude-code-cursor-codex)
+  - [Best agentic API integrations platform in 2026](https://www.nango.dev/blog/best-agentic-api-integrations-platform)
+</Update>
+---
+
 <Update label="April 22, 2026">
   ## API keys
 


### PR DESCRIPTION
## Summary
April 2026 monthly digest: 50 new APIs and 5 new blog posts.