### PR TITLE
fix(server): return credentials for get integration for gh oauth app

### DIFF
--- a/docs/llms-full.txt
+++ b/docs/llms-full.txt
@@ -8717,7 +8717,7 @@ Source: https://nango.dev/docs/reference/backend/http-api/integration/get.md
 </Info>
 
 <ResponseExample>
-```json Example Response
+```json Basic response
 {
   "data": {
     "unique_key": "slack-nango-community",
@@ -8725,7 +8725,48 @@ Source: https://nango.dev/docs/reference/backend/http-api/integration/get.md
     "provider": "slack",
     "logo": "http://localhost:3003/images/template-logos/github.svg",
     "created_at": "2023-10-16T08:45:26.241Z",
+    "updated_at": "2023-10-16T08:45:26.241Z"
+  }
+}
+```
+
+```json With credentials (OAuth2/OAuth1/TBA)
+{
+  "data": {
+    "unique_key": "github-nango",
+    "display_name": "GitHub",
+    "provider": "github",
+    "logo": "http://localhost:3003/images/template-logos/github.svg",
+    "created_at": "2023-10-16T08:45:26.241Z",
     "updated_at": "2023-10-16T08:45:26.241Z",
+    "credentials": {
+      "type": "OAUTH2",
+      "client_id": "abc123",
+      "client_secret": "secret456",
+      "scopes": "repo,user",
+      "webhook_secret": null
+    }
+  }
+}
+```
+
+```json With credentials (GitHub App / CUSTOM)
+{
+  "data": {
+    "unique_key": "github-app-nango",
+    "display_name": "GitHub App",
+    "provider": "github-app",
+    "logo": "http://localhost:3003/images/template-logos/github.svg",
+    "created_at": "2023-10-16T08:45:26.241Z",
+    "updated_at": "2023-10-16T08:45:26.241Z",
+    "credentials": {
+      "type": "CUSTOM",
+      "client_id": "abc123",
+      "client_secret": "secret456",
+      "app_id": "123456",
+      "app_link": "https://github.com/apps/my-app",
+      "private_key": "-----BEGIN RSA PRIVATE KEY-----\n...\n-----END RSA PRIVATE KEY-----"
+    }
   }
 }
 ```

--- a/docs/llms-full.txt
+++ b/docs/llms-full.txt
@@ -8724,6 +8724,7 @@ Source: https://nango.dev/docs/reference/backend/http-api/integration/get.md
     "display_name": "Slack",
     "provider": "slack",
     "logo": "http://localhost:3003/images/template-logos/github.svg",
+    "forward_webhooks": true,
     "created_at": "2023-10-16T08:45:26.241Z",
     "updated_at": "2023-10-16T08:45:26.241Z"
   }
@@ -8737,6 +8738,7 @@ Source: https://nango.dev/docs/reference/backend/http-api/integration/get.md
     "display_name": "GitHub",
     "provider": "github",
     "logo": "http://localhost:3003/images/template-logos/github.svg",
+    "forward_webhooks": false,
     "created_at": "2023-10-16T08:45:26.241Z",
     "updated_at": "2023-10-16T08:45:26.241Z",
     "credentials": {
@@ -8757,6 +8759,7 @@ Source: https://nango.dev/docs/reference/backend/http-api/integration/get.md
     "display_name": "GitHub App",
     "provider": "github-app",
     "logo": "http://localhost:3003/images/template-logos/github.svg",
+    "forward_webhooks": false,
     "created_at": "2023-10-16T08:45:26.241Z",
     "updated_at": "2023-10-16T08:45:26.241Z",
     "credentials": {
@@ -9776,7 +9779,7 @@ await nango.getIntegration(<INTEGRATION-ID>);
          The integration ID
     </ResponseField>
     <ResponseField name="include" type="array">
-        Include sensitive data. Allowed values: `webhook`
+        Include sensitive data. Allowed values: `webhook`, `credentials`
     </ResponseField>
 </Expandable>
 
@@ -9787,10 +9790,12 @@ await nango.getIntegration(<INTEGRATION-ID>);
 {
     "data": {
         "unique_key": "slack-nango-community",
+        "display_name": "Slack",
         "provider": "slack",
         "logo": "http://localhost:3003/images/template-logos/slack.svg",
+        "forward_webhooks": true,
         "created_at": "2023-10-16T08:45:26.241Z",
-        "updated_at": "2023-10-16T08:45:26.241Z",
+        "updated_at": "2023-10-16T08:45:26.241Z"
     }
 }
 ```

