### PR TITLE
fix(records): accept numeric id of 0 instead of failing the batch

### DIFF
--- a/packages/records/lib/helpers/format.ts
+++ b/packages/records/lib/helpers/format.ts
@@ -42,7 +42,8 @@ export const formatRecords = ({
             break;
         }
 
-        if (!datum['id']) {
+        // Explicit check rather than `!datum['id']` so a falsy-but-valid id (e.g. the number 0) is not treated as missing
+        if (datum['id'] === undefined || datum['id'] === null || datum['id'] === '') {
             const error = new Error(`Missing id field in record: ${JSON.stringify(datum)}. Model: ${model}`);
             return Err(error);
         }

--- a/packages/records/lib/helpers/format.unit.test.ts
+++ b/packages/records/lib/helpers/format.unit.test.ts
@@ -1,0 +1,43 @@
+import { describe, expect, it } from 'vitest';
+
+import { formatRecords } from './format.js';
+
+import type { UnencryptedRecordData } from '../types.js';
+
+const base = {
+    connectionId: 1,
+    model: 'Test',
+    syncId: '00000000-0000-0000-0000-000000000000',
+    syncJobId: 1
+};
+
+describe('formatRecords', () => {
+    it('should accept a numeric id of 0 (falsy but valid)', () => {
+        const data = [{ id: 0, name: 'zero' }] as unknown as UnencryptedRecordData[];
+
+        const res = formatRecords({ data, ...base });
+
+        expect(res.isOk()).toBe(true);
+        expect(res.unwrap()[0]?.external_id).toBe('0');
+    });
+
+    it('should not let one valid record fail the whole batch', () => {
+        const data = [
+            { id: 0, name: 'zero' },
+            { id: '1', name: 'one' }
+        ] as unknown as UnencryptedRecordData[];
+
+        const res = formatRecords({ data, ...base });
+
+        expect(res.isOk()).toBe(true);
+        expect(res.unwrap()).toHaveLength(2);
+    });
+
+    it.each([{ id: undefined }, { id: null }, { id: '' }])('should reject a record with a missing id (%o)', (record) => {
+        const data = [record] as unknown as UnencryptedRecordData[];
+
+        const res = formatRecords({ data, ...base });
+
+        expect(res.isErr()).toBe(true);
+    });
+});


### PR DESCRIPTION
## Problem

`formatRecords` checks for a missing id with `if (!datum['id'])`. But the persist route accepts numeric ids, so a record with `id: 0` is valid input — and `!0` is `true`, so it's wrongly treated as missing. That returns `Err`, which fails the **whole batch**, not just the one record.

## Fix

Check for an actually-missing id (`undefined` / `null` / `''`) instead of using truthiness, so a falsy-but-valid id like `0` is kept.

## Tests

`format.unit.test.ts`: `id: 0` is accepted, doesn't fail the batch, and `undefined` / `null` / `''` are still rejected.