### PR TITLE
fix(authz): harden permission boundaries — billing, playground, env-var read

### DIFF
--- a/packages/authz/lib/permissions.ts
+++ b/packages/authz/lib/permissions.ts
@@ -1,5 +1,4 @@
 import type { Permission } from '@nangohq/types';
-
 export const permissions = {
     // team management (global scope)
     canManageTeam: { action: 'update', resource: 'team', scope: 'global' },
@@ -8,11 +7,13 @@ export const permissions = {
     canInviteMember: { action: 'create', resource: 'invite', scope: 'global' },
     canCancelInvitation: { action: 'delete', resource: 'invite', scope: 'global' },
     canManageConnectUI: { action: 'update', resource: 'connect_ui_settings', scope: 'global' },
-    canManageBilling: { action: '*', resource: 'billing', scope: 'global' },
+    // billing (explicit actions only — no wildcard escalation)
+    canReadBilling: { action: 'read', resource: 'billing', scope: 'global' },
+    canUpdateBilling: { action: 'update', resource: 'billing', scope: 'global' },
+    canDeleteBilling: { action: 'delete', resource: 'billing', scope: 'global' },
     canChangePlan: { action: 'update', resource: 'plan', scope: 'global' },
     canToggleIsProduction: { action: 'update', resource: 'environment_production_flag', scope: 'global' },
     canCreateEnvironment: { action: 'create', resource: 'environment', scope: 'global' },
-
     // production environment access
     canAccessProdEnvironment: { action: 'read', resource: 'environment', scope: 'production' },
     canWriteProdIntegrations: { action: 'update', resource: 'integration', scope: 'production' },
@@ -22,14 +23,16 @@ export const permissions = {
     canWriteProdFlows: { action: 'update', resource: 'flow', scope: 'production' },
     canWriteProdEnvironment: { action: 'update', resource: 'environment', scope: 'production' },
     canWriteProdEnvironmentKeys: { action: 'update', resource: 'environment_key', scope: 'production' },
+    // env variables — explicit read/write separation (secret material)
+    canReadProdEnvironmentVariables: { action: 'read', resource: 'environment_variable', scope: 'production' },
     canWriteProdEnvironmentVariables: { action: 'update', resource: 'environment_variable', scope: 'production' },
     canWriteProdWebhooks: { action: 'update', resource: 'webhook', scope: 'production' },
     canDeleteProdEnvironment: { action: 'delete', resource: 'environment', scope: 'production' },
-
     // production secrets/credentials
     canReadProdSecretKey: { action: 'read', resource: 'secret_key', scope: 'production' },
     canReadProdConnectionCredentials: { action: 'read', resource: 'connection_credential', scope: 'production' },
-
-    // playground (reuses sync_command permission — whoever can trigger syncs can use the playground)
-    canUseProdPlayground: { action: 'update', resource: 'sync_command', scope: 'production' }
+    // operational sync execution
+    canExecuteProdSyncCommands: { action: 'execute', resource: 'sync_command', scope: 'production' },
+    // isolated playground capability — not coupled to sync execution
+    canUseProdPlayground: { action: 'use', resource: 'playground', scope: 'production' }
 } as const satisfies Record<string, Permission>;

--- a/packages/server/lib/authz/deny-map.ts
+++ b/packages/server/lib/authz/deny-map.ts
@@ -30,7 +30,7 @@ const PROD_WRITES: Permission[] = [
     p.canWriteProdWebhooks
 ];
 
-const PROD_SECRETS: Permission[] = [p.canReadProdSecretKey, p.canReadProdConnectionCredentials];
+const PROD_SECRETS: Permission[] = [p.canReadProdSecretKey, p.canReadProdConnectionCredentials, p.canReadProdEnvironmentVariables];
 
 export const ROLE_DENY_MAP: Record<Role, Permission[]> = {
     administrator: [],

--- a/packages/server/lib/authz/deny-map.ts
+++ b/packages/server/lib/authz/deny-map.ts
@@ -9,7 +9,9 @@ const ADMIN_ONLY: Permission[] = [
     p.canInviteMember,
     p.canCancelInvitation,
     p.canManageConnectUI,
-    p.canManageBilling,
+    p.canReadBilling,
+    p.canUpdateBilling,
+    p.canDeleteBilling,
     p.canChangePlan,
     p.canToggleIsProduction,
     p.canCreateEnvironment

--- a/packages/server/lib/authz/evaluator.unit.test.ts
+++ b/packages/server/lib/authz/evaluator.unit.test.ts
@@ -11,7 +11,9 @@ describe('StaticEvaluator', () => {
         it('should allow everything', async () => {
             const perms: Permission[] = [
                 { action: 'update', resource: 'team', scope: 'global' },
-                { action: '*', resource: 'billing', scope: 'global' },
+                { action: 'read', resource: 'billing', scope: 'global' },
+                { action: 'update', resource: 'billing', scope: 'global' },
+                { action: 'delete', resource: 'billing', scope: 'global' },
                 { action: 'update', resource: 'integration', scope: 'production' },
                 { action: 'read', resource: 'connection', scope: 'production' },
                 { action: 'read', resource: 'secret_key', scope: 'production' },
@@ -34,7 +36,9 @@ describe('StaticEvaluator', () => {
         });
 
         it('should deny billing', async () => {
-            await expect(evaluator.evaluate('production_support', { action: '*', resource: 'billing', scope: 'global' })).resolves.toBe(false);
+            await expect(evaluator.evaluate('production_support', { action: 'read', resource: 'billing', scope: 'global' })).resolves.toBe(false);
+            await expect(evaluator.evaluate('production_support', { action: 'update', resource: 'billing', scope: 'global' })).resolves.toBe(false);
+            await expect(evaluator.evaluate('production_support', { action: 'delete', resource: 'billing', scope: 'global' })).resolves.toBe(false);
             await expect(evaluator.evaluate('production_support', { action: 'update', resource: 'plan', scope: 'global' })).resolves.toBe(false);
         });
 
@@ -69,7 +73,8 @@ describe('StaticEvaluator', () => {
         });
 
         it('should allow production sync commands', async () => {
-            await expect(evaluator.evaluate('production_support', { action: 'update', resource: 'sync_command', scope: 'production' })).resolves.toBe(true);
+            await expect(evaluator.evaluate('production_support', { action: 'execute', resource: 'sync_command', scope: 'production' })).resolves.toBe(true);
+            await expect(evaluator.evaluate('production_support', { action: 'use', resource: 'playground', scope: 'production' })).resolves.toBe(true);
         });
 
         it('should allow non-prod everything', async () => {
@@ -94,9 +99,8 @@ describe('StaticEvaluator', () => {
         });
 
         it('should deny production sync commands', async () => {
-            await expect(evaluator.evaluate('development_full_access', { action: 'update', resource: 'sync_command', scope: 'production' })).resolves.toBe(
-                false
-            );
+            await expect(evaluator.evaluate('development_full_access', { action: 'execute', resource: 'sync_command', scope: 'production' })).resolves.toBe(false);
+            await expect(evaluator.evaluate('development_full_access', { action: 'use', resource: 'playground', scope: 'production' })).resolves.toBe(false);
         });
 
         it('should deny team management', async () => {

--- a/packages/server/lib/routes.private.ts
+++ b/packages/server/lib/routes.private.ts
@@ -264,7 +264,7 @@ web.route('/user/password').put(webAuth, putUserPassword);
 web.route('/sync').get(webAuth, can({ action: 'read', resource: 'flow', scopedBy: envScope }), syncController.getSyncsByParams.bind(syncController));
 web.route('/sync/command').post(
     webAuth,
-    can(p.canExecuteProdSyncCommands),
+    can({ action: 'execute', resource: 'sync_command', scopedBy: envScope }),
     syncController.syncCommand.bind(syncController)
 );
 web.route('/flows/pre-built/deploy').post(webAuth, can({ action: 'update', resource: 'flow', scopedBy: envScope }), postPreBuiltDeploy);
@@ -275,7 +275,7 @@ web.route('/flows/:id/frequency').patch(webAuth, can({ action: 'update', resourc
 web.route('/flows/:id/download').get(webAuth, can({ action: 'read', resource: 'flow', scopedBy: envScope }), getFlowDownload);
 web.route('/flow/:flowName').get(webAuth, flowController.getFlow.bind(syncController));
 
-web.route('/trigger/function').post(webAuth, can(p.canExecuteProdSyncCommands), postTriggerFunction);
+web.route('/trigger/function').post(webAuth, can({ action: 'execute', resource: 'sync_command', scopedBy: envScope }), postTriggerFunction);
 
 // Getting Started
 web.route('/getting-started').get(webAuth, getGettingStarted);
@@ -292,7 +292,7 @@ web.route('/logs/insights').post(webAuth, can({ action: 'read', resource: 'log',
 if (flagHasUsage) {
     web.route('/stripe/payment_methods').get(webAuth, can(p.canReadBilling), getStripePaymentMethods);
     web.route('/stripe/payment_methods').post(webAuth, can(p.canUpdateBilling), postStripeCollectPayment);
-    web.route('/stripe/payment_methods').delete(webAuth, can(p.canUpdateBilling), deleteStripePaymentMethod);
+    web.route('/stripe/payment_methods').delete(webAuth, can(p.canDeleteBilling), deleteStripePaymentMethod);
     web.route('/stripe/webhooks').post(rateLimiterMiddleware, postStripeWebhooks);
 
     web.route('/orb/webhooks').post((_req, _res, next) => {

--- a/packages/server/lib/routes.private.ts
+++ b/packages/server/lib/routes.private.ts
@@ -264,7 +264,7 @@ web.route('/user/password').put(webAuth, putUserPassword);
 web.route('/sync').get(webAuth, can({ action: 'read', resource: 'flow', scopedBy: envScope }), syncController.getSyncsByParams.bind(syncController));
 web.route('/sync/command').post(
     webAuth,
-    can({ action: 'update', resource: 'sync_command', scopedBy: envScope }),
+    can(p.canExecuteProdSyncCommands),
     syncController.syncCommand.bind(syncController)
 );
 web.route('/flows/pre-built/deploy').post(webAuth, can({ action: 'update', resource: 'flow', scopedBy: envScope }), postPreBuiltDeploy);
@@ -275,7 +275,7 @@ web.route('/flows/:id/frequency').patch(webAuth, can({ action: 'update', resourc
 web.route('/flows/:id/download').get(webAuth, can({ action: 'read', resource: 'flow', scopedBy: envScope }), getFlowDownload);
 web.route('/flow/:flowName').get(webAuth, flowController.getFlow.bind(syncController));
 
-web.route('/trigger/function').post(webAuth, can({ action: 'update', resource: 'sync_command', scopedBy: envScope }), postTriggerFunction);
+web.route('/trigger/function').post(webAuth, can(p.canExecuteProdSyncCommands), postTriggerFunction);
 
 // Getting Started
 web.route('/getting-started').get(webAuth, getGettingStarted);
@@ -290,9 +290,9 @@ web.route('/logs/insights').post(webAuth, can({ action: 'read', resource: 'log',
 
 // Stripe / Billing
 if (flagHasUsage) {
-    web.route('/stripe/payment_methods').get(webAuth, can(p.canManageBilling), getStripePaymentMethods);
-    web.route('/stripe/payment_methods').post(webAuth, can(p.canManageBilling), postStripeCollectPayment);
-    web.route('/stripe/payment_methods').delete(webAuth, can(p.canManageBilling), deleteStripePaymentMethod);
+    web.route('/stripe/payment_methods').get(webAuth, can(p.canReadBilling), getStripePaymentMethods);
+    web.route('/stripe/payment_methods').post(webAuth, can(p.canUpdateBilling), postStripeCollectPayment);
+    web.route('/stripe/payment_methods').delete(webAuth, can(p.canUpdateBilling), deleteStripePaymentMethod);
     web.route('/stripe/webhooks').post(rateLimiterMiddleware, postStripeWebhooks);
 
     web.route('/orb/webhooks').post((_req, _res, next) => {

--- a/packages/types/lib/authz/types.ts
+++ b/packages/types/lib/authz/types.ts
@@ -1,6 +1,5 @@
 import type { Role } from '../user/db.js';
-
-export type Action = 'create' | 'read' | 'update' | 'delete' | '*';
+export type Action = 'create' | 'read' | 'update' | 'delete' | 'execute' | 'use' | '*';
 export type Resource =
     | 'team'
     | 'team_member'
@@ -17,18 +16,17 @@ export type Resource =
     | 'connection'
     | 'flow'
     | 'sync_command'
+    | 'playground'
     | 'secret_key'
     | 'connection_credential'
     | 'log'
     | '*';
 export type Scope = 'production' | 'non-production' | 'global';
-
 export interface Permission {
     action: Action;
     resource: Resource;
     scope: Scope;
 }
-
 export interface PermissionEvaluator {
     evaluate(role: Role, permission: Permission): Promise<boolean>;
 }

--- a/packages/types/lib/user/api.ts
+++ b/packages/types/lib/user/api.ts
@@ -41,7 +41,7 @@ export interface ApiUser {
 }
 
 export type AllowedPermissions = Partial<
-    Record<string, Partial<Record<'production' | 'non-production' | 'global', ('create' | 'read' | 'update' | 'delete' | '*')[]>>>
+    Record<string, Partial<Record<'production' | 'non-production' | 'global', ('create' | 'read' | 'update' | 'delete' | 'execute' | 'use' | '*')[]>>>
 >;
 
 export type ApiUserWithPermissions = ApiUser & {


### PR DESCRIPTION
Fixes three RBAC security findings in the permission schema: wildcard action:'*' on billing replaced with explicit read/update/delete to prevent implicit privi…Fixes three RBAC security findings in the permission schema: wildcard action:'*' on billing replaced with explicit read/update/delete to prevent implicit privilege expansion; playground access decoupled from sync_command to eliminate confused deputy pattern between operational and debug capabilities; explicit canReadProdEnvironmentVariables added since production env vars are secret material and read/write must be separate grants.

Changes propagate through the full auth stack, Action and Resource types extended with execute, use, and playground; AllowedPermissions API type updated; deny-map and evaluator tests updated to reflect new capability semantics.
