### PR TITLE
feat(bird): default subdomain to `api`

### DIFF
--- a/packages/providers/providers.yaml
+++ b/packages/providers/providers.yaml
@@ -3191,6 +3191,7 @@ bird:
             title: Subdomain
             description: The subdomain of your Bird API instance
             example: api
+            default_value: api
             suffix: .bird.com
             prefix: https://
             order: 1


### PR DESCRIPTION
## What

Adds `default_value: api` to Bird's `subdomain` connection-config param.

```diff
         subdomain:
             type: string
             title: Subdomain
             description: The subdomain of your Bird API instance
             example: api
+            default_value: api
             suffix: .bird.com
             prefix: https://
```

## Why

Bird's standard REST API host is `https://api.bird.com` (per [docs.bird.com](https://docs.bird.com/api/api-access/common-api-usage)) — which is already this field's documented `example`. Without a `default_value`, every connection must manually enter the subdomain even though it's `api` in the overwhelming majority of cases. Adding the default lets the proxy resolve `https://api.bird.com` out of the box.

Callers on the non-default hosts (`media.api`, `email.{region}.api`) still override via the field as before — this only sets the common-case default.

Mirrors the existing `clio.hostname: default_value: app.clio.com` precedent for a host/subdomain field.

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/NangoHQ/nango/pull/6618?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

