### PR TITLE
refactor(data-transfer): collapse event directions

### DIFF
--- a/packages/metering/lib/processors/usage.ts
+++ b/packages/metering/lib/processors/usage.ts
@@ -294,8 +294,9 @@ export class UsageProcessor {
                     return Ok(undefined);
                 }
                 case 'usage.data_transfer': {
-                    const { package: pkg, callsite, direction } = event.payload.properties;
-                    metrics.increment(metrics.Types.DATA_TRANSFER, event.payload.value, { package: pkg, callsite, direction });
+                    const { package: pkg, callsite, ingressedBytes, egressedBytes } = event.payload.properties;
+                    metrics.increment(metrics.Types.DATA_TRANSFER, ingressedBytes, { package: pkg, callsite, direction: 'ingress' });
+                    metrics.increment(metrics.Types.DATA_TRANSFER, egressedBytes, { package: pkg, callsite, direction: 'egress' });
                     return Ok(undefined);
                 }
                 default:

--- a/packages/persist/lib/routes/runner/telemetry/postTelemetry.ts
+++ b/packages/persist/lib/routes/runner/telemetry/postTelemetry.ts
@@ -1,10 +1,11 @@
+import { makeDataTransferEvent } from '@nangohq/shared';
 import { validateRequest } from '@nangohq/utils';
 
 import { telemetryBodySchema, telemetryParamsSchema } from './validate.js';
 import { pubsub } from '../../../pubsub.js';
 
 import type { AuthLocals } from '../../../middleware/auth.middleware.js';
-import type { DBEnvironment, DBTeam, PostRunnerTelemetry, RunnerDataTransferTelemetry, UsageDataTransferEvent } from '@nangohq/types';
+import type { PostRunnerTelemetry } from '@nangohq/types';
 import type { EndpointRequest, EndpointResponse, Route, RouteHandler } from '@nangohq/utils';
 
 const path = '/environment/:environmentId/runner/telemetry';
@@ -15,42 +16,26 @@ const validate = validateRequest<PostRunnerTelemetry>({
     parseBody: (data: unknown) => telemetryBodySchema.parse(data)
 });
 
-function makeDataTransferEvent(
-    account: DBTeam,
-    environment: DBEnvironment,
-    event: RunnerDataTransferTelemetry,
-    direction: 'ingress' | 'egress'
-): Omit<UsageDataTransferEvent, 'idempotencyKey' | 'createdAt'> {
-    return {
-        subject: 'usage',
-        type: 'usage.data_transfer',
-        payload: {
-            value: direction === 'ingress' ? event.bytesReceived : event.bytesSent,
-            properties: {
-                accountId: account.id,
-                environmentId: environment.id,
-                environmentName: environment.name,
-                integrationId: event.integrationId,
-                connectionId: event.connectionId,
-                package: 'runner',
-                callsite: event.callsite,
-                direction,
-                ...(event.syncId ? { syncId: event.syncId } : {})
-            }
-        }
-    };
-}
-
 const handler = (_req: EndpointRequest, res: EndpointResponse<PostRunnerTelemetry, AuthLocals>) => {
     const { account, environment } = res.locals;
     const body = res.locals.parsedBody;
 
     const dataTransferEvents = body.events
         .filter((event) => event.type === 'data_transfer')
-        .flatMap((event) => [
-            ...(event.bytesSent > 0 ? [makeDataTransferEvent(account, environment, event, 'egress')] : []),
-            ...(event.bytesReceived > 0 ? [makeDataTransferEvent(account, environment, event, 'ingress')] : [])
-        ]);
+        .map((event) =>
+            makeDataTransferEvent({
+                pkg: 'runner',
+                callsite: event.callsite,
+                accountId: account.id,
+                connectionId: event.connectionId,
+                integrationId: event.integrationId,
+                environmentId: environment.id,
+                environmentName: environment.name,
+                meteredBytes: { sent: event.bytesSent, received: event.bytesReceived },
+                ...(event.syncId !== undefined ? { syncId: event.syncId } : {}),
+                count: event.count
+            })
+        );
 
     if (dataTransferEvents.length > 0) {
         void pubsub.publisher.publishBatch({ subject: 'usage', events: dataTransferEvents });

--- a/packages/persist/lib/routes/runner/telemetry/validate.ts
+++ b/packages/persist/lib/routes/runner/telemetry/validate.ts
@@ -11,6 +11,7 @@ export const telemetryEntrySchema = z.discriminatedUnion('type', [
             type: z.literal('data_transfer'),
             bytesSent: z.number().int().nonnegative(),
             bytesReceived: z.number().int().nonnegative(),
+            count: z.number().int().positive().default(1),
             callsite: z.enum(['proxy', 'uncontrolled_fetch', 'persist_records', 'persist_logs'])
         })
         .strict()

--- a/packages/runner/lib/sdk/sdk.ts
+++ b/packages/runner/lib/sdk/sdk.ts
@@ -140,7 +140,8 @@ export class NangoActionRunner extends NangoActionBase<never, ZodCheckpoint> {
                 integrationId: this.providerConfigKey,
                 syncId: this.syncId,
                 bytesSent,
-                bytesReceived
+                bytesReceived,
+                count: 1
             });
         });
     }
