### PR TITLE
feat(integrations): add Private API Key (Generic) integration support

### DIFF
--- a/docs/api-catalog.txt
+++ b/docs/api-catalog.txt
@@ -2,7 +2,7 @@
 
 > Compact provider slug catalog for agents. Use the slug to reconstruct provider-specific docs URLs only when needed.
 
-Provider count: 838
+Provider count: 839
 
 URL patterns:
 - Main provider page: https://nango.dev/docs/integrations/all/{slug}.md or https://nango.dev/docs/api-integrations/{slug}.md
@@ -576,6 +576,7 @@ URL patterns:
 | `printful` | Printful | OAUTH2 | [docs](https://nango.dev/docs/api-integrations/printful.md) |  | [setup](https://nango.dev/docs/api-integrations/printful/how-to-register-your-own-printful-oauth-app.md) | e-commerce |
 | `private-api-basic` | Private API (Basic Auth) | BASIC | [docs](https://nango.dev/docs/integrations/all/private-api-basic.md) | [connect](https://nango.dev/docs/integrations/all/private-api-basic/connect.md) |  | other |
 | `private-api-bearer` | Private API (Bearer Auth) | API_KEY | [docs](https://nango.dev/docs/integrations/all/private-api-bearer.md) | [connect](https://nango.dev/docs/integrations/all/private-api-bearer/connect.md) |  | other |
+| `private-api-generic` | Private API (Generic) | API_KEY | [docs](https://nango.dev/docs/integrations/all/private-api-generic.md) | [connect](https://nango.dev/docs/integrations/all/private-api-generic/connect.md) |  | other |
 | `prive` | Prive | API_KEY | [docs](https://nango.dev/docs/integrations/all/prive.md) | [connect](https://nango.dev/docs/integrations/all/prive/connect.md) |  | e-commerce |
 | `procore` | Procore | OAUTH2 | [docs](https://nango.dev/docs/api-integrations/procore.md) | [connect](https://nango.dev/docs/api-integrations/procore/connect.md) | [setup](https://nango.dev/docs/api-integrations/procore/how-to-register-your-own-procore-oauth-app.md) | erp |
 | `productboard` | Productboard | OAUTH2 | [docs](https://nango.dev/docs/integrations/all/productboard.md) |  |  | productivity |

--- a/docs/docs.json
+++ b/docs/docs.json
@@ -1461,6 +1461,7 @@
               "integrations/all/prive",
               "integrations/all/private-api-basic",
               "integrations/all/private-api-bearer",
+              "integrations/all/private-api-generic",
               "api-integrations/prospeo",
               "integrations/all/productboard",
               "api-integrations/procore",

--- a/docs/integrations/all/private-api-generic.mdx
+++ b/docs/integrations/all/private-api-generic.mdx
@@ -15,7 +15,7 @@ import PreBuiltUseCases from "/snippets/generated/private-api-generic/PreBuiltUs
 
 Use Private API (Generic) for APIs that authenticate with an API key but do not use `Authorization: Bearer <key>`. Unlike Private API (Bearer Auth), you configure per integration how the proxy presents the key:
 
-- **Key placement**: `header` or `query` param.
+- **Key placement**: `header` or `query` param. Prefer `header` — keys sent as a query param can be exposed in upstream, proxy, and CDN logs.
 - **Key name**: the header or query-param name, e.g. `Authorization`, `x-api-key`, `api_key`.
 - **Value template**: how the key is wrapped, using `${apiKey}` as the placeholder, e.g. `${apiKey}`, `Bearer ${apiKey}`, `Api-Key ${apiKey}`.
 - **Base URL**: the upstream API the proxy calls.

--- a/docs/integrations/all/private-api-generic.mdx
+++ b/docs/integrations/all/private-api-generic.mdx
@@ -26,7 +26,6 @@ The key is vaulted by Nango and injected by the proxy, so raw credentials never 
 ## Important limitations
 
 - **Limited functionality**: Private API (Generic) is limited to storing and injecting a single API key. Because it's generic, many advanced Nango features are not available for it.
-- **HTTP proxy only**: The configured key injection (placement, name, value template, base URL) is applied only by the Nango HTTP proxy (`https://api.nango.dev/proxy/...`). Calls made with `nango.proxy()` from sync/action scripts or the backend SDK do **not** apply this injection yet, so the request would be sent without the key. Use the HTTP proxy for Private API (Generic) connections.
 - **Base URL required**: You must set the base URL on the integration; there is no predefined base URL like other integrations.
 - **Recommended use cases only**: The only recommended use case for private API integrations is to store credentials for internal/customer-specific APIs that cannot be added to the Nango catalog.
 - **For all other use cases**: We recommend [contributing the API to Nango](/integrations/contribute-or-request-api) or requesting it be added by us.

--- a/docs/integrations/all/private-api-generic.mdx
+++ b/docs/integrations/all/private-api-generic.mdx
@@ -1,0 +1,53 @@
+---
+title: Private API (Generic)
+sidebarTitle: Private API (Generic)
+---
+
+import Overview from "/snippets/overview.mdx"
+import PreBuiltTooling from "/snippets/generated/private-api-generic/PreBuiltTooling.mdx"
+import PreBuiltUseCases from "/snippets/generated/private-api-generic/PreBuiltUseCases.mdx"
+
+<Overview />
+<PreBuiltTooling />
+<PreBuiltUseCases />
+
+## When to use it
+
+Use Private API (Generic) for APIs that authenticate with an API key but do not use `Authorization: Bearer <key>`. Unlike Private API (Bearer Auth), you configure per integration how the proxy presents the key:
+
+- **Key placement**: `header` or `query` param.
+- **Key name**: the header or query-param name, e.g. `Authorization`, `x-api-key`, `api_key`.
+- **Value template**: how the key is wrapped, using `${apiKey}` as the placeholder, e.g. `${apiKey}`, `Bearer ${apiKey}`, `Api-Key ${apiKey}`.
+- **Base URL**: the upstream API the proxy calls.
+- **API key label**: the label end users see for the key field in the Connect UI.
+
+The key is vaulted by Nango and injected by the proxy, so raw credentials never need to leave Nango.
+
+## Important limitations
+
+- **Limited functionality**: Private API (Generic) is limited to storing and injecting a single API key. Because it's generic, many advanced Nango features are not available for it.
+- **Base URL required**: You must set the base URL on the integration; there is no predefined base URL like other integrations.
+- **Recommended use cases only**: The only recommended use case for private API integrations is to store credentials for internal/customer-specific APIs that cannot be added to the Nango catalog.
+- **For all other use cases**: We recommend [contributing the API to Nango](/integrations/contribute-or-request-api) or requesting it be added by us.
+
+## Setup guide
+
+_No setup guide yet._
+
+<Tip>Need help getting started? Get help in the [community](https://nango.dev/slack).</Tip>
+
+<Note>Contribute improvements to the setup guide by [editing this page](https://github.com/nangohq/nango/tree/master/docs/integrations/all/private-api-generic.mdx)</Note>
+
+## Useful links
+
+_No useful links yet._
+
+<Note>Contribute useful links by [editing this page](https://github.com/nangohq/nango/tree/master/docs/integrations/all/private-api-generic.mdx)</Note>
+
+## API gotchas
+
+<Note>Contribute API gotchas by [editing this page](https://github.com/nangohq/nango/tree/master/docs/integrations/all/private-api-generic.mdx)</Note>
+
+<Card title="Connect to Private API (Generic)" icon="link" href="/integrations/all/private-api-generic/connect" horizontal>
+  Guide to connect to Private API (Generic) using Connect UI
+</Card>

--- a/docs/integrations/all/private-api-generic.mdx
+++ b/docs/integrations/all/private-api-generic.mdx
@@ -26,6 +26,7 @@ The key is vaulted by Nango and injected by the proxy, so raw credentials never 
 ## Important limitations
 
 - **Limited functionality**: Private API (Generic) is limited to storing and injecting a single API key. Because it's generic, many advanced Nango features are not available for it.
+- **HTTP proxy only**: The configured key injection (placement, name, value template, base URL) is applied only by the Nango HTTP proxy (`https://api.nango.dev/proxy/...`). Calls made with `nango.proxy()` from sync/action scripts or the backend SDK do **not** apply this injection yet, so the request would be sent without the key. Use the HTTP proxy for Private API (Generic) connections.
 - **Base URL required**: You must set the base URL on the integration; there is no predefined base URL like other integrations.
 - **Recommended use cases only**: The only recommended use case for private API integrations is to store credentials for internal/customer-specific APIs that cannot be added to the Nango catalog.
 - **For all other use cases**: We recommend [contributing the API to Nango](/integrations/contribute-or-request-api) or requesting it be added by us.

--- a/docs/integrations/all/private-api-generic/connect.mdx
+++ b/docs/integrations/all/private-api-generic/connect.mdx
@@ -1,0 +1,28 @@
+---
+title: Private API (Generic) - How do I link my account?
+sidebarTitle: Private API (Generic)
+---
+
+# Overview
+
+To authenticate with Private API (Generic), you need one key piece of information:
+
+1. **API Key** - The key that the proxy injects into your upstream API requests.
+
+How the key is presented (header vs query param, its name, and any prefix like `Bearer` or `Api-Key`) is configured on the integration by the team that set it up, not by the end user.
+
+This guide will walk you through setting up a connection with Private API (Generic).
+
+## Step 1: Get your API Key
+
+Obtain your API key from your API provider.
+
+## Step 2: Enter credentials in the Connect UI
+
+Once you have your **API Key**:
+
+1. Open the form where you need to authenticate with Private API (Generic).
+2. Enter your **API Key** in the API key field (its label may be customized for the integration).
+3. Submit the form, and you should be successfully authenticated.
+
+You are now connected to Private API (Generic).

--- a/docs/llms-full.txt
+++ b/docs/llms-full.txt
@@ -14254,6 +14254,7 @@ Use these slugs to construct provider-specific docs URLs only when needed.
 | `printful` | Printful | OAUTH2 | [docs](https://nango.dev/docs/api-integrations/printful.md) |  | [setup](https://nango.dev/docs/api-integrations/printful/how-to-register-your-own-printful-oauth-app.md) | e-commerce |
 | `private-api-basic` | Private API (Basic Auth) | BASIC | [docs](https://nango.dev/docs/integrations/all/private-api-basic.md) | [connect](https://nango.dev/docs/integrations/all/private-api-basic/connect.md) |  | other |
 | `private-api-bearer` | Private API (Bearer Auth) | API_KEY | [docs](https://nango.dev/docs/integrations/all/private-api-bearer.md) | [connect](https://nango.dev/docs/integrations/all/private-api-bearer/connect.md) |  | other |
+| `private-api-generic` | Private API (Generic) | API_KEY | [docs](https://nango.dev/docs/integrations/all/private-api-generic.md) | [connect](https://nango.dev/docs/integrations/all/private-api-generic/connect.md) |  | other |
 | `prive` | Prive | API_KEY | [docs](https://nango.dev/docs/integrations/all/prive.md) | [connect](https://nango.dev/docs/integrations/all/prive/connect.md) |  | e-commerce |
 | `procore` | Procore | OAUTH2 | [docs](https://nango.dev/docs/api-integrations/procore.md) | [connect](https://nango.dev/docs/api-integrations/procore/connect.md) | [setup](https://nango.dev/docs/api-integrations/procore/how-to-register-your-own-procore-oauth-app.md) | erp |
 | `productboard` | Productboard | OAUTH2 | [docs](https://nango.dev/docs/integrations/all/productboard.md) |  |  | productivity |

--- a/docs/llms.txt
+++ b/docs/llms.txt
@@ -134,7 +134,7 @@ Use provider URLs by replacing `{slug}` with a slug from the API catalog:
 
 ## APIs and integrations
 
-- [API catalog](https://nango.dev/docs/api-catalog.txt): 838 provider slugs with canonical docs routes, auth modes, setup guides, and connect guides.
+- [API catalog](https://nango.dev/docs/api-catalog.txt): 839 provider slugs with canonical docs routes, auth modes, setup guides, and connect guides.
 - Provider-specific pages are intentionally not expanded here so core Nango guides remain easy for agents to find.
 
 ## Resources

--- a/docs/snippets/generated/private-api-generic/PreBuiltTooling.mdx
+++ b/docs/snippets/generated/private-api-generic/PreBuiltTooling.mdx
@@ -1,0 +1,40 @@
+## Pre-built tooling
+<AccordionGroup>
+<Accordion title="✅ Authorization">
+| Tools | Status |
+| - | - |
+| Pre-built authorization (API Key) | ✅ |
+| Pre-built authorization UI | ✅ |
+| Custom authorization UI | ✅ |
+| End-user authorization guide | ✅ |
+| Expired credentials detection | ✅ |
+</Accordion>
+<Accordion title="✅ Read & write data">
+| Tools | Status |
+| - | - |
+| Pre-built integrations | 🚫 (time to contribute: &lt;48h) |
+| API unification | ✅ |
+| 2-way sync | ✅ |
+| Webhooks from Nango on data modifications | ✅ |
+| Real-time webhooks from 3rd-party API | 🚫 (time to contribute: &lt;48h) |
+| Proxy requests | ✅ |
+</Accordion>
+<Accordion title="✅ Observability & data quality">
+| Tools | Status |
+| - | - |
+| HTTP request logging | ✅ |
+| End-to-end type safety | ✅ |
+| Data runtime validation | ✅ |
+| OpenTelemetry export | ✅ |
+| Slack alerts on errors | ✅ |
+| Integration status API | ✅ |
+</Accordion>
+<Accordion title="✅ Customization">
+| Tools | Status |
+| - | - |
+| Create or customize use-cases | ✅ |
+| Pre-configured pagination | 🚫 (time to contribute: &lt;48h) |
+| Pre-configured rate-limit handling | 🚫 (time to contribute: &lt;48h) |
+| Per-customer configurations | ✅ |
+</Accordion>
+</AccordionGroup>

--- a/docs/snippets/generated/private-api-generic/PreBuiltUseCases.mdx
+++ b/docs/snippets/generated/private-api-generic/PreBuiltUseCases.mdx
@@ -1,0 +1,3 @@
+_No pre-built syncs or actions available yet._
+
+<Tip>Not seeing the integration you need? [Build your own](/guides/functions/functions-guide) independently.</Tip>

--- a/packages/connect-ui/src/views/Go.tsx
+++ b/packages/connect-ui/src/views/Go.tsx
@@ -543,6 +543,7 @@ export const Go: React.FC = () => {
                                         provider[type === 'credentials' ? 'credentials' : type === 'params' ? 'connection_config' : 'assertion_option']?.[key];
                                     // Not all fields have a definition in providers.yaml so we fallback to default
                                     const base = name in defaultConfiguration ? defaultConfiguration[name] : undefined;
+                                    const labelOverride = type === 'credentials' ? integration?.credentials_label?.[key] : undefined;
                                     const isPreconfigured = typeof preconfigured[key] !== 'undefined';
                                     const isOptional = definition && 'optional' in definition && definition.optional === true;
 
@@ -580,7 +581,8 @@ export const Go: React.FC = () => {
                                                         <div className="flex flex-col gap-2">
                                                             <div className="flex gap-2 items-center">
                                                                 <FormLabel className="text-xs font-semibold text-text-primary">
-                                                                    {definition?.title || base?.title} {!isOptional && <span className="text-error">*</span>}
+                                                                    {labelOverride || definition?.title || base?.title}{' '}
+                                                                    {!isOptional && <span className="text-error">*</span>}
                                                                 </FormLabel>
                                                                 {isOptional && (
                                                                     <span className="bg-elevated rounded-lg px-2 py-0.5 text-xs text-text-muted">optional</span>
@@ -595,7 +597,7 @@ export const Go: React.FC = () => {
                                                                     </Link>
                                                                 )}
                                                             </div>
-                                                            {definition?.description && (
+                                                            {!labelOverride && definition?.description && (
                                                                 <FormDescription className="text-text-secondary">{definition.description}</FormDescription>
                                                             )}
                                                         </div>
@@ -611,7 +613,7 @@ export const Go: React.FC = () => {
                                                                 />
                                                             ) : (
                                                                 <CustomInput
-                                                                    placeholder={definition?.example || definition?.title || base?.example}
+                                                                    placeholder={labelOverride ? '' : definition?.example || definition?.title || base?.example}
                                                                     prefix={definition?.prefix}
                                                                     suffix={definition?.suffix}
                                                                     {...(field as InputHTMLAttributes<HTMLInputElement>)}

--- a/packages/jobs/lib/execution/action.ts
+++ b/packages/jobs/lib/execution/action.ts
@@ -156,7 +156,8 @@ export async function startAction(task: TaskAction): Promise<Result<void>> {
             heartbeatTimeoutSecs: task.heartbeatTimeoutSecs,
             integrationConfig: {
                 oauth_client_id: providerConfig.oauth_client_id,
-                oauth_client_secret: providerConfig.oauth_client_secret
+                oauth_client_secret: providerConfig.oauth_client_secret,
+                custom: providerConfig.custom
             }
         };
 

--- a/packages/jobs/lib/execution/sync.ts
+++ b/packages/jobs/lib/execution/sync.ts
@@ -205,7 +205,8 @@ export async function startSync(task: TaskSync, startScriptFn = startScript): Pr
             heartbeatTimeoutSecs: task.heartbeatTimeoutSecs,
             integrationConfig: {
                 oauth_client_id: providerConfig.oauth_client_id,
-                oauth_client_secret: providerConfig.oauth_client_secret
+                oauth_client_secret: providerConfig.oauth_client_secret,
+                custom: providerConfig.custom
             },
             ...(plan?.sync_function_runtime === 'lambda'
                 ? {

--- a/packages/lambda-runner/lib/schemas.ts
+++ b/packages/lambda-runner/lib/schemas.ts
@@ -89,7 +89,8 @@ export const nangoPropsSchema = z.object({
     integrationConfig: z
         .object({
             oauth_client_id: z.string().nullable(),
-            oauth_client_secret: z.string().nullable()
+            oauth_client_secret: z.string().nullable(),
+            custom: z.record(z.string(), z.string()).nullish()
         })
         .optional()
 });

--- a/packages/providers/providers.yaml
+++ b/packages/providers/providers.yaml
@@ -15272,12 +15272,14 @@ private-api-generic:
             description: How the key is presented to the upstream API. Use ${apiKey} as the placeholder for the stored key.
             example: Api-Key ${apiKey}
             default_value: ${apiKey}
+            pattern: '\$\{apiKey\}'
             order: 3
         baseUrl:
             type: string
             title: Base URL
             description: Base URL of the upstream API the proxy will call.
             format: uri
+            pattern: '^https?://'
             example: https://api.example.com
             order: 4
         keyLabel:

--- a/packages/providers/providers.yaml
+++ b/packages/providers/providers.yaml
@@ -15243,7 +15243,57 @@ private-api-basic:
             type: string
             title: Password
             description: Your password
-
+private-api-generic:
+    display_name: Private API (Generic)
+    categories:
+        - other
+    auth_mode: API_KEY
+    proxy:
+        base_url: https://api.nango.dev/
+    integration_config:
+        keyPlacement:
+            type: string
+            title: Key placement
+            description: Where the API key is sent on proxied requests.
+            enum:
+                - header
+                - query
+            default_value: header
+            order: 1
+        keyName:
+            type: string
+            title: Key name
+            description: Header name or query-param name (e.g. Authorization, x-api-key, api_key).
+            example: Authorization
+            order: 2
+        valueTemplate:
+            type: string
+            title: Value template
+            description: How the key is presented to the upstream API. Use ${apiKey} as the placeholder for the stored key.
+            example: Api-Key ${apiKey}
+            default_value: ${apiKey}
+            order: 3
+        baseUrl:
+            type: string
+            title: Base URL
+            description: Base URL of the upstream API the proxy will call.
+            format: uri
+            example: https://api.example.com
+            order: 4
+        keyLabel:
+            type: string
+            title: API key label (shown in Connect UI)
+            description: The label end users see for the API key field in the Connect UI.
+            default_value: API Key
+            optional: true
+            order: 5
+    docs: https://nango.dev/docs/integrations/all/private-api-generic
+    docs_connect: https://nango.dev/docs/integrations/all/private-api-generic/connect
+    credentials:
+        apiKey:
+            type: string
+            title: API Key
+            description: Your API Key
 precisefp:
     display_name: PreciseFP
     categories:

--- a/packages/providers/providers.yaml
+++ b/packages/providers/providers.yaml
@@ -15259,6 +15259,8 @@ private-api-generic:
                 - header
                 - query
             default_value: header
+            warnings:
+                query: Sending the key as a query param can expose it in upstream, proxy, and CDN logs. Prefer a header when the API supports it.
             order: 1
         keyName:
             type: string

--- a/packages/server/lib/controllers/integrations/uniqueKey/patchIntegration.ts
+++ b/packages/server/lib/controllers/integrations/uniqueKey/patchIntegration.ts
@@ -12,6 +12,7 @@ import {
     providerConfigKeySchema
 } from '../../../helpers/validation.js';
 import { asyncWrapper } from '../../../utils/asyncWrapper.js';
+import { resolveIntegrationConfig } from '../../v1/integrations/integrationConfig.js';
 
 import type { PatchPublicIntegration } from '@nangohq/types';
 
@@ -93,10 +94,24 @@ export const patchPublicIntegration = asyncWrapper<PatchPublicIntegration>(async
 
     if ('custom' in body && body.custom && Object.keys(body.custom).length > 0) {
         const custom: Record<string, string> = body.custom as Record<string, string>;
-        integration.custom = {
-            ...integration.custom,
-            ...custom
-        };
+        if (provider.integration_config) {
+            // For providers with a custom integration configuration schema, validate the custom payload against it
+            // (instead of merging arbitrary keys) so this path can't write an invalid config the form/v1 API would reject.
+            const result = resolveIntegrationConfig(provider, custom, { patch: true });
+            if (result.isErr()) {
+                res.status(400).send({ error: { code: 'invalid_body', message: result.error.message } });
+                return;
+            }
+            integration.custom = {
+                ...integration.custom,
+                ...result.value
+            };
+        } else {
+            integration.custom = {
+                ...integration.custom,
+                ...custom
+            };
+        }
     }
 
     // Credentials

--- a/packages/server/lib/controllers/proxy/allProxy.ts
+++ b/packages/server/lib/controllers/proxy/allProxy.ts
@@ -12,6 +12,7 @@ import {
     configService,
     connectionService,
     errorManager,
+    getProvider,
     getProxyConfiguration,
     pubsub,
     refreshOrTestCredentials
@@ -144,6 +145,18 @@ export const allPublicProxy = asyncWrapper<AllPublicProxy>(async (req, res, next
                     code: 'unknown_provider_config',
                     message: 'Provider config not found for the given provider config key. Please make sure the provider config exists in the Nango dashboard.'
                 }
+            });
+            return;
+        }
+
+        const provider = getProvider(integration.provider);
+        const customBaseUrl = provider?.integration_config ? integration.custom?.['baseUrl'] : undefined;
+        if (customBaseUrl && isBaseUrlOverrideDenied(customBaseUrl, baseUrlOverrideDenylist)) {
+            void logCtx.error('Integration base URL is not allowed by server configuration');
+            await logCtx.failed();
+            metrics.increment(metrics.Types.PROXY_FAILURE);
+            res.status(400).send({
+                error: { code: 'base_url_override_not_allowed', message: 'This base URL is not allowed by server configuration.' }
             });
             return;
         }

--- a/packages/server/lib/controllers/proxy/allProxy.ts
+++ b/packages/server/lib/controllers/proxy/allProxy.ts
@@ -149,8 +149,10 @@ export const allPublicProxy = asyncWrapper<AllPublicProxy>(async (req, res, next
             return;
         }
 
+        // A base-url-override (already checked above) takes precedence over the integration's custom.baseUrl, so only
+        // denylist-check custom.baseUrl when no override is supplied — otherwise a safe override would be wrongly rejected.
         const provider = getProvider(integration.provider);
-        const customBaseUrl = provider?.integration_config ? integration.custom?.['baseUrl'] : undefined;
+        const customBaseUrl = !baseUrlOverride && provider?.integration_config ? integration.custom?.['baseUrl'] : undefined;
         if (customBaseUrl && isBaseUrlOverrideDenied(customBaseUrl, baseUrlOverrideDenylist)) {
             void logCtx.error('Integration base URL is not allowed by server configuration');
             await logCtx.failed();

--- a/packages/server/lib/controllers/proxy/allProxy.ts
+++ b/packages/server/lib/controllers/proxy/allProxy.ts
@@ -265,7 +265,8 @@ export const allPublicProxy = asyncWrapper<AllPublicProxy>(async (req, res, next
             },
             getIntegrationConfig: () => ({
                 oauth_client_id: integration.oauth_client_id,
-                oauth_client_secret: integration.oauth_client_secret
+                oauth_client_secret: integration.oauth_client_secret,
+                custom: integration.custom
             }),
             onBytes: ({ sent, received }) => {
                 metrics.increment(metrics.Types.PROXY_REQUEST_SIZE_IN_BYTES, sent, { callsite: 'server' });

--- a/packages/server/lib/controllers/v1/integrations/buildIntegrationConfig.ts
+++ b/packages/server/lib/controllers/v1/integrations/buildIntegrationConfig.ts
@@ -90,5 +90,13 @@ export async function buildIntegrationConfig(body: PostIntegration['Body'], envi
         }
     }
 
+    // Custom integration configuration (providers that declare `integration_config`, e.g. private-api-generic).
+    if (body.integrationConfig) {
+        config.custom = {
+            ...config.custom,
+            ...body.integrationConfig
+        };
+    }
+
     return config;
 }

--- a/packages/server/lib/controllers/v1/integrations/integrationConfig.ts
+++ b/packages/server/lib/controllers/v1/integrations/integrationConfig.ts
@@ -22,12 +22,13 @@ function hasValue(value: string | undefined): value is string {
 }
 
 /**
- * Validates the values submitted for a provider's `integration_config` schema and returns the
- * cleaned set of values (with defaults applied) ready to be merged into the integration's `custom` field.
+ * Resolves the values submitted for a provider's `integration_config` schema: validates them, applies
+ * defaults, and returns the cleaned set ready to be merged into the integration's `custom` field.
  *
- * Used for custom integration configuration (e.g. `private-api-generic`). Unknown keys are dropped.
+ * Used for custom integration configuration (e.g. `private-api-generic`). Keys not declared in the
+ * schema are rejected (rather than silently dropped) so typos surface as errors.
  */
-export function validateIntegrationConfig(
+export function resolveIntegrationConfig(
     provider: Provider,
     submitted: Record<string, string>,
     options?: { patch?: boolean }
@@ -40,6 +41,13 @@ export function validateIntegrationConfig(
 
     const errors: IntegrationConfigFieldError[] = [];
     const values: Record<string, string> = {};
+
+    // Reject keys that are not part of the provider's schema so a typo'd field surfaces instead of being dropped.
+    for (const key of Object.keys(submitted)) {
+        if (!Object.prototype.hasOwnProperty.call(schema, key)) {
+            errors.push({ field: key, message: `Unknown field ${key}` });
+        }
+    }
 
     for (const [field, definition] of Object.entries(schema)) {
         const provided = field in submitted;

--- a/packages/server/lib/controllers/v1/integrations/integrationConfig.ts
+++ b/packages/server/lib/controllers/v1/integrations/integrationConfig.ts
@@ -80,10 +80,16 @@ export function validateIntegrationConfig(
         }
 
         if (definition.format === 'uri') {
+            let protocol: string | undefined;
             try {
-                new URL(value);
+                protocol = new URL(value).protocol;
             } catch {
                 errors.push({ field, message: `${definition.title} must be a valid URL` });
+                continue;
+            }
+
+            if (protocol !== 'http:' && protocol !== 'https:') {
+                errors.push({ field, message: `${definition.title} must be an http(s) URL` });
                 continue;
             }
         }

--- a/packages/server/lib/controllers/v1/integrations/integrationConfig.ts
+++ b/packages/server/lib/controllers/v1/integrations/integrationConfig.ts
@@ -1,0 +1,99 @@
+import { Err, Ok } from '@nangohq/utils';
+
+import type { Provider } from '@nangohq/types';
+import type { Result } from '@nangohq/utils';
+
+export interface IntegrationConfigFieldError {
+    field: string;
+    message: string;
+}
+
+export class IntegrationConfigError extends Error {
+    fields: IntegrationConfigFieldError[];
+    constructor(fields: IntegrationConfigFieldError[]) {
+        super(fields.map((f) => f.message).join(', '));
+        this.name = 'IntegrationConfigError';
+        this.fields = fields;
+    }
+}
+
+function hasValue(value: string | undefined): value is string {
+    return value !== undefined && value !== '';
+}
+
+/**
+ * Validates the values submitted for a provider's `integration_config` schema and returns the
+ * cleaned set of values (with defaults applied) ready to be merged into the integration's `custom` field.
+ *
+ * Used for custom integration configuration (e.g. `private-api-generic`). Unknown keys are dropped.
+ */
+export function validateIntegrationConfig(
+    provider: Provider,
+    submitted: Record<string, string>,
+    options?: { patch?: boolean }
+): Result<Record<string, string>, IntegrationConfigError> {
+    const patch = options?.patch ?? false;
+    const schema = provider.integration_config;
+    if (!schema) {
+        return Err(new IntegrationConfigError([{ field: '_', message: 'This provider does not accept integration configuration' }]));
+    }
+
+    const errors: IntegrationConfigFieldError[] = [];
+    const values: Record<string, string> = {};
+
+    for (const [field, definition] of Object.entries(schema)) {
+        const provided = field in submitted;
+        if (patch && !provided) {
+            continue;
+        }
+
+        let value = submitted[field];
+
+        if (!hasValue(value) && definition.default_value !== undefined && !patch) {
+            value = definition.default_value;
+        }
+
+        if (!hasValue(value)) {
+            if (!definition.optional) {
+                errors.push({ field, message: `${definition.title} is required` });
+            } else if (patch) {
+                // Explicitly clearing an optional field.
+                values[field] = '';
+            }
+            continue;
+        }
+
+        if (definition.enum && definition.enum.length > 0 && !definition.enum.includes(value)) {
+            errors.push({ field, message: `${definition.title} must be one of: ${definition.enum.join(', ')}` });
+            continue;
+        }
+
+        if (definition.pattern) {
+            try {
+                if (!new RegExp(definition.pattern).test(value)) {
+                    errors.push({ field, message: `${definition.title} has an invalid format` });
+                    continue;
+                }
+            } catch {
+                // Ignore an invalid pattern in the provider schema rather than block the customer.
+            }
+        }
+
+        if (definition.format === 'uri') {
+            try {
+                new URL(value);
+            } catch {
+                errors.push({ field, message: `${definition.title} must be a valid URL` });
+                continue;
+            }
+        }
+
+        values[field] = value;
+    }
+
+    if (errors.length > 0) {
+        return Err(new IntegrationConfigError(errors));
+    }
+
+    return Ok(values);
+}

--- a/packages/server/lib/controllers/v1/integrations/integrationConfig.unit.test.ts
+++ b/packages/server/lib/controllers/v1/integrations/integrationConfig.unit.test.ts
@@ -1,0 +1,98 @@
+import { describe, expect, it } from 'vitest';
+
+import { validateIntegrationConfig } from './integrationConfig.js';
+
+import type { Provider, SimplifiedJSONSchema } from '@nangohq/types';
+
+function field(partial: Partial<SimplifiedJSONSchema>): SimplifiedJSONSchema {
+    return { type: 'string', title: partial.title ?? 'Field', description: '', order: 1, automated: false, ...partial };
+}
+
+const provider = {
+    auth_mode: 'API_KEY',
+    display_name: 'Private API (Generic)',
+    docs: '',
+    integration_config: {
+        keyPlacement: field({ title: 'Key placement', enum: ['header', 'query'], default_value: 'header' }),
+        keyName: field({ title: 'Key name' }),
+        valueTemplate: field({ title: 'Value template', default_value: '${apiKey}' }),
+        baseUrl: field({ title: 'Base URL', format: 'uri' }),
+        keyLabel: field({ title: 'API key label', optional: true, default_value: 'API Key' })
+    }
+} as unknown as Provider;
+
+describe('validateIntegrationConfig', () => {
+    it('applies defaults and accepts a valid config', () => {
+        const result = validateIntegrationConfig(provider, { keyName: 'Authorization', baseUrl: 'https://api.example.com' });
+        expect(result.isOk()).toBe(true);
+        if (result.isOk()) {
+            expect(result.value).toEqual({
+                keyPlacement: 'header',
+                keyName: 'Authorization',
+                valueTemplate: '${apiKey}',
+                baseUrl: 'https://api.example.com',
+                keyLabel: 'API Key'
+            });
+        }
+    });
+
+    it('reports required fields that are missing', () => {
+        const result = validateIntegrationConfig(provider, { baseUrl: 'https://api.example.com' });
+        expect(result.isErr()).toBe(true);
+        if (result.isErr()) {
+            expect(result.error.fields.map((e) => e.field)).toContain('keyName');
+        }
+    });
+
+    it('rejects an enum value outside the allowed set', () => {
+        const result = validateIntegrationConfig(provider, { keyName: 'Authorization', keyPlacement: 'body', baseUrl: 'https://api.example.com' });
+        expect(result.isErr()).toBe(true);
+        if (result.isErr()) {
+            expect(result.error.fields.map((e) => e.field)).toContain('keyPlacement');
+        }
+    });
+
+    it('rejects an invalid URL for uri-format fields', () => {
+        const result = validateIntegrationConfig(provider, { keyName: 'Authorization', baseUrl: 'not-a-url' });
+        expect(result.isErr()).toBe(true);
+        if (result.isErr()) {
+            expect(result.error.fields.map((e) => e.field)).toContain('baseUrl');
+        }
+    });
+
+    it('drops unknown keys not present in the schema', () => {
+        const result = validateIntegrationConfig(provider, { keyName: 'Authorization', baseUrl: 'https://api.example.com', somethingElse: 'x' });
+        expect(result.isOk()).toBe(true);
+        if (result.isOk()) {
+            expect(result.value).not.toHaveProperty('somethingElse');
+        }
+    });
+
+    describe('patch mode', () => {
+        it('validates only the submitted field and ignores missing required fields', () => {
+            const result = validateIntegrationConfig(provider, { keyName: 'X-Api-Key' }, { patch: true });
+            expect(result.isOk()).toBe(true);
+            if (result.isOk()) {
+                expect(result.value).toEqual({ keyName: 'X-Api-Key' });
+            }
+        });
+
+        it('still validates a submitted enum field', () => {
+            const result = validateIntegrationConfig(provider, { keyPlacement: 'body' }, { patch: true });
+            expect(result.isErr()).toBe(true);
+        });
+
+        it('rejects clearing a required field', () => {
+            const result = validateIntegrationConfig(provider, { keyName: '' }, { patch: true });
+            expect(result.isErr()).toBe(true);
+        });
+
+        it('allows clearing an optional field', () => {
+            const result = validateIntegrationConfig(provider, { keyLabel: '' }, { patch: true });
+            expect(result.isOk()).toBe(true);
+            if (result.isOk()) {
+                expect(result.value).toEqual({ keyLabel: '' });
+            }
+        });
+    });
+});

--- a/packages/server/lib/controllers/v1/integrations/integrationConfig.unit.test.ts
+++ b/packages/server/lib/controllers/v1/integrations/integrationConfig.unit.test.ts
@@ -68,6 +68,28 @@ describe('validateIntegrationConfig', () => {
         }
     });
 
+    it('rejects non-http(s) URI schemes', () => {
+        for (const baseUrl of ['mailto:foo@example.com', 'file:///etc/passwd', 'ftp://example.com']) {
+            const result = validateIntegrationConfig(provider, { keyName: 'Authorization', baseUrl });
+            expect(result.isErr()).toBe(true);
+            if (result.isErr()) {
+                expect(result.error.fields.map((e) => e.field)).toContain('baseUrl');
+            }
+        }
+    });
+
+    it('accepts http and https URIs', () => {
+        for (const baseUrl of ['http://internal.example.com', 'https://api.example.com']) {
+            expect(validateIntegrationConfig(provider, { keyName: 'Authorization', baseUrl }).isOk()).toBe(true);
+        }
+    });
+
+    it('rejects integrationConfig for a provider that does not declare integration_config', () => {
+        const plainProvider = { auth_mode: 'API_KEY', display_name: 'Plain', docs: '' } as unknown as Provider;
+        const result = validateIntegrationConfig(plainProvider, { anything: 'x' });
+        expect(result.isErr()).toBe(true);
+    });
+
     describe('patch mode', () => {
         it('validates only the submitted field and ignores missing required fields', () => {
             const result = validateIntegrationConfig(provider, { keyName: 'X-Api-Key' }, { patch: true });

--- a/packages/server/lib/controllers/v1/integrations/integrationConfig.unit.test.ts
+++ b/packages/server/lib/controllers/v1/integrations/integrationConfig.unit.test.ts
@@ -1,6 +1,6 @@
 import { describe, expect, it } from 'vitest';
 
-import { validateIntegrationConfig } from './integrationConfig.js';
+import { resolveIntegrationConfig } from './integrationConfig.js';
 
 import type { Provider, SimplifiedJSONSchema } from '@nangohq/types';
 
@@ -21,9 +21,9 @@ const provider = {
     }
 } as unknown as Provider;
 
-describe('validateIntegrationConfig', () => {
+describe('resolveIntegrationConfig', () => {
     it('applies defaults and accepts a valid config', () => {
-        const result = validateIntegrationConfig(provider, { keyName: 'Authorization', baseUrl: 'https://api.example.com' });
+        const result = resolveIntegrationConfig(provider, { keyName: 'Authorization', baseUrl: 'https://api.example.com' });
         expect(result.isOk()).toBe(true);
         if (result.isOk()) {
             expect(result.value).toEqual({
@@ -37,7 +37,7 @@ describe('validateIntegrationConfig', () => {
     });
 
     it('reports required fields that are missing', () => {
-        const result = validateIntegrationConfig(provider, { baseUrl: 'https://api.example.com' });
+        const result = resolveIntegrationConfig(provider, { baseUrl: 'https://api.example.com' });
         expect(result.isErr()).toBe(true);
         if (result.isErr()) {
             expect(result.error.fields.map((e) => e.field)).toContain('keyName');
@@ -45,7 +45,7 @@ describe('validateIntegrationConfig', () => {
     });
 
     it('rejects an enum value outside the allowed set', () => {
-        const result = validateIntegrationConfig(provider, { keyName: 'Authorization', keyPlacement: 'body', baseUrl: 'https://api.example.com' });
+        const result = resolveIntegrationConfig(provider, { keyName: 'Authorization', keyPlacement: 'body', baseUrl: 'https://api.example.com' });
         expect(result.isErr()).toBe(true);
         if (result.isErr()) {
             expect(result.error.fields.map((e) => e.field)).toContain('keyPlacement');
@@ -53,24 +53,24 @@ describe('validateIntegrationConfig', () => {
     });
 
     it('rejects an invalid URL for uri-format fields', () => {
-        const result = validateIntegrationConfig(provider, { keyName: 'Authorization', baseUrl: 'not-a-url' });
+        const result = resolveIntegrationConfig(provider, { keyName: 'Authorization', baseUrl: 'not-a-url' });
         expect(result.isErr()).toBe(true);
         if (result.isErr()) {
             expect(result.error.fields.map((e) => e.field)).toContain('baseUrl');
         }
     });
 
-    it('drops unknown keys not present in the schema', () => {
-        const result = validateIntegrationConfig(provider, { keyName: 'Authorization', baseUrl: 'https://api.example.com', somethingElse: 'x' });
-        expect(result.isOk()).toBe(true);
-        if (result.isOk()) {
-            expect(result.value).not.toHaveProperty('somethingElse');
+    it('rejects unknown keys not present in the schema', () => {
+        const result = resolveIntegrationConfig(provider, { keyName: 'Authorization', baseUrl: 'https://api.example.com', somethingElse: 'x' });
+        expect(result.isErr()).toBe(true);
+        if (result.isErr()) {
+            expect(result.error.fields.map((e) => e.field)).toContain('somethingElse');
         }
     });
 
     it('rejects non-http(s) URI schemes', () => {
         for (const baseUrl of ['mailto:foo@example.com', 'file:///etc/passwd', 'ftp://example.com']) {
-            const result = validateIntegrationConfig(provider, { keyName: 'Authorization', baseUrl });
+            const result = resolveIntegrationConfig(provider, { keyName: 'Authorization', baseUrl });
             expect(result.isErr()).toBe(true);
             if (result.isErr()) {
                 expect(result.error.fields.map((e) => e.field)).toContain('baseUrl');
@@ -80,19 +80,19 @@ describe('validateIntegrationConfig', () => {
 
     it('accepts http and https URIs', () => {
         for (const baseUrl of ['http://internal.example.com', 'https://api.example.com']) {
-            expect(validateIntegrationConfig(provider, { keyName: 'Authorization', baseUrl }).isOk()).toBe(true);
+            expect(resolveIntegrationConfig(provider, { keyName: 'Authorization', baseUrl }).isOk()).toBe(true);
         }
     });
 
     it('rejects integrationConfig for a provider that does not declare integration_config', () => {
         const plainProvider = { auth_mode: 'API_KEY', display_name: 'Plain', docs: '' } as unknown as Provider;
-        const result = validateIntegrationConfig(plainProvider, { anything: 'x' });
+        const result = resolveIntegrationConfig(plainProvider, { anything: 'x' });
         expect(result.isErr()).toBe(true);
     });
 
     describe('patch mode', () => {
         it('validates only the submitted field and ignores missing required fields', () => {
-            const result = validateIntegrationConfig(provider, { keyName: 'X-Api-Key' }, { patch: true });
+            const result = resolveIntegrationConfig(provider, { keyName: 'X-Api-Key' }, { patch: true });
             expect(result.isOk()).toBe(true);
             if (result.isOk()) {
                 expect(result.value).toEqual({ keyName: 'X-Api-Key' });
@@ -100,17 +100,17 @@ describe('validateIntegrationConfig', () => {
         });
 
         it('still validates a submitted enum field', () => {
-            const result = validateIntegrationConfig(provider, { keyPlacement: 'body' }, { patch: true });
+            const result = resolveIntegrationConfig(provider, { keyPlacement: 'body' }, { patch: true });
             expect(result.isErr()).toBe(true);
         });
 
         it('rejects clearing a required field', () => {
-            const result = validateIntegrationConfig(provider, { keyName: '' }, { patch: true });
+            const result = resolveIntegrationConfig(provider, { keyName: '' }, { patch: true });
             expect(result.isErr()).toBe(true);
         });
 
         it('allows clearing an optional field', () => {
-            const result = validateIntegrationConfig(provider, { keyLabel: '' }, { patch: true });
+            const result = resolveIntegrationConfig(provider, { keyLabel: '' }, { patch: true });
             expect(result.isOk()).toBe(true);
             if (result.isOk()) {
                 expect(result.value).toEqual({ keyLabel: '' });

--- a/packages/server/lib/controllers/v1/integrations/postIntegration.ts
+++ b/packages/server/lib/controllers/v1/integrations/postIntegration.ts
@@ -2,7 +2,7 @@ import { configService, getProvider, mcpClient, sharedCredentialsService } from 
 import { requireEmptyQuery, zodErrorToHTTP } from '@nangohq/utils';
 
 import { buildIntegrationConfig } from './buildIntegrationConfig.js';
-import { validateIntegrationConfig } from './integrationConfig.js';
+import { resolveIntegrationConfig } from './integrationConfig.js';
 import { postIntegrationBodySchema } from './validation.js';
 import { integrationToApi } from '../../../formatters/integration.js';
 import { asyncWrapper } from '../../../utils/asyncWrapper.js';
@@ -53,7 +53,7 @@ export const postIntegration = asyncWrapper<PostIntegration>(async (req, res) =>
             res.status(400).send({ error: { code: 'invalid_body', message: 'integrationConfig is not supported with shared credentials' } });
             return;
         }
-        const result = validateIntegrationConfig(provider, body.integrationConfig ?? {});
+        const result = resolveIntegrationConfig(provider, body.integrationConfig ?? {});
         if (result.isErr()) {
             res.status(400).send({ error: { code: 'invalid_body', message: result.error.message } });
             return;

--- a/packages/server/lib/controllers/v1/integrations/postIntegration.ts
+++ b/packages/server/lib/controllers/v1/integrations/postIntegration.ts
@@ -48,7 +48,11 @@ export const postIntegration = asyncWrapper<PostIntegration>(async (req, res) =>
         return;
     }
 
-    if (provider.integration_config) {
+    if (provider.integration_config || body.integrationConfig) {
+        if (body.useSharedCredentials) {
+            res.status(400).send({ error: { code: 'invalid_body', message: 'integrationConfig is not supported with shared credentials' } });
+            return;
+        }
         const result = validateIntegrationConfig(provider, body.integrationConfig ?? {});
         if (result.isErr()) {
             res.status(400).send({ error: { code: 'invalid_body', message: result.error.message } });

--- a/packages/server/lib/controllers/v1/integrations/postIntegration.ts
+++ b/packages/server/lib/controllers/v1/integrations/postIntegration.ts
@@ -2,6 +2,7 @@ import { configService, getProvider, mcpClient, sharedCredentialsService } from 
 import { requireEmptyQuery, zodErrorToHTTP } from '@nangohq/utils';
 
 import { buildIntegrationConfig } from './buildIntegrationConfig.js';
+import { validateIntegrationConfig } from './integrationConfig.js';
 import { postIntegrationBodySchema } from './validation.js';
 import { integrationToApi } from '../../../formatters/integration.js';
 import { asyncWrapper } from '../../../utils/asyncWrapper.js';
@@ -45,6 +46,15 @@ export const postIntegration = asyncWrapper<PostIntegration>(async (req, res) =>
     if ('auth' in body && body.auth && 'authType' in body.auth && body.auth.authType !== provider.auth_mode) {
         res.status(400).send({ error: { code: 'invalid_body', message: 'incompatible credentials auth type and provider auth' } });
         return;
+    }
+
+    if (provider.integration_config) {
+        const result = validateIntegrationConfig(provider, body.integrationConfig ?? {});
+        if (result.isErr()) {
+            res.status(400).send({ error: { code: 'invalid_body', message: result.error.message } });
+            return;
+        }
+        body.integrationConfig = result.value;
     }
 
     let integration: IntegrationConfig;

--- a/packages/server/lib/controllers/v1/integrations/providerConfigKey/patchIntegration.ts
+++ b/packages/server/lib/controllers/v1/integrations/providerConfigKey/patchIntegration.ts
@@ -3,7 +3,7 @@ import { requireEmptyQuery, zodErrorToHTTP } from '@nangohq/utils';
 
 import { validationParams } from './getIntegration.js';
 import { asyncWrapper } from '../../../../utils/asyncWrapper.js';
-import { validateIntegrationConfig } from '../integrationConfig.js';
+import { resolveIntegrationConfig } from '../integrationConfig.js';
 import { patchIntegrationBodySchema } from '../validation.js';
 
 import type { PatchIntegration } from '@nangohq/types';
@@ -158,7 +158,7 @@ export const patchIntegration = asyncWrapper<PatchIntegration>(async (req, res) 
     }
 
     if ('integrationConfig' in body && body.integrationConfig) {
-        const result = validateIntegrationConfig(provider, body.integrationConfig, { patch: true });
+        const result = resolveIntegrationConfig(provider, body.integrationConfig, { patch: true });
         if (result.isErr()) {
             res.status(400).send({ error: { code: 'invalid_body', message: result.error.message } });
             return;

--- a/packages/server/lib/controllers/v1/integrations/providerConfigKey/patchIntegration.ts
+++ b/packages/server/lib/controllers/v1/integrations/providerConfigKey/patchIntegration.ts
@@ -3,6 +3,7 @@ import { requireEmptyQuery, zodErrorToHTTP } from '@nangohq/utils';
 
 import { validationParams } from './getIntegration.js';
 import { asyncWrapper } from '../../../../utils/asyncWrapper.js';
+import { validateIntegrationConfig } from '../integrationConfig.js';
 import { patchIntegrationBodySchema } from '../validation.js';
 
 import type { PatchIntegration } from '@nangohq/types';
@@ -154,6 +155,18 @@ export const patchIntegration = asyncWrapper<PatchIntegration>(async (req, res) 
                 }
             };
         }
+    }
+
+    if ('integrationConfig' in body && body.integrationConfig) {
+        const result = validateIntegrationConfig(provider, body.integrationConfig, { patch: true });
+        if (result.isErr()) {
+            res.status(400).send({ error: { code: 'invalid_body', message: result.error.message } });
+            return;
+        }
+        integration.custom = {
+            ...integration.custom,
+            ...result.value
+        };
     }
 
     // webhook secrets

--- a/packages/server/lib/controllers/v1/integrations/validation.ts
+++ b/packages/server/lib/controllers/v1/integrations/validation.ts
@@ -97,7 +97,8 @@ export const integrationBaseBodySchema = z
         integrationId: providerConfigKeySchema.optional(),
         webhookSecret: z.union([z.string().min(0).max(255), publicKeySchema]).optional(),
         displayName: integrationDisplayNameSchema.optional(),
-        forward_webhooks: integrationForwardWebhooksSchema
+        forward_webhooks: integrationForwardWebhooksSchema,
+        integrationConfig: z.record(z.string(), z.string().max(8192)).optional()
     })
     .strict();
 

--- a/packages/server/lib/formatters/integration.ts
+++ b/packages/server/lib/formatters/integration.ts
@@ -37,6 +37,9 @@ export function integrationToPublicApi({
         provider: integration.provider,
         display_name: integration.display_name || provider.display_name,
         logo: `${basePublicUrl}/images/template-logos/${integration.provider}.svg`,
+        // Non-secret per-integration overrides for the Connect UI (e.g. the configurable API-key label).
+        // Only providers that declare `integration_config`, never expose the whole `custom` object.
+        ...(provider.integration_config && integration.custom?.['keyLabel'] ? { credentials_label: { apiKey: integration.custom['keyLabel'] } } : {}),
         ...include,
         forward_webhooks: integration.forward_webhooks === undefined ? true : integration.forward_webhooks,
         created_at: integration.created_at.toISOString(),

--- a/packages/server/lib/formatters/provider.ts
+++ b/packages/server/lib/formatters/provider.ts
@@ -18,6 +18,7 @@ export function providerListItemToAPI(
         docs_connect: properties.docs_connect,
         preConfigured,
         preConfiguredScopes,
+        ...(properties.integration_config && { integration_config: properties.integration_config }),
         ...(properties.auth_mode === 'MCP_OAUTH2' && {
             clientRegistration: (properties as ProviderMcpOAUTH2).client_registration
         })

--- a/packages/shared/lib/services/proxy/request.ts
+++ b/packages/shared/lib/services/proxy/request.ts
@@ -95,7 +95,9 @@ export class ProxyRequest {
                     const headersNeedOAuthAppCredentials =
                         proxyHeaders &&
                         Object.values(proxyHeaders).some((v) => typeof v === 'string' && (v.includes('${clientId}') || v.includes('${clientSecret}')));
-                    if (this.connection.credentials.type === 'OAUTH1' || headersNeedOAuthAppCredentials) {
+
+                    const needsIntegrationConfig = Boolean(this.config.provider.integration_config);
+                    if (this.connection.credentials.type === 'OAUTH1' || headersNeedOAuthAppCredentials || needsIntegrationConfig) {
                         this.integrationConfig = await this.getIntegrationConfig();
                     }
 

--- a/packages/shared/lib/services/proxy/utils.ts
+++ b/packages/shared/lib/services/proxy/utils.ts
@@ -329,8 +329,10 @@ export function buildProxyURL({ config, connection }: { config: ApplicationConst
     const normalizedBase = apiBase?.endsWith('/') ? apiBase.slice(0, -1) : apiBase;
     let normalizedEndpoint = apiEndpoint.replace(/^\/+/, '');
 
-    // If the endpoint is absolute and already starts with the effective base, strip it to avoid duplicating the base.
-    if (normalizedBase && !normalizedBase.includes('${') && normalizedEndpoint.startsWith(normalizedBase)) {
+    // If the endpoint is absolute and is the effective base (optionally followed by a path), strip the base to avoid
+    // duplicating it. Match only at a path boundary (exact, or base + '/') so a different host that merely shares the
+    // prefix (e.g. https://api.example.com.evil.com) isn't wrongly rewritten.
+    if (normalizedBase && !normalizedBase.includes('${') && (normalizedEndpoint === normalizedBase || normalizedEndpoint.startsWith(`${normalizedBase}/`))) {
         normalizedEndpoint = normalizedEndpoint.slice(normalizedBase.length).replace(/^\/+/, '');
     }
 

--- a/packages/shared/lib/services/proxy/utils.ts
+++ b/packages/shared/lib/services/proxy/utils.ts
@@ -329,11 +329,14 @@ export function buildProxyURL({ config, connection }: { config: ApplicationConst
     const normalizedBase = apiBase?.endsWith('/') ? apiBase.slice(0, -1) : apiBase;
     let normalizedEndpoint = apiEndpoint.replace(/^\/+/, '');
 
-    // If the endpoint is absolute and is the effective base (optionally followed by a path), strip the base to avoid
-    // duplicating it. Match only at a path boundary (exact, or base + '/') so a different host that merely shares the
-    // prefix (e.g. https://api.example.com.evil.com) isn't wrongly rewritten.
-    if (normalizedBase && !normalizedBase.includes('${') && (normalizedEndpoint === normalizedBase || normalizedEndpoint.startsWith(`${normalizedBase}/`))) {
-        normalizedEndpoint = normalizedEndpoint.slice(normalizedBase.length).replace(/^\/+/, '');
+    // If the endpoint is absolute and starts with the effective base, strip the base to avoid duplicating it.
+    // Only strip at a real boundary — end of string, or the next char is a path/query/fragment delimiter — so a
+    // different host that merely shares the prefix (e.g. https://api.example.com.evil.com) isn't wrongly rewritten.
+    if (normalizedBase && !normalizedBase.includes('${') && normalizedEndpoint.startsWith(normalizedBase)) {
+        const rest = normalizedEndpoint.slice(normalizedBase.length);
+        if (rest === '' || rest[0] === '/' || rest[0] === '?' || rest[0] === '#') {
+            normalizedEndpoint = rest.replace(/^\/+/, '');
+        }
     }
 
     const baseFormatted = interpolateProxyUrlParts(normalizedBase);

--- a/packages/shared/lib/services/proxy/utils.ts
+++ b/packages/shared/lib/services/proxy/utils.ts
@@ -88,6 +88,10 @@ export function getAxiosConfiguration({
     connection: ConnectionForProxy;
     integrationConfig?: IntegrationConfigForProxy | undefined;
 }): AxiosRequestConfig {
+    if (proxyConfig.provider.integration_config) {
+        proxyConfig = deriveIntegrationConfigProxy({ proxyConfig, integrationConfig });
+    }
+
     const url = buildProxyURL({ config: proxyConfig, connection });
     const headers = buildProxyHeaders({ config: proxyConfig, url, connection, integrationConfig });
 
@@ -256,6 +260,56 @@ export function getProxyConfiguration({
 }
 
 /**
+ * For providers that expose a customer-configurable `integration_config` schema (e.g. `private-api-generic`),
+ * the API-key injection is configured per-integration and stored in the integration's `custom` field rather than
+ * statically in providers.yaml. This derives an effective proxy config (base_url + a single header/query entry)
+ * from that per-integration config so the existing header/query interpolation can inject the key.
+ *
+ * The `valueTemplate` (e.g. `Api-Key ${apiKey}`) is interpolated downstream against the connection credentials,
+ * where `${apiKey}` resolves to the stored API key.
+ */
+export function deriveIntegrationConfigProxy({
+    proxyConfig,
+    integrationConfig
+}: {
+    proxyConfig: ApplicationConstructedProxyConfiguration;
+    integrationConfig?: IntegrationConfigForProxy | undefined;
+}): ApplicationConstructedProxyConfiguration {
+    const provider = proxyConfig.provider;
+    const custom = integrationConfig?.custom;
+
+    // Only providers that declare `integration_config` opt into per-integration proxy injection.
+    if (!provider.integration_config || !custom || !custom['keyName']) {
+        return proxyConfig;
+    }
+
+    const placement = custom['keyPlacement'] || 'header';
+    const keyName = custom['keyName'];
+    const valueTemplate = custom['valueTemplate'] || '${apiKey}';
+    const baseUrl = custom['baseUrl'];
+
+    const baseProxy = provider.proxy ?? { base_url: '' };
+    const proxy = {
+        ...baseProxy,
+        base_url: baseUrl || baseProxy.base_url,
+        headers: { ...(baseProxy.headers ?? {}) },
+        query: { ...(baseProxy.query ?? {}) }
+    };
+
+    if (placement === 'query') {
+        proxy.query[keyName] = valueTemplate;
+    } else {
+        // HTTP header names are case-insensitive; lowercase to match the providers.yaml convention.
+        proxy.headers[keyName.toLowerCase()] = valueTemplate;
+    }
+
+    return {
+        ...proxyConfig,
+        provider: { ...provider, proxy }
+    };
+}
+
+/**
  * Construct URL
  */
 export function buildProxyURL({ config, connection }: { config: ApplicationConstructedProxyConfiguration; connection: ConnectionForProxy }) {
@@ -303,8 +357,8 @@ export function buildProxyURL({ config, connection }: { config: ApplicationConst
             if (typeof value !== 'string') {
                 continue;
             }
-            if (connection.credentials.type === 'API_KEY' && value === '${apiKey}') {
-                url.searchParams.set(key, connection.credentials.apiKey);
+            if (connection.credentials.type === 'API_KEY' && value.includes('${apiKey}')) {
+                url.searchParams.set(key, interpolateIfNeeded(value, { ...(connection.credentials as unknown as Record<string, string>) }));
             } else if (value.includes('connectionConfig.')) {
                 const interpolatedValue = interpolateIfNeeded(value.replace(/connectionConfig\./g, ''), connection.connection_config);
 

--- a/packages/shared/lib/services/proxy/utils.ts
+++ b/packages/shared/lib/services/proxy/utils.ts
@@ -327,7 +327,12 @@ export function buildProxyURL({ config, connection }: { config: ApplicationConst
     }
 
     const normalizedBase = apiBase?.endsWith('/') ? apiBase.slice(0, -1) : apiBase;
-    const normalizedEndpoint = apiEndpoint.replace(/^\/+/, '');
+    let normalizedEndpoint = apiEndpoint.replace(/^\/+/, '');
+
+    // If the endpoint is absolute and already starts with the effective base, strip it to avoid duplicating the base.
+    if (normalizedBase && !normalizedBase.includes('${') && normalizedEndpoint.startsWith(normalizedBase)) {
+        normalizedEndpoint = normalizedEndpoint.slice(normalizedBase.length).replace(/^\/+/, '');
+    }
 
     const baseFormatted = interpolateProxyUrlParts(normalizedBase);
     const endpointFormatted = normalizedEndpoint ? interpolateProxyUrlParts(normalizedEndpoint) : '';

--- a/packages/shared/lib/services/proxy/utils.unit.test.ts
+++ b/packages/shared/lib/services/proxy/utils.unit.test.ts
@@ -1720,6 +1720,23 @@ describe('deriveIntegrationConfigProxy (private-api-generic style)', () => {
         expect(axiosConfig.url).toBe('https://api.example.com/users');
     });
 
+    it('does not duplicate the base when the absolute endpoint continues with a query string', () => {
+        const config = getDefaultProxy({ provider: genericProvider, endpoint: 'https://api.example.com?foo=1' });
+        const axiosConfig = getAxiosConfiguration({
+            proxyConfig: config,
+            connection: getTestConnection({ credentials: { type: 'API_KEY', apiKey: 'k' } }),
+            integrationConfig: {
+                oauth_client_id: null,
+                oauth_client_secret: null,
+                custom: { keyPlacement: 'header', keyName: 'Authorization', valueTemplate: '${apiKey}', baseUrl: 'https://api.example.com' }
+            }
+        });
+
+        const parsed = new URL(axiosConfig.url as string);
+        expect(parsed.host).toBe('api.example.com');
+        expect(parsed.searchParams.get('foo')).toBe('1');
+    });
+
     it('does not rewrite a different host that merely shares the base string prefix', () => {
         const config = getDefaultProxy({ provider: genericProvider, endpoint: 'https://api.example.com.evil.com/x' });
         const axiosConfig = getAxiosConfiguration({

--- a/packages/shared/lib/services/proxy/utils.unit.test.ts
+++ b/packages/shared/lib/services/proxy/utils.unit.test.ts
@@ -1719,4 +1719,20 @@ describe('deriveIntegrationConfigProxy (private-api-generic style)', () => {
 
         expect(axiosConfig.url).toBe('https://api.example.com/users');
     });
+
+    it('does not rewrite a different host that merely shares the base string prefix', () => {
+        const config = getDefaultProxy({ provider: genericProvider, endpoint: 'https://api.example.com.evil.com/x' });
+        const axiosConfig = getAxiosConfiguration({
+            proxyConfig: config,
+            connection: getTestConnection({ credentials: { type: 'API_KEY', apiKey: 'k' } }),
+            integrationConfig: {
+                oauth_client_id: null,
+                oauth_client_secret: null,
+                custom: { keyPlacement: 'header', keyName: 'Authorization', valueTemplate: '${apiKey}', baseUrl: 'https://api.example.com' }
+            }
+        });
+
+        // The base is not stripped (no path boundary), so the request stays under the configured host, not evil.com.
+        expect(new URL(axiosConfig.url as string).host).toBe('api.example.com');
+    });
 });

--- a/packages/shared/lib/services/proxy/utils.unit.test.ts
+++ b/packages/shared/lib/services/proxy/utils.unit.test.ts
@@ -9,6 +9,7 @@ import {
     buildCanonicalParams,
     buildProxyHeaders,
     buildProxyURL,
+    deriveIntegrationConfigProxy,
     getAxiosConfiguration,
     getProxyConfiguration
 } from './utils.js';
@@ -1629,5 +1630,78 @@ describe('buildProxyHeaders TWO_STEP', () => {
         const headers = buildProxyHeaders({ config, url: 'https://example.com', connection });
         expect(headers['authorization']).toBeUndefined();
         expect(headers['cookie']).toBe('B1SESSION=sess-token-123');
+    });
+});
+
+describe('deriveIntegrationConfigProxy (private-api-generic style)', () => {
+    const genericProvider = {
+        auth_mode: 'API_KEY' as const,
+        display_name: 'Private API (Generic)',
+        docs: '',
+        // presence of integration_config opts the provider into per-integration proxy injection
+        integration_config: { keyPlacement: { type: 'string' as const, title: 'Key placement', description: '', order: 1, automated: false } },
+        proxy: { base_url: 'https://my-private-api' }
+    };
+
+    it('injects the API key into a custom header using the value template', () => {
+        const config = getDefaultProxy({ provider: genericProvider });
+        const axiosConfig = getAxiosConfiguration({
+            proxyConfig: config,
+            connection: getTestConnection({ credentials: { type: 'API_KEY', apiKey: 'secret-key' } }),
+            integrationConfig: {
+                oauth_client_id: null,
+                oauth_client_secret: null,
+                custom: { keyPlacement: 'header', keyName: 'Authorization', valueTemplate: 'Api-Key ${apiKey}', baseUrl: 'https://api.example.com' }
+            }
+        });
+
+        expect((axiosConfig.headers as Record<string, string>)['authorization']).toBe('Api-Key secret-key');
+        expect(axiosConfig.url).toBe('https://api.example.com/api/test');
+    });
+
+    it('injects the API key into a custom non-Authorization header', () => {
+        const config = getDefaultProxy({ provider: genericProvider });
+        const axiosConfig = getAxiosConfiguration({
+            proxyConfig: config,
+            connection: getTestConnection({ credentials: { type: 'API_KEY', apiKey: 'abc' } }),
+            integrationConfig: {
+                oauth_client_id: null,
+                oauth_client_secret: null,
+                custom: { keyPlacement: 'header', keyName: 'x-ai-calls-api-key', valueTemplate: '${apiKey}', baseUrl: 'https://api.example.com' }
+            }
+        });
+
+        expect((axiosConfig.headers as Record<string, string>)['x-ai-calls-api-key']).toBe('abc');
+    });
+
+    it('injects the API key into a query param', () => {
+        const config = getDefaultProxy({ provider: genericProvider });
+        const axiosConfig = getAxiosConfiguration({
+            proxyConfig: config,
+            connection: getTestConnection({ credentials: { type: 'API_KEY', apiKey: 'qkey' } }),
+            integrationConfig: {
+                oauth_client_id: null,
+                oauth_client_secret: null,
+                custom: { keyPlacement: 'query', keyName: 'api_key', valueTemplate: '${apiKey}', baseUrl: 'https://api.example.com' }
+            }
+        });
+
+        expect(axiosConfig.url).toBe('https://api.example.com/api/test?api_key=qkey');
+    });
+
+    it('is a no-op when the provider does not declare integration_config', () => {
+        const config = getDefaultProxy({
+            provider: {
+                auth_mode: 'API_KEY',
+                display_name: 'x',
+                docs: '',
+                proxy: { base_url: 'https://static.example.com', headers: { authorization: 'Bearer ${apiKey}' } }
+            }
+        });
+        const derived = deriveIntegrationConfigProxy({
+            proxyConfig: config,
+            integrationConfig: { oauth_client_id: null, oauth_client_secret: null, custom: { keyName: 'Authorization', valueTemplate: '${apiKey}' } }
+        });
+        expect(derived).toBe(config);
     });
 });

--- a/packages/shared/lib/services/proxy/utils.unit.test.ts
+++ b/packages/shared/lib/services/proxy/utils.unit.test.ts
@@ -1704,4 +1704,19 @@ describe('deriveIntegrationConfigProxy (private-api-generic style)', () => {
         });
         expect(derived).toBe(config);
     });
+
+    it('does not duplicate the base when the endpoint is absolute and equals the custom base', () => {
+        const config = getDefaultProxy({ provider: genericProvider, endpoint: 'https://api.example.com/users' });
+        const axiosConfig = getAxiosConfiguration({
+            proxyConfig: config,
+            connection: getTestConnection({ credentials: { type: 'API_KEY', apiKey: 'k' } }),
+            integrationConfig: {
+                oauth_client_id: null,
+                oauth_client_secret: null,
+                custom: { keyPlacement: 'header', keyName: 'Authorization', valueTemplate: '${apiKey}', baseUrl: 'https://api.example.com' }
+            }
+        });
+
+        expect(axiosConfig.url).toBe('https://api.example.com/users');
+    });
 });

--- a/packages/types/lib/integration/api.ts
+++ b/packages/types/lib/integration/api.ts
@@ -14,6 +14,9 @@ export type ApiPublicIntegration = Merge<
 } & ApiPublicIntegrationInclude;
 export interface ApiPublicIntegrationInclude {
     webhook_url?: string | null;
+    // Per-integration, non-secret overrides surfaced to the Connect UI (e.g. the API key field label).
+    // Derived server-side from a curated subset of the integration's `custom` config — never the whole object.
+    credentials_label?: Record<string, string> | undefined;
     credentials?:
         | {
               type: AuthModes['OAuth2'] | AuthModes['OAuth1'] | AuthModes['TBA'];
@@ -215,6 +218,9 @@ export type PostIntegration = Endpoint<{
         displayName?: string | undefined;
         forward_webhooks?: boolean | undefined;
         auth?: IntegrationAuthBody | undefined;
+        // Custom integration configuration (providers that declare `integration_config`, e.g. private-api-generic).
+        // Validated server-side against the provider schema and merged into `custom`.
+        integrationConfig?: Record<string, string> | undefined;
     };
     Success: {
         data: ApiIntegration;
@@ -245,7 +251,14 @@ export type PatchIntegration = Endpoint<{
     Querystring: { env: string };
     Params: { providerConfigKey: string };
     Body:
-        | { integrationId?: string | undefined; webhookSecret?: string | undefined; displayName?: string | undefined; forward_webhooks?: boolean | undefined }
+        | {
+              integrationId?: string | undefined;
+              webhookSecret?: string | undefined;
+              displayName?: string | undefined;
+              forward_webhooks?: boolean | undefined;
+              // Custom integration configuration (providers that declare `integration_config`, e.g. private-api-generic).
+              integrationConfig?: Record<string, string> | undefined;
+          }
         | IntegrationAuthBody;
     Success: {
         data: {

--- a/packages/types/lib/providers/api.ts
+++ b/packages/types/lib/providers/api.ts
@@ -1,5 +1,5 @@
 import type { Endpoint } from '../api.js';
-import type { Provider } from './provider.js';
+import type { Provider, SimplifiedJSONSchema } from './provider.js';
 import type { AuthModeType } from '../auth/api.js';
 
 export type GetPublicProviders = Endpoint<{
@@ -34,6 +34,7 @@ export interface ApiProviderListItem {
     preConfigured: boolean;
     preConfiguredScopes: string[];
     clientRegistration?: 'dynamic' | 'static' | 'metadata';
+    integration_config?: Record<string, SimplifiedJSONSchema> | undefined;
 }
 
 export type GetProviders = Endpoint<{

--- a/packages/types/lib/providers/provider.ts
+++ b/packages/types/lib/providers/provider.ts
@@ -38,6 +38,8 @@ export interface SimplifiedJSONSchema {
     secret?: string;
     automated: boolean;
     enum?: string[];
+    // Maps a field value to a warning shown when that value is selected (e.g. discouraged enum options).
+    warnings?: Record<string, string>;
 }
 
 export interface BaseProvider {

--- a/packages/types/lib/providers/provider.ts
+++ b/packages/types/lib/providers/provider.ts
@@ -90,6 +90,7 @@ export interface BaseProvider {
     connection_configuration?: string[];
     connection_config?: Record<string, SimplifiedJSONSchema>;
     credentials?: Record<string, SimplifiedJSONSchema>;
+    integration_config?: Record<string, SimplifiedJSONSchema>;
     assertion_option?: Record<string, SimplifiedJSONSchema>; // introduce another property since these params are not stored and can only be used once for assertion generation
     authorization_url_fragment?: string;
     body_format?: OAuthBodyFormatType;

--- a/packages/types/lib/proxy/api.ts
+++ b/packages/types/lib/proxy/api.ts
@@ -43,7 +43,7 @@ export interface UserProvidedProxyConfiguration extends BaseProxyConfiguration {
 }
 
 export type ConnectionForProxy = Pick<DBConnectionDecrypted, 'connection_id' | 'connection_config' | 'credentials' | 'metadata'>;
-export type IntegrationConfigForProxy = Pick<DBIntegrationDecrypted, 'oauth_client_id' | 'oauth_client_secret'>;
+export type IntegrationConfigForProxy = Pick<DBIntegrationDecrypted, 'oauth_client_id' | 'oauth_client_secret' | 'custom'>;
 
 export interface ApplicationConstructedProxyConfiguration extends BaseProxyConfiguration {
     decompress: boolean;

--- a/packages/webapp/public/images/template-logos/private-api-generic.svg
+++ b/packages/webapp/public/images/template-logos/private-api-generic.svg
@@ -1,0 +1,1 @@
+private-api-bearer.svg

--- a/packages/webapp/src/pages/Integrations/components/forms/AuthCreateForm.tsx
+++ b/packages/webapp/src/pages/Integrations/components/forms/AuthCreateForm.tsx
@@ -1,5 +1,6 @@
 import { AppAuthCreateForm } from './AppAuthCreateForm';
 import { CustomAuthCreateForm } from './CustomAuthCreateForm';
+import { CustomIntegrationCreateForm } from './CustomIntegrationCreateForm';
 import { DefaultCreateForm } from './DefaultCreateForm';
 import { InstallPluginAuthCreateForm } from './InstallPluginAuthCreateForm';
 import { McpGenericCreateForm } from './McpGenericCreateForm';
@@ -15,6 +16,10 @@ interface Props {
 
 export const AuthCreateForm: React.FC<Props> = ({ provider, onSubmit }) => {
     const authMode = provider.authMode;
+
+    if (provider.integration_config && Object.keys(provider.integration_config).length > 0) {
+        return <CustomIntegrationCreateForm provider={provider} onSubmit={onSubmit} />;
+    }
 
     switch (authMode) {
         case 'OAUTH1':

--- a/packages/webapp/src/pages/Integrations/components/forms/CustomIntegrationCreateForm.tsx
+++ b/packages/webapp/src/pages/Integrations/components/forms/CustomIntegrationCreateForm.tsx
@@ -1,9 +1,11 @@
 import { zodResolver } from '@hookform/resolvers/zod';
+import { AlertTriangle } from 'lucide-react';
 import { useMemo, useState } from 'react';
 import { useForm } from 'react-hook-form';
 import { z } from 'zod';
 
 import { SecretInput } from '@/components-v2/patterns/SecretInput';
+import { Alert, AlertDescription } from '@/components-v2/ui/Alert';
 import { Button } from '@/components-v2/ui/Button';
 import { Form, FormControl, FormDescription, FormField, FormItem, FormLabel, FormMessage } from '@/components-v2/ui/Form';
 import { InputGroup, InputGroupInput } from '@/components-v2/ui/InputGroup';
@@ -85,37 +87,46 @@ export const CustomIntegrationCreateForm: React.FC<{
                                 key={name}
                                 control={form.control}
                                 name={name}
-                                render={({ field, fieldState }) => (
-                                    <FormItem>
-                                        <FormLabel>{definition.title}</FormLabel>
-                                        {definition.description && <FormDescription>{definition.description}</FormDescription>}
-                                        <FormControl>
-                                            {definition.enum && definition.enum.length > 0 ? (
-                                                <Select value={field.value as string} onValueChange={field.onChange}>
-                                                    <SelectTrigger className="w-full" aria-invalid={!!fieldState.error}>
-                                                        <SelectValue placeholder={definition.title} />
-                                                    </SelectTrigger>
-                                                    <SelectContent>
-                                                        {definition.enum.map((option) => (
-                                                            <SelectItem key={option} value={option}>
-                                                                {option}
-                                                            </SelectItem>
-                                                        ))}
-                                                    </SelectContent>
-                                                </Select>
-                                            ) : definition.secret ? (
-                                                <InputGroup>
-                                                    <SecretInput {...field} aria-invalid={!!fieldState.error} />
-                                                </InputGroup>
-                                            ) : (
-                                                <InputGroup>
-                                                    <InputGroupInput {...field} placeholder={definition.example} aria-invalid={!!fieldState.error} />
-                                                </InputGroup>
+                                render={({ field, fieldState }) => {
+                                    const warning = definition.warnings?.[field.value as string];
+                                    return (
+                                        <FormItem>
+                                            <FormLabel>{definition.title}</FormLabel>
+                                            {definition.description && <FormDescription>{definition.description}</FormDescription>}
+                                            <FormControl>
+                                                {definition.enum && definition.enum.length > 0 ? (
+                                                    <Select value={field.value as string} onValueChange={field.onChange}>
+                                                        <SelectTrigger className="w-full" aria-invalid={!!fieldState.error}>
+                                                            <SelectValue placeholder={definition.title} />
+                                                        </SelectTrigger>
+                                                        <SelectContent>
+                                                            {definition.enum.map((option) => (
+                                                                <SelectItem key={option} value={option}>
+                                                                    {option}
+                                                                </SelectItem>
+                                                            ))}
+                                                        </SelectContent>
+                                                    </Select>
+                                                ) : definition.secret ? (
+                                                    <InputGroup>
+                                                        <SecretInput {...field} aria-invalid={!!fieldState.error} />
+                                                    </InputGroup>
+                                                ) : (
+                                                    <InputGroup>
+                                                        <InputGroupInput {...field} placeholder={definition.example} aria-invalid={!!fieldState.error} />
+                                                    </InputGroup>
+                                                )}
+                                            </FormControl>
+                                            {warning && (
+                                                <Alert variant="warning">
+                                                    <AlertTriangle />
+                                                    <AlertDescription>{warning}</AlertDescription>
+                                                </Alert>
                                             )}
-                                        </FormControl>
-                                        <FormMessage />
-                                    </FormItem>
-                                )}
+                                            <FormMessage />
+                                        </FormItem>
+                                    );
+                                }}
                             />
                         ))}
                     </div>

--- a/packages/webapp/src/pages/Integrations/components/forms/CustomIntegrationCreateForm.tsx
+++ b/packages/webapp/src/pages/Integrations/components/forms/CustomIntegrationCreateForm.tsx
@@ -1,0 +1,130 @@
+import { zodResolver } from '@hookform/resolvers/zod';
+import { useMemo, useState } from 'react';
+import { useForm } from 'react-hook-form';
+import { z } from 'zod';
+
+import { SecretInput } from '@/components-v2/patterns/SecretInput';
+import { Button } from '@/components-v2/ui/Button';
+import { Form, FormControl, FormDescription, FormField, FormItem, FormLabel, FormMessage } from '@/components-v2/ui/Form';
+import { InputGroup, InputGroupInput } from '@/components-v2/ui/InputGroup';
+import { Select, SelectContent, SelectItem, SelectTrigger, SelectValue } from '@/components-v2/ui/Select';
+
+import type { ApiProviderListItem, PostIntegration, SimplifiedJSONSchema } from '@nangohq/types';
+
+type FieldEntry = [string, SimplifiedJSONSchema];
+
+function fieldToZod(definition: SimplifiedJSONSchema): z.ZodTypeAny {
+    if (definition.enum && definition.enum.length > 0) {
+        const base = z.enum(definition.enum as [string, ...string[]]);
+        return definition.optional ? z.union([base, z.literal('')]) : base;
+    }
+
+    let field = z.string();
+    if (definition.format === 'uri') {
+        field = field.url('Must be a valid URL');
+    }
+    if (definition.pattern) {
+        field = field.regex(new RegExp(definition.pattern), { message: `Invalid ${definition.title}` });
+    }
+
+    if (definition.optional) {
+        return z.union([field, z.literal('')]);
+    }
+    return field.min(1, 'This field is required');
+}
+
+/**
+ * Renders the custom integration configuration form from a provider's `integration_config`
+ * (e.g. the `private-api-generic` API-key provider). Submitted values are persisted to the
+ * integration's `custom` field server-side.
+ */
+export const CustomIntegrationCreateForm: React.FC<{
+    provider: ApiProviderListItem;
+    onSubmit?: (data: PostIntegration['Body']) => Promise<void>;
+}> = ({ provider, onSubmit }) => {
+    const fields = useMemo<FieldEntry[]>(
+        () => Object.entries(provider.integration_config ?? {}).sort((a, b) => (a[1].order ?? 0) - (b[1].order ?? 0)),
+        [provider.integration_config]
+    );
+
+    const schema = useMemo(() => z.object(Object.fromEntries(fields.map(([name, def]) => [name, fieldToZod(def)]))), [fields]);
+
+    const defaultValues = useMemo(
+        () =>
+            Object.fromEntries(fields.map(([name, def]) => [name, def.default_value ?? (def.enum && !def.optional ? (def.enum[0] ?? '') : '')])) as Record<
+                string,
+                string
+            >,
+        [fields]
+    );
+
+    const form = useForm({ resolver: zodResolver(schema), defaultValues });
+
+    const [loading, setLoading] = useState(false);
+
+    const onSubmitForm = async (formData: Record<string, string>) => {
+        setLoading(true);
+        try {
+            await onSubmit?.({
+                provider: provider.name,
+                useSharedCredentials: false,
+                integrationConfig: formData
+            });
+        } finally {
+            setLoading(false);
+        }
+    };
+
+    return (
+        <div className="flex flex-col gap-8">
+            <Form {...form}>
+                <form onSubmit={form.handleSubmit(onSubmitForm)} className="flex flex-col gap-8">
+                    <div className="flex flex-col gap-5">
+                        {fields.map(([name, definition]) => (
+                            <FormField
+                                key={name}
+                                control={form.control}
+                                name={name}
+                                render={({ field, fieldState }) => (
+                                    <FormItem>
+                                        <FormLabel>{definition.title}</FormLabel>
+                                        {definition.description && <FormDescription>{definition.description}</FormDescription>}
+                                        <FormControl>
+                                            {definition.enum && definition.enum.length > 0 ? (
+                                                <Select value={field.value as string} onValueChange={field.onChange}>
+                                                    <SelectTrigger className="w-full" aria-invalid={!!fieldState.error}>
+                                                        <SelectValue placeholder={definition.title} />
+                                                    </SelectTrigger>
+                                                    <SelectContent>
+                                                        {definition.enum.map((option) => (
+                                                            <SelectItem key={option} value={option}>
+                                                                {option}
+                                                            </SelectItem>
+                                                        ))}
+                                                    </SelectContent>
+                                                </Select>
+                                            ) : definition.secret ? (
+                                                <InputGroup>
+                                                    <SecretInput {...field} aria-invalid={!!fieldState.error} />
+                                                </InputGroup>
+                                            ) : (
+                                                <InputGroup>
+                                                    <InputGroupInput {...field} placeholder={definition.example} aria-invalid={!!fieldState.error} />
+                                                </InputGroup>
+                                            )}
+                                        </FormControl>
+                                        <FormMessage />
+                                    </FormItem>
+                                )}
+                            />
+                        ))}
+                    </div>
+
+                    <Button type="submit" loading={loading}>
+                        Create
+                    </Button>
+                </form>
+            </Form>
+        </div>
+    );
+};

--- a/packages/webapp/src/pages/Integrations/providerConfigKey/Settings/components/AuthSpecificSettings.tsx
+++ b/packages/webapp/src/pages/Integrations/providerConfigKey/Settings/components/AuthSpecificSettings.tsx
@@ -1,5 +1,6 @@
 import { AppAuthSettings } from './AppAuthSettings';
 import { CustomAuthSettings } from './CustomAuthSettings';
+import { CustomIntegrationSettings } from './CustomIntegrationSettings';
 import { InstallPluginSettings } from './InstallPluginSettings';
 import { McpGenericSettings } from './McpGenericSettings';
 import { McpOAuthSettings } from './McpOAuthSettings';
@@ -10,6 +11,10 @@ import type { ApiEnvironment, GetIntegration } from '@nangohq/types';
 
 export const AuthSpecificSettings: React.FC<{ data: GetIntegration['Success']['data']; environment: ApiEnvironment }> = ({ data, environment }) => {
     const authMode = data.template.auth_mode;
+
+    if (data.template.integration_config && Object.keys(data.template.integration_config).length > 0) {
+        return <CustomIntegrationSettings data={data} environment={environment} />;
+    }
 
     switch (authMode) {
         case 'OAUTH1':

--- a/packages/webapp/src/pages/Integrations/providerConfigKey/Settings/components/CustomIntegrationSettings.tsx
+++ b/packages/webapp/src/pages/Integrations/providerConfigKey/Settings/components/CustomIntegrationSettings.tsx
@@ -1,10 +1,13 @@
 import { useMemo, useState } from 'react';
 
+import { permissions } from '@nangohq/authz';
+
 import { EditableInput } from '@/components-v2/patterns/EditableInput';
 import { InfoTooltip } from '@/components-v2/ui/InfoTooltip';
 import { Label } from '@/components-v2/ui/Label';
 import { Select, SelectContent, SelectItem, SelectTrigger, SelectValue } from '@/components-v2/ui/Select';
 import { usePatchIntegration } from '@/hooks/useIntegration';
+import { usePermissions } from '@/hooks/usePermissions';
 import { useToast } from '@/hooks/useToast';
 import { useStore } from '@/store';
 
@@ -43,11 +46,15 @@ function buildValidator(definition: SimplifiedJSONSchema): (value: string) => st
  * independently (text fields via the inline edit/save pattern, enum fields on selection change).
  */
 export const CustomIntegrationSettings: React.FC<{ data: GetIntegration['Success']['data']; environment: ApiEnvironment }> = ({
-    data: { integration, template }
+    data: { integration, template },
+    environment
 }) => {
     const env = useStore((state) => state.env);
     const { toast } = useToast();
+    const { can } = usePermissions();
     const { mutateAsync: patchIntegration } = usePatchIntegration(env, integration.unique_key);
+
+    const canEdit = !environment.is_production || can(permissions.canWriteProdIntegrations);
 
     const fields = useMemo<FieldEntry[]>(
         () => Object.entries(template.integration_config ?? {}).sort((a, b) => (a[1].order ?? 0) - (b[1].order ?? 0)),
@@ -74,7 +81,7 @@ export const CustomIntegrationSettings: React.FC<{ data: GetIntegration['Success
                         {definition.description && <InfoTooltip>{definition.description}</InfoTooltip>}
                     </div>
                     {definition.enum && definition.enum.length > 0 ? (
-                        <EnumField name={name} definition={definition} initialValue={integration.custom?.[name]} onSave={saveField} />
+                        <EnumField name={name} definition={definition} initialValue={integration.custom?.[name]} onSave={saveField} canEdit={canEdit} />
                     ) : (
                         <EditableInput
                             id={name}
@@ -83,6 +90,8 @@ export const CustomIntegrationSettings: React.FC<{ data: GetIntegration['Success
                             placeholder={definition.example}
                             validate={buildValidator(definition)}
                             onSave={(value) => saveField(name, value)}
+                            canEdit={canEdit}
+                            canRead={canEdit}
                         />
                     )}
                 </div>
@@ -96,21 +105,27 @@ const EnumField: React.FC<{
     definition: SimplifiedJSONSchema;
     initialValue: string | undefined;
     onSave: (name: string, value: string) => Promise<void>;
-}> = ({ name, definition, initialValue, onSave }) => {
+    canEdit: boolean;
+}> = ({ name, definition, initialValue, onSave, canEdit }) => {
     const [value, setValue] = useState(initialValue ?? definition.default_value ?? definition.enum?.[0] ?? '');
+    const [saving, setSaving] = useState(false);
 
     const onChange = async (next: string) => {
         const previous = value;
         setValue(next);
+        setSaving(true);
         try {
             await onSave(name, next);
         } catch {
             setValue(previous);
+        } finally {
+            setSaving(false);
         }
     };
 
     return (
-        <Select value={value} onValueChange={onChange}>
+        // Disable while a save is in flight so a rapid second change can't be clobbered by a failed revert.
+        <Select value={value} onValueChange={onChange} disabled={!canEdit || saving}>
             <SelectTrigger id={name} className="w-full">
                 <SelectValue placeholder={definition.title} />
             </SelectTrigger>

--- a/packages/webapp/src/pages/Integrations/providerConfigKey/Settings/components/CustomIntegrationSettings.tsx
+++ b/packages/webapp/src/pages/Integrations/providerConfigKey/Settings/components/CustomIntegrationSettings.tsx
@@ -1,8 +1,10 @@
+import { AlertTriangle } from 'lucide-react';
 import { useMemo, useState } from 'react';
 
 import { permissions } from '@nangohq/authz';
 
 import { EditableInput } from '@/components-v2/patterns/EditableInput';
+import { Alert, AlertDescription } from '@/components-v2/ui/Alert';
 import { InfoTooltip } from '@/components-v2/ui/InfoTooltip';
 import { Label } from '@/components-v2/ui/Label';
 import { Select, SelectContent, SelectItem, SelectTrigger, SelectValue } from '@/components-v2/ui/Select';
@@ -123,19 +125,29 @@ const EnumField: React.FC<{
         }
     };
 
+    const warning = definition.warnings?.[value];
+
     return (
-        // Disable while a save is in flight so a rapid second change can't be clobbered by a failed revert.
-        <Select value={value} onValueChange={onChange} disabled={!canEdit || saving}>
-            <SelectTrigger id={name} className="w-full">
-                <SelectValue placeholder={definition.title} />
-            </SelectTrigger>
-            <SelectContent>
-                {definition.enum?.map((option) => (
-                    <SelectItem key={option} value={option}>
-                        {option}
-                    </SelectItem>
-                ))}
-            </SelectContent>
-        </Select>
+        <div className="flex flex-col gap-2">
+            {/* Disable while a save is in flight so a rapid second change can't be clobbered by a failed revert. */}
+            <Select value={value} onValueChange={onChange} disabled={!canEdit || saving}>
+                <SelectTrigger id={name} className="w-full">
+                    <SelectValue placeholder={definition.title} />
+                </SelectTrigger>
+                <SelectContent>
+                    {definition.enum?.map((option) => (
+                        <SelectItem key={option} value={option}>
+                            {option}
+                        </SelectItem>
+                    ))}
+                </SelectContent>
+            </Select>
+            {warning && (
+                <Alert variant="warning">
+                    <AlertTriangle />
+                    <AlertDescription>{warning}</AlertDescription>
+                </Alert>
+            )}
+        </div>
     );
 };

--- a/packages/webapp/src/pages/Integrations/providerConfigKey/Settings/components/CustomIntegrationSettings.tsx
+++ b/packages/webapp/src/pages/Integrations/providerConfigKey/Settings/components/CustomIntegrationSettings.tsx
@@ -1,0 +1,126 @@
+import { useMemo, useState } from 'react';
+
+import { EditableInput } from '@/components-v2/patterns/EditableInput';
+import { InfoTooltip } from '@/components-v2/ui/InfoTooltip';
+import { Label } from '@/components-v2/ui/Label';
+import { Select, SelectContent, SelectItem, SelectTrigger, SelectValue } from '@/components-v2/ui/Select';
+import { usePatchIntegration } from '@/hooks/useIntegration';
+import { useToast } from '@/hooks/useToast';
+import { useStore } from '@/store';
+
+import type { ApiEnvironment, GetIntegration, SimplifiedJSONSchema } from '@nangohq/types';
+
+type FieldEntry = [string, SimplifiedJSONSchema];
+
+function buildValidator(definition: SimplifiedJSONSchema): (value: string) => string | null {
+    return (value: string) => {
+        if (!value) {
+            return definition.optional ? null : 'Must not be empty';
+        }
+        if (definition.format === 'uri') {
+            try {
+                new URL(value);
+            } catch {
+                return 'Must be a valid URL';
+            }
+        }
+        if (definition.pattern) {
+            try {
+                if (!new RegExp(definition.pattern).test(value)) {
+                    return `Invalid ${definition.title}`;
+                }
+            } catch {
+                // Ignore an invalid pattern in the provider schema.
+            }
+        }
+        return null;
+    };
+}
+
+/**
+ * Editable custom integration configuration (e.g. private-api-generic), rendered from the provider's
+ * `integration_config` and pre-filled from the integration's stored `custom` values. Each field saves
+ * independently (text fields via the inline edit/save pattern, enum fields on selection change).
+ */
+export const CustomIntegrationSettings: React.FC<{ data: GetIntegration['Success']['data']; environment: ApiEnvironment }> = ({
+    data: { integration, template }
+}) => {
+    const env = useStore((state) => state.env);
+    const { toast } = useToast();
+    const { mutateAsync: patchIntegration } = usePatchIntegration(env, integration.unique_key);
+
+    const fields = useMemo<FieldEntry[]>(
+        () => Object.entries(template.integration_config ?? {}).sort((a, b) => (a[1].order ?? 0) - (b[1].order ?? 0)),
+        [template.integration_config]
+    );
+
+    const saveField = async (name: string, value: string) => {
+        try {
+            await patchIntegration({ integrationConfig: { [name]: value } });
+            toast({ title: 'Successfully updated', variant: 'success' });
+        } catch {
+            toast({ title: 'Failed to update, an error occurred', variant: 'error' });
+            // Rethrow so EditableInput stays in edit mode on failure.
+            throw new Error('Failed to update');
+        }
+    };
+
+    return (
+        <div className="flex flex-col gap-10">
+            {fields.map(([name, definition]) => (
+                <div key={name} className="flex flex-col gap-2">
+                    <div className="flex gap-2 items-center">
+                        <Label htmlFor={name}>{definition.title}</Label>
+                        {definition.description && <InfoTooltip>{definition.description}</InfoTooltip>}
+                    </div>
+                    {definition.enum && definition.enum.length > 0 ? (
+                        <EnumField name={name} definition={definition} initialValue={integration.custom?.[name]} onSave={saveField} />
+                    ) : (
+                        <EditableInput
+                            id={name}
+                            initialValue={integration.custom?.[name] ?? definition.default_value ?? ''}
+                            secret={Boolean(definition.secret)}
+                            placeholder={definition.example}
+                            validate={buildValidator(definition)}
+                            onSave={(value) => saveField(name, value)}
+                        />
+                    )}
+                </div>
+            ))}
+        </div>
+    );
+};
+
+const EnumField: React.FC<{
+    name: string;
+    definition: SimplifiedJSONSchema;
+    initialValue: string | undefined;
+    onSave: (name: string, value: string) => Promise<void>;
+}> = ({ name, definition, initialValue, onSave }) => {
+    const [value, setValue] = useState(initialValue ?? definition.default_value ?? definition.enum?.[0] ?? '');
+
+    const onChange = async (next: string) => {
+        const previous = value;
+        setValue(next);
+        try {
+            await onSave(name, next);
+        } catch {
+            setValue(previous);
+        }
+    };
+
+    return (
+        <Select value={value} onValueChange={onChange}>
+            <SelectTrigger id={name} className="w-full">
+                <SelectValue placeholder={definition.title} />
+            </SelectTrigger>
+            <SelectContent>
+                {definition.enum?.map((option) => (
+                    <SelectItem key={option} value={option}>
+                        {option}
+                    </SelectItem>
+                ))}
+            </SelectContent>
+        </Select>
+    );
+};

--- a/scripts/validation/providers/schema.json
+++ b/scripts/validation/providers/schema.json
@@ -1,5 +1,69 @@
 {
     "$schema": "http://json-schema.org/draft-07/schema#",
+    "definitions": {
+        "providerFieldSchema": {
+            "type": "object",
+            "additionalProperties": false,
+            "required": ["type", "title", "description"],
+            "properties": {
+                "type": {
+                    "type": "string",
+                    "enum": ["string"]
+                },
+                "title": {
+                    "type": "string"
+                },
+                "description": {
+                    "type": "string"
+                },
+                "example": {
+                    "type": "string"
+                },
+                "pattern": {
+                    "type": "string"
+                },
+                "format": {
+                    "type": "string",
+                    "enum": ["hostname", "uri", "uuid", "email"]
+                },
+                "enum": {
+                    "type": "array",
+                    "items": {
+                        "type": "string"
+                    },
+                    "minItems": 1
+                },
+                "order": {
+                    "type": "number"
+                },
+                "secret": {
+                    "type": "boolean"
+                },
+                "prefix": {
+                    "type": "string"
+                },
+                "suffix": {
+                    "type": "string"
+                },
+                "optional": {
+                    "type": "boolean"
+                },
+                "doc_section": {
+                    "type": "string",
+                    "pattern": "^#[a-z0-9-]+$"
+                },
+                "automated": {
+                    "type": "boolean"
+                },
+                "default_value": {
+                    "type": "string"
+                },
+                "hidden": {
+                    "type": "boolean"
+                }
+            }
+        }
+    },
     "type": "object",
     "additionalProperties": false,
     "patternProperties": {
@@ -629,66 +693,7 @@
                     "additionalProperties": false,
                     "patternProperties": {
                         "^[a-zA-Z_.-]+$": {
-                            "type": "object",
-                            "additionalProperties": false,
-                            "required": ["type", "title", "description"],
-                            "properties": {
-                                "type": {
-                                    "type": "string",
-                                    "enum": ["string"]
-                                },
-                                "title": {
-                                    "type": "string"
-                                },
-                                "description": {
-                                    "type": "string"
-                                },
-                                "example": {
-                                    "type": "string"
-                                },
-                                "pattern": {
-                                    "type": "string"
-                                },
-                                "format": {
-                                    "type": "string",
-                                    "enum": ["hostname", "uri", "uuid", "email"]
-                                },
-                                "enum": {
-                                    "type": "array",
-                                    "items": {
-                                        "type": "string"
-                                    },
-                                    "minItems": 1
-                                },
-                                "order": {
-                                    "type": "number"
-                                },
-                                "secret": {
-                                    "type": "boolean"
-                                },
-                                "prefix": {
-                                    "type": "string"
-                                },
-                                "suffix": {
-                                    "type": "string"
-                                },
-                                "optional": {
-                                    "type": "boolean"
-                                },
-                                "doc_section": {
-                                    "type": "string",
-                                    "pattern": "^#[a-z0-9-]+$"
-                                },
-                                "automated": {
-                                    "type": "boolean"
-                                },
-                                "default_value": {
-                                    "type": "string"
-                                },
-                                "hidden": {
-                                    "type": "boolean"
-                                }
-                            }
+                            "$ref": "#/definitions/providerFieldSchema"
                         }
                     }
                 },
@@ -697,66 +702,7 @@
                     "additionalProperties": false,
                     "patternProperties": {
                         "^[a-zA-Z_.-]+$": {
-                            "type": "object",
-                            "additionalProperties": false,
-                            "required": ["type", "title", "description"],
-                            "properties": {
-                                "type": {
-                                    "type": "string",
-                                    "enum": ["string"]
-                                },
-                                "title": {
-                                    "type": "string"
-                                },
-                                "description": {
-                                    "type": "string"
-                                },
-                                "example": {
-                                    "type": "string"
-                                },
-                                "pattern": {
-                                    "type": "string"
-                                },
-                                "format": {
-                                    "type": "string",
-                                    "enum": ["hostname", "uri", "uuid", "email"]
-                                },
-                                "enum": {
-                                    "type": "array",
-                                    "items": {
-                                        "type": "string"
-                                    },
-                                    "minItems": 1
-                                },
-                                "order": {
-                                    "type": "number"
-                                },
-                                "secret": {
-                                    "type": "boolean"
-                                },
-                                "prefix": {
-                                    "type": "string"
-                                },
-                                "suffix": {
-                                    "type": "string"
-                                },
-                                "optional": {
-                                    "type": "boolean"
-                                },
-                                "doc_section": {
-                                    "type": "string",
-                                    "pattern": "^#[a-z0-9-]+$"
-                                },
-                                "automated": {
-                                    "type": "boolean"
-                                },
-                                "default_value": {
-                                    "type": "string"
-                                },
-                                "hidden": {
-                                    "type": "boolean"
-                                }
-                            }
+                            "$ref": "#/definitions/providerFieldSchema"
                         }
                     }
                 },

--- a/scripts/validation/providers/schema.json
+++ b/scripts/validation/providers/schema.json
@@ -60,6 +60,12 @@
                 },
                 "hidden": {
                     "type": "boolean"
+                },
+                "warnings": {
+                    "type": "object",
+                    "additionalProperties": {
+                        "type": "string"
+                    }
                 }
             }
         }

--- a/scripts/validation/providers/schema.json
+++ b/scripts/validation/providers/schema.json
@@ -692,6 +692,74 @@
                         }
                     }
                 },
+                "integration_config": {
+                    "type": "object",
+                    "additionalProperties": false,
+                    "patternProperties": {
+                        "^[a-zA-Z_.-]+$": {
+                            "type": "object",
+                            "additionalProperties": false,
+                            "required": ["type", "title", "description"],
+                            "properties": {
+                                "type": {
+                                    "type": "string",
+                                    "enum": ["string"]
+                                },
+                                "title": {
+                                    "type": "string"
+                                },
+                                "description": {
+                                    "type": "string"
+                                },
+                                "example": {
+                                    "type": "string"
+                                },
+                                "pattern": {
+                                    "type": "string"
+                                },
+                                "format": {
+                                    "type": "string",
+                                    "enum": ["hostname", "uri", "uuid", "email"]
+                                },
+                                "enum": {
+                                    "type": "array",
+                                    "items": {
+                                        "type": "string"
+                                    },
+                                    "minItems": 1
+                                },
+                                "order": {
+                                    "type": "number"
+                                },
+                                "secret": {
+                                    "type": "boolean"
+                                },
+                                "prefix": {
+                                    "type": "string"
+                                },
+                                "suffix": {
+                                    "type": "string"
+                                },
+                                "optional": {
+                                    "type": "boolean"
+                                },
+                                "doc_section": {
+                                    "type": "string",
+                                    "pattern": "^#[a-z0-9-]+$"
+                                },
+                                "automated": {
+                                    "type": "boolean"
+                                },
+                                "default_value": {
+                                    "type": "string"
+                                },
+                                "hidden": {
+                                    "type": "boolean"
+                                }
+                            }
+                        }
+                    }
+                },
                 "credentials": {
                     "type": "object",
                     "additionalProperties": false,

--- a/scripts/validation/providers/validate.ts
+++ b/scripts/validation/providers/validate.ts
@@ -55,7 +55,8 @@ for (const [providerKey, provider] of Object.entries(providersJson)) {
     if (providerKey === 'sage-intacct' || providerKey === 'supabase-mcp') {
         continue;
     }
-    const { credentials, connection_config, ...providerWithoutSensitive } = provider;
+
+    const { credentials, connection_config, integration_config, ...providerWithoutSensitive } = provider;
     const strippedProviderYaml = dump({ [providerKey]: providerWithoutSensitive });
     const match = [...strippedProviderYaml.matchAll(invalidInterpolation)];
     if (match.length > 0) {


### PR DESCRIPTION
- Introduced a new integration type, Private API (Generic), allowing users to authenticate using an API key with customizable configurations.
- Proxy request handling to support dynamic API key injection based on user-defined configurations.
- As it stands, this provider only supports proxy calls. SDK calls to come in a future PR

