### PR TITLE
fix(server): Bump OAuth2 CC token max length

### DIFF
--- a/packages/server/lib/helpers/validation.ts
+++ b/packages/server/lib/helpers/validation.ts
@@ -164,7 +164,7 @@ export const connectionCredentialsOauth2Schema = z.strictObject({
 });
 
 export const connectionCredentialsOauth2CCSchema = z.strictObject({
-    token: z.string().min(1).max(2048),
+    token: z.string().min(1).max(4096),
     client_id: z.string().min(1).max(255),
     client_secret: z.string().min(1).max(2048),
     client_certificate: z.string().min(1).max(10000).optional(),


### PR DESCRIPTION
<!-- Describe the problem and your solution --> 
Platforms like MS encode all grants in the token and it can be quite long. Customers are getting errors from the Zod validation. 

<!-- Issue ticket number and link (if applicable) -->
[NAN-6283: fix(server): Bump OAUTH2_CC token length cap to 4096](https://linear.app/nango/issue/NAN-6283/fixserver-bump-oauth2-cc-token-length-cap-to-4096)

<!-- Testing instructions (skip if just adding/editing providers) -->



<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/NangoHQ/nango/pull/6798?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

