### PR TITLE
fix(node-client): accept webhookSigningKey, add apiKey (NAN-5980)

### DIFF
--- a/docs/guides/platform/webhooks-from-nango.mdx
+++ b/docs/guides/platform/webhooks-from-nango.mdx
@@ -50,7 +50,7 @@ Verify the signature with the **webhook signing key** from **Environment Setting
 
     ```typescript
     const nango = new Nango({
-        secretKey: process.env.NANGO_API_KEY, // used for API calls
+        apiKey: process.env.NANGO_API_KEY, // used for API calls
         webhookSigningKey: process.env.NANGO_WEBHOOK_SIGNING_KEY // used to verify webhooks
     });
 

--- a/docs/guides/platform/webhooks-from-nango.mdx
+++ b/docs/guides/platform/webhooks-from-nango.mdx
@@ -41,14 +41,18 @@ Nango webhook requests include an `X-Nango-Hmac-Sha256` header for secure verifi
 The webhook signature can be verified with the following code:
 
 <Warning>
-Initialize the client (or HMAC) with the **webhook signing key** from **Environment Settings > Webhooks > Signing key** — not your API secret key. These are two distinct keys. Using the API secret key will cause verification to fail on any environment where the keys differ.
+Verify the signature with the **webhook signing key** from **Environment Settings > Webhooks > Signing key** — not your API secret key. These are two distinct keys. With the Node SDK, pass it as `webhookSigningKey`; for raw HMAC verification, use it as the HMAC secret. Using the API secret key will cause verification to fail on any environment where the keys differ.
 </Warning>
 
 <Tabs>
   <Tab title="Node SDK">
+    Pass the webhook signing key as `webhookSigningKey` so a single client can make API calls with the API key and verify webhooks with the signing key. `webhookSigningKey` falls back to `secretKey` when omitted.
+
     ```typescript
