### PR TITLE
fix(webapp): persist records docs banner dismissal

### DIFF
--- a/packages/webapp/src/pages/Connection/components/RecordsTab.tsx
+++ b/packages/webapp/src/pages/Connection/components/RecordsTab.tsx
@@ -21,12 +21,12 @@ import { ConnectionTabLayout } from '@/pages/Connection/components/ConnectionTab
 import { useConnectionContext } from '@/pages/Connection/Show';
 import { useStore } from '@/store';
 import { APIError } from '@/utils/api';
+import { LocalStorageKeys } from '@/utils/local-storage';
 import { cn, formatDateToUSFormat } from '@/utils/utils';
 
 import type { ConnectionRecordModel, NangoRecord } from '@nangohq/types';
 
 const RECORDS_DOCS_URL = 'https://nango.dev/docs/implementation-guides/use-cases/syncs/implement-a-sync';
-const RECORDS_DOCS_BANNER_DISMISSED_KEY = 'nango_records_docs_banner_dismissed';
 const RECORDS_PAGE_SIZE = 20;
 const RECORD_ROW_HEIGHT_PX = 44;
 const RECORD_HEADER_HEIGHT_PX = 44;
@@ -37,7 +37,7 @@ export const RecordsTab = () => {
     const navigate = useNavigate();
     const { connectionData, providerConfigKey } = useConnectionContext();
     const { connection } = connectionData;
-    const [isDocsBannerDismissed, setIsDocsBannerDismissed] = useLocalStorage(RECORDS_DOCS_BANNER_DISMISSED_KEY, false);
+    const [isDocsBannerDismissed, setIsDocsBannerDismissed] = useLocalStorage(LocalStorageKeys.RecordsDocsBannerDismissed, false);
 
     const {
         data: models,

--- a/packages/webapp/src/pages/Connection/components/RecordsTab.tsx
+++ b/packages/webapp/src/pages/Connection/components/RecordsTab.tsx
@@ -2,6 +2,7 @@ import { useVirtualizer } from '@tanstack/react-virtual';
 import { ArrowUpRight, ChevronLeft, Info, Loader, X } from 'lucide-react';
 import { useEffect, useLayoutEffect, useMemo, useRef, useState } from 'react';
 import { Link, useNavigate } from 'react-router-dom';
+import { useLocalStorage } from 'react-use';
 
 import { Button, buttonVariants } from '@nangohq/design-system';
 
@@ -25,6 +26,7 @@ import { cn, formatDateToUSFormat } from '@/utils/utils';
 import type { ConnectionRecordModel, NangoRecord } from '@nangohq/types';
 
 const RECORDS_DOCS_URL = 'https://nango.dev/docs/implementation-guides/use-cases/syncs/implement-a-sync';
+const RECORDS_DOCS_BANNER_DISMISSED_KEY = 'nango_records_docs_banner_dismissed';
 const RECORDS_PAGE_SIZE = 20;
 const RECORD_ROW_HEIGHT_PX = 44;
 const RECORD_HEADER_HEIGHT_PX = 44;
@@ -35,7 +37,7 @@ export const RecordsTab = () => {
     const navigate = useNavigate();
     const { connectionData, providerConfigKey } = useConnectionContext();
     const { connection } = connectionData;
-    const [isDocsBannerVisible, setIsDocsBannerVisible] = useState(true);
+    const [isDocsBannerDismissed, setIsDocsBannerDismissed] = useLocalStorage(RECORDS_DOCS_BANNER_DISMISSED_KEY, false);
 
     const {
         data: models,
@@ -59,7 +61,7 @@ export const RecordsTab = () => {
 
                 {!modelsError && !isModelsLoading && models && models.length > 0 && (
                     <>
-                        {isDocsBannerVisible && <RecordsDocsBanner onClose={() => setIsDocsBannerVisible(false)} />}
+                        {!isDocsBannerDismissed && <RecordsDocsBanner onClose={() => setIsDocsBannerDismissed(true)} />}
                         <RecordModelsTable models={models} onSelect={handleSelectModel} />
                     </>
                 )}

--- a/packages/webapp/src/utils/local-storage.tsx
+++ b/packages/webapp/src/utils/local-storage.tsx
@@ -51,7 +51,8 @@ export enum LocalStorageKeys {
     LastEnvironment = 'nango_last_environment',
     Playground = 'nango_playground',
     FeatureFlags = 'nango_feature_flags',
-    Theme = 'nango_theme'
+    Theme = 'nango_theme',
+    RecordsDocsBannerDismissed = 'nango_records_docs_banner_dismissed'
 }
 
 /**
@@ -70,7 +71,8 @@ const KEY_CATEGORY: Record<LocalStorageKeys, 'session' | 'preference'> = {
     [LocalStorageKeys.LastEnvironment]: 'session',
     [LocalStorageKeys.Playground]: 'session',
     [LocalStorageKeys.FeatureFlags]: 'preference',
-    [LocalStorageKeys.Theme]: 'preference'
+    [LocalStorageKeys.Theme]: 'preference',
+    [LocalStorageKeys.RecordsDocsBannerDismissed]: 'preference'
 };
 
 const storage = new LocalStorage();


### PR DESCRIPTION
## Problem

On a connection's Records tab, the "Records are populated by syncs" info banner could be closed but reappeared as soon as the user navigated into a record type and back — and on any page reload. The dismissal lived only in component state, and since the record-list and record-detail views are sibling routes, going back remounted the tab and reset the banner to visible.

## Solution

- Store the banner's dismissed state in localStorage via `useLocalStorage` (already used elsewhere in the webapp) instead of ephemeral `useState`.

Fixes [NAN-6228](https://linear.app/nango/issue/NAN-6228)

## Testing

- Verified live on local dev against the remote dev API: dismissed the banner, navigated into a record model and back, and hard-reloaded the page — the banner stayed dismissed in all cases.
