### PR TITLE
refactor: drop @tabler/icons-react from webapp and connect-ui

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -38101,7 +38101,6 @@
                 "@sentry/react": "8.52.1",
                 "@stripe/react-stripe-js": "3.7.0",
                 "@stripe/stripe-js": "7.3.1",
-                "@tabler/icons-react": "3.21.0",
                 "@tailwindcss/forms": "0.5.10",
                 "@tailwindcss/vite": "4.3.1",
                 "@tanstack/react-form": "1.19.3",

--- a/package-lock.json
+++ b/package-lock.json
@@ -16091,32 +16091,6 @@
                 "@swc/counter": "^0.1.3"
             }
         },
-        "node_modules/@tabler/icons": {
-            "version": "3.21.0",
-            "resolved": "https://registry.npmjs.org/@tabler/icons/-/icons-3.21.0.tgz",
-            "integrity": "sha512-5+GkkmWCr1wgMor5cOF1/YYflTQdc15y10FUikJ3HW8hDiFjfbuoAHJi17FT1vwsr1sA78rkJMn+fDoOOjnnPA==",
-            "dev": true,
-            "funding": {
-                "type": "github",
-                "url": "https://github.com/sponsors/codecalm"
-            }
-        },
-        "node_modules/@tabler/icons-react": {
-            "version": "3.21.0",
-            "resolved": "https://registry.npmjs.org/@tabler/icons-react/-/icons-react-3.21.0.tgz",
-            "integrity": "sha512-Qq0GnZzzccbv/zuMyXAUUPlogNAqx9KsF8cr/ev3bxs+GMObqNEjXv1eZl9GFzxyQTS435siJNU8A1BaIYhX8g==",
-            "dev": true,
-            "dependencies": {
-                "@tabler/icons": "3.21.0"
-            },
-            "funding": {
-                "type": "github",
-                "url": "https://github.com/sponsors/codecalm"
-            },
-            "peerDependencies": {
-                "react": ">= 16"
-            }
-        },
         "node_modules/@tailwindcss/forms": {
             "version": "0.5.10",
             "resolved": "https://registry.npmjs.org/@tailwindcss/forms/-/forms-0.5.10.tgz",
@@ -33796,7 +33770,6 @@
                 "@radix-ui/react-label": "2.1.1",
                 "@radix-ui/react-select": "2.2.6",
                 "@radix-ui/react-slot": "1.1.1",
-                "@tabler/icons-react": "3.21.0",
                 "@tailwindcss/postcss": "4.3.1",
                 "@tailwindcss/vite": "4.3.1",
                 "@tanstack/react-query": "5.65.1",

--- a/packages/connect-ui/package.json
+++ b/packages/connect-ui/package.json
@@ -20,7 +20,6 @@
         "@radix-ui/react-label": "2.1.1",
         "@radix-ui/react-select": "2.2.6",
         "@radix-ui/react-slot": "1.1.1",
-        "@tabler/icons-react": "3.21.0",
         "@tailwindcss/postcss": "4.3.1",
         "@tailwindcss/vite": "4.3.1",
         "@tanstack/react-query": "5.65.1",

--- a/packages/connect-ui/src/views/Go.tsx
+++ b/packages/connect-ui/src/views/Go.tsx
@@ -1,7 +1,6 @@
 import { zodResolver } from '@hookform/resolvers/zod';
-import { IconCircleCheckFilled, IconCircleXFilled } from '@tabler/icons-react';
 import { Link, Navigate } from '@tanstack/react-router';
-import { ChevronDown, ChevronUp, ExternalLink, Info, TriangleAlert } from 'lucide-react';
+import { Check, ChevronDown, ChevronUp, ExternalLink, Info, TriangleAlert, X } from 'lucide-react';
 import { useCallback, useEffect, useMemo, useRef, useState } from 'react';
 import { useForm } from 'react-hook-form';
 import { useMount } from 'react-use';
@@ -396,7 +395,7 @@ export const Go: React.FC = () => {
                         detectClosedAuthWindow
                     });
                 } else {
-                    const params = { ...(values['params'] || {}) };
+                    const params = { ...values['params'] };
                     if (provider.auth_mode === 'AWS_SIGV4') {
                         params['external_id'] = awsExternalId;
                     }
@@ -470,7 +469,9 @@ export const Go: React.FC = () => {
                         <div className="relative w-16 h-16 p-2 rounded-sm border border-subtle bg-white">
                             <img alt={`${integration.display_name} logo`} src={integration.logo} />
                             <div className="absolute -bottom-3.5 -right-3.5 w-7 h-7 p-1 rounded-full bg-green-300">
-                                <IconCircleCheckFilled aria-hidden="true" className="w-full h-full text-green-600" />
+                                <div className="w-full h-full rounded-full bg-green-600 flex items-center justify-center">
+                                    <Check aria-hidden="true" className="w-3.5 h-3.5 text-white" strokeWidth={3} />
+                                </div>
                             </div>
                         </div>
                         <h2 className="text-xl font-semibold text-text-primary" id="connect-ui-title">
@@ -500,7 +501,9 @@ export const Go: React.FC = () => {
                         <div className="relative w-16 h-16 p-2 rounded-sm border border-subtle bg-white">
                             <img alt={`${integration.display_name} logo`} src={integration.logo} />
                             <div className="absolute -bottom-3.5 -right-3.5 w-7 h-7 p-1 rounded-full bg-red-300">
-                                <IconCircleXFilled aria-hidden="true" className="w-full h-full text-red-700" />
+                                <div className="w-full h-full rounded-full bg-red-700 flex items-center justify-center">
+                                    <X aria-hidden="true" className="w-3.5 h-3.5 text-white" strokeWidth={3} />
+                                </div>
                             </div>
                         </div>
                         <h2 className="text-xl font-semibold text-text-primary" id="connect-ui-title">

--- a/packages/connect-ui/vite.config.ts
+++ b/packages/connect-ui/vite.config.ts
@@ -12,10 +12,7 @@ export default defineConfig({
     plugins: [react(), svgr(), tailwindcss()] as UserConfig['plugins'],
     resolve: {
         alias: {
-            '@': path.resolve(__dirname, './src'),
-            // https://github.com/tabler/tabler-icons/issues/1233
-            // /esm/icons/index.mjs only exports the icons statically, so no separate chunks are created
-            '@tabler/icons-react': '@tabler/icons-react/dist/esm/icons/index.mjs'
+            '@': path.resolve(__dirname, './src')
         }
     },
     build: {

--- a/packages/design-system/.storybook/main.ts
+++ b/packages/design-system/.storybook/main.ts
@@ -30,8 +30,7 @@ const config: StorybookConfig = {
                 ...config.resolve,
                 alias: {
                     ...existingAlias,
-                    '@': path.resolve(__dirname, '../../webapp/src'),
-                    '@tabler/icons-react': '@tabler/icons-react/dist/esm/icons/index.mjs'
+                    '@': path.resolve(__dirname, '../../webapp/src')
                 }
             },
             server: {

--- a/packages/webapp/package.json
+++ b/packages/webapp/package.json
@@ -51,7 +51,6 @@
         "@sentry/react": "8.52.1",
         "@stripe/react-stripe-js": "3.7.0",
         "@stripe/stripe-js": "7.3.1",
-        "@tabler/icons-react": "3.21.0",
         "@tailwindcss/forms": "0.5.10",
         "@tailwindcss/vite": "4.3.1",
         "@tanstack/react-form": "1.19.3",

--- a/packages/webapp/src/components/patterns/PeriodSelector.tsx
+++ b/packages/webapp/src/components/patterns/PeriodSelector.tsx
@@ -1,5 +1,5 @@
-import { IconCalendar, IconCheck } from '@tabler/icons-react';
 import { format, subDays } from 'date-fns';
+import { Calendar, Check } from 'lucide-react';
 import { useEffect, useMemo, useState } from 'react';
 
 import { Button } from '@nangohq/design-system';
@@ -97,7 +97,7 @@ export const PeriodSelector = ({ period, isLive, onChange, presets, defaultPrese
         >
             <PopoverTrigger asChild>
                 <Button variant="outline" size="lg" className="grow truncate tabular-nums">
-                    <IconCalendar size={18} />
+                    <Calendar size={18} />
                     {buttonDisplay} {isLive && '(live)'}
                 </Button>
             </PopoverTrigger>
@@ -116,7 +116,7 @@ export const PeriodSelector = ({ period, isLive, onChange, presets, defaultPrese
                             )}
                         >
                             <div className="w-12 shrink-0 flex justify-center items-center h-full p-1 bg-surface-panel-muted rounded-md font-medium">
-                                <IconCalendar size={18} />
+                                <Calendar size={18} />
                             </div>
                             <form onSubmit={onSubmitCustomRange} className="w-full">
                                 <input
@@ -147,7 +147,7 @@ export const PeriodSelector = ({ period, isLive, onChange, presets, defaultPrese
                                         </div>
                                         <span>{preset.label}</span>
                                     </div>
-                                    {selectedPreset?.name === preset.name && <IconCheck className="w-4 h-4 mr-2" />}
+                                    {selectedPreset?.name === preset.name && <Check className="w-4 h-4 mr-2" />}
                                 </div>
                             );
                         })}

--- a/packages/webapp/src/pages/Connection/Create.tsx
+++ b/packages/webapp/src/pages/Connection/Create.tsx
@@ -1,6 +1,5 @@
 import { zodResolver } from '@hookform/resolvers/zod';
-import { IconBook } from '@tabler/icons-react';
-import { ExternalLink } from 'lucide-react';
+import { Book, ExternalLink } from 'lucide-react';
 import { useEffect, useMemo, useState } from 'react';
 import { Helmet } from 'react-helmet';
 import { useForm } from 'react-hook-form';
@@ -175,7 +174,7 @@ export const ConnectionCreate: React.FC = () => {
                                     <h2>Authorize users from your app</h2>
                                 </div>
                                 <div className="rounded-full border border-border-muted p-1.5 h-8 w-8">
-                                    <IconBook stroke={1} size={18} />
+                                    <Book strokeWidth={1} size={18} />
                                 </div>
                             </header>
                             <main>

--- a/packages/webapp/src/pages/Environment/Settings/ApiKeys.tsx
+++ b/packages/webapp/src/pages/Environment/Settings/ApiKeys.tsx
@@ -1,5 +1,4 @@
-import { IconExternalLink, IconEye, IconEyeOff, IconKey } from '@tabler/icons-react';
-import { Pencil, Trash2 } from 'lucide-react';
+import { ExternalLink, Eye, EyeOff, Key, Pencil, Trash2 } from 'lucide-react';
 import { useState } from 'react';
 
 import { permissions } from '@nangohq/authz';
@@ -124,7 +123,7 @@ const ScopeSelector: React.FC<ScopeSelectorProps> = ({ selectedScopes, onChange,
                             rel="noopener noreferrer"
                             className="text-text-muted hover:text-text-strong"
                         >
-                            <IconExternalLink stroke={1} size={14} />
+                            <ExternalLink strokeWidth={1} size={14} />
                         </a>
                     </div>
                 )}
@@ -275,7 +274,7 @@ const CreateApiKeyDialog: React.FC<CreateApiKeyDialogProps> = ({ env, onCreated,
         <Dialog open={open} onOpenChange={setOpen}>
             <DialogTrigger asChild>
                 <Button variant="primary" disabled={disabled}>
-                    <IconKey stroke={1} size={16} />
+                    <Key strokeWidth={1} size={16} />
                     Create new API key
                 </Button>
             </DialogTrigger>
@@ -380,7 +379,7 @@ const KeyConfig: React.FC<KeyConfigProps> = ({ apiKey, env, onBack, canReadSecre
                                     onClick={() => setSecretRevealed((r) => !r)}
                                     className="text-text-muted hover:text-text-strong h-7 w-7"
                                 >
-                                    {secretRevealed ? <IconEyeOff stroke={1} size={16} /> : <IconEye stroke={1} size={16} />}
+                                    {secretRevealed ? <EyeOff strokeWidth={1} size={16} /> : <Eye strokeWidth={1} size={16} />}
                                 </IconButton>
                                 <CopyButton text={apiKey.secret} />
                             </div>
@@ -453,7 +452,7 @@ const ManagedSecretKeyView: React.FC<{ secretKey: string; env: string }> = ({ se
                                 onClick={() => setRevealed((r) => !r)}
                                 className="text-text-muted hover:text-text-strong h-7 w-7"
                             >
-                                {revealed ? <IconEyeOff stroke={1} size={16} /> : <IconEye stroke={1} size={16} />}
+                                {revealed ? <EyeOff strokeWidth={1} size={16} /> : <Eye strokeWidth={1} size={16} />}
                             </IconButton>
                             <CopyButton text={secretKey} />
                         </div>

--- a/packages/webapp/src/pages/Environment/Settings/Backend.tsx
+++ b/packages/webapp/src/pages/Environment/Settings/Backend.tsx
@@ -1,5 +1,4 @@
-import { IconExternalLink } from '@tabler/icons-react';
-import { Info } from 'lucide-react';
+import { ExternalLink, Info } from 'lucide-react';
 import { useState } from 'react';
 import { Link } from 'react-router-dom';
 
@@ -47,7 +46,7 @@ export const BackendSettings: React.FC = () => {
                                 target="_blank"
                                 to="https://nango.dev/docs/guides/auth/auth-guide#custom-oauth-callback-url-optional"
                             >
-                                <IconExternalLink stroke={1} size={18} />
+                                <ExternalLink strokeWidth={1} size={18} />
                             </Link>
                         </div>
                     </>

--- a/packages/webapp/src/pages/Environment/Settings/components/DeleteButton.tsx
+++ b/packages/webapp/src/pages/Environment/Settings/components/DeleteButton.tsx
@@ -1,4 +1,4 @@
-import { Trash } from 'lucide-react';
+import { Trash2 } from 'lucide-react';
 
 import { permissions } from '@nangohq/authz';
 import { Button } from '@nangohq/design-system';
@@ -29,7 +29,7 @@ export const DeleteButton: React.FC<DeleteButtonProps> = ({ environmentName, onD
             <PermissionGate condition={canDeleteEnvironment}>
                 {(allowed) => (
                     <Button variant="danger" disabled={!!disabled || !allowed}>
-                        <Trash strokeWidth={1} size={18} />
+                        <Trash2 strokeWidth={1} size={18} />
                         <span>Delete environment</span>
                     </Button>
                 )}

--- a/packages/webapp/src/pages/Environment/Settings/components/DeleteButton.tsx
+++ b/packages/webapp/src/pages/Environment/Settings/components/DeleteButton.tsx
@@ -1,4 +1,4 @@
-import { IconTrash } from '@tabler/icons-react';
+import { Trash } from 'lucide-react';
 
 import { permissions } from '@nangohq/authz';
 import { Button } from '@nangohq/design-system';
@@ -29,7 +29,7 @@ export const DeleteButton: React.FC<DeleteButtonProps> = ({ environmentName, onD
             <PermissionGate condition={canDeleteEnvironment}>
                 {(allowed) => (
                     <Button variant="danger" disabled={!!disabled || !allowed}>
-                        <IconTrash stroke={1} size={18} />
+                        <Trash strokeWidth={1} size={18} />
                         <span>Delete environment</span>
                     </Button>
                 )}

--- a/packages/webapp/src/pages/GettingStarted/ClassicGettingStarted.tsx
+++ b/packages/webapp/src/pages/GettingStarted/ClassicGettingStarted.tsx
@@ -1,5 +1,5 @@
-import { IconChevronRight, IconLockOpen2, IconPencil, IconPlayerPlay, IconRefresh, IconTool } from '@tabler/icons-react';
 import { useScript } from '@uidotdev/usehooks';
+import { ChevronRight, LockOpen, Pencil, Play, RefreshCw, Wrench } from 'lucide-react';
 import { useEffect, useState } from 'react';
 import { Helmet } from 'react-helmet';
 
@@ -96,7 +96,7 @@ export const ClassicGettingStarted: React.FC = () => {
                     <img src="/images/demo_thumbnail.png" alt="" className="rounded-lg" />
                     <div className="absolute w-full h-full top-0 left-0 flex items-center justify-center z-10 text-text-strong">
                         <div className="transition-transform bg-surface-panel p-2 rounded-full shadow-[0_1px_100px_50px_black] group-hover:animate-pulse">
-                            <IconPlayerPlay size={50} fill="#000" />
+                            <Play size={50} fill="#000" />
                         </div>
                     </div>
                 </div>
@@ -116,7 +116,7 @@ export const ClassicGettingStarted: React.FC = () => {
                             <h2>Authorize</h2>
                         </div>
                         <div className="rounded-full border border-border-muted p-1.5 h-8 w-8">
-                            <IconLockOpen2 stroke={1} size={18} />
+                            <LockOpen strokeWidth={1} size={18} />
                         </div>
                     </header>
                     <main>
@@ -124,7 +124,7 @@ export const ClassicGettingStarted: React.FC = () => {
                     </main>
                     <footer className="mt-4">
                         <Button variant={'ghost'} className="group-hover:text-text-strong group-focus:text-text-strong">
-                            Learn more <IconChevronRight stroke={1} size={20} />
+                            Learn more <ChevronRight strokeWidth={1} size={20} />
                         </Button>
                     </footer>
                 </a>
@@ -142,7 +142,7 @@ export const ClassicGettingStarted: React.FC = () => {
                             <h2>Read data</h2>
                         </div>
                         <div className="rounded-full border border-border-muted p-1.5 h-8 w-8">
-                            <IconRefresh stroke={1} size={18} />
+                            <RefreshCw strokeWidth={1} size={18} />
                         </div>
                     </header>
                     <main>
@@ -150,7 +150,7 @@ export const ClassicGettingStarted: React.FC = () => {
                     </main>
                     <footer className="mt-4">
                         <Button variant={'ghost'} className="group-hover:text-text-strong group-focus:text-text-strong">
-                            Learn more <IconChevronRight stroke={1} size={20} />
+                            Learn more <ChevronRight strokeWidth={1} size={20} />
                         </Button>
                     </footer>
                 </a>
@@ -168,7 +168,7 @@ export const ClassicGettingStarted: React.FC = () => {
                             <h2>Write data</h2>
                         </div>
                         <div className="rounded-full border border-border-muted p-1.5 h-8 w-8">
-                            <IconPencil stroke={1} size={18} />
+                            <Pencil strokeWidth={1} size={18} />
                         </div>
                     </header>
                     <main>
@@ -176,7 +176,7 @@ export const ClassicGettingStarted: React.FC = () => {
                     </main>
                     <footer className="mt-4">
                         <Button variant={'ghost'} className="group-hover:text-text-strong group-focus:text-text-strong">
-                            Learn more <IconChevronRight stroke={1} size={20} />
+                            Learn more <ChevronRight strokeWidth={1} size={20} />
                         </Button>
                     </footer>
                 </a>
@@ -194,7 +194,7 @@ export const ClassicGettingStarted: React.FC = () => {
                             <h2>Build custom integrations</h2>
                         </div>
                         <div className="rounded-full border border-border-muted p-1.5 h-8 w-8">
-                            <IconTool stroke={1} size={18} />
+                            <Wrench strokeWidth={1} size={18} />
                         </div>
                     </header>
                     <main>
@@ -202,7 +202,7 @@ export const ClassicGettingStarted: React.FC = () => {
                     </main>
                     <footer className="mt-4">
                         <Button variant={'ghost'} className="group-hover:text-text-strong group-focus:text-text-strong">
-                            Learn more <IconChevronRight stroke={1} size={20} />
+                            Learn more <ChevronRight strokeWidth={1} size={20} />
                         </Button>
                     </footer>
                 </a>

--- a/packages/webapp/src/pages/GettingStarted/FirstStep.tsx
+++ b/packages/webapp/src/pages/GettingStarted/FirstStep.tsx
@@ -1,4 +1,4 @@
-import { IconBrandGithub } from '@tabler/icons-react';
+import { Github } from 'lucide-react';
 import { useCallback, useRef } from 'react';
 import { useUnmount } from 'react-use';
 
@@ -123,7 +123,7 @@ export const FirstStep: React.FC<FirstStepProps> = ({ connection, integration, o
                 </div>
                 <div className="w-fit">
                     <Button variant="outline" size="xl" onClick={onClickDisconnect} loading={isDeletingConnection}>
-                        <IconBrandGithub className="size-5 mr-2" />
+                        <Github className="size-5 mr-2" />
                         Disconnect from Github
                     </Button>
                 </div>
@@ -146,7 +146,7 @@ export const FirstStep: React.FC<FirstStepProps> = ({ connection, integration, o
             </div>
             <div className="w-fit">
                 <Button variant="primary" size="xl" onClick={onClickConnect}>
-                    <IconBrandGithub className="size-5" />
+                    <Github className="size-5" />
                     Connect to Github
                 </Button>
             </div>

--- a/packages/webapp/src/pages/GettingStarted/SecondStep.tsx
+++ b/packages/webapp/src/pages/GettingStarted/SecondStep.tsx
@@ -1,5 +1,4 @@
-import { IconBrandNodejs, IconTerminal2 } from '@tabler/icons-react';
-import { CodeXml, Loader } from 'lucide-react';
+import { CodeXml, Loader, Server, Terminal } from 'lucide-react';
 import { useMemo, useState } from 'react';
 
 import { Button } from '@nangohq/design-system';
@@ -144,14 +143,14 @@ export const SecondStep: React.FC<SecondStepProps> = ({ connectionId, providerCo
                             snippets={[
                                 {
                                     displayLanguage: 'Node Client',
-                                    icon: <IconBrandNodejs className="w-4 h-4" />,
+                                    icon: <Server className="w-4 h-4" />,
                                     language: 'typescript',
                                     code: nodeClientCode,
                                     highlightedLines: isTooltipOpen ? [7] : undefined
                                 },
                                 {
                                     displayLanguage: 'cURL',
-                                    icon: <IconTerminal2 className="w-4 h-4" />,
+                                    icon: <Terminal className="w-4 h-4" />,
                                     language: 'bash',
                                     code: curlCode,
                                     highlightedLines: isTooltipOpen ? [4] : undefined

--- a/packages/webapp/src/pages/Logs/Operation/Message/Show.tsx
+++ b/packages/webapp/src/pages/Logs/Operation/Message/Show.tsx
@@ -1,5 +1,5 @@
 import { Prism } from '@mantine/prism';
-import { IconCalendar, IconClockHour4 } from '@tabler/icons-react';
+import { Calendar, Clock } from 'lucide-react';
 import { useMemo } from 'react';
 
 import { Tag } from '@/components/ui/Tag';
@@ -68,14 +68,14 @@ export const ShowMessage: React.FC<{ message: MessageRow }> = ({ message }) => {
                         <div className="flex gap-2 items-center">
                             <div className="flex bg-border-default w-px h-[16px]">&nbsp;</div>
                             <div className="flex gap-2 items-center">
-                                <IconClockHour4 stroke={1} size={18} />
+                                <Clock strokeWidth={1} size={18} />
                                 <div className="text-text-muted text-s pt-px font-code">{duration}</div>
                             </div>
                         </div>
                     ) : null}
                     <div className="flex bg-border-default w-px h-[16px]">&nbsp;</div>
                     <div className="flex gap-2 items-center">
-                        <IconCalendar stroke={1} size={18} />
+                        <Calendar strokeWidth={1} size={18} />
                         <div className="text-text-muted text-s pt-px font-code">{createdAt}</div>
                     </div>
                 </div>

--- a/packages/webapp/src/pages/Logs/Operation/Show.tsx
+++ b/packages/webapp/src/pages/Logs/Operation/Show.tsx
@@ -1,6 +1,5 @@
 import { Prism } from '@mantine/prism';
-import { IconCalendar, IconClockHour4 } from '@tabler/icons-react';
-import { ExternalLink } from 'lucide-react';
+import { Calendar, Clock, ExternalLink } from 'lucide-react';
 import { useMemo } from 'react';
 import { Link } from 'react-router-dom';
 import { useInterval } from 'react-use';
@@ -109,12 +108,12 @@ export const ShowOperation: React.FC<{ operationId: string }> = ({ operationId }
                     </div>
                     <div className="flex bg-border-default w-px h-[16px]">&nbsp;</div>
                     <div className="flex gap-2 items-center">
-                        <IconClockHour4 stroke={1} size={18} />
+                        <Clock strokeWidth={1} size={18} />
                         <div className="text-text-muted text-s pt-px font-code">{duration}</div>
                     </div>
                     <div className="flex bg-border-default w-px h-[16px]">&nbsp;</div>
                     <div className="flex gap-2 items-center">
-                        <IconCalendar stroke={1} size={18} />
+                        <Calendar strokeWidth={1} size={18} />
                         <div className="text-text-muted text-s pt-px font-code">{createdAt}</div>
                     </div>
                 </div>

--- a/packages/webapp/src/pages/Logs/Operation/components/Logs.tsx
+++ b/packages/webapp/src/pages/Logs/Operation/components/Logs.tsx
@@ -1,8 +1,8 @@
-import { IconArrowLeft, IconX, IconZoom } from '@tabler/icons-react';
 import { useInfiniteQuery } from '@tanstack/react-query';
 import { flexRender, getCoreRowModel, useReactTable } from '@tanstack/react-table';
 import { useVirtualizer } from '@tanstack/react-virtual';
 import { addMinutes } from 'date-fns';
+import { ArrowLeft, Search, X } from 'lucide-react';
 import { useCallback, useEffect, useLayoutEffect, useMemo, useRef, useState } from 'react';
 import { useDebounce, useInterval, useMount } from 'react-use';
 
@@ -211,7 +211,7 @@ export const Logs: React.FC<{ operation: OperationRow; operationId: string; isLi
             <header className="flex gap-2 items-center">
                 <InputGroup className="grow border-border-muted">
                     <InputGroupAddon>
-                        <IconZoom stroke={1} size={18} />
+                        <Search strokeWidth={1} size={18} />
                     </InputGroupAddon>
                     <InputGroupInput value={search} placeholder="Search logs..." onChange={(e) => setSearch(e.target.value)} />
                     {search && (
@@ -225,7 +225,7 @@ export const Logs: React.FC<{ operation: OperationRow; operationId: string; isLi
                                     setSearch('');
                                 }}
                             >
-                                <IconX stroke={1} size={16} />
+                                <X strokeWidth={1} size={16} />
                             </InputGroupButton>
                         </InputGroupAddon>
                     )}
@@ -308,7 +308,7 @@ export const Logs: React.FC<{ operation: OperationRow; operationId: string; isLi
                                 title="Close"
                                 className="w-10 h-10 flex items-center justify-center text-text-muted hover:text-text-strong focus:text-text-strong"
                             >
-                                <IconArrowLeft stroke={1} size={24} />
+                                <ArrowLeft strokeWidth={1} size={24} />
                             </SheetClose>
                         </div>
                         {message && <ShowMessage message={message} />}

--- a/packages/webapp/src/pages/Logs/Operation/constants.tsx
+++ b/packages/webapp/src/pages/Logs/Operation/constants.tsx
@@ -1,4 +1,4 @@
-import { IconChevronRight } from '@tabler/icons-react';
+import { ChevronRight } from 'lucide-react';
 
 import { Tag } from '@/components/ui/Tag';
 import { formatDateToLogFormat, millisecondsToRuntime } from '../../../utils/utils';
@@ -67,7 +67,7 @@ export const columns: ColumnDef<SearchMessagesData>[] = [
             }
             return (
                 <div className="-ml-2">
-                    <IconChevronRight stroke={1} size={18} />
+                    <ChevronRight strokeWidth={1} size={18} />
                 </div>
             );
         }

--- a/packages/webapp/src/pages/Logs/components/OperationTag.tsx
+++ b/packages/webapp/src/pages/Logs/components/OperationTag.tsx
@@ -1,4 +1,4 @@
-import { Forward, Layers, Link, Lock, Pause, Play, Plus, RefreshCw, Settings, Settings2, Trash, X } from 'lucide-react';
+import { Forward, Layers, Link, Lock, Pause, Play, Plus, RefreshCw, Settings, Settings2, Trash2, X } from 'lucide-react';
 
 import { Tag } from '@/components/ui/Tag';
 import { Tooltip, TooltipContent, TooltipTrigger } from '@/components/ui/Tooltip';
@@ -21,7 +21,7 @@ export const OperationTag: React.FC<{ message: string; operation: SearchOperatio
                             {operation.action === 'unpause' && <Play className="w-3.5 h-3.5" />}
                             {operation.action === 'run' && <RefreshCw className="w-3.5 h-3.5" />}
                             {operation.action === 'create_variant' && <Layers className="w-3.5 h-3.5" />}
-                            {operation.action === 'delete_variant' && <Trash className="w-3.5 h-3.5" />}
+                            {operation.action === 'delete_variant' && <Trash2 className="w-3.5 h-3.5" />}
                         </Tag>
                     )}
 

--- a/packages/webapp/src/pages/Logs/components/OperationTag.tsx
+++ b/packages/webapp/src/pages/Logs/components/OperationTag.tsx
@@ -1,18 +1,4 @@
-import {
-    IconArrowForward,
-    IconClockPause,
-    IconClockPlay,
-    IconLink,
-    IconLock,
-    IconPlayerPlay,
-    IconPlus,
-    IconRefresh,
-    IconSettings,
-    IconSettingsAutomation,
-    IconStack2,
-    IconTrash,
-    IconX
-} from '@tabler/icons-react';
+import { Forward, Layers, Link, Lock, Pause, Play, Plus, RefreshCw, Settings, Settings2, Trash, X } from 'lucide-react';
 
 import { Tag } from '@/components/ui/Tag';
 import { Tooltip, TooltipContent, TooltipTrigger } from '@/components/ui/Tooltip';
@@ -27,33 +13,33 @@ export const OperationTag: React.FC<{ message: string; operation: SearchOperatio
                     <Tag>{operation.type}</Tag>
                     {operation.type === 'sync' && (
                         <Tag>
-                            {operation.action === 'cancel' && <IconX className="w-3.5 h-3.5" />}
-                            {operation.action === 'init' && <IconPlus className="w-3.5 h-3.5" />}
-                            {operation.action === 'pause' && <IconClockPause className="w-3.5 h-3.5" />}
-                            {operation.action === 'request_run' && <IconPlayerPlay className="w-3.5 h-3.5" />}
-                            {operation.action === 'request_run_full' && <IconPlayerPlay className="w-3.5 h-3.5" />}
-                            {operation.action === 'unpause' && <IconClockPlay className="w-3.5 h-3.5" />}
-                            {operation.action === 'run' && <IconRefresh className="w-3.5 h-3.5" />}
-                            {operation.action === 'create_variant' && <IconStack2 className="w-3.5 h-3.5" />}
-                            {operation.action === 'delete_variant' && <IconTrash className="w-3.5 h-3.5" />}
+                            {operation.action === 'cancel' && <X className="w-3.5 h-3.5" />}
+                            {operation.action === 'init' && <Plus className="w-3.5 h-3.5" />}
+                            {operation.action === 'pause' && <Pause className="w-3.5 h-3.5" />}
+                            {operation.action === 'request_run' && <Play className="w-3.5 h-3.5" />}
+                            {operation.action === 'request_run_full' && <Play className="w-3.5 h-3.5" />}
+                            {operation.action === 'unpause' && <Play className="w-3.5 h-3.5" />}
+                            {operation.action === 'run' && <RefreshCw className="w-3.5 h-3.5" />}
+                            {operation.action === 'create_variant' && <Layers className="w-3.5 h-3.5" />}
+                            {operation.action === 'delete_variant' && <Trash className="w-3.5 h-3.5" />}
                         </Tag>
                     )}
 
                     {operation.type === 'auth' && (
                         <Tag>
-                            {operation.action === 'create_connection' && <IconPlus className="w-3.5 h-3.5" />}
-                            {operation.action === 'post_connection' && <IconSettingsAutomation className="w-3.5 h-3.5" />}
-                            {operation.action === 'refresh_token' && <IconRefresh className="w-3.5 h-3.5" />}
+                            {operation.action === 'create_connection' && <Plus className="w-3.5 h-3.5" />}
+                            {operation.action === 'post_connection' && <Settings2 className="w-3.5 h-3.5" />}
+                            {operation.action === 'refresh_token' && <RefreshCw className="w-3.5 h-3.5" />}
                         </Tag>
                     )}
 
                     {operation.type === 'webhook' && (
                         <Tag>
-                            {operation.action === 'forward' && <IconArrowForward className="w-3.5 h-3.5" />}
-                            {operation.action === 'incoming' && <IconSettings className="w-3.5 h-3.5" />}
-                            {operation.action === 'connection_create' && <IconLink className="w-3.5 h-3.5" />}
-                            {operation.action === 'sync' && <IconRefresh className="w-3.5 h-3.5" />}
-                            {operation.action === 'connection_refresh' && <IconLock className="w-3.5 h-3.5" />}
+                            {operation.action === 'forward' && <Forward className="w-3.5 h-3.5" />}
+                            {operation.action === 'incoming' && <Settings className="w-3.5 h-3.5" />}
+                            {operation.action === 'connection_create' && <Link className="w-3.5 h-3.5" />}
+                            {operation.action === 'sync' && <RefreshCw className="w-3.5 h-3.5" />}
+                            {operation.action === 'connection_refresh' && <Lock className="w-3.5 h-3.5" />}
                         </Tag>
                     )}
                 </div>

--- a/packages/webapp/src/pages/Logs/components/SearchAllOperations.tsx
+++ b/packages/webapp/src/pages/Logs/components/SearchAllOperations.tsx
@@ -1,7 +1,7 @@
-import { IconSearch, IconX } from '@tabler/icons-react';
 import { keepPreviousData, useInfiniteQuery } from '@tanstack/react-query';
 import { flexRender, getCoreRowModel, useReactTable } from '@tanstack/react-table';
 import { useVirtualizer } from '@tanstack/react-virtual';
+import { Search, X } from 'lucide-react';
 import { parseAsArrayOf, parseAsBoolean, parseAsString, parseAsStringEnum, parseAsStringLiteral, parseAsTimestamp, useQueryState } from 'nuqs';
 import { useCallback, useEffect, useLayoutEffect, useMemo, useRef, useState } from 'react';
 import { useDebounce, useInterval, useMount, useWindowSize } from 'react-use';
@@ -261,13 +261,13 @@ export const SearchAllOperations: React.FC<Props> = ({ onSelectOperation }) => {
                 <div className="flex-1 min-w-0">
                     <InputGroup className="border-border-muted">
                         <InputGroupAddon>
-                            <IconSearch stroke={1} size={16} />
+                            <Search strokeWidth={1} size={16} />
                         </InputGroupAddon>
                         <InputGroupInput placeholder="Search logs..." onChange={(e) => setSearch(e.target.value)} value={search} />
                         {search && (
                             <InputGroupAddon align="inline-end">
                                 <InputGroupButton label="Clear search" variant={'ghost'} size={'icon-xs'} onClick={() => setSearch('')}>
-                                    <IconX stroke={1} size={18} />
+                                    <X strokeWidth={1} size={18} />
                                 </InputGroupButton>
                             </InputGroupAddon>
                         )}

--- a/packages/webapp/vite.config.ts
+++ b/packages/webapp/vite.config.ts
@@ -96,10 +96,7 @@ export default defineConfig(() => {
         plugins: [react(), svgr(), checker({ typescript: true }), tailwindcss(), envProxyPlugin],
         resolve: {
             alias: {
-                '@': path.resolve(__dirname, './src'),
-                // https://github.com/tabler/tabler-icons/issues/1233
-                // /esm/icons/index.mjs only exports the icons statically, so no separate chunks are created
-                '@tabler/icons-react': '@tabler/icons-react/dist/esm/icons/index.mjs'
+                '@': path.resolve(__dirname, './src')
             }
         },
         server: { port: DEV_PORT, proxy },


### PR DESCRIPTION
## Problem

The frontend shipped two icon libraries — `lucide-react` (primary) and `@tabler/icons-react` — across the webapp (~14 files) and connect-ui (1 file). Carrying both inflated bundles with duplicate glyph data and added an extra dependency in two packages.

## Solution

- Replace every `@tabler/icons-react` usage with its closest `lucide-react` equivalent (Tabler's `stroke` prop → Lucide's `strokeWidth`).
- webapp: swap ~30 icons across 14 files; delete icons use `Trash2` to match existing usage.
- connect-ui: replace the success/failure badges (`IconCircleCheckFilled`/`IconCircleXFilled`) with a solid green-600/red-700 circle wrapping a white lucide `Check`/`X`.
- Remove `@tabler/icons-react` from both `package.json` files and drop the now-dead Tabler vite aliases (webapp, connect-ui, and the design-system Storybook — which never actually depended on Tabler).

`@tabler/icons-react` no longer appears anywhere in the repo or the lockfile.

Fixes [NAN-5898](https://linear.app/nango/issue/NAN-5898)

## Testing

- `tsc` (0 errors) and `oxlint` (0 errors) pass for webapp and connect-ui; both build successfully.
- webapp main chunk 2,541.03 → 2,535.18 kB (−5.85 kB raw, −1.76 kB gzip). Savings are modest because the old vite alias already tree-shook Tabler to only-used icons — the main win is dropping the dependency from two packages.
- webapp: spot-checked live (dev backend) — Getting Started (Github), Logs list + operation detail (Search, Calendar, operation tags, Clock, ExternalLink, ChevronRight), API Keys (Key, Eye, ExternalLink), Connection Create (Book) all render correctly.
- connect-ui: compared the success/failure badges before/after — the solid-circle + white Check/X closely matches the previous filled look at the same size and ring.
