### PR TITLE
feat(webapp): migrate remaining components/ui v1 usages to v2

### DIFF
--- a/packages/webapp/src/components-v2/ui/GoogleButton.tsx
+++ b/packages/webapp/src/components-v2/ui/GoogleButton.tsx
@@ -1,0 +1,69 @@
+import { apiFetch } from '@/utils/api';
+
+import type { PostManagedSignup } from '@nangohq/types';
+
+interface Props {
+    text: string;
+    setServerErrorMessage: (message: string) => void;
+    invitedAccountID?: number;
+    token?: string;
+}
+
+export default function GoogleButton({ text, setServerErrorMessage, token }: Props) {
+    const googleLogin = async () => {
+        const res = await apiFetch(`/api/v1/account/managed/signup`, {
+            method: 'POST',
+            body: JSON.stringify({ provider: 'GoogleOAuth', token })
+        });
+
+        if (res.status === 200) {
+            const data = (await res.json()) as PostManagedSignup['Success'];
+            const { url } = data.data;
+            window.location.href = url;
+        } else if (res != null) {
+            const error = ((await res.json()) as PostManagedSignup['Errors']).error;
+            setServerErrorMessage(error.code);
+        }
+    };
+    return (
+        <button
+            onClick={googleLogin}
+            type="button"
+            className="flex items-center justify-center gap-2.5 p-3 bg-white text-gray-1000 font-roboto font-medium text-sm rounded w-full"
+        >
+            <svg xmlns="http://www.w3.org/2000/svg" width="18px" className="inline" viewBox="0 0 512 512">
+                <path
+                    fill="#fbbd00"
+                    d="M120 256c0-25.367 6.989-49.13 19.131-69.477v-86.308H52.823C18.568 144.703 0 198.922 0 256s18.568 111.297 52.823 155.785h86.308v-86.308C126.989 305.13 120 281.367 120 256z"
+                    data-original="#fbbd00"
+                />
+                <path
+                    fill="#0f9d58"
+                    d="m256 392-60 60 60 60c57.079 0 111.297-18.568 155.785-52.823v-86.216h-86.216C305.044 385.147 281.181 392 256 392z"
+                    data-original="#0f9d58"
+                />
+                <path
+                    fill="#31aa52"
+                    d="m139.131 325.477-86.308 86.308a260.085 260.085 0 0 0 22.158 25.235C123.333 485.371 187.62 512 256 512V392c-49.624 0-93.117-26.72-116.869-66.523z"
+                    data-original="#31aa52"
+                />
+                <path
+                    fill="#3c79e6"
+                    d="M512 256a258.24 258.24 0 0 0-4.192-46.377l-2.251-12.299H256v120h121.452a135.385 135.385 0 0 1-51.884 55.638l86.216 86.216a260.085 260.085 0 0 0 25.235-22.158C485.371 388.667 512 324.38 512 256z"
+                    data-original="#3c79e6"
+                />
+                <path
+                    fill="#cf2d48"
+                    d="m352.167 159.833 10.606 10.606 84.853-84.852-10.606-10.606C388.668 26.629 324.381 0 256 0l-60 60 60 60c36.326 0 70.479 14.146 96.167 39.833z"
+                    data-original="#cf2d48"
+                />
+                <path
+                    fill="#eb4132"
+                    d="M256 120V0C187.62 0 123.333 26.629 74.98 74.98a259.849 259.849 0 0 0-22.158 25.235l86.308 86.308C162.883 146.72 206.376 120 256 120z"
+                    data-original="#eb4132"
+                />
+            </svg>
+            <span className="ml-4">{text}</span>
+        </button>
+    );
+}

--- a/packages/webapp/src/pages/Account/Signin.tsx
+++ b/packages/webapp/src/pages/Account/Signin.tsx
@@ -6,7 +6,7 @@ import { useForm } from 'react-hook-form';
 import { useNavigate, useSearchParams } from 'react-router-dom';
 import z from 'zod';
 
-import GoogleButton from '@/components/ui/button/Auth/Google';
+import GoogleButton from '@/components-v2/ui/GoogleButton';
 import { StyledLink } from '@/components-v2/StyledLink';
 import { Alert, AlertActions, AlertButton, AlertDescription, AlertTitle } from '@/components-v2/ui/alert';
 import { Button } from '@/components-v2/ui/button';

--- a/packages/webapp/src/pages/Account/components/SignupForm.tsx
+++ b/packages/webapp/src/pages/Account/components/SignupForm.tsx
@@ -5,7 +5,7 @@ import { useForm } from 'react-hook-form';
 import { useNavigate } from 'react-router-dom';
 import z from 'zod';
 
-import GoogleButton from '@/components/ui/button/Auth/Google';
+import GoogleButton from '@/components-v2/ui/GoogleButton';
 import { StyledLink } from '@/components-v2/StyledLink';
 import { Alert, AlertActions, AlertButton, AlertDescription, AlertTitle } from '@/components-v2/ui/alert';
 import { Button } from '@/components-v2/ui/button';

--- a/packages/webapp/src/pages/Environment/Settings/components/EditableInput.tsx
+++ b/packages/webapp/src/pages/Environment/Settings/components/EditableInput.tsx
@@ -2,17 +2,16 @@ import { Edit } from 'lucide-react';
 import { useState } from 'react';
 
 import { SimpleTooltip } from '@/components/SimpleTooltip';
