### PR TITLE
chore(test): mock fetch in loggedFetch unit tests to eliminate flakiness

### DIFF
--- a/packages/shared/lib/utils/http.unit.test.ts
+++ b/packages/shared/lib/utils/http.unit.test.ts
@@ -1,4 +1,4 @@
-import { describe, expect, it } from 'vitest';
+import { afterEach, describe, expect, it, vi } from 'vitest';
 
 import { logContextGetter } from '@nangohq/logs';
 
@@ -7,7 +7,20 @@ import { loggedFetch } from './http.js';
 import type { BufferTransport } from '@nangohq/logs';
 
 describe('loggedFetch', () => {
+    afterEach(() => {
+        vi.unstubAllGlobals();
+    });
+
     it('should get and log success', async () => {
+        vi.stubGlobal(
+            'fetch',
+            vi
+                .fn()
+                .mockResolvedValue(
+                    new Response(JSON.stringify({ code: 200, description: 'OK' }), { status: 200, headers: { 'content-type': 'application/json' } })
+                )
+        );
+
         const buffer = logContextGetter.getBuffer({ accountId: 1 });
         const fetchRes = await loggedFetch(
             {
@@ -35,6 +48,16 @@ describe('loggedFetch', () => {
     });
 
     it('should get and log failure', async () => {
+        vi.stubGlobal(
+            'fetch',
+            vi.fn().mockResolvedValue(
+                new Response(JSON.stringify({ code: 500, description: 'Internal Server Error' }), {
+                    status: 500,
+                    headers: { 'content-type': 'application/json' }
+                })
+            )
+        );
+
         const buffer = logContextGetter.getBuffer({ accountId: 1 });
         const fetchRes = await loggedFetch(
             {
@@ -65,6 +88,8 @@ describe('loggedFetch', () => {
     });
 
     it('should handle network error', async () => {
+        vi.stubGlobal('fetch', vi.fn().mockRejectedValue(new TypeError('fetch failed', { cause: new Error('getaddrinfo ENOTFOUND doesnotexists.dev') })));
+
         const buffer = logContextGetter.getBuffer({ accountId: 1 });
         const fetchRes = await loggedFetch(
             {


### PR DESCRIPTION
## Problem

[Flaky test run](https://github.com/NangoHQ/nango/actions/runs/26895547741/job/79333418003)

The `loggedFetch > should handle network error` unit test was flaky in CI. It relied on fetching `https://doesnotexists.dev/500` and expecting an immediate DNS failure (`ENOTFOUND`), but in some CI runs the DNS lookup hung until vitest's default 5000ms timeout, causing the test to time out instead.

The other two tests also made real outbound HTTP requests to `httpstatuses.maor.io`, making them fragile if that service is slow or unavailable.

## Solution

Replace all three real network calls with `vi.stubGlobal('fetch', ...)` mocks:
- Success test: mocked 200 JSON response
- Failure test: mocked 500 JSON response
- Network error test: mocked `TypeError` rejection with an `ENOTFOUND` cause

Tests now run in ~5ms and are fully deterministic.

## Testing

- Ran `npx vitest run packages/shared/lib/utils/http.unit.test.ts` locally — all 3 tests pass in 5ms
