### PR TITLE
feat(records_seen): add generation bigint column (NAN-5491 Phase 2a)

### DIFF
--- a/packages/records/lib/stores/postgres/migrations/20260603100000_records_seen_add_generation.ts
+++ b/packages/records/lib/stores/postgres/migrations/20260603100000_records_seen_add_generation.ts
@@ -1,0 +1,12 @@
+import type { Knex } from 'knex';
+
+const TABLE = 'records_seen';
+
+// First step of the expand-contract widening that replaces records_seen.sync_job_id (int4) with a
+// bigint column called generation. Adding the column is metadata-only and nullable so writers can
+// adopt it (Phase 2b) without a schema dance.
+export async function up(knex: Knex): Promise<void> {
+    await knex.raw(`ALTER TABLE "${TABLE}" ADD COLUMN IF NOT EXISTS generation bigint`);
+}
+
+export async function down(): Promise<void> {}


### PR DESCRIPTION
- Adds a nullable `generation bigint` column to `nango_records.records_seen`. First step of the expand-contract widening replacing the int4 `sync_job_id` column with a bigint `generation` column. Metadata-only, no scan, no rewrite.

## Test plan

- [x] Local: migration applies cleanly; column is nullable `bigint`.
- [ ] Staging.
- [ ] Production.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
