### PR TITLE
feat(mcp): add logs get operation tool

### DIFF
--- a/packages/logs/lib/services/operations.service.ts
+++ b/packages/logs/lib/services/operations.service.ts
@@ -3,9 +3,9 @@ import { Err, Ok } from '@nangohq/utils';
 import { envs as logsEnvs } from '../env.js';
 import * as modelMessages from '../models/messages.js';
 import * as modelOperations from '../models/operations.js';
-import { LogsDisabledError } from '../utils.js';
+import { LogsDisabledError, LogsNotFoundError } from '../utils.js';
 
-import type { OperationRow, SearchOperationsState, SearchOperationsType, SearchPeriod } from '@nangohq/types';
+import type { MessageRow, OperationRow, SearchOperationsState, SearchOperationsType, SearchPeriod } from '@nangohq/types';
 import type { Result } from '@nangohq/utils';
 
 export interface ListLogOperationsParams {
@@ -24,6 +24,27 @@ export interface ListLogOperationsParams {
 
 export interface ListLogOperationsResult {
     operations: OperationRow[];
+    pagination: {
+        total: number;
+        cursor: string | null;
+    };
+}
+
+export interface GetLogOperationParams {
+    accountId: number;
+    environmentId: number;
+    operationId: string;
+    messages: {
+        limit: number;
+        cursor?: string | null | undefined;
+        search?: string | undefined;
+        period?: SearchPeriod | undefined;
+    };
+}
+
+export interface GetLogOperationResult {
+    operation: OperationRow;
+    messages: MessageRow[];
     pagination: {
         total: number;
         cursor: string | null;
@@ -53,6 +74,38 @@ export const logsOperationsService = {
                     // The limit bounds operations inspected, so this page can return fewer matches while still having a cursor.
                     total: params.search ? operations.length : rawOps.count,
                     cursor: rawOps.cursor
+                }
+            });
+        } catch (err) {
+            return Err(err);
+        }
+    },
+
+    async getOperation(params: GetLogOperationParams): Promise<Result<GetLogOperationResult>> {
+        if (!logsEnvs.NANGO_LOGS_ENABLED) {
+            return Err(new LogsDisabledError());
+        }
+
+        try {
+            const operation = await modelOperations.getOperation({ id: params.operationId });
+            if (operation.accountId !== params.accountId || operation.environmentId !== params.environmentId) {
+                return Err(new LogsNotFoundError());
+            }
+
+            const rawMessages = await modelMessages.listMessages({
+                parentId: params.operationId,
+                limit: params.messages.limit,
+                search: params.messages.search,
+                cursorAfter: params.messages.cursor,
+                period: params.messages.period
+            });
+
+            return Ok({
+                operation,
+                messages: rawMessages.items,
+                pagination: {
+                    total: rawMessages.count,
+                    cursor: rawMessages.cursorAfter
                 }
             });
         } catch (err) {

--- a/packages/logs/lib/services/operations.service.unit.test.ts
+++ b/packages/logs/lib/services/operations.service.unit.test.ts
@@ -3,11 +3,11 @@ import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 import { envs as logsEnvs } from '../env.js';
 import * as modelMessages from '../models/messages.js';
 import * as modelOperations from '../models/operations.js';
-import { LogsDisabledError } from '../utils.js';
+import { LogsDisabledError, LogsNotFoundError } from '../utils.js';
 import { logsOperationsService } from './operations.service.js';
 
-import type { ListLogOperationsParams } from './operations.service.js';
-import type { OperationRow } from '@nangohq/types';
+import type { GetLogOperationParams, ListLogOperationsParams } from './operations.service.js';
+import type { MessageRow, OperationRow } from '@nangohq/types';
 
 describe('logsOperationsService', () => {
     const previousLogsEnabled = logsEnvs.NANGO_LOGS_ENABLED;
@@ -151,6 +151,86 @@ describe('logsOperationsService', () => {
         }
         expect(result.error).toBe(error);
     });
+
+    it('returns LogsDisabledError when getting an operation and logs are disabled', async () => {
+        logsEnvs.NANGO_LOGS_ENABLED = false;
+        const getOperationSpy = vi.spyOn(modelOperations, 'getOperation');
+
+        const result = await logsOperationsService.getOperation(baseGetParams());
+
+        expect(result.isErr()).toBe(true);
+        if (result.isOk()) {
+            throw new Error('expected getOperation to fail');
+        }
+        expect(result.error).toBeInstanceOf(LogsDisabledError);
+        expect(getOperationSpy).not.toHaveBeenCalled();
+    });
+
+    it('gets one operation with messages', async () => {
+        const operation = makeOperation('op-1');
+        const messages = [makeMessage('msg-1', operation.id)];
+        const rawMessages = {
+            count: 1,
+            items: messages,
+            cursorAfter: 'cursor-after',
+            cursorBefore: 'cursor-before'
+        } satisfies Awaited<ReturnType<typeof modelMessages.listMessages>>;
+        const getOperationSpy = vi.spyOn(modelOperations, 'getOperation').mockResolvedValue(operation);
+        const listMessagesSpy = vi.spyOn(modelMessages, 'listMessages').mockResolvedValue(rawMessages);
+        const params = baseGetParams();
+
+        const result = await logsOperationsService.getOperation(params);
+
+        expect(result.isOk()).toBe(true);
+        if (result.isErr()) {
+            throw result.error;
+        }
+        expect(getOperationSpy).toHaveBeenCalledWith({ id: params.operationId });
+        expect(listMessagesSpy).toHaveBeenCalledWith({
+            parentId: params.operationId,
+            limit: params.messages.limit,
+            search: params.messages.search,
+            cursorAfter: params.messages.cursor,
+            period: params.messages.period
+        });
+        expect(result.value).toStrictEqual({
+            operation,
+            messages,
+            pagination: {
+                total: rawMessages.count,
+                cursor: rawMessages.cursorAfter
+            }
+        });
+    });
+
+    it('returns LogsNotFoundError when the operation belongs to another environment', async () => {
+        vi.spyOn(modelOperations, 'getOperation').mockResolvedValue({ ...makeOperation('op-1'), environmentId: 999 });
+        const listMessagesSpy = vi.spyOn(modelMessages, 'listMessages');
+
+        const result = await logsOperationsService.getOperation(baseGetParams());
+
+        expect(result.isErr()).toBe(true);
+        if (result.isOk()) {
+            throw new Error('expected getOperation to fail');
+        }
+        expect(result.error).toBeInstanceOf(LogsNotFoundError);
+        expect(listMessagesSpy).not.toHaveBeenCalled();
+    });
+
+    it('returns LogsNotFoundError when the operation does not exist', async () => {
+        const error = new LogsNotFoundError();
+        vi.spyOn(modelOperations, 'getOperation').mockRejectedValue(error);
+        const listMessagesSpy = vi.spyOn(modelMessages, 'listMessages');
+
+        const result = await logsOperationsService.getOperation(baseGetParams());
+
+        expect(result.isErr()).toBe(true);
+        if (result.isOk()) {
+            throw new Error('expected getOperation to fail');
+        }
+        expect(result.error).toBe(error);
+        expect(listMessagesSpy).not.toHaveBeenCalled();
+    });
 });
 
 function baseParams(): ListLogOperationsParams {
@@ -167,6 +247,23 @@ function baseParams(): ListLogOperationsParams {
         period: {
             from: '2026-01-01T00:00:00.000Z',
             to: '2026-01-02T00:00:00.000Z'
+        }
+    };
+}
+
+function baseGetParams(): GetLogOperationParams {
+    return {
+        accountId: 1,
+        environmentId: 2,
+        operationId: 'op-1',
+        messages: {
+            limit: 10,
+            cursor: 'cursor-in',
+            search: 'needle',
+            period: {
+                from: '2026-01-01T00:00:00.000Z',
+                to: '2026-01-02T00:00:00.000Z'
+            }
         }
     };
 }
@@ -189,5 +286,18 @@ function makeOperation(id: string): OperationRow {
         startedAt: '2026-01-01T00:00:00.000Z',
         endedAt: '2026-01-01T00:01:00.000Z',
         expiresAt: '2026-01-08T00:00:00.000Z'
+    };
+}
+
+function makeMessage(id: string, parentId: string): MessageRow {
+    return {
+        id,
+        source: 'user',
+        level: 'info',
+        type: 'log',
+        message: `Message ${id}`,
+        parentId,
+        accountId: 1,
+        createdAt: '2026-01-01T00:00:00.000Z'
     };
 }

