### PR TITLE
chore(ci): add composite setup-node action with npm cache

### DIFF
--- a/.github/actions/setup-node/action.yml
+++ b/.github/actions/setup-node/action.yml
@@ -32,3 +32,13 @@ runs:
               registry-url: ${{ inputs.registry-url }}
               scope: ${{ inputs.scope }}
               always-auth: ${{ inputs.always-auth }}
+
+        - name: Upgrade npm
+          shell: bash
+          run: npm install -g npm@11.12.1
+
+        - name: Check lockfile consistency
+          shell: bash
+          run: |
+              npm install --package-lock-only --ignore-scripts
+              git diff --exit-code package-lock.json

--- a/.github/actions/setup-node/action.yml
+++ b/.github/actions/setup-node/action.yml
@@ -19,10 +19,6 @@ inputs:
         description: 'Set always-auth on the configured registry.'
         required: false
         default: 'false'
-    check-lockfile:
-        description: 'Fail if package-lock.json is out of sync with package.json.'
-        required: false
-        default: 'true'
 
 runs:
     using: 'composite'
@@ -36,10 +32,3 @@ runs:
               registry-url: ${{ inputs.registry-url }}
               scope: ${{ inputs.scope }}
               always-auth: ${{ inputs.always-auth }}
-
-        - name: Check lockfile consistency
-          if: ${{ inputs.check-lockfile == 'true' }}
-          shell: bash
-          run: |
-              npm install --package-lock-only --ignore-scripts
-              git diff --exit-code package-lock.json

--- a/.github/actions/setup-node/action.yml
+++ b/.github/actions/setup-node/action.yml
@@ -1,0 +1,34 @@
+name: 'Setup Node.js'
+description: 'Sets up Node.js with npm caching enabled by default.'
+
+inputs:
+    node-version:
+        description: 'Node.js version to use. When set, overrides node-version-file.'
+        required: false
+    node-version-file:
+        description: 'Path to a file containing the Node.js version. Defaults to .nvmrc.'
+        required: false
+        default: '.nvmrc'
+    registry-url:
+        description: 'Optional registry URL for npm publishing or private registry auth.'
+        required: false
+    scope:
+        description: 'Optional npm scope used together with registry-url.'
+        required: false
+    always-auth:
+        description: 'Set always-auth on the configured registry.'
+        required: false
+        default: 'false'
+
+runs:
+    using: 'composite'
+    steps:
+        - uses: actions/setup-node@v4
+          with:
+              node-version: ${{ inputs.node-version }}
+              node-version-file: ${{ inputs.node-version-file }}
+              cache: 'npm'
+              cache-dependency-path: 'package-lock.json'
+              registry-url: ${{ inputs.registry-url }}
+              scope: ${{ inputs.scope }}
+              always-auth: ${{ inputs.always-auth }}

--- a/.github/actions/setup-node/action.yml
+++ b/.github/actions/setup-node/action.yml
@@ -19,6 +19,10 @@ inputs:
         description: 'Set always-auth on the configured registry.'
         required: false
         default: 'false'
+    check-lockfile:
+        description: 'Fail if package-lock.json is out of sync with package.json.'
+        required: false
+        default: 'true'
 
 runs:
     using: 'composite'
@@ -32,3 +36,10 @@ runs:
               registry-url: ${{ inputs.registry-url }}
               scope: ${{ inputs.scope }}
               always-auth: ${{ inputs.always-auth }}
+
+        - name: Check lockfile consistency
+          if: ${{ inputs.check-lockfile == 'true' }}
+          shell: bash
+          run: |
+              npm install --package-lock-only --ignore-scripts
+              git diff --exit-code package-lock.json

--- a/.github/actions/setup-node/action.yml
+++ b/.github/actions/setup-node/action.yml
@@ -3,12 +3,8 @@ description: 'Sets up Node.js with npm caching enabled by default.'
 
 inputs:
     node-version:
-        description: 'Node.js version to use. When set, overrides node-version-file.'
+        description: 'Node.js version to use. When set, overrides .nvmrc.'
         required: false
-    node-version-file:
-        description: 'Path to a file containing the Node.js version. Defaults to .nvmrc.'
-        required: false
-        default: '.nvmrc'
     registry-url:
         description: 'Optional registry URL for npm publishing or private registry auth.'
         required: false
