### PR TITLE
feat(design-system): extend token pipeline with @theme utilities

### DIFF
--- a/packages/design-system/scripts/tokens-fetch.mjs
+++ b/packages/design-system/scripts/tokens-fetch.mjs
@@ -157,9 +157,61 @@ export function buildPrimitivesBlock(tokens) {
 }
 
 export function buildTailwindThemeBlock(tokens) {
-    // Only semantic color tokens → Tailwind utility classes (bg-*, text-*, border-*, etc.)
-    const vars = tokens.filter((t) => t['$type'] === 'color').map((t) => `  --color-${t.name}: var(--${t.name});`);
-    return `@theme {\n${vars.join('\n')}\n}`;
+    // Semantic color tokens → --color-* → bg-*, text-*, border-*, fill-*, etc.
+    const colorVars = tokens.filter((t) => t['$type'] === 'color').map((t) => `  --color-${t.name}: var(--${t.name});`);
+
+    // Semantic boxShadow tokens → --shadow-* → shadow-*
+    // Covers --focus-outline-default / --focus-outline-danger so components can write
+    // `shadow-focus-outline-default` instead of `shadow-[var(--focus-outline-default)]`.
+    const shadowVars = tokens.filter((t) => t['$type'] === 'boxShadow').map((t) => `  --shadow-${t.name}: var(--${t.name});`);
+
+    return `@theme {\n${[...colorVars, ...shadowVars].join('\n')}\n}`;
+}
+
+/**
+ * Maps primitive dimension/typography tokens into Tailwind @theme namespaces so they
+ * can be used as plain utilities instead of arbitrary `[var(--ds-*)]` values.
+ *
+ * Mappings (all prefixed with `ds-` to avoid overriding Tailwind built-ins):
+ *   --ds-radius-*               → --radius-ds-*        → rounded-ds-xs, rounded-ds-sm …
+ *   --ds-border-width-*         → --border-width-ds-*  → border-ds-hairline, border-ds-1 …
+ *   --ds-typography-font-size-* → --text-ds-*          → text-ds-xs, text-ds-md …
+ *   --ds-typography-font-weight-* → --font-weight-ds-* → font-ds-regular, font-ds-medium …
+ *   --ds-typography-letter-spacing-* → --tracking-ds-* → tracking-ds-tight …
+ *
+ * Spacing (--ds-space-*) is intentionally omitted: Tailwind's default 4px spacing scale
+ * already matches the ds-space tokens, so `gap-2` === `--ds-space-2` without any additions.
+ */
+export function buildPrimitivesThemeBlock(tokens) {
+    const entries = [];
+
+    for (const t of tokens) {
+        const name = t.name; // kebab name produced by the name/kebab transform
+        const ref = `var(--ds-${name})`;
+
+        if (name.startsWith('radius-')) {
+            const suffix = name.slice('radius-'.length);
+            entries.push(`  --radius-ds-${suffix}: ${ref};`);
+        } else if (name.startsWith('border-width-')) {
+            const suffix = name.slice('border-width-'.length);
+            entries.push(`  --border-width-ds-${suffix}: ${ref};`);
+        } else if (name.startsWith('typography-font-size-')) {
+            const suffix = name.slice('typography-font-size-'.length);
+            entries.push(`  --text-ds-${suffix}: ${ref};`);
+        } else if (name.startsWith('typography-font-weight-')) {
+            const suffix = name.slice('typography-font-weight-'.length);
+            entries.push(`  --font-weight-ds-${suffix}: ${ref};`);
+        } else if (name.startsWith('typography-line-height-')) {
+            const suffix = name.slice('typography-line-height-'.length);
+            entries.push(`  --leading-ds-${suffix}: ${ref};`);
+        } else if (name.startsWith('typography-letter-spacing-')) {
+            const suffix = name.slice('typography-letter-spacing-'.length);
+            entries.push(`  --tracking-ds-${suffix}: ${ref};`);
+        }
+    }
+
+    if (entries.length === 0) return '';
+    return `@theme {\n${entries.join('\n')}\n}`;
 }
 
 // ─── Typography class builder ──────────────────────────────────────────────────
@@ -298,11 +350,18 @@ export async function buildCss(tokensData) {
         buildCssBlock(darkTokens, '[data-theme="dark"]'),
         '',
         '/*',
-        ' * Tailwind v4 @theme registration.',
-        ' * Maps semantic color vars to --color-* so Tailwind generates',
-        ' * utility classes: bg-surface-canvas, text-text-strong, border-border-default, etc.',
+        ' * Tailwind v4 @theme registration — semantic tokens.',
+        ' * Colors → --color-* (bg-*, text-*, border-*, etc.)',
+        ' * Box shadows → --shadow-* (shadow-focus-outline-default, etc.)',
         ' */',
         buildTailwindThemeBlock(lightTokens),
+        '',
+        '/*',
+        ' * Tailwind v4 @theme registration — primitive tokens.',
+        ' * Radius → rounded-ds-*, border-width → border-ds-*,',
+        ' * font-size → text-ds-*, font-weight → font-ds-*, letter-spacing → tracking-ds-*',
+        ' */',
+        buildPrimitivesThemeBlock(primTokens),
         typographySection,
         ''
     ].join('\n');

