### PR TITLE
fix: public function endpoint scopes

### DIFF
--- a/packages/server/lib/controllers/integrations/uniqueKey/functions/deleteFunction.integration.test.ts
+++ b/packages/server/lib/controllers/integrations/uniqueKey/functions/deleteFunction.integration.test.ts
@@ -35,7 +35,7 @@ describe(`DELETE ${route}`, () => {
     });
 
     it('should reject a key lacking the delete scope', async () => {
-        const seed = await seedWithScopes(['environment:functions:read']);
+        const seed = await seedWithScopes(['environment:integrations:functions:read']);
 
         const res = await api.fetch(route, {
             method: 'DELETE',

--- a/packages/server/lib/controllers/integrations/uniqueKey/functions/getCode.integration.test.ts
+++ b/packages/server/lib/controllers/integrations/uniqueKey/functions/getCode.integration.test.ts
@@ -77,6 +77,25 @@ describe(`GET ${endpoint}`, () => {
         shouldBeProtected(res);
     });
 
+    it('should reject a key lacking the read scope', async () => {
+        const { apiKey } = await seeders.seedAccountEnvAndUser();
+        await db
+            .knex('customer_keys')
+            .where('id', apiKey.id)
+            .update({ scopes: ['environment:integrations:functions:list'] });
+
+        const res = await api.fetch(endpoint, {
+            method: 'GET',
+            token: apiKey.secret,
+            params: { uniqueKey: 'github', name: 'get-issues' },
+            query: {}
+        });
+
+        isError(res.json);
+        expect(res.res.status).toBe(403);
+        expect(res.json.error.code).toBe('forbidden');
+    });
+
     it('returns 404 when integration is not found', async () => {
         const { apiKey } = await seeders.seedAccountEnvAndUser();
 

--- a/packages/server/lib/controllers/integrations/uniqueKey/functions/getFunction.integration.test.ts
+++ b/packages/server/lib/controllers/integrations/uniqueKey/functions/getFunction.integration.test.ts
@@ -29,7 +29,7 @@ describe(`GET ${route}`, () => {
     });
 
     it('should reject a key lacking the read scope', async () => {
-        const seed = await seedWithScopes(['environment:functions:list']);
+        const seed = await seedWithScopes(['environment:integrations:functions:list']);
 
         const res = await api.fetch(route, { method: 'GET', token: seed.apiKey.secret, params: { uniqueKey: 'github', name: 'my-sync' }, query: {} });
 

--- a/packages/server/lib/controllers/integrations/uniqueKey/functions/getFunctions.integration.test.ts
+++ b/packages/server/lib/controllers/integrations/uniqueKey/functions/getFunctions.integration.test.ts
@@ -29,7 +29,7 @@ describe(`GET ${route}`, () => {
     });
 
     it('should reject a key lacking the list scope', async () => {
-        const seed = await seedWithScopes(['environment:connections:read']);
+        const seed = await seedWithScopes(['environment:integrations:functions:read']);
 
         const res = await api.fetch(route, { method: 'GET', token: seed.apiKey.secret, params: { uniqueKey: 'github' }, query: {} });
 

--- a/packages/server/lib/controllers/providers/provider/templates/getTemplates.integration.test.ts
+++ b/packages/server/lib/controllers/providers/provider/templates/getTemplates.integration.test.ts
@@ -3,7 +3,7 @@ import { afterAll, beforeAll, describe, expect, it } from 'vitest';
 import db from '@nangohq/database';
 import { seeders } from '@nangohq/shared';
 
-import { isError, isSuccess, runServer, shouldBeProtected } from '../../../../utils/tests.js';
+import { isSuccess, runServer, shouldBeProtected } from '../../../../utils/tests.js';
 
 const route = '/providers/:provider/templates';
 let api: Awaited<ReturnType<typeof runServer>>;
@@ -28,14 +28,13 @@ describe(`GET ${route}`, () => {
         shouldBeProtected(res);
     });
 
-    it('should reject a key lacking the list scope', async () => {
+    it('should not require any scope beyond a valid key', async () => {
         const seed = await seedWithScopes(['environment:connections:read']);
 
         const res = await api.fetch(route, { method: 'GET', token: seed.apiKey.secret, params: { provider: 'github' } });
 
-        isError(res.json);
-        expect(res.res.status).toBe(403);
-        expect(res.json.error.code).toBe('forbidden');
+        expect(res.res.status).toBe(200);
+        isSuccess(res.json);
     });
 
     it('should return template functions for a known provider', async () => {

--- a/packages/server/lib/routes.public.ts
+++ b/packages/server/lib/routes.public.ts
@@ -188,7 +188,7 @@ publicAPI.route('/webhook/:environmentUuid/:providerConfigKey').post(webhookIngr
 publicAPI.use('/providers', jsonContentTypeMiddleware);
 publicAPI.route('/providers').get(connectSessionOrApiAuth, acceptLanguageMiddleware, getPublicProviders);
 publicAPI.route('/providers/:provider').get(connectSessionOrApiAuth, acceptLanguageMiddleware, getPublicProvider);
-publicAPI.route('/providers/:provider/templates').get(apiAuth, withScope('environment:functions:list'), getPublicProviderTemplates);
+publicAPI.route('/providers/:provider/templates').get(apiAuth, getPublicProviderTemplates);
 
 // @deprecated rollbacked for one customer, to delete asap
 publicAPI
@@ -212,14 +212,12 @@ publicAPI
     .get(apiAuth, withAnyScope('environment:integrations:read', 'environment:integrations:read_credentials'), getPublicIntegration);
 
 publicAPI.route('/integrations/:uniqueKey').delete(apiAuth, withScope('environment:integrations:delete'), deletePublicIntegration);
-publicAPI
-    .route('/integrations/:uniqueKey/functions/:name/code')
-    .get(apiAuth, withAnyScope('environment:integrations:read', 'environment:integrations:read_credentials'), getFunctionCode);
-publicAPI.route('/integrations/:uniqueKey/functions').get(apiAuth, withScope('environment:functions:list'), getPublicIntegrationFunctions);
+publicAPI.route('/integrations/:uniqueKey/functions/:name/code').get(apiAuth, withScope('environment:integrations:functions:read'), getFunctionCode);
+publicAPI.route('/integrations/:uniqueKey/functions').get(apiAuth, withScope('environment:integrations:functions:list'), getPublicIntegrationFunctions);
 publicAPI
     .route('/integrations/:uniqueKey/functions/:name')
-    .get(apiAuth, withScope('environment:functions:read'), getPublicIntegrationFunction)
-    .delete(apiAuth, withScope('environment:functions:delete'), deletePublicIntegrationFunction);
+    .get(apiAuth, withScope('environment:integrations:functions:read'), getPublicIntegrationFunction)
+    .delete(apiAuth, withScope('environment:integrations:functions:delete'), deletePublicIntegrationFunction);
 
 // @deprecated connections
 publicAPI.use('/connection', jsonContentTypeMiddleware);

--- a/packages/types/lib/api-keys/scopes.ts
+++ b/packages/types/lib/api-keys/scopes.ts
@@ -9,6 +9,10 @@ export const API_KEY_SCOPES = [
     'environment:integrations:create',
     'environment:integrations:update',
     'environment:integrations:delete',
+    'environment:integrations:functions:list',
+    'environment:integrations:functions:read',
+    'environment:integrations:functions:delete',
+    'environment:integrations:functions:*',
     'environment:integrations:*',
     // Connections
     'environment:connections:list',
@@ -29,9 +33,6 @@ export const API_KEY_SCOPES = [
     'environment:syncs:variant:delete',
     'environment:syncs:*',
     // Functions
-    'environment:functions:list',
-    'environment:functions:read',
-    'environment:functions:delete',
     'environment:functions:compile',
     'environment:functions:dryrun',
     'environment:functions:*',

--- a/packages/utils/lib/api-key-scopes.ts
+++ b/packages/utils/lib/api-key-scopes.ts
@@ -11,6 +11,10 @@ export const apiKeyScopes = [
     'environment:integrations:create',
     'environment:integrations:update',
     'environment:integrations:delete',
+    'environment:integrations:functions:list',
+    'environment:integrations:functions:read',
+    'environment:integrations:functions:delete',
+    'environment:integrations:functions:*',
     'environment:integrations:*',
     // Connections
     'environment:connections:list',
@@ -31,9 +35,6 @@ export const apiKeyScopes = [
     'environment:syncs:variant:delete',
     'environment:syncs:*',
     // Functions
-    'environment:functions:list',
-    'environment:functions:read',
-    'environment:functions:delete',
     'environment:functions:compile',
     'environment:functions:dryrun',
     'environment:functions:*',

--- a/packages/webapp/src/pages/Environment/Settings/ApiKeys.tsx
+++ b/packages/webapp/src/pages/Environment/Settings/ApiKeys.tsx
@@ -9,6 +9,7 @@ import {
     SCOPE_GROUPS,
     allGroupScopes,
     groupWildcard,
+    isScopeGroup,
     isScopeSelected,
     toggleCredential as toggleCredentialFn,
     toggleGroup as toggleGroupFn,
@@ -92,24 +93,79 @@ const ScopeSelector: React.FC<ScopeSelectorProps> = ({ selectedScopes, onChange,
         return wc ? selectedScopes.includes(wc) : false;
     };
 
-    const isGroupAllSelected = (group: ScopeGroup) => {
-        const all = allGroupScopes(group);
-        return isGroupWildcardSelected(group) || all.every((s) => selectedScopes.includes(s));
-    };
+    const isGroupAllSelected = (group: ScopeGroup) => allGroupScopes(group).every((s) => isScopeSelected(s, selectedScopes));
 
-    const hasAnyChildSelected = (group: ScopeGroup) => allGroupScopes(group).some((s) => selectedScopes.includes(s));
+    const hasAnyChildSelected = (group: ScopeGroup) => allGroupScopes(group).some((s) => isScopeSelected(s, selectedScopes));
 
-    const countGroupTotal = (group: ScopeGroup): number => {
-        return group.items.reduce((acc, item) => acc + (item.credentials ? 2 : 1), 0);
-    };
+    const countGroupTotal = (group: ScopeGroup): number => allGroupScopes(group).length;
 
-    const countGroupSelected = (group: ScopeGroup): number => {
-        if (isGroupWildcardSelected(group)) return countGroupTotal(group);
-        return group.items.reduce((acc, item) => {
-            const baseSelected = isScopeSelected(item.value, selectedScopes) || (!!item.credentials && isScopeSelected(item.credentials, selectedScopes));
-            const credSelected = !!item.credentials && isScopeSelected(item.credentials, selectedScopes);
-            return acc + (baseSelected ? 1 : 0) + (credSelected ? 1 : 0);
-        }, 0);
+    const countGroupSelected = (group: ScopeGroup): number => allGroupScopes(group).filter((s) => isScopeSelected(s, selectedScopes)).length;
+
+    const renderGroup = (group: ScopeGroup, depth: number, ancestorWildcardSelected: boolean): React.ReactNode => {
+        const groupSelected = isGroupAllSelected(group);
+        const wildcardActive = isGroupWildcardSelected(group) || ancestorWildcardSelected;
+        const headerIndent = depth === 0 ? '' : 'pl-7';
+        const itemIndent = depth === 0 ? 'pl-7' : 'pl-14';
+
+        return (
+            <div key={group.group} className={`flex flex-col ${depth === 0 ? 'border-b border-border-muted last:border-b-0' : ''}`}>
+                <div className={`flex items-center gap-2 py-2 ${headerIndent}`}>
+                    <label className="flex items-center gap-2 cursor-pointer flex-1">
+                        <input
+                            type="checkbox"
+                            checked={groupSelected}
+                            disabled={disabled || ancestorWildcardSelected}
+                            ref={(el) => {
+                                if (el) el.indeterminate = !groupSelected && hasAnyChildSelected(group);
+                            }}
+                            onChange={() => onChange(toggleGroupFn(group, selectedScopes))}
+                            className="accent-brand shrink-0"
+                        />
+                        <span className="text-body-small-semi text-text-strong">{group.group}</span>
+                    </label>
+                    <span className="text-body-small-regular text-text-muted">
+                        {countGroupSelected(group)}/{countGroupTotal(group)}
+                    </span>
+                </div>
+                <div className="flex flex-col pb-2">
+                    {group.items.map((item) =>
+                        isScopeGroup(item) ? (
+                            renderGroup(item, depth + 1, wildcardActive)
+                        ) : (
+                            <div key={item.value} className="flex flex-col">
+                                <label className={`flex items-center gap-2 ${itemIndent} cursor-pointer py-1`}>
+                                    <input
+                                        type="checkbox"
+                                        checked={
+                                            isScopeSelected(item.value, selectedScopes) ||
+                                            (!!item.credentials && isScopeSelected(item.credentials, selectedScopes))
+                                        }
+                                        disabled={disabled || wildcardActive}
+                                        onChange={() => onChange(toggleScopeFn(item.value, item.credentials, selectedScopes))}
+                                        className="accent-brand shrink-0"
+                                    />
+                                    <span className={`text-body-small-regular ${wildcardActive ? 'text-text-muted' : 'text-text-strong'}`}>{item.label}</span>
+                                </label>
+                                {item.credentials && (
+                                    <label className={`flex items-center gap-2 ${itemIndent} cursor-pointer py-1`}>
+                                        <input
+                                            type="checkbox"
+                                            checked={isScopeSelected(item.credentials, selectedScopes)}
+                                            disabled={disabled || wildcardActive}
+                                            onChange={() => onChange(toggleCredentialFn(item.value, item.credentials!, selectedScopes))}
+                                            className="accent-brand shrink-0"
+                                        />
+                                        <span className={`text-body-small-regular ${wildcardActive ? 'text-text-muted' : 'text-text-strong'}`}>
+                                            {item.label}:with_credentials
+                                        </span>
+                                    </label>
+                                )}
+                            </div>
+                        )
+                    )}
+                </div>
+            </div>
+        );
     };
 
     return (
@@ -153,72 +209,7 @@ const ScopeSelector: React.FC<ScopeSelectorProps> = ({ selectedScopes, onChange,
                     <label className="text-body-medium-semi text-text-strong">
                         Selected scopes<span className="text-status-danger-text">*</span>
                     </label>
-                    <div className="max-h-[320px] overflow-y-auto flex flex-col px-1">
-                        {SCOPE_GROUPS.map((group) => {
-                            const groupSelected = isGroupAllSelected(group);
-                            const wildcardSelected = isGroupWildcardSelected(group);
-
-                            return (
-                                <div key={group.group} className="flex flex-col border-b border-border-muted last:border-b-0">
-                                    <div className="flex items-center gap-2 py-2">
-                                        <label className="flex items-center gap-2 cursor-pointer flex-1">
-                                            <input
-                                                type="checkbox"
-                                                checked={groupSelected}
-                                                disabled={disabled}
-                                                ref={(el) => {
-                                                    if (el) el.indeterminate = !groupSelected && hasAnyChildSelected(group);
-                                                }}
-                                                onChange={() => onChange(toggleGroupFn(group, selectedScopes))}
-                                                className="accent-brand shrink-0"
-                                            />
-                                            <span className="text-body-small-semi text-text-strong">{group.group}</span>
-                                        </label>
-                                        <span className="text-body-small-regular text-text-muted">
-                                            {countGroupSelected(group)}/{countGroupTotal(group)}
-                                        </span>
-                                    </div>
-                                    <div className="flex flex-col pb-2">
-                                        {group.items.map((item) => (
-                                            <div key={item.value} className="flex flex-col">
-                                                <label className="flex items-center gap-2 pl-7 cursor-pointer py-1">
-                                                    <input
-                                                        type="checkbox"
-                                                        checked={
-                                                            isScopeSelected(item.value, selectedScopes) ||
-                                                            (!!item.credentials && isScopeSelected(item.credentials, selectedScopes))
-                                                        }
-                                                        disabled={disabled || wildcardSelected}
-                                                        onChange={() => onChange(toggleScopeFn(item.value, item.credentials, selectedScopes))}
-                                                        className="accent-brand shrink-0"
-                                                    />
-                                                    <span className={`text-body-small-regular ${wildcardSelected ? 'text-text-muted' : 'text-text-strong'}`}>
-                                                        {item.label}
-                                                    </span>
-                                                </label>
-                                                {item.credentials && (
-                                                    <label className="flex items-center gap-2 pl-7 cursor-pointer py-1">
-                                                        <input
-                                                            type="checkbox"
-                                                            checked={isScopeSelected(item.credentials, selectedScopes)}
-                                                            disabled={disabled || wildcardSelected}
-                                                            onChange={() => onChange(toggleCredentialFn(item.value, item.credentials!, selectedScopes))}
-                                                            className="accent-brand shrink-0"
-                                                        />
-                                                        <span
-                                                            className={`text-body-small-regular ${wildcardSelected ? 'text-text-muted' : 'text-text-strong'}`}
-                                                        >
-                                                            {item.label}:with_credentials
-                                                        </span>
-                                                    </label>
-                                                )}
-                                            </div>
-                                        ))}
-                                    </div>
-                                </div>
-                            );
-                        })}
-                    </div>
+                    <div className="max-h-[320px] overflow-y-auto flex flex-col px-1">{SCOPE_GROUPS.map((group) => renderGroup(group, 0, false))}</div>
                     {selectedScopes.length === 0 && <p className="text-body-small-regular text-status-danger-text">Select at least one scope to continue</p>}
                 </div>
             )}

--- a/packages/webapp/src/pages/Environment/Settings/scope-logic.ts
+++ b/packages/webapp/src/pages/Environment/Settings/scope-logic.ts
@@ -188,7 +188,8 @@ export function toggleGroup(group: ScopeGroup, selectedScopes: string[]): string
         return selectedScopes.filter((s) => s !== wc);
     } else if (wc) {
         const prefix = wc.slice(0, -1);
-        const cleaned = selectedScopes.filter((s) => !s.startsWith(prefix));
+        // Keep everything except this group's leaves and any narrower wildcard it replaces
+        const cleaned = selectedScopes.filter((s) => !all.includes(s) && !(s.endsWith(':*') && s.startsWith(prefix)));
         return [...cleaned, wc];
     } else {
         const allSelected = all.every((s) => selectedScopes.includes(s));

--- a/packages/webapp/src/pages/Environment/Settings/scope-logic.ts
+++ b/packages/webapp/src/pages/Environment/Settings/scope-logic.ts
@@ -8,7 +8,11 @@ export interface ScopeItem {
 
 export interface ScopeGroup {
     group: string;
-    items: ScopeItem[];
+    items: (ScopeItem | ScopeGroup)[];
+}
+
+export function isScopeGroup(item: ScopeItem | ScopeGroup): item is ScopeGroup {
+    return 'group' in item;
 }
 
 export const SCOPE_GROUPS: ScopeGroup[] = [
@@ -20,7 +24,15 @@ export const SCOPE_GROUPS: ScopeGroup[] = [
             { value: 'environment:integrations:read', label: 'read', credentials: 'environment:integrations:read_credentials' },
             { value: 'environment:integrations:create', label: 'create' },
             { value: 'environment:integrations:update', label: 'update' },
-            { value: 'environment:integrations:delete', label: 'delete' }
+            { value: 'environment:integrations:delete', label: 'delete' },
+            {
+                group: 'Functions',
+                items: [
+                    { value: 'environment:integrations:functions:list', label: 'list' },
+                    { value: 'environment:integrations:functions:read', label: 'read' },
+                    { value: 'environment:integrations:functions:delete', label: 'delete' }
+                ]
+            }
         ]
     },
     {
@@ -45,14 +57,6 @@ export const SCOPE_GROUPS: ScopeGroup[] = [
         ]
     },
     {
-        group: 'Integration Functions',
-        items: [
-            { value: 'environment:integrations:functions:list', label: 'list' },
-            { value: 'environment:integrations:functions:read', label: 'read' },
-            { value: 'environment:integrations:functions:delete', label: 'delete' }
-        ]
-    },
-    {
         group: 'Functions',
         items: [
             { value: 'environment:functions:compile', label: 'compile' },
@@ -74,7 +78,12 @@ export const SCOPE_GROUPS: ScopeGroup[] = [
 ];
 
 export function allGroupScopes(group: ScopeGroup): string[] {
-    return group.items.flatMap((item) => (item.credentials ? [item.value, item.credentials] : [item.value]));
+    return group.items.flatMap((item) => {
+        if (isScopeGroup(item)) {
+            return allGroupScopes(item);
+        }
+        return item.credentials ? [item.value, item.credentials] : [item.value];
+    });
 }
 
 export const ALL_INDIVIDUAL_SCOPES = SCOPE_GROUPS.flatMap((g) => allGroupScopes(g));
@@ -101,8 +110,11 @@ export function expandScopes(scopes: string[]): string[] {
 
 export function groupWildcard(group: ScopeGroup): string | null {
     const allScopes = allGroupScopes(group);
-    const parts = group.items[0].value.split(':');
-    if (parts.length < 3 || allScopes.length <= 1) {
+    if (allScopes.length <= 1) {
+        return null;
+    }
+    const parts = allScopes[0].split(':');
+    if (parts.length < 3) {
         return null;
     }
     return parts.slice(0, -1).join(':') + ':*';
@@ -113,15 +125,41 @@ export function isScopeSelected(scope: string, selectedScopes: string[]): boolea
     return selectedScopes.some((s) => s.endsWith(':*') && scope.startsWith(s.slice(0, -1)));
 }
 
+/**
+ * Deselect `targets` when they're currently granted by a wildcard rather than
+ * stored explicitly. The wildcard(s) covering them are expanded into their
+ * individual leaf scopes, minus the targets — so unchecking one box doesn't
+ * wipe the whole group. Returns null if no wildcard grants the targets (the
+ * caller then just removes them directly).
+ */
+function expandWildcardsExcept(targets: string[], selectedScopes: string[]): string[] | null {
+    const covering = selectedScopes.filter((s) => s.endsWith(':*') && targets.some((t) => t !== s && t.startsWith(s.slice(0, -1))));
+    if (covering.length === 0) {
+        return null;
+    }
+    const rest = selectedScopes.filter((s) => !covering.includes(s));
+    const expanded = new Set<string>();
+    for (const wc of covering) {
+        const prefix = wc.slice(0, -1);
+        for (const s of ALL_INDIVIDUAL_SCOPES) {
+            if (s.startsWith(prefix)) {
+                expanded.add(s);
+            }
+        }
+    }
+    for (const t of targets) {
+        expanded.delete(t);
+    }
+    return [...rest, ...expanded];
+}
+
 export function toggleScope(scope: string, credentialChild: string | undefined, selectedScopes: string[]): string[] {
     const isSelected = isScopeSelected(scope, selectedScopes) || (!!credentialChild && isScopeSelected(credentialChild, selectedScopes));
     if (isSelected) {
-        const matchingWildcard = selectedScopes.find((s) => s.endsWith(':*') && s !== scope && scope.startsWith(s.slice(0, -1)));
-        if (matchingWildcard) {
-            const expanded = ALL_INDIVIDUAL_SCOPES.filter((s) => s.startsWith(matchingWildcard.slice(0, -1)));
-            const without = expanded.filter((s) => s !== scope && s !== credentialChild);
-            const rest = selectedScopes.filter((s) => s !== matchingWildcard);
-            return [...rest, ...without];
+        const targets = credentialChild ? [scope, credentialChild] : [scope];
+        const expanded = expandWildcardsExcept(targets, selectedScopes);
+        if (expanded) {
+            return expanded;
         }
         return selectedScopes.filter((s) => s !== scope && s !== credentialChild);
     } else {
@@ -132,15 +170,11 @@ export function toggleScope(scope: string, credentialChild: string | undefined, 
 export function toggleCredential(parent: string, credential: string, selectedScopes: string[]): string[] {
     const isSelected = isScopeSelected(credential, selectedScopes);
     if (isSelected) {
-        const matchingWildcard = selectedScopes.find((s) => s.endsWith(':*') && s !== credential && credential.startsWith(s.slice(0, -1)));
-        if (matchingWildcard) {
-            const expanded = ALL_INDIVIDUAL_SCOPES.filter((s) => s.startsWith(matchingWildcard.slice(0, -1)));
-            const without = expanded.filter((s) => s !== credential);
-            const rest = selectedScopes.filter((s) => s !== matchingWildcard);
-            return [...rest, ...without];
-        } else {
-            return [...selectedScopes.filter((s) => s !== credential), ...(selectedScopes.includes(parent) ? [] : [parent])];
+        const expanded = expandWildcardsExcept([credential], selectedScopes);
+        if (expanded) {
+            return expanded;
         }
+        return [...selectedScopes.filter((s) => s !== credential), ...(selectedScopes.includes(parent) ? [] : [parent])];
     } else {
         return [...selectedScopes.filter((s) => s !== parent), credential];
     }
@@ -153,7 +187,8 @@ export function toggleGroup(group: ScopeGroup, selectedScopes: string[]): string
     if (wc && selectedScopes.includes(wc)) {
         return selectedScopes.filter((s) => s !== wc);
     } else if (wc) {
-        const cleaned = selectedScopes.filter((s) => !all.includes(s));
+        const prefix = wc.slice(0, -1);
+        const cleaned = selectedScopes.filter((s) => !s.startsWith(prefix));
         return [...cleaned, wc];
     } else {
         const allSelected = all.every((s) => selectedScopes.includes(s));

--- a/packages/webapp/src/pages/Environment/Settings/scope-logic.ts
+++ b/packages/webapp/src/pages/Environment/Settings/scope-logic.ts
@@ -45,11 +45,16 @@ export const SCOPE_GROUPS: ScopeGroup[] = [
         ]
     },
     {
+        group: 'Integration Functions',
+        items: [
+            { value: 'environment:integrations:functions:list', label: 'list' },
+            { value: 'environment:integrations:functions:read', label: 'read' },
+            { value: 'environment:integrations:functions:delete', label: 'delete' }
+        ]
+    },
+    {
         group: 'Functions',
         items: [
-            { value: 'environment:functions:list', label: 'list' },
-            { value: 'environment:functions:read', label: 'read' },
-            { value: 'environment:functions:delete', label: 'delete' },
             { value: 'environment:functions:compile', label: 'compile' },
             { value: 'environment:functions:dryrun', label: 'dryrun' }
         ]

--- a/packages/webapp/src/pages/Environment/Settings/scope-logic.unit.test.ts
+++ b/packages/webapp/src/pages/Environment/Settings/scope-logic.unit.test.ts
@@ -6,6 +6,7 @@ import {
     allGroupScopes,
     expandScopes,
     groupWildcard,
+    isScopeGroup,
     isScopeSelected,
     toggleCredential,
     toggleGroup,
@@ -241,6 +242,54 @@ describe('toggleGroup', () => {
         const result = toggleGroup(integrations, ['environment:deploy']);
         expect(result).toContain('environment:integrations:*');
         expect(result).toContain('environment:deploy');
+    });
+});
+
+describe('nested subgroups (integration functions)', () => {
+    const integrations = SCOPE_GROUPS.find((g) => g.group === 'Integrations')!;
+    const functions = integrations.items.filter(isScopeGroup).find((g) => g.group === 'Functions')!;
+
+    it('subgroup derives its own wildcard', () => {
+        expect(groupWildcard(functions)).toBe('environment:integrations:functions:*');
+    });
+
+    it('allGroupScopes on the parent includes nested subgroup scopes', () => {
+        const scopes = allGroupScopes(integrations);
+        expect(scopes).toContain('environment:integrations:functions:list');
+        expect(scopes).toContain('environment:integrations:functions:read');
+        expect(scopes).toContain('environment:integrations:functions:delete');
+    });
+
+    it('toggling the subgroup stores the subgroup wildcard', () => {
+        expect(toggleGroup(functions, [])).toEqual(['environment:integrations:functions:*']);
+    });
+
+    it('parent wildcard covers nested scopes', () => {
+        expect(isScopeSelected('environment:integrations:functions:read', ['environment:integrations:*'])).toBe(true);
+    });
+
+    it('selecting the parent wildcard subsumes a previously selected subgroup wildcard', () => {
+        expect(toggleGroup(integrations, ['environment:integrations:functions:*'])).toEqual(['environment:integrations:*']);
+    });
+
+    it('deselecting a nested scope under the parent wildcard drops only that scope', () => {
+        const result = toggleScope('environment:integrations:functions:read', undefined, ['environment:integrations:*']);
+        expect(result).not.toContain('environment:integrations:*');
+        expect(result).not.toContain('environment:integrations:functions:read');
+        expect(result).toContain('environment:integrations:functions:list');
+        expect(result).toContain('environment:integrations:functions:delete');
+        expect(result).toContain('environment:integrations:read');
+        expect(result).toContain('environment:integrations:list');
+    });
+
+    it('deselecting a nested scope under the subgroup wildcard expands only the subgroup', () => {
+        const result = toggleScope('environment:integrations:functions:read', undefined, ['environment:integrations:functions:*', 'environment:deploy']);
+        expect(result).not.toContain('environment:integrations:functions:*');
+        expect(result).not.toContain('environment:integrations:functions:read');
+        expect(result).toContain('environment:integrations:functions:list');
+        expect(result).toContain('environment:integrations:functions:delete');
+        expect(result).toContain('environment:deploy');
+        expect(result).not.toContain('environment:integrations:list');
     });
 });
 

--- a/packages/webapp/src/pages/Environment/Settings/scope-logic.unit.test.ts
+++ b/packages/webapp/src/pages/Environment/Settings/scope-logic.unit.test.ts
@@ -56,7 +56,10 @@ describe('expandScopes', () => {
             'environment:integrations:read_credentials',
             'environment:integrations:create',
             'environment:integrations:update',
-            'environment:integrations:delete'
+            'environment:integrations:delete',
+            'environment:integrations:functions:list',
+            'environment:integrations:functions:read',
+            'environment:integrations:functions:delete'
         ]);
     });
 

--- a/packages/webapp/src/pages/Environment/Settings/scope-logic.unit.test.ts
+++ b/packages/webapp/src/pages/Environment/Settings/scope-logic.unit.test.ts
@@ -243,6 +243,15 @@ describe('toggleGroup', () => {
         expect(result).toContain('environment:integrations:*');
         expect(result).toContain('environment:deploy');
     });
+
+    it('keeps unmodeled same-prefix scopes when enabling the group wildcard', () => {
+        // A scope the UI does not render a checkbox for (e.g. legacy/not-yet-modeled) must
+        // not be silently dropped — the new wildcard grants it, and dropping it would lose it
+        // permanently once a leaf is later deselected.
+        const result = toggleGroup(integrations, ['environment:integrations:legacy_unmodeled']);
+        expect(result).toContain('environment:integrations:*');
+        expect(result).toContain('environment:integrations:legacy_unmodeled');
+    });
 });
 
 describe('nested subgroups (integration functions)', () => {


### PR DESCRIPTION
Swapping scopes for the new endpoints: `enviroment:functions:*` to `environment:integrations:functions:*`
Technically a breaking change, but these endpoints were released a couple days ago and weren't added to docs yet.
Added support for nested scope groups in UI:
<img width="273" height="334" alt="image" src="https://github.com/user-attachments/assets/b0d72379-ec1f-42d9-8c2c-95c75f7341ca" />


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/NangoHQ/nango/pull/6552?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

