### PR TITLE
feat(proxy): apply private-api-generic key injection in SDK/sync/action proxy

### DIFF
--- a/docs/integrations/all/private-api-generic.mdx
+++ b/docs/integrations/all/private-api-generic.mdx
@@ -26,7 +26,6 @@ The key is vaulted by Nango and injected by the proxy, so raw credentials never 
 ## Important limitations
 
 - **Limited functionality**: Private API (Generic) is limited to storing and injecting a single API key. Because it's generic, many advanced Nango features are not available for it.
-- **HTTP proxy only**: The configured key injection (placement, name, value template, base URL) is applied only by the Nango HTTP proxy (`https://api.nango.dev/proxy/...`). Calls made with `nango.proxy()` from sync/action scripts or the backend SDK do **not** apply this injection yet, so the request would be sent without the key. Use the HTTP proxy for Private API (Generic) connections.
 - **Base URL required**: You must set the base URL on the integration; there is no predefined base URL like other integrations.
 - **Recommended use cases only**: The only recommended use case for private API integrations is to store credentials for internal/customer-specific APIs that cannot be added to the Nango catalog.
 - **For all other use cases**: We recommend [contributing the API to Nango](/integrations/contribute-or-request-api) or requesting it be added by us.

--- a/packages/jobs/lib/execution/action.ts
+++ b/packages/jobs/lib/execution/action.ts
@@ -156,7 +156,8 @@ export async function startAction(task: TaskAction): Promise<Result<void>> {
             heartbeatTimeoutSecs: task.heartbeatTimeoutSecs,
             integrationConfig: {
                 oauth_client_id: providerConfig.oauth_client_id,
-                oauth_client_secret: providerConfig.oauth_client_secret
+                oauth_client_secret: providerConfig.oauth_client_secret,
+                custom: providerConfig.custom
             }
         };
 

--- a/packages/jobs/lib/execution/sync.ts
+++ b/packages/jobs/lib/execution/sync.ts
@@ -205,7 +205,8 @@ export async function startSync(task: TaskSync, startScriptFn = startScript): Pr
             heartbeatTimeoutSecs: task.heartbeatTimeoutSecs,
             integrationConfig: {
                 oauth_client_id: providerConfig.oauth_client_id,
-                oauth_client_secret: providerConfig.oauth_client_secret
+                oauth_client_secret: providerConfig.oauth_client_secret,
+                custom: providerConfig.custom
             },
             ...(plan?.sync_function_runtime === 'lambda'
                 ? {

--- a/packages/lambda-runner/lib/schemas.ts
+++ b/packages/lambda-runner/lib/schemas.ts
@@ -89,7 +89,8 @@ export const nangoPropsSchema = z.object({
     integrationConfig: z
         .object({
             oauth_client_id: z.string().nullable(),
-            oauth_client_secret: z.string().nullable()
+            oauth_client_secret: z.string().nullable(),
+            custom: z.record(z.string(), z.string()).nullish()
         })
         .optional()
 });


### PR DESCRIPTION
The per-integration key injection for private-api-generic lives in the integration's `custom` field. Only the public HTTP proxy forwarded it, so nango.proxy() from sync/action/on-event/webhook scripts (and the backend SDK) sent requests without the key.

Removes the now-obsolete "HTTP proxy only" docs limitation.

NAN-5859

<!-- Describe the problem and your solution --> 

<!-- Issue ticket number and link (if applicable) -->

<!-- Testing instructions (skip if just adding/editing providers) -->

