### PR TITLE
perf(scheduler): bound the dueSchedules query per tick

### DIFF
--- a/packages/orchestrator/lib/scheduler-config.ts
+++ b/packages/orchestrator/lib/scheduler-config.ts
@@ -21,6 +21,7 @@ export function buildSchedulerConfig(envs: Envs): SchedulerConfig {
         },
         limits: {
             groupTaskCap: envs.ORCHESTRATOR_TASK_CREATED_PER_GROUP_COUNT_MAX,
+            schedulingBatchSize: envs.ORCHESTRATOR_SCHEDULING_TASKS_BATCH_SIZE,
             expiringBatchSize: envs.ORCHESTRATOR_EXPIRING_TASKS_BATCH_SIZE,
             recurringGroupMaxConcurrency: envs.SYNC_ENVIRONMENT_MAX_CONCURRENCY
         }

--- a/packages/scheduler/lib/config.ts
+++ b/packages/scheduler/lib/config.ts
@@ -19,6 +19,7 @@ export interface SchedulerConfig {
     };
     readonly limits: {
         readonly groupTaskCap: number;
+        readonly schedulingBatchSize: number;
         readonly expiringBatchSize: number;
         // Concurrency stamped on tasks materialized from a recurring schedule.
         // PR B will move this onto the schedule row itself; until then it is a single global value.
@@ -37,6 +38,7 @@ export const defaultSchedulerConfig: SchedulerConfig = {
     },
     limits: {
         groupTaskCap: 10_000,
+        schedulingBatchSize: 1000,
         expiringBatchSize: 1000,
         recurringGroupMaxConcurrency: 500
     }

--- a/packages/scheduler/lib/daemons/scheduling/scheduling.daemon.ts
+++ b/packages/scheduler/lib/daemons/scheduling/scheduling.daemon.ts
@@ -18,6 +18,7 @@ export class SchedulingDaemon extends SchedulerDaemon {
     private readonly onScheduling: (task: Task) => void;
     private readonly onEvent: (event: SchedulerEvent) => void;
     private readonly groupTaskCap: number;
+    private readonly batchSize: number;
     private readonly recurringGroupMaxConcurrency: number;
 
     constructor({
@@ -25,6 +26,7 @@ export class SchedulingDaemon extends SchedulerDaemon {
         abortSignal,
         tickIntervalMs,
         groupTaskCap,
+        batchSize,
         recurringGroupMaxConcurrency,
         onScheduling,
         onEvent,
@@ -34,6 +36,7 @@ export class SchedulingDaemon extends SchedulerDaemon {
         abortSignal: AbortSignal;
         tickIntervalMs: number;
         groupTaskCap: number;
+        batchSize: number;
         recurringGroupMaxConcurrency: number;
         onScheduling: (task: Task) => void;
         onEvent: (event: SchedulerEvent) => void;
@@ -49,6 +52,7 @@ export class SchedulingDaemon extends SchedulerDaemon {
         this.onScheduling = onScheduling;
         this.onEvent = onEvent;
         this.groupTaskCap = groupTaskCap;
+        this.batchSize = batchSize;
         this.recurringGroupMaxConcurrency = recurringGroupMaxConcurrency;
     }
 
@@ -65,7 +69,7 @@ export class SchedulingDaemon extends SchedulerDaemon {
                 if (lockGranted) {
                     await tracer.trace('scheduler.scheduling.schedule_tasks', async () => {
                         const getDueSchedules = await tracer.trace('scheduler.scheduling.due_schedules', async () => {
-                            return dueSchedules(trx);
+                            return dueSchedules(trx, { batchSize: this.batchSize });
                         });
 
                         if (getDueSchedules.isErr()) {

--- a/packages/scheduler/lib/daemons/scheduling/scheduling.integration.test.ts
+++ b/packages/scheduler/lib/daemons/scheduling/scheduling.integration.test.ts
@@ -117,6 +117,7 @@ describe('SchedulingDaemon', () => {
             abortSignal: new AbortController().signal,
             tickIntervalMs: defaultSchedulerConfig.daemons.schedulingTickIntervalMs,
             groupTaskCap: defaultSchedulerConfig.limits.groupTaskCap,
+            batchSize: defaultSchedulerConfig.limits.schedulingBatchSize,
             recurringGroupMaxConcurrency: defaultSchedulerConfig.limits.recurringGroupMaxConcurrency,
             onScheduling: () => {},
             onEvent: () => {},
@@ -128,6 +129,34 @@ describe('SchedulingDaemon', () => {
         const created = (await tasks.search(db, { scheduleId: schedule.id })).unwrap();
         expect(created).toHaveLength(1);
         expect(created[0]?.groupMaxConcurrency).toBe(defaultSchedulerConfig.limits.recurringGroupMaxConcurrency);
+    });
+
+    it('should only schedule up to batchSize tasks per tick, draining the backlog across ticks', async () => {
+        const startsAt = Seconds.ago(6 * 60);
+        for (let i = 0; i < 5; i++) {
+            await addSchedule(db, { startsAt, frequency: '5 minutes' });
+        }
+        const newDaemon = (batchSize: number): SchedulingDaemon =>
+            new SchedulingDaemon({
+                db,
+                abortSignal: new AbortController().signal,
+                tickIntervalMs: defaultSchedulerConfig.daemons.schedulingTickIntervalMs,
+                groupTaskCap: defaultSchedulerConfig.limits.groupTaskCap,
+                batchSize,
+                recurringGroupMaxConcurrency: defaultSchedulerConfig.limits.recurringGroupMaxConcurrency,
+                onScheduling: () => {},
+                onEvent: () => {},
+                onError: () => {}
+            });
+
+        await newDaemon(2).run();
+        expect((await tasks.search(db, { states: ['CREATED'] })).unwrap()).toHaveLength(2);
+
+        await newDaemon(2).run();
+        expect((await tasks.search(db, { states: ['CREATED'] })).unwrap()).toHaveLength(4);
+
+        await newDaemon(2).run();
+        expect((await tasks.search(db, { states: ['CREATED'] })).unwrap()).toHaveLength(5);
     });
 });
 

--- a/packages/scheduler/lib/daemons/scheduling/scheduling.ts
+++ b/packages/scheduler/lib/daemons/scheduling/scheduling.ts
@@ -1,13 +1,16 @@
 import { Err, Ok, stringifyError } from '@nangohq/utils';
 
+import { defaultSchedulerConfig } from '../../config.js';
 import { DbSchedule, SCHEDULES_TABLE } from '../../models/schedules.js';
 
 import type { Schedule } from '../../types.js';
 import type { Result } from '@nangohq/utils';
 import type knex from 'knex';
 
-export async function dueSchedules(db: knex.Knex): Promise<Result<Schedule[]>> {
+export async function dueSchedules(db: knex.Knex, opts: { batchSize?: number } = {}): Promise<Result<Schedule[]>> {
+    const batchSize = opts.batchSize ?? defaultSchedulerConfig.limits.schedulingBatchSize;
     try {
+        // Bounded per tick so a backlog drains across ticks rather than one transaction holding the scheduling lock.
         const schedules: DbSchedule[] = await db
             .select('*')
             .from(SCHEDULES_TABLE)
@@ -17,6 +20,8 @@ export async function dueSchedules(db: knex.Knex): Promise<Result<Schedule[]>> {
                 this.whereNotIn('last_scheduled_task_state', ['CREATED', 'STARTED']).orWhereNull('last_scheduled_task_state');
             })
             .where('next_execution_at', '<=', db.fn.now())
+            .orderBy('next_execution_at', 'asc')
+            .limit(batchSize)
             .forUpdate()
             .skipLocked();
         return Ok(schedules.map(DbSchedule.from));

--- a/packages/scheduler/lib/db/migrations/20260608120000_scheduling_index_cover_last_task_state.ts
+++ b/packages/scheduler/lib/db/migrations/20260608120000_scheduling_index_cover_last_task_state.ts
@@ -1,0 +1,27 @@
+import type { Knex } from 'knex';
+
+import { SCHEDULES_TABLE } from '../../models/schedules.js';
+
+export const config = {
+    transaction: false
+};
+
+// Cover last_scheduled_task_state so dueSchedules resolves it from the index instead of a heap fetch per row.
+// Create the new index before dropping the old one to keep a usable index throughout the deploy.
+export async function up(knex: Knex): Promise<void> {
+    await knex.raw(
+        `CREATE INDEX CONCURRENTLY IF NOT EXISTS idx_schedules_ready_for_execution_v2
+        ON ${SCHEDULES_TABLE} (next_execution_at, last_scheduled_task_state)
+        WHERE state = 'STARTED';`
+    );
+    await knex.raw(`DROP INDEX CONCURRENTLY IF EXISTS "idx_schedules_ready_for_execution";`);
+}
+
+export async function down(knex: Knex): Promise<void> {
+    await knex.raw(
+        `CREATE INDEX CONCURRENTLY IF NOT EXISTS idx_schedules_ready_for_execution
+        ON ${SCHEDULES_TABLE} (next_execution_at)
+        WHERE state = 'STARTED';`
+    );
+    await knex.raw(`DROP INDEX CONCURRENTLY IF EXISTS "idx_schedules_ready_for_execution_v2";`);
+}

--- a/packages/scheduler/lib/scheduler.ts
+++ b/packages/scheduler/lib/scheduler.ts
@@ -93,6 +93,7 @@ export class Scheduler {
             abortSignal: this.ac.signal,
             tickIntervalMs: config.daemons.schedulingTickIntervalMs,
             groupTaskCap: config.limits.groupTaskCap,
+            batchSize: config.limits.schedulingBatchSize,
             recurringGroupMaxConcurrency: config.limits.recurringGroupMaxConcurrency,
             onScheduling: (task: Task) => {
                 this.onCallbacks[task.state](task);

--- a/packages/utils/lib/environment/parse.ts
+++ b/packages/utils/lib/environment/parse.ts
@@ -129,6 +129,7 @@ export const ENVS = z.object({
     ORCHESTRATOR_TASK_CREATED_PER_GROUP_COUNT_MAX: z.coerce.number().optional().default(10_000),
     ORCHESTRATOR_DB_SSL: z.stringbool().optional().default(false),
     ORCHESTRATOR_EXPIRING_TASKS_BATCH_SIZE: z.coerce.number().optional().default(1000),
+    ORCHESTRATOR_SCHEDULING_TASKS_BATCH_SIZE: z.coerce.number().optional().default(1000),
 
     // Jobs
     JOBS_SERVICE_URL: z.url().optional().default('http://localhost:3005'),


### PR DESCRIPTION
## Describe the problem and your solution

The scheduling daemon ticks every 100ms and was selecting *every* due schedule in one query — no `LIMIT`, no `ORDER BY` — inside the transaction that holds the global scheduling advisory lock.

Steady state is fine. The failure mode is recovery: after a restart or a DB pause, every schedule that came due during the gap is due at once. Schedules are 1:1 with syncs, so that's easily 10k–100k+ rows, and one tick then tries to drain the whole backlog in a single locked transaction — blocking the job system's heartbeat.

Fix mirrors the `expiresIfTimeout` daemon, which is already bounded the same way:

- `dueSchedules` gets `ORDER BY next_execution_at ASC LIMIT schedulingBatchSize` (default 1000), so a backlog drains over several ticks instead of one transaction.
- The partial index now covers `last_scheduled_task_state`, so the filter is resolved from the index instead of a heap fetch per candidate. New index is created before the old one is dropped (usable index throughout the deploy); `down()` reverses it.

`EXPLAIN ANALYZE` on 200k STARTED schedules (~80% not dispatchable):

| | plan | time |
|---|---|---|
| before | Seq Scan, 160k rows removed by filter | 23.2 ms |
| after | Index Scan + LIMIT, stops at 1k | 2.4 ms |

~10x per tick, and bounded regardless of backlog size.

<!-- Issue ticket number and link (if applicable) -->

<!-- Testing instructions (skip if just adding/editing providers) -->

Integration test added for the per-tick bound and cross-tick drain:
`npm run test:integration --dir packages/scheduler`