### PR TITLE
docs: use checkpoints in sync webhooks to check for sync type

### DIFF
--- a/docs/guides/platform/webhooks-from-nango.mdx
+++ b/docs/guides/platform/webhooks-from-nango.mdx
@@ -257,18 +257,27 @@ Payload received following a successful sync execution:
     "providerConfigKey": "<your-integration-id>",
     "syncName": "<your-sync-script-name>",
     "model": "<your-model-name>",
-    "syncType": "INCREMENTAL | INITIAL | WEBHOOK", // DEPRECATED
+    "syncType": "INCREMENTAL | INITIAL | WEBHOOK", // DEPRECATED — use checkpoints.from instead
     "success": true,
     "modifiedAfter": "<timestamp>",
     "responseResults": {
         "added": number,
         "updated": number,
         "deleted": number
+    },
+    "checkpoints": {
+        "from": "<previous-checkpoint> | null",
+        "to": "<latest-checkpoint> | null"
     }
 }
 ```
 
 `modifiedAfter` is an ISO-8601 timestamp marking the start of the last run. To read the changed records, use cursor-based fetching as described in [Records cache → Cursors and sync progress](/guides/functions/syncs/records-cache#cursors-and-sync-progress).
+
+**Distinguishing full vs incremental syncs:** use `checkpoints.from` instead of the deprecated `syncType` field.
+
+- `checkpoints.from === null` — the run started with no prior state. This happens on the first run, after a manual reset, or when the sync explicitly cleared its checkpoint. Treat this as a full sync and overwrite your data.
+- `checkpoints.from !== null` — the run continued from a previously saved checkpoint. This is an incremental sync; merge the new records into your existing data.
 
 <Warning>
 **Fetch records promptly**: Due to Nango's [data retention policies](/guides/platform/security#synced-records-retention), you should fetch and store synced records in your own system promptly after receiving webhook notifications. Records not updated for 30 days will have their payload pruned, and sync functions not executed for 60 days will have all records deleted.
@@ -292,14 +301,18 @@ Payload received following a failed sync execution:
     "providerConfigKey": "<your-integration-id>",
     "syncName": "<your-sync-script-name>",
     "model": "<your-model-name>",
-    "syncType": "INCREMENTAL | INITIAL | WEBHOOK", // DEPRECATED
-    "success": true,
+    "syncType": "INCREMENTAL | INITIAL | WEBHOOK", // DEPRECATED — use checkpoints.from instead
+    "success": false,
     "error": {
         "type": "<string>",
         "description": "<string>"
     },
     "startedAt": "<timestamp>",
-    "failedAt": "<timestamp>"
+    "failedAt": "<timestamp>",
+    "checkpoints": {
+        "from": "<previous-checkpoint> | null",
+        "to": "<latest-checkpoint> | null"
+    }
 }
 ```
 

--- a/docs/guides/platform/webhooks-from-nango.mdx
+++ b/docs/guides/platform/webhooks-from-nango.mdx
@@ -257,7 +257,7 @@ Payload received following a successful sync execution:
     "providerConfigKey": "<your-integration-id>",
     "syncName": "<your-sync-script-name>",
     "model": "<your-model-name>",
-    "syncType": "INCREMENTAL | INITIAL | WEBHOOK", // DEPRECATED — use checkpoints.from instead
+    "syncType": "INCREMENTAL | INITIAL | WEBHOOK", // DEPRECATED — use checkpoints instead
     "success": true,
     "modifiedAfter": "<timestamp>",
     "responseResults": {
@@ -265,19 +265,27 @@ Payload received following a successful sync execution:
         "updated": number,
         "deleted": number
     },
