### PR TITLE
feat(function): tweak function input and concurrency

### DIFF
--- a/packages/runner-sdk/lib/function.ts
+++ b/packages/runner-sdk/lib/function.ts
@@ -148,7 +148,7 @@ export interface MetadataCapability<TValue> {
 }
 // Any function can be invoked.
 // The caller's input is the function's declared input or `void` when the trigger declares none.
-type InferInput<T> = T extends CreateFunctionResponse<infer _M, infer _O, infer _Me, infer _Cp, infer Tr, infer _Ac> ? z.infer<TriggerInput<Tr>> : never;
+type InferInput<T> = T extends { trigger: infer Tr } ? z.infer<TriggerInput<Tr>> : never;
 type InferOutput<T> = T extends CreateFunctionResponse<infer _M, infer O extends z.ZodTypeAny, infer _Me, infer _Cp, infer _Tr, infer _Ac> ? z.infer<O> : never;
 type InvokeConnection = { connection_id: string; integrationId: string };
 // `invoke` options: `input` is required when the target declares one, and the whole object is optional when it declares none.
@@ -157,7 +157,7 @@ type InvokeArgs<T> = [InferInput<T>] extends [void]
     : [options: { input: InferInput<T>; connection?: InvokeConnection }];
 // Present when `requires.invoke` is set: call another function and get its typed output back.
 export interface InvokeCapability {
-    invoke<T extends { type: 'function' }>(fn: T, ...args: InvokeArgs<T>): Promise<InferOutput<T>>;
+    invoke<T extends { type: 'function'; trigger: TriggerDefinition }>(fn: T, ...args: InvokeArgs<T>): Promise<InferOutput<T>>;
 }
 
 // The capability-narrowed SDK surface a function `exec` receives.

