### PR TITLE
chore(metering): remove kms dependency

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -39116,7 +39116,6 @@
                 "@aws-sdk/client-s3": "3.993.0",
                 "@nangohq/billing": "file:../billing",
                 "@nangohq/database": "file:../database",
-                "@nangohq/kms": "file:../kms",
                 "@nangohq/kvstore": "file:../kvstore",
                 "@nangohq/pubsub": "file:../pubsub",
                 "@nangohq/records": "file:../records",

--- a/packages/metering/lib/processors/usage.ts
+++ b/packages/metering/lib/processors/usage.ts
@@ -1,4 +1,5 @@
 import { billing } from '@nangohq/billing';
+import db from '@nangohq/database';
 import { Subscriber } from '@nangohq/pubsub';
 import { connectionService } from '@nangohq/shared';
 import { Err, Ok, metrics, report, stringifyError } from '@nangohq/utils';
@@ -44,11 +45,15 @@ export class UsageProcessor {
             switch (event.type) {
                 case 'usage.monthly_active_records': {
                     const { connectionId, environmentId, environmentName, integrationId, accountId, syncId, model } = event.payload.properties;
-                    const connection = await connectionService.getConnection(connectionId, integrationId, environmentId);
-                    if (!connection.response) {
+                    const connection = await connectionService.checkIfConnectionExists(db.knex, {
+                        connectionId,
+                        providerConfigKey: integrationId,
+                        environmentId
+                    });
+                    if (!connection) {
                         return Err(`Connection ${connectionId} not found`);
                     }
-                    if (connection.response.created_at > new Date(Date.now() - 30 * DAY_IN_MS)) {
+                    if (connection.created_at > new Date(Date.now() - 30 * DAY_IN_MS)) {
                         return Ok(undefined); // Skip MAR for connections younger than 30 days
                     }
                     const mar = event.payload.value;

--- a/packages/metering/package.json
+++ b/packages/metering/package.json
@@ -17,7 +17,6 @@
         "@aws-sdk/client-s3": "3.993.0",
         "@nangohq/billing": "file:../billing",
         "@nangohq/database": "file:../database",
-        "@nangohq/kms": "file:../kms",
         "@nangohq/kvstore": "file:../kvstore",
         "@nangohq/pubsub": "file:../pubsub",
         "@nangohq/records": "file:../records",


### PR DESCRIPTION
metering only needs to check a connection creation date so no need to decrypt anything: switching from using `getConnection` to `checkIfConnectionExists` and remove dependency on kms



<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/NangoHQ/nango/pull/6520?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

