### PR TITLE
fix(webapp): pass real backend URL to connect-ui for WebSocket

### DIFF
--- a/packages/server/lib/controllers/v1/getEnvJs.ts
+++ b/packages/server/lib/controllers/v1/getEnvJs.ts
@@ -20,6 +20,7 @@ import type { RequestHandler } from 'express';
 export const getEnvJs: RequestHandler = (_, res) => {
     const configObject: WindowEnv = {
         apiUrl: baseUrl,
+        connectApiUrl: baseUrl,
         publicUrl: basePublicUrl,
         connectUrl: connectUrl,
         gitHash: envs.GIT_HASH,

--- a/packages/types/lib/web/env.ts
+++ b/packages/types/lib/web/env.ts
@@ -1,5 +1,17 @@
 export interface WindowEnv {
     apiUrl: string;
+    /** In local dev, apiUrl gets rewritten to the Vite dev server origin so the
+     * webapp's private API calls (/api/v1/...) stay same-origin; private routes
+     * only allow baseUrl/basePublicUrl origins, not wildcard.
+     *
+     * ConnectUI must bypass the proxy and hit the backend directly: its routes
+     * are on the public API (origin:'*'), and its OAuth WebSocket connects to
+     * path '/' — which Vite also uses for HMR, making WS proxying impossible
+     * without breaking hot-reload.
+     *
+     * In production, connectApiUrl equals apiUrl, so this is a no-op.
+     * */
+    connectApiUrl: string;
     publicUrl: string;
     connectUrl: string;
     gitHash: string | undefined;

--- a/packages/webapp/src/pages/Connection/components/CreateConnectionSelector.tsx
+++ b/packages/webapp/src/pages/Connection/components/CreateConnectionSelector.tsx
@@ -167,7 +167,7 @@ export const CreateConnectionSelector: React.FC<CreateConnectionSelectorProps> =
 
         connectUI.current = nango.openConnectUI({
             baseURL: globalEnv.connectUrl,
-            apiURL: globalEnv.apiUrl,
+            apiURL: globalEnv.connectApiUrl,
             onEvent
         });
 
@@ -201,7 +201,7 @@ export const CreateConnectionSelector: React.FC<CreateConnectionSelectorProps> =
 
             const { connect_link: connectLink, expires_at: expiresAt } = res.json.data;
             const shareUrl = new URL(connectLink);
-            shareUrl.searchParams.set('apiURL', globalEnv.apiUrl);
+            shareUrl.searchParams.set('apiURL', globalEnv.connectApiUrl);
 
             try {
                 await navigator.clipboard.writeText(shareUrl.toString());

--- a/packages/webapp/src/pages/Environment/Settings/ConnectUISettings/components/ConnectUIPreview.tsx
+++ b/packages/webapp/src/pages/Environment/Settings/ConnectUISettings/components/ConnectUIPreview.tsx
@@ -103,7 +103,7 @@ export const ConnectUIPreview = forwardRef<ConnectUIPreviewRef, { className?: st
 
         const iframe = createConnectUIPreviewIFrame({
             baseURL: globalEnv.connectUrl,
-            apiURL: globalEnv.apiUrl,
+            apiURL: globalEnv.connectApiUrl,
             sessionToken
         });
 

--- a/packages/webapp/src/pages/GettingStarted/FirstStep.tsx
+++ b/packages/webapp/src/pages/GettingStarted/FirstStep.tsx
@@ -50,7 +50,7 @@ export const FirstStep: React.FC<FirstStepProps> = ({ connection, integration, o
 
         connectUI.current = nango.openConnectUI({
             baseURL: globalEnv.connectUrl,
-            apiURL: globalEnv.apiUrl,
+            apiURL: globalEnv.connectApiUrl,
             onEvent
         });
 


### PR DESCRIPTION
Commit 42b59bd extended apiEnvProxyPlugin to local dev, rewriting apiUrl to the Vite server origin so same-origin requests bypass the private API CORS allowlist. A side effect: ConnectUI received the Vite origin as its apiURL and opened its OAuth WebSocket there. Vite uses path '/' for HMR, so the connection_ack never arrived, the OAuth popup stayed on about:blank, and the UI hung on "Connecting" indefinitely.

Introduce connectApiUrl in WindowEnv: set to baseUrl, but left as-is by the vite proxy (apiEnvProxyPlugin). ConnectUI uses it in order to reach the public API directly -- where origin:'*' allows it.