@@ -230,7 +231,8 @@ export class NangoActionRunner extends NangoActionBase<never, ZodCheckpoint> {
                     bytesReceived: received,
                     integrationId: providerConfigKey ?? this.providerConfigKey,
                     connectionId: connectionId ?? this.connectionId,
-                    syncId: this.syncId
+                    syncId: this.syncId,
+                    count: 1
                 });
             }
         });
@@ -345,7 +347,8 @@ export class NangoActionRunner extends NangoActionBase<never, ZodCheckpoint> {
             bytesReceived: 0,
             integrationId: this.providerConfigKey,
             connectionId: this.connectionId,
-            syncId: this.syncId
+            syncId: this.syncId,
+            count: 1
         });
         const res = await this.persistClient.postLog({
             environmentId: this.environmentId,
@@ -592,7 +595,8 @@ export class NangoSyncRunner extends NangoSyncBase<never, never, ZodCheckpoint> 
                 bytesReceived: 0,
                 integrationId: this.providerConfigKey,
                 connectionId: this.connectionId,
-                syncId: this.syncId
+                syncId: this.syncId,
+                count: 1
             });
             this.setMergingStrategyByModel(modelFullName, result.value.nextMerging);
         }
@@ -632,7 +636,8 @@ export class NangoSyncRunner extends NangoSyncBase<never, never, ZodCheckpoint> 
                 bytesReceived: 0,
                 integrationId: this.providerConfigKey,
                 connectionId: this.connectionId,
-                syncId: this.syncId
+                syncId: this.syncId,
+                count: 1
             });
             this.setMergingStrategyByModel(modelFullName, result.value.nextMerging);
         }
@@ -673,7 +678,8 @@ export class NangoSyncRunner extends NangoSyncBase<never, never, ZodCheckpoint> 
                 bytesReceived: 0,
                 integrationId: this.providerConfigKey,
                 connectionId: this.connectionId,
-                syncId: this.syncId
+                syncId: this.syncId,
+                count: 1
             });
             this.setMergingStrategyByModel(modelFullName, result.value.nextMerging);
         }
@@ -803,7 +809,8 @@ export class NangoSyncRunner extends NangoSyncBase<never, never, ZodCheckpoint> 
             bytesReceived: Buffer.byteLength(JSON.stringify(res.value), 'utf8'),
             integrationId: this.providerConfigKey,
             connectionId: this.connectionId,
-            syncId: this.syncId
+            syncId: this.syncId,
+            count: 1
         });
 
         return { records: res.value.records as NangoRecord<T>[], next_cursor: res.value.nextCursor ?? null };

--- a/packages/runner/lib/telemetry.ts
+++ b/packages/runner/lib/telemetry.ts
@@ -29,7 +29,8 @@ const telemetryGrouping: Grouping<RunnerTelemetry> = {
                     integrationId: event.integrationId,
                     syncId: event.syncId,
                     bytesSent: Math.min(_acc.bytesSent + event.bytesSent, Number.MAX_SAFE_INTEGER),
-                    bytesReceived: Math.min(_acc.bytesReceived + event.bytesReceived, Number.MAX_SAFE_INTEGER)
+                    bytesReceived: Math.min(_acc.bytesReceived + event.bytesReceived, Number.MAX_SAFE_INTEGER),
+                    count: _acc.count + event.count
                 };
             default:
                 throw new Error(`Unsupported telemetry type: ${event.type}`);

