### PR TITLE
feat: prevent overriding design-system component styles

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -24,3 +24,13 @@ REMOTE_API=dev npm run dev -w packages/webapp       # https://api-development.na
 REMOTE_API=staging npm run dev -w packages/webapp   # https://api-staging.nango.dev
 REMOTE_API=prod npm run dev -w packages/webapp      # https://api.nango.dev
 ```
+
+## Design system
+
+`@nangohq/design-system` components (`Button`, `IconButton`, …) own their styling. In any consuming package (webapp, connect-ui, …), **don't override it with `className` or `style`** — a lint rule (`react/forbid-component-props`) flags these props where the design system is used. Instead:
+
+- Use the component's `variant`/`size` and other props.
+- Put layout (margin, positioning, width) on a **wrapper element**, not the component.
+- Need a look no prop covers? Add a variant to the design system — see `packages/design-system/AGENTS.md`.
+
+Full guidance: [Styling & Customization](http://storybook.nango.dev/?path=/docs/design-system-guide-styling-customization--docs) in Storybook.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -27,10 +27,10 @@ REMOTE_API=prod npm run dev -w packages/webapp      # https://api.nango.dev
 
 ## Design system
 
-`@nangohq/design-system` components (`Button`, `IconButton`, …) own their styling. In any consuming package (webapp, connect-ui, …), **don't override it with `className` or `style`** — a lint rule (`react/forbid-component-props`) flags these props where the design system is used. Instead:
+`@nangohq/design-system` components (`Button`, `IconButton`, …) own their styling. In any package that consumes the design system (webapp, …), **don't override it with `className` or `style`** — a lint rule (`react/forbid-component-props`) flags these props where the design system is used. Instead:
 
 - Use the component's `variant`/`size` and other props.
 - Put layout (margin, positioning, width) on a **wrapper element**, not the component.
 - Need a look no prop covers? Add a variant to the design system — see `packages/design-system/AGENTS.md`.
 
-Full guidance: [Styling & Customization](http://storybook.nango.dev/?path=/docs/design-system-guide-styling-customization--docs) in Storybook.
+Full guidance: `packages/design-system/stories/StylingAndCustomization.mdx`

--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -88,6 +88,30 @@ const tseslintRules = {
     '@typescript-eslint/no-deprecated': 'off' // takes 33% of the whole linting time
 };
 
+// Shared rules for packages that consume @nangohq/design-system — spread into each consuming
+// package's block. Matches design-system components by name.
+const designSystemConsumerRules = {
+    'react/forbid-component-props': [
+        'warn',
+        {
+            forbid: [
+                {
+                    propName: 'className',
+                    disallowedFor: ['Button', 'IconButton'],
+                    message:
+                        "Don't override design-system styles via className — use variant/size props or wrap for layout. Guide: http://storybook.nango.dev/?path=/docs/design-system-guide-styling-customization--docs"
+                },
+                {
+                    propName: 'style',
+                    disallowedFor: ['Button', 'IconButton'],
+                    message:
+                        "Don't override design-system styles via the style prop — use variant/size props or wrap for layout. Guide: http://storybook.nango.dev/?path=/docs/design-system-guide-styling-customization--docs"
+                }
+            ]
+        }
+    ]
+};
+
 export default tseslint.config(
     {
         ignores: [
@@ -336,6 +360,9 @@ export default tseslint.config(
                 }
             ],
 
+            // Don't override design-system component styles — see designSystemConsumerRules above.
+            ...designSystemConsumerRules,
+
             'import/extensions': 'off'
         }
     },
@@ -380,6 +407,8 @@ export default tseslint.config(
             ...react.configs.flat.recommended.rules,
             ...react.configs.flat['jsx-runtime'].rules,
             ...reactHooks.configs.recommended.rules,
+
+            ...designSystemConsumerRules,
 
             'import/extensions': 'off',
             '@typescript-eslint/member-ordering': 'error',

--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -88,30 +88,6 @@ const tseslintRules = {
     '@typescript-eslint/no-deprecated': 'off' // takes 33% of the whole linting time
 };
 
-// Shared rules for packages that consume @nangohq/design-system — spread into each consuming
-// package's block. Matches design-system components by name.
-const designSystemConsumerRules = {
-    'react/forbid-component-props': [
-        'warn',
-        {
-            forbid: [
-                {
-                    propName: 'className',
-                    disallowedFor: ['Button', 'IconButton'],
-                    message:
-                        "Don't override design-system styles via className — use variant/size props or wrap for layout. Guide: http://storybook.nango.dev/?path=/docs/design-system-guide-styling-customization--docs"
-                },
-                {
-                    propName: 'style',
-                    disallowedFor: ['Button', 'IconButton'],
-                    message:
-                        "Don't override design-system styles via the style prop — use variant/size props or wrap for layout. Guide: http://storybook.nango.dev/?path=/docs/design-system-guide-styling-customization--docs"
-                }
-            ]
-        }
-    ]
-};
-
 export default tseslint.config(
     {
         ignores: [
@@ -360,8 +336,26 @@ export default tseslint.config(
                 }
             ],
 
-            // Don't override design-system component styles — see designSystemConsumerRules above.
-            ...designSystemConsumerRules,
+            // Design-system components own their styling — don't override it with className/style.
+            'react/forbid-component-props': [
+                'warn',
+                {
+                    forbid: [
+                        {
+                            propName: 'className',
+                            disallowedFor: ['Button', 'IconButton'],
+                            message:
+                                "Don't override design-system styles via className — use variant/size props or wrap for layout. Guide: http://storybook.nango.dev/?path=/docs/design-system-guide-styling-customization--docs"
+                        },
+                        {
+                            propName: 'style',
+                            disallowedFor: ['Button', 'IconButton'],
+                            message:
+                                "Don't override design-system styles via the style prop — use variant/size props or wrap for layout. Guide: http://storybook.nango.dev/?path=/docs/design-system-guide-styling-customization--docs"
+                        }
+                    ]
+                }
+            ],
 
             'import/extensions': 'off'
         }
@@ -407,8 +401,6 @@ export default tseslint.config(
             ...react.configs.flat.recommended.rules,
             ...react.configs.flat['jsx-runtime'].rules,
             ...reactHooks.configs.recommended.rules,
-
-            ...designSystemConsumerRules,
 
             'import/extensions': 'off',
             '@typescript-eslint/member-ordering': 'error',

--- a/package-lock.json
+++ b/package-lock.json
@@ -5498,6 +5498,24 @@
                 "react": ">=16.8.0"
             }
         },
+        "node_modules/@mdx-js/react": {
+            "version": "3.1.1",
+            "resolved": "https://registry.npmjs.org/@mdx-js/react/-/react-3.1.1.tgz",
+            "integrity": "sha512-f++rKLQgUVYDAtECQ6fn/is15GkEH9+nZPM3MS0RcxVqoTfawHvDlSCH7JbMhAM6uJ32v3eXLvLmLvjGu7PTQw==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "@types/mdx": "^2.0.0"
+            },
+            "funding": {
+                "type": "opencollective",
+                "url": "https://opencollective.com/unified"
+            },
+            "peerDependencies": {
+                "@types/react": ">=16",
+                "react": ">=16"
+            }
+        },
         "node_modules/@modelcontextprotocol/sdk": {
             "version": "1.26.0",
             "resolved": "https://registry.npmjs.org/@modelcontextprotocol/sdk/-/sdk-1.26.0.tgz",
@@ -15726,6 +15744,35 @@
             "resolved": "https://registry.npmjs.org/@stomp/stompjs/-/stompjs-7.1.1.tgz",
             "integrity": "sha512-chcDs6YkAnKp1FqzwhGvh3i7v0+/ytzqWdKYw6XzINEKAzke/iD00dNgFPWSZEqktHOK+C1gSzXhLkLbARIaZw=="
         },
+        "node_modules/@storybook/addon-docs": {
+            "version": "10.4.6",
+            "resolved": "https://registry.npmjs.org/@storybook/addon-docs/-/addon-docs-10.4.6.tgz",
+            "integrity": "sha512-aWAfP5JMiT5a3zBJizwroCRzOCqZwDTJmvsYvwMD3ilIEa/kT1vhf6Xrbk4XIPhDwbh8Hpb/Gfnka1xBYEISWg==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "@mdx-js/react": "^3.0.0",
+                "@storybook/csf-plugin": "10.4.6",
+                "@storybook/icons": "^2.0.2",
+                "@storybook/react-dom-shim": "10.4.6",
+                "react": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0",
+                "react-dom": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0",
+                "ts-dedent": "^2.0.0"
+            },
+            "funding": {
+                "type": "opencollective",
+                "url": "https://opencollective.com/storybook"
+            },
+            "peerDependencies": {
+                "@types/react": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0",
+                "storybook": "^10.4.6"
+            },
+            "peerDependenciesMeta": {
+                "@types/react": {
+                    "optional": true
+                }
+            }
+        },
         "node_modules/@storybook/addon-mcp": {
             "version": "0.6.0",
             "resolved": "https://registry.npmjs.org/@storybook/addon-mcp/-/addon-mcp-0.6.0.tgz",
@@ -15746,6 +15793,41 @@
             },
             "peerDependenciesMeta": {
                 "@storybook/addon-vitest": {
+                    "optional": true
+                }
+            }
+        },
+        "node_modules/@storybook/csf-plugin": {
+            "version": "10.4.6",
+            "resolved": "https://registry.npmjs.org/@storybook/csf-plugin/-/csf-plugin-10.4.6.tgz",
+            "integrity": "sha512-NILLxDqpA/JR/AazGWpsz+4fadJwRU4uhHephGtYpVOWnQA/DkJfKT6zpcJVq8+QA8A2zKMLX3GVKsXIrxjuDA==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "unplugin": "^2.3.5"
+            },
+            "funding": {
+                "type": "opencollective",
+                "url": "https://opencollective.com/storybook"
+            },
+            "peerDependencies": {
+                "esbuild": "*",
+                "rollup": "*",
+                "storybook": "^10.4.6",
+                "vite": "*",
+                "webpack": "*"
+            },
+            "peerDependenciesMeta": {
+                "esbuild": {
+                    "optional": true
+                },
+                "rollup": {
+                    "optional": true
+                },
+                "vite": {
+                    "optional": true
+                },
+                "webpack": {
                     "optional": true
                 }
             }
@@ -15779,6 +15861,32 @@
                 "@tmcp/transport-http": "^0.8.5",
                 "tmcp": "^1.19.3",
                 "valibot": "1.2.0"
+            }
+        },
+        "node_modules/@storybook/react-dom-shim": {
+            "version": "10.4.6",
+            "resolved": "https://registry.npmjs.org/@storybook/react-dom-shim/-/react-dom-shim-10.4.6.tgz",
+            "integrity": "sha512-iGNmKzrq9vgl2PDrYAnZKI+yvac3Ym+lJXXuQaqlFRS23zA5MNm4EBX+rAG7WulqchoK6NaZ0KQOs2mAgEpTMg==",
+            "dev": true,
+            "license": "MIT",
+            "funding": {
+                "type": "opencollective",
+                "url": "https://opencollective.com/storybook"
+            },
+            "peerDependencies": {
+                "@types/react": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0",
+                "@types/react-dom": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0",
+                "react": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0",
+                "react-dom": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0",
+                "storybook": "^10.4.6"
+            },
+            "peerDependenciesMeta": {
+                "@types/react": {
+                    "optional": true
+                },
+                "@types/react-dom": {
+                    "optional": true
+                }
             }
         },
         "node_modules/@stripe/react-stripe-js": {
@@ -17021,15 +17129,6 @@
             "integrity": "sha512-nv+GSx77ZtXiJzwKdsASqi+YQ5Z7vwHsTP0JY2SiQgjGckkBRKZnk8nIM+7oUZ1VCtuTz0+By4qVR7fqzp/Dfg==",
             "dev": true
         },
-        "node_modules/@types/esrecurse": {
-            "version": "4.3.1",
-            "resolved": "https://registry.npmjs.org/@types/esrecurse/-/esrecurse-4.3.1.tgz",
-            "integrity": "sha512-xJBAbDifo5hpffDBuHl0Y8ywswbiAp/Wi7Y/GtAgSlZyIABppyurxVueOPE8LUQOxdlgi6Zqce7uoEpqNTeiUw==",
-            "dev": true,
-            "license": "MIT",
-            "optional": true,
-            "peer": true
-        },
         "node_modules/@types/estree": {
             "version": "1.0.9",
             "resolved": "https://registry.npmjs.org/@types/estree/-/estree-1.0.9.tgz",
@@ -17184,6 +17283,13 @@
         },
         "node_modules/@types/md5": {
             "version": "2.3.2",
+            "dev": true,
+            "license": "MIT"
+        },
+        "node_modules/@types/mdx": {
+            "version": "2.0.14",
+            "resolved": "https://registry.npmjs.org/@types/mdx/-/mdx-2.0.14.tgz",
+            "integrity": "sha512-T48PeuJtvLosNTPVhfnIp3i/n3a4g4Bad7YCq5k64D4u7NwDrAotikQ+5+sjtUvBmxCMlbo3dVL+C2dP0rWHzg==",
             "dev": true,
             "license": "MIT"
         },
@@ -38220,6 +38326,7 @@
             },
             "devDependencies": {
                 "@storybook/addon-a11y": "10.4.6",
+                "@storybook/addon-docs": "10.4.6",
                 "@storybook/addon-mcp": "0.6.0",
                 "@storybook/addon-themes": "10.4.6",
                 "@storybook/react": "10.4.6",
@@ -38412,67 +38519,6 @@
             "peerDependencies": {
                 "storybook": "^10.4.6",
                 "vite": "^5.0.0 || ^6.0.0 || ^7.0.0 || ^8.0.0"
-            }
-        },
-        "packages/design-system/node_modules/@storybook/react-vite/node_modules/@storybook/builder-vite/node_modules/@storybook/csf-plugin": {
-            "version": "10.4.6",
-            "resolved": "https://registry.npmjs.org/@storybook/csf-plugin/-/csf-plugin-10.4.6.tgz",
-            "integrity": "sha512-NILLxDqpA/JR/AazGWpsz+4fadJwRU4uhHephGtYpVOWnQA/DkJfKT6zpcJVq8+QA8A2zKMLX3GVKsXIrxjuDA==",
-            "dev": true,
-            "license": "MIT",
-            "dependencies": {
-                "unplugin": "^2.3.5"
-            },
-            "funding": {
-                "type": "opencollective",
-                "url": "https://opencollective.com/storybook"
-            },
-            "peerDependencies": {
-                "esbuild": "*",
-                "rollup": "*",
-                "storybook": "^10.4.6",
-                "vite": "*",
-                "webpack": "*"
-            },
-            "peerDependenciesMeta": {
-                "esbuild": {
-                    "optional": true
-                },
-                "rollup": {
-                    "optional": true
-                },
-                "vite": {
-                    "optional": true
-                },
-                "webpack": {
-                    "optional": true
-                }
-            }
-        },
-        "packages/design-system/node_modules/@storybook/react/node_modules/@storybook/react-dom-shim": {
-            "version": "10.4.6",
-            "resolved": "https://registry.npmjs.org/@storybook/react-dom-shim/-/react-dom-shim-10.4.6.tgz",
-            "integrity": "sha512-iGNmKzrq9vgl2PDrYAnZKI+yvac3Ym+lJXXuQaqlFRS23zA5MNm4EBX+rAG7WulqchoK6NaZ0KQOs2mAgEpTMg==",
-            "dev": true,
-            "license": "MIT",
-            "funding": {
-                "type": "opencollective",
-                "url": "https://opencollective.com/storybook"
-            },
-            "peerDependencies": {
-                "@types/react": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0",
-                "@types/react-dom": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0",
-                "react": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0",
-                "react-dom": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0",
-                "storybook": "^10.4.6"
-            },
-            "peerDependenciesMeta": {
-                "@types/react": {
-                    "optional": true
-                },
-                "@types/react-dom": {
-                    "optional": true
-                }
             }
         },
         "packages/design-system/node_modules/@tailwindcss/node": {
@@ -41491,93 +41537,6 @@
                 "zustand": "5.0.3"
             }
         },
-        "packages/webapp/node_modules/@eslint-community/regexpp": {
-            "version": "4.12.2",
-            "resolved": "https://registry.npmjs.org/@eslint-community/regexpp/-/regexpp-4.12.2.tgz",
-            "integrity": "sha512-EriSTlt5OC9/7SXkRSCAhfSxxoSUgBm33OH+IkwbdpgoqsSsUg7y3uh+IICI/Qg4BBWr3U2i39RpmycbxMq4ew==",
-            "dev": true,
-            "license": "MIT",
-            "optional": true,
-            "peer": true,
-            "engines": {
-                "node": "^12.0.0 || ^14.0.0 || >=16.0.0"
-            }
-        },
-        "packages/webapp/node_modules/@eslint/config-array": {
-            "version": "0.23.5",
-            "resolved": "https://registry.npmjs.org/@eslint/config-array/-/config-array-0.23.5.tgz",
-            "integrity": "sha512-Y3kKLvC1dvTOT+oGlqNQ1XLqK6D1HU2YXPc52NmAlJZbMMWDzGYXMiPRJ8TYD39muD/OTjlZmNJ4ib7dvSrMBA==",
-            "dev": true,
-            "license": "Apache-2.0",
-            "optional": true,
-            "peer": true,
-            "dependencies": {
-                "@eslint/object-schema": "^3.0.5",
-                "debug": "^4.3.1",
-                "minimatch": "^10.2.4"
-            },
-            "engines": {
-                "node": "^20.19.0 || ^22.13.0 || >=24"
-            }
-        },
-        "packages/webapp/node_modules/@eslint/config-helpers": {
-            "version": "0.6.0",
-            "resolved": "https://registry.npmjs.org/@eslint/config-helpers/-/config-helpers-0.6.0.tgz",
-            "integrity": "sha512-ii6Bw9jJ2zi2cWA2Z+9/QZ/+3DX6kwaV5Q986D/CdP3Lap3w/pgQZ373FV7byY/i7L4IRH/G43I5dz1ClsCbpA==",
-            "dev": true,
-            "license": "Apache-2.0",
-            "optional": true,
-            "peer": true,
-            "dependencies": {
-                "@eslint/core": "^1.2.1"
-            },
-            "engines": {
-                "node": "^20.19.0 || ^22.13.0 || >=24"
-            }
-        },
-        "packages/webapp/node_modules/@eslint/core": {
-            "version": "1.2.1",
-            "resolved": "https://registry.npmjs.org/@eslint/core/-/core-1.2.1.tgz",
-            "integrity": "sha512-MwcE1P+AZ4C6DWlpin/OmOA54mmIZ/+xZuJiQd4SyB29oAJjN30UW9wkKNptW2ctp4cEsvhlLY/CsQ1uoHDloQ==",
-            "dev": true,
-            "license": "Apache-2.0",
-            "optional": true,
-            "peer": true,
-            "dependencies": {
-                "@types/json-schema": "^7.0.15"
-            },
-            "engines": {
-                "node": "^20.19.0 || ^22.13.0 || >=24"
-            }
-        },
-        "packages/webapp/node_modules/@eslint/object-schema": {
-            "version": "3.0.5",
-            "resolved": "https://registry.npmjs.org/@eslint/object-schema/-/object-schema-3.0.5.tgz",
-            "integrity": "sha512-vqTaUEgxzm+YDSdElad6PiRoX4t8VGDjCtt05zn4nU810UIx/uNEV7/lZJ6KwFThKZOzOxzXy48da+No7HZaMw==",
-            "dev": true,
-            "license": "Apache-2.0",
-            "optional": true,
-            "peer": true,
-            "engines": {
-                "node": "^20.19.0 || ^22.13.0 || >=24"
-            }
-        },
-        "packages/webapp/node_modules/@eslint/plugin-kit": {
-            "version": "0.7.2",
-            "resolved": "https://registry.npmjs.org/@eslint/plugin-kit/-/plugin-kit-0.7.2.tgz",
-            "integrity": "sha512-+CNAzxglkrpNf/kKywqQfk74QjtceuOE7Qm+AF8miRvPF/wmmK5+OJOgVh3AVTT3RP2mH3+FOaxlE5v72owk0A==",
-            "dev": true,
-            "license": "Apache-2.0",
-            "optional": true,
-            "peer": true,
-            "dependencies": {
-                "@eslint/core": "^1.2.1",
-                "levn": "^0.4.1"
-            },
-            "engines": {
-                "node": "^20.19.0 || ^22.13.0 || >=24"
-            }
-        },
         "packages/webapp/node_modules/@floating-ui/react": {
             "version": "0.26.28",
             "resolved": "https://registry.npmjs.org/@floating-ui/react/-/react-0.26.28.tgz",
@@ -42175,33 +42134,6 @@
                 "vite": "^4 || ^5 || ^6 || ^7 || ^8"
             }
         },
-        "packages/webapp/node_modules/balanced-match": {
-            "version": "4.0.4",
-            "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-4.0.4.tgz",
-            "integrity": "sha512-BLrgEcRTwX2o6gGxGOCNyMvGSp35YofuYzw9h1IMTRmKqttAZZVU67bdb9Pr2vUHA8+j3i2tJfjO6C6+4myGTA==",
-            "dev": true,
-            "license": "MIT",
-            "optional": true,
-            "peer": true,
-            "engines": {
-                "node": "18 || 20 || >=22"
-            }
-        },
-        "packages/webapp/node_modules/brace-expansion": {
-            "version": "5.0.6",
-            "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.6.tgz",
-            "integrity": "sha512-kLpxurY4Z4r9sgMsyG0Z9uzsBlgiU/EFKhj/h91/8yHu0edo7XuixOIH3VcJ8kkxs6/jPzoI6U9Vj3WqbMQ94g==",
-            "dev": true,
-            "license": "MIT",
-            "optional": true,
-            "peer": true,
-            "dependencies": {
-                "balanced-match": "^4.0.2"
-            },
-            "engines": {
-                "node": "18 || 20 || >=22"
-            }
-        },
         "packages/webapp/node_modules/chokidar": {
             "version": "5.0.0",
             "resolved": "https://registry.npmjs.org/chokidar/-/chokidar-5.0.0.tgz",
@@ -42232,138 +42164,6 @@
                 "node": ">=10.13.0"
             }
         },
-        "packages/webapp/node_modules/eslint": {
-            "version": "10.5.0",
-            "resolved": "https://registry.npmjs.org/eslint/-/eslint-10.5.0.tgz",
-            "integrity": "sha512-1y+7C+vi12bUK1IpZeaV3gsH9fHLBmPvYmPx42pvT/E9yG0IC8g3PUZZgp0+JLJl7ZDK0flc2gc+Aw9dpCvIsQ==",
-            "dev": true,
-            "license": "MIT",
-            "optional": true,
-            "peer": true,
-            "workspaces": [
-                "packages/*"
-            ],
-            "dependencies": {
-                "@eslint-community/eslint-utils": "^4.8.0",
-                "@eslint-community/regexpp": "^4.12.2",
-                "@eslint/config-array": "^0.23.5",
-                "@eslint/config-helpers": "^0.6.0",
-                "@eslint/core": "^1.2.1",
-                "@eslint/plugin-kit": "^0.7.2",
-                "@humanfs/node": "^0.16.6",
-                "@humanwhocodes/module-importer": "^1.0.1",
-                "@humanwhocodes/retry": "^0.4.2",
-                "@types/estree": "^1.0.6",
-                "ajv": "^6.14.0",
-                "cross-spawn": "^7.0.6",
-                "debug": "^4.3.2",
-                "escape-string-regexp": "^4.0.0",
-                "eslint-scope": "^9.1.2",
-                "eslint-visitor-keys": "^5.0.1",
-                "espree": "^11.2.0",
-                "esquery": "^1.7.0",
-                "esutils": "^2.0.2",
-                "fast-deep-equal": "^3.1.3",
-                "file-entry-cache": "^8.0.0",
-                "find-up": "^5.0.0",
-                "glob-parent": "^6.0.2",
-                "ignore": "^5.2.0",
-                "imurmurhash": "^0.1.4",
-                "is-glob": "^4.0.0",
-                "json-stable-stringify-without-jsonify": "^1.0.1",
-                "minimatch": "^10.2.4",
-                "natural-compare": "^1.4.0",
-                "optionator": "^0.9.3"
-            },
-            "bin": {
-                "eslint": "bin/eslint.js"
-            },
-            "engines": {
-                "node": "^20.19.0 || ^22.13.0 || >=24"
-            },
-            "funding": {
-                "url": "https://eslint.org/donate"
-            },
-            "peerDependencies": {
-                "jiti": "*"
-            },
-            "peerDependenciesMeta": {
-                "jiti": {
-                    "optional": true
-                }
-            }
-        },
-        "packages/webapp/node_modules/eslint-scope": {
-            "version": "9.1.2",
-            "resolved": "https://registry.npmjs.org/eslint-scope/-/eslint-scope-9.1.2.tgz",
-            "integrity": "sha512-xS90H51cKw0jltxmvmHy2Iai1LIqrfbw57b79w/J7MfvDfkIkFZ+kj6zC3BjtUwh150HsSSdxXZcsuv72miDFQ==",
-            "dev": true,
-            "license": "BSD-2-Clause",
-            "optional": true,
-            "peer": true,
-            "dependencies": {
-                "@types/esrecurse": "^4.3.1",
-                "@types/estree": "^1.0.8",
-                "esrecurse": "^4.3.0",
-                "estraverse": "^5.2.0"
-            },
-            "engines": {
-                "node": "^20.19.0 || ^22.13.0 || >=24"
-            },
-            "funding": {
-                "url": "https://opencollective.com/eslint"
-            }
-        },
-        "packages/webapp/node_modules/eslint-visitor-keys": {
-            "version": "5.0.1",
-            "resolved": "https://registry.npmjs.org/eslint-visitor-keys/-/eslint-visitor-keys-5.0.1.tgz",
-            "integrity": "sha512-tD40eHxA35h0PEIZNeIjkHoDR4YjjJp34biM0mDvplBe//mB+IHCqHDGV7pxF+7MklTvighcCPPZC7ynWyjdTA==",
-            "dev": true,
-            "license": "Apache-2.0",
-            "optional": true,
-            "peer": true,
-            "engines": {
-                "node": "^20.19.0 || ^22.13.0 || >=24"
-            },
-            "funding": {
-                "url": "https://opencollective.com/eslint"
-            }
-        },
-        "packages/webapp/node_modules/espree": {
-            "version": "11.2.0",
-            "resolved": "https://registry.npmjs.org/espree/-/espree-11.2.0.tgz",
-            "integrity": "sha512-7p3DrVEIopW1B1avAGLuCSh1jubc01H2JHc8B4qqGblmg5gI9yumBgACjWo4JlIc04ufug4xJ3SQI8HkS/Rgzw==",
-            "dev": true,
-            "license": "BSD-2-Clause",
-            "optional": true,
-            "peer": true,
-            "dependencies": {
-                "acorn": "^8.16.0",
-                "acorn-jsx": "^5.3.2",
-                "eslint-visitor-keys": "^5.0.1"
-            },
-            "engines": {
-                "node": "^20.19.0 || ^22.13.0 || >=24"
-            },
-            "funding": {
-                "url": "https://opencollective.com/eslint"
-            }
-        },
-        "packages/webapp/node_modules/esquery": {
-            "version": "1.7.0",
-            "resolved": "https://registry.npmjs.org/esquery/-/esquery-1.7.0.tgz",
-            "integrity": "sha512-Ap6G0WQwcU/LHsvLwON1fAQX9Zp0A2Y6Y/cJBl9r/JbW90Zyg4/zbG6zzKa2OTALELarYHmKu0GhpM5EO+7T0g==",
-            "dev": true,
-            "license": "BSD-3-Clause",
-            "optional": true,
-            "peer": true,
-            "dependencies": {
-                "estraverse": "^5.1.0"
-            },
-            "engines": {
-                "node": ">=0.10"
-            }
-        },
         "packages/webapp/node_modules/is-obj": {
             "version": "3.0.0",
             "resolved": "https://registry.npmjs.org/is-obj/-/is-obj-3.0.0.tgz",
@@ -42386,24 +42186,6 @@
             },
             "funding": {
                 "url": "https://github.com/sponsors/sindresorhus"
-            }
-        },
-        "packages/webapp/node_modules/minimatch": {
-            "version": "10.2.5",
-            "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-10.2.5.tgz",
-            "integrity": "sha512-MULkVLfKGYDFYejP07QOurDLLQpcjk7Fw+7jXS2R2czRQzR56yHRveU5NDJEOviH+hETZKSkIk5c+T23GjFUMg==",
-            "dev": true,
-            "license": "BlueOak-1.0.0",
-            "optional": true,
-            "peer": true,
-            "dependencies": {
-                "brace-expansion": "^5.0.5"
-            },
-            "engines": {
-                "node": "18 || 20 || >=22"
-            },
-            "funding": {
-                "url": "https://github.com/sponsors/isaacs"
             }
         },
         "packages/webapp/node_modules/nanoid": {

--- a/packages/design-system/.storybook/main.ts
+++ b/packages/design-system/.storybook/main.ts
@@ -9,8 +9,8 @@ import type { StorybookConfig } from '@storybook/react-vite';
 import type { InlineConfig } from 'vite';
 
 const config: StorybookConfig = {
-    stories: ['../tokens/**/*.stories.@(ts|tsx)', '../src/**/*.stories.@(ts|tsx)', '../stories/**/*.stories.@(ts|tsx)'],
-    addons: ['@storybook/addon-a11y', '@storybook/addon-mcp', '@storybook/addon-themes'],
+    stories: ['../tokens/**/*.stories.@(ts|tsx)', '../src/**/*.stories.@(ts|tsx)', '../stories/**/*.stories.@(ts|tsx)', '../stories/**/*.mdx'],
+    addons: ['@storybook/addon-a11y', '@storybook/addon-docs', '@storybook/addon-mcp', '@storybook/addon-themes'],
     framework: {
         name: '@storybook/react-vite',
         options: {}

--- a/packages/design-system/AGENTS.md
+++ b/packages/design-system/AGENTS.md
@@ -174,11 +174,11 @@ Key rules:
 
 ### Step 4: Add a Storybook story
 
-Create `src/components/ui/<component-name>.stories.tsx` co-located with the component. Show every variant and state (default, hover, disabled, focused). Use Tailwind classes for layout in stories — Tailwind's default 4px scale matches our spacing tokens exactly (`gap-2` = 8px = `--ds-space-2`), so no `var(--ds-space-*)` needed.
+Add the story to the top-level `stories/` dir as `stories/<ComponentName>.stories.tsx` (not co-located with the component). Show every variant and state (default, hover, disabled, focused). Use Tailwind classes for layout in stories — Tailwind's default 4px scale matches our spacing tokens exactly (`gap-2` = 8px = `--ds-space-2`), so no `var(--ds-space-*)` needed.
 
 ```tsx
 import type { Meta, StoryObj } from '@storybook/react';
