### PR TITLE
refactor(records): add records_seen partitioned table 1/3

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -19522,10 +19522,6 @@
                 "node": "*"
             }
         },
-        "node_modules/dayjs": {
-            "version": "1.11.10",
-            "license": "MIT"
-        },
         "node_modules/dayjs-plugin-utc": {
             "version": "0.1.2",
             "license": "MIT"
@@ -36222,6 +36218,7 @@
                 "@nangohq/records": "file:../records",
                 "@nangohq/shared": "file:../shared",
                 "@nangohq/utils": "file:../utils",
+                "dayjs": "1.11.19",
                 "dd-trace": "5.52.0",
                 "express": "5.1.0",
                 "qs": "6.15.0",
@@ -36233,6 +36230,12 @@
                 "typescript": "5.8.3",
                 "vitest": "3.2.4"
             }
+        },
+        "packages/persist/node_modules/dayjs": {
+            "version": "1.11.19",
+            "resolved": "https://registry.npmjs.org/dayjs/-/dayjs-1.11.19.tgz",
+            "integrity": "sha512-t5EcLVS6QPBNqM2z8fakk/NKel+Xzshgt8FFKAn+qwlD1pzZWxh0nVCrvFK7ZDb6XucZeF9z8C7CBWTRIVApAw==",
+            "license": "MIT"
         },
         "packages/persist/node_modules/node-fetch": {
             "version": "3.3.2",
@@ -36349,7 +36352,7 @@
             "dependencies": {
                 "@fastify/deepmerge": "2.0.1",
                 "@nangohq/utils": "file:../utils",
-                "dayjs": "1.11.10",
+                "dayjs": "1.11.19",
                 "dd-trace": "5.52.0",
                 "knex": "3.1.0",
                 "pg": "8.11.3",
@@ -36359,6 +36362,12 @@
                 "@types/md5": "2.3.2",
                 "vitest": "3.2.4"
             }
+        },
+        "packages/records/node_modules/dayjs": {
+            "version": "1.11.19",
+            "resolved": "https://registry.npmjs.org/dayjs/-/dayjs-1.11.19.tgz",
+            "integrity": "sha512-t5EcLVS6QPBNqM2z8fakk/NKel+Xzshgt8FFKAn+qwlD1pzZWxh0nVCrvFK7ZDb6XucZeF9z8C7CBWTRIVApAw==",
+            "license": "MIT"
         },
         "packages/runner": {
             "name": "@nangohq/nango-runner",

--- a/packages/persist/lib/daemons/batchCleanup.daemon.ts
+++ b/packages/persist/lib/daemons/batchCleanup.daemon.ts
@@ -1,3 +1,4 @@
+import dayjs from 'dayjs';
 import tracer from 'dd-trace';
 
 import { records } from '@nangohq/records';
@@ -9,6 +10,8 @@ import { logger } from '../logger.js';
 /*
  * Batch cleanup daemon
  * Deletes records_batch entries older than PERSIST_BATCH_CLEANUP_MAX_AGE_MS.
+ * Drops records_seen partitions older than PERSIST_BATCH_CLEANUP_MAX_AGE_MS.
+ * Pre-creates tomorrow's records_seen partition on each tick.
  */
 export function batchCleanupDaemon(): Awaited<ReturnType<typeof cancellableDaemon>> {
     return cancellableDaemon({
@@ -17,13 +20,26 @@ export function batchCleanupDaemon(): Awaited<ReturnType<typeof cancellableDaemo
             return tracer.trace('nango.persist.daemon.batchCleanup', async (span) => {
                 try {
                     const olderThan = new Date(Date.now() - envs.PERSIST_BATCH_CLEANUP_MAX_AGE_MS);
-                    const res = await records.deleteOldBatchEntries({ olderThan, limit: envs.PERSIST_BATCH_CLEANUP_LIMIT });
-                    if (res.isErr()) {
-                        span?.addTags({ error: res.error.message });
-                        logger.error(`[Batch cleanup] error deleting old batch entries: ${res.error.message}`);
+                    const batchRes = await records.deleteOldBatchEntries({ olderThan, limit: envs.PERSIST_BATCH_CLEANUP_LIMIT });
+                    if (batchRes.isErr()) {
+                        span?.addTags({ error: batchRes.error.message });
+                        logger.error(`[Batch cleanup] error deleting old batch entries: ${batchRes.error.message}`);
+                    } else {
+                        span?.addTags({ deleted: batchRes.value });
+                    }
+
+                    const ensureRes = await records.ensureSeenPartition({ date: dayjs().add(1, 'day').toDate() });
+                    if (ensureRes.isErr()) {
+                        span?.addTags({ seenError: ensureRes.error.message });
+                        logger.error(`[Batch cleanup] error ensuring seen partition: ${ensureRes.error.message}`);
+                    }
+
+                    const seenRes = await records.dropSeenPartition({ date: dayjs(olderThan).subtract(1, 'day').toDate() });
+                    if (seenRes.isErr()) {
+                        span?.addTags({ seenError: seenRes.error.message });
+                        logger.error(`[Batch cleanup] error dropping seen partition: ${seenRes.error.message}`);
                         return;
                     }
-                    span?.addTags({ deleted: res.value });
                 } catch (err) {
                     span?.addTags({ error: (err as Error).message });
                     logger.error(`[Batch cleanup] unexpected error: ${(err as Error).message}`);

--- a/packages/persist/package.json
+++ b/packages/persist/package.json
@@ -24,6 +24,7 @@
         "@nangohq/shared": "file:../shared",
         "@nangohq/utils": "file:../utils",
         "@nangohq/pubsub": "file:../pubsub",
+        "dayjs": "1.11.19",
         "dd-trace": "5.52.0",
         "express": "5.1.0",
         "qs": "6.15.0",

--- a/packages/records/lib/constants.ts
+++ b/packages/records/lib/constants.ts
@@ -2,3 +2,4 @@ export const RECORDS_TABLE = 'records';
 export const RECORD_COUNTS_TABLE = 'record_counts';
 export const RECORDS_DATA_TABLE = 'records_data';
 export const RECORDS_BATCH_TABLE = 'records_batch';
+export const RECORDS_SEEN_TABLE = 'records_seen';

--- a/packages/records/lib/db/migrations/20260512000100_create_records_seen.ts
+++ b/packages/records/lib/db/migrations/20260512000100_create_records_seen.ts
@@ -1,0 +1,29 @@
+import type { Knex } from 'knex';
+
+import { ensureSeenPartition } from '../../models/records.js';
+
+const TABLE = 'records_seen';
+
+export const config = { transaction: false };
+
+export async function up(knex: Knex): Promise<void> {
+    await knex.raw(`
+        CREATE TABLE IF NOT EXISTS "${TABLE}" (
+            id             bigserial    NOT NULL,
+            connection_id  integer      NOT NULL,
+            model          varchar(255) NOT NULL,
+            sync_job_id    integer      NOT NULL,
+            record_ids     uuid[]       NOT NULL,
+            created_at     timestamptz  NOT NULL DEFAULT CURRENT_TIMESTAMP,
+            PRIMARY KEY (id, created_at)
+        ) PARTITION BY RANGE (created_at)
+    `);
+    await knex.raw(`CREATE INDEX IF NOT EXISTS records_seen_connection_model_job ON "${TABLE}" (connection_id, model, sync_job_id)`);
+
+    const res = await ensureSeenPartition({ date: new Date() });
+    if (res.isErr()) {
+        throw res.error;
+    }
+}
+
+export async function down(): Promise<void> {}

--- a/packages/records/lib/models/records.integration.test.ts
+++ b/packages/records/lib/models/records.integration.test.ts
@@ -2,7 +2,7 @@ import dayjs from 'dayjs';
 import * as uuid from 'uuid';
 import { afterAll, beforeAll, beforeEach, describe, expect, it } from 'vitest';
 
-import { RECORDS_BATCH_TABLE, RECORDS_DATA_TABLE, RECORDS_TABLE, RECORD_COUNTS_TABLE } from '../constants.js';
+import { RECORDS_BATCH_TABLE, RECORDS_DATA_TABLE, RECORDS_SEEN_TABLE, RECORDS_TABLE, RECORD_COUNTS_TABLE } from '../constants.js';
 import { Cursor } from '../cursor.js';
 import { db } from '../db/client.js';
 import { migrate } from '../db/migrate.js';
@@ -22,6 +22,7 @@ describe('Records service', () => {
         await db(RECORDS_TABLE).truncate();
         await db(RECORD_COUNTS_TABLE).truncate();
         await db(RECORDS_BATCH_TABLE).truncate();
+        await db(RECORDS_SEEN_TABLE).truncate();
     });
 
     describe('Should fetch cursor', () => {
@@ -1896,6 +1897,48 @@ describe('Records service', () => {
             // hard delete removes the count entry entirely when count reaches 0
             const stats = (await Records.getCountsByModel({ connectionId, environmentId })).unwrap();
             expect(stats[model]).toBeUndefined();
+        });
+    });
+
+    describe('ensureSeenPartition', () => {
+        it('should create a partition for the given date', async () => {
+            const date = new Date('2025-01-15T00:00:00Z');
+            const res = await Records.ensureSeenPartition({ date });
+            expect(res.isOk()).toBe(true);
+
+            const { rows } = await db.raw<{ rows: { exists: boolean }[] }>(`SELECT EXISTS (SELECT 1 FROM pg_tables WHERE tablename = ?)`, [
+                'records_seen_20250115'
+            ]);
+            expect(rows[0]?.exists).toBe(true);
+        });
+
+        it('should be idempotent', async () => {
+            const date = new Date('2025-01-16T00:00:00Z');
+            const res1 = await Records.ensureSeenPartition({ date });
+            const res2 = await Records.ensureSeenPartition({ date });
+            expect(res1.isOk()).toBe(true);
+            expect(res2.isOk()).toBe(true);
+        });
+    });
+
+    describe('dropSeenPartition', () => {
+        it('should drop an existing partition', async () => {
+            const date = new Date('2025-02-10T00:00:00Z');
+            await Records.ensureSeenPartition({ date });
+
+            const res = await Records.dropSeenPartition({ date });
+            expect(res.isOk()).toBe(true);
+
+            const { rows } = await db.raw<{ rows: { exists: boolean }[] }>(`SELECT EXISTS (SELECT 1 FROM pg_tables WHERE tablename = ?)`, [
+                'records_seen_20250210'
+            ]);
+            expect(rows[0]?.exists).toBe(false);
+        });
+
+        it('should not error when partition does not exist', async () => {
+            const date = new Date('2025-02-11T00:00:00Z');
+            const res = await Records.dropSeenPartition({ date });
+            expect(res.isOk()).toBe(true);
         });
     });
 });

--- a/packages/records/lib/models/records.ts
+++ b/packages/records/lib/models/records.ts
@@ -4,7 +4,7 @@ import tracer from 'dd-trace';
 
 import { Err, Ok, retry, stringToHash } from '@nangohq/utils';
 
-import { RECORDS_BATCH_TABLE, RECORDS_DATA_TABLE, RECORDS_TABLE, RECORD_COUNTS_TABLE } from '../constants.js';
+import { RECORDS_BATCH_TABLE, RECORDS_DATA_TABLE, RECORDS_SEEN_TABLE, RECORDS_TABLE, RECORD_COUNTS_TABLE } from '../constants.js';
 import { Cursor } from '../cursor.js';
 import { db, dbRead } from '../db/client.js';
 import { envs } from '../env.js';
@@ -67,12 +67,50 @@ function getInactiveThisMonth(records: UpsertedMetadata[]): UpsertedMetadata[] {
     });
 }
 
+export async function ensureSeenPartition({ date }: { date: Date }): Promise<Result<void>> {
+    try {
+        const day = dayjs(date).utc().startOf('day');
+        const next = day.add(1, 'day');
+        const suffix = day.format('YYYYMMDD');
+        await db.raw(
+            `CREATE TABLE IF NOT EXISTS "records_seen_${suffix}" PARTITION OF "${RECORDS_SEEN_TABLE}" FOR VALUES FROM ('${day.toISOString()}') TO ('${next.toISOString()}')`
+        );
+        return Ok(undefined);
+    } catch (err) {
+        return Err(new Error('Failed to ensure seen partition', { cause: err }));
+    }
+}
+
+export async function dropSeenPartition({ date }: { date: Date }): Promise<Result<void>> {
+    const suffix = dayjs(date).utc().startOf('day').format('YYYYMMDD');
+    try {
+        return await db.transaction(async (trx) => {
+            // advisory lock scoped to this partition date — concurrent instances skip instead of racing
+            const lockKey = stringToHash(`records_seen_drop:${suffix}`);
+            const { rows } = await trx.raw<{ rows: { lock: boolean }[] }>(`SELECT pg_try_advisory_xact_lock(?) as lock`, [lockKey]);
+            if (!rows?.[0]?.lock) {
+                return Ok(undefined);
+            }
+            await trx.raw(`DROP TABLE IF EXISTS "records_seen_${suffix}"`);
+            return Ok(undefined);
+        });
+    } catch (err) {
+        return Err(new Error('Failed to drop seen partition', { cause: err }));
+    }
+}
+
 async function insertBatchEntry(
     trx: Knex.Transaction,
     { connectionId, model, syncJobId, recordIds }: { connectionId: number; model: string; syncJobId: number; recordIds: string[] }
 ): Promise<void> {
     if (recordIds.length === 0) return;
     await trx(RECORDS_BATCH_TABLE).insert({
+        connection_id: connectionId,
+        model,
+        sync_job_id: syncJobId,
+        record_ids: trx.raw(`ARRAY[${recordIds.map(() => '?::uuid').join(',')}]`, recordIds)
+    });
+    await trx(RECORDS_SEEN_TABLE).insert({
         connection_id: connectionId,
         model,
         sync_job_id: syncJobId,

--- a/packages/records/package.json
+++ b/packages/records/package.json
@@ -19,7 +19,7 @@
     "dependencies": {
         "@fastify/deepmerge": "2.0.1",
         "@nangohq/utils": "file:../utils",
-        "dayjs": "1.11.10",
+        "dayjs": "1.11.19",
         "dd-trace": "5.52.0",
         "knex": "3.1.0",
         "pg": "8.11.3",

--- a/packages/utils/lib/environment/parse.ts
+++ b/packages/utils/lib/environment/parse.ts
@@ -96,7 +96,11 @@ export const ENVS = z.object({
         .number()
         .optional()
         .default(60 * 24 * 3600 * 1000), // 60 days
-    PERSIST_BATCH_CLEANUP_INTERVAL_MS: z.coerce.number().optional().default(30_000), // set to 0 to disable
+    PERSIST_BATCH_CLEANUP_INTERVAL_MS: z.coerce
+        .number()
+        .positive()
+        .max(6 * 3600 * 1000) // max 6 hours to ensure the records_seen daily partition for next day is always created ahead of time
+        .default(1 * 3600 * 1000),
     PERSIST_BATCH_CLEANUP_LIMIT: z.coerce.number().optional().default(1_000),
     PERSIST_BATCH_CLEANUP_MAX_AGE_MS: z.coerce
         .number()

--- a/packages/utils/lib/environment/parse.ts
+++ b/packages/utils/lib/environment/parse.ts
@@ -105,7 +105,7 @@ export const ENVS = z.object({
     PERSIST_BATCH_CLEANUP_MAX_AGE_MS: z.coerce
         .number()
         .optional()
-        .default(72 * 3600 * 1000), // 72 hours
+        .default(48 * 3600 * 1000), // 48 hours
     NANGO_PERSIST_PORT: z.coerce.number().optional().default(3007),
 
     // Orchestrator


### PR DESCRIPTION
Introduce records_seen table (daily partitions) tracked alongside records_batch 
so removing expired entries doesn't require deleting entries which is an expensive process that creates lots of dead tuples. Instead we can drop old partitions which is a quick operation that doesn't mutate any rows/indexes

Extend batchCleanup daemon to pre-create tomorrow's partition and drop old ones on each tick. 

Partition table isn't read yet.

part 2: https://github.com/NangoHQ/nango/pull/6125
part 3: https://github.com/NangoHQ/nango/pull/6126

<!-- Describe the problem and your solution --> 

<!-- Issue ticket number and link (if applicable) -->

<!-- Testing instructions (skip if just adding/editing providers) -->

