### PR TITLE
fix(webapp): align dashboard page layouts

### DIFF
--- a/packages/webapp/src/components/patterns/ErrorComponent.tsx
+++ b/packages/webapp/src/components/patterns/ErrorComponent.tsx
@@ -12,11 +12,10 @@ export const ErrorPageComponent: React.FC<{ title: string; error?: ApiError<stri
     }
 
     return (
-        <DashboardLayout>
+        <DashboardLayout fullWidth title={title}>
             <Helmet>
                 <title>Error - Nango</title>
             </Helmet>
-            <h2 className="text-3xl font-semibold text-text-strong mb-16">{title}</h2>
             <Alert variant="error">
                 <AlertDescription>
                     An error occurred, refresh your page or reach out to the support.{' '}

--- a/packages/webapp/src/pages/Connection/Create.tsx
+++ b/packages/webapp/src/pages/Connection/Create.tsx
@@ -105,7 +105,7 @@ export const ConnectionCreate: React.FC = () => {
 
     if (isLoading) {
         return (
-            <DashboardLayout title="Create test connection">
+            <DashboardLayout fullWidth title="Create test connection" className={'max-w-[1250px]'}>
                 <Helmet>
                     <title>Create Test Connection - Nango</title>
                 </Helmet>

--- a/packages/webapp/src/pages/Connection/List.tsx
+++ b/packages/webapp/src/pages/Connection/List.tsx
@@ -287,15 +287,14 @@ export const ConnectionList = () => {
                         <>
                             {/* Filters */}
                             <div className="flex items-center gap-1.5">
-                                <InputGroup className="h-10">
+                                <InputGroup className="h-10 flex-1">
                                     <InputGroupInput
-                                        className="pr-2.5"
                                         type="text"
                                         placeholder="Search connections"
                                         value={search || ''}
                                         onChange={(e) => setSearch(e.target.value)}
                                     />
-                                    <InputGroupAddon className="pl-2.5">
+                                    <InputGroupAddon>
                                         <Search />
                                     </InputGroupAddon>
                                 </InputGroup>
@@ -340,7 +339,7 @@ export const ConnectionList = () => {
                                 />
                                 <PermissionGate condition={canCreateTestConnection}>
                                     {(allowed) => (
-                                        <ButtonLink to={`/${env}/connections/create`} size="lg" disabled={!allowed} className="ml-auto">
+                                        <ButtonLink to={`/${env}/connections/create`} size="xl" disabled={!allowed} className="ml-auto">
                                             Add test connection
                                         </ButtonLink>
                                     )}

--- a/packages/webapp/src/pages/Connection/List.tsx
+++ b/packages/webapp/src/pages/Connection/List.tsx
@@ -285,8 +285,6 @@ export const ConnectionList = () => {
                 <div className="flex flex-col gap-3">
                     {(loading || hasConnections || hasFiltered) && (
                         <>
-                            {/* Connection count */}
-                            <ConnectionCount className="self-end" />
                             {/* Filters */}
                             <div className="flex items-center gap-1.5">
                                 <InputGroup className="h-10">
@@ -347,6 +345,11 @@ export const ConnectionList = () => {
                                         </ButtonLink>
                                     )}
                                 </PermissionGate>
+                            </div>
+
+                            {/* Connection count */}
+                            <div className="flex items-center justify-end">
+                                <ConnectionCount />
                             </div>
 
                             {/* Table */}

--- a/packages/webapp/src/pages/Connection/components/ConnectionCount.tsx
+++ b/packages/webapp/src/pages/Connection/components/ConnectionCount.tsx
@@ -13,7 +13,7 @@ export const ConnectionCount = ({ className, ...rest }: ConnectionCountProps) =>
     const { data: connectionsCount, loading: connectionsCountLoading } = useConnectionsCount(env);
 
     if (connectionsCountLoading) {
-        return <Skeleton className={cn('w-48 h-6', className)} />;
+        return <Skeleton className={cn('w-48 h-5', className)} />;
     }
 
     const { total, withError } = connectionsCount?.data ?? { total: 0, withError: 0 };
@@ -21,7 +21,7 @@ export const ConnectionCount = ({ className, ...rest }: ConnectionCountProps) =>
     return (
         <div className={cn('inline-flex items-center gap-1.5', className)} {...rest}>
             <Dot variant="error" />
-            <span className="text-text-muted text-body-medium-medium">
+            <span className="text-text-muted text-body-small-regular">
                 {total} connections ({withError} errored)
             </span>
         </div>

--- a/packages/webapp/src/pages/Environment/Settings/Show.tsx
+++ b/packages/webapp/src/pages/Environment/Settings/Show.tsx
@@ -41,15 +41,10 @@ export const EnvironmentSettings: React.FC = () => {
 
     if (!environmentAndAccount || !team) {
         return (
-            <DashboardLayout className="flex-col">
+            <DashboardLayout fullWidth title="Environment settings" className="flex flex-col gap-8">
                 <Helmet>
                     <title>Environment Settings - Nango</title>
                 </Helmet>
-                <div className="flex justify-between mb-8 items-center">
-                    <div className="flex text-left text-3xl tracking-tight text-text-strong">
-                        <h2 className="font-semibold">Environment Settings &mdash;</h2>&nbsp;{env}
-                    </div>
-                </div>
                 <div className="flex gap-6 h-[280px]">
                     <Skeleton className="w-[209px]" />
                     <Skeleton className="h-full w-full" />

--- a/packages/webapp/src/pages/Integrations/Show.tsx
+++ b/packages/webapp/src/pages/Integrations/Show.tsx
@@ -40,6 +40,7 @@ export const IntegrationsList = () => {
     const initialIntegrations = useMemo(() => {
         return data?.data ?? null;
     }, [data?.data]);
+    const integrationsCount = initialIntegrations?.length ?? 0;
 
     useEffect(() => {
         if (initialIntegrations) {
@@ -101,7 +102,7 @@ export const IntegrationsList = () => {
     }
 
     return (
-        <DashboardLayout fullWidth title="Integrations" className="flex flex-col gap-8">
+        <DashboardLayout fullWidth title="Integrations" className="flex flex-col gap-3">
             <Helmet>
                 <title>Integrations - Nango</title>
             </Helmet>
@@ -120,6 +121,14 @@ export const IntegrationsList = () => {
                     )}
                 </PermissionGate>
             </header>
+
+            {!isPending && data?.data && data.data.length > 0 && (
+                <div className="flex items-center justify-end">
+                    <span className="text-text-muted text-body-small-regular">
+                        {integrationsCount} {integrationsCount === 1 ? 'integration' : 'integrations'}
+                    </span>
+                </div>
+            )}
 
             <AutoIdlingBanner />
 

--- a/packages/webapp/src/pages/Logs/Show.tsx
+++ b/packages/webapp/src/pages/Logs/Show.tsx
@@ -19,7 +19,7 @@ export const LogsShow: React.FC = () => {
 
     if (!globalEnv.features.logs) {
         return (
-            <DashboardLayout fullWidth title="Logs" className="p-6">
+            <DashboardLayout fullWidth title="Logs">
                 <Helmet>
                     <title>Logs - Nango</title>
                 </Helmet>
@@ -38,7 +38,7 @@ export const LogsShow: React.FC = () => {
     }
 
     return (
-        <DashboardLayout fullWidth title="Logs" className="p-6 h-full">
+        <DashboardLayout fullWidth title="Logs" className="h-full">
             <Helmet>
                 <title>Logs - Nango</title>
             </Helmet>

--- a/packages/webapp/src/pages/Logs/components/SearchAllOperations.tsx
+++ b/packages/webapp/src/pages/Logs/components/SearchAllOperations.tsx
@@ -250,13 +250,8 @@ export const SearchAllOperations: React.FC<Props> = ({ onSelectOperation }) => {
     };
 
     return (
-        <>
-            <div className="flex justify-end items-center mb-2">
-                <div className="text-text-strong text-xs">
-                    {totalHumanReadable} {totalOperations > 1 ? 'logs' : 'log'} found
-                </div>
-            </div>
-            <div className="flex gap-2 justify-between mb-4">
+        <div className="flex h-full min-h-0 flex-col gap-3">
+            <div className="flex gap-2 justify-between">
                 <div className="flex-1 min-w-0">
                     <InputGroup className="border-border-muted">
                         <InputGroupAddon>
@@ -286,6 +281,11 @@ export const SearchAllOperations: React.FC<Props> = ({ onSelectOperation }) => {
                         presets={logsPresets}
                         defaultPreset={last24hPreset}
                     />
+                </div>
+            </div>
+            <div className="flex items-center justify-end">
+                <div className="text-text-muted text-body-small-regular">
+                    {totalHumanReadable} {totalOperations > 1 ? 'logs' : 'log'} found
                 </div>
             </div>
             <div
@@ -354,7 +354,7 @@ export const SearchAllOperations: React.FC<Props> = ({ onSelectOperation }) => {
                     )}
                 </table>
             </div>
-        </>
+        </div>
     );
 };
 

--- a/packages/webapp/src/pages/Team/Billing/Show.tsx
+++ b/packages/webapp/src/pages/Team/Billing/Show.tsx
@@ -31,7 +31,7 @@ export const TeamBilling: React.FC = () => {
     }, [canManageBilling, activeTab, setActiveTab]);
 
     return (
-        <DashboardLayout title="Billing & usage" className="flex flex-col gap-8">
+        <DashboardLayout fullWidth title="Billing & usage" className="flex flex-col gap-8">
             <Helmet>
                 <title>Billing & usage - Nango</title>
             </Helmet>

--- a/packages/webapp/src/pages/Team/Settings.tsx
+++ b/packages/webapp/src/pages/Team/Settings.tsx
@@ -19,7 +19,7 @@ export const TeamSettingsPage: React.FC = () => {
 
     if (isLoading) {
         return (
-            <DashboardLayout title="Team settings">
+            <DashboardLayout fullWidth title="Team settings" className="flex flex-col gap-8">
                 <Helmet>
                     <title>Team Settings - Nango</title>
                 </Helmet>
@@ -38,15 +38,15 @@ export const TeamSettingsPage: React.FC = () => {
     const isNangoAdmin = data?.data.isAdminTeam;
 
     return (
-        <DashboardLayout fullWidth title="Team settings" className="flex flex-col gap-10">
+        <DashboardLayout fullWidth title="Team settings" className="flex flex-col gap-8">
             <Helmet>
                 <title>Team Settings - Nango</title>
             </Helmet>
-            <div className="flex items-center justify-end">
+            <div className="grid grid-cols-[minmax(0,1fr)_auto] items-end gap-3">
+                <TeamSettings />
                 <AddTeamMemberButton />
             </div>
 
-            <TeamSettings />
             <TeamMembers />
             {isNangoAdmin && <ImpersonateForm />}
         </DashboardLayout>

--- a/packages/webapp/src/pages/Team/components/AddTeamMemberButton.tsx
+++ b/packages/webapp/src/pages/Team/components/AddTeamMemberButton.tsx
@@ -65,7 +65,7 @@ export const AddTeamMemberButton = () => {
             <PermissionGate condition={canManageTeam}>
                 {(allowed) => (
                     <DialogTrigger asChild>
-                        <Button size="xl" disabled={!allowed}>
+                        <Button size="lg" disabled={!allowed}>
                             <Plus /> Add Team Member
                         </Button>
                     </DialogTrigger>

--- a/packages/webapp/src/pages/User/Settings.tsx
+++ b/packages/webapp/src/pages/User/Settings.tsx
@@ -38,7 +38,7 @@ export const UserSettings: React.FC = () => {
 
     if (loading) {
         return (
-            <DashboardLayout title="Profile settings">
+            <DashboardLayout fullWidth title="Profile settings" className="flex flex-col gap-8">
                 <Helmet>
                     <title>Profile Settings - Nango</title>
                 </Helmet>
@@ -59,65 +59,63 @@ export const UserSettings: React.FC = () => {
     }
 
     return (
-        <DashboardLayout title="Profile settings">
+        <DashboardLayout fullWidth title="Profile settings" className="flex flex-col gap-8">
             <Helmet>
                 <title>Profile Settings - Nango</title>
             </Helmet>
-            <div className="flex flex-col gap-12 mt-16">
-                <div className="flex flex-col gap-5">
-                    <h3 className="font-semibold text-sm text-text-strong">Display Name</h3>
-                    <InputGroup className="h-[42px]">
-                        <InputGroupInput ref={ref} value={name} onChange={(e) => setName(e.target.value)} disabled={!edit} />
-                        <InputGroupAddon align="inline-end">
-                            {!edit && (
-                                <IconButton
-                                    variant={'ghost'}
-                                    size={'2xs'}
-                                    label="Edit"
-                                    onClick={() => {
-                                        setEdit(true);
-                                        setTimeout(() => {
-                                            ref.current?.focus();
-                                        }, 100);
-                                    }}
-                                >
-                                    <Edit />
-                                </IconButton>
-                            )}
-                        </InputGroupAddon>
-                    </InputGroup>
-                    {edit && (
-                        <div className="flex justify-end gap-2 items-center">
-                            <Button
-                                variant={'outline'}
+            <div className="flex flex-col gap-5">
+                <h3 className="font-semibold text-sm text-text-strong">Display Name</h3>
+                <InputGroup className="h-[42px]">
+                    <InputGroupInput ref={ref} value={name} onChange={(e) => setName(e.target.value)} disabled={!edit} />
+                    <InputGroupAddon align="inline-end">
+                        {!edit && (
+                            <IconButton
+                                variant={'ghost'}
+                                size={'2xs'}
+                                label="Edit"
                                 onClick={() => {
-                                    setName(user.name);
-                                    setEdit(false);
+                                    setEdit(true);
+                                    setTimeout(() => {
+                                        ref.current?.focus();
+                                    }, 100);
                                 }}
                             >
-                                Cancel
-                            </Button>
-                            <Button onClick={onSave}>Save</Button>
-                        </div>
-                    )}
-                </div>
-                <div className="flex flex-col gap-5">
-                    <h3 className="font-semibold text-sm text-text-strong">Email</h3>
-                    <p className="text-text-strong text-sm">{user.email}</p>
-                </div>
-                <div className="flex flex-col gap-5">
-                    <h3 className="font-semibold text-sm text-text-strong">Appearance</h3>
-                    <Select value={theme} onValueChange={(v) => setTheme(v as Theme)}>
-                        <SelectTrigger className="w-48">
-                            <SelectValue />
-                        </SelectTrigger>
-                        <SelectContent>
-                            <SelectItem value="system">System</SelectItem>
-                            <SelectItem value="light">Light</SelectItem>
-                            <SelectItem value="dark">Dark</SelectItem>
-                        </SelectContent>
-                    </Select>
-                </div>
+                                <Edit />
+                            </IconButton>
+                        )}
+                    </InputGroupAddon>
+                </InputGroup>
+                {edit && (
+                    <div className="flex justify-end gap-2 items-center">
+                        <Button
+                            variant={'outline'}
+                            onClick={() => {
+                                setName(user.name);
+                                setEdit(false);
+                            }}
+                        >
+                            Cancel
+                        </Button>
+                        <Button onClick={onSave}>Save</Button>
+                    </div>
+                )}
+            </div>
+            <div className="flex flex-col gap-5">
+                <h3 className="font-semibold text-sm text-text-strong">Email</h3>
+                <p className="text-text-strong text-sm">{user.email}</p>
+            </div>
+            <div className="flex flex-col gap-5">
+                <h3 className="font-semibold text-sm text-text-strong">Appearance</h3>
+                <Select value={theme} onValueChange={(v) => setTheme(v as Theme)}>
+                    <SelectTrigger className="w-48">
+                        <SelectValue />
+                    </SelectTrigger>
+                    <SelectContent>
+                        <SelectItem value="system">System</SelectItem>
+                        <SelectItem value="light">Light</SelectItem>
+                        <SelectItem value="dark">Dark</SelectItem>
+                    </SelectContent>
+                </Select>
             </div>
         </DashboardLayout>
     );


### PR DESCRIPTION
## Summary
- Align dashboard pages on the shared full-width layout shell to reduce page-to-page shifts.
- Normalize Integrations, Connections, and Logs list spacing with matching toolbar/count/table rhythm.
- Align settings and list-page controls so primary actions match nearby input heights.

## Test plan
- Run `npm run ts-build`.
- Verify `/dev/integrations`: search/action row, integrations count row, and table spacing stay aligned.
- Verify `/dev/connections`: search/filter/action row, connections count row, and table spacing align with Integrations.
- Verify `/dev/logs`: search/filter row, logs count row, table spacing, and scrollable table height align with the list pages.
- Verify `/user-settings`, `/team-settings`, and `/team/billing`: content uses the same full-width shell and no longer shifts between pages.
- Verify `/dev/environment-settings` loading state and `/dev/connections/create` loading state do not jump when data loads.

## Notes
- Stacked on #6636 / `matej/nan-6060-replace-webapp-inputinputgroup-with-design-system`.