### PR TITLE
fix(in-app): fix the in-app chat support button location

### DIFF
--- a/packages/webapp/src/components/PlainChat.tsx
+++ b/packages/webapp/src/components/PlainChat.tsx
@@ -113,13 +113,14 @@ function buildConfig(appId: string, darkMode: boolean, user?: ApiUser, emailHash
             alt: 'Nango'
         },
         links: [
-            { icon: 'book', text: 'View docs', url: 'https://docs.nango.dev' },
-            { icon: 'slack', text: 'Join our Slack', url: 'https://nango.dev/slack' }
+            { icon: 'book', text: 'View docs & ask AI', url: 'https://docs.nango.dev' },
+            { icon: 'slack', text: 'Join Slack & ask our engineers', url: 'https://nango.dev/slack' }
         ],
         chatButtons: [
             { icon: 'chat', text: 'Ask a question', threadDetails: {} },
             { icon: 'bulb', text: 'Share feedback', threadDetails: {} }
         ],
+        hideLauncher: true,
         hideBranding: false,
         position: { right: '16px', bottom: '16px', zIndex: '9999' },
         ...(user ? { customerDetails: { email: user.email, emailHash, fullName: user.name } } : { requireAuthentication: true })

--- a/packages/webapp/src/layout/AppHeader.tsx
+++ b/packages/webapp/src/layout/AppHeader.tsx
@@ -39,7 +39,12 @@ export const AppHeader: React.FC = () => {
                         <BookOpen />
                     </a>
                 </IconButton>
-                <IconButton variant="outline" size="md" label="Help" onClick={() => window.Plain?.open()}>
+                <IconButton
+                    variant="outline"
+                    size="md"
+                    label="Help"
+                    onClick={() => (window.Plain ? window.Plain.open() : window.open('https://nango.dev/slack', '_blank', 'noopener,noreferrer'))}
+                >
                     <HelpIcon />
                 </IconButton>
                 <IconButton variant="outline" size="md" label={darkMode ? 'Switch to light mode' : 'Switch to dark mode'} onClick={toggleDarkMode}>

--- a/packages/webapp/src/layout/AppHeader.tsx
+++ b/packages/webapp/src/layout/AppHeader.tsx
@@ -1,4 +1,4 @@
-import { BookOpen, Box, MessageCircle, Moon, Sun } from 'lucide-react';
+import { BookOpen, Box, LifeBuoy as HelpIcon, Moon, Sun } from 'lucide-react';
 
 import { permissions } from '@nangohq/authz';
 import { Button, IconButton } from '@nangohq/design-system';
@@ -40,7 +40,7 @@ export const AppHeader: React.FC = () => {
                     </a>
                 </IconButton>
                 <IconButton variant="outline" size="md" label="Help" onClick={() => window.Plain?.open()}>
-                    <MessageCircle />
+                    <HelpIcon />
                 </IconButton>
                 <IconButton variant="outline" size="md" label={darkMode ? 'Switch to light mode' : 'Switch to dark mode'} onClick={toggleDarkMode}>
                     {darkMode ? <Sun /> : <Moon />}

--- a/packages/webapp/src/layout/AppHeader.tsx
+++ b/packages/webapp/src/layout/AppHeader.tsx
@@ -1,4 +1,4 @@
-import { BookOpen, Box, LifeBuoy, Moon, Sun } from 'lucide-react';
+import { BookOpen, Box, MessageCircle, Moon, Sun } from 'lucide-react';
 
 import { permissions } from '@nangohq/authz';
 import { Button, IconButton } from '@nangohq/design-system';
@@ -39,10 +39,8 @@ export const AppHeader: React.FC = () => {
                         <BookOpen />
                     </a>
                 </IconButton>
-                <IconButton asChild variant="outline" size="md" label="Help">
-                    <a href="https://nango.dev/slack" target="_blank" rel="noreferrer">
-                        <LifeBuoy />
-                    </a>
+                <IconButton variant="outline" size="md" label="Help" onClick={() => window.Plain?.open()}>
+                    <MessageCircle />
                 </IconButton>
                 <IconButton variant="outline" size="md" label={darkMode ? 'Switch to light mode' : 'Switch to dark mode'} onClick={toggleDarkMode}>
                     {darkMode ? <Sun /> : <Moon />}


### PR DESCRIPTION
## Describe the problem and your solution

- Move the in-app chat support button from the floating button in the bottom-right corner to the Help button in the top-right corner.

<!-- Issue ticket number and link (if applicable) -->

<!-- Testing instructions (skip if just adding/editing providers) -->



<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/NangoHQ/nango/pull/6590?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

