### PR TITLE
chore(webapp): add vite proxy for multi-worktree dev

### DIFF
--- a/.agents/skills/running-and-testing-locally/SKILL.md
+++ b/.agents/skills/running-and-testing-locally/SKILL.md
@@ -73,9 +73,9 @@ Run individual services when you only need to restart one:
 
 ```bash
 npm run server:dev:watch       # API server only (port 3003)
-npm run webapp:dev:watch                          # Webapp only (port 3000, or next free port)
-npm run dev -w packages/webapp                    # Same as above, from any worktree
-REMOTE_API=dev npm run dev -w packages/webapp     # Webapp against remote API (no local backend needed)
+npm run webapp:dev:watch       # Webapp only (port 3000, or next free port)
+npm run dev -w packages/webapp # Same as above, from any worktree
+REMOTE_API=dev npm run dev -w packages/webapp # Webapp against remote API (no local backend needed)
 npm run connect-ui:dev:watch   # Connect UI only (port 3009)
 npm run jobs:dev:watch         # Jobs worker (port 3005)
 npm run persist:dev:watch      # Persist service (port 3007)

--- a/.agents/skills/running-and-testing-locally/SKILL.md
+++ b/.agents/skills/running-and-testing-locally/SKILL.md
@@ -23,7 +23,7 @@ Nango runs as a set of microservices (server, webapp, jobs, persist, orchestrato
 
 | Service | URL | Port |
 |---------|-----|------|
-| Webapp (dashboard) | http://localhost:3000 | 3000 |
+| Webapp (dashboard) | http://localhost:3000 | 3000 (auto-increments if in use) |
 | API Server | http://localhost:3003 | 3003 |
 | Connect UI | http://localhost:3009 | 3009 |
 | PostgreSQL | localhost:5432 | 5432 (user: `nango`, pass: `nango`) |
@@ -73,13 +73,29 @@ Run individual services when you only need to restart one:
 
 ```bash
 npm run server:dev:watch       # API server only (port 3003)
-npm run webapp:dev:watch       # Webapp only (port 3000)
+npm run webapp:dev:watch                          # Webapp only (port 3000, or next free port)
+npm run dev -w packages/webapp                    # Same as above, from any worktree
+REMOTE_API=staging npm run dev -w packages/webapp # Webapp against remote API (no local backend needed)
 npm run connect-ui:dev:watch   # Connect UI only (port 3009)
 npm run jobs:dev:watch         # Jobs worker (port 3005)
 npm run persist:dev:watch      # Persist service (port 3007)
 npm run orchestrator:dev:watch # Orchestrator (port 3008)
 npm run metering:dev:watch     # Metering service (cron-based, no HTTP port)
 ```
+
+## Multi-Worktree Webapp Dev
+
+Run the backend stack once (from the main project or one worktree), then start a webapp Vite server per worktree. Vite auto-increments the port when 3000 is taken, and rewrites `apiUrl` in `env.js` to match — all API traffic is proxied through Vite so there are no CORS issues.
+
+```bash
+# Worktree 1 (gets port 3000)
+npm run dev -w packages/webapp
+
+# Worktree 2 (auto-selects 3001, 3002, …)
+npm run dev -w packages/webapp
+```
+
+To avoid a local backend entirely, use `REMOTE_API=dev|staging|prod` — each worktree proxies independently to the remote.
 
 ## Environment Configuration
 

--- a/.agents/skills/running-and-testing-locally/SKILL.md
+++ b/.agents/skills/running-and-testing-locally/SKILL.md
@@ -75,7 +75,7 @@ Run individual services when you only need to restart one:
 npm run server:dev:watch       # API server only (port 3003)
 npm run webapp:dev:watch                          # Webapp only (port 3000, or next free port)
 npm run dev -w packages/webapp                    # Same as above, from any worktree
-REMOTE_API=staging npm run dev -w packages/webapp # Webapp against remote API (no local backend needed)
+REMOTE_API=dev npm run dev -w packages/webapp     # Webapp against remote API (no local backend needed)
 npm run connect-ui:dev:watch   # Connect UI only (port 3009)
 npm run jobs:dev:watch         # Jobs worker (port 3005)
 npm run persist:dev:watch      # Persist service (port 3007)

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -20,7 +20,7 @@ Run `npm run dev -w packages/webapp` from each worktree. Vite picks the next fre
 Pass `REMOTE_API=<env>` to proxy all API traffic to a live backend instead. No local backend needed.
 
 ```bash
