### PR TITLE
fix: correct public function endpoint scopes

### DIFF
--- a/docs/spec.yaml
+++ b/docs/spec.yaml
@@ -68,7 +68,7 @@ paths:
     /providers/{provider}/templates:
         get:
             summary: List provider templates
-            description: Returns the template functions available in the catalog for a provider. Requires an API key with the `environment:functions:list` scope.
+            description: Returns the template functions available in the catalog for a provider. Requires a valid API key (no specific scope).
             parameters:
                 - name: provider
                   in: path
@@ -502,7 +502,7 @@ paths:
     /integrations/{uniqueKey}/functions/{name}/code:
         get:
             summary: Get a function's source code
-            description: Returns the TypeScript source code of a function for a given integration.
+            description: Returns the TypeScript source code of a function for a given integration. Requires an API key with the `environment:functions:read` scope.
             parameters:
                 - name: uniqueKey
                   in: path

--- a/docs/spec.yaml
+++ b/docs/spec.yaml
@@ -94,8 +94,6 @@ paths:
                     $ref: '#/components/responses/BadRequest'
                 '401':
                     $ref: '#/components/responses/Unauthorized'
-                '403':
-                    $ref: '#/components/responses/Forbidden'
     /integrations:
         get:
             summary: List integrations
@@ -545,6 +543,8 @@ paths:
                     $ref: '#/components/responses/BadRequest'
                 '401':
                     $ref: '#/components/responses/Unauthorized'
+                '403':
+                    $ref: '#/components/responses/Forbidden'
                 '404':
                     $ref: '#/components/responses/NotFound'
                 '409':

--- a/docs/spec.yaml
+++ b/docs/spec.yaml
@@ -68,7 +68,7 @@ paths:
     /providers/{provider}/templates:
         get:
             summary: List provider templates
-            description: Returns the template functions available in the catalog for a provider. Requires an API key with the `environment:functions:list` scope.
+            description: Returns the template functions available in the catalog for a provider. Requires a valid API key (no specific scope).
             parameters:
                 - name: provider
                   in: path
@@ -502,7 +502,7 @@ paths:
     /integrations/{uniqueKey}/functions/{name}/code:
         get:
             summary: Get a function's source code
-            description: Returns the TypeScript source code of a function for a given integration.
+            description: Returns the TypeScript source code of a function for a given integration. Requires an API key with the `environment:functions:read` scope.
             parameters:
                 - name: uniqueKey
                   in: path
@@ -1746,7 +1746,8 @@ paths:
             description: |
                 Deploys a function to an existing integration. Use `type: function` to deploy submitted TypeScript
                 source code (asynchronous), or `type: template` to deploy a template from the provider catalog
-                (synchronous; returns the deployed function).
+                (synchronous; the response already carries a terminal status). Requires an API key with the
+                `environment:deploy` scope.
             requestBody:
                 required: true
                 content:

--- a/packages/server/lib/controllers/providers/provider/templates/getTemplates.integration.test.ts
+++ b/packages/server/lib/controllers/providers/provider/templates/getTemplates.integration.test.ts
@@ -3,7 +3,7 @@ import { afterAll, beforeAll, describe, expect, it } from 'vitest';
 import db from '@nangohq/database';
 import { seeders } from '@nangohq/shared';
 
-import { isError, isSuccess, runServer, shouldBeProtected } from '../../../../utils/tests.js';
+import { isSuccess, runServer, shouldBeProtected } from '../../../../utils/tests.js';
 
 const route = '/providers/:provider/templates';
 let api: Awaited<ReturnType<typeof runServer>>;
@@ -28,14 +28,13 @@ describe(`GET ${route}`, () => {
         shouldBeProtected(res);
     });
 
