### PR TITLE
fix(records): split records_seen entries to limit size of ids array

### DIFF
--- a/packages/records/lib/constants.ts
+++ b/packages/records/lib/constants.ts
@@ -5,3 +5,9 @@ export const RECORDS_SEEN_TABLE = 'records_seen';
 export const RECORDS_ROUTING_TABLE = 'records_routing';
 
 export const DEFAULT_RECORDS_LIMIT = 100;
+
+// Max number of record ids packed into a single records_seen row.
+// PostgreSQL pushes a tuple into TOAST storage once it exceeds ~2KB.
+// record_ids is a uuid[], so capping at 100 ids (~1.6KB for the array) keeps the whole row
+// comfortably inline and untoasted.
+export const RECORDS_SEEN_MAX_IDS_PER_ROW = 100;

--- a/packages/records/lib/stores/postgres/postgres.ts
+++ b/packages/records/lib/stores/postgres/postgres.ts
@@ -8,7 +8,15 @@ import knex from 'knex';
 
 import { Err, Ok, cancellableDaemon, retry, stringToHash } from '@nangohq/utils';
 
-import { DEFAULT_RECORDS_LIMIT, RECORDS_DATA_TABLE, RECORDS_ROUTING_TABLE, RECORDS_SEEN_TABLE, RECORDS_TABLE, RECORD_COUNTS_TABLE } from '../../constants.js';
+import {
+    DEFAULT_RECORDS_LIMIT,
+    RECORDS_DATA_TABLE,
+    RECORDS_ROUTING_TABLE,
+    RECORDS_SEEN_MAX_IDS_PER_ROW,
+    RECORDS_SEEN_TABLE,
+    RECORDS_TABLE,
+    RECORD_COUNTS_TABLE
+} from '../../constants.js';
 import { Cursor } from '../../cursor.js';
 import { envs } from '../../env.js';
 import { deepMergeRecordData } from '../../helpers/merge.js';
@@ -1759,12 +1767,19 @@ export class PostgresStore implements RecordsStore {
         if (ensureRes.isErr()) {
             throw new Error('Failed to ensure seen partition', { cause: ensureRes.error });
         }
-        await trx(RECORDS_SEEN_TABLE).insert({
-            connection_id: connectionId,
-            model,
-            generation: syncJobId,
-            record_ids: trx.raw(`ARRAY[${recordIds.map(() => '?::uuid').join(',')}]`, recordIds)
-        });
+        // Split the ids across multiple rows so no single record_ids array
+        // grows past PostgreSQL's TOAST tuple threshold (~2KB)
+        const rows: { connection_id: number; model: string; generation: number; record_ids: Knex.Raw }[] = [];
+        for (let i = 0; i < recordIds.length; i += RECORDS_SEEN_MAX_IDS_PER_ROW) {
+            const chunk = recordIds.slice(i, i + RECORDS_SEEN_MAX_IDS_PER_ROW);
+            rows.push({
+                connection_id: connectionId,
+                model,
+                generation: syncJobId,
+                record_ids: trx.raw(`ARRAY[${chunk.map(() => '?::uuid').join(',')}]`, chunk)
+            });
+        }
+        await trx(RECORDS_SEEN_TABLE).insert(rows);
     }
 }
 


### PR DESCRIPTION
When records_seen entries contains more than 100+ ids, their size goes beyond pg TOAST threshold (~2kb). We observe that pg can wait a lot of IO when "untoasting" records_seen in deleteOutdatedRecords query. 
This commit is an attempt at limiting the size of each records_seen entry so it doesn't go beyond the TOAST threshold. 
In production, it would only affect ~10-15% of the rows.

<!-- Describe the problem and your solution --> 

<!-- Issue ticket number and link (if applicable) -->

<!-- Testing instructions (skip if just adding/editing providers) -->



<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/NangoHQ/nango/pull/6485?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

