### PR TITLE
fix(server): allow data: fonts and blob: images in CSP

### DIFF
--- a/packages/server/lib/middleware/security.ts
+++ b/packages/server/lib/middleware/security.ts
@@ -40,11 +40,12 @@ export function securityMiddlewares(): RequestHandler[] {
                     'wss://*.plain.com',
                     'https://raw.githubusercontent.com'
                 ],
-                fontSrc: ["'self'", 'https://*.googleapis.com', 'https://*.gstatic.com', 'https://*.cdn-plain.com'],
+                fontSrc: ["'self'", 'data:', 'https://*.googleapis.com', 'https://*.gstatic.com', 'https://*.cdn-plain.com'],
                 frameSrc: ["'self'", 'https://accounts.google.com', hostPublic, hostApi, connectUrl, 'https://www.youtube.com', 'https://*.stripe.com'],
                 imgSrc: [
                     "'self'",
                     'data:',
+                    'blob:',
                     hostPublic,
                     hostApi,
                     'https://*.google-analytics.com',


### PR DESCRIPTION
## Problem

The report-only CSP soak surfaced two dashboard resources helmet blocks (relevant to self-hosted dashboards, which the Node server serves and helmet governs):
- a font loaded via a `data:` URI (`font-src`), and
- a `blob:` image on `/signup` (`img-src`).

The `data:` font is the same one #6725 dropped — I mis-scoped it as connect-only, but it's on the dashboard (`app.nango.dev/`), which helmet does govern for self-hosted.

## Solution

- `font-src`: add `data:`.
- `img-src`: add `blob:`.

Paired with CloudFront-side [nango-infra](https://github.com/NangoHQ/nango-infra) changes (same additions to the app policy).

Fixes [NAN-6012](https://linear.app/nango/issue/NAN-6012) (partial — report-only soak follow-up)

## Testing

- Both correspond to live report-only violations in Sentry on `app.nango.dev` (`REACT-XG` data: font, `REACT-YJ` blob: image).
- helmet is report-only by default; only affects self-hosters who enforce.
