### PR TITLE
docs: add non-technical links to llms.txt

### DIFF
--- a/docs/llms-full.txt
+++ b/docs/llms-full.txt
@@ -14504,3 +14504,10 @@ Use these slugs to construct provider-specific docs URLs only when needed.
 | `zorus` | Zorus | API_KEY | [docs](https://nango.dev/docs/api-integrations/zorus.md) | [connect](https://nango.dev/docs/api-integrations/zorus/connect.md) |  | other |
 | `zuora` | Zuora | OAUTH2_CC | [docs](https://nango.dev/docs/integrations/all/zuora.md) | [connect](https://nango.dev/docs/integrations/all/zuora/connect.md) |  | erp |
 
+## Resources
+
+- [Blog](https://nango.dev/blog): Articles, product updates, and integration deep-dives from the Nango team.
+- [Pricing](https://nango.dev/pricing): Plans and pricing for Nango Cloud.
+- [Talk to the team](https://nango.dev/demo): Book a call with Nango for sales, onboarding, or technical questions.
+- [Community Slack](https://nango.dev/slack): Get help, share feedback, and connect with other Nango developers.
+

--- a/docs/llms.txt
+++ b/docs/llms.txt
@@ -137,6 +137,13 @@ Use provider URLs by replacing `{slug}` with a slug from the API catalog:
 - [API catalog](https://nango.dev/docs/api-catalog.txt): 835 provider slugs with canonical docs routes, auth modes, setup guides, and connect guides.
 - Provider-specific pages are intentionally not expanded here so core Nango guides remain easy for agents to find.
 
+## Resources
+
+- [Blog](https://nango.dev/blog): Articles, product updates, and integration deep-dives from the Nango team.
+- [Pricing](https://nango.dev/pricing): Plans and pricing for Nango Cloud.
+- [Talk to the team](https://nango.dev/demo): Book a call with Nango for sales, onboarding, or technical questions.
+- [Community Slack](https://nango.dev/slack): Get help, share feedback, and connect with other Nango developers.
+
 ## Optional
 
 - [Changelog](https://nango.dev/docs/updates/changelog.md): Important developer & product updates, including deprecations & breaking changes.

--- a/scripts/docs-generate-llms.ts
+++ b/scripts/docs-generate-llms.ts
@@ -9,6 +9,35 @@ const docsJsonPath = path.join(docsRoot, 'docs.json');
 const providersPath = 'packages/providers/providers.yaml';
 const baseUrl = 'https://nango.dev/docs';
 
+interface ResourceLink {
+    title: string;
+    url: string;
+    description: string;
+}
+
+const resourceLinks: ResourceLink[] = [
+    {
+        title: 'Blog',
+        url: 'https://nango.dev/blog',
+        description: 'Articles, product updates, and integration deep-dives from the Nango team.'
+    },
+    {
+        title: 'Pricing',
+        url: 'https://nango.dev/pricing',
+        description: 'Plans and pricing for Nango Cloud.'
+    },
+    {
+        title: 'Talk to the team',
+        url: 'https://nango.dev/demo',
+        description: 'Book a call with Nango for sales, onboarding, or technical questions.'
+    },
+    {
+        title: 'Community Slack',
+        url: 'https://nango.dev/slack',
+        description: 'Get help, share feedback, and connect with other Nango developers.'
+    }
+];
+
 type NavItem = string | NavGroup;
 
 interface NavGroup {
@@ -145,6 +174,12 @@ async function renderLlmsTxt(documentation: NavGroup, apiOverview: NavGroup, cha
     lines.push('- Provider-specific pages are intentionally not expanded here so core Nango guides remain easy for agents to find.');
     lines.push('');
 
+    lines.push('## Resources', '');
+    for (const link of resourceLinks) {
+        lines.push(`- [${link.title}](${link.url}): ${link.description}`);
+    }
+    lines.push('');
+
     if (changelogRoutes.length > 0) {
         lines.push('## Optional', '');
         for (const route of changelogRoutes) {
@@ -208,6 +243,13 @@ async function renderLlmsFullTxt(routes: string[], catalog: CatalogEntry[]): Pro
     lines.push('Use these slugs to construct provider-specific docs URLs only when needed.');
     lines.push('');
     lines.push(renderCatalogTable(catalog));
+    lines.push('');
+
+    lines.push('## Resources');
+    lines.push('');
+    for (const link of resourceLinks) {
+        lines.push(`- [${link.title}](${link.url}): ${link.description}`);
+    }
     lines.push('');
 
     return `${lines.join('\n').replace(/\n{3,}/g, '\n\n')}\n`;


### PR DESCRIPTION
 Closes CON-87

## Summary
  - Adds a \`Resources\` section to \`llms.txt\` and \`llms-full.txt\` with blog, pricing, demo, and Slack community links
  - Source of truth lives in \`scripts/docs-generate-llms.ts\`; generated files were refreshed via \`npm run docs:generate:llms\`

 ## Test plan
  - [x] \`npm run docs:generate:llms\` runs cleanly
  - [x] \`mintlify broken-links\` from \`docs/\` reports success
  - [x] All 5 new URLs return 200"