### PR TITLE
feat(records_seen): add sync_job_id_new shadow column + mirror trigger (NAN-5491 Phase 2a)

### DIFF
--- a/packages/records/lib/stores/postgres/migrations/20260601100000_records_seen_add_sync_job_id_new.ts
+++ b/packages/records/lib/stores/postgres/migrations/20260601100000_records_seen_add_sync_job_id_new.ts
@@ -1,0 +1,30 @@
+import type { Knex } from 'knex';
+
+const TABLE = 'records_seen';
+
+// records_seen.sync_job_id is being widened int4 -> bigint online, in steps.
+// Step 1: add a nullable bigint shadow column and mirror every write into it via a trigger,
+// so the new column is populated going forward. Later migrations build its index and swap it in
+// once the column is fully populated (records_seen fully turns over within its retention window).
+// PG 16 row triggers on a partitioned parent automatically apply to existing partitions AND to
+// new ones created later, so daily partitions from ensureSeenPartition inherit it.
+export async function up(knex: Knex): Promise<void> {
+    await knex.raw(`ALTER TABLE "${TABLE}" ADD COLUMN IF NOT EXISTS sync_job_id_new bigint`);
+    await knex.raw(`
+        CREATE OR REPLACE FUNCTION ${TABLE}_mirror_sync_job_id()
+        RETURNS TRIGGER AS $$
+        BEGIN
+            NEW.sync_job_id_new := NEW.sync_job_id;
+            RETURN NEW;
+        END;
+        $$ LANGUAGE plpgsql;
+    `);
+    await knex.raw(`
+        CREATE TRIGGER ${TABLE}_mirror_sync_job_id_trigger
+        BEFORE INSERT OR UPDATE ON "${TABLE}"
+        FOR EACH ROW
+        EXECUTE FUNCTION ${TABLE}_mirror_sync_job_id();
+    `);
+}
+
+export async function down(): Promise<void> {}


### PR DESCRIPTION
Phase 2a of [NAN-5491](https://linear.app/nango/issue/NAN-5491) — online int4 → bigint widening of `records_seen.sync_job_id`. Full plan: [Analysis: migration of sync_job_id](https://linear.app/nango/document/analysis-migration-of-sync-job-id-4ad1fccf92a0).

- **Adds a nullable bigint shadow column `sync_job_id_new` on `nango_records.records_seen`** and a `BEFORE INSERT OR UPDATE` row trigger on the partitioned parent that mirrors every write of `sync_job_id` into it. PG 16 row triggers on a partitioned parent automatically propagate to existing partitions and to new ones created by `ensureSeenPartition`, so daily partitions inherit the column + trigger without per-partition plumbing. Metadata-only DDL; pre-trigger rows in live partitions stay `NULL` until they age out (48h retention) — that's exactly what the Phase 2c pre-swap gate waits for.

This is the first of a **3-PR stack** for Phase 2: this PR (column + trigger) → Phase 2b (parent partitioned index on `sync_job_id_new`) → Phase 2c (atomic swap, gated on `NULL = 0` after 48h turnover). 2c must not deploy until ≥48h after this one is live.

## Test plan
- [x] Verified locally: server-driven migration runs (`[records] migrations completed.`), `nango_records.migrations` records the entry, `\d records_seen` shows `sync_job_id_new bigint`, trigger present on parent AND today's partition with `ON TABLE … parent` ownership, and an insert with `sync_job_id = 42` populates `sync_job_id_new = 42`.
- [ ] CI: records integration suite stays green (no consumer reads `sync_job_id_new`, so existing behavior is unaffected).
- [ ] In prod after merge: confirm trigger appears on the freshly-created daily partition (`\d nango_records.records_seen_<today>`).