### PR TITLE
feat(server): new endpoint to get single function

### DIFF
--- a/packages/server/lib/controllers/v1/integrations/providerConfigKey/functions/getFunction.integration.test.ts
+++ b/packages/server/lib/controllers/v1/integrations/providerConfigKey/functions/getFunction.integration.test.ts
@@ -1,0 +1,248 @@
+import { afterAll, beforeAll, describe, expect, it } from 'vitest';
+
+import db from '@nangohq/database';
+import { seeders } from '@nangohq/shared';
+
+import { isError, isSuccess, runServer, shouldBeProtected, shouldRequireQueryEnv } from '../../../../../utils/tests.js';
+
+import type { DBOnEventScript } from '@nangohq/types';
+
+const route = '/api/v1/integrations/:providerConfigKey/functions/:functionName';
+let api: Awaited<ReturnType<typeof runServer>>;
+
+async function insertOnEventScripts({ configId, scripts }: { configId: number; scripts: { name: string; event: DBOnEventScript['event'] }[] }) {
+    await db.knex('on_event_scripts').insert(
+        scripts.map((script, index) => ({
+            config_id: configId,
+            name: script.name,
+            file_location: `s3://tests/${configId}/${script.name}-${script.event}-${index}.js`,
+            version: '0.0.1',
+            active: true,
+            event: script.event,
+            sdk_version: '0.0.0-yaml'
+        }))
+    );
+}
+
+describe(`GET ${route}`, () => {
+    beforeAll(async () => {
+        api = await runServer();
+    });
+    afterAll(() => {
+        api.server.close();
+    });
+
+    it('should be protected', async () => {
+        const res = await api.fetch(route, {
+            method: 'GET',
+            query: { env: 'dev' },
+            params: { providerConfigKey: 'test', functionName: 'some-fn' }
+        });
+        shouldBeProtected(res);
+    });
+
+    it('should enforce env query params', async () => {
+        const { apiKey } = await seeders.seedAccountEnvAndUser();
+        const res = await api.fetch(
+            route,
+            // @ts-expect-error missing query on purpose
+            { method: 'GET', token: apiKey.secret, params: { providerConfigKey: 'test', functionName: 'some-fn' } }
+        );
+        shouldRequireQueryEnv(res);
+    });
+
+    it('should 404 when integration does not exist', async () => {
+        const { apiKey } = await seeders.seedAccountEnvAndUser();
+        const res = await api.fetch(route, {
+            method: 'GET',
+            query: { env: 'dev' },
+            params: { providerConfigKey: 'missing', functionName: 'some-fn' },
+            token: apiKey.secret
+        });
+
+        isError(res.json);
+        expect(res.res.status).toBe(404);
+        expect(res.json.error.code).toBe('not_found');
+    });
+
+    it('should 404 when function does not exist on the integration', async () => {
+        const { env, apiKey } = await seeders.seedAccountEnvAndUser();
+        await seeders.createConfigSeed(env, 'github', 'github');
+
+        const res = await api.fetch(route, {
+            method: 'GET',
+            query: { env: 'dev' },
+            params: { providerConfigKey: 'github', functionName: 'does-not-exist' },
+            token: apiKey.secret
+        });
+
+        isError(res.json);
+        expect(res.res.status).toBe(404);
+        expect(res.json.error.code).toBe('not_found');
+    });
+
+    it('should return a sync function', async () => {
+        const { env, apiKey } = await seeders.seedAccountEnvAndUser();
+        const integration = await seeders.createConfigSeed(env, 'github', 'github');
+        const connection = await seeders.createConnectionSeed({ env, provider: 'github' });
+
+        await seeders.createSyncSeeds({
+            connectionId: connection.id,
+            environment_id: env.id,
+            nango_config_id: integration.id!,
+            sync_name: 'my-sync',
+            type: 'sync'
+        });
+
+        const res = await api.fetch(route, {
+            method: 'GET',
+            query: { env: 'dev' },
+            params: { providerConfigKey: 'github', functionName: 'my-sync' },
+            token: apiKey.secret
+        });
+
+        expect(res.res.status).toBe(200);
+        isSuccess(res.json);
+        expect(res.json.data.name).toBe('my-sync');
+        expect(res.json.data.type).toBe('sync');
+    });
+
+    it('should return an action function', async () => {
+        const { env, apiKey } = await seeders.seedAccountEnvAndUser();
+        const integration = await seeders.createConfigSeed(env, 'github', 'github');
+        const connection = await seeders.createConnectionSeed({ env, provider: 'github' });
+
+        await seeders.createSyncSeeds({
+            connectionId: connection.id,
+            environment_id: env.id,
+            nango_config_id: integration.id!,
+            sync_name: 'my-action',
+            type: 'action'
+        });
+
+        const res = await api.fetch(route, {
+            method: 'GET',
+            query: { env: 'dev' },
+            params: { providerConfigKey: 'github', functionName: 'my-action' },
+            token: apiKey.secret
+        });
+
+        expect(res.res.status).toBe(200);
+        isSuccess(res.json);
+        expect(res.json.data.name).toBe('my-action');
+        expect(res.json.data.type).toBe('action');
+    });
+
+    it('should return an on-event function', async () => {
+        const { env, apiKey } = await seeders.seedAccountEnvAndUser();
+        const integration = await seeders.createConfigSeed(env, 'github', 'github');
+
+        await insertOnEventScripts({
+            configId: integration.id!,
+            scripts: [{ name: 'my-on-event', event: 'POST_CONNECTION_CREATION' }]
+        });
+
+        const res = await api.fetch(route, {
+            method: 'GET',
+            query: { env: 'dev' },
+            params: { providerConfigKey: 'github', functionName: 'my-on-event' },
+            token: apiKey.secret
+        });
+
+        expect(res.res.status).toBe(200);
+        isSuccess(res.json);
+        expect(res.json.data.name).toBe('my-on-event');
+        expect(res.json.data.type).toBe('on-event');
+        if (res.json.data.type === 'on-event') {
+            expect(res.json.data.event).toBe('post-connection-creation');
+        }
+    });
+
+    it('should disambiguate name collisions across types via ?type=', async () => {
+        const { env, apiKey } = await seeders.seedAccountEnvAndUser();
+        const integration = await seeders.createConfigSeed(env, 'github', 'github');
+        const connection = await seeders.createConnectionSeed({ env, provider: 'github' });
+
+        await seeders.createSyncSeeds({
+            connectionId: connection.id,
+            environment_id: env.id,
+            nango_config_id: integration.id!,
+            sync_name: 'shared-name',
+            type: 'sync'
+        });
+        await insertOnEventScripts({
+            configId: integration.id!,
+            scripts: [{ name: 'shared-name', event: 'POST_CONNECTION_CREATION' }]
+        });
+
+        const withoutType = await api.fetch(route, {
+            method: 'GET',
+            query: { env: 'dev' },
+            params: { providerConfigKey: 'github', functionName: 'shared-name' },
+            token: apiKey.secret
+        });
+        isSuccess(withoutType.json);
+        // First-match by `type ASC` ordering — 'on-event' < 'sync' alphabetically.
+        expect(withoutType.json.data.type).toBe('on-event');
+
+        const onEventTyped = await api.fetch(route, {
+            method: 'GET',
+            query: { env: 'dev', type: 'on-event' },
+            params: { providerConfigKey: 'github', functionName: 'shared-name' },
+            token: apiKey.secret
+        });
+        isSuccess(onEventTyped.json);
+        expect(onEventTyped.json.data.type).toBe('on-event');
+
+        const syncTyped = await api.fetch(route, {
+            method: 'GET',
+            query: { env: 'dev', type: 'sync' },
+            params: { providerConfigKey: 'github', functionName: 'shared-name' },
+            token: apiKey.secret
+        });
+        isSuccess(syncTyped.json);
+        expect(syncTyped.json.data.type).toBe('sync');
+    });
+
+    it('should 404 when type filter eliminates the match', async () => {
+        const { env, apiKey } = await seeders.seedAccountEnvAndUser();
+        const integration = await seeders.createConfigSeed(env, 'github', 'github');
+        const connection = await seeders.createConnectionSeed({ env, provider: 'github' });
+
+        await seeders.createSyncSeeds({
+            connectionId: connection.id,
+            environment_id: env.id,
+            nango_config_id: integration.id!,
+            sync_name: 'my-sync',
+            type: 'sync'
+        });
+
+        const res = await api.fetch(route, {
+            method: 'GET',
+            query: { env: 'dev', type: 'action' },
+            params: { providerConfigKey: 'github', functionName: 'my-sync' },
+            token: apiKey.secret
+        });
+
+        isError(res.json);
+        expect(res.res.status).toBe(404);
+        expect(res.json.error.code).toBe('not_found');
+    });
+
+    it('should reject invalid type query', async () => {
+        const { env, apiKey } = await seeders.seedAccountEnvAndUser();
+        await seeders.createConfigSeed(env, 'github', 'github');
+
+        const res = await api.fetch(route, {
+            method: 'GET',
+            // @ts-expect-error invalid type on purpose
+            query: { env: 'dev', type: 'bogus' },
+            params: { providerConfigKey: 'github', functionName: 'my-sync' },
+            token: apiKey.secret
+        });
+
+        isError(res.json);
+        expect(res.res.status).toBe(400);
+        expect(res.json.error.code).toBe('invalid_query_params');
+    });
+});

