### PR TITLE
Surface which services need deploying and what's live per environment

### DIFF
--- a/.github/workflows/deploy.yaml
+++ b/.github/workflows/deploy.yaml
@@ -76,6 +76,8 @@ jobs:
             - name: Install dependencies
               run: npm ci
             - name: Build Webapp
+              env:
+                  GIT_HASH: ${{ github.sha }} # baked into dist/version.json so the deployed bundle reports its own commit
               run: npm run ts-build && npm run -w @nangohq/webapp build
             - name: Inject API origin into dist/index.html
               run: |
@@ -133,6 +135,8 @@ jobs:
             - name: Install dependencies
               run: npm ci
             - name: Build Connect UI
+              env:
+                  GIT_HASH: ${{ github.sha }} # baked into dist/version.json so the deployed bundle reports its own commit
               run: npm run ts-build && npm run -w @nangohq/connect-ui build
             - name: configure aws credentials
               if: inputs.stage != 'replit'

--- a/.github/workflows/notify-deploy-needed.yaml
+++ b/.github/workflows/notify-deploy-needed.yaml
@@ -1,0 +1,60 @@
+name: 'Notify deploy needed'
+run-name: 'Notify deploy needed for ${{ github.sha }}'
+
+# When a change lands on master, tell #deploys which services it affects so they don't get
+# forgotten. This only reports what the merge touched — it does not look at what's currently
+# live on any environment.
+on:
+    push:
+        branches:
+            - master
+
+# Least privilege: only checkout needs the token.
+permissions:
+    contents: read
+
+# Coalesce bursts of merges; we only care about announcing the latest landed change.
+concurrency:
+    group: notify-deploy-needed
+    cancel-in-progress: false
+
+jobs:
+    notify:
+        runs-on: ubuntu-latest
+        steps:
+            - name: Checkout
+              uses: actions/checkout@v4
+              with:
+                  # Need both `before` and `after` commits to diff the merged change, and the
+                  # package.json graph at HEAD to map changed files to services.
+                  fetch-depth: 0
+            - name: Setup Node.js
+              uses: ./.github/actions/setup-node
+            - name: Compute affected services
+              id: affected
+              env:
+                  BASE_SHA: ${{ github.event.before }}
+                  HEAD_SHA: ${{ github.sha }}
+                  DEPLOY_REPO: ${{ github.repository }}
+              run: |
+                  message="$(npx --yes tsx@4.20.3 scripts/deploy-status/affected.ts --format slack)"
+                  # Forward the multi-line Slack message to later steps; empty means nothing to announce.
+                  {
+                      echo "message<<__DEPLOY_MSG__"
+                      echo "$message"
+                      echo "__DEPLOY_MSG__"
+                  } >> "$GITHUB_OUTPUT"
+            - name: 'Post to #deploys'
+              if: steps.affected.outputs.message != ''
+              uses: slackapi/slack-github-action@v2.0.0
+              with:
+                  method: chat.postMessage
+                  token: ${{ secrets.SLACK_BOT_TOKEN }}
+                  errors: true
+                  payload: |
+                      channel: "${{ vars.SLACK_DEPLOYS_CHANNEL_ID }}"
+                      unfurl_links: false
+                      attachments:
+                        - color: "#ECB22E"
+                          mrkdwn_in: ["text"]
+                          text: ${{ toJSON(steps.affected.outputs.message) }}

--- a/package.json
+++ b/package.json
@@ -57,7 +57,9 @@
         "nango": "cd ./packages/server && npm run nango",
         "dev:docker": "docker compose --file dev/docker-compose.dev.yaml up -d",
         "changelog:providers": "tsx scripts/provider-changelog.ts",
