### PR TITLE
feat(sync_jobs): atomic PK swap from int4 id to bigint (NAN-5491 Phase 3e)

### DIFF
--- a/packages/database/lib/migrations/20260604120300_sync_jobs_id_atomic_swap.cjs
+++ b/packages/database/lib/migrations/20260604120300_sync_jobs_id_atomic_swap.cjs
@@ -6,6 +6,7 @@ exports.up = async function (knex) {
     await knex.raw(`ALTER TABLE nango._nango_sync_jobs DROP CONSTRAINT _nango_sync_jobs_pkey`);
     await knex.raw(`ALTER TABLE nango._nango_sync_jobs RENAME COLUMN id TO id_old`);
     await knex.raw(`ALTER TABLE nango._nango_sync_jobs RENAME COLUMN id_big TO id`);
+    await knex.raw(`ALTER TABLE nango._nango_sync_jobs ALTER COLUMN id_old DROP NOT NULL`);
     await knex.raw(`ALTER TABLE nango._nango_sync_jobs ADD CONSTRAINT _nango_sync_jobs_pkey PRIMARY KEY USING INDEX sync_jobs_id_big_uidx`);
     await knex.raw(`ALTER TABLE nango._nango_sync_jobs ALTER COLUMN id SET DEFAULT nextval('nango._nango_sync_jobs_id_seq')`);
     await knex.raw(`ALTER SEQUENCE nango._nango_sync_jobs_id_seq OWNED BY nango._nango_sync_jobs.id`);

--- a/packages/database/lib/migrations/20260604120300_sync_jobs_id_atomic_swap.cjs
+++ b/packages/database/lib/migrations/20260604120300_sync_jobs_id_atomic_swap.cjs
@@ -7,6 +7,8 @@ exports.up = async function (knex) {
     await knex.raw(`ALTER TABLE nango._nango_sync_jobs RENAME COLUMN id TO id_old`);
     await knex.raw(`ALTER TABLE nango._nango_sync_jobs RENAME COLUMN id_big TO id`);
     await knex.raw(`ALTER TABLE nango._nango_sync_jobs ALTER COLUMN id_old DROP NOT NULL`);
+    await knex.raw(`ALTER TABLE nango._nango_sync_jobs ALTER COLUMN id SET NOT NULL`);
+    await knex.raw(`ALTER TABLE nango._nango_sync_jobs DROP CONSTRAINT IF EXISTS id_big_not_null`);
     await knex.raw(`ALTER TABLE nango._nango_sync_jobs ADD CONSTRAINT _nango_sync_jobs_pkey PRIMARY KEY USING INDEX sync_jobs_id_big_uidx`);
     await knex.raw(`ALTER TABLE nango._nango_sync_jobs ALTER COLUMN id SET DEFAULT nextval('nango._nango_sync_jobs_id_seq')`);
     await knex.raw(`ALTER SEQUENCE nango._nango_sync_jobs_id_seq OWNED BY nango._nango_sync_jobs.id`);

--- a/packages/database/lib/migrations/20260604120300_sync_jobs_id_atomic_swap.cjs
+++ b/packages/database/lib/migrations/20260604120300_sync_jobs_id_atomic_swap.cjs
@@ -1,0 +1,16 @@
+/**
+ * @param {import('knex').Knex} knex
+ */
+exports.up = async function (knex) {
+    await knex.raw(`ALTER TABLE nango._nango_sync_jobs ALTER COLUMN id DROP DEFAULT`);
+    await knex.raw(`ALTER TABLE nango._nango_sync_jobs DROP CONSTRAINT _nango_sync_jobs_pkey`);
+    await knex.raw(`ALTER TABLE nango._nango_sync_jobs RENAME COLUMN id TO id_old`);
+    await knex.raw(`ALTER TABLE nango._nango_sync_jobs RENAME COLUMN id_big TO id`);
+    await knex.raw(`ALTER TABLE nango._nango_sync_jobs ADD CONSTRAINT _nango_sync_jobs_pkey PRIMARY KEY USING INDEX sync_jobs_id_big_uidx`);
+    await knex.raw(`ALTER TABLE nango._nango_sync_jobs ALTER COLUMN id SET DEFAULT nextval('nango._nango_sync_jobs_id_seq')`);
+    await knex.raw(`ALTER SEQUENCE nango._nango_sync_jobs_id_seq OWNED BY nango._nango_sync_jobs.id`);
+    await knex.raw(`DROP TRIGGER IF EXISTS _nango_sync_jobs_mirror_id_trigger ON nango._nango_sync_jobs`);
+    await knex.raw(`DROP FUNCTION IF EXISTS nango._nango_sync_jobs_mirror_id()`);
+};
+
+exports.down = function () {};


### PR DESCRIPTION
## Why

Flip `_nango_sync_jobs.id` from `int4` to `bigint` in a single transaction, taking the table off the int4 exhaustion path — and keep the swap fully metadata-only by leaning on the validated CHECK from Phase 3d.

## How

- **Stack:** depends on Phase 3d ([#6375](https://github.com/NangoHQ/nango/pull/6375)) — the `id_big_not_null` CHECK must be validated.
- **Check before merging:**
  - `SELECT convalidated FROM pg_constraint WHERE conrelid = 'nango._nango_sync_jobs'::regclass AND conname = 'id_big_not_null'` — returns `t`.
- **Migrations: run manually** in cloud prod from psql, wrapped in `BEGIN; SET LOCAL lock_timeout = '1s'; … COMMIT;` to bound the ACCESS EXCLUSIVE hold. The migration body itself does not carry `lock_timeout` — that's the operator session's job. Every line inside the transaction is metadata-only thanks to the validated CHECK proving `id_big IS NOT NULL` (so `SET NOT NULL` and the PK attachment don't trigger a table scan under the exclusive lock). Migration row inserted into `_nango_auth_migrations` afterward.
- **Wait after merging:** **~24 hours** of clean operation before merging Phase 3f ([#6372](https://github.com/NangoHQ/nango/pull/6372)) — gives a rollback window in case the swap surfaces a subtle issue.

## What

- Atomic PK swap of `_nango_sync_jobs.id` from `int4` to `bigint`. All metadata-only DDL inside one transaction: drop default on old `id`, drop the PK, rename `id → id_old`, rename `id_big → id`, drop NOT NULL on `id_old`, SET NOT NULL on the new `id` (uses the validated CHECK as proof — no scan), drop the now-redundant `id_big_not_null` CHECK, attach the PK via `USING INDEX sync_jobs_id_big_uidx`, restore the `nextval` default, reassign sequence ownership to the new `id`, drop the mirror trigger + function.

The sequence ceiling stays at `2^31-1` for now (Phase 3f ([#6372](https://github.com/NangoHQ/nango/pull/6372)) lifts it) — that's safe because the bigint column accepts those values without complaint and behavior is unchanged.

Linear: NAN-5491.

## Test plan

- [ ] Cloud prod: run the SQL block manually from psql with `SET LOCAL lock_timeout = '1s'`
- [ ] `\d nango._nango_sync_jobs` shows `id bigint NOT NULL DEFAULT nextval(...)` and `id_old integer`
- [ ] `id_big_not_null` constraint is gone from `pg_constraint`
- [ ] Insert + select round-trip works against the running app
- [ ] `INSERT INTO _nango_auth_migrations` to mark applied
- [ ] Self-hosted auto-runs the migration on next deploy (no manual step needed there)
