### PR TITLE
feat: add records_batch table

### DIFF
--- a/packages/persist/lib/app.ts
+++ b/packages/persist/lib/app.ts
@@ -7,6 +7,7 @@ import { getLogger, initSentry, once, report } from '@nangohq/utils';
 
 import { autoDeletingDaemon } from './daemons/autodeleting.daemon.js';
 import { autoPruningDaemon } from './daemons/autopruning.daemon.js';
+import { batchCleanupDaemon } from './daemons/batchCleanup.daemon.js';
 import { envs } from './env.js';
 import { pubsub } from './pubsub.js';
 import { server } from './server.js';
@@ -32,6 +33,7 @@ initSentry({ dsn: envs.SENTRY_DSN, applicationName: envs.NANGO_DB_APPLICATION_NA
 let api: Server;
 const autoPruning = autoPruningDaemon();
 const autoDeleting = autoDeletingDaemon();
+const batchCleanup = batchCleanupDaemon();
 
 try {
     const pubsubConnect = await pubsub.connect();
@@ -55,6 +57,7 @@ const close = once(() => {
     api.close(async () => {
         await autoPruning.abort();
         await autoDeleting.abort();
+        await batchCleanup.abort();
         await destroyLogs();
         await db.knex.destroy();
         await db.readOnly.destroy();

--- a/packages/persist/lib/daemons/batchCleanup.daemon.ts
+++ b/packages/persist/lib/daemons/batchCleanup.daemon.ts
@@ -1,0 +1,36 @@
+import tracer from 'dd-trace';
+
+import { records } from '@nangohq/records';
+import { cancellableDaemon } from '@nangohq/utils';
+
+import { envs } from '../env.js';
+import { logger } from '../logger.js';
+
+/*
+ * Batch cleanup daemon
+ * Deletes records_batch entries older than PERSIST_BATCH_CLEANUP_MAX_AGE_MS.
+ */
+export function batchCleanupDaemon(): Awaited<ReturnType<typeof cancellableDaemon>> {
+    return cancellableDaemon({
+        tickIntervalMs: envs.PERSIST_BATCH_CLEANUP_INTERVAL_MS,
+        tick: async (): Promise<void> => {
+            return tracer.trace('nango.persist.daemon.batchCleanup', async (span) => {
+                try {
+                    const olderThan = new Date(Date.now() - envs.PERSIST_BATCH_CLEANUP_MAX_AGE_MS);
+                    const res = await records.deleteOldBatchEntries({ olderThan, limit: envs.PERSIST_BATCH_CLEANUP_LIMIT });
+                    if (res.isErr()) {
+                        span?.addTags({ error: res.error.message });
+                        logger.error(`[Batch cleanup] error deleting old batch entries: ${res.error.message}`);
+                        return;
+                    }
+                    span?.addTags({ deleted: res.value });
+                } catch (err) {
+                    span?.addTags({ error: (err as Error).message });
+                    logger.error(`[Batch cleanup] unexpected error: ${(err as Error).message}`);
+                } finally {
+                    span?.finish();
+                }
+            });
+        }
+    });
+}

--- a/packages/records/lib/constants.ts
+++ b/packages/records/lib/constants.ts
@@ -1,3 +1,4 @@
 export const RECORDS_TABLE = 'records';
 export const RECORD_COUNTS_TABLE = 'record_counts';
 export const RECORDS_DATA_TABLE = 'records_data';
+export const RECORDS_BATCH_TABLE = 'records_batch';

--- a/packages/records/lib/db/migrations/20260505000100_create_records_batch.ts
+++ b/packages/records/lib/db/migrations/20260505000100_create_records_batch.ts
@@ -1,0 +1,20 @@
+import type { Knex } from 'knex';
+
+const TABLE = 'records_batch';
+
+export async function up(knex: Knex): Promise<void> {
+    await knex.raw(`
+        CREATE TABLE IF NOT EXISTS "${TABLE}" (
+            id             bigserial    PRIMARY KEY,
+            connection_id  integer      NOT NULL,
+            model          varchar(255) NOT NULL,
+            sync_job_id    integer      NOT NULL,
+            record_ids     uuid[]       NOT NULL,
+            created_at     timestamptz  NOT NULL DEFAULT CURRENT_TIMESTAMP
+        )
+    `);
+    await knex.raw(`CREATE INDEX IF NOT EXISTS records_batch_connection_model_job ON "${TABLE}" (connection_id, model, sync_job_id)`);
+    await knex.raw(`CREATE INDEX IF NOT EXISTS records_batch_created_at ON "${TABLE}" (created_at)`);
+}
+
+export async function down(): Promise<void> {}

--- a/packages/records/lib/models/records.ts
+++ b/packages/records/lib/models/records.ts
@@ -4,7 +4,7 @@ import tracer from 'dd-trace';
 
 import { Err, Ok, retry, stringToHash } from '@nangohq/utils';
 
-import { RECORDS_DATA_TABLE, RECORDS_TABLE, RECORD_COUNTS_TABLE } from '../constants.js';
+import { RECORDS_BATCH_TABLE, RECORDS_DATA_TABLE, RECORDS_TABLE, RECORD_COUNTS_TABLE } from '../constants.js';
 import { Cursor } from '../cursor.js';
 import { db, dbRead } from '../db/client.js';
 import { envs } from '../env.js';
@@ -64,6 +64,19 @@ function getInactiveThisMonth(records: UpsertedMetadata[]): UpsertedMetadata[] {
             return true;
         }
         return isInactiveThisMonth({ last_modified_at: r.last_modified_at, previous_last_modified_at: r.previous_last_modified_at });
+    });
+}
+
+async function insertBatchEntry(
+    trx: Knex.Transaction,
+    { connectionId, model, syncJobId, recordIds }: { connectionId: number; model: string; syncJobId: number; recordIds: string[] }
+): Promise<void> {
+    if (recordIds.length === 0) return;
+    await trx(RECORDS_BATCH_TABLE).insert({
+        connection_id: connectionId,
+        model,
+        sync_job_id: syncJobId,
+        record_ids: trx.raw(`ARRAY[${recordIds.map(() => '?::uuid').join(',')}]`, recordIds)
     });
 }
 
@@ -487,6 +500,13 @@ export async function upsert({
                             batchDeltaSizeInBytes = upsertDataResult.reduce((acc, r) => acc + r.new_size_bytes - r.prev_size_bytes, -totalLegacySizeInBytes);
                         }
 
+                        await insertBatchEntry(trx, {
+                            connectionId,
+                            model,
+                            syncJobId: chunk[0]!.sync_job_id,
+                            recordIds: upsertMetadata.map((r) => r.id)
+                        });
+
                         // Billing:
                         // A record is billed only once per month. ie:
                         // - If a record is inserted, it is billed
@@ -748,6 +768,13 @@ export async function update({
                         ]);
                     const updated = await query;
                     updatedKeys.push(...updated.map((record) => record.external_id));
+
+                    await insertBatchEntry(trx, {
+                        connectionId,
+                        model,
+                        syncJobId: encryptedRecords[0]!.sync_job_id,
+                        recordIds: updated.map((r) => r.id)
+                    });
 
                     for (const record of updated) {
                         const oldRecord = oldRecords.find((old) => old.external_id === record.external_id);
@@ -1169,6 +1196,17 @@ export async function deleteOutdatedRecords({
         return Err(e);
     } finally {
         span.finish();
+    }
+}
+
+export async function deleteOldBatchEntries({ olderThan, limit }: { olderThan: Date; limit: number }): Promise<Result<number>> {
+    try {
+        const count = await db(RECORDS_BATCH_TABLE)
+            .whereIn('id', db(RECORDS_BATCH_TABLE).select('id').where('created_at', '<', olderThan).limit(limit))
+            .delete();
+        return Ok(count);
+    } catch (err) {
+        return Err(new Error('Failed to delete old batch entries', { cause: err }));
     }
 }
 

--- a/packages/utils/lib/environment/parse.ts
+++ b/packages/utils/lib/environment/parse.ts
@@ -95,6 +95,12 @@ export const ENVS = z.object({
         .number()
         .optional()
         .default(60 * 24 * 3600 * 1000), // 60 days
+    PERSIST_BATCH_CLEANUP_INTERVAL_MS: z.coerce.number().optional().default(5_000), // set to 0 to disable
+    PERSIST_BATCH_CLEANUP_LIMIT: z.coerce.number().optional().default(10_000),
+    PERSIST_BATCH_CLEANUP_MAX_AGE_MS: z.coerce
+        .number()
+        .optional()
+        .default(72 * 3600 * 1000), // 72 hours
     NANGO_PERSIST_PORT: z.coerce.number().optional().default(3007),
 
     // Orchestrator


### PR DESCRIPTION
90% of records being batch saved are not being modified and have a payload identical to what's already stored.
However current logic updates every single row in order to update the sync_job_id that serves as a stamp to determine if track_deletes feature can soft-delete records that haven't been touched by a sync. 

The goal is to stop updating every single rows but instead only update records metadata/payload when hash/content is different and store the ids of all the records in the batch to be used by the track_deletes query at the end of the sync, replacing up to 1000 upserts per batch by a single insert.

This first commit adds the migration for the new table and insert batch entries in this new table. The upsert/update and track_deletes deletion isn't touched yet since it requires all batches to be inserted for a given sync. I am planning to have it run for more than 24h like this to ensure all batches for a given execution are being captured before modifying the rest of the logic.

next PR for context: https://github.com/NangoHQ/nango/pull/6049

<!-- Describe the problem and your solution --> 

<!-- Issue ticket number and link (if applicable) -->

<!-- Testing instructions (skip if just adding/editing providers) -->

