### PR TITLE
feat(server): endpoint to list templates from and integration with deployed metadata

### DIFF
--- a/packages/server/lib/controllers/v1/integrations/providerConfigKey/templates/getTemplates.integration.test.ts
+++ b/packages/server/lib/controllers/v1/integrations/providerConfigKey/templates/getTemplates.integration.test.ts
@@ -1,0 +1,152 @@
+import { afterAll, beforeAll, describe, expect, it } from 'vitest';
+
+import { seeders } from '@nangohq/shared';
+
+import { isError, isSuccess, runServer, shouldBeProtected, shouldRequireQueryEnv } from '../../../../../utils/tests.js';
+
+const route = '/api/v1/integrations/:providerConfigKey/templates';
+let api: Awaited<ReturnType<typeof runServer>>;
+
+describe(`GET ${route}`, () => {
+    beforeAll(async () => {
+        api = await runServer();
+    });
+    afterAll(() => {
+        api.server.close();
+    });
+
+    it('should be protected', async () => {
+        const res = await api.fetch(route, { method: 'GET', query: { env: 'dev' }, params: { providerConfigKey: 'github' } });
+
+        shouldBeProtected(res);
+    });
+
+    it('should enforce env query params', async () => {
+        const { apiKey } = await seeders.seedAccountEnvAndUser();
+        const res = await api.fetch(
+            route,
+            // @ts-expect-error missing query on purpose
+            { method: 'GET', token: apiKey.secret, params: { providerConfigKey: 'github' } }
+        );
+
+        shouldRequireQueryEnv(res);
+    });
+
+    it('should return 404 when integration does not exist', async () => {
+        const { apiKey } = await seeders.seedAccountEnvAndUser();
+
+        const res = await api.fetch(route, {
+            method: 'GET',
+            query: { env: 'dev' },
+            params: { providerConfigKey: 'unknown-integration' },
+            token: apiKey.secret
+        });
+
+        isError(res.json);
+        expect(res.res.status).toBe(404);
+        expect(res.json).toStrictEqual<typeof res.json>({
+            error: { code: 'not_found', message: 'Integration does not exist' }
+        });
+    });
+
+    it('should return templates without deployed metadata when nothing is deployed', async () => {
+        const { env, apiKey } = await seeders.seedAccountEnvAndUser();
+        await seeders.createConfigSeed(env, 'github', 'github');
+
+        const res = await api.fetch(route, {
+            method: 'GET',
+            query: { env: 'dev' },
+            params: { providerConfigKey: 'github' },
+            token: apiKey.secret
+        });
+
+        expect(res.res.status).toBe(200);
+        isSuccess(res.json);
+        expect(res.json.data.length).toBeGreaterThan(0);
+        for (const tpl of res.json.data) {
+            expect(tpl).not.toHaveProperty('deployed');
+        }
+    });
+
+    it('should attach deployed metadata when a function with the same name+type exists', async () => {
+        const { env, apiKey } = await seeders.seedAccountEnvAndUser();
+        const integration = await seeders.createConfigSeed(env, 'github', 'github');
+        const connection = await seeders.createConnectionSeed({ env, provider: 'github' });
+
+        await seeders.createSyncSeeds({
+            connectionId: connection.id,
+            environment_id: env.id,
+            nango_config_id: integration.id!,
+            sync_name: 'issues',
+            type: 'sync'
+        });
+
+        const res = await api.fetch(route, {
+            method: 'GET',
+            query: { env: 'dev' },
+            params: { providerConfigKey: 'github' },
+            token: apiKey.secret
+        });
+
+        expect(res.res.status).toBe(200);
+        isSuccess(res.json);
+
+        const issues = res.json.data.find((tpl) => tpl.name === 'issues' && tpl.type === 'sync');
+        expect(issues).toBeDefined();
+        expect(issues?.deployed).toMatchObject({
+            id: expect.any(Number),
+            enabled: expect.any(Boolean),
+            last_deployed: expect.any(String),
+            source: expect.any(String)
+        });
+
+        const otherTemplates = res.json.data.filter((tpl) => !(tpl.name === 'issues' && tpl.type === 'sync'));
+        for (const tpl of otherTemplates) {
+            expect(tpl).not.toHaveProperty('deployed');
+        }
+    });
+
+    it('should not match a deployed function across types or providers', async () => {
+        const { env, apiKey } = await seeders.seedAccountEnvAndUser();
+        const integration = await seeders.createConfigSeed(env, 'github', 'github');
+        const connection = await seeders.createConnectionSeed({ env, provider: 'github' });
+
+        // Same template name, but as an action — should not match the `issues` sync template.
+        await seeders.createSyncSeeds({
+            connectionId: connection.id,
+            environment_id: env.id,
+            nango_config_id: integration.id!,
+            sync_name: 'issues',
+            type: 'action'
+        });
+
+        const res = await api.fetch(route, {
+            method: 'GET',
+            query: { env: 'dev' },
+            params: { providerConfigKey: 'github' },
+            token: apiKey.secret
+        });
+
+        isSuccess(res.json);
+        const issuesSync = res.json.data.find((tpl) => tpl.name === 'issues' && tpl.type === 'sync');
+        expect(issuesSync).toBeDefined();
+        expect(issuesSync).not.toHaveProperty('deployed');
+    });
+
+    it('should return empty data when the integration has no template entries', async () => {
+        const { env, apiKey } = await seeders.seedAccountEnvAndUser();
+        // Use a unique_key for a provider that has no templates in flows.zero.json.
+        await seeders.createConfigSeed(env, 'custom', 'unauthenticated');
+
+        const res = await api.fetch(route, {
+            method: 'GET',
+            query: { env: 'dev' },
+            params: { providerConfigKey: 'custom' },
+            token: apiKey.secret
+        });
+
+        expect(res.res.status).toBe(200);
+        isSuccess(res.json);
+        expect(res.json.data).toStrictEqual([]);
+    });
+});

