### PR TITLE
feat: integrate feature flags across services

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -36722,6 +36722,7 @@
                 "@aws-sdk/client-s3": "3.993.0",
                 "@nangohq/billing": "file:../billing",
                 "@nangohq/database": "file:../database",
+                "@nangohq/feature-flags": "file:../feature-flags",
                 "@nangohq/kvstore": "file:../kvstore",
                 "@nangohq/pubsub": "file:../pubsub",
                 "@nangohq/records": "file:../records",
@@ -36824,6 +36825,7 @@
             "name": "@nangohq/nango-orchestrator",
             "version": "1.0.0",
             "dependencies": {
+                "@nangohq/feature-flags": "file:../feature-flags",
                 "@nangohq/kvstore": "file:../kvstore",
                 "@nangohq/scheduler": "file:../scheduler",
                 "@nangohq/utils": "file:../utils",
@@ -36854,6 +36856,7 @@
             "license": "SEE LICENSE IN LICENSE FILE IN GIT REPOSITORY",
             "dependencies": {
                 "@nangohq/database": "file:../database",
+                "@nangohq/feature-flags": "file:../feature-flags",
                 "@nangohq/kms": "file:../kms",
                 "@nangohq/kvstore": "file:../kvstore",
                 "@nangohq/logs": "file:../logs",

--- a/packages/feature-flags/lib/index.ts
+++ b/packages/feature-flags/lib/index.ts
@@ -139,6 +139,8 @@ export async function destroy(): Promise<void> {
             logger.info('Destroying feature flags client');
             const client = await promise;
             await client.destroy();
+        } catch (err) {
+            logger.error('Error destroying feature flags client', err);
         } finally {
             clientPromise = undefined;
             destroyPromise = undefined;

--- a/packages/feature-flags/lib/index.unit.test.ts
+++ b/packages/feature-flags/lib/index.unit.test.ts
@@ -340,4 +340,14 @@ describe('getFeatureFlagsClient', () => {
         unleashInstances[1]!.isEnabled.mockReturnValue(true);
         await expect(second.isEnabled('any-flag', {}, false)).resolves.toBe(true);
     });
+
+    it('swallows errors from client.destroy()', async () => {
+        mockEnvs.NANGO_FLAG_PROVIDER = 'unleash';
+        mockEnvs.NANGO_UNLEASH_URL = 'http://unleash.local:4242/api';
+        vi.resetModules();
+        const { getFeatureFlagsClient, destroy } = await import('./index.js');
+        const client = await getFeatureFlagsClient();
+        vi.spyOn(client, 'destroy').mockRejectedValue(new Error('destroy failed'));
+        await expect(destroy()).resolves.toBeUndefined();
+    });
 });

--- a/packages/metering/lib/app.ts
+++ b/packages/metering/lib/app.ts
@@ -78,11 +78,7 @@ try {
         if (clickhouseShutdown.isErr()) {
             logger.error('Error shutting down Clickhouse ingestion', clickhouseShutdown.error);
         }
-        try {
-            await destroyFeatureFlags();
-        } catch (err) {
-            logger.error('Error destroying feature flags', err);
-        }
+        await destroyFeatureFlags();
         cron.getTasks().forEach((task) => task.stop());
         process.exit();
     });

--- a/packages/metering/lib/app.ts
+++ b/packages/metering/lib/app.ts
@@ -78,7 +78,11 @@ try {
         if (clickhouseShutdown.isErr()) {
             logger.error('Error shutting down Clickhouse ingestion', clickhouseShutdown.error);
         }
-        await destroyFeatureFlags();
+        try {
+            await destroyFeatureFlags();
+        } catch (err) {
+            logger.error('Error destroying feature flags', err);
+        }
         cron.getTasks().forEach((task) => task.stop());
         process.exit();
     });

--- a/packages/metering/lib/app.ts
+++ b/packages/metering/lib/app.ts
@@ -3,6 +3,7 @@ import './tracer.js';
 import * as cron from 'node-cron';
 
 import { billing } from '@nangohq/billing';
+import { destroy as destroyFeatureFlags, initialize as initializeFeatureFlags } from '@nangohq/feature-flags';
 import { DefaultTransport } from '@nangohq/pubsub';
 import { Clickhouse, getUsageTracker, migrate as migrateUsage } from '@nangohq/usage';
 import { initSentry, once, report } from '@nangohq/utils';
@@ -27,6 +28,8 @@ try {
     });
 
     initSentry({ dsn: envs.SENTRY_DSN, applicationName: envs.NANGO_DB_APPLICATION_NAME, hash: envs.GIT_HASH });
+
+    await initializeFeatureFlags();
 
     // PubSub
     const pubsubTransport = new DefaultTransport();
@@ -75,6 +78,7 @@ try {
         if (clickhouseShutdown.isErr()) {
             logger.error('Error shutting down Clickhouse ingestion', clickhouseShutdown.error);
         }
+        await destroyFeatureFlags();
         cron.getTasks().forEach((task) => task.stop());
         process.exit();
     });

--- a/packages/metering/package.json
+++ b/packages/metering/package.json
@@ -17,6 +17,7 @@
         "@aws-sdk/client-s3": "3.993.0",
         "@nangohq/billing": "file:../billing",
         "@nangohq/database": "file:../database",
+        "@nangohq/feature-flags": "file:../feature-flags",
         "@nangohq/kvstore": "file:../kvstore",
         "@nangohq/pubsub": "file:../pubsub",
         "@nangohq/records": "file:../records",

