### PR TITLE
fix(webapp): prevent horizontal scroll and fix scrollbar color in logs

### DIFF
--- a/packages/webapp/src/components/ui/Sheet.tsx
+++ b/packages/webapp/src/components/ui/Sheet.tsx
@@ -103,7 +103,7 @@ function SheetContent({
                 )}
                 {...props}
             >
-                {useScrollable ? <div className="scrollbar-app flex min-h-0 w-full flex-1 flex-col overflow-auto pr-1">{children}</div> : children}
+                {useScrollable ? <div className="flex min-h-0 w-full flex-1 flex-col overflow-auto">{children}</div> : children}
                 {!hideCloseButton && (
                     <SheetPrimitive.Close className="ring-offset-white focus:ring-neutral-950 data-[state=open]:bg-neutral-100 absolute top-4 right-4 rounded-xs opacity-70 transition-opacity hover:opacity-100 focus:ring-2 focus:ring-offset-2 focus:outline-hidden disabled:pointer-events-none dark:ring-offset-neutral-950 dark:focus:ring-neutral-300 dark:data-[state=open]:bg-neutral-800">
                         <XIcon />

--- a/packages/webapp/src/index.css
+++ b/packages/webapp/src/index.css
@@ -714,6 +714,7 @@
     html,
     body,
     #root {
+        width: 100%;
         height: 100%;
     }
 

--- a/packages/webapp/src/index.css
+++ b/packages/webapp/src/index.css
@@ -726,11 +726,6 @@
         color-scheme: light;
     }
 
-    /* WebKit doesn't apply color-scheme to the resize handle — match payload background */
-    [data-theme='dark'] ::-webkit-resizer {
-        background-color: var(--color-pure-black);
-    }
-
     button,
     [role='button'] {
         cursor: pointer;

--- a/packages/webapp/src/index.css
+++ b/packages/webapp/src/index.css
@@ -718,6 +718,14 @@
         height: 100%;
     }
 
+    [data-theme='dark'] {
+        color-scheme: dark;
+    }
+
+    [data-theme='light'] {
+        color-scheme: light;
+    }
+
     button,
     [role='button'] {
         cursor: pointer;

--- a/packages/webapp/src/index.css
+++ b/packages/webapp/src/index.css
@@ -750,31 +750,3 @@
     background-color: var(--color-bg-surface) !important;
 }
 
-.scrollbar-app {
-    scrollbar-gutter: stable;
-    scrollbar-width: thin;
-    scrollbar-color: var(--color-gray-400) transparent;
-}
-.scrollbar-app::-webkit-scrollbar {
-    width: 6px;
-    height: 6px;
-}
-.scrollbar-app::-webkit-scrollbar-track {
-    background: transparent;
-}
-.scrollbar-app::-webkit-scrollbar-thumb {
-    background: var(--color-gray-400);
-    border-radius: 3px;
-}
-.scrollbar-app::-webkit-scrollbar-thumb:hover {
-    background: var(--color-gray-500);
-}
-.dark .scrollbar-app {
-    scrollbar-color: var(--color-gray-600) transparent;
-}
-.dark .scrollbar-app::-webkit-scrollbar-thumb {
-    background: var(--color-gray-600);
-}
-.dark .scrollbar-app::-webkit-scrollbar-thumb:hover {
-    background: var(--color-gray-550);
-}

--- a/packages/webapp/src/index.css
+++ b/packages/webapp/src/index.css
@@ -726,6 +726,11 @@
         color-scheme: light;
     }
 
+    /* WebKit doesn't apply color-scheme to the resize handle — match payload background */
+    [data-theme='dark'] ::-webkit-resizer {
+        background-color: var(--color-pure-black);
+    }
+
     button,
     [role='button'] {
         cursor: pointer;

--- a/packages/webapp/src/index.css
+++ b/packages/webapp/src/index.css
@@ -714,7 +714,6 @@
     html,
     body,
     #root {
-        width: 100%;
         height: 100%;
     }
 