--- a/packages/server/lib/controllers/v1/integrations/providerConfigKey/templates/getTemplates.ts
+++ b/packages/server/lib/controllers/v1/integrations/providerConfigKey/templates/getTemplates.ts
@@ -1,0 +1,55 @@
+import { configService, findActiveDeployedMeta, flowService } from '@nangohq/shared';
+import { requireEmptyQuery, zodErrorToHTTP } from '@nangohq/utils';
+
+import { toNangoFunction } from '../../../../../formatters/function.js';
+import { asyncWrapper } from '../../../../../utils/asyncWrapper.js';
+import { validationParams } from '../getIntegration.js';
+
+import type { DeployedMeta, GetIntegrationTemplates, NangoFunctionTemplate } from '@nangohq/types';
+
+export const getIntegrationTemplates = asyncWrapper<GetIntegrationTemplates>(async (req, res) => {
+    const emptyQuery = requireEmptyQuery(req, { withEnv: true });
+    if (emptyQuery) {
+        res.status(400).send({ error: { code: 'invalid_query_params', errors: zodErrorToHTTP(emptyQuery.error) } });
+        return;
+    }
+
+    const valParams = validationParams.safeParse(req.params);
+    if (!valParams.success) {
+        res.status(400).send({ error: { code: 'invalid_uri_params', errors: zodErrorToHTTP(valParams.error) } });
+        return;
+    }
+
+    const { environment } = res.locals;
+    const { providerConfigKey } = valParams.data;
+
+    const integration = await configService.getProviderConfig(providerConfigKey, environment.id);
+    if (!integration) {
+        res.status(404).send({ error: { code: 'not_found', message: 'Integration does not exist' } });
+        return;
+    }
+
+    const all = flowService.getAllAvailableFlowsAsStandardConfig();
+    const entry = all.find((value) => value.providerConfigKey === integration.provider);
+
+    const deployedRows = await findActiveDeployedMeta({ environmentId: environment.id, providerConfigKey });
+    const deployedByKey = new Map<string, DeployedMeta>(
+        deployedRows.map((row) => [
+            `${row.type}:${row.name}`,
+            { id: row.id, enabled: row.enabled, last_deployed: row.last_deployed.toISOString(), source: row.source }
+        ])
+    );
+
+    const data: NangoFunctionTemplate[] = entry
+        ? [...entry.actions, ...entry.syncs].flatMap((e) => {
+              const fn = toNangoFunction(e);
+              if (!fn) {
+                  return [];
+              }
+              const deployed = deployedByKey.get(`${fn.type}:${fn.name}`);
+              return [deployed ? { ...fn, deployed } : fn];
+          })
+        : [];
+
+    res.status(200).send({ data });
+});

