### PR TITLE
fix(scheduler): make task state transition atomic against concurrent writers

### DIFF
--- a/packages/scheduler/lib/models/tasks.integration.test.ts
+++ b/packages/scheduler/lib/models/tasks.integration.test.ts
@@ -170,6 +170,22 @@ describe('Task', () => {
             }
         }
     });
+    it('should not let concurrent transitions from the same state both succeed', async () => {
+        // Race: a worker succeeding a task while the monitor expires it.
+        // Both read STARTED and both validate, but only one update may win.
+        const t = await startTask(db);
+        const [succeeded, expired] = await Promise.all([
+            tasks.transitionState(db, { taskId: t.id, newState: 'SUCCEEDED', output: { foo: 'bar' } }),
+            tasks.transitionState(db, { taskId: t.id, newState: 'EXPIRED', output: { reason: 'timeout_exceeded' } })
+        ]);
+        const winners = [succeeded, expired].filter((r) => r.isOk());
+        const losers = [succeeded, expired].filter((r) => r.isErr());
+        expect(winners).toHaveLength(1);
+        expect(losers).toHaveLength(1);
+        const winner = winners[0];
+        const finalState = (await tasks.get(db, t.id)).unwrap().state;
+        expect(finalState).toBe(winner && winner.isOk() ? winner.value.state : undefined);
+    });
     it('should be dequeued', async () => {
         const t0 = await createTask(db, { groupKey: nanoid() });
         const t1 = await createTask(db);

--- a/packages/scheduler/lib/models/tasks.ts
+++ b/packages/scheduler/lib/models/tasks.ts
@@ -351,9 +351,14 @@ export async function transitionState(
         }
     };
 
+    // Guard the update with the state we validated against so a concurrent
+    // transition (e.g. a worker succeeding a task while the monitor expires it)
+    // cannot silently overwrite it. If the row already moved on, the update
+    // matches no rows and we surface a conflict instead of clobbering state.
     const updated = await db
         .from<DBTask>(TASKS_TABLE)
         .where('id', props.taskId)
+        .where('state', transition.value.from)
         .update({
             state: transition.value.to,
             last_state_transition_at: new Date(),
@@ -362,7 +367,7 @@ export async function transitionState(
         })
         .returning('*');
     if (!updated?.[0]) {
-        return Err(new Error(`Task with id '${props.taskId}' not found`));
+        return Err(new Error(`Task '${props.taskId}' is no longer in state '${transition.value.from}' (concurrent transition)`));
     }
 
     return Ok(DbTask.from(updated[0]));


### PR DESCRIPTION
## Problem

`transitionState()` in `packages/scheduler/lib/models/tasks.ts` read the task state with **no row lock**, validated the transition, then issued `UPDATE ... WHERE id = ?` with **no guard on the current state**.

Two transitions firing on the same task from the same state both pass validation and both apply — last writer wins. The most common race: a worker calls `succeed` (STARTED→SUCCEEDED) at the same moment the monitor calls `expire` (STARTED→EXPIRED). Both read `STARTED`, both validate, both `UPDATE`. Consequences:

- the task ends in whichever state committed last,
- the wrong `onState` callback fires,
- on the `fail` path a spurious retry task can be created.

This is the same class of bug as #6428, which moved the *cancel* transition inside its transaction but left the underlying race in `transitionState` itself. `succeed`, `fail`, `cancel`, and the expiration monitor all call it in separate transactions without locking the task row.

## Fix

Guard the `UPDATE` with the state we validated against: `WHERE id = ? AND state = <from>`. If the row already moved on, the update matches no rows and we return a clear conflict error instead of silently clobbering state. This makes the check-and-set atomic at the DB level without needing `SELECT ... FOR UPDATE`.

## Test

Added an integration test that fires concurrent `SUCCEEDED` / `EXPIRED` transitions on the same task and asserts exactly **one winner and one error**, with the persisted state matching the winner. Verified it **fails before** the fix (both transitions succeed) and **passes after**.

All 26 tests in `tasks.integration.test.ts` pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/NangoHQ/nango/pull/6484?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

