### PR TITLE
Fix Jira webhook routing by site base URL

### DIFF
--- a/packages/server/lib/webhook/jira-webhook-routing.ts
+++ b/packages/server/lib/webhook/jira-webhook-routing.ts
@@ -14,33 +14,45 @@ const getOrigin = (url: string): string | null => {
     }
 };
 
+const MAX_SELF_LINK_SCAN_NODES = 1_000;
+
 const extractBaseUrlFromSelfLink = (value: unknown): string | null => {
-    if (Array.isArray(value)) {
-        for (const item of value) {
-            const baseUrl = extractBaseUrlFromSelfLink(item);
+    const stack: unknown[] = [value];
+    const seen = new Set<object>();
+    let scannedNodes = 0;
+
+    while (stack.length > 0 && scannedNodes < MAX_SELF_LINK_SCAN_NODES) {
+        const current = stack.pop();
+        scannedNodes += 1;
+
+        if (Array.isArray(current)) {
+            if (seen.has(current)) {
+                continue;
+            }
+
+            seen.add(current);
+            for (let index = current.length - 1; index >= 0; index--) {
+                stack.push(current[index]);
+            }
+
+            continue;
+        }
+
+        if (!isRecord(current) || seen.has(current)) {
+            continue;
+        }
+
+        seen.add(current);
+        if (typeof current['self'] === 'string') {
+            const baseUrl = getOrigin(current['self']);
             if (baseUrl) {
                 return baseUrl;
             }
         }
 
-        return null;
-    }
-
-    if (!isRecord(value)) {
-        return null;
-    }
-
-    if (typeof value['self'] === 'string') {
-        const baseUrl = getOrigin(value['self']);
-        if (baseUrl) {
-            return baseUrl;
-        }
-    }
-
-    for (const item of Object.values(value)) {
-        const baseUrl = extractBaseUrlFromSelfLink(item);
-        if (baseUrl) {
-            return baseUrl;
+        const values = Object.values(current);
+        for (let index = values.length - 1; index >= 0; index--) {
+            stack.push(values[index]);
         }
     }
 
@@ -52,11 +64,14 @@ const route: WebhookHandler = async (nango, _headers, body) => {
         let connectionIds: string[] = [];
         for (const event of body) {
             const baseUrl = extractBaseUrlFromSelfLink(event);
+            if (!baseUrl) {
+                continue;
+            }
 
             const response = await nango.executeScriptForWebhooks({
                 body: event,
                 webhookType: 'webhookEvent',
-                ...(baseUrl ? { connectionIdentifierValue: baseUrl } : {}),
+                connectionIdentifierValue: baseUrl,
                 propName: 'baseUrl'
             });
             if (response && response.connectionIds?.length > 0) {
@@ -71,11 +86,19 @@ const route: WebhookHandler = async (nango, _headers, body) => {
         });
     } else {
         const baseUrl = extractBaseUrlFromSelfLink(body);
+        if (!baseUrl) {
+            return Ok({
+                content: { status: 'success' },
+                statusCode: 200,
+                connectionIds: [],
+                toForward: body
+            });
+        }
 
         const response = await nango.executeScriptForWebhooks({
             body,
             webhookType: 'webhookEvent',
-            ...(baseUrl ? { connectionIdentifierValue: baseUrl } : {}),
+            connectionIdentifierValue: baseUrl,
             propName: 'baseUrl'
         });
         return Ok({

--- a/packages/server/lib/webhook/jira-webhook-routing.ts
+++ b/packages/server/lib/webhook/jira-webhook-routing.ts
@@ -1,4 +1,7 @@
-import { Ok } from '@nangohq/utils';
+import crypto from 'node:crypto';
+
+import { NangoError } from '@nangohq/shared';
+import { Err, Ok } from '@nangohq/utils';
 
 import type { WebhookHandler } from './types.js';
 
@@ -12,6 +15,34 @@ const getOrigin = (url: string): string | null => {
     } catch {
         return null;
     }
+};
+
+const getHeader = (
+    headers: Record<string, string>,
+    headerName: string
+): string | undefined => {
+    const lowerName = headerName.toLowerCase();
+    for (const [key, value] of Object.entries(headers)) {
+        if (key.toLowerCase() === lowerName) {
+            return value;
+        }
+    }
+    return undefined;
+};
+
+const validateJiraSignature = (
+    secret: string,
+    headerSignature: string,
+    rawBody: string
+): boolean => {
+    const expectedSignature = `sha256=${crypto.createHmac('sha256', secret).update(rawBody, 'utf8').digest('hex')}`;
+    const trusted = Buffer.from(expectedSignature, 'utf8');
+    const untrusted = Buffer.from(headerSignature, 'utf8');
+
+    return (
+        trusted.length === untrusted.length &&
+        crypto.timingSafeEqual(trusted, untrusted)
+    );
 };
 
 const MAX_SELF_LINK_SCAN_NODES = 1_000;
@@ -59,7 +90,19 @@ const extractBaseUrlFromSelfLink = (value: unknown): string | null => {
     return null;
 };
 
-const route: WebhookHandler = async (nango, _headers, body) => {
+const route: WebhookHandler = async (nango, headers, body, rawBody) => {
+    const webhookSecret = nango.integration.custom?.['webhookSecret'];
+    if (webhookSecret) {
+        const signature = getHeader(headers, 'x-hub-signature-256');
+        if (!signature) {
+            return Err(new NangoError('webhook_missing_signature'));
+        }
+
+        if (!validateJiraSignature(webhookSecret, signature, rawBody)) {
+            return Err(new NangoError('webhook_invalid_signature'));
+        }
+    }
+
     if (Array.isArray(body)) {
         let connectionIds: string[] = [];
         for (const event of body) {

--- a/packages/server/lib/webhook/jira-webhook-routing.ts
+++ b/packages/server/lib/webhook/jira-webhook-routing.ts
@@ -2,15 +2,62 @@ import { Ok } from '@nangohq/utils';
 
 import type { WebhookHandler } from './types.js';
 
+const isRecord = (value: unknown): value is Record<string, unknown> => {
+    return typeof value === 'object' && value !== null;
+};
+
+const getOrigin = (url: string): string | null => {
+    try {
+        return new URL(url).origin;
+    } catch {
+        return null;
+    }
+};
+
+const extractBaseUrlFromSelfLink = (value: unknown): string | null => {
+    if (Array.isArray(value)) {
+        for (const item of value) {
+            const baseUrl = extractBaseUrlFromSelfLink(item);
+            if (baseUrl) {
+                return baseUrl;
+            }
+        }
+
+        return null;
+    }
+
+    if (!isRecord(value)) {
+        return null;
+    }
+
+    if (typeof value['self'] === 'string') {
+        const baseUrl = getOrigin(value['self']);
+        if (baseUrl) {
+            return baseUrl;
+        }
+    }
+
+    for (const item of Object.values(value)) {
+        const baseUrl = extractBaseUrlFromSelfLink(item);
+        if (baseUrl) {
+            return baseUrl;
+        }
+    }
+
+    return null;
+};
+
 const route: WebhookHandler = async (nango, _headers, body) => {
     if (Array.isArray(body)) {
         let connectionIds: string[] = [];
         for (const event of body) {
+            const baseUrl = extractBaseUrlFromSelfLink(event);
+
             const response = await nango.executeScriptForWebhooks({
                 body: event,
-                webhookType: 'payload.webhookEvent',
-                connectionIdentifier: 'payload.user.accountId',
-                propName: 'accountId'
+                webhookType: 'webhookEvent',
+                ...(baseUrl ? { connectionIdentifierValue: baseUrl } : {}),
+                propName: 'baseUrl'
             });
             if (response && response.connectionIds?.length > 0) {
                 connectionIds = connectionIds.concat(response.connectionIds);
@@ -23,11 +70,13 @@ const route: WebhookHandler = async (nango, _headers, body) => {
             connectionIds
         });
     } else {
+        const baseUrl = extractBaseUrlFromSelfLink(body);
+
         const response = await nango.executeScriptForWebhooks({
             body,
-            webhookType: 'payload.webhookEvent',
-            connectionIdentifier: 'payload.user.accountId',
-            propName: 'accountId'
+            webhookType: 'webhookEvent',
+            ...(baseUrl ? { connectionIdentifierValue: baseUrl } : {}),
+            propName: 'baseUrl'
         });
         return Ok({
             content: { status: 'success' },

--- a/packages/server/lib/webhook/jira-webhook-routing.ts
+++ b/packages/server/lib/webhook/jira-webhook-routing.ts
@@ -93,7 +93,7 @@ const extractBaseUrlFromSelfLink = (value: unknown): string | null => {
 const route: WebhookHandler = async (nango, headers, body, rawBody) => {
     const webhookSecret = nango.integration.custom?.['webhookSecret'];
     if (webhookSecret) {
-        const signature = getHeader(headers, 'x-hub-signature-256');
+        const signature = getHeader(headers, 'x-hub-signature');
         if (!signature) {
             return Err(new NangoError('webhook_missing_signature'));
         }

--- a/packages/server/lib/webhook/jira-webhook-routing.unit.test.ts
+++ b/packages/server/lib/webhook/jira-webhook-routing.unit.test.ts
@@ -1,0 +1,99 @@
+import { describe, expect, it, vi } from 'vitest';
+
+import * as JiraWebhookRouting from './jira-webhook-routing.js';
+
+const makeNango = (mock = vi.fn().mockResolvedValue({ connectionIds: ['conn-1'] })) => {
+    return { executeScriptForWebhooks: mock };
+};
+
+describe('jira-webhook-routing', () => {
+    it('routes issue webhooks by Jira site baseUrl from issue.self', async () => {
+        const mock = vi.fn().mockResolvedValue({ connectionIds: ['conn-issue'] });
+        const nango = makeNango(mock);
+        const body = {
+            webhookEvent: 'jira:issue_updated',
+            issue: {
+                self: 'https://acme.atlassian.net/rest/api/2/issue/42766',
+                id: '42766'
+            },
+            user: {
+                accountId: 'actor-account-id'
+            }
+        };
+
+        const result = await JiraWebhookRouting.default(nango as any, {}, body, '');
+
+        expect(result.isOk()).toBe(true);
+        expect((result.unwrap() as { connectionIds: string[] }).connectionIds).toEqual(['conn-issue']);
+        expect(mock).toHaveBeenCalledWith({
+            body,
+            webhookType: 'webhookEvent',
+            connectionIdentifierValue: 'https://acme.atlassian.net',
+            propName: 'baseUrl'
+        });
+    });
+
+    it('routes comment webhooks by comment.self when the root user is absent', async () => {
+        const mock = vi.fn().mockResolvedValue({ connectionIds: ['conn-comment'] });
+        const nango = makeNango(mock);
+        const body = {
+            webhookEvent: 'comment_created',
+            comment: {
+                self: 'https://acme.atlassian.net/rest/api/2/issue/42766/comment/61142',
+                author: {
+                    accountId: 'comment-author-id'
+                }
+            }
+        };
+
+        const result = await JiraWebhookRouting.default(nango as any, {}, body, '');
+
+        expect(result.isOk()).toBe(true);
+        expect((result.unwrap() as { connectionIds: string[] }).connectionIds).toEqual(['conn-comment']);
+        expect(mock).toHaveBeenCalledWith({
+            body,
+            webhookType: 'webhookEvent',
+            connectionIdentifierValue: 'https://acme.atlassian.net',
+            propName: 'baseUrl'
+        });
+    });
+
+    it('routes batched Jira events independently and combines matched connection ids', async () => {
+        const mock = vi
+            .fn()
+            .mockResolvedValueOnce({ connectionIds: ['conn-a'] })
+            .mockResolvedValueOnce({ connectionIds: ['conn-b'] });
+        const nango = makeNango(mock);
+        const body = [
+            {
+                webhookEvent: 'jira:issue_created',
+                issue: {
+                    self: 'https://acme.atlassian.net/rest/api/2/issue/10001'
+                }
+            },
+            {
+                webhookEvent: 'comment_created',
+                comment: {
+                    self: 'https://globex.atlassian.net/rest/api/2/issue/10002/comment/10003'
+                }
+            }
+        ];
+
+        const result = await JiraWebhookRouting.default(nango as any, {}, body, '');
+
+        expect(result.isOk()).toBe(true);
+        expect((result.unwrap() as { connectionIds: string[] }).connectionIds).toEqual(['conn-a', 'conn-b']);
+        expect(mock).toHaveBeenNthCalledWith(1, {
+            body: body[0],
+            webhookType: 'webhookEvent',
+            connectionIdentifierValue: 'https://acme.atlassian.net',
+            propName: 'baseUrl'
+        });
+        expect(mock).toHaveBeenNthCalledWith(2, {
+            body: body[1],
+            webhookType: 'webhookEvent',
+            connectionIdentifierValue: 'https://globex.atlassian.net',
+            propName: 'baseUrl'
+        });
+    });
+});

--- a/packages/server/lib/webhook/jira-webhook-routing.unit.test.ts
+++ b/packages/server/lib/webhook/jira-webhook-routing.unit.test.ts
@@ -96,4 +96,74 @@ describe('jira-webhook-routing', () => {
             propName: 'baseUrl'
         });
     });
+
+    it('does not execute webhook scripts when a single event has no Jira baseUrl', async () => {
+        const mock = vi.fn();
+        const nango = makeNango(mock);
+        const body = {
+            webhookEvent: 'jira:issue_deleted',
+            issue: {
+                id: '42766'
+            }
+        };
+
+        const result = await JiraWebhookRouting.default(nango as any, {}, body, '');
+
+        expect(result.isOk()).toBe(true);
+        expect((result.unwrap() as { connectionIds: string[]; toForward: unknown }).connectionIds).toEqual([]);
+        expect((result.unwrap() as { connectionIds: string[]; toForward: unknown }).toForward).toBe(body);
+        expect(mock).not.toHaveBeenCalled();
+    });
+
+    it('skips unroutable events in a Jira batch without executing a broad fallback', async () => {
+        const mock = vi.fn().mockResolvedValue({ connectionIds: ['conn-routed'] });
+        const nango = makeNango(mock);
+        const body = [
+            {
+                webhookEvent: 'jira:issue_updated',
+                issue: {
+                    id: '10001'
+                }
+            },
+            {
+                webhookEvent: 'comment_created',
+                comment: {
+                    self: 'https://globex.atlassian.net/rest/api/2/issue/10002/comment/10003'
+                }
+            }
+        ];
+
+        const result = await JiraWebhookRouting.default(nango as any, {}, body, '');
+
+        expect(result.isOk()).toBe(true);
+        expect((result.unwrap() as { connectionIds: string[] }).connectionIds).toEqual(['conn-routed']);
+        expect(mock).toHaveBeenCalledTimes(1);
+        expect(mock).toHaveBeenCalledWith({
+            body: body[1],
+            webhookType: 'webhookEvent',
+            connectionIdentifierValue: 'https://globex.atlassian.net',
+            propName: 'baseUrl'
+        });
+    });
+
+    it('handles deeply nested Jira payloads without recursive stack overflow', async () => {
+        const mock = vi.fn();
+        const nango = makeNango(mock);
+        const body: Record<string, unknown> = {
+            webhookEvent: 'jira:issue_updated'
+        };
+        let cursor = body;
+
+        for (let index = 0; index < 5_000; index++) {
+            const child: Record<string, unknown> = {};
+            cursor['child'] = child;
+            cursor = child;
+        }
+
+        const result = await JiraWebhookRouting.default(nango as any, {}, body, '');
+
+        expect(result.isOk()).toBe(true);
+        expect((result.unwrap() as { connectionIds: string[] }).connectionIds).toEqual([]);
+        expect(mock).not.toHaveBeenCalled();
+    });
 });

--- a/packages/server/lib/webhook/jira-webhook-routing.unit.test.ts
+++ b/packages/server/lib/webhook/jira-webhook-routing.unit.test.ts
@@ -211,7 +211,7 @@ describe('jira-webhook-routing', () => {
 
         const result = await JiraWebhookRouting.default(
             nango as any,
-            { 'x-hub-signature-256': signJiraBody(rawBody, secret) },
+            { 'X-Hub-Signature': signJiraBody(rawBody, secret) },
             body,
             rawBody
         );

--- a/packages/server/lib/webhook/jira-webhook-routing.unit.test.ts
+++ b/packages/server/lib/webhook/jira-webhook-routing.unit.test.ts
@@ -1,9 +1,23 @@
+import crypto from 'node:crypto';
+
 import { describe, expect, it, vi } from 'vitest';
 
 import * as JiraWebhookRouting from './jira-webhook-routing.js';
 
-const makeNango = (mock = vi.fn().mockResolvedValue({ connectionIds: ['conn-1'] })) => {
-    return { executeScriptForWebhooks: mock };
+const makeNango = (
+    mock = vi.fn().mockResolvedValue({ connectionIds: ['conn-1'] }),
+    webhookSecret?: string
+) => {
+    return {
+        executeScriptForWebhooks: mock,
+        integration: {
+            custom: webhookSecret ? { webhookSecret } : {}
+        }
+    };
+};
+
+const signJiraBody = (body: string, secret: string): string => {
+    return `sha256=${crypto.createHmac('sha256', secret).update(body, 'utf8').digest('hex')}`;
 };
 
 describe('jira-webhook-routing', () => {
@@ -165,5 +179,50 @@ describe('jira-webhook-routing', () => {
         expect(result.isOk()).toBe(true);
         expect((result.unwrap() as { connectionIds: string[] }).connectionIds).toEqual([]);
         expect(mock).not.toHaveBeenCalled();
+    });
+
+    it('rejects unsigned Jira webhooks when a webhook secret is configured', async () => {
+        const mock = vi.fn();
+        const nango = makeNango(mock, 'jira-secret');
+        const body = {
+            webhookEvent: 'jira:issue_updated',
+            issue: {
+                self: 'https://acme.atlassian.net/rest/api/2/issue/42766'
+            }
+        };
+
+        const result = await JiraWebhookRouting.default(nango as any, {}, body, JSON.stringify(body));
+
+        expect(result.isErr()).toBe(true);
+        expect(mock).not.toHaveBeenCalled();
+    });
+
+    it('routes signed Jira webhooks when the configured secret matches', async () => {
+        const mock = vi.fn().mockResolvedValue({ connectionIds: ['conn-signed'] });
+        const secret = 'jira-secret';
+        const nango = makeNango(mock, secret);
+        const body = {
+            webhookEvent: 'jira:issue_updated',
+            issue: {
+                self: 'https://acme.atlassian.net/rest/api/2/issue/42766'
+            }
+        };
+        const rawBody = JSON.stringify(body);
+
+        const result = await JiraWebhookRouting.default(
+            nango as any,
+            { 'x-hub-signature-256': signJiraBody(rawBody, secret) },
+            body,
+            rawBody
+        );
+
+        expect(result.isOk()).toBe(true);
+        expect((result.unwrap() as { connectionIds: string[] }).connectionIds).toEqual(['conn-signed']);
+        expect(mock).toHaveBeenCalledWith({
+            body,
+            webhookType: 'webhookEvent',
+            connectionIdentifierValue: 'https://acme.atlassian.net',
+            propName: 'baseUrl'
+        });
     });
 });


### PR DESCRIPTION
## Summary
- route Jira webhooks by the Jira site `baseUrl` extracted from resource `self` links instead of actor `accountId`
- use the root `webhookEvent` field when dispatching Jira webhook scripts
- add unit coverage for issue events, comment events without root `user`, and batched Jira webhook payloads

## Why
Jira post-connection already stores the workspace/site-level `baseUrl` in `connection_config`. Routing webhooks by the individual actor's `accountId` misses common cases: comment events may not have a root `user`, sprint/board events are not consistently actor-shaped, and events performed by another Jira user should still route to the connected workspace.

This follows the same workspace-level matching pattern used by other integrations such as Slack team IDs, HubSpot portal IDs, Shopify subdomains, and GitHub App installation IDs.

Fixes #5682.

## Tests
- npm run ts-build
- npx vitest run packages/server/lib/webhook/jira-webhook-routing.unit.test.ts
- npx prettier --check packages/server/lib/webhook/jira-webhook-routing.ts packages/server/lib/webhook/jira-webhook-routing.unit.test.ts
