### PR TITLE
feat(webapp): allow local dashboard dev server to connect to remote API

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -4,3 +4,15 @@ After running the initial `npm install` or `npm ci`, run `npm run prepare` to in
 ## TypeScript Build
 
 Run `npm run ts-build` before autofixing lint errors using npm run lint:fix. Fresh worktrees don't have `dist/` (gitignored), so workspace packages like `@nangohq/types` can't resolve, causing false ESLint errors and broken type-checking.
+
+## Running the webapp against a remote API
+
+Pass `REMOTE_API=<env>` when starting the dev server to proxy all API traffic through Vite instead of a local backend. No browser CORS extension needed.
+
+```bash
+REMOTE_API=staging npm run dev   # https://api-staging.nango.dev
+REMOTE_API=dev npm run dev       # https://api-development.nango.dev
+REMOTE_API=prod npm run dev      # https://api.nango.dev
+```
+
+When `REMOTE_API` is not set, the dev server behaves as normal and expects a local backend on `localhost:3003`.

--- a/packages/webapp/package.json
+++ b/packages/webapp/package.json
@@ -4,7 +4,7 @@
     "private": true,
     "type": "module",
     "scripts": {
-        "dev": "vite --port 3000",
+        "dev": "vite",
         "build": "vite build",
         "preview": "vite preview",
         "test": "vitest"

--- a/packages/webapp/vite.config.ts
+++ b/packages/webapp/vite.config.ts
@@ -56,8 +56,7 @@ function remoteApiConfig() {
             '/integrations': remote, // Connect UI integration list
             '/providers': remote,   // Connect UI provider details
             '/proxy': remote,       // Getting-started proxy call
-            '/oauth': remote,       // OAuth popup flow
-            '/oauth2': remote,
+            '/oauth2': remote,      // OAuth2 client credentials (direct POST, no popup)
             '/api-auth': remote,    // API key / basic auth
             '/auth': remote,        // TBA, JWT, two-step, etc.
             '/app-store-auth': remote,

--- a/packages/webapp/vite.config.ts
+++ b/packages/webapp/vite.config.ts
@@ -48,20 +48,20 @@ function remoteApiConfig() {
     const remote = { target: url, changeOrigin: true };
     return {
         remotePlugin: remoteApiEnvProxy(url),
-        // env.js rewrites apiUrl to localhost so the browser never goes cross-origin.
-        // Every path the @nangohq/frontend SDK and Connect UI construct from apiUrl must be proxied here.
         remoteProxy: {
             '/api': remote,
-            '/connect': remote,
-            '/integrations': remote,
-            '/providers': remote,
-            '/oauth': remote,
+            // Extra routes needed for connection creation and auth flows.
+            // Most dashboard functionality (viewing connections, logs, settings) works with /api alone.
+            '/connect': remote,     // Connect UI session + telemetry
+            '/integrations': remote, // Connect UI integration list
+            '/providers': remote,   // Connect UI provider details
+            '/proxy': remote,       // Getting-started proxy call
+            '/oauth': remote,       // OAuth popup flow
             '/oauth2': remote,
-            '/api-auth': remote,
-            '/auth': remote,
+            '/api-auth': remote,    // API key / basic auth
+            '/auth': remote,        // TBA, JWT, two-step, etc.
             '/app-store-auth': remote,
-            '/app-auth': remote,
-            '/proxy': remote
+            '/app-auth': remote     // GitHub App setup callback
         }
     };
 }

--- a/packages/webapp/vite.config.ts
+++ b/packages/webapp/vite.config.ts
@@ -60,7 +60,8 @@ function remoteApiConfig() {
             '/api-auth': remote,
             '/auth': remote,
             '/app-store-auth': remote,
-            '/app-auth': remote
+            '/app-auth': remote,
+            '/proxy': remote
         }
     };
 }

--- a/packages/webapp/vite.config.ts
+++ b/packages/webapp/vite.config.ts
@@ -10,6 +10,7 @@ import svgr from 'vite-plugin-svgr';
 import type { Plugin } from 'vite';
 
 const DEV_PORT = 3000;
