### PR TITLE
refactor: break circular dependencies in shared package

### DIFF
--- a/packages/shared/lib/clients/orchestrator.ts
+++ b/packages/shared/lib/clients/orchestrator.ts
@@ -5,10 +5,10 @@ import { v4 as uuid } from 'uuid';
 import db from '@nangohq/database';
 import { Err, Ok, errorToObject, getCheckpointKey, getFrequencyMs, stringifyError } from '@nangohq/utils';
 
-import { hardDeleteCheckpoints } from '../index.js';
 import { LogActionEnum } from '../models/Telemetry.js';
 import { SyncCommand, SyncStatus } from '../models/index.js';
 import accountService from '../services/account.service.js';
+import { hardDeleteCheckpoints } from '../services/checkpoints/checkpoints.js';
 import { getSyncConfigRaw } from '../services/sync/config/config.service.js';
 import { isSyncJobRunning, updateSyncJobStatus } from '../services/sync/job.service.js';
 import { clearLastSyncDate } from '../services/sync/sync.service.js';

--- a/packages/shared/lib/services/config.service.ts
+++ b/packages/shared/lib/services/config.service.ts
@@ -1,8 +1,8 @@
 import db from '@nangohq/database';
 import { Err, Ok, isCloud, nanoid } from '@nangohq/utils';
 
+import * as gettingStartedService from './getting-started.service.js';
 import { getProvider } from './providers.js';
-import { gettingStartedService } from '../index.js';
 import syncManager from './sync/manager.service.js';
 import { deleteByConfigId as deleteSyncConfigByConfigId, deleteSyncFilesForConfig } from '../services/sync/config/config.service.js';
 import encryptionManager from '../utils/encryption.manager.js';

--- a/packages/shared/lib/services/environment.service.ts
+++ b/packages/shared/lib/services/environment.service.ts
@@ -4,16 +4,18 @@ import db from '@nangohq/database';
 import { report, useLambdaKeepWarm } from '@nangohq/utils';
 
 import { PROD_ENVIRONMENT_NAME } from '../constants.js';
-import { configService, externalWebhookService, getGlobalOAuthCallbackUrl } from '../index.js';
+import configService from './config.service.js';
 import customerKeyService from './customerKey.service.js';
+import * as externalWebhookService from './external-webhook.service.js';
 import { pubsub } from '../utils/pubsub.js';
 import { getPlan, lambdaKeepWarmProvisionedConcurrencyMultiplier } from './plans/plans.js';
 import secretService from './secret.service.js';
 import { LogActionEnum } from '../models/Telemetry.js';
 import encryptionManager from '../utils/encryption.manager.js';
 import errorManager, { ErrorSourceEnum } from '../utils/error.manager.js';
+import { getGlobalOAuthCallbackUrl } from '../utils/utils.js';
 
-import type { Orchestrator } from '../index.js';
+import type { Orchestrator } from '../clients/orchestrator.js';
 import type { Knex } from '@nangohq/database';
 import type { DBEnvironment, DBEnvironmentVariable, SdkLogger } from '@nangohq/types';
 


### PR DESCRIPTION
Replaces barrel back-imports with direct source imports to eliminate 36 circular dependency cycles in packages/shared/lib/index.ts.