### PR TITLE
feat(metering): persist data_transfer events to CH

### DIFF
--- a/packages/metering/lib/crons/billingEventsS3Export.integration.test.ts
+++ b/packages/metering/lib/crons/billingEventsS3Export.integration.test.ts
@@ -26,10 +26,6 @@ const baseAttributes = {
 // per-branch inside `gen()`.
 type FixtureAttrs = Record<string, unknown>;
 
-// 'usage.data_transfer' excluded: not ingested into Clickhouse yet.
-// TODO: Remove Exclude when CH ingestion is added.
-type IngestedEventType = Exclude<ClickhouseRawUsageEvent['type'], 'usage.data_transfer'>;
-
 function genN({
     n,
     day,
@@ -39,7 +35,7 @@ function genN({
 }: {
     n: number;
     day: string;
-    type: IngestedEventType;
+    type: ClickhouseRawUsageEvent['type'];
     accountId: number;
     attributes?: FixtureAttrs;
 }): ClickhouseRawUsageEvent[] {
@@ -54,7 +50,7 @@ function gen({
     attributes = {}
 }: {
     day: string;
-    type: IngestedEventType;
+    type: ClickhouseRawUsageEvent['type'];
     accountId: number;
     value?: number;
     attributes?: FixtureAttrs;
@@ -87,6 +83,8 @@ function gen({
                 return { type, attrs: { ...baseAttributes, model: 'test', syncId: 'test', ...attributes } };
             case 'usage.connections':
                 return { type, attrs: { ...baseAttributes, ...attributes } };
+            case 'usage.data_transfer':
+                return { type, attrs: { ...baseAttributes, direction: 'egress', package: 'runner', callsite: 'test', ...attributes } };
             default:
                 throw new Error(`unsupported event type ${type satisfies never}`);
         }

--- a/packages/metering/lib/processors/usage.ts
+++ b/packages/metering/lib/processors/usage.ts
@@ -295,6 +295,7 @@ export class UsageProcessor {
                     const { package: pkg, callsite, ingressedBytes, egressedBytes } = event.payload.properties;
                     metrics.increment(metrics.Types.DATA_TRANSFER, ingressedBytes, { package: pkg, callsite, direction: 'ingress' });
                     metrics.increment(metrics.Types.DATA_TRANSFER, egressedBytes, { package: pkg, callsite, direction: 'egress' });
+                    this.clickhouse.add([event]);
                     return Ok(undefined);
                 }
                 default:

--- a/packages/server/lib/controllers/v1/plans/usage/getBillingUsage.ts
+++ b/packages/server/lib/controllers/v1/plans/usage/getBillingUsage.ts
@@ -24,7 +24,8 @@ const breakdownFields = {
     function_compute_gbms: z.enum(BREAKDOWN_DIMENSIONS.function_compute_gbms).optional(),
     webhook_forwards: z.enum(BREAKDOWN_DIMENSIONS.webhook_forwards).optional(),
     records: z.enum(BREAKDOWN_DIMENSIONS.records).optional(),
-    connections: z.enum(BREAKDOWN_DIMENSIONS.connections).optional()
+    connections: z.enum(BREAKDOWN_DIMENSIONS.connections).optional(),
+    data_transfer: z.enum(BREAKDOWN_DIMENSIONS.data_transfer).optional()
 } satisfies Record<UsageMetric, z.ZodTypeAny>;
 
 const breakdownSchema = z.object(breakdownFields).strict().optional();
@@ -73,7 +74,8 @@ const filterFields = {
     function_compute_gbms: parseFilter(BREAKDOWN_DIMENSIONS.function_compute_gbms).optional(),
     webhook_forwards: parseFilter(BREAKDOWN_DIMENSIONS.webhook_forwards).optional(),
     records: parseFilter(BREAKDOWN_DIMENSIONS.records).optional(),
-    connections: parseFilter(BREAKDOWN_DIMENSIONS.connections).optional()
+    connections: parseFilter(BREAKDOWN_DIMENSIONS.connections).optional(),
+    data_transfer: parseFilter(BREAKDOWN_DIMENSIONS.data_transfer).optional()
 } satisfies Record<UsageMetric, z.ZodTypeAny>;
 
 const filterSchema = z.object(filterFields).strict().optional();

--- a/packages/server/lib/controllers/v1/plans/usage/getBillingUsageTopDimensionValues.ts
+++ b/packages/server/lib/controllers/v1/plans/usage/getBillingUsageTopDimensionValues.ts
@@ -21,7 +21,8 @@ const metricBranches = {
     function_compute_gbms: z.object({ metric: z.literal('function_compute_gbms'), dimension: z.enum(BREAKDOWN_DIMENSIONS.function_compute_gbms) }),
     webhook_forwards: z.object({ metric: z.literal('webhook_forwards'), dimension: z.enum(BREAKDOWN_DIMENSIONS.webhook_forwards) }),
     records: z.object({ metric: z.literal('records'), dimension: z.enum(BREAKDOWN_DIMENSIONS.records) }),
-    connections: z.object({ metric: z.literal('connections'), dimension: z.enum(BREAKDOWN_DIMENSIONS.connections) })
+    connections: z.object({ metric: z.literal('connections'), dimension: z.enum(BREAKDOWN_DIMENSIONS.connections) }),
+    data_transfer: z.object({ metric: z.literal('data_transfer'), dimension: z.enum(BREAKDOWN_DIMENSIONS.data_transfer) })
 } satisfies Record<UsageMetric, z.ZodObject>;
 
 // `Object.values` widens to a plain array; the cast restores the non-empty

--- a/packages/server/lib/controllers/v1/plans/usage/getUsage.ts
+++ b/packages/server/lib/controllers/v1/plans/usage/getUsage.ts
@@ -60,6 +60,11 @@ export const getUsage = asyncWrapper<GetUsage>(async (req, res) => {
             label: getMetricLabel('webhook_forwards'),
             usage: usage.value.webhook_forwards.current,
             limit: plan.webhook_forwards_max
+        },
+        data_transfer: {
+            label: getMetricLabel('data_transfer'),
+            usage: usage.value.data_transfer.current,
+            limit: null
         }
     };
 

--- a/packages/server/lib/formatters/billingUsage.ts
+++ b/packages/server/lib/formatters/billingUsage.ts
@@ -7,7 +7,8 @@ const labelMap: Record<UsageMetric, string> = {
     function_compute_gbms: 'Function time (ms)',
     function_logs: 'Function logs',
     records: 'Sync records',
-    webhook_forwards: 'Webhook forwarding'
+    webhook_forwards: 'Webhook forwarding',
+    data_transfer: 'Data transfer'
 };
 
 export function getMetricLabel(metric: UsageMetric): string {
@@ -39,6 +40,7 @@ export function toApiBillingUsageMetrics(usageMetrics: BillingUsageMetrics): Api
         function_executions: toApiBillingUsageMetric(usageMetrics.function_executions, 'function_executions'),
         function_logs: toApiBillingUsageMetric(usageMetrics.function_logs, 'function_logs'),
         records: toApiBillingUsageMetric(usageMetrics.records, 'records'),
-        webhook_forwards: toApiBillingUsageMetric(usageMetrics.webhook_forwards, 'webhook_forwards')
+        webhook_forwards: toApiBillingUsageMetric(usageMetrics.webhook_forwards, 'webhook_forwards'),
+        data_transfer: toApiBillingUsageMetric(usageMetrics.data_transfer, 'data_transfer')
     };
 }

--- a/packages/types/lib/billing/types.ts
+++ b/packages/types/lib/billing/types.ts
@@ -81,6 +81,7 @@ export interface BreakdownDimensions {
     webhook_forwards: 'environment_id' | 'integration_id' | 'connection_id' | 'success';
     records: 'environment_id' | 'integration_id' | 'connection_id' | 'model';
     connections: 'environment_id' | 'integration_id';
+    data_transfer: 'environment_id' | 'integration_id' | 'connection_id' | 'direction' | 'package' | 'callsite';
 }
 
 // `'none'` is the in-band sentinel for "no breakdown" used by the CH query

--- a/packages/types/lib/billing/types.ts
+++ b/packages/types/lib/billing/types.ts
@@ -81,7 +81,7 @@ export interface BreakdownDimensions {
     webhook_forwards: 'environment_id' | 'integration_id' | 'connection_id' | 'success';
     records: 'environment_id' | 'integration_id' | 'connection_id' | 'model';
     connections: 'environment_id' | 'integration_id';
-    data_transfer: 'environment_id' | 'integration_id' | 'connection_id' | 'direction' | 'package' | 'callsite';
+    data_transfer: 'environment_id' | 'integration_id' | 'connection_id' | 'package' | 'callsite';
 }
 
 // `'none'` is the in-band sentinel for "no breakdown" used by the CH query

--- a/packages/types/lib/usage/index.ts
+++ b/packages/types/lib/usage/index.ts
@@ -1,4 +1,12 @@
-export type UsageMetric = 'proxy' | 'connections' | 'function_executions' | 'function_compute_gbms' | 'records' | 'webhook_forwards' | 'function_logs';
+export type UsageMetric =
+    | 'proxy'
+    | 'connections'
+    | 'function_executions'
+    | 'function_compute_gbms'
+    | 'records'
+    | 'webhook_forwards'
+    | 'function_logs'
+    | 'data_transfer';
 
 export interface MetricUsageSummary {
     label: string;

--- a/packages/usage/lib/capping.ts
+++ b/packages/usage/lib/capping.ts
@@ -96,6 +96,9 @@ export class Capping {
                 return plan.webhook_forwards_max;
             case 'function_logs':
                 return plan.function_logs_max;
+            case 'data_transfer':
+                // Data transfer is not capped (yet?)
+                return null;
         }
     }
 
@@ -115,6 +118,8 @@ export class Capping {
                 return 'You have reached the maximum number of webhook forwards for your plan.';
             case 'function_logs':
                 return 'You have reached the maximum number of function logs for your plan.';
+            case 'data_transfer':
+                return 'You have reached the maximum data transfer for your plan.';
         }
     }
 }

--- a/packages/usage/lib/clickhouse/clickhouse.integration.test.ts
+++ b/packages/usage/lib/clickhouse/clickhouse.integration.test.ts
@@ -84,7 +84,43 @@ describe('Clickhouse', () => {
                 genEvent({ date: dayFromNow(0), type: 'usage.records', accountId, value: 1100, attributes: { integrationId: 'a' } }),
                 genEvent({ date: dayFromNow(0), type: 'usage.records', accountId, value: 500, attributes: { integrationId: 'b' } }),
                 genEvent({ date: dayFromNow(1), type: 'usage.records', accountId, value: 1100, attributes: { integrationId: 'a' } }),
-                genEvent({ date: dayFromNow(1), type: 'usage.records', accountId, value: 500, attributes: { integrationId: 'b' } })
+                genEvent({ date: dayFromNow(1), type: 'usage.records', accountId, value: 500, attributes: { integrationId: 'b' } }),
+                // data_transfer
+                // day 0: 3 egress events × 1000 bytes = 3000 bytes egress
+                ...genEventsN({
+                    n: 3,
+                    date: dayFromNow(),
+                    type: 'usage.data_transfer',
+                    accountId,
+                    attributes: { direction: 'egress', package: 'runner', callsite: 'test' },
+                    value: 1000
+                }),
+                // day 1: 2 ingress events × 500 bytes = 1000 bytes ingress
+                ...genEventsN({
+                    n: 2,
+                    date: dayFromNow(1),
+                    type: 'usage.data_transfer',
+                    accountId,
+                    attributes: { direction: 'ingress', package: 'server', callsite: 'test' },
+                    value: 500
+                }),
+                // different account (must be excluded)
+                ...genEventsN({
+                    n: 5,
+                    date: dayFromNow(),
+                    type: 'usage.data_transfer',
+                    accountId: 999,
+                    attributes: { direction: 'egress', package: 'runner', callsite: 'test' },
+                    value: 100
+                }),
+                // out of timeframe (must be excluded)
+                genEvent({
+                    date: dayFromNow(-1),
+                    type: 'usage.data_transfer',
+                    accountId,
+                    value: 999,
+                    attributes: { direction: 'egress', package: 'server', callsite: 'test' }
+                })
             ]);
             await clickhouse.flush(); // force flush to make sure all events are ingested before we query
         });
@@ -237,6 +273,42 @@ describe('Clickhouse', () => {
                                 { day: dayFromNow(), value: 6 },
                                 { day: dayFromNow(1), value: 3 }
                             ]
+                        }
+                    ]
+                });
+            });
+
+            it('data_transfer, no dimension', async () => {
+                const res = await clickhouse.getDailyCounter({ accountId, metric: 'data_transfer', dimension: 'none', timeframe: { start, end } });
+                expect(res.unwrap()).toStrictEqual({
+                    accountId,
+                    metric: 'data_transfer',
+                    series: [
+                        {
+                            days: [
+                                { day: dayFromNow(), value: 3000 },
+                                { day: dayFromNow(1), value: 1000 }
+                            ]
+                        }
+                    ]
+                });
+            });
+
+            it('data_transfer broken down by direction', async () => {
+                const res = await clickhouse.getDailyCounter({ accountId, metric: 'data_transfer', dimension: 'direction', timeframe: { start, end } });
+                expect(res.unwrap()).toStrictEqual({
+                    accountId,
+                    metric: 'data_transfer',
+                    series: [
+                        {
+                            dimension: 'direction',
+                            dimensionValue: 'egress',
+                            days: [{ day: dayFromNow(), value: 3000 }]
+                        },
+                        {
+                            dimension: 'direction',
+                            dimensionValue: 'ingress',
+                            days: [{ day: dayFromNow(1), value: 1000 }]
                         }
                     ]
                 });
@@ -899,15 +971,17 @@ function genEventsN({
     date,
     type,
     accountId,
+    value,
     attributes = {}
 }: {
     n: number;
     date: Date;
     type: ClickhouseRawUsageEvent['type'];
     accountId: ClickhouseRawUsageEvent['account_id'];
+    value?: number;
     attributes?: Partial<ClickhouseRawUsageEvent['attributes']>;
 }): ClickhouseRawUsageEvent[] {
-    return Array.from({ length: n }).map((_) => genEvent({ date, type, accountId, attributes }));
+    return Array.from({ length: n }).map((_) => genEvent({ date, type, accountId, ...(value !== undefined ? { value } : {}), attributes }));
 }
 
 function genEvent({
@@ -1007,6 +1081,22 @@ function genEvent({
                 attributes: {
                     ...baseAttributes,
                     batchId: rnd.uuid(),
+                    ...attributes
+                }
+            };
+
+        case 'usage.data_transfer':
+            return {
+                ts: date.getTime(),
+                type,
+                idempotency_key: rnd.string(),
+                account_id: accountId,
+                value,
+                attributes: {
+                    ...baseAttributes,
+                    direction: 'egress',
+                    package: 'runner',
+                    callsite: 'test',
                     ...attributes
                 }
             };

--- a/packages/usage/lib/clickhouse/clickhouse.integration.test.ts
+++ b/packages/usage/lib/clickhouse/clickhouse.integration.test.ts
@@ -86,22 +86,22 @@ describe('Clickhouse', () => {
                 genEvent({ date: dayFromNow(1), type: 'usage.records', accountId, value: 1100, attributes: { integrationId: 'a' } }),
                 genEvent({ date: dayFromNow(1), type: 'usage.records', accountId, value: 500, attributes: { integrationId: 'b' } }),
                 // data_transfer
-                // day 0: 3 egress events × 1000 bytes = 3000 bytes egress
+                // day 0: 3 events × 1000 bytes via runner = 3000 bytes
                 ...genEventsN({
                     n: 3,
                     date: dayFromNow(),
                     type: 'usage.data_transfer',
                     accountId,
-                    attributes: { direction: 'egress', package: 'runner', callsite: 'test' },
+                    attributes: { egressedBytes: 1000, ingressedBytes: 0, package: 'runner', callsite: 'proxy' },
                     value: 1000
                 }),
-                // day 1: 2 ingress events × 500 bytes = 1000 bytes ingress
+                // day 1: 2 events × 500 bytes via server = 1000 bytes
                 ...genEventsN({
                     n: 2,
                     date: dayFromNow(1),
                     type: 'usage.data_transfer',
                     accountId,
-                    attributes: { direction: 'ingress', package: 'server', callsite: 'test' },
+                    attributes: { egressedBytes: 0, ingressedBytes: 500, package: 'server', callsite: 'proxy' },
                     value: 500
                 }),
                 // different account (must be excluded)
@@ -110,7 +110,7 @@ describe('Clickhouse', () => {
                     date: dayFromNow(),
                     type: 'usage.data_transfer',
                     accountId: 999,
-                    attributes: { direction: 'egress', package: 'runner', callsite: 'test' },
+                    attributes: { egressedBytes: 100, ingressedBytes: 0, package: 'runner', callsite: 'proxy' },
                     value: 100
                 }),
                 // out of timeframe (must be excluded)
@@ -119,7 +119,7 @@ describe('Clickhouse', () => {
                     type: 'usage.data_transfer',
                     accountId,
                     value: 999,
-                    attributes: { direction: 'egress', package: 'server', callsite: 'test' }
+                    attributes: { egressedBytes: 999, ingressedBytes: 0, package: 'server', callsite: 'proxy' }
                 })
             ]);
             await clickhouse.flush(); // force flush to make sure all events are ingested before we query
@@ -294,20 +294,20 @@ describe('Clickhouse', () => {
                 });
             });
 
-            it('data_transfer broken down by direction', async () => {
-                const res = await clickhouse.getDailyCounter({ accountId, metric: 'data_transfer', dimension: 'direction', timeframe: { start, end } });
+            it('data_transfer broken down by package', async () => {
+                const res = await clickhouse.getDailyCounter({ accountId, metric: 'data_transfer', dimension: 'package', timeframe: { start, end } });
                 expect(res.unwrap()).toStrictEqual({
                     accountId,
                     metric: 'data_transfer',
                     series: [
                         {
-                            dimension: 'direction',
-                            dimensionValue: 'egress',
+                            dimension: 'package',
+                            dimensionValue: 'runner',
                             days: [{ day: dayFromNow(), value: 3000 }]
                         },
                         {
-                            dimension: 'direction',
-                            dimensionValue: 'ingress',
+                            dimension: 'package',
+                            dimensionValue: 'server',
                             days: [{ day: dayFromNow(1), value: 1000 }]
                         }
                     ]
@@ -1094,9 +1094,10 @@ function genEvent({
                 value,
                 attributes: {
                     ...baseAttributes,
-                    direction: 'egress',
+                    egressedBytes: 0,
+                    ingressedBytes: 0,
                     package: 'runner',
-                    callsite: 'test',
+                    callsite: 'proxy',
                     ...attributes
                 }
             };

--- a/packages/usage/lib/clickhouse/clickhouse.query.ts
+++ b/packages/usage/lib/clickhouse/clickhouse.query.ts
@@ -170,7 +170,7 @@ export function quantityForMetric(metric: CounterUsageMetric): string {
             // Read `duration_ms` so the CH path matches Orb 1:1.
             return `SUM(duration_ms)`;
         case 'data_transfer':
-            return `SUM(value)`;
+            return `SUM(ingressed_bytes + egressed_bytes)`;
     }
 }
 

--- a/packages/usage/lib/clickhouse/clickhouse.query.ts
+++ b/packages/usage/lib/clickhouse/clickhouse.query.ts
@@ -17,7 +17,8 @@ const COUNTER_METRICS_SET = {
     function_executions: true,
     function_logs: true,
     function_compute_gbms: true,
-    webhook_forwards: true
+    webhook_forwards: true,
+    data_transfer: true
 } satisfies Record<CounterUsageMetric, true>;
 const AVG_METRICS_SET = {
     records: true,
@@ -37,7 +38,8 @@ export const BREAKDOWN_DIMENSIONS = {
     function_compute_gbms: ['environment_id', 'integration_id', 'connection_id', 'function_name', 'function_type', 'success'],
     webhook_forwards: ['environment_id', 'integration_id', 'connection_id', 'success'],
     records: ['environment_id', 'integration_id', 'connection_id', 'model'],
-    connections: ['environment_id', 'integration_id']
+    connections: ['environment_id', 'integration_id'],
+    data_transfer: ['environment_id', 'integration_id', 'connection_id', 'direction', 'package', 'callsite']
 } as const satisfies { [M in keyof BreakdownDimensions]: readonly BreakdownDimensions[M][] };
 
 export function isAllowedDimensionFor(metric: UsageMetric, dimension: string): boolean {
@@ -113,6 +115,8 @@ export function tableForMetric(metric: UsageMetric): string {
             return `daily_raw_records`;
         case 'connections':
             return `daily_raw_connections`;
+        case 'data_transfer':
+            return `daily_data_transfer`;
     }
 }
 
@@ -165,6 +169,8 @@ export function quantityForMetric(metric: CounterUsageMetric): string {
             // milliseconds (Orb's "Function compute time" = sum(durationMs)).
             // Read `duration_ms` so the CH path matches Orb 1:1.
             return `SUM(duration_ms)`;
+        case 'data_transfer':
+            return `SUM(value)`;
     }
 }
 

--- a/packages/usage/lib/clickhouse/clickhouse.query.ts
+++ b/packages/usage/lib/clickhouse/clickhouse.query.ts
@@ -39,7 +39,7 @@ export const BREAKDOWN_DIMENSIONS = {
     webhook_forwards: ['environment_id', 'integration_id', 'connection_id', 'success'],
     records: ['environment_id', 'integration_id', 'connection_id', 'model'],
     connections: ['environment_id', 'integration_id'],
-    data_transfer: ['environment_id', 'integration_id', 'connection_id', 'direction', 'package', 'callsite']
+    data_transfer: ['environment_id', 'integration_id', 'connection_id', 'package', 'callsite']
 } as const satisfies { [M in keyof BreakdownDimensions]: readonly BreakdownDimensions[M][] };
 
 export function isAllowedDimensionFor(metric: UsageMetric, dimension: string): boolean {

--- a/packages/usage/lib/clickhouse/clickhouse.ts
+++ b/packages/usage/lib/clickhouse/clickhouse.ts
@@ -30,6 +30,7 @@ import type {
     BillingUsageMetrics,
     UsageActionsEvent,
     UsageConnectionsEvent,
+    UsageDataTransferEvent,
     UsageEvent,
     UsageFunctionExecutionsEvent,
     UsageRecordsEvent
@@ -54,7 +55,8 @@ type ClickhouseRawUsageEventAttrs =
     | UsageAttrs<UsageConnectionsEvent, 'connectionId'>
     | UsageAttrs<UsageActionsEvent>
     | UsageAttrs<UsageEvent>
-    | UsageAttrs<UsageRecordsEvent, 'syncId'>;
+    | UsageAttrs<UsageRecordsEvent, 'syncId'>
+    | UsageAttrs<UsageDataTransferEvent>;
 
 export interface ClickhouseRawUsageEvent {
     ts: number; // Unix timestamp in milliseconds, matches DateTime64(3)
@@ -599,7 +601,8 @@ function toRaw(event: UsageEvent): ClickhouseRawUsageEvent | null {
         case 'usage.actions':
         case 'usage.function_executions':
         case 'usage.proxy':
-        case 'usage.webhook_forward': {
+        case 'usage.webhook_forward':
+        case 'usage.data_transfer': {
             const { accountId, ...properties } = event.payload.properties;
             return {
                 ts: event.createdAt.getTime(),
@@ -612,7 +615,6 @@ function toRaw(event: UsageEvent): ClickhouseRawUsageEvent | null {
         }
         case 'usage.records':
         case 'usage.connections':
-        case 'usage.data_transfer':
             // Not ingested into Clickhouse via events
             return null;
     }

--- a/packages/usage/lib/clickhouse/migrations/20260612000008_create_daily_data_transfer.ts
+++ b/packages/usage/lib/clickhouse/migrations/20260612000008_create_daily_data_transfer.ts
@@ -10,12 +10,11 @@ export const sql = [
         direction        LowCardinality(String),
         package          LowCardinality(String),
         callsite         String,
-        sync_id          String DEFAULT '',
         value            UInt64
     )
     ENGINE = SummingMergeTree(value)
     PARTITION BY toYYYYMM(day)
-    ORDER BY (account_id, day, environment_id, integration_id, connection_id, direction, package, callsite, sync_id)
+    ORDER BY (account_id, day, environment_id, integration_id, connection_id, direction, package, callsite)
     TTL day + INTERVAL 24 MONTH
     `,
     `
@@ -30,11 +29,10 @@ export const sql = [
         attributes.direction::String           AS direction,
         attributes.package::String             AS package,
         attributes.callsite::String            AS callsite,
-        coalesce(attributes.syncId::String, '') AS sync_id,
         sum(value)                             AS value
     FROM {database:Identifier}.raw_events
     WHERE type = 'usage.data_transfer'
     GROUP BY day, account_id, environment_id, integration_id, connection_id,
-             direction, package, callsite, sync_id
+             direction, package, callsite
     `
 ];

--- a/packages/usage/lib/clickhouse/migrations/20260612000008_create_daily_data_transfer.ts
+++ b/packages/usage/lib/clickhouse/migrations/20260612000008_create_daily_data_transfer.ts
@@ -7,32 +7,33 @@ export const sql = [
         environment_id   Int64,
         integration_id   LowCardinality(String),
         connection_id    String,
-        direction        LowCardinality(String),
         package          LowCardinality(String),
-        callsite         String,
-        value            UInt64
+        callsite         LowCardinality(String),
+        value            UInt64,
+        ingressed_bytes  UInt64,
+        egressed_bytes   UInt64
     )
-    ENGINE = SummingMergeTree(value)
+    ENGINE = SummingMergeTree((value, ingressed_bytes, egressed_bytes))
     PARTITION BY toYYYYMM(day)
-    ORDER BY (account_id, day, environment_id, integration_id, connection_id, direction, package, callsite)
+    ORDER BY (account_id, day, environment_id, integration_id, connection_id, package, callsite)
     TTL day + INTERVAL 24 MONTH
     `,
     `
     CREATE MATERIALIZED VIEW IF NOT EXISTS {database:Identifier}.daily_data_transfer_mv
     TO {database:Identifier}.daily_data_transfer AS
     SELECT
-        toDate(ts)                              AS day,
+        toDate(ts)                             AS day,
         account_id,
         attributes.environmentId::Int64        AS environment_id,
         attributes.integrationId::String       AS integration_id,
         attributes.connectionId::String        AS connection_id,
-        attributes.direction::String           AS direction,
         attributes.package::String             AS package,
         attributes.callsite::String            AS callsite,
-        sum(value)                             AS value
+        sum(value)                             AS value,
+        sum(attributes.ingressedBytes::UInt64) AS ingressed_bytes,
+        sum(attributes.egressedBytes::UInt64)  AS egressed_bytes
     FROM {database:Identifier}.raw_events
     WHERE type = 'usage.data_transfer'
-    GROUP BY day, account_id, environment_id, integration_id, connection_id,
-             direction, package, callsite
+    GROUP BY day, account_id, environment_id, integration_id, connection_id, package, callsite
     `
 ];

--- a/packages/usage/lib/clickhouse/migrations/20260612000008_create_daily_data_transfer.ts
+++ b/packages/usage/lib/clickhouse/migrations/20260612000008_create_daily_data_transfer.ts
@@ -1,0 +1,40 @@
+export const sql = [
+    `
+    CREATE TABLE IF NOT EXISTS {database:Identifier}.daily_data_transfer
+    (
+        day              Date,
+        account_id       Int64,
+        environment_id   Int64,
+        integration_id   LowCardinality(String),
+        connection_id    String,
+        direction        LowCardinality(String),
+        package          LowCardinality(String),
+        callsite         String,
+        sync_id          Nullable(String),
+        value            Int64
+    )
+    ENGINE = SummingMergeTree(value)
+    PARTITION BY toYYYYMM(day)
+    ORDER BY (account_id, day, environment_id, integration_id, connection_id, direction, package, callsite)
+    TTL day + INTERVAL 24 MONTH
+    `,
+    `
+    CREATE MATERIALIZED VIEW IF NOT EXISTS {database:Identifier}.daily_data_transfer_mv
+    TO {database:Identifier}.daily_data_transfer AS
+    SELECT
+        toDate(ts)                              AS day,
+        account_id,
+        attributes.environmentId::Int64        AS environment_id,
+        attributes.integrationId::String       AS integration_id,
+        attributes.connectionId::String        AS connection_id,
+        attributes.direction::String           AS direction,
+        attributes.package::String             AS package,
+        attributes.callsite::String            AS callsite,
+        attributes.syncId::Nullable(String)    AS sync_id,
+        sum(value)                             AS value
+    FROM {database:Identifier}.raw_events
+    WHERE type = 'usage.data_transfer'
+    GROUP BY day, account_id, environment_id, integration_id, connection_id,
+             direction, package, callsite, sync_id
+    `
+];

--- a/packages/usage/lib/clickhouse/migrations/20260612000008_create_daily_data_transfer.ts
+++ b/packages/usage/lib/clickhouse/migrations/20260612000008_create_daily_data_transfer.ts
@@ -11,7 +11,7 @@ export const sql = [
         package          LowCardinality(String),
         callsite         String,
         sync_id          String DEFAULT '',
-        value            Int64
+        value            UInt64
     )
     ENGINE = SummingMergeTree(value)
     PARTITION BY toYYYYMM(day)

--- a/packages/usage/lib/clickhouse/migrations/20260612000008_create_daily_data_transfer.ts
+++ b/packages/usage/lib/clickhouse/migrations/20260612000008_create_daily_data_transfer.ts
@@ -10,12 +10,12 @@ export const sql = [
         direction        LowCardinality(String),
         package          LowCardinality(String),
         callsite         String,
-        sync_id          Nullable(String),
+        sync_id          String DEFAULT '',
         value            Int64
     )
     ENGINE = SummingMergeTree(value)
     PARTITION BY toYYYYMM(day)
-    ORDER BY (account_id, day, environment_id, integration_id, connection_id, direction, package, callsite)
+    ORDER BY (account_id, day, environment_id, integration_id, connection_id, direction, package, callsite, sync_id)
     TTL day + INTERVAL 24 MONTH
     `,
     `
@@ -30,7 +30,7 @@ export const sql = [
         attributes.direction::String           AS direction,
         attributes.package::String             AS package,
         attributes.callsite::String            AS callsite,
-        attributes.syncId::Nullable(String)    AS sync_id,
+        coalesce(attributes.syncId::String, '') AS sync_id,
         sum(value)                             AS value
     FROM {database:Identifier}.raw_events
     WHERE type = 'usage.data_transfer'

--- a/packages/usage/lib/metrics.ts
+++ b/packages/usage/lib/metrics.ts
@@ -11,5 +11,6 @@ export const usageMetrics: Record<UsageMetric, UsageMetricProperties> = {
     function_compute_gbms: { reset: 'monthly' }, // Gigabyte/ms
     records: { reset: 'never' },
     webhook_forwards: { reset: 'monthly' },
-    function_logs: { reset: 'monthly' }
+    function_logs: { reset: 'monthly' },
+    data_transfer: { reset: 'monthly' }
 };

--- a/packages/usage/lib/usage.ts
+++ b/packages/usage/lib/usage.ts
@@ -306,7 +306,8 @@ export class UsageTracker implements IUsageTracker {
                 case 'function_executions':
                 case 'function_compute_gbms':
                 case 'webhook_forwards':
-                case 'function_logs': {
+                case 'function_logs':
+                case 'data_transfer': {
                     const billingUsage = await this.getBillingMetrics(accountId);
                     if (billingUsage.isErr()) {
                         if (billingUsage.error.message === 'rate_limit_exceeded') {
@@ -788,7 +789,8 @@ const sources: Record<UsageMetric, string> = {
     function_executions: 'billing:subscription:usage',
     function_compute_gbms: 'billing:subscription:usage',
     webhook_forwards: 'billing:subscription:usage',
-    function_logs: 'billing:subscription:usage'
+    function_logs: 'billing:subscription:usage',
+    data_transfer: 'billing:subscription:usage'
 };
 
 function toCumulativeUsage(periodicUsage: BillingUsageMetric): BillingUsageMetric {

--- a/packages/usage/lib/usage.ts
+++ b/packages/usage/lib/usage.ts
@@ -302,12 +302,17 @@ export class UsageTracker implements IUsageTracker {
                     span?.setTag('count', count.value);
                     return Ok(undefined);
                 }
+                case 'data_transfer': {
+                    // Not yet tracked via Orb; write 0 so the cache entry exists and avoids a revalidate loop
+                    const { cacheKey } = UsageTracker.getCacheEntryProps({ accountId, metric, now });
+                    await this.cache.overwrite(cacheKey, 0);
+                    return Ok(undefined);
+                }
                 case 'proxy':
                 case 'function_executions':
                 case 'function_compute_gbms':
                 case 'webhook_forwards':
-                case 'function_logs':
-                case 'data_transfer': {
+                case 'function_logs': {
                     const billingUsage = await this.getBillingMetrics(accountId);
                     if (billingUsage.isErr()) {
                         if (billingUsage.error.message === 'rate_limit_exceeded') {

--- a/packages/webapp/src/pages/Team/Billing/usageBreakdown.ts
+++ b/packages/webapp/src/pages/Team/Billing/usageBreakdown.ts
@@ -14,7 +14,7 @@ export const BREAKDOWN_DIMENSIONS = {
     function_executions: ['integration_id', 'connection_id', 'function_name', 'function_type', 'success', 'environment_id'],
     function_compute_gbms: ['integration_id', 'connection_id', 'function_name', 'function_type', 'success', 'environment_id'],
     function_logs: ['integration_id', 'connection_id', 'function_name', 'function_type', 'success', 'environment_id'],
-    data_transfer: ['environment_id', 'integration_id', 'connection_id', 'direction', 'package', 'callsite']
+    data_transfer: ['environment_id', 'integration_id', 'connection_id', 'package', 'callsite']
 } as const satisfies { [M in UsageMetric]: readonly BreakdownDimensions[M][] };
 
 /** Union of every breakdown dimension across all metrics. */
@@ -38,7 +38,6 @@ export const DIMENSION_LABELS: Record<AnyBreakdownDimension, string> = {
     function_type: 'Function type',
     success: 'Status',
     environment_id: 'Environment',
-    direction: 'Direction',
     package: 'Package',
     callsite: 'Callsite'
 };

--- a/packages/webapp/src/pages/Team/Billing/usageBreakdown.ts
+++ b/packages/webapp/src/pages/Team/Billing/usageBreakdown.ts
@@ -13,7 +13,8 @@ export const BREAKDOWN_DIMENSIONS = {
     webhook_forwards: ['integration_id', 'connection_id', 'success', 'environment_id'],
     function_executions: ['integration_id', 'connection_id', 'function_name', 'function_type', 'success', 'environment_id'],
     function_compute_gbms: ['integration_id', 'connection_id', 'function_name', 'function_type', 'success', 'environment_id'],
-    function_logs: ['integration_id', 'connection_id', 'function_name', 'function_type', 'success', 'environment_id']
+    function_logs: ['integration_id', 'connection_id', 'function_name', 'function_type', 'success', 'environment_id'],
+    data_transfer: ['environment_id', 'integration_id', 'connection_id', 'direction', 'package', 'callsite']
 } as const satisfies { [M in UsageMetric]: readonly BreakdownDimensions[M][] };
 
 /** Union of every breakdown dimension across all metrics. */
@@ -36,7 +37,10 @@ export const DIMENSION_LABELS: Record<AnyBreakdownDimension, string> = {
     function_name: 'Function name',
     function_type: 'Function type',
     success: 'Status',
-    environment_id: 'Environment'
+    environment_id: 'Environment',
+    direction: 'Direction',
+    package: 'Package',
+    callsite: 'Callsite'
 };
 
 /**


### PR DESCRIPTION
Wires usage.data_transfer into the full billing machinery so it lands in ClickHouse and is queryable today, with billing wiring deferred to subsequent PRs.

- New `daily_data_transfer` `SummingMergeTree` + `MV` from `raw_events`
- `toRaw()` now maps `UsageDataTransferEvent` events
- Metering processor ingests via `clickhouse.add()`
- Added to `UsageMetric`, `CounterUsageMetric`, `BreakdownDimensions` and
  all `satisfies Record<UsageMetric, …>` sites (query layer, controllers,
  formatter, capping, webapp breakdown dims)

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/NangoHQ/nango/pull/6483?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

