### PR TITLE
feat: use ephemeral API keys for remote functions

### DIFF
--- a/packages/database/lib/migrations/20260514120000_customer_keys_system_managed_expiry.cjs
+++ b/packages/database/lib/migrations/20260514120000_customer_keys_system_managed_expiry.cjs
@@ -1,0 +1,29 @@
+exports.config = { transaction: false };
+
+/**
+ * @param {import('knex').Knex} knex
+ */
+exports.up = async function (knex) {
+    await knex.raw(`
+        ALTER TABLE customer_keys
+            ADD COLUMN IF NOT EXISTS expires_at TIMESTAMPTZ,
+            ADD COLUMN IF NOT EXISTS system_managed BOOLEAN NOT NULL DEFAULT FALSE;
+
+        CREATE INDEX IF NOT EXISTS idx_customer_keys_system_managed_expires_at
+            ON customer_keys (system_managed, expires_at)
+            WHERE system_managed = TRUE;
+    `);
+};
+
+/**
+ * @param {import('knex').Knex} knex
+ */
+exports.down = async function (knex) {
+    await knex.raw(`
+        DROP INDEX IF EXISTS idx_customer_keys_system_managed_expires_at;
+
+        ALTER TABLE customer_keys
+            DROP COLUMN IF EXISTS expires_at,
+            DROP COLUMN IF EXISTS system_managed;
+    `);
+};

--- a/packages/server/lib/controllers/functions/deploy/postDeploy.ts
+++ b/packages/server/lib/controllers/functions/deploy/postDeploy.ts
@@ -12,7 +12,7 @@ import { remoteFunctionDeployBodySchema } from '../validation.js';
 
 import type { PostRemoteFunctionDeploy } from '@nangohq/types';
 
