### PR TITLE
feat(functions): add searchConnections() SDK method (NAN-5890) 3/n

### DIFF
--- a/packages/runner-sdk/lib/function.ts
+++ b/packages/runner-sdk/lib/function.ts
@@ -30,6 +30,7 @@ export abstract class NangoFunctionBase<
      */
     public async searchConnections(filter: { tags: Record<string, string> }): Promise<ApiPublicConnection[]> {
         this.throwIfAbortedOrKilled();
+        this.throwIfConnectionScoped();
 
         const { connections } = await this.nango.listConnections({
             tags: filter.tags,
@@ -39,18 +40,13 @@ export abstract class NangoFunctionBase<
     }
 
     /**
-     * Drop the current event cleanly. The reason is written to the run's activity log so the
-     * decision is visible, without surfacing as an error.
-     *
-     * @example
-     * ```ts
-     * if (connections.length === 0) {
-     *     await nango.ignore('no matching connection');
-     *     return;
-     * }
-     * ```
+     * `searchConnections` only makes sense for connection-less runs (e.g. an integration-level
+     * webhook) that fan out to the connections they discover. A connection-scoped run already has
+     * its connection, so calling it there is a mistake.
      */
-    public async ignore(reason?: string): Promise<void> {
-        await this.log(reason ? `Event ignored: ${reason}` : 'Event ignored', { level: 'info' });
+    protected throwIfConnectionScoped(): void {
+        if (this.connectionId) {
+            throw new Error('searchConnections() can only be used in connection-less functions');
+        }
     }
 }

--- a/packages/runner-sdk/lib/function.ts
+++ b/packages/runner-sdk/lib/function.ts
@@ -1,0 +1,56 @@
+import { NangoSyncBase } from './sync.js';
+
+import type { ZodCheckpoint, ZodMetadata, ZodModel } from './types.js';
+import type { ApiPublicConnection } from '@nangohq/types';
+
+/**
+ * The SDK surface a function `exec` receives. Functions are trigger-driven and may
+ * be connection-bound or connection-less, so they get a few methods that do not belong
+ * on syncs or actions. It extends the sync surface so functions keep
+ * `batchSave`/`batchUpdate`/`batchDelete` against their declared models.
+ */
+export abstract class NangoFunctionBase<
+    TModels extends Record<string, ZodModel> = never,
+    TMetadata extends ZodMetadata = never,
+    TCheckpoint extends ZodCheckpoint = never
+> extends NangoSyncBase<TModels, TMetadata, TCheckpoint> {
+    /**
+     * Search this integration's connections that this function can route to.
+     *
+     * Used by connection-less function runs (e.g. an integration-level webhook) to find the
+     * connection(s) an incoming event targets, before fanning out work to them.
+     *
+     * @example
+     * ```ts
+     * const connections = await nango.searchConnections({ tags: { portalId: '12345' } });
+     * for (const connection of connections) {
+     *     await nango.triggerSync(this.providerConfigKey, connection.connection_id, 'contacts');
+     * }
+     * ```
+     */
+    public async searchConnections(filter: { tags: Record<string, string> }): Promise<ApiPublicConnection[]> {
+        this.throwIfAbortedOrKilled();
+
+        const { connections } = await this.nango.listConnections({
+            tags: filter.tags,
+            integrationId: this.providerConfigKey
+        });
+        return connections;
+    }
+
+    /**
+     * Drop the current event cleanly. The reason is written to the run's activity log so the
+     * decision is visible, without surfacing as an error.
+     *
+     * @example
+     * ```ts
+     * if (connections.length === 0) {
+     *     await nango.ignore('no matching connection');
+     *     return;
+     * }
+     * ```
+     */
+    public async ignore(reason?: string): Promise<void> {
+        await this.log(reason ? `Event ignored: ${reason}` : 'Event ignored', { level: 'info' });
+    }
+}

--- a/packages/runner-sdk/lib/function.unit.test.ts
+++ b/packages/runner-sdk/lib/function.unit.test.ts
@@ -1,0 +1,113 @@
+import { describe, expect, it, vi } from 'vitest';
+
+import { NangoFunctionBase } from './function.js';
+
+import type { ApiPublicConnection, NangoProps } from '@nangohq/types';
+
+function makeProps(overrides: Partial<NangoProps> = {}): NangoProps {
+    // Only the fields used by the base constructor are required for these tests.
+    return {
+        connectionId: 'connection-id',
+        environmentId: 1,
+        team: { id: 1, name: 'test-team' },
+        providerConfigKey: 'provider-config-key',
+        activityLogId: 'activity-log-id',
+        runnerFlags: {},
+        scriptType: 'action',
+        isCLI: false,
+        ...overrides
+    } as unknown as NangoProps;
+}
+
+const connection = { connection_id: 'conn-1', provider_config_key: 'provider-config-key' } as unknown as ApiPublicConnection;
+
+function makeFunction(overrides: Partial<NangoProps> = {}) {
+    const listConnections = vi.fn().mockResolvedValue({ connections: [connection] });
+
+    class TestFunction extends NangoFunctionBase {
+        nango = { listConnections } as any;
+
+        proxy(): Promise<any> {
+            throw new Error('not implemented');
+        }
+        log(): any {
+            return;
+        }
+        triggerSync(): Promise<any> {
+            throw new Error('not implemented');
+        }
+        startSync(): Promise<any> {
+            throw new Error('not implemented');
+        }
+        uncontrolledFetch(): Promise<Response> {
+            throw new Error('not implemented');
+        }
+        tryAcquireLock(): Promise<boolean> {
+            return Promise.resolve(false);
+        }
+        releaseLock(): Promise<boolean> {
+            return Promise.resolve(false);
+        }
+        releaseAllLocks(): Promise<void> {
+            return Promise.resolve();
+        }
+        getCheckpoint(): Promise<any> {
+            return Promise.resolve(null);
+        }
+        saveCheckpoint(): Promise<void> {
+            return Promise.resolve();
+        }
+        clearCheckpoint(): Promise<void> {
+            return Promise.resolve();
+        }
+        batchSave(): Promise<boolean> {
+            return Promise.resolve(true);
+        }
+        batchDelete(): Promise<any> {
+            return Promise.resolve();
+        }
+        batchUpdate(): Promise<any> {
+            return Promise.resolve();
+        }
+        getRecordsByIds(): Promise<any> {
+            return Promise.resolve(new Map());
+        }
+        async *listRecords(): AsyncGenerator<any> {
+            // no records in tests
+        }
+        deleteRecordsFromPreviousExecutions(): Promise<any> {
+            return Promise.resolve({ deletedKeys: [] });
+        }
+        trackDeletesStart(): Promise<void> {
+            return Promise.resolve();
+        }
+        trackDeletesEnd(): Promise<any> {
+            return Promise.resolve({ deletedKeys: [] });
+        }
+        setMergingStrategy(): Promise<void> {
+            return Promise.resolve();
+        }
+    }
+
+    return { fn: new TestFunction(makeProps(overrides)), listConnections };
+}
+
+describe('searchConnections', () => {
+    it('throws when called from a connection-scoped run', async () => {
+        const { fn, listConnections } = makeFunction({ connectionId: 'connection-id' });
+
+        await expect(fn.searchConnections({ tags: { portalId: '12345' } })).rejects.toThrow(
+            'searchConnections() can only be used in connection-less functions'
+        );
+        expect(listConnections).not.toHaveBeenCalled();
+    });
+
+    it('searches the integration connections for connection-less runs', async () => {
+        const { fn, listConnections } = makeFunction({ connectionId: '' });
+
+        const connections = await fn.searchConnections({ tags: { portalId: '12345' } });
+
+        expect(listConnections).toHaveBeenCalledWith({ tags: { portalId: '12345' }, integrationId: 'provider-config-key' });
+        expect(connections).toEqual([connection]);
+    });
+});

--- a/packages/runner-sdk/lib/scripts.ts
+++ b/packages/runner-sdk/lib/scripts.ts
@@ -1,4 +1,5 @@
 import type { NangoActionBase } from './action.js';
+import type { NangoFunctionBase } from './function.js';
 import type { NangoSyncBase } from './sync.js';
 import type { ZodCheckpoint, ZodMetadata, ZodModel } from './types.js';
 import type { NangoSyncEndpointV2 } from '@nangohq/types';
@@ -13,6 +14,7 @@ export type CreateAnyResponse =
 
 export type { ActionError } from './errors.js';
 export type { NangoActionBase as NangoAction, ProxyConfiguration } from './action.js';
+export type { NangoFunctionBase as NangoFunction } from './function.js';
 export type { NangoSyncBase as NangoSync } from './sync.js';
 
 // ----- Sync
@@ -647,7 +649,7 @@ export interface CreateFunctionProps<
      * }
      * ```
      */
-    exec: (nango: NangoSyncBase<TModels, TMetadata, TCheckpoint>, event: FunctionEvent<z.infer<TInput>>) => MaybePromise<z.infer<TOutput>>;
+    exec: (nango: NangoFunctionBase<TModels, TMetadata, TCheckpoint>, event: FunctionEvent<z.infer<TInput>>) => MaybePromise<z.infer<TOutput>>;
 }
 
 export interface CreateFunctionResponse<
@@ -715,7 +717,7 @@ export interface CreateWebhookProps<
     output?: TOutput;
     metadata?: TMetadata;
     checkpoint?: TCheckpoint;
-    exec: (nango: NangoSyncBase<TModels, TMetadata, TCheckpoint>, event: FunctionEvent) => MaybePromise<z.infer<TOutput>>;
+    exec: (nango: NangoFunctionBase<TModels, TMetadata, TCheckpoint>, event: FunctionEvent) => MaybePromise<z.infer<TOutput>>;
 }
 
 /**

--- a/packages/runner-sdk/lib/scripts.ts
+++ b/packages/runner-sdk/lib/scripts.ts
@@ -1,4 +1,5 @@
 import type { NangoActionBase } from './action.js';
+import type { NangoFunctionBase } from './function.js';
 import type { NangoSyncBase } from './sync.js';
 import type { ZodCheckpoint, ZodMetadata, ZodModel } from './types.js';
 import type { HTTP_METHOD, NangoSyncEndpointV2 } from '@nangohq/types';
@@ -13,6 +14,7 @@ export type CreateAnyResponse =
 
 export type { ActionError } from './errors.js';
 export type { NangoActionBase as NangoAction, ProxyConfiguration } from './action.js';
+export type { NangoFunctionBase as NangoFunction } from './function.js';
 export type { NangoSyncBase as NangoSync } from './sync.js';
 
 // ----- Sync
@@ -728,7 +730,7 @@ export interface CreateFunctionProps<
      * }
      * ```
      */
-    exec: (nango: NangoSyncBase<TModels, TMetadata, TCheckpoint>, trigger: Trigger<TTrigger, z.infer<TInput>>) => MaybePromise<z.infer<TOutput>>;
+    exec: (nango: NangoFunctionBase<TModels, TMetadata, TCheckpoint>, trigger: Trigger<TTrigger, z.infer<TInput>>) => MaybePromise<z.infer<TOutput>>;
 }
 
 export interface CreateFunctionResponse<
@@ -801,7 +803,7 @@ export interface CreateWebhookProps<
         metadata?: TMetadata;
         checkpoint?: TCheckpoint;
     };
-    exec: (nango: NangoSyncBase<TModels, TMetadata, TCheckpoint>, trigger: HttpTrigger) => MaybePromise<z.infer<TOutput>>;
+    exec: (nango: NangoFunctionBase<TModels, TMetadata, TCheckpoint>, trigger: HttpTrigger) => MaybePromise<z.infer<TOutput>>;
 }
 
 /**


### PR DESCRIPTION
Connection-less function runs (e.g. integration-level webhooks) need to find the connections an event targets.

- `searchConnections({ tags })`: server-side tag-filtered lookup via the existing connections list endpoint, scoped to the function's integration. Guarded so it can only be called from connection-less runs. A connection-scoped run already has its connection.

Concrete method on `NangoFunctionBase`, available in any function `exec`.

<!-- Describe the problem and your solution -->

<!-- Issue ticket number and link (if applicable) -->

<!-- Testing instructions (skip if just adding/editing providers) -->



<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/NangoHQ/nango/pull/6555?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->
