### PR TITLE
fix(logger): fix the logger formatting

### DIFF
--- a/packages/fleet/lib/supervisor/supervisor.ts
+++ b/packages/fleet/lib/supervisor/supervisor.ts
@@ -2,7 +2,7 @@ import { setTimeout } from 'node:timers/promises';
 
 import tracer from 'dd-trace';
 
-import { Err, Ok, errorToObject, report } from '@nangohq/utils';
+import { Err, Ok, report } from '@nangohq/utils';
 
 import { envs } from '../env.js';
 import { Operation } from './operation.js';
@@ -121,7 +121,7 @@ export class Supervisor {
             });
             if (res.isErr()) {
                 await setTimeout(envs.FLEET_SUPERVISOR_RETRY_DELAY_MS);
-                logger.warning(`Fleet supervisor for fleet ${this.fleetId}:`, res.error.message, res.error.cause);
+                logger.warning(`Fleet supervisor for fleet ${this.fleetId}`, { err: res.error, cause: res.error.cause });
             }
         }
         this.state = 'stopped';
@@ -307,7 +307,7 @@ export class Supervisor {
                         const result = await this.execute(operation);
                         if (result.isErr()) {
                             operationSpan?.setTag('error', result.error);
-                            logger.error('Failed to execute operation:', result.error, errorToObject(result.error.cause));
+                            logger.error('Failed to execute operation', { err: result.error, cause: result.error.cause });
                         }
                     }
                 );

--- a/packages/records/lib/catalog/router.ts
+++ b/packages/records/lib/catalog/router.ts
@@ -138,7 +138,11 @@ const routing = new Routing(async (ctx: RoutingContext) => {
         routingCache.set(cacheKey, res.value);
         return res.value;
     }
-    logger.error('Routing error for connection', ctx.connectionId, 'model', ctx.model, ':', res.isErr() ? res.error : `invalid store ${res.value}`);
+    logger.error('Routing error for connection', {
+        connectionId: ctx.connectionId,
+        model: ctx.model,
+        error: res.isErr() ? res.error : `invalid store ${res.value}`
+    });
     return 'default';
 });
 

