### PR TITLE
feat(usage): shadow ClickHouse against Orb for /plans/billing-usage

### DIFF
--- a/packages/usage/lib/billing.ts
+++ b/packages/usage/lib/billing.ts
@@ -4,7 +4,7 @@ import { RateLimiterQueue, RateLimiterRedis, RateLimiterRes } from 'rate-limiter
 import { stringify as stableStringify } from 'safe-stable-stringify';
 
 import { billing } from '@nangohq/billing';
-import { Ok, metrics } from '@nangohq/utils';
+import { Err, Ok, metrics } from '@nangohq/utils';
 
 import { envs } from './env.js';
 
@@ -32,14 +32,17 @@ export class UsageBillingClient {
         this.billingClient = billing;
     }
 
-    public async getUsage(subscriptionId: string, opts?: GetBillingUsageOpts): Promise<Result<BillingUsageMetrics>> {
+    // `fromCache` is exposed so the caller can fire a shadow-CH comparison
+    // only on misses. Temporary — revert to plain `Result<BillingUsageMetrics>`
+    // once the shadow path is removed.
+    public async getUsage(subscriptionId: string, opts?: GetBillingUsageOpts): Promise<Result<{ value: BillingUsageMetrics; fromCache: boolean }>> {
         const cacheKey = this.getCacheKey(subscriptionId, opts);
         const cached = await this.redis.get(cacheKey);
         if (cached) {
             try {
                 const parsed: BillingUsageMetrics = JSON.parse(cached);
                 metrics.increment(metrics.Types.BILLING_USAGE_CACHE, 1, { hit: 'true' });
-                return Ok(parsed);
+                return Ok({ value: parsed, fromCache: true });
             } catch {
                 // ignore parse errors and proceed to fetch from API
             }
@@ -62,10 +65,10 @@ export class UsageBillingClient {
                 } catch {
                     // ignore cache set errors
                 }
-            } else {
-                metrics.increment(metrics.Types.BILLING_USAGE_ORB_ERRORS, 1, tags);
+                return Ok({ value: res.value, fromCache: false });
             }
-            return res;
+            metrics.increment(metrics.Types.BILLING_USAGE_ORB_ERRORS, 1, tags);
+            return Err(res.error);
         });
     }
 

