### PR TITLE
feat(webapp): add light mode

### DIFF
--- a/packages/webapp/index.html
+++ b/packages/webapp/index.html
@@ -1,5 +1,5 @@
 <!doctype html>
-<html lang="en" class="dark" data-theme="dark">
+<html lang="en">
     <head>
         <meta charset="utf-8" />
         <link rel="icon" href="/favicon.ico" />
@@ -9,11 +9,29 @@
         <link rel="manifest" href="/manifest.json" />
         <title>Nango</title>
 
+        <!-- Apply saved theme before first paint to avoid flash -->
+        <script>
+            (function () {
+                var dark;
+                try {
+                    var s = localStorage.getItem('nango_theme');
+                    var parsed = s ? JSON.parse(s) : null;
+                    var state = parsed && parsed.state;
+                    // Support new `theme` field and old boolean `darkMode`
+                    var theme = state && state.theme ? state.theme : (state && state.darkMode === false ? 'light' : 'system');
+                    dark = theme === 'system' ? window.matchMedia('(prefers-color-scheme: dark)').matches : theme === 'dark';
+                } catch (e) {
+                    dark = window.matchMedia('(prefers-color-scheme: dark)').matches;
+                }
+                document.documentElement.setAttribute('data-theme', dark ? 'dark' : 'light');
+            })();
+        </script>
+
         <meta name="nango-api-origin" content="" />
         <meta name="nango-env-hash" content="%VITE_HASH%" />
     </head>
 
-    <body class="bg-surface-canvas">
+    <body class="bg-white dark:bg-surface-canvas">
         <noscript>You need to enable JavaScript to run this app.</noscript>
         <div id="root"></div>
         <script type="module" src="/src/index.tsx"></script>

--- a/packages/webapp/index.html
+++ b/packages/webapp/index.html
@@ -17,11 +17,11 @@
                     var s = localStorage.getItem('nango_theme');
                     var parsed = s ? JSON.parse(s) : null;
                     var state = parsed && parsed.state;
-                    // Support new `theme` field and old boolean `darkMode`
-                    var theme = state && state.theme ? state.theme : (state && state.darkMode === false ? 'light' : 'system');
+                    // Support new `theme` field and old boolean `darkMode`; default to dark to match the app default
+                    var theme = state && state.theme ? state.theme : (state && state.darkMode === false ? 'light' : 'dark');
                     dark = theme === 'system' ? window.matchMedia('(prefers-color-scheme: dark)').matches : theme === 'dark';
                 } catch (e) {
-                    dark = window.matchMedia('(prefers-color-scheme: dark)').matches;
+                    dark = true;
                 }
                 document.documentElement.setAttribute('data-theme', dark ? 'dark' : 'light');
             })();

