### PR TITLE
feat: demo backend-driven feature flag banner

### DIFF
--- a/packages/feature-flags/lib/flags.ts
+++ b/packages/feature-flags/lib/flags.ts
@@ -25,6 +25,13 @@ export function buildFlags(client: FeatureFlagsClient) {
          */
         shouldKeepActionTrace(environmentId: number) {
             return client.isEnabled('action-trace-manual-keep', { targetingKey: String(environmentId), environmentId }, false);
+        },
+        /**
+         * Demo flag: when enabled, the dashboard shows an obvious banner.
+         * Used to showcase backend-driven feature flags end to end. Default `false`.
+         */
+        isDemoBannerEnabled(accountUuid: string) {
+            return client.isEnabled('demo-banner', { targetingKey: accountUuid, accountUuid }, false);
         }
     };
 }

--- a/packages/server/lib/controllers/v1/meta/getMeta.ts
+++ b/packages/server/lib/controllers/v1/meta/getMeta.ts
@@ -1,3 +1,4 @@
+import { getFlags } from '@nangohq/feature-flags';
 import { environmentService } from '@nangohq/shared';
 import { baseUrl, NANGO_VERSION, requireEmptyQuery, zodErrorToHTTP } from '@nangohq/utils';
 
@@ -13,8 +14,10 @@ export const getMeta = asyncWrapper<GetMeta>(async (req, res) => {
     }
 
     const sessionUser = res.locals.user;
+    const account = res.locals['account'];
 
     const environments = await environmentService.getEnvironmentsByAccountId(sessionUser.account_id);
+    const demoBanner = await getFlags().isDemoBannerEnabled(account.uuid);
     res.status(200).send({
         data: {
             environments: environments.map((env) => {
@@ -24,7 +27,8 @@ export const getMeta = asyncWrapper<GetMeta>(async (req, res) => {
             baseUrl,
             debugMode: req.session.debugMode === true,
             gettingStartedClosed: sessionUser.getting_started_closed,
-            billingUsageSource: 'clickhouse'
+            billingUsageSource: 'clickhouse',
+            demoBanner
         }
     });
 });

--- a/packages/types/lib/meta/api.ts
+++ b/packages/types/lib/meta/api.ts
@@ -14,6 +14,7 @@ export type GetMeta = Endpoint<{
             debugMode: boolean;
             gettingStartedClosed: boolean;
             billingUsageSource: 'clickhouse' | 'orb';
+            demoBanner: boolean;
         };
     };
 }>;

--- a/packages/webapp/src/app/App.tsx
+++ b/packages/webapp/src/app/App.tsx
@@ -44,6 +44,26 @@ const App = () => {
 
     return (
         <>
+            {meta?.demoBanner && (
+                <div
+                    style={{
+                        position: 'fixed',
+                        top: 0,
+                        left: 0,
+                        right: 0,
+                        zIndex: 9999,
+                        background: 'linear-gradient(90deg, #ff0080, #ff8c00, #ffe600)',
+                        color: '#000',
+                        fontWeight: 800,
+                        fontSize: '18px',
+                        textAlign: 'center',
+                        padding: '12px',
+                        letterSpacing: '0.05em'
+                    }}
+                >
+                    🚩 FEATURE FLAG IS ON — this banner is rendered from a backend Unleash flag 🚩
+                </div>
+            )}
             <PlainChat user={user} />
             <RouterProvider router={router} />
             <Toaster />


### PR DESCRIPTION
Add a demo-banner Unleash flag evaluated on the backend and surfaced to the dashboard via /api/v1/meta. Renders an obvious banner when the flag is on, since the frontend has no Unleash client yet.

<!-- Describe the problem and your solution --> 

<!-- Issue ticket number and link (if applicable) -->

<!-- Testing instructions (skip if just adding/editing providers) -->



<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/NangoHQ/nango/pull/6654?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

