### PR TITLE
fix: set keepAliveTimeout on all HTTP services to prevent load balancer 502s

### DIFF
--- a/packages/jobs/lib/app.ts
+++ b/packages/jobs/lib/app.ts
@@ -40,6 +40,11 @@ try {
     const port = envs.NANGO_JOBS_PORT;
     const orchestratorUrl = envs.ORCHESTRATOR_SERVICE_URL;
     const srv = server.listen(port);
+    // keepAliveTimeout must exceed the fronting proxy/load balancer idle timeout (e.g. AWS ALB defaults to 60s) so the
+    // proxy closes idle connections first. Node's 5s default closes pooled sockets the proxy still considers reusable,
+    // causing the next request to hit a dead socket -> TCP RST -> 502. Mirrors packages/server/lib/server.ts.
+    srv.keepAliveTimeout = envs.NANGO_SERVER_KEEP_ALIVE_TIMEOUT;
+    srv.headersTimeout = envs.NANGO_SERVER_KEEP_ALIVE_TIMEOUT + 1000; // needs to be longer than the keep alive timeout to avoid premature disconnections
     logger.info(`🚀 service ready at http://localhost:${port}`);
     const processor = new Processor(orchestratorUrl);
     const invocationsProcessor = new LambdaInvocationsProcessor();

--- a/packages/orchestrator/lib/app.ts
+++ b/packages/orchestrator/lib/app.ts
@@ -82,6 +82,11 @@ try {
     const api = server.listen(port, () => {
         logger.info(`🚀 Orchestrator API ready at http://localhost:${port}`);
     });
+    // keepAliveTimeout must exceed the fronting proxy/load balancer idle timeout (e.g. AWS ALB defaults to 60s) so the
+    // proxy closes idle connections first. Node's 5s default closes pooled sockets the proxy still considers reusable,
+    // causing the next request to hit a dead socket -> TCP RST -> 502. Mirrors packages/server/lib/server.ts.
+    api.keepAliveTimeout = envs.NANGO_SERVER_KEEP_ALIVE_TIMEOUT;
+    api.headersTimeout = envs.NANGO_SERVER_KEEP_ALIVE_TIMEOUT + 1000; // needs to be longer than the keep alive timeout to avoid premature disconnections
 
     // --- Close function
     const close = once(() => {

--- a/packages/persist/lib/app.ts
+++ b/packages/persist/lib/app.ts
@@ -45,6 +45,11 @@ try {
     api = server.listen(port, () => {
         logger.info(`🚀 API ready at http://localhost:${port}`);
     });
+    // keepAliveTimeout must exceed the fronting proxy/load balancer idle timeout (e.g. AWS ALB defaults to 60s) so the
+    // proxy closes idle connections first. Node's 5s default closes pooled sockets the proxy still considers reusable,
+    // causing the next request to hit a dead socket -> TCP RST -> 502. Mirrors packages/server/lib/server.ts.
+    api.keepAliveTimeout = envs.NANGO_SERVER_KEEP_ALIVE_TIMEOUT;
+    api.headersTimeout = envs.NANGO_SERVER_KEEP_ALIVE_TIMEOUT + 1000; // needs to be longer than the keep alive timeout to avoid premature disconnections
 } catch (err) {
     console.error(`Persist API error`, err);
     process.exit(1);

--- a/packages/runner/lib/app.ts
+++ b/packages/runner/lib/app.ts
@@ -21,6 +21,11 @@ try {
             logger.error(`${id} Unable to register`, res.error);
         }
     });
+    // keepAliveTimeout must exceed the fronting proxy/load balancer idle timeout (e.g. AWS ALB defaults to 60s) so the
+    // proxy closes idle connections first. Node's 5s default closes pooled sockets the proxy still considers reusable,
+    // causing the next request to hit a dead socket -> TCP RST -> 502. Mirrors packages/server/lib/server.ts.
+    srv.keepAliveTimeout = envs.NANGO_SERVER_KEEP_ALIVE_TIMEOUT;
+    srv.headersTimeout = envs.NANGO_SERVER_KEEP_ALIVE_TIMEOUT + 1000; // needs to be longer than the keep alive timeout to avoid premature disconnections
 
     const close = () => {
         logger.info(`${id} Closing...`);


### PR DESCRIPTION
## Problem

Several Nango HTTP services start their server with `server.listen()` but never set `keepAliveTimeout`, so they inherit Node's default of **5 seconds**. When a service runs behind a load balancer / reverse proxy whose idle timeout is **longer** than that (for example, an AWS ALB defaults to **60s**), a race occurs:

1. The service closes an idle keep-alive connection after 5s.
2. The load balancer still considers that pooled connection reusable (its idle timeout hasn't elapsed).
3. The LB sends the next request onto the socket the service already closed → TCP **RST** → the LB returns **HTTP 502**.

The tell-tale symptom is **502s in the load balancer metrics with no corresponding 5xx at the target/instance level** (the app never sees a complete request, so nothing appears in its own logs/APM). We see a high volume of these from the `persist` service in particular.

This is the exact failure AWS documents in its [ALB HTTP 502 troubleshooting guide](https://docs.aws.amazon.com/elasticloadbalancing/latest/application/load-balancer-troubleshooting.html):

> "The target closed the connection with a TCP RST or a TCP FIN while the load balancer had an outstanding request to the target. **Check whether the keep-alive duration of the target is shorter than the idle timeout value of the load balancer.**"

## Why this looks like an oversight

`packages/server` already guards against this — `packages/server/lib/server.ts:68-69`:

```ts
server.keepAliveTimeout = envs.NANGO_SERVER_KEEP_ALIVE_TIMEOUT;
server.headersTimeout = envs.NANGO_SERVER_KEEP_ALIVE_TIMEOUT + 1000; // needs to be longer than the keep alive timeout to avoid premature disconnections
```

`NANGO_SERVER_KEEP_ALIVE_TIMEOUT` defaults to `61_000` (`packages/utils/lib/environment/parse.ts:29`) — deliberately just above a 60s ALB. It lives in the shared `ENVS` schema and is already parsed by every service via `parseEnvs(ENVS)`, so the value is available everywhere today. The other HTTP servers simply never apply it.

## Change

Apply the same two lines (mirroring `packages/server`) to the remaining HTTP services that call `listen()` without setting the timeout:

- `packages/persist/lib/app.ts`
- `packages/runner/lib/app.ts`
- `packages/jobs/lib/app.ts`
- `packages/orchestrator/lib/app.ts`

`headersTimeout` is set to `keepAliveTimeout + 1000` (must exceed it) to avoid premature disconnections, matching the existing `server` implementation. No new configuration is introduced — all four reuse the existing `NANGO_SERVER_KEEP_ALIVE_TIMEOUT` env.

## Note for maintainers

The env is named `NANGO_SERVER_KEEP_ALIVE_TIMEOUT` but now governs four services. You may prefer to rename it to something service-agnostic (e.g. `NANGO_KEEP_ALIVE_TIMEOUT`); reusing the existing name here avoids a breaking config change. Happy to adjust if you'd like a different approach (per-service envs, a shared helper, etc.).


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/NangoHQ/nango/pull/6649?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

