### PR TITLE
refactor(webapp): route all analytics events through typed catalog

### DIFF
--- a/packages/webapp/src/features/Playground/analytics.ts
+++ b/packages/webapp/src/features/Playground/analytics.ts
@@ -1,12 +1,6 @@
-import posthog from 'posthog-js';
+import { track } from '@/utils/analytics';
 
 export type PlaygroundOpenSource = 'header' | 'connection' | 'integration' | 'function';
-
-type AnalyticsProperties = Record<string, string | number | boolean>;
-
-function track(event: string, properties?: AnalyticsProperties) {
-    posthog?.capture(event, properties);
-}
 
 export function trackPlaygroundOpened(source: PlaygroundOpenSource) {
     track('web:playground:opened', { source });

--- a/packages/webapp/src/pages/Account/EmailVerified.tsx
+++ b/packages/webapp/src/pages/Account/EmailVerified.tsx
@@ -53,8 +53,6 @@ export const EmailVerified: React.FC = () => {
 
                 track('web:account_signup', {
                     user_id: user.id,
-                    email: user.email,
-                    name: user.name,
                     accountId: user.accountId
                 });
 

--- a/packages/webapp/src/pages/Account/EmailVerified.tsx
+++ b/packages/webapp/src/pages/Account/EmailVerified.tsx
@@ -7,7 +7,7 @@ import { useSWRConfig } from 'swr';
 import { useToast } from '@/hooks/useToast';
 import DefaultLayout from '@/layout/DefaultLayout';
 import { useStore } from '../../store';
-import { useAnalyticsTrack } from '../../utils/analytics';
+import { track } from '../../utils/analytics';
 import { apiFetch } from '../../utils/api';
 import { useSignin } from '../../utils/user';
 
@@ -19,7 +19,6 @@ export const EmailVerified: React.FC = () => {
     const signin = useSignin();
     const navigate = useNavigate();
     const { toast } = useToast();
-    const analyticsTrack = useAnalyticsTrack();
     const { mutate } = useSWRConfig();
 
     const env = useStore((state) => state.env);
@@ -52,7 +51,7 @@ export const EmailVerified: React.FC = () => {
                 const user: ValidateEmailAndLogin['Success']['user'] = response['user'];
                 const showHearAboutUs = response['showHearAboutUs'] === true;
 
-                analyticsTrack('web:account_signup', {
+                track('web:account_signup', {
                     user_id: user.id,
                     email: user.email,
                     name: user.name,

--- a/packages/webapp/src/pages/Connection/Create.tsx
+++ b/packages/webapp/src/pages/Connection/Create.tsx
@@ -14,7 +14,7 @@ import { useListIntegrations } from '../../hooks/useIntegration';
 import { useUser } from '../../hooks/useUser';
 import DashboardLayout from '../../layout/DashboardLayout';
 import { useStore } from '../../store';
-import { useAnalyticsTrack } from '../../utils/analytics';
+import { track } from '../../utils/analytics';
 import { ConnectionAdvancedConfig } from './components/ConnectionAdvancedConfig';
 import { CreateConnectionSelector } from './components/CreateConnectionSelector';
 
@@ -37,7 +37,6 @@ export type ConnectionFormData = z.infer<typeof schema>;
 export const ConnectionCreate: React.FC = () => {
     const env = useStore((state) => state.env);
     const paramIntegrationId = useSearchParam('integration_id');
-    const analyticsTrack = useAnalyticsTrack();
 
     const { user } = useUser(true);
     const { data: listIntegrationData, isLoading } = useListIntegrations(env);
@@ -90,8 +89,8 @@ export const ConnectionCreate: React.FC = () => {
     }, [provider, form]);
 
     useEffect(() => {
-        analyticsTrack('web:create_connection:viewed');
-    }, [analyticsTrack]);
+        track('web:create_connection:viewed', {});
+    }, []);
 
     useEffect(() => {
         if (paramIntegrationId && listIntegration) {

--- a/packages/webapp/src/pages/Connection/CreateLegacy.tsx
+++ b/packages/webapp/src/pages/Connection/CreateLegacy.tsx
@@ -17,7 +17,7 @@ import { useListIntegrations } from '../../hooks/useIntegration';
 import { useToast } from '../../hooks/useToast';
 import DashboardLayout from '../../layout/DashboardLayout';
 import { useStore } from '../../store';
-import { useAnalyticsTrack } from '../../utils/analytics';
+import { track } from '../../utils/analytics';
 import { useGetHmacAPI } from '../../utils/api';
 import { isCloudProd } from '../../utils/cloud.js';
 import { globalEnv } from '../../utils/env';
@@ -64,7 +64,6 @@ export const ConnectionCreateLegacy: React.FC = () => {
     const [credentialsState, setCredentialsState] = useState<Record<string, string>>({});
     const [assertionOptionState, setAssertionOptionState] = useState<Record<string, string>>({});
     const [issuerId, setIssuerId] = useState('');
-    const analyticsTrack = useAnalyticsTrack();
     const getHmacAPI = useGetHmacAPI(env);
     const { toast } = useToast();
     const providerConfigKey = useSearchParam('providerConfigKey');
@@ -260,7 +259,7 @@ export const ConnectionCreateLegacy: React.FC = () => {
         getConnection
             .then(() => {
                 toast({ variant: 'success', title: 'Connection created!' });
-                analyticsTrack('web:connection_created:legacy', { provider: integration?.provider || 'unknown' });
+                track('web:connection_created:legacy', { provider: integration?.provider || 'unknown' });
                 void mutate((key) => typeof key === 'string' && key.startsWith('/api/v1/connections'), undefined);
                 navigate(`/${env}/connections`, { replace: true });
             })

--- a/packages/webapp/src/pages/Connection/components/CreateConnectionSelector.tsx
+++ b/packages/webapp/src/pages/Connection/components/CreateConnectionSelector.tsx
@@ -255,8 +255,7 @@ export const CreateConnectionSelector: React.FC<CreateConnectionSelectorProps> =
             } else if (event.type === 'error') {
                 track('web:connection_failed', {
                     provider: integration?.provider || 'unknown',
-                    errorType: event.payload.errorType,
-                    errorMessage: event.payload.errorMessage
+                    errorType: event.payload.errorType
                 });
             }
         },

--- a/packages/webapp/src/pages/Connection/components/CreateConnectionSelector.tsx
+++ b/packages/webapp/src/pages/Connection/components/CreateConnectionSelector.tsx
@@ -22,7 +22,7 @@ import { useListIntegrations } from '../../../hooks/useIntegration';
 import { GetUsageQueryKey, useApiGetUsage } from '../../../hooks/usePlan';
 import { useToast } from '../../../hooks/useToast';
 import { useStore } from '../../../store';
-import { useAnalyticsTrack } from '../../../utils/analytics';
+import { track } from '../../../utils/analytics';
 import { globalEnv } from '../../../utils/env';
 import { formatDateToPreciseUSFormat } from '../../../utils/utils';
 import { IntegrationDropdown } from './IntegrationDropdown';
@@ -67,7 +67,6 @@ export const CreateConnectionSelector: React.FC<CreateConnectionSelectorProps> =
     const toast = useToast();
     const navigate = useNavigate();
     const queryClient = useQueryClient();
-    const analyticsTrack = useAnalyticsTrack();
 
     const env = useStore((state) => state.env);
     const { data } = useEnvironment(env);
@@ -176,7 +175,7 @@ export const CreateConnectionSelector: React.FC<CreateConnectionSelectorProps> =
             return;
         }
 
-        analyticsTrack('web:create_connection_button:clicked', {
+        track('web:create_connection_button:clicked', {
             provider: integration?.provider || 'unknown'
         });
 
@@ -208,7 +207,7 @@ export const CreateConnectionSelector: React.FC<CreateConnectionSelectorProps> =
             return;
         }
 
-        analyticsTrack('web:share_connection_link_button:clicked', {
+        track('web:share_connection_link_button:clicked', {
             provider: integration?.provider || 'unknown'
         });
 
@@ -252,16 +251,16 @@ export const CreateConnectionSelector: React.FC<CreateConnectionSelectorProps> =
                 queryClient.invalidateQueries({ queryKey: ['integrations', env] });
                 queryClient.invalidateQueries({ queryKey: GetUsageQueryKey });
                 hasConnected.current = event.payload;
-                analyticsTrack('web:connection_created', { provider: integration?.provider || 'unknown' });
+                track('web:connection_created', { provider: integration?.provider || 'unknown' });
             } else if (event.type === 'error') {
-                analyticsTrack('web:connection_failed', {
+                track('web:connection_failed', {
                     provider: integration?.provider || 'unknown',
                     errorType: event.payload.errorType,
                     errorMessage: event.payload.errorMessage
                 });
             }
         },
-        [toast, queryClient, env, navigate, integration, cache, mutate, analyticsTrack]
+        [toast, queryClient, env, navigate, integration, cache, mutate]
     );
 
     useUnmount(() => {

--- a/packages/webapp/src/pages/GettingStarted/ClassicGettingStarted.tsx
+++ b/packages/webapp/src/pages/GettingStarted/ClassicGettingStarted.tsx
@@ -8,13 +8,12 @@ import { Button } from '@nangohq/design-system';
 import { Tag } from '@/components/ui/Tag';
 import { useToast } from '../../hooks/useToast';
 import DashboardLayout from '../../layout/DashboardLayout';
-import { useAnalyticsTrack } from '../../utils/analytics';
+import { track } from '../../utils/analytics';
 import { globalEnv } from '../../utils/env';
 import { cn } from '../../utils/utils';
 
 let ytLoaded = false;
 export const ClassicGettingStarted: React.FC = () => {
-    const analyticsTrack = useAnalyticsTrack();
     const { toast } = useToast();
     const [hasVideo, setHasVideo] = useState(false);
 
@@ -48,7 +47,7 @@ export const ClassicGettingStarted: React.FC = () => {
 
         setHasVideo(true);
         try {
-            analyticsTrack('web:getting_started:video:play');
+            track('web:getting_started:video:play', {});
             // @ts-expect-error I don't understand
 
             new window.YT.Player('player', {
@@ -67,7 +66,7 @@ export const ClassicGettingStarted: React.FC = () => {
                     onStateChange: (event: { data: number }) => {
                         switch (event.data) {
                             case 0:
-                                analyticsTrack('web:getting_started:video:end');
+                                track('web:getting_started:video:end', {});
                                 break;
                             default:
                                 break;
@@ -106,7 +105,7 @@ export const ClassicGettingStarted: React.FC = () => {
                 <a
                     className="transition-all block border rounded-lg border-border-muted p-7 group hover:border-border-strong hover:shadow-card focus:shadow-card focus:border-border-selected focus:outline-0"
                     href="https://nango.dev/docs/guides/auth/auth-guide"
-                    onClick={() => analyticsTrack('web:getting_started:authorize')}
+                    onClick={() => track('web:getting_started:authorize', {})}
                     target="_blank"
                     rel="noreferrer"
                 >
@@ -132,7 +131,7 @@ export const ClassicGettingStarted: React.FC = () => {
                 <a
                     className="transition-all block border rounded-lg border-border-muted p-7 group hover:border-border-strong hover:shadow-card"
                     href="https://nango.dev/docs/guides/functions/syncs/sync-functions"
-                    onClick={() => analyticsTrack('web:getting_started:read')}
+                    onClick={() => track('web:getting_started:read', {})}
                     target="_blank"
                     rel="noreferrer"
                 >
@@ -158,7 +157,7 @@ export const ClassicGettingStarted: React.FC = () => {
                 <a
                     className="transition-all block border rounded-lg border-border-muted p-7 group hover:border-border-strong hover:shadow-card"
                     href="https://nango.dev/docs/guides/functions/action-functions"
-                    onClick={() => analyticsTrack('web:getting_started:perform')}
+                    onClick={() => track('web:getting_started:perform', {})}
                     target="_blank"
                     rel="noreferrer"
                 >
@@ -184,7 +183,7 @@ export const ClassicGettingStarted: React.FC = () => {
                 <a
                     className="transition-all block border rounded-lg border-border-muted p-7 group hover:border-border-strong hover:shadow-card"
                     href="https://nango.dev/docs/guides/functions/functions-guide"
-                    onClick={() => analyticsTrack('web:getting_started:custom')}
+                    onClick={() => track('web:getting_started:custom', {})}
                     target="_blank"
                     rel="noreferrer"
                 >

--- a/packages/webapp/src/pages/GettingStarted/Show.tsx
+++ b/packages/webapp/src/pages/GettingStarted/Show.tsx
@@ -8,14 +8,13 @@ import { patchGettingStarted, useGettingStarted } from '../../hooks/useGettingSt
 import { useToast } from '../../hooks/useToast';
 import DashboardLayout from '../../layout/DashboardLayout';
 import { useStore } from '../../store';
-import { useAnalyticsTrack } from '../../utils/analytics';
+import { track } from '../../utils/analytics';
 import VerticalSteps from './components/VerticalSteps';
 import { FirstStep } from './FirstStep';
 import { SecondStep } from './SecondStep';
 import { ThirdStep } from './ThirdStep';
 
 export const GettingStarted: React.FC = () => {
-    const analyticsTrack = useAnalyticsTrack();
     const env = useStore((state) => state.env);
     const { data: gettingStartedResult, error, refetch, isLoading } = useGettingStarted(env);
     const gettingStarted = gettingStartedResult?.data;
@@ -70,10 +69,10 @@ export const GettingStarted: React.FC = () => {
                                 <FirstStep
                                     connection={gettingStarted?.connection ?? null}
                                     integration={gettingStarted?.meta.integration ?? null}
-                                    onConnectClicked={() => analyticsTrack('web:getting_started:connect-clicked')}
+                                    onConnectClicked={() => track('web:getting_started:connect-clicked', {})}
                                     onConnected={async (connectionId) => {
                                         try {
-                                            analyticsTrack('web:getting_started:connection-created');
+                                            track('web:getting_started:connection-created', {});
                                             const { res } = await patchGettingStarted(env, { connection_id: connectionId, step: 1 });
                                             if (!res.ok) {
                                                 throw new Error('Failed to patch getting started');
@@ -85,7 +84,7 @@ export const GettingStarted: React.FC = () => {
                                     }}
                                     onDisconnected={async () => {
                                         try {
-                                            analyticsTrack('web:getting_started:connection-disconnected');
+                                            track('web:getting_started:connection-disconnected', {});
                                             await refetch();
                                         } catch {
                                             toast({ title: 'Something went wrong with the getting started flow', variant: 'error' });
@@ -103,7 +102,7 @@ export const GettingStarted: React.FC = () => {
                                     providerConfigKey={gettingStarted?.meta.integration?.unique_key}
                                     onExecuted={async () => {
                                         try {
-                                            analyticsTrack('web:getting_started:code-snippet-executed');
+                                            track('web:getting_started:code-snippet-executed', {});
                                             const { res } = await patchGettingStarted(env, { step: 2 });
                                             if (!res.ok) {
                                                 throw new Error('Failed to patch getting started');
@@ -123,7 +122,7 @@ export const GettingStarted: React.FC = () => {
                                       id: 'go-deeper',
                                       icon: PartyPopper,
                                       branded: true,
-                                      content: <ThirdStep onSetupIntegrationClicked={() => analyticsTrack('web:getting_started:setup-integration-clicked')} />
+                                      content: <ThirdStep onSetupIntegrationClicked={() => track('web:getting_started:setup-integration-clicked', {})} />
                                   }
                               ]
                             : [])

--- a/packages/webapp/src/pages/Onboarding/HearAboutUs.tsx
+++ b/packages/webapp/src/pages/Onboarding/HearAboutUs.tsx
@@ -7,7 +7,7 @@ import { Button } from '@nangohq/design-system';
 import { Skeleton } from '@/components/ui/Skeleton';
 import { useOnboardingHearAboutUs, usePostOnboardingHearAboutUs } from '../../hooks/useAuth';
 import DefaultLayout from '../../layout/DefaultLayout';
-import { useAnalyticsTrack } from '../../utils/analytics';
+import { track } from '../../utils/analytics';
 
 import type { PostOnboardingHearAboutUs } from '@nangohq/types';
 
@@ -23,7 +23,6 @@ const HEAR_ABOUT_OPTIONS: { label: string; value: PostOnboardingHearAboutUs['Bod
 
 export const HearAboutUs: React.FC = () => {
     const navigate = useNavigate();
-    const analyticsTrack = useAnalyticsTrack();
 
     const { data, isLoading, error } = useOnboardingHearAboutUs();
     const { mutateAsync: postHearAboutUs, isPending } = usePostOnboardingHearAboutUs();
@@ -39,7 +38,7 @@ export const HearAboutUs: React.FC = () => {
     }, [data, error, navigate]);
 
     const submit = async (source: PostOnboardingHearAboutUs['Body']['source']) => {
-        analyticsTrack('signup_hear_about', { source });
+        track('web:signup:hear_about', { source });
         try {
             await postHearAboutUs({ source });
         } finally {

--- a/packages/webapp/src/utils/analytics.tsx
+++ b/packages/webapp/src/utils/analytics.tsx
@@ -6,19 +6,11 @@ import type { ApiUser } from '@nangohq/types';
 
 /**
  * Typed, catalog-checked event tracking. Uses the `posthog` singleton so it works inside and
- * outside React components. Prefer this over `useAnalyticsTrack` for new events: the event name
- * and properties are validated against {@link AnalyticsEvents} at compile time.
+ * outside React components. The event name and properties are validated against
+ * {@link AnalyticsEvents} at compile time.
  */
 export function track<E extends keyof AnalyticsEvents>(event: E, properties: AnalyticsEvents[E]) {
     posthog?.capture(event, properties);
-}
-
-export function useAnalyticsTrack() {
-    const posthog = usePostHog();
-
-    return (event: string, properties?: Record<string, string | number>) => {
-        posthog?.capture(event, properties);
-    };
 }
 
 export function useAnalyticsIdentify() {

--- a/packages/webapp/src/utils/analyticsEvents.ts
+++ b/packages/webapp/src/utils/analyticsEvents.ts
@@ -42,7 +42,8 @@ export interface AnalyticsEvents {
     'web:share_connection_link_button:clicked': { provider: string };
     'web:connection_created': { provider: string };
     'web:connection_created:legacy': { provider: string };
-    'web:connection_failed': { provider: string; errorType: string; errorMessage: string };
+    // errorType is a bounded code; the raw provider errorMessage is intentionally not sent (can contain PII/credentials).
+    'web:connection_failed': { provider: string; errorType: string };
 
     // Getting started
     'web:getting_started:connect-clicked': Record<string, never>;
@@ -58,6 +59,7 @@ export interface AnalyticsEvents {
     'web:getting_started:custom': Record<string, never>;
 
     // Account & onboarding
-    'web:account_signup': { user_id: number; email: string; name: string; accountId: number };
+    // email/name are intentionally not sent — identify() already attaches them as PostHog person properties.
+    'web:account_signup': { user_id: number; accountId: number };
     'web:signup:hear_about': { source: PostOnboardingHearAboutUs['Body']['source'] };
 }

--- a/packages/webapp/src/utils/analyticsEvents.ts
+++ b/packages/webapp/src/utils/analyticsEvents.ts
@@ -1,5 +1,5 @@
 import type { AnyBreakdownDimension } from '@/pages/Team/Billing/usageBreakdown';
-import type { UsageMetric } from '@nangohq/types';
+import type { PostOnboardingHearAboutUs, UsageMetric } from '@nangohq/types';
 
 /**
  * The app-wide catalog of product-analytics events and their property shapes. Each key is a
@@ -7,11 +7,12 @@ import type { UsageMetric } from '@nangohq/types';
  * `track` (utils/analytics.tsx) is typed against this map, so event names and properties are
  * checked at compile time and every tracked event is listed in one place.
  *
- * Usage-page events are the first entries; add new events here as they're introduced.
+ * Add new events here as they're introduced.
  *
  * Property values must be PostHog-serializable primitives (string | number | boolean).
  */
 export interface AnalyticsEvents {
+    // Usage page (Billing)
     'web:usage:viewed': Record<string, never>;
     'web:usage:month_changed': { direction: 'previous' | 'next' };
     'web:usage:grouped': { metric: UsageMetric; dimension: AnyBreakdownDimension };
@@ -28,4 +29,35 @@ export interface AnalyticsEvents {
     'web:usage:series_toggled': { metric: UsageMetric };
     'web:usage:invoice_details_clicked': Record<string, never>;
     'web:usage:billing_portal_clicked': Record<string, never>;
+
+    // Playground
+    'web:playground:opened': { source: 'header' | 'connection' | 'integration' | 'function' };
+    'web:playground:run:clicked': { function_type: string; integration: string; is_run_again: boolean };
+    'web:playground:run:completed': { function_type: string; integration: string; success: boolean; state: string; duration_ms: number };
+    'web:playground:run:cancelled': { function_type: string; integration: string };
+
+    // Connection creation
+    'web:create_connection:viewed': Record<string, never>;
+    'web:create_connection_button:clicked': { provider: string };
+    'web:share_connection_link_button:clicked': { provider: string };
+    'web:connection_created': { provider: string };
+    'web:connection_created:legacy': { provider: string };
+    'web:connection_failed': { provider: string; errorType: string; errorMessage: string };
+
+    // Getting started
+    'web:getting_started:connect-clicked': Record<string, never>;
+    'web:getting_started:connection-created': Record<string, never>;
+    'web:getting_started:connection-disconnected': Record<string, never>;
+    'web:getting_started:code-snippet-executed': Record<string, never>;
+    'web:getting_started:setup-integration-clicked': Record<string, never>;
+    'web:getting_started:video:play': Record<string, never>;
+    'web:getting_started:video:end': Record<string, never>;
+    'web:getting_started:authorize': Record<string, never>;
+    'web:getting_started:read': Record<string, never>;
+    'web:getting_started:perform': Record<string, never>;
+    'web:getting_started:custom': Record<string, never>;
+
+    // Account & onboarding
+    'web:account_signup': { user_id: number; email: string; name: string; accountId: number };
+    'web:signup:hear_about': { source: PostOnboardingHearAboutUs['Body']['source'] };
 }

--- a/packages/webapp/src/utils/analyticsEvents.ts
+++ b/packages/webapp/src/utils/analyticsEvents.ts
@@ -42,7 +42,6 @@ export interface AnalyticsEvents {
     'web:share_connection_link_button:clicked': { provider: string };
     'web:connection_created': { provider: string };
     'web:connection_created:legacy': { provider: string };
-    // errorType is a bounded code; the raw provider errorMessage is intentionally not sent (can contain PII/credentials).
     'web:connection_failed': { provider: string; errorType: string };
 
     // Getting started
@@ -59,7 +58,6 @@ export interface AnalyticsEvents {
     'web:getting_started:custom': Record<string, never>;
 
     // Account & onboarding
-    // email/name are intentionally not sent — identify() already attaches them as PostHog person properties.
     'web:account_signup': { user_id: number; accountId: number };
     'web:signup:hear_about': { source: PostOnboardingHearAboutUs['Body']['source'] };
 }


### PR DESCRIPTION
## Problem

After NAN-6180, only the usage-page events were on the typed analytics catalog. The rest of the webapp still tracked events through two older, untyped paths — the loose `useAnalyticsTrack()` hook (any string, no property typing) and the Playground module's own `track()` helper. Event names and properties could drift with no compile-time signal, and there was no single place listing what's tracked.

## Solution

- Add all Playground, connection-create, getting-started, and account/onboarding events to the `AnalyticsEvents` catalog with typed properties.
- Have the Playground module delegate to the shared `track()` and drop its local helper.
- Replace every `useAnalyticsTrack()` call site with `track()`, then remove the loose `useAnalyticsTrack` hook. `useAnalyticsIdentify` / `useAnalyticsReset` are unchanged.
- Rename `signup_hear_about` → `web:signup:hear_about` to follow the `web:<area>:<action>` convention. This changes the emitted event name, so PostHog history under the old name won't carry over.

Fixes [NAN-6241](https://linear.app/nango/issue/NAN-6241)

## Testing

- `npm run ts-build` clean; lint diagnostics identical to the master baseline (no new issues).
- Verified live on dev that both migration patterns still fire: the Playground module emits `web:playground:opened {source:"header"}`, and a getting-started call site emits `web:getting_started:connect-clicked {}`. The remaining migrated events use the same `track()` mechanism and are type-checked against the catalog.