-import { MyComponent } from './my-component';
+import { MyComponent } from '../src/components/ui/my-component';
 
 const meta: Meta<typeof MyComponent> = {
     title: 'Design System/Components/MyComponent',

--- a/packages/design-system/AGENTS.md
+++ b/packages/design-system/AGENTS.md
@@ -2,6 +2,10 @@
 
 This package contains the Nango design system: design tokens, React components, and Storybook.
 
+## Adding a variant for a new look
+
+Consuming apps can't restyle these components (a lint rule flags `className`/`style` on them), so when a screen needs a look no existing prop or variant covers, the fix lives **here** — add a new or extended variant. First validate with a designer that the variant is genuinely missing, then add the matching variant to the **Figma design system** so code and design stay in sync. See the [Styling & Customization](http://storybook.nango.dev/?path=/docs/design-system-guide-styling-customization--docs) guide.
+
 ## Adding a new component
 
 Components are added on-demand when first needed in a real screen — don't add components speculatively.

--- a/packages/design-system/AGENTS.md
+++ b/packages/design-system/AGENTS.md
@@ -4,7 +4,7 @@ This package contains the Nango design system: design tokens, React components, 
 
 ## Adding a variant for a new look
 
-Consuming apps can't restyle these components (a lint rule flags `className`/`style` on them), so when a screen needs a look no existing prop or variant covers, the fix lives **here** — add a new or extended variant. First validate with a designer that the variant is genuinely missing, then add the matching variant to the **Figma design system** so code and design stay in sync. See the [Styling & Customization](http://storybook.nango.dev/?path=/docs/design-system-guide-styling-customization--docs) guide.
+Consuming apps can't restyle these components (a lint rule flags `className`/`style` on them), so when a screen needs a look no existing prop or variant covers, the fix lives **here** — add a new or extended variant. First validate with a designer that the variant is genuinely missing, then add the matching variant to the **Figma design system** so code and design stay in sync. See `stories/StylingAndCustomization.mdx` for the full guide.
 
 ## Adding a new component
 
@@ -219,6 +219,7 @@ src/
     cn.ts                  cn() helper: twMerge + clsx
   index.ts                 barrel — all public exports
   index.css                CSS entry (imports tokens.generated.css)
+stories/                   Storybook stories (*.stories.tsx) and MDX guides
 tokens/
   tokens.generated.css     compiled CSS custom properties (source of truth for tokens)
   tokens.json              Tokens Studio export

--- a/packages/design-system/package.json
+++ b/packages/design-system/package.json
@@ -30,6 +30,7 @@
     },
     "devDependencies": {
         "@storybook/addon-a11y": "10.4.6",
+        "@storybook/addon-docs": "10.4.6",
         "@storybook/addon-mcp": "0.6.0",
         "@storybook/addon-themes": "10.4.6",
         "@storybook/react": "10.4.6",

--- a/packages/design-system/stories/StylingAndCustomization.mdx
+++ b/packages/design-system/stories/StylingAndCustomization.mdx
@@ -1,0 +1,89 @@
+import { Meta } from '@storybook/addon-docs/blocks';
+
+<Meta title="Design System/Guide/Styling & Customization" />
+
+# Styling & Customization
+
+**Design-system components own their styling. Don't override it with `className` or `style`.**
+
+Each component's appearance is defined once, in the design system, and wired to design tokens. Overriding it with `className` or `style` breaks that: colors and spacing drift from the tokens, dark mode stops working, and the same component ends up looking different on every page.
+
+> A lint rule (`react/forbid-component-props`) enforces this by flagging `className` and `style` on design-system components.
+
+## What to do instead
+
+### 1. Use the component's props
+
+Most "customizations" are already a prop. Reach for these before anything else.
+
+| Component    | Props                                                                                                                                 |
+| ------------ | ------------------------------------------------------------------------------------------------------------------------------------- |
+| `Button`     | `variant` (`primary`, `secondary`, `outline`, `ghost`, `danger`, `link-danger`), `size` (`xs`–`lg`), `loading`, `disabled`, `asChild` |
+| `IconButton` | same as `Button`, plus a required `label`; sizes `2xs`–`lg`                                                                           |
+| `Icon`       | `size` (`xs`–`xl`), `strokeWidth`                                                                                                     |
+| `Spinner`    | `size` (`xs`–`xl`)                                                                                                                    |
+
+```tsx
+// ❌ Don't restyle via className
+<Button className="bg-red-500 h-10 text-xs">Delete</Button>
+
+// ✅ Use the props that already express this
+<Button variant="danger" size="xl">Delete</Button>
+```
+
+### 2. Need a look that doesn't exist? Add it to the design system
+
+If no prop covers the design, add a **new or extended variant** to the component rather than overriding it locally — that keeps the look named, reusable, and token-bound.
+
+Before adding one, validate with a designer that the variant is genuinely missing. When you add it, add the matching variant to the **Figma design system** too, so code and design don't drift out of sync. This can be done as part of the product work that needs it.
+
+A one-off override solves it for one screen; a variant solves it everywhere and survives a redesign.
+
+### 3. Layout & spacing → put it on a wrapper
+
+Margin, positioning, width, and grid/flex placement are **layout**, not component styling — they belong to the parent, not the button. Wrap the component, or let the parent's `flex`/`grid` `gap` do the spacing.
+
+```tsx
+// ❌ Layout classes on the component
+<Button className="mt-4 ml-auto w-full">Save</Button>
+
+// ✅ Layout on a wrapper / the parent
+<div className="mt-4 ml-auto w-full">
+  <Button asChild>
+    {/* asChild forwards to a full-width child when you need the button itself to stretch */}
+  </Button>
+</div>
+
+// or let the container space its children
+<div className="flex justify-end gap-2">
+  <Button variant="ghost">Cancel</Button>
+  <Button>Save</Button>
+</div>
+```
+
+### 4. Coloring an icon → set the color on a parent
+
+`Icon` and `Spinner` render with `currentColor`, so they inherit the surrounding text color. Don't pass `className="text-..."` to the icon — set the color on whatever wraps it.
+
+```tsx
+// ❌ Color class on the Icon
+<Icon icon={AlertTriangle} className="text-text-danger" />
+
+// ✅ Color flows from the parent
+<span className="text-text-danger">
+  <Icon icon={AlertTriangle} />
+</span>
+```
+
+### 5. Genuine one-off? Disable the rule with a reason
+
+There are real exceptions. When you hit one, disable the rule on that line **with a comment explaining why** so the next reader knows it was deliberate.
+
+```tsx
+{
+    /* eslint-disable-next-line react/forbid-component-props -- third-party drag handle needs an inline transform */
+}
+<IconButton label="Drag" style={dragProvided.draggableProps.style} />;
+```
+
+If you find yourself reaching for this often, that's a signal the component is missing a prop or variant — see step 2.

--- a/packages/webapp/src/pages/Account/ForgotPassword.tsx
+++ b/packages/webapp/src/pages/Account/ForgotPassword.tsx
@@ -85,7 +85,7 @@ export default function Signin() {
                             )}
                         />
 
