### PR TITLE
fix: disclosure of account existence in password reset

### DIFF
--- a/packages/server/lib/controllers/v1/account/postForgotPassword.integration.test.ts
+++ b/packages/server/lib/controllers/v1/account/postForgotPassword.integration.test.ts
@@ -1,0 +1,51 @@
+import { afterAll, beforeAll, describe, expect, it } from 'vitest';
+
+import { userService } from '@nangohq/shared';
+import { nanoid } from '@nangohq/utils';
+
+import { isSuccess, runServer } from '../../../utils/tests.js';
+
+const signupRoute = '/api/v1/account/signup';
+const forgotPasswordRoute = '/api/v1/account/forgot-password';
+
+let api: Awaited<ReturnType<typeof runServer>>;
+
+async function signupVerifiedUser(): Promise<string> {
+    const email = `${nanoid()}@example.com`;
+    const password = 'aZ1-foobar!?';
+
+    const signupRes = await api.fetch(signupRoute, {
+        method: 'POST',
+        body: { email, name: 'Foobar', password, foundUs: 'tests' } as any
+    });
+    expect(signupRes.res.status).toBe(200);
+
+    const createdUser = await userService.getUserByEmail(email);
+    await userService.verifyUserEmail(createdUser!.id);
+
+    return email;
+}
+
+describe(`POST ${forgotPasswordRoute}`, () => {
+    beforeAll(async () => {
+        api = await runServer();
+    });
+
+    afterAll(() => {
+        api.server.close();
+    });
+
+    it('should respond identically whether or not the email matches an account (no user enumeration)', async () => {
+        const existingEmail = await signupVerifiedUser();
+        const unknownEmail = `${nanoid()}@example.com`;
+
+        const existing = await api.fetch(forgotPasswordRoute, { method: 'POST', body: { email: existingEmail } });
+        const unknown = await api.fetch(forgotPasswordRoute, { method: 'POST', body: { email: unknownEmail } });
+
+        expect(existing.res.status).toBe(200);
+        expect(unknown.res.status).toBe(200);
+        isSuccess(existing.json);
+        isSuccess(unknown.json);
+        expect(unknown.json).toEqual(existing.json);
+    });
+});

--- a/packages/server/lib/controllers/v1/account/postForgotPassword.integration.test.ts
+++ b/packages/server/lib/controllers/v1/account/postForgotPassword.integration.test.ts
@@ -1,9 +1,17 @@
-import { afterAll, beforeAll, describe, expect, it } from 'vitest';
+import { afterAll, afterEach, beforeAll, describe, expect, it, vi } from 'vitest';
 
 import { userService } from '@nangohq/shared';
 import { nanoid } from '@nangohq/utils';
 
+import { sendResetPasswordEmail } from '../../../helpers/email.js';
 import { isSuccess, runServer } from '../../../utils/tests.js';
+
+import type * as emailHelpers from '../../../helpers/email.js';
+
+vi.mock('../../../helpers/email.js', async (importActual) => ({
+    ...(await importActual<typeof emailHelpers>()),
+    sendResetPasswordEmail: vi.fn(() => Promise.resolve())
+}));
 
 const signupRoute = '/api/v1/account/signup';
 const forgotPasswordRoute = '/api/v1/account/forgot-password';
@@ -35,6 +43,11 @@ describe(`POST ${forgotPasswordRoute}`, () => {
         api.server.close();
     });
 
+    afterEach(() => {
+        vi.mocked(sendResetPasswordEmail).mockReset();
+        vi.mocked(sendResetPasswordEmail).mockResolvedValue(undefined);
+    });
+
     it('should respond identically whether or not the email matches an account (no user enumeration)', async () => {
         const existingEmail = await signupVerifiedUser();
         const unknownEmail = `${nanoid()}@example.com`;
@@ -47,5 +60,15 @@ describe(`POST ${forgotPasswordRoute}`, () => {
         isSuccess(existing.json);
         isSuccess(unknown.json);
         expect(unknown.json).toEqual(existing.json);
+    });
+
+    it('should still respond with success when the reset flow fails internally (no user enumeration via errors)', async () => {
+        const existingEmail = await signupVerifiedUser();
+        vi.mocked(sendResetPasswordEmail).mockRejectedValueOnce(new Error('email provider down'));
+
+        const { res, json } = await api.fetch(forgotPasswordRoute, { method: 'POST', body: { email: existingEmail } });
+
+        expect(res.status).toBe(200);
+        isSuccess(json);
     });
 });

