### PR TITLE
feat(webhooks): add createFunction/createWebhook authoring primitive (NAN-5885) 1/n

### DIFF
--- a/packages/cli/fixtures/zero/cases/webhook.ts
+++ b/packages/cli/fixtures/zero/cases/webhook.ts
@@ -1,0 +1,11 @@
+import { createWebhook } from 'nango';
+
+export default createWebhook({
+    name: 'contacts-updated',
+    description: 'Handle contact updates',
+    version: '1.0.0',
+    debounce: { key: { body: '$.portalId' }, windowMs: 5000 },
+    exec: async (nango) => {
+        await nango.log('received webhook');
+    }
+});

--- a/packages/cli/lib/index.ts
+++ b/packages/cli/lib/index.ts
@@ -182,10 +182,12 @@ program
     .option('--sync', 'Create a new sync scaffold')
     .option('--action', 'Create a new action scaffold')
     .option('--on-event', 'Create a new on event scaffold')
+    // TODO: add once released (NAN-5943)
+    //.option('--webhook', 'Create a new webhook function scaffold')
     .argument('[integration]', 'Integration name, e.g. "google-calendar"')
     .argument('[name]', 'Name of the sync/action, e.g. "calendar-events"')
     .action(async function (this: Command) {
-        const { debug, sync, action, onEvent, interactive } = this.opts();
+        const { debug, sync, action, onEvent, webhook, interactive } = this.opts();
         let [integration, name] = this.args;
         const absolutePath = process.cwd();
 
@@ -194,7 +196,7 @@ program
 
         try {
             const ensure = new Ensure(interactive);
-            const functionType = await ensure.functionType(sync, action, onEvent);
+            const functionType = await ensure.functionType({ sync, action, onEvent, webhook });
 
             let integrations: string[] = [];
 

--- a/packages/cli/lib/sdkScripts.ts
+++ b/packages/cli/lib/sdkScripts.ts
@@ -2,13 +2,16 @@
 
 export type { ActionError, NangoActionBase as NangoAction, NangoSyncBase as NangoSync, ProxyConfiguration } from '@nangohq/runner-sdk';
 
-export { createAction, createOnEvent, createSync } from '@nangohq/runner-sdk';
+export { createAction, createFunction, createOnEvent, createSync, createWebhook } from '@nangohq/runner-sdk';
 export type {
     CreateActionProps,
     CreateActionResponse,
     CreateAnyResponse,
+    CreateFunctionProps,
+    CreateFunctionResponse,
     CreateOnEventProps,
     CreateOnEventResponse,
     CreateSyncProps,
-    CreateSyncResponse
+    CreateSyncResponse,
+    CreateWebhookProps
 } from '@nangohq/runner-sdk';

--- a/packages/cli/lib/services/__snapshots__/config.service.unit.test.ts.snap
+++ b/packages/cli/lib/services/__snapshots__/config.service.unit.test.ts.snap
@@ -21,6 +21,7 @@ exports[`load > should parse a nango.yaml file that is version 1 as expected 1`]
           "version": "",
         },
       ],
+      "functions": [],
       "onEventScripts": {
         "post-connection-creation": [],
         "pre-connection-deletion": [],
@@ -223,6 +224,7 @@ exports[`load > should parse a nango.yaml file that is version 2 as expected 1`]
           "version": "",
         },
       ],
+      "functions": [],
       "onEventScripts": {
         "post-connection-creation": [],
         "pre-connection-deletion": [],

--- a/packages/cli/lib/services/ensure.service.ts
+++ b/packages/cli/lib/services/ensure.service.ts
@@ -38,12 +38,24 @@ export class Ensure {
         }
     }
 