-                        <Button type="submit" className="w-full" size={'xl'} loading={isPending} disabled={!form.formState.isValid}>
+                        <Button type="submit" size={'xl'} loading={isPending} disabled={!form.formState.isValid}>
                             Send password reset email
                         </Button>
                     </form>

--- a/packages/webapp/src/pages/Account/ManagedEmailVerification.tsx
+++ b/packages/webapp/src/pages/Account/ManagedEmailVerification.tsx
@@ -88,7 +88,7 @@ export const ManagedEmailVerification: React.FC = () => {
                     />
                 </InputGroup>
 
-                <Button type="submit" size="xl" className="w-full" loading={isPending} disabled={code.trim().length < 6}>
+                <Button type="submit" size="xl" loading={isPending} disabled={code.trim().length < 6}>
                     Verify and continue
                 </Button>
             </form>

--- a/packages/webapp/src/pages/Account/ResetPassword.tsx
+++ b/packages/webapp/src/pages/Account/ResetPassword.tsx
@@ -77,7 +77,7 @@ export default function ResetPassword() {
                         render={() => <Password placeholder="New password" autoFocus autoComplete="new-password" />}
                     />
 
-                    <Button type="submit" className="w-full" size={'xl'} loading={isPending} disabled={!form.formState.isValid}>
+                    <Button type="submit" size={'xl'} loading={isPending} disabled={!form.formState.isValid}>
                         Reset password
                     </Button>
                 </form>

--- a/packages/webapp/src/pages/Account/Signin.tsx
+++ b/packages/webapp/src/pages/Account/Signin.tsx
@@ -197,7 +197,7 @@ export const Signin: React.FC = () => {
                                 </StyledLink>
                             </div>
 
-                            <Button type="submit" size="xl" className="w-full" loading={isPending} disabled={!form.formState.isValid}>
+                            <Button type="submit" size="xl" loading={isPending} disabled={!form.formState.isValid}>
                                 {isPending ? 'Logging in...' : 'Log in'}
                             </Button>
                         </form>

--- a/packages/webapp/src/pages/Account/VerifyEmail.tsx
+++ b/packages/webapp/src/pages/Account/VerifyEmail.tsx
@@ -74,9 +74,11 @@ export function VerifyEmail() {
                 </span>
             </div>
 
-            <Button onClick={handleResendEmail} size="xl" className="w-full" loading={isResendingVerificationEmailByUuid}>
-                Resend email
-            </Button>
+            <div className="grid w-full">
+                <Button onClick={handleResendEmail} size="xl" loading={isResendingVerificationEmailByUuid}>
+                    Resend email
+                </Button>
+            </div>
         </DefaultLayout>
     );
 }

--- a/packages/webapp/src/pages/Account/components/SignupForm.tsx
+++ b/packages/webapp/src/pages/Account/components/SignupForm.tsx
@@ -176,7 +176,7 @@ export const SignupForm: React.FC<{ invitation?: ApiInvitation; token?: string }
 
                         <FormField control={form.control} name="password" render={() => <Password autoComplete="new-password" />} />
 
-                        <Button type="submit" size="xl" className="w-full" loading={isPending} disabled={!form.formState.isValid}>
+                        <Button type="submit" size="xl" loading={isPending} disabled={!form.formState.isValid}>
                             {isPending ? 'Signing up...' : 'Sign up'}
                         </Button>
                     </form>

--- a/packages/webapp/src/pages/Connection/List.tsx
+++ b/packages/webapp/src/pages/Connection/List.tsx
@@ -447,9 +447,11 @@ export const ConnectionList = () => {
                     )}
 
                     {hasNextPage && (
-                        <Button onClick={() => fetchNextPage()} loading={isFetchingNextPage} variant="outline" className="self-center">
-                            Load More
-                        </Button>
+                        <div className="self-center">
+                            <Button onClick={() => fetchNextPage()} loading={isFetchingNextPage} variant="outline">
+                                Load More
+                            </Button>
+                        </div>
                     )}
                 </div>
             </div>

--- a/packages/webapp/src/pages/Connection/components/AuthCredentials/JwtCredentials.tsx
+++ b/packages/webapp/src/pages/Connection/components/AuthCredentials/JwtCredentials.tsx
@@ -27,7 +27,7 @@ export const JwtCredentialsComponent: React.FC<{
                         <SecretInput id="token" value={credentials.token} disabled copy canRead={canRead} />
                         <PermissionGate condition={canRead} asChild>
                             {(allowed) => (
-                                <Button variant="outline" size="md" className="h-full" onClick={forceRefresh} loading={isRefreshing} disabled={!allowed}>
+                                <Button variant="outline" size="lg" onClick={forceRefresh} loading={isRefreshing} disabled={!allowed}>
                                     <RefreshCwIcon />
                                     Refresh
                                 </Button>

--- a/packages/webapp/src/pages/Connection/components/AuthCredentials/OAuth2ClientCredentials.tsx
+++ b/packages/webapp/src/pages/Connection/components/AuthCredentials/OAuth2ClientCredentials.tsx
@@ -25,7 +25,7 @@ export const OAuth2ClientCredentialsComponent: React.FC<{
                     <SecretInput id="token" value={credentials.token} disabled copy canRead={canRead} />
                     <PermissionGate condition={canRead} asChild>
                         {(allowed) => (
-                            <Button variant="outline" size="md" className="h-full" onClick={forceRefresh} loading={isRefreshing} disabled={!allowed}>
+                            <Button variant="outline" size="lg" onClick={forceRefresh} loading={isRefreshing} disabled={!allowed}>
                                 <RefreshCwIcon />
                                 Refresh
                             </Button>

--- a/packages/webapp/src/pages/Connection/components/AuthCredentials/OAuth2Credentials.tsx
+++ b/packages/webapp/src/pages/Connection/components/AuthCredentials/OAuth2Credentials.tsx
@@ -26,7 +26,7 @@ export const OAuth2CredentialsComponent: React.FC<{
                     {credentials.refresh_token && (
                         <PermissionGate condition={canRead} asChild>
                             {(allowed) => (
-                                <Button variant="outline" size="md" className="h-full" onClick={forceRefresh} loading={isRefreshing} disabled={!allowed}>
+                                <Button variant="outline" size="lg" onClick={forceRefresh} loading={isRefreshing} disabled={!allowed}>
                                     <RefreshCwIcon />
                                     Refresh
                                 </Button>

--- a/packages/webapp/src/pages/Connection/components/AuthCredentials/SignatureCredentials.tsx
+++ b/packages/webapp/src/pages/Connection/components/AuthCredentials/SignatureCredentials.tsx
@@ -36,7 +36,7 @@ export const SignatureCredentialsComponent: React.FC<{
                         <SecretInput id="token" value={credentials.token} disabled copy canRead={canRead} />
                         <PermissionGate condition={canRead} asChild>
                             {(allowed) => (
-                                <Button variant="outline" size="md" className="h-full" onClick={forceRefresh} loading={isRefreshing} disabled={!allowed}>
+                                <Button variant="outline" size="lg" onClick={forceRefresh} loading={isRefreshing} disabled={!allowed}>
                                     <RefreshCwIcon />
                                     Refresh
                                 </Button>

--- a/packages/webapp/src/pages/Connection/components/AuthCredentials/TwoStepCredentials.tsx
+++ b/packages/webapp/src/pages/Connection/components/AuthCredentials/TwoStepCredentials.tsx
@@ -27,7 +27,7 @@ export const TwoStepCredentialsComponent: React.FC<{
                         <SecretInput id="token" value={credentials.token} disabled copy canRead={canRead} />
                         <PermissionGate condition={canRead} asChild>
                             {(allowed) => (
-                                <Button variant="outline" size="md" className="h-full" onClick={forceRefresh} loading={isRefreshing} disabled={!allowed}>
+                                <Button variant="outline" size="lg" onClick={forceRefresh} loading={isRefreshing} disabled={!allowed}>
                                     <RefreshCwIcon />
                                     Refresh
                                 </Button>

--- a/packages/webapp/src/pages/Environment/Settings/ConnectUISettings/index.tsx
+++ b/packages/webapp/src/pages/Environment/Settings/ConnectUISettings/index.tsx
@@ -202,16 +202,17 @@ export const ConnectUISettings = () => {
                             {([canSubmit, isDirty]) => (
                                 <PermissionGate asChild condition={canManageConnectUI}>
                                     {(allowed) => (
-                                        <Button
-                                            type="submit"
-                                            variant="primary"
-                                            size="md"
-                                            className="self-start"
-                                            disabled={!canSubmit || !isDirty || !allowed}
-                                            loading={isUpdatingConnectUISettings}
-                                        >
-                                            Save
-                                        </Button>
+                                        <div className="self-start">
+                                            <Button
+                                                type="submit"
+                                                variant="primary"
+                                                size="md"
+                                                disabled={!canSubmit || !isDirty || !allowed}
+                                                loading={isUpdatingConnectUISettings}
+                                            >
+                                                Save
+                                            </Button>
+                                        </div>
                                     )}
                                 </PermissionGate>
                             )}

--- a/packages/webapp/src/pages/GettingStarted/FirstStep.tsx
+++ b/packages/webapp/src/pages/GettingStarted/FirstStep.tsx
@@ -121,10 +121,12 @@ export const FirstStep: React.FC<FirstStepProps> = ({ connection, integration, o
                 <div className="flex flex-col gap-1.5">
                     <h3 className="text-text-brand text-sm font-semibold">Github connection authorized!</h3>
                 </div>
-                <Button variant="outline" size="xl" onClick={onClickDisconnect} loading={isDeletingConnection} className="w-fit">
-                    <IconBrandGithub className="size-5 mr-2" />
-                    Disconnect from Github
-                </Button>
+                <div className="w-fit">
+                    <Button variant="outline" size="xl" onClick={onClickDisconnect} loading={isDeletingConnection}>
+                        <IconBrandGithub className="size-5 mr-2" />
+                        Disconnect from Github
+                    </Button>
+                </div>
             </div>
         );
     }
@@ -142,10 +144,12 @@ export const FirstStep: React.FC<FirstStepProps> = ({ connection, integration, o
                     .
                 </p>
             </div>
-            <Button variant="primary" size="xl" onClick={onClickConnect} className="w-fit">
-                <IconBrandGithub className="size-5" />
-                Connect to Github
-            </Button>
+            <div className="w-fit">
+                <Button variant="primary" size="xl" onClick={onClickConnect}>
+                    <IconBrandGithub className="size-5" />
+                    Connect to Github
+                </Button>
+            </div>
         </div>
     );
 };

--- a/packages/webapp/src/pages/Integrations/providerConfigKey/Settings/Tab.tsx
+++ b/packages/webapp/src/pages/Integrations/providerConfigKey/Settings/Tab.tsx
@@ -9,7 +9,9 @@ export const SettingsTab: React.FC<{ data: GetIntegration['Success']['data']; en
         <div className="flex-1 flex flex-col gap-10">
             <GeneralSettings data={data} environment={environment} />
             <AuthSpecificSettings data={data} environment={environment} />
-            <DeleteIntegrationButton env={environment.name} integration={data.integration} className="self-end" />
+            <div className="self-end">
+                <DeleteIntegrationButton env={environment.name} integration={data.integration} />
+            </div>
         </div>
     );
 };

--- a/packages/webapp/src/pages/Integrations/providerConfigKey/Settings/components/DeleteIntegrationButton.tsx
+++ b/packages/webapp/src/pages/Integrations/providerConfigKey/Settings/components/DeleteIntegrationButton.tsx
@@ -15,7 +15,7 @@ import { usePermissions } from '@/hooks/usePermissions.js';
 
 import type { ApiIntegration } from '@nangohq/types';
 
-export const DeleteIntegrationButton: React.FC<{ env: string; integration: ApiIntegration; className?: string }> = ({ env, integration, className = '' }) => {
+export const DeleteIntegrationButton: React.FC<{ env: string; integration: ApiIntegration }> = ({ env, integration }) => {
     const { toast } = useToast();
     const navigate = useNavigate();
 
@@ -47,7 +47,6 @@ export const DeleteIntegrationButton: React.FC<{ env: string; integration: ApiIn
                         variant="danger"
                         size="xl"
                         loading={isPending}
-                        className={className}
                         disabled={!allowed}
                         onClick={() =>
                             confirm({

--- a/packages/webapp/src/pages/Team/components/ImpersonateForm.tsx
+++ b/packages/webapp/src/pages/Team/components/ImpersonateForm.tsx
@@ -82,9 +82,11 @@ export const ImpersonateForm: React.FC = () => {
                             <span>Impersonating an account will allow you to login as that account and perform actions on their behalf.</span>
                         </AlertDescription>
                     </Alert>
-                    <Button type="submit" variant="danger" className="self-end">
-                        Impersonate
-                    </Button>
+                    <div className="self-end">
+                        <Button type="submit" variant="danger">
+                            Impersonate
+                        </Button>
+                    </div>
                     {form.formState.errors.root && <p className="mt-2 mx-4 text-sm text-status-danger-text">{form.formState.errors.root.message}</p>}
                 </form>
             </Form>


### PR DESCRIPTION
## Problem

With the webapp now using design-system buttons, nothing stopped overriding their styling with `className`/`style`. That defeats the design system and causes real bugs — e.g. a `className` that overrides only a button's base background leaves the variant's `hover:` background intact, producing a broken hover (e.g. the integration "Add" button turned into a black pill with invisible text on hover).

## Solution

Add a guardrail plus docs, then fix the existing violations.

- Add an eslint rule (`react/forbid-component-props`, level warn) that forbids `className`/`style` on `Button`/`IconButton`, scoped to `packages/webapp/src`.
- Add a "Styling & Customization" Storybook guide and point the agent docs to it, documenting the fix hierarchy: use props → add a design-system variant → put layout/spacing on a wrapper → `eslint-disable` only as a last resort.
- Fix the straightforward violations: move layout (`self-*`, `w-fit`, `w-full`, `h-full`) onto wrapper elements or rely on the parent's flex/grid, convert an icon-only button to `IconButton`, and replace look-overriding `className`s with the right `variant`/`size` (this also fixes the broken Add-button hover by using the `outline` variant).

Custom-look violations (pills, select triggers, muted icon-buttons) are intentionally left as warnings to be resolved during the screen-by-screen redesign — no `eslint-disable` added.

Stacked on top of [NAN-5946](https://linear.app/nango/issue/NAN-5946).

Fixes [NAN-5983](https://linear.app/nango/issue/NAN-5983)

## Testing

- `npx eslint packages/webapp/src` drops to the remaining deferred warnings only, with no errors and no new `eslint-disable`s.
- Verified the affected screens in light and dark via local dev against the dev API: auth pages, nav header theme toggle, profile settings, connection credentials refresh buttons, and the integration filter "Add" button hover.
