### PR TITLE
chore: add repo agent guidance and skills

### DIFF
--- a/.agents/skills/creating-database-migrations/SKILL.md
+++ b/.agents/skills/creating-database-migrations/SKILL.md
@@ -1,0 +1,43 @@
+---
+name: creating-database-migrations
+description: Use when adding or editing Nango database migrations - covers migration directory selection, timestamped .cjs naming, matching recent migration style, down migration decisions, and foreign key ON DELETE conventions.
+---
+
+# Creating Database Migrations
+
+## Workflow
+
+1. Identify the right migration directory.
+   - Main database migrations live in `packages/database/lib/migrations/`.
+   - Other services may have their own migration directories; use the directory for the service being changed.
+
+2. Before writing a migration, read 2-3 recent migrations in the same directory and follow their style.
+
+3. Name new main database migrations with the timestamped CommonJS format:
+
+   ```text
+   <YYYYMMDDHHMMSS>_<description>.cjs
+   ```
+
+   Example:
+
+   ```text
+   20260420120000_create_customer_keys.cjs
+   ```
+
+4. Decide `exports.down` explicitly.
+   - Ask the user whether rollback logic should be included or `exports.down` should be left empty.
+   - If the user already specified rollback behavior, follow that direction.
+
+5. Choose foreign key delete behavior from the relationship:
+   - Use `ON DELETE CASCADE` for ownership relationships where the child cannot exist without the parent.
+   - Use `ON DELETE SET NULL` for optional references where the child should survive parent deletion.
+   - Check existing migrations for the closest matching relationship before choosing.
+
+## Review Checklist
+
+- [ ] Migration is in the correct service migration directory.
+- [ ] Filename uses the timestamped `.cjs` migration format.
+- [ ] Style matches recent migrations in the same directory.
+- [ ] `exports.down` behavior was confirmed or explicitly requested.
+- [ ] Foreign keys use `CASCADE` for ownership and `SET NULL` for optional references.

--- a/.agents/skills/creating-skills-skill/SKILL.md
+++ b/.agents/skills/creating-skills-skill/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: creating-skills
-description: Use when creating new Claude Code skills or improving existing ones - ensures skills are discoverable, scannable, and effective through proper structure, CSO optimization, and real examples
+description: Use when creating new agent skills or improving existing ones - ensures skills are discoverable, scannable, and effective through proper structure, discovery optimization, and real examples
 tags: meta
 ---
 
@@ -8,11 +8,11 @@ tags: meta
 
 ## Overview
 
-**Skills are reference guides for proven techniques, patterns, or tools.** Write them to help future Claude instances quickly find and apply effective approaches.
+**Skills are reference guides for proven techniques, patterns, or tools.** Write them to help future agents quickly find and apply effective approaches.
 
-Skills must be **discoverable** (Claude can find them), **scannable** (quick to evaluate), and **actionable** (clear examples).
+Skills must be **discoverable** (an agent can find them), **scannable** (quick to evaluate), and **actionable** (clear examples).
 
-**Core principle**: Default assumption is Claude is already very smart. Only add context Claude doesn't already have.
+**Core principle**: Assume the agent already handles general reasoning well. Only add context the agent would not otherwise have.
 
 ## When to Use
 
