### PR TITLE
revert: "revert: "fix(redis): harden redis usage to tolerate connection issues""

### DIFF
--- a/docs/guides/platform/self-hosting.mdx
+++ b/docs/guides/platform/self-hosting.mdx
@@ -253,6 +253,35 @@ Special characters in `RECORDS_DATABASE_URL` must be URL encoded. If it is not s
 Deploying with Render or Heroku automatically generates a persistent database connected to your Nango instance.
 </Tip>
 
+### External Redis
+
+The bundled Redis is fine for local use but not for production. Connect Nango to an external Redis (or Valkey) with either a full URL or discrete variables:
+
+```sh
+NANGO_REDIS_URL=rediss://:<password>@<host>:<port>
+# or
+NANGO_REDIS_HOST=<host>
+NANGO_REDIS_PORT=<port>
+NANGO_REDIS_AUTH=<password>
+```
+
+Use the `rediss://` scheme (or discrete variables, which default to TLS) to enable in-transit encryption.
+
+#### IAM / short-lived token authentication
+
+Managed Redis with IAM authentication (for example GCP Memorystore for Valkey) uses a short-lived token as the password and requires the token to be refreshed before it expires. Instead of a static `NANGO_REDIS_AUTH`, point Nango at a file that an external process (such as a sidecar) keeps up to date:
+
+```sh
+NANGO_REDIS_HOST=<host>
+NANGO_REDIS_PORT=<port>
+NANGO_REDIS_AUTH_TOKEN_FILE=/path/to/token   # re-read on every (re)connect
+NANGO_REDIS_USERNAME=<username>              # optional; defaults to "default"
+```
+
+Nango reads the token file on every connection and reconnection, so a rotated token is always picked up without a restart. This is cloud-agnostic: anything that writes the current token to the file works. The writer must update the file atomically — write a temporary file and `rename()` it into place — so a reconnect never reads a half-written token and fails authentication. When `NANGO_REDIS_AUTH_TOKEN_FILE` is set, do not embed credentials in `NANGO_REDIS_URL`.
+
+The runner boundary has the same set of variables prefixed with `NANGO_CUSTOMER_REDIS_` (for example `NANGO_CUSTOMER_REDIS_AUTH_TOKEN_FILE`); it falls back to the system Redis when unset.
+
 ### Securing your instance
 
 #### Proxy base URL override hardening

--- a/docs/llms-full.txt
+++ b/docs/llms-full.txt
@@ -6604,6 +6604,35 @@ Special characters in `RECORDS_DATABASE_URL` must be URL encoded. If it is not s
 Deploying with Render or Heroku automatically generates a persistent database connected to your Nango instance.
 </Tip>
 
+### External Redis
+
+The bundled Redis is fine for local use but not for production. Connect Nango to an external Redis (or Valkey) with either a full URL or discrete variables:
+
+```sh
+NANGO_REDIS_URL=rediss://:<password>@<host>:<port>
+# or
+NANGO_REDIS_HOST=<host>
+NANGO_REDIS_PORT=<port>
+NANGO_REDIS_AUTH=<password>
+```
+
+Use the `rediss://` scheme (or discrete variables, which default to TLS) to enable in-transit encryption.
+
+#### IAM / short-lived token authentication
+
+Managed Redis with IAM authentication (for example GCP Memorystore for Valkey) uses a short-lived token as the password and requires the token to be refreshed before it expires. Instead of a static `NANGO_REDIS_AUTH`, point Nango at a file that an external process (such as a sidecar) keeps up to date:
+
+```sh
+NANGO_REDIS_HOST=<host>
+NANGO_REDIS_PORT=<port>
+NANGO_REDIS_AUTH_TOKEN_FILE=/path/to/token   # re-read on every (re)connect
+NANGO_REDIS_USERNAME=<username>              # optional; defaults to "default"
+```
+
+Nango reads the token file on every connection and reconnection, so a rotated token is always picked up without a restart. This is cloud-agnostic: anything that writes the current token to the file works. The writer must update the file atomically — write a temporary file and `rename()` it into place — so a reconnect never reads a half-written token and fails authentication. When `NANGO_REDIS_AUTH_TOKEN_FILE` is set, do not embed credentials in `NANGO_REDIS_URL`.
+
+The runner boundary has the same set of variables prefixed with `NANGO_CUSTOMER_REDIS_` (for example `NANGO_CUSTOMER_REDIS_AUTH_TOKEN_FILE`); it falls back to the system Redis when unset.
+
 ### Securing your instance
 
 #### Proxy base URL override hardening

--- a/package-lock.json
+++ b/package-lock.json
@@ -3261,40 +3261,6 @@
             "integrity": "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==",
             "license": "MIT"
         },
-        "node_modules/@emnapi/core": {
-            "version": "1.9.2",
-            "resolved": "https://registry.npmjs.org/@emnapi/core/-/core-1.9.2.tgz",
-            "integrity": "sha512-UC+ZhH3XtczQYfOlu3lNEkdW/p4dsJ1r/bP7H8+rhao3TTTMO1ATq/4DdIi23XuGoFY+Cz0JmCbdVl0hz9jZcA==",
-            "dev": true,
-            "license": "MIT",
-            "optional": true,
-            "dependencies": {
-                "@emnapi/wasi-threads": "1.2.1",
-                "tslib": "^2.4.0"
-            }
-        },
-        "node_modules/@emnapi/runtime": {
-            "version": "1.9.2",
-            "resolved": "https://registry.npmjs.org/@emnapi/runtime/-/runtime-1.9.2.tgz",
-            "integrity": "sha512-3U4+MIWHImeyu1wnmVygh5WlgfYDtyf0k8AbLhMFxOipihf6nrWC4syIm/SwEeec0mNSafiiNnMJwbza/Is6Lw==",
-            "dev": true,
-            "license": "MIT",
-            "optional": true,
-            "dependencies": {
-                "tslib": "^2.4.0"
-            }
-        },
-        "node_modules/@emnapi/wasi-threads": {
-            "version": "1.2.1",
-            "resolved": "https://registry.npmjs.org/@emnapi/wasi-threads/-/wasi-threads-1.2.1.tgz",
-            "integrity": "sha512-uTII7OYF+/Mes/MrcIOYp5yOtSMLBWSIoLPpcgwipoiKbli6k322tcoFsxoIIxPDqW01SQGAgko4EzZi2BNv2w==",
-            "dev": true,
-            "license": "MIT",
-            "optional": true,
-            "dependencies": {
-                "tslib": "^2.4.0"
-            }
-        },
         "node_modules/@emotion/babel-plugin": {
             "version": "11.13.5",
             "resolved": "https://registry.npmjs.org/@emotion/babel-plugin/-/babel-plugin-11.13.5.tgz",
@@ -13952,50 +13918,75 @@
             "license": "MIT"
         },
         "node_modules/@redis/bloom": {
-            "version": "1.2.0",
+            "version": "5.12.1",
+            "resolved": "https://registry.npmjs.org/@redis/bloom/-/bloom-5.12.1.tgz",
+            "integrity": "sha512-PUUfv+ms7jgPSBVoo/DN4AkPHj4D5TZSd6SbJX7egzBplkYUcKmHRE8RKia7UtZ8bSQbLguLvxVO+asKtQfZWA==",
             "license": "MIT",
+            "engines": {
+                "node": ">= 18.19.0"
+            },
             "peerDependencies": {
-                "@redis/client": "^1.0.0"
+                "@redis/client": "^5.12.1"
             }
         },
         "node_modules/@redis/client": {
-            "version": "1.5.14",
+            "version": "5.12.1",
+            "resolved": "https://registry.npmjs.org/@redis/client/-/client-5.12.1.tgz",
+            "integrity": "sha512-7aPGWeqA3uFm43o19umzdl16CEjK/JQGtSXVPevplTaOU3VJA/rseBC1QvYUz9lLDIMBimc4SW/zrW4S89BaCA==",
             "license": "MIT",
             "dependencies": {
-                "cluster-key-slot": "1.1.2",
-                "generic-pool": "3.9.0",
-                "yallist": "4.0.0"
+                "cluster-key-slot": "1.1.2"
             },
             "engines": {
-                "node": ">=14"
-            }
-        },
-        "node_modules/@redis/graph": {
-            "version": "1.1.1",
-            "license": "MIT",
+                "node": ">= 18.19.0"
+            },
             "peerDependencies": {
-                "@redis/client": "^1.0.0"
+                "@node-rs/xxhash": "^1.1.0",
+                "@opentelemetry/api": ">=1 <2"
+            },
+            "peerDependenciesMeta": {
+                "@node-rs/xxhash": {
+                    "optional": true
+                },
+                "@opentelemetry/api": {
+                    "optional": true
+                }
             }
         },
         "node_modules/@redis/json": {
-            "version": "1.0.6",
+            "version": "5.12.1",
+            "resolved": "https://registry.npmjs.org/@redis/json/-/json-5.12.1.tgz",
+            "integrity": "sha512-eOze75esLve4vfqDel7aMX08CNaiLLQS2fV8mpRN9NxPe1rVR4vQyYiW/OgtGUysF6QOr9ANhfxABKNOJfXdKg==",
             "license": "MIT",
+            "engines": {
+                "node": ">= 18.19.0"
+            },
             "peerDependencies": {
-                "@redis/client": "^1.0.0"
+                "@redis/client": "^5.12.1"
             }
         },
         "node_modules/@redis/search": {
-            "version": "1.1.6",
+            "version": "5.12.1",
+            "resolved": "https://registry.npmjs.org/@redis/search/-/search-5.12.1.tgz",
+            "integrity": "sha512-ItlxbxC9cKI6IU1TLWoczwJCRb6TdmkEpWv05UrPawqaAnWGRu3rcIqsc5vN483T2fSociuyV1UkWIL5I4//2w==",
             "license": "MIT",
+            "engines": {
+                "node": ">= 18.19.0"
+            },
             "peerDependencies": {
-                "@redis/client": "^1.0.0"
+                "@redis/client": "^5.12.1"
             }
         },
         "node_modules/@redis/time-series": {
-            "version": "1.0.5",
+            "version": "5.12.1",
+            "resolved": "https://registry.npmjs.org/@redis/time-series/-/time-series-5.12.1.tgz",
+            "integrity": "sha512-c6JL6E3EcZJuNqKFz+KM+l9l5mpcQiKvTwgA3blt5glWJ8hjDk0yeHN3beE/MpqYIQ8UEX44ItQzgkE/gCBELQ==",
             "license": "MIT",
+            "engines": {
+                "node": ">= 18.19.0"
+            },
             "peerDependencies": {
-                "@redis/client": "^1.0.0"
+                "@redis/client": "^5.12.1"
             }
         },
         "node_modules/@redocly/ajv": {
@@ -20860,6 +20851,8 @@
         },
         "node_modules/cluster-key-slot": {
             "version": "1.1.2",
+            "resolved": "https://registry.npmjs.org/cluster-key-slot/-/cluster-key-slot-1.1.2.tgz",
+            "integrity": "sha512-RMr0FhtfXemyinomL4hrWcYJxmX6deFdCxpJzhDttxgO1+bcCnkk+9drydLVDmAMG7NE6aN/fl4F7ucU/90gAA==",
             "license": "Apache-2.0",
             "engines": {
                 "node": ">=0.10.0"
@@ -25062,13 +25055,6 @@
             },
             "engines": {
                 "node": ">=18"
-            }
-        },
-        "node_modules/generic-pool": {
-            "version": "3.9.0",
-            "license": "MIT",
-            "engines": {
-                "node": ">= 4"
             }
         },
         "node_modules/gensync": {
@@ -32075,18 +32061,19 @@
             }
         },
         "node_modules/redis": {
-            "version": "4.6.13",
+            "version": "5.12.1",
+            "resolved": "https://registry.npmjs.org/redis/-/redis-5.12.1.tgz",
+            "integrity": "sha512-LDsoVvb/CpoV9EN3FXvgvSHNJWuCIzl9MiO3ppOevuGLpSGJhwfQjpEwfFJcQvNSddHADDdZaWx0HnmMxRXG7g==",
             "license": "MIT",
-            "workspaces": [
-                "./packages/*"
-            ],
             "dependencies": {
-                "@redis/bloom": "1.2.0",
-                "@redis/client": "1.5.14",
-                "@redis/graph": "1.1.1",
-                "@redis/json": "1.0.6",
-                "@redis/search": "1.1.6",
-                "@redis/time-series": "1.0.5"
+                "@redis/bloom": "5.12.1",
+                "@redis/client": "5.12.1",
+                "@redis/json": "5.12.1",
+                "@redis/search": "5.12.1",
+                "@redis/time-series": "5.12.1"
+            },
+            "engines": {
+                "node": ">= 18.19.0"
             }
         },
         "node_modules/redoc": {
@@ -38709,7 +38696,7 @@
                 "express": "5.1.0",
                 "get-port": "7.1.0",
                 "rate-limiter-flexible": "5.0.3",
-                "redis": "4.6.13",
+                "redis": "5.12.1",
                 "zod": "4.0.5"
             },
             "devDependencies": {
@@ -38812,9 +38799,10 @@
             "version": "1.0.0",
             "dependencies": {
                 "@nangohq/utils": "file:../utils",
-                "redis": "4.6.13"
+                "redis": "5.12.1"
             },
             "devDependencies": {
+                "testcontainers": "11.14.0",
                 "vitest": "4.1.8"
             }
         },
