### PR TITLE
feat(usage): server-side rollout flags for routing billing-usage to ClickHouse

### DIFF
--- a/packages/server/lib/controllers/v1/meta/getMeta.integration.test.ts
+++ b/packages/server/lib/controllers/v1/meta/getMeta.integration.test.ts
@@ -1,8 +1,8 @@
 import { afterAll, afterEach, beforeAll, describe, expect, it } from 'vitest';
 
 import { seeders } from '@nangohq/shared';
+import { envsForTests as usageEnvs } from '@nangohq/usage';
 
-import { envs } from '../../../env.js';
 import { authenticateUser, isSuccess, runServer, shouldBeProtected } from '../../../utils/tests.js';
 
 const route = '/api/v1/meta';
@@ -18,8 +18,8 @@ describe(`GET ${route}`, () => {
     });
 
     afterEach(() => {
-        (envs as any).FLAG_BILLING_USAGE_CLICKHOUSE_ROLLOUT_ACCOUNT_IDS = '';
-        (envs as any).FLAG_BILLING_USAGE_CLICKHOUSE_ROLLOUT_PERCENTAGE = 0;
+        (usageEnvs as any).FLAG_BILLING_USAGE_CLICKHOUSE_ROLLOUT_ACCOUNT_IDS = '';
+        (usageEnvs as any).FLAG_BILLING_USAGE_CLICKHOUSE_ROLLOUT_PERCENTAGE = 0;
     });
 
     it('should be protected', async () => {
@@ -40,7 +40,7 @@ describe(`GET ${route}`, () => {
 
     it('returns billingUsageSource=clickhouse when the account is in the rollout allowlist', async () => {
         const { account, user } = await seeders.seedAccountEnvAndUser();
-        (envs as any).FLAG_BILLING_USAGE_CLICKHOUSE_ROLLOUT_ACCOUNT_IDS = String(account.id);
+        (usageEnvs as any).FLAG_BILLING_USAGE_CLICKHOUSE_ROLLOUT_ACCOUNT_IDS = String(account.id);
         const session = await authenticateUser(api, user);
         // @ts-expect-error type declares `env` but the controller rejects any query param
         const res = await api.fetch(route, { method: 'GET', session });

--- a/packages/server/lib/controllers/v1/meta/getMeta.integration.test.ts
+++ b/packages/server/lib/controllers/v1/meta/getMeta.integration.test.ts
@@ -1,0 +1,51 @@
+import { afterAll, afterEach, beforeAll, describe, expect, it } from 'vitest';
+
+import { seeders } from '@nangohq/shared';
+
+import { envs } from '../../../env.js';
+import { authenticateUser, isSuccess, runServer, shouldBeProtected } from '../../../utils/tests.js';
+
+const route = '/api/v1/meta';
+let api: Awaited<ReturnType<typeof runServer>>;
+
+describe(`GET ${route}`, () => {
+    beforeAll(async () => {
+        api = await runServer();
+    });
+
+    afterAll(() => {
+        api.server.close();
+    });
+
+    afterEach(() => {
+        (envs as any).FLAG_BILLING_USAGE_CLICKHOUSE_ROLLOUT_ACCOUNT_IDS = '';
+        (envs as any).FLAG_BILLING_USAGE_CLICKHOUSE_ROLLOUT_PERCENTAGE = 0;
+    });
+
+    it('should be protected', async () => {
+        // @ts-expect-error type declares `env` but the controller rejects any query param
+        const res = await api.fetch(route, { method: 'GET' });
+        shouldBeProtected(res);
+    });
+
+    it('returns billingUsageSource=orb by default', async () => {
+        const { user } = await seeders.seedAccountEnvAndUser();
+        const session = await authenticateUser(api, user);
+        // @ts-expect-error type declares `env` but the controller rejects any query param
+        const res = await api.fetch(route, { method: 'GET', session });
+        expect(res.res.status).toBe(200);
+        isSuccess(res.json);
+        expect(res.json.data.billingUsageSource).toBe('orb');
+    });
+
+    it('returns billingUsageSource=clickhouse when the account is in the rollout allowlist', async () => {
+        const { account, user } = await seeders.seedAccountEnvAndUser();
+        (envs as any).FLAG_BILLING_USAGE_CLICKHOUSE_ROLLOUT_ACCOUNT_IDS = String(account.id);
+        const session = await authenticateUser(api, user);
+        // @ts-expect-error type declares `env` but the controller rejects any query param
+        const res = await api.fetch(route, { method: 'GET', session });
+        expect(res.res.status).toBe(200);
+        isSuccess(res.json);
+        expect(res.json.data.billingUsageSource).toBe('clickhouse');
+    });
+});

--- a/packages/server/lib/controllers/v1/meta/getMeta.ts
+++ b/packages/server/lib/controllers/v1/meta/getMeta.ts
@@ -1,4 +1,5 @@
 import { environmentService } from '@nangohq/shared';
+import { shouldUseClickhouseFor } from '@nangohq/usage';
 import { NANGO_VERSION, baseUrl, requireEmptyQuery, zodErrorToHTTP } from '@nangohq/utils';
 
 import { asyncWrapper } from '../../../utils/asyncWrapper.js';
@@ -23,7 +24,8 @@ export const getMeta = asyncWrapper<GetMeta>(async (req, res) => {
             version: NANGO_VERSION,
             baseUrl,
             debugMode: req.session.debugMode === true,
-            gettingStartedClosed: sessionUser.getting_started_closed
+            gettingStartedClosed: sessionUser.getting_started_closed,
+            billingUsageSource: shouldUseClickhouseFor(sessionUser.account_id) ? 'clickhouse' : 'orb'
         }
     });
 });

--- a/packages/types/lib/meta/api.ts
+++ b/packages/types/lib/meta/api.ts
@@ -13,6 +13,7 @@ export type GetMeta = Endpoint<{
             baseUrl: string;
             debugMode: boolean;
             gettingStartedClosed: boolean;
+            billingUsageSource: 'clickhouse' | 'orb';
         };
     };
 }>;

--- a/packages/usage/lib/index.ts
+++ b/packages/usage/lib/index.ts
@@ -18,6 +18,7 @@ export {
 } from './clickhouse/clickhouse.query.js';
 export { clickhouseClient } from './clickhouse/config.js';
 export { migrate } from './clickhouse/migrate.js';
+export { shouldUseClickhouseFor } from './usage.js';
 
 export async function getUsageTracker(redisUrl: string | undefined): Promise<IUsageTracker> {
     if (redisUrl) {

--- a/packages/usage/lib/index.ts
+++ b/packages/usage/lib/index.ts
@@ -19,6 +19,9 @@ export {
 export { clickhouseClient } from './clickhouse/config.js';
 export { migrate } from './clickhouse/migrate.js';
 export { shouldUseClickhouseFor } from './usage.js';
+// Test-only: integration tests in other packages need to mutate the
+// usage-side `envs` singleton (different from the server-side one).
+export { envs as envsForTests } from './env.js';
 
 export async function getUsageTracker(redisUrl: string | undefined): Promise<IUsageTracker> {
     if (redisUrl) {

--- a/packages/usage/lib/usage.ts
+++ b/packages/usage/lib/usage.ts
@@ -49,6 +49,35 @@ export function shouldShadow(opts: GetBillingUsageOpts | undefined): opts is Get
     return opts.timeframe.start >= SHADOW_MIN_TIMEFRAME_START;
 }
 
+let cachedAllowlistCsv: string | undefined;
+let cachedAllowlist = new Set<number>();
+function getRolloutAllowlist(): Set<number> {
+    const csv = envs.FLAG_BILLING_USAGE_CLICKHOUSE_ROLLOUT_ACCOUNT_IDS;
+    if (csv !== cachedAllowlistCsv) {
+        cachedAllowlistCsv = csv;
+        cachedAllowlist = new Set();
+        for (const part of csv.split(',')) {
+            const trimmed = part.trim();
+            if (!trimmed) continue;
+            const id = Number(trimmed);
+            if (Number.isFinite(id)) cachedAllowlist.add(id);
+        }
+    }
+    return cachedAllowlist;
+}
+
+export function shouldUseClickhouseFor(accountId: number): boolean {
+    if (getRolloutAllowlist().has(accountId)) return true;
+    const pct = envs.FLAG_BILLING_USAGE_CLICKHOUSE_ROLLOUT_PERCENTAGE;
+    if (pct > 0 && accountId % 100 < pct) return true;
+    return false;
+}
+
+export function resolveBillingUsageSource(accountId: number, requestedSource: 'clickhouse' | 'orb' | undefined): 'clickhouse' | 'orb' {
+    const respected = envs.FLAG_ALLOW_OVERRIDE_GETUSAGE_SERVICE ? requestedSource : undefined;
+    return respected ?? (shouldUseClickhouseFor(accountId) ? 'clickhouse' : 'orb');
+}
+
 export interface UsageStatus {
     accountId: number;
     metric: UsageMetric;
@@ -285,12 +314,8 @@ export class UsageTracker implements IUsageTracker {
     }
 
     public async getBillingUsage(subscriptionId: string, accountId: number, opts?: GetBillingUsageOpts): Promise<Result<BillingUsageMetrics>> {
-        // CH path: dashboard shape only (granularity='day' + timeframe), and
-        // only when the env gate is on AND the request opted in via `source`.
-        // No silent Orb fallback on error — surfaces regressions in dev.
-        // Capping (`getBillingMetrics`, no granularity) stays on Orb.
-        const requestedSource = envs.FLAG_ALLOW_OVERRIDE_GETUSAGE_SERVICE ? opts?.source : undefined;
-        const useClickhouseForDashboard = requestedSource === 'clickhouse' && opts?.granularity === 'day' && opts.timeframe?.start && opts.timeframe?.end;
+        const effectiveSource = resolveBillingUsageSource(accountId, opts?.source);
+        const useClickhouseForDashboard = effectiveSource === 'clickhouse' && opts?.granularity === 'day' && opts.timeframe?.start && opts.timeframe?.end;
 
         if (useClickhouseForDashboard) {
             return this.getBillingUsageFromClickhouse(accountId, {

--- a/packages/usage/lib/usage.ts
+++ b/packages/usage/lib/usage.ts
@@ -58,9 +58,9 @@ function getRolloutAllowlist(): Set<number> {
         cachedAllowlist = new Set();
         for (const part of csv.split(',')) {
             const trimmed = part.trim();
-            if (!trimmed) continue;
-            const id = Number(trimmed);
-            if (Number.isFinite(id)) cachedAllowlist.add(id);
+            // Strict digit-only to keep scientific/hex/decimal forms from
+            // silently casting to an unintended account id.
+            if (/^\d+$/.test(trimmed)) cachedAllowlist.add(Number(trimmed));
         }
     }
     return cachedAllowlist;

--- a/packages/usage/lib/usage.unit.test.ts
+++ b/packages/usage/lib/usage.unit.test.ts
@@ -1,7 +1,7 @@
 import { afterEach, beforeEach, describe, expect, it } from 'vitest';
 
 import { envs } from './env.js';
-import { shouldShadow, toCounterBillingMetricSeries, toRunningAvgUsage } from './usage.js';
+import { resolveBillingUsageSource, shouldShadow, shouldUseClickhouseFor, toCounterBillingMetricSeries, toRunningAvgUsage } from './usage.js';
 
 import type { GetDailyCounterResult, GetDailySumAndBatchesResult } from './clickhouse/clickhouse.query.js';
 
@@ -312,5 +312,112 @@ describe('shouldShadow', () => {
         (envs as any).FLAG_BILLING_USAGE_SHADOW_CLICKHOUSE = true;
         expect(shouldShadow({ timeframe: junePlus })).toBe(true);
         expect(shouldShadow({ timeframe: { start: new Date('2026-06-01T00:00:00.000Z'), end: new Date('2026-06-02T00:00:00.000Z') } })).toBe(true);
+    });
+});
+
+describe('shouldUseClickhouseFor', () => {
+    let originalCsv: string;
+    let originalPct: number;
+    beforeEach(() => {
+        originalCsv = envs.FLAG_BILLING_USAGE_CLICKHOUSE_ROLLOUT_ACCOUNT_IDS;
+        originalPct = envs.FLAG_BILLING_USAGE_CLICKHOUSE_ROLLOUT_PERCENTAGE;
+    });
+    afterEach(() => {
+        (envs as any).FLAG_BILLING_USAGE_CLICKHOUSE_ROLLOUT_ACCOUNT_IDS = originalCsv;
+        (envs as any).FLAG_BILLING_USAGE_CLICKHOUSE_ROLLOUT_PERCENTAGE = originalPct;
+    });
+
+    it('returns false when both flags are at defaults', () => {
+        (envs as any).FLAG_BILLING_USAGE_CLICKHOUSE_ROLLOUT_ACCOUNT_IDS = '';
+        (envs as any).FLAG_BILLING_USAGE_CLICKHOUSE_ROLLOUT_PERCENTAGE = 0;
+        expect(shouldUseClickhouseFor(0)).toBe(false);
+        expect(shouldUseClickhouseFor(99)).toBe(false);
+        expect(shouldUseClickhouseFor(15714)).toBe(false);
+    });
+
+    it('returns true when accountId is in the CSV allowlist (whitespace-tolerant)', () => {
+        (envs as any).FLAG_BILLING_USAGE_CLICKHOUSE_ROLLOUT_ACCOUNT_IDS = '15714,  4242 ,  77 ';
+        (envs as any).FLAG_BILLING_USAGE_CLICKHOUSE_ROLLOUT_PERCENTAGE = 0;
+        expect(shouldUseClickhouseFor(15714)).toBe(true);
+        expect(shouldUseClickhouseFor(4242)).toBe(true);
+        expect(shouldUseClickhouseFor(77)).toBe(true);
+        expect(shouldUseClickhouseFor(99)).toBe(false);
+    });
+
+    it('ignores non-numeric junk in the CSV without falsely matching', () => {
+        (envs as any).FLAG_BILLING_USAGE_CLICKHOUSE_ROLLOUT_ACCOUNT_IDS = 'abc,,15714,123abc,';
+        (envs as any).FLAG_BILLING_USAGE_CLICKHOUSE_ROLLOUT_PERCENTAGE = 0;
+        expect(shouldUseClickhouseFor(15714)).toBe(true);
+        expect(shouldUseClickhouseFor(0)).toBe(false);
+        // Strict numeric parse: '123abc' must NOT silently match account 123.
+        expect(shouldUseClickhouseFor(123)).toBe(false);
+    });
+
+    it('returns true when accountId falls inside the percentage bucket', () => {
+        (envs as any).FLAG_BILLING_USAGE_CLICKHOUSE_ROLLOUT_ACCOUNT_IDS = '';
+        (envs as any).FLAG_BILLING_USAGE_CLICKHOUSE_ROLLOUT_PERCENTAGE = 25;
+        expect(shouldUseClickhouseFor(0)).toBe(true);
+        expect(shouldUseClickhouseFor(24)).toBe(true);
+        expect(shouldUseClickhouseFor(124)).toBe(true);
+        expect(shouldUseClickhouseFor(25)).toBe(false);
+        expect(shouldUseClickhouseFor(99)).toBe(false);
+        expect(shouldUseClickhouseFor(125)).toBe(false);
+    });
+
+    it('100% rollout includes every accountId', () => {
+        (envs as any).FLAG_BILLING_USAGE_CLICKHOUSE_ROLLOUT_ACCOUNT_IDS = '';
+        (envs as any).FLAG_BILLING_USAGE_CLICKHOUSE_ROLLOUT_PERCENTAGE = 100;
+        expect(shouldUseClickhouseFor(0)).toBe(true);
+        expect(shouldUseClickhouseFor(99)).toBe(true);
+        expect(shouldUseClickhouseFor(15714)).toBe(true);
+    });
+
+    it('allowlist + percentage are unioned', () => {
+        (envs as any).FLAG_BILLING_USAGE_CLICKHOUSE_ROLLOUT_ACCOUNT_IDS = '999';
+        (envs as any).FLAG_BILLING_USAGE_CLICKHOUSE_ROLLOUT_PERCENTAGE = 10;
+        expect(shouldUseClickhouseFor(999)).toBe(true);
+        expect(shouldUseClickhouseFor(5)).toBe(true);
+        expect(shouldUseClickhouseFor(50)).toBe(false);
+    });
+});
+
+describe('resolveBillingUsageSource', () => {
+    let originalOverride: boolean;
+    let originalCsv: string;
+    let originalPct: number;
+    beforeEach(() => {
+        originalOverride = envs.FLAG_ALLOW_OVERRIDE_GETUSAGE_SERVICE;
+        originalCsv = envs.FLAG_BILLING_USAGE_CLICKHOUSE_ROLLOUT_ACCOUNT_IDS;
+        originalPct = envs.FLAG_BILLING_USAGE_CLICKHOUSE_ROLLOUT_PERCENTAGE;
+    });
+    afterEach(() => {
+        (envs as any).FLAG_ALLOW_OVERRIDE_GETUSAGE_SERVICE = originalOverride;
+        (envs as any).FLAG_BILLING_USAGE_CLICKHOUSE_ROLLOUT_ACCOUNT_IDS = originalCsv;
+        (envs as any).FLAG_BILLING_USAGE_CLICKHOUSE_ROLLOUT_PERCENTAGE = originalPct;
+    });
+
+    it('explicit `orb` wins over a positive rollout when the override flag is on', () => {
+        (envs as any).FLAG_ALLOW_OVERRIDE_GETUSAGE_SERVICE = true;
+        (envs as any).FLAG_BILLING_USAGE_CLICKHOUSE_ROLLOUT_ACCOUNT_IDS = '42';
+        expect(resolveBillingUsageSource(42, 'orb')).toBe('orb');
+    });
+
+    it('explicit `clickhouse` wins when the override flag is on', () => {
+        (envs as any).FLAG_ALLOW_OVERRIDE_GETUSAGE_SERVICE = true;
+        (envs as any).FLAG_BILLING_USAGE_CLICKHOUSE_ROLLOUT_ACCOUNT_IDS = '';
+        expect(resolveBillingUsageSource(42, 'clickhouse')).toBe('clickhouse');
+    });
+
+    it('explicit source is ignored when the override flag is off (falls to rollout)', () => {
+        (envs as any).FLAG_ALLOW_OVERRIDE_GETUSAGE_SERVICE = false;
+        (envs as any).FLAG_BILLING_USAGE_CLICKHOUSE_ROLLOUT_ACCOUNT_IDS = '42';
+        expect(resolveBillingUsageSource(42, 'orb')).toBe('clickhouse');
+    });
+
+    it('falls back to the rollout when no explicit source is set', () => {
+        (envs as any).FLAG_ALLOW_OVERRIDE_GETUSAGE_SERVICE = true;
+        (envs as any).FLAG_BILLING_USAGE_CLICKHOUSE_ROLLOUT_ACCOUNT_IDS = '42';
+        expect(resolveBillingUsageSource(42, undefined)).toBe('clickhouse');
+        expect(resolveBillingUsageSource(7, undefined)).toBe('orb');
     });
 });

--- a/packages/usage/lib/usage.unit.test.ts
+++ b/packages/usage/lib/usage.unit.test.ts
@@ -345,12 +345,15 @@ describe('shouldUseClickhouseFor', () => {
     });
 
     it('ignores non-numeric junk in the CSV without falsely matching', () => {
-        (envs as any).FLAG_BILLING_USAGE_CLICKHOUSE_ROLLOUT_ACCOUNT_IDS = 'abc,,15714,123abc,';
+        // Includes scientific (1e5 → 100000), hex (0x10 → 16) and decimal (1.5)
+        // forms that Number() would happily coerce — all must be rejected.
+        (envs as any).FLAG_BILLING_USAGE_CLICKHOUSE_ROLLOUT_ACCOUNT_IDS = 'abc,,15714,123abc,1e5,0x10,1.5,';
         (envs as any).FLAG_BILLING_USAGE_CLICKHOUSE_ROLLOUT_PERCENTAGE = 0;
         expect(shouldUseClickhouseFor(15714)).toBe(true);
         expect(shouldUseClickhouseFor(0)).toBe(false);
-        // Strict numeric parse: '123abc' must NOT silently match account 123.
         expect(shouldUseClickhouseFor(123)).toBe(false);
+        expect(shouldUseClickhouseFor(100000)).toBe(false);
+        expect(shouldUseClickhouseFor(16)).toBe(false);
     });
 
     it('returns true when accountId falls inside the percentage bucket', () => {

--- a/packages/utils/lib/environment/parse.ts
+++ b/packages/utils/lib/environment/parse.ts
@@ -321,6 +321,8 @@ export const ENVS = z.object({
     // fires on cache miss + June-2026+ timeframe; fire-and-forget so it adds
     // no user-visible latency. Emits `nango.billing.usage.shadow.*` metrics.
     FLAG_BILLING_USAGE_SHADOW_CLICKHOUSE: z.stringbool().optional().default(false),
+    FLAG_BILLING_USAGE_CLICKHOUSE_ROLLOUT_ACCOUNT_IDS: z.string().optional().default(''),
+    FLAG_BILLING_USAGE_CLICKHOUSE_ROLLOUT_PERCENTAGE: z.coerce.number().int().min(0).max(100).optional().default(0),
 
     // --- Third parties
     // AWS


### PR DESCRIPTION
- Two new env flags rolling `/plans/billing-usage` requests over to the ClickHouse path on a per-account basis: `FLAG_BILLING_USAGE_CLICKHOUSE_ROLLOUT_ACCOUNT_IDS` (CSV allowlist) and `FLAG_BILLING_USAGE_CLICKHOUSE_ROLLOUT_PERCENTAGE` (0..100, predicate `account_id % 100 < pct`). Unioned: an account in either bucket gets CH. Plan is to seed the allowlist first, then expand by percentage.
- Source-selection precedence in `getBillingUsage` is now: explicit per-request `source` (gated by the existing `FLAG_ALLOW_OVERRIDE_GETUSAGE_SERVICE`) > rollout > Orb default. Shadow path is unchanged — still fires on cache miss for observability regardless of which path served the response.
- Adds `billingUsageSource: 'clickhouse' | 'orb'` to the `/api/v1/meta` response so the dashboard can adapt (e.g. clamp the date picker to ≥ 2026-06 once on CH). `/meta` is account-scoped, loaded once at app boot, so the frontend knows the routing before any billing call goes out.
- Allowlist CSV is parsed once and memoized; invalidated only when the env string changes (effectively never in prod; transparently in tests).

## Open question — not addressed in this PR

Caching strategy for the CH response path is **still to be decided**: no cache, the same Redis cache the Orb path uses, a shorter TTL, or a different keying. Today the CH path bypasses the Orb-side cache entirely; whether we want it to share the cache, run with its own TTL, or stay uncached is a follow-up call (the right answer probably depends on what we see once dogfood traffic lands on it).

## Test plan

- [x] `npm run ts-build` passes.
- [x] 10 new unit tests covering: defaults-off, allowlist (whitespace + junk + strict numeric), percentage boundaries (24/25, 99/125), 100% rollout, allowlist+pct union, and 4 precedence cases on `resolveBillingUsageSource` (explicit `orb` wins, explicit `clickhouse` wins, override-off ignores explicit, undefined falls through).
- [x] First-ever integration tests on `/api/v1/meta`: default `orb`, account in allowlist → `clickhouse`.
- [ ] After merge + dev rollout: set `FLAG_BILLING_USAGE_CLICKHOUSE_ROLLOUT_ACCOUNT_IDS` to a single dogfood account; confirm DD logs show that account hitting the CH path while everyone else still hits Orb. Bump `FLAG_BILLING_USAGE_CLICKHOUSE_ROLLOUT_PERCENTAGE` only after the allowlist proves stable.