### PR TITLE
feat(server): add search query to function list endpoint

### DIFF
--- a/packages/server/lib/controllers/v1/integrations/providerConfigKey/functions/getFunctions.integration.test.ts
+++ b/packages/server/lib/controllers/v1/integrations/providerConfigKey/functions/getFunctions.integration.test.ts
@@ -346,6 +346,96 @@ describe(`GET ${route}`, () => {
         expect(res.json.data).toHaveLength(0);
     });
 
+    it('should filter by case-insensitive search on name across all function types', async () => {
+        const { env, apiKey } = await seeders.seedAccountEnvAndUser();
+        const integration = await seeders.createConfigSeed(env, 'github', 'github');
+        const connection = await seeders.createConnectionSeed({ env, provider: 'github' });
+
+        await seeders.createSyncSeeds({
+            connectionId: connection.id,
+            environment_id: env.id,
+            nango_config_id: integration.id!,
+            sync_name: 'fetch-issues',
+            type: 'sync'
+        });
+        await seeders.createSyncSeeds({
+            connectionId: connection.id,
+            environment_id: env.id,
+            nango_config_id: integration.id!,
+            sync_name: 'list-users',
+            type: 'sync'
+        });
+        await seeders.createSyncSeeds({
+            connectionId: connection.id,
+            environment_id: env.id,
+            nango_config_id: integration.id!,
+            sync_name: 'create-issue',
+            type: 'action'
+        });
+        await insertOnEventScripts({
+            configId: integration.id!,
+            scripts: [
+                { name: 'issue-listener', event: 'POST_CONNECTION_CREATION' },
+                { name: 'unrelated-listener', event: 'POST_CONNECTION_CREATION' }
+            ]
+        });
+
+        const res = await api.fetch(route, {
+            method: 'GET',
+            query: { env: 'dev', search: 'ISSUE' },
+            params: { providerConfigKey: 'github' },
+            token: apiKey.secret
+        });
+
+        expect(res.res.status).toBe(200);
+        isSuccess(res.json);
+        expect(res.json.pagination.total).toBe(3);
+        const keys = res.json.data.map((f) => `${f.type}:${f.name}`).sort();
+        expect(keys).toStrictEqual(['action:create-issue', 'on-event:issue-listener', 'sync:fetch-issues']);
+    });
+
+    it('should match LIKE wildcards literally in search', async () => {
+        const { env, apiKey } = await seeders.seedAccountEnvAndUser();
+        const integration = await seeders.createConfigSeed(env, 'github', 'github');
+        const connection = await seeders.createConnectionSeed({ env, provider: 'github' });
+
+        await seeders.createSyncSeeds({
+            connectionId: connection.id,
+            environment_id: env.id,
+            nango_config_id: integration.id!,
+            sync_name: 'fetch-issues',
+            type: 'sync'
+        });
+
+        const res = await api.fetch(route, {
+            method: 'GET',
+            query: { env: 'dev', search: '%' },
+            params: { providerConfigKey: 'github' },
+            token: apiKey.secret
+        });
+
+        expect(res.res.status).toBe(200);
+        isSuccess(res.json);
+        expect(res.json.pagination.total).toBe(0);
+        expect(res.json.data).toHaveLength(0);
+    });
+
+    it('should reject empty search after trim', async () => {
+        const { env, apiKey } = await seeders.seedAccountEnvAndUser();
+        await seeders.createConfigSeed(env, 'github', 'github');
+
+        const res = await api.fetch(route, {
+            method: 'GET',
+            query: { env: 'dev', search: '   ' },
+            params: { providerConfigKey: 'github' },
+            token: apiKey.secret
+        });
+
+        isError(res.json);
+        expect(res.res.status).toBe(400);
+        expect(res.json.error.code).toBe('invalid_query_params');
+    });
+
     it('should reject invalid type query', async () => {
         const { env, apiKey } = await seeders.seedAccountEnvAndUser();
         await seeders.createConfigSeed(env, 'github', 'github');

--- a/packages/server/lib/controllers/v1/integrations/providerConfigKey/functions/getFunctions.ts
+++ b/packages/server/lib/controllers/v1/integrations/providerConfigKey/functions/getFunctions.ts
@@ -13,6 +13,7 @@ const querystringValidation = z
     .object({
         env: envSchema,
         type: z.enum(['sync', 'action', 'on-event']).optional(),
+        search: z.string().trim().min(1).max(255).optional(),
         page: z.coerce.number().int().min(0).optional().default(0),
         limit: z.coerce.number().int().min(1).max(100).optional().default(20)
     })
@@ -33,7 +34,7 @@ export const getIntegrationFunctions = asyncWrapper<GetIntegrationFunctions>(asy
 
     const { environment } = res.locals;
     const { providerConfigKey } = valParams.data;
-    const { type, page, limit } = queryStringValues.data;
+    const { type, search, page, limit } = queryStringValues.data;
 
     const integration = await configService.getProviderConfig(providerConfigKey, environment.id);
     if (!integration) {
@@ -45,6 +46,7 @@ export const getIntegrationFunctions = asyncWrapper<GetIntegrationFunctions>(asy
         environmentId: environment.id,
         providerConfigKey,
         type,
+        search,
         limit,
         offset: page * limit
     });

--- a/packages/shared/lib/services/function.service.ts
+++ b/packages/shared/lib/services/function.service.ts
@@ -45,16 +45,18 @@ export async function listFunctions({
     environmentId,
     providerConfigKey,
     type,
+    search,
     limit,
     offset
 }: {
     environmentId: number;
     providerConfigKey: string;
     type: FunctionType | undefined;
+    search: string | undefined;
     limit: number;
     offset: number;
 }): Promise<{ rows: NangoFunctionDeployed[]; total: number }> {
-    const listing = buildListingSubquery({ environmentId, providerConfigKey, type });
+    const listing = buildListingSubquery({ environmentId, providerConfigKey, type, search });
 
     const [pageRows, countRow] = await Promise.all([
         db.knex
@@ -83,18 +85,20 @@ export async function listFunctions({
 function buildListingSubquery({
     environmentId,
     providerConfigKey,
-    type
+    type,
+    search
 }: {
     environmentId: number;
     providerConfigKey: string;
     type: FunctionType | undefined;
+    search: string | undefined;
 }): Knex.Raw {
     const branches: Knex.QueryBuilder[] = [];
     if (type !== 'on-event') {
-        branches.push(buildSyncConfigBranch({ environmentId, providerConfigKey, type }));
+        branches.push(buildSyncConfigBranch({ environmentId, providerConfigKey, type, search }));
     }
     if (type === undefined || type === 'on-event') {
-        branches.push(buildOnEventBranch({ environmentId, providerConfigKey }));
+        branches.push(buildOnEventBranch({ environmentId, providerConfigKey, search }));
     }
     return branches.length === 1 ? db.knex.raw('(?) AS listing', [branches[0]]) : db.knex.raw('(? UNION ALL ?) AS listing', branches);
 }
@@ -102,11 +106,13 @@ function buildListingSubquery({
 function buildSyncConfigBranch({
     environmentId,
     providerConfigKey,
-    type
+    type,
+    search
 }: {
     environmentId: number;
     providerConfigKey: string;
     type: 'sync' | 'action' | undefined;
+    search: string | undefined;
 }): Knex.QueryBuilder {
     // Cast on `source` (sync_config_source enum) is required for UNION ALL with the on-event branch —
     // Postgres only unions matching types.
@@ -139,12 +145,24 @@ function buildSyncConfigBranch({
         query.andWhere('sc.type', type);
     }
 
+    if (search) {
+        query.andWhereILike('sc.sync_name', `%${escapeLikePattern(search)}%`);
+    }
+
     return query;
 }
 
-function buildOnEventBranch({ environmentId, providerConfigKey }: { environmentId: number; providerConfigKey: string }): Knex.QueryBuilder {
+function buildOnEventBranch({
+    environmentId,
+    providerConfigKey,
+    search
+}: {
+    environmentId: number;
+    providerConfigKey: string;
+    search: string | undefined;
+}): Knex.QueryBuilder {
     // `oes.event` is a script_trigger_event enum and must be cast to text for UNION ALL.
-    return db.knex
+    const query = db.knex
         .from({ oes: 'on_event_scripts' })
         .join({ nc: '_nango_configs' }, 'oes.config_id', 'nc.id')
         .where('nc.environment_id', environmentId)
@@ -167,6 +185,17 @@ function buildOnEventBranch({ environmentId, providerConfigKey }: { environmentI
             db.knex.raw(`'repo'::text AS source`),
             db.knex.raw('CAST(oes.event AS text) AS event')
         );
+
+    if (search) {
+        query.andWhereILike('oes.name', `%${escapeLikePattern(search)}%`);
+    }
+
+    return query;
+}
+
+// Escapes the LIKE wildcard meta-characters so user input is matched literally.
+function escapeLikePattern(value: string): string {
+    return value.replace(/[\\%_]/g, (match) => `\\${match}`);
 }
 
 function toNangoFunctionDeployed(row: SyncConfigOrOnEventScriptRow): NangoFunctionDeployed | undefined {

--- a/packages/types/lib/functions/api.ts
+++ b/packages/types/lib/functions/api.ts
@@ -144,6 +144,7 @@ export type GetIntegrationFunctions = Endpoint<{
     Querystring: {
         env: string;
         type?: FunctionType;
+        search?: string;
         page?: number;
         limit?: number;
     };


### PR DESCRIPTION
Adding a `search` query param to filter functions server-side, necessary since it's paginated. Didn't think about it beforehand but I'm using this in upcoming frontend PRs.