### PR TITLE
fix(csp): allow Plain widget and disable Zod JIT in Connect UI

### DIFF
--- a/packages/connect-ui/src/lib/zod-config.ts
+++ b/packages/connect-ui/src/lib/zod-config.ts
@@ -1,0 +1,10 @@
+import * as z from 'zod';
+
+// Disable Zod v4's JIT validator compilation, which uses `new Function` and trips
+// the Connect UI's `script-src` CSP (report-only today). The non-JIT path is
+// functionally identical, so this keeps `script-src 'self'` without `'unsafe-eval'`.
+//
+// This lives in its own module so main.tsx can import it *first* — ES modules
+// evaluate all imports before the importing module's body, so any Zod schema
+// created in the App tree must see jitless already set.
+z.config({ jitless: true });

--- a/packages/connect-ui/src/main.tsx
+++ b/packages/connect-ui/src/main.tsx
@@ -1,15 +1,13 @@
 // import { StrictMode } from 'react';
+// Must be imported first: disables Zod's JIT (new Function) before any schema in
+// the App tree is created, so the Connect UI's `script-src` CSP isn't tripped.
+import './lib/zod-config';
+
 import { createRoot } from 'react-dom/client';
-import * as z from 'zod';
 
 import { App } from './App.tsx';
 
 import './index.css';
-
-// Disable Zod v4's JIT validator compilation, which uses `new Function` and trips
-// the Connect UI's `script-src` CSP (report-only today). The non-JIT path is
-// functionally identical, so this keeps `script-src 'self'` without `'unsafe-eval'`.
-z.config({ jitless: true });
 
 createRoot(document.getElementById('root') as HTMLElement).render(
     // <StrictMode>

--- a/packages/connect-ui/src/main.tsx
+++ b/packages/connect-ui/src/main.tsx
@@ -1,9 +1,15 @@
 // import { StrictMode } from 'react';
 import { createRoot } from 'react-dom/client';
+import * as z from 'zod';
 
 import { App } from './App.tsx';
 
 import './index.css';
+
+// Disable Zod v4's JIT validator compilation, which uses `new Function` and trips
+// the Connect UI's `script-src` CSP (report-only today). The non-JIT path is
+// functionally identical, so this keeps `script-src 'self'` without `'unsafe-eval'`.
+z.config({ jitless: true });
 
 createRoot(document.getElementById('root') as HTMLElement).render(
     // <StrictMode>

--- a/packages/server/lib/middleware/security.ts
+++ b/packages/server/lib/middleware/security.ts
@@ -39,7 +39,7 @@ export function securityMiddlewares(): RequestHandler[] {
                     'https://*.plain.com',
                     'wss://*.plain.com'
                 ],
-                fontSrc: ["'self'", 'https://*.googleapis.com', 'https://*.gstatic.com'],
+                fontSrc: ["'self'", 'https://*.googleapis.com', 'https://*.gstatic.com', 'https://*.cdn-plain.com'],
                 frameSrc: ["'self'", 'https://accounts.google.com', hostPublic, hostApi, connectUrl, 'https://www.youtube.com', 'https://*.stripe.com'],
                 imgSrc: [
                     "'self'",
@@ -68,7 +68,7 @@ export function securityMiddlewares(): RequestHandler[] {
                     'https://apis.google.com',
                     'https://*.posthog.com',
                     'https://www.youtube.com',
-                    'https://chat.cdn-plain.com'
+                    'https://*.cdn-plain.com'
                 ],
                 styleSrc: ['blob:', "'self'", "'unsafe-inline'", 'https://*.googleapis.com', hostPublic, hostApi],
                 workerSrc: ['blob:', "'self'", hostPublic, hostApi, 'https://*.googleapis.com', 'https://*.posthog.com']


### PR DESCRIPTION
## Problem

The report-only CSP rollout on the front-end distributions (NAN-6012; infra in [nango-infra#165](https://github.com/NangoHQ/nango-infra/pull/165)) surfaced two violations on dev that would break under enforcement:
- the **Plain** support widget (dashboard "Help") is blocked, and
- the **Connect UI**'s Zod validation trips `script-src` via `new Function`.

## Solution

- **server**: add Plain origins (`*.cdn-plain.com` for script/font, `*.plain.com` + `wss://*.plain.com` for connect) to the helmet CSP, mirroring the CloudFront policy so self-hosted/API stay in sync.
- **connect-ui**: `z.config({ jitless: true })` disables Zod v4's JIT validator (which compiles with `new Function`). The non-JIT path is functionally identical, so the Connect UI keeps `script-src 'self'` with no `'unsafe-eval'`.

Fixes [NAN-6012](https://linear.app/nango/issue/NAN-6012)

## Testing

- Verified against the dev report-only policy: after the Plain additions, an end-to-end dashboard sweep (agent-browser + HAR capture of CSP `report-uri` POSTs) is clean.
- The Connect UI `eval` report clears once this deploys (Zod also falls back gracefully under enforcement regardless).
- Live CSP violations (report-only): https://nango.sentry.io/issues/?project=4506314548510721&query=event.type%3Acsp&referrer=issue-list&statsPeriod=14d
