### PR TITLE
fix(webhook): add url deny list to webhook

### DIFF
--- a/packages/server/lib/controllers/v1/environment/webhook/patchWebhook.integration.test.ts
+++ b/packages/server/lib/controllers/v1/environment/webhook/patchWebhook.integration.test.ts
@@ -1,0 +1,104 @@
+import { afterAll, beforeAll, describe, expect, it } from 'vitest';
+
+import db from '@nangohq/database';
+import { seeders } from '@nangohq/shared';
+
+import { isError, isSuccess, runServer, shouldBeProtected, shouldRequireQueryEnv } from '../../../../utils/tests.js';
+
+const route = '/api/v1/environments/webhook';
+let api: Awaited<ReturnType<typeof runServer>>;
+
+describe(`PATCH ${route}`, () => {
+    beforeAll(async () => {
+        api = await runServer();
+    });
+
+    afterAll(() => {
+        api.server.close();
+    });
+
+    it('should be protected', async () => {
+        const res = await api.fetch(route, {
+            method: 'PATCH',
+            query: { env: 'dev' },
+            body: { primary_url: 'https://example.com/webhook' }
+        });
+
+        shouldBeProtected(res);
+    });
+
+    it('should enforce env query params', async () => {
+        const { apiKey } = await seeders.seedAccountEnvAndUser();
+
+        const res = await api.fetch(
+            route,
+            // @ts-expect-error missing query on purpose
+            { method: 'PATCH', token: apiKey.secret, body: { primary_url: 'https://example.com/webhook' } }
+        );
+
+        shouldRequireQueryEnv(res);
+    });
+
+    it('should reject denylisted webhook URLs', async () => {
+        const { env, apiKey } = await seeders.seedAccountEnvAndUser();
+
+        const res = await api.fetch(route, {
+            method: 'PATCH',
+            query: { env: env.name },
+            token: apiKey.secret,
+            body: { primary_url: 'http://localhost/webhook' }
+        });
+
+        expect(res.res.status).toBe(400);
+        isError(res.json);
+        expect(res.json.error.code).toBe('invalid_body');
+    });
+
+    it('should reject custom denylisted webhook URLs', async () => {
+        const { env, apiKey } = await seeders.seedAccountEnvAndUser();
+
+        const res = await api.fetch(route, {
+            method: 'PATCH',
+            query: { env: env.name },
+            token: apiKey.secret,
+            body: { primary_url: 'https://denylisted-proxy-test.invalid/webhook' }
+        });
+
+        expect(res.res.status).toBe(400);
+        isError(res.json);
+        expect(res.json.error.code).toBe('invalid_body');
+    });
+
+    it('should reject nango.dev webhook URLs', async () => {
+        const { env, apiKey } = await seeders.seedAccountEnvAndUser();
+
+        const res = await api.fetch(route, {
+            method: 'PATCH',
+            query: { env: env.name },
+            token: apiKey.secret,
+            body: { primary_url: 'https://api.nango.dev/webhook' }
+        });
+
+        expect(res.res.status).toBe(400);
+        isError(res.json);
+        expect(res.json.error.code).toBe('invalid_body');
+    });
+
+    it('should accept allowed webhook URLs', async () => {
+        const { env, apiKey } = await seeders.seedAccountEnvAndUser();
+        const primaryUrl = 'https://example.com/webhook';
+
+        const res = await api.fetch(route, {
+            method: 'PATCH',
+            query: { env: env.name },
+            token: apiKey.secret,
+            body: { primary_url: primaryUrl }
+        });
+
+        expect(res.res.status).toBe(200);
+        isSuccess(res.json);
+
+        const webhook = await db.knex('_nango_external_webhooks').where({ environment_id: env.id }).first();
+        expect(webhook?.primary_url).toBe(primaryUrl);
+    });
+});

--- a/packages/server/lib/controllers/v1/environment/webhook/patchWebhook.ts
+++ b/packages/server/lib/controllers/v1/environment/webhook/patchWebhook.ts
@@ -4,11 +4,14 @@ import * as z from 'zod';
 
 import db from '@nangohq/database';
 import { externalWebhookService } from '@nangohq/shared';
-import { requireEmptyQuery, zodErrorToHTTP } from '@nangohq/utils';
+import { isBaseUrlOverrideDenied, normalizeDenylist, requireEmptyQuery, zodErrorToHTTP } from '@nangohq/utils';
 
+import { envs } from '../../../../env.js';
 import { asyncWrapper } from '../../../../utils/asyncWrapper.js';
 
 import type { DBExternalWebhook, PatchWebhook } from '@nangohq/types';
+
+const webhookUrlDenylist = normalizeDenylist(envs.NANGO_PROXY_BASE_URL_OVERRIDE_DENYLIST);
 
 const urlValidation = z
     .union([z.url(), z.literal('')])
