### PR TITLE
fix(webapp): de-conflict breakdown chart colors

### DIFF
--- a/packages/webapp/src/components/patterns/chart/index.ts
+++ b/packages/webapp/src/components/patterns/chart/index.ts
@@ -1,4 +1,4 @@
 export { ChartCard } from './ChartCard';
-export { REST_SERIES_COLOR, REST_SERIES_KEY, colorForValue } from './usageChartColors';
+export { REST_SERIES_COLOR, REST_SERIES_KEY } from './usageChartColors';
 
 export type { ChartSeries } from './types';

--- a/packages/webapp/src/components/patterns/chart/usageChartColors.ts
+++ b/packages/webapp/src/components/patterns/chart/usageChartColors.ts
@@ -1,8 +1,8 @@
 /**
  * Categorical palette for usage breakdown charts: the design-system chart hues
  * (--color-chart-series-*) plus a few interim hex extras, ordered most-distinct-
- * first (one color per top-N series). Colors cycle once exhausted; the 'rest'
- * rollup renders neutral slate, outside this palette.
+ * first (one color per top-N series). The 'rest' rollup renders neutral slate,
+ * outside this palette.
  *
  * The raw hex extras are interim — to be promoted to design-system
  * --chart-series-* tokens (with light/dark theming) in a follow-up: NAN-5927.
@@ -30,32 +30,87 @@ export const REST_SERIES_COLOR = '#64748b'; // muted slate — neutral for the l
 const SUCCESS_SERIES_COLOR = 'var(--color-icon-success)';
 const FAILED_SERIES_COLOR = 'var(--color-icon-danger)';
 
-// Stable value → color map, shared across every breakdown chart on the page so the
-// SAME dimension value (e.g. integration "attio") always gets the SAME color —
-// otherwise colors assigned by per-chart rank make different integrations share a
-// color across charts, which reads as "the same thing". Colors are handed out in
-// first-seen order and cycle once the palette is exhausted.
-const colorByValue = new Map<string, string>();
+// Color assignment for breakdown series, kept PER DIMENSION (integration_id, model, …).
+//
+// Why per-dimension:
+//   • Same value → same color everywhere: integration "attio" is one color across every chart
+//     on the page, which is what makes a breakdown readable.
+//   • Dimensions don't share palette slots: a chart sliced by integration can't be pushed off
+//     the palette by the model/connection values shown elsewhere.
+//
+// How clashes are avoided:
+//   • Within a dimension, colors are handed out in first-seen order. With ≤10 distinct values
+//     (the common case) every value gets its own color, so no chart can clash.
+//   • Past 10 values the palette is exhausted and two values share a color; colorsForValues()
+//     then de-conflicts them per chart (see below), so a clash is never visible inside a single
+//     chart. The only trade-off: a bumped tail value may show a different color in the one chart
+//     where it collided.
+const colorByDimension = new Map<string, Map<string, string>>();
 
-/**
- * Color for a breakdown series value. The Status dimension gets the semantic
- * red/green from the logs screen; every other dimension gets a stable palette
- * color (same value → same color across all charts in the session).
- */
-export function colorForValue(value: string, dimension?: string): string {
-    if (dimension === 'success') {
-        return value === 'Failed' ? FAILED_SERIES_COLOR : SUCCESS_SERIES_COLOR;
+/** The stable (preferred) color for a value within its dimension, assigning one on first sight. */
+function preferredColor(value: string, dimensionKey: string): string {
+    let assigned = colorByDimension.get(dimensionKey);
+    if (!assigned) {
+        assigned = new Map<string, string>();
+        colorByDimension.set(dimensionKey, assigned);
     }
-    const existing = colorByValue.get(value);
+    const existing = assigned.get(value);
     if (existing) {
         return existing;
     }
-    const color = SERIES_COLORS[colorByValue.size % SERIES_COLORS.length];
-    colorByValue.set(value, color);
+    const color = SERIES_COLORS[assigned.size % SERIES_COLORS.length];
+    assigned.set(value, color);
     return color;
 }
 
-/** Test-only: clear the cross-chart color assignments so unit tests aren't order-dependent. */
+/**
+ * Colors for one chart's breakdown series, keyed by value. Guarantees that no two values in
+ * the SAME chart share a color (the palette has one slot per top-N series), while keeping each
+ * value's color stable across charts via the per-dimension assignment above. Pass the values
+ * in display (rank) order so the largest series win ties.
+ *
+ * The Status ('success') dimension is special: it gets the semantic red/green from the logs
+ * screen and is never de-conflicted (only two values, each with a fixed meaning).
+ */
+export function colorsForValues(values: string[], dimension?: string): Map<string, string> {
+    if (dimension === 'success') {
+        return new Map(values.map((value) => [value, value === 'Failed' ? FAILED_SERIES_COLOR : SUCCESS_SERIES_COLOR]));
+    }
+
+    const dimensionKey = dimension ?? '';
+    const result = new Map<string, string>();
+    const usedInChart = new Set<string>();
+
+    // Pass 1: give each value its stable (cross-chart) color where that color is still free in
+    // this chart. Higher-ranked values come first, so they win ties.
+    for (const value of values) {
+        if (result.has(value)) continue; // duplicate label — already resolved, don't take a second slot
+        const preferred = preferredColor(value, dimensionKey);
+        if (!usedInChart.has(preferred)) {
+            result.set(value, preferred);
+            usedInChart.add(preferred);
+        }
+    }
+
+    // Pass 2: any value whose stable color was already taken in this chart (only possible once
+    // the dimension has >10 distinct values) is bumped to the next free palette color. This is
+    // local to the chart — the per-dimension assignment is left untouched, so other charts keep
+    // the value's stable color.
+    for (const value of values) {
+        if (result.has(value)) continue;
+        const free = SERIES_COLORS.find((color) => !usedInChart.has(color));
+        // With top-N (DEFAULT_TOP_N) == palette size (10) a free color always exists here. The
+        // fallback only triggers if a future top-N exceeds the palette, in which case within-
+        // chart uniqueness can no longer be guaranteed and the palette repeats.
+        const color = free ?? SERIES_COLORS[result.size % SERIES_COLORS.length];
+        result.set(value, color);
+        usedInChart.add(color);
+    }
+
+    return result;
+}
+
+/** Test-only: clear the per-dimension color assignments so unit tests aren't order-dependent. */
 export function resetUsageChartColorsForTests(): void {
-    colorByValue.clear();
+    colorByDimension.clear();
 }

--- a/packages/webapp/src/components/patterns/chart/usageChartColors.unit.test.ts
+++ b/packages/webapp/src/components/patterns/chart/usageChartColors.unit.test.ts
@@ -1,45 +1,92 @@
 import { beforeEach, describe, expect, it } from 'vitest';
 
-import { colorForValue, resetUsageChartColorsForTests } from './usageChartColors.js';
+import { colorsForValues, resetUsageChartColorsForTests } from './usageChartColors.js';
 
-describe('colorForValue', () => {
+describe('colorsForValues', () => {
     beforeEach(() => resetUsageChartColorsForTests());
 
     describe('success dimension', () => {
         it('uses the semantic danger color for Failed and success color for everything else', () => {
-            expect(colorForValue('Failed', 'success')).toBe('var(--color-icon-danger)');
-            expect(colorForValue('Success', 'success')).toBe('var(--color-icon-success)');
+            const colors = colorsForValues(['Failed', 'Success'], 'success');
+            expect(colors.get('Failed')).toBe('var(--color-icon-danger)');
+            expect(colors.get('Success')).toBe('var(--color-icon-success)');
         });
 
         it('does not consume palette slots (so it never affects other dimensions)', () => {
-            colorForValue('Failed', 'success');
-            colorForValue('Success', 'success');
-            // First palette dimension value still gets the first palette color.
-            expect(colorForValue('first')).toBe(colorForValue('first'));
-            expect(colorForValue('second')).not.toBe(colorForValue('first'));
+            colorsForValues(['Failed', 'Success'], 'success');
+            // The first palette dimension value still gets the first palette color.
+            const colors = colorsForValues(['first', 'second'], 'integration_id');
+            const reference = colorsForValues(['first'], 'integration_id');
+            expect(colors.get('first')).toBe(reference.get('first'));
+            expect(colors.get('first')).not.toBe(colors.get('second'));
         });
     });
 
     describe('palette dimensions', () => {
-        it('returns the same color for the same value (stable across charts)', () => {
-            expect(colorForValue('attio')).toBe(colorForValue('attio'));
+        it('returns the same color for the same value across charts (stable)', () => {
+            const first = colorsForValues(['attio'], 'integration_id').get('attio');
+            const second = colorsForValues(['attio'], 'integration_id').get('attio');
+            expect(first).toBe(second);
         });
 
-        it('assigns distinct colors to the first 10 distinct values', () => {
-            const colors = Array.from({ length: 10 }, (_, i) => colorForValue(`v${i}`));
-            expect(new Set(colors).size).toBe(10);
+        it('gives every series in a single 10-value chart a distinct color', () => {
+            const values = Array.from({ length: 10 }, (_, i) => `v${i}`);
+            const colors = colorsForValues(values, 'integration_id');
+            expect(new Set(colors.values()).size).toBe(10);
         });
 
-        it('cycles the palette once exhausted (the 11th value reuses the 1st color)', () => {
-            const first = colorForValue('v0');
-            for (let i = 1; i < 10; i++) colorForValue(`v${i}`);
-            expect(colorForValue('v10')).toBe(first);
+        it('scopes assignments per dimension (the first value in each dimension gets the first color)', () => {
+            const integration = colorsForValues(['acme'], 'integration_id').get('acme');
+            const model = colorsForValues(['gpt-4'], 'model').get('gpt-4');
+            expect(integration).toBe(model);
+        });
+
+        it('maps a duplicated label to a single color without consuming two slots', () => {
+            const colors = colorsForValues(['a', 'a', 'b'], 'integration_id');
+            expect(colors.get('a')).not.toBe(colors.get('b'));
+            expect(colors.size).toBe(2);
+        });
+
+        describe('de-confliction past the palette size', () => {
+            // Exhaust the palette so two values (v0 and v10) share a stable color, then chart them together.
+            beforeEach(() =>
+                colorsForValues(
+                    Array.from({ length: 11 }, (_, i) => `v${i}`),
+                    'integration_id'
+                )
+            );
+
+            it('keeps colors distinct within a chart even when two values share a stable color', () => {
+                const colors = colorsForValues(['v0', 'v10'], 'integration_id');
+                expect(colors.get('v0')).not.toBe(colors.get('v10'));
+            });
+
+            it('keeps the higher-ranked value on its stable color and bumps the lower-ranked one', () => {
+                const stableV0 = colorsForValues(['v0'], 'integration_id').get('v0');
+                // v0 is listed first (higher rank), so it keeps its stable color; v10 is bumped.
+                const colors = colorsForValues(['v0', 'v10'], 'integration_id');
+                expect(colors.get('v0')).toBe(stableV0);
+                expect(colors.get('v10')).not.toBe(stableV0);
+            });
+
+            it('does not bump a value in a chart where its stable color is free', () => {
+                const stableV10 = colorsForValues(['v10'], 'integration_id').get('v10');
+                // Without the colliding v0 present, v10 keeps its stable color.
+                expect(stableV10).toBe(colorsForValues(['v10'], 'integration_id').get('v10'));
+            });
+        });
+
+        it('does not throw when a chart has more values than the palette', () => {
+            const values = Array.from({ length: 13 }, (_, i) => `v${i}`);
+            expect(() => colorsForValues(values, 'integration_id')).not.toThrow();
+            // The 10 palette colors are all used; beyond that the palette necessarily repeats.
+            expect(new Set(colorsForValues(values, 'integration_id').values()).size).toBe(10);
         });
     });
 
     it('reset clears assignments so a fresh value takes the first slot again', () => {
-        const firstSlot = colorForValue('alpha');
+        const firstSlot = colorsForValues(['alpha'], 'integration_id').get('alpha');
         resetUsageChartColorsForTests();
-        expect(colorForValue('beta')).toBe(firstSlot);
+        expect(colorsForValues(['beta'], 'integration_id').get('beta')).toBe(firstSlot);
     });
 });

--- a/packages/webapp/src/pages/Team/Billing/usageChartSeries.ts
+++ b/packages/webapp/src/pages/Team/Billing/usageChartSeries.ts
@@ -1,5 +1,5 @@
 import { formatDimensionValue } from './usageBreakdown';
-import { REST_SERIES_COLOR, REST_SERIES_KEY, colorForValue } from '../../../components/patterns/chart/usageChartColors';
+import { REST_SERIES_COLOR, REST_SERIES_KEY, colorsForValues } from '../../../components/patterns/chart/usageChartColors';
 
 import type { AnyBreakdownDimension } from './usageBreakdown';
 import type { ChartSeries } from '../../../components/patterns/chart/types';
@@ -8,9 +8,12 @@ import type { BillingUsageMetric } from '@nangohq/types';
 /** Map breakdown entries to stacked chart series: largest usage first, with the 'rest' rollup last. */
 export function toChartSeries(entries: BillingUsageMetric[], dimension: AnyBreakdownDimension): ChartSeries[] {
     const ranked = entries.filter((e) => !e.isRest).sort((a, b) => b.total - a.total);
+    const labels = ranked.map((entry) => (entry.group ? formatDimensionValue(dimension, entry.group.value) : '—'));
+    // Resolve all of this chart's colors at once so no two series share a color (see colorsForValues).
+    const colors = colorsForValues(labels, dimension);
     const series: ChartSeries[] = ranked.map((entry, i) => {
-        const label = entry.group ? formatDimensionValue(dimension, entry.group.value) : '—';
-        return { key: `s${i}`, color: colorForValue(label, dimension), label, usage: entry.usage };
+        const label = labels[i];
+        return { key: `s${i}`, color: colors.get(label) ?? REST_SERIES_COLOR, label, usage: entry.usage };
     });
     const rest = entries.find((e) => e.isRest);
     if (rest) {

--- a/packages/webapp/src/pages/Team/Billing/usageChartSeries.unit.test.ts
+++ b/packages/webapp/src/pages/Team/Billing/usageChartSeries.unit.test.ts
@@ -18,7 +18,7 @@ function entry({ value, total, isRest }: { value?: string; total: number; isRest
 }
 
 describe('toChartSeries', () => {
-    // colorForValue keeps a module-level value→color map; reset it so color assertions aren't order-dependent.
+    // Color assignment keeps a per-dimension module-level map; reset it so color assertions aren't order-dependent.
     beforeEach(() => resetUsageChartColorsForTests());
 
     it('ranks named series by total descending and keys them s0, s1, …', () => {


### PR DESCRIPTION
## Problem

Usage breakdown charts color each series from a fixed 10-color palette. Colors were handed out by a single global map shared across **every chart and every dimension**, cycling once the palette was exhausted. Once more than 10 distinct values had been seen anywhere on the page, two series **in the same chart** could get the same color — e.g. `google-calendar` and `slack` both rendered cyan on Function runs. It surfaced sporadically because the assignment depended on the order charts loaded.

## Solution

Assign colors **per dimension** and de-conflict **per chart**:

- Each dimension (integration, model, …) gets its own value→color map, so integrations no longer compete for palette slots with model/connection values, and a value keeps a stable color across charts.
- `colorsForValues()` resolves a whole chart's colors at once: each value prefers its stable color, and any collision within that chart is bumped to the next free palette color. Since top-N (10) equals the palette size (10), no two series in a chart can share a color.

Trade-off: for a dimension with **more than 10 distinct values**, a low-ranked tail value may show a different color in the one chart where it collides with a higher-ranked value. Removing that residual needs a larger palette — tracked in NAN-5927.

Fixes [NAN-5926](https://linear.app/nango/issue/NAN-5926)

## Testing

- Unit tests (`usageChartColors.unit.test.ts`, `usageChartSeries.unit.test.ts`): within-chart uniqueness, per-dimension isolation, cross-chart stability, de-confliction past the palette, success-dimension bypass, duplicate-label handling.
- Verified live against the **prod API** (Team → Billing, all metrics split by integration) on an account with >10 integrations: `google-calendar` and `slack` are distinct on Function runs across repeated reloads, every chart's colors are unique, and the same integration keeps its color across charts.

## Screenshots

**Before — clash (production):** `google-calendar` and `slack` both cyan on Function runs

<img width="858" height="438" alt="image" src="https://github.com/user-attachments/assets/c9937bba-ba72-4e71-87d9-a1ecb3835400" />


**After — fixed:** `google-calendar` cyan, `slack` amber — distinct

<img width="855" height="437" alt="image" src="https://github.com/user-attachments/assets/c363a6e0-6d2b-4772-9323-3a64c83fdecb" />


**Edge case (>10 integrations):** a tail value (`slack`) is bumped to a different color in the one chart where it collides (Sync records), while staying stable elsewhere

<img width="872" height="458" alt="image" src="https://github.com/user-attachments/assets/4c20559e-b3aa-4767-a335-6e1e55ecb7c1" />

