### PR TITLE
chore: remove unused connection last_execution_at tracking

### DIFF
--- a/packages/jobs/lib/execution/operations/start.ts
+++ b/packages/jobs/lib/execution/operations/start.ts
@@ -1,6 +1,6 @@
 import tracer from 'dd-trace';
 
-import { connectionService, localFileService, remoteFileService } from '@nangohq/shared';
+import { localFileService, remoteFileService } from '@nangohq/shared';
 import { Err, integrationFilesAreRemote, isCloud, Ok, stringifyError } from '@nangohq/utils';
 
 import { getRuntimeAdapter } from '../../runtime/runtimes.js';
@@ -69,7 +69,6 @@ export async function startScript({
                     throw res.error;
                 }
 
-                await connectionService.trackExecution(nangoProps.nangoConnectionId);
                 return Ok(undefined);
             } catch (err) {
                 span?.setTag('error', err);

--- a/packages/shared/lib/services/connection.service.ts
+++ b/packages/shared/lib/services/connection.service.ts
@@ -2086,15 +2086,6 @@ class ConnectionService {
     async hardDelete(id: number): Promise<number> {
         return await db.knex.from<DBConnection>('_nango_connections').where('id', id).delete();
     }
-
-    async trackExecution(id: number): Promise<Result<void>> {
-        try {
-            await db.knex.from('_nango_connections').where({ id, deleted_at: null }).update({ last_execution_at: db.knex.fn.now() });
-            return Ok(undefined);
-        } catch (err: unknown) {
-            return Err(new NangoError('failed_to_track_execution', { id, error: err }));
-        }
-    }
 }
 
 export function extractResponseHeaderValues(headers: Record<string, any>, entries: string[]): Record<string, string> {


### PR DESCRIPTION
- Remove `connectionService.trackExecution()` and its only call site in the jobs execution start path. The `last_execution_at` column on `_nango_connections` (added in #4266) is updated on every script execution but never read, filtered on, or exposed anywhere — this removes one UPDATE per execution for a value nobody consumes.

The column and its partial index are left in place; dropping them can be a follow-up migration once this has rolled out.

## Test plan

- [x] `tsc -b packages/shared packages/jobs` passes
- [x] Verified no remaining references to `trackExecution`, `last_execution_at`, or the `failed_to_track_execution` error code in the codebase
- [ ] After deploy: confirm executions run normally and no dashboards/ops queries depend on `last_execution_at` freshness

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/NangoHQ/nango/pull/6773?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

