### PR TITLE
fix(connect-ui): show error instead of infinite loading spinner

### DIFF
--- a/packages/connect-ui/src/components/ErrorFallback.tsx
+++ b/packages/connect-ui/src/components/ErrorFallback.tsx
@@ -4,7 +4,10 @@ import { APIError } from '@/lib/api';
 import { telemetry } from '@/lib/telemetry';
 import { HeaderButtons } from './HeaderButtons';
 
-const ErrorMsg: React.FC<{ error?: unknown }> = ({ error }) => {
+const ErrorMsg: React.FC<{ error?: unknown; message?: string }> = ({ error, message }) => {
+    if (message) {
+        return <div className="p-4 text-error text-center">{message}</div>;
+    }
     if (error instanceof APIError) {
         if (error.details.res.status === 401) {
             return <div className="p-4 text-error text-center">Your session has expired, please refresh the modal</div>;
@@ -13,7 +16,7 @@ const ErrorMsg: React.FC<{ error?: unknown }> = ({ error }) => {
     return <div className="p-4 text-error text-center">An error occurred. Please refresh your page or contact our support.</div>;
 };
 
-export const ErrorFallback: React.FC<{ error?: unknown }> = ({ error }) => {
+export const ErrorFallback: React.FC<{ error?: unknown; message?: string }> = ({ error, message }) => {
     useMount(() => {
         telemetry('view:unknown_error');
     });
@@ -21,7 +24,7 @@ export const ErrorFallback: React.FC<{ error?: unknown }> = ({ error }) => {
         <div className="h-full w-full">
             <HeaderButtons />
             <div className="relative h-full flex flex-col justify-center">
-                <ErrorMsg error={error} />
+                <ErrorMsg error={error} message={message} />
             </div>
         </div>
     );

--- a/packages/connect-ui/src/components/ErrorFallback.tsx
+++ b/packages/connect-ui/src/components/ErrorFallback.tsx
@@ -18,7 +18,9 @@ const ErrorMsg: React.FC<{ error?: unknown; message?: string }> = ({ error, mess
 
 export const ErrorFallback: React.FC<{ error?: unknown; message?: string }> = ({ error, message }) => {
     useMount(() => {
-        telemetry('view:unknown_error');
+        if (!message) {
+            telemetry('view:unknown_error');
+        }
     });
     return (
         <div className="h-full w-full">

--- a/packages/connect-ui/src/views/Home.tsx
+++ b/packages/connect-ui/src/views/Home.tsx
@@ -1,6 +1,6 @@
 import { useQuery } from '@tanstack/react-query';
 import { useNavigate } from '@tanstack/react-router';
-import { useEffect } from 'react';
+import { useEffect, useState } from 'react';
 import { useSearchParam } from 'react-use';
 
 import { ErrorFallback } from '@/components/ErrorFallback';
@@ -14,9 +14,15 @@ import { updateSettings } from '@/lib/updateSettings';
 
 import type { ConnectUIEventSettingsChanged, ConnectUIEventToken } from '@nangohq/frontend';
 
+// Fallback for embedded/iframe use: if a parent frame never postMessages a session token within
+// this delay, assume it never will. Standalone tabs (e.g. a shared "connect link") always carry
+// the token in the URL from the first load, so that case is detected immediately instead.
+const NO_SESSION_TOKEN_TIMEOUT_MS = 10000;
+
 export const Home: React.FC = () => {
     const navigate = useNavigate();
     const { sessionToken, setApiURL, setAuthLink, setSession, setSessionToken, setDetectClosedAuthWindow, setIsEmbedded, setIsPreview } = useGlobal();
+    const [noSessionToken, setNoSessionToken] = useState(false);
 
     const { data, error } = useQuery({ enabled: sessionToken !== null, queryKey: ['sessionToken'], queryFn: getConnectSession });
     const apiURL = useSearchParam('apiURL');
@@ -60,6 +66,8 @@ export const Home: React.FC = () => {
         const inUrl = search.get('session_token');
         if (inUrl) {
             setSessionToken(inUrl);
+        } else if (window.self === window.top) {
+            setNoSessionToken(true);
         }
 
         if (isPreview) {
@@ -91,8 +99,20 @@ export const Home: React.FC = () => {
         }
     }, [data]);
 
+    useEffect(() => {
+        if (sessionToken !== null || noSessionToken) {
+            return;
+        }
+        const timeout = setTimeout(() => setNoSessionToken(true), NO_SESSION_TOKEN_TIMEOUT_MS);
+        return () => clearTimeout(timeout);
+    }, [sessionToken, noSessionToken]);
+
     if (error) {
         return <ErrorFallback error={error} />;
+    }
+
+    if (noSessionToken) {
+        return <ErrorFallback message="This page can't be opened directly. Please start a connection from your application." />;
     }
 
     return <LoadingView />;


### PR DESCRIPTION
## Problem

Opening Connect UI directly with no `session_token` (a bookmark, a shared support link, or just typing the bare domain) left the modal stuck on the loading skeleton forever — no session token ever arrives, so no error was ever set and it silently spins.

## Solution

- Standalone tabs (`window.self === window.top`) always carry the `session_token` in the URL from the first load (e.g. a shared "connect link"), so a missing token there now fails immediately with an error state
- Embedded/iframe integrations get a 10s grace period for the parent's `postMessage` handoff before falling back to the same error state
- Added an optional `message` prop to `ErrorFallback` to support this custom message alongside the existing API-error messages
- The error message UI will be improved as part of [NAN-5614: Redesign Connect UI · Dev implementation](https://linear.app/nango/issue/NAN-5614/redesign-connect-ui-dev-implementation)

Fixes [NAN-6260](https://linear.app/nango/issue/NAN-6260/show-an-error-state-instead-of-an-infinite-loading-spinner-when)

## Testing
- Verified in the browser: standalone tab with no `session_token` now shows the error immediately instead of loading forever
- Verified the existing invalid/expired `session_token` path (401) is unaffected

<img width="536" height="735" alt="image" src="https://github.com/user-attachments/assets/ca7d017b-a8b3-4174-af38-8c70f9b640bb" />