### PR TITLE
feat(sync_jobs): drop legacy id_old and lift sequence to bigint (NAN-5491 Phase 3f)

### DIFF
--- a/packages/database/lib/migrations/20260604120400_sync_jobs_drop_id_old_lift_sequence.cjs
+++ b/packages/database/lib/migrations/20260604120400_sync_jobs_drop_id_old_lift_sequence.cjs
@@ -1,0 +1,9 @@
+/**
+ * @param {import('knex').Knex} knex
+ */
+exports.up = async function (knex) {
+    await knex.raw(`ALTER TABLE nango._nango_sync_jobs DROP COLUMN IF EXISTS id_old`);
+    await knex.raw(`ALTER SEQUENCE nango._nango_sync_jobs_id_seq AS bigint MAXVALUE 9223372036854775807`);
+};
+
+exports.down = function () {};


### PR DESCRIPTION
## Why

Reclaim the int4 ceiling by dropping the dead `id_old` column and lifting the sequence to bigint — the change that actually buys us the new headroom.

## How

- **Stack:** depends on Phase 3e ([#6369](https://github.com/NangoHQ/nango/pull/6369)) — the swap must be live.
- **Check before merging:**
  - Phase 3e ([#6369](https://github.com/NangoHQ/nango/pull/6369)) has been live and stable for at least **24 hours** — no rollback signal, app behavior unchanged.
  - `SELECT data_type FROM information_schema.columns WHERE table_schema='nango' AND table_name='_nango_sync_jobs' AND column_name='id'` — returns `bigint`.
  - `id_old` column is still present (gets dropped here).
- **Migrations: run manually** in cloud prod from psql, wrapped in `BEGIN; SET LOCAL lock_timeout = '1s'; … COMMIT;`. The migration body itself does not carry `lock_timeout` — that's the operator session's job. Migration row inserted into `_nango_auth_migrations` afterward.

## What

- Drop the now-dead `id_old` column (no readers since Phase 3e ([#6369](https://github.com/NangoHQ/nango/pull/6369))'s swap dropped its default before the rename).
- Lift `_nango_sync_jobs_id_seq` from int4 ceiling (`2^31-1`) to bigint (`2^63-1`). Until this lands, the bigint `id` column would still hit `nextval: reached maximum value` once the int4 range exhausted — this is the change that actually buys us the new headroom.

Linear: NAN-5491.

## Test plan

- [ ] Cloud prod: run the SQL block manually
- [ ] `\d nango._nango_sync_jobs` no longer shows `id_old`
- [ ] Sequence `maximum_value` is `2^63-1`
- [ ] `INSERT INTO _nango_auth_migrations` to mark applied
- [ ] Self-hosted auto-runs the migration on next deploy
