### PR TITLE
feat(clickhouse): prefer CLICKHOUSE_PRIVATE_URL when set, fall back to CLICKHOUSE_URL

### DIFF
--- a/packages/usage/lib/clickhouse/config.ts
+++ b/packages/usage/lib/clickhouse/config.ts
@@ -9,7 +9,7 @@ const envs = parseEnvs(ENVS);
 export const database = 'usage';
 
 export function clickhouseClient(opts?: { database: string }): ClickHouseClient | null {
-    const url = envs.CLICKHOUSE_PRIVATE_URL ?? envs.CLICKHOUSE_URL;
+    const url = envs.CLICKHOUSE_PRIVATE_URL || envs.CLICKHOUSE_URL;
     if (!url) {
         return null;
     }

--- a/packages/usage/lib/clickhouse/config.ts
+++ b/packages/usage/lib/clickhouse/config.ts
@@ -9,11 +9,12 @@ const envs = parseEnvs(ENVS);
 export const database = 'usage';
 
 export function clickhouseClient(opts?: { database: string }): ClickHouseClient | null {
-    if (!envs.CLICKHOUSE_URL) {
+    const url = envs.CLICKHOUSE_PRIVATE_URL ?? envs.CLICKHOUSE_URL;
+    if (!url) {
         return null;
     }
     return createClient({
-        url: envs.CLICKHOUSE_URL,
+        url,
         ...(opts?.database ? { database: opts.database } : {}),
         // CH Cloud auto-suspend wake-up on idle instances can exceed the 30s
         // client default — bumping to 60s rides out the cold-start.

--- a/packages/utils/lib/environment/parse.ts
+++ b/packages/utils/lib/environment/parse.ts
@@ -295,6 +295,9 @@ export const ENVS = z.object({
 
     // ClickHouse
     CLICKHOUSE_URL: z.string().optional(),
+    // When set, preferred over CLICKHOUSE_URL — routes traffic through the
+    // PrivateLink VPC endpoint instead of the public endpoint.
+    CLICKHOUSE_PRIVATE_URL: z.string().optional(),
     CLICKHOUSE_USAGE_INGEST_BATCH_SIZE: z.coerce.number().optional().default(10_000),
     CLICKHOUSE_USAGE_INGEST_BATCH_INTERVAL_MS: z.coerce.number().optional().default(5_000),
     CLICKHOUSE_USAGE_INGEST_MAX_QUEUE_SIZE: z.coerce.number().optional().default(500_000),


### PR DESCRIPTION
- Adds a parallel `CLICKHOUSE_PRIVATE_URL` env var. The ClickHouse client config prefers it over `CLICKHOUSE_URL` when set; otherwise it falls back to the existing public URL — staging and prod stay unchanged until the key is added to their respective AWS Secrets Manager secrets.
- Lets us cut dev traffic over to the PrivateLink endpoint provisioned in NangoHQ/nango-infra#144 by just adding the new key to the dev account's `nango-clickhouse` secret; no manifest or code changes per env.

## Test environment

- [x] Already set up the private link and working,
- [x]  Already added as part of the secrets manager

Once we have this one merged Im planning to repeat the same operations for staging and production, and from there decide if we just remove the `CLICKOUSE_URL` since we might want to limit the access through our global endpoint.

## Test plan

- [x] `npm run ts-build` passes.
- [ ] After merge + deploy, add `CLICKHOUSE_PRIVATE_URL` to the dev account's `nango-clickhouse` AWS Secrets Manager secret with the PrivateLink hostname.
- [ ] Force-sync the ExternalSecret (`kubectl annotate externalsecret nango-es-clickhouse force-sync=$(date +%s) -n nango`) or wait for the 1h refresh.
- [ ] Confirm `kubectl exec ... -- env | grep CLICKHOUSE_` shows both vars set in a dev pod.
- [ ] Confirm CH-backed `/plans/billing-usage` queries continue to succeed in dev (DD logs / dashboard) — traffic now goes via the VPC endpoint.
- [ ] Confirm staging and prod pods still have only `CLICKHOUSE_URL` set; CH access unchanged.