### PR TITLE
fix(server): Route connectwise-psa webhooks by ProductInstanceId

### DIFF
--- a/docs/api-integrations/connectwise-psa.mdx
+++ b/docs/api-integrations/connectwise-psa.mdx
@@ -68,6 +68,9 @@ Nango-maintained guides for common use cases.
 - [How do I link my account?](/api-integrations/connectwise-psa/connect)
 Connect your ConnectWise PSA account using the Connect UI
 
+- [How do I set up webhooks?](/api-integrations/connectwise-psa/webhooks)
+Receive real-time ConnectWise PSA events
+
 Official docs:
 - [How to obtain your keys](https://developer.connectwise.com/Products/ConnectWise_PSA/Developer_Guide#Obtaining_your_Keys)
 - [ConnectWise PSA REST docs](https://developer.connectwise.com/Products/ConnectWise_PSA/REST)

--- a/docs/api-integrations/connectwise-psa/webhooks.mdx
+++ b/docs/api-integrations/connectwise-psa/webhooks.mdx
@@ -14,20 +14,15 @@ This guide explains how Nango receives and routes ConnectWise PSA webhooks.
 
 ## Connection routing
 
-ConnectWise webhook payloads include a `CompanyId` field identifying the tenant the event belongs to. Nango routes each webhook to the connection(s) whose `metadata.companyId` **exactly matches** the payload's `CompanyId`.
-
-This is a 1:1 match:
-
-- A webhook is only dispatched to connections that have `metadata.companyId` set to the payload's `CompanyId`.
-- Connections without a matching `metadata.companyId` do not receive the webhook.
+ConnectWise webhook payloads include a `ProductInstanceId` field identifying the tenant the event belongs to. Nango routes each webhook to the connection(s) whose `metadata.productInstanceId` **exactly matches** the payload's `ProductInstanceId`.
 
 <Warning>
-You must set `metadata.companyId` on each connection for webhook routing to work. If it is unset (or does not match the `CompanyId` in the payload), the connection receives no webhooks. The match is case-sensitive.
+You must set `metadata.productInstanceId` on each connection for webhook routing to work. If it is unset (or does not match the `ProductInstanceId` in the payload), the connection receives no webhooks. The match is case-sensitive.
 </Warning>
 
-### Set `metadata.companyId` on a connection
+### Set `metadata.productInstanceId` on a connection
 
-Set `metadata.companyId` to the ConnectWise Company ID for that tenant — the same Company ID used in the connection's credentials (the value ConnectWise sends as `CompanyId` in the webhook payload).
+Set `metadata.productInstanceId` to the ConnectWise Product Instance ID for that tenant — the same Product Instance ID used in the connection's credentials (the value ConnectWise sends as `ProductInstanceId` in the webhook payload).
 
 Set it via the API:
 
@@ -38,17 +33,13 @@ curl -X PATCH "https://api.nango.dev/connections/metadata" \
   -d '{
     "connection_id": "<CONNECTION_ID>",
     "provider_config_key": "connectwise-psa",
-    "metadata": { "companyId": "<CONNECTWISE-COMPANY-ID>" }
+    "metadata": { "productInstanceId": "<CONNECTWISE-PRODUCT-INSTANCE-ID>" }
   }'
 ```
 
 `PATCH` merges the key into existing metadata; use `POST` if you want to replace all metadata.
 
-You can also set it from a [post-connection-creation event function](/getting-started/use-cases/implement-event-handler) with `nango.updateMetadata({ companyId })` once you have the Company ID for the connection.
-
-<Note>
-`metadata.companyId` must match the `CompanyId` ConnectWise sends in the webhook payload. Confirm the exact value in an incoming webhook (or the ConnectWise login Company ID) and store that same value.
-</Note>
+You can also set it from a [post-connection-creation event function](/getting-started/use-cases/implement-event-handler) with `nango.updateMetadata({ productInstanceId })` once you have the Product Instance ID for the connection.
 
 ## Handle the webhook
 

--- a/docs/api-integrations/connectwise-psa/webhooks.mdx
+++ b/docs/api-integrations/connectwise-psa/webhooks.mdx
@@ -1,0 +1,65 @@
+---
+title: 'How to set up webhooks with ConnectWise PSA on Nango'
+sidebarTitle: 'Webhooks'
+description: 'Learn how to receive real-time ConnectWise PSA events in Nango'
+---
+
+This guide explains how Nango receives and routes ConnectWise PSA webhooks.
+
+## How it works
+
+1. ConnectWise sends a signed POST request to your Nango webhook URL when a subscribed event occurs.
+2. Nango verifies the signature using the signing key referenced in the payload's `Metadata.key_url` (only trusted `*.myconnectwise.net` subdomains are accepted).
+3. Nango routes the webhook to the matching connection(s), then either forwards it to your app or runs a sync (`onWebhook`).
+
+## Connection routing
+
+ConnectWise webhook payloads include a `CompanyId` field identifying the tenant the event belongs to. Nango routes each webhook to the connection(s) whose `metadata.companyId` **exactly matches** the payload's `CompanyId`.
+
+This is a 1:1 match:
+
+- A webhook is only dispatched to connections that have `metadata.companyId` set to the payload's `CompanyId`.
+- Connections without a matching `metadata.companyId` do not receive the webhook.
+
+<Warning>
+You must set `metadata.companyId` on each connection for webhook routing to work. If it is unset (or does not match the `CompanyId` in the payload), the connection receives no webhooks. The match is case-sensitive.
+</Warning>
+
+### Set `metadata.companyId` on a connection
+
+Set `metadata.companyId` to the ConnectWise Company ID for that tenant — the same Company ID used in the connection's credentials (the value ConnectWise sends as `CompanyId` in the webhook payload).
+
+Set it via the API:
+
+```bash
+curl -X PATCH "https://api.nango.dev/connections/metadata" \
+  -H "Authorization: Bearer <NANGO-API-KEY>" \
+  -H "Content-Type: application/json" \
+  -d '{
+    "connection_id": "<CONNECTION_ID>",
+    "provider_config_key": "connectwise-psa",
+    "metadata": { "companyId": "<CONNECTWISE-COMPANY-ID>" }
+  }'
+```
+
+`PATCH` merges the key into existing metadata; use `POST` if you want to replace all metadata.
+
+You can also set it from a [post-connection-creation event function](/getting-started/use-cases/implement-event-handler) with `nango.updateMetadata({ companyId })` once you have the Company ID for the connection.
+
+<Note>
+`metadata.companyId` must match the `CompanyId` ConnectWise sends in the webhook payload. Confirm the exact value in an incoming webhook (or the ConnectWise login Company ID) and store that same value.
+</Note>
+
+## Handle the webhook
+
+Once routed to a connection, you have two options:
+
+- **Forward it to your app** — Nango verifies the signature and forwards the event to your webhook URL with connection attribution. See [External webhook forwarding](/guides/platform/webhook-forwarding).
+- **Process it in a sync** — run a sync when the webhook arrives using `webhookSubscriptions` and `onWebhook` in a sync script. See [Real-time syncs](/guides/functions/syncs/realtime-syncs).
+
+See: [Real-time syncs](/guides/functions/syncs/realtime-syncs)
+</Note>
+
+<Tip>Need help getting started? Get help in the [community](https://nango.dev/slack).</Tip>
+
+---

--- a/docs/api-integrations/connectwise-psa/webhooks.mdx
+++ b/docs/api-integrations/connectwise-psa/webhooks.mdx
@@ -57,9 +57,6 @@ Once routed to a connection, you have two options:
 - **Forward it to your app** — Nango verifies the signature and forwards the event to your webhook URL with connection attribution. See [External webhook forwarding](/guides/platform/webhook-forwarding).
 - **Process it in a sync** — run a sync when the webhook arrives using `webhookSubscriptions` and `onWebhook` in a sync script. See [Real-time syncs](/guides/functions/syncs/realtime-syncs).
 
-See: [Real-time syncs](/guides/functions/syncs/realtime-syncs)
-</Note>
-
 <Tip>Need help getting started? Get help in the [community](https://nango.dev/slack).</Tip>
 
 ---

--- a/docs/api-integrations/google-mail/webhooks.mdx
+++ b/docs/api-integrations/google-mail/webhooks.mdx
@@ -226,7 +226,7 @@ For **existing connections** created before this feature was available, you have
 - **Set the metadata manually** via the API:
 
 ```bash
