### PR TITLE
ci: raise eslint heap limit to 8GB

### DIFF
--- a/.github/workflows/lint.yaml
+++ b/.github/workflows/lint.yaml
@@ -69,7 +69,7 @@ jobs:
             - name: Lint
               if: needs.should-run.outputs.should_skip != 'true'
               env:
-                  NODE_OPTIONS: --max-old-space-size=4096
+                  NODE_OPTIONS: --max-old-space-size=8192
               run: npm run lint -- --quiet
     typecheck:
         needs: should-run


### PR DESCRIPTION
## Problem

The `lint-code` job runs type-aware eslint over the whole monorepo and OOMs at the current `--max-old-space-size=4096`, failing intermittently across multiple branches (JS heap out of memory, exit 134).

## Solution

Raise the limit to 8192. The `blacksmith-4vcpu-ubuntu-2404` runner has ~16GB RAM, so 8GB heap leaves plenty of headroom.

## Testing

- This PR's own `lint-code` job runs with the new 8GB limit and passes.