### PR TITLE
feat(sync_jobs): build unique index on id_big (NAN-5491 Phase 3c)

### DIFF
--- a/packages/database/lib/migrations/20260604120200_sync_jobs_id_big_unique_index.cjs
+++ b/packages/database/lib/migrations/20260604120200_sync_jobs_id_big_unique_index.cjs
@@ -1,0 +1,8 @@
+/**
+ * @param {import('knex').Knex} knex
+ */
+exports.up = async function (knex) {
+    await knex.raw(`CREATE UNIQUE INDEX IF NOT EXISTS sync_jobs_id_big_uidx ON nango._nango_sync_jobs (id_big)`);
+};
+
+exports.down = function () {};


### PR DESCRIPTION
## Why

Build the unique index that Phase 3e's atomic PK swap pivots on, without taking a long ACCESS EXCLUSIVE lock in cloud prod.

## How

- **Stack:** depends on Phase 3b ([#6368](https://github.com/NangoHQ/nango/pull/6368)) — backfill must be complete; the unique index would fail if any row still has duplicate `id_big` values, and a partial NULL set means the next phase's NOT NULL proof would fail.
- **Check before merging:**
  - `SELECT count(*) FROM nango._nango_sync_jobs WHERE id_big IS NULL` — returns `0`.
- **Migrations:** cloud prod runs `CREATE UNIQUE INDEX CONCURRENTLY` **manually** to avoid the ACCESS EXCLUSIVE lock the auto-run (non-CONCURRENTLY) would take. The migration row is inserted into `_nango_auth_migrations` afterward so the auto-runner skips it. Self-hosted runs the non-CONCURRENT version on deploy — fast on their small tables.

## What

- Build the `sync_jobs_id_big_uidx` UNIQUE index on `_nango_sync_jobs(id_big)`. This is the constraint backbone of Phase 3e ([#6369](https://github.com/NangoHQ/nango/pull/6369))'s `ADD CONSTRAINT _nango_sync_jobs_pkey PRIMARY KEY USING INDEX sync_jobs_id_big_uidx` — 3e cannot run without it.

Linear: NAN-5491.

## Test plan

- [ ] Cloud prod: run `CREATE UNIQUE INDEX CONCURRENTLY sync_jobs_id_big_uidx ON nango._nango_sync_jobs (id_big)` from psql
- [ ] `SELECT indisvalid FROM pg_index … = 'nango.sync_jobs_id_big_uidx'::regclass` returns `t`
- [ ] `INSERT INTO _nango_auth_migrations` to mark applied
- [ ] Self-hosted auto-runs the non-CONCURRENT migration on next deploy
