### PR TITLE
fix(webhook): Bypass integration level webhook signing for Folk

### DIFF
--- a/packages/server/lib/webhook/folk-webhook-routing.ts
+++ b/packages/server/lib/webhook/folk-webhook-routing.ts
@@ -15,7 +15,9 @@ import type { IntegrationConfig } from '@nangohq/types';
 function validate(integration: IntegrationConfig, headers: Record<string, string>, rawBody: string): boolean {
     const secret = integration.custom?.['webhookSecret'];
     if (!secret) {
-        return false;
+        // Folk webhooks are registered at the connection level, so checking against an integration secret only works if there is only a single connection for this integration.
+        // In practice, the platform does not currently support validating Folk webhooks so we will allow requests through here until we add connection level webhook validation.
+        return true;
     }
 
     const msgId = headers['webhook-id'];


### PR DESCRIPTION
<!-- Describe the problem and your solution --> 
Right now we only support signing secrets at the integration level, but Folk webhook registrations are at the connection level. There is no single key that can be used for signing all connections.

<!-- Issue ticket number and link (if applicable) -->
[NAN-5839: TheMobileFirstCo - Skip secret key validation on Folk webhooks](https://linear.app/nango/issue/NAN-5839/themobilefirstco-skip-secret-key-validation-on-folk-webhooks)

<!-- Testing instructions (skip if just adding/editing providers) -->

