### PR TITLE
docs: add MCP Auth guide

### DIFF
--- a/docs/docs.json
+++ b/docs/docs.json
@@ -694,7 +694,8 @@
                   "guides/auth/share-connect-link",
                   "guides/auth/connection-tags-configuration-metadata",
                   "guides/auth/customize-connect-ui",
-                  "guides/auth/token-refreshing"
+                  "guides/auth/token-refreshing",
+                  "guides/auth/mcp-auth"
                 ]
               },
               {

--- a/docs/guides/auth/mcp-auth.mdx
+++ b/docs/guides/auth/mcp-auth.mdx
@@ -1,0 +1,62 @@
+---
+title: 'MCP Auth'
+sidebarTitle: 'MCP Auth'
+description: 'Let your users connect to MCP servers through Nango'
+---
+
+MCP Auth lets your application authorize end users to access external MCP servers, such as Notion MCP, Linear MCP, or HubSpot MCP, so you can call those servers’ tools on behalf of each user.
+
+Nango handles OAuth with the MCP provider and stores the tokens. You can then use the connection to call the MCP server via Nango’s [proxy](/reference/backend/http-api/proxy/post).
+
+## Two ways to use MCP Auth
+
+| Type | Use case | Examples |
+|------|----------|----------|
+| **Catalog MCP servers** | Official MCP servers listed in [Nango's catalog](https://nango.dev/api-integrations?category=mcp) | [HubSpot (MCP)](/api-integrations/hubspot-mcp), [Notion MCP](/api-integrations/notion-mcp), [Linear MCP](/api-integrations/linear-mcp) |
+| **Generic MCP Server OAuth2** | Let your users connect any server that supports the [MCP Protocol](https://modelcontextprotocol.io/specification/draft). | Custom servers |
+
+If you are missing a catalog MCP servers you can [request it](/integrations/contribute-or-request-api).
+
+## How to use it
+
+### Catalog MCP servers
+
+1. **Create the integration**  
+   In the Nango UI: [Integrations](https://app.nango.dev/dev/integrations) → _Configure New Integration_ → choose the MCP provider (e.g. _HubSpot (MCP)_, _Notion MCP_).  
+   Some providers, for example HubSpot MCP, require you to [register an MCP auth app](/api-integrations/hubspot-mcp/how-to-register-your-own-hubspot-mcp-api-oauth-app) and add **Client ID** and **Client Secret** in Nango. But most support dynamic client registrations: You can just enable them on Nango, and Nango registers a client for you in the background.
+
+2. **Run the same auth flow as standard OAuth**  
+   - Backend: [create a Connect session](/guides/auth/auth-guide#generate-session-token) with `allowed_integrations: ['<integration-id>']` (e.g. `hubspot-mcp`, `notion-mcp`).  
+   - Frontend: [open the Connect UI](/guides/auth/auth-guide#trigger-auth-flow) with the session token.  
+   - Backend: [persist the connection ID](/guides/auth/auth-guide#save-connection-id-from-webhook) from the auth webhook or Connect UI callback.
+
+3. **Call the MCP server**  
+   Use the stored `connection_id` and integration id (e.g. `hubspot-mcp`) with the [Proxy API](/reference/backend/http-api/proxy/post) (JSON-RPC `tools/call`, etc.).
+
+### Generic MCP Server OAuth2
+
+1. **Create a generic MCP integration**  
+   [Integrations](https://app.nango.dev/dev/integrations) → _Configure New Integration_ → _MCP Server OAuth2 (Generic)_. Optionally set **OAuth Client Name**, **URI**, and **Logo URI** (used in dynamic client registration with the MCP server).
+
+2. **Same Connect session + Connect UI flow**  
+   As above: backend creates a session with `allowed_integrations: ['mcp-generic']` (or your custom integration id), frontend opens Connect UI with that token, backend stores the connection ID.
+
+3. **End user supplies the MCP server URL**  
+   When the user starts the connection, the Connect UI prompts for **MCP Server URL** (e.g. `https://mcp.notion.com/mcp`). Nango automatically discovers the OAuth endpoints from the server and walks the user through the OAuth connection flow.
+
+4. **Call the MCP server**  
+   Same as pre-built: use the connection with the [Proxy API](/reference/backend/http-api/proxy/post). The connection is tied to the MCP server URL the user entered.
+
+<Info>
+Our generic MCP provider currently only works with MCP servers that support automatic client registration (DCR, or CIMD).
+</Info>
+
+## End user experience
+
+- **Catalog MCP servers**  
+  User sees a list of supported MCP servers in your app → clicks connect → is redirected to the provider’s OAuth page (e.g. HubSpot or Notion) → signs in and approves → connection is created in Nango
+
+- **MCP Generic**  
+  User clicks connect → sees a form asking for the MCP Server URL → submits → is redirected to that MCP server’s OAuth page → signs in and approves → connection is created in Nango
+
+In both cases, your app only needs to open the Connect UI and pass the session token. Nango handles the rest.

--- a/docs/guides/auth/mcp-auth.mdx
+++ b/docs/guides/auth/mcp-auth.mdx
@@ -15,7 +15,7 @@ Nango handles OAuth with the MCP provider and stores the tokens. You can then us
 | **Catalog MCP servers** | Official MCP servers listed in [Nango's catalog](https://nango.dev/api-integrations?category=mcp) | [HubSpot (MCP)](/api-integrations/hubspot-mcp), [Notion MCP](/api-integrations/notion-mcp), [Linear MCP](/api-integrations/linear-mcp) |
 | **Generic MCP Server OAuth2** | Let your users connect any server that supports the [MCP Protocol](https://modelcontextprotocol.io/specification/draft). | Custom servers |
 
-If you are missing a catalog MCP servers you can [request it](/integrations/contribute-or-request-api).
+If you are missing a catalog MCP server you can [request it](/integrations/contribute-or-request-api).
 
 ## How to use it
 

--- a/docs/llms-full.txt
+++ b/docs/llms-full.txt
@@ -2073,7 +2073,7 @@ Nango handles OAuth with the MCP provider and stores the tokens. You can then us
 | **Catalog MCP servers** | Official MCP servers listed in [Nango's catalog](https://nango.dev/api-integrations?category=mcp) | [HubSpot (MCP)](/api-integrations/hubspot-mcp), [Notion MCP](/api-integrations/notion-mcp), [Linear MCP](/api-integrations/linear-mcp) |
 | **Generic MCP Server OAuth2** | Let your users connect any server that supports the [MCP Protocol](https://modelcontextprotocol.io/specification/draft). | Custom servers |
 
-If you are missing a catalog MCP servers you can [request it](/integrations/contribute-or-request-api).
+If you are missing a catalog MCP server you can [request it](/integrations/contribute-or-request-api).
 
 ## How to use it
 

--- a/docs/llms-full.txt
+++ b/docs/llms-full.txt
@@ -2057,6 +2057,68 @@ Revoked access tokens and refresh failures happen to all integrations. To handle
 **Questions, problems, feedback?** Please reach out in the [Slack community](https://nango.dev/slack).
 </Tip>
 
+## MCP Auth
+
+Source: https://nango.dev/docs/guides/auth/mcp-auth.md
+Description: Let your users connect to MCP servers through Nango
+
+MCP Auth lets your application authorize end users to access external MCP servers, such as Notion MCP, Linear MCP, or HubSpot MCP, so you can call those servers’ tools on behalf of each user.
+
+Nango handles OAuth with the MCP provider and stores the tokens. You can then use the connection to call the MCP server via Nango’s [proxy](/reference/backend/http-api/proxy/post).
+
+## Two ways to use MCP Auth
+
+| Type | Use case | Examples |
+|------|----------|----------|
+| **Catalog MCP servers** | Official MCP servers listed in [Nango's catalog](https://nango.dev/api-integrations?category=mcp) | [HubSpot (MCP)](/api-integrations/hubspot-mcp), [Notion MCP](/api-integrations/notion-mcp), [Linear MCP](/api-integrations/linear-mcp) |
+| **Generic MCP Server OAuth2** | Let your users connect any server that supports the [MCP Protocol](https://modelcontextprotocol.io/specification/draft). | Custom servers |
+
+If you are missing a catalog MCP servers you can [request it](/integrations/contribute-or-request-api).
+
+## How to use it
+
+### Catalog MCP servers
+
+1. **Create the integration**  
+   In the Nango UI: [Integrations](https://app.nango.dev/dev/integrations) → _Configure New Integration_ → choose the MCP provider (e.g. _HubSpot (MCP)_, _Notion MCP_).  
+   Some providers, for example HubSpot MCP, require you to [register an MCP auth app](/api-integrations/hubspot-mcp/how-to-register-your-own-hubspot-mcp-api-oauth-app) and add **Client ID** and **Client Secret** in Nango. But most support dynamic client registrations: You can just enable them on Nango, and Nango registers a client for you in the background.
+
+2. **Run the same auth flow as standard OAuth**  
+   - Backend: [create a Connect session](/guides/auth/auth-guide#generate-session-token) with `allowed_integrations: ['<integration-id>']` (e.g. `hubspot-mcp`, `notion-mcp`).  
+   - Frontend: [open the Connect UI](/guides/auth/auth-guide#trigger-auth-flow) with the session token.  
+   - Backend: [persist the connection ID](/guides/auth/auth-guide#save-connection-id-from-webhook) from the auth webhook or Connect UI callback.
+
+3. **Call the MCP server**  
+   Use the stored `connection_id` and integration id (e.g. `hubspot-mcp`) with the [Proxy API](/reference/backend/http-api/proxy/post) (JSON-RPC `tools/call`, etc.).
+
+### Generic MCP Server OAuth2
+
+1. **Create a generic MCP integration**  
+   [Integrations](https://app.nango.dev/dev/integrations) → _Configure New Integration_ → _MCP Server OAuth2 (Generic)_. Optionally set **OAuth Client Name**, **URI**, and **Logo URI** (used in dynamic client registration with the MCP server).
+
+2. **Same Connect session + Connect UI flow**  
+   As above: backend creates a session with `allowed_integrations: ['mcp-generic']` (or your custom integration id), frontend opens Connect UI with that token, backend stores the connection ID.
+
+3. **End user supplies the MCP server URL**  
+   When the user starts the connection, the Connect UI prompts for **MCP Server URL** (e.g. `https://mcp.notion.com/mcp`). Nango automatically discovers the OAuth endpoints from the server and walks the user through the OAuth connection flow.
+
+4. **Call the MCP server**  
+   Same as pre-built: use the connection with the [Proxy API](/reference/backend/http-api/proxy/post). The connection is tied to the MCP server URL the user entered.
+
+<Info>
+Our generic MCP provider currently only works with MCP servers that support automatic client registration (DCR, or CIMD).
+</Info>
+
+## End user experience
+
+- **Catalog MCP servers**  
+  User sees a list of supported MCP servers in your app → clicks connect → is redirected to the provider’s OAuth page (e.g. HubSpot or Notion) → signs in and approves → connection is created in Nango
+
+- **MCP Generic**  
+  User clicks connect → sees a form asking for the MCP Server URL → submits → is redirected to that MCP server’s OAuth page → signs in and approves → connection is created in Nango
+
+In both cases, your app only needs to open the Connect UI and pass the session token. Nango handles the rest.
+
 ## Functions guide
 
 Source: https://nango.dev/docs/guides/functions/functions-guide.md

--- a/docs/llms.txt
+++ b/docs/llms.txt
@@ -30,6 +30,7 @@ Use provider URLs by replacing `{slug}` with a slug from the API catalog:
 - [Auth: Connection tags, configuration, and metadata](https://nango.dev/docs/guides/auth/connection-tags-configuration-metadata.md): Use tags, connection configuration, and metadata for the right connection-level data.
 - [Auth: Customize Connect UI](https://nango.dev/docs/guides/auth/customize-connect-ui.md): Guide to branding Nango Connect UI, overriding setup links, or building a headless auth flow with your own UI.
 - [Auth: Token refreshing & validity](https://nango.dev/docs/guides/auth/token-refreshing.md): How Nango handles OAuth token refresh and what to do when tokens are revoked.
+- [Auth: MCP Auth](https://nango.dev/docs/guides/auth/mcp-auth.md): Let your users connect to MCP servers through Nango
 - [Functions: Functions guide](https://nango.dev/docs/guides/functions/functions-guide.md): Understand Nango Functions and choose the right way to start using them.
 - [Functions: Sync functions: Sync function guide](https://nango.dev/docs/guides/functions/syncs/sync-functions.md): Build sync functions that keep external API data fresh and consumable by your app.
 - [Functions: Sync functions: Sync efficiency](https://nango.dev/docs/guides/functions/syncs/sync-efficiency.md): Build sync functions that replicate external datasets without wasting API calls, memory, or compute.


### PR DESCRIPTION
## Summary
- Add an MCP Auth guide covering pre-built MCP providers and generic MCP Server OAuth2
- Link examples and auth/proxy steps to current docs paths
- List the page in the Auth section of `docs.json` after token refreshing

## Test plan
- [ ] Preview the docs and confirm MCP Auth appears under Guides → Auth after Token refreshing
- [ ] Click example provider links (HubSpot, Notion, Linear MCP)
- [ ] Click auth-guide step anchors and Proxy API links


Made with [Cursor](https://cursor.com)