### PR TITLE
feat(records_seen): swap sync_job_id to bigint, drop the int4 column (NAN-5491 Phase 2c)

### DIFF
--- a/packages/records/lib/stores/postgres/migrations/20260601120000_records_seen_swap_sync_job_id.ts
+++ b/packages/records/lib/stores/postgres/migrations/20260601120000_records_seen_swap_sync_job_id.ts
@@ -1,0 +1,22 @@
+import type { Knex } from 'knex';
+
+const TABLE = 'records_seen';
+
+// Step 3 of the online int4 -> bigint widening of records_seen.sync_job_id: swap the new column
+// in and drop the old one. Must NOT run until ≥48h after BOTH Phase 2a (column + mirror trigger)
+// AND Phase 2b (ensureSeenPartition creating the child index on new partitions) have been
+// deployed, so the daily-partition turnover has filled sync_job_id_new for every live row AND
+// every live partition has the (connection_id, model, sync_job_id_new) index.
+// Single transaction of metadata-only DDL — short ACCESS EXCLUSIVE window.
+export async function up(knex: Knex): Promise<void> {
+    await knex.raw(`SET LOCAL lock_timeout = '3s'`);
+    await knex.raw(`DROP TRIGGER IF EXISTS records_seen_mirror_sync_job_id_trigger ON "${TABLE}"`);
+    await knex.raw(`DROP FUNCTION IF EXISTS records_seen_mirror_sync_job_id()`);
+    // Dropping the old column cascades the old parent partitioned index + its auto-attached
+    // child indexes. The orphan per-partition indexes on sync_job_id_new (created by
+    // ensureSeenPartition in Phase 2b) survive — their column reference follows the rename.
+    await knex.raw(`ALTER TABLE "${TABLE}" DROP COLUMN sync_job_id`);
+    await knex.raw(`ALTER TABLE "${TABLE}" RENAME COLUMN sync_job_id_new TO sync_job_id`);
+}
+
+export async function down(): Promise<void> {}

--- a/packages/records/lib/stores/postgres/postgres.integration.test.ts
+++ b/packages/records/lib/stores/postgres/postgres.integration.test.ts
@@ -2150,7 +2150,10 @@ describe('PostgresStore', () => {
             expect(res2.isOk()).toBe(true);
         });
 
