### PR TITLE
chore(scripts): seed local ClickHouse usage data for local dev

### DIFF
--- a/package.json
+++ b/package.json
@@ -27,6 +27,7 @@
         "persist:dev:watch": "npm run dev -w @nangohq/nango-persist",
         "orchestrator:dev:watch": "npm run dev -w @nangohq/nango-orchestrator",
         "metering:dev:watch": "npm run dev -w @nangohq/nango-metering",
+        "seed:clickhouse": "tsx -r dotenv/config scripts/seed-clickhouse.ts dotenv_config_path=.env",
         "webapp:dev:watch": "cd ./packages/webapp && npm run dev",
         "connect-ui:dev:watch": "cd ./packages/connect-ui && npm run dev",
         "connect-ui:build": "npm run -w @nangohq/connect-ui build",

--- a/packages/billing/lib/clients/noop/client.ts
+++ b/packages/billing/lib/clients/noop/client.ts
@@ -1,0 +1,92 @@
+import { Ok } from '@nangohq/utils';
+
+import type {
+    BillingClient,
+    BillingCustomer,
+    BillingEvent,
+    BillingInvoicingDetails,
+    BillingPlan,
+    BillingSubscription,
+    BillingUsageMetrics,
+    DBTeam,
+    GetBillingUsageOpts
+} from '@nangohq/types';
+import type { Result } from '@nangohq/utils';
+
+/**
+ * Stub billing client for local dev / self-hosted setups with no Orb configured.
+ * Selected in index.ts when `ORB_API_KEY` is unset. Every call returns a benign
+ * success so flows that touch billing (e.g. the billing-usage dashboard, which
+ * still reads its actual numbers from ClickHouse) don't fail on the missing Orb
+ * dependency. Deployed environments always set `ORB_API_KEY` and use OrbClient.
+ */
+function stubCustomer(accountId: number, details?: Pick<BillingInvoicingDetails, 'legalEntityName' | 'email'>): BillingCustomer {
+    return {
+        id: `local-customer-${accountId}`,
+        invoicingDetails: {
+            legalEntityName: details?.legalEntityName ?? `Local account ${accountId}`,
+            email: details?.email ?? `account-${accountId}@local.nango.dev`,
+            address: null,
+            taxId: null
+        },
+        portalUrl: null
+    };
+}
+
+export class NoopBillingClient implements BillingClient {
+    ingest(_events: BillingEvent[]): Promise<Result<void>> {
+        return Promise.resolve(Ok(undefined));
+    }
+
+    linkStripeToCustomer(_teamId: number, _customerId: string): Promise<Result<void>> {
+        return Promise.resolve(Ok(undefined));
+    }
+
+    getOrCreateCustomer(accountId: number, defaultTo: Pick<BillingInvoicingDetails, 'legalEntityName' | 'email'>): Promise<Result<BillingCustomer>> {
+        return Promise.resolve(Ok(stubCustomer(accountId, defaultTo)));
+    }
+
+    getCustomer(accountId: number): Promise<Result<BillingCustomer>> {
+        return Promise.resolve(Ok(stubCustomer(accountId)));
+    }
+
+    putCustomer(accountId: number, invoicingDetails: BillingInvoicingDetails): Promise<Result<BillingCustomer>> {
+        return Promise.resolve(Ok(stubCustomer(accountId, invoicingDetails)));
+    }
+
+    getSubscription(accountId: number): Promise<Result<BillingSubscription | null>> {
+        return Promise.resolve(Ok({ id: `local-sub-${accountId}`, planExternalId: 'free' }));
+    }
+
+    createSubscription(team: DBTeam, planExternalId: string): Promise<Result<BillingSubscription>> {
+        return Promise.resolve(Ok({ id: `local-sub-${team.id}`, planExternalId }));
+    }
+
+    getUsage(_subscriptionId: string, _opts?: GetBillingUsageOpts): Promise<Result<BillingUsageMetrics>> {
+        return Promise.resolve(Ok({}));
+    }
+
+    upgrade(_opts: { subscriptionId: string; planExternalId: string }): Promise<Result<{ pendingChangeId: string; amountInCents: number | null }>> {
+        return Promise.resolve(Ok({ pendingChangeId: 'local-pending-change', amountInCents: null }));
+    }
+
+    downgrade(_opts: { subscriptionId: string; planExternalId: string }): Promise<Result<void>> {
+        return Promise.resolve(Ok(undefined));
+    }
+
+    applyPendingChanges(_opts: { pendingChangeId: string; paymentExternalId: string; amountCollected: string }): Promise<Result<BillingSubscription>> {
+        return Promise.resolve(Ok({ id: 'local-sub', planExternalId: 'free' }));
+    }
+
+    cancelPendingChanges(_opts: { pendingChangeId: string }): Promise<Result<void>> {
+        return Promise.resolve(Ok(undefined));
+    }
+
+    verifyWebhookSignature(_body: string, _headers: Record<string, unknown>, _secret: string): Result<true> {
+        return Ok(true);
+    }
+
+    getPlanById(planId: string): Promise<Result<BillingPlan>> {
+        return Promise.resolve(Ok({ id: planId, external_plan_id: planId }));
+    }
+}

--- a/packages/billing/lib/index.ts
+++ b/packages/billing/lib/index.ts
@@ -2,10 +2,18 @@ import { Billing } from './billing.js';
 import { NoopBillingClient } from './clients/noop/client.js';
 import { OrbClient } from './clients/orb/client.js';
 import { envs } from './envs.js';
+import { logger } from './logger.js';
 
 // Fall back to a stub client when Orb isn't configured (local dev / self-hosted),
 // so billing-touching flows don't fail on the missing dependency. Deployed
