### PR TITLE
feat(lint): speed up pre-commit with type-unaware ESLint

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -9,6 +9,7 @@ Run `npm run ts-build` before autofixing lint errors using npm run lint:fix. Fre
 
 - `npm run lint` / `npm run lint:fix` — full ESLint with type-aware rules (requires `ts-build` artifacts, ~74s).
 - `npm run lint:fast` / `npm run lint:fast:fix` — ESLint with type-aware rules disabled; includes Prettier and needs no `ts-build` (~20s for the repo vs ~74s; a single file ~0.5s vs ~3–5s). Use after refactors to fix import ordering and formatting fast. CI still runs the full type-aware `npm run lint`, so type-aware rules stay enforced.
+- The **pre-commit hook** lints staged files with this fast config (via `lint-staged`), so commits don't build a TypeScript program — fast, and no `ts-build` needed. Type-aware errors are caught by CI, not at commit time.
 
 ## Running Nango locally
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -5,6 +5,11 @@ After running the initial `npm install` or `npm ci`, run `npm run prepare` to in
 
 Run `npm run ts-build` before autofixing lint errors using npm run lint:fix. Fresh worktrees don't have `dist/` (gitignored), so workspace packages like `@nangohq/types` can't resolve, causing false ESLint errors and broken type-checking.
 
+## Linting
+
+- `npm run lint` / `npm run lint:fix` — full ESLint with type-aware rules (requires `ts-build` artifacts, ~74s).
+- `npm run lint:fast` / `npm run lint:fast:fix` — ESLint with type-aware rules disabled; includes Prettier and needs no `ts-build` (~20s for the repo vs ~74s; a single file ~0.5s vs ~3–5s). Use after refactors to fix import ordering and formatting fast. CI still runs the full type-aware `npm run lint`, so type-aware rules stay enforced.
+
 ## Running Nango locally
 
 For full local dev setup (Docker, service URLs, auth flows, troubleshooting), use the `running-and-testing-locally` skill.

--- a/eslint.fast.config.mjs
+++ b/eslint.fast.config.mjs
@@ -5,6 +5,7 @@ import baseConfig from './eslint.config.mjs';
 // The full ESLint config with type-aware rules disabled — for fast local linting.
 //   npm run lint:fast        - check (includes prettier)
 //   npm run lint:fast:fix    - autofix imports, formatting, and type-import style
+//   pre-commit (lint-staged) - lints staged files with this config so commits stay fast
 //
 // Type-aware rules require building a TypeScript program per tsconfig, which
 // dominates runtime (full `npm run lint` ~74s, and a single webapp file ~3-5s).

--- a/eslint.fast.config.mjs
+++ b/eslint.fast.config.mjs
@@ -1,0 +1,44 @@
+import * as tseslint from 'typescript-eslint';
+
+import baseConfig from './eslint.config.mjs';
+
+// The full ESLint config with type-aware rules disabled — for fast local linting.
+//   npm run lint:fast        - check (includes prettier)
+//   npm run lint:fast:fix    - autofix imports, formatting, and type-import style
+//
+// Type-aware rules require building a TypeScript program per tsconfig, which
+// dominates runtime (full `npm run lint` ~74s, and a single webapp file ~3-5s).
+// Disabling them drops a single file to ~0.5s and the whole repo to ~20s, with no
+// `ts-build` needed. CI still runs the full type-aware `npm run lint`, so the
+// type-aware rules remain enforced there.
+export default tseslint.config(
+    ...baseConfig,
+
+    // disableTypeChecked sets parserOptions.project: false so the TypeScript
+    // program is never loaded — this is where the speed comes from — and turns
+    // off every rule that needs type information.
+    {
+        files: ['**/*.{ts,tsx,mts,mtsx}'],
+        extends: [tseslint.configs.disableTypeChecked]
+    },
+
+    // Resolution-based import rules read each imported module to verify its
+    // exports exist. They don't help autofix imports/formatting and account for a
+    // large share of the remaining runtime, so turn them off in the fast path.
+    {
+        rules: {
+            'import/named': 'off',
+            'import/default': 'off'
+        }
+    },
+
+    // Type-aware rules are disabled here, so the codebase's inline
+    // `// eslint-disable @typescript-eslint/...` directives for those rules read
+    // as "unused" — but they're needed by the full lint. Silence these false
+    // positives so the fast path doesn't suggest removing real directives.
+    {
+        linterOptions: {
+            reportUnusedDisableDirectives: 'off'
+        }
+    }
+);

--- a/package.json
+++ b/package.json
@@ -90,7 +90,7 @@
     },
     "lint-staged": {
         "*.{js,jsx,ts,tsx,cjs}": [
-            "eslint --fix --quiet"
+            "eslint --fix --quiet --config eslint.fast.config.mjs"
         ],
         "*.{html,css,json,yaml}": [
             "prettier --write"

--- a/package.json
+++ b/package.json
@@ -13,6 +13,8 @@
         "prettier-watch": "onchange './**/*.{ts,tsx}' -- prettier --write {{changed}}",
         "lint": "eslint . ",
         "lint:fix": "eslint . --fix",
+        "lint:fast": "eslint . --config eslint.fast.config.mjs",
+        "lint:fast:fix": "eslint . --config eslint.fast.config.mjs --fix",
         "ts-build": "tsc -b tsconfig.build.json",
         "ts-build:docker": "tsc -b tsconfig.docker.json",
         "ts-clean": "npx rimraf packages/*/tsconfig.tsbuildinfo packages/*/dist",


### PR DESCRIPTION
## Problem

The pre-commit hook runs `lint-staged` → `eslint --fix` on staged files with the full type-aware config, which builds a TypeScript program first. A one-line change to a webapp file takes ~5s to lint at commit (more for other packages), so commits are slow — which pushes people to `git commit --no-verify`, and then the issues the hook would have auto-fixed (imports, formatting) reach the PR and fail CI.

## Solution

Add `eslint.fast.config.mjs` — the full config with `tseslint.configs.disableTypeChecked` applied (sets `parserOptions.project: false`, so no TypeScript program is ever built) and the slow resolution-based import rules (`import/named`, `import/default`) turned off. Point `lint-staged` at it so the pre-commit hook lints staged files in ~0.5–1.5s instead of ~5s, with no `ts-build`/`dist` needed. Also exposed as `npm run lint:fast` / `lint:fast:fix` for manual runs. It silences the false "unused eslint-disable directive" warnings that appear only because type-aware rules are off.

## Scope

- Type-aware rules (`no-floating-promises`, `no-unsafe-*`, `restrict-template-expressions`, …) are no longer checked at commit time. CI's `npm run lint` is unchanged and still runs the full type-aware lint, so they stay enforced before merge.
- The pre-commit autofixers that actually cause PR churn — Prettier, `import/order`, unused imports — still run.

## Testing

- Pre-commit `eslint --fix --quiet --config eslint.fast.config.mjs` on a webapp file: ~0.5–1.5s (vs ~5s type-aware), exit 0.
- `npm run lint:fast` over the whole repo: ~20s (vs ~74s for `npm run lint`), exit 0.
- The new `eslint.fast.config.mjs` passes the full type-aware `npm run lint`.
- No `ts-build` / `dist` artifacts needed for the hook.
