### PR TITLE
feat(design-system): align input and button sizing on one scale

### DIFF
--- a/packages/design-system/src/components/ui/button.stories.tsx
+++ b/packages/design-system/src/components/ui/button.stories.tsx
@@ -14,9 +14,8 @@ type Story = StoryObj<typeof meta>;
 
 const VARIANTS = ['primary', 'secondary', 'outline', 'ghost', 'danger', 'link-danger'] as const;
 const ICON_VARIANTS = ['primary', 'secondary', 'outline', 'ghost', 'danger'] as const;
-// 'xl' (40px) is a deprecated migration-only size (flagged in the "All sizes" story).
-const SIZES = ['xs', 'sm', 'md', 'lg', 'xl'] as const;
-// IconButton supports 2xs (20px) through lg; xl is not offered for icon buttons.
+const SIZES = ['xs', 'sm', 'md', 'lg'] as const;
+// IconButton supports 2xs (20px) through lg.
 const ICON_SIZES = ['2xs', 'xs', 'sm', 'md', 'lg'] as const;
 
 export const AllVariants: Story = {
@@ -51,10 +50,6 @@ export const AllSizes: Story = {
     name: 'All sizes',
     render: () => (
         <div className="flex flex-col gap-10">
-            <div className="max-w-2xl rounded-ds-sm border-ds-1 border-status-warning-border bg-status-warning-bg px-3 py-2 text-ds-sm text-status-warning-text">
-                <p className="font-ds-medium text-status-warning-strong">xl is deprecated</p>
-                <p>xl (40px) exists only to migrate legacy 40px webapp buttons. Use lg for new buttons.</p>
-            </div>
             {SIZES.map((size) => (
                 <div key={size} className="flex items-center gap-6">
                     <span className="text-ds-xs text-text-secondary w-12 shrink-0">{size}</span>

--- a/packages/design-system/src/components/ui/button.tsx
+++ b/packages/design-system/src/components/ui/button.tsx
@@ -88,9 +88,7 @@ export const buttonVariants = cva(
                 xs: 'h-6 px-1.5 text-ds-xs',
                 sm: 'h-7 px-2',
                 md: 'h-8 px-2.5',
-                lg: 'h-9 px-3',
-                // @deprecated 40px — legacy webapp size, kept only to migrate existing usages; do not use for new buttons
-                xl: 'h-10 px-4'
+                lg: 'h-9 px-3'
             }
         },
         defaultVariants: {

--- a/packages/design-system/src/components/ui/input-group.stories.tsx
+++ b/packages/design-system/src/components/ui/input-group.stories.tsx
@@ -75,6 +75,16 @@ export const Addons: Story = {
                     </InputGroupAddon>
                 </InputGroup>
             </div>
+            <div className="flex flex-col gap-1">
+                {/* size="auto" hugs its content instead of the fixed control height — used for search fields inside popovers/dropdowns. */}
+                <span className="story-section-heading">Hug-content (size="auto")</span>
+                <InputGroup size="auto" className="px-2.5 py-1.5">
+                    <InputGroupAddon className="p-0 pr-2">
+                        <Search />
+                    </InputGroupAddon>
+                    <InputGroupInput size="auto" placeholder="Search…" />
+                </InputGroup>
+            </div>
         </div>
     )
 };

--- a/packages/design-system/src/components/ui/input-group.tsx
+++ b/packages/design-system/src/components/ui/input-group.tsx
@@ -6,39 +6,48 @@ import { IconButton } from './button';
 import { Input } from './input';
 import { Textarea } from './textarea';
 
+import type { InputProps } from './input';
 import type { VariantProps } from 'class-variance-authority';
 
-function InputGroup({ className, ...props }: React.ComponentProps<'div'>) {
-    return (
-        <div
-            data-slot="input-group"
-            role="group"
-            className={cn(
-                'group/input-group bg-surface-input border-ds-hairline border-border-input text-text-default placeholder:text-text-secondary text-ds-md font-ds-regular leading-ds-normal relative flex w-full items-center rounded-ds-sm transition-[background-color,border-color,color,box-shadow] duration-100 ease-in-out outline-none hover:border-border-input-hover',
-                'h-9 min-w-0 has-[>textarea]:h-auto',
+const inputGroupVariants = cva(
+    [
+        'group/input-group bg-surface-input border-ds-hairline border-border-input text-text-default placeholder:text-text-secondary text-ds-md font-ds-regular leading-ds-normal relative flex w-full items-center rounded-ds-sm transition-[background-color,border-color,color,box-shadow] duration-100 ease-in-out outline-none hover:border-border-input-hover',
+        'min-w-0 has-[>textarea]:h-auto',
 
-                // Variants based on alignment.
-                'has-[>[data-align=inline-start]]:[&>input]:pl-2',
-                'has-[>[data-align=inline-end]]:[&>input]:pr-2',
-                'has-[>[data-align=block-start]]:h-auto has-[>[data-align=block-start]]:flex-col has-[>[data-align=block-start]]:[&>input]:pb-3',
-                'has-[>[data-align=block-end]]:h-auto has-[>[data-align=block-end]]:flex-col has-[>[data-align=block-end]]:[&>input]:pt-3',
+        // Variants based on alignment.
+        'has-[>[data-align=inline-start]]:[&>input]:pl-2',
+        'has-[>[data-align=inline-end]]:[&>input]:pr-2',
+        'has-[>[data-align=block-start]]:h-auto has-[>[data-align=block-start]]:flex-col has-[>[data-align=block-start]]:[&>input]:pb-3',
+        'has-[>[data-align=block-end]]:h-auto has-[>[data-align=block-end]]:flex-col has-[>[data-align=block-end]]:[&>input]:pt-3',
 
-                // Focus state — border darkens when the control is focused (focus ring removed pending design review).
-                'has-[[data-slot=input-group-control]:focus-visible]:outline-none has-[[data-slot=input-group-control]:focus-visible]:border-border-input-hover',
-                // Filled state - different border when input has text (works for both controlled and uncontrolled inputs)
-                'has-[[data-slot=input-group-control][data-filled=true]:not(:disabled)]:border-border-input-hover',
+        // Focus state — border darkens when the control is focused (focus ring removed pending design review).
+        'has-[[data-slot=input-group-control]:focus-visible]:outline-none has-[[data-slot=input-group-control]:focus-visible]:border-border-input-hover',
+        // Filled state - different border when input has text (works for both controlled and uncontrolled inputs)
+        'has-[[data-slot=input-group-control][data-filled=true]:not(:disabled)]:border-border-input-hover',
 
-                // Disabled — dedicated tokens (matches Input), no opacity.
-                'has-[[data-slot=input-group-control]:disabled]:border-border-disabled has-[[data-slot=input-group-control]:disabled]:bg-state-selected-muted',
+        // Disabled — dedicated tokens (matches Input), no opacity.
+        'has-[[data-slot=input-group-control]:disabled]:border-border-disabled has-[[data-slot=input-group-control]:disabled]:bg-state-selected-muted',
 
-                // Error state.
-                'has-[[data-slot][aria-invalid=true]]:!border-status-danger-border',
+        // Error state.
+        'has-[[data-slot][aria-invalid=true]]:!border-status-danger-border'
+    ],
+    {
+        variants: {
+            size: {
+                // Default control height (matches Input).
+                default: 'h-9',
+                // Hug-content — for in-popover search fields. Pair with `size="auto"` on the inner InputGroupInput.
+                auto: 'h-auto'
+            }
+        },
+        defaultVariants: {
+            size: 'default'
+        }
+    }
+);
 
-                className
-            )}
-            {...props}
-        />
-    );
+function InputGroup({ className, size, ...props }: Omit<React.ComponentProps<'div'>, 'size'> & VariantProps<typeof inputGroupVariants>) {
+    return <div data-slot="input-group" role="group" className={cn(inputGroupVariants({ size }), className)} {...props} />;
 }
 
 export const inputGroupAddonVariants = cva(
@@ -96,7 +105,7 @@ function InputGroupText({ className, ...props }: React.ComponentProps<'span'>) {
     );
 }
 
-const InputGroupInput = React.forwardRef<HTMLInputElement, React.ComponentProps<'input'>>(({ className, value, defaultValue, onChange, ...props }, ref) => {
+const InputGroupInput = React.forwardRef<HTMLInputElement, InputProps>(({ className, size, value, defaultValue, onChange, ...props }, ref) => {
     const [isFilled, setIsFilled] = React.useState(() => {
         // Check initial state for both controlled and uncontrolled inputs
         if (value !== undefined) {
@@ -126,6 +135,7 @@ const InputGroupInput = React.forwardRef<HTMLInputElement, React.ComponentProps<
     return (
         <Input
             ref={ref}
+            size={size}
             data-slot="input-group-control"
             data-filled={isFilled}
             className={cn('flex-1 rounded-none border-0 bg-transparent shadow-none disabled:bg-transparent focus-visible:ring-0', className)}

--- a/packages/design-system/src/components/ui/input.tsx
+++ b/packages/design-system/src/components/ui/input.tsx
@@ -1,33 +1,52 @@
+import { cva } from 'class-variance-authority';
 import * as React from 'react';
 
 import { cn } from '../../lib/cn';
 
-export type InputProps = React.ComponentProps<'input'>;
+import type { VariantProps } from 'class-variance-authority';
 
-const Input = React.forwardRef<HTMLInputElement, InputProps>(({ className, type, autoComplete, ...props }, ref) => {
+export const inputVariants = cva(
+    [
+        // Shape + spacing (Figma: hairline border, radius/sm)
+        'flex w-full min-w-0 rounded-ds-sm border-ds-hairline outline-none transition-[background-color,border-color,color,box-shadow] duration-100 ease-in-out',
+        // Typography (Figma text/regular/md)
+        'text-ds-md font-ds-regular leading-ds-normal',
+        // Default colors
+        'bg-surface-input border-border-input text-text-default placeholder:text-text-secondary',
+        // Hover / focus border (focus ring removed pending design review)
+        'hover:border-border-input-hover focus:border-border-input-hover',
+        // Invalid
+        'aria-invalid:border-status-danger-border',
+        // Disabled — dedicated tokens, no opacity (Figma state/selectedMuted bg, border/disabled, text/disabled)
+        'disabled:cursor-not-allowed disabled:border-border-disabled disabled:bg-state-selected-muted disabled:text-text-disabled disabled:placeholder:text-text-disabled',
+        // File-input affordance
+        'file:inline-flex file:h-7 file:border-0 file:bg-transparent file:text-text-strong file:text-ds-md file:font-ds-medium'
+    ],
+    {
+        variants: {
+            size: {
+                // Default control height (Figma: space/2 × space/1.5)
+                default: 'h-9 px-2 py-1.5',
+                // Hug-content — for in-popover search fields where the wrapper owns the padding
+                auto: 'h-auto p-0'
+            }
+        },
+        defaultVariants: {
+            size: 'default'
+        }
+    }
+);
+
+export interface InputProps extends Omit<React.ComponentProps<'input'>, 'size'>, VariantProps<typeof inputVariants> {}
+
+const Input = React.forwardRef<HTMLInputElement, InputProps>(({ className, type, size, autoComplete, ...props }, ref) => {
     const blockPasswordManager = !autoComplete || autoComplete === 'off';
     return (
         <input
             ref={ref}
             type={type}
             data-slot="input"
-            className={cn(
-                // Shape + spacing (Figma: hairline border, radius/sm, space/2 × space/1.5)
-                'flex h-9 w-full min-w-0 rounded-ds-sm border-ds-hairline px-2 py-1.5 outline-none transition-[background-color,border-color,color,box-shadow] duration-100 ease-in-out',
-                // Typography (Figma text/regular/md)
-                'text-ds-md font-ds-regular leading-ds-normal',
-                // Default colors
-                'bg-surface-input border-border-input text-text-default placeholder:text-text-secondary',
-                // Hover / focus border (focus ring removed pending design review)
-                'hover:border-border-input-hover focus:border-border-input-hover',
-                // Invalid
-                'aria-invalid:border-status-danger-border',
-                // Disabled — dedicated tokens, no opacity (Figma state/selectedMuted bg, border/disabled, text/disabled)
-                'disabled:cursor-not-allowed disabled:border-border-disabled disabled:bg-state-selected-muted disabled:text-text-disabled disabled:placeholder:text-text-disabled',
-                // File-input affordance
-                'file:inline-flex file:h-7 file:border-0 file:bg-transparent file:text-text-strong file:text-ds-md file:font-ds-medium',
-                className
-            )}
+            className={cn(inputVariants({ size }), className)}
             autoComplete={autoComplete ?? 'off'}
             {...(blockPasswordManager ? { 'data-1p-ignore': true, 'data-lpignore': 'true', 'data-protonpass-ignore': 'true' } : {})}
             {...props}

--- a/packages/design-system/src/index.ts
+++ b/packages/design-system/src/index.ts
@@ -1,5 +1,5 @@
 export { Button, type ButtonProps, IconButton, type IconButtonProps, buttonVariants } from './components/ui/button';
-export { Input, type InputProps } from './components/ui/input';
+export { Input, type InputProps, inputVariants } from './components/ui/input';
 export { Textarea, type TextareaProps } from './components/ui/textarea';
 export {
     InputGroup,

--- a/packages/design-system/stories/ButtonLink.stories.tsx
+++ b/packages/design-system/stories/ButtonLink.stories.tsx
@@ -20,8 +20,7 @@ export default meta;
 type Story = StoryObj<typeof meta>;
 
 const VARIANTS = ['primary', 'secondary', 'outline', 'ghost', 'danger', 'link-danger'] as const;
-// 'xl' (40px) is deprecated — kept only for migrating legacy webapp buttons
-const SIZES = ['2xs', 'xs', 'sm', 'md', 'lg', 'xl'] as const;
+const SIZES = ['2xs', 'xs', 'sm', 'md', 'lg'] as const;
 
 export const AllVariants: Story = {
     name: 'All variants',

--- a/packages/webapp/src/components/patterns/EditableInput.tsx
+++ b/packages/webapp/src/components/patterns/EditableInput.tsx
@@ -119,7 +119,7 @@ export const EditableInput: React.FC<EditableInputProps> = ({
                         id={id}
                         value={displayValue}
                         onChange={handleChange}
-                        className="h-36"
+                        rows={6}
                         disabled={!editing}
                         onKeyDown={(e) => {
                             if (e.key === 'Escape') onCancelClicked();

--- a/packages/webapp/src/components/patterns/GoogleButton.tsx
+++ b/packages/webapp/src/components/patterns/GoogleButton.tsx
@@ -29,7 +29,7 @@ export default function GoogleButton({ text, setServerErrorMessage, token }: Pro
         <button
             onClick={googleLogin}
             type="button"
-            className="flex items-center justify-center gap-2.5 p-3 bg-surface-panel text-text-strong font-roboto font-medium text-sm rounded w-full border border-border-muted"
+            className="flex items-center justify-center gap-2.5 h-9 px-3 bg-surface-panel text-text-strong font-roboto font-medium text-sm rounded w-full border border-border-muted"
         >
             <svg xmlns="http://www.w3.org/2000/svg" width="18px" className="inline" viewBox="0 0 512 512">
                 <path

--- a/packages/webapp/src/components/patterns/SecretInput.tsx
+++ b/packages/webapp/src/components/patterns/SecretInput.tsx
@@ -6,7 +6,9 @@ import { IconButton, InputGroup, InputGroupAddon, InputGroupInput } from '@nango
 import { PermissionGate } from '@/components/patterns/PermissionGate';
 import { CopyButton } from '../ui/CopyButton';
 
-interface SecretInputProps extends React.ComponentProps<'input'> {
+import type { InputProps } from '@nangohq/design-system';
+
+interface SecretInputProps extends InputProps {
     copy?: boolean;
     canRead?: boolean;
 }

--- a/packages/webapp/src/components/patterns/SecretTextArea.tsx
+++ b/packages/webapp/src/components/patterns/SecretTextArea.tsx
@@ -6,6 +6,8 @@ import { IconButton, InputGroup, InputGroupAddon, InputGroupInput, InputGroupTex
 import { PermissionGate } from '@/components/patterns/PermissionGate';
 import { CopyButton } from '../ui/CopyButton';
 
+import type { InputProps } from '@nangohq/design-system';
+
 interface SecretTextAreaProps extends Omit<React.ComponentProps<'textarea'>, 'onChange'> {
     copy?: boolean;
     canRead?: boolean;
@@ -40,7 +42,7 @@ export const SecretTextArea: React.FC<SecretTextAreaProps> = ({ copy, canRead = 
                 />
             ) : (
                 <InputGroupInput
-                    {...(props as React.ComponentProps<'input'>)}
+                    {...(props as unknown as InputProps)}
                     value={canRead ? (value as string) : '•'.repeat(32)}
                     defaultValue={canRead ? (defaultValue as string) : undefined}
                     type="password"

--- a/packages/webapp/src/components/ui/ColorInput.tsx
+++ b/packages/webapp/src/components/ui/ColorInput.tsx
@@ -4,7 +4,7 @@ import { InputGroup, InputGroupAddon, InputGroupInput } from '@nangohq/design-sy
 
 import { cn } from '@/utils/utils';
 
-import type { InputHTMLAttributes } from 'react';
+import type { InputProps } from '@nangohq/design-system';
 
 export const isValidCSSColor = (color: string): boolean => {
     if (!color) return false;
@@ -17,7 +17,7 @@ export const isValidCSSColor = (color: string): boolean => {
     return tempElement.style.color !== '';
 };
 
-export interface ColorInputProps extends Omit<InputHTMLAttributes<HTMLInputElement>, 'type' | 'value'> {
+export interface ColorInputProps extends Omit<InputProps, 'type' | 'value'> {
     value: string;
     className?: string;
     placeholder?: string;

--- a/packages/webapp/src/components/ui/Combobox.tsx
+++ b/packages/webapp/src/components/ui/Combobox.tsx
@@ -228,7 +228,7 @@ export function ComboboxSelect<T extends string = string>(props: ComboboxProps<T
             loading={props.loading}
             disabled={disabled || options.length === 0}
             variant="ghost"
-            size="xl"
+            size="lg"
             className={cn('border border-border-muted', isDirty && 'bg-state-pressed', open ? 'bg-surface-panel-inset' : 'hover:bg-state-hover', className)}
         >
             {props.label}{' '}
@@ -366,16 +366,20 @@ export function ComboboxSelect<T extends string = string>(props: ComboboxProps<T
                 )}
                 {showSearch && (
                     <div className="w-full border-b border-border-muted" onKeyDown={(e) => e.stopPropagation()}>
-                        <InputGroup className="h-auto flex-1 justify-between rounded-[4px] border-[0.5px] border-border-muted bg-surface-canvas px-2.5 py-1.5">
+                        <InputGroup
+                            size="auto"
+                            className="flex-1 justify-between rounded-[4px] border-[0.5px] border-border-muted bg-surface-canvas px-2.5 py-1.5"
+                        >
                             <InputGroupAddon className="p-0 pr-2">
                                 <Search className="size-4 text-text-muted" />
                             </InputGroupAddon>
                             <InputGroupInput
+                                size="auto"
                                 type="text"
                                 placeholder={searchPlaceholder}
                                 value={search}
                                 onChange={(e) => setSearch(e.target.value)}
-                                className="h-auto p-0 text-body-medium-regular text-text-muted placeholder:text-text-muted"
+                                className="text-body-medium-regular text-text-muted placeholder:text-text-muted"
                             />
                         </InputGroup>
                     </div>

--- a/packages/webapp/src/components/ui/LineSnippet.tsx
+++ b/packages/webapp/src/components/ui/LineSnippet.tsx
@@ -3,7 +3,7 @@ import { CopyButton } from './CopyButton';
 
 export const LineSnippet: React.FC<{ snippet: string; className?: string }> = ({ snippet, className }) => {
     return (
-        <div className={cn('relative flex h-10 min-w-100 overflow-hidden rounded-sm bg-surface-canvas border border-border-disabled', className)}>
+        <div className={cn('relative flex h-9 min-w-100 overflow-hidden rounded-sm bg-surface-canvas border border-border-disabled', className)}>
             <div className="flex min-w-0 flex-1 items-center overflow-x-auto overflow-y-hidden overscroll-x-contain px-4">
                 <span className="whitespace-nowrap text-text-secondary text-body-medium-regular">{snippet}</span>
             </div>

--- a/packages/webapp/src/components/ui/MultiSelect.tsx
+++ b/packages/webapp/src/components/ui/MultiSelect.tsx
@@ -133,7 +133,7 @@ export function MultiSelect<T extends string = string>({
                     loading={loading}
                     disabled={options.length === 0}
                     variant="ghost"
-                    size="xl"
+                    size="lg"
                     className={cn('border border-border-muted', isDirty && 'bg-state-pressed', open ? 'bg-surface-panel-inset' : 'hover:bg-state-hover')}
                 >
                     {label}{' '}
@@ -149,16 +149,17 @@ export function MultiSelect<T extends string = string>({
                 className="flex w-[var(--radix-popover-trigger-width)] min-w-[312px] flex-col items-start overflow-hidden rounded-[4px] border border-border-muted bg-surface-overlay shadow-lg p-1 pb-0"
             >
                 <div className="border-b border-border-muted w-full">
-                    <InputGroup className="h-auto flex-1 justify-between rounded-[4px] border-[0.5px] border-border-muted bg-surface-canvas px-2.5 py-1.5">
+                    <InputGroup size="auto" className="flex-1 justify-between rounded-[4px] border-[0.5px] border-border-muted bg-surface-canvas px-2.5 py-1.5">
                         <InputGroupAddon className="p-0 pr-2">
                             <Search className="size-4 text-text-muted" />
                         </InputGroupAddon>
                         <InputGroupInput
+                            size="auto"
                             type="text"
                             placeholder={searchPlaceholder}
                             value={search}
                             onChange={handleInputChange}
-                            className="h-auto p-0 text-body-medium-regular text-text-muted placeholder:text-text-muted"
+                            className="text-body-medium-regular text-text-muted placeholder:text-text-muted"
                         />
                     </InputGroup>
                 </div>

--- a/packages/webapp/src/components/ui/Sidebar.tsx
+++ b/packages/webapp/src/components/ui/Sidebar.tsx
@@ -82,7 +82,7 @@ function SidebarProvider({
 
     // Helper to toggle the sidebar.
     const toggleSidebar = React.useCallback(() => {
-        return isMobile ? setOpenMobile((open) => !open) : setOpen((open) => !open);
+        return isMobile ? void setOpenMobile((open) => !open) : void setOpen((open) => !open);
     }, [isMobile, setOpen, setOpenMobile]);
 
     // Adds a keyboard shortcut to toggle the sidebar.
@@ -287,7 +287,7 @@ function SidebarInset({ className, ...props }: React.ComponentProps<'main'>) {
 }
 
 function SidebarInput({ className, ...props }: React.ComponentProps<typeof Input>) {
-    return <Input data-slot="sidebar-input" data-sidebar="input" className={cn('bg-surface-input h-8 w-full shadow-none', className)} {...props} />;
+    return <Input data-slot="sidebar-input" data-sidebar="input" className={cn('bg-surface-input w-full shadow-none', className)} {...props} />;
 }
 
 function SidebarHeader({ className, ...props }: React.ComponentProps<'div'>) {

--- a/packages/webapp/src/pages/Account/ForgotPassword.tsx
+++ b/packages/webapp/src/pages/Account/ForgotPassword.tsx
@@ -71,7 +71,7 @@ export default function Signin() {
                             render={({ field, fieldState }) => (
                                 <FormItem>
                                     <FormControl>
-                                        <InputGroup className="h-11">
+                                        <InputGroup>
                                             <InputGroupInput placeholder="Email" {...field} aria-invalid={!!fieldState.error} />
                                         </InputGroup>
                                     </FormControl>
@@ -80,7 +80,7 @@ export default function Signin() {
                             )}
                         />
 
-                        <Button type="submit" size={'xl'} loading={isPending} disabled={!form.formState.isValid}>
+                        <Button type="submit" size={'lg'} loading={isPending} disabled={!form.formState.isValid}>
                             Send password reset email
                         </Button>
                     </form>

--- a/packages/webapp/src/pages/Account/InviteSignup.tsx
+++ b/packages/webapp/src/pages/Account/InviteSignup.tsx
@@ -81,7 +81,7 @@ export const InviteSignup: React.FC = () => {
                     <p className="text-text-secondary text-body-medium-regular">This invitation no longer exists or is expired.</p>
                 </div>
 
-                <ButtonLink to={'/signup'} variant="outline" className="w-full" size="xl">
+                <ButtonLink to={'/signup'} variant="outline" className="w-full" size="lg">
                     Back to signup
                 </ButtonLink>
             </DefaultLayout>
@@ -106,10 +106,10 @@ export const InviteSignup: React.FC = () => {
                 </div>
 
                 <div className="flex gap-2 items-center justify-center">
-                    <ButtonLink to={'/'} variant="outline" size="xl">
+                    <ButtonLink to={'/'} variant="outline" size="lg">
                         Back to home
                     </ButtonLink>
-                    <Button onClick={signout} variant="primary" size="xl">
+                    <Button onClick={signout} variant="primary" size="lg">
                         <LogOut />
                         Log out
                     </Button>
@@ -141,10 +141,10 @@ export const InviteSignup: React.FC = () => {
 
             {isLogged ? (
                 <div className="flex gap-2 items-center justify-center">
-                    <Button variant="outline" size="xl" onClick={onDecline} disabled={acceptInvite.isPending} loading={declineInvite.isPending}>
+                    <Button variant="outline" size="lg" onClick={onDecline} disabled={acceptInvite.isPending} loading={declineInvite.isPending}>
                         Decline
                     </Button>
-                    <Button variant="danger" size="xl" onClick={onAccept} disabled={declineInvite.isPending} loading={acceptInvite.isPending}>
+                    <Button variant="danger" size="lg" onClick={onAccept} disabled={declineInvite.isPending} loading={acceptInvite.isPending}>
                         Join a different team
                     </Button>
                 </div>

--- a/packages/webapp/src/pages/Account/ManagedEmailVerification.tsx
+++ b/packages/webapp/src/pages/Account/ManagedEmailVerification.tsx
@@ -76,7 +76,7 @@ export const ManagedEmailVerification: React.FC = () => {
             </div>
 
             <form onSubmit={handleSubmit} className="flex flex-col gap-5 w-full">
-                <InputGroup className="h-11">
+                <InputGroup>
                     <InputGroupInput
                         value={code}
                         onChange={(event) => setCode(event.target.value)}
@@ -87,7 +87,7 @@ export const ManagedEmailVerification: React.FC = () => {
                     />
                 </InputGroup>
 
-                <Button type="submit" size="xl" loading={isPending} disabled={code.trim().length < 6}>
+                <Button type="submit" size="lg" loading={isPending} disabled={code.trim().length < 6}>
                     Verify and continue
                 </Button>
             </form>

--- a/packages/webapp/src/pages/Account/ResetPassword.tsx
+++ b/packages/webapp/src/pages/Account/ResetPassword.tsx
@@ -77,7 +77,7 @@ export default function ResetPassword() {
                         render={() => <Password placeholder="New password" autoFocus autoComplete="new-password" />}
                     />
 
-                    <Button type="submit" size={'xl'} loading={isPending} disabled={!form.formState.isValid}>
+                    <Button type="submit" size={'lg'} loading={isPending} disabled={!form.formState.isValid}>
                         Reset password
                     </Button>
                 </form>

--- a/packages/webapp/src/pages/Account/Signin.tsx
+++ b/packages/webapp/src/pages/Account/Signin.tsx
@@ -158,7 +158,7 @@ export const Signin: React.FC = () => {
                                     render={({ field, fieldState }) => (
                                         <FormItem>
                                             <FormControl>
-                                                <InputGroup className="h-11">
+                                                <InputGroup>
                                                     <InputGroupInput placeholder="Email" autoComplete="email" {...field} aria-invalid={!!fieldState.error} />
                                                 </InputGroup>
                                             </FormControl>
@@ -174,7 +174,7 @@ export const Signin: React.FC = () => {
                                         render={({ field, fieldState }) => (
                                             <FormItem>
                                                 <FormControl>
-                                                    <InputGroup className="h-11">
+                                                    <InputGroup>
                                                         <InputGroupInput
                                                             placeholder="Password"
                                                             type="password"
@@ -196,7 +196,7 @@ export const Signin: React.FC = () => {
                                 </StyledLink>
                             </div>
 
-                            <Button type="submit" size="xl" loading={isPending} disabled={!form.formState.isValid}>
+                            <Button type="submit" size="lg" loading={isPending} disabled={!form.formState.isValid}>
                                 {isPending ? 'Logging in...' : 'Log in'}
                             </Button>
                         </form>

--- a/packages/webapp/src/pages/Account/VerifyEmail.tsx
+++ b/packages/webapp/src/pages/Account/VerifyEmail.tsx
@@ -75,7 +75,7 @@ export function VerifyEmail() {
             </div>
 
             <div className="grid w-full">
-                <Button onClick={handleResendEmail} size="xl" loading={isResendingVerificationEmailByUuid}>
+                <Button onClick={handleResendEmail} size="lg" loading={isResendingVerificationEmailByUuid}>
                     Resend email
                 </Button>
             </div>

--- a/packages/webapp/src/pages/Account/components/Password.tsx
+++ b/packages/webapp/src/pages/Account/components/Password.tsx
@@ -8,6 +8,8 @@ import { InputGroup, InputGroupInput } from '@nangohq/design-system';
 import { FormControl, FormItem, FormMessage, useFormField } from '@/components/ui/Form';
 import { cn } from '@/utils/utils';
 
+import type { InputProps } from '@nangohq/design-system';
+
 export const passwordSchema = z
     .string()
     .min(12, 'Password must be at least 12 characters')
@@ -15,7 +17,7 @@ export const passwordSchema = z
     .refine((value) => /[0-9]/.test(value), 'Password must contain at least one number')
     .refine((value) => /[^a-zA-Z0-9]/.test(value), 'Password must contain at least one special character');
 
-export const Password: React.FC<React.InputHTMLAttributes<HTMLInputElement>> = (props) => {
+export const Password: React.FC<InputProps> = (props) => {
     const { name } = useFormField();
     const { control } = useFormContext();
     const { field, fieldState } = useController({ name, control });
@@ -37,7 +39,7 @@ export const Password: React.FC<React.InputHTMLAttributes<HTMLInputElement>> = (
     return (
         <FormItem>
             <FormControl>
-                <InputGroup className="h-11">
+                <InputGroup>
                     <InputGroupInput
                         {...field}
                         id={field.name}

--- a/packages/webapp/src/pages/Account/components/SignupForm.tsx
+++ b/packages/webapp/src/pages/Account/components/SignupForm.tsx
@@ -144,7 +144,7 @@ export const SignupForm: React.FC<{ invitation?: ApiInvitation; token?: string }
                             render={({ field, fieldState }) => (
                                 <FormItem>
                                     <FormControl>
-                                        <InputGroup className="h-11">
+                                        <InputGroup>
                                             <InputGroupInput placeholder="Name" autoComplete="name" {...field} aria-invalid={!!fieldState.error} />
                                         </InputGroup>
                                     </FormControl>
@@ -158,7 +158,7 @@ export const SignupForm: React.FC<{ invitation?: ApiInvitation; token?: string }
                             render={({ field, fieldState }) => (
                                 <FormItem>
                                     <FormControl>
-                                        <InputGroup className="h-11">
+                                        <InputGroup>
                                             <InputGroupInput
                                                 disabled={!!invitation?.email}
                                                 placeholder="Email"
@@ -175,7 +175,7 @@ export const SignupForm: React.FC<{ invitation?: ApiInvitation; token?: string }
 
                         <FormField control={form.control} name="password" render={() => <Password autoComplete="new-password" />} />
 
-                        <Button type="submit" size="xl" loading={isPending} disabled={!form.formState.isValid}>
+                        <Button type="submit" size="lg" loading={isPending} disabled={!form.formState.isValid}>
                             {isPending ? 'Signing up...' : 'Sign up'}
                         </Button>
                     </form>

--- a/packages/webapp/src/pages/Connection/List.tsx
+++ b/packages/webapp/src/pages/Connection/List.tsx
@@ -287,7 +287,7 @@ export const ConnectionList = () => {
                         <>
                             {/* Filters */}
                             <div className="flex items-center gap-1.5">
-                                <InputGroup className="h-10 flex-1">
+                                <InputGroup className="flex-1">
                                     <InputGroupInput
                                         type="text"
                                         placeholder="Search connections"
@@ -339,7 +339,7 @@ export const ConnectionList = () => {
                                 />
                                 <PermissionGate condition={canCreateTestConnection}>
                                     {(allowed) => (
-                                        <ButtonLink to={`/${env}/connections/create`} size="xl" disabled={!allowed} className="ml-auto">
+                                        <ButtonLink to={`/${env}/connections/create`} size="lg" disabled={!allowed} className="ml-auto">
                                             Add test connection
                                         </ButtonLink>
                                     )}
@@ -434,7 +434,7 @@ export const ConnectionList = () => {
                                 </StyledLink>
                                 , or manually here.
                             </p>
-                            <ButtonLink to={`/${env}/connections/create`} size="xl">
+                            <ButtonLink to={`/${env}/connections/create`} size="lg">
                                 Add test connection
                             </ButtonLink>
                         </div>

--- a/packages/webapp/src/pages/Connection/components/CreateConnectionSelector.tsx
+++ b/packages/webapp/src/pages/Connection/components/CreateConnectionSelector.tsx
@@ -306,7 +306,7 @@ export const CreateConnectionSelector: React.FC<CreateConnectionSelectorProps> =
                                         {(allowed) => (
                                             <Button
                                                 onClick={onClickConnectUI}
-                                                size="xl"
+                                                size="lg"
                                                 disabled={usageCapReached || integrationHasMissingFields || !isFormValid || !allowed}
                                             >
                                                 Authorize
@@ -326,7 +326,7 @@ export const CreateConnectionSelector: React.FC<CreateConnectionSelectorProps> =
                                         {(allowed) => (
                                             <Button
                                                 onClick={onClickShareConnectionLink}
-                                                size="xl"
+                                                size="lg"
                                                 variant="ghost"
                                                 loading={isShareLinkLoading}
                                                 disabled={usageCapReached || integrationHasMissingFields || !isFormValid || !allowed}

--- a/packages/webapp/src/pages/Connection/components/IntegrationDropdown.tsx
+++ b/packages/webapp/src/pages/Connection/components/IntegrationDropdown.tsx
@@ -52,7 +52,7 @@ export const IntegrationDropdown: React.FC<IntegrationDropdownProps> = ({ integr
     return (
         <DropdownMenu modal={false}>
             <DropdownMenuTrigger
-                className={cn(buttonVariants({ variant: 'outline', size: 'xl' }), 'bg-surface-canvas justify-between grow w-full h-13')}
+                className={cn(buttonVariants({ variant: 'outline', size: 'lg' }), 'bg-surface-canvas justify-between grow w-full h-13')}
                 disabled={disabled}
             >
                 {selectedIntegration ? (
@@ -84,8 +84,9 @@ export const IntegrationDropdown: React.FC<IntegrationDropdownProps> = ({ integr
                 >
                     <Search className="size-5 shrink-0 text-icon-disabled" />
                     <Input
+                        size="auto"
                         placeholder="Github, accounting, oauth..."
-                        className="flex-1 bg-transparent border-none shadow-none focus-visible:ring-0 text-text-secondary h-auto p-0"
+                        className="flex-1 bg-transparent border-none shadow-none focus-visible:ring-0 text-text-secondary"
                         value={search}
                         onChange={(e) => setSearch(e.target.value)}
                         autoFocus

--- a/packages/webapp/src/pages/Connection/components/IntegrationDropdown.tsx
+++ b/packages/webapp/src/pages/Connection/components/IntegrationDropdown.tsx
@@ -66,7 +66,7 @@ export const IntegrationDropdown: React.FC<IntegrationDropdownProps> = ({ integr
                 <ChevronsUpDown className="size-4.5 text-text-secondary" />
             </DropdownMenuTrigger>
             <DropdownMenuContent
-                className="w-[var(--radix-dropdown-menu-trigger-width)] p-2 bg-surface-panel-inset border-none"
+                className="w-[var(--radix-dropdown-menu-trigger-width)] p-1 bg-surface-overlay border border-border-muted shadow-lg rounded-[4px]"
                 side="bottom"
                 align="start"
                 onInteractOutside={(e) => {
@@ -77,12 +77,12 @@ export const IntegrationDropdown: React.FC<IntegrationDropdownProps> = ({ integr
                 }}
             >
                 <div
-                    className="flex items-center gap-3 px-3 py-2.5 mb-2 bg-surface-panel-muted rounded-md border border-border-default"
+                    className="flex items-center gap-2 px-2.5 py-1.5 mb-1 bg-surface-canvas rounded-[4px] border-[0.5px] border-border-muted"
                     onKeyDown={(e) => {
                         e.stopPropagation();
                     }}
                 >
-                    <Search className="size-5 shrink-0 text-icon-disabled" />
+                    <Search className="size-4 shrink-0 text-text-muted" />
                     <Input
                         size="auto"
                         placeholder="Github, accounting, oauth..."
@@ -107,13 +107,16 @@ export const IntegrationDropdown: React.FC<IntegrationDropdownProps> = ({ integr
                                         onSelect(isSelected ? undefined : item);
                                         setSearch('');
                                     }}
-                                    className={cn('flex items-center justify-between cursor-pointer py-3 px-3 rounded-md', isSelected && 'bg-state-selected')}
+                                    className={cn(
+                                        'flex items-center justify-between cursor-pointer px-2 py-1.5 rounded-[4px]',
+                                        isSelected && 'bg-state-selected'
+                                    )}
                                 >
-                                    <div className="flex gap-3 items-center text-[15px]">
-                                        <IntegrationLogo provider={item.provider} className="size-8" />
+                                    <div className="flex gap-2 items-center text-sm">
+                                        <IntegrationLogo provider={item.provider} className="size-5" />
                                         {item.display_name || item.meta.displayName}
                                     </div>
-                                    {isSelected && <Check className="size-5" />}
+                                    {isSelected && <Check className="size-4" />}
                                 </DropdownMenuItem>
                             );
                         })

--- a/packages/webapp/src/pages/Connection/components/IntegrationDropdown.tsx
+++ b/packages/webapp/src/pages/Connection/components/IntegrationDropdown.tsx
@@ -52,12 +52,12 @@ export const IntegrationDropdown: React.FC<IntegrationDropdownProps> = ({ integr
     return (
         <DropdownMenu modal={false}>
             <DropdownMenuTrigger
-                className={cn(buttonVariants({ variant: 'outline', size: 'lg' }), 'bg-surface-canvas justify-between grow w-full h-13')}
+                className={cn(buttonVariants({ variant: 'outline', size: 'lg' }), 'bg-surface-canvas justify-between grow w-full')}
                 disabled={disabled}
             >
                 {selectedIntegration ? (
-                    <div className="flex gap-3 items-center">
-                        <IntegrationLogo provider={selectedIntegration.provider} className="w-10 h-10" />{' '}
+                    <div className="flex gap-2 items-center">
+                        <IntegrationLogo provider={selectedIntegration.provider} className="size-5" />{' '}
                         {selectedIntegration.display_name || selectedIntegration.meta.displayName}
                     </div>
                 ) : (

--- a/packages/webapp/src/pages/Connection/components/SettingsTab.tsx
+++ b/packages/webapp/src/pages/Connection/components/SettingsTab.tsx
@@ -50,7 +50,7 @@ export const SettingsTab = () => {
                         {(allowed) => (
                             <Button
                                 variant="danger"
-                                size="xl"
+                                size="lg"
                                 loading={isDeletingConnection}
                                 disabled={!allowed}
                                 onClick={() =>

--- a/packages/webapp/src/pages/GettingStarted/FirstStep.tsx
+++ b/packages/webapp/src/pages/GettingStarted/FirstStep.tsx
@@ -122,7 +122,7 @@ export const FirstStep: React.FC<FirstStepProps> = ({ connection, integration, o
                     <h3 className="text-text-brand text-sm font-semibold">Github connection authorized!</h3>
                 </div>
                 <div className="w-fit">
-                    <Button variant="outline" size="xl" onClick={onClickDisconnect} loading={isDeletingConnection}>
+                    <Button variant="outline" size="lg" onClick={onClickDisconnect} loading={isDeletingConnection}>
                         <Github className="size-5 mr-2" />
                         Disconnect from Github
                     </Button>
@@ -145,7 +145,7 @@ export const FirstStep: React.FC<FirstStepProps> = ({ connection, integration, o
                 </p>
             </div>
             <div className="w-fit">
-                <Button variant="primary" size="xl" onClick={onClickConnect}>
+                <Button variant="primary" size="lg" onClick={onClickConnect}>
                     <Github className="size-5" />
                     Connect to Github
                 </Button>

--- a/packages/webapp/src/pages/GettingStarted/SecondStep.tsx
+++ b/packages/webapp/src/pages/GettingStarted/SecondStep.tsx
@@ -160,7 +160,7 @@ export const SecondStep: React.FC<SecondStepProps> = ({ connectionId, providerCo
                         />
                     </div>
                     <div className={cn('flex flex-col gap-5')}>
-                        <Button variant="primary" size="xl" onClick={onExecute} disabled={isExecuting}>
+                        <Button variant="primary" size="lg" onClick={onExecute} disabled={isExecuting}>
                             {isExecuting ? (
                                 <>
                                     <Loader className="size-5 animate-spin" />

--- a/packages/webapp/src/pages/GettingStarted/ThirdStep.tsx
+++ b/packages/webapp/src/pages/GettingStarted/ThirdStep.tsx
@@ -27,7 +27,7 @@ export const ThirdStep = ({ onSetupIntegrationClicked }: ThirdStepProps) => {
                 <p className="text-text-strong">Now that you’ve had a glimpse of Nango, you can go ahead and configure your first integration!</p>
             </div>
 
-            <ButtonLink to={`/${env}/integrations/create`} onClick={onSetupIntegrationClicked} variant="primary" size="xl">
+            <ButtonLink to={`/${env}/integrations/create`} onClick={onSetupIntegrationClicked} variant="primary" size="lg">
                 Set up your own integrations
             </ButtonLink>
         </div>

--- a/packages/webapp/src/pages/Integrations/Show.tsx
+++ b/packages/webapp/src/pages/Integrations/Show.tsx
@@ -107,7 +107,7 @@ export const IntegrationsList = () => {
                 <title>Integrations - Nango</title>
             </Helmet>
             <header className="flex items-center gap-3">
-                <InputGroup className="h-10 flex-1">
+                <InputGroup className="flex-1">
                     <InputGroupInput type="text" placeholder="Search integration" onChange={handleInputChange} />
                     <InputGroupAddon>
                         <Search />
@@ -115,7 +115,7 @@ export const IntegrationsList = () => {
                 </InputGroup>
                 <PermissionGate asChild condition={canWriteIntegration}>
                     {(allowed) => (
-                        <ButtonLink disabled={!allowed} to={`/${env}/integrations/create`} size="xl">
+                        <ButtonLink disabled={!allowed} to={`/${env}/integrations/create`} size="lg">
                             Set up new integration
                         </ButtonLink>
                     )}
@@ -147,7 +147,7 @@ export const IntegrationsList = () => {
                     <p className="text-text-secondary text-body-medium-regular">You don’t have any integrations set up yet with Nango.</p>
                     <PermissionGate asChild condition={canWriteIntegration}>
                         {(allowed) => (
-                            <ButtonLink disabled={!allowed} to={`/${env}/integrations/create`} size="xl">
+                            <ButtonLink disabled={!allowed} to={`/${env}/integrations/create`} size="lg">
                                 Set up new integration
                             </ButtonLink>
                         )}
@@ -161,7 +161,7 @@ export const IntegrationsList = () => {
                     <p className="text-text-secondary text-body-medium-regular">Could not find any integrations matching your search.</p>
                     <PermissionGate asChild condition={canWriteIntegration}>
                         {(allowed) => (
-                            <ButtonLink disabled={!allowed} to={`/${env}/integrations/create`} size="xl">
+                            <ButtonLink disabled={!allowed} to={`/${env}/integrations/create`} size="lg">
                                 Set up new integration
                             </ButtonLink>
                         )}

--- a/packages/webapp/src/pages/Integrations/components/NangoProvidedInput.tsx
+++ b/packages/webapp/src/pages/Integrations/components/NangoProvidedInput.tsx
@@ -2,7 +2,9 @@ import { InputGroup, InputGroupAddon, InputGroupInput } from '@nangohq/design-sy
 
 import { Badge } from '@/components/ui/Badge';
 
-export const NangoProvidedInput: React.FC<React.ComponentProps<'input'> & { fakeValueSize?: number }> = ({ fakeValueSize = 12, ...props }) => {
+import type { InputProps } from '@nangohq/design-system';
+
+export const NangoProvidedInput: React.FC<InputProps & { fakeValueSize?: number }> = ({ fakeValueSize = 12, ...props }) => {
     return (
         <InputGroup>
             <InputGroupInput disabled value={'•'.repeat(fakeValueSize)} {...props} />

--- a/packages/webapp/src/pages/Integrations/providerConfigKey/Functions/Tab.tsx
+++ b/packages/webapp/src/pages/Integrations/providerConfigKey/Functions/Tab.tsx
@@ -123,7 +123,7 @@ export const FunctionsTab: React.FC<FunctionsTabProps> = ({ integration }) => {
             ) : (
                 <>
                     <div className="flex items-center gap-1.5">
-                        <InputGroup className="h-10">
+                        <InputGroup>
                             <InputGroupInput
                                 type="text"
                                 placeholder="Search functions"
@@ -144,7 +144,7 @@ export const FunctionsTab: React.FC<FunctionsTabProps> = ({ integration }) => {
                         />
                         <DropdownMenu>
                             <DropdownMenuTrigger asChild>
-                                <Button type="button" size="xl">
+                                <Button type="button" size="lg">
                                     <Plus /> Add
                                 </Button>
                             </DropdownMenuTrigger>

--- a/packages/webapp/src/pages/Integrations/providerConfigKey/Settings/components/DeleteIntegrationButton.tsx
+++ b/packages/webapp/src/pages/Integrations/providerConfigKey/Settings/components/DeleteIntegrationButton.tsx
@@ -45,7 +45,7 @@ export const DeleteIntegrationButton: React.FC<{ env: string; integration: ApiIn
                 {(allowed) => (
                     <Button
                         variant="danger"
-                        size="xl"
+                        size="lg"
                         loading={isPending}
                         disabled={!allowed}
                         onClick={() =>

--- a/packages/webapp/src/pages/Integrations/providerConfigKey/Show.tsx
+++ b/packages/webapp/src/pages/Integrations/providerConfigKey/Show.tsx
@@ -81,7 +81,7 @@ export const ShowIntegration: React.FC = () => {
                     </div>
                     <PermissionGate condition={canCreateTestConnection} asChild>
                         {(allowed) => (
-                            <ButtonLink to={`/${env}/connections/create?integration_id=${integration.integration.unique_key}`} size="xl" disabled={!allowed}>
+                            <ButtonLink to={`/${env}/connections/create?integration_id=${integration.integration.unique_key}`} size="lg" disabled={!allowed}>
                                 Add test connection
                             </ButtonLink>
                         )}

--- a/packages/webapp/src/pages/Integrations/providerConfigKey/Templates.tsx
+++ b/packages/webapp/src/pages/Integrations/providerConfigKey/Templates.tsx
@@ -175,7 +175,7 @@ export const Templates: React.FC = () => {
                     )}
                     <div className="flex flex-col gap-3 flex-1 min-h-0">
                         <div className="flex items-center gap-1.5 shrink-0">
-                            <InputGroup className="h-10">
+                            <InputGroup>
                                 <InputGroupInput
                                     type="text"
                                     placeholder="Search templates"

--- a/packages/webapp/src/pages/Logs/Operation/components/Logs.tsx
+++ b/packages/webapp/src/pages/Logs/Operation/components/Logs.tsx
@@ -210,9 +210,9 @@ export const Logs: React.FC<{ operation: OperationRow; operationId: string; isLi
                 </div>
             </div>
             <header className="flex gap-2 items-center">
-                <InputGroup className="grow border-border-muted">
+                <InputGroup className="grow">
                     <InputGroupAddon>
-                        <Search strokeWidth={1} size={18} />
+                        <Search />
                     </InputGroupAddon>
                     <InputGroupInput value={search} placeholder="Search logs..." onChange={(e) => setSearch(e.target.value)} />
                     {search && (
@@ -226,7 +226,7 @@ export const Logs: React.FC<{ operation: OperationRow; operationId: string; isLi
                                     setSearch('');
                                 }}
                             >
-                                <X strokeWidth={1} size={16} />
+                                <X />
                             </InputGroupButton>
                         </InputGroupAddon>
                     )}

--- a/packages/webapp/src/pages/Logs/components/SearchAllOperations.tsx
+++ b/packages/webapp/src/pages/Logs/components/SearchAllOperations.tsx
@@ -253,15 +253,15 @@ export const SearchAllOperations: React.FC<Props> = ({ onSelectOperation }) => {
         <div className="flex h-full min-h-0 flex-col gap-3">
             <div className="flex gap-2 justify-between">
                 <div className="flex-1 min-w-0">
-                    <InputGroup className="border-border-muted">
+                    <InputGroup>
                         <InputGroupAddon>
-                            <Search strokeWidth={1} size={16} />
+                            <Search />
                         </InputGroupAddon>
                         <InputGroupInput placeholder="Search logs..." onChange={(e) => setSearch(e.target.value)} value={search} />
                         {search && (
                             <InputGroupAddon align="inline-end">
                                 <InputGroupButton label="Clear search" variant={'ghost'} size={'icon-xs'} onClick={() => setSearch('')}>
-                                    <X strokeWidth={1} size={18} />
+                                    <X />
                                 </InputGroupButton>
                             </InputGroupAddon>
                         )}

--- a/packages/webapp/src/pages/Team/Billing/components/InvoicingDetailsForm.tsx
+++ b/packages/webapp/src/pages/Team/Billing/components/InvoicingDetailsForm.tsx
@@ -137,7 +137,7 @@ export const InvoicingDetailsForm: React.FC<{ customer: BillingCustomer | undefi
                 <InvoicingTaxIdFields />
 
                 <div className="flex justify-start">
-                    <Button type="submit" variant="primary" size="xl" loading={isPending}>
+                    <Button type="submit" variant="primary" size="lg" loading={isPending}>
                         Save changes
                     </Button>
                 </div>

--- a/packages/webapp/src/pages/Team/Billing/components/PaymentMethodDialog.tsx
+++ b/packages/webapp/src/pages/Team/Billing/components/PaymentMethodDialog.tsx
@@ -171,11 +171,11 @@ const PaymentMethodForm: React.FC<{ onSuccess: () => void }> = ({ onSuccess }) =
             </div>
             <DialogFooter>
                 <DialogClose asChild>
-                    <Button variant="outline" size="xl">
+                    <Button variant="outline" size="lg">
                         Cancel
                     </Button>
                 </DialogClose>
-                <Button type="submit" disabled={loading} variant={'primary'} size="xl">
+                <Button type="submit" disabled={loading} variant={'primary'} size="lg">
                     {loading && <Loader className="animate-spin" />}
                     Save payment method
                 </Button>

--- a/packages/webapp/src/pages/User/Settings.tsx
+++ b/packages/webapp/src/pages/User/Settings.tsx
@@ -65,7 +65,7 @@ export const UserSettings: React.FC = () => {
             </Helmet>
             <div className="flex flex-col gap-5">
                 <h3 className="font-semibold text-sm text-text-strong">Display Name</h3>
-                <InputGroup className="h-[42px]">
+                <InputGroup>
                     <InputGroupInput ref={ref} value={name} onChange={(e) => setName(e.target.value)} disabled={!edit} />
                     <InputGroupAddon align="inline-end">
                         {!edit && (


### PR DESCRIPTION
## Problem

Inputs and buttons that sit together in a row had to stay the same height, but their sizing came from two different ad-hoc places: inputs carried ~17 `className` height overrides (auth, search, sidebar, settings) and buttons used the deprecated `xl` (40px) size — which existed only to match those taller inputs. Sizing was fragmented across two components that must stay visually in sync.

## Solution

- Define one shared size scale at 36px: `Button`/`IconButton` drop the deprecated `xl`; `Input`/`InputGroup` gain a `size` variant (`default` 36px + `auto` for hug-content search fields).
- Migrate the 32 `xl` button usages to `lg` and remove every input height `className` override (auth, search, sidebar, settings).
- Switch the combobox / multiselect / integration-dropdown search fields to `size="auto"`, and replace the editable textarea's `h-36` with `rows`.
- Size the Google auth button to match the scale, and standardize the Logs search inputs (default border + Lucide icons) so they look like the rest of the app.
- Input wrappers (`SecretInput`, `ColorInput`, …) are retyped on `InputProps` because the new `size` variant shadows the native `<input size>` attribute.

Picked up a few related leftovers while reviewing the result:

- Integration picker (connection-create): drop the 52px (`h-13`) trigger override to 36px and shrink its selected-integration logo; restyle its dropdown — compact search and rows — to match the standard popover (`surface-overlay` + `border-border-muted` + shadow) instead of the bespoke gray panel.
- Align the CLI command snippet (`LineSnippet`) to 36px so it lines up with the adjacent "View code" button.

Fixes [NAN-6088](https://linear.app/nango/issue/NAN-6088)

## Testing

- `ts-build`, lint, and format pass.
- Verified live against the dev backend: auth forms (inputs + Log in + Google all 36px), the dashboard filter rows (search + combobox triggers + action button aligned at 36px), the combobox/multiselect hug-content search, the Logs search inputs, the integration picker trigger + dropdown (light and dark), and the "Customize this function" command snippet + button.
- Visual QA checklist: [🗂️ NAN-6088 — Align input & button sizing](https://app.notion.com/p/38ace298312181648ebefd74ce1f7887)

Changed stories: `Button` and `ButtonLink` (no more `xl`), `InputGroup` (new `size="auto"` example).

<img width="507" height="656" alt="image" src="https://github.com/user-attachments/assets/64cb8add-507c-4f44-9e14-423b65ac729f" />