### PR TITLE
fix(webapp): stop logs table bouncing on auto-refresh

### DIFF
--- a/packages/webapp/src/pages/Logs/components/SearchAllOperations.tsx
+++ b/packages/webapp/src/pages/Logs/components/SearchAllOperations.tsx
@@ -12,7 +12,6 @@ import { FilterMultiSelect } from '@/components/patterns/FilterMultiSelect';
 import { PeriodSelector } from '@/components/patterns/PeriodSelector';
 import { InputGroup, InputGroupAddon, InputGroupButton, InputGroupInput } from '@/components/ui/InputGroup';
 import { Skeleton } from '@/components/ui/Skeleton';
-import { Spinner } from '@/components/ui/Spinner';
 import { queryClient, useStore } from '../../../store';
 import { apiFetch } from '../../../utils/api';
 import { last24hPreset, logsPresets, slidePeriod } from '../../../utils/logs';
@@ -253,8 +252,7 @@ export const SearchAllOperations: React.FC<Props> = ({ onSelectOperation }) => {
 
     return (
         <>
-            <div className="flex justify-end items-center gap-2 mb-2">
-                {(isLoading || isFetching) && <Spinner />}
+            <div className="flex justify-end items-center mb-2">
                 <div className="text-text-strong text-xs">
                     {totalHumanReadable} {totalOperations > 1 ? 'logs' : 'log'} found
                 </div>


### PR DESCRIPTION
## Problem

On the Logs screen the table jumped down ~4px and back on every auto-refresh poll, making it feel like it was bouncing. It's a regression from the app-shell redesign (#6543): moving the page title into the section header left the 16px refresh spinner as the tallest element in the "N logs found" row, so it grew the row each time it mounted during a background fetch.

## Solution

Remove the refresh spinner from that row. Initial load already renders a table skeleton and the period selector's `(live)` indicator signals freshness, so no feedback is lost — and the row height (and the table below it) now stays constant across polls.

Fixes [NAN-6045](https://linear.app/nango/issue/NAN-6045)

## Testing

Verified live against the dev API by measuring the table's top offset across several poll cycles: steady at 208px with the fix, versus toggling 208px↔212px before. First-load skeleton and the `(live)` indicator are unchanged.
