### PR TITLE
docs: small docs improvements

### DIFF
--- a/docs/docs.json
+++ b/docs/docs.json
@@ -30,6 +30,7 @@
   "contextual": {
     "options": [
       "copy",
+      "mcp",
       "cursor",
       "vscode",
       "chatgpt",

--- a/docs/getting-started/quickstart.mdx
+++ b/docs/getting-started/quickstart.mdx
@@ -4,6 +4,17 @@ sidebarTitle: '🚀 Quickstart'
 description: 'Authorize any API in minutes'
 ---
 
+<Note>
+  **Building with an AI coding agent?**
+
+  1. Add Nango's documentation MCP server: `https://nango.dev/docs/mcp`
+  2. Install the Nango function builder skill:
+
+  ```bash
+  npx skills add NangoHQ/skills -s building-nango-functions-locally
+  ```
+</Note>
+
 <Steps>
   <Step title="Configure an integration">
     [Sign up](https://app.nango.dev/signup) (free, no credit card) then, on the **Integrations** tab, set up a new integration.

--- a/docs/guides/auth/auth-guide.mdx
+++ b/docs/guides/auth/auth-guide.mdx
@@ -44,7 +44,16 @@ Once you have the connection ID, fetch credentials whenever you need them:
 
 ## Guide
 
-<Tip>**Using a coding agent?** Copy the page (button top right) and paste as a prompt.</Tip>
+<Tip>
+  **Building with an AI coding agent?**
+
+  1. Add Nango's documentation MCP server: `https://nango.dev/docs/mcp`
+  2. Install the Nango function builder skill:
+
+  ```bash
+  npx skills add NangoHQ/skills -s building-nango-functions-locally
+  ```
+</Tip>
 
 <Steps>
   <Step title="Create a Nango account">

--- a/docs/guides/functions/functions-guide.mdx
+++ b/docs/guides/functions/functions-guide.mdx
@@ -119,7 +119,16 @@ A good agent workflow generates the function code, imports it from `index.ts`, a
 
 ## Step-by-step guide
 
-<Tip>**Using a coding agent?** Copy this page and the specific function type guide you choose into the agent prompt.</Tip>
+<Tip>
+  **Building with an AI coding agent?**
+
+  1. Add Nango's documentation MCP server: `https://nango.dev/docs/mcp`
+  2. Install the Nango function builder skill:
+
+  ```bash
+  npx skills add NangoHQ/skills -s building-nango-functions-locally
+  ```
+</Tip>
 
 <Steps>
   <Step title="Install and initialize">
@@ -169,7 +178,11 @@ A good agent workflow generates the function code, imports it from `index.ts`, a
     <Accordion title="For agents">
       Run `nango init nango-integrations` to scaffold the folder. Ask the user for their secret key from **Environment Settings > API Keys** and write it to `nango-integrations/.env`. Confirm that `nango-integrations/.gitignore` ignores `.env`.
 
-      For additional context while building, use Nango's documentation MCP: `https://nango.dev/docs/mcp`.
+      For additional context while building, add Nango's documentation MCP server (`https://nango.dev/docs/mcp`) and install the Nango function builder skill:
+
+      ```bash
+      npx skills add NangoHQ/skills -s building-nango-functions-locally
+      ```
     </Accordion>
   </Step>
 

--- a/docs/guides/platform/limits.mdx
+++ b/docs/guides/platform/limits.mdx
@@ -37,7 +37,9 @@ Different function types have varying execution and enqueuing time limits:
 
 ### Minimum sync frequency
 
-The minimum sync frequency is **30 seconds**, available on all plans. You can set the frequency in the sync definition or override it per connection using the [SDK](/reference/backend/backend-sdk/node#override-sync-connection-frequency) or [API](/reference/backend/http-api/sync/update-connection-frequency).
+For polling syncs, the minimum frequency is **30 seconds**, available on all plans. You can set the frequency in the sync definition or override it per connection using the [SDK](/reference/backend/backend-sdk/node#override-sync-connection-frequency) or [API](/reference/backend/http-api/sync/update-connection-frequency).
+
+For real-time updates, use [real-time syncs](/guides/functions/syncs/realtime-syncs) which trigger from external API webhooks instead of polling.
 
 ### Sync variant limits
 

--- a/docs/integrations/contribute-or-request-api.mdx
+++ b/docs/integrations/contribute-or-request-api.mdx
@@ -26,7 +26,7 @@ Nango supports all authorization types (OAuth, API key, basic), including custom
 
 ### Add an API configuration
 
-Fork the [repo](https://github.com/NangoHQ/nango) and edit the API configurations file ([providers.yaml](https://nango.dev/providers.yaml)).
+Fork the [repo](https://github.com/NangoHQ/nango) and edit the API configurations file ([providers.yaml](https://nango.dev/providers.yaml)). See the [API configuration reference](/integrations/api-configuration) for the available fields.
 
 You can test the configuration of your new provider with this command:
 


### PR DESCRIPTION
## Summary
- Link to the API configuration reference from the contribute guide
- Add an AI coding agent setup tip (docs MCP + function builder skill) to quickstart, auth guide, and functions guide
- Enable `mcp` option in the contextual menu so readers can install the docs MCP server in one click
- Clarify that the 30s minimum sync frequency applies to polling syncs and link to real-time syncs

## Test plan
- [ ] `mintlify broken-links` passes
- [ ] Spot-check each updated page in the local dev server