### PR TITLE
fix(webapp): preserve query string when switching hash-navigated tabs

### DIFF
--- a/packages/webapp/src/hooks/useHashNavigation.ts
+++ b/packages/webapp/src/hooks/useHashNavigation.ts
@@ -35,7 +35,7 @@ export function useHashNavigation(defaultValue: string = '', onValueChange?: (va
     // Handler that updates both state and URL
     const handleValueChange = (newValue: string) => {
         setValue(newValue);
-        navigate(`#${newValue}`, { replace: true });
+        navigate({ search: location.search, hash: newValue }, { replace: true });
         onValueChange?.(newValue);
     };
 


### PR DESCRIPTION
When clicking the different tabs ("Input"/"Output"/"Code") in the function page, the `useHashNavigation` hook would not preserve query parameters, causing a full page refresh.

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/NangoHQ/nango/pull/6686?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

