### PR TITLE
fix(proxy): restore header forwarding through redirects when byte-metering transport is active

### DIFF
--- a/packages/server/lib/controllers/proxy/allProxy.ts
+++ b/packages/server/lib/controllers/proxy/allProxy.ts
@@ -51,8 +51,7 @@ const schemaHeaders = z.object({
         .string()
         .regex(/^\d+(,\d+)*$/)
         .optional(),
-    // TODO: change default to 'false' after removing the metric in utils.ts
-    'forward-headers-on-redirect': z.enum(['true', 'false']).default('true'),
+    'forward-headers-on-redirect': z.enum(['true', 'false']).optional(),
     'nango-activity-log-id': z.string().max(255).optional(),
     'nango-is-sync': z.enum(['true', 'false']).optional(),
     'nango-is-dry-run': z.enum(['true', 'false']).optional()
@@ -93,7 +92,8 @@ export const allPublicProxy = asyncWrapper<AllPublicProxy>(async (req, res, next
     const retries = parsedHeaders['retries'];
     const decompress = parsedHeaders['decompress'] === 'true';
     const retryOn = parsedHeaders['retry-on'] ? parsedHeaders['retry-on'].split(',').map(Number) : null;
-    const forwardHeadersOnRedirect = parsedHeaders['forward-headers-on-redirect'] === 'true';
+    const forwardHeadersOnRedirect =
+        parsedHeaders['forward-headers-on-redirect'] !== undefined ? parsedHeaders['forward-headers-on-redirect'] === 'true' : undefined;
     const existingActivityLogId = parsedHeaders['nango-activity-log-id'];
     const isSync = parsedHeaders['nango-is-sync'] === 'true';
     const isDryRun = parsedHeaders['nango-is-dry-run'] === 'true';
@@ -211,7 +211,7 @@ export const allPublicProxy = asyncWrapper<AllPublicProxy>(async (req, res, next
                     method,
                     retryOn,
                     responseType: 'stream',
-                    forwardHeadersOnRedirect,
+                    ...(forwardHeadersOnRedirect !== undefined ? { forwardHeadersOnRedirect } : {}),
                     ...(baseUrlOverrideDenylist.size > 0
                         ? {
                               validateProxyRedirectUrl: (absoluteUrl: string) => {

--- a/packages/shared/lib/services/proxy/byte-metering-transport.ts
+++ b/packages/shared/lib/services/proxy/byte-metering-transport.ts
@@ -95,6 +95,13 @@ function withSocketMetering(nativeModule: NativeProtocolModule, onHopBytes: (byt
     };
 }
 
+function wireBeforeRedirect(options: TransportOptions, fn: (options: Record<string, unknown>, responseDetails?: unknown) => void): void {
+    const beforeRedirects = (options as unknown as Record<string, unknown>)['beforeRedirects'] as Record<string, unknown> | undefined;
+    if (beforeRedirects && !beforeRedirects['config']) {
+        beforeRedirects['config'] = fn;
+    }
+}
+
 /**
  * Axios-compatible `transport` that meters transferred bytes.
  *
@@ -124,10 +131,7 @@ export function createMeteringTransport(
     return {
         request(options, callback) {
             if (userBeforeRedirect) {
-                const beforeRedirects = (options as unknown as Record<string, unknown>)['beforeRedirects'] as Record<string, unknown> | undefined;
-                if (beforeRedirects && !beforeRedirects['config']) {
-                    beforeRedirects['config'] = userBeforeRedirect;
-                }
+                wireBeforeRedirect(options, userBeforeRedirect);
             }
             const target = options.protocol === 'https:' ? wrapped.https : wrapped.http;
             return target.request(options, callback);

--- a/packages/shared/lib/services/proxy/byte-metering-transport.ts
+++ b/packages/shared/lib/services/proxy/byte-metering-transport.ts
@@ -105,7 +105,12 @@ function withSocketMetering(nativeModule: NativeProtocolModule, onHopBytes: (byt
  * Each redirect hop runs through the bytes-metering wrapper independently and
  * invokes `onBytes` once per hop.
  */
-export function createMeteringTransport(onBytes: (bytes: MeteredBytes) => void): {
+export function createMeteringTransport(
+    onBytes: (bytes: MeteredBytes) => void,
+    // Axios skips wiring options.beforeRedirects.config for custom transports.
+    // Accept it here and wire it manually so header-forwarding still fires on redirects.
+    userBeforeRedirect?: (options: Record<string, unknown>, responseDetails?: unknown) => void
+): {
     request: (options: TransportOptions, callback?: TransportCallback) => ClientRequest;
 } {
     const meteredHttp = withSocketMetering(http, onBytes);
@@ -118,6 +123,12 @@ export function createMeteringTransport(onBytes: (bytes: MeteredBytes) => void):
 
     return {
         request(options, callback) {
+            if (userBeforeRedirect) {
+                const beforeRedirects = (options as unknown as Record<string, unknown>)['beforeRedirects'] as Record<string, unknown> | undefined;
+                if (beforeRedirects && !beforeRedirects['config']) {
+                    beforeRedirects['config'] = userBeforeRedirect;
+                }
+            }
             const target = options.protocol === 'https:' ? wrapped.https : wrapped.http;
             return target.request(options, callback);
         }

--- a/packages/shared/lib/services/proxy/byte-metering-transport.unit.test.ts
+++ b/packages/shared/lib/services/proxy/byte-metering-transport.unit.test.ts
@@ -251,31 +251,18 @@ describe('createMeteringTransport (socket bytes)', () => {
     });
 
     describe('userBeforeRedirect (header forwarding through redirects)', () => {
-        let redirectHandle: ServerHandle | undefined;
-        let targetHandle: ServerHandle | undefined;
-
-        afterEach(async () => {
-            if (redirectHandle) {
-                await closeServer(redirectHandle);
-                redirectHandle = undefined;
-            }
-            if (targetHandle) {
-                await closeServer(targetHandle);
-                targetHandle = undefined;
-            }
-        });
-
-        it('forwards headers through redirect when userBeforeRedirect is provided', async () => {
-            const capturedHeaders: http.IncomingHttpHeaders[] = [];
-
-            targetHandle = await startServer((req, res) => {
-                capturedHeaders.push(req.headers);
+        it('restores Authorization after cross-host redirect strips it', async () => {
+            // follow-redirects strips sensitive headers (Authorization, Cookie) on cross-host
+            // redirects. userBeforeRedirect must re-add them; a same-host redirect would not
+            // trigger stripping, so we need two servers on different ports here.
+            const targetHandle = await startServer((req, res) => {
                 res.writeHead(200, { 'content-type': 'application/json' });
                 res.end(JSON.stringify({ headers: req.headers }));
             });
+            const targetPort = targetHandle.port;
 
-            redirectHandle = await startServer((_req, res) => {
-                res.writeHead(302, { location: `http://127.0.0.1:${targetHandle!.port}/target` });
+            handle = await startServer((_req, res) => {
+                res.writeHead(302, { location: `http://127.0.0.1:${targetPort}/target` });
                 res.end();
             });
 
@@ -288,41 +275,45 @@ describe('createMeteringTransport (socket bytes)', () => {
             };
 
             const transport = createMeteringTransport(() => {}, userBeforeRedirect);
-            const res = await axios.request({
-                url: `http://127.0.0.1:${redirectHandle.port}/`,
-                method: 'GET',
-                headers: { ...headersToForward },
-                beforeRedirect: userBeforeRedirect as any,
-                transport: transport as any
-            });
-
-            expect(res.data.headers['authorization']).toBe('Bearer test-token');
-            expect(res.data.headers['x-custom']).toBe('value');
+            try {
+                const res = await axios.request({
+                    url: `http://127.0.0.1:${handle.port}/`,
+                    method: 'GET',
+                    headers: { ...headersToForward },
+                    beforeRedirect: userBeforeRedirect as any,
+                    transport: transport as any
+                });
+                expect(res.data.headers['authorization']).toBe('Bearer test-token');
+                expect(res.data.headers['x-custom']).toBe('value');
+            } finally {
+                await closeServer(targetHandle);
+            }
         });
 
-        it('does not forward headers when userBeforeRedirect is omitted', async () => {
-            const capturedHeaders: http.IncomingHttpHeaders[] = [];
-
-            targetHandle = await startServer((req, res) => {
-                capturedHeaders.push(req.headers);
+        it('strips Authorization on cross-host redirect when userBeforeRedirect is omitted', async () => {
+            const targetHandle = await startServer((req, res) => {
                 res.writeHead(200, { 'content-type': 'application/json' });
                 res.end(JSON.stringify({ headers: req.headers }));
             });
+            const targetPort = targetHandle.port;
 
-            redirectHandle = await startServer((_req, res) => {
-                res.writeHead(302, { location: `http://127.0.0.1:${targetHandle!.port}/target` });
+            handle = await startServer((_req, res) => {
+                res.writeHead(302, { location: `http://127.0.0.1:${targetPort}/target` });
                 res.end();
             });
 
             const transport = createMeteringTransport(() => {});
-            const res = await axios.request({
-                url: `http://127.0.0.1:${redirectHandle.port}/`,
-                method: 'GET',
-                headers: { authorization: 'Bearer test-token' },
-                transport: transport as any
-            });
-
-            expect(res.data.headers['authorization']).toBeUndefined();
+            try {
+                const res = await axios.request({
+                    url: `http://127.0.0.1:${handle.port}/`,
+                    method: 'GET',
+                    headers: { authorization: 'Bearer test-token' },
+                    transport: transport as any
+                });
+                expect(res.data.headers['authorization']).toBeUndefined();
+            } finally {
+                await closeServer(targetHandle);
+            }
         });
     });
 

--- a/packages/shared/lib/services/proxy/byte-metering-transport.unit.test.ts
+++ b/packages/shared/lib/services/proxy/byte-metering-transport.unit.test.ts
@@ -1,6 +1,7 @@
 import http from 'node:http';
 import zlib from 'node:zlib';
 
+import axios from 'axios';
 import { afterEach, describe, expect, it } from 'vitest';
 
 import { createMeteringTransport } from './byte-metering-transport.js';
@@ -247,6 +248,82 @@ describe('createMeteringTransport (socket bytes)', () => {
         expect(hops[1]!.received).toBeGreaterThanOrEqual(smallBody.length);
         expect(hops[1]!.received).toBeLessThan(largeBody.length); // delta reset — not accumulating across hops
         agent.destroy();
+    });
+
+    describe('userBeforeRedirect (header forwarding through redirects)', () => {
+        let redirectHandle: ServerHandle | undefined;
+        let targetHandle: ServerHandle | undefined;
+
+        afterEach(async () => {
+            if (redirectHandle) {
+                await closeServer(redirectHandle);
+                redirectHandle = undefined;
+            }
+            if (targetHandle) {
+                await closeServer(targetHandle);
+                targetHandle = undefined;
+            }
+        });
+
+        it('forwards headers through redirect when userBeforeRedirect is provided', async () => {
+            const capturedHeaders: http.IncomingHttpHeaders[] = [];
+
+            targetHandle = await startServer((req, res) => {
+                capturedHeaders.push(req.headers);
+                res.writeHead(200, { 'content-type': 'application/json' });
+                res.end(JSON.stringify({ headers: req.headers }));
+            });
+
+            redirectHandle = await startServer((_req, res) => {
+                res.writeHead(302, { location: `http://127.0.0.1:${targetHandle!.port}/target` });
+                res.end();
+            });
+
+            const headersToForward = { authorization: 'Bearer test-token', 'x-custom': 'value' };
+            const userBeforeRedirect = (options: Record<string, unknown>) => {
+                const hdrs = options['headers'] as Record<string, string>;
+                for (const [key, value] of Object.entries(headersToForward)) {
+                    hdrs[key] = value;
+                }
+            };
+
+            const transport = createMeteringTransport(() => {}, userBeforeRedirect);
+            const res = await axios.request({
+                url: `http://127.0.0.1:${redirectHandle.port}/`,
+                method: 'GET',
+                headers: { ...headersToForward },
+                beforeRedirect: userBeforeRedirect as any,
+                transport: transport as any
+            });
+
+            expect(res.data.headers['authorization']).toBe('Bearer test-token');
+            expect(res.data.headers['x-custom']).toBe('value');
+        });
+
+        it('does not forward headers when userBeforeRedirect is omitted', async () => {
+            const capturedHeaders: http.IncomingHttpHeaders[] = [];
+
+            targetHandle = await startServer((req, res) => {
+                capturedHeaders.push(req.headers);
+                res.writeHead(200, { 'content-type': 'application/json' });
+                res.end(JSON.stringify({ headers: req.headers }));
+            });
+
+            redirectHandle = await startServer((_req, res) => {
+                res.writeHead(302, { location: `http://127.0.0.1:${targetHandle!.port}/target` });
+                res.end();
+            });
+
+            const transport = createMeteringTransport(() => {});
+            const res = await axios.request({
+                url: `http://127.0.0.1:${redirectHandle.port}/`,
+                method: 'GET',
+                headers: { authorization: 'Bearer test-token' },
+                transport: transport as any
+            });
+
+            expect(res.data.headers['authorization']).toBeUndefined();
+        });
     });
 
     it('does not double-fire when both request write and response read complete', async () => {

--- a/packages/shared/lib/services/proxy/request.ts
+++ b/packages/shared/lib/services/proxy/request.ts
@@ -108,10 +108,13 @@ export class ProxyRequest {
                     const byteTotals = { sent: 0, received: 0 };
 
                     if (this.onBytes) {
-                        this.axiosConfig.transport = createMeteringTransport((bytes) => {
-                            byteTotals.sent += bytes.sent;
-                            byteTotals.received += bytes.received;
-                        });
+                        this.axiosConfig.transport = createMeteringTransport(
+                            (bytes) => {
+                                byteTotals.sent += bytes.sent;
+                                byteTotals.received += bytes.received;
+                            },
+                            this.axiosConfig.beforeRedirect as (opts: Record<string, unknown>) => void
+                        );
                     }
 
                     const start = new Date();

--- a/packages/shared/lib/services/proxy/utils.ts
+++ b/packages/shared/lib/services/proxy/utils.ts
@@ -4,7 +4,7 @@ import * as crypto from 'node:crypto';
 import FormData from 'form-data';
 import OAuth from 'oauth-1.0a';
 
-import { Err, Ok, SIGNATURE_METHOD, metrics } from '@nangohq/utils';
+import { Err, Ok, SIGNATURE_METHOD } from '@nangohq/utils';
 
 import {
     connectionCopyWithParsedConnectionConfig,
@@ -97,8 +97,8 @@ export function getAxiosConfiguration({
         headers
     };
 
-    // TODO: change default to false after removing the metric below
-    const shouldForward = proxyConfig.forwardHeadersOnRedirect ?? proxyConfig.provider.proxy?.forward_headers_on_redirect ?? true;
+    const shouldForward = proxyConfig.forwardHeadersOnRedirect ?? proxyConfig.provider.proxy?.forward_headers_on_redirect ?? false;
+
     axiosConfig.beforeRedirect = (options: Record<string, any>) => {
         if (proxyConfig.validateProxyRedirectUrl) {
             const absolute = absoluteUrlFromRedirectRequestOptions(options);
@@ -106,9 +106,7 @@ export function getAxiosConfiguration({
                 proxyConfig.validateProxyRedirectUrl(absolute);
             }
         }
-        metrics.increment(metrics.Types.PROXY_REDIRECT, 1, { provider: proxyConfig.providerName });
         if (shouldForward) {
-            // keep all headers from the original nango request, especially authorization as its dropped with axios follow-redirects
             Object.keys(headers).forEach((key) => {
                 if (headers[key]) {
                     options['headers'][key] = headers[key];

--- a/packages/shared/lib/services/proxy/utils.unit.test.ts
+++ b/packages/shared/lib/services/proxy/utils.unit.test.ts
@@ -1228,7 +1228,7 @@ describe('getAxiosConfiguration', () => {
         expect(axiosConfig.beforeRedirect).toBeDefined();
     });
 
-    it('should set beforeRedirect when forwardHeadersOnRedirect is false (to track metric)', () => {
+    it('should not forward headers when forwardHeadersOnRedirect is false', () => {
         const config = getDefaultProxy({
             provider: {
                 auth_mode: 'API_KEY',
@@ -1242,7 +1242,28 @@ describe('getAxiosConfiguration', () => {
             connection: getTestConnection({ credentials: { type: 'API_KEY', apiKey: 'secret' } })
         });
 
-        expect(axiosConfig.beforeRedirect).toBeDefined();
+        const redirectOptions: Record<string, any> = { headers: {} };
+        (axiosConfig.beforeRedirect as (opts: Record<string, any>) => void)(redirectOptions);
+        expect(redirectOptions['headers']['authorization']).toBeUndefined();
+    });
+
+    it('should forward headers when forwardHeadersOnRedirect is true', () => {
+        const config = getDefaultProxy({
+            provider: {
+                auth_mode: 'OAUTH2',
+                proxy: { base_url: 'https://api.example.com' }
+            },
+            forwardHeadersOnRedirect: true
+        });
+
+        const axiosConfig = getAxiosConfiguration({
+            proxyConfig: config,
+            connection: getTestConnection({ credentials: { type: 'OAUTH2', access_token: 'tok123', raw: {} } })
+        });
+
+        const redirectOptions: Record<string, any> = { headers: {} };
+        (axiosConfig.beforeRedirect as (opts: Record<string, any>) => void)(redirectOptions);
+        expect(redirectOptions['headers']['authorization']).toBe('Bearer tok123');
     });
 
     it('invokes validateProxyRedirectUrl with redirect href before other beforeRedirect work', () => {


### PR DESCRIPTION
## Describe the problem and your solution

- Fix redirect header forwarding when using custom axios transport. Wire the user-provided `beforeRedirect` callback into the metering transport so forwaded headers can be restored correctly across redirects, this is needed for providers like dayforce.

<!-- Issue ticket number and link (if applicable) -->

<!-- Testing instructions (skip if just adding/editing providers) -->