--- a/packages/webapp/src/components/ui/Chart.tsx
+++ b/packages/webapp/src/components/ui/Chart.tsx
@@ -49,7 +49,7 @@ function ChartContainer({
                 data-slot="chart"
                 data-chart={chartId}
                 className={cn(
-                    "[&_.recharts-cartesian-axis-tick_text]:fill-text-disabled [&_.recharts-cartesian-grid_line[stroke='#ccc']]:stroke-border/50 [&_.recharts-curve.recharts-tooltip-cursor]:stroke-border [&_.recharts-polar-grid_[stroke='#ccc']]:stroke-border [&_.recharts-radial-bar-background-sector]:fill-muted [&_.recharts-rectangle.recharts-tooltip-cursor]:fill-surface-panel-inset [&_.recharts-reference-line_[stroke='#ccc']]:stroke-border flex aspect-video justify-center text-xs [&_.recharts-dot[stroke='#fff']]:stroke-transparent [&_.recharts-layer]:outline-hidden [&_.recharts-sector]:outline-hidden [&_.recharts-sector[stroke='#fff']]:stroke-transparent [&_.recharts-surface]:outline-hidden",
+                    "[&_.recharts-cartesian-axis-tick_text]:fill-text-disabled [&_.recharts-cartesian-grid_line[stroke='#ccc']]:stroke-border-default/50 [&_.recharts-curve.recharts-tooltip-cursor]:stroke-border-default [&_.recharts-polar-grid_[stroke='#ccc']]:stroke-border-default [&_.recharts-radial-bar-background-sector]:fill-muted [&_.recharts-rectangle.recharts-tooltip-cursor]:fill-surface-panel-inset [&_.recharts-reference-line_[stroke='#ccc']]:stroke-border-default flex aspect-video justify-center text-xs [&_.recharts-dot[stroke='#fff']]:stroke-transparent [&_.recharts-layer]:outline-hidden [&_.recharts-sector]:outline-hidden [&_.recharts-sector[stroke='#fff']]:stroke-transparent [&_.recharts-surface]:outline-hidden",
                     className
                 )}
                 {...props}

--- a/packages/webapp/src/components/ui/Checkbox.tsx
+++ b/packages/webapp/src/components/ui/Checkbox.tsx
@@ -9,7 +9,7 @@ function Checkbox({ className, ...props }: React.ComponentProps<typeof CheckboxP
         <CheckboxPrimitive.Root
             data-slot="checkbox"
             className={cn(
-                'peer border-text-strong data-[state=checked]:bg-text-strong data-[state=checked]:text-surface focus-default aria-invalid:ring-status-danger-text/20 aria-invalid:border-status-danger-text size-4 shrink-0 rounded-xs border transition-shadow outline-none  disabled:cursor-not-allowed disabled:opacity-50',
+                'peer border-text-strong data-[state=checked]:bg-text-strong data-[state=checked]:text-text-inverse focus-default aria-invalid:ring-status-danger-text/20 aria-invalid:border-status-danger-text size-4 shrink-0 rounded-xs border transition-shadow outline-none  disabled:cursor-not-allowed disabled:opacity-50',
                 className
             )}
             {...props}

--- a/packages/webapp/src/components/ui/CodeBlock.tsx
+++ b/packages/webapp/src/components/ui/CodeBlock.tsx
@@ -5,7 +5,7 @@ import { useCallback, useState } from 'react';
 import { Badge } from './Badge.js';
 import { Button } from './Button.js';
 import { CopyButton } from './CopyButton.js';
-import { useThemeStore } from '../../lib/theme.js';
+import { darkModeSelector, useThemeStore } from '../../lib/theme.js';
 import { cn } from '../../utils/utils.js';
 
 import type { PrismProps } from '@mantine/prism';
@@ -41,7 +41,7 @@ export const CodeBlock: React.FC<CodeBlockProps> = ({
     constrainHeight = true,
     ...props
 }) => {
-    const darkMode = useThemeStore((s) => s.darkMode);
+    const darkMode = useThemeStore(darkModeSelector);
     const [isSecretVisible, setIsSecretVisible] = useState(!secret);
 
     const toggleSecretVisibility = useCallback(() => setIsSecretVisible(!isSecretVisible), [isSecretVisible]);

--- a/packages/webapp/src/components/ui/InputGroup.tsx
+++ b/packages/webapp/src/components/ui/InputGroup.tsx
@@ -43,7 +43,7 @@ const inputGroupAddonVariants = cva(
     {
         variants: {
             align: {
-                'inline-start': 'order-first pl-2 has-[>button]:ml-[-0.45rem] has-[>kbd]:ml-[-0.35rem]',
+                'inline-start': 'order-first pl-2 has-[>kbd]:ml-[-0.35rem]',
                 'inline-end': 'order-last pr-2 has-[>kbd]:mr-[-0.35rem]',
                 'block-start': 'order-first w-full justify-start px-3 pt-3 [.border-b]:pb-3 group-has-[>input]/input-group:pt-2.5',
                 'block-end': 'order-last w-full justify-start px-3 pb-3 [.border-t]:pt-3 group-has-[>input]/input-group:pb-2.5'

--- a/packages/webapp/src/components/ui/MultiLanguageCodeBlock.tsx
+++ b/packages/webapp/src/components/ui/MultiLanguageCodeBlock.tsx
@@ -57,7 +57,7 @@ export const MultiLanguageCodeBlock: React.FC<MultiLanguageCodeBlockProps> = ({ 
                             defaultValue={snippets[0].language}
                             onValueChange={(language) => setSelectedSnippetIndex(snippets.findIndex((s) => s.language === language) ?? 0)}
                         >
-                            <SelectTrigger>
+                            <SelectTrigger size="sm">
                                 <SelectValue placeholder="Language" />
                             </SelectTrigger>
                             <SelectContent>

--- a/packages/webapp/src/components/ui/SimpleCodeBlock.tsx
+++ b/packages/webapp/src/components/ui/SimpleCodeBlock.tsx
@@ -1,11 +1,11 @@
 import { Prism } from '@mantine/prism';
 
-import { useThemeStore } from '@/lib/theme';
+import { darkModeSelector, useThemeStore } from '@/lib/theme';
 
 import type { PrismProps } from '@mantine/prism';
 
 export const SimpleCodeBlock = ({ children, language }: { children: string; language: PrismProps['language'] }) => {
-    const darkMode = useThemeStore((s) => s.darkMode);
+    const darkMode = useThemeStore(darkModeSelector);
     return (
         <Prism className="w-full min-w-0" language={language} colorScheme={darkMode ? 'dark' : 'light'} noCopy={true}>
             {children}

--- a/packages/webapp/src/features/DevToolPanel.tsx
+++ b/packages/webapp/src/features/DevToolPanel.tsx
@@ -1,10 +1,11 @@
-import { BarChart3, Sun, X } from 'lucide-react';
+import { BarChart3, Moon, Sun, X } from 'lucide-react';
 import { useEffect } from 'react';
 import { create } from 'zustand';
 
 import { Button } from '@/components/ui/Button';
 import { Switch } from '@/components/ui/Switch';
 import { useTeam } from '@/hooks/useTeam';
+import { useThemeStore } from '@/lib/theme';
 import { useStore } from '@/store';
 import { useFeatureFlagsStore } from '@/store/feature-flags';
 
@@ -55,6 +56,8 @@ export const DevToolPanel: React.FC = () => {
     const themeSwitcher = useFeatureFlagsStore((s) => s.themeSwitcher);
     const usageBreakdown = useFeatureFlagsStore((s) => s.usageBreakdown);
     const setFlag = useFeatureFlagsStore((s) => s.setFlag);
+    const darkMode = useThemeStore((s) => s.darkMode);
+    const toggleDarkMode = useThemeStore((s) => s.toggleDarkMode);
 
     useEffect(() => {
         const handleKeyDown = (e: KeyboardEvent) => {
@@ -80,6 +83,18 @@ export const DevToolPanel: React.FC = () => {
                 <Button variant="ghost" size="icon" onClick={() => setOpen(false)} className="size-5 text-text-secondary hover:text-text-strong">
                     <X className="size-3.5" />
                 </Button>
+            </div>
+
+            {/* Theme */}
+            <div className="p-3 border-b border-border-muted">
+                <p className="mb-2 text-xs font-medium uppercase tracking-wider text-text-muted">Theme</p>
+                <div className="flex items-center justify-between">
+                    <div className="flex items-center gap-2">
+                        {darkMode ? <Moon className="size-4 shrink-0 text-text-secondary" /> : <Sun className="size-4 shrink-0 text-text-secondary" />}
+                        <span className="text-sm text-text-strong">{darkMode ? 'Dark' : 'Light'} mode</span>
+                    </div>
+                    <Switch checked={darkMode} onCheckedChange={toggleDarkMode} />
+                </div>
             </div>
 
             {/* Feature flags */}

--- a/packages/webapp/src/features/DevToolPanel.tsx
+++ b/packages/webapp/src/features/DevToolPanel.tsx
@@ -53,7 +53,6 @@ export const DevToolPanel: React.FC = () => {
     const open = useDevPanelStore((s) => s.open);
     const setOpen = useDevPanelStore((s) => s.setOpen);
     const toggle = useDevPanelStore((s) => s.toggle);
-    const themeSwitcher = useFeatureFlagsStore((s) => s.themeSwitcher);
     const usageBreakdown = useFeatureFlagsStore((s) => s.usageBreakdown);
     const setFlag = useFeatureFlagsStore((s) => s.setFlag);
     const theme = useThemeStore((s) => s.theme);
@@ -104,13 +103,6 @@ export const DevToolPanel: React.FC = () => {
             <div className="p-3">
                 <p className="mb-2 text-xs font-medium uppercase tracking-wider text-text-muted">Feature Flags</p>
                 <ul className="space-y-2.5">
-                    <li className="flex items-center justify-between">
-                        <div className="flex items-center gap-2">
-                            <Sun className="size-4 shrink-0 text-text-secondary" />
-                            <span className="text-sm text-text-strong">Theme switcher</span>
-                        </div>
-                        <Switch checked={themeSwitcher} onCheckedChange={(v) => setFlag('themeSwitcher', v)} />
-                    </li>
                     <li className="flex items-center justify-between">
                         <div className="flex items-center gap-2">
                             <BarChart3 className="size-4 shrink-0 text-text-secondary" />

--- a/packages/webapp/src/features/DevToolPanel.tsx
+++ b/packages/webapp/src/features/DevToolPanel.tsx
@@ -5,7 +5,7 @@ import { create } from 'zustand';
 import { Button } from '@/components/ui/Button';
 import { Switch } from '@/components/ui/Switch';
 import { useTeam } from '@/hooks/useTeam';
-import { useThemeStore } from '@/lib/theme';
+import { darkModeSelector, useThemeStore } from '@/lib/theme';
 import { useStore } from '@/store';
 import { useFeatureFlagsStore } from '@/store/feature-flags';
 
@@ -57,7 +57,7 @@ export const DevToolPanel: React.FC = () => {
     const usageBreakdown = useFeatureFlagsStore((s) => s.usageBreakdown);
     const setFlag = useFeatureFlagsStore((s) => s.setFlag);
     const theme = useThemeStore((s) => s.theme);
-    const darkMode = useThemeStore((s) => s.darkMode);
+    const darkMode = useThemeStore(darkModeSelector);
     const toggleDarkMode = useThemeStore((s) => s.toggleDarkMode);
 
     useEffect(() => {

--- a/packages/webapp/src/features/DevToolPanel.tsx
+++ b/packages/webapp/src/features/DevToolPanel.tsx
@@ -56,6 +56,7 @@ export const DevToolPanel: React.FC = () => {
     const themeSwitcher = useFeatureFlagsStore((s) => s.themeSwitcher);
     const usageBreakdown = useFeatureFlagsStore((s) => s.usageBreakdown);
     const setFlag = useFeatureFlagsStore((s) => s.setFlag);
+    const theme = useThemeStore((s) => s.theme);
     const darkMode = useThemeStore((s) => s.darkMode);
     const toggleDarkMode = useThemeStore((s) => s.toggleDarkMode);
 
@@ -91,7 +92,9 @@ export const DevToolPanel: React.FC = () => {
                 <div className="flex items-center justify-between">
                     <div className="flex items-center gap-2">
                         {darkMode ? <Moon className="size-4 shrink-0 text-text-secondary" /> : <Sun className="size-4 shrink-0 text-text-secondary" />}
-                        <span className="text-sm text-text-strong">{darkMode ? 'Dark' : 'Light'} mode</span>
+                        <span className="text-sm text-text-strong">
+                            {theme === 'system' ? `System (${darkMode ? 'dark' : 'light'})` : darkMode ? 'Dark' : 'Light'}
+                        </span>
                     </div>
                     <Switch checked={darkMode} onCheckedChange={toggleDarkMode} />
                 </div>

--- a/packages/webapp/src/layout/AppHeader.tsx
+++ b/packages/webapp/src/layout/AppHeader.tsx
@@ -9,7 +9,7 @@ import { Button, ButtonLink } from '@/components/ui/Button';
 import { useIsDevToolsEnabled } from '@/features/DevToolPanel';
 import { useEnvironment } from '@/hooks/useEnvironment';
 import { usePermissions } from '@/hooks/usePermissions';
-import { useThemeStore } from '@/lib/theme';
+import { darkModeSelector, useThemeStore } from '@/lib/theme';
 import { useStore } from '@/store';
 import { useFeatureFlagsStore } from '@/store/feature-flags';
 import { usePlaygroundStore } from '@/store/playground';
@@ -24,7 +24,7 @@ export const AppHeader: React.FC = () => {
     const canUsePlayground = envData != null && (can(permissions.canUseProdPlayground) || !environment?.is_production);
     const isDevToolsEnabled = useIsDevToolsEnabled();
     const themeSwitcher = useFeatureFlagsStore((s) => s.themeSwitcher);
-    const darkMode = useThemeStore((s) => s.darkMode);
+    const darkMode = useThemeStore(darkModeSelector);
     const toggleDarkMode = useThemeStore((s) => s.toggleDarkMode);
 
     return (

--- a/packages/webapp/src/layout/AppHeader.tsx
+++ b/packages/webapp/src/layout/AppHeader.tsx
@@ -6,12 +6,10 @@ import { SlackIcon } from '@/assets/SlackIcon';
 import { Breadcrumbs } from '@/components/patterns/Breadcrumbs';
 import { PermissionGate } from '@/components/patterns/PermissionGate';
 import { Button, ButtonLink } from '@/components/ui/Button';
-import { useIsDevToolsEnabled } from '@/features/DevToolPanel';
 import { useEnvironment } from '@/hooks/useEnvironment';
 import { usePermissions } from '@/hooks/usePermissions';
 import { darkModeSelector, useThemeStore } from '@/lib/theme';
 import { useStore } from '@/store';
-import { useFeatureFlagsStore } from '@/store/feature-flags';
 import { usePlaygroundStore } from '@/store/playground';
 
 export const AppHeader: React.FC = () => {
@@ -22,8 +20,6 @@ export const AppHeader: React.FC = () => {
     const environment = envData?.environmentAndAccount?.environment;
     const { can } = usePermissions();
     const canUsePlayground = envData != null && (can(permissions.canUseProdPlayground) || !environment?.is_production);
-    const isDevToolsEnabled = useIsDevToolsEnabled();
-    const themeSwitcher = useFeatureFlagsStore((s) => s.themeSwitcher);
     const darkMode = useThemeStore(darkModeSelector);
     const toggleDarkMode = useThemeStore((s) => s.toggleDarkMode);
 
@@ -47,17 +43,15 @@ export const AppHeader: React.FC = () => {
                     <SlackIcon />
                     Help
                 </ButtonLink>
-                {isDevToolsEnabled && themeSwitcher && (
-                    <Button
-                        variant="outline"
-                        size="sm"
-                        className="size-8 p-0"
-                        onClick={toggleDarkMode}
-                        title={darkMode ? 'Switch to light mode' : 'Switch to dark mode'}
-                    >
-                        {darkMode ? <Sun className="size-4" /> : <Moon className="size-4" />}
-                    </Button>
-                )}
+                <Button
+                    variant="outline"
+                    size="sm"
+                    className="size-8 p-0"
+                    onClick={toggleDarkMode}
+                    title={darkMode ? 'Switch to light mode' : 'Switch to dark mode'}
+                >
+                    {darkMode ? <Sun className="size-4" /> : <Moon className="size-4" />}
+                </Button>
             </div>
         </header>
     );

--- a/packages/webapp/src/layout/DashboardLayout.tsx
+++ b/packages/webapp/src/layout/DashboardLayout.tsx
@@ -19,7 +19,7 @@ const DashboardLayout = React.forwardRef<HTMLDivElement, DashboardLayoutProps>((
                 <div
                     ref={ref}
                     className={cn(
-                        'relative w-full flex-1 min-h-0 overflow-auto rounded-tl-sm border border-border-muted bg-surface-page min-w-3xl',
+                        'relative w-full flex-1 min-h-0 overflow-auto border border-border-muted bg-surface-page min-w-3xl',
                         fullWidth ? 'p-0' : 'p-11'
                     )}
                     {...props}

--- a/packages/webapp/src/lib/theme.ts
+++ b/packages/webapp/src/lib/theme.ts
@@ -17,9 +17,7 @@ export function resolveTheme(theme: Theme): boolean {
 
 export function applyTheme(theme: Theme): void {
     const dark = resolveTheme(theme);
-    const root = document.documentElement;
-    root.classList.toggle('dark', dark);
-    root.setAttribute('data-theme', dark ? 'dark' : 'light');
+    document.documentElement.setAttribute('data-theme', dark ? 'dark' : 'light');
 }
 
 function getStoredTheme(): Theme {
@@ -37,7 +35,7 @@ function getStoredTheme(): Theme {
 try {
     applyTheme(getStoredTheme());
 } catch {
-    // Keep the dark default already set on <html class="dark"> in index.html
+    // Keep the dark default already set via data-theme in index.html
 }
 
 // --- Store ---
@@ -83,13 +81,15 @@ export const darkModeSelector = (s: ThemeState) => resolveTheme(s.theme);
 
 /**
  * Syncs the persisted theme preference to the DOM.
- * Also re-applies when the OS preference changes (relevant for 'system').
+ * - Re-applies when the OS preference changes (relevant for 'system').
+ * - Syncs theme changes made in other tabs via the storage event.
  * Mount once at the app root.
  */
 export function useTheme(): void {
     const theme = useThemeStore((s) => s.theme);
     const setTheme = useThemeStore((s) => s.setTheme);
 
+    // Apply to DOM and track OS preference changes when on 'system'
     useEffect(() => {
         applyTheme(theme);
 
@@ -101,5 +101,26 @@ export function useTheme(): void {
         const handler = () => applyTheme('system');
         mq.addEventListener('change', handler);
         return () => mq.removeEventListener('change', handler);
-    }, [theme, setTheme]);
+    }, [theme]);
+
+    // Sync theme changes from other tabs
+    useEffect(() => {
+        const handleStorage = (e: StorageEvent) => {
+            if (e.key !== LocalStorageKeys.Theme || !e.newValue) {
+                return;
+            }
+            try {
+                const parsed = JSON.parse(e.newValue) as { state?: { theme?: Theme } };
+                const incoming = parsed?.state?.theme;
+                if (incoming && incoming !== useThemeStore.getState().theme) {
+                    setTheme(incoming);
+                }
+            } catch {
+                // ignore malformed storage values
+            }
+        };
+
+        window.addEventListener('storage', handleStorage);
+        return () => window.removeEventListener('storage', handleStorage);
+    }, [setTheme]);
 }

--- a/packages/webapp/src/lib/theme.ts
+++ b/packages/webapp/src/lib/theme.ts
@@ -8,7 +8,7 @@ export type Theme = 'light' | 'dark' | 'system';
 
 // Dark is the default for now so existing users keep the current look and new users
 // don't land on light mode at rollout. Revisit defaulting to 'system' once light mode
-// has been live for a while. Keep index.html's pre-paint fallback in sync with this.
+// has been live for a while (NAN-5960). Keep index.html's pre-paint fallback in sync.
 const DEFAULT_THEME: Theme = 'dark';
 
 // --- DOM utility ---

--- a/packages/webapp/src/lib/theme.ts
+++ b/packages/webapp/src/lib/theme.ts
@@ -4,21 +4,31 @@ import { createJSONStorage, persist } from 'zustand/middleware';
 
 import { LocalStorageKeys } from '@/utils/local-storage';
 
+export type Theme = 'light' | 'dark' | 'system';
+
 // --- DOM utility ---
 
-export function applyTheme(dark: boolean): void {
+export function resolveTheme(theme: Theme): boolean {
+    if (theme === 'system') {
+        return window.matchMedia('(prefers-color-scheme: dark)').matches;
+    }
+    return theme === 'dark';
+}
+
+export function applyTheme(theme: Theme): void {
+    const dark = resolveTheme(theme);
     const root = document.documentElement;
     root.classList.toggle('dark', dark);
     root.setAttribute('data-theme', dark ? 'dark' : 'light');
 }
 
 // Eagerly apply the persisted theme before the first React render.
-// Module code runs synchronously before ReactDOM.render(), so this prevents
-// a flash when the user has previously toggled to light mode.
 try {
     const raw = localStorage.getItem(LocalStorageKeys.Theme);
-    const s = raw ? (JSON.parse(raw) as { state?: { darkMode?: boolean } }) : null;
-    applyTheme(s?.state?.darkMode ?? true);
+    const s = raw ? (JSON.parse(raw) as { state?: { theme?: Theme; darkMode?: boolean } }) : null;
+    // Support old boolean `darkMode` from before migration
+    const theme: Theme = s?.state?.theme ?? (s?.state?.darkMode === false ? 'light' : 'dark');
+    applyTheme(theme);
 } catch {
     // Keep the dark default already set on <html class="dark"> in index.html
 }
@@ -26,20 +36,38 @@ try {
 // --- Store ---
 
 interface ThemeState {
-    darkMode: boolean;
+    theme: Theme;
+    setTheme: (theme: Theme) => void;
+    /** Toggle between dark and light, ignoring/overriding system. */
     toggleDarkMode: () => void;
+    /** Current effective dark value (system resolves to OS preference). */
+    darkMode: boolean;
 }
 
 export const useThemeStore = create<ThemeState>()(
     persist(
         (set, get) => ({
-            // Default to dark mode to match the existing app default
-            darkMode: true,
-            toggleDarkMode: () => set({ darkMode: !get().darkMode })
+            theme: 'dark',
+            get darkMode() {
+                return resolveTheme(get().theme);
+            },
+            setTheme: (theme) => set({ theme }),
+            toggleDarkMode: () => {
+                const currentlyDark = resolveTheme(get().theme);
+                set({ theme: currentlyDark ? 'light' : 'dark' });
+            }
         }),
         {
             name: LocalStorageKeys.Theme,
-            storage: createJSONStorage(() => localStorage)
+            storage: createJSONStorage(() => localStorage),
+            // Migrate old boolean `darkMode` field
+            migrate: (persisted: any) => {
+                if (typeof persisted?.darkMode === 'boolean') {
+                    return { theme: persisted.darkMode ? 'dark' : 'light' };
+                }
+                return persisted;
+            },
+            version: 1
         }
     )
 );
@@ -47,13 +75,24 @@ export const useThemeStore = create<ThemeState>()(
 // --- Hook ---
 
 /**
- * Syncs the persisted dark-mode preference to the DOM.
- * Mount once at the app root; consumers that only need to read
- * or toggle the value can import useThemeStore directly.
+ * Syncs the persisted theme preference to the DOM.
+ * Also re-applies when the OS preference changes (relevant for 'system').
+ * Mount once at the app root.
  */
 export function useTheme(): void {
-    const darkMode = useThemeStore((s) => s.darkMode);
+    const theme = useThemeStore((s) => s.theme);
+    const setTheme = useThemeStore((s) => s.setTheme);
+
     useEffect(() => {
-        applyTheme(darkMode);
-    }, [darkMode]);
+        applyTheme(theme);
+
+        if (theme !== 'system') {
+            return;
+        }
+
+        const mq = window.matchMedia('(prefers-color-scheme: dark)');
+        const handler = () => applyTheme('system');
+        mq.addEventListener('change', handler);
+        return () => mq.removeEventListener('change', handler);
+    }, [theme, setTheme]);
 }

--- a/packages/webapp/src/lib/theme.ts
+++ b/packages/webapp/src/lib/theme.ts
@@ -22,13 +22,20 @@ export function applyTheme(theme: Theme): void {
     root.setAttribute('data-theme', dark ? 'dark' : 'light');
 }
 
+function getStoredTheme(): Theme {
+    try {
+        const raw = localStorage.getItem(LocalStorageKeys.Theme);
+        const s = raw ? (JSON.parse(raw) as { state?: { theme?: Theme; darkMode?: boolean } }) : null;
+        return s?.state?.theme ?? (s?.state?.darkMode === false ? 'light' : 'dark');
+    } catch {
+        return 'dark';
+    }
+}
+
 // Eagerly apply the persisted theme before the first React render.
+// Module code runs synchronously before ReactDOM.render().
 try {
-    const raw = localStorage.getItem(LocalStorageKeys.Theme);
-    const s = raw ? (JSON.parse(raw) as { state?: { theme?: Theme; darkMode?: boolean } }) : null;
-    // Support old boolean `darkMode` from before migration
-    const theme: Theme = s?.state?.theme ?? (s?.state?.darkMode === false ? 'light' : 'dark');
-    applyTheme(theme);
+    applyTheme(getStoredTheme());
 } catch {
     // Keep the dark default already set on <html class="dark"> in index.html
 }
@@ -40,17 +47,14 @@ interface ThemeState {
     setTheme: (theme: Theme) => void;
     /** Toggle between dark and light, ignoring/overriding system. */
     toggleDarkMode: () => void;
-    /** Current effective dark value (system resolves to OS preference). */
-    darkMode: boolean;
 }
 
 export const useThemeStore = create<ThemeState>()(
     persist(
         (set, get) => ({
-            theme: 'dark',
-            get darkMode() {
-                return resolveTheme(get().theme);
-            },
+            // Initialize from localStorage so first render has the correct value
+            // (avoids a flash when persist hydrates asynchronously)
+            theme: getStoredTheme(),
             setTheme: (theme) => set({ theme }),
             toggleDarkMode: () => {
                 const currentlyDark = resolveTheme(get().theme);
@@ -71,6 +75,9 @@ export const useThemeStore = create<ThemeState>()(
         }
     )
 );
+
+/** Derived selector: current effective dark value (system resolves to OS preference). */
+export const darkModeSelector = (s: ThemeState) => resolveTheme(s.theme);
 
 // --- Hook ---
 

--- a/packages/webapp/src/lib/theme.ts
+++ b/packages/webapp/src/lib/theme.ts
@@ -6,6 +6,11 @@ import { LocalStorageKeys } from '@/utils/local-storage';
 
 export type Theme = 'light' | 'dark' | 'system';
 
+// Dark is the default for now so existing users keep the current look and new users
+// don't land on light mode at rollout. Revisit defaulting to 'system' once light mode
+// has been live for a while. Keep index.html's pre-paint fallback in sync with this.
+const DEFAULT_THEME: Theme = 'dark';
+
 // --- DOM utility ---
 
 export function resolveTheme(theme: Theme): boolean {
@@ -24,9 +29,9 @@ function getStoredTheme(): Theme {
     try {
         const raw = localStorage.getItem(LocalStorageKeys.Theme);
         const s = raw ? (JSON.parse(raw) as { state?: { theme?: Theme; darkMode?: boolean } }) : null;
-        return s?.state?.theme ?? (s?.state?.darkMode === false ? 'light' : 'dark');
+        return s?.state?.theme ?? (s?.state?.darkMode === false ? 'light' : DEFAULT_THEME);
     } catch {
-        return 'dark';
+        return DEFAULT_THEME;
     }
 }
 

--- a/packages/webapp/src/pages/Connection/components/CreateConnectionSelector.tsx
+++ b/packages/webapp/src/pages/Connection/components/CreateConnectionSelector.tsx
@@ -25,7 +25,7 @@ import { PermissionGate } from '@/components/patterns/PermissionGate';
 import { Card, CardContent, CardDescription, CardHeader, CardTitle } from '@/components/ui/Card';
 import { InfoTooltip } from '@/components/ui/InfoTooltip';
 import { usePermissions } from '@/hooks/usePermissions';
-import { useThemeStore } from '@/lib/theme';
+import { darkModeSelector, useThemeStore } from '@/lib/theme';
 
 import type { AuthResult, ConnectUI, OnConnectEvent } from '@nangohq/frontend';
 import type { ApiIntegrationList } from '@nangohq/types';
@@ -77,7 +77,7 @@ export const CreateConnectionSelector: React.FC<CreateConnectionSelectorProps> =
     const canCreateTestConnection = can(permissions.canWriteProdConnections) || !environment?.is_production;
 
     const connectUI = useRef<ConnectUI>();
-    const isDarkMode = useThemeStore((s) => s.darkMode);
+    const isDarkMode = useThemeStore(darkModeSelector);
     const hasConnected = useRef<AuthResult | undefined>();
     const { mutate, cache } = useSWRConfig();
     const [isShareLinkLoading, setIsShareLinkLoading] = useState(false);

--- a/packages/webapp/src/pages/GettingStarted/FirstStep.tsx
+++ b/packages/webapp/src/pages/GettingStarted/FirstStep.tsx
@@ -14,7 +14,7 @@ import { queryClient, useStore } from '../../store';
 import { globalEnv } from '../../utils/env';
 import { Button } from '@/components/ui/Button';
 import { StyledLink } from '@/components/ui/StyledLink';
-import { useThemeStore } from '@/lib/theme';
+import { darkModeSelector, useThemeStore } from '@/lib/theme';
 
 import type { ConnectUI, OnConnectEvent } from '@nangohq/frontend';
 import type { GettingStartedOutput } from '@nangohq/types';
@@ -36,7 +36,7 @@ export const FirstStep: React.FC<FirstStepProps> = ({ connection, integration, o
     const { toast } = useToast();
     const { mutateAsync: deleteConnection, isPending: isDeletingConnection } = useDeleteConnection();
     const connectUI = useRef<ConnectUI>();
-    const isDarkMode = useThemeStore((s) => s.darkMode);
+    const isDarkMode = useThemeStore(darkModeSelector);
 
     const onClickConnect = () => {
         if (!environmentAndAccount || !user) {

--- a/packages/webapp/src/pages/Logs/Operation/Message/Show.tsx
+++ b/packages/webapp/src/pages/Logs/Operation/Message/Show.tsx
@@ -5,7 +5,7 @@ import { useMemo } from 'react';
 import { formatDateToLogFormat, millisecondsToRuntime } from '../../../../utils/utils';
 import { LevelTag } from '../../components/LevelTag';
 import { Tag } from '@/components/ui/Tag';
-import { useThemeStore } from '@/lib/theme';
+import { darkModeSelector, useThemeStore } from '@/lib/theme';
 
 import type { MessageRow } from '@nangohq/types';
 
@@ -52,7 +52,7 @@ export const ShowMessage: React.FC<{ message: MessageRow }> = ({ message }) => {
         return millisecondsToRuntime(message.durationMs);
     }, [message]);
 
-    const darkMode = useThemeStore((s) => s.darkMode);
+    const darkMode = useThemeStore(darkModeSelector);
 
     return (
         <div className="py-8 px-6 flex flex-col gap-5 h-full">

--- a/packages/webapp/src/pages/Logs/Operation/Show.tsx
+++ b/packages/webapp/src/pages/Logs/Operation/Show.tsx
@@ -14,7 +14,7 @@ import { formatDateToLogFormat, getRunTime } from '../../../utils/utils';
 import { StatusTag } from '../components/StatusTag';
 import { Alert, AlertDescription } from '@/components/ui/Alert';
 import { Skeleton } from '@/components/ui/Skeleton';
-import { useThemeStore } from '@/lib/theme';
+import { darkModeSelector, useThemeStore } from '@/lib/theme';
 
 export const ShowOperation: React.FC<{ operationId: string }> = ({ operationId }) => {
     const env = useStore((state) => state.env);
@@ -69,7 +69,7 @@ export const ShowOperation: React.FC<{ operationId: string }> = ({ operationId }
         isLive ? 5000 : null
     );
 
-    const darkMode = useThemeStore((s) => s.darkMode);
+    const darkMode = useThemeStore(darkModeSelector);
 
     if (loading) {
         return (

--- a/packages/webapp/src/pages/Team/Billing/components/PaymentMethodDialog.tsx
+++ b/packages/webapp/src/pages/Team/Billing/components/PaymentMethodDialog.tsx
@@ -7,7 +7,7 @@ import { Dialog, DialogClose, DialogContent, DialogDescription, DialogFooter, Di
 import { Skeleton } from '@/components/ui/Skeleton';
 import { apiPostStripeCollectPayment } from '@/hooks/useStripe';
 import { useToast } from '@/hooks/useToast';
-import { useThemeStore } from '@/lib/theme';
+import { darkModeSelector, useThemeStore } from '@/lib/theme';
 import { queryClient, useStore } from '@/store';
 import { stripePromise } from '@/utils/stripe';
 
@@ -21,7 +21,7 @@ export const PaymentMethodDialog: React.FC<{
     children?: React.ReactElement;
 }> = ({ replace, open: openProp, onOpenChange, onSuccess, children }) => {
     const env = useStore((state) => state.env);
-    const darkMode = useThemeStore((s) => s.darkMode);
+    const darkMode = useThemeStore(darkModeSelector);
 
     const [clientSecret, setClientSecret] = useState<string | null>(null);
 

--- a/packages/webapp/src/pages/User/Settings.tsx
+++ b/packages/webapp/src/pages/User/Settings.tsx
@@ -8,13 +8,19 @@ import DashboardLayout from '../../layout/DashboardLayout';
 import { CriticalErrorAlert } from '@/components/patterns/CriticalErrorAlert';
 import { Button } from '@/components/ui/Button';
 import { InputGroup, InputGroupAddon, InputGroupInput } from '@/components/ui/InputGroup';
+import { Select, SelectContent, SelectItem, SelectTrigger, SelectValue } from '@/components/ui/Select';
 import { Skeleton } from '@/components/ui/Skeleton';
 import { Tooltip, TooltipContent, TooltipTrigger } from '@/components/ui/Tooltip';
+import { useThemeStore } from '@/lib/theme';
+
+import type { Theme } from '@/lib/theme';
 
 export const UserSettings: React.FC = () => {
     const { toast } = useToast();
 
     const { user, loading, error, mutate } = useUser();
+    const theme = useThemeStore((s) => s.theme);
+    const setTheme = useThemeStore((s) => s.setTheme);
     const ref = useRef<HTMLInputElement>(null);
     const [name, setName] = useState(() => user?.name || '');
     const [edit, setEdit] = useState(false);
@@ -107,6 +113,19 @@ export const UserSettings: React.FC = () => {
                 <div className="flex flex-col gap-5">
                     <h3 className="font-semibold text-sm text-text-strong">Email</h3>
                     <p className="text-text-strong text-sm">{user.email}</p>
+                </div>
+                <div className="flex flex-col gap-5">
+                    <h3 className="font-semibold text-sm text-text-strong">Theme</h3>
+                    <Select value={theme} onValueChange={(v) => setTheme(v as Theme)}>
+                        <SelectTrigger className="w-48">
+                            <SelectValue />
+                        </SelectTrigger>
+                        <SelectContent>
+                            <SelectItem value="system">System</SelectItem>
+                            <SelectItem value="light">Light</SelectItem>
+                            <SelectItem value="dark">Dark</SelectItem>
+                        </SelectContent>
+                    </Select>
                 </div>
             </div>
         </DashboardLayout>

--- a/packages/webapp/src/pages/User/Settings.tsx
+++ b/packages/webapp/src/pages/User/Settings.tsx
@@ -115,7 +115,7 @@ export const UserSettings: React.FC = () => {
                     <p className="text-text-strong text-sm">{user.email}</p>
                 </div>
                 <div className="flex flex-col gap-5">
-                    <h3 className="font-semibold text-sm text-text-strong">Theme</h3>
+                    <h3 className="font-semibold text-sm text-text-strong">Appearance</h3>
                     <Select value={theme} onValueChange={(v) => setTheme(v as Theme)}>
                         <SelectTrigger className="w-48">
                             <SelectValue />

--- a/packages/webapp/src/store/feature-flags.ts
+++ b/packages/webapp/src/store/feature-flags.ts
@@ -6,16 +6,8 @@ import { LocalStorageKeys } from '../utils/local-storage';
 /**
  * Local-storage-only feature flags for development use.
  * Only surfaced via DevToolPanel — never shipped to production UI.
- *
- * Each flag here controls whether a particular feature is visible/active
- * in the app UI. The flag itself is NOT the feature state — e.g. `themeSwitcher`
- * controls whether the dark/light toggle button appears in the navbar;
- * the actual theme state lives in `useThemeStore`.
  */
 export interface FeatureFlagsState {
-    /** When true, shows the dark/light mode toggle button in the app header. */
-    themeSwitcher: boolean;
-
     /** When true, surfaces per-metric breakdown controls on the billing usage dashboard. */
     usageBreakdown: boolean;
 
@@ -26,7 +18,6 @@ export const useFeatureFlagsStore = create<FeatureFlagsState>()(
     persist(
         (set) => ({
             // Off by default — enable via the dev panel (Ctrl+Shift+D)
-            themeSwitcher: false,
             usageBreakdown: false,
 
             setFlag: (key, value) => set({ [key]: value })


### PR DESCRIPTION
## Problem

Part 1 unified the webapp on design-system tokens, making light mode technically renderable — but the app was still dark-only. There was no way for users to choose light mode, no detection of the OS preference, and reloading in light mode would flash dark first.

## Solution

Ship light mode to all users:

- **`lib/theme.ts`** — replace the `darkMode: boolean` store with a `light | dark | system` `Theme`; add `resolveTheme()`, a `darkModeSelector` (resolves `system` to the OS preference), an OS-preference watcher, cross-tab sync via the `storage` event, and a migration for the old boolean state
- **`index.html`** — inline script reads the saved theme from `localStorage` and sets `data-theme` before first paint, so light mode no longer flashes dark on reload; `<html>` no longer hardcodes `class="dark"`
- **`AppHeader`** — Sun/Moon toggle is now always visible (previously gated behind the `themeSwitcher` dev flag)
- **`User/Settings`** — new **Appearance** selector (System / Light / Dark) that persists across reloads
- **`DevToolPanel`** — Theme section shows the current mode (`System (dark)`, `Dark`, `Light`) with a quick toggle
- **`feature-flags.ts`** — remove the now-unused `themeSwitcher` flag
- **7 components** (`CodeBlock`, `SimpleCodeBlock`, `CreateConnectionSelector`, `FirstStep`, `PaymentMethodDialog`, `Logs/Operation/Show`, `Logs/Operation/Message/Show`) — read the resolved theme via `darkModeSelector` so Prism syntax, logos, and colors follow `system`
- **`DashboardLayout`** — drop the top-left corner radius that left a sidebar gap

Stacked on #6444.

Fixes [NAN-5751](https://linear.app/nango/issue/NAN-5751)

## Testing

- Sun/Moon toggle in the header flips dark ↔ light app-wide, for all users
- **Appearance** selector in User Settings (System / Light / Dark) persists across reloads
- "System" follows the OS preference and updates live when the OS theme changes
- Changing the theme in one tab syncs to other open tabs
- Reloading in light mode loads light immediately (no dark flash)

<img width="374" height="55" alt="image" src="https://github.com/user-attachments/assets/86fe73e2-51b4-4544-bed1-c64aea85da0a" />

<img width="1512" height="865" alt="image" src="https://github.com/user-attachments/assets/5147ef51-1438-4ad1-88e2-d1a8a4155630" />

<img width="338" height="581" alt="image" src="https://github.com/user-attachments/assets/1ca4683f-1412-497b-a850-7d5ca3c75d37" />