-import { CopyButton } from '@/components/ui/button/CopyButton';
-import { Input } from '@/components/ui/input/Input';
+import { CopyButton } from '@/components-v2/CopyButton';
 import { Button } from '@/components-v2/ui/button';
+import { Input } from '@/components-v2/ui/input';
 import { useToast } from '@/hooks/useToast';
 import { cn } from '@/utils/utils';
 
-import type { InputProps } from '@/components/ui/input/Input';
 import type { ApiError } from '@nangohq/types';
-import type { ReactNode } from 'react';
+import type { ComponentProps, ReactNode } from 'react';
 
-interface EditableInputProps extends InputProps {
+interface EditableInputProps extends ComponentProps<typeof Input> {
     title?: string;
     subTitle?: boolean;
     secret?: boolean;
@@ -75,38 +74,32 @@ export const EditableInput: React.FC<EditableInputProps> = ({
                     {title}
                 </label>
             )}
-            <Input
-                inputSize={'lg'}
-                variant={'black'}
-                name={name}
-                value={secret && !edit ? '*'.repeat(value.length) : value}
-                onChange={(e) => setValue(e.target.value)}
-                disabled={loading || !edit}
-                className={cn(error && 'border-alert-400')}
-                after={
-                    !edit && (
-                        <div className="flex">
-                            {secret && (
-                                <div className="py-1">
-                                    <CopyButton text={value} />
-                                </div>
-                            )}
-                            {blocked ? (
-                                <SimpleTooltip tooltipContent={blockedTooltip} side="top" delay={0}>
-                                    <Button variant={'ghost'} size={'sm'} disabled>
-                                        <Edit size={18} />
-                                    </Button>
-                                </SimpleTooltip>
-                            ) : (
-                                <Button variant={'ghost'} size={'sm'} onClick={() => setEdit(true)}>
+            <div className="flex items-center gap-1">
+                <Input
+                    name={name}
+                    value={secret && !edit ? '*'.repeat(value.length) : value}
+                    onChange={(e) => setValue(e.target.value)}
+                    disabled={loading || !edit}
+                    className={cn('flex-1', error && 'border-feedback-error-border')}
+                    {...rest}
+                />
+                {!edit && (
+                    <>
+                        {secret && <CopyButton text={value} />}
+                        {blocked ? (
+                            <SimpleTooltip tooltipContent={blockedTooltip} side="top" delay={0}>
+                                <Button variant={'ghost'} size={'sm'} disabled>
                                     <Edit size={18} />
                                 </Button>
-                            )}
-                        </div>
-                    )
-                }
-                {...rest}
-            />
+                            </SimpleTooltip>
+                        ) : (
+                            <Button variant={'ghost'} size={'sm'} onClick={() => setEdit(true)}>
+                                <Edit size={18} />
+                            </Button>
+                        )}
+                    </>
+                )}
+            </div>
             {error && <div className="text-alert-400 text-s">{error}</div>}
             {edit && editInfo}
             {edit && (

--- a/packages/webapp/src/pages/Team/Billing/components/Plans.tsx
+++ b/packages/webapp/src/pages/Team/Billing/components/Plans.tsx
@@ -5,8 +5,7 @@ import { permissions } from '@nangohq/authz';
 
 import { PaymentMethodDialog } from './PaymentMethodDialog.js';
 import { Dot } from '../../../../components-v2/Dot.js';
-import { DialogClose, DialogContent, DialogDescription, DialogFooter } from '../../../../components-v2/ui/dialog.jsx';
-import { DialogHeader, DialogTitle, DialogTrigger } from '@/components/ui/Dialog.js';
+import { DialogClose, DialogContent, DialogDescription, DialogFooter, DialogHeader, DialogTitle, DialogTrigger } from '../../../../components-v2/ui/dialog.jsx';
 import { PermissionGate } from '@/components-v2/PermissionGate.js';
 import { StyledLink } from '@/components-v2/StyledLink.js';
 import { Alert, AlertDescription } from '@/components-v2/ui/alert.js';


### PR DESCRIPTION
## Problem

The webapp has two parallel UI component directories — `components/ui/` (v1, Radix UI-based) and `components-v2/ui/` (v2, shadcn/ui-based). Four redesigned pages were still importing from v1 despite v2 equivalents existing, and `GoogleButton` had no v2 home yet.

## Solution

Migrates the remaining v1 usages in the 4 files flagged in NAN-5736:

- **Plans.tsx** — consolidated `DialogHeader`, `DialogTitle`, `DialogTrigger` into the existing `@/components-v2/ui/dialog` import (they were split across v1 and v2)
- **EditableInput.tsx** — replaced v1 `Input` + `CopyButton` with v2 equivalents; since v2 `Input` has no `before`/`after` slot props, restructured to a flex wrapper with buttons alongside the input
- **GoogleButton** — added to `components-v2/ui/GoogleButton.tsx` (no v2 equivalent existed)
- **Signin.tsx** + **SignupForm.tsx** — updated `GoogleButton` import to the new v2 location

Note: `components/ui/` cannot be deleted yet — 25 files in legacy pages (Logs, Connection, User Settings, etc.) still import from it. Those need their own redesign issues.

Fixes [NAN-5736](https://linear.app/nango/issue/NAN-5736)

## Testing

- Sign-in page renders correctly (email/password form, no errors)
- Sign-up page renders correctly
- Environment Settings → General: `EditableInput` shows value with copy + edit buttons
- Environment Settings → Backend: `EditableInput` shows Callback URL with copy + edit buttons

🤖 Generated with [Claude Code](https://claude.com/claude-code)