### PR TITLE
Check deploy status from Slack with /deploy status

### DIFF
--- a/.github/workflows/deploy-status-snapshot.yaml
+++ b/.github/workflows/deploy-status-snapshot.yaml
@@ -1,0 +1,49 @@
+name: 'Deploy status snapshot'
+run-name: 'Refresh deploy-status snapshot'
+
+# Keeps the deploy-status snapshot in S3 fresh so `/deploy status` in Slack is an instant read.
+# Recomputes on the only events that change deploy state: a merge to master, and a deploy
+# completing. No cron — master pushes are frequent enough to keep relative dates current.
+on:
+    push:
+        branches:
+            - master
+    workflow_run:
+        workflows: ['[Release] Deploy service']
+        types:
+            - completed
+    workflow_dispatch:
+
+permissions:
+    id-token: write # assume the AWS OIDC role to write to S3
+    contents: read
+
+# Only the latest state matters; collapse bursts of merges/deploys.
+concurrency:
+    group: deploy-status-snapshot
+    cancel-in-progress: true
+
+jobs:
+    snapshot:
+        runs-on: ubuntu-latest
+        steps:
+            - name: Checkout
+              uses: actions/checkout@v4
+              with:
+                  fetch-depth: 0 # the engine walks history to compute drift
+            - name: Setup Node.js
+              uses: ./.github/actions/setup-node
+            - name: Install dependencies
+              run: npm ci
+            - name: Generate snapshot
+              env:
+                  GH_TOKEN: ${{ github.token }} # the engine reads deploy run history + PRs via gh
+              run: npx tsx scripts/deploy-status/snapshot.ts > deploy-status.json
+            - name: Configure AWS credentials
+              uses: aws-actions/configure-aws-credentials@v4
+              with:
+                  role-to-assume: ${{ vars.DEPLOY_STATUS_ROLE }}
+                  role-session-name: GitHub_to_AWS_via_FederatedOIDC
+                  aws-region: ${{ vars.AWS_REGION }}
+            - name: Upload snapshot to S3
+              run: aws s3 cp deploy-status.json s3://${{ vars.DEPLOY_STATUS_BUCKET }}/deploy-status.json --content-type application/json

--- a/package.json
+++ b/package.json
@@ -59,7 +59,8 @@
         "changelog:providers": "tsx scripts/provider-changelog.ts",
         "changelog:integrations": "tsx scripts/pre-built-integrations-changelog.ts",
         "deploy:status": "tsx scripts/deploy-status/cli.ts",