@@ -26,19 +22,9 @@ runs:
         - uses: actions/setup-node@v4
           with:
               node-version: ${{ inputs.node-version }}
-              node-version-file: ${{ inputs.node-version-file }}
+              node-version-file: .nvmrc
               cache: 'npm'
               cache-dependency-path: 'package-lock.json'
               registry-url: ${{ inputs.registry-url }}
               scope: ${{ inputs.scope }}
               always-auth: ${{ inputs.always-auth }}
-
-        - name: Upgrade npm
-          shell: bash
-          run: npm install -g npm@11.12.1
-
-        - name: Check lockfile consistency
-          shell: bash
-          run: |
-              npm install --package-lock-only --ignore-scripts
-              git diff --exit-code package-lock.json

--- a/.github/workflows/cache-warmup.yaml
+++ b/.github/workflows/cache-warmup.yaml
@@ -12,6 +12,8 @@ concurrency:
 jobs:
     warm-npm-cache:
         runs-on: ubuntu-latest
+        permissions:
+            contents: read
         steps:
             - uses: actions/checkout@v4
 

--- a/.github/workflows/cache-warmup.yaml
+++ b/.github/workflows/cache-warmup.yaml
@@ -1,0 +1,20 @@
+name: Cache Warmup
+
+on:
+    push:
+        branches:
+            - master
+
+concurrency:
+    group: cache-warmup
+    cancel-in-progress: true
+
+jobs:
+    warm-npm-cache:
+        runs-on: ubuntu-latest
+        steps:
+            - uses: actions/checkout@v4
+
+            - uses: ./.github/actions/setup-node
+
+            - run: npm ci

--- a/.github/workflows/cli-verification.yaml
+++ b/.github/workflows/cli-verification.yaml
@@ -63,13 +63,12 @@ jobs:
             - uses: actions/checkout@v4
               if: needs.should-run.outputs.should_skip != 'true'
 
-            - uses: actions/setup-node@v4
+            - uses: ./.github/actions/setup-node
               if: needs.should-run.outputs.should_skip != 'true'
               with:
-                  node-version-file: '.nvmrc'
                   registry-url: 'https://npm.pkg.github.com'
                   scope: '@nangohq'
-                  always-auth: true
+                  always-auth: 'true'
 
             - name: Build
               if: needs.should-run.outputs.should_skip != 'true'

--- a/.github/workflows/lint.yaml
+++ b/.github/workflows/lint.yaml
@@ -55,11 +55,8 @@ jobs:
               with:
                   fetch-depth: '0'
 
-            - uses: actions/setup-node@v4
+            - uses: ./.github/actions/setup-node
               if: needs.should-run.outputs.should_skip != 'true'
-              with:
-                  cache: 'npm'
-                  node-version-file: '.nvmrc'
 
             - name: Install dependencies
               if: needs.should-run.outputs.should_skip != 'true'
@@ -83,11 +80,8 @@ jobs:
               with:
                   fetch-depth: 1
 
-            - uses: actions/setup-node@v4
+            - uses: ./.github/actions/setup-node
               if: needs.should-run.outputs.should_skip != 'true'
-              with:
-                  cache: 'npm'
-                  node-version-file: '.nvmrc'
 
             - name: Install dependencies
               if: needs.should-run.outputs.should_skip != 'true'

--- a/.github/workflows/managed-release.yaml
+++ b/.github/workflows/managed-release.yaml
@@ -33,7 +33,6 @@ jobs:
               uses: ./.github/actions/setup-node
               with:
                   node-version: '22'
-                  check-lockfile: 'false'
 
             - name: Install dependencies
               run: |
@@ -344,7 +343,6 @@ jobs:
               uses: ./.github/actions/setup-node
               with:
                   node-version: '22'
-                  check-lockfile: 'false'
 
             - name: Download manifest artifact
               uses: actions/download-artifact@v4

--- a/.github/workflows/managed-release.yaml
+++ b/.github/workflows/managed-release.yaml
@@ -33,6 +33,7 @@ jobs:
               uses: ./.github/actions/setup-node
               with:
                   node-version: '22'
