### PR TITLE
docs: explain Nango developer apps vs. your own OAuth app

### DIFF
--- a/docs/guides/auth/auth-guide.mdx
+++ b/docs/guides/auth/auth-guide.mdx
@@ -66,7 +66,7 @@ Once you have the connection ID, fetch credentials whenever you need them:
 
     <Tip>Each API has a dedicated [Nango documentation page](/integrations/overview) with setup notes and gotchas.</Tip>
 
-    <Accordion title="⚠️ OAuth developer apps">
+    <Accordion title="⚠️ OAuth app setup">
       OAuth APIs require an OAuth developer app registered with the provider. Register one on the provider's developer portal, use the `Callback URL` shown in your Nango integration settings, then paste the `Client ID` and `Client Secret` back into Nango. Register any required scopes too.
 
       If this integration will be used in production, complete the optional custom callback URL step below before real users connect. Retrofitting a callback URL later requires updating the provider app and can break new authorization or reconnect flows until the provider and Nango settings match.

--- a/docs/guides/auth/auth-guide.mdx
+++ b/docs/guides/auth/auth-guide.mdx
@@ -385,6 +385,8 @@ Reasons to register your own:
 - **Revocation risk** — most providers don't allow shared credentials. Nango developer apps may be revoked by the provider at any time.
 - **Portability** — only your own developer app lets you export access and refresh tokens and move off Nango without users re-authorizing.
 
+The same tradeoffs apply to shared OAuth apps provided by other auth platforms — register your own OAuth app regardless of which provider you use.
+
 <Tip>
   **Questions, problems, feedback?** Reach out in the [Slack community](https://nango.dev/slack).
 </Tip>

--- a/docs/guides/auth/auth-guide.mdx
+++ b/docs/guides/auth/auth-guide.mdx
@@ -385,7 +385,7 @@ Reasons to register your own:
 - **Revocation risk** — most providers don't allow shared credentials. Nango developer apps may be revoked by the provider at any time.
 - **Portability** — only your own developer app lets you export access and refresh tokens and move off Nango without users re-authorizing.
 
-The same tradeoffs apply to shared OAuth apps provided by other auth platforms — register your own OAuth app regardless of which provider you use.
+The same tradeoffs apply to shared OAuth apps provided by other auth platforms.
 
 <Tip>
   **Questions, problems, feedback?** Reach out in the [Slack community](https://nango.dev/slack).

--- a/docs/guides/auth/auth-guide.mdx
+++ b/docs/guides/auth/auth-guide.mdx
@@ -74,7 +74,7 @@ Once you have the connection ID, fetch credentials whenever you need them:
       For OAuth 2.0 providers, Nango shows **suggested scopes** — auto-discovered and refreshed at least monthly. They're suggestions; you can use any scope the provider supports.
 
       <Note>
-        For popular APIs, Nango ships a built-in shared developer app so you can test connections with zero setup. **Do not use it in production** — it violates most providers' terms of service and is rate-limited and unreliable. Always register your own OAuth app before going live.
+        For popular APIs, Nango ships a built-in shared developer app so you can test connections with zero setup. We strongly recommend registering your own OAuth app before going live — see [Nango developer apps vs. your own OAuth app](#nango-developer-apps-vs-your-own-oauth-app).
       </Note>
     </Accordion>
 

--- a/docs/guides/auth/auth-guide.mdx
+++ b/docs/guides/auth/auth-guide.mdx
@@ -74,7 +74,7 @@ Once you have the connection ID, fetch credentials whenever you need them:
       For OAuth 2.0 providers, Nango shows **suggested scopes** — auto-discovered and refreshed at least monthly. They're suggestions; you can use any scope the provider supports.
 
       <Note>
-        For popular APIs, Nango ships a built-in shared developer app so you can test connections with zero setup. We strongly recommend registering your own OAuth app before going live — see [Nango developer apps vs. your own OAuth app](#nango-developer-apps-vs-your-own-oauth-app).
+        For popular APIs, Nango ships a built-in shared developer app so you can test connections with zero setup. We strongly recommend registering your own OAuth app before going live — see [OAuth developer apps](#oauth-developer-apps) below.
       </Note>
     </Accordion>
 
@@ -372,7 +372,7 @@ Once you have the connection ID, fetch credentials whenever you need them:
   </Step>
 </Steps>
 
-## Nango developer apps vs. your own OAuth app
+## OAuth developer apps
 
 Nango ships built-in shared developer apps for some OAuth 2.0 APIs so you can test connections with zero setup. They work in production too, but we strongly recommend registering your own OAuth app before going live.
 

--- a/docs/guides/auth/auth-guide.mdx
+++ b/docs/guides/auth/auth-guide.mdx
@@ -372,6 +372,19 @@ Once you have the connection ID, fetch credentials whenever you need them:
   </Step>
 </Steps>
 
+## Nango developer apps vs. your own OAuth app
+
+Nango ships built-in shared developer apps for some OAuth 2.0 APIs so you can test connections with zero setup. They work in production too, but we strongly recommend registering your own OAuth app before going live.
+
+Reasons to register your own:
+- **Whitelabel auth** — with Nango's app, users authorize Nango instead of your product.
+- **Scopes** — Nango developer apps have fixed scopes. Your own app supports any scope the provider exposes.
+- **Callback URL** — Nango developer apps use Nango's callback. Your own app supports a [custom callback URL](#custom-oauth-callback-url-optional) on your domain.
+- **Marketplace listings** — provider marketplaces require your own developer app.
+- **Advanced API features** — some provider features are only available to first-party apps.
+- **Revocation risk** — most providers don't allow shared credentials. Nango developer apps may be revoked by the provider at any time.
+- **Portability** — only your own developer app lets you export access and refresh tokens and move off Nango without users re-authorizing.
+
 <Tip>
   **Questions, problems, feedback?** Reach out in the [Slack community](https://nango.dev/slack).
 </Tip>


### PR DESCRIPTION
## Summary
- Adds a new section to the auth guide explaining when to register your own OAuth app instead of using Nango's built-in shared developer apps
- Lists concrete tradeoffs: whitelabel auth, scopes, callback URL, marketplace listings, advanced features, revocation risk, and portability

## Test plan
- [x] `mintlify broken-links` passes
- [ ] Visual review of the new section in the auth guide

🤖 Generated with [Claude Code](https://claude.com/claude-code)