### PR TITLE
feat(mcp): add logs list operations tool

### DIFF
--- a/packages/logs/lib/index.ts
+++ b/packages/logs/lib/index.ts
@@ -9,6 +9,6 @@ export * from './services/operations.service.js';
 export * from './otlp/otlp.js';
 export { OtlpSpan } from './otlp/otlpSpan.js';
 export { defaultOperationExpiration, envs } from './env.js';
-export { LogsDisabledError, LogsNotFoundError, ResponseError, destroy, isLogsDisabledError, isLogsNotFoundError, throwLogsDisabled } from './utils.js';
+export { LogsDisabledError, LogsNotFoundError, ResponseError, destroy, isLogsDisabledError, isLogsNotFoundError } from './utils.js';
 export * from './formatters.js';
 export * from './transport.js';

--- a/packages/logs/lib/index.ts
+++ b/packages/logs/lib/index.ts
@@ -9,6 +9,6 @@ export * from './services/operations.service.js';
 export * from './otlp/otlp.js';
 export { OtlpSpan } from './otlp/otlpSpan.js';
 export { defaultOperationExpiration, envs } from './env.js';
-export { LogsDisabledError, LogsNotFoundError, ResponseError, destroy, isLogsDisabledError, isLogsNotFoundError } from './utils.js';
+export { LogsDisabledError, LogsNotFoundError, ResponseError, destroy, isLogsNotFoundError } from './utils.js';
 export * from './formatters.js';
 export * from './transport.js';

--- a/packages/logs/lib/index.ts
+++ b/packages/logs/lib/index.ts
@@ -9,6 +9,6 @@ export * from './services/operations.service.js';
 export * from './otlp/otlp.js';
 export { OtlpSpan } from './otlp/otlpSpan.js';
 export { defaultOperationExpiration, envs } from './env.js';
-export { LogsNotFoundError, ResponseError, destroy, isLogsNotFoundError } from './utils.js';
+export { LogsDisabledError, LogsNotFoundError, ResponseError, destroy, isLogsDisabledError, isLogsNotFoundError, throwLogsDisabled } from './utils.js';
 export * from './formatters.js';
 export * from './transport.js';

--- a/packages/logs/lib/index.ts
+++ b/packages/logs/lib/index.ts
@@ -5,6 +5,7 @@ export * from './models/logContextGetter.js';
 export * as modelMessages from './models/messages.js';
 export * as modelOperations from './models/operations.js';
 export * as modelInsights from './models/insights.js';
+export * from './services/operations.service.js';
 export * from './otlp/otlp.js';
 export { OtlpSpan } from './otlp/otlpSpan.js';
 export { defaultOperationExpiration, envs } from './env.js';

--- a/packages/logs/lib/services/operations.service.ts
+++ b/packages/logs/lib/services/operations.service.ts
@@ -30,10 +30,6 @@ export interface ListLogOperationsResult {
     };
 }
 
