### PR TITLE
fix(connect-ui): preserve apiURL base path in API and WebSocket requests

### DIFF
--- a/packages/connect-ui/src/lib/api.ts
+++ b/packages/connect-ui/src/lib/api.ts
@@ -12,11 +12,6 @@ function uriParamsReplacer(tpl: string, data: Record<string, any>) {
     return res;
 }
 
-function joinPaths(basePath: string, path: string) {
-    const trimmedBase = basePath.replace(/\/$/, '');
-    return `${trimmedBase}${path.startsWith('/') ? path : `/${path}`}`;
-}
-
 export async function fetchApi<TEndpoint extends Endpoint<{ Path: any; Success: any; Method: any; Querystring?: any }>>(
     path: TEndpoint['Path'],
     opts: (TEndpoint['Method'] extends 'GET' ? { method?: TEndpoint['Method'] } : { method: TEndpoint['Method'] }) &
@@ -27,7 +22,10 @@ export async function fetchApi<TEndpoint extends Endpoint<{ Path: any; Success: 
     method?: RequestInit['method']
 ): Promise<TEndpoint['Success']> {
     const url = new URL(useGlobal.getState().apiURL);
-    url.pathname = joinPaths(url.pathname, opts.params ? uriParamsReplacer(path, opts.params) : path);
+    const resolvedPath: string = opts.params ? uriParamsReplacer(path, opts.params) : path;
+    // Append instead of assigning to `url.pathname` directly, so a base path configured in
+    // `apiURL` (e.g. a self-hosted reverse-proxy prefix) is preserved rather than replaced.
+    url.pathname = `${url.pathname.replace(/\/+$/, '')}${resolvedPath.startsWith('/') ? resolvedPath : `/${resolvedPath}`}`;
 
     if (opts?.query) {
         for (const key in opts.query) {

--- a/packages/connect-ui/src/lib/api.ts
+++ b/packages/connect-ui/src/lib/api.ts
@@ -12,6 +12,11 @@ function uriParamsReplacer(tpl: string, data: Record<string, any>) {
     return res;
 }
 
+function joinPaths(basePath: string, path: string) {
+    const trimmedBase = basePath.replace(/\/$/, '');
+    return `${trimmedBase}${path.startsWith('/') ? path : `/${path}`}`;
+}
+
 export async function fetchApi<TEndpoint extends Endpoint<{ Path: any; Success: any; Method: any; Querystring?: any }>>(
     path: TEndpoint['Path'],
     opts: (TEndpoint['Method'] extends 'GET' ? { method?: TEndpoint['Method'] } : { method: TEndpoint['Method'] }) &
@@ -22,7 +27,7 @@ export async function fetchApi<TEndpoint extends Endpoint<{ Path: any; Success: 
     method?: RequestInit['method']
 ): Promise<TEndpoint['Success']> {
     const url = new URL(useGlobal.getState().apiURL);
-    url.pathname = opts.params ? uriParamsReplacer(path, opts.params) : path;
+    url.pathname = joinPaths(url.pathname, opts.params ? uriParamsReplacer(path, opts.params) : path);
 
     if (opts?.query) {
         for (const key in opts.query) {

--- a/packages/connect-ui/src/lib/api.unit.test.ts
+++ b/packages/connect-ui/src/lib/api.unit.test.ts
@@ -1,0 +1,72 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+
+import { getConnectSession, getIntegrations, getProvider } from './api.js';
+import { useGlobal } from './store.js';
+
+const BASE_PATH_API_URL = 'https://example.com/base/path';
+
+function mockFetchOnce(status = 200, body: unknown = { data: {} }) {
+    const fetchMock = vi.fn().mockResolvedValue(new Response(JSON.stringify(body), { status }));
+    vi.stubGlobal('fetch', fetchMock);
+    return fetchMock;
+}
+
+describe('fetchApi base path handling', () => {
+    beforeEach(() => {
+        useGlobal.getState().setSessionToken('test-session-token');
+    });
+
+    afterEach(() => {
+        vi.unstubAllGlobals();
+    });
+
+    it('requests a bare-origin apiURL without altering the path', async () => {
+        useGlobal.getState().setApiURL('https://api.nango.dev');
+        const fetchMock = mockFetchOnce();
+
+        await getConnectSession();
+
+        const requestedUrl = fetchMock.mock.calls[0]?.[0] as URL;
+        expect(requestedUrl.toString()).toBe('https://api.nango.dev/connect/session');
+    });
+
+    it('preserves a self-hosted base path prefix on /connect/session', async () => {
+        useGlobal.getState().setApiURL(BASE_PATH_API_URL);
+        const fetchMock = mockFetchOnce();
+
+        await getConnectSession();
+
+        const requestedUrl = fetchMock.mock.calls[0]?.[0] as URL;
+        expect(requestedUrl.toString()).toBe(`${BASE_PATH_API_URL}/connect/session`);
+    });
+
+    it('preserves a self-hosted base path prefix on /integrations', async () => {
+        useGlobal.getState().setApiURL(BASE_PATH_API_URL);
+        const fetchMock = mockFetchOnce();
+
+        await getIntegrations();
+
+        const requestedUrl = fetchMock.mock.calls[0]?.[0] as URL;
+        expect(requestedUrl.toString()).toBe(`${BASE_PATH_API_URL}/integrations`);
+    });
+
+    it('preserves a self-hosted base path prefix on parameterized routes (/providers/:provider)', async () => {
+        useGlobal.getState().setApiURL(BASE_PATH_API_URL);
+        const fetchMock = mockFetchOnce();
+
+        await getProvider({ provider: 'jira' });
+
+        const requestedUrl = fetchMock.mock.calls[0]?.[0] as URL;
+        expect(requestedUrl.toString()).toBe(`${BASE_PATH_API_URL}/providers/jira`);
+    });
+
+    it('preserves a base path prefix with a trailing slash', async () => {
+        useGlobal.getState().setApiURL(`${BASE_PATH_API_URL}/`);
+        const fetchMock = mockFetchOnce();
+
+        await getIntegrations();
+
+        const requestedUrl = fetchMock.mock.calls[0]?.[0] as URL;
+        expect(requestedUrl.toString()).toBe(`${BASE_PATH_API_URL}/integrations`);
+    });
+});

--- a/packages/connect-ui/src/lib/nango.ts
+++ b/packages/connect-ui/src/lib/nango.ts
@@ -19,7 +19,11 @@ export function useNango() {
         setNango(
             new Nango({
                 connectSessionToken: sessionToken,
-                host: apiURL
+                host: apiURL,
+                // `Nango` resolves `websocketsPath` as an absolute path from the origin, which would
+                // silently drop any base path configured in `apiURL` (e.g. a self-hosted reverse-proxy
+                // prefix). Deriving it from apiURL's own path here keeps that prefix intact.
+                websocketsPath: `${new URL(apiURL).pathname.replace(/\/+$/, '')}/`
             })
         );
     }, [sessionToken]);

--- a/packages/webapp/src/utils/slack-connection.ts
+++ b/packages/webapp/src/utils/slack-connection.ts
@@ -31,7 +31,14 @@ export const connectSlack = async ({
     const authResponse = await res.json();
     const { hmac_digest: hmacDigest, public_key: publicKey, integration_key: integrationKey } = authResponse;
 
-    const nango = new Nango({ host: hostUrl, publicKey });
+    const nango = new Nango({
+        host: hostUrl,
+        publicKey,
+        // `Nango` resolves `websocketsPath` as an absolute path from the origin, which would
+        // silently drop any base path configured in `hostUrl` (e.g. a self-hosted reverse-proxy
+        // prefix). Deriving it from hostUrl's own path here keeps that prefix intact.
+        websocketsPath: `${new URL(hostUrl).pathname.replace(/\/+$/, '')}/`
+    });
     nango
         .auth(integrationKey, connectionId, {
             user_scope: [],


### PR DESCRIPTION
<!-- Describe the problem and your solution --> 


 - `fetchApi()` replaced `url.pathname` whole instead of appending to it, silently dropping any base path configured in `apiURL` (e.g. a self-hosted reverse-proxy prefix) on `/connect/session`, `/integrations`, and `/providers/:provider`.

- The oauth popup flow had the same issue one level down: nango's websocketsPath resolves as an absolute path from the origin, so its default value of `/` discarded `apiURL's` base path too, breaking the websocket used to detect auth completion. Fixed from the caller side by deriving `websocketsPath` from apiURL's own path.

<!-- Issue ticket number and link (if applicable) -->

<!-- Testing instructions (skip if just adding/editing providers) -->



<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/NangoHQ/nango/pull/6695?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