@@ -25,7 +25,7 @@ Skills must be **discoverable** (Claude can find them), **scannable** (quick to 
 **Don't create for:**
 - One-off solutions specific to single project
 - Standard practices well-documented elsewhere
-- Project conventions (put those in `.claude/CLAUDE.md`)
+- Project conventions (put those in project-level agent guidance such as `AGENTS.md`)
 
 ## Required Structure
 
@@ -78,7 +78,7 @@ Concrete results from using this technique
 
 - **High freedom**: Flexible tasks requiring judgment
   - Use broad guidance, principles, examples
-  - Let Claude adapt approach to context
+  - Let the agent adapt approach to context
   - Example: "Use when designing APIs - provides REST principles and patterns"
 
 - **Low freedom**: Fragile or critical operations
@@ -86,11 +86,11 @@ Concrete results from using this technique
   - Include validation checks
   - Example: "Use when deploying to production - follow exact deployment checklist with rollback procedures"
 
-**Red flag**: If skill tries to constrain Claude too much on creative tasks, reduce specificity. If skill is too vague on critical operations, add explicit steps.
+**Red flag**: If skill tries to constrain the agent too much on creative tasks, reduce specificity. If skill is too vague on critical operations, add explicit steps.
 
-## Claude Search Optimization (CSO)
+## Skill Discovery Optimization
 
-**Critical:** Future Claude reads the description to decide if skill is relevant. Optimize for discovery.
+**Critical:** Agents commonly use the description to decide if a skill is relevant. Optimize for discovery.
 
 ### Description Best Practices
 
@@ -98,7 +98,7 @@ Concrete results from using this technique
 # ❌ BAD - Too vague, doesn't mention when to use
 description: For async testing
 
-# ❌ BAD - First person (injected into system prompt)
+# ❌ BAD - First person in agent-facing metadata
 description: I help you with flaky tests
 
 # ✅ GOOD - Triggers + what it does
@@ -110,7 +110,7 @@ description: Use when using React Router and handling auth redirects - provides 
 
 ### Keyword Coverage
 
-Use words Claude would search for:
+Use words an agent would match:
 - **Error messages**: "ENOENT", "Cannot read property", "Timeout"
 - **Symptoms**: "flaky", "hanging", "race condition", "memory leak"
 - **Synonyms**: "cleanup/teardown/afterEach", "timeout/hang/freeze"
@@ -128,7 +128,7 @@ Use words Claude would search for:
 **Why gerunds work:**
 - Describes the action you're taking
 - Active and clear
-- Consistent with Anthropic conventions
+- Consistent and action-oriented
 
 **Avoid:**
 - ❌ Vague names like "Helper" or "Utils"
@@ -248,7 +248,7 @@ Skills load into every conversation. Keep them concise.
 - Frequently-loaded skills: <200 words total
 - Other skills: <500 words
 
-**Challenge each piece of information**: "Does Claude really need this explanation?"
+**Challenge each piece of information**: "Does the agent need this explanation?"
 
 ### Compression Techniques
 
@@ -314,7 +314,7 @@ For multi-step processes, include:
 | Deeply nested file references | Multiple @ symbols, complex paths | Keep references simple and direct |
 | Windows-style file paths | `C:\path\to\file` | Use forward slashes |
 | Offering too many options | 10 different approaches | Focus on one proven approach |
-| Punting error handling | "Claude figures it out" | Include explicit error handling in scripts |
+| Punting error handling | "The agent figures it out" | Include explicit error handling in scripts |
 | Time-sensitive information | "As of 2025..." | Keep content evergreen |
 | Inconsistent terminology | Mixing synonyms randomly | Use consistent terms throughout |
 
@@ -349,7 +349,7 @@ See skills/testing/test-driven-development
 
 ### Iterative Development
 
-**Best approach**: Develop skills iteratively with Claude
+**Best approach**: Develop skills iteratively with an agent
 1. Start with minimal viable skill
 2. Test with real use cases
 3. Refine based on what works
@@ -460,7 +460,7 @@ skills/
 ## Real-World Impact
 
 **Good skills:**
-- Future Claude finds them quickly (CSO optimization)
+- Future agents find them quickly through discovery optimization
 - Can be scanned in seconds (quick reference)
 - Provide clear actionable examples
 - Prevent repeating same research
@@ -477,6 +477,6 @@ skills/
 
 ---
 
-**Remember:** Skills are for future Claude, not current you. Optimize for discovery, scanning, and action.
+**Remember:** Skills are for future agents, not current you. Optimize for discovery, scanning, and action.
 
-**Golden rule:** Default assumption is Claude is already very smart. Only add context Claude doesn't already have.
+**Golden rule:** Assume the agent already handles general reasoning well. Only add context the agent would not otherwise have.

--- a/.agents/skills/ui-visual-debugging/SKILL.md
+++ b/.agents/skills/ui-visual-debugging/SKILL.md
@@ -1,0 +1,107 @@
+---
+name: ui-visual-debugging
+description: Use when modifying or visually debugging Nango frontend UI, including packages/webapp, packages/connect-ui, browser interactions, screenshots, responsive layout, and visual regressions. Prefer browser-controlled or headless Playwright checks; use Peekaboo only for native macOS, visible-browser, or Accessibility tree inspection.
+---
+
+# UI Visual Debugging
+
+## Core Rules
+
+- Use a browser-controlled or headless context for routine web UI checks. Do not open tabs in the user's existing browser unless explicitly asked.
+- Save screenshots, traces, and throwaway Playwright scripts under `.context/`; do not commit them.
+- Use Peekaboo only when the task needs the real macOS desktop, native windows, a visible browser session, or Accessibility tree inspection.
+- For local startup details, use `running-and-testing-locally` as the source of truth.
+
+## Nango Targets
+
+| Surface | URL | Common command |
+| --- | --- | --- |
+| Dashboard webapp | `http://localhost:3000` | `npm run dev:watch:web` |
+| API server | `http://localhost:3003` | `npm run server:dev:watch` |
+| Connect UI | `http://localhost:3009` | `npm run dev:watch:web` or `npm run connect-ui:dev:watch` |
+
+For most frontend work, run:
+
+```bash
+npm run dev:docker
+npm run dev:watch
+npm run dev:watch:web
+```
+
+`npm run dev:watch` and `npm run dev:watch:web` are long-running commands. Keep them in separate sessions and wait for the initial TypeScript build before browser testing.
+
+## Standard Screenshot Workflow
+
+1. Start or reuse the relevant local services.
+
+2. Capture desktop and mobile baselines with a browser-controlled tool. If a Playwright MCP/browser tool is available, use it. Otherwise use headless Playwright without modifying repo dependencies:
+
+   ```bash
+   npx playwright screenshot --browser=chromium --viewport-size=1512,862 http://127.0.0.1:3000 .context/nango-webapp-desktop.png
+   npx playwright screenshot --browser=chromium --viewport-size=390,844 http://127.0.0.1:3000 .context/nango-webapp-mobile.png
+   ```
+
+   For Connect UI:
+
+   ```bash
+   npx playwright screenshot --browser=chromium --viewport-size=1512,862 http://127.0.0.1:3009 .context/nango-connect-desktop.png
+   npx playwright screenshot --browser=chromium --viewport-size=390,844 http://127.0.0.1:3009 .context/nango-connect-mobile.png
+   ```
+
+3. Inspect screenshots with `view_image`, then edit the smallest relevant files.
+
+4. Verify after edits:
+
+   ```bash
+   npm run ts-build
+   ```
+
+   For webapp-only visual work, `cd packages/webapp && npm run build` is also useful. For Connect UI, run `npm run connect-ui:build`.
+
+5. Capture fresh desktop and mobile screenshots and compare them before finishing.
+
+## Headless Interaction
+
+For clicks, form filling, authentication flows, or multi-step checks, create a temporary Playwright script in `.context/`, run it, and save screenshots there.
+
+Use stable selectors and visible text where possible. Avoid relying on the user's browser state.
+
+Common flows:
+- Dashboard sign-in/sign-up at `http://localhost:3000`.
+- Dashboard pages after authentication: Integrations, Connections, Logs, Metrics, and Environment settings.
+- Connect UI at `http://localhost:3009`.
+
+When auth is needed, follow the local credentials and verification-log workflow in `running-and-testing-locally`.
+
+## Peekaboo Workflow
+
+Use Peekaboo only after checking permissions:
+
+```bash
+peekaboo permissions status
+```
+
+Required:
+
+```text
+Screen Recording (Required): Granted
+Accessibility (Required): Granted
+```
+
+Prefer targeted captures by window id. Capturing by app name can hang.
+
+```bash
+peekaboo list windows --app "Google Chrome" --json
+peekaboo image --mode window --window-id <window_id> --retina --path .context/nango-window.png --json-output
+peekaboo see --app "Google Chrome" --json-output
+```
+
+Avoid `peekaboo open http://... --app "Google Chrome"` for routine checks because it creates tabs in the user's existing browser.
+
+## Review Checklist
+
+- [ ] Baseline screenshot captured before UI edits when layout risk is meaningful.
+- [ ] Desktop and mobile screenshots captured after edits.
+- [ ] Screenshots, traces, and throwaway scripts stay under `.context/`.
+- [ ] Browser automation does not depend on the user's existing browser state.
+- [ ] `npm run ts-build` or the relevant package build was run after frontend changes.

--- a/.agents/skills/ui-visual-debugging/SKILL.md
+++ b/.agents/skills/ui-visual-debugging/SKILL.md
@@ -37,15 +37,21 @@ npm run dev:watch:web
 2. Capture desktop and mobile baselines with a browser-controlled tool. If a Playwright MCP/browser tool is available, use it. Otherwise use headless Playwright without modifying repo dependencies:
 
    ```bash
-   npx playwright screenshot --browser=chromium --viewport-size=1512,862 http://127.0.0.1:3000 .context/nango-webapp-desktop.png
-   npx playwright screenshot --browser=chromium --viewport-size=390,844 http://127.0.0.1:3000 .context/nango-webapp-mobile.png
+   npx playwright screenshot --browser=chromium --viewport-size=1512,862 http://localhost:3000 .context/nango-webapp-desktop.png
+   npx playwright screenshot --browser=chromium --viewport-size=390,844 http://localhost:3000 .context/nango-webapp-mobile.png
    ```
 
    For Connect UI:
 
    ```bash
-   npx playwright screenshot --browser=chromium --viewport-size=1512,862 http://127.0.0.1:3009 .context/nango-connect-desktop.png
-   npx playwright screenshot --browser=chromium --viewport-size=390,844 http://127.0.0.1:3009 .context/nango-connect-mobile.png
+   npx playwright screenshot --browser=chromium --viewport-size=1512,862 http://localhost:3009 .context/nango-connect-desktop.png
+   npx playwright screenshot --browser=chromium --viewport-size=390,844 http://localhost:3009 .context/nango-connect-mobile.png
+   ```
+
+   If Playwright reports that the Chromium executable is missing, install the browser cache without adding repo dependencies:
+
+   ```bash
+   npx playwright install chromium
    ```
 
 3. Inspect screenshots with `view_image`, then edit the smallest relevant files.
@@ -72,6 +78,22 @@ Common flows:
 - Connect UI at `http://localhost:3009`.
 
 When auth is needed, follow the local credentials and verification-log workflow in `running-and-testing-locally`.
+
+## Startup Troubleshooting
+
+If server startup fails with a Knex error like `The migration directory is corrupt, the following files are missing`, the local database has migrations from another branch. Do not reset the user's database without confirmation. For visual validation only, use a temporary database:
+
+```bash
+docker exec nango-db psql -U nango -d postgres -c "DROP DATABASE IF EXISTS nango_ui_skill_validation WITH (FORCE)"
+docker exec nango-db psql -U nango -d postgres -c "CREATE DATABASE nango_ui_skill_validation"
+NANGO_DB_NAME=nango_ui_skill_validation npm run dev:watch:web
+```
+
+After stopping the dev server, clean up the temporary database:
+
+```bash
+docker exec nango-db psql -U nango -d postgres -c "DROP DATABASE IF EXISTS nango_ui_skill_validation WITH (FORCE)"
+```
 
 ## Peekaboo Workflow
 

--- a/.agents/skills/ui-visual-debugging/SKILL.md
+++ b/.agents/skills/ui-visual-debugging/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: ui-visual-debugging
-description: Use when modifying or visually debugging Nango frontend UI, including packages/webapp, packages/connect-ui, browser interactions, screenshots, responsive layout, and visual regressions. Prefer browser-controlled or headless Playwright checks; use Peekaboo only for native macOS, visible-browser, or Accessibility tree inspection.
+description: Use when modifying or visually debugging Nango frontend UI, including packages/webapp, packages/connect-ui, browser interactions, screenshots, and visual regressions. Prefer browser-controlled or headless Playwright checks; use Peekaboo only for native macOS, visible-browser, or Accessibility tree inspection.
 ---
 
 # UI Visual Debugging
@@ -34,18 +34,16 @@ npm run dev:watch:web
 
 1. Start or reuse the relevant local services.
 
-2. Capture desktop and mobile baselines with a browser-controlled tool. If a Playwright MCP/browser tool is available, use it. Otherwise use headless Playwright without modifying repo dependencies:
+2. Capture a desktop baseline with a browser-controlled tool. If a Playwright MCP/browser tool is available, use it. Otherwise use headless Playwright without modifying repo dependencies:
 
    ```bash
    npx playwright screenshot --browser=chromium --viewport-size=1512,862 http://localhost:3000 .context/nango-webapp-desktop.png
-   npx playwright screenshot --browser=chromium --viewport-size=390,844 http://localhost:3000 .context/nango-webapp-mobile.png
    ```
 
    For Connect UI:
 
    ```bash
    npx playwright screenshot --browser=chromium --viewport-size=1512,862 http://localhost:3009 .context/nango-connect-desktop.png
-   npx playwright screenshot --browser=chromium --viewport-size=390,844 http://localhost:3009 .context/nango-connect-mobile.png
    ```
 
    If Playwright reports that the Chromium executable is missing, install the browser cache without adding repo dependencies:
@@ -64,7 +62,7 @@ npm run dev:watch:web
 
    For webapp-only visual work, `cd packages/webapp && npm run build` is also useful. For Connect UI, run `npm run connect-ui:build`.
 
-5. Capture fresh desktop and mobile screenshots and compare them before finishing.
+5. Capture fresh desktop screenshots and compare them before finishing.
 
 ## Headless Interaction
 
@@ -123,7 +121,7 @@ Avoid `peekaboo open http://... --app "Google Chrome"` for routine checks becaus
 ## Review Checklist
 
 - [ ] Baseline screenshot captured before UI edits when layout risk is meaningful.
-- [ ] Desktop and mobile screenshots captured after edits.
+- [ ] Desktop screenshots captured after edits.
 - [ ] Screenshots, traces, and throwaway scripts stay under `.context/`.
 - [ ] Browser automation does not depend on the user's existing browser state.
 - [ ] `npm run ts-build` or the relevant package build was run after frontend changes.

--- a/.gitignore
+++ b/.gitignore
@@ -13,5 +13,6 @@ integration-templates/**/.nango
 integration-templates/**/schema.ts
 integration-templates/**/models.ts
 temp
+.context/
 .claude/settings.local.json
 CLAUDE.local.md

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,2 @@
+Use `npm` as the project package manager.
+After running the initial `npm install` or `npm ci`, run `npm run prepare` to install Husky git hooks.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,1 @@
+AGENTS.md


### PR DESCRIPTION
<!-- Describe the problem and your solution -->

- Adds minimal root `AGENTS.md` setup guidance and repo-local skills for database migrations and UI visual debugging.
- Updates the skill-creation guidance to remove Claude-specific wording so it can apply to agents generally.
- Add DB migrations skill from @pfreixes PR https://github.com/NangoHQ/nango/pull/5923/changes
- Add a UI debugging skill

<!-- Issue ticket number and link (if applicable) -->
NAN-5706