-const sandboxApiKeyTimeoutBufferMs = 60 * 1000;
+const sandboxApiKeyTimeoutBufferMs = 5 * 60 * 1000;
 
 export const postRemoteFunctionDeploy = asyncWrapper<PostRemoteFunctionDeploy>(async (req, res) => {
     const emptyQuery = requireEmptyQuery(req);

--- a/packages/server/lib/controllers/functions/deploy/postDeploy.ts
+++ b/packages/server/lib/controllers/functions/deploy/postDeploy.ts
@@ -1,15 +1,18 @@
 import db from '@nangohq/database';
-import { configService, getSyncConfigRaw, secretService } from '@nangohq/shared';
+import { configService, customerKeyService, getSyncConfigRaw } from '@nangohq/shared';
 import { requireEmptyQuery, zodErrorToHTTP } from '@nangohq/utils';
 
+import { remoteFunctionDeployScopes } from '../../../services/remote-function/api-key-scopes.js';
 import { parseDeploySuccessOutput } from '../../../services/remote-function/command-output.js';
 import { invokeDeploy } from '../../../services/remote-function/deploy-client.js';
 import { RemoteFunctionError, sendStepError } from '../../../services/remote-function/helpers.js';
-import { getRemoteFunctionNangoHost } from '../../../services/remote-function/runtime.js';
+import { getRemoteFunctionNangoHost, remoteFunctionDeploySandboxTimeoutMs } from '../../../services/remote-function/runtime.js';
 import { asyncWrapper } from '../../../utils/asyncWrapper.js';
 import { remoteFunctionDeployBodySchema } from '../validation.js';
 
 import type { PostRemoteFunctionDeploy } from '@nangohq/types';
+
+const sandboxApiKeyTimeoutBufferMs = 60 * 1000;
 
 export const postRemoteFunctionDeploy = asyncWrapper<PostRemoteFunctionDeploy>(async (req, res) => {
     const emptyQuery = requireEmptyQuery(req);
@@ -25,7 +28,7 @@ export const postRemoteFunctionDeploy = asyncWrapper<PostRemoteFunctionDeploy>(a
     }
 
     const body = valBody.data;
-    const { environment } = res.locals;
+    const { account, environment } = res.locals;
 
     const providerConfig = await configService.getProviderConfig(body.integration_id, environment.id);
     if (!providerConfig || !providerConfig.id) {
@@ -50,9 +53,15 @@ export const postRemoteFunctionDeploy = asyncWrapper<PostRemoteFunctionDeploy>(a
         return;
     }
 
-    const defaultSecret = await secretService.getInternalSecretForEnv(db.readOnly, environment.id);
-    if (defaultSecret.isErr()) {
-        sendStepError({ res, status: 500, error: defaultSecret.error });
+    const sandboxApiKey = await customerKeyService.createEphemeralApiKey(db.knex, {
+        accountId: account.id,
+        environmentId: environment.id,
+        displayName: 'Remote function deploy',
+        scopes: [...remoteFunctionDeployScopes],
+        expiresAt: new Date(Date.now() + remoteFunctionDeploySandboxTimeoutMs + sandboxApiKeyTimeoutBufferMs)
+    });
+    if (sandboxApiKey.isErr()) {
+        sendStepError({ res, status: 500, error: sandboxApiKey.error });
         return;
     }
 
@@ -63,7 +72,7 @@ export const postRemoteFunctionDeploy = asyncWrapper<PostRemoteFunctionDeploy>(a
             function_type: body.function_type,
             code: body.code,
             environment_name: environment.name,
-            nango_secret_key: defaultSecret.value.secret,
+            nango_secret_key: sandboxApiKey.value.secret,
             nango_host: getRemoteFunctionNangoHost()
         });
         const output = parseDeploySuccessOutput(result.output);
@@ -78,5 +87,7 @@ export const postRemoteFunctionDeploy = asyncWrapper<PostRemoteFunctionDeploy>(a
         });
     } catch (err) {
         sendStepError({ res, error: err, ...(err instanceof RemoteFunctionError ? {} : { status: 500 }) });
+    } finally {
+        await customerKeyService.revokeEphemeralApiKey(db.knex, sandboxApiKey.value.id, environment.id);
     }
 });

--- a/packages/server/lib/controllers/functions/deploy/postDeploy.unit.test.ts
+++ b/packages/server/lib/controllers/functions/deploy/postDeploy.unit.test.ts
@@ -1,0 +1,128 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+
+import { Ok } from '@nangohq/utils';
+
+const mocks = vi.hoisted(() => ({
+    knex: {},
+    getProviderConfig: vi.fn(),
+    getSyncConfigRaw: vi.fn(),
+    createEphemeralApiKey: vi.fn(),
+    revokeEphemeralApiKey: vi.fn(),
+    createSandbox: vi.fn(),
+    sandbox: {
+        files: { write: vi.fn() },
+        commands: { run: vi.fn() },
+        kill: vi.fn()
+    }
+}));
+
+const originalE2BApiKey = process.env['E2B_API_KEY'];
+
+vi.mock('@nangohq/database', () => ({
+    default: { knex: mocks.knex }
+}));
+
+vi.mock('@nangohq/shared', async () => {
+    const z = await import('zod');
+    const connectionTagsKeySchema = z.string();
+    return {
+        TAG_MAX_COUNT: 10,
+        connectionTagsKeySchema,
+        connectionTagsSchema: z.record(connectionTagsKeySchema, z.string()),
+        validateCaseInsensitiveTagKeys: () => [],
+        getApiUrl: () => 'http://localhost:3003',
+        configService: { getProviderConfig: mocks.getProviderConfig },
+        customerKeyService: {
+            createEphemeralApiKey: mocks.createEphemeralApiKey,
+            revokeEphemeralApiKey: mocks.revokeEphemeralApiKey
+        },
+        getSyncConfigRaw: mocks.getSyncConfigRaw
+    };
+});
+
+vi.mock('e2b', () => ({
+    Sandbox: { create: mocks.createSandbox },
+    CommandExitError: class CommandExitError extends Error {},
+    TimeoutError: class TimeoutError extends Error {}
+}));
+
+import { postRemoteFunctionDeploy } from './postDeploy.js';
+
+function createResponse(locals: Record<string, unknown>) {
+    const res = {
+        locals,
+        statusCode: undefined as number | undefined,
+        body: undefined as unknown,
+        status: vi.fn((statusCode: number) => {
+            res.statusCode = statusCode;
+            return res;
+        }),
+        send: vi.fn((body: unknown) => {
+            res.body = body;
+            return res;
+        }),
+        json: vi.fn((body: unknown) => {
+            res.body = body;
+            return res;
+        })
+    };
+    return res;
+}
+
+describe('postRemoteFunctionDeploy', () => {
+    beforeEach(() => {
+        vi.clearAllMocks();
+        process.env['E2B_API_KEY'] = 'test-e2b-api-key';
+        mocks.getProviderConfig.mockResolvedValue({ id: 2 });
+        mocks.getSyncConfigRaw.mockResolvedValue(null);
+        mocks.createEphemeralApiKey.mockResolvedValue(Ok({ id: 3, secret: 'sandbox-secret' }));
+        mocks.revokeEphemeralApiKey.mockResolvedValue(Ok());
+        mocks.createSandbox.mockResolvedValue(mocks.sandbox);
+        mocks.sandbox.files.write.mockResolvedValue(undefined);
+        mocks.sandbox.kill.mockResolvedValue(undefined);
+        mocks.sandbox.commands.run.mockResolvedValue({ stdout: '✓ Deployed\n- syncIssues@1', stderr: '' });
+    });
+
+    afterEach(() => {
+        if (originalE2BApiKey === undefined) {
+            delete process.env['E2B_API_KEY'];
+        } else {
+            process.env['E2B_API_KEY'] = originalE2BApiKey;
+        }
+    });
+
+    it('creates sandbox keys with only the deploy scope', async () => {
+        const req = {
+            query: {},
+            body: {
+                integration_id: 'github',
+                function_name: 'syncIssues',
+                function_type: 'sync',
+                code: 'export default {}'
+            }
+        };
+        const res = createResponse({
+            account: { id: 1 },
+            environment: { id: 2, name: 'dev' },
+            apiKeyScopes: ['environment:*']
+        });
+
+        await postRemoteFunctionDeploy(req as any, res as any, vi.fn());
+
+        expect(mocks.createEphemeralApiKey).toHaveBeenCalledWith(
+            mocks.knex,
+            expect.objectContaining({
+                accountId: 1,
+                environmentId: 2,
+                displayName: 'Remote function deploy',
+                scopes: ['environment:deploy']
+            })
+        );
+        expect(res.statusCode).toBe(200);
+        expect(mocks.sandbox.commands.run).toHaveBeenCalledWith(
+            expect.any(String),
+            expect.objectContaining({ envs: expect.objectContaining({ NANGO_SECRET_KEY: 'sandbox-secret' }) })
+        );
+        expect(mocks.revokeEphemeralApiKey).toHaveBeenCalledWith(mocks.knex, 3, 2);
+    });
+});

--- a/packages/server/lib/controllers/functions/dryrun/postDryrun.ts
+++ b/packages/server/lib/controllers/functions/dryrun/postDryrun.ts
@@ -1,15 +1,18 @@
 import db from '@nangohq/database';
-import { connectionService, secretService } from '@nangohq/shared';
+import { connectionService, customerKeyService } from '@nangohq/shared';
 import { requireEmptyQuery, zodErrorToHTTP } from '@nangohq/utils';
 
+import { buildDryrunSandboxScopes } from '../../../services/remote-function/api-key-scopes.js';
 import { parseDryrunSuccessOutput } from '../../../services/remote-function/command-output.js';
 import { invokeDryrun } from '../../../services/remote-function/dryrun-client.js';
 import { RemoteFunctionError, sendStepError } from '../../../services/remote-function/helpers.js';
-import { getRemoteFunctionNangoHost } from '../../../services/remote-function/runtime.js';
+import { getRemoteFunctionNangoHost, remoteFunctionDryrunSandboxTimeoutMs } from '../../../services/remote-function/runtime.js';
 import { asyncWrapper } from '../../../utils/asyncWrapper.js';
 import { remoteFunctionDryrunBodySchema } from '../validation.js';
 
 import type { PostRemoteFunctionDryrun } from '@nangohq/types';
+
+const sandboxApiKeyTimeoutBufferMs = 60 * 1000;
 
 export const postRemoteFunctionDryrun = asyncWrapper<PostRemoteFunctionDryrun>(async (req, res) => {
     const emptyQuery = requireEmptyQuery(req);
@@ -25,7 +28,7 @@ export const postRemoteFunctionDryrun = asyncWrapper<PostRemoteFunctionDryrun>(a
     }
 
     const body = valBody.data;
-    const { environment } = res.locals;
+    const { account, environment } = res.locals;
 
     const connectionResult = await connectionService.getConnection(body.connection_id, body.integration_id, environment.id);
     if (!connectionResult.success || !connectionResult.response) {
@@ -37,9 +40,15 @@ export const postRemoteFunctionDryrun = asyncWrapper<PostRemoteFunctionDryrun>(a
         return;
     }
 
-    const defaultSecret = await secretService.getInternalSecretForEnv(db.readOnly, environment.id);
-    if (defaultSecret.isErr()) {
-        sendStepError({ res, status: 500, error: defaultSecret.error });
+    const sandboxApiKey = await customerKeyService.createEphemeralApiKey(db.knex, {
+        accountId: account.id,
+        environmentId: environment.id,
+        displayName: 'Remote function dryrun',
+        scopes: buildDryrunSandboxScopes(res.locals['apiKeyScopes']),
+        expiresAt: new Date(Date.now() + remoteFunctionDryrunSandboxTimeoutMs + sandboxApiKeyTimeoutBufferMs)
+    });
+    if (sandboxApiKey.isErr()) {
+        sendStepError({ res, status: 500, error: sandboxApiKey.error });
         return;
     }
 
@@ -53,7 +62,7 @@ export const postRemoteFunctionDryrun = asyncWrapper<PostRemoteFunctionDryrun>(a
             code: body.code,
             environment_name: environment.name,
             connection_id: body.connection_id,
-            nango_secret_key: defaultSecret.value.secret,
+            nango_secret_key: sandboxApiKey.value.secret,
             nango_host: getRemoteFunctionNangoHost(),
             ...(body.input !== undefined ? { input: body.input } : {}),
             ...(body.metadata ? { metadata: body.metadata } : {}),
@@ -74,5 +83,7 @@ export const postRemoteFunctionDryrun = asyncWrapper<PostRemoteFunctionDryrun>(a
         });
     } catch (err) {
         sendStepError({ res, error: err, ...(err instanceof RemoteFunctionError ? {} : { status: 500 }) });
+    } finally {
+        await customerKeyService.revokeEphemeralApiKey(db.knex, sandboxApiKey.value.id, environment.id);
     }
 });

--- a/packages/server/lib/controllers/functions/dryrun/postDryrun.ts
+++ b/packages/server/lib/controllers/functions/dryrun/postDryrun.ts
@@ -12,7 +12,7 @@ import { remoteFunctionDryrunBodySchema } from '../validation.js';
 
 import type { PostRemoteFunctionDryrun } from '@nangohq/types';
 
-const sandboxApiKeyTimeoutBufferMs = 60 * 1000;
+const sandboxApiKeyTimeoutBufferMs = 5 * 60 * 1000;
 
 export const postRemoteFunctionDryrun = asyncWrapper<PostRemoteFunctionDryrun>(async (req, res) => {
     const emptyQuery = requireEmptyQuery(req);

--- a/packages/server/lib/controllers/functions/dryrun/postDryrun.unit.test.ts
+++ b/packages/server/lib/controllers/functions/dryrun/postDryrun.unit.test.ts
@@ -1,0 +1,129 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+
+import { Ok } from '@nangohq/utils';
+
+const mocks = vi.hoisted(() => ({
+    knex: {},
+    getConnection: vi.fn(),
+    createEphemeralApiKey: vi.fn(),
+    revokeEphemeralApiKey: vi.fn(),
+    createSandbox: vi.fn(),
+    sandbox: {
+        files: { write: vi.fn() },
+        commands: { run: vi.fn() },
+        kill: vi.fn()
+    }
+}));
+
+const originalE2BApiKey = process.env['E2B_API_KEY'];
+
+vi.mock('@nangohq/database', () => ({
+    default: { knex: mocks.knex }
+}));
+
+vi.mock('@nangohq/shared', async () => {
+    const z = await import('zod');
+    const connectionTagsKeySchema = z.string();
+    return {
+        TAG_MAX_COUNT: 10,
+        connectionTagsKeySchema,
+        connectionTagsSchema: z.record(connectionTagsKeySchema, z.string()),
+        validateCaseInsensitiveTagKeys: () => [],
+        getApiUrl: () => 'http://localhost:3003',
+        connectionService: { getConnection: mocks.getConnection },
+        customerKeyService: {
+            createEphemeralApiKey: mocks.createEphemeralApiKey,
+            revokeEphemeralApiKey: mocks.revokeEphemeralApiKey
+        }
+    };
+});
+
+vi.mock('e2b', () => ({
+    Sandbox: { create: mocks.createSandbox },
+    CommandExitError: class CommandExitError extends Error {},
+    TimeoutError: class TimeoutError extends Error {}
+}));
+
+import { postRemoteFunctionDryrun } from './postDryrun.js';
+
+function createResponse(locals: Record<string, unknown>) {
+    const res = {
+        locals,
+        statusCode: undefined as number | undefined,
+        body: undefined as unknown,
+        status: vi.fn((statusCode: number) => {
+            res.statusCode = statusCode;
+            return res;
+        }),
+        send: vi.fn((body: unknown) => {
+            res.body = body;
+            return res;
+        }),
+        json: vi.fn((body: unknown) => {
+            res.body = body;
+            return res;
+        })
+    };
+    return res;
+}
+
+describe('postRemoteFunctionDryrun', () => {
+    beforeEach(() => {
+        vi.clearAllMocks();
+        process.env['E2B_API_KEY'] = 'test-e2b-api-key';
+        mocks.getConnection.mockResolvedValue({ success: true, response: { id: 1 } });
+        mocks.createEphemeralApiKey.mockResolvedValue(Ok({ id: 3, secret: 'sandbox-secret' }));
+        mocks.revokeEphemeralApiKey.mockResolvedValue(Ok());
+        mocks.createSandbox.mockResolvedValue(mocks.sandbox);
+        mocks.sandbox.files.write.mockResolvedValue(undefined);
+        mocks.sandbox.kill.mockResolvedValue(undefined);
+        mocks.sandbox.commands.run
+            .mockResolvedValueOnce({ stdout: '', stderr: '' })
+            .mockResolvedValueOnce({ stdout: 'Executing -> integration:"github" script:"syncIssues"\nDone\n{"ok":true}', stderr: '' });
+    });
+
+    afterEach(() => {
+        if (originalE2BApiKey === undefined) {
+            delete process.env['E2B_API_KEY'];
+        } else {
+            process.env['E2B_API_KEY'] = originalE2BApiKey;
+        }
+    });
+
+    it('creates sandbox keys with caller scopes and baseline scopes', async () => {
+        const req = {
+            query: {},
+            body: {
+                integration_id: 'github',
+                function_name: 'syncIssues',
+                function_type: 'sync',
+                code: 'export default {}',
+                connection_id: 'conn-1'
+            }
+        };
+        const res = createResponse({
+            account: { id: 1 },
+            environment: { id: 2, name: 'dev' },
+            apiKeyScopes: ['environment:*', 'environment:proxy']
+        });
+
+        await postRemoteFunctionDryrun(req as any, res as any, vi.fn());
+
+        expect(mocks.createEphemeralApiKey).toHaveBeenCalledWith(
+            mocks.knex,
+            expect.objectContaining({
+                accountId: 1,
+                environmentId: 2,
+                displayName: 'Remote function dryrun',
+                scopes: ['environment:*', 'environment:proxy', 'environment:connections:read', 'environment:integrations:read']
+            })
+        );
+        expect(res.statusCode).toBe(200);
+        expect(mocks.sandbox.commands.run).toHaveBeenNthCalledWith(
+            2,
+            expect.any(String),
+            expect.objectContaining({ envs: expect.objectContaining({ NANGO_SECRET_KEY: 'sandbox-secret' }) })
+        );
+        expect(mocks.revokeEphemeralApiKey).toHaveBeenCalledWith(mocks.knex, 3, 2);
+    });
+});

--- a/packages/server/lib/controllers/functions/remote-function.integration.test.ts
+++ b/packages/server/lib/controllers/functions/remote-function.integration.test.ts
@@ -1,7 +1,9 @@
+import { randomUUID } from 'node:crypto';
+
 import { afterAll, afterEach, beforeAll, describe, expect, it } from 'vitest';
 
 import db from '@nangohq/database';
-import { seeders } from '@nangohq/shared';
+import { customerKeyService, seeders } from '@nangohq/shared';
 
 import { envs } from '../../env.js';
 import { isError, runServer, shouldBeProtected } from '../../utils/tests.js';
@@ -13,6 +15,17 @@ async function seedAccountWithRemoteFunctions() {
     const seed = await seeders.seedAccountEnvAndUser();
     await db.knex('plans').where('id', seed.plan.id).update({ remote_functions: true });
     return seed;
+}
+
+async function createApiKeyWithScopes(seed: Awaited<ReturnType<typeof seedAccountWithRemoteFunctions>>, scopes: string[]) {
+    const key = await customerKeyService.createApiKey(db.knex, {
+        accountId: seed.account.id,
+        environmentId: seed.env.id,
+        displayName: `test-${randomUUID()}`,
+        scopes
+    });
+
+    return key.unwrap();
 }
 
 describe('remote-function public API', () => {
@@ -61,6 +74,55 @@ describe('remote-function public API', () => {
             error: {
                 code: 'forbidden',
                 message: 'Remote functions are not enabled for this account'
+            }
+        });
+    });
+
+    it('rejects POST /remote-function/dryrun without dryrun scope', async () => {
+        const seed = await seedAccountWithRemoteFunctions();
+        const apiKey = await createApiKeyWithScopes(seed, ['environment:connections:read']);
+
+        const res = await api.fetch('/remote-function/dryrun', {
+            method: 'POST',
+            token: apiKey.secret,
+            body: {
+                integration_id: 'github',
+                function_name: 'syncIssues',
+                function_type: 'sync',
+                code: 'export default {}',
+                connection_id: 'missing-connection'
+            }
+        });
+
+        expect(res.res.status).toBe(403);
+        expect(res.json).toStrictEqual({
+            error: {
+                code: 'forbidden',
+                message: 'Insufficient scope. Required: environment:dryrun'
+            }
+        });
+    });
+
+    it('rejects POST /remote-function/deploy without deploy scope', async () => {
+        const seed = await seedAccountWithRemoteFunctions();
+        const apiKey = await createApiKeyWithScopes(seed, ['environment:dryrun']);
+
+        const res = await api.fetch('/remote-function/deploy', {
+            method: 'POST',
+            token: apiKey.secret,
+            body: {
+                integration_id: 'github',
+                function_name: 'syncIssues',
+                function_type: 'sync',
+                code: 'export default {}'
+            }
+        });
+
+        expect(res.res.status).toBe(403);
+        expect(res.json).toStrictEqual({
+            error: {
+                code: 'forbidden',
+                message: 'Insufficient scope. Required: environment:deploy'
             }
         });
     });

--- a/packages/server/lib/controllers/v1/environment/apiKeys.integration.test.ts
+++ b/packages/server/lib/controllers/v1/environment/apiKeys.integration.test.ts
@@ -1,7 +1,7 @@
 import { afterAll, beforeAll, describe, expect, it } from 'vitest';
 
 import db from '@nangohq/database';
-import { seeders } from '@nangohq/shared';
+import { customerKeyService, seeders } from '@nangohq/shared';
 
 import { authenticateUser, isError, isSuccess, runServer, shouldBeProtected } from '../../../utils/tests.js';
 
@@ -45,6 +45,32 @@ describe('API Keys endpoints', () => {
                 secret: expect.any(String),
                 created_at: expect.any(String)
             });
+        });
+
+        it('should not list system managed api keys', async () => {
+            const { account, env, user } = await seeders.seedAccountEnvAndUser();
+            const session = await authenticateUser(api, user);
+            const systemKey = await customerKeyService.createEphemeralApiKey(db.knex, {
+                accountId: account.id,
+                environmentId: env.id,
+                displayName: 'Remote function dryrun',
+                scopes: ['environment:dryrun'],
+                expiresAt: new Date(Date.now() + 60 * 1000)
+            });
+            const key = systemKey.unwrap();
+
+            const res = await api.fetch('/api/v1/environment/api-keys', {
+                method: 'GET',
+                // @ts-expect-error query params are required
+                query: { env: env.name },
+                session
+            });
+
+            expect(res.res.status).toBe(200);
+            isSuccess(res.json);
+            expect(res.json.data).toHaveLength(1);
+            expect(res.json.data.map((apiKey: { id: number }) => apiKey.id)).not.toContain(key.id);
+            expect(res.json.data[0]!.display_name).toBe('Default - Full access');
         });
     });
 