--- a/packages/server/lib/controllers/proxy/allProxy.ts
+++ b/packages/server/lib/controllers/proxy/allProxy.ts
@@ -15,7 +15,7 @@ import {
     errorManager,
     getProvider,
     getProxyConfiguration,
-    makeDataTransferEvents,
+    makeDataTransferEvent,
     pubsub,
     refreshOrTestCredentials
 } from '@nangohq/shared';
@@ -318,19 +318,18 @@ export const allPublicProxy = asyncWrapper<AllPublicProxy>(async (req, res, next
                 custom: integration.custom
             }),
             onBytes: (meteredBytes) => {
-                const events = makeDataTransferEvents(
-                    'server',
-                    'proxy',
-                    account.id,
-                    connection.connection_id,
-                    providerConfigKey,
-                    environment.id,
-                    meteredBytes,
-                    environment.name
+                void pubsub.publisher.publish(
+                    makeDataTransferEvent({
+                        pkg: 'server',
+                        callsite: 'proxy',
+                        accountId: account.id,
+                        connectionId: connection.connection_id,
+                        integrationId: providerConfigKey,
+                        environmentId: environment.id,
+                        meteredBytes,
+                        environmentName: environment.name
+                    })
                 );
-                if (events.length > 0) {
-                    void pubsub.publisher.publishBatch({ subject: 'usage', events });
-                }
             }
         });
 

--- a/packages/server/lib/hooks/connection/credentials-verification-script.ts
+++ b/packages/server/lib/hooks/connection/credentials-verification-script.ts
@@ -1,6 +1,6 @@
 import tracer from 'dd-trace';
 
-import { ProxyRequest, getProvider, getProxyConfiguration, makeDataTransferEvents, pubsub } from '@nangohq/shared';
+import { ProxyRequest, getProvider, getProxyConfiguration, makeDataTransferEvent, pubsub } from '@nangohq/shared';
 
 import * as verificationscriptHandlers from './index.js';
 
@@ -116,18 +116,17 @@ async function execute(
                         oauth_client_secret: null
                     }),
                     onBytes: (meteredBytes) => {
-                        const events = makeDataTransferEvents(
-                            'server',
-                            'credential_verification_hook',
-                            accountId,
-                            connectionId,
-                            config.unique_key,
-                            config.environment_id,
-                            meteredBytes
+                        void pubsub.publisher.publish(
+                            makeDataTransferEvent({
+                                pkg: 'server',
+                                callsite: 'credential_verification_hook',
+                                accountId,
+                                connectionId,
+                                integrationId: config.unique_key,
+                                environmentId: config.environment_id,
+                                meteredBytes
+                            })
                         );
-                        if (events.length > 0) {
-                            void pubsub.publisher.publishBatch({ subject: 'usage', events });
-                        }
                     }
                 });
                 return (await proxy.request()).unwrap();

--- a/packages/server/lib/hooks/connection/internal-nango.ts
+++ b/packages/server/lib/hooks/connection/internal-nango.ts
@@ -1,4 +1,4 @@
-import { ProxyRequest, configService, connectionService, getProxyConfiguration, makeDataTransferEvents, pubsub } from '@nangohq/shared';
+import { ProxyRequest, configService, connectionService, getProxyConfiguration, makeDataTransferEvent, pubsub } from '@nangohq/shared';
 
 import type { Config } from '@nangohq/shared';
 import type { ConnectionConfig, DBConnectionDecrypted, InternalProxyConfiguration, Provider, UserProvidedProxyConfiguration } from '@nangohq/types';
@@ -53,18 +53,17 @@ export function getInternalNango(connection: DBConnectionDecrypted, providerName
                     return { oauth_client_id: null, oauth_client_secret: null };
                 },
                 onBytes: (meteredBytes) => {
-                    const events = makeDataTransferEvents(
-                        'server',
-                        'connection_hook',
-                        accountId,
-                        connection.connection_id,
-                        connection.provider_config_key,
-                        connection.environment_id,
-                        meteredBytes
+                    void pubsub.publisher.publish(
+                        makeDataTransferEvent({
+                            pkg: 'server',
+                            callsite: 'connection_hook',
+                            accountId,
+                            connectionId: connection.connection_id,
+                            integrationId: connection.provider_config_key,
+                            environmentId: connection.environment_id,
+                            meteredBytes
+                        })
                     );
-                    if (events.length > 0) {
-                        void pubsub.publisher.publishBatch({ subject: 'usage', events });
-                    }
                 }
             });
             const response = (await proxyInstance.request()).unwrap();

