### PR TITLE
feat: enable `can_override_docs_connect_url` for Growth+

### DIFF
--- a/packages/database/lib/migrations/20260709140000_plans_enable_override_docs_connect_url_for_growth_and_enterprise.cjs
+++ b/packages/database/lib/migrations/20260709140000_plans_enable_override_docs_connect_url_for_growth_and_enterprise.cjs
@@ -1,0 +1,15 @@
+exports.config = { transaction: true };
+
+/**
+ * @param {import('knex').Knex} knex
+ */
+exports.up = async function (knex) {
+    await knex('plans')
+        .whereIn('name', ['growth', 'growth-v2', 'enterprise', 'enterprise-cloud-hosted', 'free-uncapped', 'startup-deal'])
+        .update({ can_override_docs_connect_url: true });
+};
+
+/**
+ * @param {import('knex').Knex} knex
+ */
+exports.down = async function () {};

--- a/packages/shared/lib/services/plans/definitions.ts
+++ b/packages/shared/lib/services/plans/definitions.ts
@@ -110,7 +110,7 @@ export const growthV1Plan: PlanDefinition = {
         has_webhooks_script: true,
         has_webhooks_forward: true,
         has_rbac: true,
-        can_override_docs_connect_url: false,
+        can_override_docs_connect_url: true,
         can_customize_connect_ui_theme: true,
         can_disable_connect_ui_watermark: true,
         lambda_tenant_isolation: true
@@ -177,7 +177,7 @@ export const enterprisePlan: PlanDefinition = {
         has_webhooks_script: true,
         has_webhooks_forward: true,
         has_rbac: true,
-        can_override_docs_connect_url: false,
+        can_override_docs_connect_url: true,
         can_customize_connect_ui_theme: true,
         can_disable_connect_ui_watermark: true,
         lambda_tenant_isolation: true


### PR DESCRIPTION
Adding it to the plan definitions and backfilling existing plans.

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/NangoHQ/nango/pull/6730?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

