### PR TITLE
feat(records_seen): build sync_job_id_new index via CONCURRENTLY + ATTACH (NAN-5491 Phase 2b)

### DIFF
--- a/packages/records/lib/stores/postgres/migrations/20260601110000_records_seen_index_sync_job_id_new.ts
+++ b/packages/records/lib/stores/postgres/migrations/20260601110000_records_seen_index_sync_job_id_new.ts
@@ -22,11 +22,11 @@ export async function up(knex: Knex): Promise<void> {
     const partitions = r.rows.map((row) => row.relname);
 
     for (const p of partitions) {
-        await knex.raw(`CREATE INDEX CONCURRENTLY "${p}_connection_model_job_new" ON "${p}" (connection_id, model, sync_job_id_new)`);
+        await knex.raw('CREATE INDEX CONCURRENTLY ?? ON ?? (connection_id, model, sync_job_id_new)', [`${p}_connection_model_job_new`, p]);
     }
-    await knex.raw(`CREATE INDEX "${PARENT_INDEX}" ON ONLY "${TABLE}" (connection_id, model, sync_job_id_new)`);
+    await knex.raw('CREATE INDEX ?? ON ONLY ?? (connection_id, model, sync_job_id_new)', [PARENT_INDEX, TABLE]);
     for (const p of partitions) {
-        await knex.raw(`ALTER INDEX "${PARENT_INDEX}" ATTACH PARTITION "${p}_connection_model_job_new"`);
+        await knex.raw('ALTER INDEX ?? ATTACH PARTITION ??', [PARENT_INDEX, `${p}_connection_model_job_new`]);
     }
 }
 

--- a/packages/records/lib/stores/postgres/migrations/20260601110000_records_seen_index_sync_job_id_new.ts
+++ b/packages/records/lib/stores/postgres/migrations/20260601110000_records_seen_index_sync_job_id_new.ts
@@ -1,0 +1,33 @@
+import type { Knex } from 'knex';
+
+const TABLE = 'records_seen';
+const PARENT_INDEX = 'records_seen_connection_model_job_new';
+
+export const config = { transaction: false };
+
+// Step 2 of records_seen.sync_job_id widening: build the parent partitioned index on the shadow
+// column online, via the documented CONCURRENTLY + ATTACH path. For each live partition,
+// CREATE INDEX CONCURRENTLY (no write blocking); then CREATE INDEX ON ONLY the parent (invalid
+// until all children attached); then ALTER INDEX ... ATTACH PARTITION for each child. After the
+// last ATTACH, the parent's indisvalid flips to true. Future daily partitions auto-inherit a
+// child index from this parent template. The swap (Phase 2c) renames it to canonical.
+export async function up(knex: Knex): Promise<void> {
+    const r: { rows: { relname: string }[] } = await knex.raw(
+        `SELECT c.relname FROM pg_inherits i
+         JOIN pg_class c ON c.oid = i.inhrelid
+         WHERE i.inhparent = ?::regclass
+         ORDER BY c.relname`,
+        [TABLE]
+    );
+    const partitions = r.rows.map((row) => row.relname);
+
+    for (const p of partitions) {
+        await knex.raw(`CREATE INDEX CONCURRENTLY "${p}_connection_model_job_new" ON "${p}" (connection_id, model, sync_job_id_new)`);
+    }
+    await knex.raw(`CREATE INDEX "${PARENT_INDEX}" ON ONLY "${TABLE}" (connection_id, model, sync_job_id_new)`);
+    for (const p of partitions) {
+        await knex.raw(`ALTER INDEX "${PARENT_INDEX}" ATTACH PARTITION "${p}_connection_model_job_new"`);
+    }
+}
+
+export async function down(): Promise<void> {}


### PR DESCRIPTION
To be merged after this [one](https://github.com/NangoHQ/nango/pull/6304) 

- Builds the new partitioned index `records_seen_connection_model_job_new` on `(connection_id, model, sync_job_id_new)` online, using per-partition `CREATE INDEX CONCURRENTLY` + `CREATE INDEX ON ONLY` parent + `ALTER INDEX … ATTACH PARTITION`. Step 2 of the int4→bigint widening of `records_seen.sync_job_id` (Phase 2a is #6304); the swap that drops the old column lands in a follow-up PR (Phase 2c).

## Why the ceremony

PostgreSQL doesn't allow `CREATE INDEX CONCURRENTLY` on a partitioned parent directly — only on individual partitions. The documented online path is:

1. Per live partition: `CREATE INDEX CONCURRENTLY <child> ON <partition> (...)` — non-blocking, writes continue throughout.
2. `CREATE INDEX ON ONLY <parent> (...)` — parent template; starts `indisvalid = false` because no children are attached yet.
3. `ALTER INDEX <parent> ATTACH PARTITION <child>` per child — after the last ATTACH, the parent's `indisvalid` flips to `true`.

Future daily partitions created by `ensureSeenPartition` auto-inherit a matching child index from this parent template, so no follow-up reconcile is needed. The migration runs outside a transaction (`config = { transaction: false }`) because `CREATE INDEX CONCURRENTLY` can't run in one.

## Test plan

- [x] Local: dropped schemas, ran 2a migration only → confirmed `sync_job_id_new` column + mirror trigger present, no `_new` index.
- [x] Local: ran 2b migration → `records_seen_connection_model_job_new` exists on parent with `indisvalid = true`; today's partition has the matching child index attached and valid.
- [x] Local: manually created tomorrow's partition → PG 16 auto-attached child indexes for both the old and the new parent template.
- [ ] Staging: deploy 2a + 2b, confirm `\d nango_records.records_seen` shows the new index valid.
- [ ] Production: deploy, confirm the same before scheduling Phase 2c (swap).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
