### PR TITLE
feat(server/webapp): show function code

### DIFF
--- a/packages/server/lib/controllers/integrations/uniqueKey/functions/getCode.ts
+++ b/packages/server/lib/controllers/integrations/uniqueKey/functions/getCode.ts
@@ -1,46 +1,12 @@
-import fs from 'node:fs';
-import path from 'node:path';
-
 import * as z from 'zod';
 
-import { configService, getSyncAndActionConfigsBySyncNameAndConfigId, localFileService, onEventScriptService, remoteFileService } from '@nangohq/shared';
-import { report, useS3, zodErrorToHTTP } from '@nangohq/utils';
+import { zodErrorToHTTP } from '@nangohq/utils';
 
-import { providerConfigKeySchema, scriptNameSchema } from '../../../../helpers/validation.js';
+import { functionTypeSchema, providerConfigKeySchema, scriptNameSchema } from '../../../../helpers/validation.js';
 import { asyncWrapper } from '../../../../utils/asyncWrapper.js';
+import { handleGetFunctionCode } from '../../../v1/integrations/providerConfigKey/functions/helpers.js';
 
-import type { GetPublicFunctionCode, ScriptTypeLiteral } from '@nangohq/types';
-
-const scriptTypeToFolder: Record<ScriptTypeLiteral, 'syncs' | 'actions' | 'on-events'> = {
-    sync: 'syncs',
-    action: 'actions',
-    'on-event': 'on-events'
-};
-
-interface FunctionMatch {
-    type: ScriptTypeLiteral;
-    name: string;
-    fileLocation: string;
-}
-
-async function getFunctionTsCode({ match, providerConfigKey }: { match: FunctionMatch; providerConfigKey: string }): Promise<string | null> {
-    if (!useS3) {
-        const fileName = `${providerConfigKey}/${scriptTypeToFolder[match.type]}/${match.name}.ts`;
-        const check = localFileService.checkForIntegrationSourceFile(fileName);
-        if (!check.result) {
-            return null;
-        }
-        return await fs.promises.readFile(check.path, 'utf8');
-    }
-
-    const dir = path.dirname(match.fileLocation);
-    try {
-        return await remoteFileService.getFile(`${dir}/${match.name}.ts`);
-    } catch (err) {
-        report(err, { providerConfigKey, scriptName: match.name, scriptType: match.type });
-        return null;
-    }
-}
+import type { GetPublicFunctionCode } from '@nangohq/types';
 
 const validationParams = z
     .object({
@@ -51,7 +17,7 @@ const validationParams = z
 
 const validationQuery = z
     .object({
-        type: z.enum(['sync', 'action', 'on-event']).optional()
+        type: functionTypeSchema.optional()
     })
     .strict();
 
@@ -72,45 +38,5 @@ export const getFunctionCode = asyncWrapper<GetPublicFunctionCode>(async (req, r
     const { type } = valQuery.data;
     const { environment } = res.locals;
 
-    const providerConfig = await configService.getProviderConfig(uniqueKey, environment.id);
-    if (!providerConfig || !providerConfig.id) {
-        res.status(404).send({ error: { code: 'not_found', message: `Integration '${uniqueKey}' not found` } });
-        return;
-    }
-
-    const syncConfigMatches = type === 'on-event' ? [] : await getSyncAndActionConfigsBySyncNameAndConfigId(environment.id, providerConfig.id, name);
-    const onEventMatches = type && type !== 'on-event' ? [] : await onEventScriptService.getByConfigAndName(providerConfig.id, name);
-
-    const matches: FunctionMatch[] = [
-        ...syncConfigMatches.map((c) => ({ type: c.type, name: c.sync_name, fileLocation: c.file_location })),
-        // Multiple on-event rows can share a name (different events) but point to the same TS file, so collapse to one match.
-        ...(onEventMatches.length > 0 ? [{ type: 'on-event' as const, name: onEventMatches[0]!.name, fileLocation: onEventMatches[0]!.fileLocation }] : [])
-    ];
-
-    const filtered = type ? matches.filter((m) => m.type === type) : matches;
-
-    if (filtered.length > 1) {
-        res.status(409).send({
-            error: {
-                code: 'ambiguous_function',
-                message: `Multiple functions named '${name}' found for integration '${uniqueKey}'. Specify a type to disambiguate.`,
-                payload: { matches: filtered.map((m) => ({ type: m.type, name: m.name })) }
-            }
-        });
-        return;
-    }
-
-    const match = filtered[0];
-    if (!match) {
-        res.status(404).send({ error: { code: 'not_found', message: `Function '${name}' not found for integration '${uniqueKey}'` } });
-        return;
-    }
-
-    const code = await getFunctionTsCode({ match, providerConfigKey: uniqueKey });
-    if (code === null) {
-        res.status(404).send({ error: { code: 'not_found', message: `Source file for '${name}' not found` } });
-        return;
-    }
-
-    res.status(200).send({ type: match.type, code });
+    await handleGetFunctionCode({ res, environment, providerConfigKey: uniqueKey, name, type });
 });

--- a/packages/server/lib/controllers/v1/integrations/providerConfigKey/functions/getCode.integration.test.ts
+++ b/packages/server/lib/controllers/v1/integrations/providerConfigKey/functions/getCode.integration.test.ts
@@ -1,0 +1,188 @@
+import { afterAll, beforeAll, describe, expect, it } from 'vitest';
+
+import db from '@nangohq/database';
+import { seeders } from '@nangohq/shared';
+
+import { isError, runServer, shouldBeProtected, shouldRequireQueryEnv } from '../../../../../utils/tests.js';
+
+import type { DBOnEventScript, DBSyncConfig } from '@nangohq/types';
+
+let api: Awaited<ReturnType<typeof runServer>>;
+
+const route = '/api/v1/integrations/:providerConfigKey/functions/:functionName/code';
+
+async function insertSyncConfig({
+    environment_id,
+    nango_config_id,
+    sync_name,
+    type
+}: {
+    environment_id: number;
+    nango_config_id: number;
+    sync_name: string;
+    type: 'sync' | 'action' | 'on-event';
+}) {
+    const now = new Date();
+    await db.knex.from<DBSyncConfig>('_nango_sync_configs').insert({
+        environment_id,
+        sync_name,
+        type,
+        file_location: 'file_location',
+        nango_config_id,
+        version: '0.0.0',
+        source: 'repo',
+        active: true,
+        runs: 'runs',
+        track_deletes: false,
+        auto_start: false,
+        webhook_subscriptions: [],
+        enabled: true,
+        created_at: now,
+        updated_at: now,
+        models: []
+    });
+}
+
+async function insertOnEventScript({ config_id, name }: { config_id: number; name: string }) {
+    const now = new Date();
+    await db.knex.from<DBOnEventScript>('on_event_scripts').insert({
+        config_id,
+        name,
+        file_location: 'file_location',
+        version: '0.0.0',
+        active: true,
+        event: 'POST_CONNECTION_CREATION',
+        sdk_version: null,
+        created_at: now,
+        updated_at: now
+    });
+}
+
+describe(`GET ${route}`, () => {
+    beforeAll(async () => {
+        api = await runServer();
+    });
+
+    afterAll(() => {
+        api.server.close();
+    });
+
+    it('should be protected', async () => {
+        const res = await api.fetch(route, {
+            method: 'GET',
+            query: { env: 'dev' },
+            params: { providerConfigKey: 'github', functionName: 'get-issues' }
+        });
+
+        shouldBeProtected(res);
+    });
+
+    it('should enforce env query params', async () => {
+        const { apiKey } = await seeders.seedAccountEnvAndUser();
+        const res = await api.fetch(
+            route,
+            // @ts-expect-error missing query on purpose
+            { method: 'GET', token: apiKey.secret, params: { providerConfigKey: 'github', functionName: 'get-issues' } }
+        );
+
+        shouldRequireQueryEnv(res);
+    });
+
+    it('returns 404 when integration is not found', async () => {
+        const { apiKey } = await seeders.seedAccountEnvAndUser();
+
+        const res = await api.fetch(route, {
+            method: 'GET',
+            token: apiKey.secret,
+            query: { env: 'dev' },
+            params: { providerConfigKey: 'missing', functionName: 'get-issues' }
+        });
+
+        expect(res.res.status).toBe(404);
+        isError(res.json);
+        expect(res.json.error.code).toBe('not_found');
+    });
+
+    it('returns 404 when function name does not exist for the integration', async () => {
+        const { env, apiKey } = await seeders.seedAccountEnvAndUser();
+        await seeders.createConfigSeed(env, 'github', 'github');
+
+        const res = await api.fetch(route, {
+            method: 'GET',
+            token: apiKey.secret,
+            query: { env: 'dev' },
+            params: { providerConfigKey: 'github', functionName: 'missing-function' }
+        });
+
+        expect(res.res.status).toBe(404);
+        isError(res.json);
+        expect(res.json.error.code).toBe('not_found');
+    });
+
+    it('returns 409 ambiguous_function when sync and action share a name', async () => {
+        const { env, apiKey } = await seeders.seedAccountEnvAndUser();
+        const config = await seeders.createConfigSeed(env, 'github', 'github');
+
+        await insertSyncConfig({ environment_id: env.id, nango_config_id: config.id!, sync_name: 'shared-name', type: 'sync' });
+        await insertSyncConfig({ environment_id: env.id, nango_config_id: config.id!, sync_name: 'shared-name', type: 'action' });
+
+        const res = await api.fetch(route, {
+            method: 'GET',
+            token: apiKey.secret,
+            query: { env: 'dev' },
+            params: { providerConfigKey: 'github', functionName: 'shared-name' }
+        });
+
+        expect(res.res.status).toBe(409);
+        isError(res.json);
+        expect(res.json.error.code).toBe('ambiguous_function');
+        expect(res.json.error.payload).toStrictEqual({
+            matches: expect.arrayContaining([
+                { type: 'sync', name: 'shared-name' },
+                { type: 'action', name: 'shared-name' }
+            ])
+        });
+    });
+
+    it('disambiguates with type and returns the matching function', async () => {
+        const { env, apiKey } = await seeders.seedAccountEnvAndUser();
+        const config = await seeders.createConfigSeed(env, 'github', 'github');
+
+        await insertSyncConfig({ environment_id: env.id, nango_config_id: config.id!, sync_name: 'shared-name', type: 'sync' });
+        await insertSyncConfig({ environment_id: env.id, nango_config_id: config.id!, sync_name: 'shared-name', type: 'action' });
+
+        // With type the resolver picks the right config; the source file lookup
+        // will 404 in tests (no fixture on disk), but it must NOT be 409.
+        const res = await api.fetch(route, {
+            method: 'GET',
+            token: apiKey.secret,
+            query: { env: 'dev', type: 'sync' },
+            params: { providerConfigKey: 'github', functionName: 'shared-name' }
+        });
+
+        expect(res.res.status).toBe(404);
+        isError(res.json);
+        expect(res.json.error.code).toBe('not_found');
+        expect(res.json.error.message).toContain('Source file');
+    });
+
+    it('finds an on-event script deployed to the environment', async () => {
+        const { env, apiKey } = await seeders.seedAccountEnvAndUser();
+        const config = await seeders.createConfigSeed(env, 'github', 'github');
+        await insertOnEventScript({ config_id: config.id!, name: 'test-script' });
+
+        // The source file lookup will 404 (no fixture on disk), but it must reach the file lookup —
+        // i.e. NOT 404 with a 'Function ... not found' message.
+        const res = await api.fetch(route, {
+            method: 'GET',
+            token: apiKey.secret,
+            query: { env: 'dev', type: 'on-event' },
+            params: { providerConfigKey: 'github', functionName: 'test-script' }
+        });
+
+        expect(res.res.status).toBe(404);
+        isError(res.json);
+        expect(res.json.error.code).toBe('not_found');
+        expect(res.json.error.message).toContain('Source file');
+    });
+});

--- a/packages/server/lib/controllers/v1/integrations/providerConfigKey/functions/getCode.ts
+++ b/packages/server/lib/controllers/v1/integrations/providerConfigKey/functions/getCode.ts
@@ -1,0 +1,43 @@
+import * as z from 'zod';
+
+import { zodErrorToHTTP } from '@nangohq/utils';
+
+import { envSchema, functionTypeSchema, providerConfigKeySchema } from '../../../../../helpers/validation.js';
+import { asyncWrapper } from '../../../../../utils/asyncWrapper.js';
+import { handleGetFunctionCode } from './helpers.js';
+
+import type { GetFunctionCode } from '@nangohq/types';
+
+const querystringValidation = z
+    .object({
+        env: envSchema,
+        type: functionTypeSchema.optional()
+    })
+    .strict();
+
+const paramsValidation = z
+    .object({
+        providerConfigKey: providerConfigKeySchema,
+        functionName: z.string().min(1).max(255)
+    })
+    .strict();
+
+export const getIntegrationFunctionCode = asyncWrapper<GetFunctionCode>(async (req, res) => {
+    const queryStringValues = querystringValidation.safeParse(req.query);
+    if (!queryStringValues.success) {
+        res.status(400).send({ error: { code: 'invalid_query_params', errors: zodErrorToHTTP(queryStringValues.error) } });
+        return;
+    }
+
+    const valParams = paramsValidation.safeParse(req.params);
+    if (!valParams.success) {
+        res.status(400).send({ error: { code: 'invalid_uri_params', errors: zodErrorToHTTP(valParams.error) } });
+        return;
+    }
+
+    const { environment } = res.locals;
+    const { providerConfigKey, functionName } = valParams.data;
+    const { type } = queryStringValues.data;
+
+    await handleGetFunctionCode({ res, environment, providerConfigKey, name: functionName, type });
+});

--- a/packages/server/lib/controllers/v1/integrations/providerConfigKey/functions/helpers.ts
+++ b/packages/server/lib/controllers/v1/integrations/providerConfigKey/functions/helpers.ts
@@ -1,11 +1,61 @@
-import { configService, getFunction, listFunctions } from '@nangohq/shared';
-import { report } from '@nangohq/utils';
+import fs from 'node:fs';
+import path from 'node:path';
+
+import {
+    configService,
+    getFunction,
+    getSyncAndActionConfigsBySyncNameAndConfigId,
+    listFunctions,
+    localFileService,
+    onEventScriptService,
+    remoteFileService
+} from '@nangohq/shared';
+import { report, useS3 } from '@nangohq/utils';
 
 import { startFunctionDeletion } from '../../../../../tasks/startFunctionDeletion.js';
 
 import type { RequestLocals } from '../../../../../utils/express.js';
-import type { DBEnvironment, DeleteIntegrationFunction, FunctionType, GetIntegrationFunction, GetIntegrationFunctions } from '@nangohq/types';
+import type {
+    DBEnvironment,
+    DeleteIntegrationFunction,
+    FunctionType,
+    GetFunctionCode,
+    GetIntegrationFunction,
+    GetIntegrationFunctions,
+    ScriptTypeLiteral
+} from '@nangohq/types';
 import type { Response } from 'express';
+
+const scriptTypeToFolder: Record<ScriptTypeLiteral, 'syncs' | 'actions' | 'on-events'> = {
+    sync: 'syncs',
+    action: 'actions',
+    'on-event': 'on-events'
+};
+
+interface FunctionMatch {
+    type: ScriptTypeLiteral;
+    name: string;
+    fileLocation: string;
+}
+
+async function getFunctionTsCode({ match, providerConfigKey }: { match: FunctionMatch; providerConfigKey: string }): Promise<string | null> {
+    if (!useS3) {
+        const fileName = `${providerConfigKey}/${scriptTypeToFolder[match.type]}/${match.name}.ts`;
+        const check = localFileService.checkForIntegrationSourceFile(fileName);
+        if (!check.result) {
+            return null;
+        }
+        return await fs.promises.readFile(check.path, 'utf8');
+    }
+
+    const dir = path.dirname(match.fileLocation);
+    try {
+        return await remoteFileService.getFile(`${dir}/${match.name}.ts`);
+    } catch (err) {
+        report(err, { providerConfigKey, scriptName: match.name, scriptType: match.type });
+        return null;
+    }
+}
 
 export async function handleGetIntegrationFunction({
     res,
@@ -140,4 +190,60 @@ export async function handleDeleteIntegrationFunction({
     }
 
     res.status(200).send({ data: { success: true } });
+}
+
+export async function handleGetFunctionCode({
+    res,
+    environment,
+    providerConfigKey,
+    name,
+    type
+}: {
+    res: Response<GetFunctionCode['Reply'], Required<RequestLocals>>;
+    environment: DBEnvironment;
+    providerConfigKey: string;
+    name: string;
+    type: ScriptTypeLiteral | undefined;
+}): Promise<void> {
+    const providerConfig = await configService.getProviderConfig(providerConfigKey, environment.id);
+    if (!providerConfig || !providerConfig.id) {
+        res.status(404).send({ error: { code: 'not_found', message: `Integration '${providerConfigKey}' not found` } });
+        return;
+    }
+
+    const syncConfigMatches = type === 'on-event' ? [] : await getSyncAndActionConfigsBySyncNameAndConfigId(environment.id, providerConfig.id, name);
+    const onEventMatches = type && type !== 'on-event' ? [] : await onEventScriptService.getByConfigAndName(providerConfig.id, name);
+
+    const matches: FunctionMatch[] = [
+        ...syncConfigMatches.map((c) => ({ type: c.type, name: c.sync_name, fileLocation: c.file_location })),
+        // Multiple on-event rows can share a name (different events) but point to the same TS file, so collapse to one match.
+        ...(onEventMatches.length > 0 ? [{ type: 'on-event' as const, name: onEventMatches[0]!.name, fileLocation: onEventMatches[0]!.fileLocation }] : [])
+    ];
+
+    const filtered = type ? matches.filter((m) => m.type === type) : matches;
+
+    if (filtered.length > 1) {
+        res.status(409).send({
+            error: {
+                code: 'ambiguous_function',
+                message: `Multiple functions named '${name}' found for integration '${providerConfigKey}'. Specify a type to disambiguate.`,
+                payload: { matches: filtered.map((m) => ({ type: m.type, name: m.name })) }
+            }
+        });
+        return;
+    }
+
+    const match = filtered[0];
+    if (!match) {
+        res.status(404).send({ error: { code: 'not_found', message: `Function '${name}' not found for integration '${providerConfigKey}'` } });
+        return;
+    }
+
+    const code = await getFunctionTsCode({ match, providerConfigKey });
+    if (code === null) {
+        res.status(404).send({ error: { code: 'not_found', message: `Source file for '${name}' not found` } });
+        return;
+    }
+
+    res.status(200).send({ type: match.type, code });
 }

--- a/packages/server/lib/routes.private.ts
+++ b/packages/server/lib/routes.private.ts
@@ -66,6 +66,7 @@ import { postIntegration } from './controllers/v1/integrations/postIntegration.j
 import { deleteIntegration } from './controllers/v1/integrations/providerConfigKey/deleteIntegration.js';
 import { getIntegrationFlows } from './controllers/v1/integrations/providerConfigKey/flows/getFlows.js';
 import { deleteIntegrationFunction } from './controllers/v1/integrations/providerConfigKey/functions/deleteFunction.js';
+import { getIntegrationFunctionCode } from './controllers/v1/integrations/providerConfigKey/functions/getCode.js';
 import { getIntegrationFunction } from './controllers/v1/integrations/providerConfigKey/functions/getFunction.js';
 import { getIntegrationFunctions } from './controllers/v1/integrations/providerConfigKey/functions/getFunctions.js';
 import { getIntegration } from './controllers/v1/integrations/providerConfigKey/getIntegration.js';
@@ -248,6 +249,11 @@ web.route('/integrations/:providerConfigKey/functions').get(webAuth, can({ actio
 web.route('/integrations/:providerConfigKey/functions/:functionName')
     .get(webAuth, can({ action: 'read', resource: 'flow', scopedBy: envScope }), getIntegrationFunction)
     .delete(webAuth, can({ action: 'delete', resource: 'flow', scopedBy: envScope }), deleteIntegrationFunction);
+web.route('/integrations/:providerConfigKey/functions/:functionName/code').get(
+    webAuth,
+    can({ action: 'read', resource: 'flow', scopedBy: envScope }),
+    getIntegrationFunctionCode
+);
 web.route('/integrations/:providerConfigKey/templates').get(webAuth, can({ action: 'read', resource: 'flow', scopedBy: envScope }), getIntegrationTemplates);
 
 // Providers

--- a/packages/types/lib/api.endpoints.ts
+++ b/packages/types/lib/api.endpoints.ts
@@ -85,6 +85,7 @@ import type { GetGettingStarted, PatchGettingStarted } from './gettingStarted/ap
 import type {
     DeleteIntegration,
     DeletePublicIntegration,
+    GetFunctionCode,
     GetIntegration,
     GetIntegrationFlows,
     GetPublicFunctionCode,
@@ -206,6 +207,7 @@ export type PrivateApiEndpoints =
     | GetIntegrationFlows
     | GetIntegrationFunction
     | GetIntegrationFunctions
+    | GetFunctionCode
     | DeleteIntegrationFunction
     | GetIntegrationTemplates
     | GetProviderTemplates

--- a/packages/types/lib/integration/api.ts
+++ b/packages/types/lib/integration/api.ts
@@ -128,6 +128,24 @@ export type GetPublicFunctionCode = Endpoint<{
     Error: ApiError<'not_found'> | ApiError<'ambiguous_function', undefined, { matches: { type: ScriptTypeLiteral; name: string }[] }>;
 }>;
 
+export type GetFunctionCode = Endpoint<{
+    Method: 'GET';
+    Path: '/api/v1/integrations/:providerConfigKey/functions/:functionName/code';
+    Params: {
+        providerConfigKey: string;
+        functionName: string;
+    };
+    Querystring: {
+        env: string;
+        type?: ScriptTypeLiteral | undefined;
+    };
+    Success: {
+        type: ScriptTypeLiteral;
+        code: string;
+    };
+    Error: ApiError<'not_found'> | ApiError<'ambiguous_function', undefined, { matches: { type: ScriptTypeLiteral; name: string }[] }>;
+}>;
+
 export type ApiIntegration = Omit<Merge<IntegrationConfig, ApiTimestamps>, 'oauth_client_secret_iv' | 'oauth_client_secret_tag'>;
 export type ApiIntegrationList = ApiIntegration & {
     meta: {

--- a/packages/webapp/src/hooks/useIntegrationFunctions.tsx
+++ b/packages/webapp/src/hooks/useIntegrationFunctions.tsx
@@ -91,9 +91,10 @@ interface UseGetIntegrationFunctionCodeArgs {
     providerConfigKey: string;
     name: string;
     type?: GetFunctionCode['Querystring']['type'];
+    enabled?: boolean;
 }
 
-export function useGetIntegrationFunctionCode({ env, providerConfigKey, name, type }: UseGetIntegrationFunctionCodeArgs) {
+export function useGetIntegrationFunctionCode({ env, providerConfigKey, name, type, enabled = true }: UseGetIntegrationFunctionCodeArgs) {
     return useQuery<GetFunctionCode['Success'], APIError>({
         queryKey: ['integrations', env, providerConfigKey, 'functions', name, 'code', { type }],
         queryFn: async (): Promise<GetFunctionCode['Success']> => {
@@ -115,7 +116,7 @@ export function useGetIntegrationFunctionCode({ env, providerConfigKey, name, ty
 
             return json;
         },
-        enabled: Boolean(env && providerConfigKey && name)
+        enabled: enabled && Boolean(env && providerConfigKey && name)
     });
 }
 

--- a/packages/webapp/src/hooks/useIntegrationFunctions.tsx
+++ b/packages/webapp/src/hooks/useIntegrationFunctions.tsx
@@ -2,7 +2,7 @@ import { keepPreviousData, useInfiniteQuery, useQuery } from '@tanstack/react-qu
 
 import { APIError, apiFetch } from '../utils/api';
 
-import type { GetIntegrationFunction, GetIntegrationFunctions, GetIntegrationTemplates } from '@nangohq/types';
+import type { GetFunctionCode, GetIntegrationFunction, GetIntegrationFunctions, GetIntegrationTemplates } from '@nangohq/types';
 
 interface UseGetIntegrationFunctionsArgs {
     env: string;
@@ -76,6 +76,39 @@ export function useGetIntegrationFunction({ env, providerConfigKey, name, type }
             );
 
             const json = (await res.json()) as GetIntegrationFunction['Reply'];
+            if (!res.ok || 'error' in json) {
+                throw new APIError({ res, json });
+            }
+
+            return json;
+        },
+        enabled: Boolean(env && providerConfigKey && name)
+    });
+}
+
+interface UseGetIntegrationFunctionCodeArgs {
+    env: string;
+    providerConfigKey: string;
+    name: string;
+    type?: GetFunctionCode['Querystring']['type'];
+}
+
+export function useGetIntegrationFunctionCode({ env, providerConfigKey, name, type }: UseGetIntegrationFunctionCodeArgs) {
+    return useQuery<GetFunctionCode['Success'], APIError>({
+        queryKey: ['integrations', env, providerConfigKey, 'functions', name, 'code', { type }],
+        queryFn: async (): Promise<GetFunctionCode['Success']> => {
+            const usp = new URLSearchParams();
+            usp.set('env', env);
+            if (type) {
+                usp.set('type', type);
+            }
+
+            const res = await apiFetch(
+                `/api/v1/integrations/${encodeURIComponent(providerConfigKey)}/functions/${encodeURIComponent(name)}/code?${usp.toString()}`,
+                { method: 'GET' }
+            );
+
+            const json = (await res.json()) as GetFunctionCode['Reply'];
             if (!res.ok || 'error' in json) {
                 throw new APIError({ res, json });
             }

--- a/packages/webapp/src/pages/Integrations/providerConfigKey/Functions/One.tsx
+++ b/packages/webapp/src/pages/Integrations/providerConfigKey/Functions/One.tsx
@@ -109,7 +109,8 @@ export const FunctionsOne: React.FC = () => {
         env,
         providerConfigKey: providerConfigKey!,
         name: functionName!,
-        type: func?.type
+        type: func?.type,
+        enabled: Boolean(func)
     });
 
     const isLoading = integrationLoading || functionLoading;

--- a/packages/webapp/src/pages/Integrations/providerConfigKey/Functions/One.tsx
+++ b/packages/webapp/src/pages/Integrations/providerConfigKey/Functions/One.tsx
@@ -9,19 +9,21 @@ import { ConditionalTooltip } from '@/components/patterns/ConditionalTooltip';
 import { IntegrationLogo } from '@/components/patterns/IntegrationLogo';
 import { Alert, AlertDescription } from '@/components/ui/Alert';
 import { ButtonLink } from '@/components/ui/ButtonLink';
+import { CodeBlock } from '@/components/ui/CodeBlock';
 import { CopyButton } from '@/components/ui/CopyButton';
 import { EmptyCard } from '@/components/ui/EmptyCard';
 import { KeyValueBadge } from '@/components/ui/KeyValueBadge';
 import { LineSnippet } from '@/components/ui/LineSnippet';
 import { Navigation, NavigationContent, NavigationList, NavigationTrigger } from '@/components/ui/Navigation';
 import { Skeleton } from '@/components/ui/Skeleton';
+import { Spinner } from '@/components/ui/Spinner';
 import { StyledLink } from '@/components/ui/StyledLink';
 import { Tabs, TabsContent, TabsList, TabsTrigger } from '@/components/ui/Tabs';
 import { useConfirmDialog } from '@/hooks/useConfirmDialog';
 import { apiFlowDownload } from '@/hooks/useFlow';
 import { useHashNavigation } from '@/hooks/useHashNavigation';
 import { useDeleteIntegrationFunction, useGetIntegration } from '@/hooks/useIntegration';
-import { useGetIntegrationFunction } from '@/hooks/useIntegrationFunctions';
+import { useGetIntegrationFunction, useGetIntegrationFunctionCode } from '@/hooks/useIntegrationFunctions';
 import { useToast } from '@/hooks/useToast';
 import DashboardLayout from '@/layout/DashboardLayout';
 import PageNotFound from '@/pages/PageNotFound';
@@ -98,6 +100,17 @@ export const FunctionsOne: React.FC = () => {
     }, [func]);
 
     const [activeTab, setActiveTab] = useHashNavigation(outputSchemas && outputSchemas.length > 0 && !inputSchema ? 'output' : 'input');
+
+    const {
+        data: codeData,
+        isLoading: codeLoading,
+        error: codeError
+    } = useGetIntegrationFunctionCode({
+        env,
+        providerConfigKey: providerConfigKey!,
+        name: functionName!,
+        type: func?.type
+    });
 
     const isLoading = integrationLoading || functionLoading;
 
@@ -292,6 +305,7 @@ export const FunctionsOne: React.FC = () => {
                             <TabsList className="w-fit gap-0">
                                 <TabsTrigger value="input">Input</TabsTrigger>
                                 <TabsTrigger value="output">Output</TabsTrigger>
+                                <TabsTrigger value="code">Code</TabsTrigger>
                             </TabsList>
                             {func.type === 'action' ? (
                                 <ButtonLink variant="outline" to="https://nango.dev/docs/guides/functions/action-functions" target="_blank">
@@ -340,6 +354,19 @@ export const FunctionsOne: React.FC = () => {
                                 <EmptyCard>
                                     <span className="text-text-secondary text-body-medium-regular">No outputs.</span>
                                 </EmptyCard>
+                            )}
+                        </TabsContent>
+                        <TabsContent value="code" className="flex flex-col gap-4">
+                            {codeLoading ? (
+                                <div className="flex items-center justify-center h-96">
+                                    <Spinner className="size-5 text-text-muted" />
+                                </div>
+                            ) : codeError || !codeData ? (
+                                <EmptyCard>
+                                    <span className="text-text-secondary text-body-medium-regular">Failed to load source code.</span>
+                                </EmptyCard>
+                            ) : (
+                                <CodeBlock title={`${func.name}.ts`} language="typescript" code={codeData.code} />
                             )}
                         </TabsContent>
                     </Tabs>


### PR DESCRIPTION
Adds a `Code` to the function page that shows the code for that function. We already had a public endpoint to fetch a function's code (used by `nango pull), so I've extracted the code logic and made a private variant. All the core logic is just extracted and moved, nothing changed.

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/NangoHQ/nango/pull/6679?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

