### PR TITLE
feat(server): track API egress bytes

### DIFF
--- a/packages/server/lib/middleware/egress-meter.middleware.ts
+++ b/packages/server/lib/middleware/egress-meter.middleware.ts
@@ -3,20 +3,18 @@ import { metrics } from '@nangohq/utils';
 import type { RequestLocals } from '../utils/express.js';
 import type { NextFunction, Request, Response } from 'express';
 
+function trafficOrigin(res: Response<any, RequestLocals>): 'internal' | 'external' {
+    return res.locals['apiKeyAuthSource'] === 'api_secret' ? 'internal' : 'external';
+}
+
 export const egressMeterMiddleware = (req: Request, res: Response<any, RequestLocals>, next: NextFunction) => {
-    if (res.locals['apiKeyAuthSource'] !== 'customer_key' || !res.locals['account']) {
-        next();
-        return;
-    }
-
+    const origin = trafficOrigin(res);
     const baseline = req.socket?.bytesWritten ?? 0;
-
     res.on('finish', () => {
         const bytes = (req.socket?.bytesWritten ?? 0) - baseline;
         if (bytes > 0) {
-            metrics.increment(metrics.Types.EGRESS_BYTES, bytes);
+            metrics.increment(metrics.Types.EGRESS_BYTES, bytes, { traffic_origin: origin });
         }
     });
-
     next();
 };

--- a/packages/server/lib/middleware/egress-meter.middleware.ts
+++ b/packages/server/lib/middleware/egress-meter.middleware.ts
@@ -1,0 +1,22 @@
+import { metrics } from '@nangohq/utils';
+
+import type { RequestLocals } from '../utils/express.js';
+import type { NextFunction, Request, Response } from 'express';
+
+export const egressMeterMiddleware = (req: Request, res: Response<any, RequestLocals>, next: NextFunction) => {
+    if (res.locals['apiKeyAuthSource'] !== 'customer_key' || !res.locals['account']) {
+        next();
+        return;
+    }
+
+    const baseline = req.socket?.bytesWritten ?? 0;
+
+    res.on('finish', () => {
+        const bytes = (req.socket?.bytesWritten ?? 0) - baseline;
+        if (bytes > 0) {
+            metrics.increment(metrics.Types.EGRESS_BYTES, bytes);
+        }
+    });
+
+    next();
+};

--- a/packages/server/lib/middleware/egress-meter.middleware.ts
+++ b/packages/server/lib/middleware/egress-meter.middleware.ts
@@ -10,11 +10,19 @@ function trafficOrigin(res: Response<any, RequestLocals>): 'internal' | 'externa
 export const egressMeterMiddleware = (req: Request, res: Response<any, RequestLocals>, next: NextFunction) => {
     const origin = trafficOrigin(res);
     const baseline = req.socket?.bytesWritten ?? 0;
-    res.on('finish', () => {
+
+    let recorded = false;
+    const meterEgressedBytes = () => {
+        if (recorded) return;
         const bytes = (req.socket?.bytesWritten ?? 0) - baseline;
         if (bytes > 0) {
             metrics.increment(metrics.Types.EGRESS_BYTES, bytes, { traffic_origin: origin });
         }
-    });
+        recorded = true;
+    };
+
+    res.on('finish', meterEgressedBytes);
+    // early client disconnect: finish never fires but bytes may already be on the wire
+    res.on('close', meterEgressedBytes);
     next();
 };

