### PR TITLE
feat(server): meter bytes transferred on forward deliveries

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -39687,6 +39687,7 @@
             "dependencies": {
                 "@nangohq/kvstore": "file:../kvstore",
                 "@nangohq/logs": "file:../logs",
+                "@nangohq/shared": "file:../shared",
                 "@nangohq/utils": "file:../utils",
                 "axios": "1.15.2",
                 "dayjs": "1.11.7",

--- a/packages/server/lib/webhook/webhook.manager.ts
+++ b/packages/server/lib/webhook/webhook.manager.ts
@@ -2,7 +2,7 @@ import tracer from 'dd-trace';
 
 import db from '@nangohq/database';
 import { NangoError, customerKeyService, externalWebhookService, getProvider, pubsub } from '@nangohq/shared';
-import { Err, getLogger } from '@nangohq/utils';
+import { Err, getLogger, metrics } from '@nangohq/utils';
 import { forwardWebhook } from '@nangohq/webhooks';
 
 import * as webhookHandlers from './index.js';
@@ -134,6 +134,10 @@ export async function routeWebhook({
         })
             .then((res) => {
                 if (res.isOk()) {
+                    const { bytes } = res.value;
+                    metrics.increment(metrics.Types.WEBHOOK_REQUEST_SIZE_IN_BYTES, bytes.sent, { callsite: 'forward' });
+                    metrics.increment(metrics.Types.WEBHOOK_RESPONSE_SIZE_IN_BYTES, bytes.received, { callsite: 'forward' });
+
                     for (const connectionId of connectionIds.length > 0 ? connectionIds : ['unkown']) {
                         pubsub.publisher.publish({
                             subject: 'usage',

--- a/packages/server/lib/webhook/webhook.manager.ts
+++ b/packages/server/lib/webhook/webhook.manager.ts
@@ -130,14 +130,14 @@ export async function routeWebhook({
             connectionIds,
             payload: webhookBodyToForward,
             webhookOriginalHeaders: headers,
-            logContextGetter
+            logContextGetter,
+            onBytes: (bytes) => {
+                metrics.increment(metrics.Types.WEBHOOK_REQUEST_SIZE_IN_BYTES, bytes.sent, { callsite: 'forward' });
+                metrics.increment(metrics.Types.WEBHOOK_RESPONSE_SIZE_IN_BYTES, bytes.received, { callsite: 'forward' });
+            }
         })
             .then((res) => {
                 if (res.isOk()) {
-                    const { bytes } = res.value;
-                    metrics.increment(metrics.Types.WEBHOOK_REQUEST_SIZE_IN_BYTES, bytes.sent, { callsite: 'forward' });
-                    metrics.increment(metrics.Types.WEBHOOK_RESPONSE_SIZE_IN_BYTES, bytes.received, { callsite: 'forward' });
-
                     for (const connectionId of connectionIds.length > 0 ? connectionIds : ['unkown']) {
                         pubsub.publisher.publish({
                             subject: 'usage',

--- a/packages/shared/lib/index.ts
+++ b/packages/shared/lib/index.ts
@@ -43,6 +43,7 @@ export * from './services/invitations.js';
 export * from './services/providers.js';
 export * from './services/proxy/utils.js';
 export * from './services/proxy/request.js';
+export { type MeteredBytes, createMeteringTransport } from './services/proxy/byte-metering-transport.js';
 export * from './services/plans/plans.js';
 export * from './services/plans/definitions.js';
 export * from './services/checkpoints/checkpoints.js';

--- a/packages/utils/lib/telemetry/metrics.ts
+++ b/packages/utils/lib/telemetry/metrics.ts
@@ -68,6 +68,8 @@ export enum Types {
     WEBHOOK_ASYNC_ACTION_SUCCESS = 'nango.webhook.async_action.success',
     WEBHOOK_ASYNC_ACTION_FAILED = 'nango.webhook.async_action.failed',
     WEBHOOK_INCOMING_PAYLOAD_SIZE_BYTES = 'nango.webhook.incoming.payloadSizeBytes',
+    WEBHOOK_REQUEST_SIZE_IN_BYTES = 'nango.webhook.request.sizeInBytes',
+    WEBHOOK_RESPONSE_SIZE_IN_BYTES = 'nango.webhook.response.sizeInBytes',
     WEBHOOK_DIRECT_TRIGGER_SUCCESS = 'nango.webhook.direct_trigger.success',
 
     WEBHOOK_DISPATCH_PUBLISH_SUCCESS = 'nango.webhook.dispatch_queue.publish.success',

--- a/packages/webhooks/lib/asyncAction.unit.test.ts
+++ b/packages/webhooks/lib/asyncAction.unit.test.ts
@@ -92,23 +92,33 @@ describe('AsyncAction webhookds', () => {
             providerConfigKey: props.providerConfigKey
         };
         const bodyString = stringifyStable(body).unwrap();
-        expect(spy).toHaveBeenNthCalledWith(1, webhookSettings.primary_url, bodyString, {
-            headers: {
-                'X-Nango-Signature': expect.toBeSha256(),
-                'X-Nango-Hmac-Sha256': expect.toBeSha256(),
-                'content-type': 'application/json',
-                'user-agent': expect.stringContaining('nango/')
-            },
-            timeout: expect.any(Number)
-        });
-        expect(spy).toHaveBeenNthCalledWith(2, webhookSettings.secondary_url, bodyString, {
-            headers: {
-                'X-Nango-Signature': expect.toBeSha256(),
-                'X-Nango-Hmac-Sha256': expect.toBeSha256(),
-                'content-type': 'application/json',
-                'user-agent': expect.stringContaining('nango/')
-            },
-            timeout: expect.any(Number)
-        });
+        expect(spy).toHaveBeenNthCalledWith(
+            1,
+            webhookSettings.primary_url,
+            bodyString,
+            expect.objectContaining({
+                headers: {
+                    'X-Nango-Signature': expect.toBeSha256(),
+                    'X-Nango-Hmac-Sha256': expect.toBeSha256(),
+                    'content-type': 'application/json',
+                    'user-agent': expect.stringContaining('nango/')
+                },
+                timeout: expect.any(Number)
+            })
+        );
+        expect(spy).toHaveBeenNthCalledWith(
+            2,
+            webhookSettings.secondary_url,
+            bodyString,
+            expect.objectContaining({
+                headers: {
+                    'X-Nango-Signature': expect.toBeSha256(),
+                    'X-Nango-Hmac-Sha256': expect.toBeSha256(),
+                    'content-type': 'application/json',
+                    'user-agent': expect.stringContaining('nango/')
+                },
+                timeout: expect.any(Number)
+            })
+        );
     });
 });

--- a/packages/webhooks/lib/forward.ts
+++ b/packages/webhooks/lib/forward.ts
@@ -4,6 +4,7 @@ import { Err, Ok, metrics } from '@nangohq/utils';
 import { deliver, shouldSend } from './utils.js';
 
 import type { LogContextGetter } from '@nangohq/logs';
+import type { MeteredBytes } from '@nangohq/shared';
 import type { DBAPISecret, DBEnvironment, DBExternalWebhook, DBTeam, IntegrationConfig, NangoForwardWebhookBody, Result } from '@nangohq/types';
 
 export const forwardWebhook = async ({
@@ -26,15 +27,15 @@ export const forwardWebhook = async ({
     payload: Record<string, any> | null;
     webhookOriginalHeaders: Record<string, string>;
     logContextGetter: LogContextGetter;
-}): Promise<Result<{ forwarded: number }>> => {
+}): Promise<Result<{ forwarded: number; bytes: MeteredBytes }>> => {
     if (!webhookSettings) {
-        return Ok({ forwarded: 0 });
+        return Ok({ forwarded: 0, bytes: { sent: 0, received: 0 } });
     }
     if (!shouldSend({ success: true, type: 'forward', webhookSettings })) {
-        return Ok({ forwarded: 0 });
+        return Ok({ forwarded: 0, bytes: { sent: 0, received: 0 } });
     }
     if (!integration.forward_webhooks) {
-        return Ok({ forwarded: 0 });
+        return Ok({ forwarded: 0, bytes: { sent: 0, received: 0 } });
     }
 
     const logCtx = await logContextGetter.create(
@@ -59,6 +60,12 @@ export const forwardWebhook = async ({
         { url: webhookSettings.secondary_url, type: 'secondary webhook url' }
     ].filter((webhook) => webhook.url) as { url: string; type: string }[];
 
+    const totalBytes: MeteredBytes = { sent: 0, received: 0 };
+    const accumulateBytes = (hop: MeteredBytes) => {
+        totalBytes.sent += hop.sent;
+        totalBytes.received += hop.received;
+    };
+
     if (!connectionIds || connectionIds.length === 0) {
         const result = await deliver({
             webhooks,
@@ -66,7 +73,8 @@ export const forwardWebhook = async ({
             webhookType: 'forward',
             secret,
             logCtx,
-            incomingHeaders: webhookOriginalHeaders
+            incomingHeaders: webhookOriginalHeaders,
+            onBytes: accumulateBytes
         });
 
         if (result.isErr()) {
@@ -77,7 +85,7 @@ export const forwardWebhook = async ({
 
         metrics.increment(metrics.Types.WEBHOOK_INCOMING_FORWARDED_SUCCESS, 1, { accountId: account.id });
         await logCtx.success();
-        return Ok({ forwarded: 1 });
+        return Ok({ forwarded: 1, bytes: totalBytes });
     }
 
     let success = true;
@@ -92,7 +100,8 @@ export const forwardWebhook = async ({
             webhookType: 'forward',
             secret,
             logCtx,
-            incomingHeaders: webhookOriginalHeaders
+            incomingHeaders: webhookOriginalHeaders,
+            onBytes: accumulateBytes
         });
 
         if (result.isOk()) {
@@ -109,5 +118,5 @@ export const forwardWebhook = async ({
     } else {
         await logCtx.failed();
     }
-    return Ok({ forwarded });
+    return Ok({ forwarded, bytes: totalBytes });
 };

--- a/packages/webhooks/lib/forward.ts
+++ b/packages/webhooks/lib/forward.ts
@@ -16,7 +16,8 @@ export const forwardWebhook = async ({
     connectionIds,
     payload,
     webhookOriginalHeaders,
-    logContextGetter
+    logContextGetter,
+    onBytes
 }: {
     integration: IntegrationConfig;
     account: DBTeam;
@@ -27,96 +28,105 @@ export const forwardWebhook = async ({
     payload: Record<string, any> | null;
     webhookOriginalHeaders: Record<string, string>;
     logContextGetter: LogContextGetter;
-}): Promise<Result<{ forwarded: number; bytes: MeteredBytes }>> => {
-    if (!webhookSettings) {
-        return Ok({ forwarded: 0, bytes: { sent: 0, received: 0 } });
-    }
-    if (!shouldSend({ success: true, type: 'forward', webhookSettings })) {
-        return Ok({ forwarded: 0, bytes: { sent: 0, received: 0 } });
-    }
-    if (!integration.forward_webhooks) {
-        return Ok({ forwarded: 0, bytes: { sent: 0, received: 0 } });
-    }
-
-    const logCtx = await logContextGetter.create(
-        { operation: { type: 'webhook', action: 'forward' }, expiresAt: new Date(Date.now() + 15 * 60 * 1000).toISOString() },
-        {
-            account,
-            environment,
-            integration: { id: integration.id!, name: integration.unique_key, provider: integration.provider }
-        }
-    );
-    logCtx.attachSpan(new OtlpSpan(logCtx.operation));
-
-    const body: NangoForwardWebhookBody = {
-        from: integration.provider,
-        providerConfigKey: integration.unique_key,
-        type: 'forward',
-        payload: payload
-    };
-
-    const webhooks = [
-        { url: webhookSettings.primary_url, type: 'webhook url' },
-        { url: webhookSettings.secondary_url, type: 'secondary webhook url' }
-    ].filter((webhook) => webhook.url) as { url: string; type: string }[];
-
+    onBytes?: (bytes: MeteredBytes) => void;
+}): Promise<Result<{ forwarded: number }>> => {
     const totalBytes: MeteredBytes = { sent: 0, received: 0 };
     const accumulateBytes = (hop: MeteredBytes) => {
         totalBytes.sent += hop.sent;
         totalBytes.received += hop.received;
     };
 
-    if (!connectionIds || connectionIds.length === 0) {
-        const result = await deliver({
-            webhooks,
-            body: payload,
-            webhookType: 'forward',
-            secret,
-            logCtx,
-            incomingHeaders: webhookOriginalHeaders,
-            onBytes: accumulateBytes
-        });
-
-        if (result.isErr()) {
-            metrics.increment(metrics.Types.WEBHOOK_INCOMING_FORWARDED_FAILED, 1, { accountId: account.id });
-            await logCtx.failed();
-            return Err(result.error);
+    try {
+        if (!webhookSettings) {
+            return Ok({ forwarded: 0 });
+        }
+        if (!shouldSend({ success: true, type: 'forward', webhookSettings })) {
+            return Ok({ forwarded: 0 });
+        }
+        if (!integration.forward_webhooks) {
+            return Ok({ forwarded: 0 });
         }
 
-        metrics.increment(metrics.Types.WEBHOOK_INCOMING_FORWARDED_SUCCESS, 1, { accountId: account.id });
-        await logCtx.success();
-        return Ok({ forwarded: 1, bytes: totalBytes });
-    }
+        const logCtx = await logContextGetter.create(
+            { operation: { type: 'webhook', action: 'forward' }, expiresAt: new Date(Date.now() + 15 * 60 * 1000).toISOString() },
+            {
+                account,
+                environment,
+                integration: { id: integration.id!, name: integration.unique_key, provider: integration.provider }
+            }
+        );
+        logCtx.attachSpan(new OtlpSpan(logCtx.operation));
 
-    let success = true;
-    let forwarded = 0;
-    for (const connectionId of connectionIds) {
-        const result = await deliver({
-            webhooks,
-            body: {
-                ...body,
-                connectionId
-            },
-            webhookType: 'forward',
-            secret,
-            logCtx,
-            incomingHeaders: webhookOriginalHeaders,
-            onBytes: accumulateBytes
-        });
+        const body: NangoForwardWebhookBody = {
+            from: integration.provider,
+            providerConfigKey: integration.unique_key,
+            type: 'forward',
+            payload: payload
+        };
 
-        if (result.isOk()) {
+        const webhooks = [
+            { url: webhookSettings.primary_url, type: 'webhook url' },
+            { url: webhookSettings.secondary_url, type: 'secondary webhook url' }
+        ].filter((webhook) => webhook.url) as { url: string; type: string }[];
+
+        if (!connectionIds || connectionIds.length === 0) {
+            const result = await deliver({
+                webhooks,
+                body: payload,
+                webhookType: 'forward',
+                secret,
+                logCtx,
+                incomingHeaders: webhookOriginalHeaders,
+                onBytes: accumulateBytes
+            });
+
+            if (result.isErr()) {
+                metrics.increment(metrics.Types.WEBHOOK_INCOMING_FORWARDED_FAILED, 1, { accountId: account.id });
+                await logCtx.failed();
+                return Err(result.error);
+            }
+
             metrics.increment(metrics.Types.WEBHOOK_INCOMING_FORWARDED_SUCCESS, 1, { accountId: account.id });
-            forwarded += 1;
+            await logCtx.success();
+            return Ok({ forwarded: 1 });
+        }
+
+        let success = true;
+        let forwarded = 0;
+        for (const connectionId of connectionIds) {
+            const result = await deliver({
+                webhooks,
+                body: {
+                    ...body,
+                    connectionId
+                },
+                webhookType: 'forward',
+                secret,
+                logCtx,
+                incomingHeaders: webhookOriginalHeaders,
+                onBytes: accumulateBytes
+            });
+
+            if (result.isOk()) {
+                metrics.increment(metrics.Types.WEBHOOK_INCOMING_FORWARDED_SUCCESS, 1, { accountId: account.id });
+                forwarded += 1;
+            } else {
+                metrics.increment(metrics.Types.WEBHOOK_INCOMING_FORWARDED_FAILED, 1, { accountId: account.id });
+                success = false;
+            }
+        }
+
+        if (success) {
+            await logCtx.success();
         } else {
-            metrics.increment(metrics.Types.WEBHOOK_INCOMING_FORWARDED_FAILED, 1, { accountId: account.id });
-            success = false;
+            await logCtx.failed();
+        }
+        return Ok({ forwarded });
+    } finally {
+        try {
+            onBytes?.(totalBytes);
+        } catch (err) {
+            console.error('onBytes callback failed', err);
         }
     }
-
-    if (success) {
-        await logCtx.success();
-    } else {
-        await logCtx.failed();
-    }
-    return Ok({ forwarded, bytes: totalBytes });
 };

--- a/packages/webhooks/lib/forward.ts
+++ b/packages/webhooks/lib/forward.ts
@@ -1,5 +1,7 @@
 import { OtlpSpan } from '@nangohq/logs';
-import { Err, Ok, metrics } from '@nangohq/utils';
+import { Err, Ok, getLogger, metrics } from '@nangohq/utils';
+
+const logger = getLogger('webhooks.forward');
 
 import { deliver, shouldSend } from './utils.js';
 
@@ -126,7 +128,7 @@ export const forwardWebhook = async ({
         try {
             onBytes?.(totalBytes);
         } catch (err) {
-            console.error('onBytes callback failed', err);
+            logger.error('onBytes callback failed', err);
         }
     }
 };

--- a/packages/webhooks/lib/forward.unit.test.ts
+++ b/packages/webhooks/lib/forward.unit.test.ts
@@ -191,8 +191,9 @@ describe('Webhooks: forward notification tests', () => {
         expect(spy).toHaveBeenCalledTimes(4);
     });
 
-    it('Should return non-zero bytes.sent on successful forward', async () => {
+    it('Should report non-zero bytes.sent via onBytes on successful forward', async () => {
         const payload = { some: 'data' };
+        let reportedBytes: { sent: number; received: number } | undefined;
         const result = await forwardWebhook({
             connectionIds: [],
             account,
@@ -202,17 +203,19 @@ describe('Webhooks: forward notification tests', () => {
             logContextGetter,
             integration,
             payload,
-            webhookOriginalHeaders: {}
+            webhookOriginalHeaders: {},
+            onBytes: (b) => {
+                reportedBytes = b;
+            }
         });
         expect(result.isOk()).toBe(true);
-        if (result.isOk()) {
-            // payload sent to both primary and secondary URLs
-            const minBytes = Buffer.byteLength(JSON.stringify(payload)) * 2;
-            expect(result.value.bytes.sent).toBeGreaterThanOrEqual(minBytes);
-        }
+        // payload sent to both primary and secondary URLs
+        const minBytes = Buffer.byteLength(JSON.stringify(payload)) * 2;
+        expect(reportedBytes?.sent).toBeGreaterThanOrEqual(minBytes);
     });
 
-    it('Should return zero bytes when forwarding is skipped', async () => {
+    it('Should report zero bytes via onBytes when forwarding is skipped', async () => {
+        let reportedBytes: { sent: number; received: number } | undefined;
         const result = await forwardWebhook({
             connectionIds: [],
             account,
@@ -222,17 +225,19 @@ describe('Webhooks: forward notification tests', () => {
             logContextGetter,
             integration,
             payload: { some: 'data' },
-            webhookOriginalHeaders: {}
+            webhookOriginalHeaders: {},
+            onBytes: (b) => {
+                reportedBytes = b;
+            }
         });
         expect(result.isOk()).toBe(true);
-        if (result.isOk()) {
-            expect(result.value.bytes).toEqual({ sent: 0, received: 0 });
-        }
+        expect(reportedBytes).toEqual({ sent: 0, received: 0 });
     });
 
-    it('Should sum bytes across connections in fan-out', async () => {
+    it('Should sum bytes across connections in fan-out via onBytes', async () => {
         const connectionIds = ['conn1', 'conn2'];
         const payload = { x: 1 };
+        let reportedBytes: { sent: number; received: number } | undefined;
         const result = await forwardWebhook({
             connectionIds,
             account,
@@ -242,13 +247,16 @@ describe('Webhooks: forward notification tests', () => {
             logContextGetter,
             integration,
             payload,
-            webhookOriginalHeaders: {}
+            webhookOriginalHeaders: {},
+            onBytes: (b) => {
+                reportedBytes = b;
+            }
         });
         expect(result.isOk()).toBe(true);
         if (result.isOk()) {
             expect(result.value.forwarded).toBe(2);
-            const minBytes = Buffer.byteLength(JSON.stringify(payload)) * connectionIds.length;
-            expect(result.value.bytes.sent).toBeGreaterThanOrEqual(minBytes);
         }
+        const minBytes = Buffer.byteLength(JSON.stringify(payload)) * connectionIds.length;
+        expect(reportedBytes?.sent).toBeGreaterThanOrEqual(minBytes);
     });
 });

--- a/packages/webhooks/lib/forward.unit.test.ts
+++ b/packages/webhooks/lib/forward.unit.test.ts
@@ -190,4 +190,65 @@ describe('Webhooks: forward notification tests', () => {
         });
         expect(spy).toHaveBeenCalledTimes(4);
     });
+
+    it('Should return non-zero bytes.sent on successful forward', async () => {
+        const payload = { some: 'data' };
+        const result = await forwardWebhook({
+            connectionIds: [],
+            account,
+            environment: { name: 'dev', id: 1 } as DBEnvironment,
+            secret,
+            webhookSettings,
+            logContextGetter,
+            integration,
+            payload,
+            webhookOriginalHeaders: {}
+        });
+        expect(result.isOk()).toBe(true);
+        if (result.isOk()) {
+            // payload sent to both primary and secondary URLs
+            const minBytes = Buffer.byteLength(JSON.stringify(payload)) * 2;
+            expect(result.value.bytes.sent).toBeGreaterThanOrEqual(minBytes);
+        }
+    });
+
+    it('Should return zero bytes when forwarding is skipped', async () => {
+        const result = await forwardWebhook({
+            connectionIds: [],
+            account,
+            environment: { name: 'dev', id: 1 } as DBEnvironment,
+            secret,
+            webhookSettings: null,
+            logContextGetter,
+            integration,
+            payload: { some: 'data' },
+            webhookOriginalHeaders: {}
+        });
+        expect(result.isOk()).toBe(true);
+        if (result.isOk()) {
+            expect(result.value.bytes).toEqual({ sent: 0, received: 0 });
+        }
+    });
+
+    it('Should sum bytes across connections in fan-out', async () => {
+        const connectionIds = ['conn1', 'conn2'];
+        const payload = { x: 1 };
+        const result = await forwardWebhook({
+            connectionIds,
+            account,
+            environment: { name: 'dev', id: 1 } as DBEnvironment,
+            secret,
+            webhookSettings: { ...webhookSettings, secondary_url: '' },
+            logContextGetter,
+            integration,
+            payload,
+            webhookOriginalHeaders: {}
+        });
+        expect(result.isOk()).toBe(true);
+        if (result.isOk()) {
+            expect(result.value.forwarded).toBe(2);
+            const minBytes = Buffer.byteLength(JSON.stringify(payload)) * connectionIds.length;
+            expect(result.value.bytes.sent).toBeGreaterThanOrEqual(minBytes);
+        }
+    });
 });

--- a/packages/webhooks/lib/utils.ts
+++ b/packages/webhooks/lib/utils.ts
@@ -238,7 +238,11 @@ export const deliver = async ({
                                 return Err(new Error('unknown_error', { cause: err }));
                             }
                         } finally {
-                            onBytes?.(attemptBytes);
+                            try {
+                                onBytes?.(attemptBytes);
+                            } catch (err) {
+                                void logCtx?.error('Webhook byte metering callback failed', { error: err, url });
+                            }
                         }
                     });
 

--- a/packages/webhooks/lib/utils.ts
+++ b/packages/webhooks/lib/utils.ts
@@ -4,7 +4,9 @@ import { isAxiosError } from 'axios';
 
 import { getRedis } from '@nangohq/kvstore';
 import { createMeteringTransport } from '@nangohq/shared';
-import { Err, Ok, axiosInstance as axios, networkError, redactHeaders, retryFlexible, stringifyStable, userAgent } from '@nangohq/utils';
+import { Err, Ok, axiosInstance as axios, getLogger, networkError, redactHeaders, retryFlexible, stringifyStable, userAgent } from '@nangohq/utils';
+
+const logger = getLogger('webhooks.utils');
 
 import { CircuitBreakerPassThrough, CircuitBreakerRedis } from './circuitBreaker.js';
 import { envs } from './envs.js';
@@ -241,7 +243,7 @@ export const deliver = async ({
                             try {
                                 onBytes?.(attemptBytes);
                             } catch (err) {
-                                console.error('onBytes callback failed', err);
+                                logger.error('onBytes callback failed', err);
                             }
                         }
                     });

--- a/packages/webhooks/lib/utils.ts
+++ b/packages/webhooks/lib/utils.ts
@@ -3,12 +3,14 @@ import crypto from 'crypto';
 import { isAxiosError } from 'axios';
 
 import { getRedis } from '@nangohq/kvstore';
+import { createMeteringTransport } from '@nangohq/shared';
 import { Err, Ok, axiosInstance as axios, networkError, redactHeaders, retryFlexible, stringifyStable, userAgent } from '@nangohq/utils';
 
 import { CircuitBreakerPassThrough, CircuitBreakerRedis } from './circuitBreaker.js';
 import { envs } from './envs.js';
 
 import type { LogContext } from '@nangohq/logs';
+import type { MeteredBytes } from '@nangohq/shared';
 import type { DBAPISecret, DBExternalWebhook, MessageHTTPResponse, MessageRow, WebhookTypes } from '@nangohq/types';
 import type { Result } from '@nangohq/utils';
 import type { AxiosError, AxiosResponse } from 'axios';
@@ -149,7 +151,8 @@ export const deliver = async ({
     logCtx,
     secret,
     endingMessage = '',
-    incomingHeaders
+    incomingHeaders,
+    onBytes
 }: {
     webhooks: { url: string; type: string }[];
     body: unknown;
@@ -158,6 +161,7 @@ export const deliver = async ({
     logCtx?: LogContext | undefined;
     endingMessage?: string;
     incomingHeaders?: Record<string, string>;
+    onBytes?: (bytes: MeteredBytes) => void;
 }): Promise<Result<void>> => {
     let success = true;
 
@@ -193,8 +197,13 @@ export const deliver = async ({
                 async () => {
                     const result = await circuitBreaker.execute(url, async () => {
                         const createdAt = new Date();
+                        const attemptBytes: MeteredBytes = { sent: 0, received: 0 };
+                        const transport = createMeteringTransport((hop) => {
+                            attemptBytes.sent += hop.sent;
+                            attemptBytes.received += hop.received;
+                        });
                         try {
-                            const res = await axios.post(url, bodyString.value, { headers, timeout: envs.NANGO_WEBHOOK_TIMEOUT_MS });
+                            const res = await axios.post(url, bodyString.value, { headers, timeout: envs.NANGO_WEBHOOK_TIMEOUT_MS, transport });
 
                             void logCtx?.http(`POST ${url}`, { request: logRequest, response: formatLogResponse(res), context: 'webhook', createdAt });
                             if (res.status >= 200 && res.status < 300) {
@@ -228,6 +237,8 @@ export const deliver = async ({
                                 });
                                 return Err(new Error('unknown_error', { cause: err }));
                             }
+                        } finally {
+                            onBytes?.(attemptBytes);
                         }
                     });
 

--- a/packages/webhooks/lib/utils.ts
+++ b/packages/webhooks/lib/utils.ts
@@ -241,7 +241,7 @@ export const deliver = async ({
                             try {
                                 onBytes?.(attemptBytes);
                             } catch (err) {
-                                void logCtx?.error('Webhook byte metering callback failed', { error: err, url });
+                                console.error('onBytes callback failed', err);
                             }
                         }
                     });

--- a/packages/webhooks/lib/utils.unit.test.ts
+++ b/packages/webhooks/lib/utils.unit.test.ts
@@ -1,8 +1,11 @@
-import { describe, expect, it } from 'vitest';
+import { afterAll, beforeAll, describe, expect, it } from 'vitest';
 
 import { stringifyStable } from '@nangohq/utils';
 
-import { getHmacSignatureHeader, getSignatureHeaderUnsafe } from './utils.js';
+import { TestWebhookServer } from './helpers/test.js';
+import { deliver, getHmacSignatureHeader, getSignatureHeaderUnsafe } from './utils.js';
+
+import type { DBAPISecret } from '@nangohq/types';
 
 describe('getSignatureHeaderUnsafe', () => {
     it('should return a string', () => {
@@ -41,5 +44,50 @@ describe('getHmacSignatureHeader', () => {
         const safeSignature = getHmacSignatureHeader(secret, payload);
         const unsafeSignature = getSignatureHeaderUnsafe(secret, payload);
         expect(safeSignature).not.toEqual(unsafeSignature);
+    });
+});
+
+describe('deliver bytes metering', () => {
+    const testServer = new TestWebhookServer(4103);
+    const secret = 'test-secret' as DBAPISecret['secret'];
+
+    beforeAll(async () => {
+        await testServer.start();
+    });
+
+    afterAll(async () => {
+        await testServer.stop();
+    });
+
+    it('should fire onBytes with non-zero sent on successful POST', async () => {
+        const hops: { sent: number; received: number }[] = [];
+        const result = await deliver({
+            webhooks: [{ url: testServer.primaryUrl, type: 'primary' }],
+            body: { hello: 'world' },
+            webhookType: 'forward',
+            secret,
+            onBytes: (b) => hops.push(b)
+        });
+        expect(result.isOk()).toBe(true);
+        expect(hops.length).toBe(1);
+        expect(hops[0]!.sent).toBeGreaterThan(0);
+    });
+
+    it('should fire onBytes once per webhook URL', async () => {
+        const hops: { sent: number; received: number }[] = [];
+        await deliver({
+            webhooks: [
+                { url: testServer.primaryUrl, type: 'primary' },
+                { url: testServer.secondaryUrl, type: 'secondary' }
+            ],
+            body: { hello: 'world' },
+            webhookType: 'forward',
+            secret,
+            onBytes: (b) => hops.push(b)
+        });
+        expect(hops.length).toBe(2);
+        for (const h of hops) {
+            expect(h.sent).toBeGreaterThan(0);
+        }
     });
 });

--- a/packages/webhooks/lib/utils.unit.test.ts
+++ b/packages/webhooks/lib/utils.unit.test.ts
@@ -48,7 +48,7 @@ describe('getHmacSignatureHeader', () => {
 });
 
 describe('deliver bytes metering', () => {
-    const testServer = new TestWebhookServer(4103);
+    const testServer = new TestWebhookServer(4104);
     const secret = 'test-secret' as DBAPISecret['secret'];
 
     beforeAll(async () => {

--- a/packages/webhooks/package.json
+++ b/packages/webhooks/package.json
@@ -16,6 +16,7 @@
     "keywords": [],
     "dependencies": {
         "@nangohq/logs": "file:../logs",
+        "@nangohq/shared": "file:../shared",
         "@nangohq/utils": "file:../utils",
         "@nangohq/kvstore": "file:../kvstore",
         "axios": "1.15.2",

--- a/packages/webhooks/tsconfig.json
+++ b/packages/webhooks/tsconfig.json
@@ -16,6 +16,9 @@
         },
         {
             "path": "../kvstore"
+        },
+        {
+            "path": "../shared"
         }
     ],
     "include": ["lib/**/*", "../utils/lib/vitest.d.ts"]


### PR DESCRIPTION
Track HTTP request/response bytes per webhook delivery hop via a
metering transport. Accumulate across all URLs (primary + secondary)
and connection fan-out, then emit WEBHOOK_REQUEST_SIZE_IN_BYTES and
WEBHOOK_RESPONSE_SIZE_IN_BYTES metrics from the server.