### PR TITLE
feat(server): public endpoints for function management

### DIFF
--- a/docs/spec.yaml
+++ b/docs/spec.yaml
@@ -65,6 +65,37 @@ paths:
                     $ref: '#/components/responses/Unauthorized'
                 '404':
                     $ref: '#/components/responses/NotFound'
+    /providers/{provider}/templates:
+        get:
+            summary: List provider templates
+            description: Returns the template functions available in the catalog for a provider. Requires an API key with the `environment:functions:list` scope.
+            parameters:
+                - name: provider
+                  in: path
+                  required: true
+                  schema:
+                      type: string
+                  description: The provider name.
+            responses:
+                '200':
+                    description: Successfully returned the provider's template functions
+                    content:
+                        application/json:
+                            schema:
+                                type: object
+                                required:
+                                    - data
+                                properties:
+                                    data:
+                                        type: array
+                                        items:
+                                            $ref: '#/components/schemas/ProviderTemplateFunction'
+                '400':
+                    $ref: '#/components/responses/BadRequest'
+                '401':
+                    $ref: '#/components/responses/Unauthorized'
+                '403':
+                    $ref: '#/components/responses/Forbidden'
     /integrations:
         get:
             summary: List integrations
@@ -281,6 +312,190 @@ paths:
                     $ref: '#/components/responses/BadRequest'
                 '401':
                     $ref: '#/components/responses/Unauthorized'
+                '404':
+                    $ref: '#/components/responses/NotFound'
+
+    /integrations/{uniqueKey}/functions:
+        get:
+            summary: List functions
+            description: Returns the functions deployed to an integration. Requires an API key with the `environment:functions:list` scope.
+            parameters:
+                - name: uniqueKey
+                  in: path
+                  required: true
+                  schema:
+                      type: string
+                  description: The integration ID (unique_key) that you created in Nango.
+                - name: type
+                  in: query
+                  required: false
+                  schema:
+                      type: string
+                      enum: [sync, action, on-event]
+                  description: Filter by function type.
+                - name: search
+                  in: query
+                  required: false
+                  schema:
+                      type: string
+                      minLength: 1
+                      maxLength: 255
+                  description: Case-insensitive filter on the function name.
+                - name: page
+                  in: query
+                  required: false
+                  schema:
+                      type: integer
+                      minimum: 0
+                      default: 0
+                - name: limit
+                  in: query
+                  required: false
+                  schema:
+                      type: integer
+                      minimum: 1
+                      maximum: 100
+                      default: 20
+            responses:
+                '200':
+                    description: Successfully returned the integration's functions
+                    content:
+                        application/json:
+                            schema:
+                                type: object
+                                required:
+                                    - data
+                                    - pagination
+                                properties:
+                                    data:
+                                        type: array
+                                        items:
+                                            $ref: '#/components/schemas/DeployedNangoFunction'
+                                    pagination:
+                                        type: object
+                                        required:
+                                            - total
+                                            - page
+                                            - limit
+                                        properties:
+                                            total:
+                                                type: integer
+                                            page:
+                                                type: integer
+                                            limit:
+                                                type: integer
+                '400':
+                    $ref: '#/components/responses/BadRequest'
+                '401':
+                    $ref: '#/components/responses/Unauthorized'
+                '403':
+                    $ref: '#/components/responses/Forbidden'
+                '404':
+                    $ref: '#/components/responses/NotFound'
+
+    /integrations/{uniqueKey}/functions/{name}:
+        get:
+            summary: Get a function
+            description: Returns a single deployed function. Requires an API key with the `environment:functions:read` scope.
+            parameters:
+                - name: uniqueKey
+                  in: path
+                  required: true
+                  schema:
+                      type: string
+                  description: The integration ID (unique_key) that you created in Nango.
+                - name: name
+                  in: path
+                  required: true
+                  schema:
+                      type: string
+                  description: The name of the function.
+                - name: type
+                  in: query
+                  required: false
+                  schema:
+                      type: string
+                      enum: [sync, action, on-event]
+                  description: Disambiguates when multiple functions share the same name.
+            responses:
+                '200':
+                    description: Successfully returned the function
+                    content:
+                        application/json:
+                            schema:
+                                type: object
+                                required:
+                                    - data
+                                properties:
+                                    data:
+                                        $ref: '#/components/schemas/DeployedNangoFunction'
+                '400':
+                    $ref: '#/components/responses/BadRequest'
+                '401':
+                    $ref: '#/components/responses/Unauthorized'
+                '403':
+                    $ref: '#/components/responses/Forbidden'
+                '404':
+                    $ref: '#/components/responses/NotFound'
+        delete:
+            summary: Delete a function
+            description: Deletes a deployed function and enqueues its async teardown. Functions managed by `nango deploy` (repo source) cannot be deleted through this endpoint. Requires an API key with the `environment:functions:delete` scope.
+            parameters:
+                - name: uniqueKey
+                  in: path
+                  required: true
+                  schema:
+                      type: string
+                  description: The integration ID (unique_key) that you created in Nango.
+                - name: name
+                  in: path
+                  required: true
+                  schema:
+                      type: string
+                  description: The name of the function.
+                - name: type
+                  in: query
+                  required: true
+                  schema:
+                      type: string
+                      enum: [sync, action]
+                  description: Required to disambiguate a sync and an action that share a name. On-event functions are not yet supported.
+            responses:
+                '200':
+                    description: Successfully enqueued the function deletion
+                    content:
+                        application/json:
+                            schema:
+                                type: object
+                                required:
+                                    - data
+                                properties:
+                                    data:
+                                        type: object
+                                        required:
+                                            - success
+                                        properties:
+                                            success:
+                                                type: boolean
+                '400':
+                    description: Invalid request, or the function is managed by `nango deploy`.
+                    content:
+                        application/json:
+                            schema:
+                                type: object
+                                properties:
+                                    error:
+                                        type: object
+                                        properties:
+                                            code:
+                                                type: string
+                                                enum: [function_managed_by_deploy]
+                                            message:
+                                                type: string
+                '401':
+                    $ref: '#/components/responses/Unauthorized'
+                '403':
+                    $ref: '#/components/responses/Forbidden'
                 '404':
                     $ref: '#/components/responses/NotFound'
 
@@ -2941,6 +3156,134 @@ components:
         RunnableFunctionType:
             type: string
             enum: [action, sync]
+
+        DeployedMeta:
+            type: object
+            description: Deployment metadata attached to a deployed function.
+            required:
+                - id
+                - enabled
+                - last_deployed
+                - source
+            properties:
+                id:
+                    type: number
+                enabled:
+                    type: boolean
+                last_deployed:
+                    type: string
+                    format: date-time
+                    description: ISO-8601 timestamp.
+                source:
+                    type: string
+                    enum: [catalog, standalone, repo]
+
+        NangoSyncFunction:
+            type: object
+            required:
+                - name
+                - type
+                - returns
+                - json_schema
+                - runs
+                - auto_start
+                - track_deletes
+            properties:
+                name:
+                    type: string
+                description:
+                    type: string
+                scopes:
+                    type: array
+                    items:
+                        type: string
+                type:
+                    type: string
+                    enum: [sync]
+                input:
+                    type: string
+                returns:
+                    type: array
+                    items:
+                        type: string
+                json_schema:
+                    type: [object, 'null']
+                runs:
+                    type: [string, 'null']
+                    description: Schedule expression, e.g. `every day`.
+                auto_start:
+                    type: boolean
+                track_deletes:
+                    type: boolean
+
+        NangoActionFunction:
+            type: object
+            required:
+                - name
+                - type
+                - returns
+                - json_schema
+            properties:
+                name:
+                    type: string
+                description:
+                    type: string
+                scopes:
+                    type: array
+                    items:
+                        type: string
+                type:
+                    type: string
+                    enum: [action]
+                input:
+                    type: string
+                returns:
+                    type: array
+                    items:
+                        type: string
+                json_schema:
+                    type: [object, 'null']
+
+        NangoOnEventFunction:
+            type: object
+            required:
+                - name
+                - type
+                - event
+            properties:
+                name:
+                    type: string
+                description:
+                    type: string
+                scopes:
+                    type: array
+                    items:
+                        type: string
+                type:
+                    type: string
+                    enum: [on-event]
+                event:
+                    type: string
+                    enum: [post-connection-creation, pre-connection-deletion, validate-connection]
+
+        ProviderTemplateFunction:
+            description: A sync or action template function from the provider catalog (no deployment metadata).
+            oneOf:
+                - $ref: '#/components/schemas/NangoSyncFunction'
+                - $ref: '#/components/schemas/NangoActionFunction'
+
+        DeployedNangoFunction:
+            description: A deployed function (sync, action, or on-event) merged with its deployment metadata.
+            oneOf:
+                - allOf:
+                      - $ref: '#/components/schemas/NangoSyncFunction'
+                      - $ref: '#/components/schemas/DeployedMeta'
+                - allOf:
+                      - $ref: '#/components/schemas/NangoActionFunction'
+                      - $ref: '#/components/schemas/DeployedMeta'
+                - allOf:
+                      - $ref: '#/components/schemas/NangoOnEventFunction'
+                      - $ref: '#/components/schemas/DeployedMeta'
 
         FunctionCompileRequest:
             type: object

