### PR TITLE
docs: fix TOC active state on changelog for tall sections

### DIFF
--- a/docs/custom.css
+++ b/docs/custom.css
@@ -306,6 +306,20 @@ html:not(.dark) li[data-active="true"] > a { border-radius: 4px !important; }
   background-color: rgba(255, 255, 255, 0.08) !important;
 }
 
+/* ══ TOC — scroll-active fallback (changelog tall sections) ══════ */
+/*
+ * Show our scroll-derived active state only when Mintlify has no native
+ * active item. :not(:has(...)) ensures the two never conflict.
+ */
+#table-of-contents:not(:has(.toc-item[data-active="true"])) .toc-item[data-scroll-active="true"] > a {
+  background-color: rgba(255, 255, 255, 0.07) !important;
+  color: #ffffff !important;
+}
+html:not(.dark) #table-of-contents:not(:has(.toc-item[data-active="true"])) .toc-item[data-scroll-active="true"] > a {
+  background-color: rgba(0, 0, 0, 0.06) !important;
+  color: #000000 !important;
+}
+
 /* ══ HIDE BOTTOM CHAT ASSISTANT INPUT ════════════════════════════ */
 /*
  * Mintlify pins an "Ask a question..." chat-assistant input at the

--- a/docs/custom.css
+++ b/docs/custom.css
@@ -73,6 +73,30 @@ html:not(.dark) :has(> #sidebar-content) { border-right: 1px solid rgba(0, 0, 0,
 #sidebar-content .pointer-events-none.sticky { display: none !important; }
 #navigation-items { padding-top: 20px !important; }
 
+/* ══ TOC SCROLL-TRACKED ACTIVE — fallback for long sections ══════ */
+/*
+ * Mintlify's IntersectionObserver only marks an entry active while
+ * its anchor element is within the observed viewport strip (~top 15%).
+ * Changelog <Update> blocks can be many screens tall, so after
+ * scrolling past a heading the TOC loses its active state entirely.
+ *
+ * custom.js sets data-scroll-active="true" on the matching TOC item
+ * based on scroll position. We apply these styles only when Mintlify
+ * has no [data-active] item of its own, so the two never conflict.
+ */
+html:not(.dark) #table-of-contents:not(:has(.toc-item[data-active="true"])) .toc-item[data-scroll-active="true"] > a {
+  background-color: rgba(0, 0, 0, 0.06) !important;
+  color: rgb(0, 0, 0) !important;
+  font-weight: 500 !important;
+  border-radius: 4px !important;
+}
+.dark #table-of-contents:not(:has(.toc-item[data-active="true"])) .toc-item[data-scroll-active="true"] > a {
+  background-color: rgba(255, 255, 255, 0.07) !important;
+  color: rgba(255, 255, 255, 0.9) !important;
+  font-weight: 500 !important;
+  border-radius: 4px !important;
+}
+
 /* ══ TOC — hide scrollbar until hover ════════════════════════════ */
 /*
  * #table-of-contents has overflow-y-auto directly on it. Hide the

--- a/docs/custom.css
+++ b/docs/custom.css
@@ -143,6 +143,22 @@ html:not(.dark) #table-of-contents:not(:has(.toc-item[data-active="true"])) .toc
   display: block !important;
 }
 
+/* ══ TOC — scroll-active fallback (changelog tall sections) ══════ */
+/*
+ * Show our scroll-derived active state only when Mintlify has no native
+ * active item. :not(:has(...)) ensures the two never conflict.
+ * No !important needed — the ID + pseudo-class + attribute selector
+ * chain outweighs any Tailwind utility class.
+ */
+#table-of-contents:not(:has(.toc-item[data-active="true"])) .toc-item[data-scroll-active="true"] > a {
+  background-color: rgba(255, 255, 255, 0.07);
+  color: #ffffff;
+}
+html:not(.dark) #table-of-contents:not(:has(.toc-item[data-active="true"])) .toc-item[data-scroll-active="true"] > a {
+  background-color: rgba(0, 0, 0, 0.06);
+  color: #000000;
+}
+
 /* ══ CHANGELOG PAGE — hide left sidebar, keep TOC ════════════════ */
 /*
  * Mintlify sets data-page-href on the #content div. We use :has()
@@ -328,20 +344,6 @@ html:not(.dark) li[data-active="true"] > a { border-radius: 4px !important; }
 }
 .dark #navbar a[href="https://app.nango.dev"]:hover {
   background-color: rgba(255, 255, 255, 0.08) !important;
-}
-
-/* ══ TOC — scroll-active fallback (changelog tall sections) ══════ */
-/*
- * Show our scroll-derived active state only when Mintlify has no native
- * active item. :not(:has(...)) ensures the two never conflict.
- */
-#table-of-contents:not(:has(.toc-item[data-active="true"])) .toc-item[data-scroll-active="true"] > a {
-  background-color: rgba(255, 255, 255, 0.07) !important;
-  color: #ffffff !important;
-}
-html:not(.dark) #table-of-contents:not(:has(.toc-item[data-active="true"])) .toc-item[data-scroll-active="true"] > a {
-  background-color: rgba(0, 0, 0, 0.06) !important;
-  color: #000000 !important;
 }
 
 /* ══ HIDE BOTTOM CHAT ASSISTANT INPUT ════════════════════════════ */