--- a/packages/runner-sdk/lib/function.ts
+++ b/packages/runner-sdk/lib/function.ts
@@ -35,17 +35,15 @@ export interface DebounceOptions {
 // Triggers
 
 /**
- * A function declares exactly one trigger: the `kind` discriminates what initiates execution.
+ * A trigger declares how a function is initiated FROM OUTSIDE; the `kind` discriminates what initiates execution.
  * - `schedule`: a periodic schedule
  * - `http`: an incoming http call or webhook request
  * - `event`: an internal Nango lifecycle event
- * - `invoke`: called by another function via `nango.invoke()`
  */
 export type TriggerDefinition =
     | { kind: 'schedule'; frequency: string; autoStart?: boolean }
-    | { kind: 'http'; input?: z.ZodTypeAny; subscriptions?: string[]; debounce?: DebounceOptions }
-    | { kind: 'event'; events: OnEventType[] }
-    | { kind: 'invoke'; input?: z.ZodTypeAny };
+    | { kind: 'http'; subscriptions?: string[]; debounce?: DebounceOptions }
+    | { kind: 'event'; events: OnEventType[] };
 
 // The inbound http request that initiated the run.
 export interface HttpRequest {
@@ -62,29 +60,43 @@ export interface CoalescedInfo {
     lastSeenAt: Date;
 }
 
-type TriggerInput<TTrigger> = TTrigger extends { input: infer I extends z.ZodTypeAny } ? I : z.ZodVoid;
-
 // `debounce.take: 'all'` delivers the whole coalesced batch, so the payload becomes an array; otherwise a single input.
-type HttpPayload<TT> = TT extends { debounce: { take: 'all' } } ? z.infer<TriggerInput<TT>>[] : z.infer<TriggerInput<TT>>;
+type HttpPayload<TT, TInput extends z.ZodTypeAny> = TT extends { debounce: { take: 'all' } } ? z.infer<TInput>[] : z.infer<TInput>;
 
 interface TriggerBase {
     /**
-     * Pre-populated when the run was started with connection context.
-     * Undefined for connection-less runs.
+     * Present when the run carries connection context (invoke calls may pass one;
+     * http/event may resolve one). Undefined for connection-less runs.
      */
     connection?: { connection_id: string; integrationId: string };
 }
 
-// The runtime trigger a function `exec` receives, mapped from the declared `TriggerDefinition`.
-export type Trigger<TT extends TriggerDefinition> = TT extends { kind: 'schedule' }
-    ? TriggerBase & { kind: 'schedule'; payload: null }
-    : TT extends { kind: 'invoke' }
-      ? TriggerBase & { kind: 'invoke'; payload: z.infer<TriggerInput<TT>> }
-      : TT extends { kind: 'http' }
-        ? TriggerBase & { kind: 'http'; payload: HttpPayload<TT>; request: HttpRequest; subscriptions?: string[]; coalesced: CoalescedInfo }
-        : TT extends { kind: 'event' }
-          ? TriggerBase & { kind: 'event'; payload: { event: OnEventType } }
-          : never;
+// The per-kind runtime trigger shapes an `exec` can receive.
+export type InvokeTrigger<TInput extends z.ZodTypeAny> = TriggerBase & { kind: 'invoke'; input: z.infer<TInput> };
+export type ScheduleTrigger = TriggerBase & { kind: 'schedule'; input: null };
+export type HttpTrigger<TT, TInput extends z.ZodTypeAny> = TriggerBase & {
+    kind: 'http';
+    input: HttpPayload<TT, TInput>;
+    request: HttpRequest;
+    subscriptions?: string[];
+    coalesced: CoalescedInfo;
+};
+export type EventTrigger = TriggerBase & { kind: 'event'; input: { event: OnEventType } };
+
+/**
+ * The runtime trigger a function `exec` receives. Any function can be invoked by another, but an
+ * invoke reuses the declared trigger's shape rather than adding a separate arrival — so `exec` only
+ * ever sees its declared kind and never has to discriminate. On the invoke path the runtime
+ * synthesizes the envelope (e.g. an http `request`/`coalesced` derived from the invoked input).
+ * A function with no declared trigger is invoke-only and receives `InvokeTrigger`.
+ */
+export type Trigger<TT extends TriggerDefinition | undefined, TInput extends z.ZodTypeAny> = TT extends { kind: 'schedule' }
+    ? ScheduleTrigger
+    : TT extends { kind: 'http' }
+      ? HttpTrigger<TT, TInput>
+      : TT extends { kind: 'event' }
+        ? EventTrigger
+        : InvokeTrigger<TInput>;
 
 // Capability-narrowed nango
 
@@ -146,18 +158,21 @@ export interface MetadataCapability<TValue> {
     setMetadata(metadata: TValue): Promise<void>;
     updateMetadata(metadata: Partial<TValue>): Promise<void>;
 }
-// Any function can be invoked.
-// The caller's input is the function's declared input or `void` when the trigger declares none.
-type InferInput<T> = T extends { trigger: infer Tr } ? z.infer<TriggerInput<Tr>> : never;
-type InferOutput<T> = T extends CreateFunctionResponse<infer _M, infer O extends z.ZodTypeAny, infer _Me, infer _Cp, infer _Tr, infer _Ac> ? z.infer<O> : never;
+type InferInput<T> =
+    T extends CreateFunctionResponse<infer _M, infer I extends z.ZodTypeAny, infer _O, infer _Me, infer _Cp, infer _Tr, infer _R> ? z.infer<I> : void;
+type InferOutput<T> =
+    T extends CreateFunctionResponse<infer _M, infer _I, infer O extends z.ZodTypeAny, infer _Me, infer _Cp, infer _Tr, infer _R> ? z.infer<O> : void;
+
+// Any function can be invoked. Input/output live on the function itself, not the trigger.
 type InvokeConnection = { connection_id: string; integrationId: string };
+type InvokeTarget = { type: 'function'; capabilities: FunctionCapabilities };
 // `invoke` options: `input` is required when the target declares one, and the whole object is optional when it declares none.
 type InvokeArgs<T> = [InferInput<T>] extends [void]
     ? [options?: { connection?: InvokeConnection }]
     : [options: { input: InferInput<T>; connection?: InvokeConnection }];
 // Present when `requires.invoke` is set: call another function and get its typed output back.
 export interface InvokeCapability {
-    invoke<T extends { type: 'function'; trigger: TriggerDefinition }>(fn: T, ...args: InvokeArgs<T>): Promise<InferOutput<T>>;
+    invoke<T extends InvokeTarget>(fn: T, ...args: InvokeArgs<T>): Promise<InferOutput<T>>;
 }
 
 // The capability-narrowed SDK surface a function `exec` receives.
@@ -197,13 +212,16 @@ export interface FunctionCapabilities {
 }
 export interface CreateFunctionProps<
     TModels extends Record<string, ZodModel> = Record<never, ZodModel>,
+    TInput extends z.ZodTypeAny = z.ZodVoid,
     TOutput extends z.ZodTypeAny = z.ZodVoid,
     TMetadata extends ZodMetadata = undefined,
     TCheckpoint extends ZodCheckpoint = undefined,
-    TTrigger extends TriggerDefinition = TriggerDefinition,
+    TTrigger extends TriggerDefinition | undefined = undefined,
     TRequires extends Requires = { outbound: true; connection: true }
 > {
     description: string;
+    // Optional input schema: the invoke call argument and/or the http request body. Omit when there is no input.
+    input?: TInput;
     // Optional output schema, typing `exec`'s return value.
     output?: TOutput;
     data?: TRequires extends { connection: false }
@@ -216,8 +234,8 @@ export interface CreateFunctionProps<
               // Progress/resume state schema.
               checkpoint?: TCheckpoint;
           };
-    // What initiates execution.
-    trigger: TTrigger;
+    // How the function is initiated from outside. Omit for an invoke-only helper.
+    trigger?: TTrigger;
     // Opt in/out of capabilities (connection, outbound, invoke). See `Requires`.
     requires?: TRequires;
     limits?: {
@@ -227,16 +245,17 @@ export interface CreateFunctionProps<
         };
     };
     // The handler. Runs on the runner with the capability-narrowed `nango` surface.
-    exec: (nango: Nango<TModels, TMetadata, TCheckpoint, TRequires>, trigger: Trigger<TTrigger>) => MaybePromise<z.infer<TOutput>>;
+    exec: (nango: Nango<TModels, TMetadata, TCheckpoint, TRequires>, trigger: Trigger<TTrigger, TInput>) => MaybePromise<z.infer<TOutput>>;
 }
 export interface CreateFunctionResponse<
     TModels extends Record<string, ZodModel> = Record<never, ZodModel>,
