### PR TITLE
feat(usage): revet flip capping source from Orb to ClickHouse via percentage rollout

### DIFF
--- a/packages/usage/lib/usage.ts
+++ b/packages/usage/lib/usage.ts
@@ -87,10 +87,6 @@ export function resolveBillingUsageSource(accountId: number, requestedSource: 'c
     return respected ?? (shouldUseClickhouseFor(accountId) ? 'clickhouse' : 'orb');
 }
 
-export function resolveCappingSource(accountId: number): 'clickhouse' | 'orb' {
-    return accountId % 100 < envs.FLAG_CAPPING_CLICKHOUSE_ROLLOUT_PERCENTAGE ? 'clickhouse' : 'orb';
-}
-
 async function resolveEnvironmentNamesInBreakdown(
     usage: BillingUsageMetrics,
     breakdown: { [M in UsageMetric]?: BreakdownDimensions[M] | undefined } | undefined
@@ -358,10 +354,6 @@ export class UsageTracker implements IUsageTracker {
             });
         }
 
-        if (!opts?.timeframe && resolveCappingSource(accountId) === 'clickhouse') {
-            return this.getCappingUsageFromClickhouse(accountId);
-        }
-
         // Orb path: strip CH-only fields so they don't pollute the billing
         // client's Redis cache key. Orb itself ignores them, but the cache key
         // hashes the full opts and would miss on otherwise-identical queries.
@@ -458,35 +450,6 @@ export class UsageTracker implements IUsageTracker {
         }
     }
 
