### PR TITLE
feat(proxy): add a header allow list to forward proxy headers

### DIFF
--- a/packages/server/lib/controllers/proxy/allProxy.ts
+++ b/packages/server/lib/controllers/proxy/allProxy.ts
@@ -58,6 +58,14 @@ const schemaHeaders = z.object({
     'nango-is-dry-run': z.enum(['true', 'false']).optional()
 });
 
+// Headers from provider responses that Nango needs to explicitly forwards to the client.
+const PROXY_RESPONSE_HEADER_ALLOWLIST = [
+    'content-type',
+    'mcp-session-id', // MCP RFC — https://modelcontextprotocol.io/specification/2025-06-18/basic/transports#session-management
+    'x-request-id',
+    'x-correlation-id'
+];
+
 export const allPublicProxy = asyncWrapper<AllPublicProxy>(async (req, res, next) => {
     const valHeaders = schemaHeaders.safeParse(req.headers);
     if (!valHeaders.success) {
@@ -347,7 +355,6 @@ export function parseHeaders(req: Pick<Request, 'rawHeaders'>) {
 }
 
 export async function handleResponse({ res, responseStream, logCtx }: { res: Response; responseStream: AxiosResponse; logCtx: LogContext }) {
-    const contentType = responseStream.headers['content-type'] || '';
     const contentDisposition = responseStream.headers['content-disposition'] || '';
     const transferEncoding = responseStream.headers['transfer-encoding'] || '';
     const contentEncoding = responseStream.headers['content-encoding'] || '';
@@ -387,8 +394,11 @@ export async function handleResponse({ res, responseStream, logCtx }: { res: Res
             return;
         }
 
-        if (typeof contentType === 'string' && contentType !== '') {
-            res.setHeader('Content-Type', contentType);
+        for (const header of PROXY_RESPONSE_HEADER_ALLOWLIST) {
+            const value = responseStream.headers[header];
+            if (typeof value === 'string' && value !== '') {
+                res.setHeader(header, value);
+            }
         }
 
         try {

--- a/packages/server/lib/controllers/proxy/allProxy.unit.test.ts
+++ b/packages/server/lib/controllers/proxy/allProxy.unit.test.ts
@@ -91,7 +91,12 @@ describe('handleResponse', () => {
         };
     };
 
-    const createMockResponseStream = (data: string, contentType = 'application/json', status = 200): AxiosResponse => {
+    const createMockResponseStream = (
+        data: string,
+        contentType = 'application/json',
+        status = 200,
+        extraHeaders: Record<string, string> = {}
+    ): AxiosResponse => {
         const stream = new Readable();
         stream.push(data);
         stream.push(null);
@@ -99,7 +104,8 @@ describe('handleResponse', () => {
         return {
             status,
             headers: {
-                'content-type': contentType
+                'content-type': contentType,
+                ...extraHeaders
             },
             data: stream
         } as unknown as AxiosResponse;
@@ -155,6 +161,26 @@ describe('handleResponse', () => {
         const sentData = mockRes.getSentData();
         expect(sentData).toBeDefined();
         expect(sentData!.toString()).toBe(nonJsonPayload);
+        expect(mockLogCtx.success).toHaveBeenCalled();
+    });
+
+    it('should forward allowlisted headers (mcp-session-id, x-request-id) and drop others', async () => {
+        const mockRes = createMockResponse();
+        const mockResponseStream = createMockResponseStream('{"ok":true}', 'application/json', 200, {
+            'mcp-session-id': 'session-abc123',
+            'x-request-id': 'req-xyz',
+            'x-ratelimit-limit': '100',
+            'x-ratelimit-remaining': '42'
+        });
+
+        handleResponse({ res: mockRes.res, responseStream: mockResponseStream, logCtx: mockLogCtx });
+        await mockRes.waitForSend();
+
+        expect(mockRes.res.setHeader).toHaveBeenCalledWith('content-type', 'application/json');
+        expect(mockRes.res.setHeader).toHaveBeenCalledWith('mcp-session-id', 'session-abc123');
+        expect(mockRes.res.setHeader).toHaveBeenCalledWith('x-request-id', 'req-xyz');
+        expect(mockRes.res.setHeader).not.toHaveBeenCalledWith('x-ratelimit-limit', expect.anything());
+        expect(mockRes.res.setHeader).not.toHaveBeenCalledWith('x-ratelimit-remaining', expect.anything());
         expect(mockLogCtx.success).toHaveBeenCalled();
     });
 });


### PR DESCRIPTION
## Describe the problem and your solution

- Add a header allow list for forwarding proxy headers. This is useful for Nango MCP providers, as well as providers that pass trace IDs for debugging purposes.

<!-- Issue ticket number and link (if applicable) -->

<!-- Testing instructions (skip if just adding/editing providers) -->

