### PR TITLE
feat(oauth): enrich missing-state-cookie metric to debug impacted users

### DIFF
--- a/packages/server/lib/controllers/integrations/postIntegration.ts
+++ b/packages/server/lib/controllers/integrations/postIntegration.ts
@@ -12,6 +12,7 @@ import {
     providerSchema
 } from '../../helpers/validation.js';
 import { asyncWrapper } from '../../utils/asyncWrapper.js';
+import { resolveIntegrationConfig } from '../v1/integrations/integrationConfig.js';
 
 import type { DBCreateIntegration, PostPublicIntegration, PostPublicQuickstartIntegration } from '@nangohq/types';
 
@@ -25,7 +26,8 @@ const baseValidationBody = z
     .strict();
 
 const validationBody = baseValidationBody.extend({
-    credentials: integrationCredentialsSchema.optional()
+    credentials: integrationCredentialsSchema.optional(),
+    integration_config: z.record(z.string(), z.string().max(8192)).optional()
 });
 
 const quickstartAuthModes = new Set(['OAUTH1', 'OAUTH2']);
@@ -118,6 +120,15 @@ export const postPublicIntegration = asyncWrapper<PostPublicIntegration>(async (
                 throw new Error('Unsupported auth type');
             }
         }
+    }
+
+    if (body.integration_config && Object.keys(body.integration_config).length > 0) {
+        const cfg = resolveIntegrationConfig(provider, body.integration_config);
+        if (cfg.isErr()) {
+            res.status(400).send({ error: { code: 'invalid_body', message: cfg.error.message } });
+            return;
+        }
+        newIntegration.custom = { ...newIntegration.custom, ...cfg.value };
     }
 
     const result = await configService.createProviderConfig(newIntegration, provider);

--- a/packages/server/lib/controllers/integrations/uniqueKey/patchIntegration.ts
+++ b/packages/server/lib/controllers/integrations/uniqueKey/patchIntegration.ts
@@ -22,6 +22,7 @@ const validationBody = z
         display_name: integrationDisplayNameSchema.optional(),
         credentials: integrationCredentialsSchema.optional(),
         forward_webhooks: integrationForwardWebhooksSchema,
+        integration_config: z.record(z.string(), z.string().max(8192)).optional(),
         custom: z.record(z.string(), z.string()).optional()
     })
     .strict();
@@ -92,26 +93,30 @@ export const patchPublicIntegration = asyncWrapper<PatchPublicIntegration>(async
         integration.forward_webhooks = body.forward_webhooks;
     }
 
