### PR TITLE
feat(design-system): apply AA-safe primary button color

### DIFF
--- a/packages/design-system/tokens/tokens.generated.css
+++ b/packages/design-system/tokens/tokens.generated.css
@@ -41,6 +41,7 @@
     --ds-color-brand-500: #00b2e3;
     --ds-color-brand-600: #009cc8;
     --ds-color-brand-700: #0089b0;
+    --ds-color-brand-750: #007ca0;
     --ds-color-brand-800: #016886;
     --ds-color-brand-900: #02485d;
     --ds-color-brand-950: #013747;
@@ -54,6 +55,7 @@
     --ds-color-info-500: #00b2e3;
     --ds-color-info-600: #009cc8;
     --ds-color-info-700: #0089b0;
+    --ds-color-info-750: #007ca0;
     --ds-color-info-800: #016886;
     --ds-color-info-900: #02485d;
     --ds-color-info-950: #013747;
@@ -300,9 +302,9 @@
     --border-danger-hover: #eb2d2d;
     --border-disabled: #ebebeb;
     --border-inverse: #ffffff33;
-    --interactive-primary: #016886;
-    --interactive-primary-hover: #02485d;
-    --interactive-primary-active: #013747;
+    --interactive-primary: #007ca0;
+    --interactive-primary-hover: #016886;
+    --interactive-primary-active: #02485d;
     --interactive-danger: #e81818;
     --interactive-danger-hover: #a11313;
     --interactive-danger-active: #5a0f0f;
@@ -313,7 +315,7 @@
     --interactive-outline-hover: #0000000f;
     --interactive-outline-active: #0000001a;
     --interactive-disabled: #f5f5f5;
-    --interactive-selected-fill: #016886;
+    --interactive-selected-fill: #007ca0;
     --state-hover: #0000000f;
     --state-pressed: #0000001a;
     --state-selected: #ebebeb;
@@ -403,7 +405,7 @@
     --text-disabled: #626366;
     --text-inverse: #000000;
     --text-on-accent: #ffffff;
-    --text-on-brand: #18191b;
+    --text-on-brand: #ffffff;
     --text-brand: #66d6f0;
     --text-link: #66d6f0;
     --text-link-hover: #a3e6f6;
@@ -424,9 +426,9 @@
     --border-danger-hover: #f27474;
     --border-disabled: #ffffff0f;
     --border-inverse: #00000033;
-    --interactive-primary: #00b2e3;
-    --interactive-primary-hover: #33c4e9;
-    --interactive-primary-active: #009cc8;
+    --interactive-primary: #007ca0;
+    --interactive-primary-hover: #016886;
+    --interactive-primary-active: #02485d;
     --interactive-danger: #e81818;
     --interactive-danger-hover: #eb2d2d;
     --interactive-danger-active: #a11313;
@@ -437,7 +439,7 @@
     --interactive-outline-hover: #ffffff14;
     --interactive-outline-active: #ffffff1f;
     --interactive-disabled: #18191b;
-    --interactive-selected-fill: #00b2e3;
+    --interactive-selected-fill: #007ca0;
     --state-hover: #ffffff14;
     --state-pressed: #ffffff1f;
     --state-selected: #2a2b2f;

--- a/packages/design-system/tokens/tokens.json
+++ b/packages/design-system/tokens/tokens.json
@@ -53,6 +53,11 @@
                 "500": { "$type": "color", "$value": "#00B2E3" },
                 "600": { "$type": "color", "$value": "#009CC8" },
                 "700": { "$type": "color", "$value": "#0089B0" },
+                "750": {
+                    "$type": "color",
+                    "$value": "#007CA0",
+                    "$description": "AA-safe brand stop, added to fix the primary button. .700 (#0089B0) is the marketing/website blue but only reaches 4.03:1 with white text — fails WCAG AA (4.5:1). .800 (#016886) passes at 6.31:1 but reads as dark teal, drifting from the brand cyan. At .750, white text hits 4.78:1 (AA pass with margin) while staying visibly closer to brand.500 (#00B2E3) than .800 does. Used as the single interactive.primary fill in BOTH Light and Dark themes so the button no longer changes hue between modes."
+                },
                 "800": { "$type": "color", "$value": "#016886" },
                 "900": { "$type": "color", "$value": "#02485D" },
                 "950": { "$type": "color", "$value": "#013747" },
@@ -76,6 +81,7 @@
                 "500": { "$type": "color", "$value": "{color.brand.500}" },
                 "600": { "$type": "color", "$value": "{color.brand.600}" },
                 "700": { "$type": "color", "$value": "{color.brand.700}" },