--- a/packages/server/lib/crons/delete/deleteConnectionData.ts
+++ b/packages/server/lib/crons/delete/deleteConnectionData.ts
@@ -9,7 +9,7 @@ import type { DBConnection, DBSyncConfig } from '@nangohq/types';
 
 export async function deleteConnectionData(connection: DBConnection, opts: BatchDeleteSharedOptions) {
     const { logger } = opts;
-    logger.info('Deleting connection...', connection.id, connection.connection_id);
+    logger.info('Deleting connection...', { connectionId: connection.id, externalConnectionId: connection.connection_id });
 
     const resSyncs = await db.knex
         .select<

--- a/packages/server/lib/crons/delete/deleteEnvironmentData.ts
+++ b/packages/server/lib/crons/delete/deleteEnvironmentData.ts
@@ -10,7 +10,7 @@ import type { DBEndUser, DBEnvironment, DBEnvironmentVariable, DBExternalWebhook
 
 export async function deleteEnvironmentData(environment: DBEnvironment, opts: BatchDeleteSharedOptions) {
     const { logger } = opts;
-    logger.info('Deleting environment...', environment.id, environment.name);
+    logger.info('Deleting environment...', { environmentId: environment.id, environmentName: environment.name });
 
     await batchDelete({
         ...opts,
@@ -36,7 +36,7 @@ export async function deleteEnvironmentData(environment: DBEnvironment, opts: Ba
 
 async function deleteEndUserData(environment: DBEnvironment, opts: BatchDeleteSharedOptions) {
     const { logger } = opts;
-    logger.info('Deleting all end users in environment...', environment.id, environment.name);
+    logger.info('Deleting all end users in environment...', { environmentId: environment.id, environmentName: environment.name });
 
     await batchDelete({
         ...opts,
@@ -56,7 +56,7 @@ async function deleteEndUserData(environment: DBEnvironment, opts: BatchDeleteSh
 
 async function deleteExternalWebhooksByEnvironmentId(environment: DBEnvironment, opts: BatchDeleteSharedOptions) {
     const { logger } = opts;
-    logger.info('Deleting all webhooks in environment...', environment.id, environment.name);
+    logger.info('Deleting all webhooks in environment...', { environmentId: environment.id, environmentName: environment.name });
 
     await batchDelete({
         ...opts,
@@ -74,7 +74,7 @@ async function deleteExternalWebhooksByEnvironmentId(environment: DBEnvironment,
 
 async function deleteSlackNotificationsByEnvironmentId(environment: DBEnvironment, opts: BatchDeleteSharedOptions) {
     const { logger } = opts;
-    logger.info('Deleting all slack notifications in environment...', environment.id, environment.name);
+    logger.info('Deleting all slack notifications in environment...', { environmentId: environment.id, environmentName: environment.name });
 
     await batchDelete({
         ...opts,
@@ -94,7 +94,7 @@ async function deleteSlackNotificationsByEnvironmentId(environment: DBEnvironmen
 
 async function deleteEnvironmentVariablesByEnvironmentId(environment: DBEnvironment, opts: BatchDeleteSharedOptions) {
     const { logger } = opts;
-    logger.info('Deleting all environment variables in environment...', environment.id, environment.name);
+    logger.info('Deleting all environment variables in environment...', { environmentId: environment.id, environmentName: environment.name });
 
     await batchDelete({
         ...opts,

--- a/packages/server/lib/crons/delete/deleteProviderConfigData.ts
+++ b/packages/server/lib/crons/delete/deleteProviderConfigData.ts
@@ -14,7 +14,7 @@ export async function deleteProviderConfigData(providerConfig: IntegrationConfig
     }
 
     const { logger, deadline, limit } = opts;
-    logger.info('Deleting provider config...', providerConfig.id, providerConfig.unique_key);
+    logger.info('Deleting provider config...', { providerConfigId: providerConfig.id, uniqueKey: providerConfig.unique_key });
 
     await batchDelete({
         name: 'syncConfigs < providerConfigs',

--- a/packages/server/lib/crons/delete/deleteSyncConfigData.ts
+++ b/packages/server/lib/crons/delete/deleteSyncConfigData.ts
@@ -58,7 +58,7 @@ export async function deleteSyncConfigData({ syncConfigId, environmentId }: Dele
 
         const delEndpoints = await hardDeleteEndpoints({ syncConfigId: version.id });
         if (delEndpoints) {
-            logger.info('deleted', delEndpoints, 'endpoints');
+            logger.info('deleted endpoints', { count: delEndpoints });
         }
     }
 

--- a/packages/server/lib/crons/trial.ts
+++ b/packages/server/lib/crons/trial.ts
@@ -100,7 +100,7 @@ export async function exec(): Promise<void> {
 
             for (const env of envs) {
                 const syncs = await getSyncsByEnvironmentId(env.id);
-                logger.info('  pausing', syncs.length, 'syncs in env', env.name);
+                logger.info('  pausing syncs in env', { count: syncs.length, environmentName: env.name });
 
                 for (const sync of syncs) {
                     const updated = await disableScriptConfig({ id: sync.id, environmentId: sync.environment_id });

--- a/packages/shared/lib/services/connections/credentials/refresh.ts
+++ b/packages/shared/lib/services/connections/credentials/refresh.ts
@@ -434,7 +434,7 @@ export async function refreshCredentialsIfNeeded({
                     return Ok({ connection, refreshed: false, credentials: freshCredentials });
                 }
 
-                logger.info('Refreshing', connection.id, 'because', shouldRefresh.reason);
+                logger.info('Refreshing connection', { connectionId: connection.id, reason: shouldRefresh.reason });
                 connectionToRefresh = connection;
             } catch (err) {
                 // lock acquisition might have timed out

--- a/packages/shared/lib/utils/error.manager.ts
+++ b/packages/shared/lib/utils/error.manager.ts
@@ -1,7 +1,7 @@
 import tracer from 'dd-trace';
 import * as uuid from 'uuid';
 
-import { errorToObject, getLogger } from '@nangohq/utils';
+import { getLogger } from '@nangohq/utils';
 
 import { NangoError } from './error.js';
 
@@ -43,7 +43,7 @@ class ErrorManager {
 
     public errResFromNangoErr(res: Response, err: NangoError | null) {
         if (err) {
-            logger.error(`Response error`, errorToObject(err));
+            logger.error('Response error', { err });
             if (err.type === 'script_http_error') {
                 res.status(424).json({
                     error: {

--- a/packages/utils/lib/errorSerialize.ts
+++ b/packages/utils/lib/errorSerialize.ts
@@ -6,7 +6,7 @@ import type { ErrorObject } from 'serialize-error';
  * Transform any Error or primitive to a json-serializable object for structured logging.
  */
 export function errorToObject(err: unknown): ErrorObject {
-    if (!err) {
+    if (err == null) {
         return { message: 'Unknown error' };
     }
 

--- a/packages/utils/lib/errorSerialize.ts
+++ b/packages/utils/lib/errorSerialize.ts
@@ -1,0 +1,18 @@
+import { serializeError } from 'serialize-error';
+
+import type { ErrorObject } from 'serialize-error';
+
+/**
+ * Transform any Error or primitive to a json-serializable object for structured logging.
+ */
+export function errorToObject(err: unknown): ErrorObject {
+    if (!err) {
+        return { message: 'Unknown error' };
+    }
+
+    if (typeof err === 'string' || typeof err === 'number' || typeof err === 'boolean') {
+        return { message: String(err) };
+    }
+
+    return serializeError(err, { maxDepth: 5 });
+}

--- a/packages/utils/lib/errorSerialize.unit.test.ts
+++ b/packages/utils/lib/errorSerialize.unit.test.ts
@@ -1,0 +1,21 @@
+import { describe, expect, it } from 'vitest';
+
+import { errorToObject } from './errorSerialize.js';
+
+describe('errorToObject', () => {
+    it('returns unknown error for null and undefined', () => {
+        expect(errorToObject(null)).toEqual({ message: 'Unknown error' });
+        expect(errorToObject(undefined)).toEqual({ message: 'Unknown error' });
+    });
+
+    it('preserves falsy primitive values', () => {
+        expect(errorToObject(0)).toEqual({ message: '0' });
+        expect(errorToObject(false)).toEqual({ message: 'false' });
+        expect(errorToObject('')).toEqual({ message: '' });
+    });
+
+    it('serializes Error instances', () => {
+        const err = new Error('boom');
+        expect(errorToObject(err)).toMatchObject({ name: 'Error', message: 'boom' });
+    });
+});

--- a/packages/utils/lib/errors.ts
+++ b/packages/utils/lib/errors.ts
@@ -1,6 +1,7 @@
 import * as Sentry from '@sentry/node';
 import { serializeError } from 'serialize-error';
 
+import { errorToObject } from './errorSerialize.js';
 import { getLogger } from './logger.js';
 import { NANGO_VERSION } from './version.js';
 
@@ -90,7 +91,7 @@ export function initSentry({ dsn, hash, applicationName }: { dsn: string | undef
 
 const logger = getLogger('err');
 export function report(err: unknown, extra?: Record<string, unknown>) {
-    const message = err instanceof Error ? err.message : 'Unhandled error';
+    const message = errorToObject(err).message || 'Unknown error';
     logger.error(message, { err, ...extra });
 
     if (!sentry) {

--- a/packages/utils/lib/errors.ts
+++ b/packages/utils/lib/errors.ts
@@ -4,24 +4,9 @@ import { serializeError } from 'serialize-error';
 import { getLogger } from './logger.js';
 import { NANGO_VERSION } from './version.js';
 
-import type { ErrorObject } from 'serialize-error';
+export { errorToObject } from './errorSerialize.js';
 
 const PROVIDER_ERROR_MESSAGE_FIELDS = ['message', 'error', 'error_description', 'error_message', 'detail', 'details', 'reason', 'description'];
-
-/**
- * Transform any Error or primitive to a json object
- */
-export function errorToObject(err: unknown): ErrorObject {
-    if (!err) {
-        return { message: 'Unknown error' };
-    }
-
-    if (typeof err === 'string' || typeof err === 'number' || typeof err === 'boolean') {
-        return { message: String(err) };
-    }
-
-    return serializeError(err, { maxDepth: 5 });
-}
 
 /**
  * Transform any Error or primitive to a string
@@ -105,12 +90,12 @@ export function initSentry({ dsn, hash, applicationName }: { dsn: string | undef
 
 const logger = getLogger('err');
 export function report(err: unknown, extra?: Record<string, unknown>) {
+    const message = err instanceof Error ? err.message : 'Unhandled error';
+    logger.error(message, { err, ...extra });
+
     if (!sentry) {
-        logger.error(stringifyError(err, { stack: true, cause: true, pretty: true }), extra);
         return;
     }
-
-    logger.error(err as any, extra);
 
     Sentry.withScope((scope) => {
         if (extra) {

--- a/packages/utils/lib/errors.unit.test.ts
+++ b/packages/utils/lib/errors.unit.test.ts
@@ -1,4 +1,4 @@
-import { describe, expect, it } from 'vitest';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
 
 import { stringifyError } from './errors.js';
 
@@ -270,5 +270,46 @@ describe('stringifyError', () => {
                 }
             });
         });
+    });
+});
+
+const { mockLoggerError } = vi.hoisted(() => ({
+    mockLoggerError: vi.fn()
+}));
+
+vi.mock('./logger.js', () => ({
+    getLogger: () => ({
+        error: mockLoggerError,
+        info: vi.fn(),
+        warning: vi.fn(),
+        debug: vi.fn(),
+        close: vi.fn()
+    })
+}));
+
+describe('report', () => {
+    beforeEach(() => {
+        mockLoggerError.mockClear();
+    });
+
+    it('uses Error.message as the log message', async () => {
+        const { report } = await import('./errors.js');
+        report(new Error('boom'));
+        expect(mockLoggerError).toHaveBeenCalledWith('boom', { err: expect.any(Error) });
+    });
+
+    it('uses string errors as the log message', async () => {
+        const { report } = await import('./errors.js');
+        report('Failed to update plan', { customer: 'c1' });
+        expect(mockLoggerError).toHaveBeenCalledWith('Failed to update plan', {
+            err: 'Failed to update plan',
+            customer: 'c1'
+        });
+    });
+
+    it('uses primitive errors as the log message', async () => {
+        const { report } = await import('./errors.js');
+        report(404);
+        expect(mockLoggerError).toHaveBeenCalledWith('404', { err: 404 });
     });
 });

--- a/packages/utils/lib/logger.ts
+++ b/packages/utils/lib/logger.ts
@@ -24,11 +24,68 @@ export interface StrictLogger {
 const SPLAT = Symbol.for('splat');
 const ERROR_KEYS = ['err', 'error', 'cause'] as const;
 const FORMAT_TOKENS = /%[scdjifoO%]/g;
+const ESCAPED_PERCENT = /%%/g;
 
 const level = process.env['LOG_LEVEL'] ? process.env['LOG_LEVEL'] : isTest ? 'error' : 'info';
 
 function isPlainObject(value: unknown): value is Record<string, unknown> {
     return typeof value === 'object' && value !== null && !Array.isArray(value) && !(value instanceof Error);
+}
+
+function countExpectedFormatArgs(message: string): number {
+    const tokens = message.match(FORMAT_TOKENS);
+    if (!tokens) {
+        return 0;
+    }
+
+    const escapes = message.match(ESCAPED_PERCENT)?.length ?? 0;
+    return tokens.length - escapes;
+}
+
+function mergeSplatArgs(info: Record<string, unknown>, splat: unknown[]): void {
+    if (splat.length === 0) {
+        return;
+    }
+
+    if (splat.length === 1) {
+        const arg = splat[0];
+        if (isPlainObject(arg)) {
+            Object.assign(info, arg);
+        } else if (arg instanceof Error) {
+            info['err'] = arg;
+        } else if (arg !== undefined) {
+            info['args'] = [arg];
+        }
+        return;
+    }
+
+    const errors = splat.filter((arg): arg is Error => arg instanceof Error);
+    const objects = splat.filter(isPlainObject);
+    const rest = splat.filter((arg) => arg !== undefined && !(arg instanceof Error) && !isPlainObject(arg));
+
+    if (objects.length === 1 && errors.length <= 1 && rest.length === 0) {
+        Object.assign(info, objects[0]);
+        if (errors[0]) {
+            info['err'] = errors[0];
+        }
+        return;
+    }
+
+    info['args'] = splat.map((arg) => (arg instanceof Error ? errorToObject(arg) : arg));
+    if (errors.length === 1 && info['err'] == null && info['error'] == null) {
+        info['err'] = errors[0];
+    }
+}
+
+function promoteFormatArgErrors(info: Record<string, unknown>, formatArgs: unknown[]): void {
+    if (info['err'] != null || info['error'] != null) {
+        return;
+    }
+
+    const err = formatArgs.find((arg): arg is Error => arg instanceof Error);
+    if (err) {
+        info['err'] = err;
+    }
 }
 
 function serializeErrorFields(info: Record<string, unknown>): void {
@@ -61,35 +118,19 @@ function normalizeSplatAndErrors() {
 
         if (splat?.length) {
             const message = typeof info.message === 'string' ? info.message : String(info.message);
-            const tokens = message.match(FORMAT_TOKENS);
+            const expectedFormatArgs = countExpectedFormatArgs(message);
 
-            if (tokens?.length) {
-                info.message = utilFormat(message, ...splat);
-            } else if (splat.length === 1) {
-                const arg = splat[0];
-                if (isPlainObject(arg)) {
-                    Object.assign(info, arg);
-                } else if (arg instanceof Error) {
-                    info['err'] = arg;
-                } else if (arg !== undefined) {
-                    info['args'] = [arg];
-                }
+            if (expectedFormatArgs > 0) {
+                const splatCopy = [...splat];
+                const extraCount = expectedFormatArgs - splatCopy.length;
+                const metas = extraCount < 0 ? splatCopy.splice(extraCount) : [];
+                const formatArgs = splatCopy;
+
+                info.message = utilFormat(message, ...formatArgs);
+                mergeSplatArgs(info as Record<string, unknown>, metas);
+                promoteFormatArgErrors(info as Record<string, unknown>, formatArgs);
             } else {
-                const errors = splat.filter((arg): arg is Error => arg instanceof Error);
-                const objects = splat.filter(isPlainObject);
-                const rest = splat.filter((arg) => arg !== undefined && !(arg instanceof Error) && !isPlainObject(arg));
-
-                if (objects.length === 1 && errors.length <= 1 && rest.length === 0) {
-                    Object.assign(info, objects[0]);
-                    if (errors[0]) {
-                        info['err'] = errors[0];
-                    }
-                } else {
-                    info['args'] = splat.map((arg) => (arg instanceof Error ? errorToObject(arg) : arg));
-                    if (errors.length === 1 && info['err'] == null && info['error'] == null) {
-                        info['err'] = errors[0];
-                    }
-                }
+                mergeSplatArgs(info as Record<string, unknown>, splat);
             }
         }
 

--- a/packages/utils/lib/logger.ts
+++ b/packages/utils/lib/logger.ts
@@ -118,12 +118,61 @@ function serializeErrorFields(info: Record<string, unknown>): void {
 }
 
 function stripWinstonMetaMessageAppend(message: string, splat: unknown[] | undefined): string {
-    if (splat?.length !== 1 || !isPlainObject(splat[0]) || typeof splat[0]['message'] !== 'string') {
+    const first = splat?.[0];
+    if (!isPlainObject(first) || typeof first['message'] !== 'string') {
         return message;
     }
 
-    const suffix = ` ${splat[0]['message']}`;
+    const suffix = ` ${first['message']}`;
     return message.endsWith(suffix) ? message.slice(0, -suffix.length) : message;
+}
+
+function resolveMessage(info: Record<string, unknown>, splat: unknown[] | undefined): string {
+    const raw = info['message'];
+
+    if (typeof raw === 'string') {
+        return stripWinstonMetaMessageAppend(raw, splat);
+    }
+
+    if (raw instanceof Error) {
+        if (info['err'] == null) {
+            info['err'] = raw;
+        }
+        return stripWinstonMetaMessageAppend(raw.message, splat);
+    }
+
+    if (isPlainObject(raw)) {
+        assignMetadata(info, raw);
+        const nestedMessage = raw['message'];
+        if (isPlainObject(nestedMessage)) {
+            assignMetadata(info, nestedMessage);
+        }
+
+        const text = typeof nestedMessage === 'string' ? nestedMessage : isPlainObject(nestedMessage) ? JSON.stringify(nestedMessage) : JSON.stringify(raw);
+        return stripWinstonMetaMessageAppend(text, splat);
+    }
+
+    if (raw == null) {
+        return stripWinstonMetaMessageAppend('', splat);
+    }
+
+    if (typeof raw === 'object') {
+        return stripWinstonMetaMessageAppend(JSON.stringify(raw), splat);
+    }
+
+    if (typeof raw === 'symbol') {
+        return stripWinstonMetaMessageAppend(raw.toString(), splat);
+    }
+
+    if (typeof raw === 'function') {
+        return stripWinstonMetaMessageAppend(raw.name || '[Function]', splat);
+    }
+
+    if (typeof raw === 'number' || typeof raw === 'boolean' || typeof raw === 'bigint') {
+        return stripWinstonMetaMessageAppend(String(raw), splat);
+    }
+
+    return stripWinstonMetaMessageAppend('', splat);
 }
 
 /**
@@ -134,7 +183,7 @@ function normalizeSplatAndErrors() {
     return winston.format((info) => {
         const canonicalLevel = info.level;
         const splat = info[SPLAT] as unknown[] | undefined;
-        let message = stripWinstonMetaMessageAppend(typeof info.message === 'string' ? info.message : String(info.message), splat);
+        let message = resolveMessage(info as Record<string, unknown>, splat);
 
         if (splat?.length) {
             const expectedFormatArgs = countExpectedFormatArgs(message);

--- a/packages/utils/lib/logger.ts
+++ b/packages/utils/lib/logger.ts
@@ -1,9 +1,10 @@
-import { inspect } from 'node:util';
+import { format as utilFormat, inspect } from 'node:util';
 
 import colors from '@colors/colors';
 import winston from 'winston';
 
 import { isCloud, isEnterprise, isTest } from './environment/detection.js';
+import { errorToObject } from './errorSerialize.js';
 
 import type { LeveledLogMethod, Logform } from 'winston';
 
@@ -21,7 +22,81 @@ export interface StrictLogger {
 }
 
 const SPLAT = Symbol.for('splat');
+const ERROR_KEYS = ['err', 'error', 'cause'] as const;
+const FORMAT_TOKENS = /%[scdjifoO%]/g;
+
 const level = process.env['LOG_LEVEL'] ? process.env['LOG_LEVEL'] : isTest ? 'error' : 'info';
+
+function isPlainObject(value: unknown): value is Record<string, unknown> {
+    return typeof value === 'object' && value !== null && !Array.isArray(value) && !(value instanceof Error);
+}
+
+function serializeErrorFields(info: Record<string, unknown>): void {
+    for (const key of ERROR_KEYS) {
+        if (info[key] != null) {
+            info[key] = errorToObject(info[key]);
+        }
+    }
+
+    if (info['stack']) {
+        return;
+    }
+
+    for (const key of ERROR_KEYS) {
+        const serialized = info[key];
+        if (serialized && typeof serialized === 'object' && typeof (serialized as { stack?: unknown }).stack === 'string') {
+            info['stack'] = (serialized as { stack: string }).stack;
+            return;
+        }
+    }
+}
+
+/**
+ * Replaces winston's splat formatter for cloud JSON output. Merges metadata objects, serializes
+ * err/error/cause fields, and collects leftover positional primitives into an `args` array.
+ */
+function normalizeSplatAndErrors() {
+    return winston.format((info) => {
+        const splat = info[SPLAT] as unknown[] | undefined;
+
+        if (splat?.length) {
+            const message = typeof info.message === 'string' ? info.message : String(info.message);
+            const tokens = message.match(FORMAT_TOKENS);
+
+            if (tokens?.length) {
+                info.message = utilFormat(message, ...splat);
+            } else if (splat.length === 1) {
+                const arg = splat[0];
+                if (isPlainObject(arg)) {
+                    Object.assign(info, arg);
+                } else if (arg instanceof Error) {
+                    info['err'] = arg;
+                } else if (arg !== undefined) {
+                    info['args'] = [arg];
+                }
+            } else {
+                const errors = splat.filter((arg): arg is Error => arg instanceof Error);
+                const objects = splat.filter(isPlainObject);
+                const rest = splat.filter((arg) => arg !== undefined && !(arg instanceof Error) && !isPlainObject(arg));
+
+                if (objects.length === 1 && errors.length <= 1 && rest.length === 0) {
+                    Object.assign(info, objects[0]);
+                    if (errors[0]) {
+                        info['err'] = errors[0];
+                    }
+                } else {
+                    info['args'] = splat.map((arg) => (arg instanceof Error ? errorToObject(arg) : arg));
+                    if (errors.length === 1 && info['err'] == null && info['error'] == null) {
+                        info['err'] = errors[0];
+                    }
+                }
+            }
+        }
+
+        serializeErrorFields(info as Record<string, unknown>);
+        return info;
+    })();
+}
 
 let formatters: Logform.Format[] = [];
 if (!isCloud && !isEnterprise) {
@@ -61,7 +136,7 @@ if (!isCloud && !isEnterprise) {
     // and stack traces don't split across multiple log entries.
     formatters = [
         winston.format.errors({ stack: true }),
-        winston.format.splat(),
+        normalizeSplatAndErrors(),
         winston.format.timestamp(),
         winston.format((info) => {
             info['status'] = info.level;

--- a/packages/utils/lib/logger.ts
+++ b/packages/utils/lib/logger.ts
@@ -57,11 +57,17 @@ if (!isCloud && !isEnterprise) {
         })
     ];
 } else {
+    // Structured JSON for log collectors (Datadog). One NDJSON line per event so payloads
+    // and stack traces don't split across multiple log entries.
     formatters = [
-        winston.format.printf((info) => {
-            const splat = info[SPLAT] && info[SPLAT].length > 0 ? JSON.stringify(info[SPLAT]) : '';
-            return `${info['service'] ? ` [${info['service']}] ` : ''}${info.message} ${splat}`;
-        })
+        winston.format.errors({ stack: true }),
+        winston.format.splat(),
+        winston.format.timestamp(),
+        winston.format((info) => {
+            info['status'] = info.level;
+            return info;
+        })(),
+        winston.format.json()
     ];
 }
 

--- a/packages/utils/lib/logger.ts
+++ b/packages/utils/lib/logger.ts
@@ -5,6 +5,7 @@ import winston from 'winston';
 
 import { isCloud, isEnterprise, isTest } from './environment/detection.js';
 import { errorToObject } from './errorSerialize.js';
+import { stringifyObject } from './json.js';
 
 import type { LeveledLogMethod, Logform } from 'winston';
 
@@ -127,6 +128,14 @@ function stripWinstonMetaMessageAppend(message: string, splat: unknown[] | undef
     return message.endsWith(suffix) ? message.slice(0, -suffix.length) : message;
 }
 
+function stringifyMessageValue(value: unknown): string {
+    try {
+        return stringifyObject(value);
+    } catch {
+        return inspect(value, { depth: 5, breakLength: Infinity, compact: true });
+    }
+}
+
 function resolveMessage(info: Record<string, unknown>, splat: unknown[] | undefined): string {
     const raw = info['message'];
 
@@ -148,7 +157,12 @@ function resolveMessage(info: Record<string, unknown>, splat: unknown[] | undefi
             assignMetadata(info, nestedMessage);
         }
 
-        const text = typeof nestedMessage === 'string' ? nestedMessage : isPlainObject(nestedMessage) ? JSON.stringify(nestedMessage) : JSON.stringify(raw);
+        const text =
+            typeof nestedMessage === 'string'
+                ? nestedMessage
+                : isPlainObject(nestedMessage)
+                  ? stringifyMessageValue(nestedMessage)
+                  : stringifyMessageValue(raw);
         return stripWinstonMetaMessageAppend(text, splat);
     }
 
@@ -157,7 +171,7 @@ function resolveMessage(info: Record<string, unknown>, splat: unknown[] | undefi
     }
 
     if (typeof raw === 'object') {
-        return stripWinstonMetaMessageAppend(JSON.stringify(raw), splat);
+        return stripWinstonMetaMessageAppend(stringifyMessageValue(raw), splat);
     }
 
     if (typeof raw === 'symbol') {

--- a/packages/utils/lib/logger.ts
+++ b/packages/utils/lib/logger.ts
@@ -25,6 +25,7 @@ const SPLAT = Symbol.for('splat');
 const ERROR_KEYS = ['err', 'error', 'cause'] as const;
 const FORMAT_TOKENS = /%[scdjifoO%]/g;
 const ESCAPED_PERCENT = /%%/g;
+const RESERVED_INFO_KEYS = new Set(['level', 'message', 'service', 'timestamp', 'status', 'stack', 'splat']);
 
 const level = process.env['LOG_LEVEL'] ? process.env['LOG_LEVEL'] : isTest ? 'error' : 'info';
 
@@ -42,6 +43,14 @@ function countExpectedFormatArgs(message: string): number {
     return tokens.length - escapes;
 }
 
+function assignMetadata(info: Record<string, unknown>, meta: Record<string, unknown>): void {
+    for (const [key, value] of Object.entries(meta)) {
+        if (!RESERVED_INFO_KEYS.has(key)) {
+            info[key] = value;
+        }
+    }
+}
+
 function mergeSplatArgs(info: Record<string, unknown>, splat: unknown[]): void {
     if (splat.length === 0) {
         return;
@@ -50,7 +59,7 @@ function mergeSplatArgs(info: Record<string, unknown>, splat: unknown[]): void {
     if (splat.length === 1) {
         const arg = splat[0];
         if (isPlainObject(arg)) {
-            Object.assign(info, arg);
+            assignMetadata(info, arg);
         } else if (arg instanceof Error) {
             info['err'] = arg;
         } else if (arg !== undefined) {
@@ -64,7 +73,7 @@ function mergeSplatArgs(info: Record<string, unknown>, splat: unknown[]): void {
     const rest = splat.filter((arg) => arg !== undefined && !(arg instanceof Error) && !isPlainObject(arg));
 
     if (objects.length === 1 && errors.length <= 1 && rest.length === 0) {
-        Object.assign(info, objects[0]);
+        assignMetadata(info, objects[0]!);
         if (errors[0]) {
             info['err'] = errors[0];
         }
@@ -108,16 +117,26 @@ function serializeErrorFields(info: Record<string, unknown>): void {
     }
 }
 
+function stripWinstonMetaMessageAppend(message: string, splat: unknown[] | undefined): string {
+    if (splat?.length !== 1 || !isPlainObject(splat[0]) || typeof splat[0]['message'] !== 'string') {
+        return message;
+    }
+
+    const suffix = ` ${splat[0]['message']}`;
+    return message.endsWith(suffix) ? message.slice(0, -suffix.length) : message;
+}
+
 /**
  * Replaces winston's splat formatter for cloud JSON output. Merges metadata objects, serializes
  * err/error/cause fields, and collects leftover positional primitives into an `args` array.
  */
 function normalizeSplatAndErrors() {
     return winston.format((info) => {
+        const canonicalLevel = info.level;
         const splat = info[SPLAT] as unknown[] | undefined;
+        let message = stripWinstonMetaMessageAppend(typeof info.message === 'string' ? info.message : String(info.message), splat);
 
         if (splat?.length) {
-            const message = typeof info.message === 'string' ? info.message : String(info.message);
             const expectedFormatArgs = countExpectedFormatArgs(message);
 
             if (expectedFormatArgs > 0) {
@@ -126,13 +145,16 @@ function normalizeSplatAndErrors() {
                 const metas = extraCount < 0 ? splatCopy.splice(extraCount) : [];
                 const formatArgs = splatCopy;
 
-                info.message = utilFormat(message, ...formatArgs);
+                message = utilFormat(message, ...formatArgs);
                 mergeSplatArgs(info as Record<string, unknown>, metas);
                 promoteFormatArgErrors(info as Record<string, unknown>, formatArgs);
             } else {
                 mergeSplatArgs(info as Record<string, unknown>, splat);
             }
         }
+
+        info.message = message;
+        info.level = canonicalLevel;
 
         serializeErrorFields(info as Record<string, unknown>);
         return info;

--- a/packages/utils/lib/logger.unit.test.ts
+++ b/packages/utils/lib/logger.unit.test.ts
@@ -118,4 +118,16 @@ describe('logger cloud format', () => {
         expect(parsed.err.message).toBe('format-arg');
         expect(parsed.stack).toBeDefined();
     });
+
+    it('does not let metadata overwrite canonical log fields', async () => {
+        const logger = await getTestLogger();
+
+        logger.info('original message', { message: 'overridden', level: 'error', connectionId: 1 });
+
+        const parsed = JSON.parse(lines[0]!);
+        expect(parsed.message).toBe('original message');
+        expect(parsed.level).toBe('info');
+        expect(parsed.status).toBe('info');
+        expect(parsed.connectionId).toBe(1);
+    });
 });

--- a/packages/utils/lib/logger.unit.test.ts
+++ b/packages/utils/lib/logger.unit.test.ts
@@ -93,4 +93,29 @@ describe('logger cloud format', () => {
         expect(parsed.environmentId).toBe(1);
         expect(parsed.environmentName).toBe('prod');
     });
+
+    it('merges metadata after tokenized message interpolation', async () => {
+        const logger = await getTestLogger();
+        const err = new Error('tokenized');
+
+        logger.error('request %s failed', 'abc-123', { err, statusCode: 500 });
+
+        const parsed = JSON.parse(lines[0]!);
+        expect(parsed.message).toBe('request abc-123 failed');
+        expect(parsed.statusCode).toBe(500);
+        expect(parsed.err.message).toBe('tokenized');
+        expect(parsed.stack).toBeDefined();
+    });
+
+    it('serializes Error used as a format token argument', async () => {
+        const logger = await getTestLogger();
+        const err = new Error('format-arg');
+
+        logger.error('failed: %s', err);
+
+        const parsed = JSON.parse(lines[0]!);
+        expect(parsed.message).toContain('failed:');
+        expect(parsed.err.message).toBe('format-arg');
+        expect(parsed.stack).toBeDefined();
+    });
 });

--- a/packages/utils/lib/logger.unit.test.ts
+++ b/packages/utils/lib/logger.unit.test.ts
@@ -1,0 +1,96 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+
+type NodeConsole = Console & {
+    _stdout: NodeJS.WriteStream;
+    _stderr: NodeJS.WriteStream;
+};
+
+describe('logger cloud format', () => {
+    let lines: string[] = [];
+    let stdoutSpy: ReturnType<typeof vi.spyOn>;
+    let stderrSpy: ReturnType<typeof vi.spyOn>;
+
+    const nodeConsole = console as NodeConsole;
+
+    beforeEach(() => {
+        vi.stubEnv('NANGO_CLOUD', 'true');
+        vi.stubEnv('LOG_LEVEL', 'info');
+        vi.resetModules();
+        lines = [];
+
+        const capture = (chunk: string | Uint8Array) => {
+            const line = String(chunk).trim();
+            if (line) {
+                lines.push(line);
+            }
+            return true;
+        };
+
+        stdoutSpy = vi.spyOn(nodeConsole._stdout, 'write').mockImplementation(capture as typeof process.stdout.write);
+        stderrSpy = vi.spyOn(nodeConsole._stderr, 'write').mockImplementation(capture as typeof process.stderr.write);
+    });
+
+    afterEach(() => {
+        stdoutSpy.mockRestore();
+        stderrSpy.mockRestore();
+        vi.unstubAllEnvs();
+    });
+
+    async function getTestLogger() {
+        const { getLogger } = await import('./logger.js');
+        return getLogger('test');
+    }
+
+    it('serializes err metadata with stack lifted to top level', async () => {
+        const logger = await getTestLogger();
+        const err = new Error('boom');
+        err.stack = 'Error: boom\n    at test.ts:1:1';
+
+        logger.error('context message', { err });
+
+        expect(lines).toHaveLength(1);
+        const parsed = JSON.parse(lines[0]!);
+        expect(parsed.message).toBe('context message');
+        expect(parsed.service).toBe('test');
+        expect(parsed.status).toBe('error');
+        expect(parsed.err).toEqual({ name: 'Error', message: 'boom', stack: 'Error: boom\n    at test.ts:1:1' });
+        expect(parsed.stack).toBe('Error: boom\n    at test.ts:1:1');
+    });
+
+    it('serializes a positional Error as err', async () => {
+        const logger = await getTestLogger();
+        const err = new Error('positional');
+
+        logger.error('failed', err);
+
+        const parsed = JSON.parse(lines[0]!);
+        expect(parsed.message).toContain('failed');
+        expect(parsed.err.name).toBe('Error');
+        expect(parsed.err.message).toBe('positional');
+        expect(parsed.stack).toBeDefined();
+    });
+
+    it('merges metadata objects and serializes error key', async () => {
+        const logger = await getTestLogger();
+        const err = new Error('wrapped');
+
+        logger.warning('webhook failed', { error: err, connectionId: 42 });
+
+        const parsed = JSON.parse(lines[0]!);
+        expect(parsed.message).toBe('webhook failed');
+        expect(parsed.connectionId).toBe(42);
+        expect(parsed.error.message).toBe('wrapped');
+        expect(parsed.status).toBe('warning');
+    });
+
+    it('keeps structured fields for object metadata without errors', async () => {
+        const logger = await getTestLogger();
+
+        logger.info('Deleting environment...', { environmentId: 1, environmentName: 'prod' });
+
+        const parsed = JSON.parse(lines[0]!);
+        expect(parsed.message).toBe('Deleting environment...');
+        expect(parsed.environmentId).toBe(1);
+        expect(parsed.environmentName).toBe('prod');
+    });
+});

--- a/packages/utils/lib/logger.unit.test.ts
+++ b/packages/utils/lib/logger.unit.test.ts
@@ -147,8 +147,22 @@ describe('logger cloud format', () => {
         logger.info({ level: 'info', message: { event: 'started', connectionId: 42 } });
 
         const parsed = JSON.parse(lines[0]!);
-        expect(parsed.message).toBe('{"event":"started","connectionId":42}');
+        expect(JSON.parse(parsed.message)).toEqual({ event: 'started', connectionId: 42 });
         expect(parsed.event).toBe('started');
         expect(parsed.connectionId).toBe(42);
+    });
+
+    it('does not throw on circular object messages', async () => {
+        const logger = await getTestLogger();
+        const circular: Record<string, unknown> = { event: 'started', connectionId: 42 };
+        circular['self'] = circular;
+
+        expect(() => logger.info({ message: circular })).not.toThrow();
+
+        const parsed = JSON.parse(lines[0]!);
+        expect(parsed.event).toBe('started');
+        expect(parsed.connectionId).toBe(42);
+        expect(parsed.message).toContain('started');
+        expect(parsed.message).toContain('[Circular]');
     });
 });

--- a/packages/utils/lib/logger.unit.test.ts
+++ b/packages/utils/lib/logger.unit.test.ts
@@ -130,4 +130,25 @@ describe('logger cloud format', () => {
         expect(parsed.status).toBe('info');
         expect(parsed.connectionId).toBe(1);
     });
+
+    it('strips winston meta.message append when extra splat args are present', async () => {
+        const logger = await getTestLogger();
+
+        logger.info('original message', { message: 'overridden', connectionId: 1 }, 'extra');
+
+        const parsed = JSON.parse(lines[0]!);
+        expect(parsed.message).toBe('original message');
+        expect(parsed.connectionId).toBe(1);
+    });
+
+    it('preserves structured object messages as metadata', async () => {
+        const logger = await getTestLogger();
+
+        logger.info({ level: 'info', message: { event: 'started', connectionId: 42 } });
+
+        const parsed = JSON.parse(lines[0]!);
+        expect(parsed.message).toBe('{"event":"started","connectionId":42}');
+        expect(parsed.event).toBe('started');
+        expect(parsed.connectionId).toBe(42);
+    });
 });


### PR DESCRIPTION
Cloud/enterprise logs were emitted as plain text with no level field, so Datadog treated everything as info and metadata was appended as an unreadable JSON blob. Pretty-printed errors and stacks could also split across multiple log events.

Switch the production formatter to structured NDJSON (one line per event) with level/status, timestamps, splat metadata as top-level fields, and proper error stack handling. Local dev formatting is unchanged.

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/NangoHQ/nango/pull/6522?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

