### PR TITLE
perf(records): decrypt records with bounded concurrency in getRecords

### DIFF
--- a/packages/records/lib/stores/postgres/postgres.integration.test.ts
+++ b/packages/records/lib/stores/postgres/postgres.integration.test.ts
@@ -968,6 +968,43 @@ describe('PostgresStore', () => {
                 expect(next_cursor).toBeNull();
             });
         });
+
+        describe('bounded decrypt concurrency (RECORDS_DECRYPT_CONCURRENCY)', () => {
+            const originalConcurrency = envs.RECORDS_DECRYPT_CONCURRENCY;
+            afterAll(() => {
+                (envs as any).RECORDS_DECRYPT_CONCURRENCY = originalConcurrency;
+            });
+
+            // The decrypt loop processes records in chunks of RECORDS_DECRYPT_CONCURRENCY. A
+            // concurrency smaller than the page size forces several chunks, exercising the chunk
+            // boundary while results must stay in order (the cursor depends on the last element).
+            it.each([1, 3, 7])('Should decrypt every record in order with concurrency=%i', async (concurrency) => {
+                (envs as any).RECORDS_DECRYPT_CONCURRENCY = concurrency;
+
+                const numOfRecords = 25;
+                const { connectionId, model } = await upsertNRecords(numOfRecords);
+
+                const response = await store.getRecords({ connectionId, model, limit: numOfRecords });
+                expect(response.isOk()).toBe(true);
+                const { records } = response.unwrap();
+
+                // Completeness: no record dropped or duplicated across chunk boundaries.
+                expect(records.length).toBe(numOfRecords);
+                expect(new Set(records.map((r) => r['id'])).size).toBe(numOfRecords);
+
+                // Correctness: payload decrypted back to the original value.
+                for (const r of records) {
+                    expect(r['name']).toBe(`record ${r['id']}`);
+                }
+
+                // Order preserved: first_seen_at is non-decreasing regardless of chunking.
+                for (let i = 1; i < records.length; i++) {
+                    const cur = dayjs(records[i]?._nango_metadata.first_seen_at);
+                    const prev = dayjs(records[i - 1]?._nango_metadata.first_seen_at);
+                    expect(cur.isAfter(prev) || cur.isSame(prev)).toBe(true);
+                }
+            });
+        });
     }, 60_000);
 
     describe('deleteOutdatedRecords', () => {

--- a/packages/records/lib/stores/postgres/postgres.integration.test.ts
+++ b/packages/records/lib/stores/postgres/postgres.integration.test.ts
@@ -975,33 +975,35 @@ describe('PostgresStore', () => {
                 (envs as any).RECORDS_DECRYPT_CONCURRENCY = originalConcurrency;
             });
 
-            // The decrypt loop processes records in chunks of RECORDS_DECRYPT_CONCURRENCY. A
-            // concurrency smaller than the page size forces several chunks, exercising the chunk
-            // boundary while results must stay in order (the cursor depends on the last element).
-            it.each([1, 3, 7])('Should decrypt every record in order with concurrency=%i', async (concurrency) => {
-                (envs as any).RECORDS_DECRYPT_CONCURRENCY = concurrency;
-
+            // The decrypt loop processes records in chunks of RECORDS_DECRYPT_CONCURRENCY. The
+            // concern is that splitting a page into concurrent chunks could drop, duplicate or
+            // reorder records. We read the same dataset at several concurrencies (1 forces one
+            // record per chunk, the others straddle the chunk boundary) and assert the result is
+            // identical to a serial baseline, so any reordering across chunks would fail.
+            it('Should return the same records in the same order regardless of concurrency', async () => {
                 const numOfRecords = 25;
                 const { connectionId, model } = await upsertNRecords(numOfRecords);
 
-                const response = await store.getRecords({ connectionId, model, limit: numOfRecords });
-                expect(response.isOk()).toBe(true);
-                const { records } = response.unwrap();
+                const orderAt = async (concurrency: number) => {
+                    (envs as any).RECORDS_DECRYPT_CONCURRENCY = concurrency;
+                    const response = await store.getRecords({ connectionId, model, limit: numOfRecords });
+                    expect(response.isOk()).toBe(true);
+                    return response.unwrap().records;
+                };
 
-                // Completeness: no record dropped or duplicated across chunk boundaries.
-                expect(records.length).toBe(numOfRecords);
-                expect(new Set(records.map((r) => r['id'])).size).toBe(numOfRecords);
+                const baseline = await orderAt(1);
 
-                // Correctness: payload decrypted back to the original value.
-                for (const r of records) {
+                // Completeness + correctness on the baseline.
+                expect(baseline.length).toBe(numOfRecords);
+                expect(new Set(baseline.map((r) => r['id'])).size).toBe(numOfRecords);
+                for (const r of baseline) {
                     expect(r['name']).toBe(`record ${r['id']}`);
                 }
 
-                // Order preserved: first_seen_at is non-decreasing regardless of chunking.
-                for (let i = 1; i < records.length; i++) {
-                    const cur = dayjs(records[i]?._nango_metadata.first_seen_at);
-                    const prev = dayjs(records[i - 1]?._nango_metadata.first_seen_at);
-                    expect(cur.isAfter(prev) || cur.isSame(prev)).toBe(true);
+                const baselineIds = baseline.map((r) => r['id']);
+                for (const concurrency of [3, 7, numOfRecords + 1]) {
+                    const ids = (await orderAt(concurrency)).map((r) => r['id']);
+                    expect(ids).toEqual(baselineIds);
                 }
             });
         });

--- a/packages/records/lib/stores/postgres/postgres.ts
+++ b/packages/records/lib/stores/postgres/postgres.ts
@@ -390,25 +390,39 @@ export class PostgresStore implements RecordsStore {
 
             const decryptSpan = tracer.startSpan('nango.records.decrypt', { childOf: span });
             try {
-                // TODO: decrypt in batch
-                for (const item of recordsMetadata) {
-                    const data = dataById.get(item.id) ?? item.json ?? {};
-                    // Drop the only remaining reference to the encrypted blob so V8 can
-                    // reclaim it when GC fires under heap pressure.
-                    dataById.delete(item.id);
-                    const decryptedData = await decryptRecordData({ ...item, json: data });
-                    results.push({
-                        ...decryptedData,
-                        id: item.external_id, // record payload can be empty (when pruned), always use external_id as id
-                        _nango_metadata: {
-                            first_seen_at: item.first_seen_at,
-                            last_modified_at: item.last_modified_at,
-                            last_action: item.last_action,
-                            deleted_at: item.deleted_at,
-                            pruned_at: item.pruned_at,
-                            cursor: Cursor.new(item)
-                        }
-                    });
+                // decryptRecordData offloads to the libuv threadpool, so awaiting one record at a
+                // time leaves the other threads idle. We process in bounded chunks instead: each
+                // chunk decrypts concurrently (saturating the threadpool) while never holding more
+                // than RECORDS_DECRYPT_CONCURRENCY encrypted blobs / decrypted results live at once,
+                // preserving the per-record GC drop. Results stay in recordsMetadata order, which
+                // the cursor below depends on.
+                const concurrency = envs.RECORDS_DECRYPT_CONCURRENCY;
+                for (let start = 0; start < recordsMetadata.length; start += concurrency) {
+                    const chunk = recordsMetadata.slice(start, start + concurrency);
+                    const decryptedChunk = await Promise.all(
+                        chunk.map(async (item) => {
+                            const data = dataById.get(item.id) ?? item.json ?? {};
+                            // Drop the only remaining reference to the encrypted blob so V8 can
+                            // reclaim it when GC fires under heap pressure.
+                            dataById.delete(item.id);
+                            const decryptedData = await decryptRecordData({ ...item, json: data });
+                            return {
+                                ...decryptedData,
+                                id: item.external_id, // record payload can be empty (when pruned), always use external_id as id
+                                _nango_metadata: {
+                                    first_seen_at: item.first_seen_at,
+                                    last_modified_at: item.last_modified_at,
+                                    last_action: item.last_action,
+                                    deleted_at: item.deleted_at,
+                                    pruned_at: item.pruned_at,
+                                    cursor: Cursor.new(item)
+                                }
+                            };
+                        })
+                    );
+                    for (const decrypted of decryptedChunk) {
+                        results.push(decrypted);
+                    }
                 }
             } finally {
                 decryptSpan.finish();

--- a/packages/records/lib/stores/postgres/postgres.ts
+++ b/packages/records/lib/stores/postgres/postgres.ts
@@ -420,9 +420,7 @@ export class PostgresStore implements RecordsStore {
                             };
                         })
                     );
-                    for (const decrypted of decryptedChunk) {
-                        results.push(decrypted);
-                    }
+                    results.push(...decryptedChunk);
                 }
             } finally {
                 decryptSpan.finish();

--- a/packages/utils/lib/environment/parse.ts
+++ b/packages/utils/lib/environment/parse.ts
@@ -421,6 +421,11 @@ export const ENVS = z.object({
     RECORDS_MAX_RESPONSE_SIZE_BYTES: z.coerce.number().optional().default(0),
     // When true, the budget only emits a metric instead of truncating — used to size the limit before enforcing.
     RECORDS_MAX_RESPONSE_SIZE_DRY_RUN: z.stringbool().optional().default(true),
+    // Max number of records decrypted concurrently in getRecords. decryptAsync offloads to the
+    // libuv threadpool (UV_THREADPOOL_SIZE, default 4), so awaiting one record at a time leaves
+    // the other threads idle. Bounding the fan-out keeps every thread busy without materializing
+    // a whole page of decrypted blobs at once (which would defeat the per-record GC drop below).
+    RECORDS_DECRYPT_CONCURRENCY: z.coerce.number().int().positive().optional().default(10),
 
     // Redis (system boundary)
     NANGO_REDIS_URL: z.url().optional(),


### PR DESCRIPTION
## What

`getRecords` decrypted records one at a time in a serial `await` loop. `decryptRecordData` uses `crypto.subtle.decrypt`, which offloads to the libuv threadpool, so awaiting per record kept only one threadpool worker busy on the hottest data-read path while the rest sat idle.

## Change

Process records in chunks of `RECORDS_DECRYPT_CONCURRENCY` (default 10): each chunk decrypts concurrently to saturate the threadpool, while never holding more than one chunk of blobs live — preserving the existing per-record GC drop that keeps a full page of decrypted blobs from being materialized at once. Results stay in order, so the page cursor is unaffected.

## Test

Adds an integration test covering completeness, correctness, and ordering across chunk boundaries at concurrency 1, 3, 7. Full `ts-build` and the new tests pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)