### PR TITLE
fix: clamp retryFlexible wait to [0, maxDelay] so provider headers can't exceed the retry cap

### DIFF
--- a/packages/utils/lib/retry.ts
+++ b/packages/utils/lib/retry.ts
@@ -79,7 +79,10 @@ export async function retryFlexible<TReturn>(
                 throw err;
             }
 
-            lastWait = on.wait ?? nextWait;
+            // Clamp the wait to [0, maxDelay]. onError can derive `wait` from provider-controlled
+            // headers (e.g. Retry-After / a retry-at timestamp), so an out-of-range value must not be
+            // able to make us sleep for years or pass a negative delay to setTimeout.
+            lastWait = Math.min(Math.max(on.wait ?? nextWait, 0), maxDelay);
             await setTimeout(lastWait);
         }
     }

--- a/packages/utils/lib/retry.unit.test.ts
+++ b/packages/utils/lib/retry.unit.test.ts
@@ -1,6 +1,6 @@
 import { afterEach, describe, expect, it, vi } from 'vitest';
 
-import { retry } from './retry.js';
+import { retry, retryFlexible } from './retry.js';
 
 describe('retry', () => {
     it('should retry', async () => {
@@ -120,5 +120,64 @@ describe('httpRetryStrategy', () => {
 
         expect(httpRetryStrategy(new AxiosError('boom', 'E_ONE'), 1)).toBe(true);
         expect(httpRetryStrategy(new AxiosError('boom', 'E_TWO'), 1)).toBe(true);
+    });
+});
+
+// Capture the delays retryFlexible passes to setTimeout, without actually sleeping. Recording is gated
+// by `capturing` so ambient setTimeout calls (e.g. from setup) don't pollute the assertions.
+let capturing = false;
+const recordedDelays: number[] = [];
+vi.mock('node:timers/promises', () => ({
+    setTimeout: (delay?: number) => {
+        if (capturing) {
+            recordedDelays.push(delay ?? 0);
+        }
+        return Promise.resolve();
+    }
+}));
+
+describe('retryFlexible', () => {
+    const maxDelay = 60 * 10 * 1000; // 10 minutes, mirrors the cap inside retryFlexible
+
+    afterEach(() => {
+        capturing = false;
+        recordedDelays.length = 0;
+    });
+
+    // Runs retryFlexible forcing exactly one retry whose onError returns `onErrorWait`, and returns the
+    // delay retryFlexible actually handed to setTimeout for that retry.
+    async function getRetryDelay(onErrorWait: number): Promise<number> {
+        let call = 0;
+        capturing = true;
+        await retryFlexible(
+            () => {
+                call += 1;
+                if (call <= 1) {
+                    throw new Error('boom');
+                }
+                return 'ok';
+            },
+            {
+                max: 1,
+                onError: () => ({ retry: true, reason: 'test', wait: onErrorWait })
+            }
+        );
+        capturing = false;
+        // exactly one retry => exactly one sleep
+        expect(recordedDelays).toHaveLength(1);
+        return recordedDelays[0] ?? NaN;
+    }
+
+    it('caps a header-driven wait at the 10 minute maxDelay', async () => {
+        // A misbehaving/hostile provider returns a huge Retry-After-derived wait (~31 years).
+        expect(await getRetryDelay(1_000_000_000_000)).toBe(maxDelay);
+    });
+
+    it('does not sleep for a negative wait', async () => {
+        expect(await getRetryDelay(-5000)).toBe(0);
+    });
+
+    it('passes through a wait that is within the cap', async () => {
+        expect(await getRetryDelay(5000)).toBe(5000);
     });
 });


### PR DESCRIPTION
## Problem

`retryFlexible` (the HTTP retry helper used by the proxy / sync request path) caps its exponential backoff at `maxDelay` (10 minutes) through `getExponentialBackoff`. But when `onError` returns an explicit `wait`, that value is used verbatim:

```ts
const maxDelay = 60 * 10 * 1000; // 10 minutes
...
const nextWait = getExponentialBackoff(attempt, maxDelay); // capped
const on = await options.onError({ err, nextWait, ... });
...
lastWait = on.wait ?? nextWait; // NOT capped, NOT floored
await setTimeout(lastWait);
```

For HTTP proxy retries, `onError` (`getProxyRetryFromErr` in `packages/shared/lib/services/proxy/retry.ts`) derives `wait` directly from **provider-controlled** response data: the `Retry-After` header, a configured retry-at timestamp header, or a value parsed out of the response body.

So a misbehaving or hostile upstream can:
- Return a huge `Retry-After` / a far-future retry-at timestamp and pin the runner in `setTimeout` for hours, days, or years — far past the intended 10-minute ceiling that the same function already enforces on its exponential path.
- Return a negative `Retry-After` (the `'after'` branch in `parseRetryValue` has no lower bound, unlike the `'at'` branch), producing a negative delay passed to `setTimeout`.

## Root cause

The `maxDelay` ceiling is applied only to the exponential fallback (`getExponentialBackoff(attempt, maxDelay)`), not to the `on.wait` value that overrides it. There is also no lower bound, so negative waits pass through.

## Fix

Clamp the chosen wait to `[0, maxDelay]` so the existing cap governs the header-driven path as well, and negative values can't slip through:

```ts
lastWait = Math.min(Math.max(on.wait ?? nextWait, 0), maxDelay);
```

One-line change in `packages/utils/lib/retry.ts`. Behaviour for in-range waits is unchanged.

## Test

Added `retryFlexible` unit tests in `packages/utils/lib/retry.unit.test.ts` (this function previously had no direct coverage):
- a provider-style wait of ~31 years is clamped to `maxDelay` (600000 ms),
- a negative wait is floored to `0`,
- an in-range wait (5000 ms) passes through unchanged.

The tests mock `node:timers/promises` to capture the delay handed to `setTimeout` without sleeping.

## Repro

```
npx vitest run packages/utils/lib/retry.unit.test.ts
```

- Before the fix: the cap test sees `1000000000000` and the negative test sees `-5000` — both fail.
- After the fix: all 10 tests pass. Full `packages/utils` unit suite (266 tests) and the proxy retry/request suites (33 tests) that consume `retryFlexible` remain green.