### PR TITLE
fix(refresh): persist rotated userCredentials for CUSTOM auth_mode + OAUTH2

### DIFF
--- a/packages/shared/lib/services/connections/credentials/refresh.integration.test.ts
+++ b/packages/shared/lib/services/connections/credentials/refresh.integration.test.ts
@@ -244,6 +244,77 @@ describe('refreshOrTestCredentials', () => {
         expect(refreshed).toStrictEqual(decryptedUpdatedConnection);
     });
 
+    it('should mirror the rotated refresh_token into connection_config.userCredentials for CUSTOM auth_mode + OAUTH2 (regression: github-app-oauth)', async () => {
+        // Regression for the github-app-oauth rotation bug: `getFreshOAuth2Credentials`
+        // reads the refresh_token from `connection_config.userCredentials` when
+        // `provider.auth_mode === 'CUSTOM'` (oauth2.client.ts:112), but
+        // `refreshOrTestCredentials` previously wrote rotated tokens only to
+        // `connection.credentials`. With providers that rotate refresh_tokens on
+        // every refresh (GitHub Apps), the second refresh re-sent the original
+        // refresh_token — already invalidated by rotation — and failed
+        // permanently. The fix mirrors the write into `userCredentials`.
+        const { env, account } = await seedAccountEnvAndUser();
+        const integration = await createConfigSeed(env, 'github-app-oauth', 'github-app-oauth');
+        const originalCreds = {
+            type: 'OAUTH2' as const,
+            access_token: 'original_access',
+            refresh_token: 'original_refresh',
+            expires_at: new Date(Date.now() - 1000),
+            raw: {}
+        };
+        const connection = await createConnectionSeed({
+            env,
+            provider: 'github-app-oauth',
+            rawCredentials: originalCreds,
+            // Mirrors what the github-app-oauth post-connection hook
+            // (packages/server/lib/hooks/connection/providers/github-app-oauth/post-connection.ts)
+            // writes after an initial OAuth: a copy of the OAuth2 credentials
+            // under `userCredentials`. `getFreshOAuth2Credentials` reads
+            // refresh_token from here on every subsequent refresh.
+            connectionConfig: { userCredentials: originalCreds }
+        });
+        const decryptedConnection = encryptionManager.decryptConnection(connection);
+        if (!decryptedConnection) {
+            throw new Error('Failed to decrypt connection');
+        }
+
+        await wait(2);
+        const rotatedCreds = {
+            type: 'OAUTH2' as const,
+            access_token: 'rotated_access',
+            refresh_token: 'rotated_refresh',
+            expires_at: new Date(Date.now() + 60_000),
+            raw: {}
+        };
+        vi.spyOn(connectionService, 'getNewCredentials').mockImplementation(() => {
+            return Promise.resolve({ success: true, error: null, response: rotatedCreds });
+        });
+
+        const res = await refreshOrTestCredentials({
+            account,
+            environment: env,
+            integration,
+            instantRefresh: false,
+            connection: decryptedConnection,
+            onRefreshFailed: vi.fn(),
+            onRefreshSuccess: vi.fn(),
+            logContextGetter: logContextGetter
+        });
+        res.unwrap();
+
+        // The actual regression: persistence to both columns. Fetch the row
+        // back from the DB and verify userCredentials advanced alongside
+        // credentials — pre-fix this assertion would still see
+        // `original_refresh` here.
+        const updatedConnection = await connectionService.getConnectionById(connection.id);
+        const decryptedUpdatedConnection = encryptionManager.decryptConnection(updatedConnection!);
+        if (!decryptedUpdatedConnection) {
+            throw new Error('Failed to decrypt updated connection');
+        }
+        expect((decryptedUpdatedConnection.credentials as typeof rotatedCreds).refresh_token).toBe('rotated_refresh');
+        expect(decryptedUpdatedConnection.connection_config['userCredentials']).toEqual(rotatedCreds);
+    });
+
     it('should refresh if oauth2 and fail (wrong token)', async () => {
         const { env, account } = await seedAccountEnvAndUser();
         const integration = await createConfigSeed(env, 'test', 'airtable');

--- a/packages/shared/lib/services/connections/credentials/refresh.ts
+++ b/packages/shared/lib/services/connections/credentials/refresh.ts
@@ -466,8 +466,26 @@ export async function refreshCredentialsIfNeeded({
             } else if ('app' in newCredentials && newCredentials.app) {
                 connectionToRefresh.credentials = newCredentials.app;
             } else {
-                // Use newCredentials as fallback when neither user nor app are specifically present
+                // Use newCredentials as fallback when neither user nor app are specifically present.
                 connectionToRefresh.credentials = newCredentials;
+                // For CUSTOM auth_mode + OAUTH2 credentials (e.g. github-app-oauth),
+                // `getFreshOAuth2Credentials` reads the refresh_token from
+                // `connection_config.userCredentials` (oauth2.client.ts:112), not
+                // from `connection.credentials`. The post-connection hook seeds
+                // `userCredentials` on the initial OAuth, but every subsequent
+                // refresh updated only `credentials` here — so providers that
+                // rotate refresh_tokens on every refresh (GitHub Apps, ...)
+                // deterministically failed on the second refresh because the
+                // now-invalidated original refresh_token got re-sent. Mirror the
+                // write to keep `userCredentials` in lockstep with `credentials`.
+                // `provider` is typed as RefreshableProvider here, which doesn't
+                // include ProviderCustom (see the `as RefreshableProvider` cast
+                // in `refreshCredentials` and the "TODO: fix this type" comment
+                // on RefreshableProvider in `@nangohq/types`). Widen via Provider
+                // to read auth_mode without that narrowing lie.
+                if ((provider as Provider).auth_mode === 'CUSTOM' && newCredentials.type === 'OAUTH2') {
+                    connectionToRefresh.connection_config['userCredentials'] = newCredentials;
+                }
             }
 
             if (refreshGithubAppJwtToken) {


### PR DESCRIPTION
## What this changes

For `auth_mode: CUSTOM` providers whose refresh returns plain `OAuth2Credentials` (no `user`/`app` wrapper), `refreshCredentialsIfNeeded`'s fallback else-branch now mirrors the write into `connection_config.userCredentials` so the read source (`getFreshOAuth2Credentials` at `oauth2.client.ts:112`) and the write source stay in lockstep.

## Why

Fixes #6136.

Without this, `github-app-oauth` connections deterministically break ~8 hours after the first successful refresh. GitHub rotates the refresh_token on every use and invalidates the previous one; the first refresh writes the rotated tokens to `connection.credentials` but leaves the original refresh_token in `connection_config.userCredentials.refresh_token`. The next refresh re-reads the original from `userCredentials`, GitHub rejects it, and `GET /connection/{id}` returns 500. Affects every user, every refresh after the first.

The bug was introduced by #4341 (the CUSTOM read-from-`userCredentials` path) which didn't add a matching write-back. The fix is the symmetric write.

## How it's tested

Added an integration test (`refresh.integration.test.ts`) that:

1. Seeds a `github-app-oauth` connection with original tokens in both `connection.credentials` and `connection_config.userCredentials` (mirroring the post-connection hook's initial state).
2. Mocks `connectionService.getNewCredentials` to return rotated OAUTH2 tokens.
3. Calls `refreshOrTestCredentials`.
4. Reads the row back from the DB and asserts that **both** `credentials.refresh_token` and `connection_config.userCredentials.refresh_token` advance to the rotated value.

Pre-fix, step 4's second assertion would still see the original refresh_token. There were no existing tests covering the `userCredentials` write path in `refresh.integration.test.ts`.

`npm run ts-build` and `npx eslint` on the changed files pass; no new warnings introduced. Full integration suite needs PG + Redis which I can't run from my contributor environment — happy to address any CI feedback.

## Note on the type cast

`provider.auth_mode === 'CUSTOM'` requires casting `provider` to `Provider` because the parameter is typed `RefreshableProvider`, which (per the `// TODO: fix this type` on its definition in `@nangohq/types`) doesn't include `ProviderCustom` even though `ProviderCustom` reaches this function at runtime (via the `as RefreshableProvider` cast at `refreshCredentials` line 114). The widening cast is the minimal change here; tightening `RefreshableProvider` is a separate cleanup.

## Workaround for affected self-hosters

Until this lands, the user-recovery path is `DELETE /connection/{id}?provider_config_key=<key>` to force a fresh OAuth dance — the post-connection hook seeds `userCredentials` correctly. Documented in #6136.