--- a/docs/reference/backend/backend-sdk/node.mdx
+++ b/docs/reference/backend/backend-sdk/node.mdx
@@ -114,7 +114,7 @@ await nango.getIntegration(<INTEGRATION-ID>);
          The integration ID
     </ResponseField>
     <ResponseField name="include" type="array">
-        Include sensitive data. Allowed values: `webhook`
+        Include sensitive data. Allowed values: `webhook`, `credentials`
     </ResponseField>
 </Expandable>
 
@@ -125,10 +125,12 @@ await nango.getIntegration(<INTEGRATION-ID>);
 {
     "data": {
         "unique_key": "slack-nango-community",
+        "display_name": "Slack",
         "provider": "slack",
         "logo": "http://localhost:3003/images/template-logos/slack.svg",
+        "forward_webhooks": true,
         "created_at": "2023-10-16T08:45:26.241Z",
-        "updated_at": "2023-10-16T08:45:26.241Z",
+        "updated_at": "2023-10-16T08:45:26.241Z"
     }
 }
 ```

--- a/docs/reference/backend/http-api/integration/get.mdx
+++ b/docs/reference/backend/http-api/integration/get.mdx
@@ -8,15 +8,59 @@ openapi: 'GET /integrations/{uniqueKey}'
 </Info>
 
 <ResponseExample>
-```json Example Response
+```json Basic response
 {
   "data": {
     "unique_key": "slack-nango-community",
     "display_name": "Slack",
     "provider": "slack",
     "logo": "http://localhost:3003/images/template-logos/github.svg",
+    "forward_webhooks": true,
+    "created_at": "2023-10-16T08:45:26.241Z",
+    "updated_at": "2023-10-16T08:45:26.241Z"
+  }
+}
+```
+
+```json With credentials (OAuth2/OAuth1/TBA)
+{
+  "data": {
+    "unique_key": "github-nango",
+    "display_name": "GitHub",
+    "provider": "github",
+    "logo": "http://localhost:3003/images/template-logos/github.svg",
+    "forward_webhooks": false,
     "created_at": "2023-10-16T08:45:26.241Z",
     "updated_at": "2023-10-16T08:45:26.241Z",
+    "credentials": {
+      "type": "OAUTH2",
+      "client_id": "abc123",
+      "client_secret": "secret456",
+      "scopes": "repo,user",
+      "webhook_secret": null
+    }
+  }
+}
+```
+
+```json With credentials (GitHub App / CUSTOM)
+{
+  "data": {
+    "unique_key": "github-app-nango",
+    "display_name": "GitHub App",
+    "provider": "github-app",
+    "logo": "http://localhost:3003/images/template-logos/github.svg",
+    "forward_webhooks": false,
+    "created_at": "2023-10-16T08:45:26.241Z",
+    "updated_at": "2023-10-16T08:45:26.241Z",
+    "credentials": {
+      "type": "CUSTOM",
+      "client_id": "abc123",
+      "client_secret": "secret456",
+      "app_id": "123456",
+      "app_link": "https://github.com/apps/my-app",
+      "private_key": "-----BEGIN RSA PRIVATE KEY-----\n...\n-----END RSA PRIVATE KEY-----"
+    }
   }
 }
 ```

--- a/docs/snippets/generated/planning-center-online/PreBuiltTooling.mdx
+++ b/docs/snippets/generated/planning-center-online/PreBuiltTooling.mdx
@@ -8,7 +8,6 @@
 | Auth parameters validation | ✅ |
 | Pre-built authorization UI | ✅ |
 | Custom authorization UI | ✅ |
-| End-user authorization guide | ✅ |
 | Expired credentials detection | ✅ |
 </Accordion>
 <Accordion title="✅ Read & write data">

--- a/docs/spec.yaml
+++ b/docs/spec.yaml
@@ -3096,6 +3096,9 @@ components:
                     type: string
                     format: date-time
                     description: Last time it was updated
+                forward_webhooks:
+                    type: boolean
+                    description: Whether webhooks received from this integration's provider are forwarded to your backend.
         IntegrationFull:
             allOf:
                 - $ref: '#/components/schemas/Integration'

