### PR TITLE
feat(server): validate unique on-event function names

### DIFF
--- a/packages/server/lib/controllers/integrations/uniqueKey/functions/getCode.ts
+++ b/packages/server/lib/controllers/integrations/uniqueKey/functions/getCode.ts
@@ -79,12 +79,11 @@ export const getFunctionCode = asyncWrapper<GetPublicFunctionCode>(async (req, r
     }
 
     const syncConfigMatches = type === 'on-event' ? [] : await getSyncAndActionConfigsBySyncNameAndConfigId(environment.id, providerConfig.id, name);
-    const onEventMatches = type && type !== 'on-event' ? [] : await onEventScriptService.getByConfigAndName(providerConfig.id, name);
+    const onEventMatch = type && type !== 'on-event' ? null : await onEventScriptService.getByConfigAndName(providerConfig.id, name);
 
     const matches: FunctionMatch[] = [
         ...syncConfigMatches.map((c) => ({ type: c.type, name: c.sync_name, fileLocation: c.file_location })),
-        // Multiple on-event rows can share a name (different events) but point to the same TS file, so collapse to one match.
-        ...(onEventMatches.length > 0 ? [{ type: 'on-event' as const, name: onEventMatches[0]!.name, fileLocation: onEventMatches[0]!.fileLocation }] : [])
+        ...(onEventMatch ? [{ type: 'on-event' as const, name: onEventMatch.name, fileLocation: onEventMatch.fileLocation }] : [])
     ];
 
     const filtered = type ? matches.filter((m) => m.type === type) : matches;

--- a/packages/server/lib/controllers/sync/deploy/postConfirmation.integration.test.ts
+++ b/packages/server/lib/controllers/sync/deploy/postConfirmation.integration.test.ts
@@ -81,6 +81,45 @@ describe(`POST ${endpoint}`, () => {
         expect(res.res.status).toBe(200);
     });
 
+    it('should reject duplicate on-event names within one integration', async () => {
+        const { apiKey } = await seeders.seedAccountEnvAndUser();
+        const res = await api.fetch(endpoint, {
+            method: 'POST',
+            token: apiKey.secret,
+            body: {
+                debug: false,
+                flowConfigs: [],
+                onEventScriptsByProvider: [
+                    {
+                        providerConfigKey: 'github',
+                        scripts: [
+                            { name: 'shared-script', fileBody: { js: '', ts: '' }, event: 'post-connection-creation' },
+                            { name: 'shared-script', fileBody: { js: '', ts: '' }, event: 'validate-connection' }
+                        ]
+                    }
+                ],
+                reconcile: false,
+                deployMode: 'all'
+            }
+        });
+
+        isError(res.json);
+        expect(res.res.status).toBe(400);
+        expect(res.json).toStrictEqual({
+            error: {
+                code: 'invalid_body',
+                errors: [
+                    {
+                        code: 'custom',
+                        message:
+                            'On-event function "shared-script" is used multiple times. Please make sure all on-event function names are unique within an integration.',
+                        path: ['onEventScriptsByProvider', '0', 'scripts', '1', 'name']
+                    }
+                ]
+            }
+        });
+    });
+
     it('should show correct on-events scripts diff', async () => {
         const { account, env: environment, apiKey } = await seeders.seedAccountEnvAndUser();
         const { unique_key: providerConfigKey } = await seeders.createConfigSeed(environment, 'notion-123', 'notion');

--- a/packages/server/lib/controllers/sync/deploy/postDeploy.integration.test.ts
+++ b/packages/server/lib/controllers/sync/deploy/postDeploy.integration.test.ts
@@ -128,6 +128,46 @@ describe(`POST ${endpoint}`, () => {
         expect(res.res.status).toBe(200);
     });
 
+    it('should reject duplicate on-event names within one integration', async () => {
+        const { apiKey } = await seeders.seedAccountEnvAndUser();
+        const res = await api.fetch(endpoint, {
+            method: 'POST',
+            token: apiKey.secret,
+            body: {
+                debug: false,
+                flowConfigs: [],
+                nangoYamlBody: '',
+                onEventScriptsByProvider: [
+                    {
+                        providerConfigKey: 'github',
+                        scripts: [
+                            { name: 'shared-script', fileBody: { js: '', ts: '' }, event: 'post-connection-creation' },
+                            { name: 'shared-script', fileBody: { js: '', ts: '' }, event: 'pre-connection-deletion' }
+                        ]
+                    }
+                ],
+                reconcile: false,
+                deployMode: 'all'
+            }
+        });
+
+        isError(res.json);
+        expect(res.res.status).toBe(400);
+        expect(res.json).toStrictEqual({
+            error: {
+                code: 'invalid_body',
+                errors: [
+                    {
+                        code: 'custom',
+                        message:
+                            'On-event function "shared-script" is used multiple times. Please make sure all on-event function names are unique within an integration.',
+                        path: ['onEventScriptsByProvider', '0', 'scripts', '1', 'name']
+                    }
+                ]
+            }
+        });
+    });
+
     it('should return 409 when a concurrent deployment is already in progress', async () => {
         const { apiKey } = await seeders.seedAccountEnvAndUser();
 

--- a/packages/server/lib/controllers/sync/deploy/validation.ts
+++ b/packages/server/lib/controllers/sync/deploy/validation.ts
@@ -143,6 +143,45 @@ const postConnectionScriptsByProvider = z.array(
         }))
 );
 
+function validateNoDuplicateOnEventNames({
+    scriptGroups,
+    pathPrefix,
+    issues
+}: {
+    scriptGroups:
+        | {
+              providerConfigKey: string;
+              scripts: { name: string }[];
+          }[]
+        | undefined;
+    pathPrefix: 'onEventScriptsByProvider' | 'postConnectionScriptsByProvider';
+    issues: {
+        push: (issue: { code: 'custom'; message: string; path: (string | number)[]; input: unknown }) => void;
+    };
+}) {
+    if (!scriptGroups) {
+        return;
+    }
+
+    for (const [groupIndex, group] of scriptGroups.entries()) {
+        const seenNames = new Set<string>();
+
+        for (const [scriptIndex, script] of group.scripts.entries()) {
+            if (seenNames.has(script.name)) {
+                issues.push({
+                    code: 'custom',
+                    message: `On-event function "${script.name}" is used multiple times. Please make sure all on-event function names are unique within an integration.`,
+                    path: [pathPrefix, groupIndex, 'scripts', scriptIndex, 'name'],
+                    input: script.name
+                });
+                continue;
+            }
+
+            seenNames.add(script.name);
+        }
+    }
+}
+
 const commonValidation = z
     .object({
         flowConfigs,
@@ -163,14 +202,29 @@ const commonValidation = z
     })
     .strict();
 
-export const validation = commonValidation.transform((data) => ({
-    ...data,
-    deployMode: data.deployMode ?? (data.singleDeployMode ? 'single' : 'all')
-}));
+function validateUniqueOnEventNames(
+    data: z.infer<typeof commonValidation>,
+    issues: { push: (issue: { code: 'custom'; message: string; path: (string | number)[]; input: unknown }) => void }
+) {
+    validateNoDuplicateOnEventNames({ scriptGroups: data.onEventScriptsByProvider, pathPrefix: 'onEventScriptsByProvider', issues });
+    validateNoDuplicateOnEventNames({ scriptGroups: data.postConnectionScriptsByProvider, pathPrefix: 'postConnectionScriptsByProvider', issues });
+}
+
+export const validation = commonValidation
+    .check((payload) => {
+        validateUniqueOnEventNames(payload.value, payload.issues);
+    })
+    .transform((data) => ({
+        ...data,
+        deployMode: data.deployMode ?? (data.singleDeployMode ? 'single' : 'all')
+    }));
 
 export const validationWithNangoYaml = commonValidation
     .extend({
         nangoYamlBody: z.string()
+    })
+    .check((payload) => {
+        validateUniqueOnEventNames(payload.value, payload.issues);
     })
     .transform((data) => ({
         ...data,

--- a/packages/server/lib/controllers/v1/integrations/providerConfigKey/functions/getFunctions.integration.test.ts
+++ b/packages/server/lib/controllers/v1/integrations/providerConfigKey/functions/getFunctions.integration.test.ts
@@ -213,16 +213,16 @@ describe(`GET ${route}`, () => {
         expect(page0Names.some((name) => page2Names.includes(name))).toBe(false);
     });
 
-    it('should paginate on-event results deterministically when multiple scripts share the same name', async () => {
+    it('should paginate on-event results deterministically', async () => {
         const { env, apiKey } = await seeders.seedAccountEnvAndUser();
         const integration = await seeders.createConfigSeed(env, 'github', 'github');
 
         await insertOnEventScripts({
             configId: integration.id!,
             scripts: [
-                { name: 'shared-script', event: 'POST_CONNECTION_CREATION' },
-                { name: 'shared-script', event: 'PRE_CONNECTION_DELETION' },
-                { name: 'shared-script', event: 'VALIDATE_CONNECTION' }
+                { name: 'alpha-script', event: 'POST_CONNECTION_CREATION' },
+                { name: 'beta-script', event: 'PRE_CONNECTION_DELETION' },
+                { name: 'gamma-script', event: 'VALIDATE_CONNECTION' }
             ]
         });
 
@@ -247,8 +247,8 @@ describe(`GET ${route}`, () => {
         const page0Keys = page0.json.data.map(toFunctionKey);
         const page1Keys = page1.json.data.map(toFunctionKey);
 
-        expect(page0Keys).toStrictEqual(['on-event:shared-script:post-connection-creation', 'on-event:shared-script:pre-connection-deletion']);
-        expect(page1Keys).toStrictEqual(['on-event:shared-script:validate-connection']);
+        expect(page0Keys).toStrictEqual(['on-event:alpha-script:post-connection-creation', 'on-event:beta-script:pre-connection-deletion']);
+        expect(page1Keys).toStrictEqual(['on-event:gamma-script:validate-connection']);
         expect(page0Keys.some((key) => page1Keys.includes(key))).toBe(false);
     });
 
@@ -288,8 +288,8 @@ describe(`GET ${route}`, () => {
         await insertOnEventScripts({
             configId: integration.id!,
             scripts: [
-                { name: 'shared-script', event: 'POST_CONNECTION_CREATION' },
-                { name: 'shared-script', event: 'PRE_CONNECTION_DELETION' }
+                { name: 'on-event-a', event: 'POST_CONNECTION_CREATION' },
+                { name: 'on-event-b', event: 'PRE_CONNECTION_DELETION' }
             ]
         });
 
@@ -314,8 +314,8 @@ describe(`GET ${route}`, () => {
         const page0Keys = page0.json.data.map(toFunctionKey);
         const page1Keys = page1.json.data.map(toFunctionKey);
 
-        expect(page0Keys).toStrictEqual(['action:action-a:', 'action:action-b:', 'on-event:shared-script:post-connection-creation']);
-        expect(page1Keys).toStrictEqual(['on-event:shared-script:pre-connection-deletion', 'sync:sync-a:', 'sync:sync-b:']);
+        expect(page0Keys).toStrictEqual(['action:action-a:', 'action:action-b:', 'on-event:on-event-a:post-connection-creation']);
+        expect(page1Keys).toStrictEqual(['on-event:on-event-b:pre-connection-deletion', 'sync:sync-a:', 'sync:sync-b:']);
         expect(page0Keys.some((key) => page1Keys.includes(key))).toBe(false);
     });
 

--- a/packages/server/lib/controllers/v1/integrations/providerConfigKey/functions/getFunctions.ts
+++ b/packages/server/lib/controllers/v1/integrations/providerConfigKey/functions/getFunctions.ts
@@ -1,7 +1,7 @@
 import * as z from 'zod';
 
 import { configService, listFunctions } from '@nangohq/shared';
-import { zodErrorToHTTP } from '@nangohq/utils';
+import { report, zodErrorToHTTP } from '@nangohq/utils';
 
 import { envSchema } from '../../../../../helpers/validation.js';
 import { asyncWrapper } from '../../../../../utils/asyncWrapper.js';
@@ -42,7 +42,7 @@ export const getIntegrationFunctions = asyncWrapper<GetIntegrationFunctions>(asy
         return;
     }
 
-    const { rows, total } = await listFunctions({
+    const fnResult = await listFunctions({
         environmentId: environment.id,
         providerConfigKey,
         type,
@@ -50,6 +50,14 @@ export const getIntegrationFunctions = asyncWrapper<GetIntegrationFunctions>(asy
         limit,
         offset: page * limit
     });
+
+    if (fnResult.isErr()) {
+        report(fnResult.error);
+        res.status(500).send({ error: { code: 'server_error', message: 'Failed to list functions' } });
+        return;
+    }
+
+    const { rows, total } = fnResult.value;
 
     res.status(200).send({ data: rows, pagination: { total, page, limit } });
 });

--- a/packages/shared/lib/index.ts
+++ b/packages/shared/lib/index.ts
@@ -27,7 +27,7 @@ export * as githubAppClient from './auth/githubApp.js';
 export * as jwtClient from './auth/jwt.js';
 export * as signatureClient from './auth/signature.js';
 export * from './services/connections/credentials/refresh.js';
-export * from './services/function.service.js';
+export * from './services/functions/index.js';
 export * from './services/on-event-scripts.service.js';
 export * from './services/sync/sync.service.js';
 export * from './services/sync/job.service.js';

--- a/packages/shared/lib/services/functions/index.ts
+++ b/packages/shared/lib/services/functions/index.ts
@@ -1,8 +1,6 @@
 // Home for the Function abstraction over `_nango_sync_configs` and `on_event_scripts`.
-// Today only the read side (`listFunctions` / `getFunction`) lives here, plus shared mappers
-// (`EVENT_TYPE_MAPPINGS`, `eventTypeMapper`, `toDeployedNangoFunction`). The eventual roadmap
+// Today only the read side (`listFunctions` / `getFunction`) lives here. The eventual roadmap
 // is to consolidate write-side operations (deploy, deactivation, conflict detection) here too,
 // so callers stop reaching into the underlying tables directly.
 
 export { getFunction, listFunctions } from './service.js';
-export { EVENT_TYPE_MAPPINGS, eventTypeMapper } from './mappers.js';

--- a/packages/shared/lib/services/functions/index.ts
+++ b/packages/shared/lib/services/functions/index.ts
@@ -1,0 +1,8 @@
+// Home for the Function abstraction over `_nango_sync_configs` and `on_event_scripts`.
+// Today only the read side (`listFunctions` / `getFunction`) lives here, plus shared mappers
+// (`EVENT_TYPE_MAPPINGS`, `eventTypeMapper`, `toDeployedNangoFunction`). The eventual roadmap
+// is to consolidate write-side operations (deploy, deactivation, conflict detection) here too,
+// so callers stop reaching into the underlying tables directly.
+
+export { getFunction, listFunctions } from './service.js';
+export { EVENT_TYPE_MAPPINGS, eventTypeMapper } from './mappers.js';

--- a/packages/shared/lib/services/functions/mappers.ts
+++ b/packages/shared/lib/services/functions/mappers.ts
@@ -1,0 +1,107 @@
+import type {
+    DBOnEventScript,
+    DeployedNangoActionFunction,
+    DeployedNangoFunction,
+    DeployedNangoOnEventFunction,
+    DeployedNangoSyncFunction,
+    FunctionSource,
+    NangoConfigMetadata,
+    OnEventType
+} from '@nangohq/types';
+import type { JSONSchema7 } from 'json-schema';
+
+export const EVENT_TYPE_MAPPINGS: Record<DBOnEventScript['event'], OnEventType> = {
+    POST_CONNECTION_CREATION: 'post-connection-creation',
+    PRE_CONNECTION_DELETION: 'pre-connection-deletion',
+    VALIDATE_CONNECTION: 'validate-connection'
+} as const;
+
+export const eventTypeMapper = {
+    fromDb: (event: DBOnEventScript['event']): OnEventType => {
+        return EVENT_TYPE_MAPPINGS[event];
+    },
+    toDb: (eventType: OnEventType): DBOnEventScript['event'] => {
+        for (const [key, value] of Object.entries(EVENT_TYPE_MAPPINGS)) {
+            if (value === eventType) {
+                return key as DBOnEventScript['event'];
+            }
+        }
+        throw new Error(`Unknown event type: ${eventType}`);
+    }
+};
+
+export interface FunctionRow {
+    id: number;
+    name: string;
+    type: 'sync' | 'action' | 'on-event';
+    metadata: NangoConfigMetadata | null;
+    input: string | null;
+    returns: string[] | null;
+    json_schema: JSONSchema7 | null;
+    runs: string | null;
+    auto_start: boolean | null;
+    track_deletes: boolean | null;
+    enabled: boolean;
+    last_deployed: Date;
+    source: FunctionSource;
+    event: string | null;
+}
+
+export function toDeployedNangoFunction(row: FunctionRow): DeployedNangoFunction | undefined {
+    const description = row.metadata?.description;
+    const scopes = row.metadata?.scopes;
+    const base = {
+        name: row.name,
+        ...(description !== undefined && { description }),
+        ...(scopes !== undefined && { scopes })
+    };
+    const deployedMeta = {
+        id: row.id,
+        enabled: row.enabled,
+        last_deployed: row.last_deployed.toISOString(),
+        source: row.source
+    };
+
+    switch (row.type) {
+        case 'sync': {
+            const out: DeployedNangoSyncFunction = {
+                ...base,
+                type: 'sync',
+                ...(row.input !== null && { input: row.input }),
+                returns: row.returns ?? [],
+                json_schema: row.json_schema,
+                runs: row.runs,
+                auto_start: row.auto_start ?? false,
+                track_deletes: row.track_deletes ?? false,
+                ...deployedMeta
+            };
+            return out;
+        }
+        case 'on-event': {
+            const apiEvent = row.event ? EVENT_TYPE_MAPPINGS[row.event as DBOnEventScript['event']] : undefined;
+            if (!apiEvent) {
+                return undefined;
+            }
+            const out: DeployedNangoOnEventFunction = {
+                ...base,
+                type: 'on-event',
+                event: apiEvent,
+                ...deployedMeta
+            };
+            return out;
+        }
+        case 'action': {
+            const out: DeployedNangoActionFunction = {
+                ...base,
+                type: 'action',
+                ...(row.input !== null && { input: row.input }),
+                returns: row.returns ?? [],
+                json_schema: row.json_schema,
+                ...deployedMeta
+            };
+            return out;
+        }
+        default:
+            return undefined;
+    }
+}

--- a/packages/shared/lib/services/functions/mappers.ts
+++ b/packages/shared/lib/services/functions/mappers.ts
@@ -1,53 +1,38 @@
+import { Err, Ok } from '@nangohq/utils';
+
+import type { FunctionRow } from './repository.js';
 import type {
     DBOnEventScript,
     DeployedNangoActionFunction,
     DeployedNangoFunction,
     DeployedNangoOnEventFunction,
     DeployedNangoSyncFunction,
-    FunctionSource,
-    NangoConfigMetadata,
     OnEventType
 } from '@nangohq/types';
-import type { JSONSchema7 } from 'json-schema';
+import type { Result } from '@nangohq/utils';
 
-export const EVENT_TYPE_MAPPINGS: Record<DBOnEventScript['event'], OnEventType> = {
+const DB_TO_API_EVENT_TYPE: Record<DBOnEventScript['event'], OnEventType> = {
     POST_CONNECTION_CREATION: 'post-connection-creation',
     PRE_CONNECTION_DELETION: 'pre-connection-deletion',
     VALIDATE_CONNECTION: 'validate-connection'
 } as const;
 
+const API_TO_DB_EVENT_TYPE: Record<OnEventType, DBOnEventScript['event']> = {
+    'post-connection-creation': 'POST_CONNECTION_CREATION',
+    'pre-connection-deletion': 'PRE_CONNECTION_DELETION',
+    'validate-connection': 'VALIDATE_CONNECTION'
+} as const;
+
 export const eventTypeMapper = {
     fromDb: (event: DBOnEventScript['event']): OnEventType => {
-        return EVENT_TYPE_MAPPINGS[event];
+        return DB_TO_API_EVENT_TYPE[event];
     },
     toDb: (eventType: OnEventType): DBOnEventScript['event'] => {
-        for (const [key, value] of Object.entries(EVENT_TYPE_MAPPINGS)) {
-            if (value === eventType) {
-                return key as DBOnEventScript['event'];
-            }
-        }
-        throw new Error(`Unknown event type: ${eventType}`);
+        return API_TO_DB_EVENT_TYPE[eventType];
     }
 };
 
-export interface FunctionRow {
-    id: number;
-    name: string;
-    type: 'sync' | 'action' | 'on-event';
-    metadata: NangoConfigMetadata | null;
-    input: string | null;
-    returns: string[] | null;
-    json_schema: JSONSchema7 | null;
-    runs: string | null;
-    auto_start: boolean | null;
-    track_deletes: boolean | null;
-    enabled: boolean;
-    last_deployed: Date;
-    source: FunctionSource;
-    event: string | null;
-}
-
-export function toDeployedNangoFunction(row: FunctionRow): DeployedNangoFunction | undefined {
+export function toDeployedNangoFunction(row: FunctionRow): Result<DeployedNangoFunction> {
     const description = row.metadata?.description;
     const scopes = row.metadata?.scopes;
     const base = {
@@ -75,20 +60,25 @@ export function toDeployedNangoFunction(row: FunctionRow): DeployedNangoFunction
                 track_deletes: row.track_deletes ?? false,
                 ...deployedMeta
             };
-            return out;
+            return Ok(out);
         }
         case 'on-event': {
-            const apiEvent = row.event ? EVENT_TYPE_MAPPINGS[row.event as DBOnEventScript['event']] : undefined;
-            if (!apiEvent) {
-                return undefined;
+            if (!row.event) {
+                return Err(new Error('Unknown on-event type: null'));
             }
+
+            const apiEvent = DB_TO_API_EVENT_TYPE[row.event as DBOnEventScript['event']];
+            if (!apiEvent) {
+                return Err(new Error(`Unknown on-event type: ${row.event}`));
+            }
+
             const out: DeployedNangoOnEventFunction = {
                 ...base,
                 type: 'on-event',
                 event: apiEvent,
                 ...deployedMeta
             };
-            return out;
+            return Ok(out);
         }
         case 'action': {
             const out: DeployedNangoActionFunction = {
@@ -99,9 +89,9 @@ export function toDeployedNangoFunction(row: FunctionRow): DeployedNangoFunction
                 json_schema: row.json_schema,
                 ...deployedMeta
             };
-            return out;
+            return Ok(out);
         }
-        default:
-            return undefined;
     }
+
+    return Err(new Error(`Unknown function type: ${String(row.type)}`));
 }

--- a/packages/shared/lib/services/functions/repository.ts
+++ b/packages/shared/lib/services/functions/repository.ts
@@ -1,8 +1,25 @@
 import db from '@nangohq/database';
 
-import type { FunctionRow } from './mappers.js';
-import type { FunctionType } from '@nangohq/types';
+import type { FunctionSource, FunctionType, NangoConfigMetadata } from '@nangohq/types';
+import type { JSONSchema7 } from 'json-schema';
 import type { Knex } from 'knex';
+
+export interface FunctionRow {
+    id: number;
+    name: string;
+    type: string;
+    metadata: NangoConfigMetadata | null;
+    input: string | null;
+    returns: string[] | null;
+    json_schema: JSONSchema7 | null;
+    runs: string | null;
+    auto_start: boolean | null;
+    track_deletes: boolean | null;
+    enabled: boolean;
+    last_deployed: Date;
+    source: FunctionSource;
+    event: string | null;
+}
 
 export async function findActiveByEnvironment({
     environmentId,
@@ -65,7 +82,7 @@ export async function findActiveByName({
         ])
         .first();
 
-    return row ?? undefined;
+    return row;
 }
 
 function buildListingSubquery({

--- a/packages/shared/lib/services/functions/repository.ts
+++ b/packages/shared/lib/services/functions/repository.ts
@@ -1,49 +1,10 @@
 import db from '@nangohq/database';
-import { Err, Ok } from '@nangohq/utils';
 
-import type {
-    FunctionSource,
-    FunctionType,
-    NangoActionFunctionDeployed,
-    NangoConfigMetadata,
-    NangoFunctionDeployed,
-    NangoOnEventFunctionDeployed,
-    NangoSyncFunctionDeployed,
-    OnEventType
-} from '@nangohq/types';
-import type { Result } from '@nangohq/utils';
-import type { JSONSchema7 } from 'json-schema';
+import type { FunctionRow } from './mappers.js';
+import type { FunctionType } from '@nangohq/types';
 import type { Knex } from 'knex';
 
-const DB_EVENT_TO_API: Record<string, OnEventType> = {
-    POST_CONNECTION_CREATION: 'post-connection-creation',
-    PRE_CONNECTION_DELETION: 'pre-connection-deletion',
-    VALIDATE_CONNECTION: 'validate-connection'
-};
-
-interface SyncConfigOrOnEventScriptRow {
-    id: number;
-    name: string;
-    type: 'sync' | 'action' | 'on-event';
-    metadata: NangoConfigMetadata | null;
-    input: string | null;
-    returns: string[] | null;
-    json_schema: JSONSchema7 | null;
-    runs: string | null;
-    auto_start: boolean | null;
-    track_deletes: boolean | null;
-    enabled: boolean;
-    last_deployed: Date;
-    source: FunctionSource;
-    event: string | null;
-}
-
-/**
- * Lists active deployed functions for a single integration across syncs,
- * actions, and on-event scripts. Pagination total is returned independently
- * of the page so out-of-range pages still surface the correct total.
- */
-export async function listFunctions({
+export async function findActiveByEnvironment({
     environmentId,
     providerConfigKey,
     type,
@@ -57,13 +18,13 @@ export async function listFunctions({
     search: string | undefined;
     limit: number;
     offset: number;
-}): Promise<{ rows: NangoFunctionDeployed[]; total: number }> {
+}): Promise<{ rows: FunctionRow[]; total: number }> {
     const listing = buildListingSubquery({ environmentId, providerConfigKey, type, search });
 
     const [pageRows, countRow] = await Promise.all([
         db.knex
             .from(listing)
-            .select<SyncConfigOrOnEventScriptRow[]>('*')
+            .select<FunctionRow[]>('*')
             .orderBy([
                 { column: 'type', order: 'asc' },
                 { column: 'name', order: 'asc' },
@@ -75,21 +36,11 @@ export async function listFunctions({
         db.knex.from(listing).count<{ total: string }[]>('* as total').first()
     ]);
 
-    const rows = pageRows.flatMap((row) => {
-        const fn = toNangoFunctionDeployed(row);
-        return fn ? [fn] : [];
-    });
     const total = countRow ? Number(countRow.total) : 0;
-
-    return { rows, total };
+    return { rows: pageRows, total };
 }
 
-/**
- * Fetches a single deployed function by name within a provider config.
- * If `type` is omitted and multiple types share the same name, the first
- * match by the listing's stable order is returned.
- */
-export async function getFunction({
+export async function findActiveByName({
     environmentId,
     providerConfigKey,
     name,
@@ -99,26 +50,22 @@ export async function getFunction({
     providerConfigKey: string;
     name: string;
     type: FunctionType | undefined;
-}): Promise<Result<NangoFunctionDeployed | undefined>> {
-    try {
-        const listing = buildListingSubquery({ environmentId, providerConfigKey, type, search: undefined });
+}): Promise<FunctionRow | undefined> {
+    const listing = buildListingSubquery({ environmentId, providerConfigKey, type, search: undefined });
 
-        const row = await db.knex
-            .from(listing)
-            .select<SyncConfigOrOnEventScriptRow[]>('*')
-            .where('name', name)
-            .orderBy([
-                { column: 'type', order: 'asc' },
-                { column: 'name', order: 'asc' },
-                { column: 'event', order: 'asc' },
-                { column: 'id', order: 'asc' }
-            ])
-            .first();
+    const row = await db.knex
+        .from(listing)
+        .select<FunctionRow[]>('*')
+        .where('name', name)
+        .orderBy([
+            { column: 'type', order: 'asc' },
+            { column: 'name', order: 'asc' },
+            { column: 'event', order: 'asc' },
+            { column: 'id', order: 'asc' }
+        ])
+        .first();
 
-        return Ok(row ? toNangoFunctionDeployed(row) : undefined);
-    } catch (err) {
-        return Err(new Error('failed_to_get_function', { cause: err }));
-    }
+    return row ?? undefined;
 }
 
 function buildListingSubquery({
@@ -232,66 +179,6 @@ function buildOnEventBranch({
     return query;
 }
 
-// Escapes the LIKE wildcard meta-characters so user input is matched literally.
 function escapeLikePattern(value: string): string {
     return value.replace(/[\\%_]/g, (match) => `\\${match}`);
-}
-
-function toNangoFunctionDeployed(row: SyncConfigOrOnEventScriptRow): NangoFunctionDeployed | undefined {
-    const description = row.metadata?.description;
-    const scopes = row.metadata?.scopes;
-    const base = {
-        name: row.name,
-        ...(description !== undefined && { description }),
-        ...(scopes !== undefined && { scopes })
-    };
-    const deployedMeta = {
-        id: row.id,
-        enabled: row.enabled,
-        last_deployed: row.last_deployed.toISOString(),
-        source: row.source
-    };
-
-    switch (row.type) {
-        case 'sync': {
-            const out: NangoSyncFunctionDeployed = {
-                ...base,
-                type: 'sync',
-                ...(row.input !== null && { input: row.input }),
-                returns: row.returns ?? [],
-                json_schema: row.json_schema,
-                runs: row.runs,
-                auto_start: row.auto_start ?? false,
-                track_deletes: row.track_deletes ?? false,
-                ...deployedMeta
-            };
-            return out;
-        }
-        case 'on-event': {
-            const apiEvent = row.event ? DB_EVENT_TO_API[row.event] : undefined;
-            if (!apiEvent) {
-                return undefined;
-            }
-            const out: NangoOnEventFunctionDeployed = {
-                ...base,
-                type: 'on-event',
-                event: apiEvent,
-                ...deployedMeta
-            };
-            return out;
-        }
-        case 'action': {
-            const out: NangoActionFunctionDeployed = {
-                ...base,
-                type: 'action',
-                ...(row.input !== null && { input: row.input }),
-                returns: row.returns ?? [],
-                json_schema: row.json_schema,
-                ...deployedMeta
-            };
-            return out;
-        }
-        default:
-            return undefined;
-    }
 }

--- a/packages/shared/lib/services/functions/service.ts
+++ b/packages/shared/lib/services/functions/service.ts
@@ -25,15 +25,23 @@ export async function listFunctions({
     search: string | undefined;
     limit: number;
     offset: number;
-}): Promise<{ rows: DeployedNangoFunction[]; total: number }> {
-    const { rows: dbRows, total } = await repository.findActiveByEnvironment({ environmentId, providerConfigKey, type, search, limit, offset });
+}): Promise<Result<{ rows: DeployedNangoFunction[]; total: number }>> {
+    try {
+        const { rows: dbRows, total } = await repository.findActiveByEnvironment({ environmentId, providerConfigKey, type, search, limit, offset });
+        const rows: DeployedNangoFunction[] = [];
 
-    const rows = dbRows.flatMap((row) => {
-        const fn = toDeployedNangoFunction(row);
-        return fn ? [fn] : [];
-    });
+        for (const row of dbRows) {
+            const fn = toDeployedNangoFunction(row);
+            if (fn.isErr()) {
+                return Err(new Error('failed_to_list_functions', { cause: fn.error }));
+            }
+            rows.push(fn.value);
+        }
 
-    return { rows, total };
+        return Ok({ rows, total });
+    } catch (err) {
+        return Err(new Error('failed_to_list_functions', { cause: err }));
+    }
 }
 
 /**
@@ -54,7 +62,16 @@ export async function getFunction({
 }): Promise<Result<DeployedNangoFunction | undefined>> {
     try {
         const row = await repository.findActiveByName({ environmentId, providerConfigKey, name, type });
-        return Ok(row ? toDeployedNangoFunction(row) : undefined);
+        if (!row) {
+            return Ok(undefined);
+        }
+
+        const fn = toDeployedNangoFunction(row);
+        if (fn.isErr()) {
+            return Err(new Error('failed_to_get_function', { cause: fn.error }));
+        }
+
+        return Ok(fn.value);
     } catch (err) {
         return Err(new Error('failed_to_get_function', { cause: err }));
     }

--- a/packages/shared/lib/services/functions/service.ts
+++ b/packages/shared/lib/services/functions/service.ts
@@ -1,0 +1,61 @@
+import { Err, Ok } from '@nangohq/utils';
+
+import { toDeployedNangoFunction } from './mappers.js';
+import * as repository from './repository.js';
+
+import type { DeployedNangoFunction, FunctionType } from '@nangohq/types';
+import type { Result } from '@nangohq/utils';
+
+/**
+ * Lists active deployed functions for a single integration across syncs,
+ * actions, and on-event scripts. Pagination total is returned independently
+ * of the page so out-of-range pages still surface the correct total.
+ */
+export async function listFunctions({
+    environmentId,
+    providerConfigKey,
+    type,
+    search,
+    limit,
+    offset
+}: {
+    environmentId: number;
+    providerConfigKey: string;
+    type: FunctionType | undefined;
+    search: string | undefined;
+    limit: number;
+    offset: number;
+}): Promise<{ rows: DeployedNangoFunction[]; total: number }> {
+    const { rows: dbRows, total } = await repository.findActiveByEnvironment({ environmentId, providerConfigKey, type, search, limit, offset });
+
+    const rows = dbRows.flatMap((row) => {
+        const fn = toDeployedNangoFunction(row);
+        return fn ? [fn] : [];
+    });
+
+    return { rows, total };
+}
+
+/**
+ * Fetches a single deployed function by name within a provider config.
+ * If `type` is omitted and multiple types share the same name, the first
+ * match by the listing's stable order is returned.
+ */
+export async function getFunction({
+    environmentId,
+    providerConfigKey,
+    name,
+    type
+}: {
+    environmentId: number;
+    providerConfigKey: string;
+    name: string;
+    type: FunctionType | undefined;
+}): Promise<Result<DeployedNangoFunction | undefined>> {
+    try {
+        const row = await repository.findActiveByName({ environmentId, providerConfigKey, name, type });
+        return Ok(row ? toDeployedNangoFunction(row) : undefined);
+    } catch (err) {
+        return Err(new Error('failed_to_get_function', { cause: err }));
+    }
+}

--- a/packages/shared/lib/services/functions/service.unit.test.ts
+++ b/packages/shared/lib/services/functions/service.unit.test.ts
@@ -1,0 +1,126 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+import { getFunction, listFunctions } from './service.js';
+
+import type { FunctionRow } from './repository.js';
+
+const { mockFindActiveByEnvironment, mockFindActiveByName } = vi.hoisted(() => {
+    return {
+        mockFindActiveByEnvironment: vi.fn(),
+        mockFindActiveByName: vi.fn()
+    };
+});
+
+vi.mock('./repository.js', () => ({
+    findActiveByEnvironment: mockFindActiveByEnvironment,
+    findActiveByName: mockFindActiveByName
+}));
+
+const baseRow: FunctionRow = {
+    id: 1,
+    name: 'users',
+    type: 'sync',
+    metadata: { description: 'Sync users', scopes: ['read:users'] },
+    input: 'UserInput',
+    returns: ['User'],
+    json_schema: null,
+    runs: 'every day',
+    auto_start: true,
+    track_deletes: false,
+    enabled: true,
+    last_deployed: new Date('2026-01-01T00:00:00.000Z'),
+    source: 'repo',
+    event: null
+};
+
+describe('functions service', () => {
+    beforeEach(() => {
+        vi.clearAllMocks();
+    });
+
+    it('returns mapped rows and total for valid functions', async () => {
+        mockFindActiveByEnvironment.mockResolvedValue({ rows: [baseRow], total: 1 });
+
+        const result = await listFunctions({
+            environmentId: 1,
+            providerConfigKey: 'github',
+            type: undefined,
+            search: undefined,
+            limit: 20,
+            offset: 0
+        });
+
+        expect(result.isOk()).toBe(true);
+        if (result.isErr()) {
+            return;
+        }
+
+        expect(result.value).toEqual({
+            rows: [
+                {
+                    id: 1,
+                    name: 'users',
+                    type: 'sync',
+                    description: 'Sync users',
+                    scopes: ['read:users'],
+                    input: 'UserInput',
+                    returns: ['User'],
+                    json_schema: null,
+                    runs: 'every day',
+                    auto_start: true,
+                    track_deletes: false,
+                    enabled: true,
+                    last_deployed: '2026-01-01T00:00:00.000Z',
+                    source: 'repo'
+                }
+            ],
+            total: 1
+        });
+    });
+
+    it('returns Err instead of silently dropping invalid on-event rows', async () => {
+        mockFindActiveByEnvironment.mockResolvedValue({
+            rows: [{ ...baseRow, type: 'on-event', event: 'UNKNOWN_EVENT', input: null, returns: null, runs: null, auto_start: null, track_deletes: null }],
+            total: 1
+        });
+
+        const result = await listFunctions({
+            environmentId: 1,
+            providerConfigKey: 'github',
+            type: undefined,
+            search: undefined,
+            limit: 20,
+            offset: 0
+        });
+
+        expect(result.isErr()).toBe(true);
+        if (result.isErr()) {
+            expect(result.error.message).toBe('failed_to_list_functions');
+        }
+    });
+
+    it('returns Err when a single function row cannot be mapped', async () => {
+        mockFindActiveByName.mockResolvedValue({
+            ...baseRow,
+            type: 'on-event',
+            input: null,
+            returns: null,
+            runs: null,
+            auto_start: null,
+            track_deletes: null,
+            event: 'UNKNOWN_EVENT'
+        });
+
+        const result = await getFunction({
+            environmentId: 1,
+            providerConfigKey: 'github',
+            name: 'users',
+            type: 'on-event'
+        });
+
+        expect(result.isErr()).toBe(true);
+        if (result.isErr()) {
+            expect(result.error.message).toBe('failed_to_get_function');
+        }
+    });
+});

--- a/packages/shared/lib/services/on-event-scripts.service.ts
+++ b/packages/shared/lib/services/on-event-scripts.service.ts
@@ -143,8 +143,8 @@ export const onEventScriptService = {
         return db.knex.from<DBOnEventScript>(TABLE).where({ config_id: configId, active: true, event: eventTypeMapper.toDb(event) });
     },
 
-    getByConfigAndName: async (configId: number, name: string): Promise<OnEventScript[]> => {
-        const rows = await db.knex
+    getByConfigAndName: async (configId: number, name: string): Promise<OnEventScript | null> => {
+        const row = await db.knex
             .select<(DBOnEventScript & { provider_config_key: string })[]>(`${TABLE}.*`, '_nango_configs.unique_key as provider_config_key')
             .from(TABLE)
             .join('_nango_configs', `${TABLE}.config_id`, '_nango_configs.id')
@@ -152,8 +152,10 @@ export const onEventScriptService = {
                 [`${TABLE}.config_id`]: configId,
                 [`${TABLE}.name`]: name,
                 [`${TABLE}.active`]: true
-            });
-        return rows.map(dbMapper.from);
+            })
+            .first();
+
+        return row ? dbMapper.from(row) : null;
     },
 
     diffChanges: async ({

--- a/packages/shared/lib/services/on-event-scripts.service.ts
+++ b/packages/shared/lib/services/on-event-scripts.service.ts
@@ -3,32 +3,13 @@ import { env } from '@nangohq/utils';
 
 import configService from './config.service.js';
 import remoteFileService from './file/remote.service.js';
+import { eventTypeMapper } from './functions/mappers.js';
 import { resolveLocalFileName } from '../utils/utils.js';
 import { increment } from './sync/config/config.service.js';
 
 import type { DBEnvironment, DBOnEventScript, DBTeam, OnEventScript, OnEventScriptsByProvider, OnEventType } from '@nangohq/types';
 
 const TABLE = 'on_event_scripts';
-
-const EVENT_TYPE_MAPPINGS: Record<DBOnEventScript['event'], OnEventType> = {
-    POST_CONNECTION_CREATION: 'post-connection-creation',
-    PRE_CONNECTION_DELETION: 'pre-connection-deletion',
-    VALIDATE_CONNECTION: 'validate-connection'
-} as const;
-
-const eventTypeMapper = {
-    fromDb: (event: DBOnEventScript['event']): OnEventType => {
-        return EVENT_TYPE_MAPPINGS[event];
-    },
-    toDb: (eventType: OnEventType): DBOnEventScript['event'] => {
-        for (const [key, value] of Object.entries(EVENT_TYPE_MAPPINGS)) {
-            if (value === eventType) {
-                return key as DBOnEventScript['event'];
-            }
-        }
-        throw new Error(`Unknown event type: ${eventType}`); // This should never happen
-    }
-};
 
 const dbMapper = {
     to: (script: OnEventScript): DBOnEventScript => {

--- a/packages/types/lib/functions/api.ts
+++ b/packages/types/lib/functions/api.ts
@@ -1,9 +1,5 @@
 import type { ApiError, Endpoint } from '../api.js';
-import type { OnEventType } from '../scripts/on-events/api.js';
-import type { FunctionSource } from '../syncConfigs/db.js';
-import type { JSONSchema7 } from 'json-schema';
-
-export type FunctionType = 'action' | 'sync' | 'on-event';
+import type { DeployedNangoFunction, FunctionType, NangoActionFunction, NangoSyncFunction } from './domain.js';
 
 export type FunctionErrorCode =
     | 'invalid_request'
@@ -94,50 +90,6 @@ export type PostRemoteFunctionDeploy = Endpoint<{
     };
 }>;
 
-interface NangoFunctionBase {
-    name: string;
-    description?: string;
-    scopes?: string[];
-}
-
-export interface NangoSyncFunction extends NangoFunctionBase {
-    type: 'sync';
-    input?: string;
-    returns: string[];
-    json_schema: JSONSchema7 | null;
-    /** Cron expression. */
-    runs: string | null;
-    auto_start: boolean;
-    track_deletes: boolean;
-}
-
-export interface NangoActionFunction extends NangoFunctionBase {
-    type: 'action';
-    input?: string;
-    returns: string[];
-    json_schema: JSONSchema7 | null;
-}
-
-export interface NangoOnEventFunction extends NangoFunctionBase {
-    type: 'on-event';
-    event: OnEventType;
-}
-
-export type NangoFunction = NangoSyncFunction | NangoActionFunction | NangoOnEventFunction;
-
-interface DeployedMeta {
-    id: number;
-    enabled: boolean;
-    /** ISO-8601 timestamp. */
-    last_deployed: string;
-    source: FunctionSource;
-}
-
-export type NangoSyncFunctionDeployed = NangoSyncFunction & DeployedMeta;
-export type NangoActionFunctionDeployed = NangoActionFunction & DeployedMeta;
-export type NangoOnEventFunctionDeployed = NangoOnEventFunction & DeployedMeta;
-export type NangoFunctionDeployed = NangoSyncFunctionDeployed | NangoActionFunctionDeployed | NangoOnEventFunctionDeployed;
-
 export type GetIntegrationFunctions = Endpoint<{
     Method: 'GET';
     Path: '/api/v1/integrations/:providerConfigKey/functions';
@@ -150,7 +102,7 @@ export type GetIntegrationFunctions = Endpoint<{
     };
     Params: { providerConfigKey: string };
     Success: {
-        data: NangoFunctionDeployed[];
+        data: DeployedNangoFunction[];
         pagination: { total: number; page: number; limit: number };
     };
 }>;
@@ -160,7 +112,7 @@ export type GetIntegrationFunction = Endpoint<{
     Path: '/api/v1/integrations/:providerConfigKey/functions/:functionName';
     Querystring: { env: string; type?: FunctionType };
     Params: { providerConfigKey: string; functionName: string };
-    Success: { data: NangoFunctionDeployed };
+    Success: { data: DeployedNangoFunction };
 }>;
 
 export type GetProviderTemplates = Endpoint<{

--- a/packages/types/lib/functions/domain.ts
+++ b/packages/types/lib/functions/domain.ts
@@ -15,7 +15,7 @@ export interface NangoSyncFunction extends NangoFunctionBase {
     input?: string;
     returns: string[];
     json_schema: JSONSchema7 | null;
-    /** Cron expression. */
+    /** Schedule expression such as `every day`. */
     runs: string | null;
     auto_start: boolean;
     track_deletes: boolean;

--- a/packages/types/lib/functions/domain.ts
+++ b/packages/types/lib/functions/domain.ts
@@ -1,0 +1,49 @@
+import type { OnEventType } from '../scripts/on-events/api.js';
+import type { FunctionSource } from '../syncConfigs/db.js';
+import type { JSONSchema7 } from 'json-schema';
+
+export type FunctionType = 'action' | 'sync' | 'on-event';
+
+interface NangoFunctionBase {
+    name: string;
+    description?: string;
+    scopes?: string[];
+}
+
+export interface NangoSyncFunction extends NangoFunctionBase {
+    type: 'sync';
+    input?: string;
+    returns: string[];
+    json_schema: JSONSchema7 | null;
+    /** Cron expression. */
+    runs: string | null;
+    auto_start: boolean;
+    track_deletes: boolean;
+}
+
+export interface NangoActionFunction extends NangoFunctionBase {
+    type: 'action';
+    input?: string;
+    returns: string[];
+    json_schema: JSONSchema7 | null;
+}
+
+export interface NangoOnEventFunction extends NangoFunctionBase {
+    type: 'on-event';
+    event: OnEventType;
+}
+
+export type NangoFunction = NangoSyncFunction | NangoActionFunction | NangoOnEventFunction;
+
+interface DeployedMeta {
+    id: number;
+    enabled: boolean;
+    /** ISO-8601 timestamp. */
+    last_deployed: string;
+    source: FunctionSource;
+}
+
+export type DeployedNangoSyncFunction = NangoSyncFunction & DeployedMeta;
+export type DeployedNangoActionFunction = NangoActionFunction & DeployedMeta;
+export type DeployedNangoOnEventFunction = NangoOnEventFunction & DeployedMeta;
+export type DeployedNangoFunction = DeployedNangoSyncFunction | DeployedNangoActionFunction | DeployedNangoOnEventFunction;

--- a/packages/types/lib/index.ts
+++ b/packages/types/lib/index.ts
@@ -99,6 +99,7 @@ export type * from './checkpoint/db.js';
 
 export type * from './mcp/api.js';
 export type * from './functions/api.js';
+export type * from './functions/domain.js';
 
 export type * from './lambda/index.js';
 export type * from './authz/types.js';


### PR DESCRIPTION
This is mostly a protective cleanup.

The normal zero-yaml flow already makes duplicate on-event function names unlikely, since one event function file naturally maps to one function name. Still, the backend had logic that explicitly tolerated this state in a few places by collapsing same-name on-event entries on read paths instead of rejecting them.

I checked production and found no existing cases, so tightening this up felt like the right defensive move before we build on top of the function APIs further.