-    if ('custom' in body && body.custom && Object.keys(body.custom).length > 0) {
-        const custom: Record<string, string> = body.custom as Record<string, string>;
-        if (provider.integration_config) {
-            // For providers with a custom integration configuration schema, validate the custom payload against it
-            // (instead of merging arbitrary keys) so this path can't write an invalid config the form/v1 API would reject.
-            const result = resolveIntegrationConfig(provider, custom, { patch: true });
-            if (result.isErr()) {
-                res.status(400).send({ error: { code: 'invalid_body', message: result.error.message } });
-                return;
-            }
-            integration.custom = {
-                ...integration.custom,
-                ...result.value
-            };
-        } else {
-            integration.custom = {
-                ...integration.custom,
-                ...custom
-            };
+    // Custom integration configuration: schema-validated field for providers that declare `integration_config`.
+    if ('integration_config' in body && body.integration_config && Object.keys(body.integration_config).length > 0) {
+        const result = resolveIntegrationConfig(provider, body.integration_config, { patch: true });
+        if (result.isErr()) {
+            res.status(400).send({ error: { code: 'invalid_body', message: result.error.message } });
+            return;
         }
+        integration.custom = {
+            ...integration.custom,
+            ...result.value
+        };
+    }
+
+    // Free-form custom values, for providers without an `integration_config` schema. Schema providers must use
+    // `integration_config` (validated) so this path can't write a config the form/v1 API would reject.
+    if ('custom' in body && body.custom && Object.keys(body.custom).length > 0) {
+        if (provider.integration_config) {
+            res.status(400).send({ error: { code: 'invalid_body', message: 'This provider uses integration_config; set its values there instead of custom' } });
+            return;
+        }
+        integration.custom = {
+            ...integration.custom,
+            ...body.custom
+        };
     }
 
     // Credentials

--- a/packages/server/lib/controllers/oauth.controller.ts
+++ b/packages/server/lib/controllers/oauth.controller.ts
@@ -1195,16 +1195,32 @@ class OAuthController {
             const config = (await configService.getProviderConfig(session.providerConfigKey, session.environmentId))!;
             await logCtx.enrichOperation({ integrationId: config.id!, integrationName: config.unique_key, providerName: config.provider });
 
-            if (
-                (session.authMode === 'OAUTH2' ||
-                    session.authMode === 'CUSTOM' ||
-                    session.authMode === 'MCP_OAUTH2' ||
-                    session.authMode === 'MCP_OAUTH2_GENERIC') &&
-                req.cookies[`oauth2-${session.id}`] !== '1'
-            ) {
+            const usesStateCookie =
+                session.authMode === 'OAUTH2' ||
+                session.authMode === 'CUSTOM' ||
+                session.authMode === 'MCP_OAUTH2' ||
+                session.authMode === 'MCP_OAUTH2_GENERIC';
+            if (usesStateCookie && req.cookies[`oauth2-${session.id}`] === '1') {
+                metrics.increment(metrics.Types.AUTH_CALLBACK_STATE_COOKIE_PRESENT, 1, {
+                    account_id: account.id
+                });
+            } else if (usesStateCookie) {
+                // Sec-Fetch-* are set by browsers and cannot be spoofed from JS, so they tell us how the
+                // callback reached us: `navigate`/`document` = a real top-level browser redirect (so a missing
+                // cookie points to an iframe/3p-cookie/expiry issue), `cors`/`empty` = a fetch/XHR forward,
+                // and absent = a non-browser server-side call. The rest corroborate that classification.
+                const userAgent = req.get('user-agent') ?? '';
                 metrics.increment(metrics.Types.AUTH_CALLBACK_STATE_COOKIE_MISSING, 1, {
                     account_id: account.id,
-                    auth_mode: session.authMode
+                    auth_mode: session.authMode,
+                    provider: config.provider,
+                    sec_fetch_mode: req.get('sec-fetch-mode') ?? 'absent',
+                    sec_fetch_dest: req.get('sec-fetch-dest') ?? 'absent',
+                    sec_fetch_site: req.get('sec-fetch-site') ?? 'absent',
+                    is_browser_ua: String(/mozilla|applewebkit|gecko|chrome|safari|firefox|edg/i.test(userAgent)),
+                    has_referer: String(Boolean(req.get('referer'))),
+                    has_any_cookie: String(Boolean(req.get('cookie'))),
+                    req_secure: String(req.secure)
                 });
             }
 

--- a/packages/server/lib/controllers/oauth.controller.ts
+++ b/packages/server/lib/controllers/oauth.controller.ts
@@ -75,6 +75,21 @@ import type {
 } from '@nangohq/types';
 import type { NextFunction, Request, Response } from 'express';
 
+// Sec-Fetch-* are forbidden headers for browsers (they set them, JS can't), but a non-browser caller can
+// send arbitrary values. Validate against the spec-defined sets before tagging so untrusted input can't blow
+// up metric cardinality, while still preserving the values we actually discriminate on (navigate/cors/...).
+const SEC_FETCH_MODE_VALUES = new Set(['navigate', 'cors', 'no-cors', 'same-origin', 'websocket']);
+const SEC_FETCH_DEST_VALUES = new Set(['document', 'empty', 'iframe', 'frame', 'nested-document']);
+const SEC_FETCH_SITE_VALUES = new Set(['cross-site', 'same-origin', 'same-site', 'none']);
+
+function normalizeHeaderTag(value: string | undefined, allowed: Set<string>): string {
+    if (!value) {
+        return 'absent';
+    }
+    const normalized = value.toLowerCase();
+    return allowed.has(normalized) ? normalized : 'other';
+}
+
 class OAuthController {
     public async oauthRequest(req: Request, res: Response<any, Required<RequestLocals>>, _next: NextFunction) {
         const { account, environment, connectSession } = res.locals;
@@ -1205,18 +1220,17 @@ class OAuthController {
                     account_id: account.id
                 });
             } else if (usesStateCookie) {
-                // Sec-Fetch-* are set by browsers and cannot be spoofed from JS, so they tell us how the
-                // callback reached us: `navigate`/`document` = a real top-level browser redirect (so a missing
-                // cookie points to an iframe/3p-cookie/expiry issue), `cors`/`empty` = a fetch/XHR forward,
-                // and absent = a non-browser server-side call. The rest corroborate that classification.
+                // How the callback reached us: `navigate`/`document` = a real top-level browser redirect (so a
+                // missing cookie points to an iframe/3p-cookie/expiry issue), `cors`/`empty` = a fetch/XHR
+                // forward, and absent = a non-browser server-side call. The rest corroborate that classification.
                 const userAgent = req.get('user-agent') ?? '';
                 metrics.increment(metrics.Types.AUTH_CALLBACK_STATE_COOKIE_MISSING, 1, {
                     account_id: account.id,
                     auth_mode: session.authMode,
                     provider: config.provider,
-                    sec_fetch_mode: req.get('sec-fetch-mode') ?? 'absent',
-                    sec_fetch_dest: req.get('sec-fetch-dest') ?? 'absent',
-                    sec_fetch_site: req.get('sec-fetch-site') ?? 'absent',
+                    sec_fetch_mode: normalizeHeaderTag(req.get('sec-fetch-mode'), SEC_FETCH_MODE_VALUES),
+                    sec_fetch_dest: normalizeHeaderTag(req.get('sec-fetch-dest'), SEC_FETCH_DEST_VALUES),
+                    sec_fetch_site: normalizeHeaderTag(req.get('sec-fetch-site'), SEC_FETCH_SITE_VALUES),
                     is_browser_ua: String(/mozilla|applewebkit|gecko|chrome|safari|firefox|edg/i.test(userAgent)),
                     has_referer: String(Boolean(req.get('referer'))),
                     has_any_cookie: String(Boolean(req.get('cookie'))),

--- a/packages/server/lib/controllers/oauth.controller.ts
+++ b/packages/server/lib/controllers/oauth.controller.ts
@@ -1215,27 +1215,32 @@ class OAuthController {
                 session.authMode === 'CUSTOM' ||
                 session.authMode === 'MCP_OAUTH2' ||
                 session.authMode === 'MCP_OAUTH2_GENERIC';
-            if (usesStateCookie && req.cookies[`oauth2-${session.id}`] === '1') {
-                metrics.increment(metrics.Types.AUTH_CALLBACK_STATE_COOKIE_PRESENT, 1, {
-                    account_id: account.id
-                });
-            } else if (usesStateCookie) {
-                // How the callback reached us: `navigate`/`document` = a real top-level browser redirect (so a
-                // missing cookie points to an iframe/3p-cookie/expiry issue), `cors`/`empty` = a fetch/XHR
-                // forward, and absent = a non-browser server-side call. The rest corroborate that classification.
-                const userAgent = req.get('user-agent') ?? '';
-                metrics.increment(metrics.Types.AUTH_CALLBACK_STATE_COOKIE_MISSING, 1, {
-                    account_id: account.id,
-                    auth_mode: session.authMode,
-                    provider: config.provider,
-                    sec_fetch_mode: normalizeHeaderTag(req.get('sec-fetch-mode'), SEC_FETCH_MODE_VALUES),
-                    sec_fetch_dest: normalizeHeaderTag(req.get('sec-fetch-dest'), SEC_FETCH_DEST_VALUES),
-                    sec_fetch_site: normalizeHeaderTag(req.get('sec-fetch-site'), SEC_FETCH_SITE_VALUES),
-                    is_browser_ua: String(/mozilla|applewebkit|gecko|chrome|safari|firefox|edg/i.test(userAgent)),
-                    has_referer: String(Boolean(req.get('referer'))),
-                    has_any_cookie: String(Boolean(req.get('cookie'))),
-                    req_secure: String(req.secure)
-                });
+            if (usesStateCookie) {
+                const cookiePresent = req.cookies[`oauth2-${session.id}`] === '1';
+                if (cookiePresent) {
+                    metrics.increment(metrics.Types.AUTH_CALLBACK_STATE_COOKIE, 1, {
+                        account_id: account.id,
+                        present: 'true'
+                    });
+                } else {
+                    // How the callback reached us: `navigate`/`document` = a real top-level browser redirect (so a
+                    // missing cookie points to an iframe/3p-cookie/expiry issue), `cors`/`empty` = a fetch/XHR
+                    // forward, and absent = a non-browser server-side call. The rest corroborate that classification.
+                    const userAgent = req.get('user-agent') ?? '';
+                    metrics.increment(metrics.Types.AUTH_CALLBACK_STATE_COOKIE, 1, {
+                        account_id: account.id,
+                        present: 'false',
+                        auth_mode: session.authMode,
+                        provider: config.provider,
+                        sec_fetch_mode: normalizeHeaderTag(req.get('sec-fetch-mode'), SEC_FETCH_MODE_VALUES),
+                        sec_fetch_dest: normalizeHeaderTag(req.get('sec-fetch-dest'), SEC_FETCH_DEST_VALUES),
+                        sec_fetch_site: normalizeHeaderTag(req.get('sec-fetch-site'), SEC_FETCH_SITE_VALUES),
+                        is_browser_ua: String(/mozilla|applewebkit|gecko|chrome|safari|firefox|edg/i.test(userAgent)),
+                        has_referer: String(Boolean(req.get('referer'))),
+                        has_any_cookie: String(Boolean(req.get('cookie'))),
+                        req_secure: String(req.secure)
+                    });
+                }
             }
 
             if (session.authMode === 'OAUTH2' || session.authMode === 'CUSTOM' || session.authMode === 'MCP_OAUTH2') {

--- a/packages/types/lib/integration/api.ts
+++ b/packages/types/lib/integration/api.ts
@@ -55,6 +55,7 @@ export type PostPublicIntegration = Endpoint<{
         display_name?: string | undefined;
         credentials?: ApiPublicIntegrationCredentials | undefined;
         forward_webhooks?: boolean | undefined;
+        integration_config?: Record<string, string> | undefined;
     };
     Success: {
         data: ApiPublicIntegration;
@@ -92,6 +93,11 @@ export type PatchPublicIntegration = Endpoint<{
         display_name?: string | undefined;
         credentials?: ApiPublicIntegrationCredentials | undefined;
         forward_webhooks?: boolean | undefined;
+        // Custom integration configuration (providers that declare `integration_config`, e.g. private-api-generic).
+        // Validated server-side against the provider schema and persisted to the `custom` column.
+        integration_config?: Record<string, string> | undefined;
+        // Free-form custom values, for providers without an `integration_config` schema.
+        custom?: Record<string, string> | undefined;
     };
     Success: {
         data: ApiPublicIntegration;

--- a/packages/utils/lib/telemetry/metrics.ts
+++ b/packages/utils/lib/telemetry/metrics.ts
@@ -146,8 +146,7 @@ export enum Types {
 
     PUBSUB_PUBLISH = 'nango.pubsub.publish',
 
-    AUTH_CALLBACK_STATE_COOKIE_MISSING = 'nango.server.auth.callback.state_cookie.missing',
-    AUTH_CALLBACK_STATE_COOKIE_PRESENT = 'nango.server.auth.callback.state_cookie.present'
+    AUTH_CALLBACK_STATE_COOKIE = 'nango.server.auth.callback.state_cookie'
 }
 
 type Dimensions = Record<string, string | number> | undefined;

--- a/packages/utils/lib/telemetry/metrics.ts
+++ b/packages/utils/lib/telemetry/metrics.ts
@@ -146,7 +146,8 @@ export enum Types {
 
     PUBSUB_PUBLISH = 'nango.pubsub.publish',
 
-    AUTH_CALLBACK_STATE_COOKIE_MISSING = 'nango.server.auth.callback.state_cookie.missing'
+    AUTH_CALLBACK_STATE_COOKIE_MISSING = 'nango.server.auth.callback.state_cookie.missing',
+    AUTH_CALLBACK_STATE_COOKIE_PRESENT = 'nango.server.auth.callback.state_cookie.present'
 }
 
 type Dimensions = Record<string, string | number> | undefined;


### PR DESCRIPTION
We're re-enabling OAuth callback state-cookie validation and need to tell apart *why* the cookie is missing before enforcing, since the causes need different fixes:

- non-browser server-side call forwarding code/state -> no cookie jar
- frontend fetch/XHR forward -> cross-site cookie not sent
- legit browser navigation but iframe/3p-cookie/expiry stripped the cookie

The Sec-Fetch-* headers discriminate these cleanly (`navigate` = real top-level redirect, `cors`/`empty` = fetch, absent = server-side) and can't be spoofed from JS, so they're the most reliable signal. Adding `provider` (as requested) plus referer/cookie/UA/secure flags to corroborate.

This adds several dimensions, which we usually avoid. The trade-off is justified here: the metric only fires on the (infrequent) failure path, the extra dimensions are temporary debugging aid for this enforcement rollout, and the per-customer breakdown is what lets us identify and reach out to impacted accounts before flipping enforcement on.

The `.missing` metric only fires on the failure path, so on its own it can't tell us whether an account misses the cookie occasionally or on every flow, which is exactly the signal that separates a flaky browser/iframe case from a deterministic server-side forwarder.

<!-- Describe the problem and your solution --> 

<!-- Issue ticket number and link (if applicable) -->

<!-- Testing instructions (skip if just adding/editing providers) -->

