### PR TITLE
fix(deploy): always upload files for new functions regardless of checkIfChanged result

### DIFF
--- a/packages/shared/lib/services/sync/config/deploy.service.ts
+++ b/packages/shared/lib/services/sync/config/deploy.service.ts
@@ -344,7 +344,7 @@ async function compileDeployInfo({
         const tsLocalFileName = `${providerConfigKey}/${flow.type}s/${syncName}.ts`;
         const tsChanged = await remoteFileService.checkIfChanged({ content: fileBody.ts, objectKey: tsDestinationPath });
 
-        if (tsChanged) {
+        if (tsChanged || !previousJsFileLocation) {
             uploads.push(
                 remoteFileService.upload({
                     content: jsFile,
@@ -362,7 +362,7 @@ async function compileDeployInfo({
     // Legacy Path - Only JS is provided
     else {
         const jsChanged = await remoteFileService.checkIfChanged({ content: jsFile, objectKey: jsDestinationPath });
-        if (jsChanged) {
+        if (jsChanged || !previousJsFileLocation) {
             uploads.push(
                 remoteFileService.upload({
                     content: jsFile,
@@ -382,9 +382,7 @@ async function compileDeployInfo({
 
     if (!file_location) {
         void logCtx.error('There was an error uploading the sync file', { fileName: `${syncName}-v${version}.js` });
-
-        // this is a platform error so throw this
-        throw new NangoError('file_upload_error');
+        return { success: false, error: new NangoError('file_upload_error'), response: null };
     }
 
     let models_json_schema: JSONSchema7 | null = flow.models_json_schema ?? null;

--- a/packages/shared/lib/services/sync/config/deploy.service.ts
+++ b/packages/shared/lib/services/sync/config/deploy.service.ts
@@ -344,6 +344,12 @@ async function compileDeployInfo({
         const tsLocalFileName = `${providerConfigKey}/${flow.type}s/${syncName}.ts`;
         const tsChanged = await remoteFileService.checkIfChanged({ content: fileBody.ts, objectKey: tsDestinationPath });
 
+        // !previousJsFileLocation: always upload for new functions.
+        // If a previous deploy uploaded the file to s3 but the db transaction failed,
+        // checkIfChanged may return false (since the file already exists),
+        // but we won't have a saved file_location to reuse, so we still need to upload
+        // to ensure we have a valid file_location.
+
         if (tsChanged || !previousJsFileLocation) {
             uploads.push(
                 remoteFileService.upload({

--- a/packages/shared/lib/services/sync/config/deploy.service.unit.test.ts
+++ b/packages/shared/lib/services/sync/config/deploy.service.unit.test.ts
@@ -11,6 +11,7 @@ import { getTestEnvironment } from '../../../seeders/environment.seeder.js';
 import accountService from '../../account.service.js';
 import configService from '../../config.service.js';
 import remoteFileService from '../../file/remote.service.js';
+import { onEventScriptService } from '../../on-event-scripts.service.js';
 import * as SyncService from '../sync.service.js';
 
 import type { OrchestratorClientInterface } from '../../../clients/orchestrator.js';
@@ -106,6 +107,151 @@ describe('Sync config create', () => {
   "providerConfigKey": "google-wrong"
 }`
         );
+    });
+
+    it('returns failure and marks logCtx as failed when file upload returns null', async () => {
+        const syncs: CleanedIncomingFlowConfig[] = [
+            {
+                syncName: 'test-sync',
+                type: 'sync',
+                providerConfigKey: 'google',
+                fileBody: { js: 'integrations.js', ts: 'integrations.ts' },
+                models: ['Model_1'],
+                runs: 'every 6h',
+                version: '1',
+                track_deletes: false,
+                endpoints: []
+            }
+        ];
+
+        const mockFailed = vi.fn().mockResolvedValue(undefined);
+        vi.spyOn(logContextGetter, 'create').mockResolvedValue({
+            failed: mockFailed,
+            success: vi.fn().mockResolvedValue(undefined),
+            error: vi.fn().mockResolvedValue(undefined),
+            info: vi.fn().mockResolvedValue(undefined),
+            debug: vi.fn().mockResolvedValue(undefined),
+            enrichOperation: vi.fn().mockResolvedValue(undefined)
+        } as any);
+
+        vi.spyOn(configService, 'getProviderConfig').mockResolvedValue({
+            id: 1,
+            unique_key: 'google',
+            display_name: null,
+            provider: 'google',
+            oauth_client_id: '123',
+            oauth_client_secret: '123',
+            post_connection_scripts: null,
+            environment_id: 1,
+            created_at: new Date(),
+            updated_at: new Date(),
+            missing_fields: [],
+            forward_webhooks: true,
+            shared_credentials_id: null
+        } as any);
+
+        vi.spyOn(SyncConfigService, 'getSyncAndActionConfigByParams').mockResolvedValue(null);
+        vi.spyOn(SyncService, 'getSyncsByProviderConfigKey').mockResolvedValue([]);
+        vi.spyOn(db.knex, 'from').mockReturnValue({
+            where: vi.fn().mockReturnValue({
+                select: vi.fn().mockReturnValue({
+                    orderBy: vi.fn().mockResolvedValue([])
+                })
+            })
+        } as any);
+
+        vi.spyOn(remoteFileService, 'upload').mockResolvedValue(null as any);
+
+        const { success, error } = await DeployConfigService.deploy({
+            account,
+            environment,
+            flows: syncs,
+            nangoYamlBody: '',
+            logContextGetter,
+            orchestrator: mockOrchestrator,
+            debug,
+            sdkVersion: '0.0.0-yaml',
+            onEventScriptsByProvider: [],
+            source: 'repo'
+        });
+
+        expect(success).toBe(false);
+        expect(error?.type).toBe('file_upload_error');
+        expect(mockFailed).toHaveBeenCalledOnce();
+    });
+
+    it('uploads files for a new function when checkIfChanged returns false (orphaned S3 file from failed first deploy)', async () => {
+        const syncs: CleanedIncomingFlowConfig[] = [
+            {
+                syncName: 'check-document-access',
+                type: 'action',
+                providerConfigKey: 'google',
+                fileBody: { js: 'console.log("action")', ts: 'export default {}' },
+                models: [],
+                runs: null,
+                version: '0.0.1',
+                track_deletes: false,
+                endpoints: []
+            }
+        ];
+
+        vi.spyOn(configService, 'getProviderConfig').mockResolvedValue({
+            id: 1,
+            unique_key: 'google',
+            display_name: null,
+            provider: 'google',
+            oauth_client_id: '123',
+            oauth_client_secret: '123',
+            post_connection_scripts: null,
+            environment_id: 1,
+            created_at: new Date(),
+            updated_at: new Date(),
+            missing_fields: [],
+            forward_webhooks: true,
+            shared_credentials_id: null
+        } as any);
+
+        vi.spyOn(SyncConfigService, 'getSyncAndActionConfigByParams').mockResolvedValue(null);
+        vi.spyOn(SyncService, 'getSyncsByProviderConfigKey').mockResolvedValue([]);
+        vi.spyOn(db.knex, 'from').mockReturnValue({
+            where: vi.fn().mockReturnValue({
+                select: vi.fn().mockReturnValue({
+                    orderBy: vi.fn().mockResolvedValue([])
+                })
+            })
+        } as any);
+
+        (remoteFileService as any).checkIfChanged = vi.fn().mockResolvedValue(false);
+
+        const uploadSpy = vi.spyOn(remoteFileService, 'upload').mockResolvedValue('https://example.com/check-document-access-v0.0.1.js' as any);
+        vi.spyOn(onEventScriptService, 'update').mockResolvedValue([]);
+
+        vi.spyOn(db.knex, 'transaction').mockImplementation(async (callback: any) => {
+            const mockTrx = {
+                from: vi.fn().mockReturnValue({
+                    update: vi.fn().mockReturnValue({ whereIn: vi.fn().mockResolvedValue(undefined) }),
+                    insert: vi.fn().mockReturnValue({ returning: vi.fn().mockResolvedValue([{ id: 1 }]) })
+                })
+            };
+            await callback(mockTrx);
+        });
+
+        const { success, error } = await DeployConfigService.deploy({
+            account,
+            environment,
+            flows: syncs,
+            nangoYamlBody: '',
+            logContextGetter,
+            orchestrator: mockOrchestrator,
+            debug,
+            sdkVersion: '0.0.0-zero',
+            onEventScriptsByProvider: [],
+            source: 'standalone'
+        });
+
+        expect(success).toBe(true);
+        expect(error).toBeNull();
+        expect(uploadSpy).toHaveBeenCalled();
     });
 
     it('Throws an error at the end of the create sync process', async () => {
@@ -242,6 +388,8 @@ describe('Sync config create', () => {
         vi.spyOn(SyncService, 'getSyncsByProviderConfigKey').mockImplementation(() => {
             return Promise.resolve([]);
         });
+
+        vi.spyOn(remoteFileService, 'upload').mockResolvedValue('https://example.com/file.js' as any);
 
         vi.spyOn(db.knex, 'from').mockReturnValue({
             where: vi.fn().mockReturnValue({


### PR DESCRIPTION
## Describe the problem and your solution

- When deploying a function for the first time, if the deploy uploads the file to s3 but fails before saving the db record, every subsequent retry fails with "There was an error uploading the sync file". This happens because on retry, the upload gets skipped since the file already exists in s3, but there's no saved file location to reuse.

- Fix is to only skip the upload when the content is unchanged AND there's a valid previous file location to fall back to. Also changed the upload failure path from throw to return so the deploy operation doesn't get stuck in "Running" state.

<!-- Issue ticket number and link (if applicable) -->

<!-- Testing instructions (skip if just adding/editing providers) -->

