### PR TITLE
fix(security): oauth token outbound validation

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -49,6 +49,10 @@ NANGO_PROXY_BASE_URL_OVERRIDE_DENYLIST='["169.254.169.254","metadata.google.inte
 # defaults block DNS rebinding, private/link-local IPs, and cap redirects. Restart server and runners after changing.
 # Example (allowlist mode): NANGO_OUTBOUND_URL_POLICY='{"mode":"allowlist","allowlist":[".hubspot.com","api.github.com"]}'
 # Example (block private IPs + cap redirects): NANGO_OUTBOUND_URL_POLICY='{"blockPrivateIps":true,"maxRedirects":3}'
+# Outbound URL SSRF policy overlay (JSON) for OAuth/token flows (token, refresh, STS, JWT-bearer endpoints).
+# Applied on top of NANGO_OUTBOUND_URL_POLICY, but RFC1918/private IPs are allowed by default so self-hosted
+# token endpoints keep working; loopback/metadata/link-local stay blocked. Set blockPrivateIps to lock down.
+# Example (block private IPs for OAuth too): NANGO_OUTBOUND_URL_POLICY_OAUTH='{"blockPrivateIps":true}'
 NANGO_PUBLIC_SERVER_URL=http://localhost:3000
 CSP_REPORT_ONLY=false
 # FLAG_AUTH_ENABLED=false

--- a/docs/guides/platform/self-hosting.mdx
+++ b/docs/guides/platform/self-hosting.mdx
@@ -356,7 +356,7 @@ NANGO_OUTBOUND_URL_POLICY='{"mode":"allowlist","allowlist":[".hubspot.com","api.
 
 Each resolved address (including on every redirect hop) is validated; in `allowlist` mode, only listed hostnames are reachable regardless of IP.
 
-The same DNS-pinning protection also covers OAuth/token flows (token exchange, refresh, AWS STS, and JWT-bearer token endpoints). These use a separate overlay, `NANGO_OUTBOUND_URL_POLICY_OAUTH`, applied on top of `NANGO_OUTBOUND_URL_POLICY` but with the same JSON shape. The only difference is the default: `blockPrivateIps` is `false` for OAuth so self-hosted integrations whose token endpoints live on a private network keep working. Loopback, unspecified, and link-local/metadata addresses stay blocked regardless. Lock OAuth down to public hosts only by setting `blockPrivateIps`:
+The same DNS-pinning protection also covers OAuth/token flows (token exchange, refresh, AWS STS, and JWT-bearer token endpoints). These use a separate overlay, `NANGO_OUTBOUND_URL_POLICY_OAUTH`, applied on top of `NANGO_OUTBOUND_URL_POLICY` but with the same JSON shape. The only difference is the default: `blockPrivateIps` is `false` for OAuth so self-hosted integrations whose token endpoints live on a private network keep working. Loopback and unspecified addresses stay blocked regardless. Link-local/metadata addresses (including the cloud-metadata IP `169.254.169.254`) stay blocked by default through `blockLinkLocal`, but that check is disabled if you set `blockLinkLocal:false`. Lock OAuth down to public hosts only by setting `blockPrivateIps`:
 
 ```sh
 NANGO_OUTBOUND_URL_POLICY_OAUTH='{"blockPrivateIps":true}'

--- a/docs/guides/platform/self-hosting.mdx
+++ b/docs/guides/platform/self-hosting.mdx
@@ -312,6 +312,7 @@ NANGO_PROXY_BASE_URL_OVERRIDE_DENYLIST='["169.254.169.254","metadata.google.inte
 | `NANGO_PROXY_BASE_URL_OVERRIDE_ENABLED` | `true` | Set to `false` to reject all base URL overrides |
 | `NANGO_PROXY_BASE_URL_OVERRIDE_DENYLIST` | Secure defaults when unset | JSON array of hostnames or URLs to block; custom entries are merged with defaults |
 | `NANGO_OUTBOUND_URL_POLICY` | Secure defaults when unset | JSON object controlling SSRF protection for proxy, customer webhooks, and `uncontrolledFetch` |
+| `NANGO_OUTBOUND_URL_POLICY_OAUTH` | Inherits the base policy; RFC1918 allowed | JSON object overlay controlling SSRF protection for OAuth/token flows (token, refresh, STS, JWT-bearer endpoints) |
 
 **Operator guidance:**
 
@@ -354,6 +355,12 @@ NANGO_OUTBOUND_URL_POLICY='{"mode":"allowlist","allowlist":[".hubspot.com","api.
 | `maxRedirects` | `5` | Maximum redirect hops followed |
 
 Each resolved address (including on every redirect hop) is validated; in `allowlist` mode, only listed hostnames are reachable regardless of IP.
+
+The same DNS-pinning protection also covers OAuth/token flows (token exchange, refresh, AWS STS, and JWT-bearer token endpoints). These use a separate overlay, `NANGO_OUTBOUND_URL_POLICY_OAUTH`, applied on top of `NANGO_OUTBOUND_URL_POLICY` but with the same JSON shape. The only difference is the default: `blockPrivateIps` is `false` for OAuth so self-hosted integrations whose token endpoints live on a private network keep working. Loopback, unspecified, and link-local/metadata addresses stay blocked regardless. Lock OAuth down to public hosts only by setting `blockPrivateIps`:
+
+```sh
+NANGO_OUTBOUND_URL_POLICY_OAUTH='{"blockPrivateIps":true}'
+```
 
 #### Securing the dashboard
 

--- a/docs/llms-full.txt
+++ b/docs/llms-full.txt
@@ -7021,7 +7021,7 @@ NANGO_OUTBOUND_URL_POLICY='{"mode":"allowlist","allowlist":[".hubspot.com","api.
 
 Each resolved address (including on every redirect hop) is validated; in `allowlist` mode, only listed hostnames are reachable regardless of IP.
 
-The same DNS-pinning protection also covers OAuth/token flows (token exchange, refresh, AWS STS, and JWT-bearer token endpoints). These use a separate overlay, `NANGO_OUTBOUND_URL_POLICY_OAUTH`, applied on top of `NANGO_OUTBOUND_URL_POLICY` but with the same JSON shape. The only difference is the default: `blockPrivateIps` is `false` for OAuth so self-hosted integrations whose token endpoints live on a private network keep working. Loopback, unspecified, and link-local/metadata addresses stay blocked regardless. Lock OAuth down to public hosts only by setting `blockPrivateIps`:
+The same DNS-pinning protection also covers OAuth/token flows (token exchange, refresh, AWS STS, and JWT-bearer token endpoints). These use a separate overlay, `NANGO_OUTBOUND_URL_POLICY_OAUTH`, applied on top of `NANGO_OUTBOUND_URL_POLICY` but with the same JSON shape. The only difference is the default: `blockPrivateIps` is `false` for OAuth so self-hosted integrations whose token endpoints live on a private network keep working. Loopback and unspecified addresses stay blocked regardless. Link-local/metadata addresses (including the cloud-metadata IP `169.254.169.254`) stay blocked by default through `blockLinkLocal`, but that check is disabled if you set `blockLinkLocal:false`. Lock OAuth down to public hosts only by setting `blockPrivateIps`:
 
 ```sh
 NANGO_OUTBOUND_URL_POLICY_OAUTH='{"blockPrivateIps":true}'

--- a/docs/llms-full.txt
+++ b/docs/llms-full.txt
@@ -6977,6 +6977,7 @@ NANGO_PROXY_BASE_URL_OVERRIDE_DENYLIST='["169.254.169.254","metadata.google.inte
 | `NANGO_PROXY_BASE_URL_OVERRIDE_ENABLED` | `true` | Set to `false` to reject all base URL overrides |
 | `NANGO_PROXY_BASE_URL_OVERRIDE_DENYLIST` | Secure defaults when unset | JSON array of hostnames or URLs to block; custom entries are merged with defaults |
 | `NANGO_OUTBOUND_URL_POLICY` | Secure defaults when unset | JSON object controlling SSRF protection for proxy, customer webhooks, and `uncontrolledFetch` |
+| `NANGO_OUTBOUND_URL_POLICY_OAUTH` | Inherits the base policy; RFC1918 allowed | JSON object overlay controlling SSRF protection for OAuth/token flows (token, refresh, STS, JWT-bearer endpoints) |
 
 **Operator guidance:**
 
@@ -7019,6 +7020,12 @@ NANGO_OUTBOUND_URL_POLICY='{"mode":"allowlist","allowlist":[".hubspot.com","api.
 | `maxRedirects` | `5` | Maximum redirect hops followed |
 
 Each resolved address (including on every redirect hop) is validated; in `allowlist` mode, only listed hostnames are reachable regardless of IP.
+
+The same DNS-pinning protection also covers OAuth/token flows (token exchange, refresh, AWS STS, and JWT-bearer token endpoints). These use a separate overlay, `NANGO_OUTBOUND_URL_POLICY_OAUTH`, applied on top of `NANGO_OUTBOUND_URL_POLICY` but with the same JSON shape. The only difference is the default: `blockPrivateIps` is `false` for OAuth so self-hosted integrations whose token endpoints live on a private network keep working. Loopback, unspecified, and link-local/metadata addresses stay blocked regardless. Lock OAuth down to public hosts only by setting `blockPrivateIps`:
+
+```sh
+NANGO_OUTBOUND_URL_POLICY_OAUTH='{"blockPrivateIps":true}'
+```
 
 #### Securing the dashboard
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -35107,6 +35107,9 @@
             "name": "@nangohq/egress",
             "version": "0.71.2",
             "license": "SEE LICENSE IN LICENSE FILE IN GIT REPOSITORY",
+            "dependencies": {
+                "undici": "6.27.0"
+            },
             "devDependencies": {
                 "vitest": "4.1.9"
             }

--- a/packages/egress/lib/agent.ts
+++ b/packages/egress/lib/agent.ts
@@ -3,11 +3,15 @@ import http from 'node:http';
 import https from 'node:https';
 import net from 'node:net';
 
+import { Agent as UndiciAgent } from 'undici';
+
 import { formatHostForUrlAuthority } from './denylist.js';
 import { resolveValidatedHostAddresses, validateOutboundUrlSync } from './validate.js';
 
 import type { OutboundUrlPolicy } from './policy.js';
 import type { LookupAddress, LookupOptions } from 'node:dns';
+import type { LookupFunction } from 'node:net';
+import type { buildConnector } from 'undici';
 
 type LookupCallback = (err: NodeJS.ErrnoException | null, address: string | LookupAddress[], family?: number) => void;
 
@@ -139,4 +143,25 @@ export function getSafeHttpAgents(policy: OutboundUrlPolicy): { httpAgent: http.
         safeAgentsCache.set(key, agents);
     }
     return agents;
+}
+
+const safeUndiciCache = new Map<string, UndiciAgent>();
+
+/**
+ * Build an undici dispatcher whose connector resolves DNS through the policy's pinned, validated
+ * lookup. Use for `fetch`-based outbound paths. Pass `connectOverrides` (e.g. mTLS cert/key) for
+ * one-off dispatchers; those are not cached.
+ */
+export function getSafeUndiciDispatcher(policy: OutboundUrlPolicy, connectOverrides?: buildConnector.BuildOptions): UndiciAgent {
+    const lookup = getSafeLookup(policy) as unknown as LookupFunction;
+    if (!connectOverrides) {
+        const key = policyPinCacheKey(policy);
+        let agent = safeUndiciCache.get(key);
+        if (!agent) {
+            agent = new UndiciAgent({ connect: { lookup } as buildConnector.BuildOptions });
+            safeUndiciCache.set(key, agent);
+        }
+        return agent;
+    }
+    return new UndiciAgent({ connect: { ...connectOverrides, lookup } as buildConnector.BuildOptions });
 }

--- a/packages/egress/lib/agent.ts
+++ b/packages/egress/lib/agent.ts
@@ -147,11 +147,6 @@ export function getSafeHttpAgents(policy: OutboundUrlPolicy): { httpAgent: http.
 
 const safeUndiciCache = new Map<string, UndiciAgent>();
 
-/**
- * Build an undici dispatcher whose connector resolves DNS through the policy's pinned, validated
- * lookup. Use for `fetch`-based outbound paths. Pass `connectOverrides` (e.g. mTLS cert/key) for
- * one-off dispatchers; those are not cached.
- */
 export function getSafeUndiciDispatcher(policy: OutboundUrlPolicy, connectOverrides?: buildConnector.BuildOptions): UndiciAgent {
     const lookup = getSafeLookup(policy) as unknown as LookupFunction;
     if (!connectOverrides) {

--- a/packages/egress/lib/agent.ts
+++ b/packages/egress/lib/agent.ts
@@ -147,6 +147,53 @@ export function getSafeHttpAgents(policy: OutboundUrlPolicy): { httpAgent: http.
 
 const safeUndiciCache = new Map<string, UndiciAgent>();
 
+/**
+ * Connect options that are safe to accept from callers. Anything that could change the
+ * connection target (socketPath, path, host, hostname, port, localAddress, family, …) or
+ * replace the DNS resolver (lookup) is intentionally excluded, otherwise a caller could
+ * bypass the policy-enforcing safe lookup — e.g. by connecting directly to a Unix socket.
+ */
+const SAFE_UNDICI_CONNECT_OPTION_KEYS = new Set<string>([
+    // TLS material / verification
+    'ca',
+    'cert',
+    'key',
+    'pfx',
+    'passphrase',
+    'rejectUnauthorized',
+    'servername',
+    'ciphers',
+    'minVersion',
+    'maxVersion',
+    'secureProtocol',
+    'secureOptions',
+    'ALPNProtocols',
+    'ecdhCurve',
+    'crl',
+    'dhparam',
+    'honorCipherOrder',
+    'sigalgs',
+    'sessionTimeout',
+    'sessionIdContext',
+    'ticketKeys',
+    // Connection tuning that does not affect the destination
+    'maxCachedSessions',
+    'timeout',
+    'keepAlive',
+    'keepAliveInitialDelay',
+    'allowH2'
+]);
+
+function sanitizeConnectOverrides(connectOverrides: buildConnector.BuildOptions): buildConnector.BuildOptions {
+    const sanitized: Record<string, unknown> = {};
+    for (const [key, value] of Object.entries(connectOverrides)) {
+        if (SAFE_UNDICI_CONNECT_OPTION_KEYS.has(key)) {
+            sanitized[key] = value;
+        }
+    }
+    return sanitized as buildConnector.BuildOptions;
+}
+
 export function getSafeUndiciDispatcher(policy: OutboundUrlPolicy, connectOverrides?: buildConnector.BuildOptions): UndiciAgent {
     const lookup = getSafeLookup(policy) as unknown as LookupFunction;
     if (!connectOverrides) {
@@ -158,5 +205,7 @@ export function getSafeUndiciDispatcher(policy: OutboundUrlPolicy, connectOverri
         }
         return agent;
     }
-    return new UndiciAgent({ connect: { ...connectOverrides, lookup } as buildConnector.BuildOptions });
+    // Drop any caller-supplied option that could redirect the socket or replace the resolver;
+    // lookup is always set last so it cannot be overridden.
+    return new UndiciAgent({ connect: { ...sanitizeConnectOverrides(connectOverrides), lookup } as buildConnector.BuildOptions });
 }

--- a/packages/egress/lib/egress.unit.test.ts
+++ b/packages/egress/lib/egress.unit.test.ts
@@ -14,7 +14,7 @@ import {
 } from './denylist.js';
 import { OutboundUrlError } from './errors.js';
 import { classifyBlockedIp } from './ip.js';
-import { resolvePolicyForRunnerSync, resolvePolicyForServer } from './policy.js';
+import { resolvePolicyForOAuth, resolvePolicyForRunnerSync, resolvePolicyForServer } from './policy.js';
 import { absoluteUrlFromRedirectRequestOptions, createRedirectValidator } from './redirect.js';
 import { isBaseUrlOverrideDeniedByPolicy, validateOutboundUrlAsync, validateOutboundUrlSync } from './validate.js';
 
@@ -125,6 +125,45 @@ describe('egress permissive mode', () => {
         expect(policy.mode).toBe('permissive');
         expect(validateOutboundUrlSync('http://127.0.0.1:8080/', policy).ok).toBe(false);
         expect(isBaseUrlOverrideDeniedByPolicy('http://127.0.0.1:8080/', policy)).toBe(true);
+    });
+});
+
+describe('egress OAuth policy', () => {
+    it('allows RFC1918 by default but still blocks loopback/metadata/link-local', () => {
+        const policy = resolvePolicyForOAuth({ proxyBaseUrlOverrideDenylist: [...DEFAULT_NANGO_PROXY_BASE_URL_OVERRIDE_DENYLIST] });
+        expect(policy.blockPrivateIps).toBe(false);
+        expect(validateOutboundUrlSync('http://10.0.0.5/token', policy).ok).toBe(true);
+        expect(validateOutboundUrlSync('http://192.168.1.10/token', policy).ok).toBe(true);
+        expect(validateOutboundUrlSync('http://127.0.0.1/token', policy).ok).toBe(false);
+        expect(validateOutboundUrlSync('http://169.254.169.254/token', policy).ok).toBe(false);
+        expect(validateOutboundUrlSync('http://localhost/token', policy).ok).toBe(false);
+    });
+
+    it('lets the OAuth overlay re-enable RFC1918 blocking', () => {
+        const policy = resolvePolicyForOAuth({
+            proxyBaseUrlOverrideDenylist: [...DEFAULT_NANGO_PROXY_BASE_URL_OVERRIDE_DENYLIST],
+            outboundUrlPolicyOAuth: { blockPrivateIps: true }
+        });
+        expect(policy.blockPrivateIps).toBe(true);
+        expect(validateOutboundUrlSync('http://10.0.0.5/token', policy).ok).toBe(false);
+    });
+
+    it('inherits the base policy and lets the OAuth overlay win', () => {
+        const policy = resolvePolicyForOAuth({
+            proxyBaseUrlOverrideDenylist: [...DEFAULT_NANGO_PROXY_BASE_URL_OVERRIDE_DENYLIST],
+            outboundUrlPolicy: { mode: 'allowlist', allowlist: ['api.example.com'] },
+            outboundUrlPolicyOAuth: { maxRedirects: 2 }
+        });
+        expect(policy.mode).toBe('allowlist');
+        expect(policy.maxRedirects).toBe(2);
+        expect(validateOutboundUrlSync('https://api.example.com/token', policy).ok).toBe(true);
+        expect(validateOutboundUrlSync('https://evil.com/token', policy).ok).toBe(false);
+    });
+
+    it('keeps the default denylist even when the operator opts out of the proxy denylist', () => {
+        const policy = resolvePolicyForOAuth({ proxyBaseUrlOverrideDenylist: [] });
+        expect(policy.denylist.has('169.254.169.254')).toBe(true);
+        expect(policy.denylist.has('localhost')).toBe(true);
     });
 });
 

--- a/packages/egress/lib/egress.unit.test.ts
+++ b/packages/egress/lib/egress.unit.test.ts
@@ -12,7 +12,7 @@ import {
     resolveProxyBaseUrlOverrideDenylist,
     resolveProxyBaseUrlOverrideDenylistForRunner
 } from './denylist.js';
-import { OutboundUrlError } from './errors.js';
+import { findOutboundUrlError, OutboundUrlError } from './errors.js';
 import { classifyBlockedIp } from './ip.js';
 import { resolvePolicyForOAuth, resolvePolicyForRunnerSync, resolvePolicyForServer } from './policy.js';
 import { absoluteUrlFromRedirectRequestOptions, createRedirectValidator } from './redirect.js';
@@ -379,8 +379,16 @@ describe('getSafeUndiciDispatcher connect overrides', () => {
         // A honored socketPath would connect straight to the unix socket and never invoke the safe lookup.
         const dispatcher = getSafeUndiciDispatcher(permissive, { socketPath: '/tmp/nango-egress-should-not-be-used.sock' } as never);
 
-        await expect(fetch('http://nango-egress-test.example/', { dispatcher } as never)).rejects.toThrow();
+        const caught = await fetch('http://nango-egress-test.example/', { dispatcher } as never).then(
+            () => null,
+            (err: unknown) => err
+        );
+
         // The safe lookup ran, proving socketPath was stripped and the connection stayed policy-controlled.
         expect(lookupSpy).toHaveBeenCalled();
+        // The rejection is specifically the policy denial (loopback), not an unrelated transport failure —
+        // proving the connection was routed through the safe lookup rather than the unix socket.
+        const outboundErr = findOutboundUrlError(caught);
+        expect(outboundErr?.code).toBe('denied_dns');
     });
 });

--- a/packages/egress/lib/egress.unit.test.ts
+++ b/packages/egress/lib/egress.unit.test.ts
@@ -2,7 +2,7 @@ import dns from 'node:dns/promises';
 
 import { afterEach, describe, expect, it, vi } from 'vitest';
 
-import { clearPinnedAddressCacheForTests, createSafeHttpAgents } from './agent.js';
+import { clearPinnedAddressCacheForTests, createSafeHttpAgents, getSafeUndiciDispatcher } from './agent.js';
 import {
     canonicalizeHostnameForDenylist,
     DEFAULT_NANGO_PROXY_BASE_URL_OVERRIDE_DENYLIST,
@@ -359,5 +359,28 @@ describe('egress safe lookup pinning', () => {
 
         await lookupVia(lookupFn, 'host-2.example');
         expect(lookupSpy).toHaveBeenCalledTimes(1_004);
+    });
+});
+
+describe('getSafeUndiciDispatcher connect overrides', () => {
+    afterEach(() => {
+        vi.restoreAllMocks();
+        clearPinnedAddressCacheForTests();
+    });
+
+    it('drops socketPath so callers cannot bypass the safe lookup via a unix socket', async () => {
+        // Resolve to a loopback address so validation rejects before any real socket connect is attempted.
+        const lookupSpy = vi.spyOn(dns, 'lookup').mockResolvedValue([{ address: '127.0.0.1', family: 4 }] as never);
+        const permissive = resolvePolicyForServer({
+            proxyBaseUrlOverrideDenylist: [],
+            outboundUrlPolicy: { mode: 'permissive', blockPrivateIps: false, blockLinkLocal: false }
+        });
+
+        // A honored socketPath would connect straight to the unix socket and never invoke the safe lookup.
+        const dispatcher = getSafeUndiciDispatcher(permissive, { socketPath: '/tmp/nango-egress-should-not-be-used.sock' } as never);
+
+        await expect(fetch('http://nango-egress-test.example/', { dispatcher } as never)).rejects.toThrow();
+        // The safe lookup ran, proving socketPath was stripped and the connection stayed policy-controlled.
+        expect(lookupSpy).toHaveBeenCalled();
     });
 });

