### PR TITLE
feat(records): add multi-store routing to RecordsRouter

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -38933,6 +38933,7 @@
             "version": "1.0.0",
             "dependencies": {
                 "@fastify/deepmerge": "2.0.1",
+                "@nangohq/types": "file:../types",
                 "@nangohq/utils": "file:../utils",
                 "dayjs": "1.11.19",
                 "dd-trace": "5.52.0",

--- a/packages/records/lib/catalog/router.ts
+++ b/packages/records/lib/catalog/router.ts
@@ -1,31 +1,110 @@
+import { Ok } from '@nangohq/utils';
+
 import { defaultStore } from './default.js';
 
 import type { RecordsStore } from '../store.js';
+import type { RecordCount } from '../types.js';
+import type { DBPlan } from '@nangohq/types';
 
-export class RecordsRouter implements RecordsStore {
-    private readonly store: RecordsStore;
+// Augments a store method signature with an optional plan parameter for routing purposes.
+type Routed<F> = F extends (params: infer P) => infer R ? (params: P & { plan?: DBPlan }) => R : never;
 
-    constructor(store: RecordsStore) {
-        this.store = store;
-    }
-
-    private resolve(): RecordsStore {
-        return this.store;
-    }
-
-    migrate: RecordsStore['migrate'] = () => this.resolve().migrate();
-    close: RecordsStore['close'] = () => this.resolve().close();
-    startDaemons: RecordsStore['startDaemons'] = () => this.resolve().startDaemons();
-    getRecords: RecordsStore['getRecords'] = (params) => this.resolve().getRecords(params);
-    getCursor: RecordsStore['getCursor'] = (params) => this.resolve().getCursor(params);
-    upsert: RecordsStore['upsert'] = (params) => this.resolve().upsert(params);
-    update: RecordsStore['update'] = (params) => this.resolve().update(params);
-    deleteRecords: RecordsStore['deleteRecords'] = (params) => this.resolve().deleteRecords(params);
-    deleteOutdatedRecords: RecordsStore['deleteOutdatedRecords'] = (params) => this.resolve().deleteOutdatedRecords(params);
-    getCountsByModel: RecordsStore['getCountsByModel'] = (params) => this.resolve().getCountsByModel(params);
-    paginateCounts: RecordsStore['paginateCounts'] = (params) => this.resolve().paginateCounts(params);
-    autoPruningCandidate: RecordsStore['autoPruningCandidate'] = (params) => this.resolve().autoPruningCandidate(params);
-    autoDeletingCandidate: RecordsStore['autoDeletingCandidate'] = (params) => this.resolve().autoDeletingCandidate(params);
+interface RoutingContext {
+    plan?: DBPlan | undefined;
+    connectionId: number;
+    model: string;
 }
 
-export const records = new RecordsRouter(defaultStore);
+export class RecordsRouter<K extends string> implements RecordsStore {
+    private readonly stores: Map<K, RecordsStore>;
+    private readonly routing: Routing<K>;
+
+    constructor({ stores, routing }: { stores: Record<K, RecordsStore>; routing: Routing<K> }) {
+        this.stores = new Map(Object.entries(stores) as [K, RecordsStore][]);
+        this.routing = routing;
+    }
+
+    private resolve(ctx: RoutingContext): RecordsStore {
+        return this.stores.get(this.routing.get(ctx))!;
+    }
+
+    private random(): RecordsStore {
+        return Array.from(this.stores.values())[Math.floor(Math.random() * this.stores.size)]!;
+    }
+
+    // Lifecycle: runs against all stores
+    migrate: RecordsStore['migrate'] = async () => {
+        await Promise.all([...this.stores.values()].map((s) => s.migrate()));
+    };
+    close: RecordsStore['close'] = async () => {
+        await Promise.all([...this.stores.values()].map((s) => s.close()));
+    };
+    startDaemons: RecordsStore['startDaemons'] = () => {
+        for (const store of this.stores.values()) store.startDaemons();
+    };
+
+    // Dataset ops: routed to a specific store
+    getRecords: Routed<RecordsStore['getRecords']> = ({ plan, ...params }) =>
+        this.resolve({ plan, connectionId: params.connectionId, model: params.model }).getRecords(params);
+
+    getCursor: Routed<RecordsStore['getCursor']> = ({ plan, ...params }) =>
+        this.resolve({ plan, connectionId: params.connectionId, model: params.model }).getCursor(params);
+
+    upsert: Routed<RecordsStore['upsert']> = ({ plan, ...params }) =>
+        this.resolve({ plan, connectionId: params.connectionId, model: params.model }).upsert(params);
+
+    update: Routed<RecordsStore['update']> = ({ plan, ...params }) =>
+        this.resolve({ plan, connectionId: params.connectionId, model: params.model }).update(params);
+
+    deleteRecords: Routed<RecordsStore['deleteRecords']> = ({ plan, ...params }) =>
+        this.resolve({ plan, connectionId: params.connectionId, model: params.model }).deleteRecords(params);
+
+    deleteOutdatedRecords: Routed<RecordsStore['deleteOutdatedRecords']> = ({ plan, ...params }) =>
+        this.resolve({ plan, connectionId: params.connectionId, model: params.model }).deleteOutdatedRecords(params);
+
+    // Aggregation ops: fan-out across stores
+    getCountsByModel: RecordsStore['getCountsByModel'] = async (params) => {
+        const results = await Promise.all([...this.stores.values()].map((s) => s.getCountsByModel(params)));
+        const agg: Record<string, RecordCount> = {};
+        for (const result of results) {
+            if (result.isErr()) return result;
+            // Assumes disjoint key spaces across stores
+            // routing must ensure a given records dataset is always assigned to the same store,
+            // so the same model key will never appear in two stores.
+            Object.assign(agg, result.value);
+        }
+        return Ok(agg);
+    };
+    paginateCounts: RecordsStore['paginateCounts'] = (params) => {
+        const stores = this.stores.values();
+        return (async function* () {
+            for (const store of stores) {
+                yield* store.paginateCounts(params);
+            }
+        })();
+    };
+
+    // Candidate ops: pick a random store
+    autoPruningCandidate: RecordsStore['autoPruningCandidate'] = (params) => this.random().autoPruningCandidate(params);
+    autoDeletingCandidate: RecordsStore['autoDeletingCandidate'] = (params) => this.random().autoDeletingCandidate(params);
+}
+
+export class Routing<K extends string> {
+    constructor(private readonly routing: (ctx: RoutingContext) => K) {}
+
+    public get(ctx: RoutingContext): K {
+        return this.routing(ctx);
+    }
+}
+
+// Routing is fixed and deterministic based on the routing context.
+// It must not change across calls for a given context. (ie: Rebalancing and moving data between stores is not supported)
+const routing = new Routing((_ctx: RoutingContext) => {
+    // For now we have a single store, so we can ignore the context and always assign/return the default store
+    // In the future, this can be extended to route based on connectionId, model, plan, account, etc.
+    // and routing decisions can be stored in a database
+    return 'default';
+});
+const stores = { default: defaultStore };
+
+export const records = new RecordsRouter({ stores, routing });

--- a/packages/records/lib/catalog/router.ts
+++ b/packages/records/lib/catalog/router.ts
@@ -34,10 +34,10 @@ export class RecordsRouter<K extends string> implements RecordsStore {
 
     // Lifecycle: runs against all stores
     migrate: RecordsStore['migrate'] = async () => {
-        await Promise.all([...this.stores.values()].map((s) => s.migrate()));
+        await Promise.allSettled([...this.stores.values()].map((s) => s.migrate()));
     };
     close: RecordsStore['close'] = async () => {
-        await Promise.all([...this.stores.values()].map((s) => s.close()));
+        await Promise.allSettled([...this.stores.values()].map((s) => s.close()));
     };
     startDaemons: RecordsStore['startDaemons'] = () => {
         for (const store of this.stores.values()) store.startDaemons();

--- a/packages/records/lib/catalog/router.unit.test.ts
+++ b/packages/records/lib/catalog/router.unit.test.ts
@@ -1,23 +1,194 @@
 import { describe, expect, it, vi } from 'vitest';
 
-import { RecordsRouter } from './router.js';
+import { Err, Ok } from '@nangohq/utils';
+
+import { RecordsRouter, Routing } from './router.js';
 
 import type { RecordsStore } from '../store.js';
+import type { RecordCount } from '../types.js';
+import type { DBPlan } from '@nangohq/types';
+
+type StoreKey = 'a' | 'b';
+
+const plan = { id: 1, account_id: 1 } as unknown as DBPlan;
+const routeToA = new Routing<StoreKey>(() => 'a');
+
+function makeStore(overrides: Partial<RecordsStore> = {}): RecordsStore {
+    return overrides as unknown as RecordsStore;
+}
 
 describe('RecordsRouter', () => {
-    it('dispatches upsert and getRecords to the same store', async () => {
-        const upsert = vi.fn().mockResolvedValue({
-            ok: true,
-            value: { addedKeys: ['1'], updatedKeys: [], unchangedKeys: [], nonUniqueKeys: [], activatedKeys: [], nextMerging: { strategy: 'override' } }
+    describe('lifecycle ops', () => {
+        it('migrate calls every store', async () => {
+            const migrateA = vi.fn().mockResolvedValue(undefined);
+            const migrateB = vi.fn().mockResolvedValue(undefined);
+            const router = new RecordsRouter<StoreKey>({
+                stores: { a: makeStore({ migrate: migrateA }), b: makeStore({ migrate: migrateB }) },
+                routing: routeToA
+            });
+
+            await router.migrate();
+
+            expect(migrateA).toHaveBeenCalledOnce();
+            expect(migrateB).toHaveBeenCalledOnce();
         });
-        const getRecords = vi.fn().mockResolvedValue({ ok: true, value: { records: [], next_cursor: null } });
-        const store = { upsert, getRecords } as unknown as RecordsStore;
-        const router = new RecordsRouter(store);
 
-        await router.upsert({ records: [], connectionId: 1, environmentId: 1, model: 'foo' });
-        await router.getRecords({ connectionId: 1, model: 'foo' });
+        it('close calls every store', async () => {
+            const closeA = vi.fn().mockResolvedValue(undefined);
+            const closeB = vi.fn().mockResolvedValue(undefined);
+            const router = new RecordsRouter<StoreKey>({
+                stores: { a: makeStore({ close: closeA }), b: makeStore({ close: closeB }) },
+                routing: routeToA
+            });
 
-        expect(upsert).toHaveBeenCalledOnce();
-        expect(getRecords).toHaveBeenCalledOnce();
+            await router.close();
+
+            expect(closeA).toHaveBeenCalledOnce();
+            expect(closeB).toHaveBeenCalledOnce();
+        });
+
+        it('startDaemons calls every store', () => {
+            const startDaemonsA = vi.fn();
+            const startDaemonsB = vi.fn();
+            const router = new RecordsRouter<StoreKey>({
+                stores: { a: makeStore({ startDaemons: startDaemonsA }), b: makeStore({ startDaemons: startDaemonsB }) },
+                routing: routeToA
+            });
+
+            router.startDaemons();
+
+            expect(startDaemonsA).toHaveBeenCalledOnce();
+            expect(startDaemonsB).toHaveBeenCalledOnce();
+        });
+    });
+
+    describe('dataset ops', () => {
+        it('routing dispatches to different stores based on context', async () => {
+            const upsertA = vi
+                .fn()
+                .mockResolvedValue(
+                    Ok({ addedKeys: [], updatedKeys: [], unchangedKeys: [], nonUniqueKeys: [], activatedKeys: [], nextMerging: { strategy: 'override' } })
+                );
+            const upsertB = vi
+                .fn()
+                .mockResolvedValue(
+                    Ok({ addedKeys: [], updatedKeys: [], unchangedKeys: [], nonUniqueKeys: [], activatedKeys: [], nextMerging: { strategy: 'override' } })
+                );
+            const routing = new Routing<StoreKey>((ctx) => (ctx.connectionId === 1 ? 'a' : 'b'));
+            const router = new RecordsRouter<StoreKey>({
+                stores: { a: makeStore({ upsert: upsertA }), b: makeStore({ upsert: upsertB }) },
+                routing
+            });
+
+            await router.upsert({ plan, records: [], connectionId: 1, environmentId: 1, model: 'foo' });
+            expect(upsertA).toHaveBeenCalledOnce();
+            expect(upsertB).not.toHaveBeenCalled();
+
+            // reset mocks before next call
+            upsertA.mockClear();
+            upsertB.mockClear();
+
+            await router.upsert({ plan, records: [], connectionId: 2, environmentId: 1, model: 'foo' });
+            expect(upsertA).not.toHaveBeenCalled();
+            expect(upsertB).toHaveBeenCalledOnce();
+        });
+    });
+
+    describe('aggregation ops', () => {
+        const makeCount = (model: string): RecordCount => {
+            return { model, connection_id: 1, environment_id: 1, count: 1, size_bytes: 0, updated_at: '2024-01-01', autodelete_checked_at: null };
+        };
+        it('getCountsByModel merges results from all stores', async () => {
+            const countA = makeCount('contact');
+            const countB = makeCount('deal');
+            const router = new RecordsRouter<StoreKey>({
+                stores: {
+                    a: makeStore({ getCountsByModel: vi.fn().mockResolvedValue(Ok({ contact: countA })) }),
+                    b: makeStore({ getCountsByModel: vi.fn().mockResolvedValue(Ok({ deal: countB })) })
+                },
+                routing: routeToA
+            });
+
+            const result = await router.getCountsByModel({ connectionId: 1, environmentId: 1 });
+
+            expect(result.isErr()).toBe(false);
+            expect(result.unwrap()).toEqual({ contact: countA, deal: countB });
+        });
+
+        it('getCountsByModel returns error if any store fails', async () => {
+            const error = new Error('store failure');
+            const router = new RecordsRouter<StoreKey>({
+                stores: {
+                    a: makeStore({ getCountsByModel: vi.fn().mockResolvedValue(Err(error)) }),
+                    b: makeStore({ getCountsByModel: vi.fn().mockResolvedValue(Ok({ deal: makeCount('deal') })) })
+                },
+                routing: routeToA
+            });
+
+            const result = await router.getCountsByModel({ connectionId: 1, environmentId: 1 });
+
+            expect(result.isErr()).toBe(true);
+        });
+
+        it('paginateCounts yields from all stores in sequence', async () => {
+            const batchA: RecordCount[] = [makeCount('contact')];
+            const batchB: RecordCount[] = [makeCount('deal')];
+
+            const router = new RecordsRouter<StoreKey>({
+                stores: {
+                    a: makeStore({
+                        paginateCounts: () =>
+                            // eslint-disable-next-line @typescript-eslint/require-await
+                            (async function* () {
+                                yield Ok(batchA);
+                            })()
+                    }),
+                    b: makeStore({
+                        paginateCounts: () =>
+                            // eslint-disable-next-line @typescript-eslint/require-await
+                            (async function* () {
+                                yield Ok(batchB);
+                            })()
+                    })
+                },
+                routing: routeToA
+            });
+
+            const batches: RecordCount[][] = [];
+            for await (const result of router.paginateCounts()) {
+                expect(result.isErr()).toBe(false);
+                batches.push(result.unwrap());
+            }
+
+            expect(batches).toEqual([batchA, batchB]);
+        });
+    });
+
+    describe('candidate ops', () => {
+        it('autoPruningCandidate calls exactly one store', async () => {
+            const candidateA = vi.fn().mockResolvedValue(Ok(null));
+            const candidateB = vi.fn().mockResolvedValue(Ok(null));
+            const router = new RecordsRouter<StoreKey>({
+                stores: { a: makeStore({ autoPruningCandidate: candidateA }), b: makeStore({ autoPruningCandidate: candidateB }) },
+                routing: routeToA
+            });
+
+            await router.autoPruningCandidate({ staleAfterMs: 1000 });
+
+            expect(candidateA.mock.calls.length + candidateB.mock.calls.length).toBe(1);
+        });
+
+        it('autoDeletingCandidate calls exactly one store', async () => {
+            const candidateA = vi.fn().mockResolvedValue(Ok(null));
+            const candidateB = vi.fn().mockResolvedValue(Ok(null));
+            const router = new RecordsRouter<StoreKey>({
+                stores: { a: makeStore({ autoDeletingCandidate: candidateA }), b: makeStore({ autoDeletingCandidate: candidateB }) },
+                routing: routeToA
+            });
+
+            await router.autoDeletingCandidate({ staleAfterMs: 1000 });
+
+            expect(candidateA.mock.calls.length + candidateB.mock.calls.length).toBe(1);
+        });
     });
 });

--- a/packages/records/lib/store.ts
+++ b/packages/records/lib/store.ts
@@ -3,10 +3,12 @@ import type { CursorOffset, MergingStrategy } from '@nangohq/types';
 import type { Result } from '@nangohq/utils';
 
 export interface RecordsStore {
+    // Lifecycle operations
     migrate: () => Promise<void>;
     close: () => Promise<void>;
     startDaemons: () => void;
 
+    // Dataset operations
     getRecords: ({
         connectionId,
         model,
@@ -91,10 +93,12 @@ export interface RecordsStore {
         batchSize?: number;
     }) => Promise<Result<string[]>>;
 
+    // Aggregation operations
     getCountsByModel: ({ connectionId, environmentId }: { connectionId: number; environmentId: number }) => Promise<Result<Record<string, RecordCount>>>;
 
     paginateCounts: (params?: { connectionIds?: number[]; environmentIds?: number[]; batchSize?: number }) => AsyncGenerator<Result<RecordCount[]>>;
 
+    // Pruning operations
     autoPruningCandidate: ({ staleAfterMs }: { staleAfterMs: number }) => Promise<
         Result<{
             partition: number;

--- a/packages/records/package.json
+++ b/packages/records/package.json
@@ -18,6 +18,7 @@
     },
     "dependencies": {
         "@fastify/deepmerge": "2.0.1",
+        "@nangohq/types": "file:../types",
         "@nangohq/utils": "file:../utils",
         "dayjs": "1.11.19",
         "dd-trace": "5.52.0",


### PR DESCRIPTION
Add multi-store routing to `records` package. Routing strategy is still static, routing to only existing store.
The commit also add scaffolding and routing context so we can extend the routing strategy later based on plan, account, etc...