### PR TITLE
fix(metering): drop records slices when per-connection sum is non-positive

### DIFF
--- a/packages/metering/lib/crons/usage.ts
+++ b/packages/metering/lib/crons/usage.ts
@@ -12,6 +12,7 @@ import { flagHasUsage, getLogger, metrics } from '@nangohq/utils';
 import { envs } from '../env.js';
 
 import type { Lock } from '@nangohq/kvstore';
+import type { RecordCount } from '@nangohq/records';
 import type { RecordsBillingEvent } from '@nangohq/types';
 import type { ClickhouseRawUsageEvent } from '@nangohq/usage';
 
@@ -108,28 +109,39 @@ const usage = {
                         if (recordCounts.isErr()) {
                             throw recordCounts.error;
                         }
-                        for (const recordCount of recordCounts.value) {
+                        // Drop slices whose per-connection sum is <= 0. This mirrors the
+                        // semantics of the HTTP `usageBilling.add` path right below
+                        // (line ~232), where connections with non-positive aggregated
+                        // counts are skipped before the event is emitted. Without the
+                        // same filter here, CH-fed consumers (dashboard / S3 export)
+                        // would expose values Orb has never seen and would shift
+                        // billing on cutover. Root cause of the non-positive counts
+                        // is upstream in `records.paginateCounts` and needs separate
+                        // investigation.
+                        const positiveSlices = filterPositiveConnectionSlices(recordCounts.value);
+                        for (const recordCount of positiveSlices) {
                             const connection = connectionsMap.get(recordCount.connection_id);
-                            if (connection) {
-                                const res = clickhouse.addRaw([
-                                    {
-                                        ts: now.getTime(),
-                                        idempotency_key: uuidv7(),
-                                        type: 'usage.records',
-                                        value: recordCount.count,
-                                        account_id: connection.account.id,
-                                        attributes: {
-                                            environmentId: connection.environment.id,
-                                            integrationId: connection.connection.provider_config_key,
-                                            connectionId: connection.connection.connection_id,
-                                            model: recordCount.model,
-                                            batchId
-                                        }
+                            if (!connection) {
+                                continue;
+                            }
+                            const res = clickhouse.addRaw([
+                                {
+                                    ts: now.getTime(),
+                                    idempotency_key: uuidv7(),
+                                    type: 'usage.records',
+                                    value: recordCount.count,
+                                    account_id: connection.account.id,
+                                    attributes: {
+                                        environmentId: connection.environment.id,
+                                        integrationId: connection.connection.provider_config_key,
+                                        connectionId: connection.connection.connection_id,
+                                        model: recordCount.model,
+                                        batchId
                                     }
-                                ]);
-                                if (res.isErr()) {
-                                    throw res.error;
                                 }
+                            ]);
+                            if (res.isErr()) {
+                                throw res.error;
                             }
                         }
                     }
@@ -312,3 +324,29 @@ const billing = {
         });
     }
 };
+
+/**
+ * Returns the subset of slices whose per-connection sum of `count` is strictly
+ * positive. Slices belonging to a connection with a non-positive aggregate are
+ * dropped entirely (including any positive ones in the same connection), so
+ * the surviving set mirrors the HTTP path's behaviour: a connection is either
+ * fully present (with its model-level granularity intact) or fully absent.
+ *
+ * Exported for unit testing.
+ */
+export function filterPositiveConnectionSlices(slices: RecordCount[]): RecordCount[] {
+    const byConnection = new Map<number, RecordCount[]>();
+    for (const slice of slices) {
+        const bucket = byConnection.get(slice.connection_id) ?? [];
+        bucket.push(slice);
+        byConnection.set(slice.connection_id, bucket);
+    }
+    const out: RecordCount[] = [];
+    for (const bucket of byConnection.values()) {
+        const sum = bucket.reduce((acc, s) => acc + s.count, 0);
+        if (sum > 0) {
+            out.push(...bucket);
+        }
+    }
+    return out;
+}

--- a/packages/metering/lib/crons/usage.unit.test.ts
+++ b/packages/metering/lib/crons/usage.unit.test.ts
@@ -1,0 +1,65 @@
+import { describe, expect, it } from 'vitest';
+
+import { filterPositiveConnectionSlices } from './usage.js';
+
+import type { RecordCount } from '@nangohq/records';
+
+// Locks in the "preserve HTTP-path semantics" decision: a connection is either
+// emitted with its full model-level granularity, or dropped entirely. Mixed-sign
+// slices that net positive must be kept whole; mixed-sign that net non-positive
+// must be dropped whole. Per-slice filtering would over-count mixed-sign
+// connections vs the HTTP path that's been in prod since day one.
+
+function slice(connection_id: number, model: string, count: number): RecordCount {
+    return {
+        model,
+        connection_id,
+        environment_id: 1,
+        count,
+        size_bytes: 0,
+        updated_at: '',
+        autodelete_checked_at: null
+    };
+}
+
+describe('filterPositiveConnectionSlices', () => {
+    it('drops a connection whose slices are all negative', () => {
+        const slices = [slice(1, 'Account', -3), slice(1, 'Contact', -7)];
+        expect(filterPositiveConnectionSlices(slices)).toEqual([]);
+    });
+
+    it('keeps a connection whose slices are all positive (preserves model granularity)', () => {
+        const slices = [slice(1, 'Account', 4), slice(1, 'Contact', 6)];
+        expect(filterPositiveConnectionSlices(slices)).toEqual(slices);
+    });
+
+    it('keeps a mixed-sign connection whose net sum is positive (preserves negative slice)', () => {
+        // (-3, +10) sums to +7. HTTP would emit a `records` event with count=7, so the
+        // CH side has to retain BOTH slices — the dashboard recomputes the net via
+        // SUM(value), which only matches HTTP if the -3 row is still present.
+        const slices = [slice(1, 'Account', -3), slice(1, 'Contact', 10)];
+        expect(filterPositiveConnectionSlices(slices)).toEqual(slices);
+    });
+
+    it('drops a mixed-sign connection whose net sum is non-positive (drops both slices)', () => {
+        const slices = [slice(1, 'Account', -10), slice(1, 'Contact', 3)];
+        expect(filterPositiveConnectionSlices(slices)).toEqual([]);
+    });
+
+    it('drops a connection whose net sum is exactly zero', () => {
+        const slices = [slice(1, 'Account', -5), slice(1, 'Contact', 5)];
+        expect(filterPositiveConnectionSlices(slices)).toEqual([]);
+    });
+
+    it('handles multiple connections independently', () => {
+        const positive = [slice(1, 'Account', 4)];
+        const negative = [slice(2, 'Account', -8), slice(2, 'Contact', 3)];
+        const mixedPositive = [slice(3, 'Account', -1), slice(3, 'Contact', 5)];
+        const result = filterPositiveConnectionSlices([...positive, ...negative, ...mixedPositive]);
+        expect(result).toEqual([...positive, ...mixedPositive]);
+    });
+
+    it('returns an empty array when given no input', () => {
+        expect(filterPositiveConnectionSlices([])).toEqual([]);
+    });
+});


### PR DESCRIPTION
## Summary

- The ClickHouse branch of `cron.exportUsage` now drops `records` slices whose per-connection sum is non-positive, matching the long-standing filter in the HTTP `usageBilling.add` branch right below it. Without this, CH-fed consumers (Get Usage dashboard, S3 → Orb export) surface negative/zero account totals that the HTTP path has never emitted to Orb, which would shift billing on cutover. Production check on `daily_raw_records` for 2026-05-27 found 7 accounts with negative net counts whose Orb event stream has zero events for the same day — confirming the discrepancy is a CH-only artefact.
- Filter operates on the per-connection aggregate, not per-slice, to preserve HTTP semantics: a connection whose model slices net positive is emitted in full (including any negative slice), and a connection whose slices net non-positive is dropped in full. Per-slice filtering would over-count mixed-sign connections vs the HTTP path.
- Root cause of the upstream non-positive counts in `records.paginateCounts` is unknown and tracked separately; this PR only closes the parity gap between the two emission paths.

## Test plan

- [x] `npm run ts-build` clean
- [x] New `usage.unit.test.ts` — 7 cases covering all-negative drop, all-positive keep, mixed-sign positive-sum keep (preserves the negative slice), mixed-sign non-positive drop, exact-zero drop, multi-connection independence, empty input
- [x] Verified the test goes red on a `> 0` → `>= 0` regression in the helper
- [ ] After merge + deploy: confirm next day's `daily_raw_records` has no rows for the 7 accounts previously netting negative, and Orb event counts remain unchanged