### PR TITLE
feat(metering): emit per-run S3 export metric for monitoring

### DIFF
--- a/packages/metering/lib/crons/billingEventsS3Export.ts
+++ b/packages/metering/lib/crons/billingEventsS3Export.ts
@@ -176,6 +176,7 @@ export async function exec(): Promise<void> {
                 return;
             }
             const day = yesterdayUTC();
+            let anyFailure = false;
             try {
                 for (const metric of METRICS) {
                     const eventName = `${metric.canonicalEventName}${eventNameSuffix}`;
@@ -193,12 +194,16 @@ export async function exec(): Promise<void> {
                         logger.info(`Exporting ${eventName} for day=${day}`);
                         await client.command({ query: exportSql({ metric, day, eventName, key }) });
                         logger.info(`Exported ${eventName} for day=${day}`);
-                        metrics.increment(metrics.Types.BILLING_USAGE_CLICKHOUSE_S3_EXPORT_RESULT, 1, { metric: metric.canonicalEventName, success: 'true' });
+                        metrics.increment(metrics.Types.BILLING_USAGE_CLICKHOUSE_S3_EXPORT_FILE_RESULT, 1, {
+                            metric: metric.canonicalEventName,
+                            success: 'true'
+                        });
                     } catch (err) {
                         // Per-metric catch so a single failure (e.g. CH timeout on
                         // a heavy table) does not abort the rest of the run.
+                        anyFailure = true;
                         logger.error(`Failed to export ${eventName} for day=${day} at step=${step}`, err);
-                        metrics.increment(metrics.Types.BILLING_USAGE_CLICKHOUSE_S3_EXPORT_RESULT, 1, {
+                        metrics.increment(metrics.Types.BILLING_USAGE_CLICKHOUSE_S3_EXPORT_FILE_RESULT, 1, {
                             metric: metric.canonicalEventName,
                             success: 'false',
                             step
@@ -211,6 +216,14 @@ export async function exec(): Promise<void> {
                 }
                 logger.info(`✅ done`);
             } finally {
+                // One emit per cron tick so a monitor like
+                // `sum:...run.result{success:false}.as_count() > 3` over a 3h
+                // window reliably counts consecutive failed runs (cron is hourly).
+                // A run is failed if any single metric failed — already-uploaded
+                // skips count as success because that's the self-heal succeeding.
+                metrics.increment(metrics.Types.BILLING_USAGE_CLICKHOUSE_S3_EXPORT_RUN_RESULT, 1, {
+                    success: anyFailure ? 'false' : 'true'
+                });
                 await client.close();
             }
         });

--- a/packages/utils/lib/telemetry/metrics.ts
+++ b/packages/utils/lib/telemetry/metrics.ts
@@ -121,7 +121,8 @@ export enum Types {
     BILLING_USAGE_CLICKHOUSE_BATCHER_INGEST_DURATION_MS = 'nango.billing.usage.clickhouse.batcher.ingest.duration_ms',
     BILLING_USAGE_CLICKHOUSE_BATCHER_INGEST_RESULT = 'nango.billing.usage.clickhouse.batcher.ingest.result',
     BILLING_USAGE_CLICKHOUSE_BATCHER_RETRY = 'nango.billing.usage.clickhouse.batcher.retry',
-    BILLING_USAGE_CLICKHOUSE_S3_EXPORT_RESULT = 'nango.billing.usage.clickhouse.s3_export.result',
+    BILLING_USAGE_CLICKHOUSE_S3_EXPORT_FILE_RESULT = 'nango.billing.usage.clickhouse.s3_export.file.result',
+    BILLING_USAGE_CLICKHOUSE_S3_EXPORT_RUN_RESULT = 'nango.billing.usage.clickhouse.s3_export.run.result',
     BILLING_USAGE_CLICKHOUSE_S3_EXPORT_DURATION_MS = 'nango.billing.usage.clickhouse.s3_export.duration_ms',
 
     USAGE_IS_CAPPED = 'nango.capping.isCapped',


### PR DESCRIPTION
## Summary

- Adds `nango.billing.usage.clickhouse.s3_export.run.result` with tag `{success: true|false}`, emitted exactly once per cron tick (in the `finally` of `exec()`). The existing per-file counter could not back a simple "alert if > N failed runs in 3h" monitor because its `metric` cardinality conflates partial-failure runs with full-failure runs; the per-run counter is one row per tick, so the self-healing window (cron is hourly, so 3 ticks ≈ 3h) is directly observable. Monitor query: `sum:nango.billing.usage.clickhouse.s3_export.run.result{success:false}.as_count() > 3` over rolling 3h.
- Renames `nango.billing.usage.clickhouse.s3_export.result` → `…s3_export.file.result` (tags `{metric, success, step}` unchanged). Hard cut, not dual-emit — the original metric is two weeks old and only used in this team's dashboards.

A run is marked failed if any single file failed; already-uploaded skips count as success (that path is the self-heal succeeding).

## Test plan

- [x] `npm run ts-build` clean
- [ ] Update any DD dashboard/monitor that references the old `.s3_export.result` name to use `.s3_export.file.result`
- [ ] After deploy: confirm `.s3_export.run.result` appears in DD with one emit per hour, and set up the > 3 failures / 3h monitor