### PR TITLE
perf(auth): opt-in in-memory cache for internal-secret account context

### DIFF
--- a/packages/shared/lib/services/account.service.integration.test.ts
+++ b/packages/shared/lib/services/account.service.integration.test.ts
@@ -404,6 +404,26 @@ describe('Account service', () => {
             expect(incrementSpy).toHaveBeenCalledWith(metrics.Types.AUTH_ACCOUNT_CONTEXT_CACHE, 1, { result: 'hit', mode: 'dry' });
         });
 
+        it('should not refresh fresh entries in dry mode', async () => {
+            setCacheMode('dry');
+            vi.useFakeTimers({ toFake: ['hrtime'] });
+            const incrementSpy = vi.spyOn(metrics, 'increment');
+            const { secret } = await seedEnvironmentWithSecret();
+            const ttlMs = envs.AUTH_ACCOUNT_CONTEXT_CACHE_TTL_MS;
+
+            // t0: miss, entry cached
+            await accountService.getAccountContextByApiKey({ internalSecretKey: secret.secret });
+            // just before expiry: hit recorded, but must NOT reset the entry's TTL
+            vi.advanceTimersByTime(ttlMs - 1000);
+            await accountService.getAccountContextByApiKey({ internalSecretKey: secret.secret });
+            // past the original expiry: 'on' mode would miss here, so dry must record a miss too
+            vi.advanceTimersByTime(2000);
+            incrementSpy.mockClear();
+            await accountService.getAccountContextByApiKey({ internalSecretKey: secret.secret });
+
+            expect(incrementSpy).toHaveBeenCalledWith(metrics.Types.AUTH_ACCOUNT_CONTEXT_CACHE, 1, { result: 'miss', mode: 'dry' });
+        });
+
         it('should not touch the cache when the mode is off', async () => {
             expect(envs.AUTH_ACCOUNT_CONTEXT_CACHE_MODE).toBe('off');
             const incrementSpy = vi.spyOn(metrics, 'increment');

--- a/packages/shared/lib/services/account.service.integration.test.ts
+++ b/packages/shared/lib/services/account.service.integration.test.ts
@@ -2,7 +2,9 @@ import { v4 as uuid } from 'uuid';
 import { afterEach, beforeAll, describe, expect, it, vi } from 'vitest';
 
 import db, { multipleMigrations } from '@nangohq/database';
+import { metrics } from '@nangohq/utils';
 
+import { envs } from '../env.js';
 import { createAccount as createTestAccount } from '../seeders/account.seeder.js';
 import accountService from './account.service.js';
 import customerKeyService from './customerKey.service.js';
@@ -331,6 +333,86 @@ describe('Account service', () => {
         expect(result?.auth).toStrictEqual({
             source: 'api_secret',
             scopes: ['environment:*']
+        });
+    });
+
+    describe('internal secret account context cache', () => {
+        const setCacheMode = (mode: string) => {
+            (envs as { AUTH_ACCOUNT_CONTEXT_CACHE_MODE: string }).AUTH_ACCOUNT_CONTEXT_CACHE_MODE = mode;
+        };
+        const defaultMode = envs.AUTH_ACCOUNT_CONTEXT_CACHE_MODE;
+
+        const seedEnvironmentWithSecret = async () => {
+            const account = await createTestAccount();
+            const environment = await environmentService.createEnvironment(db.knex, { accountId: account.id, name: uuid() });
+            await plans.createPlan(db.knex, { account_id: account.id, name: 'free' });
+            const secret = (await secretService.getDefaultSecretForEnv(db.knex, environment!)).unwrap();
+            return { environment: environment!, secret };
+        };
+
+        afterEach(() => {
+            setCacheMode(defaultMode);
+            vi.useRealTimers();
+        });
+
+        it('should serve from cache within the TTL', async () => {
+            setCacheMode('on');
+            const { environment, secret } = await seedEnvironmentWithSecret();
+
+            const first = await accountService.getAccountContextByApiKey({ internalSecretKey: secret.secret });
+            expect(first?.environment.id).toBe(environment.id);
+
+            // Break the DB lookup; a cached context must still resolve without hitting the DB
+            await db.knex('api_secrets').where({ environment_id: environment.id }).update({ hashed: uuid() });
+
+            const second = await accountService.getAccountContextByApiKey({ internalSecretKey: secret.secret });
+            expect(second?.environment.id).toBe(environment.id);
+            expect(second).toStrictEqual(first);
+        });
+
+        it('should refetch once the cache TTL elapses', async () => {
+            setCacheMode('on');
+            // Fake only hrtime (the cache clock); DB clients keep real timers
+            vi.useFakeTimers({ toFake: ['hrtime'] });
+            const { environment, secret } = await seedEnvironmentWithSecret();
+
+            const first = await accountService.getAccountContextByApiKey({ internalSecretKey: secret.secret });
+            expect(first?.environment.id).toBe(environment.id);
+
+            await db.knex('api_secrets').where({ environment_id: environment.id }).update({ hashed: uuid() });
+            vi.advanceTimersByTime(envs.AUTH_ACCOUNT_CONTEXT_CACHE_TTL_MS + 1);
+
+            const second = await accountService.getAccountContextByApiKey({ internalSecretKey: secret.secret });
+            expect(second).toBeNull();
+        });
+
+        it('should not serve from cache in dry mode but still record hits', async () => {
+            setCacheMode('dry');
+            const incrementSpy = vi.spyOn(metrics, 'increment');
+            const { environment, secret } = await seedEnvironmentWithSecret();
+
+            const first = await accountService.getAccountContextByApiKey({ internalSecretKey: secret.secret });
+            expect(first?.environment.id).toBe(environment.id);
+
+            // The cached entry is fresh, but dry mode must still go to the DB and see the revoked key
+            await db.knex('api_secrets').where({ environment_id: environment.id }).update({ hashed: uuid() });
+
+            const second = await accountService.getAccountContextByApiKey({ internalSecretKey: secret.secret });
+            expect(second).toBeNull();
+
+            expect(incrementSpy).toHaveBeenCalledWith(metrics.Types.AUTH_ACCOUNT_CONTEXT_CACHE, 1, { result: 'miss', mode: 'dry' });
+            expect(incrementSpy).toHaveBeenCalledWith(metrics.Types.AUTH_ACCOUNT_CONTEXT_CACHE, 1, { result: 'hit', mode: 'dry' });
+        });
+
+        it('should not touch the cache when the mode is off', async () => {
+            expect(envs.AUTH_ACCOUNT_CONTEXT_CACHE_MODE).toBe('off');
+            const incrementSpy = vi.spyOn(metrics, 'increment');
+            const { environment, secret } = await seedEnvironmentWithSecret();
+
+            const first = await accountService.getAccountContextByApiKey({ internalSecretKey: secret.secret });
+            expect(first?.environment.id).toBe(environment.id);
+
+            expect(incrementSpy).not.toHaveBeenCalledWith(metrics.Types.AUTH_ACCOUNT_CONTEXT_CACHE, 1, expect.anything());
         });
     });
 

--- a/packages/shared/lib/services/account.service.ts
+++ b/packages/shared/lib/services/account.service.ts
@@ -740,8 +740,12 @@ class AccountService {
         };
 
         if (cacheMode !== 'off') {
-            // The cached instance is shared across requests; callers must not mutate it
-            accountContextLocalCache.set(hash, context);
+            // dry: don't refresh fresh entries — 'on' never reaches this path on a hit, so
+            // refreshing here would inflate the measured hit ratio over what 'on' would serve.
+            if (cacheMode === 'on' || accountContextLocalCache.get(hash) === undefined) {
+                // The cached instance is shared across requests; callers must not mutate it
+                accountContextLocalCache.set(hash, context);
+            }
         }
 
         return context;

--- a/packages/shared/lib/services/account.service.ts
+++ b/packages/shared/lib/services/account.service.ts
@@ -1,6 +1,7 @@
 import db from '@nangohq/database';
-import { Err, FixedSizeMap, flagHasPlan, getLogger, isCloud, metrics, Ok, report } from '@nangohq/utils';
+import { Err, FixedSizeMap, flagHasPlan, getLogger, isCloud, metrics, Ok, report, TTLFixedSizeMap } from '@nangohq/utils';
 
+import { envs } from '../env.js';
 import { LogActionEnum } from '../models/Telemetry.js';
 import { getEncryptionManager } from '../utils/encryption.manager.js';
 import errorManager, { ErrorSourceEnum } from '../utils/error.manager.js';
@@ -21,7 +22,17 @@ import type { Knex } from '@nangohq/database';
 import type { DBAPISecret, DBEnvironment, DBPlan, DBTeam, Result } from '@nangohq/types';
 
 const hashLocalCache = new FixedSizeMap<string, string>(10_000);
+// Serves stale contexts (keys/accounts/plans) for up to the TTL — keep it very short.
+// Full staleness contract: AUTH_ACCOUNT_CONTEXT_CACHE_TTL_MS in @nangohq/utils parse.ts.
+const accountContextLocalCache = new TTLFixedSizeMap<string, AccountContext>(10_000, envs.AUTH_ACCOUNT_CONTEXT_CACHE_TTL_MS);
 const logger = getLogger('AccountService');
+
+function getCachedAccountContext({ hash, mode }: { hash: string | undefined; mode: 'dry' | 'on' }): AccountContext | undefined {
+    // hash is only recorded after a successful lookup, so an unseen (never validated) key can never hit
+    const cached = hash === undefined ? undefined : accountContextLocalCache.get(hash);
+    metrics.increment(metrics.Types.AUTH_ACCOUNT_CONTEXT_CACHE, 1, { result: cached ? 'hit' : 'miss', mode });
+    return cached;
+}
 
 interface AccountContext {
     account: DBTeam;
@@ -646,6 +657,14 @@ class AccountService {
      * environment's internal secret key. Avoids polluting customer_keys.last_used_at.
      */
     private async getAccountContextByInternalSecret(secretKey: string): Promise<AccountContext | null> {
+        const cacheMode = envs.AUTH_ACCOUNT_CONTEXT_CACHE_MODE;
+        if (cacheMode !== 'off') {
+            const cached = getCachedAccountContext({ hash: hashLocalCache.get(secretKey), mode: cacheMode });
+            if (cached !== undefined && cacheMode === 'on') {
+                return cached;
+            }
+        }
+
         const hash = await this.hashSecretWithCache(secretKey);
 
         const row = await db.readOnly
@@ -687,7 +706,7 @@ class AccountService {
         const defaultSecret = getEncryptionManager().decryptAPISecret(row.default_secret);
         const pendingKey = row.pending_secret ? getEncryptionManager().decryptAPISecret(row.pending_secret) : null;
 
-        return {
+        const context: AccountContext = {
             account: {
                 ...row.account,
                 created_at: new Date(row.account.created_at),
@@ -719,6 +738,13 @@ class AccountService {
                 scopes: ['environment:*']
             }
         };
+
+        if (cacheMode !== 'off') {
+            // The cached instance is shared across requests; callers must not mutate it
+            accountContextLocalCache.set(hash, context);
+        }
+
+        return context;
     }
 }
 

--- a/packages/utils/lib/environment/parse.ts
+++ b/packages/utils/lib/environment/parse.ts
@@ -25,7 +25,7 @@ export const ENVS = z.object({
     // in the context: revoked/rotated keys, revoked accounts, plan changes and account metadata all
     // keep resolving from cache for up to this long, so keep it very short while still effective.
     // Read once at startup.
-    AUTH_ACCOUNT_CONTEXT_CACHE_TTL_MS: z.coerce.number().int().optional().default(60_000), // 1 minute
+    AUTH_ACCOUNT_CONTEXT_CACHE_TTL_MS: z.coerce.number().int().positive().optional().default(60_000), // 1 minute
     // 'dry' records hit/miss metrics but every lookup still goes to the DB; 'on' serves hits from the cache.
     AUTH_ACCOUNT_CONTEXT_CACHE_MODE: z.enum(['off', 'dry', 'on']).optional().default('off'),
 

--- a/packages/utils/lib/environment/parse.ts
+++ b/packages/utils/lib/environment/parse.ts
@@ -21,6 +21,13 @@ export const ENVS = z.object({
     LOCAL_NANGO_USER_ID: z.coerce.number().optional(),
     AUTH_ALLOW_SIGNUP: z.stringbool().optional().default(true),
     DEFAULT_USER_ROLE: z.enum(roles).optional().default('administrator'),
+    // In-memory TTL for internal-secret account context lookups. Bounds the staleness of everything
+    // in the context: revoked/rotated keys, revoked accounts, plan changes and account metadata all
+    // keep resolving from cache for up to this long, so keep it very short while still effective.
+    // Read once at startup.
+    AUTH_ACCOUNT_CONTEXT_CACHE_TTL_MS: z.coerce.number().int().optional().default(60_000), // 1 minute
+    // 'dry' records hit/miss metrics but every lookup still goes to the DB; 'on' serves hits from the cache.
+    AUTH_ACCOUNT_CONTEXT_CACHE_MODE: z.enum(['off', 'dry', 'on']).optional().default('off'),
 
     // API
     NANGO_PORT: z.coerce.number().optional().default(3003), // Sync those two ports?

--- a/packages/utils/lib/map.ts
+++ b/packages/utils/lib/map.ts
@@ -26,7 +26,7 @@ export class FixedSizeMap<K, V> {
     private maxSize: number;
 
     constructor(maxSize: number) {
-        if (maxSize <= 0) {
+        if (!Number.isInteger(maxSize) || maxSize <= 0) {
             throw new Error('maxSize must be a positive integer.');
         }
         this.map = new Map<K, V>();
@@ -81,6 +81,9 @@ export class TTLFixedSizeMap<K, V> {
     private ttlNs: bigint;
 
     constructor(maxSize: number, ttlMs: number) {
+        if (!Number.isFinite(ttlMs) || ttlMs < 0) {
+            throw new Error('ttlMs must be a finite, non-negative number.');
+        }
         this.map = new FixedSizeMap(maxSize);
         // trunc: BigInt() throws on non-integers
         this.ttlNs = BigInt(Math.trunc(ttlMs)) * 1_000_000n;

--- a/packages/utils/lib/map.ts
+++ b/packages/utils/lib/map.ts
@@ -69,3 +69,41 @@ export class FixedSizeMap<K, V> {
         return this.map.size;
     }
 }
+
+/**
+ * A FixedSizeMap whose entries also expire after a TTL.
+ *
+ * Expiry uses a monotonic clock, so wall-clock jumps cannot extend or shorten
+ * an entry's life.
+ */
+export class TTLFixedSizeMap<K, V> {
+    private map: FixedSizeMap<K, { value: V; setAtNs: bigint }>;
+    private ttlNs: bigint;
+
+    constructor(maxSize: number, ttlMs: number) {
+        this.map = new FixedSizeMap(maxSize);
+        // trunc: BigInt() throws on non-integers
+        this.ttlNs = BigInt(Math.trunc(ttlMs)) * 1_000_000n;
+    }
+
+    /** Entries written more than the TTL ago are treated as absent and evicted on read. */
+    get(key: K): V | undefined {
+        const entry = this.map.get(key);
+        if (!entry) {
+            return undefined;
+        }
+        if (process.hrtime.bigint() - entry.setAtNs >= this.ttlNs) {
+            this.map.delete(key);
+            return undefined;
+        }
+        return entry.value;
+    }
+
+    set(key: K, value: V): void {
+        this.map.set(key, { value, setAtNs: process.hrtime.bigint() });
+    }
+
+    get size(): number {
+        return this.map.size;
+    }
+}

--- a/packages/utils/lib/map.unit.test.ts
+++ b/packages/utils/lib/map.unit.test.ts
@@ -1,6 +1,6 @@
-import { describe, expect, it } from 'vitest';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 
-import { FixedSizeMap } from './map.js';
+import { FixedSizeMap, TTLFixedSizeMap } from './map.js';
 
 describe('FixedSizeMap', () => {
     describe('basic operations', () => {
@@ -192,5 +192,64 @@ describe('FixedSizeMap', () => {
             expect(map.has('key3')).toBe(false); // evicted
             expect(map.has('key4')).toBe(true);
         });
+    });
+});
+
+describe('TTLFixedSizeMap', () => {
+    beforeEach(() => {
+        vi.useFakeTimers({ toFake: ['hrtime'] });
+    });
+
+    afterEach(() => {
+        vi.useRealTimers();
+    });
+
+    it('should return entries younger than the TTL', () => {
+        const map = new TTLFixedSizeMap<string, number>(10, 60_000);
+        map.set('a', 1);
+        vi.advanceTimersByTime(59_999);
+        expect(map.get('a')).toBe(1);
+    });
+
+    it('should return undefined for missing keys', () => {
+        const map = new TTLFixedSizeMap<string, number>(10, 60_000);
+        expect(map.get('missing')).toBeUndefined();
+    });
+
+    it('should expire and evict entries once the TTL elapses', () => {
+        const map = new TTLFixedSizeMap<string, number>(10, 60_000);
+        map.set('a', 1);
+        vi.advanceTimersByTime(60_000);
+        expect(map.get('a')).toBeUndefined();
+        // The expired read evicted the entry entirely
+        expect(map.size).toBe(0);
+    });
+
+    it('should reset the TTL when an entry is rewritten', () => {
+        const map = new TTLFixedSizeMap<string, number>(10, 60_000);
+        map.set('a', 1);
+        vi.advanceTimersByTime(50_000);
+        map.set('a', 2);
+        vi.advanceTimersByTime(30_000);
+        expect(map.get('a')).toBe(2);
+    });
+
+    it('should accept a non-integer TTL', () => {
+        const map = new TTLFixedSizeMap<string, number>(10, 1500.5);
+        map.set('a', 1);
+        expect(map.get('a')).toBe(1);
+        vi.advanceTimersByTime(1500);
+        expect(map.get('a')).toBeUndefined();
+    });
+
+    it('should evict the least recently written entry at capacity', () => {
+        const map = new TTLFixedSizeMap<string, number>(2, 60_000);
+        map.set('a', 1);
+        map.set('b', 2);
+        map.set('c', 3);
+        expect(map.get('a')).toBeUndefined();
+        expect(map.get('b')).toBe(2);
+        expect(map.get('c')).toBe(3);
+        expect(map.size).toBe(2);
     });
 });

--- a/packages/utils/lib/map.unit.test.ts
+++ b/packages/utils/lib/map.unit.test.ts
@@ -234,6 +234,13 @@ describe('TTLFixedSizeMap', () => {
         expect(map.get('a')).toBe(2);
     });
 
+    it('should throw on invalid maxSize or TTL', () => {
+        expect(() => new TTLFixedSizeMap<string, number>(1.5, 60_000)).toThrow('maxSize must be a positive integer.');
+        expect(() => new TTLFixedSizeMap<string, number>(10, NaN)).toThrow('ttlMs must be a finite, non-negative number.');
+        expect(() => new TTLFixedSizeMap<string, number>(10, Infinity)).toThrow('ttlMs must be a finite, non-negative number.');
+        expect(() => new TTLFixedSizeMap<string, number>(10, -1)).toThrow('ttlMs must be a finite, non-negative number.');
+    });
+
     it('should accept a non-integer TTL', () => {
         const map = new TTLFixedSizeMap<string, number>(10, 1500.5);
         map.set('a', 1);

--- a/packages/utils/lib/telemetry/metrics.ts
+++ b/packages/utils/lib/telemetry/metrics.ts
@@ -6,6 +6,7 @@ export enum Types {
     ACTION_INCOMING_PAYLOAD_SIZE_BYTES = 'nango.action.incoming.payloadSizeBytes',
 
     AUTH_SECRET_KEY_HASH_CACHE = 'nango.auth.secretKeyHashCache',
+    AUTH_ACCOUNT_CONTEXT_CACHE = 'nango.auth.accountContextCache',
     AUTH_GET_ENV_BY_CONNECT_SESSION = 'nango.auth.getEnvByConnectSession',
     AUTH_GET_ENV_BY_SECRET_KEY = 'nango.auth.getEnvBySecretKey',
     AUTH_GET_ENV_BY_SECRET_KEY_SOURCE = 'nango.auth.getEnvBySecretKey.source',


### PR DESCRIPTION
> [!NOTE]
> Drafted pending #6800 (light internal auth context query for persist). Once that merges, this PR will be reworked so the cache wraps `getInternalAuthContext` and stores the narrow context (smaller entries, no secrets retained) instead of the full one.

- Adds an opt-in, per-process TTL cache in front of the internal-secret account-context lookup (persist/runner auth). This lookup runs an uncached 5-table join per request — ~3.3k req/s in production, roughly a third of all main-DB queries, re-authenticating the same small set of internal keys. With the cache on, that should drop to roughly one query per environment per TTL window per pod.
- New `TTLFixedSizeMap` in `@nangohq/utils`: bounded size (composes `FixedSizeMap`) plus TTL expiry on a monotonic clock, expired entries evicted on read.
- Rollout is config-driven and ships inert: `AUTH_ACCOUNT_CONTEXT_CACHE_MODE` defaults to `off`; `dry` records hit/miss metrics (`nango.auth.accountContextCache`) while every lookup still goes to the DB; `on` serves cached hits. `AUTH_ACCOUNT_CONTEXT_CACHE_TTL_MS` (default 60s) bounds staleness.

## Staleness contract

With mode `on`, everything in the cached context — rotated/revoked internal keys, revoked accounts, plan changes, account metadata — keeps resolving for up to the TTL on each pod. The TTL should stay very short while still effective. We expect a non-negligible hit ratio (misses scale with environments × pods per TTL window rather than with request rate), which will be measured while the cache runs in `dry` mode before we serve from it. Only keys that previously passed a successful lookup can ever be served from cache.

## Test plan

- [x] Unit tests for `TTLFixedSizeMap` (TTL expiry, reset on rewrite, size-limit eviction, non-integer TTL)
- [x] Integration tests for all three modes: serves from cache within TTL, refetches after TTL, dry mode records hits but stays on the DB path, off mode never touches the cache
- [x] Verified the serve-from-cache test goes red when the cache is disabled
- [ ] Deploy with default `off` — confirm no behavior change and no `nango.auth.accountContextCache` metric
- [ ] Flip `dry` in production — measure hit ratio for a day
- [ ] Flip `on` — confirm the `api_secrets` join rate and `nango-production-writer` CPU drop

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/NangoHQ/nango/pull/6779?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->