@@ -20,6 +23,13 @@ const urlValidation = z
             return !inputUrl.host.endsWith('nango.dev');
         },
         { message: `Webhook URLs cannot point to Nango's domain (nango.dev).` }
+    )
+    .refine(
+        (url) => {
+            if (!url || url.trim() === '') return true;
+            return !isBaseUrlOverrideDenied(url, webhookUrlDenylist);
+        },
+        { message: 'This webhook URL is not allowed.' }
     );
 
 const validation = z

--- a/packages/webhooks/lib/asyncAction.unit.test.ts
+++ b/packages/webhooks/lib/asyncAction.unit.test.ts
@@ -4,6 +4,7 @@ import { logContextGetter } from '@nangohq/logs';
 import { axiosInstance, stringifyStable } from '@nangohq/utils';
 
 import { sendAsyncActionWebhook } from './asyncAction.js';
+import { mockWebhookDenylistAllowAll } from './helpers/setup.unit.js';
 import { TestWebhookServer } from './helpers/test.js';
 
 import type { DBAPISecret, DBEnvironment, DBExternalWebhook } from '@nangohq/types';
@@ -43,6 +44,7 @@ describe('AsyncAction webhookds', () => {
 
     beforeEach(() => {
         vi.resetAllMocks();
+        mockWebhookDenylistAllowAll();
     });
 
     it('should not be sent if on_async_action_completion is false', async () => {

--- a/packages/webhooks/lib/auth.unit.test.ts
+++ b/packages/webhooks/lib/auth.unit.test.ts
@@ -3,6 +3,7 @@ import { afterAll, beforeAll, beforeEach, describe, expect, it, vi } from 'vites
 import { axiosInstance, stringifyStable } from '@nangohq/utils';
 
 import { sendAuth } from './auth.js';
+import { mockWebhookDenylistAllowAll } from './helpers/setup.unit.js';
 import { TestWebhookServer } from './helpers/test.js';
 
 import type { DBAPISecret, DBConnection, DBEnvironment, DBExternalWebhook, DBTeam, IntegrationConfig, NangoAuthWebhookBodySuccess, Tags } from '@nangohq/types';
@@ -59,6 +60,7 @@ describe('Webhooks: auth notification tests', () => {
 
     beforeEach(() => {
         vi.resetAllMocks();
+        mockWebhookDenylistAllowAll();
     });
 
     it('Should not send an auth webhook if the webhook url is not present even if the auth webhook is checked', async () => {

--- a/packages/webhooks/lib/forward.unit.test.ts
+++ b/packages/webhooks/lib/forward.unit.test.ts
@@ -4,6 +4,7 @@ import { logContextGetter } from '@nangohq/logs';
 import { axiosInstance } from '@nangohq/utils';
 
 import { forwardWebhook } from './forward.js';
+import { mockWebhookDenylistAllowAll } from './helpers/setup.unit.js';
 import { TestWebhookServer } from './helpers/test.js';
 
 import type { DBAPISecret, DBEnvironment, DBExternalWebhook, DBTeam, IntegrationConfig } from '@nangohq/types';
@@ -55,6 +56,7 @@ describe('Webhooks: forward notification tests', () => {
 
     beforeEach(() => {
         vi.resetAllMocks();
+        mockWebhookDenylistAllowAll();
     });
 
     it('Should not send a forward webhook if the webhook url is not present', async () => {

--- a/packages/webhooks/lib/helpers/setup.unit.ts
+++ b/packages/webhooks/lib/helpers/setup.unit.ts
@@ -1,0 +1,11 @@
+import { vi } from 'vitest';
+
+import * as utils from '@nangohq/utils';
+
+export function mockWebhookDenylistAllowAll(): void {
+    vi.spyOn(utils, 'isBaseUrlOverrideDenied').mockReturnValue(false);
+}
+
+export function restoreWebhookDenylistMock(): void {
+    vi.mocked(utils.isBaseUrlOverrideDenied).mockRestore();
+}

--- a/packages/webhooks/lib/sync.unit.test.ts
+++ b/packages/webhooks/lib/sync.unit.test.ts
@@ -3,6 +3,7 @@ import { afterAll, beforeAll, beforeEach, describe, expect, it, vi } from 'vites
 
 import { axiosInstance, stringifyStable } from '@nangohq/utils';
 
+import { mockWebhookDenylistAllowAll } from './helpers/setup.unit.js';
 import { TestWebhookServer } from './helpers/test.js';
 import { sendSync } from './sync.js';
 
@@ -107,6 +108,7 @@ describe('Webhooks: sync notification tests', () => {
 
     beforeEach(() => {
         vi.resetAllMocks();
+        mockWebhookDenylistAllowAll();
     });
 
     it('Should not send a sync webhook if the webhook url is not present', async () => {

--- a/packages/webhooks/lib/utils.ts
+++ b/packages/webhooks/lib/utils.ts
@@ -4,7 +4,19 @@ import { isAxiosError } from 'axios';
 
 import { getRedis } from '@nangohq/kvstore';
 import { createMeteringTransport } from '@nangohq/shared';
-import { Err, Ok, axiosInstance as axios, getLogger, networkError, redactHeaders, retryFlexible, stringifyStable, userAgent } from '@nangohq/utils';
+import {
+    Err,
+    Ok,
+    axiosInstance as axios,
+    getLogger,
+    isBaseUrlOverrideDenied,
+    networkError,
+    normalizeDenylist,
+    redactHeaders,
+    retryFlexible,
+    stringifyStable,
+    userAgent
+} from '@nangohq/utils';
 
 const logger = getLogger('webhooks.utils');
 
@@ -18,6 +30,8 @@ import type { Result } from '@nangohq/utils';
 import type { AxiosError, AxiosResponse } from 'axios';
 
 export const RETRY_ATTEMPTS = envs.NANGO_WEBHOOK_RETRY_ATTEMPTS;
+
+const webhookUrlDenylist = normalizeDenylist(envs.NANGO_PROXY_BASE_URL_OVERRIDE_DENYLIST);
 
 export const NON_FORWARDABLE_HEADERS = [
     'host',
@@ -169,6 +183,11 @@ export const deliver = async ({
 
     for (const webhook of webhooks) {
         const { url, type } = webhook;
+
+        if (webhookUrlDenylist.size > 0 && isBaseUrlOverrideDenied(url, webhookUrlDenylist)) {
+            void logCtx?.warn(`Skipping webhook delivery to denied URL (${type})`);
+            continue;
+        }
 
         const filteredHeaders = filterHeaders(incomingHeaders || {});
 

--- a/packages/webhooks/lib/utils.ts
+++ b/packages/webhooks/lib/utils.ts
@@ -184,7 +184,7 @@ export const deliver = async ({
     for (const webhook of webhooks) {
         const { url, type } = webhook;
 
-        if (webhookUrlDenylist.size > 0 && isBaseUrlOverrideDenied(url, webhookUrlDenylist)) {
+        if (isBaseUrlOverrideDenied(url, webhookUrlDenylist)) {
             void logCtx?.warn(`Skipping webhook delivery to denied URL (${type})`);
             continue;
         }

--- a/packages/webhooks/lib/utils.unit.test.ts
+++ b/packages/webhooks/lib/utils.unit.test.ts
@@ -1,7 +1,8 @@
-import { afterAll, beforeAll, describe, expect, it } from 'vitest';
+import { afterAll, beforeAll, beforeEach, describe, expect, it } from 'vitest';
 
 import { stringifyStable } from '@nangohq/utils';
 
+import { mockWebhookDenylistAllowAll, restoreWebhookDenylistMock } from './helpers/setup.unit.js';
 import { TestWebhookServer } from './helpers/test.js';
 import { deliver, getHmacSignatureHeader, getSignatureHeaderUnsafe } from './utils.js';
 
@@ -59,6 +60,10 @@ describe('deliver bytes metering', () => {
         await testServer.stop();
     });
 
+    beforeEach(() => {
+        mockWebhookDenylistAllowAll();
+    });
+
     it('should fire onBytes with non-zero sent on successful POST', async () => {
         const hops: { sent: number; received: number }[] = [];
         const result = await deliver({
@@ -89,5 +94,20 @@ describe('deliver bytes metering', () => {
         for (const h of hops) {
             expect(h.sent).toBeGreaterThan(0);
         }
+    });
+
+    it('should skip denylisted webhook URLs', async () => {
+        restoreWebhookDenylistMock();
+
+        const hops: { sent: number; received: number }[] = [];
+        const result = await deliver({
+            webhooks: [{ url: 'http://169.254.169.254/webhook', type: 'primary' }],
+            body: { hello: 'world' },
+            webhookType: 'forward',
+            secret,
+            onBytes: (b) => hops.push(b)
+        });
+        expect(result.isOk()).toBe(true);
+        expect(hops.length).toBe(0);
     });
 });


### PR DESCRIPTION
Hardens validation for environment webhook URLs (primary_url, secondary_url) by applying the same host denylist used elsewhere for outbound URL configuration.

Also adds a delivery-time guard so previously saved webhook URLs that match the denylist are not called.

Changes
- Reject denylisted hosts when webhook URLs are updated via the environment webhook settings API
- Skip delivery to denylisted webhook URLs at send time
- Add integration coverage for allowed and blocked URL cases

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/NangoHQ/nango/pull/6507?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

