### PR TITLE
feat(sync_jobs): shrink retention + add id_big shadow column (NAN-5491 Phase 3a)

### DIFF
--- a/packages/database/lib/migrations/20260604120000_sync_jobs_add_id_big.cjs
+++ b/packages/database/lib/migrations/20260604120000_sync_jobs_add_id_big.cjs
@@ -1,0 +1,23 @@
+/**
+ * @param {import('knex').Knex} knex
+ */
+exports.up = async function (knex) {
+    await knex.raw(`ALTER TABLE nango._nango_sync_jobs ADD COLUMN IF NOT EXISTS id_big bigint`);
+    await knex.raw(`
+        CREATE OR REPLACE FUNCTION nango._nango_sync_jobs_mirror_id()
+        RETURNS TRIGGER AS $$
+        BEGIN
+            NEW.id_big := NEW.id;
+            RETURN NEW;
+        END;
+        $$ LANGUAGE plpgsql;
+    `);
+    await knex.raw(`
+        CREATE TRIGGER _nango_sync_jobs_mirror_id_trigger
+        BEFORE INSERT OR UPDATE ON nango._nango_sync_jobs
+        FOR EACH ROW
+        EXECUTE FUNCTION nango._nango_sync_jobs_mirror_id();
+    `);
+};
+
+exports.down = function () {};

--- a/packages/utils/lib/environment/parse.ts
+++ b/packages/utils/lib/environment/parse.ts
@@ -67,7 +67,7 @@ export const ENVS = z.object({
     CRON_TIMEOUT_LOGS_MINUTES: z.coerce.number().optional().default(10),
     CRON_DELETE_OLD_JOBS_LIMIT: z.coerce.number().optional().default(1000),
     CRON_DELETE_OLD_DATA_EVERY_MIN: z.coerce.number().optional().default(10),
-    CRON_DELETE_OLD_JOBS_MAX_DAYS: z.coerce.number().optional().default(31),
+    CRON_DELETE_OLD_JOBS_MAX_DAYS: z.coerce.number().optional().default(3),
     CRON_DELETE_OLD_CONNECT_SESSION_MAX_DAYS: z.coerce.number().optional().default(31),
     CRON_DELETE_OLD_PRIVATE_KEYS_MAX_DAYS: z.coerce.number().optional().default(31),
     CRON_DELETE_OLD_OAUTH_SESSION_MAX_DAYS: z.coerce.number().optional().default(2),


### PR DESCRIPTION
## Why

Prepare `_nango_sync_jobs` for the int4 → bigint PK widening by shrinking the table and starting dual-writes to a shadow `id_big` column.

## How

- **Stack:** standalone — first PR of the Phase 3 sequence, can merge directly to master. Reverted by Phase 3g ([#6370](https://github.com/NangoHQ/nango/pull/6370)).
- **Migrations:** **run manually** in cloud prod from psql, wrapped in `BEGIN; SET LOCAL lock_timeout = '1s'; … COMMIT;` to keep the brief ACCESS EXCLUSIVE on `_nango_sync_jobs` from stacking up behind any in-flight query. Migration row inserted into `_nango_auth_migrations` afterward to skip the auto-run. Self-hosted auto-runs the migration on deploy.
- **Wait after merging:** **~3 days** for `CRON_DELETE_OLD_JOBS` to chew `_nango_sync_jobs` down to its new steady-state under 3-day retention.

## What

- Shorten `CRON_DELETE_OLD_JOBS_MAX_DAYS` default from 31 → 3 days to bring `_nango_sync_jobs` down to a workable size ahead of the swap. Restored to 31 in Phase 3g ([#6370](https://github.com/NangoHQ/nango/pull/6370)) once the swap is complete.
- Add `id_big bigint` shadow column to `_nango_sync_jobs` plus a `BEFORE INSERT OR UPDATE` trigger that mirrors `id → id_big` on every write. Dual-write starts immediately, paving the way for the backfill (3b — [#6368](https://github.com/NangoHQ/nango/pull/6368)) and atomic PK swap (3e — [#6369](https://github.com/NangoHQ/nango/pull/6369)).

Linear: NAN-5491.

## Test plan

- [ ] Cloud prod: run the `ADD COLUMN` + trigger DDL manually with `SET LOCAL lock_timeout = '1s'`
- [ ] `INSERT INTO _nango_auth_migrations` to mark migration applied
- [ ] After deploy, `WHERE id_big IS NULL AND created_at > NOW() - INTERVAL '5 minutes'` returns `0` in staging + prod
- [ ] `_nango_sync_jobs` row count visibly decreasing day-over-day in prod
- [ ] No regression in sync-job creation/update throughput
- [ ] Self-hosted auto-runs the migration on next deploy with no operator intervention
