### PR TITLE
perf(persist): fetch a narrow internal auth context on the auth hot path

### DIFF
--- a/packages/feature-flags/lib/flags.ts
+++ b/packages/feature-flags/lib/flags.ts
@@ -27,6 +27,15 @@ export function buildFlags(client: FeatureFlagsClient) {
             return client.isEnabled('action-trace-manual-keep', { targetingKey: String(environmentId), environmentId }, false);
         },
         /**
+         * Whether persist auth resolves the minimal PersistAuthContext via the light
+         * lookup instead of the full account context query. No account is known before
+         * the lookup, so gradual rollout buckets per evaluation — use random stickiness.
+         * Default `false`.
+         */
+        shouldUseLightPersistAuthContext() {
+            return client.isEnabled('persist-light-auth-context', {}, false);
+        },
+        /**
          * Whether to send sync completion webhooks for this environment and provider.
          * Default `true`.
          */

--- a/packages/persist/lib/middleware/auth.middleware.ts
+++ b/packages/persist/lib/middleware/auth.middleware.ts
@@ -1,5 +1,6 @@
 import tracer from 'dd-trace';
 
+import { getFlags } from '@nangohq/feature-flags';
 import { accountService } from '@nangohq/shared';
 import { flagHasPlan, stringifyError, tagTraceUser } from '@nangohq/utils';
 
