### PR TITLE
feat: ingest Data Transfer into Orb

### DIFF
--- a/packages/metering/lib/crons/billingEventsS3Export.integration.test.ts
+++ b/packages/metering/lib/crons/billingEventsS3Export.integration.test.ts
@@ -82,9 +82,8 @@ function gen({
             case 'usage.records':
                 return { type, attrs: { ...baseAttributes, model: 'test', syncId: 'test', ...attributes } };
             case 'usage.connections':
-                return { type, attrs: { ...baseAttributes, ...attributes } };
             case 'usage.data_transfer':
-                return { type, attrs: { ...baseAttributes, direction: 'egress', package: 'runner', callsite: 'test', ...attributes } };
+                return { type, attrs: { ...baseAttributes, ...attributes } };
             default:
                 throw new Error(`unsupported event type ${type satisfies never}`);
         }
@@ -176,6 +175,38 @@ const connectionsFixtures: ClickhouseRawUsageEvent[] = [
     gen({ day: targetDay, type: 'usage.connections', accountId: 1, value: 15, attributes: { integrationId: 'b', batchId: connectionsBatch2 } })
 ];
 
+function data_transfer_gen({
+    day,
+    package: pkg,
+    callsite,
+    egressedBytes,
+    ingressedBytes = 0
+}: {
+    day: string;
+    package: string;
+    callsite: string;
+    egressedBytes: number;
+    ingressedBytes?: number;
+}): ClickhouseRawUsageEvent {
+    return gen({ day, type: 'usage.data_transfer', accountId: 1, attributes: { package: pkg, callsite, egressedBytes, ingressedBytes } });
+}
+
+//   (runner, proxy)   egress=1000  → included
+//   (server, proxy)   egress=500   → included
+//   (server, webhook_forward) egress=250 → included
+//   (runner, uncontrolled_fetch) egress=0, ingress=7777 → included pair but egress-only, contributes 0
+//   (server, unlisted)  egress=9999 → excluded (not a billable pair)
+//   (runner, proxy) on otherDay egress=100000 → excluded by WHERE day
+// → count (total egress) = 1000+500+250+0 = 1750.
+const dataTransferFixtures: ClickhouseRawUsageEvent[] = [
+    data_transfer_gen({ day: targetDay, package: 'runner', callsite: 'proxy', egressedBytes: 1000 }),
+    data_transfer_gen({ day: targetDay, package: 'server', callsite: 'proxy', egressedBytes: 500 }),
+    data_transfer_gen({ day: targetDay, package: 'server', callsite: 'webhook_forward', egressedBytes: 250 }),
+    data_transfer_gen({ day: targetDay, package: 'runner', callsite: 'uncontrolled_fetch', egressedBytes: 0, ingressedBytes: 7777 }),
+    data_transfer_gen({ day: targetDay, package: 'server', callsite: 'unlisted', egressedBytes: 9999 }),
+    data_transfer_gen({ day: otherDay, package: 'runner', callsite: 'proxy', egressedBytes: 100000 })
+];
+
 // ---------- tests ----------
 
 describe('billingEventsS3Export', () => {
@@ -194,7 +225,8 @@ describe('billingEventsS3Export', () => {
             ...billableActionsFixtures,
             ...marFixtures,
             ...recordsFixtures,
-            ...connectionsFixtures
+            ...connectionsFixtures,
+            ...dataTransferFixtures
         ]);
         await clickhouse.flush();
     });
@@ -295,6 +327,31 @@ describe('billingEventsS3Export', () => {
             const rows = await runQuery('billable_connections_v2', 'billable_connections_v2_test');
             expect(rows).toHaveLength(1);
             expect(rows[0]!.properties).toEqual({ count: 25 });
+        });
+    });
+
+    // Egress-only, restricted to billable (package, callsite) pairs. `count` is the
+    // total egress across included pairs; each pair also gets its own property.
+    // (server, unlisted)=9999 is excluded; (runner, uncontrolled_fetch) is egress-0
+    // so contributes 0; otherDay row is excluded by WHERE day.
+    describe('data_transfer', () => {
+        it('sums egressed_bytes over billable pairs with per-pair breakdown', async () => {
+            const rows = await runQuery('data_transfer', 'data_transfer_test');
+            expect(rows).toHaveLength(1);
+            expect(rows[0]!.properties).toEqual({
+                count: 1750,
+                'server.get_/records': 0,
+                'runner.proxy': 1000,
+                'server.get_/proxy': 0,
+                'server.proxy': 500,
+                'server.post_/proxy': 0,
+                'runner.uncontrolled_fetch': 0,
+                'server.patch_/proxy': 0,
+                'server.put_/proxy': 0,
+                'server.delete_/proxy': 0,
+                'server.unknown_/proxy': 0,
+                'server.webhook_forward': 250
+            });
         });
     });
 