+    // checkpoints itself may be missing or null if the sync doesn't use checkpoints —
+    // always guard against that before reading `from`/`to`.
     "checkpoints": {
-        "from": "<previous-checkpoint> | null",
-        "to": "<latest-checkpoint> | null"
+        "from": { "<key>": "<string | number | boolean>" }, // or null if no prior checkpoint
+        "to": { "<key>": "<string | number | boolean>" } // or null if the sync didn't save one
     }
 }
 ```
 
 `modifiedAfter` is an ISO-8601 timestamp marking the start of the last run. To read the changed records, use cursor-based fetching as described in [Records cache → Cursors and sync progress](/guides/functions/syncs/records-cache#cursors-and-sync-progress).
 
-**Distinguishing full vs incremental syncs:** use `checkpoints.from` instead of the deprecated `syncType` field.
+**Distinguishing full vs incremental syncs:** use `checkpoints` instead of the deprecated `syncType` field. `checkpoints.from`/`checkpoints.to` are checkpoint objects (`Record<string, string | number | boolean>`) as saved by the sync function via `saveCheckpoint()` — not strings — and either can be `null`. The `checkpoints` field itself can also be missing or `null`, so guard against that before reading nested fields:
 
-- `checkpoints.from === null` — the run started with no prior state. This happens on the first run, after a manual reset, or when the sync explicitly cleared its checkpoint. Treat this as a full sync and overwrite your data.
-- `checkpoints.from !== null` — the run continued from a previously saved checkpoint. This is an incremental sync; merge the new records into your existing data.
+```javascript
+const { checkpoints } = payload;
+const isFullSync = !checkpoints || checkpoints.from === null;
+```
+
+- `checkpoints` is missing/`null`, or `checkpoints.from === null` — the run started with no prior state. This happens on the first run, after a manual reset, or when the sync explicitly cleared its checkpoint. Treat this as a full sync and overwrite your data.
+- `checkpoints.from` is a non-null checkpoint object — the run continued from a previously saved checkpoint. This is an incremental sync; merge the new records into your existing data.
+- **Webhook-triggered runs** (deprecated `syncType: "WEBHOOK"`): always treat these as incremental merges, regardless of `checkpoints.from`. A webhook-triggered run processes a single incoming external event on top of already-synced data — it never represents a full resync.
 
 <Warning>
 **Fetch records promptly**: Due to Nango's [data retention policies](/guides/platform/security#synced-records-retention), you should fetch and store synced records in your own system promptly after receiving webhook notifications. Records not updated for 30 days will have their payload pruned, and sync functions not executed for 60 days will have all records deleted.
@@ -301,7 +309,7 @@ Payload received following a failed sync execution:
     "providerConfigKey": "<your-integration-id>",
     "syncName": "<your-sync-script-name>",
     "model": "<your-model-name>",
-    "syncType": "INCREMENTAL | INITIAL | WEBHOOK", // DEPRECATED — use checkpoints.from instead
+    "syncType": "INCREMENTAL | INITIAL | WEBHOOK", // DEPRECATED — use checkpoints instead
     "success": false,
     "error": {
         "type": "<string>",
@@ -309,9 +317,10 @@ Payload received following a failed sync execution:
     },
     "startedAt": "<timestamp>",
     "failedAt": "<timestamp>",
+    // checkpoints itself may be missing or null — see the note above.
     "checkpoints": {
-        "from": "<previous-checkpoint> | null",
-        "to": "<latest-checkpoint> | null"
+        "from": { "<key>": "<string | number | boolean>" }, // or null
+        "to": { "<key>": "<string | number | boolean>" } // or null
     }
 }
 ```

--- a/docs/llms-full.txt
+++ b/docs/llms-full.txt
@@ -7152,18 +7152,27 @@ Payload received following a successful sync execution:
     "providerConfigKey": "<your-integration-id>",
     "syncName": "<your-sync-script-name>",
     "model": "<your-model-name>",
-    "syncType": "INCREMENTAL | INITIAL | WEBHOOK", // DEPRECATED
+    "syncType": "INCREMENTAL | INITIAL | WEBHOOK", // DEPRECATED — use checkpoints.from instead
     "success": true,
     "modifiedAfter": "<timestamp>",
     "responseResults": {
         "added": number,
         "updated": number,
         "deleted": number
+    },
+    "checkpoints": {
+        "from": "<previous-checkpoint> | null",
+        "to": "<latest-checkpoint> | null"
     }
 }
 ```
 
 `modifiedAfter` is an ISO-8601 timestamp marking the start of the last run. To read the changed records, use cursor-based fetching as described in [Records cache → Cursors and sync progress](/guides/functions/syncs/records-cache#cursors-and-sync-progress).
+
+**Distinguishing full vs incremental syncs:** use `checkpoints.from` instead of the deprecated `syncType` field.
+
+- `checkpoints.from === null` — the run started with no prior state. This happens on the first run, after a manual reset, or when the sync explicitly cleared its checkpoint. Treat this as a full sync and overwrite your data.
+- `checkpoints.from !== null` — the run continued from a previously saved checkpoint. This is an incremental sync; merge the new records into your existing data.
 
 <Warning>
 **Fetch records promptly**: Due to Nango's [data retention policies](/guides/platform/security#synced-records-retention), you should fetch and store synced records in your own system promptly after receiving webhook notifications. Records not updated for 30 days will have their payload pruned, and sync functions not executed for 60 days will have all records deleted.
@@ -7187,14 +7196,18 @@ Payload received following a failed sync execution:
     "providerConfigKey": "<your-integration-id>",
     "syncName": "<your-sync-script-name>",
     "model": "<your-model-name>",
-    "syncType": "INCREMENTAL | INITIAL | WEBHOOK", // DEPRECATED
-    "success": true,
+    "syncType": "INCREMENTAL | INITIAL | WEBHOOK", // DEPRECATED — use checkpoints.from instead
+    "success": false,
     "error": {
         "type": "<string>",
         "description": "<string>"
     },
     "startedAt": "<timestamp>",
-    "failedAt": "<timestamp>"
+    "failedAt": "<timestamp>",
+    "checkpoints": {
+        "from": "<previous-checkpoint> | null",
+        "to": "<latest-checkpoint> | null"
+    }
 }
 ```
 

--- a/docs/llms-full.txt
+++ b/docs/llms-full.txt
@@ -7152,7 +7152,7 @@ Payload received following a successful sync execution:
     "providerConfigKey": "<your-integration-id>",
     "syncName": "<your-sync-script-name>",
     "model": "<your-model-name>",
