### PR TITLE
feat(webapp): reset playground on logout

### DIFF
--- a/packages/webapp/src/store/index.ts
+++ b/packages/webapp/src/store/index.ts
@@ -1,7 +1,7 @@
 import { QueryClient } from '@tanstack/react-query';
 import { create } from 'zustand';
 
-import { usePlaygroundStore } from './playground';
+import { resetPlayground } from './playground';
 import { PROD_ENVIRONMENT_NAME } from '../utils/environments';
 import storage, { LocalStorageKeys } from '../utils/local-storage';
 
@@ -33,8 +33,7 @@ export const useStore = create<State>()((set, get) => ({
 
     setEnv: (value) => {
         if (get().env !== value) {
-            usePlaygroundStore.getState().abortActiveRun?.();
-            usePlaygroundStore.getState().reset();
+            resetPlayground();
         }
         set({ env: value });
     },

--- a/packages/webapp/src/store/playground.ts
+++ b/packages/webapp/src/store/playground.ts
@@ -124,3 +124,14 @@ export const usePlaygroundStore = create<PlaygroundStore>()(
         }
     )
 );
+
+/**
+ * Aborts any in-flight run and clears Playground selection state (also wiped
+ * from sessionStorage via the persist middleware). Call this whenever the active
+ * context goes away — switching environments or logging out — since the stored
+ * integration/connection/function belong to that context.
+ */
+export function resetPlayground() {
+    usePlaygroundStore.getState().abortActiveRun?.();
+    usePlaygroundStore.getState().reset();
+}

--- a/packages/webapp/src/utils/user.tsx
+++ b/packages/webapp/src/utils/user.tsx
@@ -3,6 +3,7 @@ import { useSWRConfig } from 'swr';
 
 import { useAnalyticsIdentify, useAnalyticsReset } from './analytics';
 import { useLogoutAPI } from '../hooks/useAuth';
+import { resetPlayground } from '../store/playground';
 import storage, { LocalStorageKeys } from '../utils/local-storage';
 
 import type { ApiUser } from '@nangohq/types';
@@ -28,6 +29,7 @@ export function useSignout() {
 
     return async () => {
         storage.clearSession();
+        resetPlayground(); // playground selections belong to the session's account/env
         analyticsReset();
         await logoutAPI(); // Destroy server session.
 


### PR DESCRIPTION
## Problem

The API Playground remembers its selected integration, connection, function, and inputs (persisted in `sessionStorage`). On logout these survived, so the next sign-in in the same browser tab started with the previous session's selections — which can point to resources from a different account/environment.

We already reset the Playground when switching environments (`setEnv` in `store/index.ts`), but logout didn't do the same.

## Solution

Extract the existing env-switch reset into a shared `resetPlayground()` helper (aborts any in-flight run + clears selection state; the persist middleware wipes the `sessionStorage` copy too) and call it from `useSignout`. Environment switching now reuses the same helper, so logout and env-switch stay consistent.

Fixes [NAN-5956](https://linear.app/nango/issue/NAN-5956)

> **Stacked on #6456** (NAN-5950) — depends on that PR's `storage.clearSession()`. Review/merge #6456 first; this PR's base is its branch.

## Testing

- `tsc` and `eslint` pass on the changed files.
- `store/index.unit.test.ts` (env-switch resets playground) exercises the shared helper and passes — 44 playground/env unit tests green.
- Manual (pending): select an integration/connection/function in the Playground → log out → sign back in → Playground starts empty.
