### PR TITLE
fix: clarify OTel feature gating error message

### DIFF
--- a/packages/server/lib/controllers/v1/environment/patchEnvironment.ts
+++ b/packages/server/lib/controllers/v1/environment/patchEnvironment.ts
@@ -91,7 +91,12 @@ export const patchEnvironment = asyncWrapper<PatchEnvironment>(async (req, res) 
 
     if (data.otlp_settings && flagHasPlan) {
         if (!plan!.has_otel) {
-            res.status(403).send({ error: { code: 'forbidden', message: 'OpenTelemetry export is not enabled for this account' } });
+            res.status(403).send({
+                error: {
+                    code: 'forbidden',
+                    message: 'OpenTelemetry export is not available for your account. Check if your Nango plan includes access to this feature.'
+                }
+            });
             return;
         }
     }


### PR DESCRIPTION
## Summary
- Replace the OpenTelemetry feature-gate error message returned by `PATCH /environment` with a clearer one that points users to check their Nango plan.

## Test plan
- [ ] Attempt to update `otlp_settings` on an environment whose plan does not include OTel and confirm the new message is returned with a 403.