### PR TITLE
fix(runner): retry httpFetch on UND_ERR_SOCKET and HTTP 5xx/429

### DIFF
--- a/packages/runner/lib/clients/http.ts
+++ b/packages/runner/lib/clients/http.ts
@@ -47,29 +47,30 @@ export async function httpFetch(url: string | URL, options?: HttpFetchOptions, b
 
     try {
         return await retryWithBackoff(async () => {
+            let res: Response;
             try {
-                const res = await fetch(url, fetchOptions);
-
-                if (!res.ok) {
-                    logger.error(`${method} ${url.toString()} -> ${res.status} ${res.statusText}`);
-                }
-
-                if (shouldRetry(null, res)) {
-                    throw new Error(`${method} ${url.toString()} -> ${res.status} ${res.statusText}`);
-                }
-
-                return res;
+                res = await fetch(url, fetchOptions);
             } catch (err) {
                 if (shouldRetry(err)) {
                     throw err;
                 }
 
-                // Non-retryable error
+                // Non-retryable network error
                 return new Response(JSON.stringify({ error: stringifyError(err, { cause: true }) }), {
                     status: 502,
                     headers: { 'Content-Type': 'application/json' }
                 });
             }
+
+            if (!res.ok) {
+                logger.error(`${method} ${url.toString()} -> ${res.status} ${res.statusText}`);
+            }
+
+            if (shouldRetry(null, res)) {
+                throw new Error(`${method} ${url.toString()} -> ${res.status} ${res.statusText}`);
+            }
+
+            return res;
         }, backoffOptions);
     } catch (err) {
         // All retries exhausted

--- a/packages/runner/lib/clients/http.unit.test.ts
+++ b/packages/runner/lib/clients/http.unit.test.ts
@@ -1,0 +1,89 @@
+import { afterEach, describe, expect, it, vi } from 'vitest';
+
+import { httpFetch } from './http.js';
+
+const url = 'http://example.com';
+
+function makeSocketError(): Error {
+    return Object.assign(new Error('other side closed'), { code: 'UND_ERR_SOCKET' });
+}
+
+afterEach(() => {
+    vi.unstubAllGlobals();
+});
+
+describe('httpFetch', () => {
+    describe('UND_ERR_SOCKET', () => {
+        it('retries and succeeds when fetch eventually resolves', async () => {
+            const fetchMock = vi
+                .fn()
+                .mockRejectedValueOnce(makeSocketError())
+                .mockRejectedValueOnce(makeSocketError())
+                .mockResolvedValueOnce(new Response('ok', { status: 200 }));
+            vi.stubGlobal('fetch', fetchMock);
+
+            const res = await httpFetch(url, undefined, { numOfAttempts: 3, startingDelay: 0 });
+
+            expect(fetchMock).toHaveBeenCalledTimes(3);
+            expect(res.status).toBe(200);
+        });
+
+        it('returns 502 after all retries exhausted', async () => {
+            vi.stubGlobal('fetch', vi.fn().mockRejectedValue(makeSocketError()));
+
+            const res = await httpFetch(url, undefined, { numOfAttempts: 3, startingDelay: 0 });
+
+            expect(res.status).toBe(502);
+        });
+    });
+
+    describe('non-retryable errors', () => {
+        it('returns 502 immediately without retrying', async () => {
+            const fetchMock = vi.fn().mockRejectedValue(new Error('some non-network error'));
+            vi.stubGlobal('fetch', fetchMock);
+
+            const res = await httpFetch(url, undefined, { numOfAttempts: 3, startingDelay: 0 });
+
+            expect(fetchMock).toHaveBeenCalledTimes(1);
+            expect(res.status).toBe(502);
+        });
+    });
+
+    describe('HTTP error responses', () => {
+        it('retries on 500 status', async () => {
+            const fetchMock = vi
+                .fn()
+                .mockResolvedValueOnce(new Response('error', { status: 500 }))
+                .mockResolvedValueOnce(new Response('ok', { status: 200 }));
+            vi.stubGlobal('fetch', fetchMock);
+
+            const res = await httpFetch(url, undefined, { numOfAttempts: 3, startingDelay: 0 });
+
+            expect(fetchMock).toHaveBeenCalledTimes(2);
+            expect(res.status).toBe(200);
+        });
+
+        it('retries on 429 status', async () => {
+            const fetchMock = vi
+                .fn()
+                .mockResolvedValueOnce(new Response('rate limited', { status: 429 }))
+                .mockResolvedValueOnce(new Response('ok', { status: 200 }));
+            vi.stubGlobal('fetch', fetchMock);
+
+            const res = await httpFetch(url, undefined, { numOfAttempts: 3, startingDelay: 0 });
+
+            expect(fetchMock).toHaveBeenCalledTimes(2);
+            expect(res.status).toBe(200);
+        });
+
+        it('does not retry on 400 status', async () => {
+            const fetchMock = vi.fn().mockResolvedValue(new Response('bad request', { status: 400 }));
+            vi.stubGlobal('fetch', fetchMock);
+
+            const res = await httpFetch(url, undefined, { numOfAttempts: 3, startingDelay: 0 });
+
+            expect(fetchMock).toHaveBeenCalledTimes(1);
+            expect(res.status).toBe(400);
+        });
+    });
+});

--- a/packages/utils/lib/retry.ts
+++ b/packages/utils/lib/retry.ts
@@ -115,6 +115,7 @@ export const networkError = [
     'ECONNREFUSED',
     'EHOSTUNREACH',
     'EAI_AGAIN',
+    'UND_ERR_SOCKET',
     ...parseCommaSeparatedEnvList(process.env['NANGO_RETRYABLE_NETWORK_ERRORS'])
 ];
 export const nonRetryableNetworkError = ['ENOTFOUND', 'ERRADDRINUSE'];


### PR DESCRIPTION
Response-based retries (5xx, 429) were silently swallowed: the throw inside the inner try was caught by the inner catch, which saw no error code and returned a 502 instead of re-throwing.

Also adds UND_ERR_SOCKET to the retryable network error list.