--- a/packages/server/lib/middleware/egress-meter.middleware.ts
+++ b/packages/server/lib/middleware/egress-meter.middleware.ts
@@ -15,9 +15,7 @@ export const egressMeterMiddleware = (req: Request, res: Response<any, RequestLo
     const meterEgressedBytes = () => {
         if (recorded) return;
         const bytes = (req.socket?.bytesWritten ?? 0) - baseline;
-        if (bytes > 0) {
-            metrics.increment(metrics.Types.EGRESS_BYTES, bytes, { traffic_origin: origin });
-        }
+        metrics.increment(metrics.Types.EGRESS_BYTES, bytes, { traffic_origin: origin });
         recorded = true;
     };
 

--- a/packages/server/lib/routes.private.ts
+++ b/packages/server/lib/routes.private.ts
@@ -104,6 +104,7 @@ import { putUserPassword } from './controllers/v1/user/password/putPassword.js';
 import { patchUser } from './controllers/v1/user/patchUser.js';
 import authMiddleware from './middleware/access.middleware.js';
 import { authenticateLocalSignin } from './middleware/authenticateLocalSignin.middleware.js';
+import { egressMeterMiddleware } from './middleware/egress-meter.middleware.js';
 import { jsonContentTypeMiddleware } from './middleware/json.middleware.js';
 import { rateLimiterMiddleware } from './middleware/ratelimit.middleware.js';
 import { isAllowedWebCorsOrigin } from './utils/cors.js';
@@ -111,7 +112,7 @@ import { isAllowedWebCorsOrigin } from './utils/cors.js';
 import type { Request, RequestHandler, Response } from 'express';
 
 let webAuth: RequestHandler[] = flagHasAuth
-    ? [passport.authenticate('session') as RequestHandler, authMiddleware.sessionAuth.bind(authMiddleware), rateLimiterMiddleware]
+    ? [passport.authenticate('session') as RequestHandler, authMiddleware.sessionAuth.bind(authMiddleware), rateLimiterMiddleware, egressMeterMiddleware]
     : isBasicAuthEnabled
       ? [passport.authenticate('basic', { session: false }) as RequestHandler, authMiddleware.basicAuth.bind(authMiddleware), rateLimiterMiddleware]
       : [authMiddleware.noAuth.bind(authMiddleware), rateLimiterMiddleware];

--- a/packages/server/lib/routes.public.ts
+++ b/packages/server/lib/routes.public.ts
@@ -71,6 +71,7 @@ import { acceptLanguageMiddleware } from './middleware/accept-language.middlewar
 import authMiddleware from './middleware/access.middleware.js';
 import { cliMaxVersion, cliMinVersion } from './middleware/cliVersionCheck.js';
 import { connectionCapping } from './middleware/connection-capping.middleware.js';
+import { egressMeterMiddleware } from './middleware/egress-meter.middleware.js';
 import { jsonContentTypeMiddleware } from './middleware/json.middleware.js';
 import { rateLimiterMiddleware } from './middleware/ratelimit.middleware.js';
 import { withAnyScope, withScope } from './middleware/scope.middleware.js';
@@ -80,7 +81,7 @@ import { isBinaryContentType } from './utils/utils.js';
 import type { DBPlan } from '@nangohq/types';
 import type { Request, RequestHandler } from 'express';
 
-const apiAuth: RequestHandler[] = [authMiddleware.secretKeyAuth.bind(authMiddleware), rateLimiterMiddleware];
+const apiAuth: RequestHandler[] = [authMiddleware.secretKeyAuth.bind(authMiddleware), rateLimiterMiddleware, egressMeterMiddleware];
 const connectSessionAuth: RequestHandler[] = [authMiddleware.connectSessionAuth.bind(authMiddleware), rateLimiterMiddleware];
 const connectSessionAuthBody: RequestHandler[] = [authMiddleware.connectSessionAuthBody.bind(authMiddleware), rateLimiterMiddleware];
 const connectSessionOrApiAuth: RequestHandler[] = [authMiddleware.connectSessionOrSecretKeyAuth.bind(authMiddleware), rateLimiterMiddleware];

--- a/packages/server/lib/routes.public.ts
+++ b/packages/server/lib/routes.public.ts
@@ -82,15 +82,19 @@ import type { DBPlan } from '@nangohq/types';
 import type { Request, RequestHandler } from 'express';
 
 const apiAuth: RequestHandler[] = [authMiddleware.secretKeyAuth.bind(authMiddleware), rateLimiterMiddleware, egressMeterMiddleware];
-const connectSessionAuth: RequestHandler[] = [authMiddleware.connectSessionAuth.bind(authMiddleware), rateLimiterMiddleware];
-const connectSessionAuthBody: RequestHandler[] = [authMiddleware.connectSessionAuthBody.bind(authMiddleware), rateLimiterMiddleware];
+const connectSessionAuth: RequestHandler[] = [authMiddleware.connectSessionAuth.bind(authMiddleware), rateLimiterMiddleware, egressMeterMiddleware];
+const connectSessionAuthBody: RequestHandler[] = [authMiddleware.connectSessionAuthBody.bind(authMiddleware), rateLimiterMiddleware, egressMeterMiddleware];
 const connectSessionOrApiAuth: RequestHandler[] = [
     authMiddleware.connectSessionOrSecretKeyAuth.bind(authMiddleware),
     rateLimiterMiddleware,
     egressMeterMiddleware
 ];
+const connectSessionOrPublicAuth: RequestHandler[] = [
+    authMiddleware.connectSessionOrPublicKeyAuth.bind(authMiddleware),
+    rateLimiterMiddleware,
+    egressMeterMiddleware
+];
 
-const connectSessionOrPublicAuth: RequestHandler[] = [authMiddleware.connectSessionOrPublicKeyAuth.bind(authMiddleware), rateLimiterMiddleware];
 const remoteFunctionAuth: RequestHandler[] = [
     ...apiAuth,
     (_req, res, next) => {

--- a/packages/server/lib/routes.public.ts
+++ b/packages/server/lib/routes.public.ts
@@ -84,7 +84,11 @@ import type { Request, RequestHandler } from 'express';
 const apiAuth: RequestHandler[] = [authMiddleware.secretKeyAuth.bind(authMiddleware), rateLimiterMiddleware, egressMeterMiddleware];
 const connectSessionAuth: RequestHandler[] = [authMiddleware.connectSessionAuth.bind(authMiddleware), rateLimiterMiddleware];
 const connectSessionAuthBody: RequestHandler[] = [authMiddleware.connectSessionAuthBody.bind(authMiddleware), rateLimiterMiddleware];
-const connectSessionOrApiAuth: RequestHandler[] = [authMiddleware.connectSessionOrSecretKeyAuth.bind(authMiddleware), rateLimiterMiddleware];
+const connectSessionOrApiAuth: RequestHandler[] = [
+    authMiddleware.connectSessionOrSecretKeyAuth.bind(authMiddleware),
+    rateLimiterMiddleware,
+    egressMeterMiddleware
+];
 
 const connectSessionOrPublicAuth: RequestHandler[] = [authMiddleware.connectSessionOrPublicKeyAuth.bind(authMiddleware), rateLimiterMiddleware];
 const remoteFunctionAuth: RequestHandler[] = [

--- a/packages/utils/lib/telemetry/metrics.ts
+++ b/packages/utils/lib/telemetry/metrics.ts
@@ -115,6 +115,8 @@ export enum Types {
     DEPLOY_INCOMING_PAYLOAD_SIZE_BYTES = 'nango.server.deploy.incoming.payloadSizeBytes',
     DEPLOY_SECURITY_SCAN = 'nango.server.deploy.security.scan',
 
+    EGRESS_BYTES = 'nango.server.egress.bytes',
+
     ACTION_CALLED_BY_MCP_SERVER = 'nango.mcp.called.action',
 
     ORB_BILLING_EVENTS_INGESTED = 'nango.billing.orb.ingested',


### PR DESCRIPTION
Meters egressing bytes per response using socket.bytesWritten delta, tagged with traffic_origin (external/internal) to distinguish customer traffic from internal service calls (persist, runners).

Applied to all auth chains: apiAuth, connectSession* and webAuth.