### PR TITLE
fix(server): webhook url to use unique_key, not provider name

### DIFF
--- a/packages/server/lib/controllers/integrations/uniqueKey/getIntegration.integration.test.ts
+++ b/packages/server/lib/controllers/integrations/uniqueKey/getIntegration.integration.test.ts
@@ -111,6 +111,24 @@ describe(`GET ${endpoint}`, () => {
         expect(res.json.data.webhook_url).toStrictEqual(`${getGlobalWebhookReceiveUrl()}/${env.uuid}/platform-google`);
     });
 
+    it('should URI-encode integration unique_key in webhook_url path segment', async () => {
+        const { env, apiKey } = await seeders.seedAccountEnvAndUser();
+        const uniqueKey = 'acme:corp';
+        await seeders.createConfigSeed(env, uniqueKey, 'google');
+
+        const res = await api.fetch(endpoint, {
+            method: 'GET',
+            token: apiKey.secret,
+            params: { uniqueKey },
+            query: { include: ['webhook'] }
+        });
+
+        isSuccess(res.json);
+        expect(res.res.status).toBe(200);
+        expect(res.json.data.unique_key).toBe(uniqueKey);
+        expect(res.json.data.webhook_url).toStrictEqual(`${getGlobalWebhookReceiveUrl()}/${env.uuid}/${encodeURIComponent(uniqueKey)}`);
+    });
+
     it('should not list other env', async () => {
         const { apiKey } = await seeders.seedAccountEnvAndUser();
         const { env: env2 } = await seeders.seedAccountEnvAndUser();

--- a/packages/server/lib/controllers/integrations/uniqueKey/getIntegration.integration.test.ts
+++ b/packages/server/lib/controllers/integrations/uniqueKey/getIntegration.integration.test.ts
@@ -1,6 +1,6 @@
 import { afterAll, beforeAll, describe, expect, it } from 'vitest';
 
-import { seeders } from '@nangohq/shared';
+import { getGlobalWebhookReceiveUrl, seeders } from '@nangohq/shared';
 
 import { getConnectSessionToken, isError, isSuccess, runServer, shouldBeProtected } from '../../../utils/tests.js';
 
@@ -91,6 +91,24 @@ describe(`GET ${endpoint}`, () => {
         isSuccess(res.json);
         expect(res.res.status).toBe(200);
         expect(res.json.data.webhook_url).toStrictEqual(null);
+    });
+
+    it('should put integration unique_key in webhook_url when it differs from provider template', async () => {
+        const { env, apiKey } = await seeders.seedAccountEnvAndUser();
+        await seeders.createConfigSeed(env, 'platform-google', 'google');
+
+        const res = await api.fetch(endpoint, {
+            method: 'GET',
+            token: apiKey.secret,
+            params: { uniqueKey: 'platform-google' },
+            query: { include: ['webhook'] }
+        });
+
+        isSuccess(res.json);
+        expect(res.res.status).toBe(200);
+        expect(res.json.data.unique_key).toBe('platform-google');
+        expect(res.json.data.provider).toBe('google');
+        expect(res.json.data.webhook_url).toStrictEqual(`${getGlobalWebhookReceiveUrl()}/${env.uuid}/platform-google`);
     });
 
     it('should not list other env', async () => {

--- a/packages/server/lib/controllers/integrations/uniqueKey/getIntegration.ts
+++ b/packages/server/lib/controllers/integrations/uniqueKey/getIntegration.ts
@@ -64,7 +64,7 @@ export const getPublicIntegration = asyncWrapper<GetPublicIntegration>(async (re
 
     const include: ApiPublicIntegrationInclude = {};
     if (queryInclude.has('webhook')) {
-        include.webhook_url = provider.webhook_routing_script ? `${getGlobalWebhookReceiveUrl()}/${environment.uuid}/${integration.provider}` : null;
+        include.webhook_url = provider.webhook_routing_script ? `${getGlobalWebhookReceiveUrl()}/${environment.uuid}/${integration.unique_key}` : null;
     }
     if (
         queryInclude.has('credentials') &&

--- a/packages/server/lib/controllers/integrations/uniqueKey/getIntegration.ts
+++ b/packages/server/lib/controllers/integrations/uniqueKey/getIntegration.ts
@@ -64,7 +64,9 @@ export const getPublicIntegration = asyncWrapper<GetPublicIntegration>(async (re
 
     const include: ApiPublicIntegrationInclude = {};
     if (queryInclude.has('webhook')) {
-        include.webhook_url = provider.webhook_routing_script ? `${getGlobalWebhookReceiveUrl()}/${environment.uuid}/${integration.unique_key}` : null;
+        include.webhook_url = provider.webhook_routing_script
+            ? `${getGlobalWebhookReceiveUrl()}/${environment.uuid}/${encodeURIComponent(integration.unique_key)}`
+            : null;
     }
     if (
         queryInclude.has('credentials') &&


### PR DESCRIPTION
<!-- Describe the problem and your solution --> 
`getPublicIntegration` sets webhook URL with `integration.provider` when it should be `integration.unique_key`. Routing uses `unique_key`. Normally they match, but a customer can change the `unique_key` to be something else and then `getWebhookURL` returns the wrong URL.

<!-- Issue ticket number and link (if applicable) -->
[NAN-5471: getWebhookURL uses provider name, not unique key](https://linear.app/nango/issue/NAN-5471/getwebhookurl-uses-provider-name-not-unique-key)

<!-- Testing instructions (skip if just adding/editing providers) -->
1. Create an integration
2. Change the id in the UI (`unique_key`)
3. Create a sync and log out the result of `getWebhookURL`. Verify it matches the URL listed in the UI and the webhook is routed appropriately.