--- a/packages/server/lib/crons/deleteOldData.ts
+++ b/packages/server/lib/crons/deleteOldData.ts
@@ -7,6 +7,7 @@ import { getLocking } from '@nangohq/kvstore';
 import {
     configService,
     connectionService,
+    customerKeyService,
     deleteExpiredInvitations,
     deleteJobsByDate,
     environmentService,
@@ -37,6 +38,7 @@ const deleteJobsOlderThan = envs.CRON_DELETE_OLD_JOBS_MAX_DAYS;
 
 const deleteConnectionSessionOlderThan = envs.CRON_DELETE_OLD_CONNECT_SESSION_MAX_DAYS;
 const deletePrivateKeysOlderThan = envs.CRON_DELETE_OLD_PRIVATE_KEYS_MAX_DAYS;
+const deleteSystemManagedCustomerKeysOlderThan = envs.CRON_DELETE_OLD_SYSTEM_MANAGED_CUSTOMER_KEYS_MAX_DAYS;
 const deleteOauthSessionOlderThan = envs.CRON_DELETE_OLD_OAUTH_SESSION_MAX_DAYS;
 const deleteInvitationsOlderThan = envs.CRON_DELETE_OLD_INVITATIONS_MAX_DAYS;
 const deleteSyncsOlderThan = envs.CRON_DELETE_OLD_SYNCS_MAX_DAYS;
@@ -111,6 +113,14 @@ export async function exec(): Promise<void> {
             ...opts,
             name: 'private keys',
             deleteFn: async () => await deleteExpiredPrivateKeys(db.knex, { olderThan: deletePrivateKeysOlderThan, limit })
+        });
+
+        // Delete system managed API keys after they have been expired for the retention window.
+        await batchDelete({
+            ...opts,
+            name: 'system managed API keys',
+            deleteFn: async () =>
+                await customerKeyService.deleteExpiredSystemManagedApiKeys(db.knex, { olderThan: deleteSystemManagedCustomerKeysOlderThan, limit })
         });
 
         // Delete oauth sessions

