### PR TITLE
fix(connections): add id as secondary sort key in listConnections

### DIFF
--- a/packages/shared/lib/services/connection.service.ts
+++ b/packages/shared/lib/services/connection.service.ts
@@ -848,6 +848,7 @@ class ConnectionService {
 
                 return subQuery
                     .orderBy('_nango_connections.created_at', 'desc')
+                    .orderBy('_nango_connections.id', 'desc')
                     .limit(limit)
                     .offset(page * limit);
             })
@@ -873,7 +874,8 @@ class ConnectionService {
             .innerJoin('_nango_configs', '_nango_connections.config_id', '_nango_configs.id')
             .leftJoin('end_users', 'end_users.id', '_nango_connections.end_user_id')
             .leftJoin('active_logs_agg', 'active_logs_agg.connection_id', '_nango_connections.id')
-            .orderBy('_nango_connections.created_at', 'desc');
+            .orderBy('_nango_connections.created_at', 'desc')
+            .orderBy('_nango_connections.id', 'desc');
 
         return await query;
     }

--- a/packages/shared/lib/services/connection.service.ts
+++ b/packages/shared/lib/services/connection.service.ts
@@ -847,8 +847,10 @@ class ConnectionService {
                 }
 
                 return subQuery
-                    .orderBy('_nango_connections.created_at', 'desc')
-                    .orderBy('_nango_connections.id', 'desc')
+                    .orderBy([
+                        { column: '_nango_connections.created_at', order: 'desc' },
+                        { column: '_nango_connections.id', order: 'desc' }
+                    ])
                     .limit(limit)
                     .offset(page * limit);
             })
@@ -874,8 +876,10 @@ class ConnectionService {
             .innerJoin('_nango_configs', '_nango_connections.config_id', '_nango_configs.id')
             .leftJoin('end_users', 'end_users.id', '_nango_connections.end_user_id')
             .leftJoin('active_logs_agg', 'active_logs_agg.connection_id', '_nango_connections.id')
-            .orderBy('_nango_connections.created_at', 'desc')
-            .orderBy('_nango_connections.id', 'desc');
+            .orderBy([
+                { column: '_nango_connections.created_at', order: 'desc' },
+                { column: '_nango_connections.id', order: 'desc' }
+            ]);
 
         return await query;
     }


### PR DESCRIPTION
## Problem

The `listConnections` integration test `should paginate` was flaky. When two connections are created back-to-back in a test, they can land on the same `created_at` millisecond timestamp. PostgreSQL returns ties in an arbitrary order, so the expected `[notion, google]` ordering would sometimes come back reversed.

## Solution

Add `id DESC` as a secondary sort key in both `orderBy` clauses in the `listConnections` query. Since `id` is an auto-incrementing integer, it provides a stable tiebreaker that preserves insertion order when timestamps collide.

## Testing

- Identified via CI run: https://github.com/NangoHQ/nango/actions/runs/25800782849/job/75789980867
- Fix is deterministic: `id` is always unique, so ordering is stable regardless of timestamp precision