--- a/packages/metering/lib/crons/billingEventsS3Export.ts
+++ b/packages/metering/lib/crons/billingEventsS3Export.ts
@@ -32,7 +32,15 @@ const DEFAULT_DATABASE = 'usage';
 
 export interface MetricSpec {
     /** Canonical Orb event_name; the suffix is appended at SQL gen time. */
-    canonicalEventName: string;
+    canonicalEventName:
+        | 'proxy'
+        | 'function_executions'
+        | 'data_transfer'
+        | 'webhook_forwards'
+        | 'billable_actions'
+        | 'monthly_active_records'
+        | 'records'
+        | 'billable_connections_v2';
     /**
      * SQL fragment that produces rows shaped:
      *   account_id, day, properties
@@ -141,6 +149,46 @@ export const METRICS: MetricSpec[] = [
             )
             GROUP BY account_id, day
         `
+    },
+    {
+        canonicalEventName: 'data_transfer',
+        // We only bill for egress traffic that can be labeled as DTO.
+        // `count` here is the sum of all egressing bytes matching the where clause;
+        // the per-package-x-callsite-pair properties break that total down into its individual contributors.
+        select: (day, database) => `
+            SELECT
+                account_id, day,
+                map(
+                    'count',                     toFloat64(SUM(egressed_bytes)),
+                    'server.get_/records',       toFloat64(SUMIf(egressed_bytes, package = 'server' AND callsite = 'get_/records')),
+                    'server.get_/proxy',         toFloat64(SUMIf(egressed_bytes, package = 'server' AND callsite = 'get_/proxy')),
+                    'server.post_/proxy',        toFloat64(SUMIf(egressed_bytes, package = 'server' AND callsite = 'post_/proxy')),
+                    'server.patch_/proxy',       toFloat64(SUMIf(egressed_bytes, package = 'server' AND callsite = 'patch_/proxy')),
+                    'server.put_/proxy',         toFloat64(SUMIf(egressed_bytes, package = 'server' AND callsite = 'put_/proxy')),
+                    'server.delete_/proxy',      toFloat64(SUMIf(egressed_bytes, package = 'server' AND callsite = 'delete_/proxy')),
+                    'server.unknown_/proxy',     toFloat64(SUMIf(egressed_bytes, package = 'server' AND callsite = 'unknown_/proxy')),
+                    'server.proxy',              toFloat64(SUMIf(egressed_bytes, package = 'server' AND callsite = 'proxy')),
+                    'server.webhook_forward',    toFloat64(SUMIf(egressed_bytes, package = 'server' AND callsite = 'webhook_forward')),
+                    'runner.proxy',              toFloat64(SUMIf(egressed_bytes, package = 'runner' AND callsite = 'proxy')),
+                    'runner.uncontrolled_fetch', toFloat64(SUMIf(egressed_bytes, package = 'runner' AND callsite = 'uncontrolled_fetch'))
+                ) AS properties
+            FROM ${database}.daily_data_transfer
+            WHERE day = toDate('${day}')
+              AND (package, callsite) IN (
+                  ('server', 'get_/records'),
+                  ('server', 'get_/proxy'),
+                  ('server', 'proxy'),
+                  ('server', 'post_/proxy'),
+                  ('server', 'patch_/proxy'),
+                  ('server', 'put_/proxy'),
+                  ('server', 'delete_/proxy'),
+                  ('server', 'unknown_/proxy'),
+                  ('server', 'webhook_forward'),
+                  ('runner', 'proxy'),
+                  ('runner', 'uncontrolled_fetch')
+              )
+            GROUP BY account_id, day
+        `
     }
 ];
 
@@ -166,6 +214,15 @@ export function billingEventsS3ExportCron(): void {
     });
 }
 
+function addEventNameSuffix(eventName: MetricSpec['canonicalEventName']): string {
+    if (eventName == 'data_transfer') {
+        // data_transfer is a new event and thus doesn't need the suffix to support live traffic cutoff.
+        return eventName;
+    }
+
+    return `${eventName}${eventNameSuffix}`;
+}
+
 export async function exec(): Promise<void> {
     await tracer.trace<Promise<void>>('nango.cron.billingEventsS3Export', async () => {
         logger.info(`Starting`);
@@ -179,7 +236,7 @@ export async function exec(): Promise<void> {
             let anyFailure = false;
             try {
                 for (const metric of METRICS) {
-                    const eventName = `${metric.canonicalEventName}${eventNameSuffix}`;
+                    const eventName = addEventNameSuffix(metric.canonicalEventName);
                     const key = objectKey({ day, eventName });
                     const start = process.hrtime.bigint();
                     // Tracks which step is in flight so a catch can tag the failure


### PR DESCRIPTION
Adds ClickHouse query to extract Data Transfer aggregates and send them to Orb via the billing-events-s3-export path.

<!-- Describe the problem and your solution --> 

<!-- Issue ticket number and link (if applicable) -->

<!-- Testing instructions (skip if just adding/editing providers) -->



<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/NangoHQ/nango/pull/6758?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

