### PR TITLE
feat(mcp): register control-plane MCP server

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -5326,9 +5326,9 @@
             }
         },
         "node_modules/@modelcontextprotocol/sdk": {
-            "version": "1.26.0",
-            "resolved": "https://registry.npmjs.org/@modelcontextprotocol/sdk/-/sdk-1.26.0.tgz",
-            "integrity": "sha512-Y5RmPncpiDtTXDbLKswIJzTqu2hyBKxTNsgKqKclDbhIgg1wgtf1fRuvxgTnRfcnxtvvgbIEcqUOzZrJ6iSReg==",
+            "version": "1.29.0",
+            "resolved": "https://registry.npmjs.org/@modelcontextprotocol/sdk/-/sdk-1.29.0.tgz",
+            "integrity": "sha512-zo37mZA9hJWpULgkRpowewez1y6ML5GsXJPY8FI0tBBCd77HEvza4jDqRKOXgHNn867PVGCyTdzqpz0izu5ZjQ==",
             "license": "MIT",
             "dependencies": {
                 "@hono/node-server": "^1.19.9",
@@ -37307,7 +37307,7 @@
             "license": "SEE LICENSE IN LICENSE FILE IN GIT REPOSITORY",
             "dependencies": {
                 "@aws-sdk/client-sqs": "3.993.0",
-                "@modelcontextprotocol/sdk": "1.26.0",
+                "@modelcontextprotocol/sdk": "1.29.0",
                 "@nangohq/authz": "file:../authz",
                 "@nangohq/billing": "file:../billing",
                 "@nangohq/database": "file:../database",
@@ -37602,7 +37602,7 @@
                 "@babel/traverse": "7.28.0",
                 "@babel/types": "7.28.2",
                 "@hapi/boom": "10.0.1",
-                "@modelcontextprotocol/sdk": "1.26.0",
+                "@modelcontextprotocol/sdk": "1.29.0",
                 "@nangohq/database": "file:../database",
                 "@nangohq/egress": "file:../egress",
                 "@nangohq/feature-flags": "file:../feature-flags",

--- a/packages/server/lib/controllers/mcp/connectionTools.ts
+++ b/packages/server/lib/controllers/mcp/connectionTools.ts
@@ -6,10 +6,10 @@ import { zodErrorToHTTP } from '@nangohq/utils';
 
 import { connectionIdSchema, providerConfigKeySchema } from '../../helpers/validation.js';
 import { asyncWrapper } from '../../utils/asyncWrapper.js';
-import { createMcpServerForConnection } from './server.js';
+import { createConnectionToolsMcpServer } from './connectionToolsServer.js';
 
 import type { Transport } from '@modelcontextprotocol/sdk/shared/transport.js';
-import type { GetMcp, PostMcp } from '@nangohq/types';
+import type { GetConnectionToolsMcp, PostConnectionToolsMcp } from '@nangohq/types';
 
 export const validationHeaders = z
     .object({
@@ -18,7 +18,7 @@ export const validationHeaders = z
     })
     .strict();
 
-export const postMcp = asyncWrapper<PostMcp>(async (req, res) => {
+export const postConnectionToolsMcp = asyncWrapper<PostConnectionToolsMcp>(async (req, res) => {
     const valHeaders = validationHeaders.safeParse({ 'connection-id': req.get('connection-id'), 'provider-config-key': req.get('provider-config-key') });
     if (!valHeaders.success) {
         res.status(400).send({ error: { code: 'invalid_headers', errors: zodErrorToHTTP(valHeaders.error) } });
@@ -26,7 +26,7 @@ export const postMcp = asyncWrapper<PostMcp>(async (req, res) => {
     }
 
     const { environment, account } = res.locals;
-    const headers: PostMcp['Headers'] = valHeaders.data;
+    const headers: PostConnectionToolsMcp['Headers'] = valHeaders.data;
 
     const connectionId = headers['connection-id'];
     const providerConfigKey = headers['provider-config-key'];
@@ -40,7 +40,7 @@ export const postMcp = asyncWrapper<PostMcp>(async (req, res) => {
         return;
     }
 
-    const result = await createMcpServerForConnection(account, environment, connection, providerConfigKey);
+    const result = await createConnectionToolsMcpServer(account, environment, connection, providerConfigKey);
     if (result.isErr()) {
         res.status(500).send({ error: { code: 'Internal server error', message: result.error.message } });
         return;
@@ -60,7 +60,7 @@ export const postMcp = asyncWrapper<PostMcp>(async (req, res) => {
 });
 
 // We have to be explicit about not supporting SSE
-export const getMcp = asyncWrapper<GetMcp>((_, res) => {
+export const getConnectionToolsMcp = asyncWrapper<GetConnectionToolsMcp>((_, res) => {
     res.writeHead(405).end(
         JSON.stringify({
             jsonrpc: '2.0',

--- a/packages/server/lib/controllers/mcp/connectionToolsServer.ts
+++ b/packages/server/lib/controllers/mcp/connectionToolsServer.ts
@@ -15,7 +15,7 @@ import type { DBConnectionDecrypted, DBEnvironment, DBSyncConfig, DBTeam, Result
 import type { Span } from 'dd-trace';
 import type { JSONSchema7 } from 'json-schema';
 
-export async function createMcpServerForConnection(
+export async function createConnectionToolsMcpServer(
     account: DBTeam,
     environment: DBEnvironment,
     connection: DBConnectionDecrypted,
@@ -23,7 +23,7 @@ export async function createMcpServerForConnection(
 ): Promise<Result<Server>> {
     const server = new Server(
         {
-            name: 'Nango MCP server',
+            name: 'Nango Connection Tools MCP server',
             version: '1.0.0'
         },
         {

--- a/packages/server/lib/controllers/mcp/controlPlane.ts
+++ b/packages/server/lib/controllers/mcp/controlPlane.ts
@@ -1,0 +1,35 @@
+import { StreamableHTTPServerTransport } from '@modelcontextprotocol/sdk/server/streamableHttp.js';
+
+import { asyncWrapper } from '../../utils/asyncWrapper.js';
+import { createControlPlaneMcpServer } from './controlPlaneServer.js';
+
+import type { Transport } from '@modelcontextprotocol/sdk/shared/transport.js';
+import type { GetControlPlaneMcp, PostControlPlaneMcp } from '@nangohq/types';
+
+export const postControlPlaneMcp = asyncWrapper<PostControlPlaneMcp>(async (req, res) => {
+    const { account, environment } = res.locals;
+    const server = createControlPlaneMcpServer(account, environment, res.locals['apiKeyScopes']);
+    const transport: StreamableHTTPServerTransport = new StreamableHTTPServerTransport();
+
+    res.on('close', () => {
+        void transport.close();
+        void server.close();
+    });
+
+    await server.connect(transport as Transport);
+    await transport.handleRequest(req, res, req.body);
+});
+
+// We have to be explicit about not supporting SSE
+export const getControlPlaneMcp = asyncWrapper<GetControlPlaneMcp>((_, res) => {
+    res.writeHead(405).end(
+        JSON.stringify({
+            jsonrpc: '2.0',
+            error: {
+                code: -32000,
+                message: 'Method not allowed.'
+            },
+            id: null
+        })
+    );
+});

--- a/packages/server/lib/controllers/mcp/controlPlaneServer.ts
+++ b/packages/server/lib/controllers/mcp/controlPlaneServer.ts
@@ -1,0 +1,17 @@
+import { McpServer } from '@modelcontextprotocol/sdk/server/mcp.js';
+
+import type { DBEnvironment, DBTeam } from '@nangohq/types';
+
+export function createControlPlaneMcpServer(_account: DBTeam, _environment: DBEnvironment, _grantedScopes: string[] | undefined): McpServer {
+    return new McpServer(
+        {
+            name: 'Nango Control Plane MCP server',
+            version: '1.0.0'
+        },
+        {
+            capabilities: {
+                tools: {}
+            }
+        }
+    );
+}

--- a/packages/server/lib/routes.control-plane-mcp.ts
+++ b/packages/server/lib/routes.control-plane-mcp.ts
@@ -1,0 +1,53 @@
+import express from 'express';
+
+import { getControlPlaneMcp, postControlPlaneMcp } from './controllers/mcp/controlPlane.js';
+import { envs } from './env.js';
+import authMiddleware from './middleware/access.middleware.js';
+import { egressMeterMiddleware } from './middleware/egress-meter.middleware.js';
+import { jsonContentTypeMiddleware } from './middleware/json.middleware.js';
+import { rateLimiterMiddleware } from './middleware/ratelimit.middleware.js';
+
+import type { Request, RequestHandler } from 'express';
+
+const apiAuth: RequestHandler[] = [authMiddleware.secretKeyAuth.bind(authMiddleware), rateLimiterMiddleware, egressMeterMiddleware];
+const bodyLimit = envs.NANGO_SERVER_PUBLIC_BODY_LIMIT;
+const controlPlaneMcpRouter = express.Router();
+
+controlPlaneMcpRouter.use(
+    '/mcp',
+    express.json({
+        limit: bodyLimit,
+        verify: (req: Request, _, buf) => {
+            req.rawBody = buf.toString();
+        }
+    }),
+    jsonContentTypeMiddleware
+);
+controlPlaneMcpRouter.route('/mcp').post(apiAuth, postControlPlaneMcp);
+controlPlaneMcpRouter.route('/mcp').get(apiAuth, getControlPlaneMcp);
+controlPlaneMcpRouter.use((_, res) => {
+    res.status(404).json({ error: { code: 'not_found', message: 'Not found' } });
+});
+
+export const controlPlaneMcpAPI: RequestHandler = (req, res, next) => {
+    if (!isControlPlaneMcpHost(req.get('host') || '')) {
+        next();
+        return;
+    }
+
+    controlPlaneMcpRouter(req, res, next);
+};
+
+function isControlPlaneMcpHost(host: string): boolean {
+    if (!envs.NANGO_CONTROL_PLANE_MCP_SERVER_URL) {
+        return false;
+    }
+
+    const hostname = host.split(':')[0]?.toLowerCase();
+    if (!hostname) {
+        return false;
+    }
+
+    const controlPlaneMcpHostname = new URL(envs.NANGO_CONTROL_PLANE_MCP_SERVER_URL).hostname.toLowerCase();
+    return hostname === controlPlaneMcpHostname;
+}

--- a/packages/server/lib/routes.public.ts
+++ b/packages/server/lib/routes.public.ts
@@ -51,7 +51,7 @@ import { getPublicIntegrationFunction } from './controllers/integrations/uniqueK
 import { getPublicIntegrationFunctions } from './controllers/integrations/uniqueKey/functions/getFunctions.js';
 import { getPublicIntegration } from './controllers/integrations/uniqueKey/getIntegration.js';
 import { patchPublicIntegration } from './controllers/integrations/uniqueKey/patchIntegration.js';
-import { getMcp, postMcp } from './controllers/mcp/mcp.js';
+import { getConnectionToolsMcp, postConnectionToolsMcp } from './controllers/mcp/connectionTools.js';
 import oauthController from './controllers/oauth.controller.js';
 import { getPublicProvider } from './controllers/providers/getProvider.js';
 import { getPublicProviders } from './controllers/providers/getProviders.js';
@@ -288,8 +288,8 @@ publicAPI.route('/sync/:name/variant/:variant').delete(apiAuth, withScope('envir
 
 // MCP
 publicAPI.use('/mcp', jsonContentTypeMiddleware);
-publicAPI.route('/mcp').post(apiAuth, withScope('environment:mcp'), postMcp);
-publicAPI.route('/mcp').get(apiAuth, withScope('environment:mcp'), getMcp);
+publicAPI.route('/mcp').post(apiAuth, withScope('environment:mcp'), postConnectionToolsMcp);
+publicAPI.route('/mcp').get(apiAuth, withScope('environment:mcp'), getConnectionToolsMcp);
 
 // Scripts config
 publicAPI.use('/scripts', jsonContentTypeMiddleware);

--- a/packages/server/lib/routes.ts
+++ b/packages/server/lib/routes.ts
@@ -9,6 +9,7 @@ import { getProvidersJSON } from './controllers/v1/getProvidersJSON.js';
 import { rateLimiterMiddleware } from './middleware/ratelimit.middleware.js';
 import { securityMiddlewares } from './middleware/security.js';
 import { getReady } from './ready.js';
+import { controlPlaneMcpAPI } from './routes.control-plane-mcp.js';
 import { internalApi } from './routes.internal.js';
 import { privateApi } from './routes.private.js';
 import { publicAPI } from './routes.public.js';
@@ -32,6 +33,7 @@ router.get('/providers.json', rateLimiterMiddleware, getProvidersJSON);
 
 // Import main routers
 // Order is important because public API has no prefix
+router.use(controlPlaneMcpAPI);
 router.use('/api/v1', privateApi);
 router.use('/internal', internalApi);
 router.use('/', publicAPI);

--- a/packages/server/package.json
+++ b/packages/server/package.json
@@ -20,7 +20,7 @@
     "license": "SEE LICENSE IN LICENSE FILE IN GIT REPOSITORY",
     "dependencies": {
         "@aws-sdk/client-sqs": "3.993.0",
-        "@modelcontextprotocol/sdk": "1.26.0",
+        "@modelcontextprotocol/sdk": "1.29.0",
         "@nangohq/authz": "file:../authz",
         "@nangohq/billing": "file:../billing",
         "@nangohq/database": "file:../database",

--- a/packages/shared/package.json
+++ b/packages/shared/package.json
@@ -23,7 +23,7 @@
         "@babel/traverse": "7.28.0",
         "@babel/types": "7.28.2",
         "@hapi/boom": "10.0.1",
-        "@modelcontextprotocol/sdk": "1.26.0",
+        "@modelcontextprotocol/sdk": "1.29.0",
         "@nangohq/database": "file:../database",
         "@nangohq/egress": "file:../egress",
         "@nangohq/feature-flags": "file:../feature-flags",

--- a/packages/types/lib/mcp/api.ts
+++ b/packages/types/lib/mcp/api.ts
@@ -1,6 +1,6 @@
 import type { ApiError, Endpoint } from '../api.js';
 
-export type PostMcp = Endpoint<{
+export type PostConnectionToolsMcp = Endpoint<{
     Method: 'POST';
     Path: '/mcp';
     Body: Record<string, unknown>;
@@ -12,7 +12,20 @@ export type PostMcp = Endpoint<{
     Error: ApiError<'missing_connection_id' | 'unknown_connection'>;
 }>;
 
-export type GetMcp = Endpoint<{
+export type GetConnectionToolsMcp = Endpoint<{
+    Method: 'GET';
+    Path: '/mcp';
+    Success: Record<string, unknown>;
+}>;
+
+export type PostControlPlaneMcp = Endpoint<{
+    Method: 'POST';
+    Path: '/mcp';
+    Body: Record<string, unknown>;
+    Success: Record<string, unknown>;
+}>;
+
+export type GetControlPlaneMcp = Endpoint<{
     Method: 'GET';
     Path: '/mcp';
     Success: Record<string, unknown>;

--- a/packages/utils/lib/environment/parse.ts
+++ b/packages/utils/lib/environment/parse.ts
@@ -26,6 +26,7 @@ export const ENVS = z.object({
     NANGO_PORT: z.coerce.number().optional().default(3003), // Sync those two ports?
     SERVER_PORT: z.coerce.number().optional().default(3003),
     NANGO_SERVER_URL: z.url().optional(),
+    NANGO_CONTROL_PLANE_MCP_SERVER_URL: z.url().optional(),
     NANGO_SERVER_KEEP_ALIVE_TIMEOUT: z.coerce.number().optional().default(61_000),
     DEFAULT_RATE_LIMIT_PER_MIN: z.coerce.number().min(1).optional().default(200),
     NANGO_CACHE_ENV_KEYS: z.stringbool().optional().default(false),

--- a/packages/utils/lib/environment/parse.unit.test.ts
+++ b/packages/utils/lib/environment/parse.unit.test.ts
@@ -24,6 +24,11 @@ describe('parse', () => {
         expect(res.E2B_SANDBOX_COMPILER_TEMPLATE).toBe('blank-workspace:dev');
     });
 
+    it('should parse the control-plane MCP server URL', () => {
+        const res = parseEnvs(ENVS, { NANGO_CONTROL_PLANE_MCP_SERVER_URL: 'https://mcp-development.nango.dev' });
+        expect(res.NANGO_CONTROL_PLANE_MCP_SERVER_URL).toBe('https://mcp-development.nango.dev');
+    });
+
     it('should parse E2B sandbox metric settings', () => {
         const res = parseEnvs(ENVS, {
             E2B_SANDBOX_METRICS_POLL_INTERVAL_MS: '120000',


### PR DESCRIPTION
Summary:
- Register a new control-plane MCP router served from `NANGO_CONTROL_PLANE_MCP_SERVER_URL`.
- Rename the existing connection-scoped MCP internals to connection tools naming.

Stacked PR 1/3.

Next: https://github.com/NangoHQ/nango/pull/6660