@@ -39547,7 +39535,7 @@
                 "passport-local": "1.0.0",
                 "qs": "6.15.0",
                 "rate-limiter-flexible": "5.0.3",
-                "redis": "4.6.13",
+                "redis": "5.12.1",
                 "semver": "7.6.3",
                 "serialize-error": "11.0.3",
                 "simple-oauth2": "5.1.0",

--- a/packages/jobs/lib/runner/render.ts
+++ b/packages/jobs/lib/runner/render.ts
@@ -5,7 +5,8 @@ import { RateLimiterMemory, RateLimiterRedis } from 'rate-limiter-flexible';
 import { createClient } from 'redis';
 
 import { waitUntilHealthy } from '@nangohq/fleet';
-import { getPersistAPIUrl, getProvidersUrl, getRedisUrl } from '@nangohq/shared';
+import { getRedisClientOptions, getRedisUrl } from '@nangohq/kvstore';
+import { getPersistAPIUrl, getProvidersUrl } from '@nangohq/shared';
 import { Err, Ok, getLogger } from '@nangohq/utils';
 
 import { RenderAPI } from './render.api.js';
@@ -222,29 +223,14 @@ const serviceCreationThrottler = await (async () => {
     };
     const url = getRedisUrl();
     if (url) {
-        const isExternal = url.startsWith('rediss://');
-        const socket = isExternal
-            ? {
-                  reconnectStrategy: (retries: number) => Math.min(retries * 200, 2000),
-                  connectTimeout: 10_000,
-                  tls: true,
-                  servername: new URL(url).hostname,
-                  keepAlive: 60_000
-              }
-            : {};
-        const redisClient = await createClient({
-            url: url,
-            disableOfflineQueue: true,
-            pingInterval: 30_000,
-            socket
-        }).connect();
+        const redisClient = await createClient(getRedisClientOptions(url)).connect();
         redisClient.on('error', (err) => {
             logger.error(`Redis (rate-limiter) error: ${err}`);
         });
         if (redisClient) {
             return new CombinedThrottler([
-                new RateLimiterRedis({ storeClient: redisClient, ...minuteThrottlerOpts }),
-                new RateLimiterRedis({ storeClient: redisClient, ...hourThrottlerOpts })
+                new RateLimiterRedis({ storeClient: redisClient, useRedisPackage: true, ...minuteThrottlerOpts }),
+                new RateLimiterRedis({ storeClient: redisClient, useRedisPackage: true, ...hourThrottlerOpts })
             ]);
         }
     }

--- a/packages/jobs/package.json
+++ b/packages/jobs/package.json
@@ -40,7 +40,7 @@
         "express": "5.1.0",
         "get-port": "7.1.0",
         "rate-limiter-flexible": "5.0.3",
-        "redis": "4.6.13",
+        "redis": "5.12.1",
         "zod": "4.0.5"
     },
     "devDependencies": {

--- a/packages/kvstore/lib/Locking.ts
+++ b/packages/kvstore/lib/Locking.ts
@@ -1,5 +1,3 @@
-import { stringifyError } from '@nangohq/utils';
-
 import type { KVStore } from './KVStore.js';
 
 export interface Lock {
@@ -40,7 +38,7 @@ export class Locking {
         try {
             await this.store.set(key, '1', { canOverride: false, ttlMs: ttlMs });
         } catch (err) {
-            throw new Error(`Failed to acquire lock for key: ${key} ${stringifyError(err)}`);
+            throw new Error(`Failed to acquire lock for key: ${key}`, { cause: err });
         }
         return { key };
     }
@@ -52,19 +50,14 @@ export class Locking {
     }
 
     public async release(lock: Lock): Promise<void> {
-        await this.store.delete(lock.key);
+        try {
+            await this.store.delete(lock.key);
+        } catch (err) {
+            throw new Error(`Failed to release lock for key: ${lock.key}`, { cause: err });
+        }
     }
 
     public async hasLock(key: string): Promise<boolean> {
         return await this.store.exists(key);
-    }
-
-    public async withLock<T>(key: string, ttlMs: number, acquisitionTimeoutMs: number, fn: () => Promise<T>): Promise<T> {
-        const lock = await this.tryAcquire(key, ttlMs, acquisitionTimeoutMs);
-        try {
-            return await fn();
-        } finally {
-            await this.release(lock);
-        }
     }
 }

--- a/packages/kvstore/lib/RedisStore.ts
+++ b/packages/kvstore/lib/RedisStore.ts
@@ -1,5 +1,5 @@
 import type { DeleteIfValueEqualsWithCompanionArgs, KVStore, SetIfValueEqualsWithCompanionArgs, SetNxWithCompanionArgs } from './KVStore.js';
-import type { RedisClientType } from 'redis';
+import type { NangoRedisClient } from './redisClient.js';
 
 /** Atomically refresh TTL only if the current value still matches (same-owner lock refresh). */
 const COMPARE_AND_SET = `
@@ -60,9 +60,9 @@ return 1
 `;
 
 export class RedisKVStore implements KVStore {
-    protected client: RedisClientType;
+    protected client: NangoRedisClient;
 
-    constructor(client: RedisClientType) {
+    constructor(client: NangoRedisClient) {
         this.client = client;
     }
 

--- a/packages/kvstore/lib/RedisStore.ts
+++ b/packages/kvstore/lib/RedisStore.ts
@@ -152,14 +152,17 @@ export class RedisKVStore implements KVStore {
             multi.pExpire(key, opts.ttlMs);
         }
         const [count] = await multi.exec();
-        return count as number;
+        return Number(count);
     }
 
     public async *scan(pattern: string): AsyncGenerator<string> {
-        for await (const key of this.client.scanIterator({
+        // node-redis v5 scanIterator yields a batch of keys per iteration (not a single key).
+        for await (const keys of this.client.scanIterator({
             MATCH: pattern
         })) {
-            yield key;
+            for (const key of keys) {
+                yield key;
+            }
         }
     }
 }

--- a/packages/kvstore/lib/index.ts
+++ b/packages/kvstore/lib/index.ts
@@ -4,9 +4,10 @@ import { FeatureFlags } from './FeatureFlags.js';
 import { InMemoryKVStore } from './InMemoryStore.js';
 import { Locking } from './Locking.js';
 import { RedisKVStore } from './RedisStore.js';
-import { envs } from './env.js';
+import { getCustomerRedisUrl, getRedisClientOptions, getRedisUrl } from './redisClient.js';
 
 import type { KVStore } from './KVStore.js';
+import type { RedisBoundary } from './redisClient.js';
 import type { RedisClientType } from 'redis';
 
 export { InMemoryKVStore } from './InMemoryStore.js';
@@ -14,40 +15,31 @@ export { FeatureFlags } from './FeatureFlags.js';
 export { RedisKVStore } from './RedisStore.js';
 export type { DeleteIfValueEqualsWithCompanionArgs, KVStore, SetIfValueEqualsWithCompanionArgs, SetNxWithCompanionArgs } from './KVStore.js';
 export { type Lock, Locking } from './Locking.js';
+export { type RedisBoundary, getCustomerRedisUrl, getRedisClientOptions, getRedisUrl } from './redisClient.js';
 
-type KvBoundary = 'system' | 'customer';
+type KvBoundary = RedisBoundary;
 
 // Those getters can be accessed at any point so we store the promise to avoid race condition
 // Not my best code
 const mapRedis = new Map<string, RedisClientType>();
-export async function getRedis(url: string): Promise<RedisClientType> {
-    if (mapRedis.has(url)) {
-        return mapRedis.get(url)!;
-    }
-    const isExternal = url.startsWith('rediss://');
-    const socket = isExternal
-        ? {
-              reconnectStrategy: (retries: number) => Math.min(retries * 200, 2000),
-              connectTimeout: 10_000,
-              tls: true,
-              servername: new URL(url).hostname,
-              keepAlive: 60_000
-          }
-        : {};
 
-    const redis = createClient({
-        url: url,
-        disableOfflineQueue: true,
-        pingInterval: 30_000,
-        socket
-    });
+function redisClientCacheKey(url: string, boundary: RedisBoundary): string {
+    return `${boundary}:${url}`;
+}
+
+export async function getRedis(url: string, boundary: RedisBoundary = 'system'): Promise<RedisClientType> {
+    const cacheKey = redisClientCacheKey(url, boundary);
+    if (mapRedis.has(cacheKey)) {
+        return mapRedis.get(cacheKey)!;
+    }
+    const redis = createClient(getRedisClientOptions(url, boundary));
     redis.on('error', (err: Error) => {
         // TODO: report error
         console.error(`Redis (kvstore) error: ${err}`);
     });
 
     await redis.connect();
-    mapRedis.set(url, redis as RedisClientType);
+    mapRedis.set(cacheKey, redis as RedisClientType);
     return redis as RedisClientType;
 }
 
@@ -64,42 +56,17 @@ export async function destroy() {
     );
 }
 
-const mapRedisUrl = new Map<KvBoundary, string | undefined>();
-mapRedisUrl.set('system', getRedisUrl());
-mapRedisUrl.set('customer', getCustomerRedisUrl() || getRedisUrl());
-
-function getRedisUrl(): string | undefined {
-    const url = envs.NANGO_REDIS_URL;
-    if (url) {
-        return url;
-    }
-    const endpoint = envs.NANGO_REDIS_HOST;
-    const port = envs.NANGO_REDIS_PORT || 6379;
-    const auth = envs.NANGO_REDIS_AUTH;
-    if (endpoint && port && auth) {
-        return `rediss://:${auth}@${endpoint}:${port}`;
-    }
-    return undefined;
-}
-
-function getCustomerRedisUrl(): string | undefined {
-    const url = envs.NANGO_CUSTOMER_REDIS_URL;
-    if (url) {
-        return url;
-    }
-    const endpoint = envs.NANGO_CUSTOMER_REDIS_HOST;
-    const port = envs.NANGO_CUSTOMER_REDIS_PORT || 6379;
-    const auth = envs.NANGO_CUSTOMER_REDIS_AUTH;
-    if (endpoint && port && auth) {
-        return `rediss://:${auth}@${endpoint}:${port}`;
-    }
-    return undefined;
-}
+// Resolve the URL and its boundary once. When the customer boundary is not
+// configured it falls back to the system URL (and system credentials).
+const mapRedisConfig = new Map<KvBoundary, { url: string | undefined; boundary: RedisBoundary }>();
+mapRedisConfig.set('system', { url: getRedisUrl(), boundary: 'system' });
+const customerRedisUrl = getCustomerRedisUrl();
+mapRedisConfig.set('customer', customerRedisUrl ? { url: customerRedisUrl, boundary: 'customer' } : { url: getRedisUrl(), boundary: 'system' });
 
 async function createKVStore(usage: KvBoundary = 'system'): Promise<KVStore> {
-    const url = mapRedisUrl.get(usage);
-    if (url) {
-        const store = new RedisKVStore(await getRedis(url));
+    const config = mapRedisConfig.get(usage);
+    if (config?.url) {
+        const store = new RedisKVStore(await getRedis(config.url, config.boundary));
         return store;
     }
     return new InMemoryKVStore();

--- a/packages/kvstore/lib/index.ts
+++ b/packages/kvstore/lib/index.ts
@@ -7,27 +7,26 @@ import { RedisKVStore } from './RedisStore.js';
 import { getCustomerRedisUrl, getRedisClientOptions, getRedisUrl } from './redisClient.js';
 
 import type { KVStore } from './KVStore.js';
-import type { RedisBoundary } from './redisClient.js';
-import type { RedisClientType } from 'redis';
+import type { NangoRedisClient, RedisBoundary } from './redisClient.js';
 
 export { InMemoryKVStore } from './InMemoryStore.js';
 export { FeatureFlags } from './FeatureFlags.js';
 export { RedisKVStore } from './RedisStore.js';
 export type { DeleteIfValueEqualsWithCompanionArgs, KVStore, SetIfValueEqualsWithCompanionArgs, SetNxWithCompanionArgs } from './KVStore.js';
 export { type Lock, Locking } from './Locking.js';
-export { type RedisBoundary, getCustomerRedisUrl, getRedisClientOptions, getRedisUrl } from './redisClient.js';
+export { type NangoRedisClient, type RedisBoundary, getCustomerRedisUrl, getRedisClientOptions, getRedisUrl } from './redisClient.js';
 
 type KvBoundary = RedisBoundary;
 
 // Those getters can be accessed at any point so we store the promise to avoid race condition
 // Not my best code
-const mapRedis = new Map<string, RedisClientType>();
+const mapRedis = new Map<string, NangoRedisClient>();
 
 function redisClientCacheKey(url: string, boundary: RedisBoundary): string {
     return `${boundary}:${url}`;
 }
 
-export async function getRedis(url: string, boundary: RedisBoundary = 'system'): Promise<RedisClientType> {
+export async function getRedis(url: string, boundary: RedisBoundary = 'system'): Promise<NangoRedisClient> {
     const cacheKey = redisClientCacheKey(url, boundary);
     if (mapRedis.has(cacheKey)) {
         return mapRedis.get(cacheKey)!;
@@ -39,8 +38,8 @@ export async function getRedis(url: string, boundary: RedisBoundary = 'system'):
     });
 
     await redis.connect();
-    mapRedis.set(cacheKey, redis as RedisClientType);
-    return redis as RedisClientType;
+    mapRedis.set(cacheKey, redis);
+    return redis;
 }
 
 export async function destroy() {

--- a/packages/kvstore/lib/redisClient.integration.test.ts
+++ b/packages/kvstore/lib/redisClient.integration.test.ts
@@ -39,15 +39,13 @@ describe('getRedisClientOptions static auth', () => {
 
     it('is rejected by the server when no password is supplied', async () => {
         const url = `redis://${host}:${port}`;
-        const client = createClient(getRedisClientOptions(url));
-        client.on('error', () => {
-            // swallow the expected NOAUTH error event
+        // RESP3 sends AUTH inside HELLO during handshake, so a missing password
+        // fails at connect time (not on the first command). Disable reconnect so
+        // the client rejects immediately instead of retrying until timeout.
+        const client = createClient({
+            ...getRedisClientOptions(url),
+            socket: { reconnectStrategy: () => false }
         });
-        await client.connect();
-        try {
-            await expect(client.get('k')).rejects.toThrow(/NOAUTH/i);
-        } finally {
-            client.destroy();
-        }
+        await expect(client.connect()).rejects.toThrow(/NOAUTH/i);
     });
 });

--- a/packages/kvstore/lib/redisClient.integration.test.ts
+++ b/packages/kvstore/lib/redisClient.integration.test.ts
@@ -1,0 +1,53 @@
+import { createClient } from 'redis';
+import { GenericContainer } from 'testcontainers';
+import { afterAll, beforeAll, describe, expect, it } from 'vitest';
+
+import { getRedisClientOptions } from './redisClient.js';
+
+import type { StartedTestContainer } from 'testcontainers';
+
+// Backward-compatibility: the static-auth path (no token file) must keep working
+// against a password-protected Redis under node-redis v5. The shared integration
+// Redis has no password, so this spins up its own `requirepass` instance.
+const PASSWORD = 'super-secret-pass';
+
+describe('getRedisClientOptions static auth', () => {
+    let container: StartedTestContainer;
+    let host: string;
+    let port: number;
+
+    beforeAll(async () => {
+        container = await new GenericContainer('redis:8.0.4-alpine').withExposedPorts(6379).withCommand(['redis-server', '--requirepass', PASSWORD]).start();
+        host = container.getHost();
+        port = container.getMappedPort(6379);
+    }, 60_000);
+
+    afterAll(async () => {
+        await container?.stop();
+    });
+
+    it('authenticates with a password-only url (requirepass) and runs commands', async () => {
+        const url = `redis://:${PASSWORD}@${host}:${port}`;
+        const client = await createClient(getRedisClientOptions(url)).connect();
+        try {
+            await client.set('k', 'v');
+            expect(await client.get('k')).toBe('v');
+        } finally {
+            await client.disconnect();
+        }
+    });
+
+    it('is rejected by the server when no password is supplied', async () => {
+        const url = `redis://${host}:${port}`;
+        const client = createClient(getRedisClientOptions(url));
+        client.on('error', () => {
+            // swallow the expected NOAUTH error event
+        });
+        await client.connect();
+        try {
+            await expect(client.get('k')).rejects.toThrow(/NOAUTH/i);
+        } finally {
+            client.destroy();
+        }
+    });
+});

--- a/packages/kvstore/lib/redisClient.ts
+++ b/packages/kvstore/lib/redisClient.ts
@@ -96,6 +96,11 @@ export function getRedisClientOptions(url: string, boundary: RedisBoundary = 'sy
 
     return {
         url,
+        // node-redis v5 defaults to RESP2, which mishandles pub/sub status replies
+        // (subscribe/unsubscribe acks) and can throw when the command queue is empty.
+        // RESP3 routes pub/sub through a dedicated push handler and also allows
+        // re-authentication while a subscriber connection is active.
+        RESP: 3 as const,
         disableOfflineQueue: true,
         pingInterval: 30_000,
         socket,

--- a/packages/kvstore/lib/redisClient.ts
+++ b/packages/kvstore/lib/redisClient.ts
@@ -1,0 +1,104 @@
+import { readFileSync } from 'node:fs';
+
+import { envs } from './env.js';
+
+export type RedisBoundary = 'system' | 'customer';
+
+const reconnectStrategy = (retries: number): number => Math.min(retries * 200, 2000);
+
+/**
+ * Resolve the system-boundary Redis URL.
+ *
+ * When a token file is configured the URL carries no inline credentials — they
+ * are supplied by the credentials provider in {@link getRedisClientOptions}.
+ */
+export function getRedisUrl(): string | undefined {
+    if (envs.NANGO_REDIS_URL) {
+        return envs.NANGO_REDIS_URL;
+    }
+    const endpoint = envs.NANGO_REDIS_HOST;
+    const port = envs.NANGO_REDIS_PORT || 6379;
+    if (!endpoint) {
+        return undefined;
+    }
+    if (envs.NANGO_REDIS_AUTH_TOKEN_FILE) {
+        return `rediss://${endpoint}:${port}`;
+    }
+    const auth = envs.NANGO_REDIS_AUTH;
+    if (auth) {
+        return `rediss://:${auth}@${endpoint}:${port}`;
+    }
+    return undefined;
+}
+
+/** Resolve the customer-boundary Redis URL. See {@link getRedisUrl}. */
+export function getCustomerRedisUrl(): string | undefined {
+    if (envs.NANGO_CUSTOMER_REDIS_URL) {
+        return envs.NANGO_CUSTOMER_REDIS_URL;
+    }
+    const endpoint = envs.NANGO_CUSTOMER_REDIS_HOST;
+    const port = envs.NANGO_CUSTOMER_REDIS_PORT || 6379;
+    if (!endpoint) {
+        return undefined;
+    }
+    if (envs.NANGO_CUSTOMER_REDIS_AUTH_TOKEN_FILE) {
+        return `rediss://${endpoint}:${port}`;
+    }
+    const auth = envs.NANGO_CUSTOMER_REDIS_AUTH;
+    if (auth) {
+        return `rediss://:${auth}@${endpoint}:${port}`;
+    }
+    return undefined;
+}
+
+function getBoundaryTokenAuth(boundary: RedisBoundary): { username: string | undefined; tokenFile: string | undefined } {
+    if (boundary === 'customer') {
+        return { username: envs.NANGO_CUSTOMER_REDIS_USERNAME, tokenFile: envs.NANGO_CUSTOMER_REDIS_AUTH_TOKEN_FILE };
+    }
+    return { username: envs.NANGO_REDIS_USERNAME, tokenFile: envs.NANGO_REDIS_AUTH_TOKEN_FILE };
+}
+
+/**
+ * Build node-redis client options for a URL, centralizing TLS/socket settings
+ * and (optionally) rotating-token authentication.
+ *
+ * When the boundary has `NANGO_(CUSTOMER_)REDIS_AUTH_TOKEN_FILE` set, an async
+ * credentials provider is attached. node-redis invokes it on every (re)connect
+ * handshake, so a token rotated on disk (e.g. GCP/AWS/Azure IAM auth) is always
+ * read fresh — no inline credentials in the URL and no manual re-AUTH needed.
+ * When unset, behaviour is identical to the previous static-auth setup.
+ */
+export function getRedisClientOptions(url: string, boundary: RedisBoundary = 'system') {
+    const isExternal = url.startsWith('rediss://');
+    const socket = isExternal
+        ? {
+              reconnectStrategy,
+              connectTimeout: 10_000,
+              tls: true as const,
+              servername: new URL(url).hostname,
+              // node-redis v5 enables keepAlive by default (initial delay 5s); keep the
+              // previous 60s initial delay so behaviour matches the pre-v5 setup.
+              keepAlive: true,
+              keepAliveInitialDelay: 60_000
+          }
+        : {};
+
+    const { username, tokenFile } = getBoundaryTokenAuth(boundary);
+    const credentialsProvider = tokenFile
+        ? {
+              type: 'async-credentials-provider' as const,
+              credentials: () => {
+                  const password = readFileSync(tokenFile, 'utf8').trim();
+                  return Promise.resolve(username !== undefined ? { username, password } : { password });
+              }
+          }
+        : undefined;
+
+    return {
+        url,
+        disableOfflineQueue: true,
+        pingInterval: 30_000,
+        socket,
+        ...(credentialsProvider ? { credentialsProvider } : {})
+    };
+}

--- a/packages/kvstore/lib/redisClient.ts
+++ b/packages/kvstore/lib/redisClient.ts
@@ -2,7 +2,10 @@ import { readFileSync } from 'node:fs';
 
 import { envs } from './env.js';
 
+import type { RedisClientType, RedisDefaultModules, RedisFunctions, RedisScripts } from 'redis';
+
 export type RedisBoundary = 'system' | 'customer';
+export type NangoRedisClient = RedisClientType<RedisDefaultModules, RedisFunctions, RedisScripts, 3>;
 
 const reconnectStrategy = (retries: number): number => Math.min(retries * 200, 2000);
 

--- a/packages/kvstore/lib/redisClient.unit.test.ts
+++ b/packages/kvstore/lib/redisClient.unit.test.ts
@@ -78,6 +78,7 @@ describe('getRedisClientOptions', () => {
 
     it('builds a TLS socket and no credentials provider for a rediss url without token file', () => {
         const options = getRedisClientOptions('rediss://host:6379');
+        expect(options.RESP).toBe(3);
         expect(options.socket).toMatchObject({ tls: true, connectTimeout: 10_000, servername: 'host' });
         expect(typeof options.socket.reconnectStrategy).toBe('function');
         expect('credentialsProvider' in options).toBe(false);

--- a/packages/kvstore/lib/redisClient.unit.test.ts
+++ b/packages/kvstore/lib/redisClient.unit.test.ts
@@ -1,0 +1,128 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+// Mutable mock env, shared by reference with the module under test.
+const mockEnvs = {
+    NANGO_REDIS_URL: undefined as string | undefined,
+    NANGO_REDIS_HOST: undefined as string | undefined,
+    NANGO_REDIS_PORT: undefined as number | undefined,
+    NANGO_REDIS_AUTH: undefined as string | undefined,
+    NANGO_REDIS_USERNAME: undefined as string | undefined,
+    NANGO_REDIS_AUTH_TOKEN_FILE: undefined as string | undefined,
+    NANGO_CUSTOMER_REDIS_URL: undefined as string | undefined,
+    NANGO_CUSTOMER_REDIS_HOST: undefined as string | undefined,
+    NANGO_CUSTOMER_REDIS_PORT: undefined as number | undefined,
+    NANGO_CUSTOMER_REDIS_AUTH: undefined as string | undefined,
+    NANGO_CUSTOMER_REDIS_USERNAME: undefined as string | undefined,
+    NANGO_CUSTOMER_REDIS_AUTH_TOKEN_FILE: undefined as string | undefined
+};
+
+vi.mock('./env.js', () => ({ envs: mockEnvs }));
+
+const readFileSync = vi.fn();
+vi.mock('node:fs', () => ({ readFileSync: (...args: unknown[]) => readFileSync(...args) }));
+
+const { getRedisUrl, getCustomerRedisUrl, getRedisClientOptions } = await import('./redisClient.js');
+
+function resetEnv() {
+    for (const key of Object.keys(mockEnvs)) {
+        (mockEnvs as Record<string, unknown>)[key] = undefined;
+    }
+}
+
+describe('getRedisUrl', () => {
+    beforeEach(resetEnv);
+
+    it('returns NANGO_REDIS_URL verbatim when set', () => {
+        mockEnvs.NANGO_REDIS_URL = 'rediss://example:6379';
+        expect(getRedisUrl()).toBe('rediss://example:6379');
+    });
+
+    it('builds a url with inline auth from host/port/auth', () => {
+        mockEnvs.NANGO_REDIS_HOST = 'host';
+        mockEnvs.NANGO_REDIS_PORT = 6380;
+        mockEnvs.NANGO_REDIS_AUTH = 'secret';
+        expect(getRedisUrl()).toBe('rediss://:secret@host:6380');
+    });
+
+    it('omits inline auth when a token file is configured', () => {
+        mockEnvs.NANGO_REDIS_HOST = 'host';
+        mockEnvs.NANGO_REDIS_AUTH_TOKEN_FILE = '/run/secrets/token';
+        expect(getRedisUrl()).toBe('rediss://host:6379');
+    });
+
+    it('returns undefined when host is set but neither auth nor token file is', () => {
+        mockEnvs.NANGO_REDIS_HOST = 'host';
+        expect(getRedisUrl()).toBeUndefined();
+    });
+
+    it('returns undefined when nothing is configured', () => {
+        expect(getRedisUrl()).toBeUndefined();
+    });
+});
+
+describe('getCustomerRedisUrl', () => {
+    beforeEach(resetEnv);
+
+    it('omits inline auth when a customer token file is configured', () => {
+        mockEnvs.NANGO_CUSTOMER_REDIS_HOST = 'chost';
+        mockEnvs.NANGO_CUSTOMER_REDIS_AUTH_TOKEN_FILE = '/run/secrets/customer-token';
+        expect(getCustomerRedisUrl()).toBe('rediss://chost:6379');
+    });
+});
+
+describe('getRedisClientOptions', () => {
+    beforeEach(() => {
+        resetEnv();
+        readFileSync.mockReset();
+    });
+
+    it('builds a TLS socket and no credentials provider for a rediss url without token file', () => {
+        const options = getRedisClientOptions('rediss://host:6379');
+        expect(options.socket).toMatchObject({ tls: true, connectTimeout: 10_000, servername: 'host' });
+        expect(typeof options.socket.reconnectStrategy).toBe('function');
+        expect('credentialsProvider' in options).toBe(false);
+    });
+
+    it('uses an empty socket for a non-TLS url', () => {
+        const options = getRedisClientOptions('redis://host:6379');
+        expect(options.socket).toEqual({});
+        expect('credentialsProvider' in options).toBe(false);
+    });
+
+    it('attaches an async credentials provider that reads the token file on every call', async () => {
+        mockEnvs.NANGO_REDIS_AUTH_TOKEN_FILE = '/run/secrets/token';
+        readFileSync.mockReturnValueOnce('token-1\n').mockReturnValueOnce('token-2\n');
+
+        const options = getRedisClientOptions('rediss://host:6379');
+        const provider = (options as { credentialsProvider?: { type: string; credentials: () => Promise<{ username?: string; password?: string }> } })
+            .credentialsProvider;
+
+        expect(provider?.type).toBe('async-credentials-provider');
+        // Re-read on each (re)connect so a rotated token is always picked up.
+        await expect(provider!.credentials()).resolves.toEqual({ password: 'token-1' });
+        await expect(provider!.credentials()).resolves.toEqual({ password: 'token-2' });
+        expect(readFileSync).toHaveBeenCalledTimes(2);
+    });
+
+    it('includes the username when configured', async () => {
+        mockEnvs.NANGO_REDIS_AUTH_TOKEN_FILE = '/run/secrets/token';
+        mockEnvs.NANGO_REDIS_USERNAME = 'iam-principal';
+        readFileSync.mockReturnValue('the-token');
+
+        const options = getRedisClientOptions('rediss://host:6379');
+        const provider = (options as { credentialsProvider?: { credentials: () => Promise<{ username?: string; password?: string }> } }).credentialsProvider;
+
+        await expect(provider!.credentials()).resolves.toEqual({ username: 'iam-principal', password: 'the-token' });
+    });
+
+    it('uses the customer token file for the customer boundary', async () => {
+        mockEnvs.NANGO_CUSTOMER_REDIS_AUTH_TOKEN_FILE = '/run/secrets/customer-token';
+        readFileSync.mockReturnValue('customer-token');
+
+        const options = getRedisClientOptions('rediss://chost:6379', 'customer');
+        const provider = (options as { credentialsProvider?: { credentials: () => Promise<{ password?: string }> } }).credentialsProvider;
+
+        await expect(provider!.credentials()).resolves.toEqual({ password: 'customer-token' });
+        expect(readFileSync).toHaveBeenCalledWith('/run/secrets/customer-token', 'utf8');
+    });
+});

--- a/packages/kvstore/package.json
+++ b/packages/kvstore/package.json
@@ -15,9 +15,10 @@
     },
     "dependencies": {
         "@nangohq/utils": "file:../utils",
-        "redis": "4.6.13"
+        "redis": "5.12.1"
     },
     "devDependencies": {
+        "testcontainers": "11.14.0",
         "vitest": "4.1.8"
     },
     "files": [

--- a/packages/lambda-runner/lib/index.ts
+++ b/packages/lambda-runner/lib/index.ts
@@ -44,7 +44,11 @@ class Gate {
     }
 
     async exit(lock: Lock) {
-        await this.locking.release(lock);
+        try {
+            await this.locking.release(lock);
+        } catch {
+            // best-effort release; lock TTL is the safety net
+        }
     }
 }
 
@@ -136,7 +140,12 @@ export const handler = async (event: unknown, context: Context): Promise<{ ok: t
     const heartbeatTimeoutMs = request.nangoProps.heartbeatTimeoutSecs ? request.nangoProps.heartbeatTimeoutSecs * 1000 : heartbeatIntervalMs * 3;
 
     const abort = setInterval(async () => {
-        const shouldAbort = await kvStore.exists(`function:${request.taskId}:abort`);
+        let shouldAbort = false;
+        try {
+            shouldAbort = await kvStore.exists(`function:${request.taskId}:abort`);
+        } catch {
+            // best-effort abort poll; retry on next interval
+        }
         if (shouldAbort) {
             logger.info('Aborting task', { taskId: request.taskId });
             abortController.abort();

--- a/packages/metering/lib/crons/billingEventsS3Export.ts
+++ b/packages/metering/lib/crons/billingEventsS3Export.ts
@@ -256,7 +256,11 @@ async function withLock(fn: () => Promise<void>): Promise<void> {
     try {
         await fn();
     } finally {
-        await locking.release(lock);
+        try {
+            await locking.release(lock);
+        } catch (err) {
+            logger.error('Error releasing lock', { lock: lock.key, error: err });
+        }
     }
 }
 

--- a/packages/metering/lib/crons/usage.ts
+++ b/packages/metering/lib/crons/usage.ts
@@ -59,7 +59,11 @@ export async function exec(): Promise<void> {
         } catch (err) {
             logger.error('Failed to export usage metrics', err);
             if (lock) {
-                await locking.release(lock);
+                try {
+                    await locking.release(lock);
+                } catch (releaseErr) {
+                    logger.error('Error releasing lock', { lock: lock.key, error: releaseErr });
+                }
             }
             // only releasing the lock on error
             // and letting it expires otherwise so no other execution can occur until the next cron

--- a/packages/server/lib/clients/publisher.client.ts
+++ b/packages/server/lib/clients/publisher.client.ts
@@ -7,9 +7,9 @@ import { getLogger } from '@nangohq/utils';
 import { authHtml } from '../utils/html.js';
 
 import type { WSErr } from '../utils/web-socket-error.js';
+import type { NangoRedisClient } from '@nangohq/kvstore';
 import type { WebSocketConnectionAck, WebSocketConnectionError, WebSocketConnectionResponseSuccess } from '@nangohq/types';
 import type { Response } from 'express';
-import type { RedisClientType } from 'redis';
 import type { WebSocket } from 'ws';
 
 const logger = getLogger('Server.Publisher');
@@ -19,8 +19,8 @@ export type WebSocketClientId = string;
 export class Redis {
     // Two redis clients are needed because the same client cannot be used for both publishing and subscribing
     // more at https://redis.io/commands/subscribe/
-    private pub: RedisClientType;
-    private sub: RedisClientType;
+    private pub: NangoRedisClient;
+    private sub: NangoRedisClient;
 
     constructor(url: string) {
         // Separate options objects: node-redis mutates the options it receives,

--- a/packages/server/lib/clients/publisher.client.ts
+++ b/packages/server/lib/clients/publisher.client.ts
@@ -1,7 +1,7 @@
 import { createClient } from 'redis';
 import * as uuid from 'uuid';
 
-import { getRedisUrl } from '@nangohq/shared';
+import { getRedisClientOptions, getRedisUrl } from '@nangohq/kvstore';
 import { getLogger } from '@nangohq/utils';
 
 import { authHtml } from '../utils/html.js';
@@ -19,30 +19,13 @@ export type WebSocketClientId = string;
 export class Redis {
     // Two redis clients are needed because the same client cannot be used for both publishing and subscribing
     // more at https://redis.io/commands/subscribe/
-    private url: string;
     private pub: RedisClientType;
     private sub: RedisClientType;
 
     constructor(url: string) {
-        this.url = url;
-
-        const isExternal = url.startsWith('rediss://');
-        const socket = isExternal
-            ? {
-                  reconnectStrategy: (retries: number) => Math.min(retries * 200, 2000),
-                  connectTimeout: 10_000,
-                  tls: true,
-                  servername: new URL(url).hostname,
-                  keepAlive: 60_000
-              }
-            : {};
-
-        this.pub = createClient({
-            url: this.url,
-            disableOfflineQueue: true,
-            pingInterval: 30_000,
-            socket
-        });
+        // Separate options objects: node-redis mutates the options it receives,
+        // and pub/sub must be two independent clients.
+        this.pub = createClient(getRedisClientOptions(url));
         this.pub.on('error', (err: Error) => {
             logger.error(`Redis (publisher) error`, err);
         });
@@ -50,12 +33,7 @@ export class Redis {
             logger.info(`Redis (publisher) connected`);
         });
 
-        this.sub = createClient({
-            url: this.url,
-            disableOfflineQueue: true,
-            pingInterval: 30_000,
-            socket
-        });
+        this.sub = createClient(getRedisClientOptions(url));
         this.sub.on('error', (err: Error) => {
             logger.error(`Redis (subscriber) error`, err);
         });

--- a/packages/server/lib/controllers/sync/deploy/postDeploy.integration.test.ts
+++ b/packages/server/lib/controllers/sync/deploy/postDeploy.integration.test.ts
@@ -136,8 +136,7 @@ describe(`POST ${endpoint}`, () => {
             release: vi.fn(),
             acquire: vi.fn().mockRejectedValue(new Error('Failed to acquire lock')),
             releaseAll: vi.fn(),
-            hasLock: vi.fn(),
-            withLock: vi.fn()
+            hasLock: vi.fn()
         } as any);
 
         try {

--- a/packages/server/lib/controllers/sync/deploy/postDeploy.ts
+++ b/packages/server/lib/controllers/sync/deploy/postDeploy.ts
@@ -2,7 +2,7 @@ import db from '@nangohq/database';
 import { getLocking } from '@nangohq/kvstore';
 import { logContextGetter } from '@nangohq/logs';
 import { NangoError, cleanIncomingFlow, deploy, errorManager, getAndReconcileDifferences, productTracking, startTrial } from '@nangohq/shared';
-import { requireEmptyQuery, zodErrorToHTTP } from '@nangohq/utils';
+import { getLogger, requireEmptyQuery, zodErrorToHTTP } from '@nangohq/utils';
 
 import { validationWithNangoYaml as validation } from './validation.js';
 import { startFunctionDeletion } from '../../../tasks/startFunctionDeletion.js';
@@ -12,6 +12,7 @@ import { getOrchestrator } from '../../../utils/utils.js';
 import type { Lock } from '@nangohq/kvstore';
 import type { PostDeploy } from '@nangohq/types';
 
+const logger = getLogger('Server.PostDeploy');
 const orchestrator = getOrchestrator();
 
 export const postDeploy = asyncWrapper<PostDeploy>(async (req, res) => {
@@ -107,7 +108,11 @@ export const postDeploy = asyncWrapper<PostDeploy>(async (req, res) => {
         res.send(syncConfigDeployResult.result);
     } finally {
         if (lock) {
-            await locking.release(lock);
+            try {
+                await locking.release(lock);
+            } catch (err) {
+                logger.error('Error releasing lock', { lock: lock.key, error: err });
+            }
         }
     }
 });

--- a/packages/server/lib/crons/deleteOldData.ts
+++ b/packages/server/lib/crons/deleteOldData.ts
@@ -219,7 +219,11 @@ export async function exec(): Promise<void> {
         });
     } finally {
         if (lock) {
-            locking.release(lock);
+            try {
+                await locking.release(lock);
+            } catch (err) {
+                logger.error('Error releasing lock', { lock: lock.key, error: err });
+            }
         }
     }
 }

--- a/packages/server/lib/crons/lambdaKeepWarm.ts
+++ b/packages/server/lib/crons/lambdaKeepWarm.ts
@@ -100,7 +100,11 @@ export async function exec(): Promise<void> {
             span.setTag('error', err);
         } finally {
             if (lock) {
-                locking.release(lock);
+                try {
+                    await locking.release(lock);
+                } catch (err) {
+                    logger.error('Error releasing lock', { lock: lock.key, error: err });
+                }
             }
         }
     });

--- a/packages/server/lib/crons/refreshConnections.ts
+++ b/packages/server/lib/crons/refreshConnections.ts
@@ -118,7 +118,11 @@ export async function exec(): Promise<void> {
             span.setTag('error', err);
         } finally {
             if (lock) {
-                locking.release(lock);
+                try {
+                    await locking.release(lock);
+                } catch (err) {
+                    logger.error('Error releasing lock', { lock: lock.key, error: err });
+                }
             }
         }
     });

--- a/packages/server/lib/crons/timeoutFunctionAsyncJobs.ts
+++ b/packages/server/lib/crons/timeoutFunctionAsyncJobs.ts
@@ -36,6 +36,10 @@ export async function exec(): Promise<void> {
             logger.info(`Timed out ${count} function async jobs`);
         }
     } finally {
-        await locking.release(lock);
+        try {
+            await locking.release(lock);
+        } catch (err) {
+            logger.error('Error releasing lock', { lock: lock.key, error: err });
+        }
     }
 }

--- a/packages/server/lib/crons/trial.ts
+++ b/packages/server/lib/crons/trial.ts
@@ -129,7 +129,11 @@ export async function exec(): Promise<void> {
         }
     } finally {
         if (lock) {
-            locking.release(lock);
+            try {
+                await locking.release(lock);
+            } catch (err) {
+                logger.error('Error releasing lock', { lock: lock.key, error: err });
+            }
         }
     }
 }

--- a/packages/server/lib/middleware/ratelimit.middleware.ts
+++ b/packages/server/lib/middleware/ratelimit.middleware.ts
@@ -2,7 +2,7 @@ import path from 'node:path';
 
 import { RateLimiterMemory, RateLimiterRedis, RateLimiterRes } from 'rate-limiter-flexible';
 
-import { getRedisUrl } from '@nangohq/shared';
+import { getRedisUrl } from '@nangohq/kvstore';
 import { flagHasAPIRateLimit, flagHasPlan, getLogger } from '@nangohq/utils';
 
 import { envs } from '../env.js';
@@ -49,7 +49,7 @@ async function getRateLimiter(size: DBPlan['api_rate_limit_size']) {
         redisClient.on('error', (err) => {
             logger.error(`Redis (rate-limiter) error: ${err}`);
         });
-        limiter = new RateLimiterRedis({ storeClient: redisClient, ...opts });
+        limiter = new RateLimiterRedis({ storeClient: redisClient, useRedisPackage: true, ...opts });
     } else {
         limiter = new RateLimiterMemory(opts);
     }

--- a/packages/server/lib/middleware/webhook-ingress-ratelimit.middleware.ts
+++ b/packages/server/lib/middleware/webhook-ingress-ratelimit.middleware.ts
@@ -1,6 +1,6 @@
 import { RateLimiterMemory, RateLimiterRedis, RateLimiterRes } from 'rate-limiter-flexible';
 
-import { getRedisUrl } from '@nangohq/shared';
+import { getRedisUrl } from '@nangohq/kvstore';
 import { getLogger, metrics } from '@nangohq/utils';
 
 import { envs } from '../env.js';
@@ -109,7 +109,7 @@ async function buildLimiter(): Promise<RateLimiterAbstract> {
         logger.error(`Redis (webhook-ingress rate-limiter) error: ${err}`);
     });
 
-    return new RateLimiterRedis({ storeClient: redisClient, ...opts });
+    return new RateLimiterRedis({ storeClient: redisClient, useRedisPackage: true, ...opts });
 }
 
 function getDefaultLimiter(): Promise<RateLimiterAbstract> {

--- a/packages/server/lib/utils/rateLimiterRedisClient.ts
+++ b/packages/server/lib/utils/rateLimiterRedisClient.ts
@@ -1,21 +1,7 @@
 import { createClient } from 'redis';
 
-export async function createRateLimiterRedisClient(url: string): Promise<ReturnType<typeof createClient>> {
-    const isExternal = url.startsWith('rediss://');
-    const socket = isExternal
-        ? {
-              reconnectStrategy: (retries: number) => Math.min(retries * 200, 2000),
-              connectTimeout: 10_000,
-              tls: true,
-              servername: new URL(url).hostname,
-              keepAlive: 60_000
-          }
-        : {};
+import { getRedisClientOptions } from '@nangohq/kvstore';
 
-    return createClient({
-        url,
-        disableOfflineQueue: true,
-        pingInterval: 30_000,
-        socket
-    }).connect();
+export async function createRateLimiterRedisClient(url: string): Promise<ReturnType<typeof createClient>> {
+    return createClient(getRedisClientOptions(url)).connect();
 }

--- a/packages/server/package.json
+++ b/packages/server/package.json
@@ -64,7 +64,7 @@
         "passport-local": "1.0.0",
         "qs": "6.15.0",
         "rate-limiter-flexible": "5.0.3",
-        "redis": "4.6.13",
+        "redis": "5.12.1",
         "semver": "7.6.3",
         "serialize-error": "11.0.3",
         "simple-oauth2": "5.1.0",

--- a/packages/shared/lib/services/connections/credentials/refresh.ts
+++ b/packages/shared/lib/services/connections/credentials/refresh.ts
@@ -525,7 +525,11 @@ export async function refreshCredentialsIfNeeded({
             return Err(error);
         } finally {
             if (lock) {
-                await locking.release(lock);
+                try {
+                    await locking.release(lock);
+                } catch (err) {
+                    logger.error('Error releasing lock', { lock: lock.key, error: err });
+                }
             }
         }
     }

--- a/packages/shared/lib/utils/utils.ts
+++ b/packages/shared/lib/utils/utils.ts
@@ -58,21 +58,6 @@ export function getServerBaseUrl() {
     return getServerHost() + `:${getServerPort()}`;
 }
 
-export function getRedisUrl() {
-    const url = process.env['NANGO_REDIS_URL'];
-    if (url) {
-        return url;
-    } else {
-        const endpoint = process.env['NANGO_REDIS_HOST'];
-        const port = process.env['NANGO_REDIS_PORT'] || 6379;
-        const auth = process.env['NANGO_REDIS_AUTH'];
-        if (endpoint && port && auth) {
-            return `rediss://:${auth}@${endpoint}:${port}`;
-        }
-        return undefined;
-    }
-}
-
 export function getOrchestratorUrl() {
     return process.env['ORCHESTRATOR_SERVICE_URL'] || `http://localhost:${process.env['NANGO_ORCHESTRATOR_PORT'] || 3008}`;
 }

--- a/packages/shared/lib/utils/utils.unit.test.ts
+++ b/packages/shared/lib/utils/utils.unit.test.ts
@@ -1,6 +1,6 @@
 import crypto from 'node:crypto';
 
-import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { describe, expect, it, vi } from 'vitest';
 
 import * as utils from './utils.js';
 
@@ -496,59 +496,6 @@ describe('parseTokenExpirationDate', () => {
         const millisecondsTimestamp = Date.now();
         const expected = new Date(millisecondsTimestamp);
         expect(utils.parseTokenExpirationDate(millisecondsTimestamp)?.getTime()).toBe(expected.getTime());
-    });
-});
-
-describe('getRedisUrl', () => {
-    const originalEnv = process.env;
-
-    beforeEach(() => {
-        vi.resetModules();
-        process.env = { ...originalEnv };
-    });
-
-    afterEach(() => {
-        process.env = originalEnv;
-    });
-
-    it('should return undefined when no relevant env vars are set', () => {
-        delete process.env['NANGO_REDIS_URL'];
-        delete process.env['NANGO_REDIS_HOST'];
-        delete process.env['NANGO_REDIS_PORT'];
-        delete process.env['NANGO_REDIS_AUTH'];
-
-        const result = utils.getRedisUrl();
-        expect(result).toBeUndefined();
-    });
-
-    it('should return NANGO_REDIS_URL when it is set', () => {
-        process.env['NANGO_REDIS_URL'] = 'redis://localhost:6379';
-        delete process.env['NANGO_REDIS_HOST'];
-        delete process.env['NANGO_REDIS_PORT'];
-        delete process.env['NANGO_REDIS_AUTH'];
-
-        const result = utils.getRedisUrl();
-        expect(result).toBe('redis://localhost:6379');
-    });
-
-    it('should return undefined when only some of the other env vars are set', () => {
-        delete process.env['NANGO_REDIS_URL'];
-        process.env['NANGO_REDIS_HOST'] = 'localhost';
-        process.env['NANGO_REDIS_PORT'] = '6379';
-        // NANGO_REDIS_AUTH is missing
-
-        const result = utils.getRedisUrl();
-        expect(result).toBeUndefined();
-    });
-
-    it('should return constructed URL when all other env vars are set', () => {
-        delete process.env['NANGO_REDIS_URL'];
-        process.env['NANGO_REDIS_HOST'] = 'localhost';
-        process.env['NANGO_REDIS_PORT'] = '6379';
-        process.env['NANGO_REDIS_AUTH'] = 'password';
-
-        const result = utils.getRedisUrl();
-        expect(result).toBe('rediss://:password@localhost:6379');
     });
 });
 

--- a/packages/usage/lib/billing.ts
+++ b/packages/usage/lib/billing.ts
@@ -22,6 +22,7 @@ export class UsageBillingClient {
         this.redis = redis;
         const limiter = new RateLimiterRedis({
             storeClient: redis,
+            useRedisPackage: true,
             keyPrefix: 'billing',
             points: envs.USAGE_BILLING_API_MAX_RPS,
             duration: 1
@@ -38,7 +39,13 @@ export class UsageBillingClient {
     // once the shadow path is removed.
     public async getUsage(subscriptionId: string, opts?: GetBillingUsageOpts): Promise<Result<{ value: BillingUsageMetrics; fromCache: boolean }>> {
         const cacheKey = this.getCacheKey(subscriptionId, opts);
-        const cached = await this.redis.get(cacheKey);
+        let cached: string | null = null;
+        try {
+            cached = await this.redis.get(cacheKey);
+        } catch (err) {
+            metrics.increment(metrics.Types.BILLING_USAGE_CACHE, 1, { hit: 'error' });
+            return Err(new Error('billing_usage_cache_error', { cause: err }));
+        }
         if (cached) {
             try {
                 const parsed: BillingUsageMetrics = JSON.parse(cached);
@@ -86,12 +93,12 @@ export class UsageBillingClient {
     private async throttle<T>(key: string, fn: () => Promise<T>): Promise<T> {
         try {
             await this.throttler.removeTokens(1, key);
-            return await fn();
         } catch (err) {
             if (err instanceof RateLimiterRes) {
                 throw new Error('rate_limit_exceeded', { cause: err });
             }
-            throw err;
+            throw new Error('billing_usage_throttle_error', { cause: err });
         }
+        return await fn();
     }
 }

--- a/packages/usage/lib/billing.unit.test.ts
+++ b/packages/usage/lib/billing.unit.test.ts
@@ -1,0 +1,57 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+import { Ok, metrics } from '@nangohq/utils';
+
+import { UsageBillingClient } from './billing.js';
+
+const { getUsageMock } = vi.hoisted(() => ({
+    getUsageMock: vi.fn()
+}));
+
+vi.mock('@nangohq/billing', () => ({
+    billing: {
+        getUsage: getUsageMock
+    }
+}));
+
+describe('UsageBillingClient', () => {
+    beforeEach(() => {
+        vi.clearAllMocks();
+    });
+
+    it('returns error when redis.get throws', async () => {
+        getUsageMock.mockResolvedValue(Ok({ proxy: { total: 1 } } as any));
+        const incrementSpy = vi.spyOn(metrics, 'increment').mockImplementation(() => {});
+
+        const redis = {
+            get: vi.fn().mockRejectedValue(new Error('redis down')),
+            set: vi.fn()
+        };
+        const client = new UsageBillingClient(redis as any);
+
+        const res = await client.getUsage('sub-1');
+        expect(res.isErr()).toBe(true);
+        if (res.isErr()) {
+            expect(res.error.message).toBe('billing_usage_cache_error');
+        }
+        expect(getUsageMock).not.toHaveBeenCalled();
+        expect(incrementSpy).toHaveBeenCalledWith(metrics.Types.BILLING_USAGE_CACHE, 1, { hit: 'error' });
+        expect(incrementSpy).not.toHaveBeenCalledWith(metrics.Types.BILLING_USAGE_CACHE, 1, { hit: 'false' });
+
+        incrementSpy.mockRestore();
+    });
+
+    it('throws when throttle fails on cache miss', async () => {
+        getUsageMock.mockResolvedValue(Ok({ proxy: { total: 1 } } as any));
+
+        const redis = {
+            get: vi.fn().mockResolvedValue(null),
+            set: vi.fn()
+        };
+        const client = new UsageBillingClient(redis as any);
+        vi.spyOn((client as any).throttler, 'removeTokens').mockRejectedValue(new Error('redis down'));
+
+        await expect(client.getUsage('sub-1')).rejects.toThrow('billing_usage_throttle_error');
+        expect(getUsageMock).not.toHaveBeenCalled();
+    });
+});

--- a/packages/usage/lib/cache.ts
+++ b/packages/usage/lib/cache.ts
@@ -68,11 +68,15 @@ export class UsageCache {
     }
 
     public async tryAcquireLock(key: string, { ttlMs }: { ttlMs: number }): Promise<Result<string>> {
-        const acquired = await this.store.set(key, '1', { NX: true, PX: ttlMs });
-        if (acquired) {
-            return Ok(key);
+        try {
+            const acquired = await this.store.set(key, '1', { NX: true, PX: ttlMs });
+            if (acquired) {
+                return Ok(key);
+            }
+            return Err(new Error(`lock_not_acquired`));
+        } catch (err) {
+            return Err(new Error(`lock_acquire_error`, { cause: err }));
         }
-        return Err(new Error(`lock_not_acquired`));
     }
 
     public async releaseLock(key: string): Promise<void> {
@@ -91,7 +95,11 @@ export class UsageCache {
         const validated = UsageCacheEntryValueSchema.safeParse(data);
         if (!validated.success) {
             // if the data is invalid, we delete the key to avoid returning invalid data again
-            await this.store.del(key);
+            try {
+                await this.store.del(key);
+            } catch {
+                // ignore delete errors
+            }
             return Err(new Error(`cache_entry_invalid`));
         }
         return Ok({

--- a/packages/usage/lib/cache.unit.test.ts
+++ b/packages/usage/lib/cache.unit.test.ts
@@ -1,0 +1,35 @@
+import { describe, expect, it, vi } from 'vitest';
+
+import { UsageCache } from './cache.js';
+
+describe('UsageCache', () => {
+    it('tryAcquireLock returns Err on redis set failure', async () => {
+        const store = {
+            set: vi.fn().mockRejectedValue(new Error('redis down'))
+        };
+        const cache = new UsageCache(store as any);
+        const res = await cache.tryAcquireLock('lock-key', { ttlMs: 1000 });
+        expect(res.isErr()).toBe(true);
+        if (res.isErr()) {
+            expect(res.error.message).toBe('lock_acquire_error');
+        }
+    });
+
+    it('get returns cache_entry_invalid when invalid entry delete fails', async () => {
+        const store = {
+            multi: () => ({
+                hGetAll: () => ({
+                    exec: () => Promise.resolve([{ count: 'bad', revalidateAfter: 'not-a-number' }])
+                })
+            }),
+            del: vi.fn().mockRejectedValue(new Error('redis down'))
+        };
+        const cache = new UsageCache(store as any);
+        const res = await cache.get('key');
+        expect(res.isErr()).toBe(true);
+        if (res.isErr()) {
+            expect(res.error.message).toBe('cache_entry_invalid');
+        }
+        expect(store.del).toHaveBeenCalledWith('key');
+    });
+});

--- a/packages/utils/lib/environment/parse.ts
+++ b/packages/utils/lib/environment/parse.ts
@@ -451,12 +451,18 @@ export const ENVS = z.object({
     NANGO_REDIS_HOST: z.string().optional(),
     NANGO_REDIS_PORT: z.coerce.number().optional().default(6379),
     NANGO_REDIS_AUTH: z.string().optional(),
+    // Optional AUTH username (e.g. IAM principal). Defaults to 'default' when a token is provided without a username.
+    NANGO_REDIS_USERNAME: z.string().optional(),
+    // Path to a file holding a short-lived auth token (e.g. IAM). Re-read on every (re)connect so rotated tokens work.
+    NANGO_REDIS_AUTH_TOKEN_FILE: z.string().optional(),
 
     // Redis (customer boundary)
     NANGO_CUSTOMER_REDIS_URL: z.url().optional(),
     NANGO_CUSTOMER_REDIS_HOST: z.string().optional(),
     NANGO_CUSTOMER_REDIS_PORT: z.coerce.number().optional().default(6379),
     NANGO_CUSTOMER_REDIS_AUTH: z.string().optional(),
+    NANGO_CUSTOMER_REDIS_USERNAME: z.string().optional(),
+    NANGO_CUSTOMER_REDIS_AUTH_TOKEN_FILE: z.string().optional(),
 
     // Render
     RENDER_API_KEY: z.string().optional(),

--- a/packages/webhooks/lib/circuitBreaker.integration.test.ts
+++ b/packages/webhooks/lib/circuitBreaker.integration.test.ts
@@ -6,10 +6,10 @@ import { Err, Ok } from '@nangohq/utils';
 import { CircuitBreakerRedis } from './circuitBreaker.js';
 
 import type { CircuitBreaker } from './circuitBreaker.js';
-import type { RedisClientType } from 'redis';
+import type { NangoRedisClient } from '@nangohq/kvstore';
 
 describe('Circuit breaker', () => {
-    let redis: RedisClientType;
+    let redis: NangoRedisClient;
     let circuitBreaker: CircuitBreaker;
 
     const failureThreshold = 3;

--- a/packages/webhooks/lib/circuitBreaker.ts
+++ b/packages/webhooks/lib/circuitBreaker.ts
@@ -47,6 +47,7 @@ export class CircuitBreakerRedis implements CircuitBreaker {
         // Rate limiter for tracking failures
         this.failureLimiter = new RateLimiterRedis({
             storeClient: redis,
+            useRedisPackage: true,
             keyPrefix: `${this.keyPrefix}:failures`,
             points: options.failureThreshold,
             duration: options.windowSecs
@@ -128,27 +129,42 @@ export class CircuitBreakerRedis implements CircuitBreaker {
                 untilMs: now + this.cooldownDurationMs
             });
         } else {
-            // Success in half-open = remove the key (back to closed/normal)
+            try {
+                await this.failureLimiter.delete(key);
+            } catch {
+                // ignore, counter has a TTL
+            }
             await this.removeState(key);
-            await this.failureLimiter.delete(key);
         }
         return res;
     }
 
     private async getState(key: string): Promise<CircuitStateData | null> {
-        const data = await this.redis.get(`${this.keyPrefix}:${key}`);
-        if (!data) {
+        try {
+            const data = await this.redis.get(`${this.keyPrefix}:${key}`);
+            if (!data) {
+                return null;
+            }
+            return JSON.parse(data);
+        } catch {
             return null;
         }
-        return JSON.parse(data);
     }
 
     private async setState(key: string, state: CircuitStateData): Promise<void> {
-        const ttlMs = this.autoResetSecs * 1000;
-        await this.redis.set(`${this.keyPrefix}:${key}`, JSON.stringify(state), { PX: ttlMs });
+        try {
+            const ttlMs = this.autoResetSecs * 1000;
+            await this.redis.set(`${this.keyPrefix}:${key}`, JSON.stringify(state), { PX: ttlMs });
+        } catch {
+            // ignore state write errors — delivery proceeds fail-open
+        }
     }
 
     private async removeState(key: string): Promise<void> {
-        await this.redis.del(`${this.keyPrefix}:${key}`);
+        try {
+            await this.redis.del(`${this.keyPrefix}:${key}`);
+        } catch {
+            // ignore state delete errors
+        }
     }
 }

--- a/packages/webhooks/lib/circuitBreaker.unit.test.ts
+++ b/packages/webhooks/lib/circuitBreaker.unit.test.ts
@@ -1,0 +1,29 @@
+import { describe, expect, it, vi } from 'vitest';
+
+import { Ok } from '@nangohq/utils';
+
+import { CircuitBreakerRedis } from './circuitBreaker.js';
+
+describe('CircuitBreakerRedis', () => {
+    it('execute runs fn when getState redis fails', async () => {
+        const redis = {
+            get: vi.fn().mockRejectedValue(new Error('redis down'))
+        };
+        const circuitBreaker = new CircuitBreakerRedis({
+            id: 'test',
+            redis: redis as any,
+            options: {
+                failureThreshold: 3,
+                windowSecs: 60,
+                cooldownDurationSecs: 60,
+                autoResetSecs: 600
+            }
+        });
+
+        const res = await circuitBreaker.execute('key', () => Promise.resolve(Ok('success')));
+        expect(res.isOk()).toBe(true);
+        if (res.isOk()) {
+            expect(res.value).toBe('success');
+        }
+    });
+});


### PR DESCRIPTION
Reverts NangoHQ/nango#6514

Enable RESP3 for all Redis clients created via getRedisClientOptions, fixing pub/sub reliability under node-redis v5 and aligning types across the codebase.

node-redis v5 defaults to RESP2, which mishandles pub/sub status replies (subscribe/unsubscribe acks) and can throw when the command queue is empty. RESP3 routes pub/sub through a dedicated push handler and supports re-authentication on active subscriber connections — both needed for the server's Redis publisher/subscriber clients.

Changes
- packages/kvstore/lib/redisClient.ts — set RESP: 3 in getRedisClientOptions (shared by kvstore, publisher, rate limiter, jobs runner, etc.)
- NangoRedisClient type — RedisClientType<..., 3> exported from kvstore so callers (getRedis, RedisKVStore, publisher.client.ts) type-check without casts
- packages/kvstore/lib/redisClient.integration.test.ts — update the no-password auth test for RESP3 semantics: auth failure happens at HELLO during connect(), not on the first command
