### PR TITLE
fix(providers): ModMed API Key incorrectly expects UUID formatting

### DIFF
--- a/packages/providers/providers.yaml
+++ b/packages/providers/providers.yaml
@@ -13288,7 +13288,6 @@ modmed:
             title: API Key
             description: Your API key (x-api-key)
             secret: true
-            format: uuid
             example: a1b2c3d4-e5f6-47a8-9b0c-d1234567890f
             doc_section: '#step-1-request-access-to-modmed-sandbox'
 


### PR DESCRIPTION
<!-- Describe the problem and your solution --> 
See title

<!-- Issue ticket number and link (if applicable) -->
[NAN-6125: fix(providers): ModMed API Key is not UUID](https://linear.app/nango/issue/NAN-6125/fixproviders-modmed-api-key-is-not-uuid)

<!-- Testing instructions (skip if just adding/editing providers) -->



<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/NangoHQ/nango/pull/6678?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

