### PR TITLE
feat(providers): add query as a new body format

### DIFF
--- a/packages/providers/providers.yaml
+++ b/packages/providers/providers.yaml
@@ -10120,6 +10120,7 @@ kno-commerce:
     auth_mode: OAUTH2_CC
     token_url: https://app-api.knocommerce.com/api/oauth2/token
     token_request_auth_method: basic
+    body_format: query
     token_params:
         grant_type: client_credentials
     proxy:

--- a/packages/shared/lib/clients/oauth2.client.ts
+++ b/packages/shared/lib/clients/oauth2.client.ts
@@ -74,7 +74,7 @@ export function getSimpleOAuth2ClientConfig(
         auth: authSection,
         options: {
             authorizationMethod: authConfig.authorization_method || 'body',
-            bodyFormat: authConfig.body_format || 'form',
+            bodyFormat: authConfig.body_format === 'json' ? 'json' : 'form',
             // @ts-expect-error seems unused ?
             scopeSeparator: provider.scope_separator || ' '
         }

--- a/packages/shared/lib/services/connection.service.ts
+++ b/packages/shared/lib/services/connection.service.ts
@@ -1220,7 +1220,9 @@ class ConnectionService {
         const params = new URLSearchParams();
 
         const bodyFormat = provider.body_format || 'form';
-        headers['Content-Type'] = bodyFormat === 'json' ? 'application/json' : 'application/x-www-form-urlencoded';
+        if (bodyFormat !== 'query') {
+            headers['Content-Type'] = bodyFormat === 'json' ? 'application/json' : 'application/x-www-form-urlencoded';
+        }
 
         if (provider.token_request_auth_method === 'basic') {
             if (!client_secret) {
@@ -1311,12 +1313,18 @@ class ConnectionService {
             }
         }
 
+        if (bodyFormat === 'query') {
+            for (const [key, value] of params.entries()) {
+                url.searchParams.append(key, value);
+            }
+        }
+
         const fetchRes = await loggedFetch<Record<string, any>>(
             {
                 url,
                 method: 'POST',
                 headers,
-                body: bodyFormat === 'json' ? JSON.stringify(Object.fromEntries(params.entries())) : params.toString(),
+                body: bodyFormat === 'query' ? null : bodyFormat === 'json' ? JSON.stringify(Object.fromEntries(params.entries())) : params.toString(),
                 agent
             },
             { logCtx, context: 'auth', valuesToFilter: [client_secret, client_private_key].filter(Boolean) as string[] }

--- a/packages/shared/lib/utils/http.ts
+++ b/packages/shared/lib/utils/http.ts
@@ -42,10 +42,11 @@ export async function loggedFetch<TBody>(
     }
 
     const createdAt = new Date();
+    const redactedUrl = redactURL({ url: url.href, valuesToFilter: options.valuesToFilter });
     const requestLog: MessageHTTPRequest = {
         headers: redactHeaders({ headers: headers }),
         method: props.method!,
-        url: redactURL({ url: url.href, valuesToFilter: options.valuesToFilter }),
+        url: redactedUrl,
         body: body ? redactObjectOrString({ data: body, valuesToFilter: options.valuesToFilter }) : undefined
     };
     try {
@@ -59,7 +60,7 @@ export async function loggedFetch<TBody>(
         }
 
         if (res.status >= 300) {
-            void options.logCtx.http(`${props.method} ${url.href}`, {
+            void options.logCtx.http(`${props.method} ${redactedUrl}`, {
                 request: requestLog,
                 response: { code: res.status, headers: redactHeaders({ headers: res.headers }) },
                 context: options.context,
@@ -67,7 +68,7 @@ export async function loggedFetch<TBody>(
                 meta: { body }
             });
         } else {
-            void options.logCtx.http(`${props.method} ${url.href}`, {
+            void options.logCtx.http(`${props.method} ${redactedUrl}`, {
                 request: requestLog,
                 response: { code: res.status, headers: redactHeaders({ headers: res.headers }) },
                 context: options.context,
@@ -83,7 +84,7 @@ export async function loggedFetch<TBody>(
             error = err.cause;
         }
 
-        void options.logCtx.http(`${props.method} ${url.href}`, {
+        void options.logCtx.http(`${props.method} ${redactedUrl}`, {
             level: 'error',
             request: requestLog,
             response: undefined,

--- a/packages/types/lib/auth/api.ts
+++ b/packages/types/lib/auth/api.ts
@@ -36,6 +36,7 @@ export type OAuthBodyFormatType = OAuthBodyFormat[keyof OAuthBodyFormat];
 export interface OAuthBodyFormat {
     FORM: 'form';
     JSON: 'json';
+    QUERY: 'query';
 }
 
 export interface ConnectionUpsertResponse {


### PR DESCRIPTION
## Describe the problem and your solution

- Add `query` as a new body format to allow token parameters to also be sent as query parameters.

<!-- Issue ticket number and link (if applicable) -->

<!-- Testing instructions (skip if just adding/editing providers) -->

