### PR TITLE
feat(webapp): enable dev tools panel on staging

### DIFF
--- a/packages/webapp/src/features/DevToolPanel.tsx
+++ b/packages/webapp/src/features/DevToolPanel.tsx
@@ -12,9 +12,13 @@ import { useFeatureFlagsStore } from '@/store/feature-flags';
  * True when the dev tool panel is available based on the current hostname:
  * - local Vite dev server
  * - *.app-development.nango.dev (development deployment and PR previews)
+ * - app-staging.nango.dev (staging deployment)
  */
 const isDevToolsEnabledByHostname =
-    import.meta.env.DEV || window.location.hostname === 'app-development.nango.dev' || window.location.hostname.endsWith('.app-development.nango.dev');
+    import.meta.env.DEV ||
+    window.location.hostname === 'app-development.nango.dev' ||
+    window.location.hostname.endsWith('.app-development.nango.dev') ||
+    window.location.hostname === 'app-staging.nango.dev';
 
 /**
  * Returns true when the dev tool panel should be available — either on a dev


### PR DESCRIPTION
## Problem

The webapp dev tools panel (feature-flag toggles, theme switcher) is only available on dev deploys and to the production admin account. Anyone testing on staging has no way to flip feature flags, so staging can't be used to validate flag-gated behavior for a non-admin account.

## Solution

Add `app-staging.nango.dev` to the hostname allowlist in `DevToolPanel.tsx`. The hostname check is account-independent, so this enables the panel for any account on staging — matching existing dev-deploy behavior. The production admin path (`isAdminTeam`) is untouched.

Fixes [NAN-5947](https://linear.app/nango/issue/NAN-5947)

## Testing

- On `app-staging.nango.dev`, sign in with any account and press `Ctrl+Shift+D` → the Dev Tools panel appears.
- On `app.nango.dev`, a non-admin account still has no panel (admin team only); dev deploys and `*.app-development.nango.dev` PR previews continue to work.
