### PR TITLE
feat: wrapped and plaintext key are mutually exclusive

### DIFF
--- a/packages/kms/lib/registry.ts
+++ b/packages/kms/lib/registry.ts
@@ -75,6 +75,11 @@ async function resolveFromEnvs({
     wrapped?: string | undefined;
     kmsKeyArn?: string | undefined;
 }): Promise<string> {
+    // Wrapped and plaintext keys are mutually exclusive: fail fast rather than silently picking one.
+    if (wrapped && plaintext) {
+        throw new Error('NANGO_ENCRYPTION_KEY and NANGO_ENCRYPTION_KEY_WRAPPED are mutually exclusive: set only one');
+    }
+
     // Wrapped key is the source of truth (unwrap it via KMS).
     // Fallback to the plaintext key (dev/self hosted) or '' (encryption disabled) when neither is set.
     // Unwrap failures are fatal: we must not silently start up with the wrong key.

--- a/packages/kms/lib/registry.unit.test.ts
+++ b/packages/kms/lib/registry.unit.test.ts
@@ -40,13 +40,14 @@ describe('DekRegistry.create', () => {
         expect(registry.get()).toBe(unwrappedDek);
     });
 
-    it('should resolve from the wrapped key even when plaintext env var is set', async () => {
-        const registry = await DekRegistry.create({
-            NANGO_ENCRYPTION_KEY: testDek,
-            NANGO_ENCRYPTION_KEY_WRAPPED: 'wrapped-both',
-            NANGO_KMS_KEY_ARN: 'arn:aws:kms:test'
-        });
-        expect(registry.get()).toBe(unwrappedDek);
+    it('should throw when both the plaintext and wrapped keys are set', async () => {
+        await expect(
+            DekRegistry.create({
+                NANGO_ENCRYPTION_KEY: testDek,
+                NANGO_ENCRYPTION_KEY_WRAPPED: 'wrapped-both',
+                NANGO_KMS_KEY_ARN: 'arn:aws:kms:test'
+            })
+        ).rejects.toThrow(/mutually exclusive/);
     });
 
     it('should throw when the wrapped key is set without a KMS key ARN', async () => {


### PR DESCRIPTION
Fail fast if both NANGO_ENCRYPTION_KEY and NANGO_ENCRYPTION_KEY_WRAPPED are set.
The goal is to prevent misconfiguration and ambiguity about which encryption key is being used.

NOTE: to only deploy once the NANGO_ENCRYPTION_KEY is removed from services in production

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/NangoHQ/nango/pull/6488?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