-        it('should create the sync_job_id_new child index on the new partition', async () => {
+        // Test schema on this branch already has the Phase 2c swap applied (the migration
+        // is part of this PR), so sync_job_id_new no longer exists by the time tests run.
+        // Exercises the EAFP fallback path naturally — no in-test schema simulation needed.
+        it('should create the sync_job_id child index on the new partition (post-Phase-2c)', async () => {
             const date = new Date('2025-01-17T00:00:00Z');
             const res = await store.ensureSeenPartition({ date });
             expect(res.isOk()).toBe(true);
@@ -2161,29 +2164,6 @@ describe('PostgresStore', () => {
                  JOIN pg_class c ON c.oid = i.indexrelid
                  WHERE c.relname = ?`,
                 ['records_seen_20250117_connection_model_job_new']
-            );
-            expect(rows).toHaveLength(1);
-            expect(rows[0]?.indisvalid).toBe(true);
-            expect(rows[0]?.indexdef).toMatch(/\(connection_id, model, sync_job_id_new\)/);
-        });
-
-        // Must run last in this describe — it leaves the schema in the post-Phase-2c state.
-        it('should fall back to sync_job_id after the shadow column has been renamed away (Phase 2c)', async () => {
-            await db.raw(`DROP TRIGGER IF EXISTS records_seen_mirror_sync_job_id_trigger ON nango_records.records_seen`);
-            await db.raw(`DROP FUNCTION IF EXISTS nango_records.records_seen_mirror_sync_job_id()`);
-            await db.raw(`ALTER TABLE nango_records.records_seen DROP COLUMN sync_job_id`);
-            await db.raw(`ALTER TABLE nango_records.records_seen RENAME COLUMN sync_job_id_new TO sync_job_id`);
-
-            const date = new Date('2025-01-18T00:00:00Z');
-            const res = await store.ensureSeenPartition({ date });
-            expect(res.isOk()).toBe(true);
-
-            const { rows } = await db.raw<{ rows: { indexdef: string; indisvalid: boolean }[] }>(
-                `SELECT pg_get_indexdef(i.indexrelid) AS indexdef, i.indisvalid
-                 FROM pg_index i
-                 JOIN pg_class c ON c.oid = i.indexrelid
-                 WHERE c.relname = ?`,
-                ['records_seen_20250118_connection_model_job_new']
             );
             expect(rows).toHaveLength(1);
             expect(rows[0]?.indisvalid).toBe(true);

--- a/packages/records/lib/stores/postgres/postgres.integration.test.ts
+++ b/packages/records/lib/stores/postgres/postgres.integration.test.ts
@@ -2150,7 +2150,7 @@ describe('PostgresStore', () => {
             expect(res2.isOk()).toBe(true);
         });
 
-        it('should create the sync_job_id child index on the new partition', async () => {
+        it('should create the sync_job_id_new child index on the new partition', async () => {
             const date = new Date('2025-01-17T00:00:00Z');
             const res = await store.ensureSeenPartition({ date });
             expect(res.isOk()).toBe(true);
@@ -2160,11 +2160,11 @@ describe('PostgresStore', () => {
                  FROM pg_index i
                  JOIN pg_class c ON c.oid = i.indexrelid
                  WHERE c.relname = ?`,
-                ['records_seen_20250117_connection_model_job']
+                ['records_seen_20250117_connection_model_job_new']
             );
             expect(rows).toHaveLength(1);
             expect(rows[0]?.indisvalid).toBe(true);
-            expect(rows[0]?.indexdef).toMatch(/\(connection_id, model, sync_job_id\)/);
+            expect(rows[0]?.indexdef).toMatch(/\(connection_id, model, sync_job_id_new\)/);
         });
     });
 

--- a/packages/records/lib/stores/postgres/postgres.integration.test.ts
+++ b/packages/records/lib/stores/postgres/postgres.integration.test.ts
@@ -2150,7 +2150,7 @@ describe('PostgresStore', () => {
             expect(res2.isOk()).toBe(true);
         });
 
-        it('should create the sync_job_id_new child index on the new partition', async () => {
+        it('should create the sync_job_id child index on the new partition', async () => {
             const date = new Date('2025-01-17T00:00:00Z');
             const res = await store.ensureSeenPartition({ date });
             expect(res.isOk()).toBe(true);
@@ -2160,11 +2160,11 @@ describe('PostgresStore', () => {
                  FROM pg_index i
                  JOIN pg_class c ON c.oid = i.indexrelid
                  WHERE c.relname = ?`,
-                ['records_seen_20250117_connection_model_job_new']
+                ['records_seen_20250117_connection_model_job']
             );
             expect(rows).toHaveLength(1);
             expect(rows[0]?.indisvalid).toBe(true);
-            expect(rows[0]?.indexdef).toMatch(/\(connection_id, model, sync_job_id_new\)/);
+            expect(rows[0]?.indexdef).toMatch(/\(connection_id, model, sync_job_id\)/);
         });
     });
 

--- a/packages/records/lib/stores/postgres/postgres.ts
+++ b/packages/records/lib/stores/postgres/postgres.ts
@@ -125,18 +125,19 @@ export class PostgresStore implements RecordsStore {
             if (!promise) {
                 const next = day.add(1, 'day');
                 const partitionName = `records_seen_${suffix}`;
-                const indexName = `${partitionName}_connection_model_job`;
+                const indexName = `${partitionName}_connection_model_job_new`;
                 // Two separate statements (not a single transaction) so the parent's
                 // ACCESS EXCLUSIVE from CREATE TABLE PARTITION OF is released before the
                 // child CREATE INDEX runs. Wrapping both in a transaction would hold the
                 // parent lock across both, briefly blocking every records_seen reader/writer.
-                // A failure between the two leaves a partition without its index — recoverable
-                // via IF NOT EXISTS on retry.
+                // A failure between the two leaves a partition without its index — benign
+                // pre-swap (no query uses the new index yet), recoverable via IF NOT EXISTS
+                // on retry, and caught by Phase 2c's pre-deploy index-coverage gate.
                 promise = this.db
                     .raw(
                         `CREATE TABLE IF NOT EXISTS "${partitionName}" PARTITION OF "${RECORDS_SEEN_TABLE}" FOR VALUES FROM ('${day.toISOString()}') TO ('${next.toISOString()}')`
                     )
-                    .then(() => this.db.raw('CREATE INDEX IF NOT EXISTS ?? ON ?? (connection_id, model, sync_job_id)', [indexName, partitionName]))
+                    .then(() => this.db.raw('CREATE INDEX IF NOT EXISTS ?? ON ?? (connection_id, model, sync_job_id_new)', [indexName, partitionName]))
                     .then(() => undefined);
                 this.seenPartitionPromises.set(suffix, promise);
             }

--- a/packages/records/lib/stores/postgres/postgres.ts
+++ b/packages/records/lib/stores/postgres/postgres.ts
@@ -125,19 +125,18 @@ export class PostgresStore implements RecordsStore {
             if (!promise) {
                 const next = day.add(1, 'day');
                 const partitionName = `records_seen_${suffix}`;
-                const indexName = `${partitionName}_connection_model_job_new`;
+                const indexName = `${partitionName}_connection_model_job`;
                 // Two separate statements (not a single transaction) so the parent's
                 // ACCESS EXCLUSIVE from CREATE TABLE PARTITION OF is released before the
                 // child CREATE INDEX runs. Wrapping both in a transaction would hold the
                 // parent lock across both, briefly blocking every records_seen reader/writer.
-                // A failure between the two leaves a partition without its index — benign
-                // pre-swap (no query uses the new index yet), recoverable via IF NOT EXISTS
-                // on retry, and caught by Phase 2c's pre-deploy index-coverage gate.
+                // A failure between the two leaves a partition without its index — recoverable
+                // via IF NOT EXISTS on retry.
                 promise = this.db
                     .raw(
                         `CREATE TABLE IF NOT EXISTS "${partitionName}" PARTITION OF "${RECORDS_SEEN_TABLE}" FOR VALUES FROM ('${day.toISOString()}') TO ('${next.toISOString()}')`
                     )
-                    .then(() => this.db.raw('CREATE INDEX IF NOT EXISTS ?? ON ?? (connection_id, model, sync_job_id_new)', [indexName, partitionName]))
+                    .then(() => this.db.raw('CREATE INDEX IF NOT EXISTS ?? ON ?? (connection_id, model, sync_job_id)', [indexName, partitionName]))
                     .then(() => undefined);
                 this.seenPartitionPromises.set(suffix, promise);
             }


### PR DESCRIPTION
To be merged after https://github.com/NangoHQ/nango/pull/6318 and after waiting 3 days!

- Drops the old `int4 sync_job_id` column (which cascades the old parent partitioned index and its auto-attached children) and renames `sync_job_id_new (bigint)` to `sync_job_id`. Final step of the int4→bigint widening of `records_seen.sync_job_id` (Phase 2a is #6304, Phase 2b is #6318). Must not deploy until ≥48h after **both** 2a and 2b are live in production, so the daily-partition turnover has filled `sync_job_id_new` for every live row AND every live partition has the `(connection_id, model, sync_job_id_new)` index (created inline by `ensureSeenPartition` in 2b).
- Updates `ensureSeenPartition` to reference the post-swap canonical column name (`sync_job_id`) so partitions created after the swap don't try to `CREATE INDEX … (sync_job_id_new)` against a column that no longer exists. Also drops the `_new` suffix from new partitions' child-index names so post-swap partitions are born with clean names.

## Why the new column is left nullable

The original `sync_job_id` was `NOT NULL`; the rebuilt one is left nullable. Restoring `NOT NULL` requires `ALTER TABLE … SET NOT NULL`, which scans the entire table under `ACCESS EXCLUSIVE` — blocking every writer for the scan duration, with no reliable bound on cost on a hot partitioned table. The CHECK-constraint trick (`ADD CONSTRAINT … NOT VALID` + `VALIDATE CONSTRAINT`) avoids the exclusive lock but still pays the full scan cost under `SHARE UPDATE EXCLUSIVE`. In practice every writer always supplies `sync_job_id`, and the 48h partition rotation means any accidental NULL would age out within two days — so we accept the relaxed schema. If we later want the guarantee back, it can be added safely via the CHECK dance outside any swap window.

## Rolling-deploy note

The migration runs on persist startup, before the daemon. During a rolling deploy of this PR:

- The first new persist instance applies the migration → column renamed → daemons in this instance use the new code path (`sync_job_id`) → succeed.
- Old persist instances still running the 2b code path (`sync_job_id_new`) will fail any cache-missing `ensureSeenPartition` call after the migration applies, because the column no longer exists by that name. The in-process `seenPartitionPromises` cache means today's partition (already created) isn't re-attempted, so insertions on today's partition continue to work. Tomorrow's pre-create attempts on old instances will log errors but the new instance's daemon picks up the work — by the time tomorrow's partition is actually needed, the new instance has created it.

Net impact: brief noise in old-instance logs during the rolling deploy window; no data loss, no insert failure.

## Pre-deploy operator gates (run in every env before this migration)

Drop the old column irreversibly — these are **hard gates, fail-closed.** Both must pass; see Linear `fc55523e` appendix for full SQL.

- **Gate 1**: every `records_seen` partition has a valid index on `(connection_id, model, sync_job_id_new)`. Zero rows from the gate query.
- **Gate 3**: `SELECT EXISTS (... sync_job_id_new IS NULL)` returns `f`.

(Gate 2 — parent `indisvalid` — no longer applies with the new 2b shape.)

## Test plan

- [x] Local: ran 2a → 2b (`ensureSeenPartition` inline index) → 2c sequence against fresh schema; old `sync_job_id (int4)` dropped, new `sync_job_id (bigint, nullable)` in place; trigger and function gone; orphan per-partition indexes survive the column rename and correctly index the renamed column.
- [x] Updated integration test asserts a newly-created partition (post-swap schema) has a valid `(connection_id, model, sync_job_id)` index named `<partition>_connection_model_job`.
- [x] Confirmed swap is purely metadata DDL (no scans, no `SET NOT NULL`) — `ACCESS EXCLUSIVE` window measured in microseconds.
- [ ] Staging: deploy ≥48h after both 2a and 2b; run the two gate queries; verify `\d nango_records.records_seen` shows `sync_job_id bigint` and the trigger is gone.
- [ ] Production: deploy ≥48h after both 2a and 2b in prod.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
