### PR TITLE
ci: automate Slack deploy notifications to #deploys

### DIFF
--- a/.github/actions/slack-deploy-notification/action.yml
+++ b/.github/actions/slack-deploy-notification/action.yml
@@ -1,0 +1,96 @@
+name: 'Slack deploy notification'
+description: 'Post a deploy status message to Slack, or update one in place when the deploy finishes.'
+
+inputs:
+    bot_token:
+        description: 'Slack bot token (xoxb-...) with the chat:write scope'
+        required: true
+    channel:
+        description: 'Slack channel ID to post to'
+        required: true
+    service:
+        description: 'Service being deployed'
+        required: true
+    stage:
+        description: 'Stage being deployed to'
+        required: true
+    phase:
+        description: '"start" to post the initial message, "result" to update it'
+        required: true
+    ts:
+        description: 'Timestamp of the message to update (result phase only)'
+        required: false
+        default: ''
+    started_at:
+        description: 'Epoch seconds captured at start, used to compute duration (result phase only)'
+        required: false
+        default: ''
+    outcome:
+        description: '"success" or "failure" (result phase only)'
+        required: false
+        default: ''
+
+outputs:
+    ts:
+        description: 'Timestamp of the posted message, for a later update'
+        value: ${{ steps.post.outputs.ts }}
+    started_at:
+        description: 'Epoch seconds captured when the start message was posted'
+        value: ${{ steps.compute.outputs.started_at }}
+
+runs:
+    using: composite
+    steps:
+        - name: Compute message color and headline
+          id: compute
+          shell: bash
+          run: |
+              if [[ "${{ inputs.phase }}" == "start" ]]; then
+                echo "started_at=$(date +%s)" >> "$GITHUB_OUTPUT"
+                echo "color=#36C5F0" >> "$GITHUB_OUTPUT"
+                echo "headline=:rocket: *Deploy started*" >> "$GITHUB_OUTPUT"
+              else
+                # Human-readable elapsed time since the start notification.
+                duration=""
+                if [[ -n "${{ inputs.started_at }}" ]]; then
+                  elapsed=$(( $(date +%s) - ${{ inputs.started_at }} ))
+                  duration="$((elapsed / 60))m $((elapsed % 60))s"
+                fi
+                if [[ "${{ inputs.outcome }}" == "success" ]]; then
+                  echo "color=#2EB67D" >> "$GITHUB_OUTPUT"
+                  echo "headline=:white_check_mark: *Deploy succeeded*${duration:+ in $duration}" >> "$GITHUB_OUTPUT"
+                else
+                  echo "color=#E01E5A" >> "$GITHUB_OUTPUT"
+                  echo "headline=:x: *Deploy failed*${duration:+ after $duration}" >> "$GITHUB_OUTPUT"
+                fi
+              fi
+
+        - name: Post deploy message
+          id: post
+          if: inputs.phase == 'start'
+          uses: slackapi/slack-github-action@v2.0.0
+          with:
+              method: chat.postMessage
+              token: ${{ inputs.bot_token }}
+              payload: |
+                  channel: "${{ inputs.channel }}"
+                  attachments:
+                    - color: "${{ steps.compute.outputs.color }}"
+                      fallback: "Deploy started — ${{ inputs.service }} → ${{ inputs.stage }} (by ${{ github.actor }})"
+                      mrkdwn_in: ["text"]
+                      text: "${{ steps.compute.outputs.headline }} — `${{ inputs.service }}` → `${{ inputs.stage }}`\nby ${{ github.actor }}  ·  <${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}|View run>\nref `${{ github.ref_name }}`"
+
+        - name: Update deploy message
+          if: inputs.phase == 'result' && inputs.ts != ''
+          uses: slackapi/slack-github-action@v2.0.0
+          with:
+              method: chat.update
+              token: ${{ inputs.bot_token }}
+              payload: |
+                  channel: "${{ inputs.channel }}"
+                  ts: "${{ inputs.ts }}"
+                  attachments:
+                    - color: "${{ steps.compute.outputs.color }}"
+                      fallback: "${{ steps.compute.outputs.headline }} — ${{ inputs.service }} → ${{ inputs.stage }} (by ${{ github.actor }})"
+                      mrkdwn_in: ["text"]
+                      text: "${{ steps.compute.outputs.headline }} — `${{ inputs.service }}` → `${{ inputs.stage }}`\nby ${{ github.actor }}  ·  <${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}|View run>\nref `${{ github.ref_name }}`"

--- a/.github/actions/slack-deploy-notification/action.yml
+++ b/.github/actions/slack-deploy-notification/action.yml
@@ -44,7 +44,13 @@ runs:
         - name: Compute message color and headline
           id: compute
           shell: bash
+          env:
+              REF_NAME: ${{ github.ref_name }}
           run: |