-    it('should reject a key lacking the list scope', async () => {
+    it('should not require a specific scope (public catalog data)', async () => {
         const seed = await seedWithScopes(['environment:connections:read']);
 
         const res = await api.fetch(route, { method: 'GET', token: seed.apiKey.secret, params: { provider: 'github' } });
 
-        isError(res.json);
-        expect(res.res.status).toBe(403);
-        expect(res.json.error.code).toBe('forbidden');
+        expect(res.res.status).toBe(200);
+        isSuccess(res.json);
     });
 
     it('should return template functions for a known provider', async () => {

--- a/packages/server/lib/routes.public.ts
+++ b/packages/server/lib/routes.public.ts
@@ -191,7 +191,7 @@ publicAPI.route('/webhook/:environmentUuid/:providerConfigKey').post(webhookIngr
 publicAPI.use('/providers', jsonContentTypeMiddleware);
 publicAPI.route('/providers').get(connectSessionOrApiAuth, acceptLanguageMiddleware, getPublicProviders);
 publicAPI.route('/providers/:provider').get(connectSessionOrApiAuth, acceptLanguageMiddleware, getPublicProvider);
-publicAPI.route('/providers/:provider/templates').get(apiAuth, withScope('environment:functions:list'), getPublicProviderTemplates);
+publicAPI.route('/providers/:provider/templates').get(apiAuth, getPublicProviderTemplates);
 
 // @deprecated rollbacked for one customer, to delete asap
 publicAPI
@@ -215,9 +215,7 @@ publicAPI
     .get(apiAuth, withAnyScope('environment:integrations:read', 'environment:integrations:read_credentials'), getPublicIntegration);
 
 publicAPI.route('/integrations/:uniqueKey').delete(apiAuth, withScope('environment:integrations:delete'), deletePublicIntegration);
-publicAPI
-    .route('/integrations/:uniqueKey/functions/:name/code')
-    .get(apiAuth, withAnyScope('environment:integrations:read', 'environment:integrations:read_credentials'), getFunctionCode);
+publicAPI.route('/integrations/:uniqueKey/functions/:name/code').get(apiAuth, withScope('environment:functions:read'), getFunctionCode);
 publicAPI.route('/integrations/:uniqueKey/functions').get(apiAuth, withScope('environment:functions:list'), getPublicIntegrationFunctions);
 publicAPI
     .route('/integrations/:uniqueKey/functions/:name')

--- a/packages/server/lib/routes.public.ts
+++ b/packages/server/lib/routes.public.ts
@@ -188,7 +188,7 @@ publicAPI.route('/webhook/:environmentUuid/:providerConfigKey').post(webhookIngr
 publicAPI.use('/providers', jsonContentTypeMiddleware);
 publicAPI.route('/providers').get(connectSessionOrApiAuth, acceptLanguageMiddleware, getPublicProviders);
 publicAPI.route('/providers/:provider').get(connectSessionOrApiAuth, acceptLanguageMiddleware, getPublicProvider);
-publicAPI.route('/providers/:provider/templates').get(apiAuth, withScope('environment:functions:list'), getPublicProviderTemplates);
+publicAPI.route('/providers/:provider/templates').get(apiAuth, getPublicProviderTemplates);
 
 // @deprecated rollbacked for one customer, to delete asap
 publicAPI
@@ -212,9 +212,7 @@ publicAPI
     .get(apiAuth, withAnyScope('environment:integrations:read', 'environment:integrations:read_credentials'), getPublicIntegration);
 
 publicAPI.route('/integrations/:uniqueKey').delete(apiAuth, withScope('environment:integrations:delete'), deletePublicIntegration);
-publicAPI
-    .route('/integrations/:uniqueKey/functions/:name/code')
-    .get(apiAuth, withAnyScope('environment:integrations:read', 'environment:integrations:read_credentials'), getFunctionCode);
+publicAPI.route('/integrations/:uniqueKey/functions/:name/code').get(apiAuth, withScope('environment:functions:read'), getFunctionCode);
 publicAPI.route('/integrations/:uniqueKey/functions').get(apiAuth, withScope('environment:functions:list'), getPublicIntegrationFunctions);
 publicAPI
     .route('/integrations/:uniqueKey/functions/:name')


### PR DESCRIPTION
## What

Corrects the API key scopes for the public function endpoints.

- `GET /providers/:provider/templates` — now requires **no scope** (public catalog data; was `environment:functions:list`).
- `GET /integrations/:uniqueKey/functions/:name/code` — now `environment:functions:read` (was `environment:integrations:read` / `:read_credentials`).
- `docs/spec.yaml` descriptions updated to match: templates (no scope), `/code` (`functions:read`), and the deploy endpoint now documents `environment:deploy`.

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/NangoHQ/nango/pull/6578?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

