### PR TITLE
fix(metering): fix incr errors due to float

### DIFF
--- a/packages/metering/lib/processors/usage.ts
+++ b/packages/metering/lib/processors/usage.ts
@@ -154,11 +154,11 @@ export class UsageProcessor {
                     const incrCompute = await this.usageTracker.incr({
                         accountId: accountId,
                         metric: 'function_compute_gbms',
-                        delta: compute
+                        delta: Math.round(compute) // HINCRBY requires an integer; compute (durationMs * memoryGb) is fractional
                     });
                     if (incrCompute.isErr()) {
                         logger.error(
-                            `Failed to increment function_compute_gbms for account ${accountId} (durationMs=${telemetryBag?.durationMs}, memoryGb=${telemetryBag?.memoryGb}, compute=${compute}): ${stringifyError(incrCompute.error, { cause: true })}`
+                            `Failed to increment function_compute_gbms for account ${accountId}: ${stringifyError(incrCompute.error, { cause: true })}`
                         );
                     }
                     const incrLogs = await this.usageTracker.incr({

--- a/packages/metering/lib/processors/usage.ts
+++ b/packages/metering/lib/processors/usage.ts
@@ -154,11 +154,11 @@ export class UsageProcessor {
                     const incrCompute = await this.usageTracker.incr({
                         accountId: accountId,
                         metric: 'function_compute_gbms',
-                        delta: Math.round(compute) // HINCRBY requires an integer; compute is fractional gb*ms
+                        delta: compute
                     });
                     if (incrCompute.isErr()) {
                         logger.error(
-                            `Failed to increment function_compute_gbms for account ${accountId}: ${stringifyError(incrCompute.error, { cause: true })}`
+                            `Failed to increment function_compute_gbms for account ${accountId} (durationMs=${telemetryBag?.durationMs}, memoryGb=${telemetryBag?.memoryGb}, compute=${compute}): ${stringifyError(incrCompute.error, { cause: true })}`
                         );
                     }
                     const incrLogs = await this.usageTracker.incr({

--- a/packages/metering/lib/processors/usage.ts
+++ b/packages/metering/lib/processors/usage.ts
@@ -154,7 +154,7 @@ export class UsageProcessor {
                     const incrCompute = await this.usageTracker.incr({
                         accountId: accountId,
                         metric: 'function_compute_gbms',
-                        delta: Math.round(compute) // HINCRBY requires an integer; compute (durationMs * memoryGb) is fractional
+                        delta: compute > 0 ? Math.max(1, Math.round(compute)) : 0 // HINCRBY needs an integer; floor non-zero compute at 1 so small values aren't dropped
                     });
                     if (incrCompute.isErr()) {
                         logger.error(

--- a/packages/metering/lib/processors/usage.ts
+++ b/packages/metering/lib/processors/usage.ts
@@ -39,6 +39,12 @@ export class UsageProcessor {
         });
     }
 
+    private logIncrError(metric: string, accountId: number, result: Result<unknown>): void {
+        if (result.isErr()) {
+            logger.error(`Failed to increment ${metric} for account ${accountId}: ${stringifyError(result.error, { cause: true })}`);
+        }
+    }
+
     public async process(event: UsageEvent): Promise<Result<void>> {
         try {
             switch (event.type) {
@@ -80,9 +86,7 @@ export class UsageProcessor {
                         metric: 'records',
                         delta: event.payload.value
                     });
-                    if (incrRecords.isErr()) {
-                        logger.error(`Failed to increment records for account ${accountId}: ${stringifyError(incrRecords.error, { cause: true })}`);
-                    }
+                    this.logIncrError('records', accountId, incrRecords);
                     return Ok(undefined); // No billing action for records, just tracking usage
                 }
                 case 'usage.actions': {
@@ -146,29 +150,19 @@ export class UsageProcessor {
                         metric: 'function_executions',
                         delta: event.payload.value
                     });
-                    if (incrExecutions.isErr()) {
-                        logger.error(
-                            `Failed to increment function_executions for account ${accountId}: ${stringifyError(incrExecutions.error, { cause: true })}`
-                        );
-                    }
+                    this.logIncrError('function_executions', accountId, incrExecutions);
                     const incrCompute = await this.usageTracker.incr({
                         accountId: accountId,
                         metric: 'function_compute_gbms',
                         delta: compute > 0 ? Math.max(1, Math.round(compute)) : 0 // HINCRBY needs an integer; floor non-zero compute at 1 so small values aren't dropped
                     });
-                    if (incrCompute.isErr()) {
-                        logger.error(
-                            `Failed to increment function_compute_gbms for account ${accountId}: ${stringifyError(incrCompute.error, { cause: true })}`
-                        );
-                    }
+                    this.logIncrError('function_compute_gbms', accountId, incrCompute);
                     const incrLogs = await this.usageTracker.incr({
                         accountId: accountId,
                         metric: 'function_logs',
                         delta: customLogs
                     });
-                    if (incrLogs.isErr()) {
-                        logger.error(`Failed to increment logs for account ${accountId}: ${stringifyError(incrLogs.error, { cause: true })}`);
-                    }
+                    this.logIncrError('function_logs', accountId, incrLogs);
 
                     // Clickhouse
                     this.clickhouse.add([event]);
@@ -266,9 +260,7 @@ export class UsageProcessor {
                         metric: 'webhook_forwards',
                         delta: event.payload.value
                     });
-                    if (incrWebhook.isErr()) {
-                        logger.error(`Failed to increment webhook_forwards for account ${accountId}: ${stringifyError(incrWebhook.error, { cause: true })}`);
-                    }
+                    this.logIncrError('webhook_forwards', accountId, incrWebhook);
                     // Clickhouse
                     this.clickhouse.add([event]);
                     // Billing

--- a/packages/metering/lib/processors/usage.ts
+++ b/packages/metering/lib/processors/usage.ts
@@ -147,7 +147,9 @@ export class UsageProcessor {
                         delta: event.payload.value
                     });
                     if (incrExecutions.isErr()) {
-                        logger.error(`Failed to increment function_executions for account ${accountId}: ${stringifyError(incrExecutions.error, { cause: true })}`);
+                        logger.error(
+                            `Failed to increment function_executions for account ${accountId}: ${stringifyError(incrExecutions.error, { cause: true })}`
+                        );
                     }
                     const incrCompute = await this.usageTracker.incr({
                         accountId: accountId,
@@ -155,7 +157,9 @@ export class UsageProcessor {
                         delta: compute
                     });
                     if (incrCompute.isErr()) {
-                        logger.error(`Failed to increment function_compute_ms for account ${accountId}: ${stringifyError(incrCompute.error, { cause: true })}`);
+                        logger.error(
+                            `Failed to increment function_compute_gbms for account ${accountId}: ${stringifyError(incrCompute.error, { cause: true })}`
+                        );
                     }
                     const incrLogs = await this.usageTracker.incr({
                         accountId: accountId,

--- a/packages/metering/lib/processors/usage.ts
+++ b/packages/metering/lib/processors/usage.ts
@@ -81,7 +81,7 @@ export class UsageProcessor {
                         delta: event.payload.value
                     });
                     if (incrRecords.isErr()) {
-                        logger.error(`Failed to increment records for account ${accountId}: ${incrRecords.error}`);
+                        logger.error(`Failed to increment records for account ${accountId}: ${stringifyError(incrRecords.error, { cause: true })}`);
                     }
                     return Ok(undefined); // No billing action for records, just tracking usage
                 }
@@ -147,7 +147,7 @@ export class UsageProcessor {
                         delta: event.payload.value
                     });
                     if (incrExecutions.isErr()) {
-                        logger.error(`Failed to increment function_executions for account ${accountId}: ${incrExecutions.error}`);
+                        logger.error(`Failed to increment function_executions for account ${accountId}: ${stringifyError(incrExecutions.error, { cause: true })}`);
                     }
                     const incrCompute = await this.usageTracker.incr({
                         accountId: accountId,
@@ -155,7 +155,7 @@ export class UsageProcessor {
                         delta: compute
                     });
                     if (incrCompute.isErr()) {
-                        logger.error(`Failed to increment function_compute_ms for account ${accountId}: ${incrCompute.error}`);
+                        logger.error(`Failed to increment function_compute_ms for account ${accountId}: ${stringifyError(incrCompute.error, { cause: true })}`);
                     }
                     const incrLogs = await this.usageTracker.incr({
                         accountId: accountId,
@@ -163,7 +163,7 @@ export class UsageProcessor {
                         delta: customLogs
                     });
                     if (incrLogs.isErr()) {
-                        logger.error(`Failed to increment logs for account ${accountId}: ${incrLogs.error}`);
+                        logger.error(`Failed to increment logs for account ${accountId}: ${stringifyError(incrLogs.error, { cause: true })}`);
                     }
 
                     // Clickhouse
@@ -263,7 +263,7 @@ export class UsageProcessor {
                         delta: event.payload.value
                     });
                     if (incrWebhook.isErr()) {
-                        logger.error(`Failed to increment webhook_forwards for account ${accountId}: ${incrWebhook.error}`);
+                        logger.error(`Failed to increment webhook_forwards for account ${accountId}: ${stringifyError(incrWebhook.error, { cause: true })}`);
                     }
                     // Clickhouse
                     this.clickhouse.add([event]);

--- a/packages/metering/lib/processors/usage.ts
+++ b/packages/metering/lib/processors/usage.ts
@@ -154,7 +154,7 @@ export class UsageProcessor {
                     const incrCompute = await this.usageTracker.incr({
                         accountId: accountId,
                         metric: 'function_compute_gbms',
-                        delta: compute
+                        delta: Math.round(compute) // HINCRBY requires an integer; compute is fractional gb*ms
                     });
                     if (incrCompute.isErr()) {
                         logger.error(


### PR DESCRIPTION
- **Fix fractional `function_compute_gbms` increment.** `compute = durationMs * memoryGb` is fractional (Lambda reports `memoryGb` as `MB/1024`), but the usage cache increments via Redis `HINCRBY`, which only accepts integers. The increment errored on every function execution, so `function_compute_gbms` was never tracked in the cache. The delta is now rounded to an integer, floored at 1 for any non-zero compute so short, low-memory executions aren't dropped. Billing is unaffected — the Orb path keeps using the exact float separately.
- **Surface the underlying cause in usage incr error logs.** The `Failed to increment <metric>` logs interpolated the `Result` error directly, which calls `Error.toString()` and drops the `{ cause }` set by `UsageCache.incr` — so every log read `Error: cache_incr_error` with no hint at the real Redis failure. They now use `stringifyError(err, { cause: true })`. This is what made the bug above diagnosable.
- **Extract a `logIncrError` helper** for the five near-identical increment-error log sites, and align the log labels with the real metric names (`function_compute_ms` → `function_compute_gbms`, `logs` → `function_logs`).

## Operational notes
- `function_compute_gbms` will start incrementing where it was previously frozen; values self-heal to correct totals on the next revalidation. Existing Datadog monitors/queries keyed on the old log strings (`function_compute_ms`, `Failed to increment logs`) need updating to the new labels.

## Test plan
- [x] Deployed to dev; confirmed the new logs surface the real cause (`MultiErrorReply` from `HINCRBY` on a fractional delta).
- [ ] Verify on dev that `Failed to increment function_compute_gbms` drops to zero after this change.
- [ ] Update any Datadog monitors/saved queries referencing the old log labels.