### PR TITLE
fix(records): avoid lock contention in batch cleanup

### DIFF
--- a/packages/records/lib/models/records.ts
+++ b/packages/records/lib/models/records.ts
@@ -1245,10 +1245,21 @@ export async function deleteOutdatedRecords({
 
 export async function deleteOldBatchEntries({ olderThan, limit }: { olderThan: Date; limit: number }): Promise<Result<number>> {
     try {
-        const count = await db(RECORDS_BATCH_TABLE)
-            .whereIn('id', db(RECORDS_BATCH_TABLE).select('id').where('created_at', '<', olderThan).limit(limit))
-            .delete();
-        return Ok(count);
+        const result = await db.raw<{ rowCount: number }>(
+            `WITH expired AS (
+                SELECT ctid
+                FROM ${RECORDS_BATCH_TABLE}
+                WHERE created_at < ?
+                ORDER BY created_at
+                LIMIT ?
+                FOR UPDATE SKIP LOCKED
+            )
+            DELETE FROM ${RECORDS_BATCH_TABLE}
+            USING expired
+            WHERE records_batch.ctid = expired.ctid`,
+            [olderThan, limit]
+        );
+        return Ok(result.rowCount);
     } catch (err) {
         return Err(new Error('Failed to delete old batch entries', { cause: err }));
     }

--- a/packages/utils/lib/environment/parse.ts
+++ b/packages/utils/lib/environment/parse.ts
@@ -96,8 +96,8 @@ export const ENVS = z.object({
         .number()
         .optional()
         .default(60 * 24 * 3600 * 1000), // 60 days
-    PERSIST_BATCH_CLEANUP_INTERVAL_MS: z.coerce.number().optional().default(5_000), // set to 0 to disable
-    PERSIST_BATCH_CLEANUP_LIMIT: z.coerce.number().optional().default(10_000),
+    PERSIST_BATCH_CLEANUP_INTERVAL_MS: z.coerce.number().optional().default(30_000), // set to 0 to disable
+    PERSIST_BATCH_CLEANUP_LIMIT: z.coerce.number().optional().default(1_000),
     PERSIST_BATCH_CLEANUP_MAX_AGE_MS: z.coerce
         .number()
         .optional()


### PR DESCRIPTION
Use FOR UPDATE SKIP LOCKED with ctid-based deletion so concurrent cleanup don't block each other.
Also reduce aggressiveness: interval 5s→30s, limit 50k→1k.

query plan 
```
Delete on records_batch  (cost=898.16..1940.65 rows=0 width=0) (actual time=75.791..75.793 rows=0 loops=1)
  Buffers: shared hit=7325 read=64
  I/O Timings: shared read=63.683
  CTE expired
    ->  Limit  (cost=0.57..898.15 rows=1000 width=20) (actual time=3.427..9.487 rows=1000 loops=1)
          Buffers: shared hit=4711 read=2
          I/O Timings: shared read=2.567
          ->  LockRows  (cost=0.57..1813137.48 rows=2020019 width=20) (actual time=3.426..9.364 rows=1000 loops=1)
                Buffers: shared hit=4711 read=2
                I/O Timings: shared read=2.567
                ->  Index Scan using records_batch_created_at on records_batch records_batch_1  (cost=0.57..1792937.29 rows=2020019 width=20) (actual time=3.419..4.752 rows=1000 loops=1)
                      Index Cond: (created_at < (CURRENT_TIMESTAMP - '72:00:00'::interval))
                      Buffers: shared hit=3601
  ->  Nested Loop  (cost=0.00..1042.50 rows=1000 width=36) (actual time=3.440..10.896 rows=1000 loops=1)
        Buffers: shared hit=5711 read=2
        I/O Timings: shared read=2.567
        ->  CTE Scan on expired  (cost=0.00..20.00 rows=1000 width=36) (actual time=3.434..10.052 rows=1000 loops=1)
              Buffers: shared hit=4711 read=2
              I/O Timings: shared read=2.567
        ->  Tid Scan on records_batch  (cost=0.00..1.01 rows=1 width=6) (actual time=0.000..0.000 rows=1 loops=1000)
              TID Cond: (ctid = expired.ctid)
              Buffers: shared hit=1000
Planning Time: 0.092 ms
Execution Time: 75.898 ms
```

<!-- Describe the problem and your solution --> 

<!-- Issue ticket number and link (if applicable) -->

<!-- Testing instructions (skip if just adding/editing providers) -->

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/NangoHQ/codesmith/nango/pr/6111"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-light.svg"><img alt="View in Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith</code> with what you need.</sup>

- [ ] Let Codesmith autofix CI failures and bot reviews
<!-- /codesmith:footer -->