### PR TITLE
feat(usage): flip capping source from Orb to ClickHouse via percentage rollout

### DIFF
--- a/packages/usage/lib/usage.ts
+++ b/packages/usage/lib/usage.ts
@@ -34,15 +34,14 @@ const cacheKeyPrefix = 'usageV2';
 // windows against Orb produces known-bad divergence (CH biases high until 30d
 // of depth). Anchor the shadow to a clean post-backfill date.
 const SHADOW_MIN_TIMEFRAME_START = new Date('2026-06-01T00:00:00.000Z');
-// CH server-side ceiling on time-bounded billing reads (shadow + capping
-// source). Bounded much tighter than the dashboard default (30s) so an
-// abandoned query doesn't keep burning CH compute after the wall-clock
-// race resolves.
-const CH_QUERY_MAX_EXECUTION_SECONDS = 5;
+// CH server-side ceiling on shadow reads. Bounded much tighter than the
+// dashboard default (30s) so an abandoned shadow doesn't keep burning CH
+// compute after the wall-clock race resolves.
+const SHADOW_CH_MAX_EXECUTION_SECONDS = 5;
 // Wall-clock fallback set ~0.5s above the CH ceiling so CH's own timeout
 // reliably fires first → `outcome:ch_error` is the deterministic signal and
 // the local race only catches network-level wedges.
