### PR TITLE
feat(providers): regenerate assertion for two_step only when the assertion expires

### DIFF
--- a/packages/shared/lib/auth/assertion.ts
+++ b/packages/shared/lib/auth/assertion.ts
@@ -1,14 +1,14 @@
 import { createPrivateKey } from 'crypto';
 
-import { DOMImplementation, XMLSerializer } from '@xmldom/xmldom';
+import { DOMImplementation, DOMParser, XMLSerializer } from '@xmldom/xmldom';
 import { v4 as uuidv4 } from 'uuid';
 import { SignedXml } from 'xml-crypto';
 
 import { Err, Ok } from '@nangohq/utils';
 
 import { AuthCredentialsError } from '../utils/error.js';
-import { formatPem, interpolateObject, interpolateString } from '../utils/utils.js';
-import { signJWT } from './jwt.js';
+import { formatPem, interpolateObject, interpolateString, isTokenExpired, parseTokenExpirationDate } from '../utils/utils.js';
+import { decode, signJWT } from './jwt.js';
 
 import type { ProviderTwoStep } from '@nangohq/types';
 import type { Result } from '@nangohq/utils';
@@ -88,6 +88,8 @@ const OBJECT_FIELD_HANDLERS: Record<string, ObjectFieldHandler> = {
 };
 
 const NAMESPACE = 'urn:oasis:names:tc:SAML:2.0:assertion';
