### PR TITLE
refactor(webapp): adopt design-system Field for ad-hoc form labels

### DIFF
--- a/packages/webapp/src/components/patterns/DestructiveActionModal.tsx
+++ b/packages/webapp/src/components/patterns/DestructiveActionModal.tsx
@@ -1,6 +1,6 @@
-import { useState } from 'react';
+import { useId, useState } from 'react';
 
-import { Button, Input } from '@nangohq/design-system';
+import { Button, Field, FieldLabel, Input } from '@nangohq/design-system';
 
 import { Dialog, DialogClose, DialogContent, DialogDescription, DialogFooter, DialogTitle, DialogTrigger } from '../ui/Dialog';
 
@@ -30,6 +30,7 @@ export const DestructiveActionModal: React.FC<DestructiveActionModalProps> = ({
     onOpenChange
 }) => {
     const [confirmText, setConfirmText] = useState('');
+    const inputId = useId();
     const isConfirmed = confirmText === confirmationKeyword;
 
     return (
@@ -39,10 +40,18 @@ export const DestructiveActionModal: React.FC<DestructiveActionModalProps> = ({
                 <DialogTitle>{title}</DialogTitle>
                 <DialogDescription className="-mt-3">{description}</DialogDescription>
 
-                <div className="flex flex-col gap-2">
-                    <p className="text-sm text-text-strong break-words">{inputLabel}</p>
-                    <Input value={confirmText} onChange={(e) => setConfirmText(e.target.value)} placeholder="Enter confirmation text" className="w-full" />
-                </div>
+                <Field>
+                    <FieldLabel htmlFor={inputId} className="break-words">
+                        {inputLabel}
+                    </FieldLabel>
+                    <Input
+                        id={inputId}
+                        value={confirmText}
+                        onChange={(e) => setConfirmText(e.target.value)}
+                        placeholder="Enter confirmation text"
+                        className="w-full"
+                    />
+                </Field>
 
                 <DialogFooter>
                     <DialogClose asChild>

--- a/packages/webapp/src/features/Playground/PlaygroundInputs.tsx
+++ b/packages/webapp/src/features/Playground/PlaygroundInputs.tsx
@@ -1,6 +1,6 @@
 import { Braces, ExternalLink, Info } from 'lucide-react';
 
-import { Input } from '@nangohq/design-system';
+import { FieldLabel, Input } from '@nangohq/design-system';
 
 import { Alert, AlertActions, AlertButtonLink, AlertDescription } from '@/components/ui/Alert';
 import { CodeBlock } from '@/components/ui/CodeBlock';
@@ -36,7 +36,7 @@ export const PlaygroundInputs: React.FC<Props> = ({ env, queryEnv, isSync, input
     if (isSync) {
         return (
             <div className="grid grid-cols-[110px_1fr] gap-x-4">
-                <label className="text-text-strong text-label-large">Metadata</label>
+                <FieldLabel>Metadata</FieldLabel>
                 <div className="min-w-0 flex flex-col gap-3">
                     <Alert variant="info" className="px-3 py-2" actionsBelow>
                         <Info />
@@ -111,7 +111,7 @@ export const PlaygroundInputs: React.FC<Props> = ({ env, queryEnv, isSync, input
 
     return (
         <div className="grid grid-cols-[110px_1fr] gap-x-4">
-            <label className="text-text-strong text-label-large">Inputs</label>
+            <FieldLabel>Inputs</FieldLabel>
             <div className="min-w-0 flex flex-col gap-3">
                 {inputFields.map((field) => (
                     <div key={field.name} className="flex flex-col gap-1">

--- a/packages/webapp/src/features/Playground/PlaygroundSelectors.tsx
+++ b/packages/webapp/src/features/Playground/PlaygroundSelectors.tsx
@@ -3,7 +3,7 @@ import { useCallback, useMemo, useState } from 'react';
 import { useNavigate } from 'react-router-dom';
 import { useDebounce } from 'react-use';
 
-import { Button } from '@nangohq/design-system';
+import { Button, FieldLabel } from '@nangohq/design-system';
 
 import { IntegrationLogo } from '@/components/patterns/IntegrationLogo';
 import { Badge } from '@/components/ui/Badge';
@@ -135,7 +135,7 @@ export const PlaygroundSelectors: React.FC<Props> = ({ env, queryEnv }) => {
 
     return (
         <div className="grid grid-cols-[110px_1fr] items-center gap-x-4 gap-y-6">
-            <label className="text-text-strong text-label-large">Integration</label>
+            <FieldLabel>Integration</FieldLabel>
             <ComboboxSelect
                 value={playgroundIntegration || ''}
                 onValueChange={handleIntegrationChange}
@@ -163,7 +163,7 @@ export const PlaygroundSelectors: React.FC<Props> = ({ env, queryEnv }) => {
                 }
             />
 
-            <label className="text-text-strong text-label-large">Connection</label>
+            <FieldLabel>Connection</FieldLabel>
             <ComboboxSelect
                 value={playgroundConnection || ''}
                 onValueChange={handleConnectionChange}
@@ -193,7 +193,7 @@ export const PlaygroundSelectors: React.FC<Props> = ({ env, queryEnv }) => {
                 }
             />
 
-            <label className="text-text-strong text-label-large">Function</label>
+            <FieldLabel>Function</FieldLabel>
             <ComboboxSelect
                 value={playgroundFunction || ''}
                 onValueChange={handleFunctionChange}

--- a/packages/webapp/src/pages/Account/components/Password.tsx
+++ b/packages/webapp/src/pages/Account/components/Password.tsx
@@ -3,7 +3,7 @@ import { useMemo, useState } from 'react';
 import { useController, useFormContext } from 'react-hook-form';
 import z from 'zod';
 
-import { InputGroup, InputGroupInput } from '@nangohq/design-system';
+import { FieldDescription, InputGroup, InputGroupInput } from '@nangohq/design-system';
 
 import { FormControl, FormItem, FormMessage, useFormField } from '@/components/ui/Form';
 import { cn } from '@/utils/utils';
@@ -60,7 +60,7 @@ export const Password: React.FC<InputProps> = (props) => {
                 id="password-requirements"
                 className={cn('flex flex-col gap-1.5 overflow-hidden transition-[max-height] duration-200 ease-out', open ? 'max-h-40' : 'max-h-0 absolute')}
             >
-                <span className="text-body-small-regular text-text-strong">Password must contain:</span>
+                <FieldDescription>Password must contain:</FieldDescription>
                 <Requirement text="At least 12 characters" check={checks.length} />
                 <Requirement text="At least one uppercase letter" check={checks.uppercase} />
                 <Requirement text="At least one number" check={checks.number} />

--- a/packages/webapp/src/pages/Environment/Settings/ConnectUISettings/index.tsx
+++ b/packages/webapp/src/pages/Environment/Settings/ConnectUISettings/index.tsx
@@ -3,7 +3,7 @@ import { Info, Lock } from 'lucide-react';
 import React, { useRef } from 'react';
 
 import { permissions } from '@nangohq/authz';
-import { Button } from '@nangohq/design-system';
+import { Button, Field, FieldError, FieldLabel } from '@nangohq/design-system';
 
 import { PermissionGate } from '@/components/patterns/PermissionGate';
 import { ButtonLink } from '@/components/ui/ButtonLink';
@@ -19,7 +19,6 @@ import { usePermissions } from '@/hooks/usePermissions';
 import { useToast } from '@/hooks/useToast';
 import { useStore } from '@/store';
 import { globalEnv } from '@/utils/env';
-import { cn } from '@/utils/utils';
 import SettingsContent from '../components/SettingsContent';
 import { ConnectUIPreview } from './components/ConnectUIPreview';
 
@@ -32,51 +31,25 @@ const ThemeColorPickers: React.FC<{ disabled: boolean; form: any }> = ({ disable
     <>
         <form.Field name="theme.light.primary">
             {(field: any) => (
-                <div className="w-full flex flex-col gap-2">
-                    <label htmlFor={field.name} className={cn('text-sm flex items-center gap-1 text-body-medium-medium>', disabled ? 'text-text-muted' : '')}>
+                <Field>
+                    <FieldLabel htmlFor={field.name} className={disabled ? 'text-text-muted' : undefined}>
                         Primary (Light theme)
-                    </label>
-                    <div className="flex items-center">
-                        <div className="w-full flex flex-col gap-1">
-                            <ColorInput
-                                value={field.state.value}
-                                onChange={(e) => field.handleChange(e.target.value)}
-                                onBlur={field.handleBlur}
-                                disabled={disabled}
-                            />
-                            {!field.state.meta.isValid && (
-                                <em role="alert" className="text-body-small-regular text-status-danger-text">
-                                    {field.state.meta.errors.join(', ')}
-                                </em>
-                            )}
-                        </div>
-                    </div>
-                </div>
+                    </FieldLabel>
+                    <ColorInput value={field.state.value} onChange={(e) => field.handleChange(e.target.value)} onBlur={field.handleBlur} disabled={disabled} />
+                    {!field.state.meta.isValid && <FieldError>{field.state.meta.errors.join(', ')}</FieldError>}
+                </Field>
             )}
         </form.Field>
 
         <form.Field name="theme.dark.primary">
             {(field: any) => (
-                <div className="w-full flex flex-col gap-2">
-                    <label htmlFor={field.name} className={cn('text-sm flex items-center gap-1 text-body-medium-medium>', disabled ? 'text-text-muted' : '')}>
+                <Field>
+                    <FieldLabel htmlFor={field.name} className={disabled ? 'text-text-muted' : undefined}>
                         Primary (Dark theme)
-                    </label>
-                    <div className="flex items-center">
-                        <div className="w-full flex flex-col gap-1">
-                            <ColorInput
-                                value={field.state.value}
-                                onChange={(e) => field.handleChange(e.target.value)}
-                                onBlur={field.handleBlur}
-                                disabled={disabled}
-                            />
-                            {!field.state.meta.isValid && (
-                                <em role="alert" className="text-sm text-status-danger-text">
-                                    {field.state.meta.errors.join(', ')}
-                                </em>
-                            )}
-                        </div>
-                    </div>
-                </div>
+                    </FieldLabel>
+                    <ColorInput value={field.state.value} onChange={(e) => field.handleChange(e.target.value)} onBlur={field.handleBlur} disabled={disabled} />
+                    {!field.state.meta.isValid && <FieldError>{field.state.meta.errors.join(', ')}</FieldError>}
+                </Field>
             )}
         </form.Field>
     </>
@@ -85,21 +58,19 @@ const ThemeColorPickers: React.FC<{ disabled: boolean; form: any }> = ({ disable
 const WatermarkToggle: React.FC<{ disabled: boolean; form: any }> = ({ disabled, form }) => (
     <form.Field name="showWatermark">
         {(field: any) => (
-            <div className="flex gap-5 items-center">
-                <label htmlFor={field.name} className={cn('text-body-medium-medium', disabled ? 'text-text-muted' : '')}>
+            <Field orientation="horizontal" className="gap-5">
+                <FieldLabel htmlFor={field.name} className={disabled ? 'text-text-muted' : undefined}>
                     Show &quot;Secured by Nango&quot;
-                </label>
-                <div className="flex items-center">
-                    <Switch
-                        id={field.name}
-                        name={field.name}
-                        checked={field.state.value}
-                        onCheckedChange={(checked) => field.handleChange(checked)}
-                        onBlur={field.handleBlur}
-                        disabled={disabled}
-                    />
-                </div>
-            </div>
+                </FieldLabel>
+                <Switch
+                    id={field.name}
+                    name={field.name}
+                    checked={field.state.value}
+                    onCheckedChange={(checked) => field.handleChange(checked)}
+                    onBlur={field.handleBlur}
+                    disabled={disabled}
+                />
+            </Field>
         )}
     </form.Field>
 );
@@ -162,8 +133,8 @@ export const ConnectUISettings = () => {
                     <div className="flex flex-col gap-6">
                         <form.Field name="defaultTheme">
                             {(field) => (
-                                <div className="w-full flex flex-col gap-2 justify-between">
-                                    <label htmlFor={field.name} className="text-body-medium-medium flex items-center gap-2">
+                                <Field>
+                                    <FieldLabel htmlFor={field.name}>
                                         Default theme
                                         <InfoTooltip icon={<Info />} side="right">
                                             <p>
@@ -178,20 +149,18 @@ export const ConnectUISettings = () => {
                                                 </StyledLink>
                                             </p>
                                         </InfoTooltip>
-                                    </label>
-                                    <div className="flex">
-                                        <Select name={field.name} value={field.state.value} onValueChange={(value) => field.handleChange(value as Theme)}>
-                                            <SelectTrigger className="w-full text-sm px-2.5 gap-2">
-                                                <SelectValue placeholder="Default theme" />
-                                            </SelectTrigger>
-                                            <SelectContent>
-                                                <SelectItem value="system">System</SelectItem>
-                                                <SelectItem value="light">Light</SelectItem>
-                                                <SelectItem value="dark">Dark</SelectItem>
-                                            </SelectContent>
-                                        </Select>
-                                    </div>
-                                </div>
+                                    </FieldLabel>
+                                    <Select name={field.name} value={field.state.value} onValueChange={(value) => field.handleChange(value as Theme)}>
+                                        <SelectTrigger id={field.name} className="w-full text-sm px-2.5 gap-2">
+                                            <SelectValue placeholder="Default theme" />
+                                        </SelectTrigger>
+                                        <SelectContent>
+                                            <SelectItem value="system">System</SelectItem>
+                                            <SelectItem value="light">Light</SelectItem>
+                                            <SelectItem value="dark">Dark</SelectItem>
+                                        </SelectContent>
+                                    </Select>
+                                </Field>
                             )}
                         </form.Field>
 

--- a/packages/webapp/src/pages/Environment/Settings/Telemetry.tsx
+++ b/packages/webapp/src/pages/Environment/Settings/Telemetry.tsx
@@ -2,7 +2,7 @@ import { ExternalLink } from 'lucide-react';
 import { useEffect, useState } from 'react';
 
 import { permissions } from '@nangohq/authz';
-import { Button, FieldLabel } from '@nangohq/design-system';
+import { Button, Field, FieldError, FieldLabel } from '@nangohq/design-system';
 
 import { EditableInput } from '@/components/patterns/EditableInput';
 import { KeyValueInput } from '@/components/patterns/KeyValueInput';
@@ -111,28 +111,28 @@ export const Telemetry: React.FC = () => {
                         />
                     </div>
                     <fieldset className="flex flex-col gap-4">
-                        <label htmlFor="otlp_headers" className="text-sm">
-                            Headers
-                        </label>
-                        <div className="flex flex-col gap-5">
-                            <KeyValueInput
-                                initialValues={headers}
-                                onChange={setHeaders}
-                                placeholderKey="MY_HEADER"
-                                placeholderValue="value"
-                                disabled={!editHeaders || loading}
-                                isSecret={true}
-                            />
-                            {errors.length > 0 && (
-                                <div className="flex flex-col gap-1">
-                                    {errors.map((err, i) => (
-                                        <div key={i} className="text-body-small-regular text-status-danger-text">
-                                            Row {err.index + 1}, {err.key}: {err.error}
-                                        </div>
-                                    ))}
-                                </div>
-                            )}
-                        </div>
+                        <Field data-invalid={errors.length > 0}>
+                            <FieldLabel htmlFor="otlp_headers">Headers</FieldLabel>
+                            <div className="flex flex-col gap-5">
+                                <KeyValueInput
+                                    initialValues={headers}
+                                    onChange={setHeaders}
+                                    placeholderKey="MY_HEADER"
+                                    placeholderValue="value"
+                                    disabled={!editHeaders || loading}
+                                    isSecret={true}
+                                />
+                                {errors.length > 0 && (
+                                    <FieldError className="flex flex-col gap-1">
+                                        {errors.map((err, i) => (
+                                            <span key={i}>
+                                                Row {err.index + 1}, {err.key}: {err.error}
+                                            </span>
+                                        ))}
+                                    </FieldError>
+                                )}
+                            </div>
+                        </Field>
                         <div className="flex justify-start gap-3 mt-1.5">
                             {!editHeaders && (
                                 <PermissionGate asChild condition={canEditEnvironment}>

--- a/packages/webapp/src/pages/Team/components/TeamMembers.tsx
+++ b/packages/webapp/src/pages/Team/components/TeamMembers.tsx
@@ -122,7 +122,7 @@ export const TeamMembers: React.FC = () => {
 
     return (
         <div className="flex flex-col gap-3">
-            <h3 className="text-heading-sm text-text-strong">Team members</h3>
+            <h3 className="text-text-strong text-ds-md font-ds-medium leading-ds-normal">Team members</h3>
             <Table>
                 <TableHeader>
                     <TableRow>

--- a/packages/webapp/src/pages/Team/components/TeamSettings.tsx
+++ b/packages/webapp/src/pages/Team/components/TeamSettings.tsx
@@ -1,4 +1,5 @@
 import { permissions } from '@nangohq/authz';
+import { Field, FieldLabel } from '@nangohq/design-system';
 
 import { CriticalErrorAlert } from '@/components/patterns/CriticalErrorAlert';
 import { EditableInput } from '@/components/patterns/EditableInput';
@@ -44,9 +45,9 @@ export const TeamSettings: React.FC = () => {
     }
 
     return (
-        <div className="flex flex-col gap-3">
-            <h3 className="text-heading-sm text-text-strong">Team name</h3>
-            <EditableInput initialValue={team?.name} canEdit={canManageTeam} onSave={onSaveTeamName} />
-        </div>
+        <Field>
+            <FieldLabel htmlFor="team-name">Team name</FieldLabel>
+            <EditableInput id="team-name" initialValue={team?.name} canEdit={canManageTeam} onSave={onSaveTeamName} />
+        </Field>
     );
 };

--- a/packages/webapp/src/pages/User/Settings.tsx
+++ b/packages/webapp/src/pages/User/Settings.tsx
@@ -2,7 +2,7 @@ import { Edit } from 'lucide-react';
 import { useRef, useState } from 'react';
 import { Helmet } from 'react-helmet';
 
-import { Button, IconButton, InputGroup, InputGroupAddon, InputGroupInput } from '@nangohq/design-system';
+import { Button, Field, FieldLabel, IconButton, InputGroup, InputGroupAddon, InputGroupInput } from '@nangohq/design-system';
 
 import { CriticalErrorAlert } from '@/components/patterns/CriticalErrorAlert';
 import { Select, SelectContent, SelectItem, SelectTrigger, SelectValue } from '@/components/ui/Select';
@@ -64,27 +64,29 @@ export const UserSettings: React.FC = () => {
                 <title>Profile Settings - Nango</title>
             </Helmet>
             <div className="flex flex-col gap-5">
-                <h3 className="font-semibold text-sm text-text-strong">Display Name</h3>
-                <InputGroup>
-                    <InputGroupInput ref={ref} value={name} onChange={(e) => setName(e.target.value)} disabled={!edit} />
-                    <InputGroupAddon align="inline-end">
-                        {!edit && (
-                            <IconButton
-                                variant={'ghost'}
-                                size={'2xs'}
-                                label="Edit"
-                                onClick={() => {
-                                    setEdit(true);
-                                    setTimeout(() => {
-                                        ref.current?.focus();
-                                    }, 100);
-                                }}
-                            >
-                                <Edit />
-                            </IconButton>
-                        )}
-                    </InputGroupAddon>
-                </InputGroup>
+                <Field>
+                    <FieldLabel htmlFor="display-name">Display Name</FieldLabel>
+                    <InputGroup>
+                        <InputGroupInput id="display-name" ref={ref} value={name} onChange={(e) => setName(e.target.value)} disabled={!edit} />
+                        <InputGroupAddon align="inline-end">
+                            {!edit && (
+                                <IconButton
+                                    variant={'ghost'}
+                                    size={'2xs'}
+                                    label="Edit"
+                                    onClick={() => {
+                                        setEdit(true);
+                                        setTimeout(() => {
+                                            ref.current?.focus();
+                                        }, 100);
+                                    }}
+                                >
+                                    <Edit />
+                                </IconButton>
+                            )}
+                        </InputGroupAddon>
+                    </InputGroup>
+                </Field>
                 {edit && (
                     <div className="flex justify-end gap-2 items-center">
                         <Button
@@ -100,14 +102,14 @@ export const UserSettings: React.FC = () => {
                     </div>
                 )}
             </div>
-            <div className="flex flex-col gap-5">
-                <h3 className="font-semibold text-sm text-text-strong">Email</h3>
+            <Field>
+                <FieldLabel>Email</FieldLabel>
                 <p className="text-text-strong text-sm">{user.email}</p>
-            </div>
-            <div className="flex flex-col gap-5">
-                <h3 className="font-semibold text-sm text-text-strong">Appearance</h3>
+            </Field>
+            <Field>
+                <FieldLabel htmlFor="appearance">Appearance</FieldLabel>
                 <Select value={theme} onValueChange={(v) => setTheme(v as Theme)}>
-                    <SelectTrigger className="w-48">
+                    <SelectTrigger id="appearance" className="w-48">
                         <SelectValue />
                     </SelectTrigger>
                     <SelectContent>
@@ -116,7 +118,7 @@ export const UserSettings: React.FC = () => {
                         <SelectItem value="dark">Dark</SelectItem>
                     </SelectContent>
                 </Select>
-            </div>
+            </Field>
         </DashboardLayout>
     );
 };


### PR DESCRIPTION
## Problem

Several settings and form screens render field labels with hand-rolled markup (`<h3 className="font-semibold text-sm text-text-strong">`, `<label className="text-body-medium-medium">`, `<p className="text-sm text-text-strong">`, …) and manual description/error text, duplicating what the design-system `Field` family now provides and drifting from it visually. ([NAN-6102](https://linear.app/nango/issue/NAN-6102))

## Solution

Convert those call sites to `Field` / `FieldLabel` / `FieldDescription` / `FieldError` across User and Team settings, Connect UI and Telemetry settings, the Playground selectors/inputs, and the destructive-action modal. Also fixes a stray `text-body-medium-medium>` class typo in Connect UI.

Deliberate visual shifts to confirm in review: Team name normalizes to the field-label size (16px → 14px medium), and the password-requirements intro becomes a muted `FieldDescription` (strong → secondary).

Stacked on the `matej/nan-6079-…` branch (the base of this PR). Bucket B — wrapping the remaining DS `Label` + control sites in `Field` — is tracked separately in [NAN-6103](https://linear.app/nango/issue/NAN-6103).

## Testing

`ts-build`, lint, and Prettier all pass. Per-screen visual QA (light + dark) is tracked in the [Notion visual checklist](https://app.notion.com/p/38ace29831218122b981c0c1d83495e6).