-// environments always set ORB_API_KEY and use the real Orb client.
-export const billing = new Billing(envs.ORB_API_KEY ? new OrbClient() : new NoopBillingClient());
+// environments always set ORB_API_KEY and use the real Orb client. Log the fallback
+// so an accidentally-missing key in a deployed environment isn't silent.
+const orbConfigured = Boolean(envs.ORB_API_KEY);
+if (!orbConfigured) {
+    logger.warning(
+        'ORB_API_KEY is not set — using a no-op billing client. Billing events are dropped and subscriptions/customers are stubbed. Expected in local dev and self-hosted; unexpected in a deployed environment.'
+    );
+}
+export const billing = new Billing(orbConfigured ? new OrbClient() : new NoopBillingClient());
 
 export { getStripe } from './stripe.js';

--- a/packages/billing/lib/index.ts
+++ b/packages/billing/lib/index.ts
@@ -1,6 +1,11 @@
 import { Billing } from './billing.js';
+import { NoopBillingClient } from './clients/noop/client.js';
 import { OrbClient } from './clients/orb/client.js';
+import { envs } from './envs.js';
 
-export const billing = new Billing(new OrbClient());
+// Fall back to a stub client when Orb isn't configured (local dev / self-hosted),
+// so billing-touching flows don't fail on the missing dependency. Deployed
+// environments always set ORB_API_KEY and use the real Orb client.
+export const billing = new Billing(envs.ORB_API_KEY ? new OrbClient() : new NoopBillingClient());
 
 export { getStripe } from './stripe.js';

--- a/scripts/README.md
+++ b/scripts/README.md
@@ -47,6 +47,6 @@ The seed itself only needs `CLICKHOUSE_URL` and a Postgres connection; the flags
 The dataset is sized to exercise the breakdown filter combobox:
 
 - **20 integrations** with overlapping names (`github`/`gitlab`, `google-calendar`/`google-drive`/`gmail`, …) for partial-string **integration search**.
-- **60 distinct connections** (20 integrations × 3) — beyond the top-N breakdown cap (25) — for **connection pagination**.
+- **Hundreds of connection UUIDs in prod** (dev holds ~10% as many), skewed like production (a few integrations have 60–150 connections, most have a handful) — far beyond the top-N breakdown cap (25) — for **connection pagination**. Connection ids are UUIDs, matching production.
 
-Events span every usage metric (proxy, function executions/logs/compute, webhook forwards, records, connections, data transfer) and every breakdown dimension, across 30 days.
+Events span every usage metric (proxy, function executions/logs/compute, webhook forwards, records, connections, data transfer) and every breakdown dimension, across 30 days. Mix mirrors reality: dev has ~10% as many connections as prod, so prod carries ~90% of traffic across every metric; the Connections/Sync-records metrics reflect the real connection counts; and proxy/webhook/function runs include failures, with the function failure rate fluctuating day to day (mostly healthy, occasional spikes up to ~20%) rather than a flat rate.

--- a/scripts/README.md
+++ b/scripts/README.md
@@ -1,0 +1,52 @@
+# Scripts
+
+Maintenance and developer scripts for the monorepo. Run them from the **repo root** via the npm aliases below — each wraps `tsx scripts/<name>.ts`. Scripts run through `tsx` and are not part of the TypeScript build (`tsconfig.build.json`); they resolve workspace packages (`@nangohq/*`) via npm-workspace hoisting.
+
+## Index
+
+| Command | Script | Purpose |
+| --- | --- | --- |
+| `npm run seed:clickhouse` | `seed-clickhouse.ts` | Seed local ClickHouse with synthetic usage data for the billing/usage dashboard |
+| `npm run docs:generate` | `docs-gen-snippets.ts`, `docs-generate-llms.ts` | Regenerate doc snippets and `llms.txt` |
+| `npm run changelog:providers` | `provider-changelog.ts` | Generate the provider changelog |
+| `npm run changelog:integrations` | `pre-built-integrations-changelog.ts` | Generate the pre-built-integrations changelog |
+| `npm run update:providers:scopes:all` / `:new` | `validation/providers/sync-scopes.ts` | Sync OAuth2 provider scopes |
+| `npm run test:providers` | `validation/providers/validate.ts` | Validate `providers.yaml` |
+
+One-off migrations live under `scripts/one-off/`, each with its own README.
+
+## `seed:clickhouse` — local usage/billing data
+
+Populates the local ClickHouse `usage` database with synthetic usage events so the **Billing & usage** dashboard renders real-looking data locally — no deployed backend and no ingestion pipeline (metering/ActiveMQ) needed. See the header of [`seed-clickhouse.ts`](./seed-clickhouse.ts) for what it writes and how the materialized views aggregate it.
+
+```bash
+npm run seed:clickhouse                          # reset + seed the last 30 days
+npm run seed:clickhouse -- --account 3 --days 60 # target one account, longer window
+npm run seed:clickhouse -- --no-reset            # append instead of dropping the DB first
+```
+
+By default it seeds the local accounts that have more than one environment (the real orgs, e.g. `Nango's Team`), skipping the throwaway fixture accounts.
+
+**Prerequisites** — ClickHouse running (`npm run dev:docker`) and, to view the data in the dashboard, these in your root `.env`:
+
+```bash
+CLICKHOUSE_URL=http://default:@localhost:8123
+FLAG_BILLING_USAGE_CLICKHOUSE_ROLLOUT_PERCENTAGE=100   # route all local accounts' reads to ClickHouse
+FLAG_ALLOW_OVERRIDE_GETUSAGE_SERVICE=true              # allow ?source=clickhouse|orb per request
+FLAG_PLAN_ENABLED=true                                 # else the endpoint returns feature_disabled
+FLAG_USAGE_ENABLED=true
+NANGO_REDIS_URL=redis://localhost:6379                 # else the server uses a no-op usage tracker
+```
+
+The seed itself only needs `CLICKHOUSE_URL` and a Postgres connection; the flags above are what make the dashboard actually read and render the data. With no Orb configured, billing falls back to a no-op client automatically.
+
+**Shared across worktrees** — ClickHouse runs in the shared `clickhouse` Docker container, so every worktree reads the same `usage` database. Seed once from any worktree and the data is visible everywhere; there's no need to re-seed per worktree.
+
+### Test data shape
+
+The dataset is sized to exercise the breakdown filter combobox:
+
+- **20 integrations** with overlapping names (`github`/`gitlab`, `google-calendar`/`google-drive`/`gmail`, …) for partial-string **integration search**.
+- **60 distinct connections** (20 integrations × 3) — beyond the top-N breakdown cap (25) — for **connection pagination**.
+
+Events span every usage metric (proxy, function executions/logs/compute, webhook forwards, records, connections, data transfer) and every breakdown dimension, across 30 days.

