### PR TITLE
fix(proxy): strip framing headers when relaying upstream error responses

### DIFF
--- a/packages/server/lib/controllers/proxy/allProxy.ts
+++ b/packages/server/lib/controllers/proxy/allProxy.ts
@@ -454,6 +454,17 @@ function proxyErrorFromErrorChain(error: unknown): ProxyError | null {
     return null;
 }
 
+function stripFramingHeaders(headers: object): Record<string, unknown> {
+    const result: Record<string, unknown> = {};
+    for (const [key, value] of Object.entries(headers)) {
+        if (key.toLowerCase() === 'transfer-encoding' || key.toLowerCase() === 'content-length') {
+            continue;
+        }
+        result[key] = value;
+    }
+    return result;
+}
+
 export function handleErrorResponse({
     res,
     error,
@@ -505,7 +516,9 @@ export function handleErrorResponse({
         const responseStatus = error.response?.status || 500;
         const responseHeaders = error.response?.headers || {};
 
-        res.status(responseStatus).set(responseHeaders).send(errorObject);
+        res.status(responseStatus)
+            .set(stripFramingHeaders(responseHeaders) as any)
+            .send(errorObject);
 
         return;
     }
@@ -538,7 +551,9 @@ export function handleErrorResponse({
             const responseHeaders = error.response?.headers || {};
             void logCtx.error('Failed with this body', { body: parsedBody });
 
-            res.status(responseStatus).set(responseHeaders).send(data);
+            res.status(responseStatus)
+                .set(stripFramingHeaders(responseHeaders) as any)
+                .send(data);
         });
     }
 }

--- a/packages/server/lib/controllers/proxy/allProxy.unit.test.ts
+++ b/packages/server/lib/controllers/proxy/allProxy.unit.test.ts
@@ -337,6 +337,35 @@ describe('handleErrorResponse', () => {
         );
     });
 
+    it('should strip framing headers from upstream Axios error responses before sending buffered body', () => {
+        const res = {
+            status: vi.fn().mockReturnThis(),
+            send: vi.fn(),
+            set: vi.fn().mockReturnThis(),
+            writeHead: vi.fn()
+        } as unknown as Response;
+        const axiosError = {
+            isAxiosError: true,
+            response: {
+                status: 502,
+                headers: {
+                    'transfer-encoding': 'chunked',
+                    'content-length': '123',
+                    'content-type': 'application/json'
+                }
+            },
+            toJSON: () => ({ message: 'Bad Gateway', config: { method: 'GET' }, code: 'ERR_BAD_RESPONSE', status: 502 })
+        };
+
+        handleErrorResponse({ res, error: axiosError, requestConfig: { url: '/api' }, logCtx: mockLogCtx });
+
+        const headersArg = vi.mocked(res.set).mock.calls[0]![0] as Record<string, string>;
+        const headerKeys = Object.keys(headersArg).map((key) => key.toLowerCase());
+        expect(headerKeys).not.toContain('transfer-encoding');
+        expect(headerKeys).not.toContain('content-length');
+        expect(headersArg).toHaveProperty('content-type', 'application/json');
+    });
+
     it('should use status 500 and full errorObject (message, stack, code, status, url, method) when Axios error has no response.data and toJSON provides stack', () => {
         const res = {
             status: vi.fn().mockReturnThis(),


### PR DESCRIPTION
## Summary

Stop forwarding the upstream `transfer-encoding` and `content-length` headers when relaying a non-success proxy response, so the relayed response no longer carries the RFC 7230 §3.3.2-forbidden combination of both framing headers.

## Why this matters

#6256: on a non-success proxy response, `handleErrorResponse` copied all upstream headers onto the Express response and called `.send()`, which re-buffers the body and adds its own `content-length`. When the upstream error carried `transfer-encoding`, the relayed response ended up with both framing headers at once. RFC 7230 §3.3.2 says they are mutually exclusive, and clients (including axios) reject the combination. The success path already deletes `content-length` for the same buffering reason.

## Changes

- Add a `stripFramingHeaders` helper that removes `transfer-encoding` and `content-length` (case-insensitive) from a copy of the forwarded headers.
- Apply it at both error-response `.set()` sites in `handleErrorResponse`, letting Express compute the correct `content-length` for the buffered body it sends.

## Testing

Added a `handleErrorResponse` unit test asserting the headers passed to `res.set` drop `transfer-encoding` and `content-length` while keeping `content-type`. Ran prettier with the repo config on the changed files (clean); the monorepo CI runs the vitest suite.

Closes #6256