-    "syncType": "INCREMENTAL | INITIAL | WEBHOOK", // DEPRECATED — use checkpoints.from instead
+    "syncType": "INCREMENTAL | INITIAL | WEBHOOK", // DEPRECATED — use checkpoints instead
     "success": true,
     "modifiedAfter": "<timestamp>",
     "responseResults": {
@@ -7160,19 +7160,27 @@ Payload received following a successful sync execution:
         "updated": number,
         "deleted": number
     },
+    // checkpoints itself may be missing or null if the sync doesn't use checkpoints —
+    // always guard against that before reading `from`/`to`.
     "checkpoints": {
-        "from": "<previous-checkpoint> | null",
-        "to": "<latest-checkpoint> | null"
+        "from": { "<key>": "<string | number | boolean>" }, // or null if no prior checkpoint
+        "to": { "<key>": "<string | number | boolean>" } // or null if the sync didn't save one
     }
 }
 ```
 
 `modifiedAfter` is an ISO-8601 timestamp marking the start of the last run. To read the changed records, use cursor-based fetching as described in [Records cache → Cursors and sync progress](/guides/functions/syncs/records-cache#cursors-and-sync-progress).
 
-**Distinguishing full vs incremental syncs:** use `checkpoints.from` instead of the deprecated `syncType` field.
+**Distinguishing full vs incremental syncs:** use `checkpoints` instead of the deprecated `syncType` field. `checkpoints.from`/`checkpoints.to` are checkpoint objects (`Record<string, string | number | boolean>`) as saved by the sync function via `saveCheckpoint()` — not strings — and either can be `null`. The `checkpoints` field itself can also be missing or `null`, so guard against that before reading nested fields:
 
-- `checkpoints.from === null` — the run started with no prior state. This happens on the first run, after a manual reset, or when the sync explicitly cleared its checkpoint. Treat this as a full sync and overwrite your data.
-- `checkpoints.from !== null` — the run continued from a previously saved checkpoint. This is an incremental sync; merge the new records into your existing data.
+```javascript
+const { checkpoints } = payload;
+const isFullSync = !checkpoints || checkpoints.from === null;
+```
+
+- `checkpoints` is missing/`null`, or `checkpoints.from === null` — the run started with no prior state. This happens on the first run, after a manual reset, or when the sync explicitly cleared its checkpoint. Treat this as a full sync and overwrite your data.
+- `checkpoints.from` is a non-null checkpoint object — the run continued from a previously saved checkpoint. This is an incremental sync; merge the new records into your existing data.
+- **Webhook-triggered runs** (deprecated `syncType: "WEBHOOK"`): always treat these as incremental merges, regardless of `checkpoints.from`. A webhook-triggered run processes a single incoming external event on top of already-synced data — it never represents a full resync.
 
 <Warning>
 **Fetch records promptly**: Due to Nango's [data retention policies](/guides/platform/security#synced-records-retention), you should fetch and store synced records in your own system promptly after receiving webhook notifications. Records not updated for 30 days will have their payload pruned, and sync functions not executed for 60 days will have all records deleted.
@@ -7196,7 +7204,7 @@ Payload received following a failed sync execution:
     "providerConfigKey": "<your-integration-id>",
     "syncName": "<your-sync-script-name>",
     "model": "<your-model-name>",
-    "syncType": "INCREMENTAL | INITIAL | WEBHOOK", // DEPRECATED — use checkpoints.from instead
+    "syncType": "INCREMENTAL | INITIAL | WEBHOOK", // DEPRECATED — use checkpoints instead
     "success": false,
     "error": {
         "type": "<string>",
@@ -7204,9 +7212,10 @@ Payload received following a failed sync execution:
     },
     "startedAt": "<timestamp>",
     "failedAt": "<timestamp>",
+    // checkpoints itself may be missing or null — see the note above.
     "checkpoints": {
-        "from": "<previous-checkpoint> | null",
-        "to": "<latest-checkpoint> | null"
+        "from": { "<key>": "<string | number | boolean>" }, // or null
+        "to": { "<key>": "<string | number | boolean>" } // or null
     }
 }
 ```

--- a/docs/snippets/generated/workday-cc/PreBuiltTooling.mdx
+++ b/docs/snippets/generated/workday-cc/PreBuiltTooling.mdx
@@ -3,8 +3,7 @@
 <Accordion title="✅ Authorization">
 | Tools | Status |
 | - | - |
-| Pre-built authorization (OAuth) | ✅ |
-| Credentials auto-refresh | ✅ |
+| Pre-built authorization (Two Step) | ✅ |
 | Pre-built authorization UI | ✅ |
 | Custom authorization UI | ✅ |
 | End-user authorization guide | ✅ |


### PR DESCRIPTION
## Describe the problem and your solution

- use checkpoints in sync webhooks to check for sync type

<!-- Issue ticket number and link (if applicable) -->

<!-- Testing instructions (skip if just adding/editing providers) -->



<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/NangoHQ/nango/pull/6629?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

