### PR TITLE
chore: cleanup fields replaced by function source

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -24979,6 +24979,7 @@
             "os": [
                 "android"
             ],
+            "peer": true,
             "engines": {
                 "node": ">= 12.0.0"
             },
@@ -25000,6 +25001,7 @@
             "os": [
                 "darwin"
             ],
+            "peer": true,
             "engines": {
                 "node": ">= 12.0.0"
             },
@@ -25021,6 +25023,7 @@
             "os": [
                 "darwin"
             ],
+            "peer": true,
             "engines": {
                 "node": ">= 12.0.0"
             },
@@ -25042,6 +25045,7 @@
             "os": [
                 "freebsd"
             ],
+            "peer": true,
             "engines": {
                 "node": ">= 12.0.0"
             },
@@ -25063,6 +25067,7 @@
             "os": [
                 "linux"
             ],
+            "peer": true,
             "engines": {
                 "node": ">= 12.0.0"
             },
@@ -25084,6 +25089,7 @@
             "os": [
                 "linux"
             ],
+            "peer": true,
             "engines": {
                 "node": ">= 12.0.0"
             },
@@ -25105,6 +25111,7 @@
             "os": [
                 "linux"
             ],
+            "peer": true,
             "engines": {
                 "node": ">= 12.0.0"
             },
@@ -25126,6 +25133,7 @@
             "os": [
                 "linux"
             ],
+            "peer": true,
             "engines": {
                 "node": ">= 12.0.0"
             },
@@ -25147,6 +25155,7 @@
             "os": [
                 "linux"
             ],
+            "peer": true,
             "engines": {
                 "node": ">= 12.0.0"
             },
@@ -25168,6 +25177,7 @@
             "os": [
                 "win32"
             ],
+            "peer": true,
             "engines": {
                 "node": ">= 12.0.0"
             },
@@ -25189,6 +25199,7 @@
             "os": [
                 "win32"
             ],
+            "peer": true,
             "engines": {
                 "node": ">= 12.0.0"
             },
@@ -36509,7 +36520,6 @@
                 "@nangohq/nango-orchestrator": "file:../orchestrator",
                 "@nangohq/nango-yaml": "file:../nango-yaml",
                 "@nangohq/providers": "file:.../providers",
-                "@nangohq/pubsub": "file:../pubsub",
                 "@nangohq/records": "file:../records",
                 "@nangohq/shared": "file:../shared",
                 "@nangohq/usage": "file:../usage",
@@ -36636,6 +36646,7 @@
                 "@nangohq/kvstore": "file:../kvstore",
                 "@nangohq/nango-yaml": "file:../nango-yaml",
                 "@nangohq/providers": "file:../providers",
+                "@nangohq/pubsub": "file:../pubsub",
                 "@nangohq/utils": "file:../utils",
                 "@xmldom/xmldom": "0.8.13",
                 "ajv": "8.18.0",