--- a/packages/server/lib/controllers/integrations/uniqueKey/functions/deleteFunction.integration.test.ts
+++ b/packages/server/lib/controllers/integrations/uniqueKey/functions/deleteFunction.integration.test.ts
@@ -1,0 +1,127 @@
+import { afterAll, beforeAll, describe, expect, it } from 'vitest';
+
+import db from '@nangohq/database';
+import { seeders } from '@nangohq/shared';
+
+import { isError, isSuccess, runServer, shouldBeProtected } from '../../../../utils/tests.js';
+
+import type { DBSyncConfig } from '@nangohq/types';
+
+const route = '/integrations/:uniqueKey/functions/:name';
+let api: Awaited<ReturnType<typeof runServer>>;
+
+async function getSyncConfig(id: number): Promise<Pick<DBSyncConfig, 'id' | 'deleted' | 'active'> | undefined> {
+    return db.knex.from<DBSyncConfig>('_nango_sync_configs').select('id', 'deleted', 'active').where({ id }).first();
+}
+
+async function seedWithScopes(scopes: string[]) {
+    const seed = await seeders.seedAccountEnvAndUser();
+    await db.knex('customer_keys').where('id', seed.apiKey.id).update({ scopes });
+    return seed;
+}
+
+describe(`DELETE ${route}`, () => {
+    beforeAll(async () => {
+        api = await runServer();
+    });
+    afterAll(() => {
+        api.server.close();
+    });
+
+    it('should be protected', async () => {
+        const res = await api.fetch(route, { method: 'DELETE', params: { uniqueKey: 'github', name: 'my-sync' }, query: { type: 'sync' } });
+
+        shouldBeProtected(res);
+    });
+
+    it('should reject a key lacking the delete scope', async () => {
+        const seed = await seedWithScopes(['environment:functions:read']);
+
+        const res = await api.fetch(route, {
+            method: 'DELETE',
+            token: seed.apiKey.secret,
+            params: { uniqueKey: 'github', name: 'my-sync' },
+            query: { type: 'sync' }
+        });
+
+        isError(res.json);
+        expect(res.res.status).toBe(403);
+        expect(res.json.error.code).toBe('forbidden');
+    });
+
+    it('should require the type query param', async () => {
+        const { env, apiKey } = await seeders.seedAccountEnvAndUser();
+        await seeders.createConfigSeed(env, 'github', 'github');
+
+        const res = await api.fetch(route, {
+            method: 'DELETE',
+            token: apiKey.secret,
+            params: { uniqueKey: 'github', name: 'my-sync' },
+            // @ts-expect-error missing type on purpose
+            query: {}
+        });
+
+        isError(res.json);
+        expect(res.res.status).toBe(400);
+        expect(res.json.error.code).toBe('invalid_query_params');
+    });
+
+    it('should reject repo functions (managed by nango deploy)', async () => {
+        const { env, apiKey } = await seeders.seedAccountEnvAndUser();
+        const integration = await seeders.createConfigSeed(env, 'github', 'github');
+        const connection = await seeders.createConnectionSeed({ env, provider: 'github' });
+
+        const { syncConfig } = await seeders.createSyncSeeds({
+            connectionId: connection.id,
+            environment_id: env.id,
+            nango_config_id: integration.id!,
+            sync_name: 'repo-sync',
+            type: 'sync',
+            source: 'repo'
+        });
+
+        const res = await api.fetch(route, {
+            method: 'DELETE',
+            token: apiKey.secret,
+            params: { uniqueKey: 'github', name: 'repo-sync' },
+            query: { type: 'sync' }
+        });
+
+        isError(res.json);
+        expect(res.res.status).toBe(400);
+        expect(res.json.error.code).toBe('function_managed_by_deploy');
+
+        const after = await getSyncConfig(syncConfig.id);
+        expect(after?.deleted).toBe(false);
+    });
+
+    it('should soft-delete a standalone function and accept the teardown', async () => {
+        const { env, apiKey } = await seeders.seedAccountEnvAndUser();
+        const integration = await seeders.createConfigSeed(env, 'github', 'github');
+        const connection = await seeders.createConnectionSeed({ env, provider: 'github' });
+
+        const { syncConfig } = await seeders.createSyncSeeds({
+            connectionId: connection.id,
+            environment_id: env.id,
+            nango_config_id: integration.id!,
+            sync_name: 'standalone-sync',
+            type: 'sync',
+            source: 'standalone'
+        });
+
+        const res = await api.fetch(route, {
+            method: 'DELETE',
+            token: apiKey.secret,
+            params: { uniqueKey: 'github', name: 'standalone-sync' },
+            query: { type: 'sync' }
+        });
+
+        expect(res.res.status).toBe(200);
+        isSuccess(res.json);
+        expect(res.json.data.success).toBe(true);
+
+        const after = await getSyncConfig(syncConfig.id);
+        expect(after?.deleted).toBe(true);
+        expect(after?.active).toBe(false);
+    });
+});

--- a/packages/server/lib/controllers/integrations/uniqueKey/functions/deleteFunction.ts
+++ b/packages/server/lib/controllers/integrations/uniqueKey/functions/deleteFunction.ts
@@ -4,7 +4,7 @@ import { zodErrorToHTTP } from '@nangohq/utils';
 
 import { deletableFunctionTypeSchema, providerConfigKeySchema, scriptNameSchema } from '../../../../helpers/validation.js';
 import { asyncWrapper } from '../../../../utils/asyncWrapper.js';
-import { handleDeleteIntegrationFunction } from '../../../v1/integrations/providerConfigKey/functions/deleteFunction.js';
+import { handleDeleteIntegrationFunction } from '../../../v1/integrations/providerConfigKey/functions/helpers.js';
 
 import type { DeletePublicIntegrationFunction } from '@nangohq/types';
 

--- a/packages/server/lib/controllers/integrations/uniqueKey/functions/deleteFunction.ts
+++ b/packages/server/lib/controllers/integrations/uniqueKey/functions/deleteFunction.ts
@@ -1,0 +1,43 @@
+import * as z from 'zod';
+
+import { zodErrorToHTTP } from '@nangohq/utils';
+
+import { deletableFunctionTypeSchema, providerConfigKeySchema, scriptNameSchema } from '../../../../helpers/validation.js';
+import { asyncWrapper } from '../../../../utils/asyncWrapper.js';
+import { handleDeleteIntegrationFunction } from '../../../v1/integrations/providerConfigKey/functions/deleteFunction.js';
+
+import type { DeletePublicIntegrationFunction } from '@nangohq/types';
+
+const validationParams = z
+    .object({
+        uniqueKey: providerConfigKeySchema,
+        name: scriptNameSchema
+    })
+    .strict();
+
+const validationQuery = z
+    .object({
+        // Required (unlike GET) to disambiguate a sync and an action that share a name.
+        type: deletableFunctionTypeSchema
+    })
+    .strict();
+
+export const deletePublicIntegrationFunction = asyncWrapper<DeletePublicIntegrationFunction>(async (req, res) => {
+    const valQuery = validationQuery.safeParse(req.query);
+    if (!valQuery.success) {
+        res.status(400).send({ error: { code: 'invalid_query_params', errors: zodErrorToHTTP(valQuery.error) } });
+        return;
+    }
+
+    const valParams = validationParams.safeParse(req.params);
+    if (!valParams.success) {
+        res.status(400).send({ error: { code: 'invalid_uri_params', errors: zodErrorToHTTP(valParams.error) } });
+        return;
+    }
+
+    const { environment } = res.locals;
+    const { uniqueKey, name } = valParams.data;
+    const { type } = valQuery.data;
+
+    await handleDeleteIntegrationFunction({ res, environment, providerConfigKey: uniqueKey, name, type });
+});

--- a/packages/server/lib/controllers/integrations/uniqueKey/functions/getFunction.integration.test.ts
+++ b/packages/server/lib/controllers/integrations/uniqueKey/functions/getFunction.integration.test.ts
@@ -1,0 +1,72 @@
+import { afterAll, beforeAll, describe, expect, it } from 'vitest';
+
+import db from '@nangohq/database';
+import { seeders } from '@nangohq/shared';
+
+import { isError, isSuccess, runServer, shouldBeProtected } from '../../../../utils/tests.js';
+
+const route = '/integrations/:uniqueKey/functions/:name';
+let api: Awaited<ReturnType<typeof runServer>>;
+
+async function seedWithScopes(scopes: string[]) {
+    const seed = await seeders.seedAccountEnvAndUser();
+    await db.knex('customer_keys').where('id', seed.apiKey.id).update({ scopes });
+    return seed;
+}
+
+describe(`GET ${route}`, () => {
+    beforeAll(async () => {
+        api = await runServer();
+    });
+    afterAll(() => {
+        api.server.close();
+    });
+
+    it('should be protected', async () => {
+        const res = await api.fetch(route, { method: 'GET', params: { uniqueKey: 'github', name: 'my-sync' }, query: {} });
+
+        shouldBeProtected(res);
+    });
+
+    it('should reject a key lacking the read scope', async () => {
+        const seed = await seedWithScopes(['environment:functions:list']);
+
+        const res = await api.fetch(route, { method: 'GET', token: seed.apiKey.secret, params: { uniqueKey: 'github', name: 'my-sync' }, query: {} });
+
+        isError(res.json);
+        expect(res.res.status).toBe(403);
+        expect(res.json.error.code).toBe('forbidden');
+    });
+
+    it('should 404 when the function does not exist', async () => {
+        const { env, apiKey } = await seeders.seedAccountEnvAndUser();
+        await seeders.createConfigSeed(env, 'github', 'github');
+
+        const res = await api.fetch(route, { method: 'GET', token: apiKey.secret, params: { uniqueKey: 'github', name: 'does-not-exist' }, query: {} });
+
+        isError(res.json);
+        expect(res.res.status).toBe(404);
+        expect(res.json.error.code).toBe('not_found');
+    });
+
+    it('should return a function for the environment derived from the key', async () => {
+        const { env, apiKey } = await seeders.seedAccountEnvAndUser();
+        const integration = await seeders.createConfigSeed(env, 'github', 'github');
+        const connection = await seeders.createConnectionSeed({ env, provider: 'github' });
+
+        await seeders.createSyncSeeds({
+            connectionId: connection.id,
+            environment_id: env.id,
+            nango_config_id: integration.id!,
+            sync_name: 'my-sync',
+            type: 'sync'
+        });
+
+        const res = await api.fetch(route, { method: 'GET', token: apiKey.secret, params: { uniqueKey: 'github', name: 'my-sync' }, query: {} });
+
+        expect(res.res.status).toBe(200);
+        isSuccess(res.json);
+        expect(res.json.data.name).toBe('my-sync');
+        expect(res.json.data.type).toBe('sync');
+    });
+});

