### PR TITLE
fix(providers): use case-sensitive /Login endpoint for sap-business-one

### DIFF
--- a/docs/integrations/all/sap-business-one/connect.mdx
+++ b/docs/integrations/all/sap-business-one/connect.mdx
@@ -46,11 +46,7 @@ The Service Layer URL consists of the server address and port where your SAP B1 
 
 <img src="/integrations/all/sap-business-one/server_url.png" />
 
-The Service Layer URL must include the API base path, typically `/b1s/v1`, for example `my-server.com:50000/b1s/v1`. Do not include the `https://` prefix or a trailing `/Login`; Nango adds those automatically.
-
-<Note>
-The Service Layer routes are case-sensitive. Nango calls the `/Login` endpoint with a capital `L`, which is the only form the Service Layer accepts. Calling `/login` in lowercase returns `401 Invalid session or session already timeout`.
-</Note>
+The Service Layer URL must include the API base path, typically `/b1s/v1` — for example, `my-server.com:50000/b1s/v1`.
 
 ### Step 4: Finding Your Database Instance
 

--- a/docs/integrations/all/sap-business-one/connect.mdx
+++ b/docs/integrations/all/sap-business-one/connect.mdx
@@ -46,6 +46,12 @@ The Service Layer URL consists of the server address and port where your SAP B1 
 
 <img src="/integrations/all/sap-business-one/server_url.png" />
 
+The Service Layer URL must include the API base path, typically `/b1s/v1`, for example `my-server.com:50000/b1s/v1`. Do not include the `https://` prefix or a trailing `/Login`; Nango adds those automatically.
+
+<Note>
+The Service Layer routes are case-sensitive. Nango calls the `/Login` endpoint with a capital `L`, which is the only form the Service Layer accepts. Calling `/login` in lowercase returns `401 Invalid session or session already timeout`.
+</Note>
+
 ### Step 4: Finding Your Database Instance
 
 1. Access the **SAP Control Center** as an administrator or system manager

--- a/packages/providers/providers.yaml
+++ b/packages/providers/providers.yaml
@@ -18079,7 +18079,7 @@ sap-business-one:
         - erp
     body_format: json
     auth_mode: TWO_STEP
-    token_url: https://${connectionConfig.domain}/login
+    token_url: https://${connectionConfig.domain}/Login
     token_params:
         CompanyDB: ${connectionConfig.companyDb}
         UserName: ${credentials.userName}
@@ -18103,7 +18103,7 @@ sap-business-one:
             type: string
             title: Service Layer URL
             prefix: https://
-            suffix: /login
+            suffix: /Login
             pattern: '^[A-Za-z0-9.-]+(?::\d+(?:/[-A-Za-z0-9.]*)*)?$'
             order: 1
             description: The base URL for your SAP Business One Service Layer


### PR DESCRIPTION
## Problem

Creating a `sap-business-one` connection always fails with a generic `two_step_error` (`An unhandled error of type 'two_step_error' with payload '{}'`). The underlying error logged by `getTwoStepCredentials` is:

```json
{
  "message": "Request failed with status code 401",
  "provider_error_payload": { "message": "Invalid session or session already timeout." }
}
```

## Root cause

The SAP Business One Service Layer is OData-based and its routes are **case-sensitive**. The provider built the token URL with a lowercase `/login`:

```yaml
token_url: https://${connectionConfig.domain}/login
```

The Service Layer does not recognize `/login` as the login endpoint. Instead of authenticating, it treats the request as access to a protected resource and returns `401 Invalid session or session already timeout`. As a result the `SessionId` is never extracted and the two-step flow fails.

This is confirmed against a live Service Layer:
- `POST /b1s/v1/login` → `401 Invalid session or session already timeout`
- `POST /b1s/v1/Login` → `200` with `{ "SessionId": "..." }`

SAP documents the endpoint as `/Login` (capital `L`). See [SAP KBA 3383703](https://userapps.support.sap.com/sap/support/knowledge/en/3383703) and [Logging in/out using the Service Layer](https://learning.sap.com/courses/leveraging-the-sap-business-one-service-layer/logging-in-and-logging-out-using-service-layer-api).

## Fix

- Use the correct `/Login` endpoint (capital `L`) in both `token_url` and the `domain` suffix.
- Document the case-sensitivity and the required `/b1s/v1` base path in the connect guide.


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/NangoHQ/nango/pull/6638?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