--- a/packages/jobs/lib/schemas/nango-props.ts
+++ b/packages/jobs/lib/schemas/nango-props.ts
@@ -37,8 +37,7 @@ export const nangoPropsSchema = z.looseObject({
         updated_at: z.coerce.date(),
         version: z.string(),
         attributes: z.record(z.string(), z.any()),
-        // TODO: remove optional at second release for smooth rollout
-        source: z.enum(['catalog', 'standalone', 'repo']).optional(),
+        source: z.enum(['catalog', 'standalone', 'repo']),
         input: z.string().nullable(),
         sync_type: z.enum(['full', 'incremental']).nullable(),
         metadata: z.record(z.string(), z.any()),

--- a/packages/lambda-runner/lib/schemas.ts
+++ b/packages/lambda-runner/lib/schemas.ts
@@ -46,8 +46,7 @@ export const nangoPropsSchema = z.object({
         type: z.enum(['sync', 'action', 'on-event']),
         auto_start: z.boolean(),
         attributes: z.record(z.string(), z.any()),
-        // TODO: remove optional at second release for smooth migration
-        source: z.enum(['catalog', 'standalone', 'repo']).optional(),
+        source: z.enum(['catalog', 'standalone', 'repo']),
         metadata: z.record(z.string(), z.any()),
         input: z.string().nullable(),
         sync_type: z.enum(['full', 'incremental']).nullable(),

--- a/packages/shared/lib/services/deploy/template.ts
+++ b/packages/shared/lib/services/deploy/template.ts
@@ -115,8 +115,6 @@ export async function deployTemplate({
         attributes: {},
         metadata: { description: template.description, scopes: template.scopes },
         source: 'catalog',
-        pre_built: true,
-        is_public: true,
         enabled: true,
         webhook_subscriptions: null,
         models_json_schema: template.json_schema,

--- a/packages/shared/lib/services/deploy/template.ts
+++ b/packages/shared/lib/services/deploy/template.ts
@@ -114,8 +114,6 @@ export async function deployTemplate({
         attributes: {},
         metadata: { description: template.description, scopes: template.scopes },
         source: 'catalog',
-        pre_built: true,
-        is_public: true,
         enabled: true,
         webhook_subscriptions: null,
         models_json_schema: template.json_schema,

--- a/packages/shared/lib/services/sync/config/deploy.service.ts
+++ b/packages/shared/lib/services/sync/config/deploy.service.ts
@@ -371,8 +371,6 @@ async function compileDeployInfo({
             idsToMarkAsInactive,
             syncConfig: {
                 source,
-                pre_built: source === 'catalog',
-                is_public: source === 'catalog',
                 environment_id,
                 nango_config_id: config.id as number,
                 sync_name: syncName,

--- a/packages/shared/lib/services/sync/config/deploy.service.ts
+++ b/packages/shared/lib/services/sync/config/deploy.service.ts
@@ -376,8 +376,6 @@ async function compileDeployInfo({
             idsToMarkAsInactive,
             syncConfig: {
                 source,
-                pre_built: source === 'catalog',
-                is_public: source === 'catalog',
                 environment_id,
                 nango_config_id: config.id as number,
                 sync_name: syncName,

--- a/packages/shared/lib/services/sync/config/deploy.service.unit.test.ts
+++ b/packages/shared/lib/services/sync/config/deploy.service.unit.test.ts
@@ -492,9 +492,7 @@ describe('Deploy transaction - queued deploys mark previous config inactive', ()
         features: [],
         created_at: new Date(),
         updated_at: new Date(),
-        deleted: false,
-        pre_built: false,
-        is_public: false
+        deleted: false
     };
 
     function mockDbKnexActiveConfig(activeConfig: DBSyncConfig | null = null) {

--- a/packages/types/lib/syncConfigs/db.ts
+++ b/packages/types/lib/syncConfigs/db.ts
@@ -22,12 +22,7 @@ export interface DBSyncConfig extends TimestampsAndDeleted {
     type: ScriptTypeLiteral;
     auto_start: boolean;
     attributes: object;
-    // TODO: make required at second release for smooth rollout
-    source?: FunctionSource | undefined;
-    /** @deprecated use `source`. Dual-written during the rollout so old readers still classify catalog rows correctly. */
-    pre_built?: boolean | undefined;
-    /** @deprecated use `source`. Dual-written during the rollout so old readers still classify catalog rows correctly. */
-    is_public?: boolean | undefined;
+    source: FunctionSource;
     metadata: NangoConfigMetadata;
     input: string | null;
     /** @deprecated **/


### PR DESCRIPTION
We have added `source` to `_nango_sync_config` to replace `is_public` and `pre_built`, but we could not just remove them at once, because it would cause errors during rollout. This is a follow-up to remove them. Migration coming in next PR.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/NangoHQ/codesmith/nango/pr/6109"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-light.svg"><img alt="View in Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith</code> with what you need.</sup>

- [ ] Let Codesmith autofix CI failures and bot reviews
<!-- /codesmith:footer -->