### PR TITLE
feat: add proxy DTO metering

### DIFF
--- a/packages/server/lib/controllers/proxy/allProxy.ts
+++ b/packages/server/lib/controllers/proxy/allProxy.ts
@@ -30,6 +30,7 @@ import { asyncWrapper } from '../../utils/asyncWrapper.js';
 import { egressTelemetryRecorder } from '../../utils/egressTelemetry.js';
 import { capping } from '../../utils/usage.js';
 
+import type { ServerEgressCallsite } from '../../utils/egressTelemetry.js';
 import type { LogContext } from '@nangohq/logs';
 import type { AllPublicProxy, HTTP_METHOD, InternalProxyConfiguration, ProxyFile } from '@nangohq/types';
 import type { AxiosRequestConfig, AxiosResponse } from 'axios';
@@ -450,29 +451,17 @@ function checkWasCompressed(responseStream: AxiosResponse): boolean | undefined 
     return ceIdx !== -1 && ceIdx + 1 < rawHeaders.length && Boolean(rawHeaders[ceIdx + 1]);
 }
 
+const callsiteByMethod: Record<string, ServerEgressCallsite> = {
+    GET: 'get_/proxy',
+    POST: 'post_/proxy',
+    PATCH: 'patch_/proxy',
+    PUT: 'put_/proxy',
+    DELETE: 'delete_/proxy'
+};
+
 function makeRecordEgressedBytes(req: Request, accountId: number, environmentId: number, environmentName: string, integrationId: string, connectionId: string) {
     return function (egressedBytes: number) {
-        let callsite: 'get_/proxy' | 'post_/proxy' | 'patch_/proxy' | 'put_/proxy' | 'delete_/proxy' | null = null;
-
-        switch (req.method) {
-            case 'GET':
-                callsite = 'get_/proxy';
-                break;
-            case 'POST':
-                callsite = 'post_/proxy';
-                break;
-            case 'PATCH':
-                callsite = 'patch_/proxy';
-                break;
-            case 'PUT':
-                callsite = 'put_/proxy';
-                break;
-            case 'DELETE':
-                callsite = 'delete_/proxy';
-                break;
-            default:
-                callsite = null;
-        }
+        const callsite: ServerEgressCallsite = callsiteByMethod[req.method] ?? 'unknown_/proxy';
 
         if (callsite !== null) {
             egressTelemetryRecorder.record({

--- a/packages/server/lib/controllers/proxy/allProxy.ts
+++ b/packages/server/lib/controllers/proxy/allProxy.ts
@@ -1,4 +1,4 @@
-import { PassThrough } from 'node:stream';
+import { finished, PassThrough } from 'node:stream';
 
 import { isAxiosError } from 'axios';
 import * as z from 'zod';
@@ -27,6 +27,7 @@ import { envs } from '../../env.js';
 import { connectionIdSchema, providerConfigKeySchema } from '../../helpers/validation.js';
 import { connectionRefreshFailed, connectionRefreshSuccess } from '../../hooks/hooks.js';
 import { asyncWrapper } from '../../utils/asyncWrapper.js';
+import { egressTelemetryRecorder } from '../../utils/egressTelemetry.js';
 import { capping } from '../../utils/usage.js';
 
 import type { LogContext } from '@nangohq/logs';
@@ -329,20 +330,33 @@ export const allPublicProxy = asyncWrapper<AllPublicProxy>(async (req, res, next
                         connectionId: connection.connection_id,
                         integrationId: providerConfigKey,
                         environmentId: environment.id,
-                        meteredBytes,
-                        environmentName: environment.name
+                        environmentName: environment.name,
+                        meteredBytes
                     })
                 );
             }
         });
 
         let success = false;
+        const recordEgressedBytes = makeRecordEgressedBytes(req, account.id, environment.id, environment.name, providerConfigKey, connection.connection_id);
+
         try {
             const responseStream = (await proxy.request()).unwrap();
-            await handleResponse({ res, responseStream, logCtx });
+            await handleResponse({
+                res,
+                responseStream,
+                logCtx,
+                onEgressedBytes: recordEgressedBytes
+            });
             success = true;
         } catch (err) {
-            handleErrorResponse({ res, error: err, requestConfig: proxy.axiosConfig, logCtx });
+            handleErrorResponse({
+                res,
+                error: err,
+                requestConfig: proxy.axiosConfig,
+                logCtx,
+                onEgressedBytes: recordEgressedBytes
+            });
             await logCtx.failed();
             metrics.increment(metrics.Types.PROXY_FAILURE);
         }
@@ -436,7 +450,56 @@ function checkWasCompressed(responseStream: AxiosResponse): boolean | undefined 
     return ceIdx !== -1 && ceIdx + 1 < rawHeaders.length && Boolean(rawHeaders[ceIdx + 1]);
 }
 
