### PR TITLE
feat(observability): instrument usage-tracker call decisions and metering consumer

### DIFF
--- a/packages/metering/lib/processors/usage.ts
+++ b/packages/metering/lib/processors/usage.ts
@@ -49,18 +49,14 @@ export class UsageProcessor {
     }
 
     public async process(event: UsageEvent): Promise<Result<void>> {
-        const span = tracer.startSpan('nango.metering.usage.process', {
-            tags: { event_type: event.type }
-        });
-        try {
+        return tracer.trace<Promise<Result<void>>>('nango.metering.usage.process', async (span) => {
+            span.setTag('event_type', event.type);
             const result = await this._process(event);
             if (result.isErr()) {
-                span?.setTag('error', result.error);
+                span.setTag('error', result.error);
             }
             return result;
-        } finally {
-            span?.finish();
-        }
+        });
     }
 
     private async _process(event: UsageEvent): Promise<Result<void>> {

--- a/packages/metering/lib/processors/usage.ts
+++ b/packages/metering/lib/processors/usage.ts
@@ -1,3 +1,5 @@
+import tracer from 'dd-trace';
+
 import { billing } from '@nangohq/billing';
 import db from '@nangohq/database';
 import { Subscriber } from '@nangohq/pubsub';
@@ -47,6 +49,21 @@ export class UsageProcessor {
     }
 
     public async process(event: UsageEvent): Promise<Result<void>> {
+        const span = tracer.startSpan('nango.metering.usage.process', {
+            tags: { event_type: event.type }
+        });
+        try {
+            const result = await this._process(event);
+            if (result.isErr()) {
+                span?.setTag('error', result.error);
+            }
+            return result;
+        } finally {
+            span?.finish();
+        }
+    }
+
+    private async _process(event: UsageEvent): Promise<Result<void>> {
         try {
             switch (event.type) {
                 case 'usage.monthly_active_records': {

--- a/packages/usage/lib/usage.ts
+++ b/packages/usage/lib/usage.ts
@@ -221,7 +221,7 @@ export class UsageTracker implements IUsageTracker {
 
     public async getAll(accountId: number): Promise<Result<Record<UsageMetric, UsageStatus>>> {
         const now = new Date();
-        const result: Record<UsageMetric, UsageStatus> = {} as Record<UsageMetric, UsageStatus>;
+        const results: Record<UsageMetric, UsageStatus> = {} as Record<UsageMetric, UsageStatus>;
         await Promise.all(
             Object.keys(usageMetrics).map(async (metric) => {
                 const { cacheKey } = UsageTracker.getCacheEntryProps({ accountId, metric: metric as UsageMetric, now });
@@ -230,19 +230,19 @@ export class UsageTracker implements IUsageTracker {
                     metrics.increment(metrics.Types.BILLING_USAGE_TRACKER_CALLS, 1, { op: 'get', metric, result: 'error' });
                     return;
                 }
-                const cacheResult = entry.value === null ? 'null' : entry.value.revalidateAfter < now.getTime() ? 'stale' : 'fresh';
-                if (cacheResult !== 'fresh') {
+                const result = entry.value === null ? 'null' : entry.value.revalidateAfter < now.getTime() ? 'stale' : 'fresh';
+                if (result !== 'fresh') {
                     void this.revalidate({ accountId, metric: metric as UsageMetric });
                 }
-                metrics.increment(metrics.Types.BILLING_USAGE_TRACKER_CALLS, 1, { op: 'get', metric, result: cacheResult });
-                result[metric as UsageMetric] = {
+                metrics.increment(metrics.Types.BILLING_USAGE_TRACKER_CALLS, 1, { op: 'get', metric, result });
+                results[metric as UsageMetric] = {
                     accountId,
                     metric: metric as UsageMetric,
                     current: entry.value?.count || 0
                 };
             })
         );
-        return Ok(result);
+        return Ok(results);
     }
 
     public async incr({

--- a/packages/usage/lib/usage.ts
+++ b/packages/usage/lib/usage.ts
@@ -204,11 +204,14 @@ export class UsageTracker implements IUsageTracker {
         const { cacheKey } = UsageTracker.getCacheEntryProps({ accountId, metric, now });
         const entry = await this.cache.get(cacheKey);
         if (entry.isErr()) {
+            metrics.increment(metrics.Types.BILLING_USAGE_TRACKER_CALLS, 1, { op: 'get', metric, result: 'error' });
             return Err(entry.error);
         }
-        if (entry.value === null || entry.value.revalidateAfter < now.getTime()) {
+        const result = entry.value === null ? 'null' : entry.value.revalidateAfter < now.getTime() ? 'stale' : 'fresh';
+        if (result !== 'fresh') {
             void this.revalidate({ accountId, metric });
         }
+        metrics.increment(metrics.Types.BILLING_USAGE_TRACKER_CALLS, 1, { op: 'get', metric, result });
         return Ok({
             accountId,
             metric,
@@ -224,11 +227,14 @@ export class UsageTracker implements IUsageTracker {
                 const { cacheKey } = UsageTracker.getCacheEntryProps({ accountId, metric: metric as UsageMetric, now });
                 const entry = await this.cache.get(cacheKey);
                 if (entry.isErr()) {
+                    metrics.increment(metrics.Types.BILLING_USAGE_TRACKER_CALLS, 1, { op: 'get', metric, result: 'error' });
                     return;
                 }
-                if (entry.value === null || entry.value.revalidateAfter < now.getTime()) {
+                const cacheResult = entry.value === null ? 'null' : entry.value.revalidateAfter < now.getTime() ? 'stale' : 'fresh';
+                if (cacheResult !== 'fresh') {
                     void this.revalidate({ accountId, metric: metric as UsageMetric });
                 }
+                metrics.increment(metrics.Types.BILLING_USAGE_TRACKER_CALLS, 1, { op: 'get', metric, result: cacheResult });
                 result[metric as UsageMetric] = {
                     accountId,
                     metric: metric as UsageMetric,
@@ -254,15 +260,18 @@ export class UsageTracker implements IUsageTracker {
         const { cacheKey, ttlMs } = UsageTracker.getCacheEntryProps({ accountId, metric, now });
         const entry = await this.cache.incr(cacheKey, { delta, ttlMs });
         if (entry.isErr()) {
+            metrics.increment(metrics.Types.BILLING_USAGE_TRACKER_CALLS, 1, { op: 'incr', metric, result: 'error' });
             return Err(entry.error);
         }
 
         // revalidate if:
         // - forced
         // - or the entry is stale
-        if (forceRevalidation || (entry.value.revalidateAfter && entry.value.revalidateAfter < now.getTime())) {
+        const stale = forceRevalidation || !!(entry.value.revalidateAfter && entry.value.revalidateAfter < now.getTime());
+        if (stale) {
             void this.revalidate({ accountId, metric });
         }
+        metrics.increment(metrics.Types.BILLING_USAGE_TRACKER_CALLS, 1, { op: 'incr', metric, result: stale ? 'stale' : 'fresh' });
 
         return Ok({
             accountId,
@@ -289,7 +298,8 @@ export class UsageTracker implements IUsageTracker {
                 case 'connections': {
                     const count = await connectionService.countByAccountId(accountId);
                     const { cacheKey } = UsageTracker.getCacheEntryProps({ accountId, metric, now });
-                    await this.cache.overwrite(cacheKey, count);
+                    const res = await this.cache.overwrite(cacheKey, count);
+                    metrics.increment(metrics.Types.BILLING_USAGE_TRACKER_CALLS, 1, { op: 'overwrite', metric, result: res.isErr() ? 'error' : 'written' });
                     return Ok(undefined);
                 }
                 case 'records': {
@@ -298,7 +308,8 @@ export class UsageTracker implements IUsageTracker {
                         throw count.error;
                     }
                     const { cacheKey } = UsageTracker.getCacheEntryProps({ accountId, metric, now });
-                    await this.cache.overwrite(cacheKey, count.value);
+                    const res = await this.cache.overwrite(cacheKey, count.value);
+                    metrics.increment(metrics.Types.BILLING_USAGE_TRACKER_CALLS, 1, { op: 'overwrite', metric, result: res.isErr() ? 'error' : 'written' });
                     span?.setTag('count', count.value);
                     return Ok(undefined);
                 }
@@ -317,7 +328,8 @@ export class UsageTracker implements IUsageTracker {
                     // update all billing-related metrics
                     for (const [metric, count] of Object.entries(billingUsage.value)) {
                         const { cacheKey } = UsageTracker.getCacheEntryProps({ accountId, metric: metric as UsageMetric, now });
-                        await this.cache.overwrite(cacheKey, count);
+                        const res = await this.cache.overwrite(cacheKey, count);
+                        metrics.increment(metrics.Types.BILLING_USAGE_TRACKER_CALLS, 1, { op: 'overwrite', metric, result: res.isErr() ? 'error' : 'written' });
                     }
                     return Ok(undefined);
                 }

--- a/packages/utils/lib/telemetry/metrics.ts
+++ b/packages/utils/lib/telemetry/metrics.ts
@@ -156,6 +156,7 @@ export enum Types {
     BILLING_USAGE_CAPPING_SHADOW_ONE_SIDED = 'nango.billing.usage.capping.shadow.one_sided',
     BILLING_USAGE_CAPPING_SHADOW_DURATION_MS = 'nango.billing.usage.capping.shadow.duration_ms',
     BILLING_USAGE_CAPPING_CH_CACHE = 'nango.billing.usage.capping.ch.cache',
+    BILLING_USAGE_TRACKER_CALLS = 'nango.billing.usage.tracker.calls',
 
     USAGE_IS_CAPPED = 'nango.capping.isCapped',
 


### PR DESCRIPTION
## Summary

Closes two diagnostic gaps that surfaced during the recent capping cache-emit anomaly investigation.

- **New counter `nango.billing.usage.tracker.calls`** — emitted from every `UsageTracker.get` / `getAll` / `incr` and from every `cache.overwrite` in the revalidate fanout. Tags: `{ op: get|incr|overwrite, metric: <UsageMetric>, result }` where `result` is `null|stale|fresh|error` for reads and `written|error` for writes. Lets us directly observe (a) raw tracker call rate per service, (b) the stale-vs-fresh revalidate-trigger ratio per metric, and (c) the fanout-write completion that previously had no metric coverage and is the load-bearing signal for the failure-amplification effect we identified.
- **New tracer span `nango.metering.usage.process`** wrapping `UsageProcessor.process(event)` with `event_type` tag and `error` tagging on `Result.Err`. Closes the consumer-side visibility gap so "did metering actually process the event?" can be answered directly via `trace.nango.metering.usage.process.hits` instead of inferred from cache-emit rates several hops downstream.

No behavior change. Observability only.

## Test plan

- [x] `npm run ts-build` clean
- [x] Existing 33 unit tests in `packages/usage/lib/usage.unit.test.ts` still pass
- [ ] After deploy: confirm `nango.billing.usage.tracker.calls` reports across all three services (`nango`, `nango-jobs`, `nango-metering`) with the expected per-op / per-metric breakdown
- [ ] After deploy: confirm `trace.nango.metering.usage.process.hits` (rate) and `.errors` show non-zero, broken down by `event_type`

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/NangoHQ/nango/pull/6580?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

