### PR TITLE
fix(webapp): make usage chart legend series clearly toggleable

### DIFF
--- a/packages/webapp/src/components/patterns/chart/BreakdownChart.tsx
+++ b/packages/webapp/src/components/patterns/chart/BreakdownChart.tsx
@@ -70,7 +70,7 @@ export const BreakdownChart: React.FC<BreakdownChartProps> = ({ chartData, confi
                             onMouseEnter={() => hoverSeries(s.key)}
                             onMouseLeave={() => unhoverSeries()}
                             onClick={bandClick(s)}
-                            className="cursor-pointer"
+                            className="cursor-pointer [&_path]:transition-all [&_path]:duration-150"
                         />
                     );
                 }

--- a/packages/webapp/src/components/patterns/chart/BreakdownChart.tsx
+++ b/packages/webapp/src/components/patterns/chart/BreakdownChart.tsx
@@ -70,7 +70,7 @@ export const BreakdownChart: React.FC<BreakdownChartProps> = ({ chartData, confi
                             onMouseEnter={() => hoverSeries(s.key)}
                             onMouseLeave={() => unhoverSeries()}
                             onClick={bandClick(s)}
-                            className="cursor-pointer [&_path]:transition-all [&_path]:duration-150"
+                            className="cursor-pointer [&_path]:transition-[fill-opacity,stroke-opacity] [&_path]:duration-150"
                         />
                     );
                 }