--- a/packages/server/lib/hooks/hooks.ts
+++ b/packages/server/lib/hooks/hooks.ts
@@ -9,7 +9,7 @@ import {
     errorNotificationService,
     externalWebhookService,
     getProxyConfiguration,
-    makeDataTransferEvents,
+    makeDataTransferEvent,
     productTracking,
     pubsub,
     syncManager
@@ -449,18 +449,17 @@ export async function credentialsTest({
                     oauth_client_secret: config.oauth_client_secret
                 }),
                 onBytes: (meteredBytes) => {
-                    const events = makeDataTransferEvents(
-                        'server',
-                        'credential_test_hook',
-                        logCtx.accountId,
-                        connectionId,
-                        config.unique_key,
-                        config.environment_id,
-                        meteredBytes
+                    void pubsub.publisher.publish(
+                        makeDataTransferEvent({
+                            pkg: 'server',
+                            callsite: 'credential_test_hook',
+                            accountId: logCtx.accountId,
+                            connectionId,
+                            integrationId: config.unique_key,
+                            environmentId: config.environment_id,
+                            meteredBytes
+                        })
                     );
-                    if (events.length > 0) {
-                        void pubsub.publisher.publishBatch({ subject: 'usage', events });
-                    }
                 }
             });
 

--- a/packages/server/lib/webhook/webhook.manager.ts
+++ b/packages/server/lib/webhook/webhook.manager.ts
@@ -1,7 +1,7 @@
 import tracer from 'dd-trace';
 
 import db from '@nangohq/database';
-import { NangoError, customerKeyService, externalWebhookService, getProvider, makeDataTransferEvents, pubsub } from '@nangohq/shared';
+import { NangoError, customerKeyService, externalWebhookService, getProvider, makeDataTransferEvent, pubsub } from '@nangohq/shared';
 import { Err, getLogger } from '@nangohq/utils';
 import { forwardWebhook } from '@nangohq/webhooks';
 
@@ -135,16 +135,16 @@ export async function routeWebhook({
             logContextGetter,
             onBytes: (bytes, connectionId) => {
                 pendingEvents.push(
-                    ...makeDataTransferEvents(
-                        'server',
-                        'webhook_forward',
-                        account.id,
+                    makeDataTransferEvent({
+                        pkg: 'server',
+                        callsite: 'webhook_forward',
+                        accountId: account.id,
                         connectionId,
-                        integration.unique_key,
-                        environment.id,
-                        bytes,
-                        environment.name
-                    )
+                        integrationId: integration.unique_key,
+                        environmentId: environment.id,
+                        meteredBytes: bytes,
+                        environmentName: environment.name
+                    })
                 );
             }
         })

--- a/packages/shared/lib/index.ts
+++ b/packages/shared/lib/index.ts
@@ -45,7 +45,7 @@ export * from './services/providers.js';
 export * from './services/proxy/utils.js';
 export * from './services/proxy/request.js';
 export { type MeteredBytes, createMeteringTransport } from './services/proxy/byte-metering-transport.js';
-export { makeDataTransferEvents } from './services/proxy/data-transfer-event.js';
+export { makeDataTransferEvent } from './services/proxy/data-transfer-event.js';
 export * from './services/plans/plans.js';
 export * from './services/plans/definitions.js';
 export * from './services/checkpoints/checkpoints.js';

