### PR TITLE
feat(storybook): catalog v1 and v2 components

### DIFF
--- a/.github/workflows/deploy-storybook.yml
+++ b/.github/workflows/deploy-storybook.yml
@@ -7,6 +7,7 @@ on:
             - master
         paths:
             - 'packages/design-system/**'
+            - 'packages/webapp/**'
     workflow_dispatch: {}
 
 permissions: {}

--- a/.github/workflows/deploy-storybook.yml
+++ b/.github/workflows/deploy-storybook.yml
@@ -28,7 +28,7 @@ jobs:
                   persist-credentials: false
 
             - name: Setup Node.js
-              uses: actions/setup-node@1d817b21320d076a0e0a54e9adc2a01bbcdeff49 # v4.4.0
+              uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4
               with:
                   node-version-file: '.nvmrc'
                   cache: 'npm'

--- a/.github/workflows/deploy-storybook.yml
+++ b/.github/workflows/deploy-storybook.yml
@@ -45,7 +45,7 @@ jobs:
               with:
                   role-to-assume: ${{ vars.STORYBOOK_DEPLOY_ROLE }}
                   role-session-name: GitHub_to_AWS_via_FederatedOIDC
-                  aws-region: ${{ vars.AWS_REGION }}
+                  aws-region: us-west-2
 
             - name: Deploy to S3
               run: |

