### PR TITLE
feat: add Mosyle (Apple MDM) provider

### DIFF
--- a/docs/docs.json
+++ b/docs/docs.json
@@ -1401,6 +1401,7 @@
               "api-integrations/modmed",
               "api-integrations/monday",
               "integrations/all/momentum-io",
+              "integrations/all/mosyle",
               "integrations/all/mural",
               "api-integrations/nable-ncentral",
               "integrations/all/nationbuilder",

--- a/docs/integrations/all/mosyle.mdx
+++ b/docs/integrations/all/mosyle.mdx
@@ -1,0 +1,83 @@
+---
+title: 'Mosyle'
+sidebarTitle: 'Mosyle'
+description: 'Access the Mosyle Business API in 2 minutes 🍏'
+---
+
+<Tabs>
+  <Tab title="🚀 Quickstart">
+    <Steps>
+      <Step title="Create an integration">
+        In Nango ([free signup](https://app.nango.dev)), go to [Integrations](https://app.nango.dev/dev/integrations) -> _Configure New Integration_ -> _Mosyle_.
+      </Step>
+      <Step title="Authorize Mosyle">
+        Go to [Connections](https://app.nango.dev/dev/connections) -> _Add Test Connection_ -> _Authorize_, then enter your Mosyle **Access Token** (from the Mosyle console: _Organization > API Integration > enable the profile_) along with an admin **email** and **password**. Later, you'll let your users do the same directly from your app.
+      </Step>
+      <Step title="Call the Mosyle API">
+        Let's make your first request to the Mosyle API (list devices). Replace the placeholders below with your [secret key](https://app.nango.dev/dev/environment-settings), [integration ID](https://app.nango.dev/dev/integrations), and [connection ID](https://app.nango.dev/dev/connections):
+        <Tabs>
+            <Tab title="cURL">
+
+                ```bash
+                curl -X POST "https://api.nango.dev/proxy/devices" \
+                  -H "Authorization: Bearer <NANGO-SECRET-KEY>" \
+                  -H "Provider-Config-Key: <INTEGRATION-ID>" \
+                  -H "Connection-Id: <CONNECTION-ID>" \
+                  -H "Content-Type: application/json" \
+                  -d '{ "operation": "list", "options": { "os": "ios" } }'
+                ```
+
+            </Tab>
+
+            <Tab title="Node">
+
+            Install Nango's backend SDK with `npm i @nangohq/node`. Then run:
+
+            ```typescript
+            import { Nango } from '@nangohq/node';
+
+            const nango = new Nango({ secretKey: '<NANGO-SECRET-KEY>' });
+
+            const res = await nango.post({
+                endpoint: '/devices',
+                providerConfigKey: '<INTEGRATION-ID>',
+                connectionId: '<CONNECTION-ID>',
+                data: { operation: 'list', options: { os: 'ios' } }
+            });
+
+            console.log(JSON.stringify(res.data, null, 2));
+            ```
+
+            </Tab>
+        </Tabs>
+      </Step>
+    </Steps>
+
+    ✅ You're connected! Check the [Logs](https://app.nango.dev/dev/logs) tab in Nango to inspect requests.
+
+    <Tip>
+    Next step: [Embed the auth flow](/guides/primitives/auth) in your app to let your users connect their Mosyle accounts.
+    </Tip>
+  </Tab>
+  <Tab title="🔗 Useful links">
+    | Topic | Links |
+    | - | - |
+    | Authorization | [Guide to connect to Mosyle using Connect UI](/integrations/all/mosyle/connect) |
+    | General | [Mosyle Website](https://mosyle.com/) |
+    | Developer | [API Documentation](https://businessapi.mosyle.com/) |
+
+    <Note>Contribute useful links by [editing this page](https://github.com/nangohq/nango/tree/master/docs/integrations/all/mosyle.mdx)</Note>
+  </Tab>
+  <Tab title="🚨 API gotchas">
+    - Every Mosyle endpoint is a **POST**; the action is selected by the `operation` field in the request body (e.g. `list`, `list_users`).
+    - Auth is two-step: Nango sends your **Access Token** (`accesstoken` header) plus an admin email/password to `/login`, and Mosyle returns a Bearer JWT in the **`Authorization` response header** (not the body). The JWT expires after ~24h; Nango refreshes it automatically.
+    - Errors are frequently returned with an HTTP `200` (and sometimes `400`/`405`) but the real status is inside `response[0].status` (e.g. `MISSING_DATA`, `DEVICES_NOTFOUND`, `UNKNOWN_COLUMNS`). Always branch on the response body, not the HTTP status.
+    - `list` requires an `os` value (`ios`, `mac`, `tvos`, or `visionos`).
+
+    <Note>Contribute API gotchas by [editing this page](https://github.com/nangohq/nango/tree/master/docs/integrations/all/mosyle.mdx)</Note>
+  </Tab>
+</Tabs>
+
+<Info>
+    Questions? Join us in the [Slack community](https://nango.dev/slack).
+</Info>

--- a/docs/integrations/all/mosyle/connect.mdx
+++ b/docs/integrations/all/mosyle/connect.mdx
@@ -1,0 +1,34 @@
+---
+title: Mosyle - How do I link my account?
+sidebarTitle: Mosyle
+---
+
+# Overview
+
+To authenticate with Mosyle Business, you need:
+1. **Access Token** – The API access token from your Mosyle console
+2. **Email** – The email address of a Mosyle admin user
+3. **Password** – The password for that Mosyle admin user
+
+This guide will walk you through finding your credentials within Mosyle.
+
+## Prerequisites
+
+- You must have a Mosyle Business account
+- You must be an admin user with permission to enable API access
+
+## Step 1: Enable the API
+
+1. Log in to your Mosyle console.
+2. Go to **Organization > API Integration** and enable the profile.
+3. Copy the **Access Token** that is shown once the profile is enabled.
+
+## Step 2: Enter credentials in the Connect UI
+
+Once you have your **Access Token**, admin **Email**, and **Password**:
+
+1. Open the form where you need to authenticate with Mosyle.
+2. Enter your **Access Token**, **Email**, and **Password** in their designated fields.
+3. Submit the form, and you should be successfully authenticated.
+
+You are now connected to Mosyle.

--- a/packages/providers/providers.yaml
+++ b/packages/providers/providers.yaml
@@ -13347,6 +13347,51 @@ modmed:
             example: a1b2c3d4-e5f6-47a8-9b0c-d1234567890f
             doc_section: '#step-1-request-access-to-modmed-sandbox'
 
+mosyle:
+    display_name: Mosyle
+    categories:
+        - other
+    auth_mode: TWO_STEP
+    body_format: json
+    token_url: https://businessapi.mosyle.com/v1/login
+    token_headers:
+        content-type: application/json
+        accesstoken: ${credentials.accessToken}
+    token_params:
+        email: ${credentials.email}
+        password: ${credentials.password}
+    token_response:
+        token: authorization
+    token_response_headers:
+        - authorization
+    token_expires_in_ms: 86400000
+    proxy:
+        base_url: https://businessapi.mosyle.com/v1
+        headers:
+            accesstoken: ${credentials.accessToken}
+            authorization: ${accessToken}
+    docs: https://nango.dev/docs/integrations/all/mosyle
+    docs_connect: https://nango.dev/docs/integrations/all/mosyle/connect
+    connection_config: {}
+    credentials:
+        accessToken:
+            type: string
+            title: Access Token
+            description: The Access Token from your Mosyle console (Organization > API Integration > enable the profile).
+            secret: true
+            doc_section: '#step-1-enable-the-api'
+        email:
+            type: string
+            title: Admin Email
+            description: Email of a Mosyle admin user with API access.
+            doc_section: '#step-1-enable-the-api'
+        password:
+            type: string
+            title: Admin Password
+            description: Password of the Mosyle admin user.
+            secret: true
+            doc_section: '#step-1-enable-the-api'
+
 mural:
     display_name: Mural
     categories:


### PR DESCRIPTION
## Describe your changes

Adds the **Mosyle Business API** (Apple MDM) as a new provider.

Mosyle authenticates in two steps: an admin `email`/`password` are POSTed to `/login` along with a console **Access Token** (`accesstoken` header), and Mosyle returns a Bearer JWT in the **`Authorization` response header** (not the body). The JWT expires after ~24h. This is modeled as a `TWO_STEP` provider using `token_response_headers` to read the JWT from the response header (following the existing `sap-business-one` provider), then proxying to `https://businessapi.mosyle.com/v1`.

- `packages/providers/providers.yaml` — `mosyle` provider entry
- `docs/integrations/all/mosyle.mdx` + `docs/integrations/all/mosyle/connect.mdx`
- `docs/docs.json` — reference added in alphabetical order

## Notes

- Credentials: `accessToken` (console API key), `email`, `password` (admin user).
- Every Mosyle endpoint is a `POST`; the action is selected by the `operation` body field.
- Header keys in `proxy.headers` must be lowercase per the schema, so `accesstoken` is used — verified that Mosyle accepts the lowercase header (HTTP headers are case-insensitive).
- `providers.yaml` passes `scripts/validation/providers/validate.ts`.

## Checklist

- [x] Added provider to `providers.yaml`
- [x] Validated the configuration
- [x] Added `<api>.mdx` docs page and referenced it in `docs.json`

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/NangoHQ/nango/pull/6710?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

