### PR TITLE
fix(cli): validate trackDeletes ordering per-model, not globally

### DIFF
--- a/packages/cli/fixtures/track-deletes-multi-model-sync.ts
+++ b/packages/cli/fixtures/track-deletes-multi-model-sync.ts
@@ -1,0 +1,11 @@
+import type { NangoSync } from './models';
+
+export default async function fetchData(nango: NangoSync) {
+    await nango.trackDeletesStart('ModelA');
+    await nango.batchSave([{ id: '1' }], 'ModelA');
+    await nango.trackDeletesEnd('ModelA');
+
+    await nango.trackDeletesStart('ModelB');
+    await nango.batchSave([{ id: '2' }], 'ModelB');
+    await nango.trackDeletesEnd('ModelB');
+}

--- a/packages/cli/fixtures/zero/cases/trackDeletes.multiModel.valid.ts
+++ b/packages/cli/fixtures/zero/cases/trackDeletes.multiModel.valid.ts
@@ -1,0 +1,31 @@
+import { createSync } from 'nango';
+import * as z from 'zod';
+
+const modelA = z.object({
+    id: z.string()
+});
+
+const modelB = z.object({
+    id: z.string()
+});
+
+export default createSync({
+    description: 'example',
+    version: '1.0.0',
+    endpoints: [{ method: 'GET', path: '/example', group: 'Issues' }],
+    frequency: 'every hour',
+    syncType: 'full',
+    models: {
+        ModelA: modelA,
+        ModelB: modelB
+    },
+    exec: async (nango) => {
+        await nango.trackDeletesStart('ModelA');
+        await nango.batchSave([{ id: '1' }], 'ModelA');
+        await nango.trackDeletesEnd('ModelA');
+
+        await nango.trackDeletesStart('ModelB');
+        await nango.batchSave([{ id: '2' }], 'ModelB');
+        await nango.trackDeletesEnd('ModelB');
+    }
+});

--- a/packages/cli/fixtures/zero/cases/trackDeletes.outOfOrder.error.ts
+++ b/packages/cli/fixtures/zero/cases/trackDeletes.outOfOrder.error.ts
@@ -1,0 +1,22 @@
+import { createSync } from 'nango';
+import * as z from 'zod';
+
+const modelA = z.object({
+    id: z.string()
+});
+
+export default createSync({
+    description: 'example',
+    version: '1.0.0',
+    endpoints: [{ method: 'GET', path: '/example', group: 'Issues' }],
+    frequency: 'every hour',
+    syncType: 'full',
+    models: {
+        ModelA: modelA
+    },
+    exec: async (nango) => {
+        await nango.batchSave([{ id: '1' }], 'ModelA');
+        await nango.trackDeletesStart('ModelA');
+        await nango.trackDeletesEnd('ModelA');
+    }
+});

--- a/packages/cli/lib/services/parser.service.ts
+++ b/packages/cli/lib/services/parser.service.ts
@@ -101,6 +101,7 @@ class ParserService {
         );
         const proxyLines: number[] = [];
         const batchingRecordsLines: number[] = [];
+        const batchingRecordsLinesByModel = new Map<string, number[]>();
         const setMergingStrategyLines: number[] = [];
         const deleteRecordsFromPreviousExecutionsLines: number[] = [];
         const trackDeletesByModel = new Map<string, { startLines: number[]; endLines: number[] }>();
