### PR TITLE
fix(webapp): update enterprise contact link to /demo

### DIFF
--- a/packages/webapp/src/pages/Team/Billing/components/Plans.tsx
+++ b/packages/webapp/src/pages/Team/Billing/components/Plans.tsx
@@ -197,7 +197,7 @@ const PlanRow: React.FC<{ planDefinition: PlanDefinitionList; activePlan?: PlanD
         }
 
         return (
-            <ButtonLink variant="secondary" className="w-27" to="https://nango.dev/support" target="_blank">
+            <ButtonLink variant="secondary" className="w-27" to="https://nango.dev/demo" target="_blank">
                 Contact us
             </ButtonLink>
         );


### PR DESCRIPTION
## Problem

The "Contact us" button on the enterprise plan card in billing & usage pointed to `https://nango.dev/support`, which returns a 404.

## Solution

Updated the link to `https://nango.dev/demo`.

Fixes [NAN-5798](https://linear.app/nango/issue/NAN-5798)

## Testing

- Verified the URL change in `Plans.tsx`
