### PR TITLE
chore(test): mock httpCall to fix flaky request tests

### DIFF
--- a/packages/shared/lib/services/proxy/request.unit.test.ts
+++ b/packages/shared/lib/services/proxy/request.unit.test.ts
@@ -1,8 +1,23 @@
+import { AxiosError } from 'axios';
 import { describe, expect, it, vi } from 'vitest';
 
 import { ProxyRequest } from './request.js';
 import { getDefaultProxy } from './utils.test.js';
 import { getTestConnection } from '../../seeders/connection.seeder.js';
+
+import type { InternalAxiosRequestConfig } from 'axios';
+
+function makeAxiosError(status: number): AxiosError {
+    const err = new AxiosError(`Request failed with status code ${status}`);
+    err.response = {
+        status,
+        data: {},
+        headers: {},
+        statusText: String(status),
+        config: {} as InternalAxiosRequestConfig
+    };
+    return err;
+}
 
 describe('call', () => {
     it('should make a single successful http call', async () => {
@@ -12,6 +27,13 @@ describe('call', () => {
             proxyConfig: getDefaultProxy({ provider: { proxy: { base_url: 'https://httpstatuses.maor.io' } }, endpoint: '/200' }),
             getConnection: () => getTestConnection(),
             getIntegrationConfig: () => ({ oauth_client_id: null, oauth_client_secret: null })
+        });
+        vi.spyOn(proxy, 'httpCall').mockResolvedValue({
+            status: 200,
+            data: {},
+            headers: {},
+            config: {} as InternalAxiosRequestConfig,
+            statusText: 'OK'
         });
         const res = (await proxy.request()).unwrap();
         expect(res).toMatchObject({ status: 200 });
@@ -36,6 +58,7 @@ describe('call', () => {
             getConnection: () => getTestConnection(),
             getIntegrationConfig: () => ({ oauth_client_id: null, oauth_client_secret: null })
         });
+        vi.spyOn(proxy, 'httpCall').mockRejectedValue(makeAxiosError(400));
         await expect(async () => (await proxy.request()).unwrap()).rejects.toThrowError();
         expect(fn).toHaveBeenNthCalledWith(
             1,
@@ -69,6 +92,7 @@ describe('call', () => {
             getConnection,
             getIntegrationConfig: () => ({ oauth_client_id: null, oauth_client_secret: null })
         });
+        vi.spyOn(proxy, 'httpCall').mockRejectedValue(makeAxiosError(500));
         await expect(async () => (await proxy.request()).unwrap()).rejects.toThrowError();
         expect(fn).toHaveBeenNthCalledWith(
             1,


### PR DESCRIPTION
## Problem

Two tests in `request.unit.test.ts` were making real HTTP calls to `httpstatuses.maor.io` with only a 5s timeout, causing intermittent CI failures when the external service was slow or unavailable.

[Original failing run](https://github.com/NangoHQ/nango/actions/runs/26891628504/job/79319075563?pr=6336).

## Solution

Mock `httpCall` (already public on `ProxyRequest` for testing purposes) on each proxy instance using `vi.spyOn`. This makes the tests network-independent and deterministic. Also mocks `httpCall` in the retry test to remove its real network dependency while keeping the `{ timeout: 10000 }` to accommodate the real 3s retry delay in `retryFlexible`.

## Testing

- All 3 tests in `request.unit.test.ts` pass locally
- Tests 1 and 2 now complete in <10ms instead of timing out at 5s
