### PR TITLE
feat(records): route to secondary store based on plan

### DIFF
--- a/packages/database/lib/migrations/20260603140000_plans_add_records_store.cjs
+++ b/packages/database/lib/migrations/20260603140000_plans_add_records_store.cjs
@@ -1,0 +1,13 @@
+/**
+ * @param {import('knex').Knex} knex
+ */
+exports.up = async function (knex) {
+    await knex.schema.raw(`ALTER TABLE plans ADD COLUMN IF NOT EXISTS records_store VARCHAR(255) NOT NULL DEFAULT 'default'`);
+};
+
+/**
+ * @param {import('knex').Knex} knex
+ */
+exports.down = async function () {};
+
+exports.config = { transaction: true };

--- a/packages/jobs/lib/execution/sync.integration.test.ts
+++ b/packages/jobs/lib/execution/sync.integration.test.ts
@@ -239,7 +239,8 @@ const runJob = async (
         connectionId: connection.id,
         environmentId: connection.environment_id,
         model,
-        softDelete
+        softDelete,
+        plan: null
     });
     if (upserting.isErr()) {
         throw new Error(`failed to upsert records: ${upserting.error.message}`);
@@ -296,7 +297,7 @@ const verifySyncRun = async (
 };
 
 const getRecords = async (connection: ConnectionJobs, model: string) => {
-    const res = await recordsService.getRecords({ connectionId: connection.id, model });
+    const res = await recordsService.getRecords({ connectionId: connection.id, model, plan: null });
     if (res.isOk()) {
         return res.value.records;
     }
@@ -324,7 +325,8 @@ async function populateRecords(
             records: records.slice(i, i + chunkSize),
             connectionId: connection.id,
             environmentId: connection.environment_id,
-            model
+            model,
+            plan: null
         });
         if (res.isErr()) {
             throw new Error(`Failed to upsert records: ${res.error.message}`);

--- a/packages/jobs/lib/execution/sync.ts
+++ b/packages/jobs/lib/execution/sync.ts
@@ -315,6 +315,7 @@ export async function handleSyncSuccess({
         }
         team = accountContext.account;
         environment = accountContext.environment;
+        const plan = accountContext.plan;
 
         if (!nangoProps.syncJobId) {
             throw new Error('syncJobId is required to update sync status');
@@ -359,7 +360,8 @@ export async function handleSyncSuccess({
                     environmentId: nangoProps.environmentId,
                     connectionId: nangoProps.nangoConnectionId,
                     model,
-                    generation: nangoProps.syncJobId
+                    generation: nangoProps.syncJobId,
+                    plan
                 });
                 if (res.isErr()) {
                     throw res.error;

--- a/packages/persist/lib/daemons/autodeleting.daemon.ts
+++ b/packages/persist/lib/daemons/autodeleting.daemon.ts
@@ -1,7 +1,8 @@
 import tracer from 'dd-trace';
 
+import db from '@nangohq/database';
 import { Cursor, records } from '@nangohq/records';
-import { isSyncStale } from '@nangohq/shared';
+import { getPlanSafe, isSyncStale } from '@nangohq/shared';
 import { cancellableDaemon } from '@nangohq/utils';
 
 import { envs } from '../env.js';
@@ -49,11 +50,14 @@ export function autoDeletingDaemon(): Awaited<ReturnType<typeof cancellableDaemo
                         return;
                     }
 
+                    const plan = await getPlanSafe(db.knex, { environmentId: candidate.value.environmentId });
+
                     const res = await records.deleteRecords({
                         environmentId: candidate.value.environmentId,
                         connectionId: candidate.value.connectionId,
                         model: candidate.value.model,
-                        mode: 'hard'
+                        mode: 'hard',
+                        plan
                     });
                     if (res.isErr()) {
                         span?.addTags({ error: res.error.message });

--- a/packages/persist/lib/daemons/autopruning.daemon.ts
+++ b/packages/persist/lib/daemons/autopruning.daemon.ts
@@ -35,6 +35,7 @@ export function autoPruningDaemon(): Awaited<ReturnType<typeof cancellableDaemon
 
                     span?.addTags({ candidate: candidate.value });
 
+                    let currentPlan = null;
                     if (flagHasPlan) {
                         const plan = await getPlan(db.knex, { environmentId: candidate.value.environmentId });
                         if (plan.isErr()) {
@@ -47,6 +48,7 @@ export function autoPruningDaemon(): Awaited<ReturnType<typeof cancellableDaemon
                             logger.info(`[Auto-pruning] skipping pruning as feature not in plan for account: ${plan.value.account_id}`);
                             return;
                         }
+                        currentPlan = plan.value;
                     }
 
                     const res = await records.deleteRecords({
@@ -55,7 +57,8 @@ export function autoPruningDaemon(): Awaited<ReturnType<typeof cancellableDaemon
                         model: candidate.value.model,
                         mode: 'prune',
                         toCursorIncluded: candidate.value.cursor,
-                        limit: envs.PERSIST_AUTO_PRUNING_LIMIT
+                        limit: envs.PERSIST_AUTO_PRUNING_LIMIT,
+                        plan: currentPlan
                     });
                     if (res.isErr()) {
                         span?.addTags({ error: res.error.message });

--- a/packages/persist/lib/records.ts
+++ b/packages/persist/lib/records.ts
@@ -9,7 +9,7 @@ import { logger } from './logger.js';
 import { pubsub } from './pubsub.js';
 
 import type { FormattedRecord, UnencryptedRecordData, UpsertSummary } from '@nangohq/records';
-import type { DBEnvironment, MergingStrategy } from '@nangohq/types';
+import type { DBEnvironment, DBPlan, MergingStrategy } from '@nangohq/types';
 import type { Result } from '@nangohq/utils';
 import type { Span } from 'dd-trace';
 
@@ -27,7 +27,8 @@ export async function persistRecords({
     model,
     records,
     activityLogId,
-    merging = { strategy: 'override' }
+    merging = { strategy: 'override' },
+    plan
 }: {
     persistType: PersistType;
     accountId: number;
@@ -40,6 +41,7 @@ export async function persistRecords({
     records: Record<string, any>[];
     activityLogId: string;
     merging?: MergingStrategy;
+    plan: DBPlan | null;
 }): Promise<Result<MergingStrategy>> {
     const active = tracer.scope().active();
     const span = tracer.startSpan('persistRecords', {
@@ -71,17 +73,17 @@ export async function persistRecords({
         case 'save':
             softDelete = false;
             persistFunction = async (records: FormattedRecord[]) =>
-                recordsService.upsert({ records, connectionId, environmentId: environment.id, model, softDelete, merging });
+                recordsService.upsert({ records, connectionId, environmentId: environment.id, model, softDelete, merging, plan });
             break;
         case 'delete':
             softDelete = true;
             persistFunction = async (records: FormattedRecord[]) =>
-                recordsService.upsert({ records, connectionId, environmentId: environment.id, model, softDelete, merging });
+                recordsService.upsert({ records, connectionId, environmentId: environment.id, model, softDelete, merging, plan });
             break;
         case 'update':
             softDelete = false;
             persistFunction = async (records: FormattedRecord[]) => {
-                return recordsService.update({ records, environmentId: environment.id, connectionId, model, merging });
+                return recordsService.update({ records, environmentId: environment.id, connectionId, model, merging, plan });
             };
             break;
     }

--- a/packages/persist/lib/routes/environment/environmentId/connection/connectionId/getCursor.ts
+++ b/packages/persist/lib/routes/environment/environmentId/connection/connectionId/getCursor.ts
@@ -30,12 +30,14 @@ const validate = validateRequest<GetCursor>(getCursorRequestParser);
 const handler = async (_req: EndpointRequest, res: EndpointResponse<GetCursor, AuthLocals>) => {
     const {
         parsedParams: { nangoConnectionId },
-        parsedQuery: { model, offset }
+        parsedQuery: { model, offset },
+        plan
     } = res.locals;
     const result = await records.getCursor({
         connectionId: nangoConnectionId,
         model,
-        offset
+        offset,
+        plan
     });
     if (result.isOk()) {
         res.json(result.value ? { cursor: result.value } : {});

--- a/packages/persist/lib/routes/environment/environmentId/connection/connectionId/getRecords.ts
+++ b/packages/persist/lib/routes/environment/environmentId/connection/connectionId/getRecords.ts
@@ -42,7 +42,7 @@ const handler = async (_req: EndpointRequest, res: EndpointResponse<GetRecords, 
     } = res.locals;
 
     let logCtx: LogContextStateless | undefined = undefined;
-    const { account } = res.locals;
+    const { account, plan } = res.locals;
     if (activityLogId) {
         logCtx = logContextGetter.getStateLess({ id: String(activityLogId), accountId: account.id });
     }
@@ -52,7 +52,8 @@ const handler = async (_req: EndpointRequest, res: EndpointResponse<GetRecords, 
         model,
         cursor,
         externalIds,
-        limit
+        limit,
+        plan
     });
 
     if (result.isOk()) {

--- a/packages/persist/lib/routes/environment/environmentId/connection/connectionId/sync/syncId/job/jobId/deleteHardRecords.ts
+++ b/packages/persist/lib/routes/environment/environmentId/connection/connectionId/sync/syncId/job/jobId/deleteHardRecords.ts
@@ -52,14 +52,15 @@ const validate = validateRequest<DeleteHardRecords>({
 const handler = async (_req: EndpointRequest, res: EndpointResponse<DeleteHardRecords, AuthLocals>) => {
     const { nangoConnectionId, environmentId, syncId } = res.locals.parsedParams;
     const { model } = res.locals.parsedBody;
-    const { account, environment } = res.locals;
+    const { account, environment, plan } = res.locals;
     const limit = envs.PERSIST_HARD_DELETE_LIMIT;
     const result = await records.deleteRecords({
         connectionId: nangoConnectionId,
         environmentId,
         model,
         mode: 'hard',
-        limit
+        limit,
+        plan
     });
     if (result.isOk()) {
         if (result.value.count > 0) {

--- a/packages/persist/lib/routes/environment/environmentId/connection/connectionId/sync/syncId/job/jobId/deleteOutdatedRecords.ts
+++ b/packages/persist/lib/routes/environment/environmentId/connection/connectionId/sync/syncId/job/jobId/deleteOutdatedRecords.ts
@@ -54,13 +54,14 @@ const validate = validateRequest<DeleteOutdatedRecords>({
 const handler = async (_req: EndpointRequest, res: EndpointResponse<DeleteOutdatedRecords, AuthLocals>) => {
     const { nangoConnectionId, syncId, syncJobId, environmentId } = res.locals.parsedParams;
     const { model, activityLogId } = res.locals.parsedBody;
-    const { account, environment } = res.locals;
+    const { account, environment, plan } = res.locals;
     const logCtx = logContextGetter.getStateLess({ id: String(activityLogId), accountId: account.id });
     const result = await records.deleteOutdatedRecords({
         environmentId,
         connectionId: nangoConnectionId,
         model,
-        generation: syncJobId
+        generation: syncJobId,
+        plan
     });
     if (result.isOk()) {
         const deleted = result.value.length;

--- a/packages/persist/lib/routes/environment/environmentId/connection/connectionId/sync/syncId/job/jobId/deleteRecords.ts
+++ b/packages/persist/lib/routes/environment/environmentId/connection/connectionId/sync/syncId/job/jobId/deleteRecords.ts
@@ -36,7 +36,7 @@ const validate = validateRequest<DeleteRecords>(recordsRequestParser);
 const handler = async (_req: EndpointRequest, res: EndpointResponse<DeleteRecords, AuthLocals>) => {
     const { nangoConnectionId, syncId, syncJobId }: DeleteRecords['Params'] = res.locals.parsedParams;
     const { model, records, providerConfigKey, activityLogId, merging }: DeleteRecords['Body'] = res.locals.parsedBody;
-    const { account, environment } = res.locals;
+    const { account, environment, plan } = res.locals;
     const result = await persistRecords({
         persistType: 'delete',
         environment,
@@ -48,7 +48,8 @@ const handler = async (_req: EndpointRequest, res: EndpointResponse<DeleteRecord
         model,
         records,
         activityLogId,
-        merging
+        merging,
+        plan
     });
     if (result.isOk()) {
         res.status(200).send({ nextMerging: result.value });

--- a/packages/persist/lib/routes/environment/environmentId/connection/connectionId/sync/syncId/job/jobId/postRecords.ts
+++ b/packages/persist/lib/routes/environment/environmentId/connection/connectionId/sync/syncId/job/jobId/postRecords.ts
@@ -36,7 +36,7 @@ const validate = validateRequest<PostRecords>(recordsRequestParser);
 const handler = async (_req: EndpointRequest, res: EndpointResponse<PostRecords, AuthLocals>) => {
     const { nangoConnectionId, syncId, syncJobId }: PostRecords['Params'] = res.locals.parsedParams;
     const { model, records, providerConfigKey, activityLogId, merging }: PostRecords['Body'] = res.locals.parsedBody;
-    const { account, environment } = res.locals;
+    const { account, environment, plan } = res.locals;
     const result = await persistRecords({
         persistType: 'save',
         accountId: account.id,
@@ -48,7 +48,8 @@ const handler = async (_req: EndpointRequest, res: EndpointResponse<PostRecords,
         model,
         records,
         activityLogId,
-        merging: merging
+        merging: merging,
+        plan
     });
     if (result.isOk()) {
         res.status(200).send({ nextMerging: result.value });

--- a/packages/persist/lib/routes/environment/environmentId/connection/connectionId/sync/syncId/job/jobId/putRecords.ts
+++ b/packages/persist/lib/routes/environment/environmentId/connection/connectionId/sync/syncId/job/jobId/putRecords.ts
@@ -36,7 +36,7 @@ const validate = validateRequest<PutRecords>(recordsRequestParser);
 const handler = async (_req: EndpointRequest, res: EndpointResponse<PutRecords, AuthLocals>) => {
     const { nangoConnectionId, syncId, syncJobId }: PutRecords['Params'] = res.locals.parsedParams;
     const { model, records, providerConfigKey, activityLogId, merging }: PutRecords['Body'] = res.locals.parsedBody;
-    const { account, environment } = res.locals;
+    const { account, environment, plan } = res.locals;
     const result = await persistRecords({
         persistType: 'update',
         accountId: account.id,
@@ -48,7 +48,8 @@ const handler = async (_req: EndpointRequest, res: EndpointResponse<PutRecords, 
         model,
         records,
         activityLogId,
-        merging
+        merging,
+        plan
     });
     if (result.isOk()) {
         res.status(200).send({ nextMerging: result.value });

--- a/packages/persist/lib/server.integration.test.ts
+++ b/packages/persist/lib/server.integration.test.ts
@@ -296,7 +296,8 @@ describe('Persist API', () => {
             const allRecords = (
                 await records.getRecords({
                     connectionId: seed.connection.id,
-                    model
+                    model,
+                    plan: null
                 })
             ).unwrap();
             const firstRecord = allRecords.records[0];
@@ -326,7 +327,8 @@ describe('Persist API', () => {
             const allRecords = (
                 await records.getRecords({
                     connectionId: seed.connection.id,
-                    model
+                    model,
+                    plan: null
                 })
             ).unwrap();
             const lastRecord = allRecords.records[allRecords.records.length - 1];
@@ -773,6 +775,7 @@ const insertRecords = async (seed: testSeed, model: string, toInsert: Unencrypte
         connectionId: seed.connection.id,
         environmentId: seed.env.id,
         model,
-        records: formatted
+        records: formatted,
+        plan: null
     });
 };

--- a/packages/records/lib/catalog/default.ts
+++ b/packages/records/lib/catalog/default.ts
@@ -1,45 +1,30 @@
 import { envs } from '../env.js';
+import { makePostgresConfig } from '../stores/postgres/config.js';
 import { PostgresStore } from '../stores/postgres/postgres.js';
-
-import type { Knex } from 'knex';
-
-export const schema = envs.RECORDS_DATABASE_SCHEMA;
 
 const databaseUrl =
     envs.RECORDS_DATABASE_URL ||
     envs.NANGO_DATABASE_URL ||
     `postgres://${encodeURIComponent(envs.NANGO_DB_USER)}:${encodeURIComponent(envs.NANGO_DB_PASSWORD)}@${envs.NANGO_DB_HOST}:${envs.NANGO_DB_PORT}/${envs.NANGO_DB_NAME}?application_name=${envs.NANGO_DB_APPLICATION_NAME}`;
-const runningMigrationOnly = process.argv.some((v) => v === 'migrate:latest');
-const isJS = !runningMigrationOnly;
 
-export const config: Knex.Config & { migrations: Knex.MigratorConfig } = {
-    client: 'postgres',
-    connection: {
-        connectionString: databaseUrl,
-        statement_timeout: envs.RECORDS_DATABASE_STATEMENT_TIMEOUT_MS,
-        ssl: envs.RECORDS_DATABASE_SSL ? { rejectUnauthorized: false } : false,
-        application_name: process.env['NANGO_DB_APPLICATION_NAME'] || '[unknown]'
-    },
-    searchPath: schema,
-    pool: { min: envs.RECORDS_DATABASE_POOL_MIN, max: envs.RECORDS_DATABASE_POOL_MAX },
-    migrations: {
-        extension: isJS ? 'js' : 'ts',
-        directory: 'migrations',
-        tableName: 'migrations',
-        loadExtensions: [isJS ? '.js' : '.ts'],
-        schemaName: schema
+const opts = {
+    databaseUrl,
+    schema: envs.RECORDS_DATABASE_SCHEMA,
+    statementTimeout: envs.RECORDS_DATABASE_STATEMENT_TIMEOUT_MS,
+    ssl: envs.RECORDS_DATABASE_SSL,
+    applicationName: process.env['NANGO_DB_APPLICATION_NAME'] || '[unknown]',
+    pool: {
+        min: envs.RECORDS_DATABASE_POOL_MIN,
+        max: envs.RECORDS_DATABASE_POOL_MAX
     }
 };
 
-const configRead: Knex.Config | undefined = envs.RECORDS_DATABASE_READ_URL
-    ? {
-          ...config,
-          connection: {
-              connectionString: envs.RECORDS_DATABASE_READ_URL,
-              statement_timeout: 60000,
-              application_name: process.env['NANGO_DB_APPLICATION_NAME'] || '[unknown]'
-          }
-      }
+const readWriteConfig = makePostgresConfig(opts);
+const readOnlyConfig = envs.RECORDS_DATABASE_READ_URL
+    ? makePostgresConfig({
+          ...opts,
+          databaseUrl: envs.RECORDS_DATABASE_READ_URL
+      })
     : undefined;
 
-export const defaultStore = new PostgresStore(config, configRead);
+export const defaultStore = new PostgresStore(readWriteConfig, readOnlyConfig);

--- a/packages/records/lib/catalog/records2.ts
+++ b/packages/records/lib/catalog/records2.ts
@@ -2,16 +2,16 @@ import { envs } from '../env.js';
 import { makePostgresConfig } from '../stores/postgres/config.js';
 import { PostgresStore } from '../stores/postgres/postgres.js';
 
-export const secondaryStore: PostgresStore | undefined = (() => {
-    if (!envs.RECORDS_SECONDARY_DATABASE_URL) {
+export const records2Store: PostgresStore | undefined = (() => {
+    if (!envs.RECORDS_2_DATABASE_URL) {
         return undefined;
     }
     const opts = {
-        databaseUrl: envs.RECORDS_SECONDARY_DATABASE_URL,
-        schema: envs.RECORDS_SECONDARY_DATABASE_SCHEMA,
+        databaseUrl: envs.RECORDS_2_DATABASE_URL,
+        schema: envs.RECORDS_2_DATABASE_SCHEMA,
         statementTimeout: envs.RECORDS_DATABASE_STATEMENT_TIMEOUT_MS,
-        ssl: envs.RECORDS_SECONDARY_DATABASE_SSL,
-        applicationName: process.env['NANGO_DB_APPLICATION_NAME'],
+        ssl: envs.RECORDS_2_DATABASE_SSL,
+        applicationName: envs.NANGO_DB_APPLICATION_NAME,
         pool: {
             min: envs.RECORDS_DATABASE_POOL_MIN,
             max: envs.RECORDS_DATABASE_POOL_MAX
@@ -19,10 +19,10 @@ export const secondaryStore: PostgresStore | undefined = (() => {
     };
 
     const readWriteConfig = makePostgresConfig(opts);
-    const readOnlyConfig = envs.RECORDS_SECONDARY_DATABASE_READ_URL
+    const readOnlyConfig = envs.RECORDS_2_DATABASE_READ_URL
         ? makePostgresConfig({
               ...opts,
-              databaseUrl: envs.RECORDS_SECONDARY_DATABASE_READ_URL
+              databaseUrl: envs.RECORDS_2_DATABASE_READ_URL
           })
         : undefined;
     return new PostgresStore(readWriteConfig, readOnlyConfig);

--- a/packages/records/lib/catalog/router.ts
+++ b/packages/records/lib/catalog/router.ts
@@ -1,7 +1,8 @@
 import { Ok, flagHasPlan } from '@nangohq/utils';
 
 import { defaultStore } from './default.js';
-import { secondaryStore } from './secondary.js';
+import { records2Store } from './records2.js';
+import { logger } from '../utils/logger.js';
 
 import type { RecordsStore } from '../store.js';
 import type { RecordCount } from '../types.js';
@@ -45,7 +46,7 @@ export class RecordsRouter<K extends string> implements RoutedRecordsStore {
 
     // Lifecycle: runs against all stores
     migrate: RecordsStore['migrate'] = async () => {
-        await Promise.allSettled([...this.stores.values()].map((s) => s.migrate()));
+        await Promise.all([...this.stores.values()].map((s) => s.migrate()));
     };
     close: RecordsStore['close'] = async () => {
         await Promise.allSettled([...this.stores.values()].map((s) => s.close()));
@@ -110,7 +111,7 @@ export class Routing<K extends string> {
 
 const stores = {
     default: defaultStore,
-    secondary: secondaryStore
+    records2: records2Store
 };
 // The routing store is the one responsible for persisting the routing decisions for each connection/model.
 // For simplicity, we use the default store, but it could be a separate store or an external service.
@@ -120,8 +121,8 @@ const routingStore = defaultStore;
 // It must not change across calls for a given context. (ie: Rebalancing and moving data between stores is not supported)
 const routingCache = new Map<string, keyof typeof stores>();
 const routing = new Routing(async (ctx: RoutingContext) => {
-    // Skip routing entirely when secondary store is not configured or feature flag is off
-    if (!flagHasPlan || !stores.secondary) return 'default';
+    // Skip routing entirely when records2 store is not configured or feature flag is off
+    if (!flagHasPlan || !stores.records2) return 'default';
 
     const cacheKey = `${ctx.connectionId}:${ctx.model}`;
     const cached = routingCache.get(cacheKey);
@@ -129,13 +130,16 @@ const routing = new Routing(async (ctx: RoutingContext) => {
 
     const storeKey = ctx.plan?.records_store || 'default';
 
-    // Persist the assignment on first access; existing records are returned unchanged
+    // Persist the assignment on first access
+    // Existing records are pinned to the assigned store at dataset creation.
     const res = await routingStore.getOrCreateRouting({ connectionId: ctx.connectionId, model: ctx.model, storeKey, ifExists: 'default' });
 
-    // Ensure the assigned store exists, otherwise fallback to default
-    const resolved = res.isOk() && stores[res.value] ? res.value : 'default';
-    routingCache.set(cacheKey, resolved);
-    return resolved;
+    if (res.isOk() && stores[res.value]) {
+        routingCache.set(cacheKey, res.value);
+        return res.value;
+    }
+    logger.error('Routing error for connection', ctx.connectionId, 'model', ctx.model, ':', res.isErr() ? res.error : `invalid store ${res.value}`);
+    return 'default';
 });
 
 export const records = new RecordsRouter({ stores, routing });

--- a/packages/records/lib/catalog/router.ts
+++ b/packages/records/lib/catalog/router.ts
@@ -1,31 +1,42 @@
-import { Ok } from '@nangohq/utils';
+import { Ok, flagHasPlan } from '@nangohq/utils';
 
 import { defaultStore } from './default.js';
+import { secondaryStore } from './secondary.js';
 
 import type { RecordsStore } from '../store.js';
 import type { RecordCount } from '../types.js';
 import type { DBPlan } from '@nangohq/types';
 
-// Augments a store method signature with an optional plan parameter for routing purposes.
-type Routed<F> = F extends (params: infer P) => infer R ? (params: P & { plan?: DBPlan }) => R : never;
+// Augments a store method signature with a plan parameter for routing purposes.
+type Routed<F> = F extends (params: infer P) => infer R ? (params: P & { plan: DBPlan | null }) => R : never;
+
+type RoutedRecordsStore = Omit<RecordsStore, 'getRecords' | 'getCursor' | 'upsert' | 'update' | 'deleteRecords' | 'deleteOutdatedRecords'> & {
+    getRecords: Routed<RecordsStore['getRecords']>;
+    getCursor: Routed<RecordsStore['getCursor']>;
+    upsert: Routed<RecordsStore['upsert']>;
+    update: Routed<RecordsStore['update']>;
+    deleteRecords: Routed<RecordsStore['deleteRecords']>;
+    deleteOutdatedRecords: Routed<RecordsStore['deleteOutdatedRecords']>;
+};
 
 interface RoutingContext {
-    plan?: DBPlan | undefined;
+    plan: DBPlan | null;
     connectionId: number;
     model: string;
 }
 
-export class RecordsRouter<K extends string> implements RecordsStore {
+export class RecordsRouter<K extends string> implements RoutedRecordsStore {
     private readonly stores: Map<K, RecordsStore>;
     private readonly routing: Routing<K>;
 
-    constructor({ stores, routing }: { stores: Record<K, RecordsStore>; routing: Routing<K> }) {
-        this.stores = new Map(Object.entries(stores) as [K, RecordsStore][]);
+    constructor({ stores, routing }: { stores: Record<K, RecordsStore | undefined>; routing: Routing<K> }) {
+        this.stores = new Map(Object.entries(stores).filter(([_, v]) => v !== undefined) as [K, RecordsStore][]);
         this.routing = routing;
     }
 
-    private resolve(ctx: RoutingContext): RecordsStore {
-        return this.stores.get(this.routing.get(ctx))!;
+    private async resolve(ctx: RoutingContext): Promise<RecordsStore> {
+        const key = await this.routing.get(ctx);
+        return this.stores.get(key)!;
     }
 
     private random(): RecordsStore {
@@ -44,23 +55,23 @@ export class RecordsRouter<K extends string> implements RecordsStore {
     };
 
     // Dataset ops: routed to a specific store
-    getRecords: Routed<RecordsStore['getRecords']> = ({ plan, ...params }) =>
-        this.resolve({ plan, connectionId: params.connectionId, model: params.model }).getRecords(params);
+    getRecords: Routed<RecordsStore['getRecords']> = async ({ plan, ...params }) =>
+        (await this.resolve({ plan, connectionId: params.connectionId, model: params.model })).getRecords(params);
 
-    getCursor: Routed<RecordsStore['getCursor']> = ({ plan, ...params }) =>
-        this.resolve({ plan, connectionId: params.connectionId, model: params.model }).getCursor(params);
+    getCursor: Routed<RecordsStore['getCursor']> = async ({ plan, ...params }) =>
+        (await this.resolve({ plan, connectionId: params.connectionId, model: params.model })).getCursor(params);
 
-    upsert: Routed<RecordsStore['upsert']> = ({ plan, ...params }) =>
-        this.resolve({ plan, connectionId: params.connectionId, model: params.model }).upsert(params);
+    upsert: Routed<RecordsStore['upsert']> = async ({ plan, ...params }) =>
+        (await this.resolve({ plan, connectionId: params.connectionId, model: params.model })).upsert(params);
 
-    update: Routed<RecordsStore['update']> = ({ plan, ...params }) =>
-        this.resolve({ plan, connectionId: params.connectionId, model: params.model }).update(params);
+    update: Routed<RecordsStore['update']> = async ({ plan, ...params }) =>
+        (await this.resolve({ plan, connectionId: params.connectionId, model: params.model })).update(params);
 
-    deleteRecords: Routed<RecordsStore['deleteRecords']> = ({ plan, ...params }) =>
-        this.resolve({ plan, connectionId: params.connectionId, model: params.model }).deleteRecords(params);
+    deleteRecords: Routed<RecordsStore['deleteRecords']> = async ({ plan, ...params }) =>
+        (await this.resolve({ plan, connectionId: params.connectionId, model: params.model })).deleteRecords(params);
 
-    deleteOutdatedRecords: Routed<RecordsStore['deleteOutdatedRecords']> = ({ plan, ...params }) =>
-        this.resolve({ plan, connectionId: params.connectionId, model: params.model }).deleteOutdatedRecords(params);
+    deleteOutdatedRecords: Routed<RecordsStore['deleteOutdatedRecords']> = async ({ plan, ...params }) =>
+        (await this.resolve({ plan, connectionId: params.connectionId, model: params.model })).deleteOutdatedRecords(params);
 
     // Aggregation ops: fan-out across stores
     getCountsByModel: RecordsStore['getCountsByModel'] = async (params) => {
@@ -90,21 +101,41 @@ export class RecordsRouter<K extends string> implements RecordsStore {
 }
 
 export class Routing<K extends string> {
-    constructor(private readonly routing: (ctx: RoutingContext) => K) {}
+    constructor(private readonly routing: (ctx: RoutingContext) => Promise<K>) {}
 
-    public get(ctx: RoutingContext): K {
+    public get(ctx: RoutingContext): Promise<K> {
         return this.routing(ctx);
     }
 }
 
+const stores = {
+    default: defaultStore,
+    secondary: secondaryStore
+};
+// The routing store is the one responsible for persisting the routing decisions for each connection/model.
+// For simplicity, we use the default store, but it could be a separate store or an external service.
+const routingStore = defaultStore;
+
 // Routing is fixed and deterministic based on the routing context.
 // It must not change across calls for a given context. (ie: Rebalancing and moving data between stores is not supported)
-const routing = new Routing((_ctx: RoutingContext) => {
-    // For now we have a single store, so we can ignore the context and always assign/return the default store
-    // In the future, this can be extended to route based on connectionId, model, plan, account, etc.
-    // and routing decisions can be stored in a database
-    return 'default';
+const routingCache = new Map<string, keyof typeof stores>();
+const routing = new Routing(async (ctx: RoutingContext) => {
+    // Skip routing entirely when secondary store is not configured or feature flag is off
+    if (!flagHasPlan || !stores.secondary) return 'default';
+
+    const cacheKey = `${ctx.connectionId}:${ctx.model}`;
+    const cached = routingCache.get(cacheKey);
+    if (cached) return cached;
+
+    const storeKey = ctx.plan?.records_store || 'default';
+
+    // Persist the assignment on first access; existing records are returned unchanged
+    const res = await routingStore.getOrCreateRouting({ connectionId: ctx.connectionId, model: ctx.model, storeKey, ifExists: 'default' });
+
+    // Ensure the assigned store exists, otherwise fallback to default
+    const resolved = res.isOk() && stores[res.value] ? res.value : 'default';
+    routingCache.set(cacheKey, resolved);
+    return resolved;
 });
-const stores = { default: defaultStore };
 
 export const records = new RecordsRouter({ stores, routing });

--- a/packages/records/lib/catalog/router.unit.test.ts
+++ b/packages/records/lib/catalog/router.unit.test.ts
@@ -11,7 +11,7 @@ import type { DBPlan } from '@nangohq/types';
 type StoreKey = 'a' | 'b';
 
 const plan = { id: 1, account_id: 1 } as unknown as DBPlan;
-const routeToA = new Routing<StoreKey>(() => 'a');
+const routeToA = new Routing<StoreKey>(async () => 'a'); // eslint-disable-line @typescript-eslint/require-await
 
 function makeStore(overrides: Partial<RecordsStore> = {}): RecordsStore {
     return overrides as unknown as RecordsStore;
@@ -74,7 +74,7 @@ describe('RecordsRouter', () => {
                 .mockResolvedValue(
                     Ok({ addedKeys: [], updatedKeys: [], unchangedKeys: [], nonUniqueKeys: [], activatedKeys: [], nextMerging: { strategy: 'override' } })
                 );
-            const routing = new Routing<StoreKey>((ctx) => (ctx.connectionId === 1 ? 'a' : 'b'));
+            const routing = new Routing<StoreKey>(async (ctx) => (ctx.connectionId === 1 ? 'a' : 'b')); // eslint-disable-line @typescript-eslint/require-await
             const router = new RecordsRouter<StoreKey>({
                 stores: { a: makeStore({ upsert: upsertA }), b: makeStore({ upsert: upsertB }) },
                 routing

--- a/packages/records/lib/catalog/secondary.ts
+++ b/packages/records/lib/catalog/secondary.ts
@@ -1,0 +1,29 @@
+import { envs } from '../env.js';
+import { makePostgresConfig } from '../stores/postgres/config.js';
+import { PostgresStore } from '../stores/postgres/postgres.js';
+
+export const secondaryStore: PostgresStore | undefined = (() => {
+    if (!envs.RECORDS_SECONDARY_DATABASE_URL) {
+        return undefined;
+    }
+    const opts = {
+        databaseUrl: envs.RECORDS_SECONDARY_DATABASE_URL,
+        schema: envs.RECORDS_SECONDARY_DATABASE_SCHEMA,
+        statementTimeout: envs.RECORDS_DATABASE_STATEMENT_TIMEOUT_MS,
+        ssl: envs.RECORDS_SECONDARY_DATABASE_SSL,
+        applicationName: process.env['NANGO_DB_APPLICATION_NAME'],
+        pool: {
+            min: envs.RECORDS_DATABASE_POOL_MIN,
+            max: envs.RECORDS_DATABASE_POOL_MAX
+        }
+    };
+
+    const readWriteConfig = makePostgresConfig(opts);
+    const readOnlyConfig = envs.RECORDS_SECONDARY_DATABASE_READ_URL
+        ? makePostgresConfig({
+              ...opts,
+              databaseUrl: envs.RECORDS_SECONDARY_DATABASE_READ_URL
+          })
+        : undefined;
+    return new PostgresStore(readWriteConfig, readOnlyConfig);
+})();

--- a/packages/records/lib/constants.ts
+++ b/packages/records/lib/constants.ts
@@ -2,5 +2,6 @@ export const RECORDS_TABLE = 'records';
 export const RECORD_COUNTS_TABLE = 'record_counts';
 export const RECORDS_DATA_TABLE = 'records_data';
 export const RECORDS_SEEN_TABLE = 'records_seen';
+export const RECORDS_ROUTING_TABLE = 'records_routing';
 
 export const DEFAULT_RECORDS_LIMIT = 100;

--- a/packages/records/lib/stores/postgres/config.ts
+++ b/packages/records/lib/stores/postgres/config.ts
@@ -1,0 +1,34 @@
+import type { Knex } from 'knex';
+
+export function makePostgresConfig(opts: {
+    databaseUrl: string;
+    schema: string;
+    statementTimeout: number;
+    ssl: boolean;
+    applicationName?: string | undefined;
+    pool: {
+        min: number;
+        max: number;
+    };
+}): Knex.Config & { migrations: Knex.MigratorConfig } {
+    const runningMigrationOnly = process.argv.some((v) => v === 'migrate:latest');
+    const isJS = !runningMigrationOnly;
+    return {
+        client: 'postgres',
+        connection: {
+            connectionString: opts.databaseUrl,
+            statement_timeout: opts.statementTimeout,
+            ssl: opts.ssl ? { rejectUnauthorized: false } : false,
+            application_name: opts.applicationName || 'unknown'
+        },
+        searchPath: opts.schema,
+        pool: { min: opts.pool.min, max: opts.pool.max },
+        migrations: {
+            extension: isJS ? 'js' : 'ts',
+            directory: 'migrations',
+            tableName: 'migrations',
+            loadExtensions: [isJS ? '.js' : '.ts'],
+            schemaName: opts.schema
+        }
+    };
+}

--- a/packages/records/lib/stores/postgres/migrations/20260603000000_create_records_routing.ts
+++ b/packages/records/lib/stores/postgres/migrations/20260603000000_create_records_routing.ts
@@ -1,0 +1,19 @@
+import type { Knex } from 'knex';
+
+const TABLE = 'records_routing';
+
+export async function up(knex: Knex): Promise<void> {
+    await knex.raw(`
+        CREATE TABLE IF NOT EXISTS "${TABLE}" (
+            connection_id integer NOT NULL,
+            model character varying(255) NOT NULL,
+            store_key character varying(255) NOT NULL DEFAULT 'default',
+            created_at timestamp with time zone NOT NULL DEFAULT CURRENT_TIMESTAMP,
+            PRIMARY KEY (connection_id, model)
+        )
+    `);
+}
+
+export async function down(knex: Knex): Promise<void> {
+    await knex.raw(`DROP TABLE IF EXISTS "${TABLE}"`);
+}

--- a/packages/records/lib/stores/postgres/postgres.integration.test.ts
+++ b/packages/records/lib/stores/postgres/postgres.integration.test.ts
@@ -4,15 +4,15 @@ import * as uuid from 'uuid';
 import { afterAll, beforeAll, beforeEach, describe, expect, it } from 'vitest';
 
 import { PostgresStore, incrCount } from './postgres.js';
-import { config } from '../../catalog/default.js';
 import { RECORDS_DATA_TABLE, RECORDS_SEEN_TABLE, RECORDS_TABLE, RECORD_COUNTS_TABLE } from '../../constants.js';
 import { Cursor } from '../../cursor.js';
 import { envs } from '../../env.js';
+import { testConfig } from './tests/helpers.js';
 import { formatRecords } from '../../helpers/format.js';
 import { decryptRecordData, encryptRecords } from '../../utils/encryption.js';
 
-const db = knex(config);
-const store = new PostgresStore(config);
+const db = knex(testConfig);
+const store = new PostgresStore(testConfig);
 
 import type { FormattedRecord, RecordData, UnencryptedRecordData, UpsertSummary } from '../../types.js';
 import type { MergingStrategy, Result } from '@nangohq/types';

--- a/packages/records/lib/stores/postgres/postgres.ts
+++ b/packages/records/lib/stores/postgres/postgres.ts
@@ -8,7 +8,7 @@ import knex from 'knex';
 
 import { Err, Ok, cancellableDaemon, retry, stringToHash } from '@nangohq/utils';
 
-import { DEFAULT_RECORDS_LIMIT, RECORDS_DATA_TABLE, RECORDS_SEEN_TABLE, RECORDS_TABLE, RECORD_COUNTS_TABLE } from '../../constants.js';
+import { DEFAULT_RECORDS_LIMIT, RECORDS_DATA_TABLE, RECORDS_ROUTING_TABLE, RECORDS_SEEN_TABLE, RECORDS_TABLE, RECORD_COUNTS_TABLE } from '../../constants.js';
 import { Cursor } from '../../cursor.js';
 import { envs } from '../../env.js';
 import { deepMergeRecordData } from '../../helpers/merge.js';
@@ -1669,6 +1669,39 @@ export class PostgresStore implements RecordsStore {
             return Ok(null);
         } catch (err) {
             return Err(new Error(`Failed to find auto-delete candidate`, { cause: err }));
+        }
+    }
+
+    async getOrCreateRouting<K extends string>({
+        connectionId,
+        model,
+        storeKey,
+        ifExists
+    }: {
+        connectionId: number;
+        model: string;
+        storeKey: K;
+        ifExists: K;
+    }): Promise<Result<K>> {
+        try {
+            const result = await this.db.raw<{ rows: { store_key: string }[] }>(
+                `INSERT INTO "${RECORDS_ROUTING_TABLE}" (connection_id, model, store_key)
+                 VALUES (
+                     :connectionId,
+                     :model,
+                     CASE WHEN EXISTS (SELECT 1 FROM "${RECORDS_TABLE}" WHERE connection_id = :connectionId AND model = :model)
+                          THEN :ifExists
+                          ELSE :storeKey
+                     END
+                 )
+                 ON CONFLICT (connection_id, model) DO UPDATE SET store_key = "${RECORDS_ROUTING_TABLE}".store_key
+                 RETURNING store_key`,
+                { connectionId, model, storeKey, ifExists }
+            );
+            const [row] = result.rows;
+            return Ok(row!.store_key as K);
+        } catch (err) {
+            return Err(new Error('Failed to get or create routing', { cause: err }));
         }
     }
 

--- a/packages/records/lib/stores/postgres/tests/helpers.ts
+++ b/packages/records/lib/stores/postgres/tests/helpers.ts
@@ -1,8 +1,21 @@
 import knex from 'knex';
 
-import { config, schema } from '../../../catalog/default.js';
+import { envs } from '../../../env.js';
+import { makePostgresConfig } from '../config.js';
 
-const db = knex(config);
+const schema = envs.RECORDS_DATABASE_SCHEMA;
+export const testConfig = makePostgresConfig({
+    databaseUrl: envs.RECORDS_DATABASE_URL!,
+    schema,
+    statementTimeout: envs.RECORDS_DATABASE_STATEMENT_TIMEOUT_MS,
+    ssl: envs.RECORDS_DATABASE_SSL,
+    applicationName: 'tests',
+    pool: {
+        min: envs.RECORDS_DATABASE_POOL_MIN,
+        max: envs.RECORDS_DATABASE_POOL_MAX
+    }
+});
+const db = knex(testConfig);
 
 // WARNING: to use only in tests
 export async function clearDb(): Promise<void> {

--- a/packages/server/lib/controllers/records/getRecords.integration.test.ts
+++ b/packages/server/lib/controllers/records/getRecords.integration.test.ts
@@ -117,7 +117,8 @@ describe(`GET ${route}`, () => {
                 .unwrap(),
             connectionId: conn.id,
             environmentId: env.id,
-            model: 'Ticket'
+            model: 'Ticket',
+            plan: null
         });
 
         // Fetch first page
@@ -206,7 +207,8 @@ describe(`GET ${route}`, () => {
                 .unwrap(),
             connectionId: conn.id,
             environmentId: env.id,
-            model: 'Ticket'
+            model: 'Ticket',
+            plan: null
         });
 
         // Added
@@ -231,7 +233,8 @@ describe(`GET ${route}`, () => {
                 .unwrap(),
             connectionId: conn.id,
             environmentId: env.id,
-            model: 'Ticket'
+            model: 'Ticket',
+            plan: null
         });
 
         // Updated
@@ -338,7 +341,8 @@ describe(`GET ${route}`, () => {
                 .unwrap(),
             connectionId: conn.id,
             environmentId: env.id,
-            model: 'Ticket'
+            model: 'Ticket',
+            plan: null
         });
 
         // One ID

--- a/packages/server/lib/controllers/records/getRecords.ts
+++ b/packages/server/lib/controllers/records/getRecords.ts
@@ -63,7 +63,7 @@ export const getPublicRecords = asyncWrapper<GetPublicRecords>(async (req, res) 
         return;
     }
 
-    const { environment, account } = res.locals;
+    const { environment, account, plan } = res.locals;
     const headers: GetPublicRecords['Headers'] = valHeaders.data;
     const query: GetPublicRecords['Querystring'] = valQuery.data;
 
@@ -84,7 +84,8 @@ export const getPublicRecords = asyncWrapper<GetPublicRecords>(async (req, res) 
             limit: query.limit,
             filter: query.filter,
             cursor: query.cursor,
-            externalIds: query.ids
+            externalIds: query.ids,
+            plan
         });
 
         if (result.isErr()) {

--- a/packages/server/lib/controllers/records/patchPruneRecords.integration.test.ts
+++ b/packages/server/lib/controllers/records/patchPruneRecords.integration.test.ts
@@ -103,12 +103,14 @@ describe(`PATCH ${route}`, () => {
                 .unwrap(),
             connectionId: conn.id,
             environmentId: env.id,
-            model: 'Ticket'
+            model: 'Ticket',
+            plan: null
         });
         const recs = (
             await records.getRecords({
                 connectionId: conn.id,
-                model: 'Ticket'
+                model: 'Ticket',
+                plan: null
             })
         ).unwrap();
         expect(recs.records.length).toBe(3);
@@ -208,13 +210,15 @@ describe(`PATCH ${route}`, () => {
                 .unwrap(),
             connectionId: conn.id,
             environmentId: env.id,
-            model: 'Ticket'
+            model: 'Ticket',
+            plan: null
         });
 
         const recs = (
             await records.getRecords({
                 connectionId: conn.id,
-                model: 'Ticket'
+                model: 'Ticket',
+                plan: null
             })
         ).unwrap();
         expect(recs.records.length).toBe(3);
@@ -237,7 +241,8 @@ describe(`PATCH ${route}`, () => {
                 .unwrap(),
             connectionId: conn.id,
             environmentId: env.id,
-            model: 'Ticket'
+            model: 'Ticket',
+            plan: null
         });
 
         const res1 = await api.fetch(route, {

--- a/packages/server/lib/controllers/records/patchPruneRecords.ts
+++ b/packages/server/lib/controllers/records/patchPruneRecords.ts
@@ -43,7 +43,7 @@ export const patchPublicPruneRecords = asyncWrapper<PatchPublicPruneRecords>(asy
         return;
     }
 
-    const { environment } = res.locals;
+    const { environment, plan } = res.locals;
     const headers: PatchPublicPruneRecords['Headers'] = valHeaders.data;
     const body: PatchPublicPruneRecords['Body'] = valBody.data;
 
@@ -64,7 +64,8 @@ export const patchPublicPruneRecords = asyncWrapper<PatchPublicPruneRecords>(asy
         mode: 'prune',
         limit: body.limit || 1000,
         batchSize: 1000,
-        toCursorIncluded: body.until_cursor
+        toCursorIncluded: body.until_cursor,
+        plan
     });
 
     if (result.isErr()) {

--- a/packages/server/lib/crons/delete/deleteSyncData.ts
+++ b/packages/server/lib/crons/delete/deleteSyncData.ts
@@ -1,6 +1,6 @@
 import db from '@nangohq/database';
 import { records } from '@nangohq/records';
-import { hardDeleteJobs, hardDeleteSync } from '@nangohq/shared';
+import { getPlanSafe, hardDeleteJobs, hardDeleteSync } from '@nangohq/shared';
 
 import { batchDelete } from './batchDelete.js';
 
@@ -36,6 +36,7 @@ export async function deleteSyncData(sync: Sync, syncConfig: DBSyncConfig | null
     });
 
     if (syncConfig) {
+        const plan = await getPlanSafe(db.knex, { environmentId: syncConfig.environment_id });
         for (const model of syncConfig.models) {
             await batchDelete({
                 name: 'records < sync',
@@ -48,7 +49,8 @@ export async function deleteSyncData(sync: Sync, syncConfig: DBSyncConfig | null
                         environmentId: syncConfig.environment_id,
                         model,
                         mode: 'hard',
-                        batchSize: limit
+                        batchSize: limit,
+                        plan
                     });
                     if (res.isOk() && res.value.count) {
                         logger.info('deleted', res.value.count, 'records for model', model);

--- a/packages/shared/lib/seeders/plan.seeder.ts
+++ b/packages/shared/lib/seeders/plan.seeder.ts
@@ -48,6 +48,7 @@ export function getTestPlan(override?: Partial<DBPlan>): DBPlan {
         has_records_autopruning: true,
         variants_per_sync_max: 100,
         fleet_node_routing_override: null,
+        records_store: 'default',
         lambda_tenant_isolation: true,
         export_runner_telemetry: true,
         ...override

--- a/packages/shared/lib/services/plans/plans.ts
+++ b/packages/shared/lib/services/plans/plans.ts
@@ -1,6 +1,6 @@
 import ms from 'ms';
 
-import { Err, Ok } from '@nangohq/utils';
+import { Err, Ok, flagHasPlan } from '@nangohq/utils';
 
 import { freePlan, isPotentialDowngrade, plansList } from './definitions.js';
 import { productTracking } from '../../utils/productTracking.js';
@@ -52,6 +52,19 @@ export async function getPlan(
     } catch (err) {
         return Err(new Error('failed_to_get_plan', { cause: err }));
     }
+}
+
+export async function getPlanSafe(
+    db: Knex,
+    opts: Partial<{
+        accountId: DBPlan['account_id'];
+        environmentId: DBEnvironment['id'];
+        stripeCustomerId: DBPlan['stripe_customer_id'];
+    }>
+): Promise<DBPlan | null> {
+    if (!flagHasPlan) return null;
+    const plan = await getPlan(db, opts);
+    return plan.isOk() ? plan.value : null;
 }
 
 export async function createPlan(
@@ -233,6 +246,7 @@ export function mergeFlags({ currentPlan, newPlanDefinition }: { currentPlan: DB
             case 'trial_end_notified_at':
             case 'trial_expired':
             case 'fleet_node_routing_override':
+            case 'records_store':
             case 'created_at':
             case 'updated_at':
                 break;

--- a/packages/shared/lib/services/plans/plans.unit.test.ts
+++ b/packages/shared/lib/services/plans/plans.unit.test.ts
@@ -136,6 +136,7 @@ function makePlan({ code, flagOverrides }: { code: DBPlan['name']; flagOverrides
         has_records_autopruning: true,
         variants_per_sync_max: 100,
         fleet_node_routing_override: null,
+        records_store: 'default',
         lambda_tenant_isolation: defaultPlanDefinition.flags.lambda_tenant_isolation ?? false,
         export_runner_telemetry: defaultPlanDefinition.flags.export_runner_telemetry ?? false,
         ...defaultPlanDefinition,

--- a/packages/types/lib/plans/db.ts
+++ b/packages/types/lib/plans/db.ts
@@ -203,7 +203,7 @@ export interface DBPlan extends Timestamps {
      * Records store key for this account
      * @default 'default'
      */
-    records_store: 'default' | 'secondary';
+    records_store: 'default' | 'records2';
 
     /**
      * Limit the number of variants per sync

--- a/packages/types/lib/plans/db.ts
+++ b/packages/types/lib/plans/db.ts
@@ -200,6 +200,12 @@ export interface DBPlan extends Timestamps {
     has_records_autopruning: boolean;
 
     /**
+     * Records store key for this account
+     * @default 'default'
+     */
+    records_store: 'default' | 'secondary';
+
+    /**
      * Limit the number of variants per sync
      * @default 100
      */

--- a/packages/utils/lib/environment/parse.ts
+++ b/packages/utils/lib/environment/parse.ts
@@ -405,6 +405,12 @@ export const ENVS = z.object({
     RECORDS_DATABASE_READ_URL: z.url().optional(),
     RECORDS_DATABASE_SCHEMA: z.string().optional().default('nango_records'),
     RECORDS_DATABASE_SSL: z.stringbool().optional().default(false),
+
+    RECORDS_SECONDARY_DATABASE_URL: z.url().optional(),
+    RECORDS_SECONDARY_DATABASE_READ_URL: z.url().optional(),
+    RECORDS_SECONDARY_DATABASE_SCHEMA: z.string().optional().default('nango_records_secondary'),
+    RECORDS_SECONDARY_DATABASE_SSL: z.stringbool().optional().default(false),
+
     RECORDS_DATABASE_POOL_MIN: z.coerce.number().optional().default(2),
     RECORDS_DATABASE_POOL_MAX: z.coerce.number().optional().default(50),
     RECORDS_DATABASE_STATEMENT_TIMEOUT_MS: z.coerce.number().optional().default(60000),

--- a/packages/utils/lib/environment/parse.ts
+++ b/packages/utils/lib/environment/parse.ts
@@ -406,10 +406,10 @@ export const ENVS = z.object({
     RECORDS_DATABASE_SCHEMA: z.string().optional().default('nango_records'),
     RECORDS_DATABASE_SSL: z.stringbool().optional().default(false),
 
-    RECORDS_SECONDARY_DATABASE_URL: z.url().optional(),
-    RECORDS_SECONDARY_DATABASE_READ_URL: z.url().optional(),
-    RECORDS_SECONDARY_DATABASE_SCHEMA: z.string().optional().default('nango_records_secondary'),
-    RECORDS_SECONDARY_DATABASE_SSL: z.stringbool().optional().default(false),
+    RECORDS_2_DATABASE_URL: z.url().optional(),
+    RECORDS_2_DATABASE_READ_URL: z.url().optional(),
+    RECORDS_2_DATABASE_SCHEMA: z.string().optional().default('nango_records_2'),
+    RECORDS_2_DATABASE_SSL: z.stringbool().optional().default(false),
 
     RECORDS_DATABASE_POOL_MIN: z.coerce.number().optional().default(2),
     RECORDS_DATABASE_POOL_MAX: z.coerce.number().optional().default(50),


### PR DESCRIPTION
Came up with a middle ground approach, creating a second logical records store but pointing it our for now at the same db instance (as another schema). This way we can have all the code ready (including plan support) but not have to operate another database yet. Let me know what you think.

The main design decision being made is `datasets` are pinned to a store. Not accounts, environments, etc... To do so we would need to implement live migration of existing records or limit new 'stores' to new customers, env, etc...

This PR:
- Adds records_store column to plans (default: 'default')
- Adds records_routing table to persist per-connection/model store assignments
- Existing connection/model with records always pin to 'default' store
- Threads plan through all records operations for routing context
- No-op when secondary store is not configured via env vars (not configure yet)

Note: `secondary` name is TBD. I am open to suggestion
