### PR TITLE
perf(records): fix deleteOutdatedRecords slow query under large seen sets

### DIFF
--- a/packages/records/lib/models/records.integration.test.ts
+++ b/packages/records/lib/models/records.integration.test.ts
@@ -824,7 +824,7 @@ describe('Records service', () => {
         });
     }, 60_000);
 
-    describe('markPreviousGenerationRecordsAsDeleted', () => {
+    describe('deleteOutdatedRecords', () => {
         it('should track size correctly when marking outdated records as deleted', async () => {
             const connectionId = rnd.number();
             const environmentId = rnd.number();
@@ -900,6 +900,40 @@ describe('Records service', () => {
                 .where({ connection_id: connectionId, model, external_id: '5' })
                 .first();
             expect(notDeleted?.deleted_at).toBeNull();
+        });
+
+        it('should not mark records from recent generation as deleted', async () => {
+            const connectionId = rnd.number();
+            const environmentId = rnd.number();
+            const model = rnd.string();
+            const syncId = uuid.v4();
+            const generation = 1;
+
+            await upsertRecords({
+                records: [
+                    { id: '1', name: 'John Doe' },
+                    { id: '2', name: 'Jane Doe' },
+                    { id: '3', name: 'Max Doe' },
+                    { id: '4', name: 'Mike Doe' }
+                ],
+                connectionId,
+                environmentId,
+                model,
+                syncId,
+                syncJobId: generation
+            });
+
+            const deletedIds = (
+                await Records.deleteOutdatedRecords({
+                    environmentId,
+                    connectionId,
+                    model,
+                    generation
+                })
+            ).unwrap();
+
+            // No records should be marked as deleted since they are from the same generation
+            expect(deletedIds).toHaveLength(0);
         });
 
         it('should not mark already deleted records', async () => {

--- a/packages/records/lib/models/records.ts
+++ b/packages/records/lib/models/records.ts
@@ -1267,6 +1267,26 @@ export async function deleteOutdatedRecords({
                         // Lock to prevent concurrent modifications with upserts and deletes
                         await acquireAdvisoryLock(trx, { name: 'lock_records_outdated', connectionId, model });
 
+                        // Fetch page bounds separately
+                        // Update query only yields soft-deleted rows
+                        // and we can't tell "end of table" from "records in page have all been seen and skipped".
+                        // The advisory lock ensures both page and update queries see the same rows.
+                        const pageQuery = trx
+                            .select<{ id: string }[]>('id')
+                            .from(RECORDS_TABLE)
+                            .where({ connection_id: connectionId, model })
+                            .whereNull('deleted_at')
+                            .orderBy('id')
+                            .limit(batchSize);
+                        if (lastId) {
+                            pageQuery.whereRaw('id > ?', [lastId]);
+                        }
+                        const pageRows = await pageQuery;
+
+                        if (pageRows.length === 0) {
+                            return { rows: [], pageLastId: null as string | null, pageSize: 0 };
+                        }
+
                         const res: {
                             id: string;
                             connection_id: number;
@@ -1277,23 +1297,33 @@ export async function deleteOutdatedRecords({
                             partition: string;
                         }[] = (
                             await trx.raw(
-                                `WITH seen AS MATERIALIZED (
-                                    SELECT DISTINCT unnest(record_ids) AS id FROM ${RECORDS_SEEN_TABLE}
+                                // Paginate records first so the planner knows the driving side is bounded by batchSize.
+                                // This forces a hash anti-join instead of a nested loop anti-join,
+                                // which the planner chooses when it can't estimate the seen CTE cardinality accurately.
+                                // ie: unnest output is consistently underestimated, pg thinks nested loop is cheap, causing O(records*seen) comparisons instead of O(seen+page).
+                                // Seen is still fully unnested.
+                                `WITH page AS (
+                                    SELECT ctid, id
+                                    FROM ${RECORDS_TABLE}
+                                    WHERE connection_id = :connectionId
+                                      AND model = :model
+                                      AND deleted_at IS NULL
+                                      AND (:lastId::text IS NULL OR id > :lastId)
+                                    ORDER BY id
+                                    LIMIT :batchSize
+                                ),
+                                seen AS (
+                                    SELECT unnest(record_ids) AS id
+                                    FROM ${RECORDS_SEEN_TABLE}
                                     WHERE connection_id = :connectionId
                                       AND model = :model
                                       AND sync_job_id >= :generation
                                 ),
-                                to_delete AS MATERIALIZED (
-                                    SELECT r.ctid, r.id
-                                    FROM ${RECORDS_TABLE} r
-                                    LEFT JOIN seen ON seen.id = r.id
-                                    WHERE r.connection_id = :connectionId
-                                      AND r.model = :model
-                                      AND r.deleted_at IS NULL
-                                      AND seen.id IS NULL
-                                      AND (:lastId::text IS NULL OR r.id > :lastId)
-                                    ORDER BY r.id
-                                    LIMIT :batchSize
+                                to_delete AS (
+                                    SELECT p.ctid, p.id
+                                    FROM page p
+                                    LEFT JOIN seen s ON s.id = p.id
+                                    WHERE s.id IS NULL
                                 )
                                 UPDATE ${RECORDS_TABLE} r
                                 SET
@@ -1345,7 +1375,7 @@ export async function deleteOutdatedRecords({
                             });
                         }
 
-                        return res;
+                        return { rows: res, pageLastId: pageRows.at(-1)?.id ?? null, pageSize: pageRows.length };
                     });
                 },
                 // Retry if deadlock detected
@@ -1363,17 +1393,19 @@ export async function deleteOutdatedRecords({
                 }
             );
 
-            if (batchResult.length < batchSize) {
+            // Use page bounds for cursor and termination
+            if (batchResult.pageLastId) {
+                lastId = batchResult.pageLastId;
+            }
+            if (batchResult.pageSize < batchSize) {
                 hasMore = false;
             }
 
-            lastId = batchResult[batchResult.length - 1]?.id ?? lastId;
-
-            if (!partition && batchResult[0]?.partition) {
-                partition = batchResult[0].partition;
+            if (!partition && batchResult.rows[0]?.partition) {
+                partition = batchResult.rows[0].partition;
             }
 
-            deletedIds.push(...batchResult.map((r) => r.external_id));
+            deletedIds.push(...batchResult.rows.map((r) => r.external_id));
         }
 
         if (partition) {


### PR DESCRIPTION
The previous query built the `seen` CTE first (DISTINCT unnest of all seend record_ids), then joined against the full records table to find unseen rows.

PostgreSQL consistently underestimates unnest() output cardinality by multiple order of magnitude. With that bad estimate the planner chose a nested loop anti-join: for every row in the records scan it re-scanned the entire seen set. In extreme cases (ex: records ≈ seen ≈ 200K) this produced ~20 billion comparisons.

Fix: paginate records first with an explicit LIMIT, then anti-join against seen.

Because the planner knows `page` has at most batchSize rows, it now picks a hash anti-join:
1. build the hash table on seen once (O(seen))
2. probe it with each page row (O(batchSize)). Total cost is O(seen + batchSize) instead of O(records × seen).

Known cost: seen is still fully unnested.

<!-- Describe the problem and your solution --> 

<!-- Issue ticket number and link (if applicable) -->

<!-- Testing instructions (skip if just adding/editing providers) -->

