### PR TITLE
perf(orch): skip dequeue query when group lock is contended

### DIFF
--- a/packages/orchestrator/lib/routes/v1/postDequeue.ts
+++ b/packages/orchestrator/lib/routes/v1/postDequeue.ts
@@ -50,31 +50,38 @@ const handler = (scheduler: Scheduler, eventEmitter: EventEmitter) => {
     return async (_req: EndpointRequest, res: EndpointResponse<PostDequeue>) => {
         const { groupKeyPattern, limit, longPolling } = res.locals.parsedBody;
         const longPollingTimeoutMs = 10_000;
-        const eventId = taskEvents.taskCreated(groupKeyPattern);
+        const deadline = Date.now() + longPollingTimeoutMs;
+        const taskCreatedEventId = taskEvents.taskCreated(groupKeyPattern);
         const cleanupAndRespond = (respond: (res: EndpointResponse<PostDequeue>) => void) => {
             if (timeout) {
                 clearTimeout(timeout);
             }
-            if (onTaskStarted) {
-                eventEmitter.removeListener(eventId, onTaskStarted);
+            if (onTaskCreated) {
+                eventEmitter.removeListener(taskCreatedEventId, onTaskCreated);
             }
             if (!res.writableEnded) {
                 respond(res);
             }
         };
-        const onTaskStarted = () => {
-            cleanupAndRespond(async (res) => {
+
+        const armTimeout = () => setTimeout(() => cleanupAndRespond((res) => res.status(200).send([])), Math.max(0, deadline - Date.now()));
+
+        const onTaskCreated = (): void => {
+            clearTimeout(timeout); // stop the timeout from firing while dequeue is in flight
+            void (async () => {
                 const getTasks = await scheduler.dequeue({ groupKeyPattern, limit });
                 if (getTasks.isErr()) {
-                    res.status(500).json({ error: { code: 'dequeue_failed', message: getTasks.error.message } });
+                    cleanupAndRespond((res) => res.status(500).json({ error: { code: 'dequeue_failed', message: getTasks.error.message } }));
+                } else if (getTasks.value.length > 0) {
+                    cleanupAndRespond((res) => res.status(200).json(getTasks.value));
                 } else {
-                    res.status(200).json(getTasks.value);
+                    // no tasks were dequeued, re-arm the timeout and wait for next event
+                    timeout = armTimeout();
+                    eventEmitter.once(taskCreatedEventId, onTaskCreated);
                 }
-            });
+            })();
         };
-        const timeout = setTimeout(() => {
-            cleanupAndRespond((res) => res.status(200).send([]));
-        }, longPollingTimeoutMs);
+        let timeout = armTimeout();
 
         const getTasks = await scheduler.dequeue({ groupKeyPattern, limit });
         if (getTasks.isErr()) {
@@ -82,7 +89,7 @@ const handler = (scheduler: Scheduler, eventEmitter: EventEmitter) => {
             return;
         }
         if (longPolling && getTasks.value.length === 0) {
-            eventEmitter.once(eventId, onTaskStarted);
+            eventEmitter.once(taskCreatedEventId, onTaskCreated);
             await new Promise((resolve) => resolve(timeout));
         } else {
             cleanupAndRespond((res) => res.status(200).json(getTasks.value));

--- a/packages/scheduler/lib/models/tasks.ts
+++ b/packages/scheduler/lib/models/tasks.ts
@@ -372,9 +372,12 @@ export async function dequeue(db: knex.Knex, { groupKeyPattern, limit }: { group
     try {
         const groupKeyLikePattern = groupKeyPattern.replace(/\*/g, '%');
         const tasks = await db.transaction(async (trx) => {
-            // Acquire a lock to prevent concurrent dequeueing of the same group
-            // in order to ensure max concurrency is respected
-            await trx.raw(`SELECT pg_advisory_xact_lock(?) as "lock_dequeue_${groupKeyPattern}"`, [stringToHash(groupKeyPattern)]);
+            // Try to acquire a lock to prevent concurrent dequeueing of the same group in order to ensure max concurrency is respected.
+            // If it is already held, another process is already dequeueing this group, so we skip the expensive query and return early.
+            const { rows } = await trx.raw<{ rows: { lock: boolean }[] }>(`SELECT pg_try_advisory_xact_lock(?) as lock`, [stringToHash(groupKeyPattern)]);
+            if (!rows?.[0]?.lock) {
+                return [];
+            }
             return (
                 trx
                     // 1. select created tasks that are ready to be started alongside their group


### PR DESCRIPTION
tl;dr:
1. tasks.ts: swaps the blocking pg_advisory_xact_lock for the non-blocking pg_try_advisory_xact_lock. A losing dequeue now returns [] immediately instead of queueing behind the winner and re-running the expensive CTE query against an already-drained group.
2. postDequeue.ts: on an empty wake-up, the long-poll handler re-parks instead of responding with [], avoiding a wasted round-trip and an immediate re-fire by the processor
------------------
Longer version:

Multiple tasks processors dequeuing at the same time and waiting for a task started event would be woken up at the same time and attempt to dequeue tasks. Dequeuing query is gated by a advisory lock that ensures queries are serialized. A 'losing' query though would wait and once unblocked run the same expensive dequeuing query even though the tasks have likely been drained by the 'winning' query.
This thundering herd problem is made worse by jobs scaling up since each instance runs one processor per group_key pattern. (ie: more jobs = more dequeuing request waiting for the same tasks)

With this commit, a 'losing' query isn't waiting anymore (via pg_try_advisory_xact_lock) and request is re-parked to wait for next task created event in order to avoid a round-trip and an immediate firing by the processor.

Risk: leftover tasks (ie: available tasks > limit) might wait until long polling timeout or another processor to fire again. In practice, leftover don't happen and dequeued tasks is always lower than the requested amount of tasks.

<!-- Describe the problem and your solution --> 

<!-- Issue ticket number and link (if applicable) -->

<!-- Testing instructions (skip if just adding/editing providers) -->



<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/NangoHQ/nango/pull/6782?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

