### PR TITLE
fix: end user deletion timeouts

### DIFF
--- a/packages/database/lib/migrations/20260608140000_end_users_fk_indexes.cjs
+++ b/packages/database/lib/migrations/20260608140000_end_users_fk_indexes.cjs
@@ -1,0 +1,26 @@
+exports.config = { transaction: false };
+
+/**
+ * @param {import('knex').Knex} knex
+ */
+exports.up = async function (knex) {
+    await knex.raw(
+        `CREATE INDEX CONCURRENTLY IF NOT EXISTS "idx_nango_connections_end_user_id"
+        ON "_nango_connections" ("end_user_id")
+        WHERE "end_user_id" IS NOT NULL`
+    );
+    await knex.raw(
+        `CREATE INDEX CONCURRENTLY IF NOT EXISTS "idx_connect_sessions_end_user_id"
+        ON "connect_sessions" ("end_user_id")
+        WHERE "end_user_id" IS NOT NULL`
+    );
+    await knex.raw(
+        `CREATE INDEX CONCURRENTLY IF NOT EXISTS "idx_end_users_environment_id"
+        ON "end_users" ("environment_id")`
+    );
+};
+
+/**
+ * @param {import('knex').Knex} knex
+ */
+exports.down = async function () {};


### PR DESCRIPTION
Each delete from `end_users` caused a full sequential scan on `connections` and `connect_sessions` tables to enforce the FK constraint because there were no index on end_user_id in either table. Making the deletion of some environments time out

The seq scan on `end_users` also lacked an index for the environment_id lookups made on deletion.

query plan before
```
Delete on end_users  (cost=9385.78..12492.59 rows=0 width=0) (actual time=17798.463..17798.465 rows=0 loops=1)
  Buffers: shared hit=8571
  ->  Nested Loop  (cost=9385.78..12492.59 rows=414 width=34) (actual time=24.061..25.657 rows=496 loops=1)
        Buffers: shared hit=7575
        ->  HashAggregate  (cost=9385.36..9389.50 rows=414 width=32) (actual time=24.043..24.206 rows=496 loops=1)
              Group Key: "ANY_subquery".id
              Batches: 1  Memory Usage: 105kB
              Buffers: shared hit=5591
              ->  Subquery Scan on "ANY_subquery"  (cost=0.00..9384.33 rows=414 width=32) (actual time=4.015..23.893 rows=496 loops=1)
                    Buffers: shared hit=5591
                    ->  Limit  (cost=0.00..9380.19 rows=414 width=4) (actual time=3.983..23.775 rows=496 loops=1)
                          Buffers: shared hit=5591
                          ->  Seq Scan on end_users end_users_1  (cost=0.00..9380.19 rows=414 width=4) (actual time=3.983..23.731 rows=496 loops=1)
                                Filter: (environment_id = 17814)
                                Rows Removed by Filter: 302983
                                Buffers: shared hit=5591
        ->  Index Scan using end_users_pkey on end_users  (cost=0.42..7.51 rows=1 width=10) (actual time=0.002..0.002 rows=1 loops=496)
              Index Cond: (id = "ANY_subquery".id)
              Buffers: shared hit=1984
Planning:
  Buffers: shared hit=11
Planning Time: 0.159 ms
Trigger for constraint _nango_connections_end_user_id_fkey: time=166567.446 calls=496
Trigger for constraint connect_sessions_end_user_id_fkey: time=31793.984 calls=496
Execution Time: 216161.297 ms
```

query plan after
```
Delete on end_users  (cost=1297.43..4404.24 rows=0 width=0) (actual time=0.012..0.013 rows=0 loops=1)
  Buffers: shared hit=3
  ->  Nested Loop  (cost=1297.43..4404.24 rows=414 width=34) (actual time=0.011..0.012 rows=0 loops=1)
        Buffers: shared hit=3
        ->  HashAggregate  (cost=1297.01..1301.15 rows=414 width=32) (actual time=0.011..0.011 rows=0 loops=1)
              Group Key: "ANY_subquery".id
              Batches: 1  Memory Usage: 37kB
              Buffers: shared hit=3
              ->  Subquery Scan on "ANY_subquery"  (cost=7.63..1295.97 rows=414 width=32) (actual time=0.009..0.009 rows=0 loops=1)
                    Buffers: shared hit=3
                    ->  Limit  (cost=7.63..1291.83 rows=414 width=4) (actual time=0.008..0.009 rows=0 loops=1)
                          Buffers: shared hit=3
                          ->  Bitmap Heap Scan on end_users end_users_1  (cost=7.63..1291.83 rows=414 width=4) (actual time=0.008..0.008 rows=0 loops=1)
                                Recheck Cond: (environment_id = 17814)
                                Buffers: shared hit=3
                                ->  Bitmap Index Scan on idx_end_users_environment_id  (cost=0.00..7.53 rows=414 width=0) (actual time=0.006..0.006 rows=0 loops=1)
                                      Index Cond: (environment_id = 17814)
                                      Buffers: shared hit=3
        ->  Index Scan using end_users_pkey on end_users  (cost=0.42..7.51 rows=1 width=10) (never executed)
              Index Cond: (id = "ANY_subquery".id)
Planning:
  Buffers: shared hit=30
Planning Time: 0.220 ms
Execution Time: 0.053 ms
```