+    TInput extends z.ZodTypeAny = z.ZodVoid,
     TOutput extends z.ZodTypeAny = z.ZodVoid,
     TMetadata extends ZodMetadata = undefined,
     TCheckpoint extends ZodCheckpoint = undefined,
-    TTrigger extends TriggerDefinition = TriggerDefinition,
+    TTrigger extends TriggerDefinition | undefined = undefined,
     TRequires extends Requires = { outbound: true; connection: true }
-> extends CreateFunctionProps<TModels, TOutput, TMetadata, TCheckpoint, TTrigger, TRequires> {
+> extends CreateFunctionProps<TModels, TInput, TOutput, TMetadata, TCheckpoint, TTrigger, TRequires> {
     type: 'function';
     // The capabilities derived from the function definition.
     capabilities: FunctionCapabilities;
@@ -259,14 +278,15 @@ export interface CreateFunctionResponse<
  */
 export function createFunction<
     TModels extends Record<string, ZodModel> = Record<never, ZodModel>,
+    TInput extends z.ZodTypeAny = z.ZodVoid,
     TOutput extends z.ZodTypeAny = z.ZodVoid,
     TMetadata extends ZodMetadata = undefined,
     TCheckpoint extends ZodCheckpoint = undefined,
-    TTrigger extends TriggerDefinition = TriggerDefinition,
+    TTrigger extends TriggerDefinition | undefined = undefined,
     TRequires extends Requires = { outbound: true; connection: true }
 >(
-    params: CreateFunctionProps<TModels, TOutput, TMetadata, TCheckpoint, TTrigger, TRequires>
-): CreateFunctionResponse<TModels, TOutput, TMetadata, TCheckpoint, TTrigger, TRequires> {
+    params: CreateFunctionProps<TModels, TInput, TOutput, TMetadata, TCheckpoint, TTrigger, TRequires>
+): CreateFunctionResponse<TModels, TInput, TOutput, TMetadata, TCheckpoint, TTrigger, TRequires> {
     const models = params.data?.models;
     // A connection-less function has no connection to proxy through, so outbound is always off.
     const connectionLess = params.requires?.connection === false;

--- a/packages/runner-sdk/lib/function.ts
+++ b/packages/runner-sdk/lib/function.ts
@@ -8,6 +8,7 @@ type InferZod<T> = T extends z.ZodTypeAny ? z.infer<T> : never;
 
 // Limits
 
+// Max concurrent runs for a single connection: `1` serializes, `'max'` lets them overlap.
 export type ConcurrencyLimit = 1 | 'max';
 
 // Debounce
@@ -220,8 +221,10 @@ export interface CreateFunctionProps<
     // Opt in/out of capabilities (connection, outbound, invoke). See `Requires`.
     requires?: TRequires;
     limits?: {
-        // Max concurrent runs. Pinned to `1` for schedule triggers; `'max'` allowed otherwise.
-        concurrency?: TTrigger extends { kind: 'schedule' } ? 1 : ConcurrencyLimit;
+        concurrency?: {
+            // Max concurrent runs for a single connection. Pinned to `1` for schedule triggers.
+            perConnection?: TTrigger extends { kind: 'schedule' } ? 1 : ConcurrencyLimit;
+        };
     };
     // The handler. Runs on the runner with the capability-narrowed `nango` surface.
     exec: (nango: Nango<TModels, TMetadata, TCheckpoint, TRequires>, trigger: Trigger<TTrigger>) => MaybePromise<z.infer<TOutput>>;

--- a/packages/runner-sdk/lib/function.ts
+++ b/packages/runner-sdk/lib/function.ts
@@ -234,7 +234,8 @@ export interface CreateFunctionProps<
 > {
     description: string;
     // Optional input schema: the invoke call argument and/or the http request body. Omit when there is no input.
-    input?: TInput;
+    // schedule or event triggers have no input
+    input?: TTrigger extends { kind: 'schedule' } | { kind: 'event' } ? never : TInput;
     // Optional output schema, typing `exec`'s return value.
     output?: TOutput;
     data?: TRequires extends { connection: false }

--- a/packages/runner-sdk/lib/function.ts
+++ b/packages/runner-sdk/lib/function.ts
@@ -44,7 +44,7 @@ export type TriggerDefinition =
     | { kind: 'schedule'; frequency: string; autoStart?: boolean }
     | { kind: 'http'; input?: z.ZodTypeAny; subscriptions?: string[]; debounce?: DebounceOptions }
     | { kind: 'event'; events: OnEventType[] }
-    | { kind: 'invoke'; input: z.ZodTypeAny };
+    | { kind: 'invoke'; input?: z.ZodTypeAny };
 
 // The inbound http request that initiated the run.
 export interface HttpRequest {
@@ -145,17 +145,18 @@ export interface MetadataCapability<TValue> {
     setMetadata(metadata: TValue): Promise<void>;
     updateMetadata(metadata: Partial<TValue>): Promise<void>;
 }
-type InferInput<T> =
-    T extends CreateFunctionResponse<infer _M, infer _O, infer _Me, infer _Cp, infer Tr, infer _Ac>
-        ? Tr extends { kind: 'invoke'; input: infer I extends z.ZodTypeAny }
-            ? z.infer<I>
-            : never
-        : never;
+// Any function can be invoked.
+// The caller's input is the function's declared input or `void` when the trigger declares none.
+type InferInput<T> = T extends CreateFunctionResponse<infer _M, infer _O, infer _Me, infer _Cp, infer Tr, infer _Ac> ? z.infer<TriggerInput<Tr>> : never;
 type InferOutput<T> = T extends CreateFunctionResponse<infer _M, infer O extends z.ZodTypeAny, infer _Me, infer _Cp, infer _Tr, infer _Ac> ? z.infer<O> : never;
+type InvokeConnection = { connection_id: string; integrationId: string };
+// `invoke` options: `input` is required when the target declares one, and the whole object is optional when it declares none.
+type InvokeArgs<T> = [InferInput<T>] extends [void]
+    ? [options?: { connection?: InvokeConnection }]
+    : [options: { input: InferInput<T>; connection?: InvokeConnection }];
 // Present when `requires.invoke` is set: call another function and get its typed output back.
-// Pass `connection` to run the invoked function against a specific connection (e.g. one found via `searchConnections`).
 export interface InvokeCapability {
-    invoke<T extends { type: 'function' }>(fn: T, input: InferInput<T>, connection?: { connection_id: string; integrationId: string }): Promise<InferOutput<T>>;
+    invoke<T extends { type: 'function' }>(fn: T, ...args: InvokeArgs<T>): Promise<InferOutput<T>>;
 }
 
 // The capability-narrowed SDK surface a function `exec` receives.

--- a/packages/runner-sdk/lib/function.ts
+++ b/packages/runner-sdk/lib/function.ts
@@ -1,7 +1,17 @@
 import type { ProxyConfiguration } from './action.js';
 import type { ZodCheckpoint, ZodMetadata, ZodModel } from './types.js';
 import type { UncontrolledFetchOptions } from './uncontrolledFetch.js';
-import type { GetPublicConnection, HTTP_METHOD, MaybePromise, MergingStrategy, OnEventType } from '@nangohq/types';
+import type {
+    AllAuthCredentials,
+    EnvironmentVariable,
+    GetPublicConnection,
+    GetPublicIntegration,
+    HTTP_METHOD,
+    MaybePromise,
+    MergingStrategy,
+    OnEventType,
+    SdkLogger
+} from '@nangohq/types';
 import type * as z from 'zod';
 
 type InferZod<T> = T extends z.ZodTypeAny ? z.infer<T> : never;
@@ -103,10 +113,15 @@ export type Trigger<TT extends TriggerDefinition | undefined, TInput extends z.Z
 // Always present: base methods every function can use.
 export interface NangoBase {
     log(message: string, options?: unknown): Promise<void>;
+    setLogger(logger: SdkLogger): void;
+    getEnvironmentVariables(): Promise<EnvironmentVariable[] | null>;
 }
 // Present for connection-bound runs: the single connection the run executes against.
 export interface ConnectionCapability {
     getConnection(): Promise<GetPublicConnection['Success']>;
+    getToken(): Promise<string | AllAuthCredentials>;
+    getIntegration(queries?: GetPublicIntegration['Querystring']): Promise<GetPublicIntegration['Success']['data']>;
+    getVariant(): string;
 }
 /**
  * Present for connection-less runs instead of `getConnection`.
@@ -138,8 +153,6 @@ export interface RecordCapability<TModels extends Record<string, ZodModel>> {
     batchSave<K extends keyof TModels>(records: z.infer<TModels[K]>[], model: K): Promise<void>;
     batchUpdate<K extends keyof TModels>(records: z.infer<TModels[K]>[], model: K): Promise<void>;
     batchDelete<K extends keyof TModels>(records: z.infer<TModels[K]>[], model: K): Promise<void>;
-    getRecordsByIds<K extends keyof TModels, TKey extends string | number = string>(ids: TKey[], model: K): Promise<Map<TKey, z.infer<TModels[K]>>>;
-    listRecords<K extends keyof TModels>(model: K, options?: { cursor?: string }): AsyncGenerator<z.infer<TModels[K]>>;
     setMergingStrategy(merging: MergingStrategy, model: keyof TModels): Promise<void>;
     trackDeletesStart(model: keyof TModels): Promise<void>;
     trackDeletesEnd(model: keyof TModels): Promise<void>;

--- a/packages/runner-sdk/lib/function.unit.test.ts
+++ b/packages/runner-sdk/lib/function.unit.test.ts
@@ -19,7 +19,6 @@ describe('createFunction', () => {
                     metadata: z.object({ org: z.string() })
                 },
                 trigger: { kind: 'schedule', frequency: 'every 2h', autoStart: true },
-                limits: { concurrency: 1 },
                 exec: async (nango, trigger) => {
                     await nango.batchSave([{ id: '1', title: 't' }], 'GithubIssue');
                     await nango.batchUpdate([{ id: '1', title: 't' }], 'GithubIssue');
@@ -100,7 +99,6 @@ describe('createFunction', () => {
                 description: 'Create a GitHub issue',
                 output: z.object({ issueId: z.string() }),
                 trigger: { kind: 'http', input: z.object({ title: z.string() }) },
-                limits: { concurrency: 'max' },
                 exec: (_nango, trigger) => {
                     expectTypeOf<Has<typeof _nango, 'proxy'>>().toEqualTypeOf<true>();
                     expectTypeOf<Has<typeof _nango, 'batchSave'>>().toEqualTypeOf<false>();
@@ -226,40 +224,27 @@ describe('createFunction', () => {
         });
     });
 
-    describe('limits.concurrency', () => {
-        it('is fixed to 1 for schedule triggers and a Concurrency value otherwise', () => {
+    describe('limits.concurrency.perConnection', () => {
+        it('is fixed to 1 for schedule triggers and a ConcurrencyLimit otherwise', () => {
             createFunction({
                 description: 'scheduled',
-                data: { models: { M: z.object({ id: z.string() }) } },
                 trigger: { kind: 'schedule', frequency: 'every hour' },
-                limits: { concurrency: 1 },
-                exec: async (nango) => {
-                    await nango.batchSave([{ id: '1' }], 'M');
-                }
-            });
-
-            createFunction({
-                description: 'http',
-                trigger: { kind: 'http', input: z.object({}) },
-                limits: { concurrency: 'max' },
+                limits: { concurrency: { perConnection: 1 } },
                 exec: () => {}
             });
 
             createFunction({
-                description: 'http writing records can exceed 1',
-                data: { models: { M: z.object({ id: z.string() }) } },
+                description: 'http can overlap runs for a connection',
                 trigger: { kind: 'http', input: z.object({}) },
-                limits: { concurrency: 'max' },
-                exec: async (nango) => {
-                    await nango.batchSave([{ id: '1' }], 'M');
-                }
+                limits: { concurrency: { perConnection: 'max' } },
+                exec: () => {}
             });
 
             createFunction({
-                description: 'schedule function cannot exceed 1',
+                description: 'schedule function cannot overlap',
                 trigger: { kind: 'schedule', frequency: 'every hour' },
-                // @ts-expect-error schedule triggers are pinned to concurrency: 1
-                limits: { concurrency: 'max' },
+                // @ts-expect-error schedule triggers are pinned to perConnection: 1
+                limits: { concurrency: { perConnection: 'max' } },
                 exec: () => {}
             });
         });

--- a/packages/runner-sdk/lib/function.unit.test.ts
+++ b/packages/runner-sdk/lib/function.unit.test.ts
@@ -47,6 +47,28 @@ describe('createFunction', () => {
                 useInvoke: false
             });
         });
+
+        it('disallows a declared input on schedule and event triggers', () => {
+            createFunction({
+                description: 'schedule cannot declare input',
+                // @ts-expect-error schedule triggers carry no caller input
+                input: z.object({ since: z.string() }),
+                trigger: { kind: 'schedule', frequency: 'every hour' },
+                exec: (_nango, trigger) => {
+                    expectTypeOf(trigger.input).toEqualTypeOf<null>();
+                }
+            });
+
+            createFunction({
+                description: 'event cannot declare input',
+                // @ts-expect-error event triggers carry no caller input
+                input: z.object({ since: z.string() }),
+                trigger: { kind: 'event', events: ['pre-connection-deletion'] },
+                exec: (_nango, trigger) => {
+                    expectTypeOf(trigger.input).toEqualTypeOf<{ event: OnEventType }>();
+                }
+            });
+        });
     });
 
     describe('http with models (webhook)', () => {

--- a/packages/runner-sdk/lib/function.unit.test.ts
+++ b/packages/runner-sdk/lib/function.unit.test.ts
@@ -187,8 +187,17 @@ describe('createFunction', () => {
                     // @ts-expect-error http input must match the trigger's input schema
                     await nango.invoke(httpFn, { input: { wrong: 1 } });
 
+                    // @ts-expect-error required input cannot be skipped
+                    await nango.invoke(httpFn);
+
                     // schedule target: no declared input
                     await nango.invoke(scheduleFn);
+
+                    // a widened/opaque function reference (with no trigger) is rejected
+                    // so it can't skip required input
+                    const opaque = httpFn as { type: 'function' };
+                    // @ts-expect-error opaque reference does not satisfy the invoke target constraint
+                    await nango.invoke(opaque, { input: { title: 'x' } });
                 }
             });
         });

--- a/packages/runner-sdk/lib/function.unit.test.ts
+++ b/packages/runner-sdk/lib/function.unit.test.ts
@@ -149,7 +149,7 @@ describe('createFunction', () => {
                 exec: async (nango) => {
                     expectTypeOf<Has<typeof nango, 'invoke'>>().toEqualTypeOf<true>();
                     expectTypeOf<Has<typeof nango, 'proxy'>>().toEqualTypeOf<false>();
-                    const res = await nango.invoke(child, { q: 'x' });
+                    const res = await nango.invoke(child, { input: { q: 'x' } });
                     expectTypeOf(res).toEqualTypeOf<{ n: number }>();
                 }
             });
@@ -160,6 +160,38 @@ describe('createFunction', () => {
                 useMetadata: false,
                 useOutbound: false,
                 useInvoke: true
+            });
+        });
+
+        it('invoke types its input from the target trigger, regardless of trigger kind', () => {
+            const httpFn = createFunction({
+                description: 'http target',
+                output: z.object({ ok: z.boolean() }),
+                trigger: { kind: 'http', input: z.object({ title: z.string() }), debounce: { windowMs: 1000, take: 'all' } },
+                exec: () => ({ ok: true })
+            });
+
+            const scheduleFn = createFunction({
+                description: 'schedule target',
+                trigger: { kind: 'schedule', frequency: 'every hour' },
+                exec: () => {}
+            });
+
+            createFunction({
+                description: 'dispatcher',
+                requires: { outbound: false, invoke: true },
+                trigger: { kind: 'schedule', frequency: 'every hour' },
+                exec: async (nango) => {
+                    // http target: input matches the trigger input (single, not the coalesced array), output is typed
+                    const httpRes = await nango.invoke(httpFn, { input: { title: 'x' } });
+                    expectTypeOf(httpRes).toEqualTypeOf<{ ok: boolean }>();
+
+                    // @ts-expect-error http input must match the trigger's input schema
+                    await nango.invoke(httpFn, { input: { wrong: 1 } });
+
+                    // schedule target: no declared input
+                    await nango.invoke(scheduleFn);
+                }
             });
         });
 

--- a/packages/runner-sdk/lib/function.unit.test.ts
+++ b/packages/runner-sdk/lib/function.unit.test.ts
@@ -34,7 +34,7 @@ describe('createFunction', () => {
                     expectTypeOf(cp).toEqualTypeOf<{ lastId: string } | undefined>();
                     expectTypeOf(nango.getMetadata()).toEqualTypeOf<Promise<{ org: string }>>();
                     expectTypeOf(trigger.kind).toEqualTypeOf<'schedule'>();
-                    expectTypeOf(trigger.payload).toEqualTypeOf<null>();
+                    expectTypeOf(trigger.input).toEqualTypeOf<null>();
                 }
             });
 
@@ -53,14 +53,15 @@ describe('createFunction', () => {
         it('exposes record capability and types the http payload from the trigger input', () => {
             const fn = createFunction({
                 description: 'Handle GitHub issue webhooks',
+                input: z.object({ action: z.string() }),
                 data: { models: { GithubIssue: z.object({ id: z.string() }) } },
-                trigger: { kind: 'http', input: z.object({ action: z.string() }), subscriptions: ['issues.opened'] },
+                trigger: { kind: 'http', subscriptions: ['issues.opened'] },
                 exec: async (nango, trigger) => {
                     await nango.batchSave([{ id: '1' }], 'GithubIssue');
 
                     expectTypeOf<Has<typeof nango, 'batchSave'>>().toEqualTypeOf<true>();
                     expectTypeOf(trigger.kind).toEqualTypeOf<'http'>();
-                    expectTypeOf(trigger.payload).toEqualTypeOf<{ action: string }>();
+                    expectTypeOf(trigger.input).toEqualTypeOf<{ action: string }>();
                     expectTypeOf(trigger.request.headers).toEqualTypeOf<Record<string, string>>();
                 }
             });
@@ -74,35 +75,38 @@ describe('createFunction', () => {
             });
         });
 
-        it('types the payload as an array when debounce take is "all"', () => {
+        it('types the input as an array when debounce take is "all"', () => {
             createFunction({
                 description: 'Handle coalesced webhooks',
-                trigger: { kind: 'http', input: z.object({ action: z.string() }), debounce: { windowMs: 5000, take: 'all' } },
+                input: z.object({ action: z.string() }),
+                trigger: { kind: 'http', debounce: { windowMs: 5000, take: 'all' } },
                 exec: (_nango, trigger) => {
-                    expectTypeOf(trigger.payload).toEqualTypeOf<{ action: string }[]>();
+                    expectTypeOf(trigger.input).toEqualTypeOf<{ action: string }[]>();
                 }
             });
 
             createFunction({
                 description: 'Handle latest webhook',
-                trigger: { kind: 'http', input: z.object({ action: z.string() }), debounce: { windowMs: 5000, take: 'latest' } },
+                input: z.object({ action: z.string() }),
+                trigger: { kind: 'http', debounce: { windowMs: 5000, take: 'latest' } },
                 exec: (_nango, trigger) => {
-                    expectTypeOf(trigger.payload).toEqualTypeOf<{ action: string }>();
+                    expectTypeOf(trigger.input).toEqualTypeOf<{ action: string }>();
                 }
             });
         });
     });
 
     describe('http without models (action)', () => {
-        it('has no record methods, types trigger input and output', () => {
+        it('has no record methods, types input and output', () => {
             const fn = createFunction({
                 description: 'Create a GitHub issue',
+                input: z.object({ title: z.string() }),
                 output: z.object({ issueId: z.string() }),
-                trigger: { kind: 'http', input: z.object({ title: z.string() }) },
+                trigger: { kind: 'http' },
                 exec: (_nango, trigger) => {
                     expectTypeOf<Has<typeof _nango, 'proxy'>>().toEqualTypeOf<true>();
                     expectTypeOf<Has<typeof _nango, 'batchSave'>>().toEqualTypeOf<false>();
-                    expectTypeOf(trigger.payload).toEqualTypeOf<{ title: string }>();
+                    expectTypeOf(trigger.input).toEqualTypeOf<{ title: string }>();
                     return { issueId: '123' };
                 }
             });
@@ -120,7 +124,7 @@ describe('createFunction', () => {
                 exec: async (nango, trigger) => {
                     await nango.log('executed');
                     expectTypeOf(trigger.kind).toEqualTypeOf<'event'>();
-                    expectTypeOf(trigger.payload).toEqualTypeOf<{ event: OnEventType }>();
+                    expectTypeOf(trigger.input).toEqualTypeOf<{ event: OnEventType }>();
                 }
             });
 
@@ -132,10 +136,11 @@ describe('createFunction', () => {
         it('exposes invoke and removes proxy when requires disables it', () => {
             const child = createFunction({
                 description: 'child',
+                input: z.object({ q: z.string() }),
                 output: z.object({ n: z.number() }),
-                trigger: { kind: 'invoke', input: z.object({ q: z.string() }) },
                 exec: (_nango, trigger) => {
-                    expectTypeOf(trigger.payload).toEqualTypeOf<{ q: string }>();
+                    expectTypeOf(trigger.kind).toEqualTypeOf<'invoke'>();
+                    expectTypeOf(trigger.input).toEqualTypeOf<{ q: string }>();
                     return { n: 1 };
                 }
             });
@@ -161,11 +166,12 @@ describe('createFunction', () => {
             });
         });
 
-        it('invoke types its input from the target trigger, regardless of trigger kind', () => {
+        it('invoke types its input from the target, regardless of trigger kind', () => {
             const httpFn = createFunction({
                 description: 'http target',
+                input: z.object({ title: z.string() }),
                 output: z.object({ ok: z.boolean() }),
-                trigger: { kind: 'http', input: z.object({ title: z.string() }), debounce: { windowMs: 1000, take: 'all' } },
+                trigger: { kind: 'http', debounce: { windowMs: 1000, take: 'all' } },
                 exec: () => ({ ok: true })
             });
 
@@ -180,11 +186,11 @@ describe('createFunction', () => {
                 requires: { outbound: false, invoke: true },
                 trigger: { kind: 'schedule', frequency: 'every hour' },
                 exec: async (nango) => {
-                    // http target: input matches the trigger input (single, not the coalesced array), output is typed
+                    // http target: invoke passes the single declared input (not the coalesced array)
                     const httpRes = await nango.invoke(httpFn, { input: { title: 'x' } });
                     expectTypeOf(httpRes).toEqualTypeOf<{ ok: boolean }>();
 
-                    // @ts-expect-error http input must match the trigger's input schema
+                    // @ts-expect-error http input must match the declared input schema
                     await nango.invoke(httpFn, { input: { wrong: 1 } });
 
                     // @ts-expect-error required input cannot be skipped
@@ -193,8 +199,7 @@ describe('createFunction', () => {
                     // schedule target: no declared input
                     await nango.invoke(scheduleFn);
 
-                    // a widened/opaque function reference (with no trigger) is rejected
-                    // so it can't skip required input
+                    // a widened/opaque function reference is rejected
                     const opaque = httpFn as { type: 'function' };
                     // @ts-expect-error opaque reference does not satisfy the invoke target constraint
                     await nango.invoke(opaque, { input: { title: 'x' } });
@@ -244,7 +249,7 @@ describe('createFunction', () => {
 
             createFunction({
                 description: 'http can overlap runs for a connection',
-                trigger: { kind: 'http', input: z.object({}) },
+                trigger: { kind: 'http' },
                 limits: { concurrency: { perConnection: 'max' } },
                 exec: () => {}
             });


### PR DESCRIPTION
Tweaking `createFunction` definition after discussion/feedback from last week

### input
- input is now a top-level attribute to align with output

### invoke
- Any function can be invoked, the caller's input is now derived from the trigger input (or void if no input)
- `invoke()` input argument is now optional and passed as part of an object instead of positionally

### concurrency
- Rename createFunctionProps attribute from `limits.concurrency` into `limits.concurrency.perConnection` to make it clearer the concurrency is at the connection level.
- making concurrency optional so customer don't have to specify it explicitly.

Note: in the future `limits` might hold parameters like compute or memory limits

### sdk methods
Add some missing runner-sdk methods and remove the records read functions