--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -273,10 +273,13 @@ export default tseslint.config(
     {
         // Design-system: disable type-aware rules to avoid loading a second
         // TypeScript program alongside the root one, which OOMs in CI.
-        files: ['packages/design-system/{src,tokens,.storybook}/**/*.{tsx,ts}'],
+        files: ['packages/design-system/{src,tokens,.storybook,stories}/**/*.{tsx,ts}'],
         extends: [tseslint.configs.disableTypeChecked],
         rules: {
-            'import/extensions': 'off'
+            'import/extensions': 'off',
+            // Stories import webapp packages (lucide-react, recharts, etc.) that live in
+            // the monorepo root node_modules but are not listed in design-system's package.json.
+            'import/no-extraneous-dependencies': 'off'
         }
     },
     {

--- a/packages/design-system/.storybook/main.ts
+++ b/packages/design-system/.storybook/main.ts
@@ -1,19 +1,39 @@
+import path from 'node:path';
+import { fileURLToPath } from 'node:url';
+
 import tailwindcss from '@tailwindcss/vite';
+
+const __dirname = path.dirname(fileURLToPath(import.meta.url));
 
 import type { StorybookConfig } from '@storybook/react-vite';
 import type { InlineConfig } from 'vite';
 
 const config: StorybookConfig = {
-    stories: ['../tokens/**/*.stories.@(ts|tsx)'],
+    stories: ['../tokens/**/*.stories.@(ts|tsx)', '../stories/**/*.stories.@(ts|tsx)'],
     addons: ['@storybook/addon-a11y', '@storybook/addon-mcp', '@storybook/addon-themes'],
     framework: {
         name: '@storybook/react-vite',
         options: {}
     },
     viteFinal(config): InlineConfig {
+        const existingAlias = Array.isArray(config.resolve?.alias) ? {} : (config.resolve?.alias ?? {});
         return {
             ...config,
-            plugins: [...(config.plugins ?? []), tailwindcss()]
+            plugins: [...(config.plugins ?? []), tailwindcss()],
+            resolve: {
+                ...config.resolve,
+                alias: {
+                    ...existingAlias,
+                    '@': path.resolve(__dirname, '../../webapp/src'),
+                    '@tabler/icons-react': '@tabler/icons-react/dist/esm/icons/index.mjs'
+                }
+            },
+            server: {
+                ...config.server,
+                fs: {
+                    allow: [path.resolve(__dirname, '../..')]
+                }
+            }
         };
     }
 };

--- a/packages/design-system/.storybook/preview.css
+++ b/packages/design-system/.storybook/preview.css
@@ -1,5 +1,7 @@
-@import 'tailwindcss';
-@import '../tokens/tokens.generated.css';
+@import '../../webapp/src/index.css';
+
+/* Tell Tailwind v4 to scan webapp source files for utility classes */
+@source '../../webapp/src';
 
 /* Wire Tailwind's font-sans / font-mono utilities to the DS fonts */
 @theme {

--- a/packages/design-system/.storybook/preview.ts
+++ b/packages/design-system/.storybook/preview.ts
@@ -27,6 +27,11 @@ const preview: Preview = {
         withDarkClass
     ],
     parameters: {
+        options: {
+            storySort: {
+                method: 'alphabetical'
+            }
+        },
         controls: {
             matchers: {
                 color: /(background|color)$/i,

--- a/packages/design-system/.storybook/preview.ts
+++ b/packages/design-system/.storybook/preview.ts
@@ -1,5 +1,5 @@
-import { useEffect } from 'react';
 import { withThemeByDataAttribute } from '@storybook/addon-themes';
+import { useEffect } from 'react';
 
 import type { Preview, StoryContext, StoryFn } from '@storybook/react';
 import './preview.css';

--- a/packages/design-system/.storybook/preview.ts
+++ b/packages/design-system/.storybook/preview.ts
@@ -1,7 +1,18 @@
+import { useEffect } from 'react';
 import { withThemeByDataAttribute } from '@storybook/addon-themes';
 
-import type { Preview } from '@storybook/react';
+import type { Preview, StoryContext, StoryFn } from '@storybook/react';
 import './preview.css';
+
+// tokens.generated.css uses [data-theme="dark"]; webapp uses .dark class.
+// This second decorator syncs both so both token stories and component stories theme correctly.
+const withDarkClass = (Story: StoryFn, context: StoryContext) => {
+    const isDark = context.globals['theme'] === 'dark';
+    useEffect(() => {
+        document.documentElement.classList.toggle('dark', isDark);
+    }, [isDark]);
+    return Story(context.args, context);
+};
 
 const preview: Preview = {
     decorators: [
@@ -12,7 +23,8 @@ const preview: Preview = {
             },
             defaultTheme: 'light',
             attributeName: 'data-theme'
-        })
+        }),
+        withDarkClass
     ],
     parameters: {
         controls: {

--- a/packages/design-system/stories/Alert.stories.tsx
+++ b/packages/design-system/stories/Alert.stories.tsx
@@ -5,7 +5,7 @@ import { Alert, AlertActions, AlertButton, AlertDescription, AlertTitle } from '
 import type { Meta, StoryObj } from '@storybook/react-vite';
 
 const meta: Meta = {
-    title: 'Components v2/Alert',
+    title: 'Components v2/UI/Alert',
     parameters: { layout: 'padded' }
 };
 export default meta;

--- a/packages/design-system/stories/Alert.stories.tsx
+++ b/packages/design-system/stories/Alert.stories.tsx
@@ -1,0 +1,44 @@
+import { CircleCheck } from 'lucide-react';
+
+import { Alert, AlertActions, AlertButton, AlertDescription, AlertTitle } from '@/components-v2/ui/Alert';
+
+import type { Meta, StoryObj } from '@storybook/react-vite';
+
+const meta: Meta = {
+    title: 'Components v2/Alert',
+    parameters: { layout: 'padded' }
+};
+export default meta;
+type Story = StoryObj<typeof meta>;
+
+const VARIANTS = ['success', 'info', 'warning', 'error'] as const;
+
+export const Default: Story = {
+    render: () => (
+        <div className="flex flex-col gap-4 max-w-2xl">
+            {VARIANTS.map((variant) => (
+                <Alert key={variant} variant={variant}>
+                    <CircleCheck />
+                    <AlertTitle className="capitalize">{variant}</AlertTitle>
+                    <AlertDescription>Your integration is connected and syncing.</AlertDescription>
+                    <AlertActions>
+                        <AlertButton variant={`${variant}-secondary`}>View logs</AlertButton>
+                    </AlertActions>
+                </Alert>
+            ))}
+        </div>
+    )
+};
+
+export const NoIcon: Story = {
+    name: 'No icon',
+    render: () => (
+        <div className="flex flex-col gap-4 max-w-2xl">
+            {VARIANTS.map((variant) => (
+                <Alert key={variant} variant={variant}>
+                    <AlertDescription>Token expires in 3 days — {variant}.</AlertDescription>
+                </Alert>
+            ))}
+        </div>
+    )
+};

--- a/packages/design-system/stories/Avatar.stories.tsx
+++ b/packages/design-system/stories/Avatar.stories.tsx
@@ -3,7 +3,7 @@ import { Avatar } from '@/components-v2/ui/Avatar';
 import type { Meta, StoryObj } from '@storybook/react-vite';
 
 const meta: Meta = {
-    title: 'Components v2/Avatar',
+    title: 'Components v2/UI/Avatar',
     parameters: { layout: 'padded' }
 };
 export default meta;

--- a/packages/design-system/stories/Avatar.stories.tsx
+++ b/packages/design-system/stories/Avatar.stories.tsx
@@ -1,0 +1,29 @@
+import { Avatar } from '@/components-v2/ui/Avatar';
+
+import type { Meta, StoryObj } from '@storybook/react-vite';
+
+const meta: Meta = {
+    title: 'Components v2/Avatar',
+    parameters: { layout: 'padded' }
+};
+export default meta;
+type Story = StoryObj<typeof meta>;
+
+const EXAMPLES = [
+    { name: 'John Doe', label: 'Two words' },
+    { name: 'Nango', label: 'Single word' },
+    { name: 'Acme/Production', label: 'Slash separator' }
+];
+
+export const Default: Story = {
+    render: () => (
+        <div className="flex items-center gap-6">
+            {EXAMPLES.map(({ name, label }) => (
+                <div key={name} className="flex flex-col items-center gap-2">
+                    <Avatar name={name} />
+                    <span className="story-section-heading">{label}</span>
+                </div>
+            ))}
+        </div>
+    )
+};

--- a/packages/design-system/stories/Badge.stories.tsx
+++ b/packages/design-system/stories/Badge.stories.tsx
@@ -3,7 +3,7 @@ import { Badge } from '@/components-v2/ui/Badge';
 import type { Meta, StoryObj } from '@storybook/react-vite';
 
 const meta: Meta = {
-    title: 'Components v2/Badge',
+    title: 'Components v2/UI/Badge',
     parameters: { layout: 'padded' }
 };
 export default meta;

--- a/packages/design-system/stories/Badge.stories.tsx
+++ b/packages/design-system/stories/Badge.stories.tsx
@@ -1,0 +1,24 @@
+import { Badge } from '@/components-v2/ui/Badge';
+
+import type { Meta, StoryObj } from '@storybook/react-vite';
+
+const meta: Meta = {
+    title: 'Components v2/Badge',
+    parameters: { layout: 'padded' }
+};
+export default meta;
+type Story = StoryObj<typeof meta>;
+
+const VARIANTS = ['gray', 'secondary', 'brand', 'mint', 'pink', 'yellow', 'green', 'ghost'] as const;
+
+export const Default: Story = {
+    render: () => (
+        <div className="flex items-center gap-3 flex-wrap">
+            {VARIANTS.map((variant) => (
+                <Badge key={variant} variant={variant}>
+                    {variant}
+                </Badge>
+            ))}
+        </div>
+    )
+};

--- a/packages/design-system/stories/BinaryToggle.stories.tsx
+++ b/packages/design-system/stories/BinaryToggle.stories.tsx
@@ -5,7 +5,7 @@ import { BinaryToggle } from '@/components-v2/ui/BinaryToggle';
 import type { Meta, StoryObj } from '@storybook/react-vite';
 
 const meta: Meta = {
-    title: 'Components v2/BinaryToggle',
+    title: 'Components v2/UI/BinaryToggle',
     parameters: { layout: 'padded' }
 };
 export default meta;

--- a/packages/design-system/stories/BinaryToggle.stories.tsx
+++ b/packages/design-system/stories/BinaryToggle.stories.tsx
@@ -1,0 +1,31 @@
+import { fn } from 'storybook/test';
+
+import { BinaryToggle } from '@/components-v2/ui/BinaryToggle';
+
+import type { Meta, StoryObj } from '@storybook/react-vite';
+
+const meta: Meta = {
+    title: 'Components v2/BinaryToggle',
+    parameters: { layout: 'padded' }
+};
+export default meta;
+type Story = StoryObj<typeof meta>;
+
+export const Default: Story = {
+    render: () => (
+        <div className="flex items-center gap-6">
+            <div className="flex flex-col gap-2">
+                <span className="story-section-heading">Off</span>
+                <BinaryToggle value={false} offLabel="List" onLabel="Grid" onChange={fn()} />
+            </div>
+            <div className="flex flex-col gap-2">
+                <span className="story-section-heading">On</span>
+                <BinaryToggle value={true} offLabel="List" onLabel="Grid" onChange={fn()} />
+            </div>
+            <div className="flex flex-col gap-2">
+                <span className="story-section-heading">Disabled</span>
+                <BinaryToggle value={false} offLabel="List" onLabel="Grid" onChange={fn()} disabled />
+            </div>
+        </div>
+    )
+};

--- a/packages/design-system/stories/Button.stories.tsx
+++ b/packages/design-system/stories/Button.stories.tsx
@@ -3,7 +3,7 @@ import { Button } from '@/components-v2/ui/Button';
 import type { Meta, StoryObj } from '@storybook/react-vite';
 
 const meta: Meta = {
-    title: 'Components v2/Button',
+    title: 'Components v2/UI/Button',
     parameters: { layout: 'padded' }
 };
 export default meta;

--- a/packages/design-system/stories/Button.stories.tsx
+++ b/packages/design-system/stories/Button.stories.tsx
@@ -1,0 +1,34 @@
+import { Button } from '@/components-v2/ui/Button';
+
+import type { Meta, StoryObj } from '@storybook/react-vite';
+
+const meta: Meta = {
+    title: 'Components v2/Button',
+    parameters: { layout: 'padded' }
+};
+export default meta;
+type Story = StoryObj<typeof meta>;
+
+const VARIANTS = ['primary', 'secondary', 'tertiary', 'destructive', 'ghost'] as const;
+
+export const Default: Story = {
+    render: () => (
+        <div className="flex flex-col gap-6">
+            {VARIANTS.map((variant) => (
+                <div key={variant} className="flex items-center gap-4 flex-wrap">
+                    <span className="story-section-heading w-24 shrink-0">{variant}</span>
+                    <Button variant={variant}>Connect</Button>
+                    <Button variant={variant} disabled>
+                        Disabled
+                    </Button>
+                    <Button variant={variant} loading>
+                        Loading
+                    </Button>
+                    <Button variant={variant} size="lg">
+                        Large
+                    </Button>
+                </div>
+            ))}
+        </div>
+    )
+};

--- a/packages/design-system/stories/Card.stories.tsx
+++ b/packages/design-system/stories/Card.stories.tsx
@@ -4,7 +4,7 @@ import { Card, CardContent, CardDescription, CardFooter, CardHeader, CardTitle }
 import type { Meta, StoryObj } from '@storybook/react-vite';
 
 const meta: Meta = {
-    title: 'Components v2/Card',
+    title: 'Components v2/UI/Card',
     parameters: { layout: 'padded' }
 };
 export default meta;

--- a/packages/design-system/stories/Card.stories.tsx
+++ b/packages/design-system/stories/Card.stories.tsx
@@ -1,0 +1,46 @@
+import { Button } from '@/components-v2/ui/Button';
+import { Card, CardContent, CardDescription, CardFooter, CardHeader, CardTitle } from '@/components-v2/ui/Card';
+
+import type { Meta, StoryObj } from '@storybook/react-vite';
+
+const meta: Meta = {
+    title: 'Components v2/Card',
+    parameters: { layout: 'padded' }
+};
+export default meta;
+type Story = StoryObj<typeof meta>;
+
+export const Default: Story = {
+    render: () => (
+        <div className="flex gap-4 flex-wrap">
+            <Card className="w-72">
+                <CardHeader>
+                    <CardTitle>GitHub Integration</CardTitle>
+                    <CardDescription>Sync pull requests and issues from your repos.</CardDescription>
+                </CardHeader>
+                <CardContent>
+                    <p className="text-body-small-regular text-text-secondary">Connected · Last synced 2 min ago</p>
+                </CardContent>
+                <CardFooter>
+                    <Button variant="secondary" size="sm">
+                        Manage
+                    </Button>
+                </CardFooter>
+            </Card>
+            <Card className="w-72">
+                <CardHeader>
+                    <CardTitle>Slack Integration</CardTitle>
+                    <CardDescription>Post notifications to channels on sync events.</CardDescription>
+                </CardHeader>
+                <CardContent>
+                    <p className="text-body-small-regular text-text-secondary">Not connected</p>
+                </CardContent>
+                <CardFooter>
+                    <Button variant="primary" size="sm">
+                        Connect
+                    </Button>
+                </CardFooter>
+            </Card>
+        </div>
+    )
+};

--- a/packages/design-system/stories/Chart.stories.tsx
+++ b/packages/design-system/stories/Chart.stories.tsx
@@ -18,7 +18,7 @@ const chartConfig: ChartConfig = {
 };
 
 const meta: Meta = {
-    title: 'Components v2/Chart',
+    title: 'Components v2/UI/Chart',
     parameters: { layout: 'padded' }
 };
 export default meta;

--- a/packages/design-system/stories/Chart.stories.tsx
+++ b/packages/design-system/stories/Chart.stories.tsx
@@ -1,0 +1,38 @@
+import { Bar, BarChart, XAxis, YAxis } from 'recharts';
+
+import { ChartContainer, ChartTooltip, ChartTooltipContent } from '@/components-v2/ui/Chart';
+
+import type { ChartConfig } from '@/components-v2/ui/Chart';
+import type { Meta, StoryObj } from '@storybook/react-vite';
+
+const chartData = [
+    { day: 'Mon', syncs: 42 },
+    { day: 'Tue', syncs: 78 },
+    { day: 'Wed', syncs: 55 },
+    { day: 'Thu', syncs: 91 },
+    { day: 'Fri', syncs: 63 }
+];
+
+const chartConfig: ChartConfig = {
+    syncs: { label: 'Syncs', color: 'var(--color-brand-500)' }
+};
+
+const meta: Meta = {
+    title: 'Components v2/Chart',
+    parameters: { layout: 'padded' }
+};
+export default meta;
+type Story = StoryObj<typeof meta>;
+
+export const Default: Story = {
+    render: () => (
+        <ChartContainer config={chartConfig} className="h-48 w-full max-w-md">
+            <BarChart data={chartData}>
+                <XAxis dataKey="day" />
+                <YAxis />
+                <ChartTooltip content={<ChartTooltipContent />} />
+                <Bar dataKey="syncs" fill="var(--color-brand-500)" radius={4} />
+            </BarChart>
+        </ChartContainer>
+    )
+};

--- a/packages/design-system/stories/Checkbox.stories.tsx
+++ b/packages/design-system/stories/Checkbox.stories.tsx
@@ -4,7 +4,7 @@ import { Label } from '@/components-v2/ui/Label';
 import type { Meta, StoryObj } from '@storybook/react-vite';
 
 const meta: Meta = {
-    title: 'Components v2/Checkbox',
+    title: 'Components v2/UI/Checkbox',
     parameters: { layout: 'padded' }
 };
 export default meta;

--- a/packages/design-system/stories/Checkbox.stories.tsx
+++ b/packages/design-system/stories/Checkbox.stories.tsx
@@ -1,0 +1,30 @@
+import { Checkbox } from '@/components-v2/ui/Checkbox';
+import { Label } from '@/components-v2/ui/Label';
+
+import type { Meta, StoryObj } from '@storybook/react-vite';
+
+const meta: Meta = {
+    title: 'Components v2/Checkbox',
+    parameters: { layout: 'padded' }
+};
+export default meta;
+type Story = StoryObj<typeof meta>;
+
+export const Default: Story = {
+    render: () => (
+        <div className="flex items-center gap-8">
+            <div className="flex items-center gap-2">
+                <Checkbox id="cb-unchecked" />
+                <Label htmlFor="cb-unchecked">Unchecked</Label>
+            </div>
+            <div className="flex items-center gap-2">
+                <Checkbox id="cb-checked" defaultChecked />
+                <Label htmlFor="cb-checked">Checked</Label>
+            </div>
+            <div className="flex items-center gap-2">
+                <Checkbox id="cb-disabled" disabled />
+                <Label htmlFor="cb-disabled">Disabled</Label>
+            </div>
+        </div>
+    )
+};

--- a/packages/design-system/stories/CodeBlock.stories.tsx
+++ b/packages/design-system/stories/CodeBlock.stories.tsx
@@ -11,7 +11,7 @@ console.log(connection.credentials);`;
 
 const meta: Meta<typeof CodeBlock> = {
     component: CodeBlock,
-    title: 'Components v2/CodeBlock',
+    title: 'Components v2/UI/CodeBlock',
     parameters: { layout: 'padded' }
 };
 export default meta;

--- a/packages/design-system/stories/CodeBlock.stories.tsx
+++ b/packages/design-system/stories/CodeBlock.stories.tsx
@@ -1,0 +1,27 @@
+import { CodeBlock } from '@/components-v2/ui/CodeBlock';
+
+import type { Meta, StoryObj } from '@storybook/react-vite';
+
+const sampleCode = `import Nango from '@nangohq/node';
+
+const nango = new Nango({ secretKey: process.env.NANGO_SECRET_KEY });
+
+const connection = await nango.getConnection('github', 'user-123');
+console.log(connection.credentials);`;
+
+const meta: Meta<typeof CodeBlock> = {
+    component: CodeBlock,
+    title: 'Components v2/CodeBlock',
+    parameters: { layout: 'padded' }
+};
+export default meta;
+type Story = StoryObj<typeof meta>;
+
+export const Default: Story = {
+    args: {
+        title: 'Node.js',
+        language: 'typescript',
+        code: sampleCode,
+        displayLanguage: 'TypeScript'
+    }
+};

--- a/packages/design-system/stories/ColorInput.stories.tsx
+++ b/packages/design-system/stories/ColorInput.stories.tsx
@@ -6,7 +6,7 @@ import type { Meta, StoryObj } from '@storybook/react-vite';
 
 const meta: Meta<typeof ColorInput> = {
     component: ColorInput,
-    title: 'Components v2/ColorInput',
+    title: 'Components v2/UI/ColorInput',
     parameters: { layout: 'centered' }
 };
 export default meta;

--- a/packages/design-system/stories/ColorInput.stories.tsx
+++ b/packages/design-system/stories/ColorInput.stories.tsx
@@ -1,0 +1,20 @@
+import { useState } from 'react';
+
+import { ColorInput } from '@/components-v2/ui/ColorInput';
+
+import type { Meta, StoryObj } from '@storybook/react-vite';
+
+const meta: Meta<typeof ColorInput> = {
+    component: ColorInput,
+    title: 'Components v2/ColorInput',
+    parameters: { layout: 'centered' }
+};
+export default meta;
+type Story = StoryObj<typeof meta>;
+
+export const Default: Story = {
+    render: () => {
+        const [value, setValue] = useState('#6366f1');
+        return <ColorInput value={value} onChange={(e) => setValue(e.target.value)} className="w-48" />;
+    }
+};

--- a/packages/design-system/stories/Combobox.stories.tsx
+++ b/packages/design-system/stories/Combobox.stories.tsx
@@ -13,7 +13,7 @@ const options = [
 ];
 
 const meta: Meta = {
-    title: 'Components v2/Combobox',
+    title: 'Components v2/UI/Combobox',
     parameters: { layout: 'padded' }
 };
 export default meta;

--- a/packages/design-system/stories/Combobox.stories.tsx
+++ b/packages/design-system/stories/Combobox.stories.tsx
@@ -1,0 +1,59 @@
+import { useState } from 'react';
+
+import { ComboboxSelect } from '@/components-v2/ui/Combobox';
+
+import type { Meta, StoryObj } from '@storybook/react-vite';
+
+const options = [
+    { value: 'github', label: 'GitHub' },
+    { value: 'slack', label: 'Slack' },
+    { value: 'hubspot', label: 'HubSpot' },
+    { value: 'salesforce', label: 'Salesforce' },
+    { value: 'notion', label: 'Notion' }
+];
+
+const meta: Meta = {
+    title: 'Components v2/Combobox',
+    parameters: { layout: 'padded' }
+};
+export default meta;
+type Story = StoryObj<typeof meta>;
+
+export const Default: Story = {
+    render: () => {
+        const [value, setValue] = useState<string>('');
+        return (
+            <div className="flex gap-8 items-start">
+                <div className="flex flex-col gap-1">
+                    <span className="story-section-heading">Single (empty)</span>
+                    <div className="w-52">
+                        <ComboboxSelect options={options} value={value} onValueChange={setValue} placeholder="Select integration…" />
+                    </div>
+                </div>
+                <div className="flex flex-col gap-1">
+                    <span className="story-section-heading">Single (selected)</span>
+                    <div className="w-52">
+                        <ComboboxSelect options={options} value="github" onValueChange={() => {}} placeholder="Select integration…" />
+                    </div>
+                </div>
+            </div>
+        );
+    }
+};
+
+export const MultiSelect: Story = {
+    name: 'Multi-select',
+    render: () => {
+        const [selected, setSelected] = useState<string[]>(['github', 'slack']);
+        return (
+            <ComboboxSelect
+                allowMultiple
+                options={options}
+                selected={selected}
+                onSelectedChange={setSelected}
+                label="Integrations"
+                onClearAll={() => setSelected([])}
+            />
+        );
+    }
+};

--- a/packages/design-system/stories/ConditionalTooltip.stories.tsx
+++ b/packages/design-system/stories/ConditionalTooltip.stories.tsx
@@ -1,5 +1,5 @@
-import { Button } from '@/components-v2/ui/Button';
 import { ConditionalTooltip } from '@/components-v2/patterns/ConditionalTooltip';
+import { Button } from '@/components-v2/ui/Button';
 
 import type { Meta, StoryObj } from '@storybook/react-vite';
 

--- a/packages/design-system/stories/ConditionalTooltip.stories.tsx
+++ b/packages/design-system/stories/ConditionalTooltip.stories.tsx
@@ -1,0 +1,32 @@
+import { Button } from '@/components-v2/ui/Button';
+import { ConditionalTooltip } from '@/components-v2/patterns/ConditionalTooltip';
+
+import type { Meta, StoryObj } from '@storybook/react-vite';
+
+const meta: Meta<typeof ConditionalTooltip> = {
+    component: ConditionalTooltip,
+    title: 'Components v2/Patterns/ConditionalTooltip',
+    parameters: { layout: 'centered' }
+};
+export default meta;
+type Story = StoryObj<typeof meta>;
+
+export const Visible: Story = {
+    render: () => (
+        <ConditionalTooltip condition={true} content="You don't have permission to edit this." asChild>
+            <Button variant="secondary" size="sm" disabled>
+                Edit
+            </Button>
+        </ConditionalTooltip>
+    )
+};
+
+export const Hidden: Story = {
+    render: () => (
+        <ConditionalTooltip condition={false} content="This tooltip is hidden.">
+            <Button variant="secondary" size="sm">
+                Edit
+            </Button>
+        </ConditionalTooltip>
+    )
+};

--- a/packages/design-system/stories/CopyButton.stories.tsx
+++ b/packages/design-system/stories/CopyButton.stories.tsx
@@ -3,7 +3,7 @@ import { CopyButton } from '@/components-v2/ui/CopyButton';
 import type { Meta, StoryObj } from '@storybook/react-vite';
 
 const meta: Meta = {
-    title: 'Components v2/CopyButton',
+    title: 'Components v2/UI/CopyButton',
     parameters: { layout: 'padded' }
 };
 export default meta;

--- a/packages/design-system/stories/CopyButton.stories.tsx
+++ b/packages/design-system/stories/CopyButton.stories.tsx
@@ -1,0 +1,25 @@
+import { CopyButton } from '@/components-v2/ui/CopyButton';
+
+import type { Meta, StoryObj } from '@storybook/react-vite';
+
+const meta: Meta = {
+    title: 'Components v2/CopyButton',
+    parameters: { layout: 'padded' }
+};
+export default meta;
+type Story = StoryObj<typeof meta>;
+
+export const Default: Story = {
+    render: () => (
+        <div className="flex items-center gap-6">
+            <div className="flex flex-col items-center gap-1">
+                <CopyButton text="nango_sk_live_abc123def456" />
+                <span className="story-section-heading">Default</span>
+            </div>
+            <div className="flex flex-col items-center gap-1">
+                <CopyButton text="disabled" disabled />
+                <span className="story-section-heading">Disabled</span>
+            </div>
+        </div>
+    )
+};

--- a/packages/design-system/stories/DestructiveActionModal.stories.tsx
+++ b/packages/design-system/stories/DestructiveActionModal.stories.tsx
@@ -1,7 +1,7 @@
 import { useState } from 'react';
 
-import { Button } from '@/components-v2/ui/Button';
 import { DestructiveActionModal } from '@/components-v2/patterns/DestructiveActionModal';
+import { Button } from '@/components-v2/ui/Button';
 
 import type { Meta, StoryObj } from '@storybook/react-vite';
 

--- a/packages/design-system/stories/DestructiveActionModal.stories.tsx
+++ b/packages/design-system/stories/DestructiveActionModal.stories.tsx
@@ -1,0 +1,37 @@
+import { useState } from 'react';
+
+import { Button } from '@/components-v2/ui/Button';
+import { DestructiveActionModal } from '@/components-v2/patterns/DestructiveActionModal';
+
+import type { Meta, StoryObj } from '@storybook/react-vite';
+
+const meta: Meta<typeof DestructiveActionModal> = {
+    component: DestructiveActionModal,
+    title: 'Components v2/Patterns/DestructiveActionModal',
+    parameters: { layout: 'centered' }
+};
+export default meta;
+type Story = StoryObj<typeof meta>;
+
+export const Default: Story = {
+    render: () => {
+        const [open, setOpen] = useState(false);
+        return (
+            <>
+                <Button variant="destructive" size="sm" onClick={() => setOpen(true)}>
+                    Delete integration
+                </Button>
+                <DestructiveActionModal
+                    open={open}
+                    onOpenChange={setOpen}
+                    title="Delete GitHub integration"
+                    description="This will permanently delete all connections and synced data for this integration."
+                    inputLabel='Type "github" to confirm'
+                    confirmationKeyword="github"
+                    confirmButtonText="Delete"
+                    onConfirm={() => setOpen(false)}
+                />
+            </>
+        );
+    }
+};

--- a/packages/design-system/stories/Dialog.stories.tsx
+++ b/packages/design-system/stories/Dialog.stories.tsx
@@ -5,7 +5,7 @@ import type { Meta, StoryObj } from '@storybook/react-vite';
 
 const meta: Meta<typeof Dialog> = {
     component: Dialog,
-    title: 'Components v2/Dialog',
+    title: 'Components v2/UI/Dialog',
     parameters: { layout: 'centered' }
 };
 export default meta;

--- a/packages/design-system/stories/Dialog.stories.tsx
+++ b/packages/design-system/stories/Dialog.stories.tsx
@@ -1,0 +1,38 @@
+import { Button } from '@/components-v2/ui/Button';
+import { Dialog, DialogContent, DialogDescription, DialogFooter, DialogHeader, DialogTitle, DialogTrigger } from '@/components-v2/ui/Dialog';
+
+import type { Meta, StoryObj } from '@storybook/react-vite';
+
+const meta: Meta<typeof Dialog> = {
+    component: Dialog,
+    title: 'Components v2/Dialog',
+    parameters: { layout: 'centered' }
+};
+export default meta;
+type Story = StoryObj<typeof meta>;
+
+export const Default: Story = {
+    render: () => (
+        <Dialog>
+            <DialogTrigger asChild>
+                <Button variant="secondary" size="sm">
+                    Open dialog
+                </Button>
+            </DialogTrigger>
+            <DialogContent>
+                <DialogHeader>
+                    <DialogTitle>Confirm action</DialogTitle>
+                    <DialogDescription>This will revoke access for all connected users. Are you sure?</DialogDescription>
+                </DialogHeader>
+                <DialogFooter>
+                    <Button variant="secondary" size="sm">
+                        Cancel
+                    </Button>
+                    <Button variant="destructive" size="sm">
+                        Confirm
+                    </Button>
+                </DialogFooter>
+            </DialogContent>
+        </Dialog>
+    )
+};

--- a/packages/design-system/stories/Dot.stories.tsx
+++ b/packages/design-system/stories/Dot.stories.tsx
@@ -3,7 +3,7 @@ import { Dot } from '@/components-v2/ui/Dot';
 import type { Meta, StoryObj } from '@storybook/react-vite';
 
 const meta: Meta = {
-    title: 'Components v2/Dot',
+    title: 'Components v2/UI/Dot',
     parameters: { layout: 'padded' }
 };
 export default meta;

--- a/packages/design-system/stories/Dot.stories.tsx
+++ b/packages/design-system/stories/Dot.stories.tsx
@@ -1,0 +1,25 @@
+import { Dot } from '@/components-v2/ui/Dot';
+
+import type { Meta, StoryObj } from '@storybook/react-vite';
+
+const meta: Meta = {
+    title: 'Components v2/Dot',
+    parameters: { layout: 'padded' }
+};
+export default meta;
+type Story = StoryObj<typeof meta>;
+
+const VARIANTS = ['brand', 'success', 'warning', 'error'] as const;
+
+export const Default: Story = {
+    render: () => (
+        <div className="flex items-center gap-4">
+            {VARIANTS.map((variant) => (
+                <div key={variant} className="flex items-center gap-2">
+                    <Dot variant={variant} />
+                    <span className="story-section-heading">{variant}</span>
+                </div>
+            ))}
+        </div>
+    )
+};

--- a/packages/design-system/stories/DropdownMenu.stories.tsx
+++ b/packages/design-system/stories/DropdownMenu.stories.tsx
@@ -5,7 +5,7 @@ import type { Meta, StoryObj } from '@storybook/react-vite';
 
 const meta: Meta<typeof DropdownMenu> = {
     component: DropdownMenu,
-    title: 'Components v2/DropdownMenu',
+    title: 'Components v2/UI/DropdownMenu',
     parameters: { layout: 'centered' }
 };
 export default meta;

--- a/packages/design-system/stories/DropdownMenu.stories.tsx
+++ b/packages/design-system/stories/DropdownMenu.stories.tsx
@@ -1,0 +1,30 @@
+import { Button } from '@/components-v2/ui/Button';
+import { DropdownMenu, DropdownMenuContent, DropdownMenuItem, DropdownMenuSeparator, DropdownMenuTrigger } from '@/components-v2/ui/DropdownMenu';
+
+import type { Meta, StoryObj } from '@storybook/react-vite';
+
+const meta: Meta<typeof DropdownMenu> = {
+    component: DropdownMenu,
+    title: 'Components v2/DropdownMenu',
+    parameters: { layout: 'centered' }
+};
+export default meta;
+type Story = StoryObj<typeof meta>;
+
+export const Default: Story = {
+    render: () => (
+        <DropdownMenu>
+            <DropdownMenuTrigger asChild>
+                <Button variant="secondary" size="sm">
+                    Actions
+                </Button>
+            </DropdownMenuTrigger>
+            <DropdownMenuContent>
+                <DropdownMenuItem>View details</DropdownMenuItem>
+                <DropdownMenuItem>Edit configuration</DropdownMenuItem>
+                <DropdownMenuSeparator />
+                <DropdownMenuItem variant="destructive">Delete</DropdownMenuItem>
+            </DropdownMenuContent>
+        </DropdownMenu>
+    )
+};

--- a/packages/design-system/stories/EditableInput.stories.tsx
+++ b/packages/design-system/stories/EditableInput.stories.tsx
@@ -1,0 +1,19 @@
+import { EditableInput } from '@/components-v2/patterns/EditableInput';
+
+import type { Meta, StoryObj } from '@storybook/react-vite';
+
+const meta: Meta<typeof EditableInput> = {
+    component: EditableInput,
+    title: 'Components v2/Patterns/EditableInput',
+    parameters: { layout: 'padded' }
+};
+export default meta;
+type Story = StoryObj<typeof meta>;
+
+export const Default: Story = {
+    render: () => (
+        <div className="w-80">
+            <EditableInput initialValue="my-github-connection" onSave={async () => {}} />
+        </div>
+    )
+};

--- a/packages/design-system/stories/EmptyCard.stories.tsx
+++ b/packages/design-system/stories/EmptyCard.stories.tsx
@@ -4,7 +4,7 @@ import type { Meta, StoryObj } from '@storybook/react-vite';
 
 const meta: Meta<typeof EmptyCard> = {
     component: EmptyCard,
-    title: 'Components v2/EmptyCard',
+    title: 'Components v2/UI/EmptyCard',
     parameters: { layout: 'padded' }
 };
 export default meta;

--- a/packages/design-system/stories/EmptyCard.stories.tsx
+++ b/packages/design-system/stories/EmptyCard.stories.tsx
@@ -1,0 +1,20 @@
+import { EmptyCard } from '@/components-v2/ui/EmptyCard';
+
+import type { Meta, StoryObj } from '@storybook/react-vite';
+
+const meta: Meta<typeof EmptyCard> = {
+    component: EmptyCard,
+    title: 'Components v2/EmptyCard',
+    parameters: { layout: 'padded' }
+};
+export default meta;
+type Story = StoryObj<typeof meta>;
+
+export const Default: Story = {
+    render: () => (
+        <EmptyCard>
+            <p className="text-text-secondary text-body-medium-regular">No integrations yet.</p>
+            <p className="text-text-tertiary text-body-small-regular">Connect your first integration to get started.</p>
+        </EmptyCard>
+    )
+};

--- a/packages/design-system/stories/Form.stories.tsx
+++ b/packages/design-system/stories/Form.stories.tsx
@@ -7,7 +7,7 @@ import { Input } from '@/components-v2/ui/Input';
 import type { Meta, StoryObj } from '@storybook/react-vite';
 
 const meta: Meta = {
-    title: 'Components v2/Form',
+    title: 'Components v2/UI/Form',
     parameters: { layout: 'padded' }
 };
 export default meta;

--- a/packages/design-system/stories/Form.stories.tsx
+++ b/packages/design-system/stories/Form.stories.tsx
@@ -1,0 +1,43 @@
+import { useForm } from 'react-hook-form';
+
+import { Button } from '@/components-v2/ui/Button';
+import { Form, FormControl, FormDescription, FormField, FormItem, FormLabel, FormMessage } from '@/components-v2/ui/Form';
+import { Input } from '@/components-v2/ui/Input';
+
+import type { Meta, StoryObj } from '@storybook/react-vite';
+
+const meta: Meta = {
+    title: 'Components v2/Form',
+    parameters: { layout: 'padded' }
+};
+export default meta;
+type Story = StoryObj<typeof meta>;
+
+export const Default: Story = {
+    render: () => {
+        const form = useForm({ defaultValues: { connectionId: '' } });
+        return (
+            <Form {...form}>
+                <form onSubmit={form.handleSubmit(() => {})} className="w-80 flex flex-col gap-4">
+                    <FormField
+                        control={form.control}
+                        name="connectionId"
+                        render={({ field }) => (
+                            <FormItem>
+                                <FormLabel>Connection ID</FormLabel>
+                                <FormControl>
+                                    <Input placeholder="user-123" {...field} />
+                                </FormControl>
+                                <FormDescription>A unique identifier for this connection.</FormDescription>
+                                <FormMessage />
+                            </FormItem>
+                        )}
+                    />
+                    <Button type="submit" size="sm">
+                        Save
+                    </Button>
+                </form>
+            </Form>
+        );
+    }
+};

--- a/packages/design-system/stories/InfoTooltip.stories.tsx
+++ b/packages/design-system/stories/InfoTooltip.stories.tsx
@@ -3,7 +3,7 @@ import { InfoTooltip } from '@/components-v2/ui/InfoTooltip';
 import type { Meta, StoryObj } from '@storybook/react-vite';
 
 const meta: Meta = {
-    title: 'Components v2/InfoTooltip',
+    title: 'Components v2/UI/InfoTooltip',
     parameters: { layout: 'padded' }
 };
 export default meta;

--- a/packages/design-system/stories/InfoTooltip.stories.tsx
+++ b/packages/design-system/stories/InfoTooltip.stories.tsx
@@ -1,0 +1,25 @@
+import { InfoTooltip } from '@/components-v2/ui/InfoTooltip';
+
+import type { Meta, StoryObj } from '@storybook/react-vite';
+
+const meta: Meta = {
+    title: 'Components v2/InfoTooltip',
+    parameters: { layout: 'padded' }
+};
+export default meta;
+type Story = StoryObj<typeof meta>;
+
+export const Default: Story = {
+    render: () => (
+        <div className="flex items-center gap-8 p-8">
+            <div className="flex flex-col items-center gap-2">
+                <InfoTooltip>Scopes define what data the integration can access.</InfoTooltip>
+                <span className="story-section-heading">Top (default)</span>
+            </div>
+            <div className="flex flex-col items-center gap-2">
+                <InfoTooltip side="right">Hover to see the tooltip on the right.</InfoTooltip>
+                <span className="story-section-heading">Right</span>
+            </div>
+        </div>
+    )
+};

--- a/packages/design-system/stories/Input.stories.tsx
+++ b/packages/design-system/stories/Input.stories.tsx
@@ -3,7 +3,7 @@ import { Input } from '@/components-v2/ui/Input';
 import type { Meta, StoryObj } from '@storybook/react-vite';
 
 const meta: Meta = {
-    title: 'Components v2/Input',
+    title: 'Components v2/UI/Input',
     parameters: { layout: 'padded' }
 };
 export default meta;

--- a/packages/design-system/stories/Input.stories.tsx
+++ b/packages/design-system/stories/Input.stories.tsx
@@ -1,0 +1,33 @@
+import { Input } from '@/components-v2/ui/Input';
+
+import type { Meta, StoryObj } from '@storybook/react-vite';
+
+const meta: Meta = {
+    title: 'Components v2/Input',
+    parameters: { layout: 'padded' }
+};
+export default meta;
+type Story = StoryObj<typeof meta>;
+
+export const Default: Story = {
+    render: () => (
+        <div className="flex flex-col gap-4 w-72">
+            <div className="flex flex-col gap-1">
+                <span className="story-section-heading">Empty</span>
+                <Input placeholder="Enter API key…" />
+            </div>
+            <div className="flex flex-col gap-1">
+                <span className="story-section-heading">Filled</span>
+                <Input defaultValue="nango_sk_live_abc123" />
+            </div>
+            <div className="flex flex-col gap-1">
+                <span className="story-section-heading">Disabled</span>
+                <Input placeholder="Disabled" disabled />
+            </div>
+            <div className="flex flex-col gap-1">
+                <span className="story-section-heading">Error</span>
+                <Input defaultValue="bad value" aria-invalid />
+            </div>
+        </div>
+    )
+};

--- a/packages/design-system/stories/InputGroup.stories.tsx
+++ b/packages/design-system/stories/InputGroup.stories.tsx
@@ -6,7 +6,7 @@ import type { Meta, StoryObj } from '@storybook/react-vite';
 
 const meta: Meta<typeof InputGroup> = {
     component: InputGroup,
-    title: 'Components v2/InputGroup',
+    title: 'Components v2/UI/InputGroup',
     parameters: { layout: 'centered' }
 };
 export default meta;

--- a/packages/design-system/stories/InputGroup.stories.tsx
+++ b/packages/design-system/stories/InputGroup.stories.tsx
@@ -1,0 +1,35 @@
+import { Search } from 'lucide-react';
+
+import { InputGroup, InputGroupAddon, InputGroupInput } from '@/components-v2/ui/InputGroup';
+
+import type { Meta, StoryObj } from '@storybook/react-vite';
+
+const meta: Meta<typeof InputGroup> = {
+    component: InputGroup,
+    title: 'Components v2/InputGroup',
+    parameters: { layout: 'centered' }
+};
+export default meta;
+type Story = StoryObj<typeof meta>;
+
+export const WithLeadingIcon: Story = {
+    render: () => (
+        <InputGroup className="w-64">
+            <InputGroupAddon>
+                <Search className="size-4 text-text-tertiary" />
+            </InputGroupAddon>
+            <InputGroupInput placeholder="Search integrations…" />
+        </InputGroup>
+    )
+};
+
+export const WithTrailingText: Story = {
+    render: () => (
+        <InputGroup className="w-48">
+            <InputGroupInput placeholder="0" type="number" />
+            <InputGroupAddon align="inline-end">
+                <span className="text-text-tertiary text-body-small-regular">minutes</span>
+            </InputGroupAddon>
+        </InputGroup>
+    )
+};

--- a/packages/design-system/stories/KeyValueBadge.stories.tsx
+++ b/packages/design-system/stories/KeyValueBadge.stories.tsx
@@ -3,7 +3,7 @@ import { KeyValueBadge } from '@/components-v2/ui/KeyValueBadge';
 import type { Meta, StoryObj } from '@storybook/react-vite';
 
 const meta: Meta = {
-    title: 'Components v2/KeyValueBadge',
+    title: 'Components v2/UI/KeyValueBadge',
     parameters: { layout: 'padded' }
 };
 export default meta;

--- a/packages/design-system/stories/KeyValueBadge.stories.tsx
+++ b/packages/design-system/stories/KeyValueBadge.stories.tsx
@@ -1,0 +1,29 @@
+import { KeyValueBadge } from '@/components-v2/ui/KeyValueBadge';
+
+import type { Meta, StoryObj } from '@storybook/react-vite';
+
+const meta: Meta = {
+    title: 'Components v2/KeyValueBadge',
+    parameters: { layout: 'padded' }
+};
+export default meta;
+type Story = StoryObj<typeof meta>;
+
+export const Default: Story = {
+    render: () => (
+        <div className="flex items-center gap-4">
+            <div className="flex flex-col gap-1">
+                <span className="story-section-heading">Darker</span>
+                <KeyValueBadge label="Status" variant="darker">
+                    Active
+                </KeyValueBadge>
+            </div>
+            <div className="flex flex-col gap-1">
+                <span className="story-section-heading">Lighter</span>
+                <KeyValueBadge label="Env" variant="lighter">
+                    Production
+                </KeyValueBadge>
+            </div>
+        </div>
+    )
+};

--- a/packages/design-system/stories/Label.stories.tsx
+++ b/packages/design-system/stories/Label.stories.tsx
@@ -3,7 +3,7 @@ import { Label } from '@/components-v2/ui/Label';
 import type { Meta, StoryObj } from '@storybook/react-vite';
 
 const meta: Meta = {
-    title: 'Components v2/Label',
+    title: 'Components v2/UI/Label',
     parameters: { layout: 'padded' }
 };
 export default meta;

--- a/packages/design-system/stories/Label.stories.tsx
+++ b/packages/design-system/stories/Label.stories.tsx
@@ -1,0 +1,21 @@
+import { Label } from '@/components-v2/ui/Label';
+
+import type { Meta, StoryObj } from '@storybook/react-vite';
+
+const meta: Meta = {
+    title: 'Components v2/Label',
+    parameters: { layout: 'padded' }
+};
+export default meta;
+type Story = StoryObj<typeof meta>;
+
+export const Default: Story = {
+    render: () => (
+        <div className="flex flex-col gap-3">
+            <Label>API Key</Label>
+            <Label>
+                Connection ID <span className="text-feedback-error-fg">*</span>
+            </Label>
+        </div>
+    )
+};

--- a/packages/design-system/stories/LineSnippet.stories.tsx
+++ b/packages/design-system/stories/LineSnippet.stories.tsx
@@ -4,7 +4,7 @@ import type { Meta, StoryObj } from '@storybook/react-vite';
 
 const meta: Meta<typeof LineSnippet> = {
     component: LineSnippet,
-    title: 'Components v2/LineSnippet',
+    title: 'Components v2/UI/LineSnippet',
     parameters: { layout: 'centered' }
 };
 export default meta;

--- a/packages/design-system/stories/LineSnippet.stories.tsx
+++ b/packages/design-system/stories/LineSnippet.stories.tsx
@@ -1,0 +1,15 @@
+import { LineSnippet } from '@/components-v2/ui/LineSnippet';
+
+import type { Meta, StoryObj } from '@storybook/react-vite';
+
+const meta: Meta<typeof LineSnippet> = {
+    component: LineSnippet,
+    title: 'Components v2/LineSnippet',
+    parameters: { layout: 'centered' }
+};
+export default meta;
+type Story = StoryObj<typeof meta>;
+
+export const Default: Story = {
+    args: { snippet: 'nango.auth("github", "user-123")' }
+};

--- a/packages/design-system/stories/MultiLanguageCodeBlock.stories.tsx
+++ b/packages/design-system/stories/MultiLanguageCodeBlock.stories.tsx
@@ -4,7 +4,7 @@ import type { Meta, StoryObj } from '@storybook/react-vite';
 
 const meta: Meta<typeof MultiLanguageCodeBlock> = {
     component: MultiLanguageCodeBlock,
-    title: 'Components v2/MultiLanguageCodeBlock',
+    title: 'Components v2/UI/MultiLanguageCodeBlock',
     parameters: { layout: 'padded' }
 };
 export default meta;

--- a/packages/design-system/stories/MultiLanguageCodeBlock.stories.tsx
+++ b/packages/design-system/stories/MultiLanguageCodeBlock.stories.tsx
@@ -1,0 +1,31 @@
+import { MultiLanguageCodeBlock } from '@/components-v2/ui/MultiLanguageCodeBlock';
+
+import type { Meta, StoryObj } from '@storybook/react-vite';
+
+const meta: Meta<typeof MultiLanguageCodeBlock> = {
+    component: MultiLanguageCodeBlock,
+    title: 'Components v2/MultiLanguageCodeBlock',
+    parameters: { layout: 'padded' }
+};
+export default meta;
+type Story = StoryObj<typeof meta>;
+
+export const Default: Story = {
+    args: {
+        title: 'Get connection',
+        snippets: [
+            {
+                language: 'typescript',
+                displayLanguage: 'Node',
+                icon: null,
+                code: `const conn = await nango.getConnection('github', 'user-123');`
+            },
+            {
+                language: 'python',
+                displayLanguage: 'Python',
+                icon: null,
+                code: `conn = nango.get_connection('github', 'user-123')`
+            }
+        ]
+    }
+};

--- a/packages/design-system/stories/MultiSelect.stories.tsx
+++ b/packages/design-system/stories/MultiSelect.stories.tsx
@@ -13,7 +13,7 @@ const options = [
 ];
 
 const meta: Meta = {
-    title: 'Components v2/MultiSelect',
+    title: 'Components v2/UI/MultiSelect',
     parameters: { layout: 'centered' }
 };
 export default meta;

--- a/packages/design-system/stories/MultiSelect.stories.tsx
+++ b/packages/design-system/stories/MultiSelect.stories.tsx
@@ -1,0 +1,27 @@
+import { useState } from 'react';
+
+import { MultiSelect } from '@/components-v2/ui/MultiSelect';
+
+import type { Meta, StoryObj } from '@storybook/react-vite';
+
+const options = [
+    { value: 'contacts', label: 'Contacts' },
+    { value: 'deals', label: 'Deals' },
+    { value: 'companies', label: 'Companies' },
+    { value: 'activities', label: 'Activities' },
+    { value: 'tasks', label: 'Tasks' }
+];
+
+const meta: Meta = {
+    title: 'Components v2/MultiSelect',
+    parameters: { layout: 'centered' }
+};
+export default meta;
+type Story = StoryObj<typeof meta>;
+
+export const Default: Story = {
+    render: () => {
+        const [selected, setSelected] = useState<string[]>(['contacts']);
+        return <MultiSelect label="Sync models" options={options} selected={selected} onValueChange={setSelected} />;
+    }
+};

--- a/packages/design-system/stories/Navigation.stories.tsx
+++ b/packages/design-system/stories/Navigation.stories.tsx
@@ -4,7 +4,7 @@ import type { Meta, StoryObj } from '@storybook/react-vite';
 
 const meta: Meta<typeof Navigation> = {
     component: Navigation,
-    title: 'Components v2/Navigation',
+    title: 'Components v2/UI/Navigation',
     parameters: { layout: 'padded' }
 };
 export default meta;

--- a/packages/design-system/stories/Navigation.stories.tsx
+++ b/packages/design-system/stories/Navigation.stories.tsx
@@ -1,0 +1,30 @@
+import { Navigation, NavigationContent, NavigationList, NavigationTrigger } from '@/components-v2/ui/Navigation';
+
+import type { Meta, StoryObj } from '@storybook/react-vite';
+
+const meta: Meta<typeof Navigation> = {
+    component: Navigation,
+    title: 'Components v2/Navigation',
+    parameters: { layout: 'padded' }
+};
+export default meta;
+type Story = StoryObj<typeof meta>;
+
+export const Vertical: Story = {
+    render: () => (
+        <Navigation defaultValue="integrations" className="w-52">
+            <NavigationList>
+                <NavigationTrigger value="integrations">Integrations</NavigationTrigger>
+                <NavigationTrigger value="connections">Connections</NavigationTrigger>
+                <NavigationTrigger value="logs">Logs</NavigationTrigger>
+                <NavigationTrigger value="settings">Settings</NavigationTrigger>
+            </NavigationList>
+            <NavigationContent value="integrations">
+                <p className="text-text-secondary text-body-medium-regular p-2">Integrations panel</p>
+            </NavigationContent>
+            <NavigationContent value="connections">
+                <p className="text-text-secondary text-body-medium-regular p-2">Connections panel</p>
+            </NavigationContent>
+        </Navigation>
+    )
+};

--- a/packages/design-system/stories/Popover.stories.tsx
+++ b/packages/design-system/stories/Popover.stories.tsx
@@ -5,7 +5,7 @@ import type { Meta, StoryObj } from '@storybook/react-vite';
 
 const meta: Meta<typeof Popover> = {
     component: Popover,
-    title: 'Components v2/Popover',
+    title: 'Components v2/UI/Popover',
     parameters: { layout: 'centered' }
 };
 export default meta;

--- a/packages/design-system/stories/Popover.stories.tsx
+++ b/packages/design-system/stories/Popover.stories.tsx
@@ -1,0 +1,27 @@
+import { Button } from '@/components-v2/ui/Button';
+import { Popover, PopoverContent, PopoverTrigger } from '@/components-v2/ui/Popover';
+
+import type { Meta, StoryObj } from '@storybook/react-vite';
+
+const meta: Meta<typeof Popover> = {
+    component: Popover,
+    title: 'Components v2/Popover',
+    parameters: { layout: 'centered' }
+};
+export default meta;
+type Story = StoryObj<typeof meta>;
+
+export const Default: Story = {
+    render: () => (
+        <Popover>
+            <PopoverTrigger asChild>
+                <Button variant="secondary" size="sm">
+                    Open popover
+                </Button>
+            </PopoverTrigger>
+            <PopoverContent className="bg-bg-elevated border border-border-muted rounded p-4 text-text-primary text-body-small-regular">
+                Configure sync frequency and field mappings here.
+            </PopoverContent>
+        </Popover>
+    )
+};

--- a/packages/design-system/stories/SecretInput.stories.tsx
+++ b/packages/design-system/stories/SecretInput.stories.tsx
@@ -1,0 +1,15 @@
+import { SecretInput } from '@/components-v2/patterns/SecretInput';
+
+import type { Meta, StoryObj } from '@storybook/react-vite';
+
+const meta: Meta<typeof SecretInput> = {
+    component: SecretInput,
+    title: 'Components v2/Patterns/SecretInput',
+    parameters: { layout: 'centered' }
+};
+export default meta;
+type Story = StoryObj<typeof meta>;
+
+export const Default: Story = {
+    render: () => <SecretInput defaultValue="super-secret-token-abc123" copy className="w-72" />
+};

--- a/packages/design-system/stories/Select.stories.tsx
+++ b/packages/design-system/stories/Select.stories.tsx
@@ -3,7 +3,7 @@ import { Select, SelectContent, SelectItem, SelectTrigger, SelectValue } from '@
 import type { Meta, StoryObj } from '@storybook/react-vite';
 
 const meta: Meta = {
-    title: 'Components v2/Select',
+    title: 'Components v2/UI/Select',
     parameters: { layout: 'padded' }
 };
 export default meta;

--- a/packages/design-system/stories/Select.stories.tsx
+++ b/packages/design-system/stories/Select.stories.tsx
@@ -1,0 +1,44 @@
+import { Select, SelectContent, SelectItem, SelectTrigger, SelectValue } from '@/components-v2/ui/Select';
+
+import type { Meta, StoryObj } from '@storybook/react-vite';
+
+const meta: Meta = {
+    title: 'Components v2/Select',
+    parameters: { layout: 'padded' }
+};
+export default meta;
+type Story = StoryObj<typeof meta>;
+
+export const Default: Story = {
+    render: () => (
+        <div className="flex items-end gap-6">
+            <div className="flex flex-col gap-1">
+                <span className="story-section-heading">Default size</span>
+                <Select defaultValue="hourly">
+                    <SelectTrigger className="w-40">
+                        <SelectValue placeholder="Frequency" />
+                    </SelectTrigger>
+                    <SelectContent>
+                        <SelectItem value="realtime">Real-time</SelectItem>
+                        <SelectItem value="hourly">Hourly</SelectItem>
+                        <SelectItem value="daily">Daily</SelectItem>
+                        <SelectItem value="weekly">Weekly</SelectItem>
+                    </SelectContent>
+                </Select>
+            </div>
+            <div className="flex flex-col gap-1">
+                <span className="story-section-heading">Small</span>
+                <Select defaultValue="production">
+                    <SelectTrigger size="sm" className="w-36">
+                        <SelectValue placeholder="Environment" />
+                    </SelectTrigger>
+                    <SelectContent>
+                        <SelectItem value="production">Production</SelectItem>
+                        <SelectItem value="staging">Staging</SelectItem>
+                        <SelectItem value="development">Development</SelectItem>
+                    </SelectContent>
+                </Select>
+            </div>
+        </div>
+    )
+};

--- a/packages/design-system/stories/Separator.stories.tsx
+++ b/packages/design-system/stories/Separator.stories.tsx
@@ -3,7 +3,7 @@ import { Separator } from '@/components-v2/ui/Separator';
 import type { Meta, StoryObj } from '@storybook/react-vite';
 
 const meta: Meta = {
-    title: 'Components v2/Separator',
+    title: 'Components v2/UI/Separator',
     parameters: { layout: 'padded' }
 };
 export default meta;

--- a/packages/design-system/stories/Separator.stories.tsx
+++ b/packages/design-system/stories/Separator.stories.tsx
@@ -1,0 +1,33 @@
+import { Separator } from '@/components-v2/ui/Separator';
+
+import type { Meta, StoryObj } from '@storybook/react-vite';
+
+const meta: Meta = {
+    title: 'Components v2/Separator',
+    parameters: { layout: 'padded' }
+};
+export default meta;
+type Story = StoryObj<typeof meta>;
+
+export const Default: Story = {
+    render: () => (
+        <div className="flex flex-col gap-8 w-64">
+            <div className="flex flex-col gap-1">
+                <span className="story-section-heading">Horizontal</span>
+                <div>
+                    <p className="text-text-primary text-body-small-regular">Above</p>
+                    <Separator className="my-3" />
+                    <p className="text-text-primary text-body-small-regular">Below</p>
+                </div>
+            </div>
+            <div className="flex flex-col gap-1">
+                <span className="story-section-heading">Vertical</span>
+                <div className="flex items-center gap-2 h-6">
+                    <span className="text-text-primary text-body-small-regular">Left</span>
+                    <Separator orientation="vertical" className="h-full" />
+                    <span className="text-text-primary text-body-small-regular">Right</span>
+                </div>
+            </div>
+        </div>
+    )
+};

--- a/packages/design-system/stories/Sheet.stories.tsx
+++ b/packages/design-system/stories/Sheet.stories.tsx
@@ -5,7 +5,7 @@ import type { Meta, StoryObj } from '@storybook/react-vite';
 
 const meta: Meta<typeof Sheet> = {
     component: Sheet,
-    title: 'Components v2/Sheet',
+    title: 'Components v2/UI/Sheet',
     parameters: { layout: 'centered' }
 };
 export default meta;

--- a/packages/design-system/stories/Sheet.stories.tsx
+++ b/packages/design-system/stories/Sheet.stories.tsx
@@ -1,0 +1,31 @@
+import { Button } from '@/components-v2/ui/Button';
+import { Sheet, SheetContent, SheetDescription, SheetHeader, SheetTitle, SheetTrigger } from '@/components-v2/ui/Sheet';
+
+import type { Meta, StoryObj } from '@storybook/react-vite';
+
+const meta: Meta<typeof Sheet> = {
+    component: Sheet,
+    title: 'Components v2/Sheet',
+    parameters: { layout: 'centered' }
+};
+export default meta;
+type Story = StoryObj<typeof meta>;
+
+export const Default: Story = {
+    render: () => (
+        <Sheet>
+            <SheetTrigger asChild>
+                <Button variant="secondary" size="sm">
+                    Open sheet
+                </Button>
+            </SheetTrigger>
+            <SheetContent>
+                <SheetHeader>
+                    <SheetTitle>Connection details</SheetTitle>
+                    <SheetDescription>View and manage this connection&apos;s settings.</SheetDescription>
+                </SheetHeader>
+                <div className="p-4 text-text-secondary text-body-small-regular">Sheet content goes here.</div>
+            </SheetContent>
+        </Sheet>
+    )
+};

--- a/packages/design-system/stories/SideInfo.stories.tsx
+++ b/packages/design-system/stories/SideInfo.stories.tsx
@@ -4,7 +4,7 @@ import type { Meta, StoryObj } from '@storybook/react-vite';
 
 const meta: Meta<typeof SideInfo> = {
     component: SideInfo,
-    title: 'Components v2/SideInfo',
+    title: 'Components v2/UI/SideInfo',
     parameters: { layout: 'padded' }
 };
 export default meta;

--- a/packages/design-system/stories/SideInfo.stories.tsx
+++ b/packages/design-system/stories/SideInfo.stories.tsx
@@ -1,0 +1,21 @@
+import { SideInfo, SideInfoRow } from '@/components-v2/ui/SideInfo';
+
+import type { Meta, StoryObj } from '@storybook/react-vite';
+
+const meta: Meta<typeof SideInfo> = {
+    component: SideInfo,
+    title: 'Components v2/SideInfo',
+    parameters: { layout: 'padded' }
+};
+export default meta;
+type Story = StoryObj<typeof meta>;
+
+export const Default: Story = {
+    render: () => (
+        <SideInfo>
+            <SideInfoRow label="Status">Active</SideInfoRow>
+            <SideInfoRow label="Integration">GitHub</SideInfoRow>
+            <SideInfoRow label="Last synced">2 minutes ago</SideInfoRow>
+        </SideInfo>
+    )
+};

--- a/packages/design-system/stories/Sidebar.stories.tsx
+++ b/packages/design-system/stories/Sidebar.stories.tsx
@@ -22,7 +22,7 @@ const navItems = [
 ];
 
 const meta: Meta = {
-    title: 'Components v2/Sidebar',
+    title: 'Components v2/UI/Sidebar',
     parameters: { layout: 'fullscreen' }
 };
 export default meta;

--- a/packages/design-system/stories/Sidebar.stories.tsx
+++ b/packages/design-system/stories/Sidebar.stories.tsx
@@ -1,0 +1,55 @@
+import { LayoutDashboard, Link, Settings, Zap } from 'lucide-react';
+
+import {
+    Sidebar,
+    SidebarContent,
+    SidebarGroup,
+    SidebarGroupContent,
+    SidebarGroupLabel,
+    SidebarMenu,
+    SidebarMenuButton,
+    SidebarMenuItem,
+    SidebarProvider
+} from '@/components-v2/ui/Sidebar';
+
+import type { Meta, StoryObj } from '@storybook/react-vite';
+
+const navItems = [
+    { label: 'Overview', icon: LayoutDashboard, value: 'overview' },
+    { label: 'Integrations', icon: Zap, value: 'integrations' },
+    { label: 'Connections', icon: Link, value: 'connections' },
+    { label: 'Settings', icon: Settings, value: 'settings' }
+];
+
+const meta: Meta = {
+    title: 'Components v2/Sidebar',
+    parameters: { layout: 'fullscreen' }
+};
+export default meta;
+type Story = StoryObj<typeof meta>;
+
+export const Default: Story = {
+    render: () => (
+        <SidebarProvider defaultOpen={true} style={{ minHeight: '400px' }}>
+            <Sidebar>
+                <SidebarContent>
+                    <SidebarGroup>
+                        <SidebarGroupLabel>Navigation</SidebarGroupLabel>
+                        <SidebarGroupContent>
+                            <SidebarMenu>
+                                {navItems.map((item) => (
+                                    <SidebarMenuItem key={item.value}>
+                                        <SidebarMenuButton>
+                                            <item.icon />
+                                            <span>{item.label}</span>
+                                        </SidebarMenuButton>
+                                    </SidebarMenuItem>
+                                ))}
+                            </SidebarMenu>
+                        </SidebarGroupContent>
+                    </SidebarGroup>
+                </SidebarContent>
+            </Sidebar>
+        </SidebarProvider>
+    )
+};

--- a/packages/design-system/stories/SimpleCodeBlock.stories.tsx
+++ b/packages/design-system/stories/SimpleCodeBlock.stories.tsx
@@ -4,7 +4,7 @@ import type { Meta, StoryObj } from '@storybook/react-vite';
 
 const meta: Meta<typeof SimpleCodeBlock> = {
     component: SimpleCodeBlock,
-    title: 'Components v2/SimpleCodeBlock',
+    title: 'Components v2/UI/SimpleCodeBlock',
     parameters: { layout: 'padded' }
 };
 export default meta;

--- a/packages/design-system/stories/SimpleCodeBlock.stories.tsx
+++ b/packages/design-system/stories/SimpleCodeBlock.stories.tsx
@@ -1,0 +1,18 @@
+import { SimpleCodeBlock } from '@/components-v2/ui/SimpleCodeBlock';
+
+import type { Meta, StoryObj } from '@storybook/react-vite';
+
+const meta: Meta<typeof SimpleCodeBlock> = {
+    component: SimpleCodeBlock,
+    title: 'Components v2/SimpleCodeBlock',
+    parameters: { layout: 'padded' }
+};
+export default meta;
+type Story = StoryObj<typeof meta>;
+
+export const Default: Story = {
+    args: {
+        language: 'typescript',
+        children: `const connection = await nango.getConnection('github', 'user-123');`
+    }
+};

--- a/packages/design-system/stories/Skeleton.stories.tsx
+++ b/packages/design-system/stories/Skeleton.stories.tsx
@@ -3,7 +3,7 @@ import { Skeleton } from '@/components-v2/ui/Skeleton';
 import type { Meta, StoryObj } from '@storybook/react-vite';
 
 const meta: Meta = {
-    title: 'Components v2/Skeleton',
+    title: 'Components v2/UI/Skeleton',
     parameters: { layout: 'padded' }
 };
 export default meta;

--- a/packages/design-system/stories/Skeleton.stories.tsx
+++ b/packages/design-system/stories/Skeleton.stories.tsx
@@ -1,0 +1,33 @@
+import { Skeleton } from '@/components-v2/ui/Skeleton';
+
+import type { Meta, StoryObj } from '@storybook/react-vite';
+
+const meta: Meta = {
+    title: 'Components v2/Skeleton',
+    parameters: { layout: 'padded' }
+};
+export default meta;
+type Story = StoryObj<typeof meta>;
+
+export const Default: Story = {
+    render: () => (
+        <div className="flex flex-col gap-4 w-72">
+            <div className="flex flex-col gap-1">
+                <span className="story-section-heading">Lines</span>
+                <div className="flex flex-col gap-2">
+                    <Skeleton className="h-4 w-full" />
+                    <Skeleton className="h-4 w-3/4" />
+                    <Skeleton className="h-4 w-1/2" />
+                </div>
+            </div>
+            <div className="flex flex-col gap-1">
+                <span className="story-section-heading">Block</span>
+                <Skeleton className="h-20 w-full" />
+            </div>
+            <div className="flex flex-col gap-1">
+                <span className="story-section-heading">Avatar-like</span>
+                <Skeleton className="size-10 rounded-full" />
+            </div>
+        </div>
+    )
+};

--- a/packages/design-system/stories/Spinner.stories.tsx
+++ b/packages/design-system/stories/Spinner.stories.tsx
@@ -3,7 +3,7 @@ import { Spinner } from '@/components-v2/ui/Spinner';
 import type { Meta, StoryObj } from '@storybook/react-vite';
 
 const meta: Meta = {
-    title: 'Components v2/Spinner',
+    title: 'Components v2/UI/Spinner',
     parameters: { layout: 'padded' }
 };
 export default meta;

--- a/packages/design-system/stories/Spinner.stories.tsx
+++ b/packages/design-system/stories/Spinner.stories.tsx
@@ -1,0 +1,29 @@
+import { Spinner } from '@/components-v2/ui/Spinner';
+
+import type { Meta, StoryObj } from '@storybook/react-vite';
+
+const meta: Meta = {
+    title: 'Components v2/Spinner',
+    parameters: { layout: 'padded' }
+};
+export default meta;
+type Story = StoryObj<typeof meta>;
+
+export const Default: Story = {
+    render: () => (
+        <div className="flex items-center gap-6">
+            <div className="flex flex-col items-center gap-2">
+                <Spinner className="size-4" />
+                <span className="story-section-heading">sm</span>
+            </div>
+            <div className="flex flex-col items-center gap-2">
+                <Spinner className="size-6" />
+                <span className="story-section-heading">md</span>
+            </div>
+            <div className="flex flex-col items-center gap-2">
+                <Spinner className="size-8" />
+                <span className="story-section-heading">lg</span>
+            </div>
+        </div>
+    )
+};

--- a/packages/design-system/stories/StatusWithIcon.stories.tsx
+++ b/packages/design-system/stories/StatusWithIcon.stories.tsx
@@ -5,7 +5,7 @@ import { StatusWithIcon } from '@/components-v2/ui/StatusWithIcon';
 import type { Meta, StoryObj } from '@storybook/react-vite';
 
 const meta: Meta = {
-    title: 'Components v2/StatusWithIcon',
+    title: 'Components v2/UI/StatusWithIcon',
     parameters: { layout: 'padded' }
 };
 export default meta;

--- a/packages/design-system/stories/StatusWithIcon.stories.tsx
+++ b/packages/design-system/stories/StatusWithIcon.stories.tsx
@@ -1,0 +1,34 @@
+import { CircleCheck, CircleX, Info, TriangleAlert } from 'lucide-react';
+
+import { StatusWithIcon } from '@/components-v2/ui/StatusWithIcon';
+
+import type { Meta, StoryObj } from '@storybook/react-vite';
+
+const meta: Meta = {
+    title: 'Components v2/StatusWithIcon',
+    parameters: { layout: 'padded' }
+};
+export default meta;
+type Story = StoryObj<typeof meta>;
+
+const ITEMS = [
+    { variant: 'success', icon: <CircleCheck />, label: 'Success' },
+    { variant: 'error', icon: <CircleX />, label: 'Error' },
+    { variant: 'warning', icon: <TriangleAlert />, label: 'Warning' },
+    { variant: 'neutral', icon: <Info />, label: 'Neutral' }
+] as const;
+
+export const Default: Story = {
+    render: () => (
+        <div className="flex items-center gap-6">
+            {ITEMS.map(({ variant, icon, label }) => (
+                <div key={variant} className="flex flex-col items-center gap-2">
+                    <StatusWithIcon variant={variant} tooltipContent={label}>
+                        {icon}
+                    </StatusWithIcon>
+                    <span className="story-section-heading">{label}</span>
+                </div>
+            ))}
+        </div>
+    )
+};

--- a/packages/design-system/stories/StyledLink.stories.tsx
+++ b/packages/design-system/stories/StyledLink.stories.tsx
@@ -6,7 +6,7 @@ import type { Meta, StoryObj } from '@storybook/react-vite';
 
 const meta: Meta<typeof StyledLink> = {
     component: StyledLink,
-    title: 'Components v2/StyledLink',
+    title: 'Components v2/UI/StyledLink',
     parameters: { layout: 'centered' },
     decorators: [
         (Story) => (

--- a/packages/design-system/stories/StyledLink.stories.tsx
+++ b/packages/design-system/stories/StyledLink.stories.tsx
@@ -1,0 +1,28 @@
+import { MemoryRouter } from 'react-router-dom';
+
+import { StyledLink } from '@/components-v2/ui/StyledLink';
+
+import type { Meta, StoryObj } from '@storybook/react-vite';
+
+const meta: Meta<typeof StyledLink> = {
+    component: StyledLink,
+    title: 'Components v2/StyledLink',
+    parameters: { layout: 'centered' },
+    decorators: [
+        (Story) => (
+            <MemoryRouter>
+                <Story />
+            </MemoryRouter>
+        )
+    ]
+};
+export default meta;
+type Story = StoryObj<typeof meta>;
+
+export const Internal: Story = {
+    args: { to: '/integrations', children: 'View integrations' }
+};
+
+export const External: Story = {
+    args: { to: 'https://docs.nango.dev', children: 'Read the docs', type: 'external', icon: true }
+};

--- a/packages/design-system/stories/Switch.stories.tsx
+++ b/packages/design-system/stories/Switch.stories.tsx
@@ -4,7 +4,7 @@ import { Switch } from '@/components-v2/ui/Switch';
 import type { Meta, StoryObj } from '@storybook/react-vite';
 
 const meta: Meta = {
-    title: 'Components v2/Switch',
+    title: 'Components v2/UI/Switch',
     parameters: { layout: 'padded' }
 };
 export default meta;

--- a/packages/design-system/stories/Switch.stories.tsx
+++ b/packages/design-system/stories/Switch.stories.tsx
@@ -1,0 +1,30 @@
+import { Label } from '@/components-v2/ui/Label';
+import { Switch } from '@/components-v2/ui/Switch';
+
+import type { Meta, StoryObj } from '@storybook/react-vite';
+
+const meta: Meta = {
+    title: 'Components v2/Switch',
+    parameters: { layout: 'padded' }
+};
+export default meta;
+type Story = StoryObj<typeof meta>;
+
+export const Default: Story = {
+    render: () => (
+        <div className="flex items-center gap-8">
+            <div className="flex items-center gap-2">
+                <Switch id="sw-off" />
+                <Label htmlFor="sw-off">Off</Label>
+            </div>
+            <div className="flex items-center gap-2">
+                <Switch id="sw-on" defaultChecked />
+                <Label htmlFor="sw-on">On</Label>
+            </div>
+            <div className="flex items-center gap-2">
+                <Switch id="sw-disabled" disabled />
+                <Label htmlFor="sw-disabled">Disabled</Label>
+            </div>
+        </div>
+    )
+};

--- a/packages/design-system/stories/Table.stories.tsx
+++ b/packages/design-system/stories/Table.stories.tsx
@@ -10,7 +10,7 @@ const rows = [
 
 const meta: Meta<typeof Table> = {
     component: Table,
-    title: 'Components v2/Table',
+    title: 'Components v2/UI/Table',
     parameters: { layout: 'padded' }
 };
 export default meta;

--- a/packages/design-system/stories/Table.stories.tsx
+++ b/packages/design-system/stories/Table.stories.tsx
@@ -1,0 +1,42 @@
+import { Table, TableBody, TableCell, TableHead, TableHeader, TableRow } from '@/components-v2/ui/Table';
+
+import type { Meta, StoryObj } from '@storybook/react-vite';
+
+const rows = [
+    { id: 'user-001', integration: 'GitHub', status: 'Active', lastSync: '2 min ago' },
+    { id: 'user-002', integration: 'Slack', status: 'Active', lastSync: '15 min ago' },
+    { id: 'user-003', integration: 'HubSpot', status: 'Error', lastSync: '1 hr ago' }
+];
+
+const meta: Meta<typeof Table> = {
+    component: Table,
+    title: 'Components v2/Table',
+    parameters: { layout: 'padded' }
+};
+export default meta;
+type Story = StoryObj<typeof meta>;
+
+export const Default: Story = {
+    render: () => (
+        <Table>
+            <TableHeader>
+                <TableRow>
+                    <TableHead>Connection ID</TableHead>
+                    <TableHead>Integration</TableHead>
+                    <TableHead>Status</TableHead>
+                    <TableHead>Last sync</TableHead>
+                </TableRow>
+            </TableHeader>
+            <TableBody>
+                {rows.map((row) => (
+                    <TableRow key={row.id}>
+                        <TableCell>{row.id}</TableCell>
+                        <TableCell>{row.integration}</TableCell>
+                        <TableCell>{row.status}</TableCell>
+                        <TableCell>{row.lastSync}</TableCell>
+                    </TableRow>
+                ))}
+            </TableBody>
+        </Table>
+    )
+};

--- a/packages/design-system/stories/Tabs.stories.tsx
+++ b/packages/design-system/stories/Tabs.stories.tsx
@@ -3,7 +3,7 @@ import { Tabs, TabsContent, TabsList, TabsTrigger } from '@/components-v2/ui/Tab
 import type { Meta, StoryObj } from '@storybook/react-vite';
 
 const meta: Meta = {
-    title: 'Components v2/Tabs',
+    title: 'Components v2/UI/Tabs',
     parameters: { layout: 'padded' }
 };
 export default meta;

--- a/packages/design-system/stories/Tabs.stories.tsx
+++ b/packages/design-system/stories/Tabs.stories.tsx
@@ -1,0 +1,34 @@
+import { Tabs, TabsContent, TabsList, TabsTrigger } from '@/components-v2/ui/Tabs';
+
+import type { Meta, StoryObj } from '@storybook/react-vite';
+
+const meta: Meta = {
+    title: 'Components v2/Tabs',
+    parameters: { layout: 'padded' }
+};
+export default meta;
+type Story = StoryObj<typeof meta>;
+
+export const Default: Story = {
+    render: () => (
+        <Tabs defaultValue="overview" className="w-96">
+            <TabsList>
+                <TabsTrigger value="overview">Overview</TabsTrigger>
+                <TabsTrigger value="syncs">Syncs</TabsTrigger>
+                <TabsTrigger value="logs">Logs</TabsTrigger>
+                <TabsTrigger value="disabled" disabled>
+                    Disabled
+                </TabsTrigger>
+            </TabsList>
+            <TabsContent value="overview">
+                <p className="text-text-secondary text-body-medium-regular pt-4">Integration overview content.</p>
+            </TabsContent>
+            <TabsContent value="syncs">
+                <p className="text-text-secondary text-body-medium-regular pt-4">Sync configuration content.</p>
+            </TabsContent>
+            <TabsContent value="logs">
+                <p className="text-text-secondary text-body-medium-regular pt-4">Log entries appear here.</p>
+            </TabsContent>
+        </Tabs>
+    )
+};

--- a/packages/design-system/stories/Textarea.stories.tsx
+++ b/packages/design-system/stories/Textarea.stories.tsx
@@ -3,7 +3,7 @@ import { Textarea } from '@/components-v2/ui/Textarea';
 import type { Meta, StoryObj } from '@storybook/react-vite';
 
 const meta: Meta = {
-    title: 'Components v2/Textarea',
+    title: 'Components v2/UI/Textarea',
     parameters: { layout: 'padded' }
 };
 export default meta;

--- a/packages/design-system/stories/Textarea.stories.tsx
+++ b/packages/design-system/stories/Textarea.stories.tsx
@@ -1,0 +1,29 @@
+import { Textarea } from '@/components-v2/ui/Textarea';
+
+import type { Meta, StoryObj } from '@storybook/react-vite';
+
+const meta: Meta = {
+    title: 'Components v2/Textarea',
+    parameters: { layout: 'padded' }
+};
+export default meta;
+type Story = StoryObj<typeof meta>;
+
+export const Default: Story = {
+    render: () => (
+        <div className="flex flex-col gap-4 w-80">
+            <div className="flex flex-col gap-1">
+                <span className="story-section-heading">Empty</span>
+                <Textarea placeholder="Enter a description…" rows={3} />
+            </div>
+            <div className="flex flex-col gap-1">
+                <span className="story-section-heading">Filled</span>
+                <Textarea defaultValue="This sync fetches all contacts from HubSpot." rows={3} />
+            </div>
+            <div className="flex flex-col gap-1">
+                <span className="story-section-heading">Disabled</span>
+                <Textarea placeholder="Disabled" disabled rows={3} />
+            </div>
+        </div>
+    )
+};

--- a/packages/design-system/stories/Toast.stories.tsx
+++ b/packages/design-system/stories/Toast.stories.tsx
@@ -4,7 +4,7 @@ import type { Meta, StoryObj } from '@storybook/react-vite';
 
 const meta: Meta<typeof Toast> = {
     component: Toast,
-    title: 'Components v2/Toast',
+    title: 'Components v2/UI/Toast',
     parameters: { layout: 'padded' }
 };
 export default meta;

--- a/packages/design-system/stories/Toast.stories.tsx
+++ b/packages/design-system/stories/Toast.stories.tsx
@@ -1,0 +1,23 @@
+import { Toast } from '@/components-v2/ui/Toast';
+
+import type { Meta, StoryObj } from '@storybook/react-vite';
+
+const meta: Meta<typeof Toast> = {
+    component: Toast,
+    title: 'Components v2/Toast',
+    parameters: { layout: 'padded' }
+};
+export default meta;
+type Story = StoryObj<typeof meta>;
+
+export const Success: Story = {
+    args: { id: 1, variant: 'success', title: 'Sync complete', description: 'All records have been imported.' }
+};
+
+export const Error: Story = {
+    args: { id: 2, variant: 'error', title: 'Sync failed', description: 'Could not reach the upstream API.' }
+};
+
+export const Info: Story = {
+    args: { id: 3, variant: 'info', title: 'Sync started', description: 'Fetching contacts from HubSpot.' }
+};

--- a/packages/design-system/stories/Tooltip.stories.tsx
+++ b/packages/design-system/stories/Tooltip.stories.tsx
@@ -4,7 +4,7 @@ import { Tooltip, TooltipContent, TooltipTrigger } from '@/components-v2/ui/Tool
 import type { Meta, StoryObj } from '@storybook/react-vite';
 
 const meta: Meta = {
-    title: 'Components v2/Tooltip',
+    title: 'Components v2/UI/Tooltip',
     parameters: { layout: 'padded' }
 };
 export default meta;

--- a/packages/design-system/stories/Tooltip.stories.tsx
+++ b/packages/design-system/stories/Tooltip.stories.tsx
@@ -1,0 +1,28 @@
+import { Button } from '@/components-v2/ui/Button';
+import { Tooltip, TooltipContent, TooltipTrigger } from '@/components-v2/ui/Tooltip';
+
+import type { Meta, StoryObj } from '@storybook/react-vite';
+
+const meta: Meta = {
+    title: 'Components v2/Tooltip',
+    parameters: { layout: 'padded' }
+};
+export default meta;
+type Story = StoryObj<typeof meta>;
+
+export const Default: Story = {
+    render: () => (
+        <div className="flex items-center gap-8 p-8">
+            {(['top', 'right', 'bottom', 'left'] as const).map((side) => (
+                <Tooltip key={side}>
+                    <TooltipTrigger asChild>
+                        <Button variant="secondary" size="sm">
+                            {side}
+                        </Button>
+                    </TooltipTrigger>
+                    <TooltipContent side={side}>Syncs data every 30 minutes</TooltipContent>
+                </Tooltip>
+            ))}
+        </div>
+    )
+};

--- a/packages/design-system/stories/v1/Alert.stories.tsx
+++ b/packages/design-system/stories/v1/Alert.stories.tsx
@@ -3,7 +3,7 @@ import { Alert, AlertDescription, AlertTitle } from '@/components/ui/Alert';
 import type { Meta, StoryObj } from '@storybook/react-vite';
 
 const meta: Meta = {
-    title: 'Components v1/Alert',
+    title: 'Components v1/UI/Alert',
     parameters: { layout: 'padded' }
 };
 export default meta;

--- a/packages/design-system/stories/v1/Alert.stories.tsx
+++ b/packages/design-system/stories/v1/Alert.stories.tsx
@@ -1,0 +1,29 @@
+import { Alert, AlertDescription, AlertTitle } from '@/components/ui/Alert';
+
+import type { Meta, StoryObj } from '@storybook/react-vite';
+
+const meta: Meta = {
+    title: 'Components v1/Alert',
+    parameters: { layout: 'padded' }
+};
+export default meta;
+type Story = StoryObj<typeof meta>;
+
+export const Default: Story = {
+    render: () => (
+        <div className="bg-bg-black p-6 rounded-md flex flex-col gap-4 max-w-xl">
+            <Alert variant="default">
+                <AlertTitle>Info</AlertTitle>
+                <AlertDescription>Your integration is connected and syncing data.</AlertDescription>
+            </Alert>
+            <Alert variant="destructive">
+                <AlertTitle>Error</AlertTitle>
+                <AlertDescription>Sync failed — could not reach the upstream API.</AlertDescription>
+            </Alert>
+            <Alert variant="warning">
+                <AlertTitle>Warning</AlertTitle>
+                <AlertDescription>Your access token expires in 3 days.</AlertDescription>
+            </Alert>
+        </div>
+    )
+};

--- a/packages/design-system/stories/v1/Button.stories.tsx
+++ b/packages/design-system/stories/v1/Button.stories.tsx
@@ -17,10 +17,18 @@ export const Default: Story = {
             {VARIANTS.map((variant) => (
                 <div key={variant} className="flex items-center gap-4 flex-wrap">
                     <span className="story-section-heading w-28 shrink-0">{variant}</span>
-                    <Button variant={variant} size="sm">Default</Button>
-                    <Button variant={variant} size="md">Medium</Button>
-                    <Button variant={variant} size="sm" disabled>Disabled</Button>
-                    <Button variant={variant} size="sm" isLoading>Loading</Button>
+                    <Button variant={variant} size="sm">
+                        Default
+                    </Button>
+                    <Button variant={variant} size="md">
+                        Medium
+                    </Button>
+                    <Button variant={variant} size="sm" disabled>
+                        Disabled
+                    </Button>
+                    <Button variant={variant} size="sm" isLoading>
+                        Loading
+                    </Button>
                 </div>
             ))}
         </div>

--- a/packages/design-system/stories/v1/Button.stories.tsx
+++ b/packages/design-system/stories/v1/Button.stories.tsx
@@ -3,7 +3,7 @@ import { Button } from '@/components/ui/button/Button';
 import type { Meta, StoryObj } from '@storybook/react-vite';
 
 const meta: Meta = {
-    title: 'Components v1/Button',
+    title: 'Components v1/UI/Button',
     parameters: { layout: 'padded' }
 };
 export default meta;

--- a/packages/design-system/stories/v1/Button.stories.tsx
+++ b/packages/design-system/stories/v1/Button.stories.tsx
@@ -1,0 +1,28 @@
+import { Button } from '@/components/ui/button/Button';
+
+import type { Meta, StoryObj } from '@storybook/react-vite';
+
+const meta: Meta = {
+    title: 'Components v1/Button',
+    parameters: { layout: 'padded' }
+};
+export default meta;
+type Story = StoryObj<typeof meta>;
+
+const VARIANTS = ['primary', 'success', 'danger', 'zombie', 'zombieGray', 'yellow', 'zinc', 'secondary', 'tertiary'] as const;
+
+export const Default: Story = {
+    render: () => (
+        <div className="bg-bg-black p-6 rounded-md flex flex-col gap-4">
+            {VARIANTS.map((variant) => (
+                <div key={variant} className="flex items-center gap-4 flex-wrap">
+                    <span className="story-section-heading w-28 shrink-0">{variant}</span>
+                    <Button variant={variant} size="sm">Default</Button>
+                    <Button variant={variant} size="md">Medium</Button>
+                    <Button variant={variant} size="sm" disabled>Disabled</Button>
+                    <Button variant={variant} size="sm" isLoading>Loading</Button>
+                </div>
+            ))}
+        </div>
+    )
+};

--- a/packages/design-system/stories/v1/Checkbox.stories.tsx
+++ b/packages/design-system/stories/v1/Checkbox.stories.tsx
@@ -14,15 +14,21 @@ export const Default: Story = {
         <div className="bg-bg-black p-6 rounded-md flex items-center gap-6">
             <div className="flex items-center gap-2">
                 <Checkbox id="v1-unchecked" />
-                <label htmlFor="v1-unchecked" className="text-white text-sm">Unchecked</label>
+                <label htmlFor="v1-unchecked" className="text-white text-sm">
+                    Unchecked
+                </label>
             </div>
             <div className="flex items-center gap-2">
                 <Checkbox id="v1-checked" defaultChecked />
-                <label htmlFor="v1-checked" className="text-white text-sm">Checked</label>
+                <label htmlFor="v1-checked" className="text-white text-sm">
+                    Checked
+                </label>
             </div>
             <div className="flex items-center gap-2">
                 <Checkbox id="v1-disabled" disabled />
-                <label htmlFor="v1-disabled" className="text-white text-sm opacity-50">Disabled</label>
+                <label htmlFor="v1-disabled" className="text-white text-sm opacity-50">
+                    Disabled
+                </label>
             </div>
         </div>
     )

--- a/packages/design-system/stories/v1/Checkbox.stories.tsx
+++ b/packages/design-system/stories/v1/Checkbox.stories.tsx
@@ -3,7 +3,7 @@ import { Checkbox } from '@/components/ui/Checkbox';
 import type { Meta, StoryObj } from '@storybook/react-vite';
 
 const meta: Meta = {
-    title: 'Components v1/Checkbox',
+    title: 'Components v1/UI/Checkbox',
     parameters: { layout: 'padded' }
 };
 export default meta;

--- a/packages/design-system/stories/v1/Checkbox.stories.tsx
+++ b/packages/design-system/stories/v1/Checkbox.stories.tsx
@@ -1,0 +1,29 @@
+import { Checkbox } from '@/components/ui/Checkbox';
+
+import type { Meta, StoryObj } from '@storybook/react-vite';
+
+const meta: Meta = {
+    title: 'Components v1/Checkbox',
+    parameters: { layout: 'padded' }
+};
+export default meta;
+type Story = StoryObj<typeof meta>;
+
+export const Default: Story = {
+    render: () => (
+        <div className="bg-bg-black p-6 rounded-md flex items-center gap-6">
+            <div className="flex items-center gap-2">
+                <Checkbox id="v1-unchecked" />
+                <label htmlFor="v1-unchecked" className="text-white text-sm">Unchecked</label>
+            </div>
+            <div className="flex items-center gap-2">
+                <Checkbox id="v1-checked" defaultChecked />
+                <label htmlFor="v1-checked" className="text-white text-sm">Checked</label>
+            </div>
+            <div className="flex items-center gap-2">
+                <Checkbox id="v1-disabled" disabled />
+                <label htmlFor="v1-disabled" className="text-white text-sm opacity-50">Disabled</label>
+            </div>
+        </div>
+    )
+};

--- a/packages/design-system/stories/v1/CopyText.stories.tsx
+++ b/packages/design-system/stories/v1/CopyText.stories.tsx
@@ -1,0 +1,19 @@
+import { CopyText } from '@/components/ui/CopyText';
+
+import type { Meta, StoryObj } from '@storybook/react-vite';
+
+const meta: Meta = {
+    title: 'Components v1/CopyText',
+    parameters: { layout: 'padded' }
+};
+export default meta;
+type Story = StoryObj<typeof meta>;
+
+export const Default: Story = {
+    render: () => (
+        <div className="bg-bg-black p-6 rounded-md flex items-center gap-4">
+            <CopyText text="nango_sk_live_abc123def456">nango_sk_live_abc123def456</CopyText>
+            <CopyText text="user-connection-id">connection-id</CopyText>
+        </div>
+    )
+};

--- a/packages/design-system/stories/v1/CopyText.stories.tsx
+++ b/packages/design-system/stories/v1/CopyText.stories.tsx
@@ -1,10 +1,12 @@
 import { CopyText } from '@/components/ui/CopyText';
+import { TooltipProvider } from '@/components/ui/Tooltip';
 
 import type { Meta, StoryObj } from '@storybook/react-vite';
 
 const meta: Meta = {
     title: 'Components v1/UI/CopyText',
-    parameters: { layout: 'padded' }
+    parameters: { layout: 'padded' },
+    decorators: [(Story) => <TooltipProvider><Story /></TooltipProvider>]
 };
 export default meta;
 type Story = StoryObj<typeof meta>;

--- a/packages/design-system/stories/v1/CopyText.stories.tsx
+++ b/packages/design-system/stories/v1/CopyText.stories.tsx
@@ -6,7 +6,13 @@ import type { Meta, StoryObj } from '@storybook/react-vite';
 const meta: Meta = {
     title: 'Components v1/UI/CopyText',
     parameters: { layout: 'padded' },
-    decorators: [(Story) => <TooltipProvider><Story /></TooltipProvider>]
+    decorators: [
+        (Story) => (
+            <TooltipProvider>
+                <Story />
+            </TooltipProvider>
+        )
+    ]
 };
 export default meta;
 type Story = StoryObj<typeof meta>;

--- a/packages/design-system/stories/v1/CopyText.stories.tsx
+++ b/packages/design-system/stories/v1/CopyText.stories.tsx
@@ -3,7 +3,7 @@ import { CopyText } from '@/components/ui/CopyText';
 import type { Meta, StoryObj } from '@storybook/react-vite';
 
 const meta: Meta = {
-    title: 'Components v1/CopyText',
+    title: 'Components v1/UI/CopyText',
     parameters: { layout: 'padded' }
 };
 export default meta;

--- a/packages/design-system/stories/v1/Dialog.stories.tsx
+++ b/packages/design-system/stories/v1/Dialog.stories.tsx
@@ -1,0 +1,31 @@
+import { Button } from '@/components/ui/button/Button';
+import { Dialog, DialogContent, DialogDescription, DialogTitle, DialogTrigger } from '@/components/ui/Dialog';
+
+import type { Meta, StoryObj } from '@storybook/react-vite';
+
+const meta: Meta = {
+    title: 'Components v1/Dialog',
+    parameters: { layout: 'padded' }
+};
+export default meta;
+type Story = StoryObj<typeof meta>;
+
+export const Default: Story = {
+    render: () => (
+        <div className="bg-bg-black p-6 rounded-md">
+            <Dialog>
+                <DialogTrigger asChild>
+                    <Button variant="zombie">Open dialog</Button>
+                </DialogTrigger>
+                <DialogContent>
+                    <DialogTitle>Confirm deletion</DialogTitle>
+                    <DialogDescription>This action cannot be undone.</DialogDescription>
+                    <div className="flex justify-end gap-2 mt-4">
+                        <Button variant="zinc" size="sm">Cancel</Button>
+                        <Button variant="danger" size="sm">Delete</Button>
+                    </div>
+                </DialogContent>
+            </Dialog>
+        </div>
+    )
+};

--- a/packages/design-system/stories/v1/Dialog.stories.tsx
+++ b/packages/design-system/stories/v1/Dialog.stories.tsx
@@ -4,7 +4,7 @@ import { Dialog, DialogContent, DialogDescription, DialogTitle, DialogTrigger } 
 import type { Meta, StoryObj } from '@storybook/react-vite';
 
 const meta: Meta = {
-    title: 'Components v1/Dialog',
+    title: 'Components v1/UI/Dialog',
     parameters: { layout: 'padded' }
 };
 export default meta;

--- a/packages/design-system/stories/v1/Dialog.stories.tsx
+++ b/packages/design-system/stories/v1/Dialog.stories.tsx
@@ -1,5 +1,5 @@
-import { Button } from '@/components/ui/button/Button';
 import { Dialog, DialogContent, DialogDescription, DialogTitle, DialogTrigger } from '@/components/ui/Dialog';
+import { Button } from '@/components/ui/button/Button';
 
 import type { Meta, StoryObj } from '@storybook/react-vite';
 
@@ -21,8 +21,12 @@ export const Default: Story = {
                     <DialogTitle>Confirm deletion</DialogTitle>
                     <DialogDescription>This action cannot be undone.</DialogDescription>
                     <div className="flex justify-end gap-2 mt-4">
-                        <Button variant="zinc" size="sm">Cancel</Button>
-                        <Button variant="danger" size="sm">Delete</Button>
+                        <Button variant="zinc" size="sm">
+                            Cancel
+                        </Button>
+                        <Button variant="danger" size="sm">
+                            Delete
+                        </Button>
                     </div>
                 </DialogContent>
             </Dialog>

--- a/packages/design-system/stories/v1/DropdownMenu.stories.tsx
+++ b/packages/design-system/stories/v1/DropdownMenu.stories.tsx
@@ -1,0 +1,29 @@
+import { Button } from '@/components/ui/button/Button';
+import { DropdownMenu, DropdownMenuContent, DropdownMenuItem, DropdownMenuSeparator, DropdownMenuTrigger } from '@/components/ui/DropdownMenu';
+
+import type { Meta, StoryObj } from '@storybook/react-vite';
+
+const meta: Meta = {
+    title: 'Components v1/DropdownMenu',
+    parameters: { layout: 'padded' }
+};
+export default meta;
+type Story = StoryObj<typeof meta>;
+
+export const Default: Story = {
+    render: () => (
+        <div className="bg-bg-black p-6 rounded-md">
+            <DropdownMenu>
+                <DropdownMenuTrigger asChild>
+                    <Button variant="zombie" size="sm">Actions</Button>
+                </DropdownMenuTrigger>
+                <DropdownMenuContent>
+                    <DropdownMenuItem>View details</DropdownMenuItem>
+                    <DropdownMenuItem>Edit configuration</DropdownMenuItem>
+                    <DropdownMenuSeparator />
+                    <DropdownMenuItem className="text-red-base">Delete</DropdownMenuItem>
+                </DropdownMenuContent>
+            </DropdownMenu>
+        </div>
+    )
+};

--- a/packages/design-system/stories/v1/DropdownMenu.stories.tsx
+++ b/packages/design-system/stories/v1/DropdownMenu.stories.tsx
@@ -4,7 +4,7 @@ import { DropdownMenu, DropdownMenuContent, DropdownMenuItem, DropdownMenuSepara
 import type { Meta, StoryObj } from '@storybook/react-vite';
 
 const meta: Meta = {
-    title: 'Components v1/DropdownMenu',
+    title: 'Components v1/UI/DropdownMenu',
     parameters: { layout: 'padded' }
 };
 export default meta;

--- a/packages/design-system/stories/v1/DropdownMenu.stories.tsx
+++ b/packages/design-system/stories/v1/DropdownMenu.stories.tsx
@@ -1,5 +1,5 @@
-import { Button } from '@/components/ui/button/Button';
 import { DropdownMenu, DropdownMenuContent, DropdownMenuItem, DropdownMenuSeparator, DropdownMenuTrigger } from '@/components/ui/DropdownMenu';
+import { Button } from '@/components/ui/button/Button';
 
 import type { Meta, StoryObj } from '@storybook/react-vite';
 
@@ -15,7 +15,9 @@ export const Default: Story = {
         <div className="bg-bg-black p-6 rounded-md">
             <DropdownMenu>
                 <DropdownMenuTrigger asChild>
-                    <Button variant="zombie" size="sm">Actions</Button>
+                    <Button variant="zombie" size="sm">
+                        Actions
+                    </Button>
                 </DropdownMenuTrigger>
                 <DropdownMenuContent>
                     <DropdownMenuItem>View details</DropdownMenuItem>

--- a/packages/design-system/stories/v1/ErrorCircle.stories.tsx
+++ b/packages/design-system/stories/v1/ErrorCircle.stories.tsx
@@ -3,7 +3,7 @@ import { ErrorCircle } from '@/components/ui/ErrorCircle';
 import type { Meta, StoryObj } from '@storybook/react-vite';
 
 const meta: Meta = {
-    title: 'Components v1/ErrorCircle',
+    title: 'Components v1/UI/ErrorCircle',
     parameters: { layout: 'padded' }
 };
 export default meta;

--- a/packages/design-system/stories/v1/ErrorCircle.stories.tsx
+++ b/packages/design-system/stories/v1/ErrorCircle.stories.tsx
@@ -1,0 +1,36 @@
+import { ErrorCircle } from '@/components/ui/ErrorCircle';
+
+import type { Meta, StoryObj } from '@storybook/react-vite';
+
+const meta: Meta = {
+    title: 'Components v1/ErrorCircle',
+    parameters: { layout: 'padded' }
+};
+export default meta;
+type Story = StoryObj<typeof meta>;
+
+const ICONS = ['!', 'sync', 'auth', 'clock', 'x', 'info', 'check'] as const;
+const COLORS = ['red-base', 'yellow-base', 'green-base', 'blue-base'] as const;
+
+export const Default: Story = {
+    render: () => (
+        <div className="bg-bg-black p-6 rounded-md flex flex-col gap-6">
+            <div className="flex items-center gap-4">
+                {ICONS.map((icon) => (
+                    <div key={icon} className="flex flex-col items-center gap-2">
+                        <ErrorCircle icon={icon} color="red-base" />
+                        <span className="story-section-heading">{icon}</span>
+                    </div>
+                ))}
+            </div>
+            <div className="flex items-center gap-4">
+                {COLORS.map((color) => (
+                    <div key={color} className="flex flex-col items-center gap-2">
+                        <ErrorCircle icon="!" color={color} />
+                        <span className="story-section-heading">{color.replace('-base', '')}</span>
+                    </div>
+                ))}
+            </div>
+        </div>
+    )
+};

--- a/packages/design-system/stories/v1/HttpLabel.stories.tsx
+++ b/packages/design-system/stories/v1/HttpLabel.stories.tsx
@@ -3,7 +3,7 @@ import { HttpLabel } from '@/components/ui/HttpLabel';
 import type { Meta, StoryObj } from '@storybook/react-vite';
 
 const meta: Meta = {
-    title: 'Components v1/HttpLabel',
+    title: 'Components v1/UI/HttpLabel',
     parameters: { layout: 'padded' }
 };
 export default meta;

--- a/packages/design-system/stories/v1/HttpLabel.stories.tsx
+++ b/packages/design-system/stories/v1/HttpLabel.stories.tsx
@@ -1,0 +1,22 @@
+import { HttpLabel } from '@/components/ui/HttpLabel';
+
+import type { Meta, StoryObj } from '@storybook/react-vite';
+
+const meta: Meta = {
+    title: 'Components v1/HttpLabel',
+    parameters: { layout: 'padded' }
+};
+export default meta;
+type Story = StoryObj<typeof meta>;
+
+const METHODS = ['GET', 'POST', 'PUT', 'PATCH', 'DELETE'] as const;
+
+export const Default: Story = {
+    render: () => (
+        <div className="bg-bg-black p-6 rounded-md flex items-center gap-4">
+            {METHODS.map((method) => (
+                <HttpLabel key={method} method={method} path="/api/endpoint" />
+            ))}
+        </div>
+    )
+};

--- a/packages/design-system/stories/v1/Input.stories.tsx
+++ b/packages/design-system/stories/v1/Input.stories.tsx
@@ -1,0 +1,29 @@
+import { Input } from '@/components/ui/input/Input';
+
+import type { Meta, StoryObj } from '@storybook/react-vite';
+
+const meta: Meta = {
+    title: 'Components v1/Input',
+    parameters: { layout: 'padded' }
+};
+export default meta;
+type Story = StoryObj<typeof meta>;
+
+export const Default: Story = {
+    render: () => (
+        <div className="bg-bg-black p-6 rounded-md flex flex-col gap-4 w-80">
+            <div className="flex flex-col gap-1">
+                <span className="story-section-heading">Empty</span>
+                <Input placeholder="Enter API key…" />
+            </div>
+            <div className="flex flex-col gap-1">
+                <span className="story-section-heading">Filled</span>
+                <Input defaultValue="nango_sk_live_abc123" />
+            </div>
+            <div className="flex flex-col gap-1">
+                <span className="story-section-heading">Disabled</span>
+                <Input placeholder="Disabled" disabled />
+            </div>
+        </div>
+    )
+};

--- a/packages/design-system/stories/v1/Input.stories.tsx
+++ b/packages/design-system/stories/v1/Input.stories.tsx
@@ -3,7 +3,7 @@ import { Input } from '@/components/ui/input/Input';
 import type { Meta, StoryObj } from '@storybook/react-vite';
 
 const meta: Meta = {
-    title: 'Components v1/Input',
+    title: 'Components v1/UI/Input',
     parameters: { layout: 'padded' }
 };
 export default meta;

--- a/packages/design-system/stories/v1/IntegrationLogo.stories.tsx
+++ b/packages/design-system/stories/v1/IntegrationLogo.stories.tsx
@@ -1,4 +1,4 @@
-import { IntegrationLogo } from '@/components/ui/IntegrationLogo';
+import IntegrationLogo from '@/components/ui/IntegrationLogo';
 
 import type { Meta, StoryObj } from '@storybook/react-vite';
 

--- a/packages/design-system/stories/v1/IntegrationLogo.stories.tsx
+++ b/packages/design-system/stories/v1/IntegrationLogo.stories.tsx
@@ -3,7 +3,7 @@ import { IntegrationLogo } from '@/components/ui/IntegrationLogo';
 import type { Meta, StoryObj } from '@storybook/react-vite';
 
 const meta: Meta = {
-    title: 'Components v1/IntegrationLogo',
+    title: 'Components v1/UI/IntegrationLogo',
     parameters: { layout: 'padded' }
 };
 export default meta;

--- a/packages/design-system/stories/v1/IntegrationLogo.stories.tsx
+++ b/packages/design-system/stories/v1/IntegrationLogo.stories.tsx
@@ -1,0 +1,25 @@
+import { IntegrationLogo } from '@/components/ui/IntegrationLogo';
+
+import type { Meta, StoryObj } from '@storybook/react-vite';
+
+const meta: Meta = {
+    title: 'Components v1/IntegrationLogo',
+    parameters: { layout: 'padded' }
+};
+export default meta;
+type Story = StoryObj<typeof meta>;
+
+const PROVIDERS = ['github', 'slack', 'hubspot', 'salesforce', 'notion', 'unknown-provider', 'unauthenticated'];
+
+export const Default: Story = {
+    render: () => (
+        <div className="bg-bg-black p-6 rounded-md flex items-center gap-6">
+            {PROVIDERS.map((provider) => (
+                <div key={provider} className="flex flex-col items-center gap-2">
+                    <IntegrationLogo provider={provider} height={8} width={8} />
+                    <span className="story-section-heading">{provider === 'unknown-provider' ? 'unknown' : provider}</span>
+                </div>
+            ))}
+        </div>
+    )
+};

--- a/packages/design-system/stories/v1/Progress.stories.tsx
+++ b/packages/design-system/stories/v1/Progress.stories.tsx
@@ -3,7 +3,7 @@ import { Progress } from '@/components/ui/Progress';
 import type { Meta, StoryObj } from '@storybook/react-vite';
 
 const meta: Meta = {
-    title: 'Components v1/Progress',
+    title: 'Components v1/UI/Progress',
     parameters: { layout: 'padded' }
 };
 export default meta;

--- a/packages/design-system/stories/v1/Progress.stories.tsx
+++ b/packages/design-system/stories/v1/Progress.stories.tsx
@@ -1,0 +1,23 @@
+import { Progress } from '@/components/ui/Progress';
+
+import type { Meta, StoryObj } from '@storybook/react-vite';
+
+const meta: Meta = {
+    title: 'Components v1/Progress',
+    parameters: { layout: 'padded' }
+};
+export default meta;
+type Story = StoryObj<typeof meta>;
+
+export const Default: Story = {
+    render: () => (
+        <div className="bg-bg-black p-6 rounded-md flex flex-col gap-4 w-72">
+            {([0, 25, 60, 100] as const).map((val) => (
+                <div key={val} className="flex flex-col gap-1">
+                    <span className="story-section-heading">{val}%</span>
+                    <Progress value={val} />
+                </div>
+            ))}
+        </div>
+    )
+};

--- a/packages/design-system/stories/v1/Select.stories.tsx
+++ b/packages/design-system/stories/v1/Select.stories.tsx
@@ -3,7 +3,7 @@ import { Select, SelectContent, SelectItem, SelectTrigger, SelectValue } from '@
 import type { Meta, StoryObj } from '@storybook/react-vite';
 
 const meta: Meta = {
-    title: 'Components v1/Select',
+    title: 'Components v1/UI/Select',
     parameters: { layout: 'padded' }
 };
 export default meta;

--- a/packages/design-system/stories/v1/Select.stories.tsx
+++ b/packages/design-system/stories/v1/Select.stories.tsx
@@ -1,0 +1,43 @@
+import { Select, SelectContent, SelectItem, SelectTrigger, SelectValue } from '@/components/ui/Select';
+
+import type { Meta, StoryObj } from '@storybook/react-vite';
+
+const meta: Meta = {
+    title: 'Components v1/Select',
+    parameters: { layout: 'padded' }
+};
+export default meta;
+type Story = StoryObj<typeof meta>;
+
+export const Default: Story = {
+    render: () => (
+        <div className="bg-bg-black p-6 rounded-md flex items-end gap-4">
+            <div className="flex flex-col gap-1">
+                <span className="story-section-heading">Placeholder</span>
+                <Select>
+                    <SelectTrigger className="w-40">
+                        <SelectValue placeholder="Select…" />
+                    </SelectTrigger>
+                    <SelectContent>
+                        <SelectItem value="hourly">Hourly</SelectItem>
+                        <SelectItem value="daily">Daily</SelectItem>
+                        <SelectItem value="weekly">Weekly</SelectItem>
+                    </SelectContent>
+                </Select>
+            </div>
+            <div className="flex flex-col gap-1">
+                <span className="story-section-heading">Selected</span>
+                <Select defaultValue="daily">
+                    <SelectTrigger className="w-40">
+                        <SelectValue />
+                    </SelectTrigger>
+                    <SelectContent>
+                        <SelectItem value="hourly">Hourly</SelectItem>
+                        <SelectItem value="daily">Daily</SelectItem>
+                        <SelectItem value="weekly">Weekly</SelectItem>
+                    </SelectContent>
+                </Select>
+            </div>
+        </div>
+    )
+};

--- a/packages/design-system/stories/v1/SimpleTooltip.stories.tsx
+++ b/packages/design-system/stories/v1/SimpleTooltip.stories.tsx
@@ -3,7 +3,7 @@ import { SimpleTooltip } from '@/components/ui/SimpleTooltip';
 import type { Meta, StoryObj } from '@storybook/react-vite';
 
 const meta: Meta = {
-    title: 'Components v1/SimpleTooltip',
+    title: 'Components v1/UI/SimpleTooltip',
     parameters: { layout: 'padded' }
 };
 export default meta;

--- a/packages/design-system/stories/v1/SimpleTooltip.stories.tsx
+++ b/packages/design-system/stories/v1/SimpleTooltip.stories.tsx
@@ -1,0 +1,23 @@
+import { SimpleTooltip } from '@/components/ui/SimpleTooltip';
+
+import type { Meta, StoryObj } from '@storybook/react-vite';
+
+const meta: Meta = {
+    title: 'Components v1/SimpleTooltip',
+    parameters: { layout: 'padded' }
+};
+export default meta;
+type Story = StoryObj<typeof meta>;
+
+export const Default: Story = {
+    render: () => (
+        <div className="bg-bg-black p-8 rounded-md flex items-center gap-8">
+            <SimpleTooltip tooltipContent="Sync fetches all contacts every hour">
+                <span className="text-white text-sm border-b border-dashed border-gray-500 cursor-help">Hover me</span>
+            </SimpleTooltip>
+            <SimpleTooltip tooltipContent="This action cannot be undone" side="right">
+                <span className="text-white text-sm border-b border-dashed border-gray-500 cursor-help">Right side</span>
+            </SimpleTooltip>
+        </div>
+    )
+};

--- a/packages/design-system/stories/v1/Skeleton.stories.tsx
+++ b/packages/design-system/stories/v1/Skeleton.stories.tsx
@@ -1,0 +1,23 @@
+import { Skeleton } from '@/components/ui/Skeleton';
+
+import type { Meta, StoryObj } from '@storybook/react-vite';
+
+const meta: Meta = {
+    title: 'Components v1/Skeleton',
+    parameters: { layout: 'padded' }
+};
+export default meta;
+type Story = StoryObj<typeof meta>;
+
+export const Default: Story = {
+    render: () => (
+        <div className="bg-bg-black p-6 rounded-md flex flex-col gap-4 w-72">
+            <div className="flex flex-col gap-2">
+                <Skeleton className="h-4 w-full" />
+                <Skeleton className="h-4 w-3/4" />
+                <Skeleton className="h-4 w-1/2" />
+            </div>
+            <Skeleton className="h-20 w-full" />
+        </div>
+    )
+};

--- a/packages/design-system/stories/v1/Skeleton.stories.tsx
+++ b/packages/design-system/stories/v1/Skeleton.stories.tsx
@@ -3,7 +3,7 @@ import { Skeleton } from '@/components/ui/Skeleton';
 import type { Meta, StoryObj } from '@storybook/react-vite';
 
 const meta: Meta = {
-    title: 'Components v1/Skeleton',
+    title: 'Components v1/UI/Skeleton',
     parameters: { layout: 'padded' }
 };
 export default meta;

--- a/packages/design-system/stories/v1/Spinner.stories.tsx
+++ b/packages/design-system/stories/v1/Spinner.stories.tsx
@@ -3,7 +3,7 @@ import Spinner from '@/components/ui/Spinner';
 import type { Meta, StoryObj } from '@storybook/react-vite';
 
 const meta: Meta = {
-    title: 'Components v1/Spinner',
+    title: 'Components v1/UI/Spinner',
     parameters: { layout: 'padded' }
 };
 export default meta;

--- a/packages/design-system/stories/v1/Spinner.stories.tsx
+++ b/packages/design-system/stories/v1/Spinner.stories.tsx
@@ -1,0 +1,23 @@
+import Spinner from '@/components/ui/Spinner';
+
+import type { Meta, StoryObj } from '@storybook/react-vite';
+
+const meta: Meta = {
+    title: 'Components v1/Spinner',
+    parameters: { layout: 'padded' }
+};
+export default meta;
+type Story = StoryObj<typeof meta>;
+
+export const Default: Story = {
+    render: () => (
+        <div className="bg-bg-black p-6 rounded-md flex items-center gap-8">
+            {([2, 4, 6] as const).map((size) => (
+                <div key={size} className="flex flex-col items-center gap-2">
+                    <Spinner size={size} />
+                    <span className="story-section-heading">size={size}</span>
+                </div>
+            ))}
+        </div>
+    )
+};

--- a/packages/design-system/stories/v1/Switch.stories.tsx
+++ b/packages/design-system/stories/v1/Switch.stories.tsx
@@ -3,7 +3,7 @@ import { Switch } from '@/components/ui/Switch';
 import type { Meta, StoryObj } from '@storybook/react-vite';
 
 const meta: Meta = {
-    title: 'Components v1/Switch',
+    title: 'Components v1/UI/Switch',
     parameters: { layout: 'padded' }
 };
 export default meta;

--- a/packages/design-system/stories/v1/Switch.stories.tsx
+++ b/packages/design-system/stories/v1/Switch.stories.tsx
@@ -14,15 +14,21 @@ export const Default: Story = {
         <div className="bg-bg-black p-6 rounded-md flex items-center gap-6">
             <div className="flex items-center gap-2">
                 <Switch id="v1-sw-off" />
-                <label htmlFor="v1-sw-off" className="text-white text-sm">Off</label>
+                <label htmlFor="v1-sw-off" className="text-white text-sm">
+                    Off
+                </label>
             </div>
             <div className="flex items-center gap-2">
                 <Switch id="v1-sw-on" defaultChecked />
-                <label htmlFor="v1-sw-on" className="text-white text-sm">On</label>
+                <label htmlFor="v1-sw-on" className="text-white text-sm">
+                    On
+                </label>
             </div>
             <div className="flex items-center gap-2">
                 <Switch id="v1-sw-disabled" disabled />
-                <label htmlFor="v1-sw-disabled" className="text-white text-sm opacity-50">Disabled</label>
+                <label htmlFor="v1-sw-disabled" className="text-white text-sm opacity-50">
+                    Disabled
+                </label>
             </div>
         </div>
     )

--- a/packages/design-system/stories/v1/Switch.stories.tsx
+++ b/packages/design-system/stories/v1/Switch.stories.tsx
@@ -1,0 +1,29 @@
+import { Switch } from '@/components/ui/Switch';
+
+import type { Meta, StoryObj } from '@storybook/react-vite';
+
+const meta: Meta = {
+    title: 'Components v1/Switch',
+    parameters: { layout: 'padded' }
+};
+export default meta;
+type Story = StoryObj<typeof meta>;
+
+export const Default: Story = {
+    render: () => (
+        <div className="bg-bg-black p-6 rounded-md flex items-center gap-6">
+            <div className="flex items-center gap-2">
+                <Switch id="v1-sw-off" />
+                <label htmlFor="v1-sw-off" className="text-white text-sm">Off</label>
+            </div>
+            <div className="flex items-center gap-2">
+                <Switch id="v1-sw-on" defaultChecked />
+                <label htmlFor="v1-sw-on" className="text-white text-sm">On</label>
+            </div>
+            <div className="flex items-center gap-2">
+                <Switch id="v1-sw-disabled" disabled />
+                <label htmlFor="v1-sw-disabled" className="text-white text-sm opacity-50">Disabled</label>
+            </div>
+        </div>
+    )
+};

--- a/packages/design-system/stories/v1/Table.stories.tsx
+++ b/packages/design-system/stories/v1/Table.stories.tsx
@@ -9,7 +9,7 @@ const rows = [
 ];
 
 const meta: Meta = {
-    title: 'Components v1/Table',
+    title: 'Components v1/UI/Table',
     parameters: { layout: 'padded' }
 };
 export default meta;

--- a/packages/design-system/stories/v1/Table.stories.tsx
+++ b/packages/design-system/stories/v1/Table.stories.tsx
@@ -1,0 +1,43 @@
+import { Table, TableBody, TableCell, TableHead, TableHeader, TableRow } from '@/components/ui/Table';
+
+import type { Meta, StoryObj } from '@storybook/react-vite';
+
+const rows = [
+    { id: 'user-001', integration: 'GitHub', status: 'Active', last: '2 min ago' },
+    { id: 'user-002', integration: 'Slack', status: 'Active', last: '15 min ago' },
+    { id: 'user-003', integration: 'HubSpot', status: 'Error', last: '1 hr ago' }
+];
+
+const meta: Meta = {
+    title: 'Components v1/Table',
+    parameters: { layout: 'padded' }
+};
+export default meta;
+type Story = StoryObj<typeof meta>;
+
+export const Default: Story = {
+    render: () => (
+        <div className="bg-bg-black p-6 rounded-md">
+            <Table>
+                <TableHeader>
+                    <TableRow>
+                        <TableHead>Connection ID</TableHead>
+                        <TableHead>Integration</TableHead>
+                        <TableHead>Status</TableHead>
+                        <TableHead>Last sync</TableHead>
+                    </TableRow>
+                </TableHeader>
+                <TableBody>
+                    {rows.map((row) => (
+                        <TableRow key={row.id}>
+                            <TableCell>{row.id}</TableCell>
+                            <TableCell>{row.integration}</TableCell>
+                            <TableCell>{row.status}</TableCell>
+                            <TableCell>{row.last}</TableCell>
+                        </TableRow>
+                    ))}
+                </TableBody>
+            </Table>
+        </div>
+    )
+};

--- a/packages/design-system/stories/v1/Table.stories.tsx
+++ b/packages/design-system/stories/v1/Table.stories.tsx
@@ -1,4 +1,4 @@
-import { Table, TableBody, TableCell, TableHead, TableHeader, TableRow } from '@/components/ui/Table';
+import { Body, Cell, Head, Header, Row, Table } from '@/components/ui/Table';
 
 import type { Meta, StoryObj } from '@storybook/react-vite';
 
@@ -19,24 +19,24 @@ export const Default: Story = {
     render: () => (
         <div className="bg-bg-black p-6 rounded-md">
             <Table>
-                <TableHeader>
-                    <TableRow>
-                        <TableHead>Connection ID</TableHead>
-                        <TableHead>Integration</TableHead>
-                        <TableHead>Status</TableHead>
-                        <TableHead>Last sync</TableHead>
-                    </TableRow>
-                </TableHeader>
-                <TableBody>
+                <Header>
+                    <Row>
+                        <Head>Connection ID</Head>
+                        <Head>Integration</Head>
+                        <Head>Status</Head>
+                        <Head>Last sync</Head>
+                    </Row>
+                </Header>
+                <Body>
                     {rows.map((row) => (
-                        <TableRow key={row.id}>
-                            <TableCell>{row.id}</TableCell>
-                            <TableCell>{row.integration}</TableCell>
-                            <TableCell>{row.status}</TableCell>
-                            <TableCell>{row.last}</TableCell>
-                        </TableRow>
+                        <Row key={row.id}>
+                            <Cell>{row.id}</Cell>
+                            <Cell>{row.integration}</Cell>
+                            <Cell>{row.status}</Cell>
+                            <Cell>{row.last}</Cell>
+                        </Row>
                     ))}
-                </TableBody>
+                </Body>
             </Table>
         </div>
     )

--- a/packages/design-system/stories/v1/Tag.stories.tsx
+++ b/packages/design-system/stories/v1/Tag.stories.tsx
@@ -15,7 +15,9 @@ export const Default: Story = {
     render: () => (
         <div className="bg-bg-black p-6 rounded-md flex items-center gap-3 flex-wrap">
             {VARIANTS.map((variant) => (
-                <Tag key={variant} variant={variant}>{variant}</Tag>
+                <Tag key={variant} variant={variant}>
+                    {variant}
+                </Tag>
             ))}
         </div>
     )

--- a/packages/design-system/stories/v1/Tag.stories.tsx
+++ b/packages/design-system/stories/v1/Tag.stories.tsx
@@ -3,7 +3,7 @@ import { Tag } from '@/components/ui/label/Tag';
 import type { Meta, StoryObj } from '@storybook/react-vite';
 
 const meta: Meta = {
-    title: 'Components v1/Tag',
+    title: 'Components v1/UI/Tag',
     parameters: { layout: 'padded' }
 };
 export default meta;

--- a/packages/design-system/stories/v1/Tag.stories.tsx
+++ b/packages/design-system/stories/v1/Tag.stories.tsx
@@ -1,0 +1,22 @@
+import { Tag } from '@/components/ui/label/Tag';
+
+import type { Meta, StoryObj } from '@storybook/react-vite';
+
+const meta: Meta = {
+    title: 'Components v1/Tag',
+    parameters: { layout: 'padded' }
+};
+export default meta;
+type Story = StoryObj<typeof meta>;
+
+const VARIANTS = ['success', 'alert', 'info', 'warning', 'gray', 'gray1', 'neutral'] as const;
+
+export const Default: Story = {
+    render: () => (
+        <div className="bg-bg-black p-6 rounded-md flex items-center gap-3 flex-wrap">
+            {VARIANTS.map((variant) => (
+                <Tag key={variant} variant={variant}>{variant}</Tag>
+            ))}
+        </div>
+    )
+};

--- a/packages/design-system/stories/v1/Tooltip.stories.tsx
+++ b/packages/design-system/stories/v1/Tooltip.stories.tsx
@@ -4,7 +4,7 @@ import { Tooltip, TooltipContent, TooltipProvider, TooltipTrigger } from '@/comp
 import type { Meta, StoryObj } from '@storybook/react-vite';
 
 const meta: Meta = {
-    title: 'Components v1/Tooltip',
+    title: 'Components v1/UI/Tooltip',
     parameters: { layout: 'padded' }
 };
 export default meta;

--- a/packages/design-system/stories/v1/Tooltip.stories.tsx
+++ b/packages/design-system/stories/v1/Tooltip.stories.tsx
@@ -1,0 +1,28 @@
+import { Button } from '@/components/ui/button/Button';
+import { Tooltip, TooltipContent, TooltipProvider, TooltipTrigger } from '@/components/ui/Tooltip';
+
+import type { Meta, StoryObj } from '@storybook/react-vite';
+
+const meta: Meta = {
+    title: 'Components v1/Tooltip',
+    parameters: { layout: 'padded' }
+};
+export default meta;
+type Story = StoryObj<typeof meta>;
+
+export const Default: Story = {
+    render: () => (
+        <div className="bg-bg-black p-8 rounded-md flex items-center gap-8">
+            {(['top', 'right', 'bottom', 'left'] as const).map((side) => (
+                <TooltipProvider key={side} delayDuration={0}>
+                    <Tooltip>
+                        <TooltipTrigger asChild>
+                            <Button variant="zombie" size="sm">{side}</Button>
+                        </TooltipTrigger>
+                        <TooltipContent side={side}>Syncs every 30 min</TooltipContent>
+                    </Tooltip>
+                </TooltipProvider>
+            ))}
+        </div>
+    )
+};

--- a/packages/design-system/stories/v1/Tooltip.stories.tsx
+++ b/packages/design-system/stories/v1/Tooltip.stories.tsx
@@ -1,5 +1,5 @@
-import { Button } from '@/components/ui/button/Button';
 import { Tooltip, TooltipContent, TooltipProvider, TooltipTrigger } from '@/components/ui/Tooltip';
+import { Button } from '@/components/ui/button/Button';
 
 import type { Meta, StoryObj } from '@storybook/react-vite';
 
@@ -17,7 +17,9 @@ export const Default: Story = {
                 <TooltipProvider key={side} delayDuration={0}>
                     <Tooltip>
                         <TooltipTrigger asChild>
-                            <Button variant="zombie" size="sm">{side}</Button>
+                            <Button variant="zombie" size="sm">
+                                {side}
+                            </Button>
                         </TooltipTrigger>
                         <TooltipContent side={side}>Syncs every 30 min</TooltipContent>
                     </Tooltip>

--- a/packages/design-system/stories/v1/Typography.stories.tsx
+++ b/packages/design-system/stories/v1/Typography.stories.tsx
@@ -3,7 +3,7 @@ import { Typography } from '@/components/ui/typography/Typography';
 import type { Meta, StoryObj } from '@storybook/react-vite';
 
 const meta: Meta = {
-    title: 'Components v1/Typography',
+    title: 'Components v1/UI/Typography',
     parameters: { layout: 'padded' }
 };
 export default meta;

--- a/packages/design-system/stories/v1/Typography.stories.tsx
+++ b/packages/design-system/stories/v1/Typography.stories.tsx
@@ -1,4 +1,4 @@
-import { Typography } from '@/components/ui/typography/Typography';
+import Typography from '@/components/ui/typography/Typography';
 
 import type { Meta, StoryObj } from '@storybook/react-vite';
 

--- a/packages/design-system/stories/v1/Typography.stories.tsx
+++ b/packages/design-system/stories/v1/Typography.stories.tsx
@@ -1,0 +1,25 @@
+import { Typography } from '@/components/ui/typography/Typography';
+
+import type { Meta, StoryObj } from '@storybook/react-vite';
+
+const meta: Meta = {
+    title: 'Components v1/Typography',
+    parameters: { layout: 'padded' }
+};
+export default meta;
+type Story = StoryObj<typeof meta>;
+
+const VARIANTS = ['h1', 'h2', 'h3', 'h4', 'h5'] as const;
+
+export const Default: Story = {
+    render: () => (
+        <div className="bg-bg-black p-6 rounded-md flex flex-col gap-4">
+            {VARIANTS.map((variant) => (
+                <div key={variant} className="flex items-center gap-4">
+                    <span className="story-section-heading w-8 shrink-0">{variant}</span>
+                    <Typography variant={variant}>Integration catalog</Typography>
+                </div>
+            ))}
+        </div>
+    )
+};

--- a/packages/design-system/stories/v1/patterns/AvatarCustom.stories.tsx
+++ b/packages/design-system/stories/v1/patterns/AvatarCustom.stories.tsx
@@ -1,0 +1,27 @@
+import { AvatarCustom } from '@/components/patterns/AvatarCustom';
+
+import type { Meta, StoryObj } from '@storybook/react-vite';
+
+const meta: Meta = {
+    title: 'Components v1/Patterns/AvatarCustom',
+    parameters: { layout: 'padded' }
+};
+export default meta;
+type Story = StoryObj<typeof meta>;
+
+export const Default: Story = {
+    render: () => (
+        <div className="bg-bg-black p-6 rounded-md flex items-center gap-6">
+            {[
+                { name: 'John Doe', label: 'Two words' },
+                { name: 'Nango', label: 'Single word' },
+                { name: 'Acme/Production', label: 'Slash' }
+            ].map(({ name, label }) => (
+                <div key={name} className="flex flex-col items-center gap-2">
+                    <AvatarCustom displayName={name} />
+                    <span className="story-section-heading">{label}</span>
+                </div>
+            ))}
+        </div>
+    )
+};

--- a/packages/design-system/stories/v1/patterns/ConfirmModal.stories.tsx
+++ b/packages/design-system/stories/v1/patterns/ConfirmModal.stories.tsx
@@ -1,7 +1,7 @@
 import { useState } from 'react';
 
-import { Button } from '@/components/ui/button/Button';
 import { ConfirmModal } from '@/components/patterns/ConfirmModal';
+import { Button } from '@/components/ui/button/Button';
 
 import type { Meta, StoryObj } from '@storybook/react-vite';
 
@@ -22,7 +22,11 @@ export const Default: Story = {
                     description="This will permanently remove the connection and all synced data."
                     confirmButtonText="Delete"
                     loading={loading}
-                    trigger={<Button variant="danger" size="sm">Delete connection</Button>}
+                    trigger={
+                        <Button variant="danger" size="sm">
+                            Delete connection
+                        </Button>
+                    }
                     onConfirm={() => setLoading(true)}
                 />
             </div>

--- a/packages/design-system/stories/v1/patterns/ConfirmModal.stories.tsx
+++ b/packages/design-system/stories/v1/patterns/ConfirmModal.stories.tsx
@@ -1,0 +1,31 @@
+import { useState } from 'react';
+
+import { Button } from '@/components/ui/button/Button';
+import { ConfirmModal } from '@/components/patterns/ConfirmModal';
+
+import type { Meta, StoryObj } from '@storybook/react-vite';
+
+const meta: Meta = {
+    title: 'Components v1/Patterns/ConfirmModal',
+    parameters: { layout: 'padded' }
+};
+export default meta;
+type Story = StoryObj<typeof meta>;
+
+export const Default: Story = {
+    render: () => {
+        const [loading, setLoading] = useState(false);
+        return (
+            <div className="bg-bg-black p-6 rounded-md">
+                <ConfirmModal
+                    title="Delete connection"
+                    description="This will permanently remove the connection and all synced data."
+                    confirmButtonText="Delete"
+                    loading={loading}
+                    trigger={<Button variant="danger" size="sm">Delete connection</Button>}
+                    onConfirm={() => setLoading(true)}
+                />
+            </div>
+        );
+    }
+};

--- a/packages/design-system/stories/v1/patterns/EmptyState.stories.tsx
+++ b/packages/design-system/stories/v1/patterns/EmptyState.stories.tsx
@@ -12,10 +12,7 @@ type Story = StoryObj<typeof meta>;
 export const Default: Story = {
     render: () => (
         <div className="bg-bg-black p-6 rounded-md max-w-2xl">
-            <EmptyState
-                title="No connections yet"
-                help="Connect your first integration to start syncing data."
-            />
+            <EmptyState title="No connections yet" help="Connect your first integration to start syncing data." />
         </div>
     )
 };

--- a/packages/design-system/stories/v1/patterns/EmptyState.stories.tsx
+++ b/packages/design-system/stories/v1/patterns/EmptyState.stories.tsx
@@ -1,0 +1,21 @@
+import { EmptyState } from '@/components/patterns/EmptyState';
+
+import type { Meta, StoryObj } from '@storybook/react-vite';
+
+const meta: Meta = {
+    title: 'Components v1/Patterns/EmptyState',
+    parameters: { layout: 'padded' }
+};
+export default meta;
+type Story = StoryObj<typeof meta>;
+
+export const Default: Story = {
+    render: () => (
+        <div className="bg-bg-black p-6 rounded-md max-w-2xl">
+            <EmptyState
+                title="No connections yet"
+                help="Connect your first integration to start syncing data."
+            />
+        </div>
+    )
+};

--- a/packages/design-system/stories/v1/patterns/Info.stories.tsx
+++ b/packages/design-system/stories/v1/patterns/Info.stories.tsx
@@ -14,7 +14,9 @@ export const Default: Story = {
         <div className="bg-bg-black p-6 rounded-md flex flex-col gap-4 max-w-xl">
             <Info>Your integration is connected and syncing data every hour.</Info>
             <Info variant="destructive">Sync failed — could not reach the upstream API.</Info>
-            <Info variant="warning" title="Token expiring">Your access token expires in 3 days.</Info>
+            <Info variant="warning" title="Token expiring">
+                Your access token expires in 3 days.
+            </Info>
         </div>
     )
 };

--- a/packages/design-system/stories/v1/patterns/Info.stories.tsx
+++ b/packages/design-system/stories/v1/patterns/Info.stories.tsx
@@ -1,0 +1,20 @@
+import { Info } from '@/components/patterns/Info';
+
+import type { Meta, StoryObj } from '@storybook/react-vite';
+
+const meta: Meta = {
+    title: 'Components v1/Patterns/Info',
+    parameters: { layout: 'padded' }
+};
+export default meta;
+type Story = StoryObj<typeof meta>;
+
+export const Default: Story = {
+    render: () => (
+        <div className="bg-bg-black p-6 rounded-md flex flex-col gap-4 max-w-xl">
+            <Info>Your integration is connected and syncing data every hour.</Info>
+            <Info variant="destructive">Sync failed — could not reach the upstream API.</Info>
+            <Info variant="warning" title="Token expiring">Your access token expires in 3 days.</Info>
+        </div>
+    )
+};

--- a/packages/design-system/stories/v1/patterns/InfoBloc.stories.tsx
+++ b/packages/design-system/stories/v1/patterns/InfoBloc.stories.tsx
@@ -13,7 +13,9 @@ export const Default: Story = {
     render: () => (
         <div className="bg-bg-black p-6 rounded-md flex flex-col gap-6 w-72">
             <InfoBloc title="Status">Active</InfoBloc>
-            <InfoBloc title="Integration" help="The integration this connection belongs to.">GitHub</InfoBloc>
+            <InfoBloc title="Integration" help="The integration this connection belongs to.">
+                GitHub
+            </InfoBloc>
             <InfoBloc title="Last synced">2 minutes ago</InfoBloc>
         </div>
     )

--- a/packages/design-system/stories/v1/patterns/InfoBloc.stories.tsx
+++ b/packages/design-system/stories/v1/patterns/InfoBloc.stories.tsx
@@ -1,0 +1,20 @@
+import { InfoBloc } from '@/components/patterns/InfoBloc';
+
+import type { Meta, StoryObj } from '@storybook/react-vite';
+
+const meta: Meta = {
+    title: 'Components v1/Patterns/InfoBloc',
+    parameters: { layout: 'padded' }
+};
+export default meta;
+type Story = StoryObj<typeof meta>;
+
+export const Default: Story = {
+    render: () => (
+        <div className="bg-bg-black p-6 rounded-md flex flex-col gap-6 w-72">
+            <InfoBloc title="Status">Active</InfoBloc>
+            <InfoBloc title="Integration" help="The integration this connection belongs to.">GitHub</InfoBloc>
+            <InfoBloc title="Last synced">2 minutes ago</InfoBloc>
+        </div>
+    )
+};

--- a/packages/design-system/stories/v1/patterns/LinkWithIcon.stories.tsx
+++ b/packages/design-system/stories/v1/patterns/LinkWithIcon.stories.tsx
@@ -7,7 +7,13 @@ import type { Meta, StoryObj } from '@storybook/react-vite';
 const meta: Meta = {
     title: 'Components v1/Patterns/LinkWithIcon',
     parameters: { layout: 'padded' },
-    decorators: [(Story) => <MemoryRouter><Story /></MemoryRouter>]
+    decorators: [
+        (Story) => (
+            <MemoryRouter>
+                <Story />
+            </MemoryRouter>
+        )
+    ]
 };
 export default meta;
 type Story = StoryObj<typeof meta>;
@@ -15,8 +21,12 @@ type Story = StoryObj<typeof meta>;
 export const Default: Story = {
     render: () => (
         <div className="bg-bg-black p-6 rounded-md flex flex-col gap-4">
-            <LinkWithIcon to="/integrations" type="internal">View integrations</LinkWithIcon>
-            <LinkWithIcon to="https://docs.nango.dev" type="external">Read the docs</LinkWithIcon>
+            <LinkWithIcon to="/integrations" type="internal">
+                View integrations
+            </LinkWithIcon>
+            <LinkWithIcon to="https://docs.nango.dev" type="external">
+                Read the docs
+            </LinkWithIcon>
         </div>
     )
 };

--- a/packages/design-system/stories/v1/patterns/LinkWithIcon.stories.tsx
+++ b/packages/design-system/stories/v1/patterns/LinkWithIcon.stories.tsx
@@ -1,0 +1,22 @@
+import { MemoryRouter } from 'react-router-dom';
+
+import LinkWithIcon from '@/components/patterns/LinkWithIcon';
+
+import type { Meta, StoryObj } from '@storybook/react-vite';
+
+const meta: Meta = {
+    title: 'Components v1/Patterns/LinkWithIcon',
+    parameters: { layout: 'padded' },
+    decorators: [(Story) => <MemoryRouter><Story /></MemoryRouter>]
+};
+export default meta;
+type Story = StoryObj<typeof meta>;
+
+export const Default: Story = {
+    render: () => (
+        <div className="bg-bg-black p-6 rounded-md flex flex-col gap-4">
+            <LinkWithIcon to="/integrations" type="internal">View integrations</LinkWithIcon>
+            <LinkWithIcon to="https://docs.nango.dev" type="external">Read the docs</LinkWithIcon>
+        </div>
+    )
+};

--- a/packages/design-system/stories/v2-patterns/ConfirmDialog.stories.tsx
+++ b/packages/design-system/stories/v2-patterns/ConfirmDialog.stories.tsx
@@ -1,7 +1,7 @@
 import { useState } from 'react';
 
-import { Button } from '@/components-v2/ui/Button';
 import { ConfirmDialog } from '@/components-v2/patterns/ConfirmDialog';
+import { Button } from '@/components-v2/ui/Button';
 
 import type { Meta, StoryObj } from '@storybook/react-vite';
 
@@ -17,7 +17,9 @@ export const Default: Story = {
         const [open, setOpen] = useState(false);
         return (
             <>
-                <Button variant="secondary" size="sm" onClick={() => setOpen(true)}>Open dialog</Button>
+                <Button variant="secondary" size="sm" onClick={() => setOpen(true)}>
+                    Open dialog
+                </Button>
                 <ConfirmDialog
                     open={open}
                     onOpenChange={setOpen}

--- a/packages/design-system/stories/v2-patterns/ConfirmDialog.stories.tsx
+++ b/packages/design-system/stories/v2-patterns/ConfirmDialog.stories.tsx
@@ -1,0 +1,33 @@
+import { useState } from 'react';
+
+import { Button } from '@/components-v2/ui/Button';
+import { ConfirmDialog } from '@/components-v2/patterns/ConfirmDialog';
+
+import type { Meta, StoryObj } from '@storybook/react-vite';
+
+const meta: Meta = {
+    title: 'Components v2/Patterns/ConfirmDialog',
+    parameters: { layout: 'padded' }
+};
+export default meta;
+type Story = StoryObj<typeof meta>;
+
+export const Default: Story = {
+    render: () => {
+        const [open, setOpen] = useState(false);
+        return (
+            <>
+                <Button variant="secondary" size="sm" onClick={() => setOpen(true)}>Open dialog</Button>
+                <ConfirmDialog
+                    open={open}
+                    onOpenChange={setOpen}
+                    title="Disconnect integration"
+                    description="This will remove all connections and stop all syncs for this integration."
+                    confirmButtonText="Disconnect"
+                    confirmVariant="destructive"
+                    onConfirm={() => setOpen(false)}
+                />
+            </>
+        );
+    }
+};

--- a/packages/design-system/stories/v2-patterns/CriticalErrorAlert.stories.tsx
+++ b/packages/design-system/stories/v2-patterns/CriticalErrorAlert.stories.tsx
@@ -7,7 +7,13 @@ import type { Meta, StoryObj } from '@storybook/react-vite';
 const meta: Meta = {
     title: 'Components v2/Patterns/CriticalErrorAlert',
     parameters: { layout: 'padded' },
-    decorators: [(Story) => <MemoryRouter><Story /></MemoryRouter>]
+    decorators: [
+        (Story) => (
+            <MemoryRouter>
+                <Story />
+            </MemoryRouter>
+        )
+    ]
 };
 export default meta;
 type Story = StoryObj<typeof meta>;

--- a/packages/design-system/stories/v2-patterns/CriticalErrorAlert.stories.tsx
+++ b/packages/design-system/stories/v2-patterns/CriticalErrorAlert.stories.tsx
@@ -1,0 +1,22 @@
+import { MemoryRouter } from 'react-router-dom';
+
+import { CriticalErrorAlert } from '@/components-v2/patterns/CriticalErrorAlert';
+
+import type { Meta, StoryObj } from '@storybook/react-vite';
+
+const meta: Meta = {
+    title: 'Components v2/Patterns/CriticalErrorAlert',
+    parameters: { layout: 'padded' },
+    decorators: [(Story) => <MemoryRouter><Story /></MemoryRouter>]
+};
+export default meta;
+type Story = StoryObj<typeof meta>;
+
+export const Default: Story = {
+    render: () => (
+        <div className="flex flex-col gap-4 max-w-xl">
+            <CriticalErrorAlert message="Failed to connect to the upstream API" />
+            <CriticalErrorAlert message="Invalid credentials — refresh your access token." />
+        </div>
+    )
+};

--- a/packages/design-system/stories/v2-patterns/IntegrationLogo.stories.tsx
+++ b/packages/design-system/stories/v2-patterns/IntegrationLogo.stories.tsx
@@ -1,0 +1,25 @@
+import { IntegrationLogo } from '@/components-v2/patterns/IntegrationLogo';
+
+import type { Meta, StoryObj } from '@storybook/react-vite';
+
+const meta: Meta = {
+    title: 'Components v2/Patterns/IntegrationLogo',
+    parameters: { layout: 'padded' }
+};
+export default meta;
+type Story = StoryObj<typeof meta>;
+
+const PROVIDERS = ['github', 'slack', 'hubspot', 'salesforce', 'notion', 'unknown-fallback', 'unauthenticated'];
+
+export const Default: Story = {
+    render: () => (
+        <div className="flex items-center gap-4 flex-wrap">
+            {PROVIDERS.map((provider) => (
+                <div key={provider} className="flex flex-col items-center gap-2">
+                    <IntegrationLogo provider={provider} />
+                    <span className="story-section-heading">{provider === 'unknown-fallback' ? 'unknown' : provider}</span>
+                </div>
+            ))}
+        </div>
+    )
+};

--- a/packages/design-system/stories/v2-patterns/KeyValueInput.stories.tsx
+++ b/packages/design-system/stories/v2-patterns/KeyValueInput.stories.tsx
@@ -20,18 +20,11 @@ export const Default: Story = {
             </div>
             <div className="flex flex-col gap-2">
                 <span className="story-section-heading">With values</span>
-                <KeyValueInput
-                    initialValues={{ Authorization: 'Bearer token123', 'X-Tenant-Id': 'acme' }}
-                    onChange={fn()}
-                />
+                <KeyValueInput initialValues={{ Authorization: 'Bearer token123', 'X-Tenant-Id': 'acme' }} onChange={fn()} />
             </div>
             <div className="flex flex-col gap-2">
                 <span className="story-section-heading">Secret</span>
-                <KeyValueInput
-                    initialValues={{ API_KEY: 'secret-key-abc' }}
-                    onChange={fn()}
-                    isSecret
-                />
+                <KeyValueInput initialValues={{ API_KEY: 'secret-key-abc' }} onChange={fn()} isSecret />
             </div>
         </div>
     )

--- a/packages/design-system/stories/v2-patterns/KeyValueInput.stories.tsx
+++ b/packages/design-system/stories/v2-patterns/KeyValueInput.stories.tsx
@@ -1,0 +1,38 @@
+import { fn } from 'storybook/test';
+
+import { KeyValueInput } from '@/components-v2/patterns/KeyValueInput';
+
+import type { Meta, StoryObj } from '@storybook/react-vite';
+
+const meta: Meta = {
+    title: 'Components v2/Patterns/KeyValueInput',
+    parameters: { layout: 'padded' }
+};
+export default meta;
+type Story = StoryObj<typeof meta>;
+
+export const Default: Story = {
+    render: () => (
+        <div className="flex flex-col gap-8 w-96">
+            <div className="flex flex-col gap-2">
+                <span className="story-section-heading">Empty</span>
+                <KeyValueInput onChange={fn()} />
+            </div>
+            <div className="flex flex-col gap-2">
+                <span className="story-section-heading">With values</span>
+                <KeyValueInput
+                    initialValues={{ Authorization: 'Bearer token123', 'X-Tenant-Id': 'acme' }}
+                    onChange={fn()}
+                />
+            </div>
+            <div className="flex flex-col gap-2">
+                <span className="story-section-heading">Secret</span>
+                <KeyValueInput
+                    initialValues={{ API_KEY: 'secret-key-abc' }}
+                    onChange={fn()}
+                    isSecret
+                />
+            </div>
+        </div>
+    )
+};

--- a/packages/design-system/stories/v2-patterns/PermissionGate.stories.tsx
+++ b/packages/design-system/stories/v2-patterns/PermissionGate.stories.tsx
@@ -1,5 +1,5 @@
-import { Button } from '@/components-v2/ui/Button';
 import { PermissionGate } from '@/components-v2/patterns/PermissionGate';
+import { Button } from '@/components-v2/ui/Button';
 
 import type { Meta, StoryObj } from '@storybook/react-vite';
 
@@ -16,13 +16,21 @@ export const Default: Story = {
             <div className="flex flex-col gap-2">
                 <span className="story-section-heading">Allowed</span>
                 <PermissionGate condition={true}>
-                    {(allowed) => <Button variant="primary" size="sm" disabled={!allowed}>Edit</Button>}
+                    {(allowed) => (
+                        <Button variant="primary" size="sm" disabled={!allowed}>
+                            Edit
+                        </Button>
+                    )}
                 </PermissionGate>
             </div>
             <div className="flex flex-col gap-2">
                 <span className="story-section-heading">Denied (hover for tooltip)</span>
                 <PermissionGate condition={false} message="You need admin role to edit this.">
-                    {(allowed) => <Button variant="primary" size="sm" disabled={!allowed}>Edit</Button>}
+                    {(allowed) => (
+                        <Button variant="primary" size="sm" disabled={!allowed}>
+                            Edit
+                        </Button>
+                    )}
                 </PermissionGate>
             </div>
         </div>

--- a/packages/design-system/stories/v2-patterns/PermissionGate.stories.tsx
+++ b/packages/design-system/stories/v2-patterns/PermissionGate.stories.tsx
@@ -1,0 +1,30 @@
+import { Button } from '@/components-v2/ui/Button';
+import { PermissionGate } from '@/components-v2/patterns/PermissionGate';
+
+import type { Meta, StoryObj } from '@storybook/react-vite';
+
+const meta: Meta = {
+    title: 'Components v2/Patterns/PermissionGate',
+    parameters: { layout: 'padded' }
+};
+export default meta;
+type Story = StoryObj<typeof meta>;
+
+export const Default: Story = {
+    render: () => (
+        <div className="flex items-center gap-6">
+            <div className="flex flex-col gap-2">
+                <span className="story-section-heading">Allowed</span>
+                <PermissionGate condition={true}>
+                    {(allowed) => <Button variant="primary" size="sm" disabled={!allowed}>Edit</Button>}
+                </PermissionGate>
+            </div>
+            <div className="flex flex-col gap-2">
+                <span className="story-section-heading">Denied (hover for tooltip)</span>
+                <PermissionGate condition={false} message="You need admin role to edit this.">
+                    {(allowed) => <Button variant="primary" size="sm" disabled={!allowed}>Edit</Button>}
+                </PermissionGate>
+            </div>
+        </div>
+    )
+};

--- a/packages/design-system/stories/v2-patterns/ScopesInput.stories.tsx
+++ b/packages/design-system/stories/v2-patterns/ScopesInput.stories.tsx
@@ -12,7 +12,7 @@ type Story = StoryObj<typeof meta>;
 export const ReadOnly: Story = {
     name: 'Read-only',
     render: () => (
-        <div className="w-96">
+        <div className="w-96 pt-4">
             <ScopesInput scopesString="repo,read:user,read:org" readOnly />
         </div>
     )
@@ -20,7 +20,7 @@ export const ReadOnly: Story = {
 
 export const Editable: Story = {
     render: () => (
-        <div className="w-96">
+        <div className="w-96 pt-4">
             <ScopesInput
                 scopesString="repo,read:user"
                 availableScopes={['repo', 'read:user', 'read:org', 'write:packages', 'delete:packages']}

--- a/packages/design-system/stories/v2-patterns/ScopesInput.stories.tsx
+++ b/packages/design-system/stories/v2-patterns/ScopesInput.stories.tsx
@@ -1,0 +1,32 @@
+import { ScopesInput } from '@/components-v2/patterns/ScopesInput';
+
+import type { Meta, StoryObj } from '@storybook/react-vite';
+
+const meta: Meta = {
+    title: 'Components v2/Patterns/ScopesInput',
+    parameters: { layout: 'padded' }
+};
+export default meta;
+type Story = StoryObj<typeof meta>;
+
+export const ReadOnly: Story = {
+    name: 'Read-only',
+    render: () => (
+        <div className="w-96">
+            <ScopesInput scopesString="repo,read:user,read:org" readOnly />
+        </div>
+    )
+};
+
+export const Editable: Story = {
+    render: () => (
+        <div className="w-96">
+            <ScopesInput
+                scopesString="repo,read:user"
+                availableScopes={['repo', 'read:user', 'read:org', 'write:packages', 'delete:packages']}
+                showAvailableScopesDropdown
+                onChange={async () => {}}
+            />
+        </div>
+    )
+};


### PR DESCRIPTION
## Problem

The team had no visual catalog of the app's component library, making it hard to find the right component during section redesigns, compare v1 and v2 equivalents during the migration, or get an a11y baseline without running the full app.

## Solution

Extends the existing design-system Storybook to catalog every component across all three tiers:

| Section | Count |
|---|---|
| Components v2 / UI | 43 — all `components-v2/ui/` components |
| Components v2 / Patterns | 10 — all `components-v2/patterns/` components |
| Components v1 / UI | 20 — visually renderable `components/ui/` components (dark canvas) |
| Components v1 / Patterns | 6 — `AvatarCustom`, `ConfirmModal`, `EmptyState`, `Info`, `InfoBloc`, `LinkWithIcon` |

**Live:** https://storybook.nango.dev/

**Infrastructure changes:**
- `main.ts`: adds `@` alias pointing to `packages/webapp/src`, `server.fs.allow`, and a `stories/**` glob so Storybook can import and scan webapp source
- `preview.css`: imports `webapp/src/index.css` (component-level semantic tokens) + `@source` so Tailwind v4 JIT generates utility classes from webapp files
- `preview.ts`: adds a `withDarkClass` decorator so the theme toggle applies `.dark` class (webapp) alongside `data-theme` (design-system tokens), making both token stories and component stories respond correctly
- Stories live in `packages/design-system/stories/` rather than colocated with components — avoids changes to webapp `tsconfig` and ESLint config since `@storybook/react-vite` is a design-system-only dep
- CI: adds `deploy-storybook.yml` to redeploy on pushes to master

Fixes [NAN-5771](https://linear.app/nango/issue/NAN-5771)

## Testing

- **Live Storybook:** https://storybook.nango.dev/
- All `Components v2 / UI` stories render with correct design tokens in both light and dark mode
- `Components v1 / UI` stories render on a dark canvas (matching how they appear in the app), useful for side-by-side migration comparison
- Existing `Design System / Tokens` stories are unaffected
- `addon-a11y` fires on every story (visible in the Accessibility tab)