### PR TITLE
docs: update API count from 700+ to 800+

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,9 +4,9 @@
 
 # Build product integrations with AI.
 
-Connect your product & AI agents with 700+ APIs. Build, run, and maintain integrations with AI in code, on infrastructure built for scale.
+Connect your product & AI agents with 800+ APIs. Build, run, and maintain integrations with AI in code, on infrastructure built for scale.
 
-[Website](https://nango.dev) · [Docs](https://nango.dev/docs/) · [700+ APIs](https://nango.dev/docs/integrations/overview/) · [Slack Community](https://nango.dev/slack)
+[Website](https://nango.dev) · [Docs](https://nango.dev/docs/) · [800+ APIs](https://nango.dev/docs/integrations/overview/) · [Slack Community](https://nango.dev/slack)
 
 [![GitHub Stars](https://img.shields.io/github/stars/NangoHQ/nango?style=social)](https://github.com/NangoHQ/nango/stargazers)
 [![License](https://img.shields.io/badge/license-Elastic-blue.svg)](https://github.com/NangoHQ/nango/blob/master/LICENSE)
@@ -16,7 +16,7 @@ Connect your product & AI agents with 700+ APIs. Build, run, and maintain integr
 
 ## What is Nango?
 
-Nango is an open-source platform for building product integrations. It supports [**700+ APIs**](https://nango.dev/docs/integrations/overview) and works with any backend language, AI coding tool, and agent SDK.
+Nango is an open-source platform for building product integrations. It supports [**800+ APIs**](https://nango.dev/docs/integrations/overview) and works with any backend language, AI coding tool, and agent SDK.
 
 You write integration logic as TypeScript functions, or let AI generate them for you, and deploy to Nango's production runtime. Nango handles auth, execution, scaling, and observability.
 
@@ -28,7 +28,7 @@ Nango gives you three primitives that cover every integration pattern:
 
 ### 1. Auth
 
-Managed OAuth, API keys, and token refresh for 700+ APIs. Embed a white-label auth flow in your app. Nango handles credentials, token storage, and multi-tenant connection management.
+Managed OAuth, API keys, and token refresh for 800+ APIs. Embed a white-label auth flow in your app. Nango handles credentials, token storage, and multi-tenant connection management.
 
 ```typescript
 // Embed auth in your frontend
@@ -117,7 +117,7 @@ Nango's AI builder generates TypeScript integration functions from natural langu
 **Production-grade infrastructure.** 
 Nango processes billions of API requests. The runtime provides per-tenant isolation, elastic scaling, automatic retries, and rate-limit handling. Battle-tested by hundreds of companies in production.
 
-**Auth for 700+ APIs, out of the box.** 
+**Auth for 800+ APIs, out of the box.** 
 OAuth flows, token refresh, credential storage, and multi-tenant support handled for you. Connect to any API without building auth from scratch.
 
 **Open source and self-hostable.** 

--- a/docs/docs.json
+++ b/docs/docs.json
@@ -881,7 +881,7 @@
             ]
           },
           {
-            "group": "700+ APIs & Integrations",
+            "group": "800+ APIs & Integrations",
             "pages": [
               "api-integrations/1password-events",
               "integrations/all/1password-scim",

--- a/docs/getting-started/intro-to-nango.mdx
+++ b/docs/getting-started/intro-to-nango.mdx
@@ -10,7 +10,7 @@ Nango is the integration layer for AI-built, code-owned product integrations.
 
 Your users connect external APIs through Nango. You generate and customize TypeScript functions with your favorite coding agent. Your app, backend jobs, or agents then consume those functions through Nango's API, SDKs, or MCP server.
 
-Nango supports [700+ APIs](/integrations/overview) and handles auth, credentials, execution, retries, rate limits, observability, environments, and tenant isolation so you can ship integrations without rebuilding the same infrastructure for every provider.
+Nango supports [800+ APIs](/integrations/overview) and handles auth, credentials, execution, retries, rate limits, observability, environments, and tenant isolation so you can ship integrations without rebuilding the same infrastructure for every provider.
 
 ## Why it matters
 

--- a/docs/getting-started/quickstart.mdx
+++ b/docs/getting-started/quickstart.mdx
@@ -8,7 +8,7 @@ description: 'Authorize an API and run your first Nango function'
   **Using a coding agent?** Set up the [docs MCP](/getting-started/coding-agent-setup#docs-mcp-server) and [skills](/getting-started/coding-agent-setup#skills), then copy this page as prompt.
 </Tip>
 
-This quickstart uses the GitHub API as an example, but you can choose any of the [700+ APIs](/integrations/overview).
+This quickstart uses the GitHub API as an example, but you can choose any of the [800+ APIs](/integrations/overview).
 
 <Steps>
   <Step id="create-integration" title="Create an integration">

--- a/docs/guides/auth/auth-guide.mdx
+++ b/docs/guides/auth/auth-guide.mdx
@@ -6,7 +6,7 @@ description: 'Let your users connect external APIs to your agents & apps.'
 
 ## Overview
 
-Nango Auth lets your users connect 700+ external APIs to your product. You embed a Nango-managed auth flow in your application, and Nango handles authorization, credential storage, refresh, and validation.
+Nango Auth lets your users connect 800+ external APIs to your product. You embed a Nango-managed auth flow in your application, and Nango handles authorization, credential storage, refresh, and validation.
 
 A **Connection** is created after each successful authorization. It stores one user's credentials for one external API and keeps them valid over time. Credentials can be retrieved at scale or used directly by other Nango primitives — without ever passing through your codebase.
 
@@ -37,7 +37,7 @@ Once you have the connection ID, fetch credentials whenever you need them:
 
 ## Capabilities
 
-- **Auth schemes** — OAuth 2.0, OAuth 1.0a, API keys, basic auth, custom. 700+ APIs supported; new ones [added on demand](/integrations/contribute-or-request-api) within days, by request or self-contributed.
+- **Auth schemes** — OAuth 2.0, OAuth 1.0a, API keys, basic auth, custom. 800+ APIs supported; new ones [added on demand](/integrations/contribute-or-request-api) within days, by request or self-contributed.
 - **Pre-built UI** — Embedded Connect UI with API-specific guidance, input validation, and your branding. Or [customize Connect UI or build a custom UI](/guides/auth/customize-connect-ui).
 - **Credential management** — Encrypted storage, automatic refresh, retrieval at scale. Combine with [Proxy](/guides/platform/proxy-requests) or [Functions](/guides/functions/functions-guide) to avoid handling credentials directly.
 - **Observability** — Failure detection, reconnect flow, and per-connection logs.

--- a/docs/integrations/contribute-or-request-api.mdx
+++ b/docs/integrations/contribute-or-request-api.mdx
@@ -65,7 +65,7 @@ If all goes well, you should see your new connection in the _Connections_ tab. C
 
 Add a `<api>.mdx` file (e.g. `github.mdx`) for your API to the `docs/integrations/all` folder. Check out [other examples](/integrations/overview) to fill out the content of the documentation page.
 
-Reference the page in the `docs/docs.json` file in the `700+ APIs & Integrations` group in alphabetical order.
+Reference the page in the `docs/docs.json` file in the `800+ APIs & Integrations` group in alphabetical order.
 
 ### Submit a pull request
 

--- a/docs/integrations/overview.mdx
+++ b/docs/integrations/overview.mdx
@@ -9,7 +9,7 @@ Nango is the leading provider of **API access for AI agents & apps**. It is desi
 
 <CardGroup cols={1}>
 <Card title="All APIs & integrations" icon="list" href="https://www.nango.dev/api-integrations">
-700+ APIs & thousands of integrations.
+800+ APIs & thousands of integrations.
 </Card>
 <Card title="Request or contribute a new API" icon="circle-question" href="/integrations/contribute-or-request-api">
 We deliver them in &lt;48h.

--- a/docs/updates/changelog.mdx
+++ b/docs/updates/changelog.mdx
@@ -1383,7 +1383,7 @@ description: "Important developer & product updates, including deprecations & br
   - [**Action trigger endpoint**](/reference/backend/http-api/action/trigger): Run actions reliably via the API
   - [**Integrated authorization**](/guides/auth/auth-guide): Use Nango’s pre-built UI to securely prompt users for access
 
-  This makes it easier to build AI agents that can reliably interact with 700+ APIs.
+  This makes it easier to build AI agents that can reliably interact with 800+ APIs.
 
   Get inspired by [AI companies using Nango](https://www.nango.dev/blog/nango-for-ai).
 
@@ -1394,7 +1394,7 @@ description: "Important developer & product updates, including deprecations & br
   <Frame>
     ![AI agent demo video illustration](/images/changelog/ai-agent-demo-video.png)
   </Frame>
-  We published a demo showing how AI agents can use Nango to trigger actions across 700+ APIs and integrations.
+  We published a demo showing how AI agents can use Nango to trigger actions across 800+ APIs and integrations.
 
   See how AI agents benefit from:
 


### PR DESCRIPTION
## Summary
- Updates "700+" → "800+" across docs and the GitHub README to reflect crossing 800+ supported APIs.
- Touches 9 references in 7 docs files (sidebar group, integrations overview, contribute guide, intro, quickstart, auth guide, changelog) and 4 references in `README.md`.
- No URL, anchor, or heading changes — no redirects needed.

Closes [NAN-5653](https://linear.app/nango/issue/NAN-5653/update-800-references-in-docs)
Closes [NAN-5654](https://linear.app/nango/issue/NAN-5654/update-800-references-in-github-readme)

## Test plan
- [x] Mintlify preview renders the sidebar group as "800+ APIs & Integrations" and the integrations overview / quickstart / auth guide pages show the new count.
- [x] `grep -rEn "700\+" docs/ README.md` returns no matches.