### PR TITLE
chore: default export_runner_telemetry to true

### DIFF
--- a/packages/database/lib/migrations/20260624120000_plans_export_runner_telemetry_default_true.cjs
+++ b/packages/database/lib/migrations/20260624120000_plans_export_runner_telemetry_default_true.cjs
@@ -1,0 +1,19 @@
+/**
+ * @param {import('knex').Knex} knex
+ */
+exports.up = async function (knex) {
+    await knex.schema.alterTable('plans', (table) => {
+        table.boolean('export_runner_telemetry').notNullable().defaultTo(true).alter();
+    });
+};
+
+/**
+ * @param {import('knex').Knex} knex
+ */
+exports.down = async function (knex) {
+    await knex.schema.alterTable('plans', (table) => {
+        table.boolean('export_runner_telemetry').notNullable().defaultTo(false).alter();
+    });
+};
+
+exports.config = { transaction: true };


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/NangoHQ/nango/pull/6652?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

