### PR TITLE
feat(sync_jobs): restore retention to 31 days (NAN-5491 Phase 3g)

### DIFF
--- a/packages/utils/lib/environment/parse.ts
+++ b/packages/utils/lib/environment/parse.ts
@@ -67,7 +67,7 @@ export const ENVS = z.object({
     CRON_TIMEOUT_LOGS_MINUTES: z.coerce.number().optional().default(10),
     CRON_DELETE_OLD_JOBS_LIMIT: z.coerce.number().optional().default(1000),
     CRON_DELETE_OLD_DATA_EVERY_MIN: z.coerce.number().optional().default(10),
-    CRON_DELETE_OLD_JOBS_MAX_DAYS: z.coerce.number().optional().default(3),
+    CRON_DELETE_OLD_JOBS_MAX_DAYS: z.coerce.number().optional().default(31),
     CRON_DELETE_OLD_CONNECT_SESSION_MAX_DAYS: z.coerce.number().optional().default(31),
     CRON_DELETE_OLD_PRIVATE_KEYS_MAX_DAYS: z.coerce.number().optional().default(31),
     CRON_DELETE_OLD_OAUTH_SESSION_MAX_DAYS: z.coerce.number().optional().default(2),


### PR DESCRIPTION
## Why

Return retention to its operational baseline now that the bigint swap removes the reason we shortened it.

## How

- **Stack:** depends on Phase 3f ([#6372](https://github.com/NangoHQ/nango/pull/6372)) — the swap is fully cleaned up and the sequence ceiling is lifted.
- **Check before merging:**
  - Phase 3f ([#6372](https://github.com/NangoHQ/nango/pull/6372)) has been live and stable.
  - `\d nango._nango_sync_jobs` no longer lists `id_old`.
  - `SELECT maximum_value FROM information_schema.sequences WHERE sequence_schema='nango' AND sequence_name='_nango_sync_jobs_id_seq'` — returns `9223372036854775807`.
- **Migrations:** none — config-only change. Auto-applied on deploy.

## What

- Revert `CRON_DELETE_OLD_JOBS_MAX_DAYS` default from 3 → 31 days. Phase 3a ([#6367](https://github.com/NangoHQ/nango/pull/6367)) temporarily dropped it to shrink the table ahead of the PK swap; with bigint in place, retention returns to its operational baseline.

Linear: NAN-5491.

## Test plan

- [ ] Default reverts back to 31
- [ ] Envs that override `CRON_DELETE_OLD_JOBS_MAX_DAYS` explicitly keep their value
- [ ] On the next retention cron run, jobs between 3 and 31 days old are no longer deleted