--- a/scripts/README.md
+++ b/scripts/README.md
@@ -40,6 +40,8 @@ NANGO_REDIS_URL=redis://localhost:6379                 # else the server uses a 
 
 The seed itself only needs `CLICKHOUSE_URL` and a Postgres connection; the flags above are what make the dashboard actually read and render the data. With no Orb configured, billing falls back to a no-op client automatically.
 
+It drops and reseeds the `usage` database, so it refuses to run unless `CLICKHOUSE_URL` points at a local host (`localhost`/`127.0.0.1`). Pass `--allow-remote` to override.
+
 **Shared across worktrees** — ClickHouse runs in the shared `clickhouse` Docker container, so every worktree reads the same `usage` database. Seed once from any worktree and the data is visible everywhere; there's no need to re-seed per worktree.
 
 ### Test data shape

--- a/scripts/seed-clickhouse.ts
+++ b/scripts/seed-clickhouse.ts
@@ -1,0 +1,322 @@
+/**
+ * Seeds the local ClickHouse `usage` database with synthetic usage events so the
+ * billing/usage breakdown dashboard renders real-looking data without a deployed
+ * backend or the ingestion pipeline (metering/ActiveMQ) running.
+ *
+ * What it does:
+ *   1. Drops & re-migrates the `usage` database (skip with --no-reset to append).
+ *   2. Detects local accounts + their environments from Postgres so the
+ *      environment-breakdown chips resolve to real names.
+ *   3. Ensures each target account has a (free) plan row — the billing-usage
+ *      endpoint returns `feature_disabled` without one (and FLAG_PLAN_ENABLED
+ *      must be on; see .env).
+ *   4. Inserts events into `raw_events` across every metric and breakdown
+ *      dimension over the last N days. ClickHouse materialized views aggregate
+ *      them into the daily_* tables the dashboard reads.
+ *
+ * Run from the repo root:
+ *   npm run seed:clickhouse
+ *   npm run seed:clickhouse -- --account 3 --days 60 --no-reset
+ *
+ * Requires CLICKHOUSE_URL in .env and the clickhouse container up (npm run dev:docker).
+ */
+import { randomUUID } from 'node:crypto';
+
+import db from '@nangohq/database';
+import { createPlan, freePlan, updatePlanByTeam } from '@nangohq/shared';
+import { Clickhouse, clickhouseClient, migrate } from '@nangohq/usage';
+
+import type { ClickhouseRawUsageEvent } from '@nangohq/usage';
+
+const DATABASE = 'usage';
+
+// Integration/connection cardinality is deliberately high to exercise the
+// breakdown filter combobox (see scripts/README.md):
+//   - 20 integration_id values feed the integration search test — names share
+//     substrings ("git" → github/gitlab, "google" → google-calendar/google-drive)
+//     so partial-string matching has something to discriminate.
+//   - 20 × 3 = 60 distinct connection_id values feed the connection pagination
+//     test — well beyond the top-N breakdown cap (25), so the combobox spans
+//     multiple pages.
+// It also exceeds the top-10 breakdown default, exercising the "rest" rollup.
+const INTEGRATIONS: { id: string; models: string[]; webhooks: boolean }[] = [
+    { id: 'salesforce', models: ['Contact', 'Account', 'Opportunity', 'Lead'], webhooks: false },
+    { id: 'hubspot', models: ['Contact', 'Company', 'Deal'], webhooks: true },
+    { id: 'google-calendar', models: ['Event', 'Calendar'], webhooks: false },
+    { id: 'google-drive', models: ['File', 'Folder'], webhooks: false },
+    { id: 'gmail', models: ['Message', 'Thread'], webhooks: true },
+    { id: 'slack', models: ['Message', 'Channel', 'User'], webhooks: true },
+    { id: 'github', models: ['Issue', 'PullRequest', 'Repository'], webhooks: true },
+    { id: 'gitlab', models: ['Issue', 'MergeRequest', 'Project'], webhooks: true },
+    { id: 'notion', models: ['Page', 'Database'], webhooks: false },
+    { id: 'linear', models: ['Issue', 'Project', 'Cycle'], webhooks: true },
+    { id: 'jira', models: ['Issue', 'Project', 'Sprint'], webhooks: true },
+    { id: 'asana', models: ['Task', 'Project'], webhooks: false },
+    { id: 'stripe', models: ['Charge', 'Customer', 'Invoice'], webhooks: true },
+    { id: 'shopify', models: ['Order', 'Product', 'Customer'], webhooks: true },
+    { id: 'zendesk', models: ['Ticket', 'User'], webhooks: true },
+    { id: 'intercom', models: ['Conversation', 'Contact'], webhooks: true },
+    { id: 'microsoft-teams', models: ['Message', 'Channel'], webhooks: false },
+    { id: 'outlook', models: ['Message', 'Event'], webhooks: false },
+    { id: 'dropbox', models: ['File', 'Folder'], webhooks: false },
+    { id: 'airtable', models: ['Record', 'Table'], webhooks: false }
+];
+const CONNECTIONS_PER_INTEGRATION = 3;
+const FUNCTION_TYPES = ['sync', 'action', 'webhook'] as const;
+const RUNTIMES = ['lambda', 'local'] as const;
+const PACKAGES = ['runner', 'server'] as const;
+const CALLSITES = ['proxy', 'webhook', 'action'] as const;
+
+function parseArgs() {
+    const argv = process.argv.slice(2);
+    const value = (name: string): string | undefined => {
+        const i = argv.indexOf(`--${name}`);
+        return i >= 0 ? argv[i + 1] : undefined;
+    };
+    const account = value('account');
+    const days = value('days');
+    return {
+        onlyAccount: account ? Number(account) : undefined,
+        days: days ? Number(days) : 30,
+        reset: !argv.includes('--no-reset')
+    };
+}
+
+const rnd = (min: number, max: number): number => Math.floor(Math.random() * (max - min + 1)) + min;
+const chance = (p: number): boolean => Math.random() < p;
+function pick<T>(arr: readonly T[]): T {
+    const value = arr[rnd(0, arr.length - 1)];
+    if (value === undefined) {
+        throw new Error('pick() called on an empty array');
+    }
+    return value;
+}
+
+// Midday UTC of `offset` days ago — keeps the event inside a single UTC calendar
+// day (CH `toDate(ts)` buckets in UTC) regardless of the runner's local timezone.
+const todayMidnightUTC = (() => {
+    const now = new Date();
+    return Date.UTC(now.getUTCFullYear(), now.getUTCMonth(), now.getUTCDate());
+})();
+const dayTs = (offset: number): number => todayMidnightUTC - offset * 86_400_000 + 12 * 3_600_000;
+
+function event(
+    type: ClickhouseRawUsageEvent['type'],
+    accountId: number,
+    ts: number,
+    value: number,
+    attributes: Record<string, unknown>
+): ClickhouseRawUsageEvent {
+    return {
+        ts,
+        type,
+        idempotency_key: `${type}-${randomUUID()}`,
+        account_id: accountId,
+        value,
+        attributes: attributes as ClickhouseRawUsageEvent['attributes']
+    };
+}
+
+function generateForEnvDay(accountId: number, environmentId: number, ts: number): ClickhouseRawUsageEvent[] {
+    const events: ClickhouseRawUsageEvent[] = [];
+    for (const integration of INTEGRATIONS) {
+        const connections = Array.from({ length: CONNECTIONS_PER_INTEGRATION }, (_, i) => `${integration.id}-conn-${i + 1}`);
+        const base = { environmentId, integrationId: integration.id };
+
+        for (const connectionId of connections) {
+            // proxy — mostly successful, with an occasional batch of failures
+            events.push(event('usage.proxy', accountId, ts, rnd(5, 80), { ...base, connectionId, success: true }));
+            if (chance(0.4)) {
+                events.push(event('usage.proxy', accountId, ts, rnd(1, 10), { ...base, connectionId, success: false }));
+            }
+
+            // webhook_forwards — only for integrations that emit webhooks
+            if (integration.webhooks) {
+                events.push(event('usage.webhook_forward', accountId, ts, rnd(2, 30), { ...base, connectionId, success: true }));
+                if (chance(0.3)) {
+                    events.push(event('usage.webhook_forward', accountId, ts, rnd(1, 5), { ...base, connectionId, success: false }));
+                }
+            }
+
+            // data_transfer — broken down by package + callsite
+            for (const pkg of PACKAGES) {
+                const callsite = pick(CALLSITES);
+                const egressedBytes = rnd(500, 200_000);
+                const ingressedBytes = rnd(500, 100_000);
+                events.push(
+                    event('usage.data_transfer', accountId, ts, egressedBytes + ingressedBytes, {
+                        ...base,
+                        connectionId,
+                        package: pkg,
+                        callsite,
+                        egressedBytes,
+                        ingressedBytes
+                    })
+                );
+            }
+        }
+
+        // function_executions — one row per function type (value = #executions; telemetry is summed)
+        for (const fnType of FUNCTION_TYPES) {
+            const executions = rnd(1, 30);
+            const perRunMs = rnd(40, 900);
+            events.push(
+                event('usage.function_executions', accountId, ts, executions, {
+                    ...base,
+                    connectionId: connections[0],
+                    type: fnType,
+                    functionName: `${integration.id}-${fnType}`,
+                    runtime: pick(RUNTIMES),
+                    success: true,
+                    telemetryBag: {
+                        durationMs: executions * perRunMs,
+                        customLogs: executions * rnd(0, 6),
+                        proxyCalls: executions * rnd(0, 4),
+                        memoryGb: pick([0.5, 1, 2, 3])
+                    }
+                })
+            );
+        }
+
+        // records — AVG metric, broken down by model. One batch per (connection, model) per day.
+        for (const model of integration.models) {
+            for (const connectionId of connections.slice(0, 2)) {
+                events.push(event('usage.records', accountId, ts, rnd(50, 5_000), { ...base, connectionId, model, batchId: randomUUID() }));
+            }
+        }
+
+        // connections — AVG metric, broken down only by environment + integration.
+        events.push(event('usage.connections', accountId, ts, rnd(1, 25), { ...base, batchId: randomUUID() }));
+    }
+    return events;
+}
+
+async function resolveTargets(onlyAccount: number | undefined): Promise<{ accountId: number; environments: { id: number; name: string }[] }[]> {
+    // Default to the "real" local orgs (those with more than one environment —
+    // e.g. dev + prod). A fresh local DB seeds hundreds of throwaway single-env
+    // fixture accounts; seeding all of them would be millions of rows. Pass
+    // --account <id> to target a specific one.
+    let accountRows: { id: number }[];
+    if (onlyAccount !== undefined) {
+        accountRows = [{ id: onlyAccount }];
+    } else {
+        accountRows = await db.knex
+            .select<{ id: number }[]>('account_id as id')
+            .from('_nango_environments')
+            .where({ deleted: false })
+            .groupBy('account_id')
+            .havingRaw('count(*) > 1')
+            .orderBy('account_id');
+        if (accountRows.length === 0) {
+            const [first] = await db.knex.select<{ id: number }[]>('id').from('_nango_accounts').orderBy('id').limit(1);
+            accountRows = first ? [first] : [];
+        }
+    }
+
+    const targets: { accountId: number; environments: { id: number; name: string }[] }[] = [];
+    for (const { id: accountId } of accountRows) {
+        const environments = await db.knex
+            .select<{ id: number; name: string }[]>('id', 'name')
+            .from('_nango_environments')
+            .where({ account_id: accountId, deleted: false })
+            .orderBy('id');
+        if (environments.length === 0) {
+            console.warn(`⚠️  account ${accountId} has no environments — skipping`);
+            continue;
+        }
+        targets.push({ accountId, environments });
+    }
+    return targets;
+}
+
+async function main() {
+    const { onlyAccount, days, reset } = parseArgs();
+
+    if (!process.env['CLICKHOUSE_URL']) {
+        console.error('✗ CLICKHOUSE_URL is not set.');
+        console.error('  Add to .env:  CLICKHOUSE_URL=http://default:@localhost:8123');
+        console.error('  And start the container:  npm run dev:docker');
+        process.exit(1);
+    }
+
+    if (reset) {
+        console.log(`Resetting local ClickHouse database "${DATABASE}" (synthetic dev data)…`);
+        const client = clickhouseClient();
+        await client?.command({ query: `DROP DATABASE IF EXISTS ${DATABASE}` });
+        await client?.close();
+    }
+
+    console.log('Running ClickHouse migrations…');
+    const migrated = await migrate();
+    if (migrated.isErr()) {
+        console.error(`✗ Migration failed: ${migrated.error}`);
+        process.exit(1);
+    }
+
+    const targets = await resolveTargets(onlyAccount);
+    if (targets.length === 0) {
+        console.error('✗ No accounts with environments found. Sign up at http://localhost:3000 first, or pass --account <id>.');
+        process.exit(1);
+    }
+
+    // The billing-usage endpoint requires a plan row (and FLAG_PLAN_ENABLED=true).
+    // createPlan ignores the insert when a row already exists, so set the placeholder
+    // orb_* ids via a follow-up update — they make the controller skip its Orb
+    // customer/subscription backfill so it works on the first request with no Orb
+    // configured (NoopBillingClient).
+    for (const { accountId } of targets) {
+        const created = await createPlan(db.knex, { account_id: accountId, name: 'free', ...freePlan.flags });
+        if (created.isErr()) {
+            console.warn(`⚠️  could not ensure a plan for account ${accountId}: ${created.error}`);
+        }
+        const updated = await updatePlanByTeam(db.knex, {
+            account_id: accountId,
+            orb_customer_id: `local-customer-${accountId}`,
+            orb_subscription_id: `local-sub-${accountId}`
+        });
+        if (updated.isErr()) {
+            console.warn(`⚠️  could not set placeholder billing ids for account ${accountId}: ${updated.error}`);
+        }
+    }
+
+    const clickhouse = new Clickhouse();
+    let total = 0;
+    for (const { accountId, environments } of targets) {
+        for (const env of environments) {
+            const events: ClickhouseRawUsageEvent[] = [];
+            for (let offset = 0; offset < days; offset++) {
+                events.push(...generateForEnvDay(accountId, env.id, dayTs(offset)));
+            }
+            // Insert in chunks to keep batch sizes sane; the batcher flushes the rest.
+            for (let i = 0; i < events.length; i += 1_000) {
+                clickhouse.addRaw(events.slice(i, i + 1_000));
+            }
+            total += events.length;
+            console.log(`  account ${accountId} · env ${env.id} (${env.name}): ${events.length} events`);
+        }
+    }
+
+    const flushed = await clickhouse.flush();
+    if (flushed.isErr()) {
+        console.error(`✗ Flush failed: ${flushed.error}`);
+        process.exit(1);
+    }
+    await clickhouse.shutdown();
+
+    const fromDay = new Date(dayTs(days - 1)).toISOString().split('T')[0];
+    const toDay = new Date(dayTs(0)).toISOString().split('T')[0];
+    console.log(`\n✓ Seeded ${total} events across ${targets.length} account(s), ${days} days (${fromDay} → ${toDay}).`);
+    console.log('  Materialized views aggregate raw_events into the daily_* tables the dashboard reads.');
+    console.log('  Ensure FLAG_BILLING_USAGE_CLICKHOUSE_ROLLOUT_PERCENTAGE=100 (or your account is allowlisted) so the server reads ClickHouse.');
+}
+
+main()
+    .then(async () => {
+        await db.knex.destroy();
+        process.exit(0);
+    })
+    .catch(async (err: unknown) => {
+        console.error(err);
+        await db.knex.destroy();
+        process.exit(1);
+    });