@@ -190,6 +191,16 @@ class ParserService {
                     }
                     if (callsBatchingRecords.includes(callee.property.name)) {
                         batchingRecordsLines.push(lineNumber);
+                        // The model is the second argument of batchSave/batchUpdate/batchDelete.
+                        // Track it per-model so trackDeletesStart/End ordering is validated against
+                        // the model's own batching calls, not every model's calls globally.
+                        const batchingArgs = path.node.arguments as t.Expression[];
+                        if (batchingArgs.length > 1 && t.isStringLiteral(batchingArgs[1])) {
+                            const batchingModel = batchingArgs[1].value;
+                            const modelLines = batchingRecordsLinesByModel.get(batchingModel) ?? [];
+                            modelLines.push(lineNumber);
+                            batchingRecordsLinesByModel.set(batchingModel, modelLines);
+                        }
                     }
                     if (callee.property.name === 'setMergingStrategy') {
                         setMergingStrategyLines.push(lineNumber);
@@ -294,6 +305,7 @@ class ParserService {
         }
 
         for (const [model, { startLines, endLines }] of trackDeletesByModel) {
+            const modelBatchingRecordsLines = batchingRecordsLinesByModel.get(model) ?? [];
             if (startLines.length > 1) {
                 console.log(chalk.red(`trackDeletesStart for model '${model}' should be called only once in "${filePath}:${Math.max(...startLines)}".`));
                 usedCorrectly = false;
@@ -316,7 +328,7 @@ class ParserService {
                 );
                 usedCorrectly = false;
             }
-            if (startLines.length > 0 && batchingRecordsLines.some((line) => line < Math.max(...startLines))) {
+            if (startLines.length > 0 && modelBatchingRecordsLines.some((line) => line < Math.max(...startLines))) {
                 console.log(
                     chalk.red(
                         `trackDeletesStart for model '${model}' should be called before all batching records functions in "${filePath}:${Math.max(...startLines)}".`
@@ -324,7 +336,7 @@ class ParserService {
                 );
                 usedCorrectly = false;
             }
-            if (endLines.length > 0 && batchingRecordsLines.some((line) => line > Math.min(...endLines))) {
+            if (endLines.length > 0 && modelBatchingRecordsLines.some((line) => line > Math.min(...endLines))) {
                 console.log(
                     chalk.red(
                         `trackDeletesEnd for model '${model}' should be called after all batching records functions in "${filePath}:${Math.min(...endLines)}".`

--- a/packages/cli/lib/sync.unit.cli-test.ts
+++ b/packages/cli/lib/sync.unit.cli-test.ts
@@ -69,6 +69,11 @@ describe('generate function tests', () => {
         expect(usedCorrectly).toBe(false);
     });
 
+    it('should allow trackDeletes for multiple models authored sequentially', () => {
+        const usedCorrectly = parserService.callsAreUsedCorrectly(join(fixturesPath, 'track-deletes-multi-model-sync.ts'), 'sync', ['ModelA', 'ModelB']);
+        expect(usedCorrectly).toBe(true);
+    });
+
     it('should be able to compile files in nested directories', async () => {
         const dir = await getTestDirectory('nested');
         init({ absolutePath: dir });

--- a/packages/cli/lib/zeroYaml/__snapshots__/compile.unit.cli-test.ts.snap
+++ b/packages/cli/lib/zeroYaml/__snapshots__/compile.unit.cli-test.ts.snap
@@ -217,3 +217,9 @@ exports[`edge cases > should catch multiple exports 1`] = `
   Named export 'test' is not allowed. Only export default and createAction, createSync, createOnEvent are permitted.
 "
 `;
+
+exports[`edge cases > should catch trackDeletesStart called after the same model batching call 1`] = `
+"err - ./zero/cases/trackDeletes.outOfOrder.error.ts:20 
+  trackDeletesStart for model 'ModelA' should be called before any batching records function
+"
+`;

--- a/packages/cli/lib/zeroYaml/compile.ts
+++ b/packages/cli/lib/zeroYaml/compile.ts
@@ -282,6 +282,7 @@ export async function bundleFile({ entryPoint, projectRootPath }: { entryPoint: 
         }
 
         for (const [model, { startLines, endLines }] of bag.trackDeletesByModel) {
+            const modelBatchingRecordsLines = bag.batchingRecordsLinesByModel.get(model) ?? [];
             if (startLines.length > 1) {
                 return Err(
                     fileErrorToText({
@@ -327,7 +328,7 @@ export async function bundleFile({ entryPoint, projectRootPath }: { entryPoint: 
                     })
                 );
             }
-            if (startLines.length > 0 && bag.batchingRecordsLines.some((line) => line < Math.min(...startLines))) {
+            if (startLines.length > 0 && modelBatchingRecordsLines.some((line) => line < Math.min(...startLines))) {
                 return Err(
                     fileErrorToText({
                         filePath: friendlyPath,
@@ -336,7 +337,7 @@ export async function bundleFile({ entryPoint, projectRootPath }: { entryPoint: 
                     })
                 );
             }
-            if (endLines.length > 0 && bag.batchingRecordsLines.some((line) => line > Math.min(...endLines))) {
+            if (endLines.length > 0 && modelBatchingRecordsLines.some((line) => line > Math.min(...endLines))) {
                 return Err(
                     fileErrorToText({
                         filePath: friendlyPath,
@@ -442,6 +443,7 @@ type AugmentedExportDefault = babel.types.ExportDefaultDeclaration & { __transfo
 function nangoPlugin({ entryPoint }: { entryPoint: string }) {
     const proxyLines: number[] = [];
     const batchingRecordsLines: number[] = [];
+    const batchingRecordsLinesByModel = new Map<string, number[]>();
     const setMergingStrategyLines: number[] = [];
     const deleteRecordsFromPreviousExecutionsLines: number[] = [];
     const trackDeletesByModel = new Map<string, { startLines: number[]; endLines: number[] }>();
@@ -449,6 +451,7 @@ function nangoPlugin({ entryPoint }: { entryPoint: string }) {
     const bag = {
         proxyLines,
         batchingRecordsLines,
+        batchingRecordsLinesByModel,
         setMergingStrategyLines,
         deleteRecordsFromPreviousExecutionsLines,
         trackDeletesByModel,
@@ -583,6 +586,16 @@ function nangoPlugin({ entryPoint }: { entryPoint: string }) {
                                     }
                                     if (callsBatchingRecords.includes(callee.property.name)) {
                                         batchingRecordsLines.push(lineNumber);
+                                        // The model is the second argument of batchSave/batchUpdate/batchDelete.
+                                        // Track it per-model so trackDeletesStart/End ordering is validated against
+                                        // the model's own batching calls, not every model's calls globally.
+                                        const batchingArgs = astPath.node.arguments;
+                                        if (batchingArgs.length > 1 && t.isStringLiteral(batchingArgs[1])) {
+                                            const batchingModel = batchingArgs[1].value;
+                                            const modelLines = batchingRecordsLinesByModel.get(batchingModel) ?? [];
+                                            modelLines.push(lineNumber);
+                                            batchingRecordsLinesByModel.set(batchingModel, modelLines);
+                                        }
                                     }
                                     if (callee.property.name === 'setMergingStrategy') {
                                         setMergingStrategyLines.push(lineNumber);

--- a/packages/cli/lib/zeroYaml/compile.unit.cli-test.ts
+++ b/packages/cli/lib/zeroYaml/compile.unit.cli-test.ts
@@ -66,6 +66,29 @@ describe('edge cases', () => {
 
         expect(result.error.toText().replaceAll('\\', '/')).toMatchSnapshot();
     });
+
+    it('should allow trackDeletes for multiple models authored sequentially', async () => {
+        const result = await bundleFile({
+            entryPoint: path.join(fixturesPath, 'zero/cases/trackDeletes.multiModel.valid.js'),
+            projectRootPath: fixturesPath
+        });
+        if (result.isErr()) {
+            throw result.error;
+        }
+        expect(result.isOk()).toBe(true);
+    });
+
+    it('should catch trackDeletesStart called after the same model batching call', async () => {
+        const result = await bundleFile({
+            entryPoint: path.join(fixturesPath, 'zero/cases/trackDeletes.outOfOrder.error.js'),
+            projectRootPath: fixturesPath
+        });
+        if (result.isErr()) {
+            expect(result.error.message.replaceAll('\\', '/')).toMatchSnapshot();
+        } else {
+            throw new Error('should be an error');
+        }
+    });
 });
 
 describe('detectFeatures', () => {


### PR DESCRIPTION
Fixes #6057.

## Summary

The compile-time lifecycle validator collected every `nango.batchSave/batchUpdate/batchDelete` line number into one **global** list, then validated each model's `trackDeletesStart`/`End` ordering against that global list. In a multi-model sync a `batchSave(..., 'ModelA')` was wrongly counted against `ModelB`'s trackDeletes window, rejecting the valid per-model pattern with `trackDeletesEnd for model 'ModelB' should be called after any batching records function`.

This tracks batching lines **per model** (keyed by the model = 2nd arg) and validates each model's window against only its own batching calls. Applied to both validator paths that shared the bug — `packages/cli/lib/zeroYaml/compile.ts` (the path the issue cites) and `packages/cli/lib/services/parser.service.ts` (legacy parser).

## Tests

- 4 tests across both paths, incl. a guard that genuinely out-of-order *same-model* calls are still rejected
- Red-green proven on both paths; `test:cli` 86/86, eslint + `tsc -b packages/cli` clean

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/NangoHQ/nango/pull/6495?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

