### PR TITLE
perf(server): Upload js and ts file to S3 in parallel during function deploy

### DIFF
--- a/packages/shared/lib/services/sync/config/deploy.service.ts
+++ b/packages/shared/lib/services/sync/config/deploy.service.ts
@@ -332,19 +332,22 @@ async function compileDeployInfo({
         return { success: false, error, response: null };
     }
 
-    const file_location = (await remoteFileService.upload({
+    const jsFileUpload = remoteFileService.upload({
         content: jsFile,
         destinationPath: `${env}/account/${account.id}/environment/${environment_id}/config/${config.id}/${syncName}-v${version}.js`,
         destinationLocalFileName: resolveLocalFileName({ syncName, providerConfigKey })
-    })) as string;
+    });
 
-    if (typeof fileBody === 'object' && fileBody.ts) {
-        await remoteFileService.upload({
-            content: fileBody.ts,
-            destinationPath: `${env}/account/${account.id}/environment/${environment_id}/config/${config.id}/${syncName}.ts`,
-            destinationLocalFileName: `${providerConfigKey}/${flow.type}s/${syncName}.ts`
-        });
-    }
+    const tsFileUpload =
+        typeof fileBody === 'object' && fileBody.ts
+            ? remoteFileService.upload({
+                  content: fileBody.ts,
+                  destinationPath: `${env}/account/${account.id}/environment/${environment_id}/config/${config.id}/${syncName}.ts`,
+                  destinationLocalFileName: `${providerConfigKey}/${flow.type}s/${syncName}.ts`
+              })
+            : Promise.resolve(null);
+
+    const [file_location] = await Promise.all([jsFileUpload, tsFileUpload]);
 
     if (!file_location) {
         void logCtx.error('There was an error uploading the sync file', { fileName: `${syncName}-v${version}.js` });

--- a/packages/shared/lib/services/sync/config/deploy.service.ts
+++ b/packages/shared/lib/services/sync/config/deploy.service.ts
@@ -332,22 +332,25 @@ async function compileDeployInfo({
         return { success: false, error, response: null };
     }
 
-    const jsFileUpload = remoteFileService.upload({
-        content: jsFile,
-        destinationPath: `${env}/account/${account.id}/environment/${environment_id}/config/${config.id}/${syncName}-v${version}.js`,
-        destinationLocalFileName: resolveLocalFileName({ syncName, providerConfigKey })
-    });
+    const uploads = [
+        remoteFileService.upload({
+            content: jsFile,
+            destinationPath: `${env}/account/${account.id}/environment/${environment_id}/config/${config.id}/${syncName}-v${version}.js`,
+            destinationLocalFileName: resolveLocalFileName({ syncName, providerConfigKey })
+        })
+    ];
 
-    const tsFileUpload =
-        typeof fileBody === 'object' && fileBody.ts
-            ? remoteFileService.upload({
-                  content: fileBody.ts,
-                  destinationPath: `${env}/account/${account.id}/environment/${environment_id}/config/${config.id}/${syncName}.ts`,
-                  destinationLocalFileName: `${providerConfigKey}/${flow.type}s/${syncName}.ts`
-              })
-            : Promise.resolve(null);
+    if (typeof fileBody === 'object' && fileBody.ts) {
+        uploads.push(
+            remoteFileService.upload({
+                content: fileBody.ts,
+                destinationPath: `${env}/account/${account.id}/environment/${environment_id}/config/${config.id}/${syncName}.ts`,
+                destinationLocalFileName: `${providerConfigKey}/${flow.type}s/${syncName}.ts`
+            })
+        );
+    }
 
-    const [file_location] = await Promise.all([jsFileUpload, tsFileUpload]);
+    const [file_location] = await Promise.all(uploads);
 
     if (!file_location) {
         void logCtx.error('There was an error uploading the sync file', { fileName: `${syncName}-v${version}.js` });


### PR DESCRIPTION
<!-- Describe the problem and your solution --> 
Deployments are taking too long, causing timeouts in ALB and hung executions on Kubernetes scale down events

Attempting to resolve issue by running TS/JS file uploads in parallel.

<!-- Issue ticket number and link (if applicable) -->
[NAN-5833: Perf - Run TS/JS S3 uploads in parallel](https://linear.app/nango/issue/NAN-5833/perf-run-tsjs-s3-uploads-in-parallel)

<!-- Testing instructions (skip if just adding/editing providers) -->

