### PR TITLE
feat(telemetry): implement CLI usage tracking

### DIFF
--- a/packages/cli/lib/index.ts
+++ b/packages/cli/lib/index.ts
@@ -21,6 +21,7 @@ import { Ensure } from './services/ensure.service.js';
 import { create } from './services/function-create.service.js';
 import { inferIntegrationsFromConnectionId } from './services/interactive.service.js';
 import { pullFromCatalog, pullFunction } from './services/pull.service.js';
+import { trackCliEvent } from './services/telemetry.service.js';
 import { generateTests } from './services/test.service.js';
 import verificationService from './services/verification.service.js';
 import { getNangoRootPath, isCI, printDebug, upgradeAction } from './utils.js';
@@ -34,7 +35,21 @@ import { initZero } from './zeroYaml/init.js';
 import { ReadableError } from './zeroYaml/utils.js';
 
 import type { DeployOptions, GlobalOptions } from './types.js';
-import type { NangoYamlParsed, ScriptTypeLiteral } from '@nangohq/types';
+import type { CliTelemetryEvent, NangoYamlParsed, ScriptTypeLiteral } from '@nangohq/types';
+
+const commandTelemetryEvents: Record<string, CliTelemetryEvent> = {
+    init: 'cli:init',
+    create: 'cli:create',
+    compile: 'cli:compile',
+    dev: 'cli:dev',
+    dryrun: 'cli:dryrun',
+    'generate:docs': 'cli:generate:docs',
+    'generate:tests': 'cli:generate:tests',
+    clone: 'cli:clone',
+    'migrate-to-zero-yaml': 'cli:migrate_to_zero_yaml',
+    deploy: 'cli:deploy',
+    pull: 'cli:pull'
+};
 
 class NangoCommand extends Command {
     override createCommand(name: string) {
@@ -46,6 +61,7 @@ class NangoCommand extends Command {
         // Passing --no-interactive will set it to false.
         cmd.option('--no-interactive', 'Disable interactive prompts for missing arguments.');
         cmd.option('--no-dependency-update', 'Skip automatic dependency updates and package installation.');
+        cmd.option('--no-telemetry', 'Disable anonymous CLI usage telemetry.');
 
         cmd.hook('preAction', async function (this: Command, actionCommand: Command) {
             const opts = actionCommand.opts<GlobalOptions>();
@@ -76,6 +92,18 @@ class NangoCommand extends Command {
                 opts.dependencyUpdate = false;
             }
             printDebug(`Dependency update: ${opts.dependencyUpdate ? 'enabled' : 'disabled'}`, opts.debug);
+
+            if (opts.telemetry === false) {
+                process.env['NANGO_CLI_TELEMETRY'] = 'false';
+            }
+            if (opts.debug) {
+                process.env['NANGO_CLI_DEBUG'] = 'true';
+            }
+
+            const telemetryEvent = commandTelemetryEvents[actionCommand.name()];
+            if (telemetryEvent) {
+                trackCliEvent(telemetryEvent);
+            }
 
             if (opts.debug && fs.existsSync('.env')) {
                 printDebug('.env file detected and loaded', opts.debug);

--- a/packages/cli/lib/services/telemetry.service.ts
+++ b/packages/cli/lib/services/telemetry.service.ts
@@ -10,7 +10,7 @@ export { isTelemetryDisabled };
 /**
  * Send an anonymous CLI usage event. Fire-and-forget
  */
-export function trackCliEvent(event: CliTelemetryEvent, properties?: Record<string, string | number | boolean>): void {
+export function trackCliEvent(event: CliTelemetryEvent): void {
     if (isTelemetryDisabled()) {
         return;
     }
@@ -18,7 +18,8 @@ export function trackCliEvent(event: CliTelemetryEvent, properties?: Record<stri
     const controller = new AbortController();
     const timeout = setTimeout(() => controller.abort(), TELEMETRY_TIMEOUT_MS);
 
-    const body: PostCliTelemetry['Body'] = { deviceId: getDeviceId(), event, properties };
+    const { deviceId, ephemeral } = getDeviceId();
+    const body: PostCliTelemetry['Body'] = { deviceId, event, ephemeral };
     void fetch(new URL('/cli/telemetry', resolveHostport()), {
         method: 'POST',
         body: JSON.stringify(body),

--- a/packages/cli/lib/services/telemetry.service.ts
+++ b/packages/cli/lib/services/telemetry.service.ts
@@ -1,0 +1,34 @@
+import { getDeviceId } from '../state.js';
+import { getCliHeaders, isCliDebugEnabled, isTelemetryDisabled, printDebug, resolveHostport } from '../utils.js';
+
+import type { CliTelemetryEvent, PostCliTelemetry } from '@nangohq/types';
+
+const TELEMETRY_TIMEOUT_MS = 2000;
+
+export { isTelemetryDisabled };
+
+/**
+ * Send an anonymous CLI usage event. Fire-and-forget
+ */
+export function trackCliEvent(event: CliTelemetryEvent, properties?: Record<string, string | number | boolean>): void {
+    if (isTelemetryDisabled()) {
+        return;
+    }
+
+    const controller = new AbortController();
+    const timeout = setTimeout(() => controller.abort(), TELEMETRY_TIMEOUT_MS);
+
+    const body: PostCliTelemetry['Body'] = { deviceId: getDeviceId(), event, properties };
+    void fetch(new URL('/cli/telemetry', resolveHostport()), {
+        method: 'POST',
+        body: JSON.stringify(body),
+        headers: new Headers({ ...getCliHeaders(), 'content-type': 'application/json' }),
+        signal: controller.signal
+    })
+        .catch((err) => {
+            printDebug(`Telemetry delivery failed: ${err instanceof Error ? err.message : String(err)}`, isCliDebugEnabled());
+        })
+        .finally(() => {
+            clearTimeout(timeout);
+        });
+}

--- a/packages/cli/lib/state.ts
+++ b/packages/cli/lib/state.ts
@@ -1,8 +1,22 @@
+import { randomUUID } from 'crypto';
+
 import Conf from 'conf';
 
 const schema = {
     lastIgnoreUpgrade: {
         type: 'number'
+    },
+    deviceId: {
+        type: 'string'
     }
 };
 export const state = new Conf({ projectName: 'nango', schema });
+
+export function getDeviceId(): string {
+    let deviceId = state.get('deviceId') as string | undefined;
+    if (!deviceId) {
+        deviceId = randomUUID();
+        state.set('deviceId', deviceId);
+    }
+    return deviceId;
+}

--- a/packages/cli/lib/state.ts
+++ b/packages/cli/lib/state.ts
@@ -12,11 +12,17 @@ const schema = {
 };
 export const state = new Conf({ projectName: 'nango', schema });
 
-export function getDeviceId(): string {
-    let deviceId = state.get('deviceId') as string | undefined;
-    if (!deviceId) {
-        deviceId = randomUUID();
-        state.set('deviceId', deviceId);
+export function getDeviceId(): { deviceId: string; ephemeral: boolean } {
+    try {
+        let deviceId = state.get('deviceId') as string | undefined;
+        if (!deviceId) {
+            deviceId = randomUUID();
+            state.set('deviceId', deviceId);
+        }
+        return { deviceId, ephemeral: false };
+    } catch {
+        // ephemeral means the id couldn't be persisted (e.g. read-only FS), so it's a throwaway
+        // that can't correlate across runs. Callers should flag it and skip device correlation.
+        return { deviceId: randomUUID(), ephemeral: true };
     }
-    return deviceId;
 }

--- a/packages/cli/lib/types.ts
+++ b/packages/cli/lib/types.ts
@@ -3,6 +3,7 @@ export interface GlobalOptions {
     debug: boolean;
     interactive: boolean;
     dependencyUpdate: boolean;
+    telemetry?: boolean;
 }
 
 export type ENV = 'local' | 'cloud';

--- a/packages/cli/lib/utils.ts
+++ b/packages/cli/lib/utils.ts
@@ -15,7 +15,7 @@ import semver from 'semver';
 import { serializeError } from 'serialize-error';
 
 import { cloudHost, localhostUrl } from './constants.js';
-import { state } from './state.js';
+import { getDeviceId, state } from './state.js';
 import { Err, Ok } from './utils/result.js';
 import { NANGO_VERSION } from './version.js';
 
@@ -273,10 +273,25 @@ export function enrichHeaders(headers: Record<string, string | number | boolean>
     return headers;
 }
 
+export function isTelemetryDisabled(): boolean {
+    return process.env['TELEMETRY'] === 'false' || process.env['NANGO_CLI_TELEMETRY'] === 'false';
+}
+
+export function isCliDebugEnabled(): boolean {
+    return process.env['NANGO_CLI_DEBUG'] === 'true';
+}
+
 const defaultHttpsAgent = new https.Agent({ keepAlive: true, rejectUnauthorized: false });
 export const http = axios.create({
-    httpsAgent: defaultHttpsAgent,
-    headers: { 'User-Agent': getUserAgent() }
+    httpsAgent: defaultHttpsAgent
+});
+
+http.interceptors.request.use((config) => {
+    const cliHeaders = getCliHeaders();
+    for (const [key, value] of Object.entries(cliHeaders)) {
+        config.headers.set(key, value);
+    }
+    return config;
 });
 
 export function getUserAgent(): string {
@@ -286,6 +301,16 @@ export function getUserAgent(): string {
     const osName = os.platform().replace(' ', '_');
     const osVersion = os.release().replace(' ', '_');
     return `nango-cli/${clientVersion} (${osName}/${osVersion}; node.js/${nodeVersion})`;
+}
+
+export function getCliHeaders(): Record<string, string> {
+    const headers: Record<string, string> = {
+        'User-Agent': getUserAgent()
+    };
+    if (!isTelemetryDisabled()) {
+        headers['Nango-CLI-Device-Id'] = getDeviceId();
+    }
+    return headers;
 }
 
 export function getNangoRootPath(debug = false): string {

--- a/packages/cli/lib/utils.ts
+++ b/packages/cli/lib/utils.ts
@@ -274,7 +274,7 @@ export function enrichHeaders(headers: Record<string, string | number | boolean>
 }
 
 export function isTelemetryDisabled(): boolean {
-    return process.env['TELEMETRY'] === 'false' || process.env['NANGO_CLI_TELEMETRY'] === 'false';
+    return process.env['NANGO_CLI_TELEMETRY'] === 'false';
 }
 
 export function isCliDebugEnabled(): boolean {
@@ -308,7 +308,11 @@ export function getCliHeaders(): Record<string, string> {
         'User-Agent': getUserAgent()
     };
     if (!isTelemetryDisabled()) {
-        headers['Nango-CLI-Device-Id'] = getDeviceId();
+        const { deviceId, ephemeral } = getDeviceId();
+        // Only correlate persisted ids; a throwaway id would just create junk aliases server-side.
+        if (!ephemeral) {
+            headers['Nango-CLI-Device-Id'] = deviceId;
+        }
     }
     return headers;
 }

--- a/packages/cli/lib/zeroYaml/deploy.ts
+++ b/packages/cli/lib/zeroYaml/deploy.ts
@@ -5,7 +5,7 @@ import chalk from 'chalk';
 import columnify from 'columnify';
 import promptly from 'promptly';
 
-import { isCI, parseSecretKey, printDebug, resolveHostport } from '../utils.js';
+import { getCliHeaders, isCI, parseSecretKey, printDebug, resolveHostport } from '../utils.js';
 import { Err, Ok } from '../utils/result.js';
 import { Spinner } from '../utils/spinner.js';
 import { NANGO_VERSION } from '../version.js';
@@ -378,6 +378,7 @@ async function postConfirmation({
             method: 'POST',
             body: JSON.stringify(body),
             headers: new Headers({
+                ...getCliHeaders(),
                 authorization: `Bearer ${process.env['NANGO_SECRET_KEY']}`,
                 'content-type': 'application/json'
             })
@@ -410,6 +411,7 @@ async function postDeploy({ hostport, body }: { hostport: string; body: PostDepl
             method: 'POST',
             body: JSON.stringify(body),
             headers: new Headers({
+                ...getCliHeaders(),
                 authorization: `Bearer ${process.env['NANGO_SECRET_KEY']}`,
                 'content-type': 'application/json'
             })

--- a/packages/server/lib/controllers/cli/postTelemetry.ts
+++ b/packages/server/lib/controllers/cli/postTelemetry.ts
@@ -1,7 +1,7 @@
 import * as z from 'zod';
 
 import { productTracking } from '@nangohq/shared';
-import { requireEmptyQuery, zodErrorToHTTP } from '@nangohq/utils';
+import { cliTelemetryEvents, requireEmptyQuery, zodErrorToHTTP } from '@nangohq/utils';
 
 import { asyncWrapper } from '../../utils/asyncWrapper.js';
 
@@ -10,20 +10,8 @@ import type { PostCliTelemetry } from '@nangohq/types';
 const bodySchema = z
     .object({
         deviceId: z.string().uuid(),
-        event: z.enum([
-            'cli:init',
-            'cli:create',
-            'cli:compile',
-            'cli:dev',
-            'cli:dryrun',
-            'cli:generate:docs',
-            'cli:generate:tests',
-            'cli:clone',
-            'cli:migrate_to_zero_yaml',
-            'cli:deploy',
-            'cli:pull'
-        ]),
-        properties: z.record(z.string(), z.union([z.string(), z.number(), z.boolean()])).optional()
+        event: z.enum(cliTelemetryEvents),
+        ephemeral: z.boolean().optional()
     })
     .strict();
 
@@ -40,8 +28,8 @@ export const postCliTelemetry = asyncWrapper<PostCliTelemetry>((req, res) => {
         return;
     }
 
-    const { deviceId, event, properties } = val.data;
-    productTracking.trackAnonymous({ name: event, distinctId: deviceId, ...(properties ? { eventProperties: properties } : {}) });
+    const { deviceId, event, ephemeral } = val.data;
+    productTracking.trackAnonymous({ name: event, distinctId: deviceId, ...(ephemeral ? { eventProperties: { 'device-id-ephemeral': true } } : {}) });
 
     res.status(204).send();
 });

--- a/packages/server/lib/controllers/cli/postTelemetry.ts
+++ b/packages/server/lib/controllers/cli/postTelemetry.ts
@@ -1,0 +1,47 @@
+import * as z from 'zod';
+
+import { productTracking } from '@nangohq/shared';
+import { requireEmptyQuery, zodErrorToHTTP } from '@nangohq/utils';
+
+import { asyncWrapper } from '../../utils/asyncWrapper.js';
+
+import type { PostCliTelemetry } from '@nangohq/types';
+
+const bodySchema = z
+    .object({
+        deviceId: z.string().uuid(),
+        event: z.enum([
+            'cli:init',
+            'cli:create',
+            'cli:compile',
+            'cli:dev',
+            'cli:dryrun',
+            'cli:generate:docs',
+            'cli:generate:tests',
+            'cli:clone',
+            'cli:migrate_to_zero_yaml',
+            'cli:deploy',
+            'cli:pull'
+        ]),
+        properties: z.record(z.string(), z.union([z.string(), z.number(), z.boolean()])).optional()
+    })
+    .strict();
+
+export const postCliTelemetry = asyncWrapper<PostCliTelemetry>((req, res) => {
+    const emptyQuery = requireEmptyQuery(req);
+    if (emptyQuery) {
+        res.status(400).send({ error: { code: 'invalid_query_params', errors: zodErrorToHTTP(emptyQuery.error) } });
+        return;
+    }
+
+    const val = bodySchema.safeParse(req.body);
+    if (!val.success) {
+        res.status(400).send({ error: { code: 'invalid_body', errors: zodErrorToHTTP(val.error) } });
+        return;
+    }
+
+    const { deviceId, event, properties } = val.data;
+    productTracking.trackAnonymous({ name: event, distinctId: deviceId, ...(properties ? { eventProperties: properties } : {}) });
+
+    res.status(204).send();
+});

--- a/packages/server/lib/controllers/sync/deploy/postDeploy.ts
+++ b/packages/server/lib/controllers/sync/deploy/postDeploy.ts
@@ -32,12 +32,16 @@ export const postDeploy = asyncWrapper<PostDeploy>(async (req, res) => {
     const body: PostDeploy['Body'] = val.data;
     const { environment, account, plan } = res.locals;
 
-    const { cliVersion } = getCliContext(req);
+    const { cliVersion, deviceId } = getCliContext(req);
     const trackingProperties: Record<string, string | number | boolean> = {
         'cli-version': cliVersion || 'unknown',
         source: body.source ?? 'repo',
         'flow-count': body.flowConfigs.length
     };
+
+    if (deviceId) {
+        productTracking.alias({ deviceId, team: account });
+    }
 
     // Prevent concurrent deploys per environment, fail immediately if another deploy is in flight.
     const locking = await getLocking();

--- a/packages/server/lib/controllers/sync/deploy/postDeploy.ts
+++ b/packages/server/lib/controllers/sync/deploy/postDeploy.ts
@@ -4,6 +4,7 @@ import { logContextGetter } from '@nangohq/logs';
 import { cleanIncomingFlow, deploy, errorManager, getAndReconcileDifferences, NangoError, productTracking, startTrial } from '@nangohq/shared';
 import { getLogger, requireEmptyQuery, zodErrorToHTTP } from '@nangohq/utils';
 
+import { getCliContext } from '../../../middleware/cliVersionCheck.js';
 import { startFunctionDeletion } from '../../../tasks/startFunctionDeletion.js';
 import { asyncWrapper } from '../../../utils/asyncWrapper.js';
 import { getOrchestrator } from '../../../utils/utils.js';
@@ -30,6 +31,13 @@ export const postDeploy = asyncWrapper<PostDeploy>(async (req, res) => {
 
     const body: PostDeploy['Body'] = val.data;
     const { environment, account, plan } = res.locals;
+
+    const { cliVersion } = getCliContext(req);
+    const trackingProperties: Record<string, string | number | boolean> = {
+        'cli-version': cliVersion || 'unknown',
+        source: body.source ?? 'repo',
+        'flow-count': body.flowConfigs.length
+    };
 
     // Prevent concurrent deploys per environment, fail immediately if another deploy is in flight.
     const locking = await getLocking();
@@ -75,6 +83,7 @@ export const postDeploy = asyncWrapper<PostDeploy>(async (req, res) => {
         }
 
         if (!success || !syncConfigDeployResult) {
+            productTracking.track({ name: 'deploy:error', team: account, eventProperties: { ...trackingProperties, 'error-code': error?.type || 'unknown' } });
             errorManager.errResFromNangoErr(res, error);
             return;
         }
@@ -93,6 +102,7 @@ export const postDeploy = asyncWrapper<PostDeploy>(async (req, res) => {
                 onFunctionDeleted: ({ syncConfigId, models }) => startFunctionDeletion({ syncConfigId, environmentId: environment.id, models })
             });
             if (!success) {
+                productTracking.track({ name: 'deploy:error', team: account, eventProperties: { ...trackingProperties, 'error-code': 'reconcile_failed' } });
                 res.status(500).send({
                     error: {
                         code: 'server_error',
@@ -103,7 +113,7 @@ export const postDeploy = asyncWrapper<PostDeploy>(async (req, res) => {
             }
         }
 
-        productTracking.track({ name: 'deploy:success', team: account });
+        productTracking.track({ name: 'deploy:success', team: account, eventProperties: trackingProperties });
 
         res.send(syncConfigDeployResult.result);
     } finally {

--- a/packages/server/lib/middleware/cliVersionCheck.ts
+++ b/packages/server/lib/middleware/cliVersionCheck.ts
@@ -8,6 +8,23 @@ import type { NextFunction, Request, Response } from 'express';
 const logger = getLogger('CliVersionCheck');
 
 const VERSION_REGEX = /nango-cli\/([0-9.]+)/;
+
+export function getCliContext(req: Request): { cliVersion?: string; deviceId?: string } {
+    const context: { cliVersion?: string; deviceId?: string } = {};
+
+    const match = req.headers['user-agent']?.match(VERSION_REGEX);
+    if (match?.[1]) {
+        context.cliVersion = match[1];
+    }
+
+    const deviceId = req.headers['nango-cli-device-id'];
+    if (typeof deviceId === 'string' && deviceId) {
+        context.deviceId = deviceId;
+    }
+
+    return context;
+}
+
 export function cliMinVersion(minVersion: string) {
     return (req: Request, res: Response, next: NextFunction) => {
         const userAgent = req.headers['user-agent'];

--- a/packages/server/lib/routes.public.ts
+++ b/packages/server/lib/routes.public.ts
@@ -21,6 +21,7 @@ import { postPublicTbaAuthorization } from './controllers/auth/postTba.js';
 import { postPublicTwoStepAuthorization } from './controllers/auth/postTwoStep.js';
 import { postPublicUnauthenticated } from './controllers/auth/postUnauthenticated.js';
 import { getClientMetadata } from './controllers/clientMetadata/environmentUuid/getClientMetadata.js';
+import { postCliTelemetry } from './controllers/cli/postTelemetry.js';
 import configController from './controllers/config.controller.js';
 import { deleteConnectSession } from './controllers/connect/deleteSession.js';
 import { getConnectSession } from './controllers/connect/getSession.js';
@@ -270,6 +271,10 @@ publicAPI.use('/sync', jsonContentTypeMiddleware);
 publicAPI.route('/sync/deploy').post(apiAuth, withScope('environment:deploy'), cliMinVersion('0.39.25'), postDeploy);
 publicAPI.route('/sync/deploy/confirmation').post(apiAuth, withScope('environment:deploy'), cliMinVersion('0.39.25'), postDeployConfirmation);
 publicAPI.route('/sync/deploy/internal').post(apiAuth, withScope('environment:deploy'), postDeployInternal);
+
+// CLI
+publicAPI.use('/cli', jsonContentTypeMiddleware);
+publicAPI.route('/cli/telemetry').post(rateLimiterMiddleware, postCliTelemetry);
 
 // Syncs
 publicAPI.route('/sync/update-connection-frequency').put(apiAuth, withScope('environment:syncs:update'), putSyncConnectionFrequency);

--- a/packages/server/lib/routes.public.ts
+++ b/packages/server/lib/routes.public.ts
@@ -20,8 +20,8 @@ import { postPublicSignatureAuthorization } from './controllers/auth/postSignatu
 import { postPublicTbaAuthorization } from './controllers/auth/postTba.js';
 import { postPublicTwoStepAuthorization } from './controllers/auth/postTwoStep.js';
 import { postPublicUnauthenticated } from './controllers/auth/postUnauthenticated.js';
-import { getClientMetadata } from './controllers/clientMetadata/environmentUuid/getClientMetadata.js';
 import { postCliTelemetry } from './controllers/cli/postTelemetry.js';
+import { getClientMetadata } from './controllers/clientMetadata/environmentUuid/getClientMetadata.js';
 import configController from './controllers/config.controller.js';
 import { deleteConnectSession } from './controllers/connect/deleteSession.js';
 import { getConnectSession } from './controllers/connect/getSession.js';

--- a/packages/shared/lib/utils/productTracking.ts
+++ b/packages/shared/lib/utils/productTracking.ts
@@ -2,15 +2,17 @@ import { PostHog } from 'posthog-node';
 
 import { baseUrl, NANGO_VERSION, report } from '@nangohq/utils';
 
-import type { DBTeam, DBUser } from '@nangohq/types';
+import type { CliTelemetryEvent, DBTeam, DBUser } from '@nangohq/types';
 
 export type ProductTrackingTypes =
+    | CliTelemetryEvent
     | 'account:trial:extend'
     | 'account:trial:started'
     | 'account:billing:plan_changed'
     | 'account:billing:downgraded'
     | 'account:billing:upgraded'
     | 'deploy:success'
+    | 'deploy:error'
     | 'prod:connections:threshold_hit'
     | 'server:resource_capped:connection_creation'
     | 'server:resource_capped:connection_imported'
@@ -75,6 +77,35 @@ class ProductTracking {
             }
 
             eventProperties['$set'] = userProperties;
+            this.client.capture({ event: name, distinctId, properties: eventProperties });
+        } catch (err) {
+            report(err);
+        }
+    }
+
+    /**
+     * Track an event that isn't tied to a resolved team, e.g. CLI events sent before or without authentication.
+     * The distinctId is a client-generated device id
+     */
+    public trackAnonymous({
+        name,
+        distinctId,
+        eventProperties
+    }: {
+        name: ProductTrackingTypes;
+        distinctId: string;
+        eventProperties?: Record<string | number, any>;
+    }) {
+        try {
+            if (this.client == null) {
+                return;
+            }
+
+            eventProperties = eventProperties || {};
+            eventProperties['host'] = baseUrl;
+            eventProperties['nango-server-version'] = NANGO_VERSION || 'unknown';
+            eventProperties['device-id'] = distinctId;
+
             this.client.capture({ event: name, distinctId, properties: eventProperties });
         } catch (err) {
             report(err);

--- a/packages/shared/lib/utils/productTracking.ts
+++ b/packages/shared/lib/utils/productTracking.ts
@@ -111,6 +111,28 @@ class ProductTracking {
             report(err);
         }
     }
+
+    /**
+     * Link an anonymous CLI device id to an identified team/user, so anonymous CLI
+     * events (tracked via trackAnonymous) merge into the identified profile in PostHog.
+     * Called from authenticated CLI requests that carry a device id, e.g. deploy.
+     */
+    public alias({ deviceId, team, user }: { deviceId: string; team: Pick<DBTeam, 'id'>; user?: Pick<DBUser, 'id'> | undefined }) {
+        try {
+            if (this.client == null) {
+                return;
+            }
+
+            let alias = `team-${team.id}`;
+            if (user) {
+                alias += `-user-${user.id}`;
+            }
+
+            this.client.alias({ distinctId: deviceId, alias });
+        } catch (err) {
+            report(err);
+        }
+    }
 }
 
 export const productTracking = new ProductTracking();

--- a/packages/types/lib/api.endpoints.ts
+++ b/packages/types/lib/api.endpoints.ts
@@ -27,8 +27,8 @@ import type {
     PostPublicTwoStepAuthorization,
     PostPublicUnauthenticatedAuthorization
 } from './auth/http.api.js';
-import type { GetPublicClientMetadata } from './clientMetadata/http.api.js';
 import type { PostCliTelemetry } from './cli/api.js';
+import type { GetPublicClientMetadata } from './clientMetadata/http.api.js';
 import type {
     DeleteConnectSession,
     GetConnectSession,

--- a/packages/types/lib/api.endpoints.ts
+++ b/packages/types/lib/api.endpoints.ts
@@ -28,6 +28,7 @@ import type {
     PostPublicUnauthenticatedAuthorization
 } from './auth/http.api.js';
 import type { GetPublicClientMetadata } from './clientMetadata/http.api.js';
+import type { PostCliTelemetry } from './cli/api.js';
 import type {
     DeleteConnectSession,
     GetConnectSession,
@@ -153,6 +154,7 @@ export type PublicApiEndpoints =
     | PatchPublicPruneRecords
     | GetPublicScriptsConfig
     | PostPublicConnectTelemetry
+    | PostCliTelemetry
     | PutPublicSyncConnectionFrequency
     | PostPublicIntegration
     | PostPublicQuickstartIntegration

--- a/packages/types/lib/cli/api.ts
+++ b/packages/types/lib/cli/api.ts
@@ -1,0 +1,25 @@
+import type { Endpoint } from '../api.js';
+
+export type CliTelemetryEvent =
+    | 'cli:init'
+    | 'cli:create'
+    | 'cli:compile'
+    | 'cli:dev'
+    | 'cli:dryrun'
+    | 'cli:generate:docs'
+    | 'cli:generate:tests'
+    | 'cli:clone'
+    | 'cli:migrate_to_zero_yaml'
+    | 'cli:deploy'
+    | 'cli:pull';
+
+export type PostCliTelemetry = Endpoint<{
+    Method: 'POST';
+    Path: '/cli/telemetry';
+    Body: {
+        deviceId: string;
+        event: CliTelemetryEvent;
+        properties?: Record<string, string | number | boolean> | undefined;
+    };
+    Success: never;
+}>;

--- a/packages/types/lib/cli/api.ts
+++ b/packages/types/lib/cli/api.ts
@@ -19,7 +19,8 @@ export type PostCliTelemetry = Endpoint<{
     Body: {
         deviceId: string;
         event: CliTelemetryEvent;
-        properties?: Record<string, string | number | boolean> | undefined;
+        // True when deviceId is a throwaway id that couldn't be persisted, so it shouldn't be treated as a stable device.
+        ephemeral?: boolean;
     };
     Success: never;
 }>;

--- a/packages/types/lib/index.ts
+++ b/packages/types/lib/index.ts
@@ -60,6 +60,7 @@ export type * from './deploy/api.js';
 export type * from './deploy/index.js';
 export type * from './deploy/incomingFlow.js';
 export type * from './endpoints/db.js';
+export type * from './cli/api.js';
 export type * from './connect/api.js';
 export type * from './connect/session.js';
 export type * from './endUser/index.js';

--- a/packages/utils/lib/cli-telemetry-events.ts
+++ b/packages/utils/lib/cli-telemetry-events.ts
@@ -1,0 +1,20 @@
+import type { CliTelemetryEvent } from '@nangohq/types';
+
+export const cliTelemetryEvents = [
+    'cli:init',
+    'cli:create',
+    'cli:compile',
+    'cli:dev',
+    'cli:dryrun',
+    'cli:generate:docs',
+    'cli:generate:tests',
+    'cli:clone',
+    'cli:migrate_to_zero_yaml',
+    'cli:deploy',
+    'cli:pull'
+] as const satisfies readonly CliTelemetryEvent[];
+
+// The `satisfies` above rejects entries that aren't valid `CliTelemetryEvent`s;
+// the assertion below rejects any `CliTelemetryEvent` missing from this array.
+// Together they keep the two lists in sync.
+true satisfies [Exclude<CliTelemetryEvent, (typeof cliTelemetryEvents)[number]>] extends [never] ? true : never;

--- a/packages/utils/lib/index.ts
+++ b/packages/utils/lib/index.ts
@@ -1,5 +1,6 @@
 export * from './roles.js';
 export * from './api-key-scopes.js';
+export * from './cli-telemetry-events.js';
 export * from './environment/constants.js';
 export * from './environment/detection.js';
 export * from './environment/parse.js';


### PR DESCRIPTION
- Added telemetry support for CLI commands to track usage events.
- Introduced device ID generation and storage for anonymous tracking.
- Updated CLI options to enable/disable telemetry.
- Created a new endpoint for receiving telemetry data on the server.
- Enhanced headers in HTTP requests to include device ID for tracking.

This change aims to improve insights into CLI usage patterns while respecting user privacy preferences.

<!-- Describe the problem and your solution --> 

<!-- Issue ticket number and link (if applicable) -->

<!-- Testing instructions (skip if just adding/editing providers) -->



<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/NangoHQ/nango/pull/6691?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

