### PR TITLE
fix(providers): update the authorization url for twitter-v2

### DIFF
--- a/packages/providers/providers.yaml
+++ b/packages/providers/providers.yaml
@@ -20667,7 +20667,7 @@ twitter-v2:
         - marketing
         - social
     auth_mode: OAUTH2
-    authorization_url: https://twitter.com/i/oauth2/authorize
+    authorization_url: https://x.com/i/oauth2/authorize
     token_url: https://api.twitter.com/2/oauth2/token
     token_request_auth_method: basic
     authorization_params:


### PR DESCRIPTION
## Describe the problem and your solution

- update the authorization url for twitter-v2 to their `x.com` hostname.

<!-- Issue ticket number and link (if applicable) -->

<!-- Testing instructions (skip if just adding/editing providers) -->



<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/NangoHQ/nango/pull/6479?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

