### PR TITLE
fix(providers): add Halo PSA OAuth scope defaults

### DIFF
--- a/docs/api-integrations/halo-psa.mdx
+++ b/docs/api-integrations/halo-psa.mdx
@@ -13,7 +13,7 @@ Connect to Halo PSA with Nango and see data flow in 2 minutes.
     In Nango ([free signup](https://app.nango.dev)), go to [Integrations](https://app.nango.dev/dev/integrations) -> _Configure New Integration_ -> _Halo PSA_.
     </Step>
     <Step title="Authorize Halo PSA">
-    Go to [Connections](https://app.nango.dev/dev/connections) -> _Add Test Connection_ -> _Authorize_, then enter your Halo PSA hostname, Client ID, and Client Secret. Later, you'll let your users do the same directly from your app.
+    Go to [Connections](https://app.nango.dev/dev/connections) -> _Add Test Connection_ -> _Authorize_, then enter your Halo PSA hostname, OAuth scopes, Client ID, and Client Secret. The scopes default to `all,all:teams`. Later, you'll let your users do the same directly from your app.
     </Step>
     <Step title="Call the Halo PSA API">
     Let's make your first request to the Halo PSA API (fetch tickets). Replace the placeholders below with your [secret key](https://app.nango.dev/dev/environment-settings), [integration ID](https://app.nango.dev/dev/integrations), and [connection ID](https://app.nango.dev/dev/connections):

--- a/docs/api-integrations/halo-psa/connect.mdx
+++ b/docs/api-integrations/halo-psa/connect.mdx
@@ -9,6 +9,7 @@ To authenticate with Halo PSA, you need:
 1. **Hostname** - Your Halo PSA hostname.
 2. **Client ID** - The client ID from your Halo API application.
 3. **Client Secret** - The client secret from your Halo API application.
+4. **Scopes** - The OAuth scopes to request. Nango defaults this to `all,all:teams`.
 
 This guide will walk you through finding your Halo API details and creating an API application that uses OAuth 2.0 Client Credentials.
 
@@ -62,6 +63,11 @@ Halo uses agent team, department, and permission settings when returning API dat
 
 In the API application's permissions tab, enable the API permissions your application needs.
 
+Nango requests `all,all:teams` by default so the access token includes the permissions granted to the API application, including team access. You can replace this default with a narrower comma-separated scope list when your integration needs less access.
+
+<Warning>
+  Do not leave the scopes field empty. Halo PSA can issue an access token without a `scope` value, but API requests made with that token will fail with `401` or `403` responses.
+</Warning>
 
 <img src="/api-integrations/halo-psa/api-permissions.png" />
 
@@ -71,9 +77,10 @@ Once you have your **Hostname**, **Client ID**, and **Client Secret**:
 
 1. Open the form where you need to authenticate with Halo PSA.
 2. Enter your **Hostname**.
-3. Enter your **Client ID**.
-4. Enter your **Client Secret**.
-5. Submit the form.
+3. Keep the prefilled **Scopes** value (`all,all:teams`), or enter a narrower comma-separated scope list.
+4. Enter your **Client ID**.
+5. Enter your **Client Secret**.
+6. Submit the form.
 
 <img src="/api-integrations/halo-psa/form.png" style={{maxWidth: "450px" }} />
 

--- a/packages/providers/providers.scopes.yaml
+++ b/packages/providers/providers.scopes.yaml
@@ -4258,8 +4258,10 @@ gusto-demo:
     - workers_compensation:read
     - workers_compensation:write
 
-# source: providers.yaml (no official scopes page or discovery endpoint found)
-halo-psa: []
+# source: providers.yaml (Halo PSA grants requested scopes from the API application's configured permissions)
+halo-psa:
+    - all
+    - all:teams
 
 # source: https://help.getharvest.com/api-v2/authentication-api/authentication/authentication/
 harvest:

--- a/packages/providers/providers.yaml
+++ b/packages/providers/providers.yaml
@@ -9620,6 +9620,14 @@ halo-psa:
             prefix: https://
             doc_section: '#step-1-find-your-halo-api-details'
             order: 1
+        oauth_scopes:
+            type: string
+            title: Scopes
+            description: Comma-separated OAuth scopes to request from Halo PSA. The default requests the permissions granted to the API application, including team access.
+            example: all,all:teams
+            default_value: all,all:teams
+            doc_section: '#step-4-set-application-permissions'
+            order: 2
     credentials:
         client_id:
             type: string

--- a/packages/providers/tests/halo-psa.unit.test.ts
+++ b/packages/providers/tests/halo-psa.unit.test.ts
@@ -1,0 +1,16 @@
+import { describe, expect, it } from 'vitest';
+
+import { getProviderScopes, loadProvidersYaml } from '../lib/index.js';
+
+describe('Halo PSA provider', () => {
+    it('prefills the OAuth scopes required for usable client credentials', () => {
+        expect(loadProvidersYaml()?.['halo-psa']).toMatchObject({
+            connection_config: {
+                oauth_scopes: {
+                    default_value: 'all,all:teams'
+                }
+            }
+        });
+        expect(getProviderScopes()?.['halo-psa']).toEqual(['all', 'all:teams']);
+    });
+});


### PR DESCRIPTION
## Why

Halo PSA's client-credentials endpoint can return a valid-looking access token when no scopes are requested, but that token cannot call the API: proxy requests fail with 401/403 responses.

Nango's OAuth client-credentials runtime already reads `connection_config.oauth_scopes`, but the Halo PSA provider template only exposed `hostname`. The dashboard therefore created scopeless connections by default and gave users no place in the connection form to correct the configuration.

Closes #6561.

## Architecture / Implementation

- Add an editable `oauth_scopes` connection-config field to the `halo-psa` provider template, prefilled with `all,all:teams`.
- Keep the value connection-specific so users can replace the default with a narrower list; the existing OAuth2 client-credentials flow converts the comma-separated value using the provider's space separator.
- Add `all` and `all:teams` to the provider scope catalog so Nango can suggest the supported values.
- Update the Halo PSA quickstart and connection guide to include scopes and explain the failure mode of an empty value.
- Add a provider regression test for the default and catalog entries.

This does not change the shared OAuth runtime or existing connections. Existing scopeless connections still need to be reconnected or updated so Halo issues a new token.

## Testing Strategy

- `npx vitest run packages/providers/tests/halo-psa.unit.test.ts packages/providers/tests/localization.unit.test.ts`
- `npm run test:providers`
- `npx prettier --check packages/providers/providers.yaml packages/providers/providers.scopes.yaml packages/providers/tests/halo-psa.unit.test.ts docs/api-integrations/halo-psa.mdx docs/api-integrations/halo-psa/connect.mdx`
- Live verification against a Halo PSA tenant: a token renewed with `all,all:teams` contained granted scopes, and `/Client`, `/Tickets`, and `/Agent` proxy requests returned HTTP 200.

## Release Notes

Halo PSA connections now request usable OAuth scopes by default instead of silently creating scopeless tokens that fail API requests.


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/NangoHQ/nango/pull/6562?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

