### PR TITLE
fix(ci): shorten preview deploy comment URL and timestamp

### DIFF
--- a/.github/workflows/preview-webapp.yml
+++ b/.github/workflows/preview-webapp.yml
@@ -49,9 +49,9 @@ jobs:
                   result-encoding: string
                   script: |
                       const { PREVIEW_URL: url, RUN_URL: runUrl } = process.env;
-                      const now = new Date().toUTCString();
+                      const now = new Date().toLocaleString('en-GB', { day: 'numeric', month: 'short', year: 'numeric', hour: '2-digit', minute: '2-digit', timeZone: 'UTC', timeZoneName: 'short' });
                       const marker = '<!-- preview-webapp-deploy-bot -->';
-                      const body = `${marker}\n## Preview Deploy\n\n| Status | URL | Deploy Logs | Last Updated |\n|--------|-----|------------|-------------|\n| 🔄 Deploying | ${url} | [Deploy Logs](${runUrl}) | ${now} |`;
+                      const body = `${marker}\n## Preview Deploy\n\n| Status | URL | Deploy Logs | Last Updated |\n|--------|-----|------------|-------------|\n| 🔄 Deploying | [Preview URL](${url}) | [Deploy Logs](${runUrl}) | ${now} |`;
 
                       const comments = await github.paginate(github.rest.issues.listComments, {
                         owner: context.repo.owner,
@@ -113,8 +113,8 @@ jobs:
               with:
                   script: |
                       const { PREVIEW_URL: url, RUN_URL: runUrl } = process.env;
-                      const now = new Date().toUTCString();
-                      const body = `<!-- preview-webapp-deploy-bot -->\n## Preview Deploy\n\n| Status | URL | Deploy Logs | Last Updated |\n|--------|-----|------------|-------------|\n| ✅ Ready | [${url}](${url}) | [Deploy Logs](${runUrl}) | ${now} |`;
+                      const now = new Date().toLocaleString('en-GB', { day: 'numeric', month: 'short', year: 'numeric', hour: '2-digit', minute: '2-digit', timeZone: 'UTC', timeZoneName: 'short' });
+                      const body = `<!-- preview-webapp-deploy-bot -->\n## Preview Deploy\n\n| Status | URL | Deploy Logs | Last Updated |\n|--------|-----|------------|-------------|\n| ✅ Ready | [Preview URL](${url}) | [Deploy Logs](${runUrl}) | ${now} |`;
                       await github.rest.issues.updateComment({
                         owner: context.repo.owner,
                         repo: context.repo.repo,
@@ -131,8 +131,8 @@ jobs:
               with:
                   script: |
                       const { PREVIEW_URL: url, RUN_URL: runUrl } = process.env;
-                      const now = new Date().toUTCString();
-                      const body = `<!-- preview-webapp-deploy-bot -->\n## Preview Deploy\n\n| Status | URL | Deploy Logs | Last Updated |\n|--------|-----|------------|-------------|\n| ❌ Failed | ${url} | [Deploy Logs](${runUrl}) | ${now} |`;
+                      const now = new Date().toLocaleString('en-GB', { day: 'numeric', month: 'short', year: 'numeric', hour: '2-digit', minute: '2-digit', timeZone: 'UTC', timeZoneName: 'short' });
+                      const body = `<!-- preview-webapp-deploy-bot -->\n## Preview Deploy\n\n| Status | URL | Deploy Logs | Last Updated |\n|--------|-----|------------|-------------|\n| ❌ Failed | [Preview URL](${url}) | [Deploy Logs](${runUrl}) | ${now} |`;
                       await github.rest.issues.updateComment({
                         owner: context.repo.owner,
                         repo: context.repo.repo,

--- a/packages/webapp/src/index.tsx
+++ b/packages/webapp/src/index.tsx
@@ -1,4 +1,3 @@
-// temp
 import { QueryClientProvider } from '@tanstack/react-query';
 import { NuqsAdapter } from 'nuqs/adapters/react-router/v6';
 import posthog from 'posthog-js';

--- a/packages/webapp/src/index.tsx
+++ b/packages/webapp/src/index.tsx
@@ -1,3 +1,4 @@
+// temp
 import { QueryClientProvider } from '@tanstack/react-query';
 import { NuqsAdapter } from 'nuqs/adapters/react-router/v6';
 import posthog from 'posthog-js';


### PR DESCRIPTION
## Problem

The preview deploy PR comment showed the full raw URL in the table and a verbose timestamp (`Mon, 25 May 2026 12:46:09 GMT`), causing the row to wrap across multiple lines.

## Solution

- URL column now renders as a `[Preview URL](...)` link instead of the full URL string
- Timestamp uses `toLocaleString('en-GB', ...)` with explicit options to produce a compact format like `25 May 2026, 12:46 UTC`, dropping the day name and seconds

## Testing

- Verified the changes look correct by reviewing the diff across all three comment states (Deploying, Ready, Failed)

<!-- start telescope-canary-packages -->
<!-- end telescope-canary-packages -->