-    public async functionType(sync: boolean, action: boolean, onEvent: boolean): Promise<FunctionType> {
+    public async functionType({
+        sync,
+        action,
+        onEvent,
+        webhook
+    }: {
+        sync?: boolean;
+        action?: boolean;
+        onEvent?: boolean;
+        webhook?: boolean;
+    }): Promise<FunctionType> {
         if (sync) return 'sync';
         if (action) return 'action';
         if (onEvent) return 'on-event';
+        if (webhook) return 'webhook';
 
         if (!this.interactive) {
+            // TODO: add --webhook once released (NAN-5943)
             throw new MissingArgumentError('Must specify --sync, --action, or --on-event');
         }
 

--- a/packages/cli/lib/services/function-create.service.ts
+++ b/packages/cli/lib/services/function-create.service.ts
@@ -20,6 +20,7 @@ export async function create({
 }): Promise<boolean> {
     try {
         if (!functionType) {
+            // TODO: add --webhook once released (NAN-5943)
             console.log(chalk.red('Must specify either --sync, --action, or --on-event'));
             return false;
         }
@@ -39,6 +40,9 @@ export async function create({
                 break;
             case 'on-event':
                 templateFile = path.join(templateFolder, 'on-event.ts');
+                break;
+            case 'webhook':
+                templateFile = path.join(templateFolder, 'webhook.ts');
                 break;
         }
 

--- a/packages/cli/lib/types.ts
+++ b/packages/cli/lib/types.ts
@@ -22,6 +22,6 @@ export interface InternalDeployOptions {
     integration?: string;
 }
 
-export const FUNCTION_TYPES = ['sync', 'action', 'on-event'] as const;
+export const FUNCTION_TYPES = ['sync', 'action', 'on-event', 'webhook'] as const;
 
 export type FunctionType = (typeof FUNCTION_TYPES)[number];

--- a/packages/cli/lib/zeroYaml/__snapshots__/compile.unit.cli-test.ts.snap
+++ b/packages/cli/lib/zeroYaml/__snapshots__/compile.unit.cli-test.ts.snap
@@ -214,6 +214,6 @@ exports[`edge cases > should catch invalid setMergingStrategy 1`] = `
 
 exports[`edge cases > should catch multiple exports 1`] = `
 "err - ./zero/cases/multipleExports.ts:25 
-  Named export 'test' is not allowed. Only export default and createAction, createSync, createOnEvent are permitted.
+  Named export 'test' is not allowed. Only export default and createAction, createSync, createOnEvent, createFunction, createWebhook are permitted.
 "
 `;

--- a/packages/cli/lib/zeroYaml/compile.ts
+++ b/packages/cli/lib/zeroYaml/compile.ts
@@ -459,7 +459,21 @@ function nangoPlugin({ entryPoint }: { entryPoint: string }) {
     // Get actual path even if entryPoint is a symlink
     const realEntryPoint = fs.realpathSync(normalizedEntryPoint.replace('.js', '.ts')).replace('.ts', '.js');
 
-    const allowedExports = ['createAction', 'createSync', 'createOnEvent'];
+    const allowedExports = {
+        createAction: { type: 'action', varName: 'action' },
+        createSync: { type: 'sync', varName: 'sync' },
+        createOnEvent: { type: 'onEvent', varName: 'onEvent' },
+        createFunction: { type: 'function', varName: 'fn' },
+        createWebhook: { type: 'function', varName: 'webhook' }
+    } as const satisfies Record<string, { type: string; varName: string }>;
+
+    type AllowedExportName = keyof typeof allowedExports;
+
+    function isAllowedExport(name: string): name is AllowedExportName {
+        // Use hasOwn rather than `in` so inherited prototype names (toString, constructor, …) are not accepted.
+        return Object.hasOwn(allowedExports, name);
+    }
+
     const needsAwait = [
         'batchDelete',
         'batchSave',
@@ -489,6 +503,36 @@ function nangoPlugin({ entryPoint }: { entryPoint: string }) {
     return {
         bag,
         plugin: ({ types: t }: { types: typeof babel.types }): babel.PluginObj<any> => {
+            // Properties that `createWebhook()` lifts into its implicit `http` trigger at runtime.
+            // Keep in sync with `createWebhook()` in runner-sdk/lib/scripts.ts.
+            const webhookTriggerFields = new Set(['name', 'scope', 'ingressChallenge', 'ingressValidation', 'debounce']);
+
+            /**
+             * `createWebhook()` is sugar for a function with a single implicit `http` trigger.
+             * The wrapper call is stripped at compile time (see nangoPlugin docblock), so we must
+             * reproduce that trigger synthesis here — otherwise the http trigger is silently dropped
+             * and the compiled function ends up with no triggers at all.
+             */
+            function buildWebhookObject(arg: babel.types.ObjectExpression): babel.types.ObjectExpression {
+                const triggerProps: babel.types.ObjectExpression['properties'] = [t.objectProperty(t.identifier('type'), t.stringLiteral('http'))];
+                const topProps: babel.types.ObjectExpression['properties'] = [];
+                for (const prop of arg.properties) {
+                    if (t.isObjectProperty(prop) && !prop.computed && t.isIdentifier(prop.key) && webhookTriggerFields.has(prop.key.name)) {
+                        triggerProps.push(prop);
+                        if (prop.key.name === 'name') {
+                            topProps.push(t.objectProperty(t.identifier('name'), t.cloneNode(prop.value)));
+                        }
+                    } else {
+                        topProps.push(prop);
+                    }
+                }
+                return t.objectExpression([
+                    t.objectProperty(t.identifier('type'), t.stringLiteral('function')),
+                    ...topProps,
+                    t.objectProperty(t.identifier('triggers'), t.arrayExpression([t.objectExpression(triggerProps)]))
+                ]);
+            }
+
             return {
                 visitor: {
                     ImportDeclaration(path) {
@@ -642,7 +686,7 @@ function nangoPlugin({ entryPoint }: { entryPoint: string }) {
                             throw new CompileError(
                                 'nango_named_export_not_allowed',
                                 lineNumber,
-                                `Named export '${exportedName}' is not allowed. Only export default and ${allowedExports.join(', ')} are permitted.`
+                                `Named export '${exportedName}' is not allowed. Only export default and ${Object.keys(allowedExports).join(', ')} are permitted.`
                             );
                         };
 
@@ -651,7 +695,7 @@ function nangoPlugin({ entryPoint }: { entryPoint: string }) {
                             for (const specifier of node.specifiers) {
                                 if (t.isExportSpecifier(specifier) && t.isIdentifier(specifier.exported)) {
                                     const exportedName = specifier.exported.name;
-                                    if (!allowedExports.includes(exportedName)) {
+                                    if (!isAllowedExport(exportedName)) {
                                         namedExportError(exportedName);
                                     }
                                 }
@@ -673,7 +717,7 @@ function nangoPlugin({ entryPoint }: { entryPoint: string }) {
                             }
 
                             for (const exportedName of exportedNames) {
-                                if (!allowedExports.includes(exportedName)) {
+                                if (!isAllowedExport(exportedName)) {
                                     namedExportError(exportedName);
                                 }
                             }
@@ -696,25 +740,28 @@ function nangoPlugin({ entryPoint }: { entryPoint: string }) {
 
                         const lineNumber = astPath.node.loc?.start.line || 0;
                         const decl = astPath.node.declaration;
-                        let calleeName = null;
                         let arg = null;
 
                         // Case 1: export default createAction({...})
-                        if (t.isCallExpression(decl) && t.isIdentifier(decl.callee) && allowedExports.includes(decl.callee.name)) {
-                            let varName = '';
-                            calleeName = decl.callee.name;
+                        if (t.isCallExpression(decl) && t.isIdentifier(decl.callee) && isAllowedExport(decl.callee.name)) {
+                            const calleeName = decl.callee.name;
                             arg = decl.arguments[0];
                             if (!t.isObjectExpression(arg)) {
                                 throw new CompileError('nango_invalid_function_param', lineNumber, 'Invalid function parameter, should be an object');
                             }
 
-                            if (calleeName === 'createAction') varName = 'action';
-                            if (calleeName === 'createSync') varName = 'sync';
-                            if (calleeName === 'createOnEvent') varName = 'onEvent';
+                            const mapping = allowedExports[calleeName];
+                            const varName = mapping.varName;
 
-                            // Inject type property
-                            arg.properties = [t.objectProperty(t.identifier('type'), t.stringLiteral(varName)), ...arg.properties];
-                            const newValue = arg;
+                            let newValue: babel.types.ObjectExpression;
+                            if (calleeName === 'createWebhook') {
+                                // createWebhook does more than tag a type: it synthesizes the implicit http trigger.
+                                newValue = buildWebhookObject(arg);
+                            } else {
+                                // Inject type property
+                                arg.properties = [t.objectProperty(t.identifier('type'), t.stringLiteral(mapping.type)), ...arg.properties];
+                                newValue = arg;
+                            }
                             // Insert: export const <varName> = <newValue>;
                             const exportConst = t.exportNamedDeclaration(
                                 t.variableDeclaration('const', [t.variableDeclarator(t.identifier(varName), newValue)]),
@@ -734,24 +781,27 @@ function nangoPlugin({ entryPoint }: { entryPoint: string }) {
                             }
 
                             const init = binding.path.node.init;
-                            if (!t.isCallExpression(init) || !t.isIdentifier(init.callee) || !allowedExports.includes(init.callee.name)) {
+                            if (!t.isCallExpression(init) || !t.isIdentifier(init.callee) || !isAllowedExport(init.callee.name)) {
                                 throw new CompileError('nango_invalid_default_export', lineNumber, badExportCompilerError);
                             }
 
-                            let varName = '';
-                            calleeName = init.callee.name;
+                            const calleeName = init.callee.name;
                             arg = init.arguments[0];
                             if (!t.isObjectExpression(arg)) {
                                 throw new CompileError('nango_invalid_function_param', lineNumber, 'Invalid function parameter, should be an object');
                             }
 
-                            if (calleeName === 'createAction') varName = 'action';
-                            if (calleeName === 'createSync') varName = 'sync';
-                            if (calleeName === 'createOnEvent') varName = 'onEvent';
-                            // Inject type property (mutate the object literal)
-                            arg.properties = [t.objectProperty(t.identifier('type'), t.stringLiteral(varName)), ...arg.properties];
+                            let newInit: babel.types.ObjectExpression;
+                            if (calleeName === 'createWebhook') {
+                                // createWebhook does more than tag a type: it synthesizes the implicit http trigger.
+                                newInit = buildWebhookObject(arg);
+                            } else {
+                                // Inject type property (mutate the object literal)
+                                arg.properties = [t.objectProperty(t.identifier('type'), t.stringLiteral(allowedExports[calleeName].type)), ...arg.properties];
+                                newInit = arg;
+                            }
                             // Replace the variable's initializer with the object literal
-                            binding.path.get('init').replaceWith(arg);
+                            binding.path.get('init').replaceWith(newInit);
                             return;
                         } else {
                             throw new CompileError('nango_unsupported_export', lineNumber, badExportCompilerError);

--- a/packages/cli/lib/zeroYaml/compile.unit.cli-test.ts
+++ b/packages/cli/lib/zeroYaml/compile.unit.cli-test.ts
@@ -23,6 +23,16 @@ describe('bundleFile', () => {
         const value = result.unwrap();
         expect(value).toMatchSnapshot();
     });
+
+    it('should synthesize the implicit http trigger when bundling a createWebhook', async () => {
+        const result = await bundleFile({ entryPoint: path.join(fixturesPath, 'zero/cases/webhook.js'), projectRootPath: fixturesPath });
+        const value = result.unwrap();
+        // createWebhook is stripped at compile time, so the http trigger must be reproduced in the output.
+        expect(value).toContain('type: "function"');
+        expect(value).toContain('triggers: [');
+        expect(value).toContain('type: "http"');
+        expect(value).toContain('name: "contacts-updated"');
+    });
 });
 
 describe('compileAll', () => {

--- a/packages/cli/lib/zeroYaml/definitions.ts
+++ b/packages/cli/lib/zeroYaml/definitions.ts
@@ -16,12 +16,20 @@ import {
 import { Err, Ok } from '../utils/result.js';
 import { printDebug } from '../utils.js';
 
-import type { CreateActionResponse, CreateOnEventResponse, CreateSyncResponse } from '@nangohq/runner-sdk';
+import type { CreateActionResponse, CreateFunctionResponse, CreateOnEventResponse, CreateSyncResponse, FunctionTrigger } from '@nangohq/runner-sdk';
 import type { ZodCheckpoint, ZodMetadata, ZodModel } from '@nangohq/runner-sdk/lib/types.js';
-import type { NangoYamlParsed, NangoYamlParsedIntegration, ParsedNangoAction, ParsedNangoSync, Result } from '@nangohq/types';
+import type {
+    NangoYamlParsed,
+    NangoYamlParsedIntegration,
+    ParsedFunctionTrigger,
+    ParsedNangoAction,
+    ParsedNangoFunction,
+    ParsedNangoSync,
+    Result
+} from '@nangohq/types';
 import type * as z from 'zod';
 
-const allowed = ['action', 'sync', 'onEvent'];
+const allowed = ['action', 'sync', 'onEvent', 'function'];
 
 export async function parseIntegrationDefinitions({ fullPath, debug }: { fullPath: string; debug: boolean }): Promise<Result<NangoYamlParsed>> {
     const parsed: NangoYamlParsed = { yamlVersion: 'v2', integrations: [], models: new Map() };
@@ -45,7 +53,12 @@ export async function parseIntegrationDefinitions({ fullPath, debug }: { fullPat
             return Err(new Error(`Script should have a default export ${modulePath}`));
         }
         if (!moduleContent.default.default.type || !allowed.includes(moduleContent.default.default.type)) {
-            return Err(new Error(`Script should be declared using utility function (createSync, createAction, createOnEvent) ${modulePath}`));
+            return Err(
+                new Error(
+                    // TODO: add createFunction, createWebhook once released (NAN-5943)
+                    `Script should be declared using utility function (createSync, createAction, createOnEvent) ${modulePath}`
+                )
+            );
         }
 
         printDebug(`Parsing ${filePath}`, debug);
@@ -53,7 +66,8 @@ export async function parseIntegrationDefinitions({ fullPath, debug }: { fullPat
         const script = moduleContent.default.default as
             | CreateSyncResponse<Record<string, ZodModel>, ZodMetadata, ZodCheckpoint>
             | CreateActionResponse<z.ZodTypeAny, z.ZodTypeAny, ZodMetadata, ZodCheckpoint>
-            | CreateOnEventResponse;
+            | CreateOnEventResponse
+            | CreateFunctionResponse<Record<string, ZodModel>, z.ZodTypeAny, z.ZodTypeAny, ZodMetadata, ZodCheckpoint>;
 
         const basename = path.basename(filePath, '.js');
         const realPath = filePath.replace('.js', '.ts');
@@ -68,6 +82,7 @@ export async function parseIntegrationDefinitions({ fullPath, debug }: { fullPat
                 providerConfigKey: integrationId,
                 actions: [],
                 syncs: [],
+                functions: [],
                 onEventScripts: { 'post-connection-creation': [], 'pre-connection-deletion': [], 'validate-connection': [] }
             };
             parsed.integrations.push(integration);
@@ -94,6 +109,14 @@ export async function parseIntegrationDefinitions({ fullPath, debug }: { fullPat
                 } else if (script.event === 'validate-connection') {
                     integration.onEventScripts['validate-connection'].push(basename);
                 }
+                break;
+            }
+            case 'function': {
+                const parsedFunctionRes = parseFunction({ filePath: realPath, params: script, integrationIdClean, basename, basenameClean });
+                if (parsedFunctionRes.isErr()) {
+                    return Err(parsedFunctionRes.error);
+                }
+                integration.functions.push(parsedFunctionRes.value);
                 break;
             }
         }
@@ -231,6 +254,94 @@ export function parseAction({
     };
 }
 
+export function parseFunction({
+    filePath,
+    params,
+    integrationIdClean,
+    basename,
+    basenameClean
+}: {
+    filePath: string;
+    params: CreateFunctionResponse<Record<string, ZodModel>, z.ZodTypeAny, z.ZodTypeAny, ZodMetadata, ZodCheckpoint>;
+    integrationIdClean: string;
+    basename: string;
+    basenameClean: string;
+}): Result<ParsedNangoFunction> {
+    if (!Array.isArray(params.triggers) || params.triggers.length === 0) {
+        return Err(new Error(`Function "${basename}" must declare at least one trigger (${filePath})`));
+    }
+
+    // Validate schedule trigger intervals
+    for (const trigger of params.triggers) {
+        if (trigger.type === 'schedule') {
+            const interval = getInterval(trigger.schedule, new Date());
+            if (interval instanceof Error) {
+                return Err(new InvalidIntervalDefinitionError(filePath, ['createFunction', 'triggers', 'schedule']));
+            }
+        }
+    }
+
+    const allZodModels: Record<string, z.ZodType> = { ...(params.models ?? {}) };
+
+    const inputName = params.input ? `FunctionInput_${integrationIdClean}_${basenameClean}` : null;
+    if (params.input && inputName) {
+        allZodModels[inputName] = params.input;
+    }
+
+    const metadataModelName = params.metadata ? `FunctionMetadata_${integrationIdClean}_${basenameClean}` : null;
+    if (params.metadata && metadataModelName) {
+        allZodModels[metadataModelName] = params.metadata;
+    }
+
+    for (const modelName of Object.keys(params.models ?? {})) {
+        if (!regexModelName.test(modelName)) {
+            return Err(new InvalidModelDefinitionError(modelName, filePath, ['createFunction', 'models']));
+        }
+    }
+
+    const outputNames = Object.keys(params.models ?? {});
+    const jsonSchema = buildJsonSchemaDefinitionsFromZodModels(allZodModels);
+    const features = detectFeatures({ entryPoint: filePath });
+
+    const fn: ParsedNangoFunction = {
+        type: 'function',
+        name: params.name || basename,
+        description: params.description || '',
+        triggers: params.triggers.map(toParsedTrigger),
+        input: inputName,
+        output: outputNames.length > 0 ? outputNames : null,
+        scopes: params.scopes || [],
+        usedModels: Object.keys(allZodModels),
+        version: params.version || '',
+        json_schema: jsonSchema,
+        features: features.isOk() ? features.value : []
+    };
+
+    return Ok(fn);
+}
+
+function toParsedTrigger(trigger: FunctionTrigger): ParsedFunctionTrigger {
+    const parsed: ParsedFunctionTrigger = { type: trigger.type };
+    if (trigger.type === 'http') {
+        if (trigger.name !== undefined) {
+            parsed.name = trigger.name;
+        }
+        if (trigger.scope !== undefined) {
+            parsed.scope = trigger.scope;
+        }
+        if (trigger.debounce !== undefined) {
+            parsed.debounce = trigger.debounce;
+        }
+        parsed.hasIngressChallenge = typeof trigger.ingressChallenge === 'function';
+        parsed.hasIngressValidation = typeof trigger.ingressValidation === 'function';
+    } else if (trigger.type === 'schedule') {
+        parsed.schedule = trigger.schedule;
+    } else if (trigger.type === 'event') {
+        parsed.event = trigger.event;
+    }
+    return parsed;
+}
+
 function postValidation(parsed: NangoYamlParsed): Result<void> {
     for (const integration of parsed.integrations) {
         const seenEndpoints = new Set<string>();
@@ -252,6 +363,17 @@ function postValidation(parsed: NangoYamlParsed): Result<void> {
                     );
                 }
                 seenEndpoints.add(key);
+            }
+        }
+
+        for (const fn of integration.functions) {
+            for (const model of fn.usedModels) {
+                if (seenModels.has(model)) {
+                    return Err(
+                        new DuplicateModelDefinitionError(model, `${integration.providerConfigKey}/functions/${fn.name}.ts`, ['createFunction', 'models'])
+                    );
+                }
+                seenModels.add(model);
             }
         }
 

--- a/packages/cli/templates/webhook.ts
+++ b/packages/cli/templates/webhook.ts
@@ -1,0 +1,15 @@
+import { createWebhook } from 'nango';
+
+export default createWebhook({
+    description: '',
+    // Runs synchronously at ingress to verify the request is authentic. No SDK, no I/O.
+    // ingressValidation: async (event) => {
+    //     return true;
+    // },
+    // Coalesce bursts of events into a single run.
+    // debounce: { key: { body: '$.id' }, windowMs: 5000 },
+    exec: async (nango, event) => {
+        // Routing lives here, on your runner. Find the matching connection(s) and trigger work.
+        await nango.log('Received webhook', event.payload);
+    }
+});

--- a/packages/nango-yaml/lib/parser.v1.ts
+++ b/packages/nango-yaml/lib/parser.v1.ts
@@ -83,6 +83,7 @@ export class NangoYamlParserV1 extends NangoYamlParser {
                 providerConfigKey: integrationName,
                 syncs,
                 actions,
+                functions: [],
                 onEventScripts: { 'post-connection-creation': [], 'pre-connection-deletion': [], 'validate-connection': [] }
             };
 

--- a/packages/nango-yaml/lib/parser.v1.unit.test.ts
+++ b/packages/nango-yaml/lib/parser.v1.unit.test.ts
@@ -54,7 +54,8 @@ describe('parse', () => {
                             usedModels: ['GithubIssue'],
                             version: ''
                         }
-                    ]
+                    ],
+                    functions: []
                 }
             ],
             models: new Map([['GithubIssue', { name: 'GithubIssue', fields: [{ name: 'id', value: 'string', tsType: true, array: false, optional: false }] }]]),
@@ -96,7 +97,8 @@ describe('parse', () => {
                         }
                     ],
                     onEventScripts: { 'post-connection-creation': [], 'pre-connection-deletion': [], 'validate-connection': [] },
-                    actions: []
+                    actions: [],
+                    functions: []
                 }
             ],
             models: new Map([

--- a/packages/nango-yaml/lib/parser.v2.ts
+++ b/packages/nango-yaml/lib/parser.v2.ts
@@ -57,6 +57,7 @@ export class NangoYamlParserV2 extends NangoYamlParser {
                 syncs: parsedSyncs,
                 actions: parseActions,
                 onEventScripts: parsedOnEventScripts,
+                functions: [],
                 ...(postConnectionScripts.length > 0 ? { postConnectionScripts } : {})
             };
 

--- a/packages/nango-yaml/lib/parser.v2.unit.test.ts
+++ b/packages/nango-yaml/lib/parser.v2.unit.test.ts
@@ -62,7 +62,8 @@ describe('parse', () => {
                             version: '',
                             features: []
                         }
-                    ]
+                    ],
+                    functions: []
                 }
             ],
             models: new Map([
@@ -111,7 +112,8 @@ describe('parse', () => {
                             version: '',
                             features: []
                         }
-                    ]
+                    ],
+                    functions: []
                 }
             ],
             models: new Map([
@@ -158,7 +160,8 @@ describe('parse', () => {
                         }
                     ],
                     onEventScripts: { 'post-connection-creation': [], 'pre-connection-deletion': [], 'validate-connection': [] },
-                    actions: []
+                    actions: [],
+                    functions: []
                 }
             ],
             models: new Map([

--- a/packages/runner-sdk/lib/scripts.ts
+++ b/packages/runner-sdk/lib/scripts.ts
@@ -8,7 +8,8 @@ import type * as z from 'zod';
 export type CreateAnyResponse =
     | CreateSyncResponse<any, ZodMetadata, ZodCheckpoint>
     | CreateActionResponse<any, any, ZodMetadata, ZodCheckpoint>
-    | CreateOnEventResponse<ZodMetadata, ZodCheckpoint>;
+    | CreateOnEventResponse<ZodMetadata, ZodCheckpoint>
+    | CreateFunctionResponse<any, any, any, ZodMetadata, ZodCheckpoint>;
 
 export type { ActionError } from './errors.js';
 export type { NangoActionBase as NangoAction, ProxyConfiguration } from './action.js';
@@ -428,4 +429,279 @@ export function createOnEvent<TMetadata extends ZodMetadata = undefined, TCheckp
     params: CreateOnEventProps<TMetadata, TCheckpoint>
 ): CreateOnEventResponse<TMetadata, TCheckpoint> {
     return { type: 'onEvent', ...params };
+}
+
+// ----- Function / Webhook
+//
+// A `function` is a trigger-agnostic primitive: it separates the trigger (what initiates
+// execution) from the handler (what runs). Webhooks are the first trigger type.
+// `createWebhook()` is syntactic sugar for a function with a single implicit `http` trigger.
+// Syncs and actions will eventually be merged into functions.
+
+/**
+ * The kind of declared trigger that initiated a function run.
+ * - `http`: an incoming http call or webhook request
+ * - `schedule`: a periodic schedule
+ * - `event`: an internal Nango event
+ *
+ * On-demand invocation (`nango.triggerFunction()`, the REST API, the CLI, or the UI) is always
+ * available regardless of declared triggers — it is not a trigger type. Such runs leave
+ * `FunctionEvent.trigger` undefined.
+ */
+export type FunctionTriggerType = 'http' | 'schedule' | 'event';
+
+/**
+ * Declares where the debounce/coalescing key is extracted from.
+ * - `{ body: '$.portalId' }` — dot-notation path into the normalized body
+ * - `{ header: 'x-goog-resource-id' }` — flat, case-insensitive header lookup
+ */
+export type DebounceKeySource = { body: string } | { header: string };
+
+/**
+ * Coalesces multiple inbound events into a single function run within a sliding window.
+ */
+export interface WebhookDebounceConfig {
+    key?: DebounceKeySource;
+    /** Sliding window in milliseconds. */
+    windowMs: number;
+    /** Hard ceiling for the window regardless of incoming events. */
+    maxWindowMs?: number;
+    /** When exceeded, the window stops sliding and `event.coalesced.overflowed` is set. */
+    maxEntities?: number;
+    /** Whether the handler receives only the latest payload or every coalesced payload. */
+    payloadMode?: 'latest' | 'all';
+}
+
+/** Read-only request view passed to ingress hooks. No SDK, no I/O, hard timeout. */
+export interface IngressEvent {
+    rawBody: string;
+    headers: Record<string, string>;
+    query: Record<string, string | string[] | undefined>;
+}
+
+/**
+ * Runs synchronously at ingress before enqueueing. Return a response object to short-circuit
+ * the HTTP exchange (provider handshake), or `undefined` to let the request proceed.
+ */
+export type IngressChallenge = (event: IngressEvent) => MaybePromise<{ status?: number; body?: unknown; headers?: Record<string, string> } | undefined | void>;
+
+/**
+ * Runs synchronously at ingress before enqueueing. Return `true` to accept the event,
+ * or `false` (or throw) to reject it with a 401.
+ */
+export type IngressValidation = (event: IngressEvent) => MaybePromise<boolean>;
+
+export interface HttpTrigger {
+    type: 'http';
+    /** Maps to the webhook URL path segment. Defaults to the file basename. */
+    name?: string;
+    /** `connection` opts into connection-level URLs (`/:webhookName/:targetToken`). */
+    scope?: 'integration' | 'connection';
+    ingressChallenge?: IngressChallenge;
+    ingressValidation?: IngressValidation;
+    debounce?: WebhookDebounceConfig;
+}
+export interface ScheduleTrigger {
+    type: 'schedule';
+    /** e.g. 'every hour', 'every 2 minutes'. */
+    schedule: string;
+}
+export interface EventTrigger {
+    type: 'event';
+    event: string;
+}
+export type FunctionTrigger = HttpTrigger | ScheduleTrigger | EventTrigger;
+
+/** Coalescing summary, present on the event when `debounce` is configured. */
+export interface CoalescedInfo {
+    count: number;
+    firstSeenAt: Date;
+    lastSeenAt: Date;
+    overflowed: boolean;
+}
+
+/**
+ * The event a function `exec` receives. Distinct from `(nango, input)` for actions —
+ * functions are trigger-driven, so the second argument describes the trigger and its payload.
+ */
+export interface FunctionEvent<TPayload = unknown> {
+    /**
+     * Which declared trigger fired, and (for named triggers) its name.
+     * Undefined when the run was started on-demand (`nango.triggerFunction()`, the REST API, the CLI, or the UI).
+     */
+    trigger?: { type: FunctionTriggerType; name?: string };
+    /**
+     * The payload that initiated the run. Typed as the function's `input` schema when declared,
+     * otherwise `unknown`. For http triggers this is the provider's body (not validated against
+     * `input` at runtime), and it is an array of `TPayload` when `payloadMode: 'all'` is set and debounced.
+     */
+    payload: TPayload;
+    /** Raw headers from the provider (http trigger only). */
+    headers?: Record<string, string>;
+    /** Original request body as received by ingress (http trigger only). */
+    rawBody?: string;
+    /** Coalescing summary when `debounce` is configured. */
+    coalesced?: CoalescedInfo;
+    /**
+     * Pre-populated when the run was started with connection context (connection-level URL,
+     * `triggerFunction({ connectionId })`, or CLI `--connection`). Undefined for connection-less runs.
+     */
+    connection?: { connection_id: string; provider_config_key: string };
+}
+
+export interface CreateFunctionProps<
+    TModels extends Record<string, ZodModel>,
+    TInput extends z.ZodTypeAny = z.ZodUnknown,
+    TOutput extends z.ZodTypeAny = z.ZodTypeAny,
+    TMetadata extends ZodMetadata = undefined,
+    TCheckpoint extends ZodCheckpoint = undefined
+> {
+    /**
+     * The version of the function. Use it to track changes inside Nango's UI.
+     * Supports semver (e.g. `'1.0.0'`)
+     * If omitted, Nango auto-manages it: `1` on first deploy, and auto-increments for subsequent deploys.
+     */
+    version?: string;
+
+    /** The description of the function. */
+    description?: string;
+
+    /**
+     * What can initiate execution. A function can have multiple triggers of different types
+     * (e.g. a webhook trigger plus a scheduled safety net). Any function can also be started
+     * on-demand via `nango.triggerFunction()` or the API regardless of declared triggers.
+     */
+    triggers: FunctionTrigger[];
+
+    /** Models the function can `batchSave`/`batchUpdate`/`batchDelete` against. */
+    models?: TModels;
+
+    /** Optional input schema. When set, it types `event.payload` and is used for API invocation. */
+    input?: TInput;
+
+    /** Optional typed output schema (reserved; unused for webhooks today). */
+    output?: TOutput;
+
+    metadata?: TMetadata;
+    checkpoint?: TCheckpoint;
+    scopes?: string[];
+
+    /**
+     * The handler. Runs on the customer runner with full SDK access.
+     * @example
+     * ```ts
+     * exec: async (nango, event) => {
+     *   const connections = await nango.searchConnections({ tags: { portalId: event.payload.portalId } });
+     *   for (const connection of connections) {
+     *     await nango.triggerSync(connection.provider_config_key, connection.connection_id, 'contacts');
+     *   }
+     * }
+     * ```
+     */
+    exec: (nango: NangoSyncBase<TModels, TMetadata, TCheckpoint>, event: FunctionEvent<z.infer<TInput>>) => MaybePromise<void>;
+}
+
+export interface CreateFunctionResponse<
+    TModels extends Record<string, ZodModel>,
+    TInput extends z.ZodTypeAny = z.ZodUnknown,
+    TOutput extends z.ZodTypeAny = z.ZodTypeAny,
+    TMetadata extends ZodMetadata = undefined,
+    TCheckpoint extends ZodCheckpoint = undefined
+> extends CreateFunctionProps<TModels, TInput, TOutput, TMetadata, TCheckpoint> {
+    type: 'function';
+    /** Set when authored via `createWebhook()`; mirrors the http trigger name. */
+    name?: string;
+}
+
+/**
+ * Create a function — the trigger-agnostic primitive.
+ *
+ * Use this directly when you need multiple trigger types (e.g. webhook + cron).
+ * For a single webhook trigger, prefer the `createWebhook()` sugar.
+ *
+ * @example
+ * ```ts
+ * export default createFunction({
+ *     triggers: [
+ *         { type: 'http', name: 'contacts-updated', debounce: { key: { body: '$.objectId' }, windowMs: 5000 } },
+ *         { type: 'schedule', schedule: 'every hour' }
+ *     ],
+ *     exec: async (nango, event) => { ... }
+ * });
+ * ```
+ */
+export function createFunction<
+    // Default to an empty model map (not `Record<string, ZodModel>`) so that when `models` is
+    // omitted `keyof TModels` is `never`, keeping `batchSave`/`batchUpdate`/`batchDelete` model
+    // names type-checked against the declared models instead of accepting any string.
+    TModels extends Record<string, ZodModel> = Record<never, ZodModel>,
+    TInput extends z.ZodTypeAny = z.ZodUnknown,
+    TOutput extends z.ZodTypeAny = z.ZodTypeAny,
+    TMetadata extends ZodMetadata = undefined,
+    TCheckpoint extends ZodCheckpoint = undefined
+>(params: CreateFunctionProps<TModels, TInput, TOutput, TMetadata, TCheckpoint>): CreateFunctionResponse<TModels, TInput, TOutput, TMetadata, TCheckpoint> {
+    return { type: 'function', ...params };
+}
+
+export interface CreateWebhookProps<
+    TModels extends Record<string, ZodModel>,
+    TMetadata extends ZodMetadata = undefined,
+    TCheckpoint extends ZodCheckpoint = undefined
+> {
+    /** Maps to the webhook URL path segment. Defaults to the file basename. */
+    name?: string;
+    version?: string;
+    description?: string;
+    /** `connection` opts into connection-level URLs (`/:webhookName/:targetToken`). */
+    scope?: 'integration' | 'connection';
+    ingressChallenge?: IngressChallenge;
+    ingressValidation?: IngressValidation;
+    debounce?: WebhookDebounceConfig;
+    models?: TModels;
+    metadata?: TMetadata;
+    checkpoint?: TCheckpoint;
+    exec: (nango: NangoSyncBase<TModels, TMetadata, TCheckpoint>, event: FunctionEvent) => MaybePromise<void>;
+}
+
+/**
+ * Create a webhook handler — sugar for a function with a single implicit `http` trigger.
+ *
+ * Routing lives entirely in `exec` (customer-owned, runs on your runner). Provider protocol
+ * mechanics (handshake, signature verification) live in `ingressChallenge` / `ingressValidation`,
+ * which run synchronously at ingress with no SDK access.
+ *
+ * @example
+ * ```ts
+ * export default createWebhook({
+ *     name: 'contacts-updated',
+ *     debounce: { key: { body: '$.portalId' }, windowMs: 5000 },
+ *     exec: async (nango, event) => {
+ *         const connections = await nango.searchConnections({ tags: { portalId: event.payload.portalId } });
+ *         for (const connection of connections) {
+ *             await nango.triggerSync(connection.provider_config_key, connection.connection_id, 'contacts');
+ *         }
+ *     }
+ * });
+ * ```
+ */
+export function createWebhook<
+    TModels extends Record<string, ZodModel> = Record<never, ZodModel>,
+    TMetadata extends ZodMetadata = undefined,
+    TCheckpoint extends ZodCheckpoint = undefined
+>(params: CreateWebhookProps<TModels, TMetadata, TCheckpoint>): CreateFunctionResponse<TModels, z.ZodTypeAny, z.ZodTypeAny, TMetadata, TCheckpoint> {
+    const { name, scope, ingressChallenge, ingressValidation, debounce, ...rest } = params;
+    const trigger: HttpTrigger = {
+        type: 'http',
+        ...(name !== undefined ? { name } : {}),
+        ...(scope !== undefined ? { scope } : {}),
+        ...(ingressChallenge !== undefined ? { ingressChallenge } : {}),
+        ...(ingressValidation !== undefined ? { ingressValidation } : {}),
+        ...(debounce !== undefined ? { debounce } : {})
+    };
+    return {
+        type: 'function',
+        ...rest,
+        ...(name !== undefined ? { name } : {}),
+        triggers: [trigger]
+    };
 }

--- a/packages/runner-sdk/lib/scripts.unit.test.ts
+++ b/packages/runner-sdk/lib/scripts.unit.test.ts
@@ -2,7 +2,7 @@
 import { describe, expect, expectTypeOf, it } from 'vitest';
 import * as z from 'zod';
 
-import { createAction, createOnEvent, createSync } from './scripts.js';
+import { createAction, createFunction, createOnEvent, createSync, createWebhook } from './scripts.js';
 
 describe('scripts', () => {
     describe('createSync', () => {
@@ -184,6 +184,100 @@ describe('scripts', () => {
                 type: 'onEvent',
                 exec: expect.any(Function)
             });
+        });
+    });
+
+    describe('createFunction', () => {
+        it('should create a function with explicit triggers', () => {
+            const fn = createFunction({
+                description: 'Handle contact updates',
+                triggers: [
+                    { type: 'http', name: 'contacts-updated', debounce: { key: { body: '$.objectId' }, windowMs: 5000 } },
+                    { type: 'schedule', schedule: 'every hour' }
+                ],
+                exec: async (nango, event) => {
+                    // No input schema declared → payload is unknown, not any.
+                    expectTypeOf(event.payload).toBeUnknown();
+                    await nango.log('event', event.payload);
+                }
+            });
+
+            expect(fn).toStrictEqual({
+                description: 'Handle contact updates',
+                triggers: [
+                    { type: 'http', name: 'contacts-updated', debounce: { key: { body: '$.objectId' }, windowMs: 5000 } },
+                    { type: 'schedule', schedule: 'every hour' }
+                ],
+                type: 'function',
+                exec: expect.any(Function)
+            });
+        });
+
+        it('should type event.payload from the input schema', () => {
+            createFunction({
+                triggers: [{ type: 'schedule', schedule: 'every hour' }],
+                input: z.object({ portalId: z.string() }),
+                exec: async (nango, event) => {
+                    expectTypeOf(event.payload).toEqualTypeOf<{ portalId: string }>();
+                    await nango.log('event', event.payload);
+                }
+            });
+        });
+    });
+
+    describe('createWebhook', () => {
+        it('should desugar into a function with a single implicit http trigger', () => {
+            const ingressValidation = () => true;
+            const webhook = createWebhook({
+                name: 'contacts-updated',
+                description: 'Contacts webhook',
+                ingressValidation,
+                debounce: { key: { body: '$.portalId' }, windowMs: 5000 },
+                exec: async (nango, event) => {
+                    // Webhook bodies are provider-defined → payload is unknown.
+                    expectTypeOf(event.payload).toBeUnknown();
+                    await nango.log('event', event.payload);
+                }
+            });
+
+            expect(webhook.type).toBe('function');
+            expect(webhook.name).toBe('contacts-updated');
+            expect(webhook.triggers).toHaveLength(1);
+            expect(webhook.triggers[0]).toStrictEqual({
+                type: 'http',
+                name: 'contacts-updated',
+                ingressValidation,
+                debounce: { key: { body: '$.portalId' }, windowMs: 5000 }
+            });
+            // ingress hooks live on the trigger, not at the top level of the function
+            expect((webhook as unknown as Record<string, unknown>)['ingressValidation']).toBeUndefined();
+        });
+
+        it('should default the trigger name from the absence of name (left to the file basename downstream)', () => {
+            const webhook = createWebhook({
+                description: 'no name',
+                exec: async (nango) => {
+                    await nango.log('hi');
+                }
+            });
+
+            expect(webhook.type).toBe('function');
+            expect(webhook.name).toBeUndefined();
+            expect(webhook.triggers).toHaveLength(1);
+            expect(webhook.triggers[0]).toStrictEqual({ type: 'http' });
+        });
+
+        it('should lift scope into the http trigger and not leak it to the top level', () => {
+            const webhook = createWebhook({
+                name: 'contacts-updated',
+                scope: 'connection',
+                exec: async (nango) => {
+                    await nango.log('hi');
+                }
+            });
+
+            expect(webhook.triggers[0]).toStrictEqual({ type: 'http', name: 'contacts-updated', scope: 'connection' });
+            expect((webhook as unknown as Record<string, unknown>)['scope']).toBeUndefined();
         });
     });
 });

--- a/packages/types/lib/nangoYaml/index.ts
+++ b/packages/types/lib/nangoYaml/index.ts
@@ -5,8 +5,13 @@ import type { JSONSchema7 } from 'json-schema';
 export type HTTP_METHOD = 'GET' | 'POST' | 'PATCH' | 'PUT' | 'DELETE';
 /** @deprecated **/
 export type SyncTypeLiteral = 'incremental' | 'full';
-export type ScriptFileType = 'actions' | 'syncs' | 'on-events' | 'post-connection-scripts'; // post-connection-scripts is deprecated
+export type ScriptFileType = 'actions' | 'syncs' | 'on-events' | 'functions' | 'webhooks' | 'post-connection-scripts'; // post-connection-scripts is deprecated
 export type ScriptTypeLiteral = 'action' | 'sync' | 'on-event';
+/**
+ * The `function` primitive is authored via `createFunction()` / `createWebhook()`. It is tracked
+ * separately from {@link ScriptTypeLiteral} (sync/action/on-event) while it is introduced additively.
+ */
+export type FunctionScriptTypeLiteral = 'function';
 
 // --------------
 // YAML V1
@@ -95,6 +100,7 @@ export interface NangoYamlParsedIntegration {
     providerConfigKey: string;
     syncs: ParsedNangoSync[];
     actions: ParsedNangoAction[];
+    functions: ParsedNangoFunction[];
     onEventScripts: Record<OnEventType, string[]>;
     /**
      * @deprecated
@@ -119,6 +125,45 @@ export interface ParsedNangoSync {
     webhookSubscriptions: string[];
     version: string;
     // TODO: make non-optional when nango-yaml is fully removed
+    json_schema?: JSONSchema7 | undefined;
+    features?: Feature[] | undefined;
+}
+
+/** Serializable view of a function trigger (the executable hooks live in the deployed file body). */
+export interface ParsedFunctionTrigger {
+    type: 'http' | 'schedule' | 'event';
+    /** http trigger: maps to the URL path segment. */
+    name?: string;
+    /** http trigger: 'integration' (default) or 'connection' for tokenized per-connection URLs. */
+    scope?: 'integration' | 'connection';
+    /** schedule trigger. */
+    schedule?: string;
+    /** event trigger. */
+    event?: string;
+    /** Whether ingress coalescing is configured (the window/key config). */
+    debounce?: {
+        key?: { body: string } | { header: string };
+        windowMs: number;
+        maxWindowMs?: number;
+        maxEntities?: number;
+        payloadMode?: 'latest' | 'all';
+    };
+    /** Whether the trigger ships an `ingressChallenge` hook (executed at ingress). */
+    hasIngressChallenge?: boolean;
+    /** Whether the trigger ships an `ingressValidation` hook (executed at ingress). */
+    hasIngressValidation?: boolean;
+}
+
+export interface ParsedNangoFunction {
+    name: string;
+    type: 'function';
+    description: string;
+    triggers: ParsedFunctionTrigger[];
+    input: string | null;
+    output: string[] | null;
+    scopes: string[];
+    usedModels: string[];
+    version: string;
     json_schema?: JSONSchema7 | undefined;
     features?: Feature[] | undefined;
 }
@@ -175,5 +220,6 @@ export interface FlowsYaml {
 }
 
 // --- flows.zero.json is a parsed nango.yaml
-export type FlowZeroJson = NangoYamlParsedIntegration & { jsonSchema?: JSONSchema7; sdkVersion: string };
+// TODO: drop the functions override once flows.zero.json is regenerated with `functions` (NAN-5943)
+export type FlowZeroJson = Omit<NangoYamlParsedIntegration, 'functions'> & { jsonSchema?: JSONSchema7; sdkVersion: string };
 export type FlowsZeroJson = FlowZeroJson[];

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -2,9 +2,21 @@
 
 // Configure Vitest (https://vitest.dev/config/)
 
+import path from 'node:path';
+import { fileURLToPath } from 'node:url';
+
 import { defaultExclude, defineConfig } from 'vitest/config';
 
+const rootDir = path.dirname(fileURLToPath(import.meta.url));
+
 export default defineConfig({
+    resolve: {
+        // Unit tests should exercise workspace source, not potentially stale dist/
+        // artifacts restored by CI incremental build caches.
+        alias: {
+            '@nangohq/nango-yaml': path.resolve(rootDir, 'packages/nango-yaml/lib/index.ts')
+        }
+    },
     test: {
         include: ['**/*.unit.{test,spec}.?(c|m)[jt]s?(x)'],
         // Vitest 4 dropped dist/** from its defaultExclude, so compiled test files


### PR DESCRIPTION
Introduce `functions` — a trigger-agnostic primitive that separates the trigger (what initiates execution) from the handler (what runs). Webhooks are the first trigger type; `createWebhook()` is sugar for a function with a single implicit `http` trigger. Syncs and actions are unchanged.

- runner-sdk: `createFunction()` / `createWebhook()` + trigger/ingress/debounce types and the `FunctionEvent` shape passed to `exec(nango, event)`.
- types: `ParsedNangoFunction` + `ParsedFunctionTrigger`, additive `functions[]` on the parsed integration (kept separate from ScriptTypeLiteral while additive).
- cli: babel plugin recognizes createFunction/createWebhook and injects `type: 'function'` (distinct const identifier since `function` is reserved); zero-yaml definitions parser builds ParsedNangoFunction; `nango create --webhook` scaffold + template.

Backend deploy acceptance of the `function` type is intentionally out of scope for this slice and tracked as follow-up.

<!-- Describe the problem and your solution --> 

<!-- Issue ticket number and link (if applicable) -->

<!-- Testing instructions (skip if just adding/editing providers) -->