--- a/packages/server/lib/controllers/mcp/controlPlane.integration.test.ts
+++ b/packages/server/lib/controllers/mcp/controlPlane.integration.test.ts
@@ -161,7 +161,7 @@ describe('POST /mcp control-plane server', () => {
         });
 
         expect(res.status).toBe(200);
-        expect(res.json.result.tools.map((tool: { name: string }) => tool.name)).toStrictEqual(['logs_list_operations']);
+        expect(res.json.result.tools.map((tool: { name: string }) => tool.name)).toStrictEqual(['logs_list_operations', 'logs_get_operation']);
     });
 
     it('returns the legacy MCP JSON-RPC error shape for GET requests', async () => {
@@ -273,5 +273,44 @@ describe('POST /mcp control-plane server', () => {
         expect(payload.operations[0]).toMatchObject({ id: matchingLogCtx.id });
         expect(payload.operations.map((operation: { id: string }) => operation.id)).not.toContain(otherLogCtx.id);
         expect(payload.pagination).toStrictEqual({ total: 1, cursor: null });
+    });
+
+    it('gets an operation and its messages for the authenticated environment', async () => {
+        const { secret, env, account } = await createKeyWithScopes(['environment:logs:read']);
+        const logCtx = await logContextGetter.create({ operation: { type: 'proxy', action: 'call' } }, { account, environment: env });
+        await logCtx.info('test info');
+        await logCtx.success();
+
+        const res = await mcpPost({
+            token: secret,
+            body: {
+                jsonrpc: '2.0',
+                id: 1,
+                method: 'tools/call',
+                params: {
+                    name: 'logs_get_operation',
+                    arguments: {
+                        operationId: logCtx.id,
+                        messages: { limit: 10 }
+                    }
+                }
+            }
+        });
+
+        expect(res.status).toBe(200);
+        const payload = parseToolText(res);
+        expect(payload.operation).toMatchObject({
+            id: logCtx.id,
+            accountId: account.id,
+            environmentId: env.id,
+            operation: { type: 'proxy', action: 'call' }
+        });
+        expect(payload.messages).toHaveLength(1);
+        expect(payload.messages[0]).toMatchObject({
+            parentId: logCtx.id,
+            accountId: account.id,
+            message: 'test info'
+        });
+        expect(payload.pagination).toMatchObject({ total: 1, cursor: expect.any(String) });
     });
 });