-curl -X PATCH "https://api.nango.dev/connection/metadata" \
+curl -X PATCH "https://api.nango.dev/connections/metadata" \
   -H "Authorization: Bearer <NANGO_SECRET_KEY>" \
   -H "Content-Type: application/json" \
   -d '{

--- a/packages/server/lib/webhook/connectwise-psa-webhook-routing.ts
+++ b/packages/server/lib/webhook/connectwise-psa-webhook-routing.ts
@@ -136,8 +136,8 @@ const route: WebhookHandler<ConnectWisePsaWebhookPayload> = async (nango, header
     const response = await nango.executeScriptForWebhooks({
         body,
         webhookType: 'Type',
-        connectionIdentifier: 'CompanyId',
-        propName: 'metadata.companyId'
+        connectionIdentifier: 'ProductInstanceId',
+        propName: 'metadata.productInstanceId'
     });
 
     return Ok({

--- a/packages/server/lib/webhook/connectwise-psa-webhook-routing.ts
+++ b/packages/server/lib/webhook/connectwise-psa-webhook-routing.ts
@@ -135,7 +135,9 @@ const route: WebhookHandler<ConnectWisePsaWebhookPayload> = async (nango, header
 
     const response = await nango.executeScriptForWebhooks({
         body,
-        webhookType: 'Type' // ConnectWise webhook type field
+        webhookType: 'Type',
+        connectionIdentifier: 'CompanyId',
+        propName: 'metadata.companyId'
     });
 
     return Ok({


### PR DESCRIPTION
<!-- Describe the problem and your solution --> 
Currently connectwise-psa webhooks are fanned out to all connections causing additional load and forcing the customer to check if a webhook matches a connection at runtime. This is causing extra load for Thrive Holdings (the only customer using connectwise-psa webhooks).

<!-- Issue ticket number and link (if applicable) -->
[NAN-6345: fix(server): Route connectwise-psa webhooks by CompanyId](https://linear.app/nango/issue/NAN-6345/fixserver-route-connectwise-psa-webhooks-by-companyid)

<!-- Testing instructions (skip if just adding/editing providers) -->

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/NangoHQ/nango/pull/6808?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

