### PR TITLE
feat: add scheduler worker for dryruns

### DIFF
--- a/dryrun-scheduler-server-sketch.ts
+++ b/dryrun-scheduler-server-sketch.ts
@@ -1,0 +1,169 @@
+/* eslint-disable import/no-extraneous-dependencies, @typescript-eslint/no-unused-vars, @typescript-eslint/require-await */
+
+// Sketch only: this is intentionally short and omits production details.
+// It shows the shape of using @nangohq/scheduler directly from server.
+
+import db from '@nangohq/database';
+import { getRemoteFunctionNangoHost, invokeDryrun, parseDryrunSuccessOutput, remoteFunctionDryrunSandboxTimeoutMs } from '@nangohq/sandbox';
+import { Scheduler, SchedulerWorker } from '@nangohq/scheduler';
+
+import { createDryrunSandboxApiKey, toFunctionDryrunError } from './packages/server/lib/controllers/functions/dryrun/helpers.js';
+
+const handlers = [
+    {
+        groupKeyPattern: 'dryrun:*',
+        limit: 5,
+        heartbeatIntervalMs: 10_000,
+        toFailureOutput: (err) => ({
+            status: 'failed',
+            error: toFunctionDryrunError(err)
+        }),
+        handle: runDryrunTask
+    },
+    {
+        groupKeyPattern: 'sync:*',
+        limit: 10,
+        heartbeatIntervalMs: 10_000,
+        handle: runSyncTask,
+        handleAbort: abortSyncTask
+    }
+];
+
+// 1. Server startup: create scheduler against the normal Nango DB.
+const scheduler = new Scheduler({
+    db: db.knex,
+    on: {
+        CREATED: () => {},
+        STARTED: () => {},
+        SUCCEEDED: () => {},
+        FAILED: () => {},
+        EXPIRED: () => {},
+        CANCELLED: () => {}
+    },
+    onError: (err) => console.error(err)
+});
+
+scheduler.start();
+
+// 2. Server startup: register workers/handlers.
+const worker = new SchedulerWorker({
+    scheduler,
+    pollIntervalMs: 1_000,
+    handlers,
+    onError: (err, ctx) => console.error({ err, ctx })
+});
+
+worker.start();
+
+// 3. Handler: one scheduler task becomes one synchronous sandbox dryrun.
+async function runDryrunTask(task) {
+    const payload = task.payload as {
+        environmentId: number;
+        environmentName: string;
+        parentCustomerKeyId: number;
+        request: {
+            integration_id: string;
+            function_name: string;
+            function_type: 'action' | 'sync';
+            code: string;
+            connection_id: string;
+            input?: unknown;
+            metadata?: Record<string, unknown>;
+            checkpoint?: Record<string, unknown>;
+            last_sync_date?: string;
+        };
+    };
+
+    const startedAt = Date.now();
+    const sandboxApiKey = await createDryrunSandboxApiKey(payload.parentCustomerKeyId, payload.environmentId, task.id);
+    if (sandboxApiKey.isErr()) {
+        throw sandboxApiKey.error;
+    }
+
+    const result = await invokeDryrun({
+        ...payload.request,
+        environment_name: payload.environmentName,
+        nango_secret_key: sandboxApiKey.value,
+        nango_host: getRemoteFunctionNangoHost()
+    });
+
+    const parsed = parseDryrunSuccessOutput(result.output);
+    return {
+        output: {
+            status: 'success',
+            output: parsed.output,
+            duration_ms: Date.now() - startedAt,
+            ...(parsed.hasResult ? { result: parsed.result } : {})
+        }
+    };
+}
+
+// 4. POST /functions/dryruns: queue a new dryrun and return the scheduler task id.
+async function queueDryrun({ environment, parentCustomerKeyId, body }) {
+    const timeoutSecs = Math.ceil(remoteFunctionDryrunSandboxTimeoutMs / 1000);
+
+    const task = await scheduler.immediate({
+        name: `dryrun:${crypto.randomUUID()}`,
+        groupKey: `dryrun:${environment.id}`,
+        payload: {
+            environmentId: environment.id,
+            environmentName: environment.name,
+            parentCustomerKeyId,
+            request: {
+                ...body,
+                function_name: 'function'
+            }
+        },
+        groupMaxConcurrency: 0,
+        retryMax: 0,
+        retryCount: 0,
+        createdToStartedTimeoutSecs: timeoutSecs,
+        startedToCompletedTimeoutSecs: timeoutSecs,
+        heartbeatTimeoutSecs: 60,
+        ownerKey: null,
+        retryKey: null
+    });
+
+    if (task.isErr()) {
+        throw task.error;
+    }
+
+    return {
+        id: task.value.id,
+        status: 'waiting',
+        created_at: task.value.createdAt.toISOString()
+    };
+}
+
+// 5. Shutdown.
+async function stopDryrunScheduler() {
+    await worker.stop();
+    await scheduler.stop();
+}
+
+async function runSyncTask(task) {
+    return {
+        output: {
+            status: 'success',
+            taskId: task.id
+        }
+    };
+}
+
+async function abortSyncTask(task) {
+    const payload = task.payload as {
+        abortedTask: {
+            id: string;
+            state: string;
+        };
+        reason: string;
+    };
+
+    return {
+        output: {
+            status: 'aborted',
+            abortedTaskId: payload.abortedTask.id,
+            reason: payload.reason
+        }
+    };
+}

--- a/package-lock.json
+++ b/package-lock.json
@@ -39036,6 +39036,7 @@
                 "@nangohq/providers": "file:.../providers",
                 "@nangohq/records": "file:../records",
                 "@nangohq/sandbox": "file:../sandbox",
