### PR TITLE
fix(providers): validate OAUTH2 has token_url + friendlier schema errors

### DIFF
--- a/scripts/validation/providers/validate.ts
+++ b/scripts/validation/providers/validate.ts
@@ -44,7 +44,14 @@ const scriptsContent = fs.readFileSync(pathConnectionScripts, 'utf-8');
 console.log('validating...');
 validator(providersJson);
 if (validator.errors) {
-    console.error(chalk.red('error'), validator.errors);
+    for (const err of validator.errors) {
+        // AJV v6 dataPath looks like "['<providerKey>'].proxy.headers"; surface the provider so contributors know where to look
+        const dataPath = err.dataPath || '';
+        const providerKey = dataPath.match(/^\['([^']+)'\]/)?.[1] || '(root)';
+        const location = dataPath || '(root)';
+        const details = err.params && Object.keys(err.params).length > 0 ? ` ${JSON.stringify(err.params)}` : '';
+        console.error(chalk.red('error'), chalk.blue(providerKey), `${location} ${err.message}${details}`);
+    }
     process.exit(1);
 }
 
@@ -252,6 +259,16 @@ function validateProvider(providerKey: string, provider: ExtendedProvider) {
     } else if (provider.auth_mode === 'OAUTH2_CC') {
         if (!provider.credentials) {
             console.warn(chalk.yellow('warning'), chalk.blue(providerKey), `"credentials" are not defined for OAUTH2_CC auth mode`);
+        }
+    } else if (provider.auth_mode === 'OAUTH2') {
+        if (!provider.token_url) {
+            console.error(chalk.red('error'), chalk.blue(providerKey), `"token_url" must be defined for OAUTH2 providers`);
+            error = true;
+        }
+        // The authorization code can also arrive via a webhook instead of a redirect, in which case there is no authorization_url
+        if (!provider.authorization_url && !provider.authorization_code_param_in_webhook) {
+            console.error(chalk.red('error'), chalk.blue(providerKey), `"authorization_url" must be defined for OAUTH2 providers`);
+            error = true;
         }
     } else if (provider.auth_mode === 'AWS_SIGV4') {
         if (!provider.credentials) {


### PR DESCRIPTION
Two improvements to `npm run test:providers` — the first gate a new-integration contributor hits.

## 1. OAUTH2 providers are now validated

OAUTH2 is the most common `auth_mode` (**274 entries**) yet had **no** positive validation — it fell into the catch-all `else`, so an omitted or typo'd `token_url`/`authorization_url` passed validation ("✅ All providers are valid") and only failed at runtime mid-OAuth-dance.

Added an `OAUTH2` branch that errors when:
- `token_url` is missing, and
- `authorization_url` is missing **unless** the flow receives the code via webhook (`authorization_code_param_in_webhook`) — the carve-out for webhook-driven OAuth like `sentry-oauth`.

Verified against the current file: all 274 OAUTH2 providers have `token_url`, and `sentry-oauth` is the only one without `authorization_url` (and it has `authorization_code_param_in_webhook`), so **zero false positives**.

## 2. Friendlier AJV schema errors

A schema failure (e.g. a typo'd field tripping `additionalProperties`) dumped a raw AJV error array with no provider name — the worst output in the script, for the earliest and most common mistake, while every later check prints a clean `error <provider> "..."`. Now each AJV error is reformatted into a per-provider line:

```
error github ['github'].proxy should NOT have additional properties {"additionalProperty":"bogusField"}
```

## Testing

`npm run test:providers` still passes on the current file (only pre-existing warnings). Both new error paths were exercised manually: the OAUTH2 branch fires on missing fields and correctly exempts the webhook flow; the AJV formatter names the offending provider and property and is null-safe for root-level errors.

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/NangoHQ/nango/pull/6596?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

