### PR TITLE
feat(metering): observability + 60s CH timeout for S3 export cron

### DIFF
--- a/packages/metering/lib/crons/billingEventsS3Export.ts
+++ b/packages/metering/lib/crons/billingEventsS3Export.ts
@@ -3,7 +3,7 @@ import * as cron from 'node-cron';
 
 import { getLocking } from '@nangohq/kvstore';
 import { clickhouseClient } from '@nangohq/usage';
-import { getLogger } from '@nangohq/utils';
+import { getLogger, metrics } from '@nangohq/utils';
 
 import { envs } from '../env.js';
 
@@ -165,18 +165,30 @@ export async function exec(): Promise<void> {
                 logger.error(`Clickhouse client not configured`);
                 return;
             }
+            const day = yesterdayUTC();
+            const runTimestamp = nowCompactUTC();
             try {
-                const day = yesterdayUTC();
-                const runTimestamp = nowCompactUTC();
                 for (const metric of METRICS) {
                     const eventName = `${metric.canonicalEventName}${eventNameSuffix}`;
                     const sql = exportSql({ metric, day, runTimestamp, eventName });
                     logger.info(`Exporting ${eventName} for day=${day}`);
-                    await client.command({ query: sql });
+                    const start = process.hrtime.bigint();
+                    try {
+                        await client.command({ query: sql });
+                        logger.info(`Exported ${eventName} for day=${day}`);
+                        metrics.increment(metrics.Types.BILLING_USAGE_CLICKHOUSE_S3_EXPORT_RESULT, 1, { metric: metric.canonicalEventName, success: 'true' });
+                    } catch (err) {
+                        // Per-metric catch so a single failure (e.g. CH timeout on
+                        // a heavy table) does not abort the rest of the run.
+                        logger.error(`Failed to export ${eventName} for day=${day}`, err);
+                        metrics.increment(metrics.Types.BILLING_USAGE_CLICKHOUSE_S3_EXPORT_RESULT, 1, { metric: metric.canonicalEventName, success: 'false' });
+                    } finally {
+                        metrics.distribution(metrics.Types.BILLING_USAGE_CLICKHOUSE_S3_EXPORT_DURATION_MS, Number(process.hrtime.bigint() - start) / 1e6, {
+                            metric: metric.canonicalEventName
+                        });
+                    }
                 }
                 logger.info(`✅ done`);
-            } catch (err) {
-                logger.error('Failed to export billing events to S3', err);
             } finally {
                 await client.close();
             }

--- a/packages/metering/lib/crons/usage.ts
+++ b/packages/metering/lib/crons/usage.ts
@@ -64,7 +64,10 @@ export async function exec(): Promise<void> {
             // only releasing the lock on error
             // and letting it expires otherwise so no other execution can occur until the next cron
         } finally {
-            await clickhouse.shutdown();
+            // Matches the bumped CH request_timeout (60s) so at least one full flush
+            // attempt can complete before shutdown bails. If that attempt times out,
+            // the shutdown-orphan metric will surface the loss in dashboards.
+            await clickhouse.shutdown({ timeoutMs: 60_000 });
         }
     });
 }

--- a/packages/usage/lib/clickhouse/batcher.ts
+++ b/packages/usage/lib/clickhouse/batcher.ts
@@ -133,6 +133,10 @@ export class Batcher<T> {
             if (Date.now() - start > timeoutMs) {
                 if (this.queue.length > 0) {
                     logger.error(`Clickhouse batcher shutdown timed out. Dropping ${this.queue.length} items.`);
+                    metrics.increment(metrics.Types.BILLING_USAGE_CLICKHOUSE_BATCHER_INGEST_RESULT, this.queue.length, {
+                        success: 'false',
+                        reason: 'shutdown_orphan'
+                    });
                 }
                 return Err(new Error('Clickhouse batcher shutdown timed out'));
             }
@@ -145,7 +149,11 @@ export class Batcher<T> {
             }
             const res = await this.flush();
             if (res.isErr()) {
-                return res;
+                // Log + continue: the per-flush retry/drop accounting still happens
+                // inside flush(), so letting the loop iterate lets retries exhaust
+                // naturally within timeoutMs. Bailing here would orphan the items
+                // without ever reaching the success=false drop threshold.
+                logger.warning(`Clickhouse batcher: flush failed during shutdown, retrying within remaining budget`);
             }
         }
         return Ok(undefined);

