### PR TITLE
feat(functions): execution pipeline (NAN-5891) 5/n

### DIFF
--- a/packages/jobs/lib/execution/function.ts
+++ b/packages/jobs/lib/execution/function.ts
@@ -1,26 +1,29 @@
 import db from '@nangohq/database';
 import { logContextGetter } from '@nangohq/logs';
 import {
-    NangoError,
     accountService,
     configService,
     environmentService,
     getApiUrl,
     getEndUserByConnectionId,
     getFunctionConfigRaw,
+    NangoError,
     secretService
 } from '@nangohq/shared';
 import { Err, Ok, tagTraceUser } from '@nangohq/utils';
 
-import { startScript } from './operations/start.js';
+import { bigQueryClient } from '../clients.js';
 import { capping } from '../utils/capping.js';
 import { getRunnerFlags } from '../utils/flags.js';
+import { pubsub } from '../utils/pubsub.js';
+import { startScript } from './operations/start.js';
 import { setTaskFailed, setTaskSuccess } from './operations/state.js';
 
 import type { TaskFunction } from '@nangohq/nango-orchestrator';
 import type { Config } from '@nangohq/shared';
 import type {
     CheckpointRange,
+    ConnectionJobs,
     DBEnvironment,
     DBSyncConfig,
     DBTeam,
@@ -81,9 +84,9 @@ export async function startFunction(task: TaskFunction): Promise<Result<void>> {
         }
 
         const logCtx = logContextGetter.get({ id: String(task.activityLogId), accountId: team.id });
-        void logCtx.info(`Starting function '${task.functionName}' (trigger: ${task.trigger?.type ?? 'on-demand'})`, {
+        void logCtx.info(`Starting function '${task.functionName}' (trigger: ${task.trigger?.kind ?? 'on-demand'})`, {
             function: task.functionName,
-            trigger: task.trigger?.type ?? 'on-demand',
+            trigger: task.trigger?.kind ?? 'on-demand',
             connection: connection.connection_id,
             integration: connection.provider_config_key
         });
@@ -114,7 +117,7 @@ export async function startFunction(task: TaskFunction): Promise<Result<void>> {
             connectionId: connection.connection_id,
             environmentId: connection.environment_id,
             environmentName: environment.name,
-            providerConfigKey: connection.provider_config_key,
+            providerConfigKey: task.providerConfigKey,
             provider: providerConfig.provider,
             activityLogId: logCtx.id,
             secretKey: defaultSecret.value.secret,
@@ -149,7 +152,9 @@ export async function startFunction(task: TaskFunction): Promise<Result<void>> {
 export async function handleFunctionSuccess({
     taskId,
     nangoProps,
-    output
+    output,
+    telemetryBag,
+    functionRuntime
 }: {
     taskId: string;
     nangoProps: NangoProps;
@@ -166,12 +171,22 @@ export async function handleFunctionSuccess({
     }
     void logCtx.info(`The function '${nangoProps.syncConfig.sync_name}' was successfully run`);
     void logCtx.success();
+
+    recordFunctionExecution({
+        nangoProps,
+        success: true,
+        content: `The function "${nangoProps.syncConfig.sync_name}" has been completed successfully.`,
+        telemetryBag,
+        functionRuntime
+    });
 }
 
 export async function handleFunctionError({
     taskId,
     nangoProps,
-    error
+    error,
+    telemetryBag,
+    functionRuntime
 }: {
     taskId: string;
     nangoProps: NangoProps;
@@ -190,4 +205,75 @@ export async function handleFunctionError({
     if (task.value.attempt === task.value.attemptMax) {
         void logCtx.failed();
     }
+
+    recordFunctionExecution({ nangoProps, success: false, content: error.message, telemetryBag, functionRuntime });
+}
+
+/**
+ * Record a function run for billing/capping (usage.function_executions) and analytics (BigQuery),
+ * mirroring how actions are recorded so function runs are not undercounted.
+ */
+function recordFunctionExecution({
+    nangoProps,
+    success,
+    content,
+    telemetryBag,
+    functionRuntime
+}: {
+    nangoProps: NangoProps;
+    success: boolean;
+    content: string;
+    telemetryBag: TelemetryBag;
+    functionRuntime: FunctionRuntime;
+}): void {
+    const connection: ConnectionJobs = {
+        id: nangoProps.nangoConnectionId,
+        connection_id: nangoProps.connectionId,
+        environment_id: nangoProps.environmentId,
+        provider_config_key: nangoProps.providerConfigKey
+    };
+
+    void bigQueryClient.insert({
+        executionType: 'function',
+        connectionId: connection.connection_id,
+        internalConnectionId: connection.id,
+        accountId: nangoProps.team.id,
+        accountName: nangoProps.team.name,
+        scriptName: nangoProps.syncConfig.sync_name,
+        scriptType: nangoProps.syncConfig.type,
+        environmentId: nangoProps.environmentId,
+        environmentName: nangoProps.environmentName || 'unknown',
+        provider: nangoProps.provider,
+        providerConfigKey: nangoProps.providerConfigKey,
+        status: success ? 'success' : 'failed',
+        syncId: null as unknown as string,
+        syncVariant: null as unknown as string,
+        scriptVersion: nangoProps.syncConfig.version,
+        content,
+        runTimeInSeconds: (Date.now() - nangoProps.startedAt.getTime()) / 1000,
+        createdAt: Date.now(),
+        internalIntegrationId: nangoProps.syncConfig.nango_config_id,
+        endUser: nangoProps.endUser,
+        source: nangoProps.syncConfig.source
+    });
+
+    void pubsub.publisher.publish({
+        subject: 'usage',
+        type: 'usage.function_executions',
+        payload: {
+            value: 1,
+            properties: {
+                accountId: nangoProps.team.id,
+                environmentId: nangoProps.environmentId,
+                environmentName: nangoProps.environmentName,
+                integrationId: nangoProps.providerConfigKey,
+                connectionId: connection.connection_id,
+                type: 'function',
+                functionName: nangoProps.syncConfig.sync_name,
+                success,
+                telemetryBag,
+                runtime: functionRuntime
+            }
+        }
+    });
 }

--- a/packages/jobs/lib/execution/function.ts
+++ b/packages/jobs/lib/execution/function.ts
@@ -1,0 +1,193 @@
+import db from '@nangohq/database';
+import { logContextGetter } from '@nangohq/logs';
+import {
+    NangoError,
+    accountService,
+    configService,
+    environmentService,
+    getApiUrl,
+    getEndUserByConnectionId,
+    getFunctionConfigRaw,
+    secretService
+} from '@nangohq/shared';
+import { Err, Ok, tagTraceUser } from '@nangohq/utils';
+
+import { startScript } from './operations/start.js';
+import { capping } from '../utils/capping.js';
+import { getRunnerFlags } from '../utils/flags.js';
+import { setTaskFailed, setTaskSuccess } from './operations/state.js';
+
+import type { TaskFunction } from '@nangohq/nango-orchestrator';
+import type { Config } from '@nangohq/shared';
+import type {
+    CheckpointRange,
+    DBEnvironment,
+    DBSyncConfig,
+    DBTeam,
+    FunctionRuntime,
+    NangoProps,
+    RoutingContext,
+    SdkLogger,
+    TelemetryBag
+} from '@nangohq/types';
+import type { Result } from '@nangohq/utils';
+import type { JsonValue } from 'type-fest';
+
+/**
+ * Execute a function run.
+ *
+ * v1 supports connection-bound runs (connection-level webhook URLs, triggerFunction({ connectionId }),
+ * CLI --connection). Connection-less routing runs (no bound connection) need environment context
+ * independent of a connection and are a follow-up.
+ */
+export async function startFunction(task: TaskFunction): Promise<Result<void>> {
+    let team: DBTeam | undefined;
+    let environment: DBEnvironment | undefined;
+    let providerConfig: Config | null = null;
+    let syncConfig: DBSyncConfig | null = null;
+    let endUser: NangoProps['endUser'] | null = null;
+
+    try {
+        if (!task.connection) {
+            throw new Error(`Connection-less function runs are not supported yet: ${task.functionName} (${task.id})`);
+        }
+        const connection = task.connection;
+
+        const accountContext = await accountService.getAccountContext({ environmentId: connection.environment_id });
+        if (!accountContext) {
+            throw new Error(`Account and environment not found`);
+        }
+        team = accountContext.account;
+        environment = accountContext.environment;
+        const plan = accountContext.plan;
+        tagTraceUser({ ...accountContext });
+
+        providerConfig = await configService.getProviderConfig(task.providerConfigKey, connection.environment_id);
+        if (providerConfig === null) {
+            throw new Error(`Provider config not found for function: ${task.functionName}`);
+        }
+
+        syncConfig = await getFunctionConfigRaw({ environmentId: providerConfig.environment_id, config_id: providerConfig.id!, name: task.functionName });
+        if (!syncConfig) {
+            throw new Error(`Function not found: ${task.functionName} (${task.id})`);
+        }
+        if (!syncConfig.enabled) {
+            throw new Error(`Function is disabled: ${task.functionName} (${task.id})`);
+        }
+
+        const getEndUser = await getEndUserByConnectionId(db.knex, { connectionId: connection.id });
+        if (getEndUser.isOk()) {
+            endUser = { id: getEndUser.value.id, endUserId: getEndUser.value.endUserId, orgId: getEndUser.value.organization?.organizationId || null };
+        }
+
+        const logCtx = logContextGetter.get({ id: String(task.activityLogId), accountId: team.id });
+        void logCtx.info(`Starting function '${task.functionName}' (trigger: ${task.trigger?.type ?? 'on-demand'})`, {
+            function: task.functionName,
+            trigger: task.trigger?.type ?? 'on-demand',
+            connection: connection.connection_id,
+            integration: connection.provider_config_key
+        });
+
+        const cappingStatus = await capping.getStatus(plan, 'function_executions', 'function_compute_gbms');
+        if (cappingStatus.isCapped) {
+            const message = cappingStatus.message || 'Your plan limits have been reached. Please upgrade your plan.';
+            void logCtx.error(message, { cappingStatus });
+            throw new Error(message);
+        }
+        const cappingFunctionLogsStatus = await capping.getStatus(plan, 'function_logs');
+        let sdkLogger: SdkLogger;
+        if (cappingFunctionLogsStatus.isCapped) {
+            sdkLogger = { level: 'off' };
+        } else {
+            sdkLogger = await environmentService.getSdkLogger(environment.id);
+        }
+
+        const defaultSecret = await secretService.getDefaultSecretForEnv(db.readOnly, environment);
+        if (defaultSecret.isErr()) {
+            return Err(defaultSecret.error);
+        }
+
+        const nangoProps: NangoProps = {
+            scriptType: 'function',
+            host: getApiUrl(),
+            team: { id: team.id, name: team.name },
+            connectionId: connection.connection_id,
+            environmentId: connection.environment_id,
+            environmentName: environment.name,
+            providerConfigKey: connection.provider_config_key,
+            provider: providerConfig.provider,
+            activityLogId: logCtx.id,
+            secretKey: defaultSecret.value.secret,
+            nangoConnectionId: connection.id,
+            attributes: syncConfig.attributes,
+            syncConfig,
+            debug: false,
+            logger: sdkLogger,
+            runnerFlags: getRunnerFlags(plan),
+            endUser,
+            startedAt: new Date(),
+            heartbeatTimeoutSecs: task.heartbeatTimeoutSecs,
+            functionEvent: { ...(task.trigger ? { trigger: task.trigger } : {}), payload: task.input },
+            connectionBound: true
+        };
+
+        const routingContext: RoutingContext = { plan, features: syncConfig.features };
+
+        const res = await startScript({ taskId: task.id, nangoProps, routingContext, logCtx, input: task.input });
+        if (res.isErr()) {
+            throw res.error;
+        }
+
+        return Ok(undefined);
+    } catch (err) {
+        const error = new NangoError('function_script_failure', { error: err instanceof Error ? err.message : err });
+        await setTaskFailed({ taskId: task.id, error });
+        return Err(error);
+    }
+}
+
+export async function handleFunctionSuccess({
+    taskId,
+    nangoProps,
+    output
+}: {
+    taskId: string;
+    nangoProps: NangoProps;
+    output: JsonValue;
+    telemetryBag: TelemetryBag;
+    functionRuntime: FunctionRuntime;
+    checkpoints: CheckpointRange;
+}): Promise<void> {
+    const logCtx = logContextGetter.get({ id: String(nangoProps.activityLogId), accountId: nangoProps.team.id });
+    const task = await setTaskSuccess({ taskId, output });
+    if (task.isErr()) {
+        void logCtx.error(`Failed to mark function as succeeded`, { error: task.error });
+        return;
+    }
+    void logCtx.info(`The function '${nangoProps.syncConfig.sync_name}' was successfully run`);
+    void logCtx.success();
+}
+
+export async function handleFunctionError({
+    taskId,
+    nangoProps,
+    error
+}: {
+    taskId: string;
+    nangoProps: NangoProps;
+    error: NangoError;
+    telemetryBag: TelemetryBag;
+    functionRuntime: FunctionRuntime;
+    checkpoints: CheckpointRange;
+}): Promise<void> {
+    const logCtx = logContextGetter.get({ id: String(nangoProps.activityLogId), accountId: nangoProps.team.id });
+    const task = await setTaskFailed({ taskId, error });
+    if (task.isErr()) {
+        void logCtx.error(`Failed to mark function as failed`, { error: task.error });
+        return;
+    }
+    void logCtx.error(`Function '${nangoProps.syncConfig.sync_name}' failed`, { error });
+    if (task.value.attempt === task.value.attemptMax) {
+        void logCtx.failed();
+    }
+}

--- a/packages/jobs/lib/execution/operations/handler.ts
+++ b/packages/jobs/lib/execution/operations/handler.ts
@@ -1,5 +1,6 @@
 import { logger } from '../../logger.js';
 import { handleActionError, handleActionSuccess } from '../action.js';
+import { handleFunctionError, handleFunctionSuccess } from '../function.js';
 import { handleOnEventError, handleOnEventSuccess } from '../onEvent.js';
 import { handleSyncError, handleSyncSuccess } from '../sync.js';
 import { handleWebhookError, handleWebhookSuccess } from '../webhook.js';
@@ -39,6 +40,9 @@ async function handleSuccess({ taskId, nangoProps, output, telemetryBag, functio
             break;
         case 'on-event':
             await handleOnEventSuccess({ taskId, nangoProps, telemetryBag, functionRuntime });
+            break;
+        case 'function':
+            await handleFunctionSuccess({ taskId, nangoProps, output, telemetryBag, functionRuntime, checkpoints });
             break;
     }
 }
@@ -80,6 +84,9 @@ async function handleError({ taskId, nangoProps, error, telemetryBag, functionRu
             break;
         case 'on-event':
             await handleOnEventError({ taskId, nangoProps, error: formattedError, telemetryBag, functionRuntime });
+            break;
+        case 'function':
+            await handleFunctionError({ taskId, nangoProps, error: formattedError, telemetryBag, functionRuntime, checkpoints });
             break;
     }
 }

--- a/packages/jobs/lib/execution/sync.integration.test.ts
+++ b/packages/jobs/lib/execution/sync.integration.test.ts
@@ -9,7 +9,7 @@ import { Ok, stringifyError } from '@nangohq/utils';
 import { envs } from '../env.js';
 import { handleSyncSuccess, startSync } from './sync.js';
 
-import type { TaskAbort, TaskAction, TaskOnEvent, TaskSync, TaskSyncAbort, TaskWebhook } from '@nangohq/nango-orchestrator';
+import type { TaskAbort, TaskAction, TaskFunction, TaskOnEvent, TaskSync, TaskSyncAbort, TaskWebhook } from '@nangohq/nango-orchestrator';
 import type { ReturnedRecord, UnencryptedRecordData } from '@nangohq/records';
 import type { Sync, Job as SyncJob } from '@nangohq/shared';
 import type { ConnectionJobs, DBSyncConfig, SyncResult } from '@nangohq/types';
@@ -207,6 +207,7 @@ const runJob = async (
         isWebhook: (): this is TaskWebhook => false,
         isAction: (): this is TaskAction => false,
         isOnEvent: (): this is TaskOnEvent => false,
+        isFunction: (): this is TaskFunction => false,
         isSyncAbort: (): this is TaskSyncAbort => false,
         isAbort: (): this is TaskAbort => false
     };

--- a/packages/jobs/lib/execution/sync.integration.test.ts
+++ b/packages/jobs/lib/execution/sync.integration.test.ts
@@ -9,7 +9,7 @@ import { Ok, stringifyError } from '@nangohq/utils';
 import { handleSyncSuccess, startSync } from './sync.js';
 import { envs } from '../env.js';
 
-import type { TaskAbort, TaskAction, TaskOnEvent, TaskSync, TaskSyncAbort, TaskWebhook } from '@nangohq/nango-orchestrator';
+import type { TaskAbort, TaskAction, TaskFunction, TaskOnEvent, TaskSync, TaskSyncAbort, TaskWebhook } from '@nangohq/nango-orchestrator';
 import type { ReturnedRecord, UnencryptedRecordData } from '@nangohq/records';
 import type { Job as SyncJob, Sync } from '@nangohq/shared';
 import type { ConnectionJobs, DBSyncConfig, SyncResult } from '@nangohq/types';
@@ -207,6 +207,7 @@ const runJob = async (
         isWebhook: (): this is TaskWebhook => false,
         isAction: (): this is TaskAction => false,
         isOnEvent: (): this is TaskOnEvent => false,
+        isFunction: (): this is TaskFunction => false,
         isSyncAbort: (): this is TaskSyncAbort => false,
         isAbort: (): this is TaskAbort => false
     };

--- a/packages/jobs/lib/processor/handler.ts
+++ b/packages/jobs/lib/processor/handler.ts
@@ -3,6 +3,7 @@ import tracer from 'dd-trace';
 import { Err, Ok } from '@nangohq/utils';
 
 import { startAction } from '../execution/action.js';
+import { startFunction } from '../execution/function.js';
 import { startOnEvent } from '../execution/onEvent.js';
 import { abortTask } from '../execution/operations/abort.js';
 import { abortSync, startSync } from '../execution/sync.js';
@@ -48,6 +49,14 @@ export async function handler(task: OrchestratorTask): Promise<Result<void>> {
         const span = tracer.startSpan('jobs.handler.onEvent');
         return await tracer.scope().activate(span, async () => {
             const res = startOnEvent(task);
+            span.finish();
+            return res;
+        });
+    }
+    if (task.isFunction()) {
+        const span = tracer.startSpan('jobs.handler.function');
+        return await tracer.scope().activate(span, async () => {
+            const res = await startFunction(task);
             span.finish();
             return res;
         });

--- a/packages/jobs/lib/runtime/runtimes.rules.ts
+++ b/packages/jobs/lib/runtime/runtimes.rules.ts
@@ -4,11 +4,13 @@ import { envs } from '../env.js';
 
 import type { DBPlan, NangoProps, Result, RoutingContext } from '@nangohq/types';
 
-const runtimeSelectors = {
+const runtimeSelectors: Record<NangoProps['scriptType'], (plan: DBPlan) => 'runner' | 'lambda'> = {
     sync: (plan: DBPlan) => plan.sync_function_runtime,
     action: (plan: DBPlan) => plan.action_function_runtime,
     webhook: (plan: DBPlan) => plan.webhook_function_runtime,
-    'on-event': (plan: DBPlan) => plan.on_event_function_runtime
+    'on-event': (plan: DBPlan) => plan.on_event_function_runtime,
+    // Functions always run on the runner fleet for now (no lambda routing yet).
+    function: () => 'runner'
 };
 
 export async function getFleetId({

--- a/packages/jobs/lib/schemas/nango-props.ts
+++ b/packages/jobs/lib/schemas/nango-props.ts
@@ -8,7 +8,7 @@ export const nangoPropsSchema = z.looseObject({
     scriptType: z.enum(['action', 'webhook', 'sync', 'on-event', 'function']),
     functionEvent: z
         .looseObject({
-            trigger: z.object({ type: z.enum(['http', 'schedule', 'event']), name: z.string().optional() }).optional(),
+            trigger: z.object({ kind: z.enum(['http', 'schedule', 'event']), name: z.string().nullish() }).optional(),
             payload: z.any().optional(),
             headers: z.record(z.string(), z.string()).optional(),
             rawBody: z.string().optional(),

--- a/packages/jobs/lib/schemas/nango-props.ts
+++ b/packages/jobs/lib/schemas/nango-props.ts
@@ -5,7 +5,17 @@ import { operationIdRegex } from '@nangohq/logs';
 import type { Feature } from '@nangohq/types';
 
 export const nangoPropsSchema = z.looseObject({
-    scriptType: z.enum(['action', 'webhook', 'sync', 'on-event']),
+    scriptType: z.enum(['action', 'webhook', 'sync', 'on-event', 'function']),
+    functionEvent: z
+        .looseObject({
+            trigger: z.object({ type: z.enum(['http', 'schedule', 'event']), name: z.string().optional() }).optional(),
+            payload: z.any().optional(),
+            headers: z.record(z.string(), z.string()).optional(),
+            rawBody: z.string().optional(),
+            coalesced: z.object({ count: z.number(), firstSeenAt: z.string(), lastSeenAt: z.string(), overflowed: z.boolean() }).optional()
+        })
+        .optional(),
+    connectionBound: z.boolean().optional(),
     connectionId: z.string().min(1),
     nangoConnectionId: z.number(),
     environmentId: z.number(),
@@ -20,7 +30,7 @@ export const nangoPropsSchema = z.looseObject({
     syncConfig: z.looseObject({
         id: z.number(),
         sync_name: z.string().min(1),
-        type: z.enum(['sync', 'action', 'on-event']),
+        type: z.enum(['sync', 'action', 'on-event', 'function']),
         environment_id: z.number(),
         models: z.array(z.string()),
         file_location: z.string(),

--- a/packages/orchestrator/lib/clients/client.ts
+++ b/packages/orchestrator/lib/clients/client.ts
@@ -19,6 +19,7 @@ import type {
     ClientError,
     ExecuteActionProps,
     ExecuteAsyncReturn,
+    ExecuteFunctionProps,
     ExecuteOnEventProps,
     ExecuteProps,
     ExecuteReturn,
@@ -303,6 +304,31 @@ export class OrchestratorClient {
 
     public async executeWebhook(props: ExecuteWebhookProps): Promise<ExecuteReturn> {
         const res = await this.immediate(this.buildWebhookSchedulingProps(props));
+        if (res.isErr()) {
+            return Err(res.error);
+        }
+        return Ok({ taskId: res.value.taskId, retryKey: res.value.retryKey });
+    }
+
+    private buildFunctionSchedulingProps(props: ExecuteFunctionProps) {
+        const { args, ...rest } = props;
+        return {
+            ...rest,
+            retry: { count: 0, max: 0 },
+            timeoutSettingsInSecs: {
+                createdToStarted: 5 * 60,
+                startedToCompleted: 60 * 60,
+                heartbeat: 5 * 60
+            },
+            args: {
+                ...args,
+                type: 'function' as const
+            }
+        };
+    }
+
+    public async executeFunction(props: ExecuteFunctionProps): Promise<ExecuteReturn> {
+        const res = await this.immediate(this.buildFunctionSchedulingProps(props));
         if (res.isErr()) {
             return Err(res.error);
         }

--- a/packages/orchestrator/lib/clients/client.ts
+++ b/packages/orchestrator/lib/clients/client.ts
@@ -20,6 +20,7 @@ import type {
     ClientError,
     ExecuteActionProps,
     ExecuteAsyncReturn,
+    ExecuteFunctionProps,
     ExecuteOnEventProps,
     ExecuteProps,
     ExecuteReturn,
@@ -303,6 +304,31 @@ export class OrchestratorClient {
 
     public async executeWebhook(props: ExecuteWebhookProps): Promise<ExecuteReturn> {
         const res = await this.immediate(this.buildWebhookSchedulingProps(props));
+        if (res.isErr()) {
+            return Err(res.error);
+        }
+        return Ok({ taskId: res.value.taskId, retryKey: res.value.retryKey });
+    }
+
+    private buildFunctionSchedulingProps(props: ExecuteFunctionProps) {
+        const { args, ...rest } = props;
+        return {
+            ...rest,
+            retry: { count: 0, max: 0 },
+            timeoutSettingsInSecs: {
+                createdToStarted: 5 * 60,
+                startedToCompleted: 60 * 60,
+                heartbeat: 5 * 60
+            },
+            args: {
+                ...args,
+                type: 'function' as const
+            }
+        };
+    }
+
+    public async executeFunction(props: ExecuteFunctionProps): Promise<ExecuteReturn> {
+        const res = await this.immediate(this.buildFunctionSchedulingProps(props));
         if (res.isErr()) {
             return Err(res.error);
         }

--- a/packages/orchestrator/lib/clients/types.ts
+++ b/packages/orchestrator/lib/clients/types.ts
@@ -58,7 +58,7 @@ interface FunctionArgs {
     activityLogId: string;
     // JSON-safe (serialized into the task payload): null (not undefined) for on-demand runs
     // (triggerFunction/API/CLI/UI); only declared triggers carry a value. name is null when absent.
-    trigger: { type: 'http' | 'schedule' | 'event'; name: string | null } | null;
+    trigger: { kind: 'http' | 'schedule' | 'event'; name: string | null } | null;
     input: JsonValue;
 }
 export type SchedulesReturn = Result<OrchestratorSchedule[]>;
@@ -301,7 +301,8 @@ export function TaskFunction(props: TaskCommonFields & FunctionArgs): TaskFuncti
     };
 }
 
-export type ExecuteFunctionProps = Omit<ExecuteProps, 'args'> & { args: FunctionArgs };
+// Function runs use fixed scheduling (see buildFunctionSchedulingProps), so retry/timeout are not caller-configurable.
+export type ExecuteFunctionProps = Omit<ExecuteProps, 'args' | 'retry' | 'timeoutSettingsInSecs'> & { args: FunctionArgs };
 
 export interface ClientError extends Error {
     name: string;

--- a/packages/orchestrator/lib/clients/types.ts
+++ b/packages/orchestrator/lib/clients/types.ts
@@ -50,6 +50,17 @@ interface OnEventArgs {
     activityLogId: string;
     sdkVersion: string | null;
 }
+interface FunctionArgs {
+    functionName: string;
+    providerConfigKey: string;
+    /** null for connection-less runs (e.g. an integration-level webhook routing run). */
+    connection: ConnectionJobs | null;
+    activityLogId: string;
+    // JSON-safe (serialized into the task payload): null (not undefined) for on-demand runs
+    // (triggerFunction/API/CLI/UI); only declared triggers carry a value. name is null when absent.
+    trigger: { type: 'http' | 'schedule' | 'event'; name: string | null } | null;
+    input: JsonValue;
+}
 export type SchedulesReturn = Result<OrchestratorSchedule[]>;
 export type VoidReturn = Result<void, ClientError>;
 export type ExecuteProps = SetOptional<ImmediateProps, 'retry' | 'timeoutSettingsInSecs'>;
@@ -68,7 +79,7 @@ export interface OrchestratorSchedule {
     nextDueDate: Date | null;
 }
 
-export type OrchestratorTask = TaskSync | TaskSyncAbort | TaskAction | TaskWebhook | TaskOnEvent | TaskAbort;
+export type OrchestratorTask = TaskSync | TaskSyncAbort | TaskAction | TaskWebhook | TaskOnEvent | TaskFunction | TaskAbort;
 
 interface TaskCommonFields {
     id: string;
@@ -87,6 +98,7 @@ interface TaskCommon extends TaskCommonFields {
     isWebhook(this: OrchestratorTask): this is TaskWebhook;
     isAction(this: OrchestratorTask): this is TaskAction;
     isOnEvent(this: OrchestratorTask): this is TaskOnEvent;
+    isFunction(this: OrchestratorTask): this is TaskFunction;
     isSyncAbort(this: OrchestratorTask): this is TaskSyncAbort;
     isAbort(this: OrchestratorTask): this is TaskAbort;
 }
@@ -110,6 +122,7 @@ export function TaskAbort(props: TaskCommonFields & AbortArgs): TaskAbort {
         isWebhook: (): this is TaskWebhook => false,
         isAction: (): this is TaskAction => false,
         isOnEvent: (): this is TaskOnEvent => false,
+        isFunction: (): this is TaskFunction => false,
         isSyncAbort: (): this is TaskSyncAbort => false,
         isAbort: (): this is TaskAbort => true
     };
@@ -138,6 +151,7 @@ export function TaskSync(props: TaskCommonFields & SyncArgs & SyncExecutionArgs)
         isWebhook: (): this is TaskWebhook => false,
         isAction: (): this is TaskAction => false,
         isOnEvent: (): this is TaskOnEvent => false,
+        isFunction: (): this is TaskFunction => false,
         isSyncAbort: (): this is TaskSyncAbort => false,
         isAbort: (): this is TaskAbort => false
     };
@@ -167,6 +181,7 @@ export function TaskSyncAbort(props: TaskCommonFields & SyncArgs & AbortArgs): T
         isWebhook: (): this is TaskWebhook => false,
         isAction: (): this is TaskAction => false,
         isOnEvent: (): this is TaskOnEvent => false,
+        isFunction: (): this is TaskFunction => false,
         isSyncAbort: (): this is TaskSyncAbort => true,
         isAbort: (): this is TaskAbort => false
     };
@@ -194,6 +209,7 @@ export function TaskAction(props: TaskCommonFields & ActionArgs): TaskAction {
         isWebhook: (): this is TaskWebhook => false,
         isAction: (): this is TaskAction => true,
         isOnEvent: (): this is TaskOnEvent => false,
+        isFunction: (): this is TaskFunction => false,
         isSyncAbort: (): this is TaskSyncAbort => false,
         isAbort: (): this is TaskAbort => false
     };
@@ -221,6 +237,7 @@ export function TaskWebhook(props: TaskCommonFields & WebhookArgs): TaskWebhook 
         isWebhook: (): this is TaskWebhook => true,
         isAction: (): this is TaskAction => false,
         isOnEvent: (): this is TaskOnEvent => false,
+        isFunction: (): this is TaskFunction => false,
         isSyncAbort: (): this is TaskSyncAbort => false,
         isAbort: (): this is TaskAbort => false
     };
@@ -249,10 +266,42 @@ export function TaskOnEvent(props: TaskCommonFields & OnEventArgs): TaskOnEvent 
         isWebhook: (): this is TaskWebhook => false,
         isAction: (): this is TaskAction => false,
         isOnEvent: (): this is TaskOnEvent => true,
+        isFunction: (): this is TaskFunction => false,
         isSyncAbort: (): this is TaskSyncAbort => false,
         isAbort: (): this is TaskAbort => false
     };
 }
+
+export interface TaskFunction extends TaskCommon, FunctionArgs {}
+export function TaskFunction(props: TaskCommonFields & FunctionArgs): TaskFunction {
+    return {
+        id: props.id,
+        name: props.name,
+        state: props.state,
+        retryKey: props.retryKey,
+        attempt: props.attempt,
+        attemptMax: props.attemptMax,
+        functionName: props.functionName,
+        providerConfigKey: props.providerConfigKey,
+        connection: props.connection,
+        activityLogId: props.activityLogId,
+        trigger: props.trigger,
+        input: props.input,
+        groupKey: props.groupKey,
+        groupMaxConcurrency: props.groupMaxConcurrency,
+        ownerKey: props.ownerKey,
+        heartbeatTimeoutSecs: props.heartbeatTimeoutSecs,
+        isSync: (): this is TaskSync => false,
+        isWebhook: (): this is TaskWebhook => false,
+        isAction: (): this is TaskAction => false,
+        isOnEvent: (): this is TaskOnEvent => false,
+        isFunction: (): this is TaskFunction => true,
+        isSyncAbort: (): this is TaskSyncAbort => false,
+        isAbort: (): this is TaskAbort => false
+    };
+}
+
+export type ExecuteFunctionProps = Omit<ExecuteProps, 'args'> & { args: FunctionArgs };
 
 export interface ClientError extends Error {
     name: string;

--- a/packages/orchestrator/lib/clients/validate.ts
+++ b/packages/orchestrator/lib/clients/validate.ts
@@ -3,7 +3,7 @@ import * as z from 'zod';
 import { taskStates } from '@nangohq/scheduler';
 import { Err, Ok } from '@nangohq/utils';
 
-import { TaskAbort, TaskAction, TaskOnEvent, TaskSync, TaskSyncAbort, TaskWebhook } from './types.js';
+import { TaskAbort, TaskAction, TaskFunction, TaskOnEvent, TaskSync, TaskSyncAbort, TaskWebhook } from './types.js';
 import { jsonSchema } from '../utils/validation.js';
 
 import type { OrchestratorSchedule, OrchestratorTask } from './types.js';
@@ -73,6 +73,19 @@ export const onEventArgsSchema = z.object({
     activityLogId: z.string(),
     ...commonSchemaArgsFields
 });
+export const functionArgsSchema = z.object({
+    type: z.literal('function'),
+    functionName: z.string().min(1),
+    providerConfigKey: z.string().min(1),
+    // null for connection-less runs (e.g. an integration-level webhook routing run)
+    connection: commonSchemaArgsFields.connection.nullable(),
+    activityLogId: z.string(),
+    trigger: z
+        .object({ type: z.enum(['http', 'schedule', 'event']), name: z.string().nullable().default(null) })
+        .nullable()
+        .default(null),
+    input: jsonSchema
+});
 
 const commonSchemaFields = {
     id: z.string().uuid(),
@@ -109,6 +122,10 @@ const webhookSchema = z.object({
 const onEventSchema = z.object({
     ...commonSchemaFields,
     payload: onEventArgsSchema
+});
+const functionSchema = z.object({
+    ...commonSchemaFields,
+    payload: functionArgsSchema
 });
 
 export function validateTask(task: Task): Result<OrchestratorTask> {
@@ -223,6 +240,29 @@ export function validateTask(task: Task): Result<OrchestratorTask> {
                 sdkVersion: onEvent.data.payload.sdkVersion,
                 activityLogId: onEvent.data.payload.activityLogId,
                 heartbeatTimeoutSecs: onEvent.data.heartbeatTimeoutSecs
+            })
+        );
+    }
+    const fn = functionSchema.safeParse(task);
+    if (fn.success) {
+        return Ok(
+            TaskFunction({
+                id: fn.data.id,
+                state: fn.data.state,
+                name: fn.data.name,
+                attempt: fn.data.retryCount + 1,
+                attemptMax: fn.data.retryMax + 1,
+                functionName: fn.data.payload.functionName,
+                providerConfigKey: fn.data.payload.providerConfigKey,
+                connection: fn.data.payload.connection,
+                activityLogId: fn.data.payload.activityLogId,
+                trigger: fn.data.payload.trigger,
+                input: fn.data.payload.input,
+                groupKey: fn.data.groupKey,
+                groupMaxConcurrency: fn.data.groupMaxConcurrency,
+                ownerKey: fn.data.ownerKey,
+                retryKey: fn.data.retryKey,
+                heartbeatTimeoutSecs: fn.data.heartbeatTimeoutSecs
             })
         );
     }

--- a/packages/orchestrator/lib/clients/validate.ts
+++ b/packages/orchestrator/lib/clients/validate.ts
@@ -4,7 +4,7 @@ import { taskStates } from '@nangohq/scheduler';
 import { Err, Ok } from '@nangohq/utils';
 
 import { jsonSchema } from '../utils/validation.js';
-import { TaskAbort, TaskAction, TaskOnEvent, TaskSync, TaskSyncAbort, TaskWebhook } from './types.js';
+import { TaskAbort, TaskAction, TaskFunction, TaskOnEvent, TaskSync, TaskSyncAbort, TaskWebhook } from './types.js';
 
 import type { OrchestratorSchedule, OrchestratorTask } from './types.js';
 import type { Schedule, Task } from '@nangohq/scheduler';
@@ -73,6 +73,19 @@ export const onEventArgsSchema = z.object({
     activityLogId: z.string(),
     ...commonSchemaArgsFields
 });
+export const functionArgsSchema = z.object({
+    type: z.literal('function'),
+    functionName: z.string().min(1),
+    providerConfigKey: z.string().min(1),
+    // null for connection-less runs (e.g. an integration-level webhook routing run)
+    connection: commonSchemaArgsFields.connection.nullable(),
+    activityLogId: z.string(),
+    trigger: z
+        .object({ type: z.enum(['http', 'schedule', 'event']), name: z.string().nullable().default(null) })
+        .nullable()
+        .default(null),
+    input: jsonSchema
+});
 
 const commonSchemaFields = {
     id: z.string().uuid(),
@@ -109,6 +122,10 @@ const webhookSchema = z.object({
 const onEventSchema = z.object({
     ...commonSchemaFields,
     payload: onEventArgsSchema
+});
+const functionSchema = z.object({
+    ...commonSchemaFields,
+    payload: functionArgsSchema
 });
 
 export function validateTask(task: Task): Result<OrchestratorTask> {
@@ -223,6 +240,29 @@ export function validateTask(task: Task): Result<OrchestratorTask> {
                 sdkVersion: onEvent.data.payload.sdkVersion,
                 activityLogId: onEvent.data.payload.activityLogId,
                 heartbeatTimeoutSecs: onEvent.data.heartbeatTimeoutSecs
+            })
+        );
+    }
+    const fn = functionSchema.safeParse(task);
+    if (fn.success) {
+        return Ok(
+            TaskFunction({
+                id: fn.data.id,
+                state: fn.data.state,
+                name: fn.data.name,
+                attempt: fn.data.retryCount + 1,
+                attemptMax: fn.data.retryMax + 1,
+                functionName: fn.data.payload.functionName,
+                providerConfigKey: fn.data.payload.providerConfigKey,
+                connection: fn.data.payload.connection,
+                activityLogId: fn.data.payload.activityLogId,
+                trigger: fn.data.payload.trigger,
+                input: fn.data.payload.input,
+                groupKey: fn.data.groupKey,
+                groupMaxConcurrency: fn.data.groupMaxConcurrency,
+                ownerKey: fn.data.ownerKey,
+                retryKey: fn.data.retryKey,
+                heartbeatTimeoutSecs: fn.data.heartbeatTimeoutSecs
             })
         );
     }

--- a/packages/orchestrator/lib/clients/validate.ts
+++ b/packages/orchestrator/lib/clients/validate.ts
@@ -81,7 +81,7 @@ export const functionArgsSchema = z.object({
     connection: commonSchemaArgsFields.connection.nullable(),
     activityLogId: z.string(),
     trigger: z
-        .object({ type: z.enum(['http', 'schedule', 'event']), name: z.string().nullable().default(null) })
+        .object({ kind: z.enum(['http', 'schedule', 'event']), name: z.string().nullable().default(null) })
         .nullable()
         .default(null),
     input: jsonSchema

--- a/packages/orchestrator/lib/routes/v1/postImmediate.ts
+++ b/packages/orchestrator/lib/routes/v1/postImmediate.ts
@@ -3,7 +3,7 @@ import * as z from 'zod';
 import { isDuplicateTaskNameError } from '@nangohq/scheduler';
 import { validateRequest } from '@nangohq/utils';
 
-import { actionArgsSchema, onEventArgsSchema, syncAbortArgsSchema, syncArgsSchema, webhookArgsSchema } from '../../clients/validate.js';
+import { actionArgsSchema, functionArgsSchema, onEventArgsSchema, syncAbortArgsSchema, syncArgsSchema, webhookArgsSchema } from '../../clients/validate.js';
 
 import type { TaskType } from '../../types.js';
 import type { Scheduler } from '@nangohq/scheduler';
@@ -36,7 +36,7 @@ export const immediateTaskSchema = z
             startedToCompleted: z.number().int().positive(),
             heartbeat: z.number().int().positive()
         }),
-        args: z.discriminatedUnion('type', [syncArgsSchema, actionArgsSchema, webhookArgsSchema, onEventArgsSchema, syncAbortArgsSchema])
+        args: z.discriminatedUnion('type', [syncArgsSchema, actionArgsSchema, webhookArgsSchema, onEventArgsSchema, functionArgsSchema, syncAbortArgsSchema])
     })
     .strict();
 

--- a/packages/orchestrator/lib/types.ts
+++ b/packages/orchestrator/lib/types.ts
@@ -1,2 +1,2 @@
-export const taskTypes = ['action', 'webhook', 'sync', 'on-event', 'abort'] as const;
+export const taskTypes = ['action', 'webhook', 'sync', 'on-event', 'function', 'abort'] as const;
 export type TaskType = (typeof taskTypes)[number];

--- a/packages/runner-sdk/lib/index.ts
+++ b/packages/runner-sdk/lib/index.ts
@@ -2,6 +2,7 @@ export type { ZodCheckpoint } from './types.js';
 export * from './action.js';
 export * from './dataValidation.js';
 export * from './errors.js';
+export * from './function.js';
 export * from './sync.js';
 export * from './scripts.js';
 export * from './checkpoint.js';

--- a/packages/runner-sdk/lib/index.ts
+++ b/packages/runner-sdk/lib/index.ts
@@ -4,6 +4,7 @@ export type { ZodCheckpoint } from './types.js';
 export * from './action.js';
 export * from './dataValidation.js';
 export * from './errors.js';
+export * from './function.js';
 export * from './sync.js';
 export * from './scripts.js';
 export * from './checkpoint.js';

--- a/packages/runner/lib/exec.ts
+++ b/packages/runner/lib/exec.ts
@@ -20,7 +20,7 @@ import { instrumentSDK, NangoActionRunner, NangoFunctionRunner, NangoSyncRunner 
 import { createTelemetryRecorder } from './telemetry.js';
 
 import type { Locks } from './sdk/locks.js';
-import type { CreateAnyResponse, FunctionEvent } from '@nangohq/runner-sdk';
+import type { CreateAnyResponse } from '@nangohq/runner-sdk';
 import type { NangoProps, Result, RunnerOutput } from '@nangohq/types';
 
 interface ScriptExports {
@@ -266,11 +266,14 @@ export async function exec({
                         : {})
                 };
 
-                const triggerType = fe?.trigger?.type ?? 'http';
-                const event: FunctionEvent =
-                    triggerType === 'http'
+                const triggerKind = fe?.trigger?.kind ?? 'http';
+                // The runtime event is keyed on `kind` to match the customer-facing Trigger type.
+                // Its full shape (Trigger with request: HttpRequest) is still converging on the
+                // single-trigger spec (NAN-6019/6601), so it is passed untyped to exec for now.
+                const event =
+                    triggerKind === 'http'
                         ? {
-                              type: 'http',
+                              kind: 'http',
                               ...base,
                               headers: fe?.headers ?? {},
                               rawBody: fe?.rawBody ?? '',
@@ -285,11 +288,11 @@ export async function exec({
                                     }
                                   : {})
                           }
-                        : triggerType === 'schedule'
-                          ? { type: 'schedule', ...base }
-                          : { type: 'event', ...base };
+                        : triggerKind === 'schedule'
+                          ? { kind: 'schedule', ...base }
+                          : { kind: 'event', ...base };
 
-                const output = await payload.exec(nango as any, event);
+                const output = await payload.exec(nango as any, event as any);
                 return Ok({ output: output ?? true, telemetryBag: nango.telemetryBag, checkpoints: nango.getCheckpointRange() });
             }
 

--- a/packages/runner/lib/exec.ts
+++ b/packages/runner/lib/exec.ts
@@ -16,11 +16,11 @@ import { Err, errorToObject, isEnterprise, Ok, truncateJson } from '@nangohq/uti
 import { PersistClient } from './clients/persist.js';
 import { logger } from './logger.js';
 import { MapLocks } from './sdk/locks.js';
-import { instrumentSDK, NangoActionRunner, NangoSyncRunner } from './sdk/sdk.js';
+import { instrumentSDK, NangoActionRunner, NangoFunctionRunner, NangoSyncRunner } from './sdk/sdk.js';
 import { createTelemetryRecorder } from './telemetry.js';
 
 import type { Locks } from './sdk/locks.js';
-import type { CreateAnyResponse } from '@nangohq/runner-sdk';
+import type { CreateAnyResponse, FunctionEvent } from '@nangohq/runner-sdk';
 import type { NangoProps, Result, RunnerOutput } from '@nangohq/types';
 
 interface ScriptExports {
@@ -63,6 +63,8 @@ export async function exec({
             case 'sync':
             case 'webhook':
                 return new NangoSyncRunner(nangoProps, { persistClient, telemetryRecorder, locks });
+            case 'function':
+                return new NangoFunctionRunner(nangoProps, { persistClient, telemetryRecorder, locks });
             case 'action':
             case 'on-event':
                 return new NangoActionRunner(nangoProps, { persistClient, telemetryRecorder, locks });
@@ -233,6 +235,62 @@ export async function exec({
                     output = await def(nango);
                 }
                 return Ok({ output, telemetryBag: nango.telemetryBag });
+            }
+
+            // Function
+            if (nangoProps.scriptType === 'function') {
+                if (!isZeroYaml) {
+                    throw new Error('Functions require the zero-yaml SDK');
+                }
+                const payload = def;
+                if (payload.type !== 'function') {
+                    throw new Error('Incorrect script loaded for function');
+                }
+                if (!payload.exec) {
+                    throw new Error(`Missing exec function`);
+                }
+
+                const fe = nangoProps.functionEvent;
+                const triggerName = fe?.trigger?.name ?? undefined;
+                const base = {
+                    payload: fe?.payload,
+                    ...(triggerName != null ? { name: triggerName } : {}),
+                    // Connection context: present only for connection-bound runs. getConnection() throws otherwise.
+                    ...(nangoProps.connectionBound
+                        ? {
+                              connection: {
+                                  connection_id: nangoProps.connectionId,
+                                  provider_config_key: nangoProps.providerConfigKey
+                              }
+                          }
+                        : {})
+                };
+
+                const triggerType = fe?.trigger?.type ?? 'http';
+                const event: FunctionEvent =
+                    triggerType === 'http'
+                        ? {
+                              type: 'http',
+                              ...base,
+                              headers: fe?.headers ?? {},
+                              rawBody: fe?.rawBody ?? '',
+                              ...(fe?.coalesced
+                                  ? {
+                                        coalesced: {
+                                            count: fe.coalesced.count,
+                                            firstSeenAt: new Date(fe.coalesced.firstSeenAt),
+                                            lastSeenAt: new Date(fe.coalesced.lastSeenAt),
+                                            overflowed: fe.coalesced.overflowed
+                                        }
+                                    }
+                                  : {})
+                          }
+                        : triggerType === 'schedule'
+                          ? { type: 'schedule', ...base }
+                          : { type: 'event', ...base };
+
+                const output = await payload.exec(nango as any, event);
+                return Ok({ output: output ?? true, telemetryBag: nango.telemetryBag, checkpoints: nango.getCheckpointRange() });
             }
 
             // Sync

--- a/packages/runner/lib/exec.ts
+++ b/packages/runner/lib/exec.ts
@@ -16,11 +16,11 @@ import { Err, Ok, errorToObject, isEnterprise, truncateJson } from '@nangohq/uti
 import { PersistClient } from './clients/persist.js';
 import { logger } from './logger.js';
 import { MapLocks } from './sdk/locks.js';
-import { NangoActionRunner, NangoSyncRunner, instrumentSDK } from './sdk/sdk.js';
+import { NangoActionRunner, NangoFunctionRunner, NangoSyncRunner, instrumentSDK } from './sdk/sdk.js';
 import { createTelemetryRecorder } from './telemetry.js';
 
 import type { Locks } from './sdk/locks.js';
-import type { CreateAnyResponse } from '@nangohq/runner-sdk';
+import type { CreateAnyResponse, FunctionEvent } from '@nangohq/runner-sdk';
 import type { NangoProps, Result, RunnerOutput } from '@nangohq/types';
 
 interface ScriptExports {
@@ -63,6 +63,8 @@ export async function exec({
             case 'sync':
             case 'webhook':
                 return new NangoSyncRunner(nangoProps, { persistClient, telemetryRecorder, locks });
+            case 'function':
+                return new NangoFunctionRunner(nangoProps, { persistClient, telemetryRecorder, locks });
             case 'action':
             case 'on-event':
                 return new NangoActionRunner(nangoProps, { persistClient, telemetryRecorder, locks });
@@ -233,6 +235,62 @@ export async function exec({
                     output = await def(nango);
                 }
                 return Ok({ output, telemetryBag: nango.telemetryBag });
+            }
+
+            // Function
+            if (nangoProps.scriptType === 'function') {
+                if (!isZeroYaml) {
+                    throw new Error('Functions require the zero-yaml SDK');
+                }
+                const payload = def;
+                if (payload.type !== 'function') {
+                    throw new Error('Incorrect script loaded for function');
+                }
+                if (!payload.exec) {
+                    throw new Error(`Missing exec function`);
+                }
+
+                const fe = nangoProps.functionEvent;
+                const triggerName = fe?.trigger?.name ?? undefined;
+                const base = {
+                    payload: fe?.payload,
+                    ...(triggerName != null ? { name: triggerName } : {}),
+                    // Connection context: present only for connection-bound runs. getConnection() throws otherwise.
+                    ...(nangoProps.connectionBound
+                        ? {
+                              connection: {
+                                  connection_id: nangoProps.connectionId,
+                                  provider_config_key: nangoProps.providerConfigKey
+                              }
+                          }
+                        : {})
+                };
+
+                const triggerType = fe?.trigger?.type ?? 'http';
+                const event: FunctionEvent =
+                    triggerType === 'http'
+                        ? {
+                              type: 'http',
+                              ...base,
+                              headers: fe?.headers ?? {},
+                              rawBody: fe?.rawBody ?? '',
+                              ...(fe?.coalesced
+                                  ? {
+                                        coalesced: {
+                                            count: fe.coalesced.count,
+                                            firstSeenAt: new Date(fe.coalesced.firstSeenAt),
+                                            lastSeenAt: new Date(fe.coalesced.lastSeenAt),
+                                            overflowed: fe.coalesced.overflowed
+                                        }
+                                    }
+                                  : {})
+                          }
+                        : triggerType === 'schedule'
+                          ? { type: 'schedule', ...base }
+                          : { type: 'event', ...base };
+
+                const output = await payload.exec(nango as any, event);
+                return Ok({ output: output ?? true, telemetryBag: nango.telemetryBag, checkpoints: nango.getCheckpointRange() });
             }
 
             // Sync

--- a/packages/runner/lib/sdk/sdk.ts
+++ b/packages/runner/lib/sdk/sdk.ts
@@ -1,5 +1,5 @@
 import { Nango } from '@nangohq/node';
-import { executeUncontrolledFetch, NangoActionBase, NangoSyncBase } from '@nangohq/runner-sdk';
+import { executeUncontrolledFetch, NangoActionBase, NangoFunctionBase, NangoSyncBase } from '@nangohq/runner-sdk';
 import { enforceProxyOutboundUrlPolicy, getProxyConfiguration, ProxyError, ProxyRequest } from '@nangohq/shared';
 import {
     DEFAULT_NANGO_PROXY_BASE_URL_OVERRIDE_DENYLIST,
@@ -908,6 +908,17 @@ export class NangoSyncRunner extends NangoSyncBase<never, never, ZodCheckpoint> 
     public getCheckpointRange(): CheckpointRange | null {
         return this.checkpointing.getRange(this.checkpointKey);
     }
+}
+
+/**
+ * Function SDK
+ *
+ * Reuses the sync runner's concrete capabilities (records, proxy, triggers) and adds the
+ * function-only methods. Same prototype-borrow approach the sync runner uses for action methods.
+ */
+export class NangoFunctionRunner extends NangoSyncRunner {
+    searchConnections = NangoFunctionBase['prototype']['searchConnections'];
+    ignore = NangoFunctionBase['prototype']['ignore'];
 }
 
 class Locking {

--- a/packages/runner/lib/sdk/sdk.ts
+++ b/packages/runner/lib/sdk/sdk.ts
@@ -858,9 +858,7 @@ export class NangoSyncRunner extends NangoSyncBase<never, never, ZodCheckpoint> 
         let cursor: string | null | undefined = options?.cursor;
         do {
             this.throwIfAbortedOrKilled();
-            const pageOptions: { cursor?: string } = {
-                ...(cursor ? { cursor } : {})
-            };
+            const pageOptions: { cursor?: string } = cursor ? { cursor } : {};
             const { records, next_cursor } = await this.fetchRecordsPage<T>(model, pageOptions);
 
             for (const record of records) {
@@ -918,7 +916,6 @@ export class NangoSyncRunner extends NangoSyncBase<never, never, ZodCheckpoint> 
  */
 export class NangoFunctionRunner extends NangoSyncRunner {
     searchConnections = NangoFunctionBase['prototype']['searchConnections'];
-    ignore = NangoFunctionBase['prototype']['ignore'];
 }
 
 class Locking {

--- a/packages/runner/lib/sdk/sdk.ts
+++ b/packages/runner/lib/sdk/sdk.ts
@@ -1,5 +1,5 @@
 import { Nango } from '@nangohq/node';
-import { NangoActionBase, NangoSyncBase, executeUncontrolledFetch } from '@nangohq/runner-sdk';
+import { NangoActionBase, NangoFunctionBase, NangoSyncBase, executeUncontrolledFetch } from '@nangohq/runner-sdk';
 import { ProxyError, ProxyRequest, enforceProxyOutboundUrlPolicy, getProxyConfiguration } from '@nangohq/shared';
 import {
     DEFAULT_NANGO_PROXY_BASE_URL_OVERRIDE_DENYLIST,
@@ -901,6 +901,17 @@ export class NangoSyncRunner extends NangoSyncBase<never, never, ZodCheckpoint> 
     public getCheckpointRange(): CheckpointRange | null {
         return this.checkpointing.getRange(this.checkpointKey);
     }
+}
+
+/**
+ * Function SDK
+ *
+ * Reuses the sync runner's concrete capabilities (records, proxy, triggers) and adds the
+ * function-only methods. Same prototype-borrow approach the sync runner uses for action methods.
+ */
+export class NangoFunctionRunner extends NangoSyncRunner {
+    searchConnections = NangoFunctionBase['prototype']['searchConnections'];
+    ignore = NangoFunctionBase['prototype']['ignore'];
 }
 
 class Locking {

--- a/packages/shared/lib/services/sync/config/config.service.ts
+++ b/packages/shared/lib/services/sync/config/config.service.ts
@@ -778,6 +778,23 @@ export async function getSyncConfigRaw(opts: { environmentId: number; config_id:
     return res || null;
 }
 
+export async function getFunctionConfigRaw(opts: { environmentId: number; config_id: number; name: string }): Promise<DBSyncConfig | null> {
+    const res = await db.readOnly
+        .select<DBSyncConfig>('*')
+        .where({
+            environment_id: opts.environmentId,
+            sync_name: opts.name,
+            nango_config_id: opts.config_id,
+            active: true,
+            type: 'function',
+            deleted: false
+        })
+        .from<DBSyncConfig>(TABLE)
+        .first();
+
+    return res || null;
+}
+
 export async function getSoftDeletedSyncConfig({ limit, olderThan }: { limit: number; olderThan: number }): Promise<DBSyncConfig[]> {
     const dateThreshold = new Date();
     dateThreshold.setDate(dateThreshold.getDate() - olderThan);

--- a/packages/types/lib/pubsub/events.ts
+++ b/packages/types/lib/pubsub/events.ts
@@ -115,7 +115,7 @@ export type UsageFunctionExecutionsEvent = UsageEventBase<
     {
         value: number;
         properties: {
-            type: 'sync' | 'action' | 'webhook' | 'on-event';
+            type: 'sync' | 'action' | 'webhook' | 'on-event' | 'function';
             success: boolean;
             functionName: string;
             runtime: FunctionRuntime | undefined;

--- a/packages/types/lib/runner/sdk.ts
+++ b/packages/types/lib/runner/sdk.ts
@@ -18,7 +18,7 @@ export type ScriptType = 'sync' | 'action' | 'webhook' | 'on-event' | 'function'
  * as its second argument. Absent for non-function script types.
  */
 export interface NangoFunctionEventProps {
-    trigger?: { type: 'http' | 'schedule' | 'event'; name?: string | null | undefined } | undefined;
+    trigger?: { kind: 'http' | 'schedule' | 'event'; name?: string | null | undefined } | undefined;
     payload?: unknown;
     headers?: Record<string, string> | undefined;
     rawBody?: string | undefined;

--- a/packages/types/lib/runner/sdk.ts
+++ b/packages/types/lib/runner/sdk.ts
@@ -11,7 +11,19 @@ export interface SdkLogger {
 
 export type ConflictResolutionMode = 'IN_MEMORY' | 'REDIS';
 
-export type ScriptType = 'sync' | 'action' | 'webhook' | 'on-event';
+export type ScriptType = 'sync' | 'action' | 'webhook' | 'on-event' | 'function';
+
+/**
+ * The event a function run is started with. The runner exposes this to the customer's `exec`
+ * as its second argument. Absent for non-function script types.
+ */
+export interface NangoFunctionEventProps {
+    trigger?: { type: 'http' | 'schedule' | 'event'; name?: string | null | undefined } | undefined;
+    payload?: unknown;
+    headers?: Record<string, string> | undefined;
+    rawBody?: string | undefined;
+    coalesced?: { count: number; firstSeenAt: string; lastSeenAt: string; overflowed: boolean } | undefined;
+}
 
 export interface NangoProps {
     scriptType: ScriptType;
@@ -51,6 +63,10 @@ export interface NangoProps {
         | undefined;
     isCLI?: boolean | undefined;
     integrationConfig?: IntegrationConfigForProxy;
+    /** Set for `scriptType: 'function'` runs; carries the trigger + payload the run was started with. */
+    functionEvent?: NangoFunctionEventProps | undefined;
+    /** True when the run was started with a bound connection (connection-level URL, triggerFunction({connectionId}), CLI --connection). */
+    connectionBound?: boolean | undefined;
 
     axios?: {
         request?: AxiosInterceptorManager<AxiosRequestConfig>;

--- a/packages/utils/lib/checkpoint/checkpoint.ts
+++ b/packages/utils/lib/checkpoint/checkpoint.ts
@@ -1,3 +1,3 @@
-export function getCheckpointKey(opts: { type: 'sync' | 'webhook' | 'action' | 'on-event'; name: string; variant?: string | undefined }) {
+export function getCheckpointKey(opts: { type: 'sync' | 'webhook' | 'action' | 'on-event' | 'function'; name: string; variant?: string | undefined }) {
     return `${opts.type}:${opts.name}${opts.variant ? `:${opts.variant}` : ''}`;
 }


### PR DESCRIPTION
Run a stored function end to end through orchestrator, jobs and runner.

What this wires:
- orchestrator: TaskFunction task type and immediate enqueue path (executeFunction)
- jobs: dispatch schema accepts function props, execution module runs function tasks
- runner: executes a function and hands exec its trigger (keyed on `kind`, matching the createFunction SDK)
- usage: function runs recorded for billing, capping and analytics like actions

Aligned with the single-trigger model (NAN-6019): the trigger discriminator is `kind` (http, schedule, event) across the whole execution path.

Deferred to later slices:
- connection-less routing runs (integration-level webhooks), currently connection-bound only
- scheduled and recurring trigger dispatch
- the full runtime Trigger surface (request: HttpRequest and friends) per the spec (NAN-6019 / NAN-6601)

Stacked on NAN-6003 (deploy and persistence). Next in the stack is NAN-6004 (triggering). Replaces #6449.

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/NangoHQ/nango/pull/6538?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->
