### PR TITLE
chore(metering): increase subscribe concurrency

### DIFF
--- a/packages/metering/lib/processors/usage.ts
+++ b/packages/metering/lib/processors/usage.ts
@@ -30,6 +30,7 @@ export class UsageProcessor {
         this.subscriber.subscribe({
             consumerGroup: 'billing', // Legacy name for backward compatibility and avoid processing duplication
             subject: 'usage',
+            concurrency: 4,
             callback: async (event) => {
                 const result = await this.process(event);
                 if (result.isErr()) {


### PR DESCRIPTION
Increase `subscribe` concurrency (to 4) for the `usage` subject.

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/NangoHQ/nango/pull/6564?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

