### PR TITLE
fix: don't skip uploading function code in local dev mode

### DIFF
--- a/packages/shared/lib/services/file/remote.service.ts
+++ b/packages/shared/lib/services/file/remote.service.ts
@@ -64,12 +64,9 @@ class RemoteFileService {
         destinationPath: string;
         destinationLocalFileName: string;
     }): Promise<string | null> {
-        if (isEnterprise && !this.useS3) {
+        if (!this.useS3) {
             localFileService.putIntegrationFile({ fileName: destinationLocalFileName, fileContent: content });
 
-            return '_LOCAL_FILE_';
-        }
-        if (!this.useS3) {
             return '_LOCAL_FILE_';
         }
 


### PR DESCRIPTION
When running Nango locally we used to be able to read the compiled function code from the local integration folder directly, without having to run `nango deploy`
Recently the function code path has been harmonized between local dev setup and enterprise with local volume so this "feature" isn't supported anymore. 
This commit ensures the function code is uploaded even when not in a enterprise setup.

<!-- Describe the problem and your solution --> 

<!-- Issue ticket number and link (if applicable) -->

<!-- Testing instructions (skip if just adding/editing providers) -->

