### PR TITLE
feat(webapp): redesign app shell

### DIFF
--- a/packages/webapp/src/index.css
+++ b/packages/webapp/src/index.css
@@ -10,6 +10,9 @@
 
 @import '@nangohq/design-system/tokens/tokens.generated.css';
 
+/* Scan the design-system package so Tailwind generates classes used only by its components (Button, IconButton, …). */
+@source '../../design-system/src';
+
 /*
   ---break---
 */
@@ -72,7 +75,6 @@
         box-shadow: var(--shadow-focus-outline-default);
     }
 }
-
 
 @utility focus-error {
     @variant focus {

--- a/packages/webapp/src/layout/AppHeader.tsx
+++ b/packages/webapp/src/layout/AppHeader.tsx
@@ -1,12 +1,10 @@
-import { BookOpen, Box, Moon, Sun } from 'lucide-react';
+import { BookOpen, Box, LifeBuoy, Moon, Sun } from 'lucide-react';
 
 import { permissions } from '@nangohq/authz';
 import { Button, IconButton } from '@nangohq/design-system';
 
-import { SlackIcon } from '@/assets/SlackIcon';
 import { Breadcrumbs } from '@/components/patterns/Breadcrumbs';
 import { PermissionGate } from '@/components/patterns/PermissionGate';
-import { ButtonLink } from '@/components/ui/ButtonLink';
 import { useEnvironment } from '@/hooks/useEnvironment';
 import { usePermissions } from '@/hooks/usePermissions';
 import { darkModeSelector, useThemeStore } from '@/lib/theme';
@@ -25,9 +23,9 @@ export const AppHeader: React.FC = () => {
     const toggleDarkMode = useThemeStore((s) => s.toggleDarkMode);
 
     return (
-        <header className="h-16 px-10 pl-2 py-2.5 items-center flex justify-between shrink-0 gap-1.5 bg-surface-canvas">
+        <header className="flex h-14 shrink-0 items-center justify-between gap-2 border-b-[0.5px] border-border-default bg-surface-canvas px-6">
             <Breadcrumbs />
-            <div className="flex gap-1.5 justify-end">
+            <div className="flex justify-end gap-2">
                 <PermissionGate condition={canUsePlayground}>
                     {(allowed) => (
                         <Button variant="outline" size="md" disabled={!allowed} onClick={() => setPlaygroundOpen(!playgroundOpen)}>
@@ -36,14 +34,16 @@ export const AppHeader: React.FC = () => {
                         </Button>
                     )}
                 </PermissionGate>
-                <ButtonLink to="https://nango.dev/docs" target="_blank" variant="outline" size="md">
-                    <BookOpen />
-                    Docs
-                </ButtonLink>
-                <ButtonLink to="https://nango.dev/slack" target="_blank" variant="outline" size="md">
-                    <SlackIcon />
-                    Help
-                </ButtonLink>
+                <IconButton asChild variant="outline" size="md" label="Docs">
+                    <a href="https://nango.dev/docs" target="_blank" rel="noreferrer">
+                        <BookOpen />
+                    </a>
+                </IconButton>
+                <IconButton asChild variant="outline" size="md" label="Help">
+                    <a href="https://nango.dev/slack" target="_blank" rel="noreferrer">
+                        <LifeBuoy />
+                    </a>
+                </IconButton>
                 <IconButton variant="outline" size="md" label={darkMode ? 'Switch to light mode' : 'Switch to dark mode'} onClick={toggleDarkMode}>
                     {darkMode ? <Sun /> : <Moon />}
                 </IconButton>

--- a/packages/webapp/src/layout/AppSidebar/CreateEnvironmentDialog.tsx
+++ b/packages/webapp/src/layout/AppSidebar/CreateEnvironmentDialog.tsx
@@ -1,13 +1,12 @@
 import { zodResolver } from '@hookform/resolvers/zod';
-import { Loader } from 'lucide-react';
 import { useForm } from 'react-hook-form';
 import { useNavigate } from 'react-router-dom';
 import z from 'zod';
 
 import { Button } from '@nangohq/design-system';
 
-import { Dialog, DialogClose, DialogContent, DialogFooter, DialogHeader, DialogTitle } from '@/components/ui/Dialog';
-import { Form, FormControl, FormDescription, FormField, FormItem, FormMessage } from '@/components/ui/Form';
+import { Dialog, DialogClose, DialogContent, DialogDescription, DialogFooter, DialogHeader, DialogTitle } from '@/components/ui/Dialog';
+import { Form, FormControl, FormField, FormItem, FormMessage } from '@/components/ui/Form';
 import { Input } from '@/components/ui/Input';
 import { usePostEnvironment } from '@/hooks/useEnvironment';
 import { useToast } from '@/hooks/useToast';
@@ -63,32 +62,35 @@ export const CreateEnvironmentDialog: React.FC<CreateEnvironmentDialogProps> = (
 
     return (
         <Dialog open={open} onOpenChange={onOpenChange} modal={true}>
-            <DialogContent>
+            <DialogContent className="gap-0 rounded border-border-default p-0 shadow-[0px_1px_2px_0px_rgba(0,0,0,0.08)] sm:max-w-md">
                 <Form {...form}>
-                    <form onSubmit={form.handleSubmit(onSubmit)} className="flex flex-col gap-10">
-                        <DialogHeader>
-                            <DialogTitle>Environment Name</DialogTitle>
+                    <form onSubmit={form.handleSubmit(onSubmit)} className="flex flex-col">
+                        <DialogHeader className="gap-2 p-4 text-left">
+                            <DialogTitle className="type-heading-sm">Create environment</DialogTitle>
+                            <DialogDescription>Use it to switch between contexts like dev, staging, or production.</DialogDescription>
                         </DialogHeader>
-                        <FormField
-                            control={form.control}
-                            name="name"
-                            render={({ field }) => (
-                                <FormItem>
-                                    <FormControl>
-                                        <Input type="text" placeholder="my-environment-name" {...field} />
-                                    </FormControl>
-                                    <FormDescription>*Must be lowercase letters, numbers, underscores and dashes.</FormDescription>
-                                    <FormMessage />
-                                </FormItem>
-                            )}
-                        />
-                        <DialogFooter>
+                        <div className="px-4 pb-4">
+                            <FormField
+                                control={form.control}
+                                name="name"
+                                render={({ field }) => (
+                                    <FormItem>
+                                        <FormControl>
+                                            <Input type="text" placeholder="my-environment-name" {...field} />
+                                        </FormControl>
+                                        <FormMessage />
+                                    </FormItem>
+                                )}
+                            />
+                        </div>
+                        <DialogFooter className="border-t border-border-muted bg-surface-panel p-4">
                             <DialogClose asChild>
-                                <Button variant="outline">Cancel</Button>
+                                <Button variant="outline" size="sm">
+                                    Cancel
+                                </Button>
                             </DialogClose>
-                            <Button variant="primary" type="submit" disabled={isPending}>
-                                {isPending && <Loader className="animate-spin h-full w-full" />}
-                                Create Environment
+                            <Button variant="primary" size="sm" type="submit" loading={isPending}>
+                                Create environment
                             </Button>
                         </DialogFooter>
                     </form>

--- a/packages/webapp/src/layout/AppSidebar/EnvironmentDropdown.tsx
+++ b/packages/webapp/src/layout/AppSidebar/EnvironmentDropdown.tsx
@@ -1,4 +1,4 @@
-import { Check, ChevronsUpDown, Lock } from 'lucide-react';
+import { ChevronsUpDown, Lock } from 'lucide-react';
 import React, { useState } from 'react';
 import { useNavigate } from 'react-router-dom';
 
@@ -6,6 +6,7 @@ import { permissions } from '@nangohq/authz';
 import { Button } from '@nangohq/design-system';
 
 import { CreateEnvironmentDialog } from './CreateEnvironmentDialog.js';
+import { NavigationItem, navigationItemVariants } from './NavigationItem.js';
 import { LogoInverted } from '@/assets/LogoInverted';
 import { ConditionalTooltip } from '@/components/patterns/ConditionalTooltip.js';
 import { PermissionGate } from '@/components/patterns/PermissionGate.js';
@@ -72,18 +73,25 @@ export const EnvironmentDropdown: React.FC = () => {
         <SidebarMenu>
             <SidebarMenuItem>
                 <DropdownMenu modal={false}>
-                    <DropdownMenuTrigger className="h-fit w-full rounded p-2.5 flex flex-row items-center justify-between cursor-pointer bg-surface-overlay border-[0.5px] border-border-muted hover:bg-surface-overlay hover:border-0 hover:border-l-[0.5px] hover:border-r-[0.5px] hover:border-r-transparent data-[state=closed]:hover:my-[0.5px] data-[state=open]:bg-surface-overlay data-[state=open]:border-[0.5px] data-[state=open]:border-border-muted">
-                        <div className="flex gap-2 items-center">
-                            <LogoInverted className="h-6 w-6 text-text-strong" />
-                            <div className="flex flex-col items-start">
-                                <span className="text-body-small-regular leading-3 text-text-secondary">Environment</span>
-                                <span className="text-body-medium-semi leading-4 text-text-strong font-semibold truncate max-w-28">{env}</span>
+                    <DropdownMenuTrigger className="flex h-14 w-full cursor-pointer flex-row items-center justify-between border-b-[0.5px] border-border-default px-4 outline-none transition-colors hover:bg-state-hover data-[state=open]:bg-surface-overlay">
+                        <div className="flex min-w-0 items-center gap-3">
+                            <div className="flex size-8 shrink-0 items-center justify-center rounded-[2px] border-[0.5px] border-border-default bg-surface-overlay">
+                                <LogoInverted className="size-5 text-text-strong" />
+                            </div>
+                            <div className="flex min-w-0 flex-col items-start">
+                                <span className="type-text-regular-xs text-text-muted">Environment</span>
+                                <span className="type-text-medium-sm max-w-28 truncate text-text-default">{env}</span>
                             </div>
                         </div>
-                        <ChevronsUpDown className="w-4.5 h-4.5 text-text-strong" />
+                        <ChevronsUpDown className="size-4 shrink-0 text-icon-secondary" />
                     </DropdownMenuTrigger>
-                    <DropdownMenuContent align="start" side="bottom" className="w-50 max-h-96 flex flex-col gap-2">
-                        <div className="flex flex-col">
+                    <DropdownMenuContent
+                        align="start"
+                        side="bottom"
+                        sideOffset={0}
+                        className="flex max-h-96 w-(--radix-dropdown-menu-trigger-width) flex-col rounded-none border-0 border-b-[0.5px] border-border-default p-0"
+                    >
+                        <div className="flex flex-col px-1 pt-1">
                             {meta?.environments.map((environment) => (
                                 <PermissionGate
                                     key={environment.name}
@@ -95,57 +103,60 @@ export const EnvironmentDropdown: React.FC = () => {
                                         <DropdownMenuItem
                                             disabled={!allowed}
                                             onSelect={() => onSelect(environment.name)}
-                                            data-active={env === environment.name}
-                                            className="flex flex-row items-center justify-between gap-2 cursor-pointer data-[active=true]:text-text-strong"
+                                            className={navigationItemVariants({ selected: env === environment.name })}
                                         >
-                                            <div className="flex flex-row items-center gap-2 ">
-                                                <Check
-                                                    className="w-5 h-5 opacity-0 data-[active=true]:opacity-100 data-[active=true]:text-text-strong"
-                                                    data-active={env === environment.name}
-                                                />
-                                                <span>{environment.name}</span>
-                                            </div>
-                                            {environment.is_production && <Badge>Prod</Badge>}
+                                            <NavigationItem
+                                                trailing={
+                                                    environment.is_production && (
+                                                        <Badge variant="brand" size="custom" className="type-code-regular-xs rounded-[2px] px-1 py-0">
+                                                            Prod
+                                                        </Badge>
+                                                    )
+                                                }
+                                            >
+                                                {environment.name}
+                                            </NavigationItem>
                                         </DropdownMenuItem>
                                     )}
                                 </PermissionGate>
                             ))}
                         </div>
-                        <PermissionGate condition={canCreateEnvironment} tooltipSide="right">
-                            {(allowed) => (
-                                <ConditionalTooltip
-                                    condition={!!isMaxEnvironmentsReached}
-                                    content={
-                                        <>
-                                            Max number of environments reached.{' '}
-                                            {environment?.plan?.name.includes('legacy') ? (
-                                                <>Contact Nango to add more</>
-                                            ) : (
-                                                <>
-                                                    <StyledLink to={`/team/billing`} className="text-s">
-                                                        Upgrade
-                                                    </StyledLink>{' '}
-                                                    to add more
-                                                </>
-                                            )}
-                                        </>
-                                    }
-                                >
-                                    <Button
-                                        disabled={!!isMaxEnvironmentsReached || !allowed}
-                                        variant="primary"
-                                        onClick={() => {
-                                            // Managed control because Dialogs within DropdownMenus behave weirdly
-                                            setEnvironmentDialogOpen(true);
-                                        }}
-                                        className="w-full"
+                        <div className="border-t-[0.5px] border-border-muted p-2 [&_button]:w-full">
+                            <PermissionGate condition={canCreateEnvironment} tooltipSide="right">
+                                {(allowed) => (
+                                    <ConditionalTooltip
+                                        condition={!!isMaxEnvironmentsReached}
+                                        content={
+                                            <>
+                                                Max number of environments reached.{' '}
+                                                {environment?.plan?.name.includes('legacy') ? (
+                                                    <>Contact Nango to add more</>
+                                                ) : (
+                                                    <>
+                                                        <StyledLink to={`/team/billing`} className="text-s">
+                                                            Upgrade
+                                                        </StyledLink>{' '}
+                                                        to add more
+                                                    </>
+                                                )}
+                                            </>
+                                        }
                                     >
-                                        {!!isMaxEnvironmentsReached && <Lock />}
-                                        Create Environment
-                                    </Button>
-                                </ConditionalTooltip>
-                            )}
-                        </PermissionGate>
+                                        <Button
+                                            disabled={!!isMaxEnvironmentsReached || !allowed}
+                                            variant="primary"
+                                            onClick={() => {
+                                                // Managed control because Dialogs within DropdownMenus behave weirdly
+                                                setEnvironmentDialogOpen(true);
+                                            }}
+                                        >
+                                            {!!isMaxEnvironmentsReached && <Lock />}
+                                            Create environment
+                                        </Button>
+                                    </ConditionalTooltip>
+                                )}
+                            </PermissionGate>
+                        </div>
                     </DropdownMenuContent>
                 </DropdownMenu>
                 <CreateEnvironmentDialog open={environmentDialogOpen} onOpenChange={setEnvironmentDialogOpen} />

--- a/packages/webapp/src/layout/AppSidebar/NavigationItem.tsx
+++ b/packages/webapp/src/layout/AppSidebar/NavigationItem.tsx
@@ -1,0 +1,56 @@
+import { cva } from 'class-variance-authority';
+
+import { cn } from '@/utils/utils';
+
+import type { VariantProps } from 'class-variance-authority';
+
+/**
+ * Shared "Navigation Item" — Figma node 1:3111. Used by the environment and profile dropdowns.
+ *
+ * Apply `navigationItemVariants(...)` to the interactive row element (e.g. a Radix
+ * `DropdownMenuItem`) and render `<NavigationItem>` as its content.
+ *
+ * States:
+ * - Default  → transparent bg, `text-secondary` label, `icon-secondary` icon
+ * - Hover    → `state-hover` bg, `text-default` label/icon (driven by `focus:` — Radix focuses on pointer)
+ * - Selected → `state-selected` bg + 2px `interactive-selected-fill` left accent bar, `text-default`
+ * - Disabled → `text-disabled` label/icon
+ */
+export const navigationItemVariants = cva(
+    cn(
+        'group/navitem flex h-8 w-full cursor-pointer items-center justify-between gap-2 rounded-none border-l-2 border-transparent pl-2 pr-1 outline-none transition-colors',
+        'type-text-regular-sm text-text-secondary [&_svg]:text-icon-secondary!',
+        'focus:bg-state-hover focus:text-text-default focus:[&_svg]:text-icon-default!',
+        'data-[disabled]:pointer-events-none data-[disabled]:opacity-100 data-[disabled]:text-text-disabled data-[disabled]:[&_svg]:text-icon-disabled!'
+    ),
+    {
+        variants: {
+            selected: {
+                true: 'bg-state-selected border-interactive-selected-fill text-text-default [&_svg]:text-icon-default!',
+                false: ''
+            }
+        },
+        defaultVariants: {
+            selected: false
+        }
+    }
+);
+
+interface NavigationItemProps extends VariantProps<typeof navigationItemVariants> {
+    /** Leading 16px icon (optional — env items have no icon). */
+    icon?: React.ReactNode;
+    /** Trailing slot, right-aligned (e.g. the "Prod" badge). */
+    trailing?: React.ReactNode;
+    children: React.ReactNode;
+}
+
+/** Inner layout of a navigation item: leading icon (16px) + label (13px) + optional trailing slot. */
+export const NavigationItem: React.FC<NavigationItemProps> = ({ icon, trailing, children }) => (
+    <>
+        <span className="flex min-w-0 flex-1 items-center gap-2.5">
+            {icon != null && <span className="flex size-4 shrink-0 items-center justify-center [&>svg]:size-4">{icon}</span>}
+            <span className="truncate">{children}</span>
+        </span>
+        {trailing != null && <span className="flex shrink-0 items-center">{trailing}</span>}
+    </>
+);

--- a/packages/webapp/src/layout/AppSidebar/ProfileDropdown.tsx
+++ b/packages/webapp/src/layout/AppSidebar/ProfileDropdown.tsx
@@ -2,7 +2,8 @@ import { ChevronsUpDown, CreditCard, LogOut, SlidersHorizontal, Sparkle, UserRou
 import { useMemo } from 'react';
 import { useNavigate } from 'react-router-dom';
 
-import { DropdownMenu, DropdownMenuContent, DropdownMenuItem, DropdownMenuSeparator, DropdownMenuTrigger } from '@/components/ui/DropdownMenu';
+import { NavigationItem, navigationItemVariants } from './NavigationItem';
+import { DropdownMenu, DropdownMenuContent, DropdownMenuItem, DropdownMenuTrigger } from '@/components/ui/DropdownMenu';
 import { SidebarMenu, SidebarMenuItem } from '@/components/ui/Sidebar';
 import { useDevPanelStore, useIsDevToolsEnabled } from '@/features/DevToolPanel';
 import { useMeta } from '@/hooks/useMeta';
@@ -65,48 +66,37 @@ export const ProfileDropdown: React.FC = () => {
         <SidebarMenu>
             <SidebarMenuItem>
                 <DropdownMenu modal={false}>
-                    <DropdownMenuTrigger className="group/profile cursor-pointer h-fit w-full p-3 inline-flex items-center justify-between bg-surface-overlay hover:bg-state-hover data-[state=open]:bg-surface-overlay border-t-[0.5px] border-border-muted">
-                        <div className="inline-flex gap-2 items-center">
-                            <div className="size-10 flex items-center justify-center rounded bg-surface-canvas border border-border-muted text-text-strong leading-5">
+                    <DropdownMenuTrigger className="group/profile flex h-14 w-full cursor-pointer items-center justify-between border-t-[0.5px] border-b-[0.5px] border-border-default px-4 outline-none transition-colors hover:bg-state-hover data-[state=open]:bg-surface-overlay">
+                        <div className="flex min-w-0 items-center gap-3">
+                            <div className="type-text-regular-xs flex size-8 shrink-0 items-center justify-center rounded-full border-[0.5px] border-border-default bg-surface-overlay text-text-default">
                                 {initials}
                             </div>
-                            <div className="flex flex-col gap-1 items-start">
-                                <span className="text-body-medium-semi leading-4 text-text-strong truncate max-w-28 ">{user?.name}</span>
-                                <span className="text-body-small-regular leading-3 text-text-secondary pb-px truncate max-w-28">{user?.email}</span>
+                            <div className="flex min-w-0 flex-col items-start">
+                                <span className="type-text-medium-sm max-w-28 truncate text-text-default">{user?.name}</span>
+                                <span className="type-text-regular-xs max-w-28 truncate text-text-muted">{user?.email}</span>
                             </div>
                         </div>
-                        <ChevronsUpDown className="size-4.5 text-text-muted group-hover/profile:text-text-secondary group-active/profile:text-text-strong" />
+                        <ChevronsUpDown className="size-4 shrink-0 text-icon-secondary group-hover/profile:text-icon-default" />
                     </DropdownMenuTrigger>
-                    <DropdownMenuContent align="end" alignOffset={0} side="right" sideOffset={0} className="w-50 p-2">
+                    <DropdownMenuContent
+                        align="end"
+                        alignOffset={0}
+                        side="right"
+                        sideOffset={0}
+                        className="w-50 rounded-none border-[0.5px] border-border-default p-1"
+                    >
                         {items.map((item, index) => (
-                            <DropdownMenuItem
-                                key={index}
-                                onSelect={() => navigate(item.href)}
-                                className="group cursor-pointer flex flex-row items-center gap-2 text-text-secondary text-body-medium-medium hover:bg-state-hover hover:text-text-strong"
-                            >
-                                <item.icon className="size-4 text-text-secondary group-hover:text-text-strong" />
-                                <span>{item.label}</span>
+                            <DropdownMenuItem key={index} onSelect={() => navigate(item.href)} className={navigationItemVariants()}>
+                                <NavigationItem icon={<item.icon />}>{item.label}</NavigationItem>
                             </DropdownMenuItem>
                         ))}
                         {isDevToolsEnabled && (
-                            <>
-                                <DropdownMenuSeparator />
-                                <DropdownMenuItem
-                                    onSelect={toggleDevPanel}
-                                    className="group cursor-pointer flex flex-row items-center gap-2 text-text-secondary text-body-medium-medium hover:bg-state-hover hover:text-text-strong"
-                                >
-                                    <SlidersHorizontal className="size-4 text-text-secondary group-hover:text-text-strong" />
-                                    <span>Dev Tools</span>
-                                </DropdownMenuItem>
-                            </>
+                            <DropdownMenuItem onSelect={toggleDevPanel} className={navigationItemVariants()}>
+                                <NavigationItem icon={<SlidersHorizontal />}>Dev Tools</NavigationItem>
+                            </DropdownMenuItem>
                         )}
-                        <DropdownMenuSeparator />
-                        <DropdownMenuItem
-                            onSelect={() => signout()}
-                            className="group cursor-pointer flex flex-row items-center gap-2 text-text-secondary text-body-medium-medium hover:bg-state-hover hover:text-text-strong"
-                        >
-                            <LogOut className="size-4 text-text-secondary group-hover:text-text-strong" />
-                            <span>Log Out</span>
+                        <DropdownMenuItem onSelect={() => signout()} className={navigationItemVariants()}>
+                            <NavigationItem icon={<LogOut />}>Log out</NavigationItem>
                         </DropdownMenuItem>
                     </DropdownMenuContent>
                 </DropdownMenu>

--- a/packages/webapp/src/layout/AppSidebar/index.tsx
+++ b/packages/webapp/src/layout/AppSidebar/index.tsx
@@ -1,4 +1,4 @@
-import { AreaChart, Blocks, Logs, Plug, Settings2, Sparkle, X } from 'lucide-react';
+import { BarChart3, Blocks, Cog, List, Plug, Sprout, X } from 'lucide-react';
 import { useMemo } from 'react';
 import { Link } from 'react-router-dom';
 
@@ -43,7 +43,7 @@ export const AppSidebar: React.FC = () => {
         const gettingStarted = {
             title: 'Getting started',
             url: `/${env}/getting-started`,
-            icon: Sparkle,
+            icon: Sprout,
             onClose: async () => {
                 await apiPatchUser({
                     gettingStartedClosed: true
@@ -56,9 +56,9 @@ export const AppSidebar: React.FC = () => {
             meta && showGettingStarted && !meta.gettingStartedClosed ? gettingStarted : null,
             { title: 'Integrations', url: `/${env}/integrations`, icon: Blocks },
             { title: 'Connections', url: `/${env}/connections`, icon: Plug },
-            { title: 'Logs', url: `/${env}/logs`, icon: Logs },
-            { title: 'Metrics', url: `/${env}`, icon: AreaChart },
-            { title: 'Environment settings', url: `/${env}/environment-settings`, icon: Settings2 }
+            { title: 'Logs', url: `/${env}/logs`, icon: List },
+            { title: 'Metrics', url: `/${env}`, icon: BarChart3 },
+            { title: 'Environment settings', url: `/${env}/environment-settings`, icon: Cog }
         ].filter((item) => item !== null);
     }, [env, meta, refetchMeta, showGettingStarted]);
 
@@ -67,24 +67,32 @@ export const AppSidebar: React.FC = () => {
     const showUsageCard = plan?.name === 'free';
 
     return (
-        <Sidebar collapsible="none">
-            <SidebarHeader className="p-0 px-3 pt-2.5 mb-7">
+        <Sidebar collapsible="none" className="border-r-[0.5px] border-border-default">
+            <SidebarHeader className="p-0">
                 <EnvironmentDropdown />
             </SidebarHeader>
-            <SidebarContent>
-                <SidebarGroup>
+            <SidebarContent className="pt-4">
+                <SidebarGroup className="p-0 px-2.5">
                     <SidebarGroupContent>
-                        <SidebarMenu>
+                        <SidebarMenu className="gap-0">
                             {items.map((item) => (
                                 <SidebarMenuItem key={item.title}>
-                                    <SidebarMenuButton asChild data-active={item.url === window.location.pathname}>
+                                    <SidebarMenuButton
+                                        asChild
+                                        data-active={item.url === window.location.pathname}
+                                        className="type-text-regular-sm gap-2.5 text-text-secondary [&>svg]:size-4!"
+                                    >
                                         <Link to={item.url}>
                                             <item.icon />
                                             <span>{item.title}</span>
                                         </Link>
                                     </SidebarMenuButton>
                                     {item.onClose && (
-                                        <SidebarMenuAction onClick={item.onClose} aria-label={`Close ${item.title}`}>
+                                        <SidebarMenuAction
+                                            onClick={item.onClose}
+                                            aria-label={`Close ${item.title}`}
+                                            className="text-icon-secondary hover:bg-transparent hover:text-icon-default"
+                                        >
                                             <X />
                                         </SidebarMenuAction>
                                     )}

--- a/packages/webapp/src/layout/DashboardLayout.tsx
+++ b/packages/webapp/src/layout/DashboardLayout.tsx
@@ -1,6 +1,7 @@
 import React from 'react';
 
 import { AppSidebar } from './AppSidebar';
+import { SectionHeader } from './SectionHeader';
 import { SidebarInset, SidebarProvider } from '@/components/ui/Sidebar';
 import { Playground } from '@/features/Playground';
 import { AppHeader } from '@/layout/AppHeader';
@@ -8,29 +9,33 @@ import { cn } from '@/utils/utils';
 
 interface DashboardLayoutProps extends React.HTMLAttributes<HTMLDivElement> {
     fullWidth?: boolean;
+    /** Section title rendered in the fixed header below the top bar. Omit to hide the section header. */
+    title?: string;
+    /** Optional badge rendered inline after the section title (e.g. an environment badge). */
+    titleBadge?: React.ReactNode;
 }
 
-const DashboardLayout = React.forwardRef<HTMLDivElement, DashboardLayoutProps>(({ children, className, fullWidth = false, ...props }, ref) => {
-    return (
-        <SidebarProvider>
-            <AppSidebar />
-            <SidebarInset className="max-h-screen overflow-hidden">
-                <AppHeader />
-                <div
-                    ref={ref}
-                    className={cn(
-                        'relative w-full flex-1 min-h-0 overflow-auto border border-border-muted bg-surface-page min-w-3xl',
-                        fullWidth ? 'p-0' : 'p-11'
-                    )}
-                    {...props}
-                >
-                    <div className={cn('grow h-auto mx-auto w-full', fullWidth ? 'p-11' : 'min-w-[968px] max-w-[1056px]', className)}>{children}</div>
-                    <Playground />
-                </div>
-            </SidebarInset>
-        </SidebarProvider>
-    );
-});
+const DashboardLayout = React.forwardRef<HTMLDivElement, DashboardLayoutProps>(
+    ({ children, className, fullWidth = false, title, titleBadge, ...props }, ref) => {
+        return (
+            <SidebarProvider>
+                <AppSidebar />
+                <SidebarInset className="max-h-screen overflow-hidden">
+                    <AppHeader />
+                    {title != null && <SectionHeader title={title} badge={titleBadge} />}
+                    <div
+                        ref={ref}
+                        className={cn('relative w-full flex-1 min-h-0 overflow-auto bg-surface-page min-w-3xl', fullWidth ? 'p-0' : 'p-11')}
+                        {...props}
+                    >
+                        <div className={cn('grow h-auto mx-auto w-full', fullWidth ? 'p-11' : 'min-w-[968px] max-w-[1056px]', className)}>{children}</div>
+                        <Playground />
+                    </div>
+                </SidebarInset>
+            </SidebarProvider>
+        );
+    }
+);
 
 DashboardLayout.displayName = 'DashboardLayout';
 

--- a/packages/webapp/src/layout/SectionHeader.tsx
+++ b/packages/webapp/src/layout/SectionHeader.tsx
@@ -1,0 +1,19 @@
+interface SectionHeaderProps {
+    /** Section/page title shown on the left. */
+    title: string;
+    /** Optional content rendered inline right after the title (e.g. an environment badge). */
+    badge?: React.ReactNode;
+}
+
+/**
+ * Section header — Figma node 1:5829. A fixed 56px row below the top bar showing the
+ * current section title (with an optional inline badge). The right side is left blank for now.
+ */
+export const SectionHeader: React.FC<SectionHeaderProps> = ({ title, badge }) => (
+    <div className="flex h-14 shrink-0 items-center justify-between border-b-[0.5px] border-border-default bg-surface-page px-6">
+        <div className="flex min-w-0 items-center gap-2.5">
+            <h1 className="type-heading-sm truncate text-text-strong">{title}</h1>
+            {badge}
+        </div>
+    </div>
+);

--- a/packages/webapp/src/pages/Connection/Create.tsx
+++ b/packages/webapp/src/pages/Connection/Create.tsx
@@ -106,13 +106,12 @@ export const ConnectionCreate: React.FC = () => {
 
     if (isLoading) {
         return (
-            <DashboardLayout>
+            <DashboardLayout title="Create test connection">
                 <Helmet>
                     <title>Create Test Connection - Nango</title>
                 </Helmet>
                 <div className="grid grid-cols-2 text-text-strong">
                     <div className="pr-10 flex flex-col gap-10">
-                        <h1 className="text-2xl">Create test connection</h1>
                         <div className="flex flex-col gap-4">
                             <Skeleton className="w-full h-10" />
                             <Skeleton className="w-full" />
@@ -125,14 +124,13 @@ export const ConnectionCreate: React.FC = () => {
     }
 
     return (
-        <DashboardLayout fullWidth className={'max-w-[1250px]'}>
+        <DashboardLayout fullWidth title="Create test connection" className={'max-w-[1250px]'}>
             <Helmet>
                 <title>Create Test Connection - Nango</title>
             </Helmet>
             <div className="grid grid-cols-[2fr_1fr] text-text-strong">
                 <div className="pr-5">
                     <div className="flex flex-col gap-8">
-                        <h1 className="text-2xl">Create a test connection</h1>
                         <CreateConnectionSelector
                             integration={integration}
                             setIntegration={setIntegration}

--- a/packages/webapp/src/pages/Connection/List.tsx
+++ b/packages/webapp/src/pages/Connection/List.tsx
@@ -276,26 +276,12 @@ export const ConnectionList = () => {
     }
 
     return (
-        <DashboardLayout fullWidth>
+        <DashboardLayout fullWidth title="Connections">
             <Helmet>
                 <title>Connections - Nango</title>
             </Helmet>
 
             <div className="flex flex-col gap-3">
-                {/* Header */}
-                <div className="flex items-center justify-between">
-                    <h2 className="text-title-subsection text-text-strong">Connections</h2>
-                    {(hasConnections || hasFiltered) && (
-                        <PermissionGate condition={canCreateTestConnection}>
-                            {(allowed) => (
-                                <ButtonLink to={`/${env}/connections/create`} size="xl" disabled={!allowed}>
-                                    Add test connection
-                                </ButtonLink>
-                            )}
-                        </PermissionGate>
-                    )}
-                </div>
-
                 {/* Content */}
                 <div className="flex flex-col gap-3">
                     {(loading || hasConnections || hasFiltered) && (
@@ -355,6 +341,13 @@ export const ConnectionList = () => {
                                     reorderOnSelect={false}
                                     showSearch={false}
                                 />
+                                <PermissionGate condition={canCreateTestConnection}>
+                                    {(allowed) => (
+                                        <ButtonLink to={`/${env}/connections/create`} size="lg" disabled={!allowed} className="ml-auto">
+                                            Add test connection
+                                        </ButtonLink>
+                                    )}
+                                </PermissionGate>
                             </div>
 
                             {/* Table */}

--- a/packages/webapp/src/pages/Environment/Settings/Show.tsx
+++ b/packages/webapp/src/pages/Environment/Settings/Show.tsx
@@ -60,22 +60,23 @@ export const EnvironmentSettings: React.FC = () => {
     const canSeeDeprecatedAuthorization = new Date(team.account.created_at) <= new Date('2025-08-25');
 
     return (
-        <DashboardLayout fullWidth className="flex flex-col gap-8">
+        <DashboardLayout
+            fullWidth
+            title="Environment settings"
+            titleBadge={
+                isProd ? (
+                    <Badge variant="brand" size="custom" className="type-code-regular-xs rounded-[2px] px-1 py-0">
+                        Prod
+                    </Badge>
+                ) : (
+                    <Badge variant="secondary">{env}</Badge>
+                )
+            }
+            className="flex flex-col gap-8"
+        >
             <Helmet>
                 <title>Environment Settings - Nango</title>
             </Helmet>
-
-            <div className="flex flex-col gap-2.5">
-                <h2 className="text-title-subsection text-text-strong">Environment settings</h2>
-                <div className="flex gap-2.5">
-                    <span className="text-heading-sm text-text-secondary">{env}</span>
-                    {isProd && (
-                        <Badge variant="secondary" className="text-heading-sm text-text-secondary">
-                            Prod
-                        </Badge>
-                    )}
-                </div>
-            </div>
 
             <div className="flex h-fit justify-center" key={env}>
                 <Navigation value={activeTab} onValueChange={setActiveTab}>

--- a/packages/webapp/src/pages/GettingStarted/Show.tsx
+++ b/packages/webapp/src/pages/GettingStarted/Show.tsx
@@ -51,12 +51,11 @@ export const GettingStarted: React.FC = () => {
     }
 
     return (
-        <DashboardLayout className="flex flex-col gap-10">
+        <DashboardLayout title="Getting started" className="flex flex-col gap-10">
             <Helmet>
                 <title>Getting Started - Nango</title>
             </Helmet>
             <header className="flex flex-col gap-3.5">
-                <h2 className="flex text-left text-2xl font-semibold tracking-tight text-text-strong">Getting started</h2>
                 <p className="text-text-secondary text-sm">Try connecting Nango with Github to see how integrations work.</p>
             </header>
             <div className="flex flex-row gap-10 min-w-0">

--- a/packages/webapp/src/pages/Integrations/CreateList.tsx
+++ b/packages/webapp/src/pages/Integrations/CreateList.tsx
@@ -91,14 +91,10 @@ export const CreateIntegrationList = () => {
     };
 
     return (
-        <DashboardLayout fullWidth className="flex flex-col gap-8">
+        <DashboardLayout fullWidth title="Set up new integration" className="flex flex-col gap-8">
             <Helmet>
                 <title>Create integration - Nango</title>
             </Helmet>
-
-            <header>
-                <h2 className="text-text-strong text-title-subsection">Set up new integration</h2>
-            </header>
 
             <InputGroup className="bg-surface-panel-inset">
                 <InputGroupInput type="text" placeholder="Github, accounting, oauth..." onChange={handleInputChange} autoFocus />

--- a/packages/webapp/src/pages/Integrations/Show.tsx
+++ b/packages/webapp/src/pages/Integrations/Show.tsx
@@ -101,12 +101,17 @@ export const IntegrationsList = () => {
     }
 
     return (
-        <DashboardLayout fullWidth className="flex flex-col gap-8">
+        <DashboardLayout fullWidth title="Integrations" className="flex flex-col gap-8">
             <Helmet>
                 <title>Integrations - Nango</title>
             </Helmet>
-            <header className="flex justify-between items-center">
-                <h2 className="text-text-strong text-title-subsection">Integrations</h2>
+            <header className="flex items-center gap-3">
+                <InputGroup className="h-10 flex-1">
+                    <InputGroupInput type="text" placeholder="Search integration" onChange={handleInputChange} autoFocus />
+                    <InputGroupAddon>
+                        <Search />
+                    </InputGroupAddon>
+                </InputGroup>
                 <PermissionGate asChild condition={canWriteIntegration}>
                     {(allowed) => (
                         <ButtonLink disabled={!allowed} to={`/${env}/integrations/create`} size="xl">
@@ -115,13 +120,6 @@ export const IntegrationsList = () => {
                     )}
                 </PermissionGate>
             </header>
-
-            <InputGroup>
-                <InputGroupInput type="text" placeholder="Search integration" onChange={handleInputChange} autoFocus />
-                <InputGroupAddon>
-                    <Search />
-                </InputGroupAddon>
-            </InputGroup>
 
             <AutoIdlingBanner />
 

--- a/packages/webapp/src/pages/Logs/Show.tsx
+++ b/packages/webapp/src/pages/Logs/Show.tsx
@@ -19,11 +19,10 @@ export const LogsShow: React.FC = () => {
 
     if (!globalEnv.features.logs) {
         return (
-            <DashboardLayout fullWidth className="p-6">
+            <DashboardLayout fullWidth title="Logs" className="p-6">
                 <Helmet>
                     <title>Logs - Nango</title>
                 </Helmet>
-                <h2 className="text-3xl font-semibold text-text-strong mb-4">Logs</h2>
                 <div className="flex gap-2 flex-col border border-border-muted rounded-md items-center text-text-strong text-center p-10 py-20">
                     <h2 className="text-xl text-center">Logs not configured</h2>
                     <div className="text-sm text-text-muted">
@@ -39,7 +38,7 @@ export const LogsShow: React.FC = () => {
     }
 
     return (
-        <DashboardLayout fullWidth className="p-6 h-full">
+        <DashboardLayout fullWidth title="Logs" className="p-6 h-full">
             <Helmet>
                 <title>Logs - Nango</title>
             </Helmet>

--- a/packages/webapp/src/pages/Logs/components/SearchAllOperations.tsx
+++ b/packages/webapp/src/pages/Logs/components/SearchAllOperations.tsx
@@ -253,8 +253,8 @@ export const SearchAllOperations: React.FC<Props> = ({ onSelectOperation }) => {
 
     return (
         <>
-            <div className="flex justify-between items-center">
-                <h2 className="text-3xl font-semibold text-text-strong mb-2 flex gap-4 items-center">Logs {(isLoading || isFetching) && <Spinner />}</h2>
+            <div className="flex justify-end items-center gap-2 mb-2">
+                {(isLoading || isFetching) && <Spinner />}
                 <div className="text-text-strong text-xs">
                     {totalHumanReadable} {totalOperations > 1 ? 'logs' : 'log'} found
                 </div>

--- a/packages/webapp/src/pages/Team/Billing/Show.tsx
+++ b/packages/webapp/src/pages/Team/Billing/Show.tsx
@@ -31,12 +31,11 @@ export const TeamBilling: React.FC = () => {
     }, [canManageBilling, activeTab, setActiveTab]);
 
     return (
-        <DashboardLayout className="flex flex-col gap-8">
+        <DashboardLayout title="Billing & usage" className="flex flex-col gap-8">
             <Helmet>
                 <title>Billing & usage - Nango</title>
             </Helmet>
-            <header className="flex justify-between items-center">
-                <h2 className="text-text-strong text-2xl font-semibold">Billing & usage</h2>
+            <header className="flex justify-end items-center">
                 {isUsageTab && (
                     <div className="flex items-center gap-4">
                         <MonthSelector onMonthChange={setSelectedMonth} />

--- a/packages/webapp/src/pages/Team/Settings.tsx
+++ b/packages/webapp/src/pages/Team/Settings.tsx
@@ -19,13 +19,10 @@ export const TeamSettingsPage: React.FC = () => {
 
     if (isLoading) {
         return (
-            <DashboardLayout>
+            <DashboardLayout title="Team settings">
                 <Helmet>
                     <title>Team Settings - Nango</title>
                 </Helmet>
-                <div className="flex items-center justify-between">
-                    <h2 className="text-heading-large text-text-strong">Team settings</h2>
-                </div>
                 <div className="flex flex-col gap-4">
                     <Skeleton className="w-[250px]" />
                     <Skeleton className="w-[250px]" />
@@ -41,12 +38,11 @@ export const TeamSettingsPage: React.FC = () => {
     const isNangoAdmin = data?.data.isAdminTeam;
 
     return (
-        <DashboardLayout fullWidth className="flex flex-col gap-10">
+        <DashboardLayout fullWidth title="Team settings" className="flex flex-col gap-10">
             <Helmet>
                 <title>Team Settings - Nango</title>
             </Helmet>
-            <div className="flex items-center justify-between">
-                <h2 className="text-heading-large text-text-strong">Team settings</h2>
+            <div className="flex items-center justify-end">
                 <AddTeamMemberButton />
             </div>
 

--- a/packages/webapp/src/pages/User/Settings.tsx
+++ b/packages/webapp/src/pages/User/Settings.tsx
@@ -39,11 +39,10 @@ export const UserSettings: React.FC = () => {
 
     if (loading) {
         return (
-            <DashboardLayout>
+            <DashboardLayout title="Profile settings">
                 <Helmet>
                     <title>Profile Settings - Nango</title>
                 </Helmet>
-                <h2 className="text-3xl font-semibold text-text-strong mb-16">Profile Settings</h2>
                 <div className="flex flex-col gap-4">
                     <Skeleton className="w-[250px]" />
                     <Skeleton className="w-[250px]" />
@@ -61,13 +60,10 @@ export const UserSettings: React.FC = () => {
     }
 
     return (
-        <DashboardLayout>
+        <DashboardLayout title="Profile settings">
             <Helmet>
                 <title>Profile Settings - Nango</title>
             </Helmet>
-            <div className="flex justify-between items-center">
-                <h2 className="text-3xl font-semibold text-text-strong">Profile Settings</h2>
-            </div>
             <div className="flex flex-col gap-12 mt-16">
                 <div className="flex flex-col gap-5">
                     <h3 className="font-semibold text-sm text-text-strong">Display Name</h3>


### PR DESCRIPTION
## Problem

The dashboard app shell — sidebar, environment switcher, profile dropdown, and top bar — didn't match the new Figma design, and each page rendered its own ad-hoc title with no consistent treatment.

## Solution

Redesign the app shell chrome to match Figma and introduce a shared section header.

- **Sidebar**: hairline borders, 13px nav labels, Figma icon set. The environment switcher and profile dropdown are rebuilt on a shared `NavigationItem` component (default/hover/selected states with a brand accent bar on the selected row), with flush square popovers and a Geist Mono `Prod` badge.
- **Top bar**: uses the design-system `Button`/`IconButton` outline variant for Playground, Docs, Help and the theme toggle.
- **Section header**: a fixed 56px row below the top bar, driven by a `title` prop on `DashboardLayout` with an optional `titleBadge` slot (e.g. the environment name / `Prod` pill on Environment settings). The primary nav, settings and create pages are migrated to it; on Integrations and Connections the primary action now sits inline with the search input.

Stacked on `matej/nan-5983-prevent-overriding-design-system-component-styles` — the redesign consumes design-system components without overriding their styles, per that branch's lint rule.

Entity detail pages (connection/integration/function detail) keep their existing headers for now.

## Testing

Verified live in light and dark mode against the dev API across the migrated pages and both dropdowns: sidebar navigation, environment + profile dropdowns (default/hover/selected states, Prod badge, full-width Create button), top-bar buttons (computed colors match the design-system tokens), and the section header (title plus env badge on dev and prod).

https://linear.app/nango/issue/NAN-5666
