### PR TITLE
fix(server): get-gh-templates integration test

### DIFF
--- a/packages/server/lib/controllers/v1/integrations/providerConfigKey/flows/getFlows.integration.test.ts
+++ b/packages/server/lib/controllers/v1/integrations/providerConfigKey/flows/getFlows.integration.test.ts
@@ -66,7 +66,7 @@ describe(`GET ${route}`, () => {
         expect(scriptCreateOrUpdateFile).toMatchObject({
             description: expect.any(String),
             enabled: false,
-            endpoints: [{ group: 'Repositories', method: 'POST', path: '/actions/create-or-update-file' }],
+            endpoints: [],
             input: 'ActionInput_github_createorupdatefile',
             source: 'catalog',
             json_schema: expect.any(Object),


### PR DESCRIPTION
The integration test started failing as of
3fcb763f5c445c48ab4b5f64ed64420aa654a4b8. Updated the test case so that it does not expect the removed `endpoint` metadata.

<!-- Describe the problem and your solution --> 

<!-- Issue ticket number and link (if applicable) -->

<!-- Testing instructions (skip if just adding/editing providers) -->



<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/NangoHQ/nango/pull/6573?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