-    private async getCappingUsageFromClickhouse(accountId: number): Promise<Result<BillingUsageMetrics>> {
-        const cacheKey = `billing:usage:ch:${accountId}`;
-        try {
-            const cached = await this.redis.get(cacheKey);
-            if (cached) {
-                const value = JSON.parse(cached) as BillingUsageMetrics;
-                metrics.increment(metrics.Types.BILLING_USAGE_CAPPING_CH_CACHE, 1, { hit: 'true' });
-                return Ok(value);
-            }
-        } catch (err) {
-            logger.warning(`capping CH cache read failed for account=${accountId}: ${stringifyError(err)}`);
-        }
-        metrics.increment(metrics.Types.BILLING_USAGE_CAPPING_CH_CACHE, 1, { hit: 'false' });
-
-        const chResult = await this.getClickhouse().getCurrentMonthBillingMetrics(accountId, new Date());
-        if (chResult.isErr()) return Err(chResult.error);
-
-        await this.writeCappingCache(accountId, chResult.value);
-        return Ok(chResult.value);
-    }
-
-    private async writeCappingCache(accountId: number, value: BillingUsageMetrics): Promise<void> {
-        try {
-            await this.redis.set(`billing:usage:ch:${accountId}`, JSON.stringify(value), { EX: envs.USAGE_BILLING_API_CACHE_TTL_SECONDS });
-        } catch (err) {
-            logger.warning(`capping CH cache write failed for account=${accountId}: ${stringifyError(err)}`);
-        }
-    }
-
     private async shadowCappingAgainstClickhouse({ accountId, orbResult }: { accountId: number; orbResult: BillingUsageMetrics }): Promise<void> {
         const start = process.hrtime.bigint();
         const timeoutErr = new Error('shadow_timeout');
@@ -504,9 +467,14 @@ export class UsageTracker implements IUsageTracker {
         metrics.distribution(metrics.Types.BILLING_USAGE_CAPPING_SHADOW_DURATION_MS, elapsedMs, { outcome });
         if (chResult.isErr()) return;
 
-        // Populate the CH cache key so the eventual source flip from Orb to
-        // CH doesn't cold-start every account against CH on cutover.
-        await this.writeCappingCache(accountId, chResult.value);
+        // Populate `billing:usage:ch:<accountId>` so the eventual source flip
+        // from Orb to CH doesn't cold-start every account against CH on cutover.
+        const cacheKey = `billing:usage:ch:${accountId}`;
+        try {
+            await this.redis.set(cacheKey, JSON.stringify(chResult.value), { EX: envs.USAGE_BILLING_API_CACHE_TTL_SECONDS });
+        } catch (err) {
+            logger.warning(`capping shadow CH cache write failed for account=${accountId}: ${stringifyError(err)}`);
+        }
 
         // Capping path covers only COUNTER metrics — connections/records read
         // from Postgres on the capping path and aren't returned by either Orb
@@ -730,6 +698,8 @@ export class UsageTracker implements IUsageTracker {
         if (!plan.value.orb_subscription_id) {
             return Err(new Error('orb_subscription_id_missing'));
         }
+        // No timeframe / no granularity → CH path is bypassed inside
+        // getBillingUsage, capping continues to read from Orb.
         const billingUsage: Result<BillingUsageMetrics> = await this.getBillingUsage(plan.value.orb_subscription_id, accountId);
         if (billingUsage.isErr()) {
             // Note: errors (including rate limit errors) are not being retried

--- a/packages/usage/lib/usage.unit.test.ts
+++ b/packages/usage/lib/usage.unit.test.ts
@@ -3,7 +3,6 @@ import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 import { envs } from './env.js';
 import {
     resolveBillingUsageSource,
-    resolveCappingSource,
     shouldShadow,
     shouldShadowCapping,
     shouldUseClickhouseFor,
@@ -478,35 +477,5 @@ describe('resolveBillingUsageSource', () => {
         (envs as any).FLAG_BILLING_USAGE_CLICKHOUSE_ROLLOUT_ACCOUNT_IDS = '42';
         expect(resolveBillingUsageSource(42, undefined)).toBe('clickhouse');
         expect(resolveBillingUsageSource(7, undefined)).toBe('orb');
-    });
-});
-
-describe('resolveCappingSource', () => {
-    let originalPct: number;
-    beforeEach(() => {
-        originalPct = envs.FLAG_CAPPING_CLICKHOUSE_ROLLOUT_PERCENTAGE;
-    });
-    afterEach(() => {
-        (envs as any).FLAG_CAPPING_CLICKHOUSE_ROLLOUT_PERCENTAGE = originalPct;
-    });
-
-    it('returns orb when pct = 0 (killswitch)', () => {
-        (envs as any).FLAG_CAPPING_CLICKHOUSE_ROLLOUT_PERCENTAGE = 0;
-        expect(resolveCappingSource(0)).toBe('orb');
-        expect(resolveCappingSource(99)).toBe('orb');
-    });
-
-    it('returns clickhouse for every account when pct >= 100', () => {
-        (envs as any).FLAG_CAPPING_CLICKHOUSE_ROLLOUT_PERCENTAGE = 100;
-        expect(resolveCappingSource(0)).toBe('clickhouse');
-        expect(resolveCappingSource(99)).toBe('clickhouse');
-    });
-
-    it('buckets accounts by accountId % 100 < pct', () => {
-        (envs as any).FLAG_CAPPING_CLICKHOUSE_ROLLOUT_PERCENTAGE = 25;
-        expect(resolveCappingSource(24)).toBe('clickhouse');
-        expect(resolveCappingSource(25)).toBe('orb');
-        expect(resolveCappingSource(124)).toBe('clickhouse');
-        expect(resolveCappingSource(125)).toBe('orb');
     });
 });

--- a/packages/utils/lib/environment/parse.ts
+++ b/packages/utils/lib/environment/parse.ts
@@ -337,7 +337,6 @@ export const ENVS = z.object({
     FLAG_BILLING_USAGE_CAPPING_SHADOW_CLICKHOUSE_PERCENTAGE: z.coerce.number().int().min(0).max(100).optional().default(0),
     FLAG_BILLING_USAGE_CLICKHOUSE_ROLLOUT_ACCOUNT_IDS: z.string().optional().default(''),
     FLAG_BILLING_USAGE_CLICKHOUSE_ROLLOUT_PERCENTAGE: z.coerce.number().int().min(0).max(100).optional().default(0),
-    FLAG_CAPPING_CLICKHOUSE_ROLLOUT_PERCENTAGE: z.coerce.number().int().min(0).max(100).optional().default(0),
 
     // --- Third parties
     // AWS

--- a/packages/utils/lib/telemetry/metrics.ts
+++ b/packages/utils/lib/telemetry/metrics.ts
@@ -155,7 +155,6 @@ export enum Types {
     BILLING_USAGE_CAPPING_SHADOW_DIVERGENCE = 'nango.billing.usage.capping.shadow.divergence',
     BILLING_USAGE_CAPPING_SHADOW_ONE_SIDED = 'nango.billing.usage.capping.shadow.one_sided',
     BILLING_USAGE_CAPPING_SHADOW_DURATION_MS = 'nango.billing.usage.capping.shadow.duration_ms',
-    BILLING_USAGE_CAPPING_CH_CACHE = 'nango.billing.usage.capping.ch.cache',
 
     USAGE_IS_CAPPED = 'nango.capping.isCapped',
 


### PR DESCRIPTION
Reverts NangoHQ/nango#6509

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/NangoHQ/nango/pull/6569?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

