### PR TITLE
fix(proxy): sanitize streamed response headers

### DIFF
--- a/packages/server/lib/controllers/proxy/allProxy.ts
+++ b/packages/server/lib/controllers/proxy/allProxy.ts
@@ -1,5 +1,3 @@
-import { PassThrough } from 'node:stream';
-
 import { isAxiosError } from 'axios';
 import * as z from 'zod';
 
@@ -30,7 +28,7 @@ import type { LogContext } from '@nangohq/logs';
 import type { AllPublicProxy, HTTP_METHOD, InternalProxyConfiguration, ProxyFile } from '@nangohq/types';
 import type { AxiosRequestConfig, AxiosResponse } from 'axios';
 import type { Request, Response } from 'express';
-import type { OutgoingHttpHeaders } from 'node:http';
+import type { OutgoingHttpHeader, OutgoingHttpHeaders } from 'node:http';
 import type { Readable } from 'node:stream';
 
 type ForwardedHeaders = Record<string, string>;
@@ -64,6 +62,19 @@ const PROXY_RESPONSE_HEADER_ALLOWLIST = [
     'x-request-id',
     'x-correlation-id'
 ];
+
+// Transport headers describe a single HTTP hop and must be regenerated for
+// the Nango-to-client response rather than copied from the provider response.
+const PROXY_STREAM_RESPONSE_HOP_BY_HOP_HEADERS = new Set([
+    'connection',
+    'keep-alive',
+    'proxy-authenticate',
+    'proxy-authorization',
+    'te',
+    'trailer',
+    'transfer-encoding',
+    'upgrade'
+]);
 
 export const allPublicProxy = asyncWrapper<AllPublicProxy>(async (req, res, next) => {
     const valHeaders = schemaHeaders.safeParse(req.headers);
@@ -422,6 +433,34 @@ function checkWasCompressed(responseStream: AxiosResponse): boolean | undefined 
     return ceIdx !== -1 && ceIdx + 1 < rawHeaders.length && Boolean(rawHeaders[ceIdx + 1]);
 }
 
+function isOutgoingHttpHeader(value: unknown): value is OutgoingHttpHeader {
+    return typeof value === 'string' || typeof value === 'number' || (Array.isArray(value) && value.every((item) => typeof item === 'string'));
+}
+
+function sanitizeStreamResponseHeaders(headers: Record<string, unknown>, { stripContentLength }: { stripContentLength: boolean }) {
+    const connectionHeader = headers['connection'];
+    const connectionTokens = new Set(
+        (Array.isArray(connectionHeader) ? connectionHeader.join(',') : typeof connectionHeader === 'string' ? connectionHeader : '')
+            .split(',')
+            .map((token) => token.trim().toLowerCase())
+            .filter(Boolean)
+    );
+
+    const sanitized: OutgoingHttpHeaders = {};
+    for (const [name, value] of Object.entries(headers)) {
+        const lowerName = name.toLowerCase();
+        if (
+            isOutgoingHttpHeader(value) &&
+            !PROXY_STREAM_RESPONSE_HOP_BY_HOP_HEADERS.has(lowerName) &&
+            !connectionTokens.has(lowerName) &&
+            !(stripContentLength && lowerName === 'content-length')
+        ) {
+            sanitized[name] = value;
+        }
+    }
+    return sanitized;
+}
+
 export async function handleResponse({ res, responseStream, logCtx }: { res: Response; responseStream: AxiosResponse; logCtx: LogContext }) {
     const contentDisposition = responseStream.headers['content-disposition'] || '';
     const transferEncoding = responseStream.headers['transfer-encoding'] || '';
@@ -430,15 +469,13 @@ export async function handleResponse({ res, responseStream, logCtx }: { res: Res
     const isAttachmentOrInline = /^(attachment|inline)(;|\s|$)/i.test(contentDisposition);
 
     if (isChunked || isAttachmentOrInline) {
-        const passthroughHeaders = Object.fromEntries(Object.entries(responseStream.headers)) as OutgoingHttpHeaders;
-        if (checkWasCompressed(responseStream)) {
-            // axios decompressed the response, so the `content-length` header is no longer valid
-            delete passthroughHeaders['content-length'];
-        }
-        const passThroughStream = new PassThrough();
-        responseStream.data.pipe(passThroughStream);
-        passThroughStream.pipe(res);
-        res.writeHead(responseStream.status, passthroughHeaders);
+        const responseHeaders = sanitizeStreamResponseHeaders(responseStream.headers, {
+            // Chunked framing belongs to the provider-to-Nango hop. Axios can
+            // also decompress the body, invalidating the provider's length.
+            stripContentLength: isChunked || checkWasCompressed(responseStream) === true
+        });
+        res.writeHead(responseStream.status, responseHeaders);
+        responseStream.data.pipe(res);
 
         metrics.increment(metrics.Types.PROXY_SUCCESS);
         await logCtx.success();

--- a/packages/server/lib/controllers/proxy/allProxy.ts
+++ b/packages/server/lib/controllers/proxy/allProxy.ts
@@ -437,14 +437,17 @@ function isOutgoingHttpHeader(value: unknown): value is OutgoingHttpHeader {
     return typeof value === 'string' || typeof value === 'number' || (Array.isArray(value) && value.every((item) => typeof item === 'string'));
 }
 
+function parseHeaderTokens(value: unknown): string[] {
+    const values = Array.isArray(value) ? value : [value];
+    return values
+        .flatMap((item) => (typeof item === 'string' ? item.split(',') : []))
+        .map((token) => token.trim().toLowerCase())
+        .filter(Boolean);
+}
+
 function sanitizeStreamResponseHeaders(headers: Record<string, unknown>, { stripContentLength }: { stripContentLength: boolean }) {
     const connectionHeader = headers['connection'];
-    const connectionTokens = new Set(
-        (Array.isArray(connectionHeader) ? connectionHeader.join(',') : typeof connectionHeader === 'string' ? connectionHeader : '')
-            .split(',')
-            .map((token) => token.trim().toLowerCase())
-            .filter(Boolean)
-    );
+    const connectionTokens = new Set(parseHeaderTokens(connectionHeader));
 
     const sanitized: OutgoingHttpHeaders = {};
     for (const [name, value] of Object.entries(headers)) {
@@ -465,14 +468,15 @@ export async function handleResponse({ res, responseStream, logCtx }: { res: Res
     const contentDisposition = responseStream.headers['content-disposition'] || '';
     const transferEncoding = responseStream.headers['transfer-encoding'] || '';
 
-    const isChunked = transferEncoding === 'chunked';
+    const transferEncodingTokens = parseHeaderTokens(transferEncoding);
+    const isChunked = transferEncodingTokens.includes('chunked');
     const isAttachmentOrInline = /^(attachment|inline)(;|\s|$)/i.test(contentDisposition);
 
     if (isChunked || isAttachmentOrInline) {
         const responseHeaders = sanitizeStreamResponseHeaders(responseStream.headers, {
             // Chunked framing belongs to the provider-to-Nango hop. Axios can
             // also decompress the body, invalidating the provider's length.
-            stripContentLength: isChunked || checkWasCompressed(responseStream) === true
+            stripContentLength: transferEncodingTokens.length > 0 || checkWasCompressed(responseStream) === true
         });
         res.writeHead(responseStream.status, responseHeaders);
         responseStream.data.pipe(res);

--- a/packages/server/lib/controllers/proxy/allProxy.unit.test.ts
+++ b/packages/server/lib/controllers/proxy/allProxy.unit.test.ts
@@ -221,7 +221,7 @@ describe('handleResponse', () => {
         const mockRes = createMockResponse();
         const mockResponseStream = createMockResponseStream('{"ok":true}', {
             headers: {
-                'transfer-encoding': 'chunked',
+                'transfer-encoding': 'gzip, CHUNKED',
                 'content-length': '11',
                 connection: 'keep-alive, x-provider-hop',
                 'keep-alive': 'timeout=5',

--- a/packages/server/lib/controllers/proxy/allProxy.unit.test.ts
+++ b/packages/server/lib/controllers/proxy/allProxy.unit.test.ts
@@ -217,6 +217,38 @@ describe('handleResponse', () => {
         expect(mockLogCtx.success).toHaveBeenCalled();
     });
 
+    it('should regenerate framing and strip hop-by-hop headers for a chunked response', async () => {
+        const mockRes = createMockResponse();
+        const mockResponseStream = createMockResponseStream('{"ok":true}', {
+            headers: {
+                'transfer-encoding': 'chunked',
+                'content-length': '11',
+                connection: 'keep-alive, x-provider-hop',
+                'keep-alive': 'timeout=5',
+                'x-provider-hop': 'remove-me',
+                'x-request-id': 'req-123'
+            }
+        });
+        const pipe = vi.fn((destination: Response) => {
+            expect(destination).toBe(mockRes.res);
+            expect(mockRes.res.writeHead).toHaveBeenCalled();
+            return destination;
+        });
+        mockResponseStream.data = { pipe } as unknown as Readable;
+
+        await handleResponse({ res: mockRes.res, responseStream: mockResponseStream, logCtx: mockLogCtx });
+
+        const [, headersArg] = vi.mocked(mockRes.res.writeHead).mock.calls[0]!;
+        expect(headersArg).not.toHaveProperty('transfer-encoding');
+        expect(headersArg).not.toHaveProperty('content-length');
+        expect(headersArg).not.toHaveProperty('connection');
+        expect(headersArg).not.toHaveProperty('keep-alive');
+        expect(headersArg).not.toHaveProperty('x-provider-hop');
+        expect(headersArg).toHaveProperty('x-request-id', 'req-123');
+        expect(pipe).toHaveBeenCalledWith(mockRes.res);
+        expect(mockLogCtx.success).toHaveBeenCalled();
+    });
+
     it('should preserve content-length for uncompressed attachment responses', async () => {
         const mockRes = createMockResponse();
         const mockResponseStream = createMockResponseStream('raw binary content', {


### PR DESCRIPTION
Closes #6575.

Related: #6256 and #6499. This PR is deliberately complementary to #6499: that contribution fixes forwarded **error** responses, while this change only fixes the successful streaming branch in `handleResponse`.

## What changed

- Remove standard hop-by-hop headers from successful streamed provider responses.
- Parse `Connection` and remove any additional connection-scoped headers it names.
- Remove `Content-Length` when the provider used chunked framing or Axios decompressed the body.
- Preserve a valid `Content-Length` for uncompressed attachments.
- Write the sanitized status and headers before piping the provider body directly to the client.
- Add a regression test covering conflicting framing, standard and `Connection`-nominated hop-by-hop headers, preservation of an end-to-end request ID, and write-before-pipe ordering.

## Why

This came from a live self-hosting qualification of Nango as a credential broker for Runner. The reproduction used Nango `0.70.7` (`nangohq/nango-server@sha256:041a8e747266d0d6b6132ad022dfc377e5bf8c7a5b783f055bc70fe5f988ea49`) with a real Google Calendar connection:

1. The Google Calendar Proxy read returned a real `200` when the pinned container was reached directly.
2. The identical request through raw Cloud Run ingress repeatedly returned `502` with `reset reason: protocol error`.
3. Compression, decompression, and `Accept-Encoding: identity` variants behaved the same way.
4. Putting Nginx in front of Nango made the successful response pass, because the intermediary terminated and regenerated the HTTP hop.

The successful streaming branch currently copies every provider header into the outgoing response. Headers such as `Transfer-Encoding`, `Connection`, and fields named by `Connection` describe the provider-to-Nango connection, not the new Nango-to-client connection. Forwarding them makes correctness depend on how tolerant the next ingress or HTTP client is.

The same qualification independently reproduced #6256 for a provider `404`; Nginx reported that Nango sent `Content-Length` and `Transfer-Encoding` together. A bounded response normalizer that removed transport framing preserved provider `200`, `404`, `409`, and `204` responses through Cloud Run. That error-path evidence has also been added to #6499.

## Impact

Self-hosted deployments behind strict managed ingress or reverse proxies receive a freshly framed response instead of provider connection metadata. End-to-end response headers continue to pass through, and uncompressed attachment lengths remain available.

## Validation

- `npx vitest run packages/server/lib/controllers/proxy/allProxy.unit.test.ts` (`17/17` passed)
- `npm run ts-build`
- `npx eslint packages/server/lib/controllers/proxy/allProxy.ts packages/server/lib/controllers/proxy/allProxy.unit.test.ts --quiet`
- Live control described above: raw Cloud Run failed; response normalization preserved `200`, `404`, `409`, and `204`

The broader integration suite was not run locally because Testcontainers could not find a working container runtime. The focused proxy unit suite and complete TypeScript build passed.


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/NangoHQ/nango/pull/6576?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