+              # Read the ref via env (not direct interpolation) and strip any double
+              # quotes so an exotic branch name can't break the YAML payload below.
+              echo "safe_ref=${REF_NAME//\"/}" >> "$GITHUB_OUTPUT"
+
               if [[ "${{ inputs.phase }}" == "start" ]]; then
                 echo "started_at=$(date +%s)" >> "$GITHUB_OUTPUT"
                 echo "color=#36C5F0" >> "$GITHUB_OUTPUT"
@@ -56,13 +62,21 @@ runs:
                   elapsed=$(( $(date +%s) - ${{ inputs.started_at }} ))
                   duration="$((elapsed / 60))m $((elapsed % 60))s"
                 fi
-                if [[ "${{ inputs.outcome }}" == "success" ]]; then
-                  echo "color=#2EB67D" >> "$GITHUB_OUTPUT"
-                  echo "headline=:white_check_mark: *Deploy succeeded*${duration:+ in $duration}" >> "$GITHUB_OUTPUT"
-                else
-                  echo "color=#E01E5A" >> "$GITHUB_OUTPUT"
-                  echo "headline=:x: *Deploy failed*${duration:+ after $duration}" >> "$GITHUB_OUTPUT"
-                fi
+                case "${{ inputs.outcome }}" in
+                  success)
+                    echo "color=#2EB67D" >> "$GITHUB_OUTPUT"
+                    echo "headline=:white_check_mark: *Deploy succeeded*${duration:+ in $duration}" >> "$GITHUB_OUTPUT"
+                    ;;
+                  failure)
+                    echo "color=#E01E5A" >> "$GITHUB_OUTPUT"
+                    echo "headline=:x: *Deploy failed*${duration:+ after $duration}" >> "$GITHUB_OUTPUT"
+                    ;;
+                  *)
+                    # No deploy job matched this service/stage (e.g. runner/lambda on replit).
+                    echo "color=#ECB22E" >> "$GITHUB_OUTPUT"
+                    echo "headline=:warning: *No deploy ran*" >> "$GITHUB_OUTPUT"
+                    ;;
+                esac
               fi
 
         - name: Post deploy message
@@ -72,13 +86,14 @@ runs:
           with:
               method: chat.postMessage
               token: ${{ inputs.bot_token }}
+              errors: true # surface Slack API failures in the step (the caller keeps the deploy green via continue-on-error)
               payload: |
                   channel: "${{ inputs.channel }}"
                   attachments:
                     - color: "${{ steps.compute.outputs.color }}"
-                      fallback: "Deploy started — ${{ inputs.service }} → ${{ inputs.stage }} (by ${{ github.actor }})"
+                      fallback: "Deploy started — ${{ inputs.service }} → ${{ inputs.stage }} (by ${{ github.triggering_actor }})"
                       mrkdwn_in: ["text"]
-                      text: "${{ steps.compute.outputs.headline }} — `${{ inputs.service }}` → `${{ inputs.stage }}`\nby ${{ github.actor }}  ·  <${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}|View run>\nref `${{ github.ref_name }}`"
+                      text: "${{ steps.compute.outputs.headline }} — `${{ inputs.service }}` → `${{ inputs.stage }}`\nby ${{ github.triggering_actor }}  ·  <${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}|View run>\nref `${{ steps.compute.outputs.safe_ref }}`"
 
         - name: Update deploy message
           if: inputs.phase == 'result' && inputs.ts != ''
@@ -86,11 +101,12 @@ runs:
           with:
               method: chat.update
               token: ${{ inputs.bot_token }}
+              errors: true # surface Slack API failures in the step (the caller keeps the deploy green via continue-on-error)
               payload: |
                   channel: "${{ inputs.channel }}"
                   ts: "${{ inputs.ts }}"
                   attachments:
                     - color: "${{ steps.compute.outputs.color }}"
-                      fallback: "${{ steps.compute.outputs.headline }} — ${{ inputs.service }} → ${{ inputs.stage }} (by ${{ github.actor }})"
+                      fallback: "${{ steps.compute.outputs.headline }} — ${{ inputs.service }} → ${{ inputs.stage }} (by ${{ github.triggering_actor }})"
                       mrkdwn_in: ["text"]
-                      text: "${{ steps.compute.outputs.headline }} — `${{ inputs.service }}` → `${{ inputs.stage }}`\nby ${{ github.actor }}  ·  <${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}|View run>\nref `${{ github.ref_name }}`"
+                      text: "${{ steps.compute.outputs.headline }} — `${{ inputs.service }}` → `${{ inputs.stage }}`\nby ${{ github.triggering_actor }}  ·  <${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}|View run>\nref `${{ steps.compute.outputs.safe_ref }}`"

--- a/.github/workflows/deploy.yaml
+++ b/.github/workflows/deploy.yaml
@@ -38,10 +38,15 @@ concurrency:
     group: deploy-${{ inputs.service }}-${{ inputs.stage }}
     cancel-in-progress: false
     queue: max
+# Least privilege by default: the GITHUB_TOKEN gets no scopes unless a job
+# explicitly opts in below.
+permissions: {}
 
 jobs:
     notify_start:
         runs-on: ubuntu-latest