-        "deploy:affected": "tsx scripts/deploy-status/affected.ts"
+        "deploy:affected": "tsx scripts/deploy-status/affected.ts",
+        "deploy:snapshot": "tsx scripts/deploy-status/snapshot.ts"
     },
     "devDependencies": {
         "@eslint/js": "9.28.0",

--- a/scripts/deploy-status/cli.ts
+++ b/scripts/deploy-status/cli.ts
@@ -1,22 +1,19 @@
 /**
- * Show, per environment × service, which master commit is live, when it was deployed, who authored
- * it, and how many commits that DIRECTLY touch that service are not yet deployed.
+ * Show, per environment × service, which master commit is live, when it was deployed, and how many
+ * commits that DIRECTLY touch that service are not yet deployed.
  *
  *   tsx scripts/deploy-status/cli.ts [--env dev|staging|prod] [--service <key>] [--verbose] [--json]
  *
- * Deployed SHAs + dates come from the deploy workflow run history (gh); drift is computed locally
- * against origin/master. Commit SHAs are clickable links to GitHub in terminals that support it.
+ * Data comes from collectStatus(); this file only renders it for the terminal. Commit SHAs are
+ * clickable links to GitHub in terminals that support it.
  */
 import { parseArgs } from 'node:util';
 
 import chalk from 'chalk';
 
-import { computeDrift, ensureFetched, latestDirectCommit, prefetchCommits } from './engine.ts';
-import { SERVICES, buildMappingContext } from './services.ts';
-import { ENVIRONMENTS, fetchDeployRuns, fetchPullRequests, latestDeploy } from './sources.ts';
+import { collectStatus } from './report.ts';
 
-import type { CommitInfo, Drift } from './engine.ts';
-import type { DeployedRef } from './sources.ts';
+import type { ServiceStatus } from './report.ts';
 
 const GITHUB_COMMIT_BASE = 'https://github.com/NangoHQ/nango/commit';
 const GITHUB_PR_BASE = 'https://github.com/NangoHQ/nango/pull';
@@ -80,29 +77,25 @@ function ageDays(iso: string): number {
     return (Date.now() - new Date(iso).getTime()) / 86_400_000;
 }
 
-function directCount(drift: Drift | null): number {
-    return drift ? drift.undeployed.filter((c) => c.reason === 'direct').length : 0;
-}
-
-interface Status {
+interface Cell {
     plain: string; // unstyled, used for column width
     color: (s: string) => string;
     link?: { label: string; url: string }; // a substring of `plain` to turn into a hyperlink
 }
 
-// Status text + colour. "behind" counts only commits that directly touch the service; 0 direct →
-// up to date. Feature-branch deploys are labelled by their PR ("PR #1234") when one can be resolved.
-function statusOf(ref: DeployedRef, drift: Drift | null, prNumber?: number): Status {
-    if (!ref.sha || !drift) return { plain: 'unknown', color: chalk.gray };
-    if (drift.status === 'orphaned') return { plain: 'orphaned', color: chalk.red };
+// "behind" counts only commits that directly touch the service; 0 direct → up to date. Feature-branch
+// deploys are labelled by their PR ("PR #1234") when one can be resolved.
+function statusOf(s: ServiceStatus): Cell {
+    if (!s.deployedSha || s.status === null) return { plain: 'unknown', color: chalk.gray };
+    if (s.status === 'orphaned') return { plain: 'orphaned', color: chalk.red };
 
-    const direct = directCount(drift);
+    const direct = s.directBehind ?? 0;
     const behind = direct > 0 ? `, ${direct} behind` : ', current';
 
-    if (drift.status === 'feature-branch') {
-        if (prNumber) {
-            const label = `PR #${prNumber}`;
-            return { plain: `${label}${behind}`, color: chalk.cyan, link: { label, url: `${GITHUB_PR_BASE}/${prNumber}` } };
+    if (s.status === 'feature-branch') {
+        if (s.pr) {
+            const label = `PR #${s.pr}`;
+            return { plain: `${label}${behind}`, color: chalk.cyan, link: { label, url: `${GITHUB_PR_BASE}/${s.pr}` } };
         }
         return { plain: `feature-branch${behind}`, color: chalk.cyan };
     }
@@ -110,143 +103,62 @@ function statusOf(ref: DeployedRef, drift: Drift | null, prNumber?: number): Sta
     return direct === 0 ? { plain: 'up to date', color: chalk.green } : { plain: `${direct} behind`, color: chalk.yellow };
 }
 
-function renderStatus(s: Status, width: number): string {
+function renderStatus(s: Cell, width: number): string {
     const body = s.link ? s.plain.replace(s.link.label, link(s.link.label, s.link.url)) : s.plain;
     return s.color(body) + ' '.repeat(Math.max(0, width - s.plain.length));
 }
 
 // Relative deploy date; coloured by staleness only when there ARE direct commits waiting to ship.
-function dateOf(ref: DeployedRef, drift: Drift | null): { plain: string; color: (s: string) => string } {
-    if (!ref.date) return { plain: '', color: chalk.dim };
-    const plain = relativeTime(ref.date);
-    if (directCount(drift) > 0) {
-        const days = ageDays(ref.date);
+function dateOf(s: ServiceStatus): { plain: string; color: (str: string) => string } {
+    if (!s.deployedAt) return { plain: '', color: chalk.dim };
+    const plain = relativeTime(s.deployedAt);
+    if ((s.directBehind ?? 0) > 0) {
+        const days = ageDays(s.deployedAt);
         if (days >= 14) return { plain, color: chalk.red };
         if (days >= 7) return { plain, color: chalk.yellow };
     }
     return { plain, color: chalk.dim };
 }
 
-interface DisplayRow {
-    key: string;
-    deployedSha: string | null;
-    date: { plain: string; color: (s: string) => string };
-    status: Status;
-    undeployed: CommitInfo[];
-}
-
 async function main(): Promise<void> {
     const start = Date.now();
     const flags = parseFlags();
-    const envFilter = flags.env;
-    const serviceFilter = flags.service;
-    const verbose = flags.verbose;
-    const asJson = flags.json;
 
-    const envs = ENVIRONMENTS.filter((e) => !envFilter || e.name === envFilter);
-    const services = SERVICES.filter((s) => !serviceFilter || s.key === serviceFilter);
-    if (envs.length === 0) throw new Error(`Unknown --env "${envFilter}". Valid: ${ENVIRONMENTS.map((e) => e.name).join(', ')}`);
-    if (services.length === 0) throw new Error(`Unknown --service "${serviceFilter}". Valid: ${SERVICES.map((s) => s.key).join(', ')}`);
+    const data = await collectStatus({ envName: flags.env, serviceKey: flags.service });
 
-    await ensureFetched();
-    const ctx = buildMappingContext();
-
-    let runs: Awaited<ReturnType<typeof fetchDeployRuns>> = [];
-    try {
-        runs = await fetchDeployRuns();
-    } catch (err) {
-        console.error(chalk.red(String(err)));
-    }
-
-    const plan = envs.map((env) => ({ env, items: services.map((service) => ({ service, ref: latestDeploy(runs, env.stage, service.key) })) }));
-    const deployedShas = plan.flatMap((p) => p.items.map((i) => i.ref.sha).filter((s): s is string => Boolean(s)));
-
-    // Fetch all deployed commits up front so drift can be computed concurrently below.
-    await prefetchCommits(deployedShas);
-
-    const [byEnv, latestByService] = await Promise.all([
-        Promise.all(
-            plan.map(async ({ env, items }) => ({
-                env,
-                rows: await Promise.all(
-                    items.map(async ({ service, ref }) => ({
-                        service,
-                        ref,
-                        drift: ref.sha ? await computeDrift(ref.sha, service, ctx, { skipFetch: true }) : null
-                    }))
-                )
-            }))
-        ),
-        Promise.all(services.map(async (s) => [s.key, await latestDirectCommit(s)] as const)).then((entries) => new Map(entries))
-    ]);
-
-    // Resolve PR numbers for feature-branch deploys so we can show "PR #1234" instead of "feature-branch".
-    const featureBranchShas = byEnv.flatMap(({ rows }) =>
-        rows.filter((r) => r.drift?.status === 'feature-branch' && r.ref.sha).map((r) => r.ref.sha as string)
-    );
-    const prNumbers = await fetchPullRequests(featureBranchShas);
-
-    if (asJson) {
-        console.log(
-            JSON.stringify(
-                byEnv.map(({ env, rows }) => ({
-                    env: env.name,
-                    services: rows.map(({ service, ref, drift }) => ({
-                        service: service.key,
-                        deployedSha: ref.sha,
-                        deployedAt: ref.date,
-                        pr: ref.sha ? (prNumbers.get(ref.sha) ?? null) : null,
-                        status: drift?.status ?? null,
-                        directBehind: drift ? directCount(drift) : null,
-                        totalBehind: drift?.undeployed.length ?? null,
-                        latestDirect: latestByService.get(service.key)?.sha ?? null,
-                        undeployed: drift?.undeployed ?? []
-                    }))
-                })),
-                null,
-                2
-            )
-        );
+    if (flags.json) {
+        console.log(JSON.stringify(data, null, 2));
         console.error(chalk.dim(`Finished in ${((Date.now() - start) / 1000).toFixed(0)}s`));
         return;
     }
 
-    // Build display rows, then size columns to the widest content so nothing shifts.
-    const display = byEnv.map(({ env, rows }) => ({
-        env,
-        rows: rows.map(
-            ({ service, ref, drift }): DisplayRow => ({
-                key: service.key,
-                deployedSha: ref.sha,
-                date: dateOf(ref, drift),
-                status: statusOf(ref, drift, ref.sha ? prNumbers.get(ref.sha) : undefined),
-                undeployed: drift?.undeployed ?? []
-            })
-        )
+    // Precompute cells, then size columns to the widest content so nothing shifts.
+    const display = data.map((env) => ({
+        env: env.env,
+        rows: env.services.map((s) => ({ s, date: dateOf(s), status: statusOf(s) }))
     }));
     const all = display.flatMap((d) => d.rows);
-    const wKey = Math.max(...all.map((r) => r.key.length));
+    const wKey = Math.max(...all.map((r) => r.s.service.length));
     const wDate = Math.max(0, ...all.map((r) => r.date.plain.length));
     const wStatus = Math.max(...all.map((r) => r.status.plain.length));
-    const anyBehind = all.some((r) => r.undeployed.some((c) => c.reason === 'direct'));
+    const anyBehind = all.some((r) => (r.s.directBehind ?? 0) > 0);
 
     for (const { env, rows } of display) {
         // "latest" is env-independent, so show it in just one group: prod when all envs are shown,
         // otherwise the single env that's displayed.
-        const showLatest = envs.length === 1 || env.name === 'prod';
-        console.log(chalk.bold.underline(`\n${env.name}`));
-        for (const r of rows) {
-            const directBehind = r.undeployed.filter((c) => c.reason === 'direct');
-            const deployed = r.deployedSha ? commitLink(r.deployedSha) : chalk.gray('—'.padEnd(9));
-            const date = r.date.color(r.date.plain.padEnd(wDate));
-            const stat = renderStatus(r.status, wStatus);
-            const latest = latestByService.get(r.key);
-            const latestCell = showLatest && directBehind.length > 0 && latest ? `${chalk.dim('latest')} ${commitLink(latest.sha)}` : '';
-            console.log(`  ${chalk.bold(r.key.padEnd(wKey))}  ${deployed}  ${date}  ${stat}  ${latestCell}`);
+        const showLatest = display.length === 1 || env === 'prod';
+        console.log(chalk.bold.underline(`\n${env}`));
+        for (const { s, date, status } of rows) {
+            const directBehind = s.undeployed.filter((c) => c.reason === 'direct');
+            const deployed = s.deployedSha ? commitLink(s.deployedSha) : chalk.gray('—'.padEnd(9));
+            const dateCell = date.color(date.plain.padEnd(wDate));
+            const statusCell = renderStatus(status, wStatus);
+            const latestCell = showLatest && directBehind.length > 0 && s.latestDirect ? `${chalk.dim('latest')} ${commitLink(s.latestDirect)}` : '';
+            console.log(`  ${chalk.bold(s.service.padEnd(wKey))}  ${deployed}  ${dateCell}  ${statusCell}  ${latestCell}`);
 
             // --verbose lists the direct (counted) commits behind as a tree under the service, so
             // they're easy to associate. Commit hash + title, both the hash and PR ref clickable.
-            if (verbose) {
+            if (flags.verbose) {
                 directBehind.forEach((c, i) => {
                     const branch = i === directBehind.length - 1 ? '└──' : '├──';
                     console.log(`  ${chalk.dim(branch)} ${commitLink(c.sha)} ${linkifyPr(c.subject)}`);
@@ -255,7 +167,7 @@ async function main(): Promise<void> {
         }
     }
 
-    if (anyBehind && !verbose) {
+    if (anyBehind && !flags.verbose) {
         console.log(chalk.dim('\nTip: add --verbose to list the undeployed commits behind each service (and --env <dev|staging|prod> to focus on one).'));
     }
     console.error(chalk.dim(`\nFinished in ${((Date.now() - start) / 1000).toFixed(0)}s`));

--- a/scripts/deploy-status/report.ts
+++ b/scripts/deploy-status/report.ts
@@ -1,0 +1,90 @@
+/**
+ * Gather the deploy-status data once, as plain structured values. This is the single source the
+ * terminal CLI, the snapshot producer, and (via the snapshot) the Slack renderer all consume.
+ * Timestamps are absolute ISO strings — relative formatting is left to each renderer so it stays
+ * accurate at display time.
+ */
+import { computeDrift, ensureFetched, latestDirectCommit, prefetchCommits } from './engine.ts';
+import { SERVICES, buildMappingContext } from './services.ts';
+import { ENVIRONMENTS, fetchDeployRuns, fetchPullRequests, latestDeploy } from './sources.ts';
+
+import type { CommitInfo, DeployStatus } from './engine.ts';
+
+export interface ServiceStatus {
+    service: string; // service key
+    deployedSha: string | null;
+    deployedAt: string | null; // ISO timestamp of the deploy
+    pr: number | null; // PR for a feature-branch deploy, if resolved
+    status: DeployStatus | null;
+    directBehind: number | null; // commits directly touching the service, undeployed
+    totalBehind: number | null; // all undeployed commits affecting it (direct + via-shared)
+    latestDirect: string | null; // sha of the latest commit on master touching the service
+    undeployed: CommitInfo[];
+}
+
+export interface EnvStatus {
+    env: string;
+    services: ServiceStatus[];
+}
+
+export async function collectStatus(opts: { envName?: string; serviceKey?: string } = {}): Promise<EnvStatus[]> {
+    const envs = ENVIRONMENTS.filter((e) => !opts.envName || e.name === opts.envName);
+    const services = SERVICES.filter((s) => !opts.serviceKey || s.key === opts.serviceKey);
+    if (envs.length === 0) throw new Error(`Unknown env "${opts.envName}". Valid: ${ENVIRONMENTS.map((e) => e.name).join(', ')}`);
+    if (services.length === 0) throw new Error(`Unknown service "${opts.serviceKey}". Valid: ${SERVICES.map((s) => s.key).join(', ')}`);
+
+    await ensureFetched();
+    const ctx = buildMappingContext();
+
+    let runs: Awaited<ReturnType<typeof fetchDeployRuns>> = [];
+    try {
+        runs = await fetchDeployRuns();
+    } catch (err) {
+        // Without runs, every service reads as unknown; surface the reason but don't crash.
+        console.error(String(err));
+    }
+
+    const plan = envs.map((env) => ({ env, items: services.map((service) => ({ service, ref: latestDeploy(runs, env.stage, service.key) })) }));
+    const deployedShas = plan.flatMap((p) => p.items.map((i) => i.ref.sha).filter((s): s is string => Boolean(s)));
+
+    // Fetch all deployed commits up front so drift can be computed concurrently below.
+    await prefetchCommits(deployedShas);
+
+    const [byEnv, latestByService] = await Promise.all([
+        Promise.all(
+            plan.map(async ({ env, items }) => ({
+                env,
+                rows: await Promise.all(
+                    items.map(async ({ service, ref }) => ({
+                        service,
+                        ref,
+                        drift: ref.sha ? await computeDrift(ref.sha, service, ctx, { skipFetch: true }) : null
+                    }))
+                )
+            }))
+        ),
+        Promise.all(services.map(async (s) => [s.key, await latestDirectCommit(s)] as const)).then((entries) => new Map(entries))
+    ]);
+
+    const featureBranchShas = byEnv.flatMap(({ rows }) =>
+        rows.filter((r) => r.drift?.status === 'feature-branch' && r.ref.sha).map((r) => r.ref.sha as string)
+    );
+    const prNumbers = await fetchPullRequests(featureBranchShas);
+
+    return byEnv.map(({ env, rows }) => ({
+        env: env.name,
+        services: rows.map(
+            ({ service, ref, drift }): ServiceStatus => ({
+                service: service.key,
+                deployedSha: ref.sha,
+                deployedAt: ref.date,
+                pr: ref.sha ? (prNumbers.get(ref.sha) ?? null) : null,
+                status: drift?.status ?? null,
+                directBehind: drift ? drift.undeployed.filter((c) => c.reason === 'direct').length : null,
+                totalBehind: drift?.undeployed.length ?? null,
+                latestDirect: latestByService.get(service.key)?.sha ?? null,
+                undeployed: drift?.undeployed ?? []
+            })
+        )
+    }));
+}

--- a/scripts/deploy-status/snapshot.ts
+++ b/scripts/deploy-status/snapshot.ts
@@ -1,0 +1,14 @@
+/**
+ * Produce the deploy-status snapshot consumed by the Slack `/deploy status` Lambda. Writes the
+ * structured data (absolute ISO timestamps) plus a `generatedAt` to stdout as JSON, so the
+ * snapshot workflow can redirect it to a file and upload to S3:
+ *
+ *   tsx scripts/deploy-status/snapshot.ts > deploy-status.json
+ *
+ * No rendering here — the Lambda renders relative dates/colors at read time so they stay live.
+ */
+import { collectStatus } from './report.ts';
+
+const envs = await collectStatus();
+const snapshot = { generatedAt: new Date().toISOString(), envs };
+process.stdout.write(JSON.stringify(snapshot));


### PR DESCRIPTION
## Problem

The deploy-status overview (NAN-6005) only helps people who run the CLI locally. We want it in Slack, where the team already looks and shares context — and it has to feel instant, which on-demand compute (~30–50s of history scans) can't deliver.

## Solution

Serve `/deploy status` from a **precomputed snapshot**. This is the monorepo half (stacked on #6542):

- Extract `collectStatus()` so the terminal CLI, the snapshot, and the Slack renderer share one data path (no behaviour change to the CLI).
- `snapshot.ts` emits the structured snapshot — absolute ISO timestamps + `generatedAt`, no rendering — so the reader renders relative dates/colours live and they're never stale.
- `deploy-status-snapshot.yaml` refreshes the snapshot to S3 on every master push and on deploy completion (via the existing GitHub→AWS OIDC role). No cron — those events are the only ones that change deploy state.

The Function-URL Lambda that verifies the Slack signature, reads the snapshot, and renders Block Kit lives in `nango-infra` (separate PR).

Fixes [NAN-6006](https://linear.app/nango/issue/NAN-6006)

## Testing

- `npm run deploy:snapshot` → structured JSON with absolute timestamps + `generatedAt`.
- CLI still renders correctly via the refactored `collectStatus()` path; 9 mapping unit tests pass; lint clean.
- Fed a real snapshot through the Lambda's render logic (nango-infra PR) → valid Block Kit with commit/PR links, relative dates, and env filtering.

Stacked on #6542 — review after that merges, or as a stack.
