### PR TITLE
test(scheduler): test(scheduler): close integration coverage gaps

### DIFF
--- a/packages/scheduler/lib/daemons/scheduling/scheduling.integration.test.ts
+++ b/packages/scheduler/lib/daemons/scheduling/scheduling.integration.test.ts
@@ -1,11 +1,15 @@
 import { uuidv7 } from 'uuidv7';
 import { afterEach, beforeEach, describe, expect, it } from 'vitest';
 
+import { SchedulingDaemon } from './scheduling.daemon.js';
 import { dueSchedules } from './scheduling.js';
+import { DatabaseClient } from '../../db/client.js';
 import { getTestDbClient } from '../../db/helpers.test.js';
+import { envs } from '../../env.js';
 import { DbSchedule, SCHEDULES_TABLE } from '../../models/schedules.js';
 import * as schedules from '../../models/schedules.js';
 import { DbTask, TASKS_TABLE } from '../../models/tasks.js';
+import * as tasks from '../../models/tasks.js';
 
 import type { DBTask } from '../../models/tasks.js';
 import type { Schedule, ScheduleState, Task, TaskState } from '../../types.js';
@@ -85,6 +89,40 @@ describe('dueSchedules', () => {
         const due = await dueSchedules(db);
         expect(due.isOk()).toBe(true);
         expect(due.unwrap().length).toBe(1);
+    });
+});
+
+describe('SchedulingDaemon', () => {
+    // Dedicated schema: running the daemon against the shared 'scheduler' schema races with the
+    // looping daemons in scheduler.integration.test.ts via SKIP LOCKED.
+    const dbClient = new DatabaseClient({
+        url: `postgres://${process.env['NANGO_DB_USER']}:${process.env['NANGO_DB_PASSWORD']}@${process.env['NANGO_DB_HOST']}:${process.env['NANGO_DB_PORT']}/${process.env['NANGO_DB_NAME']}`,
+        schema: 'scheduler_daemon'
+    });
+    const db = dbClient.db;
+
+    beforeEach(async () => {
+        await dbClient.migrate();
+    });
+
+    afterEach(async () => {
+        await dbClient.clearDatabase();
+    });
+
+    it('should stamp materialized tasks with SYNC_ENVIRONMENT_MAX_CONCURRENCY', async () => {
+        const schedule = await addSchedule(db);
+        const daemon = new SchedulingDaemon({
+            db,
+            abortSignal: new AbortController().signal,
+            onScheduling: () => {},
+            onError: () => {}
+        });
+
+        await daemon.run();
+
+        const created = (await tasks.search(db, { scheduleId: schedule.id })).unwrap();
+        expect(created).toHaveLength(1);
+        expect(created[0]?.groupMaxConcurrency).toBe(envs.SYNC_ENVIRONMENT_MAX_CONCURRENCY);
     });
 });
 

--- a/packages/scheduler/lib/models/schedules.integration.test.ts
+++ b/packages/scheduler/lib/models/schedules.integration.test.ts
@@ -121,6 +121,16 @@ describe('Schedules', () => {
         // The next execution should be set to the next due date based on the frequency
         expect(updated?.nextExecutionAt).toBeWithinMs(new Date(schedule.startsAt.getTime() + schedule.frequencyMs), 3_000);
     });
+    it('should hard-delete schedules deleted longer than N days ago', async () => {
+        const schedule = await createSchedule(db);
+        await schedules.remove(db, schedule.id);
+        const twoDaysAgo = new Date(Date.now() - 2 * 24 * 60 * 60 * 1000);
+        await db.from('schedules').where('id', schedule.id).update({ deleted_at: twoDaysAgo });
+
+        const deleted = (await schedules.hardDeleteOlderThanNDays(db, 1)).unwrap();
+
+        expect(deleted.map((s) => s.id)).toContain(schedule.id);
+    });
     it('should override next execution when nextExecutionInMs is provided', async () => {
         const schedule = await createSchedule(db);
         const taskId = uuidv7();

--- a/packages/scheduler/lib/models/tasks.integration.test.ts
+++ b/packages/scheduler/lib/models/tasks.integration.test.ts
@@ -335,6 +335,19 @@ describe('Task', () => {
             expect(result).toEqual([]);
         });
     });
+    it('should hard-delete terminated tasks older than N days and keep newer ones', async () => {
+        const twoDaysAgo = new Date(Date.now() - 2 * 24 * 60 * 60 * 1000);
+        const oldTask = await createTask(db, { startsAfter: twoDaysAgo });
+        (await tasks.transitionState(db, { taskId: oldTask.id, newState: 'STARTED' })).unwrap();
+        (await tasks.transitionState(db, { taskId: oldTask.id, newState: 'SUCCEEDED', output: {} })).unwrap();
+        const newTask = await createTaskWithState(db, 'SUCCEEDED');
+
+        (await tasks.hardDeleteOlderThanNDays(db, 1)).unwrap();
+
+        const remaining = (await tasks.search(db)).unwrap().map((t) => t.id);
+        expect(remaining).toContain(newTask.id);
+        expect(remaining).not.toContain(oldTask.id);
+    });
     it('should be successfully saving json output', async () => {
         const outputs = [1, 'one', true, null, ['a', 'b'], { a: 1, b: 2, s: 'two', arr: ['a', 'b'] }, [{ id: 'a' }, { id: 'b' }]];
         for (const output of outputs) {

--- a/packages/scheduler/lib/scheduler.integration.test.ts
+++ b/packages/scheduler/lib/scheduler.integration.test.ts
@@ -220,6 +220,11 @@ describe('Scheduler', () => {
         await immediate(scheduler, { schedule }); // first task: OK
         await expect(immediate(scheduler, { schedule })).rejects.toThrow();
     });
+    it('should create an uncapped task when immediate is called for a schedule', async () => {
+        const schedule = await recurring({ scheduler });
+        const task = await immediate(scheduler, { schedule });
+        expect(task.groupMaxConcurrency).toBe(0);
+    });
     it('should change schedule state', async () => {
         const paused = await recurring({ scheduler, state: 'PAUSED' });
         expect(paused.state).toBe('PAUSED');


### PR DESCRIPTION
Next PR will remove the "ORCH_*"  env vars and the ORCH metrics from the scheduler. Thought I'd be extra safe and cover any test coverage gaps before doing it.