### PR TITLE
chore(server): Bump oauth2 access token length limit

### DIFF
--- a/packages/server/lib/helpers/validation.ts
+++ b/packages/server/lib/helpers/validation.ts
@@ -2,6 +2,8 @@ import * as z from 'zod';
 
 import { connectionTagsKeySchema, connectionTagsSchema, TAG_MAX_COUNT, validateCaseInsensitiveTagKeys } from '@nangohq/shared';
 
+import { envs } from '../env.js';
+
 export { TAG_MAX_COUNT, connectionTagsKeySchema, connectionTagsSchema };
 
 export const providerSchema = z
@@ -112,12 +114,9 @@ export const sharedCredentialsSchema = z
     })
     .strict();
 
-// MS Graph access tokens are JWTs that scale in size based on the number of scopes requested and can be multiple KBs. Size may need to be increased in the future.
-const OAUTH2_TOKEN_MAX_LENGTH = 16 * 1024;
-
 export const connectionCredentialsOauth2Schema = z.strictObject({
-    access_token: z.string().min(1).max(OAUTH2_TOKEN_MAX_LENGTH),
-    refresh_token: z.string().min(1).max(OAUTH2_TOKEN_MAX_LENGTH).optional(),
+    access_token: z.string().min(1).max(envs.NANGO_SERVER_OAUTH2_TOKEN_MAX_LENGTH),
+    refresh_token: z.string().min(1).max(envs.NANGO_SERVER_OAUTH2_TOKEN_MAX_LENGTH).optional(),
     expires_at: z.coerce.date().optional(),
     config_override: z
         .strictObject({

--- a/packages/server/lib/helpers/validation.ts
+++ b/packages/server/lib/helpers/validation.ts
@@ -112,9 +112,12 @@ export const sharedCredentialsSchema = z
     })
     .strict();
 
+// MS Graph access tokens are JWTs that scale in size based on the number of scopes requested and can be multiple KBs. Size may need to be increased in the future.
+const OAUTH2_TOKEN_MAX_LENGTH = 16 * 1024;
+
 export const connectionCredentialsOauth2Schema = z.strictObject({
-    access_token: z.string().min(1).max(4096),
-    refresh_token: z.string().min(1).max(4096).optional(),
+    access_token: z.string().min(1).max(OAUTH2_TOKEN_MAX_LENGTH),
+    refresh_token: z.string().min(1).max(OAUTH2_TOKEN_MAX_LENGTH).optional(),
     expires_at: z.coerce.date().optional(),
     config_override: z
         .strictObject({

--- a/packages/utils/lib/environment/parse.ts
+++ b/packages/utils/lib/environment/parse.ts
@@ -32,6 +32,12 @@ export const ENVS = z.object({
     NANGO_SERVER_WEBSOCKETS_PATH: z.string().optional(),
     NANGO_ADMIN_INVITE_TOKEN: z.string().optional(),
     NANGO_SERVER_PUBLIC_BODY_LIMIT: z.string().optional().default('75mb'),
+    NANGO_SERVER_OAUTH2_TOKEN_MAX_LENGTH: z.coerce
+        .number()
+        .int()
+        .positive()
+        .optional()
+        .default(16 * 1024),
     SERVER_SHUTDOWN_DELAY_MS: z.coerce.number().optional().default(0),
     SERVER_EGRESS_TELEMETRY_BATCH_SIZE: z.coerce.number().int().positive().default(1_000),
     SERVER_EGRESS_TELEMETRY_FLUSH_INTERVAL_MS: z.coerce.number().int().nonnegative().default(60_000),

--- a/packages/utils/lib/environment/parse.unit.test.ts
+++ b/packages/utils/lib/environment/parse.unit.test.ts
@@ -21,7 +21,7 @@ describe('parse', () => {
 
     it('should parse NANGO_OAUTH2_TOKEN_MAX_LENGTH', () => {
         expect(parseEnvs(ENVS, {}).NANGO_SERVER_OAUTH2_TOKEN_MAX_LENGTH).toBe(16 * 1024);
-        expect(parseEnvs(ENVS, { NANGO_OAUTH2_TOKEN_MAX_LENGTH: '32768' }).NANGO_SERVER_OAUTH2_TOKEN_MAX_LENGTH).toBe(32768);
+        expect(parseEnvs(ENVS, { NANGO_SERVER_OAUTH2_TOKEN_MAX_LENGTH: '32768' }).NANGO_SERVER_OAUTH2_TOKEN_MAX_LENGTH).toBe(32768);
     });
 
     it('should parse the sandbox compiler template', () => {

--- a/packages/utils/lib/environment/parse.unit.test.ts
+++ b/packages/utils/lib/environment/parse.unit.test.ts
@@ -19,7 +19,7 @@ describe('parse', () => {
         expect(res).toMatchObject({ NANGO_DB_SSL: false, NANGO_PERSIST_PORT: 3007 });
     });
 
-    it('should parse NANGO_OAUTH2_TOKEN_MAX_LENGTH', () => {
+    it('should parse NANGO_SERVER_OAUTH2_TOKEN_MAX_LENGTH', () => {
         expect(parseEnvs(ENVS, {}).NANGO_SERVER_OAUTH2_TOKEN_MAX_LENGTH).toBe(16 * 1024);
         expect(parseEnvs(ENVS, { NANGO_SERVER_OAUTH2_TOKEN_MAX_LENGTH: '32768' }).NANGO_SERVER_OAUTH2_TOKEN_MAX_LENGTH).toBe(32768);
     });

--- a/packages/utils/lib/environment/parse.unit.test.ts
+++ b/packages/utils/lib/environment/parse.unit.test.ts
@@ -19,11 +19,6 @@ describe('parse', () => {
         expect(res).toMatchObject({ NANGO_DB_SSL: false, NANGO_PERSIST_PORT: 3007 });
     });
 
-    it('should parse NANGO_SERVER_OAUTH2_TOKEN_MAX_LENGTH', () => {
-        expect(parseEnvs(ENVS, {}).NANGO_SERVER_OAUTH2_TOKEN_MAX_LENGTH).toBe(16 * 1024);
-        expect(parseEnvs(ENVS, { NANGO_SERVER_OAUTH2_TOKEN_MAX_LENGTH: '32768' }).NANGO_SERVER_OAUTH2_TOKEN_MAX_LENGTH).toBe(32768);
-    });
-
     it('should parse the sandbox compiler template', () => {
         const res = parseEnvs(ENVS, { E2B_SANDBOX_COMPILER_TEMPLATE: 'blank-workspace:dev' });
         expect(res.E2B_SANDBOX_COMPILER_TEMPLATE).toBe('blank-workspace:dev');

--- a/packages/utils/lib/environment/parse.unit.test.ts
+++ b/packages/utils/lib/environment/parse.unit.test.ts
@@ -19,6 +19,11 @@ describe('parse', () => {
         expect(res).toMatchObject({ NANGO_DB_SSL: false, NANGO_PERSIST_PORT: 3007 });
     });
 
+    it('should parse NANGO_OAUTH2_TOKEN_MAX_LENGTH', () => {
+        expect(parseEnvs(ENVS, {}).NANGO_SERVER_OAUTH2_TOKEN_MAX_LENGTH).toBe(16 * 1024);
+        expect(parseEnvs(ENVS, { NANGO_OAUTH2_TOKEN_MAX_LENGTH: '32768' }).NANGO_SERVER_OAUTH2_TOKEN_MAX_LENGTH).toBe(32768);
+    });
+
     it('should parse the sandbox compiler template', () => {
         const res = parseEnvs(ENVS, { E2B_SANDBOX_COMPILER_TEMPLATE: 'blank-workspace:dev' });
         expect(res.E2B_SANDBOX_COMPILER_TEMPLATE).toBe('blank-workspace:dev');


### PR DESCRIPTION
<!-- Describe the problem and your solution --> 
MS Graph access tokens (like delta tokens) are JWTs that scale in size and can be many KBs. Bumping here to unblock [#grw-revo](https://nangohq.slack.com/archives/C09TCKP2XFB/p1782427800819089) 

<!-- Issue ticket number and link (if applicable) -->
[NAN-6119: chore(server): Bump max credential length](https://linear.app/nango/issue/NAN-6119/choreserver-bump-max-credential-length)

<!-- Testing instructions (skip if just adding/editing providers) -->



<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/NangoHQ/nango/pull/6675?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