+                  check-lockfile: 'false'
 
             - name: Install dependencies
               run: |
@@ -343,6 +344,7 @@ jobs:
               uses: ./.github/actions/setup-node
               with:
                   node-version: '22'
+                  check-lockfile: 'false'
 
             - name: Download manifest artifact
               uses: actions/download-artifact@v4

--- a/.github/workflows/managed-release.yaml
+++ b/.github/workflows/managed-release.yaml
@@ -21,11 +21,6 @@ jobs:
             app_version: ${{ steps.version-script.outputs.app_version }}
             commit_hash: ${{ inputs.commit_hash }}
         steps:
-            - name: Setup Node.js
-              uses: actions/setup-node@v4
-              with:
-                  node-version: '22'
-
             - name: Get versions
               id: versions
               uses: actions/checkout@v4
@@ -33,6 +28,11 @@ jobs:
                   ref: ${{ inputs.commit_hash }}
                   fetch-depth: 1
                   token: ${{ secrets.GITHUB_TOKEN }}
+
+            - name: Setup Node.js
+              uses: ./.github/actions/setup-node
+              with:
+                  node-version: '22'
 
             - name: Install dependencies
               run: |
@@ -326,11 +326,6 @@ jobs:
         if: success()
         runs-on: ubuntu-latest
         steps:
-            - name: Setup Node.js
-              uses: actions/setup-node@v4
-              with:
-                  node-version: '22'
-
             - uses: actions/create-github-app-token@v2
               id: create_github_app_token
               with:
@@ -343,6 +338,11 @@ jobs:
                   ref: 'master'
                   fetch-depth: 1
                   token: ${{ steps.create_github_app_token.outputs.token }}
+
+            - name: Setup Node.js
+              uses: ./.github/actions/setup-node
+              with:
+                  node-version: '22'
 
             - name: Download manifest artifact
               uses: actions/download-artifact@v4

--- a/.github/workflows/publish.yaml
+++ b/.github/workflows/publish.yaml
@@ -33,7 +33,6 @@ jobs:
             - uses: ./.github/actions/setup-node
               with:
                   registry-url: 'https://registry.npmjs.org'
-                  check-lockfile: 'false'
 
             - name: Update npm to latest
               run: npm install -g npm@11.5.1

--- a/.github/workflows/publish.yaml
+++ b/.github/workflows/publish.yaml
@@ -33,6 +33,7 @@ jobs:
             - uses: ./.github/actions/setup-node
               with:
                   registry-url: 'https://registry.npmjs.org'
+                  check-lockfile: 'false'
 
             - name: Update npm to latest
               run: npm install -g npm@11.5.1

--- a/.github/workflows/publish.yaml
+++ b/.github/workflows/publish.yaml
@@ -34,9 +34,6 @@ jobs:
               with:
                   registry-url: 'https://registry.npmjs.org'
 
-            - name: Update npm to latest
-              run: npm install -g npm@11.5.1
-
             - name: Install dependencies
               run: npm ci
 

--- a/.github/workflows/publish.yaml
+++ b/.github/workflows/publish.yaml
@@ -30,10 +30,8 @@ jobs:
                   token: ${{ steps.create_github_app_token.outputs.token }}
                   fetch-depth: 0
 
-            - uses: actions/setup-node@v4
+            - uses: ./.github/actions/setup-node
               with:
-                  cache: 'npm'
-                  node-version-file: '.nvmrc'
                   registry-url: 'https://registry.npmjs.org'
 
             - name: Update npm to latest

--- a/.github/workflows/sanity-sync.yaml
+++ b/.github/workflows/sanity-sync.yaml
@@ -42,10 +42,7 @@ jobs:
             - name: Checkout
               uses: actions/checkout@v4
 
-            - uses: actions/setup-node@v4
-              with:
-                  cache: 'npm'
-                  node-version-file: '.nvmrc'
+            - uses: ./.github/actions/setup-node
 
             - name: Install dependencies
               run: npm ci

--- a/.github/workflows/sync-new-provider-scopes.yaml
+++ b/.github/workflows/sync-new-provider-scopes.yaml
@@ -18,10 +18,7 @@ jobs:
               with:
                   fetch-depth: 0
 
