### PR TITLE
fix(server): preserve `token_response_metadata` fields when processing connection config overrides

### DIFF
--- a/packages/server/lib/controllers/oauth.controller.ts
+++ b/packages/server/lib/controllers/oauth.controller.ts
@@ -1719,12 +1719,8 @@ class OAuthController {
                     }
                 };
 
-                connectionConfig = Object.keys(session.connectionConfig).reduce((acc: Record<string, string>, key: string) => {
-                    if (key !== 'oauth_client_id_override') {
-                        acc[key] = connectionConfig[key] as string;
-                    }
-                    return acc;
-                }, {});
+                const { oauth_client_id_override: _, ...rest } = connectionConfig;
+                connectionConfig = rest;
             }
 
             if (connectionConfig['oauth_client_secret_override']) {
@@ -1736,12 +1732,8 @@ class OAuthController {
                     }
                 };
 
-                connectionConfig = Object.keys(session.connectionConfig).reduce((acc: Record<string, string>, key: string) => {
-                    if (key !== 'oauth_client_secret_override') {
-                        acc[key] = connectionConfig[key] as string;
-                    }
-                    return acc;
-                }, {});
+                const { oauth_client_secret_override: _, ...rest } = connectionConfig;
+                connectionConfig = rest;
             }
 
             if (connectionConfig['oauth_scopes_override']) {
@@ -1761,15 +1753,8 @@ class OAuthController {
                     }
                 };
 
-                connectionConfig = Object.keys(session.connectionConfig).reduce(
-                    (acc: Record<string, string | boolean>, key: string) => {
-                        if (key !== 'oauth_refresh_token_override') {
-                            acc[key] = connectionConfig[key] as string;
-                        }
-                        return acc;
-                    },
-                    { overrideTokenRefresh: true }
-                );
+                const { oauth_refresh_token_override: _, ...rest } = connectionConfig;
+                connectionConfig = { ...rest, overrideTokenRefresh: true };
             }
 
             let connectSession: ConnectSessionAndEndUser | undefined;

--- a/packages/shared/lib/clients/provider.client.ts
+++ b/packages/shared/lib/clients/provider.client.ts
@@ -264,6 +264,14 @@ class ProviderClient {
     public async introspectedTokenExpired(config: ProviderConfig, connection: DBConnectionDecrypted): Promise<boolean> {
         const { credentials } = connection;
 
+        if (credentials.type === 'OAUTH2' && (credentials.config_override?.client_id || credentials.config_override?.client_secret)) {
+            config = {
+                ...config,
+                ...(credentials.config_override.client_id && { oauth_client_id: credentials.config_override.client_id }),
+                ...(credentials.config_override.client_secret && { oauth_client_secret: credentials.config_override.client_secret })
+            };
+        }
+
         function resolveByType(): { accessToken: string; clientId: string; clientSecret: string } {
             switch (credentials.type) {
                 case 'OAUTH2':


### PR DESCRIPTION
## Describe the problem and your solution

-  preserve `token_response_metadata` fields when processing connection config overrides.
- When introspecting tokens for salesforce, use config overrides if they are present.

<!-- Issue ticket number and link (if applicable) -->

<!-- Testing instructions (skip if just adding/editing providers) -->

