### PR TITLE
fix(scheduler): de-flake schedules updatedAt tests

### DIFF
--- a/packages/scheduler/lib/models/schedules.integration.test.ts
+++ b/packages/scheduler/lib/models/schedules.integration.test.ts
@@ -41,7 +41,7 @@ describe('Schedules', () => {
     });
     it('should be successfully deleted', async () => {
         const schedule = await createSchedule(db);
-        await setTimeout(1);
+        await setTimeout(10);
         const deleted = (await schedules.remove(db, schedule.id)).unwrap();
         expect(deleted.state).toBe('DELETED');
         expect(deleted.updatedAt.getTime()).toBeGreaterThan(schedule.updatedAt.getTime());
@@ -49,7 +49,7 @@ describe('Schedules', () => {
     });
     it('should be successfully paused/unpaused', async () => {
         const schedule = await createSchedule(db);
-        await setTimeout(1);
+        await setTimeout(10);
         const paused = (await schedules.transitionState(db, schedule.id, 'PAUSED')).unwrap();
         expect(paused.state).toBe('PAUSED');
         expect(paused.updatedAt.getTime()).toBeGreaterThan(schedule.updatedAt.getTime());
@@ -68,7 +68,7 @@ describe('Schedules', () => {
     });
     it('should be successfully updated', async () => {
         const schedule = await createSchedule(db);
-        await setTimeout(1);
+        await setTimeout(10);
         const newFrequency = 600_000; // 10 minutes
         const updated = (
             await schedules.update(db, {
@@ -97,7 +97,7 @@ describe('Schedules', () => {
     });
     it('should set last scheduled task', async () => {
         const schedule = await createSchedule(db);
-        await setTimeout(1);
+        await setTimeout(10);
         const taskId = uuidv7();
         const taskState = 'STARTED';
 
@@ -109,7 +109,7 @@ describe('Schedules', () => {
     });
     it('should update last scheduled task state', async () => {
         const schedule = await createSchedule(db);
-        await setTimeout(1);
+        await setTimeout(10);
         const taskId = uuidv7();
 
         await schedules.setLastScheduledTask(db, [{ id: schedule.id, taskId, taskState: 'CREATED' }]);


### PR DESCRIPTION
## Problem

The `Schedules > should be successfully updated` integration test ([CI run](https://github.com/NangoHQ/nango/actions/runs/26086637252/job/76701338461?pr=6168)) failed with:

```
AssertionError: expected 1779180875099 to be greater than 1779180875099
 ❯ packages/scheduler/lib/models/schedules.integration.test.ts:82:45
```

The test creates a schedule, waits 1ms via `setTimeout(1)`, then updates it and asserts the new `updatedAt` is strictly greater than the original. Node's timer resolution can land within the same millisecond, so the create and update timestamps occasionally collide and the assertion fails.

The other tests in this file (delete, pause/unpause, setLastScheduledTask, scheduleNextExecution) use the same `setTimeout(1)` pattern with the same `toBeGreaterThan` assertion and are vulnerable to the same flake.

## Solution

Bump the sleep from `1` to `10` ms in all five affected tests. 10 ms is well above Node's timer resolution and PostgreSQL's millisecond rounding, making this functionally impossible to flake on CI hardware.

## Testing

- Ran `npm_config_dir=packages/scheduler npm run test:integration` locally — all 10 tests in `schedules.integration.test.ts` pass.
