### PR TITLE
fix(tests): set hookTimeout to match testTimeout in integration config

### DIFF
--- a/packages/records/lib/stores/postgres/postgres.integration.test.ts
+++ b/packages/records/lib/stores/postgres/postgres.integration.test.ts
@@ -2405,6 +2405,6 @@ async function fromDbLegacy(
 }
 
 const rnd = {
-    number: () => Math.floor(Math.random() * 1000),
+    number: () => Math.floor(Math.random() * 1_000_000_000),
     string: () => Math.random().toString(36).substring(6)
 };

--- a/vite.integration.config.ts
+++ b/vite.integration.config.ts
@@ -14,6 +14,7 @@ export default defineConfig({
         globalSetup: './tests/setup.ts',
         setupFiles: './tests/setupFiles.ts',
         testTimeout: 20000,
+        hookTimeout: 20000,
         env: {
             NANGO_ENCRYPTION_KEY: 'RzV4ZGo5RlFKMm0wYWlXdDhxTFhwb3ZrUG5KNGg3TmU=',
             NANGO_LOGS_ENABLED: 'true',


### PR DESCRIPTION
## Problem

Two separate flaky failures in the integration suite:

1. **Hook timeout** — `beforeAll` in `getRecords.integration.test.ts` was failing with "Hook timed out in 10000ms". The hook calls `runServer()` + `records.migrate()`, which can exceed the 10s vitest default under load. `testTimeout` was already 20000ms but `hookTimeout` was not set.

2. **ID collision** — `paginateCounts > should paginate through record counts for specific environments` in `postgres.integration.test.ts` was failing with `expected length 2 but got 3`. The `rnd.number()` helper generated integers in `[0, 1000)`, causing ~1.5% collision probability per run between environment IDs created in adjacent tests. A leaked row from the preceding test was picked up by the filtered query.

## Solution

- Set `hookTimeout: 20000` in `vite.integration.config.ts` to match `testTimeout`. Also covers `patchPruneRecords.integration.test.ts` and `persist/server.integration.test.ts` which have the same `records.migrate()` in `beforeAll`.
- Widen `rnd.number()` range from `1_000` to `1_000_000_000`, making collisions negligible.

## Testing

No logic change. Relies on CI passing.

Failing runs:
- https://github.com/NangoHQ/nango/actions/runs/26906102582/job/79371364105?pr=6261
- https://github.com/NangoHQ/nango/actions/runs/26943555017/job/79490785269?pr=6366