+        permissions:
+            contents: read # checkout the repo to reach the local composite action
         outputs:
             ts: ${{ steps.notify.outputs.ts }}
             started_at: ${{ steps.notify.outputs.started_at }}
@@ -218,6 +223,8 @@ jobs:
         if: inputs.service == 'runner' && inputs.stage != 'replit'
         runs-on: ubuntu-latest
         environment: ${{ inputs.stage }}
+        permissions:
+            contents: read
         steps:
             - name: Checkout
               uses: actions/checkout@v4
@@ -284,12 +291,16 @@ jobs:
             - deploy_runners
             - deploy_lambda
         runs-on: ubuntu-latest
+        permissions:
+            contents: read # checkout the repo to reach the local composite action
         steps:
             - name: Determine deploy outcome
               id: outcome
               run: |
-                  # Only one deploy job runs per dispatch; the rest are skipped. Treat
-                  # failure/cancelled from any of them as an overall failure.
+                  # Only one deploy job runs per dispatch; the rest are skipped.
+                  # failure/cancelled -> failure; a single success -> success;
+                  # nothing ran (e.g. runner/lambda on replit) -> skipped, so we
+                  # don't announce a success for a deploy that never happened.
                   results=(
                     "${{ needs.deploy_app_ui.result }}"
                     "${{ needs.deploy_connect_ui.result }}"
@@ -297,10 +308,13 @@ jobs:
                     "${{ needs.deploy_runners.result }}"
                     "${{ needs.deploy_lambda.result }}"
                   )
-                  outcome="success"
+                  outcome="skipped"
                   for r in "${results[@]}"; do
                     if [[ "$r" == "failure" || "$r" == "cancelled" ]]; then
                       outcome="failure"
+                      break
+                    elif [[ "$r" == "success" ]]; then
+                      outcome="success"
                     fi
                   done
                   echo "outcome=$outcome" >> "$GITHUB_OUTPUT"

--- a/.github/workflows/deploy.yaml
+++ b/.github/workflows/deploy.yaml
@@ -59,17 +59,10 @@ jobs:
                   payload: |
                       channel: "C0B7KSD33QE"
                       attachments:
-                        - color: "#3AA3E3"
+                        - color: "#36C5F0"
                           fallback: ":rocket: Deploy started — ${{ inputs.service }} → ${{ inputs.stage }} (by ${{ github.actor }})"
-                          blocks:
-                            - type: "section"
-                              text:
-                                type: "mrkdwn"
-                                text: "*:rocket: Deploy started* — `${{ inputs.service }}` → `${{ inputs.stage }}`"
-                            - type: "context"
-                              elements:
-                                - type: "mrkdwn"
-                                  text: ":hourglass_flowing_sand: In progress  ·  ref `${{ github.ref_name }}`  ·  by ${{ github.actor }}  ·  <${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}|View run>"
+                          mrkdwn_in: ["text"]
+                          text: ":rocket: *Deploy started* — `${{ inputs.service }}` → `${{ inputs.stage }}`\nIn progress  ·  by ${{ github.actor }}  ·  <${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}|View run>  ·  ref `${{ github.ref_name }}`"
     deploy_app_ui:
         if: inputs.service == 'app_ui'
         runs-on: ubuntu-latest
@@ -347,12 +340,5 @@ jobs:
                       attachments:
                         - color: "${{ steps.result.outputs.color }}"
                           fallback: "${{ steps.result.outputs.title }} — ${{ inputs.service }} → ${{ inputs.stage }} (by ${{ github.actor }})"
-                          blocks:
-                            - type: "section"
-                              text:
-                                type: "mrkdwn"
-                                text: "*${{ steps.result.outputs.title }}* — `${{ inputs.service }}` → `${{ inputs.stage }}`"
-                            - type: "context"
-                              elements:
-                                - type: "mrkdwn"
-                                  text: "${{ steps.result.outputs.status_text }}  ·  ref `${{ github.ref_name }}`  ·  by ${{ github.actor }}  ·  <${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}|View run>"
+                          mrkdwn_in: ["text"]
+                          text: "*${{ steps.result.outputs.title }}* — `${{ inputs.service }}` → `${{ inputs.stage }}`\n${{ steps.result.outputs.status_text }}  ·  by ${{ github.actor }}  ·  <${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}|View run>  ·  ref `${{ github.ref_name }}`"

--- a/.github/workflows/deploy.yaml
+++ b/.github/workflows/deploy.yaml
@@ -40,6 +40,41 @@ concurrency:
     queue: max
 
 jobs:
