### PR TITLE
perf(records): use cursor in records delete functions loop avoid dead tuple traversal

### DIFF
--- a/packages/records/lib/models/records.ts
+++ b/packages/records/lib/models/records.ts
@@ -1135,8 +1135,9 @@ export async function deleteRecords({
                 if (lastDeletedRecord) {
                     lastCursor = Cursor.new({ id: lastDeletedRecord.id, last_modified_at: lastDeletedRecord.updated_at });
                     // Soft delete sets updated_at = now, so RETURNING gives the new value.
-                    // Using it as a cursor would place us past all remaining records
-                    if (mode !== 'soft') {
+                    // Using it as a cursor would place us past all remaining records.
+                    // dryRun doesn't modify updated_at, so cursor advancement is safe there.
+                    if (mode !== 'soft' || dryRun) {
                         from = { updated_at: lastDeletedRecord.updated_at, id: lastDeletedRecord.id };
                     }
                 }

--- a/packages/records/lib/models/records.ts
+++ b/packages/records/lib/models/records.ts
@@ -1208,6 +1208,10 @@ export async function deleteOutdatedRecords({
     try {
         const deletedIds: string[] = [];
         let hasMore = true;
+        // Cursor as id: each batch starts right after the last processed record so the
+        // index scan doesn't re-traverse dead tuples from prior batches
+        // updated_at can't be used as cursor here since the soft delete sets it to now.
+        let lastId: string | null = null;
         // NOTE: deletion is intentionally not atomic. Each batch is its own transaction so that
         // long-running deletes (e.g. millions of records) don't hold a single DB connection and
         // row locks for the entire duration, which was causing timeouts and stalling other queries.
@@ -1244,6 +1248,8 @@ export async function deleteOutdatedRecords({
                                       AND r.model = :model
                                       AND r.deleted_at IS NULL
                                       AND seen.id IS NULL
+                                      AND (:lastId::text IS NULL OR r.id > :lastId)
+                                    ORDER BY r.id
                                     LIMIT :batchSize
                                 )
                                 UPDATE ${RECORDS_TABLE} r
@@ -1262,7 +1268,7 @@ export async function deleteOutdatedRecords({
                                   r.external_id,
                                   COALESCE(pg_column_size(r.json), 0) as legacy_size_bytes,
                                   r.tableoid::regclass as partition`,
-                                { connectionId, model, generation, batchSize }
+                                { connectionId, model, generation, batchSize, lastId }
                             )
                         ).rows;
 
@@ -1310,6 +1316,8 @@ export async function deleteOutdatedRecords({
             if (batchResult.length < batchSize) {
                 hasMore = false;
             }
+
+            lastId = batchResult[batchResult.length - 1]?.id ?? lastId;
 
             if (!partition && batchResult[0]?.partition) {
                 partition = batchResult[0].partition;

--- a/packages/records/lib/models/records.ts
+++ b/packages/records/lib/models/records.ts
@@ -1027,6 +1027,10 @@ export async function deleteRecords({
                 await acquireAdvisoryLock(trx, { name: 'lock_records_delete', connectionId, model });
             }
 
+            // Each batch starts right after the last processed record
+            // so the index scan doesn't re-traverse dead tuples from prior batches
+            let from: { updated_at: string; id: string } | null = null;
+
             do {
                 const toDelete = limit ? Math.min(batchSize, limit - totalRecords) : batchSize;
                 if (toDelete <= 0) {
@@ -1043,6 +1047,9 @@ export async function deleteRecords({
                             { column: 'id', order: 'asc' }
                         ])
                         .limit(toDelete);
+                    if (from) {
+                        subQuery.whereRaw('(updated_at, id) > (?, ?)', [from.updated_at, from.id]);
+                    }
                     if (decodedCursor) {
                         // Delete records up to and including the cursor position
                         subQuery.whereRaw('(updated_at, id) <= (?, ?)', [decodedCursor.sort, decodedCursor.id]);
@@ -1127,6 +1134,11 @@ export async function deleteRecords({
                 const lastDeletedRecord = res[res.length - 1];
                 if (lastDeletedRecord) {
                     lastCursor = Cursor.new({ id: lastDeletedRecord.id, last_modified_at: lastDeletedRecord.updated_at });
+                    // Soft delete sets updated_at = now, so RETURNING gives the new value.
+                    // Using it as a cursor would place us past all remaining records
+                    if (mode !== 'soft') {
+                        from = { updated_at: lastDeletedRecord.updated_at, id: lastDeletedRecord.id };
+                    }
                 }
 
                 if (paginatedRecords < toDelete) {


### PR DESCRIPTION
Example: When batch delete rows, they become dead tuples. The heap rows and their index entries still physically exist until VACUUM though

When batch 2 runs the subquery to get the ids to delete, the index scan starts from the beginning, hits the dead tuple index entries, checks MVCC visibility on each one, then finally reaches the live records. 
Each subsequent batch pays an ever-increasing cost in dead tuple traversal of O(n²) total index work for n records.