--- a/packages/server/lib/controllers/integrations/uniqueKey/getIntegration.ts
+++ b/packages/server/lib/controllers/integrations/uniqueKey/getIntegration.ts
@@ -83,19 +83,19 @@ export const getPublicIntegration = asyncWrapper<GetPublicIntegration>(async (re
         } else if (provider.auth_mode === 'APP') {
             include.credentials = {
                 type: provider.auth_mode,
-                app_id: integration.oauth_client_id,
-                private_key: integration.oauth_client_secret,
+                app_id: integration.shared_credentials_id ? '' : integration.oauth_client_id,
+                private_key: integration.shared_credentials_id ? '' : integration.oauth_client_secret,
                 app_link: integration.app_link || null
             };
         } else if (provider.auth_mode === 'CUSTOM') {
             const rawPrivateKey = integration.custom?.['private_key'];
             include.credentials = {
                 type: provider.auth_mode,
-                client_id: integration.oauth_client_id,
-                client_secret: integration.oauth_client_secret,
-                app_id: integration.custom?.['app_id'] || null,
+                client_id: integration.shared_credentials_id ? '' : integration.oauth_client_id,
+                client_secret: integration.shared_credentials_id ? '' : integration.oauth_client_secret,
+                app_id: integration.shared_credentials_id ? '' : integration.custom?.['app_id'] || null,
                 app_link: integration.app_link || null,
-                private_key: rawPrivateKey ? Buffer.from(rawPrivateKey, 'base64').toString('utf8') : null
+                private_key: integration.shared_credentials_id ? '' : rawPrivateKey ? Buffer.from(rawPrivateKey, 'base64').toString('utf8') : null
             };
         } else {
             include.credentials = null;

--- a/packages/server/lib/controllers/integrations/uniqueKey/getIntegration.ts
+++ b/packages/server/lib/controllers/integrations/uniqueKey/getIntegration.ts
@@ -87,6 +87,16 @@ export const getPublicIntegration = asyncWrapper<GetPublicIntegration>(async (re
                 private_key: integration.oauth_client_secret,
                 app_link: integration.app_link || null
             };
+        } else if (provider.auth_mode === 'CUSTOM') {
+            const rawPrivateKey = integration.custom?.['private_key'];
+            include.credentials = {
+                type: provider.auth_mode,
+                client_id: integration.oauth_client_id,
+                client_secret: integration.oauth_client_secret,
+                app_id: integration.custom?.['app_id'] || null,
+                app_link: integration.app_link || null,
+                private_key: rawPrivateKey ? Buffer.from(rawPrivateKey, 'base64').toString('utf8') : null
+            };
         } else {
             include.credentials = null;
         }

--- a/packages/types/lib/integration/api.ts
+++ b/packages/types/lib/integration/api.ts
@@ -23,6 +23,14 @@ export interface ApiPublicIntegrationInclude {
               webhook_secret: string | null;
           }
         | { type: AuthModes['App']; app_id: string | null; private_key: string | null; app_link: string | null }
+        | {
+              type: AuthModes['Custom'];
+              client_id: string | null;
+              client_secret: string | null;
+              app_id: string | null;
+              app_link: string | null;
+              private_key: string | null;
+          }
         | null;
 }
 

--- a/packages/webapp/src/pages/Integrations/providerConfigKey/Settings/components/OAuth2CCSettings.tsx
+++ b/packages/webapp/src/pages/Integrations/providerConfigKey/Settings/components/OAuth2CCSettings.tsx
@@ -49,6 +49,8 @@ export const OAuth2CCSettings: React.FC<{ data: GetIntegration['Success']['data'
                     onChange={handleScopesChange}
                     isSharedCredentials={isSharedCredentials}
                     readOnly={!canEdit}
+                    availableScopes={template.available_scopes}
+                    showAvailableScopesDropdown={true}
                 />
             </div>
         </div>


### PR DESCRIPTION
## Describe the problem and your solution

-  return credentials for `get integration` endpoint for github-oauth-app, which is the only provider that uses the CUSTOM auth-mode.
- Add suggested scopes property to OAUTH2_CC providers since we now have them generated by our agent.

<!-- Issue ticket number and link (if applicable) -->

<!-- Testing instructions (skip if just adding/editing providers) -->

