### PR TITLE
fix(cli,dashboard): resolve symlinked integrations in pull and github links

### DIFF
--- a/packages/cli/lib/services/clone.service.ts
+++ b/packages/cli/lib/services/clone.service.ts
@@ -143,16 +143,14 @@ export async function cloneTemplate(options: CloneOptions): Promise<boolean> {
         printDebug(`Resolved template path: ${JSON.stringify(resolved)}`, debug);
         spinner.text = `Fetching file list for: ${templatePath}`;
 
-        const { files: remoteFiles, contentCache: remoteCache } = await getFilesToClone(resolved, debug);
+        const { files: remoteFiles, contentCache } = await getFilesToClone(resolved, debug);
 
-        // Files are fetched from the resolved (target) folder but written under the requested name.
+        // Keep the remote path for fetching (and cache lookups); write under the requested name.
         const files = remoteFiles.map((file) => ({
             ...file,
+            remotePath: file.relativePath,
             relativePath: localizeIntegrationPath(file.relativePath, resolved.integration, resolved.sourceIntegration)
         }));
-        const contentCache = new Map(
-            [...remoteCache].map(([key, value]) => [localizeIntegrationPath(key, resolved.integration, resolved.sourceIntegration), value])
-        );
 
         if (files.length === 0) {
             spinner.fail(`No files found for template: ${templatePath}`);
@@ -182,10 +180,10 @@ export async function cloneTemplate(options: CloneOptions): Promise<boolean> {
 
             try {
                 let content: string;
-                if (contentCache.has(file.relativePath)) {
-                    content = contentCache.get(file.relativePath)!;
+                if (contentCache.has(file.remotePath)) {
+                    content = contentCache.get(file.remotePath)!;
                 } else {
-                    content = await fetchFileContent(file.relativePath, debug);
+                    content = await fetchFileContent(file.remotePath, debug);
                 }
                 const localPath = path.join(fullPath, file.relativePath);
 

--- a/packages/cli/lib/services/clone.service.ts
+++ b/packages/cli/lib/services/clone.service.ts
@@ -4,7 +4,15 @@ import path from 'node:path';
 import chalk from 'chalk';
 
 import { printDebug } from '../utils.js';
-import { collectDependencies, fetchDirectoryRecursively, fetchFileContent, fetchGitHubDirectory, GitHubNotFoundError } from '../utils/githubTemplates.js';
+import {
+    collectDependencies,
+    fetchDirectoryRecursively,
+    fetchFileContent,
+    fetchGitHubDirectory,
+    GitHubNotFoundError,
+    localizeIntegrationPath,
+    resolveIntegrationFolder
+} from '../utils/githubTemplates.js';
 import { checkExistingFiles, updateIndexFile } from '../utils/integrationFiles.js';
 import { Spinner } from '../utils/spinner.js';
 
@@ -21,7 +29,10 @@ interface ResolvedTemplatePath {
     type: 'directory' | 'file';
     path: string;
     mdPath?: string | undefined;
+    // Real templates-repo folder used for fetching (resolves through symlinks).
     integration: string;
+    // Folder name the user requested; where files are written locally.
+    sourceIntegration: string;
 }
 
 /**
@@ -29,18 +40,25 @@ interface ResolvedTemplatePath {
  * - If the path matches a directory, returns type: 'directory'
  * - If the path doesn't exist but {path}.ts exists, returns type: 'file' with optional .md
  * - Throws GitHubNotFoundError if neither exists
+ *
+ * Symlinked integrations (e.g. `quickbooks-sandbox` → `quickbooks`) are resolved to their target
+ * folder for fetching, while `sourceIntegration` preserves the requested name for local writes.
  */
 async function resolveTemplatePath(templatePath: string, debug: boolean): Promise<ResolvedTemplatePath> {
-    const integration = templatePath.split('/')[0];
-    if (!integration) {
+    const segments = templatePath.split('/');
+    const sourceIntegration = segments[0];
+    if (!sourceIntegration) {
         throw new Error('Template path cannot be empty');
     }
 
+    const integration = await resolveIntegrationFolder(sourceIntegration, debug);
+    const remotePath = [integration, ...segments.slice(1)].join('/');
+
     // First, try to fetch as a directory
     try {
-        await fetchGitHubDirectory(templatePath, debug);
-        printDebug(`Path "${templatePath}" resolved as directory`, debug);
-        return { type: 'directory', path: templatePath, integration };
+        await fetchGitHubDirectory(remotePath, debug);
+        printDebug(`Path "${remotePath}" resolved as directory`, debug);
+        return { type: 'directory', path: remotePath, integration, sourceIntegration };
     } catch (err) {
         if (!(err instanceof GitHubNotFoundError)) {
             throw err; // Re-throw rate limits, network errors, etc.
@@ -48,27 +66,28 @@ async function resolveTemplatePath(templatePath: string, debug: boolean): Promis
         // Directory doesn't exist, try as file
     }
 
-    const tsPath = `${templatePath}.ts`;
+    const tsPath = `${remotePath}.ts`;
     try {
         await fetchFileContent(tsPath, debug);
-        printDebug(`Path "${templatePath}" resolved as file: ${tsPath}`, debug);
+        printDebug(`Path "${remotePath}" resolved as file: ${tsPath}`, debug);
 
         // Check if companion .md file exists
-        const mdPath = `${templatePath}.md`;
+        const mdPath = `${remotePath}.md`;
         let hasMdFile = false;
         try {
             await fetchFileContent(mdPath, debug);
             hasMdFile = true;
             printDebug(`Found companion documentation: ${mdPath}`, debug);
         } catch {
-            printDebug(`No companion documentation found for ${templatePath}`, debug);
+            printDebug(`No companion documentation found for ${remotePath}`, debug);
         }
 
         return {
             type: 'file',
             path: tsPath,
             mdPath: hasMdFile ? mdPath : undefined,
-            integration
+            integration,
+            sourceIntegration
         };
     } catch (err) {
         if (!(err instanceof GitHubNotFoundError)) {
@@ -77,7 +96,7 @@ async function resolveTemplatePath(templatePath: string, debug: boolean): Promis
     }
 
     // Neither directory nor file exists
-    throw new GitHubNotFoundError(templatePath);
+    throw new GitHubNotFoundError(remotePath);
 }
 
 interface FilesToClone {
@@ -124,7 +143,17 @@ export async function cloneTemplate(options: CloneOptions): Promise<boolean> {
         printDebug(`Resolved template path: ${JSON.stringify(resolved)}`, debug);
         spinner.text = `Fetching file list for: ${templatePath}`;
 
-        const { files, contentCache } = await getFilesToClone(resolved, debug);
+        const { files: remoteFiles, contentCache: remoteCache } = await getFilesToClone(resolved, debug);
+
+        // Files are fetched from the resolved (target) folder but written under the requested name.
+        const files = remoteFiles.map((file) => ({
+            ...file,
+            relativePath: localizeIntegrationPath(file.relativePath, resolved.integration, resolved.sourceIntegration)
+        }));
+        const contentCache = new Map(
+            [...remoteCache].map(([key, value]) => [localizeIntegrationPath(key, resolved.integration, resolved.sourceIntegration), value])
+        );
+
         if (files.length === 0) {
             spinner.fail(`No files found for template: ${templatePath}`);
             return false;

--- a/packages/cli/lib/services/clone.service.ts
+++ b/packages/cli/lib/services/clone.service.ts
@@ -16,6 +16,8 @@ import {
 import { checkExistingFiles, updateIndexFile } from '../utils/integrationFiles.js';
 import { Spinner } from '../utils/spinner.js';
 
+import type { GitHubDirectoryItem } from '../utils/githubTemplates.js';
+
 interface CloneOptions {
     fullPath: string;
     templatePath: string;
@@ -33,6 +35,8 @@ interface ResolvedTemplatePath {
     integration: string;
     // Folder name the user requested; where files are written locally.
     sourceIntegration: string;
+    // Directory listing already fetched during resolution (directory type only), to avoid re-fetching.
+    contents?: GitHubDirectoryItem[] | undefined;
 }
 
 /**
@@ -51,14 +55,20 @@ async function resolveTemplatePath(templatePath: string, debug: boolean): Promis
         throw new Error('Template path cannot be empty');
     }
 
-    const integration = await resolveIntegrationFolder(sourceIntegration, debug);
+    const { folder: integration, contents } = await resolveIntegrationFolder(sourceIntegration, debug);
     const remotePath = [integration, ...segments.slice(1)].join('/');
+
+    // Whole-integration request of a real directory: reuse the listing fetched during resolution.
+    if (segments.length === 1 && contents) {
+        printDebug(`Path "${remotePath}" resolved as directory (reused listing)`, debug);
+        return { type: 'directory', path: remotePath, integration, sourceIntegration, contents };
+    }
 
     // First, try to fetch as a directory
     try {
-        await fetchGitHubDirectory(remotePath, debug);
+        const dirContents = await fetchGitHubDirectory(remotePath, debug);
         printDebug(`Path "${remotePath}" resolved as directory`, debug);
-        return { type: 'directory', path: remotePath, integration, sourceIntegration };
+        return { type: 'directory', path: remotePath, integration, sourceIntegration, contents: dirContents };
     } catch (err) {
         if (!(err instanceof GitHubNotFoundError)) {
             throw err; // Re-throw rate limits, network errors, etc.
@@ -109,7 +119,7 @@ interface FilesToClone {
  */
 async function getFilesToClone(resolved: ResolvedTemplatePath, debug: boolean): Promise<FilesToClone> {
     const files: { relativePath: string; isScript: boolean }[] = [];
-    const { type, path: resolvedPath, mdPath, integration } = resolved;
+    const { type, path: resolvedPath, mdPath, integration, contents } = resolved;
 
     if (type === 'file') {
         const isScript = /\/(actions|syncs)\/[^/]+\.ts$/.test(resolvedPath);
@@ -118,7 +128,7 @@ async function getFilesToClone(resolved: ResolvedTemplatePath, debug: boolean): 
             files.push({ relativePath: mdPath, isScript: false });
         }
     } else {
-        const dirFiles = await fetchDirectoryRecursively(resolvedPath, debug);
+        const dirFiles = await fetchDirectoryRecursively(resolvedPath, debug, contents);
         files.push(...dirFiles);
     }
 

--- a/packages/cli/lib/services/clone.service.unit.test.ts
+++ b/packages/cli/lib/services/clone.service.unit.test.ts
@@ -1,0 +1,114 @@
+import fs from 'node:fs';
+
+import axios, { AxiosError } from 'axios';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+
+import { cloneTemplate } from './clone.service.js';
+
+const RAW_BASE = 'https://raw.githubusercontent.com/NangoHQ/integration-templates/main/integrations';
+const API_BASE = 'https://api.github.com/repos/NangoHQ/integration-templates/contents/integrations';
+
+function buildNotFoundError(url: string): AxiosError {
+    return new AxiosError('Not Found', '404', undefined, undefined, {
+        status: 404,
+        statusText: 'Not Found',
+        headers: {},
+        config: { url } as any,
+        data: ''
+    });
+}
+
+/**
+ * @param files          raw file path -> content (raw.githubusercontent.com)
+ * @param dirs           directory path -> Contents API listing (array responses)
+ * @param symlinks       integration folder -> symlink target
+ */
+function mockGitHub(files: Record<string, string>, dirs: Record<string, any[]> = {}, symlinks: Record<string, string> = {}) {
+    vi.spyOn(axios, 'get').mockImplementation((url: string) => {
+        if (url.startsWith(`${API_BASE}/`)) {
+            const apiPath = url.slice(`${API_BASE}/`.length);
+            if (Object.prototype.hasOwnProperty.call(symlinks, apiPath)) {
+                return Promise.resolve({
+                    data: { name: apiPath, path: `integrations/${apiPath}`, type: 'symlink', target: symlinks[apiPath] }
+                } as any);
+            }
+            if (Object.prototype.hasOwnProperty.call(dirs, apiPath)) {
+                return Promise.resolve({ data: dirs[apiPath] } as any);
+            }
+            return Promise.reject(buildNotFoundError(url));
+        }
+        const relative = url.replace(`${RAW_BASE}/`, '');
+        if (Object.prototype.hasOwnProperty.call(files, relative)) {
+            return Promise.resolve({ data: files[relative] } as any);
+        }
+        return Promise.reject(buildNotFoundError(url));
+    });
+}
+
+function mockFsForWriting() {
+    vi.spyOn(fs, 'existsSync').mockReturnValue(false);
+    vi.spyOn(fs.promises, 'mkdir').mockResolvedValue(undefined);
+    const writeSpy = vi.spyOn(fs.promises, 'writeFile').mockResolvedValue(undefined);
+    vi.spyOn(fs.promises, 'readFile').mockResolvedValue('');
+    return writeSpy;
+}
+
+const baseOptions = {
+    fullPath: '/project',
+    debug: false,
+    force: false,
+    autoConfirm: true,
+    interactive: false
+};
+
+describe('cloneTemplate', () => {
+    beforeEach(() => {
+        vi.spyOn(console, 'log').mockImplementation(() => {});
+    });
+
+    afterEach(() => {
+        vi.restoreAllMocks();
+    });
+
+    it('clones a single function from a real integration', async () => {
+        mockGitHub({ 'github/actions/list-repos.ts': 'export default async function () {}' }, { github: [] });
+        const writeSpy = mockFsForWriting();
+
+        const success = await cloneTemplate({ ...baseOptions, templatePath: 'github/actions/list-repos' });
+
+        expect(success).toBe(true);
+        const writtenPaths = writeSpy.mock.calls.map((call) => call[0] as string);
+        expect(writtenPaths).toContain('/project/github/actions/list-repos.ts');
+    });
+
+    it('fetches a symlinked function from its target but writes under the requested name', async () => {
+        mockGitHub({ 'quickbooks/syncs/customers.ts': 'export default async function () {}' }, {}, { 'quickbooks-sandbox': 'quickbooks' });
+        const writeSpy = mockFsForWriting();
+        const axiosSpy = vi.spyOn(axios, 'get');
+
+        const success = await cloneTemplate({ ...baseOptions, templatePath: 'quickbooks-sandbox/syncs/customers' });
+
+        expect(success).toBe(true);
+        expect(axiosSpy.mock.calls.map((call) => call[0])).toContain(`${RAW_BASE}/quickbooks/syncs/customers.ts`);
+        const writtenPaths = writeSpy.mock.calls.map((call) => call[0] as string);
+        expect(writtenPaths).toContain('/project/quickbooks-sandbox/syncs/customers.ts');
+    });
+
+    it('clones a whole symlinked integration directory under the requested name', async () => {
+        mockGitHub(
+            { 'quickbooks/syncs/customers.ts': 'export default async function () {}' },
+            {
+                quickbooks: [{ name: 'syncs', path: 'integrations/quickbooks/syncs', type: 'dir' }],
+                'quickbooks/syncs': [{ name: 'customers.ts', path: 'integrations/quickbooks/syncs/customers.ts', type: 'file' }]
+            },
+            { 'quickbooks-sandbox': 'quickbooks' }
+        );
+        const writeSpy = mockFsForWriting();
+
+        const success = await cloneTemplate({ ...baseOptions, templatePath: 'quickbooks-sandbox' });
+
+        expect(success).toBe(true);
+        const writtenPaths = writeSpy.mock.calls.map((call) => call[0] as string);
+        expect(writtenPaths).toContain('/project/quickbooks-sandbox/syncs/customers.ts');
+    });
+});

--- a/packages/cli/lib/services/clone.service.unit.test.ts
+++ b/packages/cli/lib/services/clone.service.unit.test.ts
@@ -94,6 +94,28 @@ describe('cloneTemplate', () => {
         expect(writtenPaths).toContain('/project/quickbooks-sandbox/syncs/customers.ts');
     });
 
+    it('writes the companion .md of a symlinked function, fetching it from the target folder', async () => {
+        mockGitHub(
+            {
+                'quickbooks/syncs/customers.ts': 'export default async function () {}',
+                'quickbooks/syncs/customers.md': '# Customers'
+            },
+            {},
+            { 'quickbooks-sandbox': 'quickbooks' }
+        );
+        const writeSpy = mockFsForWriting();
+        const axiosSpy = vi.spyOn(axios, 'get');
+
+        const success = await cloneTemplate({ ...baseOptions, templatePath: 'quickbooks-sandbox/syncs/customers' });
+
+        expect(success).toBe(true);
+        // The .md is not cached during dependency collection, so it must be fetched from the target folder...
+        expect(axiosSpy.mock.calls.map((call) => call[0])).toContain(`${RAW_BASE}/quickbooks/syncs/customers.md`);
+        // ...and written under the requested name.
+        const writtenPaths = writeSpy.mock.calls.map((call) => call[0] as string);
+        expect(writtenPaths).toContain('/project/quickbooks-sandbox/syncs/customers.md');
+    });
+
     it('clones a whole symlinked integration directory under the requested name', async () => {
         mockGitHub(
             { 'quickbooks/syncs/customers.ts': 'export default async function () {}' },

--- a/packages/cli/lib/services/clone.service.unit.test.ts
+++ b/packages/cli/lib/services/clone.service.unit.test.ts
@@ -116,6 +116,25 @@ describe('cloneTemplate', () => {
         expect(writtenPaths).toContain('/project/quickbooks-sandbox/syncs/customers.md');
     });
 
+    it('reuses the listing from resolution and fetches the integration root only once', async () => {
+        mockGitHub(
+            { 'github/actions/list-repos.ts': 'export default async function () {}' },
+            {
+                github: [{ name: 'actions', path: 'integrations/github/actions', type: 'dir' }],
+                'github/actions': [{ name: 'list-repos.ts', path: 'integrations/github/actions/list-repos.ts', type: 'file' }]
+            }
+        );
+        const axiosSpy = vi.spyOn(axios, 'get');
+        mockFsForWriting();
+
+        const success = await cloneTemplate({ ...baseOptions, templatePath: 'github' });
+
+        expect(success).toBe(true);
+        // The integration root is fetched once (during resolution), not again by the directory probe or recursive walk.
+        const rootFetches = axiosSpy.mock.calls.map((call) => call[0]).filter((url) => url === `${API_BASE}/github`);
+        expect(rootFetches).toHaveLength(1);
+    });
+
     it('clones a whole symlinked integration directory under the requested name', async () => {
         mockGitHub(
             { 'quickbooks/syncs/customers.ts': 'export default async function () {}' },

--- a/packages/cli/lib/services/pull.service.ts
+++ b/packages/cli/lib/services/pull.service.ts
@@ -4,7 +4,7 @@ import path from 'node:path';
 import chalk from 'chalk';
 
 import { parseSecretKey, printDebug, resolveHostport } from '../utils.js';
-import { collectDependencies, fetchFileContent, GitHubNotFoundError } from '../utils/githubTemplates.js';
+import { collectDependencies, fetchFileContent, GitHubNotFoundError, localizeIntegrationPath, resolveIntegrationFolder } from '../utils/githubTemplates.js';
 import { checkExistingFiles, updateIndexFile } from '../utils/integrationFiles.js';
 import { Spinner } from '../utils/spinner.js';
 
@@ -144,11 +144,15 @@ export async function pullFromCatalog(options: PullCatalogOptions): Promise<bool
     try {
         const contentCache = new Map<string, string>();
 
+        // Symlinked integrations are fetched from their target folder;
+        // files are written back under `integrationId` (the requested name) below.
+        const remoteFolder = await resolveIntegrationFolder(integrationId, debug);
+
         const foldersToProbe: ('syncs' | 'actions' | 'on-events')[] = type ? [scriptTypeToFolder[type]] : ['syncs', 'actions', 'on-events'];
 
         const probeResults = await Promise.allSettled(
             foldersToProbe.map(async (folder) => {
-                const candidatePath = `${integrationId}/${folder}/${name}.ts`;
+                const candidatePath = `${remoteFolder}/${folder}/${name}.ts`;
                 const content = await fetchFileContent(candidatePath, debug);
                 return { folder, candidatePath, content };
             })
@@ -186,7 +190,7 @@ export async function pullFromCatalog(options: PullCatalogOptions): Promise<bool
 
         const initialFiles: { relativePath: string; isScript: boolean }[] = [{ relativePath: match.candidatePath, isScript: true }];
 
-        const mdPath = `${integrationId}/${match.folder}/${name}.md`;
+        const mdPath = `${remoteFolder}/${match.folder}/${name}.md`;
         try {
             const mdContent = await fetchFileContent(mdPath, debug);
             contentCache.set(mdPath, mdContent);
@@ -199,7 +203,20 @@ export async function pullFromCatalog(options: PullCatalogOptions): Promise<bool
             printDebug(`No companion documentation found for ${mdPath}`, debug);
         }
 
-        const files = await collectDependencies(initialFiles, integrationId, debug, contentCache);
+        const remoteFiles = await collectDependencies(initialFiles, remoteFolder, debug, contentCache);
+
+        // Rewrite fetched (target) paths to the requested integration name for local writes.
+        const files = remoteFiles.map((file) => ({
+            ...file,
+            relativePath: localizeIntegrationPath(file.relativePath, remoteFolder, integrationId)
+        }));
+        for (const [key, value] of [...contentCache]) {
+            const localKey = localizeIntegrationPath(key, remoteFolder, integrationId);
+            if (localKey !== key) {
+                contentCache.set(localKey, value);
+                contentCache.delete(key);
+            }
+        }
 
         const { proceed, filesToSkip } = await checkExistingFiles(fullPath, files, force, autoConfirm, debug, interactive);
         if (!proceed) {

--- a/packages/cli/lib/services/pull.service.ts
+++ b/packages/cli/lib/services/pull.service.ts
@@ -146,7 +146,7 @@ export async function pullFromCatalog(options: PullCatalogOptions): Promise<bool
 
         // Symlinked integrations are fetched from their target folder;
         // files are written back under `integrationId` (the requested name) below.
-        const remoteFolder = await resolveIntegrationFolder(integrationId, debug);
+        const { folder: remoteFolder } = await resolveIntegrationFolder(integrationId, debug);
 
         const foldersToProbe: ('syncs' | 'actions' | 'on-events')[] = type ? [scriptTypeToFolder[type]] : ['syncs', 'actions', 'on-events'];
 
@@ -205,18 +205,12 @@ export async function pullFromCatalog(options: PullCatalogOptions): Promise<bool
 
         const remoteFiles = await collectDependencies(initialFiles, remoteFolder, debug, contentCache);
 
-        // Rewrite fetched (target) paths to the requested integration name for local writes.
+        // Keep the remote path for cache lookups; write under the requested name.
         const files = remoteFiles.map((file) => ({
             ...file,
+            remotePath: file.relativePath,
             relativePath: localizeIntegrationPath(file.relativePath, remoteFolder, integrationId)
         }));
-        for (const [key, value] of [...contentCache]) {
-            const localKey = localizeIntegrationPath(key, remoteFolder, integrationId);
-            if (localKey !== key) {
-                contentCache.set(localKey, value);
-                contentCache.delete(key);
-            }
-        }
 
         const { proceed, filesToSkip } = await checkExistingFiles(fullPath, files, force, autoConfirm, debug, interactive);
         if (!proceed) {
@@ -230,7 +224,7 @@ export async function pullFromCatalog(options: PullCatalogOptions): Promise<bool
                 continue;
             }
 
-            const content = contentCache.get(file.relativePath)!;
+            const content = contentCache.get(file.remotePath)!;
 
             const localPath = path.join(fullPath, file.relativePath);
             await fs.promises.mkdir(path.dirname(localPath), { recursive: true });

--- a/packages/cli/lib/services/pull.service.unit.test.ts
+++ b/packages/cli/lib/services/pull.service.unit.test.ts
@@ -6,6 +6,7 @@ import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 import { pullFromCatalog } from './pull.service.js';
 
 const RAW_BASE = 'https://raw.githubusercontent.com/NangoHQ/integration-templates/main/integrations';
+const API_BASE = 'https://api.github.com/repos/NangoHQ/integration-templates/contents/integrations';
 
 function buildNotFoundError(url: string): AxiosError {
     const err = new AxiosError('Not Found', '404', undefined, undefined, {
@@ -18,8 +19,19 @@ function buildNotFoundError(url: string): AxiosError {
     return err;
 }
 
-function mockGitHub(files: Record<string, string>) {
+// `symlinks` maps an integration folder to its target (mirrors the GitHub Contents API symlink response).
+function mockGitHub(files: Record<string, string>, symlinks: Record<string, string> = {}) {
     vi.spyOn(axios, 'get').mockImplementation((url: string) => {
+        if (url.startsWith(`${API_BASE}/`)) {
+            const integration = url.slice(`${API_BASE}/`.length);
+            if (Object.prototype.hasOwnProperty.call(symlinks, integration)) {
+                return Promise.resolve({
+                    data: { name: integration, path: `integrations/${integration}`, type: 'symlink', target: symlinks[integration] }
+                } as any);
+            }
+            // A real directory: resolveIntegrationFolder only checks Array.isArray, contents are irrelevant.
+            return Promise.resolve({ data: [] } as any);
+        }
         const relative = url.replace(`${RAW_BASE}/`, '');
         if (Object.prototype.hasOwnProperty.call(files, relative)) {
             return Promise.resolve({ data: files[relative] } as any);
@@ -166,5 +178,38 @@ describe('pullFromCatalog', () => {
         const writtenPaths = writeSpy.mock.calls.map((call) => call[0] as string);
         expect(writtenPaths).toContain('/project/github/actions/list-repos.ts');
         expect(writtenPaths).toContain('/project/github/mappers/toRepo.ts');
+    });
+
+    it('fetches from the symlink target but writes under the requested integration name', async () => {
+        mockGitHub({ 'quickbooks/syncs/customers.ts': 'export default async function () {}' }, { 'quickbooks-sandbox': 'quickbooks' });
+        const writeSpy = mockFsForWriting();
+        const axiosSpy = vi.spyOn(axios, 'get');
+
+        const success = await pullFromCatalog({ ...baseOptions, integrationId: 'quickbooks-sandbox', name: 'customers', type: 'sync' });
+
+        expect(success).toBe(true);
+        // Content is fetched from the resolved target folder...
+        expect(axiosSpy.mock.calls.map((call) => call[0])).toContain(`${RAW_BASE}/quickbooks/syncs/customers.ts`);
+        // ...but written under the requested (symlink) name so deploy maps it to the right providerConfigKey.
+        const writtenPaths = writeSpy.mock.calls.map((call) => call[0] as string);
+        expect(writtenPaths).toContain('/project/quickbooks-sandbox/syncs/customers.ts');
+    });
+
+    it('localizes symlinked dependency paths too', async () => {
+        mockGitHub(
+            {
+                'quickbooks/syncs/customers.ts': "import { toCustomer } from '../mappers/toCustomer.js';\nexport default async () => toCustomer();",
+                'quickbooks/mappers/toCustomer.ts': 'export const toCustomer = () => ({});'
+            },
+            { 'quickbooks-sandbox': 'quickbooks' }
+        );
+        const writeSpy = mockFsForWriting();
+
+        const success = await pullFromCatalog({ ...baseOptions, integrationId: 'quickbooks-sandbox', name: 'customers', type: 'sync' });
+
+        expect(success).toBe(true);
+        const writtenPaths = writeSpy.mock.calls.map((call) => call[0] as string);
+        expect(writtenPaths).toContain('/project/quickbooks-sandbox/syncs/customers.ts');
+        expect(writtenPaths).toContain('/project/quickbooks-sandbox/mappers/toCustomer.ts');
     });
 });

--- a/packages/cli/lib/utils/githubTemplates.ts
+++ b/packages/cli/lib/utils/githubTemplates.ts
@@ -18,6 +18,8 @@ export interface GitHubDirectoryItem {
     name: string;
     path: string;
     type: 'file' | 'dir' | 'symlink';
+    // Present when type === 'symlink'
+    target?: string;
 }
 
 export class GitHubRateLimitError extends Error {
@@ -50,6 +52,19 @@ function getGitHubHeaders(): Record<string, string> {
     return headers;
 }
 
+function mapGitHubApiError(err: unknown, urlPath: string): Error {
+    if (axios.isAxiosError(err)) {
+        if (err.response?.status === 403) {
+            const resetTime = err.response.headers['x-ratelimit-reset'];
+            return new GitHubRateLimitError(resetTime ? Number(resetTime) : undefined);
+        }
+        if (err.response?.status === 404) {
+            return new GitHubNotFoundError(urlPath);
+        }
+    }
+    return err instanceof Error ? err : new Error(String(err));
+}
+
 export async function fetchGitHubDirectory(urlPath: string, debug: boolean): Promise<GitHubDirectoryItem[]> {
     const url = `${GITHUB_API_BASE}/${urlPath}`;
     printDebug(`Fetching GitHub directory: ${url}`, debug);
@@ -60,17 +75,54 @@ export async function fetchGitHubDirectory(urlPath: string, debug: boolean): Pro
         });
         return response.data;
     } catch (err) {
-        if (axios.isAxiosError(err)) {
-            if (err.response?.status === 403) {
-                const resetTime = err.response.headers['x-ratelimit-reset'];
-                throw new GitHubRateLimitError(resetTime ? Number(resetTime) : undefined);
-            }
-            if (err.response?.status === 404) {
-                throw new GitHubNotFoundError(urlPath);
-            }
-        }
-        throw err;
+        throw mapGitHubApiError(err, urlPath);
     }
+}
+
+/**
+ * Resolve a (possibly symlinked) integration folder name to its real folder in the templates repo.
+ */
+export async function resolveIntegrationFolder(integration: string, debug: boolean): Promise<string> {
+    const url = `${GITHUB_API_BASE}/${integration}`;
+    printDebug(`Resolving integration folder: ${url}`, debug);
+
+    let data: GitHubDirectoryItem[] | GitHubDirectoryItem;
+    try {
+        const response = await axios.get<GitHubDirectoryItem[] | GitHubDirectoryItem>(url, {
+            headers: getGitHubHeaders()
+        });
+        data = response.data;
+    } catch (err) {
+        throw mapGitHubApiError(err, integration);
+    }
+
+    if (Array.isArray(data)) {
+        return integration;
+    }
+
+    if (data.type === 'symlink' && typeof data.target === 'string') {
+        const resolved = path.posix.normalize(path.posix.join(path.posix.dirname(integration), data.target));
+        printDebug(`Integration "${integration}" is a symlink to "${resolved}"`, debug);
+        return resolved;
+    }
+
+    return integration;
+}
+
+/**
+ * Rewrite the leading integration segment of a remote templates-repo path to the local folder name.
+ * Used to write symlinked-integration files under the name the user requested while fetching their
+ * content from the resolved target folder. No-op when remote and local folders are the same.
+ */
+export function localizeIntegrationPath(remotePath: string, remoteFolder: string, localFolder: string): string {
+    if (remoteFolder === localFolder) {
+        return remotePath;
+    }
+    const segments = remotePath.split('/');
+    if (segments[0] === remoteFolder) {
+        segments[0] = localFolder;
+    }
+    return segments.join('/');
 }
 
 /**

--- a/packages/cli/lib/utils/githubTemplates.ts
+++ b/packages/cli/lib/utils/githubTemplates.ts
@@ -79,10 +79,19 @@ export async function fetchGitHubDirectory(urlPath: string, debug: boolean): Pro
     }
 }
 
+export interface ResolvedIntegrationFolder {
+    // The real templates-repo folder (resolves through symlinks).
+    folder: string;
+    // The folder's directory listing when it is a real directory, so callers can avoid re-fetching it; null for symlinks/files.
+    contents: GitHubDirectoryItem[] | null;
+}
+
 /**
  * Resolve a (possibly symlinked) integration folder name to its real folder in the templates repo.
+ * Returns the directory listing too when the folder is a real directory, so the caller can reuse it
+ * instead of fetching the same path again.
  */
-export async function resolveIntegrationFolder(integration: string, debug: boolean): Promise<string> {
+export async function resolveIntegrationFolder(integration: string, debug: boolean): Promise<ResolvedIntegrationFolder> {
     const url = `${GITHUB_API_BASE}/${integration}`;
     printDebug(`Resolving integration folder: ${url}`, debug);
 
@@ -97,22 +106,24 @@ export async function resolveIntegrationFolder(integration: string, debug: boole
     }
 
     if (Array.isArray(data)) {
-        return integration;
+        return { folder: integration, contents: data };
     }
 
     if (data.type === 'symlink' && typeof data.target === 'string') {
         const resolved = path.posix.normalize(path.posix.join(path.posix.dirname(integration), data.target));
         printDebug(`Integration "${integration}" is a symlink to "${resolved}"`, debug);
-        return resolved;
+        return { folder: resolved, contents: null };
     }
 
-    return integration;
+    return { folder: integration, contents: null };
 }
 
 /**
  * Rewrite the leading integration folder of a remote templates-repo path to the local folder name.
  * Used to write symlinked-integration files under the name the user requested while fetching their
  * content from the resolved target folder. No-op when remote and local folders are the same.
+ *
+ * Eg. localizeIntegrationPath('quickbooks/syncs/customers.ts', 'quickbooks', 'quickbooks-sandbox') => 'quickbooks-sandbox/syncs/customers.ts'
  */
 export function localizeIntegrationPath(remotePath: string, remoteFolder: string, localFolder: string): string {
     if (remoteFolder === localFolder) {
@@ -159,10 +170,14 @@ export async function fetchFileContent(urlPath: string, debug: boolean): Promise
  * Recursively fetch all files from a directory in the GitHub repository.
  * Returns file paths relative to the integrations root (e.g., "github/actions/list-repos.ts")
  */
-export async function fetchDirectoryRecursively(dirPath: string, debug: boolean): Promise<{ relativePath: string; isScript: boolean }[]> {
+export async function fetchDirectoryRecursively(
+    dirPath: string,
+    debug: boolean,
+    preloadedContents?: GitHubDirectoryItem[]
+): Promise<{ relativePath: string; isScript: boolean }[]> {
     const files: { relativePath: string; isScript: boolean }[] = [];
 
-    const contents = await fetchGitHubDirectory(dirPath, debug);
+    const contents = preloadedContents ?? (await fetchGitHubDirectory(dirPath, debug));
 
     for (const item of contents) {
         if (item.type === 'dir') {

--- a/packages/cli/lib/utils/githubTemplates.ts
+++ b/packages/cli/lib/utils/githubTemplates.ts
@@ -110,7 +110,7 @@ export async function resolveIntegrationFolder(integration: string, debug: boole
 }
 
 /**
- * Rewrite the leading integration segment of a remote templates-repo path to the local folder name.
+ * Rewrite the leading integration folder of a remote templates-repo path to the local folder name.
  * Used to write symlinked-integration files under the name the user requested while fetching their
  * content from the resolved target folder. No-op when remote and local folders are the same.
  */
@@ -118,11 +118,14 @@ export function localizeIntegrationPath(remotePath: string, remoteFolder: string
     if (remoteFolder === localFolder) {
         return remotePath;
     }
-    const segments = remotePath.split('/');
-    if (segments[0] === remoteFolder) {
-        segments[0] = localFolder;
+    if (remotePath === remoteFolder) {
+        return localFolder;
     }
-    return segments.join('/');
+    const prefix = `${remoteFolder}/`;
+    if (remotePath.startsWith(prefix)) {
+        return `${localFolder}/${remotePath.slice(prefix.length)}`;
+    }
+    return remotePath;
 }
 
 /**

--- a/packages/cli/lib/utils/githubTemplates.unit.test.ts
+++ b/packages/cli/lib/utils/githubTemplates.unit.test.ts
@@ -1,0 +1,56 @@
+import axios, { AxiosError } from 'axios';
+import { afterEach, describe, expect, it, vi } from 'vitest';
+
+import { GitHubNotFoundError, localizeIntegrationPath, resolveIntegrationFolder } from './githubTemplates.js';
+
+const API_BASE = 'https://api.github.com/repos/NangoHQ/integration-templates/contents/integrations';
+
+function buildNotFoundError(url: string): AxiosError {
+    return new AxiosError('Not Found', '404', undefined, undefined, {
+        status: 404,
+        statusText: 'Not Found',
+        headers: {},
+        config: { url } as any,
+        data: ''
+    });
+}
+
+describe('resolveIntegrationFolder', () => {
+    afterEach(() => {
+        vi.restoreAllMocks();
+    });
+
+    it('returns the same name for a real directory (array response)', async () => {
+        vi.spyOn(axios, 'get').mockResolvedValue({ data: [{ name: 'syncs', path: 'integrations/github/syncs', type: 'dir' }] } as any);
+
+        await expect(resolveIntegrationFolder('github', false)).resolves.toBe('github');
+    });
+
+    it('follows a symlink to its target sibling', async () => {
+        vi.spyOn(axios, 'get').mockResolvedValue({
+            data: { name: 'quickbooks-sandbox', path: 'integrations/quickbooks-sandbox', type: 'symlink', target: 'quickbooks' }
+        } as any);
+
+        await expect(resolveIntegrationFolder('quickbooks-sandbox', false)).resolves.toBe('quickbooks');
+    });
+
+    it('throws GitHubNotFoundError when the integration does not exist', async () => {
+        vi.spyOn(axios, 'get').mockRejectedValue(buildNotFoundError(`${API_BASE}/nope`));
+
+        await expect(resolveIntegrationFolder('nope', false)).rejects.toBeInstanceOf(GitHubNotFoundError);
+    });
+});
+
+describe('localizeIntegrationPath', () => {
+    it('rewrites the leading segment when folders differ', () => {
+        expect(localizeIntegrationPath('quickbooks/syncs/customers.ts', 'quickbooks', 'quickbooks-sandbox')).toBe('quickbooks-sandbox/syncs/customers.ts');
+    });
+
+    it('is a no-op when remote and local folders match', () => {
+        expect(localizeIntegrationPath('github/syncs/list-repos.ts', 'github', 'github')).toBe('github/syncs/list-repos.ts');
+    });
+
+    it('leaves paths outside the remote folder untouched', () => {
+        expect(localizeIntegrationPath('other/syncs/x.ts', 'quickbooks', 'quickbooks-sandbox')).toBe('other/syncs/x.ts');
+    });
+});

--- a/packages/cli/lib/utils/githubTemplates.unit.test.ts
+++ b/packages/cli/lib/utils/githubTemplates.unit.test.ts
@@ -20,18 +20,19 @@ describe('resolveIntegrationFolder', () => {
         vi.restoreAllMocks();
     });
 
-    it('returns the same name for a real directory (array response)', async () => {
-        vi.spyOn(axios, 'get').mockResolvedValue({ data: [{ name: 'syncs', path: 'integrations/github/syncs', type: 'dir' }] } as any);
+    it('returns the same name and the fetched listing for a real directory (array response)', async () => {
+        const listing = [{ name: 'syncs', path: 'integrations/github/syncs', type: 'dir' }];
+        vi.spyOn(axios, 'get').mockResolvedValue({ data: listing } as any);
 
-        await expect(resolveIntegrationFolder('github', false)).resolves.toBe('github');
+        await expect(resolveIntegrationFolder('github', false)).resolves.toEqual({ folder: 'github', contents: listing });
     });
 
-    it('follows a symlink to its target sibling', async () => {
+    it('follows a symlink to its target sibling without a directory listing', async () => {
         vi.spyOn(axios, 'get').mockResolvedValue({
             data: { name: 'quickbooks-sandbox', path: 'integrations/quickbooks-sandbox', type: 'symlink', target: 'quickbooks' }
         } as any);
 
-        await expect(resolveIntegrationFolder('quickbooks-sandbox', false)).resolves.toBe('quickbooks');
+        await expect(resolveIntegrationFolder('quickbooks-sandbox', false)).resolves.toEqual({ folder: 'quickbooks', contents: null });
     });
 
     it('throws GitHubNotFoundError when the integration does not exist', async () => {

--- a/packages/cli/lib/utils/githubTemplates.unit.test.ts
+++ b/packages/cli/lib/utils/githubTemplates.unit.test.ts
@@ -53,4 +53,10 @@ describe('localizeIntegrationPath', () => {
     it('leaves paths outside the remote folder untouched', () => {
         expect(localizeIntegrationPath('other/syncs/x.ts', 'quickbooks', 'quickbooks-sandbox')).toBe('other/syncs/x.ts');
     });
+
+    it('matches the full folder, not just the first segment, when the remote folder is nested', () => {
+        expect(localizeIntegrationPath('nested/target/syncs/x.ts', 'nested/target', 'sandbox')).toBe('sandbox/syncs/x.ts');
+        // A path that only shares the first segment must not be rewritten.
+        expect(localizeIntegrationPath('nested/other/syncs/x.ts', 'nested/target', 'sandbox')).toBe('nested/other/syncs/x.ts');
+    });
 });

--- a/packages/server/lib/controllers/v1/integrations/providerConfigKey/getIntegration.ts
+++ b/packages/server/lib/controllers/v1/integrations/providerConfigKey/getIntegration.ts
@@ -4,7 +4,7 @@ import * as z from 'zod';
 
 import { permissions } from '@nangohq/authz';
 import { getProviderScopes } from '@nangohq/providers';
-import { configService, connectionService, getGlobalWebhookReceiveUrl, getProvider } from '@nangohq/shared';
+import { configService, connectionService, flowService, getGlobalWebhookReceiveUrl, getProvider } from '@nangohq/shared';
 import { requireEmptyQuery, zodErrorToHTTP } from '@nangohq/utils';
 
 import { resolve } from '../../../../authz/resolve.js';
@@ -76,6 +76,7 @@ export const getIntegration = asyncWrapper<GetIntegration>(async (req, res) => {
         data: {
             integration: apiIntegration,
             template: provider, // TODO: fix this naming
+            symLinkTargetName: flowService.getSymLinkTargetName(integration.provider),
             meta: {
                 connectionsCount: count,
                 webhookSecret,

--- a/packages/shared/lib/services/flow.service.ts
+++ b/packages/shared/lib/services/flow.service.ts
@@ -98,6 +98,10 @@ class FlowService {
         return standardConfig;
     }
 
+    public getSymLinkTargetName(provider: string): string | null {
+        return this.flowsJson.find((flow) => flow.providerConfigKey === provider)?.symLinkTargetName ?? null;
+    }
+
     public getFlowByIntegrationAndName({ provider, type, scriptName }: { provider: string; type: ScriptTypeLiteral; scriptName: string }) {
         const availablePublicFlows = this.getAllAvailableFlowsAsStandardConfig();
         const flows = availablePublicFlows.filter((flow) => flow.providerConfigKey === provider);

--- a/packages/shared/lib/services/flow.service.unit.test.ts
+++ b/packages/shared/lib/services/flow.service.unit.test.ts
@@ -142,6 +142,19 @@ describe('Flow service tests', () => {
         }
     });
 
+    it('should resolve the symlink target name for symlinked providers and return null otherwise', () => {
+        const symlinked = FlowService.flowsJson.find((flow) => flow.symLinkTargetName);
+        expect(symlinked, 'expected at least one symlinked provider in flows.zero.json').toBeDefined();
+
+        const provider = symlinked!.providerConfigKey;
+        const target = symlinked!.symLinkTargetName!;
+
+        expect(FlowService.getSymLinkTargetName(provider)).toBe(target);
+        // The target folder is canonical, so it must not itself be a symlink.
+        expect(FlowService.getSymLinkTargetName(target)).toBeNull();
+        expect(FlowService.getSymLinkTargetName('this-provider-does-not-exist')).toBeNull();
+    });
+
     it('should cache flows standard config after first call', () => {
         // First call should populate cache
         const result1 = FlowService.getAllAvailableFlowsAsStandardConfig();

--- a/packages/types/lib/integration/api.ts
+++ b/packages/types/lib/integration/api.ts
@@ -242,6 +242,8 @@ export type GetIntegration = Endpoint<{
         data: {
             integration: ApiIntegration;
             template: Provider;
+            // Canonical templates-repo folder when the provider symlinks to another (e.g. `quickbooks-sandbox` → `quickbooks`); null otherwise.
+            symLinkTargetName: string | null;
             meta: {
                 connectionsCount: number;
                 webhookUrl: string | null;

--- a/packages/types/lib/nangoYaml/index.ts
+++ b/packages/types/lib/nangoYaml/index.ts
@@ -221,5 +221,10 @@ export interface FlowsYaml {
 
 // --- flows.zero.json is a parsed nango.yaml
 // TODO: drop the functions override once flows.zero.json is regenerated with `functions` (NAN-5943)
-export type FlowZeroJson = Omit<NangoYamlParsedIntegration, 'functions'> & { jsonSchema?: JSONSchema7; sdkVersion: string };
+export type FlowZeroJson = Omit<NangoYamlParsedIntegration, 'functions'> & {
+    jsonSchema?: JSONSchema7;
+    sdkVersion: string;
+    // Set when this integration symlinks to a canonical templates-repo folder (e.g. `quickbooks-sandbox` → `quickbooks`).
+    symLinkTargetName?: string;
+};
 export type FlowsZeroJson = FlowZeroJson[];

--- a/packages/webapp/src/pages/Integrations/providerConfigKey/Functions/One.tsx
+++ b/packages/webapp/src/pages/Integrations/providerConfigKey/Functions/One.tsx
@@ -168,7 +168,8 @@ export const FunctionsOne: React.FC = () => {
         return <PageNotFound />;
     }
 
-    const gitUrl = `${githubRepo}/tree/main/${functionRepoPath({ provider: integrationData.integration.provider, name: func.name, type: func.type })}`;
+    const repoProvider = integrationData.symLinkTargetName ?? integrationData.integration.provider;
+    const gitUrl = `${githubRepo}/tree/main/${functionRepoPath({ provider: repoProvider, name: func.name, type: func.type })}`;
 
     return (
         <DashboardLayout>

--- a/packages/webapp/src/pages/Integrations/providerConfigKey/TemplateDetail.tsx
+++ b/packages/webapp/src/pages/Integrations/providerConfigKey/TemplateDetail.tsx
@@ -27,12 +27,15 @@ import type { JSONSchema7 } from 'json-schema';
 interface TemplateDetailProps {
     template: NangoFunctionTemplate;
     provider: string;
+    // Canonical templates-repo folder when `provider` symlinks to another; used for repo URLs only.
+    symLinkTargetName?: string | null;
     onDeploy: () => void;
     isDeploying: boolean;
 }
 
-export const TemplateDetail: React.FC<TemplateDetailProps> = ({ template, provider, onDeploy, isDeploying }) => {
-    const githubUrl = `${INTEGRATION_TEMPLATES_GITHUB_URL}/tree/main/${functionRepoPath({ provider, name: template.name, type: template.type })}`;
+export const TemplateDetail: React.FC<TemplateDetailProps> = ({ template, provider, symLinkTargetName, onDeploy, isDeploying }) => {
+    const repoProvider = symLinkTargetName ?? provider;
+    const githubUrl = `${INTEGRATION_TEMPLATES_GITHUB_URL}/tree/main/${functionRepoPath({ provider: repoProvider, name: template.name, type: template.type })}`;
 
     const inputSchema = useMemo<JSONSchema7 | null>(() => {
         if (!template.input || !template.json_schema) {
@@ -182,7 +185,7 @@ export const TemplateDetail: React.FC<TemplateDetailProps> = ({ template, provid
                     )}
                 </TabsContent>
                 <TabsContent value="code" className="flex flex-col gap-4">
-                    <CodeTab provider={provider} templateType={template.type} templateName={template.name} githubUrl={githubUrl} />
+                    <CodeTab provider={repoProvider} templateType={template.type} templateName={template.name} githubUrl={githubUrl} />
                 </TabsContent>
             </Tabs>
         </div>

--- a/packages/webapp/src/pages/Integrations/providerConfigKey/Templates.tsx
+++ b/packages/webapp/src/pages/Integrations/providerConfigKey/Templates.tsx
@@ -249,6 +249,7 @@ export const Templates: React.FC = () => {
                             key={`${selected.type}:${selected.name}`}
                             template={selected}
                             provider={integrationData.integration.provider}
+                            symLinkTargetName={integrationData.symLinkTargetName}
                             onDeploy={onDeploy}
                             isDeploying={isDeploying}
                         />


### PR DESCRIPTION
The `nango pull` and `nango clone` commands would fail for symlinked integrations. Links to code in github would also be incorrect. This PR fixes that by:
- Using the metadata already available in `flows.zero.yaml` to resolve symlinks server-side.
- Doing a pre-fetch in github to check for symlinks in the CLI (it doesn't have access to the metadata, so we need to fetch).

I did not try to over-optimize this, so the CLI does an extra call to github to see if it's a symlink. Keeps the diff way shorter.

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/NangoHQ/nango/pull/6632?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

