### PR TITLE
chore: monitor how many tasks are dequeued

### DIFF
--- a/packages/orchestrator/lib/clients/processor.ts
+++ b/packages/orchestrator/lib/clients/processor.ts
@@ -3,7 +3,7 @@ import { setTimeout } from 'node:timers/promises';
 import tracer from 'dd-trace';
 import PQueue from 'p-queue';
 
-import { getLogger, stringifyError } from '@nangohq/utils';
+import { getLogger, metrics, stringifyError } from '@nangohq/utils';
 
 import type { OrchestratorClient } from './client.js';
 import type { OrchestratorTask } from './types.js';
@@ -69,6 +69,7 @@ export class OrchestratorProcessor {
                 await setTimeout(1000); // wait for a bit before retrying to avoid hammering the server in case of repetitive errors
                 continue;
             }
+            metrics.distribution(metrics.Types.ORCH_TASKS_DEQUEUED, tasks.value.length, { groupKeyPattern: this.groupKeyPattern });
             for (const task of tasks.value) {
                 const active = tracer.scope().active();
                 const span = tracer.startSpan('processor.process', {

--- a/packages/utils/lib/telemetry/metrics.ts
+++ b/packages/utils/lib/telemetry/metrics.ts
@@ -90,6 +90,7 @@ export enum Types {
     ORCH_TASKS_EXPIRED = 'nango.orch.tasks.expired',
     ORCH_TASKS_CANCELLED = 'nango.orch.tasks.cancelled',
     ORCH_QUEUE_BACKPRESSURE = 'nango.orch.queue.backpressure',
+    ORCH_TASKS_DEQUEUED = 'nango.orch.tasks.dequeued',
 
     TASKS_ENQUEUED = 'nango.tasks.enqueued',
     TASKS_RETRIED = 'nango.tasks.retried',


### PR DESCRIPTION
Monitoring how many tasks are being dequeued in order to study the dequeue rate and figure out if we could decrease the dequeuing rate to reduce the pressure on the orchestrator db

<!-- Describe the problem and your solution --> 

<!-- Issue ticket number and link (if applicable) -->

<!-- Testing instructions (skip if just adding/editing providers) -->



<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/NangoHQ/nango/pull/6774?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

