### PR TITLE
chore: revert addition of publishBatch to transports

### DIFF
--- a/packages/pubsub/lib/publisher.ts
+++ b/packages/pubsub/lib/publisher.ts
@@ -1,18 +1,11 @@
 import { v4 as uuidv4 } from 'uuid';
 
-import { Err, getLogger, metrics } from '@nangohq/utils';
+import { metrics } from '@nangohq/utils';
 
-import type { PublishBatchProps, PublishBatchResult, Transport } from './transport/transport.js';
+import type { Transport } from './transport/transport.js';
 import type { Event } from '@nangohq/types';
 import type { Result } from '@nangohq/utils';
 import type { SetOptional } from 'type-fest';
-
-const logger = getLogger('pubsub.publisher');
-
-export type MaybeStampedEvent<TSubject extends Event['subject'] = Event['subject']> = SetOptional<
-    Extract<Event, { subject: TSubject }>,
-    'idempotencyKey' | 'createdAt'
->;
 
 export class Publisher {
     private transport: Transport;
@@ -21,7 +14,7 @@ export class Publisher {
         this.transport = transport;
     }
 
-    public async publish(event: MaybeStampedEvent): Promise<Result<void>> {
+    public async publish(event: SetOptional<Event, 'idempotencyKey' | 'createdAt'>): Promise<Result<void>> {
         const res = await this.transport.publish({
             ...event,
             idempotencyKey: event.idempotencyKey ?? uuidv4(),
@@ -31,57 +24,5 @@ export class Publisher {
             metrics.increment(metrics.Types.PUBSUB_PUBLISH, 1, { subject: event.subject, success: 'false' });
         }
         return res;
-    }
-
-    public async publishBatch<TSubject extends Event['subject']>(
-        props: Omit<PublishBatchProps<TSubject>, 'events'> & { events: MaybeStampedEvent<TSubject>[] }
-    ): Promise<Result<PublishBatchResult>> {
-        const stamped = props.events.map(
-            (e) =>
-                ({
-                    ...e,
-                    idempotencyKey: e.idempotencyKey ?? uuidv4(),
-                    createdAt: e.createdAt ?? new Date()
-                }) as unknown as Extract<Event, { subject: TSubject }>
-        );
-
-        // runtime sanity check for homogeneous subject
-        const mismatchedEvents = props.events.filter((e) => e.subject !== props.subject);
-        if (mismatchedEvents.length > 0) {
-            metrics.increment(metrics.Types.PUBSUB_PUBLISH, props.events.length, { subject: props.subject, success: 'false' });
-            logger.error(`publishBatch contract violation: more than one subject in batch`, {
-                expected: props.subject,
-                unexpected: [...new Set(mismatchedEvents.map((e) => e.subject))],
-                total: props.events.length
-            });
-            return Err(new Error(`All events must be of the provided subject: "${props.subject}"`));
-        }
-
-        const res = await this.transport.publishBatch({ ...props, events: stamped });
-
-        // NOTE: `publish()` lacks logging when contrasted with `publishBatch()` because it already logs at the transport layer.
-        // `publishBatch()` takes a different approach in keeping the transport lean and log-agnostic, and concentrating reporting
-        // on this (Publisher) layer, so that consumers may still fire-and-forget publish attempts.
-        reportBatchPublishResults(props.subject, props.events.length, res);
-
-        return res;
-    }
-}
-
-function reportBatchPublishResults(subject: Event['subject'], batchSize: number, res: Result<PublishBatchResult>) {
-    if (res.isOk()) {
-        const res_ = res.value;
-        if (res_.failed.length > 0) {
-            logger.error(`publishBatch partial failure`, {
-                subject: subject,
-                failed: res_.failed.length,
-                total: batchSize,
-                errors: res_.failed
-            });
-            metrics.increment(metrics.Types.PUBSUB_PUBLISH, res_.failed.length, { subject: subject, success: 'false' });
-        }
-    } else {
-        logger.error(`publishBatch total failure`, { subject: subject, total: batchSize, error: res.error });
-        metrics.increment(metrics.Types.PUBSUB_PUBLISH, batchSize, { subject: subject, success: 'false' });
     }
 }

--- a/packages/pubsub/lib/transport/activemq.ts
+++ b/packages/pubsub/lib/transport/activemq.ts
@@ -6,10 +6,9 @@ import WebSocket from 'ws';
 import { Err, Ok, getLogger, report } from '@nangohq/utils';
 
 import { envs } from '../env.js';
-import { PublishFailure } from './transport.js';
 import { serde } from '../utils/serde.js';
 
-import type { PublishBatchProps, PublishBatchResult, SubscribeProps, Transport } from './transport.js';
+import type { SubscribeProps, Transport } from './transport.js';
 import type { Event } from '@nangohq/types';
 import type { Result } from '@nangohq/utils';
 import type { StompConfig, StompSubscription } from '@stomp/stompjs';
@@ -146,27 +145,6 @@ export class ActiveMQ implements Transport {
         } catch (err) {
             return Err(new Error(`Failed to publish message to ActiveMQ topic ${event.subject}`, { cause: err }));
         }
-    }
-
-    /**
-     * Iterates over and publishes events sequentially.
-     * Captures successful and failed events, and reports the results in a best-effort manner.
-     */
-    public async publishBatch<TSubject extends Event['subject']>({ events }: PublishBatchProps<TSubject>): Promise<Result<PublishBatchResult>> {
-        if (!this.client || !this.isConnected) {
-            return Err('ActiveMQ publisher not available');
-        }
-        const successful: string[] = [];
-        const failed: PublishFailure[] = [];
-        for (const event of events) {
-            const res = await this.publish(event);
-            if (res.isOk()) {
-                successful.push(event.idempotencyKey);
-            } else {
-                failed.push(new PublishFailure(event.idempotencyKey, `Failed to publish to ActiveMQ topic ${event.subject}`, { cause: res.error }));
-            }
-        }
-        return Ok({ successful, failed });
     }
 
     subscribe<TSubject extends Event['subject']>(props: SubscribeProps<TSubject>): void {

--- a/packages/pubsub/lib/transport/default.ts
+++ b/packages/pubsub/lib/transport/default.ts
@@ -6,7 +6,7 @@ import { NoOpTransport } from './noop.js';
 import { SnsSqs } from './sns-sqs.js';
 import { envs } from '../env.js';
 
-import type { PublishBatchProps, PublishBatchResult, SubscribeProps, Transport } from './transport.js';
+import type { SubscribeProps, Transport } from './transport.js';
 import type { Event } from '@nangohq/types';
 import type { Result } from '@nangohq/utils';
 
@@ -60,10 +60,6 @@ export class DefaultTransport implements Transport {
 
     async publish(event: Event): Promise<Result<void>> {
         return this.transport.publish(event);
-    }
-
-    async publishBatch<TSubject extends Event['subject']>(props: PublishBatchProps<TSubject>): Promise<Result<PublishBatchResult>> {
-        return this.transport.publishBatch(props);
     }
 
     subscribe<TSubject extends Event['subject']>(params: SubscribeProps<TSubject>): void {

--- a/packages/pubsub/lib/transport/migration.ts
+++ b/packages/pubsub/lib/transport/migration.ts
@@ -1,6 +1,6 @@
 import { Err, Ok } from '@nangohq/utils';
 
-import type { PublishBatchProps, PublishBatchResult, SubscribeProps, Transport } from './transport.js';
+import type { SubscribeProps, Transport } from './transport.js';
 import type { Event } from '@nangohq/types';
 import type { Result } from '@nangohq/utils';
 
@@ -52,10 +52,6 @@ export class Migration implements Transport {
     async publish(event: Event): Promise<Result<void>> {
         const results = await this.publisher.publish(event);
         return results;
-    }
-
-    async publishBatch<TSubject extends Event['subject']>(props: PublishBatchProps<TSubject>): Promise<Result<PublishBatchResult>> {
-        return this.publisher.publishBatch(props);
     }
 
     subscribe<TSubject extends Event['subject']>(params: SubscribeProps<TSubject>): void {

--- a/packages/pubsub/lib/transport/migration.unit.test.ts
+++ b/packages/pubsub/lib/transport/migration.unit.test.ts
@@ -13,7 +13,6 @@ function mockTransport(partial?: Partial<Transport>): Transport {
         connect: vi.fn().mockResolvedValue(Ok(undefined)),
         disconnect: vi.fn().mockResolvedValue(Ok(undefined)),
         publish: vi.fn().mockResolvedValue(Ok(undefined)),
-        publishBatch: vi.fn().mockResolvedValue(Ok({ successful: [], failed: [] })),
         subscribe: vi.fn(),
         ...partial
     };

--- a/packages/pubsub/lib/transport/noop.ts
+++ b/packages/pubsub/lib/transport/noop.ts
@@ -1,7 +1,6 @@
 import { Ok } from '@nangohq/utils';
 
-import type { PublishBatchProps, PublishBatchResult, Transport } from './transport.js';
-import type { Event } from '@nangohq/types';
+import type { Transport } from './transport.js';
 import type { Result } from '@nangohq/utils';
 
 export class NoOpTransport implements Transport {
@@ -18,11 +17,6 @@ export class NoOpTransport implements Transport {
     // eslint-disable-next-line @typescript-eslint/require-await
     public async publish(): Promise<Result<void>> {
         return Ok(undefined);
-    }
-
-    // eslint-disable-next-line @typescript-eslint/require-await
-    public async publishBatch<TSubject extends Event['subject']>({ events }: PublishBatchProps<TSubject>): Promise<Result<PublishBatchResult>> {
-        return Ok({ successful: events.map((e) => e.idempotencyKey), failed: [] });
     }
 
     public subscribe(): void {}

--- a/packages/pubsub/lib/transport/sns-sqs.ts
+++ b/packages/pubsub/lib/transport/sns-sqs.ts
@@ -1,20 +1,15 @@
-import { PublishBatchCommand, PublishCommand, SNSClient } from '@aws-sdk/client-sns';
+import { PublishCommand, SNSClient } from '@aws-sdk/client-sns';
 import { DeleteMessageCommand, ReceiveMessageCommand, SQSClient } from '@aws-sdk/client-sqs';
 import * as z from 'zod';
 
-import { Err, Ok, chunk, getLogger, report, runWithConcurrencyLimit } from '@nangohq/utils';
+import { Err, Ok, getLogger, report } from '@nangohq/utils';
 
 import { envs } from '../env.js';
-import { PublishFailure } from './transport.js';
 import { serde } from '../utils/serde.js';
 
-import type { PublishBatchProps, PublishBatchResult, SubscribeProps, Transport } from './transport.js';
-import type { BatchResultErrorEntry, PublishBatchRequestEntry } from '@aws-sdk/client-sns';
+import type { SubscribeProps, Transport } from './transport.js';
 import type { Event } from '@nangohq/types';
 import type { Result } from '@nangohq/utils';
-
-export const SNS_BATCH_MAX_SIZE = 10;
-export const SNS_BATCH_MAX_BYTES = 262_144;
 
 const logger = getLogger('pubsub.sns-sqs');
 
@@ -31,42 +26,6 @@ const sqsMessageAttributesSchema = z.record(z.string(), z.looseObject({ StringVa
 
 function subscriptionKey<TSubject extends Event['subject']>(consumerGroup: string, subject: TSubject): `${string}:${TSubject}` {
     return `${consumerGroup}:${subject}`;
-}
-
-function publishConcurrency(concurrency: number | undefined): number {
-    const n = concurrency ?? 10;
-    if (!Number.isFinite(n)) {
-        return 10;
-    }
-    return Math.max(1, Math.min(10, Math.floor(n)));
-}
-
-function toSnsEntry(event: Event): Result<PublishBatchRequestEntry, PublishFailure> {
-    return serde
-        .serialize(event)
-        .map((encoded: Buffer) => ({
-            Id: event.idempotencyKey,
-            Message: encoded.toString('base64'),
-            MessageAttributes: {
-                subject: { DataType: 'String', StringValue: event.subject }
-            }
-        }))
-        .mapError((e: unknown) => new PublishFailure(event.idempotencyKey, 'Failed to serialize event', { cause: e }));
-}
-
-// https://docs.aws.amazon.com/sns/latest/dg/sns-message-attributes.html
-// Message size = body + per-attribute (name + data type + string value) lengths.
-function snsEntryBytes(entry: PublishBatchRequestEntry): number {
-    const bodyBytes = Buffer.byteLength(entry.Message ?? '', 'utf8');
-    const attrBytes = Object.entries(entry.MessageAttributes ?? {}).reduce((sum, [name, attr]) => {
-        return sum + Buffer.byteLength(name, 'utf8') + Buffer.byteLength(attr.DataType ?? '', 'utf8') + Buffer.byteLength(attr.StringValue ?? '', 'utf8');
-    }, 0);
-    return bodyBytes + attrBytes;
-}
-
-function asPublishFailure(idempotencyKey: string, error: BatchResultErrorEntry): PublishFailure {
-    const errorCode = error.Code !== undefined ? { code: error.Code } : undefined;
-    return new PublishFailure(idempotencyKey, error.Message ?? 'SNS rejected message', errorCode);
 }
 
 function subscribeConcurrency(concurrency: number | undefined): number {
@@ -186,69 +145,6 @@ export class SnsSqs implements Transport {
         } catch (err) {
             logger.error(`Failed to publish message to SNS for subject ${event.subject}`, { error: err });
             return Err(new Error(`Failed to publish message to SNS for subject ${event.subject}`, { cause: err }));
-        }
-    }
-
-    public async publishBatch<S extends Event['subject']>({ subject, events, concurrency }: PublishBatchProps<S>): Promise<Result<PublishBatchResult>> {
-        if (!this.isConnected) {
-            return Err(new Error('SNS+SQS publisher not connected'));
-        }
-
-        // runtime sanity check for homogeneous subject
-        if (events.find((e) => e.subject !== subject)) {
-            return Err(new Error(`All events must be of the provided subject: "${subject}"`));
-        }
-
-        const topicArn = this.topicArns[subject];
-        if (!topicArn) {
-            return Err(new Error(`No SNS topic ARN configured for subject "${subject}"`));
-        }
-
-        const failed: PublishFailure[] = [];
-        const entries: PublishBatchRequestEntry[] = [];
-
-        try {
-            events.map(toSnsEntry).forEach((entry) => {
-                if (entry.isOk()) {
-                    entries.push(entry.value);
-                } else {
-                    failed.push(entry.error);
-                }
-            });
-
-            const batches = chunk(
-                entries,
-                () => ({ count: 0, bytes: 0 }),
-                (acc, item) => ({ count: acc.count + 1, bytes: acc.bytes + snsEntryBytes(item) }),
-                (acc, item) => acc.count >= SNS_BATCH_MAX_SIZE || acc.bytes + snsEntryBytes(item) > SNS_BATCH_MAX_BYTES
-            );
-
-            const successful: string[] = [];
-
-            await runWithConcurrencyLimit(batches, publishConcurrency(concurrency), async (batch, _) => {
-                // Map each batch entry's index to its original idempotencyKey to support a reverse-lookup from SNS responses
-                const idMap = new Map(batch.map((entry, i) => [String(i), entry.Id!]));
-                const batchWithPositionalIds = batch.map((entry, i) => ({ ...entry, Id: String(i) }));
-
-                const cmd = new PublishBatchCommand({
-                    TopicArn: topicArn,
-                    PublishBatchRequestEntries: batchWithPositionalIds
-                });
-
-                await this.sns
-                    .send(cmd)
-                    .then((response) => {
-                        successful.push(...(response.Successful ?? []).map((s) => idMap.get(s.Id!) ?? s.Id!));
-                        failed.push(...(response.Failed ?? []).map((e) => asPublishFailure(idMap.get(e.Id!) ?? e.Id!, e)));
-                    })
-                    .catch((err: unknown) => {
-                        failed.push(...batch.map((f) => new PublishFailure(f.Id!, 'Batch publish request failed', { cause: err })));
-                    });
-            });
-
-            return Ok({ successful, failed });
-        } catch (err) {
-            return Err(new Error(`Failed to publish batch to SNS for subject "${subject}"`, { cause: err }));
         }
     }
 

--- a/packages/pubsub/lib/transport/sns-sqs.unit.test.ts
+++ b/packages/pubsub/lib/transport/sns-sqs.unit.test.ts
@@ -1,4 +1,4 @@
-import { PublishBatchCommand, PublishCommand } from '@aws-sdk/client-sns';
+import { PublishCommand } from '@aws-sdk/client-sns';
 import { DeleteMessageCommand, ReceiveMessageCommand } from '@aws-sdk/client-sqs';
 import { assert, beforeEach, describe, expect, it, vi } from 'vitest';
 
@@ -34,7 +34,7 @@ function abortError(): Error {
     return err;
 }
 
-function usageEvent() {
+function usageEvent(): Event {
     return {
         idempotencyKey: 'idem-1',
         subject: 'usage',
@@ -51,7 +51,7 @@ function usageEvent() {
             }
         },
         createdAt: new Date()
-    } satisfies Event;
+    };
 }
 
 describe('SnsSqs transport', () => {
@@ -283,141 +283,6 @@ describe('SnsSqs transport', () => {
         const deleteCalls = mockSqsSend.mock.calls.filter((c) => c[0] instanceof DeleteMessageCommand);
         expect(deleteCalls).toHaveLength(0);
         await t.disconnect();
-    });
-
-    describe('publishBatch', () => {
-        it('returns Err when not connected', async () => {
-            const t = createTransport();
-            const res = await t.publishBatch({ subject: 'usage', events: [usageEvent()] });
-            assert(res.isErr());
-            expect(res.error.message).toContain('not connected');
-            expect(mockSnsSend).not.toHaveBeenCalled();
-        });
-
-        it('returns Err when no topic ARN configured for subject', async () => {
-            const t = new SnsSqs({ topicArns: {}, queueUrls: {}, snsClient, sqsClient });
-            await t.connect();
-
-            const res = await t.publishBatch({ subject: 'usage', events: [usageEvent()] });
-            assert(res.isErr());
-            expect(res.error.message).toContain('No SNS topic ARN');
-            expect(mockSnsSend).not.toHaveBeenCalled();
-        });
-
-        it('sends PublishBatchCommand with positional entry Id', async () => {
-            const t = createTransport();
-            await t.connect();
-
-            const event = usageEvent();
-            mockSnsSend.mockResolvedValue({ Successful: [{ Id: '0', MessageId: 'msg-1' }], Failed: [] });
-
-            await t.publishBatch({ subject: 'usage', events: [event] });
-
-            expect(mockSnsSend).toHaveBeenCalledTimes(1);
-            const [cmd] = mockSnsSend.mock.calls[0]!;
-            expect(cmd).toBeInstanceOf(PublishBatchCommand);
-            const encoded = serde.serialize(event).unwrap().toString('base64');
-            expect(cmd.input).toMatchObject({
-                TopicArn: topicArn,
-                PublishBatchRequestEntries: [
-                    {
-                        Id: '0',
-                        Message: encoded,
-                        MessageAttributes: { subject: { DataType: 'String', StringValue: 'usage' } }
-                    }
-                ]
-            });
-        });
-
-        it('maps successful response Ids back to idempotency keys', async () => {
-            const t = createTransport();
-            await t.connect();
-
-            const event = usageEvent();
-            mockSnsSend.mockResolvedValue({ Successful: [{ Id: '0', MessageId: 'msg-1' }], Failed: [] });
-
-            const res = await t.publishBatch({ subject: 'usage', events: [event] });
-            assert(res.isOk());
-            expect(res.value.successful).toEqual([event.idempotencyKey]);
-            expect(res.value.failed).toHaveLength(0);
-        });
-
-        it('maps SNS Failed entry Ids back to idempotency keys with failure message', async () => {
-            const t = createTransport();
-            await t.connect();
-
-            const events = [
-                { ...usageEvent(), idempotencyKey: 'ok-key' },
-                { ...usageEvent(), idempotencyKey: 'fail-key' }
-            ];
-            mockSnsSend.mockResolvedValue({
-                Successful: [{ Id: '0', MessageId: 'msg-1' }],
-                Failed: [{ Id: '1', Code: 'InvalidParameter', Message: 'bad message', SenderFault: true }]
-            });
-
-            const res = await t.publishBatch({ subject: 'usage', events });
-            assert(res.isOk());
-            expect(res.value.successful).toEqual(['ok-key']);
-            expect(res.value.failed).toHaveLength(1);
-            expect(res.value.failed[0]!.idempotencyKey).toBe('fail-key');
-            expect(res.value.failed[0]!.message).toBe('bad message');
-        });
-
-        it('puts all batch entries in failed when PublishBatchCommand throws', async () => {
-            const t = createTransport();
-            await t.connect();
-            mockSnsSend.mockRejectedValue(new Error('network error'));
-
-            const events = [
-                { ...usageEvent(), idempotencyKey: 'key-1' },
-                { ...usageEvent(), idempotencyKey: 'key-2' }
-            ];
-            const res = await t.publishBatch({ subject: 'usage', events });
-            assert(res.isOk());
-            expect(res.value.successful).toHaveLength(0);
-            expect(res.value.failed).toHaveLength(2);
-            expect(res.value.failed.map((f) => f.idempotencyKey)).toEqual(['key-1', 'key-2']);
-            expect(res.value.failed[0]!.message).toBe('Batch publish request failed');
-            expect(res.value.failed[0]!.cause).toMatchObject({ message: 'network error' });
-        });
-
-        it('chunks groups larger than 10 into multiple PublishBatchCommand calls', async () => {
-            const t = createTransport();
-            await t.connect();
-
-            const events = Array.from({ length: 11 }, (_, i) => ({ ...usageEvent(), idempotencyKey: `idem-${i}` }));
-            mockSnsSend
-                .mockResolvedValueOnce({
-                    Successful: events.slice(0, 10).map((_, i) => ({ Id: String(i), MessageId: `msg-${i}` })),
-                    Failed: []
-                })
-                .mockResolvedValueOnce({
-                    Successful: [{ Id: '0', MessageId: 'msg-10' }],
-                    Failed: []
-                });
-
-            const res = await t.publishBatch({ subject: 'usage', events });
-            assert(res.isOk());
-            expect(res.value.successful).toHaveLength(11);
-            expect(res.value.successful).toEqual(events.map((e) => e.idempotencyKey));
-            expect(res.value.failed).toHaveLength(0);
-
-            const batchCalls = mockSnsSend.mock.calls.filter((c) => c[0] instanceof PublishBatchCommand);
-            expect(batchCalls).toHaveLength(2);
-            expect(batchCalls[0]![0].input.PublishBatchRequestEntries).toHaveLength(10);
-            expect(batchCalls[1]![0].input.PublishBatchRequestEntries).toHaveLength(1);
-        });
-
-        it('does not accept events with different subjects', async () => {
-            const t = createTransport();
-            await t.connect();
-            const teamEv = { idempotencyKey: 'team-key', subject: 'team' as const, type: 'team.updated' as const, payload: { id: 1 }, createdAt: new Date() };
-            // @ts-expect-error: publishBatch enforces all events share the subject parameter
-            const res = await t.publishBatch({ subject: 'usage', events: [usageEvent(), teamEv] });
-            assert(res.isErr());
-            expect(res.error.message).toContain('All events must be of the provided subject: "usage"');
-            expect(mockSnsSend).not.toHaveBeenCalled();
-        });
     });
 
     it('disconnect aborts long polling', async () => {

--- a/packages/pubsub/lib/transport/transport.ts
+++ b/packages/pubsub/lib/transport/transport.ts
@@ -11,48 +11,8 @@ export interface SubscribeProps<TSubject extends Event['subject'] = Event['subje
     concurrency?: number;
 }
 
-export class PublishFailure extends Error {
-    idempotencyKey: string;
-    code?: string;
-
-    constructor(idempotencyKey: string, message: string, options?: { code?: string; cause?: unknown }) {
-        super(message, { cause: options?.cause });
-        this.idempotencyKey = idempotencyKey;
-        if (options?.code !== undefined) {
-            this.code = options.code;
-        }
-    }
-
-    toJSON() {
-        return {
-            idempotencyKey: this.idempotencyKey,
-            message: this.message,
-            ...(this.code !== undefined ? { code: this.code } : {}),
-            ...(this.cause instanceof Error ? { cause: this.cause.message } : typeof this.cause === 'string' ? { cause: this.cause } : {})
-        };
-    }
-}
-
-export interface PublishBatchResult {
-    successful: string[];
-    failed: PublishFailure[];
-}
-
-export interface PublishBatchProps<TSubject extends Event['subject'] = Event['subject']> {
-    subject: TSubject;
-    events: Extract<Event, { subject: NoInfer<TSubject> }>[];
-    /** SNS+SQS: Concurrent batch publish requests (default 10, clamped 1–10). Ignored by other transports. */
-    concurrency?: number;
-}
-
 export interface Transport {
     publish(event: Event): Promise<Result<void>>;
-    /**
-     * Publishes a batch of events in a best-effort manner: all events are attempted regardless of
-     * individual failures. Check `result.failed` for partial failures. Fatal failures are captured
-     * and returned as errors (e.g. transport unavailable).
-     */
-    publishBatch<TSubject extends Event['subject']>(props: PublishBatchProps<TSubject>): Promise<Result<PublishBatchResult>>;
     subscribe<TSubject extends Event['subject']>(params: SubscribeProps<TSubject>): void;
     connect(props?: { timeoutMs: number }): Promise<Result<void>>;
     disconnect(): Promise<Result<void>>;


### PR DESCRIPTION
This reverts commit cd6b98408b29eeecca6a7464774ea0e4c7fa4d76.


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/NangoHQ/nango/pull/6527?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

