### PR TITLE
fix: cancellableDaemon tick shouldn't be fire and forget

### DIFF
--- a/packages/utils/lib/daemon.ts
+++ b/packages/utils/lib/daemon.ts
@@ -1,27 +1,46 @@
 import { setTimeout } from 'node:timers/promises';
 
-export function cancellableDaemon<T>({ tick, tickIntervalMs }: { tick: () => Promise<T>; tickIntervalMs: number }): {
-    abort: () => Promise<T | void>;
+export function cancellableDaemon({
+    tick,
+    tickIntervalMs,
+    onError = () => {}
+}: {
+    tick: () => Promise<unknown>;
+    tickIntervalMs: number;
+    onError?: (err: unknown) => void;
+}): {
+    abort: () => Promise<void>;
 } {
     const ac = new AbortController();
+
     const loop = async (): Promise<void> => {
-        if (tickIntervalMs <= 0) {
+        if (!Number.isFinite(tickIntervalMs) || tickIntervalMs <= 0) {
             return;
         }
-        while (true) {
-            if (ac.signal.aborted) {
-                return;
+        while (!ac.signal.aborted) {
+            try {
+                await tick();
+            } catch (err) {
+                try {
+                    onError(err);
+                } catch {
+                    // swallow errors from the error handler itself
+                }
             }
-            tick();
-            await setTimeout(tickIntervalMs);
+            try {
+                await setTimeout(tickIntervalMs, undefined, { signal: ac.signal });
+            } catch {
+                // AbortError = normal shutdown
+            }
         }
     };
+
     const done = loop();
 
-    const abort = async () => {
-        ac.abort();
-        return await done;
+    return {
+        abort: async () => {
+            ac.abort();
+            return await done;
+        }
     };
-
-    return { abort };
 }


### PR DESCRIPTION
Improving and fixing issue with cancellableDaemon:
- fix: awaiting tick(). Right now it is fire and forget and could lead to overlapping execution if the tick takes more time than the interval
- improvement: abort the setTimeout, otherwise we must await for the setTimeout and the next loop before the daemon is aborted
- improvement: adding an onError callback with noop by default. Not used yet

<!-- Describe the problem and your solution --> 

<!-- Issue ticket number and link (if applicable) -->

<!-- Testing instructions (skip if just adding/editing providers) -->

