### PR TITLE
feat(integrations): add Signaliz provider

### DIFF
--- a/docs/api-catalog.txt
+++ b/docs/api-catalog.txt
@@ -2,7 +2,7 @@
 
 > Compact provider slug catalog for agents. Use the slug to reconstruct provider-specific docs URLs only when needed.
 
-Provider count: 831
+Provider count: 832
 
 URL patterns:
 - Main provider page: https://nango.dev/docs/integrations/all/{slug}.md or https://nango.dev/docs/api-integrations/{slug}.md
@@ -676,6 +676,7 @@ URL patterns:
 | `shopware` | Shopware (Admin API) | OAUTH2_CC | [docs](https://nango.dev/docs/api-integrations/shopware.md) | [connect](https://nango.dev/docs/api-integrations/shopware/connect.md) |  | e-commerce |
 | `shopworks` | ShopWorks | TWO_STEP | [docs](https://nango.dev/docs/api-integrations/shopworks.md) | [connect](https://nango.dev/docs/api-integrations/shopworks/connect.md) |  | other |
 | `shortcut` | Shortcut | API_KEY | [docs](https://nango.dev/docs/integrations/all/shortcut.md) |  |  | dev-tools, productivity |
+| `signaliz` | Signaliz | API_KEY | [docs](https://nango.dev/docs/integrations/all/signaliz.md) | [connect](https://nango.dev/docs/integrations/all/signaliz/connect.md) |  | marketing, dev-tools |
 | `signnow` | SignNow | OAUTH2 | [docs](https://nango.dev/docs/integrations/all/signnow.md) |  |  | legal |
 | `signnow-sandbox` | SignNow (Sandbox) | OAUTH2 | [docs](https://nango.dev/docs/integrations/all/signnow-sandbox.md) |  |  | legal |
 | `simpro` | Simpro | OAUTH2 | [docs](https://nango.dev/docs/api-integrations/simpro.md) | [connect](https://nango.dev/docs/api-integrations/simpro/connect.md) | [setup](https://nango.dev/docs/api-integrations/simpro/how-to-register-your-own-simpro-api-oauth-app.md) | productivity, invoicing |

--- a/docs/docs.json
+++ b/docs/docs.json
@@ -1562,6 +1562,7 @@
               "integrations/all/shortcut",
               "integrations/all/signnow",
               "integrations/all/signnow-sandbox",
+              "integrations/all/signaliz",
               "integrations/all/skio",
               "api-integrations/simpro",
               "api-integrations/slab",

--- a/docs/integrations/all/signaliz.mdx
+++ b/docs/integrations/all/signaliz.mdx
@@ -1,0 +1,52 @@
+---
+title: Signaliz
+sidebarTitle: Signaliz
+---
+
+import Overview from "/snippets/overview.mdx"
+import PreBuiltTooling from "/snippets/generated/signaliz/PreBuiltTooling.mdx"
+import PreBuiltUseCases from "/snippets/generated/signaliz/PreBuiltUseCases.mdx"
+
+<Overview />
+<PreBuiltTooling />
+<PreBuiltUseCases />
+
+## Access requirements
+| Pre-Requisites | Status | Comment |
+| - | - | - |
+| Signaliz account | Required | Needed to create a workspace API key. |
+| Paid plan | Optional | Paid plans include full API and MCP access with monthly fresh enrichment credits. |
+| Partnership | Not required |  |
+| App review | Not required |  |
+| Security audit | Not required |  |
+
+## Setup guide
+
+See the [Signaliz connect guide](/integrations/all/signaliz/connect) to create an API key and add it to Nango.
+
+<Note>Contribute improvements to the setup guide by [editing this page](https://github.com/nangohq/nango/tree/master/docs/integrations/all/signaliz.mdx)</Note>
+
+## Useful links
+
+- [Signaliz API documentation](https://signaliz.docs.buildwithfern.com/signaliz-api-public-docs/introduction)
+- [Signaliz REST API quickstart](https://help.signaliz.com/en/articles/14-rest-api-quickstart)
+- [Signaliz API keys and authentication](https://help.signaliz.com/en/articles/15-api-keys-and-authentication)
+- [Signaliz MCP documentation](https://signaliz.docs.buildwithfern.com/signaliz-api-public-docs/mcp-server)
+- [Signaliz homepage](https://signaliz.com)
+
+<Note>Contribute useful links by [editing this page](https://github.com/nangohq/nango/tree/master/docs/integrations/all/signaliz.mdx)</Note>
+
+## API gotchas
+
+- Signaliz uses `API_KEY` auth mode with `Authorization: Bearer API_KEY` in the request header.
+- The Nango proxy base URL is `https://api.signaliz.com`. Use the full Signaliz endpoint path when proxying requests, such as `/functions/v1/email-verification-2`, `/functions/v1/find-verified-email-v2`, `/functions/v1/company-signal-enrichment-v2`, `/functions/v1/custom-ai-prompt`, `/functions/v1/lead-generation-v2`, `/functions/v1/find-people-v2`, `/functions/v1/find-companies-v2`, or `/functions/v1/signaliz-mcp`.
+- API reads and MCP access are included on paid Signaliz plans. Fresh provider-backed work, live email verification, premium discovery, and Signaliz-hosted AI can consume fresh enrichment credits.
+- The hosted Signaliz MCP endpoint uses the same workspace API key and accepts JSON-RPC requests at `/functions/v1/signaliz-mcp`.
+
+<Note>Contribute API gotchas by [editing this page](https://github.com/nangohq/nango/tree/master/docs/integrations/all/signaliz.mdx)</Note>
+
+## Going further
+
+<Card title="Connect to Signaliz" icon="link" href="/integrations/all/signaliz/connect" horizontal>
+  Guide to connect to Signaliz using Nango Connect.
+</Card>

--- a/docs/integrations/all/signaliz/connect.mdx
+++ b/docs/integrations/all/signaliz/connect.mdx
@@ -1,0 +1,34 @@
+---
+title: Signaliz - How do I link my account?
+sidebarTitle: Signaliz
+---
+
+# Overview
+
+To authenticate with Signaliz, you need:
+
+1. **API Key** - A workspace API key that lets Nango proxy requests to Signaliz REST and MCP endpoints.
+
+This guide walks you through creating a Signaliz API key and adding it to Nango.
+
+### Prerequisites
+
+- You must have a Signaliz account and workspace.
+
+### Step 1: Create a Signaliz API key
+
+1. Log in to your Signaliz workspace.
+2. Open **Settings**.
+3. Go to **Developer** or **API Access**.
+4. Create a new API key.
+5. Copy the API key and store it securely. API keys should be treated like passwords.
+
+### Step 2: Enter credentials in the Connect UI
+
+Once you have your **API Key**:
+
+1. Open the form where you need to authenticate with Signaliz.
+2. Enter your **API Key** in its field.
+3. Submit the form to complete the connection.
+
+You are now connected to Signaliz.

--- a/docs/llms-full.txt
+++ b/docs/llms-full.txt
@@ -14364,6 +14364,7 @@ Use these slugs to construct provider-specific docs URLs only when needed.
 | `shopware` | Shopware (Admin API) | OAUTH2_CC | [docs](https://nango.dev/docs/api-integrations/shopware.md) | [connect](https://nango.dev/docs/api-integrations/shopware/connect.md) |  | e-commerce |
 | `shopworks` | ShopWorks | TWO_STEP | [docs](https://nango.dev/docs/api-integrations/shopworks.md) | [connect](https://nango.dev/docs/api-integrations/shopworks/connect.md) |  | other |
 | `shortcut` | Shortcut | API_KEY | [docs](https://nango.dev/docs/integrations/all/shortcut.md) |  |  | dev-tools, productivity |
+| `signaliz` | Signaliz | API_KEY | [docs](https://nango.dev/docs/integrations/all/signaliz.md) | [connect](https://nango.dev/docs/integrations/all/signaliz/connect.md) |  | marketing, dev-tools |
 | `signnow` | SignNow | OAUTH2 | [docs](https://nango.dev/docs/integrations/all/signnow.md) |  |  | legal |
 | `signnow-sandbox` | SignNow (Sandbox) | OAUTH2 | [docs](https://nango.dev/docs/integrations/all/signnow-sandbox.md) |  |  | legal |
 | `simpro` | Simpro | OAUTH2 | [docs](https://nango.dev/docs/api-integrations/simpro.md) | [connect](https://nango.dev/docs/api-integrations/simpro/connect.md) | [setup](https://nango.dev/docs/api-integrations/simpro/how-to-register-your-own-simpro-api-oauth-app.md) | productivity, invoicing |

--- a/docs/llms.txt
+++ b/docs/llms.txt
@@ -134,7 +134,7 @@ Use provider URLs by replacing `{slug}` with a slug from the API catalog:
 
 ## APIs and integrations
 
-- [API catalog](https://nango.dev/docs/api-catalog.txt): 831 provider slugs with canonical docs routes, auth modes, setup guides, and connect guides.
+- [API catalog](https://nango.dev/docs/api-catalog.txt): 832 provider slugs with canonical docs routes, auth modes, setup guides, and connect guides.
 - Provider-specific pages are intentionally not expanded here so core Nango guides remain easy for agents to find.
 
 ## Optional

--- a/docs/snippets/generated/signaliz/PreBuiltTooling.mdx
+++ b/docs/snippets/generated/signaliz/PreBuiltTooling.mdx
@@ -1,0 +1,40 @@
+## Pre-built tooling
+<AccordionGroup>
+<Accordion title="✅ Authorization">
+| Tools | Status |
+| - | - |
+| Pre-built authorization (API Key) | ✅ |
+| Pre-built authorization UI | ✅ |
+| Custom authorization UI | ✅ |
+| End-user authorization guide | ✅ |
+| Expired credentials detection | ✅ |
+</Accordion>
+<Accordion title="✅ Read & write data">
+| Tools | Status |
+| - | - |
+| Pre-built integrations | 🚫 (time to contribute: &lt;48h) |
+| API unification | ✅ |
+| 2-way sync | ✅ |
+| Webhooks from Nango on data modifications | ✅ |
+| Real-time webhooks from 3rd-party API | 🚫 (time to contribute: &lt;48h) |
+| Proxy requests | ✅ |
+</Accordion>
+<Accordion title="✅ Observability & data quality">
+| Tools | Status |
+| - | - |
+| HTTP request logging | ✅ |
+| End-to-end type safety | ✅ |
+| Data runtime validation | ✅ |
+| OpenTelemetry export | ✅ |
+| Slack alerts on errors | ✅ |
+| Integration status API | ✅ |
+</Accordion>
+<Accordion title="✅ Customization">
+| Tools | Status |
+| - | - |
+| Create or customize use-cases | ✅ |
+| Pre-configured pagination | 🚫 (time to contribute: &lt;48h) |
+| Pre-configured rate-limit handling | 🚫 (time to contribute: &lt;48h) |
+| Per-customer configurations | ✅ |
+</Accordion>
+</AccordionGroup>

--- a/docs/snippets/generated/signaliz/PreBuiltUseCases.mdx
+++ b/docs/snippets/generated/signaliz/PreBuiltUseCases.mdx
@@ -1,0 +1,3 @@
+_No pre-built syncs or actions available yet._
+
+<Tip>Not seeing the integration you need? [Build your own](/guides/functions/functions-guide) independently.</Tip>

--- a/packages/providers/providers.yaml
+++ b/packages/providers/providers.yaml
@@ -17491,6 +17491,44 @@ signnow-sandbox:
         base_url: https://api-eval.signnow.com
     docs: https://nango.dev/docs/integrations/all/signnow-sandbox
 
+signaliz:
+    display_name: Signaliz
+    categories:
+        - marketing
+        - dev-tools
+    auth_mode: API_KEY
+    proxy:
+        base_url: https://api.signaliz.com
+        headers:
+            authorization: Bearer ${apiKey}
+            content-type: application/json
+        verification:
+            method: POST
+            headers:
+                content-type: application/json
+                accept: application/json,text/event-stream
+            endpoints:
+                - /functions/v1/signaliz-mcp
+            data:
+                jsonrpc: '2.0'
+                id: 1
+                method: initialize
+                params:
+                    protocolVersion: '2024-11-05'
+                    capabilities: {}
+                    clientInfo:
+                        name: nango-client
+                        version: '1.0.0'
+    docs: https://nango.dev/docs/integrations/all/signaliz
+    docs_connect: https://nango.dev/docs/integrations/all/signaliz/connect
+    credentials:
+        apiKey:
+            type: string
+            title: API Key
+            description: The API key for your Signaliz workspace
+            example: sk_live_...
+            doc_section: '#step-1-create-a-signaliz-api-key'
+
 servicenow:
     display_name: ServiceNow
     categories:

--- a/packages/webapp/public/images/template-logos/signaliz.svg
+++ b/packages/webapp/public/images/template-logos/signaliz.svg
@@ -1,0 +1,16 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="64" height="64" viewBox="0 0 64 64" fill="none">
+  <rect width="64" height="64" rx="32" fill="#070B1A"/>
+  <path d="M32 6.5C46.083 6.5 57.5 17.917 57.5 32S46.083 57.5 32 57.5 6.5 46.083 6.5 32 17.917 6.5 32 6.5Z" stroke="url(#signaliz_ring)" stroke-width="3"/>
+  <path d="M9.5 35.2H21.8L26.9 25.4L31.4 42.4L37.3 18.4L42.4 35.2H54.5" stroke="url(#signaliz_wave)" stroke-width="4" stroke-linecap="round" stroke-linejoin="round"/>
+  <defs>
+    <linearGradient id="signaliz_ring" x1="14" y1="51" x2="49.5" y2="11" gradientUnits="userSpaceOnUse">
+      <stop stop-color="#00D5FF"/>
+      <stop offset="1" stop-color="#A855F7"/>
+    </linearGradient>
+    <linearGradient id="signaliz_wave" x1="10" y1="42" x2="51" y2="21" gradientUnits="userSpaceOnUse">
+      <stop stop-color="#00D5FF"/>
+      <stop offset="0.55" stop-color="#3B82F6"/>
+      <stop offset="1" stop-color="#A855F7"/>
+    </linearGradient>
+  </defs>
+</svg>


### PR DESCRIPTION
## Summary
- Add Signaliz as an API key provider with https://api.signaliz.com proxy support.
- Add Signaliz docs, connect guide, generated snippets, logo, docs nav, and generated agent catalogs.
- Use a non-spendful Signaliz MCP initialize request as provider credential verification.

## Validation
- npm run docs:generate
- npm run test:providers
- git diff --check
