### PR TITLE
fix(proxy): treat image uploads as binary

### DIFF
--- a/packages/server/lib/utils/utils.ts
+++ b/packages/server/lib/utils/utils.ts
@@ -13,7 +13,7 @@ import type { Result } from '@nangohq/utils';
 import type { Request } from 'express';
 
 const BINARY_CONTENT_TYPES = [
-    'image/png',
+    'image/',
     'video/',
     'audio/',
     'application/',

--- a/packages/server/lib/utils/utils.unit.test.ts
+++ b/packages/server/lib/utils/utils.unit.test.ts
@@ -1,6 +1,6 @@
 import { describe, expect, it } from 'vitest';
 
-import { getAdditionalAuthorizationParams, missesInterpolationParam, parseConnectionConfigParamsFromTemplate } from './utils.js';
+import { getAdditionalAuthorizationParams, isBinaryContentType, missesInterpolationParam, parseConnectionConfigParamsFromTemplate } from './utils.js';
 
 describe('Utils unit tests', () => {
     it('Should parse config params in authorization_url', () => {
@@ -212,5 +212,22 @@ describe('missesInterpolationParam', () => {
         const template = 'https://api.example.com';
         const replacers = {};
         expect(missesInterpolationParam(template, replacers)).toBe(false);
+    });
+});
+
+describe('isBinaryContentType', () => {
+    it.each(['image/png', 'image/jpeg', 'image/jpg', 'image/webp', 'image/heic', 'image/jpeg; charset=binary'])('Should treat %s as binary', (contentType) => {
+        expect(isBinaryContentType(contentType)).toBe(true);
+    });
+
+    it.each(['application/pdf', 'application/octet-stream', 'video/mp4', 'audio/mpeg'])(
+        'Should keep existing binary content-type support for %s',
+        (contentType) => {
+            expect(isBinaryContentType(contentType)).toBe(true);
+        }
+    );
+
+    it.each(['application/json', 'application/x-www-form-urlencoded', undefined])('Should not treat %s as binary', (contentType) => {
+        expect(isBinaryContentType(contentType)).toBe(false);
     });
 });


### PR DESCRIPTION
## Describe the problem and your solution

Nango Proxy currently raw-parses image uploads only when the incoming request has `Content-Type: image/png`. Other image uploads such as `image/jpeg` are not matched by `isBinaryContentType()`, so the request can reach the proxied provider with an empty body.

This changes the binary content-type prefix from `image/png` to `image/`, preserving PNG support while covering common direct image uploads such as JPEG, WebP, and HEIC.

## Issue ticket number and link

Fixes #6092.

## Testing instructions

- `docker run --rm -v /home/fortuna/dev/nango-upstream:/repo -w /repo node:22-alpine npx vitest packages/server/lib/utils/utils.unit.test.ts --run`
- Real-path smoke test on a self-hosted Nango instance with this same runtime patch:
  - `n8n -> Nango Proxy -> Xero demo`
  - Created a demo Xero BankTransaction
  - Uploaded a JPEG attachment through Nango Proxy with `Content-Type: image/jpeg`
  - Xero returned attachment `MimeType: image/jpg` and `ContentLength: 516`
  - The demo BankTransaction was then updated to `Status: DELETED`
