### PR TITLE
fix(husky): skip prepare-commit-msg during rebase

### DIFF
--- a/.husky/prepare-commit-msg
+++ b/.husky/prepare-commit-msg
@@ -1,5 +1,12 @@
 #!/bin/bash
 
+# Skip during rebase/cherry-pick — HEAD is detached and the commit messages
+# being applied have already been written by the user.
+GIT_DIR=$(git rev-parse --git-dir)
+if [ -d "$GIT_DIR/rebase-merge" ] || [ -d "$GIT_DIR/rebase-apply" ] || [ -f "$GIT_DIR/CHERRY_PICK_HEAD" ]; then
+  exit 0
+fi
+
 if [ -z "$BRANCHES_TO_SKIP" ]; then
   BRANCHES_TO_SKIP=(master main develop dev development staging stage test)
 fi


### PR DESCRIPTION
## Problem

When running `git rebase` (and similarly `git cherry-pick`) HEAD is detached for each commit being replayed. The `prepare-commit-msg` hook calls `git symbolic-ref --short HEAD`, which fails for every replayed commit with:

```
fatal: ref HEAD is not a symbolic ref
```

The errors are harmless (the rebase still succeeds), but they pollute the output. The hook would also potentially mutate already-written commit messages during replay, which is not the intent of `prepare-commit-msg`.

## Solution

Early-exit the hook when the repo is mid-rebase or mid-cherry-pick. Detection uses standard git markers under `$GIT_DIR`:

- `rebase-merge/` — interactive and merge-based rebases
- `rebase-apply/` — `git am` and `git rebase --apply` (legacy)
- `CHERRY_PICK_HEAD` — cherry-pick in progress

No `2>/dev/null` is used, so any *unexpected* failure of `git symbolic-ref` (corrupt repo, missing HEAD, etc.) will still surface during normal commits.

## Testing

Verified by running the hook directly with a temp commit-msg file under each condition:

- [x] Original script + detached HEAD + `rebase-merge/` → reproduces `fatal: ref HEAD is not a symbolic ref` (control)
- [x] Fixed script + detached HEAD + `rebase-merge/` → exits 0, no output
- [x] Fixed script + detached HEAD + `CHERRY_PICK_HEAD` → exits 0, no output
- [x] Fixed script + normal state + non-`gh-` branch → message unchanged, exits 0
- [x] Fixed script + normal state + `gh-123-foo` branch → message prefixed with `[gh-123]`, exits 0