+                "750": { "$type": "color", "$value": "{color.brand.750}" },
                 "800": { "$type": "color", "$value": "{color.brand.800}" },
                 "900": { "$type": "color", "$value": "{color.brand.900}" },
                 "950": { "$type": "color", "$value": "{color.brand.950}" },
@@ -429,7 +435,11 @@
             "disabled": { "$type": "color", "$value": "{color.neutral.600}" },
             "inverse": { "$type": "color", "$value": "{color.neutral.975}" },
             "onAccent": { "$type": "color", "$value": "{color.neutral.0}" },
-            "onBrand": { "$type": "color", "$value": "{color.neutral.900}" },
+            "onBrand": {
+                "$type": "color",
+                "$value": "{color.neutral.0}",
+                "$description": "Flipped from neutral.900 to white — required now that interactive.primary/selectedFill use info.750 (dark text on info.750 only reaches 3.68:1, fails AA; white reaches 4.78:1)."
+            },
             "brand": { "$type": "color", "$value": "{color.brand.300}" },
             "link": { "$type": "color", "$value": "{color.info.300}" },
             "linkHover": { "$type": "color", "$value": "{color.info.200}" },
@@ -444,8 +454,16 @@
             "default": { "$type": "color", "$value": "{color.alpha.white.10}" },
             "strong": { "$type": "color", "$value": "{color.alpha.white.16}" },
             "stronger": { "$type": "color", "$value": "{color.alpha.white.24}" },
-            "interactive": { "$type": "color", "$value": "{color.alpha.white.24}" },
-            "interactiveHover": { "$type": "color", "$value": "{color.alpha.white.40}" },
+            "interactive": {
+                "$type": "color",
+                "$value": "{color.alpha.white.24}",
+                "$description": "Resting border for interactive controls (checkboxes, toggles, segmented controls, chips) — same weight as border.stronger."
+            },
+            "interactiveHover": {
+                "$type": "color",
+                "$value": "{color.alpha.white.40}",
+                "$description": "Hover border for interactive controls — strengthens to the same weight as border.input."
+            },
             "input": { "$type": "color", "$value": "{color.alpha.white.40}" },
             "inputHover": { "$type": "color", "$value": "{color.alpha.white.50}" },
             "selected": { "$type": "color", "$value": "{color.info.500}" },
@@ -486,9 +504,13 @@
         },
         "interactive": {
             "$description": { "$type": "other", "$value": "Solid fill colors for buttons, switches, selected states." },
-            "primary": { "$type": "color", "$value": "{color.info.500}" },
-            "primaryHover": { "$type": "color", "$value": "{color.info.400}" },
-            "primaryActive": { "$type": "color", "$value": "{color.info.600}" },
+            "primary": {
+                "$type": "color",
+                "$value": "{color.info.750}",
+                "$description": "Unified brand-blue fill — same value used in Light theme, so the primary button no longer flips between bright cyan (dark) and dark teal (light). White text (text.onBrand) reaches 4.78:1."
+            },
+            "primaryHover": { "$type": "color", "$value": "{color.info.800}" },
+            "primaryActive": { "$type": "color", "$value": "{color.info.900}" },
             "danger": { "$type": "color", "$value": "{color.danger.700}" },
             "dangerHover": { "$type": "color", "$value": "{color.danger.600}" },
             "dangerActive": { "$type": "color", "$value": "{color.danger.800}" },
@@ -501,8 +523,8 @@
             "disabled": { "$type": "color", "$value": "{state.disabled}" },
             "selectedFill": {
                 "$type": "color",
-                "$value": "{color.info.500}",
-                "$description": "A11Y: labels/icons on selectedFill must use text.onBrand (neutral.900 → 7.10:1), never text.onAccent (white → 2.48:1). Same rule as interactive.primary."
+                "$value": "{color.info.750}",
+                "$description": "Matches interactive.primary (info.750) so selected state and primary button read as the same brand blue. text.onBrand (white) passes at 4.78:1 — verified in both themes."
             }
         },
         "state": {
@@ -664,8 +686,16 @@
             "default": { "$type": "color", "$value": "{color.neutral.200}" },
             "strong": { "$type": "color", "$value": "{color.neutral.300}" },
             "stronger": { "$type": "color", "$value": "{color.neutral.400}" },
-            "interactive": { "$type": "color", "$value": "{color.neutral.400}" },
-            "interactiveHover": { "$type": "color", "$value": "{color.neutral.450}" },
+            "interactive": {
+                "$type": "color",
+                "$value": "{color.neutral.400}",
+                "$description": "Resting border for interactive controls (checkboxes, toggles, segmented controls, chips) — same weight as border.stronger."
+            },
+            "interactiveHover": {
+                "$type": "color",
+                "$value": "{color.neutral.450}",
+                "$description": "Hover border for interactive controls — strengthens to the same weight as border.input."
+            },
             "input": { "$type": "color", "$value": "{color.neutral.450}" },
             "inputHover": { "$type": "color", "$value": "{color.neutral.600}" },
             "selected": { "$type": "color", "$value": "{color.info.600}" },
@@ -709,9 +739,13 @@
                 "$type": "other",
                 "$value": "Solid fill colors for buttons, switches, selected states. Variants compose at the component level — no button.primary/button.danger split."
             },
