### PR TITLE
fix(server): use regional STS endpoint for aws-iam credentials verification

### DIFF
--- a/packages/server/lib/hooks/connection/providers/aws-iam/credentials-verification.ts
+++ b/packages/server/lib/hooks/connection/providers/aws-iam/credentials-verification.ts
@@ -3,11 +3,30 @@ import crypto from 'crypto';
 import type { AWSAuthHeader, AWSAuthHeaderParams, AWSIAMRequestParams, ErrorResponse, GetCallerIdentityResponse } from './types.js';
 import type { InternalNango as Nango } from '../../credentials-verification-script.js';
 
+/**
+ * Resolve the STS host for a given AWS region.
+ *
+ * The legacy global endpoint `sts.amazonaws.com` only accepts SigV4 signatures
+ * scoped to `us-east-1`, which breaks credential verification for any user who
+ * picks a different region in the Connect UI. Using the regional STS endpoint
+ * keeps the user-entered region in the SigV4 scope and additionally unlocks
+ * AWS GovCloud and China partitions, where `sts.amazonaws.com` is unreachable.
+ *
+ * See: https://docs.aws.amazon.com/IAM/latest/UserGuide/id_credentials_temp_enable-regions.html
+ */
+function getStsHost(region: string): string {
+    if (region.startsWith('cn-')) {
+        return `sts.${region}.amazonaws.com.cn`;
+    }
+    return `sts.${region}.amazonaws.com`;
+}
+
 export default async function execute(nango: Nango) {
     try {
         const { credentials, provider_config_key, connection_config } = nango.getConnection();
 
         const { username, password } = credentials as { username: string; password: string };
+        const region = connection_config['region'] as string;
 
         const requestParams: AWSIAMRequestParams = {
             method: 'GET',
@@ -19,6 +38,7 @@ export default async function execute(nango: Nango) {
             }
         };
 
+        const host = getStsHost(region);
         const queryParams = new URLSearchParams(requestParams.params).toString();
         const { authorizationHeader, date } = getAWSAuthHeader({
             method: requestParams.method,
@@ -27,11 +47,12 @@ export default async function execute(nango: Nango) {
             querystring: queryParams,
             accessKeyId: username,
             secretAccessKey: password,
-            region: connection_config['region']
+            region,
+            host
         });
 
         await nango.proxy<ErrorResponse | GetCallerIdentityResponse>({
-            baseUrlOverride: `https://sts.amazonaws.com`,
+            baseUrlOverride: `https://${host}`,
             endpoint: '/',
             params: requestParams.params,
             headers: {
@@ -46,9 +67,7 @@ export default async function execute(nango: Nango) {
 }
 
 function getAWSAuthHeader(params: AWSAuthHeaderParams): AWSAuthHeader {
-    const { method, service, path, querystring, accessKeyId, secretAccessKey, region } = params;
-
-    const host = 'sts.amazonaws.com';
+    const { method, service, path, querystring, accessKeyId, secretAccessKey, region, host } = params;
 
     const date = new Date().toISOString().replace(/[:-]|\.\d{3}/g, '');
     const payloadHash = crypto.createHash('sha256').update('').digest('hex');

--- a/packages/server/lib/hooks/connection/providers/aws-iam/types.ts
+++ b/packages/server/lib/hooks/connection/providers/aws-iam/types.ts
@@ -37,4 +37,5 @@ export interface AWSAuthHeaderParams {
     accessKeyId: string;
     secretAccessKey: string;
     region: string;
+    host: string;
 }


### PR DESCRIPTION
## What

Fixes `aws-iam` credentials verification when the user picks any region other than `us-east-1` in the Connect UI.

## Root cause

`packages/server/lib/hooks/connection/providers/aws-iam/credentials-verification.ts` calls `sts:GetCallerIdentity` against the **global** STS host (`sts.amazonaws.com`) but signs the SigV4 request with `connection_config.region`. The global endpoint only accepts signatures whose credential scope is `us-east-1`, so any other region produces `SignatureDoesNotMatch`. The verifier's `catch` block swallows the AWS error and rethrows the generic `Invalid AWS credentials or permissions.`, which surfaces in the UI as **"AWS IAM did not validate your credentials"** despite valid keys.

Confirmed in the issue by `aws sts get-caller-identity` succeeding from a CLI in the same region against the regional endpoint, plus manually signing against `sts.amazonaws.com` with non-`us-east-1` scope reproducing the same error.

## Fix

Switched to the **regional STS endpoint** `sts.<region>.amazonaws.com` (Option B in the issue) and kept the user-entered region in the SigV4 scope. Added a small `getStsHost(region)` helper that:

- Returns `sts.<region>.amazonaws.com` for standard commercial regions.
- Returns `sts.<region>.amazonaws.com.cn` for China partitions (`cn-north-1`, `cn-northwest-1`).
- Implicitly works for AWS GovCloud (`us-gov-west-1`, `us-gov-east-1`), where the standard `.amazonaws.com` suffix is correct.

Plumbed `host` through `AWSAuthHeaderParams` so the canonical request, the `Host` header, and the `baseUrlOverride` all line up.

The `providers.yaml` `aws-iam` proxy template still hits the global `iam.amazonaws.com` endpoint signed with `us-east-1` - that is intentionally correct because **IAM** is a genuinely global service, while **STS** is regionalised. These are two different services and the verifier was the only place where they were conflated.

## Changes

- `packages/server/lib/hooks/connection/providers/aws-iam/credentials-verification.ts`: derive host from region, pass it into the signer, use it as `baseUrlOverride`.
- `packages/server/lib/hooks/connection/providers/aws-iam/types.ts`: add `host: string` to `AWSAuthHeaderParams`.

## Testing

- TypeScript: clean compile (no new diagnostics on the touched files).
- Logical regression: SigV4 canonical request now contains `host:sts.<region>.amazonaws.com`, the network call goes to the matching host, and `credentialScope` continues to use the same `<region>`, so the AWS-side scope check passes for the same region the user selected. For `us-east-1` callers nothing observable changes (the regional and global endpoints both accept us-east-1 scope).
- AWS docs reference: https://docs.aws.amazon.com/IAM/latest/UserGuide/id_credentials_temp_enable-regions.html

Closes #6048

---
<sub>Co-authored-by: nik464 &lt;nikhil18chaudhary@gmail.com&gt;</sub>
