### PR TITLE
feat: add function execution endpoints

### DIFF
--- a/docs/docs.json
+++ b/docs/docs.json
@@ -786,6 +786,9 @@
                       {
                         "group": "Functions",
                         "pages": [
+                          "reference/backend/http-api/functions/compile",
+                          "reference/backend/http-api/functions/dryrun",
+                          "reference/backend/http-api/functions/deployments",
                           "reference/backend/http-api/scripts/config"
                         ]
                       },

--- a/docs/docs.json
+++ b/docs/docs.json
@@ -787,7 +787,8 @@
                         "group": "Functions",
                         "pages": [
                           "reference/backend/http-api/functions/compile",
-                          "reference/backend/http-api/functions/dryrun",
+                          "reference/backend/http-api/functions/dryruns-create",
+                          "reference/backend/http-api/functions/dryruns-get",
                           "reference/backend/http-api/functions/deployments",
                           "reference/backend/http-api/scripts/config"
                         ]

--- a/docs/reference/backend/http-api/functions/compile.mdx
+++ b/docs/reference/backend/http-api/functions/compile.mdx
@@ -1,0 +1,10 @@
+---
+title: 'Compile a function'
+openapi: 'POST /functions/compile'
+---
+
+<Info>
+  Requires an API key with the `environment:deploy` scope. [Learn more about API key scopes](/reference/backend/http-api/api-keys#scopes).
+</Info>
+
+Compiles TypeScript function source code and returns the bundled JavaScript.

--- a/docs/reference/backend/http-api/functions/deployments.mdx
+++ b/docs/reference/backend/http-api/functions/deployments.mdx
@@ -1,0 +1,10 @@
+---
+title: 'Create a function deployment'
+openapi: 'POST /functions/deployments'
+---
+
+<Info>
+  Requires an API key with the `environment:deploy` scope. [Learn more about API key scopes](/reference/backend/http-api/api-keys#scopes).
+</Info>
+
+Deploys TypeScript function source code to an existing integration.

--- a/docs/reference/backend/http-api/functions/dryrun.mdx
+++ b/docs/reference/backend/http-api/functions/dryrun.mdx
@@ -1,0 +1,10 @@
+---
+title: 'Dry run a function'
+openapi: 'POST /functions/dryrun'
+---
+
+<Info>
+  Requires an API key with the `environment:dryrun` scope. [Learn more about API key scopes](/reference/backend/http-api/api-keys#scopes).
+</Info>
+
+Compiles and executes TypeScript function source code against a connection without deploying it.

--- a/docs/reference/backend/http-api/functions/dryruns-create.mdx
+++ b/docs/reference/backend/http-api/functions/dryruns-create.mdx
@@ -1,0 +1,10 @@
+---
+title: 'Create a function dry run'
+openapi: 'POST /functions/dryruns'
+---
+
+<Info>
+  Requires an API key with the `environment:dryrun` scope. [Learn more about API key scopes](/reference/backend/http-api/api-keys#scopes).
+</Info>
+
+Starts an asynchronous dry run for TypeScript function source code against a connection without deploying it.

--- a/docs/reference/backend/http-api/functions/dryruns-get.mdx
+++ b/docs/reference/backend/http-api/functions/dryruns-get.mdx
@@ -1,10 +1,10 @@
 ---
-title: 'Dry run a function'
-openapi: 'POST /functions/dryrun'
+title: 'Get a function dry run'
+openapi: 'GET /functions/dryruns/{id}'
 ---
 
 <Info>
   Requires an API key with the `environment:dryrun` scope. [Learn more about API key scopes](/reference/backend/http-api/api-keys#scopes).
 </Info>
 
-Compiles and executes TypeScript function source code against a connection without deploying it.
+Returns the status and result of an asynchronous function dry run.

--- a/docs/spec.yaml
+++ b/docs/spec.yaml
@@ -1432,6 +1432,97 @@ paths:
                 '401':
                     $ref: '#/components/responses/Unauthorized'
 
+    /functions/compile:
+        post:
+            operationId: compileFunction
+            summary: Compile a function
+            description: Compiles TypeScript function source code and returns the bundled JavaScript.
+            requestBody:
+                required: true
+                content:
+                    application/json:
+                        schema:
+                            $ref: '#/components/schemas/FunctionCompileRequest'
+            responses:
+                '200':
+                    description: Successfully compiled the function.
+                    content:
+                        application/json:
+                            schema:
+                                $ref: '#/components/schemas/FunctionCompileResponse'
+                '400':
+                    $ref: '#/components/responses/BadRequest'
+                '401':
+                    $ref: '#/components/responses/Unauthorized'
+                '403':
+                    $ref: '#/components/responses/Forbidden'
+                '500':
+                    $ref: '#/components/responses/ServerError'
+                '504':
+                    $ref: '#/components/responses/GatewayTimeout'
+
+    /functions/dryrun:
+        post:
+            operationId: dryrunFunction
+            summary: Dry run a function
+            description: Compiles and executes TypeScript function source code against a connection without deploying it.
+            requestBody:
+                required: true
+                content:
+                    application/json:
+                        schema:
+                            $ref: '#/components/schemas/FunctionDryrunRequest'
+            responses:
+                '200':
+                    description: Successfully completed the dry run.
+                    content:
+                        application/json:
+                            schema:
+                                $ref: '#/components/schemas/FunctionDryrunResponse'
+                '400':
+                    $ref: '#/components/responses/BadRequest'
+                '401':
+                    $ref: '#/components/responses/Unauthorized'
+                '403':
+                    $ref: '#/components/responses/Forbidden'
+                '404':
+                    $ref: '#/components/responses/NotFound'
+                '500':
+                    $ref: '#/components/responses/ServerError'
+                '504':
+                    $ref: '#/components/responses/GatewayTimeout'
+
+    /functions/deployments:
+        post:
+            operationId: createFunctionDeployment
+            summary: Create a function deployment
+            description: Deploys TypeScript function source code to an existing integration.
+            requestBody:
+                required: true
+                content:
+                    application/json:
+                        schema:
+                            $ref: '#/components/schemas/FunctionDeploymentRequest'
+            responses:
+                '200':
+                    description: Successfully deployed the function.
+                    content:
+                        application/json:
+                            schema:
+                                $ref: '#/components/schemas/FunctionDeployResponse'
+                '400':
+                    $ref: '#/components/responses/BadRequest'
+                '401':
+                    $ref: '#/components/responses/Unauthorized'
+                '403':
+                    $ref: '#/components/responses/Forbidden'
+                '404':
+                    $ref: '#/components/responses/NotFound'
+                '500':
+                    $ref: '#/components/responses/ServerError'
+                '504':
+                    $ref: '#/components/responses/GatewayTimeout'
+
     /records:
         get:
             summary: Get synced records
@@ -2767,6 +2858,24 @@ components:
                 application/json:
                     schema:
                         $ref: '#/components/schemas/StdError'
+        Forbidden:
+            description: Forbidden
+            content:
+                application/json:
+                    schema:
+                        $ref: '#/components/schemas/StdError'
+        ServerError:
+            description: Server error
+            content:
+                application/json:
+                    schema:
+                        $ref: '#/components/schemas/StdError'
+        GatewayTimeout:
+            description: Gateway timeout
+            content:
+                application/json:
+                    schema:
+                        $ref: '#/components/schemas/StdError'
 
     schemas:
         StdError:
@@ -2787,6 +2896,170 @@ components:
                             type: array
                             items:
                                 type: object
+
+        RunnableFunctionType:
+            type: string
+            enum: [action, sync]
+
+        FunctionCompileRequest:
+            type: object
+            additionalProperties: false
+            required:
+                - code
+            properties:
+                code:
+                    type: string
+                    minLength: 1
+                    description: The TypeScript source code for the function.
+
+        FunctionCompileResponse:
+            type: object
+            additionalProperties: false
+            required:
+                - bundle_size_bytes
+                - bundled_js
+                - compiled_at
+            properties:
+                bundle_size_bytes:
+                    type: integer
+                    minimum: 0
+                bundled_js:
+                    type: string
+                    description: The bundled JavaScript output.
+                compiled_at:
+                    type: string
+                    format: date-time
+
+        FunctionDryrunRequest:
+            type: object
+            additionalProperties: false
+            required:
+                - integration_id
+                - function_type
+                - code
+                - connection_id
+            properties:
+                integration_id:
+                    type: string
+                    description: The integration ID (unique_key) that you created in Nango.
+                function_type:
+                    $ref: '#/components/schemas/RunnableFunctionType'
+                code:
+                    type: string
+                    minLength: 1
+                    description: The TypeScript source code for the function.
+                connection_id:
+                    type: string
+                    description: The connection ID to use for the dry run.
+                input:
+                    description: Optional JSON input payload passed to the function.
+                metadata:
+                    type: object
+                    additionalProperties: true
+                    description: Optional metadata available to the function during the dry run.
+                checkpoint:
+                    type: object
+                    additionalProperties: true
+                    description: Optional checkpoint payload available to sync functions during the dry run.
+                last_sync_date:
+                    type: string
+                    format: date-time
+                    description: Optional last sync date available to sync functions during the dry run.
+
+        FunctionDryrunResponse:
+            type: object
+            additionalProperties: false
+            required:
+                - integration_id
+                - function_type
+                - execution_timeout_at
+                - duration_ms
+                - output
+            properties:
+                integration_id:
+                    type: string
+                function_type:
+                    $ref: '#/components/schemas/RunnableFunctionType'
+                execution_timeout_at:
+                    type: string
+                    format: date-time
+                duration_ms:
+                    type: integer
+                    minimum: 0
+                output:
+                    type: string
+                    description: Dry run command output.
+                result:
+                    description: The function result, when the dry run emits one.
+
+        FunctionDeploymentRequest:
+            type: object
+            additionalProperties: false
+            required:
+                - type
+                - integration_id
+                - function_name
+                - function_type
+                - code
+            properties:
+                type:
+                    type: string
+                    enum: [single]
+                    description: Deploy a single submitted function.
+                integration_id:
+                    type: string
+                    description: The integration ID (unique_key) that you created in Nango.
+                function_name:
+                    type: string
+                    description: The sync or action function name.
+                function_type:
+                    $ref: '#/components/schemas/RunnableFunctionType'
+                code:
+                    type: string
+                    minLength: 1
+                    description: The TypeScript source code for the function.
+                version:
+                    type: string
+                    description: Optional version tag for this deployment.
+                allow_destructive:
+                    type: boolean
+                    description: Allow overwriting existing non-standalone functions with the same name.
+
+        FunctionDeployResponse:
+            type: object
+            additionalProperties: false
+            required:
+                - integration_id
+                - function_name
+                - function_type
+                - deployed
+                - deployed_functions
+                - output
+            properties:
+                integration_id:
+                    type: string
+                function_name:
+                    type: string
+                function_type:
+                    $ref: '#/components/schemas/RunnableFunctionType'
+                deployed:
+                    type: boolean
+                deployed_functions:
+                    type: array
+                    items:
+                        type: object
+                        additionalProperties: false
+                        required:
+                            - name
+                            - version
+                        properties:
+                            name:
+                                type: string
+                            version:
+                                type: string
+                output:
+                    type: string
+                    description: Deployment command output.
 
         TokenUrlObject:
             properties:

--- a/docs/spec.yaml
+++ b/docs/spec.yaml
@@ -1461,11 +1461,11 @@ paths:
                 '504':
                     $ref: '#/components/responses/GatewayTimeout'
 
-    /functions/dryrun:
+    /functions/dryruns:
         post:
-            operationId: dryrunFunction
-            summary: Dry run a function
-            description: Compiles and executes TypeScript function source code against a connection without deploying it.
+            operationId: createFunctionDryrun
+            summary: Create a function dry run
+            description: Starts an asynchronous dry run for TypeScript function source code against a connection without deploying it.
             requestBody:
                 required: true
                 content:
@@ -1473,12 +1473,12 @@ paths:
                         schema:
                             $ref: '#/components/schemas/FunctionDryrunRequest'
             responses:
-                '200':
-                    description: Successfully completed the dry run.
+                '202':
+                    description: Successfully started the dry run.
                     content:
                         application/json:
                             schema:
-                                $ref: '#/components/schemas/FunctionDryrunResponse'
+                                $ref: '#/components/schemas/FunctionDryrunCreateResponse'
                 '400':
                     $ref: '#/components/responses/BadRequest'
                 '401':
@@ -1491,6 +1491,34 @@ paths:
                     $ref: '#/components/responses/ServerError'
                 '504':
                     $ref: '#/components/responses/GatewayTimeout'
+
+    /functions/dryruns/{id}:
+        get:
+            operationId: getFunctionDryrun
+            summary: Get a function dry run
+            description: Returns the status and result of an asynchronous function dry run.
+            parameters:
+                - name: id
+                  in: path
+                  required: true
+                  schema:
+                      type: string
+                      format: uuid
+            responses:
+                '200':
+                    description: Successfully retrieved the dry run.
+                    content:
+                        application/json:
+                            schema:
+                                $ref: '#/components/schemas/FunctionDryrunResponse'
+                '400':
+                    $ref: '#/components/responses/BadRequest'
+                '401':
+                    $ref: '#/components/responses/Unauthorized'
+                '403':
+                    $ref: '#/components/responses/Forbidden'
+                '404':
+                    $ref: '#/components/responses/NotFound'
 
     /functions/deployments:
         post:
@@ -2966,20 +2994,69 @@ components:
                     format: date-time
                     description: Optional last sync date available to sync functions during the dry run.
 
+        FunctionDryrunStatus:
+            type: string
+            enum: [pending, running, succeeded, failed]
+
+        FunctionDryrunCreateResponse:
+            type: object
+            additionalProperties: false
+            required:
+                - id
+                - status
+                - status_url
+                - created_at
+            properties:
+                id:
+                    type: string
+                    format: uuid
+                status:
+                    type: string
+                    enum: [pending, running]
+                status_url:
+                    type: string
+                created_at:
+                    type: string
+                    format: date-time
+                execution_timeout_at:
+                    type: string
+                    format: date-time
+
         FunctionDryrunResponse:
             type: object
             additionalProperties: false
             required:
+                - id
+                - status
                 - integration_id
                 - function_type
-                - execution_timeout_at
-                - duration_ms
-                - output
+                - status_url
+                - created_at
+                - updated_at
             properties:
+                id:
+                    type: string
+                    format: uuid
+                status:
+                    $ref: '#/components/schemas/FunctionDryrunStatus'
                 integration_id:
                     type: string
                 function_type:
                     $ref: '#/components/schemas/RunnableFunctionType'
+                status_url:
+                    type: string
+                created_at:
+                    type: string
+                    format: date-time
+                updated_at:
+                    type: string
+                    format: date-time
+                started_at:
+                    type: string
+                    format: date-time
+                completed_at:
+                    type: string
+                    format: date-time
                 execution_timeout_at:
                     type: string
                     format: date-time
@@ -2991,6 +3068,16 @@ components:
                     description: Dry run command output.
                 result:
                     description: The function result, when the dry run emits one.
+                error:
+                    type: object
+                    additionalProperties: false
+                    properties:
+                        code:
+                            type: string
+                        message:
+                            type: string
+                        payload:
+                            description: Optional error payload.
 
         FunctionDeploymentRequest:
             type: object

--- a/package-lock.json
+++ b/package-lock.json
@@ -31447,54 +31447,6 @@
             "dev": true,
             "license": "MIT"
         },
-        "node_modules/styled-components/node_modules/nanoid": {
-            "version": "3.3.11",
-            "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.11.tgz",
-            "integrity": "sha512-N8SpfPUnUp1bK+PMYW8qSWdl9U+wwNWI4QKxOYDy9JAro3WMX7p2OeVRF9v+347pnakNevPmiHhNmZ2HbFA76w==",
-            "dev": true,
-            "funding": [
-                {
-                    "type": "github",
-                    "url": "https://github.com/sponsors/ai"
-                }
-            ],
-            "license": "MIT",
-            "bin": {
-                "nanoid": "bin/nanoid.cjs"
-            },
-            "engines": {
-                "node": "^10 || ^12 || ^13.7 || ^14 || >=15.0.1"
-            }
-        },
-        "node_modules/styled-components/node_modules/postcss": {
-            "version": "8.4.49",
-            "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.4.49.tgz",
-            "integrity": "sha512-OCVPnIObs4N29kxTjzLfUryOkvZEq+pf8jTF0lg8E7uETuWHA+v7j3c/xJmiqpX450191LlmZfUKkXxkTry7nA==",
-            "dev": true,
-            "funding": [
-                {
-                    "type": "opencollective",
-                    "url": "https://opencollective.com/postcss/"
-                },
-                {
-                    "type": "tidelift",
-                    "url": "https://tidelift.com/funding/github/npm/postcss"
-                },
-                {
-                    "type": "github",
-                    "url": "https://github.com/sponsors/ai"
-                }
-            ],
-            "license": "MIT",
-            "dependencies": {
-                "nanoid": "^3.3.7",
-                "picocolors": "^1.1.1",
-                "source-map-js": "^1.2.1"
-            },
-            "engines": {
-                "node": "^10 || ^12 || >=14"
-            }
-        },
         "node_modules/styled-components/node_modules/stylis": {
             "version": "4.3.6",
             "resolved": "https://registry.npmjs.org/stylis/-/stylis-4.3.6.tgz",

--- a/package-lock.json
+++ b/package-lock.json
@@ -35611,6 +35611,7 @@
                 "@nangohq/webhooks": "file:../webhooks",
                 "axios": "1.15.2",
                 "dd-trace": "5.52.0",
+                "e2b": "2.18.0",
                 "express": "5.1.0",
                 "get-port": "7.1.0",
                 "rate-limiter-flexible": "5.0.3",

--- a/packages/database/lib/migrations/20260519120000_create_function_dryruns.cjs
+++ b/packages/database/lib/migrations/20260519120000_create_function_dryruns.cjs
@@ -1,0 +1,42 @@
+exports.config = { transaction: false };
+
+const table = 'function_dryruns';
+
+/**
+ * @param {import('knex').Knex} knex
+ */
+exports.up = async function (knex) {
+    await knex.schema.raw(`
+        CREATE TABLE IF NOT EXISTS ${table} (
+            id UUID PRIMARY KEY DEFAULT uuid_generate_v4(),
+            environment_id INTEGER NOT NULL REFERENCES _nango_environments(id) ON DELETE CASCADE,
+            request JSONB NOT NULL,
+            status TEXT NOT NULL CHECK (status IN ('pending', 'running', 'succeeded', 'failed')),
+            sandbox_id TEXT,
+            output TEXT,
+            result JSONB,
+            has_result BOOLEAN NOT NULL DEFAULT FALSE,
+            error JSONB,
+            duration_ms INTEGER,
+            execution_timeout_at TIMESTAMP WITH TIME ZONE,
+            started_at TIMESTAMP WITH TIME ZONE,
+            completed_at TIMESTAMP WITH TIME ZONE,
+            created_at TIMESTAMP WITH TIME ZONE NOT NULL DEFAULT now(),
+            updated_at TIMESTAMP WITH TIME ZONE NOT NULL DEFAULT now()
+        );
+
+        CREATE INDEX IF NOT EXISTS function_dryruns_environment_id_id_idx
+            ON ${table} (environment_id, id);
+
+        CREATE INDEX IF NOT EXISTS function_dryruns_running_timeout_idx
+            ON ${table} (execution_timeout_at)
+            WHERE status = 'running' AND execution_timeout_at IS NOT NULL;
+    `);
+};
+
+/**
+ * @param {import('knex').Knex} knex
+ */
+exports.down = async function (knex) {
+    await knex.schema.raw(`DROP TABLE IF EXISTS ${table};`);
+};

--- a/packages/jobs/lib/execution/functions/dryrun.ts
+++ b/packages/jobs/lib/execution/functions/dryrun.ts
@@ -1,0 +1,301 @@
+import { randomUUID } from 'node:crypto';
+
+import { Sandbox } from 'e2b';
+import { z } from 'zod';
+
+import db from '@nangohq/database';
+import {
+    customerKeyService,
+    environmentService,
+    getApiUrl,
+    getFunctionDryrunRow,
+    internalFunctionDryrunActionName,
+    markFunctionDryrunFailed,
+    markFunctionDryrunRunning
+} from '@nangohq/shared';
+import { Err, Ok, stringifyError } from '@nangohq/utils';
+
+import { envs } from '../../env.js';
+
+import type { TaskAction } from '@nangohq/nango-orchestrator';
+import type { FunctionDryrunError, FunctionDryrunStoredRequest } from '@nangohq/shared';
+import type { Result } from '@nangohq/utils';
+
+const projectPath = '/home/user/nango-integrations';
+const compileTimeoutMs = 3 * 60 * 1000;
+const dryrunTimeoutMs = 5 * 60 * 1000;
+const sandboxTimeoutBufferMs = 30 * 1000;
+const sandboxTokenTimeoutBufferMs = 60 * 1000;
+const dryrunSandboxTimeoutMs = compileTimeoutMs + dryrunTimeoutMs + sandboxTimeoutBufferMs;
+
+const internalDryrunInputSchema = z
+    .object({
+        dryrunId: z.string().uuid(),
+        parentCustomerKeyId: z.number().int().positive()
+    })
+    .strict();
+
+export function isInternalFunctionDryrunAction(task: TaskAction): boolean {
+    return task.actionName === internalFunctionDryrunActionName;
+}
+
+export async function startInternalFunctionDryrun(task: TaskAction): Promise<Result<void>> {
+    const input = internalDryrunInputSchema.safeParse(task.input);
+    if (!input.success) {
+        return Err(`Invalid internal function dryrun input: ${input.error.message}`);
+    }
+
+    const environmentId = task.connection.environment_id;
+    const dryrun = await getFunctionDryrunRow({ environmentId, id: input.data.dryrunId });
+    if (!dryrun) {
+        return Err(`Function dryrun '${input.data.dryrunId}' was not found`);
+    }
+
+    if (dryrun.status !== 'pending') {
+        return Ok(undefined);
+    }
+
+    const fail = async (error: FunctionDryrunError): Promise<Result<void>> => {
+        await markFunctionDryrunFailed({
+            environmentId,
+            id: dryrun.id,
+            error,
+            statuses: ['pending']
+        });
+        return Err(error.message);
+    };
+
+    const environment = await environmentService.getById(environmentId);
+    if (!environment) {
+        return fail({ code: 'dryrun_error', message: `Environment '${environmentId}' was not found` });
+    }
+
+    const sandboxApiKey = await customerKeyService.createSandboxApiKey(db.knex, {
+        parentApiKeyId: input.data.parentCustomerKeyId,
+        environmentId,
+        expiresAt: new Date(Date.now() + dryrunSandboxTimeoutMs + sandboxTokenTimeoutBufferMs)
+    });
+    if (sandboxApiKey.isErr()) {
+        return fail({ code: 'dryrun_error', message: stringifyError(sandboxApiKey.error) });
+    }
+
+    const apiKey = process.env['E2B_API_KEY'];
+    if (!apiKey) {
+        return fail({ code: 'dryrun_error', message: 'E2B_API_KEY is required for the E2B dryrun runtime' });
+    }
+
+    let sandbox: Sandbox | undefined;
+    try {
+        sandbox = await Sandbox.create(envs.E2B_SANDBOX_COMPILER_TEMPLATE, {
+            timeoutMs: dryrunSandboxTimeoutMs,
+            allowInternetAccess: true,
+            metadata: { purpose: 'nango-function-dryrun', dryrunId: dryrun.id, requestId: randomUUID() },
+            network: { allowPublicTraffic: true },
+            apiKey
+        });
+
+        const request = dryrun.request;
+        const { tsFilePath } = getFilePaths(request);
+
+        await sandbox.files.write(`${projectPath}/${tsFilePath}`, request.code);
+        await sandbox.files.write(`${projectPath}/index.ts`, buildIndexTs(request));
+
+        if (request.input !== undefined) {
+            await sandbox.files.write('/tmp/nango-dryrun-input.json', JSON.stringify(request.input));
+        }
+        if (request.metadata) {
+            await sandbox.files.write('/tmp/nango-dryrun-metadata.json', JSON.stringify(request.metadata));
+        }
+        if (request.checkpoint) {
+            await sandbox.files.write('/tmp/nango-dryrun-checkpoint.json', JSON.stringify(request.checkpoint));
+        }
+
+        await sandbox.files.write('/tmp/nango-function-dryrun.mjs', buildDryrunScript());
+
+        const startedAt = new Date();
+        await sandbox.commands.run('node /tmp/nango-function-dryrun.mjs', {
+            cwd: projectPath,
+            background: true,
+            timeoutMs: 30_000,
+            envs: {
+                NO_COLOR: '1',
+                NANGO_SECRET_KEY: sandboxApiKey.value,
+                NANGO_HOSTPORT: getApiUrl(),
+                NANGO_DRYRUN_CALLBACK_URL: `${getApiUrl()}/functions/dryruns/${dryrun.id}/result`,
+                NANGO_DRYRUN_ARGS: JSON.stringify(buildDryrunArgs(request, environment.name)),
+                NANGO_DRYRUN_COMPILE_TIMEOUT_MS: String(compileTimeoutMs),
+                NANGO_DRYRUN_TIMEOUT_MS: String(dryrunTimeoutMs)
+            }
+        });
+
+        const marked = await markFunctionDryrunRunning({
+            environmentId,
+            id: dryrun.id,
+            sandboxId: sandbox.sandboxId,
+            startedAt,
+            executionTimeoutAt: new Date(startedAt.getTime() + dryrunSandboxTimeoutMs)
+        });
+
+        if (!marked) {
+            await sandbox.kill().catch(() => undefined);
+            return Ok(undefined);
+        }
+
+        return Ok(undefined);
+    } catch (err) {
+        await sandbox?.kill().catch(() => undefined);
+        return fail({ code: 'dryrun_error', message: stringifyError(err) });
+    }
+}
+
+function getFilePaths(request: Pick<FunctionDryrunStoredRequest, 'integration_id' | 'function_name' | 'function_type'>): { tsFilePath: string } {
+    const folder = request.function_type === 'action' ? 'actions' : 'syncs';
+    return { tsFilePath: `${request.integration_id}/${folder}/${request.function_name}.ts` };
+}
+
+function buildIndexTs(request: Pick<FunctionDryrunStoredRequest, 'integration_id' | 'function_name' | 'function_type'>): string {
+    const folder = request.function_type === 'action' ? 'actions' : 'syncs';
+    return `import './${request.integration_id}/${folder}/${request.function_name}.js';\n`;
+}
+
+function buildDryrunArgs(request: FunctionDryrunStoredRequest, environmentName: string): string[] {
+    const args = [
+        'dryrun',
+        request.function_name,
+        request.connection_id,
+        '--environment',
+        environmentName,
+        '--integration-id',
+        request.integration_id,
+        '--auto-confirm',
+        '--no-interactive'
+    ];
+
+    if (request.input !== undefined) {
+        args.push('--input', '@/tmp/nango-dryrun-input.json');
+    }
+    if (request.metadata) {
+        args.push('--metadata', '@/tmp/nango-dryrun-metadata.json');
+    }
+    if (request.checkpoint) {
+        args.push('--checkpoint', '@/tmp/nango-dryrun-checkpoint.json');
+    }
+    if (request.last_sync_date) {
+        args.push('--lastSyncDate', request.last_sync_date);
+    }
+
+    return args;
+}
+
+function buildDryrunScript(): string {
+    return String.raw`
+import { spawn } from 'node:child_process';
+
+const startedAt = Date.now();
+const callbackUrl = requiredEnv('NANGO_DRYRUN_CALLBACK_URL');
+const token = requiredEnv('NANGO_SECRET_KEY');
+const dryrunArgs = JSON.parse(requiredEnv('NANGO_DRYRUN_ARGS'));
+const compileTimeoutMs = Number(requiredEnv('NANGO_DRYRUN_COMPILE_TIMEOUT_MS'));
+const dryrunTimeoutMs = Number(requiredEnv('NANGO_DRYRUN_TIMEOUT_MS'));
+
+try {
+    const compile = await runCommand('nango', ['compile'], { timeoutMs: compileTimeoutMs });
+    if (compile.timedOut) {
+        await postResult({ status: 'failed', error: { code: 'timeout', message: 'Compilation timed out' } });
+        process.exit(1);
+    }
+    if (compile.exitCode !== 0) {
+        await postResult({ status: 'failed', output: commandOutput(compile), error: { code: 'compilation_error', message: commandOutput(compile) || 'Compilation failed' } });
+        process.exit(1);
+    }
+
+    const dryrun = await runCommand('nango', dryrunArgs, { timeoutMs: dryrunTimeoutMs });
+    if (dryrun.timedOut) {
+        await postResult({ status: 'failed', output: commandOutput(dryrun), error: { code: 'timeout', message: 'Dry run timed out' } });
+        process.exit(1);
+    }
+    if (dryrun.exitCode !== 0) {
+        await postResult({ status: 'failed', output: commandOutput(dryrun), error: { code: 'dryrun_error', message: commandOutput(dryrun) || 'Dry run failed' } });
+        process.exit(1);
+    }
+
+    await postResult({ status: 'succeeded', output: dryrun.stdout.trimEnd() });
+    process.exit(0);
+} catch (err) {
+    await postResult({ status: 'failed', error: { code: 'dryrun_error', message: err instanceof Error ? err.message : String(err) } }).catch(() => undefined);
+    process.exit(1);
+}
+
+function requiredEnv(name) {
+    const value = process.env[name];
+    if (!value) {
+        throw new Error('Missing ' + name);
+    }
+    return value;
+}
+
+function runCommand(command, args, { timeoutMs }) {
+    return new Promise((resolve, reject) => {
+        const child = spawn(command, args, {
+            cwd: process.cwd(),
+            env: process.env,
+            stdio: ['ignore', 'pipe', 'pipe']
+        });
+        let stdout = '';
+        let stderr = '';
+        let timedOut = false;
+        const timer = setTimeout(() => {
+            timedOut = true;
+            child.kill('SIGKILL');
+        }, timeoutMs);
+
+        child.stdout.on('data', (chunk) => {
+            stdout += chunk.toString();
+        });
+        child.stderr.on('data', (chunk) => {
+            stderr += chunk.toString();
+        });
+        child.on('error', (err) => {
+            clearTimeout(timer);
+            reject(err);
+        });
+        child.on('close', (exitCode) => {
+            clearTimeout(timer);
+            resolve({ exitCode, stdout, stderr, timedOut });
+        });
+    });
+}
+
+async function postResult(payload) {
+    const body = JSON.stringify({ ...payload, duration_ms: Date.now() - startedAt });
+    let lastError;
+    for (let attempt = 0; attempt < 5; attempt++) {
+        try {
+            const res = await fetch(callbackUrl, {
+                method: 'POST',
+                headers: {
+                    authorization: 'Bearer ' + token,
+                    'content-type': 'application/json'
+                },
+                body
+            });
+            if (res.ok) {
+                return;
+            }
+            lastError = new Error('Callback failed with status ' + res.status);
+        } catch (err) {
+            lastError = err;
+        }
+        await new Promise((resolve) => setTimeout(resolve, 500 * (attempt + 1)));
+    }
+    throw lastError;
+}
+
+function commandOutput({ stdout, stderr }) {
+    return [stdout, stderr]
+        .map((value) => value.trimEnd())
+        .filter((value, index, values) => value && values.indexOf(value) === index)
+        .join('\n');
+}
+`.trimStart();
+}

--- a/packages/jobs/lib/processor/handler.ts
+++ b/packages/jobs/lib/processor/handler.ts
@@ -3,6 +3,7 @@ import tracer from 'dd-trace';
 import { Err, Ok } from '@nangohq/utils';
 
 import { startAction } from '../execution/action.js';
+import { isInternalFunctionDryrunAction, startInternalFunctionDryrun } from '../execution/functions/dryrun.js';
 import { startOnEvent } from '../execution/onEvent.js';
 import { abortTask } from '../execution/operations/abort.js';
 import { abortSync, startSync } from '../execution/sync.js';
@@ -31,7 +32,7 @@ export async function handler(task: OrchestratorTask): Promise<Result<void>> {
     if (task.isAction()) {
         const span = tracer.startSpan('jobs.handler.action');
         return await tracer.scope().activate(span, async () => {
-            const res = await startAction(task);
+            const res = isInternalFunctionDryrunAction(task) ? await startInternalFunctionDryrun(task) : await startAction(task);
             span.finish();
             return res;
         });

--- a/packages/jobs/package.json
+++ b/packages/jobs/package.json
@@ -36,6 +36,7 @@
         "@nangohq/webhooks": "file:../webhooks",
         "axios": "1.15.2",
         "dd-trace": "5.52.0",
+        "e2b": "2.18.0",
         "express": "5.1.0",
         "get-port": "7.1.0",
         "rate-limiter-flexible": "5.0.3",

--- a/packages/server/lib/controllers/functions/compile/postCompile.ts
+++ b/packages/server/lib/controllers/functions/compile/postCompile.ts
@@ -4,9 +4,13 @@ import { requireEmptyQuery, zodErrorToHTTP } from '@nangohq/utils';
 import { invokeCompiler } from '../../../services/remote-function/compiler-client.js';
 import { RemoteFunctionError, sendStepError } from '../../../services/remote-function/helpers.js';
 import { asyncWrapper } from '../../../utils/asyncWrapper.js';
-import { remoteFunctionCompileBodySchema } from '../validation.js';
+import { functionCompileBodySchema, remoteFunctionCompileBodySchema } from '../validation.js';
 
-import type { PostRemoteFunctionCompile } from '@nangohq/types';
+import type { PostFunctionCompile, PostRemoteFunctionCompile } from '@nangohq/types';
+
+const defaultFunctionIntegrationId = 'function';
+const defaultFunctionName = 'function';
+const defaultFunctionType = 'action';
 
 export const postRemoteFunctionCompile = asyncWrapper<PostRemoteFunctionCompile>(async (req, res) => {
     const emptyQuery = requireEmptyQuery(req);
@@ -42,6 +46,43 @@ export const postRemoteFunctionCompile = asyncWrapper<PostRemoteFunctionCompile>
             integration_id: body.integration_id,
             function_name: body.function_name,
             function_type: body.function_type,
+            bundle_size_bytes: result.bundleSizeBytes,
+            bundled_js: result.bundledJs,
+            compiled_at: new Date().toISOString()
+        });
+    } catch (err) {
+        sendStepError({
+            res,
+            error: err,
+            ...(err instanceof RemoteFunctionError ? {} : { status: 500 })
+        });
+    }
+});
+
+export const postFunctionCompile = asyncWrapper<PostFunctionCompile>(async (req, res) => {
+    const emptyQuery = requireEmptyQuery(req);
+    if (emptyQuery) {
+        res.status(400).send({ error: { code: 'invalid_query_params', errors: zodErrorToHTTP(emptyQuery.error) } });
+        return;
+    }
+
+    const valBody = functionCompileBodySchema.safeParse(req.body);
+    if (!valBody.success) {
+        res.status(400).send({ error: { code: 'invalid_body', errors: zodErrorToHTTP(valBody.error) } });
+        return;
+    }
+
+    const body = valBody.data;
+
+    try {
+        const result = await invokeCompiler({
+            integration_id: defaultFunctionIntegrationId,
+            function_name: defaultFunctionName,
+            function_type: defaultFunctionType,
+            code: body.code
+        });
+
+        res.status(200).send({
             bundle_size_bytes: result.bundleSizeBytes,
             bundled_js: result.bundledJs,
             compiled_at: new Date().toISOString()

--- a/packages/server/lib/controllers/functions/deploy/postDeploy.ts
+++ b/packages/server/lib/controllers/functions/deploy/postDeploy.ts
@@ -7,11 +7,31 @@ import { invokeDeploy } from '../../../services/remote-function/deploy-client.js
 import { RemoteFunctionError, sendStepError } from '../../../services/remote-function/helpers.js';
 import { getRemoteFunctionNangoHost, remoteFunctionDeploySandboxTimeoutMs } from '../../../services/remote-function/runtime.js';
 import { asyncWrapper } from '../../../utils/asyncWrapper.js';
-import { remoteFunctionDeployBodySchema } from '../validation.js';
+import { functionDeploymentBodySchema, remoteFunctionDeployBodySchema } from '../validation.js';
 
-import type { PostRemoteFunctionDeploy } from '@nangohq/types';
+import type { PostFunctionDeployment, PostRemoteFunctionDeploy } from '@nangohq/types';
+import type { Response } from 'express';
 
 const sandboxApiKeyTimeoutBufferMs = 60 * 1000;
+
+async function createDeploySandboxApiKey(res: Response, environmentId: number): Promise<string | null> {
+    if (res.locals['apiKeyAuthSource'] !== 'customer_key' || !res.locals['apiKeyId']) {
+        res.status(403).send({ error: { code: 'forbidden', message: 'Sandbox tokens can only be issued from a customer API key' } });
+        return null;
+    }
+
+    const sandboxApiKey = await customerKeyService.createSandboxApiKey(db.knex, {
+        parentApiKeyId: res.locals['apiKeyId'],
+        environmentId,
+        expiresAt: new Date(Date.now() + remoteFunctionDeploySandboxTimeoutMs + sandboxApiKeyTimeoutBufferMs)
+    });
+    if (sandboxApiKey.isErr()) {
+        sendStepError({ res, status: 500, error: sandboxApiKey.error });
+        return null;
+    }
+
+    return sandboxApiKey.value;
+}
 
 export const postRemoteFunctionDeploy = asyncWrapper<PostRemoteFunctionDeploy>(async (req, res) => {
     const emptyQuery = requireEmptyQuery(req);
@@ -52,18 +72,8 @@ export const postRemoteFunctionDeploy = asyncWrapper<PostRemoteFunctionDeploy>(a
         return;
     }
 
-    if (res.locals.apiKeyAuthSource !== 'customer_key' || !res.locals.apiKeyId) {
-        res.status(403).send({ error: { code: 'forbidden', message: 'Sandbox tokens can only be issued from a customer API key' } });
-        return;
-    }
-
-    const sandboxApiKey = await customerKeyService.createSandboxApiKey(db.knex, {
-        parentApiKeyId: res.locals.apiKeyId,
-        environmentId: environment.id,
-        expiresAt: new Date(Date.now() + remoteFunctionDeploySandboxTimeoutMs + sandboxApiKeyTimeoutBufferMs)
-    });
-    if (sandboxApiKey.isErr()) {
-        sendStepError({ res, status: 500, error: sandboxApiKey.error });
+    const sandboxApiKey = await createDeploySandboxApiKey(res, environment.id);
+    if (!sandboxApiKey) {
         return;
     }
 
@@ -74,8 +84,80 @@ export const postRemoteFunctionDeploy = asyncWrapper<PostRemoteFunctionDeploy>(a
             function_type: body.function_type,
             code: body.code,
             environment_name: environment.name,
-            nango_secret_key: sandboxApiKey.value,
-            nango_host: getRemoteFunctionNangoHost()
+            nango_secret_key: sandboxApiKey,
+            nango_host: getRemoteFunctionNangoHost(),
+            allow_destructive: true
+        });
+        const output = parseDeploySuccessOutput(result.output);
+
+        res.status(200).send({
+            integration_id: body.integration_id,
+            function_name: body.function_name,
+            function_type: body.function_type,
+            deployed: output.deployed,
+            deployed_functions: output.deployedFunctions,
+            output: output.output
+        });
+    } catch (err) {
+        sendStepError({ res, error: err, ...(err instanceof RemoteFunctionError ? {} : { status: 500 }) });
+    }
+});
+
+export const postFunctionDeployment = asyncWrapper<PostFunctionDeployment>(async (req, res) => {
+    const emptyQuery = requireEmptyQuery(req);
+    if (emptyQuery) {
+        res.status(400).send({ error: { code: 'invalid_query_params', errors: zodErrorToHTTP(emptyQuery.error) } });
+        return;
+    }
+
+    const valBody = functionDeploymentBodySchema.safeParse(req.body);
+    if (!valBody.success) {
+        res.status(400).send({ error: { code: 'invalid_body', errors: zodErrorToHTTP(valBody.error) } });
+        return;
+    }
+
+    const body = valBody.data;
+    const { environment } = res.locals;
+
+    const providerConfig = await configService.getProviderConfig(body.integration_id, environment.id);
+    if (!providerConfig || !providerConfig.id) {
+        res.status(404).send({ error: { code: 'integration_not_found', message: `Integration '${body.integration_id}' was not found` } });
+        return;
+    }
+
+    const existingSyncConfig = await getSyncConfigRaw({
+        environmentId: environment.id,
+        config_id: providerConfig.id,
+        name: body.function_name,
+        isAction: body.function_type === 'action'
+    });
+
+    if (existingSyncConfig && existingSyncConfig.source !== 'standalone' && !body.allow_destructive) {
+        res.status(400).send({
+            error: {
+                code: 'invalid_request',
+                message: `Cannot overwrite existing function '${body.function_name}'`
+            }
+        });
+        return;
+    }
+
+    const sandboxApiKey = await createDeploySandboxApiKey(res, environment.id);
+    if (!sandboxApiKey) {
+        return;
+    }
+
+    try {
+        const result = await invokeDeploy({
+            integration_id: body.integration_id,
+            function_name: body.function_name,
+            function_type: body.function_type,
+            code: body.code,
+            environment_name: environment.name,
+            nango_secret_key: sandboxApiKey,
+            nango_host: getRemoteFunctionNangoHost(),
+            ...(body.version ? { version: body.version } : {}),
+            ...(body.allow_destructive ? { allow_destructive: true } : {})
         });
         const output = parseDeploySuccessOutput(result.output);
 

--- a/packages/server/lib/controllers/functions/dryrun/postDryrun.ts
+++ b/packages/server/lib/controllers/functions/dryrun/postDryrun.ts
@@ -1,5 +1,17 @@
+import { z } from 'zod';
+
 import db from '@nangohq/database';
-import { configService, connectionService, customerKeyService } from '@nangohq/shared';
+import {
+    configService,
+    connectionService,
+    createFunctionDryrun,
+    customerKeyService,
+    getFunctionDryrun as getStoredFunctionDryrun,
+    getFunctionDryrunRow,
+    internalFunctionDryrunActionName,
+    markFunctionDryrunFailed,
+    markFunctionDryrunSucceeded
+} from '@nangohq/shared';
 import { requireEmptyQuery, zodErrorToHTTP } from '@nangohq/utils';
 
 import { parseDryrunSuccessOutput } from '../../../services/remote-function/command-output.js';
@@ -7,32 +19,99 @@ import { invokeDryrun } from '../../../services/remote-function/dryrun-client.js
 import { RemoteFunctionError, sendStepError } from '../../../services/remote-function/helpers.js';
 import { getRemoteFunctionNangoHost, remoteFunctionDryrunSandboxTimeoutMs } from '../../../services/remote-function/runtime.js';
 import { asyncWrapper } from '../../../utils/asyncWrapper.js';
+import { getOrchestratorClient } from '../../../utils/utils.js';
 import { functionDryrunBodySchema, remoteFunctionDryrunBodySchema } from '../validation.js';
 
-import type { PostFunctionDryrun, PostRemoteFunctionDryrun } from '@nangohq/types';
+import type { RequestLocals } from '../../../utils/express.js';
+import type { Endpoint, FunctionErrorCode, GetFunctionDryrun, PostFunctionDryrun, PostRemoteFunctionDryrun } from '@nangohq/types';
 import type { Response } from 'express';
 
 const defaultFunctionName = 'function';
 
 const sandboxApiKeyTimeoutBufferMs = 60 * 1000;
+const functionDryrunGroupMaxConcurrency = 0;
 
-async function createDryrunSandboxApiKey(res: Response, environmentId: number): Promise<string | null> {
+const dryrunParamsSchema = z
+    .object({
+        id: z.string().uuid()
+    })
+    .strict();
+
+const functionErrorCodes = new Set<string>([
+    'invalid_request',
+    'integration_not_found',
+    'compilation_error',
+    'dryrun_error',
+    'deployment_error',
+    'connection_not_found',
+    'dryrun_not_found',
+    'function_disabled',
+    'timeout',
+    'validation_error'
+] satisfies FunctionErrorCode[]);
+
+const functionDryrunResultBodySchema = z.discriminatedUnion('status', [
+    z
+        .object({
+            status: z.literal('succeeded'),
+            output: z.string(),
+            duration_ms: z.number().int().nonnegative().optional()
+        })
+        .strict(),
+    z
+        .object({
+            status: z.literal('failed'),
+            output: z.string().optional(),
+            duration_ms: z.number().int().nonnegative().optional(),
+            error: z
+                .object({
+                    code: z.string().optional(),
+                    message: z.string(),
+                    payload: z.unknown().optional()
+                })
+                .strict()
+        })
+        .strict()
+]);
+
+type FunctionDryrunResultBody = z.infer<typeof functionDryrunResultBodySchema>;
+
+type PostFunctionDryrunResult = Endpoint<{
+    Method: 'POST';
+    Path: '/functions/dryruns/:id/result';
+    Params: { id: string };
+    Body: FunctionDryrunResultBody;
+    Error: { error: { code: FunctionErrorCode; message: string; payload?: unknown } };
+    Success: { ok: true };
+}>;
+
+type RemoteDryrunResponse = Response<PostRemoteFunctionDryrun['Reply'], Required<RequestLocals>>;
+type FunctionDryrunResponse = Response<PostFunctionDryrun['Reply'], Required<RequestLocals>>;
+
+async function createDryrunSandboxApiKey(parentApiKeyId: number, environmentId: number) {
+    return await customerKeyService.createSandboxApiKey(db.knex, {
+        parentApiKeyId,
+        environmentId,
+        expiresAt: new Date(Date.now() + remoteFunctionDryrunSandboxTimeoutMs + sandboxApiKeyTimeoutBufferMs)
+    });
+}
+
+function getRemoteParentCustomerKeyId(res: RemoteDryrunResponse): number | null {
     if (res.locals['apiKeyAuthSource'] !== 'customer_key' || !res.locals['apiKeyId']) {
         res.status(403).send({ error: { code: 'forbidden', message: 'Sandbox tokens can only be issued from a customer API key' } });
         return null;
     }
 
-    const sandboxApiKey = await customerKeyService.createSandboxApiKey(db.knex, {
-        parentApiKeyId: res.locals['apiKeyId'],
-        environmentId,
-        expiresAt: new Date(Date.now() + remoteFunctionDryrunSandboxTimeoutMs + sandboxApiKeyTimeoutBufferMs)
-    });
-    if (sandboxApiKey.isErr()) {
-        sendStepError({ res, status: 500, error: sandboxApiKey.error });
+    return res.locals['apiKeyId'];
+}
+
+function getFunctionParentCustomerKeyId(res: FunctionDryrunResponse): number | null {
+    if (res.locals['apiKeyAuthSource'] !== 'customer_key' || !res.locals['apiKeyId']) {
+        res.status(403).send({ error: { code: 'forbidden', message: 'Function dryruns can only be started from a customer API key' } });
         return null;
     }
 
-    return sandboxApiKey.value;
+    return res.locals['apiKeyId'];
 }
 
 export const postRemoteFunctionDryrun = asyncWrapper<PostRemoteFunctionDryrun>(async (req, res) => {
@@ -61,8 +140,14 @@ export const postRemoteFunctionDryrun = asyncWrapper<PostRemoteFunctionDryrun>(a
         return;
     }
 
-    const sandboxApiKey = await createDryrunSandboxApiKey(res, environment.id);
-    if (!sandboxApiKey) {
+    const parentCustomerKeyId = getRemoteParentCustomerKeyId(res);
+    if (!parentCustomerKeyId) {
+        return;
+    }
+
+    const sandboxApiKey = await createDryrunSandboxApiKey(parentCustomerKeyId, environment.id);
+    if (sandboxApiKey.isErr()) {
+        sendStepError({ res, status: 500, error: sandboxApiKey.error });
         return;
     }
 
@@ -76,7 +161,7 @@ export const postRemoteFunctionDryrun = asyncWrapper<PostRemoteFunctionDryrun>(a
             code: body.code,
             environment_name: environment.name,
             connection_id: body.connection_id,
-            nango_secret_key: sandboxApiKey,
+            nango_secret_key: sandboxApiKey.value,
             nango_host: getRemoteFunctionNangoHost(),
             ...(body.input !== undefined ? { input: body.input } : {}),
             ...(body.metadata ? { metadata: body.metadata } : {}),
@@ -115,6 +200,10 @@ export const postFunctionDryrun = asyncWrapper<PostFunctionDryrun>(async (req, r
 
     const body = valBody.data;
     const { environment } = res.locals;
+    const parentCustomerKeyId = getFunctionParentCustomerKeyId(res);
+    if (!parentCustomerKeyId) {
+        return;
+    }
 
     const providerConfig = await configService.getProviderConfig(body.integration_id, environment.id);
     if (!providerConfig) {
@@ -132,41 +221,146 @@ export const postFunctionDryrun = asyncWrapper<PostFunctionDryrun>(async (req, r
         return;
     }
 
-    const sandboxApiKey = await createDryrunSandboxApiKey(res, environment.id);
-    if (!sandboxApiKey) {
-        return;
-    }
-
-    const startedAt = new Date();
-
-    try {
-        const result = await invokeDryrun({
+    const dryrun = await createFunctionDryrun({
+        environmentId: environment.id,
+        request: {
             integration_id: body.integration_id,
             function_name: defaultFunctionName,
             function_type: body.function_type,
             code: body.code,
-            environment_name: environment.name,
             connection_id: body.connection_id,
-            nango_secret_key: sandboxApiKey,
-            nango_host: getRemoteFunctionNangoHost(),
             ...(body.input !== undefined ? { input: body.input } : {}),
             ...(body.metadata ? { metadata: body.metadata } : {}),
             ...(body.checkpoint ? { checkpoint: body.checkpoint } : {}),
             ...(body.last_sync_date ? { last_sync_date: body.last_sync_date } : {})
-        });
+        }
+    });
 
-        const durationMs = Date.now() - startedAt.getTime();
-        const dryrunOutput = parseDryrunSuccessOutput(result.output);
+    const schedule = await getOrchestratorClient().executeActionAsync({
+        name: `function-dryrun:environment:${environment.id}:dryrun:${dryrun.id}`,
+        group: { key: `function-dryrun:environment:${environment.id}`, maxConcurrency: functionDryrunGroupMaxConcurrency },
+        retry: { count: 0, max: 0 },
+        ownerKey: `environment:${environment.id}`,
+        args: {
+            actionName: internalFunctionDryrunActionName,
+            connection: {
+                id: connectionResult.response.id,
+                connection_id: connectionResult.response.connection_id,
+                provider_config_key: connectionResult.response.provider_config_key,
+                environment_id: connectionResult.response.environment_id
+            },
+            activityLogId: dryrun.id,
+            input: {
+                dryrunId: dryrun.id,
+                parentCustomerKeyId
+            },
+            async: true
+        }
+    });
 
-        res.status(200).send({
-            integration_id: body.integration_id,
-            function_type: body.function_type,
-            execution_timeout_at: new Date(startedAt.getTime() + 5 * 60 * 1000).toISOString(),
-            duration_ms: durationMs,
-            output: dryrunOutput.output,
-            ...(dryrunOutput.hasResult ? { result: dryrunOutput.result } : {})
+    if (schedule.isErr()) {
+        await markFunctionDryrunFailed({
+            environmentId: environment.id,
+            id: dryrun.id,
+            error: {
+                code: 'dryrun_error',
+                message: schedule.error.message
+            }
         });
-    } catch (err) {
-        sendStepError({ res, error: err, ...(err instanceof RemoteFunctionError ? {} : { status: 500 }) });
+        sendStepError({ res, status: 500, error: schedule.error });
+        return;
     }
+
+    res.status(202).send(dryrun);
 });
+
+export const getFunctionDryrun = asyncWrapper<GetFunctionDryrun>(async (req, res) => {
+    const emptyQuery = requireEmptyQuery(req);
+    if (emptyQuery) {
+        res.status(400).send({ error: { code: 'invalid_query_params', errors: zodErrorToHTTP(emptyQuery.error) } });
+        return;
+    }
+
+    const valParams = dryrunParamsSchema.safeParse(req.params);
+    if (!valParams.success) {
+        res.status(400).send({ error: { code: 'invalid_uri_params', errors: zodErrorToHTTP(valParams.error) } });
+        return;
+    }
+
+    const { environment } = res.locals;
+    const dryrun = await getStoredFunctionDryrun({ environmentId: environment.id, id: valParams.data.id });
+    if (!dryrun) {
+        res.status(404).send({ error: { code: 'dryrun_not_found', message: `Dryrun '${valParams.data.id}' was not found` } });
+        return;
+    }
+
+    res.status(200).send(dryrun);
+});
+
+export const postFunctionDryrunResult = asyncWrapper<PostFunctionDryrunResult>(async (req, res) => {
+    const emptyQuery = requireEmptyQuery(req);
+    if (emptyQuery) {
+        res.status(400).send({ error: { code: 'invalid_query_params', errors: zodErrorToHTTP(emptyQuery.error) } });
+        return;
+    }
+
+    const valParams = dryrunParamsSchema.safeParse(req.params);
+    if (!valParams.success) {
+        res.status(400).send({ error: { code: 'invalid_uri_params', errors: zodErrorToHTTP(valParams.error) } });
+        return;
+    }
+
+    const valBody = functionDryrunResultBodySchema.safeParse(req.body);
+    if (!valBody.success) {
+        res.status(400).send({ error: { code: 'invalid_body', errors: zodErrorToHTTP(valBody.error) } });
+        return;
+    }
+
+    const { environment } = res.locals;
+    const current = await getFunctionDryrunRow({ environmentId: environment.id, id: valParams.data.id });
+    if (!current) {
+        res.status(404).send({ error: { code: 'dryrun_not_found', message: `Dryrun '${valParams.data.id}' was not found` } });
+        return;
+    }
+
+    if (current.status === 'succeeded' || current.status === 'failed') {
+        res.status(200).send({ ok: true });
+        return;
+    }
+
+    const body = valBody.data;
+    if (body.status === 'succeeded') {
+        const output = parseDryrunSuccessOutput(body.output);
+        await markFunctionDryrunSucceeded({
+            environmentId: environment.id,
+            id: current.id,
+            output: output.output,
+            result: output.result,
+            hasResult: output.hasResult,
+            durationMs: body.duration_ms
+        });
+    } else {
+        await markFunctionDryrunFailed({
+            environmentId: environment.id,
+            id: current.id,
+            statuses: ['running'],
+            output: body.output,
+            durationMs: body.duration_ms,
+            error: {
+                code: normalizeFunctionErrorCode(body.error.code),
+                message: body.error.message,
+                ...(body.error.payload !== undefined ? { payload: body.error.payload } : {})
+            }
+        });
+    }
+
+    res.status(200).send({ ok: true });
+});
+
+function normalizeFunctionErrorCode(code: string | undefined): FunctionErrorCode {
+    if (code && functionErrorCodes.has(code)) {
+        return code as FunctionErrorCode;
+    }
+
+    return 'dryrun_error';
+}

--- a/packages/server/lib/controllers/functions/dryrun/postDryrun.ts
+++ b/packages/server/lib/controllers/functions/dryrun/postDryrun.ts
@@ -1,5 +1,5 @@
 import db from '@nangohq/database';
-import { connectionService, customerKeyService } from '@nangohq/shared';
+import { configService, connectionService, customerKeyService } from '@nangohq/shared';
 import { requireEmptyQuery, zodErrorToHTTP } from '@nangohq/utils';
 
 import { parseDryrunSuccessOutput } from '../../../services/remote-function/command-output.js';
@@ -7,11 +7,33 @@ import { invokeDryrun } from '../../../services/remote-function/dryrun-client.js
 import { RemoteFunctionError, sendStepError } from '../../../services/remote-function/helpers.js';
 import { getRemoteFunctionNangoHost, remoteFunctionDryrunSandboxTimeoutMs } from '../../../services/remote-function/runtime.js';
 import { asyncWrapper } from '../../../utils/asyncWrapper.js';
-import { remoteFunctionDryrunBodySchema } from '../validation.js';
+import { functionDryrunBodySchema, remoteFunctionDryrunBodySchema } from '../validation.js';
 
-import type { PostRemoteFunctionDryrun } from '@nangohq/types';
+import type { PostFunctionDryrun, PostRemoteFunctionDryrun } from '@nangohq/types';
+import type { Response } from 'express';
+
+const defaultFunctionName = 'function';
 
 const sandboxApiKeyTimeoutBufferMs = 60 * 1000;
+
+async function createDryrunSandboxApiKey(res: Response, environmentId: number): Promise<string | null> {
+    if (res.locals['apiKeyAuthSource'] !== 'customer_key' || !res.locals['apiKeyId']) {
+        res.status(403).send({ error: { code: 'forbidden', message: 'Sandbox tokens can only be issued from a customer API key' } });
+        return null;
+    }
+
+    const sandboxApiKey = await customerKeyService.createSandboxApiKey(db.knex, {
+        parentApiKeyId: res.locals['apiKeyId'],
+        environmentId,
+        expiresAt: new Date(Date.now() + remoteFunctionDryrunSandboxTimeoutMs + sandboxApiKeyTimeoutBufferMs)
+    });
+    if (sandboxApiKey.isErr()) {
+        sendStepError({ res, status: 500, error: sandboxApiKey.error });
+        return null;
+    }
+
+    return sandboxApiKey.value;
+}
 
 export const postRemoteFunctionDryrun = asyncWrapper<PostRemoteFunctionDryrun>(async (req, res) => {
     const emptyQuery = requireEmptyQuery(req);
@@ -39,18 +61,8 @@ export const postRemoteFunctionDryrun = asyncWrapper<PostRemoteFunctionDryrun>(a
         return;
     }
 
-    if (res.locals.apiKeyAuthSource !== 'customer_key' || !res.locals.apiKeyId) {
-        res.status(403).send({ error: { code: 'forbidden', message: 'Sandbox tokens can only be issued from a customer API key' } });
-        return;
-    }
-
-    const sandboxApiKey = await customerKeyService.createSandboxApiKey(db.knex, {
-        parentApiKeyId: res.locals.apiKeyId,
-        environmentId: environment.id,
-        expiresAt: new Date(Date.now() + remoteFunctionDryrunSandboxTimeoutMs + sandboxApiKeyTimeoutBufferMs)
-    });
-    if (sandboxApiKey.isErr()) {
-        sendStepError({ res, status: 500, error: sandboxApiKey.error });
+    const sandboxApiKey = await createDryrunSandboxApiKey(res, environment.id);
+    if (!sandboxApiKey) {
         return;
     }
 
@@ -64,7 +76,7 @@ export const postRemoteFunctionDryrun = asyncWrapper<PostRemoteFunctionDryrun>(a
             code: body.code,
             environment_name: environment.name,
             connection_id: body.connection_id,
-            nango_secret_key: sandboxApiKey.value,
+            nango_secret_key: sandboxApiKey,
             nango_host: getRemoteFunctionNangoHost(),
             ...(body.input !== undefined ? { input: body.input } : {}),
             ...(body.metadata ? { metadata: body.metadata } : {}),
@@ -81,6 +93,77 @@ export const postRemoteFunctionDryrun = asyncWrapper<PostRemoteFunctionDryrun>(a
             function_type: body.function_type,
             execution_timeout_at: new Date(startedAt.getTime() + 5 * 60 * 1000).toISOString(),
             duration_ms: durationMs,
+            ...(dryrunOutput.hasResult ? { result: dryrunOutput.result } : {})
+        });
+    } catch (err) {
+        sendStepError({ res, error: err, ...(err instanceof RemoteFunctionError ? {} : { status: 500 }) });
+    }
+});
+
+export const postFunctionDryrun = asyncWrapper<PostFunctionDryrun>(async (req, res) => {
+    const emptyQuery = requireEmptyQuery(req);
+    if (emptyQuery) {
+        res.status(400).send({ error: { code: 'invalid_query_params', errors: zodErrorToHTTP(emptyQuery.error) } });
+        return;
+    }
+
+    const valBody = functionDryrunBodySchema.safeParse(req.body);
+    if (!valBody.success) {
+        res.status(400).send({ error: { code: 'invalid_body', errors: zodErrorToHTTP(valBody.error) } });
+        return;
+    }
+
+    const body = valBody.data;
+    const { environment } = res.locals;
+
+    const providerConfig = await configService.getProviderConfig(body.integration_id, environment.id);
+    if (!providerConfig) {
+        res.status(404).send({ error: { code: 'integration_not_found', message: `Integration '${body.integration_id}' was not found` } });
+        return;
+    }
+
+    const connectionResult = await connectionService.getConnection(body.connection_id, body.integration_id, environment.id);
+    if (!connectionResult.success || !connectionResult.response) {
+        sendStepError({
+            res,
+            status: 404,
+            error: { type: 'connection_not_found', message: `Connection '${body.connection_id}' was not found for integration '${body.integration_id}'` }
+        });
+        return;
+    }
+
+    const sandboxApiKey = await createDryrunSandboxApiKey(res, environment.id);
+    if (!sandboxApiKey) {
+        return;
+    }
+
+    const startedAt = new Date();
+
+    try {
+        const result = await invokeDryrun({
+            integration_id: body.integration_id,
+            function_name: defaultFunctionName,
+            function_type: body.function_type,
+            code: body.code,
+            environment_name: environment.name,
+            connection_id: body.connection_id,
+            nango_secret_key: sandboxApiKey,
+            nango_host: getRemoteFunctionNangoHost(),
+            ...(body.input !== undefined ? { input: body.input } : {}),
+            ...(body.metadata ? { metadata: body.metadata } : {}),
+            ...(body.checkpoint ? { checkpoint: body.checkpoint } : {}),
+            ...(body.last_sync_date ? { last_sync_date: body.last_sync_date } : {})
+        });
+
+        const durationMs = Date.now() - startedAt.getTime();
+        const dryrunOutput = parseDryrunSuccessOutput(result.output);
+
+        res.status(200).send({
+            integration_id: body.integration_id,
+            function_type: body.function_type,
+            execution_timeout_at: new Date(startedAt.getTime() + 5 * 60 * 1000).toISOString(),
+            duration_ms: durationMs,
+            output: dryrunOutput.output,
             ...(dryrunOutput.hasResult ? { result: dryrunOutput.result } : {})
         });
     } catch (err) {

--- a/packages/server/lib/controllers/functions/remote-function.integration.test.ts
+++ b/packages/server/lib/controllers/functions/remote-function.integration.test.ts
@@ -8,6 +8,7 @@ import { customerKeyService, seeders } from '@nangohq/shared';
 import { envs } from '../../env.js';
 import { isError, runServer, shouldBeProtected } from '../../utils/tests.js';
 
+import type { DBFunctionDryrun } from '@nangohq/shared';
 import type { ApiKeyScope } from '@nangohq/types';
 
 let api: Awaited<ReturnType<typeof runServer>>;
@@ -30,6 +31,45 @@ async function createApiKeyWithScopes(seed: Awaited<ReturnType<typeof seedAccoun
     });
 
     return key.unwrap();
+}
+
+async function createDryrunSeed({
+    environmentId,
+    functionType = 'sync',
+    sandboxId,
+    startedAt,
+    executionTimeoutAt
+}: {
+    environmentId: number;
+    functionType?: 'action' | 'sync';
+    sandboxId?: string | undefined;
+    startedAt?: Date | undefined;
+    executionTimeoutAt?: Date | undefined;
+}): Promise<DBFunctionDryrun> {
+    const rows = (await db
+        .knex('function_dryruns')
+        .insert({
+            environment_id: environmentId,
+            request: {
+                integration_id: 'github',
+                function_name: 'function',
+                function_type: functionType,
+                code: 'export default {}',
+                connection_id: 'conn'
+            },
+            status: 'running',
+            ...(sandboxId ? { sandbox_id: sandboxId } : {}),
+            ...(startedAt ? { started_at: startedAt } : {}),
+            ...(executionTimeoutAt ? { execution_timeout_at: executionTimeoutAt } : {})
+        })
+        .returning('*')) as DBFunctionDryrun[];
+
+    const row = rows[0];
+    if (!row) {
+        throw new Error('Failed to create dryrun seed');
+    }
+
+    return row;
 }
 
 describe('remote-function public API', () => {
@@ -118,11 +158,11 @@ describe('remote-function public API', () => {
         });
     });
 
-    it('rejects POST /functions/dryrun without dryrun scope', async () => {
+    it('rejects POST /functions/dryruns without dryrun scope', async () => {
         const seed = await seedAccountWithRemoteFunctions();
         const apiKey = await createApiKeyWithScopes(seed, ['environment:connections:read']);
 
-        const res = await api.fetch('/functions/dryrun', {
+        const res = await api.fetch('/functions/dryruns', {
             method: 'POST',
             token: apiKey.secret,
             body: {
@@ -303,11 +343,11 @@ describe('remote-function public API', () => {
         });
     });
 
-    it('returns connection_not_found on POST /functions/dryrun', async () => {
+    it('returns connection_not_found on POST /functions/dryruns', async () => {
         const { env, apiKey } = await seedAccountWithRemoteFunctions();
         await seeders.createConfigSeed(env, 'github', 'github');
 
-        const res = await api.fetch('/functions/dryrun', {
+        const res = await api.fetch('/functions/dryruns', {
             method: 'POST',
             token: apiKey.secret,
             body: {
@@ -327,10 +367,10 @@ describe('remote-function public API', () => {
         });
     });
 
-    it('returns integration_not_found on POST /functions/dryrun', async () => {
+    it('returns integration_not_found on POST /functions/dryruns', async () => {
         const { apiKey } = await seedAccountWithRemoteFunctions();
 
-        const res = await api.fetch('/functions/dryrun', {
+        const res = await api.fetch('/functions/dryruns', {
             method: 'POST',
             token: apiKey.secret,
             body: {
@@ -394,6 +434,96 @@ describe('remote-function public API', () => {
                 code: 'integration_not_found',
                 message: "Integration 'github' was not found"
             }
+        });
+    });
+
+    it('returns stored dryrun status on GET /functions/dryruns/:id', async () => {
+        const { env, apiKey } = await seedAccountWithRemoteFunctions(['environment:dryrun']);
+        const dryrun = await createDryrunSeed({
+            environmentId: env.id,
+            sandboxId: 'sandbox-id',
+            startedAt: new Date('2026-01-01T00:00:00.000Z'),
+            executionTimeoutAt: new Date('2026-01-01T00:10:00.000Z')
+        });
+
+        const res = await api.fetch('/functions/dryruns/:id', {
+            method: 'GET',
+            token: apiKey.secret,
+            params: { id: dryrun.id }
+        });
+
+        expect(res.res.status).toBe(200);
+        expect(res.json).toMatchObject({
+            id: dryrun.id,
+            status: 'running',
+            integration_id: 'github',
+            function_type: 'sync',
+            status_url: `/functions/dryruns/${dryrun.id}`,
+            started_at: '2026-01-01T00:00:00.000Z',
+            execution_timeout_at: '2026-01-01T00:10:00.000Z'
+        });
+    });
+
+    it('rejects POST /functions/dryruns/:id/result with a customer API key', async () => {
+        const { env, apiKey } = await seedAccountWithRemoteFunctions(['environment:dryrun']);
+        const dryrun = await createDryrunSeed({ environmentId: env.id, startedAt: new Date() });
+
+        const res = await fetch(`${api.url}/functions/dryruns/${dryrun.id}/result`, {
+            method: 'POST',
+            headers: {
+                authorization: `Bearer ${apiKey.secret}`,
+                'content-type': 'application/json'
+            },
+            body: JSON.stringify({ status: 'succeeded', output: 'Executing -> function\nDone\n{"ok":true}' })
+        });
+
+        const json = (await res.json()) as unknown;
+        expect(res.status).toBe(403);
+        expect(json).toStrictEqual({
+            error: {
+                code: 'forbidden',
+                message: 'This endpoint only accepts sandbox tokens'
+            }
+        });
+    });
+
+    it('accepts POST /functions/dryruns/:id/result with a sandbox token', async () => {
+        const seed = await seedAccountWithRemoteFunctions(['environment:dryrun']);
+        const apiKey = await createApiKeyWithScopes(seed, ['environment:dryrun']);
+        const sandboxToken = await customerKeyService.createSandboxApiKey(db.knex, {
+            parentApiKeyId: apiKey.id,
+            environmentId: seed.env.id,
+            expiresAt: new Date(Date.now() + 60_000)
+        });
+        const dryrun = await createDryrunSeed({ environmentId: seed.env.id, functionType: 'action', startedAt: new Date() });
+
+        const res = await fetch(`${api.url}/functions/dryruns/${dryrun.id}/result`, {
+            method: 'POST',
+            headers: {
+                authorization: `Bearer ${sandboxToken.unwrap()}`,
+                'content-type': 'application/json'
+            },
+            body: JSON.stringify({ status: 'succeeded', output: 'Building\nExecuting -> function\nDone\n{"ok":true}', duration_ms: 123 })
+        });
+
+        expect(res.status).toBe(200);
+        expect(await res.json()).toStrictEqual({ ok: true });
+
+        const getRes = await api.fetch('/functions/dryruns/:id', {
+            method: 'GET',
+            token: seed.apiKey.secret,
+            params: { id: dryrun.id }
+        });
+
+        expect(getRes.res.status).toBe(200);
+        expect(getRes.json).toMatchObject({
+            id: dryrun.id,
+            status: 'succeeded',
+            integration_id: 'github',
+            function_type: 'action',
+            duration_ms: 123,
+            output: 'Executing -> function\nDone',
+            result: { ok: true }
         });
     });
 });

--- a/packages/server/lib/controllers/functions/remote-function.integration.test.ts
+++ b/packages/server/lib/controllers/functions/remote-function.integration.test.ts
@@ -8,12 +8,16 @@ import { customerKeyService, seeders } from '@nangohq/shared';
 import { envs } from '../../env.js';
 import { isError, runServer, shouldBeProtected } from '../../utils/tests.js';
 
+import type { ApiKeyScope } from '@nangohq/types';
+
 let api: Awaited<ReturnType<typeof runServer>>;
 const originalNodeEnv = envs.NODE_ENV;
 
-async function seedAccountWithRemoteFunctions() {
-    const seed = await seeders.seedAccountEnvAndUser();
-    await db.knex('plans').where('id', seed.plan.id).update({ remote_functions: true });
+async function seedAccountWithRemoteFunctions(scopes?: ApiKeyScope[]) {
+    const seed = await seeders.seedAccountEnvAndUser({ plan: { remote_functions: true } });
+    if (scopes) {
+        await db.knex('customer_keys').where('id', seed.apiKey.id).update({ scopes });
+    }
     return seed;
 }
 
@@ -48,6 +52,17 @@ describe('remote-function public API', () => {
                 integration_id: 'github',
                 function_name: 'syncIssues',
                 function_type: 'sync',
+                code: 'export default {}'
+            }
+        });
+
+        shouldBeProtected(res);
+    });
+
+    it('protects POST /functions/compile', async () => {
+        const res = await api.fetch('/functions/compile', {
+            method: 'POST',
+            body: {
                 code: 'export default {}'
             }
         });
@@ -103,6 +118,30 @@ describe('remote-function public API', () => {
         });
     });
 
+    it('rejects POST /functions/dryrun without dryrun scope', async () => {
+        const seed = await seedAccountWithRemoteFunctions();
+        const apiKey = await createApiKeyWithScopes(seed, ['environment:connections:read']);
+
+        const res = await api.fetch('/functions/dryrun', {
+            method: 'POST',
+            token: apiKey.secret,
+            body: {
+                integration_id: 'github',
+                function_type: 'sync',
+                code: 'export default {}',
+                connection_id: 'missing-connection'
+            }
+        });
+
+        expect(res.res.status).toBe(403);
+        expect(res.json).toStrictEqual({
+            error: {
+                code: 'forbidden',
+                message: 'Insufficient scope. Required: environment:dryrun'
+            }
+        });
+    });
+
     it('rejects POST /remote-function/deploy without deploy scope', async () => {
         const seed = await seedAccountWithRemoteFunctions();
         const apiKey = await createApiKeyWithScopes(seed, ['environment:dryrun']);
@@ -111,6 +150,31 @@ describe('remote-function public API', () => {
             method: 'POST',
             token: apiKey.secret,
             body: {
+                integration_id: 'github',
+                function_name: 'syncIssues',
+                function_type: 'sync',
+                code: 'export default {}'
+            }
+        });
+
+        expect(res.res.status).toBe(403);
+        expect(res.json).toStrictEqual({
+            error: {
+                code: 'forbidden',
+                message: 'Insufficient scope. Required: environment:deploy'
+            }
+        });
+    });
+
+    it('rejects POST /functions/deployments without deploy scope', async () => {
+        const seed = await seedAccountWithRemoteFunctions();
+        const apiKey = await createApiKeyWithScopes(seed, ['environment:dryrun']);
+
+        const res = await api.fetch('/functions/deployments', {
+            method: 'POST',
+            token: apiKey.secret,
+            body: {
+                type: 'single',
                 integration_id: 'github',
                 function_name: 'syncIssues',
                 function_type: 'sync',
@@ -144,6 +208,26 @@ describe('remote-function public API', () => {
         isError(res.json);
         expect(res.res.status).toBe(400);
         expect(res.json.error.code).toBe('invalid_body');
+    });
+
+    it('requires deploy scope on POST /functions/compile', async () => {
+        const { apiKey } = await seedAccountWithRemoteFunctions(['environment:mcp']);
+
+        const res = await api.fetch('/functions/compile', {
+            method: 'POST',
+            token: apiKey.secret,
+            body: {
+                code: 'export default {}'
+            }
+        });
+
+        expect(res.res.status).toBe(403);
+        expect(res.json).toStrictEqual({
+            error: {
+                code: 'forbidden',
+                message: 'Insufficient scope. Required: environment:deploy'
+            }
+        });
     });
 
     it('returns integration_not_found on POST /remote-function/compile', async () => {
@@ -219,6 +303,53 @@ describe('remote-function public API', () => {
         });
     });
 
+    it('returns connection_not_found on POST /functions/dryrun', async () => {
+        const { env, apiKey } = await seedAccountWithRemoteFunctions();
+        await seeders.createConfigSeed(env, 'github', 'github');
+
+        const res = await api.fetch('/functions/dryrun', {
+            method: 'POST',
+            token: apiKey.secret,
+            body: {
+                integration_id: 'github',
+                function_type: 'sync',
+                code: 'export default {}',
+                connection_id: 'missing-connection'
+            }
+        });
+
+        expect(res.res.status).toBe(404);
+        expect(res.json).toStrictEqual({
+            error: {
+                code: 'connection_not_found',
+                message: "Connection 'missing-connection' was not found for integration 'github'"
+            }
+        });
+    });
+
+    it('returns integration_not_found on POST /functions/dryrun', async () => {
+        const { apiKey } = await seedAccountWithRemoteFunctions();
+
+        const res = await api.fetch('/functions/dryrun', {
+            method: 'POST',
+            token: apiKey.secret,
+            body: {
+                integration_id: 'github',
+                function_type: 'sync',
+                code: 'export default {}',
+                connection_id: 'missing-connection'
+            }
+        });
+
+        expect(res.res.status).toBe(404);
+        expect(res.json).toStrictEqual({
+            error: {
+                code: 'integration_not_found',
+                message: "Integration 'github' was not found"
+            }
+        });
+    });
+
     it('returns integration_not_found on POST /remote-function/deploy', async () => {
         const { apiKey } = await seedAccountWithRemoteFunctions();
 
@@ -226,6 +357,30 @@ describe('remote-function public API', () => {
             method: 'POST',
             token: apiKey.secret,
             body: {
+                integration_id: 'github',
+                function_name: 'syncIssues',
+                function_type: 'sync',
+                code: 'export default {}'
+            }
+        });
+
+        expect(res.res.status).toBe(404);
+        expect(res.json).toStrictEqual({
+            error: {
+                code: 'integration_not_found',
+                message: "Integration 'github' was not found"
+            }
+        });
+    });
+
+    it('returns integration_not_found on POST /functions/deployments', async () => {
+        const { apiKey } = await seedAccountWithRemoteFunctions();
+
+        const res = await api.fetch('/functions/deployments', {
+            method: 'POST',
+            token: apiKey.secret,
+            body: {
+                type: 'single',
                 integration_id: 'github',
                 function_name: 'syncIssues',
                 function_type: 'sync',

--- a/packages/server/lib/controllers/functions/validation.ts
+++ b/packages/server/lib/controllers/functions/validation.ts
@@ -28,3 +28,34 @@ export const remoteFunctionDryrunBodySchema = remoteFunctionBaseBodySchema
         last_sync_date: z.string().datetime().optional()
     })
     .strict();
+
+export const functionCompileBodySchema = z
+    .object({
+        code: z.string().min(1)
+    })
+    .strict();
+
+export const functionDryrunBodySchema = z
+    .object({
+        integration_id: integrationIdSchema,
+        function_type: z.enum(['action', 'sync']),
+        code: z.string().min(1),
+        connection_id: connectionIdSchema,
+        input: z.unknown().optional(),
+        metadata: z.record(z.string(), z.unknown()).optional(),
+        checkpoint: z.record(z.string(), z.unknown()).optional(),
+        last_sync_date: z.string().datetime().optional()
+    })
+    .strict();
+
+export const functionDeploymentBodySchema = z
+    .object({
+        type: z.literal('single'),
+        integration_id: integrationIdSchema,
+        function_name: syncNameSchema,
+        function_type: z.enum(['action', 'sync']),
+        code: z.string().min(1),
+        version: z.string().optional(),
+        allow_destructive: z.boolean().optional()
+    })
+    .strict();

--- a/packages/server/lib/crons/timeoutFunctionDryruns.ts
+++ b/packages/server/lib/crons/timeoutFunctionDryruns.ts
@@ -1,0 +1,41 @@
+import * as cron from 'node-cron';
+
+import { getLocking } from '@nangohq/kvstore';
+import { timeoutFunctionDryruns } from '@nangohq/shared';
+import { getLogger, report } from '@nangohq/utils';
+
+import type { Lock } from '@nangohq/kvstore';
+
+const logger = getLogger('cron.timeoutFunctionDryruns');
+const cronExpression = '* * * * *';
+const lockTtlMs = 55 * 1000;
+
+export function timeoutFunctionDryrunsCron(): void {
+    cron.schedule(cronExpression, () => {
+        exec().catch((err: unknown) => {
+            logger.error('Failed to execute function dryrun timeout cron');
+            report(new Error('cron_failed_to_timeout_function_dryruns', { cause: err }));
+        });
+    });
+}
+
+export async function exec(): Promise<void> {
+    const locking = await getLocking();
+    let lock: Lock | undefined;
+
+    try {
+        lock = await locking.acquire('lock:functionDryrunsTimeout:cron', lockTtlMs);
+    } catch {
+        logger.info('Could not acquire lock, skipping');
+        return;
+    }
+
+    try {
+        const count = await timeoutFunctionDryruns();
+        if (count > 0) {
+            logger.info(`Timed out ${count} function dryruns`);
+        }
+    } finally {
+        await locking.release(lock);
+    }
+}

--- a/packages/server/lib/routes.public.ts
+++ b/packages/server/lib/routes.public.ts
@@ -36,7 +36,7 @@ import connectionController from './controllers/connection.controller.js';
 import { getPublicEnvironmentVariables } from './controllers/environment/getVariables.js';
 import { postFunctionCompile, postRemoteFunctionCompile } from './controllers/functions/compile/postCompile.js';
 import { postFunctionDeployment, postRemoteFunctionDeploy } from './controllers/functions/deploy/postDeploy.js';
-import { postFunctionDryrun, postRemoteFunctionDryrun } from './controllers/functions/dryrun/postDryrun.js';
+import { getFunctionDryrun, postFunctionDryrun, postFunctionDryrunResult, postRemoteFunctionDryrun } from './controllers/functions/dryrun/postDryrun.js';
 import { getPublicListIntegrations } from './controllers/integrations/getListIntegrations.js';
 import { postPublicIntegration, postPublicQuickstartIntegration } from './controllers/integrations/postIntegration.js';
 import { deletePublicIntegration } from './controllers/integrations/uniqueKey/deleteIntegration.js';
@@ -98,6 +98,15 @@ const remoteFunctionAuth: RequestHandler[] = [
 ];
 const functionCompileAuth: RequestHandler[] = [...remoteFunctionAuth, withScope('environment:deploy')];
 const functionDryrunAuth: RequestHandler[] = [...remoteFunctionAuth, withScope('environment:dryrun')];
+const sandboxTokenOnly: RequestHandler = (_req, res, next) => {
+    if (res.locals['apiKeyAuthSource'] !== 'sandbox_token') {
+        res.status(403).send({ error: { code: 'forbidden', message: 'This endpoint only accepts sandbox tokens' } });
+        return;
+    }
+
+    next();
+};
+const functionDryrunResultAuth: RequestHandler[] = [...remoteFunctionAuth, sandboxTokenOnly, withScope('environment:dryrun')];
 const functionDeployAuth: RequestHandler[] = [...remoteFunctionAuth, withScope('environment:deploy')];
 
 export const publicAPI = express.Router();
@@ -276,7 +285,9 @@ publicAPI.route('/scripts/config').get(apiAuth, withScope('environment:integrati
 // Functions
 publicAPI.use('/functions', jsonContentTypeMiddleware);
 publicAPI.route('/functions/compile').post(functionCompileAuth, postFunctionCompile);
-publicAPI.route('/functions/dryrun').post(functionDryrunAuth, postFunctionDryrun);
+publicAPI.route('/functions/dryruns').post(functionDryrunAuth, postFunctionDryrun);
+publicAPI.route('/functions/dryruns/:id').get(functionDryrunAuth, getFunctionDryrun);
+publicAPI.route('/functions/dryruns/:id/result').post(functionDryrunResultAuth, postFunctionDryrunResult);
 publicAPI.route('/functions/deployments').post(functionDeployAuth, postFunctionDeployment);
 
 // Actions

--- a/packages/server/lib/routes.public.ts
+++ b/packages/server/lib/routes.public.ts
@@ -34,9 +34,9 @@ import { getPublicConnections } from './controllers/connection/getConnections.js
 import { postPublicConnection } from './controllers/connection/postConnection.js';
 import connectionController from './controllers/connection.controller.js';
 import { getPublicEnvironmentVariables } from './controllers/environment/getVariables.js';
-import { postRemoteFunctionCompile } from './controllers/functions/compile/postCompile.js';
-import { postRemoteFunctionDeploy } from './controllers/functions/deploy/postDeploy.js';
-import { postRemoteFunctionDryrun } from './controllers/functions/dryrun/postDryrun.js';
+import { postFunctionCompile, postRemoteFunctionCompile } from './controllers/functions/compile/postCompile.js';
+import { postFunctionDeployment, postRemoteFunctionDeploy } from './controllers/functions/deploy/postDeploy.js';
+import { postFunctionDryrun, postRemoteFunctionDryrun } from './controllers/functions/dryrun/postDryrun.js';
 import { getPublicListIntegrations } from './controllers/integrations/getListIntegrations.js';
 import { postPublicIntegration, postPublicQuickstartIntegration } from './controllers/integrations/postIntegration.js';
 import { deletePublicIntegration } from './controllers/integrations/uniqueKey/deleteIntegration.js';
@@ -96,6 +96,9 @@ const remoteFunctionAuth: RequestHandler[] = [
         next();
     }
 ];
+const functionCompileAuth: RequestHandler[] = [...remoteFunctionAuth, withScope('environment:deploy')];
+const functionDryrunAuth: RequestHandler[] = [...remoteFunctionAuth, withScope('environment:dryrun')];
+const functionDeployAuth: RequestHandler[] = [...remoteFunctionAuth, withScope('environment:deploy')];
 
 export const publicAPI = express.Router();
 
@@ -269,6 +272,12 @@ publicAPI.route('/mcp').get(apiAuth, withScope('environment:mcp'), getMcp);
 // Scripts config
 publicAPI.use('/scripts', jsonContentTypeMiddleware);
 publicAPI.route('/scripts/config').get(apiAuth, withScope('environment:integrations:list_functions'), getPublicScriptsConfig);
+
+// Functions
+publicAPI.use('/functions', jsonContentTypeMiddleware);
+publicAPI.route('/functions/compile').post(functionCompileAuth, postFunctionCompile);
+publicAPI.route('/functions/dryrun').post(functionDryrunAuth, postFunctionDryrun);
+publicAPI.route('/functions/deployments').post(functionDeployAuth, postFunctionDeployment);
 
 // Actions
 publicAPI.use('/action', jsonContentTypeMiddleware);

--- a/packages/server/lib/server.ts
+++ b/packages/server/lib/server.ts
@@ -21,6 +21,7 @@ import publisher from './clients/publisher.client.js';
 import { deleteOldData } from './crons/deleteOldData.js';
 import { lambdaKeepWarmCron } from './crons/lambdaKeepWarm.js';
 import { refreshConnectionsCron } from './crons/refreshConnections.js';
+import { timeoutFunctionDryrunsCron } from './crons/timeoutFunctionDryruns.js';
 import { timeoutLogsOperations } from './crons/timeoutLogsOperations.js';
 import { trialCron } from './crons/trial.js';
 import { envs } from './env.js';
@@ -92,6 +93,7 @@ if (NANGO_MIGRATE_AT_START === 'true') {
 getProviders();
 
 refreshConnectionsCron();
+timeoutFunctionDryrunsCron();
 timeoutLogsOperations();
 deleteOldData();
 trialCron();

--- a/packages/server/lib/services/remote-function/command-builders.ts
+++ b/packages/server/lib/services/remote-function/command-builders.ts
@@ -31,7 +31,7 @@ export function buildDryrunArgs(request: DryrunRequest): string[] {
 }
 
 export function buildDeployArgs(request: DeployRequest): string[] {
-    return [
+    const args = [
         'deploy',
         request.environment_name,
         '--integration',
@@ -39,7 +39,15 @@ export function buildDeployArgs(request: DeployRequest): string[] {
         request.function_type === 'action' ? '--action' : '--sync',
         request.function_name,
         '--auto-confirm',
-        '--allow-destructive',
         '--no-interactive'
     ];
+
+    if (request.version) {
+        args.push('--version', request.version);
+    }
+    if (request.allow_destructive) {
+        args.push('--allow-destructive');
+    }
+
+    return args;
 }

--- a/packages/server/lib/services/remote-function/command-builders.unit.test.ts
+++ b/packages/server/lib/services/remote-function/command-builders.unit.test.ts
@@ -12,9 +12,25 @@ describe('remote function command builders', () => {
                 code: 'export default {}',
                 environment_name: 'dev',
                 nango_secret_key: 'nango-secret',
-                nango_host: 'https://api.example.test'
+                nango_host: 'https://api.example.test',
+                allow_destructive: true
             })
-        ).toStrictEqual(['deploy', 'dev', '--integration', 'github', '--sync', 'syncIssues', '--auto-confirm', '--allow-destructive', '--no-interactive']);
+        ).toStrictEqual(['deploy', 'dev', '--integration', 'github', '--sync', 'syncIssues', '--auto-confirm', '--no-interactive', '--allow-destructive']);
+    });
+
+    it('passes the requested deploy version', () => {
+        expect(
+            buildDeployArgs({
+                integration_id: 'github',
+                function_name: 'syncIssues',
+                function_type: 'sync',
+                code: 'export default {}',
+                environment_name: 'dev',
+                nango_secret_key: 'nango-secret',
+                nango_host: 'https://api.example.test',
+                version: '1.2.3'
+            })
+        ).toStrictEqual(['deploy', 'dev', '--integration', 'github', '--sync', 'syncIssues', '--auto-confirm', '--no-interactive', '--version', '1.2.3']);
     });
 
     it('scopes dry-run to the requested integration', () => {

--- a/packages/server/lib/services/remote-function/deploy-client.ts
+++ b/packages/server/lib/services/remote-function/deploy-client.ts
@@ -21,6 +21,8 @@ export interface DeployRequest {
     environment_name: string;
     nango_secret_key: string;
     nango_host: string;
+    version?: string;
+    allow_destructive?: boolean;
 }
 
 export interface DeployResult {

--- a/packages/server/lib/services/remote-function/helpers.ts
+++ b/packages/server/lib/services/remote-function/helpers.ts
@@ -19,6 +19,7 @@ const functionErrorCodes = new Set<string>([
     'dryrun_error',
     'deployment_error',
     'connection_not_found',
+    'dryrun_not_found',
     'function_disabled',
     'timeout',
     'validation_error'

--- a/packages/shared/lib/index.ts
+++ b/packages/shared/lib/index.ts
@@ -28,6 +28,7 @@ export * as jwtClient from './auth/jwt.js';
 export * as signatureClient from './auth/signature.js';
 export * from './services/connections/credentials/refresh.js';
 export * from './services/function.service.js';
+export * from './services/functions/dryruns.service.js';
 export * from './services/on-event-scripts.service.js';
 export * from './services/sync/sync.service.js';
 export * from './services/sync/job.service.js';

--- a/packages/shared/lib/services/functions/dryruns.service.ts
+++ b/packages/shared/lib/services/functions/dryruns.service.ts
@@ -1,0 +1,250 @@
+import db from '@nangohq/database';
+
+import type { FunctionDryrunBody, FunctionDryrunCreateSuccess, FunctionDryrunResultSuccess, FunctionDryrunStatus, FunctionErrorCode } from '@nangohq/types';
+import type { Knex } from 'knex';
+
+const tableName = 'function_dryruns';
+
+export const internalFunctionDryrunActionName = '__nango_function_dryrun__';
+
+export interface FunctionDryrunStoredRequest extends FunctionDryrunBody {
+    function_name: string;
+}
+
+export interface FunctionDryrunError {
+    code: FunctionErrorCode;
+    message: string;
+    payload?: unknown;
+}
+
+export interface DBFunctionDryrun {
+    id: string;
+    environment_id: number;
+    request: FunctionDryrunStoredRequest;
+    status: FunctionDryrunStatus;
+    sandbox_id: string | null;
+    output: string | null;
+    result: unknown;
+    has_result: boolean;
+    error: FunctionDryrunError | null;
+    duration_ms: number | null;
+    execution_timeout_at: Date | string | null;
+    started_at: Date | string | null;
+    completed_at: Date | string | null;
+    created_at: Date | string;
+    updated_at: Date | string;
+}
+
+export async function createFunctionDryrun({
+    environmentId,
+    request,
+    trx = db.knex
+}: {
+    environmentId: number;
+    request: FunctionDryrunStoredRequest;
+    trx?: Knex;
+}): Promise<FunctionDryrunCreateSuccess> {
+    const [row] = await trx<DBFunctionDryrun>(tableName)
+        .insert({
+            environment_id: environmentId,
+            request: jsonb(request),
+            status: 'pending'
+        })
+        .returning('*');
+
+    if (!row) {
+        throw new Error('Failed to create function dryrun');
+    }
+
+    return toCreateResponse(row);
+}
+
+export async function getFunctionDryrunRow({
+    environmentId,
+    id,
+    trx = db.knex
+}: {
+    environmentId: number;
+    id: string;
+    trx?: Knex;
+}): Promise<DBFunctionDryrun | null> {
+    const row = await trx<DBFunctionDryrun>(tableName).where({ id, environment_id: environmentId }).first();
+    return row || null;
+}
+
+export async function getFunctionDryrun({
+    environmentId,
+    id,
+    trx = db.knex
+}: {
+    environmentId: number;
+    id: string;
+    trx?: Knex;
+}): Promise<FunctionDryrunResultSuccess | null> {
+    const row = await getFunctionDryrunRow({ environmentId, id, trx });
+    return row ? toResultResponse(row) : null;
+}
+
+export async function markFunctionDryrunRunning({
+    environmentId,
+    id,
+    sandboxId,
+    startedAt,
+    executionTimeoutAt,
+    trx = db.knex
+}: {
+    environmentId: number;
+    id: string;
+    sandboxId: string;
+    startedAt: Date;
+    executionTimeoutAt: Date;
+    trx?: Knex;
+}): Promise<DBFunctionDryrun | null> {
+    const [row] = await trx<DBFunctionDryrun>(tableName)
+        .where({ id, environment_id: environmentId, status: 'pending' })
+        .update({
+            status: 'running',
+            sandbox_id: sandboxId,
+            started_at: startedAt,
+            execution_timeout_at: executionTimeoutAt,
+            updated_at: trx.fn.now()
+        })
+        .returning('*');
+
+    return row || null;
+}
+
+export async function markFunctionDryrunSucceeded({
+    environmentId,
+    id,
+    output,
+    result,
+    hasResult,
+    durationMs,
+    trx = db.knex
+}: {
+    environmentId: number;
+    id: string;
+    output: string;
+    result?: unknown;
+    hasResult: boolean;
+    durationMs?: number | undefined;
+    trx?: Knex;
+}): Promise<DBFunctionDryrun | null> {
+    const [row] = await trx<DBFunctionDryrun>(tableName)
+        .where({ id, environment_id: environmentId, status: 'running' })
+        .update({
+            status: 'succeeded',
+            output,
+            result: hasResult ? jsonb(result ?? null) : null,
+            has_result: hasResult,
+            duration_ms: durationMs ?? null,
+            completed_at: trx.fn.now(),
+            updated_at: trx.fn.now()
+        })
+        .returning('*');
+
+    return row || null;
+}
+
+export async function markFunctionDryrunFailed({
+    environmentId,
+    id,
+    error,
+    output,
+    durationMs,
+    statuses = ['pending', 'running'],
+    trx = db.knex
+}: {
+    environmentId: number;
+    id: string;
+    error: FunctionDryrunError;
+    output?: string | undefined;
+    durationMs?: number | undefined;
+    statuses?: FunctionDryrunStatus[] | undefined;
+    trx?: Knex;
+}): Promise<DBFunctionDryrun | null> {
+    const [row] = await trx<DBFunctionDryrun>(tableName)
+        .where({ id, environment_id: environmentId })
+        .whereIn('status', statuses)
+        .update({
+            status: 'failed',
+            error: jsonb(error),
+            output: output ?? null,
+            duration_ms: durationMs ?? null,
+            completed_at: trx.fn.now(),
+            updated_at: trx.fn.now()
+        })
+        .returning('*');
+
+    return row || null;
+}
+
+export async function timeoutFunctionDryruns({
+    limit = 100,
+    trx = db.knex
+}: {
+    limit?: number;
+    trx?: Knex;
+} = {}): Promise<number> {
+    const ids = trx<DBFunctionDryrun>(tableName)
+        .select('id')
+        .where({ status: 'running' })
+        .whereNotNull('execution_timeout_at')
+        .where('execution_timeout_at', '<', trx.fn.now())
+        .orderBy('execution_timeout_at', 'asc')
+        .limit(limit);
+
+    const rows = await trx<DBFunctionDryrun>(tableName)
+        .whereIn('id', ids)
+        .update({
+            status: 'failed',
+            error: jsonb({ code: 'timeout', message: 'Dry run timed out' } satisfies FunctionDryrunError),
+            completed_at: trx.fn.now(),
+            updated_at: trx.fn.now()
+        })
+        .returning('id');
+
+    return rows.length;
+}
+
+export function toFunctionDryrunResult(row: DBFunctionDryrun): FunctionDryrunResultSuccess {
+    return toResultResponse(row);
+}
+
+function toCreateResponse(row: DBFunctionDryrun): FunctionDryrunCreateSuccess {
+    return {
+        id: row.id,
+        status: row.status === 'running' ? 'running' : 'pending',
+        status_url: `/functions/dryruns/${row.id}`,
+        created_at: toIsoString(row.created_at),
+        ...(row.execution_timeout_at ? { execution_timeout_at: toIsoString(row.execution_timeout_at) } : {})
+    };
+}
+
+function toResultResponse(row: DBFunctionDryrun): FunctionDryrunResultSuccess {
+    return {
+        id: row.id,
+        status: row.status,
+        integration_id: row.request.integration_id,
+        function_type: row.request.function_type,
+        status_url: `/functions/dryruns/${row.id}`,
+        created_at: toIsoString(row.created_at),
+        updated_at: toIsoString(row.updated_at),
+        ...(row.started_at ? { started_at: toIsoString(row.started_at) } : {}),
+        ...(row.completed_at ? { completed_at: toIsoString(row.completed_at) } : {}),
+        ...(row.execution_timeout_at ? { execution_timeout_at: toIsoString(row.execution_timeout_at) } : {}),
+        ...(row.duration_ms !== null ? { duration_ms: row.duration_ms } : {}),
+        ...(row.output !== null ? { output: row.output } : {}),
+        ...(row.has_result ? { result: row.result } : {}),
+        ...(row.error ? { error: row.error } : {})
+    };
+}
+
+function toIsoString(value: Date | string): string {
+    return value instanceof Date ? value.toISOString() : new Date(value).toISOString();
+}
+
+function jsonb(value: unknown): Knex.Raw {
+    return db.knex.raw('?::jsonb', [JSON.stringify(value)]);
+}

--- a/packages/types/lib/api.endpoints.ts
+++ b/packages/types/lib/api.endpoints.ts
@@ -63,6 +63,7 @@ import type { PatchWebhook } from './environment/api/webhook.js';
 import type { PostEnvironmentVariables } from './environment/variable/api.js';
 import type { PatchFlowDisable, PatchFlowEnable, PatchFlowFrequency, PostPreBuiltDeploy, PutUpgradePreBuiltFlow } from './flow/http.api.js';
 import type {
+    GetFunctionDryrun,
     GetIntegrationFunction,
     GetIntegrationFunctions,
     GetProviderTemplates,
@@ -155,6 +156,7 @@ export type PublicApiEndpoints =
     | PostPublicTriggerAction
     | PostFunctionCompile
     | PostFunctionDryrun
+    | GetFunctionDryrun
     | PostFunctionDeployment
     | PostRemoteFunctionCompile
     | PostRemoteFunctionDryrun

--- a/packages/types/lib/api.endpoints.ts
+++ b/packages/types/lib/api.endpoints.ts
@@ -66,6 +66,9 @@ import type {
     GetIntegrationFunction,
     GetIntegrationFunctions,
     GetProviderTemplates,
+    PostFunctionCompile,
+    PostFunctionDeployment,
+    PostFunctionDryrun,
     PostRemoteFunctionCompile,
     PostRemoteFunctionDeploy,
     PostRemoteFunctionDryrun
@@ -150,6 +153,9 @@ export type PublicApiEndpoints =
     | GetPublicSyncStatus
     | GetPublicV1
     | PostPublicTriggerAction
+    | PostFunctionCompile
+    | PostFunctionDryrun
+    | PostFunctionDeployment
     | PostRemoteFunctionCompile
     | PostRemoteFunctionDryrun
     | PostRemoteFunctionDeploy

--- a/packages/types/lib/functions/api.ts
+++ b/packages/types/lib/functions/api.ts
@@ -13,6 +13,7 @@ export type FunctionErrorCode =
     | 'dryrun_error'
     | 'deployment_error'
     | 'connection_not_found'
+    | 'dryrun_not_found'
     | 'function_disabled'
     | 'timeout'
     | 'validation_error';
@@ -60,6 +61,33 @@ export interface FunctionDryrunSuccess {
     result?: unknown;
 }
 
+export type FunctionDryrunStatus = 'pending' | 'running' | 'succeeded' | 'failed';
+
+export interface FunctionDryrunCreateSuccess {
+    id: string;
+    status: Extract<FunctionDryrunStatus, 'pending' | 'running'>;
+    status_url: string;
+    created_at: string;
+    execution_timeout_at?: string | undefined;
+}
+
+export interface FunctionDryrunResultSuccess {
+    id: string;
+    status: FunctionDryrunStatus;
+    integration_id: string;
+    function_type: RunnableFunctionType;
+    status_url: string;
+    created_at: string;
+    updated_at: string;
+    started_at?: string | undefined;
+    completed_at?: string | undefined;
+    execution_timeout_at?: string | undefined;
+    duration_ms?: number | undefined;
+    output?: string | undefined;
+    result?: unknown;
+    error?: ApiError<FunctionErrorCode>['error'] | undefined;
+}
+
 export interface FunctionDeploymentBody {
     type: 'single';
     integration_id: string;
@@ -89,10 +117,18 @@ export type PostFunctionCompile = Endpoint<{
 
 export type PostFunctionDryrun = Endpoint<{
     Method: 'POST';
-    Path: '/functions/dryrun';
+    Path: '/functions/dryruns';
     Body: FunctionDryrunBody;
     Error: ApiError<FunctionErrorCode>;
-    Success: FunctionDryrunSuccess;
+    Success: FunctionDryrunCreateSuccess;
+}>;
+
+export type GetFunctionDryrun = Endpoint<{
+    Method: 'GET';
+    Path: '/functions/dryruns/:id';
+    Params: { id: string };
+    Error: ApiError<FunctionErrorCode>;
+    Success: FunctionDryrunResultSuccess;
 }>;
 
 export type PostFunctionDeployment = Endpoint<{

--- a/packages/types/lib/functions/api.ts
+++ b/packages/types/lib/functions/api.ts
@@ -4,6 +4,7 @@ import type { FunctionSource } from '../syncConfigs/db.js';
 import type { JSONSchema7 } from 'json-schema';
 
 export type FunctionType = 'action' | 'sync' | 'on-event';
+export type RunnableFunctionType = Extract<FunctionType, 'action' | 'sync'>;
 
 export type FunctionErrorCode =
     | 'invalid_request'
@@ -29,69 +30,131 @@ export interface ProxyCall {
     headers: Record<string, unknown>;
 }
 
+export interface FunctionCompileBody {
+    code: string;
+}
+
+export interface FunctionCompileSuccess {
+    bundle_size_bytes: number;
+    bundled_js: string;
+    compiled_at: string;
+}
+
+export interface FunctionDryrunBody {
+    integration_id: string;
+    function_type: RunnableFunctionType;
+    code: string;
+    connection_id: string;
+    input?: unknown;
+    metadata?: Record<string, unknown> | undefined;
+    checkpoint?: Record<string, unknown> | undefined;
+    last_sync_date?: string | undefined;
+}
+
+export interface FunctionDryrunSuccess {
+    integration_id: string;
+    function_type: RunnableFunctionType;
+    execution_timeout_at: string;
+    duration_ms: number;
+    output: string;
+    result?: unknown;
+}
+
+export interface FunctionDeploymentBody {
+    type: 'single';
+    integration_id: string;
+    function_name: string;
+    function_type: RunnableFunctionType;
+    code: string;
+    version?: string | undefined;
+    allow_destructive?: boolean | undefined;
+}
+
+export interface FunctionDeploySuccess {
+    integration_id: string;
+    function_name: string;
+    function_type: RunnableFunctionType;
+    deployed: boolean;
+    deployed_functions: { name: string; version: string }[];
+    output: string;
+}
+
+export type PostFunctionCompile = Endpoint<{
+    Method: 'POST';
+    Path: '/functions/compile';
+    Body: FunctionCompileBody;
+    Error: ApiError<FunctionErrorCode>;
+    Success: FunctionCompileSuccess;
+}>;
+
+export type PostFunctionDryrun = Endpoint<{
+    Method: 'POST';
+    Path: '/functions/dryrun';
+    Body: FunctionDryrunBody;
+    Error: ApiError<FunctionErrorCode>;
+    Success: FunctionDryrunSuccess;
+}>;
+
+export type PostFunctionDeployment = Endpoint<{
+    Method: 'POST';
+    Path: '/functions/deployments';
+    Body: FunctionDeploymentBody;
+    Error: ApiError<FunctionErrorCode>;
+    Success: FunctionDeploySuccess;
+}>;
+
+export interface RemoteFunctionCompileBody {
+    integration_id: string;
+    function_name: string;
+    function_type: RunnableFunctionType;
+    code: string;
+}
+
+export interface RemoteFunctionCompileSuccess extends FunctionCompileSuccess {
+    integration_id: string;
+    function_name: string;
+    function_type: RunnableFunctionType;
+}
+
+export interface RemoteFunctionDryrunBody extends RemoteFunctionCompileBody {
+    connection_id: string;
+    input?: unknown;
+    metadata?: Record<string, unknown> | undefined;
+    checkpoint?: Record<string, unknown> | undefined;
+    last_sync_date?: string | undefined;
+}
+
+export interface RemoteFunctionDryrunSuccess {
+    integration_id: string;
+    function_name: string;
+    function_type: RunnableFunctionType;
+    execution_timeout_at: string;
+    duration_ms: number;
+    result?: unknown;
+}
+
 export type PostRemoteFunctionCompile = Endpoint<{
     Method: 'POST';
     Path: '/remote-function/compile';
-    Body: {
-        integration_id: string;
-        function_name: string;
-        function_type: FunctionType;
-        code: string;
-    };
+    Body: RemoteFunctionCompileBody;
     Error: ApiError<FunctionErrorCode>;
-    Success: {
-        integration_id: string;
-        function_name: string;
-        function_type: FunctionType;
-        bundle_size_bytes: number;
-        bundled_js: string;
-        compiled_at: string;
-    };
+    Success: RemoteFunctionCompileSuccess;
 }>;
 
 export type PostRemoteFunctionDryrun = Endpoint<{
     Method: 'POST';
     Path: '/remote-function/dryrun';
-    Body: {
-        integration_id: string;
-        function_name: string;
-        function_type: FunctionType;
-        code: string;
-        connection_id: string;
-        input?: unknown;
-        metadata?: Record<string, unknown> | undefined;
-        checkpoint?: Record<string, unknown> | undefined;
-        last_sync_date?: string | undefined;
-    };
+    Body: RemoteFunctionDryrunBody;
     Error: ApiError<FunctionErrorCode>;
-    Success: {
-        integration_id: string;
-        function_name: string;
-        function_type: FunctionType;
-        execution_timeout_at: string;
-        duration_ms: number;
-        result?: unknown;
-    };
+    Success: RemoteFunctionDryrunSuccess;
 }>;
 
 export type PostRemoteFunctionDeploy = Endpoint<{
     Method: 'POST';
     Path: '/remote-function/deploy';
-    Body: {
-        integration_id: string;
-        function_name: string;
-        function_type: FunctionType;
-        code: string;
-    };
+    Body: RemoteFunctionCompileBody;
     Error: ApiError<FunctionErrorCode>;
-    Success: {
-        integration_id: string;
-        function_name: string;
-        function_type: FunctionType;
-        deployed: boolean;
-        deployed_functions: { name: string; version: string }[];
-        output: string;
-    };
+    Success: FunctionDeploySuccess;
 }>;
 
 interface NangoFunctionBase {


### PR DESCRIPTION
Adds public `/functions/compile`, `/functions/dryrun`, and `/functions/deployments` endpoints that match the production API spec.
Dry-run and deployment now issue PR 6161 sandbox API tokens before invoking sandboxes, avoiding internal environment secrets in the runtime.
Updates endpoint types, OpenAPI/docs navigation, deploy argument handling, and controller coverage for auth scopes and not-found cases.

NAN-5567

RFC: https://linear.app/nango/document/rfc-functions-api-d0f6afd0f291

Stacked on #6161.