### PR TITLE
Agus/nan 5891/runtime

### DIFF
--- a/packages/cli/lib/index.ts
+++ b/packages/cli/lib/index.ts
@@ -182,10 +182,12 @@ program
     .option('--sync', 'Create a new sync scaffold')
     .option('--action', 'Create a new action scaffold')
     .option('--on-event', 'Create a new on event scaffold')
+    // TODO: add once released (NAN-5943)
+    //.option('--webhook', 'Create a new webhook function scaffold')
     .argument('[integration]', 'Integration name, e.g. "google-calendar"')
     .argument('[name]', 'Name of the sync/action, e.g. "calendar-events"')
     .action(async function (this: Command) {
-        const { debug, sync, action, onEvent, interactive } = this.opts();
+        const { debug, sync, action, onEvent, webhook, interactive } = this.opts();
         let [integration, name] = this.args;
         const absolutePath = process.cwd();
 
@@ -194,7 +196,7 @@ program
 
         try {
             const ensure = new Ensure(interactive);
-            const functionType = await ensure.functionType(sync, action, onEvent);
+            const functionType = await ensure.functionType(sync, action, onEvent, webhook);
 
             let integrations: string[] = [];
 

--- a/packages/cli/lib/services/__snapshots__/config.service.unit.test.ts.snap
+++ b/packages/cli/lib/services/__snapshots__/config.service.unit.test.ts.snap
@@ -21,6 +21,7 @@ exports[`load > should parse a nango.yaml file that is version 1 as expected 1`]
           "version": "",
         },
       ],
+      "functions": [],
       "onEventScripts": {
         "post-connection-creation": [],
         "pre-connection-deletion": [],
@@ -223,6 +224,7 @@ exports[`load > should parse a nango.yaml file that is version 2 as expected 1`]
           "version": "",
         },
       ],
+      "functions": [],
       "onEventScripts": {
         "post-connection-creation": [],
         "pre-connection-deletion": [],

--- a/packages/cli/lib/services/ensure.service.ts
+++ b/packages/cli/lib/services/ensure.service.ts
@@ -38,12 +38,14 @@ export class Ensure {
         }
     }
 