+    notify_start:
+        runs-on: ubuntu-latest
+        outputs:
+            ts: ${{ steps.slack.outputs.ts }}
+        steps:
+            - name: Post deploy started message
+              id: slack
+              continue-on-error: true
+              uses: slackapi/slack-github-action@v2.0.0
+              with:
+                  method: chat.postMessage
+                  token: ${{ secrets.SLACK_BOT_TOKEN }}
+                  payload: |
+                      channel: "C0B7KSD33QE"
+                      text: ":rocket: Deploy started — ${{ inputs.service }} → ${{ inputs.stage }} (by ${{ github.actor }})"
+                      blocks:
+                        - type: "header"
+                          text:
+                            type: "plain_text"
+                            text: ":rocket: Deploy started"
+                            emoji: true
+                        - type: "section"
+                          fields:
+                            - type: "mrkdwn"
+                              text: "*Service:*\n${{ inputs.service }}"
+                            - type: "mrkdwn"
+                              text: "*Stage:*\n${{ inputs.stage }}"
+                            - type: "mrkdwn"
+                              text: "*Triggered by:*\n${{ github.actor }}"
+                            - type: "mrkdwn"
+                              text: "*Status:*\n:hourglass_flowing_sand: In progress"
+                        - type: "context"
+                          elements:
+                            - type: "mrkdwn"
+                              text: "<${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}|View GitHub Actions run>"
     deploy_app_ui:
         if: inputs.service == 'app_ui'
         runs-on: ubuntu-latest
@@ -255,3 +290,71 @@ jobs:
                     --header "authorization: Bearer $INTERNAL_API_KEY"\
                     --header "content-type: application/json"\
                     --data "{ \"image\": \"${{ vars.LAMBDA_REPOSITORY_NAME }}:${{ github.sha }}\", \"imageType\":\"ecr\" }"
+    notify_result:
+        # Runs after whichever deploy job executed (the others are skipped) and reports the outcome.
+        if: always()
+        needs:
+            - notify_start
+            - deploy_app_ui
+            - deploy_connect_ui
+            - deploy
+            - deploy_runners
+            - deploy_lambda
+        runs-on: ubuntu-latest
+        steps:
+            - name: Determine deploy result
+              id: result
+              run: |
+                  # Only one deploy job runs per dispatch; the rest are skipped. Treat
+                  # failure/cancelled from any of them as an overall failure.
+                  results=(
+                    "${{ needs.deploy_app_ui.result }}"
+                    "${{ needs.deploy_connect_ui.result }}"
+                    "${{ needs.deploy.result }}"
+                    "${{ needs.deploy_runners.result }}"
+                    "${{ needs.deploy_lambda.result }}"
+                  )
+                  status="succeeded"
+                  for r in "${results[@]}"; do
+                    if [[ "$r" == "failure" || "$r" == "cancelled" ]]; then
+                      status="failed"
+                    fi
+                  done
+                  if [[ "$status" == "succeeded" ]]; then
+                    echo "header=:white_check_mark: Deploy succeeded" >> "$GITHUB_OUTPUT"
+                    echo "status_field=:white_check_mark: Succeeded" >> "$GITHUB_OUTPUT"
+                  else
+                    echo "header=:x: Deploy failed" >> "$GITHUB_OUTPUT"
+                    echo "status_field=:x: Failed" >> "$GITHUB_OUTPUT"
+                  fi
+            - name: Update deploy message
+              if: needs.notify_start.outputs.ts != ''
+              continue-on-error: true
+              uses: slackapi/slack-github-action@v2.0.0
+              with:
+                  method: chat.update
+                  token: ${{ secrets.SLACK_BOT_TOKEN }}
+                  payload: |
+                      channel: "C0B7KSD33QE"
+                      ts: "${{ needs.notify_start.outputs.ts }}"
+                      text: "${{ steps.result.outputs.header }} — ${{ inputs.service }} → ${{ inputs.stage }} (by ${{ github.actor }})"
+                      blocks:
+                        - type: "header"
+                          text:
+                            type: "plain_text"
+                            text: "${{ steps.result.outputs.header }}"
+                            emoji: true
+                        - type: "section"
+                          fields:
+                            - type: "mrkdwn"
+                              text: "*Service:*\n${{ inputs.service }}"
+                            - type: "mrkdwn"
+                              text: "*Stage:*\n${{ inputs.stage }}"
+                            - type: "mrkdwn"
+                              text: "*Triggered by:*\n${{ github.actor }}"
+                            - type: "mrkdwn"
+                              text: "*Status:*\n${{ steps.result.outputs.status_field }}"
+                        - type: "context"
+                          elements:
+                            - type: "mrkdwn"
+                              text: "<${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}|View GitHub Actions run>"

--- a/.github/workflows/deploy.yaml
+++ b/.github/workflows/deploy.yaml
@@ -62,7 +62,7 @@ jobs:
                         - color: "#36C5F0"
                           fallback: ":rocket: Deploy started — ${{ inputs.service }} → ${{ inputs.stage }} (by ${{ github.actor }})"
                           mrkdwn_in: ["text"]
-                          text: ":rocket: *Deploy started* — `${{ inputs.service }}` → `${{ inputs.stage }}`\nIn progress  ·  by ${{ github.actor }}  ·  <${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}|View run>\nref `${{ github.ref_name }}`"
+                          text: ":rocket: *Deploy started* — `${{ inputs.service }}` → `${{ inputs.stage }}`\nby ${{ github.actor }}  ·  <${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}|View run>\nref `${{ github.ref_name }}`"
     deploy_app_ui:
         if: inputs.service == 'app_ui'
         runs-on: ubuntu-latest
