### PR TITLE
test: stop integration runs failing on teardown console race

### DIFF
--- a/vite.integration.config.ts
+++ b/vite.integration.config.ts
@@ -35,6 +35,13 @@ export default defineConfig({
         fileParallelism: false,
         pool: 'forks',
         // Vitest 4 removed test.poolOptions; poolOptions.forks.singleFork is now maxWorkers: 1.
-        maxWorkers: 1
+        maxWorkers: 1,
+        // Send worker console output straight to stdout/stderr instead of routing it
+        // through Vitest's onUserConsoleLog RPC. Handlers here do fire-and-forget logging
+        // (e.g. the proxy's enrichOperation in a finally block) that outlives the request,
+        // so a stray log can land while the worker is tearing down. With interception on,
+        // that races the closing RPC and fails the run with
+        // "EnvironmentTeardownError: Closing rpc while onUserConsoleLog was pending".
+        disableConsoleIntercept: true
     }
 });


### PR DESCRIPTION
## Problem

Integration CI can fail even when every test passes. Under Vitest 4, worker console output is intercepted and shipped to the main process over an RPC. Handlers in these tests do fire-and-forget logging that outlives the request (e.g. the proxy's `enrichOperation` in a `finally` block), so a stray log can fire as the worker tears down and race the closing RPC. The run then fails with `EnvironmentTeardownError: Closing rpc while "onUserConsoleLog" was pending`, attributed to `allProxy.integration.test.ts` — the [most recent occurrence](https://github.com/NangoHQ/nango/actions/runs/28849938918/job/85562556963?pr=6671) passed all 317 tests but still exited 1.

## Solution

- Set `disableConsoleIntercept: true` in `vite.integration.config.ts` so worker console writes go straight to stdout/stderr, removing the RPC the stray log was racing.

This is a class of flake — any integration test whose handler logs asynchronously can trip it, not just the proxy suite. No test relies on Vitest's console interception.

## Trade-offs

**Pros**
- Removes the whole `onUserConsoleLog` teardown-race flake class, not just the proxy case.
- No production or test-logic change; a genuine failure still prints its test name and assertion stack (that comes from the test result, not console interception).
- Safer than the alternatives: `dangerouslyIgnoreUnhandledErrors` would swallow real unhandled errors, and fixing it at the source would mean blocking HTTP responses on fire-and-forget logging.

**Cons**
- Log lines lose their `stdout | file > test` prefix, so free-floating logs are no longer attributable to a specific test in CI output.
- Console output can interleave more messily (low impact here — this config runs `maxWorkers: 1` + `fileParallelism: false`, so logs stay serial).
- Applies to all integration tests — the option is project-level, can't be scoped to one file.

## Testing

- Ran `allProxy.integration.test.ts` against the fix: 7/7 pass, no `Errors` line and no `EnvironmentTeardownError`.
