### PR TITLE
feat(server): add NANGO_WEBHOOK_URL to decouple inbound webhook URL from NANGO_SERVER_URL

### DIFF
--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -34,6 +34,7 @@ services:
             - SERVER_PORT
             - CSP_REPORT_ONLY=true
             - NANGO_SERVER_URL=${NANGO_SERVER_URL:-http://localhost:3003}
+            - NANGO_WEBHOOK_URL=${NANGO_WEBHOOK_URL:-}
             - NANGO_PUBLIC_SERVER_URL=${NANGO_PUBLIC_SERVER_URL:-http://localhost:3000}
             - FLAG_AUTH_ENABLED
             - NANGO_DASHBOARD_USERNAME

--- a/docs/guides/platform/self-hosting.mdx
+++ b/docs/guides/platform/self-hosting.mdx
@@ -188,6 +188,14 @@ The resulting OAuth callback URL is `<INSTANCE-URL>/oauth/callback`.
 
 <Note>You can customize the callback URL by updating the "Callback URL" field in the "Environment Settings" tab in the Nango admin.</Note>
 
+By default, the inbound webhook URL (shown under Integrations > [Integration] > Webhooks and registered with providers) is also derived from `NANGO_SERVER_URL`. To route inbound provider webhooks through a separate host, set `NANGO_WEBHOOK_URL`:
+
+```sh
+NANGO_WEBHOOK_URL=<WEBHOOK-INSTANCE-URL>
+```
+
+The resulting webhook URL is `<WEBHOOK-INSTANCE-URL>/webhook/<environment-uuid>/<integration>`. When unset, it falls back to `NANGO_SERVER_URL`. This only affects the inbound webhook URL; the OAuth callback URL stays derived from `NANGO_SERVER_URL`.
+
 <Note>
 If you are using a custom domain, update `NANGO_SERVER_URL` to match it.
 </Note>

--- a/packages/shared/lib/utils/utils.ts
+++ b/packages/shared/lib/utils/utils.ts
@@ -169,7 +169,7 @@ export function getGlobalOAuthCallbackUrl() {
 }
 
 export function getGlobalWebhookReceiveUrl() {
-    const baseUrl = process.env['NANGO_SERVER_URL'] || getLocalOAuthCallbackUrlBaseUrl();
+    const baseUrl = process.env['NANGO_WEBHOOK_URL'] || process.env['NANGO_SERVER_URL'] || getLocalOAuthCallbackUrlBaseUrl();
     return baseUrl + '/webhook';
 }
 

--- a/packages/shared/lib/utils/utils.unit.test.ts
+++ b/packages/shared/lib/utils/utils.unit.test.ts
@@ -1,6 +1,6 @@
 import crypto from 'node:crypto';
 
-import { describe, expect, it, vi } from 'vitest';
+import { afterEach, describe, expect, it, vi } from 'vitest';
 
 import * as utils from './utils.js';
 
@@ -552,6 +552,33 @@ describe('makeUrl', () => {
         const config = { username: 'alice' };
         const result = utils.makeUrl(template, config, ['base_url']);
         expect(result.toString()).toBe('https://api.example.com/auth?user=alice');
+    });
+});
+
+describe('getGlobalWebhookReceiveUrl', () => {
+    afterEach(() => {
+        vi.unstubAllEnvs();
+    });
+
+    it('uses NANGO_WEBHOOK_URL when set', () => {
+        vi.stubEnv('NANGO_WEBHOOK_URL', 'https://webhooks.example.test');
+        vi.stubEnv('NANGO_SERVER_URL', 'https://api.example.test');
+
+        expect(utils.getGlobalWebhookReceiveUrl()).toBe('https://webhooks.example.test/webhook');
+    });
+
+    it('falls back to NANGO_SERVER_URL when NANGO_WEBHOOK_URL is not set', () => {
+        vi.stubEnv('NANGO_WEBHOOK_URL', '');
+        vi.stubEnv('NANGO_SERVER_URL', 'https://api.example.test');
+
+        expect(utils.getGlobalWebhookReceiveUrl()).toBe('https://api.example.test/webhook');
+    });
+
+    it('falls back to the local dev URL when neither is set', () => {
+        vi.stubEnv('NANGO_WEBHOOK_URL', '');
+        vi.stubEnv('NANGO_SERVER_URL', '');
+
+        expect(utils.getGlobalWebhookReceiveUrl()).toBe(`${utils.getLocalOAuthCallbackUrlBaseUrl()}/webhook`);
     });
 });
 

