### PR TITLE
fix(webapp): preserve theme and flags on logout

### DIFF
--- a/packages/webapp/src/utils/local-storage.tsx
+++ b/packages/webapp/src/utils/local-storage.tsx
@@ -28,8 +28,18 @@ class LocalStorage implements PersistentStorage {
         }
     }
 
-    clear() {
-        localStorage.clear();
+    /**
+     * Remove session-scoped data on logout. Preferences such as theme and
+     * feature flags are stored in localStorage too but must survive logout, so
+     * we remove only the keys classified as 'session' in KEY_CATEGORY rather
+     * than wiping everything (the previous `localStorage.clear()`).
+     */
+    clearSession() {
+        for (const [key, category] of Object.entries(KEY_CATEGORY)) {
+            if (category === 'session') {
+                localStorage.removeItem(key);
+            }
+        }
     }
 }
 
@@ -43,6 +53,31 @@ export enum LocalStorageKeys {
     FeatureFlags = 'nango_feature_flags',
     Theme = 'nango_theme'
 }
+
+/**
+ * Classifies every localStorage key so logout knows what to remove:
+ *   - 'session'    — data tied to the signed-in user; cleared on logout.
+ *   - 'preference' — user/device preferences; preserved across logout.
+ *
+ * Typing this as `Record<LocalStorageKeys, ...>` makes it a compile-time guard:
+ * adding a new key to the enum without categorizing it here breaks the build,
+ * so logout can never silently wipe a preference or retain stale session data.
+ *
+ * `Playground` is persisted to sessionStorage (see store/playground.ts), so
+ * removing it from localStorage on logout is a no-op. Whether logout should also
+ * reset the sessionStorage playground state is an open question, intentionally
+ * left as-is for now.
+ */
+const KEY_CATEGORY: Record<LocalStorageKeys, 'session' | 'preference'> = {
+    [LocalStorageKeys.UserEmail]: 'session',
+    [LocalStorageKeys.UserName]: 'session',
+    [LocalStorageKeys.UserId]: 'session',
+    [LocalStorageKeys.AccountId]: 'session',
+    [LocalStorageKeys.LastEnvironment]: 'session',
+    [LocalStorageKeys.Playground]: 'session',
+    [LocalStorageKeys.FeatureFlags]: 'preference',
+    [LocalStorageKeys.Theme]: 'preference'
+};
 
 const storage = new LocalStorage();
 export default storage;

--- a/packages/webapp/src/utils/local-storage.tsx
+++ b/packages/webapp/src/utils/local-storage.tsx
@@ -55,18 +55,12 @@ export enum LocalStorageKeys {
 }
 
 /**
- * Classifies every localStorage key so logout knows what to remove:
- *   - 'session'    — data tied to the signed-in user; cleared on logout.
- *   - 'preference' — user/device preferences; preserved across logout.
+ * Categorizes each key for logout: 'session' keys are cleared, 'preference'
+ * keys (theme, feature flags) survive. The Record type forces every key to be
+ * classified, so a new one can't accidentally skip this decision.
  *
- * Typing this as `Record<LocalStorageKeys, ...>` makes it a compile-time guard:
- * adding a new key to the enum without categorizing it here breaks the build,
- * so logout can never silently wipe a preference or retain stale session data.
- *
- * `Playground` is persisted to sessionStorage (see store/playground.ts), so
- * removing it from localStorage on logout is a no-op. Whether logout should also
- * reset the sessionStorage playground state is an open question, intentionally
- * left as-is for now.
+ * Playground lives in sessionStorage, so clearing it here is a no-op (whether
+ * logout should reset that state is left open).
  */
 const KEY_CATEGORY: Record<LocalStorageKeys, 'session' | 'preference'> = {
     [LocalStorageKeys.UserEmail]: 'session',

--- a/packages/webapp/src/utils/local-storage.tsx
+++ b/packages/webapp/src/utils/local-storage.tsx
@@ -59,8 +59,8 @@ export enum LocalStorageKeys {
  * keys (theme, feature flags) survive. The Record type forces every key to be
  * classified, so a new one can't accidentally skip this decision.
  *
- * Playground lives in sessionStorage, so clearing it here is a no-op (whether
- * logout should reset that state is left open).
+ * Playground lives in sessionStorage, so clearing it here is a no-op; logout
+ * resets it separately via resetPlayground() (see useSignout).
  */
 const KEY_CATEGORY: Record<LocalStorageKeys, 'session' | 'preference'> = {
     [LocalStorageKeys.UserEmail]: 'session',

--- a/packages/webapp/src/utils/user.tsx
+++ b/packages/webapp/src/utils/user.tsx
@@ -27,7 +27,7 @@ export function useSignout() {
     const { mutateAsync: logoutAPI } = useLogoutAPI();
 
     return async () => {
-        storage.clear();
+        storage.clearSession();
         analyticsReset();
         await logoutAPI(); // Destroy server session.
 


### PR DESCRIPTION
## Problem

Logging out reset the user's interface preferences — their light/dark theme choice and locally stored feature flags — back to defaults. The same reset also fired on any expired/invalid session, since any API call returning `401` triggers an automatic sign-out (SWR `onError` → `signout`).

Root cause: `useSignout` called `storage.clear()`, which is a blanket `localStorage.clear()`. Theme (`nango_theme`) and feature flags (`nango_feature_flags`) live in the same localStorage namespace as auth/session data, so they were wiped alongside it. Both are device/user-level preferences that should outlive a session.

## Solution

Replace the blanket clear with a selective `clearSession()` that removes only session-scoped keys:

- A `Record<LocalStorageKeys, 'session' | 'preference'>` map classifies every key. The `Record` index signature makes it a **compile-time guard** — adding a new key to the enum without categorizing it breaks the build, so logout can never silently wipe a preference or retain stale session data.
- `session` (cleared): user identity + `nango_last_environment`. `preference` (preserved): theme + feature flags.

Fixes [NAN-5950](https://linear.app/nango/issue/NAN-5950)

### Behavior change: we no longer wipe all of localStorage

Since we stopped calling `localStorage.clear()`, I audited everything that could be left behind. Nothing sensitive is:

- **First-party**: the only other localStorage key is `nango.billingUsageSource`, a dev-only console override — not user data. No auth token/session secret is stored in localStorage; the session is a server-side cookie destroyed by `logoutAPI()`.
- **PostHog**: identity is reset by `posthog.reset()` in the same signout (`analyticsReset()`) — the SDK's canonical logout call, independent of the blanket clear we removed.
- **Sentry**: user context is in-memory and wiped by the full `window.location.href = '/signin'` reload.
- **Stripe**: only `__stripe_mid` / `__stripe_sid` device fraud identifiers — not secrets; Stripe recommends keeping them.

The meaningful cleanup (server session, analytics identity, in-memory state + query cache) never depended on `localStorage.clear()`, so removing it doesn't open a gap.

## Testing

- `tsc` and `eslint` pass on the changed files.
- Manual verification still pending (draft): set theme to light + toggle a feature flag → log out → land on `/signin` with theme preserved → re-login and confirm theme + flags intact. Repeat for a `401`-triggered auto sign-out.
