### PR TITLE
feat(impersonation): cap impersonation sessions to a configurable role

### DIFF
--- a/packages/server/lib/authz/middleware.ts
+++ b/packages/server/lib/authz/middleware.ts
@@ -12,14 +12,15 @@ type ScopedPermission = Omit<Permission, 'scope'> & { scopedBy: (locals: Request
 
 export function can(permission: Permission | ScopedPermission): RequestHandler {
     return async (_req, res, next) => {
-        if (!flags.hasAuthRoles) {
+        const { plan, user, forceRbac } = res.locals as RequestLocals;
+
+        // forceRbac (impersonation override) enforces RBAC regardless of the feature flag or plan entitlement.
+        if (!forceRbac && !flags.hasAuthRoles) {
             next();
             return;
         }
 
-        const { plan, user } = res.locals as RequestLocals;
-
-        if (flagHasPlan && (!plan || !plan.has_rbac)) {
+        if (!forceRbac && flagHasPlan && (!plan || !plan.has_rbac)) {
             next();
             return;
         }

--- a/packages/server/lib/middleware/access.middleware.ts
+++ b/packages/server/lib/middleware/access.middleware.ts
@@ -637,7 +637,8 @@ async function fillLocalsFromSession(req: Request, res: Response<any, RequestLoc
             return;
         }
 
-        user.role = resolveImpersonationRole({ role: user.role, debugMode: req.session.debugMode, override: envs.NANGO_IMPERSONATION_ROLE });
+        const impersonation = resolveImpersonationRole({ role: user.role, debugMode: req.session.debugMode, override: envs.NANGO_IMPERSONATION_ROLE });
+        user.role = impersonation.role;
 
         const account = await accountService.getAccountById(db.knex, user.account_id);
         if (!account) {
@@ -658,6 +659,7 @@ async function fillLocalsFromSession(req: Request, res: Response<any, RequestLoc
         res.locals['user'] = user;
         res.locals['account'] = account;
         res.locals['plan'] = plan;
+        res.locals['forceRbac'] = impersonation.forced;
 
         const fullPath = path.join(req.baseUrl, req.route.path);
         if (ignoreEnvPaths.includes(fullPath)) {

--- a/packages/server/lib/middleware/access.middleware.ts
+++ b/packages/server/lib/middleware/access.middleware.ts
@@ -19,6 +19,7 @@ import {
 } from '@nangohq/utils';
 
 import { envs } from '../env.js';
+import { resolveImpersonationRole } from './impersonation.js';
 import { connectSessionTokenPrefix, connectSessionTokenSchema } from '../helpers/validation.js';
 import * as connectSessionService from '../services/connectSession.service.js';
 
@@ -635,6 +636,8 @@ async function fillLocalsFromSession(req: Request, res: Response<any, RequestLoc
             res.status(401).send({ error: { code: 'unknown_user' } });
             return;
         }
+
+        user.role = resolveImpersonationRole({ role: user.role, debugMode: req.session.debugMode, override: envs.NANGO_IMPERSONATION_ROLE });
 
         const account = await accountService.getAccountById(db.knex, user.account_id);
         if (!account) {

--- a/packages/server/lib/middleware/impersonation.integration.test.ts
+++ b/packages/server/lib/middleware/impersonation.integration.test.ts
@@ -45,7 +45,6 @@ describe('impersonation role override', () => {
         const adminSession = await authenticateUser(api, admin.user);
         const res = await api.fetch('/api/v1/admin/impersonate', {
             method: 'POST',
-            // @ts-expect-error query not in endpoint type
             query: { env: 'dev' },
             session: adminSession,
             body: { accountUUID: targetAccountUUID, loginReason: 'regression test' }

--- a/packages/server/lib/middleware/impersonation.integration.test.ts
+++ b/packages/server/lib/middleware/impersonation.integration.test.ts
@@ -1,0 +1,107 @@
+import { afterAll, afterEach, beforeAll, beforeEach, describe, expect, it } from 'vitest';
+
+import db from '@nangohq/database';
+import { seeders } from '@nangohq/shared';
+import { flags } from '@nangohq/utils';
+
+import { envs } from '../env.js';
+import { authenticateUser, runServer } from '../utils/tests.js';
+
+import type { DBEnvironment } from '@nangohq/types';
+
+let api: Awaited<ReturnType<typeof runServer>>;
+
+describe('impersonation role override', () => {
+    beforeAll(async () => {
+        api = await runServer();
+    });
+    afterAll(() => {
+        api.server.close();
+    });
+    beforeEach(() => {
+        flags.hasAuthRoles = true;
+        flags.hasAdminCapabilities = true;
+    });
+    afterEach(() => {
+        flags.hasAuthRoles = true;
+        flags.hasAdminCapabilities = false;
+        (envs as any).NANGO_ADMIN_UUID = undefined;
+        (envs as any).NANGO_IMPERSONATION_ROLE = undefined;
+    });
+
+    // Account with a production env and a default (administrator) user, RBAC enforced.
+    async function seedTargetWithProdEnv() {
+        const { account } = await seeders.seedAccountEnvAndUser({ plan: { has_rbac: true } });
+        const prodEnv = await seeders.createEnvironmentSeed(account.id, 'prod');
+        await db.knex.from<DBEnvironment>('_nango_environments').where({ id: prodEnv.id }).update({ is_production: true });
+        return { account };
+    }
+
+    // Logs in as a fresh admin, impersonates the target account, and returns the impersonated session cookie.
+    async function impersonate(targetAccountUUID: string): Promise<string> {
+        const admin = await seeders.seedAccountEnvAndUser();
+        (envs as any).NANGO_ADMIN_UUID = admin.account.uuid;
+
+        const adminSession = await authenticateUser(api, admin.user);
+        const res = await api.fetch('/api/v1/admin/impersonate', {
+            method: 'POST',
+            // @ts-expect-error query not in endpoint type
+            query: { env: 'dev' },
+            session: adminSession,
+            body: { accountUUID: targetAccountUUID, loginReason: 'regression test' }
+        });
+        expect(res.res.status).toBe(200);
+
+        // req.login does not regenerate the session id, so the admin cookie now resolves to the
+        // impersonated (debugMode) session; prefer a refreshed cookie if one was emitted.
+        const setCookie = res.res.headers.getSetCookie();
+        return setCookie[0]?.split(';')[0] ?? adminSession;
+    }
+
+    it('keeps the impersonated administrator full access when no override is configured', async () => {
+        const { account } = await seedTargetWithProdEnv();
+        (envs as any).NANGO_IMPERSONATION_ROLE = undefined;
+        const session = await impersonate(account.uuid);
+
+        const res = await api.fetch('/api/v1/environments', {
+            method: 'PATCH',
+            // @ts-expect-error query not in endpoint type
+            query: { env: 'prod' },
+            body: { slack_notifications: false },
+            session
+        });
+
+        expect(res.res.status).not.toBe(403);
+    });
+
+    it('downgrades the impersonated session to the override role, denying prod writes', async () => {
+        const { account } = await seedTargetWithProdEnv();
+        (envs as any).NANGO_IMPERSONATION_ROLE = 'production_support';
+        const session = await impersonate(account.uuid);
+
+        const res = await api.fetch('/api/v1/environments', {
+            method: 'PATCH',
+            // @ts-expect-error query not in endpoint type
+            query: { env: 'prod' },
+            body: { slack_notifications: false },
+            session
+        });
+
+        expect(res.res.status).toBe(403);
+    });
+
+    it('still allows prod reads under the override role', async () => {
+        const { account } = await seedTargetWithProdEnv();
+        (envs as any).NANGO_IMPERSONATION_ROLE = 'production_support';
+        const session = await impersonate(account.uuid);
+
+        const res = await api.fetch('/api/v1/integrations', {
+            // @ts-expect-error GET not in endpoint type
+            method: 'GET',
+            query: { env: 'prod' },
+            session
+        });
+
+        expect(res.res.status).not.toBe(403);
+    });
+});

--- a/packages/server/lib/middleware/impersonation.integration.test.ts
+++ b/packages/server/lib/middleware/impersonation.integration.test.ts
@@ -29,9 +29,9 @@ describe('impersonation role override', () => {
         (envs as any).NANGO_IMPERSONATION_ROLE = undefined;
     });
 
-    // Account with a production env and a default (administrator) user, RBAC enforced.
-    async function seedTargetWithProdEnv() {
-        const { account } = await seeders.seedAccountEnvAndUser({ plan: { has_rbac: true } });
+    // Account with a production env and a default (administrator) user.
+    async function seedTargetWithProdEnv({ hasRbac = true }: { hasRbac?: boolean } = {}) {
+        const { account } = await seeders.seedAccountEnvAndUser({ plan: { has_rbac: hasRbac } });
         const prodEnv = await seeders.createEnvironmentSeed(account.id, 'prod');
         await db.knex.from<DBEnvironment>('_nango_environments').where({ id: prodEnv.id }).update({ is_production: true });
         return { account };
@@ -75,6 +75,22 @@ describe('impersonation role override', () => {
 
     it('downgrades the impersonated session to the override role, denying prod writes', async () => {
         const { account } = await seedTargetWithProdEnv();
+        (envs as any).NANGO_IMPERSONATION_ROLE = 'production_support';
+        const session = await impersonate(account.uuid);
+
+        const res = await api.fetch('/api/v1/environments', {
+            method: 'PATCH',
+            // @ts-expect-error query not in endpoint type
+            query: { env: 'prod' },
+            body: { slack_notifications: false },
+            session
+        });
+
+        expect(res.res.status).toBe(403);
+    });
+
+    it('enforces the override role even when the impersonated plan has RBAC disabled', async () => {
+        const { account } = await seedTargetWithProdEnv({ hasRbac: false });
         (envs as any).NANGO_IMPERSONATION_ROLE = 'production_support';
         const session = await impersonate(account.uuid);
 

--- a/packages/server/lib/middleware/impersonation.ts
+++ b/packages/server/lib/middleware/impersonation.ts
@@ -1,10 +1,15 @@
 import type { Role } from '@nangohq/types';
 
 // Impersonation sessions (debugMode) run as `override` when configured, capping their privileges
-// regardless of the impersonated user's real role. Falls back to the real role otherwise.
-export function resolveImpersonationRole({ role, debugMode, override }: { role: Role; debugMode: boolean | undefined; override: Role | undefined }): Role {
+// regardless of the impersonated user's real role. `forced` signals that RBAC must be enforced for
+// the request even when the account's plan would normally bypass it, so the cap can't be dodged by
+// impersonating an account without RBAC enabled.
+export function resolveImpersonationRole({ role, debugMode, override }: { role: Role; debugMode: boolean | undefined; override: Role | undefined }): {
+    role: Role;
+    forced: boolean;
+} {
     if (debugMode === true && override) {
-        return override;
+        return { role: override, forced: true };
     }
-    return role;
+    return { role, forced: false };
 }

--- a/packages/server/lib/middleware/impersonation.ts
+++ b/packages/server/lib/middleware/impersonation.ts
@@ -1,0 +1,10 @@
+import type { Role } from '@nangohq/types';
+
+// Impersonation sessions (debugMode) run as `override` when configured, capping their privileges
+// regardless of the impersonated user's real role. Falls back to the real role otherwise.
+export function resolveImpersonationRole({ role, debugMode, override }: { role: Role; debugMode: boolean | undefined; override: Role | undefined }): Role {
+    if (debugMode === true && override) {
+        return override;
+    }
+    return role;
+}

--- a/packages/server/lib/middleware/impersonation.unit.test.ts
+++ b/packages/server/lib/middleware/impersonation.unit.test.ts
@@ -1,0 +1,18 @@
+import { describe, expect, it } from 'vitest';
+
+import { resolveImpersonationRole } from './impersonation.js';
+
+describe('resolveImpersonationRole', () => {
+    it('forces the override role on an impersonation session', () => {
+        expect(resolveImpersonationRole({ role: 'administrator', debugMode: true, override: 'production_support' })).toBe('production_support');
+    });
+
+    it('keeps the real role when the override is not configured', () => {
+        expect(resolveImpersonationRole({ role: 'administrator', debugMode: true, override: undefined })).toBe('administrator');
+    });
+
+    it('keeps the real role for non-impersonation sessions even when the override is configured', () => {
+        expect(resolveImpersonationRole({ role: 'administrator', debugMode: undefined, override: 'production_support' })).toBe('administrator');
+        expect(resolveImpersonationRole({ role: 'administrator', debugMode: false, override: 'production_support' })).toBe('administrator');
+    });
+});

--- a/packages/server/lib/middleware/impersonation.unit.test.ts
+++ b/packages/server/lib/middleware/impersonation.unit.test.ts
@@ -3,16 +3,28 @@ import { describe, expect, it } from 'vitest';
 import { resolveImpersonationRole } from './impersonation.js';
 
 describe('resolveImpersonationRole', () => {
-    it('forces the override role on an impersonation session', () => {
-        expect(resolveImpersonationRole({ role: 'administrator', debugMode: true, override: 'production_support' })).toBe('production_support');
+    it('forces the override role and flags enforcement on an impersonation session', () => {
+        expect(resolveImpersonationRole({ role: 'administrator', debugMode: true, override: 'production_support' })).toEqual({
+            role: 'production_support',
+            forced: true
+        });
     });
 
-    it('keeps the real role when the override is not configured', () => {
-        expect(resolveImpersonationRole({ role: 'administrator', debugMode: true, override: undefined })).toBe('administrator');
+    it('keeps the real role and does not force enforcement when the override is not configured', () => {
+        expect(resolveImpersonationRole({ role: 'administrator', debugMode: true, override: undefined })).toEqual({
+            role: 'administrator',
+            forced: false
+        });
     });
 
     it('keeps the real role for non-impersonation sessions even when the override is configured', () => {
-        expect(resolveImpersonationRole({ role: 'administrator', debugMode: undefined, override: 'production_support' })).toBe('administrator');
-        expect(resolveImpersonationRole({ role: 'administrator', debugMode: false, override: 'production_support' })).toBe('administrator');
+        expect(resolveImpersonationRole({ role: 'administrator', debugMode: undefined, override: 'production_support' })).toEqual({
+            role: 'administrator',
+            forced: false
+        });
+        expect(resolveImpersonationRole({ role: 'administrator', debugMode: false, override: 'production_support' })).toEqual({
+            role: 'administrator',
+            forced: false
+        });
     });
 });

--- a/packages/server/lib/utils/express.ts
+++ b/packages/server/lib/utils/express.ts
@@ -29,6 +29,7 @@ export interface RequestLocals {
     connectSession?: ConnectSession;
     endUser?: InternalEndUser | null;
     plan?: DBPlan | null;
+    forceRbac?: boolean;
     lang?: string;
     secret?: DBAPISecret;
     apiKeyScopes?: string[];

--- a/packages/utils/lib/environment/parse.ts
+++ b/packages/utils/lib/environment/parse.ts
@@ -472,6 +472,8 @@ export const ENVS = z.object({
     // Slack
     NANGO_SLACK_INTEGRATION_KEY: z.string().optional().default('slack'),
     NANGO_ADMIN_UUID: z.string().uuid().optional(),
+    // When set, impersonation sessions are forced to this role instead of the impersonated user's real role.
+    NANGO_IMPERSONATION_ROLE: z.enum(roles).optional(),
 
     // Stripe
     PUBLIC_STRIPE_KEY: z.string().optional(),


### PR DESCRIPTION
Relates to NAN-5976.

- Adds `NANGO_IMPERSONATION_ROLE` env var. When set, session impersonation requests are forced to run as that role instead of the impersonated user's real role, so a compromised admin machine can't use impersonation to read production secrets/credentials. Unset by default — no behavior change until it's configured (we'll set it to `production_support` in prod).
- The cap is applied at the session-auth chokepoint (`fillLocalsFromSession`), where the role is already re-read from the DB on every request and all RBAC funnels through the deny-map evaluator — so a single override propagates to every `can()`-gated endpoint.
- Enforces the cap regardless of the account's plan: when an override is applied, a `forceRbac` flag on `res.locals` makes `can()` evaluate the role even when the plan has RBAC disabled or the auth-roles flag is off. Without this, the cap would be dodgeable by impersonating a non-RBAC account.

## Scope / limitations
- `production_support` blocks prod secrets/credentials, prod writes, and admin actions, but still permits reading prod connection metadata, logs/operation payloads, and env-var values. It's a strong mitigation for credentials, partial for data.
- The override is a flat assignment, so an impersonated `development_full_access` user would be raised to `production_support` on prod reads (dev role denies all prod). In practice impersonation targets the first account user (usually `administrator`), so it's a downgrade. Left flat for now; can switch to most-restrictive-of-the-two if we want it bulletproof.

## Test plan
- [x] Unit tests for the `resolveImpersonationRole` helper (override on/off, non-impersonation sessions, `forced` flag)
- [x] Integration test: impersonate an administrator, then assert prod write is denied (403) when override is `production_support`, prod read still allowed, and full access retained when override is unset
- [x] Integration test: override is enforced (403 on prod write) even when the impersonated plan has RBAC disabled
- [x] Confirmed both regression guards bite — disabling the override / the `forceRbac` bypass flips the relevant integration test red
- [ ] After deploy: set `NANGO_IMPERSONATION_ROLE=production_support` in prod config and verify impersonation can't read credentials/secrets