### PR TITLE
fix(webapp): cap billing content width on wide screens

### DIFF
--- a/packages/webapp/src/pages/Team/Billing/Show.tsx
+++ b/packages/webapp/src/pages/Team/Billing/Show.tsx
@@ -30,42 +30,47 @@ export const TeamBilling: React.FC = () => {
         }
     }, [canManageBilling, activeTab, setActiveTab]);
 
+    // Full-width page shell keeps chrome consistent with the other dashboard pages, but the billing
+    // content is capped and left-aligned: the usage charts have a fixed height, so unbounded width
+    // stretches them to an unreadable aspect ratio on wide screens.
     return (
-        <DashboardLayout fullWidth title="Billing & usage" className="flex flex-col gap-8">
+        <DashboardLayout fullWidth title="Billing & usage">
             <Helmet>
                 <title>Billing & usage - Nango</title>
             </Helmet>
-            <header className="flex justify-end items-center">
-                {isUsageTab && (
-                    <div className="flex items-center gap-4">
-                        <MonthSelector onMonthChange={setSelectedMonth} />
-                    </div>
-                )}
-            </header>
-            <Navigation value={activeTab} onValueChange={setActiveTab} className="max-w-full">
-                <NavigationList>
-                    <NavigationTrigger value={'usage'}>Usage</NavigationTrigger>
-                    <NavigationTrigger value={'plans'}>Plans</NavigationTrigger>
-                    <PermissionGate condition={canManageBilling}>
-                        {(allowed) => (
-                            <NavigationTrigger value={'payment-and-invoices'} disabled={!allowed}>
-                                Payment & Invoices
-                            </NavigationTrigger>
-                        )}
-                    </PermissionGate>
-                </NavigationList>
-                <NavigationContent value={'usage'} className="w-full flex flex-col gap-6">
-                    <Usage selectedMonth={selectedMonth} />
-                </NavigationContent>
-                <NavigationContent value={'plans'} className="w-full overflow-x-auto">
-                    <Plans />
-                </NavigationContent>
-                {canManageBilling && (
-                    <NavigationContent value={'payment-and-invoices'} className="w-full">
-                        <Payment />
+            <div className="flex flex-col gap-8 max-w-[1280px]">
+                <header className="flex justify-end items-center">
+                    {isUsageTab && (
+                        <div className="flex items-center gap-4">
+                            <MonthSelector onMonthChange={setSelectedMonth} />
+                        </div>
+                    )}
+                </header>
+                <Navigation value={activeTab} onValueChange={setActiveTab} className="max-w-full">
+                    <NavigationList>
+                        <NavigationTrigger value={'usage'}>Usage</NavigationTrigger>
+                        <NavigationTrigger value={'plans'}>Plans</NavigationTrigger>
+                        <PermissionGate condition={canManageBilling}>
+                            {(allowed) => (
+                                <NavigationTrigger value={'payment-and-invoices'} disabled={!allowed}>
+                                    Payment & Invoices
+                                </NavigationTrigger>
+                            )}
+                        </PermissionGate>
+                    </NavigationList>
+                    <NavigationContent value={'usage'} className="w-full flex flex-col gap-6">
+                        <Usage selectedMonth={selectedMonth} />
                     </NavigationContent>
-                )}
-            </Navigation>
+                    <NavigationContent value={'plans'} className="w-full overflow-x-auto">
+                        <Plans />
+                    </NavigationContent>
+                    {canManageBilling && (
+                        <NavigationContent value={'payment-and-invoices'} className="w-full">
+                            <Payment />
+                        </NavigationContent>
+                    )}
+                </Navigation>
+            </div>
         </DashboardLayout>
     );
 };


### PR DESCRIPTION
## Problem

[#6637](https://github.com/NangoHQ/nango/pull/6637) moved Billing & usage onto the shared full-width layout shell. That suits the table pages it also touched, but the usage charts have a fixed height — so on wide screens (e.g. 2560px) the unbounded width stretches them past a ~3.6:1 aspect ratio: daily bars spread thin and the cumulative areas flatten into slabs, which reads poorly.

## Solution

Keep the full-width shell so the page chrome stays consistent, but cap the billing content at `max-w-[1280px]`, **left-aligned** — same left origin as the other dashboard pages, so there's no horizontal shift when navigating between them. On a 2560px screen the charts then hold ~3:1 (bar charts ~1000×320). Below ~1500px viewport it's unchanged — full-width as before — so laptops are unaffected.

## Testing

- Ran the webapp against the dev API and viewed `/team/billing` at 2560px: content is capped and left-aligned, charts sit at ~3:1 and no longer stretch across the screen.
- Confirmed it's a no-op at laptop widths.
