### PR TITLE
fix(server): enforce RBAC on flow read routes

### DIFF
--- a/packages/server/lib/authz/authz.integration.test.ts
+++ b/packages/server/lib/authz/authz.integration.test.ts
@@ -498,6 +498,37 @@ describe('authz integration', () => {
             expect(res.res.status).toBe(403);
         });
 
+        it('should deny GET prod integration flows', async () => {
+            const { account } = await seedAccountWithProdEnv();
+            const devUser = await createUserWithRole(account.id, 'development_full_access');
+            const session = await authenticateUser(api, devUser);
+
+            const res = await api.fetch('/api/v1/integrations/:providerConfigKey/flows', {
+                method: 'GET',
+                query: { env: 'prod' },
+                params: { providerConfigKey: 'some-key' },
+                session
+            });
+
+            expect(res.res.status).toBe(403);
+        });
+
+        it('should deny GET prod flow by name', async () => {
+            const { account } = await seedAccountWithProdEnv();
+            const devUser = await createUserWithRole(account.id, 'development_full_access');
+            const session = await authenticateUser(api, devUser);
+
+            // @ts-expect-error authz test — /flow/:flowName not in endpoint types
+            const res = await api.fetch('/api/v1/flow/:flowName', {
+                method: 'GET',
+                query: { env: 'prod', provider_config_key: 'some-key' },
+                params: { flowName: 'some-flow' },
+                session
+            });
+
+            expect(res.res.status).toBe(403);
+        });
+
         it('should deny PATCH prod environments', async () => {
             const { account } = await seedAccountWithProdEnv();
             const devUser = await createUserWithRole(account.id, 'development_full_access');

--- a/packages/server/lib/routes.private.ts
+++ b/packages/server/lib/routes.private.ts
@@ -244,7 +244,7 @@ web.route('/integrations').post(webAuth, can({ action: 'update', resource: 'inte
 web.route('/integrations/:providerConfigKey').get(webAuth, can({ action: 'read', resource: 'integration', scopedBy: envScope }), getIntegration);
 web.route('/integrations/:providerConfigKey').patch(webAuth, can({ action: 'update', resource: 'integration', scopedBy: envScope }), patchIntegration);
 web.route('/integrations/:providerConfigKey').delete(webAuth, can({ action: 'delete', resource: 'integration', scopedBy: envScope }), deleteIntegration);
-web.route('/integrations/:providerConfigKey/flows').get(webAuth, getIntegrationFlows);
+web.route('/integrations/:providerConfigKey/flows').get(webAuth, can({ action: 'read', resource: 'flow', scopedBy: envScope }), getIntegrationFlows);
 web.route('/integrations/:providerConfigKey/functions').get(webAuth, can({ action: 'read', resource: 'flow', scopedBy: envScope }), getIntegrationFunctions);
 web.route('/integrations/:providerConfigKey/functions/:functionName')
     .get(webAuth, can({ action: 'read', resource: 'flow', scopedBy: envScope }), getIntegrationFunction)
@@ -295,7 +295,7 @@ web.route('/flows/:id/disable').patch(webAuth, can({ action: 'update', resource:
 web.route('/flows/:id/enable').patch(webAuth, can({ action: 'update', resource: 'flow', scopedBy: envScope }), patchFlowEnable);
 web.route('/flows/:id/frequency').patch(webAuth, can({ action: 'update', resource: 'flow', scopedBy: envScope }), patchFlowFrequency);
 web.route('/flows/:id/download').get(webAuth, can({ action: 'read', resource: 'flow', scopedBy: envScope }), getFlowDownload);
-web.route('/flow/:flowName').get(webAuth, flowController.getFlow.bind(syncController));
+web.route('/flow/:flowName').get(webAuth, can({ action: 'read', resource: 'flow', scopedBy: envScope }), flowController.getFlow.bind(syncController));
 
 web.route('/trigger/function').post(webAuth, can({ action: 'update', resource: 'sync_command', scopedBy: envScope }), postTriggerFunction);
 


### PR DESCRIPTION
- Two private flow-read routes — `GET /integrations/:providerConfigKey/flows` and `GET /flow/:flowName` — were registered with only `webAuth` and were missing the `can({ action: 'read', resource: 'flow', scopedBy: envScope })` guard that every other production flow route enforces. A `development_full_access` user (denied all production access) could therefore read production flow configurations by passing `?env=prod`. This adds the read-flow RBAC check to both routes.
- Adds regression tests under the `development_full_access` authz suite asserting both routes return `403` for production.

Fixes NAN-6051.

## Test plan
- [x] `authz.integration.test.ts` — full suite passes (38), including the two new deny tests
- [x] Verified the new tests fail without the route fix (`/flows` returned 404, `/flow/:flowName` returned 200 — confirming the bypass)
- [x] `getFlows.integration.test.ts` happy path still passes (6)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/NangoHQ/nango/pull/6603?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

