### PR TITLE
fix(metering): emit S3 export timestamp at end-of-day to satisfy Orb grace period

### DIFF
--- a/packages/metering/lib/crons/billingEventsS3Export.integration.test.ts
+++ b/packages/metering/lib/crons/billingEventsS3Export.integration.test.ts
@@ -209,14 +209,14 @@ describe('billingEventsS3Export', () => {
                 idempotency_key: `proxy_test:1:${targetDay}`,
                 event_name: 'proxy_test',
                 external_customer_id: '1',
-                timestamp: `${targetDay}T00:00:00.000Z`,
+                timestamp: `${targetDay}T23:59:59.999Z`,
                 properties: { count: 14 }
             });
             expect(rows).toContainEqual({
                 idempotency_key: `proxy_test:999:${targetDay}`,
                 event_name: 'proxy_test',
                 external_customer_id: '999',
-                timestamp: `${targetDay}T00:00:00.000Z`,
+                timestamp: `${targetDay}T23:59:59.999Z`,
                 properties: { count: 3 }
             });
         });
@@ -234,7 +234,7 @@ describe('billingEventsS3Export', () => {
                 idempotency_key: `function_executions_test:1:${targetDay}`,
                 event_name: 'function_executions_test',
                 external_customer_id: '1',
-                timestamp: `${targetDay}T00:00:00.000Z`,
+                timestamp: `${targetDay}T23:59:59.999Z`,
                 properties: {
                     count: 4,
                     'telemetry.durationMs': 400,

--- a/packages/metering/lib/crons/billingEventsS3Export.ts
+++ b/packages/metering/lib/crons/billingEventsS3Export.ts
@@ -223,7 +223,11 @@ export function metricRowsSql({
             concat('${eventName}:', toString(account_id), ':', toString(day)) AS idempotency_key,
             '${eventName}' AS event_name,
             toString(account_id) AS external_customer_id,
-            concat(toString(day), 'T00:00:00.000Z') AS timestamp,
+            -- End-of-day so the timestamp falls within Orb's account grace period at
+            -- ingestion time (cron runs the day after, so 00:00:00 of D is older than
+            -- the typical 24h grace and gets rejected with "must be later than ...").
+            -- The day bucket is still D for billing purposes.
+            concat(toString(day), 'T23:59:59.999Z') AS timestamp,
             properties
         FROM (${metric.select(day, database)})
     `;


### PR DESCRIPTION
## Summary

The S3 export cron (PR #6070, NAN-5315) runs on day `D+1` and exports day `D` events with `timestamp = D T00:00:00.000Z`. Orb rejects them into the DLQ because they fall outside the account's ingestion grace period:

```
{"idempotency_key": "function_executions_poc:4:2026-05-20",
 "errors": ["Event timestamp 2026-05-20T00:00:00+00:00 must be later than
             2026-05-20T17:00:33.358758+00:00 based on account grace period.
             To ingest an event older than the account grace period,
             create a backfill: ..."]}
```

Emit `D T23:59:59.999Z` instead. The day bucket Orb uses for billing is still `D`, so per-day aggregation is unchanged — we just push the moment-in-time to the end of the day so it lands within grace.

## Test plan

- [x] Type-check clean
- [x] Integration test assertions updated to the new timestamp shape
- [ ] After deploy: verify the next cron firing no longer sends events to the Orb DLQ

🤖 Generated with [Claude Code](https://claude.com/claude-code)