--- a/packages/shared/lib/services/proxy/byte-metering-transport.ts
+++ b/packages/shared/lib/services/proxy/byte-metering-transport.ts
@@ -54,6 +54,10 @@ function withSocketMetering(nativeModule: NativeProtocolModule, onHopBytes: (byt
                     received: sock ? Math.max(0, sock.bytesRead - startRead) : 0
                 };
 
+                if (bytes.sent === 0 && bytes.received === 0) {
+                    return;
+                }
+
                 try {
                     onHopBytes(bytes);
                 } catch {

--- a/packages/shared/lib/services/proxy/byte-metering-transport.unit.test.ts
+++ b/packages/shared/lib/services/proxy/byte-metering-transport.unit.test.ts
@@ -215,6 +215,21 @@ describe('createMeteringTransport (socket bytes)', () => {
         expect(fires).toHaveLength(1);
     });
 
+    it('does not fire onBytes when request is destroyed before any bytes are written', async () => {
+        handle = await startServer((_req, res) => res.end('ok'));
+        const { port } = handle;
+
+        const fires: MeteredBytes[] = [];
+        const transport = createMeteringTransport((c) => fires.push({ ...c }));
+        // Destroy before req.end() so no HTTP headers are flushed — sent and received both remain 0.
+        const req = transport.request({ host: '127.0.0.1', port, method: 'GET', path: '/' }, () => {});
+        req.destroy();
+        req.on('error', () => {});
+
+        await new Promise((resolve) => setTimeout(resolve, 50));
+        expect(fires).toHaveLength(0);
+    });
+
     it('produces independent deltas across sequential requests on a keep-alive agent', async () => {
         let callCount = 0;
         const largeBody = Buffer.alloc(2000, 'a');
@@ -315,6 +330,40 @@ describe('createMeteringTransport (socket bytes)', () => {
                 await closeServer(targetHandle);
             }
         });
+    });
+
+    it('does not fire onBytes when keep-alive socket reuse produces zero byte delta', async () => {
+        // A keep-alive socket may already have bytesRead/bytesWritten > 0 from a prior request.
+        // If the next request completes with 0 delta bytes (e.g. aborted before any I/O), onBytes
+        // must not fire to avoid emitting a zero-value event to the metering pipeline.
+        handle = await startServer((_req, res) => res.end('ok'));
+        const agent = new http.Agent({ keepAlive: true });
+
+        const fires: MeteredBytes[] = [];
+        const transport = createMeteringTransport((c) => fires.push({ ...c }));
+        const { port } = handle;
+
+        // First request — establishes the keep-alive connection and accumulates socket bytes.
+        await new Promise<void>((resolve, reject) => {
+            const req = transport.request({ agent, host: '127.0.0.1', port, method: 'GET', path: '/' }, (res) => {
+                void drainResponse(res)
+                    .then(() => resolve())
+                    .catch(reject);
+            });
+            req.on('error', reject);
+            req.end();
+        });
+        const firstFires = fires.length;
+
+        // Simulate a request that would produce startRead === sock.bytesRead by destroying the socket
+        // immediately — the delta for sent and received both remain 0, so onBytes must be suppressed.
+        const req2 = transport.request({ agent, host: '127.0.0.1', port, method: 'GET', path: '/' }, () => {});
+        req2.destroy();
+        await new Promise((resolve) => setTimeout(resolve, 50));
+
+        // Only the first request should have fired; the destroyed request had 0-byte delta.
+        expect(fires).toHaveLength(firstFires);
+        agent.destroy();
     });
 
     it('does not double-fire when both request write and response read complete', async () => {

--- a/packages/shared/lib/services/proxy/data-transfer-event.ts
+++ b/packages/shared/lib/services/proxy/data-transfer-event.ts
@@ -1,5 +1,5 @@
 import type { MeteredBytes } from './byte-metering-transport.js';
-import type { UsageDataTransferEvent } from '@nangohq/types';
+import type { DataTransferCallsite, UsageDataTransferEvent } from '@nangohq/types';
 
 export function makeDataTransferEvent({
     pkg,
@@ -14,7 +14,7 @@ export function makeDataTransferEvent({
     count = 1
 }: {
     pkg: 'runner' | 'server' | 'shared';
-    callsite: string;
+    callsite: DataTransferCallsite;
     accountId: number;
     connectionId: string;
     integrationId: string;

--- a/packages/shared/lib/services/proxy/data-transfer-event.ts
+++ b/packages/shared/lib/services/proxy/data-transfer-event.ts
@@ -1,40 +1,46 @@
 import type { MeteredBytes } from './byte-metering-transport.js';
 import type { UsageDataTransferEvent } from '@nangohq/types';
 
-export function makeDataTransferEvents(
-    pkg: 'runner' | 'server' | 'shared',
-    callsite: string,
-    accountId: number,
-    connectionId: string,
-    integrationId: string,
-    environmentId: number,
-    meteredBytes: MeteredBytes,
-    environmentName?: string,
-    syncId?: string
-): Omit<UsageDataTransferEvent, 'idempotencyKey' | 'createdAt'>[] {
-    const events = [
-        { direction: 'ingress' as const, bytes: meteredBytes.received },
-        { direction: 'egress' as const, bytes: meteredBytes.sent }
-    ]
-        .filter((e) => e.bytes > 0)
-        .map((event) => ({
-            subject: 'usage' as const,
-            type: 'usage.data_transfer' as const,
-            payload: {
-                value: event.bytes,
-                properties: {
-                    package: pkg,
-                    accountId,
-                    environmentId,
-                    environmentName: environmentName ?? '',
-                    integrationId,
-                    connectionId,
-                    callsite,
-                    direction: event.direction,
-                    ...(syncId ? { syncId } : {})
-                }
+export function makeDataTransferEvent({
+    pkg,
+    callsite,
+    accountId,
+    connectionId,
+    integrationId,
+    environmentId,
+    meteredBytes,
+    environmentName,
+    syncId,
+    count = 1
+}: {
+    pkg: 'runner' | 'server' | 'shared';
+    callsite: string;
+    accountId: number;
+    connectionId: string;
+    integrationId: string;
+    environmentId: number;
+    meteredBytes: MeteredBytes;
+    environmentName?: string;
+    syncId?: string;
+    count?: number;
+}): Omit<UsageDataTransferEvent, 'idempotencyKey' | 'createdAt'> {
+    return {
+        subject: 'usage' as const,
+        type: 'usage.data_transfer' as const,
+        payload: {
+            value: count,
+            properties: {
+                package: pkg,
+                accountId,
+                environmentId,
+                environmentName: environmentName ?? '',
+                integrationId,
+                connectionId,
+                callsite,
+                ingressedBytes: meteredBytes.received,
+                egressedBytes: meteredBytes.sent,
+                ...(syncId ? { syncId } : {})
             }
-        }));
-
-    return events;
+        }
+    };
 }

--- a/packages/types/lib/persist/api.ts
+++ b/packages/types/lib/persist/api.ts
@@ -26,6 +26,7 @@ export type RunnerDataTransferTelemetry = WithTags<{
     callsite: 'proxy' | 'uncontrolled_fetch' | 'persist_records' | 'persist_logs';
     bytesSent: number;
     bytesReceived: number;
+    count: number;
 }>;
 
 // NOTE: discriminated union on `type`; add more telemetry types as needed.

--- a/packages/types/lib/pubsub/events.ts
+++ b/packages/types/lib/pubsub/events.ts
@@ -159,7 +159,8 @@ export type UsageDataTransferEvent = UsageEventBase<
         properties: {
             package: 'server' | 'runner' | 'shared';
             callsite: string;
-            direction: 'ingress' | 'egress';
+            ingressedBytes: number;
+            egressedBytes: number;
             syncId?: string;
         };
     }

--- a/packages/types/lib/pubsub/events.ts
+++ b/packages/types/lib/pubsub/events.ts
@@ -152,13 +152,23 @@ export type UsageWebhookForwardEvent = UsageEventBase<
     }
 >;
 
+export type DataTransferCallsite =
+    | 'credential_test_hook'
+    | 'credential_verification_hook'
+    | 'connection_hook'
+    | 'webhook_forward'
+    | 'proxy'
+    | 'uncontrolled_fetch'
+    | 'persist_logs'
+    | 'persist_records';
+
 export type UsageDataTransferEvent = UsageEventBase<
     'usage.data_transfer',
     {
         value: number;
         properties: {
             package: 'server' | 'runner' | 'shared';
-            callsite: string;
+            callsite: DataTransferCallsite;
             ingressedBytes: number;
             egressedBytes: number;
             syncId?: string;


### PR DESCRIPTION
Single event with `ingressedBytes`/`egressedBytes` replaces two per-direction events. event.payload.value now carries request count; bytes moved to properties. Halves pubsub volume and keeps directions correlated per call.