+                "@nangohq/scheduler": "file:../scheduler",
                 "@nangohq/shared": "file:../shared",
                 "@nangohq/usage": "file:../usage",
                 "@nangohq/utils": "file:../utils",

--- a/packages/scheduler/lib/config.ts
+++ b/packages/scheduler/lib/config.ts
@@ -26,6 +26,13 @@ export interface SchedulerConfig {
     };
 }
 
+export interface SchedulerStartOptions {
+    readonly scheduling?: boolean;
+    readonly expiring?: boolean;
+    readonly cleaning?: boolean;
+    readonly backpressure?: boolean;
+}
+
 export const defaultSchedulerConfig: SchedulerConfig = {
     daemons: {
         schedulingTickIntervalMs: 100,
@@ -40,6 +47,13 @@ export const defaultSchedulerConfig: SchedulerConfig = {
         expiringBatchSize: 1000,
         recurringGroupMaxConcurrency: 500
     }
+};
+
+export const defaultSchedulerStartOptions: Required<SchedulerStartOptions> = {
+    scheduling: true,
+    expiring: true,
+    cleaning: true,
+    backpressure: true
 };
 
 /**

--- a/packages/scheduler/lib/db/helpers.test.ts
+++ b/packages/scheduler/lib/db/helpers.test.ts
@@ -1,8 +1,8 @@
 import { DatabaseClient, defaultDatabaseClientOptions } from './client.js';
 
-export const getTestDbClient = () =>
+export const getTestDbClient = (schema = 'scheduler') =>
     new DatabaseClient({
         ...defaultDatabaseClientOptions,
         url: `postgres://${process.env['NANGO_DB_USER']}:${process.env['NANGO_DB_PASSWORD']}@${process.env['NANGO_DB_HOST']}:${process.env['NANGO_DB_PORT']}/${process.env['NANGO_DB_NAME']}`,
-        schema: 'scheduler'
+        schema
     });

--- a/packages/scheduler/lib/index.ts
+++ b/packages/scheduler/lib/index.ts
@@ -5,3 +5,4 @@ export * from './errors.js';
 export * from './db/helpers.test.js';
 export * from './db/client.js';
 export * from './utils/format.js';
+export * from './worker.js';

--- a/packages/scheduler/lib/scheduler-controls.integration.test.ts
+++ b/packages/scheduler/lib/scheduler-controls.integration.test.ts
@@ -1,0 +1,169 @@
+import { randomUUID } from 'node:crypto';
+import { setTimeout } from 'node:timers/promises';
+
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+
+import { nanoid } from '@nangohq/utils';
+
+import { defaultSchedulerConfig } from './config.js';
+import { getTestDbClient } from './db/helpers.test.js';
+import { Scheduler } from './scheduler.js';
+
+import type { SchedulerConfig } from './config.js';
+import type { Task } from './types.js';
+
+describe('Scheduler controls', () => {
+    const callbacks = {
+        CREATED: vi.fn(),
+        STARTED: vi.fn(),
+        SUCCEEDED: vi.fn(),
+        FAILED: vi.fn(),
+        EXPIRED: vi.fn(),
+        CANCELLED: vi.fn()
+    };
+
+    let dbClient: ReturnType<typeof getTestDbClient>;
+    let scheduler: Scheduler | undefined;
+
+    beforeEach(async () => {
+        dbClient = getTestDbClient(uniqueSchemaName('scheduler_controls'));
+        await dbClient.migrate();
+    });
+
+    afterEach(async () => {
+        await scheduler?.stop();
+        await dbClient.clearDatabase();
+        await dbClient.destroy();
+
+        callbacks.CREATED.mockReset();
+        callbacks.STARTED.mockReset();
+        callbacks.SUCCEEDED.mockReset();
+        callbacks.FAILED.mockReset();
+        callbacks.EXPIRED.mockReset();
+        callbacks.CANCELLED.mockReset();
+    });
+
+    it('can start without the expiring daemon', async () => {
+        scheduler = new Scheduler({ db: dbClient.db, on: callbacks, onError: () => {}, config: quickExpiringConfig() });
+        scheduler.start({ scheduling: false, expiring: false, cleaning: false, backpressure: false });
+
+        const task = await immediate(scheduler, { createdToStartedTimeoutSecs: 1 });
+
+        await setTimeout(1200);
+
+        const reloaded = (await scheduler.get({ taskId: task.id })).unwrap();
+        expect(reloaded.state).toBe('CREATED');
+        expect(callbacks.EXPIRED).not.toHaveBeenCalled();
+    });
+
+    it('always creates an abort task when a task expires', async () => {
+        scheduler = new Scheduler({
+            db: dbClient.db,
+            on: callbacks,
+            onError: () => {},
+            config: quickExpiringConfig()
+        });
+        scheduler.start({ scheduling: false, cleaning: false, backpressure: false });
+
+        const groupKey = nanoid();
+        const task = await immediate(scheduler, { groupKey, createdToStartedTimeoutSecs: 1 });
+
+        await waitForTaskState(scheduler, task.id, 'EXPIRED');
+        const abortTask = await waitForAbortTask(scheduler, groupKey);
+
+        const groupTasks = (await scheduler.searchTasks({ groupKey, limit: 10 })).unwrap();
+        expect(groupTasks).toHaveLength(2);
+        expect(groupTasks).toContainEqual(expect.objectContaining({ id: task.id }));
+        expect(groupTasks).toContainEqual(expect.objectContaining({ id: abortTask.id, payload: expect.objectContaining({ type: 'abort' }) }));
+        expect(callbacks.EXPIRED).toHaveBeenCalledOnce();
+    });
+
+    it('always creates an abort task when a task is cancelled', async () => {
+        scheduler = new Scheduler({
+            db: dbClient.db,
+            on: callbacks,
+            onError: () => {},
+            config: quickExpiringConfig()
+        });
+
+        const groupKey = nanoid();
+        const task = await immediate(scheduler, { groupKey });
+        (await scheduler.dequeue({ groupKeyPattern: groupKey, limit: 1 })).unwrap();
+
+        const cancelled = (await scheduler.cancel({ taskId: task.id, reason: 'cancelled by test' })).unwrap();
+
+        const groupTasks = (await scheduler.searchTasks({ groupKey, limit: 10 })).unwrap();
+        expect(cancelled.state).toBe('CANCELLED');
+        expect(groupTasks).toHaveLength(2);
+        expect(groupTasks).toContainEqual(expect.objectContaining({ id: task.id }));
+        expect(groupTasks).toContainEqual(expect.objectContaining({ payload: expect.objectContaining({ type: 'abort' }) }));
+        expect(callbacks.CANCELLED).toHaveBeenCalledOnce();
+    });
+});
+
+function uniqueSchemaName(prefix: string): string {
+    return `${prefix}_${randomUUID().replaceAll('-', '')}`;
+}
+
+function quickExpiringConfig(overrides: Partial<SchedulerConfig> = {}): SchedulerConfig {
+    return {
+        ...defaultSchedulerConfig,
+        ...overrides,
+        daemons: {
+            ...defaultSchedulerConfig.daemons,
+            expiringTickIntervalMs: 25,
+            ...overrides.daemons
+        },
+        limits: {
+            ...defaultSchedulerConfig.limits,
+            ...overrides.limits
+        }
+    };
+}
+
+async function immediate(scheduler: Scheduler, overrides: Partial<Parameters<Scheduler['immediate']>[0]> = {}): Promise<Task> {
+    return (
+        await scheduler.immediate({
+            name: nanoid(),
+            payload: {},
+            groupKey: nanoid(),
+            groupMaxConcurrency: 0,
+            retryMax: 0,
+            retryCount: 0,
+            createdToStartedTimeoutSecs: 3600,
+            startedToCompletedTimeoutSecs: 3600,
+            heartbeatTimeoutSecs: 600,
+            ownerKey: null,
+            retryKey: null,
+            ...overrides
+        })
+    ).unwrap();
+}
+
+async function waitForTaskState(scheduler: Scheduler, taskId: string, state: Task['state']): Promise<Task> {
+    const started = Date.now();
+    while (Date.now() - started < 3000) {
+        const task = (await scheduler.get({ taskId })).unwrap();
+        if (task.state === state) {
+            return task;
+        }
+        await setTimeout(25);
+    }
+
+    const task = (await scheduler.get({ taskId })).unwrap();
+    throw new Error(`Timed out waiting for task ${taskId} to reach ${state}; current state is ${task.state}`);
+}
+
+async function waitForAbortTask(scheduler: Scheduler, groupKey: string): Promise<Task> {
+    const started = Date.now();
+    while (Date.now() - started < 3000) {
+        const tasks = (await scheduler.searchTasks({ groupKey, limit: 10 })).unwrap();
+        const abortTask = tasks.find((task) => task.payload['type'] === 'abort');
+        if (abortTask) {
+            return abortTask;
+        }
+        await setTimeout(25);
+    }
+
+    throw new Error(`Timed out waiting for abort task in group ${groupKey}`);
+}

--- a/packages/scheduler/lib/scheduler.ts
+++ b/packages/scheduler/lib/scheduler.ts
@@ -2,7 +2,7 @@ import { uuidv7 } from 'uuidv7';
 
 import { Err, Ok, stringifyError } from '@nangohq/utils';
 
-import { defaultSchedulerConfig, noopLogger } from './config.js';
+import { defaultSchedulerConfig, defaultSchedulerStartOptions, noopLogger } from './config.js';
 import { CleaningDaemon } from './daemons/cleaning/cleaning.daemon.js';
 import { ExpiringDaemon } from './daemons/expiring/expiring.daemon.js';
 import { BackpressureMonitoringDaemon } from './daemons/monitoring/backpressure-monitoring.daemon.js';
@@ -11,7 +11,7 @@ import * as schedules from './models/schedules.js';
 import * as tasks from './models/tasks.js';
 import { logger, setLogger } from './utils/logger.js';
 
-import type { SchedulerConfig, SchedulerEvent } from './config.js';
+import type { SchedulerConfig, SchedulerEvent, SchedulerStartOptions } from './config.js';
 import type { FromScheduleProps, ImmediateProps, Schedule, ScheduleProps, ScheduleState, Task, TaskState } from './types.js';
 import type { Result, StrictLogger } from '@nangohq/utils';
 import type knex from 'knex';
@@ -83,7 +83,7 @@ export class Scheduler {
             batchSize: config.limits.expiringBatchSize,
             onExpiring: (task: Task) => {
                 const { reason } = task.output as unknown as { reason?: string };
-                this.scheduleAbortTask({ aborted: task, reason: `Execution expired: ${reason || 'unknown reason'}` });
+                void this.scheduleAbortTask({ aborted: task, reason: `Execution expired: ${reason || 'unknown reason'}` });
                 this.onCallbacks[task.state](task);
             },
             onError
@@ -117,12 +117,21 @@ export class Scheduler {
         });
     }
 
-    start(): void {
+    start(opts: SchedulerStartOptions = defaultSchedulerStartOptions): void {
+        const options = { ...defaultSchedulerStartOptions, ...opts };
         // we don't await. Errors will be handled by the onError callback
-        void this.expiring.start();
-        void this.scheduling.start();
-        void this.cleaning.start();
-        void this.backpressureMonitor.start();
+        if (options.expiring) {
+            void this.expiring.start();
+        }
+        if (options.scheduling) {
+            void this.scheduling.start();
+        }
+        if (options.cleaning) {
+            void this.cleaning.start();
+        }
+        if (options.backpressure) {
+            void this.backpressureMonitor.start();
+        }
     }
 
     async stop(): Promise<void> {

--- a/packages/scheduler/lib/worker.integration.test.ts
+++ b/packages/scheduler/lib/worker.integration.test.ts
@@ -1,0 +1,292 @@
+import { randomUUID } from 'node:crypto';
+import { setTimeout } from 'node:timers/promises';
+
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+
+import { nanoid } from '@nangohq/utils';
+
+import { defaultSchedulerConfig } from './config.js';
+import { getTestDbClient } from './db/helpers.test.js';
+import { Scheduler } from './scheduler.js';
+import { SchedulerWorker } from './worker.js';
+
+import type { Task } from './types.js';
+import type { SchedulerWorkerErrorContext } from './worker.js';
+
+describe('SchedulerWorker', () => {
+    const callbacks = {
+        CREATED: vi.fn(),
+        STARTED: vi.fn(),
+        SUCCEEDED: vi.fn(),
+        FAILED: vi.fn(),
+        EXPIRED: vi.fn(),
+        CANCELLED: vi.fn()
+    };
+
+    let dbClient: ReturnType<typeof getTestDbClient>;
+    let scheduler: Scheduler;
+    let worker: SchedulerWorker | undefined;
+
+    beforeEach(async () => {
+        dbClient = getTestDbClient(uniqueSchemaName('scheduler_worker'));
+        scheduler = new Scheduler({ db: dbClient.db, on: callbacks, onError: () => {}, config: defaultSchedulerConfig });
+        await dbClient.migrate();
+    });
+
+    afterEach(async () => {
+        await worker?.stop();
+        await scheduler.stop();
+        await dbClient.clearDatabase();
+        await dbClient.destroy();
+        vi.restoreAllMocks();
+
+        callbacks.CREATED.mockReset();
+        callbacks.STARTED.mockReset();
+        callbacks.SUCCEEDED.mockReset();
+        callbacks.FAILED.mockReset();
+        callbacks.EXPIRED.mockReset();
+        callbacks.CANCELLED.mockReset();
+    });
+
+    it('dequeues matching tasks and marks them as succeeded', async () => {
+        const groupKey = nanoid();
+        const task = await immediate(scheduler, { groupKey });
+
+        worker = new SchedulerWorker({
+            scheduler,
+            pollIntervalMs: 20,
+            handlers: [
+                {
+                    groupKeyPattern: groupKey,
+                    limit: 1,
+                    handle: (started) => {
+                        expect(started.id).toBe(task.id);
+                        expect(started.state).toBe('STARTED');
+                        return Promise.resolve({ output: { ok: true } });
+                    }
+                }
+            ]
+        });
+        worker.start();
+
+        const succeeded = await waitForTaskState(scheduler, task.id, 'SUCCEEDED');
+
+        expect(succeeded.output).toEqual({ ok: true });
+        expect(callbacks.STARTED).toHaveBeenCalledOnce();
+        expect(callbacks.SUCCEEDED).toHaveBeenCalledOnce();
+    });
+
+    it('marks handled task failures as failed', async () => {
+        const groupKey = nanoid();
+        const task = await immediate(scheduler, { groupKey });
+        const onError = vi.fn<(err: Error, context: SchedulerWorkerErrorContext) => void>();
+
+        worker = new SchedulerWorker({
+            scheduler,
+            pollIntervalMs: 20,
+            onError,
+            handlers: [
+                {
+                    groupKeyPattern: groupKey,
+                    limit: 1,
+                    handle: () => Promise.reject(new Error('worker failed'))
+                }
+            ]
+        });
+        worker.start();
+
+        const failed = await waitForTaskState(scheduler, task.id, 'FAILED');
+
+        expect(failed.output).toEqual({ message: 'worker failed' });
+        expect(onError).toHaveBeenCalledWith(expect.any(Error), expect.objectContaining({ phase: 'handle', task: expect.objectContaining({ id: task.id }) }));
+        expect(callbacks.FAILED).toHaveBeenCalledOnce();
+    });
+
+    it('uses custom failure output when a handler throws', async () => {
+        const groupKey = nanoid();
+        const task = await immediate(scheduler, { groupKey });
+
+        worker = new SchedulerWorker({
+            scheduler,
+            pollIntervalMs: 20,
+            handlers: [
+                {
+                    groupKeyPattern: groupKey,
+                    limit: 1,
+                    toFailureOutput: (err) => ({
+                        code: 'custom_failure',
+                        message: err instanceof Error ? err.message : 'unknown'
+                    }),
+                    handle: () => Promise.reject(new Error('typed failure'))
+                }
+            ]
+        });
+        worker.start();
+
+        const failed = await waitForTaskState(scheduler, task.id, 'FAILED');
+
+        expect(failed.output).toEqual({ code: 'custom_failure', message: 'typed failure' });
+    });
+
+    it('heartbeats while a task is running', async () => {
+        const groupKey = nanoid();
+        const task = await immediate(scheduler, { groupKey });
+        const heartbeat = vi.spyOn(scheduler, 'heartbeat');
+
+        worker = new SchedulerWorker({
+            scheduler,
+            pollIntervalMs: 20,
+            handlers: [
+                {
+                    groupKeyPattern: groupKey,
+                    limit: 1,
+                    heartbeatIntervalMs: 30,
+                    handle: async () => {
+                        await setTimeout(120);
+                        return { output: { ok: true } };
+                    }
+                }
+            ]
+        });
+        worker.start();
+
+        await waitForTaskState(scheduler, task.id, 'SUCCEEDED');
+
+        expect(heartbeat).toHaveBeenCalledWith({ taskId: task.id });
+    });
+
+    it('routes abort tasks to handleAbort', async () => {
+        const groupKey = nanoid();
+        const task = await immediate(scheduler, { groupKey });
+        (await scheduler.cancel({ taskId: task.id, reason: 'cancelled by test' })).unwrap();
+        const abortTask = await waitForAbortTask(scheduler, groupKey);
+        const handle = vi.fn(() => Promise.resolve({ output: { regular: true } }));
+        const handleAbort = vi.fn(() => Promise.resolve({ output: { aborted: true } }));
+
+        worker = new SchedulerWorker({
+            scheduler,
+            pollIntervalMs: 20,
+            handlers: [
+                {
+                    groupKeyPattern: groupKey,
+                    limit: 1,
+                    handle,
+                    handleAbort
+                }
+            ]
+        });
+        worker.start();
+
+        const succeeded = await waitForTaskState(scheduler, abortTask.id, 'SUCCEEDED');
+
+        expect(succeeded.output).toEqual({ aborted: true });
+        expect(handle).not.toHaveBeenCalled();
+        expect(handleAbort).toHaveBeenCalledWith(expect.objectContaining({ id: abortTask.id }));
+    });
+
+    it('completes abort tasks when no handleAbort is registered', async () => {
+        const groupKey = nanoid();
+        const task = await immediate(scheduler, { groupKey });
+        (await scheduler.cancel({ taskId: task.id, reason: 'cancelled by test' })).unwrap();
+        const abortTask = await waitForAbortTask(scheduler, groupKey);
+        const handle = vi.fn(() => Promise.resolve({ output: { regular: true } }));
+
+        worker = new SchedulerWorker({
+            scheduler,
+            pollIntervalMs: 20,
+            handlers: [
+                {
+                    groupKeyPattern: groupKey,
+                    limit: 1,
+                    handle
+                }
+            ]
+        });
+        worker.start();
+
+        const succeeded = await waitForTaskState(scheduler, abortTask.id, 'SUCCEEDED');
+
+        expect(succeeded.output).toBeNull();
+        expect(handle).not.toHaveBeenCalled();
+    });
+
+    it('stops polling when stopped', async () => {
+        const dequeue = vi.spyOn(scheduler, 'dequeue');
+        worker = new SchedulerWorker({
+            scheduler,
+            pollIntervalMs: 20,
+            handlers: [
+                {
+                    groupKeyPattern: nanoid(),
+                    limit: 1,
+                    handle: () => Promise.resolve({ output: {} })
+                }
+            ]
+        });
+
+        worker.start();
+        await waitFor(() => dequeue.mock.calls.length > 0);
+        await worker.stop();
+
+        const callCountAfterStop = dequeue.mock.calls.length;
+        await setTimeout(80);
+
+        expect(dequeue).toHaveBeenCalledTimes(callCountAfterStop);
+    });
+});
+
+function uniqueSchemaName(prefix: string): string {
+    return `${prefix}_${randomUUID().replaceAll('-', '')}`;
+}
+
+async function immediate(scheduler: Scheduler, overrides: Partial<Parameters<Scheduler['immediate']>[0]> = {}): Promise<Task> {
+    return (
+        await scheduler.immediate({
+            name: nanoid(),
+            payload: {},
+            groupKey: nanoid(),
+            groupMaxConcurrency: 0,
+            retryMax: 0,
+            retryCount: 0,
+            createdToStartedTimeoutSecs: 3600,
+            startedToCompletedTimeoutSecs: 3600,
+            heartbeatTimeoutSecs: 600,
+            ownerKey: null,
+            retryKey: null,
+            ...overrides
+        })
+    ).unwrap();
+}
+
+async function waitForTaskState(scheduler: Scheduler, taskId: string, state: Task['state']): Promise<Task> {
+    let lastTask: Task | undefined;
+    await waitFor(async () => {
+        lastTask = (await scheduler.get({ taskId })).unwrap();
+        return lastTask.state === state;
+    }, `Timed out waiting for task ${taskId} to reach ${state}`);
+
+    return lastTask!;
+}
+
+async function waitForAbortTask(scheduler: Scheduler, groupKey: string): Promise<Task> {
+    let abortTask: Task | undefined;
+    await waitFor(async () => {
+        const tasks = (await scheduler.searchTasks({ groupKey, limit: 10 })).unwrap();
+        abortTask = tasks.find((task) => task.payload['type'] === 'abort');
+        return abortTask !== undefined;
+    }, `Timed out waiting for abort task in group ${groupKey}`);
+
+    return abortTask!;
+}
+
+async function waitFor(predicate: () => boolean | Promise<boolean>, message = 'Timed out waiting for predicate'): Promise<void> {
+    const started = Date.now();
+    while (Date.now() - started < 3000) {
+        if (await predicate()) {
+            return;
+        }
+        await setTimeout(25);
+    }
+
+    throw new Error(message);
+}

--- a/packages/scheduler/lib/worker.ts
+++ b/packages/scheduler/lib/worker.ts
@@ -1,0 +1,211 @@
+import { setTimeout } from 'node:timers/promises';
+
+import { stringifyError } from '@nangohq/utils';
+
+import type { Scheduler } from './scheduler.js';
+import type { Task } from './types.js';
+import type { JsonObject, JsonValue } from 'type-fest';
+
+export interface SchedulerWorkerHandlerResult {
+    output: JsonValue;
+}
+
+export interface SchedulerWorkerHandler {
+    groupKeyPattern: string;
+    limit: number;
+    heartbeatIntervalMs?: number;
+    toFailureOutput?: (err: unknown, task: Task) => JsonValue;
+    handle: (task: Task) => Promise<SchedulerWorkerHandlerResult>;
+    handleAbort?: (task: Task) => Promise<SchedulerWorkerHandlerResult>;
+}
+
+export interface SchedulerWorkerErrorContext {
+    phase: 'dequeue' | 'handle' | 'handleAbort' | 'heartbeat' | 'succeed' | 'fail';
+    groupKeyPattern: string;
+    task?: Task | undefined;
+}
+
+export interface SchedulerWorkerOptions {
+    scheduler: Scheduler;
+    handlers: SchedulerWorkerHandler[];
+    pollIntervalMs?: number;
+    onError?: (err: Error, context: SchedulerWorkerErrorContext) => void;
+}
+
+const defaultPollIntervalMs = 1000;
+const defaultHeartbeatIntervalMs = 10_000;
+
+export class SchedulerWorker {
+    private readonly scheduler: Scheduler;
+    private readonly handlers: SchedulerWorkerHandler[];
+    private readonly pollIntervalMs: number;
+    private readonly onError: (err: Error, context: SchedulerWorkerErrorContext) => void;
+    private ac = new AbortController();
+    private stopped = true;
+    private loopPromises: Promise<void>[] = [];
+
+    constructor({ scheduler, handlers, pollIntervalMs = defaultPollIntervalMs, onError = () => {} }: SchedulerWorkerOptions) {
+        this.scheduler = scheduler;
+        this.handlers = handlers;
+        this.pollIntervalMs = pollIntervalMs;
+        this.onError = onError;
+    }
+
+    start(): void {
+        if (!this.stopped) {
+            return;
+        }
+
+        this.stopped = false;
+        this.ac = new AbortController();
+        this.loopPromises = this.handlers.map((handler) => this.loop(handler));
+    }
+
+    async stop(): Promise<void> {
+        if (this.stopped) {
+            return;
+        }
+
+        this.stopped = true;
+        this.ac.abort();
+        await Promise.allSettled(this.loopPromises);
+    }
+
+    private async loop(handler: SchedulerWorkerHandler): Promise<void> {
+        while (!this.stopped) {
+            try {
+                const dequeued = await this.scheduler.dequeue({ groupKeyPattern: handler.groupKeyPattern, limit: handler.limit });
+                if (dequeued.isErr()) {
+                    this.reportError(dequeued.error, { phase: 'dequeue', groupKeyPattern: handler.groupKeyPattern });
+                    await this.sleep(this.pollIntervalMs);
+                    continue;
+                }
+
+                if (dequeued.value.length === 0) {
+                    await this.sleep(this.pollIntervalMs);
+                    continue;
+                }
+
+                await Promise.allSettled(dequeued.value.map((task) => this.runTask(handler, task)));
+            } catch (err) {
+                this.reportError(err, { phase: 'dequeue', groupKeyPattern: handler.groupKeyPattern });
+                await this.sleep(this.pollIntervalMs);
+            }
+        }
+    }
+
+    private async runTask(handler: SchedulerWorkerHandler, task: Task): Promise<void> {
+        const stopHeartbeat = this.startHeartbeat(handler, task);
+        const phase = isAbortTask(task) ? 'handleAbort' : 'handle';
+        try {
+            const result = await this.handleTask(handler, task);
+            await this.succeedTask(handler, task, result.output);
+        } catch (err) {
+            this.reportError(err, { phase, groupKeyPattern: handler.groupKeyPattern, task });
+            await this.failTask(handler, task, err);
+        } finally {
+            stopHeartbeat();
+        }
+    }
+
+    private async handleTask(handler: SchedulerWorkerHandler, task: Task): Promise<SchedulerWorkerHandlerResult> {
+        if (!isAbortTask(task)) {
+            return await handler.handle(task);
+        }
+
+        if (!handler.handleAbort) {
+            return { output: null };
+        }
+
+        return await handler.handleAbort(task);
+    }
+
+    private async succeedTask(handler: SchedulerWorkerHandler, task: Task, output: JsonValue): Promise<void> {
+        try {
+            const succeeded = await this.scheduler.succeed({ taskId: task.id, output });
+            if (succeeded.isErr()) {
+                this.reportError(succeeded.error, { phase: 'succeed', groupKeyPattern: handler.groupKeyPattern, task });
+            }
+        } catch (err) {
+            this.reportError(err, { phase: 'succeed', groupKeyPattern: handler.groupKeyPattern, task });
+        }
+    }
+
+    private async failTask(handler: SchedulerWorkerHandler, task: Task, err: unknown): Promise<void> {
+        try {
+            const failed = await this.scheduler.fail({ taskId: task.id, error: handler.toFailureOutput?.(err, task) ?? toTaskError(err) });
+            if (failed.isErr()) {
+                this.reportError(failed.error, { phase: 'fail', groupKeyPattern: handler.groupKeyPattern, task });
+            }
+        } catch (failErr) {
+            this.reportError(failErr, { phase: 'fail', groupKeyPattern: handler.groupKeyPattern, task });
+        }
+    }
+
+    private startHeartbeat(handler: SchedulerWorkerHandler, task: Task): () => void {
+        const intervalMs = handler.heartbeatIntervalMs ?? defaultHeartbeatIntervalMs;
+        let inFlight = false;
+        const interval = setInterval(() => {
+            if (inFlight || this.stopped) {
+                return;
+            }
+            inFlight = true;
+            void this.scheduler
+                .heartbeat({ taskId: task.id })
+                .then((res) => {
+                    if (res.isErr()) {
+                        this.reportError(res.error, { phase: 'heartbeat', groupKeyPattern: handler.groupKeyPattern, task });
+                    }
+                })
+                .catch((err: unknown) => {
+                    this.reportError(err, { phase: 'heartbeat', groupKeyPattern: handler.groupKeyPattern, task });
+                })
+                .finally(() => {
+                    inFlight = false;
+                });
+        }, intervalMs);
+
+        return () => clearInterval(interval);
+    }
+
+    private async sleep(ms: number): Promise<void> {
+        try {
+            await setTimeout(ms, undefined, { signal: this.ac.signal });
+        } catch (err) {
+            if (!isAbortError(err)) {
+                throw err;
+            }
+        }
+    }
+
+    private reportError(err: unknown, context: SchedulerWorkerErrorContext): void {
+        try {
+            this.onError(toError(err), context);
+        } catch {
+            // Worker error observers should not stop the worker loop.
+        }
+    }
+}
+
+function toTaskError(err: unknown): JsonObject {
+    return { message: toError(err).message };
+}
+
+function toError(err: unknown): Error {
+    if (err instanceof Error) {
+        return err;
+    }
+    if (typeof err === 'string') {
+        return new Error(err);
+    }
+
+    return new Error(stringifyError(err));
+}
+
+function isAbortError(err: unknown): boolean {
+    return err instanceof Error && err.name === 'AbortError';
+}
+
+function isAbortTask(task: Task): boolean {
+    return task.payload['type'] === 'abort';
+}

--- a/packages/server/lib/controllers/functions/dryrun/schedulerWorker.ts
+++ b/packages/server/lib/controllers/functions/dryrun/schedulerWorker.ts
@@ -1,0 +1,174 @@
+import { randomUUID } from 'node:crypto';
+
+import { z } from 'zod';
+
+import { getRemoteFunctionNangoHost, invokeDryrun, parseDryrunSuccessOutput, remoteFunctionDryrunSandboxTimeoutMs } from '@nangohq/sandbox';
+import { SchedulerWorker } from '@nangohq/scheduler';
+
+import { remoteFunctionDryrunBodySchema } from '../validation.js';
+import { createDryrunSandboxApiKey, defaultFunctionName, toFunctionDryrunError } from './helpers.js';
+
+import type { ImmediateProps, Scheduler, SchedulerWorkerErrorContext, Task } from '@nangohq/scheduler';
+import type { FunctionDryrunBody } from '@nangohq/types';
+import type { JsonObject, JsonValue } from 'type-fest';
+
+export const dryrunSchedulerGroupKeyPrefix = 'dryrun';
+export const dryrunSchedulerGroupKeyPattern = `${dryrunSchedulerGroupKeyPrefix}:*`;
+export const dryrunSchedulerHeartbeatIntervalMs = 10_000;
+export const dryrunSchedulerHeartbeatTimeoutSecs = 60;
+
+const dryrunSchedulerTimeoutSecs = Math.ceil(remoteFunctionDryrunSandboxTimeoutMs / 1000);
+
+const dryrunSchedulerTaskPayloadSchema = z
+    .object({
+        environment_id: z.number().int().positive(),
+        environment_name: z.string().min(1),
+        parent_customer_key_id: z.number().int().positive(),
+        request: remoteFunctionDryrunBodySchema
+    })
+    .strict();
+
+export type DryrunSchedulerTaskPayload = z.infer<typeof dryrunSchedulerTaskPayloadSchema>;
+
+export interface CreateDryrunSchedulerWorkerOptions {
+    scheduler: Scheduler;
+    groupKeyPattern?: string;
+    limit?: number;
+    pollIntervalMs?: number;
+    heartbeatIntervalMs?: number;
+    onError?: (err: Error, context: SchedulerWorkerErrorContext) => void;
+}
+
+export interface DryrunSchedulerTaskPropsInput {
+    environment: {
+        id: number;
+        name: string;
+    };
+    parentCustomerKeyId: number;
+    body: FunctionDryrunBody;
+    groupMaxConcurrency?: number;
+}
+
+export function createDryrunSchedulerWorker({
+    scheduler,
+    groupKeyPattern = dryrunSchedulerGroupKeyPattern,
+    limit = 5,
+    pollIntervalMs,
+    heartbeatIntervalMs = dryrunSchedulerHeartbeatIntervalMs,
+    onError
+}: CreateDryrunSchedulerWorkerOptions): SchedulerWorker {
+    return new SchedulerWorker({
+        scheduler,
+        ...(pollIntervalMs !== undefined ? { pollIntervalMs } : {}),
+        ...(onError ? { onError } : {}),
+        handlers: [
+            {
+                groupKeyPattern,
+                limit,
+                heartbeatIntervalMs,
+                toFailureOutput: toDryrunFailureOutput,
+                handle: runDryrunSchedulerTask
+            }
+        ]
+    });
+}
+
+export function buildDryrunSchedulerTaskProps({
+    environment,
+    parentCustomerKeyId,
+    body,
+    groupMaxConcurrency = 0
+}: DryrunSchedulerTaskPropsInput): ImmediateProps {
+    return {
+        name: `${dryrunSchedulerGroupKey(environment.id)}:${randomUUID()}`,
+        payload: buildDryrunSchedulerTaskPayload({ environment, parentCustomerKeyId, body }),
+        groupKey: dryrunSchedulerGroupKey(environment.id),
+        groupMaxConcurrency,
+        retryMax: 0,
+        retryCount: 0,
+        createdToStartedTimeoutSecs: dryrunSchedulerTimeoutSecs,
+        startedToCompletedTimeoutSecs: dryrunSchedulerTimeoutSecs,
+        heartbeatTimeoutSecs: dryrunSchedulerHeartbeatTimeoutSecs,
+        ownerKey: null,
+        retryKey: null
+    };
+}
+
+export function dryrunSchedulerGroupKey(environmentId: number): string {
+    return `${dryrunSchedulerGroupKeyPrefix}:${environmentId}`;
+}
+
+async function runDryrunSchedulerTask(task: Task): Promise<{ output: JsonValue }> {
+    const payload = dryrunSchedulerTaskPayloadSchema.parse(task.payload);
+    const startedAt = Date.now();
+    const sandboxApiKey = await createDryrunSandboxApiKey(payload.parent_customer_key_id, payload.environment_id, task.id);
+    if (sandboxApiKey.isErr()) {
+        throw sandboxApiKey.error;
+    }
+
+    const request = payload.request;
+    const result = await invokeDryrun({
+        integration_id: request.integration_id,
+        function_name: request.function_name,
+        function_type: request.function_type,
+        code: request.code,
+        connection_id: request.connection_id,
+        environment_name: payload.environment_name,
+        nango_secret_key: sandboxApiKey.value,
+        nango_host: getRemoteFunctionNangoHost(),
+        ...(request.input !== undefined ? { input: request.input } : {}),
+        ...(request.metadata ? { metadata: request.metadata } : {}),
+        ...(request.checkpoint ? { checkpoint: request.checkpoint } : {}),
+        ...(request.last_sync_date ? { last_sync_date: request.last_sync_date } : {})
+    });
+
+    const dryrunOutput = parseDryrunSuccessOutput(result.output);
+
+    return {
+        output: toJsonObject({
+            status: 'success',
+            output: dryrunOutput.output,
+            duration_ms: Date.now() - startedAt,
+            has_result: dryrunOutput.hasResult,
+            ...(dryrunOutput.hasResult ? { result: toJsonValue(dryrunOutput.result) } : {})
+        })
+    };
+}
+
+function buildDryrunSchedulerTaskPayload({
+    environment,
+    parentCustomerKeyId,
+    body
+}: Pick<DryrunSchedulerTaskPropsInput, 'environment' | 'parentCustomerKeyId' | 'body'>): JsonObject {
+    return toJsonObject({
+        environment_id: environment.id,
+        environment_name: environment.name,
+        parent_customer_key_id: parentCustomerKeyId,
+        request: {
+            integration_id: body.integration_id,
+            function_name: defaultFunctionName,
+            function_type: body.function_type,
+            code: body.code,
+            connection_id: body.connection_id,
+            ...(body.input !== undefined ? { input: toJsonValue(body.input) } : {}),
+            ...(body.metadata ? { metadata: toJsonValue(body.metadata) } : {}),
+            ...(body.checkpoint ? { checkpoint: toJsonValue(body.checkpoint) } : {}),
+            ...(body.last_sync_date ? { last_sync_date: body.last_sync_date } : {})
+        }
+    });
+}
+
+function toDryrunFailureOutput(err: unknown): JsonObject {
+    return toJsonObject({
+        status: 'failed',
+        error: toJsonValue(toFunctionDryrunError(err))
+    });
+}
+
+function toJsonObject(value: Record<string, unknown>): JsonObject {
+    return toJsonValue(value) as JsonObject;
+}
+
+function toJsonValue(value: unknown): JsonValue {
+    return JSON.parse(JSON.stringify(value)) as JsonValue;
+}

--- a/packages/server/package.json
+++ b/packages/server/package.json
@@ -35,6 +35,7 @@
         "@nangohq/providers": "file:.../providers",
         "@nangohq/records": "file:../records",
         "@nangohq/sandbox": "file:../sandbox",
+        "@nangohq/scheduler": "file:../scheduler",
         "@nangohq/shared": "file:../shared",
         "@nangohq/utils": "file:../utils",
         "@nangohq/webhooks": "file:../webhooks",

--- a/packages/server/tsconfig.json
+++ b/packages/server/tsconfig.json
@@ -42,6 +42,9 @@
             "path": "../sandbox"
         },
         {
+            "path": "../scheduler"
+        },
+        {
             "path": "../orchestrator"
         },
         {


### PR DESCRIPTION
<!-- Describe the problem and your solution -->

This prepares the scheduler package for server-owned workers and shows how dryruns can migrate onto scheduler tasks.
It adds a generic SchedulerWorker with handler registration, heartbeat support, failure output mapping, and default no-op completion for abort tasks without an abort handler.
It also adds a server dryrun worker example/task builder plus a short root sketch for team design discussion.

<!-- Issue ticket number and link (if applicable) -->