--- a/packages/webapp/src/components/patterns/chart/ChartLegend.tsx
+++ b/packages/webapp/src/components/patterns/chart/ChartLegend.tsx
@@ -12,11 +12,15 @@ interface ChartLegendProps {
 
 /** Interactive legend: hover a row to highlight its band, click the label to isolate, click the swatch to hide/show. */
 export const ChartLegend: React.FC<ChartLegendProps> = ({ series, interactions }) => {
-    const { hidden, isSeriesHidden, toggleIsolate, toggleHidden, hoverSeries, unhoverSeries } = interactions;
+    const { hidden, isSeriesHidden, toggleIsolate, toggleHidden, hoverSeries, unhoverSeries, hoveredKey } = interactions;
     return (
-        <div className="grid grid-cols-[repeat(auto-fill,minmax(150px,1fr))] gap-x-2 gap-y-0.5 pt-3 pb-1 max-h-[88px] overflow-y-auto flex-shrink-0 text-xs">
+        <div className="grid grid-cols-[repeat(auto-fill,minmax(150px,1fr))] gap-x-2 gap-y-0.5 pt-3 pb-1 max-h-[96px] overflow-y-auto flex-shrink-0 text-[13px]">
             {series.map((s) => {
                 const dimmed = isSeriesHidden(s.key);
+                // `active` = this series is the hovered one. It's set both by hovering the legend row and by
+                // hovering the series' chart band (BreakdownChart calls hoverSeries on band enter), so highlight
+                // stays in sync in both directions.
+                const active = hoveredKey === s.key;
                 // Highlight this series' band when hovering its swatch or label. Skipped when the series is hidden.
                 const onEnter = () => {
                     if (!dimmed) hoverSeries(s.key);
@@ -35,22 +39,32 @@ export const ChartLegend: React.FC<ChartLegendProps> = ({ series, interactions }
                     // The grid cell keeps column alignment; the inner pill hugs swatch + label so the
                     // hover background only covers the content, not the empty space across the cell.
                     <div key={s.key} className="flex min-w-0">
-                        <div className="group/row inline-flex min-w-0 max-w-full cursor-pointer items-center gap-1.5 rounded-md px-1 py-0.5 transition-colors hover:bg-state-selected-muted">
-                            {/* Color chip. Row hover outlines it with a darker shade of its own color (border-box keeps the
-                                size). Hovering the swatch directly fades the chip out and swaps in a cross — or a check, if the
-                                series is already hidden — as the toggle cue. */}
-                            <button {...toggleProps} className="group/swatch relative flex size-4 shrink-0 items-center justify-center">
+                        <div
+                            className={cn(
+                                'group/row inline-flex min-w-0 max-w-full cursor-pointer items-center gap-1.5 rounded-md px-1 py-0.5 transition-colors hover:bg-state-selected-muted',
+                                active && 'bg-state-selected-muted'
+                            )}
+                        >
+                            {/* Checkbox-style swatch: a color-filled square with a ring (a darker shade of its own color)
+                                so it reads as a control at rest. OFF = empty square (neutral ring, no fill). Hovering the
+                                swatch directly swaps it for a cross — or a check, if the series is already hidden. */}
+                            <button {...toggleProps} className="group/swatch relative flex size-[18px] shrink-0 items-center justify-center">
                                 <span
                                     className={cn(
-                                        'block size-2.5 rounded-[2px] border-2 border-transparent transition group-hover/row:[border-color:color-mix(in_srgb,var(--swatch),#000_30%)] group-hover/swatch:opacity-0',
-                                        dimmed ? 'opacity-30' : 'opacity-100'
+                                        'block size-3.5 rounded-[3px] transition group-hover/swatch:opacity-0',
+                                        dimmed
+                                            ? '[box-shadow:0_0_0_1px_var(--color-border-default)]'
+                                            : cn(
+                                                  '[box-shadow:0_0_0_1px_color-mix(in_srgb,var(--swatch),#000_28%)] group-hover/row:[box-shadow:0_0_0_1.5px_color-mix(in_srgb,var(--swatch),#000_45%)]',
+                                                  active && '[box-shadow:0_0_0_1.5px_color-mix(in_srgb,var(--swatch),#000_45%)]'
+                                              )
                                     )}
-                                    style={{ backgroundColor: s.color, ['--swatch']: s.color } as React.CSSProperties}
+                                    style={dimmed ? undefined : ({ backgroundColor: s.color, ['--swatch']: s.color } as React.CSSProperties)}
                                 />
                                 {hidden.has(s.key) ? (
-                                    <Check className="pointer-events-none absolute size-3.5 text-text-secondary opacity-0 transition-opacity group-hover/swatch:opacity-100" />
+                                    <Check className="pointer-events-none absolute size-4 text-text-secondary opacity-0 transition-opacity group-hover/swatch:opacity-100" />
                                 ) : (
-                                    <X className="pointer-events-none absolute size-3.5 text-text-secondary opacity-0 transition-opacity group-hover/swatch:opacity-100" />
+                                    <X className="pointer-events-none absolute size-4 text-text-secondary opacity-0 transition-opacity group-hover/swatch:opacity-100" />
                                 )}
                             </button>
                             {/* Clicking the label isolates this series; clicking again shows all. */}
@@ -61,7 +75,9 @@ export const ChartLegend: React.FC<ChartLegendProps> = ({ series, interactions }
                                 onMouseLeave={onLeave}
                                 className={cn(
                                     'relative min-w-0 truncate transition-colors',
-                                    dimmed ? 'text-text-muted line-through hover:text-text-secondary' : 'text-text-secondary group-hover/row:text-text-strong'
+                                    dimmed
+                                        ? 'text-text-muted line-through hover:text-text-secondary'
+                                        : cn('text-text-secondary group-hover/row:text-text-strong', active && 'text-text-strong')
                                 )}
                                 title={s.label}
                             >

--- a/packages/webapp/src/components/patterns/chart/ChartLegend.tsx
+++ b/packages/webapp/src/components/patterns/chart/ChartLegend.tsx
@@ -51,12 +51,13 @@ export const ChartLegend: React.FC<ChartLegendProps> = ({ series, interactions }
                             <button {...toggleProps} className="group/swatch relative flex size-[18px] shrink-0 items-center justify-center">
                                 <span
                                     className={cn(
-                                        'block size-3.5 rounded-[3px] transition group-hover/swatch:opacity-0',
+                                        // border-box keeps the outer size fixed, so a thicker border on hover grows inward, not outward.
+                                        'block size-3.5 rounded-[3px] border transition group-hover/swatch:opacity-0',
                                         dimmed
-                                            ? '[box-shadow:0_0_0_1px_var(--color-border-default)]'
+                                            ? 'border-border-default'
                                             : cn(
-                                                  '[box-shadow:0_0_0_1px_color-mix(in_srgb,var(--swatch),#000_28%)] group-hover/row:[box-shadow:0_0_0_1.5px_color-mix(in_srgb,var(--swatch),#000_45%)]',
-                                                  active && '[box-shadow:0_0_0_1.5px_color-mix(in_srgb,var(--swatch),#000_45%)]'
+                                                  '[border-color:color-mix(in_srgb,var(--swatch),#000_28%)] group-hover/row:border-[1.5px] group-hover/row:[border-color:color-mix(in_srgb,var(--swatch),#000_45%)]',
+                                                  active && 'border-[1.5px] [border-color:color-mix(in_srgb,var(--swatch),#000_45%)]'
                                               )
                                     )}
                                     style={dimmed ? undefined : ({ backgroundColor: s.color, ['--swatch']: s.color } as React.CSSProperties)}

--- a/packages/webapp/src/components/patterns/chart/ChartLegend.tsx
+++ b/packages/webapp/src/components/patterns/chart/ChartLegend.tsx
@@ -14,55 +14,60 @@ interface ChartLegendProps {
 export const ChartLegend: React.FC<ChartLegendProps> = ({ series, interactions }) => {
     const { hidden, isSeriesHidden, toggleIsolate, toggleHidden, hoverSeries, unhoverSeries } = interactions;
     return (
-        <div className="grid grid-cols-[repeat(auto-fill,minmax(150px,1fr))] gap-x-3 gap-y-1.5 pt-3 max-h-[88px] overflow-y-auto flex-shrink-0 text-xs">
+        <div className="grid grid-cols-[repeat(auto-fill,minmax(150px,1fr))] gap-x-2 gap-y-0.5 pt-3 pb-1 max-h-[88px] overflow-y-auto flex-shrink-0 text-xs">
             {series.map((s) => {
                 const dimmed = isSeriesHidden(s.key);
-                // Highlight this series' band when hovering its swatch or label — not the empty
-                // grid-cell space to the right of a short label. Skipped when the series is hidden.
+                // Highlight this series' band when hovering its swatch or label. Skipped when the series is hidden.
                 const onEnter = () => {
                     if (!dimmed) hoverSeries(s.key);
                 };
                 const onLeave = () => unhoverSeries();
+                const toggleProps = {
+                    type: 'button' as const,
+                    onClick: () => toggleHidden(s.key),
+                    onMouseEnter: onEnter,
+                    onMouseLeave: onLeave,
+                    'aria-pressed': hidden.has(s.key),
+                    'aria-label': `${hidden.has(s.key) ? 'Show' : 'Hide'} ${s.label}`,
+                    title: `Toggle ${s.label}`
+                };
                 return (
-                    <div key={s.key} className="flex min-w-0 items-center gap-1.5">
-                        {/* Hover the swatch to reveal ✕/✓; click to toggle this series off/on. */}
-                        <button
-                            type="button"
-                            onClick={() => toggleHidden(s.key)}
-                            onMouseEnter={onEnter}
-                            onMouseLeave={onLeave}
-                            className="group/swatch relative flex size-4 shrink-0 items-center justify-center"
-                            aria-pressed={hidden.has(s.key)}
-                            aria-label={`${hidden.has(s.key) ? 'Show' : 'Hide'} ${s.label}`}
-                            title={`Toggle ${s.label}`}
-                        >
-                            <span
-                                className={cn(
-                                    'block h-2.5 w-2.5 rounded-[2px] transition-opacity group-hover/swatch:opacity-0',
-                                    dimmed ? 'opacity-30' : 'opacity-100'
+                    // The grid cell keeps column alignment; the inner pill hugs swatch + label so the
+                    // hover background only covers the content, not the empty space across the cell.
+                    <div key={s.key} className="flex min-w-0">
+                        <div className="group/row inline-flex min-w-0 max-w-full cursor-pointer items-center gap-1.5 rounded-md px-1 py-0.5 transition-colors hover:bg-state-selected-muted">
+                            {/* Color chip. Row hover outlines it with a darker shade of its own color (border-box keeps the
+                                size). Hovering the swatch directly fades the chip out and swaps in a cross — or a check, if the
+                                series is already hidden — as the toggle cue. */}
+                            <button {...toggleProps} className="group/swatch relative flex size-4 shrink-0 items-center justify-center">
+                                <span
+                                    className={cn(
+                                        'block size-2.5 rounded-[2px] border-2 border-transparent transition group-hover/row:[border-color:color-mix(in_srgb,var(--swatch),#000_30%)] group-hover/swatch:opacity-0',
+                                        dimmed ? 'opacity-30' : 'opacity-100'
+                                    )}
+                                    style={{ backgroundColor: s.color, ['--swatch']: s.color } as React.CSSProperties}
+                                />
+                                {hidden.has(s.key) ? (
+                                    <Check className="pointer-events-none absolute size-3.5 text-text-secondary opacity-0 transition-opacity group-hover/swatch:opacity-100" />
+                                ) : (
+                                    <X className="pointer-events-none absolute size-3.5 text-text-secondary opacity-0 transition-opacity group-hover/swatch:opacity-100" />
                                 )}
-                                style={{ backgroundColor: s.color }}
-                            />
-                            {hidden.has(s.key) ? (
-                                <Check className="absolute size-3.5 text-text-secondary opacity-0 transition-opacity group-hover/swatch:opacity-100" />
-                            ) : (
-                                <X className="absolute size-3.5 text-text-secondary opacity-0 transition-opacity group-hover/swatch:opacity-100" />
-                            )}
-                        </button>
-                        {/* Clicking the label isolates this series; clicking again shows all. */}
-                        <button
-                            type="button"
-                            onClick={() => toggleIsolate(s.key)}
-                            onMouseEnter={onEnter}
-                            onMouseLeave={onLeave}
-                            className={cn(
-                                'min-w-0 truncate transition-colors',
-                                dimmed ? 'text-text-muted line-through hover:text-text-secondary' : 'text-text-secondary hover:text-text-strong'
-                            )}
-                            title={s.label}
-                        >
-                            {s.label}
-                        </button>
+                            </button>
+                            {/* Clicking the label isolates this series; clicking again shows all. */}
+                            <button
+                                type="button"
+                                onClick={() => toggleIsolate(s.key)}
+                                onMouseEnter={onEnter}
+                                onMouseLeave={onLeave}
+                                className={cn(
+                                    'relative min-w-0 truncate transition-colors',
+                                    dimmed ? 'text-text-muted line-through hover:text-text-secondary' : 'text-text-secondary group-hover/row:text-text-strong'
+                                )}
+                                title={s.label}
+                            >
+                                {s.label}
+                            </button>
+                        </div>
                     </div>
                 );
             })}


### PR DESCRIPTION
## Problem

On the usage breakdown charts (Team billing → Usage, when grouped), the colored legend read like a static legend, so it wasn't obvious that each series can be clicked to hide/show or isolate it.

## Solution

- Each legend item is now a content-width pill with a subtle hover background and pointer cursor, so it reads as one interactive control.
- Swatches are checkbox-style and a touch larger: a color-filled square with a ring in a darker shade of its own color (on), or an empty square + strikethrough (off).
- Hovering the swatch directly swaps it for a cross (×) — or a check (✓) if the series is already hidden — as the toggle cue.
- Hover is synced both ways: hovering a legend row dims the other chart bands, and hovering a chart band highlights its legend row.
- Click semantics are unchanged: swatch hides/shows the series, label isolates it (click again to show all).

Fixes [NAN-6114](https://linear.app/nango/issue/NAN-6114)

## Testing

- Verified locally on the billing usage dashboard against seeded ClickHouse data.
- On/off swatch states, the swatch cross/check cue, and toggle + isolate behavior all work.
- Legend ↔ chart hover highlighting works in both directions.
- Resting swatches still color-match the chart bands.
