### PR TITLE
fix(providers): add Auvik us6 region

### DIFF
--- a/packages/providers/providers.yaml
+++ b/packages/providers/providers.yaml
@@ -2150,6 +2150,7 @@ auvik:
             enum:
                 - us1
                 - us2
+                - us6
                 - eu1
     docs: https://nango.dev/docs/integrations/all/auvik
     docs_connect: https://nango.dev/docs/integrations/all/auvik/connect


### PR DESCRIPTION
## Summary

- Add `us6` to the Auvik provider's allowed region values.

## Why

The Auvik provider template currently limits the region field to `us1`, `us2`, and `eu1`, so customers whose Auvik accounts are hosted in `us6` cannot select their region in connection forms based on this template.

The provider's proxy base URL already interpolates `connectionConfig.region`, so adding the enum value is sufficient to generate the correct `us6` API URL.

## Impact

Connection forms backed by Nango's Auvik provider template can offer `us6` as a valid region after this provider update is deployed.

## Validation

- `npm run test:providers`


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/NangoHQ/nango/pull/6707?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

