### PR TITLE
feat(webapp): show dev tools panel for Nango admins in production

### DIFF
--- a/packages/webapp/src/app/App.tsx
+++ b/packages/webapp/src/app/App.tsx
@@ -4,7 +4,7 @@ import { useLocalStorage } from 'react-use';
 import { Toaster } from 'sonner';
 
 import { router } from './router';
-import { DevToolPanel, isDevToolsEnabled } from '@/features/DevToolPanel';
+import { DevToolPanel, useIsDevToolsEnabled } from '@/features/DevToolPanel';
 import { useMeta } from '@/hooks/useMeta';
 import { useUser } from '@/hooks/useUser';
 import { useTheme } from '@/lib/theme';
@@ -14,6 +14,7 @@ import { LocalStorageKeys } from '@/utils/local-storage';
 
 const App = () => {
     const env = useStore((state) => state.env);
+    const isDevToolsEnabled = useIsDevToolsEnabled();
     const setShowGettingStarted = useStore((state) => state.setShowGettingStarted);
     // Sync persisted theme preference to the DOM
     useTheme();

--- a/packages/webapp/src/features/DevToolPanel.tsx
+++ b/packages/webapp/src/features/DevToolPanel.tsx
@@ -4,15 +4,30 @@ import { create } from 'zustand';
 
 import { Button } from '@/components/ui/Button';
 import { Switch } from '@/components/ui/Switch';
+import { useTeam } from '@/hooks/useTeam';
+import { useStore } from '@/store';
 import { useFeatureFlagsStore } from '@/store/feature-flags';
 
 /**
- * True when the dev tool panel should be available:
+ * True when the dev tool panel is available based on the current hostname:
  * - local Vite dev server
  * - *.app-development.nango.dev (development deployment and PR previews)
  */
-export const isDevToolsEnabled =
+const isDevToolsEnabledByHostname =
     import.meta.env.DEV || window.location.hostname === 'app-development.nango.dev' || window.location.hostname.endsWith('.app-development.nango.dev');
+
+/**
+ * Returns true when the dev tool panel should be available — either on a dev
+ * hostname or when the signed-in account is the Nango admin team.
+ *
+ * Defaults to false until the team query resolves, so there is no flash on
+ * first paint for non-admin accounts.
+ */
+export function useIsDevToolsEnabled(): boolean {
+    const env = useStore((s) => s.env);
+    const { data } = useTeam(env);
+    return isDevToolsEnabledByHostname || (data?.data.isAdminTeam ?? false);
+}
 
 // Toggle with: Ctrl+Shift+D
 export const DEV_PANEL_SHORTCUT = 'KeyD';

--- a/packages/webapp/src/layout/AppHeader.tsx
+++ b/packages/webapp/src/layout/AppHeader.tsx
@@ -6,7 +6,7 @@ import { SlackIcon } from '@/assets/SlackIcon';
 import { Breadcrumbs } from '@/components/patterns/Breadcrumbs';
 import { PermissionGate } from '@/components/patterns/PermissionGate';
 import { Button, ButtonLink } from '@/components/ui/Button';
-import { isDevToolsEnabled } from '@/features/DevToolPanel';
+import { useIsDevToolsEnabled } from '@/features/DevToolPanel';
 import { useEnvironment } from '@/hooks/useEnvironment';
 import { usePermissions } from '@/hooks/usePermissions';
 import { useThemeStore } from '@/lib/theme';
@@ -27,6 +27,7 @@ export const AppHeader: React.FC = () => {
     const themeSwitcher = useFeatureFlagsStore((s) => s.themeSwitcher);
     const darkMode = useThemeStore((s) => s.darkMode);
     const toggleDarkMode = useThemeStore((s) => s.toggleDarkMode);
+    const isDevToolsEnabled = useIsDevToolsEnabled();
 
     return (
         <header className="h-16 px-10 pl-2 py-2.5 items-center flex justify-between shrink-0 gap-1.5">

--- a/packages/webapp/src/layout/AppSidebar/ProfileDropdown.tsx
+++ b/packages/webapp/src/layout/AppSidebar/ProfileDropdown.tsx
@@ -4,7 +4,7 @@ import { useNavigate } from 'react-router-dom';
 
 import { DropdownMenu, DropdownMenuContent, DropdownMenuItem, DropdownMenuSeparator, DropdownMenuTrigger } from '@/components/ui/DropdownMenu';
 import { SidebarMenu, SidebarMenuItem } from '@/components/ui/Sidebar';
-import { isDevToolsEnabled, useDevPanelStore } from '@/features/DevToolPanel';
+import { useDevPanelStore, useIsDevToolsEnabled } from '@/features/DevToolPanel';
 import { useMeta } from '@/hooks/useMeta';
 import { useUser } from '@/hooks/useUser';
 import { useStore } from '@/store';
@@ -20,6 +20,7 @@ export const ProfileDropdown: React.FC = () => {
     const { user } = useUser();
     const showGettingStarted = useStore((state) => state.showGettingStarted);
     const toggleDevPanel = useDevPanelStore((s) => s.toggle);
+    const isDevToolsEnabled = useIsDevToolsEnabled();
 
     const items = useMemo(() => {
         const list = [


### PR DESCRIPTION
## Problem

The dev tools panel (Ctrl+Shift+D) and its feature flags were only accessible on `localhost` and `*.app-development.nango.dev`. Nango team members on `app.nango.dev` had no way to toggle in-development features against production data.

## Solution

Replace the static `isDevToolsEnabled` hostname constant with a `useIsDevToolsEnabled()` hook that returns `true` when either the hostname check passes **or** the signed-in account is the Nango admin team (`isAdminTeam`). The hook defaults to `false` while the team query is in-flight, so there is no panel flash for non-admin accounts on first paint.

Fixes [NAN-5923](https://linear.app/nango/issue/NAN-5923)

## Testing

- Sign in as a non-Nango account on `app.nango.dev` — dev tools panel and "Dev Tools" menu item should not appear
- Sign in as the Nango admin account on `app.nango.dev` — Ctrl+Shift+D and the "Dev Tools" dropdown item should work
- On `localhost` or `app-development.nango.dev`, the panel is still available regardless of account
