### PR TITLE
docs: clarify minimal connection scope for nango dryrun

### DIFF
--- a/docs/reference/backend/http-api/api-keys.mdx
+++ b/docs/reference/backend/http-api/api-keys.mdx
@@ -120,7 +120,13 @@ The Nango CLI uses the `NANGO_SECRET_KEY_<ENV>` environment variable for authent
 | `nango deploy` | `environment:deploy` |
 | `nango dryrun` | `environment:connections:read` + `environment:integrations:read` + `environment:proxy` |
 
-For most functions, `environment:connections:read` is sufficient for `nango dryrun` — Nango injects credentials into the proxy automatically, so the function does not need them in its response. Upgrade to `environment:connections:read_credentials` only when the function reads the `credentials` attribute on the connection object directly (e.g. `nango.getConnection().credentials`).
+For most functions, `environment:connections:read` is sufficient for `nango dryrun` — Nango injects credentials into the proxy automatically, so the function does not need them in its response. Upgrade to `environment:connections:read_credentials` when the function reads credential data from the connection, including:
+
+- accessing `connection.credentials` directly (e.g. `nango.getConnection().credentials`)
+- calling `nango.getToken()` — returns the access token from `connection.credentials`
+- calling `nango.getRawTokenResponse()` — returns `connection.credentials.raw`
+
+Without `read_credentials`, these helpers return empty values because the API strips the `credentials` field from the response.
 
 The **Default - Full access** key that comes with each environment already has all required scopes for both deploying and dry-running. For production CI/CD pipelines, consider creating a dedicated key with only the `environment:deploy` scope to follow the principle of least privilege.
 

--- a/docs/reference/backend/http-api/api-keys.mdx
+++ b/docs/reference/backend/http-api/api-keys.mdx
@@ -118,7 +118,9 @@ The Nango CLI uses the `NANGO_SECRET_KEY_<ENV>` environment variable for authent
 | CLI Command | Required Scope |
 |-------------|---------------|
 | `nango deploy` | `environment:deploy` |
-| `nango dryrun` | `environment:connections:read_credentials` + `environment:integrations:read` + `environment:proxy` |
+| `nango dryrun` | `environment:connections:read` + `environment:integrations:read` + `environment:proxy` |
+
+For most functions, `environment:connections:read` is sufficient for `nango dryrun` — Nango injects credentials into the proxy automatically, so the function does not need them in its response. Upgrade to `environment:connections:read_credentials` only when the function reads the `credentials` attribute on the connection object directly (e.g. `nango.getConnection().credentials`).
 
 The **Default - Full access** key that comes with each environment already has all required scopes for both deploying and dry-running. For production CI/CD pipelines, consider creating a dedicated key with only the `environment:deploy` scope to follow the principle of least privilege.
 


### PR DESCRIPTION
## Summary
- The required-scopes table for `nango dryrun` listed `environment:connections:read_credentials`, but the underlying `GET /connection/:id` endpoint accepts either `environment:connections:read` or `environment:connections:read_credentials`.
- For most functions, `read` is sufficient at dry-run time — Nango injects credentials into proxy calls automatically, so the function does not need credentials in the connection response.
- `read_credentials` is only required when the function reads `connection.credentials` directly (e.g. `nango.getConnection().credentials`). Updated the table and added a note explaining the distinction.

## Test plan
- [ ] Visual review of the rendered `Reference > HTTP API > API keys` page on Mintlify preview.