### PR TITLE
feat(sandbox): add AgentCore sandbox provider

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -831,6 +831,27 @@
                 "node": ">=20.0.0"
             }
         },
+        "node_modules/@aws-sdk/client-bedrock-agentcore": {
+            "version": "3.1066.0",
+            "resolved": "https://registry.npmjs.org/@aws-sdk/client-bedrock-agentcore/-/client-bedrock-agentcore-3.1066.0.tgz",
+            "integrity": "sha512-7wpBOVhp5zWi2Ngd726MJY5wN5QSX9hBDDGdc2kgZaOoW15iiA87atCbPGwjZTspTIBJH73737jgRIhT/O484A==",
+            "license": "Apache-2.0",
+            "dependencies": {
+                "@aws-crypto/sha256-browser": "5.2.0",
+                "@aws-crypto/sha256-js": "5.2.0",
+                "@aws-sdk/core": "^3.974.20",
+                "@aws-sdk/credential-provider-node": "^3.972.55",
+                "@aws-sdk/types": "^3.973.12",
+                "@smithy/core": "^3.24.6",
+                "@smithy/fetch-http-handler": "^5.4.6",
+                "@smithy/node-http-handler": "^4.7.6",
+                "@smithy/types": "^4.14.3",
+                "tslib": "^2.6.2"
+            },
+            "engines": {
+                "node": ">=20.0.0"
+            }
+        },
         "node_modules/@aws-sdk/client-dynamodb": {
             "version": "3.1066.0",
             "resolved": "https://registry.npmjs.org/@aws-sdk/client-dynamodb/-/client-dynamodb-3.1066.0.tgz",
@@ -39470,6 +39491,7 @@
             "name": "@nangohq/sandbox",
             "version": "1.0.0",
             "dependencies": {
+                "@aws-sdk/client-bedrock-agentcore": "3.1066.0",
                 "@nangohq/database": "file:../database",
                 "@nangohq/shared": "file:../shared",
                 "@nangohq/utils": "file:../utils",

--- a/packages/sandbox/agentcore-runtime/Dockerfile
+++ b/packages/sandbox/agentcore-runtime/Dockerfile
@@ -1,0 +1,36 @@
+FROM node:22-bookworm-slim
+
+ARG NANGO_VERSION=0.70.6
+
+ENV NANGO_CLI_UPGRADE_MODE=ignore
+ENV NODE_ENV=production
+
+RUN getent group user >/dev/null || groupadd user \
+    && id -u user >/dev/null 2>&1 || useradd --gid user --create-home --shell /bin/bash user \
+    && mkdir -p /tmp/template-support /home/user/agentcore-runtime \
+    && chown -R user:user /home/user/agentcore-runtime
+
+COPY packages/sandbox/agentcore-runtime/cleanup-nango-project.mjs /tmp/template-support/cleanup-nango-project.mjs
+
+RUN npm install -g nango@${NANGO_VERSION} \
+    && npm cache clean --force
+
+USER user
+WORKDIR /home/user
+
+# --copy skips dependency installation and precompile work; the image provides
+# the CLI and workspace dependencies from the pinned global install.
+RUN nango init --copy nango-integrations
+RUN node /tmp/template-support/cleanup-nango-project.mjs /home/user/nango-integrations
+
+COPY --chown=user:user packages/sandbox/agentcore-runtime/server.mjs /home/user/agentcore-runtime/server.mjs
+
+WORKDIR /home/user/nango-integrations
+# Reuse the global CLI install instead of running a second npm install.
+RUN mkdir -p node_modules \
+    && ln -s /usr/local/lib/node_modules/nango node_modules/nango \
+    && ln -s /usr/local/lib/node_modules/nango/node_modules/zod node_modules/zod
+
+EXPOSE 8080
+
+CMD ["node", "/home/user/agentcore-runtime/server.mjs"]

--- a/packages/sandbox/agentcore-runtime/README.md
+++ b/packages/sandbox/agentcore-runtime/README.md
@@ -1,0 +1,16 @@
+# AgentCore sandbox runtime
+
+Temporary Amazon Bedrock AgentCore Runtime image for the sandbox provider PoC.
+
+Build from the repo root:
+
+```bash
+docker buildx build --platform linux/arm64 -f packages/sandbox/agentcore-runtime/Dockerfile -t nango-agentcore-sandbox:local .
+```
+
+The container exposes the AgentCore HTTP contract on port `8080`:
+
+- `POST /invocations` handles sandbox adapter operations used by `AgentCoreSandboxProvider`.
+- `GET /ping` returns `HealthyBusy` while async dryrun/deploy commands are running.
+
+This is intentionally colocated with `packages/sandbox` for iteration and should move next to the canonical sandbox image definitions before production use.

--- a/packages/sandbox/agentcore-runtime/cleanup-nango-project.mjs
+++ b/packages/sandbox/agentcore-runtime/cleanup-nango-project.mjs
@@ -1,0 +1,41 @@
+#!/usr/bin/env node
+
+// `nango init --copy` gives us the CLI-maintained project shape. This strips
+// the sample integration output so each runtime session starts with a clean
+// zero-yaml workspace for files written by the sandbox provider.
+
+import { promises as fs } from 'node:fs';
+import path from 'node:path';
+
+const projectDir = process.argv[2];
+
+if (!projectDir) {
+    console.error('Usage: cleanup-nango-project.mjs <project-dir>');
+    process.exit(1);
+}
+
+const filesToRemove = ['build', 'github', '.nango/nango.json', '.nango/schema.json', '.nango/schema.ts'];
+
+const indexContents = `// Register Nango functions with side-effect imports.
+// Example: import './github/actions/my-action.js';
+`;
+
+const envLinesToEnsure = ['NANGO_CLI_UPGRADE_MODE=ignore'];
+
+await Promise.all(
+    filesToRemove.map(async (relativePath) => {
+        await fs.rm(path.join(projectDir, relativePath), { force: true, recursive: true });
+    })
+);
+
+await fs.writeFile(path.join(projectDir, 'index.ts'), indexContents);
+
+const envPath = path.join(projectDir, '.env');
+const currentEnv = await fs.readFile(envPath, 'utf8');
+const nextEnv = envLinesToEnsure.reduce((contents, line) => {
+    return contents.includes(line) ? contents : `${contents.trimEnd()}\n${line}\n`;
+}, currentEnv);
+
+if (nextEnv !== currentEnv) {
+    await fs.writeFile(envPath, nextEnv);
+}

--- a/packages/sandbox/agentcore-runtime/server.mjs
+++ b/packages/sandbox/agentcore-runtime/server.mjs
@@ -1,0 +1,162 @@
+import { spawn } from 'node:child_process';
+import { promises as fs } from 'node:fs';
+import http from 'node:http';
+import path from 'node:path';
+
+const port = 8080;
+const host = '0.0.0.0';
+const workspacePath = '/home/user/nango-integrations';
+const heartbeatIntervalMs = 5_000;
+
+let activeCommand = null;
+let timeOfLastUpdate = unixNow();
+
+setInterval(() => {
+    if (activeCommand) {
+        touch();
+    }
+}, heartbeatIntervalMs).unref();
+
+const server = http.createServer(async (req, res) => {
+    try {
+        // AgentCore calls /ping to monitor runtime health. While a background
+        // command runs, keep time_of_last_update fresh and report HealthyBusy.
+        if (req.method === 'GET' && req.url === '/ping') {
+            sendJson(res, 200, {
+                status: activeCommand ? 'HealthyBusy' : 'Healthy',
+                time_of_last_update: timeOfLastUpdate
+            });
+            return;
+        }
+
+        // AgentCore invokes HTTP runtimes through /invocations. We use this
+        // adapter for operations that do not fit the direct command API well:
+        // init, file writes/reads, and starting background commands.
+        if (req.method === 'POST' && req.url === '/invocations') {
+            const payload = JSON.parse(await readRequestBody(req));
+            const data = await handleInvocation(payload);
+            sendJson(res, 200, { ok: true, data });
+            return;
+        }
+
+        sendJson(res, 404, { ok: false, error: { message: 'Not found' } });
+    } catch (err) {
+        const statusCode = req.method === 'POST' && req.url === '/invocations' ? 200 : 500;
+        sendJson(res, statusCode, { ok: false, error: serializeError(err) });
+    }
+});
+
+server.listen(port, host, () => {
+    console.log(`AgentCore sandbox adapter listening on ${host}:${port}`);
+});
+
+async function handleInvocation(payload) {
+    switch (payload?.operation) {
+        case 'init':
+            return { workspacePath };
+        case 'writeFiles':
+            await writeFiles(payload.files);
+            return undefined;
+        case 'readTextFile':
+            return await fs.readFile(resolvePath(payload.path), 'utf8');
+        case 'startCommand':
+            startCommand(payload);
+            return undefined;
+        default:
+            throw new Error(`Unsupported operation: ${String(payload?.operation)}`);
+    }
+}
+
+async function writeFiles(files) {
+    if (!Array.isArray(files)) {
+        throw new Error('writeFiles requires files');
+    }
+
+    for (const file of files) {
+        const filePath = resolvePath(file.path);
+        await fs.mkdir(path.dirname(filePath), { recursive: true });
+        await fs.writeFile(filePath, file.contents ?? '', 'utf8');
+    }
+}
+
+function startCommand(payload) {
+    if (!payload.command || typeof payload.command !== 'string') {
+        throw new Error('startCommand requires command');
+    }
+
+    if (activeCommand) {
+        throw new Error('A command is already running in this runtime session');
+    }
+
+    const child = spawn('sh', ['-lc', payload.command], {
+        cwd: workspacePath,
+        detached: true,
+        env: { ...process.env, ...(payload.envs ?? {}) },
+        stdio: 'ignore'
+    });
+    activeCommand = child;
+    touch();
+
+    const timeout = Number(payload.timeoutMs);
+    const timeoutHandle =
+        Number.isFinite(timeout) && timeout > 0
+            ? setTimeout(() => {
+                  child.kill('SIGTERM');
+              }, timeout).unref()
+            : undefined;
+
+    const finish = () => {
+        if (timeoutHandle) {
+            clearTimeout(timeoutHandle);
+        }
+        if (activeCommand === child) {
+            activeCommand = null;
+        }
+        touch();
+    };
+
+    child.once('exit', finish);
+    child.once('error', finish);
+
+    // Let the command continue as a detached background job after this HTTP
+    // request returns; the server process itself remains alive for callbacks.
+    child.unref();
+}
+
+function resolvePath(value) {
+    if (!value || value === '.') {
+        return workspacePath;
+    }
+
+    return path.isAbsolute(value) ? value : path.join(workspacePath, value);
+}
+
+function readRequestBody(req) {
+    return new Promise((resolve, reject) => {
+        const chunks = [];
+        req.on('data', (chunk) => chunks.push(chunk));
+        req.on('end', () => resolve(Buffer.concat(chunks).toString('utf8')));
+        req.on('error', reject);
+    });
+}
+
+function sendJson(res, statusCode, payload) {
+    res.writeHead(statusCode, { 'content-type': 'application/json' });
+    res.end(JSON.stringify(payload));
+}
+
+function serializeError(err) {
+    if (err instanceof Error) {
+        return { name: err.name, message: err.message };
+    }
+
+    return { message: String(err) };
+}
+
+function touch() {
+    timeOfLastUpdate = unixNow();
+}
+
+function unixNow() {
+    return Math.floor(Date.now() / 1000);
+}

--- a/packages/sandbox/lib/providers/agentcore.ts
+++ b/packages/sandbox/lib/providers/agentcore.ts
@@ -1,15 +1,328 @@
-import { SandboxNotImplementedError } from './errors.js';
+import { randomUUID } from 'node:crypto';
 
-import type { CreateSandboxParams, Sandbox, SandboxProvider } from './types.js';
+import {
+    BedrockAgentCoreClient,
+    InvokeAgentRuntimeCommand,
+    InvokeAgentRuntimeCommandCommand,
+    StopRuntimeSessionCommand
+} from '@aws-sdk/client-bedrock-agentcore';
+
+import { stringifyError } from '@nangohq/utils';
+
+import { SandboxCommandExitError, SandboxCommandTimeoutError, SandboxUnavailableError } from './errors.js';
+import { envs } from '../env.js';
+
+import type { CreateSandboxParams, Sandbox, SandboxCommandParams, SandboxCommandResult, SandboxFile, SandboxProvider } from './types.js';
+import type { InvokeAgentRuntimeCommandStreamOutput } from '@aws-sdk/client-bedrock-agentcore';
+
+type AgentCoreAdapterRequest =
+    | { operation: 'init' }
+    | { operation: 'writeFiles'; files: SandboxFile[] }
+    | { operation: 'readTextFile'; path: string }
+    | { operation: 'startCommand'; command: string; timeoutMs: number; envs?: Record<string, string> | undefined };
+
+type AgentCoreAdapterResponse<T> =
+    | { ok: true; data: T }
+    | { ok: false; error: { message?: string; name?: string; stdout?: string; stderr?: string; exitCode?: number } };
+
+const workspacePath = '/home/user/nango-integrations';
+const jsonContentType = 'application/json';
+const eventStreamAccept = 'application/vnd.amazon.eventstream';
+const maxAgentCoreCommandTimeoutSeconds = 3600;
+const envNameRegex = /^[A-Za-z_][A-Za-z0-9_]*$/;
 
 export class AgentCoreSandboxProvider implements SandboxProvider {
     public readonly name = 'agentcore';
+    private readonly client: BedrockAgentCoreClient;
 
-    create(_params: CreateSandboxParams): Promise<Sandbox> {
-        throw new SandboxNotImplementedError('Amazon Bedrock AgentCore sandbox provider is not implemented yet');
+    constructor(client: BedrockAgentCoreClient = new BedrockAgentCoreClient(envs.AGENTCORE_REGION ? { region: envs.AGENTCORE_REGION } : {})) {
+        this.client = client;
     }
 
-    cleanup(_sandboxId: string): Promise<void> {
-        throw new SandboxNotImplementedError('Amazon Bedrock AgentCore sandbox provider is not implemented yet');
+    async create(params: CreateSandboxParams): Promise<Sandbox> {
+        const sandbox = new AgentCoreSandbox({
+            id: createRuntimeSessionId(params.purpose),
+            client: this.client,
+            runtimeArn: getRuntimeArn(),
+            qualifier: envs.AGENTCORE_RUNTIME_QUALIFIER
+        });
+
+        try {
+            await sandbox.invokeAdapter('init', { operation: 'init' });
+        } catch (err) {
+            if (isExecutionEnvironmentUnavailableError(err)) {
+                throw new SandboxUnavailableError('Function execution environment unavailable', { cause: err });
+            }
+            throw err;
+        }
+
+        return sandbox;
     }
+
+    async cleanup(sandboxId: string): Promise<void> {
+        await this.client.send(
+            new StopRuntimeSessionCommand({
+                agentRuntimeArn: getRuntimeArn(),
+                qualifier: envs.AGENTCORE_RUNTIME_QUALIFIER,
+                runtimeSessionId: sandboxId,
+                clientToken: createClientToken('nango-stop')
+            })
+        );
+    }
+}
+
+class AgentCoreSandbox implements Sandbox {
+    public readonly provider = 'agentcore';
+    public readonly id: string;
+    private readonly client: BedrockAgentCoreClient;
+    private readonly runtimeArn: string;
+    private readonly qualifier: string;
+
+    constructor(params: { id: string; client: BedrockAgentCoreClient; runtimeArn: string; qualifier: string }) {
+        this.id = params.id;
+        this.client = params.client;
+        this.runtimeArn = params.runtimeArn;
+        this.qualifier = params.qualifier;
+    }
+
+    async writeFiles(files: SandboxFile[]): Promise<void> {
+        await this.invokeAdapter<void>('writeFiles', { operation: 'writeFiles', files });
+    }
+
+    async readTextFile(path: string): Promise<string> {
+        return await this.invokeAdapter<string>('readTextFile', { operation: 'readTextFile', path });
+    }
+
+    async runCommand(params: SandboxCommandParams): Promise<SandboxCommandResult> {
+        const result = await this.client.send(
+            new InvokeAgentRuntimeCommandCommand({
+                agentRuntimeArn: this.runtimeArn,
+                qualifier: this.qualifier,
+                runtimeSessionId: this.id,
+                contentType: jsonContentType,
+                accept: eventStreamAccept,
+                body: {
+                    command: buildCommand(params),
+                    timeout: toAgentCoreTimeoutSeconds(params.timeoutMs)
+                }
+            })
+        );
+
+        return await toSandboxCommandResult(result.stream);
+    }
+
+    async startCommand(params: SandboxCommandParams): Promise<void> {
+        await this.invokeAdapter<void>('startCommand', {
+            operation: 'startCommand',
+            command: params.command,
+            timeoutMs: params.timeoutMs,
+            ...(params.envs !== undefined ? { envs: params.envs } : {})
+        });
+    }
+
+    async stop(): Promise<void> {
+        await this.client.send(
+            new StopRuntimeSessionCommand({
+                agentRuntimeArn: this.runtimeArn,
+                qualifier: this.qualifier,
+                runtimeSessionId: this.id,
+                clientToken: createClientToken('nango-stop')
+            })
+        );
+    }
+
+    async invokeAdapter<T>(operation: AgentCoreAdapterRequest['operation'], request: AgentCoreAdapterRequest): Promise<T> {
+        const response = await this.client.send(
+            new InvokeAgentRuntimeCommand({
+                agentRuntimeArn: this.runtimeArn,
+                qualifier: this.qualifier,
+                runtimeSessionId: this.id,
+                contentType: jsonContentType,
+                accept: jsonContentType,
+                payload: Buffer.from(JSON.stringify(request))
+            })
+        );
+
+        const text = await readSdkStream(response.response);
+        const parsed = parseAdapterResponse<T>(operation, text);
+        if (!parsed.ok) {
+            throw toAdapterError(operation, parsed.error);
+        }
+
+        return parsed.data;
+    }
+}
+
+function getRuntimeArn(): string {
+    if (!envs.AGENTCORE_RUNTIME_ARN) {
+        throw new Error('AGENTCORE_RUNTIME_ARN is required for the AgentCore sandbox provider');
+    }
+
+    return envs.AGENTCORE_RUNTIME_ARN;
+}
+
+function createRuntimeSessionId(purpose: CreateSandboxParams['purpose']): string {
+    return `nango-${purpose}-${randomUUID()}`;
+}
+
+function createClientToken(prefix: string): string {
+    return `${prefix}-${randomUUID()}`;
+}
+
+function buildCommand(params: SandboxCommandParams): string {
+    const cd = `cd ${shellQuote(workspacePath)}`;
+    const exports = Object.entries(params.envs ?? {})
+        .map(([key, value]) => buildExport(key, value))
+        .join('; ');
+    const script = [exports, `${cd} && ${params.command}`].filter(Boolean).join('; ');
+    return `sh -lc ${shellQuote(script)}`;
+}
+
+function shellQuote(value: string): string {
+    return `'${value.replaceAll("'", "'\"'\"'")}'`;
+}
+
+function buildExport(key: string, value: string): string {
+    if (!envNameRegex.test(key)) {
+        throw new Error(`Invalid AgentCore environment variable name: ${key}`);
+    }
+
+    return `export ${key}=${shellQuote(value)}`;
+}
+
+function toAgentCoreTimeoutSeconds(timeoutMs: number): number {
+    if (timeoutMs <= 0) {
+        return maxAgentCoreCommandTimeoutSeconds;
+    }
+
+    return Math.min(Math.max(Math.ceil(timeoutMs / 1000), 1), maxAgentCoreCommandTimeoutSeconds);
+}
+
+async function toSandboxCommandResult(stream: AsyncIterable<InvokeAgentRuntimeCommandStreamOutput> | undefined): Promise<SandboxCommandResult> {
+    if (!stream) {
+        throw new Error('AgentCore command response did not include an event stream');
+    }
+
+    let stdout = '';
+    let stderr = '';
+    let exitCode: number | undefined;
+    let status: string | undefined;
+
+    for await (const event of stream) {
+        if (event.chunk?.contentDelta?.stdout) {
+            stdout += event.chunk.contentDelta.stdout;
+        }
+        if (event.chunk?.contentDelta?.stderr) {
+            stderr += event.chunk.contentDelta.stderr;
+        }
+        if (event.chunk?.contentStop) {
+            exitCode = event.chunk.contentStop.exitCode;
+            status = event.chunk.contentStop.status;
+        }
+
+        const eventError = getAgentCoreStreamError(event);
+        if (eventError) {
+            throw eventError;
+        }
+    }
+
+    if (status === 'TIMED_OUT') {
+        throw new SandboxCommandTimeoutError('AgentCore sandbox command timed out');
+    }
+
+    if (exitCode === undefined) {
+        throw new Error('AgentCore command response did not include a completion event');
+    }
+
+    if (exitCode !== 0) {
+        throw new SandboxCommandExitError(stderr || stdout || 'AgentCore sandbox command failed', { stdout, stderr, exitCode });
+    }
+
+    return { stdout, stderr };
+}
+
+function getAgentCoreStreamError(event: InvokeAgentRuntimeCommandStreamOutput): Error | null {
+    const error =
+        event.accessDeniedException ??
+        event.internalServerException ??
+        event.resourceNotFoundException ??
+        event.runtimeClientError ??
+        event.serviceQuotaExceededException ??
+        event.throttlingException ??
+        event.validationException;
+
+    if (!error) {
+        return null;
+    }
+
+    const message = 'message' in error && typeof error.message === 'string' ? error.message : 'AgentCore command stream failed';
+    return new Error(message);
+}
+
+async function readSdkStream(stream: unknown): Promise<string> {
+    if (!stream) {
+        return '';
+    }
+
+    const sdkStream = stream as { transformToString?: () => Promise<string>; transformToByteArray?: () => Promise<Uint8Array> };
+    if (typeof sdkStream.transformToString === 'function') {
+        return await sdkStream.transformToString();
+    }
+    if (typeof sdkStream.transformToByteArray === 'function') {
+        return Buffer.from(await sdkStream.transformToByteArray()).toString('utf8');
+    }
+    if (stream instanceof Uint8Array) {
+        return Buffer.from(stream).toString('utf8');
+    }
+    if (typeof stream === 'string') {
+        return stream;
+    }
+
+    throw new Error('Unsupported AgentCore response stream');
+}
+
+function parseAdapterResponse<T>(operation: string, text: string): AgentCoreAdapterResponse<T> {
+    try {
+        return JSON.parse(text) as AgentCoreAdapterResponse<T>;
+    } catch (err) {
+        throw new Error(`AgentCore adapter returned invalid JSON for ${operation}: ${text}`, { cause: err });
+    }
+}
+
+function toAdapterError(operation: string, error: { message?: string; name?: string; stdout?: string; stderr?: string; exitCode?: number }): Error {
+    const message = error.message || `AgentCore adapter ${operation} failed`;
+    if (error.name === 'SandboxCommandTimeoutError') {
+        return new SandboxCommandTimeoutError(message);
+    }
+    if (error.name === 'SandboxCommandExitError') {
+        return new SandboxCommandExitError(message, {
+            stdout: error.stdout,
+            stderr: error.stderr,
+            exitCode: error.exitCode
+        });
+    }
+    const err = new Error(message);
+    err.name = error.name || 'AgentCoreAdapterError';
+    return err;
+}
+
+function isExecutionEnvironmentUnavailableError(error: unknown): boolean {
+    if (!error || typeof error !== 'object') {
+        return false;
+    }
+
+    const err = error as { name?: unknown; $metadata?: { httpStatusCode?: number } };
+    const name = typeof err.name === 'string' ? err.name : '';
+    const status = err.$metadata?.httpStatusCode;
+    const message = stringifyError(error).toLowerCase();
+
+    return (
+        name === 'ThrottlingException' ||
+        name === 'ServiceQuotaExceededException' ||
+        status === 402 ||
+        status === 429 ||
+        message.includes('throttl') ||
+        message.includes('rate limit') ||
+        message.includes('quota')
+    );
 }

--- a/packages/sandbox/lib/providers/agentcore.unit.test.ts
+++ b/packages/sandbox/lib/providers/agentcore.unit.test.ts
@@ -1,0 +1,213 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+const mocks = vi.hoisted(() => {
+    const send = vi.fn();
+    const envs = {
+        AGENTCORE_RUNTIME_ARN: 'arn:aws:bedrock-agentcore:us-west-2:123456789012:runtime/nango-sandbox',
+        AGENTCORE_RUNTIME_QUALIFIER: 'DEFAULT',
+        AGENTCORE_REGION: 'us-west-2'
+    };
+
+    class BedrockAgentCoreClient {
+        public readonly config: unknown;
+
+        constructor(config: unknown) {
+            this.config = config;
+        }
+
+        send(command: unknown): Promise<unknown> {
+            return send(command);
+        }
+    }
+
+    class InvokeAgentRuntimeCommand {
+        public readonly input: unknown;
+
+        constructor(input: unknown) {
+            this.input = input;
+        }
+    }
+
+    class InvokeAgentRuntimeCommandCommand {
+        public readonly input: unknown;
+
+        constructor(input: unknown) {
+            this.input = input;
+        }
+    }
+
+    class StopRuntimeSessionCommand {
+        public readonly input: unknown;
+
+        constructor(input: unknown) {
+            this.input = input;
+        }
+    }
+
+    return { BedrockAgentCoreClient, envs, InvokeAgentRuntimeCommand, InvokeAgentRuntimeCommandCommand, send, StopRuntimeSessionCommand };
+});
+
+vi.mock('@aws-sdk/client-bedrock-agentcore', () => ({
+    BedrockAgentCoreClient: mocks.BedrockAgentCoreClient,
+    InvokeAgentRuntimeCommand: mocks.InvokeAgentRuntimeCommand,
+    InvokeAgentRuntimeCommandCommand: mocks.InvokeAgentRuntimeCommandCommand,
+    StopRuntimeSessionCommand: mocks.StopRuntimeSessionCommand
+}));
+
+vi.mock('../env.js', () => ({ envs: mocks.envs }));
+
+import { AgentCoreSandboxProvider } from './agentcore.js';
+
+function adapterResponse(data?: unknown): { response: { transformToString: () => Promise<string> } } {
+    return {
+        response: {
+            transformToString: () => Promise.resolve(JSON.stringify({ ok: true, data }))
+        }
+    };
+}
+
+async function* commandStream(events: unknown[]): AsyncGenerator {
+    await Promise.resolve();
+    for (const event of events) {
+        yield event;
+    }
+}
+
+describe('AgentCoreSandboxProvider', () => {
+    beforeEach(() => {
+        vi.clearAllMocks();
+        mocks.envs.AGENTCORE_RUNTIME_ARN = 'arn:aws:bedrock-agentcore:us-west-2:123456789012:runtime/nango-sandbox';
+        mocks.envs.AGENTCORE_RUNTIME_QUALIFIER = 'DEFAULT';
+        mocks.envs.AGENTCORE_REGION = 'us-west-2';
+        mocks.send.mockResolvedValue(adapterResponse());
+    });
+
+    it('creates a runtime session by invoking the adapter init operation', async () => {
+        const sandbox = await new AgentCoreSandboxProvider().create({ purpose: 'dryrun', timeoutMs: 30_000 });
+
+        expect(sandbox.id).toMatch(/^nango-dryrun-/);
+        expect(sandbox.provider).toBe('agentcore');
+        expect(mocks.send).toHaveBeenCalledWith(expect.any(mocks.InvokeAgentRuntimeCommand));
+        expect((mocks.send.mock.calls[0]![0] as { input: Record<string, unknown> }).input).toMatchObject({
+            agentRuntimeArn: mocks.envs.AGENTCORE_RUNTIME_ARN,
+            qualifier: 'DEFAULT',
+            runtimeSessionId: sandbox.id,
+            contentType: 'application/json',
+            accept: 'application/json'
+        });
+        expect(JSON.parse(Buffer.from((mocks.send.mock.calls[0]![0] as { input: { payload: Buffer } }).input.payload).toString('utf8'))).toEqual({
+            operation: 'init'
+        });
+    });
+
+    it('writes and reads files through the runtime adapter', async () => {
+        mocks.send.mockResolvedValueOnce(adapterResponse()).mockResolvedValueOnce(adapterResponse()).mockResolvedValueOnce(adapterResponse('compiled'));
+
+        const sandbox = await new AgentCoreSandboxProvider().create({ purpose: 'compile', timeoutMs: 30_000 });
+        await sandbox.writeFiles([{ path: 'index.ts', contents: 'export default true;' }]);
+        await expect(sandbox.readTextFile('build/index.cjs')).resolves.toBe('compiled');
+
+        expect(JSON.parse(Buffer.from((mocks.send.mock.calls[1]![0] as { input: { payload: Buffer } }).input.payload).toString('utf8'))).toEqual({
+            operation: 'writeFiles',
+            files: [{ path: 'index.ts', contents: 'export default true;' }]
+        });
+        expect(JSON.parse(Buffer.from((mocks.send.mock.calls[2]![0] as { input: { payload: Buffer } }).input.payload).toString('utf8'))).toEqual({
+            operation: 'readTextFile',
+            path: 'build/index.cjs'
+        });
+    });
+
+    it('starts async commands through the runtime adapter', async () => {
+        mocks.send.mockResolvedValueOnce(adapterResponse()).mockResolvedValueOnce(adapterResponse());
+
+        const sandbox = await new AgentCoreSandboxProvider().create({ purpose: 'deploy', timeoutMs: 30_000 });
+        await sandbox.startCommand({ command: 'node /tmp/deploy.mjs', timeoutMs: 0, envs: { NO_COLOR: '1' } });
+
+        expect(JSON.parse(Buffer.from((mocks.send.mock.calls[1]![0] as { input: { payload: Buffer } }).input.payload).toString('utf8'))).toEqual({
+            operation: 'startCommand',
+            command: 'node /tmp/deploy.mjs',
+            timeoutMs: 0,
+            envs: { NO_COLOR: '1' }
+        });
+    });
+
+    it('runs synchronous commands with AgentCore command streaming', async () => {
+        mocks.send.mockResolvedValueOnce(adapterResponse()).mockResolvedValueOnce({
+            stream: commandStream([
+                { chunk: { contentDelta: { stdout: 'hello ' } } },
+                { chunk: { contentDelta: { stderr: 'warn' } } },
+                { chunk: { contentDelta: { stdout: 'world' } } },
+                { chunk: { contentStop: { exitCode: 0, status: 'COMPLETED' } } }
+            ])
+        });
+
+        const sandbox = await new AgentCoreSandboxProvider().create({ purpose: 'compile', timeoutMs: 30_000 });
+        const result = await sandbox.runCommand({ command: 'nango compile', timeoutMs: 12_300, envs: { NO_COLOR: '1' } });
+
+        expect(result).toEqual({ stdout: 'hello world', stderr: 'warn' });
+        expect(mocks.send).toHaveBeenLastCalledWith(expect.any(mocks.InvokeAgentRuntimeCommandCommand));
+        expect((mocks.send.mock.calls[1]![0] as { input: Record<string, unknown> }).input).toMatchObject({
+            agentRuntimeArn: mocks.envs.AGENTCORE_RUNTIME_ARN,
+            qualifier: 'DEFAULT',
+            runtimeSessionId: sandbox.id,
+            contentType: 'application/json',
+            accept: 'application/vnd.amazon.eventstream',
+            body: {
+                command: "sh -lc 'export NO_COLOR='\"'\"'1'\"'\"'; cd '\"'\"'/home/user/nango-integrations'\"'\"' && nango compile'",
+                timeout: 13
+            }
+        });
+    });
+
+    it('maps non-zero command exits to SandboxCommandExitError', async () => {
+        mocks.send.mockResolvedValueOnce(adapterResponse()).mockResolvedValueOnce({
+            stream: commandStream([
+                { chunk: { contentDelta: { stdout: 'compile stdout' } } },
+                { chunk: { contentDelta: { stderr: 'compile stderr' } } },
+                { chunk: { contentStop: { exitCode: 2, status: 'COMPLETED' } } }
+            ])
+        });
+
+        const sandbox = await new AgentCoreSandboxProvider().create({ purpose: 'compile', timeoutMs: 30_000 });
+
+        await expect(sandbox.runCommand({ command: 'nango compile', timeoutMs: 10_000 })).rejects.toMatchObject({
+            name: 'SandboxCommandExitError',
+            stdout: 'compile stdout',
+            stderr: 'compile stderr',
+            exitCode: 2
+        });
+    });
+
+    it('maps timed out command streams to SandboxCommandTimeoutError', async () => {
+        mocks.send.mockResolvedValueOnce(adapterResponse()).mockResolvedValueOnce({
+            stream: commandStream([{ chunk: { contentStop: { exitCode: -1, status: 'TIMED_OUT' } } }])
+        });
+
+        const sandbox = await new AgentCoreSandboxProvider().create({ purpose: 'compile', timeoutMs: 30_000 });
+
+        await expect(sandbox.runCommand({ command: 'nango compile', timeoutMs: 10_000 })).rejects.toMatchObject({
+            name: 'SandboxCommandTimeoutError'
+        });
+    });
+
+    it('stops runtime sessions for cleanup', async () => {
+        await new AgentCoreSandboxProvider().cleanup('nango-dryrun-00000000-0000-4000-8000-000000000000');
+
+        expect(mocks.send).toHaveBeenCalledWith(expect.any(mocks.StopRuntimeSessionCommand));
+        expect((mocks.send.mock.calls[0]![0] as { input: Record<string, unknown> }).input).toMatchObject({
+            agentRuntimeArn: mocks.envs.AGENTCORE_RUNTIME_ARN,
+            qualifier: 'DEFAULT',
+            runtimeSessionId: 'nango-dryrun-00000000-0000-4000-8000-000000000000'
+        });
+    });
+
+    it('normalizes AgentCore capacity errors to SandboxUnavailableError during create', async () => {
+        const error = Object.assign(new Error('Rate limit exceeded'), { name: 'ThrottlingException', $metadata: { httpStatusCode: 429 } });
+        mocks.send.mockRejectedValueOnce(error);
+
+        await expect(new AgentCoreSandboxProvider().create({ purpose: 'dryrun', timeoutMs: 30_000 })).rejects.toMatchObject({
+            name: 'SandboxUnavailableError',
+            cause: error
+        });
+    });
+});

--- a/packages/sandbox/package.json
+++ b/packages/sandbox/package.json
@@ -13,6 +13,7 @@
         "directory": "packages/sandbox"
     },
     "dependencies": {
+        "@aws-sdk/client-bedrock-agentcore": "3.1066.0",
         "@nangohq/database": "file:../database",
         "@nangohq/shared": "file:../shared",
         "@nangohq/utils": "file:../utils",

--- a/packages/utils/lib/environment/parse.ts
+++ b/packages/utils/lib/environment/parse.ts
@@ -633,6 +633,9 @@ export const ENVS = z.object({
 
     // Sandboxes
     SANDBOX_PROVIDER: z.enum(['e2b', 'docker', 'agentcore']).optional(),
+    AGENTCORE_RUNTIME_ARN: z.string().min(1).optional(),
+    AGENTCORE_RUNTIME_QUALIFIER: z.string().min(1).default('DEFAULT'),
+    AGENTCORE_REGION: z.string().min(1).optional(),
     E2B_API_KEY: z.string().optional(),
     E2B_SANDBOX_COMPILER_TEMPLATE: z.string().min(1).default('blank-workspace:staging'),
     E2B_SANDBOX_METRICS_POLL_INTERVAL_MS: z.coerce.number().int().nonnegative().default(60_000),

--- a/packages/utils/lib/environment/parse.unit.test.ts
+++ b/packages/utils/lib/environment/parse.unit.test.ts
@@ -38,6 +38,17 @@ describe('parse', () => {
         expect(res.SANDBOX_PROVIDER).toBe('agentcore');
     });
 
+    it('should parse AgentCore sandbox settings', () => {
+        const res = parseEnvs(ENVS, {
+            AGENTCORE_RUNTIME_ARN: 'arn:aws:bedrock-agentcore:us-west-2:123456789012:runtime/nango-runtime',
+            AGENTCORE_RUNTIME_QUALIFIER: 'dev',
+            AGENTCORE_REGION: 'us-west-2'
+        });
+        expect(res.AGENTCORE_RUNTIME_ARN).toBe('arn:aws:bedrock-agentcore:us-west-2:123456789012:runtime/nango-runtime');
+        expect(res.AGENTCORE_RUNTIME_QUALIFIER).toBe('dev');
+        expect(res.AGENTCORE_REGION).toBe('us-west-2');
+    });
+
     it('should coerce boolean and number', () => {
         const res = parseEnvs(ENVS, { NANGO_DB_SSL: 'true', NANGO_LOGS_ENABLED: 'false', NANGO_PERSIST_PORT: '3008' });
         expect(res).toMatchObject({ NANGO_DB_SSL: true, NANGO_PERSIST_PORT: 3008, NANGO_LOGS_ENABLED: false, NANGO_CLOUD: false, NANGO_CACHE_ENV_KEYS: false });


### PR DESCRIPTION
Adds a Bedrock AgentCore implementation for the sandbox provider interface used by compile, dryrun, and deploy flows. The provider invokes AgentCore sessions for file operations, synchronous command streaming, background command starts, and session cleanup, with new AgentCore environment settings. This also adds a temporary AgentCore runtime image under packages/sandbox/agentcore-runtime so the runtime can satisfy AgentCore HTTP health and invocation contracts while running the pinned Nango CLI.

NAN-5867

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/NangoHQ/nango/pull/6501?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

