### PR TITLE
perf(records): faster autodelete candidate query

### DIFF
--- a/packages/records/lib/db/migrations/20260514000000_record_counts_last_checked_at.ts
+++ b/packages/records/lib/db/migrations/20260514000000_record_counts_last_checked_at.ts
@@ -1,0 +1,22 @@
+import type { Knex } from 'knex';
+
+const TABLE = 'record_counts';
+
+export const config = { transaction: false };
+
+export async function up(knex: Knex): Promise<void> {
+    await knex.raw(`
+        ALTER TABLE "${TABLE}"
+        ADD COLUMN IF NOT EXISTS autodelete_checked_at timestamptz DEFAULT NULL;
+    `);
+    await knex.raw(`
+        CREATE INDEX CONCURRENTLY IF NOT EXISTS ${TABLE}_autodelete_checked_at_idx
+        ON "${TABLE}" (autodelete_checked_at ASC NULLS FIRST);
+    `);
+    // Drop existing redundant index. The same unique index already exists
+    await knex.raw(`
+        DROP INDEX CONCURRENTLY IF EXISTS ${TABLE}_environment_id_connection_id_model_index;
+    `);
+}
+
+export async function down(): Promise<void> {}

--- a/packages/records/lib/models/records.integration.test.ts
+++ b/packages/records/lib/models/records.integration.test.ts
@@ -1018,7 +1018,8 @@ describe('Records service', () => {
                         model: res1.model,
                         count: 15,
                         size_bytes: expect.any(String),
-                        updated_at: expect.any(Date)
+                        updated_at: expect.any(Date),
+                        autodelete_checked_at: null
                     },
                     {
                         environment_id: res2.environmentId,
@@ -1026,7 +1027,8 @@ describe('Records service', () => {
                         model: res2.model,
                         count: 25,
                         size_bytes: expect.any(String),
-                        updated_at: expect.any(Date)
+                        updated_at: expect.any(Date),
+                        autodelete_checked_at: null
                     },
                     {
                         environment_id: res3.environmentId,
@@ -1034,7 +1036,8 @@ describe('Records service', () => {
                         model: res3.model,
                         count: 35,
                         size_bytes: expect.any(String),
-                        updated_at: expect.any(Date)
+                        updated_at: expect.any(Date),
+                        autodelete_checked_at: null
                     }
                 ])
             );
@@ -1063,7 +1066,8 @@ describe('Records service', () => {
                         model: res1.model,
                         count: 10,
                         size_bytes: expect.any(String),
-                        updated_at: expect.any(Date)
+                        updated_at: expect.any(Date),
+                        autodelete_checked_at: null
                     },
                     {
                         environment_id: res2.environmentId,
@@ -1071,7 +1075,8 @@ describe('Records service', () => {
                         model: res2.model,
                         count: 30,
                         size_bytes: expect.any(String),
-                        updated_at: expect.any(Date)
+                        updated_at: expect.any(Date),
+                        autodelete_checked_at: null
                     }
                 ])
             );
@@ -1708,12 +1713,12 @@ describe('Records service', () => {
             expect(candidate).toBeNull();
         });
 
-        it('should randomly select candidates', async () => {
+        it('should rotate across candidates', async () => {
             const oneDay = 24 * 60 * 60 * 1000;
             const syncId = uuid.v4();
+            const total = 5;
 
-            // Insert multiple stale record counts
-            for (let i = 0; i < 5; i++) {
+            for (let i = 0; i < total; i++) {
                 const connectionId = rnd.number();
                 const environmentId = rnd.number();
                 const model = rnd.string();
@@ -1726,14 +1731,15 @@ describe('Records service', () => {
                     .update({ updated_at: new Date(Date.now() - 2 * oneDay) });
             }
 
+            // Each call should advance to a different candidate; after `total` calls all must have been seen
             const candidates = new Set<string>();
-            for (let i = 0; i < 50; i++) {
+            for (let i = 0; i < total; i++) {
                 const candidate = (await Records.autoDeletingCandidate({ staleAfterMs: oneDay })).unwrap();
                 if (candidate) {
                     candidates.add(`${candidate.environmentId}-${candidate.connectionId}-${candidate.model}`);
                 }
             }
-            expect(candidates.size).toBeGreaterThan(1);
+            expect(candidates.size).toBe(total);
         });
     });
     describe('payload migration', () => {

--- a/packages/records/lib/models/records.ts
+++ b/packages/records/lib/models/records.ts
@@ -1545,7 +1545,7 @@ export async function autoPruningCandidate({ staleAfterMs }: { staleAfterMs: num
 /*
  * autoDeletingCandidate
  * @desc finds a candidate connection/model for auto-deleting
- * by randomly selecting a connection/model that have NOT seen its count updated in the past staleAfterMs milliseconds.
+ * by selecting the least-recently-checked connection/model whose count has not been updated in the past staleAfterMs milliseconds.
  * @param staleAfterMs - milliseconds since last modification to consider a connection as potentially stale
  * @returns a Result containing either:
  * - candidate connection, model and environmentId
@@ -1560,11 +1560,25 @@ export async function autoDeletingCandidate({ staleAfterMs }: { staleAfterMs: nu
 > {
     try {
         const [candidate] = await db
-            .from(RECORD_COUNTS_TABLE)
-            .select<RecordCount[]>('*')
-            .whereRaw(`updated_at < NOW() - INTERVAL '${staleAfterMs} milliseconds'`)
-            .orderByRaw('RANDOM()')
-            .limit(1);
+            .raw<{ rows: { connection_id: number; model: string; environment_id: number }[] }>(
+                `WITH candidate AS (
+                SELECT connection_id, model, environment_id
+                FROM ${RECORD_COUNTS_TABLE}
+                WHERE updated_at < NOW() - ? * INTERVAL '1 millisecond'
+                ORDER BY autodelete_checked_at ASC NULLS FIRST, connection_id ASC
+                LIMIT 1
+                FOR UPDATE SKIP LOCKED
+            )
+            UPDATE ${RECORD_COUNTS_TABLE} rc
+            SET autodelete_checked_at = NOW()
+            FROM candidate
+            WHERE rc.connection_id = candidate.connection_id
+              AND rc.model = candidate.model
+              AND rc.environment_id = candidate.environment_id
+            RETURNING rc.connection_id, rc.model, rc.environment_id`,
+                [staleAfterMs]
+            )
+            .then((r) => r.rows);
 
         if (candidate) {
             return Ok({

--- a/packages/records/lib/types.ts
+++ b/packages/records/lib/types.ts
@@ -74,4 +74,5 @@ export interface RecordCount {
     count: number;
     size_bytes: number;
     updated_at: string;
+    autodelete_checked_at: string | null;
 }


### PR DESCRIPTION
The query to select candidates for records autodeletion is inefficient and require pg to scan the record_counts table.
It is also inefficient because randomly picking a entry can potentially return entries that have already been checked recently. This commit adds a autodelete_checked_at column (with index) to the record_counts table so the query can quickly select the least recently checked entry

<!-- Describe the problem and your solution --> 

<!-- Issue ticket number and link (if applicable) -->

<!-- Testing instructions (skip if just adding/editing providers) -->

