### PR TITLE
chore(ci): parallelize unit and integration tests

### DIFF
--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -50,7 +50,7 @@ jobs:
                   fi
 
                   echo "should_skip=$SHOULD_SKIP" >> $GITHUB_OUTPUT
-    tests:
+    tests-unit:
         needs: should-run
         runs-on: blacksmith-4vcpu-ubuntu-2404
         steps:
@@ -74,6 +74,29 @@ jobs:
               if: needs.should-run.outputs.should_skip != 'true'
 
             - run: npm run test:unit -- --exclude packages/cli/
+              if: needs.should-run.outputs.should_skip != 'true'
+
+    tests-integration:
+        needs: should-run
+        runs-on: blacksmith-4vcpu-ubuntu-2404
+        steps:
+            - name: Checkout
+              if: needs.should-run.outputs.should_skip != 'true'
+              uses: actions/checkout@v4
+              with:
+                  fetch-depth: '0'
+
+            - name: Use Node.js
+              if: needs.should-run.outputs.should_skip != 'true'
+              uses: actions/setup-node@v4
+              with:
+                  cache: 'npm'
+                  node-version-file: '.nvmrc'
+
+            - run: npm ci
+              if: needs.should-run.outputs.should_skip != 'true'
+
+            - run: npm run ts-build
               if: needs.should-run.outputs.should_skip != 'true'
 
             - run: npm run test:integration


### PR DESCRIPTION
## Problem

Unit and integration tests ran sequentially in a single `tests` job in `tests.yaml`, stacking their durations.

## Solution

Split the `tests` job into two parallel jobs — `tests-unit` and `tests-integration` — both depending on `should-run`. Each job runs `npm ci` + `npm run ts-build` independently, then its respective test suite.

Fixes [NAN-5525](https://linear.app/nangohq/issue/NAN-5525)

## Results

Measured against the last 6 PR runs before this change:

| | Wall clock |
|---|---|
| Before (sequential avg) | ~433s (7m13s) |
| After (parallel) | ~365s (6m5s) |
| **Saved** | **~68s (~16%)** |

The critical path is now `tests-integration` alone (5m36s); `tests-unit` (1m27s) runs concurrently and no longer adds to wall time.

## Testing

- Both jobs appear as separate required CI checks
- No test coverage is lost — same commands, just split across parallel jobs

> [!IMPORTANT]
> Before merge, branch protection rulesets must be updated: replace the required status check `tests` with `tests-unit` and `tests-integration`.
