### PR TITLE
ci: serialize deploys per service and stage

### DIFF
--- a/.github/workflows/deploy.yaml
+++ b/.github/workflows/deploy.yaml
@@ -30,11 +30,12 @@ on:
                     - app_ui
                     - lambda
 
-# One deploy per stage at a time: UI deploys share an S3 bucket and backend deploys
-# share nango-values.yaml, so concurrent runs clobber each other. Queue the rest
-# (queue: max) without aborting in-flight syncs/pushes (cancel-in-progress: false).
+# One deploy per service+stage at a time. UI deploys `aws s3 sync --delete` into a
+# shared bucket, so two concurrent runs silently corrupt it (left the live app
+# pointing at a deleted bundle). Queue the rest (queue: max) without aborting an
+# in-flight sync (cancel-in-progress: false).
 concurrency:
-    group: deploy-${{ inputs.stage }}
+    group: deploy-${{ inputs.service }}-${{ inputs.stage }}
     cancel-in-progress: false
     queue: max
 

--- a/.github/workflows/deploy.yaml
+++ b/.github/workflows/deploy.yaml
@@ -30,6 +30,15 @@ on:
                     - app_ui
                     - lambda
 
+# Serialize deploys per service+stage. UI deploys `aws s3 sync --delete` into a
+# shared bucket; two concurrent runs delete each other's freshly-uploaded chunks
+# and interleave their index.html writes, leaving the live site pointing at a
+# bundle that no longer exists. Queue runs instead of cancelling so a half-finished
+# sync is never aborted mid-flight.
+concurrency:
+    group: deploy-${{ inputs.service }}-${{ inputs.stage }}
+    cancel-in-progress: false
+
 jobs:
     deploy_app_ui:
         if: inputs.service == 'app_ui'

--- a/.github/workflows/deploy.yaml
+++ b/.github/workflows/deploy.yaml
@@ -36,11 +36,14 @@ on:
 # stage clobber each other — deleting freshly-uploaded S3 chunks (which left the
 # live site pointing at a missing bundle) or losing a values-file push. Grouping by
 # stage rather than service+stage also covers the shared backend deploy job, where
-# different services contend on the same file. Queue runs instead of cancelling so a
-# half-finished sync or push is never aborted mid-flight.
+# different services contend on the same file. cancel-in-progress: false never
+# aborts a half-finished sync or push, and queue: max keeps every waiting deploy
+# pending (the default `single` would cancel an older pending run when a newer one
+# is dispatched, silently dropping a deploy).
 concurrency:
     group: deploy-${{ inputs.stage }}
     cancel-in-progress: false
+    queue: max
 
 jobs:
     deploy_app_ui:

--- a/.github/workflows/deploy.yaml
+++ b/.github/workflows/deploy.yaml
@@ -30,16 +30,9 @@ on:
                     - app_ui
                     - lambda
 
-# Serialize deploys to the same stage. UI deploys `aws s3 sync --delete` into a
-# shared per-service bucket, and backend deploys all edit and push the same
-# apps/<stage>/nango-values.yaml in nango-environments. Two concurrent runs to one
-# stage clobber each other — deleting freshly-uploaded S3 chunks (which left the
-# live site pointing at a missing bundle) or losing a values-file push. Grouping by
-# stage rather than service+stage also covers the shared backend deploy job, where
-# different services contend on the same file. cancel-in-progress: false never
-# aborts a half-finished sync or push, and queue: max keeps every waiting deploy
-# pending (the default `single` would cancel an older pending run when a newer one
-# is dispatched, silently dropping a deploy).
+# One deploy per stage at a time: UI deploys share an S3 bucket and backend deploys
+# share nango-values.yaml, so concurrent runs clobber each other. Queue the rest
+# (queue: max) without aborting in-flight syncs/pushes (cancel-in-progress: false).
 concurrency:
     group: deploy-${{ inputs.stage }}
     cancel-in-progress: false

--- a/.github/workflows/deploy.yaml
+++ b/.github/workflows/deploy.yaml
@@ -30,13 +30,16 @@ on:
                     - app_ui
                     - lambda
 
-# Serialize deploys per service+stage. UI deploys `aws s3 sync --delete` into a
-# shared bucket; two concurrent runs delete each other's freshly-uploaded chunks
-# and interleave their index.html writes, leaving the live site pointing at a
-# bundle that no longer exists. Queue runs instead of cancelling so a half-finished
-# sync is never aborted mid-flight.
+# Serialize deploys to the same stage. UI deploys `aws s3 sync --delete` into a
+# shared per-service bucket, and backend deploys all edit and push the same
+# apps/<stage>/nango-values.yaml in nango-environments. Two concurrent runs to one
+# stage clobber each other — deleting freshly-uploaded S3 chunks (which left the
+# live site pointing at a missing bundle) or losing a values-file push. Grouping by
+# stage rather than service+stage also covers the shared backend deploy job, where
+# different services contend on the same file. Queue runs instead of cancelling so a
+# half-finished sync or push is never aborted mid-flight.
 concurrency:
-    group: deploy-${{ inputs.service }}-${{ inputs.stage }}
+    group: deploy-${{ inputs.stage }}
     cancel-in-progress: false
 
 jobs:


### PR DESCRIPTION
## Problem

`app-development.nango.dev` served a blank screen. Two `app_ui → development` deploys ran concurrently, both `aws s3 sync --delete` into the same bucket. Each run's `--delete` removed the other's freshly-uploaded chunks, and their `index.html` uploads raced — the surviving `index.html` pointed at a JS bundle the other run had already deleted. The browser got CloudFront's HTML fallback instead of JavaScript, so React never mounted.

Nothing serializes deploys to the same target, so staging and production are exposed too.

## Solution

Add a workflow-level `concurrency` block so only one deploy per service+stage runs at a time:

```yaml
concurrency:
    group: deploy-${{ inputs.service }}-${{ inputs.stage }}
    cancel-in-progress: false
    queue: max
```

- **`group`** — two `app_ui → production` runs queue; `app_ui` and `connect_ui` (separate buckets) still run in parallel.
- **`cancel-in-progress: false`** — never abort a half-finished sync.
- **`queue: max`** — keep all waiting deploys pending; the default `single` cancels the older pending run, silently dropping a deploy.

Fixes [NAN-5821](https://linear.app/nango/issue/NAN-5821)

## Testing

Triggered two `app_ui → development` deploys ~16s apart. Run #2 stayed `pending` for the ~2.5 min Run #1 ran, then started only once Run #1 finished. The live site then resolved its bundle correctly and the login page rendered.

- Run 1: https://github.com/NangoHQ/nango/actions/runs/26822315078
- Run 2: https://github.com/NangoHQ/nango/actions/runs/26822333073
