### PR TITLE
feat(metering): track written row count per S3 export file

### DIFF
--- a/packages/metering/lib/crons/billingEventsS3Export.ts
+++ b/packages/metering/lib/crons/billingEventsS3Export.ts
@@ -204,7 +204,7 @@ export async function exec(): Promise<void> {
                             metric: metric.canonicalEventName,
                             success: 'true'
                         });
-                        metrics.distribution(metrics.Types.BILLING_USAGE_CLICKHOUSE_S3_EXPORT_ROWS, writtenRows, {
+                        metrics.increment(metrics.Types.BILLING_USAGE_CLICKHOUSE_S3_EXPORT_ROWS, writtenRows, {
                             metric: metric.canonicalEventName
                         });
                     } catch (err) {

--- a/packages/metering/lib/crons/billingEventsS3Export.ts
+++ b/packages/metering/lib/crons/billingEventsS3Export.ts
@@ -192,11 +192,20 @@ export async function exec(): Promise<void> {
                         }
                         step = 'export';
                         logger.info(`Exporting ${eventName} for day=${day}`);
-                        await client.command({ query: exportSql({ metric, day, eventName, key }) });
-                        logger.info(`Exported ${eventName} for day=${day}`);
+                        // ClickHouse populates `written_rows` in the X-ClickHouse-Summary
+                        // response header once the multipart upload to S3 is complete
+                        // (INSERT INTO FUNCTION s3(...) is atomic — the object either
+                        // exists fully or not at all), so on the success path this row
+                        // count matches the line count in the S3 file exactly.
+                        const res = await client.command({ query: exportSql({ metric, day, eventName, key }) });
+                        const writtenRows = Number(res.summary?.written_rows ?? 0);
+                        logger.info(`Exported ${eventName} for day=${day} (rows=${writtenRows})`);
                         metrics.increment(metrics.Types.BILLING_USAGE_CLICKHOUSE_S3_EXPORT_FILE_RESULT, 1, {
                             metric: metric.canonicalEventName,
                             success: 'true'
+                        });
+                        metrics.distribution(metrics.Types.BILLING_USAGE_CLICKHOUSE_S3_EXPORT_ROWS, writtenRows, {
+                            metric: metric.canonicalEventName
                         });
                     } catch (err) {
                         // Per-metric catch so a single failure (e.g. CH timeout on

--- a/packages/utils/lib/telemetry/metrics.ts
+++ b/packages/utils/lib/telemetry/metrics.ts
@@ -143,6 +143,7 @@ export enum Types {
     BILLING_USAGE_CLICKHOUSE_S3_EXPORT_FILE_RESULT = 'nango.billing.usage.clickhouse.s3_export.file.result',
     BILLING_USAGE_CLICKHOUSE_S3_EXPORT_RUN_RESULT = 'nango.billing.usage.clickhouse.s3_export.run.result',
     BILLING_USAGE_CLICKHOUSE_S3_EXPORT_DURATION_MS = 'nango.billing.usage.clickhouse.s3_export.duration_ms',
+    BILLING_USAGE_CLICKHOUSE_S3_EXPORT_ROWS = 'nango.billing.usage.clickhouse.s3_export.rows',
     BILLING_USAGE_TRACKER_CALLS = 'nango.billing.usage.tracker.calls',
     BILLING_EVENTS_S3_DLQ_FILES = 'nango.billing.events.s3.dlq.files',
     BILLING_EVENTS_S3_DLQ_MONITOR_RUN_RESULT = 'nango.billing.events.s3.dlq.monitor.run.result',


### PR DESCRIPTION
## Summary

- Adds `nango.billing.usage.clickhouse.s3_export.rows` (counter, tagged by canonical metric name) — emitted after each successful S3 export, sourced from the `written_rows` field of ClickHouse's `X-ClickHouse-Summary` response header that `client.command()` already surfaces.
- No SDK API change, no additional CH round-trip. The current `command()` call already returned the summary; we were just discarding it.

## Context

Part of [NAN-6204](https://linear.app/nango/issue/NAN-6204/add-metric-tracking-for-event-line-counts-exported-to-s3). Complements the existing `s3_export.file.result` counter — file count answers "did we ship?", row count answers "did we ship the right amount?".

Foundation for the sibling parity-monitoring task: reconciling our exported row counts against Orb's ingested counts (daily, per metric).

## Guarantees of the metric

**On the success path, the reported `written_rows` matches the exact number of rows in the S3 file.** This holds because `INSERT INTO FUNCTION s3(...)` uses S3's multipart upload internally, and the target object appears atomically on `CompleteMultipartUpload` — either the object exists with the full payload or it doesn't exist at all. There is no observable intermediate state where the file is partially uploaded.

## Failure modes and what the metric shows in each

| Scenario | S3 object state | `command()` result | Metric emitted? |
| --- | --- | --- | --- |
| Query succeeds, response received | Full object, N rows | resolves with `summary.written_rows = N` | ✅ `N` counted |
| Query fails mid-stream (CH crash, timeout, S3 API error) | No object (multipart aborted; lifecycle policy on the bucket cleans up any orphaned parts) | throws | ❌ not emitted — the existing `.file.result{success:false}` counter fires instead |
| CH gets partway through parts, last chunk fails before `CompleteMultipartUpload` | No object | throws | ❌ not emitted |
| Query succeeds server-side but response lost in transit (network flake) | Full object, N rows | throws client-side | ❌ not emitted — the S3 file is still correct; the next hourly cron tick sees `objectExists() === true` and skips, so the file is never re-uploaded. We lose that one row-count sample but nothing else. |

**The only observability gap is the last row** — the "response lost in transit" case, where the file is on S3 but we don't have a row-count sample for that (day, metric). We accept this because the file itself is fine, and how often this shape shows up is already tracked by the existing `.file.result{success:false}` counter.

## Metric shape

- **Type**: counter (`metrics.increment`).
- **Tags**: `metric` (canonical event name — `records`, `proxy`, `function_executions`, etc.).
- **Cadence**: at most one sample per (day, metric) per cron day. Later firings on the same day skip via the `HeadObject` check.
- **Aggregation in DD**: sum over a time window → total rows shipped; rate → rows/day per metric.

## Test plan

- [ ] Deploy to dev, wait for the next 00:15 UTC S3 export cron firing, verify DD receives `nango.billing.usage.clickhouse.s3_export.rows` samples for each canonical metric.
- [ ] Cross-check the emitted row count against a manual `SELECT count(*)` from the same day/metric to confirm the summary matches ground truth.
- [ ] Deploy to prod once dev is confirmed.

Existing integration test at `billingEventsS3Export.integration.test.ts` uses `metricRowsSql` (the SELECT portion only, no S3 target), so it can't exercise the summary path without an S3-compatible endpoint. Live validation in dev instead.

🤖 Generated with [Claude Code](https://claude.com/claude-code)