--- a/packages/webapp/src/layout/DashboardLayout.tsx
+++ b/packages/webapp/src/layout/DashboardLayout.tsx
@@ -19,7 +19,7 @@ const DashboardLayout = React.forwardRef<HTMLDivElement, DashboardLayoutProps>((
                 <div
                     ref={ref}
                     className={cn(
-                        'relative w-full h-full overflow-auto rounded-tl-sm border border-border-muted bg-bg-surface min-w-3xl',
+                        'relative w-full flex-1 min-h-0 overflow-auto rounded-tl-sm border border-border-muted bg-bg-surface min-w-3xl',
                         fullWidth ? 'p-0' : 'p-11'
                     )}
                     {...props}

--- a/packages/webapp/src/pages/Logs/Operation/Show.tsx
+++ b/packages/webapp/src/pages/Logs/Operation/Show.tsx
@@ -171,7 +171,7 @@ export const ShowOperation: React.FC<{ operationId: string }> = ({ operationId }
                 <h4 className="font-semibold text-sm mb-2">Payload</h4>
                 {payload ? (
                     <div
-                        className="text-gray-400 text-sm bg-pure-black py-2 resize-y overflow-auto"
+                        className="scrollbar-app text-gray-400 text-sm bg-pure-black py-2 resize-y overflow-auto"
                         style={{
                             minHeight: '100px',
                             height: '30vh',

--- a/packages/webapp/src/pages/Logs/Operation/Show.tsx
+++ b/packages/webapp/src/pages/Logs/Operation/Show.tsx
@@ -171,7 +171,7 @@ export const ShowOperation: React.FC<{ operationId: string }> = ({ operationId }
                 <h4 className="font-semibold text-sm mb-2">Payload</h4>
                 {payload ? (
                     <div
-                        className="text-gray-400 text-sm bg-pure-black py-2 resize-y overflow-auto"
+                        className="text-gray-400 text-sm bg-pure-black py-2 resize-y overflow-y-auto overflow-x-hidden"
                         style={{
                             minHeight: '100px',
                             height: '30vh',

--- a/packages/webapp/src/pages/Logs/Operation/Show.tsx
+++ b/packages/webapp/src/pages/Logs/Operation/Show.tsx
@@ -171,7 +171,7 @@ export const ShowOperation: React.FC<{ operationId: string }> = ({ operationId }
                 <h4 className="font-semibold text-sm mb-2">Payload</h4>
                 {payload ? (
                     <div
-                        className="scrollbar-app text-gray-400 text-sm bg-pure-black py-2 resize-y overflow-auto"
+                        className="text-gray-400 text-sm bg-pure-black py-2 resize-y overflow-auto"
                         style={{
                             minHeight: '100px',
                             height: '30vh',

--- a/packages/webapp/src/pages/Logs/Operation/components/Logs.tsx
+++ b/packages/webapp/src/pages/Logs/Operation/components/Logs.tsx
@@ -241,6 +241,7 @@ export const Logs: React.FC<{ operation: OperationRow; operationId: string; isLi
                 </div>
             </header>
             <div
+                className="scrollbar-app"
                 style={{ height: '100%', overflow: 'auto', position: 'relative' }}
                 ref={tableContainerRef}
                 onScroll={(e) => fetchMoreOnBottomReached(e.currentTarget)}

--- a/packages/webapp/src/pages/Logs/Operation/components/Logs.tsx
+++ b/packages/webapp/src/pages/Logs/Operation/components/Logs.tsx
@@ -241,7 +241,7 @@ export const Logs: React.FC<{ operation: OperationRow; operationId: string; isLi
                 </div>
             </header>
             <div
-                style={{ height: '100%', overflow: 'auto', position: 'relative' }}
+                style={{ height: '100%', overflowY: 'auto', overflowX: 'hidden', position: 'relative' }}
                 ref={tableContainerRef}
                 onScroll={(e) => fetchMoreOnBottomReached(e.currentTarget)}
             >

--- a/packages/webapp/src/pages/Logs/Operation/components/Logs.tsx
+++ b/packages/webapp/src/pages/Logs/Operation/components/Logs.tsx
@@ -241,7 +241,6 @@ export const Logs: React.FC<{ operation: OperationRow; operationId: string; isLi
                 </div>
             </header>
             <div
-                className="scrollbar-app"
                 style={{ height: '100%', overflow: 'auto', position: 'relative' }}
                 ref={tableContainerRef}
                 onScroll={(e) => fetchMoreOnBottomReached(e.currentTarget)}

--- a/packages/webapp/src/pages/Logs/Show.tsx
+++ b/packages/webapp/src/pages/Logs/Show.tsx
@@ -44,7 +44,7 @@ export const LogsShow: React.FC = () => {
                 <title>Logs - Nango</title>
             </Helmet>
 
-            <div key={env} className="h-full">
+            <div key={env} className="flex flex-col h-full">
                 <SearchAllOperations onSelectOperation={onSelectOperation} />
 
                 {operationId && <OperationDrawer key={operationId} operationId={operationId} onClose={onSelectOperation} />}

--- a/packages/webapp/src/pages/Logs/components/SearchAllOperations.tsx
+++ b/packages/webapp/src/pages/Logs/components/SearchAllOperations.tsx
@@ -291,6 +291,7 @@ export const SearchAllOperations: React.FC<Props> = ({ onSelectOperation }) => {
                 </div>
             </div>
             <div
+                className="scrollbar-app"
                 style={{ height: '100%', overflow: 'auto', position: 'relative' }}
                 ref={tableContainerRef}
                 onScroll={(e) => fetchMoreOnBottomReached(e.currentTarget)}

--- a/packages/webapp/src/pages/Logs/components/SearchAllOperations.tsx
+++ b/packages/webapp/src/pages/Logs/components/SearchAllOperations.tsx
@@ -291,8 +291,8 @@ export const SearchAllOperations: React.FC<Props> = ({ onSelectOperation }) => {
                 </div>
             </div>
             <div
-                className="scrollbar-app"
-                style={{ height: '100%', overflow: 'auto', position: 'relative' }}
+                className="scrollbar-app flex-1 min-h-0"
+                style={{ overflow: 'auto', position: 'relative' }}
                 ref={tableContainerRef}
                 onScroll={(e) => fetchMoreOnBottomReached(e.currentTarget)}
             >

--- a/packages/webapp/src/pages/Logs/components/SearchAllOperations.tsx
+++ b/packages/webapp/src/pages/Logs/components/SearchAllOperations.tsx
@@ -292,7 +292,7 @@ export const SearchAllOperations: React.FC<Props> = ({ onSelectOperation }) => {
             </div>
             <div
                 className="flex-1 min-h-0"
-                style={{ overflow: 'auto', position: 'relative' }}
+                style={{ overflowY: 'auto', overflowX: 'hidden', position: 'relative' }}
                 ref={tableContainerRef}
                 onScroll={(e) => fetchMoreOnBottomReached(e.currentTarget)}
             >

--- a/packages/webapp/src/pages/Logs/components/SearchAllOperations.tsx
+++ b/packages/webapp/src/pages/Logs/components/SearchAllOperations.tsx
@@ -291,7 +291,7 @@ export const SearchAllOperations: React.FC<Props> = ({ onSelectOperation }) => {
                 </div>
             </div>
             <div
-                className="scrollbar-app flex-1 min-h-0"
+                className="flex-1 min-h-0"
                 style={{ overflow: 'auto', position: 'relative' }}
                 ref={tableContainerRef}
                 onScroll={(e) => fetchMoreOnBottomReached(e.currentTarget)}


### PR DESCRIPTION
## Problem

Several scrollbar/layout bugs in the logs view, visible when a mouse is plugged in on macOS (which switches from overlay to traditional scrollbars that take layout space):

1. **Horizontal scrollbar on the main logs table and inside the operation detail drawer** — when a vertical scrollbar appeared it consumed ~15px of width; table columns sized to the full container width then overflowed horizontally.
2. **Page-level vertical scrollbar on the logs page** — the content area used `h-full` (= 100vh) inside a flex column that also contained the navbar, so the content extended past the viewport and produced a full-height scrollbar.
3. **Scrollbar color not matching dark theme** — scroll containers rendered with the system default (light) scrollbar color.

## Solution

**Layout fix** (`DashboardLayout`, `Logs/Show`, `SearchAllOperations`):
- Content area: `h-full` → `flex-1 min-h-0` so it takes the remaining space after the navbar.
- Logs wrapper: add `flex flex-col` so children participate correctly in flex layout.
- Table container: `height: 100%` → `flex-1 min-h-0` so it fills the height remaining after the filter/search header.

**Hide horizontal overflow** (`SearchAllOperations`, `Operation/components/Logs`, `Operation/Show` payload):
- `overflow: auto` → `overflow-y: auto; overflow-x: hidden` on all three scroll containers. Tables are not designed to scroll horizontally; clipping instead of showing a scrollbar is the right behaviour.

**Dark native scrollbars** (`index.css`):
- Add `color-scheme: dark/light` keyed to `[data-theme]` on `<html>`. This makes all native browser UI — scrollbars, form controls, etc. — follow the app's theme without any per-element overrides. Removed the previous custom `scrollbar-app` class that was only applied inconsistently.

## Testing

- Open the logs page with a mouse plugged in (traditional macOS scrollbars)
- Verify no page-level vertical scrollbar spans the full height
- Verify no horizontal scrollbar on the main logs table or inside the operation detail drawer (payload, logs sub-table)
- Verify all scrollbars are dark (match the dark theme)

<!-- start telescope-canary-packages -->
<!-- end telescope-canary-packages -->
