### PR TITLE
fix(sync_jobs): restore CRON_DELETE_OLD_JOBS_MAX_DAYS default to 31 (NAN-5491)

### DIFF
--- a/packages/utils/lib/environment/parse.ts
+++ b/packages/utils/lib/environment/parse.ts
@@ -67,7 +67,7 @@ export const ENVS = z.object({
     CRON_TIMEOUT_LOGS_MINUTES: z.coerce.number().optional().default(10),
     CRON_DELETE_OLD_JOBS_LIMIT: z.coerce.number().optional().default(1000),
     CRON_DELETE_OLD_DATA_EVERY_MIN: z.coerce.number().optional().default(10),
-    CRON_DELETE_OLD_JOBS_MAX_DAYS: z.coerce.number().optional().default(3),
+    CRON_DELETE_OLD_JOBS_MAX_DAYS: z.coerce.number().optional().default(31),
     CRON_DELETE_OLD_CONNECT_SESSION_MAX_DAYS: z.coerce.number().optional().default(31),
     CRON_DELETE_OLD_PRIVATE_KEYS_MAX_DAYS: z.coerce.number().optional().default(31),
     CRON_DELETE_OLD_OAUTH_SESSION_MAX_DAYS: z.coerce.number().optional().default(2),


### PR DESCRIPTION
## Why

Phase 3a ([#6376](https://github.com/NangoHQ/nango/pull/6376)) temporarily dropped the code default for `CRON_DELETE_OLD_JOBS_MAX_DAYS` from 31 to 3 to shrink `_nango_sync_jobs` ahead of the bigint PK swap. The plan assumed cloud would inherit the default through its env config, but cloud has an explicit env override (managed in nango-environments) so the code default change had no effect there.

Meanwhile **every self-hosted instance without an explicit override has been silently dropping retention to 3 days** since 3a deployed. That's way too aggressive for them — the historical operational baseline is 31 days. Restore it now so self-hosted is not impacted while the rest of Phase 3 plays out on cloud.

## What

- `packages/utils/lib/environment/parse.ts` — `CRON_DELETE_OLD_JOBS_MAX_DAYS` default `3` → `31`.

## How

- **Stack:** standalone — does not depend on any other Phase 3 PR; can merge directly to master.
- Cloud is unaffected because cloud's value comes from the explicit env override (currently `"32"`, being lowered to `"3"` via [nango-environments#97](https://github.com/NangoHQ/nango-environments/pull/97) for the Phase 3 shrink).
- Supersedes the equivalent revert in Phase 3g ([#6382](https://github.com/NangoHQ/nango/pull/6382)) — 3g can stay open for the rest of the chain, but once this lands its only change becomes a no-op.

Linear: NAN-5491.

## Test plan

- [x] TS build clean.
- [ ] Merge + deploy.
- [ ] Self-hosted on next upgrade: retention back to 31-day default.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/NangoHQ/nango/pull/6496?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

