### PR TITLE
feat(webapp): hide usage card for paid accounts

### DIFF
--- a/packages/webapp/src/layout/AppSidebar/index.tsx
+++ b/packages/webapp/src/layout/AppSidebar/index.tsx
@@ -62,10 +62,9 @@ export const AppSidebar: React.FC = () => {
         ].filter((item) => item !== null);
     }, [env, meta, refetchMeta, showGettingStarted]);
 
-    const showUsageCard = useMemo(() => {
-        if (!plan) return false;
-        return ['free', 'starter-v2', 'growth-v2'].includes(plan?.name);
-    }, [plan]);
+    // Only free accounts see the usage/capping card. Paid accounts have no enforced caps, so the card
+    // just adds noise and surfaces upgrade/downgrade inconsistencies (NAN-5959).
+    const showUsageCard = plan?.name === 'free';
 
     return (
         <Sidebar collapsible="none">


### PR DESCRIPTION
## Problem

The sidebar usage/capping card was shown to free, `starter-v2`, and `growth-v2` accounts. Capping is only enforced for free accounts, so for paid plans this card added noise and surfaced upgrade/downgrade inconsistencies (e.g. usage resetting on plan changes, billing-period vs. calendar-month mismatches).

## Solution

Restrict the sidebar usage card to free accounts only (`plan?.name === 'free'`). Paid accounts (all `starter`/`growth`/`enterprise`/legacy variants) no longer see it, freeing up sidebar real estate. Free accounts are unaffected.

Fixes [NAN-5959](https://linear.app/nango/issue/NAN-5959)

## Testing

- Ran the webapp against the dev backend logged in as a `growth-v2` (paid) account → sidebar usage card is no longer rendered (it previously showed for `growth-v2`).
- Free accounts are unchanged: `plan?.name === 'free'` returns the same result as the previous allow-list for the `free` plan, and the `UsageCard` component is untouched.
- `tsc` and `eslint` pass on the changed file.

<!-- Screenshot suggestion: add a before/after of the sidebar footer for a paid account (card present → gone). -->
