### PR TITLE
feat(integrations): allow client credentials for sage intacct to be defined at integration level

### DIFF
--- a/docs/api-integrations/sage-intacct-cc.mdx
+++ b/docs/api-integrations/sage-intacct-cc.mdx
@@ -10,10 +10,10 @@ Connect to Sage Intacct with Nango and see data flow in 2 minutes. The Client Cr
 
 <Steps>
     <Step id="create-integration" title="Create the integration">
-    In Nango ([free signup](https://app.nango.dev)), go to **Integrations** → _Configure New Integration_ → _Sage Intacct (Client Credentials)_.
+    In Nango ([free signup](https://app.nango.dev)), go to **Integrations** → _Configure New Integration_ → _Sage Intacct (Client Credentials)_. Optionally, register your Client ID and Client Secret in the **Settings** tab so every connection reuses them — see the [setup guide](/api-integrations/sage-intacct-cc/how-to-register-your-own-sage-intacct-cc-app).
     </Step>
     <Step id="connect-sage-intacct-account" title="Connect your Sage Intacct account">
-    Go to **Connections** → _Add Test Connection_. Enter your Client ID, Client Secret, and either Username or Session ID, then save.
+    Go to **Connections** → _Add Test Connection_. Enter either your Username or Session ID, plus your Client ID and Client Secret if you left them blank on the integration, then save.
     </Step>
     <Step id="call-sage-intacct-api" title="Call the Sage Intacct API">
     Make your first request (List employee expenses). Replace the placeholders with your API key (from **Environment Settings**), integration ID, and connection ID:
@@ -65,8 +65,11 @@ Connect to Sage Intacct with Nango and see data flow in 2 minutes. The Client Cr
 
 Nango-maintained guides for common use cases.
 
-- [How to configure Sage Intacct client credentials](/api-integrations/sage-intacct-cc/connect)  
-Set up a Web Services user, authorize your client application, and obtain credentials to connect it to Nango
+- [How to register your own Sage Intacct (Client Credentials) app](/api-integrations/sage-intacct-cc/how-to-register-your-own-sage-intacct-cc-app)  
+Set up a Web Services user, register and authorize a client application, and obtain your Client ID and Client Secret
+
+- [How to link your Sage Intacct account](/api-integrations/sage-intacct-cc/connect)  
+Connect your Sage Intacct account to Nango using the Connect UI
 
 Official docs: [Sage Intacct API docs](https://developer.sage.com/intacct/docs/)
 

--- a/docs/api-integrations/sage-intacct-cc/connect.mdx
+++ b/docs/api-integrations/sage-intacct-cc/connect.mdx
@@ -6,12 +6,18 @@ sidebarTitle: 'Sage Intacct (Client Credentials)'
 # Overview
 
 To authenticate with Sage Intacct using Client Credentials, you will need:
-1. **Client ID** — Your Sage Intacct application Client ID
-2. **Client Secret** — Your Sage Intacct application Client Secret
+1. **Client ID** _(conditional)_ — Your Sage Intacct application Client ID. Only asked here if not already registered on the integration.
+2. **Client Secret** _(conditional)_ — Your Sage Intacct application Client Secret. Only asked here if not already registered on the integration.
 3. **Username** _(optional)_ — The Web Services user ID in `userId@companyId` format (e.g. `Admin@MyCompany`). Append `|entityId` for multi-entity companies. Required if not using Session ID.
 4. **Session ID** _(optional)_ — A valid UI or API session ID. Required if not using Username.
 
 This guide will walk you through obtaining each of these values.
+
+<Note>
+If the Connect UI form doesn't show Client ID and Client Secret fields, your workspace already registered them
+on the integration setting — every connection reuses them
+automatically, so skip straight to Step 4. Otherwise, follow all the steps below to get your own values.
+</Note>
 
 ### Prerequisites
 
@@ -31,19 +37,9 @@ If your company already has a Web Services user defined for your application, yo
 
 #### Step 2: Register an API client
 
-1. Go to the [Sage developer console](https://developer.sage.com/intacct/) and sign in or sign up.
-2. Click **View workspaces**, then **Add workspace** to create a workspace for your company.
-3. Click **Apps** in the left column, then **Add application**.
-4. Enter a name, home page URL, and contact email, then click **Create**.
-5. Open the new application, click **Create API keys**, and select **Sage Intacct** from the **Sage Product API** drop-down.
-6. Set **Client Scope** to **Production** or **Non-Production** as appropriate.
+Follow [How to register your own Sage Intacct (Client Credentials) app](/api-integrations/sage-intacct-cc/how-to-register-your-own-sage-intacct-cc-app) to create a Sage developer workspace, register an application, and obtain your **Client ID** and **Client Secret**.
 
-    <Note>You cannot change the client scope after it has been set.</Note>
-
-7. Click **Create**.
-8. Copy your **Client ID** and **Client Secret** from the Application Details page.
-
-    <Warning>Store the Client Secret server-side only. Never expose it in client-side code, logs, or URLs.</Warning>
+<Warning>Store the Client Secret server-side only. Never expose it in client-side code, logs, or URLs.</Warning>
 
 #### Step 3: Authorize the client application
 
@@ -53,15 +49,13 @@ If your company already has a Web Services user defined for your application, yo
 
 #### Step 4: Enter credentials in the Connect UI
 
-When you have your **Client ID**, **Client Secret**, and either **Username** or **Session ID**:
-
 1. Open the form where you need to authenticate with Sage Intacct.
-2. Enter your **Client ID** and **Client Secret** in their respective fields.
+2. If **Client ID** and **Client Secret** fields are shown, enter the values from Step 2, or the ones your integration developer gave you. Either way, that client must already be authorized (Step 3) — Sage Intacct rejects requests from a client that isn't.
 3. Enter either your **Username** or a valid **Session ID** — one of the two is required.
    - Username format: `userId@companyId` (e.g. `Admin@MyCompany`). For multi-entity companies, append the entity ID: `userId@companyId|entityId` (e.g. `Admin@MyCompany|Central Region`).
 4. Submit the form.
 
-<img src="/api-integrations/sage-intacct-cc/form.png" alt="Sage Intacct Client Credentials connect form" style={{maxWidth: "450px" }}/>
+<img src="/api-integrations/sage-intacct-cc/form.png" alt="Sage Intacct Client Credentials connect form — Client ID and Client Secret only appear here if they weren't already registered on the integration" style={{maxWidth: "450px" }}/>
 
 
 You are now connected to Sage Intacct (Client Credentials).

--- a/docs/api-integrations/sage-intacct-cc/how-to-register-your-own-sage-intacct-cc-app.mdx
+++ b/docs/api-integrations/sage-intacct-cc/how-to-register-your-own-sage-intacct-cc-app.mdx
@@ -1,0 +1,40 @@
+---
+title: 'How to register your own Sage Intacct (Client Credentials) app'
+sidebarTitle: 'Sage Intacct (Client Credentials) Setup'
+description: 'Register a Sage Intacct API client and connect it to Nango'
+---
+
+This guide shows you how to register an API client with Sage Intacct to obtain your Client ID and Client Secret. These identify your application to Sage Intacct and are shared across every customer connecting through it.
+
+<Steps>
+  <Step title="Register an API client">
+    1. Go to the [Sage developer console](https://developer.sage.com/intacct/) and sign in or sign up.
+    2. Click **View workspaces**, then **Add workspace** to create a workspace for your company.
+    3. Click **Apps** in the left column, then **Add application**.
+    4. Enter a name, home page URL, and contact email, then click **Create**.
+    5. Open the new application, click **Create API keys**, and select **Sage Intacct** from the **Sage Product API** drop-down.
+    6. Set **Client Scope** to **Production** or **Non-Production** as appropriate.
+
+        <Note>You cannot change the client scope after it has been set.</Note>
+
+    7. Click **Create**.
+    8. Copy your **Client ID** and **Client Secret** from the Application Details page.
+
+        <Warning>Store the Client Secret server-side only. Never expose it in client-side code, logs, or URLs.</Warning>
+  </Step>
+  <Step title="Register your Client ID and Client Secret in Nango (optional)">
+    Client ID and Client Secret are usually the same for every connection on an integration, since they identify your application to Sage Intacct rather than a specific customer. Register them once on the integration and every connection reuses them automatically — end users are never asked for them in the Connect UI.
+
+    1. In Nango, go to **Integrations** → your Sage Intacct (Client Credentials) integration → **Settings** tab.
+    2. Enter your **Client ID** and **Client Secret** in their respective fields. Each field saves as soon as you leave it.
+
+    If you'd rather each of your customers use their own Sage Intacct application, leave these fields blank — the Connect UI will ask for Client ID and Client Secret per connection instead.
+  </Step>
+  <Step title="Next">
+    Follow the [_Quickstart_](/getting-started/quickstart) to connect your first account.
+  </Step>
+</Steps>
+
+For more details, see [Sage Intacct API docs](https://developer.sage.com/intacct/docs/1/sage-intacct-rest-api/authorization-and-security/oauth2#client-credentials-grant-type).
+
+---

--- a/packages/connect-ui/src/test/fixtures.ts
+++ b/packages/connect-ui/src/test/fixtures.ts
@@ -41,6 +41,58 @@ export const apiKeyProvider = {
 
 export const providerResponse = { data: apiKeyProvider } satisfies GetPublicProvider['Success'];
 
+// TWO_STEP provider with a `clientId` declared only in `integration_config` — it doubles as a per-connection
+// credential fallback (see Go.tsx), asked from the end user only when the integration hasn't preconfigured it.
+export const twoStepProvider = {
+    auth_mode: 'TWO_STEP',
+    display_name: 'Sage Intacct',
+    docs: 'https://docs.example.com/sage-intacct',
+    name: 'sage-intacct-cc',
+    logo_url: 'https://app.nango.dev/images/template-logos/sage-intacct-cc.svg',
+    token_response: { token: 'access_token' },
+    credentials: {
+        username: { type: 'string', title: 'Username', description: 'Username', automated: false, order: 2 }
+    },
+    integration_config: {
+        clientId: { type: 'string', title: 'Client ID', description: 'Client ID', automated: false, optional: true, order: 1 }
+    }
+} satisfies GetPublicProvider['Success']['data'];
+
+export const twoStepIntegrationFixture: GetPublicIntegration['Success']['data'] = {
+    ...integrationFixture,
+    unique_key: 'sage-intacct-cc',
+    provider: 'sage-intacct-cc',
+    display_name: 'Sage Intacct',
+    preconfigured_credentials: ['clientId']
+};
+
+// Same integration, but with nothing preconfigured — used to assert the field renders by default.
+export const twoStepIntegrationFixtureNoPreconfig: GetPublicIntegration['Success']['data'] = {
+    ...twoStepIntegrationFixture,
+    preconfigured_credentials: undefined
+};
+
+export const twoStepOtherProvider = {
+    auth_mode: 'TWO_STEP',
+    display_name: 'Tableau',
+    docs: 'https://docs.example.com/tableau',
+    name: 'tableau',
+    logo_url: 'https://app.nango.dev/images/template-logos/tableau.svg',
+    token_response: { token: 'access_token' },
+    credentials: {
+        pat_name: { type: 'string', title: 'Personal App Token', description: 'PAT name', automated: false, order: 1 },
+        pat_secret: { type: 'string', title: 'Personal App Token Secret', description: 'PAT secret', automated: false, order: 2 }
+    }
+} satisfies GetPublicProvider['Success']['data'];
+
+export const twoStepOtherIntegrationFixture: GetPublicIntegration['Success']['data'] = {
+    ...integrationFixture,
+    unique_key: 'tableau',
+    provider: 'tableau',
+    display_name: 'Tableau',
+    preconfigured_credentials: undefined
+};
+
 export const authResultFixture = {
     providerConfigKey: 'github',
     connectionId: 'conn_test_123'

--- a/packages/connect-ui/src/views/Go.test.tsx
+++ b/packages/connect-ui/src/views/Go.test.tsx
@@ -6,7 +6,16 @@ import { AuthError } from '@nangohq/frontend';
 import { triggerClose } from '@/lib/events';
 import { useNango } from '@/lib/nango';
 import { expectAccessibleInBothThemes } from '@/test/a11y';
-import { apiKeyProvider, authResultFixture, integrationFixture } from '@/test/fixtures';
+import {
+    apiKeyProvider,
+    authResultFixture,
+    integrationFixture,
+    twoStepIntegrationFixture,
+    twoStepIntegrationFixtureNoPreconfig,
+    twoStepOtherIntegrationFixture,
+    twoStepOtherProvider,
+    twoStepProvider
+} from '@/test/fixtures';
 import { renderApp } from '@/test/render';
 
 import type * as EventsModule from '@/lib/events';
@@ -129,6 +138,38 @@ describe('Go', () => {
 
             // Back returns to the credentials form.
             await expect.element(page.getByRole('heading', { name: 'Link GitHub Account' })).toBeInTheDocument();
+        });
+    });
+
+    describe('preconfigured credentials (integration_config)', () => {
+        it('hides a credential field already set at the integration level, but still asks for the rest', async () => {
+            await renderApp({ route: '/go', seedStore: { provider: twoStepProvider, integration: twoStepIntegrationFixture } });
+            await expect.element(page.getByRole('heading', { name: 'Link Sage Intacct Account' })).toBeInTheDocument();
+
+            await expect.element(page.getByPlaceholder('Username')).toBeInTheDocument();
+            expect(page.getByPlaceholder('Client ID').query()).toBeNull();
+        });
+
+        it('asks for the field when nothing is preconfigured at the integration level', async () => {
+            await renderApp({ route: '/go', seedStore: { provider: twoStepProvider, integration: twoStepIntegrationFixtureNoPreconfig } });
+            await expect.element(page.getByRole('heading', { name: 'Link Sage Intacct Account' })).toBeInTheDocument();
+
+            await expect.element(page.getByPlaceholder('Client ID')).toBeInTheDocument();
+            await expect.element(page.getByPlaceholder('Username')).toBeInTheDocument();
+        });
+    });
+    describe('cross-provider TWO_STEP schema isolation', () => {
+        it('renders Sage Intacct with its own clientId fallback field', async () => {
+            await renderApp({ route: '/go', seedStore: { provider: twoStepProvider, integration: twoStepIntegrationFixtureNoPreconfig } });
+            await expect.element(page.getByRole('heading', { name: 'Link Sage Intacct Account' })).toBeInTheDocument();
+            await expect.element(page.getByPlaceholder('Client ID')).toBeInTheDocument();
+        });
+
+        it('does not leak that fallback field into a later, unrelated TWO_STEP provider', async () => {
+            await renderApp({ route: '/go', seedStore: { provider: twoStepOtherProvider, integration: twoStepOtherIntegrationFixture } });
+            await expect.element(page.getByRole('heading', { name: 'Link Tableau Account' })).toBeInTheDocument();
+            await expect.element(page.getByPlaceholder('Personal App Token', { exact: true })).toBeInTheDocument();
+            expect(page.getByPlaceholder('Client ID').query()).toBeNull();
         });
     });
 });

--- a/packages/connect-ui/src/views/Go.tsx
+++ b/packages/connect-ui/src/views/Go.tsx
@@ -21,7 +21,7 @@ import { telemetry } from '@/lib/telemetry';
 import { cn, compactErrorDisplay, getAllowedCallbackOrigin, jsonSchemaToZod } from '@/lib/utils';
 
 import type { AuthResult } from '@nangohq/frontend';
-import type { AuthModeType } from '@nangohq/types';
+import type { AuthModeType, SimplifiedJSONSchema } from '@nangohq/types';
 import type { InputHTMLAttributes } from 'react';
 import type { Resolver } from 'react-hook-form';
 
@@ -109,6 +109,17 @@ export const Go: React.FC = () => {
     const [connectionFailed, setConnectionFailed] = useState(false);
     const [showErrorDetails, setShowErrorDetails] = useState(false);
 
+    const integrationConfigFallbackFields = useMemo<Record<string, SimplifiedJSONSchema>>(() => {
+        if (!provider || provider.auth_mode !== 'TWO_STEP') {
+            return {};
+        }
+        return Object.fromEntries(
+            Object.entries(provider.integration_config ?? {})
+                .filter(([name]) => !(provider.credentials && name in provider.credentials))
+                .map(([name, schema]) => [name, { ...schema, optional: false }])
+        );
+    }, [provider]);
+
     const preconfiguredParams = session && integration ? session.integrations_config_defaults?.[integration.unique_key]?.connection_config || {} : {};
     const initialExternalId = useMemo(() => {
         const value = preconfiguredParams['external_id'] as string | undefined;
@@ -187,6 +198,7 @@ export const Go: React.FC = () => {
         }
 
         const baseForm = formSchema[provider.auth_mode];
+        const credentialsShape: Record<string, z.ZodType> = { ...baseForm.shape };
 
         // To order fields we use incremented int starting high because we don't know yet which fields will be sorted
         // It's a lazy algorithm that works most of the time
@@ -195,12 +207,12 @@ export const Go: React.FC = () => {
         let order = 99;
 
         // Base credentials are usually the first in the list so we start here
-        for (const name of Object.keys(baseForm.shape)) {
+        for (const name of Object.keys(credentialsShape)) {
             if ((name === 'client_certificate' || name === 'client_private_key') && provider.require_client_certificate !== true) {
                 continue;
             }
             if (name === 'client_secret' && provider.token_request_auth_method === 'private_key_jwt') {
-                baseForm.shape['client_secret'] = z.string().optional();
+                credentialsShape['client_secret'] = z.string().optional();
                 continue;
             }
             order += 1;
@@ -208,12 +220,17 @@ export const Go: React.FC = () => {
         }
 
         // Modify base form with credentials specific
-        for (const [name, schema] of Object.entries(provider.credentials || [])) {
+        for (const [name, schema] of Object.entries({ ...provider.credentials, ...integrationConfigFallbackFields })) {
             if (schema.automated) {
                 continue;
             }
 
-            baseForm.shape[name] = jsonSchemaToZod(schema);
+            // Already set at the integration level (integration_config) — don't ask the end user for it.
+            if (integration?.preconfigured_credentials?.includes(name)) {
+                continue;
+            }
+
+            credentialsShape[name] = jsonSchemaToZod(schema);
 
             // In case the field only exists in provider.yaml (TWO_STEP)
             const fullName = `credentials.${name}`;
@@ -267,8 +284,8 @@ export const Go: React.FC = () => {
             // For OAUTH2, allow users to override client credentials if preconfigured with empty values
             const allowedOverrides = ['oauth_client_id_override', 'oauth_client_secret_override', 'oauth_refresh_token_override'];
             for (const key of allowedOverrides) {
-                if (key in preconfiguredParams && !additionalFields[key] && !(key in baseForm.shape)) {
-                    baseForm.shape[key] = z.string().optional();
+                if (key in preconfiguredParams && !additionalFields[key] && !(key in credentialsShape)) {
+                    credentialsShape[key] = z.string().optional();
                     order += 1;
                     orderedFields[`credentials.${key}`] = order;
                 }
@@ -277,7 +294,7 @@ export const Go: React.FC = () => {
 
         // Only add objects if they have something otherwise it breaks react-form
         const fields = z.object({
-            ...(Object.keys(baseForm.shape).length > 0 ? { credentials: baseForm } : {}),
+            ...(Object.keys(credentialsShape).length > 0 ? { credentials: z.object(credentialsShape) } : {}),
             ...(Object.keys(additionalFields).length > 0 ? { params: z.object(additionalFields) } : {}),
             ...(Object.keys(assertionOptionFields).length > 0 ? { assertion_option: z.object(assertionOptionFields) } : {})
         });
@@ -292,7 +309,7 @@ export const Go: React.FC = () => {
             resolver,
             orderedFields: Object.entries(orderedFields).sort((a, b) => (a[1] < b[1] ? -1 : 1))
         };
-    }, [provider, preconfiguredParams]);
+    }, [provider, integration, preconfiguredParams, integrationConfigFallbackFields]);
 
     const form = useForm<z.infer<(typeof formSchema)['API_KEY']>>({
         resolver: resolver,
@@ -629,7 +646,9 @@ export const Go: React.FC = () => {
                                     const [type, key] = name.split('.') as ['credentials' | 'params' | 'assertion_option', string];
 
                                     const definition =
-                                        provider[type === 'credentials' ? 'credentials' : type === 'params' ? 'connection_config' : 'assertion_option']?.[key];
+                                        type === 'credentials'
+                                            ? (provider.credentials?.[key] ?? integrationConfigFallbackFields[key])
+                                            : provider[type === 'params' ? 'connection_config' : 'assertion_option']?.[key];
                                     // Not all fields have a definition in providers.yaml so we fallback to default
                                     const base = name in defaultConfiguration ? defaultConfiguration[name] : undefined;
                                     const labelOverride = type === 'credentials' ? integration?.credentials_label?.[key] : undefined;

--- a/packages/providers/providers.yaml
+++ b/packages/providers/providers.yaml
@@ -17609,16 +17609,21 @@ sage-intacct-cc:
     docs: https://nango.dev/docs/api-integrations/sage-intacct-cc
     docs_connect: https://nango.dev/docs/api-integrations/sage-intacct-cc/connect
     setup_guide_url: https://nango.dev/docs/api-integrations/sage-intacct-cc/connect
-    credentials:
+    integration_config:
         clientId:
             type: string
             title: Client ID
             description: Your Sage Intacct application Client ID.
+            order: 1
+            optional: true
         clientSecret:
             type: string
             title: Client Secret
             description: Your Sage Intacct application Client Secret.
             secret: true
+            order: 2
+            optional: true
+    credentials:
         username:
             type: string
             title: Username

--- a/packages/server/lib/controllers/auth/postTwoStep.ts
+++ b/packages/server/lib/controllers/auth/postTwoStep.ts
@@ -149,7 +149,7 @@ export const postPublicTwoStepAuthorization = asyncWrapper<PostPublicTwoStepAuth
             success,
             error,
             response: credentials
-        } = await connectionService.getTwoStepCredentials(providerConfigKey, provider as ProviderTwoStep, bodyData, connectionConfig);
+        } = await connectionService.getTwoStepCredentials(providerConfigKey, provider as ProviderTwoStep, bodyData, connectionConfig, false, config.custom);
 
         if (!success || !credentials) {
             void logCtx.error('Error during TwoStep credentials creation', { error, provider: config.provider });

--- a/packages/server/lib/controllers/v1/integrations/providerConfigKey/patchIntegration.integration.test.ts
+++ b/packages/server/lib/controllers/v1/integrations/providerConfigKey/patchIntegration.integration.test.ts
@@ -1,6 +1,6 @@
 import { afterAll, beforeAll, describe, expect, it } from 'vitest';
 
-import { seeders } from '@nangohq/shared';
+import { configService, seeders } from '@nangohq/shared';
 
 import { isError, isSuccess, runServer, shouldBeProtected } from '../../../../utils/tests.js';
 
@@ -286,5 +286,30 @@ describe(`PATCH ${endpoint}`, () => {
 
         isSuccess(res.json);
         expect(res.json).toStrictEqual<typeof res.json>({ data: { success: true } });
+    });
+
+    it('actually persists an updated integration_config secret across successive updates', async () => {
+        const { env, apiKey } = await seeders.seedAccountEnvAndUser();
+        await seeders.createConfigSeed(env, 'sage-intacct-cc', 'sage-intacct-cc');
+
+        await api.fetch(endpoint, {
+            method: 'PATCH',
+            query: { env: 'dev' },
+            token: apiKey.secret,
+            params: { providerConfigKey: 'sage-intacct-cc' },
+            body: { integrationConfig: { clientId: 'first-client-id', clientSecret: 'first-secret' } }
+        });
+
+        const res = await api.fetch(endpoint, {
+            method: 'PATCH',
+            query: { env: 'dev' },
+            token: apiKey.secret,
+            params: { providerConfigKey: 'sage-intacct-cc' },
+            body: { integrationConfig: { clientSecret: 'second-secret' } }
+        });
+        isSuccess(res.json);
+
+        const stored = await configService.getProviderConfig('sage-intacct-cc', env.id);
+        expect(stored?.custom).toMatchObject({ clientId: 'first-client-id', clientSecret: 'second-secret' });
     });
 });

--- a/packages/server/lib/formatters/integration.ts
+++ b/packages/server/lib/formatters/integration.ts
@@ -27,9 +27,9 @@ export function integrationToApi(data: IntegrationConfig, options?: { includeCre
 
 /**
  * Mask `custom` values for any `integration_config` field the provider declares as `secret`, so
- * secrets (e.g. AWS SigV4 built-in credentials or STS auth) are never echoed in cleartext. The "***"
- * sentinel is what the dynamic settings form treats as "configured but unchanged" — it omits such a
- * field on save, and the resolver preserves omitted fields in patch mode.
+ * secrets (e.g. AWS SigV4 built-in credentials, sage-intacct-cc's clientSecret) are never echoed in
+ * cleartext. The "***" sentinel is what the dynamic settings form treats as "configured but
+ * unchanged" — it omits such a field on save, and the resolver preserves omitted fields in patch mode.
  */
 function maskSecretConfigFields(custom: IntegrationConfig['custom'], provider: Provider | null): IntegrationConfig['custom'] {
     if (!custom || !provider?.integration_config) {
@@ -47,6 +47,14 @@ function maskSecretConfigFields(custom: IntegrationConfig['custom'], provider: P
     return masked ?? custom;
 }
 
+function getPreconfiguredCredentials(custom: IntegrationConfig['custom'], provider: Provider): string[] {
+    if (!custom || provider.auth_mode !== 'TWO_STEP' || !provider.integration_config) {
+        return [];
+    }
+
+    return Object.keys(provider.integration_config).filter((field) => Boolean(custom[field]));
+}
+
 export function integrationToPublicApi({
     integration,
     include,
@@ -56,6 +64,7 @@ export function integrationToPublicApi({
     provider: Provider;
     include?: ApiPublicIntegrationInclude;
 }): ApiPublicIntegration {
+    const preconfiguredCredentials = getPreconfiguredCredentials(integration.custom, provider);
     return {
         unique_key: integration.unique_key,
         provider: integration.provider,
@@ -64,6 +73,7 @@ export function integrationToPublicApi({
         // Non-secret per-integration overrides for the Connect UI (e.g. the configurable API-key label).
         // Only providers that declare `integration_config`, never expose the whole `custom` object.
         ...(provider.integration_config && integration.custom?.['keyLabel'] ? { credentials_label: { apiKey: integration.custom['keyLabel'] } } : {}),
+        ...(preconfiguredCredentials.length > 0 ? { preconfigured_credentials: preconfiguredCredentials } : {}),
         ...include,
         forward_webhooks: integration.forward_webhooks === undefined ? true : integration.forward_webhooks,
         created_at: integration.created_at.toISOString(),

--- a/packages/server/lib/formatters/integration.unit.test.ts
+++ b/packages/server/lib/formatters/integration.unit.test.ts
@@ -1,0 +1,55 @@
+import { describe, expect, it } from 'vitest';
+
+import { getProvider } from '@nangohq/shared';
+
+import { integrationToPublicApi } from './integration.js';
+
+import type { IntegrationConfig } from '@nangohq/types';
+
+function makeIntegration(custom: IntegrationConfig['custom']): IntegrationConfig {
+    return {
+        unique_key: 'sage-intacct-cc',
+        provider: 'sage-intacct-cc',
+        oauth_client_id: null,
+        oauth_client_secret: null,
+        environment_id: 1,
+        custom,
+        missing_fields: [],
+        display_name: null,
+        forward_webhooks: true,
+        shared_credentials_id: null,
+        created_at: new Date('2025-01-01'),
+        updated_at: new Date('2025-01-01')
+    };
+}
+
+// Load the real provider definition (not a hand-rolled fixture) so this test fails if `clientId`/`clientSecret`
+// are ever removed from `sage-intacct-cc`'s `integration_config` block, or if `auth_mode` ever stops being
+// TWO_STEP — either would silently break the Connect UI's "ask only if not preconfigured" fallback.
+const provider = getProvider('sage-intacct-cc')!;
+
+describe('integrationToPublicApi preconfigured_credentials', () => {
+    it('lists credential fields already set at the integration level', () => {
+        const result = integrationToPublicApi({ integration: makeIntegration({ clientId: 'abc', clientSecret: 'shh' }), provider });
+
+        expect(result.preconfigured_credentials).toStrictEqual(['clientId', 'clientSecret']);
+    });
+
+    it('omits fields with no value set on the integration', () => {
+        const result = integrationToPublicApi({ integration: makeIntegration({ clientId: 'abc' }), provider });
+
+        expect(result.preconfigured_credentials).toStrictEqual(['clientId']);
+    });
+
+    it('is absent when the integration has no custom config', () => {
+        const result = integrationToPublicApi({ integration: makeIntegration(null), provider });
+
+        expect(result.preconfigured_credentials).toBeUndefined();
+    });
+
+    it('never includes fields only declared in credentials, not integration_config', () => {
+        const result = integrationToPublicApi({ integration: makeIntegration({ username: 'bob' }), provider });
+
+        expect(result.preconfigured_credentials).toBeUndefined();
+    });
+});

--- a/packages/shared/lib/services/connection.service.ts
+++ b/packages/shared/lib/services/connection.service.ts
@@ -1416,8 +1416,12 @@ class ConnectionService {
         provider: ProviderTwoStep,
         dynamicCredentials: Record<string, any>,
         connectionConfig: Record<string, string>,
-        refreshToken?: boolean
+        refreshToken?: boolean,
+        integrationConfig?: Record<string, string> | null
     ): Promise<ServiceResponse<TwoStepCredentials>> {
+        const preconfiguredFields = getPreconfiguredTwoStepFields(provider, integrationConfig);
+        dynamicCredentials = applyIntegrationConfigToTwoStepCredentials(provider, dynamicCredentials, integrationConfig);
+
         if (provider.signature) {
             const create = jwtClient.createCredentials({
                 config: providerConfig,
@@ -1655,7 +1659,7 @@ class ConnectionService {
             const RESERVED_CRED_KEYS = new Set(['type', 'token', 'refresh_token', 'expires_at', 'raw']);
 
             for (const [key, value] of Object.entries(dynamicCredentials)) {
-                if (value !== undefined) {
+                if (value !== undefined && !preconfiguredFields.has(key)) {
                     parsedCreds[key] = value;
                 }
             }
@@ -1804,7 +1808,8 @@ class ConnectionService {
                 provider as ProviderTwoStep,
                 dynamicCredentials,
                 connection.connection_config,
-                true
+                true,
+                providerConfig.custom
             );
 
             if (!success || !credentials) {
@@ -2095,6 +2100,34 @@ class ConnectionService {
             return Err(new NangoError('failed_to_track_execution', { id, error: err }));
         }
     }
+}
+
+// Names of `integration_config` fields that have a value set on the integration itself (`custom`) —
+// these take precedence over anything submitted per-connection and must never be persisted onto a connection.
+export function getPreconfiguredTwoStepFields(provider: ProviderTwoStep, integrationConfig: Record<string, string> | null | undefined): Set<string> {
+    if (!integrationConfig || !provider.integration_config) {
+        return new Set();
+    }
+
+    return new Set(Object.keys(provider.integration_config).filter((field) => Boolean(integrationConfig[field])));
+}
+
+export function applyIntegrationConfigToTwoStepCredentials(
+    provider: ProviderTwoStep,
+    dynamicCredentials: Record<string, any>,
+    integrationConfig: Record<string, string> | null | undefined
+): Record<string, any> {
+    const preconfiguredFields = getPreconfiguredTwoStepFields(provider, integrationConfig);
+    if (preconfiguredFields.size === 0) {
+        return dynamicCredentials;
+    }
+
+    const overrides: Record<string, string> = {};
+    for (const field of preconfiguredFields) {
+        overrides[field] = integrationConfig![field]!;
+    }
+
+    return { ...dynamicCredentials, ...overrides };
 }
 
 export function extractResponseHeaderValues(headers: Record<string, any>, entries: string[]): Record<string, string> {

--- a/packages/shared/lib/services/connection.service.unit.test.ts
+++ b/packages/shared/lib/services/connection.service.unit.test.ts
@@ -1,9 +1,167 @@
-import { describe, expect, it } from 'vitest';
+import { describe, expect, it, vi } from 'vitest';
 
-import connectionService, { extractResponseHeaderValues } from './connection.service.js';
+import { axiosInstance } from '@nangohq/utils';
+
+import connectionService, {
+    applyIntegrationConfigToTwoStepCredentials,
+    extractResponseHeaderValues,
+    getPreconfiguredTwoStepFields
+} from './connection.service.js';
 import { REFRESH_MARGIN_MS } from './connections/utils.js';
 
 import type { ProviderTwoStep, TwoStepCredentials } from '@nangohq/types';
+
+describe('applyIntegrationConfigToTwoStepCredentials', () => {
+    // Matches the real sage-intacct-cc shape: clientId/clientSecret live only in `integration_config` (the
+    // Connect UI falls back to asking for them as regular credentials when unset — see Go.tsx).
+    const provider: ProviderTwoStep = {
+        display_name: 'Test',
+        docs: 'https://example.com',
+        auth_mode: 'TWO_STEP',
+        token_response: { token: 'access_token' },
+        credentials: {
+            username: { type: 'string', title: 'Username', description: '', automated: false, order: 3 }
+        },
+        integration_config: {
+            clientId: { type: 'string', title: 'Client ID', description: '', automated: false, order: 1 },
+            clientSecret: { type: 'string', title: 'Client Secret', description: '', automated: false, order: 2 }
+        }
+    };
+
+    it('overrides a submitted credential with the integration-level value', () => {
+        const dynamicCredentials = { refresh_token: 'rt', clientId: 'from-user', clientSecret: 'from-user-secret', username: 'bob' };
+
+        const result = applyIntegrationConfigToTwoStepCredentials(provider, dynamicCredentials, { clientId: 'from-integration', clientSecret: 'shh' });
+
+        expect(result).toStrictEqual({ refresh_token: 'rt', clientId: 'from-integration', clientSecret: 'shh', username: 'bob' });
+    });
+
+    it('falls back to the submitted/stored credential when the integration has nothing for that key', () => {
+        const dynamicCredentials = { clientId: 'from-user', username: 'bob' };
+
+        const result = applyIntegrationConfigToTwoStepCredentials(provider, dynamicCredentials, { clientSecret: '' });
+
+        expect(result).toStrictEqual({ clientId: 'from-user', username: 'bob' });
+    });
+
+    it('leaves credentials untouched when no integration config is set', () => {
+        const dynamicCredentials = { clientId: 'from-user', username: 'bob' };
+
+        expect(applyIntegrationConfigToTwoStepCredentials(provider, dynamicCredentials, null)).toBe(dynamicCredentials);
+        expect(applyIntegrationConfigToTwoStepCredentials(provider, dynamicCredentials, undefined)).toBe(dynamicCredentials);
+    });
+
+    it('only overrides fields declared in integration_config', () => {
+        const dynamicCredentials = { clientId: 'from-user', username: 'bob' };
+
+        // "username" isn't declared in integration_config, so it must never be pulled from custom config,
+        // even though the caller happens to pass a value under that key.
+        const result = applyIntegrationConfigToTwoStepCredentials(provider, dynamicCredentials, { clientId: 'from-integration', username: 'someone-else' });
+
+        expect(result).toStrictEqual({ clientId: 'from-integration', username: 'bob' });
+    });
+});
+
+describe('getPreconfiguredTwoStepFields', () => {
+    const provider: ProviderTwoStep = {
+        display_name: 'Test',
+        docs: 'https://example.com',
+        auth_mode: 'TWO_STEP',
+        token_response: { token: 'access_token' },
+        credentials: {
+            username: { type: 'string', title: 'Username', description: '', automated: false, order: 3 }
+        },
+        integration_config: {
+            clientId: { type: 'string', title: 'Client ID', description: '', automated: false, order: 1 },
+            clientSecret: { type: 'string', title: 'Client Secret', description: '', automated: false, order: 2 }
+        }
+    };
+
+    it('lists integration_config fields that have a value set on the integration', () => {
+        expect(getPreconfiguredTwoStepFields(provider, { clientId: 'abc', clientSecret: 'shh' })).toStrictEqual(new Set(['clientId', 'clientSecret']));
+    });
+
+    it('omits fields with no value set on the integration', () => {
+        expect(getPreconfiguredTwoStepFields(provider, { clientId: 'abc', clientSecret: '' })).toStrictEqual(new Set(['clientId']));
+    });
+
+    it('is empty when there is no integration config', () => {
+        expect(getPreconfiguredTwoStepFields(provider, null)).toStrictEqual(new Set());
+        expect(getPreconfiguredTwoStepFields(provider, undefined)).toStrictEqual(new Set());
+    });
+
+    it('never includes fields only declared in credentials, not integration_config', () => {
+        expect(getPreconfiguredTwoStepFields(provider, { username: 'bob' })).toStrictEqual(new Set());
+    });
+});
+
+describe('getTwoStepCredentials', () => {
+    // Mirrors sage-intacct-cc: clientId/clientSecret are only ever read from the integration's own config.
+    const provider: ProviderTwoStep = {
+        display_name: 'Test',
+        docs: 'https://example.com',
+        auth_mode: 'TWO_STEP',
+        token_url: 'https://example.com/token',
+        body_format: 'form',
+        token_params: {
+            grant_type: 'client_credentials',
+            client_id: '${credentials.clientId}',
+            client_secret: '${credentials.clientSecret}',
+            username: '${credentials.username}'
+        },
+        token_response: { token: 'access_token' },
+        credentials: {
+            username: { type: 'string', title: 'Username', description: '', automated: false, order: 3 }
+        },
+        integration_config: {
+            clientId: { type: 'string', title: 'Client ID', description: '', automated: false, order: 1 },
+            clientSecret: { type: 'string', title: 'Client Secret', description: '', automated: false, order: 2 }
+        }
+    };
+
+    it('uses the integration-level clientId/clientSecret to build the request but never persists them onto the connection', async () => {
+        const postSpy = vi.spyOn(axiosInstance, 'post').mockResolvedValue({ status: 200, data: { access_token: 'tok123' }, headers: {} });
+
+        const { success, response } = await connectionService.getTwoStepCredentials('test-config', provider, { username: 'bob' }, {}, false, {
+            clientId: 'integration-client-id',
+            clientSecret: 'integration-secret'
+        });
+
+        expect(success).toBe(true);
+
+        const body = postSpy.mock.calls[0]?.[1] as string;
+        expect(body).toContain('client_id=integration-client-id');
+        expect(body).toContain('client_secret=integration-secret');
+
+        // The integration's own clientId/clientSecret must stay resident on the integration, not get copied
+        // onto the connection — otherwise updating them on the integration wouldn't propagate to connections
+        // created before the update, and they'd needlessly be exposed on the connection's credentials.
+        expect(response).not.toHaveProperty('clientId');
+        expect(response).not.toHaveProperty('clientSecret');
+        expect(response?.['username']).toBe('bob');
+
+        postSpy.mockRestore();
+    });
+
+    it('still persists clientId/clientSecret when the integration has nothing preconfigured', async () => {
+        const postSpy = vi.spyOn(axiosInstance, 'post').mockResolvedValue({ status: 200, data: { access_token: 'tok123' }, headers: {} });
+
+        const { success, response } = await connectionService.getTwoStepCredentials(
+            'test-config',
+            provider,
+            { username: 'bob', clientId: 'from-user', clientSecret: 'from-user-secret' },
+            {},
+            false,
+            null
+        );
+
+        expect(success).toBe(true);
+        expect(response?.['clientId']).toBe('from-user');
+        expect(response?.['clientSecret']).toBe('from-user-secret');
+
+        postSpy.mockRestore();
+    });
+});
 
 function makeJwt(payload: Record<string, unknown>): string {
     const header = Buffer.from(JSON.stringify({ alg: 'HS256', typ: 'JWT' })).toString('base64url');

--- a/packages/types/lib/integration/api.ts
+++ b/packages/types/lib/integration/api.ts
@@ -17,6 +17,9 @@ export interface ApiPublicIntegrationInclude {
     // Per-integration, non-secret overrides surfaced to the Connect UI (e.g. the API key field label).
     // Derived server-side from a curated subset of the integration's `custom` config — never the whole object.
     credentials_label?: Record<string, string> | undefined;
+    // Names of `credentials` fields already set at the integration level (via `integration_config`), so the
+    // Connect UI can skip asking end users for them. Presence only — never the underlying value.
+    preconfigured_credentials?: string[] | undefined;
     credentials?:
         | {
               type: AuthModes['OAuth2'] | AuthModes['OAuth1'] | AuthModes['TBA'];


### PR DESCRIPTION
## Describe the problem and your solution

* Allow Sage Intacct client credentials to be defined at the integration level. If they are omitted, prompt the end user to provide their own credentials.
* Use these credentials to generate and refresh tokens.

<!-- Issue ticket number and link (if applicable) -->

<!-- Testing instructions (skip if just adding/editing providers) -->



<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/NangoHQ/nango/pull/6751?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

