### PR TITLE
feat(cli): expose createFunction as an experimental feature

### DIFF
--- a/packages/cli/lib/sdkExperimental.ts
+++ b/packages/cli/lib/sdkExperimental.ts
@@ -1,0 +1,5 @@
+// Experimental, not production ready.
+// Intentionally kept off the main `nango` barrel.
+
+export { createFunction } from '@nangohq/runner-sdk';
+export type { CreateFunctionProps, CreateFunctionResponse, TriggerDefinition } from '@nangohq/runner-sdk';

--- a/packages/cli/lib/zeroYaml/constants.ts
+++ b/packages/cli/lib/zeroYaml/constants.ts
@@ -43,4 +43,4 @@ export const tsconfigString: Record<string, any> = {
     moduleResolution: 'node16'
 };
 
-export const allowedPackages = ['url', 'node:url', 'crypto', 'node:crypto', 'nango', 'zod', 'unzipper', 'soap', 'botbuilder'];
+export const allowedPackages = ['nango/experimental', 'url', 'node:url', 'crypto', 'node:crypto', 'nango', 'zod', 'unzipper', 'soap', 'botbuilder'];

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -20,6 +20,11 @@
             "types": "./dist/testMocks/utils.d.ts",
             "default": "./dist/testMocks/utils.js"
         },
+        "./experimental": {
+            "require": "./dist/sdkExperimental.js",
+            "types": "./dist/sdkExperimental.d.ts",
+            "default": "./dist/sdkExperimental.js"
+        },
         "./package.json": "./package.json"
     },
     "keywords": [],

--- a/packages/runner-sdk/lib/function.ts
+++ b/packages/runner-sdk/lib/function.ts
@@ -278,6 +278,10 @@ export interface CreateFunctionResponse<
 /**
  * Create a function, a trigger-agnostic primitive with capabilities.
  *
+ * @experimental **Not production ready.**
+ * The function primitive is under active development.
+ * Its API may change or be removed without notice, do NOT USE it in production integrations.
+ *
  * @example
  * ```ts
  * export default createFunction({

--- a/packages/runner-sdk/lib/index.ts
+++ b/packages/runner-sdk/lib/index.ts
@@ -7,6 +7,8 @@ export * from './errors.js';
 export * from './sync.js';
 export * from './scripts.js';
 export * from './checkpoint.js';
+export { createFunction } from './function.js';
+export type { CreateFunctionProps, CreateFunctionResponse, TriggerDefinition } from './function.js';
 export { executeUncontrolledFetch } from './uncontrolledFetch.js';
 export type { UncontrolledFetchOptions } from './uncontrolledFetch.js';
 export { isBaseUrlOverridePolicyEnabledFromEnv, resolveProxyBaseUrlOverrideDenylist } from './baseUrlOverrideDenylist.js';


### PR DESCRIPTION
I want to avoid long-lived feature branch, as well as being able to dogfood createFunction and submit/merge bitesize PRs. 
In order to achieve this objective I propose to expose `createFunction` as a CLI experimental export. 
Experimental package is accessible via explicit 
```
import { createFunction } from 'nango/experimental'
```
but not visible via normal `nango` import in order to prevent customer to accidentally use or discover it.
Also adding a experimental JSDoc comment annotation.



<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/NangoHQ/nango/pull/6714?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