-            - uses: actions/setup-node@v4
-              with:
-                  cache: 'npm'
-                  node-version-file: '.nvmrc'
+            - uses: ./.github/actions/setup-node
 
             - run: npm ci
 

--- a/.github/workflows/sync-provider-scopes.yaml
+++ b/.github/workflows/sync-provider-scopes.yaml
@@ -15,10 +15,7 @@ jobs:
         steps:
             - uses: actions/checkout@v4
 
-            - uses: actions/setup-node@v4
-              with:
-                  cache: 'npm'
-                  node-version-file: '.nvmrc'
+            - uses: ./.github/actions/setup-node
 
             - run: npm ci
 

--- a/.github/workflows/tests-clients.yaml
+++ b/.github/workflows/tests-clients.yaml
@@ -78,11 +78,9 @@ jobs:
 
             - name: Use Node.js ${{ matrix.node-version }}
               if: needs.should-run.outputs.should_skip != 'true'
-              uses: actions/setup-node@v4
+              uses: ./.github/actions/setup-node
               with:
-                  cache: 'npm'
                   node-version: ${{ matrix.node-version }}
-                  cache-dependency-path: 'package-lock.json'
 
             - run: npm ci
               if: needs.should-run.outputs.should_skip != 'true'

--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -62,10 +62,7 @@ jobs:
 
             - name: Use Node.js
               if: needs.should-run.outputs.should_skip != 'true'
-              uses: actions/setup-node@v4
-              with:
-                  cache: 'npm'
-                  node-version-file: '.nvmrc'
+              uses: ./.github/actions/setup-node
 
             - run: npm ci
               if: needs.should-run.outputs.should_skip != 'true'
@@ -88,10 +85,7 @@ jobs:
 
             - name: Use Node.js
               if: needs.should-run.outputs.should_skip != 'true'
-              uses: actions/setup-node@v4
-              with:
-                  cache: 'npm'
-                  node-version-file: '.nvmrc'
+              uses: ./.github/actions/setup-node
 
             - run: npm ci
               if: needs.should-run.outputs.should_skip != 'true'

--- a/.github/workflows/validation.yaml
+++ b/.github/workflows/validation.yaml
@@ -64,11 +64,9 @@ jobs:
                   ref: ${{ github.head_ref || github.ref }}
                   token: ${{ secrets.GITHUB_TOKEN }}
 
-            - uses: actions/setup-node@v4
+            - uses: ./.github/actions/setup-node
               if: needs.should-run.outputs.should_skip != 'true'
               with:
-                  cache: 'npm'
-                  node-version-file: '.nvmrc'
                   registry-url: 'https://registry.npmjs.org'
 
             - run: npm ci

--- a/package-lock.json
+++ b/package-lock.json
@@ -37248,7 +37248,7 @@
                 "vitest": "3.2.4"
             },
             "engines": {
-                "node": ">=20.0"
+                "node": ">=22.22.2"
             }
         },
         "packages/cli/node_modules/ajv": {


### PR DESCRIPTION
## Problem

npm caching was inconsistent across CI workflows — some used `cache: 'npm'`, others didn't. New workflows could easily forget it. Also, master pushes from the merge-queue bot skip `npm ci` via the `should-run` check, so no npm cache was ever saved on `refs/heads/master`, meaning every feature branch paid a cold cache miss on first run.

This also lays the ground for enabling `pnpm` across the monorepo.

## Solution

Add `.github/actions/setup-node`, a composite action wrapping `actions/setup-node@v4` with `cache: 'npm'` always set. Migrate all workflows to use it.

Add `cache-warmup.yaml` that runs on every master push, doing just enough (`checkout` + `setup-node` + `npm ci`) to land an npm cache on `refs/heads/master` so feature branches can restore it.

Only `cli-verification.yaml` and `managed-release.yaml` genuinely gain new caching — the rest were already using `cache: 'npm'` and are just migrated to the composite action.

Fixes [NAN-5527](https://linear.app/nango/issue/NAN-5527)

## Testing

- [ ] CI green on this PR
- [ ] After merge, `Cache Warmup` workflow runs on the master push and saves a cache entry on `refs/heads/master`
- [ ] Next feature branch's first run shows a cache hit in the setup-node logs
