### PR TITLE
fix: schedule plan change callout message

### DIFF
--- a/packages/webapp/src/pages/Team/Billing/components/Plans.tsx
+++ b/packages/webapp/src/pages/Team/Billing/components/Plans.tsx
@@ -1,3 +1,4 @@
+import { format } from 'date-fns';
 import { Info, Loader } from 'lucide-react';
 import { useCallback, useEffect, useMemo, useRef, useState } from 'react';
 
@@ -38,11 +39,16 @@ export const Plans: React.FC = () => {
     }, [paymentMethods]);
 
     const futurePlan = useMemo(() => {
-        if (!currentPlan?.orb_future_plan) {
+        if (!currentPlan?.orb_future_plan || !currentPlan.orb_future_plan_at) {
             return null;
         }
 
-        return plansList?.data.find((p) => p.code === currentPlan.orb_future_plan);
+        const plan = plansList?.data.find((p) => p.code === currentPlan.orb_future_plan);
+        if (!plan) {
+            return null;
+        }
+
+        return { plan, futurePlanAt: format(new Date(currentPlan.orb_future_plan_at), 'yyyy-MM-dd') };
     }, [currentPlan, plansList]);
 
     const plans = useMemo<null | { list: PlanDefinitionList[]; activePlan: PlanDefinition }>(() => {
@@ -75,11 +81,11 @@ export const Plans: React.FC = () => {
             return null;
         }
 
-        if (futurePlan?.code !== 'free') {
-            return `Your ${plans?.activePlan.title} subscription will switch to Starter at the end of the month.`;
+        if (futurePlan.plan?.code === 'free') {
+            return `Your ${plans?.activePlan.title} subscription has been cancelled and will terminate at the end of the month.`;
         }
 
-        return `Your ${plans?.activePlan.title} subscription has been cancelled and will terminate at the end of the month.`;
+        return `Your ${plans?.activePlan.title} subscription will switch to ${futurePlan.plan?.title} on ${futurePlan.futurePlanAt}.`;
     }, [futurePlan, plans?.activePlan.title]);
 
     return (


### PR DESCRIPTION
The logic that renders the "scheduled plan change" callout message in the Plans page currently assumes that only downgrades rely on plan scheduling, as upgrades are executed immediately. With the addition of new plans that also rely on plan scheduling (eg. the `startup-deal` that gets scheduled to transition to Growth once the trial period ends), this message started rendering the wrong message.

This PR fixes that by interpolating the current and future plans, as well as the scheduled date. Otherwise, it retains the previous behavior, so downgrading into `free` will still render the plan cancellation message.

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/NangoHQ/nango/pull/6666?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

