### PR TITLE
fix: add custom timeouts per service

### DIFF
--- a/packages/jobs/lib/app.ts
+++ b/packages/jobs/lib/app.ts
@@ -40,6 +40,10 @@ try {
     const port = envs.NANGO_JOBS_PORT;
     const orchestratorUrl = envs.ORCHESTRATOR_SERVICE_URL;
     const srv = server.listen(port);
+    if (envs.NANGO_JOBS_KEEP_ALIVE_TIMEOUT_MS && envs.NANGO_JOBS_KEEP_ALIVE_TIMEOUT_MS > 0) {
+        srv.keepAliveTimeout = envs.NANGO_JOBS_KEEP_ALIVE_TIMEOUT_MS;
+        srv.headersTimeout = envs.NANGO_JOBS_KEEP_ALIVE_TIMEOUT_MS + 1000;
+    }
     logger.info(`🚀 service ready at http://localhost:${port}`);
     const processor = new Processor(orchestratorUrl);
     const invocationsProcessor = new LambdaInvocationsProcessor();

--- a/packages/orchestrator/lib/app.ts
+++ b/packages/orchestrator/lib/app.ts
@@ -82,7 +82,10 @@ try {
     const api = server.listen(port, () => {
         logger.info(`🚀 Orchestrator API ready at http://localhost:${port}`);
     });
-
+    if (envs.NANGO_ORCHESTRATOR_KEEP_ALIVE_TIMEOUT_MS && envs.NANGO_ORCHESTRATOR_KEEP_ALIVE_TIMEOUT_MS > 0) {
+        api.keepAliveTimeout = envs.NANGO_ORCHESTRATOR_KEEP_ALIVE_TIMEOUT_MS;
+        api.headersTimeout = envs.NANGO_ORCHESTRATOR_KEEP_ALIVE_TIMEOUT_MS + 1000;
+    }
     // --- Close function
     const close = once(() => {
         logger.info('Closing...');

--- a/packages/persist/lib/app.ts
+++ b/packages/persist/lib/app.ts
@@ -45,6 +45,10 @@ try {
     api = server.listen(port, () => {
         logger.info(`🚀 API ready at http://localhost:${port}`);
     });
+    if (envs.NANGO_PERSIST_KEEP_ALIVE_TIMEOUT_MS && envs.NANGO_PERSIST_KEEP_ALIVE_TIMEOUT_MS > 0) {
+        api.keepAliveTimeout = envs.NANGO_PERSIST_KEEP_ALIVE_TIMEOUT_MS;
+        api.headersTimeout = envs.NANGO_PERSIST_KEEP_ALIVE_TIMEOUT_MS + 1000;
+    }
 } catch (err) {
     console.error(`Persist API error`, err);
     process.exit(1);

--- a/packages/runner/lib/app.ts
+++ b/packages/runner/lib/app.ts
@@ -21,7 +21,10 @@ try {
             logger.error(`${id} Unable to register`, res.error);
         }
     });
-
+    if (envs.NANGO_RUNNER_KEEP_ALIVE_TIMEOUT_MS && envs.NANGO_RUNNER_KEEP_ALIVE_TIMEOUT_MS > 0) {
+        srv.keepAliveTimeout = envs.NANGO_RUNNER_KEEP_ALIVE_TIMEOUT_MS;
+        srv.headersTimeout = envs.NANGO_RUNNER_KEEP_ALIVE_TIMEOUT_MS + 1000;
+    }
     const close = () => {
         logger.info(`${id} Closing...`);
         providersMonitorCleanup();

--- a/packages/utils/lib/environment/parse.ts
+++ b/packages/utils/lib/environment/parse.ts
@@ -150,10 +150,12 @@ export const ENVS = z.object({
         .optional()
         .default(48 * 3600 * 1000), // 48 hours
     NANGO_PERSIST_PORT: z.coerce.number().optional().default(3007),
+    NANGO_PERSIST_KEEP_ALIVE_TIMEOUT_MS: z.coerce.number().optional(),
 
     // Orchestrator
     ORCHESTRATOR_SERVICE_URL: z.url().optional(),
     NANGO_ORCHESTRATOR_PORT: z.coerce.number().optional().default(3008),
+    NANGO_ORCHESTRATOR_KEEP_ALIVE_TIMEOUT_MS: z.coerce.number().optional(),
     ORCHESTRATOR_DATABASE_URL: z.url().optional(),
     ORCHESTRATOR_DATABASE_SCHEMA: z.string().optional().default('nango_scheduler'),
     ORCHESTRATOR_DB_POOL_MAX: z.coerce.number().optional().default(50),
@@ -180,6 +182,7 @@ export const ENVS = z.object({
     JOBS_SERVICE_URL: z.url().optional().default('http://localhost:3005'),
     JOBS_NAMESPACE: z.string().optional().default('nango'),
     NANGO_JOBS_PORT: z.coerce.number().optional().default(3005),
+    NANGO_JOBS_KEEP_ALIVE_TIMEOUT_MS: z.coerce.number().optional(),
     PROVIDERS_URL: z.url().optional(),
     PROVIDERS_RELOAD_INTERVAL: z.coerce.number().optional().default(60000),
     JOBS_PROCESSOR_CONFIG: z
@@ -247,6 +250,7 @@ export const ENVS = z.object({
         .default([]),
     RUNNER_SERVICE_URL: z.url().optional(),
     NANGO_RUNNER_PATH: z.string().optional(),
+    NANGO_RUNNER_KEEP_ALIVE_TIMEOUT_MS: z.coerce.number().optional(),
     RUNNER_OWNER_ID: z.string().optional(),
     IDLE_MAX_DURATION_MS: z.coerce.number().default(0),
     RUNNER_NODE_ID: z.coerce.number().default(1),


### PR DESCRIPTION
Add customer keep alive timeouts per service. This is only applied if environment variable is set and greater than zero.

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/NangoHQ/nango/pull/6667?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