@@ -320,12 +320,10 @@ jobs:
 
                   if [[ "$status" == "succeeded" ]]; then
                     echo "color=#2EB67D" >> "$GITHUB_OUTPUT"
-                    echo "title=:white_check_mark: Deploy succeeded" >> "$GITHUB_OUTPUT"
-                    echo "status_text=Succeeded${duration:+ in $duration}" >> "$GITHUB_OUTPUT"
+                    echo "headline=:white_check_mark: *Deploy succeeded*${duration:+ in $duration}" >> "$GITHUB_OUTPUT"
                   else
                     echo "color=#E01E5A" >> "$GITHUB_OUTPUT"
-                    echo "title=:x: Deploy failed" >> "$GITHUB_OUTPUT"
-                    echo "status_text=Failed${duration:+ after $duration}" >> "$GITHUB_OUTPUT"
+                    echo "headline=:x: *Deploy failed*${duration:+ after $duration}" >> "$GITHUB_OUTPUT"
                   fi
             - name: Update deploy message
               if: needs.notify_start.outputs.ts != ''
@@ -339,6 +337,6 @@ jobs:
                       ts: "${{ needs.notify_start.outputs.ts }}"
                       attachments:
                         - color: "${{ steps.result.outputs.color }}"
-                          fallback: "${{ steps.result.outputs.title }} — ${{ inputs.service }} → ${{ inputs.stage }} (by ${{ github.actor }})"
+                          fallback: "${{ steps.result.outputs.headline }} — ${{ inputs.service }} → ${{ inputs.stage }} (by ${{ github.actor }})"
                           mrkdwn_in: ["text"]
-                          text: "*${{ steps.result.outputs.title }}* — `${{ inputs.service }}` → `${{ inputs.stage }}`\n${{ steps.result.outputs.status_text }}  ·  by ${{ github.actor }}  ·  <${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}|View run>\nref `${{ github.ref_name }}`"
+                          text: "${{ steps.result.outputs.headline }} — `${{ inputs.service }}` → `${{ inputs.stage }}`\nby ${{ github.actor }}  ·  <${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}|View run>\nref `${{ github.ref_name }}`"

--- a/.github/workflows/deploy.yaml
+++ b/.github/workflows/deploy.yaml
@@ -62,15 +62,9 @@ jobs:
                             text: ":rocket: Deploy started"
                             emoji: true
                         - type: "section"
-                          fields:
-                            - type: "mrkdwn"
-                              text: "*Service:*\n${{ inputs.service }}"
-                            - type: "mrkdwn"
-                              text: "*Stage:*\n${{ inputs.stage }}"
-                            - type: "mrkdwn"
-                              text: "*Triggered by:*\n${{ github.actor }}"
-                            - type: "mrkdwn"
-                              text: "*Status:*\n:hourglass_flowing_sand: In progress"
+                          text:
+                            type: "mrkdwn"
+                            text: "*Service:* `${{ inputs.service }}`  •  *Stage:* `${{ inputs.stage }}`  •  *Ref:* `${{ github.ref_name }}`  •  *Triggered by:* ${{ github.actor }}  •  *Status:* :hourglass_flowing_sand: In progress"
                         - type: "context"
                           elements:
                             - type: "mrkdwn"
@@ -345,15 +339,9 @@ jobs:
                             text: "${{ steps.result.outputs.header }}"
                             emoji: true
                         - type: "section"
-                          fields:
-                            - type: "mrkdwn"
-                              text: "*Service:*\n${{ inputs.service }}"
-                            - type: "mrkdwn"
-                              text: "*Stage:*\n${{ inputs.stage }}"
-                            - type: "mrkdwn"
-                              text: "*Triggered by:*\n${{ github.actor }}"
-                            - type: "mrkdwn"
-                              text: "*Status:*\n${{ steps.result.outputs.status_field }}"
+                          text:
+                            type: "mrkdwn"
+                            text: "*Service:* `${{ inputs.service }}`  •  *Stage:* `${{ inputs.stage }}`  •  *Ref:* `${{ github.ref_name }}`  •  *Triggered by:* ${{ github.actor }}  •  *Status:* ${{ steps.result.outputs.status_field }}"
                         - type: "context"
                           elements:
                             - type: "mrkdwn"

--- a/.github/workflows/deploy.yaml
+++ b/.github/workflows/deploy.yaml
@@ -59,7 +59,7 @@ jobs:
               uses: ./.github/actions/slack-deploy-notification
               with:
                   bot_token: ${{ secrets.SLACK_BOT_TOKEN }}
-                  channel: C0B7KSD33QE
+                  channel: ${{ vars.SLACK_DEPLOYS_CHANNEL_ID }}
                   service: ${{ inputs.service }}
                   stage: ${{ inputs.stage }}
                   phase: start