--- a/packages/server/lib/routes.public.ts
+++ b/packages/server/lib/routes.public.ts
@@ -280,8 +280,8 @@ publicAPI.route('/connect/telemetry').post(connectSessionAuthBody, postConnectTe
 
 publicAPI.use('/remote-function', jsonContentTypeMiddleware);
 publicAPI.route('/remote-function/compile').post(remoteFunctionAuth, postRemoteFunctionCompile);
-publicAPI.route('/remote-function/dryrun').post(remoteFunctionAuth, postRemoteFunctionDryrun);
-publicAPI.route('/remote-function/deploy').post(remoteFunctionAuth, postRemoteFunctionDeploy);
+publicAPI.route('/remote-function/dryrun').post(remoteFunctionAuth, withScope('environment:dryrun'), postRemoteFunctionDryrun);
+publicAPI.route('/remote-function/deploy').post(remoteFunctionAuth, withScope('environment:deploy'), postRemoteFunctionDeploy);
 
 // V1 passthrough (deprecated) — scope checks are inline in allPublicV1 after action/model resolution
 publicAPI.use('/v1', jsonContentTypeMiddleware);

--- a/packages/server/lib/services/remote-function/api-key-scopes.ts
+++ b/packages/server/lib/services/remote-function/api-key-scopes.ts
@@ -1,0 +1,23 @@
+import type { ApiKeyScope } from '@nangohq/types';
+
+export const remoteFunctionDryrunBaseScopes = [
+    'environment:connections:read',
+    'environment:integrations:read',
+    'environment:proxy'
+] as const satisfies readonly ApiKeyScope[];
+
+export const remoteFunctionDeployScopes = ['environment:deploy'] as const satisfies readonly ApiKeyScope[];
+
+export function buildDryrunSandboxScopes(callerScopes: string[] | undefined): ApiKeyScope[] {
+    const scopes = new Set<string>();
+
+    for (const scope of callerScopes ?? []) {
+        scopes.add(scope);
+    }
+
+    for (const scope of remoteFunctionDryrunBaseScopes) {
+        scopes.add(scope);
+    }
+
+    return Array.from(scopes) as ApiKeyScope[];
+}

--- a/packages/server/lib/services/remote-function/api-key-scopes.unit.test.ts
+++ b/packages/server/lib/services/remote-function/api-key-scopes.unit.test.ts
@@ -31,4 +31,13 @@ describe('remote function API key scopes', () => {
             'environment:proxy'
         ]);
     });