-    // Initialize with the webhook signing key, not the API secret key
-    const nango = new Nango({ secretKey: process.env.NANGO_WEBHOOK_SIGNING_KEY });
+    const nango = new Nango({
+        secretKey: process.env.NANGO_API_KEY, // used for API calls
+        webhookSigningKey: process.env.NANGO_WEBHOOK_SIGNING_KEY // used to verify webhooks
+    });
 
     async (req, res) => {
         const isValid = nango.verifyIncomingWebhookRequest(req.body, req.headers);

--- a/docs/llms-full.txt
+++ b/docs/llms-full.txt
@@ -6827,7 +6827,7 @@ Verify the signature with the **webhook signing key** from **Environment Setting
 
     ```typescript
     const nango = new Nango({
-        secretKey: process.env.NANGO_API_KEY, // used for API calls
+        apiKey: process.env.NANGO_API_KEY, // used for API calls
         webhookSigningKey: process.env.NANGO_WEBHOOK_SIGNING_KEY // used to verify webhooks
     });
 
@@ -9741,7 +9741,7 @@ Instantiate the `Nango` class:
 ```js
 import { Nango } from '@nangohq/node';
 
-const nango = new Nango({ secretKey: '<SECRET-KEY>' });
+const nango = new Nango({ apiKey: '<API-KEY>' });
 ```
 
 **Parameters**
@@ -9749,8 +9749,12 @@ const nango = new Nango({ secretKey: '<SECRET-KEY>' });
 <Expandable>
   <ResponseField name="config" type="object" required>
     <Expandable title="config" defaultOpen>
-      <ResponseField name="secretKey" type="string" required>
-        Get your secret key in the environment settings of the Nango UI. This key should never be shared.
+      <ResponseField name="apiKey" type="string" required>
+        Your environment API key, found in **Environment Settings > API Keys** in the Nango UI. Sent as the bearer token for API calls. This key should never be shared.
+      </ResponseField>
+
+      <ResponseField name="secretKey" type="string" deprecated>
+        Deprecated alias for `apiKey`, kept for backward compatibility. Provide either `apiKey` or `secretKey`.
       </ResponseField>
 
       <ResponseField name="webhookSigningKey" type="string">
@@ -11802,7 +11806,7 @@ Asserts that a Webhook is coming from Nango's backend. Verification uses `webhoo
 
 ```js
 const nango = new Nango({
-    secretKey: '<API-KEY>',
+    apiKey: '<API-KEY>',
     webhookSigningKey: '<WEBHOOK-SIGNING-KEY>'
 });
 

--- a/docs/llms-full.txt
+++ b/docs/llms-full.txt
@@ -6818,14 +6818,18 @@ Nango webhook requests include an `X-Nango-Hmac-Sha256` header for secure verifi
 The webhook signature can be verified with the following code:
 
 <Warning>
-Initialize the client (or HMAC) with the **webhook signing key** from **Environment Settings > Webhooks > Signing key** — not your API secret key. These are two distinct keys. Using the API secret key will cause verification to fail on any environment where the keys differ.
+Verify the signature with the **webhook signing key** from **Environment Settings > Webhooks > Signing key** — not your API secret key. These are two distinct keys. With the Node SDK, pass it as `webhookSigningKey`; for raw HMAC verification, use it as the HMAC secret. Using the API secret key will cause verification to fail on any environment where the keys differ.
 </Warning>
 
 <Tabs>
   <Tab title="Node SDK">
+    Pass the webhook signing key as `webhookSigningKey` so a single client can make API calls with the API key and verify webhooks with the signing key. `webhookSigningKey` falls back to `secretKey` when omitted.
+
     ```typescript
-    // Initialize with the webhook signing key, not the API secret key
-    const nango = new Nango({ secretKey: process.env.NANGO_WEBHOOK_SIGNING_KEY });
+    const nango = new Nango({
+        secretKey: process.env.NANGO_API_KEY, // used for API calls
+        webhookSigningKey: process.env.NANGO_WEBHOOK_SIGNING_KEY // used to verify webhooks
+    });
 
     async (req, res) => {
         const isValid = nango.verifyIncomingWebhookRequest(req.body, req.headers);
@@ -9746,7 +9750,11 @@ const nango = new Nango({ secretKey: '<SECRET-KEY>' });
   <ResponseField name="config" type="object" required>
     <Expandable title="config" defaultOpen>
       <ResponseField name="secretKey" type="string" required>
-        Get your secret key in the environment settings of the Nango UI. THis key should never be shared.
+        Get your secret key in the environment settings of the Nango UI. This key should never be shared.
+      </ResponseField>
+
+      <ResponseField name="webhookSigningKey" type="string">
+        The environment's webhook signing key, found in **Environment Settings > Webhooks > Signing key**. Used by `verifyIncomingWebhookRequest` to validate incoming webhook signatures. Falls back to `secretKey` when omitted. On environments created after 2026-04-20 (or any environment that later rotated its API key), the signing key differs from the API key, so set this explicitly to verify webhooks.
       </ResponseField>
 
       <ResponseField name="host" type="string">
@@ -11790,9 +11798,14 @@ await nango.getProvider({ provider: <NAME> })
 
 ### Verify Webhook Signature
 
-Asserts that a Webhook is coming from Nango's backend.
+Asserts that a Webhook is coming from Nango's backend. Verification uses `webhookSigningKey` when the client is constructed with one, otherwise it falls back to `secretKey`. On environments created after 2026-04-20 (or any environment that later rotated its API key), the signing key differs from the API key, so construct the client with `webhookSigningKey` (from **Environment Settings > Webhooks > Signing key**).
 
 ```js
+const nango = new Nango({
+    secretKey: '<API-KEY>',
+    webhookSigningKey: '<WEBHOOK-SIGNING-KEY>'
+});
+
 async (req, res) => {
     const isValid = nango.verifyIncomingWebhookRequest(req.body, req.headers);
 }

--- a/docs/reference/backend/backend-sdk/node.mdx
+++ b/docs/reference/backend/backend-sdk/node.mdx
@@ -19,7 +19,7 @@ Instantiate the `Nango` class:
 ```js
 import { Nango } from '@nangohq/node';
 
-const nango = new Nango({ secretKey: '<SECRET-KEY>' });
+const nango = new Nango({ apiKey: '<API-KEY>' });
 ```
 
 **Parameters**
@@ -27,8 +27,12 @@ const nango = new Nango({ secretKey: '<SECRET-KEY>' });
 <Expandable>
   <ResponseField name="config" type="object" required>
     <Expandable title="config" defaultOpen>
-      <ResponseField name="secretKey" type="string" required>
-        Get your secret key in the environment settings of the Nango UI. This key should never be shared.
+      <ResponseField name="apiKey" type="string" required>
+        Your environment API key, found in **Environment Settings > API Keys** in the Nango UI. Sent as the bearer token for API calls. This key should never be shared.
+      </ResponseField>
+
+      <ResponseField name="secretKey" type="string" deprecated>
+        Deprecated alias for `apiKey`, kept for backward compatibility. Provide either `apiKey` or `secretKey`.
       </ResponseField>
 
       <ResponseField name="webhookSigningKey" type="string">
@@ -2084,7 +2088,7 @@ Asserts that a Webhook is coming from Nango's backend. Verification uses `webhoo
 
 ```js
 const nango = new Nango({
-    secretKey: '<API-KEY>',
+    apiKey: '<API-KEY>',
     webhookSigningKey: '<WEBHOOK-SIGNING-KEY>'
 });
 

--- a/docs/reference/backend/backend-sdk/node.mdx
+++ b/docs/reference/backend/backend-sdk/node.mdx
@@ -28,7 +28,11 @@ const nango = new Nango({ secretKey: '<SECRET-KEY>' });
   <ResponseField name="config" type="object" required>
     <Expandable title="config" defaultOpen>
       <ResponseField name="secretKey" type="string" required>
-        Get your secret key in the environment settings of the Nango UI. THis key should never be shared.
+        Get your secret key in the environment settings of the Nango UI. This key should never be shared.
+      </ResponseField>
+
+      <ResponseField name="webhookSigningKey" type="string">
+        The environment's webhook signing key, found in **Environment Settings > Webhooks > Signing key**. Used by `verifyIncomingWebhookRequest` to validate incoming webhook signatures. Falls back to `secretKey` when omitted. On environments created after 2026-04-20 (or any environment that later rotated its API key), the signing key differs from the API key, so set this explicitly to verify webhooks.
       </ResponseField>
 
       <ResponseField name="host" type="string">
@@ -2076,9 +2080,14 @@ await nango.getProvider({ provider: <NAME> })
 
 ### Verify Webhook Signature
 
-Asserts that a Webhook is coming from Nango's backend.
+Asserts that a Webhook is coming from Nango's backend. Verification uses `webhookSigningKey` when the client is constructed with one, otherwise it falls back to `secretKey`. On environments created after 2026-04-20 (or any environment that later rotated its API key), the signing key differs from the API key, so construct the client with `webhookSigningKey` (from **Environment Settings > Webhooks > Signing key**).
 
 ```js
+const nango = new Nango({
+    secretKey: '<API-KEY>',
+    webhookSigningKey: '<WEBHOOK-SIGNING-KEY>'
+});
+
 async (req, res) => {
     const isValid = nango.verifyIncomingWebhookRequest(req.body, req.headers);
 }

--- a/packages/node-client/lib/index.ts
+++ b/packages/node-client/lib/index.ts
@@ -79,6 +79,7 @@ export interface AdminAxiosProps {
 export class Nango {
     serverUrl: string;
     secretKey: string;
+    webhookSigningKey?: string | undefined;
     connectionId?: string;
     providerConfigKey?: string;
     isSync = false;
@@ -107,6 +108,7 @@ export class Nango {
         }
 
         this.secretKey = config.secretKey;
+        this.webhookSigningKey = config.webhookSigningKey;
         this.connectionId = config.connectionId || '';
         this.providerConfigKey = config.providerConfigKey || '';
 
@@ -1265,10 +1267,11 @@ export class Nango {
     }
 
     private _verifyWebhookSignatureImpl(signatureInHeader: string, jsonPayload: unknown): boolean {
+        const signingKey = this.webhookSigningKey ?? this.secretKey;
         return (
             crypto
                 .createHash('sha256')
-                .update(`${this.secretKey}${JSON.stringify(jsonPayload)}`)
+                .update(`${signingKey}${JSON.stringify(jsonPayload)}`)
                 .digest('hex') === signatureInHeader
         );
     }
@@ -1276,6 +1279,11 @@ export class Nango {
     /**
      *
      * Verify incoming webhooks request
+     *
+     * Uses `webhookSigningKey` when provided, otherwise falls back to `secretKey`. On environments
+     * created after 2026-04-20 (or any environment that later rotated its API key), the signing key
+     * differs from the API key, so construct the client with `webhookSigningKey` to verify webhooks
+     * without a second client.
      *
      * @param body - The raw HTTP body as a string
      * @param headers - The HTTP headers including X-Nango-Hmac-Sha256
@@ -1287,7 +1295,8 @@ export class Nango {
             return false;
         }
 
-        const expectedSignature = crypto.createHmac('sha256', this.secretKey).update(body).digest('hex');
+        const signingKey = this.webhookSigningKey ?? this.secretKey;
+        const expectedSignature = crypto.createHmac('sha256', signingKey).update(body).digest('hex');
         const actualSignature = headers[signatureInHeader];
 
         if (typeof actualSignature !== 'string') {

--- a/packages/node-client/lib/index.ts
+++ b/packages/node-client/lib/index.ts
@@ -80,9 +80,9 @@ export class Nango {
     serverUrl: string;
     apiKey: string;
     /**
-     * @deprecated Use `apiKey` instead. Populated with the same value for backward compatibility.
+     * @deprecated Use `apiKey` instead.
      */
-    secretKey: string;
+    secretKey?: string | undefined;
     webhookSigningKey?: string | undefined;
     connectionId?: string;
     providerConfigKey?: string;
@@ -101,6 +101,10 @@ export class Nango {
             this.serverUrl = this.serverUrl.slice(0, -1);
         }
 
+        if (config.apiKey && config.secretKey) {
+            throw new Error('You must specify only one of apiKey or secretKey, not both (cf. documentation).');
+        }
+
         const apiKey = config.apiKey ?? config.secretKey;
         if (!apiKey) {
             throw new Error('You must specify an API key (cf. documentation).');
@@ -113,7 +117,7 @@ export class Nango {
         }
 
         this.apiKey = apiKey;
-        this.secretKey = apiKey;
+        this.secretKey = config.secretKey;
         this.webhookSigningKey = config.webhookSigningKey;
         this.connectionId = config.connectionId || '';
         this.providerConfigKey = config.providerConfigKey || '';
@@ -1273,7 +1277,10 @@ export class Nango {
     }
 
     private _verifyWebhookSignatureImpl(signatureInHeader: string, jsonPayload: unknown): boolean {
-        const signingKey = this.webhookSigningKey ?? this.apiKey;
+        const signingKey = this.webhookSigningKey ?? this.secretKey;
+        if (!signingKey) {
+            return false;
+        }
         return (
             crypto
                 .createHash('sha256')
@@ -1286,10 +1293,10 @@ export class Nango {
      *
      * Verify incoming webhooks request
      *
-     * Uses `webhookSigningKey` when provided, otherwise falls back to `secretKey`. On environments
-     * created after 2026-04-20 (or any environment that later rotated its API key), the signing key
-     * differs from the API key, so construct the client with `webhookSigningKey` to verify webhooks
-     * without a second client.
+     * Uses `webhookSigningKey` when provided, otherwise falls back to the deprecated `secretKey`.
+     * The API key is never used to sign webhooks, so a client constructed with `apiKey` must also
+     * set `webhookSigningKey`; otherwise this returns false. On environments created after 2026-04-20
+     * (or any environment that later rotated its API key), the signing key differs from the API key.
      *
      * @param body - The raw HTTP body as a string
      * @param headers - The HTTP headers including X-Nango-Hmac-Sha256
@@ -1301,7 +1308,11 @@ export class Nango {
             return false;
         }
 
-        const signingKey = this.webhookSigningKey ?? this.apiKey;
+        const signingKey = this.webhookSigningKey ?? this.secretKey;
+        if (!signingKey) {
+            return false;
+        }
+
         const expectedSignature = crypto.createHmac('sha256', signingKey).update(body).digest('hex');
         const actualSignature = headers[signatureInHeader];
 

--- a/packages/node-client/lib/index.ts
+++ b/packages/node-client/lib/index.ts
@@ -78,6 +78,10 @@ export interface AdminAxiosProps {
 
 export class Nango {
     serverUrl: string;
+    apiKey: string;
+    /**
+     * @deprecated Use `apiKey` instead. Populated with the same value for backward compatibility.
+     */
     secretKey: string;
     webhookSigningKey?: string | undefined;
     connectionId?: string;
@@ -97,8 +101,9 @@ export class Nango {
             this.serverUrl = this.serverUrl.slice(0, -1);
         }
 
-        if (!config.secretKey) {
-            throw new Error('You must specify a secret key (cf. documentation).');
+        const apiKey = config.apiKey ?? config.secretKey;
+        if (!apiKey) {
+            throw new Error('You must specify an API key (cf. documentation).');
         }
 
         try {
@@ -107,7 +112,8 @@ export class Nango {
             throw new Error(`Invalid URL provided for the Nango host: ${this.serverUrl}`);
         }
 
-        this.secretKey = config.secretKey;
+        this.apiKey = apiKey;
+        this.secretKey = apiKey;
         this.webhookSigningKey = config.webhookSigningKey;
         this.connectionId = config.connectionId || '';
         this.providerConfigKey = config.providerConfigKey || '';
@@ -1267,7 +1273,7 @@ export class Nango {
     }
 
     private _verifyWebhookSignatureImpl(signatureInHeader: string, jsonPayload: unknown): boolean {
-        const signingKey = this.webhookSigningKey ?? this.secretKey;
+        const signingKey = this.webhookSigningKey ?? this.apiKey;
         return (
             crypto
                 .createHash('sha256')
@@ -1295,7 +1301,7 @@ export class Nango {
             return false;
         }
 
-        const signingKey = this.webhookSigningKey ?? this.secretKey;
+        const signingKey = this.webhookSigningKey ?? this.apiKey;
         const expectedSignature = crypto.createHmac('sha256', signingKey).update(body).digest('hex');
         const actualSignature = headers[signatureInHeader];
 
@@ -1393,7 +1399,7 @@ export class Nango {
      * @returns The enriched headers
      */
     private enrichHeaders(headers: Record<string, string | number | boolean> = {}): Record<string, string | number | boolean> {
-        headers['Authorization'] = 'Bearer ' + this.secretKey;
+        headers['Authorization'] = 'Bearer ' + this.apiKey;
         headers['Nango-Is-Sync'] = this.isSync;
         headers['Nango-Is-Script'] = this.isScript;
         headers['Nango-Is-Dry-Run'] = this.dryRun;

--- a/packages/node-client/lib/index.unit.test.ts
+++ b/packages/node-client/lib/index.unit.test.ts
@@ -4,6 +4,8 @@ import { beforeEach, describe, expect, it, vi } from 'vitest';
 
 import { Nango } from './index.js';
 
+import type { NangoProps } from './types.js';
+
 describe('triggerSync', () => {
     const nango = new Nango({ secretKey: 'test' });
     const mockHttp = {
@@ -287,5 +289,37 @@ describe('verifyIncomingWebhookRequest with a separate webhook signing key', () 
         const nango = new Nango({ secretKey });
 
         expect(nango.verifyIncomingWebhookRequest(bodyString, { 'x-nango-hmac-sha256': signatureFromSecretKey })).toBe(true);
+    });
+});
+
+describe('apiKey / secretKey', () => {
+    it('should accept apiKey and use it as the bearer token and webhook verification key', () => {
+        const apiKey = 'test-api-key';
+        const nango = new Nango({ apiKey });
+
+        expect(nango.apiKey).toBe(apiKey);
+
+        const body = JSON.stringify({ type: 'sync' });
+        const signature = crypto.createHmac('sha256', apiKey).update(body).digest('hex');
+        expect(nango.verifyIncomingWebhookRequest(body, { 'x-nango-hmac-sha256': signature })).toBe(true);
+    });
+
+    it('should still accept the deprecated secretKey and expose it as apiKey', () => {
+        const secretKey = 'test-secret-key';
+        const nango = new Nango({ secretKey });
+
+        expect(nango.apiKey).toBe(secretKey);
+        expect(nango.secretKey).toBe(secretKey);
+    });
+
+    it('should prefer apiKey when both are provided', () => {
+        const nango = new Nango({ apiKey: 'the-api-key', secretKey: 'the-secret-key' });
+
+        expect(nango.apiKey).toBe('the-api-key');
+    });
+
+    it('should throw when neither apiKey nor secretKey is provided', () => {
+        // The type requires at least one credential; cast to exercise the runtime guard defensively.
+        expect(() => new Nango({} as unknown as NangoProps)).toThrow(/API key/);
     });
 });

--- a/packages/node-client/lib/index.unit.test.ts
+++ b/packages/node-client/lib/index.unit.test.ts
@@ -254,3 +254,38 @@ describe('verifyIncomingWebhookRequest', () => {
         expect(nango.verifyIncomingWebhookRequest(bodyString, headersLowerCase)).toBe(true);
     });
 });
+
+describe('verifyIncomingWebhookRequest with a separate webhook signing key', () => {
+    const secretKey = 'test-secret-key';
+    const webhookSigningKey = 'test-webhook-signing-key';
+
+    const body = {
+        type: 'sync',
+        connectionId: 'test-connection',
+        providerConfigKey: 'test-provider',
+        syncName: 'test-sync',
+        model: 'TestModel',
+        responseResults: { added: 5, updated: 0, deleted: 0 }
+    };
+    const bodyString = JSON.stringify(body);
+    const signatureFromSigningKey = crypto.createHmac('sha256', webhookSigningKey).update(bodyString).digest('hex');
+    const signatureFromSecretKey = crypto.createHmac('sha256', secretKey).update(bodyString).digest('hex');
+
+    it('should verify webhooks signed with the webhook signing key', () => {
+        const nango = new Nango({ secretKey, webhookSigningKey });
+
+        expect(nango.verifyIncomingWebhookRequest(bodyString, { 'x-nango-hmac-sha256': signatureFromSigningKey })).toBe(true);
+    });
+
+    it('should reject webhooks signed with the secret key when a webhook signing key is set', () => {
+        const nango = new Nango({ secretKey, webhookSigningKey });
+
+        expect(nango.verifyIncomingWebhookRequest(bodyString, { 'x-nango-hmac-sha256': signatureFromSecretKey })).toBe(false);
+    });
+
+    it('should fall back to the secret key when no webhook signing key is set', () => {
+        const nango = new Nango({ secretKey });
+
+        expect(nango.verifyIncomingWebhookRequest(bodyString, { 'x-nango-hmac-sha256': signatureFromSecretKey })).toBe(true);
+    });
+});

--- a/packages/node-client/lib/index.unit.test.ts
+++ b/packages/node-client/lib/index.unit.test.ts
@@ -293,29 +293,47 @@ describe('verifyIncomingWebhookRequest with a separate webhook signing key', () 
 });
 
 describe('apiKey / secretKey', () => {
-    it('should accept apiKey and use it as the bearer token and webhook verification key', () => {
+    it('should accept apiKey and use it as the bearer token', () => {
         const apiKey = 'test-api-key';
         const nango = new Nango({ apiKey });
 
         expect(nango.apiKey).toBe(apiKey);
+        expect(nango.secretKey).toBeUndefined();
+    });
+
+    it('should not use the apiKey to verify webhooks (must set webhookSigningKey)', () => {
+        const apiKey = 'test-api-key';
+        const nango = new Nango({ apiKey });
 
         const body = JSON.stringify({ type: 'sync' });
         const signature = crypto.createHmac('sha256', apiKey).update(body).digest('hex');
+        // No webhookSigningKey and no deprecated secretKey, so there is no signing key to fall back to.
+        expect(nango.verifyIncomingWebhookRequest(body, { 'x-nango-hmac-sha256': signature })).toBe(false);
+    });
+
+    it('should verify webhooks with webhookSigningKey when constructed with apiKey', () => {
+        const nango = new Nango({ apiKey: 'test-api-key', webhookSigningKey: 'test-signing-key' });
+
+        const body = JSON.stringify({ type: 'sync' });
+        const signature = crypto.createHmac('sha256', 'test-signing-key').update(body).digest('hex');
         expect(nango.verifyIncomingWebhookRequest(body, { 'x-nango-hmac-sha256': signature })).toBe(true);
     });
 
-    it('should still accept the deprecated secretKey and expose it as apiKey', () => {
+    it('should still accept the deprecated secretKey for both the bearer token and webhook fallback', () => {
         const secretKey = 'test-secret-key';
         const nango = new Nango({ secretKey });
 
         expect(nango.apiKey).toBe(secretKey);
         expect(nango.secretKey).toBe(secretKey);
+
+        const body = JSON.stringify({ type: 'sync' });
+        const signature = crypto.createHmac('sha256', secretKey).update(body).digest('hex');
+        expect(nango.verifyIncomingWebhookRequest(body, { 'x-nango-hmac-sha256': signature })).toBe(true);
     });
 
-    it('should prefer apiKey when both are provided', () => {
-        const nango = new Nango({ apiKey: 'the-api-key', secretKey: 'the-secret-key' });
-
-        expect(nango.apiKey).toBe('the-api-key');
+    it('should throw when both apiKey and secretKey are provided', () => {
+        // The type forbids passing both (XOR); cast to exercise the runtime guard for JS callers.
+        expect(() => new Nango({ apiKey: 'the-api-key', secretKey: 'the-secret-key' } as unknown as NangoProps)).toThrow(/not both/);
     });
 
     it('should throw when neither apiKey nor secretKey is provided', () => {

--- a/packages/node-client/lib/types.ts
+++ b/packages/node-client/lib/types.ts
@@ -102,6 +102,14 @@ export type { NangoSyncConfig, StandardNangoConfig, SyncResult };
 export interface NangoProps {
     host?: string;
     secretKey: string;
+    /**
+     * The environment's webhook signing key (Environment Settings → Webhooks → Signing key).
+     * Used by `verifyIncomingWebhookRequest` to validate incoming webhook signatures.
+     * Defaults to `secretKey` when omitted. On environments created after 2026-04-20 (or any
+     * environment that later rotated its API key), the signing key differs from the API key,
+     * so set this explicitly to verify webhooks.
+     */
+    webhookSigningKey?: string;
     connectionId?: string;
     providerConfigKey?: string;
     isSync?: boolean;

--- a/packages/node-client/lib/types.ts
+++ b/packages/node-client/lib/types.ts
@@ -99,14 +99,34 @@ export type {
 
 export type { NangoSyncConfig, StandardNangoConfig, SyncResult };
 
-interface NangoBaseProps {
+/**
+ * SDK credentials. Provide exactly one of `apiKey` (preferred) or the deprecated `secretKey`;
+ * setting both is a compile-time error.
+ */
+type NangoCredentials =
+    | {
+          /**
+           * Your Nango environment API key (Environment Settings → API Keys).
+           * Sent as the bearer token for API calls.
+           */
+          apiKey: string;
+          secretKey?: never;
+      }
+    | {
+          apiKey?: never;
+          /** @deprecated Use `apiKey` instead. Kept as an alias for backward compatibility. */
+          secretKey: string;
+      };
+
+export type NangoProps = {
     host?: string;
     /**
      * The environment's webhook signing key (Environment Settings → Webhooks → Signing key).
      * Used by `verifyIncomingWebhookRequest` to validate incoming webhook signatures.
-     * Defaults to the API key when omitted. On environments created after 2026-04-20 (or any
-     * environment that later rotated its API key), the signing key differs from the API key,
-     * so set this explicitly to verify webhooks.
+     * Falls back to the deprecated `secretKey` when omitted; the API key is never used to sign
+     * webhooks, so a client constructed with `apiKey` must set this to verify webhooks. On
+     * environments created after 2026-04-20 (or any environment that later rotated its API key),
+     * the signing key differs from the API key.
      */
     webhookSigningKey?: string;
     connectionId?: string;
@@ -115,29 +135,7 @@ interface NangoBaseProps {
     dryRun?: boolean;
     isScript?: boolean;
     activityLogId?: string | undefined;
-}
-
-/**
- * Credentials for the SDK. At least one of `apiKey` (preferred) or the deprecated `secretKey`
- * must be provided; this is enforced at compile time.
- */
-export type NangoProps = NangoBaseProps &
-    (
-        | {
-              /**
-               * Your Nango environment API key (Environment Settings → API Keys).
-               * Sent as the bearer token for API calls.
-               */
-              apiKey: string;
-              /** @deprecated Use `apiKey` instead. Kept as an alias for backward compatibility. */
-              secretKey?: string;
-          }
-        | {
-              apiKey?: string;
-              /** @deprecated Use `apiKey` instead. Kept as an alias for backward compatibility. */
-              secretKey: string;
-          }
-    );
+} & NangoCredentials;
 
 export type ProxyConfiguration = Omit<UserProvidedProxyConfiguration, 'files' | 'providerConfigKey'> & {
     providerConfigKey?: string;

--- a/packages/node-client/lib/types.ts
+++ b/packages/node-client/lib/types.ts
@@ -99,13 +99,12 @@ export type {
 
 export type { NangoSyncConfig, StandardNangoConfig, SyncResult };
 
-export interface NangoProps {
+interface NangoBaseProps {
     host?: string;
-    secretKey: string;
     /**
      * The environment's webhook signing key (Environment Settings → Webhooks → Signing key).
      * Used by `verifyIncomingWebhookRequest` to validate incoming webhook signatures.
-     * Defaults to `secretKey` when omitted. On environments created after 2026-04-20 (or any
+     * Defaults to the API key when omitted. On environments created after 2026-04-20 (or any
      * environment that later rotated its API key), the signing key differs from the API key,
      * so set this explicitly to verify webhooks.
      */
@@ -117,6 +116,28 @@ export interface NangoProps {
     isScript?: boolean;
     activityLogId?: string | undefined;
 }
+
+/**
+ * Credentials for the SDK. At least one of `apiKey` (preferred) or the deprecated `secretKey`
+ * must be provided; this is enforced at compile time.
+ */
+export type NangoProps = NangoBaseProps &
+    (
+        | {
+              /**
+               * Your Nango environment API key (Environment Settings → API Keys).
+               * Sent as the bearer token for API calls.
+               */
+              apiKey: string;
+              /** @deprecated Use `apiKey` instead. Kept as an alias for backward compatibility. */
+              secretKey?: string;
+          }
+        | {
+              apiKey?: string;
+              /** @deprecated Use `apiKey` instead. Kept as an alias for backward compatibility. */
+              secretKey: string;
+          }
+    );
 
 export type ProxyConfiguration = Omit<UserProvidedProxyConfiguration, 'files' | 'providerConfigKey'> & {
     providerConfigKey?: string;

--- a/packages/runner/lib/sdk/sdk.ts
+++ b/packages/runner/lib/sdk/sdk.ts
@@ -320,7 +320,7 @@ export class NangoActionRunner extends NangoActionBase<never, ZodCheckpoint> {
                 acc.push(...Object.values(conn.connection.credentials));
                 return acc;
             }, []),
-            this.nango.secretKey
+            this.nango.apiKey
         ];
 
         const method = res.config.method?.toLocaleUpperCase(); // axios put it in lowercase


### PR DESCRIPTION
## Why

After the scoped API keys migration, Nango signs outgoing webhooks with the environment's dedicated webhook signing key, which differs from the API key on newer environments. The Node SDK only ever HMACed with `secretKey`, so `verifyIncomingWebhookRequest` failed unless customers spun up a second client just for verification.

## Changes

This PR has two commits:

**Commit 1 (the fix):** Add an optional `webhookSigningKey` to the SDK constructor. Both verification paths now use it and fall back to `secretKey` when omitted, so existing single-key setups keep working. A single client can now make API calls and verify webhooks.

**Commit 2 (cleanup):** Add `apiKey` as the preferred constructor field and mark `secretKey` deprecated. The value we called `secretKey` is really the API key, and "secretKey" became misleading once the signing key got its own field. `secretKey` stays as a populated alias, so nothing breaks.

If commit 2 is deemed out of scope it can be reverted on its own, but I think we should start pushing this naming now while we are touching the constructor.

Docs (Node SDK reference and the webhooks guide) updated to match.

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/NangoHQ/nango/pull/6493?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

