### PR TITLE
refactor(webapp): move GoogleButton to components-v2/patterns

### DIFF
--- a/packages/design-system/stories/v2-patterns/GoogleButton.stories.tsx
+++ b/packages/design-system/stories/v2-patterns/GoogleButton.stories.tsx
@@ -1,0 +1,18 @@
+import GoogleButton from '@/components-v2/patterns/GoogleButton';
+
+import type { Meta, StoryObj } from '@storybook/react-vite';
+
+const meta: Meta = {
+    title: 'Components v2/Patterns/GoogleButton',
+    parameters: { layout: 'padded' }
+};
+export default meta;
+type Story = StoryObj<typeof meta>;
+
+export const Default: Story = {
+    render: () => <GoogleButton text="Sign in with Google" setServerErrorMessage={() => {}} />
+};
+
+export const SignUp: Story = {
+    render: () => <GoogleButton text="Sign up with Google" setServerErrorMessage={() => {}} />
+};

--- a/packages/webapp/src/components-v2/patterns/GoogleButton.tsx
+++ b/packages/webapp/src/components-v2/patterns/GoogleButton.tsx
@@ -1,4 +1,4 @@
-import { apiFetch } from '../../../../utils/api';
+import { apiFetch } from '../../utils/api';
 
 import type { PostManagedSignup } from '@nangohq/types';
 

--- a/packages/webapp/src/pages/Account/Signin.tsx
+++ b/packages/webapp/src/pages/Account/Signin.tsx
@@ -6,7 +6,7 @@ import { useForm } from 'react-hook-form';
 import { useNavigate, useSearchParams } from 'react-router-dom';
 import z from 'zod';
 
-import GoogleButton from '@/components/ui/button/Auth/Google';
+import GoogleButton from '@/components-v2/patterns/GoogleButton';
 import { Alert, AlertActions, AlertButton, AlertDescription, AlertTitle } from '@/components-v2/ui/Alert';
 import { Button } from '@/components-v2/ui/Button';
 import { Form, FormControl, FormField, FormItem, FormMessage } from '@/components-v2/ui/Form';

--- a/packages/webapp/src/pages/Account/components/SignupForm.tsx
+++ b/packages/webapp/src/pages/Account/components/SignupForm.tsx
@@ -5,7 +5,7 @@ import { useForm } from 'react-hook-form';
 import { useNavigate } from 'react-router-dom';
 import z from 'zod';
 
-import GoogleButton from '@/components/ui/button/Auth/Google';
+import GoogleButton from '@/components-v2/patterns/GoogleButton';
 import { Alert, AlertActions, AlertButton, AlertDescription, AlertTitle } from '@/components-v2/ui/Alert';
 import { Button } from '@/components-v2/ui/Button';
 import { Form, FormControl, FormField, FormItem, FormMessage } from '@/components-v2/ui/Form';


### PR DESCRIPTION
## Problem

`GoogleButton` (the Google OAuth sign-in/sign-up button) lived under `components/ui/button/Auth/Google`, putting an app-specific OAuth flow component in the v1 design-system tree. This path is in scope for v2 migration work, which should not absorb app-specific patterns as design-system primitives.

## Solution

Moves `GoogleButton` to `components-v2/patterns/GoogleButton` — the existing home for app-specific patterns built on top of v2 primitives — and updates both callsites. Adds a Storybook story under `stories/v2-patterns/GoogleButton.stories.tsx`.

Fixes [NAN-5829](https://linear.app/nango/issue/NAN-5829)

## Testing

- TypeScript build passes clean (`npm run ts-build`)
- No remaining imports from `components/ui/button/Auth/Google`
- Sign In and Sign Up pages still render the Google button correctly (verify against staging)

<!-- start telescope-canary-packages -->
<!-- end telescope-canary-packages -->
