### PR TITLE
fix(bigchange): set partner credentials at integration level, not per-connection

### DIFF
--- a/packages/providers/providers.yaml
+++ b/packages/providers/providers.yaml
@@ -2600,16 +2600,6 @@ bigchange:
             example: '5690'
             pattern: '^[0-9]+$'
             doc_section: '#step-2-find-your-bigchange-customer-id'
-    credentials:
-        client_id:
-            type: string
-            title: Client ID
-            description: Your BigChange Partner API client_id.
-        client_secret:
-            type: string
-            title: Client Secret
-            description: Your BigChange Partner API client_secret.
-            secret: true
 
 bigcommerce:
     display_name: BigCommerce


### PR DESCRIPTION
## Description

BigChange uses a **partner model**: a single Partner API `client_id`/`client_secret` is issued to the integrator and shared across every BigChange customer, who are distinguished only by their numeric **Customer ID** (sent in the `customer-id` proxy header).

The `bigchange` provider currently declares `client_id`/`client_secret` in a per-connection `credentials` block. As a result the Connect UI prompts **every end customer** to supply the partner `client_id` and `client_secret` on each connection — credentials they do not have and should never handle.

This also **contradicts the provider's own connect documentation** (`docs/api-integrations/bigchange/connect.mdx`), which already states:

> a single Partner API `client_id` and `client_secret` are configured at the **Nango integration level**, and each individual BigChange customer is identified by their numeric Customer ID

and instructs the end user to enter **only** their Customer ID in the Connect UI.

## Change

Remove the `credentials` block from the `bigchange` provider so `client_id`/`client_secret` are set **once at the integration level** and the Connect UI collects only the per-connection `customer_id`.

This matches how 50+ other `OAUTH2_CC` providers are already defined (e.g. `databricks-account`, `auth0-cc`, `microsoft-business-central`), and aligns the provider with its own documentation.

## Notes

- No behaviour change for the token exchange itself: `token_url` + `token_params` (`grant_type: client_credentials`) are unchanged; Nango uses the integration-level `client_id`/`client_secret` to mint the OAuth2-CC token.
- Docs already describe the corrected flow, so no doc change is required.
- Single-file change.