### PR TITLE
fix(records): stop re-exporting test helper from package records

### DIFF
--- a/packages/jobs/lib/execution/sync.integration.test.ts
+++ b/packages/jobs/lib/execution/sync.integration.test.ts
@@ -1,7 +1,8 @@
 import { afterAll, beforeAll, describe, expect, it, vi } from 'vitest';
 
 import { multipleMigrations } from '@nangohq/database';
-import { clearDbTestsOnly as clearRecordsDb, format as recordsFormatter, records as recordsService } from '@nangohq/records';
+import { format as recordsFormatter, records as recordsService } from '@nangohq/records';
+import { clearDb as clearRecordsDb } from '@nangohq/records/lib/stores/postgres/tests/helpers.js';
 import { getLatestSyncJob, isSyncJobRunning, seeders, updateSyncJobResult } from '@nangohq/shared';
 import { Ok, stringifyError } from '@nangohq/utils';
 

--- a/packages/records/lib/index.ts
+++ b/packages/records/lib/index.ts
@@ -3,6 +3,5 @@ import { PostgresStore } from './stores/postgres/postgres.js';
 export * as format from './helpers/format.js';
 export { Cursor } from './cursor.js';
 export type * from './types.js';
-export { clearDb as clearDbTestsOnly } from './stores/postgres/tests/helpers.js';
 
 export const records = new PostgresStore();


### PR DESCRIPTION
`.dockerignore` strips `**/tests/` from the docker build context, so #6263's re-export of `clearDb` from a `tests/` file crashed the server on startup. Import the helper directly in the one test that uses it.