### PR TITLE
fix(kms): resolve DEK from wrapped key by default 

### DIFF
--- a/packages/kms/lib/registry.ts
+++ b/packages/kms/lib/registry.ts
@@ -44,8 +44,18 @@ export class DekRegistry {
     }
 }
 
+// Memoized so the unwrapping (and its KMS call) runs once per process
+// since several packages can each instantiate a DekRegistry.
+const resolved = new Map<string, string>();
+
 async function resolveDek(envs: DekEnvs): Promise<string> {
     const { NANGO_ENCRYPTION_KEY: plaintext, NANGO_ENCRYPTION_KEY_WRAPPED: wrapped, NANGO_KMS_KEY_ARN: kmsKeyArn } = envs;
+
+    const cacheKey = JSON.stringify([plaintext, wrapped, kmsKeyArn]);
+    const cached = resolved.get(cacheKey);
+    if (cached !== undefined) {
+        return cached;
+    }
 
     // TEMPORARY (KMS rollout validation): the plaintext key stays the source of truth.
     // When the wrapped key is also set, unwrap it in shadow mode and log whether it matches.
@@ -62,12 +72,14 @@ async function resolveDek(envs: DekEnvs): Promise<string> {
         }
     }
 
+    // No plaintext key set: encryption disabled
+    let dek = '';
     if (plaintext) {
         assertDekLength(Buffer.from(plaintext, 'base64'));
         logger.info('Loaded encryption key (source=plaintext)');
-        return plaintext;
+        dek = plaintext;
     }
 
-    // No plaintext key set: encryption disabled
-    return '';
+    resolved.set(cacheKey, dek);
+    return dek;
 }

--- a/packages/kms/lib/registry.ts
+++ b/packages/kms/lib/registry.ts
@@ -57,24 +57,17 @@ async function resolveDek(envs: DekEnvs): Promise<string> {
         return cached;
     }
 
-    // TEMPORARY (KMS rollout validation): the plaintext key stays the source of truth.
-    // When the wrapped key is also set, unwrap it in shadow mode and log whether it matches.
-    // Unwrap failures are logged, not fatal.
-    if (wrapped) {
-        try {
-            if (!kmsKeyArn) {
-                throw new Error('NANGO_KMS_KEY_ARN is required when NANGO_ENCRYPTION_KEY_WRAPPED is set');
-            }
-            const unwrapped = await unwrapDek({ wrapped, kmsKeyArn, expectedContext: GLOBAL_DEK_CONTEXT });
-            logger.info(`Wrapped encryption key validation: match=${unwrapped === (plaintext ?? '')}`);
-        } catch (err) {
-            logger.error('Unwrapping data encryption key failed', err);
-        }
-    }
-
-    // No plaintext key set: encryption disabled
+    // Wrapped key is the source of truth (unwrap it via KMS).
+    // Fallback to the plaintext key (dev/self hosted) or '' (encryption disabled) when neither is set.
+    // Unwrap failures are fatal: we must not silently start up with the wrong key.
     let dek = '';
