### PR TITLE
fix(proxy): strip stale content-length for decompressed responses

### DIFF
--- a/packages/server/lib/controllers/proxy/allProxy.ts
+++ b/packages/server/lib/controllers/proxy/allProxy.ts
@@ -362,7 +362,7 @@ function checkWasCompressed(responseStream: AxiosResponse): boolean | undefined 
     // if `content-encoding` header wasn't stripped by axios, the response is compressed
     if (contentEncoding) return true;
 
-    const rawHeaders = responseStream.request?.res?.rawHeaders ?? [];
+    const rawHeaders = responseStream.request?.res?.rawHeaders;
     // if raw headers are not available, we can't determine whether the response was compressed
     if (!rawHeaders || !Array.isArray(rawHeaders)) return undefined;
 

--- a/packages/server/lib/controllers/proxy/allProxy.ts
+++ b/packages/server/lib/controllers/proxy/allProxy.ts
@@ -357,7 +357,7 @@ export function parseHeaders(req: Pick<Request, 'rawHeaders'>) {
 /**
  * Checks whether the response was compressed (`content-encoding` header was set) before axios processed it.
  */
-function checkWasContentEncoded(responseStream: AxiosResponse): boolean | undefined {
+function checkWasCompressed(responseStream: AxiosResponse): boolean | undefined {
     const contentEncoding = responseStream.headers['content-encoding'] || '';
     // if `content-encoding` header wasn't stripped by axios, the response is compressed
     if (contentEncoding) return true;
@@ -367,7 +367,7 @@ function checkWasContentEncoded(responseStream: AxiosResponse): boolean | undefi
     if (!rawHeaders || !Array.isArray(rawHeaders)) return undefined;
 
     const ceIdx = rawHeaders.findIndex((h: unknown) => typeof h === 'string' && h.toLowerCase() === 'content-encoding');
-    // if `content-encoding` header is present in raw headers, the response was originalyl compressed and stripped by axios
+    // if `content-encoding` header is present in raw headers, the response was originally compressed and the header was stripped by axios
     return ceIdx !== -1 && ceIdx + 1 < rawHeaders.length && Boolean(rawHeaders[ceIdx + 1]);
 }
 
@@ -375,7 +375,7 @@ export async function handleResponse({ res, responseStream, logCtx }: { res: Res
     const contentDisposition = responseStream.headers['content-disposition'] || '';
     const transferEncoding = responseStream.headers['transfer-encoding'] || '';
 
-    const wasCompressed = checkWasContentEncoded(responseStream);
+    const wasCompressed = checkWasCompressed(responseStream);
     const isChunked = transferEncoding === 'chunked';
     const isAttachmentOrInline = /^(attachment|inline)(;|\s|$)/i.test(contentDisposition);
 

--- a/packages/server/lib/controllers/proxy/allProxy.ts
+++ b/packages/server/lib/controllers/proxy/allProxy.ts
@@ -354,20 +354,41 @@ export function parseHeaders(req: Pick<Request, 'rawHeaders'>) {
     return forwardedHeaders;
 }
 
+/**
+ * Checks whether the response was compressed (`content-encoding` header was set) before axios processed it.
+ */
+function checkWasContentEncoded(responseStream: AxiosResponse): boolean | undefined {
+    const contentEncoding = responseStream.headers['content-encoding'] || '';
+    // if `content-encoding` header wasn't stripped by axios, the response is compressed
+    if (contentEncoding) return true;
+
+    const rawHeaders = responseStream.request?.res?.rawHeaders ?? [];
+    // if raw headers are not available, we can't determine whether the response was compressed
+    if (!rawHeaders || !Array.isArray(rawHeaders)) return undefined;
+
+    const ceIdx = rawHeaders.findIndex((h: unknown) => typeof h === 'string' && h.toLowerCase() === 'content-encoding');
+    // if `content-encoding` header is present in raw headers, the response was originalyl compressed and stripped by axios
+    return ceIdx !== -1 && ceIdx + 1 < rawHeaders.length && Boolean(rawHeaders[ceIdx + 1]);
+}
+
 export async function handleResponse({ res, responseStream, logCtx }: { res: Response; responseStream: AxiosResponse; logCtx: LogContext }) {
     const contentDisposition = responseStream.headers['content-disposition'] || '';
     const transferEncoding = responseStream.headers['transfer-encoding'] || '';
-    const contentEncoding = responseStream.headers['content-encoding'] || '';
 
+    const wasCompressed = checkWasContentEncoded(responseStream);
     const isChunked = transferEncoding === 'chunked';
-    const isEncoded = Boolean(contentEncoding);
     const isAttachmentOrInline = /^(attachment|inline)(;|\s|$)/i.test(contentDisposition);
 
-    if (isChunked || isEncoded || isAttachmentOrInline) {
+    if (isChunked || wasCompressed || isAttachmentOrInline) {
+        const passthroughHeaders = Object.fromEntries(Object.entries(responseStream.headers)) as OutgoingHttpHeaders;
+        if (wasCompressed) {
+            // axios decompressed the response, so the `content-length` is no longer valid
+            delete passthroughHeaders['content-length'];
+        }
         const passThroughStream = new PassThrough();
         responseStream.data.pipe(passThroughStream);
         passThroughStream.pipe(res);
-        res.writeHead(responseStream.status, responseStream.headers as OutgoingHttpHeaders);
+        res.writeHead(responseStream.status, passthroughHeaders);
 
         metrics.increment(metrics.Types.PROXY_SUCCESS);
         await logCtx.success();

--- a/packages/server/lib/controllers/proxy/allProxy.ts
+++ b/packages/server/lib/controllers/proxy/allProxy.ts
@@ -375,14 +375,13 @@ export async function handleResponse({ res, responseStream, logCtx }: { res: Res
     const contentDisposition = responseStream.headers['content-disposition'] || '';
     const transferEncoding = responseStream.headers['transfer-encoding'] || '';
 
-    const wasCompressed = checkWasCompressed(responseStream);
     const isChunked = transferEncoding === 'chunked';
     const isAttachmentOrInline = /^(attachment|inline)(;|\s|$)/i.test(contentDisposition);
 
-    if (isChunked || wasCompressed || isAttachmentOrInline) {
+    if (isChunked || isAttachmentOrInline) {
         const passthroughHeaders = Object.fromEntries(Object.entries(responseStream.headers)) as OutgoingHttpHeaders;
-        if (wasCompressed) {
-            // axios decompressed the response, so the `content-length` is no longer valid
+        if (checkWasCompressed(responseStream)) {
+            // axios decompressed the response, so the `content-length` header is no longer valid
             delete passthroughHeaders['content-length'];
         }
         const passThroughStream = new PassThrough();

--- a/packages/server/lib/controllers/proxy/allProxy.unit.test.ts
+++ b/packages/server/lib/controllers/proxy/allProxy.unit.test.ts
@@ -53,6 +53,7 @@ describe('handleResponse', () => {
         log: vi.fn(),
         accountId: 1
     } as unknown as LogContext;
+
     const createMockResponse = () => {
         let sentData: Buffer | undefined;
         const headers: Record<string, string> = {};
@@ -82,7 +83,11 @@ describe('handleResponse', () => {
                 writeHead: vi.fn(),
                 end: vi.fn(() => {
                     if (sendResolve) sendResolve();
-                })
+                }),
+                on: vi.fn().mockReturnThis(),
+                once: vi.fn().mockReturnThis(),
+                emit: vi.fn().mockReturnThis(),
+                write: vi.fn()
             } as unknown as Response,
             getSentData: () => sentData,
             getHeaders: () => headers,
@@ -93,9 +98,12 @@ describe('handleResponse', () => {
 
     const createMockResponseStream = (
         data: string,
-        contentType = 'application/json',
-        status = 200,
-        extraHeaders: Record<string, string> = {}
+        {
+            contentType = 'application/json',
+            status = 200,
+            headers = {},
+            request = {}
+        }: { contentType?: string; status?: number; headers?: Record<string, string>; request?: object } = {}
     ): AxiosResponse => {
         const stream = new Readable();
         stream.push(data);
@@ -103,17 +111,15 @@ describe('handleResponse', () => {
 
         return {
             status,
-            headers: {
-                'content-type': contentType,
-                ...extraHeaders
-            },
+            headers: { 'content-type': contentType, ...headers },
+            request,
             data: stream
         } as unknown as AxiosResponse;
     };
 
     it('should handle 204 No Content response', async () => {
         const mockRes = createMockResponse();
-        const mockResponseStream = createMockResponseStream('', 'application/json', 204);
+        const mockResponseStream = createMockResponseStream('', { status: 204 });
 
         handleResponse({ res: mockRes.res, responseStream: mockResponseStream, logCtx: mockLogCtx });
         await mockRes.waitForSend();
@@ -153,7 +159,7 @@ describe('handleResponse', () => {
     it('should pass-thru non-json payload', async () => {
         const nonJsonPayload = `<foobar>`;
         const mockRes = createMockResponse();
-        const mockResponseStream = createMockResponseStream(nonJsonPayload, 'text/xml');
+        const mockResponseStream = createMockResponseStream(nonJsonPayload, { contentType: 'text/xml' });
 
         handleResponse({ res: mockRes.res, responseStream: mockResponseStream, logCtx: mockLogCtx });
         await mockRes.waitForSend();
@@ -166,11 +172,15 @@ describe('handleResponse', () => {
 
     it('should forward allowlisted headers (mcp-session-id, x-request-id) and drop others', async () => {
         const mockRes = createMockResponse();
-        const mockResponseStream = createMockResponseStream('{"ok":true}', 'application/json', 200, {
-            'mcp-session-id': 'session-abc123',
-            'x-request-id': 'req-xyz',
-            'x-ratelimit-limit': '100',
-            'x-ratelimit-remaining': '42'
+        const mockResponseStream = createMockResponseStream('{"ok":true}', {
+            contentType: 'application/json',
+            status: 200,
+            headers: {
+                'mcp-session-id': 'session-abc123',
+                'x-request-id': 'req-xyz',
+                'x-ratelimit-limit': '100',
+                'x-ratelimit-remaining': '42'
+            }
         });
 
         handleResponse({ res: mockRes.res, responseStream: mockResponseStream, logCtx: mockLogCtx });
@@ -181,6 +191,46 @@ describe('handleResponse', () => {
         expect(mockRes.res.setHeader).toHaveBeenCalledWith('x-request-id', 'req-xyz');
         expect(mockRes.res.setHeader).not.toHaveBeenCalledWith('x-ratelimit-limit', expect.anything());
         expect(mockRes.res.setHeader).not.toHaveBeenCalledWith('x-ratelimit-remaining', expect.anything());
+        expect(mockLogCtx.success).toHaveBeenCalled();
+    });
+
+    it('should strip content-length when axios decompressed a gzip-encoded response', async () => {
+        const mockRes = createMockResponse();
+        const mockResponseStream = createMockResponseStream('decompressed content', {
+            contentType: 'application/octet-stream',
+            headers: {
+                'content-length': '500',
+                'content-disposition': 'attachment; filename="file.bin"'
+                // content-encoding absent: axios stripped it after decompression
+            },
+            request: {
+                res: {
+                    rawHeaders: ['Content-Encoding', 'gzip', 'Content-Length', '500', 'Content-Disposition', 'attachment; filename="file.bin"']
+                }
+            }
+        });
+
+        await handleResponse({ res: mockRes.res, responseStream: mockResponseStream, logCtx: mockLogCtx });
+
+        const [, headersArg] = vi.mocked(mockRes.res.writeHead).mock.calls[0]!;
+        expect(headersArg).not.toHaveProperty('content-length');
+        expect(mockLogCtx.success).toHaveBeenCalled();
+    });
+
+    it('should preserve content-length for uncompressed attachment responses', async () => {
+        const mockRes = createMockResponse();
+        const mockResponseStream = createMockResponseStream('raw binary content', {
+            contentType: 'application/pdf',
+            headers: {
+                'content-length': '18',
+                'content-disposition': 'attachment; filename="report.pdf"'
+            }
+        });
+
+        await handleResponse({ res: mockRes.res, responseStream: mockResponseStream, logCtx: mockLogCtx });
+
+        const [, headersArg] = vi.mocked(mockRes.res.writeHead).mock.calls[0]!;
+        expect(headersArg).toHaveProperty('content-length', '18');
         expect(mockLogCtx.success).toHaveBeenCalled();
     });
 });


### PR DESCRIPTION
Axios decompresses responses (gzip, deflate, brotli) but leaves content-length pointing to the compressed byte count, causing downstream clients to hang waiting for bytes that never arrive.

Detect decompression by checking rawHeaders when axios strips content-encoding, then drop content-length.

Uncompressed attachments preserve their content-length unchanged.

<!-- Describe the problem and your solution --> 

<!-- Issue ticket number and link (if applicable) -->

<!-- Testing instructions (skip if just adding/editing providers) -->

