### PR TITLE
chore(diagnostic): read-only iterate over customer_keys

### DIFF
--- a/packages/database/lib/migrations/20260518140000_test_iterate_customer_keys.cjs
+++ b/packages/database/lib/migrations/20260518140000_test_iterate_customer_keys.cjs
@@ -1,0 +1,27 @@
+exports.config = { transaction: false };
+
+/**
+ * Diagnostic migration — reads every row in customer_keys and does nothing
+ * else. Used to bisect a slow-deploy issue: if THIS migration is slow on a
+ * dev deploy with ~1.3K rows, the problem is reading the table at migration
+ * time (locks, bloat, connection setup), not the legacy-scope UPDATEs.
+ *
+ * Logs the row count and elapsed read time to make the deploy log conclusive.
+ *
+ * @param {import('knex').Knex} knex
+ */
+exports.up = async function (knex) {
+    const startedAt = Date.now();
+    const rows = await knex('customer_keys').select('id', 'key_type', 'scopes');
+
+    let counted = 0;
+    for (let i = 0; i < rows.length; i++) {
+        counted++;
+    }
+
+    const elapsedMs = Date.now() - startedAt;
+    // eslint-disable-next-line no-console
+    console.log(`[diagnostic] iterated ${counted} customer_keys rows in ${elapsedMs}ms`);
+};
+
+exports.down = function () {};


### PR DESCRIPTION
## Purpose

Diagnostic-only PR. Adds one read-only migration that iterates every row in \`customer_keys\` and logs the count + elapsed time.

## Why

The dev deploy of #6088 hung on the legacy-scope expansion migration, even though the underlying \`UPDATE\` runs in ~1ms when issued directly against the same DB (~1.3K rows). This PR isolates whether the slowness is **the UPDATE specifically** or **reading customer_keys at migration time at all**.

- If this migration also stalls on deploy → the issue is generic (locks, connection setup, pool warmup, etc.) and not specific to the UPDATE.
- If this migration deploys instantly → the issue is something about the UPDATE / the legacy-scope migration in #6088.

## Plan

1. Merge / deploy this branch to dev.
2. Watch the deploy logs for the \`[diagnostic] iterated N customer_keys rows in Xms\` line and the time between deploy start and that line appearing.
3. Tear this down — close the PR without merging once we have the signal.

## Do not merge

This adds a no-op migration row to \`knex_migrations\`. Revert / close once the diagnostic is collected.

🤖 Generated with [Claude Code](https://claude.com/claude-code)