### PR TITLE
feat(records_seen): create sync_job_id_new child index in ensureSeenPartition (NAN-5491 Phase 2b)

### DIFF
--- a/packages/records/lib/stores/postgres/postgres.integration.test.ts
+++ b/packages/records/lib/stores/postgres/postgres.integration.test.ts
@@ -2166,6 +2166,29 @@ describe('PostgresStore', () => {
             expect(rows[0]?.indisvalid).toBe(true);
             expect(rows[0]?.indexdef).toMatch(/\(connection_id, model, sync_job_id_new\)/);
         });
+
+        // Must run last in this describe — it leaves the schema in the post-Phase-2c state.
+        it('should fall back to sync_job_id after the shadow column has been renamed away (Phase 2c)', async () => {
+            await db.raw(`DROP TRIGGER IF EXISTS records_seen_mirror_sync_job_id_trigger ON nango_records.records_seen`);
+            await db.raw(`DROP FUNCTION IF EXISTS nango_records.records_seen_mirror_sync_job_id()`);
+            await db.raw(`ALTER TABLE nango_records.records_seen DROP COLUMN sync_job_id`);
+            await db.raw(`ALTER TABLE nango_records.records_seen RENAME COLUMN sync_job_id_new TO sync_job_id`);
+
+            const date = new Date('2025-01-18T00:00:00Z');
+            const res = await store.ensureSeenPartition({ date });
+            expect(res.isOk()).toBe(true);
+
+            const { rows } = await db.raw<{ rows: { indexdef: string; indisvalid: boolean }[] }>(
+                `SELECT pg_get_indexdef(i.indexrelid) AS indexdef, i.indisvalid
+                 FROM pg_index i
+                 JOIN pg_class c ON c.oid = i.indexrelid
+                 WHERE c.relname = ?`,
+                ['records_seen_20250118_connection_model_job_new']
+            );
+            expect(rows).toHaveLength(1);
+            expect(rows[0]?.indisvalid).toBe(true);
+            expect(rows[0]?.indexdef).toMatch(/\(connection_id, model, sync_job_id\)/);
+        });
     });
 
     describe('dropSeenPartition', () => {

--- a/packages/records/lib/stores/postgres/postgres.integration.test.ts
+++ b/packages/records/lib/stores/postgres/postgres.integration.test.ts
@@ -2149,6 +2149,23 @@ describe('PostgresStore', () => {
             expect(res1.isOk()).toBe(true);
             expect(res2.isOk()).toBe(true);
         });
+
+        it('should create the sync_job_id_new child index on the new partition', async () => {
+            const date = new Date('2025-01-17T00:00:00Z');
+            const res = await store.ensureSeenPartition({ date });
+            expect(res.isOk()).toBe(true);
+
+            const { rows } = await db.raw<{ rows: { indexdef: string; indisvalid: boolean }[] }>(
+                `SELECT pg_get_indexdef(i.indexrelid) AS indexdef, i.indisvalid
+                 FROM pg_index i
+                 JOIN pg_class c ON c.oid = i.indexrelid
+                 WHERE c.relname = ?`,
+                ['records_seen_20250117_connection_model_job_new']
+            );
+            expect(rows).toHaveLength(1);
+            expect(rows[0]?.indisvalid).toBe(true);
+            expect(rows[0]?.indexdef).toMatch(/\(connection_id, model, sync_job_id_new\)/);
+        });
     });
 
     describe('dropSeenPartition', () => {

--- a/packages/records/lib/stores/postgres/postgres.ts
+++ b/packages/records/lib/stores/postgres/postgres.ts
@@ -130,14 +130,29 @@ export class PostgresStore implements RecordsStore {
                 // ACCESS EXCLUSIVE from CREATE TABLE PARTITION OF is released before the
                 // child CREATE INDEX runs. Wrapping both in a transaction would hold the
                 // parent lock across both, briefly blocking every records_seen reader/writer.
-                // A failure between the two leaves a partition without its index — benign
-                // pre-swap (no query uses the new index yet), recoverable via IF NOT EXISTS
-                // on retry, and caught by Phase 2c's pre-deploy index-coverage gate.
+                //
+                // The CREATE INDEX targets sync_job_id_new (the shadow column added in
+                // Phase 2a) and falls back to sync_job_id if the shadow column has already
+                // been renamed away by Phase 2c's swap. This makes ensureSeenPartition
+                // tolerant of the rename happening at any moment relative to a rolling
+                // deploy — old pods carrying this code keep functioning even after the
+                // migration commits. A follow-up PR will drop the fallback once Phase 2c
+                // has fully soaked everywhere.
                 promise = this.db
                     .raw(
                         `CREATE TABLE IF NOT EXISTS "${partitionName}" PARTITION OF "${RECORDS_SEEN_TABLE}" FOR VALUES FROM ('${day.toISOString()}') TO ('${next.toISOString()}')`
                     )
-                    .then(() => this.db.raw('CREATE INDEX IF NOT EXISTS ?? ON ?? (connection_id, model, sync_job_id_new)', [indexName, partitionName]))
+                    .then(async () => {
+                        try {
+                            await this.db.raw('CREATE INDEX IF NOT EXISTS ?? ON ?? (connection_id, model, sync_job_id_new)', [indexName, partitionName]);
+                        } catch (err: any) {
+                            if (err?.code === '42703') {
+                                await this.db.raw('CREATE INDEX IF NOT EXISTS ?? ON ?? (connection_id, model, sync_job_id)', [indexName, partitionName]);
+                            } else {
+                                throw err;
+                            }
+                        }
+                    })
                     .then(() => undefined);
                 this.seenPartitionPromises.set(suffix, promise);
             }

--- a/packages/records/lib/stores/postgres/postgres.ts
+++ b/packages/records/lib/stores/postgres/postgres.ts
@@ -124,10 +124,17 @@ export class PostgresStore implements RecordsStore {
         try {
             if (!promise) {
                 const next = day.add(1, 'day');
+                const partitionName = `records_seen_${suffix}`;
+                const indexName = `${partitionName}_connection_model_job_new`;
+                // Create the child index inline so the partition is born ready for the eventual
+                // sync_job_id_new -> sync_job_id swap. The new partition is empty so a plain
+                // (non-CONCURRENTLY) CREATE INDEX is fast and holds ACCESS EXCLUSIVE only for
+                // the catalog touch.
                 promise = this.db
                     .raw(
-                        `CREATE TABLE IF NOT EXISTS "records_seen_${suffix}" PARTITION OF "${RECORDS_SEEN_TABLE}" FOR VALUES FROM ('${day.toISOString()}') TO ('${next.toISOString()}')`
+                        `CREATE TABLE IF NOT EXISTS "${partitionName}" PARTITION OF "${RECORDS_SEEN_TABLE}" FOR VALUES FROM ('${day.toISOString()}') TO ('${next.toISOString()}')`
                     )
+                    .then(() => this.db.raw('CREATE INDEX IF NOT EXISTS ?? ON ?? (connection_id, model, sync_job_id_new)', [indexName, partitionName]))
                     .then(() => undefined);
                 this.seenPartitionPromises.set(suffix, promise);
             }

--- a/packages/records/lib/stores/postgres/postgres.ts
+++ b/packages/records/lib/stores/postgres/postgres.ts
@@ -126,17 +126,18 @@ export class PostgresStore implements RecordsStore {
                 const next = day.add(1, 'day');
                 const partitionName = `records_seen_${suffix}`;
                 const indexName = `${partitionName}_connection_model_job_new`;
-                // Create partition + child index atomically so the partition is never visible
-                // without its index for the eventual sync_job_id_new -> sync_job_id swap. The
-                // partition is empty, so the (non-CONCURRENTLY) index build is fast and the
-                // ACCESS EXCLUSIVE window stays catalog-only.
+                // Two separate statements (not a single transaction) so the parent's
+                // ACCESS EXCLUSIVE from CREATE TABLE PARTITION OF is released before the
+                // child CREATE INDEX runs. Wrapping both in a transaction would hold the
+                // parent lock across both, briefly blocking every records_seen reader/writer.
+                // A failure between the two leaves a partition without its index — benign
+                // pre-swap (no query uses the new index yet), recoverable via IF NOT EXISTS
+                // on retry, and caught by Phase 2c's pre-deploy index-coverage gate.
                 promise = this.db
-                    .transaction(async (trx) => {
-                        await trx.raw(
-                            `CREATE TABLE IF NOT EXISTS "${partitionName}" PARTITION OF "${RECORDS_SEEN_TABLE}" FOR VALUES FROM ('${day.toISOString()}') TO ('${next.toISOString()}')`
-                        );
-                        await trx.raw('CREATE INDEX IF NOT EXISTS ?? ON ?? (connection_id, model, sync_job_id_new)', [indexName, partitionName]);
-                    })
+                    .raw(
+                        `CREATE TABLE IF NOT EXISTS "${partitionName}" PARTITION OF "${RECORDS_SEEN_TABLE}" FOR VALUES FROM ('${day.toISOString()}') TO ('${next.toISOString()}')`
+                    )
+                    .then(() => this.db.raw('CREATE INDEX IF NOT EXISTS ?? ON ?? (connection_id, model, sync_job_id_new)', [indexName, partitionName]))
                     .then(() => undefined);
                 this.seenPartitionPromises.set(suffix, promise);
             }

--- a/packages/records/lib/stores/postgres/postgres.ts
+++ b/packages/records/lib/stores/postgres/postgres.ts
@@ -126,15 +126,17 @@ export class PostgresStore implements RecordsStore {
                 const next = day.add(1, 'day');
                 const partitionName = `records_seen_${suffix}`;
                 const indexName = `${partitionName}_connection_model_job_new`;
-                // Create the child index inline so the partition is born ready for the eventual
-                // sync_job_id_new -> sync_job_id swap. The new partition is empty so a plain
-                // (non-CONCURRENTLY) CREATE INDEX is fast and holds ACCESS EXCLUSIVE only for
-                // the catalog touch.
+                // Create partition + child index atomically so the partition is never visible
+                // without its index for the eventual sync_job_id_new -> sync_job_id swap. The
+                // partition is empty, so the (non-CONCURRENTLY) index build is fast and the
+                // ACCESS EXCLUSIVE window stays catalog-only.
                 promise = this.db
-                    .raw(
-                        `CREATE TABLE IF NOT EXISTS "${partitionName}" PARTITION OF "${RECORDS_SEEN_TABLE}" FOR VALUES FROM ('${day.toISOString()}') TO ('${next.toISOString()}')`
-                    )
-                    .then(() => this.db.raw('CREATE INDEX IF NOT EXISTS ?? ON ?? (connection_id, model, sync_job_id_new)', [indexName, partitionName]))
+                    .transaction(async (trx) => {
+                        await trx.raw(
+                            `CREATE TABLE IF NOT EXISTS "${partitionName}" PARTITION OF "${RECORDS_SEEN_TABLE}" FOR VALUES FROM ('${day.toISOString()}') TO ('${next.toISOString()}')`
+                        );
+                        await trx.raw('CREATE INDEX IF NOT EXISTS ?? ON ?? (connection_id, model, sync_job_id_new)', [indexName, partitionName]);
+                    })
                     .then(() => undefined);
                 this.seenPartitionPromises.set(suffix, promise);
             }


### PR DESCRIPTION
To be merged after https://github.com/NangoHQ/nango/pull/6304

- Modifies `ensureSeenPartition` to also `CREATE INDEX IF NOT EXISTS <name> ON <new_partition> (connection_id, model, sync_job_id_new)` immediately after each daily partition is created. The partition is empty at that moment, so the (non-`CONCURRENTLY`) index build is fast and holds `ACCESS EXCLUSIVE` on the child only for the catalog touch. No parent partitioned index — each partition has its own orphan child index.
- Step 2 of the int4→bigint widening of `records_seen.sync_job_id` (Phase 2a is #6304). After 48h turnover, every live partition has the index in place; Phase 2c (#6321) then swaps and drops the old column.

## Why this shape (replaces the loop-based migration that was previously #6306, now closed)

Three concerns with the migration-loop approach we tried first:

1. **Race with `dropSeenPartition`.** The migration would snapshot the partition list from `pg_inherits`, then loop `CREATE INDEX CONCURRENTLY` / `ATTACH PARTITION` over the snapshot. `seenPartition.daemon` keeps running in old persist replicas during a rolling deploy and can drop the oldest partition mid-loop, causing the migration to abort with `relation does not exist` and leaving a partial state requiring manual cleanup.
2. **Parent partitioned index dance.** That approach required `CONCURRENTLY` per child → `ON ONLY` parent → `ATTACH` each child, because PG won't `CONCURRENTLY` on a partitioned parent directly. The final `ATTACH` flipping `indisvalid = t` was a fragile operator-runbook gate.
3. **Strictly speaking, the parent isn't needed.** The planner uses each partition's child index regardless of whether it's attached to a parent template; the parent template's only value is auto-inheriting child indexes onto new partitions. Since we own the partition-creation path (`ensureSeenPartition`), that responsibility can live in code.

Approach in this PR:
- No parent partitioned index. Each partition has its own orphan child index named `<partition>_connection_model_job_new`.
- New partitions are born with the index inline; build on empty table is sub-millisecond.
- Two separate statements (not wrapped in a transaction) so the parent's `ACCESS EXCLUSIVE` from `CREATE TABLE PARTITION OF` is released before the child `CREATE INDEX` runs — a transaction would hold the parent lock across both, briefly blocking every `records_seen` reader/writer. A transient failure between the two leaves a partition without its index, which is benign pre-swap (no query uses the new index yet), recoverable via `IF NOT EXISTS` on retry, and caught by Phase 2c's pre-deploy index-coverage gate.

## Phase 2c knock-on

- Phase 2c's swap loses one DDL — there's no new parent index to rename to canonical: `ALTER TABLE records_seen DROP COLUMN sync_job_id` cascades only the *old* parent's children; the orphan children on `sync_job_id_new` survive the column rename.
- Linear pre-deploy Gate 2 (parent `indisvalid`) drops away; Gate 1 becomes "every partition has a valid index on `(connection_id, model, sync_job_id_new)`."

## Test plan

- [x] New integration test asserts `ensureSeenPartition` creates the expected `(connection_id, model, sync_job_id_new)` index on the new partition with `indisvalid = true`. Runs against the 2a schema (this branch is stacked on `pau/nan-5491-phase2a-records-seen-shadow-column`).
- [x] Pre-existing `ensureSeenPartition` tests still pass (creation, idempotency).
- [ ] Staging: deploy 2a + 2b, verify any partition created post-2b has the new child index via Gate 1 of the Linear plan's appendix.
- [ ] Production: same.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