@@ -325,7 +325,7 @@ jobs:
               uses: ./.github/actions/slack-deploy-notification
               with:
                   bot_token: ${{ secrets.SLACK_BOT_TOKEN }}
-                  channel: C0B7KSD33QE
+                  channel: ${{ vars.SLACK_DEPLOYS_CHANNEL_ID }}
                   service: ${{ inputs.service }}
                   stage: ${{ inputs.stage }}
                   phase: result

--- a/.github/workflows/deploy.yaml
+++ b/.github/workflows/deploy.yaml
@@ -43,26 +43,21 @@ jobs:
     notify_start:
         runs-on: ubuntu-latest
         outputs:
-            ts: ${{ steps.slack.outputs.ts }}
-            started_at: ${{ steps.meta.outputs.started_at }}
+            ts: ${{ steps.notify.outputs.ts }}
+            started_at: ${{ steps.notify.outputs.started_at }}
         steps:
-            - name: Capture start time
-              id: meta
-              run: echo "started_at=$(date +%s)" >> "$GITHUB_OUTPUT"
+            - name: Checkout
+              uses: actions/checkout@v4
             - name: Post deploy started message
-              id: slack
+              id: notify
               continue-on-error: true
-              uses: slackapi/slack-github-action@v2.0.0
+              uses: ./.github/actions/slack-deploy-notification
               with:
-                  method: chat.postMessage
-                  token: ${{ secrets.SLACK_BOT_TOKEN }}
-                  payload: |
-                      channel: "C0B7KSD33QE"
-                      attachments:
-                        - color: "#36C5F0"
-                          fallback: ":rocket: Deploy started — ${{ inputs.service }} → ${{ inputs.stage }} (by ${{ github.actor }})"
-                          mrkdwn_in: ["text"]
-                          text: ":rocket: *Deploy started* — `${{ inputs.service }}` → `${{ inputs.stage }}`\nby ${{ github.actor }}  ·  <${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}|View run>\nref `${{ github.ref_name }}`"
+                  bot_token: ${{ secrets.SLACK_BOT_TOKEN }}
+                  channel: C0B7KSD33QE
+                  service: ${{ inputs.service }}
+                  stage: ${{ inputs.stage }}
+                  phase: start
     deploy_app_ui:
         if: inputs.service == 'app_ui'
         runs-on: ubuntu-latest
@@ -290,8 +285,8 @@ jobs:
             - deploy_lambda
         runs-on: ubuntu-latest
         steps:
-            - name: Determine deploy result
-              id: result
+            - name: Determine deploy outcome
+              id: outcome
               run: |
                   # Only one deploy job runs per dispatch; the rest are skipped. Treat
                   # failure/cancelled from any of them as an overall failure.
@@ -302,41 +297,24 @@ jobs:
                     "${{ needs.deploy_runners.result }}"
                     "${{ needs.deploy_lambda.result }}"
                   )
-                  status="succeeded"
+                  outcome="success"
                   for r in "${results[@]}"; do
                     if [[ "$r" == "failure" || "$r" == "cancelled" ]]; then
-                      status="failed"
+                      outcome="failure"
                     fi
                   done
-
-                  # Human-readable elapsed time since the start notification.
-                  started_at="${{ needs.notify_start.outputs.started_at }}"
-                  if [[ -n "$started_at" ]]; then
-                    elapsed=$(( $(date +%s) - started_at ))
-                    duration="$((elapsed / 60))m $((elapsed % 60))s"
-                  else
-                    duration=""
-                  fi
-
-                  if [[ "$status" == "succeeded" ]]; then
-                    echo "color=#2EB67D" >> "$GITHUB_OUTPUT"
-                    echo "headline=:white_check_mark: *Deploy succeeded*${duration:+ in $duration}" >> "$GITHUB_OUTPUT"
-                  else
-                    echo "color=#E01E5A" >> "$GITHUB_OUTPUT"
-                    echo "headline=:x: *Deploy failed*${duration:+ after $duration}" >> "$GITHUB_OUTPUT"
-                  fi
+                  echo "outcome=$outcome" >> "$GITHUB_OUTPUT"
+            - name: Checkout
+              uses: actions/checkout@v4
             - name: Update deploy message
-              if: needs.notify_start.outputs.ts != ''
               continue-on-error: true
-              uses: slackapi/slack-github-action@v2.0.0
+              uses: ./.github/actions/slack-deploy-notification
               with:
-                  method: chat.update
-                  token: ${{ secrets.SLACK_BOT_TOKEN }}
-                  payload: |
-                      channel: "C0B7KSD33QE"
-                      ts: "${{ needs.notify_start.outputs.ts }}"
-                      attachments:
-                        - color: "${{ steps.result.outputs.color }}"
-                          fallback: "${{ steps.result.outputs.headline }} — ${{ inputs.service }} → ${{ inputs.stage }} (by ${{ github.actor }})"
-                          mrkdwn_in: ["text"]
-                          text: "${{ steps.result.outputs.headline }} — `${{ inputs.service }}` → `${{ inputs.stage }}`\nby ${{ github.actor }}  ·  <${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}|View run>\nref `${{ github.ref_name }}`"
+                  bot_token: ${{ secrets.SLACK_BOT_TOKEN }}
+                  channel: C0B7KSD33QE
+                  service: ${{ inputs.service }}
+                  stage: ${{ inputs.stage }}
+                  phase: result
+                  ts: ${{ needs.notify_start.outputs.ts }}
+                  started_at: ${{ needs.notify_start.outputs.started_at }}
+                  outcome: ${{ steps.outcome.outputs.outcome }}

