### PR TITLE
fix(providers/kno-commerce): Adjust param passing to query string

### DIFF
--- a/packages/providers/providers.scopes.yaml
+++ b/packages/providers/providers.scopes.yaml
@@ -2722,6 +2722,13 @@ klaviyo-oauth:
     - web-feeds:read
     - web-feeds:write
 
+# source: https://developers.knocommerce.com/ (read scopes for survey responses, questions, and webhook subscriptions)
+kno-commerce:
+    - SURVEYS
+    - RESPONSES
+    - QUESTIONS
+    - WEBHOOKS
+
 # source: https://hire.lever.co/developer/documentation
 lever:
     - applications:read:admin

--- a/packages/providers/providers.yaml
+++ b/packages/providers/providers.yaml
@@ -10069,14 +10069,20 @@ kno-commerce:
     categories:
         - e-commerce
     auth_mode: OAUTH2_CC
-    token_url: https://app-api.knocommerce.com/api/oauth2/token
+    token_url: https://app-api.knocommerce.com/api/oauth2/token?grant_type=client_credentials&scope=${connectionConfig.scope}
     token_request_auth_method: basic
-    token_params:
-        grant_type: client_credentials
     proxy:
         base_url: https://app-api.knocommerce.com
     docs: https://nango.dev/docs/api-integrations/kno-commerce
     docs_connect: https://nango.dev/docs/api-integrations/kno-commerce/connect
+    connection_config:
+        scope:
+            type: string
+            title: API Scopes
+            description: Space-separated list of Kno API scopes to grant the access token. Valid values are SURVEYS, RESPONSES, QUESTIONS, and WEBHOOKS.
+            example: SURVEYS RESPONSES QUESTIONS WEBHOOKS
+            pattern: '^[A-Z]+( [A-Z]+)*$'
+            doc_section: '#step-1-creating-an-api-client'
     credentials:
         client_id:
             type: string

--- a/packages/providers/providers.yaml
+++ b/packages/providers/providers.yaml
@@ -10069,20 +10069,13 @@ kno-commerce:
     categories:
         - e-commerce
     auth_mode: OAUTH2_CC
-    token_url: https://app-api.knocommerce.com/api/oauth2/token?grant_type=client_credentials&scope=${connectionConfig.scope}
+    token_url: https://app-api.knocommerce.com/api/oauth2/token?grant_type=client_credentials&scope=${connectionConfig.oauth_scopes}
     token_request_auth_method: basic
+    scope_separator: ' '
     proxy:
         base_url: https://app-api.knocommerce.com
     docs: https://nango.dev/docs/api-integrations/kno-commerce
     docs_connect: https://nango.dev/docs/api-integrations/kno-commerce/connect
-    connection_config:
-        scope:
-            type: string
-            title: API Scopes
-            description: Space-separated list of Kno API scopes to grant the access token. Valid values are SURVEYS, RESPONSES, QUESTIONS, and WEBHOOKS.
-            example: SURVEYS RESPONSES QUESTIONS WEBHOOKS
-            pattern: '^[A-Z]+( [A-Z]+)*$'
-            doc_section: '#step-1-creating-an-api-client'
     credentials:
         client_id:
             type: string

