### PR TITLE
feat(usage): CH-backed /plans/billing-usage (per-request override behind a dev gate)

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -6799,9 +6799,6 @@
                 "arm64"
             ],
             "dev": true,
-            "libc": [
-                "glibc"
-            ],
             "license": "MIT",
             "optional": true,
             "os": [
@@ -6819,9 +6816,6 @@
                 "arm64"
             ],
             "dev": true,
-            "libc": [
-                "musl"
-            ],
             "license": "MIT",
             "optional": true,
             "os": [
@@ -6839,9 +6833,6 @@
                 "ppc64"
             ],
             "dev": true,
-            "libc": [
-                "glibc"
-            ],
             "license": "MIT",
             "optional": true,
             "os": [
@@ -6859,9 +6850,6 @@
                 "riscv64"
             ],
             "dev": true,
-            "libc": [
-                "glibc"
-            ],
             "license": "MIT",
             "optional": true,
             "os": [
@@ -6879,9 +6867,6 @@
                 "riscv64"
             ],
             "dev": true,
-            "libc": [
-                "musl"
-            ],
             "license": "MIT",
             "optional": true,
             "os": [
@@ -6899,9 +6884,6 @@
                 "s390x"
             ],
             "dev": true,
-            "libc": [
-                "glibc"
-            ],
             "license": "MIT",
             "optional": true,
             "os": [
@@ -6919,9 +6901,6 @@
                 "x64"
             ],
             "dev": true,
-            "libc": [
-                "glibc"
-            ],
             "license": "MIT",
             "optional": true,
             "os": [
@@ -6939,9 +6918,6 @@
                 "x64"
             ],
             "dev": true,
-            "libc": [
-                "musl"
-            ],
             "license": "MIT",
             "optional": true,
             "os": [
@@ -7177,9 +7153,6 @@
                 "arm64"
             ],
             "dev": true,
-            "libc": [
-                "glibc"
-            ],
             "license": "MIT",
             "optional": true,
             "os": [
@@ -7194,9 +7167,6 @@
                 "arm64"
             ],
             "dev": true,
-            "libc": [
-                "musl"
-            ],
             "license": "MIT",
             "optional": true,
             "os": [
@@ -7211,9 +7181,6 @@
                 "ppc64"
             ],
             "dev": true,
-            "libc": [
-                "glibc"
-            ],
             "license": "MIT",
             "optional": true,
             "os": [
@@ -7228,9 +7195,6 @@
                 "riscv64"
             ],
             "dev": true,
-            "libc": [
-                "glibc"
-            ],
             "license": "MIT",
             "optional": true,
             "os": [
@@ -7245,9 +7209,6 @@
                 "riscv64"
             ],
             "dev": true,
-            "libc": [
-                "musl"
-            ],
             "license": "MIT",
             "optional": true,
             "os": [
@@ -7262,9 +7223,6 @@
                 "s390x"
             ],
             "dev": true,
-            "libc": [
-                "glibc"
-            ],
             "license": "MIT",
             "optional": true,
             "os": [
@@ -7279,9 +7237,6 @@
                 "x64"
             ],
             "dev": true,
-            "libc": [
-                "glibc"
-            ],
             "license": "MIT",
             "optional": true,
             "os": [
@@ -7296,9 +7251,6 @@
                 "x64"
             ],
             "dev": true,
