### PR TITLE
feat(kvstore): support rotating IAM tokens for Redis via node-redis v5 credentials provider

### DIFF
--- a/docs/guides/platform/self-hosting.mdx
+++ b/docs/guides/platform/self-hosting.mdx
@@ -253,6 +253,35 @@ Special characters in `RECORDS_DATABASE_URL` must be URL encoded. If it is not s
 Deploying with Render or Heroku automatically generates a persistent database connected to your Nango instance.
 </Tip>
 
+### External Redis
+
+The bundled Redis is fine for local use but not for production. Connect Nango to an external Redis (or Valkey) with either a full URL or discrete variables:
+
+```sh
+NANGO_REDIS_URL=rediss://:<password>@<host>:<port>
+# or
+NANGO_REDIS_HOST=<host>
+NANGO_REDIS_PORT=<port>
+NANGO_REDIS_AUTH=<password>
+```
+
+Use the `rediss://` scheme (or discrete variables, which default to TLS) to enable in-transit encryption.
+
+#### IAM / short-lived token authentication
+
+Managed Redis with IAM authentication (for example GCP Memorystore for Valkey) uses a short-lived token as the password and requires the token to be refreshed before it expires. Instead of a static `NANGO_REDIS_AUTH`, point Nango at a file that an external process (such as a sidecar) keeps up to date:
+
+```sh
+NANGO_REDIS_HOST=<host>
+NANGO_REDIS_PORT=<port>
+NANGO_REDIS_AUTH_TOKEN_FILE=/path/to/token   # re-read on every (re)connect
+NANGO_REDIS_USERNAME=<username>              # optional; defaults to "default"
+```
+
+Nango reads the token file on every connection and reconnection, so a rotated token is always picked up without a restart. This is cloud-agnostic: anything that writes the current token to the file works. The writer must update the file atomically — write a temporary file and `rename()` it into place — so a reconnect never reads a half-written token and fails authentication. When `NANGO_REDIS_AUTH_TOKEN_FILE` is set, do not embed credentials in `NANGO_REDIS_URL`.
+
+The runner boundary has the same set of variables prefixed with `NANGO_CUSTOMER_REDIS_` (for example `NANGO_CUSTOMER_REDIS_AUTH_TOKEN_FILE`); it falls back to the system Redis when unset.
+
 ### Securing your instance
 
 #### Securing the dashboard

--- a/package-lock.json
+++ b/package-lock.json
@@ -331,6 +331,7 @@
             "integrity": "sha512-Thbli+OlOj+iMPYFBVBfJ3OmCAnaSyNn4M1vz9T6Gka5Jt9ba/HIR56joy65tY6kx/FCF5VXNB819Y7/GUrBGA==",
             "dev": true,
             "license": "MIT",
