### PR TITLE
fix(records): skip empty records instead of dropping the rest of the batch

### DIFF
--- a/packages/records/lib/helpers/format.ts
+++ b/packages/records/lib/helpers/format.ts
@@ -35,12 +35,14 @@ export const formatRecords = ({
     const formattedRecords: FormattedRecord[] = [];
     const now = new Date();
     for (const datum of data) {
+        // Skip empty entries instead of breaking, otherwise a single null/undefined
+        // datum would silently drop every remaining record in the batch.
+        if (!datum) {
+            continue;
+        }
+
         const str = JSON.stringify(datum);
         const data_hash = createHash('md5').update(str).digest('hex');
-
-        if (!datum) {
-            break;
-        }
 
         if (!datum['id']) {
             const error = new Error(`Missing id field in record: ${JSON.stringify(datum)}. Model: ${model}`);

--- a/packages/records/lib/helpers/format.unit.test.ts
+++ b/packages/records/lib/helpers/format.unit.test.ts
@@ -1,0 +1,36 @@
+import { describe, expect, it } from 'vitest';
+
+import { formatRecords } from './format.js';
+
+import type { UnencryptedRecordData } from '../types.js';
+
+describe('formatRecords', () => {
+    const base = {
+        connectionId: 1,
+        model: 'Test',
+        syncId: '00000000-0000-0000-0000-000000000000',
+        syncJobId: 1
+    };
+
+    it('should format every record in the batch', () => {
+        const data = [{ id: '1' }, { id: '2' }, { id: '3' }];
+        const res = formatRecords({ ...base, data });
+        expect(res.isOk()).toBe(true);
+        expect(res.unwrap().map((r) => r.external_id)).toEqual(['1', '2', '3']);
+    });
+
+    it('should skip null/undefined entries without dropping the rest of the batch', () => {
+        // A single empty datum used to `break` the loop, silently dropping every
+        // subsequent record. It must be skipped, not terminate formatting.
+        const data = [{ id: '1' }, null, { id: '2' }, undefined, { id: '3' }] as unknown as UnencryptedRecordData[];
+        const res = formatRecords({ ...base, data });
+        expect(res.isOk()).toBe(true);
+        expect(res.unwrap().map((r) => r.external_id)).toEqual(['1', '2', '3']);
+    });
+
+    it('should error when a non-empty record is missing an id', () => {
+        const data = [{ id: '1' }, { name: 'no id' }] as unknown as UnencryptedRecordData[];
+        const res = formatRecords({ ...base, data });
+        expect(res.isErr()).toBe(true);
+    });
+});


### PR DESCRIPTION
## Problem

`formatRecords()` in `packages/records/lib/helpers/format.ts` checked `if (!datum) break;` **inside** the loop. A single null/undefined entry in a batch terminated formatting entirely and **silently dropped every subsequent record**.

A sync returning `[a, null, b, c]` persisted only `a`, while the run still reported success — silent data loss. The check also ran *after* `JSON.stringify` + hashing the (empty) datum.

## Fix

Move the empty-entry check to the top of the loop (before hashing) and `continue` past it, so the remaining records are still formatted and persisted.

```diff
-        const str = JSON.stringify(datum);
-        const data_hash = createHash('md5').update(str).digest('hex');
-
         if (!datum) {
-            break;
+            continue;
         }
+        const str = JSON.stringify(datum);
+        const data_hash = createHash('md5').update(str).digest('hex');
```

## Test

Added `format.unit.test.ts` covering:
- a `null`/`undefined` in the middle of a batch → surrounding records survive (`['1','2','3']`),
- the happy path,
- the missing-`id` error path.

Verified the skip-empty test **fails before** the fix (only `['1']` survives) and **passes after**. Full `ts-build` clean, lint clean.

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/NangoHQ/nango/pull/6486?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