--- a/packages/server/lib/routes.private.ts
+++ b/packages/server/lib/routes.private.ts
@@ -67,6 +67,7 @@ import { getIntegrationFunction } from './controllers/v1/integrations/providerCo
 import { getIntegrationFunctions } from './controllers/v1/integrations/providerConfigKey/functions/getFunctions.js';
 import { getIntegration } from './controllers/v1/integrations/providerConfigKey/getIntegration.js';
 import { patchIntegration } from './controllers/v1/integrations/providerConfigKey/patchIntegration.js';
+import { getIntegrationTemplates } from './controllers/v1/integrations/providerConfigKey/templates/getTemplates.js';
 import { acceptInvite } from './controllers/v1/invite/acceptInvite.js';
 import { declineInvite } from './controllers/v1/invite/declineInvite.js';
 import { deleteInvite } from './controllers/v1/invite/deleteInvite.js';
@@ -239,6 +240,7 @@ web.route('/integrations/:providerConfigKey/functions/:functionName').get(
     can({ action: 'read', resource: 'flow', scopedBy: envScope }),
     getIntegrationFunction
 );
+web.route('/integrations/:providerConfigKey/templates').get(webAuth, can({ action: 'read', resource: 'flow', scopedBy: envScope }), getIntegrationTemplates);
 
 // Providers
 web.route('/providers').get(webAuth, getProvidersList);

--- a/packages/shared/lib/services/functions/index.ts
+++ b/packages/shared/lib/services/functions/index.ts
@@ -4,3 +4,4 @@
 // so callers stop reaching into the underlying tables directly.
 
 export { getFunction, listFunctions } from './service.js';
+export { findActiveDeployedMeta } from './models/functions.js';

--- a/packages/shared/lib/services/functions/models/functions.ts
+++ b/packages/shared/lib/services/functions/models/functions.ts
@@ -21,6 +21,15 @@ export interface FunctionRow {
     event: string | null;
 }
 
