### PR TITLE
feat(webapp): Free usage charts as progress toward the cap

### DIFF
--- a/packages/webapp/src/components/patterns/chart/BreakdownChart.tsx
+++ b/packages/webapp/src/components/patterns/chart/BreakdownChart.tsx
@@ -17,24 +17,20 @@ const dayOfMonth = (date: string) => new Date(date).getUTCDate();
 const formatTooltipDate = (date: string | number) =>
     new Date(date).toLocaleDateString('en-US', { day: 'numeric', month: 'long', year: 'numeric', timeZone: 'UTC' });
 
-/** Nearest "nice" number (1, 2, 2.5, 5, 10 × 10ⁿ) at or above x — for round tick steps. */
+/** Nearest "nice" number (1, 2, 2.5, 5, 10 × 10ⁿ) ≥ x — for round tick steps. */
 function niceStep(x: number): number {
     const base = 10 ** Math.floor(Math.log10(x));
     const frac = x / base;
     return (frac <= 1 ? 1 : frac <= 2 ? 2 : frac <= 2.5 ? 2.5 : frac <= 5 ? 5 : 10) * base;
 }
 
-/**
- * Round, evenly-spaced Y-axis ticks (0, step, …, cap) for the cap-line chart so the axis reads
- * "0, 50K, 100K" rather than a ragged "0, 3, 6, 11.2". The cap is always a labelled tick; the plot
- * ceiling is only ~10% above the data/cap (unlabelled) so the chart isn't shrunk by dead headroom.
- */
+/** Round Y-axis ticks (0…top) so the axis reads "0, 50K, 100K", with the cap always a labelled tick and ~10% headroom above. */
 function niceCapAxis(dataMax: number, capLine: number): { max: number; ticks: number[] } {
     const top = Math.max(dataMax, capLine, 1);
     const step = niceStep(top / 5);
     const ticks: number[] = [];
     for (let t = 0; t <= top + step / 2; t += step) ticks.push(t);
-    // The cap is the key reference — make sure it's a labelled tick even if off the step grid.
+    // Force the cap in as a tick even if it's off the step grid.
     if (!ticks.some((t) => Math.abs(t - capLine) < step / 100)) {
         ticks.push(capLine);
         ticks.sort((a, b) => a - b);

--- a/packages/webapp/src/components/patterns/chart/BreakdownChart.tsx
+++ b/packages/webapp/src/components/patterns/chart/BreakdownChart.tsx
@@ -1,5 +1,5 @@
-import { useCallback } from 'react';
-import { Area, AreaChart, Bar, BarChart, CartesianGrid, Text, XAxis, YAxis } from 'recharts';
+import { useCallback, useMemo } from 'react';
+import { Area, AreaChart, Bar, BarChart, CartesianGrid, ReferenceLine, Text, XAxis, YAxis } from 'recharts';
 
 import { formatQuantity } from '@/utils/utils';
 import { ChartContainer, ChartTooltip, ChartTooltipContent } from '../../ui/Chart';
@@ -17,6 +17,31 @@ const dayOfMonth = (date: string) => new Date(date).getUTCDate();
 const formatTooltipDate = (date: string | number) =>
     new Date(date).toLocaleDateString('en-US', { day: 'numeric', month: 'long', year: 'numeric', timeZone: 'UTC' });
 
+/** Nearest "nice" number (1, 2, 2.5, 5, 10 × 10ⁿ) at or above x — for round tick steps. */
+function niceStep(x: number): number {
+    const base = 10 ** Math.floor(Math.log10(x));
+    const frac = x / base;
+    return (frac <= 1 ? 1 : frac <= 2 ? 2 : frac <= 2.5 ? 2.5 : frac <= 5 ? 5 : 10) * base;
+}
+
+/**
+ * Round, evenly-spaced Y-axis ticks (0, step, …, cap) for the cap-line chart so the axis reads
+ * "0, 50K, 100K" rather than a ragged "0, 3, 6, 11.2". The cap is always a labelled tick; the plot
+ * ceiling is only ~10% above the data/cap (unlabelled) so the chart isn't shrunk by dead headroom.
+ */
+function niceCapAxis(dataMax: number, capLine: number): { max: number; ticks: number[] } {
+    const top = Math.max(dataMax, capLine, 1);
+    const step = niceStep(top / 5);
+    const ticks: number[] = [];
+    for (let t = 0; t <= top + step / 2; t += step) ticks.push(t);
+    // The cap is the key reference — make sure it's a labelled tick even if off the step grid.
+    if (!ticks.some((t) => Math.abs(t - capLine) < step / 100)) {
+        ticks.push(capLine);
+        ticks.sort((a, b) => a - b);
+    }
+    return { max: top * 1.1, ticks };
+}
+
 interface BreakdownChartProps {
     /** Per-day rows: `{ date, total }` for the single series, or `{ date, [seriesKey]: value }` stacked. */
     chartData: Record<string, string | number | null | undefined>[];
@@ -28,13 +53,24 @@ interface BreakdownChartProps {
     series: ChartSeries[];
     todayDateKey: string;
     interactions: ChartInteractions;
+    /** Draw a horizontal cap reference line at this value (the metric's plan limit). */
+    capLine?: number;
 }
 
 /**
  * The recharts chart for a usage panel — a single "total" series, or a stacked
  * breakdown with hover/click interactions.
  */
-export const BreakdownChart: React.FC<BreakdownChartProps> = ({ chartData, config, isCumulative, isBreakdown, series, todayDateKey, interactions }) => {
+export const BreakdownChart: React.FC<BreakdownChartProps> = ({
+    chartData,
+    config,
+    isCumulative,
+    isBreakdown,
+    series,
+    todayDateKey,
+    interactions,
+    capLine
+}) => {
     const { hoveredKey, dimByHover, isSeriesHidden, hoverSeries, unhoverSeries, toggleIsolate } = interactions;
     // Clicking a band isolates that series (shows only it; click again shows all) — a
     // client-only view change, never a query change. Filtering lives on the Filter control.
@@ -109,6 +145,22 @@ export const BreakdownChart: React.FC<BreakdownChartProps> = ({ chartData, confi
     };
     const seriesElements = renderSeries();
 
+    // With a cap line, pin the axis to round ticks with headroom above the cap (so its tick is a
+    // nice number, not a fraction like 11.2). Sum per row so stacked breakdowns use the stack height.
+    const capAxis = useMemo(() => {
+        if (capLine === undefined) return null;
+        let dataMax = 0;
+        for (const row of chartData) {
+            let rowSum = 0;
+            for (const key in row) {
+                const value = row[key];
+                if (key !== 'date' && typeof value === 'number') rowSum += value;
+            }
+            if (rowSum > dataMax) dataMax = rowSum;
+        }
+        return niceCapAxis(dataMax, capLine);
+    }, [chartData, capLine]);
+
     // Today's day number is rendered brighter than the rest so the current date stands out
     // on the axis itself. Reuses recharts' <Text> so it sits where the default ticks do; the
     // inline style is the only thing that beats the ChartContainer's tick-fill rule.
@@ -173,9 +225,26 @@ export const BreakdownChart: React.FC<BreakdownChartProps> = ({ chartData, confi
                     tickFormatter={(value: string) => String(dayOfMonth(value))}
                     tick={renderDayTick}
                 />
-                <YAxis tickLine={false} axisLine={false} tickFormatter={(value) => formatQuantity(value)} padding={{ top: 20 }} />
+                <YAxis
+                    tickLine={false}
+                    axisLine={false}
+                    tickFormatter={(value) => formatQuantity(value)}
+                    padding={{ top: 20 }}
+                    // Round ticks + headroom above the cap line (nice tick values, cap not pinned to the top).
+                    domain={capAxis ? [0, capAxis.max] : undefined}
+                    ticks={capAxis?.ticks}
+                />
                 <ChartTooltip content={renderTooltip} isAnimationActive={false} />
                 {seriesElements}
+                {capLine !== undefined && (
+                    <ReferenceLine
+                        y={capLine}
+                        stroke="var(--color-icon-danger)"
+                        strokeDasharray="4 4"
+                        strokeOpacity={0.6}
+                        label={{ value: 'Limit', position: 'top', fill: 'var(--color-icon-danger)', fontSize: 11, offset: 6 }}
+                    />
+                )}
             </ChartComponent>
         </ChartContainer>
     );

--- a/packages/webapp/src/components/patterns/chart/BreakdownChart.tsx
+++ b/packages/webapp/src/components/patterns/chart/BreakdownChart.tsx
@@ -154,12 +154,14 @@ export const BreakdownChart: React.FC<BreakdownChartProps> = ({
             let rowSum = 0;
             for (const key in row) {
                 const value = row[key];
-                if (key !== 'date' && typeof value === 'number') rowSum += value;
+                // Sum only the series currently drawn — isolating/hiding a slice rescales the axis so the
+                // visible data (and the cap line) aren't flattened against the full stacked total.
+                if (key !== 'date' && typeof value === 'number' && !isSeriesHidden(key)) rowSum += value;
             }
             if (rowSum > dataMax) dataMax = rowSum;
         }
         return niceCapAxis(dataMax, capLine);
-    }, [chartData, capLine]);
+    }, [chartData, capLine, isSeriesHidden]);
 
     // Today's day number is rendered brighter than the rest so the current date stands out
     // on the axis itself. Reuses recharts' <Text> so it sits where the default ticks do; the

--- a/packages/webapp/src/components/patterns/chart/BreakdownChart.tsx
+++ b/packages/webapp/src/components/patterns/chart/BreakdownChart.tsx
@@ -38,6 +38,10 @@ function niceCapAxis(dataMax: number, capLine: number): { max: number; ticks: nu
     return { max: top * 1.1, ticks };
 }
 
+/** Only frame the chart against the cap once usage reaches this fraction of it. Below that the cap
+ *  dwarfs the data and the trend collapses to a sliver, so we drop the cap line and auto-scale. */
+const CAP_VISIBILITY_RATIO = 0.25;
+
 interface BreakdownChartProps {
     /** Per-day rows: `{ date, total }` for the single series, or `{ date, [seriesKey]: value }` stacked. */
     chartData: Record<string, string | number | null | undefined>[];
@@ -156,6 +160,9 @@ export const BreakdownChart: React.FC<BreakdownChartProps> = ({
             }
             if (rowSum > dataMax) dataMax = rowSum;
         }
+        // Below the visibility threshold the cap would dwarf the data — drop it and let the axis
+        // auto-scale to the trend, so a barely-used metric still shows a legible curve.
+        if (dataMax < capLine * CAP_VISIBILITY_RATIO) return null;
         return niceCapAxis(dataMax, capLine);
     }, [chartData, capLine, isSeriesHidden]);
 
@@ -234,7 +241,7 @@ export const BreakdownChart: React.FC<BreakdownChartProps> = ({
                 />
                 <ChartTooltip content={renderTooltip} isAnimationActive={false} />
                 {seriesElements}
-                {capLine !== undefined && (
+                {capAxis && capLine !== undefined && (
                     <ReferenceLine
                         y={capLine}
                         stroke="var(--color-icon-danger)"

--- a/packages/webapp/src/components/patterns/chart/ChartCard.tsx
+++ b/packages/webapp/src/components/patterns/chart/ChartCard.tsx
@@ -118,6 +118,10 @@ export const ChartCard: React.FC<ChartCardProps> = ({
     // response's top-level total); otherwise the single series' total. `effectiveEmpty` (not
     // `isEmpty`) so a breakdown with empty top-level `usage` still shows a number.
     const visibleKeys = (breakdownSeries ?? []).filter((s) => !interactions.isSeriesHidden(s.key)).map((s) => s.key);
+    // The cap applies to the whole metric, so hide the cap line whenever the chart is scoped to a
+    // slice — a filter, or an isolated/hidden breakdown series — otherwise the full cap dwarfs the
+    // slice and squishes its data flat.
+    const isSliced = Boolean(filtered) || (isBreakdown && visibleKeys.length < (breakdownSeries?.length ?? 0));
     let headlineTotal: number | undefined;
     if (effectiveEmpty) {
         headlineTotal = undefined;
@@ -200,7 +204,7 @@ export const ChartCard: React.FC<ChartCardProps> = ({
                             interactions={interactions}
                             // Cap line only on the cumulative/point-in-time (area) view; on daily bars the
                             // monthly cap dwarfs the per-day values and would flatten the bars.
-                            capLine={renderAsArea ? capLine : undefined}
+                            capLine={renderAsArea && !isSliced ? capLine : undefined}
                         />
                         {breakdownSeries && breakdownSeries.length > 0 && <ChartLegend series={breakdownSeries} interactions={interactions} />}
                         {!isBreakdown && singleSeries && (

--- a/packages/webapp/src/components/patterns/chart/ChartCard.tsx
+++ b/packages/webapp/src/components/patterns/chart/ChartCard.tsx
@@ -39,6 +39,10 @@ interface ChartCardProps {
     onSeriesToggle?: () => void;
     /** Drop the label + total header (e.g. when an outer row already shows them); the controls move atop the chart body. */
     hideHeader?: boolean;
+    /** Draw a horizontal cap reference line at the metric's plan limit (Free caps view). */
+    capLine?: number;
+    /** 'cumulative' plots counter metrics as a running month-to-date total so the curve climbs to the cap. */
+    chartMode?: 'daily' | 'cumulative';
 }
 
 /**
@@ -61,10 +65,16 @@ export const ChartCard: React.FC<ChartCardProps> = ({
     singleSeries,
     onSeriesIsolate,
     onSeriesToggle,
-    hideHeader
+    hideHeader,
+    capLine,
+    chartMode
 }) => {
     const isBreakdown = breakdownSeries !== undefined;
     const isCumulative = data?.view_mode === 'cumulative';
+    // Counter metrics can render as a running month-to-date total (Free caps view); AVG metrics
+    // (connections/records) are already a level series. renderAsArea decides area vs bars.
+    const cumulativeCounter = chartMode === 'cumulative' && !isCumulative;
+    const renderAsArea = isCumulative || cumulativeCounter;
 
     // Series labels identify the current dataset; interaction state resets when they change.
     const seriesSignature = (breakdownSeries ?? []).map((s) => s.label).join(' ');
@@ -82,7 +92,7 @@ export const ChartCard: React.FC<ChartCardProps> = ({
             onSeriesToggle?.();
         }
     };
-    const { todayDateKey, baseChartData, breakdownChartData, isEmpty } = useChartData(data, breakdownSeries, timeframe);
+    const { todayDateKey, baseChartData, breakdownChartData, isEmpty } = useChartData(data, breakdownSeries, timeframe, cumulativeCounter);
 
     const chartConfig = useMemo<ChartConfig>(() => {
         if (isBreakdown) {
@@ -112,7 +122,7 @@ export const ChartCard: React.FC<ChartCardProps> = ({
     if (effectiveEmpty) {
         headlineTotal = undefined;
     } else if (isBreakdown) {
-        headlineTotal = visibleBreakdownTotal(breakdownChartData, visibleKeys, isCumulative, todayDateKey);
+        headlineTotal = visibleBreakdownTotal(breakdownChartData, visibleKeys, renderAsArea, todayDateKey);
     } else {
         headlineTotal = data?.total;
     }
@@ -183,11 +193,14 @@ export const ChartCard: React.FC<ChartCardProps> = ({
                         <BreakdownChart
                             chartData={isBreakdown ? breakdownChartData : baseChartData}
                             config={chartConfig}
-                            isCumulative={isCumulative}
+                            isCumulative={renderAsArea}
                             isBreakdown={isBreakdown}
                             series={breakdownSeries ?? []}
                             todayDateKey={todayDateKey}
                             interactions={interactions}
+                            // Cap line only on the cumulative/point-in-time (area) view; on daily bars the
+                            // monthly cap dwarfs the per-day values and would flatten the bars.
+                            capLine={renderAsArea ? capLine : undefined}
                         />
                         {breakdownSeries && breakdownSeries.length > 0 && <ChartLegend series={breakdownSeries} interactions={interactions} />}
                         {!isBreakdown && singleSeries && (

--- a/packages/webapp/src/components/patterns/chart/useChartData.ts
+++ b/packages/webapp/src/components/patterns/chart/useChartData.ts
@@ -71,6 +71,49 @@ export function buildBreakdownChartData(
 }
 
 /**
+ * Cumulative (running-sum) rows for the base chart: each day is the total accrued so far this
+ * month. Used by the Free caps view for counter metrics, so the curve climbs toward the cap line.
+ * Future days are blanked (null) like the daily builder.
+ */
+export function buildCumulativeBaseChartData(
+    data: ApiBillingUsageMetric | undefined,
+    timeframe: { start: string; end: string },
+    todayDateKey: string
+): BaseChartRow[] {
+    if (!data) return [];
+    const usageMap = usageToDateMap(data.usage);
+    let sum = 0;
+    return daysInTimeframe(timeframe).map((date) => {
+        if (date > todayDateKey) return { date, total: null };
+        sum += usageMap.get(date) ?? 0;
+        return { date, total: sum };
+    });
+}
+
+/** Cumulative (running-sum) rows for the stacked breakdown: each series accrues over the month. */
+export function buildCumulativeBreakdownChartData(
+    breakdownSeries: ChartSeries[] | undefined,
+    timeframe: { start: string; end: string },
+    todayDateKey: string
+): BreakdownChartRow[] {
+    if (!breakdownSeries) return [];
+    const maps = breakdownSeries.map((s) => usageToDateMap(s.usage));
+    const sums = breakdownSeries.map(() => 0);
+    return daysInTimeframe(timeframe).map((date) => {
+        const row: BreakdownChartRow = { date };
+        breakdownSeries.forEach((s, i) => {
+            if (date > todayDateKey) {
+                row[s.key] = null;
+                return;
+            }
+            sums[i] += maps[i].get(date) ?? 0;
+            row[s.key] = sums[i];
+        });
+        return row;
+    });
+}
+
+/**
  * Headline total for the visible subset of a stacked breakdown — recomputed as the user
  * isolates/hides series, so the number above the chart tracks what's actually drawn.
  * Counter metrics sum every day across the visible series; running-average ("cumulative")
@@ -101,7 +144,14 @@ export function isBaseUsageEmpty(data: ApiBillingUsageMetric | undefined, baseCh
 }
 
 /** Per-day chart rows for the base (single-series) and breakdown (stacked) charts, plus the empty-state flag. */
-export function useChartData(data: ApiBillingUsageMetric | undefined, breakdownSeries: ChartSeries[] | undefined, timeframe: { start: string; end: string }) {
+export function useChartData(
+    data: ApiBillingUsageMetric | undefined,
+    breakdownSeries: ChartSeries[] | undefined,
+    timeframe: { start: string; end: string },
+    // When true, plot the running total accrued through the month (counter metrics in the Free
+    // caps view) instead of per-day values.
+    cumulative = false
+) {
     // Computed each render (not memoized on []) so a dashboard left open past midnight
     // rolls over to the new day. The value is stable within a day, so the memos below
     // (keyed on it) don't recompute until the date actually changes.
@@ -111,8 +161,14 @@ export function useChartData(data: ApiBillingUsageMetric | undefined, breakdownS
 
     // `data` (React Query) and `timeframe` (memoized upstream) are stable references, so
     // depending on them whole recomputes at the same times as granular field deps would.
-    const baseChartData = useMemo(() => buildBaseChartData(data, timeframe, todayDateKey), [data, timeframe, todayDateKey]);
-    const breakdownChartData = useMemo(() => buildBreakdownChartData(breakdownSeries, timeframe, todayDateKey), [breakdownSeries, timeframe, todayDateKey]);
+    const baseChartData = useMemo(
+        () => (cumulative ? buildCumulativeBaseChartData : buildBaseChartData)(data, timeframe, todayDateKey),
+        [data, timeframe, todayDateKey, cumulative]
+    );
+    const breakdownChartData = useMemo(
+        () => (cumulative ? buildCumulativeBreakdownChartData : buildBreakdownChartData)(breakdownSeries, timeframe, todayDateKey),
+        [breakdownSeries, timeframe, todayDateKey, cumulative]
+    );
 
     const isEmpty = isBaseUsageEmpty(data, baseChartData);
 

--- a/packages/webapp/src/pages/Team/Billing/components/ChartModeToggle.tsx
+++ b/packages/webapp/src/pages/Team/Billing/components/ChartModeToggle.tsx
@@ -1,0 +1,36 @@
+import { AreaChart, BarChart3 } from 'lucide-react';
+
+import { cn } from '@/utils/utils';
+
+export type ChartMode = 'daily' | 'cumulative';
+
+interface ChartModeToggleProps {
+    mode: ChartMode;
+    onChange: (mode: ChartMode) => void;
+}
+
+const OPTIONS: { value: ChartMode; label: string; Icon: typeof AreaChart }[] = [
+    { value: 'cumulative', label: 'Cumulative', Icon: AreaChart },
+    { value: 'daily', label: 'Daily', Icon: BarChart3 }
+];
+
+/** Segmented control to switch a counter metric's drill-in between the cumulative and daily views. */
+export const ChartModeToggle: React.FC<ChartModeToggleProps> = ({ mode, onChange }) => (
+    <div className="flex items-center h-7 rounded-[2px] border-[0.5px] border-border-interactive text-body-small-regular">
+        {OPTIONS.map(({ value, label, Icon }, i) => (
+            <button
+                key={value}
+                type="button"
+                onClick={() => onChange(value)}
+                className={cn(
+                    'flex items-center gap-1 px-2.5 h-full transition-colors focus-visible:outline-none focus-visible:shadow-focus-outline-default focus-visible:relative focus-visible:z-10',
+                    i === 0 ? 'rounded-l-[1.5px]' : 'rounded-r-[1.5px] border-l-[0.5px] border-border-interactive',
+                    mode === value ? 'bg-surface-panel-inset text-text-strong' : 'text-text-secondary hover:text-text-strong'
+                )}
+            >
+                <Icon className="size-3.5" />
+                {label}
+            </button>
+        ))}
+    </div>
+);

--- a/packages/webapp/src/pages/Team/Billing/components/ChartModeToggle.tsx
+++ b/packages/webapp/src/pages/Team/Billing/components/ChartModeToggle.tsx
@@ -16,11 +16,12 @@ const OPTIONS: { value: ChartMode; label: string; Icon: typeof AreaChart }[] = [
 
 /** Segmented control to switch a counter metric's drill-in between the cumulative and daily views. */
 export const ChartModeToggle: React.FC<ChartModeToggleProps> = ({ mode, onChange }) => (
-    <div className="flex items-center h-7 rounded-[2px] border-[0.5px] border-border-interactive text-body-small-regular">
+    <div role="group" aria-label="Chart view" className="flex items-center h-7 rounded-[2px] border-[0.5px] border-border-interactive text-body-small-regular">
         {OPTIONS.map(({ value, label, Icon }, i) => (
             <button
                 key={value}
                 type="button"
+                aria-pressed={mode === value}
                 onClick={() => onChange(value)}
                 className={cn(
                     'flex items-center gap-1 px-2.5 h-full transition-colors focus-visible:outline-none focus-visible:shadow-focus-outline-default focus-visible:relative focus-visible:z-10',

--- a/packages/webapp/src/pages/Team/Billing/components/UsageChartCard.tsx
+++ b/packages/webapp/src/pages/Team/Billing/components/UsageChartCard.tsx
@@ -136,11 +136,14 @@ export const UsageChartCard: React.FC<UsageChartCardProps> = ({
     // If it's only empty because of the active filter, keep them in so the filter can be cleared.
     // Counter metrics can toggle cumulative ↔ daily; AVG metrics (view_mode 'cumulative') are a
     // level series with no daily equivalent, so they don't get the toggle. Defaults from the prop.
-    const [chartModeState, setChartModeState] = useState<ChartMode>(chartMode ?? 'cumulative');
+    const [chartModeState, setChartModeState] = useState<ChartMode>(chartMode ?? 'daily');
     const isCounter = data?.view_mode === 'periodic';
 
     const baseEmpty = !data || data.usage.every((u) => !u.quantity);
-    const viewToggle = showControls && isCounter && !baseEmpty ? <ChartModeToggle mode={chartModeState} onChange={setChartModeState} /> : null;
+    // The daily/cumulative toggle is a chart-mode control, not a breakdown feature — show it whenever
+    // a chartMode is explicitly supplied (Free), independent of the breakdown rollout flag.
+    const canToggleMode = chartMode !== undefined || showControls;
+    const viewToggle = canToggleMode && isCounter && !baseEmpty ? <ChartModeToggle mode={chartModeState} onChange={setChartModeState} /> : null;
     const breakdownControl =
         showControls && !baseEmpty ? (
             <BreakdownFilterControl

--- a/packages/webapp/src/pages/Team/Billing/components/UsageChartCard.tsx
+++ b/packages/webapp/src/pages/Team/Billing/components/UsageChartCard.tsx
@@ -42,7 +42,7 @@ interface UsageChartCardProps {
     /** 'cumulative' plots counter metrics as a running month-to-date total (Free caps view). */
     chartMode?: 'daily' | 'cumulative';
     /** Request AVG metrics as point-in-time daily counts instead of the billing running-average. */
-    pointInTime?: boolean;
+    avgPerDay?: boolean;
 }
 
 /**
@@ -66,7 +66,7 @@ export const UsageChartCard: React.FC<UsageChartCardProps> = ({
     disableApplyToAll,
     capLine,
     chartMode,
-    pointInTime
+    avgPerDay
 }) => {
     const showControls = useBreakdownEnabled();
 
@@ -88,7 +88,7 @@ export const UsageChartCard: React.FC<UsageChartCardProps> = ({
     const isDetail = inBreakdownMode || inFilterMode;
 
     // One request covers every detail state (filtered and/or broken down). Fetched lazily.
-    const detailQuery = useApiGetBillingUsageDetail(env, timeframe, metric, { dimension, filter }, DEFAULT_TOP_N, { enabled: isDetail, pointInTime });
+    const detailQuery = useApiGetBillingUsageDetail(env, timeframe, metric, { dimension, filter }, DEFAULT_TOP_N, { enabled: isDetail, avgPerDay });
     const detailMetric = detailQuery.data?.data.usage[metric];
 
     const breakdownEntries = detailMetric?.breakdown;

--- a/packages/webapp/src/pages/Team/Billing/components/UsageChartCard.tsx
+++ b/packages/webapp/src/pages/Team/Billing/components/UsageChartCard.tsx
@@ -1,5 +1,5 @@
 import { parseAsString, useQueryState } from 'nuqs';
-import { useMemo } from 'react';
+import { useMemo, useState } from 'react';
 
 import { ChartCard } from '@/components/patterns/chart';
 import { colorsForValues } from '@/components/patterns/chart/usageChartColors';
@@ -9,9 +9,11 @@ import { BREAKDOWN_DIMENSIONS, DEFAULT_TOP_N, formatDimensionValue, parseFilterP
 import { toChartSeries } from '../usageChartSeries';
 import { useBreakdownEnabled } from '../useBreakdownEnabled';
 import { BreakdownFilterControl } from './BreakdownFilterControl';
+import { ChartModeToggle } from './ChartModeToggle';
 
 import type { AnyBreakdownDimension } from '../usageBreakdown';
 import type { GroupFilterSelection } from '../useGlobalGroupFilter';
+import type { ChartMode } from './ChartModeToggle';
 import type { ChartSeries } from '@/components/patterns/chart';
 import type { ApiBillingUsageMetric, UsageMetric } from '@nangohq/types';
 
@@ -35,6 +37,12 @@ interface UsageChartCardProps {
     extraHeaderActions?: React.ReactNode;
     /** Hide the "Apply to all" affordance (e.g. the Free caps view, where panels are independent). */
     disableApplyToAll?: boolean;
+    /** Draw a cap reference line at the metric's plan limit (Free caps view). */
+    capLine?: number;
+    /** 'cumulative' plots counter metrics as a running month-to-date total (Free caps view). */
+    chartMode?: 'daily' | 'cumulative';
+    /** Request AVG metrics as point-in-time daily counts instead of the billing running-average. */
+    pointInTime?: boolean;
 }
 
 /**
@@ -55,7 +63,10 @@ export const UsageChartCard: React.FC<UsageChartCardProps> = ({
     onApplyToAll,
     hideHeader,
     extraHeaderActions,
-    disableApplyToAll
+    disableApplyToAll,
+    capLine,
+    chartMode,
+    pointInTime
 }) => {
     const showControls = useBreakdownEnabled();
 
@@ -77,7 +88,7 @@ export const UsageChartCard: React.FC<UsageChartCardProps> = ({
     const isDetail = inBreakdownMode || inFilterMode;
 
     // One request covers every detail state (filtered and/or broken down). Fetched lazily.
-    const detailQuery = useApiGetBillingUsageDetail(env, timeframe, metric, { dimension, filter }, DEFAULT_TOP_N, { enabled: isDetail });
+    const detailQuery = useApiGetBillingUsageDetail(env, timeframe, metric, { dimension, filter }, DEFAULT_TOP_N, { enabled: isDetail, pointInTime });
     const detailMetric = detailQuery.data?.data.usage[metric];
 
     const breakdownEntries = detailMetric?.breakdown;
@@ -123,7 +134,13 @@ export const UsageChartCard: React.FC<UsageChartCardProps> = ({
 
     // No data at all for this metric (ignoring filters) → nothing to slice, so hide the controls.
     // If it's only empty because of the active filter, keep them in so the filter can be cleared.
+    // Counter metrics can toggle cumulative ↔ daily; AVG metrics (view_mode 'cumulative') are a
+    // level series with no daily equivalent, so they don't get the toggle. Defaults from the prop.
+    const [chartModeState, setChartModeState] = useState<ChartMode>(chartMode ?? 'cumulative');
+    const isCounter = data?.view_mode === 'periodic';
+
     const baseEmpty = !data || data.usage.every((u) => !u.quantity);
+    const viewToggle = showControls && isCounter && !baseEmpty ? <ChartModeToggle mode={chartModeState} onChange={setChartModeState} /> : null;
     const breakdownControl =
         showControls && !baseEmpty ? (
             <BreakdownFilterControl
@@ -152,7 +169,14 @@ export const UsageChartCard: React.FC<UsageChartCardProps> = ({
             data={live}
             isLoading={isLoading}
             timeframe={timeframe}
-            headerActions={breakdownControl}
+            headerActions={
+                breakdownControl || viewToggle ? (
+                    <>
+                        {breakdownControl}
+                        {viewToggle}
+                    </>
+                ) : undefined
+            }
             extraHeaderActions={extraHeaderActions}
             hideHeader={hideHeader}
             breakdownSeries={breakdownSeries}
@@ -163,6 +187,8 @@ export const UsageChartCard: React.FC<UsageChartCardProps> = ({
             singleSeries={singleSeries}
             onSeriesIsolate={() => track('web:usage:series_isolated', { metric })}
             onSeriesToggle={() => track('web:usage:series_toggled', { metric })}
+            capLine={capLine}
+            chartMode={chartModeState}
         />
     );
 };

--- a/packages/webapp/src/pages/Team/Billing/components/UsageLimitRow.tsx
+++ b/packages/webapp/src/pages/Team/Billing/components/UsageLimitRow.tsx
@@ -67,7 +67,18 @@ export const UsageLimitRow: React.FC<UsageLimitRowProps> = ({ metric, label, usa
                 </div>
             </CollapsibleTrigger>
             <CollapsibleContent>
-                <UsageChartCard metric={metric} data={data} isLoading={isLoading} env={env} timeframe={timeframe} hideHeader disableApplyToAll />
+                <UsageChartCard
+                    metric={metric}
+                    data={data}
+                    isLoading={isLoading}
+                    env={env}
+                    timeframe={timeframe}
+                    hideHeader
+                    disableApplyToAll
+                    capLine={limit ?? undefined}
+                    chartMode="cumulative"
+                    pointInTime
+                />
             </CollapsibleContent>
         </Collapsible>
     );

--- a/packages/webapp/src/pages/Team/Billing/components/UsageLimitRow.tsx
+++ b/packages/webapp/src/pages/Team/Billing/components/UsageLimitRow.tsx
@@ -77,7 +77,7 @@ export const UsageLimitRow: React.FC<UsageLimitRowProps> = ({ metric, label, usa
                     disableApplyToAll
                     capLine={limit ?? undefined}
                     chartMode="cumulative"
-                    pointInTime
+                    avgPerDay
                 />
             </CollapsibleContent>
         </Collapsible>

--- a/scripts/seed-clickhouse.ts
+++ b/scripts/seed-clickhouse.ts
@@ -1,7 +1,8 @@
 import { randomUUID } from 'node:crypto';
 
 import db from '@nangohq/database';
-import { createPlan, freePlan, updatePlanByTeam } from '@nangohq/shared';
+import { records } from '@nangohq/records';
+import { connectionService, createPlan, environmentService, freePlan, updatePlanByTeam } from '@nangohq/shared';
 import { Clickhouse, clickhouseClient, migrate } from '@nangohq/usage';
 
 import type { ClickhouseRawUsageEvent } from '@nangohq/usage';
@@ -109,8 +110,139 @@ function parseArgs() {
         days: days !== undefined ? Number(days) : 60,
         reset: !argv.includes('--no-reset'),
         allowRemote: argv.includes('--allow-remote'),
-        verbose: argv.includes('--verbose')
+        verbose: argv.includes('--verbose'),
+        // Make the data realistic for the Free caps view: (1) mirror the account's real Postgres
+        // connection/record counts into ClickHouse (ramping to the live count) so those AVG metrics
+        // match the DB-backed gauge, and (2) enforce the Free plan caps so counter metrics plateau
+        // at their monthly cap instead of running arbitrarily over.
+        mirrorDbCounts: argv.includes('--mirror-db-counts')
     };
+}
+
+/** Live Postgres counts the caps gauge uses for the AVG metrics (connections, records). */
+async function getDbCounts(accountId: number): Promise<{ connections: number; records: number }> {
+    const connections = await connectionService.countByAccountId(accountId);
+    const envs = await environmentService.getEnvironmentsByAccountId(accountId);
+    const environmentIds = envs.map((e) => e.id);
+    let recordCount = 0;
+    if (environmentIds.length > 0) {
+        for await (const page of records.paginateCounts({ environmentIds })) {
+            if (page.isErr()) throw new Error(`paginateCounts failed: ${page.error}`);
+            recordCount += page.value.reduce((sum, r) => sum + r.count, 0);
+        }
+    }
+    return { connections, records: recordCount };
+}
+
+/**
+ * Scale counter metrics so their monthly totals land at a realistic fraction of the Free caps: a
+ * couple just over (so they hit the cap late in the month, then plateau) and the function group
+ * comfortably under (so function runs are never blocked and the chart has data all month). Without
+ * this the breakdown-test volume is many times the cap, so metrics deplete in the first few days.
+ * The function group scales by its logs total (the binding function cap). Per calendar month.
+ */
+function scaleCountersForFreeDemo(events: ClickhouseRawUsageEvent[]): ClickhouseRawUsageEvent[] {
+    const flags = freePlan.flags;
+    const monthOf = (ts: number): string => new Date(ts).toISOString().slice(0, 7);
+
+    const proxyTotal = new Map<string, number>();
+    const webhookTotal = new Map<string, number>();
+    const logsTotal = new Map<string, number>();
+    for (const ev of events) {
+        const m = monthOf(ev.ts);
+        if (ev.type === 'usage.proxy') proxyTotal.set(m, (proxyTotal.get(m) ?? 0) + ev.value);
+        else if (ev.type === 'usage.webhook_forward') webhookTotal.set(m, (webhookTotal.get(m) ?? 0) + ev.value);
+        else if (ev.type === 'usage.function_executions') {
+            const bag = (ev.attributes as { telemetryBag?: { customLogs?: number } }).telemetryBag;
+            logsTotal.set(m, (logsTotal.get(m) ?? 0) + (bag?.customLogs ?? 0));
+        }
+    }
+    const scaleFor =
+        (totals: Map<string, number>, cap: number | null | undefined, target: number) =>
+        (m: string): number => {
+            const total = totals.get(m) ?? 0;
+            return total > 0 && cap != null && Number.isFinite(cap) ? (target * cap) / total : 1;
+        };
+    const proxyScale = scaleFor(proxyTotal, flags.proxy_max, 1.15);
+    const webhookScale = scaleFor(webhookTotal, flags.webhook_forwards_max, 1.1);
+    const fnScale = scaleFor(logsTotal, flags.function_logs_max, 0.85);
+    const scaled = (n: number, f: number): number => Math.max(1, Math.round(n * f));
+
+    return events.map((ev) => {
+        const m = monthOf(ev.ts);
+        if (ev.type === 'usage.proxy') return { ...ev, value: scaled(ev.value, proxyScale(m)) };
+        if (ev.type === 'usage.webhook_forward') return { ...ev, value: scaled(ev.value, webhookScale(m)) };
+        if (ev.type === 'usage.function_executions') {
+            const f = fnScale(m);
+            const attrs = ev.attributes as { telemetryBag?: { customLogs?: number; durationMs?: number } };
+            const bag = attrs.telemetryBag;
+            return {
+                ...ev,
+                value: scaled(ev.value, f),
+                attributes: bag
+                    ? {
+                          ...attrs,
+                          telemetryBag: { ...bag, customLogs: Math.round((bag.customLogs ?? 0) * f), durationMs: Math.round((bag.durationMs ?? 0) * f) }
+                      }
+                    : ev.attributes
+            } as ClickhouseRawUsageEvent;
+        }
+        return ev;
+    });
+}
+
+/**
+ * Model Free-plan cap enforcement: once a metric hits its monthly cap, further usage is blocked, so
+ * it plateaus at the cap instead of running arbitrarily over. proxy and webhook_forward each cap
+ * independently; the function metrics — executions plus derived logs (Σ customLogs) and compute
+ * (Σ durationMs) — all stop together once the first of their caps is reached (function runs are
+ * blocked). Caps reset per calendar month. Events for other metrics pass through untouched.
+ */
+function capUsageAtFreeLimits(events: ClickhouseRawUsageEvent[]): ClickhouseRawUsageEvent[] {
+    const flags = freePlan.flags;
+    const proxyCap = flags.proxy_max ?? Infinity;
+    const webhookCap = flags.webhook_forwards_max ?? Infinity;
+    const execCap = flags.function_executions_max ?? Infinity;
+    const logsCap = flags.function_logs_max ?? Infinity;
+    const computeCap = flags.function_compute_gbms_max ?? Infinity;
+    const monthOf = (ts: number): string => new Date(ts).toISOString().slice(0, 7);
+
+    const proxy = new Map<string, number>();
+    const webhook = new Map<string, number>();
+    const exec = new Map<string, number>();
+    const logs = new Map<string, number>();
+    const compute = new Map<string, number>();
+
+    const kept: ClickhouseRawUsageEvent[] = [];
+    // Chronological so each month's cap fills from its first day.
+    for (const ev of [...events].sort((a, b) => a.ts - b.ts)) {
+        const m = monthOf(ev.ts);
+        if (ev.type === 'usage.proxy') {
+            const used = proxy.get(m) ?? 0;
+            if (used >= proxyCap) continue;
+            const value = Math.min(ev.value, proxyCap - used);
+            proxy.set(m, used + value);
+            kept.push(value === ev.value ? ev : { ...ev, value });
+        } else if (ev.type === 'usage.webhook_forward') {
+            const used = webhook.get(m) ?? 0;
+            if (used >= webhookCap) continue;
+            const value = Math.min(ev.value, webhookCap - used);
+            webhook.set(m, used + value);
+            kept.push(value === ev.value ? ev : { ...ev, value });
+        } else if (ev.type === 'usage.function_executions') {
+            if ((exec.get(m) ?? 0) >= execCap || (logs.get(m) ?? 0) >= logsCap || (compute.get(m) ?? 0) >= computeCap) {
+                continue; // function runs blocked once any function cap is hit
+            }
+            const bag = (ev.attributes as { telemetryBag?: { customLogs?: number; durationMs?: number } }).telemetryBag;
+            exec.set(m, (exec.get(m) ?? 0) + ev.value);
+            logs.set(m, (logs.get(m) ?? 0) + (bag?.customLogs ?? 0));
+            compute.set(m, (compute.get(m) ?? 0) + (bag?.durationMs ?? 0));
+            kept.push(ev);
+        } else {
+            kept.push(ev);
+        }
+    }
+    return kept;
 }
 
 const rnd = (min: number, max: number): number => Math.floor(Math.random() * (max - min + 1)) + min;
@@ -248,7 +380,10 @@ function generateForEnvDay(
     isProduction: boolean,
     ts: number,
     batchId: string,
-    trafficMonthlyGrowth: number
+    trafficMonthlyGrowth: number,
+    // When true, skip synthetic connections/records — they're emitted once per account/day in the
+    // main loop from the real DB counts so the Free caps drill-in matches the gauge.
+    mirrorDbCounts: boolean
 ): ClickhouseRawUsageEvent[] {
     const events: ClickhouseRawUsageEvent[] = [];
     const dayScale = trafficScale(ts, trafficMonthlyGrowth);
@@ -345,22 +480,27 @@ function generateForEnvDay(
             }
         }
 
-        // records — AVG metric. The snapshot shares the day's batchId so the metric
-        // reflects the daily total record count, not a per-integration average.
-        for (const model of integration.models) {
-            for (const connectionId of connections.slice(0, 2)) {
-                events.push(event('usage.records', accountId, ts, scaledInt(50, 5_000, dayScale, 10), { ...base, connectionId, model, batchId }));
+        // records + connections (AVG metrics) are synthetic per-integration volume by default.
+        // With --mirror-db-counts they come from the primary DB instead — emitted once per
+        // account/day in the main loop — so the Free caps drill-in matches the DB-backed gauge.
+        if (!mirrorDbCounts) {
+            // records — AVG metric. The snapshot shares the day's batchId so the metric
+            // reflects the daily total record count, not a per-integration average.
+            for (const model of integration.models) {
+                for (const connectionId of connections.slice(0, 2)) {
+                    events.push(event('usage.records', accountId, ts, scaledInt(50, 5_000, dayScale, 10), { ...base, connectionId, model, batchId }));
+                }
             }
-        }
 
-        // connections — AVG metric. value = this integration's active connection count.
-        // Shares the day's batchId so the headline is the daily total, not a per-row average.
-        events.push(
-            event('usage.connections', accountId, ts, reportedConnectionCount(integration.id, pool.length, ts), {
-                ...base,
-                batchId
-            })
-        );
+            // connections — AVG metric. value = this integration's active connection count.
+            // Shares the day's batchId so the headline is the daily total, not a per-row average.
+            events.push(
+                event('usage.connections', accountId, ts, reportedConnectionCount(integration.id, pool.length, ts), {
+                    ...base,
+                    batchId
+                })
+            );
+        }
     }
     return events;
 }
@@ -406,7 +546,7 @@ async function resolveTargets(
 }
 
 async function main() {
-    const { onlyAccount, days, reset, allowRemote, verbose } = parseArgs();
+    const { onlyAccount, days, reset, allowRemote, verbose, mirrorDbCounts } = parseArgs();
 
     const clickhouseUrl = process.env['CLICKHOUSE_URL'];
     if (!clickhouseUrl) {
@@ -480,26 +620,51 @@ async function main() {
         // metering cron so the AVG metrics (connections, records) reconstruct the daily
         // total instead of a per-row average.
         const dayBatchIds = Array.from({ length: days }, () => randomUUID());
+        const dbCounts = mirrorDbCounts ? await getDbCounts(accountId) : null;
+        const prodEnv = environments.find((e) => e.isProduction) ?? environments[0];
+
+        // Collect the whole account (all envs) before flushing so the Free-cap plateau can enforce
+        // the account-level monthly caps across prod + dev together.
+        const accountEvents: ClickhouseRawUsageEvent[] = [];
         for (const env of environments) {
-            const events: ClickhouseRawUsageEvent[] = [];
             for (const [offset, batchId] of dayBatchIds.entries()) {
-                events.push(...generateForEnvDay(accountId, env.id, env.isProduction, dayTs(offset), batchId, trafficMonthlyGrowth));
+                accountEvents.push(...generateForEnvDay(accountId, env.id, env.isProduction, dayTs(offset), batchId, trafficMonthlyGrowth, mirrorDbCounts));
             }
-            // Flush each chunk before generating the next. The whole generate loop is
-            // synchronous and never yields, so the batcher's auto-flush can't run mid-loop;
-            // without awaiting here the queue fills past maxQueueSize (default 500k) and
-            // silently drops the tail on long runs (large --days or many accounts). Awaiting
-            // flush per chunk applies backpressure and keeps the queue near-empty; the chunk
-            // stays below maxBatchSize so each flush drains it fully. Transient insert errors
-            // are retried by the batcher on the next flush / during shutdown.
-            for (let i = 0; i < events.length; i += 1_000) {
-                clickhouse.addRaw(events.slice(i, i + 1_000));
-                await clickhouse.flush();
+            // Mirror snapshots: one connections + one records event per day (prod env), ramping from
+            // a fraction of the count up to the live DB count on the newest day — so the AVG charts
+            // match the gauge and still show growth rather than a flat line.
+            if (dbCounts && prodEnv && env.id === prodEnv.id) {
+                const grow = (final: number, startFraction: number, offset: number): number => {
+                    if (offset === 0) return final;
+                    const start = Math.max(1, Math.round(final * startFraction));
+                    const progress = days > 1 ? (days - 1 - offset) / (days - 1) : 1;
+                    return Math.round(start + (final - start) * progress);
+                };
+                for (const [offset, batchId] of dayBatchIds.entries()) {
+                    const ts = dayTs(offset);
+                    const attrs = { environmentId: env.id, integrationId: 'demo-github', batchId };
+                    accountEvents.push(event('usage.connections', accountId, ts, grow(dbCounts.connections, 0.25, offset), attrs));
+                    accountEvents.push(
+                        event('usage.records', accountId, ts, grow(dbCounts.records, 0.1, offset), { ...attrs, connectionId: 'db-mirror', model: 'Contact' })
+                    );
+                }
             }
-            total += events.length;
-            if (verbose) {
-                console.log(`  account ${accountId} · env ${env.id} (${env.name}): ${events.length} events`);
-            }
+        }
+
+        // Enforce the Free caps: counters plateau at their monthly cap once reached (realistic
+        // blocking) rather than running arbitrarily over.
+        const finalEvents = mirrorDbCounts ? capUsageAtFreeLimits(scaleCountersForFreeDemo(accountEvents)) : accountEvents;
+
+        // Flush in chunks with a per-chunk await. The generate loop above is synchronous and never
+        // yields, so the batcher's auto-flush can't run mid-loop; awaiting per chunk applies
+        // backpressure and keeps the queue below maxQueueSize instead of silently dropping the tail.
+        for (let i = 0; i < finalEvents.length; i += 1_000) {
+            clickhouse.addRaw(finalEvents.slice(i, i + 1_000));
+            await clickhouse.flush();
+        }
+        total += finalEvents.length;
+        if (verbose) {
+            console.log(`  account ${accountId}: ${finalEvents.length} events`);
         }
     }
 

--- a/scripts/seed-clickhouse.ts
+++ b/scripts/seed-clickhouse.ts
@@ -147,6 +147,20 @@ async function getDbCounts(accountId: number): Promise<{ connections: number; re
     return { connections, records: recordCount };
 }
 
+// --- Free-cap shaping helpers (shared by scaleCountersForFreeDemo + capUsageAtFreeLimits) ---
+
+/** YYYY-MM bucket for a timestamp — caps and scaling are per calendar month. */
+const monthOf = (ts: number): string => new Date(ts).toISOString().slice(0, 7);
+
+/** Accumulate `n` into `map[key]`, starting from 0. */
+const bump = (map: Map<string, number>, key: string, n: number): void => {
+    map.set(key, (map.get(key) ?? 0) + n);
+};
+
+/** function_executions telemetry: derived logs (customLogs) and compute (durationMs). */
+type FnAttrs = { telemetryBag?: { customLogs?: number; durationMs?: number } };
+const fnBag = (ev: ClickhouseRawUsageEvent): FnAttrs['telemetryBag'] => (ev.attributes as FnAttrs).telemetryBag;
+
 /**
  * Scale counter metrics so their monthly totals land at a realistic fraction of the Free caps: a
  * couple just over (so they hit the cap late in the month, then plateau) and the function group
@@ -156,19 +170,15 @@ async function getDbCounts(accountId: number): Promise<{ connections: number; re
  */
 function scaleCountersForFreeDemo(events: ClickhouseRawUsageEvent[]): ClickhouseRawUsageEvent[] {
     const flags = freePlan.flags;
-    const monthOf = (ts: number): string => new Date(ts).toISOString().slice(0, 7);
 
     const proxyTotal = new Map<string, number>();
     const webhookTotal = new Map<string, number>();
     const logsTotal = new Map<string, number>();
     for (const ev of events) {
         const m = monthOf(ev.ts);
-        if (ev.type === 'usage.proxy') proxyTotal.set(m, (proxyTotal.get(m) ?? 0) + ev.value);
-        else if (ev.type === 'usage.webhook_forward') webhookTotal.set(m, (webhookTotal.get(m) ?? 0) + ev.value);
-        else if (ev.type === 'usage.function_executions') {
-            const bag = (ev.attributes as { telemetryBag?: { customLogs?: number } }).telemetryBag;
-            logsTotal.set(m, (logsTotal.get(m) ?? 0) + (bag?.customLogs ?? 0));
-        }
+        if (ev.type === 'usage.proxy') bump(proxyTotal, m, ev.value);
+        else if (ev.type === 'usage.webhook_forward') bump(webhookTotal, m, ev.value);
+        else if (ev.type === 'usage.function_executions') bump(logsTotal, m, fnBag(ev)?.customLogs ?? 0);
     }
     const scaleFor =
         (totals: Map<string, number>, cap: number | null | undefined, target: number) =>
@@ -187,7 +197,7 @@ function scaleCountersForFreeDemo(events: ClickhouseRawUsageEvent[]): Clickhouse
         if (ev.type === 'usage.webhook_forward') return { ...ev, value: scaled(ev.value, webhookScale(m)) };
         if (ev.type === 'usage.function_executions') {
             const f = fnScale(m);
-            const attrs = ev.attributes as { telemetryBag?: { customLogs?: number; durationMs?: number } };
+            const attrs = ev.attributes as FnAttrs;
             const bag = attrs.telemetryBag;
             return {
                 ...ev,
@@ -218,7 +228,6 @@ function capUsageAtFreeLimits(events: ClickhouseRawUsageEvent[]): ClickhouseRawU
     const execCap = flags.function_executions_max ?? Infinity;
     const logsCap = flags.function_logs_max ?? Infinity;
     const computeCap = flags.function_compute_gbms_max ?? Infinity;
-    const monthOf = (ts: number): string => new Date(ts).toISOString().slice(0, 7);
 
     const proxy = new Map<string, number>();
     const webhook = new Map<string, number>();
@@ -226,30 +235,35 @@ function capUsageAtFreeLimits(events: ClickhouseRawUsageEvent[]): ClickhouseRawU
     const logs = new Map<string, number>();
     const compute = new Map<string, number>();
 
+    // Fill this month's cap, trimming the event to what still fits; returns null once it's exhausted.
+    const capCounter = (used: Map<string, number>, cap: number, ev: ClickhouseRawUsageEvent): ClickhouseRawUsageEvent | null => {
+        const m = monthOf(ev.ts);
+        const soFar = used.get(m) ?? 0;
+        if (soFar >= cap) return null;
+        const value = Math.min(ev.value, cap - soFar);
+        used.set(m, soFar + value);
+        return value === ev.value ? ev : { ...ev, value };
+    };
+
     const kept: ClickhouseRawUsageEvent[] = [];
     // Chronological so each month's cap fills from its first day.
     for (const ev of [...events].sort((a, b) => a.ts - b.ts)) {
-        const m = monthOf(ev.ts);
         if (ev.type === 'usage.proxy') {
-            const used = proxy.get(m) ?? 0;
-            if (used >= proxyCap) continue;
-            const value = Math.min(ev.value, proxyCap - used);
-            proxy.set(m, used + value);
-            kept.push(value === ev.value ? ev : { ...ev, value });
+            const trimmed = capCounter(proxy, proxyCap, ev);
+            if (trimmed) kept.push(trimmed);
         } else if (ev.type === 'usage.webhook_forward') {
-            const used = webhook.get(m) ?? 0;
-            if (used >= webhookCap) continue;
-            const value = Math.min(ev.value, webhookCap - used);
-            webhook.set(m, used + value);
-            kept.push(value === ev.value ? ev : { ...ev, value });
+            const trimmed = capCounter(webhook, webhookCap, ev);
+            if (trimmed) kept.push(trimmed);
         } else if (ev.type === 'usage.function_executions') {
+            // Function runs, logs, and compute all stop together once the first of their caps is hit.
+            const m = monthOf(ev.ts);
             if ((exec.get(m) ?? 0) >= execCap || (logs.get(m) ?? 0) >= logsCap || (compute.get(m) ?? 0) >= computeCap) {
-                continue; // function runs blocked once any function cap is hit
+                continue;
             }
-            const bag = (ev.attributes as { telemetryBag?: { customLogs?: number; durationMs?: number } }).telemetryBag;
-            exec.set(m, (exec.get(m) ?? 0) + ev.value);
-            logs.set(m, (logs.get(m) ?? 0) + (bag?.customLogs ?? 0));
-            compute.set(m, (compute.get(m) ?? 0) + (bag?.durationMs ?? 0));
+            const bag = fnBag(ev);
+            bump(exec, m, ev.value);
+            bump(logs, m, bag?.customLogs ?? 0);
+            bump(compute, m, bag?.durationMs ?? 0);
             kept.push(ev);
         } else {
             kept.push(ev);

--- a/scripts/seed-clickhouse.ts
+++ b/scripts/seed-clickhouse.ts
@@ -126,9 +126,22 @@ async function getDbCounts(accountId: number): Promise<{ connections: number; re
     const environmentIds = envs.map((e) => e.id);
     let recordCount = 0;
     if (environmentIds.length > 0) {
+        // Mirror the gauge (UsageTracker.getRecordsUsage): only count records whose connection
+        // still exists. record_counts can retain rows for deleted connections, which the gauge
+        // excludes (paginateConnections filters deleted=false) — summing them here would push the
+        // mirror above the gauge that --mirror-db-counts is meant to match.
         for await (const page of records.paginateCounts({ environmentIds })) {
             if (page.isErr()) throw new Error(`paginateCounts failed: ${page.error}`);
-            recordCount += page.value.reduce((sum, r) => sum + r.count, 0);
+            if (page.value.length === 0) {
+                continue;
+            }
+            const connectionIds = page.value.map((r) => r.connection_id);
+            for await (const connPage of connectionService.paginateConnections({ connectionIds })) {
+                if (connPage.isErr()) throw new Error(`paginateConnections failed: ${connPage.error}`);
+                for (const conn of connPage.value) {
+                    recordCount += page.value.filter((r) => r.connection_id === conn.connection.id).reduce((sum, r) => sum + r.count, 0);
+                }
+            }
         }
     }
     return { connections, records: recordCount };


### PR DESCRIPTION
## Problem

On the Free usage drill-in, the charts didn't frame usage against the cap: a daily bar chart under a monthly cap makes the limit effectively invisible, and level metrics (connections, sync records) had no cap reference to read against.

## Solution

- Draw the metric's cap as a dashed reference line, with the Y-axis pinned to round ticks ending at the cap plus ~10% headroom.
- Render counter metrics (proxy, functions, webhooks) as a cumulative month-to-date curve, with a daily/cumulative toggle; no cap line on the daily view.
- Draw connections/records from the point-in-time daily series (the endpoint option lands in #6789) so the plotted value is the one the cap limits, and hide the cap line when a series is filtered or isolated (a slice can't be read against the whole-metric cap).
- Make the local ClickHouse seed realistic for this view (`--mirror-db-counts`): mirror the DB connection/record counts the gauge reads, scale counters to a fraction of the caps, and plateau them at the monthly cap.

Fixes [NAN-6280](https://linear.app/nango/issue/NAN-6280)

Stacked on #6789 (Free caps table, NAN-6237).

## Testing

- Verified locally on a Free account: the cap line and cumulative/daily toggle on counter metrics, connections/records whose chart end matches the caps gauge, and the cap line hiding when filtering/isolating a slice.
- `npm run ts-build` and `npm run lint` clean.



https://github.com/user-attachments/assets/e47838a4-b955-4d84-8c18-f2cc27c128cf

