### PR TITLE
perf(scheduler): avoid unnecessary db roundtrip on task retirement

### DIFF
--- a/packages/scheduler/lib/scheduler.ts
+++ b/packages/scheduler/lib/scheduler.ts
@@ -433,7 +433,7 @@ export class Scheduler {
         const newState: TaskState = 'SUCCEEDED';
         const succeeded: Result<Task> = await this.db.transaction(async (trx) => {
             const res = await tasks.transitionState(trx, { taskId, newState, output });
-            if (res.isOk()) {
+            if (res.isOk() && res.value.scheduleId !== null) {
                 const scheduleRes = await schedules.scheduleNextExecution(trx, {
                     taskIds: [taskId],
                     taskState: newState,
@@ -484,13 +484,15 @@ export class Scheduler {
 
             const failed = await tasks.transitionState(trx, { taskId, newState, output: error });
             if (failed.isOk()) {
-                const scheduleRes = await schedules.scheduleNextExecution(trx, {
-                    taskIds: [taskId],
-                    taskState: newState,
-                    nextExecutionInMs
-                });
-                if (scheduleRes.isErr()) {
-                    return Err(`Error updating last scheduled task state for task '${taskId}': ${stringifyError(scheduleRes.error)}`);
+                if (failed.value.scheduleId !== null) {
+                    const scheduleRes = await schedules.scheduleNextExecution(trx, {
+                        taskIds: [taskId],
+                        taskState: newState,
+                        nextExecutionInMs
+                    });
+                    if (scheduleRes.isErr()) {
+                        return Err(`Error updating last scheduled task state for task '${taskId}': ${stringifyError(scheduleRes.error)}`);
+                    }
                 }
                 const task = failed.value;
                 this.onCallbacks[task.state](task);
@@ -543,7 +545,7 @@ export class Scheduler {
                 newState,
                 output: { reason }
             });
-            if (res.isOk()) {
+            if (res.isOk() && res.value.scheduleId !== null) {
                 const scheduleRes = await schedules.scheduleNextExecution(trx, {
                     taskIds: [taskId],
                     taskState: newState,

--- a/packages/scheduler/lib/scheduler.ts
+++ b/packages/scheduler/lib/scheduler.ts
@@ -433,7 +433,7 @@ export class Scheduler {
         const newState: TaskState = 'SUCCEEDED';
         const succeeded: Result<Task> = await this.db.transaction(async (trx) => {
             const res = await tasks.transitionState(trx, { taskId, newState, output });
-            if (res.isOk() && res.value.scheduleId !== null) {
+            if (res.isOk() && this.isSchedulable(res.value)) {
                 const scheduleRes = await schedules.scheduleNextExecution(trx, {
                     taskIds: [taskId],
                     taskState: newState,
@@ -484,7 +484,7 @@ export class Scheduler {
 
             const failed = await tasks.transitionState(trx, { taskId, newState, output: error });
             if (failed.isOk()) {
-                if (failed.value.scheduleId !== null) {
+                if (this.isSchedulable(failed.value)) {
                     const scheduleRes = await schedules.scheduleNextExecution(trx, {
                         taskIds: [taskId],
                         taskState: newState,
@@ -545,7 +545,7 @@ export class Scheduler {
                 newState,
                 output: { reason }
             });
-            if (res.isOk() && res.value.scheduleId !== null) {
+            if (res.isOk() && this.isSchedulable(res.value)) {
                 const scheduleRes = await schedules.scheduleNextExecution(trx, {
                     taskIds: [taskId],
                     taskState: newState,
@@ -750,5 +750,13 @@ export class Scheduler {
             return Err(abortTask.error);
         }
         return abortTask;
+    }
+
+    /**
+     * A task is schedulable if it links back to a `schedule` (i.e., it has a schedule id).
+     * Attempting to reschedule an unschedulable task (i.e., actions, webhooks, on-events) is a no-op that would only waste database resources.
+     */
+    private isSchedulable(task: Task): boolean {
+        return task.scheduleId !== null;
     }
 }


### PR DESCRIPTION
Actions, webhooks and on-event handlers are not scheduled and thus have no schedule id, so attempting to compute the schedule's `next_execution_at` timestamp is a no-op: the `UPDATE`'s `WHERE` clause will never match a tuple for non-sync functions. This PR simply adds a runtime check to validate whether the task has a schedule id before calling `scheduleNextExecution`, thus avoiding the extra roundtrip incurred by the no-op query.



<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/NangoHQ/nango/pull/6810?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

