### PR TITLE
refactor(records): drop records_batch table 3/3

### DIFF
--- a/packages/records/lib/db/migrations/20260513000100_drop_records_batch.ts
+++ b/packages/records/lib/db/migrations/20260513000100_drop_records_batch.ts
@@ -1,0 +1,7 @@
+import type { Knex } from 'knex';
+
+export async function up(knex: Knex): Promise<void> {
+    await knex.raw(`DROP TABLE IF EXISTS "records_batch"`);
+}
+
+export async function down(): Promise<void> {}

--- a/packages/records/lib/models/records.ts
+++ b/packages/records/lib/models/records.ts
@@ -110,12 +110,6 @@ async function insertSeenEntry(
         sync_job_id: syncJobId,
         record_ids: trx.raw(`ARRAY[${recordIds.map(() => '?::uuid').join(',')}]`, recordIds)
     });
-    await trx(RECORDS_SEEN_TABLE).insert({
-        connection_id: connectionId,
-        model,
-        sync_job_id: syncJobId,
-        record_ids: trx.raw(`ARRAY[${recordIds.map(() => '?::uuid').join(',')}]`, recordIds)
-    });
 }
 
 /**

--- a/packages/records/lib/models/records.ts
+++ b/packages/records/lib/models/records.ts
@@ -110,6 +110,12 @@ async function insertSeenEntry(
         sync_job_id: syncJobId,
         record_ids: trx.raw(`ARRAY[${recordIds.map(() => '?::uuid').join(',')}]`, recordIds)
     });
+    await trx(RECORDS_SEEN_TABLE).insert({
+        connection_id: connectionId,
+        model,
+        sync_job_id: syncJobId,
+        record_ids: trx.raw(`ARRAY[${recordIds.map(() => '?::uuid').join(',')}]`, recordIds)
+    });
 }
 
 /**


### PR DESCRIPTION
part 1: https://github.com/NangoHQ/nango/pull/6124
part 2: https://github.com/NangoHQ/nango/pull/6125

`records_seen` fully replaces `records_batch` for tracking seen record ids.

