### PR TITLE
ci(tests): reuse one fork for integration tests (isolate: false)

### DIFF
--- a/vite.integration.config.ts
+++ b/vite.integration.config.ts
@@ -34,7 +34,13 @@ export default defineConfig({
         },
         fileParallelism: false,
         pool: 'forks',
-        // Vitest 4 removed test.poolOptions; poolOptions.forks.singleFork is now maxWorkers: 1.
-        maxWorkers: 1
+        // vitest 3's poolOptions.forks.singleFork ran every file in ONE long-lived fork, so the
+        // module graph was imported once. The vitest 4 equivalent is maxWorkers: 1 + isolate: false.
+        // Without isolate: false, each of the ~138 files gets a fresh fork and re-imports the whole
+        // graph (~minutes of redundant module loading, amplified by runner contention). Reusing one
+        // fork relies on the suite already being order-independent (it runs serially against shared
+        // Postgres/ES today), so no extra isolation is lost.
+        maxWorkers: 1,
+        isolate: false
     }
 });


### PR DESCRIPTION
## Problem

The `tests-integration` job slowed from ~6.5 min (early June) to 20+ min, with wild run-to-run variance (9 min vs 26 min on identical code). Root cause: the vitest 3→4 upgrade (#6315) mapped `poolOptions.forks.singleFork: true` to `maxWorkers: 1`, but those aren't equivalent. `singleFork` ran all files in one long-lived fork (module graph imported once); `maxWorkers: 1` with the default `isolate: true` gives a fresh fork per file, re-importing the entire graph ~138 times.

The tests themselves never got slower — module *loading* did. vitest's own breakdown:

| | module loading | tests |
|---|---|---|
| Pre-upgrade (vitest 3, singleFork) | `collect` 36s (once) | 235s |
| Post-upgrade, warm runner | `import` 259s | 253s |
| Post-upgrade, contended runner | `import` 1278s | 275s |

Re-doing the most expensive op (cold full-graph load) 138× also amplifies mild runner contention: on one slow June 17 run, `npm ci` was 1.5× and `ts-build` 1.3× slower, but the test step was 2.9× slower.

## Solution

Set `isolate: false` on the forks pool, restoring vitest 3's single-fork behavior so the module graph is imported once instead of per file. This collapses module-loading from ~260–1280s back toward the ~36s baseline and removes the contention amplifier.

The suite already runs serially against a shared Postgres/ES (it has `fileParallelism: false`), so it's order-independent and loses no isolation it actually relied on. The risk is a test that implicitly assumed a fresh module registry per file — CI's full run on this PR is the validator.

This is a separate, alternative fix to the sharding PR (#6568); sharding spreads the bloated cost across runners, while this removes the bloat. They can stack.

Fixes [NAN-6026](https://linear.app/nango/issue/NAN-6026)

## Testing

- CI's `tests-integration` run on this PR confirms the suite still passes with `isolate: false` and shows the new timing.
