### PR TITLE
fix(egress): outbound url policy across all customer-controlled egress paths

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -45,6 +45,10 @@ NANGO_PROXY_BASE_URL_OVERRIDE_ENABLED=true
 NANGO_PROXY_BASE_URL_OVERRIDE_DENYLIST='["169.254.169.254","metadata.google.internal","localhost","127.0.0.1","[::1]","[::ffff:127.0.0.1]","[::ffff:169.254.169.254]"]'
 # To restore pre-remediation fail-open behavior: NANGO_PROXY_BASE_URL_OVERRIDE_DENYLIST='[]'
 # To fully disable the override feature: NANGO_PROXY_BASE_URL_OVERRIDE_ENABLED=false
+# Outbound URL SSRF policy (JSON) applied to proxy, customer webhooks, and uncontrolledFetch. Optional; secure
+# defaults block DNS rebinding, private/link-local IPs, and cap redirects. Restart server and runners after changing.
+# Example (allowlist mode): NANGO_OUTBOUND_URL_POLICY='{"mode":"allowlist","allowlist":[".hubspot.com","api.github.com"]}'
+# Example (block private IPs + cap redirects): NANGO_OUTBOUND_URL_POLICY='{"blockPrivateIps":true,"maxRedirects":3}'
 NANGO_PUBLIC_SERVER_URL=http://localhost:3000
 CSP_REPORT_ONLY=false
 # FLAG_AUTH_ENABLED=false

--- a/docs/guides/platform/self-hosting.mdx
+++ b/docs/guides/platform/self-hosting.mdx
@@ -313,12 +313,14 @@ Beyond the hostname denylist, Nango routes every outbound connection on the **pr
 
 The `mode` field selects how hostnames are filtered:
 
-- **`denylist`** (default): every destination is reachable except hostnames on the denylist (plus the IP-based protections below). This is the default whenever the denylist is non-empty.
+- **`denylist`** (default): every destination is reachable except hostnames on the denylist (plus the IP-based protections below). This is the out-of-the-box mode, since the denylist always carries the secure defaults.
 - **`allowlist`**: only hostnames in `allowlist` are reachable (a leading `.` matches subdomains); everything else is rejected. The denylist and the IP-based protections still apply on top, so allowlist is strictly *more* restrictive — a listed hostname that resolves to a blocked IP is still rejected.
-- **`permissive`**: no hostname-based filtering (the denylist is emptied). This is selected automatically when the denylist is empty and no explicit mode is set.
+- **`permissive`**: no hostname-based filtering (the IP-based protections below still apply). You only reach this mode deliberately — either by emptying the server denylist with no explicit mode (see below), or by setting `mode: "permissive"`.
 
 <Note>
-The IP-based protections apply in **every** mode, including `permissive`. Loopback (`127.0.0.0/8`, `::1`) and unspecified addresses are **always** blocked; private/RFC1918/CGNAT addresses (`blockPrivateIps`) and link-local addresses — including the cloud-metadata IP `169.254.169.254` (`blockLinkLocal`) — are blocked by default. Emptying the denylist (e.g. `NANGO_PROXY_BASE_URL_OVERRIDE_DENYLIST='[]'`, which switches the policy to `permissive`) only drops hostname string matches such as `localhost` and `metadata.google.internal` — literal or resolved internal IPs stay blocked unless you also set `blockPrivateIps`/`blockLinkLocal` to `false`. Runners always re-apply the secure denylist defaults even when the server has opted out.
+The IP-based protections apply in **every** mode, including `permissive`. Loopback (`127.0.0.0/8`, `::1`) and unspecified addresses are **always** blocked; private/RFC1918/CGNAT addresses (`blockPrivateIps`) and link-local addresses — including the cloud-metadata IP `169.254.169.254` (`blockLinkLocal`) — are blocked by default.
+
+The denylist is **never empty by default** — it is always seeded with the secure defaults (`localhost`, `metadata.google.internal`, `169.254.169.254`, …). It only becomes empty if you explicitly opt out: either `NANGO_PROXY_BASE_URL_OVERRIDE_DENYLIST='[]'` (server only, which then selects `permissive`) or `mode: "permissive"`. Even then, only hostname string matches such as `localhost` are dropped — literal or resolved internal IPs stay blocked unless you also set `blockPrivateIps`/`blockLinkLocal` to `false`. Runners re-apply the secure denylist defaults even when the server has emptied its denylist; note an explicit `mode: "permissive"` empties the denylist everywhere, runners included.
 </Note>
 
 ```sh
@@ -331,7 +333,7 @@ NANGO_OUTBOUND_URL_POLICY='{"mode":"allowlist","allowlist":[".hubspot.com","api.
 
 | Field | Default | Purpose |
 | - | - | - |
-| `mode` | `denylist` (or `permissive` when the denylist is empty) | `denylist`, `allowlist`, or `permissive` (see above) |
+| `mode` | `denylist` (auto-`permissive` only if you empty the denylist) | `denylist`, `allowlist`, or `permissive` (see above) |
 | `allowlist` | `[]` | In `allowlist` mode, hostnames (a leading `.` matches subdomains) that may be reached |
 | `blockPrivateIps` | `true` | Block RFC1918 / CGNAT addresses (all modes) |
 | `blockLinkLocal` | `true` | Block link-local addresses incl. `169.254.169.254` (all modes) |

--- a/docs/guides/platform/self-hosting.mdx
+++ b/docs/guides/platform/self-hosting.mdx
@@ -309,7 +309,17 @@ Denylist matching is hostname-based and applies to redirect hops as well as the 
 
 #### Outbound URL policy (DNS rebinding, private IPs, redirects)
 
-Beyond the hostname denylist, Nango routes every outbound connection on the **proxy**, **customer webhook delivery**, and **`uncontrolledFetch`** paths through DNS-pinning agents that re-validate the *resolved* IP address — closing DNS-rebinding and redirect-to-internal-address SSRF holes. The behavior is controlled by `NANGO_OUTBOUND_URL_POLICY`, a JSON object (applied on top of the denylist). It propagates automatically to Kubernetes and Lambda runners.
+Beyond the hostname denylist, Nango routes every outbound connection on the **proxy**, **customer webhook delivery**, and **`uncontrolledFetch`** paths through DNS-pinning agents that re-validate the *resolved* IP address — closing DNS-rebinding and redirect-to-internal-address SSRF holes. The behavior is controlled by `NANGO_OUTBOUND_URL_POLICY`, a JSON object (applied on top of the denylist). It propagates automatically to runners.
+
+The `mode` field selects how hostnames are filtered:
+
+- **`denylist`** (default): every destination is reachable except hostnames on the denylist (plus the IP-based protections below). This is the default whenever the denylist is non-empty.
+- **`allowlist`**: only hostnames in `allowlist` are reachable (a leading `.` matches subdomains); everything else is rejected. The denylist and the IP-based protections still apply on top, so allowlist is strictly *more* restrictive — a listed hostname that resolves to a blocked IP is still rejected.
+- **`permissive`**: no hostname-based filtering (the denylist is emptied). This is selected automatically when the denylist is empty and no explicit mode is set.
+
+<Note>
+The IP-based protections apply in **every** mode, including `permissive`. Loopback (`127.0.0.0/8`, `::1`) and unspecified addresses are **always** blocked; private/RFC1918/CGNAT addresses (`blockPrivateIps`) and link-local addresses — including the cloud-metadata IP `169.254.169.254` (`blockLinkLocal`) — are blocked by default. Emptying the denylist (e.g. `NANGO_PROXY_BASE_URL_OVERRIDE_DENYLIST='[]'`, which switches the policy to `permissive`) only drops hostname string matches such as `localhost` and `metadata.google.internal` — literal or resolved internal IPs stay blocked unless you also set `blockPrivateIps`/`blockLinkLocal` to `false`. Runners always re-apply the secure denylist defaults even when the server has opted out.
+</Note>
 
 ```sh
 # Block private/link-local IPs (default) and cap redirects at 3
@@ -321,11 +331,10 @@ NANGO_OUTBOUND_URL_POLICY='{"mode":"allowlist","allowlist":[".hubspot.com","api.
 
 | Field | Default | Purpose |
 | - | - | - |
-| `mode` | `denylist` (or `permissive` when denylist is emptied) | `denylist`, `allowlist`, or `permissive` |
+| `mode` | `denylist` (or `permissive` when the denylist is empty) | `denylist`, `allowlist`, or `permissive` (see above) |
 | `allowlist` | `[]` | In `allowlist` mode, hostnames (a leading `.` matches subdomains) that may be reached |
-| `blockPrivateIps` | `true` | Block RFC1918 / CGNAT addresses |
-| `blockLinkLocal` | `true` | Block link-local addresses (incl. `169.254.169.254`) |
-| `resolveDns` | `true` | Resolve and validate addresses (DNS rebinding protection) |
+| `blockPrivateIps` | `true` | Block RFC1918 / CGNAT addresses (all modes) |
+| `blockLinkLocal` | `true` | Block link-local addresses incl. `169.254.169.254` (all modes) |
 | `maxRedirects` | `5` | Maximum redirect hops followed |
 
 Each resolved address (including on every redirect hop) is validated; in `allowlist` mode, only listed hostnames are reachable regardless of IP.

--- a/docs/guides/platform/self-hosting.mdx
+++ b/docs/guides/platform/self-hosting.mdx
@@ -297,6 +297,7 @@ NANGO_PROXY_BASE_URL_OVERRIDE_DENYLIST='["169.254.169.254","metadata.google.inte
 | - | - | - |
 | `NANGO_PROXY_BASE_URL_OVERRIDE_ENABLED` | `true` | Set to `false` to reject all base URL overrides |
 | `NANGO_PROXY_BASE_URL_OVERRIDE_DENYLIST` | Secure defaults when unset | JSON array of hostnames or URLs to block; custom entries are merged with defaults |
+| `NANGO_OUTBOUND_URL_POLICY` | Secure defaults when unset | JSON object controlling SSRF protection for proxy, customer webhooks, and `uncontrolledFetch` |
 
 **Operator guidance:**
 
@@ -305,6 +306,29 @@ NANGO_PROXY_BASE_URL_OVERRIDE_DENYLIST='["169.254.169.254","metadata.google.inte
 - **No overrides at all:** set `NANGO_PROXY_BASE_URL_OVERRIDE_ENABLED=false`.
 
 Denylist matching is hostname-based and applies to redirect hops as well as the initial override target.
+
+#### Outbound URL policy (DNS rebinding, private IPs, redirects)
+
+Beyond the hostname denylist, Nango routes every outbound connection on the **proxy**, **customer webhook delivery**, and **`uncontrolledFetch`** paths through DNS-pinning agents that re-validate the *resolved* IP address — closing DNS-rebinding and redirect-to-internal-address SSRF holes. The behavior is controlled by `NANGO_OUTBOUND_URL_POLICY`, a JSON object (applied on top of the denylist). It propagates automatically to Kubernetes and Lambda runners.
+
+```sh
+# Block private/link-local IPs (default) and cap redirects at 3
+NANGO_OUTBOUND_URL_POLICY='{"blockPrivateIps":true,"blockLinkLocal":true,"maxRedirects":3}'
+
+# Allowlist mode: only the listed hostnames (and their subdomains) are reachable
+NANGO_OUTBOUND_URL_POLICY='{"mode":"allowlist","allowlist":[".hubspot.com","api.github.com"]}'
+```
+
+| Field | Default | Purpose |
+| - | - | - |
+| `mode` | `denylist` (or `permissive` when denylist is emptied) | `denylist`, `allowlist`, or `permissive` |
+| `allowlist` | `[]` | In `allowlist` mode, hostnames (a leading `.` matches subdomains) that may be reached |
+| `blockPrivateIps` | `true` | Block RFC1918 / CGNAT addresses |
+| `blockLinkLocal` | `true` | Block link-local addresses (incl. `169.254.169.254`) |
+| `resolveDns` | `true` | Resolve and validate addresses (DNS rebinding protection) |
+| `maxRedirects` | `5` | Maximum redirect hops followed |
+
+Each resolved address (including on every redirect hop) is validated; in `allowlist` mode, only listed hostnames are reachable regardless of IP.
 
 #### Securing the dashboard
 

--- a/docs/llms-full.txt
+++ b/docs/llms-full.txt
@@ -6715,6 +6715,7 @@ NANGO_PROXY_BASE_URL_OVERRIDE_DENYLIST='["169.254.169.254","metadata.google.inte
 | - | - | - |
 | `NANGO_PROXY_BASE_URL_OVERRIDE_ENABLED` | `true` | Set to `false` to reject all base URL overrides |
 | `NANGO_PROXY_BASE_URL_OVERRIDE_DENYLIST` | Secure defaults when unset | JSON array of hostnames or URLs to block; custom entries are merged with defaults |
+| `NANGO_OUTBOUND_URL_POLICY` | Secure defaults when unset | JSON object controlling SSRF protection for proxy, customer webhooks, and `uncontrolledFetch` |
 
 **Operator guidance:**
 
@@ -6723,6 +6724,29 @@ NANGO_PROXY_BASE_URL_OVERRIDE_DENYLIST='["169.254.169.254","metadata.google.inte
 - **No overrides at all:** set `NANGO_PROXY_BASE_URL_OVERRIDE_ENABLED=false`.
 
 Denylist matching is hostname-based and applies to redirect hops as well as the initial override target.
+
+#### Outbound URL policy (DNS rebinding, private IPs, redirects)
+
+Beyond the hostname denylist, Nango routes every outbound connection on the **proxy**, **customer webhook delivery**, and **`uncontrolledFetch`** paths through DNS-pinning agents that re-validate the *resolved* IP address — closing DNS-rebinding and redirect-to-internal-address SSRF holes. The behavior is controlled by `NANGO_OUTBOUND_URL_POLICY`, a JSON object (applied on top of the denylist). It propagates automatically to Kubernetes and Lambda runners.
+
+```sh
+# Block private/link-local IPs (default) and cap redirects at 3
+NANGO_OUTBOUND_URL_POLICY='{"blockPrivateIps":true,"blockLinkLocal":true,"maxRedirects":3}'
+
+# Allowlist mode: only the listed hostnames (and their subdomains) are reachable
+NANGO_OUTBOUND_URL_POLICY='{"mode":"allowlist","allowlist":[".hubspot.com","api.github.com"]}'
+```
+
+| Field | Default | Purpose |
+| - | - | - |
+| `mode` | `denylist` (or `permissive` when denylist is emptied) | `denylist`, `allowlist`, or `permissive` |
+| `allowlist` | `[]` | In `allowlist` mode, hostnames (a leading `.` matches subdomains) that may be reached |
+| `blockPrivateIps` | `true` | Block RFC1918 / CGNAT addresses |
+| `blockLinkLocal` | `true` | Block link-local addresses (incl. `169.254.169.254`) |
+| `resolveDns` | `true` | Resolve and validate addresses (DNS rebinding protection) |
+| `maxRedirects` | `5` | Maximum redirect hops followed |
+
+Each resolved address (including on every redirect hop) is validated; in `allowlist` mode, only listed hostnames are reachable regardless of IP.
 
 #### Securing the dashboard
 

--- a/docs/llms-full.txt
+++ b/docs/llms-full.txt
@@ -6727,7 +6727,17 @@ Denylist matching is hostname-based and applies to redirect hops as well as the 
 
 #### Outbound URL policy (DNS rebinding, private IPs, redirects)
 
-Beyond the hostname denylist, Nango routes every outbound connection on the **proxy**, **customer webhook delivery**, and **`uncontrolledFetch`** paths through DNS-pinning agents that re-validate the *resolved* IP address — closing DNS-rebinding and redirect-to-internal-address SSRF holes. The behavior is controlled by `NANGO_OUTBOUND_URL_POLICY`, a JSON object (applied on top of the denylist). It propagates automatically to Kubernetes and Lambda runners.
+Beyond the hostname denylist, Nango routes every outbound connection on the **proxy**, **customer webhook delivery**, and **`uncontrolledFetch`** paths through DNS-pinning agents that re-validate the *resolved* IP address — closing DNS-rebinding and redirect-to-internal-address SSRF holes. The behavior is controlled by `NANGO_OUTBOUND_URL_POLICY`, a JSON object (applied on top of the denylist). It propagates automatically to runners.
+
+The `mode` field selects how hostnames are filtered:
+
+- **`denylist`** (default): every destination is reachable except hostnames on the denylist (plus the IP-based protections below). This is the default whenever the denylist is non-empty.
+- **`allowlist`**: only hostnames in `allowlist` are reachable (a leading `.` matches subdomains); everything else is rejected. The denylist and the IP-based protections still apply on top, so allowlist is strictly *more* restrictive — a listed hostname that resolves to a blocked IP is still rejected.
+- **`permissive`**: no hostname-based filtering (the denylist is emptied). This is selected automatically when the denylist is empty and no explicit mode is set.
+
+<Note>
+The IP-based protections apply in **every** mode, including `permissive`. Loopback (`127.0.0.0/8`, `::1`) and unspecified addresses are **always** blocked; private/RFC1918/CGNAT addresses (`blockPrivateIps`) and link-local addresses — including the cloud-metadata IP `169.254.169.254` (`blockLinkLocal`) — are blocked by default. Emptying the denylist (e.g. `NANGO_PROXY_BASE_URL_OVERRIDE_DENYLIST='[]'`, which switches the policy to `permissive`) only drops hostname string matches such as `localhost` and `metadata.google.internal` — literal or resolved internal IPs stay blocked unless you also set `blockPrivateIps`/`blockLinkLocal` to `false`. Runners always re-apply the secure denylist defaults even when the server has opted out.
+</Note>
 
 ```sh
 # Block private/link-local IPs (default) and cap redirects at 3
@@ -6739,11 +6749,10 @@ NANGO_OUTBOUND_URL_POLICY='{"mode":"allowlist","allowlist":[".hubspot.com","api.
 
 | Field | Default | Purpose |
 | - | - | - |
-| `mode` | `denylist` (or `permissive` when denylist is emptied) | `denylist`, `allowlist`, or `permissive` |
+| `mode` | `denylist` (or `permissive` when the denylist is empty) | `denylist`, `allowlist`, or `permissive` (see above) |
 | `allowlist` | `[]` | In `allowlist` mode, hostnames (a leading `.` matches subdomains) that may be reached |
-| `blockPrivateIps` | `true` | Block RFC1918 / CGNAT addresses |
-| `blockLinkLocal` | `true` | Block link-local addresses (incl. `169.254.169.254`) |
-| `resolveDns` | `true` | Resolve and validate addresses (DNS rebinding protection) |
+| `blockPrivateIps` | `true` | Block RFC1918 / CGNAT addresses (all modes) |
+| `blockLinkLocal` | `true` | Block link-local addresses incl. `169.254.169.254` (all modes) |
 | `maxRedirects` | `5` | Maximum redirect hops followed |
 
 Each resolved address (including on every redirect hop) is validated; in `allowlist` mode, only listed hostnames are reachable regardless of IP.

--- a/docs/llms-full.txt
+++ b/docs/llms-full.txt
@@ -6731,12 +6731,14 @@ Beyond the hostname denylist, Nango routes every outbound connection on the **pr
 
 The `mode` field selects how hostnames are filtered:
 
-- **`denylist`** (default): every destination is reachable except hostnames on the denylist (plus the IP-based protections below). This is the default whenever the denylist is non-empty.
+- **`denylist`** (default): every destination is reachable except hostnames on the denylist (plus the IP-based protections below). This is the out-of-the-box mode, since the denylist always carries the secure defaults.
 - **`allowlist`**: only hostnames in `allowlist` are reachable (a leading `.` matches subdomains); everything else is rejected. The denylist and the IP-based protections still apply on top, so allowlist is strictly *more* restrictive — a listed hostname that resolves to a blocked IP is still rejected.
-- **`permissive`**: no hostname-based filtering (the denylist is emptied). This is selected automatically when the denylist is empty and no explicit mode is set.
+- **`permissive`**: no hostname-based filtering (the IP-based protections below still apply). You only reach this mode deliberately — either by emptying the server denylist with no explicit mode (see below), or by setting `mode: "permissive"`.
 
 <Note>
-The IP-based protections apply in **every** mode, including `permissive`. Loopback (`127.0.0.0/8`, `::1`) and unspecified addresses are **always** blocked; private/RFC1918/CGNAT addresses (`blockPrivateIps`) and link-local addresses — including the cloud-metadata IP `169.254.169.254` (`blockLinkLocal`) — are blocked by default. Emptying the denylist (e.g. `NANGO_PROXY_BASE_URL_OVERRIDE_DENYLIST='[]'`, which switches the policy to `permissive`) only drops hostname string matches such as `localhost` and `metadata.google.internal` — literal or resolved internal IPs stay blocked unless you also set `blockPrivateIps`/`blockLinkLocal` to `false`. Runners always re-apply the secure denylist defaults even when the server has opted out.
+The IP-based protections apply in **every** mode, including `permissive`. Loopback (`127.0.0.0/8`, `::1`) and unspecified addresses are **always** blocked; private/RFC1918/CGNAT addresses (`blockPrivateIps`) and link-local addresses — including the cloud-metadata IP `169.254.169.254` (`blockLinkLocal`) — are blocked by default.
+
+The denylist is **never empty by default** — it is always seeded with the secure defaults (`localhost`, `metadata.google.internal`, `169.254.169.254`, …). It only becomes empty if you explicitly opt out: either `NANGO_PROXY_BASE_URL_OVERRIDE_DENYLIST='[]'` (server only, which then selects `permissive`) or `mode: "permissive"`. Even then, only hostname string matches such as `localhost` are dropped — literal or resolved internal IPs stay blocked unless you also set `blockPrivateIps`/`blockLinkLocal` to `false`. Runners re-apply the secure denylist defaults even when the server has emptied its denylist; note an explicit `mode: "permissive"` empties the denylist everywhere, runners included.
 </Note>
 
 ```sh
@@ -6749,7 +6751,7 @@ NANGO_OUTBOUND_URL_POLICY='{"mode":"allowlist","allowlist":[".hubspot.com","api.
 
 | Field | Default | Purpose |
 | - | - | - |
-| `mode` | `denylist` (or `permissive` when the denylist is empty) | `denylist`, `allowlist`, or `permissive` (see above) |
+| `mode` | `denylist` (auto-`permissive` only if you empty the denylist) | `denylist`, `allowlist`, or `permissive` (see above) |
 | `allowlist` | `[]` | In `allowlist` mode, hostnames (a leading `.` matches subdomains) that may be reached |
 | `blockPrivateIps` | `true` | Block RFC1918 / CGNAT addresses (all modes) |
 | `blockLinkLocal` | `true` | Block link-local addresses incl. `169.254.169.254` (all modes) |

