### PR TITLE
chore(webapp): multi-worktree dev via dev CORS (alt to #6473)

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -13,7 +13,7 @@ For full local dev setup (Docker, service URLs, auth flows, troubleshooting), us
 
 ### Multiple worktrees (local backend)
 
-Run `npm run dev -w packages/webapp` from each worktree. Vite picks the next free port (3000 → 3001 → 3002 …) and rewrites `apiUrl` in `env.js` to match, routing all API traffic through Vite's proxy to the local backend at `localhost:3003`.
+Run `npm run dev -w packages/webapp` from each worktree. Vite picks the next free port (3000 → 3001 → 3002 …) and each dashboard calls the local backend at `localhost:3003` directly — the API's dev CORS trusts any `localhost` port, so no proxy or `apiUrl` rewrite is needed. Only `/env.js` is proxied so `window._env` loads same-origin.
 
 ### Remote API
 

--- a/packages/server/lib/utils/cors.ts
+++ b/packages/server/lib/utils/cors.ts
@@ -1,4 +1,4 @@
-import { basePublicUrl, baseUrl } from '@nangohq/utils';
+import { basePublicUrl, baseUrl, isLocal } from '@nangohq/utils';
 
 const allowedOrigins = new Set([basePublicUrl, baseUrl]);
 const publicHost = new URL(basePublicUrl).hostname;
@@ -9,6 +9,9 @@ const publicHost = new URL(basePublicUrl).hostname;
  * Allows:
  *  - undefined (same-origin / server-to-server requests)
  *  - origins in the explicit allowlist (basePublicUrl, baseUrl)
+ *  - in local dev only: any http://localhost:<port> / http://127.0.0.1:<port> origin,
+ *    so dashboards on auto-incremented Vite ports (3000, 3001, ... across worktrees)
+ *    can call the API directly without a proxy
  *  - HTTPS PR-preview subdomains of the form `pr-<number>.<publicHost>`
  */
 export function isAllowedWebCorsOrigin(origin: string | undefined): boolean {
@@ -16,6 +19,10 @@ export function isAllowedWebCorsOrigin(origin: string | undefined): boolean {
     if (allowedOrigins.has(origin)) return true;
     try {
         const url = new URL(origin);
+        // Local dev: trust any localhost port (gated to isLocal, never cloud/enterprise/docker/hosted)
+        if (isLocal && url.protocol === 'http:' && (url.hostname === 'localhost' || url.hostname === '127.0.0.1')) {
+            return true;
+        }
         // Only allow HTTPS, default port, and exact pr-<number>.<publicHost> (no extra labels)
         const escapedHost = publicHost.replace(/\./g, '\\.');
         return url.protocol === 'https:' && url.port === '' && new RegExp(`^pr-\\d+\\.${escapedHost}$`).test(url.hostname);

--- a/packages/server/lib/utils/cors.ts
+++ b/packages/server/lib/utils/cors.ts
@@ -9,7 +9,7 @@ const publicHost = new URL(basePublicUrl).hostname;
  * Allows:
  *  - undefined (same-origin / server-to-server requests)
  *  - origins in the explicit allowlist (basePublicUrl, baseUrl)
- *  - in local dev only: any http://localhost:<port> / http://127.0.0.1:<port> origin,
+ *  - in local dev only: any http loopback origin (localhost / 127.0.0.1 / [::1]) on any port,
  *    so dashboards on auto-incremented Vite ports (3000, 3001, ... across worktrees)
  *    can call the API directly without a proxy
  *  - HTTPS PR-preview subdomains of the form `pr-<number>.<publicHost>`
@@ -20,7 +20,7 @@ export function isAllowedWebCorsOrigin(origin: string | undefined): boolean {
     try {
         const url = new URL(origin);
         // Local dev: trust any localhost port (gated to isLocal, never cloud/enterprise/docker/hosted)
-        if (isLocal && url.protocol === 'http:' && (url.hostname === 'localhost' || url.hostname === '127.0.0.1')) {
+        if (isLocal && url.protocol === 'http:' && (url.hostname === 'localhost' || url.hostname === '127.0.0.1' || url.hostname === '[::1]')) {
             return true;
         }
         // Only allow HTTPS, default port, and exact pr-<number>.<publicHost> (no extra labels)

--- a/packages/server/lib/utils/cors.unit.test.ts
+++ b/packages/server/lib/utils/cors.unit.test.ts
@@ -1,55 +1,97 @@
-import { describe, expect, it, vi } from 'vitest';
+import { afterEach, describe, expect, it, vi } from 'vitest';
 
-import { isAllowedWebCorsOrigin } from './cors.js';
+// isAllowedWebCorsOrigin reads basePublicUrl/baseUrl/isLocal from @nangohq/utils at module
+// load, so we mock the module and re-import the unit fresh for each environment scenario.
+async function loadIsAllowed(utils: { basePublicUrl: string; baseUrl: string; isLocal: boolean }) {
+    vi.resetModules();
+    vi.doMock('@nangohq/utils', () => utils);
+    return (await import('./cors.js')).isAllowedWebCorsOrigin;
+}
 
-vi.mock('@nangohq/utils', () => ({
-    basePublicUrl: 'https://app-development.nango.dev',
-    baseUrl: 'https://api-development.nango.dev'
-}));
+afterEach(() => {
+    vi.resetModules();
+    vi.doUnmock('@nangohq/utils');
+});
 
-describe('isAllowedWebCorsOrigin', () => {
-    it('allows exact basePublicUrl', () => {
-        expect(isAllowedWebCorsOrigin('https://app-development.nango.dev')).toBe(true);
+describe('isAllowedWebCorsOrigin — cloud (isLocal=false)', () => {
+    const utils = { basePublicUrl: 'https://app-development.nango.dev', baseUrl: 'https://api-development.nango.dev', isLocal: false };
+
+    it('allows exact basePublicUrl', async () => {
+        expect((await loadIsAllowed(utils))('https://app-development.nango.dev')).toBe(true);
     });
 
-    it('allows exact baseUrl', () => {
-        expect(isAllowedWebCorsOrigin('https://api-development.nango.dev')).toBe(true);
+    it('allows exact baseUrl', async () => {
+        expect((await loadIsAllowed(utils))('https://api-development.nango.dev')).toBe(true);
     });
 
-    it('allows PR preview subdomains', () => {
-        expect(isAllowedWebCorsOrigin('https://pr-123.app-development.nango.dev')).toBe(true);
-        expect(isAllowedWebCorsOrigin('https://pr-0.app-development.nango.dev')).toBe(true);
-        expect(isAllowedWebCorsOrigin('https://pr-99999.app-development.nango.dev')).toBe(true);
+    it('allows PR preview subdomains', async () => {
+        const isAllowed = await loadIsAllowed(utils);
+        expect(isAllowed('https://pr-123.app-development.nango.dev')).toBe(true);
+        expect(isAllowed('https://pr-0.app-development.nango.dev')).toBe(true);
+        expect(isAllowed('https://pr-99999.app-development.nango.dev')).toBe(true);
     });
 
-    it('blocks non-pr-N subdomains', () => {
-        expect(isAllowedWebCorsOrigin('https://evil.app-development.nango.dev')).toBe(false);
-        expect(isAllowedWebCorsOrigin('https://pr-abc.app-development.nango.dev')).toBe(false);
-        expect(isAllowedWebCorsOrigin('https://pr-.app-development.nango.dev')).toBe(false);
+    it('blocks non-pr-N subdomains', async () => {
+        const isAllowed = await loadIsAllowed(utils);
+        expect(isAllowed('https://evil.app-development.nango.dev')).toBe(false);
+        expect(isAllowed('https://pr-abc.app-development.nango.dev')).toBe(false);
+        expect(isAllowed('https://pr-.app-development.nango.dev')).toBe(false);
     });
 
-    it('blocks subdomains of a different host', () => {
-        expect(isAllowedWebCorsOrigin('https://pr-123.evil.nango.dev')).toBe(false);
-        expect(isAllowedWebCorsOrigin('https://pr-123.nango.dev')).toBe(false);
+    it('blocks subdomains of a different host', async () => {
+        const isAllowed = await loadIsAllowed(utils);
+        expect(isAllowed('https://pr-123.evil.nango.dev')).toBe(false);
+        expect(isAllowed('https://pr-123.nango.dev')).toBe(false);
     });
 
-    it('allows requests with no origin (same-origin / server-to-server)', () => {
-        expect(isAllowedWebCorsOrigin(undefined)).toBe(true);
+    it('allows requests with no origin (same-origin / server-to-server)', async () => {
+        expect((await loadIsAllowed(utils))(undefined)).toBe(true);
     });
 
-    it('blocks malformed origin strings', () => {
-        expect(isAllowedWebCorsOrigin('not-a-url')).toBe(false);
+    it('blocks malformed origin strings', async () => {
+        expect((await loadIsAllowed(utils))('not-a-url')).toBe(false);
     });
 
-    it('blocks non-https preview origins', () => {
-        expect(isAllowedWebCorsOrigin('http://pr-123.app-development.nango.dev')).toBe(false);
+    it('blocks non-https preview origins', async () => {
+        expect((await loadIsAllowed(utils))('http://pr-123.app-development.nango.dev')).toBe(false);
     });
 
-    it('blocks preview origins with non-standard ports', () => {
-        expect(isAllowedWebCorsOrigin('https://pr-123.app-development.nango.dev:444')).toBe(false);
+    it('blocks preview origins with non-standard ports', async () => {
+        expect((await loadIsAllowed(utils))('https://pr-123.app-development.nango.dev:444')).toBe(false);
     });
 
-    it('blocks multi-label preview origins (e.g. pr-123.foo.publicHost)', () => {
-        expect(isAllowedWebCorsOrigin('https://pr-123.foo.app-development.nango.dev')).toBe(false);
+    it('blocks multi-label preview origins (e.g. pr-123.foo.publicHost)', async () => {
+        expect((await loadIsAllowed(utils))('https://pr-123.foo.app-development.nango.dev')).toBe(false);
+    });
+
+    it('blocks localhost origins when not local (proxy/rewrite territory, not direct)', async () => {
+        const isAllowed = await loadIsAllowed(utils);
+        expect(isAllowed('http://localhost:3000')).toBe(false);
+        expect(isAllowed('http://localhost:3001')).toBe(false);
+    });
+});
+
+describe('isAllowedWebCorsOrigin — local dev (isLocal=true)', () => {
+    const utils = { basePublicUrl: 'http://localhost:3000', baseUrl: 'http://localhost:3003', isLocal: true };
+
+    it('allows any localhost port (multi-worktree dashboards)', async () => {
+        const isAllowed = await loadIsAllowed(utils);
+        expect(isAllowed('http://localhost:3000')).toBe(true);
+        expect(isAllowed('http://localhost:3001')).toBe(true);
+        expect(isAllowed('http://localhost:54321')).toBe(true);
+    });
+
+    it('allows 127.0.0.1 on any port', async () => {
+        expect((await loadIsAllowed(utils))('http://127.0.0.1:3002')).toBe(true);
+    });
+
+    it('still blocks non-localhost origins', async () => {
+        const isAllowed = await loadIsAllowed(utils);
+        expect(isAllowed('http://evil.com')).toBe(false);
+        expect(isAllowed('https://evil.nango.dev')).toBe(false);
+    });
+
+    it('still blocks localhost-lookalike hosts', async () => {
+        expect((await loadIsAllowed(utils))('https://localhost.evil.com')).toBe(false);
     });
 });

--- a/packages/server/lib/utils/cors.unit.test.ts
+++ b/packages/server/lib/utils/cors.unit.test.ts
@@ -85,6 +85,10 @@ describe('isAllowedWebCorsOrigin — local dev (isLocal=true)', () => {
         expect((await loadIsAllowed(utils))('http://127.0.0.1:3002')).toBe(true);
     });
 
+    it('allows IPv6 loopback [::1] on any port', async () => {
+        expect((await loadIsAllowed(utils))('http://[::1]:3002')).toBe(true);
+    });
+
     it('still blocks non-localhost origins', async () => {
         const isAllowed = await loadIsAllowed(utils);
         expect(isAllowed('http://evil.com')).toBe(false);

--- a/packages/webapp/vite.config.ts
+++ b/packages/webapp/vite.config.ts
@@ -18,11 +18,10 @@ const REMOTE_API_URLS: Record<string, string> = {
     prod: 'https://api.nango.dev'
 };
 
-// REMOTE_API mode only: fetch /env.js from the remote API and rewrite apiUrl to the
-// local Vite dev server origin so all API calls are routed through Vite's proxy instead
-// of going cross-origin to a backend whose CORS we don't control. The actual listening
-// port is resolved at request time (after the server binds) so Vite's automatic port
-// increment is reflected correctly.
+// REMOTE_API mode only: fetch /env.js from the remote API and rewrite apiUrl to the local
+// Vite origin, so API calls route through Vite's proxy instead of cross-origin to a backend
+// whose CORS we don't control. Port is read at request time (after bind) to track Vite's
+// automatic port increment.
 function apiEnvProxyPlugin(apiUrl: string): Plugin {
     return {
         name: 'api-env-proxy',
@@ -47,11 +46,10 @@ function apiProxyConfig() {
         throw new Error(`[nango] Unknown REMOTE_API="${remoteApi}". Valid values: ${Object.keys(REMOTE_API_URLS).join(', ')}`);
     }
 
-    // Local dev (no REMOTE_API): the dashboard talks to the local API directly. The API's
-    // dev CORS trusts any localhost port, so multiple worktree dashboards on 3000/3001/...
-    // work without a proxy, and Connect UI reaches the real API (and its OAuth WebSocket)
-    // since apiUrl is left as the backend URL. We only proxy /env.js so the app can load
-    // window._env same-origin.
+    // Local dev (no REMOTE_API): dashboard talks to the local API directly. Dev CORS trusts
+    // any localhost port, so worktree dashboards on 3000/3001/... work without a proxy, and
+    // Connect UI reaches the real API (and its OAuth WebSocket) since apiUrl stays the backend
+    // URL. Only /env.js is proxied, so the app loads window._env same-origin.
     if (!remoteUrl) {
         return {
             envProxyPlugin: null as Plugin | null,
@@ -65,8 +63,7 @@ function apiProxyConfig() {
         envProxyPlugin: apiEnvProxyPlugin(remoteUrl) as Plugin | null,
         proxy: {
             '/api': proxyOpts,
-            // Extra routes needed for connection creation and auth flows.
-            // Most dashboard functionality (viewing connections, logs, settings) works with /api alone.
+            // Extra routes for connection creation and auth flows; most of the dashboard works with /api alone.
             '/connect': proxyOpts, // Connect UI session + telemetry
             '/integrations': proxyOpts, // Connect UI integration list
             '/providers': proxyOpts, // Connect UI provider details

--- a/packages/webapp/vite.config.ts
+++ b/packages/webapp/vite.config.ts
@@ -49,10 +49,11 @@ function apiProxyConfig() {
     // Local dev (no REMOTE_API): dashboard talks to the local API directly. Dev CORS trusts
     // any localhost port, so worktree dashboards on 3000/3001/... work without a proxy, and
     // Connect UI reaches the real API (and its OAuth WebSocket) since apiUrl stays the backend
-    // URL. Only /env.js is proxied, so the app loads window._env same-origin.
+    // URL. We still proxy /env.js because the app requests it as a relative path (it can't
+    // know the backend origin until env.js sets window._env) and only the backend serves it.
     if (!remoteUrl) {
         return {
-            envProxyPlugin: null as Plugin | null,
+            envProxyPlugin: null,
             proxy: { '/env.js': { target: `http://localhost:${LOCAL_API_PORT}` } }
         };
     }
@@ -60,7 +61,7 @@ function apiProxyConfig() {
     // REMOTE_API mode: proxy all API traffic to the remote backend and rewrite apiUrl.
     const proxyOpts = { target: remoteUrl, changeOrigin: true };
     return {
-        envProxyPlugin: apiEnvProxyPlugin(remoteUrl) as Plugin | null,
+        envProxyPlugin: apiEnvProxyPlugin(remoteUrl),
         proxy: {
             '/api': proxyOpts,
             // Extra routes for connection creation and auth flows; most of the dashboard works with /api alone.
@@ -82,7 +83,8 @@ export default defineConfig(() => {
     const { envProxyPlugin, proxy } = apiProxyConfig();
 
     return {
-        plugins: [react(), svgr(), checker({ typescript: true }), tailwindcss(), envProxyPlugin].filter((p): p is Plugin => p !== null),
+        // Vite ignores falsy plugins, so envProxyPlugin can be null in local dev (no REMOTE_API).
+        plugins: [react(), svgr(), checker({ typescript: true }), tailwindcss(), envProxyPlugin],
         resolve: {
             alias: {
                 '@': path.resolve(__dirname, './src'),

--- a/packages/webapp/vite.config.ts
+++ b/packages/webapp/vite.config.ts
@@ -18,10 +18,11 @@ const REMOTE_API_URLS: Record<string, string> = {
     prod: 'https://api.nango.dev'
 };
 
-// Fetches /env.js from apiUrl and rewrites apiUrl to the local Vite dev server
-// so all API calls are routed through Vite's proxy instead of going cross-origin.
-// The actual listening port is resolved at request time (after the server binds)
-// so Vite's automatic port increment is reflected correctly.
+// REMOTE_API mode only: fetch /env.js from the remote API and rewrite apiUrl to the
+// local Vite dev server origin so all API calls are routed through Vite's proxy instead
+// of going cross-origin to a backend whose CORS we don't control. The actual listening
+// port is resolved at request time (after the server binds) so Vite's automatic port
+// increment is reflected correctly.
 function apiEnvProxyPlugin(apiUrl: string): Plugin {
     return {
         name: 'api-env-proxy',
@@ -46,10 +47,22 @@ function apiProxyConfig() {
         throw new Error(`[nango] Unknown REMOTE_API="${remoteApi}". Valid values: ${Object.keys(REMOTE_API_URLS).join(', ')}`);
     }
 
-    const apiUrl = remoteUrl ?? `http://localhost:${LOCAL_API_PORT}`;
-    const proxyOpts = remoteUrl ? { target: apiUrl, changeOrigin: true } : { target: apiUrl };
+    // Local dev (no REMOTE_API): the dashboard talks to the local API directly. The API's
+    // dev CORS trusts any localhost port, so multiple worktree dashboards on 3000/3001/...
+    // work without a proxy, and Connect UI reaches the real API (and its OAuth WebSocket)
+    // since apiUrl is left as the backend URL. We only proxy /env.js so the app can load
+    // window._env same-origin.
+    if (!remoteUrl) {
+        return {
+            envProxyPlugin: null as Plugin | null,
+            proxy: { '/env.js': { target: `http://localhost:${LOCAL_API_PORT}` } }
+        };
+    }
+
+    // REMOTE_API mode: proxy all API traffic to the remote backend and rewrite apiUrl.
+    const proxyOpts = { target: remoteUrl, changeOrigin: true };
     return {
-        envProxyPlugin: apiEnvProxyPlugin(apiUrl),
+        envProxyPlugin: apiEnvProxyPlugin(remoteUrl) as Plugin | null,
         proxy: {
             '/api': proxyOpts,
             // Extra routes needed for connection creation and auth flows.
@@ -72,7 +85,7 @@ export default defineConfig(() => {
     const { envProxyPlugin, proxy } = apiProxyConfig();
 
     return {
-        plugins: [react(), svgr(), checker({ typescript: true }), tailwindcss(), envProxyPlugin],
+        plugins: [react(), svgr(), checker({ typescript: true }), tailwindcss(), envProxyPlugin].filter((p): p is Plugin => p !== null),
         resolve: {
             alias: {
                 '@': path.resolve(__dirname, './src'),


### PR DESCRIPTION
## Problem

Running multiple worktree dashboards means each Vite dev server binds a different port (3000, 3001, ...). The private API's dev CORS only allows `localhost:3000`, so any dashboard on another port gets CORS errors. #6261 solved this by proxying all API routes through Vite and rewriting `apiUrl` to the Vite origin — but that fed the Vite origin to Connect UI, whose OAuth WebSocket (path `/`) then collided with Vite HMR, leaving the auth popup stuck on `about:blank` (the bug #6473 fixes).

This is an alternative to #6473 that removes the proxy/rewrite machinery for local dev entirely, so the Connect UI breakage can't happen in the first place.

## Solution

Let the API's dev CORS trust any `http://localhost:<port>` / `http://127.0.0.1:<port>` origin, gated to `isLocal` (never cloud/enterprise/docker/hosted). Every worktree dashboard can then call the local API directly regardless of port — no proxy needed.

Because `apiUrl` is no longer rewritten, Connect UI receives the real backend URL and its OAuth WebSocket reaches `localhost:3003` directly instead of colliding with Vite HMR — so no `connectApiUrl` field or Connect UI call-site changes are needed.

Local webapp dev no longer proxies API routes; only `/env.js` is proxied so `window._env` loads same-origin. `REMOTE_API=dev|staging|prod` mode keeps the full proxy + `apiUrl` rewrite, since we don't control the remote backend's CORS.

### Trade-offs vs #6473

- Fewer files (3 vs 5); removes the local proxy + rewrite rather than adding a field threaded through Connect UI call sites.
- Fixes the local case only. #6473's `connectApiUrl` also repairs Connect UI under `REMOTE_API` mode; this PR leaves `REMOTE_API` Connect UI unchanged (still broken there).
- Relies on the dev session cookie being `SameSite=Lax` and `localhost:<a>`↔`localhost:<b>` being same-site (port is not part of "site"), so the cookie flows on the cross-origin XHR. Verified working.
- "Allow any localhost origin" means another page served from your own machine's localhost could call the local dev API with credentials. Dev-only (gated to `isLocal`), against dev data, and a small delta over today since `localhost:3000` is already allowed. A remote site cannot — the browser sets `Origin`, and a non-localhost origin is still rejected.

## Testing

- `cors.unit.test.ts` rewritten to cover both gates: cloud (`isLocal=false`) blocks `localhost` origins; local (`isLocal=true`) allows any localhost port and `127.0.0.1`, still blocks non-localhost and lookalike hosts. 15/15 pass.
- Manual, local backend, dashboard on **:3011** (a non-3000 port, no proxy):
  - Cross-origin login (`:3011` → `:3003`) succeeds; dashboard `/api/v1/*` calls go directly to `:3003`.
  - Connect UI → Authorize → Connect → the OAuth popup navigates to the provider's auth page instead of hanging on `about:blank`.
- Ran the same flow against #6473 for comparison — identical end result.