--- a/docs/custom.css
+++ b/docs/custom.css
@@ -73,30 +73,6 @@ html:not(.dark) :has(> #sidebar-content) { border-right: 1px solid rgba(0, 0, 0,
 #sidebar-content .pointer-events-none.sticky { display: none !important; }
 #navigation-items { padding-top: 20px !important; }
 
-/* ══ TOC SCROLL-TRACKED ACTIVE — fallback for long sections ══════ */
-/*
- * Mintlify's IntersectionObserver only marks an entry active while
- * its anchor element is within the observed viewport strip (~top 15%).
- * Changelog <Update> blocks can be many screens tall, so after
- * scrolling past a heading the TOC loses its active state entirely.
- *
- * custom.js sets data-scroll-active="true" on the matching TOC item
- * based on scroll position. We apply these styles only when Mintlify
- * has no [data-active] item of its own, so the two never conflict.
- */
-html:not(.dark) #table-of-contents:not(:has(.toc-item[data-active="true"])) .toc-item[data-scroll-active="true"] > a {
-  background-color: rgba(0, 0, 0, 0.06) !important;
-  color: rgb(0, 0, 0) !important;
-  font-weight: 500 !important;
-  border-radius: 4px !important;
-}
-.dark #table-of-contents:not(:has(.toc-item[data-active="true"])) .toc-item[data-scroll-active="true"] > a {
-  background-color: rgba(255, 255, 255, 0.07) !important;
-  color: rgba(255, 255, 255, 0.9) !important;
-  font-weight: 500 !important;
-  border-radius: 4px !important;
-}
-
 /* ══ TOC — hide scrollbar until hover ════════════════════════════ */
 /*
  * #table-of-contents has overflow-y-auto directly on it. Hide the
@@ -150,13 +126,15 @@ html:not(.dark) #table-of-contents:not(:has(.toc-item[data-active="true"])) .toc
  * No !important needed — the ID + pseudo-class + attribute selector
  * chain outweighs any Tailwind utility class.
  */
-#table-of-contents:not(:has(.toc-item[data-active="true"])) .toc-item[data-scroll-active="true"] > a {
+.dark #table-of-contents:not(:has(.toc-item[data-active="true"])) .toc-item[data-scroll-active="true"] > a {
   background-color: rgba(255, 255, 255, 0.07);
-  color: #ffffff;
+  color: rgba(255, 255, 255, 0.9);
+  font-weight: 500;
 }
 html:not(.dark) #table-of-contents:not(:has(.toc-item[data-active="true"])) .toc-item[data-scroll-active="true"] > a {
   background-color: rgba(0, 0, 0, 0.06);
   color: #000000;