--- a/packages/usage/lib/clickhouse/batcher.unit.test.ts
+++ b/packages/usage/lib/clickhouse/batcher.unit.test.ts
@@ -201,20 +201,18 @@ describe('Batcher', () => {
             expect(batcher['queue']).toEqual([]);
         });
 
-        it('should return Err if processing fails during shutdown flush', async () => {
-            const shutdownError = new Error('Shutdown process fail');
-            mockProcess.mockRejectedValueOnce(shutdownError);
+        it('should retry a transient flush failure during shutdown and succeed', async () => {
+            // shutdown() now logs+continues on flush Err so the per-flush retry path
+            // can run to success within timeoutMs.
+            mockProcess.mockRejectedValueOnce(new Error('Transient'));
             const batcher = new Batcher({ process: mockProcess, maxBatchSize: 5 });
             batcher.add('item1');
 
             const res = await batcher.shutdown();
-            expect(res.isErr()).toBe(true);
-            if (res.isErr()) {
-                expect(res.error.message).toBe('Batcher failed to process batch');
-                expect(res.error.cause).toBe(shutdownError);
-            }
-            expect(batcher['queue']).toEqual(['item1']);
-            expect(batcher['retry']).toEqual(expect.objectContaining({ size: 1, attempts: 1 }));
+            expect(res.isOk()).toBe(true);
+            expect(mockProcess).toHaveBeenCalledTimes(2);
+            expect(batcher['queue']).toEqual([]);
+            expect(batcher['retry']).toBeNull();
         });
 
         it('should return successfully when queue is empty and not processing', async () => {
@@ -223,23 +221,36 @@ describe('Batcher', () => {
             expect(res.isOk()).toBe(true);
             expect(mockProcess).not.toHaveBeenCalled();
         });
-        it('should return error from shutdown if a forced flush fails and items are discarded (max retries)', async () => {
+
+        it('should drop items after exhausting retries within shutdown and return Ok with empty queue', async () => {
+            // maxProcessingRetry=0 → first failure drops. Queue ends empty, shutdown
+            // completes cleanly (the drop itself is the terminal outcome, accounted
+            // for via BATCHER_INGEST_RESULT{success=false, reason=insert_failed}).
             const batcher = new Batcher({ process: mockProcess, maxBatchSize: 10, maxProcessingRetry: 0 });
             batcher.add('item1');
-
-            const processError = new Error('Processing failed');
-            mockProcess.mockRejectedValueOnce(processError);
+            mockProcess.mockRejectedValueOnce(new Error('Processing failed'));
 
             const res = await batcher.shutdown({ timeoutMs: 100 });
 
+            expect(res.isOk()).toBe(true);
+            expect(mockProcess).toHaveBeenCalledTimes(1);
+            expect(batcher['queue']).toEqual([]);
+        });
+
+        it('should return Err and leave items in the queue when timeoutMs elapses', async () => {
+            // Retries never exhaust because maxProcessingRetry is huge; the
+            // wall-clock budget runs out first and the orphan branch fires.
+            vi.useRealTimers(); // need actual time progression for Date.now()
+            const batcher = new Batcher({ process: mockProcess, maxBatchSize: 5, maxProcessingRetry: 1_000_000 });
+            batcher.add('item1');
+            mockProcess.mockRejectedValue(new Error('Always fails'));
+
+            const res = await batcher.shutdown({ timeoutMs: 30 });
             expect(res.isErr()).toBe(true);
             if (res.isErr()) {
-                expect(res.error.message).toBe('Batcher failed to process batch');
-                expect(res.error.cause).toBe(processError);
+                expect(res.error.message).toBe('Clickhouse batcher shutdown timed out');
             }
-            expect(mockProcess).toHaveBeenCalledTimes(1);
-            expect(mockProcess).toHaveBeenCalledWith(['item1'], expect.objectContaining({ retryKey: expect.any(String) }));
-            expect(batcher['queue']).toEqual([]);
+            expect(batcher['queue']).toEqual(['item1']);
         });
     });
 

--- a/packages/usage/lib/clickhouse/clickhouse.ts
+++ b/packages/usage/lib/clickhouse/clickhouse.ts
@@ -258,8 +258,8 @@ export class Clickhouse {
         }
     }
 
-    async shutdown(): Promise<Result<void>> {
-        const res = this.batcher ? await this.batcher.shutdown() : Ok(undefined);
+    async shutdown(opts?: { timeoutMs: number }): Promise<Result<void>> {
+        const res = this.batcher ? await this.batcher.shutdown(opts) : Ok(undefined);
 
         try {
             await this.client?.close();

--- a/packages/usage/lib/clickhouse/config.ts
+++ b/packages/usage/lib/clickhouse/config.ts
@@ -15,6 +15,9 @@ export function clickhouseClient(opts?: { database: string }): ClickHouseClient 
     return createClient({
         url: envs.CLICKHOUSE_URL,
         ...(opts?.database ? { database: opts.database } : {}),
+        // CH Cloud auto-suspend wake-up on idle instances can exceed the 30s
+        // client default — bumping to 60s rides out the cold-start.
+        request_timeout: 60_000,
         clickhouse_settings: {
             // Block-level dedup on INSERTs to raw_events. Default is 1 for Replicated/Shared
             // engines but we set it explicitly so batcher retries that re-send a bit-identical

--- a/packages/utils/lib/telemetry/metrics.ts
+++ b/packages/utils/lib/telemetry/metrics.ts
@@ -121,6 +121,8 @@ export enum Types {
     BILLING_USAGE_CLICKHOUSE_BATCHER_INGEST_DURATION_MS = 'nango.billing.usage.clickhouse.batcher.ingest.duration_ms',
     BILLING_USAGE_CLICKHOUSE_BATCHER_INGEST_RESULT = 'nango.billing.usage.clickhouse.batcher.ingest.result',
     BILLING_USAGE_CLICKHOUSE_BATCHER_RETRY = 'nango.billing.usage.clickhouse.batcher.retry',
+    BILLING_USAGE_CLICKHOUSE_S3_EXPORT_RESULT = 'nango.billing.usage.clickhouse.s3_export.result',
+    BILLING_USAGE_CLICKHOUSE_S3_EXPORT_DURATION_MS = 'nango.billing.usage.clickhouse.s3_export.duration_ms',
 
     USAGE_IS_CAPPED = 'nango.capping.isCapped',
 


### PR DESCRIPTION
## Changes

- **Observability for the S3 export cron** — we couldn't tell from logs or DataDog whether an hourly run actually succeeded; adds per-metric success log + counter + duration distribution so each metric's outcome is visible.
- **Resilience to CH Cloud cold-starts** — dev-env logs showed both the S3 export and the Batcher hitting 30s client timeouts after idle periods, with silent data loss; bumps the CH client `request_timeout` to 60s and fixes the Batcher's shutdown path so any remaining loss is now reported instead of orphaned.

## Resilience details

- **`request_timeout` 30s → 60s** — long enough to ride out CH Cloud auto-suspend wake-up.
- **`Batcher.shutdown()` no longer bails on the first flush `Err`** — it logs and continues so the per-flush retry/drop accounting can complete within `timeoutMs`, instead of orphaning items on the first timeout.
- **New `BATCHER_INGEST_RESULT{success=false, reason='shutdown_orphan'}` metric** — fires for items still queued when `timeoutMs` elapses, so the loss is visible in DataDog rather than only in a log line.
- **`cron.exportUsage` passes `shutdown({ timeoutMs: 60_000 })`** — matches the new request timeout so at least one full flush attempt fits before the budget runs out.

## Test plan

- [x] Batcher unit tests updated; one added for the orphan path. All 20 passing locally.
- [x] After deploy: confirm the hourly cron tick no longer times out at 30s in dev when CH is idle.
- [x] After deploy: confirm the new `Exported ...` log + per-metric result metric show up in DD.
- [x] Confirm a single-metric failure produces `success=false` for that metric and the rest still upload.