### PR TITLE
fix(frontend): resolve authModal stuck pending on idle-timeout WS close

### DIFF
--- a/packages/frontend/lib/authModal.ts
+++ b/packages/frontend/lib/authModal.ts
@@ -61,6 +61,7 @@ export class AuthorizationModal {
     private debug: boolean;
     private swClient: WebSocket;
     private errorHandler: ErrorHandler;
+    private settled = false;
     public modal?: Window;
     public isProcessingMessage = false;
 
@@ -88,6 +89,28 @@ export class AuthorizationModal {
             this.isProcessingMessage = true;
             this.handleMessage(message, successHandler);
             this.isProcessingMessage = false;
+        };
+
+        this.swClient.onclose = () => {
+            // The server closes the socket after every terminal message (success/error),
+            // but it can also drop the connection on idle timeout during a slow OAuth flow
+            // (e.g. a proxy/gateway closing after ~120s). In that case no success/error
+            // message is ever received, so without this fallback the auth promise never
+            // settles and the modal stays stuck in a pending state.
+            if (this.settled) {
+                return;
+            }
+
+            this.settled = true;
+
+            if (this.debug) {
+                console.log(debugLogPrefix, 'Connection closed before receiving a result. Rejecting authorization...');
+            }
+
+            this.errorHandler(
+                'connection_timeout',
+                'The connection to the Nango server was closed before the authorization flow completed. Please try connecting again.'
+            );
         };
     }
 
@@ -118,6 +141,7 @@ export class AuthorizationModal {
                     console.log(debugLogPrefix, 'Error received. Rejecting authorization...');
                 }
 
+                this.settled = true;
                 this.errorHandler(data.error_type as AuthErrorType, data.error_desc);
                 this.swClient.close();
                 break;
@@ -126,6 +150,7 @@ export class AuthorizationModal {
                     console.log(debugLogPrefix, 'Success received. Resolving authorization...');
                 }
 
+                this.settled = true;
                 successHandler({
                     providerConfigKey: data.provider_config_key,
                     connectionId: data.connection_id,

--- a/packages/frontend/lib/authModal.unit.test.ts
+++ b/packages/frontend/lib/authModal.unit.test.ts
@@ -1,0 +1,106 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+
+import { AuthorizationModal } from './authModal.js';
+
+import type { AuthErrorType, AuthSuccess } from './types.js';
+
+/**
+ * Minimal WebSocket stub that lets the test drive the socket lifecycle
+ * (incoming messages and close events) without a real network connection.
+ */
+class MockWebSocket {
+    static instances: MockWebSocket[] = [];
+
+    public onmessage: ((event: { data: string }) => void) | null = null;
+    public onclose: (() => void) | null = null;
+    public readyState = 0;
+
+    constructor(public url: string) {
+        MockWebSocket.instances.push(this);
+    }
+
+    /** Simulate a message pushed by the server. */
+    receive(data: unknown): void {
+        this.onmessage?.({ data: JSON.stringify(data) });
+    }
+
+    /** Simulate the socket closing (e.g. server idle timeout). */
+    close(): void {
+        if (this.readyState === 3) {
+            return;
+        }
+        this.readyState = 3;
+        this.onclose?.();
+    }
+}
+
+function createModal() {
+    const successHandler = vi.fn<(authSuccess: AuthSuccess) => void>();
+    const errorHandler = vi.fn<(errorType: AuthErrorType, errorDesc: string) => void>();
+
+    const modal = new AuthorizationModal({
+        baseUrl: new URL('https://api.nango.dev/oauth/connect/hubspot'),
+        debug: false,
+        webSocketUrl: 'wss://api.nango.dev/',
+        successHandler,
+        errorHandler
+    });
+
+    return { modal, successHandler, errorHandler, socket: MockWebSocket.instances.at(-1)! };
+}
+
+describe('AuthorizationModal websocket lifecycle', () => {
+    beforeEach(() => {
+        MockWebSocket.instances = [];
+        vi.stubGlobal('WebSocket', MockWebSocket);
+    });
+
+    afterEach(() => {
+        vi.unstubAllGlobals();
+    });
+
+    it('rejects the pending auth flow when the socket closes on idle timeout before a result (regression for #5849)', () => {
+        const { successHandler, errorHandler, socket } = createModal();
+
+        // Server acknowledges the connection but the OAuth flow takes too long,
+        // so the socket is dropped on idle timeout before any success message.
+        socket.receive({ message_type: 'connection_ack', ws_client_id: 'ws-1' });
+        socket.close();
+
+        expect(successHandler).not.toHaveBeenCalled();
+        expect(errorHandler).toHaveBeenCalledTimes(1);
+        expect(errorHandler.mock.calls[0]?.[0]).toBe('connection_timeout');
+    });
+
+    it('resolves on success and does not fire the timeout fallback when the socket then closes', () => {
+        const { successHandler, errorHandler, socket } = createModal();
+
+        socket.receive({ message_type: 'connection_ack', ws_client_id: 'ws-2' });
+        socket.receive({
+            message_type: 'success',
+            provider_config_key: 'hubspot',
+            connection_id: 'conn-123',
+            is_pending: false
+        });
+
+        // The success handler closes the socket, which triggers onclose - the
+        // fallback must stay quiet because the flow already resolved.
+        expect(successHandler).toHaveBeenCalledTimes(1);
+        expect(successHandler.mock.calls[0]?.[0]).toEqual({
+            providerConfigKey: 'hubspot',
+            connectionId: 'conn-123',
+            isPending: false
+        });
+        expect(errorHandler).not.toHaveBeenCalled();
+    });
+
+    it('does not turn a server error into a duplicate timeout rejection when the socket closes', () => {
+        const { successHandler, errorHandler, socket } = createModal();
+
+        socket.receive({ message_type: 'error', error_type: 'invalid_credentials', error_desc: 'nope' });
+
+        expect(successHandler).not.toHaveBeenCalled();
+        expect(errorHandler).toHaveBeenCalledTimes(1);
+        expect(errorHandler.mock.calls[0]?.[0]).toBe('invalid_credentials');
+    });
+});

--- a/packages/frontend/lib/types.ts
+++ b/packages/frontend/lib/types.ts
@@ -6,6 +6,7 @@ export type AuthErrorType =
     | 'invalid_host_url'
     | 'missing_credentials'
     | 'window_closed'
+    | 'connection_timeout'
     | 'connection_test_failed'
     | 'missing_connect_session_token'
     | 'connection_validation_failed'


### PR DESCRIPTION
Fixes #5849

### Root cause
`AuthorizationModal` only wires up `swClient.onmessage`. When the server drops the WebSocket on idle timeout during a slow OAuth flow (~120s), no `success`/`error` message is ever delivered, so the `auth()` promise never settles and the modal stays stuck in a pending state.

### Fix
I added an `onclose` fallback that rejects the pending flow with a `connection_timeout` error when the socket closes before a terminal message is received, guarded by a `settled` flag so the normal success/error close path is untouched. This transitions the modal out of "pending" cleanly so the user can retry, without broadcasting any internal data. I deliberately kept it to a frontend-only, minimal change rather than the previously-attempted popup `postMessage` broadcast (#6290), which was closed over data-exposure concerns.

### Test
Added `authModal.unit.test.ts` covering the stuck-pending case (asserts the flow now rejects with `connection_timeout` on socket close after only `connection_ack`) plus two no-regression cases (success still resolves; a server `error` is not turned into a duplicate timeout rejection). Verified red without the fix / green with it (3 passing).

Happy to adjust the approach or error naming based on maintainer preference.

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/NangoHQ/nango/pull/6815?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

