### PR TITLE
feat(functions): deploy and persistence (NAN-6003) 4/n

### DIFF
--- a/packages/cli/lib/index.ts
+++ b/packages/cli/lib/index.ts
@@ -604,6 +604,7 @@ program
     .option('-s, --sync', 'Disambiguate to a sync when multiple functions share the name')
     .option('-a, --action', 'Disambiguate to an action when multiple functions share the name')
     .option('--on-event', 'Disambiguate to an on-event script when multiple functions share the name')
+    .option('--function', 'Disambiguate to a function when multiple functions share the name')
     .option('-f, --force', 'Overwrite existing files without prompting', false)
     .action(async function (this: Command, integration: string, name: string) {
         const { debug, autoConfirm, force, interactive } = this.opts<GlobalOptions & { force: boolean }>();
@@ -613,6 +614,7 @@ program
             sync?: boolean;
             action?: boolean;
             onEvent?: boolean;
+            function?: boolean;
         }>();
         const fullPath = process.cwd();
 
@@ -628,9 +630,11 @@ program
             return;
         }
 
-        const typeFlags = [opts.sync && 'sync', opts.action && 'action', opts.onEvent && 'on-event'].filter(Boolean) as ScriptTypeLiteral[];
+        const typeFlags = [opts.sync && 'sync', opts.action && 'action', opts.onEvent && 'on-event', opts.function && 'function'].filter(
+            Boolean
+        ) as ScriptTypeLiteral[];
         if (typeFlags.length > 1) {
-            console.error(chalk.red('Specify at most one of --sync, --action, --on-event.'));
+            console.error(chalk.red('Specify at most one of --sync, --action, --on-event, --function.'));
             process.exitCode = 1;
             return;
         }

--- a/packages/cli/lib/services/pull.service.ts
+++ b/packages/cli/lib/services/pull.service.ts
@@ -10,16 +10,18 @@ import { parseSecretKey, printDebug, resolveHostport } from '../utils.js';
 
 import type { ScriptTypeLiteral } from '@nangohq/types';
 