--- a/packages/egress/lib/index.ts
+++ b/packages/egress/lib/index.ts
@@ -4,7 +4,7 @@ export * from './ip.js';
 export * from './validate.js';
 export * from './redirect.js';
 
-export { createSafeLookup, createSafeHttpAgents, agentForUrl, getSafeLookup, getSafeHttpAgents } from './agent.js';
+export { createSafeLookup, createSafeHttpAgents, agentForUrl, getSafeLookup, getSafeHttpAgents, getSafeUndiciDispatcher } from './agent.js';
 export {
     DEFAULT_OUTBOUND_URL_POLICY,
     resolvePolicyForServer,
@@ -15,4 +15,11 @@ export {
     getRunnerPolicyFromEnv,
     resolvePolicyForOAuth
 } from './policy.js';
-export type { OutboundUrlPolicyMode, OutboundUrlPolicyRaw, OutboundUrlPolicy, ServerPolicyEnvInput, RunnerPolicyEnvInput } from './policy.js';
+export type {
+    OutboundUrlPolicyMode,
+    OutboundUrlPolicyRaw,
+    OutboundUrlPolicy,
+    ServerPolicyEnvInput,
+    RunnerPolicyEnvInput,
+    OAuthPolicyEnvInput
+} from './policy.js';

--- a/packages/egress/lib/policy.ts
+++ b/packages/egress/lib/policy.ts
@@ -95,9 +95,6 @@ export interface ServerPolicyEnvInput {
     outboundUrlPolicy?: OutboundUrlPolicyRaw | undefined;
 }
 
-/**
- * Build policy for server-side services from parsed env values.
- */
 export function resolvePolicyForServer(input: ServerPolicyEnvInput): OutboundUrlPolicy {
     const jsonRaw = input.outboundUrlPolicy ?? null;
     const denylistEntries = input.proxyBaseUrlOverrideDenylist;
@@ -128,9 +125,6 @@ function isBaseUrlOverrideEnabledFromEnv(raw: string | undefined): boolean {
     return normalized !== 'false' && normalized !== '0';
 }
 
-/**
- * Build policy for runner / runner-sdk. Always applies secure denylist defaults when env is empty.
- */
 export function resolvePolicyForRunner(input: RunnerPolicyEnvInput): OutboundUrlPolicy {
     return resolvePolicyForRunnerSync(input);
 }
@@ -186,13 +180,6 @@ export interface OAuthPolicyEnvInput {
     outboundUrlPolicyOAuth?: OutboundUrlPolicyRaw | undefined;
 }
 
-/**
- * OAuth/token-flow policy: blocks metadata/loopback/link-local + DNS rebinding by default;
- * RFC1918 blocking is off unless explicitly configured, so self-hosted integrations whose token
- * endpoints live on private networks keep working. Layering: secure defaults -> base policy ->
- * OAuth overlay. The default denylist (metadata/loopback) is always re-applied so it cannot be
- * dropped by an operator opt-out.
- */
 export function resolvePolicyForOAuth(input: OAuthPolicyEnvInput): OutboundUrlPolicy {
     const denylistEntries =
         input.proxyBaseUrlOverrideDenylist.length === 0 ? [...DEFAULT_NANGO_PROXY_BASE_URL_OVERRIDE_DENYLIST] : input.proxyBaseUrlOverrideDenylist;

--- a/packages/egress/lib/policy.ts
+++ b/packages/egress/lib/policy.ts
@@ -178,23 +178,34 @@ export function getRunnerPolicyFromEnv(): OutboundUrlPolicy {
     return memoizedRunnerPolicy;
 }
 
+export interface OAuthPolicyEnvInput {
+    proxyBaseUrlOverrideDenylist: string[];
+    /** Base policy (NANGO_OUTBOUND_URL_POLICY), already parsed. */
+    outboundUrlPolicy?: OutboundUrlPolicyRaw | undefined;
+    /** OAuth-specific overlay (NANGO_OUTBOUND_URL_POLICY_OAUTH), already parsed. */
+    outboundUrlPolicyOAuth?: OutboundUrlPolicyRaw | undefined;
+}
+
 /**
- * OAuth-specific policy: blocks metadata/loopback/link-local + DNS rebinding by default;
- * RFC1918 blocking off unless explicitly configured.
+ * OAuth/token-flow policy: blocks metadata/loopback/link-local + DNS rebinding by default;
+ * RFC1918 blocking is off unless explicitly configured, so self-hosted integrations whose token
+ * endpoints live on private networks keep working. Layering: secure defaults -> base policy ->
+ * OAuth overlay. The default denylist (metadata/loopback) is always re-applied so it cannot be
+ * dropped by an operator opt-out.
  */
-export function resolvePolicyForOAuth(input: { outboundUrlPolicyOAuthRaw?: string | undefined; outboundUrlPolicyRaw?: string | undefined }): OutboundUrlPolicy {
-    const oauthRaw = parsePolicyJson(input.outboundUrlPolicyOAuthRaw);
-    const baseRaw = parsePolicyJson(input.outboundUrlPolicyRaw);
+export function resolvePolicyForOAuth(input: OAuthPolicyEnvInput): OutboundUrlPolicy {
+    const denylistEntries =
+        input.proxyBaseUrlOverrideDenylist.length === 0 ? [...DEFAULT_NANGO_PROXY_BASE_URL_OVERRIDE_DENYLIST] : input.proxyBaseUrlOverrideDenylist;
     const merged = mergePolicyRaw(
         mergePolicyRaw(
             {
                 blockPrivateIps: false,
                 mode: 'denylist',
-                denylist: [...DEFAULT_NANGO_PROXY_BASE_URL_OVERRIDE_DENYLIST]
+                denylist: denylistEntries
             },
-            baseRaw ?? {}
+            input.outboundUrlPolicy ?? {}
         ),
-        oauthRaw ?? {}
+        input.outboundUrlPolicyOAuth ?? {}
     );
     return rawToPolicy(merged, mergeProxyBaseUrlOverrideDenylist(merged.denylist ?? []));
 }

--- a/packages/egress/package.json
+++ b/packages/egress/package.json
@@ -15,6 +15,9 @@
         "dist/"
     ],
     "scripts": {},
+    "dependencies": {
+        "undici": "6.27.0"
+    },
     "devDependencies": {
         "vitest": "4.1.9"
     }

--- a/packages/server/lib/clients/oauth1.client.ts
+++ b/packages/server/lib/clients/oauth1.client.ts
@@ -13,6 +13,18 @@ interface OAuth1RequestTokenResult {
     parsed_query_string: any;
 }
 
+// Signature of node-oauth's private `_performSecureRequest`, which we wrap to validate each redirect hop.
+type PerformSecureRequest = (
+    oauthToken: string | null,
+    oauthTokenSecret: string | null,
+    method: string,
+    url: string,
+    extraParams: Record<string, any> | null,
+    postBody: string | Buffer | null,
+    postContentType: string | undefined,
+    callback?: (err: unknown, data?: any, res?: any) => void
+) => http.ClientRequest | undefined;
+
 // The choice of OAuth 1.0a libraries for node is not exactly great:
 // There are a half-dozen around but none of the is really maintained anymore (no surprise, OAuth 1.0 is officially deprecated)
 // We still need to support it though because a few dozen important services are still using it, e.g. Twitter, Etsy, Sellsy, Trello
@@ -51,16 +63,14 @@ export class OAuth1Client {
         this.client.setClientOptions({
             requestTokenHttpMethod: this.authConfig.request_http_method || 'POST',
             accessTokenHttpMethod: this.authConfig.token_http_method || 'POST',
-            // Do not auto-follow redirects: node-oauth follows `Location` without any policy check, so a
-            // request/access-token URL that 3xx-redirects could be pointed at an internal host. Token
-            // endpoints don't legitimately redirect, so refusing to follow is safe and closes that hole.
-            followRedirects: false
+            // Keep following 301/302 redirects (some OAuth1 token endpoints legitimately redirect), but every
+            // hop is validated against the OAuth egress policy via the `_performSecureRequest` wrapper below.
+            followRedirects: true
         });
 
         // node-oauth builds its request with a bare `http`/`https` client and no agent, so it never runs the
         // OAuth egress DNS-pinning lookup. Override the client factory to inject the OAuth-safe agents, which
-        // resolve + pin the connected IP and reject blocked addresses (rebinding-safe). Combined with the
-        // `assertSafeOAuthUrl` pre-flight below, this brings OAuth1 in line with the other auth modes.
+        // resolve + pin the connected IP and reject blocked addresses (rebinding-safe on the connect path).
         const { httpAgent, httpsAgent } = getOAuthSafeHttpAgents();
         const createSafeClient = (
             port: number,
@@ -75,6 +85,30 @@ export class OAuth1Client {
         };
         // @ts-expect-error `_createClient` is a private method of node-oauth that we override to pin egress.
         this.client._createClient = createSafeClient;
+
+        // node-oauth follows redirects by re-invoking `_performSecureRequest` with the `Location` URL
+        // (see oauth.js), so wrapping it lets us validate every hop — the initial request and each redirect
+        // target — against the OAuth egress policy. A blocked hop is surfaced through node-oauth's error
+        // callback (which rejects the wrapping promise) rather than thrown, since redirects are followed from
+        // an async response handler where a synchronous throw would go uncaught.
+        // @ts-expect-error `_performSecureRequest` is a private node-oauth method.
+        const originalPerformSecureRequest = this.client._performSecureRequest.bind(this.client) as PerformSecureRequest;
+        const performGuardedRequest: PerformSecureRequest = (oauthToken, oauthTokenSecret, method, url, extraParams, postBody, postContentType, callback) => {
+            // Streaming (no-callback) requests aren't used by this client; delegate untouched.
+            if (!callback) {
+                return originalPerformSecureRequest(oauthToken, oauthTokenSecret, method, url, extraParams, postBody, postContentType, callback);
+            }
+            assertSafeOAuthUrl(url)
+                .then(() => {
+                    originalPerformSecureRequest(oauthToken, oauthTokenSecret, method, url, extraParams, postBody, postContentType, callback);
+                })
+                .catch((err: unknown) => {
+                    callback(err);
+                });
+            return undefined;
+        };
+        // @ts-expect-error `_performSecureRequest` is a private node-oauth method we wrap to guard every hop.
+        this.client._performSecureRequest = performGuardedRequest;
     }
 
     async getOAuthRequestToken(): Promise<OAuth1RequestTokenResult> {

--- a/packages/server/lib/clients/oauth1.client.ts
+++ b/packages/server/lib/clients/oauth1.client.ts
@@ -3,7 +3,7 @@ import https from 'node:https';
 
 import oAuth1 from 'oauth';
 
-import { assertSafeOAuthUrl, getOAuthSafeHttpAgents } from '@nangohq/shared';
+import { assertSafeOAuthUrl, getOAuthRedirectPolicy, getOAuthSafeHttpAgents } from '@nangohq/shared';
 
 import type { IntegrationConfig, Provider, ProviderOAuth1 } from '@nangohq/types';
 
@@ -63,8 +63,14 @@ export class OAuth1Client {
         this.client.setClientOptions({
             requestTokenHttpMethod: this.authConfig.request_http_method || 'POST',
             accessTokenHttpMethod: this.authConfig.token_http_method || 'POST',
-            // Keep following 301/302 redirects (some OAuth1 token endpoints legitimately redirect), but every
-            // hop is validated against the OAuth egress policy via the `_performSecureRequest` wrapper below.
+            // Redirects stay enabled for providers whose token endpoints 3xx. This accepts a tradeoff the
+            // other OAuth paths do not: node-oauth follows a redirect by re-invoking `_performSecureRequest`
+            // against the `Location`, which re-signs for the new URL and resends the credentials — a valid
+            // `Authorization` for the new host, plus the `oauth_verifier` from the body. An OAuth1 signature
+            // is bound to the request URL, so the credential-stripping `getOAuthAxiosRequestConfig` and
+            // `loggedFetch` perform has no equivalent here; stripping would leave a request no provider can
+            // honour. Each hop is instead validated against the OAuth egress policy and capped at its
+            // `maxRedirects` by the `_performSecureRequest` wrapper below.
             followRedirects: true
         });
 
@@ -86,17 +92,30 @@ export class OAuth1Client {
         // @ts-expect-error `_createClient` is a private method of node-oauth that we override to pin egress.
         this.client._createClient = createSafeClient;
 
-        // node-oauth follows redirects by re-invoking `_performSecureRequest` with the `Location` URL
-        // (see oauth.js), so wrapping it lets us validate every hop — the initial request and each redirect
-        // target — against the OAuth egress policy. A blocked hop is surfaced through node-oauth's error
-        // callback (which rejects the wrapping promise) rather than thrown, since redirects are followed from
-        // an async response handler where a synchronous throw would go uncaught.
+        // Every token request node-oauth issues goes through `_performSecureRequest` — the initial request,
+        // each hop of a redirect chain, and the `getOAuthAccessToken` path below which calls it directly — so
+        // wrapping it validates every URL against the OAuth egress policy and enforces the policy's redirect
+        // cap. node-oauth recurses on each redirect with no cap of its own, so without this a looping token
+        // endpoint would issue unbounded serial requests. A blocked or over-budget hop is surfaced through
+        // node-oauth's error callback (which rejects the wrapping promise) rather than thrown, because the
+        // callback is also invoked from async response handlers where a synchronous throw would go uncaught.
+        const { maxRedirects } = getOAuthRedirectPolicy();
+        // node-oauth threads the same callback through every hop of a chain (see `passBackControl` in
+        // oauth.js), so the callback identifies the logical token request: its first sighting is the initial
+        // request and every later one is a redirect hop.
+        const requestsPerCallback = new WeakMap<object, number>();
         // @ts-expect-error `_performSecureRequest` is a private node-oauth method.
         const originalPerformSecureRequest = this.client._performSecureRequest.bind(this.client) as PerformSecureRequest;
         const performGuardedRequest: PerformSecureRequest = (oauthToken, oauthTokenSecret, method, url, extraParams, postBody, postContentType, callback) => {
             // Streaming (no-callback) requests aren't used by this client; delegate untouched.
             if (!callback) {
                 return originalPerformSecureRequest(oauthToken, oauthTokenSecret, method, url, extraParams, postBody, postContentType, callback);
+            }
+            const alreadyIssued = requestsPerCallback.get(callback) ?? 0;
+            requestsPerCallback.set(callback, alreadyIssued + 1);
+            if (alreadyIssued > maxRedirects) {
+                callback(new Error(`Maximum number of redirects (${maxRedirects}) exceeded`));
+                return undefined;
             }
             assertSafeOAuthUrl(url)
                 .then(() => {
@@ -107,7 +126,7 @@ export class OAuth1Client {
                 });
             return undefined;
         };
-        // @ts-expect-error `_performSecureRequest` is a private node-oauth method we wrap to guard every hop.
+        // @ts-expect-error `_performSecureRequest` is a private node-oauth method we wrap to guard egress.
         this.client._performSecureRequest = performGuardedRequest;
     }
 

--- a/packages/server/lib/clients/oauth1.client.ts
+++ b/packages/server/lib/clients/oauth1.client.ts
@@ -1,4 +1,9 @@
+import http from 'node:http';
+import https from 'node:https';
+
 import oAuth1 from 'oauth';
+
+import { assertSafeOAuthUrl, getOAuthSafeHttpAgents } from '@nangohq/shared';
 
 import type { IntegrationConfig, Provider, ProviderOAuth1 } from '@nangohq/types';
 
@@ -19,6 +24,8 @@ export class OAuth1Client {
     private client: oAuth1.OAuth;
     private config: IntegrationConfig;
     private authConfig: ProviderOAuth1;
+    private requestTokenUrl: string;
+    private accessTokenUrl: string;
 
     constructor(config: IntegrationConfig, provider: Provider, callbackUrl: string) {
         this.config = config;
@@ -26,9 +33,12 @@ export class OAuth1Client {
         this.authConfig = provider as ProviderOAuth1;
         const headers = { 'User-Agent': 'Nango' };
 
+        this.requestTokenUrl = this.authConfig.request_url;
+        this.accessTokenUrl = typeof this.authConfig.token_url === 'string' ? this.authConfig.token_url : (this.authConfig.token_url?.['OAUTH1'] as string);
+
         this.client = new oAuth1.OAuth(
-            this.authConfig.request_url,
-            typeof this.authConfig.token_url === 'string' ? this.authConfig.token_url : (this.authConfig.token_url?.['OAUTH1'] as string),
+            this.requestTokenUrl,
+            this.accessTokenUrl,
             this.config.oauth_client_id!,
             this.config.oauth_client_secret!,
             '1.0',
@@ -41,8 +51,30 @@ export class OAuth1Client {
         this.client.setClientOptions({
             requestTokenHttpMethod: this.authConfig.request_http_method || 'POST',
             accessTokenHttpMethod: this.authConfig.token_http_method || 'POST',
-            followRedirects: true
+            // Do not auto-follow redirects: node-oauth follows `Location` without any policy check, so a
+            // request/access-token URL that 3xx-redirects could be pointed at an internal host. Token
+            // endpoints don't legitimately redirect, so refusing to follow is safe and closes that hole.
+            followRedirects: false
         });
+
+        // node-oauth builds its request with a bare `http`/`https` client and no agent, so it never runs the
+        // OAuth egress DNS-pinning lookup. Override the client factory to inject the OAuth-safe agents, which
+        // resolve + pin the connected IP and reject blocked addresses (rebinding-safe). Combined with the
+        // `assertSafeOAuthUrl` pre-flight below, this brings OAuth1 in line with the other auth modes.
+        const { httpAgent, httpsAgent } = getOAuthSafeHttpAgents();
+        const createSafeClient = (
+            port: number,
+            hostname: string,
+            method: string,
+            path: string,
+            reqHeaders: http.OutgoingHttpHeaders,
+            sslEnabled: boolean
+        ): http.ClientRequest => {
+            const httpModel = sslEnabled ? https : http;
+            return httpModel.request({ host: hostname, port, path, method, headers: reqHeaders, agent: sslEnabled ? httpsAgent : httpAgent });
+        };
+        // @ts-expect-error `_createClient` is a private method of node-oauth that we override to pin egress.
+        this.client._createClient = createSafeClient;
     }
 
     async getOAuthRequestToken(): Promise<OAuth1RequestTokenResult> {
@@ -50,6 +82,8 @@ export class OAuth1Client {
         if (this.authConfig.request_params) {
             additionalTokenParams = this.authConfig.request_params;
         }
+
+        await assertSafeOAuthUrl(this.requestTokenUrl);
 
         const promise = new Promise<OAuth1RequestTokenResult>((resolve, reject) => {
             this.client.getOAuthRequestToken(
@@ -76,6 +110,8 @@ export class OAuth1Client {
         if (this.authConfig.token_params) {
             additionalTokenParams = this.authConfig.token_params;
         }
+
+        await assertSafeOAuthUrl(this.accessTokenUrl);
 
         const promise = new Promise<Record<string, any>>((resolve, reject) => {
             // This is lifted from https://github.com/ciaranj/node-oauth/blob/master/lib/oauth.js#L456

--- a/packages/server/lib/clients/oauth1.client.unit.test.ts
+++ b/packages/server/lib/clients/oauth1.client.unit.test.ts
@@ -1,6 +1,52 @@
-import { describe, expect, it } from 'vitest';
+import http from 'node:http';
+import https from 'node:https';
 
-import { extractQueryParams } from './oauth1.client.js';
+import { afterEach, describe, expect, it, vi } from 'vitest';
+
+import { assertSafeOAuthUrl } from '@nangohq/shared';
+
+import { extractQueryParams, OAuth1Client } from './oauth1.client.js';
+
+import type * as NangoShared from '@nangohq/shared';
+import type { IntegrationConfig, ProviderOAuth1 } from '@nangohq/types';
+import type { AddressInfo } from 'node:net';
+
+// OAuth1 token calls run through node-oauth, which we pin to the OAuth-safe agents and gate with
+// `assertSafeOAuthUrl`. Neutralise the egress policy here so a loopback test server is reachable
+// (loopback is always blocked by the real policy) while still exercising the guarded flow.
+vi.mock('@nangohq/shared', async (importOriginal) => {
+    const actual = await importOriginal<typeof NangoShared>();
+    return {
+        ...actual,
+        assertSafeOAuthUrl: vi.fn((url: string) => Promise.resolve(new URL(url))),
+        getOAuthSafeHttpAgents: vi.fn(() => ({ httpAgent: new http.Agent(), httpsAgent: new https.Agent() }))
+    };
+});
+
+async function withServer(handler: http.RequestListener, fn: (baseUrl: string) => Promise<void>): Promise<void> {
+    const server = http.createServer(handler);
+    await new Promise<void>((resolve) => server.listen(0, '127.0.0.1', resolve));
+    const { port } = server.address() as AddressInfo;
+    try {
+        await fn(`http://127.0.0.1:${port}`);
+    } finally {
+        await new Promise<void>((resolve) => server.close(() => resolve()));
+    }
+}
+
+const config = { oauth_client_id: 'client-id', oauth_client_secret: 'client-secret' } as IntegrationConfig;
+
+function makeProvider(overrides: Partial<ProviderOAuth1>): ProviderOAuth1 {
+    return {
+        display_name: 'OAuth1 Provider',
+        docs: 'https://docs.example.com',
+        auth_mode: 'OAUTH1',
+        signature_method: 'HMAC-SHA1',
+        request_url: 'https://example.com/request',
+        token_url: 'https://example.com/access',
+        ...overrides
+    } as ProviderOAuth1;
+}
 
 describe('oauth1', () => {
     it('should extract query params', () => {
@@ -11,5 +57,68 @@ describe('oauth1', () => {
     it('should extract undefined query params', () => {
         const res = extractQueryParams(undefined);
         expect(res).toStrictEqual({});
+    });
+});
+
+describe('OAuth1Client egress', () => {
+    afterEach(() => {
+        vi.clearAllMocks();
+    });
+
+    it('fetches a request token end-to-end through the guarded, pinned client', async () => {
+        await withServer(
+            (_req, res) => {
+                res.writeHead(200, { 'content-type': 'application/x-www-form-urlencoded' });
+                res.end('oauth_token=req-token&oauth_token_secret=req-secret&oauth_callback_confirmed=true');
+            },
+            async (baseUrl) => {
+                const provider = makeProvider({ request_url: `${baseUrl}/request`, token_url: `${baseUrl}/access` });
+                const client = new OAuth1Client(config, provider, 'https://app.example.com/callback');
+
+                const result = await client.getOAuthRequestToken();
+
+                expect(result.request_token).toBe('req-token');
+                expect(result.request_token_secret).toBe('req-secret');
+                expect(assertSafeOAuthUrl).toHaveBeenCalledWith(`${baseUrl}/request`);
+            }
+        );
+    });
+
+    it('exchanges the verifier for an access token end-to-end', async () => {
+        await withServer(
+            (_req, res) => {
+                res.writeHead(200, { 'content-type': 'application/x-www-form-urlencoded' });
+                res.end('oauth_token=access-token&oauth_token_secret=access-secret');
+            },
+            async (baseUrl) => {
+                const provider = makeProvider({ request_url: `${baseUrl}/request`, token_url: `${baseUrl}/access` });
+                const client = new OAuth1Client(config, provider, 'https://app.example.com/callback');
+
+                const result = (await client.getOAuthAccessToken('req-token', 'req-secret', 'the-verifier')) as Record<string, string>;
+
+                expect(result['oauth_token']).toBe('access-token');
+                expect(result['oauth_token_secret']).toBe('access-secret');
+                expect(assertSafeOAuthUrl).toHaveBeenCalledWith(`${baseUrl}/access`);
+            }
+        );
+    });
+
+    it('does not issue the request-token call when the request URL is blocked by policy', async () => {
+        vi.mocked(assertSafeOAuthUrl).mockRejectedValueOnce(new Error('URL resolves to a blocked address'));
+        let serverHit = false;
+        await withServer(
+            (_req, res) => {
+                serverHit = true;
+                res.writeHead(200, { 'content-type': 'application/x-www-form-urlencoded' });
+                res.end('oauth_token=should-not-happen');
+            },
+            async (baseUrl) => {
+                const provider = makeProvider({ request_url: `${baseUrl}/request`, token_url: `${baseUrl}/access` });
+                const client = new OAuth1Client(config, provider, 'https://app.example.com/callback');
+
+                await expect(client.getOAuthRequestToken()).rejects.toThrow();
+                expect(serverHit).toBe(false);
+            }
+        );
     });
 });

--- a/packages/server/lib/clients/oauth1.client.unit.test.ts
+++ b/packages/server/lib/clients/oauth1.client.unit.test.ts
@@ -4,7 +4,7 @@ import https from 'node:https';
 import oAuth1 from 'oauth';
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 
-import { assertSafeOAuthUrl, getOAuthSafeHttpAgents } from '@nangohq/shared';
+import { assertSafeOAuthUrl, getOAuthRedirectPolicy, getOAuthSafeHttpAgents } from '@nangohq/shared';
 
 import { extractQueryParams, OAuth1Client } from './oauth1.client.js';
 
@@ -16,7 +16,9 @@ import type { AddressInfo } from 'node:net';
 // `assertSafeOAuthUrl`. Neutralise the egress policy here so a loopback test server is reachable
 // (loopback is always blocked by the real policy) while still exercising the guarded flow.
 // The agents are stable singletons so the internal-wiring tests can assert the exact instances
-// node-oauth was pinned to.
+// node-oauth was pinned to. `maxRedirects` is lowered so the redirect-cap test needs only a short chain.
+const TEST_MAX_REDIRECTS = 2;
+
 vi.mock('@nangohq/shared', async (importOriginal) => {
     const actual = await importOriginal<typeof NangoShared>();
     const nodeHttp = await import('node:http');
@@ -26,7 +28,8 @@ vi.mock('@nangohq/shared', async (importOriginal) => {
     return {
         ...actual,
         assertSafeOAuthUrl: vi.fn((url: string) => Promise.resolve(new URL(url))),
-        getOAuthSafeHttpAgents: vi.fn(() => ({ httpAgent, httpsAgent }))
+        getOAuthSafeHttpAgents: vi.fn(() => ({ httpAgent, httpsAgent })),
+        getOAuthRedirectPolicy: vi.fn(() => ({ maxRedirects: 2, validate: () => Promise.resolve() }))
     };
 });
 
@@ -58,6 +61,7 @@ function makeProvider(overrides: Partial<ProviderOAuth1>): ProviderOAuth1 {
 // The private node-oauth members OAuth1Client overrides to enforce egress. Declared here so the
 // internal-wiring tests below have a typed handle on them and fail loudly if node-oauth changes them.
 interface NodeOAuthInternals {
+    _clientOptions: { followRedirects: boolean };
     _createClient: (port: number, hostname: string, method: string, path: string, headers: http.OutgoingHttpHeaders, sslEnabled: boolean) => http.ClientRequest;
     _performSecureRequest: (
         oauthToken: string | null,
@@ -205,6 +209,73 @@ describe('OAuth1Client egress', () => {
             }
         );
     });
+
+    it('stops a redirect loop at the policy cap instead of issuing unbounded requests', async () => {
+        let requestCount = 0;
+        await withServer(
+            (req, res) => {
+                requestCount += 1;
+                // A token endpoint that redirects to itself forever. node-oauth has no cap of its own, so
+                // without the wrapper's budget this would recurse until the process gave out.
+                res.writeHead(302, { location: `http://${req.headers.host}/loop` });
+                res.end();
+            },
+            async (baseUrl) => {
+                const provider = makeProvider({ request_url: `${baseUrl}/loop`, token_url: `${baseUrl}/access` });
+                const client = new OAuth1Client(config, provider, 'https://app.example.com/callback');
+
+                await expect(client.getOAuthRequestToken()).rejects.toThrow(`Maximum number of redirects (${TEST_MAX_REDIRECTS}) exceeded`);
+                // The initial request plus exactly `maxRedirects` hops, matching the undici OAuth path.
+                expect(requestCount).toBe(TEST_MAX_REDIRECTS + 1);
+            }
+        );
+    });
+
+    it('caps redirects on the access-token flow too', async () => {
+        let requestCount = 0;
+        await withServer(
+            (req, res) => {
+                requestCount += 1;
+                res.writeHead(302, { location: `http://${req.headers.host}/loop` });
+                res.end();
+            },
+            async (baseUrl) => {
+                const provider = makeProvider({ request_url: `${baseUrl}/request`, token_url: `${baseUrl}/loop` });
+                const client = new OAuth1Client(config, provider, 'https://app.example.com/callback');
+
+                await expect(client.getOAuthAccessToken('req-token', 'req-secret', 'the-verifier')).rejects.toThrow(
+                    `Maximum number of redirects (${TEST_MAX_REDIRECTS}) exceeded`
+                );
+                expect(requestCount).toBe(TEST_MAX_REDIRECTS + 1);
+            }
+        );
+    });
+
+    it('counts hops per token request, so a fresh call starts with a full redirect budget', async () => {
+        let requestCount = 0;
+        await withServer(
+            (req, res) => {
+                requestCount += 1;
+                if (req.url === '/request') {
+                    res.writeHead(302, { location: `http://${req.headers.host}/request-final` });
+                    res.end();
+                    return;
+                }
+                res.writeHead(200, { 'content-type': 'application/x-www-form-urlencoded' });
+                res.end('oauth_token=req-token&oauth_token_secret=req-secret&oauth_callback_confirmed=true');
+            },
+            async (baseUrl) => {
+                const provider = makeProvider({ request_url: `${baseUrl}/request`, token_url: `${baseUrl}/access` });
+                const client = new OAuth1Client(config, provider, 'https://app.example.com/callback');
+
+                // Reusing one client for several redirecting calls must not exhaust a shared budget.
+                for (let i = 0; i < TEST_MAX_REDIRECTS + 2; i++) {
+                    await expect(client.getOAuthRequestToken()).resolves.toMatchObject({ request_token: 'req-token' });
+                }
+                expect(requestCount).toBe((TEST_MAX_REDIRECTS + 2) * 2);
+            }
+        );
+    });
 });
 
 // These tests deliberately reach into node-oauth's private `_createClient` / `_performSecureRequest`
@@ -223,6 +294,16 @@ describe('OAuth1Client node-oauth internal wiring', () => {
         const proto = oAuth1.OAuth.prototype as unknown as Partial<NodeOAuthInternals>;
         expect(typeof proto._createClient).toBe('function');
         expect(typeof proto._performSecureRequest).toBe('function');
+    });
+
+    it('leaves redirect following on and takes its hop budget from the OAuth policy', () => {
+        const provider = makeProvider({ request_url: 'https://example.com/request', token_url: 'https://example.com/access' });
+        const client = new OAuth1Client(config, provider, 'https://app.example.com/callback');
+
+        // Redirects are followed, so the cap in the `_performSecureRequest` wrapper is the only thing bounding
+        // node-oauth's uncapped redirect recursion; it must come from the policy rather than a local constant.
+        expect(getNodeOAuthInternals(client)._clientOptions.followRedirects).toBe(true);
+        expect(getOAuthRedirectPolicy).toHaveBeenCalled();
     });
 
     it('replaces _createClient and _performSecureRequest on the constructed instance', () => {

--- a/packages/server/lib/clients/oauth1.client.unit.test.ts
+++ b/packages/server/lib/clients/oauth1.client.unit.test.ts
@@ -1,9 +1,10 @@
 import http from 'node:http';
 import https from 'node:https';
 
-import { afterEach, describe, expect, it, vi } from 'vitest';
+import oAuth1 from 'oauth';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 
-import { assertSafeOAuthUrl } from '@nangohq/shared';
+import { assertSafeOAuthUrl, getOAuthSafeHttpAgents } from '@nangohq/shared';
 
 import { extractQueryParams, OAuth1Client } from './oauth1.client.js';
 
@@ -14,12 +15,18 @@ import type { AddressInfo } from 'node:net';
 // OAuth1 token calls run through node-oauth, which we pin to the OAuth-safe agents and gate with
 // `assertSafeOAuthUrl`. Neutralise the egress policy here so a loopback test server is reachable
 // (loopback is always blocked by the real policy) while still exercising the guarded flow.
+// The agents are stable singletons so the internal-wiring tests can assert the exact instances
+// node-oauth was pinned to.
 vi.mock('@nangohq/shared', async (importOriginal) => {
     const actual = await importOriginal<typeof NangoShared>();
+    const nodeHttp = await import('node:http');
+    const nodeHttps = await import('node:https');
+    const httpAgent = new nodeHttp.Agent();
+    const httpsAgent = new nodeHttps.Agent();
     return {
         ...actual,
         assertSafeOAuthUrl: vi.fn((url: string) => Promise.resolve(new URL(url))),
-        getOAuthSafeHttpAgents: vi.fn(() => ({ httpAgent: new http.Agent(), httpsAgent: new https.Agent() }))
+        getOAuthSafeHttpAgents: vi.fn(() => ({ httpAgent, httpsAgent }))
     };
 });
 
@@ -48,6 +55,32 @@ function makeProvider(overrides: Partial<ProviderOAuth1>): ProviderOAuth1 {
     } as ProviderOAuth1;
 }
 
+// The private node-oauth members OAuth1Client overrides to enforce egress. Declared here so the
+// internal-wiring tests below have a typed handle on them and fail loudly if node-oauth changes them.
+interface NodeOAuthInternals {
+    _createClient: (port: number, hostname: string, method: string, path: string, headers: http.OutgoingHttpHeaders, sslEnabled: boolean) => http.ClientRequest;
+    _performSecureRequest: (
+        oauthToken: string | null,
+        oauthTokenSecret: string | null,
+        method: string,
+        url: string,
+        extraParams: Record<string, unknown> | null,
+        postBody: string | Buffer | null,
+        postContentType: string | undefined,
+        callback?: (err: unknown, data?: unknown, res?: unknown) => void
+    ) => http.ClientRequest | undefined;
+}
+
+function getNodeOAuthInternals(client: OAuth1Client): NodeOAuthInternals {
+    return (client as unknown as { client: NodeOAuthInternals }).client;
+}
+
+/** Minimal ClientRequest stand-in so factory/streaming tests never open a real socket. */
+function fakeClientRequest(): http.ClientRequest {
+    const stub = { on: () => stub, write: () => true, end: () => undefined, destroy: () => undefined };
+    return stub as unknown as http.ClientRequest;
+}
+
 describe('oauth1', () => {
     it('should extract query params', () => {
         const res = extractQueryParams('baz=bar&foo=bar');
@@ -61,6 +94,10 @@ describe('oauth1', () => {
 });
 
 describe('OAuth1Client egress', () => {
+    beforeEach(() => {
+        // Reset to the permissive default; individual tests override with rejections for blocked hops.
+        vi.mocked(assertSafeOAuthUrl).mockImplementation((url: string) => Promise.resolve(new URL(url)));
+    });
     afterEach(() => {
         vi.clearAllMocks();
     });
@@ -120,5 +157,183 @@ describe('OAuth1Client egress', () => {
                 expect(serverHit).toBe(false);
             }
         );
+    });
+
+    it('follows a 302 redirect on the request-token endpoint, validating each hop', async () => {
+        await withServer(
+            (req, res) => {
+                if (req.url === '/request') {
+                    // node-oauth follows 301/302 by re-requesting the absolute Location.
+                    res.writeHead(302, { location: `http://${req.headers.host}/request-final` });
+                    res.end();
+                    return;
+                }
+                res.writeHead(200, { 'content-type': 'application/x-www-form-urlencoded' });
+                res.end('oauth_token=redirected-token&oauth_token_secret=redirected-secret&oauth_callback_confirmed=true');
+            },
+            async (baseUrl) => {
+                const provider = makeProvider({ request_url: `${baseUrl}/request`, token_url: `${baseUrl}/access` });
+                const client = new OAuth1Client(config, provider, 'https://app.example.com/callback');
+
+                const result = await client.getOAuthRequestToken();
+
+                // The redirect was followed rather than surfaced as a token error.
+                expect(result.request_token).toBe('redirected-token');
+                // Both the original URL and the redirect target were validated.
+                expect(assertSafeOAuthUrl).toHaveBeenCalledWith(`${baseUrl}/request`);
+                expect(assertSafeOAuthUrl).toHaveBeenCalledWith(`${baseUrl}/request-final`);
+            }
+        );
+    });
+
+    it('rejects a redirect whose target is blocked by policy without following it', async () => {
+        // Permit the initial endpoint, but block the redirect target (e.g. cloud metadata).
+        vi.mocked(assertSafeOAuthUrl).mockImplementation((url: string) =>
+            url.includes('169.254.169.254') ? Promise.reject(new Error('URL resolves to a blocked address')) : Promise.resolve(new URL(url))
+        );
+        await withServer(
+            (_req, res) => {
+                res.writeHead(302, { location: 'http://169.254.169.254/latest/meta-data/' });
+                res.end();
+            },
+            async (baseUrl) => {
+                const provider = makeProvider({ request_url: `${baseUrl}/request`, token_url: `${baseUrl}/access` });
+                const client = new OAuth1Client(config, provider, 'https://app.example.com/callback');
+
+                await expect(client.getOAuthRequestToken()).rejects.toThrow();
+                expect(assertSafeOAuthUrl).toHaveBeenCalledWith('http://169.254.169.254/latest/meta-data/');
+            }
+        );
+    });
+});
+
+// These tests deliberately reach into node-oauth's private `_createClient` / `_performSecureRequest`
+// members because that is exactly the surface our egress hardening overrides. They document and lock in
+// the internal contract we depend on, so a node-oauth upgrade that renames, removes, or reshapes those
+// members (which would silently bypass DNS pinning / per-hop URL validation) fails here instead.
+describe('OAuth1Client node-oauth internal wiring', () => {
+    beforeEach(() => {
+        vi.mocked(assertSafeOAuthUrl).mockImplementation((url: string) => Promise.resolve(new URL(url)));
+    });
+    afterEach(() => {
+        vi.clearAllMocks();
+    });
+
+    it('depends on node-oauth private members that still exist on the prototype', () => {
+        const proto = oAuth1.OAuth.prototype as unknown as Partial<NodeOAuthInternals>;
+        expect(typeof proto._createClient).toBe('function');
+        expect(typeof proto._performSecureRequest).toBe('function');
+    });
+
+    it('replaces _createClient and _performSecureRequest on the constructed instance', () => {
+        const provider = makeProvider({ request_url: 'https://example.com/request', token_url: 'https://example.com/access' });
+        const client = new OAuth1Client(config, provider, 'https://app.example.com/callback');
+
+        const proto = oAuth1.OAuth.prototype as unknown as NodeOAuthInternals;
+        const internals = getNodeOAuthInternals(client);
+
+        expect(typeof internals._createClient).toBe('function');
+        expect(typeof internals._performSecureRequest).toBe('function');
+        // The instance members must be our overrides, not node-oauth's originals.
+        expect(internals._createClient).not.toBe(proto._createClient);
+        expect(internals._performSecureRequest).not.toBe(proto._performSecureRequest);
+    });
+
+    it('_createClient pins every request (http + https) to the injected OAuth-safe agents', () => {
+        const provider = makeProvider({ request_url: 'https://example.com/request', token_url: 'https://example.com/access' });
+        const client = new OAuth1Client(config, provider, 'https://app.example.com/callback');
+        const internals = getNodeOAuthInternals(client);
+        const { httpAgent, httpsAgent } = getOAuthSafeHttpAgents();
+
+        const httpsSpy = vi.spyOn(https, 'request').mockReturnValue(fakeClientRequest());
+        const httpSpy = vi.spyOn(http, 'request').mockReturnValue(fakeClientRequest());
+
+        try {
+            internals._createClient(443, 'example.com', 'POST', '/access', { 'x-test': '1' }, true);
+            internals._createClient(80, 'example.com', 'GET', '/request', {}, false);
+
+            expect(httpsSpy).toHaveBeenCalledWith(
+                expect.objectContaining({ host: 'example.com', port: 443, path: '/access', method: 'POST', agent: httpsAgent })
+            );
+            expect(httpSpy).toHaveBeenCalledWith(expect.objectContaining({ host: 'example.com', port: 80, path: '/request', method: 'GET', agent: httpAgent }));
+        } finally {
+            httpsSpy.mockRestore();
+            httpSpy.mockRestore();
+        }
+    });
+
+    it('the _performSecureRequest wrapper validates the hop, then delegates to node-oauth (callback path)', async () => {
+        await withServer(
+            (_req, res) => {
+                res.writeHead(200, { 'content-type': 'application/x-www-form-urlencoded' });
+                res.end('delegated=yes');
+            },
+            async (baseUrl) => {
+                const provider = makeProvider({ request_url: `${baseUrl}/request`, token_url: `${baseUrl}/access` });
+                const client = new OAuth1Client(config, provider, 'https://app.example.com/callback');
+                const url = `${baseUrl}/secure`;
+
+                const data = await new Promise<string>((resolve, reject) => {
+                    getNodeOAuthInternals(client)._performSecureRequest(null, null, 'GET', url, null, '', undefined, (err, body) =>
+                        err ? reject(err as Error) : resolve(body as string)
+                    );
+                });
+
+                // The wrapper ran the policy check and the original node-oauth implementation issued the request.
+                expect(data).toBe('delegated=yes');
+                expect(assertSafeOAuthUrl).toHaveBeenCalledWith(url);
+            }
+        );
+    });
+
+    it('the _performSecureRequest wrapper surfaces a blocked hop via the callback without issuing a request', async () => {
+        vi.mocked(assertSafeOAuthUrl).mockRejectedValueOnce(new Error('URL resolves to a blocked address'));
+        let serverHit = false;
+        await withServer(
+            (_req, res) => {
+                serverHit = true;
+                res.end('should-not-happen');
+            },
+            async (baseUrl) => {
+                const provider = makeProvider({ request_url: `${baseUrl}/request`, token_url: `${baseUrl}/access` });
+                const client = new OAuth1Client(config, provider, 'https://app.example.com/callback');
+
+                const error = await new Promise<unknown>((resolve) => {
+                    getNodeOAuthInternals(client)._performSecureRequest(null, null, 'GET', `${baseUrl}/blocked`, null, '', undefined, (err) => resolve(err));
+                });
+
+                expect(error).toBeInstanceOf(Error);
+                // The guard short-circuits before node-oauth issues the request.
+                expect(serverHit).toBe(false);
+            }
+        );
+    });
+
+    it('the _performSecureRequest wrapper delegates streaming (no-callback) requests untouched, skipping validation', () => {
+        const provider = makeProvider({ request_url: 'https://example.com/request', token_url: 'https://example.com/access' });
+        const client = new OAuth1Client(config, provider, 'https://app.example.com/callback');
+
+        const fakeRequest = fakeClientRequest();
+        const httpSpy = vi.spyOn(http, 'request').mockReturnValue(fakeRequest);
+
+        try {
+            const returned = getNodeOAuthInternals(client)._performSecureRequest(
+                null,
+                null,
+                'GET',
+                'http://example.com/stream',
+                null,
+                '',
+                undefined,
+                undefined
+            );
+
+            // No callback => the wrapper must not run the async policy check; it simply hands off to node-oauth.
+            expect(assertSafeOAuthUrl).not.toHaveBeenCalled();
+            expect(httpSpy).toHaveBeenCalledOnce();
+            expect(returned).toBe(fakeRequest);
+        } finally {
+            httpSpy.mockRestore();
+        }
     });
 });

--- a/packages/server/lib/controllers/oauth.controller.ts
+++ b/packages/server/lib/controllers/oauth.controller.ts
@@ -10,6 +10,7 @@ import { getFlags } from '@nangohq/feature-flags';
 import { defaultOperationExpiration, endUserToMeta, logContextGetter } from '@nangohq/logs';
 import {
     accountService,
+    assertSafeOAuthUrl,
     configService,
     connectionService,
     environmentService,
@@ -1708,6 +1709,7 @@ class OAuthController {
 
             const tokenUrl = typeof provider.token_url === 'string' ? provider.token_url : (provider.token_url?.['OAUTH2'] as string);
             const interpolatedTokenUrl = makeUrl(tokenUrl, connectionConfig, provider.token_url_skip_encode);
+            await assertSafeOAuthUrl(interpolatedTokenUrl.href);
             if (providerClientManager.shouldUseProviderClient(session.provider)) {
                 rawCredentials = await providerClientManager.getToken(
                     config,

--- a/packages/shared/lib/auth/aws-sigv4.ts
+++ b/packages/shared/lib/auth/aws-sigv4.ts
@@ -3,7 +3,7 @@ import crypto from 'node:crypto';
 import { axiosInstance as axios, Err, getLogger, Ok, stringifyError } from '@nangohq/utils';
 
 import { signAwsSigV4Request } from '../services/proxy/aws-sigv4.js';
-import { assertSafeOAuthUrl, getOAuthSafeHttpAgents } from '../services/proxy/outbound-policy.js';
+import { assertSafeOAuthUrl, getOAuthAxiosRequestConfig } from '../services/proxy/outbound-policy.js';
 import { NangoError } from '../utils/error.js';
 
 import type { Config as ProviderConfig } from '../models/Provider.js';
@@ -186,7 +186,7 @@ async function fetchAwsTemporaryCredentialsBuiltin({
         const response = await axios.post(stsUrl, body, {
             headers: signedHeaders,
             transformResponse: [(data: unknown) => data], // keep raw XML
-            ...getOAuthSafeHttpAgents()
+            ...getOAuthAxiosRequestConfig()
         });
 
         const creds = parseAssumeRoleResponse(response.data as string);
@@ -240,7 +240,7 @@ async function fetchAwsTemporaryCredentialsCustom({
 
     try {
         await assertSafeOAuthUrl(settings.stsEndpoint.url);
-        const response = await axios.post(settings.stsEndpoint.url, payload, { headers, ...getOAuthSafeHttpAgents() });
+        const response = await axios.post(settings.stsEndpoint.url, payload, { headers, ...getOAuthAxiosRequestConfig() });
         const creds = normalizeStsResponse(response.data);
         if (!creds) {
             return Err(

--- a/packages/shared/lib/auth/aws-sigv4.ts
+++ b/packages/shared/lib/auth/aws-sigv4.ts
@@ -3,6 +3,7 @@ import crypto from 'node:crypto';
 import { axiosInstance as axios, Err, getLogger, Ok, stringifyError } from '@nangohq/utils';
 
 import { signAwsSigV4Request } from '../services/proxy/aws-sigv4.js';
+import { assertSafeOAuthUrl, getOAuthSafeHttpAgents } from '../services/proxy/outbound-policy.js';
 import { NangoError } from '../utils/error.js';
 
 import type { Config as ProviderConfig } from '../models/Provider.js';
@@ -184,7 +185,8 @@ async function fetchAwsTemporaryCredentialsBuiltin({
     try {
         const response = await axios.post(stsUrl, body, {
             headers: signedHeaders,
-            transformResponse: [(data: unknown) => data] // keep raw XML
+            transformResponse: [(data: unknown) => data], // keep raw XML
+            ...getOAuthSafeHttpAgents()
         });
 
         const creds = parseAssumeRoleResponse(response.data as string);
@@ -237,7 +239,8 @@ async function fetchAwsTemporaryCredentialsCustom({
     }
 
     try {
-        const response = await axios.post(settings.stsEndpoint.url, payload, { headers });
+        await assertSafeOAuthUrl(settings.stsEndpoint.url);
+        const response = await axios.post(settings.stsEndpoint.url, payload, { headers, ...getOAuthSafeHttpAgents() });
         const creds = normalizeStsResponse(response.data);
         if (!creds) {
             return Err(

--- a/packages/shared/lib/auth/aws-sigv4.ts
+++ b/packages/shared/lib/auth/aws-sigv4.ts
@@ -183,6 +183,9 @@ async function fetchAwsTemporaryCredentialsBuiltin({
     });
 
     try {
+        // `region` is already regex-validated, but assert the fully-built STS URL through the egress policy
+        // as well so this path matches the custom-endpoint path and is covered by the same denylist/IP guards.
+        await assertSafeOAuthUrl(stsUrl);
         const response = await axios.post(stsUrl, body, {
             headers: signedHeaders,
             transformResponse: [(data: unknown) => data], // keep raw XML

--- a/packages/shared/lib/auth/aws-sigv4.unit.test.ts
+++ b/packages/shared/lib/auth/aws-sigv4.unit.test.ts
@@ -1,8 +1,39 @@
-import { describe, expect, it } from 'vitest';
+import http from 'node:http';
 
-import { getAwsSigV4Settings, isValidAwsRegion, parseAssumeRoleResponse } from './aws-sigv4.js';
+import { afterEach, describe, expect, it, vi } from 'vitest';
+
+import { axiosInstance } from '@nangohq/utils';
+
+import { assertSafeOAuthUrl } from '../services/proxy/outbound-policy.js';
+import { fetchAwsTemporaryCredentials, getAwsSigV4Settings, isValidAwsRegion, parseAssumeRoleResponse } from './aws-sigv4.js';
 
 import type { Config as ProviderConfig } from '../models/Provider.js';
+import type * as OutboundPolicyModule from '../services/proxy/outbound-policy.js';
+import type { AwsSigV4IntegrationSettings } from './aws-sigv4.js';
+import type { AddressInfo } from 'node:net';
+
+// The STS AssumeRole call goes through the OAuth egress policy. Neutralise the policy so a local test
+// server is reachable (loopback is always blocked by the real policy) while still asserting the URL guard.
+vi.mock('../services/proxy/outbound-policy.js', async (importOriginal) => {
+    const actual = await importOriginal<typeof OutboundPolicyModule>();
+    return {
+        ...actual,
+        assertSafeOAuthUrl: vi.fn((url: string) => Promise.resolve(new URL(url))),
+        // `proxy: false` keeps axios off any ambient HTTP(S)_PROXY so the loopback test server is reached directly.
+        getOAuthAxiosRequestConfig: vi.fn(() => ({ proxy: false }))
+    };
+});
+
+async function withServer(handler: http.RequestListener, fn: (baseUrl: string) => Promise<void>): Promise<void> {
+    const server = http.createServer(handler);
+    await new Promise<void>((resolve) => server.listen(0, '127.0.0.1', resolve));
+    const { port } = server.address() as AddressInfo;
+    try {
+        await fn(`http://127.0.0.1:${port}`);
+    } finally {
+        await new Promise<void>((resolve) => server.close(() => resolve()));
+    }
+}
 
 function makeConfig(overrides: Partial<ProviderConfig> = {}): ProviderConfig {
     return {
@@ -203,6 +234,119 @@ describe('getAwsSigV4Settings', () => {
         if (result.isOk()) {
             expect(result.value.stsEndpoint?.auth).toBeUndefined();
         }
+    });
+});
+
+describe('fetchAwsTemporaryCredentials', () => {
+    afterEach(() => {
+        vi.restoreAllMocks();
+        vi.clearAllMocks();
+    });
+
+    const input = { roleArn: 'arn:aws:iam::123456789012:role/TestRole', externalId: 'external-123', region: 'us-east-1' };
+
+    const stsXml = `<AssumeRoleResponse xmlns="https://sts.amazonaws.com/doc/2011-06-15/">
+  <AssumeRoleResult>
+    <Credentials>
+      <AccessKeyId>ASIABUILTIN</AccessKeyId>
+      <SecretAccessKey>builtinSecret</SecretAccessKey>
+      <SessionToken>builtinSession</SessionToken>
+      <Expiration>2035-01-02T04:04:05Z</Expiration>
+    </Credentials>
+  </AssumeRoleResult>
+</AssumeRoleResponse>`;
+
+    it('builtin mode: assumes the role against the region STS endpoint and validates the URL', async () => {
+        const postSpy = vi.spyOn(axiosInstance, 'post').mockResolvedValue({ status: 200, data: stsXml });
+
+        const settings: AwsSigV4IntegrationSettings = {
+            service: 's3',
+            stsMode: 'builtin',
+            defaultRegion: 'us-east-1',
+            builtinCredentials: { awsAccessKeyId: 'AKIATEST', awsSecretAccessKey: 'secret' }
+        };
+
+        const result = await fetchAwsTemporaryCredentials({ settings, input });
+
+        expect(result.isOk()).toBe(true);
+        if (result.isOk()) {
+            expect(result.value.accessKeyId).toBe('ASIABUILTIN');
+            expect(result.value.sessionToken).toBe('builtinSession');
+        }
+        // The built-in STS URL is now validated through the egress policy, matching the custom path.
+        expect(assertSafeOAuthUrl).toHaveBeenCalledWith('https://sts.us-east-1.amazonaws.com/');
+        expect(postSpy).toHaveBeenCalledOnce();
+    });
+
+    it('builtin mode: refresh re-runs the guarded assume-role call', async () => {
+        // AWS_SIGV4 refresh re-invokes fetchAwsTemporaryCredentials (connection.service), so a repeat call must succeed.
+        const postSpy = vi.spyOn(axiosInstance, 'post').mockResolvedValue({ status: 200, data: stsXml });
+        const settings: AwsSigV4IntegrationSettings = {
+            service: 's3',
+            stsMode: 'builtin',
+            defaultRegion: 'us-east-1',
+            builtinCredentials: { awsAccessKeyId: 'AKIATEST', awsSecretAccessKey: 'secret' }
+        };
+
+        const first = await fetchAwsTemporaryCredentials({ settings, input });
+        const refreshed = await fetchAwsTemporaryCredentials({ settings, input });
+
+        expect(first.isOk()).toBe(true);
+        expect(refreshed.isOk()).toBe(true);
+        expect(postSpy).toHaveBeenCalledTimes(2);
+    });
+
+    it('builtin mode: does not call STS when the URL is blocked by policy', async () => {
+        vi.mocked(assertSafeOAuthUrl).mockRejectedValueOnce(new Error('URL resolves to a blocked address'));
+        const postSpy = vi.spyOn(axiosInstance, 'post');
+
+        const settings: AwsSigV4IntegrationSettings = {
+            service: 's3',
+            stsMode: 'builtin',
+            defaultRegion: 'us-east-1',
+            builtinCredentials: { awsAccessKeyId: 'AKIATEST', awsSecretAccessKey: 'secret' }
+        };
+
+        const result = await fetchAwsTemporaryCredentials({ settings, input });
+
+        expect(result.isErr()).toBe(true);
+        if (result.isErr()) {
+            expect(result.error.type).toBe('aws_sigv4_sts_request_failed');
+        }
+        expect(postSpy).not.toHaveBeenCalled();
+    });
+
+    it('custom mode: fetches credentials from the custom STS endpoint end-to-end', async () => {
+        await withServer(
+            (_req, res) => {
+                res.writeHead(200, { 'content-type': 'application/json' });
+                res.end(
+                    JSON.stringify({
+                        accessKeyId: 'ASIACUSTOM',
+                        secretAccessKey: 'customSecret',
+                        sessionToken: 'customSession',
+                        expiration: new Date('2035-01-02T04:04:05Z').toISOString()
+                    })
+                );
+            },
+            async (baseUrl) => {
+                const settings: AwsSigV4IntegrationSettings = {
+                    service: 's3',
+                    stsMode: 'custom',
+                    defaultRegion: 'us-east-1',
+                    stsEndpoint: { url: `${baseUrl}/sts` }
+                };
+
+                const result = await fetchAwsTemporaryCredentials({ settings, input });
+
+                expect(result.isOk()).toBe(true);
+                if (result.isOk()) {
+                    expect(result.value.accessKeyId).toBe('ASIACUSTOM');
+                    expect(result.value.sessionToken).toBe('customSession');
+                }
+                expect(assertSafeOAuthUrl).toHaveBeenCalledWith(`${baseUrl}/sts`);
+            }
+        );
     });
 });
 

--- a/packages/shared/lib/auth/aws-sigv4.unit.test.ts
+++ b/packages/shared/lib/auth/aws-sigv4.unit.test.ts
@@ -239,8 +239,9 @@ describe('getAwsSigV4Settings', () => {
 
 describe('fetchAwsTemporaryCredentials', () => {
     afterEach(() => {
+        // Restores the per-test axios spy created via vi.spyOn; the factory vi.fn mocks keep their default
+        // implementations and their (assertion-irrelevant) call history across tests.
         vi.restoreAllMocks();
-        vi.clearAllMocks();
     });
 
     const input = { roleArn: 'arn:aws:iam::123456789012:role/TestRole', externalId: 'external-123', region: 'us-east-1' };

--- a/packages/shared/lib/auth/bill.ts
+++ b/packages/shared/lib/auth/bill.ts
@@ -45,7 +45,9 @@ export async function createCredentials({
 
     try {
         // Route the login/session call through the OAuth egress policy: validate the token URL and pin the
-        // connected IP so a self-hosted or misconfigured token_url can't be used to reach internal hosts.
+        // connected IP. Note the OAuth policy intentionally allows private/RFC1918 destinations by default
+        // (so self-hosted Bill gateways keep working) — it blocks loopback, link-local/cloud-metadata, and
+        // denylisted hosts, not all internal addresses.
         await assertSafeOAuthUrl(provider.token_url);
         const response = await axios.post(provider.token_url, postBody, {
             headers,

--- a/packages/shared/lib/auth/bill.ts
+++ b/packages/shared/lib/auth/bill.ts
@@ -2,6 +2,7 @@ import ms from 'ms';
 
 import { axiosInstance as axios, Err, Ok } from '@nangohq/utils';
 
+import { assertSafeOAuthUrl, getOAuthAxiosRequestConfig } from '../services/proxy/outbound-policy.js';
 import { AuthCredentialsError } from '../utils/error.js';
 
 import type { BillCredentials, ProviderBill } from '@nangohq/types';
@@ -43,8 +44,12 @@ export async function createCredentials({
     };
 
     try {
+        // Route the login/session call through the OAuth egress policy: validate the token URL and pin the
+        // connected IP so a self-hosted or misconfigured token_url can't be used to reach internal hosts.
+        await assertSafeOAuthUrl(provider.token_url);
         const response = await axios.post(provider.token_url, postBody, {
-            headers
+            headers,
+            ...getOAuthAxiosRequestConfig()
         });
 
         if (response.status !== 200) {

--- a/packages/shared/lib/auth/bill.unit.test.ts
+++ b/packages/shared/lib/auth/bill.unit.test.ts
@@ -1,0 +1,121 @@
+import http from 'node:http';
+
+import { afterEach, describe, expect, it, vi } from 'vitest';
+
+import { assertSafeOAuthUrl } from '../services/proxy/outbound-policy.js';
+import { createCredentials } from './bill.js';
+
+import type * as OutboundPolicyModule from '../services/proxy/outbound-policy.js';
+import type { ProviderBill } from '@nangohq/types';
+import type { AddressInfo } from 'node:net';
+
+// The BILL login/session call goes through the OAuth egress policy. Neutralise the policy here so the
+// flow can reach a loopback test server (loopback is always blocked by the real policy), while still
+// asserting that the URL guard is invoked before the request is sent.
+vi.mock('../services/proxy/outbound-policy.js', async (importOriginal) => {
+    const actual = await importOriginal<typeof OutboundPolicyModule>();
+    return {
+        ...actual,
+        assertSafeOAuthUrl: vi.fn((url: string) => Promise.resolve(new URL(url))),
+        // `proxy: false` keeps axios off any ambient HTTP(S)_PROXY so the loopback test server is reached directly.
+        getOAuthAxiosRequestConfig: vi.fn(() => ({ proxy: false }))
+    };
+});
+
+async function withServer(handler: http.RequestListener, fn: (baseUrl: string) => Promise<void>): Promise<void> {
+    const server = http.createServer(handler);
+    await new Promise<void>((resolve) => server.listen(0, '127.0.0.1', resolve));
+    const { port } = server.address() as AddressInfo;
+    try {
+        await fn(`http://127.0.0.1:${port}`);
+    } finally {
+        await new Promise<void>((resolve) => server.close(() => resolve()));
+    }
+}
+
+function makeProvider(overrides: Partial<ProviderBill> = {}): ProviderBill {
+    return {
+        display_name: 'Bill',
+        docs: 'https://docs.example.com',
+        auth_mode: 'BILL',
+        ...overrides
+    } as ProviderBill;
+}
+
+describe('bill createCredentials', () => {
+    afterEach(() => {
+        vi.clearAllMocks();
+    });
+
+    it('generates a session end-to-end through the guarded egress path', async () => {
+        await withServer(
+            (req, res) => {
+                let body = '';
+                req.on('data', (chunk) => (body += chunk));
+                req.on('end', () => {
+                    res.writeHead(200, { 'content-type': 'application/json' });
+                    res.end(JSON.stringify({ sessionId: 'sess-abc', organizationId: 'org-1', userId: 'user-9' }));
+                });
+            },
+            async (baseUrl) => {
+                const provider = makeProvider({ token_url: `${baseUrl}/login` });
+                const result = await createCredentials({ username: 'u', password: 'p', organizationId: 'org-1', devKey: 'dev-key', provider });
+
+                expect(result.isOk()).toBe(true);
+                if (result.isOk()) {
+                    expect(result.value.type).toBe('BILL');
+                    expect(result.value.session_id).toBe('sess-abc');
+                    expect(result.value.organization_id).toBe('org-1');
+                    expect(result.value.user_id).toBe('user-9');
+                }
+                // The token URL is validated before the request is issued.
+                expect(assertSafeOAuthUrl).toHaveBeenCalledWith(`${baseUrl}/login`);
+            }
+        );
+    });
+
+    it('refresh re-runs the same guarded login call and yields a fresh session', async () => {
+        // BILL has no dedicated refresh endpoint: connection.service refreshes by calling createCredentials
+        // again with the stored username/password. A second call must therefore succeed the same way.
+        let calls = 0;
+        await withServer(
+            (_req, res) => {
+                calls += 1;
+                res.writeHead(200, { 'content-type': 'application/json' });
+                res.end(JSON.stringify({ sessionId: `sess-${calls}`, organizationId: 'org-1', userId: 'user-9' }));
+            },
+            async (baseUrl) => {
+                const provider = makeProvider({ token_url: `${baseUrl}/login` });
+                const first = await createCredentials({ username: 'u', password: 'p', organizationId: 'org-1', devKey: 'dev-key', provider });
+                const refreshed = await createCredentials({ username: 'u', password: 'p', organizationId: 'org-1', devKey: 'dev-key', provider });
+
+                expect(first.isOk() && first.value.session_id).toBe('sess-1');
+                expect(refreshed.isOk() && refreshed.value.session_id).toBe('sess-2');
+                expect(calls).toBe(2);
+            }
+        );
+    });
+
+    it('does not issue the login request when the token URL is blocked by policy', async () => {
+        vi.mocked(assertSafeOAuthUrl).mockRejectedValueOnce(new Error('URL resolves to a blocked address'));
+        let serverHit = false;
+        await withServer(
+            (_req, res) => {
+                serverHit = true;
+                res.writeHead(200, { 'content-type': 'application/json' });
+                res.end('{}');
+            },
+            async (baseUrl) => {
+                const provider = makeProvider({ token_url: `${baseUrl}/login` });
+                const result = await createCredentials({ username: 'u', password: 'p', organizationId: 'org-1', devKey: 'dev-key', provider });
+
+                expect(result.isErr()).toBe(true);
+                if (result.isErr()) {
+                    expect(result.error.type).toBe('bill_tokens_fetch_error');
+                }
+                // The guard short-circuits before any HTTP request reaches the endpoint.
+                expect(serverHit).toBe(false);
+            }
+        );
+    });
+});

--- a/packages/shared/lib/auth/jwt.ts
+++ b/packages/shared/lib/auth/jwt.ts
@@ -2,7 +2,7 @@ import jwt from 'jsonwebtoken';
 
 import { axiosInstance as axios, Err, Ok } from '@nangohq/utils';
 
-import { assertSafeOAuthUrl, getOAuthSafeHttpAgents } from '../services/proxy/outbound-policy.js';
+import { assertSafeOAuthUrl, getOAuthAxiosRequestConfig } from '../services/proxy/outbound-policy.js';
 import { AuthCredentialsError } from '../utils/error.js';
 import { formatPem, interpolateObject, interpolateString, stripCredential } from '../utils/utils.js';
 
@@ -164,7 +164,7 @@ export async function createCredentialsFromURL({
             {},
             {
                 headers,
-                ...getOAuthSafeHttpAgents()
+                ...getOAuthAxiosRequestConfig()
             }
         );
 

--- a/packages/shared/lib/auth/jwt.ts
+++ b/packages/shared/lib/auth/jwt.ts
@@ -2,6 +2,7 @@ import jwt from 'jsonwebtoken';
 
 import { axiosInstance as axios, Err, Ok } from '@nangohq/utils';
 
+import { assertSafeOAuthUrl, getOAuthSafeHttpAgents } from '../services/proxy/outbound-policy.js';
 import { AuthCredentialsError } from '../utils/error.js';
 import { formatPem, interpolateObject, interpolateString, stripCredential } from '../utils/utils.js';
 
@@ -108,7 +109,7 @@ export function fetchJwtToken({
     payload: Record<string, string | number>;
     options: object;
 }): Result<{ jwtToken: string }, AuthCredentialsError> {
-    const hasLineBreak = /^-----BEGIN RSA PRIVATE KEY-----\n/.test(privateKey);
+    const hasLineBreak = privateKey.startsWith('-----BEGIN RSA PRIVATE KEY-----\n');
 
     if (!hasLineBreak) {
         privateKey = privateKey.replace('-----BEGIN RSA PRIVATE KEY-----', '-----BEGIN RSA PRIVATE KEY-----\n');
@@ -156,11 +157,14 @@ export async function createCredentialsFromURL({
             Object.assign(headers, additionalApiHeaders);
         }
 
+        await assertSafeOAuthUrl(url);
+
         const tokenResponse = await axios.post(
             url,
             {},
             {
-                headers
+                headers,
+                ...getOAuthSafeHttpAgents()
             }
         );
 

--- a/packages/shared/lib/clients/oauth2.client.ts
+++ b/packages/shared/lib/clients/oauth2.client.ts
@@ -1,10 +1,11 @@
 import Boom from '@hapi/boom';
 import { AuthorizationCode } from 'simple-oauth2';
 
-import { httpAgent, httpsAgent, redactHeaders } from '@nangohq/utils';
+import { redactHeaders } from '@nangohq/utils';
 
 import { LogActionEnum } from '../models/Telemetry.js';
 import connectionsManager from '../services/connection.service.js';
+import { assertSafeOAuthUrl, getOAuthSafeHttpAgents } from '../services/proxy/outbound-policy.js';
 import { NangoError } from '../utils/error.js';
 import errorManager, { ErrorSourceEnum } from '../utils/error.manager.js';
 import { makeUrl } from '../utils/utils.js';
@@ -17,16 +18,17 @@ import type { AccessToken, ModuleOptions, WreckHttpOptions } from 'simple-oauth2
 import type { Merge } from 'type-fest';
 
 // we specify these agents as getters so that they aren't cloned by simple-oauth2,
-// because as agent objects grow during usage the clone operation becomes very slow
+// because as agent objects grow during usage the clone operation becomes very slow.
+// The OAuth safe agents pin the policy-validated IP so the connected address matches what was checked.
 const agentConfig = {
     get http() {
-        return httpAgent;
+        return getOAuthSafeHttpAgents().httpAgent;
     },
     get https() {
-        return httpsAgent;
+        return getOAuthSafeHttpAgents().httpsAgent;
     },
     get httpsAllowUnauthorized() {
-        return httpsAgent;
+        return getOAuthSafeHttpAgents().httpsAgent;
     }
 };
 
@@ -130,6 +132,29 @@ export async function getFreshOAuth2Credentials({
     let rawNewAccessToken: AccessToken;
     const createdAt = new Date();
     const url = `${simpleOAuth2ClientConfig.auth.tokenHost}${simpleOAuth2ClientConfig.auth.tokenPath}`;
+
+    try {
+        await assertSafeOAuthUrl(url);
+    } catch (err) {
+        const nangoErr = new NangoError('refresh_token_external_error', { message: err instanceof Error ? err.message : 'Outbound URL blocked by policy' });
+        void logCtx.http(`POST ${url}`, {
+            level: 'error',
+            createdAt,
+            request: { method: 'POST', url, headers: {} },
+            response: undefined,
+            error: err
+        });
+        errorManager.report(nangoErr.message, {
+            environmentId: connection.environment_id,
+            source: ErrorSourceEnum.CUSTOMER,
+            operation: LogActionEnum.AUTH,
+            metadata: {
+                connectionId: connection.id,
+                configId: config.id
+            }
+        });
+        return { success: false, error: nangoErr, response: null };
+    }
 
     try {
         rawNewAccessToken = await oldAccessToken.refresh(additionalParams);

--- a/packages/shared/lib/clients/oauth2.client.unit.test.ts
+++ b/packages/shared/lib/clients/oauth2.client.unit.test.ts
@@ -1,0 +1,184 @@
+import http from 'node:http';
+
+import { AuthorizationCode } from 'simple-oauth2';
+import { afterEach, describe, expect, it, vi } from 'vitest';
+
+import { logContextGetter } from '@nangohq/logs';
+
+import { assertSafeOAuthUrl, getOAuthSafeHttpAgents } from '../services/proxy/outbound-policy.js';
+import { getFreshOAuth2Credentials, getSimpleOAuth2ClientConfig } from './oauth2.client.js';
+
+import type { Config as ProviderConfig } from '../models/index.js';
+import type * as OutboundPolicyModule from '../services/proxy/outbound-policy.js';
+import type { DBConnectionDecrypted, ProviderOAuth2 } from '@nangohq/types';
+import type { AddressInfo } from 'node:net';
+
+// OAuth2 token calls run through simple-oauth2 wired with the OAuth-safe agents and gated by
+// `assertSafeOAuthUrl`. Neutralise the egress policy so a loopback test server is reachable (loopback is
+// always blocked by the real policy) while keeping the getOAuthSafeHttpAgents() wiring intact and asserting
+// the URL guard runs. The mock returns the SAME agent instances on every call so identity checks hold.
+vi.mock('../services/proxy/outbound-policy.js', async (importOriginal) => {
+    const actual = await importOriginal<typeof OutboundPolicyModule>();
+    const nodeHttp = await import('node:http');
+    const nodeHttps = await import('node:https');
+    const httpAgent = new nodeHttp.Agent();
+    const httpsAgent = new nodeHttps.Agent();
+    return {
+        ...actual,
+        assertSafeOAuthUrl: vi.fn((url: string) => Promise.resolve(new URL(url))),
+        getOAuthSafeHttpAgents: vi.fn(() => ({ httpAgent, httpsAgent }))
+    };
+});
+
+async function withServer(handler: http.RequestListener, fn: (baseUrl: string) => Promise<void>): Promise<void> {
+    const server = http.createServer(handler);
+    await new Promise<void>((resolve) => server.listen(0, '127.0.0.1', resolve));
+    const { port } = server.address() as AddressInfo;
+    try {
+        await fn(`http://127.0.0.1:${port}`);
+    } finally {
+        await new Promise<void>((resolve) => server.close(() => resolve()));
+    }
+}
+
+function makeConfig(overrides: Partial<ProviderConfig> = {}): ProviderConfig {
+    return {
+        id: 1,
+        unique_key: 'test',
+        provider: 'test',
+        oauth_client_id: 'client-id',
+        oauth_client_secret: 'client-secret',
+        oauth_scopes: '',
+        environment_id: 1,
+        created_at: new Date(),
+        updated_at: new Date(),
+        missing_fields: [],
+        ...overrides
+    } as ProviderConfig;
+}
+
+function makeProvider(overrides: Partial<ProviderOAuth2> = {}): ProviderOAuth2 {
+    return {
+        display_name: 'OAuth2 Provider',
+        docs: 'https://docs.example.com',
+        auth_mode: 'OAUTH2',
+        ...overrides
+    } as ProviderOAuth2;
+}
+
+/** Minimal token endpoint that echoes the grant type so tests can assert generation vs refresh. */
+function tokenServer(tokenByGrant: Record<string, Record<string, unknown>>): http.RequestListener {
+    return (req, res) => {
+        let body = '';
+        req.on('data', (chunk) => (body += chunk));
+        req.on('end', () => {
+            const grantType = new URLSearchParams(body).get('grant_type') ?? 'unknown';
+            const token = tokenByGrant[grantType];
+            if (!token) {
+                res.writeHead(400, { 'content-type': 'application/json' });
+                res.end(JSON.stringify({ error: 'unsupported_grant_type', grant_type: grantType }));
+                return;
+            }
+            res.writeHead(200, { 'content-type': 'application/json' });
+            res.end(JSON.stringify(token));
+        });
+    };
+}
+
+describe('getSimpleOAuth2ClientConfig', () => {
+    it('wires the OAuth-safe agents into the simple-oauth2 http config', () => {
+        const provider = makeProvider({ token_url: 'https://api.example.com/token', authorization_url: 'https://api.example.com/authorize' });
+        const cfg = getSimpleOAuth2ClientConfig(makeConfig(), provider, {});
+
+        // The http.agents come straight from getOAuthSafeHttpAgents(), so token egress is pinned by policy.
+        const agents = (cfg.http as { agents: { http: unknown; https: unknown } }).agents;
+        expect(agents.http).toBe(getOAuthSafeHttpAgents().httpAgent);
+        expect(agents.https).toBe(getOAuthSafeHttpAgents().httpsAgent);
+    });
+});
+
+describe('OAuth2 token generation and refresh', () => {
+    afterEach(() => {
+        vi.clearAllMocks();
+    });
+
+    it('getToken succeeds end-to-end through the safe-agent wiring', async () => {
+        await withServer(
+            tokenServer({
+                authorization_code: { access_token: 'generated-access-token', token_type: 'bearer', expires_in: 3600, refresh_token: 'generated-refresh-token' }
+            }),
+            async (baseUrl) => {
+                const provider = makeProvider({ token_url: `${baseUrl}/token`, authorization_url: `${baseUrl}/authorize` });
+                const cfg = getSimpleOAuth2ClientConfig(makeConfig(), provider, {});
+                const client = new AuthorizationCode(cfg);
+
+                const token = await client.getToken({ code: 'auth-code', redirect_uri: 'https://app.example.com/callback' });
+
+                expect(token.token['access_token']).toBe('generated-access-token');
+            }
+        );
+    });
+
+    it('getFreshOAuth2Credentials refreshes end-to-end and validates the token URL', async () => {
+        await withServer(
+            tokenServer({
+                refresh_token: { access_token: 'refreshed-access-token', token_type: 'bearer', expires_in: 3600, refresh_token: 'rotated-refresh-token' }
+            }),
+            async (baseUrl) => {
+                const provider = makeProvider({ token_url: `${baseUrl}/token` });
+                const config = makeConfig();
+                const connection = {
+                    id: 1,
+                    environment_id: 1,
+                    connection_config: {},
+                    credentials: {
+                        type: 'OAUTH2',
+                        access_token: 'stale-access-token',
+                        refresh_token: 'the-refresh-token',
+                        expires_at: new Date(Date.now() - 60_000)
+                    }
+                } as unknown as DBConnectionDecrypted;
+
+                const buffer = logContextGetter.getBuffer({ accountId: 1 });
+                const result = await getFreshOAuth2Credentials({ connection, config, provider, logCtx: buffer });
+
+                expect(result.success).toBe(true);
+                expect(result.response?.access_token).toBe('refreshed-access-token');
+                expect(assertSafeOAuthUrl).toHaveBeenCalledWith(`${baseUrl}/token`);
+            }
+        );
+    });
+
+    it('getFreshOAuth2Credentials fails without issuing the refresh when the token URL is blocked by policy', async () => {
+        vi.mocked(assertSafeOAuthUrl).mockRejectedValueOnce(new Error('URL resolves to a blocked address'));
+        let serverHit = false;
+        await withServer(
+            (_req, res) => {
+                serverHit = true;
+                res.writeHead(200, { 'content-type': 'application/json' });
+                res.end(JSON.stringify({ access_token: 'should-not-happen' }));
+            },
+            async (baseUrl) => {
+                const provider = makeProvider({ token_url: `${baseUrl}/token` });
+                const connection = {
+                    id: 1,
+                    environment_id: 1,
+                    connection_config: {},
+                    credentials: {
+                        type: 'OAUTH2',
+                        access_token: 'stale-access-token',
+                        refresh_token: 'the-refresh-token',
+                        expires_at: new Date(Date.now() - 60_000)
+                    }
+                } as unknown as DBConnectionDecrypted;
+
+                const buffer = logContextGetter.getBuffer({ accountId: 1 });
+                const result = await getFreshOAuth2Credentials({ connection, config: makeConfig(), provider, logCtx: buffer });
+
+                expect(result.success).toBe(false);
+                expect(result.error?.type).toBe('refresh_token_external_error');
+                expect(serverHit).toBe(false);
+            }
+        );
+    });
+});

--- a/packages/shared/lib/clients/provider.client.ts
+++ b/packages/shared/lib/clients/provider.client.ts
@@ -3,8 +3,9 @@ import { randomUUID } from 'crypto';
 import braintree from 'braintree';
 import qs from 'qs';
 
-import { axiosInstance as axios, getLogger, stringifyError } from '@nangohq/utils';
+import { axiosInstance, getLogger, stringifyError } from '@nangohq/utils';
 
+import { assertSafeOAuthUrl, getOAuthSafeHttpAgents } from '../services/proxy/outbound-policy.js';
 import { NangoError } from '../utils/error.js';
 import { isTokenExpired, makeUrl, parseTokenExpirationDate } from '../utils/utils.js';
 
@@ -28,6 +29,15 @@ const instagramExpiresIn = 3600;
 const instagramLongLivedTokenUrl = 'https://graph.instagram.com/access_token';
 
 const logger = getLogger('Provider.Client');
+
+// Route every OAuth/token request through the OAuth safe agents, which pin the policy-validated IP.
+// This also covers interpolated secondary hosts (e.g. sharepoint `tenantId`, teams-bot
+// `botHostTenantId`) at connect time, not just the primary token URL validated at entry.
+const axios = {
+    post: (url: string, data?: unknown, config?: Parameters<typeof axiosInstance.post>[2]) =>
+        axiosInstance.post(url, data, { ...config, ...getOAuthSafeHttpAgents() }),
+    get: (url: string, config?: Parameters<typeof axiosInstance.get>[1]) => axiosInstance.get(url, { ...config, ...getOAuthSafeHttpAgents() })
+};
 
 class ProviderClient {
     public shouldUseProviderClient(provider: string): boolean {
@@ -93,6 +103,11 @@ class ProviderClient {
         connectionConfig?: Record<string, string>,
         state?: string
     ): Promise<object> {
+        try {
+            await assertSafeOAuthUrl(tokenUrl);
+        } catch (err) {
+            throw new NangoError('request_token_external_error', err instanceof Error ? err.message : 'Outbound URL blocked by policy');
+        }
         switch (config.provider) {
             case 'attio-mcp':
                 return this.createAttioMcpToken(tokenUrl, code, config.oauth_client_id, callBackUrl, codeVerifier);
@@ -184,6 +199,15 @@ class ProviderClient {
         const credentials = connection.credentials;
         const interpolatedTokenUrl = makeUrl(provider.token_url as string, connection.connection_config);
         const interpolatedRefreshUrl = provider.refresh_url ? makeUrl(provider.refresh_url, connection.connection_config) : null;
+
+        try {
+            await assertSafeOAuthUrl(interpolatedTokenUrl.href);
+            if (interpolatedRefreshUrl) {
+                await assertSafeOAuthUrl(interpolatedRefreshUrl.href);
+            }
+        } catch (err) {
+            throw new NangoError('refresh_token_external_error', { message: err instanceof Error ? err.message : 'Outbound URL blocked by policy' });
+        }
 
         if (config.provider !== 'facebook' && !credentials.refresh_token && config.provider !== 'microsoft-admin' && config.provider !== 'instagram') {
             throw new NangoError('missing_refresh_token');

--- a/packages/shared/lib/clients/provider.client.ts
+++ b/packages/shared/lib/clients/provider.client.ts
@@ -5,7 +5,7 @@ import qs from 'qs';
 
 import { axiosInstance, getLogger, stringifyError } from '@nangohq/utils';
 
-import { assertSafeOAuthUrl, getOAuthSafeHttpAgents } from '../services/proxy/outbound-policy.js';
+import { assertSafeOAuthUrl, getOAuthAxiosRequestConfig } from '../services/proxy/outbound-policy.js';
 import { NangoError } from '../utils/error.js';
 import { isTokenExpired, makeUrl, parseTokenExpirationDate } from '../utils/utils.js';
 
@@ -32,8 +32,8 @@ const logger = getLogger('Provider.Client');
 
 const axios = {
     post: (url: string, data?: unknown, config?: Parameters<typeof axiosInstance.post>[2]) =>
-        axiosInstance.post(url, data, { ...config, ...getOAuthSafeHttpAgents() }),
-    get: (url: string, config?: Parameters<typeof axiosInstance.get>[1]) => axiosInstance.get(url, { ...config, ...getOAuthSafeHttpAgents() })
+        axiosInstance.post(url, data, { ...config, ...getOAuthAxiosRequestConfig() }),
+    get: (url: string, config?: Parameters<typeof axiosInstance.get>[1]) => axiosInstance.get(url, { ...config, ...getOAuthAxiosRequestConfig() })
 };
 
 class ProviderClient {

--- a/packages/shared/lib/clients/provider.client.ts
+++ b/packages/shared/lib/clients/provider.client.ts
@@ -30,9 +30,6 @@ const instagramLongLivedTokenUrl = 'https://graph.instagram.com/access_token';
 
 const logger = getLogger('Provider.Client');
 
-// Route every OAuth/token request through the OAuth safe agents, which pin the policy-validated IP.
-// This also covers interpolated secondary hosts (e.g. sharepoint `tenantId`, teams-bot
-// `botHostTenantId`) at connect time, not just the primary token URL validated at entry.
 const axios = {
     post: (url: string, data?: unknown, config?: Parameters<typeof axiosInstance.post>[2]) =>
         axiosInstance.post(url, data, { ...config, ...getOAuthSafeHttpAgents() }),

--- a/packages/shared/lib/clients/provider.client.ts
+++ b/packages/shared/lib/clients/provider.client.ts
@@ -103,7 +103,7 @@ class ProviderClient {
         try {
             await assertSafeOAuthUrl(tokenUrl);
         } catch (err) {
-            throw new NangoError('request_token_external_error', err instanceof Error ? err.message : 'Outbound URL blocked by policy');
+            throw new NangoError('request_token_external_error', { message: err instanceof Error ? err.message : 'Outbound URL blocked by policy' });
         }
         switch (config.provider) {
             case 'attio-mcp':

--- a/packages/shared/lib/services/connection.service.ts
+++ b/packages/shared/lib/services/connection.service.ts
@@ -42,7 +42,7 @@ import {
     MAX_CONSECUTIVE_DAYS_FAILED_REFRESH,
     REFRESH_MARGIN_MS
 } from './connections/utils.js';
-import { assertSafeOAuthUrl, getOAuthSafeHttpAgents, getOAuthSafeUndiciDispatcher } from './proxy/outbound-policy.js';
+import { assertSafeOAuthUrl, findOutboundUrlError, getOAuthSafeHttpAgents, getOAuthSafeUndiciDispatcher } from './proxy/outbound-policy.js';
 import syncManager from './sync/manager.service.js';
 
 import type { Orchestrator } from '../clients/orchestrator.js';
@@ -1314,8 +1314,17 @@ class ConnectionService {
 
         try {
             await assertSafeOAuthUrl(url.href);
-        } catch {
-            return { success: false, error: new NangoError('client_credentials_fetch_error'), response: null };
+        } catch (err) {
+            const outboundErr = findOutboundUrlError(err);
+            const reasonCode = outboundErr?.code ?? 'blocked';
+            const errorMessage = outboundErr?.message ?? (err instanceof Error ? err.message : String(err));
+            logger.error(`OAuth client credentials token URL blocked by outbound policy (host: ${url.host}, code: ${reasonCode})`);
+            void logCtx.error('Token URL blocked by outbound policy', { host: url.host, code: reasonCode, error: errorMessage });
+            return {
+                success: false,
+                error: new NangoError('client_credentials_fetch_error', { host: url.host, code: reasonCode, message: errorMessage }),
+                response: null
+            };
         }
 
         let interpolatedParams: Record<string, any> = {};
@@ -1404,8 +1413,6 @@ class ConnectionService {
             }
         }
 
-        // Always route through the OAuth safe dispatcher so the policy-validated IP is the one
-        // connected to (closes the DNS-rebinding gap between validation and the request).
         let agent: Agent = getOAuthSafeUndiciDispatcher();
 
         if (client_certificate && client_private_key) {

--- a/packages/shared/lib/services/connection.service.ts
+++ b/packages/shared/lib/services/connection.service.ts
@@ -42,7 +42,13 @@ import {
     MAX_CONSECUTIVE_DAYS_FAILED_REFRESH,
     REFRESH_MARGIN_MS
 } from './connections/utils.js';
-import { assertSafeOAuthUrl, findOutboundUrlError, getOAuthAxiosRequestConfig, getOAuthSafeUndiciDispatcher } from './proxy/outbound-policy.js';
+import {
+    assertSafeOAuthUrl,
+    findOutboundUrlError,
+    getOAuthAxiosRequestConfig,
+    getOAuthRedirectPolicy,
+    getOAuthSafeUndiciDispatcher
+} from './proxy/outbound-policy.js';
 import syncManager from './sync/manager.service.js';
 
 import type { Orchestrator } from '../clients/orchestrator.js';
@@ -1445,7 +1451,8 @@ class ConnectionService {
                 method: 'POST',
                 headers,
                 body: bodyFormat === 'query' ? null : bodyFormat === 'json' ? JSON.stringify(Object.fromEntries(params.entries())) : params.toString(),
-                agent
+                agent,
+                redirect: getOAuthRedirectPolicy()
             },
             { logCtx, context: 'auth', valuesToFilter: [client_secret, client_private_key].filter(Boolean) as string[] }
         );

--- a/packages/shared/lib/services/connection.service.ts
+++ b/packages/shared/lib/services/connection.service.ts
@@ -42,7 +42,7 @@ import {
     MAX_CONSECUTIVE_DAYS_FAILED_REFRESH,
     REFRESH_MARGIN_MS
 } from './connections/utils.js';
-import { assertSafeOAuthUrl, findOutboundUrlError, getOAuthSafeHttpAgents, getOAuthSafeUndiciDispatcher } from './proxy/outbound-policy.js';
+import { assertSafeOAuthUrl, findOutboundUrlError, getOAuthAxiosRequestConfig, getOAuthSafeUndiciDispatcher } from './proxy/outbound-policy.js';
 import syncManager from './sync/manager.service.js';
 
 import type { Orchestrator } from '../clients/orchestrator.js';
@@ -1575,7 +1575,7 @@ class ConnectionService {
         try {
             await assertSafeOAuthUrl(url);
 
-            const requestOptions = { headers, ...getOAuthSafeHttpAgents() };
+            const requestOptions = { headers, ...getOAuthAxiosRequestConfig() };
 
             const bodyContent =
                 bodyFormat === 'xml'
@@ -1672,7 +1672,7 @@ class ConnectionService {
                         }
                     }
 
-                    const stepRequestOptions = { headers: stepHeaders, ...getOAuthSafeHttpAgents() };
+                    const stepRequestOptions = { headers: stepHeaders, ...getOAuthAxiosRequestConfig() };
 
                     let stepResponse: any;
 

--- a/packages/shared/lib/services/connection.service.ts
+++ b/packages/shared/lib/services/connection.service.ts
@@ -2,7 +2,6 @@ import { createPrivateKey } from 'crypto';
 
 import { XMLBuilder, XMLParser } from 'fast-xml-parser';
 import ms from 'ms';
-import { Agent } from 'undici';
 import { v4 as uuidv4 } from 'uuid';
 
 import db, { dbNamespace } from '@nangohq/database';
@@ -43,6 +42,7 @@ import {
     MAX_CONSECUTIVE_DAYS_FAILED_REFRESH,
     REFRESH_MARGIN_MS
 } from './connections/utils.js';
+import { assertSafeOAuthUrl, getOAuthSafeHttpAgents, getOAuthSafeUndiciDispatcher } from './proxy/outbound-policy.js';
 import syncManager from './sync/manager.service.js';
 
 import type { Orchestrator } from '../clients/orchestrator.js';
@@ -92,6 +92,7 @@ import type {
     TwoStepCredentials
 } from '@nangohq/types';
 import type { Result } from '@nangohq/utils';
+import type { Agent } from 'undici';
 
 const logger = getLogger('Connection');
 const ACTIVE_LOG_TABLE = dbNamespace + 'active_logs';
@@ -1311,6 +1312,12 @@ class ConnectionService {
         }
         const url = makeUrl(tokenUrl, connectionConfig);
 
+        try {
+            await assertSafeOAuthUrl(url.href);
+        } catch {
+            return { success: false, error: new NangoError('client_credentials_fetch_error'), response: null };
+        }
+
         let interpolatedParams: Record<string, any> = {};
         if (provider.token_params) {
             interpolatedParams = interpolateObjectValues(provider.token_params, connectionConfig);
@@ -1397,7 +1404,9 @@ class ConnectionService {
             }
         }
 
-        let agent: Agent | undefined;
+        // Always route through the OAuth safe dispatcher so the policy-validated IP is the one
+        // connected to (closes the DNS-rebinding gap between validation and the request).
+        let agent: Agent = getOAuthSafeUndiciDispatcher();
 
         if (client_certificate && client_private_key) {
             try {
@@ -1411,9 +1420,7 @@ class ConnectionService {
                     throw new NangoError('invalid_certificate_or_key_format');
                 }
 
-                agent = new Agent({
-                    connect: { cert, key, rejectUnauthorized: false }
-                });
+                agent = getOAuthSafeUndiciDispatcher({ cert, key, rejectUnauthorized: false });
             } catch (err) {
                 throw new NangoError('invalid_certificate_or_key_format', { err });
             }
@@ -1559,7 +1566,9 @@ class ConnectionService {
         }
 
         try {
-            const requestOptions = { headers };
+            await assertSafeOAuthUrl(url);
+
+            const requestOptions = { headers, ...getOAuthSafeHttpAgents() };
 
             const bodyContent =
                 bodyFormat === 'xml'
@@ -1645,6 +1654,7 @@ class ConnectionService {
                     const stepResponsesObjForURL = stepNumberForURL !== null ? getStepResponse(stepNumberForURL, stepResponses) : {};
                     const strippedTokenUrl = stripStepResponse(step.token_url);
                     const stepUrl = new URL(interpolateString(strippedTokenUrl, { connectionConfig, ...stepResponsesObjForURL })).toString();
+                    await assertSafeOAuthUrl(stepUrl);
                     const stepBodyContent = bodyFormat === 'form' ? new URLSearchParams(stepPostBody).toString() : JSON.stringify(stepPostBody);
 
                     const stepHeaders: Record<string, string> = {};
@@ -1655,7 +1665,7 @@ class ConnectionService {
                         }
                     }
 
-                    const stepRequestOptions = { headers: stepHeaders };
+                    const stepRequestOptions = { headers: stepHeaders, ...getOAuthSafeHttpAgents() };
 
                     let stepResponse: any;
 

--- a/packages/shared/lib/services/connection.service.twostep.unit.test.ts
+++ b/packages/shared/lib/services/connection.service.twostep.unit.test.ts
@@ -1,0 +1,111 @@
+import http from 'node:http';
+
+import { afterEach, describe, expect, it, vi } from 'vitest';
+
+import connectionService from './connection.service.js';
+import { assertSafeOAuthUrl } from './proxy/outbound-policy.js';
+
+import type * as OutboundPolicyModule from './proxy/outbound-policy.js';
+import type { ProviderTwoStep } from '@nangohq/types';
+import type { AddressInfo } from 'node:net';
+
+// TWO_STEP token exchange runs axios through the OAuth egress policy and gates every hop with
+// `assertSafeOAuthUrl`. Neutralise the policy so loopback test servers are reachable (loopback is always
+// blocked by the real policy) while still exercising the multi-step flow and the URL guard.
+vi.mock('./proxy/outbound-policy.js', async (importOriginal) => {
+    const actual = await importOriginal<typeof OutboundPolicyModule>();
+    return {
+        ...actual,
+        assertSafeOAuthUrl: vi.fn((url: string) => Promise.resolve(new URL(url))),
+        // `proxy: false` keeps axios off any ambient HTTP(S)_PROXY so the loopback test server is reached directly.
+        getOAuthAxiosRequestConfig: vi.fn(() => ({ proxy: false }))
+    };
+});
+
+async function withServer(handler: http.RequestListener, fn: (baseUrl: string) => Promise<void>): Promise<void> {
+    const server = http.createServer(handler);
+    await new Promise<void>((resolve) => server.listen(0, '127.0.0.1', resolve));
+    const { port } = server.address() as AddressInfo;
+    try {
+        await fn(`http://127.0.0.1:${port}`);
+    } finally {
+        await new Promise<void>((resolve) => server.close(() => resolve()));
+    }
+}
+
+describe('getTwoStepCredentials', () => {
+    afterEach(() => {
+        vi.clearAllMocks();
+    });
+
+    it('completes a multi-step token exchange, threading the first response into the second call', async () => {
+        const seen: Record<string, string> = {};
+        await withServer(
+            (req, res) => {
+                let body = '';
+                req.on('data', (chunk) => (body += chunk));
+                req.on('end', () => {
+                    seen[req.url ?? ''] = body;
+                    res.writeHead(200, { 'content-type': 'application/json' });
+                    if (req.url === '/step1') {
+                        res.end(JSON.stringify({ code: 'code-abc' }));
+                    } else {
+                        res.end(JSON.stringify({ access_token: 'final-two-step-token' }));
+                    }
+                });
+            },
+            async (baseUrl) => {
+                const provider: ProviderTwoStep = {
+                    display_name: 'Two Step',
+                    docs: 'https://docs.example.com',
+                    auth_mode: 'TWO_STEP',
+                    token_url: `${baseUrl}/step1`,
+                    token_params: { grant: 'first' },
+                    token_response: { token: 'access_token' },
+                    additional_steps: [{ token_url: `${baseUrl}/step2`, token_params: { code: '${step1.code}' } }]
+                };
+
+                const result = await connectionService.getTwoStepCredentials('test-two-step', provider, {}, {}, false);
+
+                expect(result.success).toBe(true);
+                expect(result.response?.token).toBe('final-two-step-token');
+                // Step 2 received the value produced by step 1.
+                expect(JSON.parse(seen['/step2'] ?? '{}')).toStrictEqual({ code: 'code-abc' });
+                // Both hops were validated through the egress policy.
+                expect(assertSafeOAuthUrl).toHaveBeenCalledWith(`${baseUrl}/step1`);
+                expect(assertSafeOAuthUrl).toHaveBeenCalledWith(`${baseUrl}/step2`);
+            }
+        );
+    });
+
+    it('refreshes against the refresh_url when a refresh token is present', async () => {
+        await withServer(
+            (req, res) => {
+                res.writeHead(200, { 'content-type': 'application/json' });
+                if (req.url === '/refresh') {
+                    res.end(JSON.stringify({ access_token: 'refreshed-two-step-token', refresh_token: 'rotated-rt' }));
+                } else {
+                    res.end(JSON.stringify({ access_token: 'should-not-be-used' }));
+                }
+            },
+            async (baseUrl) => {
+                const provider: ProviderTwoStep = {
+                    display_name: 'Two Step',
+                    docs: 'https://docs.example.com',
+                    auth_mode: 'TWO_STEP',
+                    token_url: `${baseUrl}/token`,
+                    refresh_url: `${baseUrl}/refresh`,
+                    refresh_token_params: { grant_type: 'refresh_token', token: '${refresh_token}' },
+                    token_response: { token: 'access_token', refresh_token: 'refresh_token' }
+                };
+
+                const result = await connectionService.getTwoStepCredentials('test-two-step', provider, { refresh_token: 'existing-rt' }, {}, true);
+
+                expect(result.success).toBe(true);
+                expect(result.response?.token).toBe('refreshed-two-step-token');
+                // Refresh must hit the dedicated refresh URL, which is validated by the egress policy.
+                expect(assertSafeOAuthUrl).toHaveBeenCalledWith(`${baseUrl}/refresh`);
+            }
+        );
+    });
+});

--- a/packages/shared/lib/services/proxy/outbound-policy.ts
+++ b/packages/shared/lib/services/proxy/outbound-policy.ts
@@ -73,10 +73,42 @@ export function getOAuthSafeHttpAgents(): { httpAgent: http.Agent; httpsAgent: h
     return getSafeHttpAgents(getOAuthOutboundUrlPolicy());
 }
 
+/** Headers that may be retained on OAuth token redirects; everything else is treated as credential material. */
+const SAFE_OAUTH_REDIRECT_HEADERS = new Set(['accept', 'accept-encoding', 'content-type', 'user-agent']);
+
+function isSameOriginOAuthRedirect(redirectOptions: Record<string, unknown>, requestDetails: { url?: string } | undefined): boolean {
+    if (!requestDetails?.url) {
+        return false;
+    }
+    const absolute = absoluteUrlFromRedirectRequestOptions(redirectOptions);
+    if (!absolute) {
+        return false;
+    }
+    try {
+        return new URL(requestDetails.url).origin === new URL(absolute).origin;
+    } catch {
+        return false;
+    }
+}
+
+function stripUnsafeOAuthRedirectHeaders(headers: Record<string, unknown> | undefined): void {
+    if (!headers) {
+        return;
+    }
+    for (const key of Object.keys(headers)) {
+        if (!SAFE_OAUTH_REDIRECT_HEADERS.has(key.toLowerCase())) {
+            delete headers[key];
+        }
+    }
+}
+
 /**
  * Axios request options for OAuth token egress: pinned agents, policy maxRedirects,
  * and sync validation of each redirect hop (IP literals / denied hosts).
  * DNS rebinding on redirect hostnames is still caught by the safe agent lookup.
+ *
+ * Credential header forwarding is opt-in for the proxy and never enabled here. follow-redirects
+ * only strips Authorization/Cookie; this also drops caller-defined API-key headers on cross-origin hops.
  */
 export function getOAuthAxiosRequestConfig(): Pick<AxiosRequestConfig, 'httpAgent' | 'httpsAgent' | 'maxRedirects' | 'beforeRedirect'> {
     const policy = getOAuthOutboundUrlPolicy();
@@ -87,11 +119,14 @@ export function getOAuthAxiosRequestConfig(): Pick<AxiosRequestConfig, 'httpAgen
         httpAgent: agents.httpAgent,
         httpsAgent: agents.httpsAgent,
         maxRedirects: policy.maxRedirects,
-        beforeRedirect: (options) => {
+        beforeRedirect: (options, _responseDetails, requestDetails) => {
             const absolute = absoluteUrlFromRedirectRequestOptions(options);
             // Block redirect hops to blocked IP literals / denied hosts; hostname rebinding is caught by the safe agent.
             if (absolute) {
                 redirectValidator(absolute);
+            }
+            if (!isSameOriginOAuthRedirect(options, requestDetails)) {
+                stripUnsafeOAuthRedirectHeaders(options['headers'] as Record<string, unknown> | undefined);
             }
         }
     };

--- a/packages/shared/lib/services/proxy/outbound-policy.ts
+++ b/packages/shared/lib/services/proxy/outbound-policy.ts
@@ -1,8 +1,11 @@
-import { resolvePolicyForServer } from '@nangohq/egress';
+import { assertSafeOutboundUrl, getSafeHttpAgents, getSafeUndiciDispatcher, resolvePolicyForOAuth, resolvePolicyForServer } from '@nangohq/egress';
 
 import { envs } from '../../env.js';
 
-import type { OutboundUrlPolicy } from '@nangohq/egress';
+import type { OutboundUrlPolicy, ValidateOutboundUrlContext } from '@nangohq/egress';
+import type http from 'node:http';
+import type https from 'node:https';
+import type { buildConnector, Agent as UndiciAgent } from 'undici';
 
 export {
     OutboundUrlError,
@@ -33,4 +36,44 @@ export function getServerOutboundUrlPolicy(): OutboundUrlPolicy {
 
 export function resetServerOutboundUrlPolicyForTests(): void {
     memoizedServerPolicy = null;
+}
+
+let memoizedOAuthPolicy: OutboundUrlPolicy | null = null;
+
+/**
+ * Policy for OAuth/token flows (token, refresh, STS, JWT-bearer endpoints). RFC1918 is allowed by
+ * default so self-hosted token endpoints keep working; metadata/loopback/link-local stay blocked.
+ */
+export function getOAuthOutboundUrlPolicy(): OutboundUrlPolicy {
+    if (memoizedOAuthPolicy) {
+        return memoizedOAuthPolicy;
+    }
+    memoizedOAuthPolicy = resolvePolicyForOAuth({
+        proxyBaseUrlOverrideDenylist: envs.NANGO_PROXY_BASE_URL_OVERRIDE_DENYLIST,
+        outboundUrlPolicy: envs.NANGO_OUTBOUND_URL_POLICY,
+        outboundUrlPolicyOAuth: envs.NANGO_OUTBOUND_URL_POLICY_OAUTH
+    });
+    return memoizedOAuthPolicy;
+}
+
+export function resetOAuthOutboundUrlPolicyForTests(): void {
+    memoizedOAuthPolicy = null;
+}
+
+/**
+ * Validate an interpolated OAuth/token URL against the OAuth policy (resolves DNS and checks every
+ * address). Throws the egress `OutboundUrlError` on denial; callers map it to their error type.
+ */
+export async function assertSafeOAuthUrl(url: string, ctx?: ValidateOutboundUrlContext): Promise<URL> {
+    return assertSafeOutboundUrl(url, getOAuthOutboundUrlPolicy(), { context: 'oauth', ...ctx });
+}
+
+/** Node http/https agents that pin the validated IP, for axios + simple-oauth2 OAuth/token requests. */
+export function getOAuthSafeHttpAgents(): { httpAgent: http.Agent; httpsAgent: https.Agent } {
+    return getSafeHttpAgents(getOAuthOutboundUrlPolicy());
+}
+
+/** Undici dispatcher that pins the validated IP, for `fetch`/`loggedFetch`-based OAuth/token requests. */
+export function getOAuthSafeUndiciDispatcher(connectOverrides?: buildConnector.BuildOptions): UndiciAgent {
+    return getSafeUndiciDispatcher(getOAuthOutboundUrlPolicy(), connectOverrides);
 }

--- a/packages/shared/lib/services/proxy/outbound-policy.ts
+++ b/packages/shared/lib/services/proxy/outbound-policy.ts
@@ -1,6 +1,7 @@
 import {
     absoluteUrlFromRedirectRequestOptions,
     assertSafeOutboundUrl,
+    createAsyncRedirectValidator,
     createRedirectValidator,
     getSafeHttpAgents,
     getSafeUndiciDispatcher,
@@ -76,21 +77,6 @@ export function getOAuthSafeHttpAgents(): { httpAgent: http.Agent; httpsAgent: h
 /** Headers that may be retained on OAuth token redirects; everything else is treated as credential material. */
 const SAFE_OAUTH_REDIRECT_HEADERS = new Set(['accept', 'accept-encoding', 'content-type', 'user-agent']);
 
-function isSameOriginOAuthRedirect(redirectOptions: Record<string, unknown>, requestDetails: { url?: string } | undefined): boolean {
-    if (!requestDetails?.url) {
-        return false;
-    }
-    const absolute = absoluteUrlFromRedirectRequestOptions(redirectOptions);
-    if (!absolute) {
-        return false;
-    }
-    try {
-        return new URL(requestDetails.url).origin === new URL(absolute).origin;
-    } catch {
-        return false;
-    }
-}
-
 function stripUnsafeOAuthRedirectHeaders(headers: Record<string, unknown> | undefined): void {
     if (!headers) {
         return;
@@ -107,8 +93,9 @@ function stripUnsafeOAuthRedirectHeaders(headers: Record<string, unknown> | unde
  * and sync validation of each redirect hop (IP literals / denied hosts).
  * DNS rebinding on redirect hostnames is still caught by the safe agent lookup.
  *
- * Credential header forwarding is opt-in for the proxy and never enabled here. follow-redirects
- * only strips Authorization/Cookie; this also drops caller-defined API-key headers on cross-origin hops.
+ * Credential headers are stripped on every redirect hop (not just cross-origin ones): forwarding
+ * them is not opt-in anywhere in the OAuth path, so Authorization and caller-defined API-key headers
+ * are dropped whenever a redirect is followed. follow-redirects itself only strips Authorization/Cookie.
  */
 export function getOAuthAxiosRequestConfig(): Pick<AxiosRequestConfig, 'httpAgent' | 'httpsAgent' | 'maxRedirects' | 'beforeRedirect'> {
     const policy = getOAuthOutboundUrlPolicy();
@@ -119,19 +106,33 @@ export function getOAuthAxiosRequestConfig(): Pick<AxiosRequestConfig, 'httpAgen
         httpAgent: agents.httpAgent,
         httpsAgent: agents.httpsAgent,
         maxRedirects: policy.maxRedirects,
-        beforeRedirect: (options, _responseDetails, requestDetails) => {
+        beforeRedirect: (options) => {
             const absolute = absoluteUrlFromRedirectRequestOptions(options);
             // Block redirect hops to blocked IP literals / denied hosts; hostname rebinding is caught by the safe agent.
             if (absolute) {
                 redirectValidator(absolute);
             }
-            if (!isSameOriginOAuthRedirect(options, requestDetails)) {
-                stripUnsafeOAuthRedirectHeaders(options['headers'] as Record<string, unknown> | undefined);
-            }
+            // Never forward credential material across a redirect; strip on every hop, same-origin included.
+            stripUnsafeOAuthRedirectHeaders(options['headers'] as Record<string, unknown> | undefined);
         }
     };
 }
 
 export function getOAuthSafeUndiciDispatcher(connectOverrides?: buildConnector.BuildOptions): UndiciAgent {
     return getSafeUndiciDispatcher(getOAuthOutboundUrlPolicy(), connectOverrides);
+}
+
+/**
+ * Redirect policy for the OAuth `fetch` path (client-credentials/token exchange via undici).
+ * The safe undici dispatcher only pins DNS for hostname connects and never enforces a redirect cap,
+ * so redirects are followed manually: this caps hops at the OAuth policy's `maxRedirects` and
+ * re-validates every hop (including raw IP-literal targets the dispatcher's lookup would skip).
+ */
+export function getOAuthRedirectPolicy(): { maxRedirects: number; validate: (target: URL) => Promise<void> } {
+    const policy = getOAuthOutboundUrlPolicy();
+    const validate = createAsyncRedirectValidator(policy);
+    return {
+        maxRedirects: policy.maxRedirects,
+        validate: (target: URL) => validate(target.href)
+    };
 }

--- a/packages/shared/lib/services/proxy/outbound-policy.ts
+++ b/packages/shared/lib/services/proxy/outbound-policy.ts
@@ -1,8 +1,17 @@
-import { assertSafeOutboundUrl, getSafeHttpAgents, getSafeUndiciDispatcher, resolvePolicyForOAuth, resolvePolicyForServer } from '@nangohq/egress';
+import {
+    absoluteUrlFromRedirectRequestOptions,
+    assertSafeOutboundUrl,
+    createRedirectValidator,
+    getSafeHttpAgents,
+    getSafeUndiciDispatcher,
+    resolvePolicyForOAuth,
+    resolvePolicyForServer
+} from '@nangohq/egress';
 
 import { envs } from '../../env.js';
 
 import type { OutboundUrlPolicy, ValidateOutboundUrlContext } from '@nangohq/egress';
+import type { AxiosRequestConfig } from 'axios';
 import type http from 'node:http';
 import type https from 'node:https';
 import type { buildConnector, Agent as UndiciAgent } from 'undici';
@@ -62,6 +71,30 @@ export async function assertSafeOAuthUrl(url: string, ctx?: ValidateOutboundUrlC
 
 export function getOAuthSafeHttpAgents(): { httpAgent: http.Agent; httpsAgent: https.Agent } {
     return getSafeHttpAgents(getOAuthOutboundUrlPolicy());
+}
+
+/**
+ * Axios request options for OAuth token egress: pinned agents, policy maxRedirects,
+ * and sync validation of each redirect hop (IP literals / denied hosts).
+ * DNS rebinding on redirect hostnames is still caught by the safe agent lookup.
+ */
+export function getOAuthAxiosRequestConfig(): Pick<AxiosRequestConfig, 'httpAgent' | 'httpsAgent' | 'maxRedirects' | 'beforeRedirect'> {
+    const policy = getOAuthOutboundUrlPolicy();
+    const agents = getSafeHttpAgents(policy);
+    const redirectValidator = createRedirectValidator(policy);
+
+    return {
+        httpAgent: agents.httpAgent,
+        httpsAgent: agents.httpsAgent,
+        maxRedirects: policy.maxRedirects,
+        beforeRedirect: (options) => {
+            const absolute = absoluteUrlFromRedirectRequestOptions(options);
+            // Block redirect hops to blocked IP literals / denied hosts; hostname rebinding is caught by the safe agent.
+            if (absolute) {
+                redirectValidator(absolute);
+            }
+        }
+    };
 }
 
 export function getOAuthSafeUndiciDispatcher(connectOverrides?: buildConnector.BuildOptions): UndiciAgent {

--- a/packages/shared/lib/services/proxy/outbound-policy.ts
+++ b/packages/shared/lib/services/proxy/outbound-policy.ts
@@ -40,10 +40,6 @@ export function resetServerOutboundUrlPolicyForTests(): void {
 
 let memoizedOAuthPolicy: OutboundUrlPolicy | null = null;
 
-/**
- * Policy for OAuth/token flows (token, refresh, STS, JWT-bearer endpoints). RFC1918 is allowed by
- * default so self-hosted token endpoints keep working; metadata/loopback/link-local stay blocked.
- */
 export function getOAuthOutboundUrlPolicy(): OutboundUrlPolicy {
     if (memoizedOAuthPolicy) {
         return memoizedOAuthPolicy;
@@ -60,20 +56,14 @@ export function resetOAuthOutboundUrlPolicyForTests(): void {
     memoizedOAuthPolicy = null;
 }
 
-/**
- * Validate an interpolated OAuth/token URL against the OAuth policy (resolves DNS and checks every
- * address). Throws the egress `OutboundUrlError` on denial; callers map it to their error type.
- */
 export async function assertSafeOAuthUrl(url: string, ctx?: ValidateOutboundUrlContext): Promise<URL> {
     return assertSafeOutboundUrl(url, getOAuthOutboundUrlPolicy(), { context: 'oauth', ...ctx });
 }
 
-/** Node http/https agents that pin the validated IP, for axios + simple-oauth2 OAuth/token requests. */
 export function getOAuthSafeHttpAgents(): { httpAgent: http.Agent; httpsAgent: https.Agent } {
     return getSafeHttpAgents(getOAuthOutboundUrlPolicy());
 }
 
-/** Undici dispatcher that pins the validated IP, for `fetch`/`loggedFetch`-based OAuth/token requests. */
 export function getOAuthSafeUndiciDispatcher(connectOverrides?: buildConnector.BuildOptions): UndiciAgent {
     return getSafeUndiciDispatcher(getOAuthOutboundUrlPolicy(), connectOverrides);
 }

--- a/packages/shared/lib/services/proxy/outbound-policy.unit.test.ts
+++ b/packages/shared/lib/services/proxy/outbound-policy.unit.test.ts
@@ -2,7 +2,13 @@ import { describe, expect, it } from 'vitest';
 
 import { OutboundUrlError } from '@nangohq/egress';
 
-import { assertSafeOAuthUrl, getOAuthOutboundUrlPolicy, getOAuthSafeHttpAgents, getOAuthSafeUndiciDispatcher } from './outbound-policy.js';
+import {
+    assertSafeOAuthUrl,
+    getOAuthAxiosRequestConfig,
+    getOAuthOutboundUrlPolicy,
+    getOAuthSafeHttpAgents,
+    getOAuthSafeUndiciDispatcher
+} from './outbound-policy.js';
 
 describe('OAuth outbound url policy', () => {
     it('allows RFC1918 by default so self-hosted token endpoints keep working', () => {
@@ -24,5 +30,27 @@ describe('OAuth outbound url policy', () => {
         expect(agents.httpAgent).toBeDefined();
         expect(agents.httpsAgent).toBeDefined();
         expect(getOAuthSafeUndiciDispatcher()).toBeDefined();
+    });
+
+    describe('getOAuthAxiosRequestConfig', () => {
+        it('attaches pinned agents and caps redirects from the OAuth policy', () => {
+            const policy = getOAuthOutboundUrlPolicy();
+            const cfg = getOAuthAxiosRequestConfig();
+            expect(cfg.httpAgent).toBeDefined();
+            expect(cfg.httpsAgent).toBeDefined();
+            expect(cfg.maxRedirects).toBe(policy.maxRedirects);
+            expect(typeof cfg.beforeRedirect).toBe('function');
+        });
+
+        it('blocks redirect hops to blocked IP-literal targets', () => {
+            const cfg = getOAuthAxiosRequestConfig();
+            expect(() => cfg.beforeRedirect!({ href: 'http://169.254.169.254/latest/meta-data/' } as any, {} as any, {} as any)).toThrow(OutboundUrlError);
+            expect(() => cfg.beforeRedirect!({ href: 'http://127.0.0.1/oauth/token' } as any, {} as any, {} as any)).toThrow(OutboundUrlError);
+        });
+
+        it('allows redirect hops to public hosts (DNS rebinding is caught later by the agent)', () => {
+            const cfg = getOAuthAxiosRequestConfig();
+            expect(() => cfg.beforeRedirect!({ href: 'https://api.example.com/next' } as any, {} as any, {} as any)).not.toThrow();
+        });
     });
 });

--- a/packages/shared/lib/services/proxy/outbound-policy.unit.test.ts
+++ b/packages/shared/lib/services/proxy/outbound-policy.unit.test.ts
@@ -33,6 +33,9 @@ describe('OAuth outbound url policy', () => {
     });
 
     describe('getOAuthAxiosRequestConfig', () => {
+        const requestDetails = { url: 'https://sts.example.com/oauth/token', method: 'POST', headers: {} as Record<string, string> };
+        const responseDetails = { headers: {} as Record<string, string>, statusCode: 302 };
+
         it('attaches pinned agents and caps redirects from the OAuth policy', () => {
             const policy = getOAuthOutboundUrlPolicy();
             const cfg = getOAuthAxiosRequestConfig();
@@ -42,15 +45,56 @@ describe('OAuth outbound url policy', () => {
             expect(typeof cfg.beforeRedirect).toBe('function');
         });
 
-        it('blocks redirect hops to blocked IP-literal targets', () => {
+        it('blocks redirect hops to blocked IP-literal targets (href shape from follow-redirects)', () => {
             const cfg = getOAuthAxiosRequestConfig();
-            expect(() => cfg.beforeRedirect!({ href: 'http://169.254.169.254/latest/meta-data/' } as any, {} as any, {} as any)).toThrow(OutboundUrlError);
-            expect(() => cfg.beforeRedirect!({ href: 'http://127.0.0.1/oauth/token' } as any, {} as any, {} as any)).toThrow(OutboundUrlError);
+            expect(() => cfg.beforeRedirect!({ href: 'http://169.254.169.254/latest/meta-data/' } as any, responseDetails, requestDetails)).toThrow(
+                OutboundUrlError
+            );
+            expect(() => cfg.beforeRedirect!({ href: 'http://127.0.0.1/oauth/token' } as any, responseDetails, requestDetails)).toThrow(OutboundUrlError);
+        });
+
+        it('blocks redirect hops built from protocol/hostname/path (fallback when href is absent)', () => {
+            const cfg = getOAuthAxiosRequestConfig();
+            expect(() =>
+                cfg.beforeRedirect!(
+                    { protocol: 'http:', hostname: '169.254.169.254', path: '/latest/meta-data/', headers: {} } as any,
+                    responseDetails,
+                    requestDetails
+                )
+            ).toThrow(OutboundUrlError);
         });
 
         it('allows redirect hops to public hosts (DNS rebinding is caught later by the agent)', () => {
             const cfg = getOAuthAxiosRequestConfig();
-            expect(() => cfg.beforeRedirect!({ href: 'https://api.example.com/next' } as any, {} as any, {} as any)).not.toThrow();
+            expect(() =>
+                cfg.beforeRedirect!({ protocol: 'https:', host: 'api.example.com', path: '/next', headers: {} } as any, responseDetails, requestDetails)
+            ).not.toThrow();
+        });
+
+        it('strips credential headers on cross-origin redirects', () => {
+            const cfg = getOAuthAxiosRequestConfig();
+            const headers: Record<string, string> = {
+                authorization: 'Bearer secret-jwt',
+                'x-api-key': 'sts-secret',
+                'content-type': 'application/json',
+                'user-agent': 'Nango'
+            };
+            cfg.beforeRedirect!({ href: 'https://evil.example/capture', headers } as any, responseDetails, requestDetails);
+            expect(headers['authorization']).toBeUndefined();
+            expect(headers['x-api-key']).toBeUndefined();
+            expect(headers['content-type']).toBe('application/json');
+            expect(headers['user-agent']).toBe('Nango');
+        });
+
+        it('keeps credential headers on same-origin redirects', () => {
+            const cfg = getOAuthAxiosRequestConfig();
+            const headers: Record<string, string> = {
+                authorization: 'Bearer secret-jwt',
+                'x-api-key': 'sts-secret'
+            };
+            cfg.beforeRedirect!({ href: 'https://sts.example.com/oauth/token?next=1', headers } as any, responseDetails, requestDetails);
+            expect(headers['authorization']).toBe('Bearer secret-jwt');
+            expect(headers['x-api-key']).toBe('sts-secret');
         });
     });
 });

--- a/packages/shared/lib/services/proxy/outbound-policy.unit.test.ts
+++ b/packages/shared/lib/services/proxy/outbound-policy.unit.test.ts
@@ -1,0 +1,28 @@
+import { describe, expect, it } from 'vitest';
+
+import { OutboundUrlError } from '@nangohq/egress';
+
+import { assertSafeOAuthUrl, getOAuthOutboundUrlPolicy, getOAuthSafeHttpAgents, getOAuthSafeUndiciDispatcher } from './outbound-policy.js';
+
+describe('OAuth outbound url policy', () => {
+    it('allows RFC1918 by default so self-hosted token endpoints keep working', () => {
+        expect(getOAuthOutboundUrlPolicy().blockPrivateIps).toBe(false);
+    });
+
+    it('allows a private IP-literal token URL by default', async () => {
+        await expect(assertSafeOAuthUrl('http://10.0.0.5/oauth/token')).resolves.toBeInstanceOf(URL);
+    });
+
+    it('blocks loopback and cloud-metadata token URLs (fail closed)', async () => {
+        await expect(assertSafeOAuthUrl('http://127.0.0.1/oauth/token')).rejects.toBeInstanceOf(OutboundUrlError);
+        await expect(assertSafeOAuthUrl('http://169.254.169.254/oauth/token')).rejects.toBeInstanceOf(OutboundUrlError);
+        await expect(assertSafeOAuthUrl('http://localhost/oauth/token')).rejects.toBeInstanceOf(OutboundUrlError);
+    });
+
+    it('exposes pinned node agents and an undici dispatcher for OAuth requests', () => {
+        const agents = getOAuthSafeHttpAgents();
+        expect(agents.httpAgent).toBeDefined();
+        expect(agents.httpsAgent).toBeDefined();
+        expect(getOAuthSafeUndiciDispatcher()).toBeDefined();
+    });
+});

--- a/packages/shared/lib/services/proxy/outbound-policy.unit.test.ts
+++ b/packages/shared/lib/services/proxy/outbound-policy.unit.test.ts
@@ -86,15 +86,17 @@ describe('OAuth outbound url policy', () => {
             expect(headers['user-agent']).toBe('Nango');
         });
 
-        it('keeps credential headers on same-origin redirects', () => {
+        it('strips credential headers on same-origin redirects too (no forward-on-redirect opt-in)', () => {
             const cfg = getOAuthAxiosRequestConfig();
             const headers: Record<string, string> = {
                 authorization: 'Bearer secret-jwt',
-                'x-api-key': 'sts-secret'
+                'x-api-key': 'sts-secret',
+                'content-type': 'application/json'
             };
             cfg.beforeRedirect!({ href: 'https://sts.example.com/oauth/token?next=1', headers } as any, responseDetails, requestDetails);
-            expect(headers['authorization']).toBe('Bearer secret-jwt');
-            expect(headers['x-api-key']).toBe('sts-secret');
+            expect(headers['authorization']).toBeUndefined();
+            expect(headers['x-api-key']).toBeUndefined();
+            expect(headers['content-type']).toBe('application/json');
         });
     });
 });

--- a/packages/shared/lib/utils/http.ts
+++ b/packages/shared/lib/utils/http.ts
@@ -7,19 +7,96 @@ import type { HTTP_METHOD, MessageHTTPRequest, MessageRow } from '@nangohq/types
 import type { Result } from '@nangohq/utils';
 import type { Agent } from 'undici';
 
+/**
+ * Controls how `loggedFetch` follows redirects. When provided, automatic redirect following is
+ * disabled (`redirect: 'manual'`) and every hop is validated before being followed, so the caller's
+ * outbound policy applies to the whole redirect chain — including hops to raw IP literals, which an
+ * agent's DNS lookup never sees.
+ */
+export interface LoggedFetchRedirectPolicy {
+    /** Maximum number of redirect hops to follow before failing. */
+    maxRedirects: number;
+    /** Validate the next hop. Throw to block it (e.g. blocked IP literal or denied host). */
+    validate: (target: URL) => Promise<void> | void;
+}
+
+const REDIRECT_STATUSES = new Set([301, 302, 303, 307, 308]);
+// Stripped when a redirect crosses origins, matching the browser fetch default so manual following
+// does not leak credentials to a different host than the one the caller authenticated against.
+const CREDENTIAL_HEADERS_STRIPPED_ON_CROSS_ORIGIN_REDIRECT = ['authorization', 'cookie', 'proxy-authorization'];
+
+/**
+ * Follow redirects manually, validating every hop against `redirectPolicy`. Undici's fetch skips the
+ * dispatcher's safe DNS lookup for IP-literal hosts, so relying on the agent alone would let a public
+ * token URL redirect straight to a blocked internal IP; validating each `Location` here closes that gap
+ * and enforces `maxRedirects` (which the dispatcher does not).
+ */
+async function fetchFollowingPolicyRedirects(initialUrl: URL, baseProps: RequestInit, redirectPolicy: LoggedFetchRedirectPolicy): Promise<Response> {
+    let currentUrl = initialUrl;
+    let method = (baseProps.method ?? 'GET').toUpperCase();
+    let body = baseProps.body ?? null;
+    const headers = new Headers(baseProps.headers);
+    let followed = 0;
+
+    for (;;) {
+        const res = await fetch(currentUrl, { ...baseProps, method, headers, body, redirect: 'manual' });
+        if (!REDIRECT_STATUSES.has(res.status)) {
+            return res;
+        }
+        const location = res.headers.get('location');
+        if (!location) {
+            return res;
+        }
+
+        let target: URL;
+        try {
+            target = new URL(location, currentUrl);
+        } catch {
+            // Malformed Location: surface the redirect response rather than following an unparseable target.
+            return res;
+        }
+
+        // Release the socket before issuing the next request.
+        await res.body?.cancel().catch(() => undefined);
+
+        if (followed >= redirectPolicy.maxRedirects) {
+            throw new Error(`Maximum number of redirects (${redirectPolicy.maxRedirects}) exceeded`);
+        }
+
+        await redirectPolicy.validate(target);
+
+        if (target.origin !== currentUrl.origin) {
+            for (const header of CREDENTIAL_HEADERS_STRIPPED_ON_CROSS_ORIGIN_REDIRECT) {
+                headers.delete(header);
+            }
+        }
+        if (res.status === 303 || ((res.status === 301 || res.status === 302) && method !== 'GET' && method !== 'HEAD')) {
+            method = 'GET';
+            body = null;
+            headers.delete('content-type');
+            headers.delete('content-length');
+        }
+
+        currentUrl = target;
+        followed += 1;
+    }
+}
+
 export async function loggedFetch<TBody>(
     {
         url,
         method,
         headers,
         body,
-        agent
+        agent,
+        redirect
     }: {
         url: URL;
         method?: HTTP_METHOD;
         headers?: Record<string, string> | undefined;
         body?: string | null;
         agent?: Agent | undefined;
+        redirect?: LoggedFetchRedirectPolicy | undefined;
     },
     options: {
         // TODO: maybe put that in logCtx
@@ -50,7 +127,7 @@ export async function loggedFetch<TBody>(
         body: body ? redactObjectOrString({ data: body, valuesToFilter: options.valuesToFilter }) : undefined
     };
     try {
-        const res = await fetch(url, props);
+        const res = redirect ? await fetchFollowingPolicyRedirects(url, props, redirect) : await fetch(url, props);
         let body: TBody;
         const contentType = res.headers.get('content-type');
         if (contentType?.includes('application/json')) {

--- a/packages/shared/lib/utils/http.ts
+++ b/packages/shared/lib/utils/http.ts
@@ -21,15 +21,20 @@ export interface LoggedFetchRedirectPolicy {
 }
 
 const REDIRECT_STATUSES = new Set([301, 302, 303, 307, 308]);
-// Stripped when a redirect crosses origins, matching the browser fetch default so manual following
-// does not leak credentials to a different host than the one the caller authenticated against.
-const CREDENTIAL_HEADERS_STRIPPED_ON_CROSS_ORIGIN_REDIRECT = ['authorization', 'cookie', 'proxy-authorization'];
+// Credential material is never forwarded across a redirect hop (same-origin included). Forwarding is
+// not opt-in anywhere on this path, so we drop these on every hop rather than relying on cross-origin
+// heuristics — matching the OAuth axios path, which also strips credential headers on every hop.
+const CREDENTIAL_HEADERS_STRIPPED_ON_REDIRECT = ['authorization', 'cookie', 'proxy-authorization'];
 
 /**
  * Follow redirects manually, validating every hop against `redirectPolicy`. Undici's fetch skips the
  * dispatcher's safe DNS lookup for IP-literal hosts, so relying on the agent alone would let a public
  * token URL redirect straight to a blocked internal IP; validating each `Location` here closes that gap
  * and enforces `maxRedirects` (which the dispatcher does not).
+ *
+ * Credentials are never forwarded across redirects: credential headers are stripped on every hop, and a
+ * cross-origin 307/308 (which would otherwise replay the original credential-bearing POST body — e.g.
+ * `client_secret`, a JWT assertion, or a custom-auth password) is refused rather than replayed.
  */
 async function fetchFollowingPolicyRedirects(initialUrl: URL, baseProps: RequestInit, redirectPolicy: LoggedFetchRedirectPolicy): Promise<Response> {
     let currentUrl = initialUrl;
@@ -65,16 +70,23 @@ async function fetchFollowingPolicyRedirects(initialUrl: URL, baseProps: Request
 
         await redirectPolicy.validate(target);
 
-        if (target.origin !== currentUrl.origin) {
-            for (const header of CREDENTIAL_HEADERS_STRIPPED_ON_CROSS_ORIGIN_REDIRECT) {
-                headers.delete(header);
-            }
+        const isCrossOrigin = target.origin !== currentUrl.origin;
+
+        // Never forward credential headers across a redirect, regardless of origin.
+        for (const header of CREDENTIAL_HEADERS_STRIPPED_ON_REDIRECT) {
+            headers.delete(header);
         }
+
         if (res.status === 303 || ((res.status === 301 || res.status === 302) && method !== 'GET' && method !== 'HEAD')) {
+            // 301/302/303 downgrade an unsafe method to GET and drop the request body entirely.
             method = 'GET';
             body = null;
             headers.delete('content-type');
             headers.delete('content-length');
+        } else if (isCrossOrigin && body != null) {
+            // 307/308 preserve method + body. Replaying a credential-bearing body to a different origin
+            // would leak it, so refuse the hop instead of forwarding the body unchanged.
+            throw new Error(`Refusing to replay request body across origins on redirect to ${target.origin}`);
         }
 
         currentUrl = target;

--- a/packages/shared/lib/utils/http.unit.test.ts
+++ b/packages/shared/lib/utils/http.unit.test.ts
@@ -138,10 +138,15 @@ describe('loggedFetch', () => {
     });
 
     describe('redirect policy', () => {
-        it('validates every hop and returns the final response', async () => {
+        it('validates every hop across a multi-redirect chain and returns the final response', async () => {
             await withServer(
                 (req, res) => {
                     if (req.url === '/start') {
+                        res.writeHead(302, { location: '/step' });
+                        res.end();
+                        return;
+                    }
+                    if (req.url === '/step') {
                         res.writeHead(302, { location: '/final' });
                         res.end();
                         return;
@@ -165,7 +170,8 @@ describe('loggedFetch', () => {
                         { logCtx: buffer, context: 'auth', valuesToFilter: [] }
                     );
                     expect(fetchRes.unwrap().body).toStrictEqual({ ok: true });
-                    expect(validated).toEqual([`${baseUrl}/final`]);
+                    // Both hops (not just the first) must be validated.
+                    expect(validated).toEqual([`${baseUrl}/step`, `${baseUrl}/final`]);
                 }
             );
         });
@@ -217,15 +223,18 @@ describe('loggedFetch', () => {
             );
         });
 
-        it('strips credential headers on cross-origin hops but keeps them same-origin', async () => {
+        it('strips credential headers on every redirect hop, same-origin included', async () => {
             await withServer(
                 (req, res) => {
                     res.writeHead(200, { 'content-type': 'application/json' });
                     res.end(JSON.stringify({ authorization: req.headers['authorization'] ?? null }));
                 },
                 async (targetUrl) => {
+                    // Records the Authorization header seen at each path on the origin server.
+                    const seen: Record<string, string | null> = {};
                     await withServer(
                         (req, res) => {
+                            seen[req.url ?? ''] = req.headers['authorization'] ?? null;
                             // Redirect same-origin first, then cross-origin to the second server.
                             if (req.url === '/start') {
                                 res.writeHead(302, { location: '/same-origin' });
@@ -250,10 +259,88 @@ describe('loggedFetch', () => {
                                 },
                                 { logCtx: buffer, context: 'auth', valuesToFilter: [] }
                             );
-                            // Landed on the cross-origin server, which must not have received the credential header.
+                            // The original request keeps its credential header.
+                            expect(seen['/start']).toBe('Basic secret');
+                            // The same-origin redirect hop must NOT retain the credential header.
+                            expect(seen['/same-origin']).toBeNull();
+                            // Landed on the cross-origin server, which also must not have received it.
                             expect(fetchRes.unwrap().body).toStrictEqual({ authorization: null });
                         }
                     );
+                }
+            );
+        });
+
+        it('refuses to replay a credential-bearing body across origins on a 307 redirect', async () => {
+            await withServer(
+                (req, res) => {
+                    // Cross-origin target: must never receive the original POST body.
+                    let received = '';
+                    req.on('data', (chunk) => (received += chunk));
+                    req.on('end', () => {
+                        res.writeHead(200, { 'content-type': 'application/json' });
+                        res.end(JSON.stringify({ received }));
+                    });
+                },
+                async (targetUrl) => {
+                    await withServer(
+                        (req, res) => {
+                            if (req.url === '/start') {
+                                // 307 preserves method + body; point it at a different origin.
+                                res.writeHead(307, { location: `${targetUrl}/capture` });
+                                res.end();
+                                return;
+                            }
+                            res.writeHead(200);
+                            res.end();
+                        },
+                        async (baseUrl) => {
+                            const buffer = logContextGetter.getBuffer({ accountId: 1 });
+                            const fetchRes = await loggedFetch(
+                                {
+                                    url: new URL(`${baseUrl}/start`),
+                                    method: 'POST',
+                                    body: 'client_secret=super-secret',
+                                    redirect: { maxRedirects: 5, validate: () => undefined }
+                                },
+                                { logCtx: buffer, context: 'auth', valuesToFilter: [] }
+                            );
+                            // The hop is refused rather than replaying the credential body cross-origin.
+                            expect(fetchRes.isErr()).toBe(true);
+                        }
+                    );
+                }
+            );
+        });
+
+        it('replays a body on a same-origin 307 redirect', async () => {
+            await withServer(
+                (req, res) => {
+                    if (req.url === '/start') {
+                        res.writeHead(307, { location: '/final' });
+                        res.end();
+                        return;
+                    }
+                    let received = '';
+                    req.on('data', (chunk) => (received += chunk));
+                    req.on('end', () => {
+                        res.writeHead(200, { 'content-type': 'application/json' });
+                        res.end(JSON.stringify({ received, method: req.method }));
+                    });
+                },
+                async (baseUrl) => {
+                    const buffer = logContextGetter.getBuffer({ accountId: 1 });
+                    const fetchRes = await loggedFetch<{ received: string; method: string }>(
+                        {
+                            url: new URL(`${baseUrl}/start`),
+                            method: 'POST',
+                            body: 'client_secret=super-secret',
+                            redirect: { maxRedirects: 5, validate: () => undefined }
+                        },
+                        { logCtx: buffer, context: 'auth', valuesToFilter: [] }
+                    );
+                    // Same origin: replaying the body is safe, so the POST + body survive.
+                    expect(fetchRes.unwrap().body).toStrictEqual({ received: 'client_secret=super-secret', method: 'POST' });
                 }
             );
         });

--- a/packages/shared/lib/utils/http.unit.test.ts
+++ b/packages/shared/lib/utils/http.unit.test.ts
@@ -1,3 +1,5 @@
+import http from 'node:http';
+
 import { afterEach, describe, expect, it, vi } from 'vitest';
 
 import { logContextGetter } from '@nangohq/logs';
@@ -5,6 +7,18 @@ import { logContextGetter } from '@nangohq/logs';
 import { loggedFetch } from './http.js';
 
 import type { BufferTransport } from '@nangohq/logs';
+import type { AddressInfo } from 'node:net';
+
+async function withServer(handler: http.RequestListener, fn: (baseUrl: string) => Promise<void>): Promise<void> {
+    const server = http.createServer(handler);
+    await new Promise<void>((resolve) => server.listen(0, '127.0.0.1', resolve));
+    const { port } = server.address() as AddressInfo;
+    try {
+        await fn(`http://127.0.0.1:${port}`);
+    } finally {
+        await new Promise<void>((resolve) => server.close(() => resolve()));
+    }
+}
 
 describe('loggedFetch', () => {
     afterEach(() => {
@@ -121,5 +135,127 @@ describe('loggedFetch', () => {
                 type: 'http'
             }
         ]);
+    });
+
+    describe('redirect policy', () => {
+        it('validates every hop and returns the final response', async () => {
+            await withServer(
+                (req, res) => {
+                    if (req.url === '/start') {
+                        res.writeHead(302, { location: '/final' });
+                        res.end();
+                        return;
+                    }
+                    res.writeHead(200, { 'content-type': 'application/json' });
+                    res.end(JSON.stringify({ ok: true }));
+                },
+                async (baseUrl) => {
+                    const validated: string[] = [];
+                    const buffer = logContextGetter.getBuffer({ accountId: 1 });
+                    const fetchRes = await loggedFetch<{ ok: boolean }>(
+                        {
+                            url: new URL(`${baseUrl}/start`),
+                            redirect: {
+                                maxRedirects: 5,
+                                validate: (target) => {
+                                    validated.push(target.href);
+                                }
+                            }
+                        },
+                        { logCtx: buffer, context: 'auth', valuesToFilter: [] }
+                    );
+                    expect(fetchRes.unwrap().body).toStrictEqual({ ok: true });
+                    expect(validated).toEqual([`${baseUrl}/final`]);
+                }
+            );
+        });
+
+        it('fails when a hop is rejected by the validator (blocked IP literal)', async () => {
+            await withServer(
+                (_req, res) => {
+                    res.writeHead(302, { location: 'http://169.254.169.254/latest/meta-data/' });
+                    res.end();
+                },
+                async (baseUrl) => {
+                    const buffer = logContextGetter.getBuffer({ accountId: 1 });
+                    const fetchRes = await loggedFetch(
+                        {
+                            url: new URL(`${baseUrl}/start`),
+                            redirect: {
+                                maxRedirects: 5,
+                                validate: (target) => {
+                                    if (target.hostname === '169.254.169.254') {
+                                        throw new Error('blocked');
+                                    }
+                                }
+                            }
+                        },
+                        { logCtx: buffer, context: 'auth', valuesToFilter: [] }
+                    );
+                    expect(fetchRes.isErr()).toBe(true);
+                }
+            );
+        });
+
+        it('fails once maxRedirects is exceeded', async () => {
+            await withServer(
+                (_req, res) => {
+                    res.writeHead(302, { location: '/next' });
+                    res.end();
+                },
+                async (baseUrl) => {
+                    const buffer = logContextGetter.getBuffer({ accountId: 1 });
+                    const fetchRes = await loggedFetch(
+                        {
+                            url: new URL(`${baseUrl}/start`),
+                            redirect: { maxRedirects: 2, validate: () => undefined }
+                        },
+                        { logCtx: buffer, context: 'auth', valuesToFilter: [] }
+                    );
+                    expect(fetchRes.isErr()).toBe(true);
+                }
+            );
+        });
+
+        it('strips credential headers on cross-origin hops but keeps them same-origin', async () => {
+            await withServer(
+                (req, res) => {
+                    res.writeHead(200, { 'content-type': 'application/json' });
+                    res.end(JSON.stringify({ authorization: req.headers['authorization'] ?? null }));
+                },
+                async (targetUrl) => {
+                    await withServer(
+                        (req, res) => {
+                            // Redirect same-origin first, then cross-origin to the second server.
+                            if (req.url === '/start') {
+                                res.writeHead(302, { location: '/same-origin' });
+                                res.end();
+                                return;
+                            }
+                            if (req.url === '/same-origin') {
+                                res.writeHead(302, { location: `${targetUrl}/capture` });
+                                res.end();
+                                return;
+                            }
+                            res.writeHead(200, { 'content-type': 'application/json' });
+                            res.end(JSON.stringify({ authorization: req.headers['authorization'] ?? null }));
+                        },
+                        async (baseUrl) => {
+                            const buffer = logContextGetter.getBuffer({ accountId: 1 });
+                            const fetchRes = await loggedFetch<{ authorization: string | null }>(
+                                {
+                                    url: new URL(`${baseUrl}/start`),
+                                    headers: { authorization: 'Basic secret' },
+                                    redirect: { maxRedirects: 5, validate: () => undefined }
+                                },
+                                { logCtx: buffer, context: 'auth', valuesToFilter: [] }
+                            );
+                            // Landed on the cross-origin server, which must not have received the credential header.
+                            expect(fetchRes.unwrap().body).toStrictEqual({ authorization: null });
+                        }
+                    );
+                }
+            );
+        });
     });
 });

--- a/packages/shared/lib/utils/http.unit.test.ts
+++ b/packages/shared/lib/utils/http.unit.test.ts
@@ -344,5 +344,117 @@ describe('loggedFetch', () => {
                 }
             );
         });
+
+        it.each([301, 302])('downgrades a POST to GET and drops the body/content-type/content-length on a %i redirect', async (status) => {
+            await withServer(
+                (req, res) => {
+                    if (req.url === '/start') {
+                        res.writeHead(status, { location: '/final' });
+                        res.end();
+                        return;
+                    }
+                    let received = '';
+                    req.on('data', (chunk) => (received += chunk));
+                    req.on('end', () => {
+                        res.writeHead(200, { 'content-type': 'application/json' });
+                        res.end(
+                            JSON.stringify({
+                                method: req.method,
+                                received,
+                                contentType: req.headers['content-type'] ?? null,
+                                contentLength: req.headers['content-length'] ?? null
+                            })
+                        );
+                    });
+                },
+                async (baseUrl) => {
+                    const buffer = logContextGetter.getBuffer({ accountId: 1 });
+                    const fetchRes = await loggedFetch<{ method: string; received: string; contentType: string | null; contentLength: string | null }>(
+                        {
+                            url: new URL(`${baseUrl}/start`),
+                            method: 'POST',
+                            headers: { 'content-type': 'application/x-www-form-urlencoded' },
+                            body: 'client_secret=super-secret',
+                            redirect: { maxRedirects: 5, validate: () => undefined }
+                        },
+                        { logCtx: buffer, context: 'auth', valuesToFilter: [] }
+                    );
+                    // 301/302 on an unsafe method must become a bodyless GET: the follow-up carries no body and
+                    // neither the content-type nor the content-length of the dropped body are leaked forward.
+                    expect(fetchRes.unwrap().body).toStrictEqual({ method: 'GET', received: '', contentType: null, contentLength: null });
+                }
+            );
+        });
+
+        it('returns the original redirect response when the Location header is unparseable (does not throw)', async () => {
+            await withServer(
+                (req, res) => {
+                    if (req.url === '/start') {
+                        // `http://` has a scheme but no host, so `new URL()` cannot resolve it even against a base.
+                        res.writeHead(302, { location: 'http://', 'content-type': 'application/json' });
+                        res.end(JSON.stringify({ redirected: false }));
+                        return;
+                    }
+                    res.writeHead(200, { 'content-type': 'application/json' });
+                    res.end(JSON.stringify({ redirected: true }));
+                },
+                async (baseUrl) => {
+                    const buffer = logContextGetter.getBuffer({ accountId: 1 });
+                    const fetchRes = await loggedFetch<{ redirected: boolean }>(
+                        {
+                            url: new URL(`${baseUrl}/start`),
+                            redirect: { maxRedirects: 5, validate: () => undefined }
+                        },
+                        { logCtx: buffer, context: 'auth', valuesToFilter: [] }
+                    );
+                    // A malformed Location is surfaced as the untouched 3xx response rather than an error.
+                    const { res, body } = fetchRes.unwrap();
+                    expect(res.status).toBe(302);
+                    expect(body).toStrictEqual({ redirected: false });
+                }
+            );
+        });
+
+        it('refuses to replay a credential-bearing body across origins on a 308 redirect', async () => {
+            await withServer(
+                (req, res) => {
+                    // Cross-origin target: must never receive the original POST body.
+                    let received = '';
+                    req.on('data', (chunk) => (received += chunk));
+                    req.on('end', () => {
+                        res.writeHead(200, { 'content-type': 'application/json' });
+                        res.end(JSON.stringify({ received }));
+                    });
+                },
+                async (targetUrl) => {
+                    await withServer(
+                        (req, res) => {
+                            if (req.url === '/start') {
+                                // 308, like 307, preserves method + body; point it at a different origin.
+                                res.writeHead(308, { location: `${targetUrl}/capture` });
+                                res.end();
+                                return;
+                            }
+                            res.writeHead(200);
+                            res.end();
+                        },
+                        async (baseUrl) => {
+                            const buffer = logContextGetter.getBuffer({ accountId: 1 });
+                            const fetchRes = await loggedFetch(
+                                {
+                                    url: new URL(`${baseUrl}/start`),
+                                    method: 'POST',
+                                    body: 'client_secret=super-secret',
+                                    redirect: { maxRedirects: 5, validate: () => undefined }
+                                },
+                                { logCtx: buffer, context: 'auth', valuesToFilter: [] }
+                            );
+                            // 308 shares the 307 code path; verify it too refuses the cross-origin body replay.
+                            expect(fetchRes.isErr()).toBe(true);
+                        }
+                    );
+                }
+            );
+        });
     });
 });

--- a/packages/utils/lib/environment/parse.ts
+++ b/packages/utils/lib/environment/parse.ts
@@ -3,7 +3,6 @@ import * as z from 'zod';
 import { DEFAULT_NANGO_PROXY_BASE_URL_OVERRIDE_DENYLIST, mergeProxyBaseUrlOverrideDenylist } from '../proxy/baseUrlOverrideDenylist.js';
 import { roles } from '../roles.js';
 
-// Outbound URL policy (JSON), consumed by @nangohq/egress. Shared by the base and OAuth-specific vars.
 function outboundUrlPolicySchema(varName: string) {
     return z
         .string()
@@ -29,8 +28,6 @@ function outboundUrlPolicySchema(varName: string) {
                     blockLinkLocal: z.boolean().optional(),
                     maxRedirects: z.number().int().nonnegative().optional()
                 })
-                // Reject unknown keys so a typo (e.g. `blockPrivateIp`) fails fast at startup instead of
-                // being silently dropped and weakening the intended SSRF restrictions.
                 .strict()
                 .optional()
         );

--- a/packages/utils/lib/environment/parse.ts
+++ b/packages/utils/lib/environment/parse.ts
@@ -3,6 +3,39 @@ import * as z from 'zod';
 import { DEFAULT_NANGO_PROXY_BASE_URL_OVERRIDE_DENYLIST, mergeProxyBaseUrlOverrideDenylist } from '../proxy/baseUrlOverrideDenylist.js';
 import { roles } from '../roles.js';
 
+// Outbound URL policy (JSON), consumed by @nangohq/egress. Shared by the base and OAuth-specific vars.
+function outboundUrlPolicySchema(varName: string) {
+    return z
+        .string()
+        .optional()
+        .transform((s, ctx) => {
+            if (s === undefined || s.trim() === '') {
+                return undefined;
+            }
+            try {
+                return JSON.parse(s) as unknown;
+            } catch {
+                ctx.addIssue(`Invalid JSON in ${varName}`);
+                return z.NEVER; // tells Zod to stop here and mark parse as failed
+            }
+        })
+        .pipe(
+            z
+                .object({
+                    mode: z.enum(['denylist', 'allowlist', 'permissive']).optional(),
+                    denylist: z.array(z.string()).optional(),
+                    allowlist: z.array(z.string()).optional(),
+                    blockPrivateIps: z.boolean().optional(),
+                    blockLinkLocal: z.boolean().optional(),
+                    maxRedirects: z.number().int().nonnegative().optional()
+                })
+                // Reject unknown keys so a typo (e.g. `blockPrivateIp`) fails fast at startup instead of
+                // being silently dropped and weakening the intended SSRF restrictions.
+                .strict()
+                .optional()
+        );
+}
+
 export const ENVS = z.object({
     // Node ecosystem
     NODE_ENV: z.enum(['production', 'staging', 'development', 'test']).default('development'), // TODO: a better name would be NANGO_ENV
@@ -78,36 +111,11 @@ export const ENVS = z.object({
                 return z.NEVER;
             }
         }),
-    // Outbound URL policy (JSON), consumed by @nangohq/egress.
-    NANGO_OUTBOUND_URL_POLICY: z
-        .string()
-        .optional()
-        .transform((s, ctx) => {
-            if (s === undefined || s.trim() === '') {
-                return undefined;
-            }
-            try {
-                return JSON.parse(s) as unknown;
-            } catch {
-                ctx.addIssue(`Invalid JSON in NANGO_OUTBOUND_URL_POLICY`);
-                return z.NEVER; // tells Zod to stop here and mark parse as failed
-            }
-        })
-        .pipe(
-            z
-                .object({
-                    mode: z.enum(['denylist', 'allowlist', 'permissive']).optional(),
-                    denylist: z.array(z.string()).optional(),
-                    allowlist: z.array(z.string()).optional(),
-                    blockPrivateIps: z.boolean().optional(),
-                    blockLinkLocal: z.boolean().optional(),
-                    maxRedirects: z.number().int().nonnegative().optional()
-                })
-                // Reject unknown keys so a typo (e.g. `blockPrivateIp`) fails fast at startup instead of
-                // being silently dropped and weakening the intended SSRF restrictions.
-                .strict()
-                .optional()
-        ),
+    // Outbound URL policy (JSON), consumed by @nangohq/egress for proxy/webhook/uncontrolledFetch paths.
+    NANGO_OUTBOUND_URL_POLICY: outboundUrlPolicySchema('NANGO_OUTBOUND_URL_POLICY'),
+    // Outbound URL policy overlay for OAuth/token flows. Applied on top of NANGO_OUTBOUND_URL_POLICY,
+    // but RFC1918 blocking defaults off (configurable) so self-hosted token endpoints keep working.
+    NANGO_OUTBOUND_URL_POLICY_OAUTH: outboundUrlPolicySchema('NANGO_OUTBOUND_URL_POLICY_OAUTH'),
 
     // Connect
     NANGO_PUBLIC_CONNECT_URL: z.url().optional(),

--- a/packages/utils/lib/environment/parse.unit.test.ts
+++ b/packages/utils/lib/environment/parse.unit.test.ts
@@ -195,6 +195,36 @@ describe('parse', () => {
         }).toThrow();
     });
 
+    it('should default NANGO_OUTBOUND_URL_POLICY_OAUTH to undefined when unset', () => {
+        const res = parseEnvs(ENVS, {});
+        expect(res.NANGO_OUTBOUND_URL_POLICY_OAUTH).toBeUndefined();
+    });
+
+    it('should parse a valid NANGO_OUTBOUND_URL_POLICY_OAUTH', () => {
+        const res = parseEnvs(ENVS, {
+            NANGO_OUTBOUND_URL_POLICY_OAUTH: JSON.stringify({ blockPrivateIps: true, maxRedirects: 2 })
+        });
+        expect(res.NANGO_OUTBOUND_URL_POLICY_OAUTH).toEqual({ blockPrivateIps: true, maxRedirects: 2 });
+    });
+
+    it('should throw on invalid JSON in NANGO_OUTBOUND_URL_POLICY_OAUTH', () => {
+        expect(() => {
+            parseEnvs(ENVS, { NANGO_OUTBOUND_URL_POLICY_OAUTH: 'not-json' });
+        }).toThrow('Invalid JSON in NANGO_OUTBOUND_URL_POLICY_OAUTH');
+    });
+
+    it('should throw on an invalid NANGO_OUTBOUND_URL_POLICY_OAUTH shape', () => {
+        expect(() => {
+            parseEnvs(ENVS, { NANGO_OUTBOUND_URL_POLICY_OAUTH: JSON.stringify({ mode: 'bogus' }) });
+        }).toThrow();
+    });
+
+    it('should throw on unknown keys in NANGO_OUTBOUND_URL_POLICY_OAUTH (typos fail fast)', () => {
+        expect(() => {
+            parseEnvs(ENVS, { NANGO_OUTBOUND_URL_POLICY_OAUTH: JSON.stringify({ blockPrivateIp: false }) });
+        }).toThrow();
+    });
+
     it('should default NANGO_LOGS_PROVIDER to elasticsearch', () => {
         const res = parseEnvs(ENVS, {});
         expect(res.NANGO_LOGS_PROVIDER).toBe('elasticsearch');


### PR DESCRIPTION
### Summary
Extends the existing outbound URL policy to server-side OAuth/token flows. A new `NANGO_OUTBOUND_URL_POLICY_OAUTH` validates interpolated token/refresh/STS/JWT URLs and routes those requests through the egress safe agents.

It inherits the base `NANGO_OUTBOUND_URL_POLICY` but allows private/RFC1918 hosts by default so self-hosted integrations with internal token endpoints keep working. Operators can tighten this with `NANGO_OUTBOUND_URL_POLICY_OAUTH='{"blockPrivateIps":true}'`.

### Changes
- **egress**: `resolvePolicyForOAuth` now takes parsed env objects (base + OAuth overlay); added `getSafeUndiciDispatcher` and the `undici` dep.
- **utils**: parse `NANGO_OUTBOUND_URL_POLICY_OAUTH` (shares the strict schema with the base var).
- **shared**: `getOAuthOutboundUrlPolicy`, `assertSafeOAuthUrl`, `getOAuthSafeHttpAgents`, `getOAuthSafeUndiciDispatcher`.
- **Wired**: `oauth2.client`, `provider.client`, `connection.service` (OAUTH2_CC + TWO_STEP), `auth/jwt`, `auth/aws-sigv4`, `oauth.controller`.
- **Docs/config**: `.env.example` and `self-hosting.mdx`.

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/NangoHQ/nango/pull/6672?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

