### PR TITLE
feat(metering): add usage-events subscribe env var

### DIFF
--- a/packages/metering/lib/processors/usage.ts
+++ b/packages/metering/lib/processors/usage.ts
@@ -4,6 +4,7 @@ import { Subscriber } from '@nangohq/pubsub';
 import { connectionService } from '@nangohq/shared';
 import { Err, Ok, metrics, report, stringifyError } from '@nangohq/utils';
 
+import { envs } from '../env.js';
 import { logger } from '../utils.js';
 
 import type { Transport } from '@nangohq/pubsub';
@@ -25,11 +26,12 @@ export class UsageProcessor {
     }
 
     public start(): void {
-        logger.info('Starting usage subscriber...');
+        logger.info('Starting usage subscriber...', { concurrency: envs.METERING_USAGE_EVENTS_SUBSCRIBE_CONCURRENCY });
 
         this.subscriber.subscribe({
             consumerGroup: 'billing', // Legacy name for backward compatibility and avoid processing duplication
             subject: 'usage',
+            concurrency: envs.METERING_USAGE_EVENTS_SUBSCRIBE_CONCURRENCY,
             callback: async (event) => {
                 const result = await this.process(event);
                 if (result.isErr()) {

--- a/packages/utils/lib/environment/parse.ts
+++ b/packages/utils/lib/environment/parse.ts
@@ -92,6 +92,9 @@ export const ENVS = z.object({
     // snapshot it.
     CRON_BILLING_EVENTS_S3_HOURLY_EXPORT_MINUTE: z.coerce.number().min(-1).max(59).optional().default(-1),
 
+    // Metering
+    METERING_USAGE_EVENTS_SUBSCRIBE_CONCURRENCY: z.coerce.number().optional().default(1),
+
     // Persist
     PERSIST_SERVICE_URL: z.url().optional(),
     PERSIST_HARD_DELETE_LIMIT: z.coerce.number().int().positive().optional().default(50_000),

--- a/packages/utils/lib/environment/parse.ts
+++ b/packages/utils/lib/environment/parse.ts
@@ -93,7 +93,7 @@ export const ENVS = z.object({
     CRON_BILLING_EVENTS_S3_HOURLY_EXPORT_MINUTE: z.coerce.number().min(-1).max(59).optional().default(-1),
 
     // Metering
-    METERING_USAGE_EVENTS_SUBSCRIBE_CONCURRENCY: z.coerce.number().optional().default(1),
+    METERING_USAGE_EVENTS_SUBSCRIBE_CONCURRENCY: z.coerce.number().int().min(1).optional().default(1),
 
     // Persist
     PERSIST_SERVICE_URL: z.url().optional(),


### PR DESCRIPTION
Adds environment variable to control `UsageProcessor` subscribe concurrency.

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/NangoHQ/nango/pull/6572?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

