### PR TITLE
feat: add Applied Epic provider (OAuth2 client credentials)

### DIFF
--- a/docs/api-integrations/applied-epic.mdx
+++ b/docs/api-integrations/applied-epic.mdx
@@ -1,0 +1,74 @@
+---
+title: 'Applied Epic'
+sidebarTitle: 'Applied Epic'
+description: 'Integrate your application with the Applied Epic API'
+---
+
+## 🚀 Quickstart
+
+Connect to Applied Epic with Nango and see data flow in 2 minutes.
+
+<Steps>
+    <Step title="Create the integration">
+    In Nango ([free signup](https://app.nango.dev)), go to [Integrations](https://app.nango.dev/dev/integrations) -> _Configure New Integration_ -> _Applied Epic_.
+    </Step>
+    <Step title="Authorize Applied Epic">
+    Applied Epic uses OAuth2 client credentials (a 2-legged, app-to-app flow — there is no user redirect). Go to [Connections](https://app.nango.dev/dev/connections) -> _Add Test Connection_ -> _Authorize_, then enter your **Consumer Key** (client ID) and **Consumer Secret**. Later, you'll let your users do the same directly from your app.
+    </Step>
+    <Step title="Call the Applied Epic API">
+    Let's make your first request to the clients resource. Replace the placeholders below with your [secret key](https://app.nango.dev/dev/environment-settings), [integration ID](https://app.nango.dev/dev/integrations), and [connection ID](https://app.nango.dev/dev/connections):
+    <Tabs>
+        <Tab title="cURL">
+
+            ```bash
+            curl "https://api.nango.dev/proxy/crm/v1/clients?limit=10" \
+              -H "Authorization: Bearer <NANGO-SECRET-KEY>" \
+              -H "Provider-Config-Key: <INTEGRATION-ID>" \
+              -H "Connection-Id: <CONNECTION-ID>"
+            ```
+
+        </Tab>
+
+        <Tab title="Node">
+
+        Install Nango's backend SDK with `npm i @nangohq/node`. Then run:
+
+        ```typescript
+        import { Nango } from '@nangohq/node';
+
+        const nango = new Nango({ secretKey: '<NANGO-SECRET-KEY>' });
+
+        const res = await nango.get({
+            endpoint: '/crm/v1/clients',
+            params: {
+                limit: 10
+            },
+            providerConfigKey: '<INTEGRATION-ID>',
+            connectionId: '<CONNECTION-ID>'
+        });
+
+        console.log(res.data);
+        ```
+        </Tab>
+
+
+    </Tabs>
+    Or fetch credentials with the [Node SDK](/reference/sdks/node#get-a-connection-with-credentials) or [API](/reference/api/connection/get).
+
+    ✅ You're connected! Check the [Logs](https://app.nango.dev/dev/logs) tab in Nango to inspect requests.
+    </Step>
+
+    <Step title="Implement Nango in your app">
+        Follow our [Auth implementation guide](/guides/primitives/auth) to integrate Nango in your app.
+
+        To obtain your own production credentials, follow the setup guide linked below.
+    </Step>
+</Steps>
+
+## 🔑 Obtaining credentials
+
+Production access to the Applied Epic (Applied Systems) API is partner-gated. Register an application in the [Applied DevCenter](https://devcenter.myappliedproducts.com) to obtain your **Consumer Key** (`client_id`) and **Consumer Secret** (`client_secret`). Nango mints and refreshes the bearer token for you via the client-credentials flow.
+
+Official docs: [Applied DevCenter](https://devcenter.myappliedproducts.com/docs/overview)
+
+---

--- a/docs/docs.json
+++ b/docs/docs.json
@@ -950,6 +950,7 @@
               "integrations/all/apollo-oauth",
               "integrations/all/apple-app-store",
               "api-integrations/apple-business-manager",
+              "api-integrations/applied-epic",
               "integrations/all/appstle-subscriptions",
               "api-integrations/asana",
               "api-integrations/asana-mcp",

--- a/packages/providers/providers.yaml
+++ b/packages/providers/providers.yaml
@@ -1578,6 +1578,30 @@ apple-business-manager:
             description: The EC private key (PEM format) used to sign the client assertion JWT.
             doc_section: '#step-1-create-an-api-account-and-generate-a-private-key'
 
+applied-epic:
+    display_name: Applied Epic
+    categories:
+        - other
+    auth_mode: OAUTH2_CC
+    token_url: https://api.myappliedproducts.com/v1/auth/connect/token
+    token_request_auth_method: basic
+    token_params:
+        grant_type: client_credentials
+        audience: api.myappliedproducts.com/epic
+    proxy:
+        base_url: https://api.myappliedproducts.com
+    docs: https://nango.dev/docs/api-integrations/applied-epic
+    credentials:
+        client_id:
+            type: string
+            title: Consumer Key
+            description: Your Applied DevCenter application Consumer Key (client_id).
+        client_secret:
+            type: string
+            title: Consumer Secret
+            description: Your Applied DevCenter application Consumer Secret (client_secret).
+            secret: true
+
 appstle-subscriptions:
     display_name: Appstle Subscriptions
     categories:

--- a/packages/webapp/public/images/template-logos/applied-epic.svg
+++ b/packages/webapp/public/images/template-logos/applied-epic.svg
@@ -1,0 +1,1 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="62" height="62" fill="none"><rect width="62" height="62" rx="12" fill="#0A2540"/><path d="M31 14l13 26H18l13-26z" fill="#00B2A9"/><text x="31" y="55" font-family="Arial, sans-serif" font-size="11" font-weight="700" fill="#fff" text-anchor="middle">EPIC</text></svg>


### PR DESCRIPTION
## Description

Adds **Applied Epic** (Applied Systems) — an insurance brokerage management system — as a new provider.

Applied Epic's REST API (`api.myappliedproducts.com`) authenticates with **OAuth2 client credentials**: the `client_id` / `client_secret` are sent via HTTP Basic to `POST /v1/auth/connect/token` with `grant_type=client_credentials` and a **required** `audience=api.myappliedproducts.com/epic`, returning a ~1h bearer token.

## What's included
- `packages/providers/providers.yaml` — `applied-epic` entry (`auth_mode: OAUTH2_CC`, `token_request_auth_method: basic`, `audience` token param, `proxy.base_url`).
- `docs/api-integrations/applied-epic.mdx` — quickstart guide (+ `docs/docs.json` nav entry).
- `packages/webapp/public/images/template-logos/applied-epic.svg` — logo (placeholder; happy to swap for the official brand asset if you have a preferred source).

## Verification
The auth + token flow was verified end-to-end against the Applied **mock** environment: a `client_credentials` token was minted (HTTP Basic + `audience`) and `GET /crm/v1/clients` returned `200`. Production access is partner-gated via the [Applied DevCenter](https://devcenter.myappliedproducts.com).

## Notes
- No pre-built syncs/actions are included — this is the auth + proxy provider definition only.
- `token_request_auth_method: basic` follows the same pattern as `1password-users`, `8x8`, and `checkout-com`.


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/NangoHQ/nango/pull/6622?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

