### PR TITLE
perf: speed up deploys

### DIFF
--- a/packages/shared/lib/services/deploy/template.ts
+++ b/packages/shared/lib/services/deploy/template.ts
@@ -45,7 +45,7 @@ export async function deployTemplate({
 
     const remoteBasePathConfig = `${remoteBasePath}/config/${integration.id}`;
 
-    const exists = await getSyncAndActionConfigByParams(environment.id, template.name, deployInfo.integrationId, 'catalog');
+    const exists = await getSyncAndActionConfigByParams(environment.id, template.name, integration, 'catalog');
     if (exists) {
         return Err(new NangoError('template_already_deployed'));
     }

--- a/packages/shared/lib/services/sync/config/config.service.ts
+++ b/packages/shared/lib/services/sync/config/config.service.ts
@@ -283,15 +283,9 @@ export async function getActionsByProviderConfigKey(environment_id: number, uniq
 export async function getSyncAndActionConfigByParams(
     environment_id: number,
     sync_name: string,
-    providerConfigKey: string,
+    providerConfig: ProviderConfig,
     source: FunctionSource
 ): Promise<DBSyncConfig | null> {
-    const config = await configService.getProviderConfig(providerConfigKey, environment_id);
-
-    if (!config) {
-        throw new Error('Provider config not found');
-    }
-
     try {
         const result = await db.knex
             .from<DBSyncConfig>(TABLE)
@@ -299,7 +293,7 @@ export async function getSyncAndActionConfigByParams(
             .where({
                 environment_id,
                 sync_name,
-                nango_config_id: config.id as number,
+                nango_config_id: providerConfig.id!,
                 active: true,
                 deleted: false,
                 source
@@ -318,7 +312,7 @@ export async function getSyncAndActionConfigByParams(
             metadata: {
                 environment_id,
                 sync_name,
-                providerConfigKey
+                providerConfigKey: providerConfig.unique_key
             }
         });
         return null;

--- a/packages/shared/lib/services/sync/config/deploy.service.ts
+++ b/packages/shared/lib/services/sync/config/deploy.service.ts
@@ -2,6 +2,7 @@ import db, { dbNamespace } from '@nangohq/database';
 import { nangoConfigFile } from '@nangohq/nango-yaml';
 import { env, filterJsonSchemaForModels, metrics } from '@nangohq/utils';
 
+import { envs } from '../../../env.js';
 import { NangoError } from '../../../utils/error.js';
 import { resolveLocalFileName } from '../../../utils/utils.js';
 import configService from '../../config.service.js';
@@ -14,6 +15,7 @@ import { scanCompiledDeployScript } from './deployScriptSecurityScan.js';
 
 import type { Orchestrator } from '../../../clients/orchestrator.js';
 import type { ServiceResponse } from '../../../models/Generic.js';
+import type { Config as ProviderConfig } from '../../../models/Provider.js';
 import type { LogContext, LogContextGetter } from '@nangohq/logs';
 import type {
     CleanedIncomingFlowConfig,
@@ -39,6 +41,7 @@ const nameOfType = 'sync/action';
 
 type FlowParsed = CleanedIncomingFlowConfig;
 type FlowWithoutScript = Omit<FlowParsed, 'fileBody'>;
+type CompiledDeployInfo = { idsToMarkAsInactive: number[]; syncConfig: DBSyncConfigInsert };
 
 interface SyncConfigResult {
     result: SyncDeploymentResult[];
@@ -105,44 +108,70 @@ export async function deploy({
     const flowsWithoutScript: FlowWithoutScript[] = [];
     const idsToMarkAsInactive: number[] = [];
     const syncConfigs: DBSyncConfigInsert[] = [];
-    for (const flow of flows) {
-        const { fileBody: _fileBody, ...rest } = flow;
-        flowsWithoutScript.push({ ...rest });
 
-        const { success, error, response } = await compileDeployInfo({
-            flow,
-            aggregatedJsonSchema,
-            env,
-            environment_id: environment.id,
-            account,
-            debug: Boolean(debug),
-            logCtx,
-            orchestrator,
-            sdkVersion,
-            source
-        });
-
-        if (!success || !response) {
-            void logCtx.error(`Failed to deploy script "${flow.syncName}"`, { error });
-            await logCtx.failed();
-            return { success, error, response: null };
+    const providerConfigsByKey = new Map<string, ProviderConfig>();
+    if (flows.length > 0) {
+        const providerConfigs = await configService.listProviderConfigs(db.readOnly, environment.id);
+        for (const providerConfig of providerConfigs) {
+            providerConfigsByKey.set(providerConfig.unique_key, providerConfig);
         }
+    }
 
-        idsToMarkAsInactive.push(...response.idsToMarkAsInactive);
-        syncConfigs.push(response.syncConfig);
-        const deployResult: SyncDeploymentResult = {
-            name: flow.syncName,
-            models: flow.models,
-            version: response.syncConfig.version,
-            providerConfigKey: flow.providerConfigKey,
-            type: flow.type
-        };
+    for (let i = 0; i < flows.length; i += envs.DEPLOY_BATCH_SIZE) {
+        const batch = flows.slice(i, i + envs.DEPLOY_BATCH_SIZE);
+        const batchResults = await Promise.all(
+            batch.map((flow) => {
+                const providerConfig = providerConfigsByKey.get(flow.providerConfigKey);
+                if (!providerConfig) {
+                    const error = new NangoError('unknown_provider_config', { providerConfigKey: flow.providerConfigKey });
+                    void logCtx.error(error.message);
+                    return Promise.resolve<ServiceResponse<CompiledDeployInfo>>({ success: false, error, response: null });
+                }
 
-        if (response.syncConfig.version) {
-            deployResult.version = response.syncConfig.version;
+                return compileDeployInfo({
+                    flow,
+                    providerConfig,
+                    aggregatedJsonSchema,
+                    env,
+                    environment_id: environment.id,
+                    account,
+                    debug: Boolean(debug),
+                    logCtx,
+                    orchestrator,
+                    sdkVersion,
+                    source
+                });
+            })
+        );
+
+        for (const [batchIndex, flow] of batch.entries()) {
+            const { fileBody: _fileBody, ...rest } = flow;
+            flowsWithoutScript.push({ ...rest });
+
+            const { success, error, response } = batchResults[batchIndex]!;
+
+            if (!success || !response) {
+                void logCtx.error(`Failed to deploy script "${flow.syncName}"`, { error });
+                await logCtx.failed();
+                return { success, error, response: null };
+            }
+
+            idsToMarkAsInactive.push(...response.idsToMarkAsInactive);
+            syncConfigs.push(response.syncConfig);
+            const deployResult: SyncDeploymentResult = {
+                name: flow.syncName,
+                models: flow.models,
+                version: response.syncConfig.version,
+                providerConfigKey: flow.providerConfigKey,
+                type: flow.type
+            };
+
+            if (response.syncConfig.version) {
+                deployResult.version = response.syncConfig.version;
+            }
+
+            deployResults.push(deployResult);
         }
-
-        deployResults.push(deployResult);
     }
 
     if (syncConfigs.length === 0) {
@@ -218,6 +247,7 @@ export async function deploy({
 
 async function compileDeployInfo({
     flow,
+    providerConfig,
     aggregatedJsonSchema,
     env,
     environment_id,
@@ -229,6 +259,7 @@ async function compileDeployInfo({
     source
 }: {
     flow: FlowParsed;
+    providerConfig: ProviderConfig;
     /** @deprecated */
     aggregatedJsonSchema?: JSONSchema7 | undefined;
     env: string;
@@ -239,7 +270,7 @@ async function compileDeployInfo({
     orchestrator: Orchestrator;
     sdkVersion: string | undefined;
     source: FunctionSource;
-}): Promise<ServiceResponse<{ idsToMarkAsInactive: number[]; syncConfig: DBSyncConfigInsert }>> {
+}): Promise<ServiceResponse<CompiledDeployInfo>> {
     const {
         syncName,
         providerConfigKey,
@@ -253,16 +284,8 @@ async function compileDeployInfo({
         attributes = {},
         metadata = {}
     } = flow;
-    const config = await configService.getProviderConfig(providerConfigKey, environment_id);
 
-    if (!config) {
-        const error = new NangoError('unknown_provider_config', { providerConfigKey });
-        void logCtx.error(error.message);
-
-        return { success: false, error, response: null };
-    }
-
-    const previousSyncAndActionConfig = await getSyncAndActionConfigByParams(environment_id, syncName, providerConfigKey, source);
+    const previousSyncAndActionConfig = await getSyncAndActionConfigByParams(environment_id, syncName, providerConfig, source);
     let bumpedVersion = '';
 
     if (previousSyncAndActionConfig) {
@@ -304,7 +327,7 @@ async function compileDeployInfo({
     // select all active rows, not just .first(), so any duplicates left by prior races are also cleaned up.
     const activeConfigs = await db.knex
         .from<DBSyncConfig>(TABLE)
-        .where({ environment_id, sync_name: syncName, nango_config_id: config.id as number, type, active: true, deleted: false })
+        .where({ environment_id, sync_name: syncName, nango_config_id: providerConfig.id!, type, active: true, deleted: false })
         .select('id', 'enabled')
         .orderBy('created_at', 'desc');
     const idsToMarkAsInactive: number[] = activeConfigs.map((c) => c.id);
@@ -332,7 +355,7 @@ async function compileDeployInfo({
         return { success: false, error, response: null };
     }
 
-    const jsDestinationPath = `${env}/account/${account.id}/environment/${environment_id}/config/${config.id}/${syncName}-v${targetVersion}.js`;
+    const jsDestinationPath = `${env}/account/${account.id}/environment/${environment_id}/config/${providerConfig.id}/${syncName}-v${targetVersion}.js`;
     const previousJsFileLocation = previousSyncAndActionConfig?.file_location;
     const jsLocalFileName = resolveLocalFileName({ syncName, providerConfigKey });
     // If no previous file location, we consider the file changed no matter what the content is.
@@ -347,7 +370,7 @@ async function compileDeployInfo({
 
     if (typeof fileBody === 'object' && fileBody.ts) {
         const tsFile = fileBody.ts;
-        const tsDestinationPath = `${env}/account/${account.id}/environment/${environment_id}/config/${config.id}/${syncName}.ts`;
+        const tsDestinationPath = `${env}/account/${account.id}/environment/${environment_id}/config/${providerConfig.id}/${syncName}.ts`;
         const tsLocalFileName = `${providerConfigKey}/${flow.type}s/${syncName}.ts`;
         const tsChanged = await remoteFileService.checkIfChanged({ content: fileBody.ts, objectKey: tsDestinationPath });
 
@@ -411,7 +434,7 @@ async function compileDeployInfo({
             syncConfig: {
                 source,
                 environment_id,
-                nango_config_id: config.id as number,
+                nango_config_id: providerConfig.id!,
                 sync_name: syncName,
                 type,
                 models,

--- a/packages/shared/lib/services/sync/config/deploy.service.unit.test.ts
+++ b/packages/shared/lib/services/sync/config/deploy.service.unit.test.ts
@@ -112,7 +112,7 @@ function setupDeployTestMocks({
     const capturedSyncConfigs: Record<string, unknown>[] = [];
     const existingConfig = buildDeployExistingConfig(previousVersion);
 
-    vi.spyOn(configService, 'getProviderConfig').mockResolvedValue(deployMockProviderConfig as any);
+    vi.spyOn(configService, 'listProviderConfigs').mockResolvedValue([deployMockProviderConfig] as any);
     vi.spyOn(SyncConfigService, 'getSyncAndActionConfigByParams').mockResolvedValue(existingConfig);
     vi.spyOn(SyncService, 'getSyncsByProviderConfigKey').mockResolvedValue([]);
     vi.spyOn(db.knex, 'from').mockReturnValue({
@@ -212,9 +212,7 @@ describe('Sync config create', () => {
             }
         ];
 
-        vi.spyOn(configService, 'getProviderConfig').mockImplementation(() => {
-            return Promise.resolve(null);
-        });
+        vi.spyOn(configService, 'listProviderConfigs').mockResolvedValue([]);
 
         const { error } = await DeployConfigService.deploy({
             account,
@@ -260,21 +258,23 @@ describe('Sync config create', () => {
             enrichOperation: vi.fn().mockResolvedValue(undefined)
         } as any);
 
-        vi.spyOn(configService, 'getProviderConfig').mockResolvedValue({
-            id: 1,
-            unique_key: 'google',
-            display_name: null,
-            provider: 'google',
-            oauth_client_id: '123',
-            oauth_client_secret: '123',
-            post_connection_scripts: null,
-            environment_id: 1,
-            created_at: new Date(),
-            updated_at: new Date(),
-            missing_fields: [],
-            forward_webhooks: true,
-            shared_credentials_id: null
-        } as any);
+        vi.spyOn(configService, 'listProviderConfigs').mockResolvedValue([
+            {
+                id: 1,
+                unique_key: 'google',
+                display_name: null,
+                provider: 'google',
+                oauth_client_id: '123',
+                oauth_client_secret: '123',
+                post_connection_scripts: null,
+                environment_id: 1,
+                created_at: new Date(),
+                updated_at: new Date(),
+                missing_fields: [],
+                forward_webhooks: true,
+                shared_credentials_id: null
+            }
+        ] as any);
 
         vi.spyOn(SyncConfigService, 'getSyncAndActionConfigByParams').mockResolvedValue(null);
         vi.spyOn(SyncService, 'getSyncsByProviderConfigKey').mockResolvedValue([]);
@@ -321,21 +321,23 @@ describe('Sync config create', () => {
             }
         ];
 
-        vi.spyOn(configService, 'getProviderConfig').mockResolvedValue({
-            id: 1,
-            unique_key: 'google',
-            display_name: null,
-            provider: 'google',
-            oauth_client_id: '123',
-            oauth_client_secret: '123',
-            post_connection_scripts: null,
-            environment_id: 1,
-            created_at: new Date(),
-            updated_at: new Date(),
-            missing_fields: [],
-            forward_webhooks: true,
-            shared_credentials_id: null
-        } as any);
+        vi.spyOn(configService, 'listProviderConfigs').mockResolvedValue([
+            {
+                id: 1,
+                unique_key: 'google',
+                display_name: null,
+                provider: 'google',
+                oauth_client_id: '123',
+                oauth_client_secret: '123',
+                post_connection_scripts: null,
+                environment_id: 1,
+                created_at: new Date(),
+                updated_at: new Date(),
+                missing_fields: [],
+                forward_webhooks: true,
+                shared_credentials_id: null
+            }
+        ] as any);
 
         vi.spyOn(SyncConfigService, 'getSyncAndActionConfigByParams').mockResolvedValue(null);
         vi.spyOn(SyncService, 'getSyncsByProviderConfigKey').mockResolvedValue([]);
@@ -401,8 +403,8 @@ describe('Sync config create', () => {
             }
         ];
 
-        vi.spyOn(configService, 'getProviderConfig').mockImplementation(() => {
-            return Promise.resolve({
+        vi.spyOn(configService, 'listProviderConfigs').mockResolvedValue([
+            {
                 id: 1,
                 unique_key: 'google',
                 display_name: null,
@@ -416,8 +418,8 @@ describe('Sync config create', () => {
                 missing_fields: [],
                 forward_webhooks: true,
                 shared_credentials_id: null
-            });
-        });
+            }
+        ] as any);
 
         vi.spyOn(SyncConfigService, 'getSyncAndActionConfigsBySyncNameAndConfigId').mockImplementation(() => {
             return Promise.resolve([
@@ -576,7 +578,7 @@ describe('Sync config models_json_schema handling', () => {
     };
 
     function setupInfrastructureMocks(capturedSyncConfigs: any[]) {
-        vi.spyOn(configService, 'getProviderConfig').mockResolvedValue(mockProviderConfig as any);
+        vi.spyOn(configService, 'listProviderConfigs').mockResolvedValue([mockProviderConfig] as any);
         vi.spyOn(SyncConfigService, 'getSyncAndActionConfigByParams').mockResolvedValue(null);
         vi.spyOn(remoteFileService, 'checkIfChanged').mockResolvedValue(true);
         vi.spyOn(remoteFileService, 'upload').mockResolvedValue('https://example.com/file.js' as any);
@@ -923,7 +925,7 @@ describe('Deploy transaction - queued deploys mark previous config inactive', ()
         const { mockTrx, whereInSpy } = buildMockTrx();
         mockDbKnexActiveConfig(mockExistingConfig); // activeConfig.id = 99
 
-        vi.spyOn(configService, 'getProviderConfig').mockResolvedValue(mockProviderConfig as any);
+        vi.spyOn(configService, 'listProviderConfigs').mockResolvedValue([mockProviderConfig] as any);
         vi.spyOn(SyncConfigService, 'getSyncAndActionConfigByParams').mockResolvedValue(mockExistingConfig);
         vi.spyOn(SyncService, 'getSyncsByProviderConfigKey').mockResolvedValue([]);
         vi.spyOn(remoteFileService, 'checkIfChanged').mockResolvedValue(true);
@@ -948,7 +950,7 @@ describe('Deploy transaction - queued deploys mark previous config inactive', ()
         const { mockTrx, whereInSpy } = buildMockTrx();
         mockDbKnexActiveConfig(null);
 
-        vi.spyOn(configService, 'getProviderConfig').mockResolvedValue(mockProviderConfig as any);
+        vi.spyOn(configService, 'listProviderConfigs').mockResolvedValue([mockProviderConfig] as any);
         vi.spyOn(SyncConfigService, 'getSyncAndActionConfigByParams').mockResolvedValue(null);
         vi.spyOn(SyncService, 'getSyncsByProviderConfigKey').mockResolvedValue([]);
         vi.spyOn(remoteFileService, 'checkIfChanged').mockResolvedValue(true);
@@ -974,7 +976,7 @@ describe('Deploy transaction - queued deploys mark previous config inactive', ()
         const { mockTrx } = buildMockTrx(capturedInserts);
         mockDbKnexActiveConfig({ ...mockExistingConfig, enabled: false });
 
-        vi.spyOn(configService, 'getProviderConfig').mockResolvedValue(mockProviderConfig as any);
+        vi.spyOn(configService, 'listProviderConfigs').mockResolvedValue([mockProviderConfig] as any);
         vi.spyOn(SyncConfigService, 'getSyncAndActionConfigByParams').mockResolvedValue({ ...mockExistingConfig, enabled: false });
         vi.spyOn(SyncService, 'getSyncsByProviderConfigKey').mockResolvedValue([]);
         vi.spyOn(remoteFileService, 'checkIfChanged').mockResolvedValue(true);
@@ -1001,7 +1003,7 @@ describe('Deploy transaction - queued deploys mark previous config inactive', ()
         const { mockTrx } = buildMockTrx(capturedInserts);
         mockDbKnexActiveConfig(null);
 
-        vi.spyOn(configService, 'getProviderConfig').mockResolvedValue(mockProviderConfig as any);
+        vi.spyOn(configService, 'listProviderConfigs').mockResolvedValue([mockProviderConfig] as any);
         vi.spyOn(SyncConfigService, 'getSyncAndActionConfigByParams').mockResolvedValue(null);
         vi.spyOn(SyncService, 'getSyncsByProviderConfigKey').mockResolvedValue([]);
         vi.spyOn(remoteFileService, 'checkIfChanged').mockResolvedValue(true);

--- a/packages/utils/lib/environment/parse.ts
+++ b/packages/utils/lib/environment/parse.ts
@@ -534,6 +534,9 @@ export const ENVS = z.object({
     // LIMITS
     MAX_SYNCS_PER_CONNECTION: z.coerce.number().optional().default(100),
 
+    // Deploy
+    DEPLOY_BATCH_SIZE: z.coerce.number().int().positive().optional().default(5),
+
     // PubSub
     NANGO_PUBSUB_TRANSPORT: z.enum(['activemq', 'sns-sqs', 'migration', 'none']).optional().default('none'),
     NANGO_PUBSUB_SNS_SQS_MAX_MESSAGES: z.coerce.number().min(1).max(10).optional().default(10),


### PR DESCRIPTION
with function primitive I am planning to have built-in logic to prevent deploys of functions that haven't changed. However retrofitting this behavior with current deploy logic isn't trivial.
So in order to speed up deploys I have implemented the following low-hanging changes:
- query provider configs only once per deploy instead of twice per flow. For a customers that has 1000 syncs/actions that's 2000 saved queries 🙊 
- batch processing/upload in order to parallelize some of the logic

<!-- Describe the problem and your solution --> 

<!-- Issue ticket number and link (if applicable) -->

<!-- Testing instructions (skip if just adding/editing providers) -->



<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/NangoHQ/nango/pull/6770?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

