### PR TITLE
fix(webapp): coerce authorization params to strings on form reset

### DIFF
--- a/packages/webapp/src/pages/Connection/Create.tsx
+++ b/packages/webapp/src/pages/Connection/Create.tsx
@@ -73,7 +73,7 @@ export const ConnectionCreate: React.FC = () => {
             testUserEmail: user!.email,
             testUserName: user!.name,
             testUserTags: {},
-            overrideAuthParams: integration?.meta.authorizationParams ?? {},
+            overrideAuthParams: Object.fromEntries(Object.entries(integration?.meta.authorizationParams ?? {}).map(([k, v]) => [k, String(v)])),
             overrideOauthScopes: integration?.oauth_scopes || undefined,
             overrideDevAppCredentials: false,
             overrideDocUrl: ''


### PR DESCRIPTION
## Describe the problem and your solution

- When an integration is selected, the form resets with `overrideAuthParams` set directly from `integration.meta.authorizationParams`. YAML boolean values (e.g. `true`) arrive as booleans at runtime, but the zod schema expects `z.record(z.string(), z.string())`. The boolean fails string validation, so `formState.isValid` is false and the `Authorize` button stays disabled, until the user types in the field, which triggers onChange with string values and unblocks validation.

<!-- Issue ticket number and link (if applicable) -->

<!-- Testing instructions (skip if just adding/editing providers) -->



<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/NangoHQ/nango/pull/6626?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

