### PR TITLE
feat(usage): resolve environment_id to env name on top-dimension-values

### DIFF
--- a/packages/server/lib/controllers/v1/plans/usage/getBillingUsageTopDimensionValues.integration.test.ts
+++ b/packages/server/lib/controllers/v1/plans/usage/getBillingUsageTopDimensionValues.integration.test.ts
@@ -20,9 +20,9 @@ const day1 = new Date('2026-05-02T00:00:00.000Z');
 const end = new Date('2026-05-03T00:00:00.000Z');
 
 // records on three integrations: a >> b >> c, so the top-dimension-values ordering is deterministic.
-function seedFixture(accountId: number): ClickhouseRawUsageEvent[] {
+function seedFixture(accountId: number, environmentId: number): ClickhouseRawUsageEvent[] {
     const batch = randomUUID();
-    const attrs = (integrationId: string) => ({ environmentId: 1, integrationId, batchId: batch });
+    const attrs = (integrationId: string) => ({ environmentId, integrationId, batchId: batch });
     return [
         { ts: day0.getTime(), type: 'usage.records', idempotency_key: randomUUID(), account_id: accountId, value: 1000, attributes: attrs('a') },
         { ts: day1.getTime(), type: 'usage.records', idempotency_key: randomUUID(), account_id: accountId, value: 2000, attributes: attrs('a') },
@@ -31,12 +31,12 @@ function seedFixture(accountId: number): ClickhouseRawUsageEvent[] {
     ];
 }
 
-async function seedAccount(): Promise<{ apiKey: { secret: string }; accountId: number }> {
-    const { plan, apiKey, account } = await seeders.seedAccountEnvAndUser();
+async function seedAccount(): Promise<{ apiKey: { secret: string }; accountId: number; envId: number; envName: string }> {
+    const { plan, apiKey, account, env } = await seeders.seedAccountEnvAndUser();
     await updatePlan(db.knex, { id: plan.id, orb_customer_id: 'orb_cust_123', orb_subscription_id: 'orb_sub_123' });
-    clickhouse.addRaw(seedFixture(account.id));
+    clickhouse.addRaw(seedFixture(account.id, env.id));
     await clickhouse.flush();
-    return { apiKey, accountId: account.id };
+    return { apiKey, accountId: account.id, envId: env.id, envName: env.name };
 }
 
 describe(`GET ${route}`, () => {
@@ -129,7 +129,7 @@ describe(`GET ${route}`, () => {
     });
 
     describe('Happy path', () => {
-        it('returns top values ordered by SUM(value) DESC', async () => {
+        it('returns top values ordered by SUM(value) DESC; label === id for slug dims', async () => {
             const { apiKey } = await seedAccount();
             const res = await api.fetch(route, {
                 token: apiKey.secret,
@@ -142,7 +142,11 @@ describe(`GET ${route}`, () => {
                 }
             });
             isSuccess(res.json);
-            expect(res.json.data.values).toEqual(['a', 'b', 'c']);
+            expect(res.json.data.values).toEqual([
+                { id: 'a', label: 'a' },
+                { id: 'b', label: 'b' },
+                { id: 'c', label: 'c' }
+            ]);
         });
 
         it('honours limit', async () => {
@@ -159,7 +163,26 @@ describe(`GET ${route}`, () => {
                 }
             });
             isSuccess(res.json);
-            expect(res.json.data.values).toEqual(['a', 'b']);
+            expect(res.json.data.values).toEqual([
+                { id: 'a', label: 'a' },
+                { id: 'b', label: 'b' }
+            ]);
+        });
+
+        it('resolves environment_id to the env name (label) while keeping the raw id', async () => {
+            const { apiKey, envId, envName } = await seedAccount();
+            const res = await api.fetch(route, {
+                token: apiKey.secret,
+                query: {
+                    env: 'dev',
+                    metric: 'records',
+                    dimension: 'environment_id',
+                    from: day0.toISOString(),
+                    to: end.toISOString()
+                }
+            });
+            isSuccess(res.json);
+            expect(res.json.data.values).toEqual([{ id: String(envId), label: envName }]);
         });
     });
 });

--- a/packages/server/lib/controllers/v1/plans/usage/getBillingUsageTopDimensionValues.ts
+++ b/packages/server/lib/controllers/v1/plans/usage/getBillingUsageTopDimensionValues.ts
@@ -1,5 +1,6 @@
 import z from 'zod';
 
+import { environmentService } from '@nangohq/shared';
 import { BREAKDOWN_DIMENSIONS, TOP_N_BREAKDOWN_CAP, TOP_N_BREAKDOWN_DEFAULT } from '@nangohq/usage';
 import { zodErrorToHTTP } from '@nangohq/utils';
 
@@ -62,5 +63,14 @@ export const getBillingUsageTopDimensionValues = asyncWrapper<GetBillingUsageTop
         return;
     }
 
-    res.status(200).send({ data: { values: result.value.values } });
+    let values: { id: string; label: string }[];
+    if (query.dimension === 'environment_id') {
+        const envs = await environmentService.getEnvironmentsByIds(result.value.values.map(Number));
+        const names = new Map(envs.map((e) => [e.id, e.name]));
+        values = result.value.values.map((id) => ({ id, label: names.get(Number(id)) ?? id }));
+    } else {
+        values = result.value.values.map((id) => ({ id, label: id }));
+    }
+
+    res.status(200).send({ data: { values } });
 });

--- a/packages/server/lib/controllers/v1/plans/usage/getBillingUsageTopDimensionValues.ts
+++ b/packages/server/lib/controllers/v1/plans/usage/getBillingUsageTopDimensionValues.ts
@@ -65,8 +65,7 @@ export const getBillingUsageTopDimensionValues = asyncWrapper<GetBillingUsageTop
 
     let values: { id: string; label: string }[];
     if (query.dimension === 'environment_id') {
-        const envs = await environmentService.getEnvironmentsByIds(result.value.values.map(Number));
-        const names = new Map(envs.map((e) => [e.id, e.name]));
+        const names = await environmentService.getEnvironmentNamesByIds(result.value.values.map(Number));
         values = result.value.values.map((id) => ({ id, label: names.get(Number(id)) ?? id }));
     } else {
         values = result.value.values.map((id) => ({ id, label: id }));

--- a/packages/shared/lib/services/environment.service.ts
+++ b/packages/shared/lib/services/environment.service.ts
@@ -202,6 +202,15 @@ class EnvironmentService {
         });
     }
 
+    // Cheap variant: skip secret decryption when only id→name is needed.
+    async getEnvironmentNamesByIds(environmentIds: number[]): Promise<Map<number, string>> {
+        if (environmentIds.length === 0) {
+            return new Map();
+        }
+        const rows = await db.readOnly<DBEnvironment>(TABLE).select('id', 'name').whereIn('id', environmentIds).andWhere({ deleted: false });
+        return new Map(rows.map((r) => [r.id, r.name]));
+    }
+
     async getSlackNotificationsEnabled(environmentId: number, trx = db.knex): Promise<boolean | null> {
         const result = await trx.select('slack_notifications').from<DBEnvironment>(TABLE).where({ id: environmentId, deleted: false });
 

--- a/packages/types/lib/plans/http.api.ts
+++ b/packages/types/lib/plans/http.api.ts
@@ -81,7 +81,10 @@ export type GetBillingUsageTopDimensionValues = Endpoint<{
     }[UsageMetric];
     Success: {
         data: {
-            values: string[];
+            // `id` is the raw CH value (used to filter back); `label` is the
+            // display string — resolved server-side for `environment_id`,
+            // equal to `id` for the other slug-ish dims.
+            values: { id: string; label: string }[];
         };
     };
 }>;


### PR DESCRIPTION
- Response shape of `GET /api/v1/plans/billing-usage/top-dimension-values` changes from `values: string[]` to `values: { id, label }[]`. The new endpoint is not yet wired up on the webapp, so this is a free shape change.
- For `environment_id` (the only Int64 dim), the controller batch-resolves env names so the filter dropdown can render readable names. Cost is one PG round-trip bounded by `TOP_N_BREAKDOWN_CAP` rows on a PK-indexed table — negligible. For the other dims, `label === id` (they're already user-facing slugs).
- Adds `environmentService.getEnvironmentNamesByIds`: single `SELECT id, name`, no secret join, no KMS decryption. The existing `getEnvironmentsByIds` calls `setAllSecrets` (extra query + per-env decryption) which is wasteful when only id→name is needed.

## Test plan

- [x] `npm run ts-build` passes.
- [x] Integration test: `integration_id` dim returns `{ id, label }` pairs with `label === id`.
- [x] Integration test: `environment_id` dim resolves `id` to the env name (label).
- [ ] Manual: query `/api/v1/plans/billing-usage/top-dimension-values?metric=records&dimension=environment_id&...` in dev → response includes the env name, not the raw id.