### PR TITLE
fix(tests): bump expected airtable tables template version to 2.0.1

### DIFF
--- a/packages/server/lib/controllers/v1/flows/preBuilt/postDeploy.integration.test.ts
+++ b/packages/server/lib/controllers/v1/flows/preBuilt/postDeploy.integration.test.ts
@@ -157,7 +157,7 @@ describe(`POST ${endpoint}`, () => {
             sync_type: 'full',
             track_deletes: false,
             updated_at: expect.any(Date),
-            version: '2.0.0',
+            version: '2.0.1',
             webhook_subscriptions: null
         });
     });


### PR DESCRIPTION
## Summary

Master CI is currently failing on `postDeploy.integration.test.ts` because the integration-templates auto-update bot bumped the `airtable` `tables` sync template version from `2.0.0` to `2.0.1`, but the hardcoded `version: '2.0.0'` literal in the test was not updated.

This PR updates the literal to `2.0.1` to match the deployed template version (confirmed in `packages/shared/flows.zero.json`).

Failing CI run: https://github.com/NangoHQ/nango/actions/runs/25553937971/job/75008215695

## Test plan

- [x] Ran `npm run test:integration -- --run packages/server/lib/controllers/v1/flows/preBuilt/postDeploy.integration.test.ts` locally — all 4 tests pass.