### PR TITLE
fix(runner): UND_ERR_SOCKET retries skipped

### DIFF
--- a/packages/runner/lib/clients/http.ts
+++ b/packages/runner/lib/clients/http.ts
@@ -2,12 +2,16 @@ import { networkError, retryWithBackoff, stringifyError } from '@nangohq/utils';
 
 import { logger } from '../logger.js';
 
-function hasErrorCode(error: unknown): error is { code: string } {
-    return typeof error === 'object' && error !== null && 'code' in error && typeof (error as any).code === 'string';
+function getErrorCode(error: unknown): string | undefined {
+    if (typeof error !== 'object' || error === null) return undefined;
+    if ('code' in error && typeof (error as any).code === 'string') return (error as any).code;
+    if ('cause' in error) return getErrorCode((error as any).cause);
+    return undefined;
 }
 
 function shouldRetry(error: unknown, response?: Response): boolean {
-    if (hasErrorCode(error) && networkError.includes(error.code)) {
+    const code = getErrorCode(error);
+    if (code && networkError.includes(code)) {
         return true;
     }
 

--- a/packages/runner/lib/clients/http.unit.test.ts
+++ b/packages/runner/lib/clients/http.unit.test.ts
@@ -8,32 +8,63 @@ function makeSocketError(): Error {
     return Object.assign(new Error('other side closed'), { code: 'UND_ERR_SOCKET' });
 }
 
+function makeUndSocketError(): Error {
+    const cause = Object.assign(new Error('other side closed'), { code: 'UND_ERR_SOCKET' });
+    return Object.assign(new TypeError('fetch failed'), { cause });
+}
+
 afterEach(() => {
     vi.unstubAllGlobals();
 });
 
 describe('httpFetch', () => {
-    describe('UND_ERR_SOCKET', () => {
-        it('retries and succeeds when fetch eventually resolves', async () => {
-            const fetchMock = vi
-                .fn()
-                .mockRejectedValueOnce(makeSocketError())
-                .mockRejectedValueOnce(makeSocketError())
-                .mockResolvedValueOnce(new Response('ok', { status: 200 }));
-            vi.stubGlobal('fetch', fetchMock);
+    describe('retryable network errors', () => {
+        describe('error with code on root', () => {
+            it('retries and succeeds when fetch eventually resolves', async () => {
+                const fetchMock = vi
+                    .fn()
+                    .mockRejectedValueOnce(makeSocketError())
+                    .mockRejectedValueOnce(makeSocketError())
+                    .mockResolvedValueOnce(new Response('ok', { status: 200 }));
+                vi.stubGlobal('fetch', fetchMock);
 
-            const res = await httpFetch(url, undefined, { numOfAttempts: 3, startingDelay: 0 });
+                const res = await httpFetch(url, undefined, { numOfAttempts: 3, startingDelay: 0 });
 
-            expect(fetchMock).toHaveBeenCalledTimes(3);
-            expect(res.status).toBe(200);
+                expect(fetchMock).toHaveBeenCalledTimes(3);
+                expect(res.status).toBe(200);
+            });
+
+            it('returns 502 after all retries exhausted', async () => {
+                vi.stubGlobal('fetch', vi.fn().mockRejectedValue(makeSocketError()));
+
+                const res = await httpFetch(url, undefined, { numOfAttempts: 3, startingDelay: 0 });
+
+                expect(res.status).toBe(502);
+            });
         });
 
-        it('returns 502 after all retries exhausted', async () => {
-            vi.stubGlobal('fetch', vi.fn().mockRejectedValue(makeSocketError()));
+        describe('UND_ERR_SOCKET', () => {
+            it('retries and succeeds when fetch eventually resolves', async () => {
+                const fetchMock = vi
+                    .fn()
+                    .mockRejectedValueOnce(makeUndSocketError())
+                    .mockRejectedValueOnce(makeUndSocketError())
+                    .mockResolvedValueOnce(new Response('ok', { status: 200 }));
+                vi.stubGlobal('fetch', fetchMock);
 
-            const res = await httpFetch(url, undefined, { numOfAttempts: 3, startingDelay: 0 });
+                const res = await httpFetch(url, undefined, { numOfAttempts: 3, startingDelay: 0 });
 
-            expect(res.status).toBe(502);
+                expect(fetchMock).toHaveBeenCalledTimes(3);
+                expect(res.status).toBe(200);
+            });
+
+            it('returns 502 after all retries exhausted', async () => {
+                vi.stubGlobal('fetch', vi.fn().mockRejectedValue(makeUndSocketError()));
+
+                const res = await httpFetch(url, undefined, { numOfAttempts: 3, startingDelay: 0 });
+
+                expect(res.status).toBe(502);
+            });
         });
     });
 


### PR DESCRIPTION
HTTP retries on `persistClient`s are gated by the presence of a `code` field in the error object.

This retry logic failed on `UND_ERR_SOCKET` errors due to the `code` field not living in the object root, but rather under a `cause` field. This PR adjusts the logic so that we attempt to extract `code` from the root object and, when not present, from `cause`. The remainder of the retry logic remains unchanged.