### PR TITLE
fix(server): allow github raw templates in helmet CSP

### DIFF
--- a/packages/server/lib/middleware/security.ts
+++ b/packages/server/lib/middleware/security.ts
@@ -37,7 +37,8 @@ export function securityMiddlewares(): RequestHandler[] {
                     'https://*.posthog.com',
                     'https://*.stripe.com',
                     'https://*.plain.com',
-                    'wss://*.plain.com'
+                    'wss://*.plain.com',
+                    'https://raw.githubusercontent.com'
                 ],
                 fontSrc: ["'self'", 'https://*.googleapis.com', 'https://*.gstatic.com', 'https://*.cdn-plain.com'],
                 frameSrc: ["'self'", 'https://accounts.google.com', hostPublic, hostApi, connectUrl, 'https://www.youtube.com', 'https://*.stripe.com'],


### PR DESCRIPTION
## Problem

The helmet CSP only governs what the Node server serves as HTML: the **self-hosted dashboard** (`webapp/dist`) and the **OAuth-callback page**. Cloud's `app.nango.dev` / `connect.nango.dev` come from CloudFront and bypass helmet entirely, and the Connect UI is never served by the Node server (self-hosters use the hosted `connect.nango.dev`).

The NAN-6012 report-only soak showed the dashboard fetches integration-template source from `raw.githubusercontent.com/NangoHQ` when viewing a template — which helmet's `connect-src` doesn't allow. A self-hoster running enforced CSP (`CSP_REPORT_ONLY=false`) would have template viewing break.

## Solution

- `connect-src`: add `https://raw.githubusercontent.com`.

Scoped down from an earlier draft that also added `data:` to `font-src` — that was a Connect UI resource, and helmet never governs the Connect UI, so it guarded nothing. The Connect UI / CloudFront-side fixes (including `connect-src` for customer API hosts) live in [nango-infra#170](https://github.com/NangoHQ/nango-infra/pull/170).

Fixes [NAN-6012](https://linear.app/nango/issue/NAN-6012) (partial — report-only soak follow-up)

## Testing

- Corresponds to a live report-only violation in Sentry: `connect-src` block to `raw.githubusercontent.com` on `app.nango.dev/.../integrations/<provider>/templates`.
- helmet is report-only by default; this only affects self-hosters who opt into enforcing.