@@ -29,19 +30,28 @@ export const authMiddleware = async (req: Request, res: Response<any, AuthLocals
     }
 
     try {
-        const result = await tracer.trace('persist.middleware.auth.getPersistAuthContext', async (span) => {
-            const res = await accountService.getPersistAuthContext(secret);
-            if (res.isErr()) {
-                // Err is returned, not thrown, so the span must be failed explicitly
-                span?.setTag('error', res.error);
+        // Rollout switch between two fully isolated auth paths: the legacy full
+        // account context lookup and the light PersistAuthContext one.
+        let accountContext: PersistAuthContext | null;
+        if (await getFlags().shouldUseLightPersistAuthContext()) {
+            const result = await tracer.trace('persist.middleware.auth.getPersistAuthContext', async (span) => {
+                const res = await accountService.getPersistAuthContext(secret);
+                if (res.isErr()) {
+                    // Err is returned, not thrown, so the span must be failed explicitly
+                    span?.setTag('error', res.error);
+                }
+                return res;
+            });
+            if (result.isErr()) {
+                res.status(401).json({ error: { code: 'unauthorized', message: `Unauthorized: ${stringifyError(result.error)}` } });
+                return;
             }
-            return res;
-        });
-        if (result.isErr()) {
-            res.status(401).json({ error: { code: 'unauthorized', message: `Unauthorized: ${stringifyError(result.error)}` } });
-            return;
+            accountContext = result.value;
+        } else {
+            accountContext = await tracer.trace('persist.middleware.auth.getAccountContextByApiKey', async () => {
+                return await accountService.getAccountContextByApiKey({ internalSecretKey: secret });
+            });
         }
-        const accountContext = result.value;
         if (!accountContext) {
             res.status(401).json({ error: { code: 'unauthorized', message: `Unauthorized: Account not found` } });
             return;

--- a/packages/persist/lib/middleware/auth.middleware.ts
+++ b/packages/persist/lib/middleware/auth.middleware.ts
@@ -29,9 +29,14 @@ export const authMiddleware = async (req: Request, res: Response<any, AuthLocals
     }
 
     try {
-        const accountContext = await tracer.trace('persist.middleware.auth.getPersistAuthContext', async () => {
+        const result = await tracer.trace('persist.middleware.auth.getPersistAuthContext', async () => {
             return await accountService.getPersistAuthContext(secret);
         });
+        if (result.isErr()) {
+            res.status(401).json({ error: { code: 'unauthorized', message: `Unauthorized: ${stringifyError(result.error)}` } });
+            return;
+        }
+        const accountContext = result.value;
         if (!accountContext) {
             res.status(401).json({ error: { code: 'unauthorized', message: `Unauthorized: Account not found` } });
             return;

--- a/packages/persist/lib/middleware/auth.middleware.ts
+++ b/packages/persist/lib/middleware/auth.middleware.ts
@@ -3,14 +3,10 @@ import tracer from 'dd-trace';
 import { accountService } from '@nangohq/shared';
 import { flagHasPlan, stringifyError, tagTraceUser } from '@nangohq/utils';
 
-import type { DBEnvironment, DBPlan, DBTeam } from '@nangohq/types';
+import type { InternalAuthContext } from '@nangohq/types';
 import type { NextFunction, Request, Response } from 'express';
 
-export interface AuthLocals {
-    account: DBTeam;
-    environment: DBEnvironment;
-    plan: DBPlan | null;
-}
+export type AuthLocals = InternalAuthContext;
 
 export const authMiddleware = async (req: Request, res: Response<any, AuthLocals>, next: NextFunction) => {
     const authorizationHeader = req.get('authorization');
@@ -33,8 +29,8 @@ export const authMiddleware = async (req: Request, res: Response<any, AuthLocals
     }
 
     try {
-        const accountContext = await tracer.trace('persist.middleware.auth.getAccountContextByApiKey', async () => {
-            return await accountService.getAccountContextByApiKey({ internalSecretKey: secret });
+        const accountContext = await tracer.trace('persist.middleware.auth.getInternalAuthContext', async () => {
+            return await accountService.getInternalAuthContext(secret);
         });
         if (!accountContext) {
             res.status(401).json({ error: { code: 'unauthorized', message: `Unauthorized: Account not found` } });

--- a/packages/persist/lib/middleware/auth.middleware.ts
+++ b/packages/persist/lib/middleware/auth.middleware.ts
@@ -3,10 +3,10 @@ import tracer from 'dd-trace';
 import { accountService } from '@nangohq/shared';
 import { flagHasPlan, stringifyError, tagTraceUser } from '@nangohq/utils';
 
-import type { InternalAuthContext } from '@nangohq/types';
+import type { PersistAuthContext } from '@nangohq/types';
 import type { NextFunction, Request, Response } from 'express';
 
-export type AuthLocals = InternalAuthContext;
+export type AuthLocals = PersistAuthContext;
 
 export const authMiddleware = async (req: Request, res: Response<any, AuthLocals>, next: NextFunction) => {
     const authorizationHeader = req.get('authorization');
@@ -29,8 +29,8 @@ export const authMiddleware = async (req: Request, res: Response<any, AuthLocals
     }
 
     try {
-        const accountContext = await tracer.trace('persist.middleware.auth.getInternalAuthContext', async () => {
-            return await accountService.getInternalAuthContext(secret);
+        const accountContext = await tracer.trace('persist.middleware.auth.getPersistAuthContext', async () => {
+            return await accountService.getPersistAuthContext(secret);
         });
         if (!accountContext) {
             res.status(401).json({ error: { code: 'unauthorized', message: `Unauthorized: Account not found` } });

--- a/packages/persist/lib/middleware/auth.middleware.ts
+++ b/packages/persist/lib/middleware/auth.middleware.ts
@@ -29,8 +29,13 @@ export const authMiddleware = async (req: Request, res: Response<any, AuthLocals
     }
 
     try {
-        const result = await tracer.trace('persist.middleware.auth.getPersistAuthContext', async () => {
-            return await accountService.getPersistAuthContext(secret);
+        const result = await tracer.trace('persist.middleware.auth.getPersistAuthContext', async (span) => {
+            const res = await accountService.getPersistAuthContext(secret);
+            if (res.isErr()) {
+                // Err is returned, not thrown, so the span must be failed explicitly
+                span?.setTag('error', res.error);
+            }
+            return res;
         });
         if (result.isErr()) {
             res.status(401).json({ error: { code: 'unauthorized', message: `Unauthorized: ${stringifyError(result.error)}` } });

--- a/packages/persist/lib/records.ts
+++ b/packages/persist/lib/records.ts
@@ -32,7 +32,7 @@ export async function persistRecords({
 }: {
     persistType: PersistType;
     accountId: number;
-    environment: DBEnvironment;
+    environment: Pick<DBEnvironment, 'id' | 'name'>;
     connectionId: number;
     providerConfigKey: string;
     syncId: string;
@@ -41,7 +41,7 @@ export async function persistRecords({
     records: Record<string, any>[];
     activityLogId: string;
     merging?: MergingStrategy;
-    plan: DBPlan | null;
+    plan: Pick<DBPlan, 'records_store'> | null;
 }): Promise<Result<MergingStrategy>> {
     const active = tracer.scope().active();
     const span = tracer.startSpan('persistRecords', {

--- a/packages/persist/lib/server.integration.test.ts
+++ b/packages/persist/lib/server.integration.test.ts
@@ -50,14 +50,12 @@ describe('Persist API', () => {
         seed = await initDb();
         server.listen(port);
 
-        vi.spyOn(accountService, 'getAccountContextByApiKey').mockImplementation((opts) => {
-            const key = 'internalSecretKey' in opts ? opts.internalSecretKey : 'secretKey' in opts ? opts.secretKey : '';
+        vi.spyOn(accountService, 'getInternalAuthContext').mockImplementation((key) => {
             if (key === mockSecretKey) {
                 return Promise.resolve({
-                    account: seed.account,
-                    environment: seed.env,
-                    secret: seed.secret,
-                    plan: seed.plan
+                    account: { id: seed.account.id },
+                    environment: { id: seed.env.id, name: seed.env.name },
+                    plan: { id: seed.plan.id, name: seed.plan.name, records_store: seed.plan.records_store }
                 });
             }
             return Promise.resolve(null);

--- a/packages/persist/lib/server.integration.test.ts
+++ b/packages/persist/lib/server.integration.test.ts
@@ -18,6 +18,7 @@ import {
     SyncJobsType,
     SyncStatus
 } from '@nangohq/shared';
+import { Ok } from '@nangohq/utils';
 
 import { server } from './server.js';
 
@@ -52,13 +53,15 @@ describe('Persist API', () => {
 
         vi.spyOn(accountService, 'getPersistAuthContext').mockImplementation((key) => {
             if (key === mockSecretKey) {
-                return Promise.resolve({
-                    account: { id: seed.account.id },
-                    environment: { id: seed.env.id, name: seed.env.name },
-                    plan: { id: seed.plan.id, name: seed.plan.name, records_store: seed.plan.records_store }
-                });
+                return Promise.resolve(
+                    Ok({
+                        account: { id: seed.account.id },
+                        environment: { id: seed.env.id, name: seed.env.name },
+                        plan: { id: seed.plan.id, name: seed.plan.name, records_store: seed.plan.records_store }
+                    })
+                );
             }
-            return Promise.resolve(null);
+            return Promise.resolve(Ok(null));
         });
     });
 

--- a/packages/persist/lib/server.integration.test.ts
+++ b/packages/persist/lib/server.integration.test.ts
@@ -50,7 +50,7 @@ describe('Persist API', () => {
         seed = await initDb();
         server.listen(port);
 
-        vi.spyOn(accountService, 'getInternalAuthContext').mockImplementation((key) => {
+        vi.spyOn(accountService, 'getPersistAuthContext').mockImplementation((key) => {
             if (key === mockSecretKey) {
                 return Promise.resolve({
                     account: { id: seed.account.id },

--- a/packages/persist/lib/server.integration.test.ts
+++ b/packages/persist/lib/server.integration.test.ts
@@ -2,6 +2,7 @@ import fetch from 'node-fetch';
 import { afterAll, beforeAll, describe, expect, it, vi } from 'vitest';
 
 import db, { multipleMigrations } from '@nangohq/database';
+import { getFlags } from '@nangohq/feature-flags';
 import { logContextGetter, migrateLogsMapping } from '@nangohq/logs';
 import { records } from '@nangohq/records';
 import { formatRecords } from '@nangohq/records/lib/helpers/format.js';
@@ -51,6 +52,7 @@ describe('Persist API', () => {
         seed = await initDb();
         server.listen(port);
 
+        vi.spyOn(getFlags(), 'shouldUseLightPersistAuthContext').mockResolvedValue(true);
         vi.spyOn(accountService, 'getPersistAuthContext').mockImplementation((key) => {
             if (key === mockSecretKey) {
                 return Promise.resolve(
@@ -73,6 +75,30 @@ describe('Persist API', () => {
         const response = await fetch(`${serverUrl}/health`);
         expect(response.status).toEqual(200);
         expect(await response.json()).toEqual({ status: 'ok' });
+    });
+
+    it('should authenticate through the legacy lookup when the flag is off', async () => {
+        vi.mocked(getFlags().shouldUseLightPersistAuthContext).mockResolvedValueOnce(false);
+        const legacySpy = vi.spyOn(accountService, 'getAccountContextByApiKey').mockResolvedValueOnce({
+            account: seed.account,
+            environment: seed.env,
+            secret: seed.secret,
+            plan: seed.plan
+        });
+
+        const response = await fetch(`${serverUrl}/environment/${seed.env.id}/log`, {
+            method: 'POST',
+            body: JSON.stringify({
+                activityLogId: seed.activityLogId,
+                log: { type: 'log', level: 'info', message: 'Hello from the legacy path!', createdAt: new Date().toISOString() }
+            }),
+            headers: {
+                Authorization: `Bearer ${mockSecretKey}`,
+                'Content-Type': 'application/json'
+            }
+        });
+        expect(response.status).toEqual(204);
+        expect(legacySpy).toHaveBeenCalledOnce();
     });
 
     it('should log', async () => {

--- a/packages/records/lib/catalog/router.ts
+++ b/packages/records/lib/catalog/router.ts
@@ -9,7 +9,9 @@ import type { RecordCount } from '../types.js';
 import type { DBPlan } from '@nangohq/types';
 
 // Augments a store method signature with a plan parameter for routing purposes.
-type Routed<F> = F extends (params: infer P) => infer R ? (params: P & { plan: DBPlan | null }) => R : never;
+// Only the routing-relevant field is required so narrowed auth contexts qualify.
+type RoutingPlan = Pick<DBPlan, 'records_store'> | null;
+type Routed<F> = F extends (params: infer P) => infer R ? (params: P & { plan: RoutingPlan }) => R : never;
 
 type RoutedRecordsStore = Omit<RecordsStore, 'getRecords' | 'getCursor' | 'upsert' | 'update' | 'deleteRecords' | 'deleteOutdatedRecords'> & {
     getRecords: Routed<RecordsStore['getRecords']>;
@@ -21,7 +23,7 @@ type RoutedRecordsStore = Omit<RecordsStore, 'getRecords' | 'getCursor' | 'upser
 };
 
 interface RoutingContext {
-    plan: DBPlan | null;
+    plan: RoutingPlan;
     connectionId: number;
     model: string;
 }

--- a/packages/shared/lib/services/account.service.integration.test.ts
+++ b/packages/shared/lib/services/account.service.integration.test.ts
@@ -335,11 +335,11 @@ describe('Account service', () => {
         });
     });
 
-    describe('getInternalAuthContext', () => {
+    describe('getPersistAuthContext', () => {
         it('should return exactly the narrow context fields', async () => {
             const { account, env, plan, secret } = await seedAccountEnvAndUser();
 
-            const result = await accountService.getInternalAuthContext(secret.secret);
+            const result = await accountService.getPersistAuthContext(secret.secret);
 
             expect(result).toStrictEqual({
                 account: { id: account.id },
@@ -349,7 +349,7 @@ describe('Account service', () => {
         });
 
         it('should return null for an unknown key', async () => {
-            const result = await accountService.getInternalAuthContext(`nango_secret_key_${uuid()}`);
+            const result = await accountService.getPersistAuthContext(`nango_secret_key_${uuid()}`);
             expect(result).toBeNull();
         });
 
@@ -363,7 +363,7 @@ describe('Account service', () => {
             const envVarKey = `nango_secret_key_${uuid()}`;
             process.env[envVarName] = envVarKey;
             try {
-                const result = await accountService.getInternalAuthContext(envVarKey);
+                const result = await accountService.getPersistAuthContext(envVarKey);
                 expect(result?.environment.id).toBe(environment!.id);
                 expect(result?.account.id).toBe(account.id);
             } finally {

--- a/packages/shared/lib/services/account.service.integration.test.ts
+++ b/packages/shared/lib/services/account.service.integration.test.ts
@@ -339,7 +339,7 @@ describe('Account service', () => {
         it('should return exactly the narrow context fields', async () => {
             const { account, env, plan, secret } = await seedAccountEnvAndUser();
 
-            const result = await accountService.getPersistAuthContext(secret.secret);
+            const result = (await accountService.getPersistAuthContext(secret.secret)).unwrap();
 
             expect(result).toStrictEqual({
                 account: { id: account.id },
@@ -349,7 +349,7 @@ describe('Account service', () => {
         });
 
         it('should return null for an unknown key', async () => {
-            const result = await accountService.getPersistAuthContext(`nango_secret_key_${uuid()}`);
+            const result = (await accountService.getPersistAuthContext(`nango_secret_key_${uuid()}`)).unwrap();
             expect(result).toBeNull();
         });
 
@@ -363,7 +363,7 @@ describe('Account service', () => {
             const envVarKey = `nango_secret_key_${uuid()}`;
             process.env[envVarName] = envVarKey;
             try {
-                const result = await accountService.getPersistAuthContext(envVarKey);
+                const result = (await accountService.getPersistAuthContext(envVarKey)).unwrap();
                 expect(result?.environment.id).toBe(environment!.id);
                 expect(result?.account.id).toBe(account.id);
             } finally {

--- a/packages/shared/lib/services/account.service.integration.test.ts
+++ b/packages/shared/lib/services/account.service.integration.test.ts
@@ -4,6 +4,7 @@ import { afterEach, beforeAll, describe, expect, it, vi } from 'vitest';
 import db, { multipleMigrations } from '@nangohq/database';
 
 import { createAccount as createTestAccount } from '../seeders/account.seeder.js';
+import { seedAccountEnvAndUser } from '../seeders/global.seeder.js';
 import accountService from './account.service.js';
 import customerKeyService from './customerKey.service.js';
 import environmentService, { defaultEnvironments } from './environment.service.js';
@@ -331,6 +332,44 @@ describe('Account service', () => {
         expect(result?.auth).toStrictEqual({
             source: 'api_secret',
             scopes: ['environment:*']
+        });
+    });
+
+    describe('getInternalAuthContext', () => {
+        it('should return exactly the narrow context fields', async () => {
+            const { account, env, plan, secret } = await seedAccountEnvAndUser();
+
+            const result = await accountService.getInternalAuthContext(secret.secret);
+
+            expect(result).toStrictEqual({
+                account: { id: account.id },
+                environment: { id: env.id, name: env.name },
+                plan: { id: plan.id, name: 'free', records_store: plan.records_store }
+            });
+        });
+
+        it('should return null for an unknown key', async () => {
+            const result = await accountService.getInternalAuthContext(`nango_secret_key_${uuid()}`);
+            expect(result).toBeNull();
+        });
+
+        it('should resolve env-var keys through the full-lookup fallback', async () => {
+            const account = await createTestAccount();
+            const envName = uuid();
+            const environment = await environmentService.createEnvironment(db.knex, { accountId: account.id, name: envName });
+            await plans.createPlan(db.knex, { account_id: account.id, name: 'free' });
+
+            const envVarName = `NANGO_SECRET_KEY_${envName.toUpperCase()}`;
+            const envVarKey = `nango_secret_key_${uuid()}`;
+            process.env[envVarName] = envVarKey;
+            try {
+                const result = await accountService.getInternalAuthContext(envVarKey);
+                expect(result?.environment.id).toBe(environment!.id);
+                expect(result?.account.id).toBe(account.id);
+            } finally {
+                // eslint-disable-next-line @typescript-eslint/no-dynamic-delete
+                delete process.env[envVarName];
+            }
         });
     });
 

--- a/packages/shared/lib/services/account.service.integration.test.ts
+++ b/packages/shared/lib/services/account.service.integration.test.ts
@@ -353,7 +353,7 @@ describe('Account service', () => {
             expect(result).toBeNull();
         });
 
-        it('should resolve env-var keys through the full-lookup fallback', async () => {
+        it('should resolve env-var keys before the DB lookup', async () => {
             const account = await createTestAccount();
             const envName = uuid();
             const environment = await environmentService.createEnvironment(db.knex, { accountId: account.id, name: envName });

--- a/packages/shared/lib/services/account.service.ts
+++ b/packages/shared/lib/services/account.service.ts
@@ -18,7 +18,7 @@ import secretService from './secret.service.js';
 import userService from './user.service.js';
 
 import type { Knex } from '@nangohq/database';
-import type { DBAPISecret, DBEnvironment, DBPlan, DBTeam, InternalAuthContext, Result } from '@nangohq/types';
+import type { DBAPISecret, DBEnvironment, DBPlan, DBTeam, PersistAuthContext, Result } from '@nangohq/types';
 
 const hashLocalCache = new FixedSizeMap<string, string>(10_000);
 const logger = getLogger('AccountService');
@@ -656,12 +656,14 @@ class AccountService {
     }
 
     /**
-     * Hot-path variant of the internal-secret lookup: fetches only the fields
-     * internal-secret consumers read (see InternalAuthContext) — no secret joins,
-     * no row_to_json of full rows, no decryption. The matched api_secrets row is
-     * the default secret, so no self-join is needed either.
+     * Authenticates persist requests by internal secret key. Persist authenticates every
+     * request it receives (thousands per second in production), and only reads a handful
+     * of fields from the resolved context, so this lookup is deliberately minimal: it
+     * selects six scalar columns across api_secrets/environments/accounts/plans and
+     * returns them as a PersistAuthContext. Unlike getAccountContextByApiKey it does not
+     * fetch whole rows, join the secret tables a second time, or decrypt any secret.
      */
-    async getInternalAuthContext(secretKey: string): Promise<InternalAuthContext | null> {
+    async getPersistAuthContext(secretKey: string): Promise<PersistAuthContext | null> {
         if (!isCloud) {
             // Mirror getAccountContextByApiKey: env-var keys resolve before any hashing or DB lookup
             const envMatch = await this.getAccountContextFromEnvVar(secretKey);

--- a/packages/shared/lib/services/account.service.ts
+++ b/packages/shared/lib/services/account.service.ts
@@ -18,7 +18,7 @@ import secretService from './secret.service.js';
 import userService from './user.service.js';
 
 import type { Knex } from '@nangohq/database';
-import type { DBAPISecret, DBEnvironment, DBPlan, DBTeam, Result } from '@nangohq/types';
+import type { DBAPISecret, DBEnvironment, DBPlan, DBTeam, InternalAuthContext, Result } from '@nangohq/types';
 
 const hashLocalCache = new FixedSizeMap<string, string>(10_000);
 const logger = getLogger('AccountService');
@@ -637,6 +637,72 @@ class AccountService {
                 scopes: row.auth_scopes ?? [],
                 apiKeyId: row.auth_api_key_id
             }
+        };
+    }
+
+    /**
+     * Hot-path variant of the internal-secret lookup: fetches only the fields
+     * internal-secret consumers read (see InternalAuthContext) — no secret joins,
+     * no row_to_json of full rows, no decryption. The matched api_secrets row is
+     * the default secret, so no self-join is needed either.
+     */
+    async getInternalAuthContext(secretKey: string): Promise<InternalAuthContext | null> {
+        const hash = await this.hashSecretWithCache(secretKey);
+
+        const row = await db.readOnly
+            .select<{
+                environment_id: number;
+                environment_name: string;
+                account_id: number;
+                plan_id: number | null;
+                plan_name: DBPlan['name'] | null;
+                records_store: DBPlan['records_store'] | null;
+            }>(
+                '_nango_environments.id as environment_id',
+                '_nango_environments.name as environment_name',
+                '_nango_accounts.id as account_id',
+                'plans.id as plan_id',
+                'plans.name as plan_name',
+                'plans.records_store as records_store'
+            )
+            .from<DBAPISecret>('api_secrets')
+            .join('_nango_environments', '_nango_environments.id', 'api_secrets.environment_id')
+            .join('_nango_accounts', '_nango_accounts.id', '_nango_environments.account_id')
+            .leftJoin('plans', 'plans.account_id', '_nango_accounts.id')
+            .where('api_secrets.hashed', hash)
+            .where('api_secrets.is_default', true)
+            .where('_nango_environments.deleted', false)
+            .first();
+
+        if (row) {
+            // Store only successful lookups to avoid polluting the cache
+            hashLocalCache.set(secretKey, hash);
+            return {
+                account: { id: row.account_id },
+                environment: { id: row.environment_id, name: row.environment_name },
+                plan:
+                    row.plan_id !== null && row.plan_name !== null && row.records_store !== null
+                        ? { id: row.plan_id, name: row.plan_name, records_store: row.records_store }
+                        : null
+            };
+        }
+
+        if (isCloud) {
+            // On cloud the full lookup filters on the same predicate, so it can never
+            // match when the query above missed — fail fast on unknown keys.
+            return null;
+        }
+
+        // Self-hosted keys can come from NANGO_SECRET_KEY_* env vars and may not exist in
+        // api_secrets, so fall back to the full lookup and narrow the result.
+        const full = await this.getAccountContextByApiKey({ internalSecretKey: secretKey });
+        if (!full) {
+            return null;
+        }
+        return {
+            account: { id: full.account.id },
+            environment: { id: full.environment.id, name: full.environment.name },
+            plan: full.plan ? { id: full.plan.id, name: full.plan.name, records_store: full.plan.records_store } : null
         };
     }
 

--- a/packages/shared/lib/services/account.service.ts
+++ b/packages/shared/lib/services/account.service.ts
@@ -662,8 +662,18 @@ class AccountService {
      * selects six scalar columns across api_secrets/environments/accounts/plans and
      * returns them as a PersistAuthContext. Unlike getAccountContextByApiKey it does not
      * fetch whole rows, join the secret tables a second time, or decrypt any secret.
+     *
+     * Ok(null) means the key is unknown; Err carries unexpected failures.
      */
-    async getPersistAuthContext(secretKey: string): Promise<PersistAuthContext | null> {
+    async getPersistAuthContext(secretKey: string): Promise<Result<PersistAuthContext | null>> {
+        try {
+            return Ok(await this.resolvePersistAuthContext(secretKey));
+        } catch (err) {
+            return Err(err instanceof Error ? err : new Error('failed_to_resolve_persist_auth_context', { cause: err }));
+        }
+    }
+
+    private async resolvePersistAuthContext(secretKey: string): Promise<PersistAuthContext | null> {
         if (!isCloud) {
             // Mirror getAccountContextByApiKey: env-var keys resolve before any hashing or DB lookup
             const envMatch = await this.getAccountContextFromEnvVar(secretKey);

--- a/packages/shared/lib/services/account.service.ts
+++ b/packages/shared/lib/services/account.service.ts
@@ -208,36 +208,51 @@ class AccountService {
         const key = 'secretKey' in opts ? opts.secretKey : opts.internalSecretKey;
 
         if (!isCloud) {
-            const environmentVariables = Object.keys(process.env).filter((k) => k.startsWith('NANGO_SECRET_KEY_'));
-            for (const environmentVariable of environmentVariables) {
-                const envSecretKey = process.env[environmentVariable] as string;
-                if (envSecretKey !== key) {
-                    continue;
-                }
-                const envName = environmentVariable.replace('NANGO_SECRET_KEY_', '').toLowerCase();
-                const env = await db.knex
-                    .select<Pick<DBEnvironment, 'account_id'>>('account_id')
-                    .from<DBEnvironment>('_nango_environments')
-                    .where({ name: envName, deleted: false })
-                    .first();
-                if (!env) {
-                    return null;
-                }
-                const accountContext = await this.getAccountContext({ accountId: env.account_id, envName });
-                if (!accountContext) {
-                    return null;
-                }
-                return {
+            const envMatch = await this.getAccountContextFromEnvVar(key);
+            if (envMatch) {
+                return envMatch.context;
+            }
+        }
+
+        return this.getAccountContext(opts);
+    }
+
+    /**
+     * Self-hosted keys can be provisioned via NANGO_SECRET_KEY_* env vars and may not
+     * exist in api_secrets. Returns null when no env var matches the key; when one
+     * matches, resolution failures are terminal (context: null, no hashed lookup).
+     */
+    private async getAccountContextFromEnvVar(key: string): Promise<{ context: AccountContext | null } | null> {
+        const environmentVariables = Object.keys(process.env).filter((k) => k.startsWith('NANGO_SECRET_KEY_'));
+        for (const environmentVariable of environmentVariables) {
+            const envSecretKey = process.env[environmentVariable] as string;
+            if (envSecretKey !== key) {
+                continue;
+            }
+            const envName = environmentVariable.replace('NANGO_SECRET_KEY_', '').toLowerCase();
+            const env = await db.knex
+                .select<Pick<DBEnvironment, 'account_id'>>('account_id')
+                .from<DBEnvironment>('_nango_environments')
+                .where({ name: envName, deleted: false })
+                .first();
+            if (!env) {
+                return { context: null };
+            }
+            const accountContext = await this.getAccountContext({ accountId: env.account_id, envName });
+            if (!accountContext) {
+                return { context: null };
+            }
+            return {
+                context: {
                     ...accountContext,
                     auth: {
                         source: 'env_var' as const,
                         scopes: ['environment:*']
                     }
-                };
-            }
+                }
+            };
         }
-
-        return this.getAccountContext(opts);
+        return null;
     }
 
     async getAccountContextByPublicKey(publicKey: string): Promise<AccountContext | null> {
@@ -647,6 +662,23 @@ class AccountService {
      * the default secret, so no self-join is needed either.
      */
     async getInternalAuthContext(secretKey: string): Promise<InternalAuthContext | null> {
+        if (!isCloud) {
+            // Mirror getAccountContextByApiKey: env-var keys resolve before any hashing or DB lookup
+            const envMatch = await this.getAccountContextFromEnvVar(secretKey);
+            if (envMatch) {
+                if (!envMatch.context) {
+                    return null;
+                }
+                return {
+                    account: { id: envMatch.context.account.id },
+                    environment: { id: envMatch.context.environment.id, name: envMatch.context.environment.name },
+                    plan: envMatch.context.plan
+                        ? { id: envMatch.context.plan.id, name: envMatch.context.plan.name, records_store: envMatch.context.plan.records_store }
+                        : null
+                };
+            }
+        }
+
         const hash = await this.hashSecretWithCache(secretKey);
 
         const row = await db.readOnly
@@ -674,35 +706,19 @@ class AccountService {
             .where('_nango_environments.deleted', false)
             .first();
 
-        if (row) {
-            // Store only successful lookups to avoid polluting the cache
-            hashLocalCache.set(secretKey, hash);
-            return {
-                account: { id: row.account_id },
-                environment: { id: row.environment_id, name: row.environment_name },
-                plan:
-                    row.plan_id !== null && row.plan_name !== null && row.records_store !== null
-                        ? { id: row.plan_id, name: row.plan_name, records_store: row.records_store }
-                        : null
-            };
-        }
-
-        if (isCloud) {
-            // On cloud the full lookup filters on the same predicate, so it can never
-            // match when the query above missed — fail fast on unknown keys.
+        if (!row) {
             return null;
         }
 
-        // Self-hosted keys can come from NANGO_SECRET_KEY_* env vars and may not exist in
-        // api_secrets, so fall back to the full lookup and narrow the result.
-        const full = await this.getAccountContextByApiKey({ internalSecretKey: secretKey });
-        if (!full) {
-            return null;
-        }
+        // Store only successful lookups to avoid polluting the cache
+        hashLocalCache.set(secretKey, hash);
         return {
-            account: { id: full.account.id },
-            environment: { id: full.environment.id, name: full.environment.name },
-            plan: full.plan ? { id: full.plan.id, name: full.plan.name, records_store: full.plan.records_store } : null
+            account: { id: row.account_id },
+            environment: { id: row.environment_id, name: row.environment_name },
+            plan:
+                row.plan_id !== null && row.plan_name !== null && row.records_store !== null
+                    ? { id: row.plan_id, name: row.plan_name, records_store: row.records_store }
+                    : null
         };
     }
 

--- a/packages/types/lib/account/context.ts
+++ b/packages/types/lib/account/context.ts
@@ -3,11 +3,13 @@ import type { DBPlan } from '../plans/db.js';
 import type { DBTeam } from '../team/db.js';
 
 /**
- * Minimal auth context resolved for internal-secret callers (persist hot path).
- * Only the fields consumers actually read are fetched from the DB — adding a
- * field here means extending the query in accountService.getInternalAuthContext.
+ * The context persist resolves when authenticating a request with an internal
+ * secret key. Deliberately minimal: it holds only the fields persist actually
+ * reads, fetched by a purpose-built query on the auth hot path — the Pick types
+ * make unfetched fields impossible to reference. Adding a field here requires
+ * extending the query in accountService.getPersistAuthContext.
  */
-export interface InternalAuthContext {
+export interface PersistAuthContext {
     account: Pick<DBTeam, 'id'>;
     environment: Pick<DBEnvironment, 'id' | 'name'>;
     plan: Pick<DBPlan, 'id' | 'name' | 'records_store'> | null;

--- a/packages/types/lib/account/context.ts
+++ b/packages/types/lib/account/context.ts
@@ -1,0 +1,14 @@
+import type { DBEnvironment } from '../environment/db.js';
+import type { DBPlan } from '../plans/db.js';
+import type { DBTeam } from '../team/db.js';
+
+/**
+ * Minimal auth context resolved for internal-secret callers (persist hot path).
+ * Only the fields consumers actually read are fetched from the DB — adding a
+ * field here means extending the query in accountService.getInternalAuthContext.
+ */
+export interface InternalAuthContext {
+    account: Pick<DBTeam, 'id'>;
+    environment: Pick<DBEnvironment, 'id' | 'name'>;
+    plan: Pick<DBPlan, 'id' | 'name' | 'records_store'> | null;
+}

--- a/packages/types/lib/index.ts
+++ b/packages/types/lib/index.ts
@@ -13,6 +13,7 @@ export type * from './keystore/index.js';
 export type * from './action/api.js';
 export type * from './admin/http.api.js';
 export type * from './account/api.js';
+export type * from './account/context.js';
 export type * from './user/api.js';
 export type * from './user/db.js';
 export type * from './plain/api.js';

--- a/packages/utils/lib/telemetry/tracer.ts
+++ b/packages/utils/lib/telemetry/tracer.ts
@@ -2,7 +2,15 @@ import tracer from 'dd-trace';
 
 import type { DBEnvironment, DBPlan, DBTeam } from '@nangohq/types';
 
-export function tagTraceUser({ account, environment, plan }: { account: DBTeam; environment: DBEnvironment; plan?: DBPlan | null }) {
+export function tagTraceUser({
+    account,
+    environment,
+    plan
+}: {
+    account: Pick<DBTeam, 'id'>;
+    environment: Pick<DBEnvironment, 'id'>;
+    plan?: Pick<DBPlan, 'name'> | null;
+}) {
     tracer.setUser({
         id: String(account.id),
         environmentId: String(environment.id),


### PR DESCRIPTION
- Persist authenticates every request (half of the [current](https://us3.datadoghq.com/notebook/269063?cell_id=qeu4s4b9&from_ts=1781602210008&to_ts=1784194210008&refresh_mode=sliding&tpl_var_env=%2A&tpl_var_metric=%2A) traffic in production — the single largest query family on the main DB, ~45% of all client-observed query time) by resolving the full account context: a 6-relation query serializing five `row_to_json` blobs plus two secret decryptions. Its consumers only read `environment.{id,name}`, `account.id` and two plan fields. This PR adds `accountService.getPersistAuthContext()` — a 4-relation, 6-scalar-column lookup — and switches persist to it.
- New `PersistAuthContext` type (`Pick`-based, no default values): downstream parameter types narrow to the fields they actually read, so the compiler guarantees no consumer touches a field the query doesn't fetch. Adding a consumer that needs more is a type change + query extension, never a silent gap.
- Self-hosted keys provisioned via `NANGO_SECRET_KEY_*` env vars may not exist in `api_secrets`, so a miss falls back to the full lookup and narrows the result. On cloud the full lookup filters on the same predicate and can never match a miss, so unknown keys fail fast (avoids paying a second pbkdf2 + heavy query per 401).

## Production numbers

`EXPLAIN (ANALYZE, BUFFERS)` on the production writer, same key, warm cache:

| | current query | new query | Δ |
|---|---|---|---|
| Execution time | 0.175 ms | 0.076 ms | **−57%** |
| Execution buffers | 20 shared hits | 13 | −35% |
| Planning time | 2.118 ms | 0.555 ms | −74% |
| Planning buffers | 103 | 49 | −52% |

The dropped `default_secret` self-join re-fetched the row already matched by the `WHERE` clause; the `pending_secret` join was unread. The accounts lookup becomes an Index Only Scan (zero heap fetches) since only `id` is selected. Planning matters at this rate too: pg re-plans one-shot statements per execution, and the 4-relation tree plans in ~¼ the time.

At ~3,400 req/s the execution savings alone are ~0.34 CPU-seconds/s on the writer, plus the planning-side reduction. A side benefit: persist no longer materializes decrypted secret keys, `hmac_key`, or customer OTLP headers per request — the resolved context is three ints and two short strings.

## Rollout: percentage feature flag

The middleware branches between two fully isolated auth paths, selected per request by the `persist-light-auth-context` flag (default `off`): the legacy full account context lookup, verbatim and under its original trace span, and the light `PersistAuthContext` one. No account is known before the lookup, so the Unleash gradual-rollout strategy should use random stickiness (per-request bucketing). Each path keeps its own span name, so the rollout ratio and per-path health are directly visible in APM. Once the ramp completes, deleting the flag and the legacy branch is a middleware-only change.

## Notes for reviewers

- The persist auth span renames to `persist.middleware.auth.getPersistAuthContext` — dashboards/monitors referencing `trace.persist.middleware.auth.getAccountContextByApiKey.*` need updating after deploy.
- The server's script-auth path (`access.middleware`, ~15% of this query's volume) intentionally stays on the full lookup; migrating it is a future, independent step (its locals type is shared with the customer-key path).
- PR #6779 (context cache) will be reworked on top of this once merged: the cache moves to `getPersistAuthContext`, caching the narrow context instead of the full one.

## Test plan

- [x] Exact-shape integration test (`toStrictEqual`) — fails if the query ever fetches more or fewer fields than the type declares
- [x] Unknown key returns null; env-var keys resolve through the fallback
- [x] Full monorepo build passes with the narrowed types (the compiler-level proof that no consumer reads an unfetched field)
- [x] Persist integration suite (real middleware) and records unit suite green
- [x] Legacy-path test: flag off authenticates through the legacy lookup end-to-end
- [ ] Create `persist-light-auth-context` in Unleash (gradual rollout, random stickiness); deploy with flag off — no behavior change
- [ ] Ramp to a small percentage: persist 401s stay ≈0, no failed `getPersistAuthContext` spans, latency ≤ legacy
- [ ] Ramp to 100%: `api_secrets` join rate on `postgres-nango` drops accordingly
- [ ] Update DD dashboards referencing the renamed auth span

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/NangoHQ/nango/pull/6800?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->