--- a/packages/usage/lib/clickhouse/clickhouse.query.ts
+++ b/packages/usage/lib/clickhouse/clickhouse.query.ts
@@ -44,6 +44,10 @@ export type GetDailyCounterQuery = {
         // Optional top-N breakdown size when `dimension !== 'none'`. Defaults
         // to TOP_N_BREAKDOWN_DEFAULT, clamped server-side to TOP_N_BREAKDOWN_CAP.
         top?: number;
+        // Override CH `max_execution_time` for this query. Defaults to the
+        // dashboard ceiling; callers that race against a shorter wall-clock
+        // (e.g. shadow path) set this to align server-side cancellation.
+        maxExecutionSeconds?: number;
         timeframe: {
             // exclusive end (timeframe includes events with timestamp >= start and < end)
             start: Date;
@@ -117,6 +121,8 @@ export type GetDailySumAndBatchesQuery = {
         metric: M;
         dimension: DimensionFor<M>;
         top?: number;
+        // Override CH `max_execution_time` (see GetDailyCounterQuery).
+        maxExecutionSeconds?: number;
         timeframe: { start: Date; end: Date };
     };
 }[AvgUsageMetric];

--- a/packages/usage/lib/clickhouse/clickhouse.ts
+++ b/packages/usage/lib/clickhouse/clickhouse.ts
@@ -115,7 +115,7 @@ export class Clickhouse {
             return Err(new Error('Clickhouse client not initialized'));
         }
 
-        const { accountId, metric, dimension, timeframe } = query;
+        const { accountId, metric, dimension, timeframe, maxExecutionSeconds } = query;
         if (!isAllowedDimensionFor(metric, dimension)) {
             return Err(new Error(`Invalid dimension ${JSON.stringify(dimension)} for metric ${JSON.stringify(metric)}`));
         }
@@ -167,7 +167,7 @@ export class Clickhouse {
             const res = await this.client.query({
                 query: sql,
                 format: 'JSONEachRow',
-                clickhouse_settings: { max_execution_time: READ_QUERY_MAX_EXECUTION_SECONDS }
+                clickhouse_settings: { max_execution_time: maxExecutionSeconds ?? READ_QUERY_MAX_EXECUTION_SECONDS }
             });
             const rows = await res.json<{
                 day: string;
@@ -263,7 +263,7 @@ export class Clickhouse {
         if (!this.client) {
             return Err(new Error('Clickhouse client not initialized'));
         }
-        const { accountId, metric, dimension, timeframe } = query;
+        const { accountId, metric, dimension, timeframe, maxExecutionSeconds } = query;
         if (!isAllowedDimensionFor(metric, dimension)) {
             return Err(new Error(`Invalid dimension ${JSON.stringify(dimension)} for metric ${JSON.stringify(metric)}`));
         }
@@ -331,7 +331,7 @@ export class Clickhouse {
             const res = await this.client.query({
                 query: sql,
                 format: 'JSONEachRow',
-                clickhouse_settings: { max_execution_time: READ_QUERY_MAX_EXECUTION_SECONDS }
+                clickhouse_settings: { max_execution_time: maxExecutionSeconds ?? READ_QUERY_MAX_EXECUTION_SECONDS }
             });
             const rows = await res.json<{
                 day: string;

--- a/packages/usage/lib/usage.ts
+++ b/packages/usage/lib/usage.ts
@@ -344,12 +344,16 @@ export class UsageTracker implements IUsageTracker {
         metrics.distribution(metrics.Types.BILLING_USAGE_SHADOW_DURATION_MS, elapsedMs, { outcome });
         if (chResult.isErr()) return;
 
+        // Iterate the complete metric set (not just one side's keys) and
+        // coerce `undefined` to 0 — a metric absent from either response is
+        // what the customer sees as 0 on the dashboard, so it must count
+        // toward the one-sided signal when only one side has data.
         // One-sided emits a separate counter rather than divergence=1.0 so
         // missing-data spikes don't drown out the continuous-divergence p99.
-        for (const metric of Object.keys(orbResult) as UsageMetric[]) {
-            const orbTotal = orbResult[metric]?.total;
-            const chTotal = chResult.value[metric]?.total;
-            if (orbTotal === undefined || chTotal === undefined) continue;
+        const allMetrics: UsageMetric[] = [...COUNTER_METRICS, ...AVG_METRICS];
+        for (const metric of allMetrics) {
+            const orbTotal = orbResult[metric]?.total ?? 0;
+            const chTotal = chResult.value[metric]?.total ?? 0;
             if (orbTotal === 0 && chTotal === 0) continue;
             if (orbTotal === 0 || chTotal === 0) {
                 const zeroSide = orbTotal === 0 ? 'orb' : 'ch';

--- a/packages/usage/lib/usage.ts
+++ b/packages/usage/lib/usage.ts
@@ -293,7 +293,10 @@ export class UsageTracker implements IUsageTracker {
         };
 
         if (!billingUsageMetrics.value.fromCache && shouldShadow(opts)) {
-            void this.shadowAgainstClickhouse({ accountId, timeframe: opts.timeframe, orbResult: formatted }).catch((err: unknown) => {
+            // Pass raw Orb (pre-`toCumulativeUsage`) so the AVG-metric
+            // comparison isn't biased by the formatter's `Math.floor` — both
+            // sides are floats, true apples-to-apples.
+            void this.shadowAgainstClickhouse({ accountId, timeframe: opts.timeframe, orbResult: orbValue }).catch((err: unknown) => {
                 logger.error(`billing-usage shadow failed: ${stringifyError(err)}`);
             });
         }

--- a/packages/usage/lib/usage.ts
+++ b/packages/usage/lib/usage.ts
@@ -30,7 +30,14 @@ const cacheKeyPrefix = 'usageV2';
 // windows against Orb produces known-bad divergence (CH biases high until 30d
 // of depth). Anchor the shadow to a clean post-backfill date.
 const SHADOW_MIN_TIMEFRAME_START = new Date('2026-06-01T00:00:00.000Z');
-const SHADOW_TIMEOUT_MS = 5_000;
+// CH server-side ceiling on shadow reads. Bounded much tighter than the
+// dashboard default (30s) so an abandoned shadow doesn't keep burning CH
+// compute after the wall-clock race resolves.
+const SHADOW_CH_MAX_EXECUTION_SECONDS = 5;
+// Wall-clock fallback set ~0.5s above the CH ceiling so CH's own timeout
+// reliably fires first → `outcome:ch_error` is the deterministic signal and
+// the local race only catches network-level wedges.
+const SHADOW_TIMEOUT_MS = SHADOW_CH_MAX_EXECUTION_SECONDS * 1000 + 500;
 
 export function shouldShadow(opts: GetBillingUsageOpts | undefined): opts is GetBillingUsageOpts & { timeframe: { start: Date; end: Date } } {
     if (!envs.FLAG_BILLING_USAGE_SHADOW_CLICKHOUSE) return false;
@@ -320,19 +327,22 @@ export class UsageTracker implements IUsageTracker {
     }): Promise<void> {
         const start = process.hrtime.bigint();
 
+        // Shared error reference so we can identify the timeout branch in the
+        // outcome tag without string-matching the message.
+        const timeoutErr = new Error('shadow_timeout');
         let timeoutId: ReturnType<typeof setTimeout> | undefined;
-        const chResult = await Promise.race<Result<BillingUsageMetrics> | 'timeout'>([
-            this.getBillingUsageFromClickhouse(accountId, { timeframe }),
+        const chResult = await Promise.race<Result<BillingUsageMetrics>>([
+            this.getBillingUsageFromClickhouse(accountId, { timeframe, maxExecutionSeconds: SHADOW_CH_MAX_EXECUTION_SECONDS }),
             new Promise((resolve) => {
-                timeoutId = setTimeout(() => resolve('timeout'), SHADOW_TIMEOUT_MS);
+                timeoutId = setTimeout(() => resolve(Err(timeoutErr)), SHADOW_TIMEOUT_MS);
             })
         ]);
         clearTimeout(timeoutId);
 
-        const outcome = chResult === 'timeout' ? 'timeout' : chResult.isErr() ? 'ch_error' : 'ok';
+        const outcome = chResult.isOk() ? 'ok' : chResult.error === timeoutErr ? 'timeout' : 'ch_error';
         const elapsedMs = Number(process.hrtime.bigint() - start) / 1e6;
         metrics.distribution(metrics.Types.BILLING_USAGE_SHADOW_DURATION_MS, elapsedMs, { outcome });
-        if (chResult === 'timeout' || chResult.isErr()) return;
+        if (chResult.isErr()) return;
 
         // One-sided emits a separate counter rather than divergence=1.0 so
         // missing-data spikes don't drown out the continuous-divergence p99.
@@ -369,9 +379,12 @@ export class UsageTracker implements IUsageTracker {
             metrics?: UsageMetric[];
             breakdown?: { [M in UsageMetric]?: BreakdownDimensions[M] | undefined };
             top?: number;
+            // Override CH `max_execution_time` for every fan-out query. The
+            // shadow path uses this so an abandoned race doesn't keep CH busy.
+            maxExecutionSeconds?: number;
         }
     ): Promise<Result<BillingUsageMetrics>> {
-        const { timeframe, metrics: scopedMetrics, breakdown, top } = opts;
+        const { timeframe, metrics: scopedMetrics, breakdown, top, maxExecutionSeconds } = opts;
         const scope = scopedMetrics ? new Set(scopedMetrics) : null;
         const inScope = (m: UsageMetric): boolean => !scope || scope.has(m);
         const counterMetrics: CounterUsageMetric[] = COUNTER_METRICS.filter(inScope);
@@ -380,13 +393,15 @@ export class UsageTracker implements IUsageTracker {
         const avgNoDim = avgMetrics.filter((m) => !breakdown?.[m]);
         const ch = this.getClickhouse();
 
+        const maxExecOpt = maxExecutionSeconds !== undefined ? { maxExecutionSeconds } : {};
+
         // Base calls — `dimension: 'none'` is valid for every variant, so the
         // union-typed `metric: m` is fine here.
         const counterBaseP = Promise.all(
-            counterNoDim.map((m) => ch.getDailyCounter({ accountId, metric: m, dimension: 'none', timeframe }).then((r) => [m, r] as const))
+            counterNoDim.map((m) => ch.getDailyCounter({ accountId, metric: m, dimension: 'none', timeframe, ...maxExecOpt }).then((r) => [m, r] as const))
         );
         const avgBaseP = Promise.all(
-            avgNoDim.map((m) => ch.getDailySumAndBatches({ accountId, metric: m, dimension: 'none', timeframe }).then((r) => [m, r] as const))
+            avgNoDim.map((m) => ch.getDailySumAndBatches({ accountId, metric: m, dimension: 'none', timeframe, ...maxExecOpt }).then((r) => [m, r] as const))
         );
 
         // Breakdown calls — unrolled per-metric so `metric: '<literal>'` picks
@@ -396,27 +411,41 @@ export class UsageTracker implements IUsageTracker {
         const counterBreakdownCalls = [
             inScope('proxy') && breakdown?.proxy
                 ? ch
-                      .getDailyCounter({ accountId, metric: 'proxy', dimension: breakdown.proxy, timeframe, ...topOpt })
+                      .getDailyCounter({ accountId, metric: 'proxy', dimension: breakdown.proxy, timeframe, ...topOpt, ...maxExecOpt })
                       .then((r) => ['proxy' as const, r] as const)
                 : null,
             inScope('function_executions') && breakdown?.function_executions
                 ? ch
-                      .getDailyCounter({ accountId, metric: 'function_executions', dimension: breakdown.function_executions, timeframe, ...topOpt })
+                      .getDailyCounter({
+                          accountId,
+                          metric: 'function_executions',
+                          dimension: breakdown.function_executions,
+                          timeframe,
+                          ...topOpt,
+                          ...maxExecOpt
+                      })
                       .then((r) => ['function_executions' as const, r] as const)
                 : null,
             inScope('function_logs') && breakdown?.function_logs
                 ? ch
-                      .getDailyCounter({ accountId, metric: 'function_logs', dimension: breakdown.function_logs, timeframe, ...topOpt })
+                      .getDailyCounter({ accountId, metric: 'function_logs', dimension: breakdown.function_logs, timeframe, ...topOpt, ...maxExecOpt })
                       .then((r) => ['function_logs' as const, r] as const)
                 : null,
             inScope('function_compute_gbms') && breakdown?.function_compute_gbms
                 ? ch
-                      .getDailyCounter({ accountId, metric: 'function_compute_gbms', dimension: breakdown.function_compute_gbms, timeframe, ...topOpt })
+                      .getDailyCounter({
+                          accountId,
+                          metric: 'function_compute_gbms',
+                          dimension: breakdown.function_compute_gbms,
+                          timeframe,
+                          ...topOpt,
+                          ...maxExecOpt
+                      })
                       .then((r) => ['function_compute_gbms' as const, r] as const)
                 : null,
             inScope('webhook_forwards') && breakdown?.webhook_forwards
                 ? ch
-                      .getDailyCounter({ accountId, metric: 'webhook_forwards', dimension: breakdown.webhook_forwards, timeframe, ...topOpt })
+                      .getDailyCounter({ accountId, metric: 'webhook_forwards', dimension: breakdown.webhook_forwards, timeframe, ...topOpt, ...maxExecOpt })
                       .then((r) => ['webhook_forwards' as const, r] as const)
                 : null
         ].filter((p): p is NonNullable<typeof p> => p !== null);
@@ -425,12 +454,12 @@ export class UsageTracker implements IUsageTracker {
         const avgBreakdownCalls = [
             inScope('records') && breakdown?.records
                 ? ch
-                      .getDailySumAndBatches({ accountId, metric: 'records', dimension: breakdown.records, timeframe, ...topOpt })
+                      .getDailySumAndBatches({ accountId, metric: 'records', dimension: breakdown.records, timeframe, ...topOpt, ...maxExecOpt })
                       .then((r) => ['records' as const, r] as const)
                 : null,
             inScope('connections') && breakdown?.connections
                 ? ch
-                      .getDailySumAndBatches({ accountId, metric: 'connections', dimension: breakdown.connections, timeframe, ...topOpt })
+                      .getDailySumAndBatches({ accountId, metric: 'connections', dimension: breakdown.connections, timeframe, ...topOpt, ...maxExecOpt })
                       .then((r) => ['connections' as const, r] as const)
                 : null
         ].filter((p): p is NonNullable<typeof p> => p !== null);

--- a/packages/usage/lib/usage.ts
+++ b/packages/usage/lib/usage.ts
@@ -3,7 +3,7 @@ import tracer from 'dd-trace';
 import db from '@nangohq/database';
 import { records } from '@nangohq/records';
 import { connectionService, environmentService, getPlan } from '@nangohq/shared';
-import { Err, Ok } from '@nangohq/utils';
+import { Err, Ok, metrics, stringifyError } from '@nangohq/utils';
 
 import { UsageBillingClient } from './billing.js';
 import { UsageCache } from './cache.js';
@@ -25,6 +25,18 @@ import type { BillingUsageMetric, BillingUsageMetrics, BreakdownDimensions, GetB
 import type { Result } from '@nangohq/utils';
 
 const cacheKeyPrefix = 'usageV2';
+
+// CH MV typed-projections started ingesting 2026-05-12; comparing earlier
+// windows against Orb produces known-bad divergence (CH biases high until 30d
+// of depth). Anchor the shadow to a clean post-backfill date.
+const SHADOW_MIN_TIMEFRAME_START = new Date('2026-06-01T00:00:00.000Z');
+const SHADOW_TIMEOUT_MS = 5_000;
+
+export function shouldShadow(opts: GetBillingUsageOpts | undefined): opts is GetBillingUsageOpts & { timeframe: { start: Date; end: Date } } {
+    if (!envs.FLAG_BILLING_USAGE_SHADOW_CLICKHOUSE) return false;
+    if (!opts?.timeframe?.start || !opts?.timeframe?.end) return false;
+    return opts.timeframe.start >= SHADOW_MIN_TIMEFRAME_START;
+}
 
 export interface UsageStatus {
     accountId: number;
@@ -270,14 +282,72 @@ export class UsageTracker implements IUsageTracker {
             : undefined;
         const billingUsageMetrics = await this.billingClient.getUsage(subscriptionId, orbOpts);
         if (billingUsageMetrics.isErr()) {
-            return billingUsageMetrics;
+            return Err(billingUsageMetrics.error);
         }
 
-        return Ok({
-            ...billingUsageMetrics.value,
-            connections: billingUsageMetrics.value.connections ? toCumulativeUsage(billingUsageMetrics.value.connections) : undefined,
-            records: billingUsageMetrics.value.records ? toCumulativeUsage(billingUsageMetrics.value.records) : undefined
-        });
+        const orbValue = billingUsageMetrics.value.value;
+        const formatted: BillingUsageMetrics = {
+            ...orbValue,
+            connections: orbValue.connections ? toCumulativeUsage(orbValue.connections) : undefined,
+            records: orbValue.records ? toCumulativeUsage(orbValue.records) : undefined
+        };
+
+        if (!billingUsageMetrics.value.fromCache && shouldShadow(opts)) {
+            void this.shadowAgainstClickhouse({ accountId, timeframe: opts.timeframe, orbResult: formatted }).catch((err: unknown) => {
+                logger.error(`billing-usage shadow failed: ${stringifyError(err)}`);
+            });
+        }
+
+        return Ok(formatted);
+    }
+
+    /**
+     * Fire CH with the same shape as the just-completed Orb call and emit
+     * per-metric divergence telemetry. Wrapped in a 5s timeout so a slow CH
+     * query can't pile up requests. Observability-only — never throws.
+     */
+    private async shadowAgainstClickhouse({
+        accountId,
+        timeframe,
+        orbResult
+    }: {
+        accountId: number;
+        timeframe: { start: Date; end: Date };
+        orbResult: BillingUsageMetrics;
+    }): Promise<void> {
+        const start = process.hrtime.bigint();
+
+        let timeoutId: ReturnType<typeof setTimeout> | undefined;
+        const chResult = await Promise.race<Result<BillingUsageMetrics> | 'timeout'>([
+            this.getBillingUsageFromClickhouse(accountId, { timeframe }),
+            new Promise((resolve) => {
+                timeoutId = setTimeout(() => resolve('timeout'), SHADOW_TIMEOUT_MS);
+            })
+        ]);
+        clearTimeout(timeoutId);
+
+        const outcome = chResult === 'timeout' ? 'timeout' : chResult.isErr() ? 'ch_error' : 'ok';
+        const elapsedMs = Number(process.hrtime.bigint() - start) / 1e6;
+        metrics.distribution(metrics.Types.BILLING_USAGE_SHADOW_DURATION_MS, elapsedMs, { outcome });
+        if (chResult === 'timeout' || chResult.isErr()) return;
+
+        // One-sided emits a separate counter rather than divergence=1.0 so
+        // missing-data spikes don't drown out the continuous-divergence p99.
+        for (const metric of Object.keys(orbResult) as UsageMetric[]) {
+            const orbTotal = orbResult[metric]?.total;
+            const chTotal = chResult.value[metric]?.total;
+            if (orbTotal === undefined || chTotal === undefined) continue;
+            if (orbTotal === 0 && chTotal === 0) continue;
+            if (orbTotal === 0 || chTotal === 0) {
+                const zeroSide = orbTotal === 0 ? 'orb' : 'ch';
+                metrics.increment(metrics.Types.BILLING_USAGE_SHADOW_ONE_SIDED, 1, { accountId, metric, zeroSide });
+                continue;
+            }
+            const denom = Math.max(orbTotal, chTotal);
+            const divergence = Math.abs(orbTotal - chTotal) / denom;
+            const higher = orbTotal === chTotal ? 'equal' : orbTotal > chTotal ? 'orb' : 'ch';
+            metrics.distribution(metrics.Types.BILLING_USAGE_SHADOW_DIVERGENCE, divergence, { accountId, metric, higher });
+        }
     }
 
     /**

--- a/packages/usage/lib/usage.unit.test.ts
+++ b/packages/usage/lib/usage.unit.test.ts
@@ -1,6 +1,7 @@
-import { describe, expect, it } from 'vitest';
+import { afterEach, beforeEach, describe, expect, it } from 'vitest';
 
-import { toCounterBillingMetricSeries, toRunningAvgUsage } from './usage.js';
+import { envs } from './env.js';
+import { shouldShadow, toCounterBillingMetricSeries, toRunningAvgUsage } from './usage.js';
 
 import type { GetDailyCounterResult, GetDailySumAndBatchesResult } from './clickhouse/clickhouse.query.js';
 
@@ -276,5 +277,40 @@ describe('toCounterBillingMetricSeries', () => {
     it('emits an empty array when the source has no series', () => {
         const empty: GetDailyCounterResult = { accountId, metric: 'proxy', series: [] };
         expect(toCounterBillingMetricSeries('proxy', empty)).toEqual([]);
+    });
+});
+
+describe('shouldShadow', () => {
+    const junePlus = { start: new Date('2026-06-15T00:00:00.000Z'), end: new Date('2026-06-20T00:00:00.000Z') };
+    const preJune = { start: new Date('2026-05-15T00:00:00.000Z'), end: new Date('2026-05-20T00:00:00.000Z') };
+
+    let originalFlag: boolean;
+    beforeEach(() => {
+        originalFlag = envs.FLAG_BILLING_USAGE_SHADOW_CLICKHOUSE;
+    });
+    afterEach(() => {
+        (envs as any).FLAG_BILLING_USAGE_SHADOW_CLICKHOUSE = originalFlag;
+    });
+
+    it('returns false when the flag is off', () => {
+        (envs as any).FLAG_BILLING_USAGE_SHADOW_CLICKHOUSE = false;
+        expect(shouldShadow({ timeframe: junePlus })).toBe(false);
+    });
+
+    it('returns false when timeframe is missing', () => {
+        (envs as any).FLAG_BILLING_USAGE_SHADOW_CLICKHOUSE = true;
+        expect(shouldShadow(undefined)).toBe(false);
+        expect(shouldShadow({})).toBe(false);
+    });
+
+    it('returns false when the timeframe starts before 2026-06-01', () => {
+        (envs as any).FLAG_BILLING_USAGE_SHADOW_CLICKHOUSE = true;
+        expect(shouldShadow({ timeframe: preJune })).toBe(false);
+    });
+
+    it('returns true when flag is on and timeframe starts on/after 2026-06-01', () => {
+        (envs as any).FLAG_BILLING_USAGE_SHADOW_CLICKHOUSE = true;
+        expect(shouldShadow({ timeframe: junePlus })).toBe(true);
+        expect(shouldShadow({ timeframe: { start: new Date('2026-06-01T00:00:00.000Z'), end: new Date('2026-06-02T00:00:00.000Z') } })).toBe(true);
     });
 });

--- a/packages/utils/lib/environment/parse.ts
+++ b/packages/utils/lib/environment/parse.ts
@@ -317,6 +317,11 @@ export const ENVS = z.object({
     // → Orb. Capping is unaffected (no override mechanism there).
     FLAG_ALLOW_OVERRIDE_GETUSAGE_SERVICE: z.stringbool().optional().default(false),
 
+    // Shadow dashboard read against ClickHouse to compare totals vs Orb. Only
+    // fires on cache miss + June-2026+ timeframe; fire-and-forget so it adds
+    // no user-visible latency. Emits `nango.billing.usage.shadow.*` metrics.
+    FLAG_BILLING_USAGE_SHADOW_CLICKHOUSE: z.stringbool().optional().default(false),
+
     // --- Third parties
     // AWS
     AWS_REGION: z.string().optional(),

--- a/packages/utils/lib/telemetry/metrics.ts
+++ b/packages/utils/lib/telemetry/metrics.ts
@@ -128,6 +128,9 @@ export enum Types {
     BILLING_USAGE_CLICKHOUSE_S3_EXPORT_FILE_RESULT = 'nango.billing.usage.clickhouse.s3_export.file.result',
     BILLING_USAGE_CLICKHOUSE_S3_EXPORT_RUN_RESULT = 'nango.billing.usage.clickhouse.s3_export.run.result',
     BILLING_USAGE_CLICKHOUSE_S3_EXPORT_DURATION_MS = 'nango.billing.usage.clickhouse.s3_export.duration_ms',
+    BILLING_USAGE_SHADOW_DIVERGENCE = 'nango.billing.usage.shadow.divergence',
+    BILLING_USAGE_SHADOW_ONE_SIDED = 'nango.billing.usage.shadow.one_sided',
+    BILLING_USAGE_SHADOW_DURATION_MS = 'nango.billing.usage.shadow.duration_ms',
 
     USAGE_IS_CAPPED = 'nango.capping.isCapped',
 


### PR DESCRIPTION
## Summary

- **Shadow CH vs Orb on cache misses.** New env `FLAG_BILLING_USAGE_SHADOW_CLICKHOUSE` (default off). When on + cache miss + timeframe ≥ 2026-06-01, fire a CH call alongside the served Orb response, fire-and-forget. Emits divergence telemetry; no user-visible latency, no behavior change.
- **Three Datadog signals** under `nango.billing.usage.shadow.*`: `duration_ms` (tag `outcome`: `ok` / `timeout` / `ch_error`), `divergence` (continuous `\|orb−ch\| / max(orb,ch)`, tag `higher`: `orb` / `ch` / `equal`), `one_sided` (counter when exactly one side is 0 — kept separate so missing-data spikes don't drown out the continuous-divergence p99).
- **Compares raw Orb totals (pre-`toCumulativeUsage`) against CH.** Both sides are floats, so the AVG-metric divergence signal isn't biased by the formatter's `Math.floor` artifact.

## Notes for the reviewer

- `UsageBillingClient.getUsage` return shape briefly grows a `fromCache` flag so the caller can decide to shadow only on miss. Intentionally temporary — gets reverted to plain `Result<BillingUsageMetrics>` when the shadow path is removed. Code comment in place at the function.
- DD tag cardinality: `{accountId, metric, ...}` on the distribution + counter. Bounded by gating (June+ window, cache miss only, flag-gated), but worth keeping an eye on series count once enabled in prod.

## Test plan

- [x] Unit tests for `shouldShadow` (flag off / no timeframe / pre-June / June+).
- [x] Existing usage + controller integration suites still pass with the new return shape.
- [ ] Enable `FLAG_BILLING_USAGE_SHADOW_CLICKHOUSE=true` in staging, walk the dashboard for a few accounts, verify all three metrics appear in DD with expected tag values.
- [ ] Watch `shadow.divergence{*}.p95` and `shadow.one_sided` for 24h before deciding on next steps.
- [ ] Confirm no regressions in `shadow.duration_ms{outcome:ok}.p95` vs baseline CH read latency (already capped at 30s `max_execution_time`).