### PR TITLE
feat(webapp): redesign profile settings with label-left layout

### DIFF
--- a/packages/design-system/src/components/ui/input-group.tsx
+++ b/packages/design-system/src/components/ui/input-group.tsx
@@ -25,8 +25,8 @@ const inputGroupVariants = cva(
         // Filled state - different border when input has text (works for both controlled and uncontrolled inputs)
         'has-[[data-slot=input-group-control][data-filled=true]:not(:disabled)]:border-border-interactive-hover',
 
-        // Disabled — dedicated tokens (matches Input), no opacity.
-        'has-[[data-slot=input-group-control]:disabled]:border-border-disabled has-[[data-slot=input-group-control]:disabled]:bg-state-selected-muted',
+        // Disabled — keep the interactive border (matches Input); only the bg switches to the disabled token, no opacity.
+        'has-[[data-slot=input-group-control]:disabled]:border-border-interactive has-[[data-slot=input-group-control]:disabled]:bg-state-selected-muted',
 
         // Error state.
         'has-[[data-slot][aria-invalid=true]]:!border-status-danger-border has-[[data-slot][aria-invalid=true]:focus-visible]:!border-[var(--focus-ring-danger)] has-[[data-slot][aria-invalid=true]:focus-visible]:!shadow-[0_0_0_0.5px_var(--focus-ring-danger),inset_0_0_0_0.5px_var(--focus-ring-danger)]'

--- a/packages/design-system/src/components/ui/input.tsx
+++ b/packages/design-system/src/components/ui/input.tsx
@@ -19,8 +19,8 @@ export const inputVariants = cva(
         'focus:border-[var(--focus-ring-default)] focus:shadow-[0_0_0_0.5px_var(--focus-ring-default),inset_0_0_0_0.5px_var(--focus-ring-default)]',
         // Invalid
         'aria-invalid:border-status-danger-border aria-invalid:focus:border-[var(--focus-ring-danger)] aria-invalid:focus:shadow-[0_0_0_0.5px_var(--focus-ring-danger),inset_0_0_0_0.5px_var(--focus-ring-danger)]',
-        // Disabled — dedicated tokens, no opacity (Figma state/selectedMuted bg, border/disabled, text/disabled)
-        'disabled:cursor-not-allowed disabled:border-border-disabled disabled:bg-state-selected-muted disabled:text-text-disabled disabled:placeholder:text-text-disabled',
+        // Disabled — keep the interactive border (Figma), only the bg + text switch to the disabled tokens; no opacity
+        'disabled:cursor-not-allowed disabled:border-border-interactive disabled:bg-state-selected-muted disabled:text-text-disabled disabled:placeholder:text-text-disabled',
         // File-input affordance
         'file:inline-flex file:h-7 file:border-0 file:bg-transparent file:text-text-strong file:text-ds-md file:font-ds-medium'
     ],

--- a/packages/design-system/src/components/ui/textarea.tsx
+++ b/packages/design-system/src/components/ui/textarea.tsx
@@ -22,8 +22,8 @@ const Textarea = React.forwardRef<HTMLTextAreaElement, TextareaProps>(({ classNa
                 'focus:border-[var(--focus-ring-default)] focus:shadow-[0_0_0_0.5px_var(--focus-ring-default),inset_0_0_0_0.5px_var(--focus-ring-default)]',
                 // Invalid
                 'aria-invalid:border-status-danger-border aria-invalid:focus:border-[var(--focus-ring-danger)] aria-invalid:focus:shadow-[0_0_0_0.5px_var(--focus-ring-danger),inset_0_0_0_0.5px_var(--focus-ring-danger)]',
-                // Disabled — dedicated tokens, no opacity
-                'disabled:cursor-not-allowed disabled:border-border-disabled disabled:bg-state-selected-muted disabled:text-text-disabled disabled:placeholder:text-text-disabled',
+                // Disabled — keep the interactive border, only the bg + text switch to the disabled tokens; no opacity
+                'disabled:cursor-not-allowed disabled:border-border-interactive disabled:bg-state-selected-muted disabled:text-text-disabled disabled:placeholder:text-text-disabled',
                 className
             )}
             {...props}

--- a/packages/design-system/stories/EditableInput.stories.tsx
+++ b/packages/design-system/stories/EditableInput.stories.tsx
@@ -1,19 +1,75 @@
+import { expect, fn, userEvent, within } from 'storybook/test';
+
 import { EditableInput } from '@/components/patterns/EditableInput';
 
 import type { Meta, StoryObj } from '@storybook/react-vite';
 
-const meta: Meta<typeof EditableInput> = {
-    component: EditableInput,
+const meta: Meta = {
     title: 'Components/Patterns/EditableInput',
     parameters: { layout: 'padded' }
 };
 export default meta;
 type Story = StoryObj<typeof meta>;
 
+// Mirrors a typical field constraint (e.g. profile display name: min 3, max 32).
+const validateName = (value: string): string | null => {
+    if (value.trim().length === 0) return 'Name is required';
+    if (value.length < 3) return 'Must be at least 3 characters';
+    if (value.length > 32) return 'Must be 32 characters or fewer';
+    return null;
+};
+
+/**
+ * Overview of the states — click a field's pencil to switch it into edit mode.
+ * The play function drives the "Validation" field into its error state so it's visible on load.
+ */
 export const Default: Story = {
     render: () => (
-        <div className="w-80">
-            <EditableInput initialValue="my-github-connection" onSave={async () => {}} />
+        <div className="flex flex-col gap-8 w-96">
+            <div className="flex flex-col gap-2">
+                <span className="story-section-heading">Editable</span>
+                <EditableInput initialValue="my-github-connection" onSave={fn()} />
+            </div>
+            <div className="flex flex-col gap-2">
+                <span className="story-section-heading">With hint text</span>
+                <EditableInput initialValue="acme-prod" onSave={fn()} hintText="Lowercase letters, numbers, dashes." />
+            </div>
+            <div className="flex flex-col gap-2">
+                <span className="story-section-heading">Secret</span>
+                <EditableInput initialValue="sk_live_51H8sceretvalue" onSave={fn()} secret />
+            </div>
+            <div className="flex flex-col gap-2">
+                <span className="story-section-heading">Secret multiline (private key)</span>
+                {/* The only shipping textArea usage pairs it with `secret`: masked single line at rest, multiline editor on edit. */}
+                <EditableInput
+                    initialValue={'-----BEGIN RSA PRIVATE KEY-----\nMIIEvQIBAD...\n-----END RSA PRIVATE KEY-----'}
+                    onSave={fn()}
+                    secret
+                    textArea
+                    hintText="Paste the full key contents."
+                />
+            </div>
+            <div className="flex flex-col gap-2">
+                <span className="story-section-heading">Locked (with reason)</span>
+                <EditableInput initialValue="prod" onSave={fn()} disabled="The production environment cannot be renamed." />
+            </div>
+            <div className="flex flex-col gap-2" data-testid="validation-field">
+                <span className="story-section-heading">Validation</span>
+                <EditableInput initialValue="acme" onSave={fn()} validate={validateName} hintText="Between 3 and 32 characters." />
+            </div>
         </div>
-    )
+    ),
+    // Show the validation error state on load: enter edit mode on the validation field and type a too-short value.
+    play: async ({ canvasElement }) => {
+        const field = within(within(canvasElement).getByTestId('validation-field'));
+
+        await userEvent.click(field.getByRole('button', { name: 'Edit' }));
+
+        const input = field.getByRole('textbox');
+        await userEvent.clear(input);
+        await userEvent.type(input, 'ab');
+
+        await expect(field.getByText('Must be at least 3 characters')).toBeVisible();
+        await expect(field.getByRole('button', { name: 'Save' })).toBeDisabled();
+    }
 };

--- a/packages/webapp/src/components/patterns/EditableInput.tsx
+++ b/packages/webapp/src/components/patterns/EditableInput.tsx
@@ -1,4 +1,4 @@
-import { Check, Edit, Loader2, X } from 'lucide-react';
+import { Check, Loader2, Pencil, X } from 'lucide-react';
 import { useEffect, useRef, useState } from 'react';
 
 import { InputGroup, InputGroupAddon, InputGroupButton, InputGroupInput, InputGroupTextarea } from '@nangohq/design-system';
@@ -52,12 +52,16 @@ export const EditableInput: React.FC<EditableInputProps> = ({
         onEditingChange?.(true);
     };
 
-    // We have to focus on useEffect because the input is disabled when not editing
+    // Focus in an effect because the control only becomes editable once `editing` flips.
     useEffect(() => {
         onEditingChange?.(editing);
-        if (editing) {
-            inputRef.current?.focus();
-        }
+        if (!editing) return;
+        const el = textareaRef.current ?? inputRef.current;
+        if (!el) return;
+        el.focus();
+        // Start editing from the end of the value, not wherever the caret was left in read mode.
+        const end = el.value.length;
+        el.setSelectionRange(end, end);
     }, [editing, onEditingChange]);
 
     const handleChange = (e: React.ChangeEvent<HTMLInputElement | HTMLTextAreaElement>) => {
@@ -111,7 +115,8 @@ export const EditableInput: React.FC<EditableInputProps> = ({
     const displayValue = !canRead ? '•'.repeat(32) : value;
 
     return (
-        <div className="flex flex-col gap-2">
+        // In read mode the control is editable-looking but not editable, so drop the text caret cursor.
+        <div className={`flex flex-col gap-2 ${!editing ? '[&_input]:cursor-default [&_textarea]:cursor-default' : ''}`}>
             <InputGroup>
                 {textArea && (!secret || editing) ? (
                     <InputGroupTextarea
@@ -120,8 +125,10 @@ export const EditableInput: React.FC<EditableInputProps> = ({
                         value={displayValue}
                         onChange={handleChange}
                         rows={6}
-                        disabled={!editing}
+                        // Read-only (not disabled) so the field still looks editable at rest; editing is gated by the pencil.
+                        readOnly={!editing}
                         onKeyDown={(e) => {
+                            if (!editing) return;
                             if (e.key === 'Escape') onCancelClicked();
                         }}
                         aria-invalid={!!error}
@@ -134,8 +141,10 @@ export const EditableInput: React.FC<EditableInputProps> = ({
                         placeholder={editing ? placeHolder : undefined}
                         onChange={handleChange}
                         type={secret && !editing ? 'password' : 'text'}
-                        disabled={!editing}
+                        // Read-only (not disabled) so the field still looks editable at rest; editing is gated by the pencil.
+                        readOnly={!editing}
                         onKeyDown={(e) => {
+                            if (!editing) return;
                             if (e.key === 'Enter') void onSaveClicked();
                             if (e.key === 'Escape') onCancelClicked();
                         }}
@@ -152,7 +161,7 @@ export const EditableInput: React.FC<EditableInputProps> = ({
                             <PermissionGate condition={canEdit} tooltipSide="bottom">
                                 {(allowed) => (
                                     <InputGroupButton label="Edit" disabled={!!disabled || !allowed} onClick={onEditClicked} size="icon-sm">
-                                        <Edit className="size-3.5" />
+                                        <Pencil className="size-3.5" />
                                     </InputGroupButton>
                                 )}
                             </PermissionGate>

--- a/packages/webapp/src/components/patterns/EditableInput.tsx
+++ b/packages/webapp/src/components/patterns/EditableInput.tsx
@@ -186,7 +186,7 @@ export const EditableInput: React.FC<EditableInputProps> = ({
                 )}
             </InputGroup>
             {editing && (error || hintText) && (
-                <p className={`text-body-small-regular ${error ? 'text-status-danger-text' : 'text-text-muted'}`}>*{error || hintText}</p>
+                <p className={`text-body-small-regular ${error ? 'text-status-danger-text' : 'text-text-muted'}`}>{error || hintText}</p>
             )}
         </div>
     );

--- a/packages/webapp/src/components/ui/Select.tsx
+++ b/packages/webapp/src/components/ui/Select.tsx
@@ -64,7 +64,7 @@ function SelectContent({ className, children, position = 'popper', ...props }: R
             <SelectPrimitive.Content
                 data-slot="select-content"
                 className={cn(
-                    'bg-surface-overlay text-text-secondary border border-border-muted rounded data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0 data-[state=closed]:zoom-out-95 data-[state=open]:zoom-in-95 data-[side=bottom]:slide-in-from-top-2 data-[side=left]:slide-in-from-right-2 data-[side=right]:slide-in-from-left-2 data-[side=top]:slide-in-from-bottom-2 relative z-50 max-h-(--radix-select-content-available-height) min-w-[8rem] origin-(--radix-select-content-transform-origin) overflow-x-hidden overflow-y-auto',
+                    'bg-surface-overlay text-text-secondary border-ds-hairline border-border-input-hover rounded-ds-xs data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0 data-[state=closed]:zoom-out-95 data-[state=open]:zoom-in-95 data-[side=bottom]:slide-in-from-top-2 data-[side=left]:slide-in-from-right-2 data-[side=right]:slide-in-from-left-2 data-[side=top]:slide-in-from-bottom-2 relative z-50 max-h-(--radix-select-content-available-height) min-w-[8rem] origin-(--radix-select-content-transform-origin) overflow-x-hidden overflow-y-auto',
                     position === 'popper' &&
                         'data-[side=bottom]:translate-y-1 data-[side=left]:-translate-x-1 data-[side=right]:translate-x-1 data-[side=top]:-translate-y-1',
                     className

--- a/packages/webapp/src/pages/User/Settings.tsx
+++ b/packages/webapp/src/pages/User/Settings.tsx
@@ -1,6 +1,6 @@
 import { Helmet } from 'react-helmet';
 
-import { FieldLabel, FieldSeparator, Input } from '@nangohq/design-system';
+import { FieldLabel, Input } from '@nangohq/design-system';
 
 import { CriticalErrorAlert } from '@/components/patterns/CriticalErrorAlert';
 import { EditableInput } from '@/components/patterns/EditableInput';
@@ -74,20 +74,12 @@ export const UserSettings: React.FC = () => {
             <Helmet>
                 <title>Profile Settings - Nango</title>
             </Helmet>
-            <div className="grid max-w-[600px] grid-cols-[237px_1fr] items-center gap-x-6 gap-y-8">
+            <div className="grid max-w-[700px] grid-cols-[237px_1fr] items-center gap-x-6 gap-y-8">
                 <FieldLabel htmlFor="display-name">Display name</FieldLabel>
                 <EditableInput id="display-name" initialValue={user.name} onSave={onSaveDisplayName} validate={validateDisplayName} />
 
-                <div className="col-span-2">
-                    <FieldSeparator />
-                </div>
-
                 <FieldLabel htmlFor="email">Email</FieldLabel>
                 <Input id="email" value={user.email} disabled readOnly />
-
-                <div className="col-span-2">
-                    <FieldSeparator />
-                </div>
 
                 <FieldLabel htmlFor="appearance">Appearance</FieldLabel>
                 <Select value={theme} onValueChange={(v) => setTheme(v as Theme)}>

--- a/packages/webapp/src/pages/User/Settings.tsx
+++ b/packages/webapp/src/pages/User/Settings.tsx
@@ -1,10 +1,9 @@
-import { Edit } from 'lucide-react';
-import { useRef, useState } from 'react';
 import { Helmet } from 'react-helmet';
 
-import { Button, Field, FieldLabel, IconButton, InputGroup, InputGroupAddon, InputGroupInput } from '@nangohq/design-system';
+import { FieldLabel, FieldSeparator, Input } from '@nangohq/design-system';
 
 import { CriticalErrorAlert } from '@/components/patterns/CriticalErrorAlert';
+import { EditableInput } from '@/components/patterns/EditableInput';
 import { Select, SelectContent, SelectItem, SelectTrigger, SelectValue } from '@/components/ui/Select';
 import { Skeleton } from '@/components/ui/Skeleton';
 import { useThemeStore } from '@/lib/theme';
@@ -14,31 +13,43 @@ import DashboardLayout from '../../layout/DashboardLayout';
 
 import type { Theme } from '@/lib/theme';
 
+// Mirrors the backend constraint (PATCH /api/v1/user: z.string().min(3).max(255)).
+const validateDisplayName = (value: string): string | null => {
+    if (value.trim().length === 0) {
+        return 'Display name is required';
+    }
+    if (value.length < 3) {
+        return 'Display name must be at least 3 characters';
+    }
+    if (value.length > 255) {
+        return 'Display name must be 255 characters or fewer';
+    }
+    return null;
+};
+
 export const UserSettings: React.FC = () => {
     const { toast } = useToast();
 
     const { user, loading, error, mutate } = useUser();
     const theme = useThemeStore((s) => s.theme);
     const setTheme = useThemeStore((s) => s.setTheme);
-    const ref = useRef<HTMLInputElement>(null);
-    const [name, setName] = useState(() => user?.name || '');
-    const [edit, setEdit] = useState(false);
 
-    const onSave = async () => {
+    const onSaveDisplayName = async (name: string) => {
         const updated = await apiPatchUser({ name });
 
         if ('error' in updated.json) {
             toast({ title: updated.json.error.message || 'Failed to update, an error occurred', variant: 'error' });
-        } else {
-            toast({ title: 'You have successfully updated your profile', variant: 'success' });
-            setEdit(false);
-            void mutate();
+            // Re-throw so EditableInput keeps the editor open on failure.
+            throw new Error('Failed to update profile');
         }
+
+        toast({ title: 'You have successfully updated your profile', variant: 'success' });
+        void mutate();
     };
 
     if (loading) {
         return (
-            <DashboardLayout fullWidth title="Profile settings" className="flex flex-col gap-8">
+            <DashboardLayout fullWidth title="Profile settings">
                 <Helmet>
                     <title>Profile Settings - Nango</title>
                 </Helmet>
@@ -59,54 +70,25 @@ export const UserSettings: React.FC = () => {
     }
 
     return (
-        <DashboardLayout fullWidth title="Profile settings" className="flex flex-col gap-8">
+        <DashboardLayout fullWidth title="Profile settings">
             <Helmet>
                 <title>Profile Settings - Nango</title>
             </Helmet>
-            <div className="flex flex-col gap-5">
-                <Field>
-                    <FieldLabel htmlFor="display-name">Display Name</FieldLabel>
-                    <InputGroup>
-                        <InputGroupInput id="display-name" ref={ref} value={name} onChange={(e) => setName(e.target.value)} disabled={!edit} />
-                        <InputGroupAddon align="inline-end">
-                            {!edit && (
-                                <IconButton
-                                    variant={'ghost'}
-                                    size={'2xs'}
-                                    label="Edit"
-                                    onClick={() => {
-                                        setEdit(true);
-                                        setTimeout(() => {
-                                            ref.current?.focus();
-                                        }, 100);
-                                    }}
-                                >
-                                    <Edit />
-                                </IconButton>
-                            )}
-                        </InputGroupAddon>
-                    </InputGroup>
-                </Field>
-                {edit && (
-                    <div className="flex justify-end gap-2 items-center">
-                        <Button
-                            variant={'outline'}
-                            onClick={() => {
-                                setName(user.name);
-                                setEdit(false);
-                            }}
-                        >
-                            Cancel
-                        </Button>
-                        <Button onClick={onSave}>Save</Button>
-                    </div>
-                )}
-            </div>
-            <Field>
-                <FieldLabel>Email</FieldLabel>
-                <p className="text-text-strong text-sm">{user.email}</p>
-            </Field>
-            <Field>
+            <div className="grid grid-cols-[237px_1fr] items-center gap-x-6 gap-y-8">
+                <FieldLabel htmlFor="display-name">Display name</FieldLabel>
+                <EditableInput id="display-name" initialValue={user.name} onSave={onSaveDisplayName} validate={validateDisplayName} />
+
+                <div className="col-span-2">
+                    <FieldSeparator />
+                </div>
+
+                <FieldLabel htmlFor="email">Email</FieldLabel>
+                <Input id="email" value={user.email} disabled readOnly />
+
+                <div className="col-span-2">
+                    <FieldSeparator />
+                </div>
+
                 <FieldLabel htmlFor="appearance">Appearance</FieldLabel>
                 <Select value={theme} onValueChange={(v) => setTheme(v as Theme)}>
                     <SelectTrigger id="appearance" className="w-48">
@@ -118,7 +100,7 @@ export const UserSettings: React.FC = () => {
                         <SelectItem value="dark">Dark</SelectItem>
                     </SelectContent>
                 </Select>
-            </Field>
+            </div>
         </DashboardLayout>
     );
 };

--- a/packages/webapp/src/pages/User/Settings.tsx
+++ b/packages/webapp/src/pages/User/Settings.tsx
@@ -74,7 +74,7 @@ export const UserSettings: React.FC = () => {
             <Helmet>
                 <title>Profile Settings - Nango</title>
             </Helmet>
-            <div className="grid grid-cols-[237px_1fr] items-center gap-x-6 gap-y-8">
+            <div className="grid max-w-[600px] grid-cols-[237px_1fr] items-center gap-x-6 gap-y-8">
                 <FieldLabel htmlFor="display-name">Display name</FieldLabel>
                 <EditableInput id="display-name" initialValue={user.name} onSave={onSaveDisplayName} validate={validateDisplayName} />
 
@@ -91,7 +91,7 @@ export const UserSettings: React.FC = () => {
 
                 <FieldLabel htmlFor="appearance">Appearance</FieldLabel>
                 <Select value={theme} onValueChange={(v) => setTheme(v as Theme)}>
-                    <SelectTrigger id="appearance" className="w-48">
+                    <SelectTrigger id="appearance" className="w-full">
                         <SelectValue />
                     </SelectTrigger>
                     <SelectContent>


### PR DESCRIPTION
## Problem

Profile settings stacked its fields vertically with a hand-rolled edit toggle, didn't match the [redesign](https://www.figma.com/design/UPhGLAHKgFxGfnb7vwJ6YK/Nango-%E2%80%94-Product?node-id=1-26068), and had no form validation. Along the way, the shared editable-field affordances and disabled-input styling didn't match the design.

## Solution

- Rebuild profile settings as a label-left grid on the design-system `Field` primitives; reuse `EditableInput` for the display name with validation mirroring the backend (3–255 chars). Email is a disabled input; the appearance selector stays as a third row.
- Refine `EditableInput` (app-wide): read-only rather than disabled at rest so it looks editable but stays gated behind the pencil, default cursor at rest, caret jumps to the end on edit, and the Pencil edit icon.
- Design-system (app-wide): disabled inputs/textareas/input-groups keep the interactive border; only background + text switch to the disabled tokens.

Fixes [NAN-5629](https://linear.app/nango/issue/NAN-5629)

## Testing

- Verified live on local dev against the dev API: column alignment, dark/light parity, display-name edit → save persists, sub-3-char name blocks save with the validation message, disabled Email styling.
