### PR TITLE
chore: update egress-metering middleware

### DIFF
--- a/packages/server/lib/middleware/egress-meter.middleware.ts
+++ b/packages/server/lib/middleware/egress-meter.middleware.ts
@@ -3,19 +3,21 @@ import { metrics } from '@nangohq/utils';
 import type { RequestLocals } from '../utils/express.js';
 import type { NextFunction, Request, Response } from 'express';
 
-function trafficOrigin(res: Response<any, RequestLocals>): 'internal' | 'external' {
-    return res.locals['apiKeyAuthSource'] === 'api_secret' ? 'internal' : 'external';
-}
-
 export const egressMeterMiddleware = (req: Request, res: Response<any, RequestLocals>, next: NextFunction) => {
-    const origin = trafficOrigin(res);
+    if (res.locals['apiKeyAuthSource'] !== 'customer_key') {
+        next();
+        return;
+    }
+
     const baseline = req.socket?.bytesWritten ?? 0;
+
+    const withConnectionId = req.params['connectionId'] !== undefined;
 
     let recorded = false;
     const meterEgressedBytes = () => {
         if (recorded) return;
         const bytes = (req.socket?.bytesWritten ?? 0) - baseline;
-        metrics.increment(metrics.Types.EGRESS_BYTES, bytes, { traffic_origin: origin });
+        metrics.increment(metrics.Types.EGRESS_BYTES, bytes, { withConnectionId: withConnectionId.toString() });
         recorded = true;
     };
 

--- a/packages/server/lib/middleware/egress-meter.middleware.ts
+++ b/packages/server/lib/middleware/egress-meter.middleware.ts
@@ -11,13 +11,11 @@ export const egressMeterMiddleware = (req: Request, res: Response<any, RequestLo
 
     const baseline = req.socket?.bytesWritten ?? 0;
 
-    const withConnectionId = req.params['connectionId'] !== undefined;
-
     let recorded = false;
     const meterEgressedBytes = () => {
         if (recorded) return;
         const bytes = (req.socket?.bytesWritten ?? 0) - baseline;
-        metrics.increment(metrics.Types.EGRESS_BYTES, bytes, { withConnectionId: withConnectionId.toString() });
+        metrics.increment(metrics.Types.EGRESS_BYTES, bytes);
         recorded = true;
     };
 

--- a/packages/server/lib/routes.private.ts
+++ b/packages/server/lib/routes.private.ts
@@ -109,7 +109,6 @@ import { putUserPassword } from './controllers/v1/user/password/putPassword.js';
 import { patchUser } from './controllers/v1/user/patchUser.js';
 import authMiddleware from './middleware/access.middleware.js';
 import { authenticateLocalSignin } from './middleware/authenticateLocalSignin.middleware.js';
-import { egressMeterMiddleware } from './middleware/egress-meter.middleware.js';
 import { jsonContentTypeMiddleware } from './middleware/json.middleware.js';
 import { rateLimiterMiddleware } from './middleware/ratelimit.middleware.js';
 import { isAllowedWebCorsOrigin } from './utils/cors.js';
@@ -117,7 +116,7 @@ import { isAllowedWebCorsOrigin } from './utils/cors.js';
 import type { Request, RequestHandler, Response } from 'express';
 
 let webAuth: RequestHandler[] = flagHasAuth
-    ? [passport.authenticate('session') as RequestHandler, authMiddleware.sessionAuth.bind(authMiddleware), rateLimiterMiddleware, egressMeterMiddleware]
+    ? [passport.authenticate('session') as RequestHandler, authMiddleware.sessionAuth.bind(authMiddleware), rateLimiterMiddleware]
     : isBasicAuthEnabled
       ? [passport.authenticate('basic', { session: false }) as RequestHandler, authMiddleware.basicAuth.bind(authMiddleware), rateLimiterMiddleware]
       : [authMiddleware.noAuth.bind(authMiddleware), rateLimiterMiddleware];


### PR DESCRIPTION
Only track external traffic, with `customer_key` as source. This will help us understand the volume that will soon be ingested into ClickHouse.

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/NangoHQ/nango/pull/6591?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