-    public async functionType(sync: boolean, action: boolean, onEvent: boolean): Promise<FunctionType> {
+    public async functionType(sync: boolean, action: boolean, onEvent: boolean, webhook = false): Promise<FunctionType> {
         if (sync) return 'sync';
         if (action) return 'action';
         if (onEvent) return 'on-event';
+        if (webhook) return 'webhook';
 
         if (!this.interactive) {
+            // TODO: add --webhook once released (NAN-5943)
             throw new MissingArgumentError('Must specify --sync, --action, or --on-event');
         }
 

--- a/packages/cli/lib/services/function-create.service.ts
+++ b/packages/cli/lib/services/function-create.service.ts
@@ -20,6 +20,7 @@ export async function create({
 }): Promise<boolean> {
     try {
         if (!functionType) {
+            // TODO: add --webhook once released (NAN-5943)
             console.log(chalk.red('Must specify either --sync, --action, or --on-event'));
             return false;
         }
@@ -39,6 +40,9 @@ export async function create({
                 break;
             case 'on-event':
                 templateFile = path.join(templateFolder, 'on-event.ts');
+                break;
+            case 'webhook':
+                templateFile = path.join(templateFolder, 'webhook.ts');
                 break;
         }
 

--- a/packages/cli/lib/services/pull.service.ts
+++ b/packages/cli/lib/services/pull.service.ts
@@ -10,16 +10,18 @@ import { parseSecretKey, printDebug, resolveHostport } from '../utils.js';
 
 import type { ScriptTypeLiteral } from '@nangohq/types';
 
-const scriptTypeToFolder: Record<ScriptTypeLiteral, 'syncs' | 'actions' | 'on-events'> = {
+const scriptTypeToFolder: Record<ScriptTypeLiteral, 'syncs' | 'actions' | 'on-events' | 'functions'> = {
     sync: 'syncs',
     action: 'actions',
-    'on-event': 'on-events'
+    'on-event': 'on-events',
+    function: 'functions'
 };
 
-const folderToScriptType: Record<'syncs' | 'actions' | 'on-events', ScriptTypeLiteral> = {
+const folderToScriptType: Record<'syncs' | 'actions' | 'on-events' | 'functions', ScriptTypeLiteral> = {
     syncs: 'sync',
     actions: 'action',
-    'on-events': 'on-event'
+    'on-events': 'on-event',
+    functions: 'function'
 };
 
 export function isUnsafeName(segment: string): boolean {
@@ -144,7 +146,9 @@ export async function pullFromCatalog(options: PullCatalogOptions): Promise<bool
     try {
         const contentCache = new Map<string, string>();
 
-        const foldersToProbe: ('syncs' | 'actions' | 'on-events')[] = type ? [scriptTypeToFolder[type]] : ['syncs', 'actions', 'on-events'];
+        const foldersToProbe: ('syncs' | 'actions' | 'on-events' | 'functions')[] = type
+            ? [scriptTypeToFolder[type]]
+            : ['syncs', 'actions', 'on-events', 'functions'];
 
         const probeResults = await Promise.allSettled(
             foldersToProbe.map(async (folder) => {
@@ -154,7 +158,7 @@ export async function pullFromCatalog(options: PullCatalogOptions): Promise<bool
             })
         );
 
-        const matches: { folder: 'syncs' | 'actions' | 'on-events'; candidatePath: string; content: string }[] = [];
+        const matches: { folder: 'syncs' | 'actions' | 'on-events' | 'functions'; candidatePath: string; content: string }[] = [];
         for (const result of probeResults) {
             if (result.status === 'fulfilled') {
                 matches.push(result.value);

--- a/packages/cli/lib/types.ts
+++ b/packages/cli/lib/types.ts
@@ -22,6 +22,6 @@ export interface InternalDeployOptions {
     integration?: string;
 }
 
-export const FUNCTION_TYPES = ['sync', 'action', 'on-event'] as const;
+export const FUNCTION_TYPES = ['sync', 'action', 'on-event', 'webhook'] as const;
 
 export type FunctionType = (typeof FUNCTION_TYPES)[number];

--- a/packages/cli/lib/zeroYaml/compile.ts
+++ b/packages/cli/lib/zeroYaml/compile.ts
@@ -459,7 +459,20 @@ function nangoPlugin({ entryPoint }: { entryPoint: string }) {
     // Get actual path even if entryPoint is a symlink
     const realEntryPoint = fs.realpathSync(normalizedEntryPoint.replace('.js', '.ts')).replace('.ts', '.js');
 
-    const allowedExports = ['createAction', 'createSync', 'createOnEvent'];
+    const allowedExports = {
+        createAction: { type: 'action', varName: 'action' },
+        createSync: { type: 'sync', varName: 'sync' },
+        createOnEvent: { type: 'onEvent', varName: 'onEvent' },
+        createFunction: { type: 'function', varName: 'fn' },
+        createWebhook: { type: 'function', varName: 'webhook' }
+    } as const satisfies Record<string, { type: string; varName: string }>;
+
+    type AllowedExportName = keyof typeof allowedExports;
+
+    function isAllowedExport(name: string): name is AllowedExportName {
+        return name in allowedExports;
+    }
+
     const needsAwait = [
         'batchDelete',
         'batchSave',
@@ -642,7 +655,7 @@ function nangoPlugin({ entryPoint }: { entryPoint: string }) {
                             throw new CompileError(
                                 'nango_named_export_not_allowed',
                                 lineNumber,
-                                `Named export '${exportedName}' is not allowed. Only export default and ${allowedExports.join(', ')} are permitted.`
+                                `Named export '${exportedName}' is not allowed. Only export default and ${Object.keys(allowedExports).join(', ')} are permitted.`
                             );
                         };
 
@@ -651,7 +664,7 @@ function nangoPlugin({ entryPoint }: { entryPoint: string }) {
                             for (const specifier of node.specifiers) {
                                 if (t.isExportSpecifier(specifier) && t.isIdentifier(specifier.exported)) {
                                     const exportedName = specifier.exported.name;
-                                    if (!allowedExports.includes(exportedName)) {
+                                    if (!isAllowedExport(exportedName)) {
                                         namedExportError(exportedName);
                                     }
                                 }
@@ -673,7 +686,7 @@ function nangoPlugin({ entryPoint }: { entryPoint: string }) {
                             }
 
                             for (const exportedName of exportedNames) {
-                                if (!allowedExports.includes(exportedName)) {
+                                if (!isAllowedExport(exportedName)) {
                                     namedExportError(exportedName);
                                 }
                             }
@@ -696,24 +709,22 @@ function nangoPlugin({ entryPoint }: { entryPoint: string }) {
 
                         const lineNumber = astPath.node.loc?.start.line || 0;
                         const decl = astPath.node.declaration;
-                        let calleeName = null;
                         let arg = null;
 
                         // Case 1: export default createAction({...})
-                        if (t.isCallExpression(decl) && t.isIdentifier(decl.callee) && allowedExports.includes(decl.callee.name)) {
-                            let varName = '';
-                            calleeName = decl.callee.name;
+                        if (t.isCallExpression(decl) && t.isIdentifier(decl.callee) && isAllowedExport(decl.callee.name)) {
+                            const calleeName = decl.callee.name;
                             arg = decl.arguments[0];
                             if (!t.isObjectExpression(arg)) {
                                 throw new CompileError('nango_invalid_function_param', lineNumber, 'Invalid function parameter, should be an object');
                             }
 
-                            if (calleeName === 'createAction') varName = 'action';
-                            if (calleeName === 'createSync') varName = 'sync';
-                            if (calleeName === 'createOnEvent') varName = 'onEvent';
+                            const mapping = allowedExports[calleeName];
+                            const typeName = mapping.type;
+                            const varName = mapping.varName;
 
                             // Inject type property
-                            arg.properties = [t.objectProperty(t.identifier('type'), t.stringLiteral(varName)), ...arg.properties];
+                            arg.properties = [t.objectProperty(t.identifier('type'), t.stringLiteral(typeName)), ...arg.properties];
                             const newValue = arg;
                             // Insert: export const <varName> = <newValue>;
                             const exportConst = t.exportNamedDeclaration(
@@ -734,22 +745,19 @@ function nangoPlugin({ entryPoint }: { entryPoint: string }) {
                             }
 
                             const init = binding.path.node.init;
-                            if (!t.isCallExpression(init) || !t.isIdentifier(init.callee) || !allowedExports.includes(init.callee.name)) {
+                            if (!t.isCallExpression(init) || !t.isIdentifier(init.callee) || !isAllowedExport(init.callee.name)) {
                                 throw new CompileError('nango_invalid_default_export', lineNumber, badExportCompilerError);
                             }
 
-                            let varName = '';
-                            calleeName = init.callee.name;
+                            const calleeName = init.callee.name;
                             arg = init.arguments[0];
                             if (!t.isObjectExpression(arg)) {
                                 throw new CompileError('nango_invalid_function_param', lineNumber, 'Invalid function parameter, should be an object');
                             }
 
-                            if (calleeName === 'createAction') varName = 'action';
-                            if (calleeName === 'createSync') varName = 'sync';
-                            if (calleeName === 'createOnEvent') varName = 'onEvent';
+                            const typeName = allowedExports[calleeName].type;
                             // Inject type property (mutate the object literal)
-                            arg.properties = [t.objectProperty(t.identifier('type'), t.stringLiteral(varName)), ...arg.properties];
+                            arg.properties = [t.objectProperty(t.identifier('type'), t.stringLiteral(typeName)), ...arg.properties];
                             // Replace the variable's initializer with the object literal
                             binding.path.get('init').replaceWith(arg);
                             return;

--- a/packages/cli/lib/zeroYaml/definitions.ts
+++ b/packages/cli/lib/zeroYaml/definitions.ts
@@ -16,12 +16,20 @@ import {
 import { Err, Ok } from '../utils/result.js';
 import { printDebug } from '../utils.js';
 
-import type { CreateActionResponse, CreateOnEventResponse, CreateSyncResponse } from '@nangohq/runner-sdk';
+import type { CreateActionResponse, CreateFunctionResponse, CreateOnEventResponse, CreateSyncResponse, FunctionTrigger } from '@nangohq/runner-sdk';
 import type { ZodCheckpoint, ZodMetadata, ZodModel } from '@nangohq/runner-sdk/lib/types.js';
-import type { NangoYamlParsed, NangoYamlParsedIntegration, ParsedNangoAction, ParsedNangoSync, Result } from '@nangohq/types';
+import type {
+    NangoYamlParsed,
+    NangoYamlParsedIntegration,
+    ParsedFunctionTrigger,
+    ParsedNangoAction,
+    ParsedNangoFunction,
+    ParsedNangoSync,
+    Result
+} from '@nangohq/types';
 import type * as z from 'zod';
 
-const allowed = ['action', 'sync', 'onEvent'];
+const allowed = ['action', 'sync', 'onEvent', 'function'];
 
 export async function parseIntegrationDefinitions({ fullPath, debug }: { fullPath: string; debug: boolean }): Promise<Result<NangoYamlParsed>> {
     const parsed: NangoYamlParsed = { yamlVersion: 'v2', integrations: [], models: new Map() };
@@ -45,7 +53,12 @@ export async function parseIntegrationDefinitions({ fullPath, debug }: { fullPat
             return Err(new Error(`Script should have a default export ${modulePath}`));
         }
         if (!moduleContent.default.default.type || !allowed.includes(moduleContent.default.default.type)) {
-            return Err(new Error(`Script should be declared using utility function (createSync, createAction, createOnEvent) ${modulePath}`));
+            return Err(
+                new Error(
+                    // TODO: add createFunction, createWebhook once released (NAN-5943)
+                    `Script should be declared using utility function (createSync, createAction, createOnEvent) ${modulePath}`
+                )
+            );
         }
 
         printDebug(`Parsing ${filePath}`, debug);
@@ -53,7 +66,8 @@ export async function parseIntegrationDefinitions({ fullPath, debug }: { fullPat
         const script = moduleContent.default.default as
             | CreateSyncResponse<Record<string, ZodModel>, ZodMetadata, ZodCheckpoint>
             | CreateActionResponse<z.ZodTypeAny, z.ZodTypeAny, ZodMetadata, ZodCheckpoint>
-            | CreateOnEventResponse;
+            | CreateOnEventResponse
+            | CreateFunctionResponse<Record<string, ZodModel>, z.ZodTypeAny, z.ZodTypeAny, ZodMetadata, ZodCheckpoint>;
 
         const basename = path.basename(filePath, '.js');
         const realPath = filePath.replace('.js', '.ts');
@@ -68,6 +82,7 @@ export async function parseIntegrationDefinitions({ fullPath, debug }: { fullPat
                 providerConfigKey: integrationId,
                 actions: [],
                 syncs: [],
+                functions: [],
                 onEventScripts: { 'post-connection-creation': [], 'pre-connection-deletion': [], 'validate-connection': [] }
             };
             parsed.integrations.push(integration);
@@ -94,6 +109,14 @@ export async function parseIntegrationDefinitions({ fullPath, debug }: { fullPat
                 } else if (script.event === 'validate-connection') {
                     integration.onEventScripts['validate-connection'].push(basename);
                 }
+                break;
+            }
+            case 'function': {
+                const parsedFunctionRes = parseFunction({ filePath: realPath, params: script, integrationIdClean, basename, basenameClean });
+                if (parsedFunctionRes.isErr()) {
+                    return Err(parsedFunctionRes.error);
+                }
+                integration.functions.push(parsedFunctionRes.value);
                 break;
             }
         }
@@ -229,6 +252,94 @@ export function parseAction({
         json_schema: jsonSchema,
         features: features.isOk() ? features.value : [] // silently ignore features detection error as it is only used internally and we don't want it to block the parsing
     };
+}
+
+export function parseFunction({
+    filePath,
+    params,
+    integrationIdClean,
+    basename,
+    basenameClean
+}: {
+    filePath: string;
+    params: CreateFunctionResponse<Record<string, ZodModel>, z.ZodTypeAny, z.ZodTypeAny, ZodMetadata, ZodCheckpoint>;
+    integrationIdClean: string;
+    basename: string;
+    basenameClean: string;
+}): Result<ParsedNangoFunction> {
+    if (!Array.isArray(params.triggers) || params.triggers.length === 0) {
+        return Err(new Error(`Function "${basename}" must declare at least one trigger (${filePath})`));
+    }
+
+    // Validate cron/scheduled trigger intervals
+    for (const trigger of params.triggers) {
+        if (trigger.type === 'cron' || trigger.type === 'scheduled') {
+            const interval = getInterval(trigger.schedule, new Date());
+            if (interval instanceof Error) {
+                return Err(new InvalidIntervalDefinitionError(filePath, ['createFunction', 'triggers', 'schedule']));
+            }
+        }
+    }
+
+    const allZodModels: Record<string, z.ZodType> = { ...(params.models ?? {}) };
+
+    const inputName = params.input ? `FunctionInput_${integrationIdClean}_${basenameClean}` : null;
+    if (params.input && inputName) {
+        allZodModels[inputName] = params.input;
+    }
+
+    const metadataModelName = params.metadata ? `FunctionMetadata_${integrationIdClean}_${basenameClean}` : null;
+    if (params.metadata && metadataModelName) {
+        allZodModels[metadataModelName] = params.metadata;
+    }
+
+    for (const modelName of Object.keys(params.models ?? {})) {
+        if (!regexModelName.test(modelName)) {
+            return Err(new InvalidModelDefinitionError(modelName, filePath, ['createFunction', 'models']));
+        }
+    }
+
+    const outputNames = Object.keys(params.models ?? {});
+    const jsonSchema = buildJsonSchemaDefinitionsFromZodModels(allZodModels);
+    const features = detectFeatures({ entryPoint: filePath });
+
+    const fn: ParsedNangoFunction = {
+        type: 'function',
+        name: params.name || basename,
+        description: params.description || '',
+        triggers: params.triggers.map(toParsedTrigger),
+        input: inputName,
+        output: outputNames.length > 0 ? outputNames : null,
+        scopes: params.scopes || [],
+        usedModels: Object.keys(allZodModels),
+        version: params.version || '',
+        json_schema: jsonSchema,
+        features: features.isOk() ? features.value : []
+    };
+
+    return Ok(fn);
+}
+
+function toParsedTrigger(trigger: FunctionTrigger): ParsedFunctionTrigger {
+    const parsed: ParsedFunctionTrigger = { type: trigger.type };
+    if (trigger.type === 'http' || trigger.type === 'webhook') {
+        if (trigger.name !== undefined) {
+            parsed.name = trigger.name;
+        }
+        if (trigger.scope !== undefined) {
+            parsed.scope = trigger.scope;
+        }
+        if (trigger.debounce !== undefined) {
+            parsed.debounce = trigger.debounce;
+        }
+        parsed.hasIngressChallenge = typeof trigger.ingressChallenge === 'function';
+        parsed.hasIngressValidation = typeof trigger.ingressValidation === 'function';
+    } else if (trigger.type === 'cron' || trigger.type === 'scheduled') {
+        parsed.schedule = trigger.schedule;
+    } else if (trigger.type === 'event') {
+        parsed.event = trigger.event;
+    }
+    return parsed;
 }
 
 function postValidation(parsed: NangoYamlParsed): Result<void> {

--- a/packages/cli/lib/zeroYaml/deploy.ts
+++ b/packages/cli/lib/zeroYaml/deploy.ts
@@ -270,6 +270,48 @@ async function createDeployConfirmationPackage({
                 postData.push(body);
             }
         }
+
+        if (!optionalSyncName && !optionalActionName) {
+            for (const fn of integration.functions ?? []) {
+                const metadata = {} as NangoConfigMetadata;
+                if (fn.description) {
+                    metadata['description'] = fn.description;
+                }
+                if (fn.scopes && fn.scopes.length > 0) {
+                    metadata['scopes'] = fn.scopes;
+                }
+
+                // A function lives in either webhooks/ (createWebhook) or functions/ (createFunction);
+                // the bundled artifact preserves that folder, so probe it to pick the right ScriptFileType.
+                const scriptFileType: ScriptFileType = fs.existsSync(path.join(fullPath, 'build', `${providerConfigKey}_webhooks_${fn.name}.cjs`))
+                    ? 'webhooks'
+                    : 'functions';
+
+                const files = await loadScriptFiles({ scriptName: fn.name, providerConfigKey, fullPath, type: scriptFileType });
+                if (!files) {
+                    return Err(new Error(`No script files found for "${fn.name}"`));
+                }
+
+                const body: CLIDeployFlowConfig = {
+                    syncName: fn.name,
+                    providerConfigKey,
+                    models: fn.output || [],
+                    version: version || fn.version,
+                    runs: null,
+                    metadata,
+                    input: fn.input || undefined,
+                    type: fn.type,
+                    function_config: { name: fn.name, triggers: fn.triggers },
+                    fileBody: files,
+                    endpoints: [],
+                    track_deletes: false,
+                    models_json_schema: fn.json_schema,
+                    features: fn.features
+                };
+
+                postData.push(body);
+            }
+        }
     }
 
     if (postData.length <= 0) {

--- a/packages/cli/templates/webhook.ts
+++ b/packages/cli/templates/webhook.ts
@@ -1,0 +1,15 @@
+import { createWebhook } from 'nango';
+
+export default createWebhook({
+    description: '',
+    // Runs synchronously at ingress to verify the request is authentic. No SDK, no I/O.
+    // ingressValidation: async (event) => {
+    //     return true;
+    // },
+    // Coalesce bursts of events into a single run.
+    // debounce: { key: { body: '$.id' }, windowMs: 5000 },
+    exec: async (nango, event) => {
+        // Routing lives here, on your runner. Find the matching connection(s) and trigger work.
+        await nango.log('Received webhook', event.payload);
+    }
+});

--- a/packages/database/lib/migrations/20260606160000_sync_config_function_config.cjs
+++ b/packages/database/lib/migrations/20260606160000_sync_config_function_config.cjs
@@ -1,0 +1,19 @@
+exports.config = { transaction: false };
+
+/**
+ * Functions (createFunction/createWebhook) deploy as _nango_sync_configs rows with type 'function'.
+ * Unlike syncs/actions they carry triggers (with ingress/debounce config) rather than a single `runs`
+ * schedule, so we persist that function-specific shape in a dedicated jsonb column. Null for sync/action/on-event.
+ *
+ * @param {import('knex').Knex} knex
+ */
+exports.up = async function (knex) {
+    await knex.raw(`ALTER TABLE _nango_sync_configs ADD COLUMN IF NOT EXISTS function_config JSONB`);
+};
+
+/**
+ * @param {import('knex').Knex} knex
+ */
+exports.down = async function (knex) {
+    await knex.raw(`ALTER TABLE _nango_sync_configs DROP COLUMN IF EXISTS function_config`);
+};

--- a/packages/jobs/lib/execution/function.ts
+++ b/packages/jobs/lib/execution/function.ts
@@ -34,11 +34,9 @@ import type { Result } from '@nangohq/utils';
 import type { JsonValue } from 'type-fest';
 
 /**
- * Execute a function run.
- *
- * v1 supports connection-bound runs (connection-level webhook URLs, triggerFunction({ connectionId }),
- * CLI --connection). Connection-less routing runs (no bound connection) need environment context
- * independent of a connection and are a follow-up.
+ * Execute a function run — connection-bound (connection-level webhook URL, triggerFunction({ connectionId }),
+ * CLI --connection) or connection-less (integration-level webhook routing). Connection-less runs take
+ * their environment context from the task itself and run with no bound connection (getConnection() throws).
  */
 export async function startFunction(task: TaskFunction): Promise<Result<void>> {
     let team: DBTeam | undefined;

--- a/packages/jobs/lib/execution/function.ts
+++ b/packages/jobs/lib/execution/function.ts
@@ -48,12 +48,12 @@ export async function startFunction(task: TaskFunction): Promise<Result<void>> {
     let endUser: NangoProps['endUser'] | null = null;
 
     try {
-        if (!task.connection) {
-            throw new Error(`Connection-less function runs are not supported yet: ${task.functionName} (${task.id})`);
-        }
+        // Connection-bound runs derive the environment from the connection; connection-less routing
+        // runs carry the environment on the task itself.
         const connection = task.connection;
+        const environmentId = connection?.environment_id ?? task.environmentId;
 
-        const accountContext = await accountService.getAccountContext({ environmentId: connection.environment_id });
+        const accountContext = await accountService.getAccountContext({ environmentId });
         if (!accountContext) {
             throw new Error(`Account and environment not found`);
         }
@@ -62,7 +62,7 @@ export async function startFunction(task: TaskFunction): Promise<Result<void>> {
         const plan = accountContext.plan;
         tagTraceUser({ ...accountContext });
 
-        providerConfig = await configService.getProviderConfig(task.providerConfigKey, connection.environment_id);
+        providerConfig = await configService.getProviderConfig(task.providerConfigKey, environmentId);
         if (providerConfig === null) {
             throw new Error(`Provider config not found for function: ${task.functionName}`);
         }
@@ -75,17 +75,19 @@ export async function startFunction(task: TaskFunction): Promise<Result<void>> {
             throw new Error(`Function is disabled: ${task.functionName} (${task.id})`);
         }
 
-        const getEndUser = await getEndUserByConnectionId(db.knex, { connectionId: connection.id });
-        if (getEndUser.isOk()) {
-            endUser = { id: getEndUser.value.id, endUserId: getEndUser.value.endUserId, orgId: getEndUser.value.organization?.organizationId || null };
+        if (connection) {
+            const getEndUser = await getEndUserByConnectionId(db.knex, { connectionId: connection.id });
+            if (getEndUser.isOk()) {
+                endUser = { id: getEndUser.value.id, endUserId: getEndUser.value.endUserId, orgId: getEndUser.value.organization?.organizationId || null };
+            }
         }
 
         const logCtx = logContextGetter.get({ id: String(task.activityLogId), accountId: team.id });
         void logCtx.info(`Starting function '${task.functionName}' (trigger: ${task.trigger.type})`, {
             function: task.functionName,
             trigger: task.trigger.type,
-            connection: connection.connection_id,
-            integration: connection.provider_config_key
+            connection: connection?.connection_id ?? '(connection-less)',
+            integration: task.providerConfigKey
         });
 
         const cappingStatus = await capping.getStatus(plan, 'function_executions', 'function_compute_gbms');
@@ -111,14 +113,15 @@ export async function startFunction(task: TaskFunction): Promise<Result<void>> {
             scriptType: 'function',
             host: getApiUrl(),
             team: { id: team.id, name: team.name },
-            connectionId: connection.connection_id,
-            environmentId: connection.environment_id,
+            connectionId: connection?.connection_id ?? '',
+            environmentId,
             environmentName: environment.name,
-            providerConfigKey: connection.provider_config_key,
+            providerConfigKey: task.providerConfigKey,
             provider: providerConfig.provider,
             activityLogId: logCtx.id,
             secretKey: defaultSecret.value.secret,
-            nangoConnectionId: connection.id,
+            // 0 is an unused sentinel for connection-less runs (no connection to key against).
+            nangoConnectionId: connection?.id ?? 0,
             attributes: syncConfig.attributes,
             syncConfig,
             debug: false,
@@ -128,7 +131,7 @@ export async function startFunction(task: TaskFunction): Promise<Result<void>> {
             startedAt: new Date(),
             heartbeatTimeoutSecs: task.heartbeatTimeoutSecs,
             functionEvent: { trigger: task.trigger, payload: task.input },
-            connectionBound: true
+            connectionBound: Boolean(connection)
         };
 
         const routingContext: RoutingContext = { plan, features: syncConfig.features };

--- a/packages/jobs/lib/execution/function.ts
+++ b/packages/jobs/lib/execution/function.ts
@@ -1,0 +1,193 @@
+import db from '@nangohq/database';
+import { logContextGetter } from '@nangohq/logs';
+import {
+    NangoError,
+    accountService,
+    configService,
+    environmentService,
+    getApiUrl,
+    getEndUserByConnectionId,
+    getFunctionConfigRaw,
+    secretService
+} from '@nangohq/shared';
+import { Err, Ok, tagTraceUser } from '@nangohq/utils';
+
+import { startScript } from './operations/start.js';
+import { capping } from '../utils/capping.js';
+import { getRunnerFlags } from '../utils/flags.js';
+import { setTaskFailed, setTaskSuccess } from './operations/state.js';
+
+import type { TaskFunction } from '@nangohq/nango-orchestrator';
+import type { Config } from '@nangohq/shared';
+import type {
+    CheckpointRange,
+    DBEnvironment,
+    DBSyncConfig,
+    DBTeam,
+    FunctionRuntime,
+    NangoProps,
+    RoutingContext,
+    SdkLogger,
+    TelemetryBag
+} from '@nangohq/types';
+import type { Result } from '@nangohq/utils';
+import type { JsonValue } from 'type-fest';
+
+/**
+ * Execute a function run.
+ *
+ * v1 supports connection-bound runs (connection-level webhook URLs, triggerFunction({ connectionId }),
+ * CLI --connection). Connection-less routing runs (no bound connection) need environment context
+ * independent of a connection and are a follow-up.
+ */
+export async function startFunction(task: TaskFunction): Promise<Result<void>> {
+    let team: DBTeam | undefined;
+    let environment: DBEnvironment | undefined;
+    let providerConfig: Config | null = null;
+    let syncConfig: DBSyncConfig | null = null;
+    let endUser: NangoProps['endUser'] | null = null;
+
+    try {
+        if (!task.connection) {
+            throw new Error(`Connection-less function runs are not supported yet: ${task.functionName} (${task.id})`);
+        }
+        const connection = task.connection;
+
+        const accountContext = await accountService.getAccountContext({ environmentId: connection.environment_id });
+        if (!accountContext) {
+            throw new Error(`Account and environment not found`);
+        }
+        team = accountContext.account;
+        environment = accountContext.environment;
+        const plan = accountContext.plan;
+        tagTraceUser({ ...accountContext });
+
+        providerConfig = await configService.getProviderConfig(task.providerConfigKey, connection.environment_id);
+        if (providerConfig === null) {
+            throw new Error(`Provider config not found for function: ${task.functionName}`);
+        }
+
+        syncConfig = await getFunctionConfigRaw({ environmentId: providerConfig.environment_id, config_id: providerConfig.id!, name: task.functionName });
+        if (!syncConfig) {
+            throw new Error(`Function not found: ${task.functionName} (${task.id})`);
+        }
+        if (!syncConfig.enabled) {
+            throw new Error(`Function is disabled: ${task.functionName} (${task.id})`);
+        }
+
+        const getEndUser = await getEndUserByConnectionId(db.knex, { connectionId: connection.id });
+        if (getEndUser.isOk()) {
+            endUser = { id: getEndUser.value.id, endUserId: getEndUser.value.endUserId, orgId: getEndUser.value.organization?.organizationId || null };
+        }
+
+        const logCtx = logContextGetter.get({ id: String(task.activityLogId), accountId: team.id });
+        void logCtx.info(`Starting function '${task.functionName}' (trigger: ${task.trigger.type})`, {
+            function: task.functionName,
+            trigger: task.trigger.type,
+            connection: connection.connection_id,
+            integration: connection.provider_config_key
+        });
+
+        const cappingStatus = await capping.getStatus(plan, 'function_executions', 'function_compute_gbms');
+        if (cappingStatus.isCapped) {
+            const message = cappingStatus.message || 'Your plan limits have been reached. Please upgrade your plan.';
+            void logCtx.error(message, { cappingStatus });
+            throw new Error(message);
+        }
+        const cappingFunctionLogsStatus = await capping.getStatus(plan, 'function_logs');
+        let sdkLogger: SdkLogger;
+        if (cappingFunctionLogsStatus.isCapped) {
+            sdkLogger = { level: 'off' };
+        } else {
+            sdkLogger = await environmentService.getSdkLogger(environment.id);
+        }
+
+        const defaultSecret = await secretService.getDefaultSecretForEnv(db.readOnly, environment);
+        if (defaultSecret.isErr()) {
+            return Err(defaultSecret.error);
+        }
+
+        const nangoProps: NangoProps = {
+            scriptType: 'function',
+            host: getApiUrl(),
+            team: { id: team.id, name: team.name },
+            connectionId: connection.connection_id,
+            environmentId: connection.environment_id,
+            environmentName: environment.name,
+            providerConfigKey: connection.provider_config_key,
+            provider: providerConfig.provider,
+            activityLogId: logCtx.id,
+            secretKey: defaultSecret.value.secret,
+            nangoConnectionId: connection.id,
+            attributes: syncConfig.attributes,
+            syncConfig,
+            debug: false,
+            logger: sdkLogger,
+            runnerFlags: await getRunnerFlags(plan),
+            endUser,
+            startedAt: new Date(),
+            heartbeatTimeoutSecs: task.heartbeatTimeoutSecs,
+            functionEvent: { trigger: task.trigger, payload: task.input },
+            connectionBound: true
+        };
+
+        const routingContext: RoutingContext = { plan, features: syncConfig.features };
+
+        const res = await startScript({ taskId: task.id, nangoProps, routingContext, logCtx, input: task.input });
+        if (res.isErr()) {
+            throw res.error;
+        }
+
+        return Ok(undefined);
+    } catch (err) {
+        const error = new NangoError('function_script_failure', { error: err instanceof Error ? err.message : err });
+        await setTaskFailed({ taskId: task.id, error });
+        return Err(error);
+    }
+}
+
+export async function handleFunctionSuccess({
+    taskId,
+    nangoProps,
+    output
+}: {
+    taskId: string;
+    nangoProps: NangoProps;
+    output: JsonValue;
+    telemetryBag: TelemetryBag;
+    functionRuntime: FunctionRuntime;
+    checkpoints: CheckpointRange;
+}): Promise<void> {
+    const logCtx = logContextGetter.get({ id: String(nangoProps.activityLogId), accountId: nangoProps.team.id });
+    const task = await setTaskSuccess({ taskId, output });
+    if (task.isErr()) {
+        void logCtx.error(`Failed to mark function as succeeded`, { error: task.error });
+        return;
+    }
+    void logCtx.info(`The function '${nangoProps.syncConfig.sync_name}' was successfully run`);
+    void logCtx.success();
+}
+
+export async function handleFunctionError({
+    taskId,
+    nangoProps,
+    error
+}: {
+    taskId: string;
+    nangoProps: NangoProps;
+    error: NangoError;
+    telemetryBag: TelemetryBag;
+    functionRuntime: FunctionRuntime;
+    checkpoints: CheckpointRange;
+}): Promise<void> {
+    const logCtx = logContextGetter.get({ id: String(nangoProps.activityLogId), accountId: nangoProps.team.id });
+    const task = await setTaskFailed({ taskId, error });
+    if (task.isErr()) {
+        void logCtx.error(`Failed to mark function as failed`, { error: task.error });
+        return;
+    }
+    void logCtx.error(`Function '${nangoProps.syncConfig.sync_name}' failed`, { error });
+    if (task.value.attempt === task.value.attemptMax) {
+        void logCtx.failed();
+    }
+}

--- a/packages/jobs/lib/execution/operations/handler.ts
+++ b/packages/jobs/lib/execution/operations/handler.ts
@@ -1,5 +1,6 @@
 import { logger } from '../../logger.js';
 import { handleActionError, handleActionSuccess } from '../action.js';
+import { handleFunctionError, handleFunctionSuccess } from '../function.js';
 import { handleOnEventError, handleOnEventSuccess } from '../onEvent.js';
 import { handleSyncError, handleSyncSuccess } from '../sync.js';
 import { handleWebhookError, handleWebhookSuccess } from '../webhook.js';
@@ -39,6 +40,9 @@ async function handleSuccess({ taskId, nangoProps, output, telemetryBag, functio
             break;
         case 'on-event':
             await handleOnEventSuccess({ taskId, nangoProps, telemetryBag, functionRuntime });
+            break;
+        case 'function':
+            await handleFunctionSuccess({ taskId, nangoProps, output, telemetryBag, functionRuntime, checkpoints });
             break;
     }
 }
@@ -80,6 +84,9 @@ async function handleError({ taskId, nangoProps, error, telemetryBag, functionRu
             break;
         case 'on-event':
             await handleOnEventError({ taskId, nangoProps, error: formattedError, telemetryBag, functionRuntime });
+            break;
+        case 'function':
+            await handleFunctionError({ taskId, nangoProps, error: formattedError, telemetryBag, functionRuntime, checkpoints });
             break;
     }
 }

--- a/packages/jobs/lib/execution/sync.integration.test.ts
+++ b/packages/jobs/lib/execution/sync.integration.test.ts
@@ -9,7 +9,7 @@ import { Ok, stringifyError } from '@nangohq/utils';
 import { handleSyncSuccess, startSync } from './sync.js';
 import { envs } from '../env.js';
 
-import type { TaskAbort, TaskAction, TaskOnEvent, TaskSync, TaskSyncAbort, TaskWebhook } from '@nangohq/nango-orchestrator';
+import type { TaskAbort, TaskAction, TaskFunction, TaskOnEvent, TaskSync, TaskSyncAbort, TaskWebhook } from '@nangohq/nango-orchestrator';
 import type { ReturnedRecord, UnencryptedRecordData } from '@nangohq/records';
 import type { Job as SyncJob, Sync } from '@nangohq/shared';
 import type { ConnectionJobs, DBSyncConfig, SyncResult } from '@nangohq/types';
@@ -207,6 +207,7 @@ const runJob = async (
         isWebhook: (): this is TaskWebhook => false,
         isAction: (): this is TaskAction => false,
         isOnEvent: (): this is TaskOnEvent => false,
+        isFunction: (): this is TaskFunction => false,
         isSyncAbort: (): this is TaskSyncAbort => false,
         isAbort: (): this is TaskAbort => false
     };

--- a/packages/jobs/lib/processor/handler.ts
+++ b/packages/jobs/lib/processor/handler.ts
@@ -3,6 +3,7 @@ import tracer from 'dd-trace';
 import { Err, Ok } from '@nangohq/utils';
 
 import { startAction } from '../execution/action.js';
+import { startFunction } from '../execution/function.js';
 import { startOnEvent } from '../execution/onEvent.js';
 import { abortTask } from '../execution/operations/abort.js';
 import { abortSync, startSync } from '../execution/sync.js';
@@ -48,6 +49,14 @@ export async function handler(task: OrchestratorTask): Promise<Result<void>> {
         const span = tracer.startSpan('jobs.handler.onEvent');
         return await tracer.scope().activate(span, async () => {
             const res = startOnEvent(task);
+            span.finish();
+            return res;
+        });
+    }
+    if (task.isFunction()) {
+        const span = tracer.startSpan('jobs.handler.function');
+        return await tracer.scope().activate(span, async () => {
+            const res = await startFunction(task);
             span.finish();
             return res;
         });

--- a/packages/jobs/lib/runtime/runtimes.rules.ts
+++ b/packages/jobs/lib/runtime/runtimes.rules.ts
@@ -4,11 +4,13 @@ import { envs } from '../env.js';
 
 import type { DBPlan, NangoProps, Result, RoutingContext } from '@nangohq/types';
 
-const runtimeSelectors = {
+const runtimeSelectors: Record<NangoProps['scriptType'], (plan: DBPlan) => 'runner' | 'lambda'> = {
     sync: (plan: DBPlan) => plan.sync_function_runtime,
     action: (plan: DBPlan) => plan.action_function_runtime,
     webhook: (plan: DBPlan) => plan.webhook_function_runtime,
-    'on-event': (plan: DBPlan) => plan.on_event_function_runtime
+    'on-event': (plan: DBPlan) => plan.on_event_function_runtime,
+    // Functions always run on the runner fleet for now (no lambda routing yet).
+    function: () => 'runner'
 };
 
 export async function getFleetId({

--- a/packages/jobs/lib/schemas/nango-props.ts
+++ b/packages/jobs/lib/schemas/nango-props.ts
@@ -5,7 +5,17 @@ import { operationIdRegex } from '@nangohq/logs';
 import type { Feature } from '@nangohq/types';
 
 export const nangoPropsSchema = z.looseObject({
-    scriptType: z.enum(['action', 'webhook', 'sync', 'on-event']),
+    scriptType: z.enum(['action', 'webhook', 'sync', 'on-event', 'function']),
+    functionEvent: z
+        .looseObject({
+            trigger: z.object({ type: z.enum(['http', 'webhook', 'cron', 'scheduled', 'event', 'manual']), name: z.string().optional() }),
+            payload: z.any().optional(),
+            headers: z.record(z.string(), z.string()).optional(),
+            rawBody: z.string().optional(),
+            coalesced: z.object({ count: z.number(), firstSeenAt: z.string(), lastSeenAt: z.string(), overflowed: z.boolean() }).optional()
+        })
+        .optional(),
+    connectionBound: z.boolean().optional(),
     connectionId: z.string().min(1),
     nangoConnectionId: z.number(),
     environmentId: z.number(),
@@ -20,7 +30,7 @@ export const nangoPropsSchema = z.looseObject({
     syncConfig: z.looseObject({
         id: z.number(),
         sync_name: z.string().min(1),
-        type: z.enum(['sync', 'action', 'on-event']),
+        type: z.enum(['sync', 'action', 'on-event', 'function']),
         environment_id: z.number(),
         models: z.array(z.string()),
         file_location: z.string(),

--- a/packages/nango-yaml/lib/parser.v1.ts
+++ b/packages/nango-yaml/lib/parser.v1.ts
@@ -83,6 +83,7 @@ export class NangoYamlParserV1 extends NangoYamlParser {
                 providerConfigKey: integrationName,
                 syncs,
                 actions,
+                functions: [],
                 onEventScripts: { 'post-connection-creation': [], 'pre-connection-deletion': [], 'validate-connection': [] }
             };
 

--- a/packages/nango-yaml/lib/parser.v1.unit.test.ts
+++ b/packages/nango-yaml/lib/parser.v1.unit.test.ts
@@ -54,7 +54,8 @@ describe('parse', () => {
                             usedModels: ['GithubIssue'],
                             version: ''
                         }
-                    ]
+                    ],
+                    functions: []
                 }
             ],
             models: new Map([['GithubIssue', { name: 'GithubIssue', fields: [{ name: 'id', value: 'string', tsType: true, array: false, optional: false }] }]]),
@@ -96,7 +97,8 @@ describe('parse', () => {
                         }
                     ],
                     onEventScripts: { 'post-connection-creation': [], 'pre-connection-deletion': [], 'validate-connection': [] },
-                    actions: []
+                    actions: [],
+                    functions: []
                 }
             ],
             models: new Map([

--- a/packages/nango-yaml/lib/parser.v2.ts
+++ b/packages/nango-yaml/lib/parser.v2.ts
@@ -57,6 +57,7 @@ export class NangoYamlParserV2 extends NangoYamlParser {
                 syncs: parsedSyncs,
                 actions: parseActions,
                 onEventScripts: parsedOnEventScripts,
+                functions: [],
                 ...(postConnectionScripts.length > 0 ? { postConnectionScripts } : {})
             };
 

--- a/packages/nango-yaml/lib/parser.v2.unit.test.ts
+++ b/packages/nango-yaml/lib/parser.v2.unit.test.ts
@@ -62,7 +62,8 @@ describe('parse', () => {
                             version: '',
                             features: []
                         }
-                    ]
+                    ],
+                    functions: []
                 }
             ],
             models: new Map([
@@ -111,7 +112,8 @@ describe('parse', () => {
                             version: '',
                             features: []
                         }
-                    ]
+                    ],
+                    functions: []
                 }
             ],
             models: new Map([
@@ -158,7 +160,8 @@ describe('parse', () => {
                         }
                     ],
                     onEventScripts: { 'post-connection-creation': [], 'pre-connection-deletion': [], 'validate-connection': [] },
-                    actions: []
+                    actions: [],
+                    functions: []
                 }
             ],
             models: new Map([

--- a/packages/node-client/lib/index.ts
+++ b/packages/node-client/lib/index.ts
@@ -1041,6 +1041,29 @@ export class Nango {
     }
 
     /**
+     * Schedule a function run. Optionally bind a connection (connection-bound run); omit it for a
+     * connection-less run that resolves its own targets.
+     * @param providerConfigKey - The integration the function belongs to
+     * @param functionName - The function to run
+     * @param options.connectionId - Optional connection to bind to the run
+     * @param options.payload - Arbitrary data passed to the function as event.payload
+     */
+    public async triggerFunction<In = unknown>(
+        providerConfigKey: string,
+        functionName: string,
+        options?: { connectionId?: string; payload?: In }
+    ): Promise<{ taskId: string }> {
+        const url = `${this.serverUrl}/function/trigger`;
+        const headers = {
+            'Provider-Config-Key': providerConfigKey,
+            ...(options?.connectionId ? { 'Connection-Id': options.connectionId } : {})
+        };
+        const body = { function_name: functionName, payload: options?.payload ?? null };
+        const response = await this.http.post(url, body, { headers: this.enrichHeaders(headers) });
+        return response.data;
+    }
+
+    /**
      * Triggers an action asynchronously for a connection
      * @param providerConfigKey - The key identifying the provider configuration on Nango
      * @param connectionId - The ID of the connection for which the action should be triggered

--- a/packages/orchestrator/lib/clients/client.ts
+++ b/packages/orchestrator/lib/clients/client.ts
@@ -18,6 +18,7 @@ import type {
     ClientError,
     ExecuteActionProps,
     ExecuteAsyncReturn,
+    ExecuteFunctionProps,
     ExecuteOnEventProps,
     ExecuteProps,
     ExecuteReturn,
@@ -283,6 +284,31 @@ export class OrchestratorClient {
 
     public async executeWebhook(props: ExecuteWebhookProps): Promise<ExecuteReturn> {
         const res = await this.immediate(this.buildWebhookSchedulingProps(props));
+        if (res.isErr()) {
+            return Err(res.error);
+        }
+        return Ok({ taskId: res.value.taskId, retryKey: res.value.retryKey });
+    }
+
+    private buildFunctionSchedulingProps(props: ExecuteFunctionProps) {
+        const { args, ...rest } = props;
+        return {
+            ...rest,
+            retry: { count: 0, max: 0 },
+            timeoutSettingsInSecs: {
+                createdToStarted: 5 * 60,
+                startedToCompleted: 60 * 60,
+                heartbeat: 5 * 60
+            },
+            args: {
+                ...args,
+                type: 'function' as const
+            }
+        };
+    }
+
+    public async executeFunction(props: ExecuteFunctionProps): Promise<ExecuteReturn> {
+        const res = await this.immediate(this.buildFunctionSchedulingProps(props));
         if (res.isErr()) {
             return Err(res.error);
         }

--- a/packages/orchestrator/lib/clients/types.ts
+++ b/packages/orchestrator/lib/clients/types.ts
@@ -53,6 +53,8 @@ interface OnEventArgs {
 interface FunctionArgs {
     functionName: string;
     providerConfigKey: string;
+    /** Always present so connection-less runs have environment context without a connection. */
+    environmentId: number;
     /** null for connection-less runs (e.g. an integration-level webhook routing run). */
     connection: ConnectionJobs | null;
     activityLogId: string;
@@ -282,6 +284,7 @@ export function TaskFunction(props: TaskCommonFields & FunctionArgs): TaskFuncti
         attemptMax: props.attemptMax,
         functionName: props.functionName,
         providerConfigKey: props.providerConfigKey,
+        environmentId: props.environmentId,
         connection: props.connection,
         activityLogId: props.activityLogId,
         trigger: props.trigger,

--- a/packages/orchestrator/lib/clients/types.ts
+++ b/packages/orchestrator/lib/clients/types.ts
@@ -56,7 +56,8 @@ interface FunctionArgs {
     /** null for connection-less runs (e.g. an integration-level webhook routing run). */
     connection: ConnectionJobs | null;
     activityLogId: string;
-    trigger: { type: 'http' | 'webhook' | 'cron' | 'scheduled' | 'event' | 'manual'; name?: string | undefined };
+    // JSON-safe (serialized into the task payload): name is null rather than undefined when absent.
+    trigger: { type: 'http' | 'webhook' | 'cron' | 'scheduled' | 'event' | 'manual'; name: string | null };
     input: JsonValue;
 }
 export type SchedulesReturn = Result<OrchestratorSchedule[]>;

--- a/packages/orchestrator/lib/clients/types.ts
+++ b/packages/orchestrator/lib/clients/types.ts
@@ -50,6 +50,15 @@ interface OnEventArgs {
     activityLogId: string;
     sdkVersion: string | null;
 }
+interface FunctionArgs {
+    functionName: string;
+    providerConfigKey: string;
+    /** null for connection-less runs (e.g. an integration-level webhook routing run). */
+    connection: ConnectionJobs | null;
+    activityLogId: string;
+    trigger: { type: 'http' | 'webhook' | 'cron' | 'scheduled' | 'event' | 'manual'; name?: string | undefined };
+    input: JsonValue;
+}
 export type SchedulesReturn = Result<OrchestratorSchedule[]>;
 export type VoidReturn = Result<void, ClientError>;
 export type ExecuteProps = SetOptional<ImmediateProps, 'retry' | 'timeoutSettingsInSecs'>;
@@ -68,7 +77,7 @@ export interface OrchestratorSchedule {
     nextDueDate: Date | null;
 }
 
-export type OrchestratorTask = TaskSync | TaskSyncAbort | TaskAction | TaskWebhook | TaskOnEvent | TaskAbort;
+export type OrchestratorTask = TaskSync | TaskSyncAbort | TaskAction | TaskWebhook | TaskOnEvent | TaskFunction | TaskAbort;
 
 interface TaskCommonFields {
     id: string;
@@ -87,6 +96,7 @@ interface TaskCommon extends TaskCommonFields {
     isWebhook(this: OrchestratorTask): this is TaskWebhook;
     isAction(this: OrchestratorTask): this is TaskAction;
     isOnEvent(this: OrchestratorTask): this is TaskOnEvent;
+    isFunction(this: OrchestratorTask): this is TaskFunction;
     isSyncAbort(this: OrchestratorTask): this is TaskSyncAbort;
     isAbort(this: OrchestratorTask): this is TaskAbort;
 }
@@ -110,6 +120,7 @@ export function TaskAbort(props: TaskCommonFields & AbortArgs): TaskAbort {
         isWebhook: (): this is TaskWebhook => false,
         isAction: (): this is TaskAction => false,
         isOnEvent: (): this is TaskOnEvent => false,
+        isFunction: (): this is TaskFunction => false,
         isSyncAbort: (): this is TaskSyncAbort => false,
         isAbort: (): this is TaskAbort => true
     };
@@ -138,6 +149,7 @@ export function TaskSync(props: TaskCommonFields & SyncArgs & SyncExecutionArgs)
         isWebhook: (): this is TaskWebhook => false,
         isAction: (): this is TaskAction => false,
         isOnEvent: (): this is TaskOnEvent => false,
+        isFunction: (): this is TaskFunction => false,
         isSyncAbort: (): this is TaskSyncAbort => false,
         isAbort: (): this is TaskAbort => false
     };
@@ -167,6 +179,7 @@ export function TaskSyncAbort(props: TaskCommonFields & SyncArgs & AbortArgs): T
         isWebhook: (): this is TaskWebhook => false,
         isAction: (): this is TaskAction => false,
         isOnEvent: (): this is TaskOnEvent => false,
+        isFunction: (): this is TaskFunction => false,
         isSyncAbort: (): this is TaskSyncAbort => true,
         isAbort: (): this is TaskAbort => false
     };
@@ -194,6 +207,7 @@ export function TaskAction(props: TaskCommonFields & ActionArgs): TaskAction {
         isWebhook: (): this is TaskWebhook => false,
         isAction: (): this is TaskAction => true,
         isOnEvent: (): this is TaskOnEvent => false,
+        isFunction: (): this is TaskFunction => false,
         isSyncAbort: (): this is TaskSyncAbort => false,
         isAbort: (): this is TaskAbort => false
     };
@@ -221,6 +235,7 @@ export function TaskWebhook(props: TaskCommonFields & WebhookArgs): TaskWebhook 
         isWebhook: (): this is TaskWebhook => true,
         isAction: (): this is TaskAction => false,
         isOnEvent: (): this is TaskOnEvent => false,
+        isFunction: (): this is TaskFunction => false,
         isSyncAbort: (): this is TaskSyncAbort => false,
         isAbort: (): this is TaskAbort => false
     };
@@ -249,10 +264,42 @@ export function TaskOnEvent(props: TaskCommonFields & OnEventArgs): TaskOnEvent 
         isWebhook: (): this is TaskWebhook => false,
         isAction: (): this is TaskAction => false,
         isOnEvent: (): this is TaskOnEvent => true,
+        isFunction: (): this is TaskFunction => false,
         isSyncAbort: (): this is TaskSyncAbort => false,
         isAbort: (): this is TaskAbort => false
     };
 }
+
+export interface TaskFunction extends TaskCommon, FunctionArgs {}
+export function TaskFunction(props: TaskCommonFields & FunctionArgs): TaskFunction {
+    return {
+        id: props.id,
+        name: props.name,
+        state: props.state,
+        retryKey: props.retryKey,
+        attempt: props.attempt,
+        attemptMax: props.attemptMax,
+        functionName: props.functionName,
+        providerConfigKey: props.providerConfigKey,
+        connection: props.connection,
+        activityLogId: props.activityLogId,
+        trigger: props.trigger,
+        input: props.input,
+        groupKey: props.groupKey,
+        groupMaxConcurrency: props.groupMaxConcurrency,
+        ownerKey: props.ownerKey,
+        heartbeatTimeoutSecs: props.heartbeatTimeoutSecs,
+        isSync: (): this is TaskSync => false,
+        isWebhook: (): this is TaskWebhook => false,
+        isAction: (): this is TaskAction => false,
+        isOnEvent: (): this is TaskOnEvent => false,
+        isFunction: (): this is TaskFunction => true,
+        isSyncAbort: (): this is TaskSyncAbort => false,
+        isAbort: (): this is TaskAbort => false
+    };
+}
+
+export type ExecuteFunctionProps = Omit<ExecuteProps, 'args'> & { args: FunctionArgs };
 
 export interface ClientError extends Error {
     name: string;

--- a/packages/orchestrator/lib/clients/validate.ts
+++ b/packages/orchestrator/lib/clients/validate.ts
@@ -80,7 +80,7 @@ export const functionArgsSchema = z.object({
     // null for connection-less runs (e.g. an integration-level webhook routing run)
     connection: commonSchemaArgsFields.connection.nullable(),
     activityLogId: z.string(),
-    trigger: z.object({ type: z.enum(['http', 'webhook', 'cron', 'scheduled', 'event', 'manual']), name: z.string().optional() }),
+    trigger: z.object({ type: z.enum(['http', 'webhook', 'cron', 'scheduled', 'event', 'manual']), name: z.string().nullable().default(null) }),
     input: jsonSchema
 });
 

--- a/packages/orchestrator/lib/clients/validate.ts
+++ b/packages/orchestrator/lib/clients/validate.ts
@@ -77,6 +77,7 @@ export const functionArgsSchema = z.object({
     type: z.literal('function'),
     functionName: z.string().min(1),
     providerConfigKey: z.string().min(1),
+    environmentId: z.number().positive(),
     // null for connection-less runs (e.g. an integration-level webhook routing run)
     connection: commonSchemaArgsFields.connection.nullable(),
     activityLogId: z.string(),
@@ -251,6 +252,7 @@ export function validateTask(task: Task): Result<OrchestratorTask> {
                 attemptMax: fn.data.retryMax + 1,
                 functionName: fn.data.payload.functionName,
                 providerConfigKey: fn.data.payload.providerConfigKey,
+                environmentId: fn.data.payload.environmentId,
                 connection: fn.data.payload.connection,
                 activityLogId: fn.data.payload.activityLogId,
                 trigger: fn.data.payload.trigger,

--- a/packages/orchestrator/lib/clients/validate.ts
+++ b/packages/orchestrator/lib/clients/validate.ts
@@ -3,7 +3,7 @@ import * as z from 'zod';
 import { taskStates } from '@nangohq/scheduler';
 import { Err, Ok } from '@nangohq/utils';
 
-import { TaskAbort, TaskAction, TaskOnEvent, TaskSync, TaskSyncAbort, TaskWebhook } from './types.js';
+import { TaskAbort, TaskAction, TaskFunction, TaskOnEvent, TaskSync, TaskSyncAbort, TaskWebhook } from './types.js';
 import { jsonSchema } from '../utils/validation.js';
 
 import type { OrchestratorSchedule, OrchestratorTask } from './types.js';
@@ -73,6 +73,16 @@ export const onEventArgsSchema = z.object({
     activityLogId: z.string(),
     ...commonSchemaArgsFields
 });
+export const functionArgsSchema = z.object({
+    type: z.literal('function'),
+    functionName: z.string().min(1),
+    providerConfigKey: z.string().min(1),
+    // null for connection-less runs (e.g. an integration-level webhook routing run)
+    connection: commonSchemaArgsFields.connection.nullable(),
+    activityLogId: z.string(),
+    trigger: z.object({ type: z.enum(['http', 'webhook', 'cron', 'scheduled', 'event', 'manual']), name: z.string().optional() }),
+    input: jsonSchema
+});
 
 const commonSchemaFields = {
     id: z.string().uuid(),
@@ -109,6 +119,10 @@ const webhookSchema = z.object({
 const onEventSchema = z.object({
     ...commonSchemaFields,
     payload: onEventArgsSchema
+});
+const functionSchema = z.object({
+    ...commonSchemaFields,
+    payload: functionArgsSchema
 });
 
 export function validateTask(task: Task): Result<OrchestratorTask> {
@@ -223,6 +237,29 @@ export function validateTask(task: Task): Result<OrchestratorTask> {
                 sdkVersion: onEvent.data.payload.sdkVersion,
                 activityLogId: onEvent.data.payload.activityLogId,
                 heartbeatTimeoutSecs: onEvent.data.heartbeatTimeoutSecs
+            })
+        );
+    }
+    const fn = functionSchema.safeParse(task);
+    if (fn.success) {
+        return Ok(
+            TaskFunction({
+                id: fn.data.id,
+                state: fn.data.state,
+                name: fn.data.name,
+                attempt: fn.data.retryCount + 1,
+                attemptMax: fn.data.retryMax + 1,
+                functionName: fn.data.payload.functionName,
+                providerConfigKey: fn.data.payload.providerConfigKey,
+                connection: fn.data.payload.connection,
+                activityLogId: fn.data.payload.activityLogId,
+                trigger: fn.data.payload.trigger,
+                input: fn.data.payload.input,
+                groupKey: fn.data.groupKey,
+                groupMaxConcurrency: fn.data.groupMaxConcurrency,
+                ownerKey: fn.data.ownerKey,
+                retryKey: fn.data.retryKey,
+                heartbeatTimeoutSecs: fn.data.heartbeatTimeoutSecs
             })
         );
     }

--- a/packages/orchestrator/lib/routes/v1/postImmediate.ts
+++ b/packages/orchestrator/lib/routes/v1/postImmediate.ts
@@ -3,7 +3,7 @@ import * as z from 'zod';
 import { isDuplicateTaskNameError } from '@nangohq/scheduler';
 import { validateRequest } from '@nangohq/utils';
 
-import { actionArgsSchema, onEventArgsSchema, syncAbortArgsSchema, syncArgsSchema, webhookArgsSchema } from '../../clients/validate.js';
+import { actionArgsSchema, functionArgsSchema, onEventArgsSchema, syncAbortArgsSchema, syncArgsSchema, webhookArgsSchema } from '../../clients/validate.js';
 
 import type { TaskType } from '../../types.js';
 import type { Scheduler } from '@nangohq/scheduler';
@@ -36,7 +36,7 @@ export const immediateTaskSchema = z
             startedToCompleted: z.number().int().positive(),
             heartbeat: z.number().int().positive()
         }),
-        args: z.discriminatedUnion('type', [syncArgsSchema, actionArgsSchema, webhookArgsSchema, onEventArgsSchema, syncAbortArgsSchema])
+        args: z.discriminatedUnion('type', [syncArgsSchema, actionArgsSchema, webhookArgsSchema, onEventArgsSchema, functionArgsSchema, syncAbortArgsSchema])
     })
     .strict();
 

--- a/packages/orchestrator/lib/types.ts
+++ b/packages/orchestrator/lib/types.ts
@@ -1,2 +1,2 @@
-export const taskTypes = ['action', 'webhook', 'sync', 'on-event', 'abort'] as const;
+export const taskTypes = ['action', 'webhook', 'sync', 'on-event', 'function', 'abort'] as const;
 export type TaskType = (typeof taskTypes)[number];

--- a/packages/runner-sdk/lib/action.ts
+++ b/packages/runner-sdk/lib/action.ts
@@ -315,6 +315,28 @@ export abstract class NangoActionBase<
         return cached.connection;
     }
 
+    /**
+     * Returns a connection-scoped instance: all SDK calls on it use the given connection without
+     * needing to pass connectionId. Safe in async loops — each call returns its own scoped object
+     * that shares this instance's behavior but overrides only the bound connection.
+     *
+     * @example
+     * ```ts
+     * for (const connection of connections) {
+     *     const conn = nango.withConnection(connection);
+     *     const data = await conn.get({ endpoint: '/contacts' });
+     *     await conn.batchSave([data], 'Contact');
+     * }
+     * ```
+     */
+    public withConnection(connection: { id: number; connection_id: string }): this {
+        const scoped: this = Object.create(this);
+        scoped.connectionId = connection.connection_id;
+        scoped.nangoConnectionId = connection.id;
+        scoped.connectionBound = true;
+        return scoped;
+    }
+
     public async setMetadata(metadata: TMetadataInferred): Promise<AxiosResponse<SetMetadata['Success']>> {
         this.throwIfAbortedOrKilled();
         try {

--- a/packages/runner-sdk/lib/action.ts
+++ b/packages/runner-sdk/lib/action.ts
@@ -473,6 +473,23 @@ export abstract class NangoActionBase<
         return await this.nango.triggerAction(providerConfigKey, connectionId, actionName, input);
     }
 
+    /**
+     * Schedule another function run, optionally bound to a connection. Fire-and-schedule:
+     * it enqueues the run and returns its task id, it does not wait for or return the output.
+     *
+     * @example
+     * ```ts
+     * // Fan out a connection-bound run per matched connection
+     * for (const connection of connections) {
+     *     await nango.triggerFunction('contacts-handler', { connectionId: connection.connection_id, payload: event.payload });
+     * }
+     * ```
+     */
+    public async triggerFunction<In = unknown>(functionName: string, options?: { connectionId?: string; payload?: In }): Promise<{ taskId: string }> {
+        this.throwIfAbortedOrKilled();
+        return await this.nango.triggerFunction(this.providerConfigKey, functionName, options);
+    }
+
     public async zodValidateInput<T = any, Z = any>({ zodSchema, input }: { zodSchema: z.ZodType<Z>; input: T }): Promise<z.ZodSafeParseSuccess<Z>> {
         const parsedInput = zodSchema.safeParse(input);
         if (!parsedInput.success) {

--- a/packages/runner-sdk/lib/action.ts
+++ b/packages/runner-sdk/lib/action.ts
@@ -80,6 +80,8 @@ export abstract class NangoActionBase<
     public providerConfigKey: string;
     public provider?: string;
     public integrationConfig?: NangoProps['integrationConfig'];
+    /** Whether this run was started with a bound connection. Connection-less function runs (e.g. integration-level webhook routing) are not. */
+    public connectionBound: boolean;
 
     public ActionError = ActionError;
 
@@ -95,6 +97,7 @@ export abstract class NangoActionBase<
 
     constructor(config: NangoProps) {
         this.connectionId = config.connectionId;
+        this.connectionBound = config.connectionBound ?? Boolean(config.connectionId);
         this.environmentId = config.environmentId;
         this.accountId = config.team.id;
         this.providerConfigKey = config.providerConfigKey;
@@ -278,6 +281,14 @@ export abstract class NangoActionBase<
 
         const providerConfigKey = providerConfigKeyOverride || this.providerConfigKey;
         const connectionId = connectionIdOverride || this.connectionId;
+
+        if (!connectionId) {
+            // Connection-less function run: there is no connection bound to this run. The customer must
+            // resolve a connection first (e.g. nango.searchConnections) and pass its id explicitly.
+            throw new Error(
+                'getConnection() was called without a connection context: this run was not started with a connection. Pass a connectionId, or resolve one via searchConnections() and trigger a connection-bound run.'
+            );
+        }
 
         const credentialsPair = `${providerConfigKey}${connectionId}`;
         const cached = this.memoizedConnections.get(credentialsPair);

--- a/packages/runner-sdk/lib/scripts.ts
+++ b/packages/runner-sdk/lib/scripts.ts
@@ -534,7 +534,7 @@ export interface CoalescedInfo {
  */
 export interface FunctionEvent {
     /** Which trigger fired, and (for named triggers) its name. */
-    trigger: { type: FunctionTriggerType; name?: string };
+    trigger: { type: FunctionTriggerType; name?: string | undefined };
     /** The webhook/manual payload — latest, or an array when `payloadMode: 'all'`. */
     payload: any;
     /** Raw headers from the provider (http trigger only). */

--- a/packages/runner-sdk/lib/scripts.ts
+++ b/packages/runner-sdk/lib/scripts.ts
@@ -8,7 +8,8 @@ import type * as z from 'zod';
 export type CreateAnyResponse =
     | CreateSyncResponse<any, ZodMetadata, ZodCheckpoint>
     | CreateActionResponse<any, any, ZodMetadata, ZodCheckpoint>
-    | CreateOnEventResponse<ZodMetadata, ZodCheckpoint>;
+    | CreateOnEventResponse<ZodMetadata, ZodCheckpoint>
+    | CreateFunctionResponse<any, any, any, ZodMetadata, ZodCheckpoint>;
 
 export type { ActionError } from './errors.js';
 export type { NangoActionBase as NangoAction, ProxyConfiguration } from './action.js';
@@ -428,4 +429,278 @@ export function createOnEvent<TMetadata extends ZodMetadata = undefined, TCheckp
     params: CreateOnEventProps<TMetadata, TCheckpoint>
 ): CreateOnEventResponse<TMetadata, TCheckpoint> {
     return { type: 'onEvent', ...params };
+}
+
+// ----- Function / Webhook
+//
+// A `function` is a trigger-agnostic primitive: it separates the trigger (what initiates
+// execution) from the handler (what runs). Webhooks are the first trigger type.
+// `createWebhook()` is syntactic sugar for a function with a single implicit `http` trigger.
+// Syncs and actions are unchanged; functions are introduced additively alongside them.
+
+/**
+ * The kind of trigger that initiated a function run.
+ * - `http` / `webhook`: an incoming webhook request
+ * - `cron` / `scheduled`: a periodic schedule
+ * - `event`: an internal Nango event
+ * - `manual`: started via `nango.triggerFunction()`, the API, or the CLI
+ */
+export type FunctionTriggerType = 'http' | 'webhook' | 'cron' | 'scheduled' | 'event' | 'manual';
+
+/**
+ * Declares where the debounce/coalescing key is extracted from.
+ * - `{ body: '$.portalId' }` — dot-notation path into the normalized body
+ * - `{ header: 'x-goog-resource-id' }` — flat, case-insensitive header lookup
+ */
+export type DebounceKeySource = { body: string } | { header: string };
+
+/**
+ * Coalesces multiple inbound events into a single function run within a sliding window.
+ */
+export interface WebhookDebounceConfig {
+    key?: DebounceKeySource;
+    /** Sliding window in milliseconds. */
+    windowMs: number;
+    /** Hard ceiling for the window regardless of incoming events. */
+    maxWindowMs?: number;
+    /** When exceeded, the window stops sliding and `event.coalesced.overflowed` is set. */
+    maxEntities?: number;
+    /** Whether the handler receives only the latest payload or every coalesced payload. */
+    payloadMode?: 'latest' | 'all';
+}
+
+/**
+ * Built-in ingress signature verification. The secret is resolved by Nango at ingress.
+ */
+export interface WebhookIngressConfig {
+    verify?: {
+        type: string;
+        secret: { providerConfig: string };
+    };
+}
+
+/** Read-only request view passed to ingress hooks. No SDK, no I/O, hard timeout. */
+export interface IngressEvent {
+    rawBody: string;
+    headers: Record<string, string>;
+    query: Record<string, string | string[] | undefined>;
+}
+
+/**
+ * Runs synchronously at ingress before enqueueing. Return a response object to short-circuit
+ * the HTTP exchange (provider handshake), or `undefined` to let the request proceed.
+ */
+export type IngressChallenge = (event: IngressEvent) => MaybePromise<{ status?: number; body?: unknown; headers?: Record<string, string> } | undefined | void>;
+
+/**
+ * Runs synchronously at ingress before enqueueing. Return `true` to accept the event,
+ * or `false` (or throw) to reject it with a 401.
+ */
+export type IngressValidation = (event: IngressEvent) => MaybePromise<boolean>;
+
+export interface HttpTrigger {
+    type: 'http' | 'webhook';
+    /** Maps to the webhook URL path segment. Defaults to the file basename. */
+    name?: string;
+    /** `connection` opts into connection-level URLs (`/:webhookName/:targetToken`). */
+    scope?: 'integration' | 'connection';
+    ingress?: WebhookIngressConfig;
+    ingressChallenge?: IngressChallenge;
+    ingressValidation?: IngressValidation;
+    debounce?: WebhookDebounceConfig;
+}
+export interface CronTrigger {
+    type: 'cron' | 'scheduled';
+    /** e.g. 'every hour', 'every 2 minutes'. */
+    schedule: string;
+}
+export interface EventTrigger {
+    type: 'event';
+    event: string;
+}
+export type FunctionTrigger = HttpTrigger | CronTrigger | EventTrigger;
+
+/** Coalescing summary, present on the event when `debounce` is configured. */
+export interface CoalescedInfo {
+    count: number;
+    firstSeenAt: Date;
+    lastSeenAt: Date;
+    overflowed: boolean;
+}
+
+/**
+ * The event a function `exec` receives. Distinct from `(nango, input)` for actions —
+ * functions are trigger-driven, so the second argument describes the trigger and its payload.
+ */
+export interface FunctionEvent {
+    /** Which trigger fired, and (for named triggers) its name. */
+    trigger: { type: FunctionTriggerType; name?: string };
+    /** The webhook/manual payload — latest, or an array when `payloadMode: 'all'`. */
+    payload: any;
+    /** Raw headers from the provider (http trigger only). */
+    headers?: Record<string, string>;
+    /** Original request body as received by ingress (http trigger only). */
+    rawBody?: string;
+    /** Coalescing summary when `debounce` is configured. */
+    coalesced?: CoalescedInfo;
+    /**
+     * Pre-populated when the run was started with connection context (connection-level URL,
+     * `triggerFunction({ connectionId })`, or CLI `--connection`). Undefined for connection-less runs.
+     */
+    connection?: { id: number; connection_id: string; provider_config_key: string };
+}
+
+export interface CreateFunctionProps<
+    TModels extends Record<string, ZodModel>,
+    TInput extends z.ZodTypeAny = z.ZodTypeAny,
+    TOutput extends z.ZodTypeAny = z.ZodTypeAny,
+    TMetadata extends ZodMetadata = undefined,
+    TCheckpoint extends ZodCheckpoint = undefined
+> {
+    /**
+     * The version of the function. Use it to track changes inside Nango's UI.
+     * @default '0.0.1'
+     */
+    version?: string;
+
+    /** The description of the function. */
+    description?: string;
+
+    /**
+     * What can initiate execution. A function can have multiple triggers of different types
+     * (e.g. a webhook trigger plus a cron safety net). Any function can also be started via
+     * `nango.triggerFunction()` or the API regardless of declared triggers (`manual`).
+     */
+    triggers: FunctionTrigger[];
+
+    /** Models the function can `batchSave`/`batchUpdate`/`batchDelete` against. */
+    models?: TModels;
+
+    /** Optional typed input schema (for manual/API invocation). */
+    input?: TInput;
+
+    /** Optional typed output schema (reserved; unused for webhooks today). */
+    output?: TOutput;
+
+    metadata?: TMetadata;
+    checkpoint?: TCheckpoint;
+    scopes?: string[];
+
+    /**
+     * The handler. Runs on the customer runner with full SDK access.
+     * @example
+     * ```ts
+     * exec: async (nango, event) => {
+     *   const connections = await nango.searchConnections({ tags: { portalId: event.payload.portalId } });
+     *   for (const connection of connections) {
+     *     await nango.triggerSync(connection.id, 'contacts');
+     *   }
+     * }
+     * ```
+     */
+    exec: (nango: NangoSyncBase<TModels, TMetadata, TCheckpoint>, event: FunctionEvent) => MaybePromise<void>;
+}
+
+export interface CreateFunctionResponse<
+    TModels extends Record<string, ZodModel>,
+    TInput extends z.ZodTypeAny = z.ZodTypeAny,
+    TOutput extends z.ZodTypeAny = z.ZodTypeAny,
+    TMetadata extends ZodMetadata = undefined,
+    TCheckpoint extends ZodCheckpoint = undefined
+> extends CreateFunctionProps<TModels, TInput, TOutput, TMetadata, TCheckpoint> {
+    type: 'function';
+    /** Set when authored via `createWebhook()`; mirrors the http trigger name. */
+    name?: string;
+}
+
+/**
+ * Create a function — the trigger-agnostic primitive.
+ *
+ * Use this directly when you need multiple trigger types (e.g. webhook + cron).
+ * For a single webhook trigger, prefer the `createWebhook()` sugar.
+ *
+ * @example
+ * ```ts
+ * export default createFunction({
+ *     triggers: [
+ *         { type: 'http', name: 'contacts-updated', debounce: { key: { body: '$.objectId' }, windowMs: 5000 } },
+ *         { type: 'cron', schedule: 'every hour' }
+ *     ],
+ *     exec: async (nango, event) => { ... }
+ * });
+ * ```
+ */
+export function createFunction<
+    TModels extends Record<string, ZodModel> = Record<string, ZodModel>,
+    TInput extends z.ZodTypeAny = z.ZodTypeAny,
+    TOutput extends z.ZodTypeAny = z.ZodTypeAny,
+    TMetadata extends ZodMetadata = undefined,
+    TCheckpoint extends ZodCheckpoint = undefined
+>(params: CreateFunctionProps<TModels, TInput, TOutput, TMetadata, TCheckpoint>): CreateFunctionResponse<TModels, TInput, TOutput, TMetadata, TCheckpoint> {
+    return { type: 'function', ...params };
+}
+
+export interface CreateWebhookProps<
+    TModels extends Record<string, ZodModel>,
+    TMetadata extends ZodMetadata = undefined,
+    TCheckpoint extends ZodCheckpoint = undefined
+> {
+    /** Maps to the webhook URL path segment. Defaults to the file basename. */
+    name?: string;
+    version?: string;
+    description?: string;
+    /** `connection` opts into connection-level URLs (`/:webhookName/:targetToken`). */
+    scope?: 'integration' | 'connection';
+    ingress?: WebhookIngressConfig;
+    ingressChallenge?: IngressChallenge;
+    ingressValidation?: IngressValidation;
+    debounce?: WebhookDebounceConfig;
+    models?: TModels;
+    metadata?: TMetadata;
+    checkpoint?: TCheckpoint;
+    exec: (nango: NangoSyncBase<TModels, TMetadata, TCheckpoint>, event: FunctionEvent) => MaybePromise<void>;
+}
+
+/**
+ * Create a webhook handler — sugar for a function with a single implicit `http` trigger.
+ *
+ * Routing lives entirely in `exec` (customer-owned, runs on your runner). Provider protocol
+ * mechanics (handshake, signature verification) live in `ingressChallenge` / `ingressValidation`,
+ * which run synchronously at ingress with no SDK access.
+ *
+ * @example
+ * ```ts
+ * export default createWebhook({
+ *     name: 'contacts-updated',
+ *     debounce: { key: { body: '$.portalId' }, windowMs: 5000 },
+ *     exec: async (nango, event) => {
+ *         const connections = await nango.searchConnections({ tags: { portalId: event.payload.portalId } });
+ *         for (const connection of connections) {
+ *             await nango.triggerSync(connection.id, 'contacts');
+ *         }
+ *     }
+ * });
+ * ```
+ */
+export function createWebhook<
+    TModels extends Record<string, ZodModel> = Record<string, ZodModel>,
+    TMetadata extends ZodMetadata = undefined,
+    TCheckpoint extends ZodCheckpoint = undefined
+>(params: CreateWebhookProps<TModels, TMetadata, TCheckpoint>): CreateFunctionResponse<TModels, z.ZodTypeAny, z.ZodTypeAny, TMetadata, TCheckpoint> {
+    const { name, ingress, ingressChallenge, ingressValidation, debounce, ...rest } = params;
+    const trigger: HttpTrigger = {
+        type: 'http',
+        ...(name !== undefined ? { name } : {}),
+        ...(params.scope !== undefined ? { scope: params.scope } : {}),
+        ...(ingress !== undefined ? { ingress } : {}),
+        ...(ingressChallenge !== undefined ? { ingressChallenge } : {}),
+        ...(ingressValidation !== undefined ? { ingressValidation } : {}),
+        ...(debounce !== undefined ? { debounce } : {})
+    };
+    return {
+        type: 'function',
+        ...rest,
+        ...(name !== undefined ? { name } : {}),
+        triggers: [trigger]
+    };
 }

--- a/packages/runner-sdk/lib/scripts.ts
+++ b/packages/runner-sdk/lib/scripts.ts
@@ -534,7 +534,7 @@ export interface CoalescedInfo {
  */
 export interface FunctionEvent {
     /** Which trigger fired, and (for named triggers) its name. */
-    trigger: { type: FunctionTriggerType; name?: string | undefined };
+    trigger: { type: FunctionTriggerType; name?: string | null | undefined };
     /** The webhook/manual payload — latest, or an array when `payloadMode: 'all'`. */
     payload: any;
     /** Raw headers from the provider (http trigger only). */

--- a/packages/runner-sdk/lib/scripts.unit.test.ts
+++ b/packages/runner-sdk/lib/scripts.unit.test.ts
@@ -2,7 +2,7 @@
 import { describe, expect, expectTypeOf, it } from 'vitest';
 import * as z from 'zod';
 
-import { createAction, createOnEvent, createSync } from './scripts.js';
+import { createAction, createFunction, createOnEvent, createSync, createWebhook } from './scripts.js';
 
 describe('scripts', () => {
     describe('createSync', () => {
@@ -184,6 +184,72 @@ describe('scripts', () => {
                 type: 'onEvent',
                 exec: expect.any(Function)
             });
+        });
+    });
+
+    describe('createFunction', () => {
+        it('should create a function with explicit triggers', () => {
+            const fn = createFunction({
+                description: 'Handle contact updates',
+                triggers: [
+                    { type: 'http', name: 'contacts-updated', debounce: { key: { body: '$.objectId' }, windowMs: 5000 } },
+                    { type: 'cron', schedule: 'every hour' }
+                ],
+                exec: async (nango, event) => {
+                    await nango.log('event', event.payload);
+                }
+            });
+
+            expect(fn).toStrictEqual({
+                description: 'Handle contact updates',
+                triggers: [
+                    { type: 'http', name: 'contacts-updated', debounce: { key: { body: '$.objectId' }, windowMs: 5000 } },
+                    { type: 'cron', schedule: 'every hour' }
+                ],
+                type: 'function',
+                exec: expect.any(Function)
+            });
+        });
+    });
+
+    describe('createWebhook', () => {
+        it('should desugar into a function with a single implicit http trigger', () => {
+            const ingressValidation = () => true;
+            const webhook = createWebhook({
+                name: 'contacts-updated',
+                description: 'Contacts webhook',
+                ingressValidation,
+                debounce: { key: { body: '$.portalId' }, windowMs: 5000 },
+                exec: async (nango, event) => {
+                    await nango.log('event', event.payload);
+                }
+            });
+
+            expect(webhook.type).toBe('function');
+            expect(webhook.name).toBe('contacts-updated');
+            expect(webhook.triggers).toHaveLength(1);
+            expect(webhook.triggers[0]).toStrictEqual({
+                type: 'http',
+                name: 'contacts-updated',
+                ingressValidation,
+                debounce: { key: { body: '$.portalId' }, windowMs: 5000 }
+            });
+            // ingress hooks live on the trigger, not at the top level of the function
+            expect((webhook as unknown as Record<string, unknown>)['ingressValidation']).toBeUndefined();
+        });
+
+        it('should default the trigger name from the absence of name (left to the file basename downstream)', () => {
+            const webhook = createWebhook({
+                description: 'no name',
+                exec: async (nango) => {
+                    await nango.log('hi');
+                }
+            });
+
+            expect(webhook.type).toBe('function');
+            expect(webhook.name).toBeUndefined();
+            expect(webhook.triggers).toHaveLength(1);
+            expect(webhook.triggers[0]).toStrictEqual({ type: 'http' });
         });
     });
 });

--- a/packages/runner/lib/exec.ts
+++ b/packages/runner/lib/exec.ts
@@ -20,7 +20,7 @@ import { NangoActionRunner, NangoSyncRunner, instrumentSDK } from './sdk/sdk.js'
 import { createTelemetryRecorder } from './telemetry.js';
 
 import type { Locks } from './sdk/locks.js';
-import type { CreateAnyResponse } from '@nangohq/runner-sdk';
+import type { CreateAnyResponse, FunctionEvent } from '@nangohq/runner-sdk';
 import type { NangoProps, Result, RunnerOutput } from '@nangohq/types';
 
 interface ScriptExports {
@@ -62,6 +62,8 @@ export async function exec({
         switch (nangoProps.scriptType) {
             case 'sync':
             case 'webhook':
+            case 'function':
+                // Functions reuse the sync runner's capabilities (records, proxy, triggers) for now.
                 return new NangoSyncRunner(nangoProps, { persistClient, telemetryRecorder, locks });
             case 'action':
             case 'on-event':
@@ -233,6 +235,51 @@ export async function exec({
                     output = await def(nango);
                 }
                 return Ok({ output, telemetryBag: nango.telemetryBag });
+            }
+
+            // Function
+            if (nangoProps.scriptType === 'function') {
+                if (!isZeroYaml) {
+                    throw new Error('Functions require the zero-yaml SDK');
+                }
+                const payload = def;
+                if (payload.type !== 'function') {
+                    throw new Error('Incorrect script loaded for function');
+                }
+                if (!payload.exec) {
+                    throw new Error(`Missing exec function`);
+                }
+
+                const fe = nangoProps.functionEvent;
+                const event: FunctionEvent = {
+                    trigger: fe?.trigger ?? { type: 'manual' },
+                    payload: fe?.payload,
+                    ...(fe?.headers ? { headers: fe.headers } : {}),
+                    ...(fe?.rawBody !== undefined ? { rawBody: fe.rawBody } : {}),
+                    ...(fe?.coalesced
+                        ? {
+                              coalesced: {
+                                  count: fe.coalesced.count,
+                                  firstSeenAt: new Date(fe.coalesced.firstSeenAt),
+                                  lastSeenAt: new Date(fe.coalesced.lastSeenAt),
+                                  overflowed: fe.coalesced.overflowed
+                              }
+                          }
+                        : {}),
+                    // Connection context: present only for connection-bound runs. getConnection() throws otherwise.
+                    ...(nangoProps.connectionBound
+                        ? {
+                              connection: {
+                                  id: nangoProps.nangoConnectionId,
+                                  connection_id: nangoProps.connectionId,
+                                  provider_config_key: nangoProps.providerConfigKey
+                              }
+                          }
+                        : {})
+                };
+
+                const output = await payload.exec(nango as any, event);
+                return Ok({ output: output ?? true, telemetryBag: nango.telemetryBag, checkpoints: nango.getCheckpointRange() });
             }
 
             // Sync

--- a/packages/runner/lib/sdk/sdk.ts
+++ b/packages/runner/lib/sdk/sdk.ts
@@ -431,9 +431,13 @@ export class NangoSyncRunner extends NangoSyncBase<never, never, ZodCheckpoint> 
         );
 
         if (!this.syncConfig) throw new Error('Parameter syncConfig is required');
-        if (!this.syncId) throw new Error('Parameter syncId is required');
-        if (!this.syncJobId) throw new Error('Parameter syncJobId is required');
-        if (!this.nangoConnectionId) throw new Error('Parameter nangoConnectionId is required');
+        // Functions reuse this runner for its records/proxy capabilities but have no sync job, and
+        // connection-less function runs (e.g. integration-level webhook routing) have no connection.
+        if (this.scriptType !== 'function') {
+            if (!this.syncId) throw new Error('Parameter syncId is required');
+            if (!this.syncJobId) throw new Error('Parameter syncJobId is required');
+            if (!this.nangoConnectionId) throw new Error('Parameter nangoConnectionId is required');
+        }
 
         this.persistClient = runnerProps?.persistClient || new PersistClient({ secretKey: props.secretKey });
         this.telemetryRecorder = runnerProps?.telemetryRecorder;
@@ -442,7 +446,8 @@ export class NangoSyncRunner extends NangoSyncBase<never, never, ZodCheckpoint> 
         this.checkpointing = new Checkpointing({
             persistClient: this.persistClient,
             environmentId: this.environmentId,
-            nangoConnectionId: this.nangoConnectionId
+            // Connection-less function runs have no connection to key checkpoints against; 0 is an unused sentinel.
+            nangoConnectionId: this.nangoConnectionId ?? 0
         });
     }
 

--- a/packages/server/lib/controllers/functions/postTriggerFunction.ts
+++ b/packages/server/lib/controllers/functions/postTriggerFunction.ts
@@ -1,0 +1,108 @@
+import * as z from 'zod';
+
+import { OtlpSpan, defaultOperationExpiration, logContextGetter } from '@nangohq/logs';
+import { configService, connectionService, getFunctionConfigRaw } from '@nangohq/shared';
+import { requireEmptyQuery, truncateJson, zodErrorToHTTP } from '@nangohq/utils';
+
+import { connectionIdSchema, providerConfigKeySchema } from '../../helpers/validation.js';
+import { asyncWrapper } from '../../utils/asyncWrapper.js';
+import { getOrchestrator } from '../../utils/utils.js';
+
+import type { ConnectionJobs, PostPublicTriggerFunction } from '@nangohq/types';
+
+// Functions run on the customer's runner quota; this bounds concurrent runs per environment.
+const FUNCTION_MAX_CONCURRENCY = 50;
+
+const schemaHeaders = z.object({
+    'provider-config-key': providerConfigKeySchema,
+    'connection-id': connectionIdSchema.optional()
+});
+
+const schemaBody = z.object({
+    function_name: z.string().min(1).max(255),
+    payload: z.unknown()
+});
+
+export const postPublicTriggerFunction = asyncWrapper<PostPublicTriggerFunction>(async (req, res) => {
+    const valHeaders = schemaHeaders.safeParse(req.headers);
+    if (!valHeaders.success) {
+        res.status(400).send({ error: { code: 'invalid_headers', errors: zodErrorToHTTP(valHeaders.error) } });
+        return;
+    }
+
+    const emptyQuery = requireEmptyQuery(req);
+    if (emptyQuery) {
+        res.status(400).send({ error: { code: 'invalid_query_params', errors: zodErrorToHTTP(emptyQuery.error) } });
+        return;
+    }
+
+    const valBody = schemaBody.safeParse(req.body);
+    if (!valBody.success) {
+        res.status(400).send({ error: { code: 'invalid_body', errors: zodErrorToHTTP(valBody.error) } });
+        return;
+    }
+
+    const { account, environment } = res.locals;
+    const { function_name, payload } = valBody.data;
+    const providerConfigKey = valHeaders.data['provider-config-key'];
+    const connectionId = valHeaders.data['connection-id'];
+
+    const provider = await configService.getProviderConfig(providerConfigKey, environment.id);
+    if (!provider) {
+        res.status(400).json({ error: { code: 'unknown_provider', message: 'Failed to find provider' } });
+        return;
+    }
+
+    const syncConfig = await getFunctionConfigRaw({ environmentId: environment.id, config_id: provider.id!, name: function_name });
+    if (!syncConfig) {
+        res.status(404).json({ error: { code: 'not_found', message: 'Function not found' } });
+        return;
+    }
+    if (!syncConfig.enabled) {
+        res.status(404).json({ error: { code: 'disabled_resource', message: 'The function is disabled' } });
+        return;
+    }
+
+    // Connection is optional: a connection-bound run when provided, a connection-less routing run otherwise.
+    let connection: ConnectionJobs | null = null;
+    if (connectionId) {
+        const { success, response: conn } = await connectionService.getConnection(connectionId, providerConfigKey, environment.id);
+        if (!success || !conn) {
+            res.status(400).json({ error: { code: 'unknown_connection', message: 'Failed to find connection' } });
+            return;
+        }
+        connection = { id: conn.id, connection_id: conn.connection_id, provider_config_key: conn.provider_config_key, environment_id: conn.environment_id };
+    }
+
+    const logCtx = await logContextGetter.create(
+        { operation: { type: 'action', action: 'run' }, expiresAt: defaultOperationExpiration.action() },
+        {
+            account,
+            environment,
+            integration: { id: provider.id!, name: providerConfigKey, provider: provider.provider },
+            syncConfig: { id: syncConfig.id, name: syncConfig.sync_name },
+            ...(connection ? { connection: { id: connection.id, name: connection.connection_id } } : {}),
+            meta: truncateJson({ payload })
+        }
+    );
+    logCtx.attachSpan(new OtlpSpan(logCtx.operation));
+
+    const result = await getOrchestrator().triggerFunction<{ taskId: string; retryKey: string }>({
+        functionName: function_name,
+        providerConfigKey,
+        environmentId: environment.id,
+        connection,
+        trigger: { type: 'manual', name: null },
+        input: (payload ?? {}) as object,
+        maxConcurrency: FUNCTION_MAX_CONCURRENCY,
+        logCtx
+    });
+
+    if (result.isErr()) {
+        await logCtx.failed();
+        res.status(500).json({ error: { code: 'trigger_failed', message: result.error.message } });
+        return;
+    }
+
+    res.status(200).json({ taskId: result.value.taskId });
+});

--- a/packages/server/lib/controllers/integrations/uniqueKey/functions/getCode.ts
+++ b/packages/server/lib/controllers/integrations/uniqueKey/functions/getCode.ts
@@ -11,10 +11,11 @@ import { asyncWrapper } from '../../../../utils/asyncWrapper.js';
 
 import type { GetPublicFunctionCode, ScriptTypeLiteral } from '@nangohq/types';
 
-const scriptTypeToFolder: Record<ScriptTypeLiteral, 'syncs' | 'actions' | 'on-events'> = {
+const scriptTypeToFolder: Record<ScriptTypeLiteral, 'syncs' | 'actions' | 'on-events' | 'functions'> = {
     sync: 'syncs',
     action: 'actions',
-    'on-event': 'on-events'
+    'on-event': 'on-events',
+    function: 'functions'
 };
 
 interface FunctionMatch {

--- a/packages/server/lib/controllers/sync/deploy/validation.ts
+++ b/packages/server/lib/controllers/sync/deploy/validation.ts
@@ -37,9 +37,39 @@ const nangoModel = z
     })
     .strict();
 
+const functionTrigger = z
+    .object({
+        type: z.enum(['http', 'webhook', 'cron', 'scheduled', 'event', 'manual']),
+        name: z.string().max(255).optional(),
+        scope: z.enum(['integration', 'connection']).optional(),
+        schedule: z.string().max(255).optional(),
+        event: z.string().max(255).optional(),
+        debounce: z
+            .object({
+                key: z.union([z.object({ body: z.string() }).strict(), z.object({ header: z.string() }).strict()]).optional(),
+                windowMs: z.number(),
+                maxWindowMs: z.number().optional(),
+                maxEntities: z.number().optional(),
+                payloadMode: z.enum(['latest', 'all']).optional()
+            })
+            .strict()
+            .optional(),
+        hasIngressChallenge: z.boolean().optional(),
+        hasIngressValidation: z.boolean().optional()
+    })
+    .strict();
+
+const functionConfig = z
+    .object({
+        name: z.string().max(255).optional(),
+        triggers: z.array(functionTrigger)
+    })
+    .strict();
+
 export const flowConfig = z
     .object({
-        type: z.enum(['action', 'sync']),
+        type: z.enum(['action', 'sync', 'function']),
+        function_config: functionConfig.optional(),
         models: z.array(z.string().min(1).max(255)),
         runs: z.union([z.string().length(0), frequencySchema]).nullable(), // TODO: remove or after >0.58.5 is widely adopted
         auto_start: z.boolean().optional().default(false),

--- a/packages/server/lib/routes.public.ts
+++ b/packages/server/lib/routes.public.ts
@@ -42,6 +42,7 @@ import { postFunctionDeploymentResult } from './controllers/functions/deploy/pos
 import { getFunctionDryrun } from './controllers/functions/dryrun/getDryrun.js';
 import { postFunctionDryrun } from './controllers/functions/dryrun/postDryrun.js';
 import { postFunctionDryrunResult } from './controllers/functions/dryrun/postDryrunResult.js';
+import { postPublicTriggerFunction } from './controllers/functions/postTriggerFunction.js';
 import { getPublicListIntegrations } from './controllers/integrations/getListIntegrations.js';
 import { postPublicIntegration, postPublicQuickstartIntegration } from './controllers/integrations/postIntegration.js';
 import { deletePublicIntegration } from './controllers/integrations/uniqueKey/deleteIntegration.js';
@@ -298,6 +299,10 @@ publicAPI.route('/functions/deployments/:id/result').post(functionDeploymentResu
 publicAPI.use('/action', jsonContentTypeMiddleware);
 publicAPI.route('/action/trigger').post(apiAuth, withScope('environment:actions:execute'), postPublicTriggerAction); //TODO: to deprecate
 publicAPI.route('/action/:id').get(apiAuth, withScope('environment:actions:execute'), getAsyncActionResult);
+
+// Functions
+publicAPI.use('/function', jsonContentTypeMiddleware);
+publicAPI.route('/function/trigger').post(apiAuth, withScope('environment:actions:execute'), postPublicTriggerFunction);
 
 // Connect sessions
 publicAPI.use('/connect', jsonContentTypeMiddleware);

--- a/packages/shared/lib/clients/orchestrator.ts
+++ b/packages/shared/lib/clients/orchestrator.ts
@@ -21,6 +21,7 @@ import type { LogContext, LogContextGetter, LogContextOrigin } from '@nangohq/lo
 import type {
     ExecuteActionProps,
     ExecuteAsyncReturn,
+    ExecuteFunctionProps,
     ExecuteOnEventProps,
     ExecuteReturn,
     ExecuteSyncProps,
@@ -57,6 +58,7 @@ export interface OrchestratorClientInterface {
     executeAction(props: ExecuteActionProps): Promise<ExecuteReturn>;
     executeActionAsync(props: ExecuteActionProps): Promise<ExecuteAsyncReturn>;
     executeWebhook(props: ExecuteWebhookProps): Promise<ExecuteReturn>;
+    executeFunction(props: ExecuteFunctionProps): Promise<ExecuteReturn>;
     executeOnEvent(props: ExecuteOnEventProps & { async: boolean }): Promise<VoidReturn>;
     executeSync(props: ExecuteSyncProps): Promise<VoidReturn>;
     pauseSync({ scheduleName }: { scheduleName: string }): Promise<VoidReturn>;
@@ -327,6 +329,80 @@ export class Orchestrator {
                 }
             });
 
+            span.setTag('error', formattedError);
+            return Err(formattedError);
+        } finally {
+            span.finish();
+        }
+    }
+
+    /**
+     * Schedule a function run. The connection may be null for connection-less routing runs.
+     */
+    async triggerFunction<T = unknown>({
+        functionName,
+        providerConfigKey,
+        environmentId,
+        connection,
+        trigger,
+        input,
+        maxConcurrency,
+        logCtx
+    }: {
+        functionName: string;
+        providerConfigKey: string;
+        environmentId: number;
+        connection: ConnectionJobs | null;
+        trigger: { type: 'http' | 'webhook' | 'cron' | 'scheduled' | 'event' | 'manual'; name: string | null };
+        input: object;
+        maxConcurrency: number;
+        logCtx: LogContext;
+    }): Promise<Result<T, NangoError>> {
+        const activeSpan = tracer.scope().active();
+        const span = tracer.startSpan('execute.function', {
+            tags: { 'function.name': functionName, 'function.providerConfigKey': providerConfigKey, 'function.environmentId': environmentId },
+            ...(activeSpan ? { childOf: activeSpan } : {})
+        });
+
+        try {
+            let parsedInput: JsonValue = null;
+            try {
+                parsedInput = input ? JSON.parse(JSON.stringify(input)) : null;
+            } catch (err) {
+                throw new NangoError('function_failure', { error: `Execute: Failed to parse input: ${stringifyError(err)}` });
+            }
+
+            // Granular group key per (env, integration, function) so one busy function doesn't starve others.
+            const groupKey = `function:environment:${environmentId}:${providerConfigKey}:${functionName}`;
+            const executionId = `${groupKey}:at:${new Date().toISOString()}:${uuid()}`;
+            const res = (
+                await this.client.executeFunction({
+                    name: executionId,
+                    group: { key: groupKey, maxConcurrency },
+                    args: {
+                        functionName,
+                        providerConfigKey,
+                        connection: connection
+                            ? {
+                                  id: connection.id,
+                                  connection_id: connection.connection_id,
+                                  provider_config_key: connection.provider_config_key,
+                                  environment_id: connection.environment_id
+                              }
+                            : null,
+                        activityLogId: logCtx.id,
+                        trigger,
+                        input: parsedInput
+                    }
+                })
+            ).mapError((err) => deserializeNangoError(err.payload) || new NangoError('function_script_failure', { error: err.message }));
+
+            if (res.isErr()) {
+                throw res.error;
+            }
+            return res as Result<T, NangoError>;
+        } catch (err) {
+            const formattedError = err instanceof NangoError ? err : new NangoError('function_failure', { error: errorToObject(err) });
             span.setTag('error', formattedError);
             return Err(formattedError);
         } finally {

--- a/packages/shared/lib/clients/orchestrator.ts
+++ b/packages/shared/lib/clients/orchestrator.ts
@@ -382,6 +382,7 @@ export class Orchestrator {
                     args: {
                         functionName,
                         providerConfigKey,
+                        environmentId,
                         connection: connection
                             ? {
                                   id: connection.id,

--- a/packages/shared/lib/services/file/local.service.ts
+++ b/packages/shared/lib/services/file/local.service.ts
@@ -10,14 +10,15 @@ import { NangoError } from '../../utils/error.js';
 import errorManager from '../../utils/error.manager.js';
 import { resolveLocalFileName, resolveLocalFilePath } from '../../utils/utils.js';
 
-import type { DBSyncConfig, NangoProps } from '@nangohq/types';
+import type { DBSyncConfig, NangoProps, ScriptTypeLiteral } from '@nangohq/types';
 import type { Response } from 'express';
 
-const scriptTypeToPath: Record<NangoProps['scriptType'], string> = {
+const scriptTypeToPath: Record<NangoProps['scriptType'] | ScriptTypeLiteral, string> = {
     'on-event': 'on-events',
     action: 'actions',
     sync: 'syncs',
-    webhook: 'syncs'
+    webhook: 'syncs',
+    function: 'functions'
 };
 
 class LocalFileService {

--- a/packages/shared/lib/services/flow.service.ts
+++ b/packages/shared/lib/services/flow.service.ts
@@ -105,6 +105,10 @@ class FlowService {
             return null;
         }
 
+        // Functions are not part of the public catalog (StandardNangoConfig only carries syncs/actions/on-events).
+        if (type === 'function') {
+            return null;
+        }
         const flow = flows[0][`${type}s`].find((flow) => flow.name === scriptName);
         return flow || null;
     }

--- a/packages/shared/lib/services/sync/config/config.service.ts
+++ b/packages/shared/lib/services/sync/config/config.service.ts
@@ -724,6 +724,23 @@ export async function getSyncConfigRaw(opts: { environmentId: number; config_id:
     return res || null;
 }
 
+export async function getFunctionConfigRaw(opts: { environmentId: number; config_id: number; name: string }): Promise<DBSyncConfig | null> {
+    const res = await db.readOnly
+        .select<DBSyncConfig>('*')
+        .where({
+            environment_id: opts.environmentId,
+            sync_name: opts.name,
+            nango_config_id: opts.config_id,
+            active: true,
+            type: 'function',
+            deleted: false
+        })
+        .from<DBSyncConfig>(TABLE)
+        .first();
+
+    return res || null;
+}
+
 export async function getSoftDeletedSyncConfig({ limit, olderThan }: { limit: number; olderThan: number }): Promise<DBSyncConfig[]> {
     const dateThreshold = new Date();
     dateThreshold.setDate(dateThreshold.getDate() - olderThan);

--- a/packages/shared/lib/services/sync/config/deploy.service.ts
+++ b/packages/shared/lib/services/sync/config/deploy.service.ts
@@ -426,6 +426,7 @@ async function compileDeployInfo({
                 input: typeof flow.input === 'string' ? flow.input : null,
                 sync_type: flow.sync_type || null,
                 webhook_subscriptions: flow.webhookSubscriptions || [],
+                function_config: flow.function_config ?? null,
                 enabled: lastSyncWasEnabled,
                 model_schema: null,
                 models_json_schema,

--- a/packages/shared/lib/services/sync/config/deploy.service.unit.test.ts
+++ b/packages/shared/lib/services/sync/config/deploy.service.unit.test.ts
@@ -23,6 +23,7 @@ const orchestratorClientNoop: OrchestratorClientInterface = {
     executeAction: () => Promise.resolve({}) as any,
     executeActionAsync: () => Promise.resolve({}) as any,
     executeWebhook: () => Promise.resolve({}) as any,
+    executeFunction: () => Promise.resolve({}) as any,
     executeOnEvent: () => Promise.resolve({}) as any,
     executeSync: () => Promise.resolve({}) as any,
     cancel: () => Promise.resolve({}) as any,

--- a/packages/shared/lib/services/sync/sync.service.unit.test.ts
+++ b/packages/shared/lib/services/sync/sync.service.unit.test.ts
@@ -17,6 +17,7 @@ const orchestratorClientNoop: OrchestratorClientInterface = {
     executeAction: () => Promise.resolve({}) as any,
     executeActionAsync: () => Promise.resolve({}) as any,
     executeWebhook: () => Promise.resolve({}) as any,
+    executeFunction: () => Promise.resolve({}) as any,
     executeOnEvent: () => Promise.resolve({}) as any,
     executeSync: () => Promise.resolve({}) as any,
     cancel: () => Promise.resolve({}) as any,

--- a/packages/types/lib/deploy/incomingFlow.ts
+++ b/packages/types/lib/deploy/incomingFlow.ts
@@ -1,4 +1,4 @@
-import type { NangoSyncEndpointOld, NangoSyncEndpointV2, ScriptTypeLiteral, SyncTypeLiteral } from '../nangoYaml/index.js';
+import type { FunctionConfig, NangoSyncEndpointOld, NangoSyncEndpointV2, ScriptTypeLiteral, SyncTypeLiteral } from '../nangoYaml/index.js';
 import type { OnEventType } from '../scripts/on-events/api.js';
 import type { Feature } from '../syncConfigs/db.js';
 import type { JSONSchema7 } from 'json-schema';
@@ -88,6 +88,8 @@ export interface CLIDeployFlowConfig {
     /** @deprecated **/
     sync_type?: SyncTypeLiteral | undefined;
     webhookSubscriptions?: string[] | undefined;
+    /** Set only for `type: 'function'` deploys: the function's triggers + ingress/debounce config. */
+    function_config?: FunctionConfig | undefined;
     // TODO: make non-optional when nango-yaml and `schema.ts` are fully removed
     models_json_schema?: JSONSchema7 | undefined;
     features?: Feature[] | undefined;

--- a/packages/types/lib/functions/api.ts
+++ b/packages/types/lib/functions/api.ts
@@ -3,6 +3,25 @@ import type { DeployedNangoFunction, FunctionType, NangoActionFunction, NangoFun
 
 export type RunnableFunctionType = Extract<FunctionType, 'action' | 'sync'>;
 
+/**
+ * Public endpoint backing `nango.triggerFunction()`. Schedules a function run, optionally bound to
+ * a connection (omit `connection-id` for a connection-less routing run).
+ */
+export type PostPublicTriggerFunction = Endpoint<{
+    Method: 'POST';
+    Path: '/function/trigger';
+    Body: {
+        function_name: string;
+        payload?: unknown;
+    };
+    Headers: {
+        'provider-config-key': string;
+        'connection-id'?: string;
+    };
+    Error: ApiError<'unknown_provider' | 'unknown_connection' | 'not_found' | 'disabled_resource' | 'trigger_failed'>;
+    Success: { taskId: string };
+}>;
+
 export type FunctionErrorCode =
     | 'invalid_request'
     | 'integration_not_found'

--- a/packages/types/lib/nangoYaml/index.ts
+++ b/packages/types/lib/nangoYaml/index.ts
@@ -5,8 +5,13 @@ import type { JSONSchema7 } from 'json-schema';
 export type HTTP_METHOD = 'GET' | 'POST' | 'PATCH' | 'PUT' | 'DELETE';
 /** @deprecated **/
 export type SyncTypeLiteral = 'incremental' | 'full';
-export type ScriptFileType = 'actions' | 'syncs' | 'on-events' | 'post-connection-scripts'; // post-connection-scripts is deprecated
+export type ScriptFileType = 'actions' | 'syncs' | 'on-events' | 'functions' | 'webhooks' | 'post-connection-scripts'; // post-connection-scripts is deprecated
 export type ScriptTypeLiteral = 'action' | 'sync' | 'on-event';
+/**
+ * The `function` primitive is authored via `createFunction()` / `createWebhook()`. It is tracked
+ * separately from {@link ScriptTypeLiteral} (sync/action/on-event) while it is introduced additively.
+ */
+export type FunctionScriptTypeLiteral = 'function';
 
 // --------------
 // YAML V1
@@ -95,6 +100,7 @@ export interface NangoYamlParsedIntegration {
     providerConfigKey: string;
     syncs: ParsedNangoSync[];
     actions: ParsedNangoAction[];
+    functions: ParsedNangoFunction[];
     onEventScripts: Record<OnEventType, string[]>;
     /**
      * @deprecated
@@ -119,6 +125,45 @@ export interface ParsedNangoSync {
     webhookSubscriptions: string[];
     version: string;
     // TODO: make non-optional when nango-yaml is fully removed
+    json_schema?: JSONSchema7 | undefined;
+    features?: Feature[] | undefined;
+}
+
+/** Serializable view of a function trigger (the executable hooks live in the deployed file body). */
+export interface ParsedFunctionTrigger {
+    type: 'http' | 'webhook' | 'cron' | 'scheduled' | 'event' | 'manual';
+    /** http trigger: maps to the URL path segment. */
+    name?: string;
+    /** http trigger: 'integration' (default) or 'connection' for tokenized per-connection URLs. */
+    scope?: 'integration' | 'connection';
+    /** cron/scheduled trigger. */
+    schedule?: string;
+    /** event trigger. */
+    event?: string;
+    /** Whether ingress coalescing is configured (the window/key config). */
+    debounce?: {
+        key?: { body: string } | { header: string };
+        windowMs: number;
+        maxWindowMs?: number;
+        maxEntities?: number;
+        payloadMode?: 'latest' | 'all';
+    };
+    /** Whether the trigger ships an `ingressChallenge` hook (executed at ingress). */
+    hasIngressChallenge?: boolean;
+    /** Whether the trigger ships an `ingressValidation` hook (executed at ingress). */
+    hasIngressValidation?: boolean;
+}
+
+export interface ParsedNangoFunction {
+    name: string;
+    type: 'function';
+    description: string;
+    triggers: ParsedFunctionTrigger[];
+    input: string | null;
+    output: string[] | null;
+    scopes: string[];
+    usedModels: string[];
+    version: string;
     json_schema?: JSONSchema7 | undefined;
     features?: Feature[] | undefined;
 }
@@ -175,5 +220,6 @@ export interface FlowsYaml {
 }
 
 // --- flows.zero.json is a parsed nango.yaml
-export type FlowZeroJson = NangoYamlParsedIntegration & { jsonSchema?: JSONSchema7; sdkVersion: string };
+// TODO: drop the functions override once flows.zero.json is regenerated with `functions` (NAN-5943)
+export type FlowZeroJson = Omit<NangoYamlParsedIntegration, 'functions'> & { jsonSchema?: JSONSchema7; sdkVersion: string };
 export type FlowsZeroJson = FlowZeroJson[];

--- a/packages/types/lib/nangoYaml/index.ts
+++ b/packages/types/lib/nangoYaml/index.ts
@@ -6,12 +6,7 @@ export type HTTP_METHOD = 'GET' | 'POST' | 'PATCH' | 'PUT' | 'DELETE';
 /** @deprecated **/
 export type SyncTypeLiteral = 'incremental' | 'full';
 export type ScriptFileType = 'actions' | 'syncs' | 'on-events' | 'functions' | 'webhooks' | 'post-connection-scripts'; // post-connection-scripts is deprecated
-export type ScriptTypeLiteral = 'action' | 'sync' | 'on-event';
-/**
- * The `function` primitive is authored via `createFunction()` / `createWebhook()`. It is tracked
- * separately from {@link ScriptTypeLiteral} (sync/action/on-event) while it is introduced additively.
- */
-export type FunctionScriptTypeLiteral = 'function';
+export type ScriptTypeLiteral = 'action' | 'sync' | 'on-event' | 'function';
 
 // --------------
 // YAML V1
@@ -166,6 +161,15 @@ export interface ParsedNangoFunction {
     version: string;
     json_schema?: JSONSchema7 | undefined;
     features?: Feature[] | undefined;
+}
+
+/**
+ * Function-specific configuration persisted alongside a deployed function (in `_nango_sync_configs.function_config`).
+ * Captures what makes a function distinct from a sync/action: its triggers (and their ingress/debounce config).
+ */
+export interface FunctionConfig {
+    name?: string | undefined;
+    triggers: ParsedFunctionTrigger[];
 }
 
 export interface ParsedNangoAction {

--- a/packages/types/lib/nangoYaml/index.ts
+++ b/packages/types/lib/nangoYaml/index.ts
@@ -128,25 +128,27 @@ export interface ParsedNangoSync {
 export interface ParsedFunctionTrigger {
     type: 'http' | 'webhook' | 'cron' | 'scheduled' | 'event' | 'manual';
     /** http trigger: maps to the URL path segment. */
-    name?: string;
+    name?: string | undefined;
     /** http trigger: 'integration' (default) or 'connection' for tokenized per-connection URLs. */
-    scope?: 'integration' | 'connection';
+    scope?: 'integration' | 'connection' | undefined;
     /** cron/scheduled trigger. */
-    schedule?: string;
+    schedule?: string | undefined;
     /** event trigger. */
-    event?: string;
+    event?: string | undefined;
     /** Whether ingress coalescing is configured (the window/key config). */
-    debounce?: {
-        key?: { body: string } | { header: string };
-        windowMs: number;
-        maxWindowMs?: number;
-        maxEntities?: number;
-        payloadMode?: 'latest' | 'all';
-    };
+    debounce?:
+        | {
+              key?: { body: string } | { header: string } | undefined;
+              windowMs: number;
+              maxWindowMs?: number | undefined;
+              maxEntities?: number | undefined;
+              payloadMode?: 'latest' | 'all' | undefined;
+          }
+        | undefined;
     /** Whether the trigger ships an `ingressChallenge` hook (executed at ingress). */
-    hasIngressChallenge?: boolean;
+    hasIngressChallenge?: boolean | undefined;
     /** Whether the trigger ships an `ingressValidation` hook (executed at ingress). */
-    hasIngressValidation?: boolean;
+    hasIngressValidation?: boolean | undefined;
 }
 
 export interface ParsedNangoFunction {

--- a/packages/types/lib/runner/sdk.ts
+++ b/packages/types/lib/runner/sdk.ts
@@ -18,7 +18,7 @@ export type ScriptType = 'sync' | 'action' | 'webhook' | 'on-event' | 'function'
  * as its second argument. Absent for non-function script types.
  */
 export interface NangoFunctionEventProps {
-    trigger: { type: 'http' | 'webhook' | 'cron' | 'scheduled' | 'event' | 'manual'; name?: string | undefined };
+    trigger: { type: 'http' | 'webhook' | 'cron' | 'scheduled' | 'event' | 'manual'; name?: string | null | undefined };
     payload?: unknown;
     headers?: Record<string, string> | undefined;
     rawBody?: string | undefined;

--- a/packages/types/lib/runner/sdk.ts
+++ b/packages/types/lib/runner/sdk.ts
@@ -11,7 +11,19 @@ export interface SdkLogger {
 
 export type ConflictResolutionMode = 'IN_MEMORY' | 'REDIS';
 
-export type ScriptType = 'sync' | 'action' | 'webhook' | 'on-event';
+export type ScriptType = 'sync' | 'action' | 'webhook' | 'on-event' | 'function';
+
+/**
+ * The event a function run is started with. The runner exposes this to the customer's `exec`
+ * as its second argument. Absent for non-function script types.
+ */
+export interface NangoFunctionEventProps {
+    trigger: { type: 'http' | 'webhook' | 'cron' | 'scheduled' | 'event' | 'manual'; name?: string | undefined };
+    payload?: unknown;
+    headers?: Record<string, string> | undefined;
+    rawBody?: string | undefined;
+    coalesced?: { count: number; firstSeenAt: string; lastSeenAt: string; overflowed: boolean } | undefined;
+}
 
 export interface NangoProps {
     scriptType: ScriptType;
@@ -51,6 +63,10 @@ export interface NangoProps {
         | undefined;
     isCLI?: boolean | undefined;
     integrationConfig?: IntegrationConfigForProxy;
+    /** Set for `scriptType: 'function'` runs; carries the trigger + payload the run was started with. */
+    functionEvent?: NangoFunctionEventProps | undefined;
+    /** True when the run was started with a bound connection (connection-level URL, triggerFunction({connectionId}), CLI --connection). */
+    connectionBound?: boolean | undefined;
 
     axios?: {
         request?: AxiosInterceptorManager<AxiosRequestConfig>;

--- a/packages/types/lib/syncConfigs/db.ts
+++ b/packages/types/lib/syncConfigs/db.ts
@@ -1,6 +1,6 @@
 import type { TimestampsAndDeleted } from '../db.js';
 import type { LegacySyncModelSchema, NangoConfigMetadata } from '../deploy/incomingFlow.js';
-import type { NangoModel, ScriptTypeLiteral, SyncTypeLiteral } from '../nangoYaml/index.js';
+import type { FunctionConfig, NangoModel, ScriptTypeLiteral, SyncTypeLiteral } from '../nangoYaml/index.js';
 import type { JSONSchema7 } from 'json-schema';
 
 export type Feature = 'checkpoints';
@@ -32,5 +32,7 @@ export interface DBSyncConfig extends TimestampsAndDeleted {
     models_json_schema: JSONSchema7 | null;
     sdk_version: string | null;
     features: Feature[];
+    /** Set only for `type: 'function'` rows; null for sync/action/on-event. */
+    function_config?: FunctionConfig | null;
 }
 export type DBSyncConfigInsert = Omit<DBSyncConfig, 'id'>;

--- a/packages/utils/lib/checkpoint/checkpoint.ts
+++ b/packages/utils/lib/checkpoint/checkpoint.ts
@@ -1,3 +1,3 @@
-export function getCheckpointKey(opts: { type: 'sync' | 'webhook' | 'action' | 'on-event'; name: string; variant?: string | undefined }) {
+export function getCheckpointKey(opts: { type: 'sync' | 'webhook' | 'action' | 'on-event' | 'function'; name: string; variant?: string | undefined }) {
     return `${opts.type}:${opts.name}${opts.variant ? `:${opts.variant}` : ''}`;
 }


### PR DESCRIPTION
Connection-less function runs (e.g. integration-level webhooks) need to find the connection(s) an event targets and to drop unmatched events cleanly.

- searchConnections({ tags }): server-side tag-filtered lookup via the existing connections list endpoint, scoped to the function's integration by default. The { subscriptions } path throws a clear error until webhook_subscriptions (NAN-5886) lands.
- ignore(reason?): drops the event and records the reason on the run's activity log.

Both are concrete methods on NangoActionBase, available in any function/action exec. forward(), getConnection(connectionId?) and triggerSync(connectionId, ...) are connection-context-coupled and land with NAN-5891.

<!-- Describe the problem and your solution --> 

<!-- Issue ticket number and link (if applicable) -->

<!-- Testing instructions (skip if just adding/editing providers) -->