--- a/scripts/seed-clickhouse.ts
+++ b/scripts/seed-clickhouse.ts
@@ -35,9 +35,10 @@ const DATABASE = 'usage';
 //   - 20 integration_id values feed the integration search test — names share
 //     substrings ("git" → github/gitlab, "google" → google-calendar/google-drive)
 //     so partial-string matching has something to discriminate.
-//   - 20 × 3 = 60 distinct connection_id values feed the connection pagination
-//     test — well beyond the top-N breakdown cap (25), so the combobox spans
-//     multiple pages.
+//   - hundreds of distinct connection UUIDs in prod (dev holds ~10% as many), skewed
+//     like production (a few integrations have 60–150 connections, most a handful),
+//     feed the connection pagination test — far beyond the top-N cap (25), so the
+//     combobox spans many pages. Connection ids are UUIDs, matching production.
 // It also exceeds the top-10 breakdown default, exercising the "rest" rollup.
 const INTEGRATIONS: { id: string; models: string[]; webhooks: boolean }[] = [
     { id: 'salesforce', models: ['Contact', 'Account', 'Opportunity', 'Lead'], webhooks: false },
@@ -61,8 +62,15 @@ const INTEGRATIONS: { id: string; models: string[]; webhooks: boolean }[] = [
     { id: 'dropbox', models: ['File', 'Folder'], webhooks: false },
     { id: 'airtable', models: ['Record', 'Table'], webhooks: false }
 ];
-const CONNECTIONS_PER_INTEGRATION = 3;
-const FUNCTION_TYPES = ['sync', 'action', 'webhook'] as const;
+// Connection counts are skewed like production: a few integrations carry the bulk
+// of the connections (e.g. the account's primary CRM with one connection per
+// customer), while most have only a handful. Totals land in the hundreds per env.
+const HIGH_VOLUME_INTEGRATION_CHANCE = 0.15;
+const HIGH_VOLUME_CONNECTIONS: [number, number] = [60, 150];
+const LONG_TAIL_CONNECTIONS: [number, number] = [2, 12];
+// dev holds ~10% as many connections as prod. That fewer-connections ratio is what
+// makes dev ≈ 10% of traffic across every metric — no separate volume scaling.
+const DEV_CONNECTION_SHARE = 0.1;
 const RUNTIMES = ['lambda', 'local'] as const;
 const PACKAGES = ['runner', 'server'] as const;
 const CALLSITES = ['proxy', 'webhook', 'action'] as const;
@@ -83,6 +91,7 @@ function parseArgs() {
 }
 
 const rnd = (min: number, max: number): number => Math.floor(Math.random() * (max - min + 1)) + min;
+const rndFloat = (min: number, max: number): number => Math.random() * (max - min) + min;
 const chance = (p: number): boolean => Math.random() < p;
 function pick<T>(arr: readonly T[]): T {
     const value = arr[rnd(0, arr.length - 1)];
@@ -90,6 +99,37 @@ function pick<T>(arr: readonly T[]): T {
         throw new Error('pick() called on an empty array');
     }
     return value;
+}
+
+// Base (prod) connection count per integration, decided once. Skewed like production:
+// a few integrations carry the bulk of the connections, most have only a handful.
+const connectionCountCache = new Map<string, number>();
+function baseConnectionCount(integrationId: string): number {
+    let count = connectionCountCache.get(integrationId);
+    if (count === undefined) {
+        const [min, max] = chance(HIGH_VOLUME_INTEGRATION_CHANCE) ? HIGH_VOLUME_CONNECTIONS : LONG_TAIL_CONNECTIONS;
+        count = rnd(min, max);
+        connectionCountCache.set(integrationId, count);
+    }
+    return count;
+}
+
+// Connection ids are UUIDs in reality. Memoize a stable set per (environment,
+// integration) so the same connections recur across every day. dev holds ~10% as many
+// as prod (DEV_CONNECTION_SHARE) — having fewer connections is what makes dev ≈ 10% of
+// traffic across every metric. dev may end up with 0 for small integrations (it simply
+// doesn't use them).
+const connectionIdCache = new Map<string, string[]>();
+function connectionsFor(environmentId: number, integrationId: string, isProduction: boolean): string[] {
+    const key = `${environmentId}:${integrationId}`;
+    let connections = connectionIdCache.get(key);
+    if (!connections) {
+        const base = baseConnectionCount(integrationId);
+        const count = isProduction ? base : Math.round(base * DEV_CONNECTION_SHARE);
+        connections = Array.from({ length: count }, () => randomUUID());
+        connectionIdCache.set(key, connections);
+    }
+    return connections;
 }
 
 // Midday UTC of `offset` days ago — keeps the event inside a single UTC calendar
@@ -117,10 +157,17 @@ function event(
     };
 }
 