--- a/packages/server/lib/controllers/v1/integrations/providerConfigKey/functions/getFunction.ts
+++ b/packages/server/lib/controllers/v1/integrations/providerConfigKey/functions/getFunction.ts
@@ -1,0 +1,61 @@
+import * as z from 'zod';
+
+import { configService, getFunction } from '@nangohq/shared';
+import { zodErrorToHTTP } from '@nangohq/utils';
+
+import { envSchema, providerConfigKeySchema } from '../../../../../helpers/validation.js';
+import { asyncWrapper } from '../../../../../utils/asyncWrapper.js';
+
+import type { GetIntegrationFunction } from '@nangohq/types';
+
+const querystringValidation = z
+    .object({
+        env: envSchema,
+        type: z.enum(['sync', 'action', 'on-event']).optional()
+    })
+    .strict();
+
+const paramsValidation = z
+    .object({
+        providerConfigKey: providerConfigKeySchema,
+        functionName: z.string().min(1).max(255)
+    })
+    .strict();
+
+export const getIntegrationFunction = asyncWrapper<GetIntegrationFunction>(async (req, res) => {
+    const queryStringValues = querystringValidation.safeParse(req.query);
+    if (!queryStringValues.success) {
+        res.status(400).send({ error: { code: 'invalid_query_params', errors: zodErrorToHTTP(queryStringValues.error) } });
+        return;
+    }
+
+    const valParams = paramsValidation.safeParse(req.params);
+    if (!valParams.success) {
+        res.status(400).send({ error: { code: 'invalid_uri_params', errors: zodErrorToHTTP(valParams.error) } });
+        return;
+    }
+
+    const { environment } = res.locals;
+    const { providerConfigKey, functionName } = valParams.data;
+    const { type } = queryStringValues.data;
+
+    const integration = await configService.getProviderConfig(providerConfigKey, environment.id);
+    if (!integration) {
+        res.status(404).send({ error: { code: 'not_found', message: 'Integration does not exist' } });
+        return;
+    }
+
+    const fn = await getFunction({
+        environmentId: environment.id,
+        providerConfigKey,
+        name: functionName,
+        type
+    });
+
+    if (!fn) {
+        res.status(404).send({ error: { code: 'not_found', message: 'Function does not exist' } });
+        return;
+    }
+
+    res.status(200).send({ data: fn });
+});

