### PR TITLE
fix(server): raise OAUTH2_CC token length cap to 4096

### DIFF
--- a/packages/server/lib/helpers/validation.ts
+++ b/packages/server/lib/helpers/validation.ts
@@ -114,7 +114,7 @@ export const connectionCredentialsOauth2Schema = z.strictObject({
 });
 
 export const connectionCredentialsOauth2CCSchema = z.strictObject({
-    token: z.string().min(1).max(2048),
+    token: z.string().min(1).max(4096),
     client_id: z.string().min(1).max(255),
     client_secret: z.string().min(1).max(2048),
     client_certificate: z.string().min(1).max(10000).optional(),

--- a/packages/server/lib/helpers/validation.unit.test.ts
+++ b/packages/server/lib/helpers/validation.unit.test.ts
@@ -1,0 +1,49 @@
+import { describe, expect, it } from 'vitest';
+
+import { connectionCredentialsOauth2CCSchema } from './validation.js';
+
+describe('connectionCredentialsOauth2CCSchema', () => {
+    const baseCredentials = {
+        token: 'a',
+        client_id: 'client-id',
+        client_secret: 'client-secret'
+    };
+
+    it('accepts a token longer than 2048 chars (regression for #6239)', () => {
+        // Microsoft Entra OAUTH2_CC access tokens are JWTs that routinely land in the
+        // 2050-2200 char range, which the previous 2048 cap wrongly rejected on import.
+        const res = connectionCredentialsOauth2CCSchema.safeParse({
+            ...baseCredentials,
+            token: 'a'.repeat(2099)
+        });
+
+        expect(res.success).toBe(true);
+    });
+
+    it('accepts a token up to 4096 chars', () => {
+        const res = connectionCredentialsOauth2CCSchema.safeParse({
+            ...baseCredentials,
+            token: 'a'.repeat(4096)
+        });
+
+        expect(res.success).toBe(true);
+    });
+
+    it('rejects a token longer than 4096 chars', () => {
+        const res = connectionCredentialsOauth2CCSchema.safeParse({
+            ...baseCredentials,
+            token: 'a'.repeat(4097)
+        });
+
+        expect(res.success).toBe(false);
+    });
+
+    it('rejects an empty token', () => {
+        const res = connectionCredentialsOauth2CCSchema.safeParse({
+            ...baseCredentials,
+            token: ''
+        });
+
+        expect(res.success).toBe(false);
+    });
+});

--- a/packages/server/lib/helpers/validation.unit.test.ts
+++ b/packages/server/lib/helpers/validation.unit.test.ts
@@ -2,6 +2,11 @@ import { describe, expect, it } from 'vitest';
 
 import { connectionCredentialsOauth2CCSchema } from './validation.js';
 
+// The previous cap that wrongly rejected long OAUTH2_CC tokens on import (#6239).
+const OLD_MAX_TOKEN_LENGTH = 2048;
+// The current cap, matched to the OAUTH2 `access_token` limit.
+const MAX_TOKEN_LENGTH = 4096;
+
 describe('connectionCredentialsOauth2CCSchema', () => {
     const baseCredentials = {
         token: 'a',
@@ -9,30 +14,31 @@ describe('connectionCredentialsOauth2CCSchema', () => {
         client_secret: 'client-secret'
     };
 
-    it('accepts a token longer than 2048 chars (regression for #6239)', () => {
+    it('accepts a token longer than the old cap (regression for #6239)', () => {
         // Microsoft Entra OAUTH2_CC access tokens are JWTs that routinely land in the
-        // 2050-2200 char range, which the previous 2048 cap wrongly rejected on import.
+        // 2050-2200 char range, which the previous OLD_MAX_TOKEN_LENGTH cap wrongly
+        // rejected on import. Just over the old cap is enough to prove the regression.
         const res = connectionCredentialsOauth2CCSchema.safeParse({
             ...baseCredentials,
-            token: 'a'.repeat(2099)
+            token: 'a'.repeat(OLD_MAX_TOKEN_LENGTH + 1)
         });
 
         expect(res.success).toBe(true);
     });
 
-    it('accepts a token up to 4096 chars', () => {
+    it('accepts a token up to the max length', () => {
         const res = connectionCredentialsOauth2CCSchema.safeParse({
             ...baseCredentials,
-            token: 'a'.repeat(4096)
+            token: 'a'.repeat(MAX_TOKEN_LENGTH)
         });
 
         expect(res.success).toBe(true);
     });
 
-    it('rejects a token longer than 4096 chars', () => {
+    it('rejects a token longer than the max length', () => {
         const res = connectionCredentialsOauth2CCSchema.safeParse({
             ...baseCredentials,
-            token: 'a'.repeat(4097)
+            token: 'a'.repeat(MAX_TOKEN_LENGTH + 1)
         });
 
         expect(res.success).toBe(false);


### PR DESCRIPTION
## Summary

The `POST /connection` import schema capped the OAUTH2_CC `token` at `max(2048)` while the sibling OAUTH2 `access_token` and `refresh_token` allow `max(4096)`. Microsoft Entra `client_credentials` access tokens are JWTs carrying role/group claims that routinely run 2050-2200 chars, so importing those connections returned `400 invalid_body` — even though the normal server-side create/refresh flow handles them fine (it never hits this validator).

This raises the cap to 4096 to match `access_token`.

## Changes

- `token: z.string().min(1).max(2048)` → `max(4096)` in `validation.ts`
- Unit test covering the regression (>2048) and the 4096 / 4097 / empty boundaries

## Testing

Verified the schema against the pinned `zod@4.0.5`: a 2099-char token now passes, 4096 passes, 4097 and empty are rejected. Credentials are stored in a Postgres `json` column (no length constraint), so there is no downstream limit that would still reject a longer token.

Closes #6239

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/NangoHQ/nango/pull/6494?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