-REMOTE_API=staging npm run dev -w packages/webapp   # https://api-staging.nango.dev
 REMOTE_API=dev npm run dev -w packages/webapp       # https://api-development.nango.dev
+REMOTE_API=staging npm run dev -w packages/webapp   # https://api-staging.nango.dev
 REMOTE_API=prod npm run dev -w packages/webapp      # https://api.nango.dev
 ```

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -5,6 +5,10 @@ After running the initial `npm install` or `npm ci`, run `npm run prepare` to in
 
 Run `npm run ts-build` before autofixing lint errors using npm run lint:fix. Fresh worktrees don't have `dist/` (gitignored), so workspace packages like `@nangohq/types` can't resolve, causing false ESLint errors and broken type-checking.
 
+## Running Nango locally
+
+For full local dev setup (Docker, service URLs, auth flows, troubleshooting), use the `running-and-testing-locally` skill.
+
 ## Running the webapp dev server
 
 ### Multiple worktrees (local backend)

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -5,14 +5,18 @@ After running the initial `npm install` or `npm ci`, run `npm run prepare` to in
 
 Run `npm run ts-build` before autofixing lint errors using npm run lint:fix. Fresh worktrees don't have `dist/` (gitignored), so workspace packages like `@nangohq/types` can't resolve, causing false ESLint errors and broken type-checking.
 
-## Running the webapp against a remote API
+## Running the webapp dev server
 
-Pass `REMOTE_API=<env>` when starting the dev server to proxy all API traffic through Vite instead of a local backend. No browser CORS extension needed.
+### Multiple worktrees (local backend)
+
+Just run `npm run dev` from each worktree. Vite automatically picks the next free port (3000 → 3001 → 3002 …) and rewrites `apiUrl` in `env.js` to match, so all API traffic is proxied through Vite to the local backend at `localhost:3003`. No CORS issues, no manual port configuration.
+
+### Remote API
+
+Pass `REMOTE_API=<env>` to proxy all API traffic to a live backend instead. No local backend needed.
 
 ```bash
 REMOTE_API=staging npm run dev   # https://api-staging.nango.dev
 REMOTE_API=dev npm run dev       # https://api-development.nango.dev
 REMOTE_API=prod npm run dev      # https://api.nango.dev
 ```
-
-When `REMOTE_API` is not set, the dev server behaves as normal and expects a local backend on `localhost:3003`.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -9,14 +9,14 @@ Run `npm run ts-build` before autofixing lint errors using npm run lint:fix. Fre
 
 ### Multiple worktrees (local backend)
 
-Just run `npm run dev` from each worktree. Vite automatically picks the next free port (3000 → 3001 → 3002 …) and rewrites `apiUrl` in `env.js` to match, so all API traffic is proxied through Vite to the local backend at `localhost:3003`. No CORS issues, no manual port configuration.
+Run `npm run dev -w packages/webapp` from each worktree. Vite picks the next free port (3000 → 3001 → 3002 …) and rewrites `apiUrl` in `env.js` to match, routing all API traffic through Vite's proxy to the local backend at `localhost:3003`.
 
 ### Remote API
 
 Pass `REMOTE_API=<env>` to proxy all API traffic to a live backend instead. No local backend needed.
 
 ```bash
