### PR TITLE
fix(docs): fix Ask AI sidebar panel broken by overly broad CSS rule NAN-5519

### DIFF
--- a/docs/custom.css
+++ b/docs/custom.css
@@ -433,16 +433,17 @@ html:not(.dark) li[data-active="true"] > a { border-radius: 4px !important; }
  * button, so this bottom input is redundant. Mintlify doesn't expose
  * a docs.json toggle for it.
  *
- * Two layers needed: the input itself uses `chat-assistant-` prefixed
- * classes (caught by [class*="chat-assistant"]), but its outer wrapper
- * uses only generic Tailwind classes — `rounded-2xl pointer-events-auto
- * bg-background-light/90 ...`. That combination is distinctive enough
- * to target without false positives on regular page content.
+ * Two layers needed:
+ * 1. The floating input bar itself (.chat-assistant-floating-input).
+ * 2. Its rounded-2xl wrapper div — which also appears identically
+ *    inside the Ask AI sidebar panel, so the rule must be scoped to
+ *    #content-area to avoid hiding the panel's own input container.
+ *
+ * Do NOT use [class*="chat-assistant"] (hides the panel) or
+ * #chat-assistant-textarea (that ID is duplicated on the panel
+ * textarea and would hide it too).
  */
-#chat-assistant-textarea,
-[class*="chat-assistant"] {
-  display: none !important;
-}
-div.rounded-2xl.pointer-events-auto[class*="bg-background-light"] {
+.chat-assistant-floating-input,
+#content-area div.rounded-2xl.pointer-events-auto[class*="bg-background-light"] {
   display: none !important;
 }


### PR DESCRIPTION
## Problem

Clicking the "Ask AI" button on the docs opens the sidebar panel but it appears completely white — the panel content (header, input, messages) is invisible.

## Solution

The custom CSS in `docs/custom.css` added in #6026 had two rules to hide the redundant floating bottom chat input. Both selectors were too broad and also matched elements inside the Ask AI sidebar panel:

1. `[class*="chat-assistant"]` matched the panel's own elements (`chat-assistant-sheet`, `chat-assistant-input`, etc.)
2. `div.rounded-2xl.pointer-events-auto[class*="bg-background-light"]` matched the panel's input container (Mintlify uses the identical class inside the panel)
3. `#chat-assistant-textarea` also matched the panel's textarea — Mintlify duplicates that ID on both the floating and panel textareas

Fixed by using specific, scoped selectors:

```css
/* hides the floating bar container (covers its textarea too) */
.chat-assistant-floating-input,
/* scoped to #content-area so it doesn't match the panel's identical wrapper */
#content-area div.rounded-2xl.pointer-events-auto[class*="bg-background-light"] {
  display: none !important;
}
```

## Testing

Verified on the [preview deploy](https://nango-fix-ask-ai-sidebar-panel.mintlify.app/getting-started/intro-to-nango):
- Clicking "Ask AI" opens the sidebar panel with the "Assistant" header and input visible
- The redundant floating bottom input bar remains hidden

<img width="1280" height="577" alt="image" src="https://github.com/user-attachments/assets/44016f2c-afaf-43e1-848b-d7b34583fe7d" />