### PR TITLE
refactor(records_seen): drop ensureSeenPartition fallback after Phase 2c (NAN-5491 Phase 2d)

### DIFF
--- a/packages/records/lib/stores/postgres/postgres.integration.test.ts
+++ b/packages/records/lib/stores/postgres/postgres.integration.test.ts
@@ -2150,7 +2150,15 @@ describe('PostgresStore', () => {
             expect(res2.isOk()).toBe(true);
         });
 
-        it('should create the sync_job_id_new child index on the new partition', async () => {
+        // Must run last in this describe — it leaves the schema in the post-Phase-2c state,
+        // which is what 2d's ensureSeenPartition is designed for. Simulating the swap inline
+        // because this branch isn't stacked on 2c — its test schema only has 2a's migration.
+        it('should create the sync_job_id child index on the new partition (post-Phase-2c state)', async () => {
+            await db.raw(`DROP TRIGGER IF EXISTS records_seen_mirror_sync_job_id_trigger ON nango_records.records_seen`);
+            await db.raw(`DROP FUNCTION IF EXISTS nango_records.records_seen_mirror_sync_job_id()`);
+            await db.raw(`ALTER TABLE nango_records.records_seen DROP COLUMN sync_job_id`);
+            await db.raw(`ALTER TABLE nango_records.records_seen RENAME COLUMN sync_job_id_new TO sync_job_id`);
+
             const date = new Date('2025-01-17T00:00:00Z');
             const res = await store.ensureSeenPartition({ date });
             expect(res.isOk()).toBe(true);
@@ -2160,30 +2168,7 @@ describe('PostgresStore', () => {
                  FROM pg_index i
                  JOIN pg_class c ON c.oid = i.indexrelid
                  WHERE c.relname = ?`,
-                ['records_seen_20250117_connection_model_job_new']
-            );
-            expect(rows).toHaveLength(1);
-            expect(rows[0]?.indisvalid).toBe(true);
-            expect(rows[0]?.indexdef).toMatch(/\(connection_id, model, sync_job_id_new\)/);
-        });
-
-        // Must run last in this describe — it leaves the schema in the post-Phase-2c state.
-        it('should fall back to sync_job_id after the shadow column has been renamed away (Phase 2c)', async () => {
-            await db.raw(`DROP TRIGGER IF EXISTS records_seen_mirror_sync_job_id_trigger ON nango_records.records_seen`);
-            await db.raw(`DROP FUNCTION IF EXISTS nango_records.records_seen_mirror_sync_job_id()`);
-            await db.raw(`ALTER TABLE nango_records.records_seen DROP COLUMN sync_job_id`);
-            await db.raw(`ALTER TABLE nango_records.records_seen RENAME COLUMN sync_job_id_new TO sync_job_id`);
-
-            const date = new Date('2025-01-18T00:00:00Z');
-            const res = await store.ensureSeenPartition({ date });
-            expect(res.isOk()).toBe(true);
-
-            const { rows } = await db.raw<{ rows: { indexdef: string; indisvalid: boolean }[] }>(
-                `SELECT pg_get_indexdef(i.indexrelid) AS indexdef, i.indisvalid
-                 FROM pg_index i
-                 JOIN pg_class c ON c.oid = i.indexrelid
-                 WHERE c.relname = ?`,
-                ['records_seen_20250118_connection_model_job_new']
+                ['records_seen_20250117_connection_model_job']
             );
             expect(rows).toHaveLength(1);
             expect(rows[0]?.indisvalid).toBe(true);

--- a/packages/records/lib/stores/postgres/postgres.ts
+++ b/packages/records/lib/stores/postgres/postgres.ts
@@ -125,34 +125,16 @@ export class PostgresStore implements RecordsStore {
             if (!promise) {
                 const next = day.add(1, 'day');
                 const partitionName = `records_seen_${suffix}`;
-                const indexName = `${partitionName}_connection_model_job_new`;
+                const indexName = `${partitionName}_connection_model_job`;
                 // Two separate statements (not a single transaction) so the parent's
                 // ACCESS EXCLUSIVE from CREATE TABLE PARTITION OF is released before the
                 // child CREATE INDEX runs. Wrapping both in a transaction would hold the
                 // parent lock across both, briefly blocking every records_seen reader/writer.
-                //
-                // The CREATE INDEX targets sync_job_id_new (the shadow column added in
-                // Phase 2a) and falls back to sync_job_id if the shadow column has already
-                // been renamed away by Phase 2c's swap. This makes ensureSeenPartition
-                // tolerant of the rename happening at any moment relative to a rolling
-                // deploy — old pods carrying this code keep functioning even after the
-                // migration commits. A follow-up PR will drop the fallback once Phase 2c
-                // has fully soaked everywhere.
                 promise = this.db
                     .raw(
                         `CREATE TABLE IF NOT EXISTS "${partitionName}" PARTITION OF "${RECORDS_SEEN_TABLE}" FOR VALUES FROM ('${day.toISOString()}') TO ('${next.toISOString()}')`
                     )
-                    .then(async () => {
-                        try {
-                            await this.db.raw('CREATE INDEX IF NOT EXISTS ?? ON ?? (connection_id, model, sync_job_id_new)', [indexName, partitionName]);
-                        } catch (err: any) {
-                            if (err?.code === '42703') {
-                                await this.db.raw('CREATE INDEX IF NOT EXISTS ?? ON ?? (connection_id, model, sync_job_id)', [indexName, partitionName]);
-                            } else {
-                                throw err;
-                            }
-                        }
-                    })
+                    .then(() => this.db.raw('CREATE INDEX IF NOT EXISTS ?? ON ?? (connection_id, model, sync_job_id)', [indexName, partitionName]))
                     .then(() => undefined);
                 this.seenPartitionPromises.set(suffix, promise);
             }


### PR DESCRIPTION
> ⚠️ **Do not merge until Phase 2c (#6321) has fully soaked in production.** While the migration is still rolling out anywhere on `master`, the `sync_job_id_new` shadow column may still exist and the EAFP catch this PR removes is what keeps `ensureSeenPartition` working through that transition.

- Drops the `try/catch` fallback that Phase 2b added to `ensureSeenPartition`. Once Phase 2c's swap is universally applied, `sync_job_id_new` no longer exists anywhere and the first attempt would always fail — paying an extra round-trip on every cache-missing call forever. With the catch removed, `ensureSeenPartition` does a single `CREATE INDEX … (sync_job_id)` on each new partition.
- Drops the now-misleading `_new` suffix from new partitions' child-index names (`records_seen_<YYYYMMDD>_connection_model_job` instead of `…_connection_model_job_new`). Pre-Phase-2d partitions keep their `_new`-suffixed names until they age out via the 48h `records_seen` retention.

## Test plan

- [x] Locally: 5 records integration tests in the `ensureSeenPartition` + `dropSeenPartition` describes pass.
- [x] Deliberately broke the code (reverted the column back to `sync_job_id_new`) and confirmed the post-Phase-2c-state test goes red on `expect(res.isOk()).toBe(true)` — the test catches the regression.
- [ ] Staging: deploy ≥48h after Phase 2c is in staging.
- [ ] Production: deploy ≥48h after Phase 2c is in production (so any in-flight `ensureSeenPartition` calls from older replicas have drained).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
