### PR TITLE
feat(metering): deterministic S3 keys + skip-if-exists for billing export

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -37441,6 +37441,7 @@
             "name": "@nangohq/nango-metering",
             "version": "1.0.0",
             "dependencies": {
+                "@aws-sdk/client-s3": "3.993.0",
                 "@nangohq/billing": "file:../billing",
                 "@nangohq/database": "file:../database",
                 "@nangohq/kvstore": "file:../kvstore",

--- a/packages/metering/lib/crons/billingEventsS3Export.ts
+++ b/packages/metering/lib/crons/billingEventsS3Export.ts
@@ -11,16 +11,17 @@ import { envs } from '../env.js';
 import type { Lock } from '@nangohq/kvstore';
 
 const logger = getLogger('cron.billingEventsS3Export');
-const cronMinutes = envs.CRON_BILLING_EVENTS_S3_EXPORT_MINUTES;
-const cronOffsetMinutes = envs.CRON_BILLING_EVENTS_S3_EXPORT_OFFSET_MINUTES;
+// Minute-of-the-hour to fire on (0–59). -1 disables the cron entirely.
+// See CRON_BILLING_EVENTS_S3_HOURLY_EXPORT_MINUTE in packages/utils/lib/environment/parse.ts.
+const cronMinute = envs.CRON_BILLING_EVENTS_S3_HOURLY_EXPORT_MINUTE;
 const bucket = envs.BILLING_EVENTS_S3_BUCKET;
 const roleArn = envs.BILLING_EVENTS_S3_WRITER_ROLE_ARN;
 const region = envs.BILLING_EVENTS_S3_REGION;
 const eventNameSuffix = envs.BILLING_EVENTS_S3_EVENT_NAME_SUFFIX ?? '';
 
 const LOCK_KEY = 'lock:cron:billingEventsS3Export';
-const LOCK_TTL_MS_CAP = 30 * 60 * 1000; // hard cap; the export query is seconds, no reason to hold a lock for hours
-const lockTtlMs = Math.min(cronMinutes * 60 * 1000 * 0.8, LOCK_TTL_MS_CAP);
+// Cron fires hourly; lock should expire well before the next tick.
+const lockTtlMs = 30 * 60 * 1000;
 
 // Single S3 client reused across cron ticks — `new S3Client()` doesn't open any
 // connection eagerly so this is cheap at module load, and reusing the client lets
@@ -144,8 +145,8 @@ export const METRICS: MetricSpec[] = [
 ];
 
 export function billingEventsS3ExportCron(): void {
-    if (cronMinutes <= 0) {
-        logger.info(`Skipping (CRON_BILLING_EVENTS_S3_EXPORT_MINUTES=${cronMinutes})`);
+    if (cronMinute < 0) {
+        logger.info(`Skipping (CRON_BILLING_EVENTS_S3_HOURLY_EXPORT_MINUTE=${cronMinute})`);
         return;
     }
     if (!bucket || !roleArn) {
@@ -157,10 +158,8 @@ export function billingEventsS3ExportCron(): void {
         return;
     }
 
-    // Hourly cron with a configurable minute-of-the-hour offset
-    // (CRON_BILLING_EVENTS_S3_EXPORT_OFFSET_MINUTES — default 0). The MINUTES var
-    // stays the kill switch (0 = disabled, anything > 0 enables).
-    cron.schedule(`${cronOffsetMinutes} * * * *`, () => {
+    // Hourly cron at minute `cronMinute` of every hour.
+    cron.schedule(`${cronMinute} * * * *`, () => {
         exec().catch((err: unknown) => {
             logger.error('Cron tick failed unexpectedly', err);
         });

--- a/packages/metering/lib/crons/billingEventsS3Export.ts
+++ b/packages/metering/lib/crons/billingEventsS3Export.ts
@@ -12,6 +12,7 @@ import type { Lock } from '@nangohq/kvstore';
 
 const logger = getLogger('cron.billingEventsS3Export');
 const cronMinutes = envs.CRON_BILLING_EVENTS_S3_EXPORT_MINUTES;
+const cronOffsetMinutes = envs.CRON_BILLING_EVENTS_S3_EXPORT_OFFSET_MINUTES;
 const bucket = envs.BILLING_EVENTS_S3_BUCKET;
 const roleArn = envs.BILLING_EVENTS_S3_WRITER_ROLE_ARN;
 const region = envs.BILLING_EVENTS_S3_REGION;
@@ -156,7 +157,10 @@ export function billingEventsS3ExportCron(): void {
         return;
     }
 
-    cron.schedule(`*/${cronMinutes} * * * *`, () => {
+    // Hourly cron with a configurable minute-of-the-hour offset
+    // (CRON_BILLING_EVENTS_S3_EXPORT_OFFSET_MINUTES — default 0). The MINUTES var
+    // stays the kill switch (0 = disabled, anything > 0 enables).
+    cron.schedule(`${cronOffsetMinutes} * * * *`, () => {
         exec().catch((err: unknown) => {
             logger.error('Cron tick failed unexpectedly', err);
         });

--- a/packages/metering/lib/crons/billingEventsS3Export.ts
+++ b/packages/metering/lib/crons/billingEventsS3Export.ts
@@ -12,7 +12,6 @@ import type { Lock } from '@nangohq/kvstore';
 
 const logger = getLogger('cron.billingEventsS3Export');
 const cronMinutes = envs.CRON_BILLING_EVENTS_S3_EXPORT_MINUTES;
-const cronSchedule = envs.CRON_BILLING_EVENTS_S3_EXPORT_SCHEDULE;
 const bucket = envs.BILLING_EVENTS_S3_BUCKET;
 const roleArn = envs.BILLING_EVENTS_S3_WRITER_ROLE_ARN;
 const region = envs.BILLING_EVENTS_S3_REGION;
@@ -157,7 +156,7 @@ export function billingEventsS3ExportCron(): void {
         return;
     }
 
-    cron.schedule(cronSchedule, () => {
+    cron.schedule(`*/${cronMinutes} * * * *`, () => {
         exec().catch((err: unknown) => {
             logger.error('Cron tick failed unexpectedly', err);
         });

--- a/packages/metering/lib/crons/billingEventsS3Export.ts
+++ b/packages/metering/lib/crons/billingEventsS3Export.ts
@@ -12,6 +12,7 @@ import type { Lock } from '@nangohq/kvstore';
 
 const logger = getLogger('cron.billingEventsS3Export');
 const cronMinutes = envs.CRON_BILLING_EVENTS_S3_EXPORT_MINUTES;
+const cronSchedule = envs.CRON_BILLING_EVENTS_S3_EXPORT_SCHEDULE;
 const bucket = envs.BILLING_EVENTS_S3_BUCKET;
 const roleArn = envs.BILLING_EVENTS_S3_WRITER_ROLE_ARN;
 const region = envs.BILLING_EVENTS_S3_REGION;
@@ -21,11 +22,10 @@ const LOCK_KEY = 'lock:cron:billingEventsS3Export';
 const LOCK_TTL_MS_CAP = 30 * 60 * 1000; // hard cap; the export query is seconds, no reason to hold a lock for hours
 const lockTtlMs = Math.min(cronMinutes * 60 * 1000 * 0.8, LOCK_TTL_MS_CAP);
 
-// Fires every hour at :15 — the 15-min skew gives ClickHouse a buffer to ingest
-// late events from the previous UTC day before we snapshot it. Each (day, metric)
-// is uploaded exactly once (skip-if-exists below); later ticks on the same UTC
-// day no-op, providing only self-healing if the first attempt failed.
-const CRON_SCHEDULE = '15 * * * *';
+// Single S3 client reused across cron ticks — `new S3Client()` doesn't open any
+// connection eagerly so this is cheap at module load, and reusing the client lets
+// the SDK pool TCP connections across runs.
+const s3 = new S3Client({ region });
 
 const DEFAULT_DATABASE = 'usage';
 
@@ -157,7 +157,7 @@ export function billingEventsS3ExportCron(): void {
         return;
     }
 
-    cron.schedule(CRON_SCHEDULE, () => {
+    cron.schedule(cronSchedule, () => {
         exec().catch((err: unknown) => {
             logger.error('Cron tick failed unexpectedly', err);
         });
@@ -173,7 +173,6 @@ export async function exec(): Promise<void> {
                 logger.error(`Clickhouse client not configured`);
                 return;
             }
-            const s3 = new S3Client({ region });
             const day = yesterdayUTC();
             try {
                 for (const metric of METRICS) {
@@ -184,7 +183,7 @@ export async function exec(): Promise<void> {
                     // without us having to introspect the thrown error.
                     let step: 's3_check' | 'export' = 's3_check';
                     try {
-                        if (await objectExists(s3, key)) {
+                        if (await objectExists(key)) {
                             logger.info(`Skipping ${eventName} for day=${day} (already in s3://${bucket}/${key})`);
                             continue;
                         }
@@ -211,13 +210,12 @@ export async function exec(): Promise<void> {
                 logger.info(`✅ done`);
             } finally {
                 await client.close();
-                s3.destroy();
             }
         });
     });
 }
 
-async function objectExists(s3: S3Client, key: string): Promise<boolean> {
+async function objectExists(key: string): Promise<boolean> {
     try {
         await s3.send(new HeadObjectCommand({ Bucket: bucket, Key: key }));
         return true;

--- a/packages/metering/lib/crons/billingEventsS3Export.ts
+++ b/packages/metering/lib/crons/billingEventsS3Export.ts
@@ -1,3 +1,4 @@
+import { HeadObjectCommand, S3Client } from '@aws-sdk/client-s3';
 import tracer from 'dd-trace';
 import * as cron from 'node-cron';
 
@@ -13,11 +14,18 @@ const logger = getLogger('cron.billingEventsS3Export');
 const cronMinutes = envs.CRON_BILLING_EVENTS_S3_EXPORT_MINUTES;
 const bucket = envs.BILLING_EVENTS_S3_BUCKET;
 const roleArn = envs.BILLING_EVENTS_S3_WRITER_ROLE_ARN;
+const region = envs.BILLING_EVENTS_S3_REGION;
 const eventNameSuffix = envs.BILLING_EVENTS_S3_EVENT_NAME_SUFFIX ?? '';
 
 const LOCK_KEY = 'lock:cron:billingEventsS3Export';
 const LOCK_TTL_MS_CAP = 30 * 60 * 1000; // hard cap; the export query is seconds, no reason to hold a lock for hours
 const lockTtlMs = Math.min(cronMinutes * 60 * 1000 * 0.8, LOCK_TTL_MS_CAP);
+
+// Fires every hour at :15 — the 15-min skew gives ClickHouse a buffer to ingest
+// late events from the previous UTC day before we snapshot it. Each (day, metric)
+// is uploaded exactly once (skip-if-exists below); later ticks on the same UTC
+// day no-op, providing only self-healing if the first attempt failed.
+const CRON_SCHEDULE = '15 * * * *';
 
 const DEFAULT_DATABASE = 'usage';
 
@@ -149,7 +157,7 @@ export function billingEventsS3ExportCron(): void {
         return;
     }
 
-    cron.schedule(`*/${cronMinutes} * * * *`, () => {
+    cron.schedule(CRON_SCHEDULE, () => {
         exec().catch((err: unknown) => {
             logger.error('Cron tick failed unexpectedly', err);
         });
@@ -165,16 +173,20 @@ export async function exec(): Promise<void> {
                 logger.error(`Clickhouse client not configured`);
                 return;
             }
+            const s3 = new S3Client({ region });
             const day = yesterdayUTC();
-            const runTimestamp = nowCompactUTC();
             try {
                 for (const metric of METRICS) {
                     const eventName = `${metric.canonicalEventName}${eventNameSuffix}`;
-                    const sql = exportSql({ metric, day, runTimestamp, eventName });
-                    logger.info(`Exporting ${eventName} for day=${day}`);
+                    const key = objectKey({ day, eventName });
                     const start = process.hrtime.bigint();
                     try {
-                        await client.command({ query: sql });
+                        if (await objectExists(s3, key)) {
+                            logger.info(`Skipping ${eventName} for day=${day} (already in s3://${bucket}/${key})`);
+                            continue;
+                        }
+                        logger.info(`Exporting ${eventName} for day=${day}`);
+                        await client.command({ query: exportSql({ metric, day, eventName, key }) });
                         logger.info(`Exported ${eventName} for day=${day}`);
                         metrics.increment(metrics.Types.BILLING_USAGE_CLICKHOUSE_S3_EXPORT_RESULT, 1, { metric: metric.canonicalEventName, success: 'true' });
                     } catch (err) {
@@ -191,9 +203,23 @@ export async function exec(): Promise<void> {
                 logger.info(`✅ done`);
             } finally {
                 await client.close();
+                s3.destroy();
             }
         });
     });
+}
+
+async function objectExists(s3: S3Client, key: string): Promise<boolean> {
+    try {
+        await s3.send(new HeadObjectCommand({ Bucket: bucket, Key: key }));
+        return true;
+    } catch (err) {
+        const status = (err as { $metadata?: { httpStatusCode?: number }; name?: string }).$metadata?.httpStatusCode;
+        if (status === 404 || (err as Error).name === 'NotFound') {
+            return false;
+        }
+        throw err;
+    }
 }
 
 async function withLock(fn: () => Promise<void>): Promise<void> {
@@ -245,9 +271,13 @@ export function metricRowsSql({
     `;
 }
 
-function exportSql({ metric, day, runTimestamp, eventName }: { metric: MetricSpec; day: string; runTimestamp: string; eventName: string }): string {
+function objectKey({ day, eventName }: { day: string; eventName: string }): string {
     const dayCompact = day.replace(/-/g, '');
-    const url = `https://${bucket}.s3.amazonaws.com/${dayCompact}/${runTimestamp}_${eventName}.jsonl`;
+    return `${dayCompact}/${eventName}.jsonl`;
+}
+
+function exportSql({ metric, day, eventName, key }: { metric: MetricSpec; day: string; eventName: string; key: string }): string {
+    const url = `https://${bucket}.s3.amazonaws.com/${key}`;
 
     // Argument order matters: ClickHouse 25.8+ docs show s3(url, format, extra_credentials(...)).
     // Reversing the last two raises a syntax error.
@@ -265,11 +295,4 @@ function yesterdayUTC(): string {
     const d = new Date();
     d.setUTCDate(d.getUTCDate() - 1);
     return d.toISOString().slice(0, 10); // YYYY-MM-DD
-}
-
-function nowCompactUTC(): string {
-    return new Date()
-        .toISOString()
-        .replace(/[-:]/g, '')
-        .replace(/\.\d{3}Z$/, 'Z'); // YYYYMMDDTHHMMSSZ
 }

--- a/packages/metering/lib/crons/billingEventsS3Export.ts
+++ b/packages/metering/lib/crons/billingEventsS3Export.ts
@@ -182,7 +182,7 @@ export async function exec(): Promise<void> {
                     const start = process.hrtime.bigint();
                     // Tracks which step is in flight so a catch can tag the failure
                     // without us having to introspect the thrown error.
-                    let step: 'head' | 'export' = 'head';
+                    let step: 's3_check' | 'export' = 's3_check';
                     try {
                         if (await objectExists(s3, key)) {
                             logger.info(`Skipping ${eventName} for day=${day} (already in s3://${bucket}/${key})`);

--- a/packages/metering/lib/crons/billingEventsS3Export.ts
+++ b/packages/metering/lib/crons/billingEventsS3Export.ts
@@ -180,11 +180,15 @@ export async function exec(): Promise<void> {
                     const eventName = `${metric.canonicalEventName}${eventNameSuffix}`;
                     const key = objectKey({ day, eventName });
                     const start = process.hrtime.bigint();
+                    // Tracks which step is in flight so a catch can tag the failure
+                    // without us having to introspect the thrown error.
+                    let step: 'head' | 'export' = 'head';
                     try {
                         if (await objectExists(s3, key)) {
                             logger.info(`Skipping ${eventName} for day=${day} (already in s3://${bucket}/${key})`);
                             continue;
                         }
+                        step = 'export';
                         logger.info(`Exporting ${eventName} for day=${day}`);
                         await client.command({ query: exportSql({ metric, day, eventName, key }) });
                         logger.info(`Exported ${eventName} for day=${day}`);
@@ -192,8 +196,12 @@ export async function exec(): Promise<void> {
                     } catch (err) {
                         // Per-metric catch so a single failure (e.g. CH timeout on
                         // a heavy table) does not abort the rest of the run.
-                        logger.error(`Failed to export ${eventName} for day=${day}`, err);
-                        metrics.increment(metrics.Types.BILLING_USAGE_CLICKHOUSE_S3_EXPORT_RESULT, 1, { metric: metric.canonicalEventName, success: 'false' });
+                        logger.error(`Failed to export ${eventName} for day=${day} at step=${step}`, err);
+                        metrics.increment(metrics.Types.BILLING_USAGE_CLICKHOUSE_S3_EXPORT_RESULT, 1, {
+                            metric: metric.canonicalEventName,
+                            success: 'false',
+                            step
+                        });
                     } finally {
                         metrics.distribution(metrics.Types.BILLING_USAGE_CLICKHOUSE_S3_EXPORT_DURATION_MS, Number(process.hrtime.bigint() - start) / 1e6, {
                             metric: metric.canonicalEventName

--- a/packages/metering/package.json
+++ b/packages/metering/package.json
@@ -14,6 +14,7 @@
         "directory": "packages/metering"
     },
     "dependencies": {
+        "@aws-sdk/client-s3": "3.993.0",
         "@nangohq/usage": "file:../usage",
         "@nangohq/database": "file:../database",
         "@nangohq/billing": "file:../billing",

--- a/packages/utils/lib/environment/parse.ts
+++ b/packages/utils/lib/environment/parse.ts
@@ -285,6 +285,7 @@ export const ENVS = z.object({
     BILLING_EVENTS_S3_BUCKET: z.string().optional(),
     BILLING_EVENTS_S3_WRITER_ROLE_ARN: z.string().optional(),
     BILLING_EVENTS_S3_EVENT_NAME_SUFFIX: z.string().optional(),
+    BILLING_EVENTS_S3_REGION: z.string().optional().default('us-west-2'),
 
     // ClickHouse
     CLICKHOUSE_URL: z.string().optional(),

--- a/packages/utils/lib/environment/parse.ts
+++ b/packages/utils/lib/environment/parse.ts
@@ -82,6 +82,9 @@ export const ENVS = z.object({
     CRON_REFRESH_CONNECTIONS_LIMIT: z.coerce.number().optional().default(100),
     CRON_LAMBDA_KEEP_WARM_EVERY_MINUTES: z.coerce.number().optional().default(0),
     CRON_BILLING_EVENTS_S3_EXPORT_MINUTES: z.coerce.number().optional().default(0),
+    // Fires every hour at :15 by default — the 15-min skew gives ClickHouse a buffer
+    // to ingest late events from the previous UTC day before we snapshot it.
+    CRON_BILLING_EVENTS_S3_EXPORT_SCHEDULE: z.string().optional().default('15 * * * *'),
 
     // Persist
     PERSIST_SERVICE_URL: z.url().optional(),

--- a/packages/utils/lib/environment/parse.ts
+++ b/packages/utils/lib/environment/parse.ts
@@ -82,6 +82,10 @@ export const ENVS = z.object({
     CRON_REFRESH_CONNECTIONS_LIMIT: z.coerce.number().optional().default(100),
     CRON_LAMBDA_KEEP_WARM_EVERY_MINUTES: z.coerce.number().optional().default(0),
     CRON_BILLING_EVENTS_S3_EXPORT_MINUTES: z.coerce.number().optional().default(0),
+    // Minute-of-the-hour offset for the billing-events S3 export cron. Default 0
+    // fires at HH:00; set to 15 to give ClickHouse a ~15min buffer to ingest the
+    // tail end of the previous UTC day before we snapshot it.
+    CRON_BILLING_EVENTS_S3_EXPORT_OFFSET_MINUTES: z.coerce.number().min(0).max(59).optional().default(0),
 
     // Persist
     PERSIST_SERVICE_URL: z.url().optional(),

--- a/packages/utils/lib/environment/parse.ts
+++ b/packages/utils/lib/environment/parse.ts
@@ -82,9 +82,6 @@ export const ENVS = z.object({
     CRON_REFRESH_CONNECTIONS_LIMIT: z.coerce.number().optional().default(100),
     CRON_LAMBDA_KEEP_WARM_EVERY_MINUTES: z.coerce.number().optional().default(0),
     CRON_BILLING_EVENTS_S3_EXPORT_MINUTES: z.coerce.number().optional().default(0),
-    // Fires every hour at :15 by default — the 15-min skew gives ClickHouse a buffer
-    // to ingest late events from the previous UTC day before we snapshot it.
-    CRON_BILLING_EVENTS_S3_EXPORT_SCHEDULE: z.string().optional().default('15 * * * *'),
 
     // Persist
     PERSIST_SERVICE_URL: z.url().optional(),

--- a/packages/utils/lib/environment/parse.ts
+++ b/packages/utils/lib/environment/parse.ts
@@ -82,10 +82,10 @@ export const ENVS = z.object({
     CRON_REFRESH_CONNECTIONS_LIMIT: z.coerce.number().optional().default(100),
     CRON_LAMBDA_KEEP_WARM_EVERY_MINUTES: z.coerce.number().optional().default(0),
     CRON_BILLING_EVENTS_S3_EXPORT_MINUTES: z.coerce.number().optional().default(0),
-    // Minute-of-the-hour offset for the billing-events S3 export cron. Default 0
-    // fires at HH:00; set to 15 to give ClickHouse a ~15min buffer to ingest the
-    // tail end of the previous UTC day before we snapshot it.
-    CRON_BILLING_EVENTS_S3_EXPORT_OFFSET_MINUTES: z.coerce.number().min(0).max(59).optional().default(0),
+    // Minute-of-the-hour offset for the billing-events S3 export cron. Default 15
+    // gives ClickHouse a ~15min buffer to ingest the tail end of the previous UTC
+    // day before we snapshot it. Set to 0 to fire at HH:00 (no buffer).
+    CRON_BILLING_EVENTS_S3_EXPORT_OFFSET_MINUTES: z.coerce.number().min(0).max(59).optional().default(15),
 
     // Persist
     PERSIST_SERVICE_URL: z.url().optional(),

--- a/packages/utils/lib/environment/parse.ts
+++ b/packages/utils/lib/environment/parse.ts
@@ -81,11 +81,11 @@ export const ENVS = z.object({
     CRON_REFRESH_CONNECTIONS_EVERY_MIN: z.coerce.number().optional().default(10),
     CRON_REFRESH_CONNECTIONS_LIMIT: z.coerce.number().optional().default(100),
     CRON_LAMBDA_KEEP_WARM_EVERY_MINUTES: z.coerce.number().optional().default(0),
-    CRON_BILLING_EVENTS_S3_EXPORT_MINUTES: z.coerce.number().optional().default(0),
-    // Minute-of-the-hour offset for the billing-events S3 export cron. Default 15
-    // gives ClickHouse a ~15min buffer to ingest the tail end of the previous UTC
-    // day before we snapshot it. Set to 0 to fire at HH:00 (no buffer).
-    CRON_BILLING_EVENTS_S3_EXPORT_OFFSET_MINUTES: z.coerce.number().min(0).max(59).optional().default(15),
+    // Billing-events S3 export cron (hourly). Value is the minute-of-the-hour the
+    // cron fires on (0–59). -1 (default) disables the cron entirely. 15 gives
+    // ClickHouse a ~15min buffer to ingest the previous UTC day's tail before we
+    // snapshot it.
+    CRON_BILLING_EVENTS_S3_HOURLY_EXPORT_MINUTE: z.coerce.number().min(-1).max(59).optional().default(-1),
 
     // Persist
     PERSIST_SERVICE_URL: z.url().optional(),


### PR DESCRIPTION
## Changes

- S3 object key is now `{day-compact}/{eventName}.jsonl` (no `runTimestamp` prefix) — one canonical key per (day, metric). The hourly cron does an `S3 HeadObject` before `INSERT INTO FUNCTION s3` and skips if the file already exists, so each (day, metric) lands in S3 exactly once instead of 24× per day.
- Cron schedule moves from top-of-hour (`*/N * * * *`) to `15 * * * *` so the first run of each day has a ~15-min buffer for ClickHouse to ingest any late events from the previous UTC day before we snapshot it. Later ticks on the same UTC day are pure self-healing no-ops.

This one is taking care of the permissions https://github.com/NangoHQ/nango-infra/pull/132

## Trade-off worth noting

With deterministic + skip-if-exists, the **first run on day D+1 wins** — late ClickHouse events arriving after that first snapshot don't make it into Orb. In practice the day boundary plus the 15-min skew should cover ingest lag, but we lose the "accidental absorb" property the old re-upload-every-hour pattern had.

## Out of scope

- No `FORCE` env var or backfill runbook — manual `aws s3 rm` + wait-for-next-tick if we need to re-export a day.
- No metric on the skip path — only the actual upload outcome ticks `BILLING_USAGE_CLICKHOUSE_S3_EXPORT_RESULT`.

## Test plan

- [x] Type-check clean (`npm run ts-build`)
- [ ] After deploy: confirm exactly one `Exported …` log per (day, metric) on day D+1 at HH:15
- [ ] Confirm later ticks on the same UTC day produce `Skipping … (already in s3://…)` logs and no S3 writes
- [ ] Confirm S3 bucket size growth drops accordingly

Linear: https://linear.app/nango/issue/NAN-5315