### PR TITLE
feat(usage): dual-write Orb + ClickHouse on the capping path with divergence telemetry

### DIFF
--- a/packages/usage/lib/billing.ts
+++ b/packages/usage/lib/billing.ts
@@ -4,9 +4,10 @@ import { RateLimiterQueue, RateLimiterRedis, RateLimiterRes } from 'rate-limiter
 import { stringify as stableStringify } from 'safe-stable-stringify';
 
 import { billing } from '@nangohq/billing';
-import { Err, Ok, metrics } from '@nangohq/utils';
+import { Err, Ok, metrics, stringifyError } from '@nangohq/utils';
 
 import { envs } from './env.js';
+import { logger } from './logger.js';
 
 import type { getRedis } from '@nangohq/kvstore';
 import type { BillingUsageMetrics, GetBillingUsageOpts } from '@nangohq/types';
@@ -62,8 +63,8 @@ export class UsageBillingClient {
                     await this.redis.set(cacheKey, JSON.stringify(res.value), {
                         EX: envs.USAGE_BILLING_API_CACHE_TTL_SECONDS
                     });
-                } catch {
-                    // ignore cache set errors
+                } catch (err) {
+                    logger.warning(`billing usage Orb cache write failed for subscription=${subscriptionId}: ${stringifyError(err)}`);
                 }
                 return Ok({ value: res.value, fromCache: false });
             }

