### PR TITLE
feat(node-client): add function and provider template methods

### DIFF
--- a/docs/llms-full.txt
+++ b/docs/llms-full.txt
@@ -10810,6 +10810,80 @@ This method polls for a connection every 2 seconds for up to 60 seconds (30 atte
 
 ## Integration functions
 
+### List functions
+
+Returns the functions deployed to an integration, with pagination.
+
+```ts
+await nango.listFunctions({ uniqueKey: 'github' });
+```
+
+Filter by function type, name, or page:
+
+```ts
+await nango.listFunctions({ uniqueKey: 'github' }, { type: 'action', search: 'issue', page: 0, limit: 20 });
+```
+
+**Parameters**
+
+<Expandable>
+    <ResponseField name="uniqueKey" type="string" required>
+        The integration ID.
+    </ResponseField>
+    <ResponseField name="type" type="string">
+        Filter by function type: `sync`, `action`, or `on-event`.
+    </ResponseField>
+    <ResponseField name="search" type="string">
+        Case-insensitive filter on the function name.
+    </ResponseField>
+    <ResponseField name="page" type="number">
+        Page to return (starts at `0`, default `0`).
+    </ResponseField>
+    <ResponseField name="limit" type="number">
+        Results per page (1-100, default `20`).
+    </ResponseField>
+</Expandable>
+
+**Example Response**
+
+<Expandable>
+```json
+{
+    "data": [
+        {
+            "type": "action",
+            "name": "create-issue",
+            "description": "Create a GitHub issue",
+            "returns": ["GithubIssue"],
+            "json_schema": null,
+            "id": 42,
+            "enabled": true,
+            "last_deployed": "2024-03-28T14:00:00.000Z",
+            "source": "repo"
+        },
+        {
+            "type": "sync",
+            "name": "issues",
+            "returns": ["GithubIssue"],
+            "json_schema": null,
+            "runs": "every hour",
+            "auto_start": true,
+            "track_deletes": false,
+            "id": 43,
+            "enabled": true,
+            "last_deployed": "2024-03-28T14:00:00.000Z",
+            "source": "repo"
+        }
+    ],
+    "pagination": {
+        "total": 2,
+        "page": 0,
+        "limit": 20
+    }
+}
+```
+</Expandable>
+
 ### Get integration functions config
 
 Return the configuration for all integration functions

--- a/docs/llms-full.txt
+++ b/docs/llms-full.txt
@@ -10884,6 +10884,121 @@ await nango.listFunctions({ uniqueKey: 'github' }, { type: 'action', search: 'is
 ```
 </Expandable>
 
+### Get a function
+
+Retrieves a deployed function of an integration.
+
+```ts
+await nango.getFunction({ uniqueKey: 'github', name: 'create-issue' });
+```
+
+Pass `type` to disambiguate when a sync and an action share the same name:
+
+```ts
+await nango.getFunction({ uniqueKey: 'github', name: 'issues' }, { type: 'sync' });
+```
+
+**Parameters**
+
+<Expandable>
+    <ResponseField name="uniqueKey" type="string" required>
+        The integration ID.
+    </ResponseField>
+    <ResponseField name="name" type="string" required>
+        The function name.
+    </ResponseField>
+    <ResponseField name="type" type="string">
+        Disambiguates when functions share a name: `sync`, `action`, or `on-event`.
+    </ResponseField>
+</Expandable>
+
+**Example Response**
+
+<Expandable>
+```json
+{
+    "data": {
+        "type": "action",
+        "name": "create-issue",
+        "description": "Create a GitHub issue",
+        "returns": ["GithubIssue"],
+        "json_schema": null,
+        "id": 42,
+        "enabled": true,
+        "last_deployed": "2024-03-28T14:00:00.000Z",
+        "source": "repo"
+    }
+}
+```
+</Expandable>
+
+### Get function code
+
+Retrieves the source code of a deployed function.
+
+```ts
+await nango.getFunctionCode({ uniqueKey: 'github', name: 'create-issue' }, { type: 'action' });
+```
+
+**Parameters**
+
+<Expandable>
+    <ResponseField name="uniqueKey" type="string" required>
+        The integration ID.
+    </ResponseField>
+    <ResponseField name="name" type="string" required>
+        The function name.
+    </ResponseField>
+    <ResponseField name="type" type="string">
+        Disambiguates when functions share a name: `sync`, `action`, or `on-event`.
+    </ResponseField>
+</Expandable>
+
+**Example Response**
+
+<Expandable>
+```json
+{
+    "type": "action",
+    "code": "export default createAction({ /* ... */ });"
+}
+```
+</Expandable>
+
+### Delete a function
+
+Deletes a deployed function of an integration. The `type` is required.
+
+```ts
+await nango.deleteFunction({ uniqueKey: 'github', name: 'create-issue' }, { type: 'action' });
+```
+
+**Parameters**
+
+<Expandable>
+    <ResponseField name="uniqueKey" type="string" required>
+        The integration ID.
+    </ResponseField>
+    <ResponseField name="name" type="string" required>
+        The function name.
+    </ResponseField>
+    <ResponseField name="type" type="string" required>
+        The function type: `sync` or `action`.
+    </ResponseField>
+</Expandable>
+
+**Example Response**
+
+<Expandable>
+```json
+{
+    "data": {
+        "success": true
+    }
+}
+```
+</Expandable>
+
 ### Get integration functions config
 
 Return the configuration for all integration functions
@@ -12119,6 +12234,40 @@ await nango.getProvider({ provider: <NAME> })
         },
         "docs": "https://nango.dev/docs/api-integrations/posthog"
     }
+}
+```
+</Expandable>
+
+### Get provider templates
+
+Returns the function templates available for a provider.
+
+```js
+await nango.getProviderTemplates({ provider: <NAME> })
+```
+
+**Parameters**
+
+<Expandable>
+    <ResponseField name="provider" type="string" required>
+        The provider name.
+    </ResponseField>
+</Expandable>
+
+**Example Response**
+
+<Expandable>
+```json
+{
+    "data": [
+        {
+            "type": "action",
+            "name": "create-issue",
+            "description": "Create a GitHub issue",
+            "returns": ["GithubIssue"],
+            "json_schema": null
+        }
+    ]
 }
 ```
 </Expandable>

--- a/docs/reference/backend/backend-sdk/node.mdx
+++ b/docs/reference/backend/backend-sdk/node.mdx
@@ -857,6 +857,79 @@ This method polls for a connection every 2 seconds for up to 60 seconds (30 atte
 
 ## Integration functions
 
+### List functions
+
+Returns the functions deployed to an integration, with pagination.
+
+```ts
+await nango.listFunctions({ uniqueKey: 'github' });
+```
+
+Filter by function type, name, or page:
+
+```ts
+await nango.listFunctions({ uniqueKey: 'github' }, { type: 'action', search: 'issue', page: 0, limit: 20 });
+```
+
+**Parameters**
+
+<Expandable>
+    <ResponseField name="uniqueKey" type="string" required>
+        The integration ID.
+    </ResponseField>
+    <ResponseField name="type" type="string">
+        Filter by function type: `sync`, `action`, or `on-event`.
+    </ResponseField>
+    <ResponseField name="search" type="string">
+        Case-insensitive filter on the function name.
+    </ResponseField>
+    <ResponseField name="page" type="number">
+        Page to return (starts at `0`, default `0`).
+    </ResponseField>
+    <ResponseField name="limit" type="number">
+        Results per page (1-100, default `20`).
+    </ResponseField>
+</Expandable>
+
+**Example Response**
+
+<Expandable>
+```json
+{
+    "data": [
+        {
+            "type": "action",
+            "name": "create-issue",
+            "description": "Create a GitHub issue",
+            "returns": ["GithubIssue"],
+            "json_schema": null,
+            "id": 42,
+            "enabled": true,
+            "last_deployed": "2024-03-28T14:00:00.000Z",
+            "source": "repo"
+        },
+        {
+            "type": "sync",
+            "name": "issues",
+            "returns": ["GithubIssue"],
+            "json_schema": null,
+            "runs": "every hour",
+            "auto_start": true,
+            "track_deletes": false,
+            "id": 43,
+            "enabled": true,
+            "last_deployed": "2024-03-28T14:00:00.000Z",
+            "source": "repo"
+        }
+    ],
+    "pagination": {
+        "total": 2,
+        "page": 0,
+        "limit": 20
+    }
+}
+```
+</Expandable>
 
 ### Get integration functions config
 

--- a/docs/reference/backend/backend-sdk/node.mdx
+++ b/docs/reference/backend/backend-sdk/node.mdx
@@ -931,6 +931,121 @@ await nango.listFunctions({ uniqueKey: 'github' }, { type: 'action', search: 'is
 ```
 </Expandable>
 
+### Get a function
+
+Retrieves a deployed function of an integration.
+
+```ts
+await nango.getFunction({ uniqueKey: 'github', name: 'create-issue' });
+```
+
+Pass `type` to disambiguate when a sync and an action share the same name:
+
+```ts
+await nango.getFunction({ uniqueKey: 'github', name: 'issues' }, { type: 'sync' });
+```
+
+**Parameters**
+
+<Expandable>
+    <ResponseField name="uniqueKey" type="string" required>
+        The integration ID.
+    </ResponseField>
+    <ResponseField name="name" type="string" required>
+        The function name.
+    </ResponseField>
+    <ResponseField name="type" type="string">
+        Disambiguates when functions share a name: `sync`, `action`, or `on-event`.
+    </ResponseField>
+</Expandable>
+
+**Example Response**
+
+<Expandable>
+```json
+{
+    "data": {
+        "type": "action",
+        "name": "create-issue",
+        "description": "Create a GitHub issue",
+        "returns": ["GithubIssue"],
+        "json_schema": null,
+        "id": 42,
+        "enabled": true,
+        "last_deployed": "2024-03-28T14:00:00.000Z",
+        "source": "repo"
+    }
+}
+```
+</Expandable>
+
+### Get function code
+
+Retrieves the source code of a deployed function.
+
+```ts
+await nango.getFunctionCode({ uniqueKey: 'github', name: 'create-issue' }, { type: 'action' });
+```
+
+**Parameters**
+
+<Expandable>
+    <ResponseField name="uniqueKey" type="string" required>
+        The integration ID.
+    </ResponseField>
+    <ResponseField name="name" type="string" required>
+        The function name.
+    </ResponseField>
+    <ResponseField name="type" type="string">
+        Disambiguates when functions share a name: `sync`, `action`, or `on-event`.
+    </ResponseField>
+</Expandable>
+
+**Example Response**
+
+<Expandable>
+```json
+{
+    "type": "action",
+    "code": "export default createAction({ /* ... */ });"
+}
+```
+</Expandable>
+
+### Delete a function
+
+Deletes a deployed function of an integration. The `type` is required.
+
+```ts
+await nango.deleteFunction({ uniqueKey: 'github', name: 'create-issue' }, { type: 'action' });
+```
+
+**Parameters**
+
+<Expandable>
+    <ResponseField name="uniqueKey" type="string" required>
+        The integration ID.
+    </ResponseField>
+    <ResponseField name="name" type="string" required>
+        The function name.
+    </ResponseField>
+    <ResponseField name="type" type="string" required>
+        The function type: `sync` or `action`.
+    </ResponseField>
+</Expandable>
+
+**Example Response**
+
+<Expandable>
+```json
+{
+    "data": {
+        "success": true
+    }
+}
+```
+</Expandable>
+
 ### Get integration functions config
 
 Return the configuration for all integration functions
@@ -2167,6 +2282,40 @@ await nango.getProvider({ provider: <NAME> })
         },
         "docs": "https://nango.dev/docs/api-integrations/posthog"
     }
+}
+```
+</Expandable>
+
+### Get provider templates
+
+Returns the function templates available for a provider.
+
+```js
+await nango.getProviderTemplates({ provider: <NAME> })
+```
+
+**Parameters**
+
+<Expandable>
+    <ResponseField name="provider" type="string" required>
+        The provider name.
+    </ResponseField>
+</Expandable>
+
+**Example Response**
+
+<Expandable>
+```json
+{
+    "data": [
+        {
+            "type": "action",
+            "name": "create-issue",
+            "description": "Create a GitHub issue",
+            "returns": ["GithubIssue"],
+            "json_schema": null
+        }
+    ]
 }
 ```
 </Expandable>

--- a/packages/node-client/lib/index.ts
+++ b/packages/node-client/lib/index.ts
@@ -27,15 +27,19 @@ import type {
     BillCredentials,
     CredentialsCommon,
     CustomCredentials,
+    DeletePublicIntegrationFunction,
     DeleteSyncVariant,
     GetPublicConnection,
     GetPublicConnections,
     GetPublicEnvironmentVariables,
+    GetPublicFunctionCode,
     GetPublicIntegration,
+    GetPublicIntegrationFunction,
     GetPublicIntegrationFunctions,
     GetPublicListIntegrations,
     GetPublicProvider,
     GetPublicProviders,
+    GetPublicProviderTemplates,
     InstallPluginCredentials,
     JwtCredentials,
     NangoRecord,
@@ -180,6 +184,16 @@ export class Nango {
     }
 
     /**
+     * Returns the function templates available for a provider
+     * @param params - Identifies the provider (`provider`)
+     * @returns A promise that resolves with the provider's function templates
+     */
+    public async getProviderTemplates(params: GetPublicProviderTemplates['Params']): Promise<GetPublicProviderTemplates['Success']> {
+        const response = await this.http.get(`${this.serverUrl}/providers/${params.provider}/templates`, { headers: this.enrichHeaders({}) });
+        return response.data;
+    }
+
+    /**
      * =======
      * INTEGRATIONS
      *      LIST
@@ -260,6 +274,63 @@ export class Nango {
         addQueryParams(url, queries as GetPublicIntegrationFunctions['Querystring']);
 
         const response = await this.http.get(url.href, { headers: this.enrichHeaders(headers) });
+        return response.data;
+    }
+
+    /**
+     * Retrieves a deployed function of an integration
+     * @param params - Identifies the function (`uniqueKey`, `name`)
+     * @param queries - Optional `type` to disambiguate when functions share a name
+     * @returns A promise that resolves with the deployed function
+     */
+    public async getFunction(
+        params: GetPublicIntegrationFunction['Params'],
+        queries?: GetPublicIntegrationFunction['Querystring']
+    ): Promise<GetPublicIntegrationFunction['Success']> {
+        const headers = { 'Content-Type': 'application/json' };
+
+        const url = new URL(`${this.serverUrl}/integrations/${params.uniqueKey}/functions/${params.name}`);
+        addQueryParams(url, queries as GetPublicIntegrationFunction['Querystring']);
+
+        const response = await this.http.get(url.href, { headers: this.enrichHeaders(headers) });
+        return response.data;
+    }
+
+    /**
+     * Retrieves the source code of a deployed function
+     * @param params - Identifies the function (`uniqueKey`, `name`)
+     * @param queries - Optional `type` to disambiguate when functions share a name
+     * @returns A promise that resolves with the function type and code
+     */
+    public async getFunctionCode(
+        params: GetPublicFunctionCode['Params'],
+        queries?: GetPublicFunctionCode['Querystring']
+    ): Promise<GetPublicFunctionCode['Success']> {
+        const headers = { 'Content-Type': 'application/json' };
+
+        const url = new URL(`${this.serverUrl}/integrations/${params.uniqueKey}/functions/${params.name}/code`);
+        addQueryParams(url, queries as GetPublicFunctionCode['Querystring']);
+
+        const response = await this.http.get(url.href, { headers: this.enrichHeaders(headers) });
+        return response.data;
+    }
+
+    /**
+     * Deletes a deployed function of an integration
+     * @param params - Identifies the function (`uniqueKey`, `name`)
+     * @param queries - The function `type` (required)
+     * @returns A promise that resolves with the deletion result
+     */
+    public async deleteFunction(
+        params: DeletePublicIntegrationFunction['Params'],
+        queries: DeletePublicIntegrationFunction['Querystring']
+    ): Promise<DeletePublicIntegrationFunction['Success']> {
+        const headers = { 'Content-Type': 'application/json' };
+
+        const url = new URL(`${this.serverUrl}/integrations/${params.uniqueKey}/functions/${params.name}`);
+        addQueryParams(url, queries as DeletePublicIntegrationFunction['Querystring']);
+
+        const response = await this.http.delete(url.href, { headers: this.enrichHeaders(headers) });
         return response.data;
     }
 

--- a/packages/node-client/lib/index.ts
+++ b/packages/node-client/lib/index.ts
@@ -32,6 +32,7 @@ import type {
     GetPublicConnections,
     GetPublicEnvironmentVariables,
     GetPublicIntegration,
+    GetPublicIntegrationFunctions,
     GetPublicListIntegrations,
     GetPublicProvider,
     GetPublicProviders,
@@ -241,6 +242,25 @@ export class Nango {
     public async deleteIntegration(providerConfigKey: string): Promise<AxiosResponse<void>> {
         const url = `${this.serverUrl}/integrations/${providerConfigKey}`;
         return await this.http.delete(url, { headers: this.enrichHeaders({}) });
+    }
+
+    /**
+     * Lists the deployed functions of an integration
+     * @param params - Identifies the integration (`uniqueKey`)
+     * @param queries - Optional filters: `type`, `search`, `page`, `limit`
+     * @returns A promise that resolves with the deployed functions and pagination metadata
+     */
+    public async listFunctions(
+        params: GetPublicIntegrationFunctions['Params'],
+        queries?: GetPublicIntegrationFunctions['Querystring']
+    ): Promise<GetPublicIntegrationFunctions['Success']> {
+        const headers = { 'Content-Type': 'application/json' };
+
+        const url = new URL(`${this.serverUrl}/integrations/${params.uniqueKey}/functions`);
+        addQueryParams(url, queries as GetPublicIntegrationFunctions['Querystring']);
+
+        const response = await this.http.get(url.href, { headers: this.enrichHeaders(headers) });
+        return response.data;
     }
 
     /**


### PR DESCRIPTION
Adds SDK methods to the node client for the public function endpoints (NAN-5480) that previously had no SDK coverage:

- `listFunctions` — list an integration's deployed functions
- `getFunction` — get a single deployed function
- `getFunctionCode` — get a function's source code
- `deleteFunction` — delete a deployed function
- `getProviderTemplates` — list a provider's function templates

Includes reference docs for each method.


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/NangoHQ/nango/pull/6732?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

