### PR TITLE
feat(design-system): add focus ring to input fields

### DIFF
--- a/packages/design-system/src/components/ui/input-group.tsx
+++ b/packages/design-system/src/components/ui/input-group.tsx
@@ -20,8 +20,8 @@ const inputGroupVariants = cva(
         'has-[>[data-align=block-start]]:h-auto has-[>[data-align=block-start]]:flex-col has-[>[data-align=block-start]]:[&>input]:pb-3',
         'has-[>[data-align=block-end]]:h-auto has-[>[data-align=block-end]]:flex-col has-[>[data-align=block-end]]:[&>input]:pt-3',
 
-        // Focus state — a 2px ring is drawn as an outset shadow and the 0.5px hairline border adopts the ring color so it blends into the ring.
-        'has-[[data-slot=input-group-control]:focus-visible]:outline-none has-[[data-slot=input-group-control]:focus-visible]:border-[var(--focus-ring-default)] has-[[data-slot=input-group-control]:focus-visible]:shadow-[0_0_0_2px_var(--focus-ring-default)]',
+        // Focus state — the 0.5px hairline border adopts the ring color and a 1px inset shadow draws the ring just inside the edge, covering the border without expanding the footprint.
+        'has-[[data-slot=input-group-control]:focus-visible]:outline-none has-[[data-slot=input-group-control]:focus-visible]:border-[var(--focus-ring-default)] has-[[data-slot=input-group-control]:focus-visible]:shadow-[inset_0_0_0_1px_var(--focus-ring-default)]',
         // Filled state - different border when input has text (works for both controlled and uncontrolled inputs)
         'has-[[data-slot=input-group-control][data-filled=true]:not(:disabled)]:border-border-interactive-hover',
 
@@ -29,7 +29,7 @@ const inputGroupVariants = cva(
         'has-[[data-slot=input-group-control]:disabled]:border-border-disabled has-[[data-slot=input-group-control]:disabled]:bg-state-selected-muted',
 
         // Error state.
-        'has-[[data-slot][aria-invalid=true]]:!border-status-danger-border has-[[data-slot][aria-invalid=true]:focus-visible]:!border-[var(--focus-ring-danger)] has-[[data-slot][aria-invalid=true]:focus-visible]:!shadow-[0_0_0_2px_var(--focus-ring-danger)]'
+        'has-[[data-slot][aria-invalid=true]]:!border-status-danger-border has-[[data-slot][aria-invalid=true]:focus-visible]:!border-[var(--focus-ring-danger)] has-[[data-slot][aria-invalid=true]:focus-visible]:!shadow-[inset_0_0_0_1px_var(--focus-ring-danger)]'
     ],
     {
         variants: {

--- a/packages/design-system/src/components/ui/input-group.tsx
+++ b/packages/design-system/src/components/ui/input-group.tsx
@@ -20,8 +20,8 @@ const inputGroupVariants = cva(
         'has-[>[data-align=block-start]]:h-auto has-[>[data-align=block-start]]:flex-col has-[>[data-align=block-start]]:[&>input]:pb-3',
         'has-[>[data-align=block-end]]:h-auto has-[>[data-align=block-end]]:flex-col has-[>[data-align=block-end]]:[&>input]:pt-3',
 
-        // Focus state — border darkens when the control is focused (focus ring removed pending design review).
-        'has-[[data-slot=input-group-control]:focus-visible]:outline-none has-[[data-slot=input-group-control]:focus-visible]:border-border-interactive-hover',
+        // Focus state — border darkens and a flush focus ring appears when the control is focused (no offset like the button's padded ring).
+        'has-[[data-slot=input-group-control]:focus-visible]:outline-none has-[[data-slot=input-group-control]:focus-visible]:border-border-interactive-hover has-[[data-slot=input-group-control]:focus-visible]:shadow-[0_0_0_2px_var(--focus-ring-default)]',
         // Filled state - different border when input has text (works for both controlled and uncontrolled inputs)
         'has-[[data-slot=input-group-control][data-filled=true]:not(:disabled)]:border-border-interactive-hover',
 
@@ -29,7 +29,7 @@ const inputGroupVariants = cva(
         'has-[[data-slot=input-group-control]:disabled]:border-border-disabled has-[[data-slot=input-group-control]:disabled]:bg-state-selected-muted',
 
         // Error state.
-        'has-[[data-slot][aria-invalid=true]]:!border-status-danger-border'
+        'has-[[data-slot][aria-invalid=true]]:!border-status-danger-border has-[[data-slot][aria-invalid=true]:focus-visible]:!shadow-[0_0_0_2px_var(--focus-ring-danger)]'
     ],
     {
         variants: {
@@ -138,7 +138,7 @@ const InputGroupInput = React.forwardRef<HTMLInputElement, InputProps>(({ classN
             size={size}
             data-slot="input-group-control"
             data-filled={isFilled}
-            className={cn('flex-1 rounded-none border-0 bg-transparent shadow-none disabled:bg-transparent focus-visible:ring-0', className)}
+            className={cn('flex-1 rounded-none border-0 bg-transparent shadow-none focus:shadow-none disabled:bg-transparent focus-visible:ring-0', className)}
             value={value}
             defaultValue={defaultValue}
             onChange={handleChange}
@@ -182,7 +182,7 @@ const InputGroupTextarea = React.forwardRef<HTMLTextAreaElement, React.Component
                 data-slot="input-group-control"
                 data-filled={isFilled}
                 className={cn(
-                    'flex-1 resize-none rounded-none border-0 bg-transparent py-3 shadow-none disabled:bg-transparent focus-visible:ring-0',
+                    'flex-1 resize-none rounded-none border-0 bg-transparent py-3 shadow-none focus:shadow-none disabled:bg-transparent focus-visible:ring-0',
                     className
                 )}
                 value={value}

--- a/packages/design-system/src/components/ui/input-group.tsx
+++ b/packages/design-system/src/components/ui/input-group.tsx
@@ -21,7 +21,7 @@ const inputGroupVariants = cva(
         'has-[>[data-align=block-end]]:h-auto has-[>[data-align=block-end]]:flex-col has-[>[data-align=block-end]]:[&>input]:pt-3',
 
         // Focus state — border darkens and a flush focus ring appears when the control is focused (no offset like the button's padded ring).
-        'has-[[data-slot=input-group-control]:focus-visible]:outline-none has-[[data-slot=input-group-control]:focus-visible]:border-border-interactive-hover has-[[data-slot=input-group-control]:focus-visible]:shadow-[0_0_0_2px_var(--focus-ring-default)]',
+        'has-[[data-slot=input-group-control]:focus-visible]:outline-none has-[[data-slot=input-group-control]:focus-visible]:border-border-interactive-hover has-[[data-slot=input-group-control]:focus-visible]:shadow-[inset_0_0_0_2px_var(--focus-ring-default)]',
         // Filled state - different border when input has text (works for both controlled and uncontrolled inputs)
         'has-[[data-slot=input-group-control][data-filled=true]:not(:disabled)]:border-border-interactive-hover',
 
@@ -29,7 +29,7 @@ const inputGroupVariants = cva(
         'has-[[data-slot=input-group-control]:disabled]:border-border-disabled has-[[data-slot=input-group-control]:disabled]:bg-state-selected-muted',
 
         // Error state.
-        'has-[[data-slot][aria-invalid=true]]:!border-status-danger-border has-[[data-slot][aria-invalid=true]:focus-visible]:!shadow-[0_0_0_2px_var(--focus-ring-danger)]'
+        'has-[[data-slot][aria-invalid=true]]:!border-status-danger-border has-[[data-slot][aria-invalid=true]:focus-visible]:!shadow-[inset_0_0_0_2px_var(--focus-ring-danger)]'
     ],
     {
         variants: {

--- a/packages/design-system/src/components/ui/input-group.tsx
+++ b/packages/design-system/src/components/ui/input-group.tsx
@@ -20,8 +20,8 @@ const inputGroupVariants = cva(
         'has-[>[data-align=block-start]]:h-auto has-[>[data-align=block-start]]:flex-col has-[>[data-align=block-start]]:[&>input]:pb-3',
         'has-[>[data-align=block-end]]:h-auto has-[>[data-align=block-end]]:flex-col has-[>[data-align=block-end]]:[&>input]:pt-3',
 
-        // Focus state — the 0.5px hairline border adopts the ring color and a 1px inset shadow draws the ring just inside the edge, covering the border without expanding the footprint.
-        'has-[[data-slot=input-group-control]:focus-visible]:outline-none has-[[data-slot=input-group-control]:focus-visible]:border-[var(--focus-ring-default)] has-[[data-slot=input-group-control]:focus-visible]:shadow-[inset_0_0_0_1px_var(--focus-ring-default)]',
+        // Focus state — the hairline border adopts the ring color and 0.5px outset + 0.5px inset shadows draw a 1px ring centered on the field edge (half outside, half inside).
+        'has-[[data-slot=input-group-control]:focus-visible]:outline-none has-[[data-slot=input-group-control]:focus-visible]:border-[var(--focus-ring-default)] has-[[data-slot=input-group-control]:focus-visible]:shadow-[0_0_0_0.5px_var(--focus-ring-default),inset_0_0_0_0.5px_var(--focus-ring-default)]',
         // Filled state - different border when input has text (works for both controlled and uncontrolled inputs)
         'has-[[data-slot=input-group-control][data-filled=true]:not(:disabled)]:border-border-interactive-hover',
 
@@ -29,7 +29,7 @@ const inputGroupVariants = cva(
         'has-[[data-slot=input-group-control]:disabled]:border-border-disabled has-[[data-slot=input-group-control]:disabled]:bg-state-selected-muted',
 
         // Error state.
-        'has-[[data-slot][aria-invalid=true]]:!border-status-danger-border has-[[data-slot][aria-invalid=true]:focus-visible]:!border-[var(--focus-ring-danger)] has-[[data-slot][aria-invalid=true]:focus-visible]:!shadow-[inset_0_0_0_1px_var(--focus-ring-danger)]'
+        'has-[[data-slot][aria-invalid=true]]:!border-status-danger-border has-[[data-slot][aria-invalid=true]:focus-visible]:!border-[var(--focus-ring-danger)] has-[[data-slot][aria-invalid=true]:focus-visible]:!shadow-[0_0_0_0.5px_var(--focus-ring-danger),inset_0_0_0_0.5px_var(--focus-ring-danger)]'
     ],
     {
         variants: {

--- a/packages/design-system/src/components/ui/input-group.tsx
+++ b/packages/design-system/src/components/ui/input-group.tsx
@@ -138,7 +138,10 @@ const InputGroupInput = React.forwardRef<HTMLInputElement, InputProps>(({ classN
             size={size}
             data-slot="input-group-control"
             data-filled={isFilled}
-            className={cn('flex-1 rounded-none border-0 bg-transparent shadow-none focus:shadow-none disabled:bg-transparent focus-visible:ring-0', className)}
+            className={cn(
+                'flex-1 rounded-none border-0 bg-transparent shadow-none focus:shadow-none aria-invalid:focus:shadow-none disabled:bg-transparent focus-visible:ring-0',
+                className
+            )}
             value={value}
             defaultValue={defaultValue}
             onChange={handleChange}
@@ -182,7 +185,7 @@ const InputGroupTextarea = React.forwardRef<HTMLTextAreaElement, React.Component
                 data-slot="input-group-control"
                 data-filled={isFilled}
                 className={cn(
-                    'flex-1 resize-none rounded-none border-0 bg-transparent py-3 shadow-none focus:shadow-none disabled:bg-transparent focus-visible:ring-0',
+                    'flex-1 resize-none rounded-none border-0 bg-transparent py-3 shadow-none focus:shadow-none aria-invalid:focus:shadow-none disabled:bg-transparent focus-visible:ring-0',
                     className
                 )}
                 value={value}

--- a/packages/design-system/src/components/ui/input-group.tsx
+++ b/packages/design-system/src/components/ui/input-group.tsx
@@ -20,8 +20,8 @@ const inputGroupVariants = cva(
         'has-[>[data-align=block-start]]:h-auto has-[>[data-align=block-start]]:flex-col has-[>[data-align=block-start]]:[&>input]:pb-3',
         'has-[>[data-align=block-end]]:h-auto has-[>[data-align=block-end]]:flex-col has-[>[data-align=block-end]]:[&>input]:pt-3',
 
-        // Focus state — border darkens and a flush focus ring appears when the control is focused (no offset like the button's padded ring).
-        'has-[[data-slot=input-group-control]:focus-visible]:outline-none has-[[data-slot=input-group-control]:focus-visible]:border-border-interactive-hover has-[[data-slot=input-group-control]:focus-visible]:shadow-[inset_0_0_0_2px_var(--focus-ring-default)]',
+        // Focus state — a 2px ring is drawn as an outset shadow and the 0.5px hairline border adopts the ring color so it blends into the ring.
+        'has-[[data-slot=input-group-control]:focus-visible]:outline-none has-[[data-slot=input-group-control]:focus-visible]:border-[var(--focus-ring-default)] has-[[data-slot=input-group-control]:focus-visible]:shadow-[0_0_0_2px_var(--focus-ring-default)]',
         // Filled state - different border when input has text (works for both controlled and uncontrolled inputs)
         'has-[[data-slot=input-group-control][data-filled=true]:not(:disabled)]:border-border-interactive-hover',
 
@@ -29,7 +29,7 @@ const inputGroupVariants = cva(
         'has-[[data-slot=input-group-control]:disabled]:border-border-disabled has-[[data-slot=input-group-control]:disabled]:bg-state-selected-muted',
 
         // Error state.
-        'has-[[data-slot][aria-invalid=true]]:!border-status-danger-border has-[[data-slot][aria-invalid=true]:focus-visible]:!shadow-[inset_0_0_0_2px_var(--focus-ring-danger)]'
+        'has-[[data-slot][aria-invalid=true]]:!border-status-danger-border has-[[data-slot][aria-invalid=true]:focus-visible]:!border-[var(--focus-ring-danger)] has-[[data-slot][aria-invalid=true]:focus-visible]:!shadow-[0_0_0_2px_var(--focus-ring-danger)]'
     ],
     {
         variants: {

--- a/packages/design-system/src/components/ui/input.tsx
+++ b/packages/design-system/src/components/ui/input.tsx
@@ -13,12 +13,12 @@ export const inputVariants = cva(
         'text-ds-md font-ds-regular leading-ds-normal',
         // Default colors
         'bg-surface-input border-border-interactive text-text-default placeholder:text-text-secondary',
-        // Hover border. On focus the 0.5px hairline border adopts the ring color and a 1px inset shadow draws the ring just inside
-        // the edge, so the ring covers the border and sits flush inside without expanding the field's footprint.
+        // Hover border. On focus the hairline border adopts the ring color and 0.5px outset + 0.5px inset shadows draw a 1px ring
+        // centered on the field edge (half outside, half inside), continuous with the recolored border.
         'hover:border-border-interactive-hover',
-        'focus:border-[var(--focus-ring-default)] focus:shadow-[inset_0_0_0_1px_var(--focus-ring-default)]',
+        'focus:border-[var(--focus-ring-default)] focus:shadow-[0_0_0_0.5px_var(--focus-ring-default),inset_0_0_0_0.5px_var(--focus-ring-default)]',
         // Invalid
-        'aria-invalid:border-status-danger-border aria-invalid:focus:border-[var(--focus-ring-danger)] aria-invalid:focus:shadow-[inset_0_0_0_1px_var(--focus-ring-danger)]',
+        'aria-invalid:border-status-danger-border aria-invalid:focus:border-[var(--focus-ring-danger)] aria-invalid:focus:shadow-[0_0_0_0.5px_var(--focus-ring-danger),inset_0_0_0_0.5px_var(--focus-ring-danger)]',
         // Disabled — dedicated tokens, no opacity (Figma state/selectedMuted bg, border/disabled, text/disabled)
         'disabled:cursor-not-allowed disabled:border-border-disabled disabled:bg-state-selected-muted disabled:text-text-disabled disabled:placeholder:text-text-disabled',
         // File-input affordance

--- a/packages/design-system/src/components/ui/input.tsx
+++ b/packages/design-system/src/components/ui/input.tsx
@@ -13,12 +13,12 @@ export const inputVariants = cva(
         'text-ds-md font-ds-regular leading-ds-normal',
         // Default colors
         'bg-surface-input border-border-interactive text-text-default placeholder:text-text-secondary',
-        // Hover border. On focus a 2px ring is drawn as an outset shadow, and the 0.5px hairline border adopts the ring color
-        // so it blends into the ring instead of showing through as a separate line.
+        // Hover border. On focus the 0.5px hairline border adopts the ring color and a 1px inset shadow draws the ring just inside
+        // the edge, so the ring covers the border and sits flush inside without expanding the field's footprint.
         'hover:border-border-interactive-hover',
-        'focus:border-[var(--focus-ring-default)] focus:shadow-[0_0_0_2px_var(--focus-ring-default)]',
+        'focus:border-[var(--focus-ring-default)] focus:shadow-[inset_0_0_0_1px_var(--focus-ring-default)]',
         // Invalid
-        'aria-invalid:border-status-danger-border aria-invalid:focus:border-[var(--focus-ring-danger)] aria-invalid:focus:shadow-[0_0_0_2px_var(--focus-ring-danger)]',
+        'aria-invalid:border-status-danger-border aria-invalid:focus:border-[var(--focus-ring-danger)] aria-invalid:focus:shadow-[inset_0_0_0_1px_var(--focus-ring-danger)]',
         // Disabled — dedicated tokens, no opacity (Figma state/selectedMuted bg, border/disabled, text/disabled)
         'disabled:cursor-not-allowed disabled:border-border-disabled disabled:bg-state-selected-muted disabled:text-text-disabled disabled:placeholder:text-text-disabled',
         // File-input affordance

--- a/packages/design-system/src/components/ui/input.tsx
+++ b/packages/design-system/src/components/ui/input.tsx
@@ -15,9 +15,9 @@ export const inputVariants = cva(
         'bg-surface-input border-border-interactive text-text-default placeholder:text-text-secondary',
         // Hover / focus border + focus ring. The ring is flush against the field (no offset), unlike the button's padded ring.
         'hover:border-border-interactive-hover focus:border-border-interactive-hover',
-        'focus:shadow-[0_0_0_2px_var(--focus-ring-default)]',
+        'focus:shadow-[inset_0_0_0_2px_var(--focus-ring-default)]',
         // Invalid
-        'aria-invalid:border-status-danger-border aria-invalid:focus:shadow-[0_0_0_2px_var(--focus-ring-danger)]',
+        'aria-invalid:border-status-danger-border aria-invalid:focus:shadow-[inset_0_0_0_2px_var(--focus-ring-danger)]',
         // Disabled — dedicated tokens, no opacity (Figma state/selectedMuted bg, border/disabled, text/disabled)
         'disabled:cursor-not-allowed disabled:border-border-disabled disabled:bg-state-selected-muted disabled:text-text-disabled disabled:placeholder:text-text-disabled',
         // File-input affordance

--- a/packages/design-system/src/components/ui/input.tsx
+++ b/packages/design-system/src/components/ui/input.tsx
@@ -13,10 +13,11 @@ export const inputVariants = cva(
         'text-ds-md font-ds-regular leading-ds-normal',
         // Default colors
         'bg-surface-input border-border-interactive text-text-default placeholder:text-text-secondary',
-        // Hover / focus border (focus ring removed pending design review)
+        // Hover / focus border + focus ring. The ring is flush against the field (no offset), unlike the button's padded ring.
         'hover:border-border-interactive-hover focus:border-border-interactive-hover',
+        'focus:shadow-[0_0_0_2px_var(--focus-ring-default)]',
         // Invalid
-        'aria-invalid:border-status-danger-border',
+        'aria-invalid:border-status-danger-border aria-invalid:focus:shadow-[0_0_0_2px_var(--focus-ring-danger)]',
         // Disabled — dedicated tokens, no opacity (Figma state/selectedMuted bg, border/disabled, text/disabled)
         'disabled:cursor-not-allowed disabled:border-border-disabled disabled:bg-state-selected-muted disabled:text-text-disabled disabled:placeholder:text-text-disabled',
         // File-input affordance

--- a/packages/design-system/src/components/ui/input.tsx
+++ b/packages/design-system/src/components/ui/input.tsx
@@ -13,11 +13,12 @@ export const inputVariants = cva(
         'text-ds-md font-ds-regular leading-ds-normal',
         // Default colors
         'bg-surface-input border-border-interactive text-text-default placeholder:text-text-secondary',
-        // Hover / focus border + focus ring. The ring is flush against the field (no offset), unlike the button's padded ring.
-        'hover:border-border-interactive-hover focus:border-border-interactive-hover',
-        'focus:shadow-[inset_0_0_0_2px_var(--focus-ring-default)]',
+        // Hover border. On focus a 2px ring is drawn as an outset shadow, and the 0.5px hairline border adopts the ring color
+        // so it blends into the ring instead of showing through as a separate line.
+        'hover:border-border-interactive-hover',
+        'focus:border-[var(--focus-ring-default)] focus:shadow-[0_0_0_2px_var(--focus-ring-default)]',
         // Invalid
-        'aria-invalid:border-status-danger-border aria-invalid:focus:shadow-[inset_0_0_0_2px_var(--focus-ring-danger)]',
+        'aria-invalid:border-status-danger-border aria-invalid:focus:border-[var(--focus-ring-danger)] aria-invalid:focus:shadow-[0_0_0_2px_var(--focus-ring-danger)]',
         // Disabled — dedicated tokens, no opacity (Figma state/selectedMuted bg, border/disabled, text/disabled)
         'disabled:cursor-not-allowed disabled:border-border-disabled disabled:bg-state-selected-muted disabled:text-text-disabled disabled:placeholder:text-text-disabled',
         // File-input affordance

--- a/packages/design-system/src/components/ui/textarea.tsx
+++ b/packages/design-system/src/components/ui/textarea.tsx
@@ -18,9 +18,9 @@ const Textarea = React.forwardRef<HTMLTextAreaElement, TextareaProps>(({ classNa
                 'bg-surface-input border-border-interactive text-text-default placeholder:text-text-secondary',
                 // Hover / focus border + focus ring. The ring is flush against the field (no offset), unlike the button's padded ring.
                 'hover:border-border-interactive-hover focus:border-border-interactive-hover',
-                'focus:shadow-[0_0_0_2px_var(--focus-ring-default)]',
+                'focus:shadow-[inset_0_0_0_2px_var(--focus-ring-default)]',
                 // Invalid
-                'aria-invalid:border-status-danger-border aria-invalid:focus:shadow-[0_0_0_2px_var(--focus-ring-danger)]',
+                'aria-invalid:border-status-danger-border aria-invalid:focus:shadow-[inset_0_0_0_2px_var(--focus-ring-danger)]',
                 // Disabled — dedicated tokens, no opacity
                 'disabled:cursor-not-allowed disabled:border-border-disabled disabled:bg-state-selected-muted disabled:text-text-disabled disabled:placeholder:text-text-disabled',
                 className

--- a/packages/design-system/src/components/ui/textarea.tsx
+++ b/packages/design-system/src/components/ui/textarea.tsx
@@ -16,11 +16,12 @@ const Textarea = React.forwardRef<HTMLTextAreaElement, TextareaProps>(({ classNa
                 'text-ds-md font-ds-regular leading-ds-normal',
                 // Default colors
                 'bg-surface-input border-border-interactive text-text-default placeholder:text-text-secondary',
-                // Hover / focus border + focus ring. The ring is flush against the field (no offset), unlike the button's padded ring.
-                'hover:border-border-interactive-hover focus:border-border-interactive-hover',
-                'focus:shadow-[inset_0_0_0_2px_var(--focus-ring-default)]',
+                // Hover border. On focus a 2px ring is drawn as an outset shadow, and the 0.5px hairline border adopts the ring color
+                // so it blends into the ring instead of showing through as a separate line.
+                'hover:border-border-interactive-hover',
+                'focus:border-[var(--focus-ring-default)] focus:shadow-[0_0_0_2px_var(--focus-ring-default)]',
                 // Invalid
-                'aria-invalid:border-status-danger-border aria-invalid:focus:shadow-[inset_0_0_0_2px_var(--focus-ring-danger)]',
+                'aria-invalid:border-status-danger-border aria-invalid:focus:border-[var(--focus-ring-danger)] aria-invalid:focus:shadow-[0_0_0_2px_var(--focus-ring-danger)]',
                 // Disabled — dedicated tokens, no opacity
                 'disabled:cursor-not-allowed disabled:border-border-disabled disabled:bg-state-selected-muted disabled:text-text-disabled disabled:placeholder:text-text-disabled',
                 className

--- a/packages/design-system/src/components/ui/textarea.tsx
+++ b/packages/design-system/src/components/ui/textarea.tsx
@@ -16,10 +16,11 @@ const Textarea = React.forwardRef<HTMLTextAreaElement, TextareaProps>(({ classNa
                 'text-ds-md font-ds-regular leading-ds-normal',
                 // Default colors
                 'bg-surface-input border-border-interactive text-text-default placeholder:text-text-secondary',
-                // Hover / focus border (focus ring removed pending design review)
+                // Hover / focus border + focus ring. The ring is flush against the field (no offset), unlike the button's padded ring.
                 'hover:border-border-interactive-hover focus:border-border-interactive-hover',
+                'focus:shadow-[0_0_0_2px_var(--focus-ring-default)]',
                 // Invalid
-                'aria-invalid:border-status-danger-border',
+                'aria-invalid:border-status-danger-border aria-invalid:focus:shadow-[0_0_0_2px_var(--focus-ring-danger)]',
                 // Disabled — dedicated tokens, no opacity
                 'disabled:cursor-not-allowed disabled:border-border-disabled disabled:bg-state-selected-muted disabled:text-text-disabled disabled:placeholder:text-text-disabled',
                 className

--- a/packages/design-system/src/components/ui/textarea.tsx
+++ b/packages/design-system/src/components/ui/textarea.tsx
@@ -16,12 +16,12 @@ const Textarea = React.forwardRef<HTMLTextAreaElement, TextareaProps>(({ classNa
                 'text-ds-md font-ds-regular leading-ds-normal',
                 // Default colors
                 'bg-surface-input border-border-interactive text-text-default placeholder:text-text-secondary',
-                // Hover border. On focus the 0.5px hairline border adopts the ring color and a 1px inset shadow draws the ring just inside
-                // the edge, so the ring covers the border and sits flush inside without expanding the field's footprint.
+                // Hover border. On focus the hairline border adopts the ring color and 0.5px outset + 0.5px inset shadows draw a 1px ring
+                // centered on the field edge (half outside, half inside), continuous with the recolored border.
                 'hover:border-border-interactive-hover',
-                'focus:border-[var(--focus-ring-default)] focus:shadow-[inset_0_0_0_1px_var(--focus-ring-default)]',
+                'focus:border-[var(--focus-ring-default)] focus:shadow-[0_0_0_0.5px_var(--focus-ring-default),inset_0_0_0_0.5px_var(--focus-ring-default)]',
                 // Invalid
-                'aria-invalid:border-status-danger-border aria-invalid:focus:border-[var(--focus-ring-danger)] aria-invalid:focus:shadow-[inset_0_0_0_1px_var(--focus-ring-danger)]',
+                'aria-invalid:border-status-danger-border aria-invalid:focus:border-[var(--focus-ring-danger)] aria-invalid:focus:shadow-[0_0_0_0.5px_var(--focus-ring-danger),inset_0_0_0_0.5px_var(--focus-ring-danger)]',
                 // Disabled — dedicated tokens, no opacity
                 'disabled:cursor-not-allowed disabled:border-border-disabled disabled:bg-state-selected-muted disabled:text-text-disabled disabled:placeholder:text-text-disabled',
                 className

--- a/packages/design-system/src/components/ui/textarea.tsx
+++ b/packages/design-system/src/components/ui/textarea.tsx
@@ -16,12 +16,12 @@ const Textarea = React.forwardRef<HTMLTextAreaElement, TextareaProps>(({ classNa
                 'text-ds-md font-ds-regular leading-ds-normal',
                 // Default colors
                 'bg-surface-input border-border-interactive text-text-default placeholder:text-text-secondary',
-                // Hover border. On focus a 2px ring is drawn as an outset shadow, and the 0.5px hairline border adopts the ring color
-                // so it blends into the ring instead of showing through as a separate line.
+                // Hover border. On focus the 0.5px hairline border adopts the ring color and a 1px inset shadow draws the ring just inside
+                // the edge, so the ring covers the border and sits flush inside without expanding the field's footprint.
                 'hover:border-border-interactive-hover',
-                'focus:border-[var(--focus-ring-default)] focus:shadow-[0_0_0_2px_var(--focus-ring-default)]',
+                'focus:border-[var(--focus-ring-default)] focus:shadow-[inset_0_0_0_1px_var(--focus-ring-default)]',
                 // Invalid
-                'aria-invalid:border-status-danger-border aria-invalid:focus:border-[var(--focus-ring-danger)] aria-invalid:focus:shadow-[0_0_0_2px_var(--focus-ring-danger)]',
+                'aria-invalid:border-status-danger-border aria-invalid:focus:border-[var(--focus-ring-danger)] aria-invalid:focus:shadow-[inset_0_0_0_1px_var(--focus-ring-danger)]',
                 // Disabled — dedicated tokens, no opacity
                 'disabled:cursor-not-allowed disabled:border-border-disabled disabled:bg-state-selected-muted disabled:text-text-disabled disabled:placeholder:text-text-disabled',
                 className


### PR DESCRIPTION
## Problem

Focus rings were removed from the design-system `Input`, `Textarea`, and `InputGroup` "pending design review", so focused text fields only darken their border — a weak keyboard-focus affordance. Buttons kept their ring, but its padded offset (an inner gap in the surface color) looks wrong on inputs.

## Solution

- Re-add the focus ring on `Input`, `Textarea`, and the `InputGroup` wrapper as a 1px ring centered on the field edge (0.5px outset + 0.5px inset box-shadow).
- On focus the 0.5px hairline border adopts the ring color so it stays continuous with the ring instead of showing through as a separate neutral line.
- Add a matching danger ring on `aria-invalid` fields; colors come from the existing `--focus-ring-default` / `--focus-ring-danger` tokens.
- Suppress the inner control's own ring inside `InputGroup` so the wrapper owns focus styling.

The ring geometry is inline because `tokens.json` is Figma-synced and would drop a hand-added shadow token on the next `tokens:fetch`. If design wants this as a first-class token later, a designer adds `focus.outline-input-default` / `-danger` in Figma and we swap the inline shadows for `shadow-focus-outline-input-*`.

Fixes [NAN-6159](https://linear.app/nango/issue/NAN-6159)

## Testing

- Ran the webapp against the dev API and focused live fields (dark mode): login inputs, Connections search box, editable Team-name field — 1px ring centered on the edge, continuous with the recolored border.
- `tsc` clean; lint + prettier pass on commit.