-interface ListLogOperationsSearchParams extends ListLogOperationsParams {
-    search: string;
-}
-
 export const logsOperationsService = {
     async listOperations(params: ListLogOperationsParams): Promise<Result<ListLogOperationsResult>> {
         if (!logsEnvs.NANGO_LOGS_ENABLED) {
@@ -41,15 +37,21 @@ export const logsOperationsService = {
         }
 
         try {
-            if (params.search) {
-                return Ok(await listOperationsWithMessageSearch({ ...params, search: params.search }));
+            const rawOps = await listOperationPage(params);
+            let operations = rawOps.items;
+
+            if (params.search && rawOps.items.length > 0) {
+                const bucket = await modelMessages.searchForMessagesInsideOperations({ search: params.search, operationsIds: rawOps.items.map((op) => op.id) });
+                const matched = new Set(bucket.items.map((item) => item.key));
+                operations = rawOps.items.filter((item) => matched.has(item.id));
             }
 
-            const rawOps = await listOperationPage(params);
             return Ok({
-                operations: rawOps.items,
+                operations,
                 pagination: {
-                    total: rawOps.count,
+                    // Message search is applied to one fetched operations page because it queries the messages index.
+                    // The limit bounds operations inspected, so this page can return fewer matches while still having a cursor.
+                    total: params.search ? operations.length : rawOps.count,
                     cursor: rawOps.cursor
                 }
             });
@@ -62,7 +64,7 @@ export const logsOperationsService = {
 type ListOperationPage = Awaited<ReturnType<typeof modelOperations.listOperations>>;
 
 async function listOperationPage(params: ListLogOperationsParams): Promise<ListOperationPage> {
-    return await modelOperations.listOperations({
+    return modelOperations.listOperations({
         accountId: params.accountId,
         environmentId: params.environmentId,
         limit: params.limit,
@@ -74,25 +76,4 @@ async function listOperationPage(params: ListLogOperationsParams): Promise<ListO
         period: params.period,
         cursor: params.cursor
     });
-}
-
-async function listOperationsWithMessageSearch(params: ListLogOperationsSearchParams): Promise<ListLogOperationsResult> {
-    const rawOps = await listOperationPage(params);
-    let operations = rawOps.items;
-
-    if (rawOps.items.length > 0) {
-        const bucket = await modelMessages.searchForMessagesInsideOperations({ search: params.search, operationsIds: rawOps.items.map((op) => op.id) });
-        const matched = new Set(bucket.items.map((item) => item.key));
-        operations = rawOps.items.filter((item) => matched.has(item.id));
-    }
-
-    return {
-        operations,
-        pagination: {
-            // Message search is applied to one fetched operations page because it queries the messages index.
-            // The limit bounds operations inspected, so this page can return fewer matches while still having a cursor.
-            total: operations.length,
-            cursor: rawOps.cursor
-        }
-    };
 }

--- a/packages/logs/lib/services/operations.service.ts
+++ b/packages/logs/lib/services/operations.service.ts
@@ -1,0 +1,85 @@
+import { Err, Ok } from '@nangohq/utils';
+
+import { envs as logsEnvs } from '../env.js';
+import * as modelMessages from '../models/messages.js';
+import * as modelOperations from '../models/operations.js';
+
+import type { OperationRow, SearchOperationsState, SearchOperationsType, SearchPeriod } from '@nangohq/types';
+import type { Result } from '@nangohq/utils';
+
+export interface ListLogOperationsParams {
+    accountId: number;
+    environmentId: number;
+    limit: number;
+    cursor?: string | null | undefined;
+    states?: SearchOperationsState[] | undefined;
+    types?: SearchOperationsType[] | undefined;
+    integrations?: string[] | undefined;
+    connections?: string[] | undefined;
+    syncs?: string[] | undefined;
+    period: SearchPeriod;
+    search?: string | undefined;
+}
+
+export interface ListLogOperationsResult {
+    operations: OperationRow[];
+    pagination: {
+        total: number;
+        cursor: string | null;
+    };
+}
+
+export class LogsDisabledError extends Error {
+    constructor() {
+        super('Nango logs are disabled');
+        this.name = 'LogsDisabledError';
+    }
+}
+
+export const logsOperationsService = {
+    async listOperations(params: ListLogOperationsParams): Promise<Result<ListLogOperationsResult>> {
+        if (!logsEnvs.NANGO_LOGS_ENABLED) {
+            return Err(new LogsDisabledError());
+        }
+
+        let rawOps: Awaited<ReturnType<typeof modelOperations.listOperations>>;
+        try {
+            rawOps = await modelOperations.listOperations({
+                accountId: params.accountId,
+                environmentId: params.environmentId,
+                limit: params.limit,
+                states: params.states,
+                types: params.types,
+                integrations: params.integrations,
+                connections: params.connections,
+                syncs: params.syncs,
+                period: params.period,
+                cursor: params.cursor
+            });
+        } catch (err) {
+            return Err(err);
+        }
+
+        let operations = rawOps.items;
+        if (params.search && rawOps.items.length > 0) {
+            try {
+                const bucket = await modelMessages.searchForMessagesInsideOperations({ search: params.search, operationsIds: rawOps.items.map((op) => op.id) });
+                const matched = new Set(bucket.items.map((item) => item.key));
+                operations = rawOps.items.filter((item) => matched.has(item.id));
+            } catch (err) {
+                return Err(err);
+            }
+        }
+
+        return Ok({
+            operations,
+            pagination: {
+                // With search, we fetch a page of operations first and then keep only the ones with matching messages.
+                // rawOps.count still counts every operation before that message filter. The real fix is to move
+                // message search into the operation query so the backend can return a filtered count and cursor.
+                total: params.search ? operations.length : rawOps.count,
+                cursor: rawOps.cursor
+            }
+        });
+    }
+};

--- a/packages/logs/lib/services/operations.service.ts
+++ b/packages/logs/lib/services/operations.service.ts
@@ -46,7 +46,7 @@ export const logsOperationsService = {
                 return Ok(await listOperationsWithMessageSearch({ ...params, search: params.search }));
             }
 
-            const rawOps = await listOperationPage(params, { limit: params.limit, cursor: params.cursor });
+            const rawOps = await listOperationPage(params);
             return Ok({
                 operations: rawOps.items,
                 pagination: {
@@ -62,23 +62,23 @@ export const logsOperationsService = {
 
 type ListOperationPage = Awaited<ReturnType<typeof modelOperations.listOperations>>;
 
-async function listOperationPage(params: ListLogOperationsParams, page: { limit: number; cursor?: string | null | undefined }): Promise<ListOperationPage> {
+async function listOperationPage(params: ListLogOperationsParams): Promise<ListOperationPage> {
     return await modelOperations.listOperations({
         accountId: params.accountId,
         environmentId: params.environmentId,
-        limit: page.limit,
+        limit: params.limit,
         states: params.states,
         types: params.types,
         integrations: params.integrations,
         connections: params.connections,
         syncs: params.syncs,
         period: params.period,
-        cursor: page.cursor
+        cursor: params.cursor
     });
 }
 
 async function listOperationsWithMessageSearch(params: ListLogOperationsSearchParams): Promise<ListLogOperationsResult> {
-    const rawOps = await listOperationPage(params, { limit: params.limit, cursor: params.cursor });
+    const rawOps = await listOperationPage(params);
     let operations = rawOps.items;
 
     if (rawOps.items.length > 0) {

--- a/packages/logs/lib/services/operations.service.ts
+++ b/packages/logs/lib/services/operations.service.ts
@@ -29,12 +29,7 @@ export interface ListLogOperationsResult {
     };
 }
 
-export class LogsDisabledError extends Error {
-    constructor() {
-        super('Nango logs are disabled');
-        this.name = 'LogsDisabledError';
-    }
-}
+export const logsDisabledErrorMessage = 'Nango logs are disabled';
 
 interface ListLogOperationsSearchParams extends ListLogOperationsParams {
     search: string;
@@ -43,7 +38,7 @@ interface ListLogOperationsSearchParams extends ListLogOperationsParams {
 export const logsOperationsService = {
     async listOperations(params: ListLogOperationsParams): Promise<Result<ListLogOperationsResult>> {
         if (!logsEnvs.NANGO_LOGS_ENABLED) {
-            return Err(new LogsDisabledError());
+            return Err(new Error(logsDisabledErrorMessage));
         }
 
         try {
@@ -83,33 +78,22 @@ async function listOperationPage(params: ListLogOperationsParams, page: { limit:
 }
 
 async function listOperationsWithMessageSearch(params: ListLogOperationsSearchParams): Promise<ListLogOperationsResult> {
-    const operations: OperationRow[] = [];
-    let cursor = params.cursor;
-    let nextCursor: string | null = null;
+    const rawOps = await listOperationPage(params, { limit: params.limit, cursor: params.cursor });
+    let operations = rawOps.items;
 
-    while (operations.length < params.limit) {
-        const rawOps = await listOperationPage(params, { limit: params.limit - operations.length, cursor });
-        nextCursor = rawOps.cursor;
-
-        if (rawOps.items.length > 0) {
-            const bucket = await modelMessages.searchForMessagesInsideOperations({ search: params.search, operationsIds: rawOps.items.map((op) => op.id) });
-            const matched = new Set(bucket.items.map((item) => item.key));
-            operations.push(...rawOps.items.filter((item) => matched.has(item.id)));
-        }
-
-        if (!rawOps.cursor || rawOps.items.length <= 0) {
-            break;
-        }
-        cursor = rawOps.cursor;
+    if (rawOps.items.length > 0) {
+        const bucket = await modelMessages.searchForMessagesInsideOperations({ search: params.search, operationsIds: rawOps.items.map((op) => op.id) });
+        const matched = new Set(bucket.items.map((item) => item.key));
+        operations = rawOps.items.filter((item) => matched.has(item.id));
     }
 
     return {
         operations,
         pagination: {
-            // Message search is applied after fetching operation pages because it queries the messages index.
-            // We only know how many matching operations were collected for this response without a cross-index query.
+            // Message search is applied to one fetched operations page because it queries the messages index.
+            // The limit bounds operations inspected, so this page can return fewer matches while still having a cursor.
             total: operations.length,
-            cursor: nextCursor
+            cursor: rawOps.cursor
         }
     };
 }

--- a/packages/logs/lib/services/operations.service.ts
+++ b/packages/logs/lib/services/operations.service.ts
@@ -3,6 +3,7 @@ import { Err, Ok } from '@nangohq/utils';
 import { envs as logsEnvs } from '../env.js';
 import * as modelMessages from '../models/messages.js';
 import * as modelOperations from '../models/operations.js';
+import { LogsDisabledError } from '../utils.js';
 
 import type { OperationRow, SearchOperationsState, SearchOperationsType, SearchPeriod } from '@nangohq/types';
 import type { Result } from '@nangohq/utils';
@@ -29,8 +30,6 @@ export interface ListLogOperationsResult {
     };
 }
 
-export const logsDisabledErrorMessage = 'Nango logs are disabled';
-
 interface ListLogOperationsSearchParams extends ListLogOperationsParams {
     search: string;
 }
@@ -38,7 +37,7 @@ interface ListLogOperationsSearchParams extends ListLogOperationsParams {
 export const logsOperationsService = {
     async listOperations(params: ListLogOperationsParams): Promise<Result<ListLogOperationsResult>> {
         if (!logsEnvs.NANGO_LOGS_ENABLED) {
-            return Err(new Error(logsDisabledErrorMessage));
+            return Err(new LogsDisabledError());
         }
 
         try {

--- a/packages/logs/lib/services/operations.service.ts
+++ b/packages/logs/lib/services/operations.service.ts
@@ -36,50 +36,80 @@ export class LogsDisabledError extends Error {
     }
 }
 
+interface ListLogOperationsSearchParams extends ListLogOperationsParams {
+    search: string;
+}
+
 export const logsOperationsService = {
     async listOperations(params: ListLogOperationsParams): Promise<Result<ListLogOperationsResult>> {
         if (!logsEnvs.NANGO_LOGS_ENABLED) {
             return Err(new LogsDisabledError());
         }
 
-        let rawOps: Awaited<ReturnType<typeof modelOperations.listOperations>>;
         try {
-            rawOps = await modelOperations.listOperations({
-                accountId: params.accountId,
-                environmentId: params.environmentId,
-                limit: params.limit,
-                states: params.states,
-                types: params.types,
-                integrations: params.integrations,
-                connections: params.connections,
-                syncs: params.syncs,
-                period: params.period,
-                cursor: params.cursor
+            if (params.search) {
+                return Ok(await listOperationsWithMessageSearch({ ...params, search: params.search }));
+            }
+
+            const rawOps = await listOperationPage(params, { limit: params.limit, cursor: params.cursor });
+            return Ok({
+                operations: rawOps.items,
+                pagination: {
+                    total: rawOps.count,
+                    cursor: rawOps.cursor
+                }
             });
         } catch (err) {
             return Err(err);
         }
-
-        let operations = rawOps.items;
-        if (params.search && rawOps.items.length > 0) {
-            try {
-                const bucket = await modelMessages.searchForMessagesInsideOperations({ search: params.search, operationsIds: rawOps.items.map((op) => op.id) });
-                const matched = new Set(bucket.items.map((item) => item.key));
-                operations = rawOps.items.filter((item) => matched.has(item.id));
-            } catch (err) {
-                return Err(err);
-            }
-        }
-
-        return Ok({
-            operations,
-            pagination: {
-                // With search, we fetch a page of operations first and then keep only the ones with matching messages.
-                // rawOps.count still counts every operation before that message filter. The real fix is to move
-                // message search into the operation query so the backend can return a filtered count and cursor.
-                total: params.search ? operations.length : rawOps.count,
-                cursor: rawOps.cursor
-            }
-        });
     }
 };
+
+type ListOperationPage = Awaited<ReturnType<typeof modelOperations.listOperations>>;
+
+async function listOperationPage(params: ListLogOperationsParams, page: { limit: number; cursor?: string | null | undefined }): Promise<ListOperationPage> {
+    return await modelOperations.listOperations({
+        accountId: params.accountId,
+        environmentId: params.environmentId,
+        limit: page.limit,
+        states: params.states,
+        types: params.types,
+        integrations: params.integrations,
+        connections: params.connections,
+        syncs: params.syncs,
+        period: params.period,
+        cursor: page.cursor
+    });
+}
+
+async function listOperationsWithMessageSearch(params: ListLogOperationsSearchParams): Promise<ListLogOperationsResult> {
+    const operations: OperationRow[] = [];
+    let cursor = params.cursor;
+    let nextCursor: string | null = null;
+
+    while (operations.length < params.limit) {
+        const rawOps = await listOperationPage(params, { limit: params.limit - operations.length, cursor });
+        nextCursor = rawOps.cursor;
+
+        if (rawOps.items.length > 0) {
+            const bucket = await modelMessages.searchForMessagesInsideOperations({ search: params.search, operationsIds: rawOps.items.map((op) => op.id) });
+            const matched = new Set(bucket.items.map((item) => item.key));
+            operations.push(...rawOps.items.filter((item) => matched.has(item.id)));
+        }
+
+        if (!rawOps.cursor || rawOps.items.length <= 0) {
+            break;
+        }
+        cursor = rawOps.cursor;
+    }
+
+    return {
+        operations,
+        pagination: {
+            // Message search is applied after fetching operation pages because it queries the messages index.
+            // We only know how many matching operations were collected for this response without a cross-index query.
+            total: operations.length,
+            cursor: nextCursor
+        }
+    };
+}

--- a/packages/logs/lib/services/operations.service.unit.test.ts
+++ b/packages/logs/lib/services/operations.service.unit.test.ts
@@ -3,7 +3,7 @@ import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 import { envs as logsEnvs } from '../env.js';
 import * as modelMessages from '../models/messages.js';
 import * as modelOperations from '../models/operations.js';
-import { LogsDisabledError, logsOperationsService } from './operations.service.js';
+import { logsDisabledErrorMessage, logsOperationsService } from './operations.service.js';
 
 import type { ListLogOperationsParams } from './operations.service.js';
 import type { OperationRow } from '@nangohq/types';
@@ -20,7 +20,7 @@ describe('logsOperationsService', () => {
         vi.restoreAllMocks();
     });
 
-    it('returns LogsDisabledError when logs are disabled', async () => {
+    it('returns an error when logs are disabled', async () => {
         logsEnvs.NANGO_LOGS_ENABLED = false;
         const listOperationsSpy = vi.spyOn(modelOperations, 'listOperations');
 
@@ -30,7 +30,7 @@ describe('logsOperationsService', () => {
         if (result.isOk()) {
             throw new Error('expected listOperations to fail');
         }
-        expect(result.error).toBeInstanceOf(LogsDisabledError);
+        expect(result.error).toStrictEqual(new Error(logsDisabledErrorMessage));
         expect(listOperationsSpy).not.toHaveBeenCalled();
     });
 
@@ -79,18 +79,11 @@ describe('logsOperationsService', () => {
         });
     });
 
-    it('continues paging operations until message search fills the requested limit', async () => {
+    it('returns a cursor when the searched operation page has more results but no message matches', async () => {
         const op1 = makeOperation('op-1');
         const op2 = makeOperation('op-2');
-        const op3 = makeOperation('op-3');
-        const listOperationsSpy = vi
-            .spyOn(modelOperations, 'listOperations')
-            .mockResolvedValueOnce({ count: 10, items: [op1, op2], cursor: 'cursor-page-2' })
-            .mockResolvedValueOnce({ count: 10, items: [op3], cursor: 'cursor-page-3' });
-        const searchMessagesSpy = vi
-            .spyOn(modelMessages, 'searchForMessagesInsideOperations')
-            .mockResolvedValueOnce({ items: [{ key: 'op-1', doc_count: 1 }] })
-            .mockResolvedValueOnce({ items: [{ key: 'op-3', doc_count: 1 }] });
+        const listOperationsSpy = vi.spyOn(modelOperations, 'listOperations').mockResolvedValue({ count: 10, items: [op1, op2], cursor: 'cursor-page-2' });
+        const searchMessagesSpy = vi.spyOn(modelMessages, 'searchForMessagesInsideOperations').mockResolvedValue({ items: [] });
         const params = { ...baseParams(), limit: 2, search: 'needle' };
 
         const result = await logsOperationsService.listOperations(params);
@@ -99,15 +92,14 @@ describe('logsOperationsService', () => {
         if (result.isErr()) {
             throw result.error;
         }
-        expect(listOperationsSpy).toHaveBeenNthCalledWith(1, { ...baseParams(), limit: 2 });
-        expect(listOperationsSpy).toHaveBeenNthCalledWith(2, { ...baseParams(), limit: 1, cursor: 'cursor-page-2' });
-        expect(searchMessagesSpy).toHaveBeenNthCalledWith(1, { search: 'needle', operationsIds: ['op-1', 'op-2'] });
-        expect(searchMessagesSpy).toHaveBeenNthCalledWith(2, { search: 'needle', operationsIds: ['op-3'] });
+        expect(listOperationsSpy).toHaveBeenCalledTimes(1);
+        expect(listOperationsSpy).toHaveBeenCalledWith({ ...baseParams(), limit: 2 });
+        expect(searchMessagesSpy).toHaveBeenCalledWith({ search: 'needle', operationsIds: ['op-1', 'op-2'] });
         expect(result.value).toStrictEqual({
-            operations: [op1, op3],
+            operations: [],
             pagination: {
-                total: 2,
-                cursor: 'cursor-page-3'
+                total: 0,
+                cursor: 'cursor-page-2'
             }
         });
     });

--- a/packages/logs/lib/services/operations.service.unit.test.ts
+++ b/packages/logs/lib/services/operations.service.unit.test.ts
@@ -1,0 +1,153 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+
+import { envs as logsEnvs } from '../env.js';
+import * as modelMessages from '../models/messages.js';
+import * as modelOperations from '../models/operations.js';
+import { LogsDisabledError, logsOperationsService } from './operations.service.js';
+
+import type { ListLogOperationsParams } from './operations.service.js';
+import type { OperationRow } from '@nangohq/types';
+
+describe('logsOperationsService', () => {
+    const previousLogsEnabled = logsEnvs.NANGO_LOGS_ENABLED;
+
+    beforeEach(() => {
+        logsEnvs.NANGO_LOGS_ENABLED = true;
+    });
+
+    afterEach(() => {
+        logsEnvs.NANGO_LOGS_ENABLED = previousLogsEnabled;
+        vi.restoreAllMocks();
+    });
+
+    it('returns LogsDisabledError when logs are disabled', async () => {
+        logsEnvs.NANGO_LOGS_ENABLED = false;
+        const listOperationsSpy = vi.spyOn(modelOperations, 'listOperations');
+
+        const result = await logsOperationsService.listOperations(baseParams());
+
+        expect(result.isErr()).toBe(true);
+        if (result.isOk()) {
+            throw new Error('expected listOperations to fail');
+        }
+        expect(result.error).toBeInstanceOf(LogsDisabledError);
+        expect(listOperationsSpy).not.toHaveBeenCalled();
+    });
+
+    it('lists operations with the provided params', async () => {
+        const operations = [makeOperation('op-1'), makeOperation('op-2')];
+        const rawOperations = { count: 10, items: operations, cursor: 'cursor-next' } satisfies Awaited<ReturnType<typeof modelOperations.listOperations>>;
+        const listOperationsSpy = vi.spyOn(modelOperations, 'listOperations').mockResolvedValue(rawOperations);
+        const searchMessagesSpy = vi.spyOn(modelMessages, 'searchForMessagesInsideOperations');
+        const params = baseParams();
+
+        const result = await logsOperationsService.listOperations(params);
+
+        expect(result.isOk()).toBe(true);
+        if (result.isErr()) {
+            throw result.error;
+        }
+        expect(listOperationsSpy).toHaveBeenCalledWith(params);
+        expect(searchMessagesSpy).not.toHaveBeenCalled();
+        expect(result.value).toStrictEqual({
+            operations,
+            pagination: {
+                total: rawOperations.count,
+                cursor: rawOperations.cursor
+            }
+        });
+    });
+
+    it('filters operations by matching messages when search is provided', async () => {
+        const operations = [makeOperation('op-1'), makeOperation('op-2'), makeOperation('op-3')];
+        vi.spyOn(modelOperations, 'listOperations').mockResolvedValue({ count: 10, items: operations, cursor: 'cursor-next' });
+        const searchMessagesSpy = vi.spyOn(modelMessages, 'searchForMessagesInsideOperations').mockResolvedValue({ items: [{ key: 'op-2', doc_count: 2 }] });
+
+        const result = await logsOperationsService.listOperations({ ...baseParams(), search: 'needle' });
+
+        expect(result.isOk()).toBe(true);
+        if (result.isErr()) {
+            throw result.error;
+        }
+        expect(searchMessagesSpy).toHaveBeenCalledWith({ search: 'needle', operationsIds: ['op-1', 'op-2', 'op-3'] });
+        expect(result.value).toStrictEqual({
+            operations: [operations[1]],
+            pagination: {
+                total: 1,
+                cursor: 'cursor-next'
+            }
+        });
+    });
+
+    it('does not search messages when no operations are returned', async () => {
+        vi.spyOn(modelOperations, 'listOperations').mockResolvedValue({ count: 0, items: [], cursor: null });
+        const searchMessagesSpy = vi.spyOn(modelMessages, 'searchForMessagesInsideOperations');
+
+        const result = await logsOperationsService.listOperations({ ...baseParams(), search: 'needle' });
+
+        expect(result.isOk()).toBe(true);
+        if (result.isErr()) {
+            throw result.error;
+        }
+        expect(searchMessagesSpy).not.toHaveBeenCalled();
+        expect(result.value).toStrictEqual({
+            operations: [],
+            pagination: {
+                total: 0,
+                cursor: null
+            }
+        });
+    });
+
+    it('returns model errors', async () => {
+        const error = new Error('model failed');
+        vi.spyOn(modelOperations, 'listOperations').mockRejectedValue(error);
+
+        const result = await logsOperationsService.listOperations(baseParams());
+
+        expect(result.isErr()).toBe(true);
+        if (result.isOk()) {
+            throw new Error('expected listOperations to fail');
+        }
+        expect(result.error).toBe(error);
+    });
+});
+
+function baseParams(): ListLogOperationsParams {
+    return {
+        accountId: 1,
+        environmentId: 2,
+        limit: 25,
+        cursor: 'cursor-in',
+        states: ['success'],
+        types: ['sync:run'],
+        integrations: ['github'],
+        connections: ['github-connection'],
+        syncs: ['github-sync'],
+        period: {
+            from: '2026-01-01T00:00:00.000Z',
+            to: '2026-01-02T00:00:00.000Z'
+        }
+    };
+}
+
+function makeOperation(id: string): OperationRow {
+    return {
+        id,
+        source: 'internal',
+        level: 'info',
+        type: 'operation',
+        message: `Operation ${id}`,
+        operation: { type: 'sync', action: 'run' },
+        state: 'success',
+        accountId: 1,
+        accountName: 'Account',
+        environmentId: 2,
+        environmentName: 'dev',
+        createdAt: '2026-01-01T00:00:00.000Z',
+        updatedAt: '2026-01-01T00:00:00.000Z',
+        startedAt: '2026-01-01T00:00:00.000Z',
+        endedAt: '2026-01-01T00:01:00.000Z',
+        expiresAt: '2026-01-08T00:00:00.000Z'
+    };
+}

--- a/packages/logs/lib/services/operations.service.unit.test.ts
+++ b/packages/logs/lib/services/operations.service.unit.test.ts
@@ -3,7 +3,8 @@ import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 import { envs as logsEnvs } from '../env.js';
 import * as modelMessages from '../models/messages.js';
 import * as modelOperations from '../models/operations.js';
-import { logsDisabledErrorMessage, logsOperationsService } from './operations.service.js';
+import { LogsDisabledError } from '../utils.js';
+import { logsOperationsService } from './operations.service.js';
 
 import type { ListLogOperationsParams } from './operations.service.js';
 import type { OperationRow } from '@nangohq/types';
@@ -20,7 +21,7 @@ describe('logsOperationsService', () => {
         vi.restoreAllMocks();
     });
 
-    it('returns an error when logs are disabled', async () => {
+    it('returns LogsDisabledError when logs are disabled', async () => {
         logsEnvs.NANGO_LOGS_ENABLED = false;
         const listOperationsSpy = vi.spyOn(modelOperations, 'listOperations');
 
@@ -30,7 +31,7 @@ describe('logsOperationsService', () => {
         if (result.isOk()) {
             throw new Error('expected listOperations to fail');
         }
-        expect(result.error).toStrictEqual(new Error(logsDisabledErrorMessage));
+        expect(result.error).toBeInstanceOf(LogsDisabledError);
         expect(listOperationsSpy).not.toHaveBeenCalled();
     });
 

--- a/packages/logs/lib/services/operations.service.unit.test.ts
+++ b/packages/logs/lib/services/operations.service.unit.test.ts
@@ -60,7 +60,7 @@ describe('logsOperationsService', () => {
 
     it('filters operations by matching messages when search is provided', async () => {
         const operations = [makeOperation('op-1'), makeOperation('op-2'), makeOperation('op-3')];
-        vi.spyOn(modelOperations, 'listOperations').mockResolvedValue({ count: 10, items: operations, cursor: 'cursor-next' });
+        vi.spyOn(modelOperations, 'listOperations').mockResolvedValue({ count: 10, items: operations, cursor: null });
         const searchMessagesSpy = vi.spyOn(modelMessages, 'searchForMessagesInsideOperations').mockResolvedValue({ items: [{ key: 'op-2', doc_count: 2 }] });
 
         const result = await logsOperationsService.listOperations({ ...baseParams(), search: 'needle' });
@@ -74,7 +74,40 @@ describe('logsOperationsService', () => {
             operations: [operations[1]],
             pagination: {
                 total: 1,
-                cursor: 'cursor-next'
+                cursor: null
+            }
+        });
+    });
+
+    it('continues paging operations until message search fills the requested limit', async () => {
+        const op1 = makeOperation('op-1');
+        const op2 = makeOperation('op-2');
+        const op3 = makeOperation('op-3');
+        const listOperationsSpy = vi
+            .spyOn(modelOperations, 'listOperations')
+            .mockResolvedValueOnce({ count: 10, items: [op1, op2], cursor: 'cursor-page-2' })
+            .mockResolvedValueOnce({ count: 10, items: [op3], cursor: 'cursor-page-3' });
+        const searchMessagesSpy = vi
+            .spyOn(modelMessages, 'searchForMessagesInsideOperations')
+            .mockResolvedValueOnce({ items: [{ key: 'op-1', doc_count: 1 }] })
+            .mockResolvedValueOnce({ items: [{ key: 'op-3', doc_count: 1 }] });
+        const params = { ...baseParams(), limit: 2, search: 'needle' };
+
+        const result = await logsOperationsService.listOperations(params);
+
+        expect(result.isOk()).toBe(true);
+        if (result.isErr()) {
+            throw result.error;
+        }
+        expect(listOperationsSpy).toHaveBeenNthCalledWith(1, { ...baseParams(), limit: 2 });
+        expect(listOperationsSpy).toHaveBeenNthCalledWith(2, { ...baseParams(), limit: 1, cursor: 'cursor-page-2' });
+        expect(searchMessagesSpy).toHaveBeenNthCalledWith(1, { search: 'needle', operationsIds: ['op-1', 'op-2'] });
+        expect(searchMessagesSpy).toHaveBeenNthCalledWith(2, { search: 'needle', operationsIds: ['op-3'] });
+        expect(result.value).toStrictEqual({
+            operations: [op1, op3],
+            pagination: {
+                total: 2,
+                cursor: 'cursor-page-3'
             }
         });
     });
@@ -97,6 +130,20 @@ describe('logsOperationsService', () => {
                 cursor: null
             }
         });
+    });
+
+    it('returns message search errors', async () => {
+        const error = new Error('message search failed');
+        vi.spyOn(modelOperations, 'listOperations').mockResolvedValue({ count: 1, items: [makeOperation('op-1')], cursor: null });
+        vi.spyOn(modelMessages, 'searchForMessagesInsideOperations').mockRejectedValue(error);
+
+        const result = await logsOperationsService.listOperations({ ...baseParams(), search: 'needle' });
+
+        expect(result.isErr()).toBe(true);
+        if (result.isOk()) {
+            throw new Error('expected listOperations to fail');
+        }
+        expect(result.error).toBe(error);
     });
 
     it('returns model errors', async () => {

--- a/packages/logs/lib/utils.ts
+++ b/packages/logs/lib/utils.ts
@@ -34,6 +34,13 @@ export class LogsNotFoundError extends Error {
     }
 }
 
+export class LogsDisabledError extends Error {
+    constructor() {
+        super('Nango logs are disabled');
+        this.name = 'LogsDisabledError';
+    }
+}
+
 export function isLogsNotFoundError(err: unknown): boolean {
     if (err instanceof LogsNotFoundError) {
         return true;
@@ -47,6 +54,14 @@ export function isLogsNotFoundError(err: unknown): boolean {
     return false;
 }
 
+export function isLogsDisabledError(err: unknown): boolean {
+    return err instanceof LogsDisabledError;
+}
+
 export function throwLogsNotFound(): never {
     throw new LogsNotFoundError();
+}
+
+export function throwLogsDisabled(): never {
+    throw new LogsDisabledError();
 }

--- a/packages/logs/lib/utils.ts
+++ b/packages/logs/lib/utils.ts
@@ -61,7 +61,3 @@ export function isLogsDisabledError(err: unknown): boolean {
 export function throwLogsNotFound(): never {
     throw new LogsNotFoundError();
 }
-
-export function throwLogsDisabled(): never {
-    throw new LogsDisabledError();
-}

--- a/packages/logs/lib/utils.ts
+++ b/packages/logs/lib/utils.ts
@@ -54,10 +54,6 @@ export function isLogsNotFoundError(err: unknown): boolean {
     return false;
 }
 
-export function isLogsDisabledError(err: unknown): boolean {
-    return err instanceof LogsDisabledError;
-}
-
 export function throwLogsNotFound(): never {
     throw new LogsNotFoundError();
 }

--- a/packages/server/lib/controllers/mcp/controlPlane.integration.test.ts
+++ b/packages/server/lib/controllers/mcp/controlPlane.integration.test.ts
@@ -1,0 +1,277 @@
+import { request } from 'node:http';
+
+import { afterAll, beforeAll, describe, expect, it, vi } from 'vitest';
+
+import { logContextGetter } from '@nangohq/logs';
+import { seeders } from '@nangohq/shared';
+
+import type { authenticateUser as authenticateUserType, runServer as runServerType } from '../../utils/tests.js';
+import type { ApiKeyScope } from '@nangohq/types';
+
+type AuthenticateUser = typeof authenticateUserType;
+type RunServer = typeof runServerType;
+
+let originalControlPlaneMcpServerUrl: string | undefined;
+let authenticateUser: AuthenticateUser;
+let runServer: RunServer;
+let api: Awaited<ReturnType<RunServer>>;
+
+async function mcpFetch({
+    token,
+    method,
+    body,
+    host = 'mcp-development.nango.dev'
+}: {
+    token: string;
+    method: 'GET' | 'POST';
+    body?: Record<string, unknown>;
+    host?: string;
+}): Promise<{ status: number; json: any }> {
+    const url = new URL('/mcp', api.url);
+    const headers: Record<string, string> = {
+        Authorization: `Bearer ${token}`,
+        Host: host
+    };
+
+    if (body) {
+        headers['Accept'] = 'application/json, text/event-stream';
+        headers['content-type'] = 'application/json';
+    }
+
+    return await new Promise((resolve, reject) => {
+        const req = request(
+            {
+                hostname: url.hostname,
+                port: url.port,
+                path: url.pathname,
+                method,
+                headers
+            },
+            (res) => {
+                let data = '';
+                res.setEncoding('utf8');
+                res.on('data', (chunk) => {
+                    data += chunk;
+                });
+                res.on('end', () => {
+                    try {
+                        resolve({ status: res.statusCode ?? 0, json: parseMcpResponse(data) });
+                    } catch (err) {
+                        reject(err);
+                    }
+                });
+            }
+        );
+        req.on('error', reject);
+        if (body) {
+            req.write(JSON.stringify(body));
+        }
+        req.end();
+    });
+}
+
+async function mcpGet({ token, host = 'mcp-development.nango.dev' }: { token: string; host?: string }): Promise<{ status: number; json: any }> {
+    return await mcpFetch({ token, method: 'GET', host });
+}
+
+async function mcpPost({
+    token,
+    body,
+    host = 'mcp-development.nango.dev'
+}: {
+    token: string;
+    body: Record<string, unknown>;
+    host?: string;
+}): Promise<{ status: number; json: any }> {
+    return await mcpFetch({ token, method: 'POST', body, host });
+}
+
+function parseMcpResponse(data: string): any {
+    const trimmed = data.trim();
+    if (!trimmed) {
+        return {};
+    }
+    if (trimmed.startsWith('event:') || trimmed.startsWith('data:')) {
+        return parseServerSentEventJson(trimmed);
+    }
+
+    return JSON.parse(trimmed);
+}
+
+function parseServerSentEventJson(data: string): any {
+    for (const event of data.split(/\r?\n\r?\n/)) {
+        const payload = event
+            .split(/\r?\n/)
+            .filter((line) => line.startsWith('data:'))
+            .map((line) => line.slice('data:'.length).trimStart())
+            .join('\n');
+
+        if (payload) {
+            return JSON.parse(payload);
+        }
+    }
+
+    throw new Error('MCP SSE response did not contain a data payload');
+}
+
+async function createKeyWithScopes(scopes: ApiKeyScope[]) {
+    const { env, account, user } = await seeders.seedAccountEnvAndUser();
+    const session = await authenticateUser(api, user);
+    const res = await api.fetch('/api/v1/environment/api-keys', {
+        method: 'POST',
+        // @ts-expect-error query params are required
+        query: { env: env.name },
+        body: { display_name: 'test', scopes },
+        session
+    });
+    if ('error' in res.json) {
+        throw new Error(`Failed to create API key: ${JSON.stringify(res.json.error)}`);
+    }
+    return { secret: res.json.data.secret, env, account };
+}
+
+function parseToolText(res: any) {
+    return JSON.parse(res.json.result.content[0].text);
+}
+
+describe('POST /mcp control-plane server', () => {
+    beforeAll(async () => {
+        originalControlPlaneMcpServerUrl = process.env['NANGO_CONTROL_PLANE_MCP_SERVER_URL'];
+        process.env['NANGO_CONTROL_PLANE_MCP_SERVER_URL'] = 'https://mcp-development.nango.dev';
+
+        vi.resetModules();
+        ({ authenticateUser, runServer } = await import('../../utils/tests.js'));
+        api = await runServer();
+    });
+
+    afterAll(() => {
+        api.server.close();
+        if (originalControlPlaneMcpServerUrl === undefined) {
+            delete process.env['NANGO_CONTROL_PLANE_MCP_SERVER_URL'];
+        } else {
+            process.env['NANGO_CONTROL_PLANE_MCP_SERVER_URL'] = originalControlPlaneMcpServerUrl;
+        }
+    });
+
+    it('lists log tools with logs:read scope', async () => {
+        const { secret } = await createKeyWithScopes(['environment:logs:read']);
+        const res = await mcpPost({
+            token: secret,
+            body: { jsonrpc: '2.0', id: 1, method: 'tools/list', params: {} }
+        });
+
+        expect(res.status).toBe(200);
+        expect(res.json.result.tools.map((tool: { name: string }) => tool.name)).toStrictEqual(['logs_list_operations']);
+    });
+
+    it('returns the legacy MCP JSON-RPC error shape for GET requests', async () => {
+        const { secret } = await createKeyWithScopes(['environment:logs:read']);
+        const res = await mcpGet({ token: secret });
+
+        expect(res.status).toBe(405);
+        expect(res.json).toStrictEqual({
+            jsonrpc: '2.0',
+            error: {
+                code: -32000,
+                message: 'Method not allowed.'
+            },
+            id: null
+        });
+    });
+
+    it('does not grant logs tools with only the legacy mcp scope', async () => {
+        const { secret } = await createKeyWithScopes(['environment:mcp']);
+        const res = await mcpPost({
+            token: secret,
+            body: { jsonrpc: '2.0', id: 1, method: 'tools/list', params: {} }
+        });
+
+        expect(res.status).toBe(200);
+        expect(res.json.result.tools).toStrictEqual([]);
+    });
+
+    it('does not intercept the existing public API MCP hosts', async () => {
+        const { secret } = await createKeyWithScopes(['environment:logs:read']);
+        const res = await mcpPost({
+            token: secret,
+            host: 'api-development.nango.dev',
+            body: { jsonrpc: '2.0', id: 1, method: 'tools/list', params: {} }
+        });
+
+        expect(res.status).toBe(403);
+        expect(res.json.error).toMatchObject({
+            code: 'forbidden',
+            message: 'Insufficient scope. Required: environment:mcp'
+        });
+    });
+
+    it('lists operations for the authenticated environment', async () => {
+        const { secret, env, account } = await createKeyWithScopes(['environment:logs:read']);
+        const logCtx = await logContextGetter.create({ operation: { type: 'auth', action: 'create_connection' } }, { account, environment: env });
+        await logCtx.info('test info');
+        await logCtx.success();
+
+        const res = await mcpPost({
+            token: secret,
+            body: {
+                jsonrpc: '2.0',
+                id: 1,
+                method: 'tools/call',
+                params: {
+                    name: 'logs_list_operations',
+                    arguments: {
+                        limit: 10,
+                        states: ['success'],
+                        operations: [{ type: 'auth', actions: ['create_connection'] }]
+                    }
+                }
+            }
+        });
+
+        expect(res.status).toBe(200);
+        const payload = parseToolText(res);
+        expect(payload.operations).toHaveLength(1);
+        expect(payload.operations[0]).toMatchObject({
+            id: logCtx.id,
+            accountId: account.id,
+            environmentId: env.id,
+            state: 'success',
+            operation: { type: 'auth', action: 'create_connection' }
+        });
+        expect(payload.pagination).toStrictEqual({ total: 1, cursor: null });
+    });
+
+    it('returns filtered pagination totals when searching operation messages', async () => {
+        const { secret, env, account } = await createKeyWithScopes(['environment:logs:read']);
+        const matchingLogCtx = await logContextGetter.create({ operation: { type: 'auth', action: 'create_connection' } }, { account, environment: env });
+        await matchingLogCtx.info('needle message');
+        await matchingLogCtx.success();
+
+        const otherLogCtx = await logContextGetter.create({ operation: { type: 'auth', action: 'create_connection' } }, { account, environment: env });
+        await otherLogCtx.info('unrelated message');
+        await otherLogCtx.success();
+
+        const res = await mcpPost({
+            token: secret,
+            body: {
+                jsonrpc: '2.0',
+                id: 1,
+                method: 'tools/call',
+                params: {
+                    name: 'logs_list_operations',
+                    arguments: {
+                        limit: 10,
+                        search: 'needle'
+                    }
+                }
+            }
+        });
+
+        expect(res.status).toBe(200);
+        const payload = parseToolText(res);
+        expect(payload.operations).toHaveLength(1);
+        expect(payload.operations[0]).toMatchObject({ id: matchingLogCtx.id });
+        expect(payload.operations.map((operation: { id: string }) => operation.id)).not.toContain(otherLogCtx.id);
+        expect(payload.pagination).toStrictEqual({ total: 1, cursor: null });
+    });
+});

--- a/packages/server/lib/controllers/mcp/controlPlaneServer.ts
+++ b/packages/server/lib/controllers/mcp/controlPlaneServer.ts
@@ -25,8 +25,7 @@ export function createControlPlaneMcpServer(account: DBTeam, environment: DBEnvi
 
     const context = { account, environment, grantedScopes };
     for (const toolDefinition of controlPlaneMcpTools) {
-        // packages/server and the MCP SDK resolve different Zod versions. Schemas are runtime-compatible,
-        // but TypeScript cannot assign package-local Zod schemas to the SDK's AnySchema.
+        // Need to cast because we have a different Zod version than the MCP SDK
         const config = {
             description: toolDefinition.description,
             inputSchema: toolDefinition.inputSchema as unknown as AnySchema,

--- a/packages/server/lib/controllers/mcp/controlPlaneServer.ts
+++ b/packages/server/lib/controllers/mcp/controlPlaneServer.ts
@@ -5,6 +5,7 @@ import { logsListOperationsTool } from './logs/listOperations.js';
 import { handleMcpToolError, jsonStructuredContent } from './utils.js';
 
 import type { ControlPlaneMcpTool } from './controlPlaneTool.js';
+import type { AnySchema } from '@modelcontextprotocol/sdk/server/zod-compat.js';
 import type { ApiKeyScope, DBEnvironment, DBTeam } from '@nangohq/types';
 
 const controlPlaneMcpTools: ControlPlaneMcpTool[] = [logsListOperationsTool];
@@ -24,10 +25,12 @@ export function createControlPlaneMcpServer(account: DBTeam, environment: DBEnvi
 
     const context = { account, environment, grantedScopes };
     for (const toolDefinition of controlPlaneMcpTools) {
+        // packages/server and the MCP SDK resolve different Zod versions. Schemas are runtime-compatible,
+        // but TypeScript cannot assign package-local Zod schemas to the SDK's AnySchema.
         const config = {
             description: toolDefinition.description,
-            inputSchema: toolDefinition.inputSchema,
-            ...(toolDefinition.outputSchema ? { outputSchema: toolDefinition.outputSchema } : {})
+            inputSchema: toolDefinition.inputSchema as unknown as AnySchema,
+            ...(toolDefinition.outputSchema ? { outputSchema: toolDefinition.outputSchema as unknown as AnySchema } : {})
         };
         const registeredTool = server.registerTool(toolDefinition.name, config, async (args: unknown) => {
             try {

--- a/packages/server/lib/controllers/mcp/controlPlaneServer.ts
+++ b/packages/server/lib/controllers/mcp/controlPlaneServer.ts
@@ -1,9 +1,16 @@
 import { McpServer } from '@modelcontextprotocol/sdk/server/mcp.js';
 
-import type { DBEnvironment, DBTeam } from '@nangohq/types';
+import { hasScope } from '../../middleware/scope.middleware.js';
+import { logsListOperationsTool } from './logs/listOperations.js';
+import { handleMcpToolError, jsonStructuredContent } from './utils.js';
 
-export function createControlPlaneMcpServer(_account: DBTeam, _environment: DBEnvironment, _grantedScopes: string[] | undefined): McpServer {
-    return new McpServer(
+import type { ControlPlaneMcpTool } from './controlPlaneTool.js';
+import type { ApiKeyScope, DBEnvironment, DBTeam } from '@nangohq/types';
+
+const controlPlaneMcpTools: ControlPlaneMcpTool[] = [logsListOperationsTool];
+
+export function createControlPlaneMcpServer(account: DBTeam, environment: DBEnvironment, grantedScopes: string[] | undefined): McpServer {
+    const server = new McpServer(
         {
             name: 'Nango Control Plane MCP server',
             version: '1.0.0'
@@ -14,4 +21,36 @@ export function createControlPlaneMcpServer(_account: DBTeam, _environment: DBEn
             }
         }
     );
+
+    const context = { account, environment, grantedScopes };
+    for (const toolDefinition of controlPlaneMcpTools) {
+        const config = {
+            description: toolDefinition.description,
+            inputSchema: toolDefinition.inputSchema,
+            ...(toolDefinition.outputSchema ? { outputSchema: toolDefinition.outputSchema } : {})
+        };
+        const registeredTool = server.registerTool(toolDefinition.name, config, async (args: unknown) => {
+            try {
+                const result = await toolDefinition.handler(args, context);
+                if (result.isErr()) {
+                    return handleMcpToolError(result.error, toolDefinition.name);
+                }
+
+                return jsonStructuredContent(result.value);
+            } catch (err) {
+                return handleMcpToolError(err, toolDefinition.name);
+            }
+        });
+
+        if (!hasRequiredScopes({ grantedScopes, requiredScopes: toolDefinition.requiredScopes })) {
+            // Disabled tools are omitted from tools/list and rejected by the SDK if called.
+            registeredTool.disable();
+        }
+    }
+
+    return server;
+}
+
+function hasRequiredScopes({ grantedScopes, requiredScopes }: { grantedScopes: string[] | undefined; requiredScopes: ApiKeyScope[] }): boolean {
+    return requiredScopes.every((scope) => hasScope({ grantedScopes, requiredScope: scope }));
 }

--- a/packages/server/lib/controllers/mcp/controlPlaneServer.unit.test.ts
+++ b/packages/server/lib/controllers/mcp/controlPlaneServer.unit.test.ts
@@ -1,0 +1,195 @@
+import { Client } from '@modelcontextprotocol/sdk/client/index.js';
+import { InMemoryTransport } from '@modelcontextprotocol/sdk/inMemory.js';
+import { describe, expect, it, vi } from 'vitest';
+
+import { envs as logsEnvs } from '@nangohq/logs';
+import { Err, Ok } from '@nangohq/utils';
+
+import { createControlPlaneMcpServer } from './controlPlaneServer.js';
+import { logsListOperationsTool } from './logs/listOperations.js';
+import { PublicMcpError } from './utils.js';
+
+import type { McpServer } from '@modelcontextprotocol/sdk/server/mcp.js';
+import type { DBEnvironment, DBTeam } from '@nangohq/types';
+
+describe('createControlPlaneMcpServer', () => {
+    it('disables tools when required scopes are missing', async () => {
+        const handlerSpy = vi.spyOn(logsListOperationsTool, 'handler');
+        const { client, server } = await createTestClient(['environment:mcp']);
+
+        try {
+            await expect(client.listTools()).resolves.toStrictEqual({ tools: [] });
+            const result = await client.callTool({ name: 'logs_list_operations', arguments: {} });
+
+            expect(result).toStrictEqual({
+                content: [{ type: 'text', text: 'MCP error -32602: Tool logs_list_operations disabled' }],
+                isError: true
+            });
+            expect(handlerSpy).not.toHaveBeenCalled();
+        } finally {
+            handlerSpy.mockRestore();
+            await client.close();
+            await server.close();
+        }
+    });
+
+    it('wraps successful tool results as JSON text and structured content', async () => {
+        const response = {
+            operations: [],
+            pagination: { total: 0, cursor: null }
+        };
+        const handlerSpy = vi.spyOn(logsListOperationsTool, 'handler').mockResolvedValueOnce(Ok(response));
+        const { client, server } = await createTestClient(['environment:logs:read']);
+
+        try {
+            const result = await client.callTool({
+                name: 'logs_list_operations',
+                arguments: {}
+            });
+
+            expect(result).toStrictEqual({
+                content: [{ type: 'text', text: JSON.stringify(response, null, 2) }],
+                structuredContent: response
+            });
+            expect(handlerSpy).toHaveBeenCalledOnce();
+        } finally {
+            handlerSpy.mockRestore();
+            await client.close();
+            await server.close();
+        }
+    });
+
+    it('returns a tool error result when an enabled tool handler throws a public error', async () => {
+        const handlerSpy = vi.spyOn(logsListOperationsTool, 'handler').mockResolvedValueOnce(Err(new PublicMcpError('Operation not found')));
+        const { client, server } = await createTestClient(['environment:logs:read']);
+
+        try {
+            const result = await client.callTool({
+                name: 'logs_list_operations',
+                arguments: {}
+            });
+
+            expect(result).toStrictEqual({
+                content: [{ type: 'text', text: 'Operation not found' }],
+                isError: true
+            });
+            expect(handlerSpy).toHaveBeenCalledOnce();
+        } finally {
+            handlerSpy.mockRestore();
+            await client.close();
+            await server.close();
+        }
+    });
+
+    it('does not expose unexpected tool handler error messages returned as results', async () => {
+        const handlerSpy = vi.spyOn(logsListOperationsTool, 'handler').mockResolvedValueOnce(Err(new Error('sensitive internal error')));
+        const { client, server } = await createTestClient(['environment:logs:read']);
+
+        try {
+            const result = await client.callTool({
+                name: 'logs_list_operations',
+                arguments: {}
+            });
+
+            expect(result).toStrictEqual({
+                content: [{ type: 'text', text: 'Internal error' }],
+                isError: true
+            });
+            expect(handlerSpy).toHaveBeenCalledOnce();
+        } finally {
+            handlerSpy.mockRestore();
+            await client.close();
+            await server.close();
+        }
+    });
+
+    it('does not expose unexpected tool handler error messages', async () => {
+        const handlerSpy = vi.spyOn(logsListOperationsTool, 'handler').mockRejectedValueOnce(new Error('sensitive internal error'));
+        const { client, server } = await createTestClient(['environment:logs:read']);
+
+        try {
+            const result = await client.callTool({
+                name: 'logs_list_operations',
+                arguments: {}
+            });
+
+            expect(result).toStrictEqual({
+                content: [{ type: 'text', text: 'Internal error' }],
+                isError: true
+            });
+            expect(handlerSpy).toHaveBeenCalledOnce();
+        } finally {
+            handlerSpy.mockRestore();
+            await client.close();
+            await server.close();
+        }
+    });
+
+    it('returns an explicit public error for invalid logs list arguments', async () => {
+        const previousLogsEnabled = logsEnvs.NANGO_LOGS_ENABLED;
+        logsEnvs.NANGO_LOGS_ENABLED = true;
+
+        try {
+            await expect(
+                logsListOperationsTool.handler(
+                    { limit: 0 },
+                    { account: fakeAccount(), environment: fakeEnvironment(), grantedScopes: ['environment:logs:read'] }
+                )
+            ).resolves.toSatisfy((result) => result.isErr() && result.error.message.includes('Invalid logs_list_operations arguments'));
+        } finally {
+            logsEnvs.NANGO_LOGS_ENABLED = previousLogsEnabled;
+        }
+    });
+});
+
+async function createTestClient(grantedScopes: string[]): Promise<{ client: Client; server: McpServer }> {
+    const [clientTransport, serverTransport] = InMemoryTransport.createLinkedPair();
+    const server = createControlPlaneMcpServer(fakeAccount(), fakeEnvironment(), grantedScopes);
+    const client = new Client({ name: 'test-client', version: '1.0.0' });
+
+    await server.connect(serverTransport);
+    await client.connect(clientTransport);
+
+    return { client, server };
+}
+
+function fakeAccount(): DBTeam {
+    const now = new Date();
+    return {
+        id: 1,
+        name: 'Test Account',
+        uuid: 'test-account',
+        found_us: null,
+        created_at: now,
+        updated_at: now
+    };
+}
+
+function fakeEnvironment(): DBEnvironment {
+    const now = new Date();
+    return {
+        id: 1,
+        uuid: 'test-environment',
+        name: 'dev',
+        account_id: 1,
+        secret_key: 'secret',
+        public_key: 'public',
+        callback_url: null,
+        webhook_url: null,
+        webhook_url_secondary: null,
+        websockets_path: null,
+        hmac_enabled: false,
+        always_send_webhook: false,
+        send_auth_webhook: false,
+        hmac_key: null,
+        pending_secret_key: null,
+        slack_notifications: false,
+        webhook_receive_url: null,
+        otlp_settings: null,
+        is_production: false,
+        deleted_at: null,
+        deleted: false,
+        created_at: now,
+        updated_at: now
+    };
+}

--- a/packages/server/lib/controllers/mcp/controlPlaneServer.unit.test.ts
+++ b/packages/server/lib/controllers/mcp/controlPlaneServer.unit.test.ts
@@ -140,6 +140,19 @@ describe('createControlPlaneMcpServer', () => {
             logsEnvs.NANGO_LOGS_ENABLED = previousLogsEnabled;
         }
     });
+
+    it('returns an explicit public error when logs are disabled', async () => {
+        const previousLogsEnabled = logsEnvs.NANGO_LOGS_ENABLED;
+        logsEnvs.NANGO_LOGS_ENABLED = false;
+
+        try {
+            await expect(
+                logsListOperationsTool.handler({}, { account: fakeAccount(), environment: fakeEnvironment(), grantedScopes: ['environment:logs:read'] })
+            ).resolves.toSatisfy((result) => result.isErr() && result.error instanceof PublicMcpError && result.error.message === 'Nango logs are disabled');
+        } finally {
+            logsEnvs.NANGO_LOGS_ENABLED = previousLogsEnabled;
+        }
+    });
 });
 
 async function createTestClient(grantedScopes: string[]): Promise<{ client: Client; server: McpServer }> {

--- a/packages/server/lib/controllers/mcp/controlPlaneTool.ts
+++ b/packages/server/lib/controllers/mcp/controlPlaneTool.ts
@@ -1,0 +1,18 @@
+import type { AnySchema } from '@modelcontextprotocol/sdk/server/zod-compat.js';
+import type { ApiKeyScope, DBEnvironment, DBTeam } from '@nangohq/types';
+import type { Result } from '@nangohq/utils';
+
+export interface ControlPlaneMcpContext {
+    account: DBTeam;
+    environment: DBEnvironment;
+    grantedScopes: string[] | undefined;
+}
+
+export interface ControlPlaneMcpTool<TResponse extends object = object> {
+    name: string;
+    description: string;
+    inputSchema: AnySchema;
+    outputSchema?: AnySchema;
+    requiredScopes: ApiKeyScope[];
+    handler: (args: unknown, context: ControlPlaneMcpContext) => Promise<Result<TResponse>>;
+}

--- a/packages/server/lib/controllers/mcp/controlPlaneTool.ts
+++ b/packages/server/lib/controllers/mcp/controlPlaneTool.ts
@@ -1,6 +1,7 @@
 import type { AnySchema } from '@modelcontextprotocol/sdk/server/zod-compat.js';
 import type { ApiKeyScope, DBEnvironment, DBTeam } from '@nangohq/types';
 import type { Result } from '@nangohq/utils';
+import type * as z from 'zod/v4';
 
 export interface ControlPlaneMcpContext {
     account: DBTeam;
@@ -8,11 +9,17 @@ export interface ControlPlaneMcpContext {
     grantedScopes: string[] | undefined;
 }
 
+export type ControlPlaneMcpSchema = AnySchema | z.ZodType;
+
 export interface ControlPlaneMcpTool<TResponse extends object = object> {
     name: string;
     description: string;
-    inputSchema: AnySchema;
-    outputSchema?: AnySchema;
+    inputSchema: ControlPlaneMcpSchema;
+    outputSchema?: ControlPlaneMcpSchema;
     requiredScopes: ApiKeyScope[];
     handler: (args: unknown, context: ControlPlaneMcpContext) => Promise<Result<TResponse>>;
+}
+
+export function defineControlPlaneMcpTool<TResponse extends object>(tool: ControlPlaneMcpTool<TResponse>): ControlPlaneMcpTool<TResponse> {
+    return tool;
 }

--- a/packages/server/lib/controllers/mcp/logs/listOperations.ts
+++ b/packages/server/lib/controllers/mcp/logs/listOperations.ts
@@ -1,6 +1,6 @@
 import * as z from 'zod/v4';
 
-import { logsDisabledErrorMessage, logsOperationsService } from '@nangohq/logs';
+import { isLogsDisabledError, logsOperationsService } from '@nangohq/logs';
 import { Err, Ok } from '@nangohq/utils';
 
 import { defineControlPlaneMcpTool } from '../controlPlaneTool.js';
@@ -194,8 +194,8 @@ export const logsListOperationsTool = defineControlPlaneMcpTool<ListLogOperation
         });
 
         return result.mapError((error) => {
-            if (error.message === logsDisabledErrorMessage) {
-                return new PublicMcpError(logsDisabledErrorMessage);
+            if (isLogsDisabledError(error)) {
+                return new PublicMcpError(error.message);
             }
 
             return error;

--- a/packages/server/lib/controllers/mcp/logs/listOperations.ts
+++ b/packages/server/lib/controllers/mcp/logs/listOperations.ts
@@ -1,0 +1,272 @@
+import * as z from 'zod/v4';
+
+import { modelMessages, modelOperations } from '@nangohq/logs';
+import { Err, Ok } from '@nangohq/utils';
+
+import { PublicMcpError } from '../utils.js';
+import { checkLogsEnabled, defaultLimit, logsReadScope, maxLimit, normalizePeriod, periodSchema } from './utils.js';
+
+import type { ControlPlaneMcpTool } from '../controlPlaneTool.js';
+import type { AnySchema } from '@modelcontextprotocol/sdk/server/zod-compat.js';
+import type { DBEnvironment, DBTeam, OperationRow, SearchOperationsState, SearchOperationsType, SearchPeriod } from '@nangohq/types';
+import type { Result } from '@nangohq/utils';
+
+const defaultOperationsPeriodMs = 24 * 60 * 60 * 1000;
+
+const statesSchema = z
+    .array(z.enum(['waiting', 'running', 'success', 'failed', 'timeout', 'cancelled'] satisfies SearchOperationsState[]))
+    .max(10)
+    .optional();
+
+const actionOperationFilterSchema = z
+    .object({
+        type: z.literal('action'),
+        actions: z
+            .array(z.enum(['run']))
+            .min(1)
+            .max(1)
+            .optional()
+    })
+    .strict();
+
+const syncOperationFilterSchema = z
+    .object({
+        type: z.literal('sync'),
+        actions: z
+            .array(z.enum(['pause', 'unpause', 'run', 'request_run', 'request_run_full', 'cancel', 'init', 'create_variant', 'delete_variant']))
+            .min(1)
+            .max(9)
+            .optional()
+    })
+    .strict();
+
+const proxyOperationFilterSchema = z
+    .object({
+        type: z.literal('proxy'),
+        actions: z
+            .array(z.enum(['call']))
+            .min(1)
+            .max(1)
+            .optional()
+    })
+    .strict();
+
+const eventsOperationFilterSchema = z
+    .object({
+        type: z.literal('events'),
+        actions: z
+            .array(z.enum(['post_connection_creation', 'pre_connection_deletion', 'validate_connection']))
+            .min(1)
+            .max(3)
+            .optional()
+    })
+    .strict();
+
+const authOperationFilterSchema = z
+    .object({
+        type: z.literal('auth'),
+        actions: z
+            .array(z.enum(['create_connection', 'refresh_token', 'post_connection', 'connection_test']))
+            .min(1)
+            .max(4)
+            .optional()
+    })
+    .strict();
+
+const adminOperationFilterSchema = z
+    .object({
+        type: z.literal('admin'),
+        actions: z
+            .array(z.enum(['impersonation']))
+            .min(1)
+            .max(1)
+            .optional()
+    })
+    .strict();
+
+const webhookOperationFilterSchema = z
+    .object({
+        type: z.literal('webhook'),
+        actions: z
+            .array(z.enum(['incoming', 'forward', 'sync', 'connection_create', 'connection_refresh']))
+            .min(1)
+            .max(5)
+            .optional()
+    })
+    .strict();
+
+const deployOperationFilterSchema = z
+    .object({
+        type: z.literal('deploy'),
+        actions: z
+            .array(z.enum(['prebuilt', 'custom']))
+            .min(1)
+            .max(2)
+            .optional()
+    })
+    .strict();
+
+const operationFilterSchema = z.discriminatedUnion('type', [
+    actionOperationFilterSchema,
+    syncOperationFilterSchema,
+    proxyOperationFilterSchema,
+    eventsOperationFilterSchema,
+    authOperationFilterSchema,
+    adminOperationFilterSchema,
+    webhookOperationFilterSchema,
+    deployOperationFilterSchema
+]);
+
+const listOperationsArgumentsSchema = z
+    .object({
+        search: z.string().max(256).optional(),
+        limit: z.number().int().min(1).max(maxLimit).optional().default(defaultLimit),
+        cursor: z.string().nullable().optional(),
+        states: statesSchema,
+        operations: z.array(operationFilterSchema).max(20).optional(),
+        integrations: z.array(z.string().min(1).max(256)).max(20).optional(),
+        connections: z.array(z.string().min(1).max(256)).max(20).optional(),
+        syncs: z.array(z.string().min(1).max(256)).max(20).optional(),
+        period: periodSchema.optional()
+    })
+    .strict();
+
+const listOperationsOutputSchema = z
+    .object({
+        operations: z.array(z.object({}).passthrough()),
+        pagination: z
+            .object({
+                total: z.number(),
+                cursor: z.string().nullable()
+            })
+            .strict()
+    })
+    .strict();
+
+type ListOperationsArguments = z.infer<typeof listOperationsArgumentsSchema>;
+
+interface ListOperationsResponse {
+    operations: OperationRow[];
+    pagination: {
+        total: number;
+        cursor: string | null;
+    };
+}
+
+export const logsListOperationsTool: ControlPlaneMcpTool<ListOperationsResponse> = {
+    name: 'logs_list_operations',
+    description: [
+        'List Nango log operations.',
+        'Log operations are top-level execution records for syncs, actions, auth, webhooks, proxy calls, and other Nango activity; each operation contains its related log messages.',
+        'Results are newest first and can be filtered by status, operation, integration, connection, script, date range, and message search.'
+    ].join(' '),
+    inputSchema: listOperationsArgumentsSchema as unknown as AnySchema,
+    outputSchema: listOperationsOutputSchema as unknown as AnySchema,
+    requiredScopes: [logsReadScope],
+    async handler(args, { account, environment }) {
+        const logsEnabled = checkLogsEnabled();
+        if (logsEnabled.isErr()) {
+            return Err(logsEnabled.error);
+        }
+
+        return await listOperations({ account, environment, args });
+    }
+};
+
+function defaultOperationsPeriod(): SearchPeriod {
+    const to = new Date();
+    const from = new Date(to.getTime() - defaultOperationsPeriodMs);
+    return { from: from.toISOString(), to: to.toISOString() };
+}
+
+function normalizeOperations(filters: ListOperationsArguments['operations']): SearchOperationsType[] | undefined {
+    if (!filters || filters.length <= 0) {
+        return undefined;
+    }
+
+    const normalized = new Set<SearchOperationsType>();
+    for (const filter of filters) {
+        if (!filter.actions) {
+            normalized.add(filter.type);
+            continue;
+        }
+
+        for (const action of filter.actions) {
+            normalized.add(`${filter.type}:${action}` as SearchOperationsType);
+        }
+    }
+
+    return Array.from(normalized);
+}
+
+function normalizeFilterArray<T>(values: T[] | undefined): T[] | undefined {
+    return values && values.length > 0 ? values : undefined;
+}
+
+async function listOperations({
+    account,
+    environment,
+    args
+}: {
+    account: DBTeam;
+    environment: DBEnvironment;
+    args: unknown;
+}): Promise<Result<ListOperationsResponse>> {
+    const parsedArgs = listOperationsArgumentsSchema.safeParse(args ?? {});
+    if (!parsedArgs.success) {
+        return Err(new PublicMcpError(formatListOperationsArgumentsError(parsedArgs.error)));
+    }
+
+    const parsed = parsedArgs.data;
+    const period = parsed.period ? normalizePeriod(parsed.period) : defaultOperationsPeriod();
+    let rawOps: Awaited<ReturnType<typeof modelOperations.listOperations>>;
+    try {
+        rawOps = await modelOperations.listOperations({
+            accountId: account.id,
+            environmentId: environment.id,
+            limit: parsed.limit,
+            states: normalizeFilterArray(parsed.states),
+            types: normalizeOperations(parsed.operations),
+            integrations: normalizeFilterArray(parsed.integrations),
+            connections: normalizeFilterArray(parsed.connections),
+            syncs: normalizeFilterArray(parsed.syncs),
+            period,
+            cursor: parsed.cursor
+        });
+    } catch (err) {
+        return Err(err);
+    }
+
+    let operations = rawOps.items;
+    if (parsed.search && rawOps.items.length > 0) {
+        try {
+            const bucket = await modelMessages.searchForMessagesInsideOperations({ search: parsed.search, operationsIds: rawOps.items.map((op) => op.id) });
+            const matched = new Set(bucket.items.map((item) => item.key));
+            operations = rawOps.items.filter((item) => matched.has(item.id));
+        } catch (err) {
+            return Err(err);
+        }
+    }
+
+    return Ok({
+        operations,
+        pagination: {
+            // With search, we fetch a page of operations first and then keep only the ones with matching messages.
+            // rawOps.count still counts every operation before that message filter. The real fix is to move
+            // message search into the operation query so the backend can return a filtered count and cursor.
+            total: parsed.search ? operations.length : rawOps.count,
+            cursor: rawOps.cursor
+        }
+    });
+}
+
+function formatListOperationsArgumentsError(error: z.ZodError): string {
+    const details = error.issues
+        .map((issue) => {
+            const path = issue.path.length > 0 ? issue.path.map(String).join('.') : 'arguments';
+            return `${path}: ${issue.message}`;
+        })
+        .join('; ');
+
+    return details ? `Invalid logs_list_operations arguments: ${details}` : 'Invalid logs_list_operations arguments';
+}

--- a/packages/server/lib/controllers/mcp/logs/listOperations.ts
+++ b/packages/server/lib/controllers/mcp/logs/listOperations.ts
@@ -1,22 +1,20 @@
 import * as z from 'zod/v4';
 
-import { modelMessages, modelOperations } from '@nangohq/logs';
+import { LogsDisabledError, logsOperationsService } from '@nangohq/logs';
 import { Err, Ok } from '@nangohq/utils';
 
 import { defineControlPlaneMcpTool } from '../controlPlaneTool.js';
 import { PublicMcpError } from '../utils.js';
-import { checkLogsEnabled, defaultLimit, logsReadScope, maxLimit, normalizePeriod, periodSchema } from './utils.js';
+import { defaultLimit, logsReadScope, maxLimit, normalizePeriod, periodSchema } from './utils.js';
 
+import type { ListLogOperationsParams, ListLogOperationsResult } from '@nangohq/logs';
 import type {
-    DBEnvironment,
-    DBTeam,
     OperationAction,
     OperationAdmin,
     OperationAuth,
     OperationDeploy,
     OperationOnEvents,
     OperationProxy,
-    OperationRow,
     OperationSync,
     OperationWebhook,
     SearchOperationsState,
@@ -170,16 +168,9 @@ const listOperationsOutputSchema = z
     .strict();
 
 type ListOperationsArguments = z.infer<typeof listOperationsArgumentsSchema>;
+type ParsedListOperationsArguments = Omit<ListLogOperationsParams, 'accountId' | 'environmentId'>;
 
-interface ListOperationsResponse {
-    operations: OperationRow[];
-    pagination: {
-        total: number;
-        cursor: string | null;
-    };
-}
-
-export const logsListOperationsTool = defineControlPlaneMcpTool<ListOperationsResponse>({
+export const logsListOperationsTool = defineControlPlaneMcpTool<ListLogOperationsResult>({
     name: 'logs_list_operations',
     description: [
         'List Nango log operations.',
@@ -190,12 +181,24 @@ export const logsListOperationsTool = defineControlPlaneMcpTool<ListOperationsRe
     outputSchema: listOperationsOutputSchema,
     requiredScopes: [logsReadScope],
     async handler(args, { account, environment }) {
-        const logsEnabled = checkLogsEnabled();
-        if (logsEnabled.isErr()) {
-            return Err(logsEnabled.error);
+        const parsedArgs = parseListOperationsArguments(args);
+        if (parsedArgs.isErr()) {
+            return Err(parsedArgs.error);
         }
 
-        return listOperations({ account, environment, args });
+        const result = await logsOperationsService.listOperations({
+            accountId: account.id,
+            environmentId: environment.id,
+            ...parsedArgs.value
+        });
+
+        return result.mapError((error) => {
+            if (error instanceof LogsDisabledError) {
+                return new PublicMcpError(error.message);
+            }
+
+            return error;
+        });
     }
 });
 
@@ -229,15 +232,7 @@ function normalizeFilterArray<T>(values: T[] | undefined): T[] | undefined {
     return values && values.length > 0 ? values : undefined;
 }
 
-async function listOperations({
-    account,
-    environment,
-    args
-}: {
-    account: DBTeam;
-    environment: DBEnvironment;
-    args: unknown;
-}): Promise<Result<ListOperationsResponse>> {
+function parseListOperationsArguments(args: unknown): Result<ParsedListOperationsArguments> {
     const parsedArgs = listOperationsArgumentsSchema.safeParse(args ?? {});
     if (!parsedArgs.success) {
         return Err(new PublicMcpError(formatListOperationsArgumentsError(parsedArgs.error)));
@@ -245,44 +240,17 @@ async function listOperations({
 
     const parsed = parsedArgs.data;
     const period = parsed.period ? normalizePeriod(parsed.period) : defaultOperationsPeriod();
-    let rawOps: Awaited<ReturnType<typeof modelOperations.listOperations>>;
-    try {
-        rawOps = await modelOperations.listOperations({
-            accountId: account.id,
-            environmentId: environment.id,
-            limit: parsed.limit,
-            states: normalizeFilterArray(parsed.states),
-            types: normalizeOperations(parsed.operations),
-            integrations: normalizeFilterArray(parsed.integrations),
-            connections: normalizeFilterArray(parsed.connections),
-            syncs: normalizeFilterArray(parsed.syncs),
-            period,
-            cursor: parsed.cursor
-        });
-    } catch (err) {
-        return Err(err);
-    }
-
-    let operations = rawOps.items;
-    if (parsed.search && rawOps.items.length > 0) {
-        try {
-            const bucket = await modelMessages.searchForMessagesInsideOperations({ search: parsed.search, operationsIds: rawOps.items.map((op) => op.id) });
-            const matched = new Set(bucket.items.map((item) => item.key));
-            operations = rawOps.items.filter((item) => matched.has(item.id));
-        } catch (err) {
-            return Err(err);
-        }
-    }
 
     return Ok({
-        operations,
-        pagination: {
-            // With search, we fetch a page of operations first and then keep only the ones with matching messages.
-            // rawOps.count still counts every operation before that message filter. The real fix is to move
-            // message search into the operation query so the backend can return a filtered count and cursor.
-            total: parsed.search ? operations.length : rawOps.count,
-            cursor: rawOps.cursor
-        }
+        limit: parsed.limit,
+        cursor: parsed.cursor,
+        states: normalizeFilterArray(parsed.states),
+        types: normalizeOperations(parsed.operations),
+        integrations: normalizeFilterArray(parsed.integrations),
+        connections: normalizeFilterArray(parsed.connections),
+        syncs: normalizeFilterArray(parsed.syncs),
+        period,
+        search: parsed.search
     });
 }
 

--- a/packages/server/lib/controllers/mcp/logs/listOperations.ts
+++ b/packages/server/lib/controllers/mcp/logs/listOperations.ts
@@ -1,6 +1,6 @@
 import * as z from 'zod/v4';
 
-import { isLogsDisabledError, logsOperationsService } from '@nangohq/logs';
+import { LogsDisabledError, logsOperationsService } from '@nangohq/logs';
 import { Err, Ok } from '@nangohq/utils';
 
 import { defineControlPlaneMcpTool } from '../controlPlaneTool.js';
@@ -194,7 +194,7 @@ export const logsListOperationsTool = defineControlPlaneMcpTool<ListLogOperation
         });
 
         return result.mapError((error) => {
-            if (isLogsDisabledError(error)) {
+            if (error instanceof LogsDisabledError) {
                 return new PublicMcpError(error.message);
             }
 

--- a/packages/server/lib/controllers/mcp/logs/listOperations.ts
+++ b/packages/server/lib/controllers/mcp/logs/listOperations.ts
@@ -3,12 +3,26 @@ import * as z from 'zod/v4';
 import { modelMessages, modelOperations } from '@nangohq/logs';
 import { Err, Ok } from '@nangohq/utils';
 
+import { defineControlPlaneMcpTool } from '../controlPlaneTool.js';
 import { PublicMcpError } from '../utils.js';
 import { checkLogsEnabled, defaultLimit, logsReadScope, maxLimit, normalizePeriod, periodSchema } from './utils.js';
 
-import type { ControlPlaneMcpTool } from '../controlPlaneTool.js';
-import type { AnySchema } from '@modelcontextprotocol/sdk/server/zod-compat.js';
-import type { DBEnvironment, DBTeam, OperationRow, SearchOperationsState, SearchOperationsType, SearchPeriod } from '@nangohq/types';
+import type {
+    DBEnvironment,
+    DBTeam,
+    OperationAction,
+    OperationAdmin,
+    OperationAuth,
+    OperationDeploy,
+    OperationOnEvents,
+    OperationProxy,
+    OperationRow,
+    OperationSync,
+    OperationWebhook,
+    SearchOperationsState,
+    SearchOperationsType,
+    SearchPeriod
+} from '@nangohq/types';
 import type { Result } from '@nangohq/utils';
 
 const defaultOperationsPeriodMs = 24 * 60 * 60 * 1000;
@@ -22,7 +36,7 @@ const actionOperationFilterSchema = z
     .object({
         type: z.literal('action'),
         actions: z
-            .array(z.enum(['run']))
+            .array(z.enum(['run'] satisfies OperationAction['action'][]))
             .min(1)
             .max(1)
             .optional()
@@ -33,7 +47,19 @@ const syncOperationFilterSchema = z
     .object({
         type: z.literal('sync'),
         actions: z
-            .array(z.enum(['pause', 'unpause', 'run', 'request_run', 'request_run_full', 'cancel', 'init', 'create_variant', 'delete_variant']))
+            .array(
+                z.enum([
+                    'pause',
+                    'unpause',
+                    'run',
+                    'request_run',
+                    'request_run_full',
+                    'cancel',
+                    'init',
+                    'create_variant',
+                    'delete_variant'
+                ] satisfies OperationSync['action'][])
+            )
             .min(1)
             .max(9)
             .optional()
@@ -44,7 +70,7 @@ const proxyOperationFilterSchema = z
     .object({
         type: z.literal('proxy'),
         actions: z
-            .array(z.enum(['call']))
+            .array(z.enum(['call'] satisfies OperationProxy['action'][]))
             .min(1)
             .max(1)
             .optional()
@@ -55,7 +81,7 @@ const eventsOperationFilterSchema = z
     .object({
         type: z.literal('events'),
         actions: z
-            .array(z.enum(['post_connection_creation', 'pre_connection_deletion', 'validate_connection']))
+            .array(z.enum(['post_connection_creation', 'pre_connection_deletion', 'validate_connection'] satisfies OperationOnEvents['action'][]))
             .min(1)
             .max(3)
             .optional()
@@ -66,7 +92,7 @@ const authOperationFilterSchema = z
     .object({
         type: z.literal('auth'),
         actions: z
-            .array(z.enum(['create_connection', 'refresh_token', 'post_connection', 'connection_test']))
+            .array(z.enum(['create_connection', 'refresh_token', 'post_connection', 'connection_test'] satisfies OperationAuth['action'][]))
             .min(1)
             .max(4)
             .optional()
@@ -77,7 +103,7 @@ const adminOperationFilterSchema = z
     .object({
         type: z.literal('admin'),
         actions: z
-            .array(z.enum(['impersonation']))
+            .array(z.enum(['impersonation'] satisfies OperationAdmin['action'][]))
             .min(1)
             .max(1)
             .optional()
@@ -88,7 +114,7 @@ const webhookOperationFilterSchema = z
     .object({
         type: z.literal('webhook'),
         actions: z
-            .array(z.enum(['incoming', 'forward', 'sync', 'connection_create', 'connection_refresh']))
+            .array(z.enum(['incoming', 'forward', 'sync', 'connection_create', 'connection_refresh'] satisfies OperationWebhook['action'][]))
             .min(1)
             .max(5)
             .optional()
@@ -99,7 +125,7 @@ const deployOperationFilterSchema = z
     .object({
         type: z.literal('deploy'),
         actions: z
-            .array(z.enum(['prebuilt', 'custom']))
+            .array(z.enum(['prebuilt', 'custom'] satisfies OperationDeploy['action'][]))
             .min(1)
             .max(2)
             .optional()
@@ -133,7 +159,7 @@ const listOperationsArgumentsSchema = z
 
 const listOperationsOutputSchema = z
     .object({
-        operations: z.array(z.object({}).passthrough()),
+        operations: z.array(z.looseObject({})),
         pagination: z
             .object({
                 total: z.number(),
@@ -153,15 +179,15 @@ interface ListOperationsResponse {
     };
 }
 
-export const logsListOperationsTool: ControlPlaneMcpTool<ListOperationsResponse> = {
+export const logsListOperationsTool = defineControlPlaneMcpTool<ListOperationsResponse>({
     name: 'logs_list_operations',
     description: [
         'List Nango log operations.',
         'Log operations are top-level execution records for syncs, actions, auth, webhooks, proxy calls, and other Nango activity; each operation contains its related log messages.',
         'Results are newest first and can be filtered by status, operation, integration, connection, script, date range, and message search.'
     ].join(' '),
-    inputSchema: listOperationsArgumentsSchema as unknown as AnySchema,
-    outputSchema: listOperationsOutputSchema as unknown as AnySchema,
+    inputSchema: listOperationsArgumentsSchema,
+    outputSchema: listOperationsOutputSchema,
     requiredScopes: [logsReadScope],
     async handler(args, { account, environment }) {
         const logsEnabled = checkLogsEnabled();
@@ -169,9 +195,9 @@ export const logsListOperationsTool: ControlPlaneMcpTool<ListOperationsResponse>
             return Err(logsEnabled.error);
         }
 
-        return await listOperations({ account, environment, args });
+        return listOperations({ account, environment, args });
     }
-};
+});
 
 function defaultOperationsPeriod(): SearchPeriod {
     const to = new Date();

--- a/packages/server/lib/controllers/mcp/logs/listOperations.ts
+++ b/packages/server/lib/controllers/mcp/logs/listOperations.ts
@@ -1,6 +1,6 @@
 import * as z from 'zod/v4';
 
-import { LogsDisabledError, logsOperationsService } from '@nangohq/logs';
+import { logsDisabledErrorMessage, logsOperationsService } from '@nangohq/logs';
 import { Err, Ok } from '@nangohq/utils';
 
 import { defineControlPlaneMcpTool } from '../controlPlaneTool.js';
@@ -175,7 +175,8 @@ export const logsListOperationsTool = defineControlPlaneMcpTool<ListLogOperation
     description: [
         'List Nango log operations.',
         'Log operations are top-level execution records for syncs, actions, auth, webhooks, proxy calls, and other Nango activity; each operation contains its related log messages.',
-        'Results are newest first and can be filtered by status, operation, integration, connection, script, date range, and message search.'
+        'Results are newest first and can be filtered by status, operation, integration, connection, script, date range, and message search.',
+        'When message search is used, limit is the maximum number of operations inspected for one call, so the response can contain fewer or zero matching operations while still returning a pagination cursor for the next page.'
     ].join(' '),
     inputSchema: listOperationsArgumentsSchema,
     outputSchema: listOperationsOutputSchema,
@@ -193,8 +194,8 @@ export const logsListOperationsTool = defineControlPlaneMcpTool<ListLogOperation
         });
 
         return result.mapError((error) => {
-            if (error instanceof LogsDisabledError) {
-                return new PublicMcpError(error.message);
+            if (error.message === logsDisabledErrorMessage) {
+                return new PublicMcpError(logsDisabledErrorMessage);
             }
 
             return error;

--- a/packages/server/lib/controllers/mcp/logs/utils.ts
+++ b/packages/server/lib/controllers/mcp/logs/utils.ts
@@ -1,0 +1,35 @@
+import * as z from 'zod/v4';
+
+import { envs as logsEnvs } from '@nangohq/logs';
+import { Err, Ok } from '@nangohq/utils';
+
+import { PublicMcpError } from '../utils.js';
+
+import type { ApiKeyScope, SearchPeriod } from '@nangohq/types';
+import type { Result } from '@nangohq/utils';
+
+export const logsReadScope: ApiKeyScope = 'environment:logs:read';
+export const defaultLimit = 25;
+export const maxLimit = 500;
+
+export const periodSchema = z
+    .object({
+        from: z.string().datetime(),
+        to: z.string().datetime().optional()
+    })
+    .strict();
+
+export function checkLogsEnabled(): Result<void> {
+    if (!logsEnvs.NANGO_LOGS_ENABLED) {
+        return Err(new PublicMcpError('Nango logs are disabled'));
+    }
+
+    return Ok();
+}
+
+export function normalizePeriod(period: z.infer<typeof periodSchema>): SearchPeriod {
+    return {
+        from: period.from,
+        to: period.to ?? new Date().toISOString()
+    };
+}

--- a/packages/server/lib/controllers/mcp/logs/utils.ts
+++ b/packages/server/lib/controllers/mcp/logs/utils.ts
@@ -1,6 +1,6 @@
 import * as z from 'zod/v4';
 
-import { envs as logsEnvs } from '@nangohq/logs';
+import { logsDisabledErrorMessage, envs as logsEnvs } from '@nangohq/logs';
 import { Err, Ok } from '@nangohq/utils';
 
 import { PublicMcpError } from '../utils.js';
@@ -21,7 +21,7 @@ export const periodSchema = z
 
 export function checkLogsEnabled(): Result<void> {
     if (!logsEnvs.NANGO_LOGS_ENABLED) {
-        return Err(new PublicMcpError('Nango logs are disabled'));
+        return Err(new PublicMcpError(logsDisabledErrorMessage));
     }
 
     return Ok();

--- a/packages/server/lib/controllers/mcp/logs/utils.ts
+++ b/packages/server/lib/controllers/mcp/logs/utils.ts
@@ -1,12 +1,6 @@
 import * as z from 'zod/v4';
 
-import { LogsDisabledError, envs as logsEnvs } from '@nangohq/logs';
-import { Err, Ok } from '@nangohq/utils';
-
-import { PublicMcpError } from '../utils.js';
-
 import type { ApiKeyScope, SearchPeriod } from '@nangohq/types';
-import type { Result } from '@nangohq/utils';
 
 export const logsReadScope: ApiKeyScope = 'environment:logs:read';
 export const defaultLimit = 25;
@@ -18,14 +12,6 @@ export const periodSchema = z
         to: z.string().datetime().optional()
     })
     .strict();
-
-export function checkLogsEnabled(): Result<void> {
-    if (!logsEnvs.NANGO_LOGS_ENABLED) {
-        return Err(new PublicMcpError(new LogsDisabledError().message));
-    }
-
-    return Ok();
-}
 
 export function normalizePeriod(period: z.infer<typeof periodSchema>): SearchPeriod {
     return {

--- a/packages/server/lib/controllers/mcp/logs/utils.ts
+++ b/packages/server/lib/controllers/mcp/logs/utils.ts
@@ -1,6 +1,6 @@
 import * as z from 'zod/v4';
 
-import { logsDisabledErrorMessage, envs as logsEnvs } from '@nangohq/logs';
+import { LogsDisabledError, envs as logsEnvs } from '@nangohq/logs';
 import { Err, Ok } from '@nangohq/utils';
 
 import { PublicMcpError } from '../utils.js';
@@ -21,7 +21,7 @@ export const periodSchema = z
 
 export function checkLogsEnabled(): Result<void> {
     if (!logsEnvs.NANGO_LOGS_ENABLED) {
-        return Err(new PublicMcpError(logsDisabledErrorMessage));
+        return Err(new PublicMcpError(new LogsDisabledError().message));
     }
 
     return Ok();

--- a/packages/server/lib/controllers/mcp/utils.ts
+++ b/packages/server/lib/controllers/mcp/utils.ts
@@ -1,0 +1,46 @@
+import { getLogger } from '@nangohq/utils';
+
+import type { CallToolResult } from '@modelcontextprotocol/sdk/types.js';
+
+const logger = getLogger('Server.MCP');
+
+export class PublicMcpError extends Error {
+    constructor(message: string) {
+        super(message);
+        this.name = 'PublicMcpError';
+    }
+}
+
+export function jsonContent(data: unknown): CallToolResult {
+    return {
+        content: [
+            {
+                type: 'text',
+                text: JSON.stringify(data, null, 2)
+            }
+        ]
+    };
+}
+
+export function jsonStructuredContent(data: object): CallToolResult {
+    return {
+        ...jsonContent(data),
+        structuredContent: data as { [key: string]: unknown }
+    };
+}
+
+export function mcpToolError(message: string): CallToolResult {
+    return {
+        content: [{ type: 'text', text: message }],
+        isError: true
+    };
+}
+
+export function handleMcpToolError(err: unknown, toolName: string): CallToolResult {
+    if (err instanceof PublicMcpError) {
+        return mcpToolError(err.message);
+    }
+
+    logger.error('MCP tool handler failed', { err, toolName });
+    return mcpToolError('Internal error');
+}

--- a/packages/server/lib/middleware/scope.middleware.unit.test.ts
+++ b/packages/server/lib/middleware/scope.middleware.unit.test.ts
@@ -25,6 +25,7 @@ describe('hasScope', () => {
         expect(hasScope({ grantedScopes: ['environment:*'], requiredScope: 'environment:deploy' })).toBe(true);
         expect(hasScope({ grantedScopes: ['environment:*'], requiredScope: 'environment:integrations:list' })).toBe(true);
         expect(hasScope({ grantedScopes: ['environment:*'], requiredScope: 'environment:connections:read_credentials' })).toBe(true);
+        expect(hasScope({ grantedScopes: ['environment:*'], requiredScope: 'environment:logs:read' })).toBe(true);
     });
 
     it('group wildcard matches scopes within the group', () => {

--- a/packages/types/lib/api-keys/scopes.ts
+++ b/packages/types/lib/api-keys/scopes.ts
@@ -41,6 +41,8 @@ export const API_KEY_SCOPES = [
     'environment:records:read',
     'environment:records:write',
     'environment:records:*',
+    // Logs
+    'environment:logs:read',
     // Actions
     'environment:actions:execute',
     'environment:actions:*',

--- a/packages/utils/lib/api-key-scopes.ts
+++ b/packages/utils/lib/api-key-scopes.ts
@@ -43,6 +43,8 @@ export const apiKeyScopes = [
     'environment:records:read',
     'environment:records:write',
     'environment:records:*',
+    // Logs
+    'environment:logs:read',
     // Actions
     'environment:actions:execute',
     'environment:actions:*',

--- a/packages/webapp/src/pages/Environment/Settings/scope-logic.ts
+++ b/packages/webapp/src/pages/Environment/Settings/scope-logic.ts
@@ -62,6 +62,7 @@ export const SCOPE_GROUPS: ScopeGroup[] = [
             { value: 'environment:records:write', label: 'write' }
         ]
     },
+    { group: 'Logs', items: [{ value: 'environment:logs:read', label: 'read' }] },
     { group: 'Actions', items: [{ value: 'environment:actions:execute', label: 'execute' }] },
     { group: 'Proxy', items: [{ value: 'environment:proxy', label: 'proxy' }] },
     { group: 'Variables', items: [{ value: 'environment:variables:read', label: 'read' }] },


### PR DESCRIPTION
Summary:
- Add `logs_list_operations` for listing Nango log operations with UI-aligned filters.

Stacked PR 2/3.

Previous: https://github.com/NangoHQ/nango/pull/6659
Next: https://github.com/NangoHQ/nango/pull/6661