### PR TITLE
feat: reach any value when filtering usage, not just top-N (NAN-6038)

### DIFF
--- a/packages/design-system/stories/v2-patterns/FilterSelect.stories.tsx
+++ b/packages/design-system/stories/v2-patterns/FilterSelect.stories.tsx
@@ -50,14 +50,48 @@ const DATA: Record<string, { value: string; label: string }[]> = {
     ].map((v) => ({ value: v, label: v }))
 };
 
-const Demo: React.FC<{ initial?: { group: string; value: string } | null }> = ({ initial = null }) => {
+// A long list to demonstrate paging — far more than fits without scrolling.
+const MANY = Array.from({ length: 60 }, (_, i) => {
+    const v = `conn-${String(i + 1).padStart(2, '0')}`;
+    return { value: v, label: v };
+});
+
+// Serves MANY in pages of 20, with a brief simulated delay on each load so the next-page spinner
+// shows. Lives in FilterSelect's value pane (which remounts per group), so the page count resets
+// each time the group reopens. Named `use*` because it holds hook state.
+const usePaginatingGroupData = (_group: string): FilterSelectGroupData => {
+    const PAGE = 20;
+    const [loaded, setLoaded] = useState(PAGE);
+    const [fetchingNext, setFetchingNext] = useState(false);
+    return {
+        options: MANY.slice(0, loaded),
+        isLoading: false,
+        isError: false,
+        hasNextPage: loaded < MANY.length,
+        isFetchingNextPage: fetchingNext,
+        fetchNextPage: () => {
+            if (fetchingNext || loaded >= MANY.length) return;
+            setFetchingNext(true);
+            setTimeout(() => {
+                setLoaded((n) => Math.min(n + PAGE, MANY.length));
+                setFetchingNext(false);
+            }, 500);
+        }
+    };
+};
+
+const Demo: React.FC<{
+    initial?: { group: string; value: string } | null;
+    groups?: { value: string; label: string }[];
+    useGroupData?: (group: string) => FilterSelectGroupData;
+}> = ({ initial = null, groups = GROUPS, useGroupData }) => {
     const [open, setOpen] = useState(false);
     const [filter, setFilter] = useState<{ group: string; value: string } | null>(initial);
 
-    // In the app this fetches per-dimension values; here it's static.
-    const useGroupData = (group: string): FilterSelectGroupData => ({ options: DATA[group] ?? [], isLoading: false, isError: false });
+    // In the app this fetches per-dimension values; here it's static unless a story overrides it.
+    const defaultUseGroupData = (group: string): FilterSelectGroupData => ({ options: DATA[group] ?? [], isLoading: false, isError: false });
 
-    const activeLabel = filter ? `${GROUPS.find((g) => g.value === filter.group)?.label}: ${filter.value}` : 'Filter';
+    const activeLabel = filter ? `${groups.find((g) => g.value === filter.group)?.label}: ${filter.value}` : 'Filter';
     const trigger = (
         <button
             type="button"
@@ -73,8 +107,8 @@ const Demo: React.FC<{ initial?: { group: string; value: string } | null }> = ({
             trigger={trigger}
             open={open}
             onOpenChange={setOpen}
-            groups={GROUPS}
-            useGroupData={useGroupData}
+            groups={groups}
+            useGroupData={useGroupData ?? defaultUseGroupData}
             selectedValueFor={(g: string) => (filter?.group === g ? filter.value : null)}
             onSelect={(group: string, value: string) => setFilter({ group, value })}
             // `status` is a fixed set: no free text and no search box — the others allow both.
@@ -91,4 +125,24 @@ export const Default: Story = {
 export const WithSelection: Story = {
     name: 'With a selection',
     render: () => <Demo initial={{ group: 'status', value: 'true' }} />
+};
+
+export const Paginating: Story = {
+    name: 'Paging (load more on scroll)',
+    render: () => <Demo groups={[{ value: 'connection', label: 'Connection' }]} useGroupData={usePaginatingGroupData} />
+};
+
+export const Loading: Story = {
+    name: 'Loading values',
+    render: () => <Demo groups={[{ value: 'function', label: 'Function name' }]} useGroupData={() => ({ options: [], isLoading: true, isError: false })} />
+};
+
+export const Searching: Story = {
+    name: 'Search fetch in flight',
+    render: () => (
+        <Demo
+            groups={[{ value: 'function', label: 'Function name' }]}
+            useGroupData={(group) => ({ options: DATA[group] ?? [], isLoading: false, isFetching: true, isError: false })}
+        />
+    )
 };

--- a/packages/design-system/stories/v2-patterns/FilterSelect.stories.tsx
+++ b/packages/design-system/stories/v2-patterns/FilterSelect.stories.tsx
@@ -77,8 +77,9 @@ const Demo: React.FC<{ initial?: { group: string; value: string } | null }> = ({
             useGroupData={useGroupData}
             selectedValueFor={(g: string) => (filter?.group === g ? filter.value : null)}
             onSelect={(group: string, value: string) => setFilter({ group, value })}
-            // `status` is a fixed set: no free text, and so no search box — the others allow both.
+            // `status` is a fixed set: no free text and no search box — the others allow both.
             allowCreate={(g: string) => g !== 'status'}
+            searchable={(g: string) => g !== 'status'}
         />
     );
 };

--- a/packages/server/lib/controllers/v1/plans/usage/getBillingUsageTopDimensionValues.integration.test.ts
+++ b/packages/server/lib/controllers/v1/plans/usage/getBillingUsageTopDimensionValues.integration.test.ts
@@ -284,6 +284,20 @@ describe(`GET ${route}`, () => {
             expect(page1.json.data.pagination).toEqual({ page: 1, limit: 25, hasMore: false });
         });
 
+        it('reports hasMore: false when the last page is exactly full', async () => {
+            // Exactly one page of values: the final page is full but there's nothing after it, so
+            // hasMore must be false (guards the phantom next-page a naive page-full check would return).
+            const exactlyOnePage = recordsFor(Array.from({ length: 25 }, (_, i) => ({ integrationId: `int-${String(i).padStart(2, '0')}`, value: 1000 - i })));
+            const { apiKey } = await seedAccountWith(exactlyOnePage);
+            const res = await api.fetch(route, {
+                token: apiKey.secret,
+                query: { env: 'dev', metric: 'records', dimension: 'integration_id', from: day0.toISOString(), to: end.toISOString(), page: '0' }
+            });
+            isSuccess(res.json);
+            expect(res.json.data.values).toHaveLength(25);
+            expect(res.json.data.pagination).toEqual({ page: 0, limit: 25, hasMore: false });
+        });
+
         it('pages equal-ranked values disjointly and completely (stable tie-break)', async () => {
             // All 30 share the same volume, so only the `dim ASC` tie-break orders them.
             const tied = recordsFor(Array.from({ length: 30 }, (_, i) => ({ integrationId: `tie-${String(i).padStart(2, '0')}`, value: 100 })));

--- a/packages/server/lib/controllers/v1/plans/usage/getBillingUsageTopDimensionValues.integration.test.ts
+++ b/packages/server/lib/controllers/v1/plans/usage/getBillingUsageTopDimensionValues.integration.test.ts
@@ -238,8 +238,11 @@ describe(`GET ${route}`, () => {
             expect(res.json.data.pagination.hasMore).toBe(false);
         });
 
-        it('ignores search for environment_id (still returns the env)', async () => {
-            const { apiKey, envId, envName } = await seedAccount();
+        it('applies search to environment_id like any dimension (not special-cased)', async () => {
+            // environment_id stores the numeric id, so a search that matches no id returns nothing —
+            // it is not exempt from the search filter. (The dashboard never searches it; it is a
+            // closed dimension with no search box. Labels are still resolved to env names.)
+            const { apiKey } = await seedAccount();
             const res = await api.fetch(route, {
                 token: apiKey.secret,
                 query: {
@@ -252,7 +255,7 @@ describe(`GET ${route}`, () => {
                 }
             });
             isSuccess(res.json);
-            expect(res.json.data.values).toEqual([{ id: String(envId), label: envName }]);
+            expect(res.json.data.values).toEqual([]);
             expect(res.json.data.pagination.hasMore).toBe(false);
         });
     });

--- a/packages/server/lib/controllers/v1/plans/usage/getBillingUsageTopDimensionValues.integration.test.ts
+++ b/packages/server/lib/controllers/v1/plans/usage/getBillingUsageTopDimensionValues.integration.test.ts
@@ -31,12 +31,34 @@ function seedFixture(accountId: number, environmentId: number): ClickhouseRawUsa
     ];
 }
 
-async function seedAccount(): Promise<{ apiKey: { secret: string }; accountId: number; envId: number; envName: string }> {
+// One `records` event per (integration_id, value) — lets a test control the
+// distinct value count and their volume ordering precisely.
+function recordsFor(specs: { integrationId: string; value: number }[]) {
+    return (accountId: number, environmentId: number): ClickhouseRawUsageEvent[] => {
+        const batch = randomUUID();
+        return specs.map((s) => ({
+            ts: day0.getTime(),
+            type: 'usage.records',
+            idempotency_key: randomUUID(),
+            account_id: accountId,
+            value: s.value,
+            attributes: { environmentId, integrationId: s.integrationId, batchId: batch }
+        }));
+    };
+}
+
+async function seedAccountWith(
+    seedFn: (accountId: number, environmentId: number) => ClickhouseRawUsageEvent[]
+): Promise<{ apiKey: { secret: string }; accountId: number; envId: number; envName: string }> {
     const { plan, apiKey, account, env } = await seeders.seedAccountEnvAndUser();
     await updatePlan(db.knex, { id: plan.id, orb_customer_id: 'orb_cust_123', orb_subscription_id: 'orb_sub_123' });
-    clickhouse.addRaw(seedFixture(account.id, env.id));
+    clickhouse.addRaw(seedFn(account.id, env.id));
     await clickhouse.flush();
     return { apiKey, accountId: account.id, envId: env.id, envName: env.name };
+}
+
+function seedAccount(): Promise<{ apiKey: { secret: string }; accountId: number; envId: number; envName: string }> {
+    return seedAccountWith(seedFixture);
 }
 
 describe(`GET ${route}`, () => {
@@ -147,26 +169,8 @@ describe(`GET ${route}`, () => {
                 { id: 'b', label: 'b' },
                 { id: 'c', label: 'c' }
             ]);
-        });
-
-        it('honours limit', async () => {
-            const { apiKey } = await seedAccount();
-            const res = await api.fetch(route, {
-                token: apiKey.secret,
-                query: {
-                    env: 'dev',
-                    metric: 'records',
-                    dimension: 'integration_id',
-                    from: day0.toISOString(),
-                    to: end.toISOString(),
-                    limit: '2'
-                }
-            });
-            isSuccess(res.json);
-            expect(res.json.data.values).toEqual([
-                { id: 'a', label: 'a' },
-                { id: 'b', label: 'b' }
-            ]);
+            // Fewer than a full page → no next page.
+            expect(res.json.data.pagination).toEqual({ page: 0, limit: 25, hasMore: false });
         });
 
         it('resolves environment_id to the env name (label) while keeping the raw id', async () => {
@@ -183,6 +187,123 @@ describe(`GET ${route}`, () => {
             });
             isSuccess(res.json);
             expect(res.json.data.values).toEqual([{ id: String(envId), label: envName }]);
+        });
+    });
+
+    describe('Search', () => {
+        it('matches a case-insensitive substring across the full set, ranked by volume', async () => {
+            const { apiKey } = await seedAccountWith(
+                recordsFor([
+                    { integrationId: 'Stripe', value: 1000 },
+                    { integrationId: 'stripe-prod', value: 500 },
+                    { integrationId: 'github', value: 800 }
+                ])
+            );
+            const res = await api.fetch(route, {
+                token: apiKey.secret,
+                query: {
+                    env: 'dev',
+                    metric: 'records',
+                    dimension: 'integration_id',
+                    from: day0.toISOString(),
+                    to: end.toISOString(),
+                    search: 'strip'
+                }
+            });
+            isSuccess(res.json);
+            // Both stripe values (ranked by volume), github excluded — even though
+            // github outranks stripe-prod, it doesn't match the search.
+            expect(res.json.data.values).toEqual([
+                { id: 'Stripe', label: 'Stripe' },
+                { id: 'stripe-prod', label: 'stripe-prod' }
+            ]);
+            expect(res.json.data.pagination.hasMore).toBe(false);
+        });
+
+        it('returns no values when nothing matches', async () => {
+            const { apiKey } = await seedAccount();
+            const res = await api.fetch(route, {
+                token: apiKey.secret,
+                query: {
+                    env: 'dev',
+                    metric: 'records',
+                    dimension: 'integration_id',
+                    from: day0.toISOString(),
+                    to: end.toISOString(),
+                    search: 'no-such-integration'
+                }
+            });
+            isSuccess(res.json);
+            expect(res.json.data.values).toEqual([]);
+            expect(res.json.data.pagination.hasMore).toBe(false);
+        });
+
+        it('ignores search for environment_id (still returns the env)', async () => {
+            const { apiKey, envId, envName } = await seedAccount();
+            const res = await api.fetch(route, {
+                token: apiKey.secret,
+                query: {
+                    env: 'dev',
+                    metric: 'records',
+                    dimension: 'environment_id',
+                    from: day0.toISOString(),
+                    to: end.toISOString(),
+                    search: 'no-such-env'
+                }
+            });
+            isSuccess(res.json);
+            expect(res.json.data.values).toEqual([{ id: String(envId), label: envName }]);
+            expect(res.json.data.pagination.hasMore).toBe(false);
+        });
+    });
+
+    describe('Paging', () => {
+        // 30 integrations with strictly descending volume → deterministic ranking int-00 … int-29.
+        const descending = recordsFor(Array.from({ length: 30 }, (_, i) => ({ integrationId: `int-${String(i).padStart(2, '0')}`, value: 1000 - i })));
+        const expectedOrder = Array.from({ length: 30 }, (_, i) => `int-${String(i).padStart(2, '0')}`);
+
+        it('returns a full first page with hasMore, then the remainder', async () => {
+            const { apiKey } = await seedAccountWith(descending);
+            const page0 = await api.fetch(route, {
+                token: apiKey.secret,
+                query: { env: 'dev', metric: 'records', dimension: 'integration_id', from: day0.toISOString(), to: end.toISOString(), page: '0' }
+            });
+            isSuccess(page0.json);
+            expect(page0.json.data.values.map((v) => v.id)).toEqual(expectedOrder.slice(0, 25));
+            expect(page0.json.data.pagination).toEqual({ page: 0, limit: 25, hasMore: true });
+
+            const page1 = await api.fetch(route, {
+                token: apiKey.secret,
+                query: { env: 'dev', metric: 'records', dimension: 'integration_id', from: day0.toISOString(), to: end.toISOString(), page: '1' }
+            });
+            isSuccess(page1.json);
+            expect(page1.json.data.values.map((v) => v.id)).toEqual(expectedOrder.slice(25));
+            expect(page1.json.data.pagination).toEqual({ page: 1, limit: 25, hasMore: false });
+        });
+
+        it('pages equal-ranked values disjointly and completely (stable tie-break)', async () => {
+            // All 30 share the same volume, so only the `dim ASC` tie-break orders them.
+            const tied = recordsFor(Array.from({ length: 30 }, (_, i) => ({ integrationId: `tie-${String(i).padStart(2, '0')}`, value: 100 })));
+            const { apiKey } = await seedAccountWith(tied);
+            const q = (page: string) => ({
+                env: 'dev',
+                metric: 'records' as const,
+                dimension: 'integration_id' as const,
+                from: day0.toISOString(),
+                to: end.toISOString(),
+                page
+            });
+            const page0 = await api.fetch(route, { token: apiKey.secret, query: q('0') });
+            const page1 = await api.fetch(route, { token: apiKey.secret, query: q('1') });
+            isSuccess(page0.json);
+            isSuccess(page1.json);
+            const ids0 = page0.json.data.values.map((v) => v.id);
+            const ids1 = page1.json.data.values.map((v) => v.id);
+            expect(ids0).toHaveLength(25);
+            expect(ids1).toHaveLength(5);
+            // No value skipped or duplicated across the page boundary.
+            expect(new Set([...ids0, ...ids1]).size).toBe(30);
+            expect(ids0.filter((id) => ids1.includes(id))).toEqual([]);
         });
     });
 });

--- a/packages/server/lib/controllers/v1/plans/usage/getBillingUsageTopDimensionValues.ts
+++ b/packages/server/lib/controllers/v1/plans/usage/getBillingUsageTopDimensionValues.ts
@@ -55,28 +55,24 @@ export const getBillingUsageTopDimensionValues = asyncWrapper<GetBillingUsageTop
     const query = parsedQuery.data;
     const { account } = res.locals;
 
-    // `environment_id` stores the numeric id, but the user searches by env
-    // name — a server-side substring match on the id can't match a name. Envs
-    // per account are few (always within the first page), so for this one
-    // dimension we never page or push `search` down: return the full small set
-    // (page 0, no search) and let the dropdown filter by label client-side.
-    const isEnvironmentId = query.dimension === 'environment_id';
-
     const result = await usageTracker.getTopDimensionValues({
         accountId: account.id,
         metric: query.metric,
         dimension: query.dimension,
         timeframe: { start: new Date(query.from), end: new Date(query.to) },
-        search: isEnvironmentId ? undefined : query.search,
-        page: isEnvironmentId ? 0 : (query.page ?? 0)
+        search: query.search,
+        page: query.page ?? 0
     });
     if (result.isErr()) {
         res.status(500).send({ error: { code: 'server_error', message: 'Failed to get top dimension values' } });
         return;
     }
 
+    // `environment_id` stores the numeric env id; resolve it to the env name here, since the only
+    // env list the dashboard has (`/api/v1/meta`) carries names but not these ids. Every other
+    // dimension already stores a human-readable value, so id === label.
     let values: { id: string; label: string }[];
-    if (isEnvironmentId) {
+    if (query.dimension === 'environment_id') {
         const names = await environmentService.getEnvironmentNamesByIds(result.value.values.map(Number));
         values = result.value.values.map((id) => ({ id, label: names.get(Number(id)) ?? id }));
     } else {
@@ -86,11 +82,7 @@ export const getBillingUsageTopDimensionValues = asyncWrapper<GetBillingUsageTop
     res.status(200).send({
         data: {
             values,
-            pagination: {
-                page: isEnvironmentId ? 0 : (query.page ?? 0),
-                limit: TOP_N_BREAKDOWN_PAGE_SIZE,
-                hasMore: isEnvironmentId ? false : result.value.hasMore
-            }
+            pagination: { page: query.page ?? 0, limit: TOP_N_BREAKDOWN_PAGE_SIZE, hasMore: result.value.hasMore }
         }
     });
 });

--- a/packages/server/lib/controllers/v1/plans/usage/getBillingUsageTopDimensionValues.ts
+++ b/packages/server/lib/controllers/v1/plans/usage/getBillingUsageTopDimensionValues.ts
@@ -1,7 +1,7 @@
 import z from 'zod';
 
 import { environmentService } from '@nangohq/shared';
-import { BREAKDOWN_DIMENSIONS, TOP_N_BREAKDOWN_CAP, TOP_N_BREAKDOWN_DEFAULT } from '@nangohq/usage';
+import { BREAKDOWN_DIMENSIONS, TOP_N_BREAKDOWN_PAGE_SIZE } from '@nangohq/usage';
 import { zodErrorToHTTP } from '@nangohq/utils';
 
 import { asyncWrapper } from '../../../../utils/asyncWrapper.js';
@@ -35,7 +35,10 @@ const querySchema = z
         env: z.string(),
         from: z.iso.datetime(),
         to: z.iso.datetime(),
-        limit: z.coerce.number().int().positive().max(TOP_N_BREAKDOWN_CAP).optional()
+        // Substring match on the dimension value; the page size is fixed
+        // server-side so callers only ever ask for "the next page".
+        search: z.string().trim().min(1).optional(),
+        page: z.coerce.number().int().nonnegative().optional()
     })
     .and(metricAndDimensionSchema)
     .refine((data) => new Date(data.from) <= new Date(data.to), {
@@ -52,12 +55,20 @@ export const getBillingUsageTopDimensionValues = asyncWrapper<GetBillingUsageTop
     const query = parsedQuery.data;
     const { account } = res.locals;
 
+    // `environment_id` stores the numeric id, but the user searches by env
+    // name — a server-side substring match on the id can't match a name. Envs
+    // per account are few (always within the first page), so for this one
+    // dimension we never page or push `search` down: return the full small set
+    // (page 0, no search) and let the dropdown filter by label client-side.
+    const isEnvironmentId = query.dimension === 'environment_id';
+
     const result = await usageTracker.getTopDimensionValues({
         accountId: account.id,
         metric: query.metric,
         dimension: query.dimension,
         timeframe: { start: new Date(query.from), end: new Date(query.to) },
-        limit: query.limit ?? TOP_N_BREAKDOWN_DEFAULT
+        search: isEnvironmentId ? undefined : query.search,
+        page: isEnvironmentId ? 0 : (query.page ?? 0)
     });
     if (result.isErr()) {
         res.status(500).send({ error: { code: 'server_error', message: 'Failed to get top dimension values' } });
@@ -65,12 +76,21 @@ export const getBillingUsageTopDimensionValues = asyncWrapper<GetBillingUsageTop
     }
 
     let values: { id: string; label: string }[];
-    if (query.dimension === 'environment_id') {
+    if (isEnvironmentId) {
         const names = await environmentService.getEnvironmentNamesByIds(result.value.values.map(Number));
         values = result.value.values.map((id) => ({ id, label: names.get(Number(id)) ?? id }));
     } else {
         values = result.value.values.map((id) => ({ id, label: id }));
     }
 
-    res.status(200).send({ data: { values } });
+    res.status(200).send({
+        data: {
+            values,
+            pagination: {
+                page: isEnvironmentId ? 0 : (query.page ?? 0),
+                limit: TOP_N_BREAKDOWN_PAGE_SIZE,
+                hasMore: isEnvironmentId ? false : result.value.hasMore
+            }
+        }
+    });
 });

--- a/packages/types/lib/plans/http.api.ts
+++ b/packages/types/lib/plans/http.api.ts
@@ -59,8 +59,11 @@ export type GetUsage = Endpoint<{
     };
 }>;
 
-// Top-N seen dimension values for (metric, dimension) over a timeframe.
-// Populates the filter dropdown UI on the billing-usage dashboard.
+// Seen dimension values for (metric, dimension) over a timeframe, ordered by
+// volume DESC. Populates the filter dropdown UI on the billing-usage
+// dashboard. A `search` term narrows to matching values across the customer's
+// FULL set (not just the top page), and `page` walks the long tail so any
+// value is reachable by name/substring without typing it verbatim.
 //
 // Querystring is a per-metric discriminated union so the `dimension` field is
 // constrained to the metric's whitelist at compile time; the controller's zod
@@ -75,8 +78,13 @@ export type GetBillingUsageTopDimensionValues = Endpoint<{
             dimension: BreakdownDimensions[M];
             from: string;
             to: string;
-            // Number of values to return. Defaults to 10, server-capped.
-            limit?: string | undefined;
+            // Case-insensitive substring match on the dimension value. Applied
+            // server-side (ClickHouse) so values below the first page are
+            // reachable. Ignored for `environment_id` (filtered client-side by
+            // label — its set is tiny and always fits the first page).
+            search?: string | undefined;
+            // Zero-based page index; page size is fixed server-side.
+            page?: string | undefined;
         };
     }[UsageMetric];
     Success: {
@@ -85,6 +93,9 @@ export type GetBillingUsageTopDimensionValues = Endpoint<{
             // display string — resolved server-side for `environment_id`,
             // equal to `id` for the other slug-ish dims.
             values: { id: string; label: string }[];
+            // `hasMore` is a page-full heuristic (this page came back full),
+            // so the picker can offer "load more" without a count query.
+            pagination: { page: number; limit: number; hasMore: boolean };
         };
     };
 }>;

--- a/packages/usage/lib/clickhouse/clickhouse.integration.test.ts
+++ b/packages/usage/lib/clickhouse/clickhouse.integration.test.ts
@@ -528,30 +528,34 @@ describe('Clickhouse', () => {
         });
 
         describe('getTopDimensionValues', () => {
-            it('returns top dimension values ordered by SUM(value) DESC', async () => {
+            it('returns dimension values ordered by SUM(value) DESC', async () => {
                 // records fixture: integrationId=a → 1000+1100+1100=3200; b → 500+500=1000.
                 const res = await clickhouse.getTopDimensionValues({
                     accountId,
                     metric: 'records',
                     dimension: 'integration_id',
                     timeframe: { start, end },
-                    limit: 10
+                    page: 0
                 });
                 expect(res.unwrap()).toStrictEqual({
                     accountId,
                     metric: 'records',
                     dimension: 'integration_id',
-                    values: ['a', 'b']
+                    values: ['a', 'b'],
+                    // Two values < one full page → no next page.
+                    hasMore: false
                 });
             });
 
-            it('honours limit (clamped to TOP_N_BREAKDOWN_CAP upstream)', async () => {
+            it('filters by case-insensitive substring search', async () => {
                 const res = await clickhouse.getTopDimensionValues({
                     accountId,
                     metric: 'records',
                     dimension: 'integration_id',
                     timeframe: { start, end },
-                    limit: 1
+                    page: 0,
+                    // Uppercase term still matches the lowercase 'a' (and not 'b').
+                    search: 'A'
                 });
                 expect(res.unwrap().values).toEqual(['a']);
             });
@@ -563,7 +567,7 @@ describe('Clickhouse', () => {
                     metric: 'proxy',
                     dimension: 'success',
                     timeframe: { start, end },
-                    limit: 10
+                    page: 0
                 });
                 const values = res.unwrap().values;
                 expect(values).toEqual(['true', 'false']);
@@ -576,7 +580,7 @@ describe('Clickhouse', () => {
                     metric: 'connections',
                     dimension: 'model' as any,
                     timeframe: { start, end },
-                    limit: 10
+                    page: 0
                 });
                 expect(res.isErr()).toBe(true);
             });
@@ -587,7 +591,7 @@ describe('Clickhouse', () => {
                     metric: 'records',
                     dimension: 'none' as any,
                     timeframe: { start, end },
-                    limit: 10
+                    page: 0
                 });
                 expect(res.isErr()).toBe(true);
             });
@@ -598,7 +602,7 @@ describe('Clickhouse', () => {
                     metric: 'records',
                     dimension: 'integration_id',
                     timeframe: { start, end },
-                    limit: 10
+                    page: 0
                 });
                 expect(res.unwrap().values).toEqual([]);
             });

--- a/packages/usage/lib/clickhouse/clickhouse.query.ts
+++ b/packages/usage/lib/clickhouse/clickhouse.query.ts
@@ -8,6 +8,11 @@ export type { AvgUsageMetric, CounterUsageMetric, DimensionFor } from '@nangohq/
 export const TOP_N_BREAKDOWN_DEFAULT = 10;
 export const TOP_N_BREAKDOWN_CAP = 25;
 
+// Page size for the filter value picker's `getTopDimensionValues` paging.
+// Kept distinct from `TOP_N_BREAKDOWN_CAP` (same value today) so the chart's
+// top-N + 'rest' cap and the picker's page size can diverge independently.
+export const TOP_N_BREAKDOWN_PAGE_SIZE = 25;
+
 // `satisfies Record<…, true>` on the set object forces an entry per metric;
 // projecting via `Object.keys` gives the runtime array. Adding a new metric
 // to `CounterUsageMetric` / `AvgUsageMetric` without updating the set fails
@@ -137,16 +142,21 @@ export function rankingQuantityForMetric(metric: UsageMetric): string {
     return quantityForMetric(metric);
 }
 
-// Top-N seen dimension values for (metric, dimension) over a timeframe.
-// Returns a flat string list; the filter UI uses this to populate dropdowns.
+// Seen dimension values for (metric, dimension) over a timeframe, ordered by
+// volume DESC. Returns a flat string list; the filter UI uses this to populate
+// dropdowns. Supports server-side substring `search` and offset `page` paging
+// so values below the first page are reachable.
 export type GetTopDimensionValuesQuery = {
     [M in UsageMetric]: {
         accountId: number;
         metric: M;
         dimension: BreakdownDimensions[M];
         timeframe: { start: Date; end: Date };
-        // Number of values to return. Clamped server-side to TOP_N_BREAKDOWN_CAP.
-        limit: number;
+        // Case-insensitive substring match on the dimension value (literal,
+        // not a LIKE pattern). Empty/undefined → no filter.
+        search?: string | undefined;
+        // Zero-based page index; page size is TOP_N_BREAKDOWN_PAGE_SIZE.
+        page: number;
     };
 }[UsageMetric];
 
@@ -155,6 +165,9 @@ export interface GetTopDimensionValuesResult {
     metric: UsageMetric;
     dimension: string;
     values: string[];
+    // Page-full heuristic: this page returned a full TOP_N_BREAKDOWN_PAGE_SIZE
+    // of values, so there may be another page.
+    hasMore: boolean;
 }
 
 export function quantityForMetric(metric: CounterUsageMetric): string {

--- a/packages/usage/lib/clickhouse/clickhouse.ts
+++ b/packages/usage/lib/clickhouse/clickhouse.ts
@@ -497,19 +497,14 @@ export class Clickhouse {
         const table = `${this.database}.${tableForMetric(metric)}`;
         const offset = Math.max(page, 0) * TOP_N_BREAKDOWN_PAGE_SIZE;
 
-        // `search` binds through CH's parameterized `query_params` (no string
-        // interpolation of user input); `positionCaseInsensitiveUTF8` treats it
-        // as a literal substring so `%`/`_` need no escaping. `${dimension}` is
-        // safe to interpolate — it comes from the zod enum, never free text.
+        // `search` is bound via `query_params` (no interpolation of user input) and matched as a
+        // literal substring, so `%`/`_` need no escaping. `${dimension}` is a zod enum, safe to inline.
         const searchClause = trimmedSearch ? `AND positionCaseInsensitiveUTF8(toString(${dimension}), {search:String}) > 0` : '';
         const queryParams = trimmedSearch ? { search: trimmedSearch } : undefined;
 
-        // The output alias is `dim` (not `value`) so the `ORDER BY` reference
-        // to the table column `value` (used by `rankingQuantityForMetric`) is
-        // not shadowed by the projection. The `dim ASC` tie-break makes the
-        // order deterministic across separate paged queries, so equal-ranked
-        // values can't be skipped or duplicated between pages. Paging is
-        // still best-effort for the current month (ranking accrues live).
+        // Alias is `dim` (not `value`) so `ORDER BY` still sees the table's `value` column. The
+        // `dim ASC` tie-break keeps the order stable across paged queries, so equal-ranked values
+        // aren't skipped or duplicated (best-effort for the still-accruing current month).
         const sql = `
             SELECT toString(${dimension}) AS dim
             FROM ${table}

--- a/packages/usage/lib/clickhouse/clickhouse.ts
+++ b/packages/usage/lib/clickhouse/clickhouse.ts
@@ -10,7 +10,8 @@ import {
     rankingQuantityForMetric,
     tableForMetric,
     TOP_N_BREAKDOWN_CAP,
-    TOP_N_BREAKDOWN_DEFAULT
+    TOP_N_BREAKDOWN_DEFAULT,
+    TOP_N_BREAKDOWN_PAGE_SIZE
 } from './clickhouse.query.js';
 import { clickhouseClient, database as usageDatabase } from './config.js';
 
@@ -468,16 +469,19 @@ export class Clickhouse {
     }
 
     /**
-     * Top-N seen dimension values for (metric, dimension) over a timeframe,
-     * ordered DESC by `rankingQuantityForMetric(metric)`. Populates the
-     * filter dropdown UI. Limit is clamped to `TOP_N_BREAKDOWN_CAP`.
+     * Seen dimension values for (metric, dimension) over a timeframe, ordered
+     * DESC by `rankingQuantityForMetric(metric)`. Populates the filter dropdown
+     * UI. A `search` term filters to values whose string contains it
+     * (case-insensitive substring), and `page` walks the long tail in pages of
+     * `TOP_N_BREAKDOWN_PAGE_SIZE`, so any value is reachable — not just the
+     * first page. `hasMore` is a page-full heuristic (avoids a count query).
      */
     async getTopDimensionValues(query: GetTopDimensionValuesQuery): Promise<Result<GetTopDimensionValuesResult>> {
         if (!this.client) {
             return Err(new Error('Clickhouse client not initialized'));
         }
 
-        const { accountId, metric, dimension, timeframe, limit } = query;
+        const { accountId, metric, dimension, timeframe, search, page } = query;
         // `isAllowedDimensionFor` accepts 'none' (valid for breakdown callers,
         // not for top-values — would emit `SELECT toString(none)`). The cast
         // defends against runtime callers bypassing the discriminated-union
@@ -486,30 +490,43 @@ export class Clickhouse {
             return Err(new Error(`Invalid dimension ${JSON.stringify(dimension)} for metric ${JSON.stringify(metric)}`));
         }
         const queryStart = process.hrtime.bigint();
-        const tags = { metric };
+        const trimmedSearch = search?.trim();
+        const tags = { metric, search: trimmedSearch ? 'true' : 'false' };
         const startDate = timeframe.start.toISOString().split('T')[0];
         const endDate = timeframe.end.toISOString().split('T')[0];
         const table = `${this.database}.${tableForMetric(metric)}`;
-        const cappedLimit = Math.min(Math.max(limit, 1), TOP_N_BREAKDOWN_CAP);
+        const offset = Math.max(page, 0) * TOP_N_BREAKDOWN_PAGE_SIZE;
+
+        // `search` binds through CH's parameterized `query_params` (no string
+        // interpolation of user input); `positionCaseInsensitiveUTF8` treats it
+        // as a literal substring so `%`/`_` need no escaping. `${dimension}` is
+        // safe to interpolate — it comes from the zod enum, never free text.
+        const searchClause = trimmedSearch ? `AND positionCaseInsensitiveUTF8(toString(${dimension}), {search:String}) > 0` : '';
+        const queryParams = trimmedSearch ? { search: trimmedSearch } : undefined;
 
         // The output alias is `dim` (not `value`) so the `ORDER BY` reference
         // to the table column `value` (used by `rankingQuantityForMetric`) is
-        // not shadowed by the projection.
+        // not shadowed by the projection. The `dim ASC` tie-break makes the
+        // order deterministic across separate paged queries, so equal-ranked
+        // values can't be skipped or duplicated between pages. Paging is
+        // still best-effort for the current month (ranking accrues live).
         const sql = `
             SELECT toString(${dimension}) AS dim
             FROM ${table}
             WHERE account_id = ${accountId}
               AND day >= toDate('${startDate}')
               AND day < toDate('${endDate}')
+              ${searchClause}
             GROUP BY ${dimension}
-            ORDER BY ${rankingQuantityForMetric(metric)} DESC
-            LIMIT ${cappedLimit}
+            ORDER BY ${rankingQuantityForMetric(metric)} DESC, dim ASC
+            LIMIT ${TOP_N_BREAKDOWN_PAGE_SIZE} OFFSET ${offset}
         `;
 
         try {
             const res = await this.client.query({
                 query: sql,
                 format: 'JSONEachRow',
+                ...(queryParams ? { query_params: queryParams } : {}),
                 clickhouse_settings: { max_execution_time: READ_QUERY_MAX_EXECUTION_SECONDS }
             });
             const rows = await res.json<{ dim: string }>();
@@ -517,7 +534,7 @@ export class Clickhouse {
                 ...tags,
                 success: 'true'
             });
-            return Ok({ accountId, metric, dimension, values: rows.map((r) => r.dim) });
+            return Ok({ accountId, metric, dimension, values: rows.map((r) => r.dim), hasMore: rows.length === TOP_N_BREAKDOWN_PAGE_SIZE });
         } catch (err) {
             metrics.distribution(metrics.Types.BILLING_USAGE_CLICKHOUSE_TOP_DIMENSION_VALUES_DURATION_MS, Number(process.hrtime.bigint() - queryStart) / 1e6, {
                 ...tags,

--- a/packages/usage/lib/clickhouse/clickhouse.ts
+++ b/packages/usage/lib/clickhouse/clickhouse.ts
@@ -474,7 +474,8 @@ export class Clickhouse {
      * UI. A `search` term filters to values whose string contains it
      * (case-insensitive substring), and `page` walks the long tail in pages of
      * `TOP_N_BREAKDOWN_PAGE_SIZE`, so any value is reachable — not just the
-     * first page. `hasMore` is a page-full heuristic (avoids a count query).
+     * first page. To set `hasMore` we fetch one extra row as a next-page
+     * sentinel (avoids a count query) and drop it from the returned values.
      */
     async getTopDimensionValues(query: GetTopDimensionValuesQuery): Promise<Result<GetTopDimensionValuesResult>> {
         if (!this.client) {
@@ -514,7 +515,7 @@ export class Clickhouse {
               ${searchClause}
             GROUP BY ${dimension}
             ORDER BY ${rankingQuantityForMetric(metric)} DESC, dim ASC
-            LIMIT ${TOP_N_BREAKDOWN_PAGE_SIZE} OFFSET ${offset}
+            LIMIT ${TOP_N_BREAKDOWN_PAGE_SIZE + 1} OFFSET ${offset}
         `;
 
         try {
@@ -529,7 +530,10 @@ export class Clickhouse {
                 ...tags,
                 success: 'true'
             });
-            return Ok({ accountId, metric, dimension, values: rows.map((r) => r.dim), hasMore: rows.length === TOP_N_BREAKDOWN_PAGE_SIZE });
+            // We fetched one row past the page; if it came back there's a next page — drop it here.
+            const hasMore = rows.length > TOP_N_BREAKDOWN_PAGE_SIZE;
+            const values = hasMore ? rows.slice(0, TOP_N_BREAKDOWN_PAGE_SIZE) : rows;
+            return Ok({ accountId, metric, dimension, values: values.map((r) => r.dim), hasMore });
         } catch (err) {
             metrics.distribution(metrics.Types.BILLING_USAGE_CLICKHOUSE_TOP_DIMENSION_VALUES_DURATION_MS, Number(process.hrtime.bigint() - queryStart) / 1e6, {
                 ...tags,

--- a/packages/usage/lib/index.ts
+++ b/packages/usage/lib/index.ts
@@ -14,7 +14,8 @@ export {
     COUNTER_METRICS,
     FILTER_PARAM_TYPE_FOR_DIM,
     TOP_N_BREAKDOWN_CAP,
-    TOP_N_BREAKDOWN_DEFAULT
+    TOP_N_BREAKDOWN_DEFAULT,
+    TOP_N_BREAKDOWN_PAGE_SIZE
 } from './clickhouse/clickhouse.query.js';
 export { clickhouseClient } from './clickhouse/config.js';
 export { migrate } from './clickhouse/migrate.js';

--- a/packages/usage/lib/usage.ts
+++ b/packages/usage/lib/usage.ts
@@ -66,7 +66,10 @@ export interface GetTopDimensionValuesParams {
     metric: UsageMetric;
     dimension: string;
     timeframe: { start: Date; end: Date };
-    limit: number;
+    // Case-insensitive substring match on the dimension value (empty → none).
+    search?: string | undefined;
+    // Zero-based page index; page size is fixed server-side.
+    page: number;
 }
 
 export class UsageTrackerNoOps implements IUsageTracker {
@@ -111,7 +114,7 @@ export class UsageTrackerNoOps implements IUsageTracker {
     }
 
     public async getTopDimensionValues(params: GetTopDimensionValuesParams): Promise<Result<GetTopDimensionValuesResult>> {
-        return Promise.resolve(Ok({ accountId: params.accountId, metric: params.metric, dimension: params.dimension, values: [] }));
+        return Promise.resolve(Ok({ accountId: params.accountId, metric: params.metric, dimension: params.dimension, values: [], hasMore: false }));
     }
 }
 

--- a/packages/webapp/src/components/patterns/FilterSelect.tsx
+++ b/packages/webapp/src/components/patterns/FilterSelect.tsx
@@ -62,6 +62,13 @@ interface FilterSelectProps {
      * Pass a predicate to decide per group — e.g. off for groups whose values are a fixed, fully-listed set.
      */
     allowCreate?: boolean | ((group: string) => boolean);
+    /**
+     * Whether a group's value pane shows a search box. Off for closed, fully-listed sets (e.g.
+     * Status, Environment) where the short list needs no filtering. Pass a predicate to decide per
+     * group. Defaults to true. Independent of `allowCreate` — a list can be searchable without
+     * accepting typed-but-unlisted values (e.g. when search already covers the full set).
+     */
+    searchable?: boolean | ((group: string) => boolean);
     searchPlaceholder?: string;
     /** Called when a group's pane opens — e.g. to prefetch. */
     onOpenGroup?: (group: string) => void;
@@ -94,6 +101,7 @@ const FilterValuePane: React.FC<{
     useGroupData: (group: string) => FilterSelectGroupData;
     selectedValue: string | null;
     allowCreate: boolean;
+    searchable: boolean;
     searchPlaceholder: string;
     /** Focus the search on mount — true only when the pane was opened via keyboard. */
     autoFocus: boolean;
@@ -102,7 +110,7 @@ const FilterValuePane: React.FC<{
     onBack: () => void;
     /** Esc: close the whole filter. */
     onCloseAll: () => void;
-}> = ({ anchor, group, useGroupData, selectedValue, allowCreate, searchPlaceholder, autoFocus, onSelect, onBack, onCloseAll }) => {
+}> = ({ anchor, group, useGroupData, selectedValue, allowCreate, searchable, searchPlaceholder, autoFocus, onSelect, onBack, onCloseAll }) => {
     const inputRef = useRef<HTMLInputElement>(null);
     const { options, isLoading, isError } = useGroupData(group);
     const [inputValue, setInputValue] = useState('');
@@ -126,10 +134,9 @@ const FilterValuePane: React.FC<{
     const items: PaneItem[] = showCreate ? [...matches, { value: trimmed, label: trimmed, isCreate: true }] : matches;
     const selectedOption = options.find((o) => o.value === selectedValue) ?? null;
 
-    // Groups that take no free text (a fixed, fully-listed set like Status or Environment) need no
-    // search box — just their short list. The input stays mounted but visually hidden so the
-    // combobox keeps driving keyboard navigation (arrows, Enter, ←/Esc) the same way.
-    const searchable = allowCreate;
+    // When `searchable` is false (a fixed, fully-listed set like Status or Environment) the pane
+    // shows just the short list. The input stays mounted but visually hidden (below) so the combobox
+    // keeps driving keyboard navigation (arrows, Enter, ←/Esc) the same way.
 
     return (
         <Combobox.Root
@@ -262,6 +269,7 @@ export const FilterSelect: React.FC<FilterSelectProps> = ({
     selectedValueFor,
     onSelect,
     allowCreate = false,
+    searchable = true,
     searchPlaceholder = 'Search…',
     onOpenGroup
 }) => {
@@ -345,6 +353,7 @@ export const FilterSelect: React.FC<FilterSelectProps> = ({
                                 useGroupData={useGroupData}
                                 selectedValue={selectedValueFor?.(openGroup) ?? null}
                                 allowCreate={typeof allowCreate === 'function' ? allowCreate(openGroup) : allowCreate}
+                                searchable={typeof searchable === 'function' ? searchable(openGroup) : searchable}
                                 searchPlaceholder={searchPlaceholder}
                                 autoFocus={openViaKeyboard}
                                 onSelect={(value) => {

--- a/packages/webapp/src/components/patterns/FilterSelect.tsx
+++ b/packages/webapp/src/components/patterns/FilterSelect.tsx
@@ -240,7 +240,10 @@ const FilterValuePane: React.FC<{
                                     <Combobox.Collection>
                                         {(item: PaneItem) => <ValueRow key={item.isCreate ? '__create' : item.value} item={item} />}
                                     </Combobox.Collection>
-                                    {!hasMatches && !showCreate && (
+                                    {/* Hold off on "No values" while a search is pending — the loaded list may not
+                                        match the term being typed yet, and flashing it before results land reads as
+                                        "nothing found". */}
+                                    {!hasMatches && !showCreate && !searching && (
                                         <div className="px-2 py-3 text-center text-text-muted text-body-small-regular">
                                             {isError ? 'Failed to load values' : 'No values'}
                                         </div>

--- a/packages/webapp/src/components/patterns/FilterSelect.tsx
+++ b/packages/webapp/src/components/patterns/FilterSelect.tsx
@@ -40,6 +40,10 @@ export interface FilterSelectGroupData {
     options: FilterSelectOption[];
     isLoading: boolean;
     isError: boolean;
+    // A background fetch is in flight while previous results stay shown (e.g. a debounced search
+    // refetch keeping prior data). Drives an inline spinner in the search box so typing has visible
+    // feedback. Distinct from `isLoading` (first load, blank list) — leave unset for sync data.
+    isFetching?: boolean;
     // Optional incremental paging for long value lists. When `fetchNextPage` is
     // provided, the value pane loads the next page as it nears the bottom on
     // scroll (and shows a spinner while `isFetchingNextPage`). Consumers that
@@ -130,7 +134,14 @@ const FilterValuePane: React.FC<{
     // server-backed `useGroupData` isn't re-queried on every keystroke; the pane's
     // own Base UI filtering still narrows the loaded list instantly as you type.
     const debouncedSearch = useDebouncedValue(inputValue.trim(), 300);
-    const { options, isLoading, isError, hasNextPage, isFetchingNextPage, fetchNextPage } = useGroupData(group, { search: debouncedSearch });
+    const { options, isLoading, isError, isFetching, hasNextPage, isFetchingNextPage, fetchNextPage } = useGroupData(group, { search: debouncedSearch });
+
+    // Show an inline search spinner from the moment the user types until fresh results land:
+    // first while the debounce hasn't caught up (input ahead of the term we've queried), then
+    // while that query is in flight. Excludes the first blank load (its own list spinner) and
+    // next-page fetches (their own bottom spinner).
+    const searchPending = inputValue.trim() !== debouncedSearch;
+    const searching = searchable && !isLoading && (searchPending || (Boolean(isFetching) && !isFetchingNextPage));
 
     // Load the next page as the list nears the bottom. A scroll-position check on the list
     // itself is used rather than an IntersectionObserver sentinel: the list is a short
@@ -195,28 +206,31 @@ const FilterValuePane: React.FC<{
                         onPointerLeave={() => inputRef.current?.blur()}
                         className="flex w-fit min-w-[14rem] max-w-[32rem] flex-col rounded border border-border-muted bg-surface-overlay p-1 text-text-secondary shadow-md outline-hidden"
                     >
-                        <Combobox.Input
-                            ref={inputRef}
-                            placeholder={searchPlaceholder}
-                            onKeyDown={(e) => {
-                                // Enter commits the highlighted item (a match or the create row) — Base UI
-                                // handles it via autoHighlight, so it isn't special-cased here.
-                                if (e.key === 'Escape') {
-                                    e.preventDefault();
-                                    e.stopPropagation();
-                                    onCloseAll();
-                                } else if (e.key === 'ArrowLeft' && e.currentTarget.selectionStart === 0 && e.currentTarget.selectionEnd === 0) {
-                                    // At the start of the input, ← steps back to the group list.
-                                    e.preventDefault();
-                                    onBack();
-                                }
-                            }}
-                            className={cn(
-                                searchable
-                                    ? 'mb-1 h-8 w-full rounded border-[0.5px] border-border-muted bg-surface-canvas px-2.5 text-body-medium-regular text-text-strong outline-none placeholder:text-text-muted'
-                                    : 'sr-only'
+                        <div className={cn('relative', !searchable && 'sr-only')}>
+                            <Combobox.Input
+                                ref={inputRef}
+                                placeholder={searchPlaceholder}
+                                onKeyDown={(e) => {
+                                    // Enter commits the highlighted item (a match or the create row) — Base UI
+                                    // handles it via autoHighlight, so it isn't special-cased here.
+                                    if (e.key === 'Escape') {
+                                        e.preventDefault();
+                                        e.stopPropagation();
+                                        onCloseAll();
+                                    } else if (e.key === 'ArrowLeft' && e.currentTarget.selectionStart === 0 && e.currentTarget.selectionEnd === 0) {
+                                        // At the start of the input, ← steps back to the group list.
+                                        e.preventDefault();
+                                        onBack();
+                                    }
+                                }}
+                                className="mb-1 h-8 w-full rounded border-[0.5px] border-border-muted bg-surface-canvas pr-8 pl-2.5 text-body-medium-regular text-text-strong outline-none placeholder:text-text-muted"
+                            />
+                            {searching && (
+                                <span className="pointer-events-none absolute top-0 right-2.5 flex h-8 items-center">
+                                    <Spinner className="size-3.5 text-text-muted" />
+                                </span>
                             )}
-                        />
+                        </div>
                         <Combobox.List className="max-h-[50vh] overflow-y-auto" onScroll={onListScroll}>
                             {isLoading ? (
                                 <div className="flex justify-center py-3">

--- a/packages/webapp/src/components/patterns/FilterSelect.tsx
+++ b/packages/webapp/src/components/patterns/FilterSelect.tsx
@@ -136,17 +136,13 @@ const FilterValuePane: React.FC<{
     const debouncedSearch = useDebouncedValue(inputValue.trim(), 300);
     const { options, isLoading, isError, isFetching, hasNextPage, isFetchingNextPage, fetchNextPage } = useGroupData(group, { search: debouncedSearch });
 
-    // Show an inline search spinner from the moment the user types until fresh results land:
-    // first while the debounce hasn't caught up (input ahead of the term we've queried), then
-    // while that query is in flight. Excludes the first blank load (its own list spinner) and
-    // next-page fetches (their own bottom spinner).
+    // Spinner in the search box while a search is pending — the debounce window (input ahead of the
+    // queried term) then the fetch — but not the first load or next-page (they have their own).
     const searchPending = inputValue.trim() !== debouncedSearch;
     const searching = searchable && !isLoading && (searchPending || (Boolean(isFetching) && !isFetchingNextPage));
 
-    // Load the next page as the list nears the bottom. A scroll-position check on the list
-    // itself is used rather than an IntersectionObserver sentinel: the list is a short
-    // overflow container inside a portalled popup, where a viewport-rooted observer never
-    // sees a bottom sentinel cross into view.
+    // Page when the list nears the bottom. A scroll-position check beats an IntersectionObserver
+    // sentinel here: in this short, portalled overflow pane a viewport-rooted observer never fires.
     const onListScroll = (e: React.UIEvent<HTMLDivElement>) => {
         if (!fetchNextPage || isFetchingNextPage || !hasNextPage) return;
         const el = e.currentTarget;
@@ -204,33 +200,36 @@ const FilterValuePane: React.FC<{
                         // leaves, so the search isn't held focused once you've moved off the pane.
                         onPointerEnter={() => inputRef.current?.focus()}
                         onPointerLeave={() => inputRef.current?.blur()}
-                        className="flex w-fit min-w-[14rem] max-w-[32rem] flex-col rounded border border-border-muted bg-surface-overlay p-1 text-text-secondary shadow-md outline-hidden"
+                        className="relative flex w-fit min-w-[14rem] max-w-[32rem] flex-col rounded border border-border-muted bg-surface-overlay p-1 text-text-secondary shadow-md outline-hidden"
                     >
-                        <div className={cn('relative', !searchable && 'sr-only')}>
-                            <Combobox.Input
-                                ref={inputRef}
-                                placeholder={searchPlaceholder}
-                                onKeyDown={(e) => {
-                                    // Enter commits the highlighted item (a match or the create row) — Base UI
-                                    // handles it via autoHighlight, so it isn't special-cased here.
-                                    if (e.key === 'Escape') {
-                                        e.preventDefault();
-                                        e.stopPropagation();
-                                        onCloseAll();
-                                    } else if (e.key === 'ArrowLeft' && e.currentTarget.selectionStart === 0 && e.currentTarget.selectionEnd === 0) {
-                                        // At the start of the input, ← steps back to the group list.
-                                        e.preventDefault();
-                                        onBack();
-                                    }
-                                }}
-                                className="mb-1 h-8 w-full rounded border-[0.5px] border-border-muted bg-surface-canvas pr-8 pl-2.5 text-body-medium-regular text-text-strong outline-none placeholder:text-text-muted"
-                            />
-                            {searching && (
-                                <span className="pointer-events-none absolute top-0 right-2.5 flex h-8 items-center">
-                                    <Spinner className="size-3.5 text-text-muted" />
-                                </span>
+                        <Combobox.Input
+                            ref={inputRef}
+                            placeholder={searchPlaceholder}
+                            onKeyDown={(e) => {
+                                // Enter commits the highlighted item (a match or the create row) — Base UI
+                                // handles it via autoHighlight, so it isn't special-cased here.
+                                if (e.key === 'Escape') {
+                                    e.preventDefault();
+                                    e.stopPropagation();
+                                    onCloseAll();
+                                } else if (e.key === 'ArrowLeft' && e.currentTarget.selectionStart === 0 && e.currentTarget.selectionEnd === 0) {
+                                    // At the start of the input, ← steps back to the group list.
+                                    e.preventDefault();
+                                    onBack();
+                                }
+                            }}
+                            className={cn(
+                                searchable
+                                    ? 'mb-1 h-8 w-full rounded border-[0.5px] border-border-muted bg-surface-canvas pr-8 pl-2.5 text-body-medium-regular text-text-strong outline-none placeholder:text-text-muted'
+                                    : 'sr-only'
                             )}
-                        </div>
+                        />
+                        {/* Search spinner, overlaid at the input's right (the popup is the positioning context). */}
+                        {searching && (
+                            <span className="pointer-events-none absolute top-1 right-2.5 flex h-8 items-center">
+                                <Spinner className="size-3.5 text-text-muted" />
+                            </span>
+                        )}
                         <Combobox.List className="max-h-[50vh] overflow-y-auto" onScroll={onListScroll}>
                             {isLoading ? (
                                 <div className="flex justify-center py-3">

--- a/packages/webapp/src/components/patterns/FilterSelect.tsx
+++ b/packages/webapp/src/components/patterns/FilterSelect.tsx
@@ -3,6 +3,7 @@ import { Check, ChevronRight } from 'lucide-react';
 import { forwardRef, useEffect, useRef, useState } from 'react';
 
 import { Spinner } from '@/components/ui/Spinner';
+import { useDebouncedValue } from '@/hooks/useDebouncedValue';
 import { cn } from '@/utils/utils';
 
 /**
@@ -39,6 +40,13 @@ export interface FilterSelectGroupData {
     options: FilterSelectOption[];
     isLoading: boolean;
     isError: boolean;
+    // Optional incremental paging for long value lists. When `fetchNextPage` is
+    // provided, the value pane loads the next page as it nears the bottom on
+    // scroll (and shows a spinner while `isFetchingNextPage`). Consumers that
+    // return their whole set at once leave these unset.
+    hasNextPage?: boolean;
+    isFetchingNextPage?: boolean;
+    fetchNextPage?: () => void;
 }
 
 /** A value-pane row: a real option, or the synthetic free-text "create" row appended after matches. */
@@ -52,8 +60,13 @@ interface FilterSelectProps {
     open: boolean;
     onOpenChange: (open: boolean) => void;
     groups: readonly FilterSelectGroup[];
-    /** Hook the value pane calls to load a group's options (mounts per open group). */
-    useGroupData: (group: string) => FilterSelectGroupData;
+    /**
+     * Hook the value pane calls to load a group's options (mounts per open group).
+     * Receives the pane's debounced `search` term so the consumer can filter the
+     * full set server-side; consumers that filter client-side can ignore it (the
+     * pane still narrows the loaded list by the live input).
+     */
+    useGroupData: (group: string, opts: { search: string }) => FilterSelectGroupData;
     /** The currently-applied value for a group, if any — drives the check next to the group. */
     selectedValueFor?: (group: string) => string | null;
     onSelect: (group: string, value: string) => void;
@@ -98,7 +111,7 @@ const ValueRow: React.FC<{ item: PaneItem }> = ({ item }) =>
 const FilterValuePane: React.FC<{
     anchor: React.RefObject<HTMLElement | null>;
     group: string;
-    useGroupData: (group: string) => FilterSelectGroupData;
+    useGroupData: (group: string, opts: { search: string }) => FilterSelectGroupData;
     selectedValue: string | null;
     allowCreate: boolean;
     searchable: boolean;
@@ -112,8 +125,22 @@ const FilterValuePane: React.FC<{
     onCloseAll: () => void;
 }> = ({ anchor, group, useGroupData, selectedValue, allowCreate, searchable, searchPlaceholder, autoFocus, onSelect, onBack, onCloseAll }) => {
     const inputRef = useRef<HTMLInputElement>(null);
-    const { options, isLoading, isError } = useGroupData(group);
     const [inputValue, setInputValue] = useState('');
+    // Debounce the typed term before handing it to the consumer's data hook so a
+    // server-backed `useGroupData` isn't re-queried on every keystroke; the pane's
+    // own Base UI filtering still narrows the loaded list instantly as you type.
+    const debouncedSearch = useDebouncedValue(inputValue.trim(), 300);
+    const { options, isLoading, isError, hasNextPage, isFetchingNextPage, fetchNextPage } = useGroupData(group, { search: debouncedSearch });
+
+    // Load the next page as the list nears the bottom. A scroll-position check on the list
+    // itself is used rather than an IntersectionObserver sentinel: the list is a short
+    // overflow container inside a portalled popup, where a viewport-rooted observer never
+    // sees a bottom sentinel cross into view.
+    const onListScroll = (e: React.UIEvent<HTMLDivElement>) => {
+        if (!fetchNextPage || isFetchingNextPage || !hasNextPage) return;
+        const el = e.currentTarget;
+        if (el.scrollTop + el.clientHeight >= el.scrollHeight - 120) fetchNextPage();
+    };
 
     // Focus the search only when opened via keyboard. On hover-open we defer to the popup's
     // onPointerEnter, so moving the cursor across the group list can't reset a filtered list.
@@ -190,7 +217,7 @@ const FilterValuePane: React.FC<{
                                     : 'sr-only'
                             )}
                         />
-                        <Combobox.List className="max-h-[50vh] overflow-y-auto">
+                        <Combobox.List className="max-h-[50vh] overflow-y-auto" onScroll={onListScroll}>
                             {isLoading ? (
                                 <div className="flex justify-center py-3">
                                     <Spinner />
@@ -203,6 +230,11 @@ const FilterValuePane: React.FC<{
                                     {!hasMatches && !showCreate && (
                                         <div className="px-2 py-3 text-center text-text-muted text-body-small-regular">
                                             {isError ? 'Failed to load values' : 'No values'}
+                                        </div>
+                                    )}
+                                    {isFetchingNextPage && (
+                                        <div className="flex justify-center py-2">
+                                            <Spinner />
                                         </div>
                                     )}
                                 </>

--- a/packages/webapp/src/hooks/usePlan.tsx
+++ b/packages/webapp/src/hooks/usePlan.tsx
@@ -248,8 +248,8 @@ function fetchTopDimensionValuesPage(
  * Seen values for a (metric, dimension) over a timeframe, ranked by usage and
  * paged so ANY value is reachable — `search` narrows to matching values across
  * the customer's full set (server-side), and pages load incrementally past the
- * first. Backs the filter typeahead; free-text entry remains a fallback for the
- * raw long tail. Lazy — only fires when `enabled` and a dimension is set.
+ * first. Backs the filter value picker. Lazy — only fires when `enabled` and a
+ * dimension is set.
  */
 export function useApiGetBillingUsageTopDimensionValues<M extends UsageMetric>(
     env: string,

--- a/packages/webapp/src/hooks/usePlan.tsx
+++ b/packages/webapp/src/hooks/usePlan.tsx
@@ -1,4 +1,4 @@
-import { queryOptions, useMutation, useQuery, useQueryClient } from '@tanstack/react-query';
+import { keepPreviousData, queryOptions, useInfiniteQuery, useMutation, useQuery, useQueryClient } from '@tanstack/react-query';
 import { useCallback, useMemo } from 'react';
 
 import { APIError, apiFetch } from '../utils/api';
@@ -17,6 +17,7 @@ import type {
     PutBillingInvoicingDetails,
     UsageMetric
 } from '@nangohq/types';
+import type { InfiniteData, QueryKey } from '@tanstack/react-query';
 
 export async function fetchCurrentPlan(env: string): Promise<GetPlan['Success']> {
     const res = await apiFetch(`/api/v1/plans/current?env=${env}`, { method: 'GET' });
@@ -206,25 +207,30 @@ export const GetBillingUsageTopDimensionValuesQueryKey = ['plans', 'billing-usag
 // reopening (or prefetching) the filter popover serves the cache instead of refetching.
 const TOP_DIMENSION_VALUES_STALE_TIME = 5 * 60 * 1000;
 
-function topDimensionValuesQueryKey(timeframe: { start: string; end: string } | undefined, metric: UsageMetric, dimension: string | null, limit: number) {
-    return [...GetBillingUsageTopDimensionValuesQueryKey, timeframe, metric, dimension, limit];
+// `search` is part of the key so each search term caches independently; `page`
+// is the infinite-query page param, not the key.
+function topDimensionValuesQueryKey(timeframe: { start: string; end: string } | undefined, metric: UsageMetric, dimension: string | null, search: string) {
+    return [...GetBillingUsageTopDimensionValuesQueryKey, timeframe, metric, dimension, search];
 }
 
-function fetchTopDimensionValues(
+function fetchTopDimensionValuesPage(
     env: string,
     metric: UsageMetric,
     dimension: string | null,
     timeframe: { start: string; end: string } | undefined,
-    limit: number
+    search: string
 ) {
-    return async (): Promise<GetBillingUsageTopDimensionValues['Success']> => {
-        const params = new URLSearchParams({ env, metric, limit: String(limit) });
+    return async ({ pageParam = 0 }: { pageParam?: number }): Promise<GetBillingUsageTopDimensionValues['Success']> => {
+        const params = new URLSearchParams({ env, metric, page: String(pageParam) });
         if (timeframe) {
             params.append('from', timeframe.start);
             params.append('to', timeframe.end);
         }
         if (dimension) {
             params.append('dimension', dimension);
+        }
+        if (search) {
+            params.append('search', search);
         }
 
         const res = await apiFetch(`/api/v1/plans/billing-usage/top-dimension-values?${params.toString()}`, { method: 'GET' });
@@ -239,52 +245,59 @@ function fetchTopDimensionValues(
 }
 
 /**
- * Top-N seen values for a (metric, dimension) over a timeframe, ranked by usage.
- * Backs the filter typeahead so a value can be picked even when it isn't a
- * visible breakdown slice (the long tail still needs free-text, since values
- * below the cap never appear here). Lazy — only fires when `enabled` and a
- * dimension is set.
+ * Seen values for a (metric, dimension) over a timeframe, ranked by usage and
+ * paged so ANY value is reachable — `search` narrows to matching values across
+ * the customer's full set (server-side), and pages load incrementally past the
+ * first. Backs the filter typeahead; free-text entry remains a fallback for the
+ * raw long tail. Lazy — only fires when `enabled` and a dimension is set.
  */
 export function useApiGetBillingUsageTopDimensionValues<M extends UsageMetric>(
     env: string,
     metric: M,
     dimension: BreakdownDimensions[M] | null,
     timeframe: { start: string; end: string } | undefined,
-    limit: number,
+    search: string,
     options?: { enabled?: boolean }
 ) {
-    return useQuery<GetBillingUsageTopDimensionValues['Success'], APIError>({
+    return useInfiniteQuery<
+        GetBillingUsageTopDimensionValues['Success'],
+        APIError,
+        InfiniteData<GetBillingUsageTopDimensionValues['Success']>,
+        QueryKey,
+        number
+    >({
         enabled: Boolean(env) && Boolean(timeframe) && Boolean(dimension) && (options?.enabled ?? true),
         staleTime: TOP_DIMENSION_VALUES_STALE_TIME,
-        queryKey: topDimensionValuesQueryKey(timeframe, metric, dimension, limit),
-        queryFn: fetchTopDimensionValues(env, metric, dimension, timeframe, limit)
+        queryKey: topDimensionValuesQueryKey(timeframe, metric, dimension, search),
+        queryFn: fetchTopDimensionValuesPage(env, metric, dimension, timeframe, search),
+        initialPageParam: 0,
+        getNextPageParam: (lastPage) => (lastPage.data.pagination.hasMore ? lastPage.data.pagination.page + 1 : undefined),
+        // Keep showing the previous pages while a new search term's first page loads, so the
+        // input doesn't unmount mid-keystroke and lose focus (see useGetIntegrationFunctions).
+        placeholderData: keepPreviousData
     });
 }
 
 /**
- * Returns a callback that warms the top-values cache for a set of dimensions. Call it when the
- * filter popover opens so picking a dimension shows its values instantly instead of spinning
- * through a fetch. No-ops per dimension while the cached values are still fresh.
+ * Returns a callback that warms the value cache (first page, no search) for a set of dimensions.
+ * Call it when the filter popover opens so picking a dimension shows its values instantly instead
+ * of spinning through a fetch. No-ops per dimension while the cached values are still fresh.
  */
-export function useApiPrefetchBillingUsageTopDimensionValues(
-    env: string,
-    metric: UsageMetric,
-    timeframe: { start: string; end: string } | undefined,
-    limit: number
-) {
+export function useApiPrefetchBillingUsageTopDimensionValues(env: string, metric: UsageMetric, timeframe: { start: string; end: string } | undefined) {
     const queryClient = useQueryClient();
     return useCallback(
         (dimensions: readonly string[]) => {
             if (!env || !timeframe) return;
             for (const dimension of dimensions) {
-                void queryClient.prefetchQuery({
+                void queryClient.prefetchInfiniteQuery({
                     staleTime: TOP_DIMENSION_VALUES_STALE_TIME,
-                    queryKey: topDimensionValuesQueryKey(timeframe, metric, dimension, limit),
-                    queryFn: fetchTopDimensionValues(env, metric, dimension, timeframe, limit)
+                    queryKey: topDimensionValuesQueryKey(timeframe, metric, dimension, ''),
+                    queryFn: fetchTopDimensionValuesPage(env, metric, dimension, timeframe, ''),
+                    initialPageParam: 0
                 });
             }
         },
-        [queryClient, env, metric, timeframe, limit]
+        [queryClient, env, metric, timeframe]
     );
 }
 

--- a/packages/webapp/src/pages/Team/Billing/components/BreakdownFilterControl.tsx
+++ b/packages/webapp/src/pages/Team/Billing/components/BreakdownFilterControl.tsx
@@ -89,26 +89,22 @@ export const BreakdownFilterControl: React.FC<BreakdownFilterControlProps> = ({
     // Warm every filterable dimension's first page when the menu opens, so each value pane shows instantly.
     const prefetchValues = useApiPrefetchBillingUsageTopDimensionValues(env, metric, timeframe);
 
-    // Loads one dimension's values for the FilterSelect's value pane. Called only from that pane,
-    // which mounts when (and remounts each time) a dimension opens — so it fetches lazily, and the
-    // prefetch above keeps the first page instant. `search` (debounced by the pane) hits ClickHouse
-    // so any value is reachable, and pages load on scroll. `environment_id` is the exception: its
-    // stored value is a numeric id, so a name search can't match server-side — its set is tiny, so
-    // we load it whole (no search/paging) and let the pane filter by label client-side.
+    // Loads one dimension's values for the FilterSelect value pane (mounted per open group, so it
+    // fetches lazily; the prefetch above keeps the first page instant). `search` (debounced by the
+    // pane) hits ClickHouse so any value is reachable, and pages load on scroll. Closed dimensions
+    // like environment_id aren't searchable, so they just get their small set back unfiltered.
     const useGroupData = (dimension: string, { search }: { search: string }): FilterSelectGroupData => {
         const dim = dimension as AnyBreakdownDimension;
-        const isEnv = dim === 'environment_id';
-        const query = useApiGetBillingUsageTopDimensionValues(env, metric, dim, timeframe, isEnv ? '' : search, { enabled: true });
+        const query = useApiGetBillingUsageTopDimensionValues(env, metric, dim, timeframe, search, { enabled: true });
         const options = (query.data?.pages.flatMap((p) => p.data.values) ?? []).map((v) => ({ value: v.id, label: formatDimensionValue(dim, v.label) }));
         return {
             options,
             isLoading: query.isLoading,
             isError: query.isError,
-            // env_id never searches server-side, so don't flag a fetch spinner for it.
-            isFetching: isEnv ? false : query.isFetching,
-            hasNextPage: isEnv ? false : query.hasNextPage,
+            isFetching: query.isFetching,
+            hasNextPage: query.hasNextPage,
             isFetchingNextPage: query.isFetchingNextPage,
-            fetchNextPage: isEnv ? undefined : query.fetchNextPage
+            fetchNextPage: query.fetchNextPage
         };
     };
 

--- a/packages/webapp/src/pages/Team/Billing/components/BreakdownFilterControl.tsx
+++ b/packages/webapp/src/pages/Team/Billing/components/BreakdownFilterControl.tsx
@@ -117,13 +117,12 @@ export const BreakdownFilterControl: React.FC<BreakdownFilterControlProps> = ({
         enabled: filterNeedsLabel
     });
     const filterLabelValues = filterLabelQuery.data?.pages.flatMap((p) => p.data.values) ?? null;
-    const filterLabel: string | null = !filter
-        ? ''
-        : filterNeedsLabel
-          ? filterLabelValues
-              ? (filterLabelValues.find((v) => v.id === filter.value)?.label ?? filter.value)
-              : null
-          : filter.value;
+    // Non-env dimensions already store a readable value. For environment_id, resolve the id to the
+    // env name once loaded; `null` means it's still loading, which renders a skeleton in the chip.
+    let filterLabel: string | null = filter ? filter.value : '';
+    if (filter && filterNeedsLabel) {
+        filterLabel = filterLabelValues ? (filterLabelValues.find((v) => v.id === filter.value)?.label ?? filter.value) : null;
+    }
 
     const filterTriggerButton = (
         <button type="button" className={cn(TRIGGER, filter ? 'pr-9' : 'pr-6')} title="Filter this metric to a single value">

--- a/packages/webapp/src/pages/Team/Billing/components/BreakdownFilterControl.tsx
+++ b/packages/webapp/src/pages/Team/Billing/components/BreakdownFilterControl.tsx
@@ -191,6 +191,7 @@ export const BreakdownFilterControl: React.FC<BreakdownFilterControlProps> = ({
                     selectedValueFor={(g) => (filter?.dimension === g ? filter.value : null)}
                     onSelect={(g, value) => onApplyFilter(g as AnyBreakdownDimension, value)}
                     allowCreate={(g) => allowsFreeTextFilter(g as AnyBreakdownDimension)}
+                    searchable={(g) => allowsFreeTextFilter(g as AnyBreakdownDimension)}
                 />
             </SlotTrigger>
         </div>

--- a/packages/webapp/src/pages/Team/Billing/components/BreakdownFilterControl.tsx
+++ b/packages/webapp/src/pages/Team/Billing/components/BreakdownFilterControl.tsx
@@ -104,6 +104,8 @@ export const BreakdownFilterControl: React.FC<BreakdownFilterControlProps> = ({
             options,
             isLoading: query.isLoading,
             isError: query.isError,
+            // env_id never searches server-side, so don't flag a fetch spinner for it.
+            isFetching: isEnv ? false : query.isFetching,
             hasNextPage: isEnv ? false : query.hasNextPage,
             isFetchingNextPage: query.isFetchingNextPage,
             fetchNextPage: isEnv ? undefined : query.fetchNextPage

--- a/packages/webapp/src/pages/Team/Billing/components/BreakdownFilterControl.tsx
+++ b/packages/webapp/src/pages/Team/Billing/components/BreakdownFilterControl.tsx
@@ -7,7 +7,7 @@ import { Skeleton } from '@/components/ui/Skeleton';
 import { Tooltip, TooltipContent, TooltipTrigger } from '@/components/ui/Tooltip';
 import { useApiGetBillingUsageTopDimensionValues, useApiPrefetchBillingUsageTopDimensionValues } from '@/hooks/usePlan';
 import { cn } from '@/utils/utils';
-import { allowsFreeTextFilter, DIMENSION_LABELS, FILTER_VALUES_TOP_N, formatDimensionValue } from '../usageBreakdown';
+import { DIMENSION_LABELS, formatDimensionValue, isSearchableDimension } from '../usageBreakdown';
 
 import type { AnyBreakdownDimension } from '../usageBreakdown';
 import type { FilterSelectGroupData } from '@/components/patterns/FilterSelect';
@@ -86,35 +86,46 @@ export const BreakdownFilterControl: React.FC<BreakdownFilterControlProps> = ({
 
     const filterGroups = dimensions.map((d) => ({ value: d, label: DIMENSION_LABELS[d] }));
 
-    // Warm every dimension's values when the menu opens so each value pane shows instantly.
-    const prefetchValues = useApiPrefetchBillingUsageTopDimensionValues(env, metric, timeframe, FILTER_VALUES_TOP_N);
+    // Warm every filterable dimension's first page when the menu opens, so each value pane shows instantly.
+    const prefetchValues = useApiPrefetchBillingUsageTopDimensionValues(env, metric, timeframe);
 
-    // Loads one dimension's values for a FilterSelect value pane. Called only from that pane, which
-    // mounts (and remounts) when a dimension opens — so it fetches lazily, kept instant by the prefetch.
-    const useGroupData = (dimension: string): FilterSelectGroupData => {
+    // Loads one dimension's values for the FilterSelect's value pane. Called only from that pane,
+    // which mounts when (and remounts each time) a dimension opens — so it fetches lazily, and the
+    // prefetch above keeps the first page instant. `search` (debounced by the pane) hits ClickHouse
+    // so any value is reachable, and pages load on scroll. `environment_id` is the exception: its
+    // stored value is a numeric id, so a name search can't match server-side — its set is tiny, so
+    // we load it whole (no search/paging) and let the pane filter by label client-side.
+    const useGroupData = (dimension: string, { search }: { search: string }): FilterSelectGroupData => {
         const dim = dimension as AnyBreakdownDimension;
-        const query = useApiGetBillingUsageTopDimensionValues(env, metric, dim, timeframe, FILTER_VALUES_TOP_N, { enabled: true });
-        const options = (query.data?.data.values ?? []).map((v) => ({ value: v.id, label: formatDimensionValue(dim, v.label) }));
-        return { options, isLoading: query.isLoading, isError: query.isError };
+        const isEnv = dim === 'environment_id';
+        const query = useApiGetBillingUsageTopDimensionValues(env, metric, dim, timeframe, isEnv ? '' : search, { enabled: true });
+        const options = (query.data?.pages.flatMap((p) => p.data.values) ?? []).map((v) => ({ value: v.id, label: formatDimensionValue(dim, v.label) }));
+        return {
+            options,
+            isLoading: query.isLoading,
+            isError: query.isError,
+            hasNextPage: isEnv ? false : query.hasNextPage,
+            isFetchingNextPage: query.isFetchingNextPage,
+            fetchNextPage: isEnv ? undefined : query.fetchNextPage
+        };
     };
 
-    // environment_id filters store the env id, so resolve it to a name via top-dimension-values
-    // (other dimensions store their own label). `null` = name not resolved yet → show a skeleton
-    // rather than flash the raw id; fall back to the id if it's outside the fetched top-N.
+    // Active-filter chip label. `top-dimension-values` is the id→label source for environment_id
+    // (e.g. 105 → "dev"); slug dims have id === label. `null` means the env name hasn't resolved
+    // yet — render a skeleton rather than flash the raw id, then show the name (or the id, if it's
+    // outside the fetched set).
     const filterNeedsLabel = filter?.dimension === 'environment_id';
-    const envLabelQuery = useApiGetBillingUsageTopDimensionValues(env, metric, filterNeedsLabel ? 'environment_id' : null, timeframe, FILTER_VALUES_TOP_N, {
+    const filterLabelQuery = useApiGetBillingUsageTopDimensionValues(env, metric, filterNeedsLabel ? 'environment_id' : null, timeframe, '', {
         enabled: filterNeedsLabel
     });
-    let filterLabel: string | null = '';
-    if (filter) {
-        if (!filterNeedsLabel) {
-            filterLabel = filter.value;
-        } else if (envLabelQuery.data) {
-            filterLabel = envLabelQuery.data.data.values.find((v) => v.id === filter.value)?.label ?? filter.value;
-        } else {
-            filterLabel = null;
-        }
-    }
+    const filterLabelValues = filterLabelQuery.data?.pages.flatMap((p) => p.data.values) ?? null;
+    const filterLabel: string | null = !filter
+        ? ''
+        : filterNeedsLabel
+          ? filterLabelValues
+              ? (filterLabelValues.find((v) => v.id === filter.value)?.label ?? filter.value)
+              : null
+          : filter.value;
 
     const filterTriggerButton = (
         <button type="button" className={cn(TRIGGER, filter ? 'pr-9' : 'pr-6')} title="Filter this metric to a single value">
@@ -190,8 +201,7 @@ export const BreakdownFilterControl: React.FC<BreakdownFilterControlProps> = ({
                     useGroupData={useGroupData}
                     selectedValueFor={(g) => (filter?.dimension === g ? filter.value : null)}
                     onSelect={(g, value) => onApplyFilter(g as AnyBreakdownDimension, value)}
-                    allowCreate={(g) => allowsFreeTextFilter(g as AnyBreakdownDimension)}
-                    searchable={(g) => allowsFreeTextFilter(g as AnyBreakdownDimension)}
+                    searchable={(g) => isSearchableDimension(g as AnyBreakdownDimension)}
                 />
             </SlotTrigger>
         </div>

--- a/packages/webapp/src/pages/Team/Billing/usageBreakdown.ts
+++ b/packages/webapp/src/pages/Team/Billing/usageBreakdown.ts
@@ -73,11 +73,12 @@ export function parseFilterParam(raw: string, allowed: readonly AnyBreakdownDime
 }
 
 /**
- * Dimensions whose values are a small, fully-listed, closed set — `environment_id` (a handful of
- * envs) and `success` (true/false). Their Filter value pane shows no search box; the rest are
- * open, high-cardinality id/name dimensions where server-side search earns its place.
+ * Dimensions whose values are a small, fully-listed, closed set, so their Filter value pane shows
+ * no search box: `environment_id` (a handful of envs), `success` (true/false), `function_type`
+ * (sync/action/webhook/…), and data-transfer `package` / `callsite` (a fixed handful each). The
+ * rest are open, high-cardinality id/name dimensions where server-side search earns its place.
  */
-const ENUMERATED_DIMENSIONS = new Set<AnyBreakdownDimension>(['environment_id', 'success']);
+const ENUMERATED_DIMENSIONS = new Set<AnyBreakdownDimension>(['environment_id', 'success', 'function_type', 'package', 'callsite']);
 
 /** Whether the Filter value pane shows a search box for this dimension. */
 export function isSearchableDimension(dimension: AnyBreakdownDimension): boolean {

--- a/packages/webapp/src/pages/Team/Billing/usageBreakdown.ts
+++ b/packages/webapp/src/pages/Team/Billing/usageBreakdown.ts
@@ -73,17 +73,14 @@ export function parseFilterParam(raw: string, allowed: readonly AnyBreakdownDime
 }
 
 /**
- * Dimensions whose filter values are a small, fully-listed, closed set, so the Filter typeahead
- * never needs free text: `environment_id` (a handful of envs, and the stored value is an id the
- * user can't type) and `success` (just true/false, shown as Success/Failed). Free text on these
- * could only commit a value the backend won't match — a name where it wants an id, or "succ"
- * where it wants "true" — silently yielding an empty chart. Open-ended id/name dimensions
- * (integration, connection, model, …) still allow free text to reach long-tail 'Rest' values.
+ * Dimensions whose values are a small, fully-listed, closed set — `environment_id` (a handful of
+ * envs) and `success` (true/false). Their Filter value pane shows no search box; the rest are
+ * open, high-cardinality id/name dimensions where server-side search earns its place.
  */
 const ENUMERATED_DIMENSIONS = new Set<AnyBreakdownDimension>(['environment_id', 'success']);
 
-/** Whether the Filter typeahead may commit a typed-but-unlisted value for this dimension. */
-export function allowsFreeTextFilter(dimension: AnyBreakdownDimension): boolean {
+/** Whether the Filter value pane shows a search box for this dimension. */
+export function isSearchableDimension(dimension: AnyBreakdownDimension): boolean {
     return !ENUMERATED_DIMENSIONS.has(dimension);
 }
 

--- a/packages/webapp/src/pages/Team/Billing/usageBreakdown.ts
+++ b/packages/webapp/src/pages/Team/Billing/usageBreakdown.ts
@@ -101,13 +101,6 @@ export function resolveBreakdownDimension(
 export const DEFAULT_TOP_N = 10;
 
 /**
- * How many values the Filter dropdown lists per dimension — more than the chart's top-N so more
- * are directly pickable (incl. ones in the chart's 'rest'). Matches the backend's TOP_N_BREAKDOWN_CAP;
- * the searchable, height-capped pane handles the length. Reaching beyond this is server-side search (NAN-6038).
- */
-export const FILTER_VALUES_TOP_N = 25;
-
-/**
  * Earliest month (UTC epoch ms) with ClickHouse granular data; the month picker is
  * floored here while the breakdown view is active. A primitive — not a shared `Date` —
  * so it can't be mutated by reference.

--- a/packages/webapp/src/pages/Team/Billing/usageBreakdown.unit.test.ts
+++ b/packages/webapp/src/pages/Team/Billing/usageBreakdown.unit.test.ts
@@ -4,6 +4,7 @@ import {
     BREAKDOWN_DIMENSIONS,
     DIMENSION_LABELS,
     formatDimensionValue,
+    isSearchableDimension,
     metricsSupportingDimension,
     parseFilterParam,
     resolveBreakdownDimension
@@ -81,6 +82,31 @@ describe('parseFilterParam', () => {
     it('returns null for a dimension the metric does not support', () => {
         // function_executions has no `model` dimension — e.g. a stale deep-link.
         expect(parseFilterParam('model:gpt-4o', allowed)).toBeNull();
+    });
+});
+
+describe('isSearchableDimension', () => {
+    it('is false for small, fully-listed enum dimensions (no search box)', () => {
+        for (const dim of ['environment_id', 'success', 'function_type', 'package', 'callsite'] as const) {
+            expect(isSearchableDimension(dim), `${dim} should not be searchable`).toBe(false);
+        }
+    });
+
+    it('is true for open, high-cardinality id/name dimensions', () => {
+        for (const dim of ['integration_id', 'connection_id', 'model', 'function_name'] as const) {
+            expect(isSearchableDimension(dim), `${dim} should be searchable`).toBe(true);
+        }
+    });
+
+    it('classifies every dimension referenced by any metric', () => {
+        // Guards against a new dimension silently defaulting to "searchable" without a deliberate choice.
+        const referenced = new Set<AnyBreakdownDimension>(Object.values(BREAKDOWN_DIMENSIONS).flat());
+        const open = new Set<AnyBreakdownDimension>(['integration_id', 'connection_id', 'model', 'function_name']);
+        const closed = new Set<AnyBreakdownDimension>(['environment_id', 'success', 'function_type', 'package', 'callsite']);
+        for (const dim of referenced) {
+            expect(open.has(dim) || closed.has(dim), `unclassified dimension "${dim}"`).toBe(true);
+            expect(isSearchableDimension(dim)).toBe(open.has(dim));
+        }
     });
 });
 

--- a/scripts/README.md
+++ b/scripts/README.md
@@ -20,8 +20,8 @@ One-off migrations live under `scripts/one-off/`, each with its own README.
 Populates the local ClickHouse `usage` database with synthetic usage events so the **Billing & usage** dashboard renders real-looking data locally — no deployed backend and no ingestion pipeline (metering/ActiveMQ) needed. See the header of [`seed-clickhouse.ts`](./seed-clickhouse.ts) for what it writes and how the materialized views aggregate it.
 
 ```bash
-npm run seed:clickhouse                          # reset + seed the last 30 days
-npm run seed:clickhouse -- --account 3 --days 60 # target one account, longer window
+npm run seed:clickhouse                          # reset + seed the last 60 days
+npm run seed:clickhouse -- --account 3 --days 90 # target one account, longer window
 npm run seed:clickhouse -- --no-reset            # append instead of dropping the DB first
 ```
 
@@ -51,4 +51,4 @@ The dataset is sized to exercise the breakdown filter combobox:
 - **20 integrations** with overlapping names (`github`/`gitlab`, `google-calendar`/`google-drive`/`gmail`, …) for partial-string **integration search**.
 - **Hundreds of connection UUIDs in prod** (dev holds ~10% as many), skewed like production (a few integrations have 60–150 connections, most have a handful) — far beyond the top-N breakdown cap (25) — for **connection pagination**. Connection ids are UUIDs, matching production.
 
-Events span every usage metric (proxy, function executions/logs/compute, webhook forwards, records, connections, data transfer) and every breakdown dimension, across 30 days. Mix mirrors reality: dev has ~10% as many connections as prod, so prod carries ~90% of traffic across every metric; the Connections/Sync-records metrics reflect the real connection counts; and proxy/webhook/function runs include failures, with the function failure rate fluctuating day to day (mostly healthy, occasional spikes up to ~20%) rather than a flat rate.
+Events span every usage metric (proxy, function executions/logs/compute, webhook forwards, records, connections, data transfer) and every breakdown dimension, across 60 days. Mix mirrors reality: dev has ~10% as many connections as prod, so prod carries ~90% of traffic across every metric; the Connections/Sync-records metrics reflect the real connection counts; and proxy/webhook/function runs include failures, with the function failure rate fluctuating day to day (mostly healthy, occasional spikes up to ~20%) rather than a flat rate.

--- a/scripts/seed-clickhouse.ts
+++ b/scripts/seed-clickhouse.ts
@@ -11,12 +11,13 @@
  *      endpoint returns `feature_disabled` without one (and FLAG_PLAN_ENABLED
  *      must be on; see .env).
  *   4. Inserts events into `raw_events` across every metric and breakdown
- *      dimension over the last N days. ClickHouse materialized views aggregate
- *      them into the daily_* tables the dashboard reads.
+ *      dimension over the last N days (default 60, enough to fill the dashboard's
+ *      month view when navigating to the previous month). ClickHouse materialized
+ *      views aggregate them into the daily_* tables the dashboard reads.
  *
  * Run from the repo root:
  *   npm run seed:clickhouse
- *   npm run seed:clickhouse -- --account 3 --days 60 --no-reset
+ *   npm run seed:clickhouse -- --account 3 --days 90 --no-reset
  *
  * Requires CLICKHOUSE_URL in .env and the clickhouse container up (npm run dev:docker).
  */
@@ -96,7 +97,10 @@ function parseArgs() {
     }
     return {
         onlyAccount: account !== undefined ? Number(account) : undefined,
-        days: days !== undefined ? Number(days) : 30,
+        // Default to 60 days so the dashboard's month view (1st → last day) is fully
+        // covered even when the current month is only a few days in — a 30-day window
+        // would leave the start of the previous month empty when you navigate back.
+        days: days !== undefined ? Number(days) : 60,
         reset: !argv.includes('--no-reset'),
         allowRemote: argv.includes('--allow-remote')
     };


### PR DESCRIPTION
## Problem

The usage breakdown filter (Team → Billing) only loaded the top-N values by volume (hard cap 25) and searched that in-memory list, so any value below the cap — a smaller integration, a specific connection, model, or function — was unreachable: searching showed "no matches" and there was no way to browse past the cap. The only workaround was typing the exact raw value as free text, which is awkward for opaque ids.

## Solution

- **Backend** — `top-dimension-values` gains an optional case-insensitive substring `search` (ClickHouse `positionCaseInsensitiveUTF8`, bound via query params) and an offset `page`; results stay volume-ordered with a `dim ASC` tie-break for stable paging and a page-full `hasMore` heuristic (no count query).
- **API change** — the endpoint drops the old `limit` param for a fixed server-side page size plus a zero-based `page`. With offset paging the picker only ever wants "the next page," so a caller-tunable `limit` added ambiguity (offset math depends on it) for no UX gain.
- **Pagination shape** — the response is `{ page, limit, hasMore }`, not the service's usual `{ total, … }`. Elsewhere `total` backs a visible count ("N functions/operations"); this picker is an infinite-scroll dropdown with no count, so a page-full `hasMore` gives the "load more?" signal directly and skips a `count(DISTINCT)` on high-cardinality dimensions.
- **Frontend** — the filter value pane (reusable `FilterSelect`) runs an infinite query: typing searches the customer's full set server-side (debounced), the list pages in on scroll, and an inline spinner shows while a fetch is in flight.
- **No free-text** — server search now surfaces every value that has data, so a typed-but-unlisted value could only ever yield an empty chart; the "Filter to '…'" row is gone.
- **Closed dimensions** — status, environment, function type, and data-transfer package/callsite show no search box (fixed enums).
- **`environment_id`** — keeps server-side id→name resolution, since `/api/v1/meta` exposes env names but not the numeric ids usage data keys on.
- **`FilterSelect`** — `searchable` is decoupled from `allowCreate`, so a list can be searchable without accepting typed values.

Fixes [NAN-6038](https://linear.app/nango/issue/NAN-6038)

## Demo

https://www.loom.com/share/0d56391e1f7942ef8ac0ce76ada8e75f

## Testing

- Integration: `getBillingUsageTopDimensionValues` (paging boundary + `hasMore`, case-insensitive search, no-match, `environment_id` applies search, equal-ranked tie-break is disjoint and complete) and the ClickHouse query path.
- Unit: `isSearchableDimension`. Storybook: `FilterSelect` paging / loading / search-in-flight states.
- Manual (local ClickHouse seed): on a metric's **Filter**, type to reach a value below the top page (Sync records → Model → `Sprint`; Function runs → Function name → `stripe`), scroll **Connection** to page through hundreds of values, and confirm closed dims (Status, Environment) have no search box.