-const scriptTypeToFolder: Record<ScriptTypeLiteral, 'syncs' | 'actions' | 'on-events'> = {
+const scriptTypeToFolder: Record<ScriptTypeLiteral, 'syncs' | 'actions' | 'on-events' | 'functions'> = {
     sync: 'syncs',
     action: 'actions',
-    'on-event': 'on-events'
+    'on-event': 'on-events',
+    function: 'functions'
 };
 
-const folderToScriptType: Record<'syncs' | 'actions' | 'on-events', ScriptTypeLiteral> = {
+const folderToScriptType: Record<'syncs' | 'actions' | 'on-events' | 'functions', ScriptTypeLiteral> = {
     syncs: 'sync',
     actions: 'action',
-    'on-events': 'on-event'
+    'on-events': 'on-event',
+    functions: 'function'
 };
 
 export function isUnsafeName(segment: string): boolean {
@@ -144,7 +146,9 @@ export async function pullFromCatalog(options: PullCatalogOptions): Promise<bool
     try {
         const contentCache = new Map<string, string>();
 
-        const foldersToProbe: ('syncs' | 'actions' | 'on-events')[] = type ? [scriptTypeToFolder[type]] : ['syncs', 'actions', 'on-events'];
+        const foldersToProbe: ('syncs' | 'actions' | 'on-events' | 'functions')[] = type
+            ? [scriptTypeToFolder[type]]
+            : ['syncs', 'actions', 'on-events', 'functions'];
 
         const probeResults = await Promise.allSettled(
             foldersToProbe.map(async (folder) => {
@@ -154,7 +158,7 @@ export async function pullFromCatalog(options: PullCatalogOptions): Promise<bool
             })
         );
 
-        const matches: { folder: 'syncs' | 'actions' | 'on-events'; candidatePath: string; content: string }[] = [];
+        const matches: { folder: 'syncs' | 'actions' | 'on-events' | 'functions'; candidatePath: string; content: string }[] = [];
         for (const result of probeResults) {
             if (result.status === 'fulfilled') {
                 matches.push(result.value);

--- a/packages/cli/lib/services/pull.service.ts
+++ b/packages/cli/lib/services/pull.service.ts
@@ -81,7 +81,7 @@ export async function pullFunction(options: PullFunctionOptions): Promise<boolea
             spinner.fail(`Failed to pull '${name}'`);
             console.log(chalk.red(`\n${errMessage} ${chalk.gray(`(${errCode})`)}`));
             if (errCode === 'ambiguous_function') {
-                console.log(chalk.gray(`Re-run with --sync, --action, or --on-event to disambiguate.`));
+                console.log(chalk.gray(`Re-run with --sync, --action, --on-event, or --function to disambiguate.`));
             }
             return false;
         }
@@ -181,7 +181,7 @@ export async function pullFromCatalog(options: PullCatalogOptions): Promise<bool
             const matchedTypes = matches.map((m) => folderToScriptType[m.folder]).join(', ');
             spinner.fail(`Failed to pull '${name}'`);
             console.log(chalk.red(`\nMultiple functions named '${name}' exist for '${integrationId}' (${matchedTypes}).`));
-            console.log(chalk.gray(`Re-run with --sync, --action, or --on-event to disambiguate.`));
+            console.log(chalk.gray(`Re-run with --sync, --action, --on-event, or --function to disambiguate.`));
             return false;
         }
 

--- a/packages/cli/lib/services/pull.service.ts
+++ b/packages/cli/lib/services/pull.service.ts
@@ -10,16 +10,18 @@ import { Spinner } from '../utils/spinner.js';
 
 import type { ScriptTypeLiteral } from '@nangohq/types';
 
-const scriptTypeToFolder: Record<ScriptTypeLiteral, 'syncs' | 'actions' | 'on-events'> = {
+const scriptTypeToFolder: Record<ScriptTypeLiteral, 'syncs' | 'actions' | 'on-events' | 'functions'> = {
     sync: 'syncs',
     action: 'actions',
-    'on-event': 'on-events'
+    'on-event': 'on-events',
+    function: 'functions'
 };
 
-const folderToScriptType: Record<'syncs' | 'actions' | 'on-events', ScriptTypeLiteral> = {
+const folderToScriptType: Record<'syncs' | 'actions' | 'on-events' | 'functions', ScriptTypeLiteral> = {
     syncs: 'sync',
     actions: 'action',
-    'on-events': 'on-event'
+    'on-events': 'on-event',
+    functions: 'function'
 };
 
 export function isUnsafeName(segment: string): boolean {
@@ -144,7 +146,9 @@ export async function pullFromCatalog(options: PullCatalogOptions): Promise<bool
     try {
         const contentCache = new Map<string, string>();
 
-        const foldersToProbe: ('syncs' | 'actions' | 'on-events')[] = type ? [scriptTypeToFolder[type]] : ['syncs', 'actions', 'on-events'];
+        const foldersToProbe: ('syncs' | 'actions' | 'on-events' | 'functions')[] = type
+            ? [scriptTypeToFolder[type]]
+            : ['syncs', 'actions', 'on-events', 'functions'];
 
         const probeResults = await Promise.allSettled(
             foldersToProbe.map(async (folder) => {
@@ -154,7 +158,7 @@ export async function pullFromCatalog(options: PullCatalogOptions): Promise<bool
             })
         );
 
-        const matches: { folder: 'syncs' | 'actions' | 'on-events'; candidatePath: string; content: string }[] = [];
+        const matches: { folder: 'syncs' | 'actions' | 'on-events' | 'functions'; candidatePath: string; content: string }[] = [];
         for (const result of probeResults) {
             if (result.status === 'fulfilled') {
                 matches.push(result.value);

--- a/packages/cli/lib/zeroYaml/definitions.ts
+++ b/packages/cli/lib/zeroYaml/definitions.ts
@@ -326,6 +326,7 @@ export function parseFunction({
     const fn: ParsedNangoFunction = {
         type: 'function',
         name: params.name || basename,
+        fileName: basename,
         description: params.description || '',
         trigger: parsedTrigger,
         input: inputName,

--- a/packages/cli/lib/zeroYaml/deploy.ts
+++ b/packages/cli/lib/zeroYaml/deploy.ts
@@ -270,6 +270,48 @@ async function createDeployConfirmationPackage({
                 postData.push(body);
             }
         }
+
+        if (!optionalSyncName && !optionalActionName) {
+            for (const fn of integration.functions ?? []) {
+                const metadata = {} as NangoConfigMetadata;
+                if (fn.description) {
+                    metadata['description'] = fn.description;
+                }
+                if (fn.scopes && fn.scopes.length > 0) {
+                    metadata['scopes'] = fn.scopes;
+                }
+
+                // A function lives in either webhooks/ (createWebhook) or functions/ (createFunction);
+                // the bundled artifact preserves that folder, so probe it to pick the right ScriptFileType.
+                const scriptFileType: ScriptFileType = fs.existsSync(path.join(fullPath, 'build', `${providerConfigKey}_webhooks_${fn.name}.cjs`))
+                    ? 'webhooks'
+                    : 'functions';
+
+                const files = await loadScriptFiles({ scriptName: fn.name, providerConfigKey, fullPath, type: scriptFileType });
+                if (!files) {
+                    return Err(new Error(`No script files found for "${fn.name}"`));
+                }
+
+                const body: CLIDeployFlowConfig = {
+                    syncName: fn.name,
+                    providerConfigKey,
+                    models: fn.output || [],
+                    version: version || fn.version,
+                    runs: null,
+                    metadata,
+                    input: fn.input || undefined,
+                    type: fn.type,
+                    function_config: { name: fn.name, triggers: fn.triggers },
+                    fileBody: files,
+                    endpoints: [],
+                    track_deletes: false,
+                    models_json_schema: fn.json_schema,
+                    features: fn.features
+                };
+
+                postData.push(body);
+            }
+        }
     }
 
     if (postData.length <= 0) {

--- a/packages/cli/lib/zeroYaml/deploy.ts
+++ b/packages/cli/lib/zeroYaml/deploy.ts
@@ -270,6 +270,48 @@ async function createDeployConfirmationPackage({
                 postData.push(body);
             }
         }
+
+        if (!optionalSyncName && !optionalActionName) {
+            for (const fn of integration.functions ?? []) {
+                const metadata = {} as NangoConfigMetadata;
+                if (fn.description) {
+                    metadata['description'] = fn.description;
+                }
+                if (fn.scopes && fn.scopes.length > 0) {
+                    metadata['scopes'] = fn.scopes;
+                }
+
+                // A function lives in either webhooks/ (createWebhook) or functions/ (createFunction);
+                // the bundled artifact preserves that folder, so probe it to pick the right ScriptFileType.
+                const scriptFileType: ScriptFileType = fs.existsSync(path.join(fullPath, 'build', `${providerConfigKey}_webhooks_${fn.name}.cjs`))
+                    ? 'webhooks'
+                    : 'functions';
+
+                const files = await loadScriptFiles({ scriptName: fn.name, providerConfigKey, fullPath, type: scriptFileType });
+                if (!files) {
+                    return Err(new Error(`No script files found for "${fn.name}"`));
+                }
+
+                const body: CLIDeployFlowConfig = {
+                    syncName: fn.name,
+                    providerConfigKey,
+                    models: fn.output || [],
+                    version: version || fn.version,
+                    runs: null,
+                    metadata,
+                    input: fn.input || undefined,
+                    type: fn.type,
+                    function_config: { name: fn.name, triggers: fn.triggers, ...(fn.debounce !== undefined ? { debounce: fn.debounce } : {}) },
+                    fileBody: files,
+                    endpoints: [],
+                    track_deletes: false,
+                    models_json_schema: fn.json_schema,
+                    features: fn.features
+                };
+
+                postData.push(body);
+            }
+        }
     }
 
     if (postData.length <= 0) {

--- a/packages/cli/lib/zeroYaml/deploy.ts
+++ b/packages/cli/lib/zeroYaml/deploy.ts
@@ -283,13 +283,14 @@ async function createDeployConfirmationPackage({
 
                 // A function lives in either webhooks/ (createWebhook) or functions/ (createFunction);
                 // the bundled artifact preserves that folder, so probe it to pick the right ScriptFileType.
-                const scriptFileType: ScriptFileType = fs.existsSync(path.join(fullPath, 'build', `${providerConfigKey}_webhooks_${fn.name}.cjs`))
+                // The artifact is keyed by the source file basename, not the (possibly custom) function name.
+                const scriptFileType: ScriptFileType = fs.existsSync(path.join(fullPath, 'build', `${providerConfigKey}_webhooks_${fn.fileName}.cjs`))
                     ? 'webhooks'
                     : 'functions';
 
-                const files = await loadScriptFiles({ scriptName: fn.name, providerConfigKey, fullPath, type: scriptFileType });
+                const files = await loadScriptFiles({ scriptName: fn.fileName, providerConfigKey, fullPath, type: scriptFileType });
                 if (!files) {
-                    return Err(new Error(`No script files found for "${fn.name}"`));
+                    return Err(new Error(`No script files found for "${fn.fileName}"`));
                 }
 
                 const body: CLIDeployFlowConfig = {
@@ -301,7 +302,7 @@ async function createDeployConfirmationPackage({
                     metadata,
                     input: fn.input || undefined,
                     type: fn.type,
-                    function_config: { name: fn.name, triggers: fn.triggers },
+                    function_config: { name: fn.name, trigger: fn.trigger },
                     fileBody: files,
                     endpoints: [],
                     track_deletes: false,

--- a/packages/database/lib/migrations/20260606160000_sync_config_function_config.cjs
+++ b/packages/database/lib/migrations/20260606160000_sync_config_function_config.cjs
@@ -1,0 +1,19 @@
+exports.config = { transaction: false };
+
+/**
+ * Functions (createFunction/createWebhook) deploy as _nango_sync_configs rows with type 'function'.
+ * Unlike syncs/actions they carry triggers (with ingress/debounce config) rather than a single `runs`
+ * schedule, so we persist that function-specific shape in a dedicated jsonb column. Null for sync/action/on-event.
+ *
+ * @param {import('knex').Knex} knex
+ */
+exports.up = async function (knex) {
+    await knex.raw(`ALTER TABLE _nango_sync_configs ADD COLUMN IF NOT EXISTS function_config JSONB`);
+};
+
+/**
+ * @param {import('knex').Knex} knex
+ */
+exports.down = async function (knex) {
+    await knex.raw(`ALTER TABLE _nango_sync_configs DROP COLUMN IF EXISTS function_config`);
+};

--- a/packages/database/lib/migrations/20260606160000_sync_config_function_config.cjs
+++ b/packages/database/lib/migrations/20260606160000_sync_config_function_config.cjs
@@ -1,19 +1,7 @@
 exports.config = { transaction: false };
 
-/**
- * Functions (createFunction/createWebhook) deploy as _nango_sync_configs rows with type 'function'.
- * Unlike syncs/actions they carry triggers (with ingress/debounce config) rather than a single `runs`
- * schedule, so we persist that function-specific shape in a dedicated jsonb column. Null for sync/action/on-event.
- *
- * @param {import('knex').Knex} knex
- */
 exports.up = async function (knex) {
     await knex.raw(`ALTER TABLE _nango_sync_configs ADD COLUMN IF NOT EXISTS function_config JSONB`);
 };
 
-/**
- * @param {import('knex').Knex} knex
- */
-exports.down = async function (knex) {
-    await knex.raw(`ALTER TABLE _nango_sync_configs DROP COLUMN IF EXISTS function_config`);
-};
+exports.down = async function () {};

--- a/packages/feature-flags/lib/flags.ts
+++ b/packages/feature-flags/lib/flags.ts
@@ -18,6 +18,14 @@ export function buildFlags(client: FeatureFlagsClient) {
             // targetingKey drives gradual-rollout stickiness (same account => same bucket);
             // accountUuid is exposed as a property so strategies can allow/exclude specific accounts.
             return client.isEnabled('oauth-state-cookie-enforcement', { targetingKey: accountUuid, accountUuid }, false);
+        },
+        /**
+         * Whether this account may deploy functions. Gated to an allowlist of accounts while the
+         * function primitive is rolled out. Default `false`.
+         */
+        canDeployFunctions(accountUuid: string) {
+            // accountUuid is exposed as a property so the Unleash strategy can allowlist specific accounts.
+            return client.isEnabled('function-deployment', { targetingKey: accountUuid, accountUuid }, false);
         }
     };
 }

--- a/packages/feature-flags/lib/flags.ts
+++ b/packages/feature-flags/lib/flags.ts
@@ -24,7 +24,6 @@ export function buildFlags(client: FeatureFlagsClient) {
          * function primitive is rolled out. Default `false`.
          */
         canDeployFunctions(accountUuid: string) {
-            // accountUuid is exposed as a property so the Unleash strategy can allowlist specific accounts.
             return client.isEnabled('function-deployment', { targetingKey: accountUuid, accountUuid }, false);
         }
     };

--- a/packages/nango-yaml/lib/errors.ts
+++ b/packages/nango-yaml/lib/errors.ts
@@ -132,3 +132,13 @@ export class ParserErrorBothPostConnectionScriptsAndOnEventsPresent extends Pars
         });
     }
 }
+
+export class ParserErrorFunctionNotSupportedInV1 extends ParserError {
+    constructor(options: { name: string; path: string[] }) {
+        super({
+            code: 'function_not_supported_in_v1',
+            message: `"${options.name}" declares type "function", which is not supported in nango.yaml. Functions are defined with createFunction in TypeScript.`,
+            path: options.path
+        });
+    }
+}

--- a/packages/nango-yaml/lib/parser.v1.ts
+++ b/packages/nango-yaml/lib/parser.v1.ts
@@ -1,3 +1,4 @@
+import { ParserErrorFunctionNotSupportedInV1 } from './errors.js';
 import { NangoYamlParser } from './parser.js';
 
 import type { NangoYamlParsedIntegration, NangoYamlV1, ParsedNangoAction, ParsedNangoSync } from '@nangohq/types';
@@ -28,6 +29,11 @@ export class NangoYamlParserV1 extends NangoYamlParser {
             for (const syncOrActionName in integration) {
                 const syncOrAction = integration[syncOrActionName];
                 if (!syncOrAction) {
+                    continue;
+                }
+
+                if (syncOrAction.type === 'function') {
+                    this.errors.push(new ParserErrorFunctionNotSupportedInV1({ name: syncOrActionName, path: [integrationName, syncOrActionName] }));
                     continue;
                 }
 

--- a/packages/server/lib/controllers/integrations/uniqueKey/functions/getCode.ts
+++ b/packages/server/lib/controllers/integrations/uniqueKey/functions/getCode.ts
@@ -52,7 +52,7 @@ const validationParams = z
 
 const validationQuery = z
     .object({
-        type: z.enum(['sync', 'action', 'on-event']).optional()
+        type: z.enum(['sync', 'action', 'on-event', 'function']).optional()
     })
     .strict();
 

--- a/packages/server/lib/controllers/integrations/uniqueKey/functions/getCode.ts
+++ b/packages/server/lib/controllers/integrations/uniqueKey/functions/getCode.ts
@@ -11,10 +11,11 @@ import { asyncWrapper } from '../../../../utils/asyncWrapper.js';
 
 import type { GetPublicFunctionCode, ScriptTypeLiteral } from '@nangohq/types';
 
-const scriptTypeToFolder: Record<ScriptTypeLiteral, 'syncs' | 'actions' | 'on-events'> = {
+const scriptTypeToFolder: Record<ScriptTypeLiteral, 'syncs' | 'actions' | 'on-events' | 'functions'> = {
     sync: 'syncs',
     action: 'actions',
-    'on-event': 'on-events'
+    'on-event': 'on-events',
+    function: 'functions'
 };
 
 interface FunctionMatch {

--- a/packages/server/lib/controllers/sync/deploy/functionDeployGate.ts
+++ b/packages/server/lib/controllers/sync/deploy/functionDeployGate.ts
@@ -1,0 +1,16 @@
+import { getFlags } from '@nangohq/feature-flags';
+
+import type { CLIDeployFlowConfig } from '@nangohq/types';
+
+/**
+ * Function deployment is gated to an allowlist of accounts (Unleash `function-deployment`) while the
+ * primitive is rolled out. Returns true when the payload deploys a function but the account is not
+ * allowlisted, so the caller can reject the deploy.
+ */
+export async function isFunctionDeployBlocked({ flowConfigs, accountUuid }: { flowConfigs: CLIDeployFlowConfig[]; accountUuid: string }): Promise<boolean> {
+    const deploysFunction = flowConfigs.some((flow) => flow.type === 'function');
+    if (!deploysFunction) {
+        return false;
+    }
+    return !(await getFlags().canDeployFunctions(accountUuid));
+}

--- a/packages/server/lib/controllers/sync/deploy/postConfirmation.ts
+++ b/packages/server/lib/controllers/sync/deploy/postConfirmation.ts
@@ -4,6 +4,7 @@ import { metrics, requireEmptyQuery, zodErrorToHTTP } from '@nangohq/utils';
 
 import { asyncWrapper } from '../../../utils/asyncWrapper.js';
 import { getOrchestrator } from '../../../utils/utils.js';
+import { isFunctionDeployBlocked } from './functionDeployGate.js';
 import { validation } from './validation.js';
 
 import type { PostDeployConfirmation, ScriptDifferences } from '@nangohq/types';
@@ -26,6 +27,11 @@ export const postDeployConfirmation = asyncWrapper<PostDeployConfirmation>(async
     const { account } = res.locals;
     const body: PostDeployConfirmation['Body'] = val.data;
     const environmentId = res.locals['environment'].id;
+
+    if (await isFunctionDeployBlocked({ flowConfigs: body.flowConfigs, accountUuid: account.uuid })) {
+        res.status(403).send({ error: { code: 'forbidden', message: 'Function deployment is not enabled for this account' } });
+        return;
+    }
 
     metrics.increment(metrics.Types.DEPLOY_INCOMING_PAYLOAD_SIZE_BYTES, req.rawBody ? Buffer.byteLength(req.rawBody) : 0, { accountId: account.id });
 

--- a/packages/server/lib/controllers/sync/deploy/postDeploy.ts
+++ b/packages/server/lib/controllers/sync/deploy/postDeploy.ts
@@ -7,6 +7,7 @@ import { getLogger, requireEmptyQuery, zodErrorToHTTP } from '@nangohq/utils';
 import { startFunctionDeletion } from '../../../tasks/startFunctionDeletion.js';
 import { asyncWrapper } from '../../../utils/asyncWrapper.js';
 import { getOrchestrator } from '../../../utils/utils.js';
+import { isFunctionDeployBlocked } from './functionDeployGate.js';
 import { validationWithNangoYaml as validation } from './validation.js';
 
 import type { Lock } from '@nangohq/kvstore';
@@ -30,6 +31,11 @@ export const postDeploy = asyncWrapper<PostDeploy>(async (req, res) => {
 
     const body: PostDeploy['Body'] = val.data;
     const { environment, account, plan } = res.locals;
+
+    if (await isFunctionDeployBlocked({ flowConfigs: body.flowConfigs, accountUuid: account.uuid })) {
+        res.status(403).send({ error: { code: 'forbidden', message: 'Function deployment is not enabled for this account' } });
+        return;
+    }
 
     // Prevent concurrent deploys per environment, fail immediately if another deploy is in flight.
     const locking = await getLocking();

--- a/packages/server/lib/controllers/sync/deploy/validation.ts
+++ b/packages/server/lib/controllers/sync/deploy/validation.ts
@@ -37,9 +37,40 @@ const nangoModel = z
     })
     .strict();
 
+const functionTrigger = z
+    .object({
+        type: z.enum(['http', 'schedule', 'event']),
+        name: z.string().max(255).optional(),
+        scope: z.enum(['integration', 'connection']).optional(),
+        schedule: z.string().max(255).optional(),
+        event: z.string().max(255).optional(),
+        hasIngressChallenge: z.boolean().optional(),
+        hasIngressValidation: z.boolean().optional()
+    })
+    .strict();
+
+const functionDebounce = z
+    .object({
+        key: z.union([z.object({ body: z.string() }).strict(), z.object({ header: z.string() }).strict()]).optional(),
+        windowMs: z.number(),
+        maxWindowMs: z.number().optional(),
+        maxEntities: z.number().optional(),
+        payloadMode: z.enum(['latest', 'all']).optional()
+    })
+    .strict();
+
+const functionConfig = z
+    .object({
+        name: z.string().max(255).optional(),
+        triggers: z.array(functionTrigger),
+        debounce: functionDebounce.optional()
+    })
+    .strict();
+
 export const flowConfig = z
     .object({
-        type: z.enum(['action', 'sync']),
+        type: z.enum(['action', 'sync', 'function']),
+        function_config: functionConfig.optional(),
         models: z.array(z.string().min(1).max(255)),
         runs: z.union([z.string().length(0), frequencySchema]).nullable(), // TODO: remove or after >0.58.5 is widely adopted
         auto_start: z.boolean().optional().default(false),

--- a/packages/server/lib/controllers/sync/deploy/validation.ts
+++ b/packages/server/lib/controllers/sync/deploy/validation.ts
@@ -1,8 +1,12 @@
 import * as z from 'zod';
 
+import { getInterval } from '@nangohq/nango-yaml';
+
 import { frequencySchema, providerConfigKeySchema, syncNameSchema } from '../../../helpers/validation.js';
 
 import type { Feature, NangoModelField, OnEventType } from '@nangohq/types';
+
+const MAX_DEBOUNCE_KEY_SOURCES = 10;
 
 const fileBody = z.object({ js: z.string(), ts: z.string() }).strict();
 const jsonSchema = z
@@ -41,10 +45,10 @@ const functionDebounceKey = z.union([z.object({ body: z.string() }).strict(), z.
 
 const functionDebounce = z
     .object({
-        key: z.union([functionDebounceKey, z.array(functionDebounceKey)]).optional(),
-        windowMs: z.number(),
-        maxWindowMs: z.number().optional(),
-        maxEntities: z.number().optional(),
+        key: z.union([functionDebounceKey, z.array(functionDebounceKey).max(MAX_DEBOUNCE_KEY_SOURCES)]).optional(),
+        windowMs: z.number().int().positive(),
+        maxWindowMs: z.number().int().positive().optional(),
+        maxEntities: z.number().int().positive().optional(),
         payloadMode: z.enum(['latest', 'all']).optional()
     })
     .strict();
@@ -75,7 +79,7 @@ const functionIngress = z
                     .strict()
                     .optional(),
                 respond: z
-                    .object({ status: z.number().optional(), contentType: z.enum(['text/plain', 'application/json']).optional() })
+                    .object({ status: z.number().int().min(100).max(599).optional(), contentType: z.enum(['text/plain', 'application/json']).optional() })
                     .strict()
                     .optional()
             })
@@ -84,7 +88,6 @@ const functionIngress = z
     })
     .strict();
 
-// One trigger per function, discriminated on `kind` so each kind only carries its own fields.
 const functionTrigger = z.discriminatedUnion('kind', [
     z
         .object({
@@ -98,14 +101,17 @@ const functionTrigger = z.discriminatedUnion('kind', [
         .object({
             kind: z.literal('schedule'),
             name: z.string().max(255).optional(),
-            schedule: z.string().max(255)
+            schedule: z
+                .string()
+                .max(255)
+                .refine((value) => !(getInterval(value, new Date()) instanceof Error), { message: 'Invalid schedule interval' })
         })
         .strict(),
     z
         .object({
             kind: z.literal('event'),
             name: z.string().max(255).optional(),
-            event: z.string().max(255)
+            event: z.string().min(1).max(255)
         })
         .strict()
 ]);

--- a/packages/server/lib/controllers/sync/deploy/validation.ts
+++ b/packages/server/lib/controllers/sync/deploy/validation.ts
@@ -37,21 +37,11 @@ const nangoModel = z
     })
     .strict();
 
-const functionTrigger = z
-    .object({
-        type: z.enum(['http', 'schedule', 'event']),
-        name: z.string().max(255).optional(),
-        scope: z.enum(['integration', 'connection']).optional(),
-        schedule: z.string().max(255).optional(),
-        event: z.string().max(255).optional(),
-        hasIngressChallenge: z.boolean().optional(),
-        hasIngressValidation: z.boolean().optional()
-    })
-    .strict();
+const functionDebounceKey = z.union([z.object({ body: z.string() }).strict(), z.object({ header: z.string() }).strict()]);
 
 const functionDebounce = z
     .object({
-        key: z.union([z.object({ body: z.string() }).strict(), z.object({ header: z.string() }).strict()]).optional(),
+        key: z.union([functionDebounceKey, z.array(functionDebounceKey)]).optional(),
         windowMs: z.number(),
         maxWindowMs: z.number().optional(),
         maxEntities: z.number().optional(),
@@ -59,11 +49,71 @@ const functionDebounce = z
     })
     .strict();
 
+const functionIngress = z
+    .object({
+        validation: z
+            .object({
+                type: z.literal('hmac'),
+                algorithm: z.enum(['sha1', 'sha256', 'sha512']),
+                header: z.string(),
+                encoding: z.enum(['base64', 'hex']),
+                prefix: z.string().optional(),
+                secret: z.object({ source: z.literal('integrationConfig'), key: z.string() }).strict()
+            })
+            .strict()
+            .optional(),
+        challenge: z
+            .object({
+                type: z.literal('echo'),
+                token: z.object({ in: z.enum(['query', 'body', 'header']), key: z.string() }).strict(),
+                verify: z
+                    .object({
+                        in: z.enum(['query', 'body', 'header']),
+                        key: z.string(),
+                        secret: z.object({ source: z.literal('integrationConfig'), key: z.string() }).strict()
+                    })
+                    .strict()
+                    .optional(),
+                respond: z
+                    .object({ status: z.number().optional(), contentType: z.enum(['text/plain', 'application/json']).optional() })
+                    .strict()
+                    .optional()
+            })
+            .strict()
+            .optional()
+    })
+    .strict();
+
+// One trigger per function, discriminated on `kind` so each kind only carries its own fields.
+const functionTrigger = z.discriminatedUnion('kind', [
+    z
+        .object({
+            kind: z.literal('http'),
+            name: z.string().max(255).optional(),
+            ingress: functionIngress.optional(),
+            debounce: functionDebounce.optional()
+        })
+        .strict(),
+    z
+        .object({
+            kind: z.literal('schedule'),
+            name: z.string().max(255).optional(),
+            schedule: z.string().max(255)
+        })
+        .strict(),
+    z
+        .object({
+            kind: z.literal('event'),
+            name: z.string().max(255).optional(),
+            event: z.string().max(255)
+        })
+        .strict()
+]);
+
 const functionConfig = z
     .object({
         name: z.string().max(255).optional(),
-        triggers: z.array(functionTrigger),
-        debounce: functionDebounce.optional()
+        trigger: functionTrigger
     })
     .strict();
 
@@ -138,6 +188,10 @@ export const flowConfig = z
         },
         { message: 'models_json_schema is missing definitions for some models or input', path: ['models_json_schema'] }
     )
+    .refine((data) => (data.type === 'function' ? data.function_config !== undefined : data.function_config === undefined), {
+        message: 'function_config is required for function deploys and not allowed otherwise',
+        path: ['function_config']
+    })
     .strict();
 const flowConfigs = z.array(flowConfig);
 const onEventScriptsByProvider = z.array(

--- a/packages/server/lib/controllers/sync/deploy/validation.unit.test.ts
+++ b/packages/server/lib/controllers/sync/deploy/validation.unit.test.ts
@@ -1,0 +1,49 @@
+import { describe, expect, it } from 'vitest';
+
+import { flowConfig } from './validation.js';
+
+const base = {
+    type: 'sync' as const,
+    models: ['Contact'],
+    runs: null,
+    syncName: 'my-flow',
+    providerConfigKey: 'github',
+    fileBody: { js: 'compiled', ts: 'source' }
+};
+
+describe('flowConfig function validation', () => {
+    it('accepts a non-function flow without function_config', () => {
+        expect(flowConfig.safeParse(base).success).toBe(true);
+    });
+
+    it('requires function_config for function deploys', () => {
+        const result = flowConfig.safeParse({ ...base, type: 'function' });
+        expect(result.success).toBe(false);
+    });
+
+    it('rejects function_config on non-function deploys', () => {
+        const result = flowConfig.safeParse({ ...base, function_config: { trigger: { kind: 'http' } } });
+        expect(result.success).toBe(false);
+    });
+
+    it('accepts a function with an http trigger', () => {
+        const result = flowConfig.safeParse({ ...base, type: 'function', function_config: { trigger: { kind: 'http' } } });
+        expect(result.success).toBe(true);
+    });
+
+    it('requires a schedule on schedule triggers', () => {
+        const missing = flowConfig.safeParse({ ...base, type: 'function', function_config: { trigger: { kind: 'schedule' } } });
+        expect(missing.success).toBe(false);
+
+        const present = flowConfig.safeParse({ ...base, type: 'function', function_config: { trigger: { kind: 'schedule', schedule: 'every hour' } } });
+        expect(present.success).toBe(true);
+    });
+
+    it('requires an event on event triggers', () => {
+        const missing = flowConfig.safeParse({ ...base, type: 'function', function_config: { trigger: { kind: 'event' } } });
+        expect(missing.success).toBe(false);
+
+        const present = flowConfig.safeParse({ ...base, type: 'function', function_config: { trigger: { kind: 'event', event: 'post-connection-creation' } } });
+        expect(present.success).toBe(true);
+    });
+});

--- a/packages/shared/lib/services/file/local.service.ts
+++ b/packages/shared/lib/services/file/local.service.ts
@@ -10,14 +10,15 @@ import { NangoError } from '../../utils/error.js';
 import errorManager from '../../utils/error.manager.js';
 import { resolveLocalFileName, resolveLocalFilePath } from '../../utils/utils.js';
 
-import type { DBSyncConfig, NangoProps } from '@nangohq/types';
+import type { DBSyncConfig, NangoProps, ScriptTypeLiteral } from '@nangohq/types';
 import type { Response } from 'express';
 
-const scriptTypeToPath: Record<NangoProps['scriptType'], string> = {
+const scriptTypeToPath: Record<NangoProps['scriptType'] | ScriptTypeLiteral, string> = {
     'on-event': 'on-events',
     action: 'actions',
     sync: 'syncs',
-    webhook: 'syncs'
+    webhook: 'syncs',
+    function: 'functions'
 };
 
 class LocalFileService {

--- a/packages/shared/lib/services/flow.service.ts
+++ b/packages/shared/lib/services/flow.service.ts
@@ -105,6 +105,10 @@ class FlowService {
             return null;
         }
 
+        // Functions are not part of the public catalog (StandardNangoConfig only carries syncs/actions/on-events).
+        if (type === 'function') {
+            return null;
+        }
         const flow = flows[0][`${type}s`].find((flow) => flow.name === scriptName);
         return flow || null;
     }

--- a/packages/shared/lib/services/sync/config/deploy.service.ts
+++ b/packages/shared/lib/services/sync/config/deploy.service.ts
@@ -426,6 +426,7 @@ async function compileDeployInfo({
                 input: typeof flow.input === 'string' ? flow.input : null,
                 sync_type: flow.sync_type || null,
                 webhook_subscriptions: flow.webhookSubscriptions || [],
+                function_config: flow.function_config ?? null,
                 enabled: lastSyncWasEnabled,
                 model_schema: null,
                 models_json_schema,

--- a/packages/shared/lib/services/sync/sync.service.ts
+++ b/packages/shared/lib/services/sync/sync.service.ts
@@ -476,8 +476,9 @@ export const getAndReconcileDifferences = async ({
             continue;
         }
 
-        // Functions are persisted on deploy but are not scheduled as syncs, so they have nothing to
-        // reconcile here. Deletion of a removed function is still handled by the loop below.
+        // Function scheduling isn't wired up yet. Until it is, skip reconciliation so functions
+        // (persisted on deploy with runs: null) aren't treated as syncs and given sync jobs.
+        // Deletion of a removed function is still handled by the loop below.
         if (type === 'function') {
             continue;
         }

--- a/packages/shared/lib/services/sync/sync.service.ts
+++ b/packages/shared/lib/services/sync/sync.service.ts
@@ -476,6 +476,12 @@ export const getAndReconcileDifferences = async ({
             continue;
         }
 
+        // Functions are persisted on deploy but are not scheduled as syncs, so they have nothing to
+        // reconcile here. Deletion of a removed function is still handled by the loop below.
+        if (type === 'function') {
+            continue;
+        }
+
         if (!existingSyncsByProviderConfig[providerConfigKey]) {
             // this gets syncs that have a sync config and are active OR just have a sync config
             existingSyncsByProviderConfig[providerConfigKey] = await getSyncConfigsByProviderConfigKey(environmentId, providerConfigKey);

--- a/packages/types/lib/deploy/incomingFlow.ts
+++ b/packages/types/lib/deploy/incomingFlow.ts
@@ -1,4 +1,4 @@
-import type { NangoSyncEndpointOld, NangoSyncEndpointV2, ScriptTypeLiteral, SyncTypeLiteral } from '../nangoYaml/index.js';
+import type { FunctionConfig, NangoSyncEndpointOld, NangoSyncEndpointV2, ScriptTypeLiteral, SyncTypeLiteral } from '../nangoYaml/index.js';
 import type { OnEventType } from '../scripts/on-events/api.js';
 import type { Feature } from '../syncConfigs/db.js';
 import type { JSONSchema7 } from 'json-schema';
@@ -88,6 +88,8 @@ export interface CLIDeployFlowConfig {
     /** @deprecated **/
     sync_type?: SyncTypeLiteral | undefined;
     webhookSubscriptions?: string[] | undefined;
+    /** Set only for `type: 'function'` deploys: the function's triggers + ingress/debounce config. */
+    function_config?: FunctionConfig | undefined;
     // TODO: make non-optional when nango-yaml and `schema.ts` are fully removed
     models_json_schema?: JSONSchema7 | undefined;
     features?: Feature[] | undefined;

--- a/packages/types/lib/nangoYaml/index.ts
+++ b/packages/types/lib/nangoYaml/index.ts
@@ -174,7 +174,6 @@ export interface ParsedFunctionTrigger {
 
 export interface ParsedNangoFunction {
     name: string;
-    /** Source file basename. The bundled artifact is keyed by this, while `name` may be a custom logical name. */
     fileName: string;
     type: 'function';
     description: string;

--- a/packages/types/lib/nangoYaml/index.ts
+++ b/packages/types/lib/nangoYaml/index.ts
@@ -128,44 +128,54 @@ export interface ParsedNangoSync {
 export interface ParsedFunctionTrigger {
     kind: 'http' | 'schedule' | 'event';
     /** http trigger: URL path segment. schedule/event triggers: disambiguates multiple of the same kind. */
-    name?: string;
+    name?: string | undefined;
     /** schedule trigger. */
     schedule?: string | undefined;
     /** event trigger. */
-    event?: string;
+    event?: string | undefined;
     /**
      * http trigger: declarative ingress validation/challenge. Nango injects and runs the
      * implementation at ingress (no author code runs inline). Discriminated on `type`.
      */
-    ingress?: {
-        validation?: {
-            type: 'hmac';
-            algorithm: 'sha1' | 'sha256' | 'sha512';
-            header: string;
-            encoding: 'base64' | 'hex';
-            prefix?: string;
-            secret: { source: 'integrationConfig'; key: string };
-        };
-        challenge?: {
-            type: 'echo';
-            token: { in: 'query' | 'body' | 'header'; key: string };
-            verify?: { in: 'query' | 'body' | 'header'; key: string; secret: { source: 'integrationConfig'; key: string } };
-            respond?: { status?: number; contentType?: 'text/plain' | 'application/json' };
-        };
-    };
+    ingress?:
+        | {
+              validation?:
+                  | {
+                        type: 'hmac';
+                        algorithm: 'sha1' | 'sha256' | 'sha512';
+                        header: string;
+                        encoding: 'base64' | 'hex';
+                        prefix?: string | undefined;
+                        secret: { source: 'integrationConfig'; key: string };
+                    }
+                  | undefined;
+              challenge?:
+                  | {
+                        type: 'echo';
+                        token: { in: 'query' | 'body' | 'header'; key: string };
+                        verify?: { in: 'query' | 'body' | 'header'; key: string; secret: { source: 'integrationConfig'; key: string } } | undefined;
+                        respond?: { status?: number | undefined; contentType?: 'text/plain' | 'application/json' | undefined } | undefined;
+                    }
+                  | undefined;
+          }
+        | undefined;
     /** http trigger: ingress coalescing config (the window/key). */
-    debounce?: {
-        /** One source, or an array combined into a composite key. */
-        key?: { body: string } | { header: string } | ({ body: string } | { header: string })[];
-        windowMs: number;
-        maxWindowMs?: number;
-        maxEntities?: number;
-        payloadMode?: 'latest' | 'all';
-    };
+    debounce?:
+        | {
+              /** One source, or an array combined into a composite key. */
+              key?: { body: string } | { header: string } | ({ body: string } | { header: string })[] | undefined;
+              windowMs: number;
+              maxWindowMs?: number | undefined;
+              maxEntities?: number | undefined;
+              payloadMode?: 'latest' | 'all' | undefined;
+          }
+        | undefined;
 }
 
 export interface ParsedNangoFunction {
     name: string;
+    /** Source file basename. The bundled artifact is keyed by this, while `name` may be a custom logical name. */
+    fileName: string;
     type: 'function';
     description: string;
     trigger: ParsedFunctionTrigger;
@@ -180,11 +190,11 @@ export interface ParsedNangoFunction {
 
 /**
  * Function-specific configuration persisted alongside a deployed function (in `_nango_sync_configs.function_config`).
- * Captures what makes a function distinct from a sync/action: its triggers (and their ingress/debounce config).
+ * Captures what makes a function distinct from a sync/action: its trigger (and its ingress/debounce config).
  */
 export interface FunctionConfig {
     name?: string | undefined;
-    triggers: ParsedFunctionTrigger[];
+    trigger: ParsedFunctionTrigger;
 }
 
 export interface ParsedNangoAction {

--- a/packages/types/lib/nangoYaml/index.ts
+++ b/packages/types/lib/nangoYaml/index.ts
@@ -6,12 +6,7 @@ export type HTTP_METHOD = 'GET' | 'POST' | 'PATCH' | 'PUT' | 'DELETE';
 /** @deprecated **/
 export type SyncTypeLiteral = 'incremental' | 'full';
 export type ScriptFileType = 'actions' | 'syncs' | 'on-events' | 'functions' | 'webhooks' | 'post-connection-scripts'; // post-connection-scripts is deprecated
-export type ScriptTypeLiteral = 'action' | 'sync' | 'on-event';
-/**
- * The `function` primitive is authored via `createFunction()` / `createWebhook()`. It is tracked
- * separately from {@link ScriptTypeLiteral} (sync/action/on-event) while it is introduced additively.
- */
-export type FunctionScriptTypeLiteral = 'function';
+export type ScriptTypeLiteral = 'action' | 'sync' | 'on-event' | 'function';
 
 // --------------
 // YAML V1
@@ -135,9 +130,9 @@ export interface ParsedFunctionTrigger {
     /** http trigger: URL path segment. schedule/event triggers: disambiguates multiple of the same type. */
     name?: string;
     /** http trigger: 'integration' (default) or 'connection' for tokenized per-connection URLs. */
-    scope?: 'integration' | 'connection';
+    scope?: 'integration' | 'connection' | undefined;
     /** schedule trigger. */
-    schedule?: string;
+    schedule?: string | undefined;
     /** event trigger. */
     event?: string;
     /** Whether the trigger ships one or more `ingressHooks` (executed at ingress). */
@@ -165,6 +160,16 @@ export interface ParsedNangoFunction {
     version: string;
     json_schema?: JSONSchema7 | undefined;
     features?: Feature[] | undefined;
+}
+
+/**
+ * Function-specific configuration persisted alongside a deployed function (in `_nango_sync_configs.function_config`).
+ * Captures what makes a function distinct from a sync/action: its triggers (and their ingress/debounce config).
+ */
+export interface FunctionConfig {
+    name?: string | undefined;
+    triggers: ParsedFunctionTrigger[];
+    debounce?: ParsedNangoFunction['debounce'];
 }
 
 export interface ParsedNangoAction {

--- a/packages/types/lib/nangoYaml/index.ts
+++ b/packages/types/lib/nangoYaml/index.ts
@@ -6,12 +6,7 @@ export type HTTP_METHOD = 'GET' | 'POST' | 'PATCH' | 'PUT' | 'DELETE';
 /** @deprecated **/
 export type SyncTypeLiteral = 'incremental' | 'full';
 export type ScriptFileType = 'actions' | 'syncs' | 'on-events' | 'functions' | 'webhooks' | 'post-connection-scripts'; // post-connection-scripts is deprecated
-export type ScriptTypeLiteral = 'action' | 'sync' | 'on-event';
-/**
- * The `function` primitive is authored via `createFunction()` / `createWebhook()`. It is tracked
- * separately from {@link ScriptTypeLiteral} (sync/action/on-event) while it is introduced additively.
- */
-export type FunctionScriptTypeLiteral = 'function';
+export type ScriptTypeLiteral = 'action' | 'sync' | 'on-event' | 'function';
 
 // --------------
 // YAML V1
@@ -135,7 +130,7 @@ export interface ParsedFunctionTrigger {
     /** http trigger: URL path segment. schedule/event triggers: disambiguates multiple of the same kind. */
     name?: string;
     /** schedule trigger. */
-    schedule?: string;
+    schedule?: string | undefined;
     /** event trigger. */
     event?: string;
     /**
@@ -181,6 +176,15 @@ export interface ParsedNangoFunction {
     version: string;
     json_schema?: JSONSchema7 | undefined;
     features?: Feature[] | undefined;
+}
+
+/**
+ * Function-specific configuration persisted alongside a deployed function (in `_nango_sync_configs.function_config`).
+ * Captures what makes a function distinct from a sync/action: its triggers (and their ingress/debounce config).
+ */
+export interface FunctionConfig {
+    name?: string | undefined;
+    triggers: ParsedFunctionTrigger[];
 }
 
 export interface ParsedNangoAction {

--- a/packages/types/lib/syncConfigs/db.ts
+++ b/packages/types/lib/syncConfigs/db.ts
@@ -1,6 +1,6 @@
 import type { TimestampsAndDeleted } from '../db.js';
 import type { LegacySyncModelSchema, NangoConfigMetadata } from '../deploy/incomingFlow.js';
-import type { NangoModel, ScriptTypeLiteral, SyncTypeLiteral } from '../nangoYaml/index.js';
+import type { FunctionConfig, NangoModel, ScriptTypeLiteral, SyncTypeLiteral } from '../nangoYaml/index.js';
 import type { JSONSchema7 } from 'json-schema';
 
 export type Feature = 'checkpoints';
@@ -32,5 +32,7 @@ export interface DBSyncConfig extends TimestampsAndDeleted {
     models_json_schema: JSONSchema7 | null;
     sdk_version: string | null;
     features: Feature[];
+    /** Set only for `type: 'function'` rows; null for sync/action/on-event. */
+    function_config?: FunctionConfig | null;
 }
 export type DBSyncConfigInsert = Omit<DBSyncConfig, 'id'>;

--- a/packages/types/lib/syncConfigs/db.ts
+++ b/packages/types/lib/syncConfigs/db.ts
@@ -32,7 +32,6 @@ export interface DBSyncConfig extends TimestampsAndDeleted {
     models_json_schema: JSONSchema7 | null;
     sdk_version: string | null;
     features: Feature[];
-    /** Set only for `type: 'function'` rows; null for sync/action/on-event. */
     function_config?: FunctionConfig | null;
 }
 export type DBSyncConfigInsert = Omit<DBSyncConfig, 'id'>;


### PR DESCRIPTION
Slice 1 of 3 splitting the old functions runtime branch into reviewable PRs.

Persist and deploy functions, before anything runs them:
- migration adds `_nango_sync_configs.type` and a `function_config` column
- backend accepts and stores function deploys, with deploy validation for triggers
- CLI emits function deploy payloads

Stacked on `agus/NAN-5890/function-sdk-methods`. Next in the stack is NAN-5891 (execution).


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/NangoHQ/nango/pull/6537?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

