### PR TITLE
fix(docs): link logo and website to nango.dev not www

### DIFF
--- a/docs/custom.js
+++ b/docs/custom.js
@@ -1,4 +1,4 @@
-/* global document, window, requestAnimationFrame, history, localStorage, MutationObserver */
+/* global document, window, requestAnimationFrame, history */
 /* ── Changelog TOC scroll-active fallback ──────────────────────────────── */
 /*
  * Mintlify clears the TOC active highlight as soon as a section anchor
@@ -69,57 +69,4 @@
   } else {
     updateActive();
   }
-})();
-
-/* Theme sync between nango.dev (website) and nango.dev/docs (Mintlify).
- *
- * The two sites use different localStorage keys:
- *   website  → localStorage.theme      ("dark" | "light" | "system")
- *   Mintlify → localStorage.isDarkMode ("dark" | "light"; absent = OS preference)
- *
- * The website writes isDarkMode whenever the user explicitly picks dark/light,
- * so Mintlify's own head script reads the correct value on page load (no flash).
- * This script handles two remaining cases:
- *   A) Cross-tab sync: user toggles theme on the website tab, docs tab updates.
- *   B) Docs → website: user toggles in docs, write back to theme so the website
- *      picks it up on the next visit.
- */
-(function () {
-  'use strict';
-
-  var syncing = false;
-
-  // Case A: website changed theme in another tab/window
-  window.addEventListener('storage', function (e) {
-    if (e.key !== 'theme') return;
-    var t = e.newValue;
-    var isDark;
-    syncing = true;
-    if (t === 'dark' || t === 'light') {
-      isDark = t === 'dark';
-      document.documentElement.classList.toggle('dark', isDark);
-      localStorage.setItem('isDarkMode', t);
-    } else {
-      // 'system' or cleared — follow OS and let Mintlify use its own detection
-      isDark = window.matchMedia('(prefers-color-scheme: dark)').matches;
-      document.documentElement.classList.toggle('dark', isDark);
-      localStorage.removeItem('isDarkMode');
-    }
-    setTimeout(function () { syncing = false; }, 50);
-  });
-
-  // Case B: Mintlify toggled the dark class → write back to website's theme key
-  var observer = new MutationObserver(function () {
-    if (syncing) return;
-    var isDark = document.documentElement.classList.contains('dark');
-    var resolved = isDark ? 'dark' : 'light';
-    if (localStorage.getItem('theme') !== resolved) {
-      localStorage.setItem('theme', resolved);
-    }
-  });
-
-  observer.observe(document.documentElement, {
-    attributes: true,
-    attributeFilter: ['class'],
-  });
 })();

--- a/docs/docs.json
+++ b/docs/docs.json
@@ -25,7 +25,7 @@
   "logo": {
     "light": "/images/Nango-Light-Mode.svg",
     "dark": "/images/Nango-Dark-Mode.svg",
-    "href": "https://www.nango.dev"
+    "href": "https://nango.dev"
   },
   "favicon": "/favicon.png",
   "contextual": {
@@ -69,7 +69,7 @@
       "linkedin": "https://www.linkedin.com/company/nangohq/",
       "github": "https://github.com/NangoHQ/nango",
       "slack": "https://nango.dev/slack",
-      "website": "https://www.nango.dev/"
+      "website": "https://nango.dev/"
     }
   },
   "integrations": {


### PR DESCRIPTION
Linear Issue: [NAN-5453](https://linear.app/nango/issue/NAN-5453/sync-darklight-mode-between-website-and-docs)

## Summary

This PR contains two changes:

**1. Fix subdomain origin mismatch (`docs.json`)**

`www.nango.dev` and `nango.dev` are separate browser origins with completely isolated `localStorage`. The docs live at `nango.dev/docs`, so when a user toggles theme in docs, Mintlify writes `isDarkMode` to `nango.dev`'s storage.

The logo `href` and `website` link both pointed to `https://www.nango.dev`, meaning clicking the logo navigated to a different origin. Any theme changes made in docs were then invisible to the website, and the website's sync code read from the wrong storage bucket.

Changing both to `https://nango.dev` keeps the navigation within the same origin so localStorage is shared correctly.

**2. Revert theme sync code from `custom.js`**

A previous PR added a `storage` event listener and a `MutationObserver` on `<html>` to `custom.js` for real-time cross-tab sync. This caused a regression: React hydration adds font/utility classes to `<html>` after the observer is registered, triggering it and silently overwriting `localStorage.theme = "system"` with `"light"` or `"dark"`.

The custom sync isn't needed — with the subdomain fix in place, full-page navigation in both directions is sufficient:
- **Website → docs**: website toggle writes `isDarkMode` to `nango.dev` localStorage; Mintlify reads it natively on page load
- **Docs → website**: Mintlify toggle writes `isDarkMode`; website reads it in the inline head script on page load (and on bfcache restore)

## Testing

1. Set light mode on nango.dev → click Docs → toggle dark mode → click Nango logo → website should show dark
2. Repeat in reverse (dark → light)
3. Set "System" on the website → navigate to docs → navigate back → website should still follow OS preference