### PR TITLE
fix(oauth): surface OAuth2 client credentials provider errors

### DIFF
--- a/packages/server/lib/controllers/oauth.controller.ts
+++ b/packages/server/lib/controllers/oauth.controller.ts
@@ -504,7 +504,7 @@ class OAuthController {
                 void logCtx.error('Error during OAuth2 client credentials creation', { error, provider: config.provider });
                 await logCtx.failed();
 
-                errorManager.errRes(res, 'oauth2_cc_error');
+                errorManager.errRes(res, 'oauth2_cc_error', error);
 
                 return;
             }

--- a/packages/shared/lib/services/connection.service.ts
+++ b/packages/shared/lib/services/connection.service.ts
@@ -1369,9 +1369,13 @@ class ConnectionService {
             { logCtx, context: 'auth', valuesToFilter: [client_secret, client_private_key].filter(Boolean) as string[] }
         );
         if (fetchRes.isErr() || fetchRes.value.res.status >= 300) {
-            const error = new NangoError('client_credentials_fetch_error');
+            const payload = fetchRes.isErr()
+            ? { message: fetchRes.error.message }
+            : { status: fetchRes.value.res.status, body: fetchRes.value.body };
+
+            const error = new NangoError('client_credentials_fetch_error', payload);
             return { success: false, error, response: null };
-        }
+        } 
 
         const parsedCreds = this.parseRawCredentials(fetchRes.value.body, 'OAUTH2_CC', provider) as OAuth2ClientCredentials;
 

--- a/packages/shared/lib/utils/error.manager.ts
+++ b/packages/shared/lib/utils/error.manager.ts
@@ -68,8 +68,8 @@ class ErrorManager {
         }
     }
 
-    public errRes(res: Response, type: string) {
-        const err = new NangoError(type);
+    public errRes(res: Response, type: string, payload = {}) {
+        const err = new NangoError(type, payload);
         this.errResFromNangoErr(res, err);
     }
 

--- a/packages/shared/lib/utils/error.ts
+++ b/packages/shared/lib/utils/error.ts
@@ -117,6 +117,10 @@ export class NangoError extends NangoInternalError {
                 this.status = 400;
                 this.message = 'The requested OAuth scopes are invalid. OAuth scopes should be comma separated and not an array';
                 break;
+            case 'oauth2_cc_error':
+                this.status = 502;
+                this.message = 'OAuth2 client credentials token request failed.';
+                break;
 
             case 'invalid_invite_token':
                 this.status = 400;


### PR DESCRIPTION
## Summary

Fixes #6416.

OAuth2 Client Credentials failures were returned as an opaque `unhandled_oauth2_cc_error` with an empty payload, even though the underlying provider/token error was available internally.

This PR:
- registers `oauth2_cc_error` as a handled Nango error
- returns a 502 instead of falling through to the generic unhandled error wrapper
- allows `errorManager.errRes()` to include a payload
- preserves token fetch failure details from `getOauthClientCredentials()`

## Why

When an OAuth2 CC provider rejects a token request, integrators need the upstream status/body/message to diagnose the failure. Returning an empty `unhandled_*` error makes the failure look like an unexpected platform crash and hides the real provider response.

## Testing

Not run locally; sparse checkout was used to keep the clone small.

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/NangoHQ/nango/pull/6613?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

