### PR TITLE
chore(server): Add new rate limit tier for LFX

### DIFF
--- a/packages/server/lib/middleware/ratelimit.middleware.ts
+++ b/packages/server/lib/middleware/ratelimit.middleware.ts
@@ -23,7 +23,8 @@ const rateLimiterSize: Record<DBPlan['api_rate_limit_size'], number> = {
     xl: defaultLimit * 10,
     '2xl': defaultLimit * 25,
     '3xl': defaultLimit * 50,
-    '4xl': defaultLimit * 75
+    '4xl': defaultLimit * 75,
+    '5xl': defaultLimit * 100
 };
 const limiters = new Map<DBPlan['api_rate_limit_size'], RateLimiterAbstract>();
 

--- a/packages/shared/lib/services/plans/plans.ts
+++ b/packages/shared/lib/services/plans/plans.ts
@@ -327,7 +327,8 @@ export function mergeFlags({ currentPlan, newPlanDefinition }: { currentPlan: DB
                     xl: 4,
                     '2xl': 5,
                     '3xl': 6,
-                    '4xl': 7
+                    '4xl': 7,
+                    '5xl': 8
                 };
                 const currentIndex = sizeIndex[currentPlan[key]];
                 const newIndex = sizeIndex[newPlanDefinition.flags[key]];

--- a/packages/types/lib/plans/db.ts
+++ b/packages/types/lib/plans/db.ts
@@ -124,7 +124,7 @@ export interface DBPlan extends Timestamps {
      * Change the applied rate limit for the public API
      * @default "m"
      */
-    api_rate_limit_size: 's' | 'm' | 'l' | 'xl' | '2xl' | '3xl' | '4xl';
+    api_rate_limit_size: 's' | 'm' | 'l' | 'xl' | '2xl' | '3xl' | '4xl' | '5xl';
 
     /**
      * Enable or disable machine auto idling


### PR DESCRIPTION
<!-- Describe the problem and your solution --> 


<!-- Issue ticket number and link (if applicable) -->
[NAN-6143: chore(server): Add new rate limit tier for Linux Foundation](https://linear.app/nango/issue/NAN-6143/choreserver-add-new-rate-limit-tier-for-linux-foundation)

<!-- Testing instructions (skip if just adding/editing providers) -->



<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/NangoHQ/nango/pull/6690?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

