### PR TITLE
feat(proxy): introspect and refresh sf token on error instead of before every request

### DIFF
--- a/packages/server/lib/controllers/proxy/allProxy.ts
+++ b/packages/server/lib/controllers/proxy/allProxy.ts
@@ -165,6 +165,7 @@ export const allPublicProxy = asyncWrapper<AllPublicProxy>(async (req, res, next
             integration,
             logContextGetter,
             instantRefresh: false,
+            skipIntrospection: true,
             onRefreshSuccess: connectionRefreshSuccess,
             onRefreshFailed: connectionRefreshFailed
         });
@@ -240,6 +241,24 @@ export const allPublicProxy = asyncWrapper<AllPublicProxy>(async (req, res, next
             logger: (msg) => {
                 void logCtx?.log(msg);
             },
+            onRefreshToken: async () => {
+                const credentialResponse = await refreshOrTestCredentials({
+                    account,
+                    environment,
+                    connection: freshConnection,
+                    integration,
+                    logContextGetter,
+                    instantRefresh: false,
+                    skipIntrospection: true,
+                    onRefreshSuccess: connectionRefreshSuccess,
+                    onRefreshFailed: connectionRefreshFailed
+                });
+                if (credentialResponse.isErr()) {
+                    throw new ProxyError('failed_to_refresh_connection', 'Failed to refresh credentials', credentialResponse.error);
+                }
+                freshConnection = credentialResponse.value;
+                lastConnectionRefresh = Date.now();
+            },
             getConnection: async () => {
                 if (Date.now() - lastConnectionRefresh < MEMOIZED_CONNECTION_TTL) {
                     return freshConnection;
@@ -253,6 +272,7 @@ export const allPublicProxy = asyncWrapper<AllPublicProxy>(async (req, res, next
                     integration,
                     logContextGetter,
                     instantRefresh: false,
+                    skipIntrospection: true,
                     onRefreshSuccess: connectionRefreshSuccess,
                     onRefreshFailed: connectionRefreshFailed
                 });

--- a/packages/server/lib/controllers/proxy/allProxy.ts
+++ b/packages/server/lib/controllers/proxy/allProxy.ts
@@ -242,6 +242,7 @@ export const allPublicProxy = asyncWrapper<AllPublicProxy>(async (req, res, next
                 void logCtx?.log(msg);
             },
             onRefreshToken: async () => {
+                let refreshed = false;
                 const credentialResponse = await refreshOrTestCredentials({
                     account,
                     environment,
@@ -249,8 +250,11 @@ export const allPublicProxy = asyncWrapper<AllPublicProxy>(async (req, res, next
                     integration,
                     logContextGetter,
                     instantRefresh: false,
-                    skipIntrospection: true,
-                    onRefreshSuccess: connectionRefreshSuccess,
+                    skipIntrospection: false,
+                    onRefreshSuccess: async (args) => {
+                        refreshed = true;
+                        await connectionRefreshSuccess(args);
+                    },
                     onRefreshFailed: connectionRefreshFailed
                 });
                 if (credentialResponse.isErr()) {
@@ -258,6 +262,7 @@ export const allPublicProxy = asyncWrapper<AllPublicProxy>(async (req, res, next
                 }
                 freshConnection = credentialResponse.value;
                 lastConnectionRefresh = Date.now();
+                return refreshed;
             },
             getConnection: async () => {
                 if (Date.now() - lastConnectionRefresh < MEMOIZED_CONNECTION_TTL) {
@@ -272,7 +277,7 @@ export const allPublicProxy = asyncWrapper<AllPublicProxy>(async (req, res, next
                     integration,
                     logContextGetter,
                     instantRefresh: false,
-                    skipIntrospection: true,
+                    skipIntrospection: false,
                     onRefreshSuccess: connectionRefreshSuccess,
                     onRefreshFailed: connectionRefreshFailed
                 });

--- a/packages/server/lib/hooks/hooks.ts
+++ b/packages/server/lib/hooks/hooks.ts
@@ -385,7 +385,8 @@ export async function credentialsTest({
             provider,
             providerName: config.provider,
             providerConfigKey: config.unique_key,
-            decompress: false
+            decompress: false,
+            refreshTokenOn: null
         };
 
         if (headers) {

--- a/packages/shared/lib/services/connections/credentials/refresh.ts
+++ b/packages/shared/lib/services/connections/credentials/refresh.ts
@@ -58,6 +58,7 @@ interface RefreshProps {
           }) => Promise<Result<{ tested: boolean }, NangoError>>)
         | undefined;
     refreshGithubAppJwtToken?: boolean;
+    skipIntrospection?: boolean;
 }
 
 const logger = getLogger('connectionRefresh');
@@ -179,6 +180,7 @@ async function refreshCredentials(
         account,
         connection: oldConnection,
         instantRefresh,
+        skipIntrospection,
         logContextGetter,
         onRefreshFailed,
         onRefreshSuccess,
@@ -194,6 +196,7 @@ async function refreshCredentials(
         provider: provider,
         environment_id: environment.id,
         instantRefresh,
+        ...(skipIntrospection !== undefined ? { skipIntrospection } : {}),
         logCtx: logsBuffer,
         refreshGithubAppJwtToken
     });
@@ -341,6 +344,7 @@ export async function refreshCredentialsIfNeeded({
     provider,
     environment_id,
     instantRefresh = false,
+    skipIntrospection = false,
     logCtx,
     refreshGithubAppJwtToken
 }: {
@@ -350,6 +354,7 @@ export async function refreshCredentialsIfNeeded({
     provider: RefreshableProvider;
     environment_id: number;
     instantRefresh?: boolean;
+    skipIntrospection?: boolean;
     logCtx: LogContextStateless;
     refreshGithubAppJwtToken?: boolean | undefined;
 }): Promise<Result<{ connection: DBConnectionDecrypted; refreshed: boolean; credentials: RefreshableCredentials }, NangoInternalError>> {
@@ -400,6 +405,7 @@ export async function refreshCredentialsIfNeeded({
                 providerConfig,
                 provider,
                 instantRefresh,
+                skipIntrospection,
                 refreshGithubAppJwtToken
             });
 
@@ -539,6 +545,7 @@ export async function shouldRefreshCredentials({
     providerConfig,
     provider,
     instantRefresh,
+    skipIntrospection = false,
     refreshGithubAppJwtToken
 }: {
     connection: DBConnectionDecrypted;
@@ -546,6 +553,7 @@ export async function shouldRefreshCredentials({
     providerConfig: ProviderConfig;
     provider: RefreshableProvider;
     instantRefresh: boolean;
+    skipIntrospection?: boolean;
     refreshGithubAppJwtToken?: boolean | undefined;
 }): Promise<{ should: boolean; reason: string }> {
     const expirationBufferInSeconds = provider.token_expiration_buffer || REFRESH_MARGIN_MS / 1000;
@@ -589,7 +597,7 @@ export async function shouldRefreshCredentials({
     }
 
     if (!instantRefresh) {
-        if (providerClient.shouldIntrospectToken(providerConfig.provider)) {
+        if (!skipIntrospection && providerClient.shouldIntrospectToken(providerConfig.provider)) {
             if (await providerClient.introspectedTokenExpired(providerConfig, connection)) {
                 return { should: true, reason: 'expired_introspected_token' };
             }

--- a/packages/shared/lib/services/connections/credentials/refresh.ts
+++ b/packages/shared/lib/services/connections/credentials/refresh.ts
@@ -360,7 +360,9 @@ export async function refreshCredentialsIfNeeded({
 }): Promise<Result<{ connection: DBConnectionDecrypted; refreshed: boolean; credentials: RefreshableCredentials }, NangoInternalError>> {
     const providerConfigKey = providerConfig.unique_key;
 
-    const cacheKey = `${environment_id}:${providerConfigKey}:${connectionId}`;
+    // skipIntrospection=true forces a direct refresh without checking token validity first,
+    // so it must not collapse onto an in-flight refresh that may decide "no refresh needed"
+    const cacheKey = `${environment_id}:${providerConfigKey}:${connectionId}:${skipIntrospection ? 'skip' : 'full'}`;
 
     // if a refresh is already in-flight for this connection, return the existing promise
     const existingPromise = inFlightRefreshes.get(cacheKey);

--- a/packages/shared/lib/services/proxy/request.ts
+++ b/packages/shared/lib/services/proxy/request.ts
@@ -16,7 +16,7 @@ import type { AxiosRequestConfig, AxiosResponse } from 'axios';
 
 const logger = getLogger('proxy:metering');
 
-const MAX_REFRESH_TOKEN_ATTEMPTS = 2;
+const MAX_REFRESH_TOKEN_ATTEMPTS = 1;
 
 interface Props {
     proxyConfig: ApplicationConstructedProxyConfiguration;
@@ -25,8 +25,9 @@ interface Props {
     onBytes?: (bytes: MeteredBytes) => MaybePromise<void>;
     /**
      * Called when retry reason is refresh_token; use to introspect and refresh credentials before the next attempt.
+     * Return true if a refresh actually happened (retry is worthwhile), false if token is still active (stop retrying).
      */
-    onRefreshToken?: () => Promise<void>;
+    onRefreshToken?: () => Promise<boolean>;
     getConnection: () => MaybePromise<ConnectionForProxy>;
     getIntegrationConfig: () => MaybePromise<IntegrationConfigForProxy>;
 }
@@ -164,7 +165,10 @@ export class ProxyRequest {
                             } else {
                                 this.refreshTokenAttempts++;
                                 if (this.onRefreshToken) {
-                                    await this.onRefreshToken();
+                                    const refreshed = await this.onRefreshToken();
+                                    if (!refreshed) {
+                                        retry = { retry: false, reason: 'token_still_active' };
+                                    }
                                 }
                             }
                         } else if (retry.retry && attempt > (this.config.retries || 0)) {

--- a/packages/shared/lib/services/proxy/request.ts
+++ b/packages/shared/lib/services/proxy/request.ts
@@ -16,11 +16,17 @@ import type { AxiosRequestConfig, AxiosResponse } from 'axios';
 
 const logger = getLogger('proxy:metering');
 
+const MAX_REFRESH_TOKEN_ATTEMPTS = 2;
+
 interface Props {
     proxyConfig: ApplicationConstructedProxyConfiguration;
     logger: (msg: MessageRowInsert) => MaybePromise<void>;
     onError?: (args: { err: unknown; max: number; attempt: number; retry: RetryReason }) => RetryReason;
     onBytes?: (bytes: MeteredBytes) => MaybePromise<void>;
+    /**
+     * Called when retry reason is refresh_token; use to introspect and refresh credentials before the next attempt.
+     */
+    onRefreshToken?: () => Promise<void>;
     getConnection: () => MaybePromise<ConnectionForProxy>;
     getIntegrationConfig: () => MaybePromise<IntegrationConfigForProxy>;
 }
@@ -56,6 +62,10 @@ export class ProxyRequest {
      */
     onBytes?: Props['onBytes'];
 
+    onRefreshToken?: Props['onRefreshToken'];
+
+    private refreshTokenAttempts = 0;
+
     /**
      * Build at each iteration
      */
@@ -76,6 +86,7 @@ export class ProxyRequest {
         this.logger = props.logger;
         this.onError = props.onError;
         this.onBytes = props.onBytes;
+        this.onRefreshToken = props.onRefreshToken;
         this.getConnection = props.getConnection;
         this.getIntegrationConfig = props.getIntegrationConfig;
     }
@@ -143,9 +154,22 @@ export class ProxyRequest {
                     }
                 },
                 {
-                    max: this.config.retries || 0,
+                    max: Math.max(this.config.retries || 0, this.config.refreshTokenOn?.length && this.onRefreshToken ? MAX_REFRESH_TOKEN_ATTEMPTS + 1 : 0),
                     onError: async ({ err, nextWait, max, attempt }) => {
                         let retry = getProxyRetryFromErr({ err, proxyConfig: this.config });
+
+                        if (retry.retry && retry.reason === 'refresh_token') {
+                            if (this.refreshTokenAttempts >= MAX_REFRESH_TOKEN_ATTEMPTS) {
+                                retry = { retry: false, reason: 'refresh_token_max_attempts' };
+                            } else {
+                                this.refreshTokenAttempts++;
+                                if (this.onRefreshToken) {
+                                    await this.onRefreshToken();
+                                }
+                            }
+                        } else if (retry.retry && attempt > (this.config.retries || 0)) {
+                            retry = { retry: false, reason: retry.reason };
+                        }
 
                         // Only call onError if it's an actionable error
                         if (retry.reason !== 'unknown_error' && this.onError) {

--- a/packages/shared/lib/services/proxy/request.unit.test.ts
+++ b/packages/shared/lib/services/proxy/request.unit.test.ts
@@ -121,7 +121,7 @@ describe('call', () => {
 
 describe('Salesforce introspect-on-error (refreshTokenOn)', () => {
     it('should call onRefreshToken on 401 and succeed on retry', async () => {
-        const onRefreshToken = vi.fn();
+        const onRefreshToken = vi.fn().mockResolvedValue(true);
         const proxy = new ProxyRequest({
             logger: vi.fn(),
             proxyConfig: getDefaultProxy({
@@ -140,8 +140,8 @@ describe('Salesforce introspect-on-error (refreshTokenOn)', () => {
         expect(onRefreshToken).toHaveBeenCalledTimes(1);
     });
 
-    it('should cap onRefreshToken at 2 attempts then stop retrying', { timeout: 15000 }, async () => {
-        const onRefreshToken = vi.fn();
+    it('should cap onRefreshToken at 1 attempt then stop retrying', { timeout: 15000 }, async () => {
+        const onRefreshToken = vi.fn().mockResolvedValue(true);
         const proxy = new ProxyRequest({
             logger: vi.fn(),
             proxyConfig: getDefaultProxy({
@@ -157,7 +157,27 @@ describe('Salesforce introspect-on-error (refreshTokenOn)', () => {
 
         const res = await proxy.request();
         expect(res.isErr()).toBe(true);
-        expect(onRefreshToken).toHaveBeenCalledTimes(2);
+        expect(onRefreshToken).toHaveBeenCalledTimes(1);
+    });
+
+    it('should stop retrying immediately when onRefreshToken returns false (token still active)', async () => {
+        const onRefreshToken = vi.fn().mockResolvedValue(false);
+        const proxy = new ProxyRequest({
+            logger: vi.fn(),
+            proxyConfig: getDefaultProxy({
+                provider: { auth_mode: 'OAUTH2', proxy: { base_url: 'https://example.com' } },
+                endpoint: '/api',
+                refreshTokenOn: [401, 403]
+            }),
+            getConnection: () => getTestConnection(),
+            getIntegrationConfig: () => ({ oauth_client_id: null, oauth_client_secret: null }),
+            onRefreshToken
+        });
+        vi.spyOn(proxy, 'httpCall').mockRejectedValue(createAxiosError(401));
+
+        const res = await proxy.request();
+        expect(res.isErr()).toBe(true);
+        expect(onRefreshToken).toHaveBeenCalledTimes(1);
     });
 
     it('should not call onRefreshToken for non-Salesforce provider (refreshTokenOn is null)', async () => {

--- a/packages/shared/lib/services/proxy/request.unit.test.ts
+++ b/packages/shared/lib/services/proxy/request.unit.test.ts
@@ -1,8 +1,21 @@
+import { AxiosError } from 'axios';
 import { describe, expect, it, vi } from 'vitest';
 
 import { ProxyRequest } from './request.js';
 import { getDefaultProxy } from './utils.test.js';
 import { getTestConnection } from '../../seeders/connection.seeder.js';
+
+import type { AxiosResponse, InternalAxiosRequestConfig } from 'axios';
+
+function createAxiosError(status: number): AxiosError {
+    const err = new AxiosError(`HTTP ${status}`);
+    err.response = { status, data: {}, headers: {}, statusText: 'Error', config: {} as InternalAxiosRequestConfig };
+    return err;
+}
+
+function createSuccessResponse(): AxiosResponse {
+    return { status: 200, data: {}, headers: {}, config: {} as InternalAxiosRequestConfig, statusText: 'OK' };
+}
 
 describe('call', () => {
     it('should make a single successful http call', async () => {
@@ -103,5 +116,67 @@ describe('call', () => {
 
         // should dynamically rebuild proxy config on each iteration
         expect(getConnection).toHaveBeenCalledTimes(2);
+    });
+});
+
+describe('Salesforce introspect-on-error (refreshTokenOn)', () => {
+    it('should call onRefreshToken on 401 and succeed on retry', async () => {
+        const onRefreshToken = vi.fn();
+        const proxy = new ProxyRequest({
+            logger: vi.fn(),
+            proxyConfig: getDefaultProxy({
+                provider: { auth_mode: 'OAUTH2', proxy: { base_url: 'https://example.com' } },
+                endpoint: '/api',
+                refreshTokenOn: [401, 403]
+            }),
+            getConnection: () => getTestConnection(),
+            getIntegrationConfig: () => ({ oauth_client_id: null, oauth_client_secret: null }),
+            onRefreshToken
+        });
+        vi.spyOn(proxy, 'httpCall').mockRejectedValueOnce(createAxiosError(401)).mockResolvedValueOnce(createSuccessResponse());
+
+        const res = await proxy.request();
+        expect(res.isOk()).toBe(true);
+        expect(onRefreshToken).toHaveBeenCalledTimes(1);
+    });
+
+    it('should cap onRefreshToken at 2 attempts then stop retrying', { timeout: 15000 }, async () => {
+        const onRefreshToken = vi.fn();
+        const proxy = new ProxyRequest({
+            logger: vi.fn(),
+            proxyConfig: getDefaultProxy({
+                provider: { auth_mode: 'OAUTH2', proxy: { base_url: 'https://example.com' } },
+                endpoint: '/api',
+                refreshTokenOn: [401, 403]
+            }),
+            getConnection: () => getTestConnection(),
+            getIntegrationConfig: () => ({ oauth_client_id: null, oauth_client_secret: null }),
+            onRefreshToken
+        });
+        vi.spyOn(proxy, 'httpCall').mockRejectedValue(createAxiosError(401));
+
+        const res = await proxy.request();
+        expect(res.isErr()).toBe(true);
+        expect(onRefreshToken).toHaveBeenCalledTimes(2);
+    });
+
+    it('should not call onRefreshToken for non-Salesforce provider (refreshTokenOn is null)', async () => {
+        const onRefreshToken = vi.fn();
+        const proxy = new ProxyRequest({
+            logger: vi.fn(),
+            proxyConfig: getDefaultProxy({
+                provider: { auth_mode: 'OAUTH2', proxy: { base_url: 'https://example.com' } },
+                endpoint: '/api',
+                refreshTokenOn: null
+            }),
+            getConnection: () => getTestConnection(),
+            getIntegrationConfig: () => ({ oauth_client_id: null, oauth_client_secret: null }),
+            onRefreshToken
+        });
+        vi.spyOn(proxy, 'httpCall').mockRejectedValue(createAxiosError(401));
+
+        const res = await proxy.request();
+        expect(res.isErr()).toBe(true);
+        expect(onRefreshToken).not.toHaveBeenCalled();
     });
 });

--- a/packages/shared/lib/services/proxy/retry.ts
+++ b/packages/shared/lib/services/proxy/retry.ts
@@ -55,6 +55,10 @@ export function getProxyRetryFromErr({ err, proxyConfig }: { err: unknown; proxy
         }
     }
 
+    if (proxyConfig.refreshTokenOn?.some((code) => matchesStatusCode(status, String(code)))) {
+        return { retry: true, reason: 'refresh_token' };
+    }
+
     if (!isRetryable && customHeaderConf?.remaining && err.response?.headers[customHeaderConf.remaining] === '0') {
         // Custom header in providers.yaml
         isRetryable = true;

--- a/packages/shared/lib/services/proxy/retry.ts
+++ b/packages/shared/lib/services/proxy/retry.ts
@@ -55,8 +55,11 @@ export function getProxyRetryFromErr({ err, proxyConfig }: { err: unknown; proxy
         }
     }
 
-    if (proxyConfig.refreshTokenOn?.some((code) => matchesStatusCode(status, String(code)))) {
-        return { retry: true, reason: 'refresh_token' };
+    // Mark for token refresh but don't return yet — Retry-After headers take priority
+    // so a rate-limited response with a backoff header is respected before refreshing
+    const isRefreshToken = proxyConfig.refreshTokenOn?.some((code) => matchesStatusCode(status, String(code))) ?? false;
+    if (isRefreshToken) {
+        isRetryable = true;
     }
 
     if (!isRetryable && customHeaderConf?.remaining && err.response?.headers[customHeaderConf.remaining] === '0') {
@@ -131,7 +134,7 @@ export function getProxyRetryFromErr({ err, proxyConfig }: { err: unknown; proxy
         }
     }
 
-    return { retry: true, reason: reason || `status_code_${status}` };
+    return { retry: true, reason: isRefreshToken ? 'refresh_token' : reason || `status_code_${status}` };
 }
 
 /**

--- a/packages/shared/lib/services/proxy/retry.unit.test.ts
+++ b/packages/shared/lib/services/proxy/retry.unit.test.ts
@@ -98,6 +98,53 @@ describe('getProxyRetryFromErr', () => {
         expect(res).toStrictEqual({ retry: false, reason: 'not_retryable' });
     });
 
+    describe('refresh_token (Salesforce introspect-on-error)', () => {
+        it.each([401, 403])('should return refresh_token reason when status %d matches refreshTokenOn', (status) => {
+            const err = getDefaultError({ response: { status } });
+            const res = getProxyRetryFromErr({
+                err,
+                proxyConfig: getDefaultProxy({ refreshTokenOn: [401, 403], provider: { auth_mode: 'OAUTH2' } })
+            });
+            expect(res).toStrictEqual({ retry: true, reason: 'refresh_token' });
+        });
+
+        it.each([500, 502, 429, 404, 422])('should not return refresh_token reason when status %d does not match refreshTokenOn', (status) => {
+            const err = getDefaultError({ response: { status } });
+            const res = getProxyRetryFromErr({
+                err,
+                proxyConfig: getDefaultProxy({ refreshTokenOn: [401, 403], provider: { auth_mode: 'OAUTH2' } })
+            });
+            expect(res).not.toStrictEqual({ retry: true, reason: 'refresh_token' });
+        });
+
+        it('should not return refresh_token when status is not in refreshTokenOn', () => {
+            const err = getDefaultError({ response: { status: 200 } });
+            const res = getProxyRetryFromErr({
+                err,
+                proxyConfig: getDefaultProxy({ refreshTokenOn: [401, 403], provider: { auth_mode: 'OAUTH2' } })
+            });
+            expect(res).toStrictEqual({ retry: false, reason: 'not_retryable' });
+        });
+
+        it('should not return refresh_token for 401 when refreshTokenOn is null (non-Salesforce)', () => {
+            const err = getDefaultError({ response: { status: 401 } });
+            const res = getProxyRetryFromErr({
+                err,
+                proxyConfig: getDefaultProxy({ refreshTokenOn: null })
+            });
+            expect(res).toStrictEqual({ retry: true, reason: 'status_code_401' });
+        });
+
+        it('should not return refresh_token for 403 when refreshTokenOn is null (non-Salesforce)', () => {
+            const err = getDefaultError({ response: { status: 403 } });
+            const res = getProxyRetryFromErr({
+                err,
+                proxyConfig: getDefaultProxy({ refreshTokenOn: null })
+            });
+            expect(res).toStrictEqual({ retry: false, reason: 'not_retryable' });
+        });
+    });
+
     it.each([500, 501, 429])('should retry some status code "%d"', (value) => {
         const mockAxiosError = getDefaultError({ response: { status: value } });
         const res = getProxyRetryFromErr({ err: mockAxiosError, proxyConfig: getDefaultProxy({}) });

--- a/packages/shared/lib/services/proxy/retry.unit.test.ts
+++ b/packages/shared/lib/services/proxy/retry.unit.test.ts
@@ -126,7 +126,7 @@ describe('getProxyRetryFromErr', () => {
             expect(res).toStrictEqual({ retry: false, reason: 'not_retryable' });
         });
 
-        it('should not return refresh_token for 401 when refreshTokenOn is null (non-Salesforce)', () => {
+        it('should return status_code_401 for 401 when refreshTokenOn is null (non-Salesforce)', () => {
             const err = getDefaultError({ response: { status: 401 } });
             const res = getProxyRetryFromErr({
                 err,

--- a/packages/shared/lib/services/proxy/utils.test.ts
+++ b/packages/shared/lib/services/proxy/utils.test.ts
@@ -12,6 +12,7 @@ export function getDefaultProxy(
         providerConfigKey: 'freshteam',
         providerName: 'freshteam',
         decompress: false,
+        refreshTokenOn: null,
         ...override,
         provider: {
             auth_mode: 'API_KEY',

--- a/packages/shared/lib/services/proxy/utils.ts
+++ b/packages/shared/lib/services/proxy/utils.ts
@@ -6,6 +6,7 @@ import OAuth from 'oauth-1.0a';
 
 import { Err, Ok, SIGNATURE_METHOD, metrics } from '@nangohq/utils';
 
+import providerClient from '../../clients/provider.client.js';
 import {
     connectionCopyWithParsedConnectionConfig,
     formatPem,
@@ -14,6 +15,8 @@ import {
     interpolateProxyUrlParts
 } from '../../utils/utils.js';
 import { getProvider } from '../providers.js';
+
+const SALESFORCE_INTROSPECT_ON_ERRORS: (number | string)[] = [401, 403];
 
 import type {
     ApplicationConstructedProxyConfiguration,
@@ -37,6 +40,7 @@ type ProxyErrorCode =
     | 'invalid_query_params'
     | 'unknown_error'
     | 'failed_to_get_connection'
+    | 'failed_to_refresh_connection'
     | 'invalid_certificate_or_key_format'
     | 'proxy_redirect_to_denied_host';
 
@@ -250,6 +254,7 @@ export function getProxyConfiguration({
         params: externalConfig.params as Record<string, string>, // TODO: fix this
         responseType: externalConfig.responseType,
         retryOn: retryOn && Array.isArray(retryOn) ? retryOn.map(Number) : null,
+        refreshTokenOn: providerClient.shouldIntrospectToken(providerName) ? SALESFORCE_INTROSPECT_ON_ERRORS : null,
         ...(forwardHeadersOnRedirect !== undefined ? { forwardHeadersOnRedirect } : {}),
         ...(validateProxyRedirectUrl !== undefined ? { validateProxyRedirectUrl } : {})
     };

--- a/packages/types/lib/proxy/api.ts
+++ b/packages/types/lib/proxy/api.ts
@@ -50,6 +50,7 @@ export interface ApplicationConstructedProxyConfiguration extends BaseProxyConfi
     method: HTTP_METHOD;
     providerName: string;
     provider: Provider;
+    refreshTokenOn: (number | string)[] | null;
 }
 
 export type ResponseType = 'arraybuffer' | 'blob' | 'document' | 'json' | 'text' | 'stream';


### PR DESCRIPTION
## Describe the problem and your solution

- introspect and refresh sf token on error instead of before every request

<!-- Issue ticket number and link (if applicable) -->

<!-- Testing instructions (skip if just adding/editing providers) -->

