### PR TITLE
chore(deps): bump axios to 1.16.0 across all packages

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -16863,12 +16863,12 @@
             }
         },
         "node_modules/axios": {
-            "version": "1.15.2",
-            "resolved": "https://registry.npmjs.org/axios/-/axios-1.15.2.tgz",
-            "integrity": "sha512-wLrXxPtcrPTsNlJmKjkPnNPK2Ihe0hn0wGSaTEiHRPxwjvJwT3hKmXF4dpqxmPO9SoNb2FsYXj/xEo0gHN+D5A==",
+            "version": "1.16.0",
+            "resolved": "https://registry.npmjs.org/axios/-/axios-1.16.0.tgz",
+            "integrity": "sha512-6hp5CwvTPlN2A31g5dxnwAX0orzM7pmCRDLnZSX772mv8WDqICwFjowHuPs04Mc8deIld1+ejhtaMn5vp6b+1w==",
             "license": "MIT",
             "dependencies": {
-                "follow-redirects": "^1.15.11",
+                "follow-redirects": "^1.16.0",
                 "form-data": "^4.0.5",
                 "proxy-from-env": "^2.1.0"
             }
@@ -35014,7 +35014,7 @@
                 "@types/unzipper": "0.10.11",
                 "ajv": "8.18.0",
                 "ajv-errors": "3.0.0",
-                "axios": "1.15.2",
+                "axios": "1.16.0",
                 "chalk": "5.4.1",
                 "chokidar": "3.5.3",
                 "columnify": "1.6.0",
@@ -35540,7 +35540,7 @@
                 "@nangohq/usage": "file:../usage",
                 "@nangohq/utils": "file:../utils",
                 "@nangohq/webhooks": "file:../webhooks",
-                "axios": "1.15.2",
+                "axios": "1.16.0",
                 "dd-trace": "5.52.0",
                 "express": "5.1.0",
                 "get-port": "7.1.0",
@@ -36173,7 +36173,7 @@
             "license": "SEE LICENSE IN LICENSE FILE IN GIT REPOSITORY",
             "dependencies": {
                 "@nangohq/types": "0.70.2",
-                "axios": "1.15.2"
+                "axios": "1.16.0"
             },
             "devDependencies": {
                 "tsup": "8.5.1",
@@ -36373,7 +36373,7 @@
                 "@nangohq/utils": "file:../utils",
                 "@trpc/client": "10.45.3",
                 "@trpc/server": "10.45.3",
-                "axios": "1.15.2",
+                "axios": "1.16.0",
                 "botbuilder": "4.23.2",
                 "connect-timeout": "1.9.1",
                 "dd-trace": "5.52.0",
@@ -36407,7 +36407,7 @@
             "devDependencies": {
                 "@nangohq/types": "0.70.2",
                 "@types/json-schema": "7.0.15",
-                "axios": "1.15.2",
+                "axios": "1.16.0",
                 "json-schema": "0.4.0",
                 "vitest": "3.2.4"
             },
@@ -36526,7 +36526,7 @@
                 "@nangohq/utils": "file:../utils",
                 "@nangohq/webhooks": "file:../webhooks",
                 "@workos-inc/node": "6.2.0",
-                "axios": "1.15.2",
+                "axios": "1.16.0",
                 "body-parser": "2.2.1",
                 "connect-session-knex": "4.0.0",
                 "cookie-parser": "1.4.7",
@@ -36652,7 +36652,7 @@
                 "ajv": "8.18.0",
                 "ajv-formats": "3.0.1",
                 "archiver": "7.0.1",
-                "axios": "1.15.2",
+                "axios": "1.16.0",
                 "braintree": "3.15.0",
                 "dayjs": "1.11.19",
                 "dd-trace": "5.52.0",
@@ -36816,7 +36816,7 @@
             "version": "0.70.2",
             "license": "SEE LICENSE IN LICENSE FILE IN GIT REPOSITORY",
             "dependencies": {
-                "axios": "1.15.2",
+                "axios": "1.16.0",
                 "json-schema": "0.4.0",
                 "type-fest": "4.41.0"
             },
@@ -36864,7 +36864,7 @@
             "dependencies": {
                 "@colors/colors": "1.6.0",
                 "@sentry/node": "9.3.0",
-                "axios": "1.15.2",
+                "axios": "1.16.0",
                 "dd-trace": "5.52.0",
                 "exponential-backoff": "3.1.1",
                 "fast-safe-stringify": "2.1.1",
@@ -39095,7 +39095,7 @@
                 "@nangohq/kvstore": "file:../kvstore",
                 "@nangohq/logs": "file:../logs",
                 "@nangohq/utils": "file:../utils",
-                "axios": "1.15.2",
+                "axios": "1.16.0",
                 "dayjs": "1.11.7",
                 "dayjs-plugin-utc": "0.1.2",
                 "rate-limiter-flexible": "5.0.3"

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -48,7 +48,7 @@
         "@types/unzipper": "0.10.11",
         "ajv": "8.18.0",
         "ajv-errors": "3.0.0",
-        "axios": "1.15.2",
+        "axios": "1.16.0",
         "chalk": "5.4.1",
         "chokidar": "3.5.3",
         "columnify": "1.6.0",

--- a/packages/jobs/package.json
+++ b/packages/jobs/package.json
@@ -34,7 +34,7 @@
         "@nangohq/shared": "file:../shared",
         "@nangohq/utils": "file:../utils",
         "@nangohq/webhooks": "file:../webhooks",
-        "axios": "1.15.2",
+        "axios": "1.16.0",
         "dd-trace": "5.52.0",
         "express": "5.1.0",
         "get-port": "7.1.0",

--- a/packages/node-client/package.json
+++ b/packages/node-client/package.json
@@ -26,7 +26,7 @@
     "license": "SEE LICENSE IN LICENSE FILE IN GIT REPOSITORY",
     "dependencies": {
         "@nangohq/types": "0.70.2",
-        "axios": "1.15.2"
+        "axios": "1.16.0"
     },
     "engines": {
         "node": ">=20.0"

--- a/packages/runner-sdk/package.json
+++ b/packages/runner-sdk/package.json
@@ -20,7 +20,7 @@
     "devDependencies": {
         "@nangohq/types": "0.70.2",
         "@types/json-schema": "7.0.15",
-        "axios": "1.15.2",
+        "axios": "1.16.0",
         "json-schema": "0.4.0",
         "vitest": "3.2.4"
     },

--- a/packages/runner/package.json
+++ b/packages/runner/package.json
@@ -26,7 +26,7 @@
         "@nangohq/utils": "file:../utils",
         "@trpc/client": "10.45.3",
         "@trpc/server": "10.45.3",
-        "axios": "1.15.2",
+        "axios": "1.16.0",
         "botbuilder": "4.23.2",
         "connect-timeout": "1.9.1",
         "dd-trace": "5.52.0",

--- a/packages/server/package.json
+++ b/packages/server/package.json
@@ -38,7 +38,7 @@
         "@nangohq/utils": "file:../utils",
         "@nangohq/webhooks": "file:../webhooks",
         "@workos-inc/node": "6.2.0",
-        "axios": "1.15.2",
+        "axios": "1.16.0",
         "body-parser": "2.2.1",
         "connect-session-knex": "4.0.0",
         "cookie-parser": "1.4.7",

--- a/packages/shared/package.json
+++ b/packages/shared/package.json
@@ -34,7 +34,7 @@
         "ajv": "8.18.0",
         "ajv-formats": "3.0.1",
         "archiver": "7.0.1",
-        "axios": "1.15.2",
+        "axios": "1.16.0",
         "braintree": "3.15.0",
         "dayjs": "1.11.19",
         "dd-trace": "5.52.0",

--- a/packages/types/package.json
+++ b/packages/types/package.json
@@ -12,7 +12,7 @@
         "directory": "packages/utils"
     },
     "dependencies": {
-        "axios": "1.15.2",
+        "axios": "1.16.0",
         "json-schema": "0.4.0",
         "type-fest": "4.41.0"
     },

--- a/packages/utils/package.json
+++ b/packages/utils/package.json
@@ -17,7 +17,7 @@
     "dependencies": {
         "@colors/colors": "1.6.0",
         "@sentry/node": "9.3.0",
-        "axios": "1.15.2",
+        "axios": "1.16.0",
         "dd-trace": "5.52.0",
         "exponential-backoff": "3.1.1",
         "fast-safe-stringify": "2.1.1",

--- a/packages/webhooks/package.json
+++ b/packages/webhooks/package.json
@@ -18,7 +18,7 @@
         "@nangohq/logs": "file:../logs",
         "@nangohq/utils": "file:../utils",
         "@nangohq/kvstore": "file:../kvstore",
-        "axios": "1.15.2",
+        "axios": "1.16.0",
         "dayjs": "1.11.7",
         "dayjs-plugin-utc": "0.1.2",
         "rate-limiter-flexible": "5.0.3"


### PR DESCRIPTION
## What

Bumps `axios` from **1.15.2** to **1.16.0** in every workspace package that pins it directly (10 packages total), and updates the corresponding `package-lock.json` entries.

## Why

The previously released SDK packages on npm (`@nangohq/node@0.70.1` and `@nangohq/types@0.70.1`) still pin `axios@1.15.0`, which is affected by several GitHub Advisory Database entries against the 1.15.x line:

| Advisory | CVE | Severity | Summary | Fixed in |
|---|---|---|---|---|
| GHSA-q8qp-cvcw-x6jj | CVE-2026-42264 | High | Prototype-pollution gadgets in the HTTP adapter (credential injection, request hijacking, SSRF via `socketPath`, redirect callback execution) | 1.15.2 |
| GHSA-pf86-5x62-jrwf | CVE-2026-42033 | High | JSON response tampering / data exfiltration via prototype pollution | 1.15.1 |
| GHSA-6chq-wfr3-2hj9 | CVE-2026-42035 | High | Header injection via FormData duck typing | 1.15.1 |
| GHSA-pmwg-cvhr-8vh7 | CVE-2026-42043 | High | Incomplete NO_PROXY bypass fix in 1.15.0 (alternate `127.0.0.0/8` loopback addresses) | 1.15.1 |
| GHSA-3w6x-2g7m-8v23 | CVE-2026-42044 | Moderate | JSON tampering via `parseReviver` | 1.15.2 |

Bumping to `1.16.0` lets the next SDK release ship clean so consumers don't need npm `overrides` workarounds.

## Changes

- `packages/{node-client, types, server, shared, cli, jobs, runner, runner-sdk, utils, webhooks}/package.json`: `axios` `1.15.2` → `1.16.0`
- `package-lock.json`: regenerated entries for `node_modules/axios` (new resolved tarball + integrity, follow-redirects requirement bumped to `^1.16.0` to match 1.16.0's peer range) and the matching `version` fields in each workspace package node. `follow-redirects@1.16.0` was already locked, so no transitive churn.

## Testing

- `node -e "JSON.parse(require('fs').readFileSync('package-lock.json','utf8'))"` — lockfile is valid JSON.
- Diff is intentionally surgical: 11 files, 24 insertions / 24 deletions.

Closes #6116

---
<sub>Co-authored-by: nik464 &lt;nikhil18chaudhary@gmail.com&gt;</sub>