--- a/packages/server/lib/controllers/v1/integrations/providerConfigKey/functions/getFunction.ts
+++ b/packages/server/lib/controllers/v1/integrations/providerConfigKey/functions/getFunction.ts
@@ -1,7 +1,7 @@
 import * as z from 'zod';
 
 import { configService, getFunction } from '@nangohq/shared';
-import { zodErrorToHTTP } from '@nangohq/utils';
+import { report, zodErrorToHTTP } from '@nangohq/utils';
 
 import { envSchema, providerConfigKeySchema } from '../../../../../helpers/validation.js';
 import { asyncWrapper } from '../../../../../utils/asyncWrapper.js';
@@ -45,17 +45,23 @@ export const getIntegrationFunction = asyncWrapper<GetIntegrationFunction>(async
         return;
     }
 
-    const fn = await getFunction({
+    const fnResult = await getFunction({
         environmentId: environment.id,
         providerConfigKey,
         name: functionName,
         type
     });
 
-    if (!fn) {
+    if (fnResult.isErr()) {
+        report(fnResult.error);
+        res.status(500).send({ error: { code: 'server_error', message: 'Failed to get function' } });
+        return;
+    }
+
+    if (!fnResult.value) {
         res.status(404).send({ error: { code: 'not_found', message: 'Function does not exist' } });
         return;
     }
 
-    res.status(200).send({ data: fn });
+    res.status(200).send({ data: fnResult.value });
 });

--- a/packages/server/lib/routes.private.ts
+++ b/packages/server/lib/routes.private.ts
@@ -63,6 +63,7 @@ import { getIntegrations } from './controllers/v1/integrations/getIntegrations.j
 import { postIntegration } from './controllers/v1/integrations/postIntegration.js';
 import { deleteIntegration } from './controllers/v1/integrations/providerConfigKey/deleteIntegration.js';
 import { getIntegrationFlows } from './controllers/v1/integrations/providerConfigKey/flows/getFlows.js';
+import { getIntegrationFunction } from './controllers/v1/integrations/providerConfigKey/functions/getFunction.js';
 import { getIntegrationFunctions } from './controllers/v1/integrations/providerConfigKey/functions/getFunctions.js';
 import { getIntegration } from './controllers/v1/integrations/providerConfigKey/getIntegration.js';
 import { patchIntegration } from './controllers/v1/integrations/providerConfigKey/patchIntegration.js';
@@ -229,6 +230,11 @@ web.route('/integrations/:providerConfigKey').patch(webAuth, can({ action: 'upda
 web.route('/integrations/:providerConfigKey').delete(webAuth, can({ action: 'delete', resource: 'integration', scopedBy: envScope }), deleteIntegration);
 web.route('/integrations/:providerConfigKey/flows').get(webAuth, getIntegrationFlows);
 web.route('/integrations/:providerConfigKey/functions').get(webAuth, can({ action: 'read', resource: 'flow', scopedBy: envScope }), getIntegrationFunctions);
+web.route('/integrations/:providerConfigKey/functions/:functionName').get(
+    webAuth,
+    can({ action: 'read', resource: 'flow', scopedBy: envScope }),
+    getIntegrationFunction
+);
 
 // Providers
 web.route('/providers').get(webAuth, getProvidersList);

--- a/packages/shared/lib/services/function.service.ts
+++ b/packages/shared/lib/services/function.service.ts
@@ -1,4 +1,5 @@
 import db from '@nangohq/database';
+import { Err, Ok } from '@nangohq/utils';
 
 import type {
     FunctionSource,
@@ -10,6 +11,7 @@ import type {
     NangoSyncFunctionDeployed,
     OnEventType
 } from '@nangohq/types';
+import type { Result } from '@nangohq/utils';
 import type { JSONSchema7 } from 'json-schema';
 import type { Knex } from 'knex';
 
@@ -97,22 +99,26 @@ export async function getFunction({
     providerConfigKey: string;
     name: string;
     type: FunctionType | undefined;
-}): Promise<NangoFunctionDeployed | undefined> {
-    const listing = buildListingSubquery({ environmentId, providerConfigKey, type, search: undefined });
+}): Promise<Result<NangoFunctionDeployed | undefined>> {
+    try {
+        const listing = buildListingSubquery({ environmentId, providerConfigKey, type, search: undefined });
 
-    const row = await db.knex
-        .from(listing)
-        .select<SyncConfigOrOnEventScriptRow[]>('*')
-        .where('name', name)
-        .orderBy([
-            { column: 'type', order: 'asc' },
-            { column: 'name', order: 'asc' },
-            { column: 'event', order: 'asc' },
-            { column: 'id', order: 'asc' }
-        ])
-        .first();
+        const row = await db.knex
+            .from(listing)
+            .select<SyncConfigOrOnEventScriptRow[]>('*')
+            .where('name', name)
+            .orderBy([
+                { column: 'type', order: 'asc' },
+                { column: 'name', order: 'asc' },
+                { column: 'event', order: 'asc' },
+                { column: 'id', order: 'asc' }
+            ])
+            .first();
 
-    return row ? toNangoFunctionDeployed(row) : undefined;
+        return Ok(row ? toNangoFunctionDeployed(row) : undefined);
+    } catch (err) {
+        return Err(new Error('failed_to_get_function', { cause: err }));
+    }
 }
 
 function buildListingSubquery({

--- a/packages/shared/lib/services/function.service.ts
+++ b/packages/shared/lib/services/function.service.ts
@@ -82,6 +82,39 @@ export async function listFunctions({
     return { rows, total };
 }
 
+/**
+ * Fetches a single deployed function by name within a provider config.
+ * If `type` is omitted and multiple types share the same name, the first
+ * match by the listing's stable order is returned.
+ */
+export async function getFunction({
+    environmentId,
+    providerConfigKey,
+    name,
+    type
+}: {
+    environmentId: number;
+    providerConfigKey: string;
+    name: string;
+    type: FunctionType | undefined;
+}): Promise<NangoFunctionDeployed | undefined> {
+    const listing = buildListingSubquery({ environmentId, providerConfigKey, type, search: undefined });
+
+    const row = await db.knex
+        .from(listing)
+        .select<SyncConfigOrOnEventScriptRow[]>('*')
+        .where('name', name)
+        .orderBy([
+            { column: 'type', order: 'asc' },
+            { column: 'name', order: 'asc' },
+            { column: 'event', order: 'asc' },
+            { column: 'id', order: 'asc' }
+        ])
+        .first();
+
+    return row ? toNangoFunctionDeployed(row) : undefined;
+}
+
 function buildListingSubquery({
     environmentId,
     providerConfigKey,

--- a/packages/types/lib/api.endpoints.ts
+++ b/packages/types/lib/api.endpoints.ts
@@ -63,6 +63,7 @@ import type { PatchWebhook } from './environment/api/webhook.js';
 import type { PostEnvironmentVariables } from './environment/variable/api.js';
 import type { PatchFlowDisable, PatchFlowEnable, PatchFlowFrequency, PostPreBuiltDeploy, PutUpgradePreBuiltFlow } from './flow/http.api.js';
 import type {
+    GetIntegrationFunction,
     GetIntegrationFunctions,
     GetProviderTemplates,
     PostRemoteFunctionCompile,
@@ -179,6 +180,7 @@ export type PrivateApiEndpoints =
     | SearchFilters
     | PostInternalConnectSessions
     | GetIntegrationFlows
+    | GetIntegrationFunction
     | GetIntegrationFunctions
     | GetProviderTemplates
     | DeleteIntegration

--- a/packages/types/lib/functions/api.ts
+++ b/packages/types/lib/functions/api.ts
@@ -155,6 +155,14 @@ export type GetIntegrationFunctions = Endpoint<{
     };
 }>;
 
+export type GetIntegrationFunction = Endpoint<{
+    Method: 'GET';
+    Path: '/api/v1/integrations/:providerConfigKey/functions/:functionName';
+    Querystring: { env: string; type?: FunctionType };
+    Params: { providerConfigKey: string; functionName: string };
+    Success: { data: NangoFunctionDeployed };
+}>;
+
 export type GetProviderTemplates = Endpoint<{
     Method: 'GET';
     Path: '/api/v1/providers/:providerConfigKey/templates';


### PR DESCRIPTION
I've made an endpoint to list functions, but not one to retrieve a single one. This didn't exist previously, and the frontend uses `/flows`, which returns a list, including catalog functions, even for the single function page (which is pretty bad). This will help with improving that situation.

All private for now. Will eventually look back at these interfaces and make them public if we think they're solid.