--- a/packages/utils/lib/environment/parse.ts
+++ b/packages/utils/lib/environment/parse.ts
@@ -26,6 +26,7 @@ export const ENVS = z.object({
     NANGO_PORT: z.coerce.number().optional().default(3003), // Sync those two ports?
     SERVER_PORT: z.coerce.number().optional().default(3003),
     NANGO_SERVER_URL: z.url().optional(),
+    NANGO_WEBHOOK_URL: z.url().optional(),
     NANGO_SERVER_KEEP_ALIVE_TIMEOUT: z.coerce.number().optional().default(61_000),
     DEFAULT_RATE_LIMIT_PER_MIN: z.coerce.number().min(1).optional().default(200),
     NANGO_CACHE_ENV_KEYS: z.stringbool().optional().default(false),

--- a/packages/utils/lib/environment/parse.unit.test.ts
+++ b/packages/utils/lib/environment/parse.unit.test.ts
@@ -24,6 +24,17 @@ describe('parse', () => {
         expect(res.E2B_SANDBOX_COMPILER_TEMPLATE).toBe('blank-workspace:dev');
     });
 
+    it('should parse a valid NANGO_WEBHOOK_URL', () => {
+        const res = parseEnvs(ENVS, { NANGO_WEBHOOK_URL: 'https://webhooks.example.com' });
+        expect(res.NANGO_WEBHOOK_URL).toBe('https://webhooks.example.com');
+    });
+
+    it('should throw on an invalid NANGO_WEBHOOK_URL', () => {
+        expect(() => {
+            parseEnvs(ENVS, { NANGO_WEBHOOK_URL: 'not-a-url' });
+        }).toThrowError();
+    });
+
     it('should parse E2B sandbox metric settings', () => {
         const res = parseEnvs(ENVS, {
             E2B_SANDBOX_METRICS_POLL_INTERVAL_MS: '120000',


### PR DESCRIPTION
## Summary

Adds an optional `NANGO_WEBHOOK_URL` env var so the inbound integration webhook base URL can be configured independently of `NANGO_SERVER_URL`.

`getGlobalWebhookReceiveUrl()` now resolves its base URL as `NANGO_WEBHOOK_URL` → `NANGO_SERVER_URL` → local dev URL. When `NANGO_WEBHOOK_URL` is unset, behavior is unchanged. The OAuth callback URL (`getGlobalOAuthCallbackUrl`) and the API base URL intentionally stay on `NANGO_SERVER_URL`.

This is the env-var mechanism proposed in #6614, mirroring how the OAuth callback URL is already decoupled from `NANGO_SERVER_URL`. It lets self-hosters route inbound `/webhook/*` traffic through a dedicated host/ingress (separate WAF/rate-limiting posture, stable webhook domain) while keeping the API surface internal.

## Changes

- `packages/utils/lib/environment/parse.ts` — declare `NANGO_WEBHOOK_URL` (`z.url().optional()`).
- `packages/shared/lib/utils/utils.ts` — `getGlobalWebhookReceiveUrl()` prefers `NANGO_WEBHOOK_URL`, falls back to `NANGO_SERVER_URL`. All downstream consumers (environment `webhook_receive_url`, integration `webhookUrl`, config controller, gmail routing) inherit the change automatically.
- `docs/guides/platform/self-hosting.mdx` — document the new variable.
- `docker-compose.yaml` — pass through `NANGO_WEBHOOK_URL` (empty default preserves fallback).
- Unit tests for env parsing and the three resolution branches.

## Backward compatibility

Fully backward compatible — when `NANGO_WEBHOOK_URL` is unset, the generated webhook URL is identical to today's.

## Testing

`npx vitest run packages/utils/lib/environment/parse.unit.test.ts packages/shared/lib/utils/utils.unit.test.ts` → all pass.

Closes #6614

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/NangoHQ/nango/pull/6621?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

