### PR TITLE
fix(sandbox): disable e2b background command timeout

### DIFF
--- a/packages/sandbox/lib/functions/deploy-client.ts
+++ b/packages/sandbox/lib/functions/deploy-client.ts
@@ -83,7 +83,7 @@ export async function prepareAsyncDeploy(request: AsyncDeployRequest): Promise<P
                 await sandbox.commands.run('node /tmp/nango-function-deploy.mjs', {
                     cwd: remoteFunctionProjectPath,
                     background: true,
-                    timeoutMs: 30_000,
+                    timeoutMs: 0,
                     envs: {
                         NO_COLOR: '1',
                         NANGO_SECRET_KEY: request.nango_secret_key,

--- a/packages/sandbox/lib/functions/deploy-client.unit.test.ts
+++ b/packages/sandbox/lib/functions/deploy-client.unit.test.ts
@@ -98,7 +98,7 @@ describe('remote function deploy client', () => {
         expect(mocks.run).toHaveBeenCalledWith('node /tmp/nango-function-deploy.mjs', {
             cwd: '/home/user/nango-integrations',
             background: true,
-            timeoutMs: 30_000,
+            timeoutMs: 0,
             envs: expect.objectContaining({
                 NANGO_DEPLOY_CALLBACK_URL: 'https://api.example.test/functions/deployments/7b539769-6d39-4442-89fc-33fbac96ea66/result',
                 NANGO_DEPLOY_ARGS: JSON.stringify([

--- a/packages/sandbox/lib/functions/dryrun-client.ts
+++ b/packages/sandbox/lib/functions/dryrun-client.ts
@@ -93,7 +93,7 @@ export async function prepareAsyncDryrun(request: AsyncDryrunRequest): Promise<P
                 await sandbox.commands.run('node /tmp/nango-function-dryrun.mjs', {
                     cwd: remoteFunctionProjectPath,
                     background: true,
-                    timeoutMs: 30_000,
+                    timeoutMs: 0,
                     envs: {
                         NO_COLOR: '1',
                         NANGO_SECRET_KEY: request.nango_secret_key,

--- a/packages/sandbox/lib/functions/dryrun-client.unit.test.ts
+++ b/packages/sandbox/lib/functions/dryrun-client.unit.test.ts
@@ -85,7 +85,7 @@ describe('remote function dryrun client', () => {
         expect(mocks.run).toHaveBeenCalledWith('node /tmp/nango-function-dryrun.mjs', {
             cwd: '/home/user/nango-integrations',
             background: true,
-            timeoutMs: 30_000,
+            timeoutMs: 0,
             envs: expect.objectContaining({
                 NANGO_DRYRUN_CALLBACK_URL: 'https://api.example.test/functions/dryruns/7b539769-6d39-4442-89fc-33fbac96ea66/result',
                 NANGO_DRYRUN_ARGS: JSON.stringify([

--- a/packages/sandbox/lib/functions/sandbox.ts
+++ b/packages/sandbox/lib/functions/sandbox.ts
@@ -6,6 +6,7 @@ import { getLogger, stringifyError } from '@nangohq/utils';
 
 import { FunctionError } from './helpers.js';
 import { remoteFunctionCompilerTemplate } from './runtime.js';
+import { envs } from '../env.js';
 
 import type { SandboxListOpts } from 'e2b';
 
@@ -16,6 +17,29 @@ export const executionEnvironmentUnavailableMessage = 'The function execution en
 export type FunctionSandbox = Awaited<ReturnType<typeof Sandbox.create>>;
 
 export type FunctionSandboxPurpose = 'compile' | 'deploy' | 'dryrun';
+
+export async function cleanupFunctionSandbox({
+    sandboxId,
+    apiKey = envs.E2B_API_KEY
+}: {
+    sandboxId: string | null | undefined;
+    apiKey?: string | undefined;
+}): Promise<void> {
+    if (!sandboxId || sandboxId === 'local') {
+        return;
+    }
+
+    if (!apiKey) {
+        logger.warning('Skipping function sandbox cleanup because E2B_API_KEY is not set', { sandboxId });
+        return;
+    }
+
+    try {
+        await Sandbox.kill(sandboxId, { apiKey });
+    } catch (err) {
+        logger.warning('Failed to clean up function sandbox', { sandboxId, err });
+    }
+}
 
 export async function getRunningSandboxCount({ apiKey, requestTimeoutMs }: { apiKey: string; requestTimeoutMs?: number | undefined }): Promise<number> {
     const listOptions = {

--- a/packages/sandbox/lib/functions/sandbox.ts
+++ b/packages/sandbox/lib/functions/sandbox.ts
@@ -37,7 +37,7 @@ export async function cleanupFunctionSandbox({
     try {
         await Sandbox.kill(sandboxId, { apiKey });
     } catch (err) {
-        logger.warning('Failed to clean up function sandbox', { sandboxId, err });
+        logger.warning('Failed to clean up function sandbox', { sandboxId, err: stringifyError(err) });
     }
 }
 

--- a/packages/sandbox/lib/functions/sandbox.unit.test.ts
+++ b/packages/sandbox/lib/functions/sandbox.unit.test.ts
@@ -1,7 +1,13 @@
 import { RateLimitError, Sandbox } from 'e2b';
 import { afterEach, describe, expect, it, vi } from 'vitest';
 
-import { createFunctionSandbox, executionEnvironmentUnavailableMessage, getRunningSandboxCount, toExecutionEnvironmentUnavailableError } from './sandbox.js';
+import {
+    cleanupFunctionSandbox,
+    createFunctionSandbox,
+    executionEnvironmentUnavailableMessage,
+    getRunningSandboxCount,
+    toExecutionEnvironmentUnavailableError
+} from './sandbox.js';
 
 import type { FunctionError } from './helpers.js';
 
@@ -62,6 +68,32 @@ describe('remote function sandbox helpers', () => {
             query: { state: ['running'] }
         });
         expect(paginator.nextItems).toHaveBeenCalledTimes(2);
+    });
+
+    it('cleans up a remote function sandbox by id', async () => {
+        const kill = vi.spyOn(Sandbox, 'kill').mockResolvedValueOnce(true);
+
+        await cleanupFunctionSandbox({ sandboxId: 'sandbox-id', apiKey: 'e2b-key' });
+
+        expect(kill).toHaveBeenCalledWith('sandbox-id', { apiKey: 'e2b-key' });
+    });
+
+    it('skips function sandbox cleanup when there is no remote sandbox to kill', async () => {
+        const kill = vi.spyOn(Sandbox, 'kill').mockResolvedValue(true);
+
+        await cleanupFunctionSandbox({ sandboxId: null, apiKey: 'e2b-key' });
+        await cleanupFunctionSandbox({ sandboxId: 'local', apiKey: 'e2b-key' });
+        await cleanupFunctionSandbox({ sandboxId: 'sandbox-id', apiKey: undefined });
+
+        expect(kill).not.toHaveBeenCalled();
+    });
+
+    it('does not throw when remote function sandbox cleanup fails', async () => {
+        const kill = vi.spyOn(Sandbox, 'kill').mockRejectedValueOnce(new Error('sandbox not found'));
+
+        await expect(cleanupFunctionSandbox({ sandboxId: 'sandbox-id', apiKey: 'e2b-key' })).resolves.toBeUndefined();
+
+        expect(kill).toHaveBeenCalledWith('sandbox-id', { apiKey: 'e2b-key' });
     });
 
     it('maps sandbox capacity-shaped errors without exposing provider details', () => {

--- a/packages/server/lib/controllers/functions/deploy/postDeployResult.ts
+++ b/packages/server/lib/controllers/functions/deploy/postDeployResult.ts
@@ -1,4 +1,10 @@
-import { getFunctionDeploymentRow, markFunctionDeploymentFailed, markFunctionDeploymentSuccess, parseDeploySuccessOutput } from '@nangohq/sandbox';
+import {
+    cleanupFunctionSandbox,
+    getFunctionDeploymentRow,
+    markFunctionDeploymentFailed,
+    markFunctionDeploymentSuccess,
+    parseDeploySuccessOutput
+} from '@nangohq/sandbox';
 import { requireEmptyQuery, zodErrorToHTTP } from '@nangohq/utils';
 
 import { asyncWrapper } from '../../../utils/asyncWrapper.js';
@@ -40,6 +46,7 @@ export const postFunctionDeploymentResult = asyncWrapper<PostFunctionDeploymentR
 
     if (current.status === 'success' || current.status === 'failed') {
         res.status(200).send({ ok: true });
+        await cleanupFunctionSandbox({ sandboxId: current.sandbox_id });
         return;
     }
 
@@ -79,4 +86,5 @@ export const postFunctionDeploymentResult = asyncWrapper<PostFunctionDeploymentR
     }
 
     res.status(200).send({ ok: true });
+    await cleanupFunctionSandbox({ sandboxId: current.sandbox_id });
 });

--- a/packages/server/lib/controllers/functions/dryrun/postDryrunResult.ts
+++ b/packages/server/lib/controllers/functions/dryrun/postDryrunResult.ts
@@ -1,4 +1,4 @@
-import { getFunctionDryrunRow, markFunctionDryrunFailed, markFunctionDryrunSuccess, parseDryrunSuccessOutput } from '@nangohq/sandbox';
+import { cleanupFunctionSandbox, getFunctionDryrunRow, markFunctionDryrunFailed, markFunctionDryrunSuccess, parseDryrunSuccessOutput } from '@nangohq/sandbox';
 import { requireEmptyQuery, zodErrorToHTTP } from '@nangohq/utils';
 
 import { asyncWrapper } from '../../../utils/asyncWrapper.js';
@@ -40,6 +40,7 @@ export const postFunctionDryrunResult = asyncWrapper<PostFunctionDryrunResult>(a
 
     if (current.status === 'success' || current.status === 'failed') {
         res.status(200).send({ ok: true });
+        await cleanupFunctionSandbox({ sandboxId: current.sandbox_id });
         return;
     }
 
@@ -79,4 +80,5 @@ export const postFunctionDryrunResult = asyncWrapper<PostFunctionDryrunResult>(a
     }
 
     res.status(200).send({ ok: true });
+    await cleanupFunctionSandbox({ sandboxId: current.sandbox_id });
 });

--- a/packages/server/lib/controllers/functions/resultCallbacks.unit.test.ts
+++ b/packages/server/lib/controllers/functions/resultCallbacks.unit.test.ts
@@ -13,6 +13,7 @@ const mocks = vi.hoisted(() => {
     }
 
     return {
+        cleanupFunctionSandbox: vi.fn(),
         FunctionError,
         getFunctionDeploymentRow: vi.fn(),
         getFunctionDryrunRow: vi.fn(),
@@ -26,6 +27,7 @@ const mocks = vi.hoisted(() => {
 });
 
 vi.mock('@nangohq/sandbox', () => ({
+    cleanupFunctionSandbox: mocks.cleanupFunctionSandbox,
     FunctionError: mocks.FunctionError,
     getFunctionDeploymentRow: mocks.getFunctionDeploymentRow,
     getFunctionDryrunRow: mocks.getFunctionDryrunRow,
@@ -54,11 +56,12 @@ describe('function result callbacks', () => {
         mocks.markFunctionDeploymentSuccess.mockResolvedValue({});
         mocks.markFunctionDryrunFailed.mockResolvedValue({});
         mocks.markFunctionDryrunSuccess.mockResolvedValue({});
+        mocks.cleanupFunctionSandbox.mockResolvedValue(undefined);
     });
 
     it('marks deployments as failed when success result processing fails', async () => {
         const deploymentId = '7b539769-6d39-4442-89fc-33fbac96ea66';
-        mocks.getFunctionDeploymentRow.mockResolvedValue({ id: deploymentId, status: 'running' });
+        mocks.getFunctionDeploymentRow.mockResolvedValue({ id: deploymentId, status: 'running', sandbox_id: 'deployment-sandbox' });
         mocks.parseDeploySuccessOutput.mockImplementation(() => {
             throw new Error('Failed to parse deploy output');
         });
@@ -87,13 +90,14 @@ describe('function result callbacks', () => {
                 message: expect.stringContaining('Failed to parse deploy output')
             })
         });
+        expect(mocks.cleanupFunctionSandbox).toHaveBeenCalledWith({ sandboxId: 'deployment-sandbox' });
         expect(status).toHaveBeenCalledWith(200);
         expect(send).toHaveBeenCalledWith({ ok: true });
     });
 
     it('marks dryruns as failed when success result processing fails', async () => {
         const dryrunId = '7b539769-6d39-4442-89fc-33fbac96ea66';
-        mocks.getFunctionDryrunRow.mockResolvedValue({ id: dryrunId, status: 'running' });
+        mocks.getFunctionDryrunRow.mockResolvedValue({ id: dryrunId, status: 'running', sandbox_id: 'dryrun-sandbox' });
         mocks.parseDryrunSuccessOutput.mockReturnValue({ output: 'Executing -> function\nDone', result: { ok: true }, hasResult: true });
         mocks.markFunctionDryrunSuccess.mockRejectedValue(new Error('Failed to save dryrun result'));
 
@@ -120,6 +124,7 @@ describe('function result callbacks', () => {
                 message: expect.stringContaining('Failed to save dryrun result')
             })
         });
+        expect(mocks.cleanupFunctionSandbox).toHaveBeenCalledWith({ sandboxId: 'dryrun-sandbox' });
         expect(status).toHaveBeenCalledWith(200);
         expect(send).toHaveBeenCalledWith({ ok: true });
     });


### PR DESCRIPTION
Async deploy and dryrun callback scripts now disable the E2B command timeout so they are not killed before Nango's own operation timeouts can run.

The issue surfaced after the sandbox image update because newer OpenCode no longer leaves its web server detached from the tracked command; old OpenCode did, so the timeout was previously masked. Result callbacks now also clean up their stored E2B sandbox IDs after persisting terminal dryrun/deploy results, reducing idle sandbox time while keeping cleanup failures non-fatal.
