### PR TITLE
docs: sync dark/light mode with website

### DIFF
--- a/docs/custom.js
+++ b/docs/custom.js
@@ -1,4 +1,4 @@
-/* global document, window, requestAnimationFrame, history */
+/* global document, window, requestAnimationFrame, history, localStorage, MutationObserver */
 /* ── Changelog TOC scroll-active fallback ──────────────────────────────── */
 /*
  * Mintlify clears the TOC active highlight as soon as a section anchor
@@ -69,4 +69,57 @@
   } else {
     updateActive();
   }
+})();
+
+/* Theme sync between nango.dev (website) and nango.dev/docs (Mintlify).
+ *
+ * The two sites use different localStorage keys:
+ *   website  → localStorage.theme      ("dark" | "light" | "system")
+ *   Mintlify → localStorage.isDarkMode ("dark" | "light"; absent = OS preference)
+ *
+ * The website writes isDarkMode whenever the user explicitly picks dark/light,
+ * so Mintlify's own head script reads the correct value on page load (no flash).
+ * This script handles two remaining cases:
+ *   A) Cross-tab sync: user toggles theme on the website tab, docs tab updates.
+ *   B) Docs → website: user toggles in docs, write back to theme so the website
+ *      picks it up on the next visit.
+ */
+(function () {
+  'use strict';
+
+  var syncing = false;
+
+  // Case A: website changed theme in another tab/window
+  window.addEventListener('storage', function (e) {
+    if (e.key !== 'theme') return;
+    var t = e.newValue;
+    var isDark;
+    syncing = true;
+    if (t === 'dark' || t === 'light') {
+      isDark = t === 'dark';
+      document.documentElement.classList.toggle('dark', isDark);
+      localStorage.setItem('isDarkMode', t);
+    } else {
+      // 'system' or cleared — follow OS and let Mintlify use its own detection
+      isDark = window.matchMedia('(prefers-color-scheme: dark)').matches;
+      document.documentElement.classList.toggle('dark', isDark);
+      localStorage.removeItem('isDarkMode');
+    }
+    setTimeout(function () { syncing = false; }, 50);
+  });
+
+  // Case B: Mintlify toggled the dark class → write back to website's theme key
+  var observer = new MutationObserver(function () {
+    if (syncing) return;
+    var isDark = document.documentElement.classList.contains('dark');
+    var resolved = isDark ? 'dark' : 'light';
+    if (localStorage.getItem('theme') !== resolved) {
+      localStorage.setItem('theme', resolved);
+    }
+  });
+
+  observer.observe(document.documentElement, {
+    attributes: true,
+    attributeFilter: ['class'],
+  });
 })();


### PR DESCRIPTION
Linear Issue: [NAN-5453](https://linear.app/nango/issue/NAN-5453/sync-darklight-mode-between-website-and-docs)

Companion PR (website): NangoHQ/website#93

## Summary

The website (`localStorage.theme`) and Mintlify docs (`localStorage.isDarkMode`) use different storage keys, so toggling dark mode on the website had no effect in the docs.

- `docs.json`: adds `"js": "custom.js"` — the script existed but was never referenced, so it was never loaded in production
- `custom.js`: adds cross-tab sync (storage event listener propagates website theme changes to an open docs tab) and a MutationObserver that writes back to `localStorage.theme` when the user toggles inside the docs
- `eslint.config.mjs`: ignores `docs/custom.js` (browser-only script; consistent with existing `docs/script.js` ignore)

The website-side change (writing `isDarkMode` on explicit toggle) is in the companion PR above.

## Testing

1. Set dark mode on nango.dev → navigate to nango.dev/docs → docs opens dark
2. Toggle theme in docs → navigate back to website → website reflects the change
3. Open website and docs in separate tabs → toggle in one → the other updates