-            "libc": [
-                "musl"
-            ],
             "license": "MIT",
             "optional": true,
             "os": [
@@ -34782,22 +34734,6 @@
             "optional": true,
             "os": [
                 "netbsd"
-            ],
-            "engines": {
-                "node": ">=18"
-            }
-        },
-        "node_modules/tsup/node_modules/@esbuild/linux-x64": {
-            "version": "0.27.3",
-            "resolved": "https://registry.npmjs.org/@esbuild/linux-x64/-/linux-x64-0.27.3.tgz",
-            "integrity": "sha512-Czi8yzXUWIQYAtL/2y6vogER8pvcsOsk5cpwL4Gk5nJqH5UZiVByIY8Eorm5R13gq+DQKYg0+JyQoytLQas4dA==",
-            "cpu": [
-                "x64"
-            ],
-            "license": "MIT",
-            "optional": true,
-            "os": [
-                "linux"
             ],
             "engines": {
                 "node": ">=18"

--- a/packages/server/lib/controllers/v1/plans/usage/getBillingUsage.ts
+++ b/packages/server/lib/controllers/v1/plans/usage/getBillingUsage.ts
@@ -73,7 +73,7 @@ export const getBillingUsage = asyncWrapper<GetBillingUsage>(async (req, res) =>
         return;
     }
 
-    const usage = await usageTracker.getBillingUsage(plan.orb_subscription_id, {
+    const usage = await usageTracker.getBillingUsage(plan.orb_subscription_id, account.id, {
         granularity: 'day',
         ...(query.from && query.to ? { timeframe: { start: new Date(query.from), end: new Date(query.to) } } : {})
     });

--- a/packages/server/lib/controllers/v1/plans/usage/getBillingUsage.ts
+++ b/packages/server/lib/controllers/v1/plans/usage/getBillingUsage.ts
@@ -14,7 +14,12 @@ const querySchema = z
     .object({
         env: z.string(),
         from: z.iso.datetime().optional(),
-        to: z.iso.datetime().optional()
+        to: z.iso.datetime().optional(),
+        // Per-request override of the USAGE_BILLING_FROM_CLICKHOUSE default,
+        // for dev-tools flipping without a redeploy. Webapp picks it up from
+        // localStorage('nango.billingUsageSource') and forwards. Missing
+        // → falls back to the env flag.
+        source: z.enum(['clickhouse', 'orb']).optional()
     })
     .refine(
         (data) => {
@@ -75,7 +80,8 @@ export const getBillingUsage = asyncWrapper<GetBillingUsage>(async (req, res) =>
 
     const usage = await usageTracker.getBillingUsage(plan.orb_subscription_id, account.id, {
         granularity: 'day',
-        ...(query.from && query.to ? { timeframe: { start: new Date(query.from), end: new Date(query.to) } } : {})
+        ...(query.from && query.to ? { timeframe: { start: new Date(query.from), end: new Date(query.to) } } : {}),
+        ...(query.source ? { source: query.source } : {})
     });
 
     if (usage.isErr()) {

--- a/packages/server/lib/controllers/v1/plans/usage/getBillingUsage.ts
+++ b/packages/server/lib/controllers/v1/plans/usage/getBillingUsage.ts
@@ -15,10 +15,11 @@ const querySchema = z
         env: z.string(),
         from: z.iso.datetime().optional(),
         to: z.iso.datetime().optional(),
-        // Per-request override of the USAGE_BILLING_FROM_CLICKHOUSE default,
-        // for dev-tools flipping without a redeploy. Webapp picks it up from
-        // localStorage('nango.billingUsageSource') and forwards. Missing
-        // → falls back to the env flag.
+        // Per-request dashboard backend override. Webapp picks it up from
+        // localStorage('nango.billingUsageSource') and forwards. Honoured
+        // server-side only when ALLOW_OVERRIDE_GETUSAGE_SERVICE is on (dev
+        // gate). Without the gate, this is ignored and the dashboard stays
+        // on Orb.
         source: z.enum(['clickhouse', 'orb']).optional()
     })
     .refine(

--- a/packages/types/lib/billing/types.ts
+++ b/packages/types/lib/billing/types.ts
@@ -76,6 +76,12 @@ export interface GetBillingUsageOpts {
         id: string;
         group_by?: 'environmentId' | 'environmentName' | 'integrationId' | 'type' | 'functionName' | 'model';
     };
+    /**
+     * Per-request override of the env-level `USAGE_BILLING_FROM_CLICKHOUSE`
+     * default. Only used by `UsageTracker.getBillingUsage`; the Orb client
+     * itself ignores it. Lets dev tools flip between paths without redeploy.
+     */
+    source?: 'clickhouse' | 'orb';
 }
 
 export interface BillingUsageMetric {

--- a/packages/types/lib/billing/types.ts
+++ b/packages/types/lib/billing/types.ts
@@ -77,9 +77,10 @@ export interface GetBillingUsageOpts {
         group_by?: 'environmentId' | 'environmentName' | 'integrationId' | 'type' | 'functionName' | 'model';
     };
     /**
-     * Per-request override of the env-level `USAGE_BILLING_FROM_CLICKHOUSE`
-     * default. Only used by `UsageTracker.getBillingUsage`; the Orb client
-     * itself ignores it. Lets dev tools flip between paths without redeploy.
+     * Per-request override of the dashboard backend source. Honoured only
+     * when `ALLOW_OVERRIDE_GETUSAGE_SERVICE` is enabled (dev gate); ignored
+     * everywhere else, so the default stays Orb. Only used by
+     * `UsageTracker.getBillingUsage`; the Orb client itself ignores it.
      */
     source?: 'clickhouse' | 'orb';
 }

--- a/packages/types/lib/plans/http.api.ts
+++ b/packages/types/lib/plans/http.api.ts
@@ -1,8 +1,8 @@
+import type { DBPlan } from './db.js';
+import type { Endpoint } from '../api.js';
 import type { ApiBillingUsageMetrics, BillingCustomer, BillingInvoicingDetails } from '../billing/types.js';
 import type { MetricUsageSummary, UsageMetric } from '../usage/index.js';
 import type { ReplaceInObject } from '../utils.js';
-import type { DBPlan } from './db.js';
-import type { Endpoint } from '../api.js';
 
 export type ApiPlan = ReplaceInObject<DBPlan, Date, string>;
 
@@ -62,7 +62,7 @@ export type GetUsage = Endpoint<{
 export type GetBillingUsage = Endpoint<{
     Method: 'GET';
     Path: '/api/v1/plans/billing-usage';
-    Querystring: { env: string; from?: string | undefined; to?: string | undefined };
+    Querystring: { env: string; from?: string | undefined; to?: string | undefined; source?: 'clickhouse' | 'orb' | undefined };
     Success: {
         data: {
             customer: BillingCustomer;

--- a/packages/usage/lib/clickhouse/clickhouse.integration.test.ts
+++ b/packages/usage/lib/clickhouse/clickhouse.integration.test.ts
@@ -114,32 +114,9 @@ describe('Clickhouse', () => {
                 };
                 expect(res.unwrap()).toStrictEqual(expected);
             });
-            it('for a cumulative metric', async () => {
-                const res = await clickhouse.getUsage({
-                    accountId,
-                    metrics: { connections: { dimension: 'none' } },
-                    granularity: 'none',
-                    timeframe: { start, end }
-                });
-                const expected = {
-                    accountId: accountId,
-                    granularity: 'none',
-                    metrics: {
-                        connections: {
-                            series: [
-                                {
-                                    // (day0=70 + day1=10) / 7 days = 11
-                                    dataPoints: [{ timeframe: { start, end }, quantity: 11 }],
-                                    total: 11
-                                }
-                            ],
-                            total: 11,
-                            view_mode: 'cumulative'
-                        }
-                    }
-                };
-                expect(res.unwrap()).toStrictEqual(expected);
-            });
+            // The cumulative-metric case (records / connections) is covered by the
+            // `getDailySumAndBatches` describe block below — `getUsage` no longer
+            // accepts those metrics.
         });
 
         describe('with day granularity', () => {
@@ -245,9 +222,7 @@ describe('Clickhouse', () => {
                         function_executions: { dimension: 'function_type' },
                         function_logs: { dimension: 'none' },
                         function_compute_gbms: { dimension: 'none' },
-                        webhook_forwards: { dimension: 'none' },
-                        connections: { dimension: 'none' },
-                        records: { dimension: 'integration_id' }
+                        webhook_forwards: { dimension: 'none' }
                     },
                     granularity: 'day',
                     timeframe: { start, end }
@@ -345,49 +320,123 @@ describe('Clickhouse', () => {
                             ],
                             total: 9,
                             view_mode: 'periodic'
-                        },
-                        // connections
-                        connections: {
-                            series: [
-                                {
-                                    dataPoints: [
-                                        { timeframe: { start: dayFromNow(), end: dayFromNow(1) }, quantity: 70 },
-                                        { timeframe: { start: dayFromNow(1), end: dayFromNow(2) }, quantity: 10 }
-                                    ],
-                                    total: 11
-                                }
-                            ],
-                            total: 11,
-                            view_mode: 'cumulative'
-                        },
-                        // records
-                        records: {
-                            series: [
-                                {
-                                    dimension: 'integration_id',
-                                    dimensionValue: 'a',
-                                    dataPoints: [
-                                        { timeframe: { start: dayFromNow(), end: dayFromNow(1) }, quantity: 1050 },
-                                        { timeframe: { start: dayFromNow(1), end: dayFromNow(2) }, quantity: 1100 }
-                                    ],
-                                    total: 307
-                                },
-                                {
-                                    dimension: 'integration_id',
-                                    dimensionValue: 'b',
-                                    dataPoints: [
-                                        { timeframe: { start: dayFromNow(), end: dayFromNow(1) }, quantity: 500 },
-                                        { timeframe: { start: dayFromNow(1), end: dayFromNow(2) }, quantity: 500 }
-                                    ],
-                                    total: 143
-                                }
-                            ],
-                            total: 450,
-                            view_mode: 'cumulative'
                         }
                     }
                 };
                 expect(res.unwrap()).toStrictEqual(expected);
+            });
+        });
+
+        // Per-day (sum, batches) shape for AVG-style metrics. The running-period-average
+        // + delta math that turns this into Orb's `view_mode='cumulative'` wire shape
+        // lives in the server-side formatter (separate ticket); this method only
+        // exposes the two accumulators the formatter needs.
+        //
+        // For the dimension breakdown, `batches` is the GLOBAL per-day batch count
+        // (same for every dim value) so per-dim running averages are additive to
+        // the no-dim global running average — see method docstring for rationale.
+        //
+        // Fixture recap (account 1):
+        //   day 0 records: value=1000 (int=a), 1100 (int=a), 500 (int=b)
+        //                  → sum=2600, 3 distinct batches global
+        //                    per-int=a: sum=2100, per-int=b: sum=500; batches=3 for both
+        //   day 1 records: value=1100 (int=a), 500 (int=b)
+        //                  → sum=1600, 2 distinct batches global
+        //                    per-int=a: sum=1100, per-int=b: sum=500; batches=2 for both
+        //   day 0 connections: value=50, 60, 100 (each its own batch)
+        //                  → sum=210, batches=3
+        //   day 1 connections: value=20, 10, 0
+        //                  → sum=30,  batches=3
+        describe('getDailySumAndBatches', () => {
+            it('records, no dimension', async () => {
+                const res = await clickhouse.getDailySumAndBatches({
+                    accountId,
+                    metric: 'records',
+                    dimension: 'none',
+                    timeframe: { start, end }
+                });
+                expect(res.unwrap()).toStrictEqual({
+                    accountId,
+                    metric: 'records',
+                    series: [
+                        {
+                            days: [
+                                { day: dayFromNow(), sum: 2600, batches: 3 },
+                                { day: dayFromNow(1), sum: 1600, batches: 2 }
+                            ]
+                        }
+                    ]
+                });
+            });
+
+            it('records, broken down by integration_id — batches is global per-day (additive to no-dim)', async () => {
+                const res = await clickhouse.getDailySumAndBatches({
+                    accountId,
+                    metric: 'records',
+                    dimension: 'integration_id',
+                    timeframe: { start, end }
+                });
+                expect(res.unwrap()).toStrictEqual({
+                    accountId,
+                    metric: 'records',
+                    series: [
+                        {
+                            dimension: 'integration_id',
+                            dimensionValue: 'a',
+                            days: [
+                                { day: dayFromNow(), sum: 2100, batches: 3 },
+                                { day: dayFromNow(1), sum: 1100, batches: 2 }
+                            ]
+                        },
+                        {
+                            dimension: 'integration_id',
+                            dimensionValue: 'b',
+                            days: [
+                                { day: dayFromNow(), sum: 500, batches: 3 },
+                                { day: dayFromNow(1), sum: 500, batches: 2 }
+                            ]
+                        }
+                    ]
+                });
+            });
+
+            it('connections, no dimension', async () => {
+                const res = await clickhouse.getDailySumAndBatches({
+                    accountId,
+                    metric: 'connections',
+                    dimension: 'none',
+                    timeframe: { start, end }
+                });
+                expect(res.unwrap()).toStrictEqual({
+                    accountId,
+                    metric: 'connections',
+                    series: [
+                        {
+                            days: [
+                                { day: dayFromNow(), sum: 210, batches: 3 },
+                                { day: dayFromNow(1), sum: 30, batches: 3 }
+                            ]
+                        }
+                    ]
+                });
+            });
+
+            it('excludes events outside the timeframe and from other accounts', async () => {
+                const res = await clickhouse.getDailySumAndBatches({
+                    accountId,
+                    metric: 'records',
+                    dimension: 'none',
+                    timeframe: { start: dayFromNow(1), end: dayFromNow(2) }
+                });
+                expect(res.unwrap()).toStrictEqual({
+                    accountId,
+                    metric: 'records',
+                    series: [
+                        {
+                            days: [{ day: dayFromNow(1), sum: 1600, batches: 2 }]
+                        }
+                    ]
+                });
             });
         });
     });

--- a/packages/usage/lib/clickhouse/clickhouse.query.ts
+++ b/packages/usage/lib/clickhouse/clickhouse.query.ts
@@ -1,7 +1,18 @@
 import type { UsageEvent, UsageMetric } from '@nangohq/types';
 
+// Top-N + 'rest' breakdown: any dimension query is collapsed to the top N
+// dimension values (by SUM of the metric's quantity over the window) plus a
+// single 'rest' bucket aggregating the long tail. Cap exists so callers can't
+// blow up the response — the long tail can be tens of thousands of values
+// (e.g., `records` by `connection_id` on the doomsday account).
+export const TOP_N_BREAKDOWN_DEFAULT = 10;
+export const TOP_N_BREAKDOWN_CAP = 25;
+
 interface GetUsageQueryMetricDimensions<TDimension extends string = 'none'> {
     dimension: 'none' | 'environment_id' | 'integration_id' | TDimension;
+    // Optional override for the top-N breakdown size when `dimension !== 'none'`.
+    // Defaults to TOP_N_BREAKDOWN_DEFAULT, clamped server-side to TOP_N_BREAKDOWN_CAP.
+    top?: number;
 }
 
 // `getUsage` covers counter metrics only — the SUM-aggregated tables that don't
@@ -143,6 +154,9 @@ export type GetDailySumAndBatchesQuery =
           accountId: number;
           metric: 'records';
           dimension: 'none' | 'environment_id' | 'integration_id' | 'connection_id' | 'model';
+          // Optional top-N breakdown size when `dimension !== 'none'`. Defaults to
+          // TOP_N_BREAKDOWN_DEFAULT, clamped server-side to TOP_N_BREAKDOWN_CAP.
+          top?: number;
           timeframe: {
               // exclusive end (timeframe includes events with timestamp >= start and < end)
               start: Date;
@@ -153,6 +167,7 @@ export type GetDailySumAndBatchesQuery =
           accountId: number;
           metric: 'connections';
           dimension: 'none' | 'environment_id' | 'integration_id';
+          top?: number;
           timeframe: { start: Date; end: Date };
       };
 

--- a/packages/usage/lib/clickhouse/clickhouse.query.ts
+++ b/packages/usage/lib/clickhouse/clickhouse.query.ts
@@ -4,11 +4,16 @@ interface GetUsageQueryMetricDimensions<TDimension extends string = 'none'> {
     dimension: 'none' | 'environment_id' | 'integration_id' | TDimension;
 }
 
-type ValidateMetrics<T extends Record<UsageMetric, unknown> & Record<Exclude<keyof T, UsageMetric>, never>> = T;
+// `getUsage` covers counter metrics only — the SUM-aggregated tables that don't
+// carry a `batch_id` column. AVG-style metrics (`records`, `connections`) are
+// served by `getDailySumAndBatches`, which exposes the two accumulators their
+// `view_mode='cumulative'` rendering needs and isn't expressible in this query
+// shape.
+export type CounterUsageMetric = Exclude<UsageMetric, 'records' | 'connections'>;
+
+type ValidateMetrics<T extends Record<CounterUsageMetric, unknown> & Record<Exclude<keyof T, CounterUsageMetric>, never>> = T;
 
 type GetUsageQueryMetrics = ValidateMetrics<{
-    connections: GetUsageQueryMetricDimensions;
-    records: GetUsageQueryMetricDimensions<'connection_id' | 'model'>;
     proxy: GetUsageQueryMetricDimensions<'connection_id' | 'success'>;
     webhook_forwards: GetUsageQueryMetricDimensions<'connection_id' | 'success'>;
     function_executions: GetUsageQueryMetricDimensions<'connection_id' | 'function_name' | 'function_type' | 'success'>;
@@ -98,7 +103,10 @@ export function tableForMetric(metric: UsageMetric): string {
     }
 }
 
-export function quantityForMetric(metric: UsageMetric): string {
+// Counter metrics only — AVG-style metrics (`records`, `connections`) are not
+// reachable through `getUsage` (excluded from `GetUsageQuery.metrics` at the
+// type level) and use `getDailySumAndBatches` instead.
+export function quantityForMetric(metric: CounterUsageMetric): string {
     switch (metric) {
         case 'function_executions':
         case 'proxy':
@@ -108,10 +116,58 @@ export function quantityForMetric(metric: UsageMetric): string {
             return `SUM(custom_logs)`;
         case 'function_compute_gbms':
             return `SUM(compute_gbms)`;
-        case 'records':
-        case 'connections':
-            // Records and connections build their own SQL in `clickhouse.ts` (three-level
-            // sum-then-avg over the raw projection MVs). This branch isn't reached for them.
-            return `SUM(value)`;
     }
+}
+
+// ----------------------------------------------------------------------------
+// Per-day (sum, batches) accumulators for AVG-style metrics — `records` and
+// `connections` only, which are the two metrics whose write path tags each
+// metering-cron firing with a `batch_id` column (one batch = one Orb event in
+// the `average(count)` billable metric). Other metrics live in counter tables
+// that lack `batch_id` and don't need this shape, so the type is intentionally
+// restricted at compile time.
+//
+// Returns the two accumulators the server-side formatter needs to reconstruct
+// the running period average for `view_mode='cumulative'`:
+//   running_avg(D) = SUM(value)[start..D] / uniqExact(batch_id)[start..D]
+//
+// `batches` is the number of distinct `batch_id`s for the day (NOT the row
+// count — each batch contributes multiple rows, one per slice). For the
+// dimension breakdown, `batches` is the GLOBAL per-day count (same for every
+// dimension value) so per-dimension running averages sum to the global
+// running average exactly — see Clickhouse.getDailySumAndBatches docstring.
+// ----------------------------------------------------------------------------
+
+export type GetDailySumAndBatchesQuery =
+    | {
+          accountId: number;
+          metric: 'records';
+          dimension: 'none' | 'environment_id' | 'integration_id' | 'connection_id' | 'model';
+          timeframe: {
+              // exclusive end (timeframe includes events with timestamp >= start and < end)
+              start: Date;
+              end: Date;
+          };
+      }
+    | {
+          accountId: number;
+          metric: 'connections';
+          dimension: 'none' | 'environment_id' | 'integration_id';
+          timeframe: { start: Date; end: Date };
+      };
+
+export interface GetDailySumAndBatchesDay {
+    day: Date;
+    sum: number;
+    batches: number;
+}
+
+export type GetDailySumAndBatchesSeries =
+    | { days: GetDailySumAndBatchesDay[] }
+    | { dimension: string; dimensionValue: string | number | boolean; days: GetDailySumAndBatchesDay[] };
+
+export interface GetDailySumAndBatchesResult {
+    accountId: number;
+    metric: 'records' | 'connections';
+    series: GetDailySumAndBatchesSeries[];
 }

--- a/packages/usage/lib/clickhouse/clickhouse.ts
+++ b/packages/usage/lib/clickhouse/clickhouse.ts
@@ -1,7 +1,15 @@
 import { ENVS, Err, Ok, parseEnvs, stringifyError } from '@nangohq/utils';
 
 import { Batcher } from './batcher.js';
-import { granularityGroupBy, granularityOrderBy, quantityForMetric, startSelect, tableForMetric } from './clickhouse.query.js';
+import {
+    TOP_N_BREAKDOWN_CAP,
+    TOP_N_BREAKDOWN_DEFAULT,
+    granularityGroupBy,
+    granularityOrderBy,
+    quantityForMetric,
+    startSelect,
+    tableForMetric
+} from './clickhouse.query.js';
 import { clickhouseClient, database as usageDatabase } from './config.js';
 import { logger } from '../logger.js';
 
@@ -115,23 +123,43 @@ export class Clickhouse {
         }
 
         try {
+            const startDate = query.timeframe.start.toISOString().split('T')[0];
+            const endDate = query.timeframe.end.toISOString().split('T')[0];
             const qs = (Object.keys(query.metrics) as CounterUsageMetric[]).map(async (metric) => {
-                const dimension = query.metrics[metric]?.dimension || 'none';
-                const dimensionColumn = dimension === 'none' ? "'none'" : dimension; // quoted 'none' to be used directly in SQL queries as a string literal when no dimension is needed
-                const dimensionSelect = `, ${dimensionColumn}`;
-                const dimensionGroupBy = dimensionColumn ? `, ${dimensionColumn}` : '';
-                const dimensionOrderBy = dimensionColumn ? `, ${dimensionColumn}` : '';
+                const metricCfg = query.metrics[metric];
+                const dimension = metricCfg?.dimension || 'none';
+                const table = `${this.database}.${tableForMetric(metric)}`;
+                // Dimension breakdown is always top-N + 'rest' bounded. `top_dims` picks the
+                // top N dimension values by total SUM across the window; anything outside
+                // collapses into a single 'rest' bucket. When dimension === 'none' we emit
+                // the literal 'none' so a single series falls out of the same machinery.
+                const dimensionValueExpr = dimension === 'none' ? `'none'` : `IF(${dimension} IN (SELECT dim FROM top_dims), toString(${dimension}), 'rest')`;
+                const top = Math.min(metricCfg?.top ?? TOP_N_BREAKDOWN_DEFAULT, TOP_N_BREAKDOWN_CAP);
+                const topDimsCte =
+                    dimension === 'none'
+                        ? ''
+                        : `WITH top_dims AS (
+                            SELECT ${dimension} AS dim, ${quantityForMetric(metric)} AS total
+                            FROM ${table}
+                            WHERE account_id = ${query.accountId}
+                              AND day >= toDate('${startDate}')
+                              AND day < toDate('${endDate}')
+                            GROUP BY ${dimension}
+                            ORDER BY total DESC
+                            LIMIT ${top}
+                        )`;
                 const sql = `
+                    ${topDimsCte}
                     SELECT
                         ${quantityForMetric(metric)} AS quantity,
-                        ${startSelect(query)}
-                        ${dimensionSelect} AS dimension
-                    FROM ${this.database}.${tableForMetric(metric)}
+                        ${startSelect(query)},
+                        ${dimensionValueExpr} AS dimension
+                    FROM ${table}
                     WHERE account_id = ${query.accountId}
-                    AND day >= toDate('${query.timeframe.start.toISOString().split('T')[0]}')
-                    AND day < toDate('${query.timeframe.end.toISOString().split('T')[0]}')
-                    GROUP BY account_id ${granularityGroupBy(query)} ${dimensionGroupBy}
-                    ORDER BY account_id ${granularityOrderBy(query)} ${dimensionOrderBy}
+                    AND day >= toDate('${startDate}')
+                    AND day < toDate('${endDate}')
+                    GROUP BY account_id ${granularityGroupBy(query)}, dimension
+                    ORDER BY account_id ${granularityOrderBy(query)}, dimension
                 `;
                 const res = await this.client?.query({ query: sql, format: 'JSONEachRow' });
                 return {
@@ -158,13 +186,17 @@ export class Clickhouse {
                     const { metric, dimension, rows } = entry.value;
                     const seriesMap: Record<string, GetUsageResultSeries> = {};
                     for (const row of rows) {
-                        const dimensionValue = row.dimension;
-                        if (!seriesMap[dimensionValue]) {
-                            seriesMap[dimensionValue] =
-                                dimension !== 'none' ? { dimension, dimensionValue: dimensionValue, total: 0, dataPoints: [] } : { total: 0, dataPoints: [] };
+                        // CH returns the dimension value as a string (toString in the IF
+                        // is required so 'rest' and the raw column share a type). Coerce
+                        // back to the typed value so downstream consumers get the same
+                        // shape the no-top-N variant used to return.
+                        const dimensionValue = coerceDimensionValue(row.dimension, dimension);
+                        const key = String(row.dimension);
+                        if (!seriesMap[key]) {
+                            seriesMap[key] = dimension !== 'none' ? { dimension, dimensionValue, total: 0, dataPoints: [] } : { total: 0, dataPoints: [] };
                         }
-                        seriesMap[dimensionValue].total += row.quantity;
-                        seriesMap[dimensionValue].dataPoints.push({
+                        seriesMap[key].total += row.quantity;
+                        seriesMap[key].dataPoints.push({
                             timeframe: {
                                 start: new Date(row.start),
                                 end: new Date(row.end)
@@ -252,12 +284,15 @@ export class Clickhouse {
         const startDate = timeframe.start.toISOString().split('T')[0];
         const endDate = timeframe.end.toISOString().split('T')[0];
         const table = `${this.database}.${tableForMetric(metric)}`;
+        const top = Math.min(query.top ?? TOP_N_BREAKDOWN_DEFAULT, TOP_N_BREAKDOWN_CAP);
 
         // 'none' branch: per-day batch count IS the no-dim denominator, simple SQL.
         // dim branch: per-dim sum + day-level global batches (so series are additive
-        // to the global). The CTE `global_batches` is a single tiny aggregate scan;
-        // the outer GROUP BY adds the dimension while keeping the same denominator
-        // across dim values via INNER JOIN on day.
+        // to the global), with a hard top-N + 'rest' cap on the dimension. The
+        // `top_dims` CTE picks the top-N dimension values by total SUM across the
+        // window; anything outside lands in a single 'rest' bucket. `global_batches`
+        // keeps every series sharing the same per-day denominator so per-series
+        // running averages still sum to the global running average.
         const sql =
             dimension === 'none'
                 ? `
@@ -280,19 +315,29 @@ export class Clickhouse {
                 AND day >= toDate('${startDate}')
                 AND day < toDate('${endDate}')
                 GROUP BY day
+            ),
+            top_dims AS (
+                SELECT ${dimension} AS dim, SUM(value) AS total
+                FROM ${table}
+                WHERE account_id = ${accountId}
+                AND day >= toDate('${startDate}')
+                AND day < toDate('${endDate}')
+                GROUP BY ${dimension}
+                ORDER BY total DESC
+                LIMIT ${top}
             )
             SELECT
                 t.day AS day,
                 SUM(t.value) AS sum,
                 any(g.batches) AS batches,
-                t.${dimension} AS dimensionValue
+                IF(t.${dimension} IN (SELECT dim FROM top_dims), toString(t.${dimension}), 'rest') AS dimensionValue
             FROM ${table} t
             INNER JOIN global_batches g ON g.day = t.day
             WHERE t.account_id = ${accountId}
             AND t.day >= toDate('${startDate}')
             AND t.day < toDate('${endDate}')
-            GROUP BY t.day, t.${dimension}
-            ORDER BY t.day, t.${dimension}
+            GROUP BY t.day, dimensionValue
+            ORDER BY t.day, dimensionValue
         `;
 
         try {
@@ -351,6 +396,20 @@ export class Clickhouse {
 
         return res;
     }
+}
+
+// Coerces the raw string value returned by ClickHouse (forced to String by the
+// `toString` inside the top-N IF, so the 'rest' literal and the column share a
+// type) back to the typed value expected by GetUsageResultSeries.dimensionValue.
+// `none` stays as 'none' so the no-dim series falls out untouched.
+function coerceDimensionValue(raw: string, dimension: string): string | number | boolean {
+    if (raw === 'rest' || dimension === 'none') {
+        return raw;
+    }
+    if (dimension === 'success') {
+        return raw === 'true';
+    }
+    return raw;
 }
 
 function toRaw(event: UsageEvent): ClickhouseRawUsageEvent | null {

--- a/packages/usage/lib/clickhouse/clickhouse.ts
+++ b/packages/usage/lib/clickhouse/clickhouse.ts
@@ -5,8 +5,17 @@ import { granularityGroupBy, granularityOrderBy, quantityForMetric, startSelect,
 import { clickhouseClient, database as usageDatabase } from './config.js';
 import { logger } from '../logger.js';
 
-import type { GetUsageQuery, GetUsageResult, GetUsageResultSeries } from './clickhouse.query.js';
-import type { UsageActionsEvent, UsageConnectionsEvent, UsageEvent, UsageFunctionExecutionsEvent, UsageMetric, UsageRecordsEvent } from '@nangohq/types';
+import type {
+    CounterUsageMetric,
+    GetDailySumAndBatchesDay,
+    GetDailySumAndBatchesQuery,
+    GetDailySumAndBatchesResult,
+    GetDailySumAndBatchesSeries,
+    GetUsageQuery,
+    GetUsageResult,
+    GetUsageResultSeries
+} from './clickhouse.query.js';
+import type { UsageActionsEvent, UsageConnectionsEvent, UsageEvent, UsageFunctionExecutionsEvent, UsageRecordsEvent } from '@nangohq/types';
 import type { Result } from '@nangohq/utils';
 
 const envs = parseEnvs(ENVS);
@@ -93,110 +102,49 @@ export class Clickhouse {
         return this.batcher ? this.batcher.flush() : Promise.resolve(Ok(undefined));
     }
 
+    /**
+     * Counter metrics only — `proxy`, `function_executions`, `function_logs`,
+     * `function_compute_gbms`, `webhook_forwards`. AVG-style metrics (`records`,
+     * `connections`) are served by `getDailySumAndBatches` and are excluded from
+     * `GetUsageQuery.metrics` at the type level, so the switch below doesn't
+     * need to handle them.
+     */
     async getUsage(query: GetUsageQuery): Promise<Result<GetUsageResult>> {
         if (!this.client) {
             return Err(new Error('Clickhouse client not initialized'));
         }
 
         try {
-            const qs = (Object.keys(query.metrics) as UsageMetric[]).map(async (metric) => {
+            const qs = (Object.keys(query.metrics) as CounterUsageMetric[]).map(async (metric) => {
                 const dimension = query.metrics[metric]?.dimension || 'none';
                 const dimensionColumn = dimension === 'none' ? "'none'" : dimension; // quoted 'none' to be used directly in SQL queries as a string literal when no dimension is needed
                 const dimensionSelect = `, ${dimensionColumn}`;
                 const dimensionGroupBy = dimensionColumn ? `, ${dimensionColumn}` : '';
                 const dimensionOrderBy = dimensionColumn ? `, ${dimensionColumn}` : '';
-                switch (metric) {
-                    case 'proxy':
-                    case 'function_executions':
-                    case 'function_logs':
-                    case 'function_compute_gbms':
-                    case 'webhook_forwards': {
-                        const sql = `
-                            SELECT
-                                ${quantityForMetric(metric)} AS quantity,
-                                ${startSelect(query)}
-                                ${dimensionSelect} AS dimension
-                            FROM ${this.database}.${tableForMetric(metric)}
-                            WHERE account_id = ${query.accountId}
-                            AND day >= toDate('${query.timeframe.start.toISOString().split('T')[0]}')
-                            AND day < toDate('${query.timeframe.end.toISOString().split('T')[0]}')
-                            GROUP BY account_id ${granularityGroupBy(query)} ${dimensionGroupBy}
-                            ORDER BY account_id ${granularityOrderBy(query)} ${dimensionOrderBy}
-                        `;
-                        const res = await this.client?.query({ query: sql, format: 'JSONEachRow' });
-                        return {
-                            accountId: query.accountId,
-                            metric,
-                            dimension,
-                            rows: (await res?.json()) as {
-                                quantity: number;
-                                start: string;
-                                end: string;
-                                dimension: string;
-                            }[],
-                            viewMode: 'periodic' as const
-                        };
-                    }
-                    case 'records':
-                    case 'connections': {
-                        // Gauge metrics, sampled by the metering observability cron.
-                        // Three-level query reconstructs Orb's `average(count)` semantic:
-                        //   inner:  SUM(value) per (account, day, batch_id, dimension)
-                        //           → per-firing account total at the dimension grain
-                        //   middle: AVG(batch_val) per (account, day, dimension)
-                        //           → day-average of those firings
-                        //   outer:  SUM(day_avg) per (account, dimension) optionally /day_count
-                        //           → period or per-day result, same shape the avg-then-sum
-                        //           branch used to produce
-                        const startDate = query.timeframe.start.toISOString().split('T')[0];
-                        const endDate = query.timeframe.end.toISOString().split('T')[0];
-                        const quantityExpr = (() => {
-                            switch (query.granularity) {
-                                case 'none':
-                                    return `ROUND(SUM(day_avg) / GREATEST(1, dateDiff('day', toDate('${startDate}'), toDate('${endDate}'))))`;
-                                case 'day':
-                                    return `ROUND(SUM(day_avg))`;
-                            }
-                        })();
-                        const sql = `
-                            SELECT
-                                ${quantityExpr} AS quantity,
-                                ${startSelect(query)}
-                                ${dimensionSelect} AS dimension
-                            FROM (
-                                SELECT
-                                    AVG(batch_val) AS day_avg,
-                                    account_id, day ${dimensionGroupBy}
-                                FROM (
-                                    SELECT
-                                        SUM(value) AS batch_val,
-                                        account_id, day, batch_id ${dimensionGroupBy}
-                                    FROM ${this.database}.${tableForMetric(metric)}
-                                    WHERE account_id = ${query.accountId}
-                                    AND day >= toDate('${startDate}')
-                                    AND day < toDate('${endDate}')
-                                    GROUP BY account_id, day, batch_id ${dimensionGroupBy}
-                                )
-                                GROUP BY account_id, day ${dimensionGroupBy}
-                            )
-                            GROUP BY account_id ${granularityGroupBy(query)} ${dimensionGroupBy}
-                            ORDER BY account_id ${granularityOrderBy(query)} ${dimensionOrderBy}
-                        `;
-                        const res = await this.client?.query({ query: sql, format: 'JSONEachRow' });
-                        return {
-                            accountId: query.accountId,
-                            metric,
-                            dimension,
-                            rows: (await res?.json()) as {
-                                quantity: number;
-                                start: string;
-                                end: string;
-                                dimension: string;
-                            }[],
-                            viewMode: 'cumulative' as const
-                        };
-                    }
-                }
+                const sql = `
+                    SELECT
+                        ${quantityForMetric(metric)} AS quantity,
+                        ${startSelect(query)}
+                        ${dimensionSelect} AS dimension
+                    FROM ${this.database}.${tableForMetric(metric)}
+                    WHERE account_id = ${query.accountId}
+                    AND day >= toDate('${query.timeframe.start.toISOString().split('T')[0]}')
+                    AND day < toDate('${query.timeframe.end.toISOString().split('T')[0]}')
+                    GROUP BY account_id ${granularityGroupBy(query)} ${dimensionGroupBy}
+                    ORDER BY account_id ${granularityOrderBy(query)} ${dimensionOrderBy}
+                `;
+                const res = await this.client?.query({ query: sql, format: 'JSONEachRow' });
+                return {
+                    accountId: query.accountId,
+                    metric,
+                    dimension,
+                    rows: (await res?.json()) as {
+                        quantity: number;
+                        start: string;
+                        end: string;
+                        dimension: string;
+                    }[]
+                };
             });
             const results = await Promise.allSettled(qs);
             const usage: GetUsageResult = {
@@ -207,7 +155,7 @@ export class Clickhouse {
             for (const [i, entry] of results.entries()) {
                 if (entry.status === 'fulfilled') {
                     if (!entry.value) continue;
-                    const { metric, dimension, rows, viewMode } = entry.value;
+                    const { metric, dimension, rows } = entry.value;
                     const seriesMap: Record<string, GetUsageResultSeries> = {};
                     for (const row of rows) {
                         const dimensionValue = row.dimension;
@@ -225,28 +173,17 @@ export class Clickhouse {
                         });
                     }
 
-                    const shouldProrate = viewMode === 'cumulative' && query.granularity === 'day';
-                    const timeframeDays = shouldProrate
-                        ? Math.max(1, (query.timeframe.end.getTime() - query.timeframe.start.getTime()) / (1000 * 60 * 60 * 24))
-                        : 1;
-
                     // sort series by dimension value for consistent ordering
                     const series = Object.entries(seriesMap)
                         .sort(([a], [b]) => a.localeCompare(b))
-                        .map(([, value]) => {
-                            if (shouldProrate) {
-                                value.total = Math.round(value.total / timeframeDays);
-                            }
-                            return value;
-                        });
+                        .map(([, value]) => value);
 
-                    const seriesTotal = rows.reduce((sum, row) => sum + row.quantity, 0);
-                    const total = shouldProrate ? Math.round(seriesTotal / timeframeDays) : seriesTotal;
+                    const total = rows.reduce((sum, row) => sum + row.quantity, 0);
 
                     usage.metrics[metric] = {
                         series,
                         total,
-                        view_mode: viewMode
+                        view_mode: 'periodic'
                     };
                 } else {
                     logger.error(`Failed to execute Clickhouse query for metric ${Object.keys(query.metrics)[i]}: ${stringifyError(entry.reason)}`);
@@ -255,6 +192,146 @@ export class Clickhouse {
             return Ok(usage);
         } catch (err) {
             return Err(new Error('Failed to execute Clickhouse query', { cause: err }));
+        }
+    }
+
+    /**
+     * Per-day `(sum, batches)` over `daily_raw_records` / `daily_raw_connections`
+     * for AVG-style metrics. Only `records` and `connections` use this method —
+     * they're the two billable metrics whose write path tags each metering-cron
+     * firing with a `batch_id` column. The query type constrains `metric` to
+     * that pair at compile time.
+     *
+     * One series per dimension value (or a single series when
+     * `dimension === 'none'`), one entry per day that had ≥ 1 batch.
+     *
+     * Both numbers are needed because the dashboard's `view_mode='cumulative'`
+     * series is the running PERIOD average across all batches in the period:
+     *
+     *     running_avg(D) = SUM(value)[start..D] / uniqExact(batch_id)[start..D]
+     *
+     * Per-day averages alone aren't enough — when batch counts differ across
+     * days you can't recombine them. Worked example, one account:
+     *
+     *     day 0:  10 batches × 100 each  →  sum=1000, batches=10
+     *     day 1:   2 batches × 1000 each →  sum=2000, batches= 2
+     *
+     *     truth after day 1 = (10·100 + 2·1000) / 12     = 250
+     *     formatter:          (1000 + 2000) / (10 + 2)   = 250 ✓
+     *     avg-of-daily-avgs:  (100 + 1000) / 2           = 550 ✗
+     *
+     * Returning the two associative accumulators lets the formatter weight
+     * batches correctly at every day boundary.
+     *
+     * `batches` is `uniqExact(batch_id)` (distinct Orb-equivalent batches),
+     * NOT the row count: one batch produces multiple rows in `daily_raw_records`
+     * (one per slice). The flat `SUM(value)` is equivalent to the two-level
+     * "sum per batch, then aggregate across batches" pattern the S3 export cron
+     * uses — we skip the inner GROUP BY because SUM is associative across
+     * grouping levels. The S3 cron keeps the inner step because its outer op
+     * is AVG, which isn't.
+     *
+     * Dimension breakdown — `batches` is the GLOBAL per-day count, not per-dim.
+     * The dim branch JOINs each dimension row against the day's global batch
+     * count so every series shares the same denominator. This makes per-dim
+     * running averages **additive to the global**: their sum at any day equals
+     * the no-dim global average for that day. The alternative (per-dim batch
+     * count) would give "average size of dim when present", which is meaningful
+     * but doesn't compose with the global view — wrong for a billing dashboard
+     * where the breakdown is expected to decompose the bill total.
+     *
+     * Running-avg reconstruction lives in the server-side formatter (separate
+     * ticket), mirroring `toCumulativeUsage` on the Orb path. Capping doesn't
+     * consume these primitives — it reads Postgres for these metrics.
+     */
+    async getDailySumAndBatches(query: GetDailySumAndBatchesQuery): Promise<Result<GetDailySumAndBatchesResult>> {
+        if (!this.client) {
+            return Err(new Error('Clickhouse client not initialized'));
+        }
+        const { accountId, metric, dimension, timeframe } = query;
+        const startDate = timeframe.start.toISOString().split('T')[0];
+        const endDate = timeframe.end.toISOString().split('T')[0];
+        const table = `${this.database}.${tableForMetric(metric)}`;
+
+        // 'none' branch: per-day batch count IS the no-dim denominator, simple SQL.
+        // dim branch: per-dim sum + day-level global batches (so series are additive
+        // to the global). The CTE `global_batches` is a single tiny aggregate scan;
+        // the outer GROUP BY adds the dimension while keeping the same denominator
+        // across dim values via INNER JOIN on day.
+        const sql =
+            dimension === 'none'
+                ? `
+            SELECT
+                day AS day,
+                SUM(value) AS sum,
+                uniqExact(batch_id) AS batches
+            FROM ${table}
+            WHERE account_id = ${accountId}
+            AND day >= toDate('${startDate}')
+            AND day < toDate('${endDate}')
+            GROUP BY day
+            ORDER BY day
+        `
+                : `
+            WITH global_batches AS (
+                SELECT day, uniqExact(batch_id) AS batches
+                FROM ${table}
+                WHERE account_id = ${accountId}
+                AND day >= toDate('${startDate}')
+                AND day < toDate('${endDate}')
+                GROUP BY day
+            )
+            SELECT
+                t.day AS day,
+                SUM(t.value) AS sum,
+                any(g.batches) AS batches,
+                t.${dimension} AS dimensionValue
+            FROM ${table} t
+            INNER JOIN global_batches g ON g.day = t.day
+            WHERE t.account_id = ${accountId}
+            AND t.day >= toDate('${startDate}')
+            AND t.day < toDate('${endDate}')
+            GROUP BY t.day, t.${dimension}
+            ORDER BY t.day, t.${dimension}
+        `;
+
+        try {
+            const res = await this.client.query({ query: sql, format: 'JSONEachRow' });
+            const rows = await res.json();
+
+            // One series per distinct dimensionValue; preserve insertion order for stability.
+            const seriesMap = new Map<string, GetDailySumAndBatchesSeries>();
+            for (const row of rows) {
+                const dayPoint: GetDailySumAndBatchesDay = {
+                    day: new Date(row.day),
+                    sum: Number(row.sum),
+                    batches: Number(row.batches)
+                };
+                if (dimension !== 'none') {
+                    const key = String(row.dimensionValue);
+                    let entry = seriesMap.get(key);
+                    if (!entry) {
+                        entry = { dimension, dimensionValue: row.dimensionValue!, days: [] };
+                        seriesMap.set(key, entry);
+                    }
+                    entry.days.push(dayPoint);
+                } else {
+                    let entry = seriesMap.get('');
+                    if (!entry) {
+                        entry = { days: [] };
+                        seriesMap.set('', entry);
+                    }
+                    entry.days.push(dayPoint);
+                }
+            }
+
+            const series = Array.from(seriesMap.entries())
+                .sort(([a], [b]) => a.localeCompare(b))
+                .map(([, value]) => value);
+
+            return Ok({ accountId, metric, series });
+        } catch (err) {
+            return Err(new Error('Failed to execute Clickhouse daily sum+batches query', { cause: err }));
         }
     }
 

--- a/packages/usage/lib/clickhouse/clickhouse.ts
+++ b/packages/usage/lib/clickhouse/clickhouse.ts
@@ -297,7 +297,12 @@ export class Clickhouse {
 
         try {
             const res = await this.client.query({ query: sql, format: 'JSONEachRow' });
-            const rows = await res.json();
+            const rows = await res.json<{
+                day: string;
+                sum: string | number;
+                batches: string | number;
+                dimensionValue?: string;
+            }>();
 
             // One series per distinct dimensionValue; preserve insertion order for stability.
             const seriesMap = new Map<string, GetDailySumAndBatchesSeries>();

--- a/packages/usage/lib/usage.ts
+++ b/packages/usage/lib/usage.ts
@@ -10,6 +10,7 @@ import { UsageCache } from './cache.js';
 import { logger } from './logger.js';
 import { usageMetrics } from './metrics.js';
 
+import type { GetDailySumAndBatchesResult, GetDailySumAndBatchesSeries } from './clickhouse/clickhouse.query.js';
 import type { getRedis } from '@nangohq/kvstore';
 import type { BillingUsageMetric, BillingUsageMetrics, GetBillingUsageOpts, UsageMetric } from '@nangohq/types';
 import type { Result } from '@nangohq/utils';
@@ -342,4 +343,79 @@ function toCumulativeUsage(periodicUsage: BillingUsageMetric): BillingUsageMetri
         total: Math.floor(previousQuantity),
         usage: cumulativeUsage
     };
+}
+
+/**
+ * CH-path sibling of `toCumulativeUsage`. Turns the per-day `(sum, batches)`
+ * accumulators returned by `Clickhouse.getDailySumAndBatches` into
+ * `BillingUsageMetric[]` with `view_mode='cumulative'` — the same wire shape
+ * the dashboard already consumes for `records` / `connections` from the Orb
+ * path. One `BillingUsageMetric` per series (no-dim → 1; dim → one per dim
+ * value with `group: {key, value}`).
+ *
+ * Walks each series in day order, accumulates `running_sum` and
+ * `running_batches`, and emits `Math.round(running_sum / running_batches)` per
+ * day. Bypasses `toCumulativeUsage` because the output is already
+ * cumulative-shaped (running averages, not running sums of deltas).
+ *
+ * Dim-breakdown additivity contract: per-dim series share the same global
+ * per-day batches (by design of `getDailySumAndBatches`' dim branch), so the
+ * sum of per-dim running averages equals the global running average exactly
+ * at every day — the breakdown decomposes the bill total rather than being
+ * a "size when active" view.
+ *
+ * Worked example (10×100 vs 2×1000 → 100, 250) lives in
+ * `getDailySumAndBatches`' docstring.
+ */
+export function toRunningAvgUsage(result: GetDailySumAndBatchesResult): BillingUsageMetric[] {
+    return result.series.map((series) => seriesToCumulativeAvg(result.metric, series)).filter((m): m is BillingUsageMetric => m !== null);
+}
+
+function seriesToCumulativeAvg(metric: GetDailySumAndBatchesResult['metric'], series: GetDailySumAndBatchesSeries): BillingUsageMetric | null {
+    if (series.days.length === 0) {
+        return null;
+    }
+
+    const sorted = [...series.days].sort((a, b) => a.day.getTime() - b.day.getTime());
+
+    let runningSum = 0;
+    let runningBatches = 0;
+    const usage: BillingUsageMetric['usage'] = [];
+    for (const day of sorted) {
+        runningSum += day.sum;
+        runningBatches += day.batches;
+        if (runningBatches === 0) {
+            // Defensive: a series shouldn't appear with batches=0 (the SQL filters
+            // empty-day groups out), but if it does we skip rather than divide by zero.
+            continue;
+        }
+        const quantity = Math.round(runningSum / runningBatches);
+        usage.push({
+            timeframeStart: day.day,
+            timeframeEnd: addOneDay(day.day),
+            quantity
+        });
+    }
+
+    if (usage.length === 0) {
+        return null;
+    }
+
+    const lastQuantity = usage[usage.length - 1]!.quantity;
+    const base: BillingUsageMetric = {
+        externalId: metric,
+        total: lastQuantity,
+        usage,
+        view_mode: 'cumulative'
+    };
+    if ('dimension' in series) {
+        base.group = { key: series.dimension, value: String(series.dimensionValue) };
+    }
+    return base;
+}
+
+function addOneDay(d: Date): Date {
+    const out = new Date(d);
+    out.setUTCDate(out.getUTCDate() + 1);
+    return out;
 }

--- a/packages/usage/lib/usage.ts
+++ b/packages/usage/lib/usage.ts
@@ -247,8 +247,13 @@ export class UsageTracker implements IUsageTracker {
         //
         // The dim breakdown wiring belongs to a follow-up — `BillingUsageMetric`
         // is single-series, so it can't represent per-dim panels here yet.
-        const useClickhouseForDashboard =
-            parsedEnvs.USAGE_BILLING_FROM_CLICKHOUSE && opts?.granularity === 'day' && opts.timeframe?.start && opts.timeframe?.end;
+        //
+        // `opts.source` is a per-request override (webapp reads it from
+        // `localStorage('nango.billingUsageSource')` and forwards as a query
+        // param). When set, it takes precedence over the env-level default —
+        // lets dev tools flip paths without a redeploy.
+        const sourceIsClickhouse = opts?.source ? opts.source === 'clickhouse' : parsedEnvs.USAGE_BILLING_FROM_CLICKHOUSE;
+        const useClickhouseForDashboard = sourceIsClickhouse && opts?.granularity === 'day' && opts.timeframe?.start && opts.timeframe?.end;
 
         if (useClickhouseForDashboard) {
             return this.getBillingUsageFromClickhouse(accountId, opts.timeframe!);

--- a/packages/usage/lib/usage.ts
+++ b/packages/usage/lib/usage.ts
@@ -11,7 +11,7 @@ import { Clickhouse } from './clickhouse/clickhouse.js';
 import { logger } from './logger.js';
 import { usageMetrics } from './metrics.js';
 
-import type { GetDailySumAndBatchesResult, GetDailySumAndBatchesSeries } from './clickhouse/clickhouse.query.js';
+import type { CounterUsageMetric, GetDailySumAndBatchesResult, GetDailySumAndBatchesSeries, GetUsageResult } from './clickhouse/clickhouse.query.js';
 import type { getRedis } from '@nangohq/kvstore';
 import type { BillingUsageMetric, BillingUsageMetrics, GetBillingUsageOpts, UsageMetric } from '@nangohq/types';
 import type { Result } from '@nangohq/utils';
@@ -79,9 +79,9 @@ export class UsageTrackerNoOps implements IUsageTracker {
 export class UsageTracker implements IUsageTracker {
     private cache: UsageCache;
     public billingClient: UsageBillingClient;
-    // Read-only client for the AVG-from-ClickHouse path (guarded by
-    // USAGE_BILLING_AVG_FROM_CLICKHOUSE). Lazy-init keeps the dependency out
-    // of code paths that never read records/connections from CH.
+    // Read-only client for the dashboard CH path (guarded by
+    // USAGE_BILLING_FROM_CLICKHOUSE). Lazy-init keeps the dependency out
+    // of code paths that never read billing usage from CH.
     private clickhouse: Clickhouse | null = null;
 
     constructor(redis: Awaited<ReturnType<typeof getRedis>>) {
@@ -235,35 +235,28 @@ export class UsageTracker implements IUsageTracker {
     }
 
     public async getBillingUsage(subscriptionId: string, accountId: number, opts?: GetBillingUsageOpts): Promise<Result<BillingUsageMetrics>> {
-        const billingUsageMetrics = await this.billingClient.getUsage(subscriptionId, opts);
-
-        if (billingUsageMetrics.isErr()) {
-            return billingUsageMetrics;
-        }
-
-        // CH-backed AVG path. Counter metrics always come from Orb; only
-        // records / connections can be overridden. Scope intentionally limited:
-        //   - flag is on
-        //   - caller asked for a day-granularity series within an explicit
-        //     timeframe (the dashboard path; capping calls without timeframe
-        //     stay on Orb)
+        // CH-only dashboard path. Skips Orb entirely for the dashboard shape
+        // (granularity='day' + explicit timeframe). Counter metrics use
+        // `Clickhouse.getUsage`, AVG metrics use `getDailySumAndBatches` +
+        // `toRunningAvgUsage`. Errors propagate — no silent Orb fallback,
+        // so any regression surfaces immediately in dev.
+        //
+        // Capping (`getBillingMetrics`, no granularity / timeframe) continues
+        // to use the Orb path regardless of the flag — the CH side doesn't
+        // have an equivalent of Orb's "current period totals" yet.
+        //
         // The dim breakdown wiring belongs to a follow-up — `BillingUsageMetric`
         // is single-series, so it can't represent per-dim panels here yet.
-        const useClickhouseForAvg = parsedEnvs.USAGE_BILLING_AVG_FROM_CLICKHOUSE && opts?.granularity === 'day' && opts.timeframe?.start && opts.timeframe?.end;
+        const useClickhouseForDashboard =
+            parsedEnvs.USAGE_BILLING_FROM_CLICKHOUSE && opts?.granularity === 'day' && opts.timeframe?.start && opts.timeframe?.end;
 
-        if (useClickhouseForAvg) {
-            const [records, connections] = await Promise.all([
-                this.getCumulativeAvgFromClickhouse({ accountId, metric: 'records', timeframe: opts.timeframe! }),
-                this.getCumulativeAvgFromClickhouse({ accountId, metric: 'connections', timeframe: opts.timeframe! })
-            ]);
-            return Ok({
-                ...billingUsageMetrics.value,
-                // Fall back to the Orb-derived value if the CH read failed; we'd
-                // rather show stale data than no data while the dashboard adopts
-                // the new path.
-                connections: connections ?? (billingUsageMetrics.value.connections ? toCumulativeUsage(billingUsageMetrics.value.connections) : undefined),
-                records: records ?? (billingUsageMetrics.value.records ? toCumulativeUsage(billingUsageMetrics.value.records) : undefined)
-            });
+        if (useClickhouseForDashboard) {
+            return this.getBillingUsageFromClickhouse(accountId, opts.timeframe!);
+        }
+
+        const billingUsageMetrics = await this.billingClient.getUsage(subscriptionId, opts);
+        if (billingUsageMetrics.isErr()) {
+            return billingUsageMetrics;
         }
 
         return Ok({
@@ -274,32 +267,44 @@ export class UsageTracker implements IUsageTracker {
     }
 
     /**
-     * Reads the AVG-metric daily series from ClickHouse and turns it into the
-     * single-series BillingUsageMetric the dashboard already consumes. Returns
-     * `null` on read error (caller falls back to Orb) or when CH has no data
-     * for the window (treated like the metric being absent).
+     * Reads all 7 billable metrics (5 counter + 2 AVG) from ClickHouse and
+     * shapes them into BillingUsageMetric. Skips Orb entirely.
      */
-    private async getCumulativeAvgFromClickhouse({
-        accountId,
-        metric,
-        timeframe
-    }: {
-        accountId: number;
-        metric: 'records' | 'connections';
-        timeframe: { start: Date; end: Date };
-    }): Promise<BillingUsageMetric | null> {
-        const res = await this.getClickhouse().getDailySumAndBatches({
-            accountId,
-            metric,
-            dimension: 'none',
-            timeframe
-        });
-        if (res.isErr()) {
-            logger.error(`CH AVG read failed for accountId=${accountId} metric=${metric}, falling back to Orb`, res.error);
-            return null;
+    private async getBillingUsageFromClickhouse(accountId: number, timeframe: { start: Date; end: Date }): Promise<Result<BillingUsageMetrics>> {
+        const counterMetrics: CounterUsageMetric[] = ['proxy', 'function_executions', 'function_logs', 'function_compute_gbms', 'webhook_forwards'];
+
+        const ch = this.getClickhouse();
+        const [counterRes, recordsRes, connectionsRes] = await Promise.all([
+            ch.getUsage({
+                accountId,
+                granularity: 'day',
+                timeframe,
+                metrics: Object.fromEntries(counterMetrics.map((m) => [m, { dimension: 'none' as const }]))
+            }),
+            ch.getDailySumAndBatches({ accountId, metric: 'records', dimension: 'none', timeframe }),
+            ch.getDailySumAndBatches({ accountId, metric: 'connections', dimension: 'none', timeframe })
+        ]);
+
+        if (counterRes.isErr()) {
+            return Err(counterRes.error);
         }
-        const series = toRunningAvgUsage(res.value);
-        return series[0] ?? null;
+        if (recordsRes.isErr()) {
+            return Err(recordsRes.error);
+        }
+        if (connectionsRes.isErr()) {
+            return Err(connectionsRes.error);
+        }
+
+        const result: BillingUsageMetrics = {};
+        for (const metric of counterMetrics) {
+            const m = counterRes.value.metrics[metric];
+            if (m) {
+                result[metric] = toCounterBillingMetric(metric, m);
+            }
+        }
+        result.records = toRunningAvgUsage(recordsRes.value)[0];
+        result.connections = toRunningAvgUsage(connectionsRes.value)[0];
+        return Ok(result);
     }
 
     private static getCacheEntryProps({ accountId, metric, now }: { accountId: number; metric: UsageMetric; now: Date }): { cacheKey: string; ttlMs?: number } {
@@ -488,4 +493,30 @@ function addOneDay(d: Date): Date {
     const out = new Date(d);
     out.setUTCDate(out.getUTCDate() + 1);
     return out;
+}
+
+/**
+ * Single-metric counter result from `Clickhouse.getUsage` → `BillingUsageMetric`.
+ * No dim, so we take the single series and map per-day dataPoints into the
+ * `usage` array. Counter metrics are always `view_mode='periodic'` (Orb's same
+ * shape — daily deltas not running totals); the dashboard adds them itself if
+ * needed.
+ */
+type CounterUsageMetricResult = NonNullable<GetUsageResult['metrics'][CounterUsageMetric]>;
+
+export function toCounterBillingMetric(metric: CounterUsageMetric, result: CounterUsageMetricResult): BillingUsageMetric {
+    // With `dimension: 'none'` the result has exactly one series; the inner
+    // dataPoints carry per-day quantities sized by the query's timeframe.
+    const series = result.series[0];
+    const dataPoints = series && 'dataPoints' in series ? series.dataPoints : [];
+    return {
+        externalId: metric,
+        total: result.total,
+        usage: dataPoints.map((dp) => ({
+            timeframeStart: dp.timeframe.start,
+            timeframeEnd: dp.timeframe.end,
+            quantity: dp.quantity
+        })),
+        view_mode: 'periodic'
+    };
 }

--- a/packages/usage/lib/usage.ts
+++ b/packages/usage/lib/usage.ts
@@ -79,9 +79,10 @@ export class UsageTrackerNoOps implements IUsageTracker {
 export class UsageTracker implements IUsageTracker {
     private cache: UsageCache;
     public billingClient: UsageBillingClient;
-    // Read-only client for the dashboard CH path (guarded by
-    // USAGE_BILLING_FROM_CLICKHOUSE). Lazy-init keeps the dependency out
-    // of code paths that never read billing usage from CH.
+    // Read-only client for the dashboard CH path (gated by
+    // ALLOW_OVERRIDE_GETUSAGE_SERVICE + per-request `source` override).
+    // Lazy-init keeps the dependency out of code paths that never read
+    // billing usage from CH.
     private clickhouse: Clickhouse | null = null;
 
     constructor(redis: Awaited<ReturnType<typeof getRedis>>) {
@@ -242,18 +243,21 @@ export class UsageTracker implements IUsageTracker {
         // so any regression surfaces immediately in dev.
         //
         // Capping (`getBillingMetrics`, no granularity / timeframe) continues
-        // to use the Orb path regardless of the flag — the CH side doesn't
-        // have an equivalent of Orb's "current period totals" yet.
+        // to use the Orb path — the CH side doesn't have an equivalent of
+        // Orb's "current period totals" yet.
         //
         // The dim breakdown wiring belongs to a follow-up — `BillingUsageMetric`
         // is single-series, so it can't represent per-dim panels here yet.
         //
-        // `opts.source` is a per-request override (webapp reads it from
-        // `localStorage('nango.billingUsageSource')` and forwards as a query
-        // param). When set, it takes precedence over the env-level default —
-        // lets dev tools flip paths without a redeploy.
-        const sourceIsClickhouse = opts?.source ? opts.source === 'clickhouse' : parsedEnvs.USAGE_BILLING_FROM_CLICKHOUSE;
-        const useClickhouseForDashboard = sourceIsClickhouse && opts?.granularity === 'day' && opts.timeframe?.start && opts.timeframe?.end;
+        // Resolution: `opts.source` is a per-request override (webapp reads it
+        // from `localStorage('nango.billingUsageSource')` and forwards as a
+        // query param). It's honoured ONLY when
+        // `ALLOW_OVERRIDE_GETUSAGE_SERVICE` is set (gate, dev-only) — otherwise
+        // the param is ignored and Orb is always used. The flag does not
+        // change the default; even on dev, a request with no override stays
+        // on Orb until someone explicitly opts in.
+        const requestedSource = parsedEnvs.ALLOW_OVERRIDE_GETUSAGE_SERVICE ? opts?.source : undefined;
+        const useClickhouseForDashboard = requestedSource === 'clickhouse' && opts?.granularity === 'day' && opts.timeframe?.start && opts.timeframe?.end;
 
         if (useClickhouseForDashboard) {
             return this.getBillingUsageFromClickhouse(accountId, opts.timeframe!);

--- a/packages/usage/lib/usage.ts
+++ b/packages/usage/lib/usage.ts
@@ -3,10 +3,11 @@ import tracer from 'dd-trace';
 import db from '@nangohq/database';
 import { records } from '@nangohq/records';
 import { connectionService, environmentService, getPlan } from '@nangohq/shared';
-import { Err, Ok } from '@nangohq/utils';
+import { ENVS, Err, Ok, parseEnvs } from '@nangohq/utils';
 
 import { UsageBillingClient } from './billing.js';
 import { UsageCache } from './cache.js';
+import { Clickhouse } from './clickhouse/clickhouse.js';
 import { logger } from './logger.js';
 import { usageMetrics } from './metrics.js';
 
@@ -14,6 +15,8 @@ import type { GetDailySumAndBatchesResult, GetDailySumAndBatchesSeries } from '.
 import type { getRedis } from '@nangohq/kvstore';
 import type { BillingUsageMetric, BillingUsageMetrics, GetBillingUsageOpts, UsageMetric } from '@nangohq/types';
 import type { Result } from '@nangohq/utils';
+
+const parsedEnvs = parseEnvs(ENVS);
 
 const cacheKeyPrefix = 'usageV2';
 
@@ -28,7 +31,7 @@ export interface IUsageTracker {
     getAll(accountId: number): Promise<Result<Record<UsageMetric, UsageStatus>>>;
     incr(params: { accountId: number; metric: UsageMetric; delta?: number; forceRevalidation?: boolean }): Promise<Result<UsageStatus>>;
     revalidate({ accountId, metric }: { accountId: number; metric: UsageMetric }): Promise<Result<void>>;
-    getBillingUsage(subscriptionId: string, opts?: GetBillingUsageOpts): Promise<Result<BillingUsageMetrics>>;
+    getBillingUsage(subscriptionId: string, accountId: number, opts?: GetBillingUsageOpts): Promise<Result<BillingUsageMetrics>>;
 }
 
 export class UsageTrackerNoOps implements IUsageTracker {
@@ -76,10 +79,21 @@ export class UsageTrackerNoOps implements IUsageTracker {
 export class UsageTracker implements IUsageTracker {
     private cache: UsageCache;
     public billingClient: UsageBillingClient;
+    // Read-only client for the AVG-from-ClickHouse path (guarded by
+    // USAGE_BILLING_AVG_FROM_CLICKHOUSE). Lazy-init keeps the dependency out
+    // of code paths that never read records/connections from CH.
+    private clickhouse: Clickhouse | null = null;
 
     constructor(redis: Awaited<ReturnType<typeof getRedis>>) {
         this.cache = new UsageCache(redis);
         this.billingClient = new UsageBillingClient(redis);
+    }
+
+    private getClickhouse(): Clickhouse {
+        if (!this.clickhouse) {
+            this.clickhouse = new Clickhouse();
+        }
+        return this.clickhouse;
     }
 
     public async get({ accountId, metric }: { accountId: number; metric: UsageMetric }): Promise<Result<UsageStatus>> {
@@ -220,11 +234,36 @@ export class UsageTracker implements IUsageTracker {
         }
     }
 
-    public async getBillingUsage(subscriptionId: string, opts?: GetBillingUsageOpts): Promise<Result<BillingUsageMetrics>> {
+    public async getBillingUsage(subscriptionId: string, accountId: number, opts?: GetBillingUsageOpts): Promise<Result<BillingUsageMetrics>> {
         const billingUsageMetrics = await this.billingClient.getUsage(subscriptionId, opts);
 
         if (billingUsageMetrics.isErr()) {
             return billingUsageMetrics;
+        }
+
+        // CH-backed AVG path. Counter metrics always come from Orb; only
+        // records / connections can be overridden. Scope intentionally limited:
+        //   - flag is on
+        //   - caller asked for a day-granularity series within an explicit
+        //     timeframe (the dashboard path; capping calls without timeframe
+        //     stay on Orb)
+        // The dim breakdown wiring belongs to a follow-up — `BillingUsageMetric`
+        // is single-series, so it can't represent per-dim panels here yet.
+        const useClickhouseForAvg = parsedEnvs.USAGE_BILLING_AVG_FROM_CLICKHOUSE && opts?.granularity === 'day' && opts.timeframe?.start && opts.timeframe?.end;
+
+        if (useClickhouseForAvg) {
+            const [records, connections] = await Promise.all([
+                this.getCumulativeAvgFromClickhouse({ accountId, metric: 'records', timeframe: opts.timeframe! }),
+                this.getCumulativeAvgFromClickhouse({ accountId, metric: 'connections', timeframe: opts.timeframe! })
+            ]);
+            return Ok({
+                ...billingUsageMetrics.value,
+                // Fall back to the Orb-derived value if the CH read failed; we'd
+                // rather show stale data than no data while the dashboard adopts
+                // the new path.
+                connections: connections ?? (billingUsageMetrics.value.connections ? toCumulativeUsage(billingUsageMetrics.value.connections) : undefined),
+                records: records ?? (billingUsageMetrics.value.records ? toCumulativeUsage(billingUsageMetrics.value.records) : undefined)
+            });
         }
 
         return Ok({
@@ -232,6 +271,35 @@ export class UsageTracker implements IUsageTracker {
             connections: billingUsageMetrics.value.connections ? toCumulativeUsage(billingUsageMetrics.value.connections) : undefined,
             records: billingUsageMetrics.value.records ? toCumulativeUsage(billingUsageMetrics.value.records) : undefined
         });
+    }
+
+    /**
+     * Reads the AVG-metric daily series from ClickHouse and turns it into the
+     * single-series BillingUsageMetric the dashboard already consumes. Returns
+     * `null` on read error (caller falls back to Orb) or when CH has no data
+     * for the window (treated like the metric being absent).
+     */
+    private async getCumulativeAvgFromClickhouse({
+        accountId,
+        metric,
+        timeframe
+    }: {
+        accountId: number;
+        metric: 'records' | 'connections';
+        timeframe: { start: Date; end: Date };
+    }): Promise<BillingUsageMetric | null> {
+        const res = await this.getClickhouse().getDailySumAndBatches({
+            accountId,
+            metric,
+            dimension: 'none',
+            timeframe
+        });
+        if (res.isErr()) {
+            logger.error(`CH AVG read failed for accountId=${accountId} metric=${metric}, falling back to Orb`, res.error);
+            return null;
+        }
+        const series = toRunningAvgUsage(res.value);
+        return series[0] ?? null;
     }
 
     private static getCacheEntryProps({ accountId, metric, now }: { accountId: number; metric: UsageMetric; now: Date }): { cacheKey: string; ttlMs?: number } {
@@ -256,7 +324,9 @@ export class UsageTracker implements IUsageTracker {
         if (!plan.value.orb_subscription_id) {
             return Err(new Error('orb_subscription_id_missing'));
         }
-        const billingUsage: Result<BillingUsageMetrics> = await this.getBillingUsage(plan.value.orb_subscription_id);
+        // No timeframe / no granularity → CH path is bypassed inside
+        // getBillingUsage, capping continues to read from Orb.
+        const billingUsage: Result<BillingUsageMetrics> = await this.getBillingUsage(plan.value.orb_subscription_id, accountId);
         if (billingUsage.isErr()) {
             // Note: errors (including rate limit errors) are not being retried
             // revalidateAfter isn't being updated, so next incr will attempt to revalidate again

--- a/packages/usage/lib/usage.unit.test.ts
+++ b/packages/usage/lib/usage.unit.test.ts
@@ -1,0 +1,155 @@
+import { describe, expect, it } from 'vitest';
+
+import { toRunningAvgUsage } from './usage.js';
+
+import type { GetDailySumAndBatchesResult } from './clickhouse/clickhouse.query.js';
+
+const accountId = 1;
+
+function day(offset: number): Date {
+    const d = new Date('2026-06-01T00:00:00.000Z');
+    d.setUTCDate(d.getUTCDate() + offset);
+    return d;
+}
+
+describe('toRunningAvgUsage', () => {
+    it('emits the docstring worked example (10×100 vs 2×1000 → 100, 250)', () => {
+        const result: GetDailySumAndBatchesResult = {
+            accountId,
+            metric: 'records',
+            series: [
+                {
+                    days: [
+                        { day: day(0), sum: 1000, batches: 10 },
+                        { day: day(1), sum: 2000, batches: 2 }
+                    ]
+                }
+            ]
+        };
+
+        const [out] = toRunningAvgUsage(result);
+
+        expect(out).toEqual({
+            externalId: 'records',
+            total: 250,
+            view_mode: 'cumulative',
+            usage: [
+                { timeframeStart: day(0), timeframeEnd: day(1), quantity: 100 },
+                { timeframeStart: day(1), timeframeEnd: day(2), quantity: 250 }
+            ]
+        });
+    });
+
+    it('per-dim series are additive to the no-dim global (design B contract)', () => {
+        // Same fixture as the AVG integration test: day 0 records (int=a: sum=2100,
+        // int=b: sum=500; both share batches=3 because batches is global per day),
+        // day 1 (int=a: sum=1100, int=b: sum=500; batches=2 global per day).
+        const withDim: GetDailySumAndBatchesResult = {
+            accountId,
+            metric: 'records',
+            series: [
+                {
+                    dimension: 'integration_id',
+                    dimensionValue: 'a',
+                    days: [
+                        { day: day(0), sum: 2100, batches: 3 },
+                        { day: day(1), sum: 1100, batches: 2 }
+                    ]
+                },
+                {
+                    dimension: 'integration_id',
+                    dimensionValue: 'b',
+                    days: [
+                        { day: day(0), sum: 500, batches: 3 },
+                        { day: day(1), sum: 500, batches: 2 }
+                    ]
+                }
+            ]
+        };
+        const withoutDim: GetDailySumAndBatchesResult = {
+            accountId,
+            metric: 'records',
+            series: [
+                {
+                    days: [
+                        { day: day(0), sum: 2600, batches: 3 },
+                        { day: day(1), sum: 1600, batches: 2 }
+                    ]
+                }
+            ]
+        };
+
+        const dimMetrics = toRunningAvgUsage(withDim);
+        const [globalMetric] = toRunningAvgUsage(withoutDim);
+
+        expect(dimMetrics).toHaveLength(2);
+        // Both per-dim series should carry a `group` with the dimension info.
+        expect(dimMetrics[0]!.group).toEqual({ key: 'integration_id', value: 'a' });
+        expect(dimMetrics[1]!.group).toEqual({ key: 'integration_id', value: 'b' });
+
+        // Per-day additivity: Σᵢ quantity_i(D) === quantity_global(D), at every day.
+        for (let i = 0; i < globalMetric!.usage.length; i++) {
+            const globalDay = globalMetric!.usage[i]!;
+            const dimSum = dimMetrics.reduce((acc, m) => acc + m.usage[i]!.quantity, 0);
+            expect(dimSum).toBe(globalDay.quantity);
+        }
+        // And period total is additive too.
+        const dimTotal = dimMetrics.reduce((acc, m) => acc + m.total, 0);
+        expect(dimTotal).toBe(globalMetric!.total);
+    });
+
+    it('sorts days chronologically before accumulating (defends against unordered input)', () => {
+        const result: GetDailySumAndBatchesResult = {
+            accountId,
+            metric: 'records',
+            // Days deliberately out of order.
+            series: [
+                {
+                    days: [
+                        { day: day(1), sum: 2000, batches: 2 },
+                        { day: day(0), sum: 1000, batches: 10 }
+                    ]
+                }
+            ]
+        };
+
+        const [out] = toRunningAvgUsage(result);
+
+        expect(out!.usage[0]!.timeframeStart).toEqual(day(0));
+        expect(out!.usage[0]!.quantity).toBe(100);
+        expect(out!.usage[1]!.timeframeStart).toEqual(day(1));
+        expect(out!.usage[1]!.quantity).toBe(250);
+    });
+
+    it('skips series with no days', () => {
+        const result: GetDailySumAndBatchesResult = {
+            accountId,
+            metric: 'connections',
+            series: [{ days: [] }, { dimension: 'integration_id', dimensionValue: 'a', days: [] }]
+        };
+        expect(toRunningAvgUsage(result)).toEqual([]);
+    });
+
+    it('handles a single-day series', () => {
+        const result: GetDailySumAndBatchesResult = {
+            accountId,
+            metric: 'connections',
+            series: [{ days: [{ day: day(0), sum: 210, batches: 3 }] }]
+        };
+        const [out] = toRunningAvgUsage(result);
+        expect(out!.usage).toEqual([{ timeframeStart: day(0), timeframeEnd: day(1), quantity: 70 }]);
+        expect(out!.total).toBe(70);
+    });
+
+    it('rounds running averages to the nearest integer (matches Orb wire shape)', () => {
+        // 100 / 3 = 33.33...
+        const result: GetDailySumAndBatchesResult = {
+            accountId,
+            metric: 'records',
+            series: [{ days: [{ day: day(0), sum: 100, batches: 3 }] }]
+        };
+        const [out] = toRunningAvgUsage(result);
+        expect(out!.usage[0]!.quantity).toBe(33);
+        expect(out!.total).toBe(33);
+    });
+});

--- a/packages/utils/lib/environment/parse.ts
+++ b/packages/utils/lib/environment/parse.ts
@@ -301,6 +301,11 @@ export const ENVS = z.object({
         .number()
         .optional()
         .default(3600 * 6), // 6 hour
+    // When true, `records` and `connections` in `getBillingUsage` come from
+    // ClickHouse (getDailySumAndBatches + toRunningAvgUsage) instead of Orb.
+    // Counter metrics still come from Orb. Off by default until per-day +
+    // cumulative parity (NAN-5684 / EXT-1138) clears against prod data.
+    USAGE_BILLING_AVG_FROM_CLICKHOUSE: z.stringbool().optional().default(false),
 
     // --- Third parties
     // AWS

--- a/packages/utils/lib/environment/parse.ts
+++ b/packages/utils/lib/environment/parse.ts
@@ -301,11 +301,13 @@ export const ENVS = z.object({
         .number()
         .optional()
         .default(3600 * 6), // 6 hour
-    // When true, `records` and `connections` in `getBillingUsage` come from
-    // ClickHouse (getDailySumAndBatches + toRunningAvgUsage) instead of Orb.
-    // Counter metrics still come from Orb. Off by default until per-day +
-    // cumulative parity (NAN-5684 / EXT-1138) clears against prod data.
-    USAGE_BILLING_AVG_FROM_CLICKHOUSE: z.stringbool().optional().default(false),
+    // When true, the dashboard path of `getBillingUsage` (granularity='day' +
+    // explicit timeframe) reads ALL metrics — counters and AVG — from
+    // ClickHouse and skips Orb entirely. Capping (`getBillingMetrics`, no
+    // granularity / timeframe) still hits Orb regardless. Off by default
+    // until per-day + cumulative parity (NAN-5684 / EXT-1138) clears
+    // against prod data.
+    USAGE_BILLING_FROM_CLICKHOUSE: z.stringbool().optional().default(false),
 
     // --- Third parties
     // AWS

--- a/packages/utils/lib/environment/parse.ts
+++ b/packages/utils/lib/environment/parse.ts
@@ -301,13 +301,14 @@ export const ENVS = z.object({
         .number()
         .optional()
         .default(3600 * 6), // 6 hour
-    // When true, the dashboard path of `getBillingUsage` (granularity='day' +
-    // explicit timeframe) reads ALL metrics — counters and AVG — from
-    // ClickHouse and skips Orb entirely. Capping (`getBillingMetrics`, no
-    // granularity / timeframe) still hits Orb regardless. Off by default
-    // until per-day + cumulative parity (NAN-5684 / EXT-1138) clears
-    // against prod data.
-    USAGE_BILLING_FROM_CLICKHOUSE: z.stringbool().optional().default(false),
+    // Gate that *permits* the per-request `source` override on
+    // `getBillingUsage` (dashboard path). When OFF (prod default), the
+    // `source` query param is ignored and the dashboard always uses Orb;
+    // when ON (dev), the param is honoured, letting individual sessions
+    // flip via localStorage('nango.billingUsageSource') without a redeploy.
+    // The flag does NOT change the default — even when on, missing override
+    // → Orb. Capping is unaffected (no override mechanism there).
+    ALLOW_OVERRIDE_GETUSAGE_SERVICE: z.stringbool().optional().default(false),
 
     // --- Third parties
     // AWS

--- a/packages/webapp/src/hooks/usePlan.tsx
+++ b/packages/webapp/src/hooks/usePlan.tsx
@@ -88,6 +88,24 @@ export function useApiGetUsage(env: string) {
 
 export const GetBillingUsageQueryKey = ['plans', 'billing-usage'];
 
+// Dev-tools toggle for flipping the billing-usage source per-request.
+// Set in the browser console with:
+//   localStorage.setItem('nango.billingUsageSource', 'clickhouse')   // or 'orb'
+//   localStorage.removeItem('nango.billingUsageSource')              // back to env default
+// Then reload the page (or wait for the next refetch). The server treats
+// missing as "use the env-level default" — no flipping in prod unless you
+// explicitly set the localStorage value.
+const BILLING_USAGE_SOURCE_KEY = 'nango.billingUsageSource';
+
+function readBillingUsageSourceOverride(): 'clickhouse' | 'orb' | null {
+    try {
+        const v = localStorage.getItem(BILLING_USAGE_SOURCE_KEY);
+        return v === 'clickhouse' || v === 'orb' ? v : null;
+    } catch {
+        return null;
+    }
+}
+
 export function useApiGetBillingUsage(env: string, timeframe?: { start: string; end: string }) {
     return useQuery<GetBillingUsage['Success'], APIError>({
         enabled: Boolean(env),
@@ -97,6 +115,10 @@ export function useApiGetBillingUsage(env: string, timeframe?: { start: string; 
             if (timeframe) {
                 params.append('from', timeframe.start);
                 params.append('to', timeframe.end);
+            }
+            const source = readBillingUsageSourceOverride();
+            if (source) {
+                params.append('source', source);
             }
 
             const res = await apiFetch(`/api/v1/plans/billing-usage?${params.toString()}`, {


### PR DESCRIPTION
## Summary

- **`Clickhouse.getDailySumAndBatches`** — new CH read method returning per-day `(sum, batches)` accumulators over `daily_raw_records` / `daily_raw_connections`. The two-number shape is needed because `view_mode='cumulative'` is a running **period average** across all batches in the window, which isn't reconstructible from per-day averages when batch counts differ — the formatter accumulates both and divides at every day boundary. Worked example in the docstring (10 batches × 100 vs 2 batches × 1000 → 250 truth vs 550 if you averaged daily averages). Type constrains `metric` to `records | connections` since `batch_id` is particular to those two. Restricts `Clickhouse.getUsage` to counter metrics in the same step.
- **`toRunningAvgUsage` + `toCounterBillingMetric` formatters** — added in `usage.ts` alongside `toCumulativeUsage` (Orb-path sibling). Turn the CH primitives into the `BillingUsageMetric[]` wire shape the dashboard already consumes from the Orb path. AVG side walks each series accumulating `running_sum`/`running_batches` and emits `Math.round(running_sum / running_batches)` per day. Counter side maps the `getUsage` per-day dataPoints into the same `usage[]` shape with `view_mode='periodic'`.
- **Dimension breakdown is additive to the global** (when shipped). `batches` is the same global per-day count across every dim value (JOIN against a per-day CTE), so per-dim running averages sum to the no-dim global at every day. The alternative (per-dim batch count) would give "average size of dim when present" — meaningful for an operational chart but wrong for a billing dashboard whose breakdown decomposes the bill total. Wiring the breakdown into the dashboard is a separate PR.
- **Per-request source override behind a dev gate.** `ALLOW_OVERRIDE_GETUSAGE_SERVICE` (default off) permits a `?source=clickhouse|orb` query param on `/plans/billing-usage`. Default stays Orb everywhere. The webapp reads `localStorage('nango.billingUsageSource')` and forwards it as the query param, so dev sessions can flip to CH per request without a redeploy. Prod stays safe by construction — even if someone sets the localStorage value, the server ignores the param without the gate.

Signature change: `getBillingUsage(subscriptionId, accountId, opts?)` gains `accountId` — both callers (internal `getBillingMetrics`, `/plans/billing-usage` controller) had it in scope already.

### Resolution flow

```
gate OFF (prod default):           source param ignored → Orb
gate ON (dev), source=clickhouse:  CH (counter + AVG, no Orb call)
gate ON (dev), source=orb:         Orb
gate ON (dev), source missing:     Orb (no implicit default flip)
```

### Dev-tools flow

```js
// browser console on dev
localStorage.setItem('nango.billingUsageSource', 'clickhouse')   // force CH on this session
localStorage.setItem('nango.billingUsageSource', 'orb')          // force Orb
localStorage.removeItem('nango.billingUsageSource')              // back to default (Orb)
// reload /plans/billing-usage
```

## Test plan

- [x] `npm run ts-build` clean
- [x] `getDailySumAndBatches` integration tests pass (records / no-dim, records by integration_id with additivity assertion, connections / no-dim, timeframe + account filtering) — 11/11
- [x] `toRunningAvgUsage` unit tests pass — worked example, additivity invariant, sort stability, empty/single-day, rounding — 6/6
- [ ] Post env PR [nango-environments#73](https://github.com/NangoHQ/nango-environments/pull/73): set `localStorage('nango.billingUsageSource')` to `clickhouse` in dev console, reload `/plans/billing-usage`, eyeball that all 7 metrics come from CH and match the Orb-path numbers within rounding before discussing promotion to staging / prod