### PR TITLE
fix(docker): update Postgres image pins

### DIFF
--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -1,7 +1,7 @@
 version: '3.9'
 services:
     nango-db:
-        image: postgres:16.0-alpine
+        image: postgres:16.14-alpine
         container_name: nango-db
         environment:
             POSTGRES_PASSWORD: nango

--- a/tests/setup.ts
+++ b/tests/setup.ts
@@ -34,7 +34,7 @@ async function setupPostgres() {
     const dbName = 'postgres';
     const user = 'postgres';
     const password = 'nango_test';
-    const container = new PostgreSqlContainer('postgres:15.5-alpine');
+    const container = new PostgreSqlContainer('postgres:16.14-alpine');
     const pg = await container
         .withDatabase(dbName)
         .withUsername(user)


### PR DESCRIPTION
## Describe the problem and your solution

Nango's public self-host compose file pins Postgres to `postgres:16.0-alpine`, and the testcontainer setup still uses `postgres:15.5-alpine`.

This updates two Postgres image references to `postgres:16.14-alpine`:

- `docker-compose.yaml`: `postgres:16.0-alpine` -> `postgres:16.14-alpine`
- `tests/setup.ts`: `postgres:15.5-alpine` -> `postgres:16.14-alpine`

For the public compose file, this stays within the existing Postgres 16 major line while picking up the current patch release. For testcontainer usage, this aligns the ephemeral integration-test database with the public self-host Postgres baseline.

This intentionally leaves `dev/docker-compose.dev.yaml` on `postgres:15.5-alpine` because it uses a persistent bind-mounted `./nango-data` directory. Moving that dev compose file from Postgres 15 to 16 should include a migration or reset plan so existing local developer databases do not fail to start.

## Issue ticket number and link

Fixes #6287.

## Testing instructions

- `docker compose -f docker-compose.yaml config`
- `docker compose -f dev/docker-compose.dev.yaml config`
- `git diff --check`
- Commit hook completed successfully:
  - `prettier --write`
  - `eslint --fix --quiet`