+const LOCAL_API_PORT = 3003;
 
 const REMOTE_API_URLS: Record<string, string> = {
     dev: 'https://api-development.nango.dev',
@@ -38,7 +39,7 @@ function remoteApiEnvProxy(remoteApiUrl: string): Plugin {
 function remoteApiConfig() {
     const remoteApi = process.env['REMOTE_API'];
     if (!remoteApi) {
-        return { remoteProxy: { '/env.js': { target: 'http://localhost:3003' } } };
+        return { remoteProxy: { '/env.js': { target: `http://localhost:${LOCAL_API_PORT}` } } };
     }
     const url = REMOTE_API_URLS[remoteApi];
     if (!url) {

--- a/packages/webapp/vite.config.ts
+++ b/packages/webapp/vite.config.ts
@@ -7,7 +7,9 @@ import { defineConfig } from 'vite';
 import checker from 'vite-plugin-checker';
 import svgr from 'vite-plugin-svgr';
 
-import type { Plugin, PluginOption } from 'vite';
+import type { Plugin } from 'vite';
+
+const DEV_PORT = 3000;
 
 const REMOTE_API_URLS: Record<string, string> = {
     dev: 'https://api-development.nango.dev',
@@ -24,7 +26,7 @@ function remoteApiEnvProxy(remoteApiUrl: string): Plugin {
         configureServer(server) {
             // eslint-disable-next-line @typescript-eslint/no-misused-promises
             server.middlewares.use('/env.js', async (req, res) => {
-                const origin = `http://${req.headers.host ?? 'localhost:3000'}`;
+                const origin = `http://${req.headers.host ?? `localhost:${DEV_PORT}`}`;
                 const body = await fetch(`${remoteApiUrl}/env.js`).then((r) => r.text());
                 res.setHeader('Content-Type', 'text/javascript');
                 res.end(body.replace(/"apiUrl": "[^"]*"/, `"apiUrl": "${origin}"`));
@@ -33,23 +35,24 @@ function remoteApiEnvProxy(remoteApiUrl: string): Plugin {
     };
 }
 
-function remoteApiConfig(remoteApi: string | undefined) {
+function remoteApiConfig() {
+    const remoteApi = process.env['REMOTE_API'];
     if (!remoteApi) {
-        return { remotePlugin: null, remoteProxy: { '/env.js': { target: 'http://localhost:3003' } } };
+        return { remoteProxy: { '/env.js': { target: 'http://localhost:3003' } } };
     }
     const url = REMOTE_API_URLS[remoteApi];
     if (!url) {
-        throw new Error(`Unknown REMOTE_API="${remoteApi}". Valid values: ${Object.keys(REMOTE_API_URLS).join(', ')}`);
+        throw new Error(`[nango] Unknown REMOTE_API="${remoteApi}". Valid values: ${Object.keys(REMOTE_API_URLS).join(', ')}`);
     }
     return { remotePlugin: remoteApiEnvProxy(url), remoteProxy: { '/api': { target: url, changeOrigin: true } } };
 }
 
 // https://vitejs.dev/config/
 export default defineConfig(() => {
-    const { remotePlugin, remoteProxy } = remoteApiConfig(process.env['REMOTE_API']);
+    const { remotePlugin, remoteProxy } = remoteApiConfig();
 
     return {
-        plugins: [react(), svgr(), checker({ typescript: true }), tailwindcss(), remotePlugin] as PluginOption[],
+        plugins: [react(), svgr(), checker({ typescript: true }), tailwindcss(), remotePlugin],
         resolve: {
             alias: {
                 '@': path.resolve(__dirname, './src'),
@@ -58,7 +61,7 @@ export default defineConfig(() => {
                 '@tabler/icons-react': '@tabler/icons-react/dist/esm/icons/index.mjs'
             }
         },
-        server: { proxy: remoteProxy },
+        server: { port: DEV_PORT, proxy: remoteProxy },
         define: {
             'import.meta.env.VITE_HASH': JSON.stringify(createHash('md5').update(Date.now().toString()).digest('hex').slice(0, 8))
         }

--- a/packages/webapp/vite.config.ts
+++ b/packages/webapp/vite.config.ts
@@ -48,8 +48,18 @@ function remoteApiConfig() {
     return {
         remotePlugin: remoteApiEnvProxy(url),
         // env.js rewrites apiUrl to localhost so the browser never goes cross-origin.
-        // Every path the @nangohq/frontend SDK constructs from apiUrl must be proxied here.
-        remoteProxy: { '/api': remote, '/oauth': remote, '/oauth2': remote, '/api-auth': remote, '/auth': remote, '/app-store-auth': remote }
+        // Every path the @nangohq/frontend SDK and Connect UI construct from apiUrl must be proxied here.
+        remoteProxy: {
+            '/api': remote,
+            '/connect': remote,
+            '/integrations': remote,
+            '/providers': remote,
+            '/oauth': remote,
+            '/oauth2': remote,
+            '/api-auth': remote,
+            '/auth': remote,
+            '/app-store-auth': remote
+        }
     };
 }
 

--- a/packages/webapp/vite.config.ts
+++ b/packages/webapp/vite.config.ts
@@ -58,7 +58,8 @@ function remoteApiConfig() {
             '/oauth2': remote,
             '/api-auth': remote,
             '/auth': remote,
-            '/app-store-auth': remote
+            '/app-store-auth': remote,
+            '/app-auth': remote
         }
     };
 }

--- a/packages/webapp/vite.config.ts
+++ b/packages/webapp/vite.config.ts
@@ -26,7 +26,7 @@ function remoteApiEnvProxy(remoteApiUrl: string): Plugin {
         name: 'remote-api-env-proxy',
         configureServer(server) {
             // eslint-disable-next-line @typescript-eslint/no-misused-promises
-            server.middlewares.use('/env.js', async (req, res) => {
+            server.middlewares.use('/env.js', async (_req, res) => {
                 const origin = `http://localhost:${DEV_PORT}`;
                 const body = await fetch(`${remoteApiUrl}/env.js`).then((r) => r.text());
                 res.setHeader('Content-Type', 'text/javascript');

--- a/packages/webapp/vite.config.ts
+++ b/packages/webapp/vite.config.ts
@@ -7,32 +7,62 @@ import { defineConfig } from 'vite';
 import checker from 'vite-plugin-checker';
 import svgr from 'vite-plugin-svgr';
 
-import type { PluginOption } from 'vite';
+import type { Plugin, PluginOption, ProxyOptions } from 'vite';
+
+const REMOTE_API_URLS: Record<string, string> = {
+    dev: 'https://api-development.nango.dev',
+    staging: 'https://api-staging.nango.dev',
+    prod: 'https://api.nango.dev'
+};
+
+// Fetches /env.js from a remote API and rewrites apiUrl to the local dev server
+// so all API calls are routed through Vite's proxy instead of going cross-origin.
+// Activated by setting REMOTE_API=dev|staging|prod when running the dev server.
+function remoteApiEnvProxy(remoteApiUrl: string): Plugin {
+    return {
+        name: 'remote-api-env-proxy',
+        configureServer(server) {
+            server.middlewares.use('/env.js', async (req, res) => {
+                const origin = `http://${req.headers.host ?? 'localhost:3000'}`;
+                const body = await fetch(`${remoteApiUrl}/env.js`).then((r) => r.text());
+                res.setHeader('Content-Type', 'text/javascript');
+                res.end(body.replace(/"apiUrl": "[^"]*"/, `"apiUrl": "${origin}"`));
+            });
+        }
+    };
+}
 
 // https://vitejs.dev/config/
-export default defineConfig({
-    plugins: [
-        react(),
-        svgr(),
-        checker({
-            typescript: true
-        }),
-        tailwindcss()
-    ] as PluginOption[],
-    resolve: {
-        alias: {
-            '@': path.resolve(__dirname, './src'),
-            // https://github.com/tabler/tabler-icons/issues/1233
-            // /esm/icons/index.mjs only exports the icons statically, so no separate chunks are created
-            '@tabler/icons-react': '@tabler/icons-react/dist/esm/icons/index.mjs'
-        }
-    },
-    server: {
-        proxy: {
-            '/env.js': 'http://localhost:3003'
-        }
-    },
-    define: {
-        'import.meta.env.VITE_HASH': JSON.stringify(createHash('md5').update(Date.now().toString()).digest('hex').slice(0, 8))
+export default defineConfig(() => {
+    const remoteApi = process.env['REMOTE_API'];
+    const remoteApiUrl = remoteApi ? REMOTE_API_URLS[remoteApi] : undefined;
+    if (remoteApi && !remoteApiUrl) {
+        throw new Error(`Unknown REMOTE_API="${remoteApi}". Valid values: ${Object.keys(REMOTE_API_URLS).join(', ')}`);
     }
+
+    const plugins: PluginOption[] = [react(), svgr(), checker({ typescript: true }), tailwindcss()];
+    const proxy: Record<string, ProxyOptions> = {};
+
+    if (remoteApiUrl) {
+        plugins.push(remoteApiEnvProxy(remoteApiUrl));
+        proxy['/api'] = { target: remoteApiUrl, changeOrigin: true };
+    } else {
+        proxy['/env.js'] = { target: 'http://localhost:3003' };
+    }
+
+    return {
+        plugins,
+        resolve: {
+            alias: {
+                '@': path.resolve(__dirname, './src'),
+                // https://github.com/tabler/tabler-icons/issues/1233
+                // /esm/icons/index.mjs only exports the icons statically, so no separate chunks are created
+                '@tabler/icons-react': '@tabler/icons-react/dist/esm/icons/index.mjs'
+            }
+        },
+        server: { proxy },
+        define: {
+            'import.meta.env.VITE_HASH': JSON.stringify(createHash('md5').update(Date.now().toString()).digest('hex').slice(0, 8))
+        }
+    };
 });

--- a/packages/webapp/vite.config.ts
+++ b/packages/webapp/vite.config.ts
@@ -47,7 +47,9 @@ function remoteApiConfig() {
     const remote = { target: url, changeOrigin: true };
     return {
         remotePlugin: remoteApiEnvProxy(url),
-        remoteProxy: { '/api': remote, '/oauth': remote, '/oauth2': remote, '/api-auth': remote, '/auth': remote }
+        // env.js rewrites apiUrl to localhost so the browser never goes cross-origin.
+        // Every path the @nangohq/frontend SDK constructs from apiUrl must be proxied here.
+        remoteProxy: { '/api': remote, '/oauth': remote, '/oauth2': remote, '/api-auth': remote, '/auth': remote, '/app-store-auth': remote }
     };
 }
 

--- a/packages/webapp/vite.config.ts
+++ b/packages/webapp/vite.config.ts
@@ -52,15 +52,15 @@ function remoteApiConfig() {
             '/api': remote,
             // Extra routes needed for connection creation and auth flows.
             // Most dashboard functionality (viewing connections, logs, settings) works with /api alone.
-            '/connect': remote,     // Connect UI session + telemetry
+            '/connect': remote, // Connect UI session + telemetry
             '/integrations': remote, // Connect UI integration list
-            '/providers': remote,   // Connect UI provider details
-            '/proxy': remote,       // Getting-started proxy call
-            '/oauth2': remote,      // OAuth2 client credentials (direct POST, no popup)
-            '/api-auth': remote,    // API key / basic auth
-            '/auth': remote,        // TBA, JWT, two-step, etc.
+            '/providers': remote, // Connect UI provider details
+            '/proxy': remote, // Getting-started proxy call
+            '/oauth2': remote, // OAuth2 client credentials
+            '/api-auth': remote, // API key / basic auth
+            '/auth': remote, // TBA, JWT, two-step, etc.
             '/app-store-auth': remote,
-            '/app-auth': remote     // GitHub App setup callback
+            '/app-auth': remote // GitHub App setup callback
         }
     };
 }

--- a/packages/webapp/vite.config.ts
+++ b/packages/webapp/vite.config.ts
@@ -44,7 +44,11 @@ function remoteApiConfig() {
     if (!url) {
         throw new Error(`[nango] Unknown REMOTE_API="${remoteApi}". Valid values: ${Object.keys(REMOTE_API_URLS).join(', ')}`);
     }
-    return { remotePlugin: remoteApiEnvProxy(url), remoteProxy: { '/api': { target: url, changeOrigin: true } } };
+    const remote = { target: url, changeOrigin: true };
+    return {
+        remotePlugin: remoteApiEnvProxy(url),
+        remoteProxy: { '/api': remote, '/oauth': remote, '/oauth2': remote, '/api-auth': remote, '/auth': remote }
+    };
 }
 
 // https://vitejs.dev/config/

--- a/packages/webapp/vite.config.ts
+++ b/packages/webapp/vite.config.ts
@@ -7,7 +7,7 @@ import { defineConfig } from 'vite';
 import checker from 'vite-plugin-checker';
 import svgr from 'vite-plugin-svgr';
 
-import type { Plugin, PluginOption, ProxyOptions } from 'vite';
+import type { Plugin, PluginOption } from 'vite';
 
 const REMOTE_API_URLS: Record<string, string> = {
     dev: 'https://api-development.nango.dev',

--- a/packages/webapp/vite.config.ts
+++ b/packages/webapp/vite.config.ts
@@ -22,6 +22,7 @@ function remoteApiEnvProxy(remoteApiUrl: string): Plugin {
     return {
         name: 'remote-api-env-proxy',
         configureServer(server) {
+            // eslint-disable-next-line @typescript-eslint/no-misused-promises
             server.middlewares.use('/env.js', async (req, res) => {
                 const origin = `http://${req.headers.host ?? 'localhost:3000'}`;
                 const body = await fetch(`${remoteApiUrl}/env.js`).then((r) => r.text());
@@ -32,26 +33,23 @@ function remoteApiEnvProxy(remoteApiUrl: string): Plugin {
     };
 }
 
-// https://vitejs.dev/config/
-export default defineConfig(() => {
-    const remoteApi = process.env['REMOTE_API'];
-    const remoteApiUrl = remoteApi ? REMOTE_API_URLS[remoteApi] : undefined;
-    if (remoteApi && !remoteApiUrl) {
+function remoteApiConfig(remoteApi: string | undefined) {
+    if (!remoteApi) {
+        return { remotePlugin: null, remoteProxy: { '/env.js': { target: 'http://localhost:3003' } } };
+    }
+    const url = REMOTE_API_URLS[remoteApi];
+    if (!url) {
         throw new Error(`Unknown REMOTE_API="${remoteApi}". Valid values: ${Object.keys(REMOTE_API_URLS).join(', ')}`);
     }
+    return { remotePlugin: remoteApiEnvProxy(url), remoteProxy: { '/api': { target: url, changeOrigin: true } } };
+}
 
-    const plugins: PluginOption[] = [react(), svgr(), checker({ typescript: true }), tailwindcss()];
-    const proxy: Record<string, ProxyOptions> = {};
-
-    if (remoteApiUrl) {
-        plugins.push(remoteApiEnvProxy(remoteApiUrl));
-        proxy['/api'] = { target: remoteApiUrl, changeOrigin: true };
-    } else {
-        proxy['/env.js'] = { target: 'http://localhost:3003' };
-    }
+// https://vitejs.dev/config/
+export default defineConfig(() => {
+    const { remotePlugin, remoteProxy } = remoteApiConfig(process.env['REMOTE_API']);
 
     return {
-        plugins,
+        plugins: [react(), svgr(), checker({ typescript: true }), tailwindcss(), remotePlugin] as PluginOption[],
         resolve: {
             alias: {
                 '@': path.resolve(__dirname, './src'),
@@ -60,7 +58,7 @@ export default defineConfig(() => {
                 '@tabler/icons-react': '@tabler/icons-react/dist/esm/icons/index.mjs'
             }
         },
-        server: { proxy },
+        server: { proxy: remoteProxy },
         define: {
             'import.meta.env.VITE_HASH': JSON.stringify(createHash('md5').update(Date.now().toString()).digest('hex').slice(0, 8))
         }

--- a/packages/webapp/vite.config.ts
+++ b/packages/webapp/vite.config.ts
@@ -27,7 +27,7 @@ function remoteApiEnvProxy(remoteApiUrl: string): Plugin {
         configureServer(server) {
             // eslint-disable-next-line @typescript-eslint/no-misused-promises
             server.middlewares.use('/env.js', async (req, res) => {
-                const origin = `http://${req.headers.host ?? `localhost:${DEV_PORT}`}`;
+                const origin = `http://localhost:${DEV_PORT}`;
                 const body = await fetch(`${remoteApiUrl}/env.js`).then((r) => r.text());
                 res.setHeader('Content-Type', 'text/javascript');
                 res.end(body.replace(/"apiUrl": "[^"]*"/, `"apiUrl": "${origin}"`));


### PR DESCRIPTION
## Problem

Running the local dashboard dev server against a remote API (staging, dev, prod) required a browser CORS extension or manual workarounds. There was no first-class way to point the local frontend at a remote backend.

## Solution

Add a `REMOTE_API` env var to the Vite dev server config. When set, Vite proxies all `/api` traffic to the target remote API and intercepts `/env.js` to rewrite `apiUrl` to point back through the local proxy — so the browser never makes cross-origin requests.

```bash
REMOTE_API=staging npm run dev   # https://api-staging.nango.dev
REMOTE_API=dev npm run dev       # https://api-development.nango.dev
REMOTE_API=prod npm run dev      # https://api.nango.dev
```

When `REMOTE_API` is unset, behavior is unchanged (local backend on `localhost:3003`).

Also documents the workflow in `AGENTS.md`.

Fixes [NAN-5795](https://linear.app/nango/issue/NAN-5795)

## Testing

- Ran `REMOTE_API=staging npm run dev` and confirmed the dashboard loaded and API calls went through the Vite proxy to staging
- Verified `REMOTE_API` unset still works as before (local backend)
- Verified an invalid `REMOTE_API` value throws a clear error at startup

<!-- start telescope-canary-packages -->
<!-- end telescope-canary-packages -->