--- a/packages/shared/lib/services/connection.service.ts
+++ b/packages/shared/lib/services/connection.service.ts
@@ -1202,8 +1202,12 @@ class ConnectionService {
         client_certificate?: string | undefined;
         client_private_key?: string | undefined;
     }): Promise<ServiceResponse<OAuth2ClientCredentials>> {
+        const scope =
+            connectionConfig['oauth_scopes'] && typeof connectionConfig['oauth_scopes'] === 'string'
+                ? connectionConfig['oauth_scopes'].split(',').join(provider.scope_separator || ' ')
+                : '';
         const strippedTokenUrl = typeof provider.token_url === 'string' ? provider.token_url.replace(/connectionConfig\./g, '') : '';
-        const url = new URL(interpolateString(strippedTokenUrl, connectionConfig));
+        const url = new URL(interpolateString(strippedTokenUrl, { ...connectionConfig, oauth_scopes: scope }));
 
         let interpolatedParams: Record<string, any> = {};
         if (provider.token_params) {
@@ -1211,8 +1215,7 @@ class ConnectionService {
         }
         let tokenParams = interpolatedParams && Object.keys(interpolatedParams).length > 0 ? new URLSearchParams(interpolatedParams).toString() : '';
 
-        if (connectionConfig['oauth_scopes'] && typeof connectionConfig['oauth_scopes'] === 'string') {
-            const scope = connectionConfig['oauth_scopes'].split(',').join(provider.scope_separator || ' ');
+        if (scope) {
             tokenParams += (tokenParams ? '&' : '') + `scope=${encodeURIComponent(scope)}`;
         }
 

--- a/scripts/validation/providers/validate.ts
+++ b/scripts/validation/providers/validate.ts
@@ -150,6 +150,8 @@ function validateProvider(providerKey: string, provider: ExtendedProvider) {
         }
     }
 
+    const RUNTIME_DYNAMIC_KEYS = new Set(['oauth_scopes']);
+
     // Find all connectionConfig references
     const connectionConfigReferences = findConnectionConfigReferences(provider);
 
@@ -158,8 +160,9 @@ function validateProvider(providerKey: string, provider: ExtendedProvider) {
         for (const reference of connectionConfigReferences) {
             const defined = provider.connection_config && reference.key in provider.connection_config;
             const inTokenResponseMetadata = provider.token_response_metadata?.includes(reference.key);
+            const isRuntimeDynamic = RUNTIME_DYNAMIC_KEYS.has(reference.key);
 
-            if (!defined && !inTokenResponseMetadata) {
+            if (!defined && !inTokenResponseMetadata && !isRuntimeDynamic) {
                 console.error(
                     chalk.red('error'),
                     chalk.blue(providerKey),


### PR DESCRIPTION
Kno's OAuth2 setup require the parameters to be passed through query string rather than through the body. In the `OAUTH2_CC`, `token_params` are passed as a part of the body. I change the url to include these instead as well as adding a second param that is required for the token url.

Local testing against the token endpoint verifies this:

| Layout                                | Result                  |
|---------------------------------------|-------------------------|
| URL: grant_type+scope, body: empty    | ✅ 200                  |
| URL: empty, body: grant_type+scope    | ❌ 400 invalid_request  |
| URL: grant_type, body: scope          | ❌ 400 invalid_request  |
| URL: scope, body: grant_type          | ❌ 400 invalid_request  |

This can be verified by running this python code with a valid client secret and id

  ```{python}
  #!/usr/bin/env python3                                                                                                                                                                                                                          
  """Probe Kno's OAuth2 token endpoint to show which param locations work.                                                                                                                                                                        
                                                                                                                                                                                                                                                  
  Requires:                                                                                                                                                                                                                
      export KNO_CLIENT_ID=<your-client-id>
      export KNO_CLIENT_SECRET=<your-client-secret>
  """                                                                                                                                                                                                                                             
  import os                                                                         
  import sys                                                                                                                                                                                                                                      
  from urllib.parse import urlencode
                                                                                                                                                                                                                                                  
  import requests                                                                                                                     
  from requests.auth import HTTPBasicAuth                                           
                                              
  CID = os.environ.get("KNO_CLIENT_ID")   
  CSEC = os.environ.get("KNO_CLIENT_SECRET")
                                                                                                                                                                                                                                                  
  URL = "https://app-api.knocommerce.com/api/oauth2/token"                                                                            
  SCOPE = "SURVEYS RESPONSES QUESTIONS WEBHOOKS"                                                                                                                                                                                                  
  GT = {"grant_type": "client_credentials"}
  SC = {"scope": SCOPE}                                                                                                                                                                                                                           
                                                                                                                                                                                                                                                  
  PERMUTATIONS = [                                                                  
      ("URL: grant_type+scope, body: empty",  {**GT, **SC}, {}),                                                                                                                                                                                  
      ("URL: empty, body: grant_type+scope",  {},          {**GT, **SC}),                                                             
      ("URL: grant_type, body: scope",        GT,           SC),                                                                                                                                                                                  
      ("URL: scope, body: grant_type",        SC,           GT),                                                                      
  ]                                                                                                                                                                                                                                               
                              
  results = []                                                                                                                                                                                                                                    
  for label, qs, body in PERMUTATIONS:                                                                                                
      full_url = URL + (f"?{urlencode(qs)}" if qs else "")                                                                                                                                                                                        
      r = requests.post(                                                                                                              
          full_url,                                                                 
          auth=HTTPBasicAuth(CID, CSEC),
          headers={"Content-Type": "application/x-www-form-urlencoded"},                                                                                                                                                                          
          data=urlencode(body) if body else "",
      )                                                                                                                                                                                                                                           
      if r.ok:                                                                                                                        
          outcome = "✅ 200"                                                                                                                                                                                                                      
      else:                   
          try:                                                                                                                                                                                                                                    
              err = r.json().get("error", r.text[:40])                                                                                
          except ValueError:                                                        
              err = r.text[:40]                                                                                                                                                                                                                   
          outcome = f"❌ {r.status_code} {err}"
      results.append((label, outcome))                                                                                                                                                                                                            
                                                                                                                                      
  # Render unicode table                                                            
  w1 = max(len(l) for l, _ in results)                                                                                                                                                                                                            
  w2 = max(len(r) for _, r in results)
  top    = f"┌{'─' * (w1 + 2)}┬{'─' * (w2 + 2)}┐"                                                                                                                                                                                                 
  mid    = f"├{'─' * (w1 + 2)}┼{'─' * (w2 + 2)}┤"                                                                                     
  bottom = f"└{'─' * (w1 + 2)}┴{'─' * (w2 + 2)}┘"                                   
  print(top)                              
  print(f"│ {'Layout'.ljust(w1)} │ {'Result'.ljust(w2)} │")                                                                                                                                                                                       
  print(mid)                                                                                                                                                                                                                                      
  for i, (lbl, out) in enumerate(results):
      print(f"│ {lbl.ljust(w1)} │ {out.ljust(w2)} │")
      if i < len(results) - 1:
          print(mid)
  print(bottom)
  ```