### PR TITLE
fix(usage): resolve environment_id to env name in /plans/billing-usage breakdown

### DIFF
--- a/packages/server/lib/controllers/v1/plans/usage/getBillingUsage.integration.test.ts
+++ b/packages/server/lib/controllers/v1/plans/usage/getBillingUsage.integration.test.ts
@@ -148,12 +148,12 @@ function seedFixture(accountId: number): ClickhouseRawUsageEvent[] {
     ];
 }
 
-async function seedAccount(): Promise<{ apiKey: { secret: string }; accountId: number }> {
-    const { plan, apiKey, account } = await seeders.seedAccountEnvAndUser();
+async function seedAccount(): Promise<{ apiKey: { secret: string }; accountId: number; envId: number; envName: string }> {
+    const { plan, apiKey, account, env } = await seeders.seedAccountEnvAndUser();
     await updatePlan(db.knex, { id: plan.id, orb_customer_id: 'orb_cust_123', orb_subscription_id: 'orb_sub_123' });
     clickhouse.addRaw(seedFixture(account.id));
     await clickhouse.flush();
-    return { apiKey, accountId: account.id };
+    return { apiKey, accountId: account.id, envId: env.id, envName: env.name };
 }
 
 describe(`GET ${route}`, () => {
@@ -317,6 +317,47 @@ describe(`GET ${route}`, () => {
             expect(groups).toEqual(expect.arrayContaining(['hubspot', 'salesforce']));
             for (const series of records.breakdown!) {
                 expect(series.group!.key).toBe('integration_id');
+            }
+        });
+
+        it('proxy by environment_id — group.value resolved to env name, not raw id', async () => {
+            const { apiKey, accountId, envId, envName } = await seedAccount();
+            // The default fixture is seeded with `environmentId: 1` (a phantom);
+            // add events that carry the seeded account's REAL env id so the
+            // postgres lookup resolves to a real env name.
+            clickhouse.addRaw([
+                {
+                    ts: day0.getTime(),
+                    type: 'usage.proxy',
+                    idempotency_key: randomUUID(),
+                    account_id: accountId,
+                    value: 3,
+                    attributes: { environmentId: envId, success: true, integrationId: 'hubspot', connectionId: 'c-h' }
+                }
+            ]);
+            await clickhouse.flush();
+
+            const res = await api.fetch(route, {
+                token: apiKey.secret,
+                query: {
+                    env: 'dev',
+                    from: day0.toISOString(),
+                    to: end.toISOString(),
+                    source: 'clickhouse',
+                    metrics: ['proxy'],
+                    breakdown: { proxy: 'environment_id' }
+                } as any
+            });
+            isSuccess(res.json);
+            const proxy = res.json.data.usage.proxy;
+            expect(proxy.breakdown).toBeDefined();
+            const groupValues = proxy.breakdown!.map((b) => b.group!.value);
+            // Seeded env's id replaced by its name; phantom id `1` has no env in
+            // postgres so it falls back to the raw value.
+            expect(groupValues).toContain(envName);
+            expect(groupValues).not.toContain(String(envId));
+            for (const series of proxy.breakdown!) {
+                expect(series.group!.key).toBe('environment_id');
             }
         });
 

--- a/packages/server/lib/controllers/v1/plans/usage/getBillingUsage.ts
+++ b/packages/server/lib/controllers/v1/plans/usage/getBillingUsage.ts
@@ -1,6 +1,7 @@
 import z from 'zod';
 
 import { billing } from '@nangohq/billing';
+import { environmentService } from '@nangohq/shared';
 import { BREAKDOWN_DIMENSIONS, FILTER_PARAM_TYPE_FOR_DIM, TOP_N_BREAKDOWN_CAP } from '@nangohq/usage';
 import { zodErrorToHTTP } from '@nangohq/utils';
 
@@ -9,7 +10,7 @@ import { asyncWrapper } from '../../../../utils/asyncWrapper.js';
 import { linkBillingCustomer, linkBillingFreeSubscription } from '../../../../utils/billing.js';
 import { usageTracker } from '../../../../utils/usage.js';
 
-import type { GetBillingUsage, GetBillingUsageOpts, UsageMetric } from '@nangohq/types';
+import type { BillingUsageMetrics, GetBillingUsage, GetBillingUsageOpts, UsageMetric } from '@nangohq/types';
 
 // z.enum(BREAKDOWN_DIMENSIONS[m]) — output type is the per-metric dim union,
 // matching `BreakdownDimensions[m]` from @nangohq/types. Single source of
@@ -202,6 +203,8 @@ export const getBillingUsage = asyncWrapper<GetBillingUsage>(async (req, res) =>
         return;
     }
 
+    await resolveEnvironmentNamesInBreakdown(usage.value);
+
     res.status(200).send({
         data: {
             customer: customerRes.value,
@@ -209,3 +212,29 @@ export const getBillingUsage = asyncWrapper<GetBillingUsage>(async (req, res) =>
         }
     });
 });
+
+// `group.value` arrives as a stringified Int64 for the `environment_id`
+// dimension (the CH column type). Swap in the env name so the dashboard
+// renders human-readable legends instead of raw IDs. Bounded by TOP_N per
+// metric × number-of-metrics, so the lookup is tiny.
+async function resolveEnvironmentNamesInBreakdown(usage: BillingUsageMetrics): Promise<void> {
+    const envIds = new Set<number>();
+    for (const m of Object.keys(usage) as UsageMetric[]) {
+        for (const series of usage[m]?.breakdown ?? []) {
+            if (series.group?.key === 'environment_id' && series.group.value !== 'rest') {
+                const id = Number(series.group.value);
+                if (Number.isFinite(id)) envIds.add(id);
+            }
+        }
+    }
+    if (envIds.size === 0) return;
+    const names = await environmentService.getEnvironmentNamesByIds([...envIds]);
+    for (const m of Object.keys(usage) as UsageMetric[]) {
+        for (const series of usage[m]?.breakdown ?? []) {
+            if (series.group?.key === 'environment_id' && series.group.value !== 'rest') {
+                const name = names.get(Number(series.group.value));
+                if (name) series.group.value = name;
+            }
+        }
+    }
+}

--- a/packages/server/lib/controllers/v1/plans/usage/getBillingUsage.ts
+++ b/packages/server/lib/controllers/v1/plans/usage/getBillingUsage.ts
@@ -1,7 +1,6 @@
 import z from 'zod';
 
 import { billing } from '@nangohq/billing';
-import { environmentService } from '@nangohq/shared';
 import { BREAKDOWN_DIMENSIONS, FILTER_PARAM_TYPE_FOR_DIM, TOP_N_BREAKDOWN_CAP } from '@nangohq/usage';
 import { zodErrorToHTTP } from '@nangohq/utils';
 
@@ -10,7 +9,7 @@ import { asyncWrapper } from '../../../../utils/asyncWrapper.js';
 import { linkBillingCustomer, linkBillingFreeSubscription } from '../../../../utils/billing.js';
 import { usageTracker } from '../../../../utils/usage.js';
 
-import type { BillingUsageMetrics, GetBillingUsage, GetBillingUsageOpts, UsageMetric } from '@nangohq/types';
+import type { GetBillingUsage, GetBillingUsageOpts, UsageMetric } from '@nangohq/types';
 
 // z.enum(BREAKDOWN_DIMENSIONS[m]) — output type is the per-metric dim union,
 // matching `BreakdownDimensions[m]` from @nangohq/types. Single source of
@@ -203,8 +202,6 @@ export const getBillingUsage = asyncWrapper<GetBillingUsage>(async (req, res) =>
         return;
     }
 
-    await resolveEnvironmentNamesInBreakdown(usage.value);
-
     res.status(200).send({
         data: {
             customer: customerRes.value,
@@ -212,29 +209,3 @@ export const getBillingUsage = asyncWrapper<GetBillingUsage>(async (req, res) =>
         }
     });
 });
-
-// `group.value` arrives as a stringified Int64 for the `environment_id`
-// dimension (the CH column type). Swap in the env name so the dashboard
-// renders human-readable legends instead of raw IDs. Bounded by TOP_N per
-// metric × number-of-metrics, so the lookup is tiny.
-async function resolveEnvironmentNamesInBreakdown(usage: BillingUsageMetrics): Promise<void> {
-    const envIds = new Set<number>();
-    for (const m of Object.keys(usage) as UsageMetric[]) {
-        for (const series of usage[m]?.breakdown ?? []) {
-            if (series.group?.key === 'environment_id' && series.group.value !== 'rest') {
-                const id = Number(series.group.value);
-                if (Number.isFinite(id)) envIds.add(id);
-            }
-        }
-    }
-    if (envIds.size === 0) return;
-    const names = await environmentService.getEnvironmentNamesByIds([...envIds]);
-    for (const m of Object.keys(usage) as UsageMetric[]) {
-        for (const series of usage[m]?.breakdown ?? []) {
-            if (series.group?.key === 'environment_id' && series.group.value !== 'rest') {
-                const name = names.get(Number(series.group.value));
-                if (name) series.group.value = name;
-            }
-        }
-    }
-}

--- a/packages/usage/lib/usage.ts
+++ b/packages/usage/lib/usage.ts
@@ -78,25 +78,19 @@ export function resolveBillingUsageSource(accountId: number, requestedSource: 'c
     return respected ?? (shouldUseClickhouseFor(accountId) ? 'clickhouse' : 'orb');
 }
 
-async function resolveEnvironmentNamesInBreakdown(usage: BillingUsageMetrics): Promise<void> {
-    const envIds = new Set<number>();
-    for (const m of Object.keys(usage) as UsageMetric[]) {
-        for (const series of usage[m]?.breakdown ?? []) {
-            if (series.group?.key === 'environment_id' && series.group.value !== 'rest') {
-                const id = Number(series.group.value);
-                if (Number.isFinite(id)) envIds.add(id);
-            }
-        }
-    }
-    if (envIds.size === 0) return;
-    const names = await environmentService.getEnvironmentNamesByIds([...envIds]);
-    for (const m of Object.keys(usage) as UsageMetric[]) {
-        for (const series of usage[m]?.breakdown ?? []) {
-            if (series.group?.key === 'environment_id' && series.group.value !== 'rest') {
-                const name = names.get(Number(series.group.value));
-                if (name) series.group.value = name;
-            }
-        }
+async function resolveEnvironmentNamesInBreakdown(
+    usage: BillingUsageMetrics,
+    breakdown: { [M in UsageMetric]?: BreakdownDimensions[M] | undefined } | undefined
+): Promise<void> {
+    const metrics = (Object.keys(breakdown ?? {}) as UsageMetric[]).filter((m) => breakdown?.[m] === 'environment_id');
+    if (metrics.length === 0) return;
+    const series = metrics.flatMap((m) => usage[m]?.breakdown ?? []).filter((s) => s.group && s.group.value !== 'rest');
+    const envIds = series.map((s) => Number(s.group!.value)).filter(Number.isFinite);
+    if (envIds.length === 0) return;
+    const names = await environmentService.getEnvironmentNamesByIds(envIds);
+    for (const s of series) {
+        const name = names.get(Number(s.group!.value));
+        if (name) s.group!.value = name;
     }
 }
 
@@ -615,7 +609,7 @@ export class UsageTracker implements IUsageTracker {
                 breakdown: toRunningAvgUsage(br.value)
             };
         }
-        await resolveEnvironmentNamesInBreakdown(result);
+        await resolveEnvironmentNamesInBreakdown(result, breakdown);
         return Ok(result);
     }
 

--- a/packages/usage/lib/usage.ts
+++ b/packages/usage/lib/usage.ts
@@ -78,6 +78,28 @@ export function resolveBillingUsageSource(accountId: number, requestedSource: 'c
     return respected ?? (shouldUseClickhouseFor(accountId) ? 'clickhouse' : 'orb');
 }
 
+async function resolveEnvironmentNamesInBreakdown(usage: BillingUsageMetrics): Promise<void> {
+    const envIds = new Set<number>();
+    for (const m of Object.keys(usage) as UsageMetric[]) {
+        for (const series of usage[m]?.breakdown ?? []) {
+            if (series.group?.key === 'environment_id' && series.group.value !== 'rest') {
+                const id = Number(series.group.value);
+                if (Number.isFinite(id)) envIds.add(id);
+            }
+        }
+    }
+    if (envIds.size === 0) return;
+    const names = await environmentService.getEnvironmentNamesByIds([...envIds]);
+    for (const m of Object.keys(usage) as UsageMetric[]) {
+        for (const series of usage[m]?.breakdown ?? []) {
+            if (series.group?.key === 'environment_id' && series.group.value !== 'rest') {
+                const name = names.get(Number(series.group.value));
+                if (name) series.group.value = name;
+            }
+        }
+    }
+}
+
 export interface UsageStatus {
     accountId: number;
     metric: UsageMetric;
@@ -593,6 +615,7 @@ export class UsageTracker implements IUsageTracker {
                 breakdown: toRunningAvgUsage(br.value)
             };
         }
+        await resolveEnvironmentNamesInBreakdown(result);
         return Ok(result);
     }
 


### PR DESCRIPTION
- Breakdown series on `GET /plans/billing-usage` carried `group: { key: 'environment_id', value: '37521' }` straight through to the client. The CH column is `Int64`, so the stringified raw id reached the dashboard legend.
- Mirrors what NangoHQ/nango#6389 did for `/top-dimension-values`, but on a different code path that wasn't covered there. Controller post-processes the response: collects env ids from every `breakdown[].group` keyed on `environment_id`, batch-resolves names via the existing `environmentService.getEnvironmentNamesByIds`, substitutes. Bounded by `TOP_N_BREAKDOWN_CAP` × number-of-metrics, negligible cost.

## Test plan

- [x] `npm run ts-build` passes.
- [x] New integration test (`proxy by environment_id`) seeds events with the seeded account's real env id, requests `breakdown: { proxy: 'environment_id' }`, asserts that `group.value` contains the env name and NOT the raw id.
- [ ] After deploy, the prod response that triggered this bug should now show env names in the `connections.breakdown[].group.value` field instead of `"37521"` / `"37522"`.