### PR TITLE
fix(ci): isolate npm publish setup for trusted publishing

### DIFF
--- a/.github/workflows/publish.yaml
+++ b/.github/workflows/publish.yaml
@@ -30,7 +30,7 @@ jobs:
                   token: ${{ steps.create_github_app_token.outputs.token }}
                   fetch-depth: 0
 
-            - uses: actions/setup-node@v4
+            - uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4.4.0
               with:
                   node-version-file: '.nvmrc'
                   registry-url: 'https://registry.npmjs.org'

--- a/.github/workflows/publish.yaml
+++ b/.github/workflows/publish.yaml
@@ -30,9 +30,13 @@ jobs:
                   token: ${{ steps.create_github_app_token.outputs.token }}
                   fetch-depth: 0
 
-            - uses: ./.github/actions/setup-node
+            - uses: actions/setup-node@v4
               with:
+                  node-version-file: '.nvmrc'
                   registry-url: 'https://registry.npmjs.org'
+
+            - name: Update npm to latest trusted-publishing version
+              run: npm install -g npm@11.5.1
 
             - name: Install dependencies
               run: npm ci

--- a/.github/workflows/publish.yaml
+++ b/.github/workflows/publish.yaml
@@ -35,6 +35,7 @@ jobs:
                   node-version-file: '.nvmrc'
                   registry-url: 'https://registry.npmjs.org'
 
+            # Trusted publishing requires npm CLI version 11.5.1 or later.
             - name: Update npm to latest trusted-publishing version
               run: npm install -g npm@11.5.1
 


### PR DESCRIPTION
This fixes npm publish after the setup-node refactor.

The publish workflow was switched over to the shared composite action, which enables npm cache by default and no longer installs the npm version we need for trusted publishing. That left the release job running with the runner’s default npm instead of `npm@11.5.1`, which breaks npm trusted publishing and shows up as a misleading 404 during npm publish.

**This change gives the publish workflow its own setup again:**
- use actions/setup-node@v4 directly in publish.yaml
- do not enable npm cache for the release job
- explicitly install npm@11.5.1 before npm ci

**Why this is needed:**
- npm trusted publishing requires a newer npm than the runner default
- release publish should not inherit CI caching defaults
- the previous trusted publishing setup already pinned npm and worked before the refactor

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/NangoHQ/nango/pull/6531?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

