### PR TITLE
feat(design-system): reduce default form-control height to 32px

### DIFF
--- a/packages/design-system/src/components/ui/input-group.tsx
+++ b/packages/design-system/src/components/ui/input-group.tsx
@@ -11,7 +11,7 @@ import type { VariantProps } from 'class-variance-authority';
 
 const inputGroupVariants = cva(
     [
-        'group/input-group bg-surface-input border-ds-hairline border-border-interactive text-text-default placeholder:text-text-secondary text-ds-md font-ds-regular leading-ds-normal relative flex w-full items-center rounded-ds-sm transition-[background-color,border-color,color,box-shadow] duration-100 ease-in-out outline-none hover:border-border-interactive-hover',
+        'group/input-group bg-surface-input border-ds-hairline border-border-interactive text-text-default placeholder:text-text-secondary text-ds-md font-ds-regular leading-ds-normal relative flex w-full items-center rounded-ds-xs transition-[background-color,border-color,color,box-shadow] duration-100 ease-in-out outline-none hover:border-border-interactive-hover',
         'min-w-0 has-[>textarea]:h-auto',
 
         // Variants based on alignment.

--- a/packages/design-system/src/components/ui/input-group.tsx
+++ b/packages/design-system/src/components/ui/input-group.tsx
@@ -35,7 +35,7 @@ const inputGroupVariants = cva(
         variants: {
             size: {
                 // Default control height (matches Input).
-                default: 'h-9',
+                default: 'h-8',
                 // Hug-content — for in-popover search fields. Pair with `size="auto"` on the inner InputGroupInput.
                 auto: 'h-auto'
             }

--- a/packages/design-system/src/components/ui/input.tsx
+++ b/packages/design-system/src/components/ui/input.tsx
@@ -7,8 +7,8 @@ import type { VariantProps } from 'class-variance-authority';
 
 export const inputVariants = cva(
     [
-        // Shape + spacing (Figma: hairline border, radius/sm)
-        'flex w-full min-w-0 rounded-ds-sm border-ds-hairline outline-none transition-[background-color,border-color,color,box-shadow] duration-100 ease-in-out',
+        // Shape + spacing (Figma: hairline border, radius/xs)
+        'flex w-full min-w-0 rounded-ds-xs border-ds-hairline outline-none transition-[background-color,border-color,color,box-shadow] duration-100 ease-in-out',
         // Typography (Figma text/regular/md)
         'text-ds-md font-ds-regular leading-ds-normal',
         // Default colors

--- a/packages/design-system/src/components/ui/input.tsx
+++ b/packages/design-system/src/components/ui/input.tsx
@@ -26,7 +26,7 @@ export const inputVariants = cva(
         variants: {
             size: {
                 // Default control height (Figma: space/2 × space/1.5)
-                default: 'h-9 px-2 py-1.5',
+                default: 'h-8 px-2 py-1.5',
                 // Hug-content — for in-popover search fields where the wrapper owns the padding
                 auto: 'h-auto p-0'
             }

--- a/packages/design-system/src/components/ui/textarea.tsx
+++ b/packages/design-system/src/components/ui/textarea.tsx
@@ -11,7 +11,7 @@ const Textarea = React.forwardRef<HTMLTextAreaElement, TextareaProps>(({ classNa
             data-slot="textarea"
             className={cn(
                 // Shape + spacing (matches Input)
-                'flex w-full min-w-0 rounded-ds-sm border-ds-hairline px-2 py-1.5 outline-none transition-[background-color,border-color,color,box-shadow] duration-100 ease-in-out',
+                'flex w-full min-w-0 rounded-ds-xs border-ds-hairline px-2 py-1.5 outline-none transition-[background-color,border-color,color,box-shadow] duration-100 ease-in-out',
                 // Typography (Figma text/regular/md)
                 'text-ds-md font-ds-regular leading-ds-normal',
                 // Default colors

--- a/packages/webapp/src/components/patterns/FilterMultiSelect.tsx
+++ b/packages/webapp/src/components/patterns/FilterMultiSelect.tsx
@@ -179,7 +179,7 @@ export function FilterMultiSelect<T extends string = string>({
     return (
         <Popover open={open} onOpenChange={setOpen}>
             <PopoverTrigger asChild>
-                <Button variant="outline" size="lg" className={cn('text-text-muted', isDirty && 'text-text-strong')}>
+                <Button variant="outline" size="md" className={cn('text-text-muted', isDirty && 'text-text-strong')}>
                     {label}
                     {isDirty && (
                         <span

--- a/packages/webapp/src/components/patterns/KeyValueInput.tsx
+++ b/packages/webapp/src/components/patterns/KeyValueInput.tsx
@@ -204,7 +204,7 @@ export const KeyValueInput: React.FC<KeyValueInputProps> = ({
                                 />
                             )}
                             <div className={cn((pair.key === '' && pair.value === '') || disabled ? 'invisible' : '')}>
-                                <IconButton type="button" variant="ghost" size="lg" label="Remove entry" onClick={() => !disabled && onRemove(i)}>
+                                <IconButton type="button" variant="ghost" size="md" label="Remove entry" onClick={() => !disabled && onRemove(i)}>
                                     <Trash2 className="text-text-danger" />
                                 </IconButton>
                             </div>

--- a/packages/webapp/src/components/patterns/PeriodSelector.tsx
+++ b/packages/webapp/src/components/patterns/PeriodSelector.tsx
@@ -96,7 +96,7 @@ export const PeriodSelector = ({ period, isLive, onChange, presets, defaultPrese
             }}
         >
             <PopoverTrigger asChild>
-                <Button variant="outline" size="lg" className="grow truncate tabular-nums">
+                <Button variant="outline" size="md" className="grow truncate tabular-nums">
                     <Calendar size={18} />
                     {buttonDisplay} {isLive && '(live)'}
                 </Button>

--- a/packages/webapp/src/components/patterns/ScopesInput.tsx
+++ b/packages/webapp/src/components/patterns/ScopesInput.tsx
@@ -119,7 +119,7 @@ export const ScopesInput: React.FC<ScopesInputProps> = ({
 
     if (isSharedCredentials || readOnly) {
         return (
-            <div className="flex flex-wrap items-center gap-1.5 min-h-9 rounded border border-border-muted bg-surface-canvas px-2 py-1.5">
+            <div className="flex flex-wrap items-center gap-1.5 min-h-8 rounded border border-border-muted bg-surface-canvas px-2 py-1.5">
                 {scopes.map((scope) => (
                     <span
                         key={scope}
@@ -177,7 +177,7 @@ export const ScopesInput: React.FC<ScopesInputProps> = ({
                 open={hasAvailableScopesDropdown ? dropdownOpen : false}
                 onOpenChange={setDropdownOpen}
             >
-                <ComboboxChips ref={chipsRef} className={cn('px-1.5 gap-1 min-h-9')}>
+                <ComboboxChips ref={chipsRef} className={cn('px-1.5 gap-1 min-h-8')}>
                     {scopes.length > 0 && (
                         <ComboboxValue>
                             {scopes.map((scope) => (

--- a/packages/webapp/src/components/ui/Combobox.tsx
+++ b/packages/webapp/src/components/ui/Combobox.tsx
@@ -228,7 +228,7 @@ export function ComboboxSelect<T extends string = string>(props: ComboboxProps<T
             loading={props.loading}
             disabled={disabled || options.length === 0}
             variant="ghost"
-            size="lg"
+            size="md"
             className={cn(
                 'border-ds-hairline border-border-interactive',
                 isDirty && 'bg-state-pressed',

--- a/packages/webapp/src/components/ui/LineSnippet.tsx
+++ b/packages/webapp/src/components/ui/LineSnippet.tsx
@@ -3,7 +3,7 @@ import { CopyButton } from './CopyButton';
 
 export const LineSnippet: React.FC<{ snippet: string; className?: string }> = ({ snippet, className }) => {
     return (
-        <div className={cn('relative flex h-9 min-w-100 overflow-hidden rounded-sm bg-surface-canvas border border-border-disabled', className)}>
+        <div className={cn('relative flex h-8 min-w-100 overflow-hidden rounded-sm bg-surface-canvas border border-border-disabled', className)}>
             <div className="flex min-w-0 flex-1 items-center overflow-x-auto overflow-y-hidden overscroll-x-contain px-4">
                 <span className="whitespace-nowrap text-text-secondary text-body-medium-regular">{snippet}</span>
             </div>

--- a/packages/webapp/src/components/ui/MultiSelect.tsx
+++ b/packages/webapp/src/components/ui/MultiSelect.tsx
@@ -133,7 +133,7 @@ export function MultiSelect<T extends string = string>({
                     loading={loading}
                     disabled={options.length === 0}
                     variant="ghost"
-                    size="lg"
+                    size="md"
                     className={cn(
                         'border-ds-hairline border-border-interactive',
                         isDirty && 'bg-state-pressed',

--- a/packages/webapp/src/components/ui/Select.tsx
+++ b/packages/webapp/src/components/ui/Select.tsx
@@ -30,7 +30,7 @@ function SelectTrigger({ className, children, size = 'default', onFocus, ...prop
             data-slot="select-trigger"
             className={cn(
                 "flex w-fit items-center justify-between gap-1.5 rounded px-1.5 py-0.5 bg-surface-overlay border-ds-hairline border-border-interactive text-text-secondary hover:bg-state-hover focus-visible:border-border-interactive-hover data-[placeholder]:text-text-muted [&_svg:not([class*='text-'])]:text-text-secondary focus-default whitespace-nowrap transition-[color,box-shadow] disabled:cursor-not-allowed disabled:opacity-50 *:data-[slot=select-value]:line-clamp-1 *:data-[slot=select-value]:flex *:data-[slot=select-value]:items-center *:data-[slot=select-value]:gap-2 [&_svg]:pointer-events-none [&_svg]:shrink-0 [&_svg:not([class*='size-'])]:size-3",
-                size === 'sm' ? 'h-7 text-s' : 'h-9 text-sm',
+                size === 'sm' ? 'h-7 text-s' : 'h-8 text-sm',
                 className
             )}
             onFocus={(e) => {

--- a/packages/webapp/src/components/ui/Select.tsx
+++ b/packages/webapp/src/components/ui/Select.tsx
@@ -29,7 +29,7 @@ function SelectTrigger({ className, children, size = 'default', onFocus, ...prop
         <SelectPrimitive.Trigger
             data-slot="select-trigger"
             className={cn(
-                "flex w-fit items-center justify-between gap-1.5 rounded px-1.5 py-0.5 bg-surface-overlay border-ds-hairline border-border-interactive text-text-secondary hover:bg-state-hover focus-visible:border-border-interactive-hover data-[placeholder]:text-text-muted [&_svg:not([class*='text-'])]:text-text-secondary focus-default whitespace-nowrap transition-[color,box-shadow] disabled:cursor-not-allowed disabled:opacity-50 *:data-[slot=select-value]:line-clamp-1 *:data-[slot=select-value]:flex *:data-[slot=select-value]:items-center *:data-[slot=select-value]:gap-2 [&_svg]:pointer-events-none [&_svg]:shrink-0 [&_svg:not([class*='size-'])]:size-3",
+                "flex w-fit items-center justify-between gap-1.5 rounded-ds-xs px-1.5 py-0.5 bg-surface-overlay border-ds-hairline border-border-interactive text-text-secondary hover:bg-state-hover focus-visible:border-border-interactive-hover data-[placeholder]:text-text-muted [&_svg:not([class*='text-'])]:text-text-secondary focus-default whitespace-nowrap transition-[color,box-shadow] disabled:cursor-not-allowed disabled:opacity-50 *:data-[slot=select-value]:line-clamp-1 *:data-[slot=select-value]:flex *:data-[slot=select-value]:items-center *:data-[slot=select-value]:gap-2 [&_svg]:pointer-events-none [&_svg]:shrink-0 [&_svg:not([class*='size-'])]:size-3",
                 size === 'sm' ? 'h-7 text-s' : 'h-8 text-sm',
                 className
             )}

--- a/packages/webapp/src/pages/Connection/List.tsx
+++ b/packages/webapp/src/pages/Connection/List.tsx
@@ -345,7 +345,7 @@ export const ConnectionList = () => {
                                 />
                                 <PermissionGate condition={canCreateTestConnection}>
                                     {(allowed) => (
-                                        <ButtonLink to={`/${env}/connections/create`} size="lg" disabled={!allowed} className="ml-auto">
+                                        <ButtonLink to={`/${env}/connections/create`} size="md" disabled={!allowed} className="ml-auto">
                                             Add test connection
                                         </ButtonLink>
                                     )}

--- a/packages/webapp/src/pages/Connection/components/AuthCredentials/JwtCredentials.tsx
+++ b/packages/webapp/src/pages/Connection/components/AuthCredentials/JwtCredentials.tsx
@@ -26,7 +26,7 @@ export const JwtCredentialsComponent: React.FC<{
                         <SecretInput id="token" value={credentials.token} disabled copy canRead={canRead} />
                         <PermissionGate condition={canRead} asChild>
                             {(allowed) => (
-                                <Button variant="outline" size="lg" onClick={forceRefresh} loading={isRefreshing} disabled={!allowed}>
+                                <Button variant="outline" size="md" onClick={forceRefresh} loading={isRefreshing} disabled={!allowed}>
                                     <RefreshCwIcon />
                                     Refresh
                                 </Button>

--- a/packages/webapp/src/pages/Connection/components/AuthCredentials/OAuth2ClientCredentials.tsx
+++ b/packages/webapp/src/pages/Connection/components/AuthCredentials/OAuth2ClientCredentials.tsx
@@ -24,7 +24,7 @@ export const OAuth2ClientCredentialsComponent: React.FC<{
                     <SecretInput id="token" value={credentials.token} disabled copy canRead={canRead} />
                     <PermissionGate condition={canRead} asChild>
                         {(allowed) => (
-                            <Button variant="outline" size="lg" onClick={forceRefresh} loading={isRefreshing} disabled={!allowed}>
+                            <Button variant="outline" size="md" onClick={forceRefresh} loading={isRefreshing} disabled={!allowed}>
                                 <RefreshCwIcon />
                                 Refresh
                             </Button>

--- a/packages/webapp/src/pages/Connection/components/AuthCredentials/OAuth2Credentials.tsx
+++ b/packages/webapp/src/pages/Connection/components/AuthCredentials/OAuth2Credentials.tsx
@@ -25,7 +25,7 @@ export const OAuth2CredentialsComponent: React.FC<{
                     {credentials.refresh_token && (
                         <PermissionGate condition={canRead} asChild>
                             {(allowed) => (
-                                <Button variant="outline" size="lg" onClick={forceRefresh} loading={isRefreshing} disabled={!allowed}>
+                                <Button variant="outline" size="md" onClick={forceRefresh} loading={isRefreshing} disabled={!allowed}>
                                     <RefreshCwIcon />
                                     Refresh
                                 </Button>

--- a/packages/webapp/src/pages/Connection/components/AuthCredentials/SignatureCredentials.tsx
+++ b/packages/webapp/src/pages/Connection/components/AuthCredentials/SignatureCredentials.tsx
@@ -35,7 +35,7 @@ export const SignatureCredentialsComponent: React.FC<{
                         <SecretInput id="token" value={credentials.token} disabled copy canRead={canRead} />
                         <PermissionGate condition={canRead} asChild>
                             {(allowed) => (
-                                <Button variant="outline" size="lg" onClick={forceRefresh} loading={isRefreshing} disabled={!allowed}>
+                                <Button variant="outline" size="md" onClick={forceRefresh} loading={isRefreshing} disabled={!allowed}>
                                     <RefreshCwIcon />
                                     Refresh
                                 </Button>

--- a/packages/webapp/src/pages/Connection/components/AuthCredentials/TwoStepCredentials.tsx
+++ b/packages/webapp/src/pages/Connection/components/AuthCredentials/TwoStepCredentials.tsx
@@ -26,7 +26,7 @@ export const TwoStepCredentialsComponent: React.FC<{
                         <SecretInput id="token" value={credentials.token} disabled copy canRead={canRead} />
                         <PermissionGate condition={canRead} asChild>
                             {(allowed) => (
-                                <Button variant="outline" size="lg" onClick={forceRefresh} loading={isRefreshing} disabled={!allowed}>
+                                <Button variant="outline" size="md" onClick={forceRefresh} loading={isRefreshing} disabled={!allowed}>
                                     <RefreshCwIcon />
                                     Refresh
                                 </Button>

--- a/packages/webapp/src/pages/Connection/components/CreateConnectionSelector.tsx
+++ b/packages/webapp/src/pages/Connection/components/CreateConnectionSelector.tsx
@@ -324,7 +324,7 @@ export const CreateConnectionSelector: React.FC<CreateConnectionSelectorProps> =
                                         {(allowed) => (
                                             <Button
                                                 onClick={onClickConnectUI}
-                                                size="lg"
+                                                size="md"
                                                 disabled={usageCapReached || integrationHasMissingFields || !isFormValid || !allowed}
                                             >
                                                 Authorize
@@ -344,7 +344,7 @@ export const CreateConnectionSelector: React.FC<CreateConnectionSelectorProps> =
                                         {(allowed) => (
                                             <Button
                                                 onClick={onClickShareConnectionLink}
-                                                size="lg"
+                                                size="md"
                                                 variant="ghost"
                                                 loading={isShareLinkLoading}
                                                 disabled={usageCapReached || integrationHasMissingFields || !isFormValid || !allowed}

--- a/packages/webapp/src/pages/Connection/components/IntegrationDropdown.tsx
+++ b/packages/webapp/src/pages/Connection/components/IntegrationDropdown.tsx
@@ -52,7 +52,7 @@ export const IntegrationDropdown: React.FC<IntegrationDropdownProps> = ({ integr
     return (
         <DropdownMenu modal={false}>
             <DropdownMenuTrigger
-                className={cn(buttonVariants({ variant: 'outline', size: 'lg' }), 'bg-surface-canvas justify-between grow w-full')}
+                className={cn(buttonVariants({ variant: 'outline', size: 'md' }), 'bg-surface-canvas justify-between grow w-full')}
                 disabled={disabled}
             >
                 {selectedIntegration ? (

--- a/packages/webapp/src/pages/Connection/components/SettingsTab.tsx
+++ b/packages/webapp/src/pages/Connection/components/SettingsTab.tsx
@@ -50,7 +50,7 @@ export const SettingsTab = () => {
                         {(allowed) => (
                             <Button
                                 variant="danger"
-                                size="lg"
+                                size="md"
                                 loading={isDeletingConnection}
                                 disabled={!allowed}
                                 onClick={() =>

--- a/packages/webapp/src/pages/Integrations/Show.tsx
+++ b/packages/webapp/src/pages/Integrations/Show.tsx
@@ -115,7 +115,7 @@ export const IntegrationsList = () => {
                 </InputGroup>
                 <PermissionGate asChild condition={canWriteIntegration}>
                     {(allowed) => (
-                        <ButtonLink disabled={!allowed} to={`/${env}/integrations/create`} size="lg">
+                        <ButtonLink disabled={!allowed} to={`/${env}/integrations/create`} size="md">
                             Set up new integration
                         </ButtonLink>
                     )}

--- a/packages/webapp/src/pages/Integrations/providerConfigKey/Functions/One.tsx
+++ b/packages/webapp/src/pages/Integrations/providerConfigKey/Functions/One.tsx
@@ -293,7 +293,7 @@ export const FunctionsOne: React.FC = () => {
                                 })}
                             />
                             {func.source === 'catalog' && (
-                                <ButtonLink to={gitUrl} target="_blank" variant="secondary" size="lg">
+                                <ButtonLink to={gitUrl} target="_blank" variant="secondary" size="md">
                                     View code <ExternalLink />
                                 </ButtonLink>
                             )}

--- a/packages/webapp/src/pages/Integrations/providerConfigKey/Functions/Tab.tsx
+++ b/packages/webapp/src/pages/Integrations/providerConfigKey/Functions/Tab.tsx
@@ -144,7 +144,7 @@ export const FunctionsTab: React.FC<FunctionsTabProps> = ({ integration }) => {
                         />
                         <DropdownMenu>
                             <DropdownMenuTrigger asChild>
-                                <Button type="button" size="lg">
+                                <Button type="button" size="md">
                                     <Plus /> Add
                                 </Button>
                             </DropdownMenuTrigger>

--- a/packages/webapp/src/pages/Integrations/providerConfigKey/Settings/components/DeleteIntegrationButton.tsx
+++ b/packages/webapp/src/pages/Integrations/providerConfigKey/Settings/components/DeleteIntegrationButton.tsx
@@ -45,7 +45,7 @@ export const DeleteIntegrationButton: React.FC<{ env: string; integration: ApiIn
                 {(allowed) => (
                     <Button
                         variant="danger"
-                        size="lg"
+                        size="md"
                         loading={isPending}
                         disabled={!allowed}
                         onClick={() =>

--- a/packages/webapp/src/pages/Integrations/providerConfigKey/Show.tsx
+++ b/packages/webapp/src/pages/Integrations/providerConfigKey/Show.tsx
@@ -81,7 +81,7 @@ export const ShowIntegration: React.FC = () => {
                     </div>
                     <PermissionGate condition={canCreateTestConnection} asChild>
                         {(allowed) => (
-                            <ButtonLink to={`/${env}/connections/create?integration_id=${integration.integration.unique_key}`} size="lg" disabled={!allowed}>
+                            <ButtonLink to={`/${env}/connections/create?integration_id=${integration.integration.unique_key}`} size="md" disabled={!allowed}>
                                 Add test connection
                             </ButtonLink>
                         )}

--- a/packages/webapp/src/pages/Team/Billing/components/InvoicingDetailsForm.tsx
+++ b/packages/webapp/src/pages/Team/Billing/components/InvoicingDetailsForm.tsx
@@ -137,7 +137,7 @@ export const InvoicingDetailsForm: React.FC<{ customer: BillingCustomer | undefi
                 <InvoicingTaxIdFields />
 
                 <div className="flex justify-start">
-                    <Button type="submit" variant="primary" size="lg" loading={isPending}>
+                    <Button type="submit" variant="primary" size="md" loading={isPending}>
                         Save changes
                     </Button>
                 </div>

--- a/packages/webapp/src/pages/Team/components/AddTeamMemberButton.tsx
+++ b/packages/webapp/src/pages/Team/components/AddTeamMemberButton.tsx
@@ -65,7 +65,7 @@ export const AddTeamMemberButton = () => {
             <PermissionGate condition={canManageTeam}>
                 {(allowed) => (
                     <DialogTrigger asChild>
-                        <Button size="lg" disabled={!allowed}>
+                        <Button size="md" disabled={!allowed}>
                             <Plus /> Add Team Member
                         </Button>
                     </DialogTrigger>


### PR DESCRIPTION
## Problem

Inputs and the buttons/controls beside them rendered at 36px with a 4px corner radius, reading heavier and rounder than the rest of the redesigned UI. Inputs and inline buttons only stayed aligned because both were pinned to 36px.

## Solution

- Drop the design-system `Input`/`InputGroup`/`Textarea` and the webapp `Select` trigger and `ScopesInput` to a 32px control height.
- Move buttons that sit inline with an input or in a header/toolbar/form row from `lg` to `md`: the DS component triggers (`Combobox`, `MultiSelect`, `FilterMultiSelect`, `PeriodSelector`, `IntegrationDropdown`), the `AuthCredentials` refresh buttons, and content-page actions across integrations, connections, function detail, and team settings. Shrink `LineSnippet` to match the adjacent "View code" button.
- Reduce the input radius from 4px (`rounded-ds-sm`) to 2px (`rounded-ds-xs`) on `Input`/`InputGroup`/`Textarea` and the `Select` trigger, matching the button radius.
- Keep the `lg` button size for prominent CTAs and full-width form submits (auth pages, Getting Started, empty-state create buttons, dialog actions), which stay intentionally larger.

Fixes [NAN-6160](https://linear.app/nango/issue/NAN-6160)

## Testing

- Verified live on dev: inputs and their adjacent buttons/controls render at 32px and aligned across Logs, environment settings, connection auth, integrations, functions, and team settings; kept-`lg` CTAs still measure 36px.
