### PR TITLE
fix(auth): invalidate other sessions on password change and reset

### DIFF
--- a/packages/server/lib/clients/auth.client.ts
+++ b/packages/server/lib/clients/auth.client.ts
@@ -13,15 +13,31 @@ import { baseUrl, flagHasAuth, isBasicAuthEnabled } from '@nangohq/utils';
 
 import type { StoreFactory } from 'connect-session-knex';
 import type express from 'express';
+import type { Knex } from 'knex';
+
+const SESSION_TABLE = '_nango_sessions';
 
 // @ts-expect-error types are wrong
 const KnexSessionStore = connectSessionKnex(session) as StoreFactory;
 
 const sessionStore = new KnexSessionStore({
     knex: database.knex,
-    tablename: '_nango_sessions',
+    tablename: SESSION_TABLE,
     sidfieldname: 'sid'
 });
+
+/**
+ * Delete a user's web sessions, e.g. after a password change so that other
+ * devices/browsers are forced to re-authenticate. Passport stores the
+ * serialized user at `sess.passport.user`.
+ */
+export async function deleteUserSessions(userId: number, { exceptSid, trx }: { exceptSid?: string; trx?: Knex } = {}): Promise<void> {
+    const query = (trx ?? database.knex).from(SESSION_TABLE).whereRaw(`(sess->'passport'->'user'->>'id')::int = ?`, [userId]);
+    if (exceptSid) {
+        query.andWhereNot('sid', exceptSid);
+    }
+    await query.delete();
+}
 
 export function setupAuth(app: express.Router) {
     app.use(cookieParser());

--- a/packages/server/lib/clients/auth.client.ts
+++ b/packages/server/lib/clients/auth.client.ts
@@ -31,12 +31,11 @@ const sessionStore = new KnexSessionStore({
  * devices/browsers are forced to re-authenticate. Passport stores the
  * serialized user at `sess.passport.user`.
  */
-export async function deleteUserSessions(userId: number, { exceptSid, trx }: { exceptSid?: string; trx?: Knex } = {}): Promise<void> {
-    const query = (trx ?? database.knex).from(SESSION_TABLE).whereRaw(`(sess->'passport'->'user'->>'id')::int = ?`, [userId]);
-    if (exceptSid) {
-        query.andWhereNot('sid', exceptSid);
-    }
-    await query.delete();
+export async function deleteUserSessions(userId: number, { trx }: { trx?: Knex } = {}): Promise<void> {
+    await (trx ?? database.knex)
+        .from(SESSION_TABLE)
+        .whereRaw(`sess->'passport'->'user'->>'id' = ?`, [String(userId)])
+        .delete();
 }
 
 export function setupAuth(app: express.Router) {

--- a/packages/server/lib/controllers/v1/account/putResetPassword.integration.test.ts
+++ b/packages/server/lib/controllers/v1/account/putResetPassword.integration.test.ts
@@ -1,0 +1,74 @@
+import jwt from 'jsonwebtoken';
+import { afterAll, beforeAll, describe, expect, it } from 'vitest';
+
+import { userService } from '@nangohq/shared';
+import { nanoid } from '@nangohq/utils';
+
+import { isSuccess, runServer } from '../../../utils/tests.js';
+import { resetPasswordSecret } from '../../../utils/utils.js';
+
+const signupRoute = '/api/v1/account/signup';
+const signinRoute = '/api/v1/account/signin';
+const resetPasswordRoute = '/api/v1/account/reset-password';
+const userRoute = '/api/v1/user';
+
+let api: Awaited<ReturnType<typeof runServer>>;
+
+async function signupVerifiedUser(): Promise<{ email: string; password: string }> {
+    const email = `${nanoid()}@example.com`;
+    const password = 'aZ1-foobar!';
+
+    const signupRes = await api.fetch(signupRoute, {
+        method: 'POST',
+        body: { email, name: 'Foobar', password, foundUs: 'tests' } as any
+    });
+    expect(signupRes.res.status).toBe(200);
+
+    const createdUser = await userService.getUserByEmail(email);
+    await userService.verifyUserEmail(createdUser!.id);
+
+    return { email, password };
+}
+
+async function signin(email: string, password: string): Promise<string> {
+    const { res } = await api.fetch(signinRoute, { method: 'POST', body: { email, password } });
+    expect(res.status).toBe(200);
+    const cookie = res.headers.getSetCookie()[0];
+    expect(cookie).toMatch(/^nango_session=/);
+    return cookie!.split(';')[0]!;
+}
+
+describe(`PUT ${resetPasswordRoute}`, () => {
+    beforeAll(async () => {
+        api = await runServer();
+    });
+
+    afterAll(() => {
+        api.server.close();
+    });
+
+    it('should invalidate all sessions after a password reset', async () => {
+        const { email, password } = await signupVerifiedUser();
+
+        const sessionA = await signin(email, password);
+        const sessionB = await signin(email, password);
+
+        expect((await api.fetch(userRoute, { method: 'GET', session: sessionA })).res.status).toBe(200);
+        expect((await api.fetch(userRoute, { method: 'GET', session: sessionB })).res.status).toBe(200);
+
+        const dbUser = await userService.getUserByEmail(email);
+        const token = jwt.sign({ user: email }, resetPasswordSecret(), { expiresIn: '10m' });
+        await userService.editUserPassword({ id: dbUser!.id, reset_password_token: token, hashed_password: dbUser!.hashed_password });
+
+        const { res, json } = await api.fetch(resetPasswordRoute, {
+            method: 'PUT',
+            body: { token, password: 'aZ1-newpass!' }
+        });
+        expect(res.status).toBe(200);
+        isSuccess(json);
+
+        // every session is forcibly logged out (the reset flow is anonymous, so none is spared)
+        expect((await api.fetch(userRoute, { method: 'GET', session: sessionA })).res.status).toBe(401);
+        expect((await api.fetch(userRoute, { method: 'GET', session: sessionB })).res.status).toBe(401);
+    });
+});

--- a/packages/server/lib/controllers/v1/account/putResetPassword.integration.test.ts
+++ b/packages/server/lib/controllers/v1/account/putResetPassword.integration.test.ts
@@ -16,7 +16,7 @@ let api: Awaited<ReturnType<typeof runServer>>;
 
 async function signupVerifiedUser(): Promise<{ email: string; password: string }> {
     const email = `${nanoid()}@example.com`;
-    const password = 'aZ1-foobar!';
+    const password = 'aZ1-foobar!?';
 
     const signupRes = await api.fetch(signupRoute, {
         method: 'POST',
@@ -62,7 +62,7 @@ describe(`PUT ${resetPasswordRoute}`, () => {
 
         const { res, json } = await api.fetch(resetPasswordRoute, {
             method: 'PUT',
-            body: { token, password: 'aZ1-newpass!' }
+            body: { token, password: 'aZ1-newpass!?' }
         });
         expect(res.status).toBe(200);
         isSuccess(json);

--- a/packages/server/lib/controllers/v1/account/putResetPassword.ts
+++ b/packages/server/lib/controllers/v1/account/putResetPassword.ts
@@ -1,10 +1,12 @@
 import jwt from 'jsonwebtoken';
 import * as z from 'zod';
 
+import db from '@nangohq/database';
 import { pbkdf2, userService } from '@nangohq/shared';
 import { requireEmptyQuery, zodErrorToHTTP } from '@nangohq/utils';
 
 import { passwordSchema } from './signup.js';
+import { deleteUserSessions } from '../../../clients/auth.client.js';
 import { asyncWrapper } from '../../../utils/asyncWrapper.js';
 import { resetPasswordSecret } from '../../../utils/utils.js';
 
@@ -49,7 +51,10 @@ export const putResetPassword = asyncWrapper<PutResetPassword>(async (req, res) 
 
         user.hashed_password = hashedPassword;
         user.reset_password_token = null;
-        await userService.editUserPassword(user);
+        await db.knex.transaction(async (trx) => {
+            await userService.editUserPassword(user, trx);
+            await deleteUserSessions(user.id, { trx });
+        });
 
         res.status(200).json({
             success: true

--- a/packages/server/lib/controllers/v1/account/putResetPassword.ts
+++ b/packages/server/lib/controllers/v1/account/putResetPassword.ts
@@ -46,23 +46,23 @@ export const putResetPassword = asyncWrapper<PutResetPassword>(async (req, res) 
 
     try {
         jwt.verify(token, resetPasswordSecret());
-
-        const hashedPassword = (await pbkdf2(password, user.salt, 310000, 32, 'sha256')).toString('base64');
-
-        user.hashed_password = hashedPassword;
-        user.reset_password_token = null;
-        await db.knex.transaction(async (trx) => {
-            await userService.editUserPassword(user, trx);
-            await deleteUserSessions(user.id, { trx });
-        });
-
-        res.status(200).json({
-            success: true
-        });
     } catch {
         res.status(400).send({
             error: { code: 'invalid_token' }
         });
         return;
     }
+
+    const hashedPassword = (await pbkdf2(password, user.salt, 310000, 32, 'sha256')).toString('base64');
+
+    user.hashed_password = hashedPassword;
+    user.reset_password_token = null;
+    await db.knex.transaction(async (trx) => {
+        await userService.editUserPassword(user, trx);
+        await deleteUserSessions(user.id, { trx });
+    });
+
+    res.status(200).json({
+        success: true
+    });
 });

--- a/packages/server/lib/controllers/v1/user/password/putPassword.integration.test.ts
+++ b/packages/server/lib/controllers/v1/user/password/putPassword.integration.test.ts
@@ -45,7 +45,7 @@ describe(`PUT ${passwordRoute}`, () => {
         api.server.close();
     });
 
-    it('should invalidate other sessions but keep the current one after a password change', async () => {
+    it('should rotate the current session and invalidate all others after a password change', async () => {
         const { email, password } = await signupVerifiedUser();
 
         const currentSession = await signin(email, password);
@@ -63,10 +63,19 @@ describe(`PUT ${passwordRoute}`, () => {
         expect(res.status).toBe(200);
         isSuccess(json);
 
+        // the change rotates the current session: a fresh cookie is issued and it differs from the old one
+        const rotatedCookie = res.headers.getSetCookie()[0];
+        expect(rotatedCookie).toMatch(/^nango_session=/);
+        const rotatedSession = rotatedCookie!.split(';')[0]!;
+        expect(rotatedSession).not.toBe(currentSession);
+
+        // the old cookie (e.g. a stolen one) is now dead, even though it initiated the change
+        expect((await api.fetch(userRoute, { method: 'GET', session: currentSession })).res.status).toBe(401);
+
         // the other session is forcibly logged out
         expect((await api.fetch(userRoute, { method: 'GET', session: otherSession })).res.status).toBe(401);
 
-        // the session that made the change stays authenticated
-        expect((await api.fetch(userRoute, { method: 'GET', session: currentSession })).res.status).toBe(200);
+        // the user who made the change stays authenticated via the rotated session
+        expect((await api.fetch(userRoute, { method: 'GET', session: rotatedSession })).res.status).toBe(200);
     });
 });

--- a/packages/server/lib/controllers/v1/user/password/putPassword.integration.test.ts
+++ b/packages/server/lib/controllers/v1/user/password/putPassword.integration.test.ts
@@ -1,0 +1,72 @@
+import { afterAll, beforeAll, describe, expect, it } from 'vitest';
+
+import { userService } from '@nangohq/shared';
+import { nanoid } from '@nangohq/utils';
+
+import { isSuccess, runServer } from '../../../../utils/tests.js';
+
+const signupRoute = '/api/v1/account/signup';
+const signinRoute = '/api/v1/account/signin';
+const passwordRoute = '/api/v1/user/password';
+const userRoute = '/api/v1/user';
+
+let api: Awaited<ReturnType<typeof runServer>>;
+
+async function signupVerifiedUser(): Promise<{ email: string; password: string }> {
+    const email = `${nanoid()}@example.com`;
+    const password = 'aZ1-foobar!';
+
+    const signupRes = await api.fetch(signupRoute, {
+        method: 'POST',
+        body: { email, name: 'Foobar', password, foundUs: 'tests' } as any
+    });
+    expect(signupRes.res.status).toBe(200);
+
+    const createdUser = await userService.getUserByEmail(email);
+    await userService.verifyUserEmail(createdUser!.id);
+
+    return { email, password };
+}
+
+async function signin(email: string, password: string): Promise<string> {
+    const { res } = await api.fetch(signinRoute, { method: 'POST', body: { email, password } });
+    expect(res.status).toBe(200);
+    const cookie = res.headers.getSetCookie()[0];
+    expect(cookie).toMatch(/^nango_session=/);
+    return cookie!.split(';')[0]!;
+}
+
+describe(`PUT ${passwordRoute}`, () => {
+    beforeAll(async () => {
+        api = await runServer();
+    });
+
+    afterAll(() => {
+        api.server.close();
+    });
+
+    it('should invalidate other sessions but keep the current one after a password change', async () => {
+        const { email, password } = await signupVerifiedUser();
+
+        const currentSession = await signin(email, password);
+        const otherSession = await signin(email, password);
+
+        // sanity: both sessions are valid before the change
+        expect((await api.fetch(userRoute, { method: 'GET', session: currentSession })).res.status).toBe(200);
+        expect((await api.fetch(userRoute, { method: 'GET', session: otherSession })).res.status).toBe(200);
+
+        const { res, json } = await api.fetch(passwordRoute, {
+            method: 'PUT',
+            session: currentSession,
+            body: { oldPassword: password, newPassword: 'aZ1-newpass!' }
+        });
+        expect(res.status).toBe(200);
+        isSuccess(json);
+
+        // the other session is forcibly logged out
+        expect((await api.fetch(userRoute, { method: 'GET', session: otherSession })).res.status).toBe(401);
+
+        // the session that made the change stays authenticated
+        expect((await api.fetch(userRoute, { method: 'GET', session: currentSession })).res.status).toBe(200);
+    });
+});

--- a/packages/server/lib/controllers/v1/user/password/putPassword.integration.test.ts
+++ b/packages/server/lib/controllers/v1/user/password/putPassword.integration.test.ts
@@ -14,7 +14,7 @@ let api: Awaited<ReturnType<typeof runServer>>;
 
 async function signupVerifiedUser(): Promise<{ email: string; password: string }> {
     const email = `${nanoid()}@example.com`;
-    const password = 'aZ1-foobar!';
+    const password = 'aZ1-foobar!?';
 
     const signupRes = await api.fetch(signupRoute, {
         method: 'POST',
@@ -58,7 +58,7 @@ describe(`PUT ${passwordRoute}`, () => {
         const { res, json } = await api.fetch(passwordRoute, {
             method: 'PUT',
             session: currentSession,
-            body: { oldPassword: password, newPassword: 'aZ1-newpass!' }
+            body: { oldPassword: password, newPassword: 'aZ1-newpass!?' }
         });
         expect(res.status).toBe(200);
         isSuccess(json);

--- a/packages/server/lib/controllers/v1/user/password/putPassword.ts
+++ b/packages/server/lib/controllers/v1/user/password/putPassword.ts
@@ -52,11 +52,9 @@ export const putUserPassword = asyncWrapper<PutUserPassword, never>(async (req, 
     });
 
     // Re-issue a fresh session so the user who just changed their password stays logged in seamlessly.
-    // Best effort basis, if it fails the user can simply re-authenticate with the new password.
+    // req.logIn regenerates the session id internally (passport's fixation guard), rotating the current
+    // session. Best effort: if it fails the user can simply re-authenticate with the new password.
     try {
-        await new Promise<void>((resolve, reject) =>
-            req.session.regenerate((err) => (err ? reject(err instanceof Error ? err : new Error(String(err))) : resolve()))
-        );
         await new Promise<void>((resolve, reject) =>
             req.logIn(user as Express.User, (err) => (err ? reject(err instanceof Error ? err : new Error(String(err))) : resolve()))
         );

--- a/packages/server/lib/controllers/v1/user/password/putPassword.ts
+++ b/packages/server/lib/controllers/v1/user/password/putPassword.ts
@@ -2,9 +2,11 @@ import crypto from 'node:crypto';
 
 import * as z from 'zod';
 
+import db from '@nangohq/database';
 import { pbkdf2, userService } from '@nangohq/shared';
 import { requireEmptyQuery, zodErrorToHTTP } from '@nangohq/utils';
 
+import { deleteUserSessions } from '../../../../clients/auth.client.js';
 import { asyncWrapper } from '../../../../utils/asyncWrapper.js';
 import { passwordSchema } from '../../account/signup.js';
 
@@ -44,7 +46,10 @@ export const putUserPassword = asyncWrapper<PutUserPassword, never>(async (req, 
     const salt = crypto.randomBytes(16).toString('base64');
     const hashedPassword = (await pbkdf2(body.newPassword, salt, 310000, 32, 'sha256')).toString('base64');
 
-    await userService.update({ id: user.id, hashed_password: hashedPassword, salt });
+    await db.knex.transaction(async (trx) => {
+        await userService.update({ id: user.id, hashed_password: hashedPassword, salt }, trx);
+        await deleteUserSessions(user.id, { exceptSid: req.sessionID, trx });
+    });
 
     res.status(200).send({ success: true });
 });

--- a/packages/server/lib/controllers/v1/user/password/putPassword.ts
+++ b/packages/server/lib/controllers/v1/user/password/putPassword.ts
@@ -4,7 +4,7 @@ import * as z from 'zod';
 
 import db from '@nangohq/database';
 import { pbkdf2, userService } from '@nangohq/shared';
-import { requireEmptyQuery, zodErrorToHTTP } from '@nangohq/utils';
+import { report, requireEmptyQuery, zodErrorToHTTP } from '@nangohq/utils';
 
 import { deleteUserSessions } from '../../../../clients/auth.client.js';
 import { asyncWrapper } from '../../../../utils/asyncWrapper.js';
@@ -48,8 +48,21 @@ export const putUserPassword = asyncWrapper<PutUserPassword, never>(async (req, 
 
     await db.knex.transaction(async (trx) => {
         await userService.update({ id: user.id, hashed_password: hashedPassword, salt }, trx);
-        await deleteUserSessions(user.id, { exceptSid: req.sessionID, trx });
+        await deleteUserSessions(user.id, { trx });
     });
+
+    // Re-issue a fresh session so the user who just changed their password stays logged in seamlessly.
+    // Best effort basis, if it fails the user can simply re-authenticate with the new password.
+    try {
+        await new Promise<void>((resolve, reject) =>
+            req.session.regenerate((err) => (err ? reject(err instanceof Error ? err : new Error(String(err))) : resolve()))
+        );
+        await new Promise<void>((resolve, reject) =>
+            req.logIn(user as Express.User, (err) => (err ? reject(err instanceof Error ? err : new Error(String(err))) : resolve()))
+        );
+    } catch (err) {
+        report(err);
+    }
 
     res.status(200).send({ success: true });
 });

--- a/packages/server/lib/middleware/access.middleware.ts
+++ b/packages/server/lib/middleware/access.middleware.ts
@@ -35,6 +35,7 @@ const ignoreEnvPaths = [
     '/api/v1/meta',
     '/api/v1/user',
     '/api/v1/user/name',
+    '/api/v1/user/password',
     '/api/v1/signin',
     '/api/v1/invite/:id',
     '/api/v1/account/onboarding/hear-about-us'

--- a/packages/shared/lib/services/user.service.ts
+++ b/packages/shared/lib/services/user.service.ts
@@ -5,6 +5,7 @@ import { ENVS, Err, Ok, parseEnvs } from '@nangohq/utils';
 
 import type { DBUser } from '@nangohq/types';
 import type { Result } from '@nangohq/utils';
+import type { Knex } from 'knex';
 
 const VERIFICATION_EMAIL_EXPIRATION = 3 * 24 * 60 * 60 * 1000;
 const envs = parseEnvs(ENVS);
@@ -146,8 +147,8 @@ class UserService {
         return null;
     }
 
-    async editUserPassword(user: Pick<DBUser, 'id' | 'reset_password_token' | 'hashed_password'>) {
-        return db.knex.from<DBUser>(`_nango_users`).where({ id: user.id }).update({
+    async editUserPassword(user: Pick<DBUser, 'id' | 'reset_password_token' | 'hashed_password'>, trx: Knex = db.knex) {
+        return trx.from<DBUser>(`_nango_users`).where({ id: user.id }).update({
             reset_password_token: user.reset_password_token,
             hashed_password: user.hashed_password
         });
@@ -163,8 +164,8 @@ class UserService {
         return db.knex.from<DBUser>(`_nango_users`).where({ id }).update({ email_verified: true, email_verification_token: null });
     }
 
-    async update({ id, ...data }: { id: number } & Omit<Partial<DBUser>, 'id'>): Promise<DBUser | null> {
-        const [up] = await db.knex
+    async update({ id, ...data }: { id: number } & Omit<Partial<DBUser>, 'id'>, trx: Knex = db.knex): Promise<DBUser | null> {
+        const [up] = await trx
             .from<DBUser>(`_nango_users`)
             .update({ ...data, updated_at: new Date() })
             .where({ id })

--- a/packages/types/lib/api.endpoints.ts
+++ b/packages/types/lib/api.endpoints.ts
@@ -107,7 +107,7 @@ import type {
 } from './sharedCredentials/api.js';
 import type { GetPublicSyncStatus, PostPublicSyncPause, PostPublicSyncStart, PostPublicTrigger, PutPublicSyncConnectionFrequency } from './sync/api.js';
 import type { DeleteTeamUser, GetTeam, PatchTeamUser, PutTeam } from './team/api.js';
-import type { GetUser, PatchUser } from './user/api.js';
+import type { GetUser, PatchUser, PutUserPassword } from './user/api.js';
 import type { PostPublicWebhook } from './webhooks/http.api.js';
 
 export type PublicApiEndpoints =
@@ -180,6 +180,7 @@ export type PrivateApiEndpoints =
     | GetBillingUsageTopDimensionValues
     | GetUser
     | PatchUser
+    | PutUserPassword
     | PostInvite
     | DeleteInvite
     | DeleteTeamUser


### PR DESCRIPTION
Added utility to delete user sessions. Using it on both password reset flows:
- Forgot password - invalidate all sessions
- `PUT /api/v1/user/password` - Not used. Looks like it was intended for a password change when logged in in the dashboard. Fixed nonetheless so this is safe out of the gate if we ever add it. It invalidates all sessions and creates and returns a new one on a best-effort basis (failure is non-blocking).

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/NangoHQ/nango/pull/6490?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

