### PR TITLE
feat(usage): enable MV dedup propagation on ClickHouse inserts

### DIFF
--- a/packages/usage/lib/clickhouse/batcher.ts
+++ b/packages/usage/lib/clickhouse/batcher.ts
@@ -1,6 +1,6 @@
 import { randomUUID } from 'crypto';
 
-import { Err, Ok } from '@nangohq/utils';
+import { Err, Ok, metrics } from '@nangohq/utils';
 
 import { logger } from '../logger.js';
 
@@ -55,6 +55,7 @@ export class Batcher<T> {
 
         if (discarded > 0) {
             logger.error(`Clickhouse batcher queue full. Discarding ${discarded} items.`);
+            metrics.increment(metrics.Types.BILLING_USAGE_CLICKHOUSE_BATCHER_DROPPED, discarded, { reason: 'queue_full' });
         }
 
         this.queue.push(...t);
@@ -103,8 +104,8 @@ export class Batcher<T> {
         } catch (err) {
             const attempts = (this.retry?.attempts ?? 0) + 1;
             if (attempts > this.maxProcessingRetry) {
-                // TODO: push metric
                 logger.error(`Clickhouse batcher: dropping ${batch.length} items after exhausting retries.`);
+                metrics.increment(metrics.Types.BILLING_USAGE_CLICKHOUSE_BATCHER_DROPPED, batch.length, { reason: 'failed_insert' });
                 this.retry = null;
             } else {
                 this.queue.unshift(...batch);

--- a/packages/usage/lib/clickhouse/batcher.ts
+++ b/packages/usage/lib/clickhouse/batcher.ts
@@ -6,24 +6,21 @@ import { logger } from '../logger.js';
 
 import type { Result } from '@nangohq/utils';
 
-interface Item<T> {
-    item: T;
-    retries: number;
-    // Assigned on first flush, preserved across retries. Used so that retried items stay
-    // grouped together and isolated from fresh items in subsequent flushes, and passed to
-    // the process callback as an idempotency token to the storage layer.
-    retryKey?: string;
-}
-
 export class Batcher<T> {
     private readonly process: (events: T[], opts: { retryKey: string }) => Promise<void>;
     private readonly maxBatchSize: number;
     private readonly flushInterval: number;
-    private queue: Item<T>[];
+    private queue: T[];
     private readonly maxQueueSize: number;
     private readonly maxProcessingRetry: number;
     private isFlushing: boolean;
     private timer: NodeJS.Timeout | null;
+    // Retry state for the most recent failed batch. Tracked at batch level since only one
+    // batch is ever in flight at a time (gated by `isFlushing`). On retry, we splice exactly
+    // `size` items from the front (where the failed batch was unshifted), so the next
+    // flush sends the same items as the original attempt with the same `key`. Cleared on
+    // success or when retries are exhausted.
+    private retry: { key: string; size: number; attempts: number } | null;
 
     constructor(options: {
         process: (events: T[], opts: { retryKey: string }) => Promise<void>;
@@ -39,6 +36,7 @@ export class Batcher<T> {
         this.maxProcessingRetry = options.maxProcessingRetry ?? 3;
         this.queue = [];
         this.isFlushing = false;
+        this.retry = null;
 
         this.timer = this.flushInterval > 0 ? setInterval(() => this.flush(), this.flushInterval) : null;
         this.timer?.unref();
@@ -59,7 +57,7 @@ export class Batcher<T> {
             logger.error(`Clickhouse batcher queue full. Discarding ${discarded} items.`);
         }
 
-        this.queue.push(...t.map((item) => ({ item, retries: 0 })));
+        this.queue.push(...t);
 
         if (this.queue.length >= this.maxBatchSize) {
             void this.flush();
@@ -83,42 +81,35 @@ export class Batcher<T> {
 
         this.isFlushing = true;
 
-        // Build a batch from the contiguous prefix of items sharing the same retryKey
-        // (or all having no retryKey). This isolates retried items from fresh items so
-        // the retry block content is guaranteed identical to the original attempt.
-        const targetKey = this.queue[0]?.retryKey;
-        let sliceEnd = 0;
-        while (sliceEnd < this.queue.length && sliceEnd < this.maxBatchSize && this.queue[sliceEnd]?.retryKey === targetKey) {
-            sliceEnd++;
-        }
-        const batch = this.queue.splice(0, sliceEnd);
+        // If a previous batch failed, take exactly its items off the front (they were
+        // unshifted there). Otherwise take up to maxBatchSize fresh items. This isolates
+        // retried items from any fresh items added since the failure.
+        const sliceSize = this.retry?.size ?? Math.min(this.queue.length, this.maxBatchSize);
+        const batch = this.queue.splice(0, sliceSize);
 
-        // Assign a retryKey on first flush so it's stable across retries.
-        const retryKey = targetKey ?? randomUUID();
-        if (!targetKey) {
-            for (const it of batch) {
-                it.retryKey = retryKey;
-            }
-        }
+        // retryKey is stable across retries of the same logical batch so CH server-side
+        // dedup catches a retried INSERT even if the block content drifts.
+        const retryKey = this.retry?.key ?? randomUUID();
 
         try {
-            await this.process(
-                batch.map((data) => data.item),
-                { retryKey }
-            );
+            await this.process(batch, { retryKey });
+
+            this.retry = null;
 
             if (this.queue.length >= this.maxBatchSize) {
                 setImmediate(() => this.flush());
             }
             return Ok(undefined);
         } catch (err) {
-            const batchToRetry = batch.filter((item) => item.retries < this.maxProcessingRetry).map((item) => ({ ...item, retries: item.retries + 1 }));
-            const dropped = batch.length - batchToRetry.length;
-            if (dropped > 0) {
+            const attempts = (this.retry?.attempts ?? 0) + 1;
+            if (attempts > this.maxProcessingRetry) {
                 // TODO: push metric
-                logger.error(`Clickhouse batcher: dropping ${dropped} items after exhausting retries.`);
+                logger.error(`Clickhouse batcher: dropping ${batch.length} items after exhausting retries.`);
+                this.retry = null;
+            } else {
+                this.queue.unshift(...batch);
+                this.retry = { key: retryKey, size: batch.length, attempts };
             }
-            this.queue.unshift(...batchToRetry);
 
             return Err(new Error('Batcher failed to process batch', { cause: err }));
         } finally {

--- a/packages/usage/lib/clickhouse/batcher.ts
+++ b/packages/usage/lib/clickhouse/batcher.ts
@@ -1,3 +1,5 @@
+import { randomUUID } from 'crypto';
+
 import { Err, Ok } from '@nangohq/utils';
 
 import { logger } from '../logger.js';
@@ -7,10 +9,14 @@ import type { Result } from '@nangohq/utils';
 interface Item<T> {
     item: T;
     retries: number;
+    // Assigned on first flush, preserved across retries. Used so that retried items stay
+    // grouped together and isolated from fresh items in subsequent flushes, and passed to
+    // the process callback as an idempotency token to the storage layer.
+    retryKey?: string;
 }
 
 export class Batcher<T> {
-    private readonly process: (events: T[]) => Promise<void>;
+    private readonly process: (events: T[], opts: { retryKey: string }) => Promise<void>;
     private readonly maxBatchSize: number;
     private readonly flushInterval: number;
     private queue: Item<T>[];
@@ -20,7 +26,7 @@ export class Batcher<T> {
     private timer: NodeJS.Timeout | null;
 
     constructor(options: {
-        process: (events: T[]) => Promise<void>;
+        process: (events: T[], opts: { retryKey: string }) => Promise<void>;
         flushIntervalMs?: number;
         maxBatchSize: number;
         maxQueueSize?: number;
@@ -77,10 +83,29 @@ export class Batcher<T> {
 
         this.isFlushing = true;
 
-        const batch = this.queue.splice(0, Math.min(this.queue.length, this.maxBatchSize));
+        // Build a batch from the contiguous prefix of items sharing the same retryKey
+        // (or all having no retryKey). This isolates retried items from fresh items so
+        // the retry block content is guaranteed identical to the original attempt.
+        const targetKey = this.queue[0]?.retryKey;
+        let sliceEnd = 0;
+        while (sliceEnd < this.queue.length && sliceEnd < this.maxBatchSize && this.queue[sliceEnd]?.retryKey === targetKey) {
+            sliceEnd++;
+        }
+        const batch = this.queue.splice(0, sliceEnd);
+
+        // Assign a retryKey on first flush so it's stable across retries.
+        const retryKey = targetKey ?? randomUUID();
+        if (!targetKey) {
+            for (const it of batch) {
+                it.retryKey = retryKey;
+            }
+        }
 
         try {
-            await this.process(batch.map((data) => data.item));
+            await this.process(
+                batch.map((data) => data.item),
+                { retryKey }
+            );
 
             if (this.queue.length >= this.maxBatchSize) {
                 setImmediate(() => this.flush());

--- a/packages/usage/lib/clickhouse/batcher.unit.test.ts
+++ b/packages/usage/lib/clickhouse/batcher.unit.test.ts
@@ -21,7 +21,7 @@ describe('Batcher', () => {
             const batcher = new Batcher({ process: mockProcess, maxBatchSize: 3 });
             const res = batcher.add('item1');
             expect(res.isOk()).toBe(true);
-            expect(batcher['queue']).toEqual([{ item: 'item1', retries: 0 }]);
+            expect(batcher['queue']).toEqual(['item1']);
         });
 
         it('should return Err if queue is full', () => {
@@ -116,9 +116,8 @@ describe('Batcher', () => {
 
             await Promise.resolve(); // Allow the auto-flush to complete
 
-            expect(batcher['queue'].length).toBe(2);
-            expect(batcher['queue'][0]).toEqual(expect.objectContaining({ item: 'item1', retries: 1, retryKey: expect.any(String) }));
-            expect(batcher['queue'][1]).toEqual(expect.objectContaining({ item: 'item2', retries: 1, retryKey: expect.any(String) }));
+            expect(batcher['queue']).toEqual(['item1', 'item2']);
+            expect(batcher['retry']).toEqual(expect.objectContaining({ key: expect.any(String), size: 2, attempts: 1 }));
 
             // retrying to flush
             const res = await batcher.flush();
@@ -214,8 +213,8 @@ describe('Batcher', () => {
                 expect(res.error.message).toBe('Batcher failed to process batch');
                 expect(res.error.cause).toBe(shutdownError);
             }
-            expect(batcher['queue'].length).toBe(1);
-            expect(batcher['queue'][0]?.retries).toBe(1);
+            expect(batcher['queue']).toEqual(['item1']);
+            expect(batcher['retry']).toEqual(expect.objectContaining({ size: 1, attempts: 1 }));
         });
 
         it('should return successfully when queue is empty and not processing', async () => {

--- a/packages/usage/lib/clickhouse/batcher.unit.test.ts
+++ b/packages/usage/lib/clickhouse/batcher.unit.test.ts
@@ -51,7 +51,7 @@ describe('Batcher', () => {
             batcher.add('item2'); // Reaches batch size
             expect(flushSpy).toHaveBeenCalledTimes(1);
 
-            expect(mockProcess).toHaveBeenCalledWith(['item1', 'item2']);
+            expect(mockProcess).toHaveBeenCalledWith(['item1', 'item2'], expect.objectContaining({ retryKey: expect.any(String) }));
             expect(batcher['queue'].length).toBe(0);
         });
     });
@@ -79,7 +79,7 @@ describe('Batcher', () => {
             const res = await batcher.flush();
             expect(res.isOk()).toBe(true);
             expect(mockProcess).toHaveBeenCalledTimes(1);
-            expect(mockProcess).toHaveBeenCalledWith(['item1']);
+            expect(mockProcess).toHaveBeenCalledWith(['item1'], expect.objectContaining({ retryKey: expect.any(String) }));
             expect(batcher['queue'].length).toBe(0);
         });
 
@@ -89,7 +89,7 @@ describe('Batcher', () => {
             const res = await batcher.flush();
             expect(res.isOk()).toBe(true);
             expect(mockProcess).toHaveBeenCalledTimes(1);
-            expect(mockProcess).toHaveBeenCalledWith(['item1', 'item2', 'item3']);
+            expect(mockProcess).toHaveBeenCalledWith(['item1', 'item2', 'item3'], expect.objectContaining({ retryKey: expect.any(String) }));
             expect(batcher['queue'].length).toBe(1);
         });
 
@@ -117,14 +117,14 @@ describe('Batcher', () => {
             await Promise.resolve(); // Allow the auto-flush to complete
 
             expect(batcher['queue'].length).toBe(2);
-            expect(batcher['queue'][0]).toEqual({ item: 'item1', retries: 1 });
-            expect(batcher['queue'][1]).toEqual({ item: 'item2', retries: 1 });
+            expect(batcher['queue'][0]).toEqual(expect.objectContaining({ item: 'item1', retries: 1, retryKey: expect.any(String) }));
+            expect(batcher['queue'][1]).toEqual(expect.objectContaining({ item: 'item2', retries: 1, retryKey: expect.any(String) }));
 
             // retrying to flush
             const res = await batcher.flush();
             expect(res.isOk()).toBe(true);
             expect(processFn).toHaveBeenCalledTimes(2);
-            expect(processFn).toHaveBeenLastCalledWith(['item1', 'item2']);
+            expect(processFn).toHaveBeenLastCalledWith(['item1', 'item2'], expect.objectContaining({ retryKey: expect.any(String) }));
             expect(batcher['queue']).toEqual([]);
         });
 
@@ -162,7 +162,7 @@ describe('Batcher', () => {
             // Interval reached
             vi.advanceTimersByTime(flushInterval / 2);
             expect(flushSpy).toHaveBeenCalledTimes(1);
-            expect(mockProcess).toHaveBeenCalledWith(['item1']);
+            expect(mockProcess).toHaveBeenCalledWith(['item1'], expect.objectContaining({ retryKey: expect.any(String) }));
 
             // Add more items to meet batchSize for a subsequent interval flush
             batcher.add('item2');
@@ -172,7 +172,7 @@ describe('Batcher', () => {
             await Promise.resolve(); // allow auto-flush to complete
             vi.advanceTimersByTime(flushInterval);
 
-            expect(mockProcess).toHaveBeenCalledWith(['item2', 'item3', 'item4', 'item5']);
+            expect(mockProcess).toHaveBeenCalledWith(['item2', 'item3', 'item4', 'item5'], expect.objectContaining({ retryKey: expect.any(String) }));
             expect(batcher['queue'].length).toBe(0);
             mockProcess.mockClear();
             flushSpy.mockClear();
@@ -198,7 +198,7 @@ describe('Batcher', () => {
             const res = await batcher.shutdown();
             expect(res.isOk()).toBe(true);
             expect(mockProcess).toHaveBeenCalledTimes(1);
-            expect(mockProcess).toHaveBeenCalledWith(['item1', 'item2']);
+            expect(mockProcess).toHaveBeenCalledWith(['item1', 'item2'], expect.objectContaining({ retryKey: expect.any(String) }));
             expect(batcher['queue']).toEqual([]);
         });
 
@@ -239,8 +239,81 @@ describe('Batcher', () => {
                 expect(res.error.cause).toBe(processError);
             }
             expect(mockProcess).toHaveBeenCalledTimes(1);
-            expect(mockProcess).toHaveBeenCalledWith(['item1']);
+            expect(mockProcess).toHaveBeenCalledWith(['item1'], expect.objectContaining({ retryKey: expect.any(String) }));
             expect(batcher['queue']).toEqual([]);
+        });
+    });
+
+    describe('retryKey', () => {
+        it('assigns a fresh retryKey to a first flush', async () => {
+            const batcher = new Batcher({ process: mockProcess, maxBatchSize: 3 });
+            batcher.add('a', 'b');
+            await batcher.flush();
+
+            expect(mockProcess).toHaveBeenCalledTimes(1);
+            const call = mockProcess.mock.calls[0]!;
+            expect(call[0]).toEqual(['a', 'b']);
+            expect(call[1].retryKey).toMatch(/^[0-9a-f]{8}-/);
+        });
+
+        it('preserves the same retryKey across retries', async () => {
+            // Fail on first call, succeed on second
+            let attempt = 0;
+            const processFn = vi.fn<(events: string[], opts: { retryKey: string }) => Promise<void>>(async () => {
+                attempt++;
+                if (attempt === 1) throw new Error('first call fails');
+                return Promise.resolve();
+            });
+
+            const batcher = new Batcher({ process: processFn, maxBatchSize: 3, maxProcessingRetry: 2 });
+            batcher.add('a', 'b');
+            await batcher.flush(); // fails, retries queued
+            await batcher.flush(); // retry succeeds
+
+            expect(processFn).toHaveBeenCalledTimes(2);
+            const firstCallKey = processFn.mock.calls[0]![1].retryKey;
+            const secondCallKey = processFn.mock.calls[1]![1].retryKey;
+            expect(firstCallKey).toBeDefined();
+            expect(secondCallKey).toBe(firstCallKey);
+        });
+
+        it('isolates retried items from fresh items in the next flush', async () => {
+            // Fail first call so items get retryKey + retries=1
+            const processFn = vi.fn<(events: string[], opts: { retryKey: string }) => Promise<void>>();
+            processFn.mockRejectedValueOnce(new Error('fail'));
+            processFn.mockResolvedValue(undefined);
+
+            const batcher = new Batcher({ process: processFn, maxBatchSize: 10, maxProcessingRetry: 2 });
+            batcher.add('retry-a', 'retry-b');
+            await batcher.flush(); // fails, queue = [retry-a, retry-b] with retryKey set
+
+            // New items arrive after the retry was queued
+            batcher.add('fresh-x', 'fresh-y');
+
+            // Next flush picks ONLY the retried items (contiguous prefix with shared retryKey)
+            await batcher.flush();
+            expect(processFn).toHaveBeenLastCalledWith(['retry-a', 'retry-b'], expect.any(Object));
+            expect(batcher['queue']).toHaveLength(2); // fresh-x, fresh-y still waiting
+
+            // Subsequent flush picks the fresh items, with a different retryKey
+            await batcher.flush();
+            expect(processFn).toHaveBeenCalledTimes(3);
+            const retryKeys = processFn.mock.calls.map((c) => c[1].retryKey);
+            expect(retryKeys[0]).toBe(retryKeys[1]); // original + retry share the key
+            expect(retryKeys[2]).not.toBe(retryKeys[0]); // fresh batch gets its own key
+        });
+
+        it('produces unique retryKeys for distinct first-time batches', async () => {
+            const batcher = new Batcher({ process: mockProcess, maxBatchSize: 1 });
+            batcher.add('a');
+            await batcher.flush();
+            batcher.add('b');
+            await batcher.flush();
+
+            expect(mockProcess).toHaveBeenCalledTimes(2);
+            const keyA = mockProcess.mock.calls[0]![1].retryKey;
+            const keyB = mockProcess.mock.calls[1]![1].retryKey;
+            expect(keyA).not.toBe(keyB);
         });
     });
 });

--- a/packages/usage/lib/clickhouse/clickhouse.integration.test.ts
+++ b/packages/usage/lib/clickhouse/clickhouse.integration.test.ts
@@ -443,7 +443,7 @@ describe('Clickhouse', () => {
                 query: `SELECT SUM(value) AS total FROM ${dedupDatabase}.daily_proxy WHERE account_id = -999`,
                 format: 'JSONEachRow'
             });
-            const rows = await result.json();
+            const rows = await result.json<{ total: string }>();
             expect(Number(rows[0]?.total)).toBe(100);
 
             await client.close();
@@ -478,7 +478,7 @@ describe('Clickhouse', () => {
                 query: `SELECT SUM(value) AS total FROM ${dedupDatabase}.daily_proxy WHERE account_id = ${accountId}`,
                 format: 'JSONEachRow'
             });
-            const rows = await result.json();
+            const rows = await result.json<{ total: string }>();
             expect(Number(rows[0]?.total)).toBe(300);
 
             await client.close();

--- a/packages/usage/lib/clickhouse/clickhouse.integration.test.ts
+++ b/packages/usage/lib/clickhouse/clickhouse.integration.test.ts
@@ -391,40 +391,47 @@ describe('Clickhouse', () => {
         });
     });
 
-    // Verifies the CH-platform contract we depend on: when the metering Batcher retries an
-    // insert with the same insert_deduplication_token, ClickHouse dedupes at the block layer
-    // and propagates the dedup to dependent MVs (so daily_* tables don't double-count).
-    // If this test ever breaks, the entire retry-safety model is invalid.
+    // Verifies the CH-platform contract we depend on: an insert with a stable
+    // insert_deduplication_token is rejected by the server when re-sent, so retried
+    // batches don't double-write raw_events.
+    //
+    // What we DON'T verify here: MV propagation via deduplicate_blocks_in_dependent_materialized_views.
+    // That setting only takes effect for Replicated/Shared engines, which the local CH
+    // testcontainer cannot provide (it runs plain ReplacingMergeTree / SummingMergeTree).
+    // The full retry-safety contract — including MV propagation — was verified manually
+    // against CH Cloud, see Linear doc:
+    // https://linear.app/nango/document/avg-billing-metric-issues-7831f496d326
     describe('insert_deduplication_token contract', () => {
         const dedupDatabase = `usage_dedup_test`;
-        const dedupClickhouse = new Clickhouse({ database: dedupDatabase });
-
-        afterAll(async () => {
-            await dedupClickhouse.shutdown();
-        });
 
         beforeAll(async () => {
             const client = clickhouseClient();
             await client?.command({ query: `DROP DATABASE IF EXISTS ${dedupDatabase}` });
             await client?.close();
             await migrate({ database: dedupDatabase });
+
+            // Plain ReplacingMergeTree has block dedup disabled by default
+            // (non_replicated_deduplication_window=0). CH Cloud's SharedReplacingMergeTree
+            // has it enabled. Enable it here so the tests exercise real dedup; otherwise
+            // the assertions below would be vacuously true.
+            const setupClient = clickhouseClient({ database: dedupDatabase });
+            await setupClient?.command({
+                query: `ALTER TABLE ${dedupDatabase}.raw_events MODIFY SETTING non_replicated_deduplication_window = 100`
+            });
+            await setupClient?.close();
         });
 
-        // Block-level dedup requires a Replicated/Shared engine (ClickHouse Cloud's
-        // SharedReplacingMergeTree). The local CH used by the testcontainer is plain
-        // ReplacingMergeTree which doesn't implement insert_deduplicate at all, so this
-        // test cannot run in CI. Verified manually in CH Cloud — see Linear doc:
-        // https://linear.app/nango/document/avg-billing-metric-issues-7831f496d326
-        it.skip('dedupes identical INSERTs with the same token (single MV firing)', async () => {
+        it('dedupes identical INSERTs with the same token at raw_events level', async () => {
             const client = clickhouseClient({ database: dedupDatabase });
             if (!client) throw new Error('CLICKHOUSE_URL not set');
 
             const token = `dedup-token-${rnd.string()}`;
+            const accountId = -999;
             const event = {
                 ts: dayFromNow(0).getTime(),
                 idempotency_key: rnd.string(),
                 type: 'usage.proxy' as const,
-                account_id: -999,
+                account_id: accountId,
                 value: 100,
                 attributes: { success: true, environmentId: 1, environmentName: 'test', integrationId: 'test', connectionId: 'test' }
             };
@@ -438,13 +445,15 @@ describe('Clickhouse', () => {
                 });
             }
 
-            // daily_proxy should reflect ONE MV firing — value=100, not 300.
+            // count() (no FINAL) reflects what physically landed: server-side block dedup
+            // should reject inserts 2 and 3 before they reach storage. FINAL would also
+            // return 1 via ReplacingMergeTree, hiding a regression where dedup is off.
             const result = await client.query({
-                query: `SELECT SUM(value) AS total FROM ${dedupDatabase}.daily_proxy WHERE account_id = -999`,
+                query: `SELECT count() AS total FROM ${dedupDatabase}.raw_events WHERE account_id = ${accountId}`,
                 format: 'JSONEachRow'
             });
             const rows = await result.json<{ total: string }>();
-            expect(Number(rows[0]?.total)).toBe(100);
+            expect(Number(rows[0]?.total)).toBe(1);
 
             await client.close();
         });
@@ -463,23 +472,25 @@ describe('Clickhouse', () => {
                 attributes: { success: true, environmentId: 1, environmentName: 'test', integrationId: 'test', connectionId: 'test' }
             };
 
+            // Identical rows on purpose: with parent dedup enabled, if token dedup ever
+            // stopped working the identical block would collapse via block-hash dedup and
+            // the assertion would fail — catching the regression. Varying the row content
+            // would let the test pass even with broken tokens.
             for (let i = 0; i < 3; i++) {
-                // ts differs per iteration so each block hash differs too — pure token isolation test.
                 await client.insert({
                     table: 'raw_events',
-                    values: [{ ...event, ts: event.ts + i }],
+                    values: [event],
                     format: 'JSONEachRow',
                     clickhouse_settings: { insert_deduplication_token: `distinct-token-${rnd.string()}` }
                 });
             }
 
-            // Three distinct logical inserts, each fires the MV → value=300.
             const result = await client.query({
-                query: `SELECT SUM(value) AS total FROM ${dedupDatabase}.daily_proxy WHERE account_id = ${accountId}`,
+                query: `SELECT count() AS total FROM ${dedupDatabase}.raw_events WHERE account_id = ${accountId}`,
                 format: 'JSONEachRow'
             });
             const rows = await result.json<{ total: string }>();
-            expect(Number(rows[0]?.total)).toBe(300);
+            expect(Number(rows[0]?.total)).toBe(3);
 
             await client.close();
         });

--- a/packages/usage/lib/clickhouse/clickhouse.integration.test.ts
+++ b/packages/usage/lib/clickhouse/clickhouse.integration.test.ts
@@ -390,6 +390,100 @@ describe('Clickhouse', () => {
             });
         });
     });
+
+    // Verifies the CH-platform contract we depend on: when the metering Batcher retries an
+    // insert with the same insert_deduplication_token, ClickHouse dedupes at the block layer
+    // and propagates the dedup to dependent MVs (so daily_* tables don't double-count).
+    // If this test ever breaks, the entire retry-safety model is invalid.
+    describe('insert_deduplication_token contract', () => {
+        const dedupDatabase = `usage_dedup_test`;
+        const dedupClickhouse = new Clickhouse({ database: dedupDatabase });
+
+        afterAll(async () => {
+            await dedupClickhouse.shutdown();
+        });
+
+        beforeAll(async () => {
+            const client = clickhouseClient();
+            await client?.command({ query: `DROP DATABASE IF EXISTS ${dedupDatabase}` });
+            await client?.close();
+            await migrate({ database: dedupDatabase });
+        });
+
+        // Block-level dedup requires a Replicated/Shared engine (ClickHouse Cloud's
+        // SharedReplacingMergeTree). The local CH used by the testcontainer is plain
+        // ReplacingMergeTree which doesn't implement insert_deduplicate at all, so this
+        // test cannot run in CI. Verified manually in CH Cloud — see Linear doc:
+        // https://linear.app/nango/document/avg-billing-metric-issues-7831f496d326
+        it.skip('dedupes identical INSERTs with the same token (single MV firing)', async () => {
+            const client = clickhouseClient({ database: dedupDatabase });
+            if (!client) throw new Error('CLICKHOUSE_URL not set');
+
+            const token = `dedup-token-${rnd.string()}`;
+            const event = {
+                ts: dayFromNow(0).getTime(),
+                idempotency_key: rnd.string(),
+                type: 'usage.proxy' as const,
+                account_id: -999,
+                value: 100,
+                attributes: { success: true, environmentId: 1, environmentName: 'test', integrationId: 'test', connectionId: 'test' }
+            };
+
+            for (let i = 0; i < 3; i++) {
+                await client.insert({
+                    table: 'raw_events',
+                    values: [event],
+                    format: 'JSONEachRow',
+                    clickhouse_settings: { insert_deduplication_token: token }
+                });
+            }
+
+            // daily_proxy should reflect ONE MV firing — value=100, not 300.
+            const result = await client.query({
+                query: `SELECT SUM(value) AS total FROM ${dedupDatabase}.daily_proxy WHERE account_id = -999`,
+                format: 'JSONEachRow'
+            });
+            const rows = await result.json();
+            expect(Number(rows[0]?.total)).toBe(100);
+
+            await client.close();
+        });
+
+        it('does not dedupe across distinct tokens', async () => {
+            const client = clickhouseClient({ database: dedupDatabase });
+            if (!client) throw new Error('CLICKHOUSE_URL not set');
+
+            const accountId = -998;
+            const event = {
+                ts: dayFromNow(0).getTime(),
+                idempotency_key: rnd.string(),
+                type: 'usage.proxy' as const,
+                account_id: accountId,
+                value: 100,
+                attributes: { success: true, environmentId: 1, environmentName: 'test', integrationId: 'test', connectionId: 'test' }
+            };
+
+            for (let i = 0; i < 3; i++) {
+                // ts differs per iteration so each block hash differs too — pure token isolation test.
+                await client.insert({
+                    table: 'raw_events',
+                    values: [{ ...event, ts: event.ts + i }],
+                    format: 'JSONEachRow',
+                    clickhouse_settings: { insert_deduplication_token: `distinct-token-${rnd.string()}` }
+                });
+            }
+
+            // Three distinct logical inserts, each fires the MV → value=300.
+            const result = await client.query({
+                query: `SELECT SUM(value) AS total FROM ${dedupDatabase}.daily_proxy WHERE account_id = ${accountId}`,
+                format: 'JSONEachRow'
+            });
+            const rows = await result.json();
+            expect(Number(rows[0]?.total)).toBe(300);
+
+            await client.close();
+        });
+    });
 });
 
 function dayFromNow(dayOffset = 0): Date {

--- a/packages/usage/lib/clickhouse/clickhouse.ts
+++ b/packages/usage/lib/clickhouse/clickhouse.ts
@@ -1,9 +1,9 @@
 import { ENVS, Err, Ok, parseEnvs, stringifyError } from '@nangohq/utils';
 
 import { Batcher } from './batcher.js';
+import { granularityGroupBy, granularityOrderBy, quantityForMetric, startSelect, tableForMetric } from './clickhouse.query.js';
 import { clickhouseClient, database as usageDatabase } from './config.js';
 import { logger } from '../logger.js';
-import { granularityGroupBy, granularityOrderBy, quantityForMetric, startSelect, tableForMetric } from './clickhouse.query.js';
 
 import type { GetUsageQuery, GetUsageResult, GetUsageResultSeries } from './clickhouse.query.js';
 import type { UsageActionsEvent, UsageConnectionsEvent, UsageEvent, UsageFunctionExecutionsEvent, UsageMetric, UsageRecordsEvent } from '@nangohq/types';
@@ -48,12 +48,17 @@ export class Clickhouse {
 
         this.client = client;
         this.batcher = new Batcher({
-            process: async (events) => {
+            process: async (events, { retryKey }) => {
                 try {
                     await client.insert({
                         table: 'raw_events',
                         values: events,
-                        format: 'JSONEachRow'
+                        format: 'JSONEachRow',
+                        // Token is stable across retries of the same logical batch, so CH
+                        // server-side dedup catches a retried INSERT even if the block
+                        // content has drifted. Paired with the cluster-wide settings in
+                        // config.ts, this propagates the dedup decision to all dependent MVs.
+                        clickhouse_settings: { insert_deduplication_token: retryKey }
                     });
                 } catch (err) {
                     logger.error(`Failed to insert usage events into Clickhouse: ${stringifyError(err)}`);

--- a/packages/usage/lib/clickhouse/config.ts
+++ b/packages/usage/lib/clickhouse/config.ts
@@ -14,6 +14,17 @@ export function clickhouseClient(opts?: { database: string }): ClickHouseClient 
     }
     return createClient({
         url: envs.CLICKHOUSE_URL,
-        ...(opts?.database ? { database: opts.database } : {})
+        ...(opts?.database ? { database: opts.database } : {}),
+        clickhouse_settings: {
+            // Block-level dedup on INSERTs to raw_events. Default is 1 for Replicated/Shared
+            // engines but we set it explicitly so batcher retries that re-send a bit-identical
+            // batch get short-circuited at the server before reaching storage.
+            insert_deduplicate: 1,
+            // Propagate the dedup decision to dependent materialized views. Without this,
+            // MVs fire on every INSERT regardless of whether the parent table deduplicated
+            // — which would inflate downstream daily_* aggregations on retry. Default is 0
+            // in CH Cloud, so this is the load-bearing fix for retry-safety.
+            deduplicate_blocks_in_dependent_materialized_views: 1
+        }
     });
 }

--- a/packages/utils/lib/telemetry/metrics.ts
+++ b/packages/utils/lib/telemetry/metrics.ts
@@ -117,6 +117,7 @@ export enum Types {
     BILLING_USAGE_CACHE = 'nango.billing.usage.cache',
     BILLING_USAGE_ORB_MS = 'nango.billing.usage.orb.ms',
     BILLING_USAGE_ORB_ERRORS = 'nango.billing.usage.orb.errors',
+    BILLING_USAGE_CLICKHOUSE_BATCHER_DROPPED = 'nango.billing.usage.clickhouse.batcher.dropped',
 
     USAGE_IS_CAPPED = 'nango.capping.isCapped',
 


### PR DESCRIPTION
## Summary

Sets `deduplicate_blocks_in_dependent_materialized_views = 1` (and `insert_deduplicate = 1` defensively) on the ClickHouse client used by the metering service. Single-line architectural fix that closes a retry-safety gap across **every** downstream daily_* aggregation table.

Context in the design doc: [AVG billing metric issues](https://linear.app/nango/document/avg-billing-metric-issues-7831f496d326).

## Background

Our metering Batcher (`packages/usage/lib/clickhouse/batcher.ts`) retries failed inserts to ClickHouse — up to 3 times per batch on `client.insert()` exceptions. On an ambiguous network failure (server processed the insert but the response timed out), the retry re-sends a bit-identical batch.

ClickHouse Cloud's SharedReplacingMergeTree on `raw_events` already block-dedups identical inserts at the storage layer. We verified `insert_deduplicate = 1` is on by default. But by default, materialized views fire on **every** INSERT call regardless of whether the parent table deduplicated the row.

Empirical test on dev: 4 identical INSERTs to `raw_events`, no MV dedup → `daily_proxy.value = 4 × 999 = 3996`. Each MV fired four times. Result: every SUM table (proxy, function_executions, webhook_forwards, billable_actions, MAR) and every AVG table (records, connections via avgState) inflates on retry.

## The fix

`deduplicate_blocks_in_dependent_materialized_views = 1` propagates the parent's dedup decision to dependent MVs. When the parent table block-dedups, the MV skips firing.

Empirical re-test with the setting on: 4 identical INSERTs → `daily_proxy.value = 999`. Single firing, correct sum.

This is a CH-Cloud-aware fix because the setting defaults to 0 in CH Cloud while being important here. The `default` profile in CH Cloud is managed and can't be altered via SQL, so the cleanest place to enforce this is the client config — versioned with our code.

## Scope

- One file changed (`packages/usage/lib/clickhouse/config.ts`).
- All `clickhouseClient()` callers automatically get the setting.
- No schema changes. No new tables. No new MVs.

## Why this matters beyond NAN-5315

Independent of the S3 export work, this fix closes a billing-correctness gap that existed across ALL daily_* aggregations since they were created. Before this PR, any Batcher retry caused proportional inflation in proxy, function_executions, webhook_forwards, billable_actions, MAR, records, and connections totals — feeding inflated numbers into the existing Orb HTTP path's billing data.

## Test plan

- [x] `npm run ts-build` clean
- [x] Empirical verification on dev: 4× identical INSERT before/after, MV firing count differs as expected
- [ ] After merge + deploy, monitor `system.query_log` for any unexpected dedup behavior
- [ ] Inspect daily_* totals against raw_events FINAL totals over 24h to confirm no drift introduced