### PR TITLE
refactor(usage): replace BATCHER_DROPPED with ingest result + latency

### DIFF
--- a/packages/usage/lib/clickhouse/batcher.ts
+++ b/packages/usage/lib/clickhouse/batcher.ts
@@ -117,8 +117,8 @@ export class Batcher<T> {
 
             return Err(new Error('Batcher failed to process batch', { cause: err }));
         } finally {
-            metrics.distribution(metrics.Types.BILLING_USAGE_CLICKHOUSE_BATCHER_INGEST_DURATION_MS, Number(process.hrtime.bigint() - start) / 1e6);
             this.isFlushing = false;
+            metrics.distribution(metrics.Types.BILLING_USAGE_CLICKHOUSE_BATCHER_INGEST_DURATION_MS, Number(process.hrtime.bigint() - start) / 1e6);
         }
     }
 

--- a/packages/usage/lib/clickhouse/batcher.ts
+++ b/packages/usage/lib/clickhouse/batcher.ts
@@ -55,7 +55,7 @@ export class Batcher<T> {
 
         if (discarded > 0) {
             logger.error(`Clickhouse batcher queue full. Discarding ${discarded} items.`);
-            metrics.increment(metrics.Types.BILLING_USAGE_CLICKHOUSE_BATCHER_DROPPED, discarded, { reason: 'queue_full' });
+            metrics.increment(metrics.Types.BILLING_USAGE_CLICKHOUSE_BATCHER_INGEST_RESULT, discarded, { success: 'false', reason: 'queue_full' });
         }
 
         this.queue.push(...t);
@@ -92,8 +92,10 @@ export class Batcher<T> {
         // dedup catches a retried INSERT even if the block content drifts.
         const retryKey = this.retry?.key ?? randomUUID();
 
+        const start = process.hrtime.bigint();
         try {
             await this.process(batch, { retryKey });
+            metrics.increment(metrics.Types.BILLING_USAGE_CLICKHOUSE_BATCHER_INGEST_RESULT, batch.length, { success: 'true' });
 
             this.retry = null;
 
@@ -105,15 +107,17 @@ export class Batcher<T> {
             const attempts = (this.retry?.attempts ?? 0) + 1;
             if (attempts > this.maxProcessingRetry) {
                 logger.error(`Clickhouse batcher: dropping ${batch.length} items after exhausting retries.`);
-                metrics.increment(metrics.Types.BILLING_USAGE_CLICKHOUSE_BATCHER_DROPPED, batch.length, { reason: 'failed_insert' });
+                metrics.increment(metrics.Types.BILLING_USAGE_CLICKHOUSE_BATCHER_INGEST_RESULT, batch.length, { success: 'false', reason: 'insert_failed' });
                 this.retry = null;
             } else {
                 this.queue.unshift(...batch);
                 this.retry = { key: retryKey, size: batch.length, attempts };
+                metrics.increment(metrics.Types.BILLING_USAGE_CLICKHOUSE_BATCHER_RETRY, 1);
             }
 
             return Err(new Error('Batcher failed to process batch', { cause: err }));
         } finally {
+            metrics.distribution(metrics.Types.BILLING_USAGE_CLICKHOUSE_BATCHER_INGEST_DURATION_MS, Number(process.hrtime.bigint() - start) / 1e6);
             this.isFlushing = false;
         }
     }

--- a/packages/utils/lib/telemetry/metrics.ts
+++ b/packages/utils/lib/telemetry/metrics.ts
@@ -117,7 +117,9 @@ export enum Types {
     BILLING_USAGE_CACHE = 'nango.billing.usage.cache',
     BILLING_USAGE_ORB_MS = 'nango.billing.usage.orb.ms',
     BILLING_USAGE_ORB_ERRORS = 'nango.billing.usage.orb.errors',
-    BILLING_USAGE_CLICKHOUSE_BATCHER_DROPPED = 'nango.billing.usage.clickhouse.batcher.dropped',
+    BILLING_USAGE_CLICKHOUSE_BATCHER_INGEST_DURATION_MS = 'nango.billing.usage.clickhouse.batcher.ingest.duration_ms',
+    BILLING_USAGE_CLICKHOUSE_BATCHER_INGEST_RESULT = 'nango.billing.usage.clickhouse.batcher.ingest.result',
+    BILLING_USAGE_CLICKHOUSE_BATCHER_RETRY = 'nango.billing.usage.clickhouse.batcher.retry',
 
     USAGE_IS_CAPPED = 'nango.capping.isCapped',
 


### PR DESCRIPTION
## Summary

Replaces the single `BATCHER_DROPPED` counter (added in #6122) with three separate metrics so we can measure latency, per-batch outcome, and retry pressure independently — without retry inflation polluting the success-rate math.

## Metrics

| Metric | Type | Tags | Fires when |
| --- | --- | --- | --- |
| `nango.billing.usage.clickhouse.batcher.ingest.duration_ms` | distribution | (none) | Every `process()` attempt. Emitted in `finally` so success and failure paths share one call site. Monotonic clock via `process.hrtime.bigint()`. |
| `nango.billing.usage.clickhouse.batcher.ingest.result` | counter (item-weighted) | `success: true \| false`, `reason: queue_full \| insert_failed` (only when `success=false`) | **Final** outcome per item. `true` on a landed batch; `false` with reason on dropped items. No retry inflation. |
| `nango.billing.usage.clickhouse.batcher.retry` | counter | (none) | Each time a failed batch is unshifted for another attempt. |

## Derived signals

- **Item success rate** = `count{success=true} / count{success=*}` (item-weighted, direct).
- **Items lost** = `count{success=false}` split by `reason`.
- **Wire latency** = distribution percentiles, untagged.
- **Retry pressure** = `count(retry)`.

## Notes

- The old `BILLING_USAGE_CLICKHOUSE_BATCHER_DROPPED` is removed. `BATCHER_INGEST_RESULT{success=false}` sums to the same item count it tracked, with the addition of the success branch.
- Considered using `metrics.time()` but it wraps the awaited promise in `.then(onFulfilled, onRejected)`, adding a microtask hop that breaks three existing tests using `await Promise.resolve()` to settle. Kept the manual `hrtime.bigint()` pair, which preserves the original microtask budget and works cleanly with `finally`.

## Test plan

- [x] `npm run ts-build` clean
- [x] All 19 existing `batcher.unit.test.ts` tests pass unchanged
- [ ] After deploy, verify the three new metrics appear in DataDog under `nango.billing.usage.clickhouse.batcher.*`

Refs NAN-5315 / NAN-5251.