### PR TITLE
fix(integrations): correct Simpro brand casing (was simPRO)

### DIFF
--- a/docs/api-integrations/simpro.mdx
+++ b/docs/api-integrations/simpro.mdx
@@ -1,22 +1,22 @@
 ---
-title: 'simPRO'
-sidebarTitle: 'simPRO'
-description: 'Integrate your application with the simPRO API'
+title: 'Simpro'
+sidebarTitle: 'Simpro'
+description: 'Integrate your application with the Simpro API'
 ---
 
 ## 🚀 Quickstart
 
-Connect to simPRO with Nango and see data flow in 2 minutes.
+Connect to Simpro with Nango and see data flow in 2 minutes.
 
 <Steps>
     <Step title="Create the integration">
-    In Nango ([free signup](https://app.nango.dev)), go to [Integrations](https://app.nango.dev/dev/integrations) -> _Configure New Integration_ -> _simPRO_.
+    In Nango ([free signup](https://app.nango.dev)), go to [Integrations](https://app.nango.dev/dev/integrations) -> _Configure New Integration_ -> _Simpro_.
     </Step>
-    <Step title="Authorize simPRO">
-    Go to [Connections](https://app.nango.dev/dev/connections) -> _Add Test Connection_ -> _Authorize_, enter your simPRO build name (the subdomain part of your simPRO URL — e.g. `<your-build-name>` for `<your-build-name>.simprosuite.com`), then log in. Later, you'll let your users do the same directly from your app.
+    <Step title="Authorize Simpro">
+    Go to [Connections](https://app.nango.dev/dev/connections) -> _Add Test Connection_ -> _Authorize_, enter your Simpro build name (the subdomain part of your Simpro URL — e.g. `<your-build-name>` for `<your-build-name>.simprosuite.com`), then log in. Later, you'll let your users do the same directly from your app.
     </Step>
-    <Step title="Call the simPRO API">
-    Let's make your first request to the simPRO API. Replace the placeholders below with your [secret key](https://app.nango.dev/dev/environment-settings), [integration ID](https://app.nango.dev/dev/integrations), and [connection ID](https://app.nango.dev/dev/connections):
+    <Step title="Call the Simpro API">
+    Let's make your first request to the Simpro API. Replace the placeholders below with your [secret key](https://app.nango.dev/dev/environment-settings), [integration ID](https://app.nango.dev/dev/integrations), and [connection ID](https://app.nango.dev/dev/connections):
     <Tabs>
         <Tab title="cURL">
 
@@ -61,16 +61,16 @@ Connect to simPRO with Nango and see data flow in 2 minutes.
     </Step>
 </Steps>
 
-## 📚 simPRO Integration Guides
+## 📚 Simpro Integration Guides
 
 Nango maintained guides for common use cases.
 
-- [How to register your own simPRO API OAuth app](/api-integrations/simpro/how-to-register-your-own-simpro-api-oauth-app)
-Register an OAuth app inside your simPRO build (or request central partner credentials from the Simpro Group partner team) and obtain credentials to connect it to Nango.
+- [How to register your own Simpro API OAuth app](/api-integrations/simpro/how-to-register-your-own-simpro-api-oauth-app)
+Register an OAuth app inside your Simpro build (or request central partner credentials from the Simpro Group partner team) and obtain credentials to connect it to Nango.
 
-Official docs: [simPRO API docs](https://developer.simprogroup.com/apidoc/)
+Official docs: [Simpro API docs](https://developer.simprogroup.com/apidoc/)
 
-## 🧩 Pre-built syncs & actions for simPRO
+## 🧩 Pre-built syncs & actions for Simpro
 
 Enable them in your dashboard. Extend and customize to fit your needs.
 

--- a/docs/api-integrations/simpro/connect.mdx
+++ b/docs/api-integrations/simpro/connect.mdx
@@ -1,39 +1,39 @@
 ---
-title: simPRO - How do I link my account?
-sidebarTitle: simPRO
+title: Simpro - How do I link my account?
+sidebarTitle: Simpro
 ---
 
 # Overview
 
-To authenticate with simPRO, you will need:
-1. **simPRO Build Name** - The subdomain part of your simPRO URL (e.g. `<your-build-name>` for `<your-build-name>.simprosuite.com`).
+To authenticate with Simpro, you will need:
+1. **Simpro Build Name** - The subdomain part of your Simpro URL (e.g. `<your-build-name>` for `<your-build-name>.simprosuite.com`).
 
-This guide will walk you through finding your **simPRO Build Name** so you can complete the OAuth connection.
+This guide will walk you through finding your **Simpro Build Name** so you can complete the OAuth connection.
 
 ### Prerequisites:
 
-- You must have access to a simPRO Premium build.
+- You must have access to a Simpro Premium build.
 - You must have administrator access if you are connecting your own build via a single-tenant OAuth application. (Multi-tenant partner OAuth apps do not require admin access on each customer build.)
 
 ### Instructions:
 
-#### Step 1: Find your simPRO Build Name
+#### Step 1: Find your Simpro Build Name
 
-1. Log in to your simPRO Premium build in a web browser.
+1. Log in to your Simpro Premium build in a web browser.
 2. Look at the URL in your browser's address bar. It will be in the form:
    - `https://<your-build-name>.simprosuite.com/...`
-3. Your **simPRO Build Name** is the subdomain — everything before `.simprosuite.com`.
+3. Your **Simpro Build Name** is the subdomain — everything before `.simprosuite.com`.
    - Example: for the URL `https://acme.simprosuite.com/jobs`, the Build Name is `acme`.
 4. Enter this value (without `https://` and without `.simprosuite.com`) when prompted.
 
-<Tip>If you manage multiple simPRO builds, each build has its own subdomain and requires a separate connection.</Tip>
+<Tip>If you manage multiple Simpro builds, each build has its own subdomain and requires a separate connection.</Tip>
 
 #### Step 2: Enter credentials in the Connect UI
 
-Once you have your **simPRO Build Name**:
+Once you have your **Simpro Build Name**:
 
-1. Open the form where you need to authenticate with simPRO.
-2. Enter your **simPRO Build Name**.
-3. Click **Authorize** and sign in to simPRO to complete the OAuth flow.
+1. Open the form where you need to authenticate with Simpro.
+2. Enter your **Simpro Build Name**.
+3. Click **Authorize** and sign in to Simpro to complete the OAuth flow.
 
-You are now connected to simPRO.
+You are now connected to Simpro.

--- a/docs/api-integrations/simpro/how-to-register-your-own-simpro-api-oauth-app.mdx
+++ b/docs/api-integrations/simpro/how-to-register-your-own-simpro-api-oauth-app.mdx
@@ -1,19 +1,19 @@
 ---
-title: 'How to register your own simPRO OAuth app'
-sidebarTitle: 'simPRO Setup'
-description: 'Register an OAuth app with simPRO and connect it to Nango'
+title: 'How to register your own Simpro OAuth app'
+sidebarTitle: 'Simpro Setup'
+description: 'Register an OAuth app with Simpro and connect it to Nango'
 ---
 
-This guide shows you how to register your own app with simPRO to obtain your OAuth credentials (client id & secret). These are required to let your users grant your app access to their simPRO account.
+This guide shows you how to register your own app with Simpro to obtain your OAuth credentials (client id & secret). These are required to let your users grant your app access to their Simpro account.
 
-simPRO offers two paths depending on whether you're integrating against a single build (typical for in-house tooling) or building a public integration distributed to many simPRO customers.
+Simpro offers two paths depending on whether you're integrating against a single build (typical for in-house tooling) or building a public integration distributed to many Simpro customers.
 
 ## Path 1 — single-build OAuth app (in-house use)
 
-Use this path if you only need to connect to your own simPRO build.
+Use this path if you only need to connect to your own Simpro build.
 
 <Steps>
-  <Step title="Log in to your simPRO build">
+  <Step title="Log in to your Simpro build">
     Go to `https://<your-build-name>.simprosuite.com/` and log in with an admin account.
   </Step>
   <Step title="Open API Applications">
@@ -28,7 +28,7 @@ Use this path if you only need to connect to your own simPRO build.
     6. Click **Create**
   </Step>
   <Step title="Get your credentials">
-    Copy your **Client ID** and **Client Secret** from the application detail page (or download the key file simPRO offers on creation). You'll need these when configuring the integration in Nango.
+    Copy your **Client ID** and **Client Secret** from the application detail page (or download the key file Simpro offers on creation). You'll need these when configuring the integration in Nango.
   </Step>
   <Step title="Next">
     Follow the [_Quickstart_](/getting-started/quickstart) to connect your first account. Note that this app's credentials only work against the build it was created in — if you need to connect multiple customer builds, see Path 2.
@@ -37,7 +37,7 @@ Use this path if you only need to connect to your own simPRO build.
 
 ## Path 2 — central partner OAuth app (multi-tenant integrations)
 
-Use this path if you're building a public integration that connects to many simPRO customers' builds.
+Use this path if you're building a public integration that connects to many Simpro customers' builds.
 
 <Steps>
   <Step title="Sign the Simpro Group Partner Program Agreement">
@@ -50,13 +50,13 @@ Use this path if you're building a public integration that connects to many simP
     In the integration approval form, set the redirect URI to `https://api.nango.dev/oauth/callback`.
   </Step>
   <Step title="Receive central OAuth credentials">
-    After approval, the Simpro Group partner team will issue you a central client ID and secret that work across every customer's simPRO build. Use these in your Nango integration settings.
+    After approval, the Simpro Group partner team will issue you a central client ID and secret that work across every customer's Simpro build. Use these in your Nango integration settings.
   </Step>
   <Step title="Next">
-    Follow the [_Quickstart_](/getting-started/quickstart) to connect your first customer's account. Each customer enters their own simPRO build name when authorising.
+    Follow the [_Quickstart_](/getting-started/quickstart) to connect your first customer's account. Each customer enters their own Simpro build name when authorising.
   </Step>
 </Steps>
 
-For more details, see [simPRO's API authentication docs](https://developer.simprogroup.com/apidoc/?page=3366d2ea7906f693b27d57ed9cca3acb#tag/Authorisation-code-grant-workflow).
+For more details, see [Simpro's API authentication docs](https://developer.simprogroup.com/apidoc/?page=3366d2ea7906f693b27d57ed9cca3acb#tag/Authorisation-code-grant-workflow).
 
 ---

--- a/packages/providers/providers.yaml
+++ b/packages/providers/providers.yaml
@@ -17572,7 +17572,7 @@ shortcut:
             description: The API key for your Shortcut account
 
 simpro:
-    display_name: simPRO
+    display_name: Simpro
     categories:
         - productivity
         - invoicing
@@ -17592,8 +17592,8 @@ simpro:
     connection_config:
         build:
             type: string
-            title: simPRO Build Name
-            description: The subdomain part of your simPRO URL.
+            title: Simpro Build Name
+            description: The subdomain part of your Simpro URL.
             pattern: '^[a-z0-9_-]+$'
             example: yourcompany
             suffix: .simprosuite.com


### PR DESCRIPTION
## Summary

Per Simpro's brand guidelines and as confirmed by Noam Horenczyk (Principal, Technology Partnerships at Simpro) on 18-05-2026, the brand name should be written as **Simpro** consistently — not **simPRO**.

This is a follow-up to #5915 (which I opened to add the Simpro provider 4 weeks ago); Noam reached out today asking to align the lettering with Simpro's current brand — the lowercase-s + uppercase-PRO casing is legacy and Simpro Group no longer uses it.

## Changes

- `packages/providers/providers.yaml` — 3 lines in the `simpro:` section:
  - `display_name: simPRO` → `display_name: Simpro`
  - `connection_config.build.title: simPRO Build Name` → `Simpro Build Name`
  - `connection_config.build.description: The subdomain part of your simPRO URL.` → `The subdomain part of your Simpro URL.`
- `docs/api-integrations/simpro.mdx` — 14 instances in body copy
- `docs/api-integrations/simpro/connect.mdx` — 15 instances in body copy
- `docs/api-integrations/simpro/how-to-register-your-own-simpro-api-oauth-app.mdx` — 15 instances in body copy

## What's unchanged

- File/folder paths stay lowercase `simpro` (no breaking change to the provider unique key, URL slugs, frontmatter, or any code references)
- CHANGELOG.md historical entries (those are time-stamped records)
- No code or behaviour changes — purely user-visible string updates

## Test plan

- [x] `grep -c "simPRO" packages/providers/providers.yaml docs/api-integrations/simpro*` → 0 in all four files
- [x] `grep -c "Simpro" packages/providers/providers.yaml docs/api-integrations/simpro*` → 3, 14, 15, 15 respectively
- [x] Provider unique key, URL slug, file paths unchanged — verified

## Why now

Noam is gating Simpro's approval of TrainAR's downstream integration (built on top of this provider) on the brand casing being correct. Without the fix, every user who clicks Connect on a Simpro integration sees \"simPRO\" in Nango's pre-connection modal — Simpro doesn't want their brand displayed that way to end users.

🤖 Generated with [Claude Code](https://claude.com/claude-code)