+
+const ASSERTION_REFRESH_MARGIN_SECONDS = 60;
 
 function uid(len: number = 32) {
     return uuidv4().replace(/-/g, '').slice(0, len);
@@ -316,6 +318,40 @@ export function generateSamlAssertion({
         return Ok(assertion);
     } catch (err) {
         return Err(new AuthCredentialsError('failed_to_generate_assertion', { cause: err }));
+    }
+}
+
+export function isJwtAssertionExpired(assertion: string): boolean {
+    try {
+        const decoded = decode(assertion);
+        if (!decoded || typeof decoded['exp'] !== 'number') {
+            return true;
+        }
+        return isTokenExpired(new Date(decoded['exp'] * 1000), ASSERTION_REFRESH_MARGIN_SECONDS);
+    } catch {
+        return true;
+    }
+}
+
+export function isSamlAssertionExpired(assertion: string): boolean {
+    try {
+        const xml = Buffer.from(assertion, 'base64').toString('utf-8');
+        const doc = new DOMParser().parseFromString(xml, 'text/xml');
+        const conditions = doc.getElementsByTagNameNS(NAMESPACE, 'Conditions')[0];
+        if (!conditions) {
+            return true;
+        }
+        const notOnOrAfter = conditions.getAttribute('NotOnOrAfter');
+        if (!notOnOrAfter) {
+            return true;
+        }
+        const expireDate = parseTokenExpirationDate(notOnOrAfter);
+        if (!expireDate) {
+            return true;
+        }
+        return isTokenExpired(expireDate, ASSERTION_REFRESH_MARGIN_SECONDS);
+    } catch {
+        return true;
     }
 }
 

--- a/packages/shared/lib/auth/assertion.unit.test.ts
+++ b/packages/shared/lib/auth/assertion.unit.test.ts
@@ -1,0 +1,78 @@
+import jwt from 'jsonwebtoken';
+import { describe, expect, it } from 'vitest';
+
+import { isJwtAssertionExpired, isSamlAssertionExpired } from './assertion.js';
+
+const SAML_NAMESPACE = 'urn:oasis:names:tc:SAML:2.0:assertion';
+
+function nowSeconds(): number {
+    return Math.floor(Date.now() / 1000);
+}
+
+function makeSamlAssertion(notOnOrAfter: string): string {
+    const xml = `<saml:Assertion xmlns:saml="${SAML_NAMESPACE}"><saml:Conditions NotBefore="2024-01-01T00:00:00Z" NotOnOrAfter="${notOnOrAfter}"/></saml:Assertion>`;
+    return Buffer.from(xml).toString('base64');
+}
+
+describe('isJwtAssertionExpired', () => {
+    it('returns true for a malformed token string', () => {
+        expect(isJwtAssertionExpired('not-a-jwt')).toBe(true);
+    });
+
+    it('returns true for a token missing the exp claim', () => {
+        const token = jwt.sign({ sub: 'test' }, 'secret');
+        expect(isJwtAssertionExpired(token)).toBe(true);
+    });
+
+    it('returns true for an already expired token', () => {
+        const token = jwt.sign({ exp: nowSeconds() - 3600 }, 'secret');
+        expect(isJwtAssertionExpired(token)).toBe(true);
+    });
+
+    it('returns true for a token expiring within the 60-second refresh margin', () => {
+        const token = jwt.sign({ exp: nowSeconds() + 30 }, 'secret');
+        expect(isJwtAssertionExpired(token)).toBe(true);
+    });
+
+    it('returns false for a token with more than 60 seconds remaining', () => {
+        const token = jwt.sign({ exp: nowSeconds() + 3600 }, 'secret');
+        expect(isJwtAssertionExpired(token)).toBe(false);
+    });
+});
+
+describe('isSamlAssertionExpired', () => {
+    it('returns true for content that decodes to non-XML', () => {
+        const notXml = Buffer.from('hello world').toString('base64');
+        expect(isSamlAssertionExpired(notXml)).toBe(true);
+    });
+
+    it('returns true for XML missing the Conditions element', () => {
+        const xml = `<saml:Assertion xmlns:saml="${SAML_NAMESPACE}"><saml:Issuer>test</saml:Issuer></saml:Assertion>`;
+        expect(isSamlAssertionExpired(Buffer.from(xml).toString('base64'))).toBe(true);
+    });
+
+    it('returns true for a Conditions element with an unparseable NotOnOrAfter date', () => {
+        const xml = `<saml:Assertion xmlns:saml="${SAML_NAMESPACE}"><saml:Conditions NotBefore="2024-01-01T00:00:00Z" NotOnOrAfter="not-a-date"/></saml:Assertion>`;
+        expect(isSamlAssertionExpired(Buffer.from(xml).toString('base64'))).toBe(true);
+    });
+
+    it('returns true for a Conditions element missing the NotOnOrAfter attribute', () => {
+        const xml = `<saml:Assertion xmlns:saml="${SAML_NAMESPACE}"><saml:Conditions NotBefore="2024-01-01T00:00:00Z"/></saml:Assertion>`;
+        expect(isSamlAssertionExpired(Buffer.from(xml).toString('base64'))).toBe(true);
+    });
+
+    it('returns true for an already expired assertion', () => {
+        const notOnOrAfter = new Date((nowSeconds() - 3600) * 1000).toISOString();
+        expect(isSamlAssertionExpired(makeSamlAssertion(notOnOrAfter))).toBe(true);
+    });
+
+    it('returns true for an assertion expiring within the 60-second refresh margin', () => {
+        const notOnOrAfter = new Date((nowSeconds() + 30) * 1000).toISOString();
+        expect(isSamlAssertionExpired(makeSamlAssertion(notOnOrAfter))).toBe(true);
+    });
+
+    it('returns false for an assertion with more than 60 seconds remaining', () => {
+        const notOnOrAfter = new Date((nowSeconds() + 3600) * 1000).toISOString();
+        expect(isSamlAssertionExpired(makeSamlAssertion(notOnOrAfter))).toBe(false);
+    });
+});

--- a/packages/shared/lib/services/connection.service.ts
+++ b/packages/shared/lib/services/connection.service.ts
@@ -1412,28 +1412,18 @@ class ConnectionService {
 
             const assertionType = provider.assertion.type;
             const existingAssertion = credentials['assertion'] as string | undefined;
-            const assertionExpired =
-                !existingAssertion ||
-                (assertionType === 'jwt'
-                    ? assertionClient.isJwtAssertionExpired(existingAssertion)
-                    : assertionClient.isSamlAssertionExpired(existingAssertion));
+            const assertionArgs = { provider, dynamicCredentials: credentials, connectionConfig, ...(assertionOption && { assertionOption }) };
 
-            if (assertionExpired) {
-                const create =
-                    assertionType === 'jwt'
-                        ? assertionClient.generateJwtAssertion({
-                              provider,
-                              dynamicCredentials: credentials,
-                              connectionConfig,
-                              ...(assertionOption && { assertionOption })
-                          })
-                        : assertionClient.generateSamlAssertion({
-                              provider,
-                              dynamicCredentials: credentials,
-                              connectionConfig,
-                              ...(assertionOption && { assertionOption })
-                          });
+            let create;
+            if (assertionType === 'jwt') {
+                if (!existingAssertion || assertionClient.isJwtAssertionExpired(existingAssertion)) {
+                    create = assertionClient.generateJwtAssertion(assertionArgs);
+                }
+            } else if (!existingAssertion || assertionClient.isSamlAssertionExpired(existingAssertion)) {
+                create = assertionClient.generateSamlAssertion(assertionArgs);
+            }
 
+            if (create) {
                 if (create.isErr()) {
                     console.log(create.error);
                     return { success: false, error: create.error, response: null };

--- a/packages/shared/lib/services/connection.service.ts
+++ b/packages/shared/lib/services/connection.service.ts
@@ -1405,35 +1405,44 @@ class ConnectionService {
             dynamicCredentials['token'] = token;
         }
 
-        // Regenerate the assertion on initial auth or when no refresh_token exists.
+        // Regenerate the assertion on initial auth or when no refresh_token exists and when the assertion expires.
         if (provider.assertion && (refreshToken === false || refreshToken === undefined || !dynamicCredentials['refresh_token'])) {
             const { assertionOption: assertionOptionValue, ...credentials } = dynamicCredentials;
             const assertionOption = assertionOptionValue as Record<string, any> | undefined;
 
             const assertionType = provider.assertion.type;
-            const create =
-                assertionType === 'jwt'
-                    ? assertionClient.generateJwtAssertion({
-                          provider,
-                          dynamicCredentials: credentials,
-                          connectionConfig,
-                          ...(assertionOption && { assertionOption })
-                      })
-                    : assertionClient.generateSamlAssertion({
-                          provider,
-                          dynamicCredentials: credentials,
-                          connectionConfig,
-                          ...(assertionOption && { assertionOption })
-                      });
+            const existingAssertion = credentials['assertion'] as string | undefined;
+            const assertionExpired =
+                !existingAssertion ||
+                (assertionType === 'jwt'
+                    ? assertionClient.isJwtAssertionExpired(existingAssertion)
+                    : assertionClient.isSamlAssertionExpired(existingAssertion));
 
-            if (create.isErr()) {
-                console.log(create.error);
-                return { success: false, error: create.error, response: null };
+            if (assertionExpired) {
+                const create =
+                    assertionType === 'jwt'
+                        ? assertionClient.generateJwtAssertion({
+                              provider,
+                              dynamicCredentials: credentials,
+                              connectionConfig,
+                              ...(assertionOption && { assertionOption })
+                          })
+                        : assertionClient.generateSamlAssertion({
+                              provider,
+                              dynamicCredentials: credentials,
+                              connectionConfig,
+                              ...(assertionOption && { assertionOption })
+                          });
+
+                if (create.isErr()) {
+                    console.log(create.error);
+                    return { success: false, error: create.error, response: null };
+                }
+
+                credentials['assertion'] = create.value;
+
+                Object.assign(dynamicCredentials, credentials);
             }
-
-            credentials['assertion'] = create.value;
-
-            Object.assign(dynamicCredentials, credentials);
         }
 
         // Some providers may rate-limit the token URL because they offer a different endpoint for refreshing tokens.


### PR DESCRIPTION
## Describe the problem and your solution

- regenerate assertion for `two_step` only when the assertion expires

<!-- Issue ticket number and link (if applicable) -->

<!-- Testing instructions (skip if just adding/editing providers) -->



<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/NangoHQ/nango/pull/6680?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