--- a/packages/server/lib/controllers/integrations/uniqueKey/functions/getFunction.ts
+++ b/packages/server/lib/controllers/integrations/uniqueKey/functions/getFunction.ts
@@ -1,0 +1,42 @@
+import * as z from 'zod';
+
+import { zodErrorToHTTP } from '@nangohq/utils';
+
+import { functionTypeSchema, providerConfigKeySchema, scriptNameSchema } from '../../../../helpers/validation.js';
+import { asyncWrapper } from '../../../../utils/asyncWrapper.js';
+import { handleGetIntegrationFunction } from '../../../v1/integrations/providerConfigKey/functions/getFunction.js';
+
+import type { GetPublicIntegrationFunction } from '@nangohq/types';
+
+const validationParams = z
+    .object({
+        uniqueKey: providerConfigKeySchema,
+        name: scriptNameSchema
+    })
+    .strict();
+
+const validationQuery = z
+    .object({
+        type: functionTypeSchema.optional()
+    })
+    .strict();
+
+export const getPublicIntegrationFunction = asyncWrapper<GetPublicIntegrationFunction>(async (req, res) => {
+    const valQuery = validationQuery.safeParse(req.query);
+    if (!valQuery.success) {
+        res.status(400).send({ error: { code: 'invalid_query_params', errors: zodErrorToHTTP(valQuery.error) } });
+        return;
+    }
+
+    const valParams = validationParams.safeParse(req.params);
+    if (!valParams.success) {
+        res.status(400).send({ error: { code: 'invalid_uri_params', errors: zodErrorToHTTP(valParams.error) } });
+        return;
+    }
+
+    const { environment } = res.locals;
+    const { uniqueKey, name } = valParams.data;
+    const { type } = valQuery.data;
+
+    await handleGetIntegrationFunction({ res, environment, providerConfigKey: uniqueKey, name, type });
+});

--- a/packages/server/lib/controllers/integrations/uniqueKey/functions/getFunction.ts
+++ b/packages/server/lib/controllers/integrations/uniqueKey/functions/getFunction.ts
@@ -4,7 +4,7 @@ import { zodErrorToHTTP } from '@nangohq/utils';
 
 import { functionTypeSchema, providerConfigKeySchema, scriptNameSchema } from '../../../../helpers/validation.js';
 import { asyncWrapper } from '../../../../utils/asyncWrapper.js';
-import { handleGetIntegrationFunction } from '../../../v1/integrations/providerConfigKey/functions/getFunction.js';
+import { handleGetIntegrationFunction } from '../../../v1/integrations/providerConfigKey/functions/helpers.js';
 
 import type { GetPublicIntegrationFunction } from '@nangohq/types';
 

--- a/packages/server/lib/controllers/integrations/uniqueKey/functions/getFunctions.integration.test.ts
+++ b/packages/server/lib/controllers/integrations/uniqueKey/functions/getFunctions.integration.test.ts
@@ -1,0 +1,125 @@
+import { afterAll, beforeAll, describe, expect, it } from 'vitest';
+
+import db from '@nangohq/database';
+import { seeders } from '@nangohq/shared';
+
+import { isError, isSuccess, runServer, shouldBeProtected } from '../../../../utils/tests.js';
+
+const route = '/integrations/:uniqueKey/functions';
+let api: Awaited<ReturnType<typeof runServer>>;
+
+async function seedWithScopes(scopes: string[]) {
+    const seed = await seeders.seedAccountEnvAndUser();
+    await db.knex('customer_keys').where('id', seed.apiKey.id).update({ scopes });
+    return seed;
+}
+
+describe(`GET ${route}`, () => {
+    beforeAll(async () => {
+        api = await runServer();
+    });
+    afterAll(() => {
+        api.server.close();
+    });
+
+    it('should be protected', async () => {
+        const res = await api.fetch(route, { method: 'GET', params: { uniqueKey: 'github' }, query: {} });
+
+        shouldBeProtected(res);
+    });
+
+    it('should reject a key lacking the list scope', async () => {
+        const seed = await seedWithScopes(['environment:connections:read']);
+
+        const res = await api.fetch(route, { method: 'GET', token: seed.apiKey.secret, params: { uniqueKey: 'github' }, query: {} });
+
+        isError(res.json);
+        expect(res.res.status).toBe(403);
+        expect(res.json.error.code).toBe('forbidden');
+    });
+
+    it('should reject an env query param (env comes from the key)', async () => {
+        const { apiKey } = await seeders.seedAccountEnvAndUser();
+
+        const res = await api.fetch(route, {
+            method: 'GET',
+            token: apiKey.secret,
+            params: { uniqueKey: 'github' },
+            // @ts-expect-error env is not accepted on the public endpoint
+            query: { env: 'dev' }
+        });
+
+        isError(res.json);
+        expect(res.res.status).toBe(400);
+        expect(res.json.error.code).toBe('invalid_query_params');
+    });
+
+    it('should 404 when the integration does not exist', async () => {
+        const { apiKey } = await seeders.seedAccountEnvAndUser();
+
+        const res = await api.fetch(route, { method: 'GET', token: apiKey.secret, params: { uniqueKey: 'missing' }, query: {} });
+
+        isError(res.json);
+        expect(res.res.status).toBe(404);
+        expect(res.json.error.code).toBe('not_found');
+    });
+
+    it('should list functions for the environment derived from the key', async () => {
+        const { env, apiKey } = await seeders.seedAccountEnvAndUser();
+        const integration = await seeders.createConfigSeed(env, 'github', 'github');
+        const connection = await seeders.createConnectionSeed({ env, provider: 'github' });
+
+        await seeders.createSyncSeeds({
+            connectionId: connection.id,
+            environment_id: env.id,
+            nango_config_id: integration.id!,
+            sync_name: 'my-sync',
+            type: 'sync'
+        });
+        await seeders.createSyncSeeds({
+            connectionId: connection.id,
+            environment_id: env.id,
+            nango_config_id: integration.id!,
+            sync_name: 'my-action',
+            type: 'action'
+        });
+
+        const res = await api.fetch(route, { method: 'GET', token: apiKey.secret, params: { uniqueKey: 'github' }, query: {} });
+
+        expect(res.res.status).toBe(200);
+        isSuccess(res.json);
+        expect(res.json.pagination).toStrictEqual({ total: 2, page: 0, limit: 20 });
+        expect(res.json.data.map((f) => ({ name: f.name, type: f.type }))).toStrictEqual([
+            { name: 'my-action', type: 'action' },
+            { name: 'my-sync', type: 'sync' }
+        ]);
+    });
+
+    it('should filter by type and search', async () => {
+        const { env, apiKey } = await seeders.seedAccountEnvAndUser();
+        const integration = await seeders.createConfigSeed(env, 'github', 'github');
+        const connection = await seeders.createConnectionSeed({ env, provider: 'github' });
+
+        await seeders.createSyncSeeds({
+            connectionId: connection.id,
+            environment_id: env.id,
+            nango_config_id: integration.id!,
+            sync_name: 'fetch-issues',
+            type: 'sync'
+        });
+        await seeders.createSyncSeeds({
+            connectionId: connection.id,
+            environment_id: env.id,
+            nango_config_id: integration.id!,
+            sync_name: 'fetch-users',
+            type: 'sync'
+        });
+
+        const res = await api.fetch(route, { method: 'GET', token: apiKey.secret, params: { uniqueKey: 'github' }, query: { type: 'sync', search: 'issue' } });
+
+        expect(res.res.status).toBe(200);
+        isSuccess(res.json);
+        expect(res.json.pagination.total).toBe(1);
+        expect(res.json.data[0]?.name).toBe('fetch-issues');
+    });
+});

--- a/packages/server/lib/controllers/integrations/uniqueKey/functions/getFunctions.ts
+++ b/packages/server/lib/controllers/integrations/uniqueKey/functions/getFunctions.ts
@@ -4,7 +4,7 @@ import { zodErrorToHTTP } from '@nangohq/utils';
 
 import { functionListQueryFields, providerConfigKeySchema } from '../../../../helpers/validation.js';
 import { asyncWrapper } from '../../../../utils/asyncWrapper.js';
-import { handleListIntegrationFunctions } from '../../../v1/integrations/providerConfigKey/functions/getFunctions.js';
+import { handleListIntegrationFunctions } from '../../../v1/integrations/providerConfigKey/functions/helpers.js';
 
 import type { GetPublicIntegrationFunctions } from '@nangohq/types';
 

--- a/packages/server/lib/controllers/integrations/uniqueKey/functions/getFunctions.ts
+++ b/packages/server/lib/controllers/integrations/uniqueKey/functions/getFunctions.ts
@@ -1,0 +1,37 @@
+import * as z from 'zod';
+
+import { zodErrorToHTTP } from '@nangohq/utils';
+
+import { functionListQueryFields, providerConfigKeySchema } from '../../../../helpers/validation.js';
+import { asyncWrapper } from '../../../../utils/asyncWrapper.js';
+import { handleListIntegrationFunctions } from '../../../v1/integrations/providerConfigKey/functions/getFunctions.js';
+
+import type { GetPublicIntegrationFunctions } from '@nangohq/types';
+
+const validationParams = z
+    .object({
+        uniqueKey: providerConfigKeySchema
+    })
+    .strict();
+
+const validationQuery = z.object({ ...functionListQueryFields }).strict();
+
+export const getPublicIntegrationFunctions = asyncWrapper<GetPublicIntegrationFunctions>(async (req, res) => {
+    const valQuery = validationQuery.safeParse(req.query);
+    if (!valQuery.success) {
+        res.status(400).send({ error: { code: 'invalid_query_params', errors: zodErrorToHTTP(valQuery.error) } });
+        return;
+    }
+
+    const valParams = validationParams.safeParse(req.params);
+    if (!valParams.success) {
+        res.status(400).send({ error: { code: 'invalid_uri_params', errors: zodErrorToHTTP(valParams.error) } });
+        return;
+    }
+
+    const { environment } = res.locals;
+    const { uniqueKey } = valParams.data;
+    const { type, search, page, limit } = valQuery.data;
+
+    await handleListIntegrationFunctions({ res, environment, providerConfigKey: uniqueKey, type, search, page, limit });
+});