+export interface DeployedFunctionMetaRow {
+    id: number;
+    name: string;
+    type: 'sync' | 'action';
+    enabled: boolean;
+    last_deployed: Date;
+    source: FunctionSource;
+}
+
 export async function findActiveByEnvironment({
     environmentId,
     providerConfigKey,
@@ -55,6 +64,34 @@ export async function findActiveByEnvironment({
 
     const total = countRow ? Number(countRow.total) : 0;
     return { rows: pageRows, total };
+}
+
+/**
+ * Returns a slim list of active deployed sync/action functions for an integration,
+ * intended for cross-referencing the template catalog with what is already deployed.
+ *
+ * Unpaginated and excludes on-event scripts — the templates catalog contains only
+ * syncs and actions, so callers building a `(name, type) -> deployed` lookup only
+ * need those two types.
+ */
+export async function findActiveDeployedMeta({
+    environmentId,
+    providerConfigKey
+}: {
+    environmentId: number;
+    providerConfigKey: string;
+}): Promise<DeployedFunctionMetaRow[]> {
+    return db.knex
+        .from({ sc: '_nango_sync_configs' })
+        .join({ nc: '_nango_configs' }, 'sc.nango_config_id', 'nc.id')
+        .where('nc.environment_id', environmentId)
+        .andWhere('nc.unique_key', providerConfigKey)
+        .andWhere('nc.deleted', false)
+        .andWhere('sc.deleted', false)
+        .andWhere('sc.active', true)
+        .select<
+            DeployedFunctionMetaRow[]
+        >('sc.id', db.knex.raw('sc.sync_name AS name'), 'sc.type', 'sc.enabled', db.knex.raw('sc.updated_at AS last_deployed'), 'sc.source');
 }
 
 export async function findActiveByName({

--- a/packages/shared/lib/services/functions/models/functions.ts
+++ b/packages/shared/lib/services/functions/models/functions.ts
@@ -81,6 +81,17 @@ export async function findActiveDeployedMeta({
     environmentId: number;
     providerConfigKey: string;
 }): Promise<DeployedFunctionMetaRow[]> {
+    return activeSyncConfigBase({ environmentId, providerConfigKey }).select<DeployedFunctionMetaRow[]>(
+        'sc.id',
+        'sc.sync_name AS name',
+        'sc.type',
+        'sc.enabled',
+        'sc.created_at AS last_deployed',
+        'sc.source'
+    );
+}
+
+function activeSyncConfigBase({ environmentId, providerConfigKey }: { environmentId: number; providerConfigKey: string }): Knex.QueryBuilder {
     return db.knex
         .from({ sc: '_nango_sync_configs' })
         .join({ nc: '_nango_configs' }, 'sc.nango_config_id', 'nc.id')
@@ -88,10 +99,7 @@ export async function findActiveDeployedMeta({
         .andWhere('nc.unique_key', providerConfigKey)
         .andWhere('nc.deleted', false)
         .andWhere('sc.deleted', false)
-        .andWhere('sc.active', true)
-        .select<
-            DeployedFunctionMetaRow[]
-        >('sc.id', db.knex.raw('sc.sync_name AS name'), 'sc.type', 'sc.enabled', db.knex.raw('sc.updated_at AS last_deployed'), 'sc.source');
+        .andWhere('sc.active', true);
 }
 
 export async function findActiveByName({
@@ -156,30 +164,22 @@ function buildSyncConfigBranch({
 }): Knex.QueryBuilder {
     // Cast on `source` (sync_config_source enum) is required for UNION ALL with the on-event branch —
     // Postgres only unions matching types.
-    const query = db.knex
-        .from({ sc: '_nango_sync_configs' })
-        .join({ nc: '_nango_configs' }, 'sc.nango_config_id', 'nc.id')
-        .where('nc.environment_id', environmentId)
-        .andWhere('nc.unique_key', providerConfigKey)
-        .andWhere('nc.deleted', false)
-        .andWhere('sc.deleted', false)
-        .andWhere('sc.active', true)
-        .select(
-            'sc.id',
-            db.knex.raw('sc.sync_name AS name'),
-            'sc.type',
-            'sc.metadata',
-            'sc.input',
-            db.knex.raw('sc.models AS returns'),
-            db.knex.raw('sc.models_json_schema AS json_schema'),
-            'sc.runs',
-            'sc.auto_start',
-            'sc.track_deletes',
-            'sc.enabled',
-            db.knex.raw('sc.updated_at AS last_deployed'),
-            db.knex.raw('CAST(sc.source AS text) AS source'),
-            db.knex.raw('NULL::text AS event')
-        );
+    const query = activeSyncConfigBase({ environmentId, providerConfigKey }).select(
+        'sc.id',
+        'sc.sync_name AS name',
+        'sc.type',
+        'sc.metadata',
+        'sc.input',
+        'sc.models AS returns',
+        'sc.models_json_schema AS json_schema',
+        'sc.runs',
+        'sc.auto_start',
+        'sc.track_deletes',
+        'sc.enabled',
+        'sc.created_at AS last_deployed',
+        db.knex.raw('CAST(sc.source AS text) AS source'),
+        db.knex.raw('NULL::text AS event')
+    );
 
     if (type) {
         query.andWhere('sc.type', type);
@@ -221,7 +221,7 @@ function buildOnEventBranch({
             db.knex.raw('NULL::boolean AS auto_start'),
             db.knex.raw('NULL::boolean AS track_deletes'),
             db.knex.raw('oes.active AS enabled'),
-            db.knex.raw('oes.updated_at AS last_deployed'),
+            db.knex.raw('oes.created_at AS last_deployed'),
             db.knex.raw(`'repo'::text AS source`),
             db.knex.raw('CAST(oes.event AS text) AS event')
         );

--- a/packages/types/lib/api.endpoints.ts
+++ b/packages/types/lib/api.endpoints.ts
@@ -65,6 +65,7 @@ import type { PatchFlowDisable, PatchFlowEnable, PatchFlowFrequency, PostPreBuil
 import type {
     GetIntegrationFunction,
     GetIntegrationFunctions,
+    GetIntegrationTemplates,
     GetProviderTemplates,
     PostRemoteFunctionCompile,
     PostRemoteFunctionDeploy,
@@ -182,6 +183,7 @@ export type PrivateApiEndpoints =
     | GetIntegrationFlows
     | GetIntegrationFunction
     | GetIntegrationFunctions
+    | GetIntegrationTemplates
     | GetProviderTemplates
     | DeleteIntegration
     | PatchIntegration

--- a/packages/types/lib/functions/api.ts
+++ b/packages/types/lib/functions/api.ts
@@ -1,5 +1,5 @@
 import type { ApiError, Endpoint } from '../api.js';
-import type { DeployedNangoFunction, FunctionType, NangoActionFunction, NangoSyncFunction } from './domain.js';
+import type { DeployedNangoFunction, FunctionType, NangoActionFunction, NangoFunctionTemplate, NangoSyncFunction } from './domain.js';
 
 export type FunctionErrorCode =
     | 'invalid_request'
@@ -121,4 +121,12 @@ export type GetProviderTemplates = Endpoint<{
     Querystring: { env: string };
     Params: { providerConfigKey: string };
     Success: { data: (NangoSyncFunction | NangoActionFunction)[] };
+}>;
+
+export type GetIntegrationTemplates = Endpoint<{
+    Method: 'GET';
+    Path: '/api/v1/integrations/:providerConfigKey/templates';
+    Querystring: { env: string };
+    Params: { providerConfigKey: string };
+    Success: { data: NangoFunctionTemplate[] };
 }>;

--- a/packages/types/lib/functions/domain.ts
+++ b/packages/types/lib/functions/domain.ts
@@ -35,7 +35,7 @@ export interface NangoOnEventFunction extends NangoFunctionBase {
 
 export type NangoFunction = NangoSyncFunction | NangoActionFunction | NangoOnEventFunction;
 
-interface DeployedMeta {
+export interface DeployedMeta {
     id: number;
     enabled: boolean;
     /** ISO-8601 timestamp. */
@@ -47,3 +47,5 @@ export type DeployedNangoSyncFunction = NangoSyncFunction & DeployedMeta;
 export type DeployedNangoActionFunction = NangoActionFunction & DeployedMeta;
 export type DeployedNangoOnEventFunction = NangoOnEventFunction & DeployedMeta;
 export type DeployedNangoFunction = DeployedNangoSyncFunction | DeployedNangoActionFunction | DeployedNangoOnEventFunction;
+
+export type NangoFunctionTemplate = (NangoSyncFunction | NangoActionFunction) & { deployed?: DeployedMeta };


### PR DESCRIPTION
In order to have a visualization such as the one you see in the screenshot, we need to co-relate a list of templates with a list of deployed templates in an integration. This endpoint is slightly different from the existing `GET /api/v1/providers/:providerConfigKey/template` endpoint, because it is tied to a specific integration and it checks for existing functions matching the same name and type, to return some metadata about it.
<img width="1510" height="805" alt="image" src="https://github.com/user-attachments/assets/cd024342-f87c-4579-9f81-9ba10f3d42bf" />
> The UI in the screenshot is not in this PR