### PR TITLE
feat: connection-level webhook url override

### DIFF
--- a/packages/jobs/lib/execution/action.ts
+++ b/packages/jobs/lib/execution/action.ts
@@ -5,6 +5,7 @@ import { getFormattedOperation, logContextGetter, OtlpSpan } from '@nangohq/logs
 import {
     accountService,
     configService,
+    connectionService,
     customerKeyService,
     environmentService,
     errorManager,
@@ -559,10 +560,16 @@ async function sendWebhookIfNeeded({
         if (webhookSigningKey.isErr()) {
             throw webhookSigningKey.error;
         }
+        const connectionConfig = await connectionService.getConnectionConfig({
+            connection_id: connectionId,
+            provider_config_key: providerConfigKey,
+            environment_id: environment.id
+        });
         await sendAsyncActionWebhook({
             secret: webhookSigningKey.value,
             connectionId: connectionId,
             providerConfigKey: providerConfigKey,
+            connectionConfig,
             payload: {
                 id: task.retryKey,
                 statusUrl: `/action/${task.retryKey}`

--- a/packages/jobs/lib/execution/sync.ts
+++ b/packages/jobs/lib/execution/sync.ts
@@ -30,7 +30,7 @@ import {
     updateSyncJobStatus
 } from '@nangohq/shared';
 import { Err, getFrequencyMs, Ok, tagTraceUser } from '@nangohq/utils';
-import { resolveWebhookSettings, sendSync as sendSyncWebhook } from '@nangohq/webhooks';
+import { sendSync as sendSyncWebhook } from '@nangohq/webhooks';
 
 import { bigQueryClient, orchestratorClient, slackService } from '../clients.js';
 import { envs } from '../env.js';
@@ -345,10 +345,8 @@ export async function handleSyncSuccess({
             records: {} as Record<string, SyncResult>,
             runTimeSecs: runTime
         };
-        const baseWebhookSettings = await externalWebhookService.get(nangoProps.environmentId);
-        const webhookSettings = baseWebhookSettings
-            ? resolveWebhookSettings(baseWebhookSettings, await connectionService.getConnectionConfig(connection))
-            : null;
+        const webhookSettings = await externalWebhookService.get(nangoProps.environmentId);
+        const connectionConfig = webhookSettings ? await connectionService.getConnectionConfig(connection) : null;
         const webhookSigningSecret = webhookSettings
             ? await customerKeyService.getWebhookSigningKeyForEnv(db.knex, nangoProps.environmentId).then((r) => {
                   if (r.isErr()) throw r.error;
@@ -471,6 +469,7 @@ export async function handleSyncSuccess({
                                 syncVariant: nangoProps.syncVariant || 'base',
                                 providerConfig,
                                 webhookSettings,
+                                connectionConfig,
                                 model,
                                 now: nangoProps.startedAt,
                                 success: true,
@@ -930,10 +929,8 @@ async function onFailure({
     }
 
     if (environment) {
-        const baseWebhookSettings = await externalWebhookService.get(environment.id);
-        const webhookSettings = baseWebhookSettings
-            ? resolveWebhookSettings(baseWebhookSettings, await connectionService.getConnectionConfig(connection))
-            : null;
+        const webhookSettings = await externalWebhookService.get(environment.id);
+        const connectionConfig = webhookSettings ? await connectionService.getConnectionConfig(connection) : null;
 
         if (team && syncConfig && providerConfig && webhookSettings) {
             const span = tracer.startSpan('jobs.sync.webhook', {
@@ -961,6 +958,7 @@ async function onFailure({
                         environment: environment,
                         secret: webhookSigningKey.value,
                         webhookSettings,
+                        connectionConfig,
                         model: models.join(','),
                         success: false,
                         error: {

--- a/packages/jobs/lib/execution/sync.ts
+++ b/packages/jobs/lib/execution/sync.ts
@@ -6,6 +6,7 @@ import { records } from '@nangohq/records';
 import {
     accountService,
     configService,
+    connectionService,
     createSyncJob,
     customerKeyService,
     environmentService,
@@ -29,7 +30,7 @@ import {
     updateSyncJobStatus
 } from '@nangohq/shared';
 import { Err, getFrequencyMs, Ok, tagTraceUser } from '@nangohq/utils';
-import { sendSync as sendSyncWebhook } from '@nangohq/webhooks';
+import { resolveWebhookSettings, sendSync as sendSyncWebhook } from '@nangohq/webhooks';
 
 import { bigQueryClient, orchestratorClient, slackService } from '../clients.js';
 import { envs } from '../env.js';
@@ -344,7 +345,10 @@ export async function handleSyncSuccess({
             records: {} as Record<string, SyncResult>,
             runTimeSecs: runTime
         };
-        const webhookSettings = await externalWebhookService.get(nangoProps.environmentId);
+        const baseWebhookSettings = await externalWebhookService.get(nangoProps.environmentId);
+        const webhookSettings = baseWebhookSettings
+            ? resolveWebhookSettings(baseWebhookSettings, await connectionService.getConnectionConfig(connection))
+            : null;
         const webhookSigningSecret = webhookSettings
             ? await customerKeyService.getWebhookSigningKeyForEnv(db.knex, nangoProps.environmentId).then((r) => {
                   if (r.isErr()) throw r.error;
@@ -926,7 +930,10 @@ async function onFailure({
     }
 
     if (environment) {
-        const webhookSettings = await externalWebhookService.get(environment.id);
+        const baseWebhookSettings = await externalWebhookService.get(environment.id);
+        const webhookSettings = baseWebhookSettings
+            ? resolveWebhookSettings(baseWebhookSettings, await connectionService.getConnectionConfig(connection))
+            : null;
 
         if (team && syncConfig && providerConfig && webhookSettings) {
             const span = tracer.startSpan('jobs.sync.webhook', {

--- a/packages/jobs/lib/execution/webhook.ts
+++ b/packages/jobs/lib/execution/webhook.ts
@@ -5,6 +5,7 @@ import { logContextGetter } from '@nangohq/logs';
 import {
     accountService,
     configService,
+    connectionService,
     createSyncJob,
     customerKeyService,
     environmentService,
@@ -285,6 +286,12 @@ export async function handleWebhookSuccess({
             throw webhookSigningKey.error;
         }
 
+        const connectionConfig = await connectionService.getConnectionConfig({
+            connection_id: nangoProps.connectionId,
+            provider_config_key: nangoProps.providerConfigKey,
+            environment_id: nangoProps.environmentId
+        });
+
         for (const model of nangoProps.syncConfig.models || []) {
             const span = tracer.startSpan('jobs.webhook.webhook', {
                 tags: {
@@ -310,6 +317,7 @@ export async function handleWebhookSuccess({
                         environment: environment,
                         secret: webhookSigningKey.value,
                         webhookSettings,
+                        connectionConfig,
                         syncConfig: nangoProps.syncConfig,
                         syncVariant: nangoProps.syncVariant || 'base',
                         providerConfig,
@@ -481,12 +489,15 @@ async function onFailure({
                             throw webhookSigningKey.error;
                         }
 
+                        const connectionConfig = await connectionService.getConnectionConfig(connection);
+
                         const res = await sendSyncWebhook({
                             account: team,
                             environment,
                             secret: webhookSigningKey.value,
                             connection: connection,
                             webhookSettings,
+                            connectionConfig,
                             syncConfig,
                             syncVariant,
                             providerConfig,

--- a/packages/server/lib/controllers/appAuth.controller.ts
+++ b/packages/server/lib/controllers/appAuth.controller.ts
@@ -7,11 +7,12 @@ import publisher from '../clients/publisher.client.js';
 import { connectionCreated as connectionCreatedHook, connectionCreationFailed as connectionCreationFailedHook } from '../hooks/hooks.js';
 import { getConnectSession } from '../services/connectSession.service.js';
 import oAuthSessionService from '../services/oauth-session.service.js';
+import { resolveConnectionConfig } from '../utils/auth.js';
 import { missesInterpolationParam } from '../utils/utils.js';
 import * as WSErrBuilder from '../utils/web-socket-error.js';
 
 import type { ConnectSessionAndEndUser } from '../services/connectSession.service.js';
-import type { ProviderGithubApp } from '@nangohq/types';
+import type { ConnectionConfig, ProviderGithubApp } from '@nangohq/types';
 import type { NextFunction, Request, Response } from 'express';
 
 class AppAuthController {
@@ -52,6 +53,8 @@ class AppAuthController {
 
         const { providerConfigKey, connectionId: receivedConnectionId, webSocketClientId: wsClientId } = session;
         const logCtx = logContextGetter.get({ id: session.activityLogId, accountId: account.id });
+        // Hoisted so the failure hook in the catch can also honor a per-connection webhook URL override.
+        let connectionConfigOverride: ConnectionConfig = {};
 
         try {
             if (!providerConfigKey) {
@@ -158,10 +161,8 @@ class AppAuthController {
 
             // Apply the connect session's connection_config defaults (e.g. a per-connection webhook URL override).
             // Done after credential creation so it can't interfere with the GitHub App JWT generation above.
-            const overrideConnectionConfig = connectSession?.connectSession.integrationsConfigDefaults?.[providerConfigKey]?.connectionConfig;
-            if (overrideConnectionConfig) {
-                Object.assign(connectionConfig, overrideConnectionConfig);
-            }
+            connectionConfigOverride = resolveConnectionConfig({ params: undefined, connectSession: connectSession?.connectSession, providerConfigKey });
+            Object.assign(connectionConfig, connectionConfigOverride);
 
             const [updatedConnection] = await connectionService.upsertConnection({
                 connectionId,
@@ -224,7 +225,7 @@ class AppAuthController {
 
             void connectionCreationFailedHook(
                 {
-                    connection: { connection_id: receivedConnectionId, provider_config_key: providerConfigKey },
+                    connection: { connection_id: receivedConnectionId, provider_config_key: providerConfigKey, connection_config: connectionConfigOverride },
                     environment,
                     account,
                     auth_mode: 'APP',

--- a/packages/server/lib/controllers/appAuth.controller.ts
+++ b/packages/server/lib/controllers/appAuth.controller.ts
@@ -54,7 +54,7 @@ class AppAuthController {
         const { providerConfigKey, connectionId: receivedConnectionId, webSocketClientId: wsClientId } = session;
         const logCtx = logContextGetter.get({ id: session.activityLogId, accountId: account.id });
         // Hoisted so the failure hook in the catch can also honor a per-connection webhook URL override.
-        let connectionConfigOverride: ConnectionConfig = {};
+        let resolvedConnectionConfig: ConnectionConfig = {};
 
         try {
             if (!providerConfigKey) {
@@ -161,8 +161,8 @@ class AppAuthController {
 
             // Apply the connect session's connection_config defaults (e.g. a per-connection webhook URL override).
             // Done after credential creation so it can't interfere with the GitHub App JWT generation above.
-            connectionConfigOverride = resolveConnectionConfig({ params: undefined, connectSession: connectSession?.connectSession, providerConfigKey });
-            Object.assign(connectionConfig, connectionConfigOverride);
+            resolvedConnectionConfig = resolveConnectionConfig({ params: undefined, connectSession: connectSession?.connectSession, providerConfigKey });
+            Object.assign(connectionConfig, resolvedConnectionConfig);
 
             const [updatedConnection] = await connectionService.upsertConnection({
                 connectionId,
@@ -225,7 +225,7 @@ class AppAuthController {
 
             void connectionCreationFailedHook(
                 {
-                    connection: { connection_id: receivedConnectionId, provider_config_key: providerConfigKey, connection_config: connectionConfigOverride },
+                    connection: { connection_id: receivedConnectionId, provider_config_key: providerConfigKey, connection_config: resolvedConnectionConfig },
                     environment,
                     account,
                     auth_mode: 'APP',

--- a/packages/server/lib/controllers/appAuth.controller.ts
+++ b/packages/server/lib/controllers/appAuth.controller.ts
@@ -156,6 +156,13 @@ class AppAuthController {
 
             const tags = connectSession?.connectSession.tags;
 
+            // Apply the connect session's connection_config defaults (e.g. a per-connection webhook URL override).
+            // Done after credential creation so it can't interfere with the GitHub App JWT generation above.
+            const overrideConnectionConfig = connectSession?.connectSession.integrationsConfigDefaults?.[providerConfigKey]?.connectionConfig;
+            if (overrideConnectionConfig) {
+                Object.assign(connectionConfig, overrideConnectionConfig);
+            }
+
             const [updatedConnection] = await connectionService.upsertConnection({
                 connectionId,
                 providerConfigKey,

--- a/packages/server/lib/controllers/appAuth.controller.unit.test.ts
+++ b/packages/server/lib/controllers/appAuth.controller.unit.test.ts
@@ -136,4 +136,25 @@ describe('AppAuthController.connect', () => {
             })
         );
     });
+
+    it('threads the per-connection webhook URL override into the creation-failure hook', async () => {
+        mockUpsertConnection.mockRejectedValue(new Error('boom'));
+
+        const req = {
+            query: { installation_id: 'install-1', state: 'session-id' }
+        } as unknown as Request;
+        const res = { redirect: vi.fn(), sendStatus: vi.fn(), status: vi.fn().mockReturnThis(), send: vi.fn().mockReturnThis() } as unknown as Response;
+        const next = vi.fn();
+
+        await appAuthController.connect(req, res, next);
+
+        expect(mockConnectionCreationFailed).toHaveBeenCalledWith(
+            expect.objectContaining({
+                connection: expect.objectContaining({
+                    connection_config: expect.objectContaining({ webhook_url: 'https://override.example.com/hook' })
+                })
+            }),
+            expect.anything()
+        );
+    });
 });

--- a/packages/server/lib/controllers/appAuth.controller.unit.test.ts
+++ b/packages/server/lib/controllers/appAuth.controller.unit.test.ts
@@ -1,0 +1,139 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+import { Ok } from '@nangohq/utils';
+
+import appAuthController from './appAuth.controller.js';
+
+import type * as SharedModule from '@nangohq/shared';
+import type { Request, Response } from 'express';
+
+const {
+    mockFindById,
+    mockSessionDelete,
+    mockGetAccountContext,
+    mockGetProviderConfig,
+    mockGetProvider,
+    mockCreateCredentials,
+    mockGetConnectSession,
+    mockGenerateConnectionId,
+    mockUpsertConnection,
+    mockConnectionCreated,
+    mockConnectionCreationFailed,
+    mockLogCtx
+} = vi.hoisted(() => {
+    return {
+        mockFindById: vi.fn(),
+        mockSessionDelete: vi.fn(),
+        mockGetAccountContext: vi.fn(),
+        mockGetProviderConfig: vi.fn(),
+        mockGetProvider: vi.fn(),
+        mockCreateCredentials: vi.fn(),
+        mockGetConnectSession: vi.fn(),
+        mockGenerateConnectionId: vi.fn(),
+        mockUpsertConnection: vi.fn(),
+        mockConnectionCreated: vi.fn(),
+        mockConnectionCreationFailed: vi.fn(),
+        mockLogCtx: {
+            error: vi.fn(),
+            failed: vi.fn(),
+            success: vi.fn(),
+            info: vi.fn(),
+            enrichOperation: vi.fn()
+        }
+    };
+});
+
+vi.mock('@nangohq/database', async () => {
+    const actual: typeof import('@nangohq/database') = await vi.importActual('@nangohq/database');
+    return { ...actual, default: { knex: {} } };
+});
+
+vi.mock('@nangohq/logs', () => ({
+    logContextGetter: { get: vi.fn(() => mockLogCtx) }
+}));
+
+vi.mock('@nangohq/shared', async () => {
+    const actual: typeof SharedModule = await vi.importActual('@nangohq/shared');
+    return {
+        ...actual,
+        accountService: { getAccountContext: mockGetAccountContext },
+        configService: { getProviderConfig: mockGetProviderConfig },
+        connectionService: {
+            generateConnectionId: mockGenerateConnectionId,
+            upsertConnection: mockUpsertConnection
+        },
+        errorManager: { errRes: vi.fn() },
+        getProvider: mockGetProvider,
+        githubAppClient: { createCredentials: mockCreateCredentials },
+        syncEndUserToConnection: vi.fn()
+    };
+});
+
+vi.mock('../clients/publisher.client.js', () => ({
+    default: { notifySuccess: vi.fn(), notifyErr: vi.fn() }
+}));
+
+vi.mock('../hooks/hooks.js', () => ({
+    connectionCreated: mockConnectionCreated,
+    connectionCreationFailed: mockConnectionCreationFailed
+}));
+
+vi.mock('../services/connectSession.service.js', () => ({
+    getConnectSession: mockGetConnectSession
+}));
+
+vi.mock('../services/oauth-session.service.js', () => ({
+    default: { findById: mockFindById, delete: mockSessionDelete }
+}));
+
+describe('AppAuthController.connect', () => {
+    beforeEach(() => {
+        vi.clearAllMocks();
+
+        mockFindById.mockResolvedValue({
+            id: 'session-id',
+            environmentId: 2,
+            providerConfigKey: 'github-app',
+            connectionId: 'conn-1',
+            webSocketClientId: undefined,
+            activityLogId: 'activity-1',
+            connectSessionId: 10
+        });
+        mockGetAccountContext.mockResolvedValue({ environment: { id: 2, name: 'dev' }, account: { id: 1, name: 'acme' } });
+        mockGetProviderConfig.mockResolvedValue({ id: 1, unique_key: 'github-app', provider: 'github-app', oauth_client_id: 'app-123' });
+        mockGetProvider.mockReturnValue({ auth_mode: 'APP', token_url: 'https://api.github.com/app/installations' });
+        mockCreateCredentials.mockResolvedValue(Ok({ type: 'APP', jwtToken: 'jwt-token' }));
+        mockGenerateConnectionId.mockReturnValue('generated-connection-id');
+        mockGetConnectSession.mockResolvedValue(
+            Ok({
+                connectSession: {
+                    tags: {},
+                    endUser: null,
+                    integrationsConfigDefaults: { 'github-app': { connectionConfig: { webhook_url: 'https://override.example.com/hook' } } }
+                }
+            })
+        );
+        mockUpsertConnection.mockResolvedValue([{ connection: { id: 1, connection_id: 'conn-1', provider_config_key: 'github-app' }, operation: 'creation' }]);
+    });
+
+    it('stores the connect session webhook URL override alongside the GitHub App connection config', async () => {
+        const req = {
+            query: { installation_id: 'install-1', state: 'session-id' }
+        } as unknown as Request;
+        const res = { redirect: vi.fn(), sendStatus: vi.fn(), status: vi.fn().mockReturnThis(), send: vi.fn().mockReturnThis() } as unknown as Response;
+        const next = vi.fn();
+
+        await appAuthController.connect(req, res, next);
+
+        expect(mockUpsertConnection).toHaveBeenCalledWith(
+            expect.objectContaining({
+                connectionConfig: expect.objectContaining({
+                    webhook_url: 'https://override.example.com/hook',
+                    installation_id: 'install-1',
+                    app_id: 'app-123',
+                    jwtToken: 'jwt-token'
+                })
+            })
+        );
+    });
+});

--- a/packages/server/lib/controllers/appAuth.controller.unit.test.ts
+++ b/packages/server/lib/controllers/appAuth.controller.unit.test.ts
@@ -4,6 +4,7 @@ import { Ok } from '@nangohq/utils';
 
 import appAuthController from './appAuth.controller.js';
 
+import type * as DatabaseModule from '@nangohq/database';
 import type * as SharedModule from '@nangohq/shared';
 import type { Request, Response } from 'express';
 
@@ -44,7 +45,7 @@ const {
 });
 
 vi.mock('@nangohq/database', async () => {
-    const actual: typeof import('@nangohq/database') = await vi.importActual('@nangohq/database');
+    const actual: typeof DatabaseModule = await vi.importActual('@nangohq/database');
     return { ...actual, default: { knex: {} } };
 });
 

--- a/packages/server/lib/controllers/auth/postApiKey.ts
+++ b/packages/server/lib/controllers/auth/postApiKey.ts
@@ -2,16 +2,7 @@ import * as z from 'zod';
 
 import db from '@nangohq/database';
 import { defaultOperationExpiration, endUserToMeta, logContextGetter } from '@nangohq/logs';
-import {
-    configService,
-    connectionService,
-    errorManager,
-    ErrorSourceEnum,
-    getConnectionConfig,
-    getProvider,
-    LogActionEnum,
-    syncEndUserToConnection
-} from '@nangohq/shared';
+import { configService, connectionService, errorManager, ErrorSourceEnum, getProvider, LogActionEnum, syncEndUserToConnection } from '@nangohq/shared';
 import { metrics, stringifyError, zodErrorToHTTP } from '@nangohq/utils';
 
 import {
@@ -28,7 +19,7 @@ import {
     testConnectionCredentials
 } from '../../hooks/hooks.js';
 import { asyncWrapper } from '../../utils/asyncWrapper.js';
-import { errorRestrictConnectionId, isIntegrationAllowed } from '../../utils/auth.js';
+import { errorRestrictConnectionId, isIntegrationAllowed, resolveConnectionConfig } from '../../utils/auth.js';
 import { hmacCheck } from '../../utils/hmac.js';
 
 import type { LogContext } from '@nangohq/logs';
@@ -80,7 +71,7 @@ export const postPublicApiKeyAuthorization = asyncWrapper<PostPublicApiKeyAuthor
     const { apiKey }: PostPublicApiKeyAuthorization['Body'] = val.data;
     const queryString: PostPublicApiKeyAuthorization['Querystring'] = queryStringVal.data;
     const { providerConfigKey }: PostPublicApiKeyAuthorization['Params'] = paramsVal.data;
-    const connectionConfig = queryString.params ? getConnectionConfig(queryString.params) : {};
+    const connectionConfig = resolveConnectionConfig({ params: queryString.params, connectSession, providerConfigKey });
     let connectionId = queryString.connection_id || connectionService.generateConnectionId();
     const hmac = 'hmac' in queryString ? queryString.hmac : undefined;
     const isConnectSession = res.locals['authType'] === 'connectSession';

--- a/packages/server/lib/controllers/auth/postApiKey.ts
+++ b/packages/server/lib/controllers/auth/postApiKey.ts
@@ -238,7 +238,7 @@ export const postPublicApiKeyAuthorization = asyncWrapper<PostPublicApiKeyAuthor
         if (logCtx) {
             void connectionCreationFailedHook(
                 {
-                    connection: { connection_id: connectionId, provider_config_key: providerConfigKey },
+                    connection: { connection_id: connectionId, provider_config_key: providerConfigKey, connection_config: connectionConfig },
                     environment,
                     account,
                     auth_mode: 'API_KEY',

--- a/packages/server/lib/controllers/auth/postApiKey.ts
+++ b/packages/server/lib/controllers/auth/postApiKey.ts
@@ -14,7 +14,13 @@ import {
 } from '@nangohq/shared';
 import { metrics, stringifyError, zodErrorToHTTP } from '@nangohq/utils';
 
-import { connectionCredential, connectionCredentialsApiKeySchema, connectionIdSchema, providerConfigKeySchema } from '../../helpers/validation.js';
+import {
+    connectionConfigParamsSchema,
+    connectionCredential,
+    connectionCredentialsApiKeySchema,
+    connectionIdSchema,
+    providerConfigKeySchema
+} from '../../helpers/validation.js';
 import { handleValidateConnectionFailure, validateConnection } from '../../hooks/connection/on/validate-connection.js';
 import {
     connectionCreated as connectionCreatedHook,
@@ -35,7 +41,7 @@ const bodyValidation = connectionCredentialsApiKeySchema;
 const queryStringValidation = z
     .object({
         connection_id: connectionIdSchema.optional(),
-        params: z.record(z.string(), z.any()).optional()
+        params: connectionConfigParamsSchema
     })
     .and(connectionCredential);
 

--- a/packages/server/lib/controllers/auth/postAppStore.ts
+++ b/packages/server/lib/controllers/auth/postAppStore.ts
@@ -77,7 +77,7 @@ export const postPublicAppStoreAuthorization = asyncWrapper<PostPublicAppStoreAu
     const { issuerId, privateKey, privateKeyId, scope }: PostPublicAppStoreAuthorization['Body'] = val.data;
     const queryString: PostPublicAppStoreAuthorization['Querystring'] = queryStringVal.data;
     const { providerConfigKey }: PostPublicAppStoreAuthorization['Params'] = paramsVal.data;
-    const connectionConfigOverride = resolveConnectionConfig({ params: queryString.params, connectSession, providerConfigKey });
+    const resolvedConnectionConfig = resolveConnectionConfig({ params: queryString.params, connectSession, providerConfigKey });
     let connectionId = queryString.connection_id || connectionService.generateConnectionId();
     const hmac = 'hmac' in queryString ? queryString.hmac : undefined;
     const isConnectSession = res.locals['authType'] === 'connectSession';
@@ -151,7 +151,7 @@ export const postPublicAppStoreAuthorization = asyncWrapper<PostPublicAppStoreAu
         await logCtx.enrichOperation({ integrationId: config.id!, integrationName: config.unique_key, providerName: config.provider });
 
         const connectionConfig: ConnectionConfig = {
-            ...connectionConfigOverride,
+            ...resolvedConnectionConfig,
             privateKeyId,
             issuerId,
             scope
@@ -247,7 +247,7 @@ export const postPublicAppStoreAuthorization = asyncWrapper<PostPublicAppStoreAu
         if (logCtx) {
             void connectionCreationFailedHook(
                 {
-                    connection: { connection_id: connectionId, provider_config_key: providerConfigKey, connection_config: connectionConfigOverride },
+                    connection: { connection_id: connectionId, provider_config_key: providerConfigKey, connection_config: resolvedConnectionConfig },
                     environment,
                     account,
                     auth_mode: 'APP_STORE',

--- a/packages/server/lib/controllers/auth/postAppStore.ts
+++ b/packages/server/lib/controllers/auth/postAppStore.ts
@@ -77,6 +77,7 @@ export const postPublicAppStoreAuthorization = asyncWrapper<PostPublicAppStoreAu
     const { issuerId, privateKey, privateKeyId, scope }: PostPublicAppStoreAuthorization['Body'] = val.data;
     const queryString: PostPublicAppStoreAuthorization['Querystring'] = queryStringVal.data;
     const { providerConfigKey }: PostPublicAppStoreAuthorization['Params'] = paramsVal.data;
+    const connectionConfigOverride = resolveConnectionConfig({ params: queryString.params, connectSession, providerConfigKey });
     let connectionId = queryString.connection_id || connectionService.generateConnectionId();
     const hmac = 'hmac' in queryString ? queryString.hmac : undefined;
     const isConnectSession = res.locals['authType'] === 'connectSession';
@@ -150,7 +151,7 @@ export const postPublicAppStoreAuthorization = asyncWrapper<PostPublicAppStoreAu
         await logCtx.enrichOperation({ integrationId: config.id!, integrationName: config.unique_key, providerName: config.provider });
 
         const connectionConfig: ConnectionConfig = {
-            ...resolveConnectionConfig({ params: queryString.params, connectSession, providerConfigKey }),
+            ...connectionConfigOverride,
             privateKeyId,
             issuerId,
             scope
@@ -246,7 +247,7 @@ export const postPublicAppStoreAuthorization = asyncWrapper<PostPublicAppStoreAu
         if (logCtx) {
             void connectionCreationFailedHook(
                 {
-                    connection: { connection_id: connectionId, provider_config_key: providerConfigKey },
+                    connection: { connection_id: connectionId, provider_config_key: providerConfigKey, connection_config: connectionConfigOverride },
                     environment,
                     account,
                     auth_mode: 'APP_STORE',

--- a/packages/server/lib/controllers/auth/postAppStore.ts
+++ b/packages/server/lib/controllers/auth/postAppStore.ts
@@ -14,11 +14,11 @@ import {
 } from '@nangohq/shared';
 import { metrics, report, stringifyError, zodErrorToHTTP } from '@nangohq/utils';
 
-import { connectionCredential, connectionIdSchema, providerConfigKeySchema } from '../../helpers/validation.js';
+import { connectionConfigParamsSchema, connectionCredential, connectionIdSchema, providerConfigKeySchema } from '../../helpers/validation.js';
 import { handleValidateConnectionFailure, validateConnection } from '../../hooks/connection/on/validate-connection.js';
 import { connectionCreated as connectionCreatedHook, connectionCreationFailed as connectionCreationFailedHook } from '../../hooks/hooks.js';
 import { asyncWrapper } from '../../utils/asyncWrapper.js';
-import { errorRestrictConnectionId, isIntegrationAllowed } from '../../utils/auth.js';
+import { errorRestrictConnectionId, isIntegrationAllowed, resolveConnectionConfig } from '../../utils/auth.js';
 import { hmacCheck } from '../../utils/hmac.js';
 
 import type { LogContext } from '@nangohq/logs';
@@ -38,7 +38,7 @@ const bodyValidation = z
 const queryStringValidation = z
     .object({
         connection_id: connectionIdSchema.optional(),
-        params: z.record(z.string(), z.any()).optional()
+        params: connectionConfigParamsSchema
     })
     .and(connectionCredential);
 
@@ -77,7 +77,6 @@ export const postPublicAppStoreAuthorization = asyncWrapper<PostPublicAppStoreAu
     const { issuerId, privateKey, privateKeyId, scope }: PostPublicAppStoreAuthorization['Body'] = val.data;
     const queryString: PostPublicAppStoreAuthorization['Querystring'] = queryStringVal.data;
     const { providerConfigKey }: PostPublicAppStoreAuthorization['Params'] = paramsVal.data;
-    // const connectionConfig = queryString.params ? getConnectionConfig(queryString.params) : {};
     let connectionId = queryString.connection_id || connectionService.generateConnectionId();
     const hmac = 'hmac' in queryString ? queryString.hmac : undefined;
     const isConnectSession = res.locals['authType'] === 'connectSession';
@@ -151,6 +150,7 @@ export const postPublicAppStoreAuthorization = asyncWrapper<PostPublicAppStoreAu
         await logCtx.enrichOperation({ integrationId: config.id!, integrationName: config.unique_key, providerName: config.provider });
 
         const connectionConfig: ConnectionConfig = {
+            ...resolveConnectionConfig({ params: queryString.params, connectSession, providerConfigKey }),
             privateKeyId,
             issuerId,
             scope

--- a/packages/server/lib/controllers/auth/postAppStore.unit.test.ts
+++ b/packages/server/lib/controllers/auth/postAppStore.unit.test.ts
@@ -50,6 +50,7 @@ vi.mock('@nangohq/shared', async () => {
         ...actual,
         ErrorSourceEnum: { PLATFORM: 'platform' },
         LogActionEnum: { AUTH: 'auth' },
+        errorManager: { report: vi.fn() },
         appleAppStoreClient: { createCredentials: mockCreateCredentials },
         configService: { getProviderConfig: mockGetProviderConfig },
         connectionService: {
@@ -132,6 +133,34 @@ describe('postPublicAppStoreAuthorization', () => {
                     issuerId: 'issuer-id'
                 })
             })
+        );
+    });
+
+    it('threads the per-connection webhook URL override into the creation-failure hook', async () => {
+        mockUpsertConnection.mockRejectedValue(new Error('boom'));
+
+        const req = {
+            body: { privateKeyId: 'key-id', privateKey: 'private-key', issuerId: 'issuer-id' },
+            query: { public_key: '550e8400-e29b-41d4-a716-446655440000', params: { webhook_url: 'https://override.example.com/hook' } },
+            params: { providerConfigKey: 'appstore' }
+        } as unknown as Request;
+
+        const res = {
+            locals: { account: { id: 1 }, environment: { id: 2 }, connectSession: null, authType: 'publicKey', endUser: null },
+            status: vi.fn().mockReturnThis(),
+            send: vi.fn().mockReturnThis()
+        } as unknown as Response;
+        const next = vi.fn();
+
+        await postPublicAppStoreAuthorization(req, res, next);
+
+        expect(mockConnectionCreationFailed).toHaveBeenCalledWith(
+            expect.objectContaining({
+                connection: expect.objectContaining({
+                    connection_config: expect.objectContaining({ webhook_url: 'https://override.example.com/hook' })
+                })
+            }),
+            expect.anything()
         );
     });
 });

--- a/packages/server/lib/controllers/auth/postAppStore.unit.test.ts
+++ b/packages/server/lib/controllers/auth/postAppStore.unit.test.ts
@@ -4,6 +4,7 @@ import { Ok } from '@nangohq/utils';
 
 import { postPublicAppStoreAuthorization } from './postAppStore.js';
 
+import type * as DatabaseModule from '@nangohq/database';
 import type * as SharedModule from '@nangohq/shared';
 import type { Request, Response } from 'express';
 
@@ -34,7 +35,7 @@ const {
 });
 
 vi.mock('@nangohq/database', async () => {
-    const actual: typeof import('@nangohq/database') = await vi.importActual('@nangohq/database');
+    const actual: typeof DatabaseModule = await vi.importActual('@nangohq/database');
     return { ...actual, default: { knex: {} } };
 });
 

--- a/packages/server/lib/controllers/auth/postAppStore.unit.test.ts
+++ b/packages/server/lib/controllers/auth/postAppStore.unit.test.ts
@@ -1,0 +1,137 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+import { Ok } from '@nangohq/utils';
+
+import { postPublicAppStoreAuthorization } from './postAppStore.js';
+
+import type * as SharedModule from '@nangohq/shared';
+import type { Request, Response } from 'express';
+
+const {
+    mockCreateLogContext,
+    mockGenerateConnectionId,
+    mockGetProviderConfig,
+    mockGetProvider,
+    mockCreateCredentials,
+    mockUpsertConnection,
+    mockHmacCheck,
+    mockValidateConnection,
+    mockConnectionCreated,
+    mockConnectionCreationFailed
+} = vi.hoisted(() => {
+    return {
+        mockCreateLogContext: vi.fn(),
+        mockGenerateConnectionId: vi.fn(),
+        mockGetProviderConfig: vi.fn(),
+        mockGetProvider: vi.fn(),
+        mockCreateCredentials: vi.fn(),
+        mockUpsertConnection: vi.fn(),
+        mockHmacCheck: vi.fn(),
+        mockValidateConnection: vi.fn(),
+        mockConnectionCreated: vi.fn(),
+        mockConnectionCreationFailed: vi.fn()
+    };
+});
+
+vi.mock('@nangohq/database', async () => {
+    const actual: typeof import('@nangohq/database') = await vi.importActual('@nangohq/database');
+    return { ...actual, default: { knex: {} } };
+});
+
+vi.mock('@nangohq/logs', () => ({
+    defaultOperationExpiration: { auth: () => new Date('2026-01-01T00:00:00.000Z') },
+    endUserToMeta: vi.fn(() => null),
+    logContextGetter: { create: mockCreateLogContext, get: vi.fn() }
+}));
+
+vi.mock('@nangohq/shared', async () => {
+    const actual: typeof SharedModule = await vi.importActual('@nangohq/shared');
+    return {
+        ...actual,
+        ErrorSourceEnum: { PLATFORM: 'platform' },
+        LogActionEnum: { AUTH: 'auth' },
+        appleAppStoreClient: { createCredentials: mockCreateCredentials },
+        configService: { getProviderConfig: mockGetProviderConfig },
+        connectionService: {
+            generateConnectionId: mockGenerateConnectionId,
+            getConnectionById: vi.fn(),
+            upsertConnection: mockUpsertConnection
+        },
+        getProvider: mockGetProvider,
+        syncEndUserToConnection: vi.fn()
+    };
+});
+
+vi.mock('../../hooks/connection/on/validate-connection.js', () => ({
+    validateConnection: mockValidateConnection
+}));
+
+vi.mock('../../hooks/hooks.js', () => ({
+    connectionCreated: mockConnectionCreated,
+    connectionCreationFailed: mockConnectionCreationFailed
+}));
+
+vi.mock('../../utils/hmac.js', () => ({
+    hmacCheck: mockHmacCheck
+}));
+
+describe('postPublicAppStoreAuthorization', () => {
+    beforeEach(() => {
+        vi.clearAllMocks();
+
+        mockCreateLogContext.mockResolvedValue({
+            error: vi.fn(),
+            failed: vi.fn(),
+            enrichOperation: vi.fn(),
+            warn: vi.fn(),
+            log: vi.fn(),
+            info: vi.fn(),
+            success: vi.fn()
+        });
+        mockGenerateConnectionId.mockReturnValue('generated-connection-id');
+        mockGetProviderConfig.mockResolvedValue({ id: 1, unique_key: 'appstore', provider: 'apple-app-store' });
+        mockGetProvider.mockReturnValue({ auth_mode: 'APP_STORE' });
+        mockCreateCredentials.mockResolvedValue(Ok({ type: 'APP_STORE' }));
+        mockUpsertConnection.mockResolvedValue([
+            { connection: { id: 1, connection_id: 'generated-connection-id', provider_config_key: 'appstore' }, operation: 'creation' }
+        ]);
+        mockHmacCheck.mockResolvedValue(true);
+        mockValidateConnection.mockResolvedValue(Ok({ tested: true }));
+    });
+
+    it('stores the resolved per-connection webhook URL override alongside the App Store connection config', async () => {
+        // The override is supplied via `params` and resolved by the real resolveConnectionConfig (not mocked).
+        const req = {
+            body: { privateKeyId: 'key-id', privateKey: 'private-key', issuerId: 'issuer-id' },
+            query: { public_key: '550e8400-e29b-41d4-a716-446655440000', params: { webhook_url: 'https://override.example.com/hook' } },
+            params: { providerConfigKey: 'appstore' }
+        } as unknown as Request;
+
+        const status = vi.fn().mockReturnThis();
+        const send = vi.fn().mockReturnThis();
+        const res = {
+            locals: {
+                account: { id: 1 },
+                environment: { id: 2 },
+                connectSession: null,
+                authType: 'publicKey',
+                endUser: null
+            },
+            status,
+            send
+        } as unknown as Response;
+        const next = vi.fn();
+
+        await postPublicAppStoreAuthorization(req, res, next);
+
+        expect(mockUpsertConnection).toHaveBeenCalledWith(
+            expect.objectContaining({
+                connectionConfig: expect.objectContaining({
+                    webhook_url: 'https://override.example.com/hook',
+                    privateKeyId: 'key-id',
+                    issuerId: 'issuer-id'
+                })
+            })
+        );
+    });
+});

--- a/packages/server/lib/controllers/auth/postAppStore.unit.test.ts
+++ b/packages/server/lib/controllers/auth/postAppStore.unit.test.ts
@@ -100,11 +100,20 @@ describe('postPublicAppStoreAuthorization', () => {
         mockValidateConnection.mockResolvedValue(Ok({ tested: true }));
     });
 
+    // The override is only honored from the backend-set connect session default, never from client params,
+    // and is resolved by the real resolveConnectionConfig (not mocked).
+    const connectSessionWithOverride = {
+        operationId: null,
+        connectionId: null,
+        allowedIntegrations: null,
+        integrationsConfigDefaults: { appstore: { connectionConfig: { webhook_url: 'https://override.example.com/hook' } } }
+    };
+    const sessionTokenQuery = { connect_session_token: `nango_connect_session_${'a'.repeat(64)}` };
+
     it('stores the resolved per-connection webhook URL override alongside the App Store connection config', async () => {
-        // The override is supplied via `params` and resolved by the real resolveConnectionConfig (not mocked).
         const req = {
             body: { privateKeyId: 'key-id', privateKey: 'private-key', issuerId: 'issuer-id' },
-            query: { public_key: '550e8400-e29b-41d4-a716-446655440000', params: { webhook_url: 'https://override.example.com/hook' } },
+            query: sessionTokenQuery,
             params: { providerConfigKey: 'appstore' }
         } as unknown as Request;
 
@@ -114,8 +123,8 @@ describe('postPublicAppStoreAuthorization', () => {
             locals: {
                 account: { id: 1 },
                 environment: { id: 2 },
-                connectSession: null,
-                authType: 'publicKey',
+                connectSession: connectSessionWithOverride,
+                authType: 'connectSession',
                 endUser: null
             },
             status,
@@ -136,17 +145,38 @@ describe('postPublicAppStoreAuthorization', () => {
         );
     });
 
-    it('threads the per-connection webhook URL override into the creation-failure hook', async () => {
-        mockUpsertConnection.mockRejectedValue(new Error('boom'));
-
+    it('ignores a client-supplied webhook_url param', async () => {
         const req = {
             body: { privateKeyId: 'key-id', privateKey: 'private-key', issuerId: 'issuer-id' },
-            query: { public_key: '550e8400-e29b-41d4-a716-446655440000', params: { webhook_url: 'https://override.example.com/hook' } },
+            query: { public_key: '550e8400-e29b-41d4-a716-446655440000', params: { webhook_url: 'https://attacker.example.com/hook' } },
             params: { providerConfigKey: 'appstore' }
         } as unknown as Request;
 
         const res = {
             locals: { account: { id: 1 }, environment: { id: 2 }, connectSession: null, authType: 'publicKey', endUser: null },
+            status: vi.fn().mockReturnThis(),
+            send: vi.fn().mockReturnThis()
+        } as unknown as Response;
+        const next = vi.fn();
+
+        await postPublicAppStoreAuthorization(req, res, next);
+
+        expect(mockUpsertConnection).toHaveBeenCalledWith(
+            expect.objectContaining({ connectionConfig: expect.not.objectContaining({ webhook_url: expect.anything() }) })
+        );
+    });
+
+    it('threads the per-connection webhook URL override into the creation-failure hook', async () => {
+        mockUpsertConnection.mockRejectedValue(new Error('boom'));
+
+        const req = {
+            body: { privateKeyId: 'key-id', privateKey: 'private-key', issuerId: 'issuer-id' },
+            query: sessionTokenQuery,
+            params: { providerConfigKey: 'appstore' }
+        } as unknown as Request;
+
+        const res = {
+            locals: { account: { id: 1 }, environment: { id: 2 }, connectSession: connectSessionWithOverride, authType: 'connectSession', endUser: null },
             status: vi.fn().mockReturnThis(),
             send: vi.fn().mockReturnThis()
         } as unknown as Response;

--- a/packages/server/lib/controllers/auth/postAwsSigV4.ts
+++ b/packages/server/lib/controllers/auth/postAwsSigV4.ts
@@ -20,7 +20,7 @@ import {
 } from '@nangohq/shared';
 import { metrics, zodErrorToHTTP } from '@nangohq/utils';
 
-import { connectionCredential, connectionIdSchema, providerConfigKeySchema } from '../../helpers/validation.js';
+import { connectionConfigParamsSchema, connectionCredential, connectionIdSchema, providerConfigKeySchema } from '../../helpers/validation.js';
 import { handleValidateConnectionFailure, validateConnection } from '../../hooks/connection/on/validate-connection.js';
 import { connectionCreated as connectionCreatedHook, connectionCreationFailed as connectionCreationFailedHook } from '../../hooks/hooks.js';
 import { asyncWrapper } from '../../utils/asyncWrapper.js';
@@ -49,7 +49,7 @@ const bodyValidation = z
 const queryValidation = z
     .object({
         connection_id: connectionIdSchema.optional(),
-        params: z.record(z.string(), z.any()).optional(),
+        params: connectionConfigParamsSchema,
         user_scope: z.string().optional()
     })
     .and(connectionCredential);

--- a/packages/server/lib/controllers/auth/postAwsSigV4.ts
+++ b/packages/server/lib/controllers/auth/postAwsSigV4.ts
@@ -334,7 +334,7 @@ export const postPublicAwsSigV4Authorization = asyncWrapper<PostPublicAwsSigV4Au
     } catch (err) {
         void connectionCreationFailedHook(
             {
-                connection: { connection_id: connectionId, provider_config_key: providerConfigKey },
+                connection: { connection_id: connectionId, provider_config_key: providerConfigKey, connection_config: connectionConfig },
                 environment,
                 account,
                 auth_mode: 'AWS_SIGV4',

--- a/packages/server/lib/controllers/auth/postAwsSigV4.ts
+++ b/packages/server/lib/controllers/auth/postAwsSigV4.ts
@@ -9,7 +9,6 @@ import {
     connectionService,
     errorManager,
     ErrorSourceEnum,
-    getConnectionConfig,
     getProvider,
     getProxyConfiguration,
     getServerOutboundUrlPolicy,
@@ -24,7 +23,7 @@ import { connectionConfigParamsSchema, connectionCredential, connectionIdSchema,
 import { handleValidateConnectionFailure, validateConnection } from '../../hooks/connection/on/validate-connection.js';
 import { connectionCreated as connectionCreatedHook, connectionCreationFailed as connectionCreationFailedHook } from '../../hooks/hooks.js';
 import { asyncWrapper } from '../../utils/asyncWrapper.js';
-import { errorRestrictConnectionId, isIntegrationAllowed } from '../../utils/auth.js';
+import { errorRestrictConnectionId, isIntegrationAllowed, resolveConnectionConfig } from '../../utils/auth.js';
 import { hmacCheck } from '../../utils/hmac.js';
 
 import type { LogContext } from '@nangohq/logs';
@@ -85,7 +84,7 @@ export const postPublicAwsSigV4Authorization = asyncWrapper<PostPublicAwsSigV4Au
     const { providerConfigKey } = valParams.data;
 
     let connectionId = query.connection_id || connectionService.generateConnectionId();
-    const connectionConfig = query.params ? getConnectionConfig(query.params) : {};
+    const connectionConfig = resolveConnectionConfig({ params: query.params, connectSession, providerConfigKey });
     const hmac = 'hmac' in query ? query.hmac : undefined;
     const isConnectSession = res.locals['authType'] === 'connectSession';
 

--- a/packages/server/lib/controllers/auth/postAwsSigV4.unit.test.ts
+++ b/packages/server/lib/controllers/auth/postAwsSigV4.unit.test.ts
@@ -4,6 +4,7 @@ import { Err, Ok } from '@nangohq/utils';
 
 import { postPublicAwsSigV4Authorization } from './postAwsSigV4.js';
 
+import type * as AuthUtilsModule from '../../utils/auth.js';
 import type * as DatabaseModule from '@nangohq/database';
 import type * as SharedModule from '@nangohq/shared';
 import type { Request, Response } from 'express';
@@ -25,7 +26,8 @@ const {
     mockHmacCheck,
     mockValidateConnection,
     mockConnectionCreated,
-    mockConnectionCreationFailed
+    mockConnectionCreationFailed,
+    mockUpsertAuthConnection
 } = vi.hoisted(() => {
     return {
         mockCreateLogContext: vi.fn(),
@@ -44,7 +46,8 @@ const {
         mockHmacCheck: vi.fn(),
         mockValidateConnection: vi.fn(),
         mockConnectionCreated: vi.fn(),
-        mockConnectionCreationFailed: vi.fn()
+        mockConnectionCreationFailed: vi.fn(),
+        mockUpsertAuthConnection: vi.fn()
     };
 });
 
@@ -106,14 +109,13 @@ vi.mock('@nangohq/shared', async () => {
             generateConnectionId: mockGenerateConnectionId,
             getConnection: mockGetConnection,
             getConnectionById: vi.fn(),
-            upsertAuthConnection: vi.fn(),
+            upsertAuthConnection: mockUpsertAuthConnection,
             hardDelete: vi.fn()
         },
         errorManager: {
             errResFromNangoErr: vi.fn(),
             report: mockReport
         },
-        getConnectionConfig: vi.fn((params) => params),
         getProvider: mockGetProvider,
         getProxyConfiguration: mockGetProxyConfiguration,
         syncEndUserToConnection: vi.fn()
@@ -129,11 +131,14 @@ vi.mock('../../hooks/hooks.js', () => ({
     connectionCreationFailed: mockConnectionCreationFailed
 }));
 
-vi.mock('../../utils/auth.js', () => ({
-    errorRestrictConnectionId: vi.fn(),
-    isIntegrationAllowed: mockIsIntegrationAllowed,
-    resolveConnectionConfig: vi.fn(({ params }) => params ?? {})
-}));
+vi.mock('../../utils/auth.js', async () => {
+    const actual: typeof AuthUtilsModule = await vi.importActual('../../utils/auth.js');
+    return {
+        ...actual,
+        errorRestrictConnectionId: vi.fn(),
+        isIntegrationAllowed: mockIsIntegrationAllowed
+    };
+});
 
 vi.mock('../../utils/hmac.js', () => ({
     hmacCheck: mockHmacCheck
@@ -183,7 +188,29 @@ describe('postPublicAwsSigV4Authorization', () => {
         mockIsIntegrationAllowed.mockResolvedValue(true);
         mockHmacCheck.mockResolvedValue(true);
         mockValidateConnection.mockResolvedValue(Ok({ tested: true }));
+        mockUpsertAuthConnection.mockResolvedValue([
+            { connection: { id: 1, connection_id: 'generated-connection-id', provider_config_key: 'aws-sigv4' }, operation: 'creation' }
+        ]);
     });
+
+    // Drive the controller all the way to a successful upsert: GetCallerIdentity must return an ARN
+    // whose role name matches the requested role_arn.
+    const succeedCredentialVerification = () =>
+        mockProxyRequest.mockResolvedValue(
+            Ok({
+                data: '<GetCallerIdentityResponse><GetCallerIdentityResult><Arn>arn:aws:sts::123456789012:assumed-role/NangoAccessRole/session</Arn></GetCallerIdentityResult></GetCallerIdentityResponse>'
+            })
+        );
+
+    // The override is only honored from the backend-set connect session default, never from client params,
+    // and is resolved by the real resolveConnectionConfig (not mocked).
+    const connectSessionWithOverride = {
+        operationId: null,
+        connectionId: null,
+        allowedIntegrations: null,
+        integrationsConfigDefaults: { 'aws-sigv4': { connectionConfig: { webhook_url: 'https://override.example.com/hook' } } }
+    };
+    const sessionTokenQuery = { connect_session_token: `nango_connect_session_${'a'.repeat(64)}` };
 
     it('returns connection_test_failed when AWS credential verification fails', async () => {
         const req = {
@@ -267,5 +294,96 @@ describe('postPublicAwsSigV4Authorization', () => {
             actualArn: 'arn:aws:sts::123456789012:assumed-role/UnexpectedRole/session'
         });
         expect(next).not.toHaveBeenCalled();
+    });
+
+    it('stores the resolved per-connection webhook URL override alongside the connection config', async () => {
+        succeedCredentialVerification();
+
+        const req = {
+            body: { role_arn: 'arn:aws:iam::123456789012:role/NangoAccessRole', region: 'us-east-1' },
+            query: sessionTokenQuery,
+            params: { providerConfigKey: 'aws-sigv4' },
+            route: { path: '/auth/aws-sigv4/:providerConfigKey' },
+            originalUrl: '/auth/aws-sigv4/aws-sigv4',
+            header: vi.fn()
+        } as unknown as Request;
+
+        const res = {
+            locals: { account: { id: 1 }, environment: { id: 2 }, connectSession: connectSessionWithOverride, authType: 'connectSession', endUser: null },
+            status: vi.fn().mockReturnThis(),
+            send: vi.fn().mockReturnThis()
+        } as unknown as Response;
+        const next = vi.fn();
+
+        await postPublicAwsSigV4Authorization(req, res, next);
+
+        expect(mockUpsertAuthConnection).toHaveBeenCalledWith(
+            expect.objectContaining({
+                connectionConfig: expect.objectContaining({
+                    webhook_url: 'https://override.example.com/hook',
+                    role_arn: 'arn:aws:iam::123456789012:role/NangoAccessRole',
+                    region: 'us-east-1'
+                })
+            })
+        );
+    });
+
+    it('ignores a client-supplied webhook_url param', async () => {
+        succeedCredentialVerification();
+
+        const req = {
+            body: { role_arn: 'arn:aws:iam::123456789012:role/NangoAccessRole', region: 'us-east-1' },
+            query: { public_key: '550e8400-e29b-41d4-a716-446655440000', params: { webhook_url: 'https://attacker.example.com/hook' } },
+            params: { providerConfigKey: 'aws-sigv4' },
+            route: { path: '/auth/aws-sigv4/:providerConfigKey' },
+            originalUrl: '/auth/aws-sigv4/aws-sigv4',
+            header: vi.fn()
+        } as unknown as Request;
+
+        const res = {
+            locals: { account: { id: 1 }, environment: { id: 2 }, connectSession: null, authType: 'publicKey', endUser: null },
+            status: vi.fn().mockReturnThis(),
+            send: vi.fn().mockReturnThis()
+        } as unknown as Response;
+        const next = vi.fn();
+
+        await postPublicAwsSigV4Authorization(req, res, next);
+
+        expect(mockUpsertAuthConnection).toHaveBeenCalledWith(
+            expect.objectContaining({ connectionConfig: expect.not.objectContaining({ webhook_url: expect.anything() }) })
+        );
+    });
+
+    it('threads the per-connection webhook URL override into the creation-failure hook', async () => {
+        succeedCredentialVerification();
+        mockUpsertAuthConnection.mockRejectedValue(new Error('boom'));
+
+        const req = {
+            body: { role_arn: 'arn:aws:iam::123456789012:role/NangoAccessRole', region: 'us-east-1' },
+            query: sessionTokenQuery,
+            params: { providerConfigKey: 'aws-sigv4' },
+            route: { path: '/auth/aws-sigv4/:providerConfigKey' },
+            originalUrl: '/auth/aws-sigv4/aws-sigv4',
+            header: vi.fn()
+        } as unknown as Request;
+
+        const res = {
+            locals: { account: { id: 1 }, environment: { id: 2 }, connectSession: connectSessionWithOverride, authType: 'connectSession', endUser: null },
+            status: vi.fn().mockReturnThis(),
+            send: vi.fn().mockReturnThis()
+        } as unknown as Response;
+        const next = vi.fn();
+
+        await postPublicAwsSigV4Authorization(req, res, next);
+
+        expect(mockConnectionCreationFailed).toHaveBeenCalledWith(
+            expect.objectContaining({
+                connection: expect.objectContaining({
+                    connection_config: expect.objectContaining({ webhook_url: 'https://override.example.com/hook' })
+                })
+            }),
+            expect.anything(),
+            expect.anything()
+        );
     });
 });

--- a/packages/server/lib/controllers/auth/postAwsSigV4.unit.test.ts
+++ b/packages/server/lib/controllers/auth/postAwsSigV4.unit.test.ts
@@ -131,7 +131,8 @@ vi.mock('../../hooks/hooks.js', () => ({
 
 vi.mock('../../utils/auth.js', () => ({
     errorRestrictConnectionId: vi.fn(),
-    isIntegrationAllowed: mockIsIntegrationAllowed
+    isIntegrationAllowed: mockIsIntegrationAllowed,
+    resolveConnectionConfig: vi.fn(({ params }) => params ?? {})
 }));
 
 vi.mock('../../utils/hmac.js', () => ({

--- a/packages/server/lib/controllers/auth/postBasic.ts
+++ b/packages/server/lib/controllers/auth/postBasic.ts
@@ -2,16 +2,7 @@ import * as z from 'zod';
 
 import db from '@nangohq/database';
 import { defaultOperationExpiration, endUserToMeta, logContextGetter } from '@nangohq/logs';
-import {
-    configService,
-    connectionService,
-    errorManager,
-    ErrorSourceEnum,
-    getConnectionConfig,
-    getProvider,
-    LogActionEnum,
-    syncEndUserToConnection
-} from '@nangohq/shared';
+import { configService, connectionService, errorManager, ErrorSourceEnum, getProvider, LogActionEnum, syncEndUserToConnection } from '@nangohq/shared';
 import { metrics, stringifyError, zodErrorToHTTP } from '@nangohq/utils';
 
 import {
@@ -28,7 +19,7 @@ import {
     testConnectionCredentials
 } from '../../hooks/hooks.js';
 import { asyncWrapper } from '../../utils/asyncWrapper.js';
-import { errorRestrictConnectionId, isIntegrationAllowed } from '../../utils/auth.js';
+import { errorRestrictConnectionId, isIntegrationAllowed, resolveConnectionConfig } from '../../utils/auth.js';
 import { hmacCheck } from '../../utils/hmac.js';
 
 import type { LogContext } from '@nangohq/logs';
@@ -78,7 +69,7 @@ export const postPublicBasicAuthorization = asyncWrapper<PostPublicBasicAuthoriz
     const { username, password }: PostPublicBasicAuthorization['Body'] = val.data;
     const queryString: PostPublicBasicAuthorization['Querystring'] = queryStringVal.data;
     const { providerConfigKey }: PostPublicBasicAuthorization['Params'] = paramsVal.data;
-    const connectionConfig = queryString.params ? getConnectionConfig(queryString.params) : {};
+    const connectionConfig = resolveConnectionConfig({ params: queryString.params, connectSession, providerConfigKey });
     let connectionId = queryString.connection_id || connectionService.generateConnectionId();
     const hmac = 'hmac' in queryString ? queryString.hmac : undefined;
     const isConnectSession = res.locals['authType'] === 'connectSession';

--- a/packages/server/lib/controllers/auth/postBasic.ts
+++ b/packages/server/lib/controllers/auth/postBasic.ts
@@ -237,7 +237,7 @@ export const postPublicBasicAuthorization = asyncWrapper<PostPublicBasicAuthoriz
         if (logCtx) {
             void connectionCreationFailedHook(
                 {
-                    connection: { connection_id: connectionId, provider_config_key: providerConfigKey },
+                    connection: { connection_id: connectionId, provider_config_key: providerConfigKey, connection_config: connectionConfig },
                     environment,
                     account,
                     auth_mode: 'BASIC',

--- a/packages/server/lib/controllers/auth/postBasic.ts
+++ b/packages/server/lib/controllers/auth/postBasic.ts
@@ -14,7 +14,13 @@ import {
 } from '@nangohq/shared';
 import { metrics, stringifyError, zodErrorToHTTP } from '@nangohq/utils';
 
-import { connectionCredential, connectionCredentialsBasicSchema, connectionIdSchema, providerConfigKeySchema } from '../../helpers/validation.js';
+import {
+    connectionConfigParamsSchema,
+    connectionCredential,
+    connectionCredentialsBasicSchema,
+    connectionIdSchema,
+    providerConfigKeySchema
+} from '../../helpers/validation.js';
 import { handleValidateConnectionFailure, validateConnection } from '../../hooks/connection/on/validate-connection.js';
 import {
     connectionCreated as connectionCreatedHook,
@@ -33,7 +39,7 @@ import type { NextFunction } from 'express';
 const queryStringValidation = z
     .object({
         connection_id: connectionIdSchema.optional(),
-        params: z.record(z.string(), z.any()).optional()
+        params: connectionConfigParamsSchema
     })
     .and(connectionCredential);
 

--- a/packages/server/lib/controllers/auth/postBill.ts
+++ b/packages/server/lib/controllers/auth/postBill.ts
@@ -239,7 +239,7 @@ export const postPublicBillAuthorization = asyncWrapper<PostPublicBillAuthorizat
 
         void connectionCreationFailedHook(
             {
-                connection: { connection_id: connectionId, provider_config_key: providerConfigKey },
+                connection: { connection_id: connectionId, provider_config_key: providerConfigKey, connection_config: connectionConfig },
                 environment,
                 account,
                 auth_mode: 'BILL',

--- a/packages/server/lib/controllers/auth/postBill.ts
+++ b/packages/server/lib/controllers/auth/postBill.ts
@@ -8,7 +8,6 @@ import {
     connectionService,
     errorManager,
     ErrorSourceEnum,
-    getConnectionConfig,
     getProvider,
     LogActionEnum,
     syncEndUserToConnection
@@ -19,7 +18,7 @@ import { connectionConfigParamsSchema, connectionCredential, connectionIdSchema,
 import { handleValidateConnectionFailure, validateConnection } from '../../hooks/connection/on/validate-connection.js';
 import { connectionCreated as connectionCreatedHook, connectionCreationFailed as connectionCreationFailedHook } from '../../hooks/hooks.js';
 import { asyncWrapper } from '../../utils/asyncWrapper.js';
-import { errorRestrictConnectionId, isIntegrationAllowed } from '../../utils/auth.js';
+import { errorRestrictConnectionId, isIntegrationAllowed, resolveConnectionConfig } from '../../utils/auth.js';
 import { hmacCheck } from '../../utils/hmac.js';
 
 import type { LogContext } from '@nangohq/logs';
@@ -79,7 +78,7 @@ export const postPublicBillAuthorization = asyncWrapper<PostPublicBillAuthorizat
     const { username, password: password, organization_id: organizationId, dev_key: devkey }: PostPublicBillAuthorization['Body'] = val.data;
     const queryString: PostPublicBillAuthorization['Querystring'] = queryStringVal.data;
     const { providerConfigKey }: PostPublicBillAuthorization['Params'] = paramsVal.data;
-    const connectionConfig = queryString.params ? getConnectionConfig(queryString.params) : {};
+    const connectionConfig = resolveConnectionConfig({ params: queryString.params, connectSession, providerConfigKey });
     let connectionId = queryString.connection_id || connectionService.generateConnectionId();
     const hmac = 'hmac' in queryString ? queryString.hmac : undefined;
     const isConnectSession = res.locals['authType'] === 'connectSession';

--- a/packages/server/lib/controllers/auth/postBill.ts
+++ b/packages/server/lib/controllers/auth/postBill.ts
@@ -15,7 +15,7 @@ import {
 } from '@nangohq/shared';
 import { metrics, report, stringifyError, zodErrorToHTTP } from '@nangohq/utils';
 
-import { connectionCredential, connectionIdSchema, providerConfigKeySchema } from '../../helpers/validation.js';
+import { connectionConfigParamsSchema, connectionCredential, connectionIdSchema, providerConfigKeySchema } from '../../helpers/validation.js';
 import { handleValidateConnectionFailure, validateConnection } from '../../hooks/connection/on/validate-connection.js';
 import { connectionCreated as connectionCreatedHook, connectionCreationFailed as connectionCreationFailedHook } from '../../hooks/hooks.js';
 import { asyncWrapper } from '../../utils/asyncWrapper.js';
@@ -39,7 +39,7 @@ const bodyValidation = z
 const queryStringValidation = z
     .object({
         connection_id: connectionIdSchema.optional(),
-        params: z.record(z.string(), z.any()).optional(),
+        params: connectionConfigParamsSchema,
         user_scope: z.string().optional()
     })
     .and(connectionCredential);

--- a/packages/server/lib/controllers/auth/postJwt.ts
+++ b/packages/server/lib/controllers/auth/postJwt.ts
@@ -15,7 +15,7 @@ import {
 } from '@nangohq/shared';
 import { metrics, stringifyError, zodErrorToHTTP } from '@nangohq/utils';
 
-import { connectionCredential, connectionIdSchema, providerConfigKeySchema } from '../../helpers/validation.js';
+import { connectionConfigParamsSchema, connectionCredential, connectionIdSchema, providerConfigKeySchema } from '../../helpers/validation.js';
 import { handleValidateConnectionFailure, validateConnection } from '../../hooks/connection/on/validate-connection.js';
 import {
     connectionCreated as connectionCreatedHook,
@@ -35,7 +35,7 @@ const bodyValidation = z.looseObject({});
 const queryStringValidation = z
     .object({
         connection_id: connectionIdSchema.optional(),
-        params: z.record(z.string(), z.any()).optional(),
+        params: connectionConfigParamsSchema,
         user_scope: z.string().optional()
     })
     .and(connectionCredential);

--- a/packages/server/lib/controllers/auth/postJwt.ts
+++ b/packages/server/lib/controllers/auth/postJwt.ts
@@ -7,7 +7,6 @@ import {
     connectionService,
     errorManager,
     ErrorSourceEnum,
-    getConnectionConfig,
     getProvider,
     jwtClient,
     LogActionEnum,
@@ -23,7 +22,7 @@ import {
     testConnectionCredentials
 } from '../../hooks/hooks.js';
 import { asyncWrapper } from '../../utils/asyncWrapper.js';
-import { errorRestrictConnectionId, isIntegrationAllowed } from '../../utils/auth.js';
+import { errorRestrictConnectionId, isIntegrationAllowed, resolveConnectionConfig } from '../../utils/auth.js';
 import { hmacCheck } from '../../utils/hmac.js';
 
 import type { LogContext } from '@nangohq/logs';
@@ -75,7 +74,7 @@ export const postPublicJwtAuthorization = asyncWrapper<PostPublicJwtAuthorizatio
     const bodyData = val.data as PostPublicJwtAuthorization['Body'];
     const queryString: PostPublicJwtAuthorization['Querystring'] = queryStringVal.data;
     const { providerConfigKey }: PostPublicJwtAuthorization['Params'] = paramVal.data;
-    const connectionConfig = queryString.params ? getConnectionConfig(queryString.params) : {};
+    const connectionConfig = resolveConnectionConfig({ params: queryString.params, connectSession, providerConfigKey });
     let connectionId = queryString.connection_id || connectionService.generateConnectionId();
     const hmac = 'hmac' in queryString ? queryString.hmac : undefined;
     const isConnectSession = res.locals['authType'] === 'connectSession';

--- a/packages/server/lib/controllers/auth/postJwt.ts
+++ b/packages/server/lib/controllers/auth/postJwt.ts
@@ -248,7 +248,7 @@ export const postPublicJwtAuthorization = asyncWrapper<PostPublicJwtAuthorizatio
 
         void connectionCreationFailedHook(
             {
-                connection: { connection_id: connectionId, provider_config_key: providerConfigKey },
+                connection: { connection_id: connectionId, provider_config_key: providerConfigKey, connection_config: connectionConfig },
                 environment,
                 account,
                 auth_mode: 'JWT',

--- a/packages/server/lib/controllers/auth/postOauthOutbound.ts
+++ b/packages/server/lib/controllers/auth/postOauthOutbound.ts
@@ -2,23 +2,14 @@ import * as z from 'zod';
 
 import db from '@nangohq/database';
 import { defaultOperationExpiration, endUserToMeta, logContextGetter } from '@nangohq/logs';
-import {
-    configService,
-    connectionService,
-    errorManager,
-    ErrorSourceEnum,
-    getConnectionConfig,
-    getProvider,
-    LogActionEnum,
-    syncEndUserToConnection
-} from '@nangohq/shared';
+import { configService, connectionService, errorManager, ErrorSourceEnum, getProvider, LogActionEnum, syncEndUserToConnection } from '@nangohq/shared';
 import { metrics, stringifyError, zodErrorToHTTP } from '@nangohq/utils';
 
 import { connectionConfigParamsSchema, connectionCredential, connectionIdSchema, providerConfigKeySchema } from '../../helpers/validation.js';
 import { handleValidateConnectionFailure, validateConnection } from '../../hooks/connection/on/validate-connection.js';
 import { connectionCreated as connectionCreatedHook, connectionCreationFailed as connectionCreationFailedHook } from '../../hooks/hooks.js';
 import { asyncWrapper } from '../../utils/asyncWrapper.js';
-import { errorRestrictConnectionId, isIntegrationAllowed } from '../../utils/auth.js';
+import { errorRestrictConnectionId, isIntegrationAllowed, resolveConnectionConfig } from '../../utils/auth.js';
 import { hmacCheck } from '../../utils/hmac.js';
 
 import type { LogContext } from '@nangohq/logs';
@@ -58,7 +49,7 @@ export const postPublicOauthOutboundAuthorization = asyncWrapper<PostPublicOauth
     const { account, environment, connectSession } = res.locals;
     const { providerConfigKey }: PostPublicOauthOutboundAuthorization['Params'] = paramsVal.data;
     const queryString: PostPublicOauthOutboundAuthorization['Querystring'] = queryStringVal.data;
-    const connectionConfig = queryString.params ? getConnectionConfig(queryString.params) : {};
+    const connectionConfig = resolveConnectionConfig({ params: queryString.params, connectSession, providerConfigKey });
     let connectionId = queryString.connection_id || connectionService.generateConnectionId();
     const hmac = 'hmac' in queryString ? queryString.hmac : undefined;
     const isConnectSession = res.locals['authType'] === 'connectSession';

--- a/packages/server/lib/controllers/auth/postOauthOutbound.ts
+++ b/packages/server/lib/controllers/auth/postOauthOutbound.ts
@@ -14,7 +14,7 @@ import {
 } from '@nangohq/shared';
 import { metrics, stringifyError, zodErrorToHTTP } from '@nangohq/utils';
 
-import { connectionCredential, connectionIdSchema, providerConfigKeySchema } from '../../helpers/validation.js';
+import { connectionConfigParamsSchema, connectionCredential, connectionIdSchema, providerConfigKeySchema } from '../../helpers/validation.js';
 import { handleValidateConnectionFailure, validateConnection } from '../../hooks/connection/on/validate-connection.js';
 import { connectionCreated as connectionCreatedHook, connectionCreationFailed as connectionCreationFailedHook } from '../../hooks/hooks.js';
 import { asyncWrapper } from '../../utils/asyncWrapper.js';
@@ -30,7 +30,7 @@ const queryStringValidation = z
     .object({
         connection_id: connectionIdSchema.optional(),
         hmac: z.string().optional(),
-        params: z.record(z.string(), z.any()).optional()
+        params: connectionConfigParamsSchema
     })
     .and(connectionCredential);
 

--- a/packages/server/lib/controllers/auth/postOauthOutbound.ts
+++ b/packages/server/lib/controllers/auth/postOauthOutbound.ts
@@ -220,7 +220,7 @@ export const postPublicOauthOutboundAuthorization = asyncWrapper<PostPublicOauth
         if (logCtx) {
             void connectionCreationFailedHook(
                 {
-                    connection: { connection_id: connectionId, provider_config_key: providerConfigKey },
+                    connection: { connection_id: connectionId, provider_config_key: providerConfigKey, connection_config: connectionConfig },
                     environment,
                     account,
                     auth_mode: 'OAUTH2',

--- a/packages/server/lib/controllers/auth/postSignature.ts
+++ b/packages/server/lib/controllers/auth/postSignature.ts
@@ -15,7 +15,7 @@ import {
 } from '@nangohq/shared';
 import { metrics, report, stringifyError, zodErrorToHTTP } from '@nangohq/utils';
 
-import { connectionCredential, connectionIdSchema, providerConfigKeySchema } from '../../helpers/validation.js';
+import { connectionConfigParamsSchema, connectionCredential, connectionIdSchema, providerConfigKeySchema } from '../../helpers/validation.js';
 import { handleValidateConnectionFailure, validateConnection } from '../../hooks/connection/on/validate-connection.js';
 import {
     connectionCreated as connectionCreatedHook,
@@ -42,7 +42,7 @@ const bodyValidation = z
 const queryStringValidation = z
     .object({
         connection_id: connectionIdSchema.optional(),
-        params: z.record(z.string(), z.any()).optional(),
+        params: connectionConfigParamsSchema,
         user_scope: z.string().optional()
     })
     .and(connectionCredential);

--- a/packages/server/lib/controllers/auth/postSignature.ts
+++ b/packages/server/lib/controllers/auth/postSignature.ts
@@ -254,7 +254,7 @@ export const postPublicSignatureAuthorization = asyncWrapper<PostPublicSignature
 
         void connectionCreationFailedHook(
             {
-                connection: { connection_id: connectionId, provider_config_key: providerConfigKey },
+                connection: { connection_id: connectionId, provider_config_key: providerConfigKey, connection_config: connectionConfig },
                 environment,
                 account,
                 auth_mode: 'SIGNATURE',

--- a/packages/server/lib/controllers/auth/postSignature.ts
+++ b/packages/server/lib/controllers/auth/postSignature.ts
@@ -7,7 +7,6 @@ import {
     connectionService,
     errorManager,
     ErrorSourceEnum,
-    getConnectionConfig,
     getProvider,
     LogActionEnum,
     signatureClient,
@@ -23,7 +22,7 @@ import {
     testConnectionCredentials
 } from '../../hooks/hooks.js';
 import { asyncWrapper } from '../../utils/asyncWrapper.js';
-import { errorRestrictConnectionId, isIntegrationAllowed } from '../../utils/auth.js';
+import { errorRestrictConnectionId, isIntegrationAllowed, resolveConnectionConfig } from '../../utils/auth.js';
 import { hmacCheck } from '../../utils/hmac.js';
 
 import type { LogContext } from '@nangohq/logs';
@@ -82,7 +81,7 @@ export const postPublicSignatureAuthorization = asyncWrapper<PostPublicSignature
     const { username, password }: PostPublicSignatureAuthorization['Body'] = val.data;
     const queryString: PostPublicSignatureAuthorization['Querystring'] = queryStringVal.data;
     const { providerConfigKey }: PostPublicSignatureAuthorization['Params'] = paramsVal.data;
-    const connectionConfig = queryString.params ? getConnectionConfig(queryString.params) : {};
+    const connectionConfig = resolveConnectionConfig({ params: queryString.params, connectSession, providerConfigKey });
     let connectionId = queryString.connection_id || connectionService.generateConnectionId();
     const hmac = 'hmac' in queryString ? queryString.hmac : undefined;
     const isConnectSession = res.locals['authType'] === 'connectSession';

--- a/packages/server/lib/controllers/auth/postTba.ts
+++ b/packages/server/lib/controllers/auth/postTba.ts
@@ -2,16 +2,7 @@ import * as z from 'zod';
 
 import db from '@nangohq/database';
 import { defaultOperationExpiration, endUserToMeta, logContextGetter } from '@nangohq/logs';
-import {
-    configService,
-    connectionService,
-    errorManager,
-    ErrorSourceEnum,
-    getConnectionConfig,
-    getProvider,
-    LogActionEnum,
-    syncEndUserToConnection
-} from '@nangohq/shared';
+import { configService, connectionService, errorManager, ErrorSourceEnum, getProvider, LogActionEnum, syncEndUserToConnection } from '@nangohq/shared';
 import { metrics, stringifyError, zodErrorToHTTP } from '@nangohq/utils';
 
 import { connectionConfigParamsSchema, connectionCredential, connectionIdSchema, providerConfigKeySchema } from '../../helpers/validation.js';
@@ -22,7 +13,7 @@ import {
     testConnectionCredentials
 } from '../../hooks/hooks.js';
 import { asyncWrapper } from '../../utils/asyncWrapper.js';
-import { errorRestrictConnectionId, isIntegrationAllowed } from '../../utils/auth.js';
+import { errorRestrictConnectionId, isIntegrationAllowed, resolveConnectionConfig } from '../../utils/auth.js';
 import { hmacCheck } from '../../utils/hmac.js';
 
 import type { LogContext } from '@nangohq/logs';
@@ -82,7 +73,7 @@ export const postPublicTbaAuthorization = asyncWrapper<PostPublicTbaAuthorizatio
     const { token_id: tokenId, token_secret: tokenSecret, oauth_client_id_override, oauth_client_secret_override } = body;
     const queryString = queryStringVal.data satisfies PostPublicTbaAuthorization['Querystring'];
     const { providerConfigKey } = paramVal.data satisfies PostPublicTbaAuthorization['Params'];
-    const connectionConfig = queryString.params ? getConnectionConfig(queryString.params) : {};
+    const connectionConfig = resolveConnectionConfig({ params: queryString.params, connectSession, providerConfigKey });
     let connectionId = queryString.connection_id || connectionService.generateConnectionId();
     const hmac = 'hmac' in queryString ? queryString.hmac : undefined;
     const isConnectSession = res.locals['authType'] === 'connectSession';

--- a/packages/server/lib/controllers/auth/postTba.ts
+++ b/packages/server/lib/controllers/auth/postTba.ts
@@ -270,7 +270,7 @@ export const postPublicTbaAuthorization = asyncWrapper<PostPublicTbaAuthorizatio
 
         void connectionCreationFailedHook(
             {
-                connection: { connection_id: connectionId, provider_config_key: providerConfigKey },
+                connection: { connection_id: connectionId, provider_config_key: providerConfigKey, connection_config: connectionConfig },
                 environment,
                 account,
                 auth_mode: 'TBA',

--- a/packages/server/lib/controllers/auth/postTba.ts
+++ b/packages/server/lib/controllers/auth/postTba.ts
@@ -14,7 +14,7 @@ import {
 } from '@nangohq/shared';
 import { metrics, stringifyError, zodErrorToHTTP } from '@nangohq/utils';
 
-import { connectionCredential, connectionIdSchema, providerConfigKeySchema } from '../../helpers/validation.js';
+import { connectionConfigParamsSchema, connectionCredential, connectionIdSchema, providerConfigKeySchema } from '../../helpers/validation.js';
 import { handleValidateConnectionFailure, validateConnection } from '../../hooks/connection/on/validate-connection.js';
 import {
     connectionCreated as connectionCreatedHook,
@@ -32,7 +32,7 @@ import type { PostPublicTbaAuthorization, TbaCredentials } from '@nangohq/types'
 const queryStringValidation = z
     .object({
         connection_id: connectionIdSchema.optional(),
-        params: z.record(z.string(), z.any()).optional(),
+        params: connectionConfigParamsSchema,
         user_scope: z.string().optional()
     })
     .and(connectionCredential);

--- a/packages/server/lib/controllers/auth/postTwoStep.ts
+++ b/packages/server/lib/controllers/auth/postTwoStep.ts
@@ -248,7 +248,7 @@ export const postPublicTwoStepAuthorization = asyncWrapper<PostPublicTwoStepAuth
 
         void connectionCreationFailedHook(
             {
-                connection: { connection_id: connectionId, provider_config_key: providerConfigKey },
+                connection: { connection_id: connectionId, provider_config_key: providerConfigKey, connection_config: connectionConfig },
                 environment,
                 account,
                 auth_mode: 'TWO_STEP',

--- a/packages/server/lib/controllers/auth/postTwoStep.ts
+++ b/packages/server/lib/controllers/auth/postTwoStep.ts
@@ -7,7 +7,6 @@ import {
     connectionService,
     errorManager,
     ErrorSourceEnum,
-    getConnectionConfig,
     getConnectionMetadata,
     getProvider,
     LogActionEnum,
@@ -19,7 +18,7 @@ import { connectionConfigParamsSchema, connectionCredential, connectionIdSchema,
 import { handleValidateConnectionFailure, validateConnection } from '../../hooks/connection/on/validate-connection.js';
 import { connectionCreated as connectionCreatedHook, connectionCreationFailed as connectionCreationFailedHook } from '../../hooks/hooks.js';
 import { asyncWrapper } from '../../utils/asyncWrapper.js';
-import { errorRestrictConnectionId, isIntegrationAllowed } from '../../utils/auth.js';
+import { errorRestrictConnectionId, isIntegrationAllowed, resolveConnectionConfig } from '../../utils/auth.js';
 import { hmacCheck } from '../../utils/hmac.js';
 
 import type { LogContext } from '@nangohq/logs';
@@ -72,7 +71,7 @@ export const postPublicTwoStepAuthorization = asyncWrapper<PostPublicTwoStepAuth
     const bodyData: PostPublicTwoStepAuthorization['Body'] = val.data;
     const queryString: PostPublicTwoStepAuthorization['Querystring'] = queryStringVal.data;
     const { providerConfigKey }: PostPublicTwoStepAuthorization['Params'] = paramsVal.data;
-    let connectionConfig = queryString.params ? getConnectionConfig(queryString.params) : {};
+    let connectionConfig = resolveConnectionConfig({ params: queryString.params, connectSession, providerConfigKey });
     let connectionId = queryString.connection_id || connectionService.generateConnectionId();
     const hmac = 'hmac' in queryString ? queryString.hmac : undefined;
     const isConnectSession = res.locals['authType'] === 'connectSession';

--- a/packages/server/lib/controllers/auth/postTwoStep.ts
+++ b/packages/server/lib/controllers/auth/postTwoStep.ts
@@ -15,7 +15,7 @@ import {
 } from '@nangohq/shared';
 import { metrics, stringifyError, zodErrorToHTTP } from '@nangohq/utils';
 
-import { connectionCredential, connectionIdSchema, providerConfigKeySchema } from '../../helpers/validation.js';
+import { connectionConfigParamsSchema, connectionCredential, connectionIdSchema, providerConfigKeySchema } from '../../helpers/validation.js';
 import { handleValidateConnectionFailure, validateConnection } from '../../hooks/connection/on/validate-connection.js';
 import { connectionCreated as connectionCreatedHook, connectionCreationFailed as connectionCreationFailedHook } from '../../hooks/hooks.js';
 import { asyncWrapper } from '../../utils/asyncWrapper.js';
@@ -32,7 +32,7 @@ const bodyValidation = z.looseObject({});
 const queryStringValidation = z
     .object({
         connection_id: connectionIdSchema.optional(),
-        params: z.record(z.string(), z.any()).optional(),
+        params: connectionConfigParamsSchema,
         user_scope: z.string().optional()
     })
     .and(connectionCredential);

--- a/packages/server/lib/controllers/auth/postUnauthenticated.integration.test.ts
+++ b/packages/server/lib/controllers/auth/postUnauthenticated.integration.test.ts
@@ -41,6 +41,58 @@ describe(`GET ${endpoint}`, () => {
         });
     });
 
+    it('should reject a webhook_url override pointing to nango.dev', async () => {
+        const { env, apiKey } = await seeders.seedAccountEnvAndUser();
+        const config = await seeders.createConfigSeed(env, 'unauthenticated', 'unauthenticated');
+
+        const resSession = await api.fetch('/connect/sessions', {
+            method: 'POST',
+            token: apiKey.secret,
+            body: { end_user: { id: '1', email: 'john@example.com' }, allowed_integrations: ['unauthenticated'] }
+        });
+        isSuccess(resSession.json);
+
+        const res = await api.fetch(endpoint, {
+            method: 'POST',
+            query: { connect_session_token: resSession.json.data.token, params: { webhook_url: 'https://api.nango.dev/hook' } },
+            params: { providerConfigKey: config.unique_key }
+        });
+
+        isError(res.json);
+        expect(res.json).toStrictEqual<typeof res.json>({
+            error: {
+                code: 'invalid_query_params',
+                errors: [{ code: 'custom', message: `Webhook URLs cannot point to Nango's domain (nango.dev).`, path: ['params', 'webhook_url'] }]
+            }
+        });
+    });
+
+    it('should store a valid webhook_url override in connection_config', async () => {
+        const { env, apiKey } = await seeders.seedAccountEnvAndUser();
+        const config = await seeders.createConfigSeed(env, 'unauthenticated', 'unauthenticated');
+
+        const resSession = await api.fetch('/connect/sessions', {
+            method: 'POST',
+            token: apiKey.secret,
+            body: { end_user: { id: '1', email: 'john@example.com' }, allowed_integrations: ['unauthenticated'] }
+        });
+        isSuccess(resSession.json);
+
+        const res = await api.fetch(endpoint, {
+            method: 'POST',
+            query: { connect_session_token: resSession.json.data.token, params: { webhook_url: 'https://example.com/webhooks-from-nango' } },
+            params: { providerConfigKey: config.unique_key }
+        });
+        isSuccess(res.json);
+
+        const connection = await connectionService.checkIfConnectionExists(db.knex, {
+            connectionId: res.json.connectionId,
+            providerConfigKey: res.json.providerConfigKey,
+            environmentId: env.id
+        });
+        expect(connection?.connection_config).toStrictEqual({ webhook_url: 'https://example.com/webhooks-from-nango' });
+    });
+
     it('should not be allowed to connect to an integration if disallowed by sessionToken', async () => {
         const { env, apiKey } = await seeders.seedAccountEnvAndUser();
         const config = await seeders.createConfigSeed(env, 'unauthenticated', 'unauthenticated');

--- a/packages/server/lib/controllers/auth/postUnauthenticated.integration.test.ts
+++ b/packages/server/lib/controllers/auth/postUnauthenticated.integration.test.ts
@@ -41,7 +41,9 @@ describe(`GET ${endpoint}`, () => {
         });
     });
 
-    it('should reject a webhook_url override pointing to nango.dev', async () => {
+    // webhook_url is privileged: an untrusted client must not be able to redirect a connection's webhooks
+    // by passing it as a param. It is silently dropped and never persisted from this path.
+    it('ignores a client-supplied webhook_url param and does not store it', async () => {
         const { env, apiKey } = await seeders.seedAccountEnvAndUser();
         const config = await seeders.createConfigSeed(env, 'unauthenticated', 'unauthenticated');
 
@@ -54,33 +56,7 @@ describe(`GET ${endpoint}`, () => {
 
         const res = await api.fetch(endpoint, {
             method: 'POST',
-            query: { connect_session_token: resSession.json.data.token, params: { webhook_url: 'https://api.nango.dev/hook' } },
-            params: { providerConfigKey: config.unique_key }
-        });
-
-        isError(res.json);
-        expect(res.json).toStrictEqual<typeof res.json>({
-            error: {
-                code: 'invalid_query_params',
-                errors: [{ code: 'custom', message: `Webhook URLs cannot point to Nango's domain (nango.dev).`, path: ['params', 'webhook_url'] }]
-            }
-        });
-    });
-
-    it('should store a valid webhook_url override in connection_config', async () => {
-        const { env, apiKey } = await seeders.seedAccountEnvAndUser();
-        const config = await seeders.createConfigSeed(env, 'unauthenticated', 'unauthenticated');
-
-        const resSession = await api.fetch('/connect/sessions', {
-            method: 'POST',
-            token: apiKey.secret,
-            body: { end_user: { id: '1', email: 'john@example.com' }, allowed_integrations: ['unauthenticated'] }
-        });
-        isSuccess(resSession.json);
-
-        const res = await api.fetch(endpoint, {
-            method: 'POST',
-            query: { connect_session_token: resSession.json.data.token, params: { webhook_url: 'https://example.com/webhooks-from-nango' } },
+            query: { connect_session_token: resSession.json.data.token, params: { webhook_url: 'https://attacker.example.com/hook' } },
             params: { providerConfigKey: config.unique_key }
         });
         isSuccess(res.json);
@@ -90,7 +66,36 @@ describe(`GET ${endpoint}`, () => {
             providerConfigKey: res.json.providerConfigKey,
             environmentId: env.id
         });
-        expect(connection?.connection_config).toStrictEqual({ webhook_url: 'https://example.com/webhooks-from-nango' });
+        expect(connection?.connection_config).toStrictEqual({});
+    });
+
+    it('rejects a nango.dev webhook_url set as a connect session default', async () => {
+        const { env, apiKey } = await seeders.seedAccountEnvAndUser();
+        await seeders.createConfigSeed(env, 'unauthenticated', 'unauthenticated');
+
+        const resSession = await api.fetch('/connect/sessions', {
+            method: 'POST',
+            token: apiKey.secret,
+            body: {
+                end_user: { id: '1', email: 'john@example.com' },
+                allowed_integrations: ['unauthenticated'],
+                integrations_config_defaults: { unauthenticated: { connection_config: { webhook_url: 'https://api.nango.dev/hook' } } }
+            }
+        });
+
+        isError(resSession.json);
+        expect(resSession.json).toStrictEqual<typeof resSession.json>({
+            error: {
+                code: 'invalid_body',
+                errors: [
+                    {
+                        code: 'custom',
+                        message: `Webhook URLs cannot point to Nango's domain (nango.dev).`,
+                        path: ['integrations_config_defaults', 'unauthenticated', 'connection_config', 'webhook_url']
+                    }
+                ]
+            }
+        });
     });
 
     it('should apply a webhook_url override set as a connect session default (without passing it as a param)', async () => {

--- a/packages/server/lib/controllers/auth/postUnauthenticated.integration.test.ts
+++ b/packages/server/lib/controllers/auth/postUnauthenticated.integration.test.ts
@@ -93,6 +93,36 @@ describe(`GET ${endpoint}`, () => {
         expect(connection?.connection_config).toStrictEqual({ webhook_url: 'https://example.com/webhooks-from-nango' });
     });
 
+    it('should apply a webhook_url override set as a connect session default (without passing it as a param)', async () => {
+        const { env, apiKey } = await seeders.seedAccountEnvAndUser();
+        const config = await seeders.createConfigSeed(env, 'unauthenticated', 'unauthenticated');
+
+        const resSession = await api.fetch('/connect/sessions', {
+            method: 'POST',
+            token: apiKey.secret,
+            body: {
+                end_user: { id: '1', email: 'john@example.com' },
+                allowed_integrations: ['unauthenticated'],
+                integrations_config_defaults: { unauthenticated: { connection_config: { webhook_url: 'https://example.com/webhooks-from-nango' } } }
+            }
+        });
+        isSuccess(resSession.json);
+
+        const res = await api.fetch(endpoint, {
+            method: 'POST',
+            query: { connect_session_token: resSession.json.data.token },
+            params: { providerConfigKey: config.unique_key }
+        });
+        isSuccess(res.json);
+
+        const connection = await connectionService.checkIfConnectionExists(db.knex, {
+            connectionId: res.json.connectionId,
+            providerConfigKey: res.json.providerConfigKey,
+            environmentId: env.id
+        });
+        expect(connection?.connection_config).toStrictEqual({ webhook_url: 'https://example.com/webhooks-from-nango' });
+    });
+
     it('should not be allowed to connect to an integration if disallowed by sessionToken', async () => {
         const { env, apiKey } = await seeders.seedAccountEnvAndUser();
         const config = await seeders.createConfigSeed(env, 'unauthenticated', 'unauthenticated');

--- a/packages/server/lib/controllers/auth/postUnauthenticated.ts
+++ b/packages/server/lib/controllers/auth/postUnauthenticated.ts
@@ -2,14 +2,14 @@ import * as z from 'zod';
 
 import db from '@nangohq/database';
 import { defaultOperationExpiration, endUserToMeta, logContextGetter } from '@nangohq/logs';
-import { configService, connectionService, errorManager, getConnectionConfig, getProvider, syncEndUserToConnection } from '@nangohq/shared';
+import { configService, connectionService, errorManager, getProvider, syncEndUserToConnection } from '@nangohq/shared';
 import { metrics, requireEmptyBody, stringifyError, zodErrorToHTTP } from '@nangohq/utils';
 
 import { connectionConfigParamsSchema, connectionCredential, connectionIdSchema, providerConfigKeySchema } from '../../helpers/validation.js';
 import { handleValidateConnectionFailure, validateConnection } from '../../hooks/connection/on/validate-connection.js';
 import { connectionCreated, connectionCreationFailed } from '../../hooks/hooks.js';
 import { asyncWrapper } from '../../utils/asyncWrapper.js';
-import { errorRestrictConnectionId, isIntegrationAllowed } from '../../utils/auth.js';
+import { errorRestrictConnectionId, isIntegrationAllowed, resolveConnectionConfig } from '../../utils/auth.js';
 import { hmacCheck } from '../../utils/hmac.js';
 
 import type { LogContext } from '@nangohq/logs';
@@ -51,7 +51,7 @@ export const postPublicUnauthenticated = asyncWrapper<PostPublicUnauthenticatedA
     const { account, environment, connectSession } = res.locals;
     const queryString: PostPublicUnauthenticatedAuthorization['Querystring'] = queryStringVal.data;
     const { providerConfigKey }: PostPublicUnauthenticatedAuthorization['Params'] = paramVal.data;
-    const connectionConfig = queryString.params ? getConnectionConfig(queryString.params) : {};
+    const connectionConfig = resolveConnectionConfig({ params: queryString.params, connectSession, providerConfigKey });
     let connectionId = queryString.connection_id || connectionService.generateConnectionId();
     const hmac = 'hmac' in queryString ? queryString.hmac : undefined;
     const isConnectSession = res.locals['authType'] === 'connectSession';

--- a/packages/server/lib/controllers/auth/postUnauthenticated.ts
+++ b/packages/server/lib/controllers/auth/postUnauthenticated.ts
@@ -5,7 +5,7 @@ import { defaultOperationExpiration, endUserToMeta, logContextGetter } from '@na
 import { configService, connectionService, errorManager, getConnectionConfig, getProvider, syncEndUserToConnection } from '@nangohq/shared';
 import { metrics, requireEmptyBody, stringifyError, zodErrorToHTTP } from '@nangohq/utils';
 
-import { connectionCredential, connectionIdSchema, providerConfigKeySchema } from '../../helpers/validation.js';
+import { connectionConfigParamsSchema, connectionCredential, connectionIdSchema, providerConfigKeySchema } from '../../helpers/validation.js';
 import { handleValidateConnectionFailure, validateConnection } from '../../hooks/connection/on/validate-connection.js';
 import { connectionCreated, connectionCreationFailed } from '../../hooks/hooks.js';
 import { asyncWrapper } from '../../utils/asyncWrapper.js';
@@ -19,7 +19,7 @@ import type { PostPublicUnauthenticatedAuthorization } from '@nangohq/types';
 const queryStringValidation = z
     .object({
         connection_id: connectionIdSchema.optional(),
-        params: z.record(z.string(), z.any()).optional()
+        params: connectionConfigParamsSchema
     })
     .and(connectionCredential);
 

--- a/packages/server/lib/controllers/auth/postUnauthenticated.ts
+++ b/packages/server/lib/controllers/auth/postUnauthenticated.ts
@@ -203,7 +203,7 @@ export const postPublicUnauthenticated = asyncWrapper<PostPublicUnauthenticatedA
 
         void connectionCreationFailed(
             {
-                connection: { connection_id: connectionId, provider_config_key: providerConfigKey },
+                connection: { connection_id: connectionId, provider_config_key: providerConfigKey, connection_config: connectionConfig },
                 environment,
                 account,
                 auth_mode: 'NONE',

--- a/packages/server/lib/controllers/connect/postSessions.ts
+++ b/packages/server/lib/controllers/connect/postSessions.ts
@@ -36,8 +36,7 @@ export const bodySchema = z
                         connection_config: z
                             .looseObject({
                                 oauth_scopes_override: z.string().optional(),
-                                webhook_url: webhookUrlSchema,
-                                webhook_url_secondary: webhookUrlSchema
+                                webhook_url: webhookUrlSchema
                             })
                             .optional()
                     })

--- a/packages/server/lib/controllers/connect/postSessions.ts
+++ b/packages/server/lib/controllers/connect/postSessions.ts
@@ -6,7 +6,7 @@ import { defaultOperationExpiration, endUserToMeta, logContextGetter } from '@na
 import { buildTagsFromEndUser, configService, EndUserMapper } from '@nangohq/shared';
 import { connectUrl, requireEmptyQuery, zodErrorToHTTP } from '@nangohq/utils';
 
-import { connectionTagsSchema, endUserSchema, providerConfigKeySchema } from '../../helpers/validation.js';
+import { connectionTagsSchema, endUserSchema, providerConfigKeySchema, webhookUrlSchema } from '../../helpers/validation.js';
 import * as connectSessionService from '../../services/connectSession.service.js';
 import { asyncWrapper } from '../../utils/asyncWrapper.js';
 
@@ -35,7 +35,9 @@ export const bodySchema = z
                         authorization_params: z.record(z.string(), z.string()).optional(),
                         connection_config: z
                             .looseObject({
-                                oauth_scopes_override: z.string().optional()
+                                oauth_scopes_override: z.string().optional(),
+                                webhook_url: webhookUrlSchema,
+                                webhook_url_secondary: webhookUrlSchema
                             })
                             .optional()
                     })

--- a/packages/server/lib/controllers/connection.controller.ts
+++ b/packages/server/lib/controllers/connection.controller.ts
@@ -10,8 +10,9 @@ import {
     githubAppClient,
     NangoError
 } from '@nangohq/shared';
-import { flags } from '@nangohq/utils';
+import { flags, zodErrorToHTTP } from '@nangohq/utils';
 
+import { webhookUrlSchema } from '../helpers/validation.js';
 import { preConnectionDeletion } from '../hooks/connection/on/pre-connection-deletion.js';
 import {
     connectionCreated as connectionCreatedHook,
@@ -178,6 +179,12 @@ class ConnectionController {
 
             if (!provider_config_key) {
                 errorManager.errRes(res, 'missing_provider_config');
+                return;
+            }
+
+            const webhookUrlValidation = webhookUrlSchema.safeParse(connection_config?.webhook_url);
+            if (!webhookUrlValidation.success) {
+                res.status(400).send({ error: { code: 'invalid_body', errors: zodErrorToHTTP(webhookUrlValidation.error) } });
                 return;
             }
 

--- a/packages/server/lib/controllers/connection/postConnection.integration.test.ts
+++ b/packages/server/lib/controllers/connection/postConnection.integration.test.ts
@@ -230,6 +230,51 @@ describe(`POST ${endpoint}`, () => {
         });
     });
 
+    it('should reject a webhook_url override pointing to nango.dev', async () => {
+        const { env, apiKey } = await seeders.seedAccountEnvAndUser();
+        await seeders.createConfigSeed(env, 'github', 'github');
+        const res = await api.fetch(endpoint, {
+            method: 'POST',
+            token: apiKey.secret,
+            body: {
+                provider_config_key: 'github',
+                credentials: { type: 'OAUTH2', access_token: '123' },
+                connection_config: { webhook_url: 'https://api.nango.dev/hook' }
+            }
+        });
+
+        isError(res.json);
+        expect(res.json).toStrictEqual<typeof res.json>({
+            error: {
+                code: 'invalid_body',
+                errors: [
+                    {
+                        code: 'custom',
+                        message: `Webhook URLs cannot point to Nango's domain (nango.dev).`,
+                        path: ['connection_config', 'webhook_url']
+                    }
+                ]
+            }
+        });
+    });
+
+    it('should store a valid webhook_url override in connection_config', async () => {
+        const { env, apiKey } = await seeders.seedAccountEnvAndUser();
+        await seeders.createConfigSeed(env, 'github', 'github');
+        const res = await api.fetch(endpoint, {
+            method: 'POST',
+            token: apiKey.secret,
+            body: {
+                provider_config_key: 'github',
+                credentials: { type: 'OAUTH2', access_token: '123' },
+                connection_config: { webhook_url: 'https://example.com/webhooks-from-nango' }
+            }
+        });
+
+        isSuccess(res.json);
+        expect(res.json.connection_config).toStrictEqual({ webhook_url: 'https://example.com/webhooks-from-nango' });
+    });
+
     it('should import oauth2 connection with config_override', async () => {
         const { env, apiKey } = await seeders.seedAccountEnvAndUser();
         await seeders.createConfigSeed(env, 'github', 'github');

--- a/packages/server/lib/controllers/connection/postConnection.ts
+++ b/packages/server/lib/controllers/connection/postConnection.ts
@@ -25,7 +25,8 @@ import {
     connectionCredentialsOauth2Schema,
     connectionCredentialsTBASchema,
     connectionTagsSchema,
-    endUserSchema
+    endUserSchema,
+    webhookUrlSchema
 } from '../../helpers/validation.js';
 import { handleValidateConnectionFailure, validateConnection } from '../../hooks/connection/on/validate-connection.js';
 import { connectionCreated, connectionCreationStartCapCheck, connectionRefreshSuccess, testConnectionCredentials } from '../../hooks/hooks.js';
@@ -38,7 +39,9 @@ const schemaBody = z.strictObject({
     metadata: z.record(z.string(), z.unknown()).optional(),
     connection_config: z
         .looseObject({
-            oauth_scopes_override: z.string().array().optional()
+            oauth_scopes_override: z.string().array().optional(),
+            webhook_url: webhookUrlSchema,
+            webhook_url_secondary: webhookUrlSchema
         })
         .optional(),
     connection_id: z.string().optional(),

--- a/packages/server/lib/controllers/connection/postConnection.ts
+++ b/packages/server/lib/controllers/connection/postConnection.ts
@@ -26,7 +26,7 @@ import {
     connectionCredentialsTBASchema,
     connectionTagsSchema,
     endUserSchema,
-    webhookUrlConnectionConfigShape
+    webhookUrlSchema
 } from '../../helpers/validation.js';
 import { handleValidateConnectionFailure, validateConnection } from '../../hooks/connection/on/validate-connection.js';
 import { connectionCreated, connectionCreationStartCapCheck, connectionRefreshSuccess, testConnectionCredentials } from '../../hooks/hooks.js';
@@ -40,7 +40,7 @@ const schemaBody = z.strictObject({
     connection_config: z
         .looseObject({
             oauth_scopes_override: z.string().array().optional(),
-            ...webhookUrlConnectionConfigShape
+            webhook_url: webhookUrlSchema
         })
         .optional(),
     connection_id: z.string().optional(),

--- a/packages/server/lib/controllers/connection/postConnection.ts
+++ b/packages/server/lib/controllers/connection/postConnection.ts
@@ -26,7 +26,7 @@ import {
     connectionCredentialsTBASchema,
     connectionTagsSchema,
     endUserSchema,
-    webhookUrlSchema
+    webhookUrlConnectionConfigShape
 } from '../../helpers/validation.js';
 import { handleValidateConnectionFailure, validateConnection } from '../../hooks/connection/on/validate-connection.js';
 import { connectionCreated, connectionCreationStartCapCheck, connectionRefreshSuccess, testConnectionCredentials } from '../../hooks/hooks.js';
@@ -40,8 +40,7 @@ const schemaBody = z.strictObject({
     connection_config: z
         .looseObject({
             oauth_scopes_override: z.string().array().optional(),
-            webhook_url: webhookUrlSchema,
-            webhook_url_secondary: webhookUrlSchema
+            ...webhookUrlConnectionConfigShape
         })
         .optional(),
     connection_id: z.string().optional(),

--- a/packages/server/lib/controllers/oauth.controller.ts
+++ b/packages/server/lib/controllers/oauth.controller.ts
@@ -592,7 +592,7 @@ class OAuthController {
 
             void connectionCreationFailedHook(
                 {
-                    connection: { connection_id: receivedConnectionId!, provider_config_key: providerConfigKey! },
+                    connection: { connection_id: receivedConnectionId!, provider_config_key: providerConfigKey!, connection_config: connectionConfig },
                     environment,
                     account,
                     auth_mode: 'OAUTH2_CC',
@@ -1522,7 +1522,7 @@ class OAuthController {
 
             void connectionCreationFailedHook(
                 {
-                    connection: { connection_id: connectionId, provider_config_key: providerConfigKey },
+                    connection: { connection_id: connectionId, provider_config_key: providerConfigKey, connection_config: session.connectionConfig },
                     environment,
                     account,
                     auth_mode: provider.auth_mode,
@@ -1606,7 +1606,7 @@ class OAuthController {
 
             void connectionCreationFailedHook(
                 {
-                    connection: { connection_id: connectionId, provider_config_key: providerConfigKey },
+                    connection: { connection_id: connectionId, provider_config_key: providerConfigKey, connection_config: session.connectionConfig },
                     environment,
                     account,
                     auth_mode: provider.auth_mode,
@@ -1733,7 +1733,7 @@ class OAuthController {
 
                 void connectionCreationFailedHook(
                     {
-                        connection: { connection_id: connectionId, provider_config_key: providerConfigKey },
+                        connection: { connection_id: connectionId, provider_config_key: providerConfigKey, connection_config: session.connectionConfig },
                         environment,
                         account,
                         auth_mode: provider.auth_mode,
@@ -2023,7 +2023,7 @@ class OAuthController {
 
             void connectionCreationFailedHook(
                 {
-                    connection: { connection_id: connectionId, provider_config_key: providerConfigKey },
+                    connection: { connection_id: connectionId, provider_config_key: providerConfigKey, connection_config: session.connectionConfig },
                     environment,
                     account,
                     auth_mode: provider.auth_mode,
@@ -2202,7 +2202,7 @@ class OAuthController {
 
             void connectionCreationFailedHook(
                 {
-                    connection: { connection_id: connectionId, provider_config_key: providerConfigKey },
+                    connection: { connection_id: connectionId, provider_config_key: providerConfigKey, connection_config: session.connectionConfig },
                     environment,
                     account,
                     auth_mode: provider.auth_mode,
@@ -2363,7 +2363,7 @@ class OAuthController {
 
                 void connectionCreationFailedHook(
                     {
-                        connection: { connection_id: connectionId, provider_config_key: providerConfigKey },
+                        connection: { connection_id: connectionId, provider_config_key: providerConfigKey, connection_config: session.connectionConfig },
                         environment,
                         account,
                         auth_mode: provider.auth_mode,
@@ -2532,7 +2532,7 @@ class OAuthController {
 
             void connectionCreationFailedHook(
                 {
-                    connection: { connection_id: connectionId, provider_config_key: providerConfigKey },
+                    connection: { connection_id: connectionId, provider_config_key: providerConfigKey, connection_config: session.connectionConfig },
                     environment,
                     account,
                     auth_mode: provider.auth_mode,

--- a/packages/server/lib/controllers/v1/environment/webhook/patchWebhook.ts
+++ b/packages/server/lib/controllers/v1/environment/webhook/patchWebhook.ts
@@ -1,39 +1,18 @@
-import { URL } from 'url';
-
 import * as z from 'zod';
 
 import db from '@nangohq/database';
-import { externalWebhookService, getServerOutboundUrlPolicy, isOutboundUrlAllowed } from '@nangohq/shared';
+import { externalWebhookService } from '@nangohq/shared';
 import { requireEmptyQuery, zodErrorToHTTP } from '@nangohq/utils';
 
+import { webhookUrlSchema } from '../../../../helpers/validation.js';
 import { asyncWrapper } from '../../../../utils/asyncWrapper.js';
 
 import type { DBExternalWebhook, PatchWebhook } from '@nangohq/types';
 
-const urlValidation = z
-    .union([z.url(), z.literal('')])
-    .optional()
-    .refine(
-        (url) => {
-            if (!url || url.trim() === '') return true;
-            const inputUrl = new URL(url);
-            return !inputUrl.host.endsWith('nango.dev');
-        },
-        { message: `Webhook URLs cannot point to Nango's domain (nango.dev).` }
-    )
-    .refine(
-        (url) => {
-            if (!url || url.trim() === '') return true;
-            // Reject denylisted hosts and blocked IP literals (loopback, private, link-local, metadata) at registration.
-            return isOutboundUrlAllowed(url, getServerOutboundUrlPolicy());
-        },
-        { message: 'This webhook URL is not allowed.' }
-    );
-
 const validation = z
     .object({
-        primary_url: urlValidation,
-        secondary_url: urlValidation,
+        primary_url: webhookUrlSchema,
+        secondary_url: webhookUrlSchema,
         on_sync_completion_always: z.boolean().optional(),
         on_auth_creation: z.boolean().optional(),
         on_auth_refresh_error: z.boolean().optional(),

--- a/packages/server/lib/helpers/validation.ts
+++ b/packages/server/lib/helpers/validation.ts
@@ -2,7 +2,14 @@ import { URL } from 'url';
 
 import * as z from 'zod';
 
-import { connectionTagsKeySchema, connectionTagsSchema, getServerOutboundUrlPolicy, isOutboundUrlAllowed, TAG_MAX_COUNT, validateCaseInsensitiveTagKeys } from '@nangohq/shared';
+import {
+    connectionTagsKeySchema,
+    connectionTagsSchema,
+    getServerOutboundUrlPolicy,
+    isOutboundUrlAllowed,
+    TAG_MAX_COUNT,
+    validateCaseInsensitiveTagKeys
+} from '@nangohq/shared';
 
 export { TAG_MAX_COUNT, connectionTagsKeySchema, connectionTagsSchema };
 
@@ -29,7 +36,10 @@ export const webhookUrlSchema = z
         { message: 'This webhook URL is not allowed.' }
     );
 
-export const connectionConfigParamsSchema = z.looseObject({ webhook_url: webhookUrlSchema }).optional();
+// Connection params come from untrusted clients. `webhook_url` is intentionally NOT accepted here: it is a
+// privileged routing directive set only by the backend via the connect session (see postSessions). Any
+// client-supplied `webhook_url` is stripped in getConnectionConfig.
+export const connectionConfigParamsSchema = z.looseObject({}).optional();
 
 export const providerSchema = z
     .string()

--- a/packages/server/lib/helpers/validation.ts
+++ b/packages/server/lib/helpers/validation.ts
@@ -1,8 +1,32 @@
+import { URL } from 'url';
+
 import * as z from 'zod';
 
-import { connectionTagsKeySchema, connectionTagsSchema, TAG_MAX_COUNT, validateCaseInsensitiveTagKeys } from '@nangohq/shared';
+import { connectionTagsKeySchema, connectionTagsSchema, getServerOutboundUrlPolicy, isOutboundUrlAllowed, TAG_MAX_COUNT, validateCaseInsensitiveTagKeys } from '@nangohq/shared';
 
 export { TAG_MAX_COUNT, connectionTagsKeySchema, connectionTagsSchema };
+
+/**
+ * Validates a webhook URL: must be a valid URL (or empty), cannot point to Nango's own domain,
+ * and cannot resolve to a blocked host (loopback, private, link-local, metadata, ...).
+ */
+export const webhookUrlSchema = z
+    .union([z.url(), z.literal('')])
+    .optional()
+    .refine(
+        (url) => {
+            if (!url || url.trim() === '') return true;
+            return !new URL(url).host.endsWith('nango.dev');
+        },
+        { message: `Webhook URLs cannot point to Nango's domain (nango.dev).` }
+    )
+    .refine(
+        (url) => {
+            if (!url || url.trim() === '') return true;
+            return isOutboundUrlAllowed(url, getServerOutboundUrlPolicy());
+        },
+        { message: 'This webhook URL is not allowed.' }
+    );
 
 export const providerSchema = z
     .string()

--- a/packages/server/lib/helpers/validation.ts
+++ b/packages/server/lib/helpers/validation.ts
@@ -28,6 +28,13 @@ export const webhookUrlSchema = z
         { message: 'This webhook URL is not allowed.' }
     );
 
+export const connectionConfigParamsSchema = z
+    .looseObject({
+        webhook_url: webhookUrlSchema,
+        webhook_url_secondary: webhookUrlSchema
+    })
+    .optional();
+
 export const providerSchema = z
     .string()
     .regex(/^[a-zA-Z0-9_-]+$/)

--- a/packages/server/lib/helpers/validation.ts
+++ b/packages/server/lib/helpers/validation.ts
@@ -16,7 +16,8 @@ export const webhookUrlSchema = z
     .refine(
         (url) => {
             if (!url || url.trim() === '') return true;
-            return !new URL(url).host.endsWith('nango.dev');
+            const hostname = new URL(url).hostname.replace(/\.+$/, '');
+            return hostname !== 'nango.dev' && !hostname.endsWith('.nango.dev');
         },
         { message: `Webhook URLs cannot point to Nango's domain (nango.dev).` }
     )
@@ -28,12 +29,12 @@ export const webhookUrlSchema = z
         { message: 'This webhook URL is not allowed.' }
     );
 
-export const connectionConfigParamsSchema = z
-    .looseObject({
-        webhook_url: webhookUrlSchema,
-        webhook_url_secondary: webhookUrlSchema
-    })
-    .optional();
+export const webhookUrlConnectionConfigShape = {
+    webhook_url: webhookUrlSchema,
+    webhook_url_secondary: webhookUrlSchema
+};
+
+export const connectionConfigParamsSchema = z.looseObject(webhookUrlConnectionConfigShape).optional();
 
 export const providerSchema = z
     .string()

--- a/packages/server/lib/helpers/validation.ts
+++ b/packages/server/lib/helpers/validation.ts
@@ -29,12 +29,7 @@ export const webhookUrlSchema = z
         { message: 'This webhook URL is not allowed.' }
     );
 
-export const webhookUrlConnectionConfigShape = {
-    webhook_url: webhookUrlSchema,
-    webhook_url_secondary: webhookUrlSchema
-};
-
-export const connectionConfigParamsSchema = z.looseObject(webhookUrlConnectionConfigShape).optional();
+export const connectionConfigParamsSchema = z.looseObject({ webhook_url: webhookUrlSchema }).optional();
 
 export const providerSchema = z
     .string()

--- a/packages/server/lib/helpers/validation.unit.test.ts
+++ b/packages/server/lib/helpers/validation.unit.test.ts
@@ -1,0 +1,40 @@
+import { describe, expect, it } from 'vitest';
+
+import { webhookUrlSchema } from './validation.js';
+
+const accepts = (url: string | undefined) => webhookUrlSchema.safeParse(url).success;
+
+describe('webhookUrlSchema', () => {
+    it('accepts valid external URLs and empty/undefined', () => {
+        expect(accepts('https://example.com/hook')).toBe(true);
+        expect(accepts('')).toBe(true);
+        expect(accepts(undefined)).toBe(true);
+    });
+
+    it('rejects malformed URLs', () => {
+        expect(accepts('not-a-url')).toBe(false);
+    });
+
+    it("rejects Nango's domain and its subdomains", () => {
+        expect(accepts('https://nango.dev/hook')).toBe(false);
+        expect(accepts('https://api.nango.dev/hook')).toBe(false);
+    });
+
+    // Regression: the domain restriction must not be bypassable via a trailing dot, a port, or casing.
+    it('rejects nango.dev bypass attempts', () => {
+        expect(accepts('https://nango.dev./hook')).toBe(false); // trailing dot
+        expect(accepts('https://nango.dev:8443/hook')).toBe(false); // non-default port
+        expect(accepts('https://nango.dev:443/hook')).toBe(false);
+        expect(accepts('https://api.nango.dev./hook')).toBe(false); // subdomain + trailing dot
+        expect(accepts('https://nango.dev.:443/hook')).toBe(false);
+        expect(accepts('HTTPS://NANGO.DEV./hook')).toBe(false);
+    });
+
+    it('allows unrelated domains that merely share the suffix', () => {
+        expect(accepts('https://notnango.dev/hook')).toBe(true);
+    });
+
+    it('rejects denylisted hosts (e.g. localhost)', () => {
+        expect(accepts('http://localhost/hook')).toBe(false);
+    });
+});

--- a/packages/server/lib/hooks/hooks.ts
+++ b/packages/server/lib/hooks/hooks.ts
@@ -16,7 +16,7 @@ import {
     syncManager
 } from '@nangohq/shared';
 import { Err, getLogger, isHosted, Ok, report } from '@nangohq/utils';
-import { resolveWebhookSettings, sendAuth as sendAuthWebhook } from '@nangohq/webhooks';
+import { sendAuth as sendAuthWebhook } from '@nangohq/webhooks';
 
 import { slackService } from '../services/slack.js';
 import { getOrchestrator } from '../utils/utils.js';
@@ -151,8 +151,7 @@ export const connectionCreated = async (
         await syncManager.createSyncForConnection({ connectionId: connection.id, syncVariant: 'base', logContextGetter, orchestrator });
     }
 
-    const baseWebhookSettings = await externalWebhookService.get(environment.id);
-    const webhookSettings = baseWebhookSettings ? resolveWebhookSettings(baseWebhookSettings, connection.connection_config) : null;
+    const webhookSettings = await externalWebhookService.get(environment.id);
 
     if (webhookSettings) {
         const webhookSigningKey = await customerKeyService.getWebhookSigningKeyForEnv(db.knex, environment.id);
@@ -313,8 +312,7 @@ export const connectionRefreshFailed = async ({
         report(new Error(errorMessage, { cause: err }), { id: connection.id });
     }
 
-    const baseWebhookSettings = await externalWebhookService.get(environment.id);
-    const webhookSettings = baseWebhookSettings ? resolveWebhookSettings(baseWebhookSettings, connection.connection_config) : null;
+    const webhookSettings = await externalWebhookService.get(environment.id);
 
     if (webhookSettings) {
         const webhookSigningKey = await customerKeyService.getWebhookSigningKeyForEnv(db.knex, environment.id);

--- a/packages/server/lib/hooks/hooks.ts
+++ b/packages/server/lib/hooks/hooks.ts
@@ -16,7 +16,7 @@ import {
     syncManager
 } from '@nangohq/shared';
 import { Err, getLogger, isHosted, Ok, report } from '@nangohq/utils';
-import { sendAuth as sendAuthWebhook } from '@nangohq/webhooks';
+import { resolveWebhookSettings, sendAuth as sendAuthWebhook } from '@nangohq/webhooks';
 
 import { slackService } from '../services/slack.js';
 import { getOrchestrator } from '../utils/utils.js';
@@ -151,7 +151,8 @@ export const connectionCreated = async (
         await syncManager.createSyncForConnection({ connectionId: connection.id, syncVariant: 'base', logContextGetter, orchestrator });
     }
 
-    const webhookSettings = await externalWebhookService.get(environment.id);
+    const baseWebhookSettings = await externalWebhookService.get(environment.id);
+    const webhookSettings = baseWebhookSettings ? resolveWebhookSettings(baseWebhookSettings, connection.connection_config) : null;
 
     if (webhookSettings) {
         const webhookSigningKey = await customerKeyService.getWebhookSigningKeyForEnv(db.knex, environment.id);
@@ -312,7 +313,8 @@ export const connectionRefreshFailed = async ({
         report(new Error(errorMessage, { cause: err }), { id: connection.id });
     }
 
-    const webhookSettings = await externalWebhookService.get(environment.id);
+    const baseWebhookSettings = await externalWebhookService.get(environment.id);
+    const webhookSettings = baseWebhookSettings ? resolveWebhookSettings(baseWebhookSettings, connection.connection_config) : null;
 
     if (webhookSettings) {
         const webhookSigningKey = await customerKeyService.getWebhookSigningKeyForEnv(db.knex, environment.id);

--- a/packages/server/lib/utils/auth.ts
+++ b/packages/server/lib/utils/auth.ts
@@ -1,9 +1,32 @@
+import { getConnectionConfig } from '@nangohq/shared';
 import { zodErrorToHTTP } from '@nangohq/utils';
 
 import type { RequestLocals } from './express.js';
 import type { LogContext } from '@nangohq/logs';
-import type { ApiError, IntegrationConfig } from '@nangohq/types';
+import type { ApiError, ConnectionConfig, ConnectSession, IntegrationConfig } from '@nangohq/types';
 import type { Response } from 'express';
+
+/**
+ * Merges connection config from the session defaults with the request params.
+ */
+export function resolveConnectionConfig({
+    params,
+    connectSession,
+    providerConfigKey
+}: {
+    params: Record<string, any> | undefined;
+    connectSession: ConnectSession | undefined;
+    providerConfigKey: string;
+}): ConnectionConfig {
+    const connectionConfig: ConnectionConfig = params ? getConnectionConfig(params) : {};
+
+    const defaults = connectSession?.integrationsConfigDefaults?.[providerConfigKey]?.connectionConfig;
+    if (defaults) {
+        Object.assign(connectionConfig, defaults);
+    }
+
+    return connectionConfig;
+}
 
 export async function isIntegrationAllowed({
     config,

--- a/packages/server/lib/utils/auth.unit.test.ts
+++ b/packages/server/lib/utils/auth.unit.test.ts
@@ -1,0 +1,74 @@
+import { describe, expect, it } from 'vitest';
+
+import { resolveConnectionConfig } from './auth.js';
+
+import type { ConnectSession } from '@nangohq/types';
+
+function connectSessionWith(connectionConfig: Record<string, unknown> | undefined, integrationKey = 'github'): ConnectSession {
+    return {
+        id: 1,
+        endUserId: null,
+        accountId: 1,
+        environmentId: 1,
+        connectionId: null,
+        operationId: null,
+        allowedIntegrations: null,
+        integrationsConfigDefaults: connectionConfig ? { [integrationKey]: { connectionConfig } } : null,
+        overrides: null,
+        endUser: null,
+        tags: {},
+        createdAt: new Date(),
+        updatedAt: null
+    };
+}
+
+describe('resolveConnectionConfig', () => {
+    it('returns the request params when there is no connect session', () => {
+        expect(resolveConnectionConfig({ params: { subdomain: 'acme' }, connectSession: undefined, providerConfigKey: 'github' })).toEqual({
+            subdomain: 'acme'
+        });
+    });
+
+    it('returns an empty object when there are no params and no session', () => {
+        expect(resolveConnectionConfig({ params: undefined, connectSession: undefined, providerConfigKey: 'github' })).toEqual({});
+    });
+
+    it('merges session defaults on top of the request params', () => {
+        const connectSession = connectSessionWith({ webhook_url: 'https://example.com/hook' });
+        expect(resolveConnectionConfig({ params: { subdomain: 'acme' }, connectSession, providerConfigKey: 'github' })).toEqual({
+            subdomain: 'acme',
+            webhook_url: 'https://example.com/hook'
+        });
+    });
+
+    // This pins the deliberate precedence decision: session defaults (backend-set) win over request
+    // params (end-user-supplied), mirroring the OAuth flow. Flipping the merge order breaks this.
+    it('lets session defaults win over a conflicting request param', () => {
+        const connectSession = connectSessionWith({ subdomain: 'from-session' });
+        expect(resolveConnectionConfig({ params: { subdomain: 'from-params' }, connectSession, providerConfigKey: 'github' })).toEqual({
+            subdomain: 'from-session'
+        });
+    });
+
+    it('applies session defaults even when no params are passed', () => {
+        const connectSession = connectSessionWith({ webhook_url: 'https://example.com/hook' });
+        expect(resolveConnectionConfig({ params: undefined, connectSession, providerConfigKey: 'github' })).toEqual({
+            webhook_url: 'https://example.com/hook'
+        });
+    });
+
+    it('ignores defaults configured for a different integration', () => {
+        const connectSession = connectSessionWith({ webhook_url: 'https://example.com/hook' }, 'github');
+        expect(resolveConnectionConfig({ params: { subdomain: 'acme' }, connectSession, providerConfigKey: 'slack' })).toEqual({
+            subdomain: 'acme'
+        });
+    });
+
+    it('drops non-string param values while keeping session defaults', () => {
+        const connectSession = connectSessionWith({ webhook_url: 'https://example.com/hook' });
+        expect(resolveConnectionConfig({ params: { subdomain: 'acme', count: 5 }, connectSession, providerConfigKey: 'github' })).toEqual({
+            subdomain: 'acme',
+            webhook_url: 'https://example.com/hook'
+        });
+    });
+});

--- a/packages/server/lib/utils/auth.unit.test.ts
+++ b/packages/server/lib/utils/auth.unit.test.ts
@@ -71,4 +71,23 @@ describe('resolveConnectionConfig', () => {
             webhook_url: 'https://example.com/hook'
         });
     });
+
+    // webhook_url is privileged: an untrusted client must not be able to redirect a connection's webhooks
+    // by passing it as a request param. It is only honored from the (backend-set) connect session defaults.
+    it('drops a client-supplied webhook_url param', () => {
+        expect(
+            resolveConnectionConfig({
+                params: { subdomain: 'acme', webhook_url: 'https://attacker.example.com/hook' },
+                connectSession: undefined,
+                providerConfigKey: 'github'
+            })
+        ).toEqual({ subdomain: 'acme' });
+    });
+
+    it('ignores a client webhook_url param even when the session pins its own', () => {
+        const connectSession = connectSessionWith({ webhook_url: 'https://backend.example.com/hook' });
+        expect(resolveConnectionConfig({ params: { webhook_url: 'https://attacker.example.com/hook' }, connectSession, providerConfigKey: 'github' })).toEqual({
+            webhook_url: 'https://backend.example.com/hook'
+        });
+    });
 });

--- a/packages/server/lib/webhook/webhook.manager.ts
+++ b/packages/server/lib/webhook/webhook.manager.ts
@@ -127,20 +127,14 @@ export async function routeWebhook({
                   })
                 : '';
 
-            // Fetch each matched connection's config so forwardWebhook can honor a per-connection webhook URL override.
-            const connectionConfigByConnectionId = new Map<string, ConnectionConfig>();
-            if (webhookSettings) {
-                for (const connectionId of connectionIds) {
-                    connectionConfigByConnectionId.set(
-                        connectionId,
-                        await connectionService.getConnectionConfig({
-                            connection_id: connectionId,
-                            provider_config_key: integration.unique_key,
-                            environment_id: environment.id
-                        })
-                    );
-                }
-            }
+            // Fetch the matched connections' config so forwardWebhook can honor a per-connection webhook URL override.
+            const connectionConfigByConnectionId = webhookSettings
+                ? await connectionService.getConnectionConfigByConnectionIds({
+                      connectionIds,
+                      provider_config_key: integration.unique_key,
+                      environment_id: environment.id
+                  })
+                : new Map<string, ConnectionConfig>();
 
             return forwardWebhook({
                 integration,

--- a/packages/server/lib/webhook/webhook.manager.ts
+++ b/packages/server/lib/webhook/webhook.manager.ts
@@ -109,64 +109,69 @@ export async function routeWebhook({
         const webhookBodyToForward = 'toForward' in res ? res.toForward : body;
         const connectionIds = 'connectionIds' in res ? res.connectionIds : [];
 
-        const webhookSettings = await externalWebhookService.get(environment.id);
-
-        const webhookSigningSecret = webhookSettings
-            ? await customerKeyService.getWebhookSigningKeyForEnv(db.knex, environment.id).then((r) => {
-                  if (r.isErr()) throw r.error;
-                  return r.value;
-              })
-            : '';
-
-        // Fetch each matched connection's config so forwardWebhook can honor a per-connection webhook URL override.
-        const connectionConfigByConnectionId = new Map<string, ConnectionConfig>();
-        if (webhookSettings) {
-            for (const connectionId of connectionIds) {
-                connectionConfigByConnectionId.set(
-                    connectionId,
-                    await connectionService.getConnectionConfig({
-                        connection_id: connectionId,
-                        provider_config_key: integration.unique_key,
-                        environment_id: environment.id
-                    })
-                );
-            }
-        }
-
         // Forward the webhook to the customer asynchronously to avoid provider timeouts.
-        // Some providers stop sending webhooks if Nango doesn't respond quickly due to slow customer endpoints
+        // Some providers stop sending webhooks if Nango doesn't respond quickly due to slow customer endpoints.
+        // All forward-related DB work (settings, signing key, per-connection config) runs inside this
+        // fire-and-forget block, off the provider response path, so a large connection fan-out can't delay
+        // the response back to the provider.
         const forwardSpan = tracer.startSpan('webhook.forward');
         const pendingEvents: MaybeStampedEvent<'usage'>[] = [];
 
-        void forwardWebhook({
-            integration,
-            account,
-            environment,
-            secret: webhookSigningSecret,
-            webhookSettings,
-            connectionIds,
-            connectionConfigByConnectionId,
-            payload: webhookBodyToForward,
-            webhookOriginalHeaders: headers,
-            logContextGetter,
-            onBytes: (bytes, connectionId) => {
-                pendingEvents.push(
-                    makeDataTransferEvent({
-                        pkg: 'server',
-                        callsite: 'webhook_forward',
-                        accountId: account.id,
+        void (async () => {
+            const webhookSettings = await externalWebhookService.get(environment.id);
+
+            const webhookSigningSecret = webhookSettings
+                ? await customerKeyService.getWebhookSigningKeyForEnv(db.knex, environment.id).then((r) => {
+                      if (r.isErr()) throw r.error;
+                      return r.value;
+                  })
+                : '';
+
+            // Fetch each matched connection's config so forwardWebhook can honor a per-connection webhook URL override.
+            const connectionConfigByConnectionId = new Map<string, ConnectionConfig>();
+            if (webhookSettings) {
+                for (const connectionId of connectionIds) {
+                    connectionConfigByConnectionId.set(
                         connectionId,
-                        integrationId: integration.unique_key,
-                        environmentId: environment.id,
-                        meteredBytes: bytes,
-                        environmentName: environment.name
-                    })
-                );
+                        await connectionService.getConnectionConfig({
+                            connection_id: connectionId,
+                            provider_config_key: integration.unique_key,
+                            environment_id: environment.id
+                        })
+                    );
+                }
             }
-        })
-            .then((res) => {
-                if (res.isOk()) {
-                    for (const { connectionId, success } of res.value.results) {
+
+            return forwardWebhook({
+                integration,
+                account,
+                environment,
+                secret: webhookSigningSecret,
+                webhookSettings,
+                connectionIds,
+                connectionConfigByConnectionId,
+                payload: webhookBodyToForward,
+                webhookOriginalHeaders: headers,
+                logContextGetter,
+                onBytes: (bytes, connectionId) => {
+                    pendingEvents.push(
+                        makeDataTransferEvent({
+                            pkg: 'server',
+                            callsite: 'webhook_forward',
+                            accountId: account.id,
+                            connectionId,
+                            integrationId: integration.unique_key,
+                            environmentId: environment.id,
+                            meteredBytes: bytes,
+                            environmentName: environment.name
+                        })
+                    );
+                }
+            });
+        })()
+            .then((forwardResult) => {
+                if (forwardResult?.isOk()) {
+                    for (const { connectionId, success } of forwardResult.value.results) {
                         pendingEvents.push({
                             subject: 'usage',
                             type: 'usage.webhook_forward',
@@ -184,6 +189,9 @@ export async function routeWebhook({
                         });
                     }
                 }
+            })
+            .catch((err: unknown) => {
+                logger.error(`error forwarding webhook for ${integration.unique_key} - `, err);
             })
             .finally(() => {
                 if (pendingEvents.length > 0) {

--- a/packages/server/lib/webhook/webhook.manager.ts
+++ b/packages/server/lib/webhook/webhook.manager.ts
@@ -1,7 +1,7 @@
 import tracer from 'dd-trace';
 
 import db from '@nangohq/database';
-import { customerKeyService, externalWebhookService, getProvider, makeDataTransferEvent, NangoError, pubsub } from '@nangohq/shared';
+import { connectionService, customerKeyService, externalWebhookService, getProvider, makeDataTransferEvent, NangoError, pubsub } from '@nangohq/shared';
 import { Err, getLogger } from '@nangohq/utils';
 import { forwardWebhook } from '@nangohq/webhooks';
 
@@ -13,7 +13,7 @@ import type { WebhookHandlersMap, WebhookResponse } from './types.js';
 import type { LogContextGetter } from '@nangohq/logs';
 import type { MaybeStampedEvent } from '@nangohq/pubsub';
 import type { Config } from '@nangohq/shared';
-import type { DBEnvironment, DBPlan, DBTeam } from '@nangohq/types';
+import type { ConnectionConfig, DBEnvironment, DBPlan, DBTeam } from '@nangohq/types';
 import type { Result } from '@nangohq/utils';
 
 const logger = getLogger('Webhook.Manager');
@@ -118,6 +118,21 @@ export async function routeWebhook({
               })
             : '';
 
+        // Fetch each matched connection's config so forwardWebhook can honor a per-connection webhook URL override.
+        const connectionConfigByConnectionId = new Map<string, ConnectionConfig>();
+        if (webhookSettings) {
+            for (const connectionId of connectionIds) {
+                connectionConfigByConnectionId.set(
+                    connectionId,
+                    await connectionService.getConnectionConfig({
+                        connection_id: connectionId,
+                        provider_config_key: integration.unique_key,
+                        environment_id: environment.id
+                    })
+                );
+            }
+        }
+
         // Forward the webhook to the customer asynchronously to avoid provider timeouts.
         // Some providers stop sending webhooks if Nango doesn't respond quickly due to slow customer endpoints
         const forwardSpan = tracer.startSpan('webhook.forward');
@@ -130,6 +145,7 @@ export async function routeWebhook({
             secret: webhookSigningSecret,
             webhookSettings,
             connectionIds,
+            connectionConfigByConnectionId,
             payload: webhookBodyToForward,
             webhookOriginalHeaders: headers,
             logContextGetter,

--- a/packages/server/lib/webhook/webhook.manager.ts
+++ b/packages/server/lib/webhook/webhook.manager.ts
@@ -109,63 +109,58 @@ export async function routeWebhook({
         const webhookBodyToForward = 'toForward' in res ? res.toForward : body;
         const connectionIds = 'connectionIds' in res ? res.connectionIds : [];
 
+        const webhookSettings = await externalWebhookService.get(environment.id);
+
+        const webhookSigningSecret = webhookSettings
+            ? await customerKeyService.getWebhookSigningKeyForEnv(db.knex, environment.id).then((r) => {
+                  if (r.isErr()) throw r.error;
+                  return r.value;
+              })
+            : '';
+
+        // Fetch the matched connections' config so forwardWebhook can honor a per-connection webhook URL override.
+        const connectionConfigByConnectionId = webhookSettings
+            ? await connectionService.getConnectionConfigByConnectionIds({
+                  connectionIds,
+                  provider_config_key: integration.unique_key,
+                  environment_id: environment.id
+              })
+            : new Map<string, ConnectionConfig>();
+
         // Forward the webhook to the customer asynchronously to avoid provider timeouts.
-        // Some providers stop sending webhooks if Nango doesn't respond quickly due to slow customer endpoints.
-        // All forward-related DB work (settings, signing key, per-connection config) runs inside this
-        // fire-and-forget block, off the provider response path, so a large connection fan-out can't delay
-        // the response back to the provider.
+        // Some providers stop sending webhooks if Nango doesn't respond quickly due to slow customer endpoints
         const forwardSpan = tracer.startSpan('webhook.forward');
         const pendingEvents: MaybeStampedEvent<'usage'>[] = [];
 
-        void (async () => {
-            const webhookSettings = await externalWebhookService.get(environment.id);
-
-            const webhookSigningSecret = webhookSettings
-                ? await customerKeyService.getWebhookSigningKeyForEnv(db.knex, environment.id).then((r) => {
-                      if (r.isErr()) throw r.error;
-                      return r.value;
-                  })
-                : '';
-
-            // Fetch the matched connections' config so forwardWebhook can honor a per-connection webhook URL override.
-            const connectionConfigByConnectionId = webhookSettings
-                ? await connectionService.getConnectionConfigByConnectionIds({
-                      connectionIds,
-                      provider_config_key: integration.unique_key,
-                      environment_id: environment.id
-                  })
-                : new Map<string, ConnectionConfig>();
-
-            return forwardWebhook({
-                integration,
-                account,
-                environment,
-                secret: webhookSigningSecret,
-                webhookSettings,
-                connectionIds,
-                connectionConfigByConnectionId,
-                payload: webhookBodyToForward,
-                webhookOriginalHeaders: headers,
-                logContextGetter,
-                onBytes: (bytes, connectionId) => {
-                    pendingEvents.push(
-                        makeDataTransferEvent({
-                            pkg: 'server',
-                            callsite: 'webhook_forward',
-                            accountId: account.id,
-                            connectionId,
-                            integrationId: integration.unique_key,
-                            environmentId: environment.id,
-                            meteredBytes: bytes,
-                            environmentName: environment.name
-                        })
-                    );
-                }
-            });
-        })()
-            .then((forwardResult) => {
-                if (forwardResult?.isOk()) {
-                    for (const { connectionId, success } of forwardResult.value.results) {
+        void forwardWebhook({
+            integration,
+            account,
+            environment,
+            secret: webhookSigningSecret,
+            webhookSettings,
+            connectionIds,
+            connectionConfigByConnectionId,
+            payload: webhookBodyToForward,
+            webhookOriginalHeaders: headers,
+            logContextGetter,
+            onBytes: (bytes, connectionId) => {
+                pendingEvents.push(
+                    makeDataTransferEvent({
+                        pkg: 'server',
+                        callsite: 'webhook_forward',
+                        accountId: account.id,
+                        connectionId,
+                        integrationId: integration.unique_key,
+                        environmentId: environment.id,
+                        meteredBytes: bytes,
+                        environmentName: environment.name
+                    })
+                );
+            }
+        })
+            .then((res) => {
+                if (res.isOk()) {
+                    for (const { connectionId, success } of res.value.results) {
                         pendingEvents.push({
                             subject: 'usage',
                             type: 'usage.webhook_forward',
@@ -183,9 +178,6 @@ export async function routeWebhook({
                         });
                     }
                 }
-            })
-            .catch((err: unknown) => {
-                logger.error(`error forwarding webhook for ${integration.unique_key} - `, err);
             })
             .finally(() => {
                 if (pendingEvents.length > 0) {

--- a/packages/server/lib/webhook/webhook.manager.ts
+++ b/packages/server/lib/webhook/webhook.manager.ts
@@ -179,6 +179,9 @@ export async function routeWebhook({
                     }
                 }
             })
+            .catch((err: unknown) => {
+                logger.error(`error forwarding webhook for ${integration.unique_key} - `, err);
+            })
             .finally(() => {
                 if (pendingEvents.length > 0) {
                     void pubsub.publisher.publishBatch({ subject: 'usage', events: pendingEvents });

--- a/packages/shared/lib/services/connection.service.integration.test.ts
+++ b/packages/shared/lib/services/connection.service.integration.test.ts
@@ -144,6 +144,98 @@ describe('Connection service integration tests', () => {
         });
     });
 
+    describe('getConnectionConfigByConnectionIds', () => {
+        it('returns connection_config keyed by connection_id for the requested ids', async () => {
+            const env = await createEnvironmentSeed();
+            const config = (await createConfigSeed(env, `batch-${Math.random().toString(36).slice(2, 10)}`, 'google')) as ProviderConfig;
+
+            const withOverride = await createConnectionSeed({
+                env,
+                provider: config.unique_key,
+                connectionId: `batch-a-${Math.random().toString(36).slice(2, 10)}`,
+                connectionConfig: { webhook_url: 'https://override.example.com/hook' }
+            });
+            const withoutOverride = await createConnectionSeed({
+                env,
+                provider: config.unique_key,
+                connectionId: `batch-b-${Math.random().toString(36).slice(2, 10)}`,
+                connectionConfig: {}
+            });
+
+            const result = await connectionService.getConnectionConfigByConnectionIds({
+                connectionIds: [withOverride.connection_id, withoutOverride.connection_id],
+                provider_config_key: config.unique_key,
+                environment_id: env.id
+            });
+
+            expect(result.size).toBe(2);
+            expect(result.get(withOverride.connection_id)).toEqual({ webhook_url: 'https://override.example.com/hook' });
+            expect(result.get(withoutOverride.connection_id)).toEqual({});
+        });
+
+        it('omits connection ids that do not exist', async () => {
+            const env = await createEnvironmentSeed();
+            const config = (await createConfigSeed(env, `batch-${Math.random().toString(36).slice(2, 10)}`, 'google')) as ProviderConfig;
+            const existing = await createConnectionSeed({
+                env,
+                provider: config.unique_key,
+                connectionId: `batch-c-${Math.random().toString(36).slice(2, 10)}`,
+                connectionConfig: { webhook_url: 'https://override.example.com/hook' }
+            });
+
+            const result = await connectionService.getConnectionConfigByConnectionIds({
+                connectionIds: [existing.connection_id, 'does-not-exist'],
+                provider_config_key: config.unique_key,
+                environment_id: env.id
+            });
+
+            expect(result.size).toBe(1);
+            expect(result.has('does-not-exist')).toBe(false);
+            expect(result.get(existing.connection_id)).toEqual({ webhook_url: 'https://override.example.com/hook' });
+        });
+
+        it('does not return a connection sharing the id under a different integration', async () => {
+            const env = await createEnvironmentSeed();
+            const configA = (await createConfigSeed(env, `batch-a-${Math.random().toString(36).slice(2, 10)}`, 'google')) as ProviderConfig;
+            const configB = (await createConfigSeed(env, `batch-b-${Math.random().toString(36).slice(2, 10)}`, 'notion')) as ProviderConfig;
+
+            const inA = await createConnectionSeed({
+                env,
+                provider: configA.unique_key,
+                connectionId: `shared-${Math.random().toString(36).slice(2, 10)}`,
+                connectionConfig: { webhook_url: 'https://a.example.com/hook' }
+            });
+            await createConnectionSeed({
+                env,
+                provider: configB.unique_key,
+                connectionId: inA.connection_id,
+                connectionConfig: { webhook_url: 'https://b.example.com/hook' }
+            });
+
+            const result = await connectionService.getConnectionConfigByConnectionIds({
+                connectionIds: [inA.connection_id],
+                provider_config_key: configA.unique_key,
+                environment_id: env.id
+            });
+
+            expect(result.size).toBe(1);
+            expect(result.get(inA.connection_id)).toEqual({ webhook_url: 'https://a.example.com/hook' });
+        });
+
+        it('returns an empty map when no connection ids are requested', async () => {
+            const env = await createEnvironmentSeed();
+            const config = (await createConfigSeed(env, `batch-${Math.random().toString(36).slice(2, 10)}`, 'google')) as ProviderConfig;
+
+            const result = await connectionService.getConnectionConfigByConnectionIds({
+                connectionIds: [],
+                provider_config_key: config.unique_key,
+                environment_id: env.id
+            });
+
+            expect(result.size).toBe(0);
+        });
+    });
+
     describe('listConnections', () => {
         it('should return all connections', async () => {
             const env = await createEnvironmentSeed();

--- a/packages/shared/lib/services/connection.service.ts
+++ b/packages/shared/lib/services/connection.service.ts
@@ -540,6 +540,33 @@ class ConnectionService {
         return result[0].connection_config;
     }
 
+    public async getConnectionConfigByConnectionIds({
+        connectionIds,
+        provider_config_key,
+        environment_id
+    }: {
+        connectionIds: string[];
+        provider_config_key: string;
+        environment_id: number;
+    }): Promise<Map<string, ConnectionConfig>> {
+        const configByConnectionId = new Map<string, ConnectionConfig>();
+        if (connectionIds.length === 0) {
+            return configByConnectionId;
+        }
+
+        const result = await db.knex
+            .from<DBConnection>(`_nango_connections`)
+            .select('connection_id', 'connection_config')
+            .whereIn('connection_id', connectionIds)
+            .where({ provider_config_key, environment_id, deleted: false });
+
+        for (const row of result) {
+            configByConnectionId.set(row.connection_id, row.connection_config);
+        }
+
+        return configByConnectionId;
+    }
+
     public async countConnections({ environmentId, providerConfigKey }: { environmentId: number; providerConfigKey: string }): Promise<number> {
         const res = await db.knex
             .from<DBConnection>(`_nango_connections`)

--- a/packages/shared/lib/utils/utils.ts
+++ b/packages/shared/lib/utils/utils.ts
@@ -495,8 +495,14 @@ export function interpolateIfNeeded(str: string, replacers: Record<string, any>)
     return str;
 }
 
+// Connection config keys a client is not allowed to supply: they are privileged and only set by the backend.
+const CLIENT_FORBIDDEN_CONNECTION_CONFIG_KEYS = new Set([
+    // `webhook_url` routes a connection's webhooks, so it is only honored from the backend-set connect session.
+    'webhook_url'
+]);
+
 export function getConnectionConfig(queryParams: any): Record<string, string> {
-    const arr = Object.entries(queryParams).filter(([, v]) => typeof v === 'string'); // Filter strings
+    const arr = Object.entries(queryParams).filter(([k, v]) => typeof v === 'string' && !CLIENT_FORBIDDEN_CONNECTION_CONFIG_KEYS.has(k));
     return Object.fromEntries(arr) as Record<string, string>;
 }
 

--- a/packages/shared/lib/utils/utils.unit.test.ts
+++ b/packages/shared/lib/utils/utils.unit.test.ts
@@ -17,6 +17,22 @@ describe('Proxy service Construct Header Tests', () => {
         expect(utils.isValidHttpUrl('/api/v2/tickets?per_page=100&include=requester,description&page=3')).toBe(false);
     });
 });
+describe('getConnectionConfig', () => {
+    it('keeps string query params', () => {
+        expect(utils.getConnectionConfig({ subdomain: 'acme', region: 'eu' })).toEqual({ subdomain: 'acme', region: 'eu' });
+    });
+
+    it('drops non-string values', () => {
+        expect(utils.getConnectionConfig({ subdomain: 'acme', count: 5, flag: true })).toEqual({ subdomain: 'acme' });
+    });
+
+    // webhook_url is a privileged routing directive: it must only be settable by the backend via the
+    // connect session, never by an untrusted client passing it as a connection param. Stripping it here
+    // closes every client-param entry point (auth endpoints + OAuth) in one place.
+    it('strips webhook_url so an untrusted client cannot route webhooks', () => {
+        expect(utils.getConnectionConfig({ subdomain: 'acme', webhook_url: 'https://attacker.example.com/hook' })).toEqual({ subdomain: 'acme' });
+    });
+});
 describe('encodeParameters Function Tests', () => {
     it('should encode parameters correctly', () => {
         const params = {

--- a/packages/types/lib/connect/api.ts
+++ b/packages/types/lib/connect/api.ts
@@ -15,7 +15,6 @@ export interface ConnectSessionInput {
                             [key: string]: unknown;
                             oauth_scopes_override?: string | undefined;
                             webhook_url?: string | undefined;
-                            webhook_url_secondary?: string | undefined;
                         }
                       | undefined;
               }

--- a/packages/types/lib/connect/api.ts
+++ b/packages/types/lib/connect/api.ts
@@ -14,6 +14,8 @@ export interface ConnectSessionInput {
                       | {
                             [key: string]: unknown;
                             oauth_scopes_override?: string | undefined;
+                            webhook_url?: string | undefined;
+                            webhook_url_secondary?: string | undefined;
                         }
                       | undefined;
               }

--- a/packages/types/lib/connection/db.ts
+++ b/packages/types/lib/connection/db.ts
@@ -58,9 +58,7 @@ export interface FailedConnectionError {
 }
 
 export interface RecentlyFailedConnection {
-    // connection_config carries the attempted per-connection webhook URL override so failure webhooks can
-    // honor it even though the connection was never persisted (there is no DB row to read it back from).
-    connection: DBConnection | (Pick<DBConnection, 'connection_id' | 'provider_config_key'> & { connection_config?: ConnectionConfig });
+    connection: DBConnection | (Pick<DBConnection, 'connection_id' | 'provider_config_key'> & Partial<Pick<DBConnection, 'connection_config'>>);
     auth_mode: AuthModeType;
     error?: FailedConnectionError;
     operation: AuthOperationType;

--- a/packages/types/lib/connection/db.ts
+++ b/packages/types/lib/connection/db.ts
@@ -14,7 +14,6 @@ export interface ConnectionConfig {
     oauth_scopes?: string | undefined;
     authorization_params?: Record<string, string> | undefined;
     webhook_url?: string | undefined;
-    webhook_url_secondary?: string | undefined;
 }
 
 export interface DBConnection extends TimestampsAndDeletedCorrect {

--- a/packages/types/lib/connection/db.ts
+++ b/packages/types/lib/connection/db.ts
@@ -58,7 +58,7 @@ export interface FailedConnectionError {
 }
 
 export interface RecentlyFailedConnection {
-    connection: DBConnection | (Pick<DBConnection, 'connection_id' | 'provider_config_key'> & Partial<Pick<DBConnection, 'connection_config'>>);
+    connection: DBConnection | Pick<DBConnection, 'connection_id' | 'provider_config_key' | 'connection_config'>;
     auth_mode: AuthModeType;
     error?: FailedConnectionError;
     operation: AuthOperationType;

--- a/packages/types/lib/connection/db.ts
+++ b/packages/types/lib/connection/db.ts
@@ -58,7 +58,9 @@ export interface FailedConnectionError {
 }
 
 export interface RecentlyFailedConnection {
-    connection: DBConnection | Pick<DBConnection, 'connection_id' | 'provider_config_key'>;
+    // connection_config carries the attempted per-connection webhook URL override so failure webhooks can
+    // honor it even though the connection was never persisted (there is no DB row to read it back from).
+    connection: DBConnection | (Pick<DBConnection, 'connection_id' | 'provider_config_key'> & { connection_config?: ConnectionConfig });
     auth_mode: AuthModeType;
     error?: FailedConnectionError;
     operation: AuthOperationType;

--- a/packages/types/lib/connection/db.ts
+++ b/packages/types/lib/connection/db.ts
@@ -13,6 +13,8 @@ export interface ConnectionConfig {
     oauth_scopes_override?: string[] | undefined;
     oauth_scopes?: string | undefined;
     authorization_params?: Record<string, string> | undefined;
+    webhook_url?: string | undefined;
+    webhook_url_secondary?: string | undefined;
 }
 
 export interface DBConnection extends TimestampsAndDeletedCorrect {

--- a/packages/webapp/src/pages/Connection/Create.tsx
+++ b/packages/webapp/src/pages/Connection/Create.tsx
@@ -20,23 +20,17 @@ import { CreateConnectionSelector } from './components/CreateConnectionSelector'
 
 import type { ApiIntegrationList } from '@nangohq/types';
 
-const schema = z
-    .object({
-        testUserId: z.string().min(1, 'User ID is required').max(255, 'User ID must be less than 255 characters'),
-        testUserEmail: z.string().email('Invalid email address').min(5).optional().or(z.literal('')),
-        testUserName: z.string().max(255, 'Display name must be less than 255 characters').optional(),
-        testUserTags: z.record(z.string(), z.string()).refine((tags) => Object.keys(tags).length < 64, 'Max 64 tags allowed'),
-        overrideAuthParams: z.record(z.string(), z.string()),
-        overrideOauthScopes: z.string().optional(),
-        overrideDevAppCredentials: z.boolean(),
-        overrideDocUrl: z.string().optional().or(z.literal('')),
-        overrideWebhookUrl: z.string().url('Please enter a valid URL').optional().or(z.literal('')),
-        overrideWebhookUrlSecondary: z.string().url('Please enter a valid URL').optional().or(z.literal(''))
-    })
-    .refine((data) => !(data.overrideWebhookUrlSecondary && !data.overrideWebhookUrl), {
-        message: 'Set a primary webhook URL before a secondary one',
-        path: ['overrideWebhookUrlSecondary']
-    });
+const schema = z.object({
+    testUserId: z.string().min(1, 'User ID is required').max(255, 'User ID must be less than 255 characters'),
+    testUserEmail: z.string().email('Invalid email address').min(5).optional().or(z.literal('')),
+    testUserName: z.string().max(255, 'Display name must be less than 255 characters').optional(),
+    testUserTags: z.record(z.string(), z.string()).refine((tags) => Object.keys(tags).length < 64, 'Max 64 tags allowed'),
+    overrideAuthParams: z.record(z.string(), z.string()),
+    overrideOauthScopes: z.string().optional(),
+    overrideDevAppCredentials: z.boolean(),
+    overrideDocUrl: z.string().optional().or(z.literal('')),
+    overrideWebhookUrl: z.string().url('Please enter a valid URL').optional().or(z.literal(''))
+});
 
 export type ConnectionFormData = z.infer<typeof schema>;
 
@@ -63,8 +57,7 @@ export const ConnectionCreate: React.FC = () => {
             overrideOauthScopes: undefined,
             overrideDevAppCredentials: false,
             overrideDocUrl: '',
-            overrideWebhookUrl: '',
-            overrideWebhookUrlSecondary: ''
+            overrideWebhookUrl: ''
         },
         mode: 'onChange'
     });
@@ -85,8 +78,7 @@ export const ConnectionCreate: React.FC = () => {
             overrideOauthScopes: integration?.oauth_scopes || undefined,
             overrideDevAppCredentials: false,
             overrideDocUrl: '',
-            overrideWebhookUrl: '',
-            overrideWebhookUrlSecondary: ''
+            overrideWebhookUrl: ''
         });
     }, [user, integration, form]);
 
@@ -154,7 +146,6 @@ export const ConnectionCreate: React.FC = () => {
                             overrideClientSecret={overrideClientSecret}
                             overrideDocUrl={formValues.overrideDocUrl}
                             overrideWebhookUrl={formValues.overrideWebhookUrl}
-                            overrideWebhookUrlSecondary={formValues.overrideWebhookUrlSecondary}
                             defaultDocUrl={provider?.data.docs_connect}
                             isFormValid={form.formState.isValid}
                         />

--- a/packages/webapp/src/pages/Connection/Create.tsx
+++ b/packages/webapp/src/pages/Connection/Create.tsx
@@ -20,16 +20,23 @@ import { CreateConnectionSelector } from './components/CreateConnectionSelector'
 
 import type { ApiIntegrationList } from '@nangohq/types';
 
-const schema = z.object({
-    testUserId: z.string().min(1, 'User ID is required').max(255, 'User ID must be less than 255 characters'),
-    testUserEmail: z.string().email('Invalid email address').min(5).optional().or(z.literal('')),
-    testUserName: z.string().max(255, 'Display name must be less than 255 characters').optional(),
-    testUserTags: z.record(z.string(), z.string()).refine((tags) => Object.keys(tags).length < 64, 'Max 64 tags allowed'),
-    overrideAuthParams: z.record(z.string(), z.string()),
-    overrideOauthScopes: z.string().optional(),
-    overrideDevAppCredentials: z.boolean(),
-    overrideDocUrl: z.string().optional().or(z.literal(''))
-});
+const schema = z
+    .object({
+        testUserId: z.string().min(1, 'User ID is required').max(255, 'User ID must be less than 255 characters'),
+        testUserEmail: z.string().email('Invalid email address').min(5).optional().or(z.literal('')),
+        testUserName: z.string().max(255, 'Display name must be less than 255 characters').optional(),
+        testUserTags: z.record(z.string(), z.string()).refine((tags) => Object.keys(tags).length < 64, 'Max 64 tags allowed'),
+        overrideAuthParams: z.record(z.string(), z.string()),
+        overrideOauthScopes: z.string().optional(),
+        overrideDevAppCredentials: z.boolean(),
+        overrideDocUrl: z.string().optional().or(z.literal('')),
+        overrideWebhookUrl: z.string().url('Please enter a valid URL').optional().or(z.literal('')),
+        overrideWebhookUrlSecondary: z.string().url('Please enter a valid URL').optional().or(z.literal(''))
+    })
+    .refine((data) => !(data.overrideWebhookUrlSecondary && !data.overrideWebhookUrl), {
+        message: 'Set a primary webhook URL before a secondary one',
+        path: ['overrideWebhookUrlSecondary']
+    });
 
 export type ConnectionFormData = z.infer<typeof schema>;
 
@@ -55,7 +62,9 @@ export const ConnectionCreate: React.FC = () => {
             overrideAuthParams: {},
             overrideOauthScopes: undefined,
             overrideDevAppCredentials: false,
-            overrideDocUrl: ''
+            overrideDocUrl: '',
+            overrideWebhookUrl: '',
+            overrideWebhookUrlSecondary: ''
         },
         mode: 'onChange'
     });
@@ -75,7 +84,9 @@ export const ConnectionCreate: React.FC = () => {
             overrideAuthParams: Object.fromEntries(Object.entries(integration?.meta.authorizationParams ?? {}).map(([k, v]) => [k, String(v)])),
             overrideOauthScopes: integration?.oauth_scopes || undefined,
             overrideDevAppCredentials: false,
-            overrideDocUrl: ''
+            overrideDocUrl: '',
+            overrideWebhookUrl: '',
+            overrideWebhookUrlSecondary: ''
         });
     }, [user, integration, form]);
 
@@ -142,6 +153,8 @@ export const ConnectionCreate: React.FC = () => {
                             overrideClientId={overrideClientId}
                             overrideClientSecret={overrideClientSecret}
                             overrideDocUrl={formValues.overrideDocUrl}
+                            overrideWebhookUrl={formValues.overrideWebhookUrl}
+                            overrideWebhookUrlSecondary={formValues.overrideWebhookUrlSecondary}
                             defaultDocUrl={provider?.data.docs_connect}
                             isFormValid={form.formState.isValid}
                         />

--- a/packages/webapp/src/pages/Connection/components/ConnectionAdvancedConfig.tsx
+++ b/packages/webapp/src/pages/Connection/components/ConnectionAdvancedConfig.tsx
@@ -313,28 +313,6 @@ export const ConnectionAdvancedConfig: React.FC<ConnectionAdvancedConfigProps> =
                                         </FormItem>
                                     )}
                                 />
-                                <FormField
-                                    control={control}
-                                    name="overrideWebhookUrlSecondary"
-                                    render={({ field }) => (
-                                        <FormItem>
-                                            <FormLabelWithTooltip
-                                                tooltip={
-                                                    <p>
-                                                        Optional second URL to also receive this connection&apos;s webhooks. Only used when a primary override
-                                                        URL is set.
-                                                    </p>
-                                                }
-                                            >
-                                                Override secondary webhook URL
-                                            </FormLabelWithTooltip>
-                                            <FormControl>
-                                                <Input placeholder="https://example.com/webhooks-from-nango" {...field} />
-                                            </FormControl>
-                                            <FormMessage />
-                                        </FormItem>
-                                    )}
-                                />
                                 {showDocsOverrideField && (
                                     <FormField
                                         control={control}

--- a/packages/webapp/src/pages/Connection/components/ConnectionAdvancedConfig.tsx
+++ b/packages/webapp/src/pages/Connection/components/ConnectionAdvancedConfig.tsx
@@ -290,6 +290,50 @@ export const ConnectionAdvancedConfig: React.FC<ConnectionAdvancedConfigProps> =
                                                     </FormItem>
                                                 )}
                                             />
+                                            <FormField
+                                                control={control}
+                                                name="overrideWebhookUrl"
+                                                render={({ field }) => (
+                                                    <FormItem>
+                                                        <FormLabelWithTooltip
+                                                            tooltip={
+                                                                <p>
+                                                                    Deliver this connection&apos;s webhooks to a different URL than the environment-wide
+                                                                    webhook URL. Useful for routing a single connection&apos;s events to a development tunnel.
+                                                                </p>
+                                                            }
+                                                        >
+                                                            Override webhook URL
+                                                        </FormLabelWithTooltip>
+                                                        <FormControl>
+                                                            <Input placeholder="https://example.com/webhooks-from-nango" {...field} />
+                                                        </FormControl>
+                                                        <FormMessage />
+                                                    </FormItem>
+                                                )}
+                                            />
+                                            <FormField
+                                                control={control}
+                                                name="overrideWebhookUrlSecondary"
+                                                render={({ field }) => (
+                                                    <FormItem>
+                                                        <FormLabelWithTooltip
+                                                            tooltip={
+                                                                <p>
+                                                                    Optional second URL to also receive this connection&apos;s webhooks. Only used when a
+                                                                    primary override URL is set.
+                                                                </p>
+                                                            }
+                                                        >
+                                                            Override secondary webhook URL
+                                                        </FormLabelWithTooltip>
+                                                        <FormControl>
+                                                            <Input placeholder="https://example.com/webhooks-from-nango" {...field} />
+                                                        </FormControl>
+                                                        <FormMessage />
+                                                    </FormItem>
+                                                )}
+                                            />
                                         </>
                                     )}
                                     {showDocsOverrideField && (

--- a/packages/webapp/src/pages/Connection/components/ConnectionAdvancedConfig.tsx
+++ b/packages/webapp/src/pages/Connection/components/ConnectionAdvancedConfig.tsx
@@ -183,172 +183,25 @@ export const ConnectionAdvancedConfig: React.FC<ConnectionAdvancedConfigProps> =
                             />
                         </div>
 
-                        {(isOauth2 || showDocsOverrideField) && (
-                            <>
-                                <Separator className="bg-border-muted" />
+                        <>
+                            <Separator className="bg-border-muted" />
 
-                                <div className="flex flex-col gap-5">
-                                    <h3 className="text-body-small-medium uppercase text-text-secondary">Overrides</h3>
-                                    {isOauth2 && (
-                                        <>
-                                            <FormField
-                                                control={control}
-                                                name="overrideAuthParams"
-                                                render={({ field }) => (
-                                                    <FormItem>
-                                                        <FormLabelWithTooltip
-                                                            tooltip={
-                                                                <p>
-                                                                    Query params passed to the OAuth flow (for OAuth2 only)
-                                                                    <br />
-                                                                    <StyledLink
-                                                                        to="https://nango.dev/docs/reference/backend/http-api/connect/sessions/create#body-integrations-config-defaults-additional-properties-authorization-params"
-                                                                        type="external"
-                                                                        size="sm"
-                                                                        icon
-                                                                    >
-                                                                        Documentation
-                                                                    </StyledLink>
-                                                                </p>
-                                                            }
-                                                        >
-                                                            Override authorization parameters
-                                                        </FormLabelWithTooltip>
-                                                        <KeyValueInput
-                                                            initialValues={field.value}
-                                                            onChange={field.onChange}
-                                                            placeholderKey="Param Name"
-                                                            placeholderValue="Param Value"
-                                                        />
-                                                    </FormItem>
-                                                )}
-                                            />
-                                            <FormField
-                                                control={control}
-                                                name="overrideDevAppCredentials"
-                                                render={({ field }) => (
-                                                    <FormItem>
-                                                        <FormLabelWithTooltip
-                                                            tooltip={
-                                                                <p>
-                                                                    Allow end users to provide their own OAuth client ID and secret.
-                                                                    <br />
-                                                                    <StyledLink
-                                                                        to="https://nango.dev/docs/reference/backend/http-api/connect/sessions/create#body-integrations-config-defaults-additional-properties-connection-config-oauth-client-id-override"
-                                                                        type="external"
-                                                                        size="sm"
-                                                                        icon
-                                                                    >
-                                                                        Documentation
-                                                                    </StyledLink>
-                                                                </p>
-                                                            }
-                                                        >
-                                                            Override developer app credentials
-                                                        </FormLabelWithTooltip>
-                                                        <BinaryToggle
-                                                            value={field.value}
-                                                            onChange={field.onChange}
-                                                            offLabel="No override"
-                                                            onLabel="End-user provided"
-                                                            offTooltip="Use the OAuth credentials configured in the integration settings"
-                                                            onTooltip="End users will provide their own OAuth client ID and secret"
-                                                        />
-                                                    </FormItem>
-                                                )}
-                                            />
-                                            <FormField
-                                                control={control}
-                                                name="overrideOauthScopes"
-                                                render={({ field }) => (
-                                                    <FormItem>
-                                                        <FormLabelWithTooltip
-                                                            tooltip={
-                                                                <p>
-                                                                    Override oauth scopes
-                                                                    <br />
-                                                                    <StyledLink
-                                                                        to="https://nango.dev/docs/reference/backend/http-api/connect/sessions/create#body-integrations-config-defaults-additional-properties-connection-config-oauth-scopes-override"
-                                                                        type="external"
-                                                                        size="sm"
-                                                                        icon
-                                                                    >
-                                                                        Documentation
-                                                                    </StyledLink>
-                                                                </p>
-                                                            }
-                                                        >
-                                                            Override OAuth scopes
-                                                        </FormLabelWithTooltip>
-                                                        <ScopesInput
-                                                            scopesString={field.value}
-                                                            onChange={(newScopes) => {
-                                                                field.onChange(newScopes);
-                                                                return Promise.resolve();
-                                                            }}
-                                                        />
-                                                    </FormItem>
-                                                )}
-                                            />
-                                            <FormField
-                                                control={control}
-                                                name="overrideWebhookUrl"
-                                                render={({ field }) => (
-                                                    <FormItem>
-                                                        <FormLabelWithTooltip
-                                                            tooltip={
-                                                                <p>
-                                                                    Deliver this connection&apos;s webhooks to a different URL than the environment-wide
-                                                                    webhook URL. Useful for routing a single connection&apos;s events to a development tunnel.
-                                                                </p>
-                                                            }
-                                                        >
-                                                            Override webhook URL
-                                                        </FormLabelWithTooltip>
-                                                        <FormControl>
-                                                            <Input placeholder="https://example.com/webhooks-from-nango" {...field} />
-                                                        </FormControl>
-                                                        <FormMessage />
-                                                    </FormItem>
-                                                )}
-                                            />
-                                            <FormField
-                                                control={control}
-                                                name="overrideWebhookUrlSecondary"
-                                                render={({ field }) => (
-                                                    <FormItem>
-                                                        <FormLabelWithTooltip
-                                                            tooltip={
-                                                                <p>
-                                                                    Optional second URL to also receive this connection&apos;s webhooks. Only used when a
-                                                                    primary override URL is set.
-                                                                </p>
-                                                            }
-                                                        >
-                                                            Override secondary webhook URL
-                                                        </FormLabelWithTooltip>
-                                                        <FormControl>
-                                                            <Input placeholder="https://example.com/webhooks-from-nango" {...field} />
-                                                        </FormControl>
-                                                        <FormMessage />
-                                                    </FormItem>
-                                                )}
-                                            />
-                                        </>
-                                    )}
-                                    {showDocsOverrideField && (
+                            <div className="flex flex-col gap-5">
+                                <h3 className="text-body-small-medium uppercase text-text-secondary">Overrides</h3>
+                                {isOauth2 && (
+                                    <>
                                         <FormField
                                             control={control}
-                                            name="overrideDocUrl"
+                                            name="overrideAuthParams"
                                             render={({ field }) => (
                                                 <FormItem>
                                                     <FormLabelWithTooltip
                                                         tooltip={
                                                             <p>
-                                                                Override the documentation URL we show on the Connect UI for this connection.
+                                                                Query params passed to the OAuth flow (for OAuth2 only)
                                                                 <br />
                                                                 <StyledLink
-                                                                    to="https://nango.dev/docs/reference/backend/http-api/connect/sessions/create#body-overrides-additional-properties-docs-connect"
+                                                                    to="https://nango.dev/docs/reference/backend/http-api/connect/sessions/create#body-integrations-config-defaults-additional-properties-authorization-params"
                                                                     type="external"
                                                                     size="sm"
                                                                     icon
@@ -358,19 +211,164 @@ export const ConnectionAdvancedConfig: React.FC<ConnectionAdvancedConfigProps> =
                                                             </p>
                                                         }
                                                     >
-                                                        Override end-user documentation URL
+                                                        Override authorization parameters
                                                     </FormLabelWithTooltip>
-                                                    <FormControl>
-                                                        <Input placeholder="https://example.com/docs" {...field} />
-                                                    </FormControl>
-                                                    <FormMessage />
+                                                    <KeyValueInput
+                                                        initialValues={field.value}
+                                                        onChange={field.onChange}
+                                                        placeholderKey="Param Name"
+                                                        placeholderValue="Param Value"
+                                                    />
                                                 </FormItem>
                                             )}
                                         />
+                                        <FormField
+                                            control={control}
+                                            name="overrideDevAppCredentials"
+                                            render={({ field }) => (
+                                                <FormItem>
+                                                    <FormLabelWithTooltip
+                                                        tooltip={
+                                                            <p>
+                                                                Allow end users to provide their own OAuth client ID and secret.
+                                                                <br />
+                                                                <StyledLink
+                                                                    to="https://nango.dev/docs/reference/backend/http-api/connect/sessions/create#body-integrations-config-defaults-additional-properties-connection-config-oauth-client-id-override"
+                                                                    type="external"
+                                                                    size="sm"
+                                                                    icon
+                                                                >
+                                                                    Documentation
+                                                                </StyledLink>
+                                                            </p>
+                                                        }
+                                                    >
+                                                        Override developer app credentials
+                                                    </FormLabelWithTooltip>
+                                                    <BinaryToggle
+                                                        value={field.value}
+                                                        onChange={field.onChange}
+                                                        offLabel="No override"
+                                                        onLabel="End-user provided"
+                                                        offTooltip="Use the OAuth credentials configured in the integration settings"
+                                                        onTooltip="End users will provide their own OAuth client ID and secret"
+                                                    />
+                                                </FormItem>
+                                            )}
+                                        />
+                                        <FormField
+                                            control={control}
+                                            name="overrideOauthScopes"
+                                            render={({ field }) => (
+                                                <FormItem>
+                                                    <FormLabelWithTooltip
+                                                        tooltip={
+                                                            <p>
+                                                                Override oauth scopes
+                                                                <br />
+                                                                <StyledLink
+                                                                    to="https://nango.dev/docs/reference/backend/http-api/connect/sessions/create#body-integrations-config-defaults-additional-properties-connection-config-oauth-scopes-override"
+                                                                    type="external"
+                                                                    size="sm"
+                                                                    icon
+                                                                >
+                                                                    Documentation
+                                                                </StyledLink>
+                                                            </p>
+                                                        }
+                                                    >
+                                                        Override OAuth scopes
+                                                    </FormLabelWithTooltip>
+                                                    <ScopesInput
+                                                        scopesString={field.value}
+                                                        onChange={(newScopes) => {
+                                                            field.onChange(newScopes);
+                                                            return Promise.resolve();
+                                                        }}
+                                                    />
+                                                </FormItem>
+                                            )}
+                                        />
+                                    </>
+                                )}
+                                <FormField
+                                    control={control}
+                                    name="overrideWebhookUrl"
+                                    render={({ field }) => (
+                                        <FormItem>
+                                            <FormLabelWithTooltip
+                                                tooltip={
+                                                    <p>
+                                                        Deliver this connection&apos;s webhooks to a different URL than the environment-wide webhook URL. Useful
+                                                        for routing a single connection&apos;s events to a development tunnel.
+                                                    </p>
+                                                }
+                                            >
+                                                Override webhook URL
+                                            </FormLabelWithTooltip>
+                                            <FormControl>
+                                                <Input placeholder="https://example.com/webhooks-from-nango" {...field} />
+                                            </FormControl>
+                                            <FormMessage />
+                                        </FormItem>
                                     )}
-                                </div>
-                            </>
-                        )}
+                                />
+                                <FormField
+                                    control={control}
+                                    name="overrideWebhookUrlSecondary"
+                                    render={({ field }) => (
+                                        <FormItem>
+                                            <FormLabelWithTooltip
+                                                tooltip={
+                                                    <p>
+                                                        Optional second URL to also receive this connection&apos;s webhooks. Only used when a primary override
+                                                        URL is set.
+                                                    </p>
+                                                }
+                                            >
+                                                Override secondary webhook URL
+                                            </FormLabelWithTooltip>
+                                            <FormControl>
+                                                <Input placeholder="https://example.com/webhooks-from-nango" {...field} />
+                                            </FormControl>
+                                            <FormMessage />
+                                        </FormItem>
+                                    )}
+                                />
+                                {showDocsOverrideField && (
+                                    <FormField
+                                        control={control}
+                                        name="overrideDocUrl"
+                                        render={({ field }) => (
+                                            <FormItem>
+                                                <FormLabelWithTooltip
+                                                    tooltip={
+                                                        <p>
+                                                            Override the documentation URL we show on the Connect UI for this connection.
+                                                            <br />
+                                                            <StyledLink
+                                                                to="https://nango.dev/docs/reference/backend/http-api/connect/sessions/create#body-overrides-additional-properties-docs-connect"
+                                                                type="external"
+                                                                size="sm"
+                                                                icon
+                                                            >
+                                                                Documentation
+                                                            </StyledLink>
+                                                        </p>
+                                                    }
+                                                >
+                                                    Override end-user documentation URL
+                                                </FormLabelWithTooltip>
+                                                <FormControl>
+                                                    <Input placeholder="https://example.com/docs" {...field} />
+                                                </FormControl>
+                                                <FormMessage />
+                                            </FormItem>
+                                        )}
+                                    />
+                                )}
+                            </div>
+                        </>
                     </CardContent>
                 </CollapsibleContent>
             </Collapsible>

--- a/packages/webapp/src/pages/Connection/components/CreateConnectionSelector.tsx
+++ b/packages/webapp/src/pages/Connection/components/CreateConnectionSelector.tsx
@@ -42,6 +42,8 @@ interface CreateConnectionSelectorProps {
     overrideClientId: string | undefined;
     overrideClientSecret: string | undefined;
     overrideDocUrl: string | undefined;
+    overrideWebhookUrl: string | undefined;
+    overrideWebhookUrlSecondary: string | undefined;
     defaultDocUrl?: string;
     isFormValid?: boolean;
 }
@@ -58,6 +60,8 @@ export const CreateConnectionSelector: React.FC<CreateConnectionSelectorProps> =
     overrideClientId,
     overrideClientSecret,
     overrideDocUrl,
+    overrideWebhookUrl,
+    overrideWebhookUrlSecondary,
     defaultDocUrl,
     isFormValid = true
 }) => {
@@ -122,7 +126,10 @@ export const CreateConnectionSelector: React.FC<CreateConnectionSelectorProps> =
         const isOauth2 = integration && ['OAUTH2', 'OAUTH2_CC', 'MCP_OAUTH2', 'MCP_OAUTH2_GENERIC'].includes(integration.meta.authMode);
 
         const oauthScopesOverride = overrideOauthScopes !== undefined && overrideOauthScopes !== integration?.oauth_scopes ? overrideOauthScopes : undefined;
-        const hasConnectionConfigOverrides = overrideClientId !== undefined || overrideClientSecret !== undefined || oauthScopesOverride !== undefined;
+        const webhookUrl = overrideWebhookUrl?.trim() ? overrideWebhookUrl.trim() : undefined;
+        const webhookUrlSecondary = webhookUrl && overrideWebhookUrlSecondary?.trim() ? overrideWebhookUrlSecondary.trim() : undefined;
+        const hasConnectionConfigOverrides =
+            overrideClientId !== undefined || overrideClientSecret !== undefined || oauthScopesOverride !== undefined || webhookUrl !== undefined;
         const shouldSendDocsConnect = overrideDocUrl && overrideDocUrl !== defaultDocUrl;
 
         return await apiConnectSessions(env, {
@@ -137,7 +144,9 @@ export const CreateConnectionSelector: React.FC<CreateConnectionSelectorProps> =
                                   ? {
                                         oauth_client_id_override: overrideClientId,
                                         oauth_client_secret_override: overrideClientSecret,
-                                        oauth_scopes_override: oauthScopesOverride
+                                        oauth_scopes_override: oauthScopesOverride,
+                                        webhook_url: webhookUrl,
+                                        webhook_url_secondary: webhookUrlSecondary
                                     }
                                   : undefined
                       }
@@ -151,7 +160,19 @@ export const CreateConnectionSelector: React.FC<CreateConnectionSelectorProps> =
                   }
                 : undefined
         });
-    }, [integration, overrideOauthScopes, overrideClientId, overrideClientSecret, overrideDocUrl, defaultDocUrl, env, testUser, overrideAuthParams]);
+    }, [
+        integration,
+        overrideOauthScopes,
+        overrideClientId,
+        overrideClientSecret,
+        overrideDocUrl,
+        overrideWebhookUrl,
+        overrideWebhookUrlSecondary,
+        defaultDocUrl,
+        env,
+        testUser,
+        overrideAuthParams
+    ]);
 
     const onClickConnectUI = () => {
         if (!environmentAndAccount) {

--- a/packages/webapp/src/pages/Connection/components/CreateConnectionSelector.tsx
+++ b/packages/webapp/src/pages/Connection/components/CreateConnectionSelector.tsx
@@ -128,9 +128,21 @@ export const CreateConnectionSelector: React.FC<CreateConnectionSelectorProps> =
         const oauthScopesOverride = overrideOauthScopes !== undefined && overrideOauthScopes !== integration?.oauth_scopes ? overrideOauthScopes : undefined;
         const webhookUrl = overrideWebhookUrl?.trim() ? overrideWebhookUrl.trim() : undefined;
         const webhookUrlSecondary = webhookUrl && overrideWebhookUrlSecondary?.trim() ? overrideWebhookUrlSecondary.trim() : undefined;
-        const hasConnectionConfigOverrides =
-            overrideClientId !== undefined || overrideClientSecret !== undefined || oauthScopesOverride !== undefined || webhookUrl !== undefined;
         const shouldSendDocsConnect = overrideDocUrl && overrideDocUrl !== defaultDocUrl;
+
+        // OAuth client/scope overrides only apply to OAuth flows; webhook URL overrides apply to every auth type.
+        const oauthConfigOverrides =
+            isOauth2 && (overrideClientId !== undefined || overrideClientSecret !== undefined || oauthScopesOverride !== undefined)
+                ? {
+                      oauth_client_id_override: overrideClientId,
+                      oauth_client_secret_override: overrideClientSecret,
+                      oauth_scopes_override: oauthScopesOverride
+                  }
+                : undefined;
+        const connectionConfig =
+            oauthConfigOverrides || webhookUrl
+                ? { ...oauthConfigOverrides, ...(webhookUrl ? { webhook_url: webhookUrl, webhook_url_secondary: webhookUrlSecondary } : {}) }
+                : undefined;
 
         return await apiConnectSessions(env, {
             allowed_integrations: integration ? [integration.unique_key] : undefined,
@@ -139,16 +151,7 @@ export const CreateConnectionSelector: React.FC<CreateConnectionSelectorProps> =
                 ? {
                       [integration.unique_key]: {
                           authorization_params: isOauth2 && overrideAuthParams && Object.keys(overrideAuthParams).length > 0 ? overrideAuthParams : undefined,
-                          connection_config:
-                              isOauth2 && hasConnectionConfigOverrides
-                                  ? {
-                                        oauth_client_id_override: overrideClientId,
-                                        oauth_client_secret_override: overrideClientSecret,
-                                        oauth_scopes_override: oauthScopesOverride,
-                                        webhook_url: webhookUrl,
-                                        webhook_url_secondary: webhookUrlSecondary
-                                    }
-                                  : undefined
+                          connection_config: connectionConfig
                       }
                   }
                 : undefined,

--- a/packages/webapp/src/pages/Connection/components/CreateConnectionSelector.tsx
+++ b/packages/webapp/src/pages/Connection/components/CreateConnectionSelector.tsx
@@ -43,7 +43,6 @@ interface CreateConnectionSelectorProps {
     overrideClientSecret: string | undefined;
     overrideDocUrl: string | undefined;
     overrideWebhookUrl: string | undefined;
-    overrideWebhookUrlSecondary: string | undefined;
     defaultDocUrl?: string;
     isFormValid?: boolean;
 }
@@ -61,7 +60,6 @@ export const CreateConnectionSelector: React.FC<CreateConnectionSelectorProps> =
     overrideClientSecret,
     overrideDocUrl,
     overrideWebhookUrl,
-    overrideWebhookUrlSecondary,
     defaultDocUrl,
     isFormValid = true
 }) => {
@@ -127,7 +125,6 @@ export const CreateConnectionSelector: React.FC<CreateConnectionSelectorProps> =
 
         const oauthScopesOverride = overrideOauthScopes !== undefined && overrideOauthScopes !== integration?.oauth_scopes ? overrideOauthScopes : undefined;
         const webhookUrl = overrideWebhookUrl?.trim() ? overrideWebhookUrl.trim() : undefined;
-        const webhookUrlSecondary = webhookUrl && overrideWebhookUrlSecondary?.trim() ? overrideWebhookUrlSecondary.trim() : undefined;
         const shouldSendDocsConnect = overrideDocUrl && overrideDocUrl !== defaultDocUrl;
 
         // OAuth client/scope overrides only apply to OAuth flows; webhook URL overrides apply to every auth type.
@@ -140,9 +137,7 @@ export const CreateConnectionSelector: React.FC<CreateConnectionSelectorProps> =
                   }
                 : undefined;
         const connectionConfig =
-            oauthConfigOverrides || webhookUrl
-                ? { ...oauthConfigOverrides, ...(webhookUrl ? { webhook_url: webhookUrl, webhook_url_secondary: webhookUrlSecondary } : {}) }
-                : undefined;
+            oauthConfigOverrides || webhookUrl ? { ...oauthConfigOverrides, ...(webhookUrl ? { webhook_url: webhookUrl } : {}) } : undefined;
 
         return await apiConnectSessions(env, {
             allowed_integrations: integration ? [integration.unique_key] : undefined,
@@ -170,7 +165,6 @@ export const CreateConnectionSelector: React.FC<CreateConnectionSelectorProps> =
         overrideClientSecret,
         overrideDocUrl,
         overrideWebhookUrl,
-        overrideWebhookUrlSecondary,
         defaultDocUrl,
         env,
         testUser,

--- a/packages/webhooks/lib/asyncAction.ts
+++ b/packages/webhooks/lib/asyncAction.ts
@@ -1,15 +1,16 @@
 import { metrics } from '@nangohq/utils';
 
-import { deliver, shouldSend } from './utils.js';
+import { deliver, resolveWebhookSettings, shouldSend } from './utils.js';
 
 import type { LogContext } from '@nangohq/logs';
-import type { AsyncActionResponse, DBAPISecret, DBExternalWebhook, NangoAsyncActionWebhookBody } from '@nangohq/types';
+import type { AsyncActionResponse, ConnectionConfig, DBAPISecret, DBExternalWebhook, NangoAsyncActionWebhookBody } from '@nangohq/types';
 
 export const sendAsyncActionWebhook = async ({
     secret,
     connectionId,
     providerConfigKey,
     webhookSettings,
+    connectionConfig,
     payload,
     logCtx
 }: {
@@ -17,6 +18,7 @@ export const sendAsyncActionWebhook = async ({
     connectionId: string;
     providerConfigKey: string;
     webhookSettings: DBExternalWebhook | null;
+    connectionConfig: Pick<ConnectionConfig, 'webhook_url'> | null;
     payload: AsyncActionResponse;
     logCtx: LogContext;
 }): Promise<void> => {
@@ -24,7 +26,9 @@ export const sendAsyncActionWebhook = async ({
         return;
     }
 
-    if (!shouldSend({ success: true, type: 'async_action', webhookSettings })) {
+    const settings = resolveWebhookSettings(webhookSettings, connectionConfig);
+
+    if (!shouldSend({ success: true, type: 'async_action', webhookSettings: settings })) {
         return;
     }
 
@@ -37,8 +41,8 @@ export const sendAsyncActionWebhook = async ({
     };
 
     const webhooks = [
-        { url: webhookSettings.primary_url, type: 'webhook url' },
-        { url: webhookSettings.secondary_url, type: 'secondary webhook url' }
+        { url: settings.primary_url, type: 'webhook url' },
+        { url: settings.secondary_url, type: 'secondary webhook url' }
     ].filter((webhook) => webhook.url) as { url: string; type: string }[];
 
     const result = await deliver({

--- a/packages/webhooks/lib/asyncAction.unit.test.ts
+++ b/packages/webhooks/lib/asyncAction.unit.test.ts
@@ -53,6 +53,7 @@ describe('AsyncAction webhooks', () => {
             connectionId: '123',
             secret,
             providerConfigKey: 'some-provider',
+            connectionConfig: null,
             webhookSettings: {
                 ...webhookSettings,
                 on_async_action_completion: false
@@ -72,6 +73,7 @@ describe('AsyncAction webhooks', () => {
             connectionId: '123',
             secret,
             providerConfigKey: 'some-provider',
+            connectionConfig: null,
             webhookSettings: {
                 ...webhookSettings,
                 on_async_action_completion: true
@@ -96,5 +98,25 @@ describe('AsyncAction webhooks', () => {
             payload: props.payload,
             providerConfigKey: props.providerConfigKey
         });
+    });
+
+    it('sends only to the per-connection webhook URL override (env secondary is dropped)', async () => {
+        const logCtx = await logContextGetter.create(
+            { operation: { type: 'sync', action: 'run' } },
+            { account: { id: environment.account_id, name: '' }, environment: { id: environment.id, name: environment.name } }
+        );
+
+        await sendAsyncActionWebhook({
+            connectionId: '123',
+            secret,
+            providerConfigKey: 'some-provider',
+            connectionConfig: { webhook_url: testServer.overrideUrl },
+            webhookSettings,
+            payload: { id: '00000000-0000-0000-0000-000000000000', statusUrl: '/action/00000000-0000-0000-0000-000000000000' },
+            logCtx
+        });
+
+        expect(spy).toHaveBeenCalledTimes(1);
+        expect(spy).toHaveBeenCalledWith(testServer.overrideUrl, expect.any(String), expect.anything());
     });
 });

--- a/packages/webhooks/lib/asyncAction.unit.test.ts
+++ b/packages/webhooks/lib/asyncAction.unit.test.ts
@@ -106,17 +106,18 @@ describe('AsyncAction webhooks', () => {
             { account: { id: environment.account_id, name: '' }, environment: { id: environment.id, name: environment.name } }
         );
 
+        const overrideUrl = 'https://override.example.com/hook';
         await sendAsyncActionWebhook({
             connectionId: '123',
             secret,
             providerConfigKey: 'some-provider',
-            connectionConfig: { webhook_url: testServer.overrideUrl },
+            connectionConfig: { webhook_url: overrideUrl },
             webhookSettings,
             payload: { id: '00000000-0000-0000-0000-000000000000', statusUrl: '/action/00000000-0000-0000-0000-000000000000' },
             logCtx
         });
 
-        expect(spy).toHaveBeenCalledTimes(1);
-        expect(spy).toHaveBeenCalledWith(testServer.overrideUrl, expect.any(String), expect.anything());
+        expect(deliverMock).toHaveBeenCalledTimes(1);
+        expect(deliverMock.mock.calls[0]![0].webhooks).toEqual([{ url: overrideUrl, type: 'webhook url' }]);
     });
 });

--- a/packages/webhooks/lib/auth.ts
+++ b/packages/webhooks/lib/auth.ts
@@ -1,7 +1,7 @@
 import { logContextGetter, OtlpSpan } from '@nangohq/logs';
 import { metrics } from '@nangohq/utils';
 
-import { deliver, shouldSend } from './utils.js';
+import { deliver, resolveWebhookSettings, shouldSend } from './utils.js';
 
 import type {
     AuthModeType,
@@ -54,11 +54,13 @@ export async function sendAuth({
         return;
     }
 
+    const settings = resolveWebhookSettings(webhookSettings, 'connection_config' in connection ? connection.connection_config : null);
+
     if (operation === 'unknown') {
         return;
     }
 
-    if (!shouldSend({ success, type: AUTH_OPERATION_TO_TYPE[operation], webhookSettings })) {
+    if (!shouldSend({ success, type: AUTH_OPERATION_TO_TYPE[operation], webhookSettings: settings })) {
         return;
     }
 
@@ -99,11 +101,11 @@ export async function sendAuth({
     }
 
     const webhooks: { url: string; type: string }[] = [];
-    if (webhookSettings.primary_url) {
-        webhooks.push({ url: webhookSettings.primary_url, type: 'webhook url' });
+    if (settings.primary_url) {
+        webhooks.push({ url: settings.primary_url, type: 'webhook url' });
     }
-    if (webhookSettings.secondary_url) {
-        webhooks.push({ url: webhookSettings.secondary_url, type: 'secondary webhook url' });
+    if (settings.secondary_url) {
+        webhooks.push({ url: settings.secondary_url, type: 'secondary webhook url' });
     }
 
     const action = operation === 'creation' ? 'connection_create' : 'connection_refresh';

--- a/packages/webhooks/lib/auth.unit.test.ts
+++ b/packages/webhooks/lib/auth.unit.test.ts
@@ -319,6 +319,31 @@ describe('Webhooks: auth notification tests', () => {
         });
     });
 
+    it('sends only to the per-connection webhook URL override (env secondary is dropped)', async () => {
+        const connectionWithOverride = { ...connection, connection_config: { webhook_url: testServer.overrideUrl } };
+
+        await sendAuth({
+            connection: connectionWithOverride,
+            success: true,
+            environment: {
+                name: 'dev',
+                id: 1
+            } as DBEnvironment,
+            secret,
+            webhookSettings: {
+                ...webhookSettings,
+                on_auth_creation: true
+            },
+            providerConfig,
+            account,
+            auth_mode: 'OAUTH2',
+            operation: 'creation'
+        });
+
+        expect(spy).toHaveBeenCalledTimes(1);
+        expect(spy).toHaveBeenCalledWith(testServer.overrideUrl, expect.any(String), expect.anything());
+    });
+
     describe('tags', () => {
         it('Should include connection tags in webhook body', async () => {
             const tags: Tags = { department: 'engineering', priority: 'high' };

--- a/packages/webhooks/lib/auth.unit.test.ts
+++ b/packages/webhooks/lib/auth.unit.test.ts
@@ -320,7 +320,8 @@ describe('Webhooks: auth notification tests', () => {
     });
 
     it('sends only to the per-connection webhook URL override (env secondary is dropped)', async () => {
-        const connectionWithOverride = { ...connection, connection_config: { webhook_url: testServer.overrideUrl } };
+        const overrideUrl = 'https://override.example.com/hook';
+        const connectionWithOverride = { ...connection, connection_config: { webhook_url: overrideUrl } };
 
         await sendAuth({
             connection: connectionWithOverride,
@@ -340,12 +341,13 @@ describe('Webhooks: auth notification tests', () => {
             operation: 'creation'
         });
 
-        expect(spy).toHaveBeenCalledTimes(1);
-        expect(spy).toHaveBeenCalledWith(testServer.overrideUrl, expect.any(String), expect.anything());
+        expect(deliverMock).toHaveBeenCalledTimes(1);
+        expect(deliverMock.mock.calls[0]![0].webhooks).toEqual([{ url: overrideUrl, type: 'webhook url' }]);
     });
 
     it('routes a connection-creation failure webhook to the per-connection override URL', async () => {
-        const connectionWithOverride = { ...connection, connection_config: { webhook_url: testServer.overrideUrl } };
+        const overrideUrl = 'https://override.example.com/hook';
+        const connectionWithOverride = { ...connection, connection_config: { webhook_url: overrideUrl } };
 
         await sendAuth({
             connection: connectionWithOverride,
@@ -366,8 +368,8 @@ describe('Webhooks: auth notification tests', () => {
             operation: 'creation'
         });
 
-        expect(spy).toHaveBeenCalledTimes(1);
-        expect(spy).toHaveBeenCalledWith(testServer.overrideUrl, expect.any(String), expect.anything());
+        expect(deliverMock).toHaveBeenCalledTimes(1);
+        expect(deliverMock.mock.calls[0]![0].webhooks).toEqual([{ url: overrideUrl, type: 'webhook url' }]);
     });
 
     describe('tags', () => {

--- a/packages/webhooks/lib/auth.unit.test.ts
+++ b/packages/webhooks/lib/auth.unit.test.ts
@@ -344,6 +344,32 @@ describe('Webhooks: auth notification tests', () => {
         expect(spy).toHaveBeenCalledWith(testServer.overrideUrl, expect.any(String), expect.anything());
     });
 
+    it('routes a connection-creation failure webhook to the per-connection override URL', async () => {
+        const connectionWithOverride = { ...connection, connection_config: { webhook_url: testServer.overrideUrl } };
+
+        await sendAuth({
+            connection: connectionWithOverride,
+            success: false,
+            error: { type: 'error', description: 'creation failed' },
+            environment: {
+                name: 'dev',
+                id: 1
+            } as DBEnvironment,
+            secret,
+            webhookSettings: {
+                ...webhookSettings,
+                on_auth_creation: true
+            },
+            providerConfig,
+            account,
+            auth_mode: 'OAUTH2',
+            operation: 'creation'
+        });
+
+        expect(spy).toHaveBeenCalledTimes(1);
+        expect(spy).toHaveBeenCalledWith(testServer.overrideUrl, expect.any(String), expect.anything());
+    });
+
     describe('tags', () => {
         it('Should include connection tags in webhook body', async () => {
             const tags: Tags = { department: 'engineering', priority: 'high' };

--- a/packages/webhooks/lib/forward.ts
+++ b/packages/webhooks/lib/forward.ts
@@ -83,6 +83,7 @@ export const forwardWebhook = async ({
 
     if (!connectionIds || connectionIds.length === 0) {
         if (!shouldSend({ success: true, type: 'forward', webhookSettings })) {
+            await logCtx.success();
             return Ok({ results: [] });
         }
         const webhooks = toWebhooks(webhookSettings);

--- a/packages/webhooks/lib/forward.ts
+++ b/packages/webhooks/lib/forward.ts
@@ -1,11 +1,20 @@
 import { OtlpSpan } from '@nangohq/logs';
 import { Err, getLogger, metrics, Ok } from '@nangohq/utils';
 
-import { deliver, shouldSend } from './utils.js';
+import { deliver, resolveWebhookSettings, shouldSend } from './utils.js';
 
 import type { LogContextGetter } from '@nangohq/logs';
 import type { MeteredBytes } from '@nangohq/shared';
-import type { DBAPISecret, DBEnvironment, DBExternalWebhook, DBTeam, IntegrationConfig, NangoForwardWebhookBody, Result } from '@nangohq/types';
+import type {
+    ConnectionConfig,
+    DBAPISecret,
+    DBEnvironment,
+    DBExternalWebhook,
+    DBTeam,
+    IntegrationConfig,
+    NangoForwardWebhookBody,
+    Result
+} from '@nangohq/types';
 
 const logger = getLogger('webhooks.forward');
 
@@ -16,6 +25,7 @@ export const forwardWebhook = async ({
     secret,
     webhookSettings,
     connectionIds,
+    connectionConfigByConnectionId,
     payload,
     webhookOriginalHeaders,
     logContextGetter,
@@ -27,6 +37,7 @@ export const forwardWebhook = async ({
     secret: DBAPISecret['secret'];
     webhookSettings: DBExternalWebhook | null;
     connectionIds: string[];
+    connectionConfigByConnectionId: Map<string, Pick<ConnectionConfig, 'webhook_url'>>;
     payload: Record<string, any> | null;
     webhookOriginalHeaders: Record<string, string>;
     logContextGetter: LogContextGetter;
@@ -41,9 +52,6 @@ export const forwardWebhook = async ({
     };
 
     if (!webhookSettings) {
-        return Ok({ results: [] });
-    }
-    if (!shouldSend({ success: true, type: 'forward', webhookSettings })) {
         return Ok({ results: [] });
     }
     if (!integration.forward_webhooks) {
@@ -67,12 +75,17 @@ export const forwardWebhook = async ({
         payload: payload
     };
 
-    const webhooks = [
-        { url: webhookSettings.primary_url, type: 'webhook url' },
-        { url: webhookSettings.secondary_url, type: 'secondary webhook url' }
-    ].filter((webhook) => webhook.url) as { url: string; type: string }[];
+    const toWebhooks = (settings: DBExternalWebhook): { url: string; type: string }[] =>
+        [
+            { url: settings.primary_url, type: 'webhook url' },
+            { url: settings.secondary_url, type: 'secondary webhook url' }
+        ].filter((webhook) => webhook.url) as { url: string; type: string }[];
 
     if (!connectionIds || connectionIds.length === 0) {
+        if (!shouldSend({ success: true, type: 'forward', webhookSettings })) {
+            return Ok({ results: [] });
+        }
+        const webhooks = toWebhooks(webhookSettings);
         const deliverBytes: MeteredBytes = { sent: 0, received: 0 };
         const result = await deliver({
             webhooks,
@@ -102,6 +115,14 @@ export const forwardWebhook = async ({
     let success = true;
     const results: { connectionId: string; success: boolean }[] = [];
     for (const connectionId of connectionIds) {
+        // Resolve the per-connection webhook URL override (if any) so a connection's forwarded webhooks
+        // honor it, just like its sync/auth/action webhooks.
+        const settings = resolveWebhookSettings(webhookSettings, connectionConfigByConnectionId.get(connectionId) ?? null);
+        if (!shouldSend({ success: true, type: 'forward', webhookSettings: settings })) {
+            continue;
+        }
+        const webhooks = toWebhooks(settings);
+
         const deliverBytes: MeteredBytes = { sent: 0, received: 0 };
         const result = await deliver({
             webhooks,

--- a/packages/webhooks/lib/forward.unit.test.ts
+++ b/packages/webhooks/lib/forward.unit.test.ts
@@ -84,6 +84,29 @@ describe('Webhooks: forward notification tests', () => {
         expect(deliverMock).not.toHaveBeenCalled();
     });
 
+    it('closes the log context when there is no URL to send to (no leaked open operation)', async () => {
+        const logCtx = { attachSpan: vi.fn(), success: vi.fn().mockResolvedValue(undefined), failed: vi.fn().mockResolvedValue(undefined) };
+        const createSpy = vi.spyOn(logContextGetter, 'create').mockResolvedValue(logCtx as unknown as Awaited<ReturnType<typeof logContextGetter.create>>);
+
+        await forwardWebhook({
+            connectionIds: [],
+            connectionConfigByConnectionId: new Map(),
+            account,
+            environment: { name: 'dev', id: 1 } as DBEnvironment,
+            secret,
+            webhookSettings: { ...webhookSettings, primary_url: '', secondary_url: '' },
+            logContextGetter,
+            integration,
+            payload: { some: 'data' },
+            webhookOriginalHeaders: {}
+        });
+
+        expect(deliverMock).not.toHaveBeenCalled();
+        expect(logCtx.success).toHaveBeenCalledTimes(1);
+        expect(logCtx.failed).not.toHaveBeenCalled();
+        createSpy.mockRestore();
+    });
+
     it('Should not send a forward webhook if forward_webhooks is false', async () => {
         await forwardWebhook({
             connectionIds: [],

--- a/packages/webhooks/lib/forward.unit.test.ts
+++ b/packages/webhooks/lib/forward.unit.test.ts
@@ -62,6 +62,7 @@ describe('Webhooks: forward notification tests', () => {
     it('Should not send a forward webhook if the webhook url is not present', async () => {
         await forwardWebhook({
             connectionIds: [],
+            connectionConfigByConnectionId: new Map(),
             account,
             environment: {
                 name: 'dev',
@@ -86,6 +87,7 @@ describe('Webhooks: forward notification tests', () => {
     it('Should not send a forward webhook if forward_webhooks is false', async () => {
         await forwardWebhook({
             connectionIds: [],
+            connectionConfigByConnectionId: new Map(),
             account,
             environment: {
                 name: 'dev',
@@ -109,6 +111,7 @@ describe('Webhooks: forward notification tests', () => {
     it('Should send a forward webhook to the secondary url if the primary is not present', async () => {
         await forwardWebhook({
             connectionIds: [],
+            connectionConfigByConnectionId: new Map(),
             account,
             environment: {
                 name: 'dev',
@@ -133,6 +136,7 @@ describe('Webhooks: forward notification tests', () => {
     it('Should deliver to both webhook urls in a single deliver call when both are present', async () => {
         await forwardWebhook({
             connectionIds: [],
+            connectionConfigByConnectionId: new Map(),
             account,
             environment: {
                 name: 'dev',
@@ -157,6 +161,7 @@ describe('Webhooks: forward notification tests', () => {
     it('Should call deliver once per connection when connectionIds are present', async () => {
         await forwardWebhook({
             connectionIds: ['1', '2'],
+            connectionConfigByConnectionId: new Map(),
             account,
             environment: {
                 name: 'dev',
@@ -186,6 +191,7 @@ describe('Webhooks: forward notification tests', () => {
         let reportedBytes: { sent: number; received: number } | undefined;
         const result = await forwardWebhook({
             connectionIds: [],
+            connectionConfigByConnectionId: new Map(),
             account,
             environment: { name: 'dev', id: 1 } as DBEnvironment,
             secret,
@@ -206,6 +212,7 @@ describe('Webhooks: forward notification tests', () => {
         let called = false;
         const result = await forwardWebhook({
             connectionIds: [],
+            connectionConfigByConnectionId: new Map(),
             account,
             environment: { name: 'dev', id: 1 } as DBEnvironment,
             secret,
@@ -228,6 +235,7 @@ describe('Webhooks: forward notification tests', () => {
         const calls: { connectionId: string; sent: number }[] = [];
         const result = await forwardWebhook({
             connectionIds,
+            connectionConfigByConnectionId: new Map(),
             account,
             environment: { name: 'dev', id: 1 } as DBEnvironment,
             secret,
@@ -248,5 +256,24 @@ describe('Webhooks: forward notification tests', () => {
             { connectionId: 'conn1', sent: 10 },
             { connectionId: 'conn2', sent: 10 }
         ]);
+    });
+
+    it('forwards to the per-connection webhook URL override (env secondary is dropped)', async () => {
+        const overrideUrl = 'https://override.example.com/hook';
+        await forwardWebhook({
+            connectionIds: ['conn1'],
+            connectionConfigByConnectionId: new Map([['conn1', { webhook_url: overrideUrl }]]),
+            account,
+            environment: { name: 'dev', id: 1 } as DBEnvironment,
+            secret,
+            webhookSettings,
+            logContextGetter,
+            integration,
+            payload: { some: 'data' },
+            webhookOriginalHeaders: {}
+        });
+
+        expect(deliverMock).toHaveBeenCalledTimes(1);
+        expect(deliverMock.mock.calls[0]![0].webhooks).toEqual([{ url: overrideUrl, type: 'webhook url' }]);
     });
 });

--- a/packages/webhooks/lib/helpers/test.ts
+++ b/packages/webhooks/lib/helpers/test.ts
@@ -8,10 +8,12 @@ export class TestWebhookServer {
     private server: http.Server | null = null;
     public readonly primaryUrl: string;
     public readonly secondaryUrl: string;
+    public readonly overrideUrl: string;
 
     constructor(private readonly port: number) {
         this.primaryUrl = `http://localhost:${port}/webhook`;
         this.secondaryUrl = `http://localhost:${port}/webhook-secondary`;
+        this.overrideUrl = `http://localhost:${port}/webhook-override`;
     }
 
     async start(): Promise<void> {

--- a/packages/webhooks/lib/index.ts
+++ b/packages/webhooks/lib/index.ts
@@ -4,6 +4,7 @@ export { sendAuth } from './auth.js';
 export { sendAsyncActionWebhook } from './asyncAction.js';
 
 export { forwardWebhook } from './forward.js';
+export { resolveWebhookSettings } from './utils.js';
 
 type SendSyncParams = Parameters<typeof sendSync>[0];
 

--- a/packages/webhooks/lib/sync.ts
+++ b/packages/webhooks/lib/sync.ts
@@ -4,10 +4,11 @@ import utc from 'dayjs/plugin/utc.js';
 import { logContextGetter, OtlpSpan } from '@nangohq/logs';
 import { metrics, Ok } from '@nangohq/utils';
 
-import { deliver, shouldSend } from './utils.js';
+import { deliver, resolveWebhookSettings, shouldSend } from './utils.js';
 
 import type {
     CheckpointRange,
+    ConnectionConfig,
     ConnectionJobs,
     DBAPISecret,
     DBEnvironment,
@@ -32,6 +33,7 @@ export const sendSync = async ({
     account,
     providerConfig,
     webhookSettings,
+    connectionConfig,
     syncConfig,
     syncVariant,
     model,
@@ -48,6 +50,7 @@ export const sendSync = async ({
     account: Pick<DBTeam, 'id' | 'name'>;
     providerConfig: IntegrationConfig;
     webhookSettings: DBExternalWebhook | null;
+    connectionConfig: Pick<ConnectionConfig, 'webhook_url'> | null;
     syncConfig: Pick<DBSyncConfig, 'id' | 'sync_name' | 'version'>;
     syncVariant: string;
     model: string;
@@ -62,7 +65,9 @@ export const sendSync = async ({
         return Ok(undefined);
     }
 
-    if (!shouldSend({ success, type: 'sync', webhookSettings })) {
+    const settings = resolveWebhookSettings(webhookSettings, connectionConfig);
+
+    if (!shouldSend({ success, type: 'sync', webhookSettings: settings })) {
         return Ok(undefined);
     }
 
@@ -101,7 +106,7 @@ export const sendSync = async ({
         const noChanges =
             responseResults?.added === 0 && responseResults?.updated === 0 && (responseResults.deleted === 0 || responseResults.deleted === undefined);
 
-        if (!webhookSettings.on_sync_completion_always && noChanges) {
+        if (!settings.on_sync_completion_always && noChanges) {
             void logCtx.info(`There were no added, updated, or deleted results for model ${model}. No webhook sent, as per your environment settings`);
             await logCtx.success();
 
@@ -135,8 +140,8 @@ export const sendSync = async ({
     }
 
     const webhooks = [
-        { url: webhookSettings.primary_url, type: 'primary' },
-        { url: webhookSettings.secondary_url, type: 'secondary' }
+        { url: settings.primary_url, type: 'primary' },
+        { url: settings.secondary_url, type: 'secondary' }
     ].filter((webhook) => webhook.url) as { url: string; type: string }[];
 
     const result = await deliver({

--- a/packages/webhooks/lib/sync.unit.test.ts
+++ b/packages/webhooks/lib/sync.unit.test.ts
@@ -104,6 +104,7 @@ describe('Webhooks: sync notification tests', () => {
         await sendSync({
             account,
             connection,
+            connectionConfig: null,
             environment: { name: 'dev', id: 1 } as DBEnvironment,
             secret,
             providerConfig,
@@ -129,6 +130,7 @@ describe('Webhooks: sync notification tests', () => {
         await sendSync({
             account,
             connection,
+            connectionConfig: null,
             environment: { name: 'dev', id: 1 } as DBEnvironment,
             secret,
             providerConfig,
@@ -154,6 +156,7 @@ describe('Webhooks: sync notification tests', () => {
         await sendSync({
             account,
             connection,
+            connectionConfig: null,
             environment: { name: 'dev', id: 1 } as DBEnvironment,
             secret,
             providerConfig,
@@ -178,6 +181,7 @@ describe('Webhooks: sync notification tests', () => {
         await sendSync({
             account,
             connection,
+            connectionConfig: null,
             environment: { name: 'dev', id: 1 } as DBEnvironment,
             secret,
             providerConfig,
@@ -202,6 +206,7 @@ describe('Webhooks: sync notification tests', () => {
         await sendSync({
             account,
             connection,
+            connectionConfig: null,
             environment: { name: 'dev', id: 1 } as DBEnvironment,
             secret,
             providerConfig,
@@ -226,6 +231,7 @@ describe('Webhooks: sync notification tests', () => {
         await sendSync({
             account,
             connection,
+            connectionConfig: null,
             environment: { name: 'dev', id: 1 } as DBEnvironment,
             secret,
             providerConfig,
@@ -250,6 +256,7 @@ describe('Webhooks: sync notification tests', () => {
         await sendSync({
             account,
             connection,
+            connectionConfig: null,
             environment: { name: 'dev', id: 1 } as DBEnvironment,
             secret,
             providerConfig,
@@ -279,6 +286,7 @@ describe('Webhooks: sync notification tests', () => {
         await sendSync({
             account,
             connection,
+            connectionConfig: null,
             environment: { name: 'dev', id: 1 } as DBEnvironment,
             secret,
             providerConfig,
@@ -310,6 +318,30 @@ describe('Webhooks: sync notification tests', () => {
         });
     });
 
+    it('sends only to the per-connection webhook URL override (env secondary is dropped)', async () => {
+        const responseResults = { added: 10, updated: 0, deleted: 0 };
+
+        await sendSync({
+            account,
+            connection,
+            connectionConfig: { webhook_url: testServer.overrideUrl },
+            environment: { name: 'dev', id: 1 } as DBEnvironment,
+            secret,
+            providerConfig,
+            syncConfig,
+            syncVariant: 'base',
+            model: 'model',
+            responseResults,
+            operation: 'INCREMENTAL',
+            now: new Date(),
+            success: true,
+            webhookSettings
+        });
+
+        expect(spy).toHaveBeenCalledTimes(1);
+        expect(spy).toHaveBeenCalledWith(testServer.overrideUrl, expect.any(String), expect.anything());
+    });
+
     it('Should not send an error webhook if the option is not checked', async () => {
         const error = {
             type: 'error',
@@ -319,6 +351,7 @@ describe('Webhooks: sync notification tests', () => {
         await sendSync({
             account,
             connection,
+            connectionConfig: null,
             environment: { name: 'dev', id: 1 } as DBEnvironment,
             secret,
             providerConfig,
@@ -347,6 +380,7 @@ describe('Webhooks: sync notification tests', () => {
         await sendSync({
             account,
             connection,
+            connectionConfig: null,
             environment: { name: 'dev', id: 1 } as DBEnvironment,
             secret,
             providerConfig,

--- a/packages/webhooks/lib/sync.unit.test.ts
+++ b/packages/webhooks/lib/sync.unit.test.ts
@@ -320,11 +320,12 @@ describe('Webhooks: sync notification tests', () => {
 
     it('sends only to the per-connection webhook URL override (env secondary is dropped)', async () => {
         const responseResults = { added: 10, updated: 0, deleted: 0 };
+        const overrideUrl = 'https://override.example.com/hook';
 
         await sendSync({
             account,
             connection,
-            connectionConfig: { webhook_url: testServer.overrideUrl },
+            connectionConfig: { webhook_url: overrideUrl },
             environment: { name: 'dev', id: 1 } as DBEnvironment,
             secret,
             providerConfig,
@@ -338,8 +339,8 @@ describe('Webhooks: sync notification tests', () => {
             webhookSettings
         });
 
-        expect(spy).toHaveBeenCalledTimes(1);
-        expect(spy).toHaveBeenCalledWith(testServer.overrideUrl, expect.any(String), expect.anything());
+        expect(deliverMock).toHaveBeenCalledTimes(1);
+        expect(deliverMock.mock.calls[0]![0].webhooks).toEqual([{ url: overrideUrl, type: 'primary' }]);
     });
 
     it('Should not send an error webhook if the option is not checked', async () => {

--- a/packages/webhooks/lib/utils.ts
+++ b/packages/webhooks/lib/utils.ts
@@ -192,24 +192,23 @@ export const shouldSend = ({
 };
 
 /**
- * Overrides the environment webhook URLs with the connection's webhook URLs overrides if set.
- * If only the primary URL is set on the connection, the environment secondary URL is NOT used as
- * fallback to prevent leaking the connection's webhooks to the shared endpoint.
+ * Overrides the environment webhook URL with the connection's webhook URL override if set.
+ * The environment secondary URL is dropped so the connection's webhooks are not also delivered to the
+ * shared endpoint.
  */
 export function resolveWebhookSettings(
     webhookSettings: DBExternalWebhook,
-    connectionConfig: Pick<ConnectionConfig, 'webhook_url' | 'webhook_url_secondary'> | null | undefined
+    connectionConfig: Pick<ConnectionConfig, 'webhook_url'> | null | undefined
 ): DBExternalWebhook {
     const primary = connectionConfig?.webhook_url;
     if (typeof primary !== 'string' || primary.trim() === '') {
         return webhookSettings;
     }
 
-    const secondary = connectionConfig?.webhook_url_secondary;
     return {
         ...webhookSettings,
         primary_url: primary,
-        secondary_url: typeof secondary === 'string' && secondary.trim() !== '' ? secondary : null
+        secondary_url: null
     };
 }
 

--- a/packages/webhooks/lib/utils.ts
+++ b/packages/webhooks/lib/utils.ts
@@ -19,7 +19,7 @@ import { envs } from './envs.js';
 import type { OutboundUrlPolicy } from '@nangohq/egress';
 import type { LogContext } from '@nangohq/logs';
 import type { MeteredBytes } from '@nangohq/shared';
-import type { DBAPISecret, DBExternalWebhook, MessageHTTPResponse, MessageRow, WebhookTypes } from '@nangohq/types';
+import type { ConnectionConfig, DBAPISecret, DBExternalWebhook, MessageHTTPResponse, MessageRow, WebhookTypes } from '@nangohq/types';
 import type { Result } from '@nangohq/utils';
 import type { AxiosError, AxiosResponse } from 'axios';
 
@@ -190,6 +190,28 @@ export const shouldSend = ({
 
     return true;
 };
+
+/**
+ * Overrides the environment webhook URLs with the connection's webhook URLs overrides if set.
+ * If only the primary URL is set on the connection, the environment secondary URL is NOT used as
+ * fallback to prevent leaking the connection's webhooks to the shared endpoint.
+ */
+export function resolveWebhookSettings(
+    webhookSettings: DBExternalWebhook,
+    connectionConfig: Pick<ConnectionConfig, 'webhook_url' | 'webhook_url_secondary'> | null | undefined
+): DBExternalWebhook {
+    const primary = connectionConfig?.webhook_url;
+    if (typeof primary !== 'string' || primary.trim() === '') {
+        return webhookSettings;
+    }
+
+    const secondary = connectionConfig?.webhook_url_secondary;
+    return {
+        ...webhookSettings,
+        primary_url: primary,
+        secondary_url: typeof secondary === 'string' && secondary.trim() !== '' ? secondary : null
+    };
+}
 
 export const deliver = async ({
     webhooks,

--- a/packages/webhooks/lib/utils.unit.test.ts
+++ b/packages/webhooks/lib/utils.unit.test.ts
@@ -131,26 +131,14 @@ describe('resolveWebhookSettings', () => {
         expect(resolveWebhookSettings(envSettings, {})).toBe(envSettings);
     });
 
-    it('replaces both URLs and keeps the environment event flags', () => {
-        const result = resolveWebhookSettings(envSettings, {
-            webhook_url: 'https://dev-tunnel.example.com/hook',
-            webhook_url_secondary: 'https://dev-tunnel-2.example.com/hook'
-        });
+    it('overrides the primary URL, drops the env secondary, and keeps the environment event flags', () => {
+        const result = resolveWebhookSettings(envSettings, { webhook_url: 'https://dev-tunnel.example.com/hook' });
         expect(result.primary_url).toBe('https://dev-tunnel.example.com/hook');
-        expect(result.secondary_url).toBe('https://dev-tunnel-2.example.com/hook');
+        // The env secondary is dropped so the connection's webhooks are not also sent to the shared endpoint.
+        expect(result.secondary_url).toBeNull();
         expect(result.on_sync_completion_always).toBe(true);
         expect(result.on_sync_error).toBe(true);
         expect(result.on_auth_creation).toBe(true);
-    });
-
-    it('drops the secondary to null (does NOT fall back to env secondary) when only primary is overridden', () => {
-        const result = resolveWebhookSettings(envSettings, { webhook_url: 'https://dev-tunnel.example.com/hook' });
-        expect(result.primary_url).toBe('https://dev-tunnel.example.com/hook');
-        expect(result.secondary_url).toBeNull();
-    });
-
-    it('ignores a lone secondary override (no primary)', () => {
-        expect(resolveWebhookSettings(envSettings, { webhook_url_secondary: 'https://dev-tunnel-2.example.com/hook' })).toBe(envSettings);
     });
 
     it('treats blank/whitespace override URLs as no override', () => {

--- a/packages/webhooks/lib/utils.unit.test.ts
+++ b/packages/webhooks/lib/utils.unit.test.ts
@@ -4,9 +4,9 @@ import { axiosInstance, stringifyStable } from '@nangohq/utils';
 
 import { allowAllWebhookOutbound } from './helpers/setup.unit.js';
 import { TestWebhookServer } from './helpers/test.js';
-import { deliver, getHmacSignatureHeader, getSignatureHeaderUnsafe } from './utils.js';
+import { deliver, getHmacSignatureHeader, getSignatureHeaderUnsafe, resolveWebhookSettings } from './utils.js';
 
-import type { DBAPISecret } from '@nangohq/types';
+import type { DBAPISecret, DBExternalWebhook } from '@nangohq/types';
 import type { AxiosResponse } from 'axios';
 import type { MockInstance } from 'vitest';
 
@@ -107,6 +107,61 @@ describe('deliver request shape', () => {
         expect(config.maxRedirects).toBe(allowAll.policy.maxRedirects);
         expect(config.httpAgent).toBe(allowAll.agents.httpAgent);
         expect(config.httpsAgent).toBe(allowAll.agents.httpsAgent);
+    });
+});
+
+describe('resolveWebhookSettings', () => {
+    const envSettings: DBExternalWebhook = {
+        id: 1,
+        environment_id: 1,
+        primary_url: 'https://env-primary.example.com/hook',
+        secondary_url: 'https://env-secondary.example.com/hook',
+        on_sync_completion_always: true,
+        on_auth_creation: true,
+        on_auth_refresh_error: true,
+        on_sync_error: true,
+        on_async_action_completion: true,
+        created_at: new Date(),
+        updated_at: new Date()
+    };
+
+    it('returns the environment settings unchanged when there is no override', () => {
+        expect(resolveWebhookSettings(envSettings, null)).toBe(envSettings);
+        expect(resolveWebhookSettings(envSettings, undefined)).toBe(envSettings);
+        expect(resolveWebhookSettings(envSettings, {})).toBe(envSettings);
+    });
+
+    it('replaces both URLs and keeps the environment event flags', () => {
+        const result = resolveWebhookSettings(envSettings, {
+            webhook_url: 'https://dev-tunnel.example.com/hook',
+            webhook_url_secondary: 'https://dev-tunnel-2.example.com/hook'
+        });
+        expect(result.primary_url).toBe('https://dev-tunnel.example.com/hook');
+        expect(result.secondary_url).toBe('https://dev-tunnel-2.example.com/hook');
+        expect(result.on_sync_completion_always).toBe(true);
+        expect(result.on_sync_error).toBe(true);
+        expect(result.on_auth_creation).toBe(true);
+    });
+
+    it('drops the secondary to null (does NOT fall back to env secondary) when only primary is overridden', () => {
+        const result = resolveWebhookSettings(envSettings, { webhook_url: 'https://dev-tunnel.example.com/hook' });
+        expect(result.primary_url).toBe('https://dev-tunnel.example.com/hook');
+        expect(result.secondary_url).toBeNull();
+    });
+
+    it('ignores a lone secondary override (no primary)', () => {
+        expect(resolveWebhookSettings(envSettings, { webhook_url_secondary: 'https://dev-tunnel-2.example.com/hook' })).toBe(envSettings);
+    });
+
+    it('treats blank/whitespace override URLs as no override', () => {
+        expect(resolveWebhookSettings(envSettings, { webhook_url: '' })).toBe(envSettings);
+        expect(resolveWebhookSettings(envSettings, { webhook_url: '   ' })).toBe(envSettings);
+    });
+
+    it('does not mutate the original environment settings', () => {
+        resolveWebhookSettings(envSettings, { webhook_url: 'https://dev-tunnel.example.com/hook' });
+        expect(envSettings.primary_url).toBe('https://env-primary.example.com/hook');
+        expect(envSettings.secondary_url).toBe('https://env-secondary.example.com/hook');
     });
 });
 


### PR DESCRIPTION
### What
Lets a single connection override the environment-wide webhook URLs with its own URL. Useful for routing one connection's sync/auth webhooks somewhere specific (e.g. a dev tunnel) without changing the shared environment endpoint. Works for all auth types, settable via the REST API, the connect SDK, or the dashboard's "Create connection" overrides.

### How
Added `webhook_url ` to `ConnectionConfig`. This config is set at session creation time. We validate it just like the environment-level webhook urls (valid url that is not in our deny list). OAuth already merges connect-session `connection_config` defaults server-side; non-OAuth flows historically ignored them and only read request `params`. Had to tweak non-OAuth to do the same as OAuth: apply `connection_config` from the session on top of the ones from `params`. The session values intentionally override the `params`, since the session is the one created by the trusted actor.

We only allow setting `webhook_url` at session creation, we ignore it from the `params` (because it's untrusted at that point).

### Usage

Via sdk:
```ts
const session = await nango.createConnectSession({
    end_user: { id: 'user-123' },
    allowed_integrations: ['my-integration'],
    integrations_config_defaults: {
        'my-integration': {
            connection_config: {
                webhook_url: 'https://my-app.dev/nango-webhooks',
                webhook_url_secondary: 'https://my-app.dev/nango-webhooks-2' // optional
            }
        }
    }
});
```

In dashboard:
<img width="1672" height="1478" alt="Kapture 2026-06-23 at 23 17 46" src="https://github.com/user-attachments/assets/e8193201-a538-420e-86f0-d67ecb645816" />


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/NangoHQ/nango/pull/6639?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