--- a/packages/server/lib/controllers/v1/account/postForgotPassword.ts
+++ b/packages/server/lib/controllers/v1/account/postForgotPassword.ts
@@ -30,20 +30,16 @@ export const postForgotPassword = asyncWrapper<PostForgotPassword>(async (req, r
     const { email } = val.data;
 
     const user = await userService.getUserByEmail(email);
-    if (!user) {
-        res.status(400).send({
-            error: { code: 'user_not_found' }
-        });
-        return;
+    if (user) {
+        const resetToken = jwt.sign({ user: email }, resetPasswordSecret(), { expiresIn: '10m' });
+
+        user.reset_password_token = resetToken;
+        await userService.editUserPassword(user);
+
+        await sendResetPasswordEmail({ user, token: resetToken });
     }
 
-    const resetToken = jwt.sign({ user: email }, resetPasswordSecret(), { expiresIn: '10m' });
-
-    user.reset_password_token = resetToken;
-    await userService.editUserPassword(user);
-
-    await sendResetPasswordEmail({ user, token: resetToken });
-
+    // Always respond with success, regardless of whether the email matches an account
     res.status(200).json({
         success: true
     });

--- a/packages/server/lib/controllers/v1/account/postForgotPassword.ts
+++ b/packages/server/lib/controllers/v1/account/postForgotPassword.ts
@@ -2,13 +2,15 @@ import jwt from 'jsonwebtoken';
 import * as z from 'zod';
 
 import { userService } from '@nangohq/shared';
-import { requireEmptyQuery, zodErrorToHTTP } from '@nangohq/utils';
+import { getLogger, report, requireEmptyQuery, zodErrorToHTTP } from '@nangohq/utils';
 
 import { sendResetPasswordEmail } from '../../../helpers/email.js';
 import { asyncWrapper } from '../../../utils/asyncWrapper.js';
 import { resetPasswordSecret } from '../../../utils/utils.js';
 
 import type { PostForgotPassword } from '@nangohq/types';
+
+const logger = getLogger('Server.PostForgotPassword');
 
 const validation = z.object({ email: z.string().email() }).strict();
 
@@ -29,17 +31,23 @@ export const postForgotPassword = asyncWrapper<PostForgotPassword>(async (req, r
 
     const { email } = val.data;
 
-    const user = await userService.getUserByEmail(email);
-    if (user) {
-        const resetToken = jwt.sign({ user: email }, resetPasswordSecret(), { expiresIn: '10m' });
+    try {
+        const user = await userService.getUserByEmail(email);
+        if (user) {
+            const resetToken = jwt.sign({ user: email }, resetPasswordSecret(), { expiresIn: '10m' });
 
-        user.reset_password_token = resetToken;
-        await userService.editUserPassword(user);
+            user.reset_password_token = resetToken;
+            await userService.editUserPassword(user);
 
-        await sendResetPasswordEmail({ user, token: resetToken });
+            await sendResetPasswordEmail({ user, token: resetToken });
+        }
+    } catch (err) {
+        logger.error('Failed to process password reset request', err);
+        report(err);
     }
 
-    // Always respond with success, regardless of whether the email matches an account
+    // Always respond with success, regardless of whether the email matches an account or the
+    // reset flow fails internally
     res.status(200).json({
         success: true
     });

--- a/packages/types/lib/account/api.ts
+++ b/packages/types/lib/account/api.ts
@@ -107,12 +107,11 @@ export type PostLogout = Endpoint<{
 }>;
 
 export type PostForgotPassword = Endpoint<{
-    Method: 'PUT';
+    Method: 'POST';
     Path: '/api/v1/account/forgot-password';
     Body: {
         email: string;
     };
-    Error: ApiError<'user_not_found'>;
     Success: {
         success: true;
     };

--- a/packages/webapp/src/pages/Account/ForgotPassword.tsx
+++ b/packages/webapp/src/pages/Account/ForgotPassword.tsx
@@ -35,17 +35,13 @@ export default function Signin() {
         setServerErrorMessage('');
 
         try {
-            const result = await requestPasswordReset({ email: data.email });
+            await requestPasswordReset({ email: data.email });
 
-            if (result.status === 200) {
-                toast({
-                    title: 'Email sent!',
-                    variant: 'success'
-                });
-                setDone(true);
-            } else {
-                setServerErrorMessage('No user matching this email.');
-            }
+            toast({
+                title: 'Email sent!',
+                variant: 'success'
+            });
+            setDone(true);
         } catch {
             setServerErrorMessage('Issue sending password reset email. Please try again.');
         }


### PR DESCRIPTION
- `POST /api/v1/account/forgot-password` now always returns `200 { success: true }`. The reset token is generated and the email sent only when the account exists;
unknown emails silently no-op, so responses are indistinguishable.
- Removed the now-unreachable `user_not_found` error from the `PostForgotPassword` type and corrected its method (`PUT` → `POST`) to match the route.
- Forgot-password page always shows the "email sent" confirmation, no longer surfacing whether an email is registered.


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/NangoHQ/nango/pull/6559?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

