### PR TITLE
feat(webhooks): gate webhook-triggered sync completion webhooks behind a flag

### DIFF
--- a/packages/feature-flags/lib/flags.ts
+++ b/packages/feature-flags/lib/flags.ts
@@ -27,10 +27,10 @@ export function buildFlags(client: FeatureFlagsClient) {
             return client.isEnabled('action-trace-manual-keep', { targetingKey: String(environmentId), environmentId }, false);
         },
         /**
-         * Whether to send sync completion webhooks when the sync was triggered by an incoming
-         * provider webhook (`syncType: WEBHOOK`). Default `true` (preserve existing behavior).
+         * Whether to send sync completion webhooks for this environment and provider.
+         * Default `true`.
          */
-        shouldSendSyncCompletedWebhookForWebhookOperation(environmentId: number, providerConfigKey: string) {
+        shouldSendSyncCompletedWebhook(environmentId: number, providerConfigKey: string) {
             return client.isEnabled(
                 'sync-completion-webhook-for-webhook-operation',
                 {

--- a/packages/feature-flags/lib/flags.ts
+++ b/packages/feature-flags/lib/flags.ts
@@ -25,6 +25,21 @@ export function buildFlags(client: FeatureFlagsClient) {
          */
         shouldKeepActionTrace(environmentId: number) {
             return client.isEnabled('action-trace-manual-keep', { targetingKey: String(environmentId), environmentId }, false);
+        },
+        /**
+         * Whether to send sync completion webhooks when the sync was triggered by an incoming
+         * provider webhook (`syncType: WEBHOOK`). Default `true` (preserve existing behavior).
+         */
+        shouldSendSyncCompletedWebhookForWebhookOperation(environmentId: number, providerConfigKey: string) {
+            return client.isEnabled(
+                'sync-completion-webhook-for-webhook-operation',
+                {
+                    targetingKey: `${environmentId}:${providerConfigKey}`,
+                    environmentId,
+                    providerConfigKey
+                },
+                true
+            );
         }
     };
 }

--- a/packages/feature-flags/lib/index.unit.test.ts
+++ b/packages/feature-flags/lib/index.unit.test.ts
@@ -170,6 +170,28 @@ describe('getFeatureFlagsClient', () => {
         );
     });
 
+    it('shouldSendSyncCompletedWebhookForWebhookOperation evaluates per environment and provider', async () => {
+        mockEnvs.NANGO_FLAG_PROVIDER = 'unleash';
+        mockEnvs.NANGO_UNLEASH_URL = 'http://unleash.local:4242/api';
+        vi.resetModules();
+        const { initialize, getFlags } = await import('./index.js');
+        await initialize();
+        const [unleash] = unleashInstances;
+        if (!unleash) {
+            throw new Error('Expected Unleash provider to initialize');
+        }
+        unleash.isEnabled.mockReturnValue(false);
+        await expect(getFlags().shouldSendSyncCompletedWebhookForWebhookOperation(16693, 'hubspot')).resolves.toBe(false);
+        expect(unleash.isEnabled).toHaveBeenCalledWith(
+            'sync-completion-webhook-for-webhook-operation',
+            {
+                userId: '16693:hubspot',
+                properties: { environmentId: '16693', providerConfigKey: 'hubspot' }
+            },
+            true
+        );
+    });
+
     it('reads non-boolean variant payloads (getString), falling back to default otherwise', async () => {
         mockEnvs.NANGO_FLAG_PROVIDER = 'unleash';
         mockEnvs.NANGO_UNLEASH_URL = 'http://unleash.local:4242/api';

--- a/packages/feature-flags/lib/index.unit.test.ts
+++ b/packages/feature-flags/lib/index.unit.test.ts
@@ -170,7 +170,7 @@ describe('getFeatureFlagsClient', () => {
         );
     });
 
-    it('shouldSendSyncCompletedWebhookForWebhookOperation evaluates per environment and provider', async () => {
+    it('shouldSendSyncCompletedWebhook evaluates per environment and provider', async () => {
         mockEnvs.NANGO_FLAG_PROVIDER = 'unleash';
         mockEnvs.NANGO_UNLEASH_URL = 'http://unleash.local:4242/api';
         vi.resetModules();
@@ -181,7 +181,7 @@ describe('getFeatureFlagsClient', () => {
             throw new Error('Expected Unleash provider to initialize');
         }
         unleash.isEnabled.mockReturnValue(false);
-        await expect(getFlags().shouldSendSyncCompletedWebhookForWebhookOperation(16693, 'hubspot')).resolves.toBe(false);
+        await expect(getFlags().shouldSendSyncCompletedWebhook(16693, 'hubspot')).resolves.toBe(false);
         expect(unleash.isEnabled).toHaveBeenCalledWith(
             'sync-completion-webhook-for-webhook-operation',
             {

--- a/packages/webhooks/lib/sync.ts
+++ b/packages/webhooks/lib/sync.ts
@@ -72,8 +72,10 @@ export const sendSync = async ({
         return Ok(undefined);
     }
 
+    // Real-time integrations can emit a completion webhook on every provider event.
+    // This flag lets us disable those callbacks per environment and integration.
     if (success && operation === 'WEBHOOK') {
-        const shouldSendWebhook = await getFlags().shouldSendSyncCompletedWebhookForWebhookOperation(environment.id, connection.provider_config_key);
+        const shouldSendWebhook = await getFlags().shouldSendSyncCompletedWebhook(environment.id, connection.provider_config_key);
         if (!shouldSendWebhook) {
             return Ok(undefined);
         }

--- a/packages/webhooks/lib/sync.ts
+++ b/packages/webhooks/lib/sync.ts
@@ -1,6 +1,7 @@
 import dayjs from 'dayjs';
 import utc from 'dayjs/plugin/utc.js';
 
+import { getFlags } from '@nangohq/feature-flags';
 import { logContextGetter, OtlpSpan } from '@nangohq/logs';
 import { metrics, Ok } from '@nangohq/utils';
 
@@ -69,6 +70,13 @@ export const sendSync = async ({
 
     if (!shouldSend({ success, type: 'sync', webhookSettings: settings })) {
         return Ok(undefined);
+    }
+
+    if (success && operation === 'WEBHOOK') {
+        const shouldSendWebhook = await getFlags().shouldSendSyncCompletedWebhookForWebhookOperation(environment.id, connection.provider_config_key);
+        if (!shouldSendWebhook) {
+            return Ok(undefined);
+        }
     }
 
     const logCtx = await logContextGetter.create(

--- a/packages/webhooks/lib/sync.unit.test.ts
+++ b/packages/webhooks/lib/sync.unit.test.ts
@@ -7,11 +7,11 @@ import { deliver } from './utils.js';
 
 import type { ConnectionJobs, DBAPISecret, DBEnvironment, DBExternalWebhook, DBSyncConfig, DBTeam, IntegrationConfig } from '@nangohq/types';
 
-const shouldSendSyncCompletedWebhookForWebhookOperation = vi.fn().mockResolvedValue(true);
+const shouldSendSyncCompletedWebhook = vi.fn().mockResolvedValue(true);
 
 vi.mock('@nangohq/feature-flags', () => ({
     getFlags: () => ({
-        shouldSendSyncCompletedWebhookForWebhookOperation
+        shouldSendSyncCompletedWebhook
     })
 }));
 
@@ -104,8 +104,8 @@ describe('Webhooks: sync notification tests', () => {
     beforeEach(() => {
         deliverMock.mockReset();
         deliverMock.mockResolvedValue(Ok(undefined));
-        shouldSendSyncCompletedWebhookForWebhookOperation.mockReset();
-        shouldSendSyncCompletedWebhookForWebhookOperation.mockResolvedValue(true);
+        shouldSendSyncCompletedWebhook.mockReset();
+        shouldSendSyncCompletedWebhook.mockResolvedValue(true);
     });
 
     it('Should not send a sync webhook if the webhook url is not present', async () => {
@@ -417,7 +417,7 @@ describe('Webhooks: sync notification tests', () => {
     });
 
     it('Should not send a webhook-triggered sync completion webhook when the feature flag disables it', async () => {
-        shouldSendSyncCompletedWebhookForWebhookOperation.mockResolvedValue(false);
+        shouldSendSyncCompletedWebhook.mockResolvedValue(false);
 
         await sendSync({
             account,
@@ -435,12 +435,12 @@ describe('Webhooks: sync notification tests', () => {
             webhookSettings
         });
 
-        expect(shouldSendSyncCompletedWebhookForWebhookOperation).toHaveBeenCalledWith(1, connection.provider_config_key);
+        expect(shouldSendSyncCompletedWebhook).toHaveBeenCalledWith(1, connection.provider_config_key);
         expect(deliverMock).not.toHaveBeenCalled();
     });
 
     it('Should still send webhook-triggered sync error webhooks when the feature flag disables completion webhooks', async () => {
-        shouldSendSyncCompletedWebhookForWebhookOperation.mockResolvedValue(false);
+        shouldSendSyncCompletedWebhook.mockResolvedValue(false);
 
         await sendSync({
             account,
@@ -464,7 +464,7 @@ describe('Webhooks: sync notification tests', () => {
             }
         });
 
-        expect(shouldSendSyncCompletedWebhookForWebhookOperation).not.toHaveBeenCalled();
+        expect(shouldSendSyncCompletedWebhook).not.toHaveBeenCalled();
         expect(deliverMock).toHaveBeenCalledTimes(1);
     });
 });

--- a/packages/webhooks/lib/sync.unit.test.ts
+++ b/packages/webhooks/lib/sync.unit.test.ts
@@ -104,6 +104,7 @@ describe('Webhooks: sync notification tests', () => {
     beforeEach(() => {
         deliverMock.mockReset();
         deliverMock.mockResolvedValue(Ok(undefined));
+        shouldSendSyncCompletedWebhookForWebhookOperation.mockReset();
         shouldSendSyncCompletedWebhookForWebhookOperation.mockResolvedValue(true);
     });
 

--- a/packages/webhooks/lib/sync.unit.test.ts
+++ b/packages/webhooks/lib/sync.unit.test.ts
@@ -7,6 +7,14 @@ import { deliver } from './utils.js';
 
 import type { ConnectionJobs, DBAPISecret, DBEnvironment, DBExternalWebhook, DBSyncConfig, DBTeam, IntegrationConfig } from '@nangohq/types';
 
+const shouldSendSyncCompletedWebhookForWebhookOperation = vi.fn().mockResolvedValue(true);
+
+vi.mock('@nangohq/feature-flags', () => ({
+    getFlags: () => ({
+        shouldSendSyncCompletedWebhookForWebhookOperation
+    })
+}));
+
 vi.mock('./utils.js', async (importOriginal) => {
     const actual = await importOriginal<Record<string, unknown>>();
     return { ...actual, deliver: vi.fn() };
@@ -96,6 +104,7 @@ describe('Webhooks: sync notification tests', () => {
     beforeEach(() => {
         deliverMock.mockReset();
         deliverMock.mockResolvedValue(Ok(undefined));
+        shouldSendSyncCompletedWebhookForWebhookOperation.mockResolvedValue(true);
     });
 
     it('Should not send a sync webhook if the webhook url is not present', async () => {
@@ -404,5 +413,57 @@ describe('Webhooks: sync notification tests', () => {
             success: false,
             error
         });
+    });
+
+    it('Should not send a webhook-triggered sync completion webhook when the feature flag disables it', async () => {
+        shouldSendSyncCompletedWebhookForWebhookOperation.mockResolvedValue(false);
+
+        await sendSync({
+            account,
+            connection,
+            environment: { name: 'dev', id: 1 } as DBEnvironment,
+            secret,
+            providerConfig,
+            syncConfig,
+            syncVariant: 'base',
+            model: 'model',
+            responseResults: { added: 10, updated: 0, deleted: 0 },
+            success: true,
+            operation: 'WEBHOOK',
+            now: new Date(),
+            webhookSettings
+        });
+
+        expect(shouldSendSyncCompletedWebhookForWebhookOperation).toHaveBeenCalledWith(1, connection.provider_config_key);
+        expect(deliverMock).not.toHaveBeenCalled();
+    });
+
+    it('Should still send webhook-triggered sync error webhooks when the feature flag disables completion webhooks', async () => {
+        shouldSendSyncCompletedWebhookForWebhookOperation.mockResolvedValue(false);
+
+        await sendSync({
+            account,
+            connection,
+            environment: { name: 'dev', id: 1 } as DBEnvironment,
+            secret,
+            providerConfig,
+            syncConfig,
+            syncVariant: 'base',
+            model: 'model',
+            success: false,
+            error: {
+                type: 'error',
+                description: 'error description'
+            },
+            operation: 'WEBHOOK',
+            now: new Date(),
+            webhookSettings: {
+                ...webhookSettings,
+                on_sync_error: true
+            }
+        });
+
+        expect(shouldSendSyncCompletedWebhookForWebhookOperation).not.toHaveBeenCalled();
+        expect(deliverMock).toHaveBeenCalledTimes(1);
     });
 });

--- a/packages/webhooks/lib/sync.unit.test.ts
+++ b/packages/webhooks/lib/sync.unit.test.ts
@@ -422,6 +422,7 @@ describe('Webhooks: sync notification tests', () => {
         await sendSync({
             account,
             connection,
+            connectionConfig: null,
             environment: { name: 'dev', id: 1 } as DBEnvironment,
             secret,
             providerConfig,
@@ -445,6 +446,7 @@ describe('Webhooks: sync notification tests', () => {
         await sendSync({
             account,
             connection,
+            connectionConfig: null,
             environment: { name: 'dev', id: 1 } as DBEnvironment,
             secret,
             providerConfig,

--- a/packages/webhooks/package.json
+++ b/packages/webhooks/package.json
@@ -16,6 +16,7 @@
     "keywords": [],
     "dependencies": {
         "@nangohq/egress": "file:../egress",
+        "@nangohq/feature-flags": "file:../feature-flags",
         "@nangohq/logs": "file:../logs",
         "@nangohq/shared": "file:../shared",
         "@nangohq/utils": "file:../utils",

--- a/packages/webhooks/tsconfig.json
+++ b/packages/webhooks/tsconfig.json
@@ -9,6 +9,9 @@
             "path": "../egress"
         },
         {
+            "path": "../feature-flags"
+        },
+        {
             "path": "../utils"
         },
         {


### PR DESCRIPTION


Allow muting Nango sync completion webhooks for provider webhook runs per environment and integration via Unleash.

<!-- Describe the problem and your solution --> 

<!-- Issue ticket number and link (if applicable) -->

<!-- Testing instructions (skip if just adding/editing providers) -->



<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/NangoHQ/nango/pull/6665?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

