### PR TITLE
fix(webapp): fix focus rings in sidebar navigation

### DIFF
--- a/packages/webapp/src/components/ui/Sidebar.tsx
+++ b/packages/webapp/src/components/ui/Sidebar.tsx
@@ -82,7 +82,7 @@ function SidebarProvider({
 
     // Helper to toggle the sidebar.
     const toggleSidebar = React.useCallback(() => {
-        return isMobile ? void setOpenMobile((open) => !open) : void setOpen((open) => !open);
+        return isMobile ? setOpenMobile((open) => !open) : setOpen((open) => !open);
     }, [isMobile, setOpen, setOpenMobile]);
 
     // Adds a keyboard shortcut to toggle the sidebar.
@@ -362,11 +362,13 @@ function SidebarMenu({ className, ...props }: React.ComponentProps<'ul'>) {
 }
 
 function SidebarMenuItem({ className, ...props }: React.ComponentProps<'li'>) {
-    return <li data-slot="sidebar-menu-item" data-sidebar="menu-item" className={cn('group/menu-item relative', className)} {...props} />;
+    return (
+        <li data-slot="sidebar-menu-item" data-sidebar="menu-item" className={cn('group/menu-item relative has-[:focus-visible]:z-10', className)} {...props} />
+    );
 }
 
 const sidebarMenuButtonVariants = cva(
-    'peer/menu-button flex w-full items-center gap-2 overflow-hidden rounded p-2 text-left text-body-medium-medium outline-hidden focus-default transition-[width,height,padding] hover:bg-state-hover hover:text-text-strong focus-visible:bg-state-hover focus-visible:text-text-strong active:bg-state-selected disabled:pointer-events-none disabled:opacity-50 group-has-data-[sidebar=menu-action]/menu-item:pr-8 aria-disabled:pointer-events-none aria-disabled:opacity-50 data-[active=true]:bg-state-selected data-[active=true]:text-text-strong data-[state=open]:hover:bg-state-hover data-[state=open]:hover:text-text-strong group-data-[collapsible=icon]:size-8! group-data-[collapsible=icon]:p-2! [&>span:last-child]:truncate [&>svg]:size-5 [&>svg]:shrink-0',
+    'peer/menu-button flex w-full items-center gap-2 overflow-hidden rounded p-2 text-left text-body-medium-medium outline-hidden focus-default transition-[width,height,padding] hover:bg-state-hover hover:text-text-strong active:bg-state-selected disabled:pointer-events-none disabled:opacity-50 group-has-data-[sidebar=menu-action]/menu-item:pr-8 aria-disabled:pointer-events-none aria-disabled:opacity-50 data-[active=true]:bg-state-selected data-[active=true]:text-text-strong data-[state=open]:hover:bg-state-hover data-[state=open]:hover:text-text-strong group-data-[collapsible=icon]:size-8! group-data-[collapsible=icon]:p-2! [&>span:last-child]:truncate [&>svg]:size-5 [&>svg]:shrink-0',
     {
         variants: {
             variant: {

--- a/packages/webapp/src/components/ui/Sidebar.tsx
+++ b/packages/webapp/src/components/ui/Sidebar.tsx
@@ -82,7 +82,7 @@ function SidebarProvider({
 
     // Helper to toggle the sidebar.
     const toggleSidebar = React.useCallback(() => {
-        return isMobile ? setOpenMobile((open) => !open) : setOpen((open) => !open);
+        return isMobile ? void setOpenMobile((open) => !open) : void setOpen((open) => !open);
     }, [isMobile, setOpen, setOpenMobile]);
 
     // Adds a keyboard shortcut to toggle the sidebar.
@@ -449,7 +449,7 @@ function SidebarMenuAction({
             data-slot="sidebar-menu-action"
             data-sidebar="menu-action"
             className={cn(
-                'text-text-muted focus-default cursor-pointer hover:bg-state-hover hover:text-text-strong peer-hover/menu-button:text-text-strong absolute top-1.5 right-1 flex aspect-square w-5 items-center justify-center rounded-md p-0 outline-hidden transition-transform focus-visible:ring-2 [&>svg]:size-4 [&>svg]:shrink-0',
+                'text-text-muted focus-default cursor-pointer hover:bg-state-hover hover:text-text-strong peer-hover/menu-button:text-text-strong absolute top-1.5 right-1 flex aspect-square w-5 items-center justify-center rounded-md p-0 outline-hidden transition-transform [&>svg]:size-4 [&>svg]:shrink-0',
                 // Increases the hit area of the button on mobile.
                 'after:absolute after:-inset-2 md:after:hidden',
                 'peer-data-[size=sm]/menu-button:top-1',

--- a/packages/webapp/src/index.css
+++ b/packages/webapp/src/index.css
@@ -76,6 +76,14 @@
     }
 }
 
+/* Inset variant of focus-default, for full-bleed elements where an outset ring would clip against a container edge. */
+@utility focus-inset {
+    @variant focus-visible {
+        outline: none;
+        box-shadow: inset 0 0 0 2px var(--color-focus-ring-default);
+    }
+}
+
 @utility focus-error {
     @variant focus {
         outline: none;

--- a/packages/webapp/src/layout/AppSidebar/EnvironmentDropdown.tsx
+++ b/packages/webapp/src/layout/AppSidebar/EnvironmentDropdown.tsx
@@ -73,7 +73,7 @@ export const EnvironmentDropdown: React.FC = () => {
         <SidebarMenu>
             <SidebarMenuItem>
                 <DropdownMenu modal={false}>
-                    <DropdownMenuTrigger className="flex h-14 w-full cursor-pointer flex-row items-center justify-between border-b-[0.5px] border-border-default px-4 outline-none transition-colors hover:bg-state-hover data-[state=open]:bg-surface-overlay">
+                    <DropdownMenuTrigger className="focus-inset flex h-14 w-full cursor-pointer flex-row items-center justify-between border-b-[0.5px] border-border-default px-4 outline-none transition-colors hover:bg-state-hover data-[state=open]:bg-surface-overlay">
                         <div className="flex min-w-0 items-center gap-3">
                             <div className="flex size-8 shrink-0 items-center justify-center rounded-[2px] border-[0.5px] border-border-default bg-surface-overlay">
                                 <LogoInverted className="size-5 text-text-strong" />

--- a/packages/webapp/src/layout/AppSidebar/ProfileDropdown.tsx
+++ b/packages/webapp/src/layout/AppSidebar/ProfileDropdown.tsx
@@ -66,7 +66,7 @@ export const ProfileDropdown: React.FC = () => {
         <SidebarMenu>
             <SidebarMenuItem>
                 <DropdownMenu modal={false}>
-                    <DropdownMenuTrigger className="group/profile flex h-14 w-full cursor-pointer items-center justify-between border-t-[0.5px] border-b-[0.5px] border-border-default px-4 outline-none transition-colors hover:bg-state-hover data-[state=open]:bg-surface-overlay">
+                    <DropdownMenuTrigger className="group/profile focus-inset flex h-14 w-full cursor-pointer items-center justify-between border-t-[0.5px] border-b-[0.5px] border-border-default px-4 outline-none transition-colors hover:bg-state-hover data-[state=open]:bg-surface-overlay">
                         <div className="flex min-w-0 items-center gap-3">
                             <div className="type-text-regular-xs flex size-8 shrink-0 items-center justify-center rounded-full border-[0.5px] border-border-default bg-surface-overlay text-text-default">
                                 {initials}


### PR DESCRIPTION
## Problem

Keyboard focus rings in the app sidebar were broken: on nav items the ring was partially covered by the selected item's background, and focusing an item also swapped its background color. The env switcher (top) and profile trigger (bottom) had no focus ring at all.

## Solution

- Lift the focused menu item above its neighbors (`has-[:focus-visible]:z-10` on the row) so its outset ring is no longer covered by the selected item below it.
- Drop the focus-only background/text swap on nav items — focus now shows the ring only.
- Add an inset focus ring (`focus-inset` utility) to the env switcher and profile triggers, where an outset ring would clip against the sidebar's edges.

Fixes [NAN-6178](https://linear.app/nango/issue/NAN-6178)

## Testing

Verified in the browser (light + dark) that all three controls show a fully-visible, theme-aware ring on keyboard focus, the ring clears the selected item and keeps the Getting Started "×" visible, and mouse clicks show no ring.

<img width="1292" height="587" alt="image" src="https://github.com/user-attachments/assets/fab31224-9765-40b9-8ead-4995aab70434" />

<img width="236" height="324" alt="image" src="https://github.com/user-attachments/assets/44a0360f-2e48-4421-b7a6-acf076f8a389" />

