### PR TITLE
perf(records): concurrent decrypt + O(1) match in store.update()

### DIFF
--- a/packages/records/lib/stores/postgres/postgres.integration.test.ts
+++ b/packages/records/lib/stores/postgres/postgres.integration.test.ts
@@ -470,6 +470,45 @@ describe('PostgresStore', () => {
             });
         });
 
+        it('should merge each record to its own value across decrypt-concurrency chunk boundaries', async () => {
+            const connectionId = rnd.number();
+            const environmentId = rnd.number();
+            const model = rnd.string();
+            const syncId = uuid.v4();
+
+            // More records than RECORDS_DECRYPT_CONCURRENCY (default 10) so the update loop spans
+            // multiple decrypt chunks; each record must still merge against its own old value.
+            const count = 25;
+            const ids = Array.from({ length: count }, (_, i) => `${i}`);
+
+            const inserted = await upsertRecords({
+                records: ids.map((id) => ({ id, name: `name-${id}`, keep: `keep-${id}` })),
+                connectionId,
+                environmentId,
+                model,
+                syncId,
+                syncJobId: 1
+            });
+            expect(inserted.addedKeys.sort()).toStrictEqual([...ids].sort());
+
+            await updateRecords({
+                records: ids.map((id) => ({ id, name: `updated-${id}` })),
+                connectionId,
+                environmentId,
+                model,
+                syncId,
+                syncJobId: 2
+            });
+
+            const { records: found } = (await store.getRecords({ connectionId, model })).unwrap();
+            expect(found.length).toBe(count);
+            for (const id of ids) {
+                const record = found.find((r) => r.id === id);
+                // name overwritten by the update, keep retained from the original via deep merge
+                expect(record).toMatchObject({ id, name: `updated-${id}`, keep: `keep-${id}` });
+            }
+        });
+
         describe('should respect merging strategy', () => {
             it('when strategy = override', async () => {
                 const connectionId = rnd.number();

--- a/packages/records/lib/stores/postgres/postgres.ts
+++ b/packages/records/lib/stores/postgres/postgres.ts
@@ -945,24 +945,41 @@ export class PostgresStore implements RecordsStore {
 
                     const oldRecords = await getRecordsToUpdate({ trx, records: chunk, connectionId, model });
 
+                    // Index the input chunk by external_id so matching an old record to its input is O(1)
+                    // rather than an O(n) scan per old record (O(n^2) over the chunk).
+                    const inputByExternalId = new Map(chunk.map((record) => [record.external_id, record]));
+
+                    // decryptRecordData offloads AES-GCM to the libuv threadpool, so awaiting one record at a
+                    // time leaves the other threads idle. Decrypt in bounded concurrency chunks (matching the
+                    // getRecords read path) so the threadpool is saturated without holding every decrypted
+                    // blob live at once.
+                    const concurrency = envs.RECORDS_DECRYPT_CONCURRENCY;
                     const recordsToUpdate: FormattedRecord[] = [];
-                    for (const oldRecord of oldRecords) {
-                        const oldRecordData = await decryptRecordData(oldRecord);
+                    for (let start = 0; start < oldRecords.length; start += concurrency) {
+                        const decryptChunk = oldRecords.slice(start, start + concurrency);
+                        const merged = await Promise.all(
+                            decryptChunk.map(async (oldRecord) => {
+                                const inputRecord = inputByExternalId.get(oldRecord.external_id);
+                                if (!inputRecord) {
+                                    return null;
+                                }
 
-                        const inputRecord = chunk.find((record) => record.external_id === oldRecord.external_id);
-                        if (!inputRecord) {
-                            continue;
+                                const [oldRecordData, newRecordData] = await Promise.all([decryptRecordData(oldRecord), decryptRecordData(inputRecord)]);
+
+                                const { json, ...newRecordRest } = inputRecord;
+                                const newRecord: FormattedRecord = {
+                                    ...newRecordRest,
+                                    json: deepMergeRecordData(oldRecordData, newRecordData),
+                                    updated_at: new Date()
+                                };
+                                return newRecord;
+                            })
+                        );
+                        for (const newRecord of merged) {
+                            if (newRecord) {
+                                recordsToUpdate.push(newRecord);
+                            }
                         }
-
-                        const { json, ...newRecordRest } = inputRecord;
-                        const newRecordData = await decryptRecordData(inputRecord);
-
-                        const newRecord: FormattedRecord = {
-                            ...newRecordRest,
-                            json: deepMergeRecordData(oldRecordData, newRecordData),
-                            updated_at: new Date()
-                        };
-                        recordsToUpdate.push(newRecord);
                     }
                     if (recordsToUpdate.length > 0) {
                         const encryptedRecords = encryptRecords(recordsToUpdate);


### PR DESCRIPTION
## Problem

`store.update()` — the `batchUpdate` / partial-merge records path — had two scale issues in its per-chunk loop (`packages/records/lib/stores/postgres/postgres.ts`):

1. **Serial decryption.** It looped over each old record doing two back-to-back `await decryptRecordData()` calls (old + new). `decryptRecordData` offloads AES-GCM to the libuv threadpool, so awaiting one record before starting the next leaves the pool idle — effectively serial crypto, scaling linearly with batch size.
2. **O(n²) matching.** Each old record was matched to its input via `chunk.find(r => r.external_id === ...)`, an O(n) scan per record over a batch of up to `RECORDS_BATCH_SIZE`.

The `getRecords` read path was already rewritten to avoid exactly the serial-decrypt anti-pattern (the `RECORDS_DECRYPT_CONCURRENCY` chunked `Promise.all` block); `update()` never got the same treatment.

## Fix

Mirror the read path:
- Build a `Map<external_id, inputRecord>` once → O(1) matching.
- Decrypt old+new in `RECORDS_DECRYPT_CONCURRENCY`-bounded `Promise.all` chunks so the threadpool is saturated without holding every decrypted blob live at once.

Behavior is unchanged: same deep-merge semantics, same records updated, same skip when an old record has no matching input.

## Testing

- New integration test updates 25 records (> the default decrypt concurrency of 10) so the loop spans multiple chunks, asserting each record merges against its **own** old value (name overwritten, untouched field retained).
- Full records Postgres integration suite passes (70/70).
- `tsc -b` on the records package is clean.

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/NangoHQ/nango/pull/6598?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