--- a/packages/server/lib/controllers/providers/provider/templates/getTemplates.integration.test.ts
+++ b/packages/server/lib/controllers/providers/provider/templates/getTemplates.integration.test.ts
@@ -1,0 +1,66 @@
+import { afterAll, beforeAll, describe, expect, it } from 'vitest';
+
+import db from '@nangohq/database';
+import { seeders } from '@nangohq/shared';
+
+import { isError, isSuccess, runServer, shouldBeProtected } from '../../../../utils/tests.js';
+
+const route = '/providers/:provider/templates';
+let api: Awaited<ReturnType<typeof runServer>>;
+
+async function seedWithScopes(scopes: string[]) {
+    const seed = await seeders.seedAccountEnvAndUser();
+    await db.knex('customer_keys').where('id', seed.apiKey.id).update({ scopes });
+    return seed;
+}
+
+describe(`GET ${route}`, () => {
+    beforeAll(async () => {
+        api = await runServer();
+    });
+    afterAll(() => {
+        api.server.close();
+    });
+
+    it('should be protected', async () => {
+        const res = await api.fetch(route, { method: 'GET', params: { provider: 'github' } });
+
+        shouldBeProtected(res);
+    });
+
+    it('should reject a key lacking the list scope', async () => {
+        const seed = await seedWithScopes(['environment:connections:read']);
+
+        const res = await api.fetch(route, { method: 'GET', token: seed.apiKey.secret, params: { provider: 'github' } });
+
+        isError(res.json);
+        expect(res.res.status).toBe(403);
+        expect(res.json.error.code).toBe('forbidden');
+    });
+
+    it('should return template functions for a known provider', async () => {
+        const { apiKey } = await seeders.seedAccountEnvAndUser();
+
+        const res = await api.fetch(route, { method: 'GET', token: apiKey.secret, params: { provider: 'github' } });
+
+        expect(res.res.status).toBe(200);
+        isSuccess(res.json);
+        expect(res.json.data.length).toBeGreaterThan(0);
+
+        const issues = res.json.data.find((value) => value.name === 'issues');
+        expect(issues).toMatchObject({ name: 'issues', type: 'sync' });
+        // The public catalog listing carries no deployment metadata.
+        expect(issues).not.toHaveProperty('source');
+        expect(issues).not.toHaveProperty('id');
+    });
+
+    it('should return an empty array for a provider with no templates', async () => {
+        const { apiKey } = await seeders.seedAccountEnvAndUser();
+
+        const res = await api.fetch(route, { method: 'GET', token: apiKey.secret, params: { provider: 'definitely-not-a-real-provider' } });
+
+        expect(res.res.status).toBe(200);
+        isSuccess(res.json);
+        expect(res.json.data).toStrictEqual([]);
+    });
+});

--- a/packages/server/lib/controllers/providers/provider/templates/getTemplates.ts
+++ b/packages/server/lib/controllers/providers/provider/templates/getTemplates.ts
@@ -4,7 +4,7 @@ import { requireEmptyQuery, zodErrorToHTTP } from '@nangohq/utils';
 
 import { providerNameSchema } from '../../../../helpers/validation.js';
 import { asyncWrapper } from '../../../../utils/asyncWrapper.js';
-import { handleGetProviderTemplates } from '../../../v1/providers/providerConfigKey/templates/getTemplates.js';
+import { handleGetProviderTemplates } from '../../../v1/providers/providerConfigKey/templates/helpers.js';
 
 import type { GetPublicProviderTemplates } from '@nangohq/types';
 

--- a/packages/server/lib/controllers/providers/provider/templates/getTemplates.ts
+++ b/packages/server/lib/controllers/providers/provider/templates/getTemplates.ts
@@ -1,0 +1,33 @@
+import * as z from 'zod';
+
+import { requireEmptyQuery, zodErrorToHTTP } from '@nangohq/utils';
+
+import { providerNameSchema } from '../../../../helpers/validation.js';
+import { asyncWrapper } from '../../../../utils/asyncWrapper.js';
+import { handleGetProviderTemplates } from '../../../v1/providers/providerConfigKey/templates/getTemplates.js';
+
+import type { GetPublicProviderTemplates } from '@nangohq/types';
+
+const validationParams = z
+    .object({
+        provider: providerNameSchema
+    })
+    .strict();
+
+export const getPublicProviderTemplates = asyncWrapper<GetPublicProviderTemplates>((req, res) => {
+    const emptyQuery = requireEmptyQuery(req);
+    if (emptyQuery) {
+        res.status(400).send({ error: { code: 'invalid_query_params', errors: zodErrorToHTTP(emptyQuery.error) } });
+        return;
+    }
+
+    const valParams = validationParams.safeParse(req.params);
+    if (!valParams.success) {
+        res.status(400).send({ error: { code: 'invalid_uri_params', errors: zodErrorToHTTP(valParams.error) } });
+        return;
+    }
+
+    const { provider } = valParams.data;
+
+    handleGetProviderTemplates({ res, providerConfigKey: provider });
+});

--- a/packages/server/lib/controllers/v1/integrations/providerConfigKey/functions/deleteFunction.ts
+++ b/packages/server/lib/controllers/v1/integrations/providerConfigKey/functions/deleteFunction.ts
@@ -1,15 +1,12 @@
 import * as z from 'zod';
 
-import { configService, getFunction } from '@nangohq/shared';
-import { report, zodErrorToHTTP } from '@nangohq/utils';
+import { zodErrorToHTTP } from '@nangohq/utils';
 
+import { handleDeleteIntegrationFunction } from './helpers.js';
 import { deletableFunctionTypeSchema, envSchema, providerConfigKeySchema } from '../../../../../helpers/validation.js';
-import { startFunctionDeletion } from '../../../../../tasks/startFunctionDeletion.js';
 import { asyncWrapper } from '../../../../../utils/asyncWrapper.js';
 
-import type { RequestLocals } from '../../../../../utils/express.js';
-import type { DBEnvironment, DeleteIntegrationFunction } from '@nangohq/types';
-import type { Response } from 'express';
+import type { DeleteIntegrationFunction } from '@nangohq/types';
 
 const querystringValidation = z
     .object({
@@ -25,58 +22,6 @@ const paramsValidation = z
         functionName: z.string().min(1).max(255)
     })
     .strict();
-
-export async function handleDeleteIntegrationFunction({
-    res,
-    environment,
-    providerConfigKey,
-    name,
-    type
-}: {
-    res: Response<DeleteIntegrationFunction['Reply'], Required<RequestLocals>>;
-    environment: DBEnvironment;
-    providerConfigKey: string;
-    name: string;
-    type: 'sync' | 'action';
-}): Promise<void> {
-    const integration = await configService.getProviderConfig(providerConfigKey, environment.id);
-    if (!integration) {
-        res.status(404).send({ error: { code: 'not_found', message: 'Integration does not exist' } });
-        return;
-    }
-
-    const fnResult = await getFunction({ environmentId: environment.id, providerConfigKey, name, type });
-    if (fnResult.isErr()) {
-        report(fnResult.error);
-        res.status(500).send({ error: { code: 'server_error', message: 'Failed to get function' } });
-        return;
-    }
-    if (!fnResult.value) {
-        res.status(404).send({ error: { code: 'not_found', message: 'Function does not exist' } });
-        return;
-    }
-
-    const fn = fnResult.value;
-    if (fn.source === 'repo') {
-        res.status(400).send({
-            error: { code: 'function_managed_by_deploy', message: 'repo functions are deleted through `nango deploy`, not this endpoint' }
-        });
-        return;
-    }
-
-    const enqueued = await startFunctionDeletion({
-        syncConfigId: fn.id,
-        environmentId: environment.id,
-        models: fn.type === 'on-event' ? [] : fn.returns
-    });
-    if (enqueued.isErr()) {
-        report(enqueued.error);
-        res.status(500).send({ error: { code: 'server_error', message: 'Failed to delete function' } });
-        return;
-    }
-
-    res.status(200).send({ data: { success: true } });
-}
 
 export const deleteIntegrationFunction = asyncWrapper<DeleteIntegrationFunction>(async (req, res) => {
     const queryStringValues = querystringValidation.safeParse(req.query);

--- a/packages/server/lib/controllers/v1/integrations/providerConfigKey/functions/deleteFunction.ts
+++ b/packages/server/lib/controllers/v1/integrations/providerConfigKey/functions/deleteFunction.ts
@@ -3,17 +3,19 @@ import * as z from 'zod';
 import { configService, getFunction } from '@nangohq/shared';
 import { report, zodErrorToHTTP } from '@nangohq/utils';
 
-import { envSchema, providerConfigKeySchema } from '../../../../../helpers/validation.js';
+import { deletableFunctionTypeSchema, envSchema, providerConfigKeySchema } from '../../../../../helpers/validation.js';
 import { startFunctionDeletion } from '../../../../../tasks/startFunctionDeletion.js';
 import { asyncWrapper } from '../../../../../utils/asyncWrapper.js';
 
-import type { DeleteIntegrationFunction } from '@nangohq/types';
+import type { RequestLocals } from '../../../../../utils/express.js';
+import type { DBEnvironment, DeleteIntegrationFunction } from '@nangohq/types';
+import type { Response } from 'express';
 
 const querystringValidation = z
     .object({
         env: envSchema,
         // Required (unlike GET) to disambiguate a sync and an action that share a name.
-        type: z.enum(['sync', 'action'])
+        type: deletableFunctionTypeSchema
     })
     .strict();
 
@@ -24,30 +26,26 @@ const paramsValidation = z
     })
     .strict();
 
