### PR TITLE
fix(scheduler): run cancel task transition inside the transaction

### DIFF
--- a/packages/scheduler/lib/scheduler.ts
+++ b/packages/scheduler/lib/scheduler.ts
@@ -516,7 +516,7 @@ export class Scheduler {
     }): Promise<Result<Task>> {
         const newState: TaskState = 'CANCELLED';
         const cancelled: Result<Task> = await this.db.transaction(async (trx) => {
-            const res = await tasks.transitionState(this.db, {
+            const res = await tasks.transitionState(trx, {
                 taskId: taskId,
                 newState,
                 output: { reason }


### PR DESCRIPTION
## What

`cancel()` opens a transaction but runs `tasks.transitionState` on `this.db` (the connection pool) instead of `trx`. The task state `UPDATE` therefore runs on a separate pooled connection and auto-commits **outside** the transaction, while the follow-up `scheduleNextExecution` runs on `trx`.

The two writes are meant to be atomic. If the transaction rolls back after the state transition (DB error in `scheduleNextExecution`, serialization failure, or a failed commit), the task is left permanently `CANCELLED` while the schedule's `last_scheduled_task_state` / `next_execution_at` stay stale — desyncing schedule state.

## Change

Pass `trx`, matching `succeed()` and `fail()` which already run their transition on the transaction handle. One-token fix; no behavior change on the success path.

## Test

Scheduler integration suite passes (34/34); existing `cancel` coverage (callback fires, schedule update, `nextExecutionInMs` override, cancel-on-delete) confirms the normal flow is unaffected. The atomicity itself is only observable on a rollback, so no contrived fault-injection test was added.