--- a/packages/server/lib/controllers/mcp/controlPlaneServer.ts
+++ b/packages/server/lib/controllers/mcp/controlPlaneServer.ts
@@ -1,6 +1,7 @@
 import { McpServer } from '@modelcontextprotocol/sdk/server/mcp.js';
 
 import { hasScope } from '../../middleware/scope.middleware.js';
+import { logsGetOperationTool } from './logs/getOperation.js';
 import { logsListOperationsTool } from './logs/listOperations.js';
 import { handleMcpToolError, jsonStructuredContent } from './utils.js';
 
@@ -8,7 +9,7 @@ import type { ControlPlaneMcpTool } from './controlPlaneTool.js';
 import type { AnySchema } from '@modelcontextprotocol/sdk/server/zod-compat.js';
 import type { ApiKeyScope, DBEnvironment, DBTeam } from '@nangohq/types';
 
-const controlPlaneMcpTools: ControlPlaneMcpTool[] = [logsListOperationsTool];
+const controlPlaneMcpTools: ControlPlaneMcpTool[] = [logsListOperationsTool, logsGetOperationTool];
 
 export function createControlPlaneMcpServer(account: DBTeam, environment: DBEnvironment, grantedScopes: string[] | undefined): McpServer {
     const server = new McpServer(

--- a/packages/server/lib/controllers/mcp/controlPlaneServer.unit.test.ts
+++ b/packages/server/lib/controllers/mcp/controlPlaneServer.unit.test.ts
@@ -6,6 +6,7 @@ import { envs as logsEnvs } from '@nangohq/logs';
 import { Err, Ok } from '@nangohq/utils';
 
 import { createControlPlaneMcpServer } from './controlPlaneServer.js';
+import { logsGetOperationTool } from './logs/getOperation.js';
 import { logsListOperationsTool } from './logs/listOperations.js';
 import { PublicMcpError } from './utils.js';
 
@@ -149,6 +150,19 @@ describe('createControlPlaneMcpServer', () => {
             await expect(
                 logsListOperationsTool.handler({}, { account: fakeAccount(), environment: fakeEnvironment(), grantedScopes: ['environment:logs:read'] })
             ).resolves.toSatisfy((result) => result.isErr() && result.error instanceof PublicMcpError && result.error.message === 'Nango logs are disabled');
+        } finally {
+            logsEnvs.NANGO_LOGS_ENABLED = previousLogsEnabled;
+        }
+    });
+
+    it('returns an explicit public error for invalid get operation arguments', async () => {
+        const previousLogsEnabled = logsEnvs.NANGO_LOGS_ENABLED;
+        logsEnvs.NANGO_LOGS_ENABLED = true;
+
+        try {
+            await expect(
+                logsGetOperationTool.handler({}, { account: fakeAccount(), environment: fakeEnvironment(), grantedScopes: ['environment:logs:read'] })
+            ).resolves.toSatisfy((result) => result.isErr() && result.error.message.includes('Invalid logs_get_operation arguments'));
         } finally {
             logsEnvs.NANGO_LOGS_ENABLED = previousLogsEnabled;
         }

--- a/packages/server/lib/controllers/mcp/logs/getOperation.ts
+++ b/packages/server/lib/controllers/mcp/logs/getOperation.ts
@@ -1,0 +1,102 @@
+import * as z from 'zod/v4';
+
+import { isLogsNotFoundError, LogsDisabledError, logsOperationsService, operationIdRegex } from '@nangohq/logs';
+import { Err, Ok } from '@nangohq/utils';
+
+import { defineControlPlaneMcpTool } from '../controlPlaneTool.js';
+import { PublicMcpError } from '../utils.js';
+import { defaultLimit, logsReadScope, maxLimit, normalizePeriod, periodSchema } from './utils.js';
+
+import type { GetLogOperationParams, GetLogOperationResult } from '@nangohq/logs';
+import type { Result } from '@nangohq/utils';
+
+const getOperationArgumentsSchema = z
+    .object({
+        operationId: operationIdRegex,
+        messages: z
+            .object({
+                limit: z.number().int().min(1).max(maxLimit).optional().default(defaultLimit),
+                cursor: z.string().nullable().optional(),
+                search: z.string().max(100).optional(),
+                period: periodSchema.optional()
+            })
+            .strict()
+            .optional()
+    })
+    .strict();
+
+const getOperationOutputSchema = z
+    .object({
+        operation: z.looseObject({}),
+        messages: z.array(z.looseObject({})),
+        pagination: z
+            .object({
+                total: z.number(),
+                cursor: z.string().nullable()
+            })
+            .strict()
+    })
+    .strict();
+
+type ParsedGetOperationArguments = Omit<GetLogOperationParams, 'accountId' | 'environmentId'>;
+
+export const logsGetOperationTool = defineControlPlaneMcpTool<GetLogOperationResult>({
+    name: 'logs_get_operation',
+    description: 'Get one Nango log operation and a page of its message rows for the authenticated environment. Messages are returned newest first.',
+    inputSchema: getOperationArgumentsSchema,
+    outputSchema: getOperationOutputSchema,
+    requiredScopes: [logsReadScope],
+    async handler(args, { account, environment }) {
+        const parsedArgs = parseGetOperationArguments(args);
+        if (parsedArgs.isErr()) {
+            return Err(parsedArgs.error);
+        }
+
+        const result = await logsOperationsService.getOperation({
+            accountId: account.id,
+            environmentId: environment.id,
+            ...parsedArgs.value
+        });
+
+        return result.mapError((error) => {
+            if (error instanceof LogsDisabledError) {
+                return new PublicMcpError(error.message);
+            }
+
+            if (isLogsNotFoundError(error)) {
+                return new PublicMcpError('Operation not found');
+            }
+
+            return error;
+        });
+    }
+});
+
+function parseGetOperationArguments(args: unknown): Result<ParsedGetOperationArguments> {
+    const parsedArgs = getOperationArgumentsSchema.safeParse(args ?? {});
+    if (!parsedArgs.success) {
+        return Err(new PublicMcpError(formatGetOperationArgumentsError(parsedArgs.error)));
+    }
+
+    const parsed = parsedArgs.data;
+    return Ok({
+        operationId: parsed.operationId,
+        messages: {
+            limit: parsed.messages?.limit ?? defaultLimit,
+            cursor: parsed.messages?.cursor,
+            search: parsed.messages?.search,
+            period: parsed.messages?.period ? normalizePeriod(parsed.messages.period) : undefined
+        }
+    });
+}
+
+function formatGetOperationArgumentsError(error: z.ZodError): string {
+    const details = error.issues
+        .map((issue) => {
+            const path = issue.path.length > 0 ? issue.path.map(String).join('.') : 'arguments';
+            return `${path}: ${issue.message}`;
+        })
+        .join('; ');
+
+    return details ? `Invalid logs_get_operation arguments: ${details}` : 'Invalid logs_get_operation arguments';
+}


### PR DESCRIPTION
Summary:
- Add `logs_get_operation` control-plane MCP tool.

Stacked PR 3/3.

Previous: https://github.com/NangoHQ/nango/pull/6660



