### PR TITLE
fix(hooks): skip lint-staged during rebase

### DIFF
--- a/.husky/pre-commit
+++ b/.husky/pre-commit
@@ -3,6 +3,14 @@ set -e
 
 . "$(dirname -- "$0")/_/husky.sh"
 
+# Skip during rebase/cherry-pick — these replay commits whose changes were
+# already reviewed, and lint-staged shouldn't rewrite them mid-replay. Mirrors
+# the guard in prepare-commit-msg.
+GIT_DIR=$(git rev-parse --git-dir)
+if [ -d "$GIT_DIR/rebase-merge" ] || [ -d "$GIT_DIR/rebase-apply" ] || [ -f "$GIT_DIR/CHERRY_PICK_HEAD" ]; then
+  exit 0
+fi
+
 npx lint-staged --allow-empty
 
 if [ $(git diff --cached --numstat -- ./docs/integrations/all/ ./packages/shared/flows.yaml | wc -l) -gt "0" ]; then


### PR DESCRIPTION
## Problem

The `pre-commit` hook runs `lint-staged` unconditionally. A plain `git rebase` doesn't invoke `pre-commit`, but an interactive rebase that amends/edits commits (or resolving a conflict with `git commit`) does — so `lint-staged` re-runs on changes that were already reviewed, mid-replay. That's slow and disruptive when rebasing frequently.

`prepare-commit-msg` already guards against this; `pre-commit` did not.

## Solution

Bail out of `pre-commit` early when a rebase or cherry-pick is in progress, mirroring the existing guard in `prepare-commit-msg`:

- `rebase-merge` / `rebase-apply` directories, or
- `CHERRY_PICK_HEAD`

Normal commits are unaffected — `lint-staged` (`eslint --fix`) still runs.

## Testing

- Confirmed in a scratch repo that a plain `git rebase` does **not** invoke `pre-commit`, while `git rebase --exec 'git commit --amend --no-edit'` **does** — and that `rebase-merge` exists at that point, so the new guard short-circuits before `lint-staged` runs.
- Verified a normal `git commit` matches no guard condition, so `lint-staged` still runs as before.
