### PR TITLE
fix(server): make email comparisons case insensitive

### DIFF
--- a/packages/server/lib/controllers/v1/account/managed/auth.ts
+++ b/packages/server/lib/controllers/v1/account/managed/auth.ts
@@ -1,6 +1,6 @@
 import db from '@nangohq/database';
 import { acceptInvitation, accountService, expirePreviousInvitations, getInvitation, userService } from '@nangohq/shared';
-import { basePublicUrl, flagHasUsage, nanoid, report } from '@nangohq/utils';
+import { basePublicUrl, flagHasUsage, nanoid, normalizeEmailAddress, report } from '@nangohq/utils';
 
 import { envs } from '../../../../env.js';
 import { linkBillingCustomer, linkBillingFreeSubscription } from '../../../../utils/billing.js';
@@ -133,7 +133,7 @@ export async function finalizeManagedAuthentication({
     let invitation: DBInvitation | null = null;
     if (state?.token) {
         invitation = await getInvitation(state.token);
-        if (!invitation || invitation.email !== authorizedUser.email) {
+        if (!invitation || normalizeEmailAddress(invitation.email) !== normalizeEmailAddress(authorizedUser.email)) {
             res.status(400).send({ error: { code: 'not_found', message: 'Invitation does not exist or is expired' } });
             return;
         }

--- a/packages/server/lib/controllers/v1/account/managed/verification.integration.test.ts
+++ b/packages/server/lib/controllers/v1/account/managed/verification.integration.test.ts
@@ -65,7 +65,7 @@ describe(`POST ${route}`, () => {
     });
 
     it('should complete the pending WorkOS email verification flow and create the local user', async () => {
-        const email = `${nanoid()}@example.com`;
+        const email = `${nanoid().toLowerCase()}@example.com`;
         const verificationCode = '123456';
 
         workosMocks.authenticateWithCode.mockRejectedValue({
@@ -152,6 +152,54 @@ describe(`POST ${route}`, () => {
                 code: 'not_found',
                 message: 'No pending WorkOS email verification was found. Please try signing in with Google again.'
             }
+        });
+    });
+
+    it('should lowercase the persisted user email from a mixed-case WorkOS email', async () => {
+        const normalizedEmail = `case-${nanoid().toLowerCase()}@example.com`;
+        const mixedCaseEmail = `Case-${normalizedEmail.slice('case-'.length)}`;
+
+        workosMocks.authenticateWithCode.mockRejectedValue({
+            rawData: {
+                code: 'email_verification_required',
+                message: 'Email ownership must be verified before authentication.',
+                pending_authentication_token: 'pending_token_123',
+                email: mixedCaseEmail,
+                email_verification_id: 'email_verification_123'
+            }
+        });
+
+        workosMocks.authenticateWithEmailVerification.mockResolvedValue({
+            user: {
+                email: mixedCaseEmail,
+                firstName: 'Managed',
+                lastName: 'User'
+            },
+            organizationId: undefined
+        });
+
+        const callbackRes = await fetch(`${api.url}/api/v1/login/callback?code=oauth_code_123`, {
+            redirect: 'manual'
+        });
+
+        const sessionCookie = callbackRes.headers.getSetCookie()[0]?.split(';')[0];
+        expect(sessionCookie).toBeTruthy();
+
+        const postVerificationRes = await api.fetch('/api/v1/account/managed/verification', {
+            method: 'POST',
+            session: sessionCookie!,
+            body: {
+                code: '123456'
+            }
+        });
+
+        expect(postVerificationRes.res.status).toBe(200);
+
+        const createdUser = await userService.getUserByEmail(normalizedEmail);
+        expect(createdUser).toMatchObject({
+            email: normalizedEmail,
+            email_verified: true,
+            name: 'Managed User'
         });
     });
 

--- a/packages/server/lib/controllers/v1/account/postForgotPassword.integration.test.ts
+++ b/packages/server/lib/controllers/v1/account/postForgotPassword.integration.test.ts
@@ -1,0 +1,41 @@
+import { afterAll, beforeAll, describe, expect, it } from 'vitest';
+
+import db from '@nangohq/database';
+import { seeders, userService } from '@nangohq/shared';
+import { nanoid } from '@nangohq/utils';
+
+import { isSuccess, runServer } from '../../../utils/tests.js';
+
+const route = '/api/v1/account/forgot-password';
+
+let api: Awaited<ReturnType<typeof runServer>>;
+
+describe(`POST ${route}`, () => {
+    beforeAll(async () => {
+        api = await runServer();
+    });
+
+    afterAll(() => {
+        api.server.close();
+    });
+
+    it('should find a mixed-case stored email with lowercase input', async () => {
+        const { user } = await seeders.seedAccountEnvAndUser();
+        const inputEmail = `casing-${nanoid()}@example.com`;
+        const mixedCaseEmail = `Casing-${inputEmail.slice('casing-'.length)}`;
+
+        await db.knex('_nango_users').where({ id: user.id }).update({ email: mixedCaseEmail });
+
+        const res = await api.fetch(route, {
+            method: 'POST',
+            body: { email: inputEmail }
+        });
+
+        expect(res.res.status).toBe(200);
+        isSuccess(res.json);
+        expect(res.json).toStrictEqual({ success: true });
+
+        const updatedUser = await userService.getUserByEmail(inputEmail);
+        expect(updatedUser?.reset_password_token).toBeTruthy();
+    });
+});

--- a/packages/server/lib/controllers/v1/account/signin.integration.test.ts
+++ b/packages/server/lib/controllers/v1/account/signin.integration.test.ts
@@ -1,6 +1,7 @@
 import { afterAll, beforeAll, describe, expect, it } from 'vitest';
 
-import { userService } from '@nangohq/shared';
+import db from '@nangohq/database';
+import { seeders, userService } from '@nangohq/shared';
 import { nanoid } from '@nangohq/utils';
 
 import { isError, isSuccess, runServer } from '../../../utils/tests.js';
@@ -84,5 +85,23 @@ describe(`POST ${signinRoute}`, () => {
         const cookies = res.headers.getSetCookie();
         expect(cookies.length).toBeGreaterThan(0);
         expect(cookies[0]).toMatch(/^nango_session=/);
+    });
+
+    it('should authenticate a mixed-case stored email with lowercase input', async () => {
+        const { user } = await seeders.seedAccountEnvAndUser();
+        const inputEmail = `casing-${nanoid()}@example.com`;
+        const mixedCaseEmail = `Casing-${inputEmail.slice('casing-'.length)}`;
+
+        await db.knex('_nango_users').where({ id: user.id }).update({ email: mixedCaseEmail });
+
+        const { res, json } = await api.fetch(signinRoute, {
+            method: 'POST',
+            body: { email: inputEmail, password: 'Password123!' }
+        });
+
+        expect(res.status).toBe(200);
+        isSuccess(json);
+        expect(json).toHaveProperty('user');
+        expect(res.headers.getSetCookie()[0]).toMatch(/^nango_session=/);
     });
 });

--- a/packages/server/lib/controllers/v1/account/signup.integration.test.ts
+++ b/packages/server/lib/controllers/v1/account/signup.integration.test.ts
@@ -1,8 +1,10 @@
 import { afterAll, beforeAll, describe, expect, it } from 'vitest';
 
+import db from '@nangohq/database';
+import { seeders } from '@nangohq/shared';
 import { nanoid } from '@nangohq/utils';
 
-import { isSuccess, runServer } from '../../../utils/tests.js';
+import { isError, isSuccess, runServer } from '../../../utils/tests.js';
 
 const route = '/api/v1/account/signup';
 let api: Awaited<ReturnType<typeof runServer>>;
@@ -72,5 +74,22 @@ describe('POST /api/v1/account/signup', () => {
         isSuccess(res.json);
         expect(res.json.data.verified).toBe(false);
         expect(typeof res.json.data.uuid).toBe('string');
+    });
+
+    it('should treat existing user emails case-insensitively', async () => {
+        const { user } = await seeders.seedAccountEnvAndUser();
+        const inputEmail = `casing-${nanoid()}@example.com`;
+        const mixedCaseEmail = `Casing-${inputEmail.slice('casing-'.length)}`;
+
+        await db.knex('_nango_users').where({ id: user.id }).update({ email: mixedCaseEmail });
+
+        const res = await api.fetch(route, {
+            method: 'POST',
+            body: { email: inputEmail, name: 'Foobar', password: 'aZ1-foobar!', foundUs: 'the internet' }
+        });
+
+        expect(res.res.status).toBe(400);
+        isError(res.json);
+        expect(res.json.error.code).toBe('user_already_exists');
     });
 });

--- a/packages/server/lib/controllers/v1/invite/acceptInvite.ts
+++ b/packages/server/lib/controllers/v1/invite/acceptInvite.ts
@@ -1,7 +1,7 @@
 import * as z from 'zod';
 
 import { acceptInvitation, getInvitation, userService } from '@nangohq/shared';
-import { requireEmptyQuery, zodErrorToHTTP } from '@nangohq/utils';
+import { normalizeEmailAddress, requireEmptyQuery, zodErrorToHTTP } from '@nangohq/utils';
 
 import { asyncWrapper } from '../../../utils/asyncWrapper.js';
 
@@ -31,7 +31,7 @@ export const acceptInvite = asyncWrapper<AcceptInvite>(async (req, res) => {
     const { user } = res.locals;
     const data: AcceptInvite['Params'] = val.data;
     const invitation = await getInvitation(data.id);
-    if (!invitation || invitation.email !== user.email) {
+    if (!invitation || normalizeEmailAddress(invitation.email) !== normalizeEmailAddress(user.email)) {
         res.status(400).send({ error: { code: 'not_found', message: 'Invitation does not exist or is expired' } });
         return;
     }

--- a/packages/server/lib/controllers/v1/invite/acceptInvite.unit.test.ts
+++ b/packages/server/lib/controllers/v1/invite/acceptInvite.unit.test.ts
@@ -91,4 +91,41 @@ describe('acceptInvite', () => {
         expect(status).toHaveBeenCalledWith(200);
         expect(send).toHaveBeenCalledWith({ data: { success: true } });
     });
+
+    it('matches invite emails case-insensitively', async () => {
+        const invitationId = crypto.randomUUID();
+        mockGetInvitation.mockResolvedValue({
+            token: invitationId,
+            email: 'invitee@example.com',
+            account_id: 3,
+            role: nonDefaultRole
+        });
+
+        const req = {
+            params: { id: invitationId },
+            query: {},
+            route: { path: '/api/v1/invite/:id' },
+            originalUrl: '/api/v1/invite/:id',
+            header: vi.fn(),
+            session: {
+                passport: {},
+                save: vi.fn((callback: (err?: Error) => void) => callback())
+            }
+        } as unknown as Request;
+        const status = vi.fn().mockReturnThis();
+        const send = vi.fn().mockReturnThis();
+        const res = {
+            locals: {
+                user: { id: 2, email: 'Invitee@example.com' }
+            },
+            status,
+            send
+        } as unknown as Response;
+
+        await acceptInvite(req, res, vi.fn());
+
+        expect(mockUpdateUser).toHaveBeenCalledWith({ id: 2, account_id: 3, role: nonDefaultRole });
+        expect(status).toHaveBeenCalledWith(200);
+        expect(send).toHaveBeenCalledWith({ data: { success: true } });
+    });
 });

--- a/packages/server/lib/controllers/v1/invite/declineInvite.ts
+++ b/packages/server/lib/controllers/v1/invite/declineInvite.ts
@@ -1,7 +1,7 @@
 import * as z from 'zod';
 
 import { declineInvitation, getInvitation } from '@nangohq/shared';
-import { requireEmptyQuery, zodErrorToHTTP } from '@nangohq/utils';
+import { normalizeEmailAddress, requireEmptyQuery, zodErrorToHTTP } from '@nangohq/utils';
 
 import { asyncWrapper } from '../../../utils/asyncWrapper.js';
 
@@ -31,7 +31,7 @@ export const declineInvite = asyncWrapper<DeclineInvite>(async (req, res) => {
     const { user } = res.locals;
     const data: DeclineInvite['Params'] = val.data;
     const invitation = await getInvitation(data.id);
-    if (!invitation || invitation.email !== user.email) {
+    if (!invitation || normalizeEmailAddress(invitation.email) !== normalizeEmailAddress(user.email)) {
         res.status(400).send({ error: { code: 'not_found', message: 'Invitation does not exist or is expired' } });
         return;
     }

--- a/packages/server/lib/controllers/v1/invite/declineInvite.unit.test.ts
+++ b/packages/server/lib/controllers/v1/invite/declineInvite.unit.test.ts
@@ -1,0 +1,57 @@
+import crypto from 'node:crypto';
+
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+import { declineInvite } from './declineInvite.js';
+
+import type { Request, Response } from 'express';
+
+const { mockDeclineInvitation, mockGetInvitation } = vi.hoisted(() => {
+    return {
+        mockDeclineInvitation: vi.fn(),
+        mockGetInvitation: vi.fn()
+    };
+});
+
+vi.mock('@nangohq/shared', () => ({
+    declineInvitation: mockDeclineInvitation,
+    getInvitation: mockGetInvitation
+}));
+
+describe('declineInvite', () => {
+    beforeEach(() => {
+        vi.clearAllMocks();
+        mockDeclineInvitation.mockResolvedValue(true);
+    });
+
+    it('matches invite emails case-insensitively', async () => {
+        const invitationId = crypto.randomUUID();
+        mockGetInvitation.mockResolvedValue({
+            token: invitationId,
+            email: 'invitee@example.com'
+        });
+
+        const req = {
+            params: { id: invitationId },
+            query: {},
+            route: { path: '/api/v1/invite/:id' },
+            originalUrl: '/api/v1/invite/:id',
+            header: vi.fn()
+        } as unknown as Request;
+        const status = vi.fn().mockReturnThis();
+        const send = vi.fn().mockReturnThis();
+        const res = {
+            locals: {
+                user: { email: 'Invitee@example.com' }
+            },
+            status,
+            send
+        } as unknown as Response;
+
+        await declineInvite(req, res, vi.fn());
+
+        expect(mockDeclineInvitation).toHaveBeenCalledWith(invitationId);
+        expect(status).toHaveBeenCalledWith(200);
+        expect(send).toHaveBeenCalledWith({ data: { success: true } });
+    });
+});

--- a/packages/server/lib/utils/pii.ts
+++ b/packages/server/lib/utils/pii.ts
@@ -1,10 +1,8 @@
 import crypto from 'node:crypto';
 
-const EMAIL_ADDRESS_HASH_CONTEXT = 'nango.emailAddressHash.v1';
+import { normalizeEmailAddress } from '@nangohq/utils';
 
-export function normalizeEmailAddress(emailAddress: string): string {
-    return emailAddress.trim().toLowerCase();
-}
+const EMAIL_ADDRESS_HASH_CONTEXT = 'nango.emailAddressHash.v1';
 
 /**
  * Pseudonymize an email address for storage/comparison.

--- a/packages/shared/lib/services/invitations.ts
+++ b/packages/shared/lib/services/invitations.ts
@@ -10,15 +10,27 @@ const INVITE_EMAIL_EXPIRATION = 7 * 24 * 60 * 60 * 1000;
 
 export async function expirePreviousInvitations({ email, accountId, trx }: { email: string; accountId: number; trx: Knex }) {
     const normalizedEmail = normalizeEmailAddress(email);
-    const result = await trx
+    const exactMatchResult = await trx
         .from<DBInvitation>(`_nango_invited_users`)
-        .where({ account_id: accountId, accepted: false })
-        .whereRaw('LOWER(email) = ?', [normalizedEmail])
+        .where({ account_id: accountId, accepted: false, email: normalizedEmail })
         .update({
             expires_at: new Date(),
             updated_at: new Date()
         });
-    return result;
+
+    if (exactMatchResult > 0) {
+        return exactMatchResult;
+    }
+
+    // Separate check for mixed-case emails, so the first check can leverage the index
+    return await trx
+        .from<DBInvitation>(`_nango_invited_users`)
+        .where({ account_id: accountId, accepted: false })
+        .whereRaw('LOWER(TRIM(email)) = ?', [normalizedEmail])
+        .update({
+            expires_at: new Date(),
+            updated_at: new Date()
+        });
 }
 
 export async function inviteEmail({

--- a/packages/shared/lib/services/invitations.ts
+++ b/packages/shared/lib/services/invitations.ts
@@ -1,7 +1,7 @@
 import * as uuid from 'uuid';
 
 import db from '@nangohq/database';
-import { isEnterprise } from '@nangohq/utils';
+import { isEnterprise, normalizeEmailAddress } from '@nangohq/utils';
 
 import type { Knex } from '@nangohq/database';
 import type { DBInvitation } from '@nangohq/types';
@@ -9,13 +9,11 @@ import type { DBInvitation } from '@nangohq/types';
 const INVITE_EMAIL_EXPIRATION = 7 * 24 * 60 * 60 * 1000;
 
 export async function expirePreviousInvitations({ email, accountId, trx }: { email: string; accountId: number; trx: Knex }) {
+    const normalizedEmail = normalizeEmailAddress(email);
     const result = await trx
         .from<DBInvitation>(`_nango_invited_users`)
-        .where({
-            email,
-            account_id: accountId,
-            accepted: false
-        })
+        .where({ account_id: accountId, accepted: false })
+        .whereRaw('LOWER(email) = ?', [normalizedEmail])
         .update({
             expires_at: new Date(),
             updated_at: new Date()
@@ -40,11 +38,12 @@ export async function inviteEmail({
 }) {
     const token = uuid.v4();
     const expires_at = new Date(new Date().getTime() + INVITE_EMAIL_EXPIRATION);
+    const normalizedEmail = normalizeEmailAddress(email);
 
     const result = await trx
         .from<DBInvitation>(`_nango_invited_users`)
         .insert({
-            email,
+            email: normalizedEmail,
             name,
             account_id: accountId,
             invited_by: invitedByUserId,

--- a/packages/shared/lib/services/user.service.ts
+++ b/packages/shared/lib/services/user.service.ts
@@ -95,7 +95,18 @@ class UserService {
 
     async getUserByEmail(email: string): Promise<DBUser | null> {
         const normalizedEmail = normalizeEmailAddress(email);
-        const result = await db.knex.select('*').from<DBUser>(`_nango_users`).whereRaw('LOWER(email) = ?', [normalizedEmail]).orderBy('id', 'asc').first();
+
+        const exactMatch = await db.knex.select('*').from<DBUser>(`_nango_users`).where({ email: normalizedEmail }).first();
+        if (exactMatch) {
+            return exactMatch;
+        }
+        // Separate check for mixed-case emails, so the first check can leverage the index
+        const result = await db.knex
+            .select('*')
+            .from<DBUser>(`_nango_users`)
+            .whereRaw('LOWER(TRIM(email)) = ?', [normalizedEmail])
+            .orderBy('id', 'asc')
+            .first();
 
         return result || null;
     }

--- a/packages/shared/lib/services/user.service.ts
+++ b/packages/shared/lib/services/user.service.ts
@@ -1,7 +1,7 @@
 import * as uuid from 'uuid';
 
 import db from '@nangohq/database';
-import { ENVS, Err, Ok, parseEnvs } from '@nangohq/utils';
+import { ENVS, Err, Ok, normalizeEmailAddress, parseEnvs } from '@nangohq/utils';
 
 import type { DBUser } from '@nangohq/types';
 import type { Result } from '@nangohq/utils';
@@ -94,7 +94,8 @@ class UserService {
     }
 
     async getUserByEmail(email: string): Promise<DBUser | null> {
-        const result = await db.knex.select('*').from<DBUser>(`_nango_users`).where({ email: email }).first();
+        const normalizedEmail = normalizeEmailAddress(email);
+        const result = await db.knex.select('*').from<DBUser>(`_nango_users`).whereRaw('LOWER(email) = ?', [normalizedEmail]).orderBy('id', 'asc').first();
 
         return result || null;
     }
@@ -122,11 +123,12 @@ class UserService {
         email_verified: boolean;
         role?: DBUser['role'];
     }): Promise<DBUser | null> {
+        const normalizedEmail = normalizeEmailAddress(email);
         const expires_at = new Date(new Date().getTime() + VERIFICATION_EMAIL_EXPIRATION);
         const result: Pick<DBUser, 'id'>[] = await db.knex
             .from<DBUser>('_nango_users')
             .insert({
-                email,
+                email: normalizedEmail,
                 name,
                 hashed_password,
                 salt,
@@ -164,9 +166,13 @@ class UserService {
     }
 
     async update({ id, ...data }: { id: number } & Omit<Partial<DBUser>, 'id'>): Promise<DBUser | null> {
+        const normalizedData = {
+            ...data,
+            ...(data.email !== undefined ? { email: normalizeEmailAddress(data.email) } : {})
+        };
         const [up] = await db.knex
             .from<DBUser>(`_nango_users`)
-            .update({ ...data, updated_at: new Date() })
+            .update({ ...normalizedData, updated_at: new Date() })
             .where({ id })
             .returning('*');
         return up || null;

--- a/packages/types/lib/account/api.ts
+++ b/packages/types/lib/account/api.ts
@@ -107,7 +107,7 @@ export type PostLogout = Endpoint<{
 }>;
 
 export type PostForgotPassword = Endpoint<{
-    Method: 'PUT';
+    Method: 'POST';
     Path: '/api/v1/account/forgot-password';
     Body: {
         email: string;

--- a/packages/utils/lib/email.ts
+++ b/packages/utils/lib/email.ts
@@ -1,0 +1,3 @@
+export function normalizeEmailAddress(emailAddress: string): string {
+    return emailAddress.trim().toLowerCase();
+}

--- a/packages/utils/lib/index.ts
+++ b/packages/utils/lib/index.ts
@@ -1,4 +1,5 @@
 export * from './roles.js';
+export * from './email.js';
 export * from './api-key-scopes.js';
 export * from './environment/constants.js';
 export * from './environment/detection.js';

--- a/packages/webapp/src/pages/Account/InviteSignup.tsx
+++ b/packages/webapp/src/pages/Account/InviteSignup.tsx
@@ -88,7 +88,7 @@ export const InviteSignup: React.FC = () => {
 
     const inviteData = inviteResponse.json.data;
 
-    if (isLogged && isLogged.email !== inviteData.invitation.email) {
+    if (isLogged && isLogged.email.trim().toLowerCase() !== inviteData.invitation.email.trim().toLowerCase()) {
         return (
             <DefaultLayout className="gap-10">
                 <Helmet>


### PR DESCRIPTION
We were not normalizing emails for comparison, creating all sorts of issues if a user was inconsistent with capitalization.