### PR TITLE
chore(runner): increase telemetry batching thresholds

### DIFF
--- a/packages/runner/lib/telemetry.ts
+++ b/packages/runner/lib/telemetry.ts
@@ -45,7 +45,7 @@ function createTelemetryBatcher({ environmentId, persistClient }: { environmentI
         process: async (events) => {
             const res = await persistClient.postRunnerTelemetry(environmentId, events);
             if (res.isErr()) {
-                logger.warning('Failed to post runner telemetry, might retry later', {
+                logger.warning('Failed to post runner telemetry, will retry later', {
                     environmentId: environmentId,
                     events,
                     reason: res.error.message

--- a/packages/utils/lib/environment/parse.ts
+++ b/packages/utils/lib/environment/parse.ts
@@ -235,8 +235,8 @@ export const ENVS = z.object({
     RUNNER_ABORT_CHECK_INTERVAL_MS: z.coerce.number().optional().default(1_000),
     RUNNER_HEARTBEAT_INTERVAL_MS: z.coerce.number().optional().default(30_000),
     RUNNER_SYNC_CONFLICT_HEARTBEAT_INTERVAL_MULTIPLIER: z.coerce.number().optional().default(3.1),
-    RUNNER_TELEMETRY_BATCH_SIZE: z.coerce.number().int().positive().max(1000).default(10),
-    RUNNER_TELEMETRY_FLUSH_INTERVAL_MS: z.coerce.number().int().nonnegative().default(2000),
+    RUNNER_TELEMETRY_BATCH_SIZE: z.coerce.number().int().positive().max(1000).default(100),
+    RUNNER_TELEMETRY_FLUSH_INTERVAL_MS: z.coerce.number().int().nonnegative().default(5000),
 
     // FLEET
     RUNNERS_DATABASE_URL: z.url().optional(),


### PR DESCRIPTION
Increase telemetry recorder batching thresholds to 5s or 100 items. This should help in reducing the number of roundtrips (and therefore telemetry data points) sent to `persist`.


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/NangoHQ/nango/pull/6551?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

