### PR TITLE
fix(server): gate Slack alert admin routes with RBAC

### DIFF
--- a/packages/server/lib/authz/authz.integration.test.ts
+++ b/packages/server/lib/authz/authz.integration.test.ts
@@ -105,6 +105,35 @@ describe('authz integration', () => {
 
             expect(res.res.status).not.toBe(403);
         });
+
+        it('should allow GET prod Slack admin-auth helper', async () => {
+            const { user } = await seedAccountWithProdEnv();
+            const session = await authenticateUser(api, user);
+
+            // @ts-expect-error authz test — route not in endpoint types
+            const res = await api.fetch('/api/v1/environment/admin-auth', {
+                method: 'GET',
+                query: { env: 'prod', connection_id: 'account-x-1' },
+                session
+            });
+
+            expect(res.res.status).not.toBe(403);
+        });
+
+        it('should allow DELETE prod Slack admin connection helper', async () => {
+            const { user } = await seedAccountWithProdEnv();
+            const session = await authenticateUser(api, user);
+
+            // @ts-expect-error authz test — route not in endpoint types
+            const res = await api.fetch('/api/v1/connections/admin/:connectionId', {
+                method: 'DELETE',
+                query: { env: 'prod' },
+                params: { connectionId: 'account-x-1' },
+                session
+            });
+
+            expect(res.res.status).not.toBe(403);
+        });
     });
 
     // ── production_support — denied writes on prod ──────────
@@ -226,6 +255,37 @@ describe('authz integration', () => {
                 query: { env: 'dev' },
                 params: { id: 9999 },
                 body: { role: 'production_support' },
+                session
+            });
+
+            expect(res.res.status).toBe(403);
+        });
+
+        it('should deny GET prod Slack admin-auth helper', async () => {
+            const { account } = await seedAccountWithProdEnv();
+            const supportUser = await createUserWithRole(account.id, 'production_support');
+            const session = await authenticateUser(api, supportUser);
+
+            // @ts-expect-error authz test — route not in endpoint types
+            const res = await api.fetch('/api/v1/environment/admin-auth', {
+                method: 'GET',
+                query: { env: 'prod', connection_id: 'account-x-1' },
+                session
+            });
+
+            expect(res.res.status).toBe(403);
+        });
+
+        it('should deny DELETE prod Slack admin connection helper', async () => {
+            const { account } = await seedAccountWithProdEnv();
+            const supportUser = await createUserWithRole(account.id, 'production_support');
+            const session = await authenticateUser(api, supportUser);
+
+            // @ts-expect-error authz test — route not in endpoint types
+            const res = await api.fetch('/api/v1/connections/admin/:connectionId', {
+                method: 'DELETE',
+                query: { env: 'prod' },
+                params: { connectionId: 'account-x-1' },
                 session
             });
 

--- a/packages/server/lib/routes.private.ts
+++ b/packages/server/lib/routes.private.ts
@@ -221,7 +221,11 @@ web.route('/environment/api-keys/:keyId').patch(webAuth, can({ action: 'update',
 web.route('/environment/api-keys/:keyId').delete(webAuth, can({ action: 'update', resource: 'environment_key', scopedBy: envScope }), deleteApiKey);
 
 web.route('/environment/hmac').get(webAuth, environmentController.getHmacDigest.bind(environmentController));
-web.route('/environment/admin-auth').get(webAuth, environmentController.getAdminAuthInfo.bind(environmentController));
+web.route('/environment/admin-auth').get(
+    webAuth,
+    can({ action: 'update', resource: 'environment', scopedBy: envScope }),
+    environmentController.getAdminAuthInfo.bind(environmentController)
+);
 
 // Connect
 web.route('/connect/sessions').post(webAuth, can({ action: 'update', resource: 'connection', scopedBy: envScope }), postInternalConnectSessions);
@@ -256,7 +260,11 @@ web.route('/connections/count').get(webAuth, can({ action: 'read', resource: 'co
 web.route('/connections/:connectionId').get(webAuth, can({ action: 'read', resource: 'connection', scopedBy: envScope }), getConnectionWeb);
 web.route('/connections/:connectionId/refresh').post(webAuth, can({ action: 'update', resource: 'connection', scopedBy: envScope }), getConnectionRefresh);
 web.route('/connections/:connectionId').delete(webAuth, can({ action: 'delete', resource: 'connection', scopedBy: envScope }), deleteConnection);
-web.route('/connections/admin/:connectionId').delete(webAuth, connectionController.deleteAdminConnection.bind(connectionController));
+web.route('/connections/admin/:connectionId').delete(
+    webAuth,
+    can({ action: 'update', resource: 'environment', scopedBy: envScope }),
+    connectionController.deleteAdminConnection.bind(connectionController)
+);
 
 // User
 web.route('/user').get(webAuth, getUser);


### PR DESCRIPTION
- The Slack alert connect (`GET /environment/admin-auth`) and disconnect (`DELETE /connections/admin/:connectionId`) helper routes were registered with `webAuth` only — no authorization middleware — so any authenticated user, including a read-only `production_support`, could reach them. They now require `can({ action: 'update', resource: 'environment', scopedBy: envScope })`, matching the `canWriteProdEnvironment` gate the webapp already enforces for connecting/disconnecting Slack alerts.
- Added authz regression tests: `production_support` is forbidden (403) on both routes, and an administrator is not.

## Test plan
- [x] `npm run test:integration -- authz.integration` (36 passing)
- [x] Confirmed the new deny tests fail (400, not 403) when the guard is removed
- [ ] Verify on a deployed environment that an administrator can still connect/disconnect Slack alerts and a `production_support` user cannot