### PR TITLE
fix(providers): Fix Tanium verification URL and hostname

### DIFF
--- a/docs/api-integrations/tanium.mdx
+++ b/docs/api-integrations/tanium.mdx
@@ -18,7 +18,7 @@ Connect to Tanium with Nango and see data flow in 2 minutes.
             <Tab title="cURL">
 
                 ```bash
-                curl "https://api.nango.dev/proxy/v2/session/info" \
+                curl "https://api.nango.dev/proxy/v2/session/current" \
                   -H "Authorization: Bearer <NANGO-SECRET-KEY>" \
                   -H "Provider-Config-Key: <INTEGRATION-ID>" \
                   -H "Connection-Id: <CONNECTION-ID>"
@@ -36,7 +36,7 @@ Connect to Tanium with Nango and see data flow in 2 minutes.
             const nango = new Nango({ secretKey: '<NANGO-SECRET-KEY>' });
 
             const res = await nango.get({
-                endpoint: '/v2/session/info',
+                endpoint: '/v2/session/current',
                 providerConfigKey: '<INTEGRATION-ID>',
                 connectionId: '<CONNECTION-ID>'
             });

--- a/docs/api-integrations/tanium/connect.mdx
+++ b/docs/api-integrations/tanium/connect.mdx
@@ -7,7 +7,7 @@ sidebarTitle: Tanium
 
 To authenticate with Tanium, you will need:
 1. **API Token** — an API token generated from the Tanium Console.
-2. **Hostname** — your Tanium Cloud hostname (e.g. `acme.cloud.tanium.com`).
+2. **Hostname** — your Tanium Cloud API hostname (e.g. `acme-api.cloud.tanium.com`).
 
 This guide walks you through generating your **API Token** and finding your **Hostname** in Tanium.
 
@@ -27,7 +27,8 @@ This guide walks you through generating your **API Token** and finding your **Ho
 
 #### Step 2: Find your hostname
 
-- Your Tanium Cloud hostname is the domain you use to access the Tanium Console, for example `acme.cloud.tanium.com`.
+- Tanium Cloud uses a separate hostname for API access. Take the domain you use to access the Tanium Console (for example `acme.cloud.tanium.com`) and append `-api` to the subdomain: `acme-api.cloud.tanium.com`.
+- For Tanium Cloud for U.S. Government, use `-api.cloud.taniumfed.com` instead of `-api.cloud.tanium.com`.
 
 
 #### Step 3: Enter credentials in the Connect UI

--- a/packages/providers/providers.yaml
+++ b/packages/providers/providers.yaml
@@ -20519,7 +20519,7 @@ tanium:
         verification:
             method: GET
             endpoints:
-                - /v2/session/info
+                - /v2/session/current
     docs: https://nango.dev/docs/api-integrations/tanium
     docs_connect: https://nango.dev/docs/api-integrations/tanium/connect
     credentials:
@@ -20532,8 +20532,8 @@ tanium:
         hostname:
             type: string
             title: Hostname
-            description: Your Tanium Cloud hostname.
-            example: acme.cloud.tanium.com
+            description: Your Tanium Cloud API hostname.
+            example: acme-api.cloud.tanium.com
             format: hostname
             prefix: https://
             doc_section: '#step-2-find-your-hostname'


### PR DESCRIPTION
<!-- Describe the problem and your solution --> 
Incorrect verification URL and docs indicate to use cloud console host name instead of API host name

<!-- Issue ticket number and link (if applicable) -->
[NAN-6087: fix(providers): Incorrect URLs in Tanium provider](https://linear.app/nango/issue/NAN-6087/fixproviders-incorrect-urls-in-tanium-provider)

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/NangoHQ/nango/pull/6644?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

