### PR TITLE
chore: add env var to control how many old syncs to delete

### DIFF
--- a/packages/server/lib/crons/deleteOldData.ts
+++ b/packages/server/lib/crons/deleteOldData.ts
@@ -34,6 +34,7 @@ const cronMinutes = envs.CRON_DELETE_OLD_DATA_EVERY_MIN;
 
 const limit = envs.CRON_DELETE_OLD_JOBS_LIMIT;
 const deleteJobsOlderThan = envs.CRON_DELETE_OLD_JOBS_MAX_DAYS;
+const deleteSyncsLimit = envs.CRON_DELETE_OLD_SYNCS_LIMIT;
 
 const deleteConnectionSessionOlderThan = envs.CRON_DELETE_OLD_CONNECT_SESSION_MAX_DAYS;
 const deletePrivateKeysOlderThan = envs.CRON_DELETE_OLD_PRIVATE_KEYS_MAX_DAYS;
@@ -132,7 +133,7 @@ export async function exec(): Promise<void> {
             ...opts,
             name: 'sync',
             deleteFn: async () => {
-                const syncs = await getSoftDeletedSyncs({ limit: 2, olderThan: deleteSyncsOlderThan });
+                const syncs = await getSoftDeletedSyncs({ limit: deleteSyncsLimit, olderThan: deleteSyncsOlderThan });
                 if (syncs.isErr()) {
                     throw syncs.error;
                 }

--- a/packages/utils/lib/environment/parse.ts
+++ b/packages/utils/lib/environment/parse.ts
@@ -73,6 +73,7 @@ export const ENVS = z.object({
     CRON_DELETE_OLD_OAUTH_SESSION_MAX_DAYS: z.coerce.number().optional().default(2),
     CRON_DELETE_OLD_INVITATIONS_MAX_DAYS: z.coerce.number().optional().default(2),
     CRON_DELETE_OLD_SYNCS_MAX_DAYS: z.coerce.number().optional().default(1),
+    CRON_DELETE_OLD_SYNCS_LIMIT: z.coerce.number().optional().default(25),
     CRON_DELETE_OLD_CONFIGS_MAX_DAYS: z.coerce.number().optional().default(31),
     CRON_DELETE_OLD_SYNC_CONFIGS_MAX_DAYS: z.coerce.number().optional().default(31),
     CRON_DELETE_OLD_CONNECTIONS_MAX_DAYS: z.coerce.number().optional().default(31),


### PR DESCRIPTION
Adding a separate env var to control how many syncs must be deleted by the deleteOldData cron job. It was originally using the default limit of 1000 but was dropped to 2 when investigating the slowdown of the records db.
Starting with a conservative value of 25 that could be increased to match the desired rate

<!-- Describe the problem and your solution --> 

<!-- Issue ticket number and link (if applicable) -->

<!-- Testing instructions (skip if just adding/editing providers) -->