--- a/packages/metering/tsconfig.json
+++ b/packages/metering/tsconfig.json
@@ -12,6 +12,9 @@
             "path": "../database"
         },
         {
+            "path": "../feature-flags"
+        },
+        {
             "path": "../kms"
         },
         {

--- a/packages/orchestrator/lib/app.ts
+++ b/packages/orchestrator/lib/app.ts
@@ -53,6 +53,11 @@ try {
         onError: async (err) => {
             report(err);
             logger.error(`Scheduler error: ${stringifyError(err)}`);
+            try {
+                await destroyFeatureFlags();
+            } catch (destroyErr) {
+                logger.error('Error destroying feature flags', destroyErr);
+            }
             await dbClient.destroy();
             logger.close();
 

--- a/packages/orchestrator/lib/app.ts
+++ b/packages/orchestrator/lib/app.ts
@@ -53,11 +53,7 @@ try {
         onError: async (err) => {
             report(err);
             logger.error(`Scheduler error: ${stringifyError(err)}`);
-            try {
-                await destroyFeatureFlags();
-            } catch (destroyErr) {
-                logger.error('Error destroying feature flags', destroyErr);
-            }
+            await destroyFeatureFlags();
             await dbClient.destroy();
             logger.close();
 

--- a/packages/orchestrator/lib/app.ts
+++ b/packages/orchestrator/lib/app.ts
@@ -1,5 +1,6 @@
 import './tracer.js';
 
+import { destroy as destroyFeatureFlags, initialize as initializeFeatureFlags } from '@nangohq/feature-flags';
 import { DatabaseClient, defaultDatabaseClientOptions, Scheduler } from '@nangohq/scheduler';
 import { initSentry, once, report, stringifyError } from '@nangohq/utils';
 
@@ -31,6 +32,8 @@ const databaseUrl =
     `postgres://${encodeURIComponent(envs.NANGO_DB_USER)}:${encodeURIComponent(envs.NANGO_DB_PASSWORD)}@${envs.NANGO_DB_HOST}:${envs.NANGO_DB_PORT}/${envs.NANGO_DB_NAME}`;
 
 try {
+    await initializeFeatureFlags();
+
     const dbClient = new DatabaseClient({
         ...defaultDatabaseClientOptions,
         url: databaseUrl,
@@ -91,6 +94,7 @@ try {
             await backpressureMonitor.stop();
             await scheduler.stop();
             await eventsHandler.disconnect();
+            await destroyFeatureFlags();
             await dbClient.destroy();
 
             logger.close();

--- a/packages/orchestrator/package.json
+++ b/packages/orchestrator/package.json
@@ -14,6 +14,7 @@
         "directory": "packages/orchestrator"
     },
     "dependencies": {
+        "@nangohq/feature-flags": "file:../feature-flags",
         "@nangohq/scheduler": "file:../scheduler",
         "@nangohq/utils": "file:../utils",
         "@nangohq/kvstore": "file:../kvstore",

--- a/packages/orchestrator/tsconfig.json
+++ b/packages/orchestrator/tsconfig.json
@@ -6,6 +6,9 @@
     },
     "references": [
         {
+            "path": "../feature-flags"
+        },
+        {
             "path": "../types"
         },
         {

--- a/packages/persist/lib/app.ts
+++ b/packages/persist/lib/app.ts
@@ -1,6 +1,7 @@
 import './tracer.js';
 
 import db from '@nangohq/database';
+import { destroy as destroyFeatureFlags, initialize as initializeFeatureFlags } from '@nangohq/feature-flags';
 import { destroy as destroyKvstore } from '@nangohq/kvstore';
 import { destroy as destroyLogs } from '@nangohq/logs';
 import { records } from '@nangohq/records';
@@ -36,6 +37,8 @@ const autoDeleting = autoDeletingDaemon();
 records.startDaemons();
 
 try {
+    await initializeFeatureFlags();
+
     const pubsubConnect = await pubsub.connect();
     if (pubsubConnect.isErr()) {
         logger.error(`PubSub: Failed to connect to transport: ${pubsubConnect.error.message}`);
@@ -57,6 +60,7 @@ const close = once(() => {
     api.close(async () => {
         await autoPruning.abort();
         await autoDeleting.abort();
+        await destroyFeatureFlags();
         await destroyLogs();
         await db.knex.destroy();
         await db.readOnly.destroy();

--- a/packages/persist/package.json
+++ b/packages/persist/package.json
@@ -19,6 +19,7 @@
     "license": "SEE LICENSE IN LICENSE FILE IN GIT REPOSITORY",
     "dependencies": {
         "@nangohq/database": "file:../database",
+        "@nangohq/feature-flags": "file:../feature-flags",
         "@nangohq/kvstore": "file:../kvstore",
         "@nangohq/kms": "file:../kms",
         "@nangohq/logs": "file:../logs",

--- a/packages/persist/tsconfig.json
+++ b/packages/persist/tsconfig.json
@@ -12,6 +12,9 @@
             "path": "../database"
         },
         {
+            "path": "../feature-flags"
+        },
+        {
             "path": "../kms"
         },
         {


### PR DESCRIPTION
Added the `@nangohq/feature-flags` dependency and integrated its initialization and destruction in the `app.ts` files of the `metering`, `orchestrator`, and `persist` packages. Updated relevant `package.json` and `tsconfig.json` files to include the new dependency and its path references.

<!-- Describe the problem and your solution --> 

<!-- Issue ticket number and link (if applicable) -->

<!-- Testing instructions (skip if just adding/editing providers) -->



<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/NangoHQ/nango/pull/6677?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

