### PR TITLE
feat(records_seen): swap sync_job_id to bigint, drop the int4 column (NAN-5491 Phase 2c)

### DIFF
--- a/packages/records/lib/stores/postgres/migrations/20260601120000_records_seen_swap_sync_job_id.ts
+++ b/packages/records/lib/stores/postgres/migrations/20260601120000_records_seen_swap_sync_job_id.ts
@@ -1,0 +1,19 @@
+import type { Knex } from 'knex';
+
+const TABLE = 'records_seen';
+
+// Step 3 of the online int4 -> bigint widening of records_seen.sync_job_id: swap the new column
+// in and drop the old one. Must NOT run until ≥48h after Phase 2a deployed, so the daily
+// partition turnover has filled sync_job_id_new for every row written before the trigger went
+// live. Single transaction of metadata-only DDL — short ACCESS EXCLUSIVE window.
+export async function up(knex: Knex): Promise<void> {
+    await knex.raw(`SET LOCAL lock_timeout = '3s'`);
+    await knex.raw(`DROP TRIGGER IF EXISTS records_seen_mirror_sync_job_id_trigger ON "${TABLE}"`);
+    await knex.raw(`DROP FUNCTION IF EXISTS records_seen_mirror_sync_job_id()`);
+    // Dropping the old column cascades the old parent partitioned index + its child indexes.
+    await knex.raw(`ALTER TABLE "${TABLE}" DROP COLUMN sync_job_id`);
+    await knex.raw(`ALTER TABLE "${TABLE}" RENAME COLUMN sync_job_id_new TO sync_job_id`);
+    await knex.raw(`ALTER INDEX records_seen_connection_model_job_new RENAME TO records_seen_connection_model_job`);
+}
+
+export async function down(): Promise<void> {}


### PR DESCRIPTION
To be merged after this one https://github.com/NangoHQ/nango/pull/6306 with a gate time of 3 days and checking that indices are in place and we have no null

- Drops the old `int4 sync_job_id`, renames `sync_job_id_new (bigint)` to `sync_job_id`, renames the new parent partitioned index to the canonical name, and drops the mirror trigger + function. Final step of the int4→bigint widening of `records_seen.sync_job_id` (Phase 2a is #6304, Phase 2b is #6306). Must not deploy until ≥48h after Phase 2a so the daily-partition turnover has filled `sync_job_id_new` for every live row.

## Why the new column is left nullable

The original `sync_job_id` was `NOT NULL`; the rebuilt one is left nullable. Restoring `NOT NULL` requires `ALTER TABLE … SET NOT NULL`, which scans the entire table under `ACCESS EXCLUSIVE` — blocking every writer for the scan duration, with no reliable bound on cost on a hot partitioned table. The CHECK-constraint trick (`ADD CONSTRAINT … NOT VALID` + `VALIDATE CONSTRAINT`) avoids the exclusive lock but still pays the full scan cost under `SHARE UPDATE EXCLUSIVE`. In practice every writer always supplies `sync_job_id`, and the 48h partition rotation means any accidental NULL would age out within two days — so we accept the relaxed schema. If we later want the guarantee back, it can be added safely via the CHECK dance outside any swap window.

## Test plan

- [x] Local: ran 2a → 2b → 2c in sequence → old `sync_job_id (int4)` dropped, new `sync_job_id (bigint, nullable)` in place; trigger and function gone; parent index renamed to canonical; today's partition and a manually-created tomorrow partition both have their child indexes attached to the canonical parent on the new column.
- [x] Local: confirmed the swap migration is purely metadata DDL (no scans, no `SET NOT NULL`) — `ACCESS EXCLUSIVE` window measured in microseconds.
- [ ] Staging: deploy ≥48h after Phase 2a is in staging; verify `\d nango_records.records_seen` shows `sync_job_id bigint` and the trigger is gone.
- [ ] Production: deploy ≥48h after Phase 2a is in production.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
