### PR TITLE
feat(webapp): edit connection webhook URL override in Settings

### DIFF
--- a/docs/guides/platform/webhooks-from-nango.mdx
+++ b/docs/guides/platform/webhooks-from-nango.mdx
@@ -59,14 +59,17 @@ Set `webhook_url_override` when creating a [connect session](/reference/backend/
   </Tab>
 </Tabs>
 
-You can also set `webhook_url_override` from the **Create connection** flow in the Nango dashboard, under the connection's advanced configuration.
+You can also set or edit `webhook_url_override` from:
+
+- The **Create connection** flow in the Nango dashboard (advanced configuration), or later on the connection's **Settings** tab
+- `PATCH /connections/{connectionId}` with a `webhook_url` field (see [Patch a connection](/reference/backend/http-api/connections/patch))
 
 <Note>
-    `webhook_url_override` is set by the trusted backend that creates the connect session. A `webhook_url` passed to `nango.auth()` `params` from the client is ignored.
+    `webhook_url_override` is set by a trusted actor — via connect-session creation, the public API with an API key, or the dashboard. A `webhook_url` passed to `nango.auth()` `params` from the client is ignored.
 </Note>
 
 <Tip>
-    **Local development:** create a connection with `webhook_url_override` pointing at your local webhook endpoint (for example via [ngrok](https://ngrok.com/) or [webhook.site](https://webhook.site/)) to receive that connection's webhooks on your machine — without changing the shared environment webhook URLs. See [Engineering collaboration](/guides/platform/environments#engineering-collaboration) for the shared-environment workflow.
+    **Local development:** set a connection's `webhook_url_override` to your local webhook endpoint (for example via [ngrok](https://ngrok.com/) or [webhook.site](https://webhook.site/)) to receive that connection's webhooks on your machine — without changing the shared environment webhook URLs. See [Engineering collaboration](/guides/platform/environments#engineering-collaboration) for the shared-environment workflow.
 </Tip>
 
 ## Verifying webhooks from Nango

--- a/docs/guides/platform/webhooks-from-nango.mdx
+++ b/docs/guides/platform/webhooks-from-nango.mdx
@@ -62,7 +62,7 @@ Set `webhook_url_override` when creating a [connect session](/reference/backend/
 You can also set or edit `webhook_url_override` from:
 
 - The **Create connection** flow in the Nango dashboard (advanced configuration), or later on the connection's **Settings** tab
-- `PATCH /connections/{connectionId}` with a `webhook_url` field (see [Patch a connection](/reference/backend/http-api/connections/patch))
+- `PATCH /connections/{connectionId}` with a `webhook_url_override` field (see [Patch a connection](/reference/backend/http-api/connections/patch))
 
 <Note>
     `webhook_url_override` is set by a trusted actor — via connect-session creation, the public API with an API key, or the dashboard. A `webhook_url` passed to `nango.auth()` `params` from the client is ignored.

--- a/docs/llms-full.txt
+++ b/docs/llms-full.txt
@@ -7251,7 +7251,7 @@ Set `webhook_url_override` when creating a [connect session](/reference/backend/
 You can also set or edit `webhook_url_override` from:
 
 - The **Create connection** flow in the Nango dashboard (advanced configuration), or later on the connection's **Settings** tab
-- `PATCH /connections/{connectionId}` with a `webhook_url` field (see [Patch a connection](/reference/backend/http-api/connections/patch))
+- `PATCH /connections/{connectionId}` with a `webhook_url_override` field (see [Patch a connection](/reference/backend/http-api/connections/patch))
 
 <Note>
     `webhook_url_override` is set by a trusted actor — via connect-session creation, the public API with an API key, or the dashboard. A `webhook_url` passed to `nango.auth()` `params` from the client is ignored.
@@ -10898,7 +10898,7 @@ await nango.patchConnection({
                     </ResponseField>
                 </Expandable>
             </ResponseField>
-            <ResponseField name="webhook_url" type="string">
+            <ResponseField name="webhook_url_override" type="string">
                 Override the environment's webhook URLs for this connection. When set, this connection's webhooks are sent only to this URL. Pass an empty string to clear the override.
             </ResponseField>
             <ResponseField name="end_user" type="object" deprecated>

--- a/docs/llms-full.txt
+++ b/docs/llms-full.txt
@@ -7248,14 +7248,17 @@ Set `webhook_url_override` when creating a [connect session](/reference/backend/
   </Tab>
 </Tabs>
 
-You can also set `webhook_url_override` from the **Create connection** flow in the Nango dashboard, under the connection's advanced configuration.
+You can also set or edit `webhook_url_override` from:
+
+- The **Create connection** flow in the Nango dashboard (advanced configuration), or later on the connection's **Settings** tab
+- `PATCH /connections/{connectionId}` with a `webhook_url` field (see [Patch a connection](/reference/backend/http-api/connections/patch))
 
 <Note>
-    `webhook_url_override` is set by the trusted backend that creates the connect session. A `webhook_url` passed to `nango.auth()` `params` from the client is ignored.
+    `webhook_url_override` is set by a trusted actor — via connect-session creation, the public API with an API key, or the dashboard. A `webhook_url` passed to `nango.auth()` `params` from the client is ignored.
 </Note>
 
 <Tip>
-    **Local development:** create a connection with `webhook_url_override` pointing at your local webhook endpoint (for example via [ngrok](https://ngrok.com/) or [webhook.site](https://webhook.site/)) to receive that connection's webhooks on your machine — without changing the shared environment webhook URLs. See [Engineering collaboration](/guides/platform/environments#engineering-collaboration) for the shared-environment workflow.
+    **Local development:** set a connection's `webhook_url_override` to your local webhook endpoint (for example via [ngrok](https://ngrok.com/) or [webhook.site](https://webhook.site/)) to receive that connection's webhooks on your machine — without changing the shared environment webhook URLs. See [Engineering collaboration](/guides/platform/environments#engineering-collaboration) for the shared-environment workflow.
 </Tip>
 
 ## Verifying webhooks from Nango
@@ -10894,6 +10897,9 @@ await nango.patchConnection({
                           Maximum string length: 255
                     </ResponseField>
                 </Expandable>
+            </ResponseField>
+            <ResponseField name="webhook_url" type="string">
+                Override the environment's webhook URLs for this connection. When set, this connection's webhooks are sent only to this URL. Pass an empty string to clear the override.
             </ResponseField>
             <ResponseField name="end_user" type="object" deprecated>
                 Deprecated. Use tags instead

--- a/docs/reference/backend/backend-sdk/node.mdx
+++ b/docs/reference/backend/backend-sdk/node.mdx
@@ -641,7 +641,7 @@ await nango.patchConnection({
                     </ResponseField>
                 </Expandable>
             </ResponseField>
-            <ResponseField name="webhook_url" type="string">
+            <ResponseField name="webhook_url_override" type="string">
                 Override the environment's webhook URLs for this connection. When set, this connection's webhooks are sent only to this URL. Pass an empty string to clear the override.
             </ResponseField>
             <ResponseField name="end_user" type="object" deprecated>

--- a/docs/reference/backend/backend-sdk/node.mdx
+++ b/docs/reference/backend/backend-sdk/node.mdx
@@ -641,6 +641,9 @@ await nango.patchConnection({
                     </ResponseField>
                 </Expandable>
             </ResponseField>
+            <ResponseField name="webhook_url" type="string">
+                Override the environment's webhook URLs for this connection. When set, this connection's webhooks are sent only to this URL. Pass an empty string to clear the override.
+            </ResponseField>
             <ResponseField name="end_user" type="object" deprecated>
                 Deprecated. Use tags instead
                 <Expandable title="end_user">

--- a/docs/spec.yaml
+++ b/docs/spec.yaml
@@ -1335,7 +1335,7 @@ paths:
                             properties:
                                 tags:
                                     $ref: '#/components/schemas/Tags'
-                                webhook_url:
+                                webhook_url_override:
                                     type: string
                                     description: >
                                         Override the environment's webhook URLs for this connection.

--- a/packages/server/lib/controllers/connection/connectionId/patchConnection.integration.test.ts
+++ b/packages/server/lib/controllers/connection/connectionId/patchConnection.integration.test.ts
@@ -256,8 +256,8 @@ describe(`PATCH ${endpoint}`, () => {
         });
     });
 
-    describe('webhook_url', () => {
-        it('should set webhook_url override', async () => {
+    describe('webhook_url_override', () => {
+        it('should set webhook_url_override', async () => {
             const { env, apiKey } = await seeders.seedAccountEnvAndUser();
             await seeders.createConfigSeed(env, 'github', 'github');
             const conn = await seeders.createConnectionSeed({ env, provider: 'github' });
@@ -267,7 +267,7 @@ describe(`PATCH ${endpoint}`, () => {
                 token: apiKey.secret,
                 params: { connectionId: conn.connection_id },
                 query: { provider_config_key: 'github' },
-                body: { webhook_url: 'https://example.com/webhooks-from-nango' }
+                body: { webhook_url_override: 'https://example.com/webhooks-from-nango' }
             });
 
             isSuccess(res.json);
@@ -278,7 +278,7 @@ describe(`PATCH ${endpoint}`, () => {
             expect(updatedConn?.connection_config).not.toHaveProperty('webhook_url');
         });
 
-        it('should clear webhook_url override with empty string', async () => {
+        it('should clear webhook_url_override with empty string', async () => {
             const { env, apiKey } = await seeders.seedAccountEnvAndUser();
             await seeders.createConfigSeed(env, 'github', 'github');
             const conn = await seeders.createConnectionSeed({
@@ -292,7 +292,7 @@ describe(`PATCH ${endpoint}`, () => {
                 token: apiKey.secret,
                 params: { connectionId: conn.connection_id },
                 query: { provider_config_key: 'github' },
-                body: { webhook_url: '' }
+                body: { webhook_url_override: '' }
             });
 
             isSuccess(res.json);
@@ -301,7 +301,7 @@ describe(`PATCH ${endpoint}`, () => {
             expect(updatedConn?.webhook_url_override).toBeNull();
         });
 
-        it('should reject invalid webhook_url', async () => {
+        it('should reject invalid webhook_url_override', async () => {
             const { env, apiKey } = await seeders.seedAccountEnvAndUser();
             await seeders.createConfigSeed(env, 'github', 'github');
             const conn = await seeders.createConnectionSeed({ env, provider: 'github' });
@@ -311,7 +311,7 @@ describe(`PATCH ${endpoint}`, () => {
                 token: apiKey.secret,
                 params: { connectionId: conn.connection_id },
                 query: { provider_config_key: 'github' },
-                body: { webhook_url: 'not-a-url' }
+                body: { webhook_url_override: 'not-a-url' }
             });
 
             isError(res.json);

--- a/packages/server/lib/controllers/shared/connections/patchConnection.ts
+++ b/packages/server/lib/controllers/shared/connections/patchConnection.ts
@@ -13,7 +13,7 @@ import type { Response } from 'express';
 export const patchConnectionBodySchema = z.strictObject({
     end_user: endUserSchema.optional(),
     tags: connectionTagsSchema.optional(),
-    webhook_url: webhookUrlSchema
+    webhook_url_override: webhookUrlSchema
 });
 
 export async function handlePatchConnection({
@@ -32,7 +32,7 @@ export async function handlePatchConnection({
     body: {
         end_user?: EndUserInput | undefined;
         tags?: Tags | undefined;
-        webhook_url?: string | undefined;
+        webhook_url_override?: string | undefined;
     };
 }): Promise<void> {
     const integration = await configService.getProviderConfig(providerConfigKey, environment.id);
@@ -83,9 +83,9 @@ export async function handlePatchConnection({
         }
     }
 
-    // webhook_url is stored in the per-connection webhook_url_override column (not connection_config). An empty string clears it.
-    if (typeof body.webhook_url === 'string') {
-        await connectionService.updateWebhookUrlOverride(connection, body.webhook_url === '' ? null : body.webhook_url);
+    // An empty string clears the per-connection override.
+    if (typeof body.webhook_url_override === 'string') {
+        await connectionService.updateWebhookUrlOverride(connection, body.webhook_url_override === '' ? null : body.webhook_url_override);
     }
 
     res.status(200).send({ success: true });

--- a/packages/server/lib/controllers/v1/connections/connectionId/patchConnection.integration.test.ts
+++ b/packages/server/lib/controllers/v1/connections/connectionId/patchConnection.integration.test.ts
@@ -63,7 +63,7 @@ describe(`PATCH ${route}`, () => {
         expect(updatedConn?.tags).toStrictEqual({ projectid: '123' });
     });
 
-    it('should update webhook_url', async () => {
+    it('should update webhook_url_override', async () => {
         const { env, apiKey } = await seeders.seedAccountEnvAndUser();
         await seeders.createConfigSeed(env, 'github', 'github');
         const conn = await seeders.createConnectionSeed({ env, provider: 'github' });
@@ -73,7 +73,7 @@ describe(`PATCH ${route}`, () => {
             token: apiKey.secret,
             params: { connectionId: conn.connection_id },
             query: { env: env.name, provider_config_key: 'github' },
-            body: { webhook_url: 'https://example.com/webhooks-from-nango' }
+            body: { webhook_url_override: 'https://example.com/webhooks-from-nango' }
         });
 
         isSuccess(res.json);

--- a/packages/types/lib/connection/api/get.ts
+++ b/packages/types/lib/connection/api/get.ts
@@ -170,7 +170,7 @@ export type PatchPublicConnection = Endpoint<{
     Body: {
         end_user?: EndUserInput | undefined;
         tags?: Tags | undefined;
-        webhook_url?: string | undefined;
+        webhook_url_override?: string | undefined;
     };
     Success: { success: boolean };
     Error: ApiError<'unknown_provider_config' | 'not_found' | 'server_error' | 'invalid_body'>;
@@ -189,7 +189,7 @@ export type PatchConnection = Endpoint<{
     Body: {
         end_user?: EndUserInput | undefined;
         tags?: Tags | undefined;
-        webhook_url?: string | undefined;
+        webhook_url_override?: string | undefined;
     };
     Success: { success: boolean };
     Error: ApiError<'unknown_provider_config' | 'not_found' | 'server_error' | 'invalid_body'>;

--- a/packages/webapp/src/pages/Connection/components/SettingsTab.tsx
+++ b/packages/webapp/src/pages/Connection/components/SettingsTab.tsx
@@ -7,6 +7,7 @@ import { Button, FieldLabel } from '@nangohq/design-system';
 import { EditableInput } from '@/components/patterns/EditableInput';
 import { PermissionGate } from '@/components/patterns/PermissionGate';
 import { InfoTooltip } from '@/components/ui/InfoTooltip';
+import { StyledLink } from '@/components/ui/StyledLink';
 import { useConfirmDialog } from '@/hooks/useConfirmDialog';
 import { useDeleteConnection, usePatchConnection } from '@/hooks/useConnections';
 import { useEnvironment } from '@/hooks/useEnvironment';
@@ -67,7 +68,17 @@ export const SettingsTab = () => {
                     <div className="flex flex-col gap-2">
                         <div className="flex gap-2 items-center">
                             <FieldLabel htmlFor="webhook_url_override">Override webhook URL</FieldLabel>
-                            <InfoTooltip>Deliver this connection&apos;s webhooks to a different URL than the environment-wide webhook URL.</InfoTooltip>
+                            <InfoTooltip>
+                                Override the environment-wide webhook URL for this connection. Use this for local development. See{' '}
+                                <StyledLink
+                                    to="https://nango.dev/docs/guides/platform/environments#engineering-collaboration"
+                                    type="external"
+                                    className="text-s"
+                                >
+                                    Engineering collaboration
+                                </StyledLink>
+                                .
+                            </InfoTooltip>
                         </div>
                         <EditableInput
                             id="webhook_url_override"

--- a/packages/webapp/src/pages/Connection/components/SettingsTab.tsx
+++ b/packages/webapp/src/pages/Connection/components/SettingsTab.tsx
@@ -67,10 +67,7 @@ export const SettingsTab = () => {
                     <div className="flex flex-col gap-2">
                         <div className="flex gap-2 items-center">
                             <FieldLabel htmlFor="webhook_url_override">Override webhook URL</FieldLabel>
-                            <InfoTooltip>
-                                Deliver this connection&apos;s webhooks to a different URL than the environment-wide webhook URL. Useful for routing a single
-                                connection&apos;s events to a development tunnel.
-                            </InfoTooltip>
+                            <InfoTooltip>Deliver this connection&apos;s webhooks to a different URL than the environment-wide webhook URL.</InfoTooltip>
                         </div>
                         <EditableInput
                             id="webhook_url_override"

--- a/packages/webapp/src/pages/Connection/components/SettingsTab.tsx
+++ b/packages/webapp/src/pages/Connection/components/SettingsTab.tsx
@@ -38,7 +38,7 @@ export const SettingsTab = () => {
             await patchConnection({
                 params: { connectionId: connection.connection_id },
                 query: { provider_config_key: providerConfigKey, env },
-                body: { webhook_url: webhook_url_override }
+                body: { webhook_url_override }
             });
             toast({ title: 'Successfully updated', variant: 'success' });
         } catch {

--- a/packages/webapp/src/pages/Connection/components/SettingsTab.tsx
+++ b/packages/webapp/src/pages/Connection/components/SettingsTab.tsx
@@ -2,15 +2,18 @@ import { Trash2 } from 'lucide-react';
 import { useNavigate } from 'react-router-dom';
 
 import { permissions } from '@nangohq/authz';
-import { Button } from '@nangohq/design-system';
+import { Button, FieldLabel } from '@nangohq/design-system';
 
+import { EditableInput } from '@/components/patterns/EditableInput';
 import { PermissionGate } from '@/components/patterns/PermissionGate';
+import { InfoTooltip } from '@/components/ui/InfoTooltip';
 import { useConfirmDialog } from '@/hooks/useConfirmDialog';
-import { useDeleteConnection } from '@/hooks/useConnections';
+import { useDeleteConnection, usePatchConnection } from '@/hooks/useConnections';
 import { useEnvironment } from '@/hooks/useEnvironment';
 import { usePermissions } from '@/hooks/usePermissions';
 import { useToast } from '@/hooks/useToast';
 import { useConnectionContext } from '@/pages/Connection/Show';
+import { validateUrl } from '@/pages/Integrations/utils';
 import { useStore } from '@/store';
 import { ConnectionSideInfo } from './ConnectionSideInfo';
 
@@ -21,12 +24,28 @@ export const SettingsTab = () => {
     const { data } = useEnvironment(env);
     const environment = data?.environmentAndAccount?.environment;
     const { can } = usePermissions();
+    const canWriteConnection = can(permissions.canWriteProdConnections) || !environment?.is_production;
     const canDeleteConnection = can(permissions.canDeleteProdConnections) || !environment?.is_production;
     const navigate = useNavigate();
 
     const { toast } = useToast();
     const { mutateAsync: deleteConnection, isPending: isDeletingConnection } = useDeleteConnection();
+    const { mutateAsync: patchConnection } = usePatchConnection();
     const { confirm, DialogComponent } = useConfirmDialog();
+
+    const onSaveWebhookUrl = async (webhook_url_override: string) => {
+        try {
+            await patchConnection({
+                params: { connectionId: connection.connection_id },
+                query: { provider_config_key: providerConfigKey, env },
+                body: { webhook_url: webhook_url_override }
+            });
+            toast({ title: 'Successfully updated', variant: 'success' });
+        } catch {
+            toast({ title: 'Failed to update, an error occurred', variant: 'error' });
+            throw new Error('Failed to update webhook URL');
+        }
+    };
 
     const onDelete = async () => {
         try {
@@ -44,30 +63,49 @@ export const SettingsTab = () => {
         <>
             {DialogComponent}
             <div className="flex justify-between items-start gap-11">
-                <div className="w-full flex items-center justify-between">
-                    <span className="text-body-medium-semi text-text-strong">Connection deletion</span>
-                    <PermissionGate condition={canDeleteConnection} asChild>
-                        {(allowed) => (
-                            <Button
-                                variant="danger"
-                                size="md"
-                                loading={isDeletingConnection}
-                                disabled={!allowed}
-                                onClick={() =>
-                                    confirm({
-                                        title: 'Delete connection?',
-                                        description: 'All credentials & synced data associated with this connection will be deleted.',
-                                        confirmButtonText: 'Delete connection',
-                                        confirmVariant: 'danger',
-                                        onConfirm: onDelete
-                                    })
-                                }
-                            >
-                                <Trash2 />
-                                Delete connection
-                            </Button>
-                        )}
-                    </PermissionGate>
+                <div className="w-full flex flex-col gap-10">
+                    <div className="flex flex-col gap-2">
+                        <div className="flex gap-2 items-center">
+                            <FieldLabel htmlFor="webhook_url_override">Override webhook URL</FieldLabel>
+                            <InfoTooltip>
+                                Deliver this connection&apos;s webhooks to a different URL than the environment-wide webhook URL. Useful for routing a single
+                                connection&apos;s events to a development tunnel.
+                            </InfoTooltip>
+                        </div>
+                        <EditableInput
+                            id="webhook_url_override"
+                            placeholder="https://example.com/webhooks-from-nango"
+                            initialValue={connection.webhook_url_override || ''}
+                            onSave={onSaveWebhookUrl}
+                            validate={(value) => validateUrl(value, true)}
+                            canEdit={canWriteConnection}
+                        />
+                    </div>
+                    <div className="w-full flex items-center justify-between">
+                        <span className="text-body-medium-semi text-text-strong">Connection deletion</span>
+                        <PermissionGate condition={canDeleteConnection} asChild>
+                            {(allowed) => (
+                                <Button
+                                    variant="danger"
+                                    size="md"
+                                    loading={isDeletingConnection}
+                                    disabled={!allowed}
+                                    onClick={() =>
+                                        confirm({
+                                            title: 'Delete connection?',
+                                            description: 'All credentials & synced data associated with this connection will be deleted.',
+                                            confirmButtonText: 'Delete connection',
+                                            confirmVariant: 'danger',
+                                            onConfirm: onDelete
+                                        })
+                                    }
+                                >
+                                    <Trash2 />
+                                    Delete connection
+                                </Button>
+                            )}
+                        </PermissionGate>
+                    </div>
                 </div>
                 <ConnectionSideInfo connectionData={connectionData} />
             </div>


### PR DESCRIPTION
## Summary
- Add an editable **Override webhook URL** field on the connection Settings tab
- Wire it to private `PATCH /api/v1/connections/:connectionId`
- Update guide + Node SDK docs for setting/editing the override

Depends on #6739.

<img width="878" height="440" alt="image" src="https://github.com/user-attachments/assets/45e97df0-08d8-4dcc-b9e5-6e5680c76f49" />

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/NangoHQ/nango/pull/6740?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