--- a/.github/workflows/deploy.yaml
+++ b/.github/workflows/deploy.yaml
@@ -44,7 +44,11 @@ jobs:
         runs-on: ubuntu-latest
         outputs:
             ts: ${{ steps.slack.outputs.ts }}
+            started_at: ${{ steps.meta.outputs.started_at }}
         steps:
+            - name: Capture start time
+              id: meta
+              run: echo "started_at=$(date +%s)" >> "$GITHUB_OUTPUT"
             - name: Post deploy started message
               id: slack
               continue-on-error: true
@@ -54,21 +58,18 @@ jobs:
                   token: ${{ secrets.SLACK_BOT_TOKEN }}
                   payload: |
                       channel: "C0B7KSD33QE"
-                      text: ":rocket: Deploy started — ${{ inputs.service }} → ${{ inputs.stage }} (by ${{ github.actor }})"
-                      blocks:
-                        - type: "header"
-                          text:
-                            type: "plain_text"
-                            text: ":rocket: Deploy started"
-                            emoji: true
-                        - type: "section"
-                          text:
-                            type: "mrkdwn"
-                            text: "*Service:* `${{ inputs.service }}`  •  *Stage:* `${{ inputs.stage }}`  •  *Ref:* `${{ github.ref_name }}`  •  *Triggered by:* ${{ github.actor }}  •  *Status:* :hourglass_flowing_sand: In progress"
-                        - type: "context"
-                          elements:
-                            - type: "mrkdwn"
-                              text: "<${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}|View GitHub Actions run>"
+                      attachments:
+                        - color: "#3AA3E3"
+                          fallback: ":rocket: Deploy started — ${{ inputs.service }} → ${{ inputs.stage }} (by ${{ github.actor }})"
+                          blocks:
+                            - type: "section"
+                              text:
+                                type: "mrkdwn"
+                                text: "*:rocket: Deploy started* — `${{ inputs.service }}` → `${{ inputs.stage }}`"
+                            - type: "context"
+                              elements:
+                                - type: "mrkdwn"
+                                  text: ":hourglass_flowing_sand: In progress  ·  ref `${{ github.ref_name }}`  ·  by ${{ github.actor }}  ·  <${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}|View run>"
     deploy_app_ui:
         if: inputs.service == 'app_ui'
         runs-on: ubuntu-latest
@@ -314,12 +315,24 @@ jobs:
                       status="failed"
                     fi
                   done
-                  if [[ "$status" == "succeeded" ]]; then
-                    echo "header=:white_check_mark: Deploy succeeded" >> "$GITHUB_OUTPUT"
-                    echo "status_field=:white_check_mark: Succeeded" >> "$GITHUB_OUTPUT"
+
+                  # Human-readable elapsed time since the start notification.
+                  started_at="${{ needs.notify_start.outputs.started_at }}"
+                  if [[ -n "$started_at" ]]; then
+                    elapsed=$(( $(date +%s) - started_at ))
+                    duration="$((elapsed / 60))m $((elapsed % 60))s"
                   else
-                    echo "header=:x: Deploy failed" >> "$GITHUB_OUTPUT"
-                    echo "status_field=:x: Failed" >> "$GITHUB_OUTPUT"
+                    duration=""
+                  fi
+
+                  if [[ "$status" == "succeeded" ]]; then
+                    echo "color=#2EB67D" >> "$GITHUB_OUTPUT"
+                    echo "title=:white_check_mark: Deploy succeeded" >> "$GITHUB_OUTPUT"
+                    echo "status_text=Succeeded${duration:+ in $duration}" >> "$GITHUB_OUTPUT"
+                  else
+                    echo "color=#E01E5A" >> "$GITHUB_OUTPUT"
+                    echo "title=:x: Deploy failed" >> "$GITHUB_OUTPUT"
+                    echo "status_text=Failed${duration:+ after $duration}" >> "$GITHUB_OUTPUT"
                   fi
             - name: Update deploy message
               if: needs.notify_start.outputs.ts != ''
@@ -331,18 +344,15 @@ jobs:
                   payload: |
                       channel: "C0B7KSD33QE"
                       ts: "${{ needs.notify_start.outputs.ts }}"
