### PR TITLE
feat(records): add budgetTotalBytes span tag for dry-run overshoot

### DIFF
--- a/packages/records/lib/models/records.ts
+++ b/packages/records/lib/models/records.ts
@@ -278,16 +278,20 @@ export async function getRecords({
         if (hasMore) {
             recordsMetadata.pop();
         }
+        let budgetTotalBytes = 0;
         if (budgetEnabled) {
             let acc = 0;
             let truncateAt: number | null = null;
             for (let i = 0; i < recordsMetadata.length; i++) {
+                const sz = recordsMetadata[i]!.size;
+                budgetTotalBytes += sz;
+                if (truncateAt !== null) continue;
                 // i > 0: always keep at least one record so pagination can progress past oversized rows.
-                if (i > 0 && acc + recordsMetadata[i]!.size > budgetBytes) {
+                if (i > 0 && acc + sz > budgetBytes) {
                     truncateAt = i;
-                    break;
+                    continue;
                 }
-                acc += recordsMetadata[i]!.size;
+                acc += sz;
             }
             if (truncateAt !== null) {
                 budgetTruncated = true;
@@ -298,6 +302,7 @@ export async function getRecords({
                 span.addTags({
                     'nango.records.budgetTruncated': true,
                     'nango.records.budgetKeptBytes': acc,
+                    'nango.records.budgetTotalBytes': budgetTotalBytes,
                     'nango.records.budgetDryRun': envs.RECORDS_MAX_RESPONSE_SIZE_DRY_RUN
                 });
             }


### PR DESCRIPTION
## Summary

Tiny follow-up to #6187. The existing `nango.records.budgetKeptBytes` span tag only reports the bytes up to the truncation point — useful for knowing the kept-size envelope, but it doesn't tell us how far the request would have **overshot** the threshold. In dry-run that's exactly the question we're trying to answer.

Adds a sibling tag `nango.records.budgetTotalBytes` with the full untruncated page size. Combined with the configured budget (already known from env config), this gives overshoot per request at p50/p95/max in dd-trace without standing up a new metric.


## Test plan

- [x] `npm run test:integration -- packages/records/lib/models/records.integration.test.ts -t "size budget"` — 5/5 still pass.
- [x] TypeScript clean.
- [ ] CI green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)