+
+    it('keeps wildcard caller scopes and avoids duplicate baseline scopes', () => {
+        expect(buildDryrunSandboxScopes(['environment:*', 'environment:proxy'])).toStrictEqual([
+            'environment:*',
+            'environment:proxy',
+            'environment:connections:read',
+            'environment:integrations:read'
+        ]);
+    });
 });

--- a/packages/server/lib/services/remote-function/api-key-scopes.unit.test.ts
+++ b/packages/server/lib/services/remote-function/api-key-scopes.unit.test.ts
@@ -1,0 +1,34 @@
+import { describe, expect, it } from 'vitest';
+
+import { buildDryrunSandboxScopes } from './api-key-scopes.js';
+
+describe('remote function API key scopes', () => {
+    it('keeps caller scopes and adds dryrun baseline scopes', () => {
+        expect(buildDryrunSandboxScopes(['environment:dryrun', 'environment:records:read'])).toStrictEqual([
+            'environment:dryrun',
+            'environment:records:read',
+            'environment:connections:read',
+            'environment:integrations:read',
+            'environment:proxy'
+        ]);
+    });
+
+    it('does not duplicate baseline scopes already present on the caller key', () => {
+        expect(buildDryrunSandboxScopes(['environment:dryrun', 'environment:proxy'])).toStrictEqual([
+            'environment:dryrun',
+            'environment:proxy',
+            'environment:connections:read',
+            'environment:integrations:read'
+        ]);
+    });
+
+    it('keeps caller scopes as provided', () => {
+        expect(buildDryrunSandboxScopes(['environment:dryrun', 'environment:connections:*'])).toStrictEqual([
+            'environment:dryrun',
+            'environment:connections:*',
+            'environment:connections:read',
+            'environment:integrations:read',
+            'environment:proxy'
+        ]);
+    });
+});

--- a/packages/shared/lib/services/account.service.integration.test.ts
+++ b/packages/shared/lib/services/account.service.integration.test.ts
@@ -172,7 +172,7 @@ describe('Account service', () => {
         expect(bySecretKey).toBeNull();
     });
 
