### PR TITLE
feat(telemetry): wire data transfer through pubsub

### DIFF
--- a/packages/metering/lib/crons/billingEventsS3Export.integration.test.ts
+++ b/packages/metering/lib/crons/billingEventsS3Export.integration.test.ts
@@ -26,6 +26,10 @@ const baseAttributes = {
 // per-branch inside `gen()`.
 type FixtureAttrs = Record<string, unknown>;
 
+// 'usage.data_transfer' excluded: not ingested into Clickhouse yet.
+// TODO: Remove Exclude when CH ingestion is added.
+type IngestedEventType = Exclude<ClickhouseRawUsageEvent['type'], 'usage.data_transfer'>;
+
 function genN({
     n,
     day,
@@ -35,7 +39,7 @@ function genN({
 }: {
     n: number;
     day: string;
-    type: ClickhouseRawUsageEvent['type'];
+    type: IngestedEventType;
     accountId: number;
     attributes?: FixtureAttrs;
 }): ClickhouseRawUsageEvent[] {
@@ -50,7 +54,7 @@ function gen({
     attributes = {}
 }: {
     day: string;
-    type: ClickhouseRawUsageEvent['type'];
+    type: IngestedEventType;
     accountId: number;
     value?: number;
     attributes?: FixtureAttrs;

--- a/packages/metering/lib/processors/usage.ts
+++ b/packages/metering/lib/processors/usage.ts
@@ -293,6 +293,11 @@ export class UsageProcessor {
                     ]);
                     return Ok(undefined);
                 }
+                case 'usage.data_transfer': {
+                    const { package: pkg, callsite, direction } = event.payload.properties;
+                    metrics.increment(metrics.Types.DATA_TRANSFER, event.payload.value, { package: pkg, callsite, direction });
+                    return Ok(undefined);
+                }
                 default:
                     ((_exhaustiveCheck: never) => {
                         throw new Error(`Unhandled event type: ${JSON.stringify(_exhaustiveCheck)}`);

--- a/packages/persist/lib/routes/runner/telemetry/postTelemetry.ts
+++ b/packages/persist/lib/routes/runner/telemetry/postTelemetry.ts
@@ -1,9 +1,10 @@
-import { metrics, validateRequest } from '@nangohq/utils';
+import { validateRequest } from '@nangohq/utils';
 
 import { telemetryBodySchema, telemetryParamsSchema } from './validate.js';
+import { pubsub } from '../../../pubsub.js';
 
 import type { AuthLocals } from '../../../middleware/auth.middleware.js';
-import type { PostRunnerTelemetry, RunnerDataTransferTelemetry } from '@nangohq/types';
+import type { DBEnvironment, DBTeam, PostRunnerTelemetry, RunnerDataTransferTelemetry, UsageDataTransferEvent } from '@nangohq/types';
 import type { EndpointRequest, EndpointResponse, Route, RouteHandler } from '@nangohq/utils';
 
 const path = '/environment/:environmentId/runner/telemetry';
@@ -14,45 +15,45 @@ const validate = validateRequest<PostRunnerTelemetry>({
     parseBody: (data: unknown) => telemetryBodySchema.parse(data)
 });
 
-function groupEventsByCallsite(events: RunnerDataTransferTelemetry[]): Map<string, RunnerDataTransferTelemetry[]> {
-    const eventsByCallsite = new Map<string, RunnerDataTransferTelemetry[]>();
-    for (const event of events) {
-        const { callsite } = event;
-        if (!eventsByCallsite.has(callsite)) {
-            eventsByCallsite.set(callsite, []);
+function makeDataTransferEvent(
+    account: DBTeam,
+    environment: DBEnvironment,
+    event: RunnerDataTransferTelemetry,
+    direction: 'ingress' | 'egress'
+): Omit<UsageDataTransferEvent, 'idempotencyKey' | 'createdAt'> {
+    return {
+        subject: 'usage',
+        type: 'usage.data_transfer',
+        payload: {
+            value: direction === 'ingress' ? event.bytesReceived : event.bytesSent,
+            properties: {
+                accountId: account.id,
+                environmentId: environment.id,
+                environmentName: environment.name,
+                integrationId: event.integrationId,
+                connectionId: event.connectionId,
+                package: 'runner',
+                callsite: event.callsite,
+                direction,
+                ...(event.syncId ? { syncId: event.syncId } : {})
+            }
         }
-        eventsByCallsite.get(callsite)!.push(event);
-    }
-    return eventsByCallsite;
+    };
 }
 
 const handler = (_req: EndpointRequest, res: EndpointResponse<PostRunnerTelemetry, AuthLocals>) => {
+    const { account, environment } = res.locals;
     const body = res.locals.parsedBody;
 
-    const dataTransferEvents = body.events.filter((event) => event.type === 'data_transfer');
-    const eventsByCallsite = groupEventsByCallsite(dataTransferEvents);
+    const dataTransferEvents = body.events
+        .filter((event) => event.type === 'data_transfer')
+        .flatMap((event) => [
+            ...(event.bytesSent > 0 ? [makeDataTransferEvent(account, environment, event, 'egress')] : []),
+            ...(event.bytesReceived > 0 ? [makeDataTransferEvent(account, environment, event, 'ingress')] : [])
+        ]);
 
-    for (const [callsite, events] of eventsByCallsite) {
-        const bytesSent = events.reduce((acc, event) => Math.min(acc + event.bytesSent, Number.MAX_SAFE_INTEGER), 0);
-        const bytesReceived = events.reduce((acc, event) => Math.min(acc + event.bytesReceived, Number.MAX_SAFE_INTEGER), 0);
-
-        switch (callsite) {
-            case 'proxy':
-                metrics.increment(metrics.Types.PROXY_REQUEST_SIZE_IN_BYTES, bytesSent, { callsite: 'runner' });
-                metrics.increment(metrics.Types.PROXY_RESPONSE_SIZE_IN_BYTES, bytesReceived, { callsite: 'runner' });
-                break;
-            case 'uncontrolled_fetch':
-                metrics.increment(metrics.Types.RUNNER_UNCONTROLLED_FETCH_REQUEST_SIZE_BYTES, bytesSent);
-                metrics.increment(metrics.Types.RUNNER_UNCONTROLLED_FETCH_RESPONSE_SIZE_BYTES, bytesReceived);
-                break;
-            case 'persist_records':
-                metrics.increment(metrics.Types.RUNNER_PERSIST_RECORDS_SENT_SIZE_IN_BYTES, bytesSent);
-                metrics.increment(metrics.Types.RUNNER_PERSIST_RECORDS_RECEIVED_SIZE_IN_BYTES, bytesReceived);
-                break;
-            case 'persist_logs':
-                metrics.increment(metrics.Types.RUNNER_PERSIST_LOGS_SENT_SIZE_IN_BYTES, bytesSent);
-                break;
-        }
+    if (dataTransferEvents.length > 0) {
+        void pubsub.publisher.publishBatch({ subject: 'usage', events: dataTransferEvents });
     }
 
     res.status(204).send();

--- a/packages/pubsub/lib/publisher.ts
+++ b/packages/pubsub/lib/publisher.ts
@@ -75,9 +75,7 @@ function reportBatchPublishResults(subject: Event['subject'], batchSize: number,
             res_.failed.forEach((error: PublishFailure) => {
                 logger.error(`publishBatch partial failure`, {
                     subject: subject,
-                    error_code: error.code,
-                    error: error.message,
-                    idempotency_key: error.idempotencyKey
+                    ...error.toJSON()
                 });
             });
             metrics.increment(metrics.Types.PUBSUB_PUBLISH, res_.failed.length, { subject: subject, success: 'false' });

--- a/packages/pubsub/lib/publisher.ts
+++ b/packages/pubsub/lib/publisher.ts
@@ -75,7 +75,9 @@ function reportBatchPublishResults(subject: Event['subject'], batchSize: number,
             res_.failed.forEach((error: PublishFailure) => {
                 logger.error(`publishBatch partial failure`, {
                     subject: subject,
-                    error: error.message
+                    error_code: error.code,
+                    error: error.message,
+                    idempotency_key: error.idempotencyKey
                 });
             });
             metrics.increment(metrics.Types.PUBSUB_PUBLISH, res_.failed.length, { subject: subject, success: 'false' });

--- a/packages/pubsub/lib/publisher.ts
+++ b/packages/pubsub/lib/publisher.ts
@@ -2,7 +2,7 @@ import { v4 as uuidv4 } from 'uuid';
 
 import { Err, getLogger, metrics } from '@nangohq/utils';
 
-import type { PublishBatchProps, PublishBatchResult, Transport } from './transport/transport.js';
+import type { PublishBatchProps, PublishBatchResult, PublishFailure, Transport } from './transport/transport.js';
 import type { Event } from '@nangohq/types';
 import type { Result } from '@nangohq/utils';
 import type { SetOptional } from 'type-fest';
@@ -72,11 +72,11 @@ function reportBatchPublishResults(subject: Event['subject'], batchSize: number,
     if (res.isOk()) {
         const res_ = res.value;
         if (res_.failed.length > 0) {
-            logger.error(`publishBatch partial failure`, {
-                subject: subject,
-                failed: res_.failed.length,
-                total: batchSize,
-                errors: res_.failed
+            res_.failed.forEach((error: PublishFailure) => {
+                logger.error(`publishBatch partial failure`, {
+                    subject: subject,
+                    error: error.message
+                });
             });
             metrics.increment(metrics.Types.PUBSUB_PUBLISH, res_.failed.length, { subject: subject, success: 'false' });
         }

--- a/packages/pubsub/lib/publisher.ts
+++ b/packages/pubsub/lib/publisher.ts
@@ -81,7 +81,7 @@ function reportBatchPublishResults(subject: Event['subject'], batchSize: number,
             metrics.increment(metrics.Types.PUBSUB_PUBLISH, res_.failed.length, { subject: subject, success: 'false' });
         }
     } else {
-        logger.error(`publishBatch total failure`, { subject: subject, total: batchSize, error: res.error });
+        logger.error(`publishBatch total failure`, { subject: subject, total: batchSize, error: res.error.message });
         metrics.increment(metrics.Types.PUBSUB_PUBLISH, batchSize, { subject: subject, success: 'false' });
     }
 }

--- a/packages/pubsub/lib/publisher.ts
+++ b/packages/pubsub/lib/publisher.ts
@@ -1,11 +1,13 @@
 import { v4 as uuidv4 } from 'uuid';
 
-import { Err, metrics } from '@nangohq/utils';
+import { Err, getLogger, metrics } from '@nangohq/utils';
 
 import type { PublishBatchProps, PublishBatchResult, Transport } from './transport/transport.js';
 import type { Event } from '@nangohq/types';
 import type { Result } from '@nangohq/utils';
 import type { SetOptional } from 'type-fest';
+
+const logger = getLogger('pubsub.publisher');
 
 export type MaybeStampedEvent<TSubject extends Event['subject'] = Event['subject']> = SetOptional<
     Extract<Event, { subject: TSubject }>,
@@ -44,20 +46,42 @@ export class Publisher {
         );
 
         // runtime sanity check for homogeneous subject
-        if (props.events.find((e) => e.subject !== props.subject)) {
+        const mismatchedEvents = props.events.filter((e) => e.subject !== props.subject);
+        if (mismatchedEvents.length > 0) {
             metrics.increment(metrics.Types.PUBSUB_PUBLISH, props.events.length, { subject: props.subject, success: 'false' });
+            logger.error(`publishBatch contract violation: more than one subject in batch`, {
+                expected: props.subject,
+                unexpected: [...new Set(mismatchedEvents.map((e) => e.subject))],
+                total: props.events.length
+            });
             return Err(new Error(`All events must be of the provided subject: "${props.subject}"`));
         }
 
         const res = await this.transport.publishBatch({ ...props, events: stamped });
 
-        if (res.isOk()) {
-            metrics.increment(metrics.Types.PUBSUB_PUBLISH, res.value.successful.length, { subject: props.subject, success: 'true' });
-            metrics.increment(metrics.Types.PUBSUB_PUBLISH, res.value.failed.length, { subject: props.subject, success: 'false' });
-        } else {
-            metrics.increment(metrics.Types.PUBSUB_PUBLISH, props.events.length, { subject: props.subject, success: 'false' });
-        }
+        // NOTE: `publish()` lacks logging when contrasted with `publishBatch()` because it already logs at the transport layer.
+        // `publishBatch()` takes a different approach in keeping the transport lean and log-agnostic, and concentrating reporting
+        // on this (Publisher) layer, so that consumers may still fire-and-forget publish attempts.
+        reportBatchPublishResults(props.subject, props.events.length, res);
 
         return res;
+    }
+}
+
+function reportBatchPublishResults(subject: Event['subject'], batchSize: number, res: Result<PublishBatchResult>) {
+    if (res.isOk()) {
+        const res_ = res.value;
+        if (res_.failed.length > 0) {
+            logger.error(`publishBatch partial failure`, {
+                subject: subject,
+                failed: res_.failed.length,
+                total: batchSize,
+                errors: res_.failed
+            });
+            metrics.increment(metrics.Types.PUBSUB_PUBLISH, res_.failed.length, { subject: subject, success: 'false' });
+        }
+    } else {
+        logger.error(`publishBatch total failure`, { subject: subject, total: batchSize, error: res.error });
+        metrics.increment(metrics.Types.PUBSUB_PUBLISH, batchSize, { subject: subject, success: 'false' });
     }
 }

--- a/packages/server/lib/controllers/proxy/allProxy.ts
+++ b/packages/server/lib/controllers/proxy/allProxy.ts
@@ -15,6 +15,7 @@ import {
     errorManager,
     getProvider,
     getProxyConfiguration,
+    makeDataTransferEvents,
     pubsub,
     refreshOrTestCredentials
 } from '@nangohq/shared';
@@ -316,9 +317,20 @@ export const allPublicProxy = asyncWrapper<AllPublicProxy>(async (req, res, next
                 oauth_client_secret: integration.oauth_client_secret,
                 custom: integration.custom
             }),
-            onBytes: ({ sent, received }) => {
-                metrics.increment(metrics.Types.PROXY_REQUEST_SIZE_IN_BYTES, sent, { callsite: 'server' });
-                metrics.increment(metrics.Types.PROXY_RESPONSE_SIZE_IN_BYTES, received, { callsite: 'server' });
+            onBytes: (meteredBytes) => {
+                const events = makeDataTransferEvents(
+                    'server',
+                    'proxy',
+                    account.id,
+                    connection.connection_id,
+                    providerConfigKey,
+                    environment.id,
+                    meteredBytes,
+                    environment.name
+                );
+                if (events.length > 0) {
+                    void pubsub.publisher.publishBatch({ subject: 'usage', events });
+                }
             }
         });
 

--- a/packages/server/lib/hooks/connection/credentials-verification-script.ts
+++ b/packages/server/lib/hooks/connection/credentials-verification-script.ts
@@ -1,7 +1,6 @@
 import tracer from 'dd-trace';
 
-import { ProxyRequest, getProvider, getProxyConfiguration } from '@nangohq/shared';
-import { metrics } from '@nangohq/utils';
+import { ProxyRequest, getProvider, getProxyConfiguration, makeDataTransferEvents, pubsub } from '@nangohq/shared';
 
 import * as verificationscriptHandlers from './index.js';
 
@@ -37,7 +36,7 @@ async function execute(
     credentials: ApiKeyCredentials | BasicApiCredentials | TbaCredentials | JwtCredentials | SignatureCredentials | InstallPluginCredentials,
     connectionId: string,
     connectionConfig: ConnectionConfig,
-    _accountId: number
+    accountId: number
 ) {
     const { provider: providerName, unique_key: providerConfigKey } = config;
 
@@ -116,9 +115,19 @@ async function execute(
                         oauth_client_id: null,
                         oauth_client_secret: null
                     }),
-                    onBytes: ({ sent, received }) => {
-                        metrics.increment(metrics.Types.PROXY_REQUEST_SIZE_IN_BYTES, sent, { callsite: 'server_credential_verification_hook' });
-                        metrics.increment(metrics.Types.PROXY_RESPONSE_SIZE_IN_BYTES, received, { callsite: 'server_credential_verification_hook' });
+                    onBytes: (meteredBytes) => {
+                        const events = makeDataTransferEvents(
+                            'server',
+                            'credential_verification_hook',
+                            accountId,
+                            connectionId,
+                            config.unique_key,
+                            config.environment_id,
+                            meteredBytes
+                        );
+                        if (events.length > 0) {
+                            void pubsub.publisher.publishBatch({ subject: 'usage', events });
+                        }
                     }
                 });
                 return (await proxy.request()).unwrap();

--- a/packages/server/lib/hooks/connection/internal-nango.ts
+++ b/packages/server/lib/hooks/connection/internal-nango.ts
@@ -1,5 +1,4 @@
-import { ProxyRequest, configService, connectionService, getProxyConfiguration } from '@nangohq/shared';
-import { metrics } from '@nangohq/utils';
+import { ProxyRequest, configService, connectionService, getProxyConfiguration, makeDataTransferEvents, pubsub } from '@nangohq/shared';
 
 import type { Config } from '@nangohq/shared';
 import type { ConnectionConfig, DBConnectionDecrypted, InternalProxyConfiguration, Provider, UserProvidedProxyConfiguration } from '@nangohq/types';
@@ -13,7 +12,7 @@ export interface InternalNango {
     getIntegration: () => Promise<Config | null>;
 }
 
-export function getInternalNango(connection: DBConnectionDecrypted, providerName: string, _accountId: number): InternalNango {
+export function getInternalNango(connection: DBConnectionDecrypted, providerName: string, accountId: number): InternalNango {
     const internalConfig: InternalProxyConfiguration = {
         providerName
     };
@@ -53,9 +52,19 @@ export function getInternalNango(connection: DBConnectionDecrypted, providerName
                     }
                     return { oauth_client_id: null, oauth_client_secret: null };
                 },
-                onBytes: ({ sent, received }) => {
-                    metrics.increment(metrics.Types.PROXY_REQUEST_SIZE_IN_BYTES, sent, { callsite: 'server_connection_hook' });
-                    metrics.increment(metrics.Types.PROXY_RESPONSE_SIZE_IN_BYTES, received, { callsite: 'server_connection_hook' });
+                onBytes: (meteredBytes) => {
+                    const events = makeDataTransferEvents(
+                        'server',
+                        'connection_hook',
+                        accountId,
+                        connection.connection_id,
+                        connection.provider_config_key,
+                        connection.environment_id,
+                        meteredBytes
+                    );
+                    if (events.length > 0) {
+                        void pubsub.publisher.publishBatch({ subject: 'usage', events });
+                    }
                 }
             });
             const response = (await proxyInstance.request()).unwrap();

--- a/packages/server/lib/hooks/hooks.ts
+++ b/packages/server/lib/hooks/hooks.ts
@@ -9,11 +9,12 @@ import {
     errorNotificationService,
     externalWebhookService,
     getProxyConfiguration,
+    makeDataTransferEvents,
     productTracking,
     pubsub,
     syncManager
 } from '@nangohq/shared';
-import { Err, Ok, getLogger, isHosted, metrics, report } from '@nangohq/utils';
+import { Err, Ok, getLogger, isHosted, report } from '@nangohq/utils';
 import { sendAuth as sendAuthWebhook } from '@nangohq/webhooks';
 
 import { slackService } from '../services/slack.js';
@@ -414,9 +415,19 @@ export async function credentialsTest({
                     oauth_client_id: config.oauth_client_id,
                     oauth_client_secret: config.oauth_client_secret
                 }),
-                onBytes: ({ sent, received }) => {
-                    metrics.increment(metrics.Types.PROXY_REQUEST_SIZE_IN_BYTES, sent, { callsite: 'server_credential_test_hook' });
-                    metrics.increment(metrics.Types.PROXY_RESPONSE_SIZE_IN_BYTES, received, { callsite: 'server_credential_test_hook' });
+                onBytes: (meteredBytes) => {
+                    const events = makeDataTransferEvents(
+                        'server',
+                        'credential_test_hook',
+                        logCtx.accountId,
+                        connectionId,
+                        config.unique_key,
+                        config.environment_id,
+                        meteredBytes
+                    );
+                    if (events.length > 0) {
+                        void pubsub.publisher.publishBatch({ subject: 'usage', events });
+                    }
                 }
             });
 

--- a/packages/server/lib/webhook/webhook.manager.ts
+++ b/packages/server/lib/webhook/webhook.manager.ts
@@ -1,8 +1,8 @@
 import tracer from 'dd-trace';
 
 import db from '@nangohq/database';
-import { NangoError, customerKeyService, externalWebhookService, getProvider, pubsub } from '@nangohq/shared';
-import { Err, getLogger, metrics } from '@nangohq/utils';
+import { NangoError, customerKeyService, externalWebhookService, getProvider, makeDataTransferEvents, pubsub } from '@nangohq/shared';
+import { Err, getLogger } from '@nangohq/utils';
 import { forwardWebhook } from '@nangohq/webhooks';
 
 import * as webhookHandlers from './index.js';
@@ -11,6 +11,7 @@ import { capping } from '../utils/usage.js';
 
 import type { WebhookHandlersMap, WebhookResponse } from './types.js';
 import type { LogContextGetter } from '@nangohq/logs';
+import type { MaybeStampedEvent } from '@nangohq/pubsub';
 import type { Config } from '@nangohq/shared';
 import type { DBEnvironment, DBPlan, DBTeam } from '@nangohq/types';
 import type { Result } from '@nangohq/utils';
@@ -120,6 +121,7 @@ export async function routeWebhook({
         // Forward the webhook to the customer asynchronously to avoid provider timeouts.
         // Some providers stop sending webhooks if Nango doesn't respond quickly due to slow customer endpoints
         const forwardSpan = tracer.startSpan('webhook.forward');
+        const pendingEvents: MaybeStampedEvent<'usage'>[] = [];
 
         void forwardWebhook({
             integration,
@@ -131,15 +133,25 @@ export async function routeWebhook({
             payload: webhookBodyToForward,
             webhookOriginalHeaders: headers,
             logContextGetter,
-            onBytes: (bytes) => {
-                metrics.increment(metrics.Types.WEBHOOK_REQUEST_SIZE_IN_BYTES, bytes.sent, { callsite: 'forward' });
-                metrics.increment(metrics.Types.WEBHOOK_RESPONSE_SIZE_IN_BYTES, bytes.received, { callsite: 'forward' });
+            onBytes: (bytes, connectionId) => {
+                pendingEvents.push(
+                    ...makeDataTransferEvents(
+                        'server',
+                        'webhook_forward',
+                        account.id,
+                        connectionId,
+                        integration.unique_key,
+                        environment.id,
+                        bytes,
+                        environment.name
+                    )
+                );
             }
         })
             .then((res) => {
                 if (res.isOk()) {
-                    for (const connectionId of connectionIds.length > 0 ? connectionIds : ['unkown']) {
-                        pubsub.publisher.publish({
+                    for (const { connectionId, success } of res.value.results) {
+                        pendingEvents.push({
                             subject: 'usage',
                             type: 'usage.webhook_forward',
                             payload: {
@@ -150,14 +162,20 @@ export async function routeWebhook({
                                     environmentName: environment.name,
                                     integrationId: integration.unique_key,
                                     connectionId,
-                                    success: true
+                                    success
                                 }
                             }
                         });
                     }
                 }
             })
-            .finally(() => forwardSpan.finish());
+            .finally(() => {
+                if (pendingEvents.length > 0) {
+                    void pubsub.publisher.publishBatch({ subject: 'usage', events: pendingEvents });
+                }
+
+                forwardSpan.finish();
+            });
     }
 
     return res;

--- a/packages/shared/lib/index.ts
+++ b/packages/shared/lib/index.ts
@@ -45,6 +45,7 @@ export * from './services/providers.js';
 export * from './services/proxy/utils.js';
 export * from './services/proxy/request.js';
 export { type MeteredBytes, createMeteringTransport } from './services/proxy/byte-metering-transport.js';
+export { makeDataTransferEvents } from './services/proxy/data-transfer-event.js';
 export * from './services/plans/plans.js';
 export * from './services/plans/definitions.js';
 export * from './services/checkpoints/checkpoints.js';

--- a/packages/shared/lib/services/notification/slack.service.ts
+++ b/packages/shared/lib/services/notification/slack.service.ts
@@ -1,13 +1,11 @@
 import db, { dbNamespace, schema } from '@nangohq/database';
 import { Err, Ok, basePublicUrl, getLogger, metrics, stringToHash, truncateJson } from '@nangohq/utils';
 
-import { pubsub } from '../../utils/pubsub.js';
 import accountService from '../account.service.js';
 import configService from '../config.service.js';
 import connectionService from '../connection.service.js';
 import { refreshOrTestCredentials } from '../connections/credentials/refresh.js';
 import environmentService from '../environment.service.js';
-import { makeDataTransferEvents } from '../proxy/data-transfer-event.js';
 import { ProxyRequest } from '../proxy/request.js';
 import { getProxyConfiguration } from '../proxy/utils.js';
 
@@ -641,9 +639,7 @@ export class SlackService {
         const res = await this.proxySlackMessage({
             slackConnection: refreshedConnection.value,
             payload,
-            integration,
-            accountId: account.id,
-            environmentId: environment.id
+            integration
         });
 
         if (res.isErr()) {
@@ -667,15 +663,11 @@ export class SlackService {
     private async proxySlackMessage({
         slackConnection,
         payload,
-        integration,
-        accountId,
-        environmentId
+        integration
     }: {
         slackConnection: DBConnectionDecrypted;
         payload: NotificationPayload;
         integration: Config;
-        accountId: number;
-        environmentId: number;
     }): Promise<Result<PostSlackMessageResponse>> {
         const color = payload.status === 'open' ? '#e01e5a' : '#36a64f';
 
@@ -709,21 +701,7 @@ export class SlackService {
                 getIntegrationConfig: () => ({
                     oauth_client_id: integration.oauth_client_id,
                     oauth_client_secret: integration.oauth_client_secret
-                }),
-                onBytes: (meteredBytes) => {
-                    const events = makeDataTransferEvents(
-                        'shared',
-                        'slack_join_channel',
-                        accountId,
-                        slackConnection.connection_id,
-                        slackConnection.provider_config_key,
-                        environmentId,
-                        meteredBytes
-                    );
-                    if (events.length > 0) {
-                        void pubsub.publisher.publishBatch({ subject: 'usage', events });
-                    }
-                }
+                })
             });
             const join = await proxy.request();
             if (join.isErr()) {
@@ -796,21 +774,7 @@ export class SlackService {
                 getIntegrationConfig: () => ({
                     oauth_client_id: integration.oauth_client_id,
                     oauth_client_secret: integration.oauth_client_secret
-                }),
-                onBytes: (meteredBytes) => {
-                    const events = makeDataTransferEvents(
-                        'shared',
-                        'slack_send_message',
-                        accountId,
-                        slackConnection.connection_id,
-                        slackConnection.provider_config_key,
-                        environmentId,
-                        meteredBytes
-                    );
-                    if (events.length > 0) {
-                        void pubsub.publisher.publishBatch({ subject: 'usage', events });
-                    }
-                }
+                })
             });
             const slackMessage = await proxy.request();
 

--- a/packages/shared/lib/services/notification/slack.service.ts
+++ b/packages/shared/lib/services/notification/slack.service.ts
@@ -1,11 +1,13 @@
 import db, { dbNamespace, schema } from '@nangohq/database';
 import { Err, Ok, basePublicUrl, getLogger, metrics, stringToHash, truncateJson } from '@nangohq/utils';
 
+import { pubsub } from '../../utils/pubsub.js';
 import accountService from '../account.service.js';
 import configService from '../config.service.js';
 import connectionService from '../connection.service.js';
 import { refreshOrTestCredentials } from '../connections/credentials/refresh.js';
 import environmentService from '../environment.service.js';
+import { makeDataTransferEvents } from '../proxy/data-transfer-event.js';
 import { ProxyRequest } from '../proxy/request.js';
 import { getProxyConfiguration } from '../proxy/utils.js';
 
@@ -636,7 +638,13 @@ export class SlackService {
             return Err(refreshedConnection.error);
         }
 
-        const res = await this.proxySlackMessage({ slackConnection: refreshedConnection.value, payload, integration });
+        const res = await this.proxySlackMessage({
+            slackConnection: refreshedConnection.value,
+            payload,
+            integration,
+            accountId: account.id,
+            environmentId: environment.id
+        });
 
         if (res.isErr()) {
             metrics.increment(metrics.Types.SLACK_NOTIFICATION_FAILURE, 1, { accountId: account.id });
@@ -659,11 +667,15 @@ export class SlackService {
     private async proxySlackMessage({
         slackConnection,
         payload,
-        integration
+        integration,
+        accountId,
+        environmentId
     }: {
         slackConnection: DBConnectionDecrypted;
         payload: NotificationPayload;
         integration: Config;
+        accountId: number;
+        environmentId: number;
     }): Promise<Result<PostSlackMessageResponse>> {
         const color = payload.status === 'open' ? '#e01e5a' : '#36a64f';
 
@@ -698,9 +710,19 @@ export class SlackService {
                     oauth_client_id: integration.oauth_client_id,
                     oauth_client_secret: integration.oauth_client_secret
                 }),
-                onBytes: ({ sent, received }) => {
-                    metrics.increment(metrics.Types.PROXY_REQUEST_SIZE_IN_BYTES, sent, { callsite: 'slack_join_channel' });
-                    metrics.increment(metrics.Types.PROXY_RESPONSE_SIZE_IN_BYTES, received, { callsite: 'slack_join_channel' });
+                onBytes: (meteredBytes) => {
+                    const events = makeDataTransferEvents(
+                        'shared',
+                        'slack_join_channel',
+                        accountId,
+                        slackConnection.connection_id,
+                        slackConnection.provider_config_key,
+                        environmentId,
+                        meteredBytes
+                    );
+                    if (events.length > 0) {
+                        void pubsub.publisher.publishBatch({ subject: 'usage', events });
+                    }
                 }
             });
             const join = await proxy.request();
@@ -775,9 +797,19 @@ export class SlackService {
                     oauth_client_id: integration.oauth_client_id,
                     oauth_client_secret: integration.oauth_client_secret
                 }),
-                onBytes: ({ sent, received }) => {
-                    metrics.increment(metrics.Types.PROXY_REQUEST_SIZE_IN_BYTES, sent, { callsite: 'slack_send_message' });
-                    metrics.increment(metrics.Types.PROXY_RESPONSE_SIZE_IN_BYTES, received, { callsite: 'slack_send_message' });
+                onBytes: (meteredBytes) => {
+                    const events = makeDataTransferEvents(
+                        'shared',
+                        'slack_send_message',
+                        accountId,
+                        slackConnection.connection_id,
+                        slackConnection.provider_config_key,
+                        environmentId,
+                        meteredBytes
+                    );
+                    if (events.length > 0) {
+                        void pubsub.publisher.publishBatch({ subject: 'usage', events });
+                    }
                 }
             });
             const slackMessage = await proxy.request();

--- a/packages/shared/lib/services/proxy/data-transfer-event.ts
+++ b/packages/shared/lib/services/proxy/data-transfer-event.ts
@@ -1,0 +1,40 @@
+import type { MeteredBytes } from './byte-metering-transport.js';
+import type { UsageDataTransferEvent } from '@nangohq/types';
+
+export function makeDataTransferEvents(
+    pkg: 'runner' | 'server' | 'shared',
+    callsite: string,
+    accountId: number,
+    connectionId: string,
+    integrationId: string,
+    environmentId: number,
+    meteredBytes: MeteredBytes,
+    environmentName?: string,
+    syncId?: string
+): Omit<UsageDataTransferEvent, 'idempotencyKey' | 'createdAt'>[] {
+    const events = [
+        { direction: 'ingress' as const, bytes: meteredBytes.received },
+        { direction: 'egress' as const, bytes: meteredBytes.sent }
+    ]
+        .filter((e) => e.bytes > 0)
+        .map((event) => ({
+            subject: 'usage' as const,
+            type: 'usage.data_transfer' as const,
+            payload: {
+                value: event.bytes,
+                properties: {
+                    package: pkg,
+                    accountId,
+                    environmentId,
+                    environmentName: environmentName ?? '',
+                    integrationId,
+                    connectionId,
+                    callsite,
+                    direction: event.direction,
+                    ...(syncId ? { syncId } : {})
+                }
+            }
+        }));
+
+    return events;
+}

--- a/packages/types/lib/pubsub/events.ts
+++ b/packages/types/lib/pubsub/events.ts
@@ -152,7 +152,27 @@ export type UsageWebhookForwardEvent = UsageEventBase<
     }
 >;
 
+export type UsageDataTransferEvent = UsageEventBase<
+    'usage.data_transfer',
+    {
+        value: number;
+        properties: {
+            package: 'server' | 'runner' | 'shared';
+            callsite: string;
+            direction: 'ingress' | 'egress';
+            syncId?: string;
+        };
+    }
+>;
+
 type EnforceUsageEventBase<T extends UsageEventBase<any, any>> = T;
 export type UsageEvent = EnforceUsageEventBase<
-    UsageMarEvent | UsageRecordsEvent | UsageActionsEvent | UsageConnectionsEvent | UsageFunctionExecutionsEvent | UsageProxyEvent | UsageWebhookForwardEvent
+    | UsageMarEvent
+    | UsageRecordsEvent
+    | UsageActionsEvent
+    | UsageConnectionsEvent
+    | UsageFunctionExecutionsEvent
+    | UsageProxyEvent
+    | UsageWebhookForwardEvent
+    | UsageDataTransferEvent
 >;

--- a/packages/usage/lib/clickhouse/clickhouse.ts
+++ b/packages/usage/lib/clickhouse/clickhouse.ts
@@ -612,6 +612,7 @@ function toRaw(event: UsageEvent): ClickhouseRawUsageEvent | null {
         }
         case 'usage.records':
         case 'usage.connections':
+        case 'usage.data_transfer':
             // Not ingested into Clickhouse via events
             return null;
     }

--- a/packages/utils/lib/telemetry/metrics.ts
+++ b/packages/utils/lib/telemetry/metrics.ts
@@ -39,8 +39,7 @@ export enum Types {
     PROXY = 'nango.server.proxyCall',
     PROXY_SUCCESS = 'nango.server.proxy.success',
     PROXY_FAILURE = 'nango.server.proxy.failure',
-    PROXY_REQUEST_SIZE_IN_BYTES = 'nango.server.proxy.request.sizeInBytes',
-    PROXY_RESPONSE_SIZE_IN_BYTES = 'nango.server.proxy.response.sizeInBytes',
+    DATA_TRANSFER = 'nango.dataTransfer',
     PROXY_REDIRECT = 'nango.server.proxy.redirect',
     PROXY_BASE_URL_OVERRIDE_DENIED = 'nango.server.proxy.baseUrlOverrideDenied',
 
@@ -56,11 +55,6 @@ export enum Types {
     RUNNER_SDK = 'nango.runner.sdk',
     RUNNER_INVALID_SYNCS_RECORDS = 'nango.runner.invalidSyncsRecords',
     RUNNER_MEMORY_USAGE = 'nango.runner.memoryUsage',
-    RUNNER_UNCONTROLLED_FETCH_REQUEST_SIZE_BYTES = 'nango.runner.uncontrolledFetch.request.sizeBytes',
-    RUNNER_UNCONTROLLED_FETCH_RESPONSE_SIZE_BYTES = 'nango.runner.uncontrolledFetch.response.sizeBytes',
-    RUNNER_PERSIST_RECORDS_SENT_SIZE_IN_BYTES = 'nango.runner.persist.records.sent.sizeInBytes',
-    RUNNER_PERSIST_RECORDS_RECEIVED_SIZE_IN_BYTES = 'nango.runner.persist.records.received.sizeInBytes',
-    RUNNER_PERSIST_LOGS_SENT_SIZE_IN_BYTES = 'nango.runner.persist.logs.sent.sizeInBytes',
 
     FUNCTION_EXECUTIONS = 'nango.jobs.function.executions',
 

--- a/packages/webhooks/lib/forward.ts
+++ b/packages/webhooks/lib/forward.ts
@@ -30,105 +30,110 @@ export const forwardWebhook = async ({
     payload: Record<string, any> | null;
     webhookOriginalHeaders: Record<string, string>;
     logContextGetter: LogContextGetter;
-    onBytes?: (bytes: MeteredBytes) => void;
-}): Promise<Result<{ forwarded: number }>> => {
-    const totalBytes: MeteredBytes = { sent: 0, received: 0 };
-    const accumulateBytes = (hop: MeteredBytes) => {
-        totalBytes.sent += hop.sent;
-        totalBytes.received += hop.received;
-    };
-
-    try {
-        if (!webhookSettings) {
-            return Ok({ forwarded: 0 });
-        }
-        if (!shouldSend({ success: true, type: 'forward', webhookSettings })) {
-            return Ok({ forwarded: 0 });
-        }
-        if (!integration.forward_webhooks) {
-            return Ok({ forwarded: 0 });
-        }
-
-        const logCtx = await logContextGetter.create(
-            { operation: { type: 'webhook', action: 'forward' }, expiresAt: new Date(Date.now() + 15 * 60 * 1000).toISOString() },
-            {
-                account,
-                environment,
-                integration: { id: integration.id!, name: integration.unique_key, provider: integration.provider }
-            }
-        );
-        logCtx.attachSpan(new OtlpSpan(logCtx.operation));
-
-        const body: NangoForwardWebhookBody = {
-            from: integration.provider,
-            providerConfigKey: integration.unique_key,
-            type: 'forward',
-            payload: payload
-        };
-
-        const webhooks = [
-            { url: webhookSettings.primary_url, type: 'webhook url' },
-            { url: webhookSettings.secondary_url, type: 'secondary webhook url' }
-        ].filter((webhook) => webhook.url) as { url: string; type: string }[];
-
-        if (!connectionIds || connectionIds.length === 0) {
-            const result = await deliver({
-                webhooks,
-                body: payload,
-                webhookType: 'forward',
-                secret,
-                logCtx,
-                incomingHeaders: webhookOriginalHeaders,
-                onBytes: accumulateBytes
-            });
-
-            if (result.isErr()) {
-                metrics.increment(metrics.Types.WEBHOOK_INCOMING_FORWARDED_FAILED, 1, { accountId: account.id });
-                await logCtx.failed();
-                return Err(result.error);
-            }
-
-            metrics.increment(metrics.Types.WEBHOOK_INCOMING_FORWARDED_SUCCESS, 1, { accountId: account.id });
-            await logCtx.success();
-            return Ok({ forwarded: 1 });
-        }
-
-        let success = true;
-        let forwarded = 0;
-        for (const connectionId of connectionIds) {
-            const result = await deliver({
-                webhooks,
-                body: {
-                    ...body,
-                    connectionId
-                },
-                webhookType: 'forward',
-                secret,
-                logCtx,
-                incomingHeaders: webhookOriginalHeaders,
-                onBytes: accumulateBytes
-            });
-
-            if (result.isOk()) {
-                metrics.increment(metrics.Types.WEBHOOK_INCOMING_FORWARDED_SUCCESS, 1, { accountId: account.id });
-                forwarded += 1;
-            } else {
-                metrics.increment(metrics.Types.WEBHOOK_INCOMING_FORWARDED_FAILED, 1, { accountId: account.id });
-                success = false;
-            }
-        }
-
-        if (success) {
-            await logCtx.success();
-        } else {
-            await logCtx.failed();
-        }
-        return Ok({ forwarded });
-    } finally {
+    onBytes?: (bytes: MeteredBytes, connectionId: string) => void;
+}): Promise<Result<{ results: { connectionId: string; success: boolean }[] }>> => {
+    const safeOnBytes = (bytes: MeteredBytes, connectionId: string) => {
         try {
-            onBytes?.(totalBytes);
+            onBytes?.(bytes, connectionId);
         } catch (err) {
             logger.error('onBytes callback failed', err);
         }
+    };
+
+    if (!webhookSettings) {
+        return Ok({ results: [] });
     }
+    if (!shouldSend({ success: true, type: 'forward', webhookSettings })) {
+        return Ok({ results: [] });
+    }
+    if (!integration.forward_webhooks) {
+        return Ok({ results: [] });
+    }
+
+    const logCtx = await logContextGetter.create(
+        { operation: { type: 'webhook', action: 'forward' }, expiresAt: new Date(Date.now() + 15 * 60 * 1000).toISOString() },
+        {
+            account,
+            environment,
+            integration: { id: integration.id!, name: integration.unique_key, provider: integration.provider }
+        }
+    );
+    logCtx.attachSpan(new OtlpSpan(logCtx.operation));
+
+    const body: NangoForwardWebhookBody = {
+        from: integration.provider,
+        providerConfigKey: integration.unique_key,
+        type: 'forward',
+        payload: payload
+    };
+
+    const webhooks = [
+        { url: webhookSettings.primary_url, type: 'webhook url' },
+        { url: webhookSettings.secondary_url, type: 'secondary webhook url' }
+    ].filter((webhook) => webhook.url) as { url: string; type: string }[];
+
+    if (!connectionIds || connectionIds.length === 0) {
+        const deliverBytes: MeteredBytes = { sent: 0, received: 0 };
+        const result = await deliver({
+            webhooks,
+            body: payload,
+            webhookType: 'forward',
+            secret,
+            logCtx,
+            incomingHeaders: webhookOriginalHeaders,
+            onBytes: (b) => {
+                deliverBytes.sent += b.sent;
+                deliverBytes.received += b.received;
+            }
+        });
+        safeOnBytes(deliverBytes, 'unknown');
+
+        if (result.isErr()) {
+            metrics.increment(metrics.Types.WEBHOOK_INCOMING_FORWARDED_FAILED, 1, { accountId: account.id });
+            await logCtx.failed();
+            return Err(result.error);
+        }
+
+        metrics.increment(metrics.Types.WEBHOOK_INCOMING_FORWARDED_SUCCESS, 1, { accountId: account.id });
+        await logCtx.success();
+        return Ok({ results: [{ connectionId: 'unknown', success: true }] });
+    }
+
+    let success = true;
+    const results: { connectionId: string; success: boolean }[] = [];
+    for (const connectionId of connectionIds) {
+        const deliverBytes: MeteredBytes = { sent: 0, received: 0 };
+        const result = await deliver({
+            webhooks,
+            body: {
+                ...body,
+                connectionId
+            },
+            webhookType: 'forward',
+            secret,
+            logCtx,
+            incomingHeaders: webhookOriginalHeaders,
+            onBytes: (b) => {
+                deliverBytes.sent += b.sent;
+                deliverBytes.received += b.received;
+            }
+        });
+        safeOnBytes(deliverBytes, connectionId);
+
+        if (result.isOk()) {
+            metrics.increment(metrics.Types.WEBHOOK_INCOMING_FORWARDED_SUCCESS, 1, { accountId: account.id });
+            results.push({ connectionId, success: true });
+        } else {
+            metrics.increment(metrics.Types.WEBHOOK_INCOMING_FORWARDED_FAILED, 1, { accountId: account.id });
+            success = false;
+            results.push({ connectionId, success: false });
+        }
+    }
+
+    if (success) {
+        await logCtx.success();
+    } else {
+        await logCtx.failed();
+    }
+    return Ok({ results });
 };

--- a/packages/webhooks/lib/forward.unit.test.ts
+++ b/packages/webhooks/lib/forward.unit.test.ts
@@ -216,8 +216,8 @@ describe('Webhooks: forward notification tests', () => {
         expect(reportedBytes?.sent).toBeGreaterThanOrEqual(minBytes);
     });
 
-    it('Should report zero bytes via onBytes when forwarding is skipped', async () => {
-        let reportedBytes: { sent: number; received: number } | undefined;
+    it('Should not invoke onBytes when forwarding is skipped', async () => {
+        let called = false;
         const result = await forwardWebhook({
             connectionIds: [],
             account,
@@ -228,18 +228,18 @@ describe('Webhooks: forward notification tests', () => {
             integration,
             payload: { some: 'data' },
             webhookOriginalHeaders: {},
-            onBytes: (b) => {
-                reportedBytes = b;
+            onBytes: () => {
+                called = true;
             }
         });
         expect(result.isOk()).toBe(true);
-        expect(reportedBytes).toEqual({ sent: 0, received: 0 });
+        expect(called).toBe(false);
     });
 
-    it('Should sum bytes across connections in fan-out via onBytes', async () => {
+    it('Should invoke onBytes once per connection with that connection id', async () => {
         const connectionIds = ['conn1', 'conn2'];
         const payload = { x: 1 };
-        let reportedBytes: { sent: number; received: number } | undefined;
+        const calls: { connectionId: string; sent: number }[] = [];
         const result = await forwardWebhook({
             connectionIds,
             account,
@@ -250,15 +250,18 @@ describe('Webhooks: forward notification tests', () => {
             integration,
             payload,
             webhookOriginalHeaders: {},
-            onBytes: (b) => {
-                reportedBytes = b;
+            onBytes: (b, connectionId) => {
+                calls.push({ connectionId, sent: b.sent });
             }
         });
         expect(result.isOk()).toBe(true);
         if (result.isOk()) {
-            expect(result.value.forwarded).toBe(2);
+            expect(result.value.results.filter((r) => r.success).length).toBe(2);
         }
-        const minBytes = Buffer.byteLength(JSON.stringify(payload)) * connectionIds.length;
-        expect(reportedBytes?.sent).toBeGreaterThanOrEqual(minBytes);
+        expect(calls.map((c) => c.connectionId)).toEqual(['conn1', 'conn2']);
+        const minBytesPerConnection = Buffer.byteLength(JSON.stringify(payload));
+        for (const call of calls) {
+            expect(call.sent).toBeGreaterThanOrEqual(minBytesPerConnection);
+        }
     });
 });


### PR DESCRIPTION
This PR re-introduces data transfer telemetry wiring through pubsub by reverting 2caacb7c7cdb2f0fd3450e22580eae638b37f315 and removing the problematic bits:

- Remove the metering of slack-service, which was the culprit behind the increased error rate during the last deployment.
- Fix error logging in `publisher.publisBatch` failures: rather than relying on error serialization, simply log the error message(s).

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/NangoHQ/nango/pull/6530?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

