### PR TITLE
fix(webapp): replace virtualized records table with plain table

### DIFF
--- a/packages/webapp/src/pages/Connection/components/RecordsTab.tsx
+++ b/packages/webapp/src/pages/Connection/components/RecordsTab.tsx
@@ -1,5 +1,6 @@
+import { useVirtualizer } from '@tanstack/react-virtual';
 import { ArrowUpRight, ChevronLeft, Info, Loader, X } from 'lucide-react';
-import { useEffect, useRef, useState } from 'react';
+import { useEffect, useLayoutEffect, useRef, useState } from 'react';
 import { Link, useNavigate } from 'react-router-dom';
 
 import { Button, buttonVariants } from '@nangohq/design-system';
@@ -25,6 +26,7 @@ import type { ConnectionRecordModel, NangoRecord } from '@nangohq/types';
 
 const RECORDS_DOCS_URL = 'https://nango.dev/docs/implementation-guides/use-cases/syncs/implement-a-sync';
 const RECORDS_PAGE_SIZE = 20;
+const RECORD_ROW_HEIGHT_PX = 44;
 
 export const RecordsTab = () => {
     const env = useStore((state) => state.env);
@@ -213,9 +215,9 @@ export const ConnectionRecordTable = ({
                 <>
                     <div
                         ref={scrollParentRef}
-                        className="max-h-[70vh] w-full min-w-0 overflow-auto rounded border border-border-muted [scrollbar-width:none] [-ms-overflow-style:none] [&::-webkit-scrollbar]:hidden"
+                        className="h-[70vh] w-full min-w-0 overflow-auto rounded border border-border-muted [scrollbar-width:none] [-ms-overflow-style:none] [&::-webkit-scrollbar]:hidden"
                     >
-                        <RecordRowsTable records={records} onOpenPayload={setActiveRecordId} />
+                        <VirtualizedRecordRows scrollParentRef={scrollParentRef} records={records} onOpenPayload={setActiveRecordId} />
                         {hasNextPage && (
                             <div
                                 ref={loadMoreSentinelRef}
@@ -246,40 +248,72 @@ export const ConnectionRecordTable = ({
     );
 };
 
-const RecordRowsTable = ({ records, onOpenPayload }: { records: NangoRecord[]; onOpenPayload: (recordId: string) => void }) => {
-    const cellBase = 'px-6 py-2';
+const VirtualizedRecordRows = ({
+    records,
+    scrollParentRef,
+    onOpenPayload
+}: {
+    records: NangoRecord[];
+    scrollParentRef: React.RefObject<HTMLDivElement | null>;
+    onOpenPayload: (recordId: string) => void;
+}) => {
+    const rowVirtualizer = useVirtualizer<HTMLDivElement, HTMLTableRowElement>({
+        count: records.length,
+        getScrollElement: () => scrollParentRef.current,
+        estimateSize: () => RECORD_ROW_HEIGHT_PX,
+        measureElement:
+            typeof window !== 'undefined' && navigator.userAgent.indexOf('Firefox') === -1 ? (element) => element?.getBoundingClientRect().height : undefined,
+        overscan: 5
+    });
+
+    useLayoutEffect(() => {
+        rowVirtualizer.measure();
+    }, [records.length, rowVirtualizer]);
+
+    const cellBase = 'flex items-center px-6 py-2';
     const headerBase = `${cellBase} text-left text-body-small-semi`;
     const col = {
-        id: 'min-w-0 max-w-0 w-[50%]',
-        action: 'w-36 whitespace-nowrap',
-        modified: 'w-56 whitespace-nowrap'
+        id: 'min-w-0 flex-1 basis-0',
+        action: 'w-36 shrink-0 whitespace-nowrap',
+        modified: 'w-56 shrink-0 min-w-0 whitespace-nowrap'
     } as const;
 
     return (
-        <table className="w-full min-w-0 table-fixed text-sm text-text-strong">
-            <thead className="sticky top-0 z-10 bg-surface-canvas border-b border-border-muted">
-                <tr>
+        <table className="grid w-full min-w-0 caption-bottom border-separate border-spacing-0 text-sm text-text-strong">
+            <thead className="grid sticky top-0 z-10 bg-surface-canvas border-b border-border-muted">
+                <tr className="flex w-full">
                     <th className={cn(headerBase, col.id)}>ID</th>
                     <th className={cn(headerBase, col.action)}>Action</th>
                     <th className={cn(headerBase, col.modified)}>Modified</th>
                 </tr>
             </thead>
-            <tbody>
-                {records.map((record) => (
-                    <tr
-                        key={String(record.id)}
-                        className="cursor-pointer border-b border-border-muted hover:bg-state-selected-muted transition-colors"
-                        onClick={() => onOpenPayload(String(record.id))}
-                    >
-                        <td className={cn(cellBase, col.id, 'truncate text-body-small-regular')}>{String(record.id)}</td>
-                        <td className={cn(cellBase, col.action)}>
-                            <RecordActionBadge action={record._nango_metadata.last_action} />
-                        </td>
-                        <td className={cn(cellBase, col.modified, 'text-body-small-regular text-text-secondary')}>
-                            {formatDateToUSFormat(record._nango_metadata.last_modified_at)}
-                        </td>
-                    </tr>
-                ))}
+            <tbody className="grid relative" style={{ height: `${rowVirtualizer.getTotalSize()}px` }}>
+                {rowVirtualizer.getVirtualItems().map((vRow) => {
+                    const record = records[vRow.index];
+                    return (
+                        <tr
+                            key={String(record.id)}
+                            data-index={vRow.index}
+                            ref={(node) => rowVirtualizer.measureElement(node)}
+                            className={cn(
+                                'absolute left-0 flex w-full cursor-pointer border-b border-border-muted hover:bg-state-selected-muted',
+                                'transition-colors'
+                            )}
+                            style={{
+                                transform: `translateY(${vRow.start}px)`
+                            }}
+                            onClick={() => onOpenPayload(String(record.id))}
+                        >
+                            <td className={cn(cellBase, col.id, 'truncate text-body-small-regular')}>{String(record.id)}</td>
+                            <td className={cn(cellBase, col.action)}>
+                                <RecordActionBadge action={record._nango_metadata.last_action} />
+                            </td>
+                            <td className={cn(cellBase, col.modified, 'text-body-small-regular text-text-secondary')}>
+                                {formatDateToUSFormat(record._nango_metadata.last_modified_at)}
+                            </td>
+                        </tr>
+                    );
+                })}
             </tbody>
         </table>
     );

--- a/packages/webapp/src/pages/Connection/components/RecordsTab.tsx
+++ b/packages/webapp/src/pages/Connection/components/RecordsTab.tsx
@@ -1,6 +1,6 @@
 import { useVirtualizer } from '@tanstack/react-virtual';
 import { ArrowUpRight, ChevronLeft, Info, Loader, X } from 'lucide-react';
-import { useEffect, useLayoutEffect, useRef, useState } from 'react';
+import { useEffect, useLayoutEffect, useMemo, useRef, useState } from 'react';
 import { Link, useNavigate } from 'react-router-dom';
 
 import { Button, buttonVariants } from '@nangohq/design-system';
@@ -27,6 +27,8 @@ import type { ConnectionRecordModel, NangoRecord } from '@nangohq/types';
 const RECORDS_DOCS_URL = 'https://nango.dev/docs/implementation-guides/use-cases/syncs/implement-a-sync';
 const RECORDS_PAGE_SIZE = 20;
 const RECORD_ROW_HEIGHT_PX = 44;
+const RECORD_HEADER_HEIGHT_PX = 44;
+const LOAD_MORE_SENTINEL_HEIGHT_PX = 48;
 
 export const RecordsTab = () => {
     const env = useStore((state) => state.env);
@@ -153,6 +155,7 @@ export const ConnectionRecordTable = ({
     );
 
     const records = data?.pages.flatMap((page) => page.records) || [];
+    const scrollContainerHeight = useMemo(() => getRecordScrollContainerHeight(records.length, Boolean(hasNextPage)), [records.length, hasNextPage]);
     const [activeRecordId, setActiveRecordId] = useState<string | null>(null);
     const scrollParentRef = useRef<HTMLDivElement>(null);
     const loadMoreSentinelRef = useRef<HTMLDivElement>(null);
@@ -215,7 +218,8 @@ export const ConnectionRecordTable = ({
                 <>
                     <div
                         ref={scrollParentRef}
-                        className="h-[70vh] w-full min-w-0 overflow-auto rounded border border-border-muted [scrollbar-width:none] [-ms-overflow-style:none] [&::-webkit-scrollbar]:hidden"
+                        className="w-full min-w-0 overflow-auto rounded border border-border-muted [scrollbar-width:none] [-ms-overflow-style:none] [&::-webkit-scrollbar]:hidden"
+                        style={{ height: scrollContainerHeight }}
                     >
                         <VirtualizedRecordRows scrollParentRef={scrollParentRef} records={records} onOpenPayload={setActiveRecordId} />
                         {hasNextPage && (
@@ -270,8 +274,8 @@ const VirtualizedRecordRows = ({
         rowVirtualizer.measure();
     }, [records.length, rowVirtualizer]);
 
-    const cellBase = 'flex items-center px-6 py-2';
-    const headerBase = `${cellBase} text-left text-body-small-semi`;
+    const cellBase = 'flex items-center px-6';
+    const headerBase = `${cellBase} h-11 text-left text-body-small-semi`;
     const col = {
         id: 'min-w-0 flex-1 basis-0',
         action: 'w-36 shrink-0 whitespace-nowrap',
@@ -281,7 +285,7 @@ const VirtualizedRecordRows = ({
     return (
         <table className="grid w-full min-w-0 caption-bottom border-separate border-spacing-0 text-sm text-text-strong">
             <thead className="grid sticky top-0 z-10 bg-surface-canvas border-b border-border-muted">
-                <tr className="flex w-full">
+                <tr className="flex h-11 w-full">
                     <th className={cn(headerBase, col.id)}>ID</th>
                     <th className={cn(headerBase, col.action)}>Action</th>
                     <th className={cn(headerBase, col.modified)}>Modified</th>
@@ -296,7 +300,7 @@ const VirtualizedRecordRows = ({
                             data-index={vRow.index}
                             ref={(node) => rowVirtualizer.measureElement(node)}
                             className={cn(
-                                'absolute left-0 flex w-full cursor-pointer border-b border-border-muted hover:bg-state-selected-muted',
+                                'absolute left-0 flex h-11 w-full cursor-pointer border-b border-border-muted hover:bg-state-selected-muted',
                                 'transition-colors'
                             )}
                             style={{
@@ -399,6 +403,12 @@ function formatCount(count: number) {
 
 function formatCountCompact(count: number) {
     return new Intl.NumberFormat('en-US', { notation: 'compact', maximumFractionDigits: 1 }).format(count).toLowerCase();
+}
+
+function getRecordScrollContainerHeight(recordCount: number, hasNextPage: boolean): string {
+    const contentHeightPx = RECORD_HEADER_HEIGHT_PX + recordCount * RECORD_ROW_HEIGHT_PX + (hasNextPage ? LOAD_MORE_SENTINEL_HEIGHT_PX : 0);
+
+    return `min(70vh, ${contentHeightPx}px)`;
 }
 
 function RecordActionBadge({ action }: { action: string }) {

--- a/packages/webapp/src/pages/Connection/components/RecordsTab.tsx
+++ b/packages/webapp/src/pages/Connection/components/RecordsTab.tsx
@@ -257,10 +257,12 @@ const VirtualizedRecordRows = ({
     scrollParentRef: React.RefObject<HTMLDivElement | null>;
     onOpenPayload: (recordId: string) => void;
 }) => {
-    const rowVirtualizer = useVirtualizer({
+    const rowVirtualizer = useVirtualizer<HTMLDivElement, HTMLTableRowElement>({
         count: records.length,
         getScrollElement: () => scrollParentRef.current,
         estimateSize: () => RECORD_ROW_HEIGHT_PX,
+        measureElement:
+            typeof window !== 'undefined' && navigator.userAgent.indexOf('Firefox') === -1 ? (element) => element?.getBoundingClientRect().height : undefined,
         overscan: 2
     });
 
@@ -273,26 +275,27 @@ const VirtualizedRecordRows = ({
     } as const;
 
     return (
-        <table className="w-full min-w-0 border-collapse text-sm text-text-strong">
-            <thead className="sticky top-0 z-10 bg-surface-canvas border-b border-border-muted">
+        <table className="grid w-full min-w-0 caption-bottom border-separate border-spacing-0 text-sm text-text-strong">
+            <thead className="grid sticky top-0 z-10 bg-surface-canvas border-b border-border-muted">
                 <tr className="flex w-full">
                     <th className={cn(headerBase, col.id)}>ID</th>
                     <th className={cn(headerBase, col.action)}>Action</th>
                     <th className={cn(headerBase, col.modified)}>Modified</th>
                 </tr>
             </thead>
-            <tbody className="relative block" style={{ height: `${rowVirtualizer.getTotalSize()}px` }}>
+            <tbody className="grid relative" style={{ height: `${rowVirtualizer.getTotalSize()}px` }}>
                 {rowVirtualizer.getVirtualItems().map((vRow) => {
                     const record = records[vRow.index];
                     return (
                         <tr
                             key={String(record.id)}
+                            data-index={vRow.index}
+                            ref={(node) => rowVirtualizer.measureElement(node)}
                             className={cn(
                                 'absolute left-0 flex w-full cursor-pointer border-b border-border-muted hover:bg-state-selected-muted',
                                 'transition-colors'
                             )}
                             style={{
-                                height: RECORD_ROW_HEIGHT_PX,
                                 transform: `translateY(${vRow.start}px)`
                             }}
                             onClick={() => onOpenPayload(String(record.id))}

--- a/packages/webapp/src/pages/Connection/components/RecordsTab.tsx
+++ b/packages/webapp/src/pages/Connection/components/RecordsTab.tsx
@@ -1,4 +1,3 @@
-import { useVirtualizer } from '@tanstack/react-virtual';
 import { ArrowUpRight, ChevronLeft, Info, Loader, X } from 'lucide-react';
 import { useEffect, useRef, useState } from 'react';
 import { Link, useNavigate } from 'react-router-dom';
@@ -26,7 +25,6 @@ import type { ConnectionRecordModel, NangoRecord } from '@nangohq/types';
 
 const RECORDS_DOCS_URL = 'https://nango.dev/docs/implementation-guides/use-cases/syncs/implement-a-sync';
 const RECORDS_PAGE_SIZE = 20;
-const RECORD_ROW_HEIGHT_PX = 44;
 
 export const RecordsTab = () => {
     const env = useStore((state) => state.env);
@@ -217,7 +215,7 @@ export const ConnectionRecordTable = ({
                         ref={scrollParentRef}
                         className="max-h-[70vh] w-full min-w-0 overflow-auto rounded border border-border-muted [scrollbar-width:none] [-ms-overflow-style:none] [&::-webkit-scrollbar]:hidden"
                     >
-                        <VirtualizedRecordRows scrollParentRef={scrollParentRef} records={records} onOpenPayload={setActiveRecordId} />
+                        <RecordRowsTable records={records} onOpenPayload={setActiveRecordId} />
                         {hasNextPage && (
                             <div
                                 ref={loadMoreSentinelRef}
@@ -248,68 +246,40 @@ export const ConnectionRecordTable = ({
     );
 };
 
-const VirtualizedRecordRows = ({
-    records,
-    scrollParentRef,
-    onOpenPayload
-}: {
-    records: NangoRecord[];
-    scrollParentRef: React.RefObject<HTMLDivElement | null>;
-    onOpenPayload: (recordId: string) => void;
-}) => {
-    const rowVirtualizer = useVirtualizer<HTMLDivElement, HTMLTableRowElement>({
-        count: records.length,
-        getScrollElement: () => scrollParentRef.current,
-        estimateSize: () => RECORD_ROW_HEIGHT_PX,
-        measureElement:
-            typeof window !== 'undefined' && navigator.userAgent.indexOf('Firefox') === -1 ? (element) => element?.getBoundingClientRect().height : undefined,
-        overscan: 2
-    });
-
-    const cellBase = 'flex items-center px-6 py-2';
+const RecordRowsTable = ({ records, onOpenPayload }: { records: NangoRecord[]; onOpenPayload: (recordId: string) => void }) => {
+    const cellBase = 'px-6 py-2';
     const headerBase = `${cellBase} text-left text-body-small-semi`;
     const col = {
-        id: 'min-w-0 flex-1 basis-0',
-        action: 'w-36 shrink-0 whitespace-nowrap',
-        modified: 'w-56 shrink-0 min-w-0 whitespace-nowrap'
+        id: 'min-w-0 max-w-0 w-[50%]',
+        action: 'w-36 whitespace-nowrap',
+        modified: 'w-56 whitespace-nowrap'
     } as const;
 
     return (
-        <table className="grid w-full min-w-0 caption-bottom border-separate border-spacing-0 text-sm text-text-strong">
-            <thead className="grid sticky top-0 z-10 bg-surface-canvas border-b border-border-muted">
-                <tr className="flex w-full">
+        <table className="w-full min-w-0 table-fixed text-sm text-text-strong">
+            <thead className="sticky top-0 z-10 bg-surface-canvas border-b border-border-muted">
+                <tr>
                     <th className={cn(headerBase, col.id)}>ID</th>
                     <th className={cn(headerBase, col.action)}>Action</th>
                     <th className={cn(headerBase, col.modified)}>Modified</th>
                 </tr>
             </thead>
-            <tbody className="grid relative" style={{ height: `${rowVirtualizer.getTotalSize()}px` }}>
-                {rowVirtualizer.getVirtualItems().map((vRow) => {
-                    const record = records[vRow.index];
-                    return (
-                        <tr
-                            key={String(record.id)}
-                            data-index={vRow.index}
-                            ref={(node) => rowVirtualizer.measureElement(node)}
-                            className={cn(
-                                'absolute left-0 flex w-full cursor-pointer border-b border-border-muted hover:bg-state-selected-muted',
-                                'transition-colors'
-                            )}
-                            style={{
-                                transform: `translateY(${vRow.start}px)`
-                            }}
-                            onClick={() => onOpenPayload(String(record.id))}
-                        >
-                            <td className={cn(cellBase, col.id, 'truncate text-body-small-regular')}>{String(record.id)}</td>
-                            <td className={cn(cellBase, col.action)}>
-                                <RecordActionBadge action={record._nango_metadata.last_action} />
-                            </td>
-                            <td className={cn(cellBase, col.modified, 'text-body-small-regular text-text-secondary')}>
-                                {formatDateToUSFormat(record._nango_metadata.last_modified_at)}
-                            </td>
-                        </tr>
-                    );
-                })}
+            <tbody>
+                {records.map((record) => (
+                    <tr
+                        key={String(record.id)}
+                        className="cursor-pointer border-b border-border-muted hover:bg-state-selected-muted transition-colors"
+                        onClick={() => onOpenPayload(String(record.id))}
+                    >
+                        <td className={cn(cellBase, col.id, 'truncate text-body-small-regular')}>{String(record.id)}</td>
+                        <td className={cn(cellBase, col.action)}>
+                            <RecordActionBadge action={record._nango_metadata.last_action} />
+                        </td>
+                        <td className={cn(cellBase, col.modified, 'text-body-small-regular text-text-secondary')}>
+                            {formatDateToUSFormat(record._nango_metadata.last_modified_at)}
+                        </td>
+                    </tr>
+                ))}
             </tbody>
         </table>
     );


### PR DESCRIPTION
Use grid-based table layout for the virtualized records list so rows are visible when metadata-only API responses return successfully.

<!-- Describe the problem and your solution --> 

<!-- Issue ticket number and link (if applicable) -->

<!-- Testing instructions (skip if just adding/editing providers) -->



<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/NangoHQ/nango/pull/6579?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