+  font-weight: 500;
 }
 
 /* ══ CHANGELOG PAGE — hide left sidebar, keep TOC ════════════════ */

--- a/docs/custom.js
+++ b/docs/custom.js
@@ -1,0 +1,99 @@
+/* global document, window, location, requestAnimationFrame */
+/* ── Changelog TOC scroll-active fallback ──────────────────────────────── */
+/*
+ * Mintlify's IntersectionObserver only fires while a section heading is in
+ * the top ~15% of the viewport. Changelog <Update> blocks are many screens
+ * tall, so the heading anchor leaves that strip almost immediately and
+ * Mintlify clears the active highlight entirely.
+ *
+ * This script maintains a data-scroll-active="true" attribute on the
+ * matching .toc-item element based on which heading has most recently
+ * scrolled past 30% of the viewport. CSS shows it only when Mintlify has
+ * no native data-active="true" item, so the two never conflict.
+ */
+(function () {
+  var rafPending = false;
+  var currentPath = location.pathname;
+
+  function getHeadings() {
+    return Array.from(document.querySelectorAll('#content-area h2, #content-area h3'));
+  }
+
+  function getTocItems() {
+    return Array.from(document.querySelectorAll('#table-of-contents .toc-item'));
+  }
+
+  function clearScrollActive() {
+    getTocItems().forEach(function (item) {
+      item.removeAttribute('data-scroll-active');
+    });
+  }
+
+  function updateActive() {
+    rafPending = false;
+
+    var threshold = window.innerHeight * 0.3;
+    var headings = getHeadings();
+    if (!headings.length) return;
+
+    // Find the last heading whose top edge is at or above 30% viewport height
+    var active = null;
+    for (var i = 0; i < headings.length; i++) {
+      if (headings[i].getBoundingClientRect().top <= threshold) {
+        active = headings[i];
+      }
+    }
+    if (!active) active = headings[0];
+
+    var id = active.id;
+    var tocItems = getTocItems();
+
+    tocItems.forEach(function (item) {
+      var link = item.querySelector('a');
+      if (link && link.getAttribute('href') === '#' + id) {
+        item.setAttribute('data-scroll-active', 'true');
+      } else {
+        item.removeAttribute('data-scroll-active');
+      }
+    });
+  }
+
+  function onScroll() {
+    if (!rafPending) {
+      rafPending = true;
+      requestAnimationFrame(updateActive);
+    }
+  }
+
+  function setup() {
+    window.addEventListener('scroll', onScroll, { passive: true });
+    updateActive();
+  }
+
+  function teardown() {
+    window.removeEventListener('scroll', onScroll);
+    clearScrollActive();
+  }
+
+  // Re-run on Next.js SPA navigation (URL changes without full page reload)
+  function watchNavigation() {
+    setInterval(function () {
+      if (location.pathname !== currentPath) {
+        currentPath = location.pathname;
+        teardown();
+        // Small delay to let Next.js finish swapping the DOM
+        setTimeout(setup, 200);
+      }
+    }, 200);
+  }
+
+  if (document.readyState === 'loading') {
+    document.addEventListener('DOMContentLoaded', function () {
+      setup();
+      watchNavigation();
+    });
+  } else {
+    setup();
+    watchNavigation();
+  }
+})();