--- a/package-lock.json
+++ b/package-lock.json
@@ -37073,7 +37073,8 @@
                 "ajv": "8.18.0",
                 "ajv-formats": "3.0.1",
                 "lodash-es": "4.18.1",
-                "parse-link-header": "2.0.0"
+                "parse-link-header": "2.0.0",
+                "undici": "6.27.0"
             },
             "devDependencies": {
                 "@nangohq/types": "0.70.9",

--- a/package-lock.json
+++ b/package-lock.json
@@ -37631,6 +37631,7 @@
                 "@hapi/boom": "10.0.1",
                 "@modelcontextprotocol/sdk": "1.26.0",
                 "@nangohq/database": "file:../database",
+                "@nangohq/egress": "file:../egress",
                 "@nangohq/feature-flags": "file:../feature-flags",
                 "@nangohq/kms": "file:../kms",
                 "@nangohq/kvstore": "file:../kvstore",
@@ -39094,6 +39095,7 @@
             "name": "@nangohq/webhooks",
             "version": "1.0.0",
             "dependencies": {
+                "@nangohq/egress": "file:../egress",
                 "@nangohq/kvstore": "file:../kvstore",
                 "@nangohq/logs": "file:../logs",
                 "@nangohq/shared": "file:../shared",

--- a/packages/egress/lib/agent.ts
+++ b/packages/egress/lib/agent.ts
@@ -117,10 +117,6 @@ export function agentForUrl(url: string, agents: { httpAgent: http.Agent; httpsA
 const safeLookupCache = new Map<string, typeof dns.lookup>();
 const safeAgentsCache = new Map<string, { httpAgent: http.Agent; httpsAgent: https.Agent }>();
 
-/**
- * Memoized safe DNS lookup keyed by policy. Reuse across requests so the pinned-address
- * cache is shared and so http/https Agents can keep connections alive.
- */
 export function getSafeLookup(policy: OutboundUrlPolicy): typeof dns.lookup {
     const key = policyPinCacheKey(policy);
     let lookup = safeLookupCache.get(key);
@@ -131,10 +127,6 @@ export function getSafeLookup(policy: OutboundUrlPolicy): typeof dns.lookup {
     return lookup;
 }
 
-/**
- * Memoized keep-alive Agents whose connections only succeed when the resolved address
- * passes the policy. Reused across requests for connection pooling.
- */
 export function getSafeHttpAgents(policy: OutboundUrlPolicy): { httpAgent: http.Agent; httpsAgent: https.Agent } {
     const key = policyPinCacheKey(policy);
     let agents = safeAgentsCache.get(key);

--- a/packages/egress/lib/agent.ts
+++ b/packages/egress/lib/agent.ts
@@ -113,3 +113,38 @@ export function createSafeHttpAgents(policy: OutboundUrlPolicy): { httpAgent: ht
 export function agentForUrl(url: string, agents: { httpAgent: http.Agent; httpsAgent: https.Agent }): http.Agent | https.Agent {
     return url.startsWith('https:') ? agents.httpsAgent : agents.httpAgent;
 }
+
+const safeLookupCache = new Map<string, typeof dns.lookup>();
+const safeAgentsCache = new Map<string, { httpAgent: http.Agent; httpsAgent: https.Agent }>();
+
+/**
+ * Memoized safe DNS lookup keyed by policy. Reuse across requests so the pinned-address
+ * cache is shared and so http/https Agents can keep connections alive.
+ */
+export function getSafeLookup(policy: OutboundUrlPolicy): typeof dns.lookup {
+    const key = policyPinCacheKey(policy);
+    let lookup = safeLookupCache.get(key);
+    if (!lookup) {
+        lookup = createSafeLookup(policy);
+        safeLookupCache.set(key, lookup);
+    }
+    return lookup;
+}
+
+/**
+ * Memoized keep-alive Agents whose connections only succeed when the resolved address
+ * passes the policy. Reused across requests for connection pooling.
+ */
+export function getSafeHttpAgents(policy: OutboundUrlPolicy): { httpAgent: http.Agent; httpsAgent: https.Agent } {
+    const key = policyPinCacheKey(policy);
+    let agents = safeAgentsCache.get(key);
+    if (!agents) {
+        const lookup = getSafeLookup(policy);
+        agents = {
+            httpAgent: new http.Agent({ lookup, keepAlive: true }),
+            httpsAgent: new https.Agent({ lookup, keepAlive: true })
+        };
+        safeAgentsCache.set(key, agents);
+    }
+    return agents;
+}

--- a/packages/egress/lib/egress.unit.test.ts
+++ b/packages/egress/lib/egress.unit.test.ts
@@ -14,7 +14,7 @@ import {
 } from './denylist.js';
 import { OutboundUrlError } from './errors.js';
 import { classifyBlockedIp } from './ip.js';
-import { resetRunnerPolicyCacheForTests, resolvePolicyForRunnerSync, resolvePolicyForServer } from './policy.js';
+import { resolvePolicyForRunnerSync, resolvePolicyForServer } from './policy.js';
 import { absoluteUrlFromRedirectRequestOptions, createRedirectValidator } from './redirect.js';
 import { isBaseUrlOverrideDeniedByPolicy, validateOutboundUrlAsync, validateOutboundUrlSync } from './validate.js';
 
@@ -108,12 +108,12 @@ describe('egress allowlist mode', () => {
     it('allows only matching hostnames', () => {
         const policy = resolvePolicyForServer({
             proxyBaseUrlOverrideDenylist: [],
-            outboundUrlPolicyRaw: JSON.stringify({
+            outboundUrlPolicy: {
                 mode: 'allowlist',
                 allowlist: ['.example.com', 'api.hubspot.com'],
                 blockPrivateIps: false,
                 resolveDns: false
-            })
+            }
         });
         expect(validateOutboundUrlSync('https://api.example.com/x', policy).ok).toBe(true);
         expect(validateOutboundUrlSync('https://evil.com/x', policy).ok).toBe(false);
@@ -130,11 +130,6 @@ describe('egress permissive mode', () => {
 });
 
 describe('egress runner policy', () => {
-    afterEach(() => {
-        resetRunnerPolicyCacheForTests();
-        clearPinnedAddressCacheForTests();
-    });
-
     it('always applies secure defaults when denylist env is empty', () => {
         const policy = resolvePolicyForRunnerSync({ proxyBaseUrlOverrideDenylistRaw: '[]' });
         expect(policy.denylist.has('localhost')).toBe(true);

--- a/packages/egress/lib/egress.unit.test.ts
+++ b/packages/egress/lib/egress.unit.test.ts
@@ -135,6 +135,42 @@ describe('egress runner policy', () => {
     });
 });
 
+describe('egress maxRedirects sanitization', () => {
+    // Runners parse NANGO_OUTBOUND_URL_POLICY straight from process.env with no schema, so the policy
+    // resolver must coerce maxRedirects into a safe non-negative integer (else a NaN would disable the
+    // redirect-loop cap entirely).
+    it('accepts a valid non-negative integer', () => {
+        const policy = resolvePolicyForServer({ proxyBaseUrlOverrideDenylist: [], outboundUrlPolicy: { maxRedirects: 3 } });
+        expect(policy.maxRedirects).toBe(3);
+    });
+
+    it('falls back to the default for non-numeric values', () => {
+        const policy = resolvePolicyForServer({
+            proxyBaseUrlOverrideDenylist: [],
+            outboundUrlPolicy: { maxRedirects: 'oops' as unknown as number }
+        });
+        expect(policy.maxRedirects).toBe(5);
+    });
+
+    it('falls back to the default for NaN', () => {
+        const policy = resolvePolicyForServer({
+            proxyBaseUrlOverrideDenylist: [],
+            outboundUrlPolicy: { maxRedirects: Number.NaN }
+        });
+        expect(policy.maxRedirects).toBe(5);
+    });
+
+    it('falls back to the default for negative or non-integer values', () => {
+        expect(resolvePolicyForServer({ proxyBaseUrlOverrideDenylist: [], outboundUrlPolicy: { maxRedirects: -1 } }).maxRedirects).toBe(5);
+        expect(resolvePolicyForServer({ proxyBaseUrlOverrideDenylist: [], outboundUrlPolicy: { maxRedirects: 2.5 } }).maxRedirects).toBe(5);
+    });
+
+    it('allows zero (disables redirect following)', () => {
+        const policy = resolvePolicyForServer({ proxyBaseUrlOverrideDenylist: [], outboundUrlPolicy: { maxRedirects: 0 } });
+        expect(policy.maxRedirects).toBe(0);
+    });
+});
+
 describe('egress redirect validator', () => {
     const policy = resolvePolicyForServer({
         proxyBaseUrlOverrideDenylist: [...DEFAULT_NANGO_PROXY_BASE_URL_OVERRIDE_DENYLIST]

--- a/packages/egress/lib/egress.unit.test.ts
+++ b/packages/egress/lib/egress.unit.test.ts
@@ -111,8 +111,7 @@ describe('egress allowlist mode', () => {
             outboundUrlPolicy: {
                 mode: 'allowlist',
                 allowlist: ['.example.com', 'api.hubspot.com'],
-                blockPrivateIps: false,
-                resolveDns: false
+                blockPrivateIps: false
             }
         });
         expect(validateOutboundUrlSync('https://api.example.com/x', policy).ok).toBe(true);

--- a/packages/egress/lib/errors.ts
+++ b/packages/egress/lib/errors.ts
@@ -23,3 +23,20 @@ export class OutboundUrlError extends Error {
         }
     }
 }
+
+export function findOutboundUrlError(error: unknown): OutboundUrlError | null {
+    let current: unknown = error;
+    const seen = new Set<unknown>();
+    while (current && typeof current === 'object' && !seen.has(current)) {
+        seen.add(current);
+        if (current instanceof OutboundUrlError) {
+            return current;
+        }
+        if ('cause' in current && (current as { cause?: unknown }).cause !== undefined) {
+            current = (current as { cause: unknown }).cause;
+        } else {
+            break;
+        }
+    }
+    return null;
+}

--- a/packages/egress/lib/index.ts
+++ b/packages/egress/lib/index.ts
@@ -1,7 +1,21 @@
 export * from './denylist.js';
 export * from './errors.js';
 export * from './ip.js';
-export * from './policy.js';
 export * from './validate.js';
-export * from './agent.js';
 export * from './redirect.js';
+
+// Curated public surface for ./agent.js and ./policy.js: test-only helpers
+// (e.g. clearPinnedAddressCacheForTests) stay importable via relative paths within the
+// package but are intentionally kept off the package's public contract.
+export { createSafeLookup, createSafeHttpAgents, agentForUrl, getSafeLookup, getSafeHttpAgents } from './agent.js';
+export {
+    DEFAULT_OUTBOUND_URL_POLICY,
+    resolvePolicyForServer,
+    resolvePolicyForRunner,
+    resolvePolicyForRunnerSync,
+    resolvePolicyFromProcessEnvForRunner,
+    resolveProxyDenylistFromServerRaw,
+    getRunnerPolicyFromEnv,
+    resolvePolicyForOAuth
+} from './policy.js';
+export type { OutboundUrlPolicyMode, OutboundUrlPolicyRaw, OutboundUrlPolicy, ServerPolicyEnvInput, RunnerPolicyEnvInput } from './policy.js';

--- a/packages/egress/lib/index.ts
+++ b/packages/egress/lib/index.ts
@@ -4,9 +4,6 @@ export * from './ip.js';
 export * from './validate.js';
 export * from './redirect.js';
 
-// Curated public surface for ./agent.js and ./policy.js: test-only helpers
-// (e.g. clearPinnedAddressCacheForTests) stay importable via relative paths within the
-// package but are intentionally kept off the package's public contract.
 export { createSafeLookup, createSafeHttpAgents, agentForUrl, getSafeLookup, getSafeHttpAgents } from './agent.js';
 export {
     DEFAULT_OUTBOUND_URL_POLICY,

--- a/packages/egress/lib/policy.ts
+++ b/packages/egress/lib/policy.ts
@@ -68,13 +68,7 @@ function mergePolicyRaw(base: OutboundUrlPolicyRaw, overlay: OutboundUrlPolicyRa
     return merged;
 }
 
-/**
- * Coerce maxRedirects into a safe, non-negative integer. The server validates this via Zod, but runners
- * parse NANGO_OUTBOUND_URL_POLICY straight from process.env with no schema, so an invalid value (string,
- * NaN, negative, float) could otherwise reach the redirect-loop stop condition. A NaN in particular makes
- * `count >= maxRedirects` always false, allowing unbounded redirect loops — so we fail safe to the default.
- */
-function sanitizeMaxRedirects(value: unknown): number {
+function safeMaxRedirects(value: unknown): number {
     if (typeof value === 'number' && Number.isInteger(value) && value >= 0) {
         return value;
     }
@@ -91,15 +85,13 @@ function rawToPolicy(raw: OutboundUrlPolicyRaw, denylistEntries: string[]): Outb
         allowlist: raw.allowlist ?? [],
         blockPrivateIps: raw.blockPrivateIps ?? true,
         blockLinkLocal: raw.blockLinkLocal ?? true,
-        // Fixed, non-operator-editable security boundary: only http/https are ever permitted.
         allowedSchemes: new Set(['http:', 'https:']),
-        maxRedirects: sanitizeMaxRedirects(raw.maxRedirects)
+        maxRedirects: safeMaxRedirects(raw.maxRedirects)
     };
 }
 
 export interface ServerPolicyEnvInput {
     proxyBaseUrlOverrideDenylist: string[];
-    /** Already-parsed + validated policy object (see ENVS.NANGO_OUTBOUND_URL_POLICY). */
     outboundUrlPolicy?: OutboundUrlPolicyRaw | undefined;
 }
 
@@ -124,10 +116,6 @@ export function resolvePolicyForServer(input: ServerPolicyEnvInput): OutboundUrl
 export interface RunnerPolicyEnvInput {
     proxyBaseUrlOverrideEnabled?: string | undefined;
     proxyBaseUrlOverrideDenylistRaw?: string | undefined;
-    /**
-     * Already-parsed + validated policy object (see ENVS.NANGO_OUTBOUND_URL_POLICY). The runner passes
-     * this through from its parsed envs; the process.env helper parses the raw JSON before calling.
-     */
     outboundUrlPolicy?: OutboundUrlPolicyRaw | undefined;
     lambdaRuntimeApi?: string | undefined;
 }

--- a/packages/egress/lib/policy.ts
+++ b/packages/egress/lib/policy.ts
@@ -68,6 +68,19 @@ function mergePolicyRaw(base: OutboundUrlPolicyRaw, overlay: OutboundUrlPolicyRa
     return merged;
 }
 
+/**
+ * Coerce maxRedirects into a safe, non-negative integer. The server validates this via Zod, but runners
+ * parse NANGO_OUTBOUND_URL_POLICY straight from process.env with no schema, so an invalid value (string,
+ * NaN, negative, float) could otherwise reach the redirect-loop stop condition. A NaN in particular makes
+ * `count >= maxRedirects` always false, allowing unbounded redirect loops — so we fail safe to the default.
+ */
+function sanitizeMaxRedirects(value: unknown): number {
+    if (typeof value === 'number' && Number.isInteger(value) && value >= 0) {
+        return value;
+    }
+    return DEFAULT_OUTBOUND_URL_POLICY.maxRedirects;
+}
+
 function rawToPolicy(raw: OutboundUrlPolicyRaw, denylistEntries: string[]): OutboundUrlPolicy {
     const mode = raw.mode ?? (denylistEntries.length === 0 ? 'permissive' : 'denylist');
     const denylist = mode === 'permissive' ? new Set<string>() : normalizeDenylist(denylistEntries);
@@ -80,7 +93,7 @@ function rawToPolicy(raw: OutboundUrlPolicyRaw, denylistEntries: string[]): Outb
         blockLinkLocal: raw.blockLinkLocal ?? true,
         // Fixed, non-operator-editable security boundary: only http/https are ever permitted.
         allowedSchemes: new Set(['http:', 'https:']),
-        maxRedirects: raw.maxRedirects ?? 5
+        maxRedirects: sanitizeMaxRedirects(raw.maxRedirects)
     };
 }
 

--- a/packages/egress/lib/policy.ts
+++ b/packages/egress/lib/policy.ts
@@ -10,14 +10,14 @@ import {
 export type OutboundUrlPolicyMode = 'denylist' | 'allowlist' | 'permissive';
 
 export interface OutboundUrlPolicyRaw {
-    mode?: OutboundUrlPolicyMode;
-    denylist?: string[];
-    allowlist?: string[];
-    blockPrivateIps?: boolean;
-    blockLinkLocal?: boolean;
-    resolveDns?: boolean;
-    allowedSchemes?: string[];
-    maxRedirects?: number;
+    mode?: OutboundUrlPolicyMode | undefined;
+    denylist?: string[] | undefined;
+    allowlist?: string[] | undefined;
+    blockPrivateIps?: boolean | undefined;
+    blockLinkLocal?: boolean | undefined;
+    resolveDns?: boolean | undefined;
+    allowedSchemes?: string[] | undefined;
+    maxRedirects?: number | undefined;
 }
 
 export interface OutboundUrlPolicy {
@@ -92,14 +92,15 @@ function rawToPolicy(raw: OutboundUrlPolicyRaw, denylistEntries: string[]): Outb
 
 export interface ServerPolicyEnvInput {
     proxyBaseUrlOverrideDenylist: string[];
-    outboundUrlPolicyRaw?: string | undefined;
+    /** Already-parsed + validated policy object (see ENVS.NANGO_OUTBOUND_URL_POLICY). */
+    outboundUrlPolicy?: OutboundUrlPolicyRaw | undefined;
 }
 
 /**
  * Build policy for server-side services from parsed env values.
  */
 export function resolvePolicyForServer(input: ServerPolicyEnvInput): OutboundUrlPolicy {
-    const jsonRaw = parsePolicyJson(input.outboundUrlPolicyRaw);
+    const jsonRaw = input.outboundUrlPolicy ?? null;
     const denylistEntries = input.proxyBaseUrlOverrideDenylist;
 
     if (!jsonRaw) {
@@ -116,7 +117,11 @@ export function resolvePolicyForServer(input: ServerPolicyEnvInput): OutboundUrl
 export interface RunnerPolicyEnvInput {
     proxyBaseUrlOverrideEnabled?: string | undefined;
     proxyBaseUrlOverrideDenylistRaw?: string | undefined;
-    outboundUrlPolicyRaw?: string | undefined;
+    /**
+     * Already-parsed + validated policy object (see ENVS.NANGO_OUTBOUND_URL_POLICY). The runner passes
+     * this through from its parsed envs; the process.env helper parses the raw JSON before calling.
+     */
+    outboundUrlPolicy?: OutboundUrlPolicyRaw | undefined;
     lambdaRuntimeApi?: string | undefined;
 }
 
@@ -141,7 +146,7 @@ export function resolvePolicyForRunnerSync(input: RunnerPolicyEnvInput): Outboun
         ? resolveProxyBaseUrlOverrideDenylistForRunner(input.proxyBaseUrlOverrideDenylistRaw)
         : [...DEFAULT_NANGO_PROXY_BASE_URL_OVERRIDE_DENYLIST];
 
-    const jsonRaw = parsePolicyJson(input.outboundUrlPolicyRaw);
+    const jsonRaw = input.outboundUrlPolicy ?? null;
     const policy = jsonRaw ? rawToPolicy(mergePolicyRaw({}, jsonRaw), denylistEntries) : rawToPolicy({}, denylistEntries);
 
     if (input.lambdaRuntimeApi) {
@@ -159,7 +164,7 @@ export function resolvePolicyFromProcessEnvForRunner(): OutboundUrlPolicy {
     return resolvePolicyForRunnerSync({
         proxyBaseUrlOverrideEnabled: env['NANGO_PROXY_BASE_URL_OVERRIDE_ENABLED'],
         proxyBaseUrlOverrideDenylistRaw: env['NANGO_PROXY_BASE_URL_OVERRIDE_DENYLIST'],
-        outboundUrlPolicyRaw: env['NANGO_OUTBOUND_URL_POLICY'],
+        outboundUrlPolicy: parsePolicyJson(env['NANGO_OUTBOUND_URL_POLICY']) ?? undefined,
         lambdaRuntimeApi: env['AWS_LAMBDA_RUNTIME_API']
     });
 }
@@ -176,10 +181,6 @@ export function getRunnerPolicyFromEnv(): OutboundUrlPolicy {
     }
     memoizedRunnerPolicy = resolvePolicyFromProcessEnvForRunner();
     return memoizedRunnerPolicy;
-}
-
-export function resetRunnerPolicyCacheForTests(): void {
-    memoizedRunnerPolicy = null;
 }
 
 /**

--- a/packages/egress/lib/policy.ts
+++ b/packages/egress/lib/policy.ts
@@ -15,8 +15,6 @@ export interface OutboundUrlPolicyRaw {
     allowlist?: string[] | undefined;
     blockPrivateIps?: boolean | undefined;
     blockLinkLocal?: boolean | undefined;
-    resolveDns?: boolean | undefined;
-    allowedSchemes?: string[] | undefined;
     maxRedirects?: number | undefined;
 }
 
@@ -26,7 +24,6 @@ export interface OutboundUrlPolicy {
     allowlist: string[];
     blockPrivateIps: boolean;
     blockLinkLocal: boolean;
-    resolveDns: boolean;
     allowedSchemes: Set<string>;
     maxRedirects: number;
 }
@@ -37,7 +34,6 @@ export const DEFAULT_OUTBOUND_URL_POLICY: OutboundUrlPolicy = {
     allowlist: [],
     blockPrivateIps: true,
     blockLinkLocal: true,
-    resolveDns: true,
     allowedSchemes: new Set(['http:', 'https:']),
     maxRedirects: 5
 };
@@ -68,8 +64,6 @@ function mergePolicyRaw(base: OutboundUrlPolicyRaw, overlay: OutboundUrlPolicyRa
     if (overlay.allowlist !== undefined) merged.allowlist = overlay.allowlist;
     if (overlay.blockPrivateIps !== undefined) merged.blockPrivateIps = overlay.blockPrivateIps;
     if (overlay.blockLinkLocal !== undefined) merged.blockLinkLocal = overlay.blockLinkLocal;
-    if (overlay.resolveDns !== undefined) merged.resolveDns = overlay.resolveDns;
-    if (overlay.allowedSchemes !== undefined) merged.allowedSchemes = overlay.allowedSchemes;
     if (overlay.maxRedirects !== undefined) merged.maxRedirects = overlay.maxRedirects;
     return merged;
 }
@@ -84,8 +78,8 @@ function rawToPolicy(raw: OutboundUrlPolicyRaw, denylistEntries: string[]): Outb
         allowlist: raw.allowlist ?? [],
         blockPrivateIps: raw.blockPrivateIps ?? true,
         blockLinkLocal: raw.blockLinkLocal ?? true,
-        resolveDns: raw.resolveDns ?? true,
-        allowedSchemes: new Set(raw.allowedSchemes ?? ['http:', 'https:']),
+        // Fixed, non-operator-editable security boundary: only http/https are ever permitted.
+        allowedSchemes: new Set(['http:', 'https:']),
         maxRedirects: raw.maxRedirects ?? 5
     };
 }

--- a/packages/egress/lib/validate.ts
+++ b/packages/egress/lib/validate.ts
@@ -198,10 +198,6 @@ export async function validateOutboundUrlAsync(url: string, policy: OutboundUrlP
         return syncResult;
     }
 
-    if (!policy.resolveDns) {
-        return syncResult;
-    }
-
     const hostname = syncResult.hostname;
     if (net.isIP(hostname)) {
         return syncResult;

--- a/packages/jobs/lib/runner/kubernetes.ts
+++ b/packages/jobs/lib/runner/kubernetes.ts
@@ -420,6 +420,7 @@ class Kubernetes {
             ...(envs.NANGO_PROXY_BASE_URL_OVERRIDE_DENYLIST.length > 0
                 ? [{ name: 'NANGO_PROXY_BASE_URL_OVERRIDE_DENYLIST', value: JSON.stringify(envs.NANGO_PROXY_BASE_URL_OVERRIDE_DENYLIST) }]
                 : []),
+            ...(envs.NANGO_OUTBOUND_URL_POLICY ? [{ name: 'NANGO_OUTBOUND_URL_POLICY', value: JSON.stringify(envs.NANGO_OUTBOUND_URL_POLICY) }] : []),
             ...(envs.DD_ENV ? [{ name: 'DD_ENV', value: envs.DD_ENV }] : []),
             ...(envs.DD_SITE ? [{ name: 'DD_SITE', value: envs.DD_SITE }] : []),
             ...(envs.DD_TRACE_AGENT_URL ? [{ name: 'DD_TRACE_AGENT_URL', value: envs.DD_TRACE_AGENT_URL }] : []),

--- a/packages/jobs/lib/runner/lambda.ts
+++ b/packages/jobs/lib/runner/lambda.ts
@@ -271,6 +271,7 @@ class Lambda {
                 ...(envs.NANGO_PROXY_BASE_URL_OVERRIDE_DENYLIST.length > 0
                     ? { NANGO_PROXY_BASE_URL_OVERRIDE_DENYLIST: JSON.stringify(envs.NANGO_PROXY_BASE_URL_OVERRIDE_DENYLIST) }
                     : {}),
+                ...(envs.NANGO_OUTBOUND_URL_POLICY ? { NANGO_OUTBOUND_URL_POLICY: JSON.stringify(envs.NANGO_OUTBOUND_URL_POLICY) } : {}),
                 ...(envs.LAMBDA_PAYLOADS_BUCKET_NAME ? { LAMBDA_PAYLOADS_BUCKET_NAME: envs.LAMBDA_PAYLOADS_BUCKET_NAME } : {}),
                 ...(envs.LAMBDA_PAYLOAD_MAX_SIZE_BYTES ? { LAMBDA_PAYLOAD_MAX_SIZE_BYTES: String(envs.LAMBDA_PAYLOAD_MAX_SIZE_BYTES) } : {})
             }

--- a/packages/runner-sdk/lib/baseUrlOverrideDenylist.ts
+++ b/packages/runner-sdk/lib/baseUrlOverrideDenylist.ts
@@ -1,7 +1,3 @@
-/**
- * Backward-compatible re-exports for runner-sdk sandbox code.
- * Canonical implementation lives in @nangohq/egress.
- */
 export {
     DEFAULT_NANGO_PROXY_BASE_URL_OVERRIDE_DENYLIST,
     canonicalizeHostnameForDenylist,

--- a/packages/runner-sdk/lib/baseUrlOverrideDenylist.ts
+++ b/packages/runner-sdk/lib/baseUrlOverrideDenylist.ts
@@ -1,5 +1,3 @@
-import { getRunnerPolicyFromEnv } from '@nangohq/egress';
-
 /**
  * Backward-compatible re-exports for runner-sdk sandbox code.
  * Canonical implementation lives in @nangohq/egress.
@@ -13,10 +11,6 @@ export {
     normalizeDenylistHost,
     resolveProxyBaseUrlOverrideDenylistForRunner as resolveProxyBaseUrlOverrideDenylist
 } from '@nangohq/egress';
-
-export function getBaseUrlOverrideDenylistFromEnv(): Set<string> {
-    return getRunnerPolicyFromEnv().denylist;
-}
 
 export function isBaseUrlOverridePolicyEnabledFromEnv(): boolean {
     const raw = typeof process !== 'undefined' ? process.env['NANGO_PROXY_BASE_URL_OVERRIDE_ENABLED'] : undefined;

--- a/packages/runner-sdk/lib/uncontrolledFetch.ts
+++ b/packages/runner-sdk/lib/uncontrolledFetch.ts
@@ -35,11 +35,15 @@ export async function executeUncontrolledFetch(
 
     // Resolve DNS and validate every resolved address against the policy before each hop.
     // This closes DNS-rebinding and redirect-to-internal-address SSRF on the uncontrolledFetch path.
-    // A hostname that fails to resolve is not a SSRF risk (no connection is possible), so we let the
-    // fetch attempt fail naturally instead of masking it as a policy denial.
+    //
+    // Fail closed on every validation error, including DNS resolution failures. The validation lookup
+    // and the subsequent native fetch resolve DNS independently (fetch does not use a DNS-pinning agent
+    // here), so a resolution failure during validation does NOT guarantee the fetch will also fail —
+    // a transient/resolver-specific failure (or an attacker-timed one) could be followed by a fetch
+    // that succeeds to a blocked/private IP. Treating the URL as not allowed avoids that fail-open.
     const assertOutboundUrlAllowed = async (absoluteUrl: string): Promise<void> => {
         const result = await validateOutboundUrlAsync(absoluteUrl, policy, { context: 'uncontrolled_fetch' });
-        if (!result.ok && result.error.code !== 'dns_resolution_failed') {
+        if (!result.ok) {
             throw makeActionError('url_not_allowed', 'This URL is not allowed by server configuration.');
         }
     };

--- a/packages/runner-sdk/lib/uncontrolledFetch.ts
+++ b/packages/runner-sdk/lib/uncontrolledFetch.ts
@@ -1,6 +1,8 @@
-import { getBaseUrlOverrideDenylistFromEnv, isBaseUrlOverrideDenied } from './baseUrlOverrideDenylist.js';
+import { getRunnerPolicyFromEnv, validateOutboundUrlAsync } from '@nangohq/egress';
+
 import { ActionError } from './errors.js';
 
+import type { OutboundUrlPolicy } from '@nangohq/egress';
 import type { HTTP_METHOD } from '@nangohq/types';
 
 const UNCONTROLLED_FETCH_MAX_REDIRECTS = 5;
@@ -20,21 +22,29 @@ export interface UncontrolledFetchOptions {
 
 export async function executeUncontrolledFetch(
     options: UncontrolledFetchOptions,
-    onBytes: (params: { bytesSent: number; bytesReceived: number }) => void
+    onBytes: (params: { bytesSent: number; bytesReceived: number }) => void,
+    // The runner builds a single validated policy from its parsed envs and injects it here. Callers that
+    // lack parsed envs (e.g. the CLI) omit it and fall back to resolving the policy from process.env.
+    outboundPolicy?: OutboundUrlPolicy
 ): Promise<Response> {
     const recordTransfer = (params: { bytesSent: number; bytesReceived: number }) => {
         if (params.bytesSent > 0 || params.bytesReceived > 0) onBytes(params);
     };
 
-    const baseUrlOverrideDenylist = getBaseUrlOverrideDenylistFromEnv();
+    const policy = outboundPolicy ?? getRunnerPolicyFromEnv();
 
-    const throwIfDenied = (absoluteUrl: string): void => {
-        if (baseUrlOverrideDenylist.size > 0 && isBaseUrlOverrideDenied(absoluteUrl, baseUrlOverrideDenylist)) {
+    // Resolve DNS and validate every resolved address against the policy before each hop.
+    // This closes DNS-rebinding and redirect-to-internal-address SSRF on the uncontrolledFetch path.
+    // A hostname that fails to resolve is not a SSRF risk (no connection is possible), so we let the
+    // fetch attempt fail naturally instead of masking it as a policy denial.
+    const assertOutboundUrlAllowed = async (absoluteUrl: string): Promise<void> => {
+        const result = await validateOutboundUrlAsync(absoluteUrl, policy, { context: 'uncontrolled_fetch' });
+        if (!result.ok && result.error.code !== 'dns_resolution_failed') {
             throw makeActionError('url_not_allowed', 'This URL is not allowed by server configuration.');
         }
     };
 
-    throwIfDenied(options.url.toString());
+    await assertOutboundUrlAllowed(options.url.toString());
 
     let currentUrl = new URL(options.url.href);
     let method: HTTP_METHOD = options.method || 'GET';
@@ -106,7 +116,7 @@ export async function executeUncontrolledFetch(
             throw makeActionError('invalid_redirect', 'Redirect Location must use http: or https:.');
         }
 
-        throwIfDenied(nextUrl.toString());
+        await assertOutboundUrlAllowed(nextUrl.toString());
 
         // Native fetch strips sensitive headers when redirecting to a different origin.
         // Because we follow redirects manually, we must replicate that to avoid credential leaks.

--- a/packages/runner-sdk/lib/uncontrolledFetch.ts
+++ b/packages/runner-sdk/lib/uncontrolledFetch.ts
@@ -5,9 +5,7 @@ import { ActionError } from './errors.js';
 import type { OutboundUrlPolicy } from '@nangohq/egress';
 import type { HTTP_METHOD } from '@nangohq/types';
 
-const UNCONTROLLED_FETCH_MAX_REDIRECTS = 5;
 const REDIRECT_STATUS_CODES = new Set([301, 302, 303, 307, 308]);
-const ALLOWED_REDIRECT_PROTOCOLS = new Set(['http:', 'https:']);
 
 const makeActionError = (code: string, message: string) => {
     return new ActionError({ code, message });
@@ -104,8 +102,8 @@ export async function executeUncontrolledFetch(
         // We're about to follow the redirect; we won't return this response, so cancel its body.
         void response.body?.cancel();
 
-        if (redirectsFollowed >= UNCONTROLLED_FETCH_MAX_REDIRECTS) {
-            throw makeActionError('too_many_redirects', `Exceeded maximum of ${UNCONTROLLED_FETCH_MAX_REDIRECTS} redirects.`);
+        if (redirectsFollowed >= policy.maxRedirects) {
+            throw makeActionError('too_many_redirects', `Exceeded maximum of ${policy.maxRedirects} redirects.`);
         }
 
         let nextUrl: URL;
@@ -115,8 +113,8 @@ export async function executeUncontrolledFetch(
             throw makeActionError('invalid_redirect', 'Redirect Location could not be parsed as a URL.');
         }
 
-        // Native fetch rejects redirects to non-HTTP(S) schemes.
-        if (!ALLOWED_REDIRECT_PROTOCOLS.has(nextUrl.protocol)) {
+        // Reject redirects to schemes not permitted by the policy (defaults to http/https).
+        if (!policy.allowedSchemes.has(nextUrl.protocol)) {
             throw makeActionError('invalid_redirect', 'Redirect Location must use http: or https:.');
         }
 

--- a/packages/runner-sdk/lib/uncontrolledFetch.ts
+++ b/packages/runner-sdk/lib/uncontrolledFetch.ts
@@ -1,15 +1,37 @@
-import { getRunnerPolicyFromEnv, validateOutboundUrlAsync } from '@nangohq/egress';
+import { Agent } from 'undici';
+
+import { getRunnerPolicyFromEnv, getSafeLookup, validateOutboundUrlAsync } from '@nangohq/egress';
 
 import { ActionError } from './errors.js';
 
 import type { OutboundUrlPolicy } from '@nangohq/egress';
 import type { HTTP_METHOD } from '@nangohq/types';
+import type { LookupFunction } from 'node:net';
+import type { Dispatcher } from 'undici';
 
 const REDIRECT_STATUS_CODES = new Set([301, 302, 303, 307, 308]);
 
 const makeActionError = (code: string, message: string) => {
     return new ActionError({ code, message });
 };
+
+const safeDispatchers = new WeakMap<OutboundUrlPolicy, Dispatcher>();
+
+/**
+ * undici dispatcher whose connector resolves DNS through the policy's safe lookup, so the address that
+ * passes validation is the exact address undici connects to — on the initial request and on every
+ * redirect hop. This closes the DNS-rebinding TOCTOU window that exists when validation and the actual
+ * connection resolve DNS independently. Memoized per policy so connections pool and the pinned-address
+ * cache is shared.
+ */
+function getSafeDispatcher(policy: OutboundUrlPolicy): Dispatcher {
+    let dispatcher = safeDispatchers.get(policy);
+    if (!dispatcher) {
+        dispatcher = new Agent({ connect: { lookup: getSafeLookup(policy) as unknown as LookupFunction } });
+        safeDispatchers.set(policy, dispatcher);
+    }
+    return dispatcher;
+}
 
 export interface UncontrolledFetchOptions {
     url: URL;
@@ -30,15 +52,11 @@ export async function executeUncontrolledFetch(
     };
 
     const policy = outboundPolicy ?? getRunnerPolicyFromEnv();
+    const dispatcher = getSafeDispatcher(policy);
 
-    // Resolve DNS and validate every resolved address against the policy before each hop.
-    // This closes DNS-rebinding and redirect-to-internal-address SSRF on the uncontrolledFetch path.
-    //
-    // Fail closed on every validation error, including DNS resolution failures. The validation lookup
-    // and the subsequent native fetch resolve DNS independently (fetch does not use a DNS-pinning agent
-    // here), so a resolution failure during validation does NOT guarantee the fetch will also fail —
-    // a transient/resolver-specific failure (or an attacker-timed one) could be followed by a fetch
-    // that succeeds to a blocked/private IP. Treating the URL as not allowed avoids that fail-open.
+    // Defense-in-depth on top of the DNS-pinning dispatcher above: pre-validate every hop so scripts get
+    // a clean error (and the hostname denylist/allowlist + scheme are enforced) before any socket opens.
+    // Fail closed on every validation error, including DNS resolution failures.
     const assertOutboundUrlAllowed = async (absoluteUrl: string): Promise<void> => {
         const result = await validateOutboundUrlAsync(absoluteUrl, policy, { context: 'uncontrolled_fetch' });
         if (!result.ok) {
@@ -54,11 +72,11 @@ export async function executeUncontrolledFetch(
     const headerBag = new Headers(options.headers);
 
     for (let redirectsFollowed = 0; ; redirectsFollowed++) {
-        const props: RequestInit = {
+        const props: RequestInit & { dispatcher?: Dispatcher } = {
             headers: new Headers(headerBag),
             method,
-            redirect: 'manual'
-            // TODO: use agent
+            redirect: 'manual',
+            dispatcher
         };
 
         if (body) {

--- a/packages/runner-sdk/lib/uncontrolledFetch.ts
+++ b/packages/runner-sdk/lib/uncontrolledFetch.ts
@@ -105,6 +105,12 @@ export async function executeUncontrolledFetch(
             return response;
         }
 
+        // maxRedirects === 0 means "don't follow redirects". Match axios/proxy semantics and return the
+        // 3XX response as-is rather than treating it as an error (axios uses the plain transport in this case).
+        if (policy.maxRedirects === 0) {
+            return response;
+        }
+
         // We're about to follow the redirect; we won't return this response, so cancel its body.
         void response.body?.cancel();
 

--- a/packages/runner-sdk/lib/uncontrolledFetch.ts
+++ b/packages/runner-sdk/lib/uncontrolledFetch.ts
@@ -17,13 +17,6 @@ const makeActionError = (code: string, message: string) => {
 
 const safeDispatchers = new WeakMap<OutboundUrlPolicy, Dispatcher>();
 
-/**
- * undici dispatcher whose connector resolves DNS through the policy's safe lookup, so the address that
- * passes validation is the exact address undici connects to — on the initial request and on every
- * redirect hop. This closes the DNS-rebinding TOCTOU window that exists when validation and the actual
- * connection resolve DNS independently. Memoized per policy so connections pool and the pinned-address
- * cache is shared.
- */
 function getSafeDispatcher(policy: OutboundUrlPolicy): Dispatcher {
     let dispatcher = safeDispatchers.get(policy);
     if (!dispatcher) {
@@ -43,8 +36,6 @@ export interface UncontrolledFetchOptions {
 export async function executeUncontrolledFetch(
     options: UncontrolledFetchOptions,
     onBytes: (params: { bytesSent: number; bytesReceived: number }) => void,
-    // The runner builds a single validated policy from its parsed envs and injects it here. Callers that
-    // lack parsed envs (e.g. the CLI) omit it and fall back to resolving the policy from process.env.
     outboundPolicy?: OutboundUrlPolicy
 ): Promise<Response> {
     const recordTransfer = (params: { bytesSent: number; bytesReceived: number }) => {
@@ -54,9 +45,6 @@ export async function executeUncontrolledFetch(
     const policy = outboundPolicy ?? getRunnerPolicyFromEnv();
     const dispatcher = getSafeDispatcher(policy);
 
-    // Defense-in-depth on top of the DNS-pinning dispatcher above: pre-validate every hop so scripts get
-    // a clean error (and the hostname denylist/allowlist + scheme are enforced) before any socket opens.
-    // Fail closed on every validation error, including DNS resolution failures.
     const assertOutboundUrlAllowed = async (absoluteUrl: string): Promise<void> => {
         const result = await validateOutboundUrlAsync(absoluteUrl, policy, { context: 'uncontrolled_fetch' });
         if (!result.ok) {

--- a/packages/runner-sdk/lib/uncontrolledFetch.unit.test.ts
+++ b/packages/runner-sdk/lib/uncontrolledFetch.unit.test.ts
@@ -153,6 +153,45 @@ describe('uncontrolledFetch', () => {
         expect(fetchMock).toHaveBeenCalledTimes(1);
     });
 
+    it('blocks an initial request to a loopback IP literal', async () => {
+        const fetchMock = vi.fn().mockResolvedValue(new Response('ok'));
+        vi.stubGlobal('fetch', fetchMock as any);
+
+        const { action } = await makeActionInstance();
+
+        await expect(action.uncontrolledFetch({ url: new URL('http://127.0.0.1/secret') })).rejects.toMatchObject({
+            type: 'action_script_runtime_error',
+            payload: { code: 'url_not_allowed' }
+        });
+        expect(fetchMock).not.toHaveBeenCalled();
+    });
+
+    it('blocks an initial request to a private RFC1918 IP literal', async () => {
+        const fetchMock = vi.fn().mockResolvedValue(new Response('ok'));
+        vi.stubGlobal('fetch', fetchMock as any);
+
+        const { action } = await makeActionInstance();
+
+        await expect(action.uncontrolledFetch({ url: new URL('http://10.0.0.1/secret') })).rejects.toMatchObject({
+            type: 'action_script_runtime_error',
+            payload: { code: 'url_not_allowed' }
+        });
+        expect(fetchMock).not.toHaveBeenCalled();
+    });
+
+    it('blocks a redirect hop to a cloud metadata IP literal', async () => {
+        const fetchMock = vi.fn().mockResolvedValue(new Response(null, { status: 302, headers: { Location: 'http://169.254.169.254/latest/meta-data/' } }));
+        vi.stubGlobal('fetch', fetchMock as any);
+
+        const { action } = await makeActionInstance();
+
+        await expect(action.uncontrolledFetch({ url: new URL('https://example.com/start') })).rejects.toMatchObject({
+            type: 'action_script_runtime_error',
+            payload: { code: 'url_not_allowed' }
+        });
+        expect(fetchMock).toHaveBeenCalledTimes(1);
+    });
+
     it('strips sensitive headers when redirecting to a different origin', async () => {
         const fetchMock = vi
             .fn()

--- a/packages/runner-sdk/lib/uncontrolledFetch.unit.test.ts
+++ b/packages/runner-sdk/lib/uncontrolledFetch.unit.test.ts
@@ -107,10 +107,12 @@ describe('uncontrolledFetch', () => {
     });
 
     it('honors NANGO_PROXY_BASE_URL_OVERRIDE_ENABLED=false by ignoring custom denylist env', async () => {
-        const customOnlyHost = 'https://custom-deny-only.invalid/path';
+        // Use a resolvable host so the only thing under test is the custom denylist, not DNS resolution
+        // (outbound validation fails closed on resolution failures).
+        const customOnlyHost = 'https://example.com/path';
 
         vi.stubEnv('NANGO_PROXY_BASE_URL_OVERRIDE_ENABLED', 'true');
-        vi.stubEnv('NANGO_PROXY_BASE_URL_OVERRIDE_DENYLIST', JSON.stringify(['custom-deny-only.invalid']));
+        vi.stubEnv('NANGO_PROXY_BASE_URL_OVERRIDE_DENYLIST', JSON.stringify(['example.com']));
         const fetchMockEnabled = vi.fn().mockResolvedValue(new Response('ok'));
         vi.stubGlobal('fetch', fetchMockEnabled as any);
 
@@ -125,7 +127,7 @@ describe('uncontrolledFetch', () => {
         vi.resetModules();
         vi.unstubAllEnvs();
         vi.stubEnv('NANGO_PROXY_BASE_URL_OVERRIDE_ENABLED', 'false');
-        vi.stubEnv('NANGO_PROXY_BASE_URL_OVERRIDE_DENYLIST', JSON.stringify(['custom-deny-only.invalid']));
+        vi.stubEnv('NANGO_PROXY_BASE_URL_OVERRIDE_DENYLIST', JSON.stringify(['example.com']));
         const fetchMockDisabled = vi.fn().mockResolvedValue(new Response('ok'));
         vi.stubGlobal('fetch', fetchMockDisabled as any);
 
@@ -133,6 +135,21 @@ describe('uncontrolledFetch', () => {
 
         await expect(actionDisabled.uncontrolledFetch({ url: new URL(customOnlyHost) })).resolves.toBeDefined();
         expect(fetchMockDisabled).toHaveBeenCalled();
+    });
+
+    it('fails closed when DNS resolution fails during validation', async () => {
+        const fetchMock = vi.fn().mockResolvedValue(new Response('ok'));
+        vi.stubGlobal('fetch', fetchMock as any);
+
+        const { action } = await makeActionInstance();
+
+        // A non-resolvable hostname must be rejected rather than allowed through to fetch, because the
+        // native fetch performs its own DNS resolution and could still reach a blocked/private IP.
+        await expect(action.uncontrolledFetch({ url: new URL('https://does-not-resolve.invalid/secret') })).rejects.toMatchObject({
+            type: 'action_script_runtime_error',
+            payload: { code: 'url_not_allowed' }
+        });
+        expect(fetchMock).not.toHaveBeenCalled();
     });
 
     it('blocks a redirect hop to a denylisted host', async () => {
@@ -195,14 +212,16 @@ describe('uncontrolledFetch', () => {
     it('strips sensitive headers when redirecting to a different origin', async () => {
         const fetchMock = vi
             .fn()
-            .mockResolvedValueOnce(new Response(null, { status: 302, headers: { Location: 'https://b.example/next' } }))
+            .mockResolvedValueOnce(new Response(null, { status: 302, headers: { Location: 'https://example.org/next' } }))
             .mockResolvedValueOnce(new Response('ok', { status: 200 }));
         vi.stubGlobal('fetch', fetchMock as any);
 
         const { action } = await makeActionInstance();
 
+        // Two distinct, resolvable origins: outbound validation fails closed on DNS resolution failures,
+        // so reserved non-resolving placeholder domains can't be used here.
         const res = await action.uncontrolledFetch({
-            url: new URL('https://a.example/start'),
+            url: new URL('https://example.com/start'),
             headers: { Authorization: 'Bearer secret', 'X-Test': '1' }
         });
 

--- a/packages/runner-sdk/lib/uncontrolledFetch.unit.test.ts
+++ b/packages/runner-sdk/lib/uncontrolledFetch.unit.test.ts
@@ -224,6 +224,20 @@ describe('uncontrolledFetch', () => {
         expect(fetchMock).toHaveBeenCalledTimes(2);
     });
 
+    it('returns the 3XX response (does not follow or throw) when maxRedirects is 0', async () => {
+        vi.stubEnv('NANGO_OUTBOUND_URL_POLICY', JSON.stringify({ maxRedirects: 0 }));
+        const fetchMock = vi.fn().mockResolvedValue(new Response(null, { status: 302, headers: { Location: 'https://example.org/next' } }));
+        vi.stubGlobal('fetch', fetchMock as any);
+
+        const { action } = await makeActionInstance();
+
+        // Matches axios/proxy behavior: maxRedirects=0 means "don't follow", so the 3XX is returned as-is.
+        const res = await action.uncontrolledFetch({ url: new URL('https://example.com/start') });
+        expect(res.status).toBe(302);
+        expect(res.headers.get('Location')).toBe('https://example.org/next');
+        expect(fetchMock).toHaveBeenCalledTimes(1);
+    });
+
     it('strips sensitive headers when redirecting to a different origin', async () => {
         const fetchMock = vi
             .fn()

--- a/packages/runner-sdk/lib/uncontrolledFetch.unit.test.ts
+++ b/packages/runner-sdk/lib/uncontrolledFetch.unit.test.ts
@@ -209,6 +209,21 @@ describe('uncontrolledFetch', () => {
         expect(fetchMock).toHaveBeenCalledTimes(1);
     });
 
+    it('honors maxRedirects from the outbound policy', async () => {
+        vi.stubEnv('NANGO_OUTBOUND_URL_POLICY', JSON.stringify({ maxRedirects: 1 }));
+        const fetchMock = vi.fn().mockResolvedValue(new Response(null, { status: 302, headers: { Location: 'https://example.org/next' } }));
+        vi.stubGlobal('fetch', fetchMock as any);
+
+        const { action } = await makeActionInstance();
+
+        await expect(action.uncontrolledFetch({ url: new URL('https://example.com/start') })).rejects.toMatchObject({
+            type: 'action_script_runtime_error',
+            payload: { code: 'too_many_redirects' }
+        });
+        // Initial request + one followed redirect, then capped by the policy's maxRedirects.
+        expect(fetchMock).toHaveBeenCalledTimes(2);
+    });
+
     it('strips sensitive headers when redirecting to a different origin', async () => {
         const fetchMock = vi
             .fn()

--- a/packages/runner-sdk/package.json
+++ b/packages/runner-sdk/package.json
@@ -16,7 +16,8 @@
         "ajv": "8.18.0",
         "ajv-formats": "3.0.1",
         "lodash-es": "4.18.1",
-        "parse-link-header": "2.0.0"
+        "parse-link-header": "2.0.0",
+        "undici": "6.27.0"
     },
     "devDependencies": {
         "@nangohq/types": "0.70.9",

--- a/packages/runner/lib/sdk/sdk.ts
+++ b/packages/runner/lib/sdk/sdk.ts
@@ -1,15 +1,12 @@
 import { Nango } from '@nangohq/node';
 import { executeUncontrolledFetch, NangoActionBase, NangoSyncBase } from '@nangohq/runner-sdk';
-import { enforceProxyOutboundUrlPolicy, getProxyConfiguration, ProxyError, ProxyRequest } from '@nangohq/shared';
+import { enforceProxyOutboundUrlPolicy, getProxyConfiguration, ProxyError, ProxyRequest, resolvePolicyForRunner } from '@nangohq/shared';
 import {
-    DEFAULT_NANGO_PROXY_BASE_URL_OVERRIDE_DENYLIST,
     getCheckpointKey,
     isBaseUrlOverrideDenied,
     isTest,
     MAX_LOG_PAYLOAD,
     metrics,
-    normalizeDenylist,
-    normalizeDenylistHost,
     redactHeaders,
     redactURL,
     stringifyAndTruncateValue,
@@ -56,28 +53,21 @@ const HTTP_LOG_MIN_CALLS = 5;
 const HTTP_LOG_SAMPLE_PCT = envs.RUNNER_HTTP_LOG_SAMPLE_PCT; // set to empty to disable sampling
 
 /**
- * Snapshot proxy override policy at runner module load (before any user script runs).
+ * Snapshot the outbound URL policy at runner module load (before any user script runs).
  * Do not read process.env during request handling — sandboxed scripts share the runner process.
+ *
+ * The policy bundles the override denylist (with secure defaults + Lambda runtime API host) and the
+ * SSRF controls (DNS rebinding, private/link-local IP blocking, redirect cap). The denylist keeps its
+ * runner-specific semantics (secure defaults are enforced even if the server opted out), so it is read
+ * from raw env; the SSRF controls come from the already-parsed + validated NANGO_OUTBOUND_URL_POLICY object.
  */
-function buildRunnerProxyDenylistFromEnvs(): Set<string> {
-    const entries =
-        !envs.NANGO_PROXY_BASE_URL_OVERRIDE_ENABLED || envs.NANGO_PROXY_BASE_URL_OVERRIDE_DENYLIST.length === 0
-            ? [...DEFAULT_NANGO_PROXY_BASE_URL_OVERRIDE_DENYLIST]
-            : envs.NANGO_PROXY_BASE_URL_OVERRIDE_DENYLIST;
-
-    const denylist = normalizeDenylist(entries);
-    const lambdaRuntimeApi = process.env['AWS_LAMBDA_RUNTIME_API'];
-    if (lambdaRuntimeApi) {
-        const normalized = normalizeDenylistHost(lambdaRuntimeApi);
-        if (normalized) {
-            denylist.add(normalized);
-        }
-    }
-
-    return denylist;
-}
-
-const runnerProxyDenylist = buildRunnerProxyDenylistFromEnvs();
+const runnerOutboundPolicy = resolvePolicyForRunner({
+    proxyBaseUrlOverrideEnabled: process.env['NANGO_PROXY_BASE_URL_OVERRIDE_ENABLED'],
+    proxyBaseUrlOverrideDenylistRaw: process.env['NANGO_PROXY_BASE_URL_OVERRIDE_DENYLIST'],
+    outboundUrlPolicy: envs.NANGO_OUTBOUND_URL_POLICY,
+    lambdaRuntimeApi: process.env['AWS_LAMBDA_RUNTIME_API']
+});
+const runnerProxyDenylist = runnerOutboundPolicy.denylist;
 const runnerProxyOverrideEnabled = envs.NANGO_PROXY_BASE_URL_OVERRIDE_ENABLED;
 
 /**
@@ -132,18 +122,22 @@ export class NangoActionRunner extends NangoActionBase<never, ZodCheckpoint> {
 
     public override async uncontrolledFetch(options: UncontrolledFetchOptions): Promise<Response> {
         this.throwIfAbortedOrKilled();
-        return executeUncontrolledFetch(options, ({ bytesSent, bytesReceived }) => {
-            this.telemetryRecorder?.record({
-                type: 'data_transfer',
-                callsite: 'uncontrolled_fetch',
-                connectionId: this.connectionId,
-                integrationId: this.providerConfigKey,
-                syncId: this.syncId,
-                bytesSent,
-                bytesReceived,
-                count: 1
-            });
-        });
+        return executeUncontrolledFetch(
+            options,
+            ({ bytesSent, bytesReceived }) => {
+                this.telemetryRecorder?.record({
+                    type: 'data_transfer',
+                    callsite: 'uncontrolled_fetch',
+                    connectionId: this.connectionId,
+                    integrationId: this.providerConfigKey,
+                    syncId: this.syncId,
+                    bytesSent,
+                    bytesReceived,
+                    count: 1
+                });
+            },
+            runnerOutboundPolicy
+        );
     }
 
     public override async proxy<T = any>(config: ProxyConfiguration): Promise<AxiosResponse<T>> {
@@ -183,6 +177,7 @@ export class NangoActionRunner extends NangoActionBase<never, ZodCheckpoint> {
                     providerName: this.provider!
                 }
             }).unwrap(),
+            outboundPolicy: runnerOutboundPolicy,
             logger: async (log) => {
                 // We only sample successful HTTP logs because they are the most common and the most noisy.
                 if (HTTP_LOG_SAMPLE_PCT && this.scriptType === 'sync' && log.type === 'http' && log.level === 'info') {
@@ -858,9 +853,7 @@ export class NangoSyncRunner extends NangoSyncBase<never, never, ZodCheckpoint> 
         let cursor: string | null | undefined = options?.cursor;
         do {
             this.throwIfAbortedOrKilled();
-            const pageOptions: { cursor?: string } = {
-                ...(cursor ? { cursor } : {})
-            };
+            const pageOptions: { cursor?: string } = cursor ? { cursor } : {};
             const { records, next_cursor } = await this.fetchRecordsPage<T>(model, pageOptions);
 
             for (const record of records) {

--- a/packages/runner/lib/sdk/sdk.ts
+++ b/packages/runner/lib/sdk/sdk.ts
@@ -52,15 +52,6 @@ export const oldLevelToNewLevel = {
 const HTTP_LOG_MIN_CALLS = 5;
 const HTTP_LOG_SAMPLE_PCT = envs.RUNNER_HTTP_LOG_SAMPLE_PCT; // set to empty to disable sampling
 
-/**
- * Snapshot the outbound URL policy at runner module load (before any user script runs).
- * Do not read process.env during request handling — sandboxed scripts share the runner process.
- *
- * The policy bundles the override denylist (with secure defaults + Lambda runtime API host) and the
- * SSRF controls (DNS rebinding, private/link-local IP blocking, redirect cap). The denylist keeps its
- * runner-specific semantics (secure defaults are enforced even if the server opted out), so it is read
- * from raw env; the SSRF controls come from the already-parsed + validated NANGO_OUTBOUND_URL_POLICY object.
- */
 const runnerOutboundPolicy = resolvePolicyForRunner({
     proxyBaseUrlOverrideEnabled: process.env['NANGO_PROXY_BASE_URL_OVERRIDE_ENABLED'],
     proxyBaseUrlOverrideDenylistRaw: process.env['NANGO_PROXY_BASE_URL_OVERRIDE_DENYLIST'],

--- a/packages/server/lib/controllers/auth/postAwsSigV4.ts
+++ b/packages/server/lib/controllers/auth/postAwsSigV4.ts
@@ -12,6 +12,7 @@ import {
     getConnectionConfig,
     getProvider,
     getProxyConfiguration,
+    getServerOutboundUrlPolicy,
     LogActionEnum,
     NangoError,
     ProxyRequest,
@@ -411,6 +412,7 @@ async function verifyAwsCredentials({
 
     const proxy = new ProxyRequest({
         proxyConfig: proxyConfigResult.value,
+        outboundPolicy: getServerOutboundUrlPolicy(),
         logger: (msg) => {
             void logCtx?.log(msg);
         },

--- a/packages/server/lib/controllers/proxy/allProxy.ts
+++ b/packages/server/lib/controllers/proxy/allProxy.ts
@@ -10,12 +10,12 @@ import {
     enforceProxyOutboundUrlPolicy,
     errorManager,
     ErrorSourceEnum,
+    findOutboundUrlError,
     getProvider,
     getProxyConfiguration,
     getServerOutboundUrlPolicy,
     LogActionEnum,
     makeDataTransferEvent,
-    OutboundUrlError,
     ProxyError,
     ProxyRequest,
     pubsub,
@@ -517,23 +517,6 @@ function proxyErrorFromErrorChain(error: unknown): ProxyError | null {
     return null;
 }
 
-function outboundUrlErrorFromErrorChain(error: unknown): OutboundUrlError | null {
-    let current: unknown = error;
-    const seen = new Set<unknown>();
-    while (current && typeof current === 'object' && !seen.has(current)) {
-        seen.add(current);
-        if (current instanceof OutboundUrlError) {
-            return current;
-        }
-        if ('cause' in current && (current as { cause?: unknown }).cause !== undefined) {
-            current = (current as { cause: unknown }).cause;
-        } else {
-            break;
-        }
-    }
-    return null;
-}
-
 export function handleErrorResponse({
     res,
     error,
@@ -557,8 +540,7 @@ export function handleErrorResponse({
         return;
     }
 
-    // DNS-pinning agent rejected the resolved address (rebinding / private / metadata IP), possibly on a redirect hop.
-    const outboundErr = outboundUrlErrorFromErrorChain(error);
+    const outboundErr = findOutboundUrlError(error);
     if (outboundErr) {
         void logCtx.error('Proxy outbound URL denied by policy', { error: outboundErr });
         res.status(400).send({

--- a/packages/server/lib/controllers/proxy/allProxy.ts
+++ b/packages/server/lib/controllers/proxy/allProxy.ts
@@ -12,8 +12,10 @@ import {
     ErrorSourceEnum,
     getProvider,
     getProxyConfiguration,
+    getServerOutboundUrlPolicy,
     LogActionEnum,
     makeDataTransferEvent,
+    OutboundUrlError,
     ProxyError,
     ProxyRequest,
     pubsub,
@@ -286,6 +288,7 @@ export const allPublicProxy = asyncWrapper<AllPublicProxy>(async (req, res, next
                 },
                 internalConfig
             }).unwrap(),
+            outboundPolicy: getServerOutboundUrlPolicy(),
             logger: (msg) => {
                 void logCtx?.log(msg);
             },
@@ -514,6 +517,23 @@ function proxyErrorFromErrorChain(error: unknown): ProxyError | null {
     return null;
 }
 
+function outboundUrlErrorFromErrorChain(error: unknown): OutboundUrlError | null {
+    let current: unknown = error;
+    const seen = new Set<unknown>();
+    while (current && typeof current === 'object' && !seen.has(current)) {
+        seen.add(current);
+        if (current instanceof OutboundUrlError) {
+            return current;
+        }
+        if ('cause' in current && (current as { cause?: unknown }).cause !== undefined) {
+            current = (current as { cause: unknown }).cause;
+        } else {
+            break;
+        }
+    }
+    return null;
+}
+
 export function handleErrorResponse({
     res,
     error,
@@ -532,6 +552,19 @@ export function handleErrorResponse({
             error: {
                 code: 'base_url_override_not_allowed',
                 message: 'This base URL override is not allowed by server configuration.'
+            }
+        });
+        return;
+    }
+
+    // DNS-pinning agent rejected the resolved address (rebinding / private / metadata IP), possibly on a redirect hop.
+    const outboundErr = outboundUrlErrorFromErrorChain(error);
+    if (outboundErr) {
+        void logCtx.error('Proxy outbound URL denied by policy', { error: outboundErr });
+        res.status(400).send({
+            error: {
+                code: 'base_url_override_not_allowed',
+                message: 'This outbound URL is not allowed by server configuration.'
             }
         });
         return;

--- a/packages/server/lib/controllers/v1/environment/webhook/patchWebhook.ts
+++ b/packages/server/lib/controllers/v1/environment/webhook/patchWebhook.ts
@@ -3,15 +3,12 @@ import { URL } from 'url';
 import * as z from 'zod';
 
 import db from '@nangohq/database';
-import { externalWebhookService } from '@nangohq/shared';
-import { isBaseUrlOverrideDenied, normalizeDenylist, requireEmptyQuery, zodErrorToHTTP } from '@nangohq/utils';
+import { externalWebhookService, getServerOutboundUrlPolicy, isOutboundUrlAllowed } from '@nangohq/shared';
+import { requireEmptyQuery, zodErrorToHTTP } from '@nangohq/utils';
 
-import { envs } from '../../../../env.js';
 import { asyncWrapper } from '../../../../utils/asyncWrapper.js';
 
 import type { DBExternalWebhook, PatchWebhook } from '@nangohq/types';
-
-const webhookUrlDenylist = normalizeDenylist(envs.NANGO_PROXY_BASE_URL_OVERRIDE_DENYLIST);
 
 const urlValidation = z
     .union([z.url(), z.literal('')])
@@ -27,7 +24,8 @@ const urlValidation = z
     .refine(
         (url) => {
             if (!url || url.trim() === '') return true;
-            return !isBaseUrlOverrideDenied(url, webhookUrlDenylist);
+            // Reject denylisted hosts and blocked IP literals (loopback, private, link-local, metadata) at registration.
+            return isOutboundUrlAllowed(url, getServerOutboundUrlPolicy());
         },
         { message: 'This webhook URL is not allowed.' }
     );

--- a/packages/server/lib/hooks/connection/credentials-verification-script.ts
+++ b/packages/server/lib/hooks/connection/credentials-verification-script.ts
@@ -1,6 +1,6 @@
 import tracer from 'dd-trace';
 
-import { getProvider, getProxyConfiguration, makeDataTransferEvent, ProxyRequest, pubsub } from '@nangohq/shared';
+import { getProvider, getProxyConfiguration, getServerOutboundUrlPolicy, makeDataTransferEvent, ProxyRequest, pubsub } from '@nangohq/shared';
 
 import * as verificationscriptHandlers from './index.js';
 
@@ -108,6 +108,7 @@ async function execute(
                         // TODO: log something here?
                     },
                     proxyConfig,
+                    outboundPolicy: getServerOutboundUrlPolicy(),
                     getConnection: () => {
                         return connection;
                     },

--- a/packages/server/lib/hooks/hooks.ts
+++ b/packages/server/lib/hooks/hooks.ts
@@ -7,6 +7,7 @@ import {
     errorNotificationService,
     externalWebhookService,
     getProxyConfiguration,
+    getServerOutboundUrlPolicy,
     makeDataTransferEvent,
     NangoError,
     productTracking,
@@ -441,6 +442,7 @@ export async function credentialsTest({
                     void logCtx.log(msg);
                 },
                 proxyConfig,
+                outboundPolicy: getServerOutboundUrlPolicy(),
                 getConnection: () => {
                     return connection;
                 },

--- a/packages/shared/lib/index.ts
+++ b/packages/shared/lib/index.ts
@@ -44,6 +44,7 @@ export * from './services/invitations.js';
 export * from './services/providers.js';
 export * from './services/proxy/utils.js';
 export * from './services/proxy/request.js';
+export * from './services/proxy/outbound-policy.js';
 export { type MeteredBytes, createMeteringTransport } from './services/proxy/byte-metering-transport.js';
 export { makeDataTransferEvent } from './services/proxy/data-transfer-event.js';
 export * from './services/plans/plans.js';

--- a/packages/shared/lib/services/proxy/byte-metering-transport.ts
+++ b/packages/shared/lib/services/proxy/byte-metering-transport.ts
@@ -22,6 +22,7 @@ export interface MeteredBytes {
 
 interface TransportOptions extends RequestOptions {
     protocol?: string | undefined | null;
+    maxRedirects?: number | undefined;
 }
 
 type TransportCallback = (res: IncomingMessage) => void;
@@ -116,12 +117,23 @@ function wireBeforeRedirect(options: TransportOptions, fn: (options: Record<stri
  * Each redirect hop runs through the bytes-metering wrapper independently and
  * invokes `onBytes` once per hop.
  */
-export function createMeteringTransport(
-    onBytes: (bytes: MeteredBytes) => void,
-    // Axios skips wiring options.beforeRedirects.config for custom transports.
-    // Accept it here and wire it manually so header-forwarding still fires on redirects.
-    userBeforeRedirect?: (options: Record<string, unknown>, responseDetails?: unknown) => void
-): {
+export interface MeteringTransportOptions {
+    /** Invoked once per redirect hop with the socket byte deltas for that hop. */
+    onBytes: (bytes: MeteredBytes) => void;
+    /**
+     * Axios skips wiring options.beforeRedirects.config for custom transports. Pass it here and we wire
+     * it manually so header-forwarding (and redirect validation) still fires on redirects.
+     */
+    beforeRedirect?: ((options: Record<string, unknown>, responseDetails?: unknown) => void) | undefined;
+    /**
+     * Axios only copies config.maxRedirects into options.maxRedirects for its built-in follow-redirects
+     * transport; with a custom transport it's skipped, so follow-redirects would fall back to its default
+     * of 21. Pass the cap here and we set it manually to honor the configured policy.
+     */
+    maxRedirects?: number | undefined;
+}
+
+export function createMeteringTransport({ onBytes, beforeRedirect, maxRedirects }: MeteringTransportOptions): {
     request: (options: TransportOptions, callback?: TransportCallback) => ClientRequest;
 } {
     const meteredHttp = withSocketMetering(http, onBytes);
@@ -134,8 +146,11 @@ export function createMeteringTransport(
 
     return {
         request(options, callback) {
-            if (userBeforeRedirect) {
-                wireBeforeRedirect(options, userBeforeRedirect);
+            if (beforeRedirect) {
+                wireBeforeRedirect(options, beforeRedirect);
+            }
+            if (maxRedirects !== undefined) {
+                options.maxRedirects = maxRedirects;
             }
             const target = options.protocol === 'https:' ? wrapped.https : wrapped.http;
             return target.request(options, callback);

--- a/packages/shared/lib/services/proxy/byte-metering-transport.unit.test.ts
+++ b/packages/shared/lib/services/proxy/byte-metering-transport.unit.test.ts
@@ -58,7 +58,7 @@ describe('createMeteringTransport (socket bytes)', () => {
         });
 
         const { onBytes, promise } = onBytesAwaitable();
-        const transport = createMeteringTransport(onBytes);
+        const transport = createMeteringTransport({ onBytes });
         const req = transport.request({ host: '127.0.0.1', port: handle.port, method: 'GET', path: '/' }, (res) => {
             void drainResponse(res);
         });
@@ -80,7 +80,7 @@ describe('createMeteringTransport (socket bytes)', () => {
         });
 
         const { onBytes, promise } = onBytesAwaitable();
-        const transport = createMeteringTransport(onBytes);
+        const transport = createMeteringTransport({ onBytes });
         const req = transport.request(
             {
                 host: '127.0.0.1',
@@ -108,7 +108,7 @@ describe('createMeteringTransport (socket bytes)', () => {
         });
 
         const { onBytes, promise } = onBytesAwaitable();
-        const transport = createMeteringTransport(onBytes);
+        const transport = createMeteringTransport({ onBytes });
         const headers = { 'x-custom-header': 'somevalue', accept: 'application/json' };
         const headerBytes = Buffer.byteLength(
             Object.entries(headers)
@@ -134,7 +134,7 @@ describe('createMeteringTransport (socket bytes)', () => {
         });
 
         const { onBytes, promise } = onBytesAwaitable();
-        const transport = createMeteringTransport(onBytes);
+        const transport = createMeteringTransport({ onBytes });
         const req = transport.request({ host: '127.0.0.1', port: handle.port, method: 'GET', path: '/' }, (res) => {
             void drainResponse(res);
         });
@@ -154,7 +154,7 @@ describe('createMeteringTransport (socket bytes)', () => {
         });
 
         const { onBytes, promise } = onBytesAwaitable();
-        const transport = createMeteringTransport(onBytes);
+        const transport = createMeteringTransport({ onBytes });
         const req = transport.request({ host: '127.0.0.1', port: handle.port, method: 'GET', path: '/' }, (res) => {
             void drainResponse(res);
         });
@@ -181,7 +181,7 @@ describe('createMeteringTransport (socket bytes)', () => {
             hops.push({ ...bytes });
             if (hops.length === 2) onBytes(bytes);
         };
-        const transport = createMeteringTransport(wrapped);
+        const transport = createMeteringTransport({ onBytes: wrapped });
 
         const req = transport.request({ host: '127.0.0.1', port: handle.port, method: 'GET', path: '/' }, (res) => {
             void drainResponse(res);
@@ -190,6 +190,29 @@ describe('createMeteringTransport (socket bytes)', () => {
 
         await promise;
         expect(hops).toHaveLength(2);
+    });
+
+    it('enforces the maxRedirects cap passed to the transport', async () => {
+        // Axios does not copy config.maxRedirects into options.maxRedirects for custom transports, so the
+        // cap must be applied by the transport itself; otherwise follow-redirects defaults to 21.
+        let hits = 0;
+        handle = await startServer((_req, res) => {
+            hits++;
+            res.writeHead(302, { location: '/next' });
+            res.end();
+        });
+
+        const transport = createMeteringTransport({ onBytes: () => {}, maxRedirects: 2 });
+        await expect(
+            axios.request({
+                url: `http://127.0.0.1:${handle.port}/`,
+                method: 'GET',
+                transport: transport as any
+            })
+        ).rejects.toMatchObject({ code: 'ERR_FR_TOO_MANY_REDIRECTS' });
+
+        // Initial request + 2 followed redirects = 3 hits, then capped (well under follow-redirects' default of 21).
+        expect(hits).toBe(3);
     });
 
     it('fires exactly once on connect failure', async () => {
@@ -204,7 +227,7 @@ describe('createMeteringTransport (socket bytes)', () => {
             fires.push(bytes);
             onBytes(bytes);
         };
-        const transport = createMeteringTransport(wrapped);
+        const transport = createMeteringTransport({ onBytes: wrapped });
         const req = transport.request({ host: '127.0.0.1', port, method: 'GET', path: '/' }, () => {});
         req.on('error', () => {});
         req.end();
@@ -220,7 +243,7 @@ describe('createMeteringTransport (socket bytes)', () => {
         const { port } = handle;
 
         const fires: MeteredBytes[] = [];
-        const transport = createMeteringTransport((c) => fires.push({ ...c }));
+        const transport = createMeteringTransport({ onBytes: (c) => fires.push({ ...c }) });
         // Destroy before req.end() so no HTTP headers are flushed — sent and received both remain 0.
         const req = transport.request({ host: '127.0.0.1', port, method: 'GET', path: '/' }, () => {});
         req.destroy();
@@ -243,7 +266,7 @@ describe('createMeteringTransport (socket bytes)', () => {
 
         const agent = new http.Agent({ keepAlive: true });
         const hops: MeteredBytes[] = [];
-        const transport = createMeteringTransport((c) => hops.push({ ...c }));
+        const transport = createMeteringTransport({ onBytes: (c) => hops.push({ ...c }) });
         const { port } = handle;
 
         for (let i = 0; i < 2; i++) {
@@ -289,7 +312,7 @@ describe('createMeteringTransport (socket bytes)', () => {
                 }
             };
 
-            const transport = createMeteringTransport(() => {}, userBeforeRedirect);
+            const transport = createMeteringTransport({ onBytes: () => {}, beforeRedirect: userBeforeRedirect });
             try {
                 const res = await axios.request({
                     url: `http://127.0.0.1:${handle.port}/`,
@@ -317,7 +340,7 @@ describe('createMeteringTransport (socket bytes)', () => {
                 res.end();
             });
 
-            const transport = createMeteringTransport(() => {});
+            const transport = createMeteringTransport({ onBytes: () => {} });
             try {
                 const res = await axios.request({
                     url: `http://127.0.0.1:${handle.port}/`,
@@ -340,7 +363,7 @@ describe('createMeteringTransport (socket bytes)', () => {
         const agent = new http.Agent({ keepAlive: true });
 
         const fires: MeteredBytes[] = [];
-        const transport = createMeteringTransport((c) => fires.push({ ...c }));
+        const transport = createMeteringTransport({ onBytes: (c) => fires.push({ ...c }) });
         const { port } = handle;
 
         // First request — establishes the keep-alive connection and accumulates socket bytes.
@@ -373,7 +396,7 @@ describe('createMeteringTransport (socket bytes)', () => {
         });
 
         const fires: MeteredBytes[] = [];
-        const transport = createMeteringTransport((c) => fires.push({ ...c }));
+        const transport = createMeteringTransport({ onBytes: (c) => fires.push({ ...c }) });
         const req = transport.request({ host: '127.0.0.1', port: handle.port, method: 'POST', path: '/' }, (res) => {
             void drainResponse(res);
         });

--- a/packages/shared/lib/services/proxy/outbound-policy.ts
+++ b/packages/shared/lib/services/proxy/outbound-policy.ts
@@ -6,6 +6,7 @@ import type { OutboundUrlPolicy } from '@nangohq/egress';
 
 export {
     OutboundUrlError,
+    findOutboundUrlError,
     resolvePolicyForServer,
     resolvePolicyForRunner,
     resolvePolicyForRunnerSync,
@@ -19,10 +20,6 @@ export type { OutboundUrlPolicy, OutboundUrlPolicyMode, OutboundUrlPolicyRaw } f
 
 let memoizedServerPolicy: OutboundUrlPolicy | null = null;
 
-/**
- * Server-side outbound URL policy, built once from env (denylist + NANGO_OUTBOUND_URL_POLICY).
- * Used by the proxy controller, credential-verification hooks, and any server-side ProxyRequest.
- */
 export function getServerOutboundUrlPolicy(): OutboundUrlPolicy {
     if (memoizedServerPolicy) {
         return memoizedServerPolicy;

--- a/packages/shared/lib/services/proxy/outbound-policy.ts
+++ b/packages/shared/lib/services/proxy/outbound-policy.ts
@@ -1,0 +1,39 @@
+import { resolvePolicyForServer } from '@nangohq/egress';
+
+import { envs } from '../../env.js';
+
+import type { OutboundUrlPolicy } from '@nangohq/egress';
+
+export {
+    OutboundUrlError,
+    resolvePolicyForServer,
+    resolvePolicyForRunner,
+    resolvePolicyForRunnerSync,
+    getRunnerPolicyFromEnv,
+    resolvePolicyForOAuth,
+    isOutboundUrlAllowed,
+    validateOutboundUrlSync,
+    assertSafeOutboundUrlSync
+} from '@nangohq/egress';
+export type { OutboundUrlPolicy, OutboundUrlPolicyMode, OutboundUrlPolicyRaw } from '@nangohq/egress';
+
+let memoizedServerPolicy: OutboundUrlPolicy | null = null;
+
+/**
+ * Server-side outbound URL policy, built once from env (denylist + NANGO_OUTBOUND_URL_POLICY).
+ * Used by the proxy controller, credential-verification hooks, and any server-side ProxyRequest.
+ */
+export function getServerOutboundUrlPolicy(): OutboundUrlPolicy {
+    if (memoizedServerPolicy) {
+        return memoizedServerPolicy;
+    }
+    memoizedServerPolicy = resolvePolicyForServer({
+        proxyBaseUrlOverrideDenylist: envs.NANGO_PROXY_BASE_URL_OVERRIDE_DENYLIST,
+        outboundUrlPolicy: envs.NANGO_OUTBOUND_URL_POLICY
+    });
+    return memoizedServerPolicy;
+}
+
+export function resetServerOutboundUrlPolicyForTests(): void {
+    memoizedServerPolicy = null;
+}

--- a/packages/shared/lib/services/proxy/request.ts
+++ b/packages/shared/lib/services/proxy/request.ts
@@ -24,10 +24,6 @@ interface Props {
     onBytes?: (bytes: MeteredBytes) => MaybePromise<void>;
     getConnection: () => MaybePromise<ConnectionForProxy>;
     getIntegrationConfig: () => MaybePromise<IntegrationConfigForProxy>;
-    /**
-     * Outbound URL SSRF policy. When set, every connection (including redirect hops) is routed
-     * through DNS-pinning agents that validate the resolved IP, and redirects are capped.
-     */
     outboundPolicy?: OutboundUrlPolicy | undefined;
 }
 

--- a/packages/shared/lib/services/proxy/request.ts
+++ b/packages/shared/lib/services/proxy/request.ts
@@ -123,13 +123,14 @@ export class ProxyRequest {
                     const byteTotals = { sent: 0, received: 0 };
 
                     if (this.onBytes) {
-                        this.axiosConfig.transport = createMeteringTransport(
-                            (bytes) => {
+                        this.axiosConfig.transport = createMeteringTransport({
+                            onBytes: (bytes) => {
                                 byteTotals.sent += bytes.sent;
                                 byteTotals.received += bytes.received;
                             },
-                            this.axiosConfig.beforeRedirect as (opts: Record<string, unknown>) => void
-                        );
+                            beforeRedirect: this.axiosConfig.beforeRedirect as (opts: Record<string, unknown>) => void,
+                            maxRedirects: this.axiosConfig.maxRedirects
+                        });
                     }
 
                     const start = new Date();

--- a/packages/shared/lib/services/proxy/request.ts
+++ b/packages/shared/lib/services/proxy/request.ts
@@ -10,6 +10,7 @@ import { getAxiosConfiguration, ProxyError } from './utils.js';
 
 import type { MeteredBytes } from './byte-metering-transport.js';
 import type { RetryReason } from './utils.js';
+import type { OutboundUrlPolicy } from '@nangohq/egress';
 import type { ApplicationConstructedProxyConfiguration, ConnectionForProxy, IntegrationConfigForProxy, MaybePromise, MessageRowInsert } from '@nangohq/types';
 import type { Result, RetryAttemptArgument } from '@nangohq/utils';
 import type { AxiosRequestConfig, AxiosResponse } from 'axios';
@@ -23,6 +24,11 @@ interface Props {
     onBytes?: (bytes: MeteredBytes) => MaybePromise<void>;
     getConnection: () => MaybePromise<ConnectionForProxy>;
     getIntegrationConfig: () => MaybePromise<IntegrationConfigForProxy>;
+    /**
+     * Outbound URL SSRF policy. When set, every connection (including redirect hops) is routed
+     * through DNS-pinning agents that validate the resolved IP, and redirects are capped.
+     */
+    outboundPolicy?: OutboundUrlPolicy | undefined;
 }
 
 /**
@@ -71,6 +77,11 @@ export class ProxyRequest {
      */
     integrationConfig?: IntegrationConfigForProxy | undefined;
 
+    /**
+     * Outbound URL SSRF policy applied to every request attempt (incl. redirect hops).
+     */
+    outboundPolicy?: Props['outboundPolicy'];
+
     constructor(props: Props) {
         this.config = props.proxyConfig;
         this.logger = props.logger;
@@ -78,6 +89,7 @@ export class ProxyRequest {
         this.onBytes = props.onBytes;
         this.getConnection = props.getConnection;
         this.getIntegrationConfig = props.getIntegrationConfig;
+        this.outboundPolicy = props.outboundPolicy;
     }
 
     /**
@@ -104,7 +116,8 @@ export class ProxyRequest {
                     this.axiosConfig = getAxiosConfiguration({
                         integrationConfig: this.integrationConfig,
                         proxyConfig: this.config,
-                        connection: this.connection
+                        connection: this.connection,
+                        outboundPolicy: this.outboundPolicy
                     });
 
                     const byteTotals = { sent: 0, received: 0 };

--- a/packages/shared/lib/services/proxy/ssrf.unit.test.ts
+++ b/packages/shared/lib/services/proxy/ssrf.unit.test.ts
@@ -1,0 +1,67 @@
+import { describe, expect, it } from 'vitest';
+
+import { DEFAULT_OUTBOUND_URL_POLICY, OutboundUrlError } from '@nangohq/egress';
+
+import { getTestConnection } from '../../seeders/connection.seeder.js';
+import { getAxiosConfiguration } from './utils.js';
+import { getDefaultProxy } from './utils.test.js';
+
+import type { OutboundUrlPolicy } from '@nangohq/egress';
+
+const policy: OutboundUrlPolicy = DEFAULT_OUTBOUND_URL_POLICY;
+const connection = getTestConnection();
+
+function buildConfig({ baseUrl, endpoint = '/', outboundPolicy }: { baseUrl: string; endpoint?: string; outboundPolicy?: OutboundUrlPolicy }) {
+    return getAxiosConfiguration({
+        proxyConfig: getDefaultProxy({ provider: { proxy: { base_url: baseUrl } }, endpoint }),
+        connection,
+        ...(outboundPolicy ? { outboundPolicy } : {})
+    });
+}
+
+describe('proxy outbound policy wiring', () => {
+    it('attaches DNS-pinning agents and caps redirects when a policy is present', () => {
+        const cfg = buildConfig({ baseUrl: 'https://api.example.com', outboundPolicy: policy });
+        expect(cfg.httpAgent).toBeDefined();
+        expect(cfg.httpsAgent).toBeDefined();
+        expect(cfg.maxRedirects).toBe(policy.maxRedirects);
+    });
+
+    it('reuses the same agents across requests for the same policy (connection pooling)', () => {
+        const a = buildConfig({ baseUrl: 'https://api.example.com', outboundPolicy: policy });
+        const b = buildConfig({ baseUrl: 'https://other.example.com', outboundPolicy: policy });
+        expect(a.httpsAgent).toBe(b.httpsAgent);
+        expect(a.httpAgent).toBe(b.httpAgent);
+    });
+
+    it('does not attach agents or cap redirects when no policy is present (back-compat)', () => {
+        const cfg = buildConfig({ baseUrl: 'https://api.example.com' });
+        expect(cfg.httpAgent).toBeUndefined();
+        expect(cfg.httpsAgent).toBeUndefined();
+        expect(cfg.maxRedirects).toBeUndefined();
+    });
+
+    it.each([
+        ['loopback', 'http://127.0.0.1'],
+        ['ipv6 loopback', 'http://[::1]'],
+        ['private RFC1918', 'http://10.0.0.1'],
+        ['link-local cloud metadata', 'http://169.254.169.254']
+    ])('blocks %s IP-literal targets synchronously', (_label, baseUrl) => {
+        expect(() => buildConfig({ baseUrl, outboundPolicy: policy })).toThrow(OutboundUrlError);
+    });
+
+    it('does not block blocked IP literals when no policy is configured (back-compat)', () => {
+        expect(() => buildConfig({ baseUrl: 'http://10.0.0.1' })).not.toThrow();
+    });
+
+    it('blocks redirect hops to blocked IP-literal targets', () => {
+        const cfg = buildConfig({ baseUrl: 'https://api.example.com', outboundPolicy: policy });
+        expect(typeof cfg.beforeRedirect).toBe('function');
+        expect(() => cfg.beforeRedirect!({ href: 'http://169.254.169.254/latest/meta-data/' } as any, {} as any, {} as any)).toThrow(OutboundUrlError);
+    });
+
+    it('allows redirect hops to public hosts (DNS rebinding is caught later by the agent)', () => {
+        const cfg = buildConfig({ baseUrl: 'https://api.example.com', outboundPolicy: policy });
+        expect(() => cfg.beforeRedirect!({ href: 'https://api.example.com/next' } as any, {} as any, {} as any)).not.toThrow();
+    });
+});

--- a/packages/shared/lib/services/proxy/utils.ts
+++ b/packages/shared/lib/services/proxy/utils.ts
@@ -108,8 +108,8 @@ export function getAxiosConfiguration({
             ...(integrationConfig !== undefined ? { integrationConfig } : {})
         });
     }
-    // Synchronous policy check catches blocked IP literals (loopback, private, link-local, metadata), denied
-    // hostnames, schemes, and allowlist misses. Hostname-based DNS rebinding is caught later by the safe agent.
+    // Synchronous policy check catches blocked IP literals (loopback, private, link-local, metadata), denied hostnames,
+    // schemes, and allowlist misses. Hostname-based DNS rebinding is caught later by the safe agent.
     if (outboundPolicy) {
         assertSafeOutboundUrlSync(url, outboundPolicy, { context: 'proxy' });
     }

--- a/packages/shared/lib/services/proxy/utils.ts
+++ b/packages/shared/lib/services/proxy/utils.ts
@@ -108,8 +108,6 @@ export function getAxiosConfiguration({
             ...(integrationConfig !== undefined ? { integrationConfig } : {})
         });
     }
-    // Synchronous policy check catches blocked IP literals (loopback, private, link-local, metadata), denied hostnames,
-    // schemes, and allowlist misses. Hostname-based DNS rebinding is caught later by the safe agent.
     if (outboundPolicy) {
         assertSafeOutboundUrlSync(url, outboundPolicy, { context: 'proxy' });
     }
@@ -182,7 +180,6 @@ export function getAxiosConfiguration({
                     cert,
                     key,
                     rejectUnauthorized: false,
-                    // Pin + validate the resolved address against the outbound policy even for mTLS connections.
                     ...(outboundPolicy ? { lookup: getSafeLookup(outboundPolicy) } : {})
                 });
 
@@ -197,9 +194,6 @@ export function getAxiosConfiguration({
         }
     }
 
-    // Outbound URL policy: cap redirects and route every connection (including each redirect hop)
-    // through DNS-pinning Agents that validate the resolved IP, closing DNS-rebinding and
-    // redirect-to-internal-address SSRF holes. mTLS connections already received the safe lookup above.
     if (outboundPolicy) {
         axiosConfig.maxRedirects = outboundPolicy.maxRedirects;
         if (!axiosConfig.httpAgent && !axiosConfig.httpsAgent) {

--- a/packages/shared/lib/services/proxy/utils.ts
+++ b/packages/shared/lib/services/proxy/utils.ts
@@ -4,6 +4,7 @@ import * as crypto from 'node:crypto';
 import FormData from 'form-data';
 import OAuth from 'oauth-1.0a';
 
+import { assertSafeOutboundUrlSync, getSafeHttpAgents, getSafeLookup } from '@nangohq/egress';
 import { Err, isBaseUrlOverrideDenied, Ok, SIGNATURE_METHOD } from '@nangohq/utils';
 
 import {
@@ -16,6 +17,7 @@ import {
 import { getProvider } from '../providers.js';
 import { signAwsSigV4Request } from './aws-sigv4.js';
 
+import type { OutboundUrlPolicy } from '@nangohq/egress';
 import type {
     ApplicationConstructedProxyConfiguration,
     ConnectionForProxy,
@@ -85,11 +87,13 @@ export function absoluteUrlFromRedirectRequestOptions(options: Record<string, un
 export function getAxiosConfiguration({
     proxyConfig,
     connection,
-    integrationConfig
+    integrationConfig,
+    outboundPolicy
 }: {
     proxyConfig: ApplicationConstructedProxyConfiguration;
     connection: ConnectionForProxy;
     integrationConfig?: IntegrationConfigForProxy | undefined;
+    outboundPolicy?: OutboundUrlPolicy | undefined;
 }): AxiosRequestConfig {
     if (proxyConfig.provider.integration_config) {
         proxyConfig = deriveIntegrationConfigProxy({ proxyConfig, integrationConfig });
@@ -103,6 +107,11 @@ export function getAxiosConfiguration({
             connection,
             ...(integrationConfig !== undefined ? { integrationConfig } : {})
         });
+    }
+    // Synchronous policy check catches blocked IP literals (loopback, private, link-local, metadata), denied
+    // hostnames, schemes, and allowlist misses. Hostname-based DNS rebinding is caught later by the safe agent.
+    if (outboundPolicy) {
+        assertSafeOutboundUrlSync(url, outboundPolicy, { context: 'proxy' });
     }
     // Merge proxy.body into proxyConfig.data before building headers so that any
     // body-signing headers (e.g. HMAC, AWS SigV4) are computed against the final body.
@@ -122,11 +131,13 @@ export function getAxiosConfiguration({
     const shouldForward = proxyConfig.forwardHeadersOnRedirect ?? proxyConfig.provider.proxy?.forward_headers_on_redirect ?? false;
 
     axiosConfig.beforeRedirect = (options: Record<string, any>, _responseDetails, _requestDetails) => {
-        if (proxyConfig.validateProxyRedirectUrl) {
-            const absolute = absoluteUrlFromRedirectRequestOptions(options);
-            if (absolute) {
-                proxyConfig.validateProxyRedirectUrl(absolute);
-            }
+        const absolute = absoluteUrlFromRedirectRequestOptions(options);
+        if (proxyConfig.validateProxyRedirectUrl && absolute) {
+            proxyConfig.validateProxyRedirectUrl(absolute);
+        }
+        // Block redirect hops to blocked IP literals / denied hosts; hostname rebinding is caught by the safe agent.
+        if (outboundPolicy && absolute) {
+            assertSafeOutboundUrlSync(absolute, outboundPolicy, { context: 'redirect' });
         }
         if (shouldForward) {
             Object.keys(headers).forEach((key) => {
@@ -170,7 +181,9 @@ export function getAxiosConfiguration({
                 const agent = new https.Agent({
                     cert,
                     key,
-                    rejectUnauthorized: false
+                    rejectUnauthorized: false,
+                    // Pin + validate the resolved address against the outbound policy even for mTLS connections.
+                    ...(outboundPolicy ? { lookup: getSafeLookup(outboundPolicy) } : {})
                 });
 
                 axiosConfig.httpAgent = agent;
@@ -181,6 +194,18 @@ export function getAxiosConfiguration({
                     `Certificate and private key must be in PEM format with proper BEGIN/END boundaries: ${err}`
                 );
             }
+        }
+    }
+
+    // Outbound URL policy: cap redirects and route every connection (including each redirect hop)
+    // through DNS-pinning Agents that validate the resolved IP, closing DNS-rebinding and
+    // redirect-to-internal-address SSRF holes. mTLS connections already received the safe lookup above.
+    if (outboundPolicy) {
+        axiosConfig.maxRedirects = outboundPolicy.maxRedirects;
+        if (!axiosConfig.httpAgent && !axiosConfig.httpsAgent) {
+            const agents = getSafeHttpAgents(outboundPolicy);
+            axiosConfig.httpAgent = agents.httpAgent;
+            axiosConfig.httpsAgent = agents.httpsAgent;
         }
     }
 
@@ -314,8 +339,8 @@ export function deriveIntegrationConfigProxy({
     const proxy = {
         ...baseProxy,
         base_url: baseUrl || baseProxy.base_url,
-        headers: { ...(baseProxy.headers ?? {}) },
-        query: { ...(baseProxy.query ?? {}) }
+        headers: { ...baseProxy.headers },
+        query: { ...baseProxy.query }
     };
 
     if (placement === 'query') {

--- a/packages/shared/package.json
+++ b/packages/shared/package.json
@@ -25,6 +25,7 @@
         "@hapi/boom": "10.0.1",
         "@modelcontextprotocol/sdk": "1.26.0",
         "@nangohq/database": "file:../database",
+        "@nangohq/egress": "file:../egress",
         "@nangohq/feature-flags": "file:../feature-flags",
         "@nangohq/kms": "file:../kms",
         "@nangohq/kvstore": "file:../kvstore",

--- a/packages/shared/tsconfig.json
+++ b/packages/shared/tsconfig.json
@@ -9,6 +9,9 @@
             "path": "../database"
         },
         {
+            "path": "../egress"
+        },
+        {
             "path": "../feature-flags"
         },
         {

--- a/packages/utils/lib/environment/parse.ts
+++ b/packages/utils/lib/environment/parse.ts
@@ -61,6 +61,37 @@ export const ENVS = z.object({
                 return z.NEVER;
             }
         }),
+    // Outbound URL policy (JSON), consumed by @nangohq/egress (resolvePolicyForServer / resolvePolicyForRunner).
+    // Controls SSRF hardening for proxy + webhooks + uncontrolledFetch. Parsed and validated here so misconfiguration
+    // fails fast at startup; runners receive it re-serialized and parse it from process.env.
+    NANGO_OUTBOUND_URL_POLICY: z
+        .string()
+        .optional()
+        .transform((s, ctx) => {
+            if (s === undefined || s.trim() === '') {
+                return undefined;
+            }
+            try {
+                return JSON.parse(s) as unknown;
+            } catch {
+                ctx.addIssue(`Invalid JSON in NANGO_OUTBOUND_URL_POLICY`);
+                return z.NEVER; // tells Zod to stop here and mark parse as failed
+            }
+        })
+        .pipe(
+            z
+                .object({
+                    mode: z.enum(['denylist', 'allowlist', 'permissive']).optional(),
+                    denylist: z.array(z.string()).optional(),
+                    allowlist: z.array(z.string()).optional(),
+                    blockPrivateIps: z.boolean().optional(),
+                    blockLinkLocal: z.boolean().optional(),
+                    resolveDns: z.boolean().optional(),
+                    allowedSchemes: z.array(z.string()).optional(),
+                    maxRedirects: z.number().int().nonnegative().optional()
+                })
+                .optional()
+        ),
 
     // Connect
     NANGO_PUBLIC_CONNECT_URL: z.url().optional(),

--- a/packages/utils/lib/environment/parse.ts
+++ b/packages/utils/lib/environment/parse.ts
@@ -86,8 +86,6 @@ export const ENVS = z.object({
                     allowlist: z.array(z.string()).optional(),
                     blockPrivateIps: z.boolean().optional(),
                     blockLinkLocal: z.boolean().optional(),
-                    resolveDns: z.boolean().optional(),
-                    allowedSchemes: z.array(z.string()).optional(),
                     maxRedirects: z.number().int().nonnegative().optional()
                 })
                 // Reject unknown keys so a typo (e.g. `blockPrivateIp`) fails fast at startup instead of

--- a/packages/utils/lib/environment/parse.ts
+++ b/packages/utils/lib/environment/parse.ts
@@ -61,9 +61,7 @@ export const ENVS = z.object({
                 return z.NEVER;
             }
         }),
-    // Outbound URL policy (JSON), consumed by @nangohq/egress (resolvePolicyForServer / resolvePolicyForRunner).
-    // Controls SSRF hardening for proxy + webhooks + uncontrolledFetch. Parsed and validated here so misconfiguration
-    // fails fast at startup; runners receive it re-serialized and parse it from process.env.
+    // Outbound URL policy (JSON), consumed by @nangohq/egress.
     NANGO_OUTBOUND_URL_POLICY: z
         .string()
         .optional()

--- a/packages/utils/lib/environment/parse.ts
+++ b/packages/utils/lib/environment/parse.ts
@@ -90,6 +90,9 @@ export const ENVS = z.object({
                     allowedSchemes: z.array(z.string()).optional(),
                     maxRedirects: z.number().int().nonnegative().optional()
                 })
+                // Reject unknown keys so a typo (e.g. `blockPrivateIp`) fails fast at startup instead of
+                // being silently dropped and weakening the intended SSRF restrictions.
+                .strict()
                 .optional()
         ),
 

--- a/packages/utils/lib/environment/parse.unit.test.ts
+++ b/packages/utils/lib/environment/parse.unit.test.ts
@@ -183,6 +183,13 @@ describe('parse', () => {
         }).toThrow();
     });
 
+    it('should throw on unknown keys in NANGO_OUTBOUND_URL_POLICY (typos fail fast)', () => {
+        expect(() => {
+            // `blockPrivateIp` (missing trailing s) must not be silently dropped.
+            parseEnvs(ENVS, { NANGO_OUTBOUND_URL_POLICY: JSON.stringify({ blockPrivateIp: false }) });
+        }).toThrow();
+    });
+
     it('should default NANGO_LOGS_PROVIDER to elasticsearch', () => {
         const res = parseEnvs(ENVS, {});
         expect(res.NANGO_LOGS_PROVIDER).toBe('elasticsearch');

--- a/packages/utils/lib/environment/parse.unit.test.ts
+++ b/packages/utils/lib/environment/parse.unit.test.ts
@@ -159,6 +159,30 @@ describe('parse', () => {
         });
     });
 
+    it('should default NANGO_OUTBOUND_URL_POLICY to undefined when unset', () => {
+        const res = parseEnvs(ENVS, {});
+        expect(res.NANGO_OUTBOUND_URL_POLICY).toBeUndefined();
+    });
+
+    it('should parse a valid NANGO_OUTBOUND_URL_POLICY', () => {
+        const res = parseEnvs(ENVS, {
+            NANGO_OUTBOUND_URL_POLICY: JSON.stringify({ mode: 'allowlist', allowlist: ['.hubspot.com'], blockPrivateIps: true, maxRedirects: 3 })
+        });
+        expect(res.NANGO_OUTBOUND_URL_POLICY).toEqual({ mode: 'allowlist', allowlist: ['.hubspot.com'], blockPrivateIps: true, maxRedirects: 3 });
+    });
+
+    it('should throw on invalid JSON in NANGO_OUTBOUND_URL_POLICY', () => {
+        expect(() => {
+            parseEnvs(ENVS, { NANGO_OUTBOUND_URL_POLICY: 'not-json' });
+        }).toThrow('Invalid JSON in NANGO_OUTBOUND_URL_POLICY');
+    });
+
+    it('should throw on an invalid NANGO_OUTBOUND_URL_POLICY shape', () => {
+        expect(() => {
+            parseEnvs(ENVS, { NANGO_OUTBOUND_URL_POLICY: JSON.stringify({ mode: 'bogus' }) });
+        }).toThrow();
+    });
+
     it('should default NANGO_LOGS_PROVIDER to elasticsearch', () => {
         const res = parseEnvs(ENVS, {});
         expect(res.NANGO_LOGS_PROVIDER).toBe('elasticsearch');

--- a/packages/webhooks/lib/asyncAction.unit.test.ts
+++ b/packages/webhooks/lib/asyncAction.unit.test.ts
@@ -1,23 +1,30 @@
-import { afterAll, beforeAll, beforeEach, describe, expect, it, vi } from 'vitest';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
 
 import { logContextGetter } from '@nangohq/logs';
-import { axiosInstance, stringifyStable } from '@nangohq/utils';
+import { Ok } from '@nangohq/utils';
 
 import { sendAsyncActionWebhook } from './asyncAction.js';
-import { mockWebhookDenylistAllowAll } from './helpers/setup.unit.js';
-import { TestWebhookServer } from './helpers/test.js';
+import { deliver } from './utils.js';
 
 import type { DBAPISecret, DBEnvironment, DBExternalWebhook } from '@nangohq/types';
 
-const spy = vi.spyOn(axiosInstance, 'post');
+// The sender decides whether/what to deliver; the on-the-wire behavior is `deliver`'s responsibility
+// (covered in utils.unit.test.ts). Mock `deliver` and assert on the sender's orchestration.
+vi.mock('./utils.js', async (importOriginal) => {
+    const actual = await importOriginal<Record<string, unknown>>();
+    return { ...actual, deliver: vi.fn() };
+});
 
-const testServer = new TestWebhookServer(4100);
+const deliverMock = vi.mocked(deliver);
+
+const primaryUrl = 'https://example.com/webhook';
+const secondaryUrl = 'https://example.com/webhook-secondary';
 
 const webhookSettings: DBExternalWebhook = {
     id: 1,
     environment_id: 1,
-    primary_url: testServer.primaryUrl,
-    secondary_url: testServer.secondaryUrl,
+    primary_url: primaryUrl,
+    secondary_url: secondaryUrl,
     on_sync_completion_always: true,
     on_auth_creation: true,
     on_auth_refresh_error: true,
@@ -33,18 +40,10 @@ const environment = {
 
 const secret = 'secret' as DBAPISecret['secret'];
 
-describe('AsyncAction webhookds', () => {
-    beforeAll(async () => {
-        await testServer.start();
-    });
-
-    afterAll(async () => {
-        await testServer.stop();
-    });
-
+describe('AsyncAction webhooks', () => {
     beforeEach(() => {
-        vi.resetAllMocks();
-        mockWebhookDenylistAllowAll();
+        deliverMock.mockReset();
+        deliverMock.mockResolvedValue(Ok(undefined));
     });
 
     it('should not be sent if on_async_action_completion is false', async () => {
@@ -63,10 +62,10 @@ describe('AsyncAction webhookds', () => {
             payload: { id: '00000000-0000-0000-0000-000000000000', statusUrl: '/action/00000000-0000-0000-0000-000000000000' },
             logCtx
         });
-        expect(spy).toHaveBeenCalledTimes(0);
+        expect(deliverMock).not.toHaveBeenCalled();
     });
 
-    it('should be sent if on_async_action_completion is true', async () => {
+    it('should deliver to both urls with the correct body if on_async_action_completion is true', async () => {
         const logCtx = await logContextGetter.create(
             { operation: { type: 'sync', action: 'run' } },
             { account: { id: environment.account_id, name: '' }, environment: { id: environment.id, name: environment.name } }
@@ -85,42 +84,19 @@ describe('AsyncAction webhookds', () => {
 
         await sendAsyncActionWebhook(props);
 
-        expect(spy).toHaveBeenCalledTimes(2);
-        const body = {
+        expect(deliverMock).toHaveBeenCalledTimes(1);
+        const args = deliverMock.mock.calls[0]![0];
+        expect(args.webhookType).toBe('async_action');
+        expect(args.webhooks).toEqual([
+            { url: primaryUrl, type: 'webhook url' },
+            { url: secondaryUrl, type: 'secondary webhook url' }
+        ]);
+        expect(args.body).toEqual({
             type: 'async_action',
             from: 'nango',
             connectionId: props.connectionId,
             payload: props.payload,
             providerConfigKey: props.providerConfigKey
-        };
-        const bodyString = stringifyStable(body).unwrap();
-        expect(spy).toHaveBeenNthCalledWith(
-            1,
-            webhookSettings.primary_url,
-            bodyString,
-            expect.objectContaining({
-                headers: {
-                    'X-Nango-Signature': expect.toBeSha256(),
-                    'X-Nango-Hmac-Sha256': expect.toBeSha256(),
-                    'content-type': 'application/json',
-                    'user-agent': expect.stringContaining('nango/')
-                },
-                timeout: expect.any(Number)
-            })
-        );
-        expect(spy).toHaveBeenNthCalledWith(
-            2,
-            webhookSettings.secondary_url,
-            bodyString,
-            expect.objectContaining({
-                headers: {
-                    'X-Nango-Signature': expect.toBeSha256(),
-                    'X-Nango-Hmac-Sha256': expect.toBeSha256(),
-                    'content-type': 'application/json',
-                    'user-agent': expect.stringContaining('nango/')
-                },
-                timeout: expect.any(Number)
-            })
-        );
+        });
     });
 });

--- a/packages/webhooks/lib/asyncAction.unit.test.ts
+++ b/packages/webhooks/lib/asyncAction.unit.test.ts
@@ -8,8 +8,6 @@ import { deliver } from './utils.js';
 
 import type { DBAPISecret, DBEnvironment, DBExternalWebhook } from '@nangohq/types';
 
-// The sender decides whether/what to deliver; the on-the-wire behavior is `deliver`'s responsibility
-// (covered in utils.unit.test.ts). Mock `deliver` and assert on the sender's orchestration.
 vi.mock('./utils.js', async (importOriginal) => {
     const actual = await importOriginal<Record<string, unknown>>();
     return { ...actual, deliver: vi.fn() };

--- a/packages/webhooks/lib/auth.unit.test.ts
+++ b/packages/webhooks/lib/auth.unit.test.ts
@@ -7,8 +7,6 @@ import { deliver } from './utils.js';
 
 import type { DBAPISecret, DBConnection, DBEnvironment, DBExternalWebhook, DBTeam, IntegrationConfig, Tags } from '@nangohq/types';
 
-// The sender decides whether/what to deliver; the on-the-wire behavior is `deliver`'s responsibility
-// (covered in utils.unit.test.ts). Mock `deliver` and assert on the sender's orchestration.
 vi.mock('./utils.js', async (importOriginal) => {
     const actual = await importOriginal<Record<string, unknown>>();
     return { ...actual, deliver: vi.fn() };

--- a/packages/webhooks/lib/auth.unit.test.ts
+++ b/packages/webhooks/lib/auth.unit.test.ts
@@ -1,16 +1,23 @@
-import { afterAll, beforeAll, beforeEach, describe, expect, it, vi } from 'vitest';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
 
-import { axiosInstance, stringifyStable } from '@nangohq/utils';
+import { Ok } from '@nangohq/utils';
 
 import { sendAuth } from './auth.js';
-import { mockWebhookDenylistAllowAll } from './helpers/setup.unit.js';
-import { TestWebhookServer } from './helpers/test.js';
+import { deliver } from './utils.js';
 
-import type { DBAPISecret, DBConnection, DBEnvironment, DBExternalWebhook, DBTeam, IntegrationConfig, NangoAuthWebhookBodySuccess, Tags } from '@nangohq/types';
+import type { DBAPISecret, DBConnection, DBEnvironment, DBExternalWebhook, DBTeam, IntegrationConfig, Tags } from '@nangohq/types';
 
-const spy = vi.spyOn(axiosInstance, 'post');
+// The sender decides whether/what to deliver; the on-the-wire behavior is `deliver`'s responsibility
+// (covered in utils.unit.test.ts). Mock `deliver` and assert on the sender's orchestration.
+vi.mock('./utils.js', async (importOriginal) => {
+    const actual = await importOriginal<Record<string, unknown>>();
+    return { ...actual, deliver: vi.fn() };
+});
 
-const testServer = new TestWebhookServer(4101);
+const deliverMock = vi.mocked(deliver);
+
+const primaryUrl = 'https://example.com/webhook';
+const secondaryUrl = 'https://example.com/webhook-secondary';
 
 const account: DBTeam = {
     id: 1,
@@ -30,8 +37,8 @@ const connection: Pick<DBConnection, 'id' | 'connection_id' | 'provider_config_k
 const webhookSettings: DBExternalWebhook = {
     id: 1,
     environment_id: 1,
-    primary_url: testServer.primaryUrl,
-    secondary_url: testServer.secondaryUrl,
+    primary_url: primaryUrl,
+    secondary_url: secondaryUrl,
     on_sync_completion_always: true,
     on_auth_creation: true,
     on_auth_refresh_error: true,
@@ -50,17 +57,9 @@ const providerConfig = {
 const secret = 'secret' as DBAPISecret['secret'];
 
 describe('Webhooks: auth notification tests', () => {
-    beforeAll(async () => {
-        await testServer.start();
-    });
-
-    afterAll(async () => {
-        await testServer.stop();
-    });
-
     beforeEach(() => {
-        vi.resetAllMocks();
-        mockWebhookDenylistAllowAll();
+        deliverMock.mockReset();
+        deliverMock.mockResolvedValue(Ok(undefined));
     });
 
     it('Should not send an auth webhook if the webhook url is not present even if the auth webhook is checked', async () => {
@@ -83,10 +82,10 @@ describe('Webhooks: auth notification tests', () => {
             auth_mode: 'OAUTH2',
             operation: 'creation'
         });
-        expect(spy).not.toHaveBeenCalled();
+        expect(deliverMock).not.toHaveBeenCalled();
     });
 
-    it('Should send an auth webhook if the primary webhook url is present but the secondary is not', async () => {
+    it('Should deliver to the primary webhook url when only the primary is present', async () => {
         await sendAuth({
             connection,
             success: true,
@@ -105,10 +104,11 @@ describe('Webhooks: auth notification tests', () => {
             auth_mode: 'OAUTH2',
             operation: 'creation'
         });
-        expect(spy).toHaveBeenCalledTimes(1);
+        expect(deliverMock).toHaveBeenCalledTimes(1);
+        expect(deliverMock.mock.calls[0]![0].webhooks).toEqual([{ url: primaryUrl, type: 'webhook url' }]);
     });
 
-    it('Should send an auth webhook if the webhook url is not present but the secondary is', async () => {
+    it('Should deliver to the secondary webhook url when only the secondary is present', async () => {
         await sendAuth({
             connection,
             success: true,
@@ -128,10 +128,11 @@ describe('Webhooks: auth notification tests', () => {
             auth_mode: 'OAUTH2',
             operation: 'creation'
         });
-        expect(spy).toHaveBeenCalledTimes(1);
+        expect(deliverMock).toHaveBeenCalledTimes(1);
+        expect(deliverMock.mock.calls[0]![0].webhooks).toEqual([{ url: secondaryUrl, type: 'secondary webhook url' }]);
     });
 
-    it('Should send an auth webhook twice if the webhook url is present and the secondary is as well', async () => {
+    it('Should deliver to both webhook urls in a single deliver call when both are present', async () => {
         await sendAuth({
             connection,
             success: true,
@@ -149,7 +150,11 @@ describe('Webhooks: auth notification tests', () => {
             auth_mode: 'OAUTH2',
             operation: 'creation'
         });
-        expect(spy).toHaveBeenCalledTimes(2);
+        expect(deliverMock).toHaveBeenCalledTimes(1);
+        expect(deliverMock.mock.calls[0]![0].webhooks).toEqual([
+            { url: primaryUrl, type: 'webhook url' },
+            { url: secondaryUrl, type: 'secondary webhook url' }
+        ]);
     });
 
     it('Should send an auth webhook if the webhook url is present and if the auth webhook is checked and the operation failed', async () => {
@@ -175,7 +180,12 @@ describe('Webhooks: auth notification tests', () => {
             auth_mode: 'OAUTH2',
             operation: 'creation'
         });
-        expect(spy).toHaveBeenCalledTimes(1);
+        expect(deliverMock).toHaveBeenCalledTimes(1);
+        expect(deliverMock.mock.calls[0]![0].body).toMatchObject({
+            type: 'auth',
+            success: false,
+            error: { type: 'error', description: 'error description' }
+        });
     });
 
     it('Should not send an auth webhook if the webhook url is present and if the auth webhook is not checked', async () => {
@@ -196,7 +206,7 @@ describe('Webhooks: auth notification tests', () => {
             auth_mode: 'OAUTH2',
             operation: 'creation'
         });
-        expect(spy).not.toHaveBeenCalled();
+        expect(deliverMock).not.toHaveBeenCalled();
     });
 
     it('Should not send an auth webhook if on refresh error is checked but there is no webhook url', async () => {
@@ -220,7 +230,8 @@ describe('Webhooks: auth notification tests', () => {
             auth_mode: 'OAUTH2',
             operation: 'refresh'
         });
-        expect(spy).not.toHaveBeenCalled();
+        // No webhook urls => shouldSend short-circuits and deliver is never invoked.
+        expect(deliverMock).not.toHaveBeenCalled();
     });
 
     it('Should send an auth webhook if on refresh error is checked', async () => {
@@ -243,7 +254,8 @@ describe('Webhooks: auth notification tests', () => {
             auth_mode: 'OAUTH2',
             operation: 'refresh'
         });
-        expect(spy).toHaveBeenCalledTimes(1);
+        expect(deliverMock).toHaveBeenCalledTimes(1);
+        expect(deliverMock.mock.calls[0]![0].webhooks).toEqual([{ url: primaryUrl, type: 'webhook url' }]);
     });
 
     it('Should not send an auth webhook if on refresh error is not checked', async () => {
@@ -266,10 +278,10 @@ describe('Webhooks: auth notification tests', () => {
             operation: 'refresh'
         });
 
-        expect(spy).not.toHaveBeenCalled();
+        expect(deliverMock).not.toHaveBeenCalled();
     });
 
-    it('Should send an auth webhook twice if on refresh error is checked and there are two webhook urls with the correct body', async () => {
+    it('Should deliver to both urls with the correct body on refresh error', async () => {
         await sendAuth({
             connection,
             success: true,
@@ -289,9 +301,14 @@ describe('Webhooks: auth notification tests', () => {
             operation: 'refresh'
         });
 
-        expect(spy).toHaveBeenCalledTimes(2);
-
-        const body: NangoAuthWebhookBodySuccess = {
+        expect(deliverMock).toHaveBeenCalledTimes(1);
+        const args = deliverMock.mock.calls[0]![0];
+        expect(args.webhookType).toBe('auth');
+        expect(args.webhooks).toEqual([
+            { url: primaryUrl, type: 'webhook url' },
+            { url: secondaryUrl, type: 'secondary webhook url' }
+        ]);
+        expect(args.body).toMatchObject({
             from: 'nango',
             type: 'auth',
             connectionId: connection.connection_id,
@@ -301,36 +318,7 @@ describe('Webhooks: auth notification tests', () => {
             environment: 'dev',
             success: true,
             operation: 'refresh'
-        };
-        const bodyString = stringifyStable(body).unwrap();
-
-        expect(spy).toHaveBeenNthCalledWith(
-            1,
-            webhookSettings.primary_url,
-            bodyString,
-            expect.objectContaining({
-                headers: {
-                    'X-Nango-Signature': expect.toBeSha256(),
-                    'X-Nango-Hmac-Sha256': expect.toBeSha256(),
-                    'content-type': 'application/json',
-                    'user-agent': expect.stringContaining('nango/')
-                }
-            })
-        );
-
-        expect(spy).toHaveBeenNthCalledWith(
-            2,
-            webhookSettings.secondary_url,
-            bodyString,
-            expect.objectContaining({
-                headers: {
-                    'X-Nango-Signature': expect.toBeSha256(),
-                    'X-Nango-Hmac-Sha256': expect.toBeSha256(),
-                    'content-type': 'application/json',
-                    'user-agent': expect.stringContaining('nango/')
-                }
-            })
-        );
+        });
     });
 
     describe('tags', () => {
@@ -360,31 +348,10 @@ describe('Webhooks: auth notification tests', () => {
                 operation: 'creation'
             });
 
-            expect(spy).toHaveBeenCalledTimes(1);
-
-            const body: NangoAuthWebhookBodySuccess = {
-                from: 'nango',
-                type: 'auth',
-                connectionId: connection.connection_id,
-                providerConfigKey: connection.provider_config_key,
-                authMode: 'OAUTH2',
-                provider: 'hubspot',
-                environment: 'dev',
-                success: true,
-                operation: 'creation',
+            expect(deliverMock).toHaveBeenCalledTimes(1);
+            expect(deliverMock.mock.calls[0]![0].body).toMatchObject({
                 tags: { department: 'engineering', priority: 'high' }
-            };
-            const bodyString = stringifyStable(body).unwrap();
-
-            expect(spy).toHaveBeenCalledWith(
-                webhookSettings.primary_url,
-                bodyString,
-                expect.objectContaining({
-                    headers: expect.objectContaining({
-                        'content-type': 'application/json'
-                    })
-                })
-            );
+            });
         });
 
         it('Should not include tags when connection has no tags', async () => {
@@ -407,30 +374,8 @@ describe('Webhooks: auth notification tests', () => {
                 operation: 'creation'
             });
 
-            expect(spy).toHaveBeenCalledTimes(1);
-
-            const body: NangoAuthWebhookBodySuccess = {
-                from: 'nango',
-                type: 'auth',
-                connectionId: connection.connection_id,
-                providerConfigKey: connection.provider_config_key,
-                authMode: 'OAUTH2',
-                provider: 'hubspot',
-                environment: 'dev',
-                success: true,
-                operation: 'creation'
-            };
-            const bodyString = stringifyStable(body).unwrap();
-
-            expect(spy).toHaveBeenCalledWith(
-                webhookSettings.primary_url,
-                bodyString,
-                expect.objectContaining({
-                    headers: expect.objectContaining({
-                        'content-type': 'application/json'
-                    })
-                })
-            );
+            expect(deliverMock).toHaveBeenCalledTimes(1);
+            expect((deliverMock.mock.calls[0]![0].body as Record<string, unknown>)['tags']).toBeUndefined();
         });
     });
 });

--- a/packages/webhooks/lib/forward.unit.test.ts
+++ b/packages/webhooks/lib/forward.unit.test.ts
@@ -8,9 +8,6 @@ import { deliver } from './utils.js';
 
 import type { DBAPISecret, DBEnvironment, DBExternalWebhook, DBTeam, IntegrationConfig } from '@nangohq/types';
 
-// The senders' job is to decide whether/what to deliver and call `deliver`. The on-the-wire behavior
-// (SSRF policy, agents, axios, signatures, byte metering) is `deliver`'s responsibility and is covered
-// in utils.unit.test.ts. So here we mock `deliver` and assert on how the sender orchestrates it.
 vi.mock('./utils.js', async (importOriginal) => {
     const actual = await importOriginal<Record<string, unknown>>();
     return { ...actual, deliver: vi.fn() };

--- a/packages/webhooks/lib/forward.unit.test.ts
+++ b/packages/webhooks/lib/forward.unit.test.ts
@@ -1,17 +1,25 @@
-import { afterAll, beforeAll, beforeEach, describe, expect, it, vi } from 'vitest';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
 
 import { logContextGetter } from '@nangohq/logs';
-import { axiosInstance } from '@nangohq/utils';
+import { Ok } from '@nangohq/utils';
 
 import { forwardWebhook } from './forward.js';
-import { mockWebhookDenylistAllowAll } from './helpers/setup.unit.js';
-import { TestWebhookServer } from './helpers/test.js';
+import { deliver } from './utils.js';
 
 import type { DBAPISecret, DBEnvironment, DBExternalWebhook, DBTeam, IntegrationConfig } from '@nangohq/types';
 
-const spy = vi.spyOn(axiosInstance, 'post');
+// The senders' job is to decide whether/what to deliver and call `deliver`. The on-the-wire behavior
+// (SSRF policy, agents, axios, signatures, byte metering) is `deliver`'s responsibility and is covered
+// in utils.unit.test.ts. So here we mock `deliver` and assert on how the sender orchestrates it.
+vi.mock('./utils.js', async (importOriginal) => {
+    const actual = await importOriginal<Record<string, unknown>>();
+    return { ...actual, deliver: vi.fn() };
+});
 
-const testServer = new TestWebhookServer(4102);
+const deliverMock = vi.mocked(deliver);
+
+const primaryUrl = 'https://example.com/webhook';
+const secondaryUrl = 'https://example.com/webhook-secondary';
 
 const account: DBTeam = {
     id: 1,
@@ -25,8 +33,8 @@ const account: DBTeam = {
 const webhookSettings: DBExternalWebhook = {
     id: 1,
     environment_id: 1,
-    primary_url: testServer.primaryUrl,
-    secondary_url: testServer.secondaryUrl,
+    primary_url: primaryUrl,
+    secondary_url: secondaryUrl,
     on_sync_completion_always: true,
     on_auth_creation: true,
     on_auth_refresh_error: true,
@@ -46,17 +54,12 @@ const integration = {
 const secret = 'secret' as DBAPISecret['secret'];
 
 describe('Webhooks: forward notification tests', () => {
-    beforeAll(async () => {
-        await testServer.start();
-    });
-
-    afterAll(async () => {
-        await testServer.stop();
-    });
-
     beforeEach(() => {
-        vi.resetAllMocks();
-        mockWebhookDenylistAllowAll();
+        deliverMock.mockReset();
+        deliverMock.mockImplementation((args) => {
+            args.onBytes?.({ sent: 10, received: 5 });
+            return Promise.resolve(Ok(undefined));
+        });
     });
 
     it('Should not send a forward webhook if the webhook url is not present', async () => {
@@ -80,7 +83,7 @@ describe('Webhooks: forward notification tests', () => {
                 'content-type': 'application/json'
             }
         });
-        expect(spy).not.toHaveBeenCalled();
+        expect(deliverMock).not.toHaveBeenCalled();
     });
 
     it('Should not send a forward webhook if forward_webhooks is false', async () => {
@@ -103,10 +106,10 @@ describe('Webhooks: forward notification tests', () => {
                 'content-type': 'application/json'
             }
         });
-        expect(spy).not.toHaveBeenCalled();
+        expect(deliverMock).not.toHaveBeenCalled();
     });
 
-    it('Should send a forward webhook if the webhook url is not present but the secondary is', async () => {
+    it('Should send a forward webhook to the secondary url if the primary is not present', async () => {
         await forwardWebhook({
             connectionIds: [],
             account,
@@ -126,34 +129,11 @@ describe('Webhooks: forward notification tests', () => {
                 'content-type': 'application/json'
             }
         });
-        expect(spy).toHaveBeenCalledTimes(1);
+        expect(deliverMock).toHaveBeenCalledTimes(1);
+        expect(deliverMock.mock.calls[0]![0].webhooks).toEqual([{ url: secondaryUrl, type: 'secondary webhook url' }]);
     });
 
-    it('Should send a forwarded webhook if the webhook url is present', async () => {
-        await forwardWebhook({
-            connectionIds: [],
-            account,
-            environment: {
-                name: 'dev',
-                id: 1,
-                always_send_webhook: true
-            } as DBEnvironment,
-            secret,
-            webhookSettings: {
-                ...webhookSettings,
-                primary_url: ''
-            },
-            logContextGetter,
-            integration,
-            payload: { some: 'data' },
-            webhookOriginalHeaders: {
-                'content-type': 'application/json'
-            }
-        });
-        expect(spy).toHaveBeenCalledTimes(1);
-    });
-
-    it('Should send a forwarded webhook twice if the webhook url and secondary are present', async () => {
+    it('Should deliver to both webhook urls in a single deliver call when both are present', async () => {
         await forwardWebhook({
             connectionIds: [],
             account,
@@ -162,7 +142,7 @@ describe('Webhooks: forward notification tests', () => {
                 id: 1
             } as DBEnvironment,
             secret,
-            webhookSettings: webhookSettings,
+            webhookSettings,
             logContextGetter,
             integration,
             payload: { some: 'data' },
@@ -170,10 +150,14 @@ describe('Webhooks: forward notification tests', () => {
                 'content-type': 'application/json'
             }
         });
-        expect(spy).toHaveBeenCalledTimes(2);
+        expect(deliverMock).toHaveBeenCalledTimes(1);
+        expect(deliverMock.mock.calls[0]![0].webhooks).toEqual([
+            { url: primaryUrl, type: 'webhook url' },
+            { url: secondaryUrl, type: 'secondary webhook url' }
+        ]);
     });
 
-    it('Should send a forwarded webhook to each webhook and for each connection if the webhook url and secondary are present', async () => {
+    it('Should call deliver once per connection when connectionIds are present', async () => {
         await forwardWebhook({
             connectionIds: ['1', '2'],
             account,
@@ -182,7 +166,7 @@ describe('Webhooks: forward notification tests', () => {
                 id: 1
             } as DBEnvironment,
             secret,
-            webhookSettings: webhookSettings,
+            webhookSettings,
             logContextGetter,
             integration,
             payload: { some: 'data' },
@@ -190,11 +174,18 @@ describe('Webhooks: forward notification tests', () => {
                 'content-type': 'application/json'
             }
         });
-        expect(spy).toHaveBeenCalledTimes(4);
+        expect(deliverMock).toHaveBeenCalledTimes(2);
+        for (const call of deliverMock.mock.calls) {
+            expect(call[0].webhooks).toEqual([
+                { url: primaryUrl, type: 'webhook url' },
+                { url: secondaryUrl, type: 'secondary webhook url' }
+            ]);
+        }
+        expect(deliverMock.mock.calls[0]![0].body).toMatchObject({ connectionId: '1' });
+        expect(deliverMock.mock.calls[1]![0].body).toMatchObject({ connectionId: '2' });
     });
 
-    it('Should report non-zero bytes.sent via onBytes on successful forward', async () => {
-        const payload = { some: 'data' };
+    it('Should report bytes via onBytes on successful forward', async () => {
         let reportedBytes: { sent: number; received: number } | undefined;
         const result = await forwardWebhook({
             connectionIds: [],
@@ -204,16 +195,14 @@ describe('Webhooks: forward notification tests', () => {
             webhookSettings,
             logContextGetter,
             integration,
-            payload,
+            payload: { some: 'data' },
             webhookOriginalHeaders: {},
             onBytes: (b) => {
                 reportedBytes = b;
             }
         });
         expect(result.isOk()).toBe(true);
-        // payload sent to both primary and secondary URLs
-        const minBytes = Buffer.byteLength(JSON.stringify(payload)) * 2;
-        expect(reportedBytes?.sent).toBeGreaterThanOrEqual(minBytes);
+        expect(reportedBytes).toEqual({ sent: 10, received: 5 });
     });
 
     it('Should not invoke onBytes when forwarding is skipped', async () => {
@@ -234,11 +223,11 @@ describe('Webhooks: forward notification tests', () => {
         });
         expect(result.isOk()).toBe(true);
         expect(called).toBe(false);
+        expect(deliverMock).not.toHaveBeenCalled();
     });
 
     it('Should invoke onBytes once per connection with that connection id', async () => {
         const connectionIds = ['conn1', 'conn2'];
-        const payload = { x: 1 };
         const calls: { connectionId: string; sent: number }[] = [];
         const result = await forwardWebhook({
             connectionIds,
@@ -248,7 +237,7 @@ describe('Webhooks: forward notification tests', () => {
             webhookSettings: { ...webhookSettings, secondary_url: '' },
             logContextGetter,
             integration,
-            payload,
+            payload: { x: 1 },
             webhookOriginalHeaders: {},
             onBytes: (b, connectionId) => {
                 calls.push({ connectionId, sent: b.sent });
@@ -258,10 +247,9 @@ describe('Webhooks: forward notification tests', () => {
         if (result.isOk()) {
             expect(result.value.results.filter((r) => r.success).length).toBe(2);
         }
-        expect(calls.map((c) => c.connectionId)).toEqual(['conn1', 'conn2']);
-        const minBytesPerConnection = Buffer.byteLength(JSON.stringify(payload));
-        for (const call of calls) {
-            expect(call.sent).toBeGreaterThanOrEqual(minBytesPerConnection);
-        }
+        expect(calls).toEqual([
+            { connectionId: 'conn1', sent: 10 },
+            { connectionId: 'conn2', sent: 10 }
+        ]);
     });
 });

--- a/packages/webhooks/lib/helpers/setup.unit.ts
+++ b/packages/webhooks/lib/helpers/setup.unit.ts
@@ -12,7 +12,6 @@ const permissivePolicy: OutboundUrlPolicy = {
     allowlist: [],
     blockPrivateIps: false,
     blockLinkLocal: false,
-    resolveDns: false,
     allowedSchemes: new Set(['http:', 'https:']),
     maxRedirects: 5
 };

--- a/packages/webhooks/lib/helpers/setup.unit.ts
+++ b/packages/webhooks/lib/helpers/setup.unit.ts
@@ -1,11 +1,30 @@
-import { vi } from 'vitest';
+import http from 'node:http';
+import https from 'node:https';
 
-import * as utils from '@nangohq/utils';
+import { createWebhookOutbound } from '../utils.js';
 
-export function mockWebhookDenylistAllowAll(): void {
-    vi.spyOn(utils, 'isBaseUrlOverrideDenied').mockReturnValue(false);
-}
+import type { WebhookOutbound } from '../utils.js';
+import type { OutboundUrlPolicy } from '@nangohq/egress';
 
-export function restoreWebhookDenylistMock(): void {
-    vi.mocked(utils.isBaseUrlOverrideDenied).mockRestore();
+const permissivePolicy: OutboundUrlPolicy = {
+    mode: 'permissive',
+    denylist: new Set(),
+    allowlist: [],
+    blockPrivateIps: false,
+    blockLinkLocal: false,
+    resolveDns: false,
+    allowedSchemes: new Set(['http:', 'https:']),
+    maxRedirects: 5
+};
+
+/**
+ * Outbound transport for `deliver` tests that hit a loopback test server. The real env-derived policy +
+ * DNS-pinning agents always block loopback, so these tests pass this permissive transport (plain
+ * keep-alive agents, no resolved-address validation) to `deliver` via its `outbound` arg.
+ */
+export function allowAllWebhookOutbound(): WebhookOutbound {
+    return createWebhookOutbound({
+        policy: permissivePolicy,
+        agents: { httpAgent: new http.Agent({ keepAlive: true }), httpsAgent: new https.Agent({ keepAlive: true }) }
+    });
 }

--- a/packages/webhooks/lib/helpers/setup.unit.ts
+++ b/packages/webhooks/lib/helpers/setup.unit.ts
@@ -16,11 +16,6 @@ const permissivePolicy: OutboundUrlPolicy = {
     maxRedirects: 5
 };
 
-/**
- * Outbound transport for `deliver` tests that hit a loopback test server. The real env-derived policy +
- * DNS-pinning agents always block loopback, so these tests pass this permissive transport (plain
- * keep-alive agents, no resolved-address validation) to `deliver` via its `outbound` arg.
- */
 export function allowAllWebhookOutbound(): WebhookOutbound {
     return createWebhookOutbound({
         policy: permissivePolicy,

--- a/packages/webhooks/lib/sync.unit.test.ts
+++ b/packages/webhooks/lib/sync.unit.test.ts
@@ -1,26 +1,23 @@
-/* eslint-disable @typescript-eslint/unbound-method */
-import { afterAll, beforeAll, beforeEach, describe, expect, it, vi } from 'vitest';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
 
-import { axiosInstance, stringifyStable } from '@nangohq/utils';
+import { Ok } from '@nangohq/utils';
 
-import { mockWebhookDenylistAllowAll } from './helpers/setup.unit.js';
-import { TestWebhookServer } from './helpers/test.js';
 import { sendSync } from './sync.js';
+import { deliver } from './utils.js';
 
-import type {
-    ConnectionJobs,
-    DBAPISecret,
-    DBEnvironment,
-    DBExternalWebhook,
-    DBSyncConfig,
-    DBTeam,
-    IntegrationConfig,
-    NangoSyncWebhookBodySuccess
-} from '@nangohq/types';
+import type { ConnectionJobs, DBAPISecret, DBEnvironment, DBExternalWebhook, DBSyncConfig, DBTeam, IntegrationConfig } from '@nangohq/types';
 
-const spy = vi.spyOn(axiosInstance, 'post');
+// The sender decides whether/what to deliver; the on-the-wire behavior is `deliver`'s responsibility
+// (covered in utils.unit.test.ts). Mock `deliver` and assert on the sender's orchestration.
+vi.mock('./utils.js', async (importOriginal) => {
+    const actual = await importOriginal<Record<string, unknown>>();
+    return { ...actual, deliver: vi.fn() };
+});
 
-const testServer = new TestWebhookServer(4103);
+const deliverMock = vi.mocked(deliver);
+
+const primaryUrl = 'https://example.com/webhook';
+const secondaryUrl = 'https://example.com/webhook-secondary';
 
 const account: DBTeam = {
     id: 1,
@@ -84,8 +81,8 @@ const connection: ConnectionJobs = {
 const webhookSettings: DBExternalWebhook = {
     id: 1,
     environment_id: 1,
-    primary_url: testServer.primaryUrl,
-    secondary_url: testServer.secondaryUrl,
+    primary_url: primaryUrl,
+    secondary_url: secondaryUrl,
     on_sync_completion_always: true,
     on_auth_creation: true,
     on_auth_refresh_error: true,
@@ -98,17 +95,9 @@ const webhookSettings: DBExternalWebhook = {
 const secret = 'secret' as DBAPISecret['secret'];
 
 describe('Webhooks: sync notification tests', () => {
-    beforeAll(async () => {
-        await testServer.start();
-    });
-
-    afterAll(async () => {
-        await testServer.stop();
-    });
-
     beforeEach(() => {
-        vi.resetAllMocks();
-        mockWebhookDenylistAllowAll();
+        deliverMock.mockReset();
+        deliverMock.mockResolvedValue(Ok(undefined));
     });
 
     it('Should not send a sync webhook if the webhook url is not present', async () => {
@@ -134,7 +123,7 @@ describe('Webhooks: sync notification tests', () => {
             operation: 'INCREMENTAL',
             now: new Date()
         });
-        expect(spy).not.toHaveBeenCalled();
+        expect(deliverMock).not.toHaveBeenCalled();
     });
 
     it('Should not send a sync webhook if the webhook url is not present even if always send is checked', async () => {
@@ -159,7 +148,7 @@ describe('Webhooks: sync notification tests', () => {
                 on_sync_completion_always: true
             }
         });
-        expect(axiosInstance.post).not.toHaveBeenCalled();
+        expect(deliverMock).not.toHaveBeenCalled();
     });
 
     it('Should not send a sync webhook if the webhook url is present but if always send is not checked and there were no sync changes', async () => {
@@ -183,7 +172,7 @@ describe('Webhooks: sync notification tests', () => {
                 on_sync_completion_always: false
             }
         });
-        expect(spy).not.toHaveBeenCalled();
+        expect(deliverMock).not.toHaveBeenCalled();
     });
 
     it('Should send a sync webhook if the webhook url is present and if always send is not checked and there were sync changes', async () => {
@@ -207,7 +196,7 @@ describe('Webhooks: sync notification tests', () => {
                 on_sync_completion_always: false
             }
         });
-        expect(spy).toHaveBeenCalled();
+        expect(deliverMock).toHaveBeenCalledTimes(1);
     });
 
     it('Should send a sync webhook if the webhook url is present and if always send is checked and there were sync changes', async () => {
@@ -231,7 +220,7 @@ describe('Webhooks: sync notification tests', () => {
                 on_sync_completion_always: true
             }
         });
-        expect(spy).toHaveBeenCalled();
+        expect(deliverMock).toHaveBeenCalledTimes(1);
     });
 
     it('Should send an sync webhook if the webhook url is present and if always send is checked and there were no sync changes', async () => {
@@ -255,10 +244,10 @@ describe('Webhooks: sync notification tests', () => {
                 on_sync_completion_always: true
             }
         });
-        expect(spy).toHaveBeenCalled();
+        expect(deliverMock).toHaveBeenCalledTimes(1);
     });
 
-    it('Should send an sync webhook twice if the webhook url and secondary are present and if always send is checked and there were no sync changes', async () => {
+    it('Should deliver to both webhook urls in a single deliver call when both are present', async () => {
         const responseResults = { added: 0, updated: 0, deleted: 0 };
         await sendSync({
             account,
@@ -278,10 +267,14 @@ describe('Webhooks: sync notification tests', () => {
                 on_sync_completion_always: true
             }
         });
-        expect(spy).toHaveBeenCalledTimes(2);
+        expect(deliverMock).toHaveBeenCalledTimes(1);
+        expect(deliverMock.mock.calls[0]![0].webhooks).toEqual([
+            { url: primaryUrl, type: 'primary' },
+            { url: secondaryUrl, type: 'secondary' }
+        ]);
     });
 
-    it('Should send a webhook with the correct body on sync success', async () => {
+    it('Should pass the correct body to deliver on sync success', async () => {
         const now = new Date();
 
         const responseResults = { added: 10, updated: 0, deleted: 0 };
@@ -301,50 +294,22 @@ describe('Webhooks: sync notification tests', () => {
             webhookSettings: webhookSettings
         });
 
-        const body: NangoSyncWebhookBodySuccess = {
+        expect(deliverMock).toHaveBeenCalledTimes(1);
+        const args = deliverMock.mock.calls[0]![0];
+        expect(args.webhookType).toBe('sync');
+        expect(args.body).toMatchObject({
             from: 'nango',
             type: 'sync',
-            modifiedAfter: now.toISOString(),
             model: 'model',
-            queryTimeStamp: now as unknown as string,
-            responseResults,
+            modifiedAfter: now.toISOString(),
+            responseResults: { added: 10, updated: 0, deleted: 0 },
             connectionId: connection.connection_id,
             syncName: 'a_sync',
             syncVariant: 'base',
             providerConfigKey: connection.provider_config_key,
             success: true,
             syncType: 'INCREMENTAL'
-        };
-        const bodyString = stringifyStable(body).unwrap();
-        expect(spy).toHaveBeenCalledTimes(2);
-
-        expect(spy).toHaveBeenNthCalledWith(
-            1,
-            webhookSettings.primary_url,
-            bodyString,
-            expect.objectContaining({
-                headers: {
-                    'X-Nango-Signature': expect.toBeSha256(),
-                    'X-Nango-Hmac-Sha256': expect.toBeSha256(),
-                    'content-type': 'application/json',
-                    'user-agent': expect.stringContaining('nango/')
-                }
-            })
-        );
-
-        expect(spy).toHaveBeenNthCalledWith(
-            2,
-            webhookSettings.secondary_url,
-            bodyString,
-            expect.objectContaining({
-                headers: {
-                    'X-Nango-Signature': expect.toBeSha256(),
-                    'X-Nango-Hmac-Sha256': expect.toBeSha256(),
-                    'content-type': 'application/json',
-                    'user-agent': expect.stringContaining('nango/')
-                }
-            })
-        );
+        });
     });
 
     it('Should not send an error webhook if the option is not checked', async () => {
@@ -372,10 +337,10 @@ describe('Webhooks: sync notification tests', () => {
             }
         });
 
-        expect(spy).not.toHaveBeenCalled();
+        expect(deliverMock).not.toHaveBeenCalled();
     });
 
-    it('Should send an error webhook if the option is checked with the correct body', async () => {
+    it('Should pass the correct body to deliver on sync error if the option is checked', async () => {
         const error = {
             type: 'error',
             description: 'error description'
@@ -400,6 +365,11 @@ describe('Webhooks: sync notification tests', () => {
             }
         });
 
-        expect(spy).toHaveBeenCalled();
+        expect(deliverMock).toHaveBeenCalledTimes(1);
+        expect(deliverMock.mock.calls[0]![0].body).toMatchObject({
+            type: 'sync',
+            success: false,
+            error
+        });
     });
 });

--- a/packages/webhooks/lib/sync.unit.test.ts
+++ b/packages/webhooks/lib/sync.unit.test.ts
@@ -7,8 +7,6 @@ import { deliver } from './utils.js';
 
 import type { ConnectionJobs, DBAPISecret, DBEnvironment, DBExternalWebhook, DBSyncConfig, DBTeam, IntegrationConfig } from '@nangohq/types';
 
-// The sender decides whether/what to deliver; the on-the-wire behavior is `deliver`'s responsibility
-// (covered in utils.unit.test.ts). Mock `deliver` and assert on the sender's orchestration.
 vi.mock('./utils.js', async (importOriginal) => {
     const actual = await importOriginal<Record<string, unknown>>();
     return { ...actual, deliver: vi.fn() };

--- a/packages/webhooks/lib/utils.ts
+++ b/packages/webhooks/lib/utils.ts
@@ -267,10 +267,14 @@ export const deliver = async ({
                     const result = await circuitBreaker.execute(url, async () => {
                         const createdAt = new Date();
                         const attemptBytes: MeteredBytes = { sent: 0, received: 0 };
-                        const transport = createMeteringTransport((hop) => {
-                            attemptBytes.sent += hop.sent;
-                            attemptBytes.received += hop.received;
-                        }, outbound.validateRedirect);
+                        const transport = createMeteringTransport({
+                            onBytes: (hop) => {
+                                attemptBytes.sent += hop.sent;
+                                attemptBytes.received += hop.received;
+                            },
+                            beforeRedirect: outbound.validateRedirect,
+                            maxRedirects: outbound.policy.maxRedirects
+                        });
                         try {
                             const res = await axios.post(url, bodyString.value, {
                                 headers,

--- a/packages/webhooks/lib/utils.ts
+++ b/packages/webhooks/lib/utils.ts
@@ -29,13 +29,6 @@ export const RETRY_ATTEMPTS = envs.NANGO_WEBHOOK_RETRY_ATTEMPTS;
 
 export type WebhookAgents = ReturnType<typeof getSafeHttpAgents>;
 
-/**
- * Everything needed to deliver a customer webhook safely: the SSRF policy used for the pre-flight
- * allow-check and redirect cap, the DNS-pinning keep-alive agents, and the per-hop redirect validator.
- * Build once and reuse so the agents can pool connections. Production code uses the env-derived default
- * ({@link deliver} fills it in); callers that need a different transport (e.g. a test delivering to a
- * loopback server) construct their own with {@link createWebhookOutbound} and pass it to {@link deliver}.
- */
 export interface WebhookOutbound {
     policy: OutboundUrlPolicy;
     agents: WebhookAgents;
@@ -60,10 +53,6 @@ export function createWebhookOutbound({ policy, agents }: { policy: OutboundUrlP
 
 let defaultWebhookOutbound: WebhookOutbound | undefined;
 
-/**
- * Env-derived outbound transport for customer webhook delivery (denylist + DNS rebinding / private-IP /
- * redirect controls). Built lazily on first use and memoized so the agents can pool connections.
- */
 function getDefaultWebhookOutbound(): WebhookOutbound {
     if (!defaultWebhookOutbound) {
         const policy = resolvePolicyForServer({
@@ -221,10 +210,6 @@ export const deliver = async ({
     endingMessage?: string;
     incomingHeaders?: Record<string, string>;
     onBytes?: (bytes: MeteredBytes) => void;
-    /**
-     * Outbound transport (SSRF policy + DNS-pinning agents + redirect validator). Defaults to the
-     * env-derived production transport; tests inject a permissive one to reach a loopback server.
-     */
     outbound?: WebhookOutbound;
 }): Promise<Result<void>> => {
     let success = true;

--- a/packages/webhooks/lib/utils.ts
+++ b/packages/webhooks/lib/utils.ts
@@ -2,25 +2,21 @@ import crypto from 'crypto';
 
 import { isAxiosError } from 'axios';
 
+import {
+    absoluteUrlFromRedirectRequestOptions,
+    createRedirectValidator,
+    getSafeHttpAgents,
+    isOutboundUrlAllowed,
+    resolvePolicyForServer
+} from '@nangohq/egress';
 import { getRedis } from '@nangohq/kvstore';
 import { createMeteringTransport } from '@nangohq/shared';
-import {
-    axiosInstance as axios,
-    Err,
-    getLogger,
-    isBaseUrlOverrideDenied,
-    networkError,
-    normalizeDenylist,
-    Ok,
-    redactHeaders,
-    retryFlexible,
-    stringifyStable,
-    userAgent
-} from '@nangohq/utils';
+import { axiosInstance as axios, Err, getLogger, networkError, Ok, redactHeaders, retryFlexible, stringifyStable, userAgent } from '@nangohq/utils';
 
 import { CircuitBreakerPassThrough, CircuitBreakerRedis } from './circuitBreaker.js';
 import { envs } from './envs.js';
 
+import type { OutboundUrlPolicy } from '@nangohq/egress';
 import type { LogContext } from '@nangohq/logs';
 import type { MeteredBytes } from '@nangohq/shared';
 import type { DBAPISecret, DBExternalWebhook, MessageHTTPResponse, MessageRow, WebhookTypes } from '@nangohq/types';
@@ -31,7 +27,53 @@ const logger = getLogger('webhooks.utils');
 
 export const RETRY_ATTEMPTS = envs.NANGO_WEBHOOK_RETRY_ATTEMPTS;
 
-const webhookUrlDenylist = normalizeDenylist(envs.NANGO_PROXY_BASE_URL_OVERRIDE_DENYLIST);
+export type WebhookAgents = ReturnType<typeof getSafeHttpAgents>;
+
+/**
+ * Everything needed to deliver a customer webhook safely: the SSRF policy used for the pre-flight
+ * allow-check and redirect cap, the DNS-pinning keep-alive agents, and the per-hop redirect validator.
+ * Build once and reuse so the agents can pool connections. Production code uses the env-derived default
+ * ({@link deliver} fills it in); callers that need a different transport (e.g. a test delivering to a
+ * loopback server) construct their own with {@link createWebhookOutbound} and pass it to {@link deliver}.
+ */
+export interface WebhookOutbound {
+    policy: OutboundUrlPolicy;
+    agents: WebhookAgents;
+    validateRedirect: (options: Record<string, unknown>) => void;
+}
+
+/** Build a {@link WebhookOutbound} from a policy and its agents, wiring the redirect validator to the policy. */
+export function createWebhookOutbound({ policy, agents }: { policy: OutboundUrlPolicy; agents: WebhookAgents }): WebhookOutbound {
+    const redirectValidator = createRedirectValidator(policy);
+    return {
+        policy,
+        agents,
+        // Validate each redirect target (scheme + hostname denylist) before follow-redirects follows it.
+        validateRedirect: (options) => {
+            const absolute = absoluteUrlFromRedirectRequestOptions(options);
+            if (absolute) {
+                redirectValidator(absolute);
+            }
+        }
+    };
+}
+
+let defaultWebhookOutbound: WebhookOutbound | undefined;
+
+/**
+ * Env-derived outbound transport for customer webhook delivery (denylist + DNS rebinding / private-IP /
+ * redirect controls). Built lazily on first use and memoized so the agents can pool connections.
+ */
+function getDefaultWebhookOutbound(): WebhookOutbound {
+    if (!defaultWebhookOutbound) {
+        const policy = resolvePolicyForServer({
+            proxyBaseUrlOverrideDenylist: envs.NANGO_PROXY_BASE_URL_OVERRIDE_DENYLIST,
+            outboundUrlPolicy: envs.NANGO_OUTBOUND_URL_POLICY
+        });
+        defaultWebhookOutbound = createWebhookOutbound({ policy, agents: getSafeHttpAgents(policy) });
+    }
+    return defaultWebhookOutbound;
+}
 
 export const NON_FORWARDABLE_HEADERS = [
     'host',
@@ -168,7 +210,8 @@ export const deliver = async ({
     secret,
     endingMessage = '',
     incomingHeaders,
-    onBytes
+    onBytes,
+    outbound = getDefaultWebhookOutbound()
 }: {
     webhooks: { url: string; type: string }[];
     body: unknown;
@@ -178,13 +221,18 @@ export const deliver = async ({
     endingMessage?: string;
     incomingHeaders?: Record<string, string>;
     onBytes?: (bytes: MeteredBytes) => void;
+    /**
+     * Outbound transport (SSRF policy + DNS-pinning agents + redirect validator). Defaults to the
+     * env-derived production transport; tests inject a permissive one to reach a loopback server.
+     */
+    outbound?: WebhookOutbound;
 }): Promise<Result<void>> => {
     let success = true;
 
     for (const webhook of webhooks) {
         const { url, type } = webhook;
 
-        if (isBaseUrlOverrideDenied(url, webhookUrlDenylist)) {
+        if (!isOutboundUrlAllowed(url, outbound.policy)) {
             void logCtx?.warn(`Skipping webhook delivery to denied URL (${type})`);
             continue;
         }
@@ -222,9 +270,16 @@ export const deliver = async ({
                         const transport = createMeteringTransport((hop) => {
                             attemptBytes.sent += hop.sent;
                             attemptBytes.received += hop.received;
-                        });
+                        }, outbound.validateRedirect);
                         try {
-                            const res = await axios.post(url, bodyString.value, { headers, timeout: envs.NANGO_WEBHOOK_TIMEOUT_MS, transport });
+                            const res = await axios.post(url, bodyString.value, {
+                                headers,
+                                timeout: envs.NANGO_WEBHOOK_TIMEOUT_MS,
+                                transport,
+                                httpAgent: outbound.agents.httpAgent,
+                                httpsAgent: outbound.agents.httpsAgent,
+                                maxRedirects: outbound.policy.maxRedirects
+                            });
 
                             void logCtx?.http(`POST ${url}`, { request: logRequest, response: formatLogResponse(res), context: 'webhook', createdAt });
                             if (res.status >= 200 && res.status < 300) {

--- a/packages/webhooks/lib/utils.unit.test.ts
+++ b/packages/webhooks/lib/utils.unit.test.ts
@@ -1,12 +1,14 @@
-import { afterAll, beforeAll, beforeEach, describe, expect, it } from 'vitest';
+import { afterAll, afterEach, beforeAll, beforeEach, describe, expect, it, vi } from 'vitest';
 
-import { stringifyStable } from '@nangohq/utils';
+import { axiosInstance, stringifyStable } from '@nangohq/utils';
 
-import { mockWebhookDenylistAllowAll, restoreWebhookDenylistMock } from './helpers/setup.unit.js';
+import { allowAllWebhookOutbound } from './helpers/setup.unit.js';
 import { TestWebhookServer } from './helpers/test.js';
 import { deliver, getHmacSignatureHeader, getSignatureHeaderUnsafe } from './utils.js';
 
 import type { DBAPISecret } from '@nangohq/types';
+import type { AxiosResponse } from 'axios';
+import type { MockInstance } from 'vitest';
 
 describe('getSignatureHeaderUnsafe', () => {
     it('should return a string', () => {
@@ -48,9 +50,71 @@ describe('getHmacSignatureHeader', () => {
     });
 });
 
+describe('deliver request shape', () => {
+    const secret = 'secret' as DBAPISecret['secret'];
+    const allowAll = allowAllWebhookOutbound();
+    const okResponse = { status: 200, statusText: 'OK', headers: {}, data: { ok: true }, config: {} } as unknown as AxiosResponse;
+
+    let postSpy: MockInstance<typeof axiosInstance.post>;
+
+    beforeEach(() => {
+        postSpy = vi.spyOn(axiosInstance, 'post').mockResolvedValue(okResponse);
+    });
+
+    afterEach(() => {
+        postSpy.mockRestore();
+    });
+
+    it('POSTs once per webhook URL with the stable body and signed headers', async () => {
+        const body = { hello: 'world' };
+        const result = await deliver({
+            webhooks: [
+                { url: 'https://example.com/primary', type: 'primary' },
+                { url: 'https://example.com/secondary', type: 'secondary' }
+            ],
+            body,
+            webhookType: 'forward',
+            secret,
+            outbound: allowAll
+        });
+
+        expect(result.isOk()).toBe(true);
+        expect(postSpy).toHaveBeenCalledTimes(2);
+
+        const bodyString = stringifyStable(body).unwrap();
+        const expectedHeaders = {
+            'X-Nango-Signature': expect.toBeSha256(),
+            'X-Nango-Hmac-Sha256': expect.toBeSha256(),
+            'content-type': 'application/json',
+            'user-agent': expect.stringContaining('nango/')
+        };
+
+        expect(postSpy).toHaveBeenNthCalledWith(1, 'https://example.com/primary', bodyString, expect.objectContaining({ headers: expectedHeaders }));
+        expect(postSpy).toHaveBeenNthCalledWith(2, 'https://example.com/secondary', bodyString, expect.objectContaining({ headers: expectedHeaders }));
+    });
+
+    it('caps redirects and attaches the outbound agents from the transport', async () => {
+        await deliver({
+            webhooks: [{ url: 'https://example.com/primary', type: 'primary' }],
+            body: { hello: 'world' },
+            webhookType: 'forward',
+            secret,
+            outbound: allowAll
+        });
+
+        expect(postSpy).toHaveBeenCalledTimes(1);
+        const config = postSpy.mock.calls[0]![2]!;
+        expect(config.maxRedirects).toBe(allowAll.policy.maxRedirects);
+        expect(config.httpAgent).toBe(allowAll.agents.httpAgent);
+        expect(config.httpsAgent).toBe(allowAll.agents.httpsAgent);
+    });
+});
+
 describe('deliver bytes metering', () => {
     const testServer = new TestWebhookServer(4104);
     const secret = 'test-secret' as DBAPISecret['secret'];
+    // Permissive transport so we can reach the loopback test server (the real policy blocks loopback).
+    const allowAll = allowAllWebhookOutbound();
 
     beforeAll(async () => {
         await testServer.start();
@@ -60,10 +124,6 @@ describe('deliver bytes metering', () => {
         await testServer.stop();
     });
 
-    beforeEach(() => {
-        mockWebhookDenylistAllowAll();
-    });
-
     it('should fire onBytes with non-zero sent on successful POST', async () => {
         const hops: { sent: number; received: number }[] = [];
         const result = await deliver({
@@ -71,6 +131,7 @@ describe('deliver bytes metering', () => {
             body: { hello: 'world' },
             webhookType: 'forward',
             secret,
+            outbound: allowAll,
             onBytes: (b) => hops.push(b)
         });
         expect(result.isOk()).toBe(true);
@@ -88,6 +149,7 @@ describe('deliver bytes metering', () => {
             body: { hello: 'world' },
             webhookType: 'forward',
             secret,
+            outbound: allowAll,
             onBytes: (b) => hops.push(b)
         });
         expect(hops.length).toBe(2);
@@ -96,12 +158,24 @@ describe('deliver bytes metering', () => {
         }
     });
 
+    // No `outbound` override here: exercise the real env-derived policy so the SSRF checks actually run.
     it('should skip denylisted webhook URLs', async () => {
-        restoreWebhookDenylistMock();
-
         const hops: { sent: number; received: number }[] = [];
         const result = await deliver({
             webhooks: [{ url: 'http://169.254.169.254/webhook', type: 'primary' }],
+            body: { hello: 'world' },
+            webhookType: 'forward',
+            secret,
+            onBytes: (b) => hops.push(b)
+        });
+        expect(result.isOk()).toBe(true);
+        expect(hops.length).toBe(0);
+    });
+
+    it('should skip webhook URLs pointing at private (RFC1918) IP literals', async () => {
+        const hops: { sent: number; received: number }[] = [];
+        const result = await deliver({
+            webhooks: [{ url: 'http://10.0.0.1/webhook', type: 'primary' }],
             body: { hello: 'world' },
             webhookType: 'forward',
             secret,

--- a/packages/webhooks/package.json
+++ b/packages/webhooks/package.json
@@ -15,6 +15,7 @@
     },
     "keywords": [],
     "dependencies": {
+        "@nangohq/egress": "file:../egress",
         "@nangohq/logs": "file:../logs",
         "@nangohq/shared": "file:../shared",
         "@nangohq/utils": "file:../utils",

--- a/packages/webhooks/tsconfig.json
+++ b/packages/webhooks/tsconfig.json
@@ -6,6 +6,9 @@
     },
     "references": [
         {
+            "path": "../egress"
+        },
+        {
             "path": "../utils"
         },
         {


### PR DESCRIPTION
## Summary

Builds on the existing base-URL denylist and the `@nangohq/egress` package to add a single, configurable outbound URL policy across all customer-controlled egress paths. Every outbound connection - including each redirect hop - is now routed through DNS-pinning agents that re-validate the *resolved* IP, with a configurable redirect cap. Secure defaults apply out of the box; behavior is tunable via `NANGO_OUTBOUND_URL_POLICY`.

## What changed

**Egress policy is now applied at the leaf of each outbound path:**
- **Proxy (server + runner):** `ProxyRequest` accepts an `outboundPolicy`; `getAxiosConfiguration` attaches DNS-pinning keep-alive agents, caps `maxRedirects`, and re-validates the resolved address on the initial request and on every `beforeRedirect` hop (mTLS connections included).
- **Customer webhook delivery:** `deliver()` resolves an env-derived transport (policy + agents + redirect validator) by default, applies the redirect cap, and skips disallowed targets.
- **`uncontrolledFetch` (runner SDK):** validates the resolved address per hop; unresolvable hostnames fall through to a normal fetch failure rather than a policy denial.
- **Credential verification + AWS SigV4 hooks:** the internal `ProxyRequest` calls now carry the server policy too.
- **Webhook registration (`PATCH .../webhook`):** rejects disallowed URLs at save time.

**Config & propagation:**
- New optional `NANGO_OUTBOUND_URL_POLICY` (JSON), parsed/validated at startup and memoized.
- Propagated automatically to Kubernetes and Lambda runners.
- Documented in `.env.example` and the self-hosting guide.

**Performance:** safe DNS lookups and agents are memoized per-policy so connections pool and the pinned-address cache is shared across requests.

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/NangoHQ/nango/pull/6646?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

