### PR TITLE
fix(server): stop treating application/x-www-form-urlencoded as binary

### DIFF
--- a/packages/server/lib/utils/utils.ts
+++ b/packages/server/lib/utils/utils.ts
@@ -289,6 +289,8 @@ export function getOrchestrator() {
 
 export function isBinaryContentType(contentType: string | undefined): boolean {
     if (!contentType) return false;
+    const base = contentType.split(';')[0]!.trim().toLowerCase();
+    if (base === 'application/json' || base === 'application/x-www-form-urlencoded') return false;
     return BINARY_CONTENT_TYPES.some((type) => contentType.startsWith(type));
 }
 


### PR DESCRIPTION
## Describe the problem and your solution

-`bodyParser.raw()` was handling form-encoded requests before `express.urlencoded()` had a chance to parse them. This happened because `BINARY_CONTENT_TYPES` was matching the very broad `application/*` prefix. As a result, slack interactivity webhooks like `block_actions` were being treated as raw binary payloads, so the request body arrived as a buffer instead of the expected parsed object.



<!-- Issue ticket number and link (if applicable) -->

<!-- Testing instructions (skip if just adding/editing providers) -->