-const CH_QUERY_TIMEOUT_MS = CH_QUERY_MAX_EXECUTION_SECONDS * 1000 + 500;
+const SHADOW_TIMEOUT_MS = SHADOW_CH_MAX_EXECUTION_SECONDS * 1000 + 500;
 
 export function shouldShadow(opts: GetBillingUsageOpts | undefined): opts is GetBillingUsageOpts & { timeframe: { start: Date; end: Date } } {
     if (!envs.FLAG_BILLING_USAGE_SHADOW_CLICKHOUSE) return false;
@@ -424,9 +423,9 @@ export class UsageTracker implements IUsageTracker {
         const timeoutErr = new Error('shadow_timeout');
         let timeoutId: ReturnType<typeof setTimeout> | undefined;
         const chResult = await Promise.race<Result<BillingUsageMetrics>>([
-            this.getBillingUsageFromClickhouse(accountId, { timeframe, maxExecutionSeconds: CH_QUERY_MAX_EXECUTION_SECONDS }),
+            this.getBillingUsageFromClickhouse(accountId, { timeframe, maxExecutionSeconds: SHADOW_CH_MAX_EXECUTION_SECONDS }),
             new Promise((resolve) => {
-                timeoutId = setTimeout(() => resolve(Err(timeoutErr)), CH_QUERY_TIMEOUT_MS);
+                timeoutId = setTimeout(() => resolve(Err(timeoutErr)), SHADOW_TIMEOUT_MS);
             })
         ]);
         clearTimeout(timeoutId);
@@ -470,19 +469,8 @@ export class UsageTracker implements IUsageTracker {
             logger.warning(`capping CH cache read failed for account=${accountId}: ${stringifyError(err)}`);
         }
 
-        const timeoutErr = new Error('capping_ch_timeout');
-        let timeoutId: ReturnType<typeof setTimeout> | undefined;
-        const chResult = await Promise.race<Result<BillingUsageMetrics>>([
-            this.getClickhouse().getCurrentMonthBillingMetrics(accountId, new Date(), { maxExecutionSeconds: CH_QUERY_MAX_EXECUTION_SECONDS }),
-            new Promise((resolve) => {
-                timeoutId = setTimeout(() => resolve(Err(timeoutErr)), CH_QUERY_TIMEOUT_MS);
-            })
-        ]);
-        clearTimeout(timeoutId);
-
-        if (chResult.isErr()) {
-            return Err(chResult.error);
-        }
+        const chResult = await this.getClickhouse().getCurrentMonthBillingMetrics(accountId, new Date());
+        if (chResult.isErr()) return Err(chResult.error);
 
         await this.writeCappingCache(accountId, chResult.value);
         return Ok(chResult.value);
@@ -501,9 +489,9 @@ export class UsageTracker implements IUsageTracker {
         const timeoutErr = new Error('shadow_timeout');
         let timeoutId: ReturnType<typeof setTimeout> | undefined;
         const chResult = await Promise.race<Result<BillingUsageMetrics>>([
-            this.getClickhouse().getCurrentMonthBillingMetrics(accountId, new Date(), { maxExecutionSeconds: CH_QUERY_MAX_EXECUTION_SECONDS }),
+            this.getClickhouse().getCurrentMonthBillingMetrics(accountId, new Date(), { maxExecutionSeconds: SHADOW_CH_MAX_EXECUTION_SECONDS }),
             new Promise((resolve) => {
-                timeoutId = setTimeout(() => resolve(Err(timeoutErr)), CH_QUERY_TIMEOUT_MS);
+                timeoutId = setTimeout(() => resolve(Err(timeoutErr)), SHADOW_TIMEOUT_MS);
             })
         ]);
         clearTimeout(timeoutId);

--- a/packages/usage/lib/usage.ts
+++ b/packages/usage/lib/usage.ts
@@ -463,8 +463,9 @@ export class UsageTracker implements IUsageTracker {
         try {
             const cached = await this.redis.get(cacheKey);
             if (cached) {
+                const value = JSON.parse(cached) as BillingUsageMetrics;
                 metrics.increment(metrics.Types.BILLING_USAGE_CAPPING_CH_CACHE, 1, { hit: 'true' });
-                return Ok(JSON.parse(cached) as BillingUsageMetrics);
+                return Ok(value);
             }
         } catch (err) {
             logger.warning(`capping CH cache read failed for account=${accountId}: ${stringifyError(err)}`);

--- a/packages/usage/lib/usage.ts
+++ b/packages/usage/lib/usage.ts
@@ -87,6 +87,10 @@ export function resolveBillingUsageSource(accountId: number, requestedSource: 'c
     return respected ?? (shouldUseClickhouseFor(accountId) ? 'clickhouse' : 'orb');
 }
 
+export function resolveCappingSource(accountId: number): 'clickhouse' | 'orb' {
+    return accountId % 100 < envs.FLAG_CAPPING_CLICKHOUSE_ROLLOUT_PERCENTAGE ? 'clickhouse' : 'orb';
+}
+
 async function resolveEnvironmentNamesInBreakdown(
     usage: BillingUsageMetrics,
     breakdown: { [M in UsageMetric]?: BreakdownDimensions[M] | undefined } | undefined
@@ -354,6 +358,10 @@ export class UsageTracker implements IUsageTracker {
             });
         }
 
+        if (!opts?.timeframe && resolveCappingSource(accountId) === 'clickhouse') {
+            return this.getCappingUsageFromClickhouse(accountId);
+        }
+
         // Orb path: strip CH-only fields so they don't pollute the billing
         // client's Redis cache key. Orb itself ignores them, but the cache key
         // hashes the full opts and would miss on otherwise-identical queries.
@@ -450,6 +458,43 @@ export class UsageTracker implements IUsageTracker {
         }
     }
 
+    private async getCappingUsageFromClickhouse(accountId: number): Promise<Result<BillingUsageMetrics>> {
+        const cacheKey = `billing:usage:ch:${accountId}`;
+        try {
+            const cached = await this.redis.get(cacheKey);
+            if (cached) {
+                return Ok(JSON.parse(cached) as BillingUsageMetrics);
+            }
+        } catch (err) {
+            logger.warning(`capping CH cache read failed for account=${accountId}: ${stringifyError(err)}`);
+        }
+
+        const timeoutErr = new Error('capping_ch_timeout');
+        let timeoutId: ReturnType<typeof setTimeout> | undefined;
+        const chResult = await Promise.race<Result<BillingUsageMetrics>>([
+            this.getClickhouse().getCurrentMonthBillingMetrics(accountId, new Date(), { maxExecutionSeconds: SHADOW_CH_MAX_EXECUTION_SECONDS }),
+            new Promise((resolve) => {
+                timeoutId = setTimeout(() => resolve(Err(timeoutErr)), SHADOW_TIMEOUT_MS);
+            })
+        ]);
+        clearTimeout(timeoutId);
+
+        if (chResult.isErr()) {
+            return Err(chResult.error);
+        }
+
+        await this.writeCappingCache(accountId, chResult.value);
+        return Ok(chResult.value);
+    }
+
+    private async writeCappingCache(accountId: number, value: BillingUsageMetrics): Promise<void> {
+        try {
+            await this.redis.set(`billing:usage:ch:${accountId}`, JSON.stringify(value), { EX: envs.USAGE_BILLING_API_CACHE_TTL_SECONDS });
+        } catch (err) {
+            logger.warning(`capping CH cache write failed for account=${accountId}: ${stringifyError(err)}`);
+        }
+    }
+
     private async shadowCappingAgainstClickhouse({ accountId, orbResult }: { accountId: number; orbResult: BillingUsageMetrics }): Promise<void> {
         const start = process.hrtime.bigint();
         const timeoutErr = new Error('shadow_timeout');
@@ -467,14 +512,9 @@ export class UsageTracker implements IUsageTracker {
         metrics.distribution(metrics.Types.BILLING_USAGE_CAPPING_SHADOW_DURATION_MS, elapsedMs, { outcome });
         if (chResult.isErr()) return;
 
-        // Populate `billing:usage:ch:<accountId>` so the eventual source flip
-        // from Orb to CH doesn't cold-start every account against CH on cutover.
-        const cacheKey = `billing:usage:ch:${accountId}`;
-        try {
-            await this.redis.set(cacheKey, JSON.stringify(chResult.value), { EX: envs.USAGE_BILLING_API_CACHE_TTL_SECONDS });
-        } catch (err) {
-            logger.warning(`capping shadow CH cache write failed for account=${accountId}: ${stringifyError(err)}`);
-        }
+        // Populate the CH cache key so the eventual source flip from Orb to
+        // CH doesn't cold-start every account against CH on cutover.
+        await this.writeCappingCache(accountId, chResult.value);
 
         // Capping path covers only COUNTER metrics — connections/records read
         // from Postgres on the capping path and aren't returned by either Orb

--- a/packages/usage/lib/usage.ts
+++ b/packages/usage/lib/usage.ts
@@ -463,11 +463,13 @@ export class UsageTracker implements IUsageTracker {
         try {
             const cached = await this.redis.get(cacheKey);
             if (cached) {
+                metrics.increment(metrics.Types.BILLING_USAGE_CAPPING_CH_CACHE, 1, { hit: 'true' });
                 return Ok(JSON.parse(cached) as BillingUsageMetrics);
             }
         } catch (err) {
             logger.warning(`capping CH cache read failed for account=${accountId}: ${stringifyError(err)}`);
         }
+        metrics.increment(metrics.Types.BILLING_USAGE_CAPPING_CH_CACHE, 1, { hit: 'false' });
 
         const chResult = await this.getClickhouse().getCurrentMonthBillingMetrics(accountId, new Date());
         if (chResult.isErr()) return Err(chResult.error);

--- a/packages/usage/lib/usage.ts
+++ b/packages/usage/lib/usage.ts
@@ -34,14 +34,15 @@ const cacheKeyPrefix = 'usageV2';
 // windows against Orb produces known-bad divergence (CH biases high until 30d
 // of depth). Anchor the shadow to a clean post-backfill date.
 const SHADOW_MIN_TIMEFRAME_START = new Date('2026-06-01T00:00:00.000Z');
-// CH server-side ceiling on shadow reads. Bounded much tighter than the
-// dashboard default (30s) so an abandoned shadow doesn't keep burning CH
-// compute after the wall-clock race resolves.
-const SHADOW_CH_MAX_EXECUTION_SECONDS = 5;
+// CH server-side ceiling on time-bounded billing reads (shadow + capping
+// source). Bounded much tighter than the dashboard default (30s) so an
+// abandoned query doesn't keep burning CH compute after the wall-clock
+// race resolves.
+const CH_QUERY_MAX_EXECUTION_SECONDS = 5;
 // Wall-clock fallback set ~0.5s above the CH ceiling so CH's own timeout
 // reliably fires first → `outcome:ch_error` is the deterministic signal and
 // the local race only catches network-level wedges.
-const SHADOW_TIMEOUT_MS = SHADOW_CH_MAX_EXECUTION_SECONDS * 1000 + 500;
+const CH_QUERY_TIMEOUT_MS = CH_QUERY_MAX_EXECUTION_SECONDS * 1000 + 500;
 
 export function shouldShadow(opts: GetBillingUsageOpts | undefined): opts is GetBillingUsageOpts & { timeframe: { start: Date; end: Date } } {
     if (!envs.FLAG_BILLING_USAGE_SHADOW_CLICKHOUSE) return false;
@@ -423,9 +424,9 @@ export class UsageTracker implements IUsageTracker {
         const timeoutErr = new Error('shadow_timeout');
         let timeoutId: ReturnType<typeof setTimeout> | undefined;
         const chResult = await Promise.race<Result<BillingUsageMetrics>>([
-            this.getBillingUsageFromClickhouse(accountId, { timeframe, maxExecutionSeconds: SHADOW_CH_MAX_EXECUTION_SECONDS }),
+            this.getBillingUsageFromClickhouse(accountId, { timeframe, maxExecutionSeconds: CH_QUERY_MAX_EXECUTION_SECONDS }),
             new Promise((resolve) => {
-                timeoutId = setTimeout(() => resolve(Err(timeoutErr)), SHADOW_TIMEOUT_MS);
+                timeoutId = setTimeout(() => resolve(Err(timeoutErr)), CH_QUERY_TIMEOUT_MS);
             })
         ]);
         clearTimeout(timeoutId);
@@ -472,9 +473,9 @@ export class UsageTracker implements IUsageTracker {
         const timeoutErr = new Error('capping_ch_timeout');
         let timeoutId: ReturnType<typeof setTimeout> | undefined;
         const chResult = await Promise.race<Result<BillingUsageMetrics>>([
-            this.getClickhouse().getCurrentMonthBillingMetrics(accountId, new Date(), { maxExecutionSeconds: SHADOW_CH_MAX_EXECUTION_SECONDS }),
+            this.getClickhouse().getCurrentMonthBillingMetrics(accountId, new Date(), { maxExecutionSeconds: CH_QUERY_MAX_EXECUTION_SECONDS }),
             new Promise((resolve) => {
-                timeoutId = setTimeout(() => resolve(Err(timeoutErr)), SHADOW_TIMEOUT_MS);
+                timeoutId = setTimeout(() => resolve(Err(timeoutErr)), CH_QUERY_TIMEOUT_MS);
             })
         ]);
         clearTimeout(timeoutId);
@@ -500,9 +501,9 @@ export class UsageTracker implements IUsageTracker {
         const timeoutErr = new Error('shadow_timeout');
         let timeoutId: ReturnType<typeof setTimeout> | undefined;
         const chResult = await Promise.race<Result<BillingUsageMetrics>>([
-            this.getClickhouse().getCurrentMonthBillingMetrics(accountId, new Date(), { maxExecutionSeconds: SHADOW_CH_MAX_EXECUTION_SECONDS }),
+            this.getClickhouse().getCurrentMonthBillingMetrics(accountId, new Date(), { maxExecutionSeconds: CH_QUERY_MAX_EXECUTION_SECONDS }),
             new Promise((resolve) => {
-                timeoutId = setTimeout(() => resolve(Err(timeoutErr)), SHADOW_TIMEOUT_MS);
+                timeoutId = setTimeout(() => resolve(Err(timeoutErr)), CH_QUERY_TIMEOUT_MS);
             })
         ]);
         clearTimeout(timeoutId);

--- a/packages/usage/lib/usage.ts
+++ b/packages/usage/lib/usage.ts
@@ -727,8 +727,6 @@ export class UsageTracker implements IUsageTracker {
         if (!plan.value.orb_subscription_id) {
             return Err(new Error('orb_subscription_id_missing'));
         }
-        // No timeframe / no granularity → CH path is bypassed inside
-        // getBillingUsage, capping continues to read from Orb.
         const billingUsage: Result<BillingUsageMetrics> = await this.getBillingUsage(plan.value.orb_subscription_id, accountId);
         if (billingUsage.isErr()) {
             // Note: errors (including rate limit errors) are not being retried

--- a/packages/usage/lib/usage.unit.test.ts
+++ b/packages/usage/lib/usage.unit.test.ts
@@ -3,6 +3,7 @@ import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 import { envs } from './env.js';
 import {
     resolveBillingUsageSource,
+    resolveCappingSource,
     shouldShadow,
     shouldShadowCapping,
     shouldUseClickhouseFor,
@@ -477,5 +478,35 @@ describe('resolveBillingUsageSource', () => {
         (envs as any).FLAG_BILLING_USAGE_CLICKHOUSE_ROLLOUT_ACCOUNT_IDS = '42';
         expect(resolveBillingUsageSource(42, undefined)).toBe('clickhouse');
         expect(resolveBillingUsageSource(7, undefined)).toBe('orb');
+    });
+});
+
+describe('resolveCappingSource', () => {
+    let originalPct: number;
+    beforeEach(() => {
+        originalPct = envs.FLAG_CAPPING_CLICKHOUSE_ROLLOUT_PERCENTAGE;
+    });
+    afterEach(() => {
+        (envs as any).FLAG_CAPPING_CLICKHOUSE_ROLLOUT_PERCENTAGE = originalPct;
+    });
+
+    it('returns orb when pct = 0 (killswitch)', () => {
+        (envs as any).FLAG_CAPPING_CLICKHOUSE_ROLLOUT_PERCENTAGE = 0;
+        expect(resolveCappingSource(0)).toBe('orb');
+        expect(resolveCappingSource(99)).toBe('orb');
+    });
+
+    it('returns clickhouse for every account when pct >= 100', () => {
+        (envs as any).FLAG_CAPPING_CLICKHOUSE_ROLLOUT_PERCENTAGE = 100;
+        expect(resolveCappingSource(0)).toBe('clickhouse');
+        expect(resolveCappingSource(99)).toBe('clickhouse');
+    });
+
+    it('buckets accounts by accountId % 100 < pct', () => {
+        (envs as any).FLAG_CAPPING_CLICKHOUSE_ROLLOUT_PERCENTAGE = 25;
+        expect(resolveCappingSource(24)).toBe('clickhouse');
+        expect(resolveCappingSource(25)).toBe('orb');
+        expect(resolveCappingSource(124)).toBe('clickhouse');
+        expect(resolveCappingSource(125)).toBe('orb');
     });
 });

--- a/packages/utils/lib/environment/parse.ts
+++ b/packages/utils/lib/environment/parse.ts
@@ -337,6 +337,7 @@ export const ENVS = z.object({
     FLAG_BILLING_USAGE_CAPPING_SHADOW_CLICKHOUSE_PERCENTAGE: z.coerce.number().int().min(0).max(100).optional().default(0),
     FLAG_BILLING_USAGE_CLICKHOUSE_ROLLOUT_ACCOUNT_IDS: z.string().optional().default(''),
     FLAG_BILLING_USAGE_CLICKHOUSE_ROLLOUT_PERCENTAGE: z.coerce.number().int().min(0).max(100).optional().default(0),
+    FLAG_CAPPING_CLICKHOUSE_ROLLOUT_PERCENTAGE: z.coerce.number().int().min(0).max(100).optional().default(0),
 
     // --- Third parties
     // AWS

--- a/packages/utils/lib/telemetry/metrics.ts
+++ b/packages/utils/lib/telemetry/metrics.ts
@@ -155,6 +155,7 @@ export enum Types {
     BILLING_USAGE_CAPPING_SHADOW_DIVERGENCE = 'nango.billing.usage.capping.shadow.divergence',
     BILLING_USAGE_CAPPING_SHADOW_ONE_SIDED = 'nango.billing.usage.capping.shadow.one_sided',
     BILLING_USAGE_CAPPING_SHADOW_DURATION_MS = 'nango.billing.usage.capping.shadow.duration_ms',
+    BILLING_USAGE_CAPPING_CH_CACHE = 'nango.billing.usage.capping.ch.cache',
 
     USAGE_IS_CAPPED = 'nango.capping.isCapped',
 


### PR DESCRIPTION
## Summary

- Adds `FLAG_CAPPING_CLICKHOUSE_ROLLOUT_PERCENTAGE` (0..100, default 0). When `account_id % 100 < pct`, the no-timeframe `getBillingUsage` path reads from ClickHouse via `billing:usage:ch:<accountId>` instead of Orb. Cache key + 6h TTL stay shared with the existing shadow writer (NAN-5953) via a new `writeCappingCache` helper, so cutover hits warm cache.
- CH error propagates up — no runtime fallback to Orb. The env flag is the killswitch: set back to 0 and redeploy to revert.

## Rollout plan

**Do not deploy this PR's env flag bump until the capping shadow has run for at least another 24 hours** ([NAN-5953](https://linear.app/nango/issue/NAN-5953) — 100% in production since 2026-06-15). Once the shadow has accumulated a full additional day at 100%, do a final review of `nango.billing.usage.capping.shadow.*` (divergence, one_sided, duration_ms) against the [dashboard](https://us3.datadoghq.com/notebook/291677/capping-shadow-divergence-report) before flipping the source.

After the final check, ramp via separate `nango-environments` PRs: 5 → 25 → 50 → 100, same cadence as the shadow rollout. Monitor `revalidate` error rate at each step.

## Follow-ups in [NAN-5955](https://linear.app/nango/issue/NAN-5955)

Held back from this PR to keep the diff focused on the source flip:

- Remove the Orb call from the capping path entirely (once CH is at 100% for ~1 week as a soft safety net).
- Drop the 6h inner TTL — pointless once Orb is gone; CH can be queried fresh on revalidate.
- **Consolidate the CH cache read/write into `UsageCache`** — the new `writeCappingCache` helper + raw `redis.get/set` in `getCappingUsageFromClickhouse` are intentionally minimal here so the consolidation lands as one clean refactor in NAN-5955, not piecemeal.

## Test plan

- [x] `ts-build` clean
- [x] 33 unit tests pass (`packages/usage/lib/usage.unit.test.ts`)
- [x] New `resolveCappingSource` covered at boundaries (killswitch, full, mid-bucket with wraparound)
- [ ] Smoke test against `dev` after deploy (flag at 100%) — confirm capping cache stays correct
- [ ] After ramp at staging at 100%, confirm `usageV2:*` cache entries match the CH source for a sample account