### PR TITLE
fix(eslint): eliminate IDE false positives in browser packages

### DIFF
--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -9,6 +9,101 @@ import unicorn from 'eslint-plugin-unicorn';
 import globals from 'globals';
 import * as tseslint from 'typescript-eslint';
 
+// Shared typescript-eslint preset extends and custom rule overrides.
+//
+// We use these in both the root `**/*.{ts,tsx}` block (with the root tsconfig)
+// AND in each browser-package block (webapp / frontend / connect-ui) that has
+// its own incompatible tsconfig.  Keeping them in one place ensures the rules
+// are identical regardless of which block applies to a file.
+//
+// Background: IDEs (e.g. VS Code ESLint extension) create a separate TypeScript
+// program for every unique `parserOptions.project` value they see in matching
+// config blocks.  If a file matches both the root block (project: './tsconfig.json')
+// and a package block (project: 'packages/webapp/tsconfig.json'), the IDE runs
+// type-aware rules from the root block with the root tsconfig — which has no
+// DOM/React lib, so every React hook import degrades to `error` type and fires
+// spurious `no-unnecessary-type-assertion` / unsafe-* violations.
+//
+// The fix: exclude browser-package source trees from the root block (via
+// `ignores`) so only one TypeScript program is created for those files, and
+// replicate the shared typescript-eslint setup directly in each package block.
+const tseslintExtends = [
+    tseslint.configs.recommended,
+    tseslint.configs.recommendedTypeChecked,
+    tseslint.configs.strict,
+    tseslint.configs.stylistic,
+    tseslint.configs.strictTypeChecked
+];
+
+const tseslintRules = {
+    'no-unused-vars': 'off',
+    '@typescript-eslint/no-inferrable-types': 'off',
+    '@typescript-eslint/require-await': 'error',
+
+    '@typescript-eslint/restrict-template-expressions': [
+        'error',
+        {
+            allowNumber: true,
+            allowBoolean: true,
+            allowNever: true
+        }
+    ],
+
+    '@typescript-eslint/await-thenable': 'error',
+    '@typescript-eslint/no-invalid-void-type': 'warn',
+    '@typescript-eslint/no-base-to-string': 'error',
+    '@typescript-eslint/restrict-plus-operands': 'warn',
+    '@typescript-eslint/consistent-type-exports': 'error',
+    '@typescript-eslint/no-unnecessary-condition': 'off',
+    '@typescript-eslint/only-throw-error': 'error',
+
+    '@typescript-eslint/no-unused-vars': [
+        'error',
+        {
+            args: 'all',
+            argsIgnorePattern: '^_',
+            caughtErrors: 'all',
+            caughtErrorsIgnorePattern: '^_',
+            destructuredArrayIgnorePattern: '^_',
+            varsIgnorePattern: '^_',
+            ignoreRestSiblings: true
+        }
+    ],
+
+    '@typescript-eslint/consistent-type-imports': [
+        'error',
+        {
+            prefer: 'type-imports',
+            fixStyle: 'separate-type-imports'
+        }
+    ],
+
+    '@typescript-eslint/no-confusing-void-expression': [
+        'warn',
+        {
+            ignoreVoidOperator: true,
+            ignoreArrowShorthand: true
+        }
+    ],
+
+    // To re-enable as error progressively
+    '@typescript-eslint/no-floating-promises': 'warn',
+    '@typescript-eslint/no-unsafe-assignment': 'warn',
+    '@typescript-eslint/no-non-null-assertion': 'warn',
+    '@typescript-eslint/no-explicit-any': 'warn',
+    '@typescript-eslint/no-unsafe-member-access': 'warn',
+    '@typescript-eslint/no-unsafe-call': 'warn',
+    '@typescript-eslint/no-unsafe-argument': 'warn',
+    '@typescript-eslint/no-misused-promises': 'warn',
+    '@typescript-eslint/no-unsafe-return': 'warn',
+    '@typescript-eslint/no-empty-function': 'warn',
+    '@typescript-eslint/no-unsafe-enum-comparison': 'warn',
+    '@typescript-eslint/no-unnecessary-type-parameters': 'off',
+
+    // Off for good reason
+    '@typescript-eslint/no-deprecated': 'off' // takes 33% of the whole linting time
+};
+
 export default tseslint.config(
     {
         ignores: [
@@ -113,17 +208,18 @@ export default tseslint.config(
         }
     },
     {
+        // Root typescript-eslint block — covers every TypeScript file that does NOT
+        // have its own package-specific block below (server, jobs, cli, shared libs…).
+        // Browser packages (webapp, frontend, connect-ui) are excluded because they
+        // use incompatible tsconfigs (DOM lib, different module mode) and each has its
+        // own block that sets up the same rules via the shared `tseslintExtends` /
+        // `tseslintRules` variables above.
         files: ['**/*.{ts,tsx}'],
+        ignores: ['packages/webapp/src/**', 'packages/frontend/**', 'packages/connect-ui/src/**'],
         plugins: {
             '@typescript-eslint': tseslint.plugin
         },
-        extends: [
-            tseslint.configs.recommended,
-            tseslint.configs.recommendedTypeChecked,
-            tseslint.configs.strict,
-            tseslint.configs.stylistic,
-            tseslint.configs.strictTypeChecked
-        ],
+        extends: tseslintExtends,
 
         languageOptions: {
             parser: tsParser,
@@ -140,74 +236,7 @@ export default tseslint.config(
             }
         },
 
-        rules: {
-            'no-unused-vars': 'off',
-            '@typescript-eslint/no-inferrable-types': 'off',
-            '@typescript-eslint/require-await': 'error',
-
-            '@typescript-eslint/restrict-template-expressions': [
-                'error',
-                {
-                    allowNumber: true,
-                    allowBoolean: true,
-                    allowNever: true
-                }
-            ],
-
-            '@typescript-eslint/await-thenable': 'error',
-            '@typescript-eslint/no-invalid-void-type': 'warn',
-            '@typescript-eslint/no-base-to-string': 'error',
-            '@typescript-eslint/restrict-plus-operands': 'warn',
-            '@typescript-eslint/consistent-type-exports': 'error',
-            '@typescript-eslint/no-unnecessary-condition': 'off',
-            '@typescript-eslint/only-throw-error': 'error',
-
-            '@typescript-eslint/no-unused-vars': [
-                'error',
-                {
-                    args: 'all',
-                    argsIgnorePattern: '^_',
-                    caughtErrors: 'all',
-                    caughtErrorsIgnorePattern: '^_',
-                    destructuredArrayIgnorePattern: '^_',
-                    varsIgnorePattern: '^_',
-                    ignoreRestSiblings: true
-                }
-            ],
-
-            '@typescript-eslint/consistent-type-imports': [
-                'error',
-                {
-                    prefer: 'type-imports',
-                    fixStyle: 'separate-type-imports'
-                }
-            ],
-
-            '@typescript-eslint/no-confusing-void-expression': [
-                'warn',
-                {
-                    ignoreVoidOperator: true,
-                    ignoreArrowShorthand: true
-                }
-            ],
-
-            // To re-enable as error progressively
-            '@typescript-eslint/no-floating-promises': 'warn',
-            '@typescript-eslint/no-unsafe-assignment': 'warn',
-            '@typescript-eslint/no-non-null-assertion': 'warn',
-            '@typescript-eslint/no-explicit-any': 'warn',
-            '@typescript-eslint/no-unsafe-member-access': 'warn',
-            '@typescript-eslint/no-unsafe-call': 'warn',
-            '@typescript-eslint/no-unsafe-argument': 'warn',
-            '@typescript-eslint/no-misused-promises': 'warn',
-            '@typescript-eslint/no-unsafe-return': 'warn',
-            '@typescript-eslint/no-empty-function': 'warn',
-            '@typescript-eslint/no-unsafe-enum-comparison': 'warn',
-            '@typescript-eslint/no-unnecessary-type-parameters': 'off',
-
-            // Off for good reason
-            '@typescript-eslint/no-deprecated': 'off' // takes 33% of the whole linting time
-        }
+        rules: tseslintRules
     },
     {
         files: ['integration-templates/**/*.ts'],
@@ -225,6 +254,10 @@ export default tseslint.config(
     },
     {
         files: ['packages/frontend/**/*.ts'],
+        plugins: {
+            '@typescript-eslint': tseslint.plugin
+        },
+        extends: tseslintExtends,
         languageOptions: {
             globals: {
                 ...globals.browser,
@@ -244,6 +277,7 @@ export default tseslint.config(
             }
         },
         rules: {
+            ...tseslintRules,
             'no-console': 'off',
 
             '@typescript-eslint/no-misused-promises': [
@@ -269,9 +303,11 @@ export default tseslint.config(
     {
         files: ['packages/webapp/src/**/*.{tsx,ts}'],
         plugins: {
+            '@typescript-eslint': tseslint.plugin,
             react: react,
             'react-hooks': reactHooks
         },
+        extends: tseslintExtends,
         settings: {
             react: {
                 version: 'detect'
@@ -298,6 +334,7 @@ export default tseslint.config(
         },
 
         rules: {
+            ...tseslintRules,
             ...react.configs.flat.recommended.rules,
             ...react.configs.flat['jsx-runtime'].rules,
             ...reactHooks.configs.recommended.rules,
@@ -324,9 +361,11 @@ export default tseslint.config(
         files: ['packages/connect-ui/src/**/*.{tsx,ts}'],
 
         plugins: {
+            '@typescript-eslint': tseslint.plugin,
             react: react,
             'react-hooks': reactHooks
         },
+        extends: tseslintExtends,
 
         settings: {
             react: {
@@ -355,6 +394,7 @@ export default tseslint.config(
         },
 
         rules: {
+            ...tseslintRules,
             ...react.configs.flat.recommended.rules,
             ...react.configs.flat['jsx-runtime'].rules,
             ...reactHooks.configs.recommended.rules,

--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -9,24 +9,8 @@ import unicorn from 'eslint-plugin-unicorn';
 import globals from 'globals';
 import * as tseslint from 'typescript-eslint';
 
-// Shared typescript-eslint preset extends and custom rule overrides.
-//
-// We use these in both the root `**/*.{ts,tsx}` block (with the root tsconfig)
-// AND in each browser-package block (webapp / frontend / connect-ui) that has
-// its own incompatible tsconfig.  Keeping them in one place ensures the rules
-// are identical regardless of which block applies to a file.
-//
-// Background: IDEs (e.g. VS Code ESLint extension) create a separate TypeScript
-// program for every unique `parserOptions.project` value they see in matching
-// config blocks.  If a file matches both the root block (project: './tsconfig.json')
-// and a package block (project: 'packages/webapp/tsconfig.json'), the IDE runs
-// type-aware rules from the root block with the root tsconfig — which has no
-// DOM/React lib, so every React hook import degrades to `error` type and fires
-// spurious `no-unnecessary-type-assertion` / unsafe-* violations.
-//
-// The fix: exclude browser-package source trees from the root block (via
-// `ignores`) so only one TypeScript program is created for those files, and
-// replicate the shared typescript-eslint setup directly in each package block.
+// Shared presets and rule overrides used by both the root block and each
+// browser-package block (webapp / frontend / connect-ui) that has its own tsconfig.
 const tseslintExtends = [
     tseslint.configs.recommended,
     tseslint.configs.recommendedTypeChecked,
@@ -208,12 +192,7 @@ export default tseslint.config(
         }
     },
     {
-        // Root typescript-eslint block — covers every TypeScript file that does NOT
-        // have its own package-specific block below (server, jobs, cli, shared libs…).
-        // Browser packages (webapp, frontend, connect-ui) are excluded because they
-        // use incompatible tsconfigs (DOM lib, different module mode) and each has its
-        // own block that sets up the same rules via the shared `tseslintExtends` /
-        // `tseslintRules` variables above.
+        // Browser packages are excluded — each has its own block with its tsconfig.
         files: ['**/*.{ts,tsx}'],
         ignores: ['packages/webapp/src/**', 'packages/frontend/**', 'packages/connect-ui/src/**'],
         plugins: {


### PR DESCRIPTION
## Problem

Type-aware ESLint rules fire hundreds of false-positive errors in the IDE for `packages/webapp`, `packages/frontend`, and `packages/connect-ui` — but the same files pass lint cleanly in CI.

The root cause: the VS Code ESLint extension creates a **separate TypeScript program per unique `parserOptions.project`** value it finds in matching config blocks. These browser-package files match both the root `**/*.{ts,tsx}` block (`project: './tsconfig.json'`) and their own package block (`project: 'packages/webapp/tsconfig.json'`). The root tsconfig has no DOM or React lib, so the IDE type-checks React code against it, every hook import degrades to an `error` type, and rules like `no-unnecessary-type-assertion` fire as false positives.

The CLI doesn't have this problem because flat config merges all matching blocks into one before parsing — so only the last `parserOptions.project` wins and the correct tsconfig is used.

## Solution

Extracted the shared typescript-eslint presets and rule overrides into module-level variables (`tseslintExtends`, `tseslintRules`), then:

- Added `ignores` to the root `**/*.{ts,tsx}` block for the three browser packages — the IDE now creates only one TypeScript program (the package-specific one) for those files
- Added `@typescript-eslint` plugin + `extends: tseslintExtends` + `rules: { ...tseslintRules }` directly to each browser-package block so they get the full rule set evaluated against their own tsconfig

No rules were added or removed. CI lint output is unchanged.

Fixes [NAN-5733](https://linear.app/nango/issue/NAN-5733)

## Testing

- `eslint packages/webapp/src/pages/Connection/CreateLegacy.tsx` — same 8 warnings as before, no false positives
- `eslint packages/connect-ui/src/App.tsx` + `packages/frontend/lib/index.ts` — no regressions
