### PR TITLE
docs: surface API setup guides and reorder Slack tip in auth guide

### DIFF
--- a/docs/guides/auth/auth-guide.mdx
+++ b/docs/guides/auth/auth-guide.mdx
@@ -378,9 +378,9 @@ Once you have the connection ID, fetch credentials whenever you need them:
 
 ## OAuth developer apps
 
-Nango ships built-in shared developer apps for some OAuth 2.0 APIs so you can test connections with zero setup. They work in production too, but we strongly recommend registering your own OAuth app before going live.
+Nango ships built-in shared developer apps for some OAuth 2.0 APIs so you can test connections with zero setup.
 
-Many OAuth APIs have step-by-step setup guides in [APIs & Integrations](/integrations/overview) covering OAuth app registration and provider approval — for example, [Gmail setup](/api-integrations/google-mail/how-to-register-your-own-gmail-api-oauth-app).
+They work in production too, but we strongly recommend registering your own before going live. Most OAuth APIs have a step-by-step setup guide in [APIs & Integrations](/integrations/overview) — for example, [Gmail](/api-integrations/google-mail/how-to-register-your-own-gmail-api-oauth-app).
 
 Reasons to register your own:
 - **Whitelabel auth** — with Nango's app, users authorize Nango instead of your product.

--- a/docs/guides/auth/auth-guide.mdx
+++ b/docs/guides/auth/auth-guide.mdx
@@ -372,9 +372,15 @@ Once you have the connection ID, fetch credentials whenever you need them:
   </Step>
 </Steps>
 
+<Tip>
+  **Questions, problems, feedback?** Reach out in the [Slack community](https://nango.dev/slack).
+</Tip>
+
 ## OAuth developer apps
 
 Nango ships built-in shared developer apps for some OAuth 2.0 APIs so you can test connections with zero setup. They work in production too, but we strongly recommend registering your own OAuth app before going live.
+
+Many OAuth APIs have step-by-step setup guides in [APIs & Integrations](/integrations/overview) covering OAuth app registration and provider approval — for example, [Gmail setup](/api-integrations/google-mail/how-to-register-your-own-gmail-api-oauth-app).
 
 Reasons to register your own:
 - **Whitelabel auth** — with Nango's app, users authorize Nango instead of your product.
@@ -386,10 +392,6 @@ Reasons to register your own:
 - **Portability** — only your own developer app lets you export access and refresh tokens and move off Nango without users re-authorizing.
 
 The same tradeoffs apply to shared OAuth apps provided by other auth platforms.
-
-<Tip>
-  **Questions, problems, feedback?** Reach out in the [Slack community](https://nango.dev/slack).
-</Tip>
 
 ## Related guides
 


### PR DESCRIPTION
## Summary
- Moves the Slack community tip above the OAuth developer apps section so it sits right under the guide steps
- Adds a sentence under OAuth developer apps pointing readers to the per-API setup guides in API & Integrations, using Gmail as an example link

## Test plan
- [x] `mintlify broken-links` passes
- [ ] Visual review of the new copy placement

🤖 Generated with [Claude Code](https://claude.com/claude-code)