### PR TITLE
feat(observability): add nango.usage.revalidate.work span for lock-acquired path

### DIFF
--- a/packages/usage/lib/usage.ts
+++ b/packages/usage/lib/usage.ts
@@ -290,8 +290,33 @@ export class UsageTracker implements IUsageTracker {
         const lock = await this.cache.tryAcquireLock(lockKey, { ttlMs: 60_000 });
         if (lock.isErr()) {
             // another revalidation is in progress, skip
+            span?.setTag('lock_acquired', false);
+            span?.finish();
             return Ok(undefined);
         }
+        span?.setTag('lock_acquired', true);
+        try {
+            return await this._revalidate({ accountId, metric, source, parentSpan: span });
+        } finally {
+            span?.finish();
+        }
+    }
+
+    private async _revalidate({
+        accountId,
+        metric,
+        source,
+        parentSpan
+    }: {
+        accountId: number;
+        metric: UsageMetric;
+        source: string;
+        parentSpan: ReturnType<typeof tracer.startSpan> | undefined;
+    }): Promise<Result<void>> {
+        const span = tracer.startSpan('nango.usage.revalidate.work', {
+            tags: { accountId, metric, source },
+            ...(parentSpan ? { childOf: parentSpan } : {})
+        });
         try {
             const now = new Date();
             switch (metric) {


### PR DESCRIPTION
## Summary

Adds a distinct `nango.usage.revalidate.work` child span that wraps only the actual revalidate work (the path that successfully acquired the lock). Surfaces useful-work rate cleanly separated from fire-and-forget lock-loser invocations — directly queryable in DD via `trace.nango.usage.revalidate.work.hits` with no UI-side tag configuration. Also fixes a latent span leak on the lock-loser path (outer span was never finished when `tryAcquireLock` returned `Err`).

The outer `nango.usage.revalidate` span continues to count every invocation, now tagged `lock_acquired:true|false`. The new work span is created as a child of the outer span (`childOf`) so the trace tree renders `revalidate.work` nested under `revalidate`.

Implementation: split `revalidate` into a thin dispatcher (lock check + outer span + delegate) and a private `_revalidate` (work span + switch body) so the original switch stays at its original indentation. Follow-up to #6580 (the observability instrumentation that landed earlier).

## Test plan

- [x] `npm run ts-build` clean
- [x] Existing 33 unit tests in `packages/usage/lib/usage.unit.test.ts` still pass
- [ ] After deploy: confirm `trace.nango.usage.revalidate.work.hits` is non-zero and `trace.nango.usage.revalidate.hits` continues to count all invocations (including lock-losers)
- [ ] After deploy: confirm `nango.billing.usage.tracker.calls{op:overwrite}` ≈ 5× `trace.nango.usage.revalidate.work.hits` for billing metrics — the fanout health signal

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/NangoHQ/nango/pull/6586?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

