### PR TITLE
fix(providers): fix sap-success-factors company id pattern

### DIFF
--- a/packages/providers/providers.yaml
+++ b/packages/providers/providers.yaml
@@ -17777,7 +17777,7 @@ sap-success-factors:
             title: Company ID
             description: The company ID of your SAP SuccessFactors account
             example: SFSALES012345
-            pattern: '^[A-Z0-9]+$'
+            pattern: '^[A-Za-z0-9]+$'
             doc_section: '#step-2-finding-your-company-id'
             order: 2
     credentials:


### PR DESCRIPTION
## Describe the problem and your solution
- fix sap-success-factors company id pattern. They do allow [customization](https://userapps.support.sap.com/sap/support/knowledge/en/2087436) of this id after the instance has been provisioned.

**Criteria:**
1. Must be unique on the target Environment 
2. Case-sensitive - Upper and Lower Case are respected 
3. 13 characters or less 
4. Only letters and numbers - spaces or special characters are not supported

<!-- Issue ticket number and link (if applicable) -->

<!-- Testing instructions (skip if just adding/editing providers) -->



<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/NangoHQ/nango/pull/6553?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

