### PR TITLE
fix(runner): harden function access

### DIFF
--- a/packages/runner/lib/exec.ts
+++ b/packages/runner/lib/exec.ts
@@ -16,7 +16,7 @@ import { Err, errorToObject, isEnterprise, Ok, truncateJson } from '@nangohq/uti
 import { PersistClient } from './clients/persist.js';
 import { logger } from './logger.js';
 import { MapLocks } from './sdk/locks.js';
-import { instrumentSDK, NangoActionRunner, NangoSyncRunner } from './sdk/sdk.js';
+import { createFunctionFacade, instrumentSDK, NangoActionRunner, NangoSyncRunner } from './sdk/sdk.js';
 import { createTelemetryRecorder } from './telemetry.js';
 
 import type { Locks } from './sdk/locks.js';
@@ -70,6 +70,12 @@ export async function exec({
     })();
     const nango = process.env['NANGO_TELEMETRY_SDK'] ? instrumentSDK(rawNango) : rawNango;
     nango.abortSignal = abortController.signal;
+
+    // Customer-authored functions receive a restricted facade so they cannot reach internal properties
+    // (most importantly the underlying node client and its raw Axios instance via `nango.nango.http`),
+    // which would let them bypass the SDK. `exec` keeps using the real instance for its own needs
+    // (telemetryBag, getCheckpointRange, clearRecordsIfNeeded, ...).
+    const functionNango = createFunctionFacade(nango);
 
     const wrappedCode = `(function() { var module = { exports: {} }; var exports = module.exports; ${code}
         return module.exports;
@@ -153,7 +159,7 @@ export async function exec({
                         throw new Error(`Missing onWebhook function`);
                     }
 
-                    const output = await payload.onWebhook(nango as any, codeParams);
+                    const output = await payload.onWebhook(functionNango as any, codeParams);
                     return Ok({
                         output,
                         telemetryBag: nango.telemetryBag,
@@ -166,7 +172,7 @@ export async function exec({
                         throw new Error(content);
                     }
 
-                    const output = await scriptExports.onWebhookPayloadReceived(nango as NangoSyncRunner, codeParams);
+                    const output = await scriptExports.onWebhookPayloadReceived(functionNango as NangoSyncRunner, codeParams);
                     return Ok({
                         output,
                         telemetryBag: nango.telemetryBag,
@@ -191,9 +197,9 @@ export async function exec({
                     if (!payload.exec) {
                         throw new Error(`Missing exec function`);
                     }
-                    output = await payload.exec(nango, codeParams);
+                    output = await payload.exec(functionNango, codeParams);
                 } else {
-                    output = await def(nango, inputParams);
+                    output = await def(functionNango, inputParams);
                 }
 
                 if (output) {
@@ -228,9 +234,9 @@ export async function exec({
                     if (!payload.exec) {
                         throw new Error(`Missing exec function`);
                     }
-                    output = await payload.exec(nango as any);
+                    output = await payload.exec(functionNango as any);
                 } else {
-                    output = await def(nango);
+                    output = await def(functionNango);
                 }
                 return Ok({ output, telemetryBag: nango.telemetryBag });
             }
@@ -246,14 +252,14 @@ export async function exec({
                     throw new Error(`Missing exec function`);
                 }
 
-                await payload.exec(nango as any);
+                await payload.exec(functionNango as any);
                 return Ok({
                     output: true,
                     telemetryBag: nango.telemetryBag,
                     checkpoints: nango.getCheckpointRange()
                 });
             } else {
-                await def(nango);
+                await def(functionNango);
                 return Ok({
                     output: true,
                     telemetryBag: nango.telemetryBag,

--- a/packages/runner/lib/exec.ts
+++ b/packages/runner/lib/exec.ts
@@ -71,10 +71,6 @@ export async function exec({
     const nango = process.env['NANGO_TELEMETRY_SDK'] ? instrumentSDK(rawNango) : rawNango;
     nango.abortSignal = abortController.signal;
 
-    // Customer-authored functions receive a restricted facade so they cannot reach internal properties
-    // (most importantly the underlying node client and its raw Axios instance via `nango.nango.http`),
-    // which would let them bypass the SDK. `exec` keeps using the real instance for its own needs
-    // (telemetryBag, getCheckpointRange, clearRecordsIfNeeded, ...).
     const functionNango = createFunctionFacade(nango);
 
     const wrappedCode = `(function() { var module = { exports: {} }; var exports = module.exports; ${code}

--- a/packages/runner/lib/sdk/sdk.ts
+++ b/packages/runner/lib/sdk/sdk.ts
@@ -1026,11 +1026,11 @@ export function createFunctionFacade<T extends NangoActionRunner | NangoSyncRunn
     const boundCache = new Map<string | symbol, (...args: any[]) => any>();
 
     return new Proxy(runner, {
-        get(target, prop) {
+        get(target, prop, receiver) {
             if (FUNCTION_BLOCKED_PROPERTIES.has(prop)) {
                 throwBlockedAccess(prop);
             }
-            const value = Reflect.get(target, prop);
+            const value = Reflect.get(target, prop, receiver);
             if (typeof value !== 'function') {
                 return value;
             }
@@ -1041,12 +1041,12 @@ export function createFunctionFacade<T extends NangoActionRunner | NangoSyncRunn
             }
             return bound;
         },
-        set(target, prop, value) {
+        set(target, prop, value, receiver) {
             if (FUNCTION_BLOCKED_PROPERTIES.has(prop)) {
                 throwBlockedAccess(prop);
             }
             boundCache.delete(prop);
-            return Reflect.set(target, prop, value);
+            return Reflect.set(target, prop, value, receiver);
         },
         defineProperty(target, prop, descriptor) {
             if (FUNCTION_BLOCKED_PROPERTIES.has(prop)) {

--- a/packages/runner/lib/sdk/sdk.ts
+++ b/packages/runner/lib/sdk/sdk.ts
@@ -968,3 +968,76 @@ export function instrumentSDK(rawNango: NangoActionRunner | NangoSyncRunner) {
         }
     });
 }
+
+/**
+ * @internal
+ *
+ * Properties on the runner that must never be reachable from customer-authored functions.
+ * Most importantly `nango` (the node client) exposes a raw Axios instance via `nango.nango.http`,
+ * which would let functions bypass the SDK (HTTP logging, redaction, telemetry, outbound URL policy,
+ * retries, credential refresh) and leak the secret key through `nango.nango.apiKey`.
+ */
+const FUNCTION_BLOCKED_PROPERTIES = new Set<string | symbol>(['nango', 'persistClient', 'telemetryRecorder', 'locking', 'checkpointing', 'checkpointKey']);
+
+function throwBlockedAccess(prop: string | symbol): never {
+    const name = typeof prop === 'symbol' ? prop.toString() : prop;
+    throw new Error(`Access to "${name}" is not allowed. Use the Nango SDK methods (e.g. nango.proxy(), nango.fetch()) to make HTTP requests.`);
+}
+
+/**
+ * @internal
+ *
+ * Wraps a runner instance in a Proxy that is safe to hand to customer-authored functions.
+ * It hides internal properties (most importantly the underlying node client) so functions cannot
+ * bypass the SDK, while binding every method to the real runner so internal calls (which rely on
+ * `this.nango` and the other hidden properties) keep working. This also covers the methods that
+ * `NangoSyncRunner` borrows from `NangoActionRunner.prototype`, since they are bound to the real
+ * target rather than to the facade.
+ */
+export function createFunctionFacade<T extends NangoActionRunner | NangoSyncRunner>(runner: T): T {
+    return new Proxy(runner, {
+        get(target, prop) {
+            if (FUNCTION_BLOCKED_PROPERTIES.has(prop)) {
+                throwBlockedAccess(prop);
+            }
+            const value = Reflect.get(target, prop);
+            if (typeof value === 'function') {
+                return value.bind(target);
+            }
+            return value;
+        },
+        set(target, prop, value) {
+            if (FUNCTION_BLOCKED_PROPERTIES.has(prop)) {
+                throwBlockedAccess(prop);
+            }
+            return Reflect.set(target, prop, value);
+        },
+        defineProperty(target, prop, descriptor) {
+            if (FUNCTION_BLOCKED_PROPERTIES.has(prop)) {
+                throwBlockedAccess(prop);
+            }
+            return Reflect.defineProperty(target, prop, descriptor);
+        },
+        deleteProperty(target, prop) {
+            if (FUNCTION_BLOCKED_PROPERTIES.has(prop)) {
+                throwBlockedAccess(prop);
+            }
+            return Reflect.deleteProperty(target, prop);
+        },
+        has(target, prop) {
+            if (FUNCTION_BLOCKED_PROPERTIES.has(prop)) {
+                return false;
+            }
+            return Reflect.has(target, prop);
+        },
+        getOwnPropertyDescriptor(target, prop) {
+            if (FUNCTION_BLOCKED_PROPERTIES.has(prop)) {
+                return undefined;
+            }
+            return Reflect.getOwnPropertyDescriptor(target, prop);
+        },
+        ownKeys(target) {
+            return Reflect.ownKeys(target).filter((key) => !FUNCTION_BLOCKED_PROPERTIES.has(key));
+        }
+    });
+}

--- a/packages/runner/lib/sdk/sdk.ts
+++ b/packages/runner/lib/sdk/sdk.ts
@@ -974,34 +974,19 @@ export function instrumentSDK(rawNango: NangoActionRunner | NangoSyncRunner) {
  *
  * Properties on the runner that must never be reachable from customer-authored functions.
  *
- * This is the complement of the public SDK surface (everything declared on `NangoAction` /
- * `NangoSync` in `runner-sdk/models.d.ts`). Anything that is NOT a documented public method or a
- * non-sensitive public field belongs here: internal clients, secret-bearing state, usage/metering
- * accounting, and internal helper methods. When adding a new internal member to the runner classes,
- * add it here too.
- *
- * Note: internal `this.*` access from the runner's own methods bypasses the facade entirely (the
- * proxy binds methods to the raw target), so blocking these only affects direct customer access.
  */
 const FUNCTION_BLOCKED_PROPERTIES = new Set<string | symbol>([
-    // Internal clients & cross-run capabilities (raw node client carries the secret key + raw axios)
     'nango',
     'persistClient',
     'telemetryRecorder',
     'locking',
     'checkpointing',
     'checkpointKey',
-
-    // Secret-bearing / sensitive state
-    'integrationConfig', // holds the decrypted oauth_client_secret
-    'memoizedConnections', // cached connection credentials
+    'integrationConfig',
+    'memoizedConnections',
     'memoizedIntegration',
     'attributes',
-
-    // Usage/metering accounting — must not be tamperable by customer code
     'telemetryBag',
-
-    // Internal helper methods (not part of the public SDK surface)
     'getProxyConfig',
     'throwIfAbortedOrKilled',
     'throwIfInterrupted',
@@ -1017,8 +1002,6 @@ const FUNCTION_BLOCKED_PROPERTIES = new Set<string | symbol>([
     'fetchRecordsPage',
     'getCheckpointRange',
     'clearRecordsIfNeeded',
-
-    // Internal tuning / bookkeeping state
     'batchSize',
     'getRecordsBatchSize',
     'mergingByModel',

--- a/packages/runner/lib/sdk/sdk.ts
+++ b/packages/runner/lib/sdk/sdk.ts
@@ -978,7 +978,7 @@ const FUNCTION_BLOCKED_PROPERTIES = new Set<string | symbol>(['nango', 'persistC
 
 function throwBlockedAccess(prop: string | symbol): never {
     const name = typeof prop === 'symbol' ? prop.toString() : prop;
-    throw new Error(`Access to "${name}" is not allowed. Use the Nango SDK methods (e.g. nango.proxy(), nango.fetch()) to make HTTP requests.`);
+    throw new Error(`Access to "${name}" is not allowed. Use the Nango SDK methods (e.g. nango.proxy(), nango.uncontrolledFetch()) to make HTTP requests.`);
 }
 
 /**

--- a/packages/runner/lib/sdk/sdk.ts
+++ b/packages/runner/lib/sdk/sdk.ts
@@ -973,9 +973,6 @@ export function instrumentSDK(rawNango: NangoActionRunner | NangoSyncRunner) {
  * @internal
  *
  * Properties on the runner that must never be reachable from customer-authored functions.
- * Most importantly `nango` (the node client) exposes a raw Axios instance via `nango.nango.http`,
- * which would let functions bypass the SDK (HTTP logging, redaction, telemetry, outbound URL policy,
- * retries, credential refresh) and leak the secret key through `nango.nango.apiKey`.
  */
 const FUNCTION_BLOCKED_PROPERTIES = new Set<string | symbol>(['nango', 'persistClient', 'telemetryRecorder', 'locking', 'checkpointing', 'checkpointKey']);
 
@@ -988,11 +985,6 @@ function throwBlockedAccess(prop: string | symbol): never {
  * @internal
  *
  * Wraps a runner instance in a Proxy that is safe to hand to customer-authored functions.
- * It hides internal properties (most importantly the underlying node client) so functions cannot
- * bypass the SDK, while binding every method to the real runner so internal calls (which rely on
- * `this.nango` and the other hidden properties) keep working. This also covers the methods that
- * `NangoSyncRunner` borrows from `NangoActionRunner.prototype`, since they are bound to the real
- * target rather than to the facade.
  */
 export function createFunctionFacade<T extends NangoActionRunner | NangoSyncRunner>(runner: T): T {
     return new Proxy(runner, {

--- a/packages/runner/lib/sdk/sdk.ts
+++ b/packages/runner/lib/sdk/sdk.ts
@@ -978,7 +978,7 @@ const FUNCTION_BLOCKED_PROPERTIES = new Set<string | symbol>(['nango', 'persistC
 
 function throwBlockedAccess(prop: string | symbol): never {
     const name = typeof prop === 'symbol' ? prop.toString() : prop;
-    throw new Error(`Access to "${name}" is not allowed. Use the Nango SDK methods (e.g. nango.proxy(), nango.uncontrolledFetch()) to make HTTP requests.`);
+    throw new Error(`Access to "${name}" is not allowed.`);
 }
 
 /**

--- a/packages/runner/lib/sdk/sdk.ts
+++ b/packages/runner/lib/sdk/sdk.ts
@@ -1005,7 +1005,9 @@ const FUNCTION_BLOCKED_PROPERTIES = new Set<string | symbol>([
     'batchSize',
     'getRecordsBatchSize',
     'mergingByModel',
-    'httpLogSample'
+    'httpLogSample',
+    '__proto__',
+    'constructor'
 ]);
 
 function throwBlockedAccess(prop: string | symbol): never {
@@ -1072,6 +1074,12 @@ export function createFunctionFacade<T extends NangoActionRunner | NangoSyncRunn
         },
         ownKeys(target) {
             return Reflect.ownKeys(target).filter((key) => !FUNCTION_BLOCKED_PROPERTIES.has(key));
+        },
+        getPrototypeOf() {
+            return null;
+        },
+        setPrototypeOf() {
+            throwBlockedAccess('prototype');
         }
     });
 }

--- a/packages/runner/lib/sdk/sdk.ts
+++ b/packages/runner/lib/sdk/sdk.ts
@@ -973,8 +973,57 @@ export function instrumentSDK(rawNango: NangoActionRunner | NangoSyncRunner) {
  * @internal
  *
  * Properties on the runner that must never be reachable from customer-authored functions.
+ *
+ * This is the complement of the public SDK surface (everything declared on `NangoAction` /
+ * `NangoSync` in `runner-sdk/models.d.ts`). Anything that is NOT a documented public method or a
+ * non-sensitive public field belongs here: internal clients, secret-bearing state, usage/metering
+ * accounting, and internal helper methods. When adding a new internal member to the runner classes,
+ * add it here too.
+ *
+ * Note: internal `this.*` access from the runner's own methods bypasses the facade entirely (the
+ * proxy binds methods to the raw target), so blocking these only affects direct customer access.
  */
-const FUNCTION_BLOCKED_PROPERTIES = new Set<string | symbol>(['nango', 'persistClient', 'telemetryRecorder', 'locking', 'checkpointing', 'checkpointKey']);
+const FUNCTION_BLOCKED_PROPERTIES = new Set<string | symbol>([
+    // Internal clients & cross-run capabilities (raw node client carries the secret key + raw axios)
+    'nango',
+    'persistClient',
+    'telemetryRecorder',
+    'locking',
+    'checkpointing',
+    'checkpointKey',
+
+    // Secret-bearing / sensitive state
+    'integrationConfig', // holds the decrypted oauth_client_secret
+    'memoizedConnections', // cached connection credentials
+    'memoizedIntegration',
+    'attributes',
+
+    // Usage/metering accounting — must not be tamperable by customer code
+    'telemetryBag',
+
+    // Internal helper methods (not part of the public SDK surface)
+    'getProxyConfig',
+    'throwIfAbortedOrKilled',
+    'throwIfInterrupted',
+    'shouldLog',
+    'validateRecords',
+    'removeMetadata',
+    'modelFullName',
+    'sendLogToPersist',
+    'logAPICall',
+    'getMergingStrategy',
+    'setMergingStrategyByModel',
+    'trackDeletesKey',
+    'fetchRecordsPage',
+    'getCheckpointRange',
+    'clearRecordsIfNeeded',
+
+    // Internal tuning / bookkeeping state
+    'batchSize',
+    'getRecordsBatchSize',
+    'mergingByModel',
+    'httpLogSample'
+]);
 
 function throwBlockedAccess(prop: string | symbol): never {
     const name = typeof prop === 'symbol' ? prop.toString() : prop;
@@ -987,33 +1036,43 @@ function throwBlockedAccess(prop: string | symbol): never {
  * Wraps a runner instance in a Proxy that is safe to hand to customer-authored functions.
  */
 export function createFunctionFacade<T extends NangoActionRunner | NangoSyncRunner>(runner: T): T {
+    const boundCache = new Map<string | symbol, (...args: any[]) => any>();
+
     return new Proxy(runner, {
         get(target, prop) {
             if (FUNCTION_BLOCKED_PROPERTIES.has(prop)) {
                 throwBlockedAccess(prop);
             }
             const value = Reflect.get(target, prop);
-            if (typeof value === 'function') {
-                return value.bind(target);
+            if (typeof value !== 'function') {
+                return value;
             }
-            return value;
+            let bound = boundCache.get(prop);
+            if (!bound) {
+                bound = (value as (...args: any[]) => any).bind(target);
+                boundCache.set(prop, bound);
+            }
+            return bound;
         },
         set(target, prop, value) {
             if (FUNCTION_BLOCKED_PROPERTIES.has(prop)) {
                 throwBlockedAccess(prop);
             }
+            boundCache.delete(prop);
             return Reflect.set(target, prop, value);
         },
         defineProperty(target, prop, descriptor) {
             if (FUNCTION_BLOCKED_PROPERTIES.has(prop)) {
                 throwBlockedAccess(prop);
             }
+            boundCache.delete(prop);
             return Reflect.defineProperty(target, prop, descriptor);
         },
         deleteProperty(target, prop) {
             if (FUNCTION_BLOCKED_PROPERTIES.has(prop)) {
                 throwBlockedAccess(prop);
             }
+            boundCache.delete(prop);
             return Reflect.deleteProperty(target, prop);
         },
         has(target, prop) {

--- a/packages/runner/lib/sdk/sdk.ts
+++ b/packages/runner/lib/sdk/sdk.ts
@@ -987,6 +987,8 @@ const FUNCTION_BLOCKED_PROPERTIES = new Set<string | symbol>([
     'memoizedIntegration',
     'attributes',
     'telemetryBag',
+    'abortSignal',
+    'lifecycle',
     'getProxyConfig',
     'throwIfAbortedOrKilled',
     'throwIfInterrupted',

--- a/packages/runner/lib/sdk/sdk.unit.test.ts
+++ b/packages/runner/lib/sdk/sdk.unit.test.ts
@@ -916,6 +916,42 @@ describe('createFunctionFacade', () => {
         });
     });
 
+    describe('protects execution-control fields (abort/kill)', () => {
+        it('throws when reading abortSignal or lifecycle', () => {
+            const { facade } = buildActionFacade();
+            expect(() => (facade as any).abortSignal).toThrowError(/is not allowed/);
+            expect(() => (facade as any).lifecycle).toThrowError(/is not allowed/);
+        });
+
+        it('throws when overwriting abortSignal or lifecycle', () => {
+            const { facade } = buildActionFacade();
+            expect(() => {
+                (facade as any).abortSignal = { aborted: false };
+            }).toThrowError(/is not allowed/);
+            expect(() => {
+                (facade as any).lifecycle = undefined;
+            }).toThrowError(/is not allowed/);
+        });
+
+        it('cannot disable abort enforcement by overwriting abortSignal through the facade', async () => {
+            const ac = new AbortController();
+            const persistClient = new PersistClient({ secretKey: '***' });
+            persistClient.postLog = vi.fn().mockResolvedValue(Ok(undefined));
+            const runner = new NangoActionRunner({ ...nangoProps, scriptType: 'action', abortSignal: ac.signal }, { persistClient, locks });
+            const facade = createFunctionFacade(runner);
+            ac.abort();
+
+            // Attempt to neutralize the abort signal via the facade — must be rejected
+            expect(() => {
+                (facade as any).abortSignal = { aborted: false };
+            }).toThrowError(/is not allowed/);
+
+            // The real signal is untouched, so SDK calls still honor the abort
+            expect(runner.abortSignal?.aborted).toBe(true);
+            await expect(facade.log('hello')).rejects.toThrowError(new ExecutionAbortedSDKError());
+        });
+    });
+
     describe('blocks prototype-chain escape hatches', () => {
         it('hides the real runner prototype via getPrototypeOf', () => {
             const { facade } = buildActionFacade();

--- a/packages/runner/lib/sdk/sdk.unit.test.ts
+++ b/packages/runner/lib/sdk/sdk.unit.test.ts
@@ -9,7 +9,7 @@ import { Ok } from '@nangohq/utils';
 
 import { PersistClient } from '../clients/persist.js';
 import { MapLocks } from './locks.js';
-import { NangoActionRunner, NangoSyncRunner } from './sdk.js';
+import { createFunctionFacade, NangoActionRunner, NangoSyncRunner } from './sdk.js';
 
 import type { CursorPagination, DBSyncConfig, LinkPagination, NangoProps, OffsetPagination, Pagination, Provider } from '@nangohq/types';
 import type { AxiosResponse } from 'axios';
@@ -836,5 +836,122 @@ describe('proxy 401 invalid credentials', () => {
         expect(httpSpy).toHaveBeenCalledTimes(2);
         expect(getConnectionMock).toHaveBeenCalledTimes(2);
         expectInvalidCredentialsInLogs(persistClient, false);
+    });
+});
+
+describe('createFunctionFacade', () => {
+    const blockedProperties = ['nango', 'persistClient', 'telemetryRecorder', 'locking', 'checkpointing', 'checkpointKey'] as const;
+
+    beforeEach(async () => {
+        const nodeClient = (await import('@nangohq/node')).Nango;
+        nodeClient.prototype.getConnection = vi.fn().mockResolvedValue({ credentials: {} });
+        nodeClient.prototype.setMetadata = vi.fn().mockResolvedValue({});
+        nodeClient.prototype.getIntegration = vi.fn().mockResolvedValue({ data: { provider: 'github' } });
+        vi.spyOn(ProxyRequest.prototype, 'httpCall').mockResolvedValue({
+            status: 200,
+            statusText: 'OK',
+            data: {},
+            headers: {},
+            config: {} as never
+        } as AxiosResponse);
+    });
+
+    afterEach(() => {
+        vi.clearAllMocks();
+    });
+
+    function buildActionFacade() {
+        const persistClient = new PersistClient({ secretKey: '***' });
+        persistClient.postLog = vi.fn().mockResolvedValue(Ok(undefined));
+        const runner = new NangoActionRunner({ ...nangoProps, scriptType: 'action' }, { persistClient, locks });
+        return { facade: createFunctionFacade(runner), persistClient };
+    }
+
+    function buildSyncFacade() {
+        const persistClient = new PersistClient({ secretKey: '***' });
+        persistClient.postLog = vi.fn().mockResolvedValue(Ok(undefined));
+        persistClient.postRecords = vi.fn().mockResolvedValue({ result: Ok({ nextMerging: { strategy: 'override' } }), bytesSent: 0 });
+        const runner = new NangoSyncRunner({ ...nangoProps }, { persistClient, locks });
+        return { facade: createFunctionFacade(runner), persistClient };
+    }
+
+    describe('blocks access to internal properties', () => {
+        for (const prop of blockedProperties) {
+            it(`throws when reading "${prop}"`, () => {
+                const { facade } = buildActionFacade();
+                expect(() => (facade as any)[prop]).toThrowError(/is not allowed/);
+            });
+        }
+
+        it('blocks reaching the raw Axios instance via nango.http', () => {
+            const { facade } = buildActionFacade();
+            // Accessing `.nango` throws before `.http` can be reached
+            expect(() => (facade as any).nango.http).toThrowError(/is not allowed/);
+        });
+
+        it('cannot recover the node client via getOwnPropertyDescriptor', () => {
+            const { facade } = buildActionFacade();
+            expect(Object.getOwnPropertyDescriptor(facade, 'nango')).toBeUndefined();
+        });
+
+        it('hides blocked properties from "in", Object.keys and ownKeys', () => {
+            const { facade } = buildActionFacade();
+            for (const prop of blockedProperties) {
+                expect(prop in facade).toBe(false);
+            }
+            expect(Object.keys(facade)).not.toContain('nango');
+            expect(Reflect.ownKeys(facade)).not.toContain('nango');
+        });
+
+        it('throws when writing to a blocked property', () => {
+            const { facade } = buildActionFacade();
+            expect(() => {
+                (facade as any).nango = {};
+            }).toThrowError(/is not allowed/);
+        });
+
+        it('blocks access on the sync runner facade too', () => {
+            const { facade } = buildSyncFacade();
+            expect(() => (facade as any).nango).toThrowError(/is not allowed/);
+        });
+    });
+
+    describe('still exposes the public SDK surface', () => {
+        it('reads non-blocked properties', () => {
+            const { facade } = buildActionFacade();
+            expect(facade.connectionId).toBe(nangoProps.connectionId);
+            expect(facade.providerConfigKey).toBe(nangoProps.providerConfigKey);
+        });
+
+        it('runs proxy() through the facade', async () => {
+            const { facade } = buildActionFacade();
+            const res = await facade.proxy({ endpoint: '/issues' });
+            expect(res.status).toBe(200);
+        });
+
+        it('runs getConnection() through the facade', async () => {
+            const { facade } = buildActionFacade();
+            await expect(facade.getConnection()).resolves.toBeDefined();
+        });
+
+        it('runs log() through the facade', async () => {
+            const { facade, persistClient } = buildActionFacade();
+            await facade.log('hello');
+            expect(persistClient.postLog).toHaveBeenCalledOnce();
+        });
+
+        it('runs borrowed methods (proxy, log, batchSave) on the sync runner facade', async () => {
+            const { facade, persistClient } = buildSyncFacade();
+            const res = await facade.proxy({ endpoint: '/issues' });
+            expect(res.status).toBe(200);
+
+            // proxy() can emit its own HTTP log, so reset before asserting log() specifically
+            vi.mocked(persistClient.postLog).mockClear();
+            await facade.log('hello');
+            expect(persistClient.postLog).toHaveBeenCalledOnce();
+
+            await expect(facade.batchSave([{ id: '1' }], 'SomeModel')).resolves.toBe(true);
+            expect(persistClient.postRecords).toHaveBeenCalledOnce();
+        });
     });
 });

--- a/packages/runner/lib/sdk/sdk.unit.test.ts
+++ b/packages/runner/lib/sdk/sdk.unit.test.ts
@@ -916,6 +916,45 @@ describe('createFunctionFacade', () => {
         });
     });
 
+    describe('blocks prototype-chain escape hatches', () => {
+        it('hides the real runner prototype via getPrototypeOf', () => {
+            const { facade } = buildActionFacade();
+            expect(Object.getPrototypeOf(facade)).toBeNull();
+            expect(Reflect.getPrototypeOf(facade)).toBeNull();
+        });
+
+        it('throws when reading __proto__ or constructor', () => {
+            const { facade } = buildActionFacade();
+            expect(() => (facade as any).__proto__).toThrowError(/is not allowed/);
+            expect(() => (facade as any).constructor).toThrowError(/is not allowed/);
+        });
+
+        it('throws when re-parenting the runner', () => {
+            const { facade } = buildActionFacade();
+            expect(() => {
+                (facade as any).__proto__ = {};
+            }).toThrowError(/is not allowed/);
+            expect(() => Object.setPrototypeOf(facade, {})).toThrowError(/is not allowed/);
+        });
+
+        it('cannot pollute the shared class prototype through the facade', () => {
+            const { facade } = buildActionFacade();
+            const original = NangoActionRunner.prototype.proxy;
+
+            // getPrototypeOf returns null, so there is no reachable prototype object to mutate
+            expect(Object.getPrototypeOf(facade)).toBeNull();
+
+            // and the real shared prototype is left untouched
+            expect(NangoActionRunner.prototype.proxy).toBe(original);
+        });
+
+        it('hides prototype escape hatches on the sync runner facade too', () => {
+            const { facade } = buildSyncFacade();
+            expect(Object.getPrototypeOf(facade)).toBeNull();
+            expect(() => (facade as any).constructor).toThrowError(/is not allowed/);
+        });
+    });
+
     describe('still exposes the public SDK surface', () => {
         it('reads non-blocked properties', () => {
             const { facade } = buildActionFacade();

--- a/packages/runner/lib/sdk/sdk.unit.test.ts
+++ b/packages/runner/lib/sdk/sdk.unit.test.ts
@@ -952,6 +952,55 @@ describe('createFunctionFacade', () => {
         });
     });
 
+    describe('blocks injected-accessor receiver escapes', () => {
+        it('blocks a getter installed via defineProperty from leaking the raw client', () => {
+            const { facade } = buildActionFacade();
+            Object.defineProperty(facade, 'x', { get: () => (facade as any).nango, configurable: true });
+            // The injected getter runs with `this` = the facade, so reaching `.nango` re-enters the trap
+            expect(() => (facade as any).x).toThrowError(/is not allowed/);
+        });
+
+        it('blocks a getter that returns `this.nango`', () => {
+            const { facade } = buildActionFacade();
+            Object.defineProperty(facade, 'x', {
+                get() {
+                    return (this as any).nango;
+                },
+                configurable: true
+            });
+            expect(() => (facade as any).x).toThrowError(/is not allowed/);
+        });
+
+        it('does not let a setter capture the raw runner instance', () => {
+            const { facade } = buildActionFacade();
+            Object.defineProperty(facade, 'capture', {
+                set(v: any) {
+                    v.stolen = this;
+                },
+                configurable: true
+            });
+            const box: any = {};
+            (facade as any).capture = box;
+            // `this` inside the setter must be the facade, never the raw runner
+            expect(box.stolen).toBe(facade);
+            expect(() => box.stolen.nango).toThrowError(/is not allowed/);
+        });
+
+        it('blocks a getter installed via __defineGetter__', () => {
+            const { facade } = buildActionFacade();
+            (facade as any).__defineGetter__('y', function (this: any) {
+                return this.nango;
+            });
+            expect(() => (facade as any).y).toThrowError(/is not allowed/);
+        });
+
+        it('still allows normal data-property writes and reads through the facade', () => {
+            const { facade } = buildActionFacade();
+            (facade as any).customField = 42;
+            expect((facade as any).customField).toBe(42);
+        });
+    });
+
     describe('blocks prototype-chain escape hatches', () => {
         it('hides the real runner prototype via getPrototypeOf', () => {
             const { facade } = buildActionFacade();


### PR DESCRIPTION
- Tightens how the runner instance is exposed to customer-authored functions so that only the supported SDK surface is reachable. 
- No changes to the public SDK API or existing function behavior.
- Added test coverage for the new behavior.

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/NangoHQ/nango/pull/6669?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