-function generateForEnvDay(accountId: number, environmentId: number, ts: number): ClickhouseRawUsageEvent[] {
+function generateForEnvDay(accountId: number, environmentId: number, isProduction: boolean, ts: number, batchId: string): ClickhouseRawUsageEvent[] {
     const events: ClickhouseRawUsageEvent[] = [];
+    // One failure rate for the whole day, shared across this day's function groups, so
+    // the failure series fluctuates day to day (mostly healthy, occasional spikes)
+    // instead of averaging to a flat ~10%. Squared → biased low; capped near 20%.
+    const dayFailureRate = Math.random() ** 2 * 0.2;
     for (const integration of INTEGRATIONS) {
-        const connections = Array.from({ length: CONNECTIONS_PER_INTEGRATION }, (_, i) => `${integration.id}-conn-${i + 1}`);
+        const connections = connectionsFor(environmentId, integration.id, isProduction);
+        if (connections.length === 0) {
+            continue; // dev doesn't actively use every integration
+        }
         const base = { environmentId, integrationId: integration.id };
 
         for (const connectionId of connections) {
@@ -140,7 +187,6 @@ function generateForEnvDay(accountId: number, environmentId: number, ts: number)
 
             // data_transfer — broken down by package + callsite
             for (const pkg of PACKAGES) {
-                const callsite = pick(CALLSITES);
                 const egressedBytes = rnd(500, 200_000);
                 const ingressedBytes = rnd(500, 100_000);
                 events.push(
@@ -148,50 +194,72 @@ function generateForEnvDay(accountId: number, environmentId: number, ts: number)
                         ...base,
                         connectionId,
                         package: pkg,
-                        callsite,
+                        callsite: pick(CALLSITES),
                         egressedBytes,
                         ingressedBytes
                     })
                 );
             }
-        }
 
-        // function_executions — one row per function type (value = #executions; telemetry is summed)
-        for (const fnType of FUNCTION_TYPES) {
-            const executions = rnd(1, 30);
-            const perRunMs = rnd(40, 900);
-            events.push(
-                event('usage.function_executions', accountId, ts, executions, {
-                    ...base,
-                    connectionId: connections[0],
-                    type: fnType,
-                    functionName: `${integration.id}-${fnType}`,
-                    runtime: pick(RUNTIMES),
-                    success: true,
-                    telemetryBag: {
-                        durationMs: executions * perRunMs,
-                        customLogs: executions * rnd(0, 6),
-                        proxyCalls: executions * rnd(0, 4),
-                        memoryGb: pick([0.5, 1, 2, 3])
+            // function_executions — runs happen per connection (its own syncs/actions),
+            // so they spread roughly evenly across connections. sync runs every day;
+            // actions/webhooks fire some days. value = #runs, split by the day's rate.
+            const fnRuns: { type: 'sync' | 'action' | 'webhook'; runs: number }[] = [{ type: 'sync', runs: rnd(1, 10) }];
+            if (chance(0.5)) {
+                fnRuns.push({ type: 'action', runs: rnd(1, 6) });
+            }
+            if (integration.webhooks && chance(0.5)) {
+                fnRuns.push({ type: 'webhook', runs: rnd(1, 8) });
+            }
+            for (const { type, runs } of fnRuns) {
+                const failed = Math.min(runs, Math.round(runs * dayFailureRate * rndFloat(0.7, 1.3)));
+                const perRunMs = rnd(40, 900);
+                for (const [success, count] of [
+                    [true, runs - failed],
+                    [false, failed]
+                ] as const) {
+                    if (count <= 0) {
+                        continue;
                     }
-                })
-            );
-        }
-
-        // records — AVG metric, broken down by model. One batch per (connection, model) per day.
-        for (const model of integration.models) {
-            for (const connectionId of connections.slice(0, 2)) {
-                events.push(event('usage.records', accountId, ts, rnd(50, 5_000), { ...base, connectionId, model, batchId: randomUUID() }));
+                    events.push(
+                        event('usage.function_executions', accountId, ts, count, {
+                            ...base,
+                            connectionId,
+                            type,
+                            functionName: `${integration.id}-${type}`,
+                            runtime: pick(RUNTIMES),
+                            success,
+                            telemetryBag: {
+                                durationMs: count * perRunMs,
+                                customLogs: count * rnd(0, 6),
+                                proxyCalls: count * rnd(0, 4),
+                                memoryGb: pick([0.5, 1, 2, 3])
+                            }
+                        })
+                    );
+                }
             }
         }
 
-        // connections — AVG metric, broken down only by environment + integration.
-        events.push(event('usage.connections', accountId, ts, rnd(1, 25), { ...base, batchId: randomUUID() }));
+        // records — AVG metric. The snapshot shares the day's batchId so the metric
+        // reflects the daily total record count, not a per-integration average.
+        for (const model of integration.models) {
+            for (const connectionId of connections.slice(0, 2)) {
+                events.push(event('usage.records', accountId, ts, rnd(50, 5_000), { ...base, connectionId, model, batchId }));
+            }
+        }
+
+        // connections — AVG metric. value = this integration's active connection count
+        // (most connections active), so the metric mirrors the real connection cardinality.
+        // Shares the day's batchId so the headline is the daily total, not a per-row average.
+        events.push(event('usage.connections', accountId, ts, Math.round(connections.length * rndFloat(0.85, 1)), { ...base, batchId }));
     }
     return events;
 }
 
-async function resolveTargets(onlyAccount: number | undefined): Promise<{ accountId: number; environments: { id: number; name: string }[] }[]> {
+async function resolveTargets(
+    onlyAccount: number | undefined
+): Promise<{ accountId: number; environments: { id: number; name: string; isProduction: boolean }[] }[]> {
     // Default to the "real" local orgs (those with more than one environment —
     // e.g. dev + prod). A fresh local DB seeds hundreds of throwaway single-env
     // fixture accounts; seeding all of them would be millions of rows. Pass
@@ -213,10 +281,10 @@ async function resolveTargets(onlyAccount: number | undefined): Promise<{ accoun
         }
     }
 
-    const targets: { accountId: number; environments: { id: number; name: string }[] }[] = [];
+    const targets: { accountId: number; environments: { id: number; name: string; isProduction: boolean }[] }[] = [];
     for (const { id: accountId } of accountRows) {
         const environments = await db.knex
-            .select<{ id: number; name: string }[]>('id', 'name')
+            .select<{ id: number; name: string; isProduction: boolean }[]>('id', 'name', { isProduction: 'is_production' })
             .from('_nango_environments')
             .where({ account_id: accountId, deleted: false })
             .orderBy('id');
@@ -282,10 +350,14 @@ async function main() {
     const clickhouse = new Clickhouse();
     let total = 0;
     for (const { accountId, environments } of targets) {
+        // One snapshot batchId per day, shared across environments — matches the real
+        // metering cron so the AVG metrics (connections, records) reconstruct the daily
+        // total instead of a per-row average.
+        const dayBatchIds = Array.from({ length: days }, () => randomUUID());
         for (const env of environments) {
             const events: ClickhouseRawUsageEvent[] = [];
-            for (let offset = 0; offset < days; offset++) {
-                events.push(...generateForEnvDay(accountId, env.id, dayTs(offset)));
+            for (const [offset, batchId] of dayBatchIds.entries()) {
+                events.push(...generateForEnvDay(accountId, env.id, env.isProduction, dayTs(offset), batchId));
             }
             // Insert in chunks to keep batch sizes sane; the batcher flushes the rest.
             for (let i = 0; i < events.length; i += 1_000) {

--- a/scripts/seed-clickhouse.ts
+++ b/scripts/seed-clickhouse.ts
@@ -81,12 +81,24 @@ function parseArgs() {
         const i = argv.indexOf(`--${name}`);
         return i >= 0 ? argv[i + 1] : undefined;
     };
+    const fail = (message: string): never => {
+        console.error(`✗ ${message}`);
+        process.exit(1);
+    };
+
     const account = value('account');
+    if (account !== undefined && !/^\d+$/.test(account)) {
+        fail(`--account must be a non-negative integer, got "${account}".`);
+    }
     const days = value('days');
+    if (days !== undefined && (!/^\d+$/.test(days) || Number(days) === 0)) {
+        fail(`--days must be a positive integer, got "${days}".`);
+    }
     return {
-        onlyAccount: account ? Number(account) : undefined,
-        days: days ? Number(days) : 30,
-        reset: !argv.includes('--no-reset')
+        onlyAccount: account !== undefined ? Number(account) : undefined,
+        days: days !== undefined ? Number(days) : 30,
+        reset: !argv.includes('--no-reset'),
+        allowRemote: argv.includes('--allow-remote')
     };
 }
 
@@ -298,12 +310,25 @@ async function resolveTargets(
 }
 
 async function main() {
-    const { onlyAccount, days, reset } = parseArgs();
+    const { onlyAccount, days, reset, allowRemote } = parseArgs();
 
-    if (!process.env['CLICKHOUSE_URL']) {
+    const clickhouseUrl = process.env['CLICKHOUSE_URL'];
+    if (!clickhouseUrl) {
         console.error('✗ CLICKHOUSE_URL is not set.');
         console.error('  Add to .env:  CLICKHOUSE_URL=http://default:@localhost:8123');
         console.error('  And start the container:  npm run dev:docker');
+        process.exit(1);
+    }
+
+    // This script DROPs and re-seeds the `usage` database, so refuse to run against a
+    // non-local ClickHouse — a stray CLICKHOUSE_URL must not be able to wipe a remote
+    // instance. --allow-remote overrides (you almost certainly shouldn't).
+    const host = new URL(clickhouseUrl).hostname;
+    const LOCAL_HOSTS = new Set(['localhost', '127.0.0.1', '::1', '[::1]']);
+    if (!LOCAL_HOSTS.has(host) && !allowRemote) {
+        console.error(`✗ Refusing to run against non-local ClickHouse host "${host}".`);
+        console.error('  This script resets and seeds synthetic data — it is meant for local dev only.');
+        console.error('  Pass --allow-remote to override.');
         process.exit(1);
     }
 
@@ -359,21 +384,29 @@ async function main() {
             for (const [offset, batchId] of dayBatchIds.entries()) {
                 events.push(...generateForEnvDay(accountId, env.id, env.isProduction, dayTs(offset), batchId));
             }
-            // Insert in chunks to keep batch sizes sane; the batcher flushes the rest.
+            // Flush each chunk before generating the next. The whole generate loop is
+            // synchronous and never yields, so the batcher's auto-flush can't run mid-loop;
+            // without awaiting here the queue fills past maxQueueSize (default 500k) and
+            // silently drops the tail on long runs (large --days or many accounts). Awaiting
+            // flush per chunk applies backpressure and keeps the queue near-empty; the chunk
+            // stays below maxBatchSize so each flush drains it fully. Transient insert errors
+            // are retried by the batcher on the next flush / during shutdown.
             for (let i = 0; i < events.length; i += 1_000) {
                 clickhouse.addRaw(events.slice(i, i + 1_000));
+                await clickhouse.flush();
             }
             total += events.length;
             console.log(`  account ${accountId} · env ${env.id} (${env.name}): ${events.length} events`);
         }
     }
 
-    const flushed = await clickhouse.flush();
-    if (flushed.isErr()) {
-        console.error(`✗ Flush failed: ${flushed.error}`);
+    // shutdown() drains anything still queued, retrying within its timeout. If it errors,
+    // some events were dropped — fail loudly rather than report a count that didn't land.
+    const drained = await clickhouse.shutdown();
+    if (drained.isErr()) {
+        console.error(`✗ Not all events were persisted: ${drained.error}`);
         process.exit(1);
     }
-    await clickhouse.shutdown();
 
     const fromDay = new Date(dayTs(days - 1)).toISOString().split('T')[0];
     const toDay = new Date(dayTs(0)).toISOString().split('T')[0];


### PR DESCRIPTION
## Problem

The billing/usage breakdown dashboard can't be run locally: it reads usage from ClickHouse (empty on a fresh local DB), the billing-usage endpoint requires an Orb customer/subscription that isn't configured locally, and there's no way to populate realistic usage data — so iterating on usage UI means redeploying the backend.

## Solution

- Add `scripts/seed-clickhouse.ts` (`npm run seed:clickhouse`) that migrates the local ClickHouse `usage` DB and inserts synthetic events across every metric and breakdown dimension; materialized views aggregate them into the `daily_*` tables the dashboard reads.
- Fall back to a no-op billing client when `ORB_API_KEY` is unset, so billing-touching flows work locally without Orb (deployed envs set the key and keep using `OrbClient`, unchanged).
- Shape the data to mirror production and exercise the breakdown filter combobox: 20 integrations with overlapping names (search), hundreds of UUID connections skewed so a few integrations dominate, dev with ~10% of prod's connections (so prod is ~90% of traffic), function runs even per connection, and a function failure rate that fluctuates day to day.
- Document the script and its `.env` prerequisites in `scripts/README.md`.

## Testing

- Ran `npm run seed:clickhouse`, then verified on localhost that every usage metric renders with working group/filter breakdowns.
- Confirmed via ClickHouse: 20 integrations, hundreds of connections (dev ~10% of prod), prod ~90% of proxy traffic, function runs even across connections, and day-to-day failure fluctuation.
