### PR TITLE
feat(persist): upsert and track_deletes logic refactor

### DIFF
--- a/packages/records/lib/models/records.integration.test.ts
+++ b/packages/records/lib/models/records.integration.test.ts
@@ -2,7 +2,7 @@ import dayjs from 'dayjs';
 import * as uuid from 'uuid';
 import { afterAll, beforeAll, beforeEach, describe, expect, it } from 'vitest';
 
-import { RECORDS_DATA_TABLE, RECORDS_TABLE, RECORD_COUNTS_TABLE } from '../constants.js';
+import { RECORDS_BATCH_TABLE, RECORDS_DATA_TABLE, RECORDS_TABLE, RECORD_COUNTS_TABLE } from '../constants.js';
 import { Cursor } from '../cursor.js';
 import { db } from '../db/client.js';
 import { migrate } from '../db/migrate.js';
@@ -21,6 +21,7 @@ describe('Records service', () => {
     afterAll(async () => {
         await db(RECORDS_TABLE).truncate();
         await db(RECORD_COUNTS_TABLE).truncate();
+        await db(RECORDS_BATCH_TABLE).truncate();
     });
 
     describe('Should fetch cursor', () => {
@@ -105,14 +106,13 @@ describe('Records service', () => {
         expect(stats[model]?.count).toBe(4);
         expect(stats[model]?.size_bytes).toBe(556);
 
-        await expect(fromDb(connectionId, model, '1')).resolves.toMatchObject({ external_id: '1', sync_job_id: 2, decrypted: { id: '1', name: 'John Doe' } });
+        await expect(fromDb(connectionId, model, '1')).resolves.toMatchObject({ external_id: '1', decrypted: { id: '1', name: 'John Doe' } });
         await expect(fromDb(connectionId, model, '2')).resolves.toMatchObject({
             external_id: '2',
-            sync_job_id: 2,
             decrypted: { id: '2', name: 'Jane Much Longer Name Doe' }
         });
-        await expect(fromDb(connectionId, model, '3')).resolves.toMatchObject({ external_id: '3', sync_job_id: 1, decrypted: { id: '3', name: 'Max Doe' } });
-        await expect(fromDb(connectionId, model, '4')).resolves.toMatchObject({ external_id: '4', sync_job_id: 1, decrypted: { id: '4', name: 'Mike Doe' } });
+        await expect(fromDb(connectionId, model, '3')).resolves.toMatchObject({ external_id: '3', decrypted: { id: '3', name: 'Max Doe' } });
+        await expect(fromDb(connectionId, model, '4')).resolves.toMatchObject({ external_id: '4', decrypted: { id: '4', name: 'Mike Doe' } });
 
         const updated = await updateRecords({ records: [{ id: '1', name: 'Maurice Doe' }], connectionId, environmentId, model, syncId, syncJobId: 3 });
         expect(updated).toStrictEqual({
@@ -129,7 +129,6 @@ describe('Records service', () => {
         expect(stats[model]?.size_bytes).toBe(560);
         await expect(fromDb(connectionId, model, '1')).resolves.toMatchObject({
             external_id: '1',
-            sync_job_id: 3,
             decrypted: { id: '1', name: 'Maurice Doe' }
         });
     });
@@ -176,22 +175,18 @@ describe('Records service', () => {
 
                 await expect(fromDb(connectionId, model, '1')).resolves.toMatchObject({
                     external_id: '1',
-                    sync_job_id: 2,
                     decrypted: { id: '1', name: 'John Doe' }
                 });
                 await expect(fromDb(connectionId, model, '2')).resolves.toMatchObject({
                     external_id: '2',
-                    sync_job_id: 2,
                     decrypted: { id: '2', name: 'Jane Moe' }
                 });
                 await expect(fromDb(connectionId, model, '3')).resolves.toMatchObject({
                     external_id: '3',
-                    sync_job_id: 1,
                     decrypted: { id: '3', name: 'Max Doe' }
                 });
                 await expect(fromDb(connectionId, model, '4')).resolves.toMatchObject({
                     external_id: '4',
-                    sync_job_id: 1,
                     decrypted: { id: '4', name: 'Mike Doe' }
                 });
             });
@@ -895,9 +890,16 @@ describe('Records service', () => {
                 .where({ connection_id: connectionId, model })
                 .whereNotNull('deleted_at');
             deleted.forEach((r) => {
-                expect(r.sync_job_id).toBe(3);
                 expect(r.deleted_at).not.toBeNull();
             });
+
+            // Check that the record from generation 3 is not marked as deleted
+            const notDeleted = await db
+                .select<FormattedRecord[]>('*')
+                .from(RECORDS_TABLE)
+                .where({ connection_id: connectionId, model, external_id: '5' })
+                .first();
+            expect(notDeleted?.deleted_at).toBeNull();
         });
 
         it('should not mark already deleted records', async () => {

--- a/packages/records/lib/models/records.ts
+++ b/packages/records/lib/models/records.ts
@@ -386,7 +386,8 @@ export async function upsert({
                                     `${RECORDS_TABLE}.updated_at`,
                                     trx.raw(`incoming.data_hash IS DISTINCT FROM ${RECORDS_TABLE}.data_hash as has_changed`),
                                     trx.raw(`(${RECORDS_TABLE}.json IS NOT NULL OR ${RECORDS_TABLE}.pruned_at IS NOT NULL) as must_upsert_data`),
-                                    trx.raw(`COALESCE(pg_column_size(${RECORDS_TABLE}.json), 0) as legacy_size_bytes`)
+                                    trx.raw(`COALESCE(pg_column_size(${RECORDS_TABLE}.json), 0) as legacy_size_bytes`),
+                                    trx.raw(`${RECORDS_TABLE}.tableoid::regclass as partition`)
                                 )
                                     .from(RECORDS_TABLE)
                                     .where(`${RECORDS_TABLE}.connection_id`, '=', connectionId)
@@ -412,6 +413,19 @@ export async function upsert({
                                     .into(RECORDS_TABLE)
                                     .onConflict(['connection_id', 'model', 'external_id'])
                                     .merge()
+                                    // Skip the UPDATE except:
+                                    // - changed records (data_hash has changed)
+                                    // - deleted/undeleted records (deleted_at has changed)
+                                    // - legacy records (json IS NOT NULL) so data migration fires
+                                    // - pruned records (pruned_at IS NOT NULL) so pruned_at gets cleared
+                                    .whereRaw(
+                                        `(
+                                            ${RECORDS_TABLE}.data_hash IS DISTINCT FROM EXCLUDED.data_hash
+                                            OR ${RECORDS_TABLE}.deleted_at IS DISTINCT FROM EXCLUDED.deleted_at
+                                            OR ${RECORDS_TABLE}.json IS NOT NULL
+                                            OR ${RECORDS_TABLE}.pruned_at IS NOT NULL
+                                        )`
+                                    )
                                     .returning(['id', 'external_id', 'deleted_at', 'updated_at', trx.raw('tableoid::regclass as partition')]);
                                 if (merging.strategy === 'ignore_if_modified_after_cursor' && merging.cursor) {
                                     const cursor = Cursor.from(merging.cursor);
@@ -420,12 +434,22 @@ export async function upsert({
                                     }
                                 }
                             })
+                            // Records skipped by the ON CONFLICT WHERE (truly unchanged, non-legacy, non-pruned)
+                            // are absent from the upsert CTE. Include them so they appear as 'unchanged' in the result.
+                            // Cursor-filtered records (has_changed = true but skipped by cursor) are excluded here
+                            // intentionally — they preserve the same behavior as before (not classified).
+                            .with('skipped', (qb) => {
+                                qb.select('id', 'external_id', 'deleted_at', 'updated_at', 'partition')
+                                    .from('existing')
+                                    .where({ has_changed: false, must_upsert_data: false })
+                                    .whereNotExists(trx('upsert').select(trx.raw('1')).whereRaw('upsert.external_id = existing.external_id'));
+                            })
                             .select<UpsertedMetadata[]>(
                                 trx.raw(`
-                                    upsert.partition as partition,
-                                    upsert.id as id,
-                                    upsert.external_id as external_id,
-                                    to_json(upsert.updated_at) as last_modified_at,
+                                    combined.partition as partition,
+                                    combined.id as id,
+                                    combined.external_id as external_id,
+                                    to_json(combined.updated_at) as last_modified_at,
                                     COALESCE(existing.has_changed OR existing.must_upsert_data, true) as needs_data_write,
                                     COALESCE(existing.legacy_size_bytes, 0) as legacy_size_bytes,
                                     CASE
@@ -436,18 +460,18 @@ export async function upsert({
                                         WHEN existing.external_id IS NULL THEN 'inserted'
                                         ELSE
                                             CASE
-                                                WHEN existing.deleted_at IS NOT NULL AND upsert.deleted_at IS NULL THEN 'undeleted'
-                                                WHEN existing.deleted_at IS NULL AND upsert.deleted_at IS NOT NULL THEN 'deleted'
+                                                WHEN existing.deleted_at IS NOT NULL AND combined.deleted_at IS NULL THEN 'undeleted'
+                                                WHEN existing.deleted_at IS NULL AND combined.deleted_at IS NOT NULL THEN 'deleted'
                                                 WHEN existing.has_changed THEN 'changed'
                                                 ELSE 'unchanged'
                                             END
                                     END as status`)
                             )
-                            .from('upsert')
-                            .leftJoin('existing', 'existing.external_id', 'upsert.external_id')
+                            .from(trx.raw('(SELECT * FROM upsert UNION ALL SELECT * FROM skipped) AS combined'))
+                            .leftJoin('existing', 'existing.external_id', 'combined.external_id')
                             .orderBy([
-                                { column: 'upsert.updated_at', order: 'asc' },
-                                { column: 'upsert.id', order: 'asc' }
+                                { column: 'combined.updated_at', order: 'asc' },
+                                { column: 'combined.id', order: 'asc' }
                             ]);
 
                         // Upsert data for:
@@ -504,7 +528,7 @@ export async function upsert({
                             connectionId,
                             model,
                             syncJobId: chunk[0]!.sync_job_id,
-                            recordIds: upsertMetadata.map((r) => r.id)
+                            recordIds: chunk.map((r) => r.id)
                         });
 
                         // Billing:
@@ -1060,7 +1084,7 @@ export async function deleteOutdatedRecords({
     connectionId,
     model,
     generation,
-    batchSize = 1000
+    batchSize = 10_000
 }: {
     environmentId: number;
     connectionId: number;
@@ -1099,24 +1123,31 @@ export async function deleteOutdatedRecords({
                             partition: string;
                         }[] = (
                             await trx.raw(
-                                `WITH to_delete AS MATERIALIZED (
-                                    SELECT ctid, id
-                                    FROM ${RECORDS_TABLE}
-                                    WHERE connection_id = ?
-                                      AND model = ?
-                                      AND sync_job_id < ?
-                                      AND deleted_at IS NULL
-                                    LIMIT ?
+                                `WITH seen AS MATERIALIZED (
+                                    SELECT DISTINCT unnest(record_ids) AS id FROM ${RECORDS_BATCH_TABLE}
+                                    WHERE connection_id = :connectionId
+                                      AND model = :model
+                                      AND sync_job_id >= :generation
+                                ),
+                                to_delete AS MATERIALIZED (
+                                    SELECT r.ctid, r.id
+                                    FROM ${RECORDS_TABLE} r
+                                    LEFT JOIN seen ON seen.id = r.id
+                                    WHERE r.connection_id = :connectionId
+                                      AND r.model = :model
+                                      AND r.deleted_at IS NULL
+                                      AND seen.id IS NULL
+                                    LIMIT :batchSize
                                 )
                                 UPDATE ${RECORDS_TABLE} r
                                 SET
                                     deleted_at = current_timestamp(6),
-                                    updated_at = current_timestamp(6),
-                                    sync_job_id = ?
+                                    updated_at = current_timestamp(6)
                                 FROM to_delete
                                 WHERE r.ctid = to_delete.ctid
-                                  AND r.connection_id = ?
-                                  AND r.model = ?
+                                  AND r.id = to_delete.id
+                                  AND r.connection_id = :connectionId
+                                  AND r.model = :model
                                 RETURNING
                                   r.id,
                                   r.connection_id,
@@ -1124,7 +1155,7 @@ export async function deleteOutdatedRecords({
                                   r.external_id,
                                   COALESCE(pg_column_size(r.json), 0) as legacy_size_bytes,
                                   r.tableoid::regclass as partition`,
-                                [connectionId, model, generation, batchSize, generation, connectionId, model]
+                                { connectionId, model, generation, batchSize }
                             )
                         ).rows;
 


### PR DESCRIPTION
follow-up of https://github.com/NangoHQ/nango/pull/6046

This commit:
- uses the new records_batch table to determine which records must be soft-deleted in `
deleteOutdatedRecords`
- stop updating a record if unchanged, potentially rows churn of the
  records table by 90%