+            "peer": true,
             "dependencies": {
                 "fast-deep-equal": "^3.1.3",
                 "fast-uri": "^3.0.1",
@@ -1855,6 +1856,7 @@
             "resolved": "https://registry.npmjs.org/@babel/core/-/core-7.28.0.tgz",
             "integrity": "sha512-UlLAnTPrFdNGoFtbSXwcGFQBtQZJCNjaN6hQNP3UPvuNXT1i82N26KL3dZeIpNalWywr9IuQuncaAfUaS1g6sQ==",
             "license": "MIT",
+            "peer": true,
             "dependencies": {
                 "@ampproject/remapping": "^2.2.0",
                 "@babel/code-frame": "^7.27.1",
@@ -2608,7 +2610,8 @@
             "version": "2.11.0",
             "resolved": "https://registry.npmjs.org/@bufbuild/protobuf/-/protobuf-2.11.0.tgz",
             "integrity": "sha512-sBXGT13cpmPR5BMgHE6UEEfEaShh5Ror6rfN3yEK5si7QVrtZg8LEPQb0VVhiLRUslD2yLnXtnRzG035J/mZXQ==",
-            "license": "(Apache-2.0 AND BSD-3-Clause)"
+            "license": "(Apache-2.0 AND BSD-3-Clause)",
+            "peer": true
         },
         "node_modules/@bundled-es-modules/deepmerge": {
             "version": "4.3.1",
@@ -2776,6 +2779,7 @@
             "resolved": "https://registry.npmjs.org/@connectrpc/connect/-/connect-2.0.0-rc.3.tgz",
             "integrity": "sha512-ARBt64yEyKbanyRETTjcjJuHr2YXorzQo0etyS5+P6oSeW8xEuzajA9g+zDnMcj1hlX2dQE93foIWQGfpru7gQ==",
             "license": "Apache-2.0",
+            "peer": true,
             "peerDependencies": {
                 "@bufbuild/protobuf": "^2.2.0"
             }
@@ -2956,29 +2960,6 @@
             "integrity": "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==",
             "license": "MIT"
         },
-        "node_modules/@emnapi/core": {
-            "version": "1.9.2",
-            "resolved": "https://registry.npmjs.org/@emnapi/core/-/core-1.9.2.tgz",
-            "integrity": "sha512-UC+ZhH3XtczQYfOlu3lNEkdW/p4dsJ1r/bP7H8+rhao3TTTMO1ATq/4DdIi23XuGoFY+Cz0JmCbdVl0hz9jZcA==",
-            "dev": true,
-            "license": "MIT",
-            "optional": true,
-            "dependencies": {
-                "@emnapi/wasi-threads": "1.2.1",
-                "tslib": "^2.4.0"
-            }
-        },
-        "node_modules/@emnapi/runtime": {
-            "version": "1.9.2",
-            "resolved": "https://registry.npmjs.org/@emnapi/runtime/-/runtime-1.9.2.tgz",
-            "integrity": "sha512-3U4+MIWHImeyu1wnmVygh5WlgfYDtyf0k8AbLhMFxOipihf6nrWC4syIm/SwEeec0mNSafiiNnMJwbza/Is6Lw==",
-            "dev": true,
-            "license": "MIT",
-            "optional": true,
-            "dependencies": {
-                "tslib": "^2.4.0"
-            }
-        },
         "node_modules/@emnapi/wasi-threads": {
             "version": "1.2.1",
             "resolved": "https://registry.npmjs.org/@emnapi/wasi-threads/-/wasi-threads-1.2.1.tgz",
@@ -2996,7 +2977,6 @@
             "integrity": "sha512-pxHCpT2ex+0q+HH91/zsdHkw/lXd468DIN2zvfvLtPKLLMo6gQj7oLObq8PhkrxOZb/gGCq03S3Z7PDhS8pduQ==",
             "dev": true,
             "license": "MIT",
-            "peer": true,
             "dependencies": {
                 "@babel/helper-module-imports": "^7.16.7",
                 "@babel/runtime": "^7.18.3",
@@ -3017,7 +2997,6 @@
             "integrity": "sha512-LbrmJOMUSdEVxIKvdcJzQC+nQhe8FUZQTXQy6+I75skNgn3OoQ0DZA8YnFa7gp8tqtL3KPf1kmo0R5DoApeSGQ==",
             "dev": true,
             "license": "BSD-3-Clause",
-            "peer": true,
             "engines": {
                 "node": ">=0.10.0"
             }
@@ -3028,7 +3007,6 @@
             "integrity": "sha512-L/B1lc/TViYk4DcpGxtAVbx0ZyiKM5ktoIyafGkH6zg/tj+mA+NE//aPYKG0k8kCHSHVJrpLpcAlOBEXQ3SavA==",
             "dev": true,
             "license": "MIT",
-            "peer": true,
             "dependencies": {
                 "@emotion/memoize": "^0.9.0",
                 "@emotion/sheet": "^1.4.0",
@@ -3042,8 +3020,7 @@
             "resolved": "https://registry.npmjs.org/@emotion/hash/-/hash-0.9.2.tgz",
             "integrity": "sha512-MyqliTZGuOm3+5ZRSaaBGP3USLw6+EGykkwZns2EPC5g8jJ4z9OrdZY9apkl3+UP9+sdz76YYkwCKP5gh8iY3g==",
             "dev": true,
-            "license": "MIT",
-            "peer": true
+            "license": "MIT"
         },
         "node_modules/@emotion/is-prop-valid": {
             "version": "1.4.0",
@@ -3094,7 +3071,6 @@
             "integrity": "sha512-EISGqt7sSNWHGI76hC7x1CksiXPahbxEOrC5RjmFRJTqLyEK9/9hZvBbiYn70dw4wuwMKiEMCUlR6ZXTSWQqxA==",
             "dev": true,
             "license": "MIT",
-            "peer": true,
             "dependencies": {
                 "@emotion/hash": "^0.9.2",
                 "@emotion/memoize": "^0.9.0",
@@ -3108,8 +3084,7 @@
             "resolved": "https://registry.npmjs.org/@emotion/sheet/-/sheet-1.4.0.tgz",
             "integrity": "sha512-fTBW9/8r2w3dXWYM4HCB1Rdp8NLibOw2+XELH5m5+AkWiL/KqYX6dc0kKYlaYyKjrQ6ds33MCdMPEwgs2z1rqg==",
             "dev": true,
-            "license": "MIT",
-            "peer": true
+            "license": "MIT"
         },
         "node_modules/@emotion/unitless": {
             "version": "0.10.0",
@@ -3124,7 +3099,6 @@
             "integrity": "sha512-yJMtVdH59sxi/aVJBpk9FQq+OR8ll5GT8oWd57UpeaKEVGab41JWaCFA7FRLoMLloOZF/c/wsPoe+bfGmRKgDg==",
             "dev": true,
             "license": "MIT",
-            "peer": true,
             "peerDependencies": {
                 "react": ">=16.8.0"
             }
@@ -3134,16 +3108,14 @@
             "resolved": "https://registry.npmjs.org/@emotion/utils/-/utils-1.4.2.tgz",
             "integrity": "sha512-3vLclRofFziIa3J2wDh9jjbkUz9qk5Vi3IZ/FSTKViB0k+ef0fPV7dYrUIugbgupYDx7v9ud/SjrtEP8Y4xLoA==",
             "dev": true,
-            "license": "MIT",
-            "peer": true
+            "license": "MIT"
         },
         "node_modules/@emotion/weak-memoize": {
             "version": "0.4.0",
             "resolved": "https://registry.npmjs.org/@emotion/weak-memoize/-/weak-memoize-0.4.0.tgz",
             "integrity": "sha512-snKqtPW01tN0ui7yu9rGv69aJXr/a/Ywvl11sUjNtEcRc+ng/mQriFL0wLXMef74iHa/EkftbDzU9F8iFbH+zg==",
             "dev": true,
-            "license": "MIT",
-            "peer": true
+            "license": "MIT"
         },
         "node_modules/@esbuild/aix-ppc64": {
             "version": "0.27.7",
@@ -3775,7 +3747,6 @@
             "integrity": "sha512-JyNk4A0Ezirq8FlXECvRtQOX/iBe5Ize0W/pLkrZjfHW9GUV7Xnq6zm6fyZuQzaHHqEnVizmvlA96e1/CkZv+w==",
             "dev": true,
             "license": "MIT",
-            "peer": true,
             "dependencies": {
                 "@floating-ui/react-dom": "^1.3.0",
                 "aria-hidden": "^1.1.3",
@@ -3806,7 +3777,6 @@
             "integrity": "sha512-htwHm67Ji5E/pROEAr7f8IKFShuiCKHwUC/UY4vC3I5jiSvGFAYnSYiZO5MlGmads+QqvUkR9ANHEguGrDv72g==",
             "dev": true,
             "license": "MIT",
-            "peer": true,
             "dependencies": {
                 "@floating-ui/dom": "^1.2.1"
             },
@@ -4722,7 +4692,6 @@
             "integrity": "sha512-ZMp1V8ZFcPG5dIWnQLr3NSI1MiCU7UETdS/A0G8V/XWHvJv3ZsFqutJn1Y5RPmAPX6F3BiE397OqveU/9NCuIA==",
             "dev": true,
             "license": "MIT",
-            "peer": true,
             "dependencies": {
                 "@jridgewell/gen-mapping": "^0.3.5",
                 "@jridgewell/trace-mapping": "^0.3.25"
@@ -4734,7 +4703,6 @@
             "integrity": "sha512-zzNR+SdQSDJzc8joaeP8QQoCQr8NuYx2dIIytl1QeBEZHJ9uW6hebsrYgbz8hJwUQao3TWCMtmfV8Nu1twOLAw==",
             "dev": true,
             "license": "MIT",
-            "peer": true,
             "dependencies": {
                 "@jridgewell/resolve-uri": "^3.1.0",
                 "@jridgewell/sourcemap-codec": "^1.4.14"
@@ -5265,7 +5233,6 @@
             "integrity": "sha512-F4tqHSEVM9D6/iSqHfPda+Xl5XgSEPHAAkT01Zwzj4Jnbd10qGrlqr/SFUop2CIcuKYnmra9XltUahUPXBC2BQ==",
             "dev": true,
             "license": "MIT",
-            "peer": true,
             "dependencies": {
                 "@floating-ui/react": "^0.19.1",
                 "@mantine/styles": "5.10.5",
@@ -5285,7 +5252,6 @@
             "integrity": "sha512-Ofwh/1HX69ZfJRiRBMTy7rgjAzHmwe4kW9C9Y99HTRUcYLUuVT0KESFj15rPjRgKJs20GPq8Bm5aEDJ8DuA3vA==",
             "dev": true,
             "license": "MIT",
-            "peer": true,
             "dependencies": {
                 "@babel/runtime": "^7.13.10"
             }
@@ -5296,7 +5262,6 @@
             "integrity": "sha512-3e7rn8FDMin4CgeL7Z/49smCA3rFYY3Ha2rUQ7HRWFadS5iCRw08ZgVT1LaNTCNqgvrUiyczLflrVrF0SRQtNA==",
             "dev": true,
             "license": "MIT",
-            "peer": true,
             "dependencies": {
                 "@babel/runtime": "^7.13.10"
             }
@@ -5307,7 +5272,6 @@
             "integrity": "sha512-0KaSv6sx787/hK3eF53iOkiSLwAGlFMx5lotrqD2pTjB18KbybKoEIgkNZTKC60YECDQTKGTRcDBILwZVqVKvA==",
             "dev": true,
             "license": "MIT",
-            "peer": true,
             "dependencies": {
                 "@babel/runtime": "^7.13.10"
             },
@@ -5321,7 +5285,6 @@
             "integrity": "sha512-1pVM9RfOQ+n/N5PJK33kRSKsr1glNxomxONs5c49MliinBY6Yw2Q995qfBUUo0/Mbg05B/sGA0gkgPI7kmSHBg==",
             "dev": true,
             "license": "MIT",
-            "peer": true,
             "dependencies": {
                 "@babel/runtime": "^7.13.10"
             },
@@ -5335,7 +5298,6 @@
             "integrity": "sha512-2HV05lGUgYcA6xgLQ4BKPDmtL+QbIZYH5fCOTAOOcJ5O0QbWS3i9lKaurLzliYUDhORI2Qr3pyjhJh44lKA3rQ==",
             "dev": true,
             "license": "MIT",
-            "peer": true,
             "dependencies": {
                 "@babel/runtime": "^7.13.10"
             },
@@ -5349,7 +5311,6 @@
             "integrity": "sha512-A+6XEvN01NfVWiKu38ybawfHsBjWum42MRPnEuqPsBZ4eV7e/7K321B5VgYMPv3Xx5An6o1/l9ZuDBgmcmWK3w==",
             "dev": true,
             "license": "MIT",
-            "peer": true,
             "dependencies": {
                 "@babel/runtime": "^7.13.10",
                 "@radix-ui/react-compose-refs": "1.0.0",
@@ -5366,7 +5327,6 @@
             "integrity": "sha512-fHbmislWVkZaIdeF6GZxF0A/NH/3BjrGIYj+Ae6eTmTCr7EB0RQAAVEiqsXK6p3/JcRqVSBQoceZroj30Jj3XA==",
             "dev": true,
             "license": "MIT",
-            "peer": true,
             "dependencies": {
                 "@babel/runtime": "^7.13.10",
                 "@radix-ui/react-slot": "1.0.1"
@@ -5382,7 +5342,6 @@
             "integrity": "sha512-k8VseTxI26kcKJaX0HPwkvlNBPTs56JRdYzcZ/vzrNUkDlvXBy8sMc7WvCpYzZkHgb+hd72VW9MqkqecGtuNgg==",
             "dev": true,
             "license": "MIT",
-            "peer": true,
             "dependencies": {
                 "@babel/runtime": "^7.13.10",
                 "@radix-ui/number": "1.0.0",
@@ -5406,7 +5365,6 @@
             "integrity": "sha512-GZtyzoHz95Rhs6S63D2t/eqvdFCm7I+yHMLVQheKM7nBD8mbZIt+ct1jz4536MDnaOGKIxynJ8eHTkVGVVkoTg==",
             "dev": true,
             "license": "MIT",
-            "peer": true,
             "dependencies": {
                 "@babel/runtime": "^7.13.10"
             },
@@ -5420,7 +5378,6 @@
             "integrity": "sha512-6Tpkq+R6LOlmQb1R5NNETLG0B4YP0wc+klfXafpUCj6JGyaUc8il7/kUZ7m59rGbXGczE9Bs+iz2qloqsZBduQ==",
             "dev": true,
             "license": "MIT",
-            "peer": true,
             "dependencies": {
                 "@babel/runtime": "^7.13.10"
             },
@@ -5460,7 +5417,6 @@
             "integrity": "sha512-0NXk8c/XGzuTUkZc6KceF2NaTCMEu5mHR4ru0x+ttb9DGnLpHuGWduTHjSfr4hl6eAJgedD0zauO+VAhDzO9zA==",
             "dev": true,
             "license": "MIT",
-            "peer": true,
             "dependencies": {
                 "clsx": "1.1.1",
                 "csstype": "3.0.9"
@@ -5477,7 +5433,6 @@
             "integrity": "sha512-6/bPho624p3S2pMyvP5kKBPXnI3ufHLObBFCfgx+LkeR5lg2XYy2hqZqUf45ypD8COn2bhgGJSUE+l5dhNBieA==",
             "dev": true,
             "license": "MIT",
-            "peer": true,
             "engines": {
                 "node": ">=6"
             }
@@ -5487,8 +5442,7 @@
             "resolved": "https://registry.npmjs.org/csstype/-/csstype-3.0.9.tgz",
             "integrity": "sha512-rpw6JPxK6Rfg1zLOYCSwle2GFOOsnjmDYDaBwEcwoOg4qlsIVCN789VkBZDJAGi4T07gI4YSutR43t9Zz4Lzuw==",
             "dev": true,
-            "license": "MIT",
-            "peer": true
+            "license": "MIT"
         },
         "node_modules/@mantine/utils": {
             "version": "5.10.5",
@@ -5973,6 +5927,7 @@
             "resolved": "https://registry.npmjs.org/@opentelemetry/api/-/api-1.9.1.tgz",
             "integrity": "sha512-gLyJlPHPZYdAk1JENA9LeHejZe1Ti77/pTeFm/nMXmQH/HFZlcS/O2XJB+L8fkbrNSqhdtlvjBVjxwUYanNH5Q==",
             "license": "Apache-2.0",
+            "peer": true,
             "engines": {
                 "node": ">=8.0.0"
             }
@@ -5992,6 +5947,7 @@
             "version": "1.30.1",
             "resolved": "https://registry.npmjs.org/@opentelemetry/context-async-hooks/-/context-async-hooks-1.30.1.tgz",
             "integrity": "sha512-s5vvxXPVdjqS3kTLKMeBMvop9hbWkwzBpu+mUO2M7sZtlkyDJGwFe33wRKnbaYDo8ExRVBIIdwIGrqpxHuKttA==",
+            "peer": true,
             "engines": {
                 "node": ">=14"
             },
@@ -6003,6 +5959,7 @@
             "version": "1.30.1",
             "resolved": "https://registry.npmjs.org/@opentelemetry/core/-/core-1.30.1.tgz",
             "integrity": "sha512-OOCM2C/QIURhJMuKaekP3TRBxBKxG/TWWA0TL2J6nXUtDnuCtccy49LUJF8xPFXMX+0LMcxFpCo8M9cGY1W6rQ==",
+            "peer": true,
             "dependencies": {
                 "@opentelemetry/semantic-conventions": "1.28.0"
             },
@@ -6106,6 +6063,7 @@
             "version": "0.57.2",
             "resolved": "https://registry.npmjs.org/@opentelemetry/instrumentation/-/instrumentation-0.57.2.tgz",
             "integrity": "sha512-BdBGhQBh8IjZ2oIIX6F2/Q3LKm/FDDKi6ccYKcBTeilh6SNdNKveDOLk73BkSJjQLJk6qe4Yh+hHw1UPhCDdrg==",
+            "peer": true,
             "dependencies": {
                 "@opentelemetry/api-logs": "0.57.2",
                 "@types/shimmer": "^1.2.0",
@@ -13583,50 +13541,76 @@
             "license": "MIT"
         },
         "node_modules/@redis/bloom": {
-            "version": "1.2.0",
+            "version": "5.12.1",
+            "resolved": "https://registry.npmjs.org/@redis/bloom/-/bloom-5.12.1.tgz",
+            "integrity": "sha512-PUUfv+ms7jgPSBVoo/DN4AkPHj4D5TZSd6SbJX7egzBplkYUcKmHRE8RKia7UtZ8bSQbLguLvxVO+asKtQfZWA==",
             "license": "MIT",
+            "engines": {
+                "node": ">= 18.19.0"
+            },
             "peerDependencies": {
-                "@redis/client": "^1.0.0"
+                "@redis/client": "^5.12.1"
             }
         },
         "node_modules/@redis/client": {
-            "version": "1.5.14",
+            "version": "5.12.1",
+            "resolved": "https://registry.npmjs.org/@redis/client/-/client-5.12.1.tgz",
+            "integrity": "sha512-7aPGWeqA3uFm43o19umzdl16CEjK/JQGtSXVPevplTaOU3VJA/rseBC1QvYUz9lLDIMBimc4SW/zrW4S89BaCA==",
             "license": "MIT",
+            "peer": true,
             "dependencies": {
-                "cluster-key-slot": "1.1.2",
-                "generic-pool": "3.9.0",
-                "yallist": "4.0.0"
+                "cluster-key-slot": "1.1.2"
             },
             "engines": {
-                "node": ">=14"
-            }
-        },
-        "node_modules/@redis/graph": {
-            "version": "1.1.1",
-            "license": "MIT",
+                "node": ">= 18.19.0"
+            },
             "peerDependencies": {
-                "@redis/client": "^1.0.0"
+                "@node-rs/xxhash": "^1.1.0",
+                "@opentelemetry/api": ">=1 <2"
+            },
+            "peerDependenciesMeta": {
+                "@node-rs/xxhash": {
+                    "optional": true
+                },
+                "@opentelemetry/api": {
+                    "optional": true
+                }
             }
         },
         "node_modules/@redis/json": {
-            "version": "1.0.6",
+            "version": "5.12.1",
+            "resolved": "https://registry.npmjs.org/@redis/json/-/json-5.12.1.tgz",
+            "integrity": "sha512-eOze75esLve4vfqDel7aMX08CNaiLLQS2fV8mpRN9NxPe1rVR4vQyYiW/OgtGUysF6QOr9ANhfxABKNOJfXdKg==",
             "license": "MIT",
+            "engines": {
+                "node": ">= 18.19.0"
+            },
             "peerDependencies": {
-                "@redis/client": "^1.0.0"
+                "@redis/client": "^5.12.1"
             }
         },
         "node_modules/@redis/search": {
-            "version": "1.1.6",
+            "version": "5.12.1",
+            "resolved": "https://registry.npmjs.org/@redis/search/-/search-5.12.1.tgz",
+            "integrity": "sha512-ItlxbxC9cKI6IU1TLWoczwJCRb6TdmkEpWv05UrPawqaAnWGRu3rcIqsc5vN483T2fSociuyV1UkWIL5I4//2w==",
             "license": "MIT",
+            "engines": {
+                "node": ">= 18.19.0"
+            },
             "peerDependencies": {
-                "@redis/client": "^1.0.0"
+                "@redis/client": "^5.12.1"
             }
         },
         "node_modules/@redis/time-series": {
-            "version": "1.0.5",
+            "version": "5.12.1",
+            "resolved": "https://registry.npmjs.org/@redis/time-series/-/time-series-5.12.1.tgz",
+            "integrity": "sha512-c6JL6E3EcZJuNqKFz+KM+l9l5mpcQiKvTwgA3blt5glWJ8hjDk0yeHN3beE/MpqYIQ8UEX44ItQzgkE/gCBELQ==",
             "license": "MIT",
+            "engines": {
+                "node": ">= 18.19.0"
+            },
             "peerDependencies": {
-                "@redis/client": "^1.0.0"
+                "@redis/client": "^5.12.1"
             }
         },
         "node_modules/@redocly/ajv": {
@@ -14602,6 +14586,7 @@
             "resolved": "https://registry.npmjs.org/@opentelemetry/semantic-conventions/-/semantic-conventions-1.41.1.tgz",
             "integrity": "sha512-/UhIkaZgPutTFmQ7RnIJGgDXZmtEJ7Dvi86xNTFWcnRxVRNk/aotsqDJYeEvDP+FSMB2SdW+pQzNMcWP0rwuNA==",
             "license": "Apache-2.0",
+            "peer": true,
             "engines": {
                 "node": ">=14"
             }
@@ -15487,6 +15472,7 @@
             "integrity": "sha512-pTzb864TQWDRQBPLgSPFRoyjSDUqpCkbEgTzpsjiTjGz1Z5SxZNXJek28w1s6Dyry4CyW4/Izj5jHE/J9hCJYQ==",
             "dev": true,
             "license": "MIT",
+            "peer": true,
             "engines": {
                 "node": ">=12.16"
             }
@@ -15497,6 +15483,7 @@
             "integrity": "sha512-YWqn+0IKXDhqVLKoac4v2tV6hJqB/wOh8/Br8zjqeqBkKa77Qb0Kw2i7LOFzjFNZbZaPH6AlMGlBwNrxaauaAg==",
             "hasInstallScript": true,
             "license": "Apache-2.0",
+            "peer": true,
             "dependencies": {
                 "@swc/counter": "^0.1.3",
                 "@swc/types": "^0.1.23"
@@ -16512,7 +16499,8 @@
             "funding": [
                 "https://trpc.io/sponsor"
             ],
-            "license": "MIT"
+            "license": "MIT",
+            "peer": true
         },
         "node_modules/@tsconfig/node10": {
             "version": "1.0.9",
@@ -16817,6 +16805,7 @@
             "resolved": "https://registry.npmjs.org/@types/express/-/express-5.0.2.tgz",
             "integrity": "sha512-BtjL3ZwbCQriyb0DGw+Rt12qAXPiBTPs815lsUvtt1Grk0vLRMZNMUZ741d5rjk+UQOxfDiBZ3dxpX00vSkK3g==",
             "dev": true,
+            "peer": true,
             "dependencies": {
                 "@types/body-parser": "*",
                 "@types/express-serve-static-core": "^5.0.0",
@@ -17032,8 +17021,7 @@
             "resolved": "https://registry.npmjs.org/@types/parse-json/-/parse-json-4.0.2.tgz",
             "integrity": "sha512-dISoDXWWQwUquiKsyZ4Ng+HX2KsPL7LyHKHQwgGFEA3IaKac4Obd+h2a/a6waisAoepJlBcx9paWqjA8/HVjCw==",
             "dev": true,
-            "license": "MIT",
-            "peer": true
+            "license": "MIT"
         },
         "node_modules/@types/parse-link-header": {
             "version": "2.0.3",
@@ -17128,6 +17116,7 @@
             "resolved": "https://registry.npmjs.org/@types/react/-/react-18.3.4.tgz",
             "integrity": "sha512-J7W30FTdfCxDDjmfRM+/JqLHBIyl7xUIp9kwK637FGmY7+mkSFSe6L4jpZzhj5QMfLssSDP4/i75AKkrdC7/Jw==",
             "dev": true,
+            "peer": true,
             "dependencies": {
                 "@types/prop-types": "*",
                 "csstype": "^3.0.2"
@@ -17354,6 +17343,7 @@
             "integrity": "sha512-Zhy8HCvBUEfBECzIl1PKqF4p11+d0aUJS1GeUiuqK9WmOug8YCmC4h4bjyBvMyAMI9sbRczmrYL5lKg/YMbrcQ==",
             "dev": true,
             "license": "MIT",
+            "peer": true,
             "dependencies": {
                 "@typescript-eslint/scope-manager": "8.38.0",
                 "@typescript-eslint/types": "8.38.0",
@@ -17841,7 +17831,6 @@
             "integrity": "sha512-nuBEDgQfm1ccRp/8bCQrx1frohyufl4JlbMMZ4P1wpeOfDhF6FQkxZJ1b/e+PLwr6X1Nhw6OLme5usuBWYBvuQ==",
             "dev": true,
             "license": "MIT",
-            "peer": true,
             "dependencies": {
                 "@webassemblyjs/helper-numbers": "1.13.2",
                 "@webassemblyjs/helper-wasm-bytecode": "1.13.2"
@@ -17852,24 +17841,21 @@
             "resolved": "https://registry.npmjs.org/@webassemblyjs/floating-point-hex-parser/-/floating-point-hex-parser-1.13.2.tgz",
             "integrity": "sha512-6oXyTOzbKxGH4steLbLNOu71Oj+C8Lg34n6CqRvqfS2O71BxY6ByfMDRhBytzknj9yGUPVJ1qIKhRlAwO1AovA==",
             "dev": true,
-            "license": "MIT",
-            "peer": true
+            "license": "MIT"
         },
         "node_modules/@webassemblyjs/helper-api-error": {
             "version": "1.13.2",
             "resolved": "https://registry.npmjs.org/@webassemblyjs/helper-api-error/-/helper-api-error-1.13.2.tgz",
             "integrity": "sha512-U56GMYxy4ZQCbDZd6JuvvNV/WFildOjsaWD3Tzzvmw/mas3cXzRJPMjP83JqEsgSbyrmaGjBfDtV7KDXV9UzFQ==",
             "dev": true,
-            "license": "MIT",
-            "peer": true
+            "license": "MIT"
         },
         "node_modules/@webassemblyjs/helper-buffer": {
             "version": "1.14.1",
             "resolved": "https://registry.npmjs.org/@webassemblyjs/helper-buffer/-/helper-buffer-1.14.1.tgz",
             "integrity": "sha512-jyH7wtcHiKssDtFPRB+iQdxlDf96m0E39yb0k5uJVhFGleZFoNw1c4aeIcVUPPbXUVJ94wwnMOAqUHyzoEPVMA==",
             "dev": true,
-            "license": "MIT",
-            "peer": true
+            "license": "MIT"
         },
         "node_modules/@webassemblyjs/helper-numbers": {
             "version": "1.13.2",
@@ -17877,7 +17863,6 @@
             "integrity": "sha512-FE8aCmS5Q6eQYcV3gI35O4J789wlQA+7JrqTTpJqn5emA4U2hvwJmvFRC0HODS+3Ye6WioDklgd6scJ3+PLnEA==",
             "dev": true,
             "license": "MIT",
-            "peer": true,
             "dependencies": {
                 "@webassemblyjs/floating-point-hex-parser": "1.13.2",
                 "@webassemblyjs/helper-api-error": "1.13.2",
@@ -17889,8 +17874,7 @@
             "resolved": "https://registry.npmjs.org/@webassemblyjs/helper-wasm-bytecode/-/helper-wasm-bytecode-1.13.2.tgz",
             "integrity": "sha512-3QbLKy93F0EAIXLh0ogEVR6rOubA9AoZ+WRYhNbFyuB70j3dRdwH9g+qXhLAO0kiYGlg3TxDV+I4rQTr/YNXkA==",
             "dev": true,
-            "license": "MIT",
-            "peer": true
+            "license": "MIT"
         },
         "node_modules/@webassemblyjs/helper-wasm-section": {
             "version": "1.14.1",
@@ -17898,7 +17882,6 @@
             "integrity": "sha512-ds5mXEqTJ6oxRoqjhWDU83OgzAYjwsCV8Lo/N+oRsNDmx/ZDpqalmrtgOMkHwxsG0iI//3BwWAErYRHtgn0dZw==",
             "dev": true,
             "license": "MIT",
-            "peer": true,
             "dependencies": {
                 "@webassemblyjs/ast": "1.14.1",
                 "@webassemblyjs/helper-buffer": "1.14.1",
@@ -17912,7 +17895,6 @@
             "integrity": "sha512-4LtOzh58S/5lX4ITKxnAK2USuNEvpdVV9AlgGQb8rJDHaLeHciwG4zlGr0j/SNWlr7x3vO1lDEsuePvtcDNCkw==",
             "dev": true,
             "license": "MIT",
-            "peer": true,
             "dependencies": {
                 "@xtuc/ieee754": "^1.2.0"
             }
@@ -17923,7 +17905,6 @@
             "integrity": "sha512-Lde1oNoIdzVzdkNEAWZ1dZ5orIbff80YPdHx20mrHwHrVNNTjNr8E3xz9BdpcGqRQbAEa+fkrCb+fRFTl/6sQw==",
             "dev": true,
             "license": "Apache-2.0",
-            "peer": true,
             "dependencies": {
                 "@xtuc/long": "4.2.2"
             }
@@ -17933,8 +17914,7 @@
             "resolved": "https://registry.npmjs.org/@webassemblyjs/utf8/-/utf8-1.13.2.tgz",
             "integrity": "sha512-3NQWGjKTASY1xV5m7Hr0iPeXD9+RDobLll3T9d2AO+g3my8xy5peVyjSag4I50mR1bBSN/Ct12lo+R9tJk0NZQ==",
             "dev": true,
-            "license": "MIT",
-            "peer": true
+            "license": "MIT"
         },
         "node_modules/@webassemblyjs/wasm-edit": {
             "version": "1.14.1",
@@ -17942,7 +17922,6 @@
             "integrity": "sha512-RNJUIQH/J8iA/1NzlE4N7KtyZNHi3w7at7hDjvRNm5rcUXa00z1vRz3glZoULfJ5mpvYhLybmVcwcjGrC1pRrQ==",
             "dev": true,
             "license": "MIT",
-            "peer": true,
             "dependencies": {
                 "@webassemblyjs/ast": "1.14.1",
                 "@webassemblyjs/helper-buffer": "1.14.1",
@@ -17960,7 +17939,6 @@
             "integrity": "sha512-AmomSIjP8ZbfGQhumkNvgC33AY7qtMCXnN6bL2u2Js4gVCg8fp735aEiMSBbDR7UQIj90n4wKAFUSEd0QN2Ukg==",
             "dev": true,
             "license": "MIT",
-            "peer": true,
             "dependencies": {
                 "@webassemblyjs/ast": "1.14.1",
                 "@webassemblyjs/helper-wasm-bytecode": "1.13.2",
@@ -17975,7 +17953,6 @@
             "integrity": "sha512-PTcKLUNvBqnY2U6E5bdOQcSM+oVP/PmrDY9NzowJjislEjwP/C4an2303MCVS2Mg9d3AJpIGdUFIQQWbPds0Sw==",
             "dev": true,
             "license": "MIT",
-            "peer": true,
             "dependencies": {
                 "@webassemblyjs/ast": "1.14.1",
                 "@webassemblyjs/helper-buffer": "1.14.1",
@@ -17989,7 +17966,6 @@
             "integrity": "sha512-JLBl+KZ0R5qB7mCnud/yyX08jWFw5MsoalJ1pQ4EdFlgj9VdXKGuENGsiCIjegI1W7p91rUlcB/LB5yRJKNTcQ==",
             "dev": true,
             "license": "MIT",
-            "peer": true,
             "dependencies": {
                 "@webassemblyjs/ast": "1.14.1",
                 "@webassemblyjs/helper-api-error": "1.13.2",
@@ -18005,7 +17981,6 @@
             "integrity": "sha512-kPSSXE6De1XOR820C90RIo2ogvZG+c3KiHzqUoO/F34Y2shGzesfqv7o57xrxovZJH/MetF5UjroJ/R/3isoiw==",
             "dev": true,
             "license": "MIT",
-            "peer": true,
             "dependencies": {
                 "@webassemblyjs/ast": "1.14.1",
                 "@xtuc/long": "4.2.2"
@@ -18052,16 +18027,14 @@
             "resolved": "https://registry.npmjs.org/@xtuc/ieee754/-/ieee754-1.2.0.tgz",
             "integrity": "sha512-DX8nKgqcGwsc0eJSqYt5lwP4DH5FlHnmuWWBRy7X0NcaGR0ZtuyeESgMwTYVEtxmsNGY+qit4QYT/MIYTOTPeA==",
             "dev": true,
-            "license": "BSD-3-Clause",
-            "peer": true
+            "license": "BSD-3-Clause"
         },
         "node_modules/@xtuc/long": {
             "version": "4.2.2",
             "resolved": "https://registry.npmjs.org/@xtuc/long/-/long-4.2.2.tgz",
             "integrity": "sha512-NuHqBY1PB/D8xU6s/thBgOAiAP7HOYDQ32+BFZILJ8ivkUkAHQnWfn6WhL79Owj1qmUnoN/YPhktdIoucipkAQ==",
             "dev": true,
-            "license": "Apache-2.0",
-            "peer": true
+            "license": "Apache-2.0"
         },
         "node_modules/@zeit/schemas": {
             "version": "2.36.0",
@@ -18149,6 +18122,7 @@
             "resolved": "https://registry.npmjs.org/acorn/-/acorn-8.16.0.tgz",
             "integrity": "sha512-UVJyE9MttOsBQIDKw1skb9nAwQuR5wuGD3+82K6JgJlm/Y+KI92oNsMNGZCYdDsVtRHSak0pcV5Dno5+4jh9sw==",
             "license": "MIT",
+            "peer": true,
             "bin": {
                 "acorn": "bin/acorn"
             },
@@ -18170,7 +18144,6 @@
             "integrity": "sha512-wKmbr/DDiIXzEOiWrTTUcDm24kQ2vGfZQvM2fwg2vXqR5uW6aapr7ObPtj1th32b9u90/Pf4AItvdTh42fBmVQ==",
             "dev": true,
             "license": "MIT",
-            "peer": true,
             "engines": {
                 "node": ">=10.13.0"
             },
@@ -18225,6 +18198,7 @@
             "integrity": "sha512-fgFx7Hfoq60ytK2c7DhnF8jIvzYgOMxfugjLOSMHjLIPgenqa7S7oaagATUq99mV6IYvN2tRmC0wnTYX6iPbMw==",
             "dev": true,
             "license": "MIT",
+            "peer": true,
             "dependencies": {
                 "fast-deep-equal": "^3.1.1",
                 "fast-json-stable-stringify": "^2.0.0",
@@ -18931,7 +18905,6 @@
             "integrity": "sha512-Cg7TFGpIr01vOQNODXOOaGz2NpCU5gl8x1qJFbb6hbZxR7XrcE2vtbAsTAbJ7/xwJtUuJEw8K8Zr/AE0LHlesg==",
             "dev": true,
             "license": "MIT",
-            "peer": true,
             "dependencies": {
                 "@babel/runtime": "^7.12.5",
                 "cosmiconfig": "^7.0.0",
@@ -18950,7 +18923,8 @@
             "version": "2.5.4",
             "resolved": "https://registry.npmjs.org/bare-events/-/bare-events-2.5.4.tgz",
             "integrity": "sha512-+gFfDkR8pj4/TrWCGUGWmJIkBwuxPS5F+a5yWjOHQt2hHvNZd5YLzadjmDUtFmMM4y429bnKLa8bYBMHcYdnQA==",
-            "license": "Apache-2.0"
+            "license": "Apache-2.0",
+            "peer": true
         },
         "node_modules/bare-fs": {
             "version": "4.7.1",
@@ -19805,6 +19779,7 @@
                 }
             ],
             "license": "MIT",
+            "peer": true,
             "dependencies": {
                 "baseline-browser-mapping": "^2.9.0",
                 "caniuse-lite": "^1.0.30001759",
@@ -20182,7 +20157,6 @@
             "integrity": "sha512-rNjApaLzuwaOTjCiT8lSDdGN1APCiqkChLMJxJPWLunPAt5fy8xgU9/jNOchV84wfIxrA0lRQB7oCT8jrn/wrQ==",
             "dev": true,
             "license": "MIT",
-            "peer": true,
             "engines": {
                 "node": ">=6.0"
             }
@@ -20438,6 +20412,8 @@
         },
         "node_modules/cluster-key-slot": {
             "version": "1.1.2",
+            "resolved": "https://registry.npmjs.org/cluster-key-slot/-/cluster-key-slot-1.1.2.tgz",
+            "integrity": "sha512-RMr0FhtfXemyinomL4hrWcYJxmX6deFdCxpJzhDttxgO1+bcCnkk+9drydLVDmAMG7NE6aN/fl4F7ucU/90gAA==",
             "license": "Apache-2.0",
             "engines": {
                 "node": ">=0.10.0"
@@ -20921,8 +20897,7 @@
             "resolved": "https://registry.npmjs.org/convert-source-map/-/convert-source-map-1.9.0.tgz",
             "integrity": "sha512-ASFBup0Mz1uyiIjANan1jzLQami9z1PoYSZCiiYW2FczPbenXc45FZdBZLzOT+r6+iciuEModtmCti+hjaAk0A==",
             "dev": true,
-            "license": "MIT",
-            "peer": true
+            "license": "MIT"
         },
         "node_modules/cookie": {
             "version": "0.7.2",
@@ -21026,6 +21001,7 @@
             "integrity": "sha512-raM0ew0/jJUqkJ0E6e8UDtl+y/7ktFivgWvqw8dNSQeNWoSDLvQ1H/RN3aPXB9tBd4/FhyR4RDPGhsNIMsAn7g==",
             "dev": true,
             "hasInstallScript": true,
+            "peer": true,
             "funding": {
                 "type": "opencollective",
                 "url": "https://opencollective.com/core-js"
@@ -21066,7 +21042,6 @@
             "integrity": "sha512-AdmX6xUzdNASswsFtmwSt7Vj8po9IuqXm0UXz7QKPuEUmPB4XyjGfaAr2PSuELMwkRMVH1EpIkX5bTZGRB3eCA==",
             "dev": true,
             "license": "MIT",
-            "peer": true,
             "dependencies": {
                 "@types/parse-json": "^4.0.0",
                 "import-fresh": "^3.2.1",
@@ -21084,7 +21059,6 @@
             "integrity": "sha512-vIYeF1u3CjlhAFekPPAk2h/Kv4T3mAkMox5OymRiJQB0spDP10LHvt+K7G9Ny6NuuMAb25/6n1qyUjAcGNf/AA==",
             "dev": true,
             "license": "ISC",
-            "peer": true,
             "engines": {
                 "node": ">= 6"
             }
@@ -21502,6 +21476,7 @@
             "integrity": "sha512-Ukq0owbQXxa/U3EGtsdVBkR1w7KOQ5gIBqdH2hkvknzZPYvBxb/aa6E8L7tmjFtkwZBu3UXBbjIgPo/Ez4xaNg==",
             "dev": true,
             "license": "MIT",
+            "peer": true,
             "funding": {
                 "type": "github",
                 "url": "https://github.com/sponsors/kossnocorp"
@@ -23146,6 +23121,7 @@
             "integrity": "sha512-VmQ+sifHUbI/IcSopBCF/HO3YiHQx/AVd3UVyYL6weuwW+HvON9VYn5l6Zl1WZzPWXPNZrSQpxwkkZ/VuvJZzg==",
             "dev": true,
             "license": "MIT",
+            "peer": true,
             "dependencies": {
                 "@eslint-community/eslint-utils": "^4.8.0",
                 "@eslint-community/regexpp": "^4.12.1",
@@ -23205,6 +23181,7 @@
             "resolved": "https://registry.npmjs.org/eslint-config-prettier/-/eslint-config-prettier-10.1.5.tgz",
             "integrity": "sha512-zc1UmCpNltmVY34vuLRV61r1K27sWuX39E+uyUnY8xS2Bex88VV9cugG+UZbRSRGtGyFboj+D8JODyme1plMpw==",
             "dev": true,
+            "peer": true,
             "bin": {
                 "eslint-config-prettier": "bin/cli.js"
             },
@@ -23473,7 +23450,6 @@
             "integrity": "sha512-2NxwbF/hZ0KpepYN0cNbo+FN6XoK7GaHlQhgx/hIZl6Va0bF45RQOOwhLIy8lQDbuCiadSLCBnH2CFYquit5bw==",
             "dev": true,
             "license": "BSD-2-Clause",
-            "peer": true,
             "dependencies": {
                 "esrecurse": "^4.3.0",
                 "estraverse": "^4.1.1"
@@ -23488,7 +23464,6 @@
             "integrity": "sha512-39nnKffWz8xN1BU/2c79n9nB9HDzo0niYUqx6xyqUnyoAnQyyWpOTdZEeiCch8BBu515t4wp9ZmgVfVhn9EBpw==",
             "dev": true,
             "license": "BSD-2-Clause",
-            "peer": true,
             "engines": {
                 "node": ">=4.0"
             }
@@ -23813,6 +23788,7 @@
             "version": "5.1.0",
             "resolved": "https://registry.npmjs.org/express/-/express-5.1.0.tgz",
             "integrity": "sha512-DT9ck5YIRU+8GYzzU5kT3eHGA5iL+1Zd0EutOmTE9Dtk+Tvuzd23VBU+ec7HPNSTxXYO55gPV/hq4pSBJDjFpA==",
+            "peer": true,
             "dependencies": {
                 "accepts": "^2.0.0",
                 "body-parser": "^2.2.0",
@@ -24367,8 +24343,7 @@
             "resolved": "https://registry.npmjs.org/find-root/-/find-root-1.1.0.tgz",
             "integrity": "sha512-NKfW6bec6GfKc0SGx1e07QZY9PE99u0Bft/0rzSD5k3sO/vwkVUpDUKVm5Gpp5Ue3YfShPFTX2070tDs5kB9Ng==",
             "dev": true,
-            "license": "MIT",
-            "peer": true
+            "license": "MIT"
         },
         "node_modules/find-up": {
             "version": "5.0.0",
@@ -24720,13 +24695,6 @@
             },
             "engines": {
                 "node": ">=18"
-            }
-        },
-        "node_modules/generic-pool": {
-            "version": "3.9.0",
-            "license": "MIT",
-            "engines": {
-                "node": ">= 4"
             }
         },
         "node_modules/gensync": {
@@ -25189,8 +25157,7 @@
             "resolved": "https://registry.npmjs.org/glob-to-regexp/-/glob-to-regexp-0.4.1.tgz",
             "integrity": "sha512-lkX1HJXwyMcprw/5YUZc2s7DrpAiHB21/V+E1rHUrVNokkvB6bqMzT0VfV6/86ZNabt1k14YOIaT7nDvOX3Iiw==",
             "dev": true,
-            "license": "BSD-2-Clause",
-            "peer": true
+            "license": "BSD-2-Clause"
         },
         "node_modules/globals": {
             "version": "15.14.0",
@@ -25464,6 +25431,7 @@
             "resolved": "https://registry.npmjs.org/hono/-/hono-4.12.19.tgz",
             "integrity": "sha512-xa3eYXYXx68XTT4hZ7dRzsXBhaq85ToSrlUJNoR0gwz/1Ap/CNwX47wfvV7pc/xWhjKVVkLT7zBJy8chhNguqQ==",
             "license": "MIT",
+            "peer": true,
             "engines": {
                 "node": ">=16.9.0"
             }
@@ -26591,7 +26559,6 @@
             "integrity": "sha512-7vuh85V5cdDofPyxn58nrPjBktZo0u9x1g8WtjQol+jZDaE+fhN+cIvTj11GndBnMnyfrUOG1sZQxCdjKh+DKg==",
             "dev": true,
             "license": "MIT",
-            "peer": true,
             "dependencies": {
                 "@types/node": "*",
                 "merge-stream": "^2.0.0",
@@ -26607,7 +26574,6 @@
             "integrity": "sha512-MpUEN2OodtUzxvKQl72cUF7RQ5EiHsGvSsVG0ia9c5RbWGL2CI4C7EpPS8UTBIplnlzZiNuV56w+FuNxy3ty2Q==",
             "dev": true,
             "license": "MIT",
-            "peer": true,
             "dependencies": {
                 "has-flag": "^4.0.0"
             },
@@ -26730,6 +26696,7 @@
             "resolved": "https://registry.npmjs.org/jsep/-/jsep-1.4.0.tgz",
             "integrity": "sha512-B7qPcEVE3NVkmSJbaYxvv4cHkVW7DQsZz13pUMrfS8z8Q/BuShN+gcTXrUlPiGqM2/t/EEaI030bpxMqY8gMlw==",
             "license": "MIT",
+            "peer": true,
             "engines": {
                 "node": ">= 10.16.0"
             }
@@ -27104,6 +27071,7 @@
             "integrity": "sha512-l51N2r93WmGUye3WuFoN5k10zyvrVs0qfKBhyC5ogUQ6Ew6JUSswh78mbSO+IU3nTWsyOArqPCcShdQSadghBQ==",
             "dev": true,
             "license": "MPL-2.0",
+            "peer": true,
             "dependencies": {
                 "detect-libc": "^2.0.3"
             },
@@ -27692,7 +27660,6 @@
             "integrity": "sha512-DFEqQ3ihfS9blba08cLfYf1NRAIEm+dDjic073DRDc3/JspI/8wYmtDsHwd3+4hwvdxSK7PGaElfTmm0awWJ4w==",
             "dev": true,
             "license": "MIT",
-            "peer": true,
             "engines": {
                 "node": ">=6.11.5"
             },
@@ -28355,6 +28322,7 @@
             "integrity": "sha512-UczzB+0nnwGotYSgllfARAqWCJ5e/skuV2K/l+Zyck/H6pJIhLXuBnz+6vn2i211o7DtbE78HQtsYEKICHGI+g==",
             "dev": true,
             "license": "MIT",
+            "peer": true,
             "funding": {
                 "type": "opencollective",
                 "url": "https://opencollective.com/mobx"
@@ -29271,6 +29239,7 @@
             "resolved": "https://registry.npmjs.org/optionator/-/optionator-0.9.4.tgz",
             "integrity": "sha512-6IpQ7mKUxRcZNLIObR0hz7lxsapSSIYNZJwXPGeF0mTVqGKFIXj1DQcMoT22S3ROcLyY/rz0PWaWZ9ayWmad9g==",
             "dev": true,
+            "peer": true,
             "dependencies": {
                 "deep-is": "^0.1.3",
                 "fast-levenshtein": "^2.0.6",
@@ -29820,6 +29789,7 @@
         "node_modules/pg": {
             "version": "8.11.3",
             "license": "MIT",
+            "peer": true,
             "dependencies": {
                 "buffer-writer": "2.0.0",
                 "packet-reader": "1.0.0",
@@ -29903,6 +29873,7 @@
             "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-4.0.4.tgz",
             "integrity": "sha512-QP88BAKvMam/3NxH6vj2o21R6MjxZUAd6nlwAS/pnGvN9IVLocLHxGYIzFhg6fUQ+5th6P4dv4eW9jX3DSIj7A==",
             "license": "MIT",
+            "peer": true,
             "engines": {
                 "node": ">=12"
             },
@@ -30213,6 +30184,7 @@
             "integrity": "sha512-I7AIg5boAr5R0FFtJ6rCfD+LFsWHp81dolrFD8S79U9tb8Az2nGrJncnMSnys+bpQJfRUzqs9hnA81OAA3hCuQ==",
             "dev": true,
             "license": "MIT",
+            "peer": true,
             "bin": {
                 "prettier": "bin/prettier.cjs"
             },
@@ -31095,6 +31067,7 @@
             "integrity": "sha512-wS+hAgJShR0KhEvPJArfuPVN1+Hz1t0Y6n5jLrGQbkb4urgPE/0Rve+1kMB1v/oWgHgm4WIcV+i7F2pTVj+2iQ==",
             "dev": true,
             "license": "MIT",
+            "peer": true,
             "dependencies": {
                 "loose-envify": "^1.1.0"
             },
@@ -31166,6 +31139,7 @@
             "integrity": "sha512-5m4nQKp+rZRb09LNH59GM4BxTh9251/ylbKIbpe7TpGxfJ+9kv6BLkLBXIjjspbgbnIBNqlI23tRnTWT0snUIw==",
             "dev": true,
             "license": "MIT",
+            "peer": true,
             "dependencies": {
                 "loose-envify": "^1.1.0",
                 "scheduler": "^0.23.2"
@@ -31211,6 +31185,7 @@
             "integrity": "sha512-ZwueDMvUeucovM2VjkCf7zIHcs1aAlDimZu2Hvel5C5907gUzMpm4xCrQXtRzCvsBqFjonB4m3x4LzCFI1ZKWA==",
             "dev": true,
             "license": "MIT",
+            "peer": true,
             "engines": {
                 "node": ">=18.0.0"
             },
@@ -31295,6 +31270,7 @@
             "integrity": "sha512-XRnlbKMTmktBkjCLE8/XcZFlnHvr2Ltdr1eJX4idL55/9BbORzyZEaIkBFDhFGCEWBBItsVrDxwx3gnisMitdw==",
             "dev": true,
             "license": "MIT",
+            "peer": true,
             "dependencies": {
                 "@remix-run/router": "1.23.2"
             },
@@ -31311,6 +31287,7 @@
             "integrity": "sha512-pxPcv1AczD4vso7G4Z3TKcvlxK7g7TNt3/FNGMhfqyntocvYKj+GCatfigGDjbLozC4baguJ0ReCigoDJXb0ag==",
             "dev": true,
             "license": "MIT",
+            "peer": true,
             "dependencies": {
                 "@remix-run/router": "1.23.2",
                 "react-router": "6.30.3"
@@ -31390,7 +31367,6 @@
             "integrity": "sha512-CdtmP8Dc19xL8/R6sWvtknD/eCXkQr30dtvC4VmGInhRsfF8X/ihXCq6+9l9qbxmKRiq407/7z5fxE7cVWQNgQ==",
             "dev": true,
             "license": "MIT",
-            "peer": true,
             "dependencies": {
                 "@babel/runtime": "^7.10.2",
                 "use-composed-ref": "^1.3.0",
@@ -31632,18 +31608,19 @@
             }
         },
         "node_modules/redis": {
-            "version": "4.6.13",
+            "version": "5.12.1",
+            "resolved": "https://registry.npmjs.org/redis/-/redis-5.12.1.tgz",
+            "integrity": "sha512-LDsoVvb/CpoV9EN3FXvgvSHNJWuCIzl9MiO3ppOevuGLpSGJhwfQjpEwfFJcQvNSddHADDdZaWx0HnmMxRXG7g==",
             "license": "MIT",
-            "workspaces": [
-                "./packages/*"
-            ],
             "dependencies": {
-                "@redis/bloom": "1.2.0",
-                "@redis/client": "1.5.14",
-                "@redis/graph": "1.1.1",
-                "@redis/json": "1.0.6",
-                "@redis/search": "1.1.6",
-                "@redis/time-series": "1.0.5"
+                "@redis/bloom": "5.12.1",
+                "@redis/client": "5.12.1",
+                "@redis/json": "5.12.1",
+                "@redis/search": "5.12.1",
+                "@redis/time-series": "5.12.1"
+            },
+            "engines": {
+                "node": ">= 18.19.0"
             }
         },
         "node_modules/redoc": {
@@ -32536,6 +32513,7 @@
             "integrity": "sha512-Thbli+OlOj+iMPYFBVBfJ3OmCAnaSyNn4M1vz9T6Gka5Jt9ba/HIR56joy65tY6kx/FCF5VXNB819Y7/GUrBGA==",
             "dev": true,
             "license": "MIT",
+            "peer": true,
             "dependencies": {
                 "fast-deep-equal": "^3.1.3",
                 "fast-uri": "^3.0.1",
@@ -33922,6 +33900,7 @@
             "integrity": "sha512-x8sqaLZCYDP+wzPkrUPPlnBuQ9ndwtzzrQE9AchXARGmC7KFnjVwDufDokiGsgDuUR9V94Iw5D0K8Oyxj7vrlQ==",
             "dev": true,
             "license": "Apache-2.0",
+            "peer": true,
             "dependencies": {
                 "@bundled-es-modules/deepmerge": "^4.3.1",
                 "@bundled-es-modules/glob": "^13.0.6",
@@ -33960,6 +33939,7 @@
             "integrity": "sha512-J72R4ltw0UBVUlEjTzI0gg2STOqlI9JBhQOL4Dxt7aJOnnSesy0qJDn4PYfMCafk9cWOaVg129Pesl5o+DIh0Q==",
             "dev": true,
             "license": "MIT",
+            "peer": true,
             "dependencies": {
                 "@emotion/is-prop-valid": "1.4.0",
                 "@emotion/unitless": "0.10.0",
@@ -34048,8 +34028,7 @@
             "resolved": "https://registry.npmjs.org/stylis/-/stylis-4.2.0.tgz",
             "integrity": "sha512-Orov6g6BB1sDfYgzWfTHDOxamtX1bE/zo104Dh9e6fqJ3PooipYyfJ0pUmrZO2wAvO8YbEyeFrkV91XTsGMSrw==",
             "dev": true,
-            "license": "MIT",
-            "peer": true
+            "license": "MIT"
         },
         "node_modules/sucrase": {
             "version": "3.35.0",
@@ -34284,7 +34263,8 @@
             "resolved": "https://registry.npmjs.org/tailwindcss/-/tailwindcss-4.1.13.tgz",
             "integrity": "sha512-i+zidfmTqtwquj4hMEwdjshYYgMbOrPzb9a0M3ZgNa0JMoZeFC6bxZvO8yr8ozS6ix2SDz0+mvryPeBs2TFE+w==",
             "dev": true,
-            "license": "MIT"
+            "license": "MIT",
+            "peer": true
         },
         "node_modules/tailwindcss-animate": {
             "version": "1.0.7",
@@ -34415,7 +34395,6 @@
             "integrity": "sha512-J/9An6vs9Us6wKRriSFXBWdRZapREHqFzdNUKk0pmu804EMR6dr6winwo7e5JDxN4xahxQsuysyYFwlwj4XN/Q==",
             "dev": true,
             "license": "BSD-2-Clause",
-            "peer": true,
             "dependencies": {
                 "@jridgewell/source-map": "^0.3.3",
                 "acorn": "^8.15.0",
@@ -34435,7 +34414,6 @@
             "integrity": "sha512-201R5j+sJpK8nFWwKVyNfZot8FaJbLZDq5evriVzbV1wDtSXDjRUDRfJzHpAaxFDMEhsZL1QkeqM61wgsS3KaQ==",
             "dev": true,
             "license": "MIT",
-            "peer": true,
             "dependencies": {
                 "@jridgewell/trace-mapping": "^0.3.25",
                 "jest-worker": "^27.4.5",
@@ -34497,7 +34475,6 @@
             "integrity": "sha512-zzNR+SdQSDJzc8joaeP8QQoCQr8NuYx2dIIytl1QeBEZHJ9uW6hebsrYgbz8hJwUQao3TWCMtmfV8Nu1twOLAw==",
             "dev": true,
             "license": "MIT",
-            "peer": true,
             "dependencies": {
                 "@jridgewell/resolve-uri": "^3.1.0",
                 "@jridgewell/sourcemap-codec": "^1.4.14"
@@ -34508,8 +34485,7 @@
             "resolved": "https://registry.npmjs.org/commander/-/commander-2.20.3.tgz",
             "integrity": "sha512-GpVkmM8vF2vQUkj2LvZmD35JxeJOLCwJ9cUkugyk2nuhbv3+mJvpLYYt+0+USMxE+oj+ey/lJEnhZw75x/OMcQ==",
             "dev": true,
-            "license": "MIT",
-            "peer": true
+            "license": "MIT"
         },
         "node_modules/testcontainers": {
             "version": "11.14.0",
@@ -34759,6 +34735,7 @@
             "integrity": "sha512-fMoUJ3Gef9iA0yKZNeW2SQCCKTluCwghUyOz/qxPS8XxrQk6Jlw4lgql3S+s6L//FteLeSJ7erKxMWl727mZoQ==",
             "dev": true,
             "license": "MIT",
+            "peer": true,
             "dependencies": {
                 "@standard-schema/spec": "^1.0.0",
                 "json-rpc-2.0": "^1.7.1",
@@ -34984,7 +34961,8 @@
         "node_modules/tslib": {
             "version": "2.8.1",
             "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.8.1.tgz",
-            "integrity": "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w=="
+            "integrity": "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w==",
+            "peer": true
         },
         "node_modules/tsup": {
             "version": "8.5.1",
@@ -35213,6 +35191,7 @@
             "integrity": "sha512-qjbnuR9Tr+FJOMBqJCW5ehvIo/buZq7vH7qD7JziU98h6l3qGy0a/yPFjwO+y0/T7GFpNgNAvEcPPVfyT8rrPQ==",
             "devOptional": true,
             "license": "MIT",
+            "peer": true,
             "dependencies": {
                 "esbuild": "~0.25.0",
                 "get-tsconfig": "^4.7.5"
@@ -35391,6 +35370,7 @@
             "version": "5.8.3",
             "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.8.3.tgz",
             "integrity": "sha512-p1diW6TqL9L07nNxvRMM7hMMw4c5XOo/1ibL4aAIGmSAt9slTE1Xgw5KWuof2uTOvCg9BY7ZRi+GaF+7sfgPeQ==",
+            "peer": true,
             "bin": {
                 "tsc": "bin/tsc",
                 "tsserver": "bin/tsserver"
@@ -35880,6 +35860,7 @@
             "integrity": "sha512-mm1rxUsmOxzrwnX5arGS+U4T25RdvpPjPN4yR0u9pUBov9+zGVtO84tif1eY4r6zWxVxu3KzIyknJy3rxfRZZg==",
             "dev": true,
             "license": "MIT",
+            "peer": true,
             "peerDependencies": {
                 "typescript": ">=5"
             },
@@ -35933,6 +35914,7 @@
             "integrity": "sha512-Bby3NOsna2jsjfLVOHKes8sGwgl4TT0E6vvpYgnAYDIF/tie7MRaFthmKuHx1NSXjiTueXH3do80FMQgvEktRg==",
             "dev": true,
             "license": "MIT",
+            "peer": true,
             "dependencies": {
                 "esbuild": "^0.27.0",
                 "fdir": "^6.5.0",
@@ -36322,6 +36304,7 @@
             "resolved": "https://registry.npmjs.org/@svgr/core/-/core-8.1.0.tgz",
             "integrity": "sha512-8QqtOQT5ACVlmsvKOJNEaWmRPmcojMOzCz4Hs2BGG/toAp/K38LcsMRyLp349glq5AzJbCEeimEoxaX6v/fLrA==",
             "dev": true,
+            "peer": true,
             "dependencies": {
                 "@babel/core": "^7.21.3",
                 "@svgr/babel-preset": "8.1.0",
@@ -36685,7 +36668,6 @@
             "integrity": "sha512-Zn5uXdcFNIA1+1Ei5McRd+iRzfhENPCe7LeABkJtNulSxjma+l7ltNx55BWZkRlwRnpOgHqxnjyaDgJnNXnqzg==",
             "dev": true,
             "license": "MIT",
-            "peer": true,
             "dependencies": {
                 "glob-to-regexp": "^0.4.1",
                 "graceful-fs": "^4.1.2"
@@ -36814,7 +36796,6 @@
             "integrity": "sha512-HPuy+uuoTCaaoEoI1LQ3JN9+vrPBvEesnnX1jADHy728cHSMlq4wUc4afYqahq2B1mhQVZxCXOkNTnXltr+2vQ==",
             "dev": true,
             "license": "MIT",
-            "peer": true,
             "engines": {
                 "node": ">=10.13.0"
             }
@@ -36832,7 +36813,6 @@
             "integrity": "sha512-aU5EJuIN2WDemCcAp2vFBfp/m4EAhWJnUNSSw0ixs7/kXbd6Pg64EmwJkNdFhB8aWt1sH2CTXrLxo/iAGV3oPQ==",
             "dev": true,
             "license": "MIT",
-            "peer": true,
             "engines": {
                 "node": ">= 0.6"
             }
@@ -37165,6 +37145,7 @@
             "resolved": "https://registry.npmjs.org/ws/-/ws-8.18.2.tgz",
             "integrity": "sha512-DMricUmwGZUVr++AEAe2uiVM7UoO9MAVZMDu05UQOaUII0lp+zOzLLU4Xqh/JvTqklB1T4uELaaPBKyjE1r4fQ==",
             "license": "MIT",
+            "peer": true,
             "engines": {
                 "node": ">=10.0.0"
             },
@@ -37290,6 +37271,7 @@
             "integrity": "sha512-2AvhNX3mb8zd6Zy7INTtSpl1F15HW6Wnqj0srWlkKLcpYl/gMIMJiyuGq2KeI2YFxUPjdlB+3Lc10seMLtL4cA==",
             "devOptional": true,
             "license": "ISC",
+            "peer": true,
             "bin": {
                 "yaml": "bin.mjs"
             },
@@ -37398,6 +37380,7 @@
             "resolved": "https://registry.npmjs.org/zod/-/zod-4.3.6.tgz",
             "integrity": "sha512-rftlrkhHZOcjDwkGlnUtZZkvaPHCsDATp4pGpuOOMDaTdDDXF91wuVDJoWoPsKX/3YPQ5fHuF3STjcYyKr+Qhg==",
             "license": "MIT",
+            "peer": true,
             "funding": {
                 "url": "https://github.com/sponsors/colinhacks"
             }
@@ -37572,6 +37555,7 @@
             "resolved": "https://registry.npmjs.org/ajv/-/ajv-8.18.0.tgz",
             "integrity": "sha512-PlXPeEWMXMZ7sPYOHqmDyCJzcfNrUr3fGNKtezX14ykXOEIvyK81d+qydx89KY5O71FKMPaQ2vBfBFI5NHR63A==",
             "license": "MIT",
+            "peer": true,
             "dependencies": {
                 "fast-deep-equal": "^3.1.3",
                 "fast-uri": "^3.0.1",
@@ -37843,6 +37827,7 @@
             "resolved": "https://registry.npmjs.org/@types/react/-/react-18.3.3.tgz",
             "integrity": "sha512-hti/R0pS0q1/xx+TsI73XIqk26eBsISZ2R0wUijXIngRK9R/e7Xw/cXVxQK7R5JjW+SV4zGcn5hXjudkN/pLIw==",
             "dev": true,
+            "peer": true,
             "dependencies": {
                 "@types/prop-types": "*",
                 "csstype": "^3.0.2"
@@ -37854,6 +37839,7 @@
             "integrity": "sha512-SBrYOvMbDB7cV8ZfNpaiLcgjH/a1c7aK0lK+aNigpf4xWLO8q+o4tcvVurv3c4EOyzn/3dCsYt4GKD42VvJ/+A==",
             "dev": true,
             "license": "MIT",
+            "peer": true,
             "engines": {
                 "node": ">=18.0.0"
             },
@@ -38213,6 +38199,7 @@
             "integrity": "sha512-V1Zd2e+gBFufqAQVZ1JR8KLqALsEZ3JYSBnWwQbKa6zCfWWanR6AFMyuOkLt2gZOgGp3h2Riuz88pGNVTQSG0A==",
             "dev": true,
             "license": "MIT",
+            "peer": true,
             "dependencies": {
                 "@storybook/global": "^5.0.0",
                 "@storybook/icons": "^2.0.2",
@@ -38385,7 +38372,7 @@
                 "express": "5.1.0",
                 "get-port": "7.1.0",
                 "rate-limiter-flexible": "5.0.3",
-                "redis": "4.6.13",
+                "redis": "5.12.1",
                 "zod": "4.0.5"
             },
             "devDependencies": {
@@ -38476,9 +38463,10 @@
             "version": "1.0.0",
             "dependencies": {
                 "@nangohq/utils": "file:../utils",
-                "redis": "4.6.13"
+                "redis": "5.12.1"
             },
             "devDependencies": {
+                "testcontainers": "11.14.0",
                 "vitest": "4.1.8"
             }
         },
@@ -39227,7 +39215,7 @@
                 "passport-local": "1.0.0",
                 "qs": "6.15.0",
                 "rate-limiter-flexible": "5.0.3",
-                "redis": "4.6.13",
+                "redis": "5.12.1",
                 "semver": "7.6.3",
                 "serialize-error": "11.0.3",
                 "simple-oauth2": "5.1.0",

--- a/packages/jobs/lib/runner/render.ts
+++ b/packages/jobs/lib/runner/render.ts
@@ -5,7 +5,8 @@ import { RateLimiterMemory, RateLimiterRedis } from 'rate-limiter-flexible';
 import { createClient } from 'redis';
 
 import { waitUntilHealthy } from '@nangohq/fleet';
-import { getPersistAPIUrl, getProvidersUrl, getRedisUrl } from '@nangohq/shared';
+import { getRedisClientOptions, getRedisUrl } from '@nangohq/kvstore';
+import { getPersistAPIUrl, getProvidersUrl } from '@nangohq/shared';
 import { Err, Ok, getLogger } from '@nangohq/utils';
 
 import { RenderAPI } from './render.api.js';
@@ -222,22 +223,7 @@ const serviceCreationThrottler = await (async () => {
     };
     const url = getRedisUrl();
     if (url) {
-        const isExternal = url.startsWith('rediss://');
-        const socket = isExternal
-            ? {
-                  reconnectStrategy: (retries: number) => Math.min(retries * 200, 2000),
-                  connectTimeout: 10_000,
-                  tls: true,
-                  servername: new URL(url).hostname,
-                  keepAlive: 60_000
-              }
-            : {};
-        const redisClient = await createClient({
-            url: url,
-            disableOfflineQueue: true,
-            pingInterval: 30_000,
-            socket
-        }).connect();
+        const redisClient = await createClient(getRedisClientOptions(url)).connect();
         redisClient.on('error', (err) => {
             logger.error(`Redis (rate-limiter) error: ${err}`);
         });

--- a/packages/jobs/package.json
+++ b/packages/jobs/package.json
@@ -39,7 +39,7 @@
         "express": "5.1.0",
         "get-port": "7.1.0",
         "rate-limiter-flexible": "5.0.3",
-        "redis": "4.6.13",
+        "redis": "5.12.1",
         "zod": "4.0.5"
     },
     "devDependencies": {

--- a/packages/kvstore/lib/RedisStore.ts
+++ b/packages/kvstore/lib/RedisStore.ts
@@ -152,14 +152,17 @@ export class RedisKVStore implements KVStore {
             multi.pExpire(key, opts.ttlMs);
         }
         const [count] = await multi.exec();
-        return count as number;
+        return Number(count);
     }
 
     public async *scan(pattern: string): AsyncGenerator<string> {
-        for await (const key of this.client.scanIterator({
+        // node-redis v5 scanIterator yields a batch of keys per iteration (not a single key).
+        for await (const keys of this.client.scanIterator({
             MATCH: pattern
         })) {
-            yield key;
+            for (const key of keys) {
+                yield key;
+            }
         }
     }
 }

--- a/packages/kvstore/lib/index.ts
+++ b/packages/kvstore/lib/index.ts
@@ -4,9 +4,10 @@ import { FeatureFlags } from './FeatureFlags.js';
 import { InMemoryKVStore } from './InMemoryStore.js';
 import { Locking } from './Locking.js';
 import { RedisKVStore } from './RedisStore.js';
-import { envs } from './env.js';
+import { getCustomerRedisUrl, getRedisClientOptions, getRedisUrl } from './redisClient.js';
 
 import type { KVStore } from './KVStore.js';
+import type { RedisBoundary } from './redisClient.js';
 import type { RedisClientType } from 'redis';
 
 export { InMemoryKVStore } from './InMemoryStore.js';
@@ -14,33 +15,18 @@ export { FeatureFlags } from './FeatureFlags.js';
 export { RedisKVStore } from './RedisStore.js';
 export type { DeleteIfValueEqualsWithCompanionArgs, KVStore, SetIfValueEqualsWithCompanionArgs, SetNxWithCompanionArgs } from './KVStore.js';
 export { type Lock, Locking } from './Locking.js';
+export { type RedisBoundary, getCustomerRedisUrl, getRedisClientOptions, getRedisUrl } from './redisClient.js';
 
-type KvBoundary = 'system' | 'customer';
+type KvBoundary = RedisBoundary;
 
 // Those getters can be accessed at any point so we store the promise to avoid race condition
 // Not my best code
 const mapRedis = new Map<string, RedisClientType>();
-export async function getRedis(url: string): Promise<RedisClientType> {
+export async function getRedis(url: string, boundary: RedisBoundary = 'system'): Promise<RedisClientType> {
     if (mapRedis.has(url)) {
         return mapRedis.get(url)!;
     }
-    const isExternal = url.startsWith('rediss://');
-    const socket = isExternal
-        ? {
-              reconnectStrategy: (retries: number) => Math.min(retries * 200, 2000),
-              connectTimeout: 10_000,
-              tls: true,
-              servername: new URL(url).hostname,
-              keepAlive: 60_000
-          }
-        : {};
-
-    const redis = createClient({
-        url: url,
-        disableOfflineQueue: true,
-        pingInterval: 30_000,
-        socket
-    });
+    const redis = createClient(getRedisClientOptions(url, boundary));
     redis.on('error', (err: Error) => {
         // TODO: report error
         console.error(`Redis (kvstore) error: ${err}`);
@@ -64,42 +50,17 @@ export async function destroy() {
     );
 }
 
-const mapRedisUrl = new Map<KvBoundary, string | undefined>();
-mapRedisUrl.set('system', getRedisUrl());
-mapRedisUrl.set('customer', getCustomerRedisUrl() || getRedisUrl());
-
-function getRedisUrl(): string | undefined {
-    const url = envs.NANGO_REDIS_URL;
-    if (url) {
-        return url;
-    }
-    const endpoint = envs.NANGO_REDIS_HOST;
-    const port = envs.NANGO_REDIS_PORT || 6379;
-    const auth = envs.NANGO_REDIS_AUTH;
-    if (endpoint && port && auth) {
-        return `rediss://:${auth}@${endpoint}:${port}`;
-    }
-    return undefined;
-}
-
-function getCustomerRedisUrl(): string | undefined {
-    const url = envs.NANGO_CUSTOMER_REDIS_URL;
-    if (url) {
-        return url;
-    }
-    const endpoint = envs.NANGO_CUSTOMER_REDIS_HOST;
-    const port = envs.NANGO_CUSTOMER_REDIS_PORT || 6379;
-    const auth = envs.NANGO_CUSTOMER_REDIS_AUTH;
-    if (endpoint && port && auth) {
-        return `rediss://:${auth}@${endpoint}:${port}`;
-    }
-    return undefined;
-}
+// Resolve the URL and its boundary once. When the customer boundary is not
+// configured it falls back to the system URL (and system credentials).
+const mapRedisConfig = new Map<KvBoundary, { url: string | undefined; boundary: RedisBoundary }>();
+mapRedisConfig.set('system', { url: getRedisUrl(), boundary: 'system' });
+const customerRedisUrl = getCustomerRedisUrl();
+mapRedisConfig.set('customer', customerRedisUrl ? { url: customerRedisUrl, boundary: 'customer' } : { url: getRedisUrl(), boundary: 'system' });
 
 async function createKVStore(usage: KvBoundary = 'system'): Promise<KVStore> {
-    const url = mapRedisUrl.get(usage);
-    if (url) {
-        const store = new RedisKVStore(await getRedis(url));
+    const config = mapRedisConfig.get(usage);
+    if (config?.url) {
+        const store = new RedisKVStore(await getRedis(config.url, config.boundary));
         return store;
     }
     return new InMemoryKVStore();

--- a/packages/kvstore/lib/redisClient.integration.test.ts
+++ b/packages/kvstore/lib/redisClient.integration.test.ts
@@ -1,0 +1,53 @@
+import { createClient } from 'redis';
+import { GenericContainer } from 'testcontainers';
+import { afterAll, beforeAll, describe, expect, it } from 'vitest';
+
+import { getRedisClientOptions } from './redisClient.js';
+
+import type { StartedTestContainer } from 'testcontainers';
+
+// Backward-compatibility: the static-auth path (no token file) must keep working
+// against a password-protected Redis under node-redis v5. The shared integration
+// Redis has no password, so this spins up its own `requirepass` instance.
+const PASSWORD = 'super-secret-pass';
+
+describe('getRedisClientOptions static auth', () => {
+    let container: StartedTestContainer;
+    let host: string;
+    let port: number;
+
+    beforeAll(async () => {
+        container = await new GenericContainer('redis:8.0.4-alpine').withExposedPorts(6379).withCommand(['redis-server', '--requirepass', PASSWORD]).start();
+        host = container.getHost();
+        port = container.getMappedPort(6379);
+    }, 60_000);
+
+    afterAll(async () => {
+        await container?.stop();
+    });
+
+    it('authenticates with a password-only url (requirepass) and runs commands', async () => {
+        const url = `redis://:${PASSWORD}@${host}:${port}`;
+        const client = await createClient(getRedisClientOptions(url)).connect();
+        try {
+            await client.set('k', 'v');
+            expect(await client.get('k')).toBe('v');
+        } finally {
+            await client.disconnect();
+        }
+    });
+
+    it('is rejected by the server when no password is supplied', async () => {
+        const url = `redis://${host}:${port}`;
+        const client = createClient(getRedisClientOptions(url));
+        client.on('error', () => {
+            // swallow the expected NOAUTH error event
+        });
+        await client.connect();
+        try {
+            await expect(client.get('k')).rejects.toThrow(/NOAUTH/i);
+        } finally {
+            client.destroy();
+        }
+    });
+});

--- a/packages/kvstore/lib/redisClient.ts
+++ b/packages/kvstore/lib/redisClient.ts
@@ -1,0 +1,104 @@
+import { readFileSync } from 'node:fs';
+
+import { envs } from './env.js';
+
+export type RedisBoundary = 'system' | 'customer';
+
+const reconnectStrategy = (retries: number): number => Math.min(retries * 200, 2000);
+
+/**
+ * Resolve the system-boundary Redis URL.
+ *
+ * When a token file is configured the URL carries no inline credentials — they
+ * are supplied by the credentials provider in {@link getRedisClientOptions}.
+ */
+export function getRedisUrl(): string | undefined {
+    if (envs.NANGO_REDIS_URL) {
+        return envs.NANGO_REDIS_URL;
+    }
+    const endpoint = envs.NANGO_REDIS_HOST;
+    const port = envs.NANGO_REDIS_PORT || 6379;
+    if (!endpoint) {
+        return undefined;
+    }
+    if (envs.NANGO_REDIS_AUTH_TOKEN_FILE) {
+        return `rediss://${endpoint}:${port}`;
+    }
+    const auth = envs.NANGO_REDIS_AUTH;
+    if (auth) {
+        return `rediss://:${auth}@${endpoint}:${port}`;
+    }
+    return undefined;
+}
+
+/** Resolve the customer-boundary Redis URL. See {@link getRedisUrl}. */
+export function getCustomerRedisUrl(): string | undefined {
+    if (envs.NANGO_CUSTOMER_REDIS_URL) {
+        return envs.NANGO_CUSTOMER_REDIS_URL;
+    }
+    const endpoint = envs.NANGO_CUSTOMER_REDIS_HOST;
+    const port = envs.NANGO_CUSTOMER_REDIS_PORT || 6379;
+    if (!endpoint) {
+        return undefined;
+    }
+    if (envs.NANGO_CUSTOMER_REDIS_AUTH_TOKEN_FILE) {
+        return `rediss://${endpoint}:${port}`;
+    }
+    const auth = envs.NANGO_CUSTOMER_REDIS_AUTH;
+    if (auth) {
+        return `rediss://:${auth}@${endpoint}:${port}`;
+    }
+    return undefined;
+}
+
+function getBoundaryTokenAuth(boundary: RedisBoundary): { username: string | undefined; tokenFile: string | undefined } {
+    if (boundary === 'customer') {
+        return { username: envs.NANGO_CUSTOMER_REDIS_USERNAME, tokenFile: envs.NANGO_CUSTOMER_REDIS_AUTH_TOKEN_FILE };
+    }
+    return { username: envs.NANGO_REDIS_USERNAME, tokenFile: envs.NANGO_REDIS_AUTH_TOKEN_FILE };
+}
+
+/**
+ * Build node-redis client options for a URL, centralizing TLS/socket settings
+ * and (optionally) rotating-token authentication.
+ *
+ * When the boundary has `NANGO_(CUSTOMER_)REDIS_AUTH_TOKEN_FILE` set, an async
+ * credentials provider is attached. node-redis invokes it on every (re)connect
+ * handshake, so a token rotated on disk (e.g. GCP/AWS/Azure IAM auth) is always
+ * read fresh — no inline credentials in the URL and no manual re-AUTH needed.
+ * When unset, behaviour is identical to the previous static-auth setup.
+ */
+export function getRedisClientOptions(url: string, boundary: RedisBoundary = 'system') {
+    const isExternal = url.startsWith('rediss://');
+    const socket = isExternal
+        ? {
+              reconnectStrategy,
+              connectTimeout: 10_000,
+              tls: true as const,
+              servername: new URL(url).hostname,
+              // node-redis v5 enables keepAlive by default (initial delay 5s); keep the
+              // previous 60s initial delay so behaviour matches the pre-v5 setup.
+              keepAlive: true,
+              keepAliveInitialDelay: 60_000
+          }
+        : {};
+
+    const { username, tokenFile } = getBoundaryTokenAuth(boundary);
+    const credentialsProvider = tokenFile
+        ? {
+              type: 'async-credentials-provider' as const,
+              credentials: () => {
+                  const password = readFileSync(tokenFile, 'utf8').trim();
+                  return Promise.resolve(username !== undefined ? { username, password } : { password });
+              }
+          }
+        : undefined;
+
+    return {
+        url,
+        disableOfflineQueue: true,
+        pingInterval: 30_000,
+        socket,
+        ...(credentialsProvider ? { credentialsProvider } : {})
+    };
+}

--- a/packages/kvstore/lib/redisClient.unit.test.ts
+++ b/packages/kvstore/lib/redisClient.unit.test.ts
@@ -1,0 +1,128 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+// Mutable mock env, shared by reference with the module under test.
+const mockEnvs = {
+    NANGO_REDIS_URL: undefined as string | undefined,
+    NANGO_REDIS_HOST: undefined as string | undefined,
+    NANGO_REDIS_PORT: undefined as number | undefined,
+    NANGO_REDIS_AUTH: undefined as string | undefined,
+    NANGO_REDIS_USERNAME: undefined as string | undefined,
+    NANGO_REDIS_AUTH_TOKEN_FILE: undefined as string | undefined,
+    NANGO_CUSTOMER_REDIS_URL: undefined as string | undefined,
+    NANGO_CUSTOMER_REDIS_HOST: undefined as string | undefined,
+    NANGO_CUSTOMER_REDIS_PORT: undefined as number | undefined,
+    NANGO_CUSTOMER_REDIS_AUTH: undefined as string | undefined,
+    NANGO_CUSTOMER_REDIS_USERNAME: undefined as string | undefined,
+    NANGO_CUSTOMER_REDIS_AUTH_TOKEN_FILE: undefined as string | undefined
+};
+
+vi.mock('./env.js', () => ({ envs: mockEnvs }));
+
+const readFileSync = vi.fn();
+vi.mock('node:fs', () => ({ readFileSync: (...args: unknown[]) => readFileSync(...args) }));
+
+const { getRedisUrl, getCustomerRedisUrl, getRedisClientOptions } = await import('./redisClient.js');
+
+function resetEnv() {
+    for (const key of Object.keys(mockEnvs)) {
+        (mockEnvs as Record<string, unknown>)[key] = undefined;
+    }
+}
+
+describe('getRedisUrl', () => {
+    beforeEach(resetEnv);
+
+    it('returns NANGO_REDIS_URL verbatim when set', () => {
+        mockEnvs.NANGO_REDIS_URL = 'rediss://example:6379';
+        expect(getRedisUrl()).toBe('rediss://example:6379');
+    });
+
+    it('builds a url with inline auth from host/port/auth', () => {
+        mockEnvs.NANGO_REDIS_HOST = 'host';
+        mockEnvs.NANGO_REDIS_PORT = 6380;
+        mockEnvs.NANGO_REDIS_AUTH = 'secret';
+        expect(getRedisUrl()).toBe('rediss://:secret@host:6380');
+    });
+
+    it('omits inline auth when a token file is configured', () => {
+        mockEnvs.NANGO_REDIS_HOST = 'host';
+        mockEnvs.NANGO_REDIS_AUTH_TOKEN_FILE = '/run/secrets/token';
+        expect(getRedisUrl()).toBe('rediss://host:6379');
+    });
+
+    it('returns undefined when host is set but neither auth nor token file is', () => {
+        mockEnvs.NANGO_REDIS_HOST = 'host';
+        expect(getRedisUrl()).toBeUndefined();
+    });
+
+    it('returns undefined when nothing is configured', () => {
+        expect(getRedisUrl()).toBeUndefined();
+    });
+});
+
+describe('getCustomerRedisUrl', () => {
+    beforeEach(resetEnv);
+
+    it('omits inline auth when a customer token file is configured', () => {
+        mockEnvs.NANGO_CUSTOMER_REDIS_HOST = 'chost';
+        mockEnvs.NANGO_CUSTOMER_REDIS_AUTH_TOKEN_FILE = '/run/secrets/customer-token';
+        expect(getCustomerRedisUrl()).toBe('rediss://chost:6379');
+    });
+});
+
+describe('getRedisClientOptions', () => {
+    beforeEach(() => {
+        resetEnv();
+        readFileSync.mockReset();
+    });
+
+    it('builds a TLS socket and no credentials provider for a rediss url without token file', () => {
+        const options = getRedisClientOptions('rediss://host:6379');
+        expect(options.socket).toMatchObject({ tls: true, connectTimeout: 10_000, servername: 'host' });
+        expect(typeof options.socket.reconnectStrategy).toBe('function');
+        expect('credentialsProvider' in options).toBe(false);
+    });
+
+    it('uses an empty socket for a non-TLS url', () => {
+        const options = getRedisClientOptions('redis://host:6379');
+        expect(options.socket).toEqual({});
+        expect('credentialsProvider' in options).toBe(false);
+    });
+
+    it('attaches an async credentials provider that reads the token file on every call', async () => {
+        mockEnvs.NANGO_REDIS_AUTH_TOKEN_FILE = '/run/secrets/token';
+        readFileSync.mockReturnValueOnce('token-1\n').mockReturnValueOnce('token-2\n');
+
+        const options = getRedisClientOptions('rediss://host:6379');
+        const provider = (options as { credentialsProvider?: { type: string; credentials: () => Promise<{ username?: string; password?: string }> } })
+            .credentialsProvider;
+
+        expect(provider?.type).toBe('async-credentials-provider');
+        // Re-read on each (re)connect so a rotated token is always picked up.
+        await expect(provider!.credentials()).resolves.toEqual({ password: 'token-1' });
+        await expect(provider!.credentials()).resolves.toEqual({ password: 'token-2' });
+        expect(readFileSync).toHaveBeenCalledTimes(2);
+    });
+
+    it('includes the username when configured', async () => {
+        mockEnvs.NANGO_REDIS_AUTH_TOKEN_FILE = '/run/secrets/token';
+        mockEnvs.NANGO_REDIS_USERNAME = 'iam-principal';
+        readFileSync.mockReturnValue('the-token');
+
+        const options = getRedisClientOptions('rediss://host:6379');
+        const provider = (options as { credentialsProvider?: { credentials: () => Promise<{ username?: string; password?: string }> } }).credentialsProvider;
+
+        await expect(provider!.credentials()).resolves.toEqual({ username: 'iam-principal', password: 'the-token' });
+    });
+
+    it('uses the customer token file for the customer boundary', async () => {
+        mockEnvs.NANGO_CUSTOMER_REDIS_AUTH_TOKEN_FILE = '/run/secrets/customer-token';
+        readFileSync.mockReturnValue('customer-token');
+
+        const options = getRedisClientOptions('rediss://chost:6379', 'customer');
+        const provider = (options as { credentialsProvider?: { credentials: () => Promise<{ password?: string }> } }).credentialsProvider;
+
+        await expect(provider!.credentials()).resolves.toEqual({ password: 'customer-token' });
+        expect(readFileSync).toHaveBeenCalledWith('/run/secrets/customer-token', 'utf8');
+    });
+});

--- a/packages/kvstore/package.json
+++ b/packages/kvstore/package.json
@@ -15,9 +15,10 @@
     },
     "dependencies": {
         "@nangohq/utils": "file:../utils",
-        "redis": "4.6.13"
+        "redis": "5.12.1"
     },
     "devDependencies": {
+        "testcontainers": "11.14.0",
         "vitest": "4.1.8"
     },
     "files": [

--- a/packages/server/lib/clients/publisher.client.ts
+++ b/packages/server/lib/clients/publisher.client.ts
@@ -1,7 +1,7 @@
 import { createClient } from 'redis';
 import * as uuid from 'uuid';
 
-import { getRedisUrl } from '@nangohq/shared';
+import { getRedisClientOptions, getRedisUrl } from '@nangohq/kvstore';
 import { getLogger } from '@nangohq/utils';
 
 import { authHtml } from '../utils/html.js';
@@ -19,30 +19,13 @@ export type WebSocketClientId = string;
 export class Redis {
     // Two redis clients are needed because the same client cannot be used for both publishing and subscribing
     // more at https://redis.io/commands/subscribe/
-    private url: string;
     private pub: RedisClientType;
     private sub: RedisClientType;
 
     constructor(url: string) {
-        this.url = url;
-
-        const isExternal = url.startsWith('rediss://');
-        const socket = isExternal
-            ? {
-                  reconnectStrategy: (retries: number) => Math.min(retries * 200, 2000),
-                  connectTimeout: 10_000,
-                  tls: true,
-                  servername: new URL(url).hostname,
-                  keepAlive: 60_000
-              }
-            : {};
-
-        this.pub = createClient({
-            url: this.url,
-            disableOfflineQueue: true,
-            pingInterval: 30_000,
-            socket
-        });
+        // Separate options objects: node-redis mutates the options it receives,
+        // and pub/sub must be two independent clients.
+        this.pub = createClient(getRedisClientOptions(url));
         this.pub.on('error', (err: Error) => {
             logger.error(`Redis (publisher) error`, err);
         });
@@ -50,12 +33,7 @@ export class Redis {
             logger.info(`Redis (publisher) connected`);
         });
 
-        this.sub = createClient({
-            url: this.url,
-            disableOfflineQueue: true,
-            pingInterval: 30_000,
-            socket
-        });
+        this.sub = createClient(getRedisClientOptions(url));
         this.sub.on('error', (err: Error) => {
             logger.error(`Redis (subscriber) error`, err);
         });

--- a/packages/server/lib/middleware/ratelimit.middleware.ts
+++ b/packages/server/lib/middleware/ratelimit.middleware.ts
@@ -2,7 +2,7 @@ import path from 'node:path';
 
 import { RateLimiterMemory, RateLimiterRedis, RateLimiterRes } from 'rate-limiter-flexible';
 
-import { getRedisUrl } from '@nangohq/shared';
+import { getRedisUrl } from '@nangohq/kvstore';
 import { flagHasAPIRateLimit, flagHasPlan, getLogger } from '@nangohq/utils';
 
 import { envs } from '../env.js';

--- a/packages/server/lib/middleware/webhook-ingress-ratelimit.middleware.ts
+++ b/packages/server/lib/middleware/webhook-ingress-ratelimit.middleware.ts
@@ -1,6 +1,6 @@
 import { RateLimiterMemory, RateLimiterRedis, RateLimiterRes } from 'rate-limiter-flexible';
 
-import { getRedisUrl } from '@nangohq/shared';
+import { getRedisUrl } from '@nangohq/kvstore';
 import { getLogger, metrics } from '@nangohq/utils';
 
 import { envs } from '../env.js';

--- a/packages/server/lib/utils/rateLimiterRedisClient.ts
+++ b/packages/server/lib/utils/rateLimiterRedisClient.ts
@@ -1,21 +1,7 @@
 import { createClient } from 'redis';
 
-export async function createRateLimiterRedisClient(url: string): Promise<ReturnType<typeof createClient>> {
-    const isExternal = url.startsWith('rediss://');
-    const socket = isExternal
-        ? {
-              reconnectStrategy: (retries: number) => Math.min(retries * 200, 2000),
-              connectTimeout: 10_000,
-              tls: true,
-              servername: new URL(url).hostname,
-              keepAlive: 60_000
-          }
-        : {};
+import { getRedisClientOptions } from '@nangohq/kvstore';
 
-    return createClient({
-        url,
-        disableOfflineQueue: true,
-        pingInterval: 30_000,
-        socket
-    }).connect();
+export async function createRateLimiterRedisClient(url: string): Promise<ReturnType<typeof createClient>> {
+    return createClient(getRedisClientOptions(url)).connect();
 }

--- a/packages/server/package.json
+++ b/packages/server/package.json
@@ -62,7 +62,7 @@
         "passport-local": "1.0.0",
         "qs": "6.15.0",
         "rate-limiter-flexible": "5.0.3",
-        "redis": "4.6.13",
+        "redis": "5.12.1",
         "semver": "7.6.3",
         "serialize-error": "11.0.3",
         "simple-oauth2": "5.1.0",

--- a/packages/utils/lib/environment/parse.ts
+++ b/packages/utils/lib/environment/parse.ts
@@ -427,12 +427,18 @@ export const ENVS = z.object({
     NANGO_REDIS_HOST: z.string().optional(),
     NANGO_REDIS_PORT: z.coerce.number().optional().default(6379),
     NANGO_REDIS_AUTH: z.string().optional(),
+    // Optional AUTH username (e.g. IAM principal). Defaults to 'default' when a token is provided without a username.
+    NANGO_REDIS_USERNAME: z.string().optional(),
+    // Path to a file holding a short-lived auth token (e.g. IAM). Re-read on every (re)connect so rotated tokens work.
+    NANGO_REDIS_AUTH_TOKEN_FILE: z.string().optional(),
 
     // Redis (customer boundary)
     NANGO_CUSTOMER_REDIS_URL: z.url().optional(),
     NANGO_CUSTOMER_REDIS_HOST: z.string().optional(),
     NANGO_CUSTOMER_REDIS_PORT: z.coerce.number().optional().default(6379),
     NANGO_CUSTOMER_REDIS_AUTH: z.string().optional(),
+    NANGO_CUSTOMER_REDIS_USERNAME: z.string().optional(),
+    NANGO_CUSTOMER_REDIS_AUTH_TOKEN_FILE: z.string().optional(),
 
     // Render
     RENDER_API_KEY: z.string().optional(),


### PR DESCRIPTION
## Context

Self-hosting Nango against a managed Redis/Valkey that enforces **IAM authentication** (e.g. GCP Memorystore for Valkey) requires a **short-lived token** (~1h) as the AUTH password, refreshed before it expires. Previously Nango read a static auth string once at startup and embedded it in the connection URL, and node-redis v4 had no way to supply fresh credentials on reconnect — so the connection would break once the token rotated.

## What changed

- **Upgrade node-redis `4.6.13` → `5.12.1`** (kvstore, server, jobs).
- **Centralize Redis client creation** in `getRedisClientOptions()` (`packages/kvstore/lib/redisClient.ts`): a single place for TLS/socket settings and an optional async credentials provider. The 4 previously-duplicated `createClient` call sites (kvstore, publisher, rate-limiter, jobs/render) now go through it.
- **New env** `NANGO_REDIS_USERNAME` / `NANGO_REDIS_AUTH_TOKEN_FILE` (and `NANGO_CUSTOMER_REDIS_*` equivalents). When a token file is configured, an `AsyncCredentialsProvider` re-reads it on **every (re)connect handshake**, so a rotated token is always picked up without a restart. The token source stays out of the app (a cloud-agnostic file written by a sidecar/cron), so no cloud SDK is pulled into Nango.
- **Adapt `RedisStore` to v5**: `scanIterator` now yields batches; `multi.exec` typing.

## Backward compatibility

With **no new env set**, behaviour is unchanged: the generated `rediss://` URL is identical, and the `AUTH` command sent is the same (`AUTH <password>` for `requirepass`, `AUTH <user> <password>` for ACL). Verified against node-redis v5's URL parsing + AUTH command construction, and by a `requirepass` integration test.

## Why async (not streaming) is the right fit here

Per GCP docs, **Memorystore for Valkey keeps already-authenticated connections alive even after the token expires** — the token only matters at (re)connect time. So there is no hourly reconnect churn to proactively avoid, and the async-at-reconnect provider is sufficient (a `StreamingCredentialsProvider` would add complexity for no benefit).

## Testing

- `npm run ts-build`: passes
- Unit: **45 passed** (incl. new factory tests: static vs token-file, username, customer boundary)
- Integration (real Redis via testcontainers): **25 passed** — 23 `RedisStore` (v5 `scanIterator`/`multi`/`eval`/`set`) + 2 new `requirepass` (static-auth backward compat under v5)
- ESLint / Prettier: clean

## Operational requirement (for IAM mode)

A token refresher (sidecar / cron) must keep the token file populated with a **currently-valid** token and **write it atomically** (temp + rename). The runner (`customer`) boundary uses its own `NANGO_CUSTOMER_REDIS_AUTH_TOKEN_FILE`.

## Draft — follow-ups before marking ready

- [ ] Add a concrete sidecar example (token-refresh loop + k8s shared-volume snippet) to the self-hosting guide (needs verification).
- [ ] Broader v5 runtime regression for pub/sub and rate-limiter.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
