### PR TITLE
docs: update providers.yaml URL to providers-yaml

### DIFF
--- a/docs/integrations/contribute-or-request-api.mdx
+++ b/docs/integrations/contribute-or-request-api.mdx
@@ -26,7 +26,7 @@ Nango supports all authorization types (OAuth, API key, basic), including custom
 
 ### Add an API configuration
 
-Fork the [repo](https://github.com/NangoHQ/nango) and edit the API configurations file ([providers.yaml](https://nango.dev/providers.yaml)). See the [API configuration reference](/integrations/api-configuration) for the available fields.
+Fork the [repo](https://github.com/NangoHQ/nango) and edit the API configurations file ([providers.yaml](https://nango.dev/providers-yaml)). See the [API configuration reference](/integrations/api-configuration) for the available fields.
 
 You can test the configuration of your new provider with this command:
 


### PR DESCRIPTION
## Summary
- Update the link to the `providers.yaml` file in `docs/integrations/contribute-or-request-api.mdx` from `https://nango.dev/providers.yaml` to `https://nango.dev/providers-yaml`, following the path change in [NangoHQ/website@9ef42d9](https://github.com/NangoHQ/website/commit/9ef42d9).

## Test plan
- [ ] Verify the link resolves on nango.dev
- [ ] `mintlify broken-links` from `docs/` passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)