-    if (plaintext) {
+    if (wrapped) {
+        if (!kmsKeyArn) {
+            throw new Error('NANGO_KMS_KEY_ARN is required when NANGO_ENCRYPTION_KEY_WRAPPED is set');
+        }
+        dek = await unwrapDek({ wrapped, kmsKeyArn, expectedContext: GLOBAL_DEK_CONTEXT });
+        logger.info('Loaded encryption key (source=wrapped)');
+    } else if (plaintext) {
         assertDekLength(Buffer.from(plaintext, 'base64'));
         logger.info('Loaded encryption key (source=plaintext)');
         dek = plaintext;

--- a/packages/kms/lib/registry.ts
+++ b/packages/kms/lib/registry.ts
@@ -44,11 +44,11 @@ export class DekRegistry {
     }
 }
 
-// Memoized so the unwrapping (and its KMS call) runs once per process
-// since several packages can each instantiate a DekRegistry.
-const resolved = new Map<string, string>();
+// Cache the in-flight promise so the KMS unwrap runs once per process,
+// even when several packages instantiate a DekRegistry concurrently.
+const resolved = new Map<string, Promise<string>>();
 
-async function resolveDek(envs: DekEnvs): Promise<string> {
+function resolveDek(envs: DekEnvs): Promise<string> {
     const { NANGO_ENCRYPTION_KEY: plaintext, NANGO_ENCRYPTION_KEY_WRAPPED: wrapped, NANGO_KMS_KEY_ARN: kmsKeyArn } = envs;
 
     const cacheKey = JSON.stringify([plaintext, wrapped, kmsKeyArn]);
@@ -57,22 +57,41 @@ async function resolveDek(envs: DekEnvs): Promise<string> {
         return cached;
     }
 
+    const promise = resolveFromEnvs({ plaintext, wrapped, kmsKeyArn }).catch((err: unknown) => {
+        // Don't cache failures: a transient KMS error must not poison every future caller.
+        resolved.delete(cacheKey);
+        throw err;
+    });
+    resolved.set(cacheKey, promise);
+    return promise;
+}
+
+async function resolveFromEnvs({
+    plaintext,
+    wrapped,
+    kmsKeyArn
+}: {
+    plaintext?: string | undefined;
+    wrapped?: string | undefined;
+    kmsKeyArn?: string | undefined;
+}): Promise<string> {
     // Wrapped key is the source of truth (unwrap it via KMS).
     // Fallback to the plaintext key (dev/self hosted) or '' (encryption disabled) when neither is set.
     // Unwrap failures are fatal: we must not silently start up with the wrong key.
-    let dek = '';
     if (wrapped) {
         if (!kmsKeyArn) {
             throw new Error('NANGO_KMS_KEY_ARN is required when NANGO_ENCRYPTION_KEY_WRAPPED is set');
         }
-        dek = await unwrapDek({ wrapped, kmsKeyArn, expectedContext: GLOBAL_DEK_CONTEXT });
+        const dek = await unwrapDek({ wrapped, kmsKeyArn, expectedContext: GLOBAL_DEK_CONTEXT });
         logger.info('Loaded encryption key (source=wrapped)');
-    } else if (plaintext) {
-        assertDekLength(Buffer.from(plaintext, 'base64'));
-        logger.info('Loaded encryption key (source=plaintext)');
-        dek = plaintext;
+        return dek;
     }
 
-    resolved.set(cacheKey, dek);
-    return dek;
+    if (plaintext) {
+        assertDekLength(Buffer.from(plaintext, 'base64'));
+        logger.info('Loaded encryption key (source=plaintext)');
+        return plaintext;
+    }
+
+    return '';
 }

--- a/packages/kms/lib/registry.unit.test.ts
+++ b/packages/kms/lib/registry.unit.test.ts
@@ -1,13 +1,23 @@
 import crypto from 'node:crypto';
 
-import { describe, expect, it } from 'vitest';
+import { describe, expect, it, vi } from 'vitest';
 
 import { DekRegistry } from './registry.js';
 
 const testDek = crypto.randomBytes(32).toString('base64');
 
+// The wrapped key is unwrapped through KMS, which unit tests can't reach.
+// Here we stub unwrapDek to assert the registry's resolution priority.
+const { unwrappedDek } = vi.hoisted(() => ({ unwrappedDek: 'unwrapped-from-kms' }));
+
+vi.mock('./envelope.js', async (importActual) => {
+    // eslint-disable-next-line @typescript-eslint/consistent-type-imports
+    const actual = await importActual<typeof import('./envelope.js')>();
+    return { ...actual, unwrapDek: () => Promise.resolve(unwrappedDek) };
+});
+
 describe('DekRegistry.create', () => {
-    it('should hold the plaintext key', async () => {
+    it('should resolve to the plaintext key', async () => {
         const registry = await DekRegistry.create({ NANGO_ENCRYPTION_KEY: testDek });
         expect(registry.get()).toBe(testDek);
     });
@@ -17,20 +27,29 @@ describe('DekRegistry.create', () => {
         await expect(DekRegistry.create({ NANGO_ENCRYPTION_KEY: shortKey })).rejects.toThrow(/32 bytes/);
     });
 
-    it('should hold an empty key when no env is set (encryption disabled)', async () => {
+    it('should resolve to an empty key when no env is set (encryption disabled)', async () => {
         const registry = await DekRegistry.create({});
         expect(registry.get()).toBe('');
     });
 
-    // TEMPORARY (KMS rollout validation): wrapped key is unwrapped in shadow mode only;
-    // plaintext stays the source of truth and unwrap failures are not fatal.
-    it('should resolve from plaintext when both envs are set', async () => {
-        const registry = await DekRegistry.create({ NANGO_ENCRYPTION_KEY: testDek, NANGO_ENCRYPTION_KEY_WRAPPED: 'anything' });
-        expect(registry.get()).toBe(testDek);
+    it('should resolve from the wrapped key', async () => {
+        const registry = await DekRegistry.create({
+            NANGO_ENCRYPTION_KEY_WRAPPED: 'wrapped-only',
+            NANGO_KMS_KEY_ARN: 'arn:aws:kms:test'
+        });
+        expect(registry.get()).toBe(unwrappedDek);
     });
 
-    it('should not use the wrapped key even when it is the only one set', async () => {
-        const registry = await DekRegistry.create({ NANGO_ENCRYPTION_KEY_WRAPPED: 'anything' });
-        expect(registry.get()).toBe('');
+    it('should resolve from the wrapped key even when plaintext env var is set', async () => {
+        const registry = await DekRegistry.create({
+            NANGO_ENCRYPTION_KEY: testDek,
+            NANGO_ENCRYPTION_KEY_WRAPPED: 'wrapped-both',
+            NANGO_KMS_KEY_ARN: 'arn:aws:kms:test'
+        });
+        expect(registry.get()).toBe(unwrappedDek);
+    });
+
+    it('should throw when the wrapped key is set without a KMS key ARN', async () => {
+        await expect(DekRegistry.create({ NANGO_ENCRYPTION_KEY_WRAPPED: 'no-arn' })).rejects.toThrow(/NANGO_KMS_KEY_ARN is required/);
     });
 });


### PR DESCRIPTION
By order of priority the kms package will resolve the DEK:
1. from unwrapped key in NANGO_ENCRYPTION_KEY_WRAPPED
2. from plaintext key in NANGO_ENCRYPTION_KEY
3. empty string '' if encryption is disabled (ie: no env vars)

This PR is also memoizing the DEK so apps that depends on multiple packages using encryption don't trigger multiple unwrapping and call to KMS


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/NangoHQ/nango/pull/6487?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

