### PR TITLE
feat(scheduler): add at() for one-shot deferred tasks

### DIFF
--- a/packages/scheduler/lib/scheduler.integration.test.ts
+++ b/packages/scheduler/lib/scheduler.integration.test.ts
@@ -259,6 +259,27 @@ describe('Scheduler', () => {
         expect(found[0]?.id).toBe(schedule.id);
     });
 
+    describe('delayed', () => {
+        it('should create a task in CREATED state with the given startsAfter', async () => {
+            const startsAfter = new Date(Date.now() + 60_000);
+            const task = await delayed(scheduler, { startsAfter });
+            expect(task.state).toBe('CREATED');
+            expect(task.startsAfter).toBeWithinMs(startsAfter, 1_000);
+        });
+        it('should not be dequeue-able before startsAfter', async () => {
+            const task = await delayed(scheduler, { startsAfter: new Date(Date.now() + 60_000) });
+            const dequeued = (await scheduler.dequeue({ groupKeyPattern: task.groupKey, limit: 1 })).unwrap();
+            expect(dequeued.length).toBe(0);
+        });
+        it('should become dequeue-able once startsAfter has passed', async () => {
+            const delayMs = 1_000;
+            const task = await delayed(scheduler, { startsAfter: new Date(Date.now() + delayMs) });
+            expect((await scheduler.dequeue({ groupKeyPattern: task.groupKey, limit: 1 })).unwrap().length).toBe(0);
+            await new Promise((resolve) => setTimeout(resolve, delayMs + 300));
+            expect((await scheduler.dequeue({ groupKeyPattern: task.groupKey, limit: 1 })).unwrap().length).toBe(1);
+        });
+    });
+
     describe('immediateBatch', () => {
         it('should create a batch of tasks', async () => {
             const groupKey = nanoid();
@@ -340,6 +361,28 @@ function batchProps(overrides: Partial<TaskProps> = {}): Parameters<Scheduler['i
         ownerKey: overrides.ownerKey ?? null,
         retryKey: overrides.retryKey ?? null
     };
+}
+
+async function delayed(
+    scheduler: Scheduler,
+    { startsAfter, taskProps }: { startsAfter: Date; taskProps?: Partial<Omit<TaskProps, 'startsAfter' | 'scheduleId'>> }
+): Promise<Task> {
+    return (
+        await scheduler.delayed({
+            name: taskProps?.name || nanoid(),
+            payload: taskProps?.payload || {},
+            groupKey: taskProps?.groupKey || nanoid(),
+            groupMaxConcurrency: taskProps?.groupMaxConcurrency || 0,
+            retryMax: taskProps?.retryMax ?? 1,
+            retryCount: taskProps?.retryCount || 0,
+            createdToStartedTimeoutSecs: taskProps?.createdToStartedTimeoutSecs || 3600,
+            startedToCompletedTimeoutSecs: taskProps?.startedToCompletedTimeoutSecs || 3600,
+            heartbeatTimeoutSecs: taskProps?.heartbeatTimeoutSecs || 600,
+            ownerKey: taskProps?.ownerKey || null,
+            retryKey: taskProps?.retryKey || null,
+            startsAfter
+        })
+    ).unwrap();
 }
 
 async function recurring({ scheduler, state = 'PAUSED' }: { scheduler: Scheduler; state?: ScheduleState }): Promise<Schedule> {

--- a/packages/scheduler/lib/scheduler.integration.test.ts
+++ b/packages/scheduler/lib/scheduler.integration.test.ts
@@ -259,21 +259,21 @@ describe('Scheduler', () => {
         expect(found[0]?.id).toBe(schedule.id);
     });
 
-    describe('delayed', () => {
+    describe('at', () => {
         it('should create a task in CREATED state with the given startsAfter', async () => {
             const startsAfter = new Date(Date.now() + 60_000);
-            const task = await delayed(scheduler, { startsAfter });
+            const task = await at(scheduler, { startsAfter });
             expect(task.state).toBe('CREATED');
             expect(task.startsAfter).toBeWithinMs(startsAfter, 1_000);
         });
         it('should not be dequeue-able before startsAfter', async () => {
-            const task = await delayed(scheduler, { startsAfter: new Date(Date.now() + 60_000) });
+            const task = await at(scheduler, { startsAfter: new Date(Date.now() + 60_000) });
             const dequeued = (await scheduler.dequeue({ groupKeyPattern: task.groupKey, limit: 1 })).unwrap();
             expect(dequeued.length).toBe(0);
         });
         it('should become dequeue-able once startsAfter has passed', async () => {
             const delayMs = 1_000;
-            const task = await delayed(scheduler, { startsAfter: new Date(Date.now() + delayMs) });
+            const task = await at(scheduler, { startsAfter: new Date(Date.now() + delayMs) });
             expect((await scheduler.dequeue({ groupKeyPattern: task.groupKey, limit: 1 })).unwrap().length).toBe(0);
             await new Promise((resolve) => setTimeout(resolve, delayMs + 300));
             expect((await scheduler.dequeue({ groupKeyPattern: task.groupKey, limit: 1 })).unwrap().length).toBe(1);
@@ -363,12 +363,12 @@ function batchProps(overrides: Partial<TaskProps> = {}): Parameters<Scheduler['i
     };
 }
 
-async function delayed(
+async function at(
     scheduler: Scheduler,
     { startsAfter, taskProps }: { startsAfter: Date; taskProps?: Partial<Omit<TaskProps, 'startsAfter' | 'scheduleId'>> }
 ): Promise<Task> {
     return (
-        await scheduler.delayed({
+        await scheduler.at({
             name: taskProps?.name || nanoid(),
             payload: taskProps?.payload || {},
             groupKey: taskProps?.groupKey || nanoid(),

--- a/packages/scheduler/lib/scheduler.ts
+++ b/packages/scheduler/lib/scheduler.ts
@@ -11,7 +11,7 @@ import * as tasks from './models/tasks.js';
 import { logger, setLogger } from './utils/logger.js';
 
 import type { SchedulerConfig, SchedulerEvent } from './config.js';
-import type { FromScheduleProps, ImmediateProps, Schedule, ScheduleProps, ScheduleState, Task, TaskState } from './types.js';
+import type { DelayedProps, FromScheduleProps, ImmediateProps, Schedule, ScheduleProps, ScheduleState, Task, TaskState } from './types.js';
 import type { Result, StrictLogger } from '@nangohq/utils';
 import type knex from 'knex';
 import type { JsonObject, JsonValue } from 'type-fest';
@@ -268,6 +268,44 @@ export class Scheduler {
                 if (scheduleRes.isErr()) {
                     return Err(`Error updating last scheduled task for schedule '${task.scheduleId}': ${stringifyError(scheduleRes.error)}`);
                 }
+            }
+            this.onCallbacks[task.state](task);
+            return Ok(task);
+        });
+        for (const [groupKey, count] of cappedCounts) {
+            this.onEvent({ type: 'task_dropped', groupKey, count, reason: 'task_cap' });
+        }
+        return result;
+    }
+
+    /**
+     * Schedule a one-shot task that only becomes dequeue-able at/after `startsAfter`.
+     *
+     * Unlike `immediate`, the task waits until `startsAfter` before it can be dequeued. The
+     * created→started timeout is measured from `startsAfter`, so long delays don't cause the task
+     * to expire while waiting. Use this for deferred work (e.g. "run in 30 days").
+     * @example
+     * const scheduled = await scheduler.delayed({ ...props, startsAfter: addDays(new Date(), 30) });
+     */
+    public async delayed(props: DelayedProps): Promise<Result<Task>> {
+        const cappedCounts = new Map<string, number>();
+        const result = await this.db.transaction<Result<Task>>(async (trx) => {
+            const taskProps: tasks.TaskProps = {
+                ...props,
+                scheduleId: null
+            };
+            const createResult = await tasks.create(trx, [taskProps], { groupTaskCap: this.config.limits.groupTaskCap });
+            if (createResult.isErr()) {
+                return Err(createResult.error);
+            }
+            for (const d of createResult.value.discarded) {
+                if (d.reason === 'capped') {
+                    cappedCounts.set(d.props.groupKey, (cappedCounts.get(d.props.groupKey) ?? 0) + 1);
+                }
+            }
+            const task = createResult.value.created[0];
+            if (!task) {
+                return Err(`Failed to create task '${taskProps.name}'`);
             }
             this.onCallbacks[task.state](task);
             return Ok(task);

--- a/packages/scheduler/lib/scheduler.ts
+++ b/packages/scheduler/lib/scheduler.ts
@@ -11,7 +11,7 @@ import * as tasks from './models/tasks.js';
 import { logger, setLogger } from './utils/logger.js';
 
 import type { SchedulerConfig, SchedulerEvent } from './config.js';
-import type { DelayedProps, FromScheduleProps, ImmediateProps, Schedule, ScheduleProps, ScheduleState, Task, TaskState } from './types.js';
+import type { AtProps, FromScheduleProps, ImmediateProps, Schedule, ScheduleProps, ScheduleState, Task, TaskState } from './types.js';
 import type { Result, StrictLogger } from '@nangohq/utils';
 import type knex from 'knex';
 import type { JsonObject, JsonValue } from 'type-fest';
@@ -202,80 +202,46 @@ export class Scheduler {
      * const scheduled = await scheduler.immediate(schedulingProps);
      */
     public async immediate(props: ImmediateProps | FromScheduleProps): Promise<Result<Task>> {
-        const cappedCounts = new Map<string, number>();
-        const result = await this.db.transaction<Result<Task>>(async (trx) => {
-            const now = new Date();
-            let taskProps: tasks.TaskProps;
-            if ('scheduleName' in props) {
-                // forUpdate = true so that the schedule is locked to prevent any concurrent update or concurrent scheduling of tasks
-                const getSchedules = await schedules.search(trx, { names: [props.scheduleName], limit: 1, forUpdate: true });
-                if (getSchedules.isErr()) {
-                    return Err(getSchedules.error);
-                }
-                const schedule = getSchedules.value[0];
-                if (!schedule) {
-                    return Err(new Error(`Schedule '${props.scheduleName}' not found`));
-                }
-                // Not scheduling a task if another task for the same schedule is already running
-                const running = await tasks.search(trx, {
-                    scheduleId: schedule.id,
-                    states: ['CREATED', 'STARTED']
-                });
-                if (running.isErr()) {
-                    return Err(running.error);
-                }
-                if (running.value.length > 0) {
-                    // TODO: identify this error so we can return something else than a 500
-                    return Err(new Error(`Task for schedule '${props.scheduleName}' is already running: ${running.value[0]?.id}`));
-                }
-                taskProps = {
-                    name: `${schedule.name}:${uuidv7()}`,
-                    payload: { ...schedule.payload, ...props.extra },
-                    groupKey: schedule.groupKey,
-                    groupMaxConcurrency: 0,
-                    retryMax: schedule.retryMax,
-                    retryCount: 0,
-                    createdToStartedTimeoutSecs: schedule.createdToStartedTimeoutSecs,
-                    startedToCompletedTimeoutSecs: schedule.startedToCompletedTimeoutSecs,
-                    heartbeatTimeoutSecs: schedule.heartbeatTimeoutSecs,
-                    startsAfter: now,
-                    scheduleId: schedule.id,
-                    ownerKey: null
-                };
-            } else {
-                taskProps = {
-                    ...props,
-                    startsAfter: now,
-                    scheduleId: null
-                };
-            }
-
-            const createResult = await tasks.create(trx, [taskProps], { groupTaskCap: this.config.limits.groupTaskCap });
-            if (createResult.isErr()) {
-                return Err(createResult.error);
-            }
-            for (const d of createResult.value.discarded) {
-                if (d.reason === 'capped') {
-                    cappedCounts.set(d.props.groupKey, (cappedCounts.get(d.props.groupKey) ?? 0) + 1);
-                }
-            }
-            const task = createResult.value.created[0];
-            if (!task) {
-                return Err(`Failed to create task '${taskProps.name}'`);
-            }
-            if (task.scheduleId) {
-                const scheduleRes = await schedules.setLastScheduledTask(trx, [{ id: task.scheduleId, taskId: task.id, taskState: task.state }]);
-                if (scheduleRes.isErr()) {
-                    return Err(`Error updating last scheduled task for schedule '${task.scheduleId}': ${stringifyError(scheduleRes.error)}`);
-                }
-            }
-            this.onCallbacks[task.state](task);
-            return Ok(task);
-        });
-        for (const [groupKey, count] of cappedCounts) {
-            this.onEvent({ type: 'task_dropped', groupKey, count, reason: 'task_cap' });
+        if (!('scheduleName' in props)) {
+            return this.at({ ...props, startsAfter: new Date() });
         }
-        return result;
+        return this.db.transaction<Result<Task>>(async (trx) => {
+            // forUpdate = true so that the schedule is locked to prevent any concurrent update or concurrent scheduling of tasks
+            const getSchedules = await schedules.search(trx, { names: [props.scheduleName], limit: 1, forUpdate: true });
+            if (getSchedules.isErr()) {
+                return Err(getSchedules.error);
+            }
+            const schedule = getSchedules.value[0];
+            if (!schedule) {
+                return Err(new Error(`Schedule '${props.scheduleName}' not found`));
+            }
+            // Not scheduling a task if another task for the same schedule is already running
+            const running = await tasks.search(trx, {
+                scheduleId: schedule.id,
+                states: ['CREATED', 'STARTED']
+            });
+            if (running.isErr()) {
+                return Err(running.error);
+            }
+            if (running.value.length > 0) {
+                // TODO: identify this error so we can return something else than a 500
+                return Err(new Error(`Task for schedule '${props.scheduleName}' is already running: ${running.value[0]?.id}`));
+            }
+            return this.insertTask(trx, {
+                name: `${schedule.name}:${uuidv7()}`,
+                payload: { ...schedule.payload, ...props.extra },
+                groupKey: schedule.groupKey,
+                groupMaxConcurrency: 0,
+                retryMax: schedule.retryMax,
+                retryCount: 0,
+                createdToStartedTimeoutSecs: schedule.createdToStartedTimeoutSecs,
+                startedToCompletedTimeoutSecs: schedule.startedToCompletedTimeoutSecs,
+                heartbeatTimeoutSecs: schedule.heartbeatTimeoutSecs,
+                startsAfter: new Date(),
+                scheduleId: schedule.id,
+                ownerKey: null
+            });
+        });
     }
 
     /**
@@ -285,35 +251,38 @@ export class Scheduler {
      * created→started timeout is measured from `startsAfter`, so long delays don't cause the task
      * to expire while waiting. Use this for deferred work (e.g. "run in 30 days").
      * @example
-     * const scheduled = await scheduler.delayed({ ...props, startsAfter: addDays(new Date(), 30) });
+     * const scheduled = await scheduler.at({ ...props, startsAfter: addDays(new Date(), 30) });
      */
-    public async delayed(props: DelayedProps): Promise<Result<Task>> {
-        const cappedCounts = new Map<string, number>();
-        const result = await this.db.transaction<Result<Task>>(async (trx) => {
-            const taskProps: tasks.TaskProps = {
-                ...props,
-                scheduleId: null
-            };
-            const createResult = await tasks.create(trx, [taskProps], { groupTaskCap: this.config.limits.groupTaskCap });
-            if (createResult.isErr()) {
-                return Err(createResult.error);
-            }
+    public async at(props: AtProps): Promise<Result<Task>> {
+        return this.db.transaction<Result<Task>>((trx) => this.insertTask(trx, { ...props, scheduleId: null }));
+    }
+
+    /**
+     * Create a single task within the given transaction and fire its state callback. A capped task
+     * is never created, so it surfaces as an Err and a `task_dropped` event rather than a returned task.
+     */
+    private async insertTask(trx: knex.Knex, taskProps: tasks.TaskProps): Promise<Result<Task>> {
+        const createResult = await tasks.create(trx, [taskProps], { groupTaskCap: this.config.limits.groupTaskCap });
+        if (createResult.isErr()) {
+            return Err(createResult.error);
+        }
+        const task = createResult.value.created[0];
+        if (!task) {
             for (const d of createResult.value.discarded) {
                 if (d.reason === 'capped') {
-                    cappedCounts.set(d.props.groupKey, (cappedCounts.get(d.props.groupKey) ?? 0) + 1);
+                    this.onEvent({ type: 'task_dropped', groupKey: d.props.groupKey, count: 1, reason: 'task_cap' });
                 }
             }
-            const task = createResult.value.created[0];
-            if (!task) {
-                return Err(`Failed to create task '${taskProps.name}'`);
-            }
-            this.onCallbacks[task.state](task);
-            return Ok(task);
-        });
-        for (const [groupKey, count] of cappedCounts) {
-            this.onEvent({ type: 'task_dropped', groupKey, count, reason: 'task_cap' });
+            return Err(`Failed to create task '${taskProps.name}'`);
         }
-        return result;
+        if (task.scheduleId) {
+            const scheduleRes = await schedules.setLastScheduledTask(trx, [{ id: task.scheduleId, taskId: task.id, taskState: task.state }]);
+            if (scheduleRes.isErr()) {
+                return Err(`Error updating last scheduled task for schedule '${task.scheduleId}': ${stringifyError(scheduleRes.error)}`);
+            }
+        }
+        this.onCallbacks[task.state](task);
+        return Ok(task);
     }
 
     /**

--- a/packages/scheduler/lib/scheduler.ts
+++ b/packages/scheduler/lib/scheduler.ts
@@ -205,7 +205,8 @@ export class Scheduler {
         if (!('scheduleName' in props)) {
             return this.at({ ...props, startsAfter: new Date() });
         }
-        return this.db.transaction<Result<Task>>(async (trx) => {
+        const events: SchedulerEvent[] = [];
+        const result = await this.db.transaction<Result<Task>>(async (trx) => {
             // forUpdate = true so that the schedule is locked to prevent any concurrent update or concurrent scheduling of tasks
             const getSchedules = await schedules.search(trx, { names: [props.scheduleName], limit: 1, forUpdate: true });
             if (getSchedules.isErr()) {
@@ -227,7 +228,7 @@ export class Scheduler {
                 // TODO: identify this error so we can return something else than a 500
                 return Err(new Error(`Task for schedule '${props.scheduleName}' is already running: ${running.value[0]?.id}`));
             }
-            return this.insertTask(trx, {
+            const inserted = await this.insertTask(trx, {
                 name: `${schedule.name}:${uuidv7()}`,
                 payload: { ...schedule.payload, ...props.extra },
                 groupKey: schedule.groupKey,
@@ -241,7 +242,11 @@ export class Scheduler {
                 scheduleId: schedule.id,
                 ownerKey: null
             });
+            events.push(...inserted.events);
+            return inserted.result;
         });
+        events.forEach((event) => this.onEvent(event));
+        return result;
     }
 
     /**
@@ -254,35 +259,40 @@ export class Scheduler {
      * const scheduled = await scheduler.at({ ...props, startsAfter: addDays(new Date(), 30) });
      */
     public async at(props: AtProps): Promise<Result<Task>> {
-        return this.db.transaction<Result<Task>>((trx) => this.insertTask(trx, { ...props, scheduleId: null }));
+        const { result, events } = await this.db.transaction((trx) => this.insertTask(trx, { ...props, scheduleId: null }));
+        events.forEach((event) => this.onEvent(event));
+        return result;
     }
 
     /**
      * Create a single task within the given transaction and fire its state callback. A capped task
      * is never created, so it surfaces as an Err and a `task_dropped` event rather than a returned task.
+     * Events are returned (not emitted) so the caller can emit them only after the transaction
+     * commits, never for work that ends up rolled back.
      */
-    private async insertTask(trx: knex.Knex, taskProps: tasks.TaskProps): Promise<Result<Task>> {
+    private async insertTask(trx: knex.Knex, taskProps: tasks.TaskProps): Promise<{ result: Result<Task>; events: SchedulerEvent[] }> {
         const createResult = await tasks.create(trx, [taskProps], { groupTaskCap: this.config.limits.groupTaskCap });
         if (createResult.isErr()) {
-            return Err(createResult.error);
+            return { result: Err(createResult.error), events: [] };
         }
         const task = createResult.value.created[0];
         if (!task) {
-            for (const d of createResult.value.discarded) {
-                if (d.reason === 'capped') {
-                    this.onEvent({ type: 'task_dropped', groupKey: d.props.groupKey, count: 1, reason: 'task_cap' });
-                }
-            }
-            return Err(`Failed to create task '${taskProps.name}'`);
+            const events = createResult.value.discarded
+                .filter((d) => d.reason === 'capped')
+                .map((d): SchedulerEvent => ({ type: 'task_dropped', groupKey: d.props.groupKey, count: 1, reason: 'task_cap' }));
+            return { result: Err(`Failed to create task '${taskProps.name}'`), events };
         }
         if (task.scheduleId) {
             const scheduleRes = await schedules.setLastScheduledTask(trx, [{ id: task.scheduleId, taskId: task.id, taskState: task.state }]);
             if (scheduleRes.isErr()) {
-                return Err(`Error updating last scheduled task for schedule '${task.scheduleId}': ${stringifyError(scheduleRes.error)}`);
+                return {
+                    result: Err(`Error updating last scheduled task for schedule '${task.scheduleId}': ${stringifyError(scheduleRes.error)}`),
+                    events: []
+                };
             }
         }
         this.onCallbacks[task.state](task);
-        return Ok(task);
+        return { result: Ok(task), events: [] };
     }
 
     /**

--- a/packages/scheduler/lib/types.ts
+++ b/packages/scheduler/lib/types.ts
@@ -30,6 +30,8 @@ export interface Task {
 }
 
 export type ImmediateProps = SetOptional<Omit<TaskProps, 'startsAfter' | 'scheduleId'>, 'retryKey'>;
+/** Like ImmediateProps but the task only becomes dequeue-able at/after `startsAfter`. */
+export type DelayedProps = ImmediateProps & { startsAfter: Date };
 export interface FromScheduleProps {
     scheduleName: string;
     extra: JsonObject;

--- a/packages/scheduler/lib/types.ts
+++ b/packages/scheduler/lib/types.ts
@@ -29,9 +29,9 @@ export interface Task {
     readonly ownerKey: string | null;
 }
 
-export type ImmediateProps = SetOptional<Omit<TaskProps, 'startsAfter' | 'scheduleId'>, 'retryKey'>;
-/** Like ImmediateProps but the task only becomes dequeue-able at/after `startsAfter`. */
-export type DelayedProps = ImmediateProps & { startsAfter: Date };
+export type AtProps = SetOptional<Omit<TaskProps, 'scheduleId'>, 'retryKey'>;
+/** Like AtProps but starts immediately (no `startsAfter`). */
+export type ImmediateProps = Omit<AtProps, 'startsAfter'>;
 export interface FromScheduleProps {
     scheduleName: string;
     extra: JsonObject;


### PR DESCRIPTION
Basically a mirror of `immediate`, except it sets the `startsAfter` to the chosen time. It makes it dequeue-able only at that time. Eg:
```ts
await scheduler.at({ ...props, startsAfter: addDays(new Date(), 30) });
```