-                      text: "${{ steps.result.outputs.header }} — ${{ inputs.service }} → ${{ inputs.stage }} (by ${{ github.actor }})"
-                      blocks:
-                        - type: "header"
-                          text:
-                            type: "plain_text"
-                            text: "${{ steps.result.outputs.header }}"
-                            emoji: true
-                        - type: "section"
-                          text:
-                            type: "mrkdwn"
-                            text: "*Service:* `${{ inputs.service }}`  •  *Stage:* `${{ inputs.stage }}`  •  *Ref:* `${{ github.ref_name }}`  •  *Triggered by:* ${{ github.actor }}  •  *Status:* ${{ steps.result.outputs.status_field }}"
-                        - type: "context"
-                          elements:
-                            - type: "mrkdwn"
-                              text: "<${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}|View GitHub Actions run>"
+                      attachments:
+                        - color: "${{ steps.result.outputs.color }}"
+                          fallback: "${{ steps.result.outputs.title }} — ${{ inputs.service }} → ${{ inputs.stage }} (by ${{ github.actor }})"
+                          blocks:
+                            - type: "section"
+                              text:
+                                type: "mrkdwn"
+                                text: "*${{ steps.result.outputs.title }}* — `${{ inputs.service }}` → `${{ inputs.stage }}`"
+                            - type: "context"
+                              elements:
+                                - type: "mrkdwn"
+                                  text: "${{ steps.result.outputs.status_text }}  ·  ref `${{ github.ref_name }}`  ·  by ${{ github.actor }}  ·  <${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}|View run>"

--- a/.github/workflows/deploy.yaml
+++ b/.github/workflows/deploy.yaml
@@ -62,7 +62,7 @@ jobs:
                         - color: "#36C5F0"
                           fallback: ":rocket: Deploy started — ${{ inputs.service }} → ${{ inputs.stage }} (by ${{ github.actor }})"
                           mrkdwn_in: ["text"]
-                          text: ":rocket: *Deploy started* — `${{ inputs.service }}` → `${{ inputs.stage }}`\nIn progress  ·  by ${{ github.actor }}  ·  <${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}|View run>  ·  ref `${{ github.ref_name }}`"
+                          text: ":rocket: *Deploy started* — `${{ inputs.service }}` → `${{ inputs.stage }}`\nIn progress  ·  by ${{ github.actor }}  ·  <${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}|View run>\nref `${{ github.ref_name }}`"
     deploy_app_ui:
         if: inputs.service == 'app_ui'
         runs-on: ubuntu-latest
@@ -341,4 +341,4 @@ jobs:
                         - color: "${{ steps.result.outputs.color }}"
                           fallback: "${{ steps.result.outputs.title }} — ${{ inputs.service }} → ${{ inputs.stage }} (by ${{ github.actor }})"
                           mrkdwn_in: ["text"]
-                          text: "*${{ steps.result.outputs.title }}* — `${{ inputs.service }}` → `${{ inputs.stage }}`\n${{ steps.result.outputs.status_text }}  ·  by ${{ github.actor }}  ·  <${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}|View run>  ·  ref `${{ github.ref_name }}`"
+                          text: "*${{ steps.result.outputs.title }}* — `${{ inputs.service }}` → `${{ inputs.stage }}`\n${{ steps.result.outputs.status_text }}  ·  by ${{ github.actor }}  ·  <${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}|View run>\nref `${{ github.ref_name }}`"


### PR DESCRIPTION
## Problem

Deploys are announced manually in the engineering channel, which is easy to forget and clutters the wrong channel. There's no passive, reliable awareness of who is deploying what, where.

## Solution

Notify [#deploys](https://nangohq.slack.com/archives/C0B7KSD33QE) automatically on every `workflow_dispatch` deploy, via a reusable composite action at `.github/actions/slack-deploy-notification`:

- `notify_start` posts a status message with a colored bar (blue) showing the service, stage, ref, who triggered it, and a link to the run. It runs independently of the deploy jobs, so Slack never delays or blocks a deploy.
- `notify_result` updates that same message in place once the deploy finishes:
    - ✅ green — `Deploy succeeded in 2m 37s`
    - ❌ red — `Deploy failed after 2m 37s`
    - ⚠️ yellow — `No deploy ran` when no job matched the service/stage (e.g. `runner`/`lambda` on `replit`), so a no-op never reports success.

Covers all services (`server`, `jobs`, `runner`, `persist`, `orchestrator`, `metering`, `connect_ui`, `app_ui`, `lambda`) and all stages (dev / staging / prod / replit).

The workflow also gains a least-privilege `permissions: {}` block, granting `contents: read` only to the jobs that check out the repo.

### Slack setup (done)

The **Nango CI** Slack app (scope `chat:write`) is installed and invited to `#deploys`, and its bot token is stored as the `SLACK_BOT_TOKEN` repository secret. A bot token is required because incoming webhooks can't do `chat.update`.

Fixes [NAN-5643](https://linear.app/nango/issue/NAN-5643)

## Testing

- Triggered `app_ui` and `connect_ui` deploys to `development` from this branch and confirmed the `#deploys` message transitions in place from blue "Deploy started" to green "Deploy succeeded in Xm Ys".
- Verified the composite action resolves in both notify jobs and that the `permissions: {}` block doesn't break checkout.
