### PR TITLE
fix(server): proxy splat url does not match query only routes

### DIFF
--- a/packages/server/lib/controllers/proxy/allProxy.integration.test.ts
+++ b/packages/server/lib/controllers/proxy/allProxy.integration.test.ts
@@ -103,6 +103,13 @@ describe(`GET ${route}`, () => {
         });
     });
 
+    it.each(['/proxy?Param=IHaveNoPath', '/proxy/?Param=IHaveNoPath'])('should match proxy route for query-only path %s', async (path) => {
+        const res = await fetch(`${api.url}${path}`, { method: 'GET' });
+        const json = await res.json();
+
+        shouldBeProtected({ res, json });
+    });
+
     it('should use all the headers', async () => {
         const { env, apiKey } = await seeders.seedAccountEnvAndUser();
         const integration = await seeders.createConfigSeed(env, 'github', 'github');

--- a/packages/server/lib/controllers/proxy/allProxy.ts
+++ b/packages/server/lib/controllers/proxy/allProxy.ts
@@ -141,7 +141,7 @@ export const allPublicProxy = asyncWrapper<AllPublicProxy>(async (req, res, next
         const method = req.method.toUpperCase() as HTTP_METHOD;
 
         // contains the path and querystring
-        const endpoint = req.originalUrl.replace(/^\/proxy\//, '/');
+        const endpoint = req.originalUrl.replace(/^\/proxy\/?/, '/');
 
         const headers = parseHeaders(req);
 

--- a/packages/server/lib/routes.public.ts
+++ b/packages/server/lib/routes.public.ts
@@ -312,4 +312,4 @@ publicAPI.use('/v1', jsonContentTypeMiddleware);
 publicAPI.route('/v1/*splat').all(apiAuth, allPublicV1);
 
 // Proxy
-publicAPI.route('/proxy/*splat').all(apiAuth, withScope('environment:proxy'), upload.any(), allPublicProxy);
+publicAPI.route('/proxy{/*splat}').all(apiAuth, withScope('environment:proxy'), upload.any(), allPublicProxy);


### PR DESCRIPTION
<!-- Describe the problem and your solution --> 
Pathless proxy requests don't match the current splat route and therefore fail to proxy. 

[AWS IAM ](https://nango.dev/docs/api-integrations/aws-iam)for example uses routes like: https://api.nango.dev/proxy/?Action=ListUsers&Version=2010-05-08. This route fails to match the current route: '/proxy/*splat'

<!-- Issue ticket number and link (if applicable) -->
[NAN-5985: bug(server): proxy splat URL does not match pathless routes](https://linear.app/nango/issue/NAN-5985/bugserver-proxy-splat-url-does-not-match-pathless-routes)

<!-- Testing instructions (skip if just adding/editing providers) -->
Proxy a request to any endpoint without a path and notice that it routes to the provider instead of returning an HTML blob from Nango. 


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/NangoHQ/nango/pull/6508?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

