### PR TITLE
feat(sync_jobs): backfill id_big from id (NAN-5491 Phase 3b)

### DIFF
--- a/packages/database/lib/migrations/20260604120100_sync_jobs_backfill_id_big.cjs
+++ b/packages/database/lib/migrations/20260604120100_sync_jobs_backfill_id_big.cjs
@@ -1,0 +1,8 @@
+/**
+ * @param {import('knex').Knex} knex
+ */
+exports.up = async function (knex) {
+    await knex.raw(`UPDATE nango._nango_sync_jobs SET id_big = id WHERE id_big IS NULL`);
+};
+
+exports.down = function () {};


### PR DESCRIPTION
## Why

Confirm every row in `_nango_sync_jobs` has `id_big` populated before Phase 3c builds the unique index on it.

## How

- **Stack:** depends on Phase 3a ([#6367](https://github.com/NangoHQ/nango/pull/6367)) — `id_big` column + mirror trigger must exist.
- **Check before merging:**
  - Phase 3a ([#6367](https://github.com/NangoHQ/nango/pull/6367)) has been live for **3+ days** and `_nango_sync_jobs` row count has plateaued under 3-day retention.
  - `SELECT count(*) FROM nango._nango_sync_jobs WHERE id_big IS NULL AND created_at > NOW() - INTERVAL '5 minutes'` — returns `0` (dual-write is working).
- **Migrations (cloud): no upfront bulk UPDATE.** Phase 3a's `BEFORE INSERT OR UPDATE` mirror trigger populates `id_big` on every write, and with 3-day retention any unpaused sync will fire again and have its row touched within the window. The cloud runbook is a SELECT gate, with a small manual UPDATE only for paused-sync stragglers:
  1. Run `SELECT count(*) FROM nango._nango_sync_jobs WHERE id_big IS NULL;`.
  2. If the count is non-zero **and still decreasing**, wait longer — more syncs are still rotating through.
  3. If the count plateaus at a small number, those rows belong to paused syncs that aren't firing. Run a targeted manual UPDATE out-of-band from psql: `UPDATE nango._nango_sync_jobs SET id_big = id WHERE id_big IS NULL;`.
  4. Re-run the SELECT — it must return `0`.
  5. `INSERT INTO _nango_auth_migrations` to mark the migration applied, so the auto-runner skips it.
- **Migrations (self-hosted):** the migration body's `UPDATE` runs automatically on deploy — catches everything (paused or not) in one shot on the small self-hosted table; no operator step.

## What

- Backfill `id_big = id` across rows in `_nango_sync_jobs` whose `id_big` is still NULL. In cloud the mirror trigger does almost all of this organically; the migration body is the safety net for self-hosted and for any paused-sync stragglers that an operator catches via the SELECT gate.

Linear: NAN-5491.

## Test plan

- [ ] Cloud: SELECT count of NULL `id_big` plateaus at the paused-sync count (small)
- [ ] Cloud: targeted manual `UPDATE … WHERE id_big IS NULL` clears the residual
- [ ] Cloud: SELECT count = `0`, then `INSERT INTO _nango_auth_migrations` to mark applied
- [ ] Self-hosted: auto-runs the migration on next deploy with no operator intervention