--- a/docs/custom.js
+++ b/docs/custom.js
@@ -1,23 +1,20 @@
 /* global document, window, location, requestAnimationFrame */
 /* ── Changelog TOC scroll-active fallback ──────────────────────────────── */
 /*
- * Mintlify's IntersectionObserver only fires while a section heading is in
+ * Mintlify's IntersectionObserver only fires while a section anchor is in
  * the top ~15% of the viewport. Changelog <Update> blocks are many screens
- * tall, so the heading anchor leaves that strip almost immediately and
- * Mintlify clears the active highlight entirely.
+ * tall, so the anchor leaves that strip almost immediately and Mintlify
+ * clears the active highlight entirely.
  *
  * This script maintains a data-scroll-active="true" attribute on the
- * matching .toc-item element based on which heading has most recently
- * scrolled past 30% of the viewport. CSS shows it only when Mintlify has
- * no native data-active="true" item, so the two never conflict.
+ * matching .toc-item element. It resolves anchor targets directly from TOC
+ * link hrefs (which point to <div id="..."> Update containers, not headings).
+ * CSS shows the fallback only when Mintlify has no native data-active="true"
+ * item, so the two never conflict.
  */
 (function () {
   var rafPending = false;
   var currentPath = location.pathname;
-
-  function getHeadings() {
-    return Array.from(document.querySelectorAll('#content-area h2, #content-area h3'));
-  }
 
   function getTocItems() {
     return Array.from(document.querySelectorAll('#table-of-contents .toc-item'));
@@ -32,25 +29,33 @@
   function updateActive() {
     rafPending = false;
 
-    var threshold = window.innerHeight * 0.3;
-    var headings = getHeadings();
-    if (!headings.length) return;
-
-    // Find the last heading whose top edge is at or above 30% viewport height
-    var active = null;
-    for (var i = 0; i < headings.length; i++) {
-      if (headings[i].getBoundingClientRect().top <= threshold) {
-        active = headings[i];
-      }
-    }
-    if (!active) active = headings[0];
-
-    var id = active.id;
     var tocItems = getTocItems();
+    if (!tocItems.length) return;
 
+    // Build ordered list of {item, target} pairs from TOC link hrefs
+    var anchors = [];
     tocItems.forEach(function (item) {
       var link = item.querySelector('a');
-      if (link && link.getAttribute('href') === '#' + id) {
+      if (!link) return;
+      var href = link.getAttribute('href');
+      if (!href || href.charAt(0) !== '#') return;
+      var target = document.getElementById(href.slice(1));
+      if (target) anchors.push({ item: item, target: target });
+    });
+    if (!anchors.length) return;
+
+    // The active section is the last anchor whose top edge is at or above
+    // 30% of the viewport height (i.e. it has scrolled into view past that point)
+    var threshold = window.innerHeight * 0.3;
+    var active = anchors[0];
+    for (var i = 0; i < anchors.length; i++) {
+      if (anchors[i].target.getBoundingClientRect().top <= threshold) {
+        active = anchors[i];
+      }
+    }
+
+    tocItems.forEach(function (item) {
+      if (item === active.item) {
         item.setAttribute('data-scroll-active', 'true');
       } else {
         item.removeAttribute('data-scroll-active');

--- a/docs/custom.js
+++ b/docs/custom.js
@@ -1,65 +1,39 @@
-/* global document, window, location, requestAnimationFrame, history */
+/* global document, window, requestAnimationFrame, history */
 /* ── Changelog TOC scroll-active fallback ──────────────────────────────── */
 /*
- * Mintlify's IntersectionObserver only fires while a section anchor is in
- * the top ~15% of the viewport. Changelog <Update> blocks are many screens
- * tall, so the anchor leaves that strip almost immediately and Mintlify
- * clears the active highlight entirely.
+ * Mintlify clears the TOC active highlight as soon as a section anchor
+ * scrolls past the top ~15% of the viewport. Changelog <Update> blocks
+ * span many screens, so the TOC goes dark.
  *
- * This script maintains a data-scroll-active="true" attribute on the
- * matching .toc-item element. It resolves anchor targets directly from TOC
- * link hrefs (which point to <div id="..."> Update containers, not headings).
- * CSS shows the fallback only when Mintlify has no native data-active="true"
- * item, so the two never conflict.
+ * Set data-scroll-active="true" on the TOC item whose target has scrolled
+ * past 30% of the viewport. CSS only applies it when Mintlify has no
+ * native data-active item, so the two never conflict.
  */
 (function () {
   var rafPending = false;
-  var currentPath = location.pathname;
-  var cachedAnchors = null; // built once per page, invalidated on navigation
-  var navigationWatching = false;
-
-  function buildAnchors() {
-    var result = [];
-    document.querySelectorAll('#table-of-contents .toc-item').forEach(function (item) {
-      var link = item.querySelector('a');
-      if (!link) return;
-      var href = link.getAttribute('href');
-      if (!href || href.charAt(0) !== '#') return;
-      var target = document.getElementById(href.slice(1));
-      if (target) result.push({ item: item, target: target });
-    });
-    return result;
-  }
-
-  function clearScrollActive() {
-    document.querySelectorAll('#table-of-contents .toc-item[data-scroll-active]').forEach(function (item) {
-      item.removeAttribute('data-scroll-active');
-    });
-  }
 
   function updateActive() {
     rafPending = false;
-    // Don't cache empty results — TOC may not be mounted yet on a fresh
-    // SPA navigation. Keep retrying until we get a non-empty list.
-    if (!cachedAnchors || !cachedAnchors.length) cachedAnchors = buildAnchors();
-    var anchors = cachedAnchors;
-    if (!anchors.length) return;
+    var items = document.querySelectorAll('#table-of-contents .toc-item');
+    if (!items.length) return;
 
-    // The active section is the last anchor whose top edge is at or above
-    // 30% of the viewport height (i.e. it has scrolled into view past that point)
     var threshold = window.innerHeight * 0.3;
-    var active = anchors[0];
-    for (var i = 0; i < anchors.length; i++) {
-      if (anchors[i].target.getBoundingClientRect().top <= threshold) {
-        active = anchors[i];
+    var activeItem = null;
+    items.forEach(function (item) {
+      var link = item.querySelector('a');
+      var href = link && link.getAttribute('href');
+      if (!href || href.charAt(0) !== '#') return;
+      var target = document.getElementById(href.slice(1));
+      if (target && target.getBoundingClientRect().top <= threshold) {
+        activeItem = item;
       }
-    }
+    });
 
-    anchors.forEach(function (a) {
-      if (a === active) {
-        a.item.setAttribute('data-scroll-active', 'true');
+    items.forEach(function (item) {
+      if (item === activeItem) {
+        item.setAttribute('data-scroll-active', 'true');
       } else {
-        a.item.removeAttribute('data-scroll-active');
+        item.removeAttribute('data-scroll-active');
       }
     });
   }
@@ -71,53 +45,28 @@
     }
   }
 
-  function setup() {
-    cachedAnchors = null; // invalidate for the new page
-    window.addEventListener('scroll', onScroll, { passive: true });
-    updateActive();
-  }
-
-  function teardown() {
-    window.removeEventListener('scroll', onScroll);
-    clearScrollActive();
-  }
-
+  // Re-run after Next.js SPA navigation. 200ms gives the DOM time to swap.
   function onNavigate() {
-    var newPath = location.pathname;
-    if (newPath !== currentPath) {
-      currentPath = newPath;
-      teardown();
-      // Small delay to let Next.js finish swapping the DOM
-      setTimeout(setup, 200);
-    }
+    setTimeout(updateActive, 200);
   }
 
-  // Called once — patches history and listens for popstate.
-  // The popstate listener intentionally lives here (not in teardown/setup)
-  // because navigation detection must survive page transitions.
-  function watchNavigation() {
-    if (navigationWatching) return;
-    navigationWatching = true;
-    var origPush = history.pushState;
-    history.pushState = function () {
-      origPush.apply(this, arguments);
-      onNavigate();
-    };
-    var origReplace = history.replaceState;
-    history.replaceState = function () {
-      origReplace.apply(this, arguments);
-      onNavigate();
-    };
-    window.addEventListener('popstate', onNavigate);
-  }
+  window.addEventListener('scroll', onScroll, { passive: true });
+  window.addEventListener('popstate', onNavigate);
+
+  var origPush = history.pushState;
+  history.pushState = function () {
+    origPush.apply(this, arguments);
+    onNavigate();
+  };
+  var origReplace = history.replaceState;
+  history.replaceState = function () {
+    origReplace.apply(this, arguments);
+    onNavigate();
+  };
 
   if (document.readyState === 'loading') {
-    document.addEventListener('DOMContentLoaded', function () {
-      setup();
-      watchNavigation();
-    });
+    document.addEventListener('DOMContentLoaded', updateActive);
   } else {
-    setup();
-    watchNavigation();
+    updateActive();
   }
 })();

--- a/docs/custom.js
+++ b/docs/custom.js
@@ -15,33 +15,32 @@
 (function () {
   var rafPending = false;
   var currentPath = location.pathname;
+  var cachedAnchors = null; // built once per page, invalidated on navigation
+  var navigationWatching = false;
 
-  function getTocItems() {
-    return Array.from(document.querySelectorAll('#table-of-contents .toc-item'));
+  function buildAnchors() {
+    var result = [];
+    document.querySelectorAll('#table-of-contents .toc-item').forEach(function (item) {
+      var link = item.querySelector('a');
+      if (!link) return;
+      var href = link.getAttribute('href');
+      if (!href || href.charAt(0) !== '#') return;
+      var target = document.getElementById(href.slice(1));
+      if (target) result.push({ item: item, target: target });
+    });
+    return result;
   }
 
   function clearScrollActive() {
-    getTocItems().forEach(function (item) {
+    document.querySelectorAll('#table-of-contents .toc-item[data-scroll-active]').forEach(function (item) {
       item.removeAttribute('data-scroll-active');
     });
   }
 
   function updateActive() {
     rafPending = false;
-
-    var tocItems = getTocItems();
-    if (!tocItems.length) return;
-
-    // Build ordered list of {item, target} pairs from TOC link hrefs
-    var anchors = [];
-    tocItems.forEach(function (item) {
-      var link = item.querySelector('a');
-      if (!link) return;
-      var href = link.getAttribute('href');
-      if (!href || href.charAt(0) !== '#') return;
-      var target = document.getElementById(href.slice(1));
-      if (target) anchors.push({ item: item, target: target });
-    });
+    if (!cachedAnchors) cachedAnchors = buildAnchors();
+    var anchors = cachedAnchors;
     if (!anchors.length) return;
 
     // The active section is the last anchor whose top edge is at or above
@@ -54,11 +53,11 @@
       }
     }
 
-    tocItems.forEach(function (item) {
-      if (item === active.item) {
-        item.setAttribute('data-scroll-active', 'true');
+    anchors.forEach(function (a) {
+      if (a === active) {
+        a.item.setAttribute('data-scroll-active', 'true');
       } else {
-        item.removeAttribute('data-scroll-active');
+        a.item.removeAttribute('data-scroll-active');
       }
     });
   }
@@ -71,6 +70,7 @@
   }
 
   function setup() {
+    cachedAnchors = null; // invalidate for the new page
     window.addEventListener('scroll', onScroll, { passive: true });
     updateActive();
   }
@@ -80,7 +80,6 @@
     clearScrollActive();
   }
 
-  // Re-run on Next.js SPA navigation (event-driven, no polling)
   function onNavigate() {
     var newPath = location.pathname;
     if (newPath !== currentPath) {
@@ -91,8 +90,12 @@
     }
   }
 
+  // Called once — patches history and listens for popstate.
+  // The popstate listener intentionally lives here (not in teardown/setup)
+  // because navigation detection must survive page transitions.
   function watchNavigation() {
-    // Patch pushState / replaceState to catch programmatic navigation
+    if (navigationWatching) return;
+    navigationWatching = true;
     var origPush = history.pushState;
     history.pushState = function () {
       origPush.apply(this, arguments);
@@ -103,7 +106,6 @@
       origReplace.apply(this, arguments);
       onNavigate();
     };
-    // Catch browser back/forward
     window.addEventListener('popstate', onNavigate);
   }
 

--- a/docs/custom.js
+++ b/docs/custom.js
@@ -39,7 +39,9 @@
 
   function updateActive() {
     rafPending = false;
-    if (!cachedAnchors) cachedAnchors = buildAnchors();
+    // Don't cache empty results — TOC may not be mounted yet on a fresh
+    // SPA navigation. Keep retrying until we get a non-empty list.
+    if (!cachedAnchors || !cachedAnchors.length) cachedAnchors = buildAnchors();
     var anchors = cachedAnchors;
     if (!anchors.length) return;
 

--- a/docs/custom.js
+++ b/docs/custom.js
@@ -1,4 +1,4 @@
-/* global document, window, location, requestAnimationFrame */
+/* global document, window, location, requestAnimationFrame, history */
 /* ── Changelog TOC scroll-active fallback ──────────────────────────────── */
 /*
  * Mintlify's IntersectionObserver only fires while a section anchor is in
@@ -80,16 +80,31 @@
     clearScrollActive();
   }
 
-  // Re-run on Next.js SPA navigation (URL changes without full page reload)
+  // Re-run on Next.js SPA navigation (event-driven, no polling)
+  function onNavigate() {
+    var newPath = location.pathname;
+    if (newPath !== currentPath) {
+      currentPath = newPath;
+      teardown();
+      // Small delay to let Next.js finish swapping the DOM
+      setTimeout(setup, 200);
+    }
+  }
+
   function watchNavigation() {
-    setInterval(function () {
-      if (location.pathname !== currentPath) {
-        currentPath = location.pathname;
-        teardown();
-        // Small delay to let Next.js finish swapping the DOM
-        setTimeout(setup, 200);
-      }
-    }, 200);
+    // Patch pushState / replaceState to catch programmatic navigation
+    var origPush = history.pushState;
+    history.pushState = function () {
+      origPush.apply(this, arguments);
+      onNavigate();
+    };
+    var origReplace = history.replaceState;
+    history.replaceState = function () {
+      origReplace.apply(this, arguments);
+      onNavigate();
+    };
+    // Catch browser back/forward
+    window.addEventListener('popstate', onNavigate);
   }
 
   if (document.readyState === 'loading') {

--- a/docs/docs.json
+++ b/docs/docs.json
@@ -21,6 +21,7 @@
     }
   },
   "css": "custom.css",
+  "js": "custom.js",
   "logo": {
     "light": "/images/Nango-Light-Mode.svg",
     "dark": "/images/Nango-Dark-Mode.svg",


### PR DESCRIPTION
<!-- Describe the problem and your solution -->

Fixes the changelog TOC active state disappearing when scrolling through tall `<Update>` sections.

Mintlify's IntersectionObserver only marks a TOC item active while its anchor is in the top ~15% of the viewport. Changelog entries are many screens tall, so the anchor leaves that strip almost immediately and the TOC goes dark for the rest of the section.

**Solution:**

- `docs/custom.js` — scroll listener (rAF-throttled) that sets `data-scroll-active="true"` on the `.toc-item` whose target has scrolled past 30% of the viewport. Targets are resolved directly from each TOC link's `href`, which on the changelog page points to `<div id="...">` Update containers (not headings). SPA navigation is handled by patching `history.pushState`/`replaceState` and listening to `popstate` — no polling.
- `docs/custom.css` — fallback highlight scoped behind `:not(:has(.toc-item[data-active="true"]))` so it only applies when Mintlify has no native active item. The two never conflict.
- `docs/docs.json` — wires up `custom.js`.

<!-- Issue ticket number and link (if applicable) -->

Linear: [NAN-5451](https://linear.app/nango/issue/NAN-5451)

## Screenshots

**Before**
<img width="1405" height="558" alt="image" src="https://github.com/user-attachments/assets/67e4e7e9-6692-4a4f-af35-58bf260d793c" />

**After**
<img width="1419" height="569" alt="image" src="https://github.com/user-attachments/assets/87d71103-dcd4-44a8-88a9-95a68811f5a2" />
