### PR TITLE
feat(ci): deploy design system Storybook to storybook.nango.dev

### DIFF
--- a/.github/workflows/deploy-storybook.yml
+++ b/.github/workflows/deploy-storybook.yml
@@ -1,0 +1,49 @@
+name: '[Release] Deploy Storybook'
+run-name: '[Release] Deploy Storybook (${{ github.ref_name }})'
+
+on:
+    push:
+        branches:
+            - master
+        paths:
+            - 'packages/design-system/**'
+    workflow_dispatch: {}
+
+permissions: {}
+
+concurrency:
+    group: deploy-storybook
+    cancel-in-progress: true
+
+jobs:
+    deploy:
+        runs-on: ubuntu-latest
+        permissions:
+            id-token: write
+            contents: read
+        steps:
+            - name: Checkout
+              uses: actions/checkout@v4
+
+            - name: Install dependencies
+              run: npm ci
+
+            - name: Build Storybook
+              run: npm run -w @nangohq/design-system build-storybook
+
+            - name: Configure AWS credentials
+              uses: aws-actions/configure-aws-credentials@v4
+              with:
+                  role-to-assume: ${{ vars.STORYBOOK_DEPLOY_ROLE }}
+                  role-session-name: GitHub_to_AWS_via_FederatedOIDC
+                  aws-region: ${{ vars.AWS_REGION }}
+
+            - name: Deploy to S3
+              run: |
+                  aws s3 sync --delete packages/design-system/storybook-static/ s3://${{ vars.STORYBOOK_BUCKET }}
+
+            - name: Invalidate CloudFront cache
+              run: |
+                  aws cloudfront create-invalidation \
+                    --distribution-id ${{ vars.STORYBOOK_DISTRIBUTION_ID }} \
+                    --paths "/*"

--- a/.github/workflows/deploy-storybook.yml
+++ b/.github/workflows/deploy-storybook.yml
@@ -23,10 +23,12 @@ jobs:
             contents: read
         steps:
             - name: Checkout
-              uses: actions/checkout@v4
+              uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
+              with:
+                  persist-credentials: false
 
             - name: Setup Node.js
-              uses: actions/setup-node@v4
+              uses: actions/setup-node@1d817b21320d076a0e0a54e9adc2a01bbcdeff49 # v4.4.0
               with:
                   node-version-file: '.nvmrc'
                   cache: 'npm'
@@ -38,7 +40,7 @@ jobs:
               run: npm run -w @nangohq/design-system build-storybook
 
             - name: Configure AWS credentials
-              uses: aws-actions/configure-aws-credentials@v4
+              uses: aws-actions/configure-aws-credentials@7474bc4690e29a8392af63c5b98e7449536d5c3a # v4
               with:
                   role-to-assume: ${{ vars.STORYBOOK_DEPLOY_ROLE }}
                   role-session-name: GitHub_to_AWS_via_FederatedOIDC

--- a/.github/workflows/deploy-storybook.yml
+++ b/.github/workflows/deploy-storybook.yml
@@ -25,6 +25,12 @@ jobs:
             - name: Checkout
               uses: actions/checkout@v4
 
+            - name: Setup Node.js
+              uses: actions/setup-node@v4
+              with:
+                  node-version-file: '.nvmrc'
+                  cache: 'npm'
+
             - name: Install dependencies
               run: npm ci
 


### PR DESCRIPTION
## Problem

No publicly accessible Storybook instance exists for the design system — reviewing implemented components requires running Storybook locally.

## Solution

Adds a GitHub Actions workflow that deploys the design system Storybook to `storybook.nango.dev` (via S3 + CloudFront, provisioned in the companion nango-infra PR).

- Auto-deploys on every push to `master` when `packages/design-system/**` changes
- Also supports manual dispatch (`workflow_dispatch`) — run the workflow from any branch in the GitHub UI to push a preview to `storybook.nango.dev`
- Reads three repo-level GitHub Actions variables set after the infra PR is applied: `STORYBOOK_DEPLOY_ROLE`, `STORYBOOK_BUCKET`, `STORYBOOK_DISTRIBUTION_ID`

Companion infra PR: https://github.com/NangoHQ/nango-infra/pull/139

Closes [NAN-5773](https://linear.app/nango/issue/NAN-5773)

## Testing

- Workflow triggers correctly on `packages/design-system/**` changes to `master`
- Manual dispatch deploys from the selected branch
- After infra is applied and GitHub vars are set: `storybook.nango.dev` serves the built Storybook
