### PR TITLE
fix(webapp): enable auth submit buttons by default

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -39067,6 +39067,7 @@
             "version": "1.0.0",
             "dependencies": {
                 "@nangohq/egress": "file:../egress",
+                "@nangohq/feature-flags": "file:../feature-flags",
                 "@nangohq/kvstore": "file:../kvstore",
                 "@nangohq/logs": "file:../logs",
                 "@nangohq/shared": "file:../shared",

--- a/packages/webapp/src/pages/Account/ForgotPassword.tsx
+++ b/packages/webapp/src/pages/Account/ForgotPassword.tsx
@@ -22,7 +22,10 @@ type ForgotPasswordFormData = z.infer<typeof forgotPasswordSchema>;
 export default function Signin() {
     const form = useForm<ForgotPasswordFormData>({
         resolver: zodResolver(forgotPasswordSchema),
-        mode: 'onTouched'
+        defaultValues: {
+            email: ''
+        },
+        mode: 'onSubmit'
     });
 
     const { toast } = useToast();
@@ -80,7 +83,7 @@ export default function Signin() {
                             )}
                         />
 
-                        <Button type="submit" size={'lg'} loading={isPending} disabled={!form.formState.isValid}>
+                        <Button type="submit" size={'lg'} loading={isPending}>
                             Send password reset email
                         </Button>
                     </form>

--- a/packages/webapp/src/pages/Account/ResetPassword.tsx
+++ b/packages/webapp/src/pages/Account/ResetPassword.tsx
@@ -24,7 +24,10 @@ type ResetPasswordFormData = z.infer<typeof resetPasswordSchema>;
 export default function ResetPassword() {
     const form = useForm<ResetPasswordFormData>({
         resolver: zodResolver(resetPasswordSchema),
-        mode: 'onTouched'
+        defaultValues: {
+            password: ''
+        },
+        mode: 'onSubmit'
     });
     const { mutateAsync: resetPassword, isPending } = useResetPasswordAPI();
 
@@ -77,7 +80,7 @@ export default function ResetPassword() {
                         render={() => <Password placeholder="New password" autoFocus autoComplete="new-password" />}
                     />
 
-                    <Button type="submit" size={'lg'} loading={isPending} disabled={!form.formState.isValid}>
+                    <Button type="submit" size={'lg'} loading={isPending}>
                         Reset password
                     </Button>
                 </form>

--- a/packages/webapp/src/pages/Account/Signin.tsx
+++ b/packages/webapp/src/pages/Account/Signin.tsx
@@ -60,7 +60,11 @@ export const Signin: React.FC = () => {
 
     const form = useForm<SigninFormData>({
         resolver: zodResolver(signinSchema),
-        mode: 'onTouched'
+        defaultValues: {
+            email: '',
+            password: ''
+        },
+        mode: 'onSubmit'
     });
 
     const onSubmitForm = async (data: SigninFormData) => {
@@ -196,7 +200,7 @@ export const Signin: React.FC = () => {
                                 </StyledLink>
                             </div>
 
-                            <Button type="submit" size="lg" loading={isPending} disabled={!form.formState.isValid}>
+                            <Button type="submit" size="lg" loading={isPending}>
                                 {isPending ? 'Logging in...' : 'Log in'}
                             </Button>
                         </form>

--- a/packages/webapp/src/pages/Account/components/SignupForm.tsx
+++ b/packages/webapp/src/pages/Account/components/SignupForm.tsx
@@ -35,7 +35,7 @@ export const SignupForm: React.FC<{ invitation?: ApiInvitation; token?: string }
             email: invitation?.email || '',
             password: ''
         },
-        mode: 'onTouched'
+        mode: 'onSubmit'
     });
 
     const navigate = useNavigate();
@@ -175,7 +175,7 @@ export const SignupForm: React.FC<{ invitation?: ApiInvitation; token?: string }
 
                         <FormField control={form.control} name="password" render={() => <Password autoComplete="new-password" />} />
 
-                        <Button type="submit" size="lg" loading={isPending} disabled={!form.formState.isValid}>
+                        <Button type="submit" size="lg" loading={isPending}>
                             {isPending ? 'Signing up...' : 'Sign up'}
                         </Button>
                     </form>


### PR DESCRIPTION
## Problem

The login, signup, and password forms kept their submit button disabled until the whole form was valid, and validated on `onTouched`. The button rendered greyed-out and hard to see (an a11y concern), and focusing a field then clicking away showed a premature "Required" error before the user typed anything.

## Solution

- Drop the `disabled={!form.formState.isValid}` gating so the submit button is actionable by default (it still disables while a request is in flight via `loading`).
- Switch validation from `mode: 'onTouched'` to `mode: 'onSubmit'`, so validation only runs when the button is clicked and re-validates live afterwards.
- Add `defaultValues` to Signin/ForgotPassword/ResetPassword so an empty submit shows the descriptive schema messages (e.g. "Please enter a valid email address") instead of a generic "Required".

Fixes [NAN-6172](https://linear.app/nango/issue/NAN-6172)

## Testing

Ran the webapp against the remote dev API and drove each form (`/signin`, `/signup`, `/forgot-password`, `/reset-password/:token`): button is enabled on load, focus+blur of an empty field shows no error, an empty submit shows the descriptive messages, errors clear live after a failed submit, and a valid login redirects normally.
