### PR TITLE
feat(providers): use a different pattern for salesforce hostname

### DIFF
--- a/packages/providers/providers.yaml
+++ b/packages/providers/providers.yaml
@@ -15494,7 +15494,7 @@ salesforce:
             type: string
             title: Hostname
             description: The hostname to your Salesforce instance
-            format: hostname
+            pattern: '^(?!.*\.lightning\.(force|salesforce)\.com)[a-zA-Z0-9]([a-zA-Z0-9\-]{0,61}[a-zA-Z0-9])?(\.[a-zA-Z0-9]([a-zA-Z0-9\-]{0,61}[a-zA-Z0-9])?)*$'
             example: acme.my.salesforce.com
             prefix: https://
             optional: true
@@ -15525,7 +15525,7 @@ salesforce-cc:
             type: string
             title: Hostname
             description: The hostname to your Salesforce instance
-            format: hostname
+            pattern: '^(?!.*\.lightning\.(force|salesforce)\.com)[a-zA-Z0-9]([a-zA-Z0-9\-]{0,61}[a-zA-Z0-9])?(\.[a-zA-Z0-9]([a-zA-Z0-9\-]{0,61}[a-zA-Z0-9])?)*$'
             example: acme.my.salesforce.com
             prefix: https://
 

--- a/packages/providers/providers.yaml
+++ b/packages/providers/providers.yaml
@@ -15494,7 +15494,7 @@ salesforce:
             type: string
             title: Hostname
             description: The hostname to your Salesforce instance
-            pattern: '^(?!.*\.lightning\.(force|salesforce)\.com)[a-zA-Z0-9]([a-zA-Z0-9\-]{0,61}[a-zA-Z0-9])?(\.[a-zA-Z0-9]([a-zA-Z0-9\-]{0,61}[a-zA-Z0-9])?)*$'
+            pattern: '^(?!(?:.*\.)?[Ll][Ii][Gg][Hh][Tt][Nn][Ii][Nn][Gg]\.([Ff][Oo][Rr][Cc][Ee]|[Ss][Aa][Ll][Ee][Ss][Ff][Oo][Rr][Cc][Ee])\.[Cc][Oo][Mm]$)[a-zA-Z0-9]([a-zA-Z0-9\-]{0,61}[a-zA-Z0-9])?(\.[a-zA-Z0-9]([a-zA-Z0-9\-]{0,61}[a-zA-Z0-9])?)*$'
             example: acme.my.salesforce.com
             prefix: https://
             optional: true
@@ -15525,7 +15525,7 @@ salesforce-cc:
             type: string
             title: Hostname
             description: The hostname to your Salesforce instance
-            pattern: '^(?!.*\.lightning\.(force|salesforce)\.com)[a-zA-Z0-9]([a-zA-Z0-9\-]{0,61}[a-zA-Z0-9])?(\.[a-zA-Z0-9]([a-zA-Z0-9\-]{0,61}[a-zA-Z0-9])?)*$'
+            pattern: '^(?!(?:.*\.)?[Ll][Ii][Gg][Hh][Tt][Nn][Ii][Nn][Gg]\.([Ff][Oo][Rr][Cc][Ee]|[Ss][Aa][Ll][Ee][Ss][Ff][Oo][Rr][Cc][Ee])\.[Cc][Oo][Mm]$)[a-zA-Z0-9]([a-zA-Z0-9\-]{0,61}[a-zA-Z0-9])?(\.[a-zA-Z0-9]([a-zA-Z0-9\-]{0,61}[a-zA-Z0-9])?)*$'
             example: acme.my.salesforce.com
             prefix: https://
 


### PR DESCRIPTION
## Describe the problem and your solution

- Use a different pattern for the Salesforce hostname to reject any web hostname containing `lightning.salesforce.com`.

<!-- Issue ticket number and link (if applicable) -->

<!-- Testing instructions (skip if just adding/editing providers) -->