-export async function handleResponse({ res, responseStream, logCtx }: { res: Response; responseStream: AxiosResponse; logCtx: LogContext }) {
+function makeRecordEgressedBytes(req: Request, accountId: number, environmentId: number, environmentName: string, integrationId: string, connectionId: string) {
+    return function (egressedBytes: number) {
+        let callsite: 'get_/proxy' | 'post_/proxy' | 'patch_/proxy' | 'put_/proxy' | 'delete_/proxy' | null = null;
+
+        switch (req.method) {
+            case 'GET':
+                callsite = 'get_/proxy';
+                break;
+            case 'POST':
+                callsite = 'post_/proxy';
+                break;
+            case 'PATCH':
+                callsite = 'patch_/proxy';
+                break;
+            case 'PUT':
+                callsite = 'put_/proxy';
+                break;
+            case 'DELETE':
+                callsite = 'delete_/proxy';
+                break;
+            default:
+                callsite = null;
+        }
+
+        if (callsite !== null) {
+            egressTelemetryRecorder.record({
+                accountId,
+                environmentId,
+                environmentName,
+                integrationId,
+                connectionId,
+                callsite,
+                egressedBytes,
+                count: 1
+            });
+        }
+    };
+}
+
+export async function handleResponse({
+    res,
+    responseStream,
+    logCtx,
+    onEgressedBytes
+}: {
+    res: Response;
+    responseStream: AxiosResponse;
+    logCtx: LogContext;
+    onEgressedBytes?: ((egressedBytes: number) => void) | undefined;
+}) {
     const contentDisposition = responseStream.headers['content-disposition'] || '';
     const transferEncoding = responseStream.headers['transfer-encoding'] || '';
 
@@ -449,7 +512,15 @@ export async function handleResponse({ res, responseStream, logCtx }: { res: Res
             // axios decompressed the response, so the `content-length` header is no longer valid
             delete passthroughHeaders['content-length'];
         }
+        let egressedBytes = 0;
         const passThroughStream = new PassThrough();
+        passThroughStream.on('data', (chunk: Buffer) => {
+            egressedBytes += chunk.length;
+        });
+        const cleanup = finished(res, () => {
+            onEgressedBytes?.(egressedBytes);
+            cleanup();
+        });
         responseStream.data.pipe(passThroughStream);
         passThroughStream.pipe(res);
         res.writeHead(responseStream.status, passthroughHeaders);
@@ -474,6 +545,7 @@ export async function handleResponse({ res, responseStream, logCtx }: { res: Res
 
         if (responseStream.status === 204) {
             res.status(204).end();
+            onEgressedBytes?.(0);
             metrics.increment(metrics.Types.PROXY_SUCCESS);
             await logCtx.success();
             return;
@@ -493,6 +565,8 @@ export async function handleResponse({ res, responseStream, logCtx }: { res: Res
             await logCtx.failed();
             metrics.increment(metrics.Types.PROXY_FAILURE);
             return;
+        } finally {
+            onEgressedBytes?.(responseLen);
         }
 
         await logCtx.success();
@@ -521,12 +595,14 @@ export function handleErrorResponse({
     res,
     error,
     requestConfig,
-    logCtx
+    logCtx,
+    onEgressedBytes
 }: {
     res: Response;
     error: unknown;
     requestConfig?: AxiosRequestConfig | undefined;
     logCtx: LogContext;
+    onEgressedBytes?: ((egressedBytes: number) => void) | undefined;
 }) {
     const proxyErr = proxyErrorFromErrorChain(error);
     if (proxyErr?.code === 'proxy_redirect_to_denied_host') {
@@ -596,7 +672,8 @@ export function handleErrorResponse({
             res.status(500).send();
         });
         errorStream.on('end', () => {
-            const data = chunks.length > 0 ? Buffer.concat(chunks).toString() : '';
+            const buffer = chunks.length > 0 ? Buffer.concat(chunks) : Buffer.alloc(0);
+            const data = buffer.toString();
             let parsedBody: string | Record<string, string> = data;
             const contentTypeHeader = error.response?.headers?.['content-type'];
             const contentType =
@@ -610,10 +687,12 @@ export function handleErrorResponse({
             }
 
             const responseStatus = error.response?.status || 500;
-            const responseHeaders = error.response?.headers || {};
+            const responseHeaders = { ...error.response?.headers };
+            delete (responseHeaders as Record<string, unknown>)['transfer-encoding'];
             void logCtx.error('Failed with this body', { body: parsedBody });
 
             res.status(responseStatus).set(responseHeaders).send(data);
+            onEgressedBytes?.(buffer.length);
         });
     }
 }

--- a/packages/server/lib/controllers/proxy/allProxy.ts
+++ b/packages/server/lib/controllers/proxy/allProxy.ts
@@ -461,20 +461,16 @@ const callsiteByMethod: Record<string, ServerEgressCallsite> = {
 
 function makeRecordEgressedBytes(req: Request, accountId: number, environmentId: number, environmentName: string, integrationId: string, connectionId: string) {
     return function (egressedBytes: number) {
-        const callsite: ServerEgressCallsite = callsiteByMethod[req.method] ?? 'unknown_/proxy';
-
-        if (callsite !== null) {
-            egressTelemetryRecorder.record({
-                accountId,
-                environmentId,
-                environmentName,
-                integrationId,
-                connectionId,
-                callsite,
-                egressedBytes,
-                count: 1
-            });
-        }
+        egressTelemetryRecorder.record({
+            accountId,
+            environmentId,
+            environmentName,
+            integrationId,
+            connectionId,
+            callsite: callsiteByMethod[req.method] ?? 'unknown_/proxy',
+            egressedBytes,
+            count: 1
+        });
     };
 }
 

--- a/packages/server/lib/controllers/proxy/allProxy.ts
+++ b/packages/server/lib/controllers/proxy/allProxy.ts
@@ -560,13 +560,12 @@ export async function handleResponse({
 
         try {
             res.send(Buffer.concat(responseData));
+            onEgressedBytes?.(responseLen);
         } catch (err) {
             void logCtx.error('Failed to write response', { error: err });
             await logCtx.failed();
             metrics.increment(metrics.Types.PROXY_FAILURE);
             return;
-        } finally {
-            onEgressedBytes?.(responseLen);
         }
 
         await logCtx.success();

--- a/packages/server/lib/controllers/proxy/allProxy.ts
+++ b/packages/server/lib/controllers/proxy/allProxy.ts
@@ -604,41 +604,52 @@ export function handleErrorResponse({
     logCtx: LogContext;
     onEgressedBytes?: ((egressedBytes: number) => void) | undefined;
 }) {
+    const countBytes = (body: Record<string, unknown>): number => {
+        return Buffer.byteLength(JSON.stringify(body));
+    };
+
     const proxyErr = proxyErrorFromErrorChain(error);
     if (proxyErr?.code === 'proxy_redirect_to_denied_host') {
         void logCtx.error('Proxy redirect denied by denylist', { error: proxyErr });
-        res.status(400).send({
+        const body = {
             error: {
                 code: 'base_url_override_not_allowed',
                 message: 'This base URL override is not allowed by server configuration.'
             }
-        });
+        };
+        res.status(400).send(body);
+        onEgressedBytes?.(countBytes(body));
         return;
     }
 
     const outboundErr = findOutboundUrlError(error);
     if (outboundErr) {
         void logCtx.error('Proxy outbound URL denied by policy', { error: outboundErr });
-        res.status(400).send({
+        const body = {
             error: {
                 code: 'base_url_override_not_allowed',
                 message: 'This outbound URL is not allowed by server configuration.'
             }
-        });
+        };
+        res.status(400).send(body);
+        onEgressedBytes?.(countBytes(body));
         return;
     }
 
     if (!isAxiosError(error)) {
         if (error instanceof ProxyError) {
             void logCtx.error('Unknown error', { error });
-            res.status(400).send({
+            const body = {
                 error: { code: error.code, message: error.message }
-            });
+            };
+            res.status(400).send(body);
+            onEgressedBytes?.(countBytes(body));
             return;
         }
 
         void logCtx.error('Unknown error', { error });
         res.status(500).send();
+        onEgressedBytes?.(0);
         return;
     }
 
@@ -657,6 +668,7 @@ export function handleErrorResponse({
         const responseHeaders = error.response?.headers || {};
 
         res.status(responseStatus).set(responseHeaders).send(errorObject);
+        onEgressedBytes?.(countBytes(errorObject));
 
         return;
     }
@@ -670,6 +682,7 @@ export function handleErrorResponse({
         errorStream.on('error', (err) => {
             void logCtx.error('Error reading upstream error stream', { error: err });
             res.status(500).send();
+            onEgressedBytes?.(0);
         });
         errorStream.on('end', () => {
             const buffer = chunks.length > 0 ? Buffer.concat(chunks) : Buffer.alloc(0);

--- a/packages/server/lib/controllers/records/getRecords.ts
+++ b/packages/server/lib/controllers/records/getRecords.ts
@@ -114,7 +114,6 @@ export const getPublicRecords = asyncWrapper<GetPublicRecords>(async (req, res) 
             environmentName: environment.name,
             integrationId: headers['provider-config-key'],
             connectionId: connection.connection_id,
-            package: 'server',
             callsite: 'get_/records',
             egressedBytes: responseSize,
             count: 1

--- a/packages/server/lib/utils/egressTelemetry.ts
+++ b/packages/server/lib/utils/egressTelemetry.ts
@@ -7,8 +7,13 @@ import type { Grouping, Result } from '@nangohq/utils';
 const envs = parseEnvs(ENVS);
 const logger = getLogger('server.egress.telemetry');
 
+export type ServerEgressCallsite = Extract<
+    DataTransferCallsite,
+    'get_/records' | 'get_/proxy' | 'post_/proxy' | 'patch_/proxy' | 'put_/proxy' | 'delete_/proxy' | 'unknown_/proxy'
+>;
+
 export interface ServerEgressTelemetry {
-    callsite: Extract<DataTransferCallsite, 'get_/records' | 'get_/proxy' | 'post_/proxy' | 'patch_/proxy' | 'put_/proxy' | 'delete_/proxy'>;
+    callsite: ServerEgressCallsite;
     accountId: number;
     connectionId: string;
     integrationId: string;

--- a/packages/server/lib/utils/egressTelemetry.ts
+++ b/packages/server/lib/utils/egressTelemetry.ts
@@ -8,8 +8,7 @@ const envs = parseEnvs(ENVS);
 const logger = getLogger('server.egress.telemetry');
 
 export interface ServerEgressTelemetry {
-    package: 'server';
-    callsite: Extract<DataTransferCallsite, 'get_/records'>;
+    callsite: Extract<DataTransferCallsite, 'get_/records' | 'get_/proxy' | 'post_/proxy' | 'patch_/proxy' | 'put_/proxy' | 'delete_/proxy'>;
     accountId: number;
     connectionId: string;
     integrationId: string;
@@ -39,7 +38,7 @@ const batcher = new Batcher<ServerEgressTelemetry>({
             subject: 'usage',
             events: events.map((t) =>
                 makeDataTransferEvent({
-                    pkg: t.package,
+                    pkg: 'server',
                     callsite: t.callsite,
                     accountId: t.accountId,
                     connectionId: t.connectionId,

--- a/packages/types/lib/pubsub/events.ts
+++ b/packages/types/lib/pubsub/events.ts
@@ -166,7 +166,8 @@ export type DataTransferCallsite =
     | 'patch_/proxy'
     | 'post_/proxy'
     | 'put_/proxy'
-    | 'delete_/proxy';
+    | 'delete_/proxy'
+    | 'unknown_/proxy';
 
 export type UsageDataTransferEvent = UsageEventBase<
     'usage.data_transfer',

--- a/packages/types/lib/pubsub/events.ts
+++ b/packages/types/lib/pubsub/events.ts
@@ -161,7 +161,12 @@ export type DataTransferCallsite =
     | 'uncontrolled_fetch'
     | 'persist_logs'
     | 'persist_records'
-    | 'get_/records';
+    | 'get_/records'
+    | 'get_/proxy'
+    | 'patch_/proxy'
+    | 'post_/proxy'
+    | 'put_/proxy'
+    | 'delete_/proxy';
 
 export type UsageDataTransferEvent = UsageEventBase<
     'usage.data_transfer',


### PR DESCRIPTION
Meters proxy response bytes sent back to the caller. Follows the same pattern introduced in the metering of getRecords for the callsite resolution, that is, the http method plus the route joined by an underscore character.

<!-- Describe the problem and your solution --> 

<!-- Issue ticket number and link (if applicable) -->

<!-- Testing instructions (skip if just adding/editing providers) -->



<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/NangoHQ/nango/pull/6709?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