-    it('should hide system managed API keys from environment API key listing', async () => {
+    it('should retrieve account context with a system managed customer key', async () => {
         const account = await createTestAccount();
         const environment = await environmentService.createEnvironment(db.knex, { accountId: account.id, name: uuid() });
         await plans.createPlan(db.knex, { account_id: account.id, name: 'free' });
@@ -184,12 +184,17 @@ describe('Account service', () => {
             scopes: ['environment:dryrun'],
             expiresAt: new Date(Date.now() + 60 * 1000)
         });
-        systemKey.unwrap();
+        const key = systemKey.unwrap();
 
-        const apiKeys = (await customerKeyService.getApiKeysByEnv(db.knex, environment!.id)).unwrap();
+        const bySecretKey = await accountService.getAccountContext({ secretKey: key.secret });
 
-        expect(apiKeys).toHaveLength(1);
-        expect(apiKeys[0]!.display_name).toBe('Default - Full access');
+        expect(bySecretKey?.account.id).toBe(account.id);
+        expect(bySecretKey?.environment.id).toBe(environment!.id);
+        expect(bySecretKey?.auth).toStrictEqual({
+            source: 'customer_key',
+            scopes: ['environment:dryrun'],
+            apiKeyId: key.id
+        });
     });
 
     it('should debounce customer key last_used_at updates when resolving by secretKey', async () => {

--- a/packages/shared/lib/services/account.service.integration.test.ts
+++ b/packages/shared/lib/services/account.service.integration.test.ts
@@ -156,6 +156,42 @@ describe('Account service', () => {
         expect(bySecretKey).toBeNull();
     });
 
+    it('should return null when customer key is expired', async () => {
+        const account = await createTestAccount();
+        const environment = await environmentService.createEnvironment(db.knex, { accountId: account.id, name: uuid() });
+        await plans.createPlan(db.knex, { account_id: account.id, name: 'free' });
+        const apiKeys = (await customerKeyService.getApiKeysByEnv(db.knex, environment!.id)).unwrap();
+
+        await db
+            .knex('customer_keys')
+            .where({ id: apiKeys[0]!.id })
+            .update({ expires_at: new Date(Date.now() - 60 * 1000) });
+
+        const bySecretKey = await accountService.getAccountContext({ secretKey: apiKeys[0]!.secret });
+
+        expect(bySecretKey).toBeNull();
+    });
+
+    it('should hide system managed API keys from environment API key listing', async () => {
+        const account = await createTestAccount();
+        const environment = await environmentService.createEnvironment(db.knex, { accountId: account.id, name: uuid() });
+        await plans.createPlan(db.knex, { account_id: account.id, name: 'free' });
+
+        const systemKey = await customerKeyService.createEphemeralApiKey(db.knex, {
+            accountId: account.id,
+            environmentId: environment!.id,
+            displayName: 'test ephemeral',
+            scopes: ['environment:dryrun'],
+            expiresAt: new Date(Date.now() + 60 * 1000)
+        });
+        systemKey.unwrap();
+
+        const apiKeys = (await customerKeyService.getApiKeysByEnv(db.knex, environment!.id)).unwrap();
+
+        expect(apiKeys).toHaveLength(1);
+        expect(apiKeys[0]!.display_name).toBe('Default - Full access');
+    });
+
     it('should debounce customer key last_used_at updates when resolving by secretKey', async () => {
         const account = await createTestAccount();
         const environment = await environmentService.createEnvironment(db.knex, { accountId: account.id, name: uuid() });

--- a/packages/shared/lib/services/account.service.ts
+++ b/packages/shared/lib/services/account.service.ts
@@ -396,6 +396,7 @@ class AccountService {
                     WHERE ck.hashed = ?
                       AND ck.key_type = 'api'
                       AND ck.deleted_at IS NULL
+                      AND (ck.expires_at IS NULL OR ck.expires_at > NOW())
                       AND ckr.entity_type = 'environment'
                     LIMIT 1
                 ),

--- a/packages/shared/lib/services/customerKey.service.integration.test.ts
+++ b/packages/shared/lib/services/customerKey.service.integration.test.ts
@@ -1,0 +1,80 @@
+import { v4 as uuid } from 'uuid';
+import { beforeAll, describe, expect, it } from 'vitest';
+
+import db, { multipleMigrations } from '@nangohq/database';
+
+import customerKeyService from './customerKey.service.js';
+import environmentService from './environment.service.js';
+import { createAccount as createTestAccount } from '../seeders/account.seeder.js';
+
+function daysAgo(days: number): Date {
+    return new Date(Date.now() - days * 24 * 60 * 60 * 1000);
+}
+
+describe('Customer key service', () => {
+    beforeAll(async () => {
+        await multipleMigrations();
+    });
+
+    it('should hard delete only system managed API keys expired before the retention window', async () => {
+        const account = await createTestAccount();
+        const environment = await environmentService.createEnvironment(db.knex, { accountId: account.id, name: uuid() });
+        expect(environment).toBeDefined();
+
+        const oldSystemKey = (
+            await customerKeyService.createEphemeralApiKey(db.knex, {
+                accountId: account.id,
+                environmentId: environment!.id,
+                displayName: 'old system key',
+                scopes: ['environment:dryrun'],
+                expiresAt: daysAgo(40)
+            })
+        ).unwrap();
+        const recentSystemKey = (
+            await customerKeyService.createEphemeralApiKey(db.knex, {
+                accountId: account.id,
+                environmentId: environment!.id,
+                displayName: 'recent system key',
+                scopes: ['environment:dryrun'],
+                expiresAt: daysAgo(10)
+            })
+        ).unwrap();
+        const activeSystemKey = (
+            await customerKeyService.createEphemeralApiKey(db.knex, {
+                accountId: account.id,
+                environmentId: environment!.id,
+                displayName: 'active system key',
+                scopes: ['environment:dryrun'],
+                expiresAt: new Date(Date.now() + 60 * 1000)
+            })
+        ).unwrap();
+        const regularKey = (
+            await customerKeyService.createApiKey(db.knex, {
+                accountId: account.id,
+                environmentId: environment!.id,
+                displayName: 'regular key',
+                scopes: ['environment:*']
+            })
+        ).unwrap();
+        await db
+            .knex('customer_keys')
+            .where({ id: regularKey.id })
+            .update({ expires_at: daysAgo(40) });
+
+        const deleted = await customerKeyService.deleteExpiredSystemManagedApiKeys(db.knex, { olderThan: 31, limit: 10 });
+
+        expect(deleted).toBe(1);
+        const remainingRows = await db
+            .knex('customer_keys')
+            .select('id')
+            .whereIn('id', [oldSystemKey.id, recentSystemKey.id, activeSystemKey.id, regularKey.id]);
+        const remainingIds = new Set(remainingRows.map((row) => row.id));
+        expect(remainingIds.has(oldSystemKey.id)).toBe(false);
+        expect(remainingIds.has(recentSystemKey.id)).toBe(true);
+        expect(remainingIds.has(activeSystemKey.id)).toBe(true);
+        expect(remainingIds.has(regularKey.id)).toBe(true);
+
+        const oldRelation = await db.knex('customer_keys_relations').where({ customer_key_id: oldSystemKey.id }).first();
+        expect(oldRelation).toBeUndefined();
+    });
+});

--- a/packages/shared/lib/services/customerKey.service.ts
+++ b/packages/shared/lib/services/customerKey.service.ts
@@ -21,6 +21,64 @@ class CustomerKeyService {
         const lockKey = stringToHash(`customer_key_name:${accountId}:${keyType}`);
         await trx.raw(`SELECT pg_advisory_xact_lock(?) as "lock_customer_key_name_${keyType}"`, [lockKey]);
     }
+
+    private async insertApiKeyForEnvironment(
+        trx: Knex,
+        {
+            accountId,
+            environmentId,
+            displayName,
+            scopes,
+            expiresAt = null,
+            systemManaged = false
+        }: {
+            accountId: number;
+            environmentId: number;
+            displayName: string;
+            scopes: string[];
+            expiresAt?: Date | null;
+            systemManaged?: boolean;
+        }
+    ): Promise<DBCustomerKey> {
+        const plainText = uuid.v4();
+
+        const hashed = await this.hashSecret(plainText);
+        if (hashed.isErr()) {
+            throw hashed.error;
+        }
+
+        const customerKey = {
+            account_id: accountId,
+            key_type: 'api' as const,
+            display_name: displayName,
+            scopes,
+            secret: plainText,
+            iv: '',
+            tag: '',
+            hashed: hashed.value,
+            last_used_at: null,
+            deleted_at: null,
+            expires_at: expiresAt,
+            system_managed: systemManaged
+        } satisfies Partial<DBCustomerKey>;
+
+        const encrypted = encryptionManager.encryptAPISecret(customerKey as Parameters<typeof encryptionManager.encryptAPISecret>[0]) as typeof customerKey;
+
+        const [row] = await trx<DBCustomerKey>(CUSTOMER_KEYS_TABLE).insert(encrypted).returning('*');
+        if (!row) {
+            throw new NangoError('impossible_condition');
+        }
+
+        await trx<DBCustomerKeyRelation>(CUSTOMER_KEYS_RELATIONS_TABLE).insert({
+            customer_key_id: row.id,
+            entity_type: 'environment',
+            entity_id: environmentId
+        });
+
+        row.secret = plainText; // Callers expect unencrypted secret.
+        return row;
+    }
+
     public async createApiKey(
         trx: Knex,
         {
@@ -36,13 +94,6 @@ class CustomerKeyService {
         }
     ): Promise<Result<DBCustomerKey>> {
         try {
-            const plainText = uuid.v4();
-
-            const hashed = await this.hashSecret(plainText);
-            if (hashed.isErr()) {
-                throw hashed.error;
-            }
-
             const created = await trx.transaction(async (innerTrx) => {
                 await this.acquireNameLock(innerTrx, accountId, 'api');
 
@@ -54,6 +105,7 @@ class CustomerKeyService {
                     .where(`${CUSTOMER_KEYS_TABLE}.display_name`, displayName)
                     .where(`${CUSTOMER_KEYS_RELATIONS_TABLE}.entity_type`, 'environment')
                     .where(`${CUSTOMER_KEYS_RELATIONS_TABLE}.entity_id`, environmentId)
+                    .where(`${CUSTOMER_KEYS_TABLE}.system_managed`, false)
                     .whereNull(`${CUSTOMER_KEYS_TABLE}.deleted_at`)
                     .first();
 
@@ -67,6 +119,7 @@ class CustomerKeyService {
                     .where(`${CUSTOMER_KEYS_TABLE}.key_type`, 'api')
                     .where(`${CUSTOMER_KEYS_RELATIONS_TABLE}.entity_type`, 'environment')
                     .where(`${CUSTOMER_KEYS_RELATIONS_TABLE}.entity_id`, environmentId)
+                    .where(`${CUSTOMER_KEYS_TABLE}.system_managed`, false)
                     .whereNull(`${CUSTOMER_KEYS_TABLE}.deleted_at`)
                     .count('* as total')
                     .first();
@@ -74,38 +127,48 @@ class CustomerKeyService {
                     throw new NangoError('resource_capped', { max: MAX_API_KEYS_PER_ENV });
                 }
 
-                const customerKey = {
-                    account_id: accountId,
-                    key_type: 'api' as const,
-                    display_name: displayName,
+                return await this.insertApiKeyForEnvironment(innerTrx, {
+                    accountId,
+                    environmentId,
+                    displayName,
                     scopes,
-                    secret: plainText,
-                    iv: '',
-                    tag: '',
-                    hashed: hashed.value,
-                    last_used_at: null,
-                    deleted_at: null
-                } satisfies Partial<DBCustomerKey>;
-
-                const encrypted = encryptionManager.encryptAPISecret(
-                    customerKey as Parameters<typeof encryptionManager.encryptAPISecret>[0]
-                ) as typeof customerKey;
-
-                const [row] = await innerTrx<DBCustomerKey>(CUSTOMER_KEYS_TABLE).insert(encrypted).returning('*');
-                if (!row) {
-                    throw new NangoError('impossible_condition');
-                }
-
-                await innerTrx<DBCustomerKeyRelation>(CUSTOMER_KEYS_RELATIONS_TABLE).insert({
-                    customer_key_id: row.id,
-                    entity_type: 'environment',
-                    entity_id: environmentId
+                    systemManaged: false
                 });
-
-                return row;
             });
 
-            created.secret = plainText; // Callers expect unencrypted secret.
+            return Ok(created);
+        } catch (err) {
+            return Err(err);
+        }
+    }
+
+    public async createEphemeralApiKey(
+        trx: Knex,
+        {
+            accountId,
+            environmentId,
+            displayName,
+            scopes,
+            expiresAt
+        }: {
+            accountId: number;
+            environmentId: number;
+            displayName: string;
+            scopes: string[];
+            expiresAt: Date;
+        }
+    ): Promise<Result<DBCustomerKey>> {
+        try {
+            const created = await trx.transaction(async (innerTrx) => {
+                return await this.insertApiKeyForEnvironment(innerTrx, {
+                    accountId,
+                    environmentId,
+                    displayName: `${displayName} ${uuid.v4().slice(0, 8)}`,
+                    scopes,
+                    expiresAt,
+                    systemManaged: true
+                });
+            });
             return Ok(created);
         } catch (err) {
             return Err(err);
@@ -140,7 +203,9 @@ class CustomerKeyService {
                 tag: '',
                 hashed: hashed.value,
                 last_used_at: null,
-                deleted_at: null
+                deleted_at: null,
+                expires_at: null,
+                system_managed: false
             } satisfies Partial<DBCustomerKey>;
 
             const encrypted = encryptionManager.encryptAPISecret(customerKey as Parameters<typeof encryptionManager.encryptAPISecret>[0]) as typeof customerKey;
@@ -171,6 +236,7 @@ class CustomerKeyService {
                 .where(`${CUSTOMER_KEYS_RELATIONS_TABLE}.entity_type`, 'environment')
                 .where(`${CUSTOMER_KEYS_RELATIONS_TABLE}.entity_id`, envId)
                 .where(`${CUSTOMER_KEYS_TABLE}.key_type`, 'api')
+                .where(`${CUSTOMER_KEYS_TABLE}.system_managed`, false)
                 .whereNull(`${CUSTOMER_KEYS_TABLE}.deleted_at`)
                 .orderBy(`${CUSTOMER_KEYS_TABLE}.display_name`, 'asc');
 
@@ -224,6 +290,7 @@ class CustomerKeyService {
                     .where(`${CUSTOMER_KEYS_TABLE}.display_name`, displayName)
                     .where(`${CUSTOMER_KEYS_RELATIONS_TABLE}.entity_type`, 'environment')
                     .where(`${CUSTOMER_KEYS_RELATIONS_TABLE}.entity_id`, envId)
+                    .where(`${CUSTOMER_KEYS_TABLE}.system_managed`, false)
                     .whereNull(`${CUSTOMER_KEYS_TABLE}.deleted_at`)
                     .whereNot(`${CUSTOMER_KEYS_TABLE}.id`, keyId)
                     .first();
@@ -235,6 +302,7 @@ class CustomerKeyService {
                 const updated = await innerTrx<DBCustomerKey>(CUSTOMER_KEYS_TABLE)
                     .where(`${CUSTOMER_KEYS_TABLE}.id`, keyId)
                     .where(`${CUSTOMER_KEYS_TABLE}.key_type`, 'api')
+                    .where(`${CUSTOMER_KEYS_TABLE}.system_managed`, false)
                     .whereNull(`${CUSTOMER_KEYS_TABLE}.deleted_at`)
                     .whereExists(function () {
                         void this.select(innerTrx.raw('1'))
@@ -259,6 +327,7 @@ class CustomerKeyService {
             const updated = await trx<DBCustomerKey>(CUSTOMER_KEYS_TABLE)
                 .where(`${CUSTOMER_KEYS_TABLE}.id`, keyId)
                 .where(`${CUSTOMER_KEYS_TABLE}.key_type`, 'api')
+                .where(`${CUSTOMER_KEYS_TABLE}.system_managed`, false)
                 .whereNull(`${CUSTOMER_KEYS_TABLE}.deleted_at`)
                 .whereExists(function () {
                     void this.select(trx.raw('1'))
@@ -282,6 +351,33 @@ class CustomerKeyService {
             const updated = await trx<DBCustomerKey>(CUSTOMER_KEYS_TABLE)
                 .where(`${CUSTOMER_KEYS_TABLE}.id`, keyId)
                 .where(`${CUSTOMER_KEYS_TABLE}.key_type`, 'api')
+                .where(`${CUSTOMER_KEYS_TABLE}.system_managed`, false)
+                .whereNull(`${CUSTOMER_KEYS_TABLE}.deleted_at`)
+                .whereExists(function () {
+                    void this.select(trx.raw('1'))
+                        .from(CUSTOMER_KEYS_RELATIONS_TABLE)
+                        .whereRaw(`${CUSTOMER_KEYS_RELATIONS_TABLE}.customer_key_id = ${CUSTOMER_KEYS_TABLE}.id`)
+                        .whereRaw(`${CUSTOMER_KEYS_RELATIONS_TABLE}.entity_type = ?`, ['environment'])
+                        .whereRaw(`${CUSTOMER_KEYS_RELATIONS_TABLE}.entity_id = ?`, [envId]);
+                })
+                .update({
+                    deleted_at: trx.fn.now() as unknown as Date
+                });
+            if (updated === 0) {
+                return Err(new NangoError('no_such_api_secret', { id: keyId }));
+            }
+            return Ok();
+        } catch (err) {
+            return Err(err);
+        }
+    }
+
+    public async revokeEphemeralApiKey(trx: Knex, keyId: number, envId: number): Promise<Result<void>> {
+        try {
+            const updated = await trx<DBCustomerKey>(CUSTOMER_KEYS_TABLE)
+                .where(`${CUSTOMER_KEYS_TABLE}.id`, keyId)
+                .where(`${CUSTOMER_KEYS_TABLE}.key_type`, 'api')
+                .where(`${CUSTOMER_KEYS_TABLE}.system_managed`, true)
                 .whereNull(`${CUSTOMER_KEYS_TABLE}.deleted_at`)
                 .whereExists(function () {
                     void this.select(trx.raw('1'))

--- a/packages/shared/lib/services/customerKey.service.ts
+++ b/packages/shared/lib/services/customerKey.service.ts
@@ -398,6 +398,24 @@ class CustomerKeyService {
         }
     }
 
+    public async deleteExpiredSystemManagedApiKeys(trx: Knex, { limit, olderThan }: { limit: number; olderThan: number }): Promise<number> {
+        const dateThreshold = new Date();
+        dateThreshold.setDate(dateThreshold.getDate() - olderThan);
+
+        return await trx<DBCustomerKey>(CUSTOMER_KEYS_TABLE)
+            .whereIn('id', function (sub) {
+                void sub
+                    .select('id')
+                    .from<DBCustomerKey>(CUSTOMER_KEYS_TABLE)
+                    .where('key_type', 'api')
+                    .where('system_managed', true)
+                    .whereNotNull('expires_at')
+                    .where('expires_at', '<=', dateThreshold.toISOString())
+                    .limit(limit);
+            })
+            .delete();
+    }
+
     private async hashSecret(plainText: string): Promise<Result<string>> {
         try {
             if (!encryptionManager.shouldEncrypt()) {

--- a/packages/types/lib/api-keys/scopes.ts
+++ b/packages/types/lib/api-keys/scopes.ts
@@ -23,6 +23,8 @@ export const API_KEY_SCOPES = [
     'environment:syncs:*',
     // Deploy
     'environment:deploy',
+    // Dryrun
+    'environment:dryrun',
     // Records
     'environment:records:read',
     'environment:records:write',

--- a/packages/types/lib/environment/db.ts
+++ b/packages/types/lib/environment/db.ts
@@ -93,6 +93,8 @@ export interface DBCustomerKey extends Timestamps {
     hashed: string;
     last_used_at: Date | null;
     deleted_at: Date | null;
+    expires_at: Date | null;
+    system_managed: boolean;
 }
 
 export type CustomerKeyEntityType = 'environment' | 'account';

--- a/packages/utils/lib/api-key-scopes.ts
+++ b/packages/utils/lib/api-key-scopes.ts
@@ -25,6 +25,8 @@ export const apiKeyScopes = [
     'environment:syncs:*',
     // Deploy
     'environment:deploy',
+    // Dryrun
+    'environment:dryrun',
     // Records
     'environment:records:read',
     'environment:records:write',

--- a/packages/utils/lib/environment/parse.ts
+++ b/packages/utils/lib/environment/parse.ts
@@ -70,6 +70,7 @@ export const ENVS = z.object({
     CRON_DELETE_OLD_JOBS_MAX_DAYS: z.coerce.number().optional().default(31),
     CRON_DELETE_OLD_CONNECT_SESSION_MAX_DAYS: z.coerce.number().optional().default(31),
     CRON_DELETE_OLD_PRIVATE_KEYS_MAX_DAYS: z.coerce.number().optional().default(31),
+    CRON_DELETE_OLD_SYSTEM_MANAGED_CUSTOMER_KEYS_MAX_DAYS: z.coerce.number().optional().default(31),
     CRON_DELETE_OLD_OAUTH_SESSION_MAX_DAYS: z.coerce.number().optional().default(2),
     CRON_DELETE_OLD_INVITATIONS_MAX_DAYS: z.coerce.number().optional().default(2),
     CRON_DELETE_OLD_SYNCS_MAX_DAYS: z.coerce.number().optional().default(1),

--- a/packages/webapp/src/pages/Environment/Settings/scope-logic.ts
+++ b/packages/webapp/src/pages/Environment/Settings/scope-logic.ts
@@ -38,6 +38,7 @@ export const SCOPE_GROUPS: ScopeGroup[] = [
         ]
     },
     { group: 'Deploy', items: [{ value: 'environment:deploy', label: 'deploy' }] },
+    { group: 'Dryrun', items: [{ value: 'environment:dryrun', label: 'dryrun' }] },
     {
         group: 'Records',
         items: [

--- a/packages/webapp/src/pages/Environment/Settings/scope-logic.unit.test.ts
+++ b/packages/webapp/src/pages/Environment/Settings/scope-logic.unit.test.ts
@@ -44,7 +44,7 @@ describe('expandScopes', () => {
     it('environment:* expands to all individual scopes', () => {
         const expanded = expandScopes(['environment:*']);
         expect(expanded).toEqual(ALL_INDIVIDUAL_SCOPES);
-        expect(expanded.length).toBe(21);
+        expect(expanded.length).toBe(22);
     });
 
     it('group wildcard expands to group scopes', () => {


### PR DESCRIPTION
<!-- Describe the problem and your solution -->
Remote function deploy and dryrun now use short-lived system-managed API keys instead of the environment default key. Dryrun callers must have `environment:dryrun`, and dryrun sandbox keys receive the caller scopes plus `environment:connections:read`, `environment:integrations:read`, and `environment:proxy`.

<!-- Issue ticket number and link (if applicable) -->
NAN-5445

<!-- Testing instructions (skip if just adding/editing providers) -->
- `npm run test:unit -- packages/server/lib/services/remote-function/api-key-scopes.unit.test.ts packages/server/lib/middleware/scope.middleware.unit.test.ts packages/webapp/src/pages/Environment/Settings/scope-logic.unit.test.ts`
- `npm run test:integration -- packages/shared/lib/services/account.service.integration.test.ts packages/server/lib/controllers/functions/remote-function.integration.test.ts`
- `npm run ts-build`
- `npm run dev:watch` initial compile
