### PR TITLE
fix(webapp): fix KeyValueInput inconsistent empty row and rename tabs

### DIFF
--- a/packages/webapp/src/components-v2/KeyValueInput.tsx
+++ b/packages/webapp/src/components-v2/KeyValueInput.tsx
@@ -19,7 +19,6 @@ interface KeyValueInputProps {
     placeholderValue?: string;
     disabled?: boolean;
     isSecret?: boolean;
-    alwaysShowEmptyRow?: boolean;
 }
 
 let nextId = 0;
@@ -31,14 +30,15 @@ export const KeyValueInput: React.FC<KeyValueInputProps> = ({
     placeholderKey = 'Key',
     placeholderValue = 'Value',
     disabled = false,
-    isSecret = false,
-    alwaysShowEmptyRow = false
+    isSecret = false
 }) => {
+    const showEmptyRow = !disabled;
+
     const buildPairsFromValues = (values: Record<string, string>): KeyValuePair[] => {
         const entries = Object.entries(values);
         if (entries.length > 0) {
             const mapped = entries.map(([key, value]) => ({ id: generateId(), key, value }));
-            return alwaysShowEmptyRow ? [...mapped, { id: generateId(), key: '', value: '' }] : mapped;
+            return showEmptyRow ? [...mapped, { id: generateId(), key: '', value: '' }] : mapped;
         }
         return [{ id: generateId(), key: '', value: '' }];
     };
@@ -54,7 +54,23 @@ export const KeyValueInput: React.FC<KeyValueInputProps> = ({
             lastReportedRef.current = initialValuesKey;
         }
         // eslint-disable-next-line react-hooks/exhaustive-deps
-    }, [initialValuesKey, alwaysShowEmptyRow]);
+    }, [initialValuesKey, showEmptyRow]);
+
+    useEffect(() => {
+        setPairs((prev) => {
+            if (prev.length === 0) return prev;
+            const last = prev[prev.length - 1];
+            const hasTrailingEmpty = last.key === '' && last.value === '';
+
+            if (showEmptyRow && !hasTrailingEmpty) {
+                return [...prev, { id: generateId(), key: '', value: '' }];
+            }
+            if (!showEmptyRow && hasTrailingEmpty && prev.length > 1) {
+                return prev.slice(0, -1);
+            }
+            return prev;
+        });
+    }, [showEmptyRow]);
 
     useEffect(() => {
         const newValues = pairs.reduce<Record<string, string>>((acc, curr) => {

--- a/packages/webapp/src/components-v2/KeyValueInput.tsx
+++ b/packages/webapp/src/components-v2/KeyValueInput.tsx
@@ -35,12 +35,8 @@ export const KeyValueInput: React.FC<KeyValueInputProps> = ({
     const showEmptyRow = !disabled;
 
     const buildPairsFromValues = (values: Record<string, string>): KeyValuePair[] => {
-        const entries = Object.entries(values);
-        if (entries.length > 0) {
-            const mapped = entries.map(([key, value]) => ({ id: generateId(), key, value }));
-            return showEmptyRow ? [...mapped, { id: generateId(), key: '', value: '' }] : mapped;
-        }
-        return [{ id: generateId(), key: '', value: '' }];
+        const mapped = Object.entries(values).map(([key, value]) => ({ id: generateId(), key, value }));
+        return showEmptyRow ? [...mapped, { id: generateId(), key: '', value: '' }] : mapped;
     };
 
     const [pairs, setPairs] = useState<KeyValuePair[]>(() => buildPairsFromValues(initialValues));
@@ -58,14 +54,13 @@ export const KeyValueInput: React.FC<KeyValueInputProps> = ({
 
     useEffect(() => {
         setPairs((prev) => {
-            if (prev.length === 0) return prev;
             const last = prev[prev.length - 1];
-            const hasTrailingEmpty = last.key === '' && last.value === '';
+            const hasTrailingEmpty = last && last.key === '' && last.value === '';
 
             if (showEmptyRow && !hasTrailingEmpty) {
                 return [...prev, { id: generateId(), key: '', value: '' }];
             }
-            if (!showEmptyRow && hasTrailingEmpty && prev.length > 1) {
+            if (!showEmptyRow && hasTrailingEmpty) {
                 return prev.slice(0, -1);
             }
             return prev;

--- a/packages/webapp/src/pages/Connection/components/ConnectionAdvancedConfig.tsx
+++ b/packages/webapp/src/pages/Connection/components/ConnectionAdvancedConfig.tsx
@@ -175,7 +175,6 @@ export const ConnectionAdvancedConfig: React.FC<ConnectionAdvancedConfigProps> =
                                             onChange={field.onChange}
                                             placeholderKey="Tag Name"
                                             placeholderValue="Tag Value"
-                                            alwaysShowEmptyRow={true}
                                         />
                                         <FormMessage />
                                     </FormItem>
@@ -219,7 +218,6 @@ export const ConnectionAdvancedConfig: React.FC<ConnectionAdvancedConfigProps> =
                                                             onChange={field.onChange}
                                                             placeholderKey="Param Name"
                                                             placeholderValue="Param Value"
-                                                            alwaysShowEmptyRow={true}
                                                         />
                                                     </FormItem>
                                                 )}

--- a/packages/webapp/src/pages/Environment/Settings/Backend.tsx
+++ b/packages/webapp/src/pages/Environment/Settings/Backend.tsx
@@ -36,7 +36,7 @@ export const BackendSettings: React.FC = () => {
     }
 
     return (
-        <SettingsContent title="Backend">
+        <SettingsContent title="Auth callback">
             <SettingsGroup
                 label={
                     <>

--- a/packages/webapp/src/pages/Environment/Settings/Functions.tsx
+++ b/packages/webapp/src/pages/Environment/Settings/Functions.tsx
@@ -78,7 +78,7 @@ export const Functions: React.FC = () => {
     }
 
     return (
-        <SettingsContent title="Functions">
+        <SettingsContent title="Function env vars">
             <div className="flex flex-col gap-2.5">
                 <div className="inline-flex items-center gap-2">
                     Environment variables
@@ -95,7 +95,6 @@ export const Functions: React.FC = () => {
                             placeholderValue="value"
                             disabled={!edit || isPending}
                             isSecret={true}
-                            alwaysShowEmptyRow={edit}
                         />
                         {errors.length > 0 && (
                             <div className="flex flex-col gap-1">

--- a/packages/webapp/src/pages/Environment/Settings/Show.tsx
+++ b/packages/webapp/src/pages/Environment/Settings/Show.tsx
@@ -84,11 +84,11 @@ export const EnvironmentSettings: React.FC = () => {
                         <NavigationTrigger value="api-keys" onClick={() => setApiKeysResetKey((k) => k + 1)}>
                             API Keys
                         </NavigationTrigger>
-                        <NavigationTrigger value="backend">Backend</NavigationTrigger>
+                        <NavigationTrigger value="auth-callback">Auth callback</NavigationTrigger>
                         <NavigationTrigger value="connect-ui">Connect UI</NavigationTrigger>
                         <NavigationTrigger value="webhooks">Webhooks</NavigationTrigger>
                         <NavigationTrigger value="slack-alerts">Slack alerts</NavigationTrigger>
-                        <NavigationTrigger value="functions">Functions</NavigationTrigger>
+                        <NavigationTrigger value="function-env-vars">Function env vars</NavigationTrigger>
                         <NavigationTrigger value="telemetry">Telemetry</NavigationTrigger>
                         {canSeeDeprecatedAuthorization && <NavigationTrigger value="deprecated">Deprecated</NavigationTrigger>}
                     </NavigationList>
@@ -98,7 +98,7 @@ export const EnvironmentSettings: React.FC = () => {
                     <EnvironmentSettingsContent value={'api-keys'}>
                         <ApiKeys key={apiKeysResetKey} />
                     </EnvironmentSettingsContent>
-                    <EnvironmentSettingsContent value={'backend'}>
+                    <EnvironmentSettingsContent value={'auth-callback'}>
                         <BackendSettings />
                     </EnvironmentSettingsContent>
                     <EnvironmentSettingsContent value={'connect-ui'}>
@@ -110,7 +110,7 @@ export const EnvironmentSettings: React.FC = () => {
                     <EnvironmentSettingsContent value={'slack-alerts'}>
                         <SlackAlertsSettings />
                     </EnvironmentSettingsContent>
-                    <EnvironmentSettingsContent value={'functions'}>
+                    <EnvironmentSettingsContent value={'function-env-vars'}>
                         <Functions />
                     </EnvironmentSettingsContent>
                     <EnvironmentSettingsContent value={'telemetry'}>

--- a/packages/webapp/src/pages/Environment/Settings/Telemetry.tsx
+++ b/packages/webapp/src/pages/Environment/Settings/Telemetry.tsx
@@ -122,7 +122,6 @@ export const Telemetry: React.FC = () => {
                                 placeholderValue="value"
                                 disabled={!editHeaders || loading}
                                 isSecret={true}
-                                alwaysShowEmptyRow={editHeaders}
                             />
                             {errors.length > 0 && (
                                 <div className="flex flex-col gap-1">


### PR DESCRIPTION
The `KeyValueInput` component is supposed to always show an empty line while you're editing, so you can add new values. But when clicking edit, it would glitch and not show it. This PR fixes it. I noticed that "alwaysShowEmptyRow" was always tied to "editing", so I made it work based on "disabled" instead.

Also renamed the tabs as per product request.

Before:
<img width="961" height="367" alt="image" src="https://github.com/user-attachments/assets/73b79050-112f-4976-97bb-75b7e698905f" />

After: 
<img width="964" height="358" alt="image" src="https://github.com/user-attachments/assets/3ac7c33d-652f-4a52-b33a-23d50dbf339f" />

