### PR TITLE
feat(sync_jobs): validate id_big NOT NULL (NAN-5491 Phase 3d)

### DIFF
--- a/packages/database/lib/migrations/20260604120250_sync_jobs_validate_id_big_not_null.cjs
+++ b/packages/database/lib/migrations/20260604120250_sync_jobs_validate_id_big_not_null.cjs
@@ -1,0 +1,9 @@
+/**
+ * @param {import('knex').Knex} knex
+ */
+exports.up = async function (knex) {
+    await knex.raw(`ALTER TABLE nango._nango_sync_jobs ADD CONSTRAINT id_big_not_null CHECK (id_big IS NOT NULL) NOT VALID`);
+    await knex.raw(`ALTER TABLE nango._nango_sync_jobs VALIDATE CONSTRAINT id_big_not_null`);
+};
+
+exports.down = function () {};


### PR DESCRIPTION
## Why

Prove `id_big` has no NULL rows so Phase 3e's swap stays metadata-only under `ACCESS EXCLUSIVE` — the long scan happens here, in a non-blocking lock mode.

## How

- **Stack:** depends on Phase 3c ([#6371](https://github.com/NangoHQ/nango/pull/6371)) — the unique index is in place.
- **Check before merging:**
  - `SELECT indisvalid FROM pg_index WHERE indexrelid = 'nango.sync_jobs_id_big_uidx'::regclass` — returns `t`.
  - `SELECT count(*) FROM nango._nango_sync_jobs WHERE id_big IS NULL` — returns `0`. (Unique indexes allow multiple NULLs, so the index being valid doesn't on its own prove NULL-freeness — we re-assert here explicitly.)
- **Migrations: run manually** in cloud prod from a psql session, but **not** inside the swap's exclusive-lock window. The two statements are:
  - `ALTER TABLE nango._nango_sync_jobs ADD CONSTRAINT id_big_not_null CHECK (id_big IS NOT NULL) NOT VALID` — instant, metadata-only.
  - `ALTER TABLE nango._nango_sync_jobs VALIDATE CONSTRAINT id_big_not_null` — scans the table under `SHARE UPDATE EXCLUSIVE`, so concurrent reads/writes keep flowing. Takes tens of seconds but doesn't block traffic. Aborts if any row has `id_big IS NULL` — that's the safety net.

  After the SQL succeeds, insert a row into `_nango_auth_migrations` to skip the auto-run. Self-hosted runs the migration automatically (instant + small-table scan, no concern).

## What

- Add a validated `CHECK (id_big IS NOT NULL)` constraint named `id_big_not_null` to `_nango_sync_jobs`. From that point on, every INSERT/UPDATE is also constraint-checked, so the table can't drift back into containing NULLs while we wait to run 3e.
- 3e's swap then uses this validated CHECK as proof (PG 12+ optimization): `ALTER COLUMN id SET NOT NULL` becomes metadata-only, and `ADD CONSTRAINT … PRIMARY KEY USING INDEX` no longer has to scan under `ACCESS EXCLUSIVE`. The redundant CHECK is dropped inside the swap right before the PK supersedes it.

Linear: NAN-5491.

## Test plan

- [ ] Cloud prod: run the two `ALTER` statements manually
- [ ] `SELECT convalidated FROM pg_constraint … WHERE conname = 'id_big_not_null'` returns `t`
- [ ] `INSERT INTO _nango_auth_migrations` to mark applied
- [ ] Self-hosted auto-runs the migration on next deploy