-export const deleteIntegrationFunction = asyncWrapper<DeleteIntegrationFunction>(async (req, res) => {
-    const queryStringValues = querystringValidation.safeParse(req.query);
-    if (!queryStringValues.success) {
-        res.status(400).send({ error: { code: 'invalid_query_params', errors: zodErrorToHTTP(queryStringValues.error) } });
-        return;
-    }
-
-    const valParams = paramsValidation.safeParse(req.params);
-    if (!valParams.success) {
-        res.status(400).send({ error: { code: 'invalid_uri_params', errors: zodErrorToHTTP(valParams.error) } });
-        return;
-    }
-
-    const { environment } = res.locals;
-    const { providerConfigKey, functionName } = valParams.data;
-    const { type } = queryStringValues.data;
-
+export async function handleDeleteIntegrationFunction({
+    res,
+    environment,
+    providerConfigKey,
+    name,
+    type
+}: {
+    res: Response<DeleteIntegrationFunction['Reply'], Required<RequestLocals>>;
+    environment: DBEnvironment;
+    providerConfigKey: string;
+    name: string;
+    type: 'sync' | 'action';
+}): Promise<void> {
     const integration = await configService.getProviderConfig(providerConfigKey, environment.id);
     if (!integration) {
         res.status(404).send({ error: { code: 'not_found', message: 'Integration does not exist' } });
         return;
     }
 
-    const fnResult = await getFunction({ environmentId: environment.id, providerConfigKey, name: functionName, type });
+    const fnResult = await getFunction({ environmentId: environment.id, providerConfigKey, name, type });
     if (fnResult.isErr()) {
         report(fnResult.error);
         res.status(500).send({ error: { code: 'server_error', message: 'Failed to get function' } });
@@ -78,4 +76,24 @@ export const deleteIntegrationFunction = asyncWrapper<DeleteIntegrationFunction>
     }
 
     res.status(200).send({ data: { success: true } });
+}
+
+export const deleteIntegrationFunction = asyncWrapper<DeleteIntegrationFunction>(async (req, res) => {
+    const queryStringValues = querystringValidation.safeParse(req.query);
+    if (!queryStringValues.success) {
+        res.status(400).send({ error: { code: 'invalid_query_params', errors: zodErrorToHTTP(queryStringValues.error) } });
+        return;
+    }
+
+    const valParams = paramsValidation.safeParse(req.params);
+    if (!valParams.success) {
+        res.status(400).send({ error: { code: 'invalid_uri_params', errors: zodErrorToHTTP(valParams.error) } });
+        return;
+    }
+
+    const { environment } = res.locals;
+    const { providerConfigKey, functionName } = valParams.data;
+    const { type } = queryStringValues.data;
+
+    await handleDeleteIntegrationFunction({ res, environment, providerConfigKey, name: functionName, type });
 });

--- a/packages/server/lib/controllers/v1/integrations/providerConfigKey/functions/getFunction.ts
+++ b/packages/server/lib/controllers/v1/integrations/providerConfigKey/functions/getFunction.ts
@@ -1,14 +1,12 @@
 import * as z from 'zod';
 
-import { configService, getFunction } from '@nangohq/shared';
-import { report, zodErrorToHTTP } from '@nangohq/utils';
+import { zodErrorToHTTP } from '@nangohq/utils';
 
+import { handleGetIntegrationFunction } from './helpers.js';
 import { envSchema, functionTypeSchema, providerConfigKeySchema } from '../../../../../helpers/validation.js';
 import { asyncWrapper } from '../../../../../utils/asyncWrapper.js';
 
-import type { RequestLocals } from '../../../../../utils/express.js';
-import type { DBEnvironment, FunctionType, GetIntegrationFunction } from '@nangohq/types';
-import type { Response } from 'express';
+import type { GetIntegrationFunction } from '@nangohq/types';
 
 const querystringValidation = z
     .object({
@@ -23,46 +21,6 @@ const paramsValidation = z
         functionName: z.string().min(1).max(255)
     })
     .strict();
-
-export async function handleGetIntegrationFunction({
-    res,
-    environment,
-    providerConfigKey,
-    name,
-    type
-}: {
-    res: Response<GetIntegrationFunction['Reply'], Required<RequestLocals>>;
-    environment: DBEnvironment;
-    providerConfigKey: string;
-    name: string;
-    type: FunctionType | undefined;
-}): Promise<void> {
-    const integration = await configService.getProviderConfig(providerConfigKey, environment.id);
-    if (!integration) {
-        res.status(404).send({ error: { code: 'not_found', message: 'Integration does not exist' } });
-        return;
-    }
-
-    const fnResult = await getFunction({
-        environmentId: environment.id,
-        providerConfigKey,
-        name,
-        type
-    });
-
-    if (fnResult.isErr()) {
-        report(fnResult.error);
-        res.status(500).send({ error: { code: 'server_error', message: 'Failed to get function' } });
-        return;
-    }
-
-    if (!fnResult.value) {
-        res.status(404).send({ error: { code: 'not_found', message: 'Function does not exist' } });
-        return;
-    }
-
-    res.status(200).send({ data: fnResult.value });
-}
 
 export const getIntegrationFunction = asyncWrapper<GetIntegrationFunction>(async (req, res) => {
     const queryStringValues = querystringValidation.safeParse(req.query);

--- a/packages/server/lib/controllers/v1/integrations/providerConfigKey/functions/getFunction.ts
+++ b/packages/server/lib/controllers/v1/integrations/providerConfigKey/functions/getFunction.ts
@@ -3,15 +3,17 @@ import * as z from 'zod';
 import { configService, getFunction } from '@nangohq/shared';
 import { report, zodErrorToHTTP } from '@nangohq/utils';
 
-import { envSchema, providerConfigKeySchema } from '../../../../../helpers/validation.js';
+import { envSchema, functionTypeSchema, providerConfigKeySchema } from '../../../../../helpers/validation.js';
 import { asyncWrapper } from '../../../../../utils/asyncWrapper.js';
 
-import type { GetIntegrationFunction } from '@nangohq/types';
+import type { RequestLocals } from '../../../../../utils/express.js';
+import type { DBEnvironment, FunctionType, GetIntegrationFunction } from '@nangohq/types';
+import type { Response } from 'express';
 
 const querystringValidation = z
     .object({
         env: envSchema,
-        type: z.enum(['sync', 'action', 'on-event']).optional()
+        type: functionTypeSchema.optional()
     })
     .strict();
 
@@ -21,6 +23,46 @@ const paramsValidation = z
         functionName: z.string().min(1).max(255)
     })
     .strict();
+
+export async function handleGetIntegrationFunction({
+    res,
+    environment,
+    providerConfigKey,
+    name,
+    type
+}: {
+    res: Response<GetIntegrationFunction['Reply'], Required<RequestLocals>>;
+    environment: DBEnvironment;
+    providerConfigKey: string;
+    name: string;
+    type: FunctionType | undefined;
+}): Promise<void> {
+    const integration = await configService.getProviderConfig(providerConfigKey, environment.id);
+    if (!integration) {
+        res.status(404).send({ error: { code: 'not_found', message: 'Integration does not exist' } });
+        return;
+    }
+
+    const fnResult = await getFunction({
+        environmentId: environment.id,
+        providerConfigKey,
+        name,
+        type
+    });
+
+    if (fnResult.isErr()) {
+        report(fnResult.error);
+        res.status(500).send({ error: { code: 'server_error', message: 'Failed to get function' } });
+        return;
+    }
+
+    if (!fnResult.value) {
+        res.status(404).send({ error: { code: 'not_found', message: 'Function does not exist' } });
+        return;
+    }
+
+    res.status(200).send({ data: fnResult.value });
+}
 
 export const getIntegrationFunction = asyncWrapper<GetIntegrationFunction>(async (req, res) => {
     const queryStringValues = querystringValidation.safeParse(req.query);
@@ -39,29 +81,5 @@ export const getIntegrationFunction = asyncWrapper<GetIntegrationFunction>(async
     const { providerConfigKey, functionName } = valParams.data;
     const { type } = queryStringValues.data;
 
-    const integration = await configService.getProviderConfig(providerConfigKey, environment.id);
-    if (!integration) {
-        res.status(404).send({ error: { code: 'not_found', message: 'Integration does not exist' } });
-        return;
-    }
-
-    const fnResult = await getFunction({
-        environmentId: environment.id,
-        providerConfigKey,
-        name: functionName,
-        type
-    });
-
-    if (fnResult.isErr()) {
-        report(fnResult.error);
-        res.status(500).send({ error: { code: 'server_error', message: 'Failed to get function' } });
-        return;
-    }
-
-    if (!fnResult.value) {
-        res.status(404).send({ error: { code: 'not_found', message: 'Function does not exist' } });
-        return;
-    }
-
-    res.status(200).send({ data: fnResult.value });
+    await handleGetIntegrationFunction({ res, environment, providerConfigKey, name: functionName, type });
 });

--- a/packages/server/lib/controllers/v1/integrations/providerConfigKey/functions/getFunctions.ts
+++ b/packages/server/lib/controllers/v1/integrations/providerConfigKey/functions/getFunctions.ts
@@ -1,15 +1,13 @@
 import * as z from 'zod';
 
-import { configService, listFunctions } from '@nangohq/shared';
-import { report, zodErrorToHTTP } from '@nangohq/utils';
+import { zodErrorToHTTP } from '@nangohq/utils';
 
+import { handleListIntegrationFunctions } from './helpers.js';
 import { envSchema, functionListQueryFields } from '../../../../../helpers/validation.js';
 import { asyncWrapper } from '../../../../../utils/asyncWrapper.js';
 import { validationParams } from '../getIntegration.js';
 
-import type { RequestLocals } from '../../../../../utils/express.js';
-import type { DBEnvironment, FunctionType, GetIntegrationFunctions } from '@nangohq/types';
-import type { Response } from 'express';
+import type { GetIntegrationFunctions } from '@nangohq/types';
 
 const querystringValidation = z
     .object({
@@ -17,49 +15,6 @@ const querystringValidation = z
         ...functionListQueryFields
     })
     .strict();
-
-export async function handleListIntegrationFunctions({
-    res,
-    environment,
-    providerConfigKey,
-    type,
-    search,
-    page,
-    limit
-}: {
-    res: Response<GetIntegrationFunctions['Reply'], Required<RequestLocals>>;
-    environment: DBEnvironment;
-    providerConfigKey: string;
-    type: FunctionType | undefined;
-    search: string | undefined;
-    page: number;
-    limit: number;
-}): Promise<void> {
-    const integration = await configService.getProviderConfig(providerConfigKey, environment.id);
-    if (!integration) {
-        res.status(404).send({ error: { code: 'not_found', message: 'Integration does not exist' } });
-        return;
-    }
-
-    const fnResult = await listFunctions({
-        environmentId: environment.id,
-        providerConfigKey,
-        type,
-        search,
-        limit,
-        offset: page * limit
-    });
-
-    if (fnResult.isErr()) {
-        report(fnResult.error);
-        res.status(500).send({ error: { code: 'server_error', message: 'Failed to list functions' } });
-        return;
-    }
-
-    const { rows, total } = fnResult.value;
-
-    res.status(200).send({ data: rows, pagination: { total, page, limit } });
-}
 
 export const getIntegrationFunctions = asyncWrapper<GetIntegrationFunctions>(async (req, res) => {
     const queryStringValues = querystringValidation.safeParse(req.query);

--- a/packages/server/lib/controllers/v1/integrations/providerConfigKey/functions/getFunctions.ts
+++ b/packages/server/lib/controllers/v1/integrations/providerConfigKey/functions/getFunctions.ts
@@ -3,39 +3,38 @@ import * as z from 'zod';
 import { configService, listFunctions } from '@nangohq/shared';
 import { report, zodErrorToHTTP } from '@nangohq/utils';
 
-import { envSchema } from '../../../../../helpers/validation.js';
+import { envSchema, functionListQueryFields } from '../../../../../helpers/validation.js';
 import { asyncWrapper } from '../../../../../utils/asyncWrapper.js';
 import { validationParams } from '../getIntegration.js';
 
-import type { GetIntegrationFunctions } from '@nangohq/types';
+import type { RequestLocals } from '../../../../../utils/express.js';
+import type { DBEnvironment, FunctionType, GetIntegrationFunctions } from '@nangohq/types';
+import type { Response } from 'express';
 
 const querystringValidation = z
     .object({
         env: envSchema,
-        type: z.enum(['sync', 'action', 'on-event']).optional(),
-        search: z.string().trim().min(1).max(255).optional(),
-        page: z.coerce.number().int().min(0).optional().default(0),
-        limit: z.coerce.number().int().min(1).max(100).optional().default(20)
+        ...functionListQueryFields
     })
     .strict();
 
-export const getIntegrationFunctions = asyncWrapper<GetIntegrationFunctions>(async (req, res) => {
-    const queryStringValues = querystringValidation.safeParse(req.query);
-    if (!queryStringValues.success) {
-        res.status(400).send({ error: { code: 'invalid_query_params', errors: zodErrorToHTTP(queryStringValues.error) } });
-        return;
-    }
-
-    const valParams = validationParams.safeParse(req.params);
-    if (!valParams.success) {
-        res.status(400).send({ error: { code: 'invalid_uri_params', errors: zodErrorToHTTP(valParams.error) } });
-        return;
-    }
-
-    const { environment } = res.locals;
-    const { providerConfigKey } = valParams.data;
-    const { type, search, page, limit } = queryStringValues.data;
-
+export async function handleListIntegrationFunctions({
+    res,
+    environment,
+    providerConfigKey,
+    type,
+    search,
+    page,
+    limit
+}: {
+    res: Response<GetIntegrationFunctions['Reply'], Required<RequestLocals>>;
+    environment: DBEnvironment;
+    providerConfigKey: string;
+    type: FunctionType | undefined;
+    search: string | undefined;
+    page: number;
+    limit: number;
+}): Promise<void> {
     const integration = await configService.getProviderConfig(providerConfigKey, environment.id);
     if (!integration) {
         res.status(404).send({ error: { code: 'not_found', message: 'Integration does not exist' } });
@@ -60,4 +59,24 @@ export const getIntegrationFunctions = asyncWrapper<GetIntegrationFunctions>(asy
     const { rows, total } = fnResult.value;
 
     res.status(200).send({ data: rows, pagination: { total, page, limit } });
+}
+
+export const getIntegrationFunctions = asyncWrapper<GetIntegrationFunctions>(async (req, res) => {
+    const queryStringValues = querystringValidation.safeParse(req.query);
+    if (!queryStringValues.success) {
+        res.status(400).send({ error: { code: 'invalid_query_params', errors: zodErrorToHTTP(queryStringValues.error) } });
+        return;
+    }
+
+    const valParams = validationParams.safeParse(req.params);
+    if (!valParams.success) {
+        res.status(400).send({ error: { code: 'invalid_uri_params', errors: zodErrorToHTTP(valParams.error) } });
+        return;
+    }
+
+    const { environment } = res.locals;
+    const { providerConfigKey } = valParams.data;
+    const { type, search, page, limit } = queryStringValues.data;
+
+    await handleListIntegrationFunctions({ res, environment, providerConfigKey, type, search, page, limit });
 });

--- a/packages/server/lib/controllers/v1/integrations/providerConfigKey/functions/helpers.ts
+++ b/packages/server/lib/controllers/v1/integrations/providerConfigKey/functions/helpers.ts
@@ -1,0 +1,143 @@
+import { configService, getFunction, listFunctions } from '@nangohq/shared';
+import { report } from '@nangohq/utils';
+
+import { startFunctionDeletion } from '../../../../../tasks/startFunctionDeletion.js';
+
+import type { RequestLocals } from '../../../../../utils/express.js';
+import type { DBEnvironment, DeleteIntegrationFunction, FunctionType, GetIntegrationFunction, GetIntegrationFunctions } from '@nangohq/types';
+import type { Response } from 'express';
+
+export async function handleGetIntegrationFunction({
+    res,
+    environment,
+    providerConfigKey,
+    name,
+    type
+}: {
+    res: Response<GetIntegrationFunction['Reply'], Required<RequestLocals>>;
+    environment: DBEnvironment;
+    providerConfigKey: string;
+    name: string;
+    type: FunctionType | undefined;
+}): Promise<void> {
+    const integration = await configService.getProviderConfig(providerConfigKey, environment.id);
+    if (!integration) {
+        res.status(404).send({ error: { code: 'not_found', message: 'Integration does not exist' } });
+        return;
+    }
+
+    const fnResult = await getFunction({
+        environmentId: environment.id,
+        providerConfigKey,
+        name,
+        type
+    });
+
+    if (fnResult.isErr()) {
+        report(fnResult.error);
+        res.status(500).send({ error: { code: 'server_error', message: 'Failed to get function' } });
+        return;
+    }
+
+    if (!fnResult.value) {
+        res.status(404).send({ error: { code: 'not_found', message: 'Function does not exist' } });
+        return;
+    }
+
+    res.status(200).send({ data: fnResult.value });
+}
+
+export async function handleListIntegrationFunctions({
+    res,
+    environment,
+    providerConfigKey,
+    type,
+    search,
+    page,
+    limit
+}: {
+    res: Response<GetIntegrationFunctions['Reply'], Required<RequestLocals>>;
+    environment: DBEnvironment;
+    providerConfigKey: string;
+    type: FunctionType | undefined;
+    search: string | undefined;
+    page: number;
+    limit: number;
+}): Promise<void> {
+    const integration = await configService.getProviderConfig(providerConfigKey, environment.id);
+    if (!integration) {
+        res.status(404).send({ error: { code: 'not_found', message: 'Integration does not exist' } });
+        return;
+    }
+
+    const fnResult = await listFunctions({
+        environmentId: environment.id,
+        providerConfigKey,
+        type,
+        search,
+        limit,
+        offset: page * limit
+    });
+
+    if (fnResult.isErr()) {
+        report(fnResult.error);
+        res.status(500).send({ error: { code: 'server_error', message: 'Failed to list functions' } });
+        return;
+    }
+
+    const { rows, total } = fnResult.value;
+
+    res.status(200).send({ data: rows, pagination: { total, page, limit } });
+}
+
+export async function handleDeleteIntegrationFunction({
+    res,
+    environment,
+    providerConfigKey,
+    name,
+    type
+}: {
+    res: Response<DeleteIntegrationFunction['Reply'], Required<RequestLocals>>;
+    environment: DBEnvironment;
+    providerConfigKey: string;
+    name: string;
+    type: 'sync' | 'action';
+}): Promise<void> {
+    const integration = await configService.getProviderConfig(providerConfigKey, environment.id);
+    if (!integration) {
+        res.status(404).send({ error: { code: 'not_found', message: 'Integration does not exist' } });
+        return;
+    }
+
+    const fnResult = await getFunction({ environmentId: environment.id, providerConfigKey, name, type });
+    if (fnResult.isErr()) {
+        report(fnResult.error);
+        res.status(500).send({ error: { code: 'server_error', message: 'Failed to get function' } });
+        return;
+    }
+    if (!fnResult.value) {
+        res.status(404).send({ error: { code: 'not_found', message: 'Function does not exist' } });
+        return;
+    }
+
+    const fn = fnResult.value;
+    if (fn.source === 'repo') {
+        res.status(400).send({
+            error: { code: 'function_managed_by_deploy', message: 'repo functions are deleted through `nango deploy`, not this endpoint' }
+        });
+        return;
+    }
+
+    const enqueued = await startFunctionDeletion({
+        syncConfigId: fn.id,
+        environmentId: environment.id,
+        models: fn.type === 'on-event' ? [] : fn.returns
+    });
+    if (enqueued.isErr()) {
+        report(enqueued.error);
+        res.status(500).send({ error: { code: 'server_error', message: 'Failed to enqueue function deletion' } });
+        return;
+    }
+
+    res.status(200).send({ data: { success: true } });
+}

--- a/packages/server/lib/controllers/v1/providers/providerConfigKey/templates/getTemplates.ts
+++ b/packages/server/lib/controllers/v1/providers/providerConfigKey/templates/getTemplates.ts
@@ -1,32 +1,10 @@
-import { flowService } from '@nangohq/shared';
 import { requireEmptyQuery, zodErrorToHTTP } from '@nangohq/utils';
 
-import { toNangoFunction } from '../../../../../formatters/function.js';
+import { handleGetProviderTemplates } from './helpers.js';
 import { asyncWrapper } from '../../../../../utils/asyncWrapper.js';
 import { validationParams } from '../../getProvider.js';
 
-import type { RequestLocals } from '../../../../../utils/express.js';
 import type { GetProviderTemplates } from '@nangohq/types';
-import type { Response } from 'express';
-
-export function handleGetProviderTemplates({
-    res,
-    providerConfigKey
-}: {
-    res: Response<GetProviderTemplates['Reply'], Required<RequestLocals>>;
-    providerConfigKey: string;
-}): void {
-    const all = flowService.getAllAvailableFlowsAsStandardConfig();
-    const entry = all.find((value) => value.providerConfigKey === providerConfigKey);
-    const data = entry
-        ? [...entry.actions, ...entry.syncs].flatMap((e) => {
-              const fn = toNangoFunction(e);
-              return fn ? [fn] : [];
-          })
-        : [];
-
-    res.status(200).send({ data });
-}
 
 export const getProviderTemplates = asyncWrapper<GetProviderTemplates>((req, res) => {
     const emptyQuery = requireEmptyQuery(req, { withEnv: true });

--- a/packages/server/lib/controllers/v1/providers/providerConfigKey/templates/getTemplates.ts
+++ b/packages/server/lib/controllers/v1/providers/providerConfigKey/templates/getTemplates.ts
@@ -5,7 +5,28 @@ import { toNangoFunction } from '../../../../../formatters/function.js';
 import { asyncWrapper } from '../../../../../utils/asyncWrapper.js';
 import { validationParams } from '../../getProvider.js';
 
+import type { RequestLocals } from '../../../../../utils/express.js';
 import type { GetProviderTemplates } from '@nangohq/types';
+import type { Response } from 'express';
+
+export function handleGetProviderTemplates({
+    res,
+    providerConfigKey
+}: {
+    res: Response<GetProviderTemplates['Reply'], Required<RequestLocals>>;
+    providerConfigKey: string;
+}): void {
+    const all = flowService.getAllAvailableFlowsAsStandardConfig();
+    const entry = all.find((value) => value.providerConfigKey === providerConfigKey);
+    const data = entry
+        ? [...entry.actions, ...entry.syncs].flatMap((e) => {
+              const fn = toNangoFunction(e);
+              return fn ? [fn] : [];
+          })
+        : [];
+
+    res.status(200).send({ data });
+}
 
 export const getProviderTemplates = asyncWrapper<GetProviderTemplates>((req, res) => {
     const emptyQuery = requireEmptyQuery(req, { withEnv: true });
@@ -21,14 +42,6 @@ export const getProviderTemplates = asyncWrapper<GetProviderTemplates>((req, res
     }
 
     const { providerConfigKey } = valParams.data;
-    const all = flowService.getAllAvailableFlowsAsStandardConfig();
-    const entry = all.find((value) => value.providerConfigKey === providerConfigKey);
-    const data = entry
-        ? [...entry.actions, ...entry.syncs].flatMap((e) => {
-              const fn = toNangoFunction(e);
-              return fn ? [fn] : [];
-          })
-        : [];
 
-    res.status(200).send({ data });
+    handleGetProviderTemplates({ res, providerConfigKey });
 });

--- a/packages/server/lib/controllers/v1/providers/providerConfigKey/templates/helpers.ts
+++ b/packages/server/lib/controllers/v1/providers/providerConfigKey/templates/helpers.ts
@@ -1,0 +1,26 @@
+import { flowService } from '@nangohq/shared';
+
+import { toNangoFunction } from '../../../../../formatters/function.js';
+
+import type { RequestLocals } from '../../../../../utils/express.js';
+import type { GetProviderTemplates } from '@nangohq/types';
+import type { Response } from 'express';
+
+export function handleGetProviderTemplates({
+    res,
+    providerConfigKey
+}: {
+    res: Response<GetProviderTemplates['Reply'], Required<RequestLocals>>;
+    providerConfigKey: string;
+}): void {
+    const all = flowService.getAllAvailableFlowsAsStandardConfig();
+    const entry = all.find((value) => value.providerConfigKey === providerConfigKey);
+    const data = entry
+        ? [...entry.actions, ...entry.syncs].flatMap((e) => {
+              const fn = toNangoFunction(e);
+              return fn ? [fn] : [];
+          })
+        : [];
+
+    res.status(200).send({ data });
+}

--- a/packages/server/lib/helpers/validation.ts
+++ b/packages/server/lib/helpers/validation.ts
@@ -22,6 +22,17 @@ export const scriptNameSchema = z
     .string()
     .regex(/^[a-zA-Z0-9_-]+$/)
     .max(255);
+export const functionTypeSchema = z.enum(['sync', 'action', 'on-event']);
+// On-event functions can't be targeted by name alone yet, so deletion is limited to sync/action.
+export const deletableFunctionTypeSchema = z.enum(['sync', 'action']);
+// Shared querystring fields for the function-list endpoints. The private route adds `env`; the public route
+// derives the environment from the secret key, so it spreads these as-is.
+export const functionListQueryFields = {
+    type: functionTypeSchema.optional(),
+    search: z.string().trim().min(1).max(255).optional(),
+    page: z.coerce.number().int().min(0).optional().default(0),
+    limit: z.coerce.number().int().min(1).max(100).optional().default(20)
+};
 export const connectionIdSchema = z
     .string()
     .regex(/^[a-zA-Z0-9,.;:=+~[\]|@${}"'\\/_ -]+$/) // For legacy reason (some people are stringifying json and passing email)

--- a/packages/server/lib/routes.public.ts
+++ b/packages/server/lib/routes.public.ts
@@ -45,13 +45,17 @@ import { postFunctionDryrunResult } from './controllers/functions/dryrun/postDry
 import { getPublicListIntegrations } from './controllers/integrations/getListIntegrations.js';
 import { postPublicIntegration, postPublicQuickstartIntegration } from './controllers/integrations/postIntegration.js';
 import { deletePublicIntegration } from './controllers/integrations/uniqueKey/deleteIntegration.js';
+import { deletePublicIntegrationFunction } from './controllers/integrations/uniqueKey/functions/deleteFunction.js';
 import { getFunctionCode } from './controllers/integrations/uniqueKey/functions/getCode.js';
+import { getPublicIntegrationFunction } from './controllers/integrations/uniqueKey/functions/getFunction.js';
+import { getPublicIntegrationFunctions } from './controllers/integrations/uniqueKey/functions/getFunctions.js';
 import { getPublicIntegration } from './controllers/integrations/uniqueKey/getIntegration.js';
 import { patchPublicIntegration } from './controllers/integrations/uniqueKey/patchIntegration.js';
 import { getMcp, postMcp } from './controllers/mcp/mcp.js';
 import oauthController from './controllers/oauth.controller.js';
 import { getPublicProvider } from './controllers/providers/getProvider.js';
 import { getPublicProviders } from './controllers/providers/getProviders.js';
+import { getPublicProviderTemplates } from './controllers/providers/provider/templates/getTemplates.js';
 import { allPublicProxy } from './controllers/proxy/allProxy.js';
 import { getPublicRecords } from './controllers/records/getRecords.js';
 import { patchPublicPruneRecords } from './controllers/records/patchPruneRecords.js';
@@ -184,6 +188,7 @@ publicAPI.route('/webhook/:environmentUuid/:providerConfigKey').post(webhookIngr
 publicAPI.use('/providers', jsonContentTypeMiddleware);
 publicAPI.route('/providers').get(connectSessionOrApiAuth, acceptLanguageMiddleware, getPublicProviders);
 publicAPI.route('/providers/:provider').get(connectSessionOrApiAuth, acceptLanguageMiddleware, getPublicProvider);
+publicAPI.route('/providers/:provider/templates').get(apiAuth, withScope('environment:functions:list'), getPublicProviderTemplates);
 
 // @deprecated rollbacked for one customer, to delete asap
 publicAPI
@@ -210,6 +215,11 @@ publicAPI.route('/integrations/:uniqueKey').delete(apiAuth, withScope('environme
 publicAPI
     .route('/integrations/:uniqueKey/functions/:name/code')
     .get(apiAuth, withAnyScope('environment:integrations:read', 'environment:integrations:read_credentials'), getFunctionCode);
+publicAPI.route('/integrations/:uniqueKey/functions').get(apiAuth, withScope('environment:functions:list'), getPublicIntegrationFunctions);
+publicAPI
+    .route('/integrations/:uniqueKey/functions/:name')
+    .get(apiAuth, withScope('environment:functions:read'), getPublicIntegrationFunction)
+    .delete(apiAuth, withScope('environment:functions:delete'), deletePublicIntegrationFunction);
 
 // @deprecated connections
 publicAPI.use('/connection', jsonContentTypeMiddleware);

--- a/packages/types/lib/api-keys/scopes.ts
+++ b/packages/types/lib/api-keys/scopes.ts
@@ -29,6 +29,9 @@ export const API_KEY_SCOPES = [
     'environment:syncs:variant:delete',
     'environment:syncs:*',
     // Functions
+    'environment:functions:list',
+    'environment:functions:read',
+    'environment:functions:delete',
     'environment:functions:compile',
     'environment:functions:dryrun',
     'environment:functions:*',

--- a/packages/types/lib/api.endpoints.ts
+++ b/packages/types/lib/api.endpoints.ts
@@ -65,12 +65,16 @@ import type { PostEnvironmentVariables } from './environment/variable/api.js';
 import type { PatchFlowDisable, PatchFlowEnable, PatchFlowFrequency, PostPreBuiltDeploy, PutUpgradePreBuiltFlow } from './flow/http.api.js';
 import type {
     DeleteIntegrationFunction,
+    DeletePublicIntegrationFunction,
     GetFunctionDeployment,
     GetFunctionDryrun,
     GetIntegrationFunction,
     GetIntegrationFunctions,
     GetIntegrationTemplates,
     GetProviderTemplates,
+    GetPublicIntegrationFunction,
+    GetPublicIntegrationFunctions,
+    GetPublicProviderTemplates,
     PostFunctionCompile,
     PostFunctionDeployment,
     PostFunctionDeploymentResult,
@@ -166,6 +170,10 @@ export type PublicApiEndpoints =
     | GetFunctionDeployment
     | PostFunctionDeploymentResult
     | GetPublicFunctionCode
+    | GetPublicIntegrationFunctions
+    | GetPublicIntegrationFunction
+    | DeletePublicIntegrationFunction
+    | GetPublicProviderTemplates
     | AllPublicProxy;
 
 export type PrivateApiEndpoints =

--- a/packages/types/lib/functions/api.ts
+++ b/packages/types/lib/functions/api.ts
@@ -201,21 +201,38 @@ export type PostFunctionDeploymentResult = Endpoint<{
     Success: { ok: true };
 }>;
 
+// Shared between the private and public function-management endpoints. The two surfaces differ only in auth,
+// path, param names, and the `env` querystring (private) — the payloads and filters below are identical.
+export interface FunctionListFilters {
+    type?: FunctionType;
+    search?: string;
+    page?: number;
+    limit?: number;
+}
+
+export interface FunctionListSuccess {
+    data: DeployedNangoFunction[];
+    pagination: { total: number; page: number; limit: number };
+}
+
+export interface DeployedFunctionSuccess {
+    data: DeployedNangoFunction;
+}
+
+export interface FunctionDeletionSuccess {
+    data: { success: boolean };
+}
+
+export interface ProviderTemplatesSuccess {
+    data: (NangoSyncFunction | NangoActionFunction)[];
+}
+
 export type GetIntegrationFunctions = Endpoint<{
     Method: 'GET';
     Path: '/api/v1/integrations/:providerConfigKey/functions';
-    Querystring: {
-        env: string;
-        type?: FunctionType;
-        search?: string;
-        page?: number;
-        limit?: number;
-    };
+    Querystring: { env: string } & FunctionListFilters;
     Params: { providerConfigKey: string };
-    Success: {
-        data: DeployedNangoFunction[];
-        pagination: { total: number; page: number; limit: number };
-    };
+    Success: FunctionListSuccess;
 }>;
 
 export type GetIntegrationFunction = Endpoint<{
@@ -223,17 +240,17 @@ export type GetIntegrationFunction = Endpoint<{
     Path: '/api/v1/integrations/:providerConfigKey/functions/:functionName';
     Querystring: { env: string; type?: FunctionType };
     Params: { providerConfigKey: string; functionName: string };
-    Success: { data: DeployedNangoFunction };
+    Success: DeployedFunctionSuccess;
 }>;
 
 export type DeleteIntegrationFunction = Endpoint<{
     Method: 'DELETE';
     Path: '/api/v1/integrations/:providerConfigKey/functions/:functionName';
     /** TODO: support deleting on-event functions */
-    Querystring: { env: string; type: 'sync' | 'action' };
+    Querystring: { env: string; type: RunnableFunctionType };
     Params: { providerConfigKey: string; functionName: string };
     Error: ApiError<'function_managed_by_deploy'>;
-    Success: { data: { success: boolean } };
+    Success: FunctionDeletionSuccess;
 }>;
 
 export type GetProviderTemplates = Endpoint<{
@@ -241,7 +258,40 @@ export type GetProviderTemplates = Endpoint<{
     Path: '/api/v1/providers/:providerConfigKey/templates';
     Querystring: { env: string };
     Params: { providerConfigKey: string };
-    Success: { data: (NangoSyncFunction | NangoActionFunction)[] };
+    Success: ProviderTemplatesSuccess;
+}>;
+
+export type GetPublicIntegrationFunctions = Endpoint<{
+    Method: 'GET';
+    Path: '/integrations/:uniqueKey/functions';
+    Querystring: FunctionListFilters;
+    Params: { uniqueKey: string };
+    Success: FunctionListSuccess;
+}>;
+
+export type GetPublicIntegrationFunction = Endpoint<{
+    Method: 'GET';
+    Path: '/integrations/:uniqueKey/functions/:name';
+    Querystring: { type?: FunctionType };
+    Params: { uniqueKey: string; name: string };
+    Success: DeployedFunctionSuccess;
+}>;
+
+export type DeletePublicIntegrationFunction = Endpoint<{
+    Method: 'DELETE';
+    Path: '/integrations/:uniqueKey/functions/:name';
+    /** TODO: support deleting on-event functions */
+    Querystring: { type: RunnableFunctionType };
+    Params: { uniqueKey: string; name: string };
+    Error: ApiError<'function_managed_by_deploy'>;
+    Success: FunctionDeletionSuccess;
+}>;
+
+export type GetPublicProviderTemplates = Endpoint<{
+    Method: 'GET';
+    Path: '/providers/:provider/templates';
+    Params: { provider: string };
+    Success: ProviderTemplatesSuccess;
 }>;
 
 export type GetIntegrationTemplates = Endpoint<{

--- a/packages/usage/lib/clickhouse/migrate.ts
+++ b/packages/usage/lib/clickhouse/migrate.ts
@@ -37,7 +37,8 @@ export async function migrate({ database }: { database: string } = { database: u
 
     const client = clickhouseClient({ database });
     if (!client) {
-        return Err(Error('Clickhouse client not configured'));
+        logger.info('Clickhouse migration: config not set, skipping migration');
+        return Ok(undefined);
     }
     try {
         const migrationTable = `${database}.migrations`;

--- a/packages/utils/lib/api-key-scopes.ts
+++ b/packages/utils/lib/api-key-scopes.ts
@@ -55,7 +55,6 @@ export const apiKeyScopes = [
 ] as const satisfies readonly ApiKeyScope[];
 
 // The `satisfies` above rejects entries that aren't valid `ApiKeyScope`s;
-// the check below rejects any `ApiKeyScope` missing from this array.
-// Together they fail the build if the two lists drift apart.
-type Expect<T extends true> = T;
-export type _ApiKeyScopesAreExhaustive = Expect<[Exclude<ApiKeyScope, (typeof apiKeyScopes)[number]>] extends [never] ? true : false>;
+// the assertion below rejects any `ApiKeyScope` missing from this array.
+// Together they keep the two lists in sync.
+true satisfies [Exclude<ApiKeyScope, (typeof apiKeyScopes)[number]>] extends [never] ? true : never;

--- a/packages/utils/lib/api-key-scopes.ts
+++ b/packages/utils/lib/api-key-scopes.ts
@@ -31,6 +31,9 @@ export const apiKeyScopes = [
     'environment:syncs:variant:delete',
     'environment:syncs:*',
     // Functions
+    'environment:functions:list',
+    'environment:functions:read',
+    'environment:functions:delete',
     'environment:functions:compile',
     'environment:functions:dryrun',
     'environment:functions:*',
@@ -50,3 +53,9 @@ export const apiKeyScopes = [
     // MCP
     'environment:mcp'
 ] as const satisfies readonly ApiKeyScope[];
+
+// The `satisfies` above rejects entries that aren't valid `ApiKeyScope`s;
+// the check below rejects any `ApiKeyScope` missing from this array.
+// Together they fail the build if the two lists drift apart.
+type Expect<T extends true> = T;
+export type _ApiKeyScopesAreExhaustive = Expect<[Exclude<ApiKeyScope, (typeof apiKeyScopes)[number]>] extends [never] ? true : false>;

--- a/packages/webapp/src/pages/Environment/Settings/scope-logic.ts
+++ b/packages/webapp/src/pages/Environment/Settings/scope-logic.ts
@@ -47,6 +47,9 @@ export const SCOPE_GROUPS: ScopeGroup[] = [
     {
         group: 'Functions',
         items: [
+            { value: 'environment:functions:list', label: 'list' },
+            { value: 'environment:functions:read', label: 'read' },
+            { value: 'environment:functions:delete', label: 'delete' },
             { value: 'environment:functions:compile', label: 'compile' },
             { value: 'environment:functions:dryrun', label: 'dryrun' }
         ]


### PR DESCRIPTION
## Make function-management endpoints public

Adds public, secret-key-authed variants of the function-management endpoints so external clients can manage functions programmatically (previously webapp-only, behind session auth + RBAC).

### Approach

Each private handler's logic was extracted into a **shared core**, bound from both routers:

- **Private** (unchanged): `webAuth` + `can()` RBAC, environment from the `?env=` query.
- **Public** (new): `apiAuth` + scopes, environment derived from the secret key.

The two surfaces only differ at the seam — auth, path, param names (`uniqueKey`/`name` vs `providerConfigKey`/`functionName`), and `env` source. Everything else is shared: the business logic (core handlers), the validation rules (zod fragments in `helpers/validation.ts`), and the response/filter contracts (`Endpoint<>` types). No breaking change to the webapp.

### Migrated endpoints

- `GET /integrations/:uniqueKey/functions` — scope `environment:functions:list`
- `GET /integrations/:uniqueKey/functions/:name` — scope `environment:functions:read`
- `DELETE /integrations/:uniqueKey/functions/:name` — scope `environment:functions:delete`
- `GET /providers/:provider/templates` — scope `environment:functions:list`

The private `/api/v1/...` routes remain as-is. The richer `GET /integrations/:providerConfigKey/templates` (with deployment metadata) stays private.

### Also included

- New `environment:functions:{list,read,delete}` API-key scopes.
- OpenAPI spec entries in `docs/spec.yaml`, with `DeployedNangoFunction` / template payloads modeled as precise `oneOf` discriminated unions over shared base schemas.
- Integration tests for all four public endpoints (auth, scope enforcement, env-from-key, repo-delete rejection, soft-delete teardown, list/filter/pagination).