### PR TITLE
fix(invite): send login link to existing users instead of signup link

### DIFF
--- a/packages/server/lib/controllers/v1/account/managed/auth.ts
+++ b/packages/server/lib/controllers/v1/account/managed/auth.ts
@@ -153,7 +153,11 @@ export async function finalizeManagedAuthentication({
             name = nanoid();
         }
 
-        if (organizationId) {
+        if (invitation) {
+            // Invitation takes priority over org membership — user joins the invited team
+            isNewTeam = false;
+            account = (await accountService.getAccountById(db.knex, invitation.account_id))!;
+        } else if (organizationId) {
             const organization = await workos.organizations.getOrganization(organizationId);
 
             const resAccount = await accountService.getOrCreateAccount(organization.name);
@@ -163,13 +167,7 @@ export async function finalizeManagedAuthentication({
             }
 
             account = resAccount;
-
-            if (!invitation) {
-                await expirePreviousInvitations({ accountId: account.id, email: authorizedUser.email, trx: db.knex });
-            }
-        } else if (invitation) {
-            isNewTeam = false;
-            account = (await accountService.getAccountById(db.knex, invitation.account_id))!;
+            await expirePreviousInvitations({ accountId: account.id, email: authorizedUser.email, trx: db.knex });
         } else {
             if (!envs.AUTH_ALLOW_SIGNUP) {
                 res.status(403).send({ error: { code: 'forbidden', message: 'Signup is disabled.' } });

--- a/packages/server/lib/controllers/v1/account/managed/auth.ts
+++ b/packages/server/lib/controllers/v1/account/managed/auth.ts
@@ -220,17 +220,13 @@ export async function finalizeManagedAuthentication({
     }
 
     try {
-        if (invitation) {
+        if (invitation && isNewUser) {
+            // New user: created directly in the invited team, auto-accept and proceed
             await acceptInvitation(invitation.token);
-            const updated = await userService.update({ id: user.id, account_id: invitation.account_id });
-            if (!updated) {
-                res.status(500).send({ error: { code: 'server_error', message: 'failed to update user team' } });
-                return;
-            }
-
-            // @ts-expect-error you got to love passport
-            req.session.passport.user.account_id = invitation.account_id;
             respondWithSuccess(res, `${basePublicUrl}/`, responseMode);
+        } else if (invitation) {
+            // Existing user: log them in and let them explicitly accept or decline on the invite page
+            respondWithSuccess(res, `${basePublicUrl}/signup/${invitation.token}`, responseMode);
         } else if (isNewUser) {
             respondWithSuccess(res, `${basePublicUrl}/onboarding/hear-about-us`, responseMode);
         } else {

--- a/packages/server/lib/controllers/v1/invite/postInvite.ts
+++ b/packages/server/lib/controllers/v1/invite/postInvite.ts
@@ -67,7 +67,7 @@ export const postInvite = asyncWrapper<PostInvite>(async (req, res) => {
             return;
         }
 
-        await sendInviteEmail({ email, account, user, invitation });
+        await sendInviteEmail({ email, account, user, invitation, isExistingUser: !!existingUser });
         invited.push(email);
     }
 

--- a/packages/server/lib/controllers/v1/invite/postInvite.unit.test.ts
+++ b/packages/server/lib/controllers/v1/invite/postInvite.unit.test.ts
@@ -99,4 +99,57 @@ describe('postInvite', () => {
         expect(status).toHaveBeenCalledWith(200);
         expect(send).toHaveBeenCalledWith({ data: { invited: ['invitee@example.com'] } });
     });
+
+    it('sends isExistingUser=false for new users', async () => {
+        mockGetUserByEmail.mockResolvedValue(null);
+
+        const req = {
+            body: { emails: ['newuser@example.com'] },
+            query: { env: 'dev' },
+            route: { path: '/api/v1/invite' },
+            originalUrl: '/api/v1/invite',
+            header: vi.fn()
+        } as unknown as Request;
+        const { res } = createResponse();
+
+        await postInvite(req, res, vi.fn());
+
+        expect(mockSendInviteEmail).toHaveBeenCalledWith(expect.objectContaining({ email: 'newuser@example.com', isExistingUser: false }));
+    });
+
+    it('sends isExistingUser=true when invitee already has an account on a different team', async () => {
+        mockGetUserByEmail.mockResolvedValue({ id: 99, account_id: 999 });
+
+        const req = {
+            body: { emails: ['existing@example.com'] },
+            query: { env: 'dev' },
+            route: { path: '/api/v1/invite' },
+            originalUrl: '/api/v1/invite',
+            header: vi.fn()
+        } as unknown as Request;
+        const { res } = createResponse();
+
+        await postInvite(req, res, vi.fn());
+
+        expect(mockSendInviteEmail).toHaveBeenCalledWith(expect.objectContaining({ email: 'existing@example.com', isExistingUser: true }));
+    });
+
+    it('skips invite when invitee is already a member of the same team', async () => {
+        mockGetUserByEmail.mockResolvedValue({ id: 99, account_id: 1 }); // same account_id as res.locals.account.id
+
+        const req = {
+            body: { emails: ['member@example.com'] },
+            query: { env: 'dev' },
+            route: { path: '/api/v1/invite' },
+            originalUrl: '/api/v1/invite',
+            header: vi.fn()
+        } as unknown as Request;
+        const { res, send, status } = createResponse();
+
+        await postInvite(req, res, vi.fn());
+
+        expect(mockSendInviteEmail).not.toHaveBeenCalled();
+        expect(status).toHaveBeenCalledWith(200);
+        expect(send).toHaveBeenCalledWith({ data: { invited: [] } });
+    });
 });

--- a/packages/server/lib/helpers/email.ts
+++ b/packages/server/lib/helpers/email.ts
@@ -44,14 +44,21 @@ export async function sendInviteEmail({
     email,
     account,
     user,
-    invitation
+    invitation,
+    isExistingUser = false
 }: {
     email: string;
     account: DBTeam;
     user: Pick<DBUser, 'name'>;
     invitation: DBInvitation;
+    isExistingUser?: boolean;
 }) {
     const emailClient = EmailClient.getInstance();
+    const inviteLink = isExistingUser ? `${basePublicUrl}/signin?next=/signup/${invitation.token}` : `${basePublicUrl}/signup/${invitation.token}`;
+    const callToAction = isExistingUser
+        ? `Log in to accept the invitation by clicking <a href="${inviteLink}">here</a>.`
+        : `Join this team by clicking <a href="${inviteLink}">here</a> and completing your signup.`;
+
     await emailClient.send(
         email,
         `You're Invited! Join "${account.name}" on Nango`,
@@ -59,7 +66,7 @@ export async function sendInviteEmail({
 
 <p>${he.encode(user.name)} invites you to join "${he.encode(account.name)}" on Nango.</p>
 
-<p>Join this team by clicking <a href="${basePublicUrl}/signup/${invitation.token}">here</a> and completing your signup.</p>
+<p>${callToAction}</p>
 
 <p>Questions or issues? We are happy to help on the <a href="https://nango.dev/slack">Slack community</a>!</p>
 

--- a/packages/webapp/src/pages/Account/InviteSignup.tsx
+++ b/packages/webapp/src/pages/Account/InviteSignup.tsx
@@ -150,7 +150,7 @@ export const InviteSignup: React.FC = () => {
                 <div className="flex flex-col gap-4 items-center w-full">
                     <SignupForm invitation={inviteData.invitation} token={token} />
                     <span className="text-body-medium-regular text-text-tertiary">
-                        Already have an account? <StyledLink to="/signin">Log in.</StyledLink>
+                        Already have an account? <StyledLink to={`/signin?next=/signup/${token}`}>Log in.</StyledLink>
                     </span>
                 </div>
             )}

--- a/packages/webapp/src/pages/Account/Signin.tsx
+++ b/packages/webapp/src/pages/Account/Signin.tsx
@@ -39,6 +39,8 @@ export const Signin: React.FC = () => {
 
     const [searchParams, setSearchParams] = useSearchParams();
     const error = searchParams.get('error');
+    const next = searchParams.get('next');
+    const inviteToken = next?.match(/^\/signup\/([^/]+)$/)?.[1];
 
     const [errorMessage, setServerErrorMessage] = useState(() => {
         if (error === 'sso_session_expired') {
@@ -69,7 +71,7 @@ export const Signin: React.FC = () => {
             if (res.status === 200) {
                 const user: ApiUser = res.json.user;
                 signin(user);
-                navigate('/');
+                navigate(next && next.startsWith('/') && !next.startsWith('//') ? next : '/');
             } else if (res.status === 401) {
                 setServerErrorMessage('Invalid email or password.');
                 form.resetField('password', { defaultValue: '' });
@@ -213,7 +215,7 @@ export const Signin: React.FC = () => {
                             </div>
                         )}
 
-                        <GoogleButton text="Sign in with Google" setServerErrorMessage={setServerErrorMessage} />
+                        <GoogleButton text="Sign in with Google" setServerErrorMessage={setServerErrorMessage} token={inviteToken} />
                     </div>
                 )}
 

--- a/packages/webapp/src/pages/Account/components/SignupForm.tsx
+++ b/packages/webapp/src/pages/Account/components/SignupForm.tsx
@@ -46,9 +46,11 @@ export const SignupForm: React.FC<{ invitation?: ApiInvitation; token?: string }
 
     const [serverErrorMessage, setServerErrorMessage] = useState('');
     const [showResendEmail, setShowResendEmail] = useState(false);
+    const [showLoginForInvite, setShowLoginForInvite] = useState(false);
 
     const onSubmitForm = async (data: SignupFormData) => {
         setServerErrorMessage('');
+        setShowLoginForInvite(false);
         try {
             const res = await signupMutation(token ? { ...data, token } : data);
             if (res.status === 200) {
@@ -61,6 +63,12 @@ export const SignupForm: React.FC<{ invitation?: ApiInvitation; token?: string }
                         toast({ title: 'You are now a member of the team', variant: 'success' });
                     }
                 }
+                return;
+            }
+
+            if (res.json.error.code === 'user_already_exists' && token) {
+                setShowResendEmail(false);
+                setShowLoginForInvite(true);
                 return;
             }
 
@@ -97,6 +105,16 @@ export const SignupForm: React.FC<{ invitation?: ApiInvitation; token?: string }
     return (
         <div className="flex flex-col gap-10 w-full">
             <div className="flex flex-col gap-5 w-full">
+                {showLoginForInvite && (
+                    <Alert variant="error">
+                        <CircleX />
+                        <AlertDescription>
+                            An account with this email already exists. <StyledLink to={`/signin?next=/signup/${token}`}>Log in</StyledLink> to accept the
+                            invitation.
+                        </AlertDescription>
+                    </Alert>
+                )}
+
                 {serverErrorMessage && !showResendEmail && (
                     <Alert variant="error">
                         <CircleX />


### PR DESCRIPTION
## Describe the problem and your solution

**Problem:** 
Existing users receiving a team invite would hit a dead end, the invite email sent them to `/signup/:token`, they'd fill the form, and get "User with this email already exists" with no way forward.

**Changes:**
- At the email level, we now detect whether the invitee already has a Nango account at send time. If they do, the invite email links them to the login page with a redirect back to the invite, so they land on the Accept/Decline page immediately after signing in instead of a signup form that rejects them.

- On the frontend, the signin page now respects a ?next= redirect param and preserves the invite token through the google OAuth flow, so both email/password and Google auth users arrive at the right place.

- For google managed auth, existing users with an invite token are no longer silently switched to the new team, they're redirected to the invite page to explicitly accept or decline. Also fixed a deeper issue where sso org users with a pending invite were being created in the wrong account, causing billing to be provisioned on the org account before the user was moved to the invited team.



<!-- Issue ticket number and link (if applicable) -->

<!-- Testing instructions (skip if just adding/editing providers) -->