-            "primary": { "$type": "color", "$value": "{color.info.800}" },
-            "primaryHover": { "$type": "color", "$value": "{color.info.900}" },
-            "primaryActive": { "$type": "color", "$value": "{color.info.950}" },
+            "primary": {
+                "$type": "color",
+                "$value": "{color.info.750}",
+                "$description": "Unified brand-blue fill — same value used in Dark theme. White text (text.onBrand) reaches 4.78:1."
+            },
+            "primaryHover": { "$type": "color", "$value": "{color.info.800}" },
+            "primaryActive": { "$type": "color", "$value": "{color.info.900}" },
             "danger": { "$type": "color", "$value": "{color.danger.700}" },
             "dangerHover": { "$type": "color", "$value": "{color.danger.800}" },
             "dangerActive": { "$type": "color", "$value": "{color.danger.900}" },
@@ -724,8 +758,8 @@
             "disabled": { "$type": "color", "$value": "{state.disabled}" },
             "selectedFill": {
                 "$type": "color",
-                "$value": "{color.info.800}",
-                "$description": "A11Y FIX: was info.700 — white labels only reached 4.03:1. At info.800, text.onBrand (white) passes at 6.31:1, matching interactive.primary. Labels/icons on selectedFill must use text.onBrand / icon.onAccent — verified in both themes."
+                "$value": "{color.info.750}",
+                "$description": "Matches interactive.primary (info.750) so selected state and primary button read as the same brand blue. text.onBrand (white) passes at 4.78:1 — verified in both themes."
             }
         },
         "state": {
@@ -1228,7 +1262,9 @@
                 "chart.series.6": "87551bacc7a6c1a22bbc93ac5797c19f23d9b2c6",
                 "control.switch.trackOff": "7a8cc2dace19e2fa9a52418b9792e1486ad3dd9c",
                 "control.switch.trackOffDanger": "80060ad205d783e6e0cb9a9977d8ebb22f86e916",
-                "control.switch.thumbOff": "8baea2871f1449acc9f45e83853d6528302463b6"
+                "control.switch.thumbOff": "8baea2871f1449acc9f45e83853d6528302463b6",
+                "border.interactive": "621db556b0bdbad7e48868c86d0a671ebbe873aa",
+                "border.interactiveHover": "e0539b6402372dcc726cba800d756f8ef7014e40"
             },
             "$figmaCollectionId": "VariableCollectionId:3:2",
             "$figmaModeId": "3:0",
@@ -1300,6 +1336,8 @@
                 "border.default": "8478e96e7b86e431f697f4aefb6a6ecc3bd93565",
                 "border.strong": "10c67e470156c83f662472ea04d8951875244281",
                 "border.stronger": "c36df234c6b3739649acbff89641ae6c047e7538",
+                "border.interactive": "621db556b0bdbad7e48868c86d0a671ebbe873aa",
+                "border.interactiveHover": "e0539b6402372dcc726cba800d756f8ef7014e40",
                 "border.input": "01ae89567e4890007fbd5158ecee01d4a928371a",
                 "border.inputHover": "dc913e1518547dd2d805f00d4a21b621b7e33e2a",
                 "border.selected": "bd541b171bf340a84ea3219553d5c9603652872c",
@@ -1426,6 +1464,7 @@
                 "color.brand.500": "641daf2ee6625960ae2fbf10f6d877f5197ef8b8",
                 "color.brand.600": "5887811fa9e294bf36da141ad5f0d18e0bde29b8",
                 "color.brand.700": "e4b4ef2be806ea7bdc7af93d0317eea3ad630d15",
