### PR TITLE
feat(usage): Clickhouse capping read primitive

### DIFF
--- a/packages/usage/lib/clickhouse/clickhouse.integration.test.ts
+++ b/packages/usage/lib/clickhouse/clickhouse.integration.test.ts
@@ -798,6 +798,83 @@ describe('Clickhouse', () => {
             await client.close();
         });
     });
+
+    describe('getCurrentMonthBillingMetrics', () => {
+        const accountId = 4242;
+        const now = new Date();
+        const monthStart = new Date(Date.UTC(now.getUTCFullYear(), now.getUTCMonth(), 1));
+        const inMonth = new Date(monthStart.getTime() + 12 * 60 * 60 * 1000); // first day at noon UTC
+        const prevMonth = new Date(monthStart.getTime() - 24 * 60 * 60 * 1000); // 24h before month start
+
+        beforeAll(async () => {
+            await cleanup();
+            clickhouse.addRaw([
+                // proxy: 100 in current month, 999 in prev month (must be excluded), 50 on another account
+                ...genEventsN({ n: 100, date: inMonth, type: 'usage.proxy', accountId, attributes: { success: true } }),
+                ...genEventsN({ n: 999, date: prevMonth, type: 'usage.proxy', accountId, attributes: { success: true } }),
+                ...genEventsN({ n: 50, date: inMonth, type: 'usage.proxy', accountId: 9999, attributes: { success: true } }),
+                // function_executions: 3 events this month
+                ...genEventsN({
+                    n: 3,
+                    date: inMonth,
+                    type: 'usage.function_executions',
+                    accountId,
+                    attributes: { type: 'sync', telemetryBag: { durationMs: 100, customLogs: 5, proxyCalls: 0, memoryGb: 2 } }
+                }),
+                // webhook_forwards: 5 this month
+                ...genEventsN({ n: 5, date: inMonth, type: 'usage.webhook_forward', accountId, attributes: { success: true } })
+            ]);
+            await clickhouse.flush();
+        });
+
+        it('returns calendar-month-to-date totals for every COUNTER metric, scoped to the account', async () => {
+            const res = await clickhouse.getCurrentMonthBillingMetrics(accountId, now);
+            const usage = res.unwrap();
+
+            // proxy: SUM(value) over 100 events with value=1 → 100.
+            expect(usage.proxy?.total).toBe(100);
+            // function_executions / _logs / _compute_gbms all derived from the 3 seeded function events.
+            // value=1, customLogs=5, durationMs=100 each.
+            expect(usage.function_executions?.total).toBe(3);
+            expect(usage.function_logs?.total).toBe(15); // SUM(custom_logs) = 3 * 5
+            expect(usage.function_compute_gbms?.total).toBe(300); // SUM(duration_ms) = 3 * 100
+            expect(usage.webhook_forwards?.total).toBe(5);
+
+            // AVG metrics aren't in the response — capping reads connections/records from Postgres.
+            expect(usage.records).toBeUndefined();
+            expect(usage.connections).toBeUndefined();
+        });
+
+        it('excludes events from the previous calendar month', async () => {
+            const res = await clickhouse.getCurrentMonthBillingMetrics(accountId, now);
+            // 100 (this month) + 999 (prev month, excluded) → 100 if window is right
+            expect(res.unwrap().proxy?.total).toBe(100);
+        });
+
+        it('returns zeros for an account with no events', async () => {
+            const res = await clickhouse.getCurrentMonthBillingMetrics(8888, now);
+            const usage = res.unwrap();
+            expect(usage.proxy?.total).toBe(0);
+            expect(usage.function_executions?.total).toBe(0);
+            expect(usage.webhook_forwards?.total).toBe(0);
+            expect(usage.function_logs?.total).toBe(0);
+            expect(usage.function_compute_gbms?.total).toBe(0);
+        });
+
+        it('returns zeros for unused metrics on a partially active account', async () => {
+            const partialAccount = 7777;
+            // Only seed `proxy` for this account — every other metric must come back as total=0.
+            clickhouse.addRaw([...genEventsN({ n: 7, date: inMonth, type: 'usage.proxy', accountId: partialAccount, attributes: { success: true } })]);
+            await clickhouse.flush();
+
+            const usage = (await clickhouse.getCurrentMonthBillingMetrics(partialAccount, now)).unwrap();
+            expect(usage.proxy?.total).toBe(7);
+            expect(usage.function_executions?.total).toBe(0);
+            expect(usage.function_logs?.total).toBe(0);
+            expect(usage.function_compute_gbms?.total).toBe(0);
+            expect(usage.webhook_forwards?.total).toBe(0);
+        });
+    });
 });
 
 function dayFromNow(dayOffset = 0): Date {

--- a/packages/usage/lib/clickhouse/clickhouse.ts
+++ b/packages/usage/lib/clickhouse/clickhouse.ts
@@ -2,6 +2,7 @@ import { ENVS, Err, Ok, metrics, parseEnvs, stringifyError } from '@nangohq/util
 
 import { Batcher } from './batcher.js';
 import {
+    COUNTER_METRICS,
     FILTER_PARAM_TYPE_FOR_DIM,
     TOP_N_BREAKDOWN_CAP,
     TOP_N_BREAKDOWN_DEFAULT,
@@ -25,7 +26,14 @@ import type {
     GetTopDimensionValuesQuery,
     GetTopDimensionValuesResult
 } from './clickhouse.query.js';
-import type { UsageActionsEvent, UsageConnectionsEvent, UsageEvent, UsageFunctionExecutionsEvent, UsageRecordsEvent } from '@nangohq/types';
+import type {
+    BillingUsageMetrics,
+    UsageActionsEvent,
+    UsageConnectionsEvent,
+    UsageEvent,
+    UsageFunctionExecutionsEvent,
+    UsageRecordsEvent
+} from '@nangohq/types';
 import type { Result } from '@nangohq/utils';
 
 const envs = parseEnvs(ENVS);
@@ -516,6 +524,40 @@ export class Clickhouse {
             logger.error(`Clickhouse getTopDimensionValues failed for account=${accountId} metric=${metric} dimension=${dimension}: ${stringifyError(err)}`);
             return Err(new Error('Failed to execute Clickhouse top-dimension-values query', { cause: err }));
         }
+    }
+
+    // CH-backed equivalent of `UsageBillingClient.getUsage(subscriptionId)` (no
+    // timeframe) — month-to-date COUNTER totals scoped to the calendar month
+    // containing `now`. Returned shape mirrors what Orb returns so the two are
+    // swappable at the caller. `records` / `connections` are not included;
+    // capping reads those from Postgres.
+    //
+    // Returns all five COUNTER billing metrics in one call (matches Orb's
+    // shape). One revalidate amortises the cache refresh across every billing
+    // metric — keep this fanned-out even though the trigger is per-metric.
+    async getCurrentMonthBillingMetrics(accountId: number, now: Date): Promise<Result<BillingUsageMetrics>> {
+        const monthStart = new Date(Date.UTC(now.getUTCFullYear(), now.getUTCMonth(), 1));
+        const nextMonth = new Date(Date.UTC(now.getUTCFullYear(), now.getUTCMonth() + 1, 1));
+        const timeframe = { start: monthStart, end: nextMonth };
+
+        const results = await Promise.all(
+            COUNTER_METRICS.map((metric) =>
+                this.getDailyCounter({ accountId, metric, dimension: 'none', timeframe } as GetDailyCounterQuery).then((r) => [metric, r] as const)
+            )
+        );
+
+        const usage: BillingUsageMetrics = {};
+        for (const [metric, res] of results) {
+            if (res.isErr()) return Err(res.error);
+            // Empty series → account has no events for this metric in the
+            // window (new account, paused, or partially active). Emit total: 0
+            // — capping needs an explicit zero, and skipping the entry would
+            // leave a stale cache value untouched.
+            const days = res.value.series[0]?.days ?? [];
+            const total = days.reduce((acc, d) => acc + d.value, 0);
+            usage[metric] = { externalId: metric, total, usage: [], view_mode: 'periodic' };
+        }
+        return Ok(usage);
     }
 
     async shutdown(opts?: { timeoutMs: number }): Promise<Result<void>> {


### PR DESCRIPTION
- Adds `Clickhouse.getCurrentMonthBillingMetrics(accountId, now)` — calendar-month-to-date totals for the 5 COUNTER billing metrics (`proxy`, `function_executions`, `function_compute_gbms`, `function_logs`, `webhook_forwards`). Returned shape mirrors Orb's `BillingUsageMetrics` so the two are interchangeable at the caller.
- Pure building block — not yet wired into `getBillingMetrics()` / the capping cache. The dual-write wiring lands in [NAN-5953](https://linear.app/nango/issue/NAN-5953).
- `connections` and `records` are intentionally excluded; capping reads those from Postgres today and that stays unchanged.

## Test plan

- [x] `npm run ts-build` passes.
- [x] 4 integration tests against the CH testcontainer: happy-path totals across all 5 metrics, previous-month exclusion, fully-empty account, partially-active account (uses proxy only — other 4 must come back as 0 in the same response).
- [ ] No production behavior change yet — the method is unreferenced from any code path. Activation lands in NAN-5953.

Closes NAN-5952.