-REMOTE_API=staging npm run dev   # https://api-staging.nango.dev
-REMOTE_API=dev npm run dev       # https://api-development.nango.dev
-REMOTE_API=prod npm run dev      # https://api.nango.dev
+REMOTE_API=staging npm run dev -w packages/webapp   # https://api-staging.nango.dev
+REMOTE_API=dev npm run dev -w packages/webapp       # https://api-development.nango.dev
+REMOTE_API=prod npm run dev -w packages/webapp      # https://api.nango.dev
 ```

--- a/packages/webapp/vite.config.ts
+++ b/packages/webapp/vite.config.ts
@@ -22,7 +22,7 @@ const REMOTE_API_URLS: Record<string, string> = {
 // so all API calls are routed through Vite's proxy instead of going cross-origin.
 // The actual listening port is resolved at request time (after the server binds)
 // so Vite's automatic port increment is reflected correctly.
-function apiEnvProxy(apiUrl: string): Plugin {
+function apiEnvProxyPlugin(apiUrl: string): Plugin {
     return {
         name: 'api-env-proxy',
         configureServer(server) {
@@ -49,7 +49,7 @@ function apiProxyConfig() {
     const apiUrl = remoteUrl ?? `http://localhost:${LOCAL_API_PORT}`;
     const proxyOpts = remoteUrl ? { target: apiUrl, changeOrigin: true } : { target: apiUrl };
     return {
-        envPlugin: apiEnvProxy(apiUrl),
+        envPlugin: apiEnvProxyPlugin(apiUrl),
         proxy: {
             '/api': proxyOpts,
             // Extra routes needed for connection creation and auth flows.

--- a/packages/webapp/vite.config.ts
+++ b/packages/webapp/vite.config.ts
@@ -49,7 +49,7 @@ function apiProxyConfig() {
     const apiUrl = remoteUrl ?? `http://localhost:${LOCAL_API_PORT}`;
     const proxyOpts = remoteUrl ? { target: apiUrl, changeOrigin: true } : { target: apiUrl };
     return {
-        envPlugin: apiEnvProxyPlugin(apiUrl),
+        envProxyPlugin: apiEnvProxyPlugin(apiUrl),
         proxy: {
             '/api': proxyOpts,
             // Extra routes needed for connection creation and auth flows.
@@ -69,10 +69,10 @@ function apiProxyConfig() {
 
 // https://vitejs.dev/config/
 export default defineConfig(() => {
-    const { envPlugin, proxy } = apiProxyConfig();
+    const { envProxyPlugin, proxy } = apiProxyConfig();
 
     return {
-        plugins: [react(), svgr(), checker({ typescript: true }), tailwindcss(), envPlugin],
+        plugins: [react(), svgr(), checker({ typescript: true }), tailwindcss(), envProxyPlugin],
         resolve: {
             alias: {
                 '@': path.resolve(__dirname, './src'),

--- a/packages/webapp/vite.config.ts
+++ b/packages/webapp/vite.config.ts
@@ -18,17 +18,20 @@ const REMOTE_API_URLS: Record<string, string> = {
     prod: 'https://api.nango.dev'
 };
 
-// Fetches /env.js from a remote API and rewrites apiUrl to the local dev server
+// Fetches /env.js from apiUrl and rewrites apiUrl to the local Vite dev server
 // so all API calls are routed through Vite's proxy instead of going cross-origin.
-// Activated by setting REMOTE_API=dev|staging|prod when running the dev server.
-function remoteApiEnvProxy(remoteApiUrl: string): Plugin {
+// The actual listening port is resolved at request time (after the server binds)
+// so Vite's automatic port increment is reflected correctly.
+function apiEnvProxy(apiUrl: string): Plugin {
     return {
-        name: 'remote-api-env-proxy',
+        name: 'api-env-proxy',
         configureServer(server) {
             // eslint-disable-next-line @typescript-eslint/no-misused-promises
             server.middlewares.use('/env.js', async (_req, res) => {
-                const origin = `http://localhost:${DEV_PORT}`;
-                const body = await fetch(`${remoteApiUrl}/env.js`).then((r) => r.text());
+                const addr = server.httpServer?.address();
+                const port = addr && typeof addr === 'object' ? addr.port : DEV_PORT;
+                const origin = `http://localhost:${port}`;
+                const body = await fetch(`${apiUrl}/env.js`).then((r) => r.text());
                 res.setHeader('Content-Type', 'text/javascript');
                 res.end(body.replace(/"apiUrl": "[^"]*"/, `"apiUrl": "${origin}"`));
             });
@@ -36,41 +39,40 @@ function remoteApiEnvProxy(remoteApiUrl: string): Plugin {
     };
 }
 
-function remoteApiConfig() {
+function apiProxyConfig() {
     const remoteApi = process.env['REMOTE_API'];
-    if (!remoteApi) {
-        return { remoteProxy: { '/env.js': { target: `http://localhost:${LOCAL_API_PORT}` } } };
-    }
-    const url = REMOTE_API_URLS[remoteApi];
-    if (!url) {
+    const remoteUrl = remoteApi ? REMOTE_API_URLS[remoteApi] : null;
+    if (remoteApi && !remoteUrl) {
         throw new Error(`[nango] Unknown REMOTE_API="${remoteApi}". Valid values: ${Object.keys(REMOTE_API_URLS).join(', ')}`);
     }
-    const remote = { target: url, changeOrigin: true };
+
+    const apiUrl = remoteUrl ?? `http://localhost:${LOCAL_API_PORT}`;
+    const proxyOpts = remoteUrl ? { target: apiUrl, changeOrigin: true } : { target: apiUrl };
     return {
-        remotePlugin: remoteApiEnvProxy(url),
-        remoteProxy: {
-            '/api': remote,
+        envPlugin: apiEnvProxy(apiUrl),
+        proxy: {
+            '/api': proxyOpts,
             // Extra routes needed for connection creation and auth flows.
             // Most dashboard functionality (viewing connections, logs, settings) works with /api alone.
-            '/connect': remote, // Connect UI session + telemetry
-            '/integrations': remote, // Connect UI integration list
-            '/providers': remote, // Connect UI provider details
-            '/proxy': remote, // Getting-started proxy call
-            '/oauth2': remote, // OAuth2 client credentials
-            '/api-auth': remote, // API key / basic auth
-            '/auth': remote, // TBA, JWT, two-step, etc.
-            '/app-store-auth': remote,
-            '/app-auth': remote // GitHub App setup callback
+            '/connect': proxyOpts, // Connect UI session + telemetry
+            '/integrations': proxyOpts, // Connect UI integration list
+            '/providers': proxyOpts, // Connect UI provider details
+            '/proxy': proxyOpts, // Getting-started proxy call
+            '/oauth2': proxyOpts, // OAuth2 client credentials
+            '/api-auth': proxyOpts, // API key / basic auth
+            '/auth': proxyOpts, // TBA, JWT, two-step, etc.
+            '/app-store-auth': proxyOpts,
+            '/app-auth': proxyOpts // GitHub App setup callback
         }
     };
 }
 
 // https://vitejs.dev/config/
 export default defineConfig(() => {
-    const { remotePlugin, remoteProxy } = remoteApiConfig();
+    const { envPlugin, proxy } = apiProxyConfig();
 
     return {
-        plugins: [react(), svgr(), checker({ typescript: true }), tailwindcss(), remotePlugin],
+        plugins: [react(), svgr(), checker({ typescript: true }), tailwindcss(), envPlugin],
         resolve: {
             alias: {
                 '@': path.resolve(__dirname, './src'),
@@ -79,7 +81,7 @@ export default defineConfig(() => {
                 '@tabler/icons-react': '@tabler/icons-react/dist/esm/icons/index.mjs'
             }
         },
-        server: { port: DEV_PORT, proxy: remoteProxy },
+        server: { port: DEV_PORT, proxy },
         define: {
             'import.meta.env.VITE_HASH': JSON.stringify(createHash('md5').update(Date.now().toString()).digest('hex').slice(0, 8))
         }


### PR DESCRIPTION
## Problem

When running multiple worktrees simultaneously, each Vite dev server must use a different port. The local API server at `localhost:3003` has CORS configured for `localhost:3000` only, so any worktree on a different port gets CORS errors — `apiUrl` in `env.js` is an absolute `http://localhost:3003` URL, causing the browser to make direct cross-origin requests.

## Solution

Apply the same proxy-based approach already used for `REMOTE_API` mode to local development:

- **`apiEnvProxyPlugin`** intercepts `/env.js`, fetches it from the API server, and rewrites `apiUrl` to match the actual Vite dev server origin. The port is resolved lazily at request time via `server.httpServer.address()`, so Vite's automatic port increment (3000 → 3001 → 3002 …) is always reflected correctly.
- **All API routes** (`/api`, `/connect`, `/auth`, etc.) are proxied through Vite, keeping every request same-origin regardless of port.
- **Unified config**: `remoteApiConfig` / `remoteApiEnvProxy` are replaced by a single `apiProxyConfig` / `apiEnvProxyPlugin` that handles both local and remote cases.

No production code changes. Running `npm run dev -w packages/webapp` from any worktree now just works — Vite picks the next free port automatically.

Fixes [NAN-5742](https://linear.app/nango/issue/NAN-5742)

## Known limitation

With 3+ webapp worktrees running simultaneously, Vite's auto-increment can land on a backend service port (3003–3009) if those services haven't started yet, causing the proxy to point to the wrong process. Tracked in [NAN-5854](https://linear.app/nango/issue/NAN-5854).

## Testing

- Start the webapp on port 3000; start a second instance — confirm Vite auto-selects 3001 and `window._env.apiUrl` equals `http://localhost:3001`
- `REMOTE_API=dev npm run dev -w packages/webapp` — confirm remote API mode still works

<!-- start telescope-canary-packages -->
<!-- end telescope-canary-packages -->