### PR TITLE
fix(frontend): make ConnectUI.open() idempotent

### DIFF
--- a/packages/frontend/lib/connectUI.ts
+++ b/packages/frontend/lib/connectUI.ts
@@ -73,9 +73,15 @@ export class ConnectUI {
     }
 
     /**
-     * Open UI in an iframe and listen to events
+     * Open UI in an iframe and listen to events.
+     * No-op if the iframe is already mounted, so duplicate open() calls
+     * don't leave orphan iframes that close() can't clean up.
      */
     open() {
+        if (this.iframe) {
+            return;
+        }
+
         this.iframe = this.createIframe();
         document.body.append(this.iframe);
 

--- a/packages/frontend/lib/connectUI.ts
+++ b/packages/frontend/lib/connectUI.ts
@@ -76,10 +76,15 @@ export class ConnectUI {
      * Open UI in an iframe and listen to events.
      * No-op if the iframe is already mounted, so duplicate open() calls
      * don't leave orphan iframes that close() can't clean up.
+     * If the iframe ref is stale (detached externally), reset state before re-creating
+     * so reopen still works.
      */
     open() {
-        if (this.iframe) {
+        if (this.iframe?.isConnected) {
             return;
+        }
+        if (this.iframe) {
+            this.close();
         }
 
         this.iframe = this.createIframe();
@@ -175,9 +180,10 @@ export class ConnectUI {
     close() {
         if (this.listener) {
             window.removeEventListener('message', this.listener);
+            this.listener = null;
         }
         if (this.iframe) {
-            document.body.removeChild(this.iframe);
+            this.iframe.remove();
             this.iframe = null;
 
             document.body.style.overflow = '';


### PR DESCRIPTION
## Changes

Fixes #6481

`Nango.openConnectUI()` already calls `connect.open()` internally, so when a caller follows up with `ui.open()`, the SDK appends a **second** `<iframe id="connect-ui">` and overwrites `this.iframe` to point at it. `ConnectUI#close()` then only removes the second iframe — the first one is orphaned in the DOM and keeps its `position: fixed; z-index: 9999` skeleton modal on top of the page, intercepting all clicks (its own X has no postMessage listener on the parent side, so it's unkillable from the UI).

The minimal fix: guard `open()` so a second call is a no-op when the iframe is already mounted. The single `ConnectUI` instance keeps owning its iframe and `close()` stays authoritative.

- No change to the public surface (`open` / `close` / `setSessionToken` / iframe id).
- Does not alter the in-flight handshake when a duplicate call lands mid-flow — we keep the existing iframe rather than tearing it down and re-creating it.
- Matches the existing `if (this.win)` re-entry pattern in `Nango.auth()` (see `packages/frontend/lib/index.ts`).

## 🧪 Tests

Repro from #6481:

```ts
const ui = nango.openConnectUI({ apiURL: "https://api.nango.dev", onEvent: (e) => {
  if (e.type === "connect") {
    console.log("before close:", document.querySelectorAll("iframe#connect-ui").length);
    ui.close();
    console.log("after close:", document.querySelectorAll("iframe#connect-ui").length);
  }
}});
ui.open(); // duplicate call — was creating an orphan iframe
ui.setSessionToken(sessionToken);
```

Expected after this PR:
- `before close: 1` (was `2`)
- `after close: 0` (was `1`)

Manual verification path:
- Open Connect UI from the webapp dashboard for any OAuth / BASIC integration.
- Confirm a single `<iframe id="connect-ui">` is mounted and `close()` (or the in-iframe X) removes it cleanly with no orphan and `document.body.style.overflow` restored.