-        "changelog:integrations": "tsx scripts/pre-built-integrations-changelog.ts"
+        "changelog:integrations": "tsx scripts/pre-built-integrations-changelog.ts",
+        "deploy:status": "tsx scripts/deploy-status/cli.ts",
+        "deploy:affected": "tsx scripts/deploy-status/affected.ts"
     },
     "devDependencies": {
         "@eslint/js": "9.28.0",

--- a/packages/connect-ui/vite.config.ts
+++ b/packages/connect-ui/vite.config.ts
@@ -1,3 +1,4 @@
+import { execSync } from 'node:child_process';
 import path from 'node:path';
 
 import tailwindcss from '@tailwindcss/vite';
@@ -5,11 +6,32 @@ import react from '@vitejs/plugin-react-swc';
 import { defineConfig } from 'vite';
 import svgr from 'vite-plugin-svgr';
 
-import type { UserConfig } from 'vite';
+import type { Plugin, UserConfig } from 'vite';
+
+// Emit a static version.json at the dist root carrying the real git SHA this bundle was built
+// from, so an outside observer can read the deployed commit at <origin>/version.json. The SHA
+// comes from CI ($GITHUB_SHA), an explicit $GIT_HASH, or local git as a fallback.
+function emitVersionJson(): Plugin {
+    return {
+        name: 'emit-version-json',
+        apply: 'build',
+        generateBundle() {
+            let sha = process.env['GITHUB_SHA'] ?? process.env['GIT_HASH'];
+            if (!sha) {
+                try {
+                    sha = execSync('git rev-parse HEAD', { encoding: 'utf8' }).trim();
+                } catch {
+                    sha = '';
+                }
+            }
+            this.emitFile({ type: 'asset', fileName: 'version.json', source: JSON.stringify({ sha }) });
+        }
+    };
+}
 
 // https://vitejs.dev/config/
 export default defineConfig({
-    plugins: [react(), svgr(), tailwindcss()] as UserConfig['plugins'],
+    plugins: [react(), svgr(), tailwindcss(), emitVersionJson()] as UserConfig['plugins'],
     resolve: {
         alias: {
             '@': path.resolve(__dirname, './src'),

--- a/packages/webapp/vite.config.ts
+++ b/packages/webapp/vite.config.ts
@@ -1,3 +1,4 @@
+import { execSync } from 'node:child_process';
 import { createHash } from 'node:crypto';
 import path from 'node:path';
 
@@ -35,6 +36,27 @@ function apiEnvProxyPlugin(apiUrl: string): Plugin {
                 res.setHeader('Content-Type', 'text/javascript');
                 res.end(body.replace(/"apiUrl": "[^"]*"/, `"apiUrl": "${origin}"`));
             });
+        }
+    };
+}
+
+// Emit a static version.json at the dist root carrying the real git SHA this bundle was built
+// from, so an outside observer can read the deployed commit at <origin>/version.json. The SHA
+// comes from CI ($GITHUB_SHA), an explicit $GIT_HASH, or local git as a fallback.
+function emitVersionJson(): Plugin {
+    return {
+        name: 'emit-version-json',
+        apply: 'build',
+        generateBundle() {
+            let sha = process.env['GITHUB_SHA'] ?? process.env['GIT_HASH'];
+            if (!sha) {
+                try {
+                    sha = execSync('git rev-parse HEAD', { encoding: 'utf8' }).trim();
+                } catch {
+                    sha = '';
+                }
+            }
+            this.emitFile({ type: 'asset', fileName: 'version.json', source: JSON.stringify({ sha }) });
         }
     };
 }
@@ -84,7 +106,7 @@ export default defineConfig(() => {
 
     return {
         // Vite ignores falsy plugins, so envProxyPlugin can be null in local dev (no REMOTE_API).
-        plugins: [react(), svgr(), checker({ typescript: true }), tailwindcss(), envProxyPlugin],
+        plugins: [react(), svgr(), checker({ typescript: true }), tailwindcss(), envProxyPlugin, emitVersionJson()],
         resolve: {
             alias: {
                 '@': path.resolve(__dirname, './src'),

--- a/scripts/deploy-status/affected.ts
+++ b/scripts/deploy-status/affected.ts
@@ -1,0 +1,67 @@
+/**
+ * Compute which deployable services a range of commits affects, and emit a report.
+ * Used by the merge-time "should deploy" GitHub Action (.github/workflows/notify-deploy-needed.yaml)
+ * and runnable locally to preview what a merge would announce.
+ *
+ *   tsx scripts/deploy-status/affected.ts --base <sha> --head <sha> [--format text|slack|json]
+ *
+ * Defaults: base/head from $BASE_SHA/$HEAD_SHA env (set by the workflow), format "text".
+ */
+import { execFileSync } from 'node:child_process';
+
+import { affectedByFiles, buildMappingContext } from './services.ts';
+
+import type { Affected } from './services.ts';
+
+const REPO = process.env['DEPLOY_REPO'] ?? 'NangoHQ/nango';
+const DEPLOY_WORKFLOW_URL = `https://github.com/${REPO}/actions/workflows/deploy.yaml`;
+
+function arg(name: string): string | undefined {
+    const idx = process.argv.indexOf(`--${name}`);
+    return idx >= 0 ? process.argv[idx + 1] : undefined;
+}
+
+// Uses node:child_process (not zx) so the merge workflow can run this with `npx tsx` alone — no npm ci.
+function changedFiles(base: string, head: string): string[] {
+    // --no-renames so a renamed file shows both old and new paths (both may map to services).
+    const out = execFileSync('git', ['diff', '--name-only', '--no-renames', base, head], { encoding: 'utf8' });
+    return out
+        .split('\n')
+        .map((l) => l.trim())
+        .filter(Boolean);
+}
+
+function renderText(affected: Affected[]): string {
+    if (affected.length === 0) return 'No deployable services affected by these changes.';
+    const lines = affected.map((a) => `  - ${a.service.key}${a.reason === 'via-shared' ? ' (via shared package)' : ''}`);
+    return `Changes landed on master — these services should be deployed:\n${lines.join('\n')}`;
+}
+
+function renderSlack(affected: Affected[]): string {
+    // Slack mrkdwn. Empty string signals "nothing to announce" to the workflow.
+    if (affected.length === 0) return '';
+    const lines = affected.map((a) => `• \`${a.service.key}\`${a.reason === 'via-shared' ? ' _(via shared package)_' : ''}`);
+    return [':package: *Changes landed on `master` — these services should be deployed:*', ...lines, `<${DEPLOY_WORKFLOW_URL}|Run a deploy>`].join('\n');
+}
+
+const head = arg('head') ?? process.env['HEAD_SHA'] ?? 'HEAD';
+let base = arg('base') ?? process.env['BASE_SHA'];
+// On a brand-new branch GitHub sends an all-zero "before" SHA; also handle a missing base
+// (e.g. local preview) by diffing just the head commit against its first parent.
+if (!base || /^0+$/.test(base)) base = `${head}^`;
+const format = arg('format') ?? 'text';
+
+const files = changedFiles(base, head);
+const ctx = buildMappingContext();
+const affected = affectedByFiles(files, ctx);
+
+switch (format) {
+    case 'json':
+        console.log(JSON.stringify({ base, head, files, services: affected.map((a) => ({ key: a.service.key, reason: a.reason })) }, null, 2));
+        break;
+    case 'slack':
+        process.stdout.write(renderSlack(affected));
+        break;
+    default:
+        console.log(renderText(affected));
+}

--- a/scripts/deploy-status/cli.ts
+++ b/scripts/deploy-status/cli.ts
@@ -1,0 +1,264 @@
+/**
+ * Show, per environment × service, which master commit is live, when it was deployed, who authored
+ * it, and how many commits that DIRECTLY touch that service are not yet deployed.
+ *
+ *   tsx scripts/deploy-status/cli.ts [--env dev|staging|prod] [--service <key>] [--verbose] [--json]
+ *
+ * Deployed SHAs + dates come from the deploy workflow run history (gh); drift is computed locally
+ * against origin/master. Commit SHAs are clickable links to GitHub in terminals that support it.
+ */
+import { parseArgs } from 'node:util';
+
+import chalk from 'chalk';
+
+import { computeDrift, ensureFetched, latestDirectCommit, prefetchCommits } from './engine.ts';
+import { SERVICES, buildMappingContext } from './services.ts';
+import { ENVIRONMENTS, fetchDeployRuns, fetchPullRequests, latestDeploy } from './sources.ts';
+
+import type { CommitInfo, Drift } from './engine.ts';
+import type { DeployedRef } from './sources.ts';
+
+const GITHUB_COMMIT_BASE = 'https://github.com/NangoHQ/nango/commit';
+const GITHUB_PR_BASE = 'https://github.com/NangoHQ/nango/pull';
+
+// Strict flag parsing via node's built-in parseArgs (as in scripts/wrap-dek): unknown or malformed
+// flags fail loudly instead of being silently ignored.
+function parseFlags() {
+    try {
+        return parseArgs({
+            options: {
+                env: { type: 'string' },
+                service: { type: 'string' },
+                verbose: { type: 'boolean', default: false },
+                json: { type: 'boolean', default: false }
+            }
+        }).values;
+    } catch (err) {
+        console.error(chalk.red(err instanceof Error ? err.message : String(err)));
+        console.error('Usage: tsx scripts/deploy-status/cli.ts [--env dev|staging|prod] [--service <key>] [--verbose] [--json]');
+        process.exit(1);
+    }
+}
+
+const short = (sha: string): string => sha.slice(0, 9);
+
+// OSC 8 terminal hyperlink — renders as a clickable link, degrades to plain text elsewhere.
+function link(text: string, url: string): string {
+    return `\x1b]8;;${url}\x07${text}\x1b]8;;\x07`;
+}
+function commitLink(sha: string): string {
+    return link(short(sha), `${GITHUB_COMMIT_BASE}/${sha}`);
+}
+// Turn any "(#1234)" PR reference in a commit subject into a clickable link.
+function linkifyPr(subject: string): string {
+    return subject.replace(/#(\d+)/g, (match, num: string) => link(match, `${GITHUB_PR_BASE}/${num}`));
+}
+
+function relativeTime(iso: string): string {
+    const sec = Math.max(0, (Date.now() - new Date(iso).getTime()) / 1000);
+    const units: [number, string][] = [
+        [60, 'second'],
+        [60, 'minute'],
+        [24, 'hour'],
+        [7, 'day'],
+        [4.345, 'week'],
+        [12, 'month'],
+        [Number.POSITIVE_INFINITY, 'year']
+    ];
+    let value = sec;
+    for (const [size, label] of units) {
+        if (value < size) {
+            const n = Math.floor(value);
+            return n <= 0 ? 'just now' : `${n} ${label}${n === 1 ? '' : 's'} ago`;
+        }
+        value /= size;
+    }
+    return 'just now';
+}
+
+function ageDays(iso: string): number {
+    return (Date.now() - new Date(iso).getTime()) / 86_400_000;
+}
+
+function directCount(drift: Drift | null): number {
+    return drift ? drift.undeployed.filter((c) => c.reason === 'direct').length : 0;
+}
+
+interface Status {
+    plain: string; // unstyled, used for column width
+    color: (s: string) => string;
+    link?: { label: string; url: string }; // a substring of `plain` to turn into a hyperlink
+}
+
+// Status text + colour. "behind" counts only commits that directly touch the service; 0 direct →
+// up to date. Feature-branch deploys are labelled by their PR ("PR #1234") when one can be resolved.
+function statusOf(ref: DeployedRef, drift: Drift | null, prNumber?: number): Status {
+    if (!ref.sha || !drift) return { plain: 'unknown', color: chalk.gray };
+    if (drift.status === 'orphaned') return { plain: 'orphaned', color: chalk.red };
+
+    const direct = directCount(drift);
+    const behind = direct > 0 ? `, ${direct} behind` : ', current';
+
+    if (drift.status === 'feature-branch') {
+        if (prNumber) {
+            const label = `PR #${prNumber}`;
+            return { plain: `${label}${behind}`, color: chalk.cyan, link: { label, url: `${GITHUB_PR_BASE}/${prNumber}` } };
+        }
+        return { plain: `feature-branch${behind}`, color: chalk.cyan };
+    }
+
+    return direct === 0 ? { plain: 'up to date', color: chalk.green } : { plain: `${direct} behind`, color: chalk.yellow };
+}
+
+function renderStatus(s: Status, width: number): string {
+    const body = s.link ? s.plain.replace(s.link.label, link(s.link.label, s.link.url)) : s.plain;
+    return s.color(body) + ' '.repeat(Math.max(0, width - s.plain.length));
+}
+
+// Relative deploy date; coloured by staleness only when there ARE direct commits waiting to ship.
+function dateOf(ref: DeployedRef, drift: Drift | null): { plain: string; color: (s: string) => string } {
+    if (!ref.date) return { plain: '', color: chalk.dim };
+    const plain = relativeTime(ref.date);
+    if (directCount(drift) > 0) {
+        const days = ageDays(ref.date);
+        if (days >= 14) return { plain, color: chalk.red };
+        if (days >= 7) return { plain, color: chalk.yellow };
+    }
+    return { plain, color: chalk.dim };
+}
+
+interface DisplayRow {
+    key: string;
+    deployedSha: string | null;
+    date: { plain: string; color: (s: string) => string };
+    status: Status;
+    undeployed: CommitInfo[];
+}
+
+async function main(): Promise<void> {
+    const start = Date.now();
+    const flags = parseFlags();
+    const envFilter = flags.env;
+    const serviceFilter = flags.service;
+    const verbose = flags.verbose;
+    const asJson = flags.json;
+
+    const envs = ENVIRONMENTS.filter((e) => !envFilter || e.name === envFilter);
+    const services = SERVICES.filter((s) => !serviceFilter || s.key === serviceFilter);
+    if (envs.length === 0) throw new Error(`Unknown --env "${envFilter}". Valid: ${ENVIRONMENTS.map((e) => e.name).join(', ')}`);
+    if (services.length === 0) throw new Error(`Unknown --service "${serviceFilter}". Valid: ${SERVICES.map((s) => s.key).join(', ')}`);
+
+    await ensureFetched();
+    const ctx = buildMappingContext();
+
+    let runs: Awaited<ReturnType<typeof fetchDeployRuns>> = [];
+    try {
+        runs = await fetchDeployRuns();
+    } catch (err) {
+        console.error(chalk.red(String(err)));
+    }
+
+    const plan = envs.map((env) => ({ env, items: services.map((service) => ({ service, ref: latestDeploy(runs, env.stage, service.key) })) }));
+    const deployedShas = plan.flatMap((p) => p.items.map((i) => i.ref.sha).filter((s): s is string => Boolean(s)));
+
+    // Fetch all deployed commits up front so drift can be computed concurrently below.
+    await prefetchCommits(deployedShas);
+
+    const [byEnv, latestByService] = await Promise.all([
+        Promise.all(
+            plan.map(async ({ env, items }) => ({
+                env,
+                rows: await Promise.all(
+                    items.map(async ({ service, ref }) => ({
+                        service,
+                        ref,
+                        drift: ref.sha ? await computeDrift(ref.sha, service, ctx, { skipFetch: true }) : null
+                    }))
+                )
+            }))
+        ),
+        Promise.all(services.map(async (s) => [s.key, await latestDirectCommit(s)] as const)).then((entries) => new Map(entries))
+    ]);
+
+    // Resolve PR numbers for feature-branch deploys so we can show "PR #1234" instead of "feature-branch".
+    const featureBranchShas = byEnv.flatMap(({ rows }) =>
+        rows.filter((r) => r.drift?.status === 'feature-branch' && r.ref.sha).map((r) => r.ref.sha as string)
+    );
+    const prNumbers = await fetchPullRequests(featureBranchShas);
+
+    if (asJson) {
+        console.log(
+            JSON.stringify(
+                byEnv.map(({ env, rows }) => ({
+                    env: env.name,
+                    services: rows.map(({ service, ref, drift }) => ({
+                        service: service.key,
+                        deployedSha: ref.sha,
+                        deployedAt: ref.date,
+                        pr: ref.sha ? (prNumbers.get(ref.sha) ?? null) : null,
+                        status: drift?.status ?? null,
+                        directBehind: drift ? directCount(drift) : null,
+                        totalBehind: drift?.undeployed.length ?? null,
+                        latestDirect: latestByService.get(service.key)?.sha ?? null,
+                        undeployed: drift?.undeployed ?? []
+                    }))
+                })),
+                null,
+                2
+            )
+        );
+        console.error(chalk.dim(`Finished in ${((Date.now() - start) / 1000).toFixed(0)}s`));
+        return;
+    }
+
+    // Build display rows, then size columns to the widest content so nothing shifts.
+    const display = byEnv.map(({ env, rows }) => ({
+        env,
+        rows: rows.map(
+            ({ service, ref, drift }): DisplayRow => ({
+                key: service.key,
+                deployedSha: ref.sha,
+                date: dateOf(ref, drift),
+                status: statusOf(ref, drift, ref.sha ? prNumbers.get(ref.sha) : undefined),
+                undeployed: drift?.undeployed ?? []
+            })
+        )
+    }));
+    const all = display.flatMap((d) => d.rows);
+    const wKey = Math.max(...all.map((r) => r.key.length));
+    const wDate = Math.max(0, ...all.map((r) => r.date.plain.length));
+    const wStatus = Math.max(...all.map((r) => r.status.plain.length));
+    const anyBehind = all.some((r) => r.undeployed.some((c) => c.reason === 'direct'));
+
+    for (const { env, rows } of display) {
+        // "latest" is env-independent, so show it in just one group: prod when all envs are shown,
+        // otherwise the single env that's displayed.
+        const showLatest = envs.length === 1 || env.name === 'prod';
+        console.log(chalk.bold.underline(`\n${env.name}`));
+        for (const r of rows) {
+            const directBehind = r.undeployed.filter((c) => c.reason === 'direct');
+            const deployed = r.deployedSha ? commitLink(r.deployedSha) : chalk.gray('—'.padEnd(9));
+            const date = r.date.color(r.date.plain.padEnd(wDate));
+            const stat = renderStatus(r.status, wStatus);
+            const latest = latestByService.get(r.key);
+            const latestCell = showLatest && directBehind.length > 0 && latest ? `${chalk.dim('latest')} ${commitLink(latest.sha)}` : '';
+            console.log(`  ${chalk.bold(r.key.padEnd(wKey))}  ${deployed}  ${date}  ${stat}  ${latestCell}`);
+
+            // --verbose lists the direct (counted) commits behind as a tree under the service, so
+            // they're easy to associate. Commit hash + title, both the hash and PR ref clickable.
+            if (verbose) {
+                directBehind.forEach((c, i) => {
+                    const branch = i === directBehind.length - 1 ? '└──' : '├──';
+                    console.log(`  ${chalk.dim(branch)} ${commitLink(c.sha)} ${linkifyPr(c.subject)}`);
+                });
+            }
+        }
+    }
+
+    if (anyBehind && !verbose) {
+        console.log(chalk.dim('\nTip: add --verbose to list the undeployed commits behind each service (and --env <dev|staging|prod> to focus on one).'));
+    }
+    console.error(chalk.dim(`\nFinished in ${((Date.now() - start) / 1000).toFixed(0)}s`));
+}
+
+await main();

--- a/scripts/deploy-status/engine.ts
+++ b/scripts/deploy-status/engine.ts
@@ -1,0 +1,117 @@
+/**
+ * Drift engine: given a service's currently-deployed SHA, work out how far behind master it is
+ * w.r.t. commits that actually touch that service. Uses local git (the CLI runs in a checkout);
+ * a future backend port would swap these git calls for the GitHub compare API but keep the logic.
+ */
+import { $ } from 'zx';
+
+import { affectedByFiles } from './services.ts';
+
+import type { MappingContext, Reason, ServiceDef } from './services.ts';
+
+$.verbose = false;
+
+const MASTER = 'origin/master';
+
+export interface CommitInfo {
+    sha: string;
+    shortSha: string;
+    date: string; // ISO
+    author: string;
+    subject: string;
+    reason: Reason; // how this commit affects the service in question
+}
+
+export type DeployStatus =
+    | 'on-master' // deployed SHA is an ancestor of master — the normal case
+    | 'feature-branch' // deployed SHA has commits master doesn't (e.g. dev deployed from a branch)
+    | 'orphaned'; // deployed SHA not found in the repo (deleted/GC'd branch)
+
+export interface Drift {
+    status: DeployStatus;
+    /** For feature-branch deploys: where the branch forked from master. Drift is measured from here. */
+    mergeBase?: string;
+    /** Commits affecting this service that master has but the deploy doesn't, newest first. */
+    undeployed: CommitInfo[];
+}
+
+/** Refresh origin/master so drift is measured against the latest. */
+export async function ensureFetched(): Promise<void> {
+    await $`git fetch origin master --quiet`.nothrow();
+}
+
+/**
+ * Fetch any deployed commits not present locally, in one pass, so callers can then compute drift
+ * concurrently without each spawning its own (lock-contending) `git fetch`.
+ */
+export async function prefetchCommits(shas: string[]): Promise<void> {
+    const missing: string[] = [];
+    for (const sha of shas) {
+        if (!(await commitExists(sha))) missing.push(sha);
+    }
+    if (missing.length === 0) return;
+    const combined = await $`git fetch origin ${missing} --quiet`.nothrow().quiet();
+    if (combined.exitCode !== 0) {
+        // Some SHA is unfetchable (e.g. a deleted branch) — fetch the rest individually.
+        for (const sha of missing) await $`git fetch origin ${sha} --quiet`.nothrow().quiet();
+    }
+}
+
+async function commitExists(sha: string): Promise<boolean> {
+    const r = await $`git cat-file -e ${`${sha}^{commit}`}`.nothrow().quiet();
+    return r.exitCode === 0;
+}
+
+async function isAncestorOfMaster(sha: string): Promise<boolean> {
+    const r = await $`git merge-base --is-ancestor ${sha} ${MASTER}`.nothrow().quiet();
+    return r.exitCode === 0;
+}
+
+// Parse `git log --name-only` into commits, keeping only those that affect `service`.
+// A NUL prefix delimits each commit record so blank lines in the file list can't confuse parsing.
+async function commitsAffecting(range: string, service: ServiceDef, ctx: MappingContext): Promise<CommitInfo[]> {
+    const out = await $`git log --no-renames --name-only --pretty=format:${'%x00%H%x1f%cI%x1f%an%x1f%s'} ${range}`.text();
+    const result: CommitInfo[] = [];
+    for (const record of out.split('\0')) {
+        const trimmed = record.replace(/^\n/, '');
+        if (!trimmed.trim()) continue;
+        const lines = trimmed.split('\n');
+        const [sha, date, author, subject] = (lines[0] ?? '').split('\x1f');
+        if (!sha) continue;
+        const files = lines
+            .slice(1)
+            .map((l) => l.trim())
+            .filter(Boolean);
+        const hit = affectedByFiles(files, ctx).find((a) => a.service.key === service.key);
+        if (hit) {
+            result.push({ sha, shortSha: sha.slice(0, 9), date: date ?? '', author: author ?? '', subject: subject ?? '', reason: hit.reason });
+        }
+    }
+    return result; // git log is newest-first
+}
+
+export async function computeDrift(deployedSha: string, service: ServiceDef, ctx: MappingContext): Promise<Drift> {
+    if (!(await commitExists(deployedSha))) {
+        // The SHA may belong to a branch we haven't fetched; try once before giving up.
+        await $`git fetch origin ${deployedSha} --quiet`.nothrow().quiet();
+    }
+    if (!(await commitExists(deployedSha))) {
+        return { status: 'orphaned', undeployed: [] };
+    }
+
+    if (await isAncestorOfMaster(deployedSha)) {
+        return { status: 'on-master', undeployed: await commitsAffecting(`${deployedSha}..${MASTER}`, service, ctx) };
+    }
+
+    const mergeBase = (await $`git merge-base ${deployedSha} ${MASTER}`.text()).trim();
+    return { status: 'feature-branch', mergeBase, undeployed: await commitsAffecting(`${mergeBase}..${MASTER}`, service, ctx) };
+}
+
+// The latest commit on master that directly touches this service's own package. This is
+// env-independent ("the latest version with <service> changes"), unlike per-env drift.
+export async function latestDirectCommit(service: ServiceDef): Promise<CommitInfo | null> {
+    const out = await $`git log -1 --no-renames --pretty=format:${'%H%x1f%cI%x1f%an%x1f%s'} ${MASTER} -- ${service.dir}`.text();
+    const [sha, date, author, subject] = out.split('\x1f');
+    if (!sha) return null;
+    return { sha, shortSha: sha.slice(0, 9), date: date ?? '', author: author ?? '', subject: subject ?? '', reason: 'direct' };
+}

--- a/scripts/deploy-status/services.ts
+++ b/scripts/deploy-status/services.ts
@@ -1,0 +1,175 @@
+import fs from 'node:fs';
+import path from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+// scripts/deploy-status -> repo root
+export const REPO_ROOT = path.resolve(path.dirname(fileURLToPath(import.meta.url)), '..', '..');
+const PACKAGES_DIR = path.join(REPO_ROOT, 'packages');
+
+export interface ServiceDef {
+    /** Value accepted by the `service` input of .github/workflows/deploy.yaml */
+    key: string;
+    /** Repo-relative package directory, e.g. "packages/server" */
+    dir: string;
+}
+
+// The deployable units, keyed by the exact `service` values deploy.yaml accepts. Replit is out of scope.
+export const SERVICES: ServiceDef[] = [
+    { key: 'server', dir: 'packages/server' },
+    { key: 'jobs', dir: 'packages/jobs' },
+    { key: 'persist', dir: 'packages/persist' },
+    { key: 'orchestrator', dir: 'packages/orchestrator' },
+    { key: 'metering', dir: 'packages/metering' },
+    { key: 'runner', dir: 'packages/runner' },
+    { key: 'lambda', dir: 'packages/lambda-runner' },
+    { key: 'connect_ui', dir: 'packages/connect-ui' },
+    { key: 'app_ui', dir: 'packages/webapp' }
+];
+
+// Files at the repo root whose change rebuilds the image / every workspace, so they
+// invalidate every deployable service. Matched exactly against the repo-relative path.
+// package-lock.json is deliberately excluded: it churns on nearly every dependency bump,
+// so flagging all services on every lockfile change is too noisy to be useful.
+const ROOT_BUILD_INPUTS = new Set([
+    'Dockerfile',
+    'Dockerfile.self_hosted',
+    'package.json',
+    'tsconfig.json',
+    'tsconfig.build.json',
+    'tsconfig.docker.json',
+    'scripts/build_docker.sh',
+    'scripts/build_docker_self_hosted.sh'
+]);
+
+export type Reason = 'direct' | 'via-shared';
+
+export interface Affected {
+    service: ServiceDef;
+    /** "direct" = the service's own package changed; "via-shared" = a dependency (or build input) changed. */
+    reason: Reason;
+}
+
+export interface MappingContext {
+    /** service key -> set of package dirs in that service's transitive internal-dependency closure (excludes its own dir). */
+    closures: Map<string, Set<string>>;
+}
+
+interface PackageNode {
+    name: string;
+    dir: string;
+    internalDepDirs: string[];
+}
+
+interface RawPackageJson {
+    name: string;
+    dependencies?: Record<string, string>;
+    devDependencies?: Record<string, string>;
+}
+
+function readPackageJson(filePath: string): RawPackageJson {
+    return JSON.parse(fs.readFileSync(filePath, 'utf8')) as RawPackageJson;
+}
+
+// Load every workspace package under packages/ and resolve its internal deps to dirs.
+// Internal deps are linked with `file:../<dir>` (e.g. lambda-runner -> "file:../runner"),
+// which npm resolves by PATH, not by name — and the dep key can differ from the target's
+// real package name (lambda-runner lists "@nangohq/runner" for a package named
+// "@nangohq/nango-runner"). So resolve `file:` by path first, and fall back to name.
+function loadPackages(): Map<string, PackageNode> {
+    const byDir = new Map<string, { name: string; deps: Record<string, string> }>();
+    for (const entry of fs.readdirSync(PACKAGES_DIR, { withFileTypes: true })) {
+        if (!entry.isDirectory()) continue;
+        const pkgJsonPath = path.join(PACKAGES_DIR, entry.name, 'package.json');
+        if (!fs.existsSync(pkgJsonPath)) continue;
+        const json = readPackageJson(pkgJsonPath);
+        byDir.set(`packages/${entry.name}`, { name: json.name, deps: { ...json.dependencies, ...json.devDependencies } });
+    }
+
+    const nameToDir = new Map<string, string>();
+    for (const [dir, { name }] of byDir) nameToDir.set(name, dir);
+
+    const nodes = new Map<string, PackageNode>();
+    for (const [dir, { name, deps }] of byDir) {
+        const internalDepDirs = new Set<string>();
+        for (const [depKey, spec] of Object.entries(deps)) {
+            if (typeof spec === 'string' && spec.startsWith('file:')) {
+                // path.join keeps forward slashes on posix; resolve relative to the depending package's dir.
+                const target = path.join(dir, spec.slice('file:'.length));
+                if (byDir.has(target)) {
+                    internalDepDirs.add(target);
+                    continue;
+                }
+            }
+            const byName = nameToDir.get(depKey);
+            if (byName) internalDepDirs.add(byName);
+        }
+        nodes.set(dir, { name, dir, internalDepDirs: [...internalDepDirs] });
+    }
+    return nodes;
+}
+
+// Transitive closure of internal dependency dirs, excluding the start dir itself.
+function transitiveClosure(startDir: string, nodes: Map<string, PackageNode>): Set<string> {
+    const seen = new Set<string>();
+    const stack = [...(nodes.get(startDir)?.internalDepDirs ?? [])];
+    while (stack.length) {
+        const dir = stack.pop()!;
+        if (seen.has(dir)) continue;
+        seen.add(dir);
+        for (const dep of nodes.get(dir)?.internalDepDirs ?? []) {
+            if (!seen.has(dep)) stack.push(dep);
+        }
+    }
+    return seen;
+}
+
+/** Build the mapping context once (reads package.json files), then reuse for many classify calls. */
+export function buildMappingContext(): MappingContext {
+    const nodes = loadPackages();
+    const closures = new Map<string, Set<string>>();
+    for (const svc of SERVICES) {
+        closures.set(svc.key, transitiveClosure(svc.dir, nodes));
+    }
+    return { closures };
+}
+
+function packageDirOf(filePath: string): string | null {
+    const match = filePath.match(/^packages\/[^/]+/);
+    return match ? match[0] : null;
+}
+
+/** Which services a single changed file affects, and whether directly or via a shared dependency. */
+export function affectedByFile(filePath: string, ctx: MappingContext): Affected[] {
+    if (ROOT_BUILD_INPUTS.has(filePath)) {
+        // A build input changed: rebuilds everything, so every service is (conservatively) affected.
+        return SERVICES.map((service) => ({ service, reason: 'via-shared' as const }));
+    }
+
+    const pkgDir = packageDirOf(filePath);
+    if (!pkgDir) return []; // docs/, .github/, etc. — no service redeploy implied
+
+    const result: Affected[] = [];
+    for (const service of SERVICES) {
+        if (pkgDir === service.dir) {
+            result.push({ service, reason: 'direct' });
+        } else if (ctx.closures.get(service.key)!.has(pkgDir)) {
+            result.push({ service, reason: 'via-shared' });
+        }
+    }
+    return result;
+}
+
+/** Aggregate affected services across many changed files. "direct" wins over "via-shared" per service. */
+export function affectedByFiles(filePaths: string[], ctx: MappingContext): Affected[] {
+    const byKey = new Map<string, Affected>();
+    for (const filePath of filePaths) {
+        for (const affected of affectedByFile(filePath, ctx)) {
+            const existing = byKey.get(affected.service.key);
+            if (!existing || (existing.reason === 'via-shared' && affected.reason === 'direct')) {
+                byKey.set(affected.service.key, affected);
+            }
+        }
+    }
+    // Stable order matching SERVICES declaration.
+    return SERVICES.map((s) => byKey.get(s.key)).filter((a): a is Affected => Boolean(a));
+}

--- a/scripts/deploy-status/services.unit.test.ts
+++ b/scripts/deploy-status/services.unit.test.ts
@@ -1,0 +1,61 @@
+import { describe, expect, it } from 'vitest';
+
+import { affectedByFile, affectedByFiles, buildMappingContext } from './services.ts';
+
+const ctx = buildMappingContext();
+
+function reasons(files: string[]): Record<string, string> {
+    return Object.fromEntries(affectedByFiles(files, ctx).map((a) => [a.service.key, a.reason]));
+}
+
+describe('service mapping', () => {
+    it('classifies a change to a service package as direct', () => {
+        expect(reasons(['packages/server/lib/server.ts'])).toEqual({ server: 'direct' });
+    });
+
+    it('treats a shared backend dep as via-shared for backend services but not the UIs', () => {
+        const r = reasons(['packages/utils/lib/x.ts']);
+        expect(r['server']).toBe('via-shared');
+        expect(r['jobs']).toBe('via-shared');
+        expect(r['app_ui']).toBeUndefined();
+        expect(r['connect_ui']).toBeUndefined();
+    });
+
+    it('maps design-system only to app_ui (not backend, not connect_ui)', () => {
+        expect(reasons(['packages/design-system/src/x.ts'])).toEqual({ app_ui: 'via-shared' });
+    });
+
+    it('maps a runner change to runner (direct) + jobs and lambda (via-shared), resolving the file: dep name mismatch', () => {
+        // lambda-runner depends on packages/runner via "@nangohq/runner": "file:../runner",
+        // but the package is named "@nangohq/nango-runner" — path resolution must still catch it.
+        const r = reasons(['packages/runner/lib/x.ts']);
+        expect(r['runner']).toBe('direct');
+        expect(r['jobs']).toBe('via-shared');
+        expect(r['lambda']).toBe('via-shared');
+    });
+
+    it('maps a types change to every deployable service', () => {
+        expect(Object.keys(reasons(['packages/types/lib/index.ts']))).toHaveLength(9);
+    });
+
+    it('treats a root build input as via-shared for every service', () => {
+        const r = reasons(['Dockerfile']);
+        expect(Object.keys(r)).toHaveLength(9);
+        expect(Object.values(r).every((v) => v === 'via-shared')).toBe(true);
+    });
+
+    it('ignores package-lock.json (too noisy to invalidate all services)', () => {
+        expect(affectedByFile('package-lock.json', ctx)).toEqual([]);
+    });
+
+    it('ignores paths that map to no service', () => {
+        expect(affectedByFile('docs/x.md', ctx)).toEqual([]);
+        expect(affectedByFile('.github/workflows/deploy.yaml', ctx)).toEqual([]);
+    });
+
+    it('lets a direct change win over via-shared when both apply', () => {
+        const r = reasons(['packages/orchestrator/lib/x.ts', 'packages/server/lib/x.ts']);
+        expect(r['orchestrator']).toBe('direct');
+        expect(r['server']).toBe('direct');
+    });
+});

--- a/scripts/deploy-status/sources.ts
+++ b/scripts/deploy-status/sources.ts
@@ -1,0 +1,68 @@
+/**
+ * Read each service's currently-deployed SHA + deploy date, per environment, from the deploy
+ * workflow's run history. Every service is shipped by deploy.yaml, whose run is titled
+ * "[Release] [<stage>] Deploy <service>" with headSha equal to the deployed commit (the
+ * nango-environments image tag for backend services, the rolled-out image for runner/lambda,
+ * the built bundle for the UIs). One `gh run list` covers everything — no nango-environments
+ * access and no API key needed.
+ */
+import { $ } from 'zx';
+
+$.verbose = false;
+
+export interface EnvDef {
+    name: string; // dev | staging | prod
+    stage: string; // development | staging | production (the deploy `stage` input)
+}
+
+// Replit is out of scope.
+export const ENVIRONMENTS: EnvDef[] = [
+    { name: 'dev', stage: 'development' },
+    { name: 'staging', stage: 'staging' },
+    { name: 'prod', stage: 'production' }
+];
+
+export interface DeployedRef {
+    sha: string | null;
+    date: string | null; // ISO timestamp of the deploy run, or null when unknown
+    note?: string; // why sha is null
+}
+
+interface DeployRun {
+    displayTitle: string;
+    headSha: string;
+    conclusion: string;
+    createdAt: string;
+}
+
+// Fetch recent deploy.yaml runs once; callers match per env+service in memory.
+// 1000 runs goes back far enough to catch infrequently-deployed services (UIs/fleet).
+export async function fetchDeployRuns(): Promise<DeployRun[]> {
+    const r = await $`gh run list --workflow deploy.yaml -L 1000 --json ${'displayTitle,headSha,conclusion,createdAt'}`.nothrow();
+    if (r.exitCode !== 0) throw new Error(`gh run list failed: ${r.stderr.trim()}`);
+    return JSON.parse(r.stdout) as DeployRun[];
+}
+
+// The latest successful deploy of a service to a stage → its commit and when it ran.
+export function latestDeploy(runs: DeployRun[], stage: string, serviceKey: string): DeployedRef {
+    const needle = `[${stage}] Deploy ${serviceKey}`;
+    // gh returns newest-first.
+    const match = runs.find((run) => run.conclusion === 'success' && run.displayTitle.includes(needle));
+    return match ? { sha: match.headSha, date: match.createdAt } : { sha: null, date: null, note: 'no successful deploy run found' };
+}
+
+const REPO = 'NangoHQ/nango';
+
+// The PR number associated with each commit (the first GitHub reports), keyed by full SHA. Used to
+// label feature-branch deploys as "PR #1234". One call per unique SHA, fetched in parallel.
+export async function fetchPullRequests(shas: string[]): Promise<Map<string, number>> {
+    const prs = new Map<string, number>();
+    await Promise.all(
+        [...new Set(shas)].map(async (sha) => {
+            const r = await $`gh api ${`repos/${REPO}/commits/${sha}/pulls`} --jq ${'.[0].number // ""'}`.nothrow();
+            const n = Number(r.stdout.trim());
+            if (r.exitCode === 0 && n) prs.set(sha, n);
+        })
+    );
+    return prs;
+}


### PR DESCRIPTION
## Problem

We deploy services independently from `master` to dev, staging, and prod, and people sometimes forget or deliberately skip an environment. There's no single view of which services a merge still needs deployed, nor which master commit is live for each service on each environment — so a service can silently run old code with no easy way to notice.

## Solution

Because each commit is service-scoped, everything here is computed per service. Three pieces:

- **Merge notification** — a push-to-`master` workflow (`notify-deploy-needed.yaml`) maps the merged change to the services it affects (`direct` vs `via a shared package`, derived from the workspace dependency graph) and posts the list to `#deploys` so a needed deploy isn't forgotten.
- **`version.json`** — bake the real build SHA into the webapp and connect-ui bundles so each UI reports the commit it was actually built from (today they echo the server's hash).
- **`deploy-status` CLI** (`npm run deploy:status`) — per environment × service, shows the live commit, its deploy date, and how many commits that *directly* touch the service are undeployed. Feature-branch deploys are labelled by their PR (`PR #1234`); `--verbose` lists the undeployed commits as a tree with clickable commit and PR links.

Source of truth: deployed SHAs come from the deploy workflow's run history via `gh` (the run's `headSha` is exactly what each deploy ships), so no extra repo access or API key is needed. Replit is out of scope.

Fixes [NAN-6005](https://linear.app/nango/issue/NAN-6005)

## Testing

- `npm run deploy:status` across dev/staging/prod — live SHAs match the deploy runs, drift counts match `git log`, and feature-branch deploys (currently several on dev) are detected and labelled by PR.
- `npm run deploy:status -- --verbose --env prod` — lists the undeployed direct commits per service with commit and PR links.
- Strict flag parsing: malformed/unknown flags and positional args (`--foo`, `prod`) fail with a clear message and exit 1.
- `npx vitest run scripts/deploy-status/services.unit.test.ts` — 9 mapping tests pass (direct vs via-shared, `file:` workspace-link resolution, root build inputs).
- Built both UIs and confirmed `dist/version.json` contains the injected SHA.
- The merge workflow's Slack post is the one piece only fully exercisable in CI — worth confirming on the first merge to master.