+                "color.brand.750": "ef0c7acada85e69b5e0e864bd5870bf2fda14486",
                 "color.brand.800": "87de9bf63e606ec76e5226e0a062bfcc6b170d18",
                 "color.brand.900": "b0fcda374a2aec4c5b07d2fcbb48b3913cc7fd1e",
                 "color.brand.950": "049f68681e2410951f37e040a0d6d9ad0efcf81f",
@@ -1439,6 +1478,7 @@
                 "color.info.500": "28736e0803979e26b71e948301069a3449df588f",
                 "color.info.600": "4adc9f95cd2f3166a3d31e0122e0293ee3427ec7",
                 "color.info.700": "9d3fd736cc6bcc6aab7a0260a8fa5c1616204467",
+                "color.info.750": "32b97217bd2fa1a4650c19171a0641c4fd0fbb94",
                 "color.info.800": "edca613791b8b7de20e4383f47ee7c6c95e44551",
                 "color.info.900": "74d3aa0070cf50a0da26dc1331ae28692abe7098",
                 "color.info.950": "0ded5fe67c3aae423e771b9395d5005de89e60d3",
@@ -1515,7 +1555,7 @@
                 "color.accent.yellow.500": "a298c2f64fa8cc4c641db0bcd584a3d5aeed3080",
                 "typography.fontFamily.sans": "17548bea3dcf900a71ae85d736f74409b3f38cac",
                 "typography.fontFamily.mono": "e2a22b7de6c7b64bc45cac1c5e657d231230ff1d",
-                "typography.fontSize.3xs": "497fb4015561e67cedd410c5d2c88064e26b5440",
+                "typography.fontSize.3xs": "4365f17ab4efcf649c5ca479ef648d916289e90c",
                 "typography.fontSize.2xs": "91f12227335a791cb6a7af8023f8d65166ba91ab",
                 "typography.fontSize.xs": "e63bfe8f93b52f74dcdc5737e34c9c12f36889be",
                 "typography.fontSize.sm": "ec65830ac0772ae6d6b86b1782f26f551f2ba9fe",


### PR DESCRIPTION
## Problem

The primary button used the semantic `interactive.primary` token, which resolved to a different blue per theme — dark teal `#016886` in light and bright cyan `#00B2E3` in dark. So the button changed hue between modes, and the dark-mode cyan with white text hit only 2.48:1, failing WCAG AA (needs 4.5:1).

## Solution

- Fetched the new `color.brand.750` / `color.info.750` stop (`#007CA0`) from Token Studio — an AA-safe brand blue added specifically for the primary button.
- `interactive.primary` and `selectedFill` now use `#007CA0`; hover and active stay darker shades (`#016886` / `#02485D`) for interaction feedback. The key change is that each state resolves to the **same value in light and dark**, so the button no longer flips hue between modes (dark previously used bright cyan `#00B2E3`, light a dark teal). White on `#007CA0` is 4.78:1 (AA pass); `text.onBrand` flips to white in dark for the same reason. The `Button` component itself is unchanged — it already consumes these tokens.
- Held `--status-danger-border` (light) at the existing `#e81818` rather than the regenerated `danger.200` (`#fac9c9`) — that alias is too light for a status border and a corrected value is coming from Token Studio.

Fixes [NAN-6155](https://linear.app/nango/issue/NAN-6155)

## Testing

- Verified the primary button in Storybook (light + dark): same blue in both modes, legible white text.
- Contrast checked: `#007CA0` with white = 4.78:1; hover `#016886` = 6.31:1; active `#02485D` = 10.06:1.
- Design-system token unit tests pass (36/36).

## Scope: design-system button only

`#007CA0` is a **fill** color — AA-safe only for white text placed *on* it, which is exactly how our `Button` uses it. Places that use the brand color differently stay on the brand cyan `#00B2E3` and are not touched here:

- **Stripe Elements** — uses the color as accent **text** (the "Card" label), which must stay bright on dark backgrounds; `#007CA0` drops to ~3.95:1 there.
- **Plain chat** — auto-derives the Send-button color per theme. In dark mode `#007CA0` renders as a low-contrast mid-teal, while the brand cyan renders cleanly (verified live in both themes).
- **connect-ui** — has its own separate primary palette (`#00B2E3`), tracked by NAN-6055 / the skipped `Go.test.tsx` a11y tests.

**For the Gabby sync:** the `color.brand.500` "single source of truth" note in `tokens.json` is now inaccurate — the button uses `brand.750`, not `brand.500`. To be fixed in Token Studio.