--- a/packages/design-system/scripts/tokens-fetch.mjs
+++ b/packages/design-system/scripts/tokens-fetch.mjs
@@ -186,12 +186,12 @@ export function buildTailwindThemeBlock(tokens) {
 // Each entry drives both the CSS variable name and the completeness guard.
 // To add a new token group, add one row here — no other changes needed.
 const PRIM_MAPPINGS = [
-    { prefix: 'radius-',                    cssVar: 'radius-ds-'       },
-    { prefix: 'border-width-',              cssVar: 'border-width-ds-' },
-    { prefix: 'typography-font-size-',      cssVar: 'text-ds-'         },
-    { prefix: 'typography-font-weight-',    cssVar: 'font-weight-ds-'  },
-    { prefix: 'typography-line-height-',    cssVar: 'leading-ds-'      },
-    { prefix: 'typography-letter-spacing-', cssVar: 'tracking-ds-'     },
+    { prefix: 'radius-', cssVar: 'radius-ds-' },
+    { prefix: 'border-width-', cssVar: 'border-width-ds-' },
+    { prefix: 'typography-font-size-', cssVar: 'text-ds-' },
+    { prefix: 'typography-font-weight-', cssVar: 'font-weight-ds-' },
+    { prefix: 'typography-line-height-', cssVar: 'leading-ds-' },
+    { prefix: 'typography-letter-spacing-', cssVar: 'tracking-ds-' }
 ];
 
 /**

--- a/packages/design-system/scripts/tokens-fetch.mjs
+++ b/packages/design-system/scripts/tokens-fetch.mjs
@@ -184,6 +184,8 @@ export function buildTailwindThemeBlock(tokens) {
 
 // Token name prefixes that must each produce at least one entry.
 // If a prefix yields zero matches the build throws — catches renames/deletions early.
+// IMPORTANT: keep this list in sync with the if/else chain in buildPrimitivesThemeBlock below.
+// Adding a new token group requires updating both places.
 const EXPECTED_PRIM_PREFIXES = [
     'radius-',
     'border-width-',

--- a/packages/design-system/scripts/tokens-fetch.mjs
+++ b/packages/design-system/scripts/tokens-fetch.mjs
@@ -182,17 +182,16 @@ export function buildTailwindThemeBlock(tokens) {
     return colorBlock + shadowBlock;
 }
 
-// Token name prefixes that must each produce at least one entry.
-// If a prefix yields zero matches the build throws — catches renames/deletions early.
-// IMPORTANT: keep this list in sync with the if/else chain in buildPrimitivesThemeBlock below.
-// Adding a new token group requires updating both places.
-const EXPECTED_PRIM_PREFIXES = [
-    'radius-',
-    'border-width-',
-    'typography-font-size-',
-    'typography-font-weight-',
-    'typography-line-height-',
-    'typography-letter-spacing-'
+// Single source of truth for primitive token mappings.
+// Each entry drives both the CSS variable name and the completeness guard.
+// To add a new token group, add one row here — no other changes needed.
+const PRIM_MAPPINGS = [
+    { prefix: 'radius-',                    cssVar: 'radius-ds-'       },
+    { prefix: 'border-width-',              cssVar: 'border-width-ds-' },
+    { prefix: 'typography-font-size-',      cssVar: 'text-ds-'         },
+    { prefix: 'typography-font-weight-',    cssVar: 'font-weight-ds-'  },
+    { prefix: 'typography-line-height-',    cssVar: 'leading-ds-'      },
+    { prefix: 'typography-letter-spacing-', cssVar: 'tracking-ds-'     },
 ];
 
 /**
@@ -219,29 +218,16 @@ export function buildPrimitivesThemeBlock(tokens) {
     for (const t of tokens) {
         const name = t.name; // kebab name produced by the name/kebab transform
         const ref = `var(--ds-${name})`;
-
-        if (name.startsWith('radius-')) {
-            matched.add('radius-');
-            entries.push(`  --radius-ds-${name.slice('radius-'.length)}: ${ref};`);
-        } else if (name.startsWith('border-width-')) {
-            matched.add('border-width-');
-            entries.push(`  --border-width-ds-${name.slice('border-width-'.length)}: ${ref};`);
-        } else if (name.startsWith('typography-font-size-')) {
-            matched.add('typography-font-size-');
-            entries.push(`  --text-ds-${name.slice('typography-font-size-'.length)}: ${ref};`);
-        } else if (name.startsWith('typography-font-weight-')) {
-            matched.add('typography-font-weight-');
-            entries.push(`  --font-weight-ds-${name.slice('typography-font-weight-'.length)}: ${ref};`);
-        } else if (name.startsWith('typography-line-height-')) {
-            matched.add('typography-line-height-');
-            entries.push(`  --leading-ds-${name.slice('typography-line-height-'.length)}: ${ref};`);
-        } else if (name.startsWith('typography-letter-spacing-')) {
-            matched.add('typography-letter-spacing-');
-            entries.push(`  --tracking-ds-${name.slice('typography-letter-spacing-'.length)}: ${ref};`);
+        for (const { prefix, cssVar } of PRIM_MAPPINGS) {
+            if (name.startsWith(prefix)) {
+                matched.add(prefix);
+                entries.push(`  --${cssVar}${name.slice(prefix.length)}: ${ref};`);
+                break;
+            }
         }
     }
 
-    for (const prefix of EXPECTED_PRIM_PREFIXES) {
+    for (const { prefix } of PRIM_MAPPINGS) {
         if (!matched.has(prefix)) {
             throw new Error(`buildPrimitivesThemeBlock: no tokens matched prefix '${prefix}' — was a token group renamed or deleted?`);
         }

--- a/packages/design-system/scripts/tokens-fetch.mjs
+++ b/packages/design-system/scripts/tokens-fetch.mjs
@@ -163,13 +163,20 @@ export function buildTailwindThemeBlock(tokens) {
     // Semantic boxShadow tokens → --shadow-* → shadow-*
     // Covers --focus-outline-default / --focus-outline-danger so components can write
     // `shadow-focus-outline-default` instead of `shadow-[var(--focus-outline-default)]`.
+    //
+    // @theme inline is used so the generated utility references the semantic variable
+    // directly (e.g. `var(--focus-outline-default)`) rather than going through an
+    // intermediate `--shadow-*` CSS property. This ensures dark-theme overrides on the
+    // underlying semantic vars are always picked up.
     const shadowVars = tokens.filter((t) => t['$type'] === 'boxShadow').map((t) => `  --shadow-${t.name}: var(--${t.name});`);
 
     if (tokens.length > 0 && colorVars.length === 0) {
         throw new Error(`buildTailwindThemeBlock: no color tokens found — was the $type renamed or the semantic token set emptied?`);
     }
 
-    return `@theme {\n${[...colorVars, ...shadowVars].join('\n')}\n}`;
+    const colorBlock = `@theme {\n${colorVars.join('\n')}\n}`;
+    const shadowBlock = shadowVars.length > 0 ? `\n@theme inline {\n${shadowVars.join('\n')}\n}` : '';
+    return colorBlock + shadowBlock;
 }
 
 // Token name prefixes that must each produce at least one entry.

--- a/packages/design-system/scripts/tokens-fetch.mjs
+++ b/packages/design-system/scripts/tokens-fetch.mjs
@@ -180,7 +180,7 @@ const EXPECTED_PRIM_PREFIXES = [
     'typography-font-size-',
     'typography-font-weight-',
     'typography-line-height-',
-    'typography-letter-spacing-',
+    'typography-letter-spacing-'
 ];
 
 /**

--- a/packages/design-system/scripts/tokens-fetch.mjs
+++ b/packages/design-system/scripts/tokens-fetch.mjs
@@ -165,52 +165,76 @@ export function buildTailwindThemeBlock(tokens) {
     // `shadow-focus-outline-default` instead of `shadow-[var(--focus-outline-default)]`.
     const shadowVars = tokens.filter((t) => t['$type'] === 'boxShadow').map((t) => `  --shadow-${t.name}: var(--${t.name});`);
 
+    if (tokens.length > 0 && colorVars.length === 0) {
+        throw new Error(`buildTailwindThemeBlock: no color tokens found — was the $type renamed or the semantic token set emptied?`);
+    }
+
     return `@theme {\n${[...colorVars, ...shadowVars].join('\n')}\n}`;
 }
+
+// Token name prefixes that must each produce at least one entry.
+// If a prefix yields zero matches the build throws — catches renames/deletions early.
+const EXPECTED_PRIM_PREFIXES = [
+    'radius-',
+    'border-width-',
+    'typography-font-size-',
+    'typography-font-weight-',
+    'typography-line-height-',
+    'typography-letter-spacing-',
+];
 
 /**
  * Maps primitive dimension/typography tokens into Tailwind @theme namespaces so they
  * can be used as plain utilities instead of arbitrary `[var(--ds-*)]` values.
  *
  * Mappings (all prefixed with `ds-` to avoid overriding Tailwind built-ins):
- *   --ds-radius-*               → --radius-ds-*        → rounded-ds-xs, rounded-ds-sm …
- *   --ds-border-width-*         → --border-width-ds-*  → border-ds-hairline, border-ds-1 …
- *   --ds-typography-font-size-* → --text-ds-*          → text-ds-xs, text-ds-md …
- *   --ds-typography-font-weight-* → --font-weight-ds-* → font-ds-regular, font-ds-medium …
- *   --ds-typography-letter-spacing-* → --tracking-ds-* → tracking-ds-tight …
+ *   --ds-radius-*                    → --radius-ds-*        → rounded-ds-xs, rounded-ds-sm …
+ *   --ds-border-width-*              → --border-width-ds-*  → border-ds-hairline, border-ds-1 …
+ *   --ds-typography-font-size-*      → --text-ds-*          → text-ds-xs, text-ds-md …
+ *   --ds-typography-font-weight-*    → --font-weight-ds-*   → font-ds-regular, font-ds-medium …
+ *   --ds-typography-line-height-*    → --leading-ds-*       → leading-ds-tight, leading-ds-normal …
+ *   --ds-typography-letter-spacing-* → --tracking-ds-*      → tracking-ds-tight …
  *
  * Spacing (--ds-space-*) is intentionally omitted: Tailwind's default 4px spacing scale
  * already matches the ds-space tokens, so `gap-2` === `--ds-space-2` without any additions.
  */
 export function buildPrimitivesThemeBlock(tokens) {
+    if (tokens.length === 0) return '';
+
     const entries = [];
+    const matched = new Set();
 
     for (const t of tokens) {
         const name = t.name; // kebab name produced by the name/kebab transform
         const ref = `var(--ds-${name})`;
 
         if (name.startsWith('radius-')) {
-            const suffix = name.slice('radius-'.length);
-            entries.push(`  --radius-ds-${suffix}: ${ref};`);
+            matched.add('radius-');
+            entries.push(`  --radius-ds-${name.slice('radius-'.length)}: ${ref};`);
         } else if (name.startsWith('border-width-')) {
-            const suffix = name.slice('border-width-'.length);
-            entries.push(`  --border-width-ds-${suffix}: ${ref};`);
+            matched.add('border-width-');
+            entries.push(`  --border-width-ds-${name.slice('border-width-'.length)}: ${ref};`);
         } else if (name.startsWith('typography-font-size-')) {
-            const suffix = name.slice('typography-font-size-'.length);
-            entries.push(`  --text-ds-${suffix}: ${ref};`);
+            matched.add('typography-font-size-');
+            entries.push(`  --text-ds-${name.slice('typography-font-size-'.length)}: ${ref};`);
         } else if (name.startsWith('typography-font-weight-')) {
-            const suffix = name.slice('typography-font-weight-'.length);
-            entries.push(`  --font-weight-ds-${suffix}: ${ref};`);
+            matched.add('typography-font-weight-');
+            entries.push(`  --font-weight-ds-${name.slice('typography-font-weight-'.length)}: ${ref};`);
         } else if (name.startsWith('typography-line-height-')) {
-            const suffix = name.slice('typography-line-height-'.length);
-            entries.push(`  --leading-ds-${suffix}: ${ref};`);
+            matched.add('typography-line-height-');
+            entries.push(`  --leading-ds-${name.slice('typography-line-height-'.length)}: ${ref};`);
         } else if (name.startsWith('typography-letter-spacing-')) {
-            const suffix = name.slice('typography-letter-spacing-'.length);
-            entries.push(`  --tracking-ds-${suffix}: ${ref};`);
+            matched.add('typography-letter-spacing-');
+            entries.push(`  --tracking-ds-${name.slice('typography-letter-spacing-'.length)}: ${ref};`);
         }
     }
 
-    if (entries.length === 0) return '';
+    for (const prefix of EXPECTED_PRIM_PREFIXES) {
+        if (!matched.has(prefix)) {
+            throw new Error(`buildPrimitivesThemeBlock: no tokens matched prefix '${prefix}' — was a token group renamed or deleted?`);
+        }
+    }
+
     return `@theme {\n${entries.join('\n')}\n}`;
 }
 

--- a/packages/design-system/scripts/tokens-fetch.mjs
+++ b/packages/design-system/scripts/tokens-fetch.mjs
@@ -173,9 +173,12 @@ export function buildTailwindThemeBlock(tokens) {
     if (tokens.length > 0 && colorVars.length === 0) {
         throw new Error(`buildTailwindThemeBlock: no color tokens found — was the $type renamed or the semantic token set emptied?`);
     }
+    if (tokens.length > 0 && shadowVars.length === 0) {
+        throw new Error(`buildTailwindThemeBlock: no boxShadow tokens found — was the $type renamed or the semantic token set emptied?`);
+    }
 
     const colorBlock = `@theme {\n${colorVars.join('\n')}\n}`;
-    const shadowBlock = shadowVars.length > 0 ? `\n@theme inline {\n${shadowVars.join('\n')}\n}` : '';
+    const shadowBlock = `\n@theme inline {\n${shadowVars.join('\n')}\n}`;
     return colorBlock + shadowBlock;
 }
 

--- a/packages/design-system/scripts/tokens-fetch.unit.test.mjs
+++ b/packages/design-system/scripts/tokens-fetch.unit.test.mjs
@@ -100,41 +100,41 @@ describe('buildPrimitivesBlock', () => {
 // ─── buildTailwindThemeBlock ───────────────────────────────────────────────────
 
 describe('buildTailwindThemeBlock', () => {
+    // Minimal valid token set — both color and boxShadow are always required.
+    const BASE_TOKENS = [
+        { name: 'surface-canvas', $type: 'color' },
+        { name: 'focus-outline-default', $type: 'boxShadow' }
+    ];
+
     it('maps color tokens to --color-* vars', () => {
-        const tokens = [
-            { name: 'surface-canvas', $type: 'color' },
-            { name: 'text-strong', $type: 'color' }
-        ];
-        expect(buildTailwindThemeBlock(tokens)).toBe(
-            '@theme {\n  --color-surface-canvas: var(--surface-canvas);\n  --color-text-strong: var(--text-strong);\n}'
-        );
+        const tokens = [...BASE_TOKENS, { name: 'text-strong', $type: 'color' }];
+        expect(buildTailwindThemeBlock(tokens)).toContain('--color-surface-canvas: var(--surface-canvas)');
+        expect(buildTailwindThemeBlock(tokens)).toContain('--color-text-strong: var(--text-strong)');
     });
 
     it('emits boxShadow tokens in a separate @theme inline block', () => {
-        const tokens = [
-            { name: 'surface-canvas', $type: 'color' },
-            { name: 'focus-outline-default', $type: 'boxShadow' }
-        ];
-        expect(buildTailwindThemeBlock(tokens)).toBe(
+        expect(buildTailwindThemeBlock(BASE_TOKENS)).toBe(
             '@theme {\n  --color-surface-canvas: var(--surface-canvas);\n}\n@theme inline {\n  --shadow-focus-outline-default: var(--focus-outline-default);\n}'
         );
     });
 
     it('excludes non-color, non-boxShadow tokens', () => {
-        const tokens = [
-            { name: 'surface-canvas', $type: 'color' },
-            { name: 'ds-space-2', $type: 'spacing' }
-        ];
-        expect(buildTailwindThemeBlock(tokens)).toBe('@theme {\n  --color-surface-canvas: var(--surface-canvas);\n}');
+        const tokens = [...BASE_TOKENS, { name: 'ds-space-2', $type: 'spacing' }];
+        expect(buildTailwindThemeBlock(tokens)).not.toContain('ds-space-2');
     });
 
-    it('returns an empty @theme block for an empty token list', () => {
-        expect(buildTailwindThemeBlock([])).toBe('@theme {\n\n}');
+    it('returns empty @theme blocks for an empty token list', () => {
+        expect(buildTailwindThemeBlock([])).toBe('@theme {\n\n}\n@theme inline {\n\n}');
     });
 
     it('throws when tokens are present but none are color type', () => {
         const tokens = [{ name: 'focus-outline-default', $type: 'boxShadow' }];
         expect(() => buildTailwindThemeBlock(tokens)).toThrow(/no color tokens found/);
+    });
+
+    it('throws when tokens are present but none are boxShadow type', () => {
+        const tokens = [{ name: 'surface-canvas', $type: 'color' }];
+        expect(() => buildTailwindThemeBlock(tokens)).toThrow(/no boxShadow tokens found/);
     });
 });
 

--- a/packages/design-system/scripts/tokens-fetch.unit.test.mjs
+++ b/packages/design-system/scripts/tokens-fetch.unit.test.mjs
@@ -128,47 +128,63 @@ describe('buildTailwindThemeBlock', () => {
         expect(buildTailwindThemeBlock(tokens)).toBe('@theme {\n  --color-surface-canvas: var(--surface-canvas);\n}');
     });
 
-    it('returns an empty @theme block for no color tokens', () => {
+    it('returns an empty @theme block for an empty token list', () => {
         expect(buildTailwindThemeBlock([])).toBe('@theme {\n\n}');
+    });
+
+    it('throws when tokens are present but none are color type', () => {
+        const tokens = [{ name: 'focus-outline-default', $type: 'boxShadow' }];
+        expect(() => buildTailwindThemeBlock(tokens)).toThrow(/no color tokens found/);
     });
 });
 
 // ─── buildPrimitivesThemeBlock ────────────────────────────────────────────────
 
 describe('buildPrimitivesThemeBlock', () => {
+    // Minimal token set that satisfies all required prefix groups.
+    // Per-mapping tests use this fixture to avoid tripping the completeness guard,
+    // then assert on the specific entry they care about via toContain.
+    const BASE_TOKENS = [
+        { name: 'radius-sm', $type: 'borderRadius', $value: '4px' },
+        { name: 'border-width-1', $type: 'borderWidth', $value: '1px' },
+        { name: 'typography-font-size-md', $type: 'dimension', $value: '14px' },
+        { name: 'typography-font-weight-medium', $type: 'fontWeight', $value: '500' },
+        { name: 'typography-line-height-normal', $type: 'dimension', $value: '1.5' },
+        { name: 'typography-letter-spacing-tight', $type: 'dimension', $value: '-0.01em' },
+    ];
+
     it('maps radius-* tokens to --radius-ds-*', () => {
-        const tokens = [{ name: 'radius-sm', $type: 'borderRadius', $value: '4px' }];
-        expect(buildPrimitivesThemeBlock(tokens)).toBe('@theme {\n  --radius-ds-sm: var(--ds-radius-sm);\n}');
+        expect(buildPrimitivesThemeBlock(BASE_TOKENS)).toContain('--radius-ds-sm: var(--ds-radius-sm)');
     });
 
     it('maps border-width-* tokens to --border-width-ds-*', () => {
-        const tokens = [{ name: 'border-width-1', $type: 'borderWidth', $value: '1px' }];
-        expect(buildPrimitivesThemeBlock(tokens)).toBe('@theme {\n  --border-width-ds-1: var(--ds-border-width-1);\n}');
+        expect(buildPrimitivesThemeBlock(BASE_TOKENS)).toContain('--border-width-ds-1: var(--ds-border-width-1)');
     });
 
     it('maps typography-font-size-* tokens to --text-ds-*', () => {
-        const tokens = [{ name: 'typography-font-size-md', $type: 'dimension', $value: '14px' }];
-        expect(buildPrimitivesThemeBlock(tokens)).toBe('@theme {\n  --text-ds-md: var(--ds-typography-font-size-md);\n}');
+        expect(buildPrimitivesThemeBlock(BASE_TOKENS)).toContain('--text-ds-md: var(--ds-typography-font-size-md)');
     });
 
     it('maps typography-font-weight-* tokens to --font-weight-ds-*', () => {
-        const tokens = [{ name: 'typography-font-weight-medium', $type: 'fontWeight', $value: '500' }];
-        expect(buildPrimitivesThemeBlock(tokens)).toBe('@theme {\n  --font-weight-ds-medium: var(--ds-typography-font-weight-medium);\n}');
+        expect(buildPrimitivesThemeBlock(BASE_TOKENS)).toContain('--font-weight-ds-medium: var(--ds-typography-font-weight-medium)');
     });
 
     it('maps typography-line-height-* tokens to --leading-ds-*', () => {
-        const tokens = [{ name: 'typography-line-height-normal', $type: 'dimension', $value: '1.5' }];
-        expect(buildPrimitivesThemeBlock(tokens)).toBe('@theme {\n  --leading-ds-normal: var(--ds-typography-line-height-normal);\n}');
+        expect(buildPrimitivesThemeBlock(BASE_TOKENS)).toContain('--leading-ds-normal: var(--ds-typography-line-height-normal)');
     });
 
     it('maps typography-letter-spacing-* tokens to --tracking-ds-*', () => {
-        const tokens = [{ name: 'typography-letter-spacing-tight', $type: 'dimension', $value: '-0.01em' }];
-        expect(buildPrimitivesThemeBlock(tokens)).toBe('@theme {\n  --tracking-ds-tight: var(--ds-typography-letter-spacing-tight);\n}');
+        expect(buildPrimitivesThemeBlock(BASE_TOKENS)).toContain('--tracking-ds-tight: var(--ds-typography-letter-spacing-tight)');
     });
 
     it('ignores tokens that do not match any mapped prefix', () => {
-        const tokens = [{ name: 'color-neutral-50', $type: 'color', $value: '#f9fafb' }];
-        expect(buildPrimitivesThemeBlock(tokens)).toBe('');
+        const tokens = [...BASE_TOKENS, { name: 'color-neutral-50', $type: 'color', $value: '#f9fafb' }];
+        expect(buildPrimitivesThemeBlock(tokens)).not.toContain('color-neutral-50');
+    });
+
+    it('throws when a required prefix group produces no entries', () => {
+        const missingRadius = BASE_TOKENS.filter((t) => !t.name.startsWith('radius-'));
+        expect(() => buildPrimitivesThemeBlock(missingRadius)).toThrow(/prefix 'radius-'.*renamed or deleted/);
     });
 
     it('returns empty string for an empty token list', () => {

--- a/packages/design-system/scripts/tokens-fetch.unit.test.mjs
+++ b/packages/design-system/scripts/tokens-fetch.unit.test.mjs
@@ -1,6 +1,14 @@
 import { describe, expect, it } from 'vitest';
 
-import { buildCss, buildCssBlock, buildPrimitivesBlock, buildTailwindThemeBlock, buildTypographyBlock, formatTokenValue } from './tokens-fetch.mjs';
+import {
+    buildCss,
+    buildCssBlock,
+    buildPrimitivesBlock,
+    buildPrimitivesThemeBlock,
+    buildTailwindThemeBlock,
+    buildTypographyBlock,
+    formatTokenValue
+} from './tokens-fetch.mjs';
 
 // ─── formatTokenValue ──────────────────────────────────────────────────────────
 
@@ -102,16 +110,69 @@ describe('buildTailwindThemeBlock', () => {
         );
     });
 
-    it('excludes non-color tokens', () => {
+    it('includes boxShadow tokens as --shadow-* vars', () => {
         const tokens = [
             { name: 'surface-canvas', $type: 'color' },
             { name: 'focus-outline-default', $type: 'boxShadow' }
+        ];
+        expect(buildTailwindThemeBlock(tokens)).toBe(
+            '@theme {\n  --color-surface-canvas: var(--surface-canvas);\n  --shadow-focus-outline-default: var(--focus-outline-default);\n}'
+        );
+    });
+
+    it('excludes non-color, non-boxShadow tokens', () => {
+        const tokens = [
+            { name: 'surface-canvas', $type: 'color' },
+            { name: 'ds-space-2', $type: 'spacing' }
         ];
         expect(buildTailwindThemeBlock(tokens)).toBe('@theme {\n  --color-surface-canvas: var(--surface-canvas);\n}');
     });
 
     it('returns an empty @theme block for no color tokens', () => {
         expect(buildTailwindThemeBlock([])).toBe('@theme {\n\n}');
+    });
+});
+
+// ─── buildPrimitivesThemeBlock ────────────────────────────────────────────────
+
+describe('buildPrimitivesThemeBlock', () => {
+    it('maps radius-* tokens to --radius-ds-*', () => {
+        const tokens = [{ name: 'radius-sm', $type: 'borderRadius', $value: '4px' }];
+        expect(buildPrimitivesThemeBlock(tokens)).toBe('@theme {\n  --radius-ds-sm: var(--ds-radius-sm);\n}');
+    });
+
+    it('maps border-width-* tokens to --border-width-ds-*', () => {
+        const tokens = [{ name: 'border-width-1', $type: 'borderWidth', $value: '1px' }];
+        expect(buildPrimitivesThemeBlock(tokens)).toBe('@theme {\n  --border-width-ds-1: var(--ds-border-width-1);\n}');
+    });
+
+    it('maps typography-font-size-* tokens to --text-ds-*', () => {
+        const tokens = [{ name: 'typography-font-size-md', $type: 'dimension', $value: '14px' }];
+        expect(buildPrimitivesThemeBlock(tokens)).toBe('@theme {\n  --text-ds-md: var(--ds-typography-font-size-md);\n}');
+    });
+
+    it('maps typography-font-weight-* tokens to --font-weight-ds-*', () => {
+        const tokens = [{ name: 'typography-font-weight-medium', $type: 'fontWeight', $value: '500' }];
+        expect(buildPrimitivesThemeBlock(tokens)).toBe('@theme {\n  --font-weight-ds-medium: var(--ds-typography-font-weight-medium);\n}');
+    });
+
+    it('maps typography-line-height-* tokens to --leading-ds-*', () => {
+        const tokens = [{ name: 'typography-line-height-normal', $type: 'dimension', $value: '1.5' }];
+        expect(buildPrimitivesThemeBlock(tokens)).toBe('@theme {\n  --leading-ds-normal: var(--ds-typography-line-height-normal);\n}');
+    });
+
+    it('maps typography-letter-spacing-* tokens to --tracking-ds-*', () => {
+        const tokens = [{ name: 'typography-letter-spacing-tight', $type: 'dimension', $value: '-0.01em' }];
+        expect(buildPrimitivesThemeBlock(tokens)).toBe('@theme {\n  --tracking-ds-tight: var(--ds-typography-letter-spacing-tight);\n}');
+    });
+
+    it('ignores tokens that do not match any mapped prefix', () => {
+        const tokens = [{ name: 'color-neutral-50', $type: 'color', $value: '#f9fafb' }];
+        expect(buildPrimitivesThemeBlock(tokens)).toBe('');
+    });
+
+    it('returns empty string for an empty token list', () => {
+        expect(buildPrimitivesThemeBlock([])).toBe('');
     });
 });
 

--- a/packages/design-system/scripts/tokens-fetch.unit.test.mjs
+++ b/packages/design-system/scripts/tokens-fetch.unit.test.mjs
@@ -150,7 +150,7 @@ describe('buildPrimitivesThemeBlock', () => {
         { name: 'typography-font-size-md', $type: 'dimension', $value: '14px' },
         { name: 'typography-font-weight-medium', $type: 'fontWeight', $value: '500' },
         { name: 'typography-line-height-normal', $type: 'dimension', $value: '1.5' },
-        { name: 'typography-letter-spacing-tight', $type: 'dimension', $value: '-0.01em' },
+        { name: 'typography-letter-spacing-tight', $type: 'dimension', $value: '-0.01em' }
     ];
 
     it('maps radius-* tokens to --radius-ds-*', () => {

--- a/packages/design-system/scripts/tokens-fetch.unit.test.mjs
+++ b/packages/design-system/scripts/tokens-fetch.unit.test.mjs
@@ -110,13 +110,13 @@ describe('buildTailwindThemeBlock', () => {
         );
     });
 
-    it('includes boxShadow tokens as --shadow-* vars', () => {
+    it('emits boxShadow tokens in a separate @theme inline block', () => {
         const tokens = [
             { name: 'surface-canvas', $type: 'color' },
             { name: 'focus-outline-default', $type: 'boxShadow' }
         ];
         expect(buildTailwindThemeBlock(tokens)).toBe(
-            '@theme {\n  --color-surface-canvas: var(--surface-canvas);\n  --shadow-focus-outline-default: var(--focus-outline-default);\n}'
+            '@theme {\n  --color-surface-canvas: var(--surface-canvas);\n}\n@theme inline {\n  --shadow-focus-outline-default: var(--focus-outline-default);\n}'
         );
     });
 

--- a/packages/design-system/tokens/tokens.generated.css
+++ b/packages/design-system/tokens/tokens.generated.css
@@ -491,9 +491,9 @@
 }
 
 /*
- * Tailwind v4 @theme registration.
- * Maps semantic color vars to --color-* so Tailwind generates
- * utility classes: bg-surface-canvas, text-text-strong, border-border-default, etc.
+ * Tailwind v4 @theme registration — semantic tokens.
+ * Colors → --color-* (bg-*, text-*, border-*, etc.)
+ * Box shadows → --shadow-* (shadow-focus-outline-default, etc.)
  */
 @theme {
     --color-icon-default: var(--icon-default);
@@ -609,6 +609,53 @@
     --color-control-switch-track-off: var(--control-switch-track-off);
     --color-control-switch-track-off-danger: var(--control-switch-track-off-danger);
     --color-control-switch-thumb-off: var(--control-switch-thumb-off);
+    --shadow-focus-outline-default: var(--focus-outline-default);
+    --shadow-focus-outline-danger: var(--focus-outline-danger);
+    --shadow-container-inset: var(--container-inset);
+    --shadow-container-panel: var(--container-panel);
+    --shadow-container-sheet: var(--container-sheet);
+}
+
+/*
+ * Tailwind v4 @theme registration — primitive tokens.
+ * Radius → rounded-ds-*, border-width → border-ds-*,
+ * font-size → text-ds-*, font-weight → font-ds-*, letter-spacing → tracking-ds-*
+ */
+@theme {
+    --text-ds-3xs: var(--ds-typography-font-size-3xs);
+    --text-ds-2xs: var(--ds-typography-font-size-2xs);
+    --text-ds-xs: var(--ds-typography-font-size-xs);
+    --text-ds-sm: var(--ds-typography-font-size-sm);
+    --text-ds-md: var(--ds-typography-font-size-md);
+    --text-ds-lg: var(--ds-typography-font-size-lg);
+    --text-ds-xl: var(--ds-typography-font-size-xl);
+    --text-ds-2xl: var(--ds-typography-font-size-2xl);
+    --text-ds-3xl: var(--ds-typography-font-size-3xl);
+    --text-ds-4xl: var(--ds-typography-font-size-4xl);
+    --font-weight-ds-regular: var(--ds-typography-font-weight-regular);
+    --font-weight-ds-medium: var(--ds-typography-font-weight-medium);
+    --font-weight-ds-semibold: var(--ds-typography-font-weight-semibold);
+    --font-weight-ds-bold: var(--ds-typography-font-weight-bold);
+    --leading-ds-tight: var(--ds-typography-line-height-tight);
+    --leading-ds-snug: var(--ds-typography-line-height-snug);
+    --leading-ds-normal: var(--ds-typography-line-height-normal);
+    --leading-ds-relaxed: var(--ds-typography-line-height-relaxed);
+    --tracking-ds-tight: var(--ds-typography-letter-spacing-tight);
+    --tracking-ds-normal: var(--ds-typography-letter-spacing-normal);
+    --tracking-ds-wide: var(--ds-typography-letter-spacing-wide);
+    --radius-ds-none: var(--ds-radius-none);
+    --radius-ds-xs: var(--ds-radius-xs);
+    --radius-ds-sm: var(--ds-radius-sm);
+    --radius-ds-md: var(--ds-radius-md);
+    --radius-ds-lg: var(--ds-radius-lg);
+    --radius-ds-xl: var(--ds-radius-xl);
+    --radius-ds-2xl: var(--ds-radius-2xl);
+    --radius-ds-3xl: var(--ds-radius-3xl);
+    --radius-ds-full: var(--ds-radius-full);
+    --border-width-ds-0: var(--ds-border-width-0);
+    --border-width-ds-1: var(--ds-border-width-1);
+    --border-width-ds-2: var(--ds-border-width-2);
+    --border-width-ds-hairline: var(--ds-border-width-hairline);
 }
 
 /*

--- a/packages/design-system/tokens/tokens.generated.css
+++ b/packages/design-system/tokens/tokens.generated.css
@@ -609,6 +609,8 @@
     --color-control-switch-track-off: var(--control-switch-track-off);
     --color-control-switch-track-off-danger: var(--control-switch-track-off-danger);
     --color-control-switch-thumb-off: var(--control-switch-thumb-off);
+}
+@theme inline {
     --shadow-focus-outline-default: var(--focus-outline-default);
     --shadow-focus-outline-danger: var(--focus-outline-danger);
     --shadow-container-inset: var(--container-inset);


### PR DESCRIPTION
## Problem

Components were forced to use arbitrary `[var(--ds-*)]` values for spacing, radius, font sizes, and focus rings — making class lists verbose and harder to read.

## Solution

Extends the token pipeline to emit a second `@theme` block that maps all primitive dimension/typography tokens to named Tailwind utilities:

| Token prefix | Tailwind utility | Example |
|---|---|---|
| `--ds-radius-*` | `rounded-ds-*` | `rounded-ds-xs`, `rounded-ds-sm` |
| `--ds-border-width-*` | `border-ds-*` | `border-ds-hairline`, `border-ds-1` |
| `--ds-typography-font-size-*` | `text-ds-*` | `text-ds-xs`, `text-ds-md` |
| `--ds-typography-font-weight-*` | `font-ds-*` | `font-ds-medium` |
| `--ds-typography-line-height-*` | `leading-ds-*` | `leading-ds-normal` |
| `--ds-typography-letter-spacing-*` | `tracking-ds-*` | `tracking-ds-tight` |

Also extends `buildTailwindThemeBlock()` to include boxShadow tokens as `--shadow-*` so focus ring utilities like `shadow-focus-outline-default` work without arbitrary var() wrappers.

Spacing tokens are intentionally omitted — Tailwind's default 4px scale already matches `--ds-space-*` exactly.

**Rename/deletion guards:** both builder functions now throw at build time if an expected token group produces zero entries (e.g. if `typography-font-size-*` is renamed to `typo-font-size-*` in Figma). Previously this would silently produce an empty `@theme` block. The expected prefixes are declared in `EXPECTED_PRIM_PREFIXES` — one place to update if a group is added or renamed intentionally.

Part of [NAN-5667](https://linear.app/nango/issue/NAN-5667)

## Testing

- `npm run tokens:build` — rebuilds `tokens.generated.css` with the new `@theme` entries
- `npm test` — all 35 unit tests pass, including new tests for `buildPrimitivesThemeBlock` and the throw guards
