### PR TITLE
feat(metering): emit batchId on records and connections cron events

### DIFF
--- a/packages/metering/lib/crons/usage.ts
+++ b/packages/metering/lib/crons/usage.ts
@@ -74,6 +74,9 @@ const usage = {
         await tracer.trace<Promise<void>>('nango.cron.exportUsage.metrics', async (span) => {
             try {
                 const now = new Date();
+                // Shared by every records/connections event emitted in this cron run. Used downstream
+                // (NAN-5315) so the read side can sum across slices per firing and average across firings.
+                const batchId = uuidv7();
                 // Note: connectionsPerAccount is held in memory for the duration of the entire function execution
                 // While unbounded the number of account/environment/integration combinations is expected to be manageable
                 const connectionsPerAccount = new Map<string, { accountId: number; environmentId: number; integrationId: string; count: number }>();
@@ -116,7 +119,8 @@ const usage = {
                                             environmentId: connection.environment.id,
                                             integrationId: connection.connection.provider_config_key,
                                             connectionId: connection.connection.connection_id,
-                                            model: recordCount.model
+                                            model: recordCount.model,
+                                            batchId
                                         }
                                     }
                                 ]);
@@ -138,7 +142,8 @@ const usage = {
                             account_id: accountId,
                             attributes: {
                                 environmentId,
-                                integrationId
+                                integrationId,
+                                batchId
                             }
                         };
                     }

--- a/packages/types/lib/pubsub/events.ts
+++ b/packages/types/lib/pubsub/events.ts
@@ -70,6 +70,9 @@ export type UsageRecordsEvent = UsageEventBase<
         properties: {
             syncId: string;
             model: string;
+            // Set by the metering observability cron only. Groups all events emitted by a single
+            // cron firing so the read side can reconstruct per-firing account totals.
+            batchId?: string;
         };
     }
 >;
@@ -99,6 +102,11 @@ export type UsageConnectionsEvent = UsageEventBase<
     'usage.connections',
     {
         value: number;
+        properties: {
+            // Set by the metering observability cron only. Groups all events emitted by a single
+            // cron firing so the read side can reconstruct per-firing account totals.
+            batchId?: string;
+        };
     }
 >;
 


### PR DESCRIPTION
## Summary

Adds an optional `batchId` (uuidv7) to the events emitted by the metering observability cron for `usage.records` and `usage.connections`. One batchId per cron firing, shared by every event emitted in that run.

This is **part 1 of 2** for [NAN-5315](https://linear.app/nango/issue/NAN-5315). Pure additive change — `raw_events.attributes` is a generic JSON column, existing MVs ignore the new field, no readers care yet.

Part 2 (separate [PR](https://github.com/NangoHQ/nango/pull/6101)) will add the new typed-projection MVs (`daily_raw_records` / `daily_raw_connections`) that consume `batchId` to do sum-across-slices-per-firing then average-across-firings — matching Orb's `average(count)` semantic exactly, no /24 zero-fill, no drift on multi-slice-mixed-duration accounts.

Design doc: [AVG billing metric issues](https://linear.app/nango/document/avg-billing-metric-issues-7831f496d326)

## Why we want this ordering

Shipping batchId emission first lets data accumulate in `raw_events` before the new MVs go live. When part 2 deploys, the MVs see batchId from minute one. Reverse order would either fail the new MV's UUID cast or collapse all events from all firings into one "null-batch" group (broken math).

## Scope

- `packages/types/lib/pubsub/events.ts`: adds `batchId?: string` to `UsageRecordsEvent` and `UsageConnectionsEvent` payload properties. Optional because only the metering cron emits these; other publishers (server hooks, persist, jobs) don't need it.
- `packages/metering/lib/crons/usage.ts`: generates `batchId` once per `exportMetrics` run, attaches to every records + connections event emitted via `clickhouse.addRaw()`.

## Test plan

- [x] `npm run ts-build` clean
- [ ] After deploy to dev, verify a recent cron firing's events in `raw_events` all share the same `attributes.batchId` (one UUID per firing, distinct per firing)