--- a/packages/usage/lib/clickhouse/clickhouse.ts
+++ b/packages/usage/lib/clickhouse/clickhouse.ts
@@ -535,14 +535,17 @@ export class Clickhouse {
     // Returns all five COUNTER billing metrics in one call (matches Orb's
     // shape). One revalidate amortises the cache refresh across every billing
     // metric — keep this fanned-out even though the trigger is per-metric.
-    async getCurrentMonthBillingMetrics(accountId: number, now: Date): Promise<Result<BillingUsageMetrics>> {
+    async getCurrentMonthBillingMetrics(accountId: number, now: Date, opts?: { maxExecutionSeconds?: number }): Promise<Result<BillingUsageMetrics>> {
         const monthStart = new Date(Date.UTC(now.getUTCFullYear(), now.getUTCMonth(), 1));
         const nextMonth = new Date(Date.UTC(now.getUTCFullYear(), now.getUTCMonth() + 1, 1));
         const timeframe = { start: monthStart, end: nextMonth };
+        const maxExecOpt = opts?.maxExecutionSeconds !== undefined ? { maxExecutionSeconds: opts.maxExecutionSeconds } : {};
 
         const results = await Promise.all(
             COUNTER_METRICS.map((metric) =>
-                this.getDailyCounter({ accountId, metric, dimension: 'none', timeframe } as GetDailyCounterQuery).then((r) => [metric, r] as const)
+                this.getDailyCounter({ accountId, metric, dimension: 'none', timeframe, ...maxExecOpt } as GetDailyCounterQuery).then(
+                    (r) => [metric, r] as const
+                )
             )
         );
 

--- a/packages/usage/lib/usage.ts
+++ b/packages/usage/lib/usage.ts
@@ -455,7 +455,7 @@ export class UsageTracker implements IUsageTracker {
         const timeoutErr = new Error('shadow_timeout');
         let timeoutId: ReturnType<typeof setTimeout> | undefined;
         const chResult = await Promise.race<Result<BillingUsageMetrics>>([
-            this.getClickhouse().getCurrentMonthBillingMetrics(accountId, new Date()),
+            this.getClickhouse().getCurrentMonthBillingMetrics(accountId, new Date(), { maxExecutionSeconds: SHADOW_CH_MAX_EXECUTION_SECONDS }),
             new Promise((resolve) => {
                 timeoutId = setTimeout(() => resolve(Err(timeoutErr)), SHADOW_TIMEOUT_MS);
             })

--- a/packages/usage/lib/usage.ts
+++ b/packages/usage/lib/usage.ts
@@ -49,6 +49,15 @@ export function shouldShadow(opts: GetBillingUsageOpts | undefined): opts is Get
     return opts.timeframe.start >= SHADOW_MIN_TIMEFRAME_START;
 }
 
+// Per-call random sample (not account-based) so we can ramp + killswitch CH
+// load without an account cohort being permanently in or out.
+export function shouldShadowCapping(opts: GetBillingUsageOpts | undefined): boolean {
+    if (opts?.timeframe) return false;
+    const pct = envs.FLAG_BILLING_USAGE_CAPPING_SHADOW_CLICKHOUSE_PERCENTAGE;
+    if (pct <= 0) return false;
+    return Math.random() * 100 < pct;
+}
+
 let cachedAllowlistCsv: string | undefined;
 let cachedAllowlist = new Set<number>();
 function getRolloutAllowlist(): Set<number> {
@@ -165,6 +174,7 @@ export class UsageTrackerNoOps implements IUsageTracker {
 
 export class UsageTracker implements IUsageTracker {
     private cache: UsageCache;
+    private redis: Awaited<ReturnType<typeof getRedis>>;
     public billingClient: UsageBillingClient;
     // Read-only client for the dashboard CH path (gated by
     // FLAG_ALLOW_OVERRIDE_GETUSAGE_SERVICE + per-request `source` override).
@@ -174,6 +184,7 @@ export class UsageTracker implements IUsageTracker {
 
     constructor(redis: Awaited<ReturnType<typeof getRedis>>) {
         this.cache = new UsageCache(redis);
+        this.redis = redis;
         this.billingClient = new UsageBillingClient(redis);
     }
 
@@ -374,6 +385,12 @@ export class UsageTracker implements IUsageTracker {
             });
         }
 
+        if (!billingUsageMetrics.value.fromCache && shouldShadowCapping(opts)) {
+            void this.shadowCappingAgainstClickhouse({ accountId, orbResult: orbValue }).catch((err: unknown) => {
+                logger.error(`billing-usage capping shadow failed: ${stringifyError(err)}`);
+            });
+        }
+
         return Ok(formatted);
     }
 
@@ -430,6 +447,52 @@ export class UsageTracker implements IUsageTracker {
             const divergence = Math.abs(orbTotal - chTotal) / denom;
             const higher = orbTotal === chTotal ? 'equal' : orbTotal > chTotal ? 'orb' : 'ch';
             metrics.distribution(metrics.Types.BILLING_USAGE_SHADOW_DIVERGENCE, divergence, { accountId, metric, higher });
+        }
+    }
+
+    private async shadowCappingAgainstClickhouse({ accountId, orbResult }: { accountId: number; orbResult: BillingUsageMetrics }): Promise<void> {
+        const start = process.hrtime.bigint();
+        const timeoutErr = new Error('shadow_timeout');
+        let timeoutId: ReturnType<typeof setTimeout> | undefined;
+        const chResult = await Promise.race<Result<BillingUsageMetrics>>([
+            this.getClickhouse().getCurrentMonthBillingMetrics(accountId, new Date()),
+            new Promise((resolve) => {
+                timeoutId = setTimeout(() => resolve(Err(timeoutErr)), SHADOW_TIMEOUT_MS);
+            })
+        ]);
+        clearTimeout(timeoutId);
+
+        const outcome = chResult.isOk() ? 'ok' : chResult.error === timeoutErr ? 'timeout' : 'ch_error';
+        const elapsedMs = Number(process.hrtime.bigint() - start) / 1e6;
+        metrics.distribution(metrics.Types.BILLING_USAGE_CAPPING_SHADOW_DURATION_MS, elapsedMs, { outcome });
+        if (chResult.isErr()) return;
+
+        // Populate `billing:usage:ch:<accountId>` so the eventual source flip
+        // from Orb to CH doesn't cold-start every account against CH on cutover.
+        const cacheKey = `billing:usage:ch:${accountId}`;
+        try {
+            await this.redis.set(cacheKey, JSON.stringify(chResult.value), { EX: envs.USAGE_BILLING_API_CACHE_TTL_SECONDS });
+        } catch (err) {
+            logger.warning(`capping shadow CH cache write failed for account=${accountId}: ${stringifyError(err)}`);
+        }
+
+        // Capping path covers only COUNTER metrics — connections/records read
+        // from Postgres on the capping path and aren't returned by either Orb
+        // (no-timeframe scopes to billing period totals, AVG metrics are
+        // formatter-only) or the CH primitive here.
+        for (const metric of COUNTER_METRICS) {
+            const orbTotal = orbResult[metric]?.total ?? 0;
+            const chTotal = chResult.value[metric]?.total ?? 0;
+            if (orbTotal === 0 && chTotal === 0) continue;
+            if (orbTotal === 0 || chTotal === 0) {
+                const zeroSide = orbTotal === 0 ? 'orb' : 'ch';
+                metrics.increment(metrics.Types.BILLING_USAGE_CAPPING_SHADOW_ONE_SIDED, 1, { accountId, metric, zeroSide });
+                continue;
+            }
+            const denom = Math.max(orbTotal, chTotal);
+            const divergence = Math.abs(orbTotal - chTotal) / denom;
+            const higher = orbTotal === chTotal ? 'equal' : orbTotal > chTotal ? 'orb' : 'ch';
+            metrics.distribution(metrics.Types.BILLING_USAGE_CAPPING_SHADOW_DIVERGENCE, divergence, { accountId, metric, higher });
         }
     }
 

--- a/packages/usage/lib/usage.unit.test.ts
+++ b/packages/usage/lib/usage.unit.test.ts
@@ -1,7 +1,14 @@
-import { afterEach, beforeEach, describe, expect, it } from 'vitest';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 
 import { envs } from './env.js';
-import { resolveBillingUsageSource, shouldShadow, shouldUseClickhouseFor, toCounterBillingMetricSeries, toRunningAvgUsage } from './usage.js';
+import {
+    resolveBillingUsageSource,
+    shouldShadow,
+    shouldShadowCapping,
+    shouldUseClickhouseFor,
+    toCounterBillingMetricSeries,
+    toRunningAvgUsage
+} from './usage.js';
 
 import type { GetDailyCounterResult, GetDailySumAndBatchesResult } from './clickhouse/clickhouse.query.js';
 
@@ -312,6 +319,54 @@ describe('shouldShadow', () => {
         (envs as any).FLAG_BILLING_USAGE_SHADOW_CLICKHOUSE = true;
         expect(shouldShadow({ timeframe: junePlus })).toBe(true);
         expect(shouldShadow({ timeframe: { start: new Date('2026-06-01T00:00:00.000Z'), end: new Date('2026-06-02T00:00:00.000Z') } })).toBe(true);
+    });
+});
+
+describe('shouldShadowCapping', () => {
+    const someTimeframe = { start: new Date('2026-06-15T00:00:00.000Z'), end: new Date('2026-06-20T00:00:00.000Z') };
+
+    let originalPct: number;
+    let randomSpy: ReturnType<typeof vi.spyOn>;
+    beforeEach(() => {
+        originalPct = envs.FLAG_BILLING_USAGE_CAPPING_SHADOW_CLICKHOUSE_PERCENTAGE;
+        randomSpy = vi.spyOn(Math, 'random');
+    });
+    afterEach(() => {
+        (envs as any).FLAG_BILLING_USAGE_CAPPING_SHADOW_CLICKHOUSE_PERCENTAGE = originalPct;
+        randomSpy.mockRestore();
+    });
+
+    it('returns false when the percentage is at the default 0 (killswitch)', () => {
+        (envs as any).FLAG_BILLING_USAGE_CAPPING_SHADOW_CLICKHOUSE_PERCENTAGE = 0;
+        randomSpy.mockReturnValue(0); // even a 0 roll shouldn't fire
+        expect(shouldShadowCapping(undefined)).toBe(false);
+        expect(shouldShadowCapping({})).toBe(false);
+    });
+
+    it('returns false when a timeframe is present (dashboard path, not capping)', () => {
+        (envs as any).FLAG_BILLING_USAGE_CAPPING_SHADOW_CLICKHOUSE_PERCENTAGE = 100;
+        randomSpy.mockReturnValue(0);
+        expect(shouldShadowCapping({ timeframe: someTimeframe })).toBe(false);
+    });
+
+    it('fires when the random roll is under the percentage', () => {
+        (envs as any).FLAG_BILLING_USAGE_CAPPING_SHADOW_CLICKHOUSE_PERCENTAGE = 25;
+        randomSpy.mockReturnValue(0.24); // 24% — under 25%
+        expect(shouldShadowCapping(undefined)).toBe(true);
+    });
+
+    it('does not fire when the random roll is at or over the percentage', () => {
+        (envs as any).FLAG_BILLING_USAGE_CAPPING_SHADOW_CLICKHOUSE_PERCENTAGE = 25;
+        randomSpy.mockReturnValue(0.25); // 25% — boundary, NOT under
+        expect(shouldShadowCapping(undefined)).toBe(false);
+        randomSpy.mockReturnValue(0.99);
+        expect(shouldShadowCapping(undefined)).toBe(false);
+    });
+
+    it('always fires at 100%', () => {
+        (envs as any).FLAG_BILLING_USAGE_CAPPING_SHADOW_CLICKHOUSE_PERCENTAGE = 100;
+        randomSpy.mockReturnValue(0.999);
+        expect(shouldShadowCapping(undefined)).toBe(true);
     });
 });
 

--- a/packages/utils/lib/environment/parse.ts
+++ b/packages/utils/lib/environment/parse.ts
@@ -329,6 +329,7 @@ export const ENVS = z.object({
     // fires on cache miss + June-2026+ timeframe; fire-and-forget so it adds
     // no user-visible latency. Emits `nango.billing.usage.shadow.*` metrics.
     FLAG_BILLING_USAGE_SHADOW_CLICKHOUSE: z.stringbool().optional().default(false),
+    FLAG_BILLING_USAGE_CAPPING_SHADOW_CLICKHOUSE_PERCENTAGE: z.coerce.number().int().min(0).max(100).optional().default(0),
     FLAG_BILLING_USAGE_CLICKHOUSE_ROLLOUT_ACCOUNT_IDS: z.string().optional().default(''),
     FLAG_BILLING_USAGE_CLICKHOUSE_ROLLOUT_PERCENTAGE: z.coerce.number().int().min(0).max(100).optional().default(0),
 

--- a/packages/utils/lib/telemetry/metrics.ts
+++ b/packages/utils/lib/telemetry/metrics.ts
@@ -152,6 +152,9 @@ export enum Types {
     BILLING_USAGE_SHADOW_DIVERGENCE = 'nango.billing.usage.shadow.divergence',
     BILLING_USAGE_SHADOW_ONE_SIDED = 'nango.billing.usage.shadow.one_sided',
     BILLING_USAGE_SHADOW_DURATION_MS = 'nango.billing.usage.shadow.duration_ms',
+    BILLING_USAGE_CAPPING_SHADOW_DIVERGENCE = 'nango.billing.usage.capping.shadow.divergence',
+    BILLING_USAGE_CAPPING_SHADOW_ONE_SIDED = 'nango.billing.usage.capping.shadow.one_sided',
+    BILLING_USAGE_CAPPING_SHADOW_DURATION_MS = 'nango.billing.usage.capping.shadow.duration_ms',
 
     USAGE_IS_CAPPED = 'nango.capping.isCapped',
 


### PR DESCRIPTION
- Adds a percentage-gated shadow on the Orb capping cache-miss path: when sampled in (`FLAG_BILLING_USAGE_CAPPING_SHADOW_CLICKHOUSE_PERCENTAGE`, default `0`), fires CH alongside Orb, races it against a 5.5s timeout, caches the response under `billing:usage:ch:<accountId>` with the same 6h TTL as the Orb cache, and emits per-metric divergence telemetry under `nango.billing.usage.capping.shadow.*`. Orb stays authoritative; net production behaviour at deploy is unchanged.
- Aligns Orb-side cache-write failure handling with the new CH side: both now `logger.warning(...)` + swallow + rely on the next request to refill (Orb previously caught silently).
- Unblocks NAN-5954: with this path running at full rampup for one inner-TTL cycle (6h), every revalidating account will have a populated CH cache entry, so the source flip won't cold-start every account against CH.

## Test plan

- [x] `npm run ts-build` passes.
- [x] 5 unit tests on `shouldShadowCapping`: killswitch at 0, timeframe-present rejection, under-pct fires, at/over-pct doesn't, 100% always fires.
- [ ] After merge + deploy with `FLAG_BILLING_USAGE_CAPPING_SHADOW_CLICKHOUSE_PERCENTAGE=0`: zero behaviour change — no CH calls, no DD signals.
- [ ] After bumping to e.g. 5%: DD shows `nango.billing.usage.capping.shadow.duration_ms{outcome:ok}` populating, `.divergence` and `.one_sided` start emitting per-metric samples.
- [ ] Confirm `billing:usage:ch:<accountId>` keys appear in Redis with ~6h TTL for accounts that got sampled.

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/NangoHQ/nango/pull/6482?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

