### PR TITLE
feat(design-system): validate removed tokens against webapp usages

### DIFF
--- a/.github/workflows/tokens-check.yaml
+++ b/.github/workflows/tokens-check.yaml
@@ -64,3 +64,23 @@ jobs:
 
             - name: Check for removed tokens still in use
               run: npm run tokens:check --workspace=@nangohq/design-system
+
+    # Stable required-status-check name. `check-tokens` is path-skipped on PRs that
+    # don't touch tokens, and a skipped required check would hang the PR/merge queue.
+    # This job always runs and translates skipped -> success, so it can be marked
+    # required in branch protection. Mark `token-check` (not `check-tokens`) required.
+    token-check:
+        needs: [should-run, check-tokens]
+        if: always()
+        runs-on: ubuntu-latest
+        permissions: {}
+        steps:
+            - name: Verify token check passed
+              run: |
+                  result="${{ needs.check-tokens.result }}"
+                  if [[ "$result" == "success" || "$result" == "skipped" ]]; then
+                      echo "Token check: $result"
+                      exit 0
+                  fi
+                  echo "Token check did not pass: $result"
+                  exit 1

--- a/.github/workflows/tokens-check.yaml
+++ b/.github/workflows/tokens-check.yaml
@@ -59,5 +59,8 @@ jobs:
             - name: Install dependencies
               run: npm ci
 
+            - name: Validate token aliases resolve cleanly
+              run: npm run tokens:build --workspace=@nangohq/design-system -- --strict
+
             - name: Check for removed tokens still in use
               run: npm run tokens:check --workspace=@nangohq/design-system

--- a/.github/workflows/tokens-check.yaml
+++ b/.github/workflows/tokens-check.yaml
@@ -62,6 +62,17 @@ jobs:
             - name: Validate token aliases resolve cleanly
               run: npm run tokens:build --workspace=@nangohq/design-system -- --strict
 
+            # The previous step rebuilds tokens.generated.css from the committed
+            # tokens.json. If the committed CSS is stale, hand-edited, or mangled by
+            # a merge, it now differs from the rebuild — fail so the true build output
+            # is what ships (and what the removed-token check below runs against).
+            - name: Verify committed CSS matches tokens.json
+              run: |
+                  if ! git diff --exit-code -- packages/design-system/tokens/tokens.generated.css; then
+                      echo "::error::tokens.generated.css is out of date with tokens.json. Run 'npm run tokens:build --workspace=@nangohq/design-system' and commit the result."
+                      exit 1
+                  fi
+
             - name: Check for removed tokens still in use
               run: npm run tokens:check --workspace=@nangohq/design-system
 

--- a/.github/workflows/tokens-check.yaml
+++ b/.github/workflows/tokens-check.yaml
@@ -8,6 +8,10 @@ on:
     pull_request:
     merge_group:
 
+# Least privilege: every job only reads the repo. token-check narrows further to {}.
+permissions:
+    contents: read
+
 jobs:
     should-run:
         runs-on: ubuntu-latest

--- a/.github/workflows/tokens-check.yaml
+++ b/.github/workflows/tokens-check.yaml
@@ -1,0 +1,63 @@
+name: Token check
+
+on:
+    push:
+        branches:
+            - master
+            - staging/**
+    pull_request:
+    merge_group:
+
+jobs:
+    should-run:
+        runs-on: ubuntu-latest
+        outputs:
+            should_skip: ${{ steps.check.outputs.should_skip }}
+        steps:
+            - uses: actions/checkout@v4
+            - uses: dorny/paths-filter@v4
+              id: filter
+              with:
+                  filters: |
+                      tokens:
+                          - 'packages/design-system/tokens/**'
+                          - 'packages/design-system/scripts/tokens-**'
+                          - 'packages/webapp/src/**'
+                          - '.github/workflows/tokens-check.yaml'
+            - name: Determine if should skip
+              id: check
+              run: |
+                  IS_PR="${{ github.event_name == 'pull_request' }}"
+                  IS_MERGE_QUEUE="${{ github.event_name == 'merge_group' }}"
+                  IS_DIRECT_PUSH_TO_MASTER="${{ github.event_name == 'push' && github.ref == 'refs/heads/master' && github.actor != 'github-merge-queue[bot]' }}"
+                  TOKENS_CHANGED="${{ steps.filter.outputs.tokens == 'true' }}"
+
+                  SHOULD_SKIP="true"
+                  if [[ "$IS_MERGE_QUEUE" == "true" || "$IS_DIRECT_PUSH_TO_MASTER" == "true" ]]; then
+                      SHOULD_SKIP="false"
+                  elif [[ "$IS_PR" == "true" && "$TOKENS_CHANGED" == "true" ]]; then
+                      SHOULD_SKIP="false"
+                  fi
+
+                  echo "should_skip=$SHOULD_SKIP" >> $GITHUB_OUTPUT
+
+    check-tokens:
+        needs: should-run
+        if: needs.should-run.outputs.should_skip != 'true'
+        runs-on: blacksmith-4vcpu-ubuntu-2404
+        steps:
+            - uses: actions/checkout@v4
+              with:
+                  # Full history needed to resolve the merge-base against origin/master
+                  fetch-depth: 0
+
+            - uses: actions/setup-node@v4
+              with:
+                  cache: 'npm'
+                  node-version-file: '.nvmrc'
+
+            - name: Install dependencies
+              run: npm ci
+
+            - name: Check for removed tokens still in use
+              run: npm run tokens:check --workspace=@nangohq/design-system

--- a/packages/design-system/package.json
+++ b/packages/design-system/package.json
@@ -6,6 +6,7 @@
     "scripts": {
         "tokens:fetch": "node scripts/tokens-fetch.mjs",
         "tokens:build": "node scripts/tokens-fetch.mjs --build-only",
+        "tokens:check": "node scripts/tokens-check-removed.mjs",
         "test": "vitest run --config vitest.config.mjs",
         "storybook": "NODE_PATH=./node_modules storybook dev -p 6006 --ci",
         "build-storybook": "NODE_PATH=./node_modules storybook build"

--- a/packages/design-system/scripts/tokens-check-removed.mjs
+++ b/packages/design-system/scripts/tokens-check-removed.mjs
@@ -1,0 +1,273 @@
+#!/usr/bin/env node
+/* eslint-disable no-console */
+/**
+ * Validate that no removed design tokens are still referenced in the webapp.
+ *
+ * Used two ways:
+ *
+ *   1. As a module — imported by tokens-fetch.mjs to emit a local warning after
+ *      rebuilding CSS.  The caller decides whether to exit non-zero (--strict flag).
+ *
+ *   2. As a CLI (npm run tokens:check) — CI entry point.  Reads the merge-base
+ *      version of tokens.generated.css from git, compares it to the working-tree
+ *      version, and exits 1 if any removed tokens are still referenced.
+ */
+
+import { execFileSync } from 'child_process';
+import { existsSync, readFileSync } from 'fs';
+import { readdir } from 'fs/promises';
+import path from 'path';
+import { fileURLToPath } from 'url';
+
+const __dirname = path.dirname(fileURLToPath(import.meta.url));
+const TOKENS_CSS_PATH = path.resolve(__dirname, '../tokens/tokens.generated.css');
+const WEBAPP_SRC_DIR = path.resolve(__dirname, '../../webapp/src');
+
+// ─── CSS-variable extraction ───────────────────────────────────────────────────
+
+/**
+ * Return the set of CSS custom-property names *defined* in `css`.
+ * Only matches definitions (i.e. `--name:`) — not `var(--name)` references.
+ * Names include the leading `--`.
+ */
+export function extractDefinedVars(css) {
+    const re = /--([a-zA-Z0-9-]+)\s*:/g;
+    const vars = new Set();
+    let match;
+    while ((match = re.exec(css)) !== null) {
+        vars.add('--' + match[1]);
+    }
+    return vars;
+}
+
+/**
+ * Return CSS variable names present in `oldCss` but absent in `newCss`.
+ *
+ * `--color-*` variables are Tailwind @theme aliases always derived from a
+ * semantic var — skipped here to avoid noise (the parent semantic var is
+ * already in the removed set and generates the Tailwind utility patterns).
+ */
+export function findRemovedVars(oldCss, newCss) {
+    const oldVars = extractDefinedVars(oldCss);
+    const newVars = extractDefinedVars(newCss);
+    return [...oldVars].filter((v) => !newVars.has(v) && !v.startsWith('--color-'));
+}
+
+// ─── Tailwind pattern generation ───────────────────────────────────────────────
+
+// All Tailwind v4 color utility prefixes.
+const TAILWIND_COLOR_PREFIXES = [
+    'accent',
+    'bg',
+    'border',
+    'caret',
+    'decoration',
+    'divide',
+    'fill',
+    'from',
+    'outline',
+    'placeholder',
+    'ring',
+    'ring-offset',
+    'shadow',
+    'stroke',
+    'text',
+    'to',
+    'via'
+];
+
+/**
+ * Return all literal strings to search for when a CSS variable is removed.
+ *
+ *  • `var(--token)` — direct CSS-variable reference (all tokens)
+ *  • `prefix-token-name` — Tailwind utility class patterns for semantic tokens
+ *    (i.e. tokens NOT prefixed with `--ds-`, which are primitives kept out of
+ *    @theme and therefore have no Tailwind utilities)
+ */
+export function getSearchPatterns(varName) {
+    const name = varName.slice(2); // strip '--'
+    const patterns = [`var(${varName})`];
+
+    if (!name.startsWith('ds-')) {
+        for (const prefix of TAILWIND_COLOR_PREFIXES) {
+            patterns.push(`${prefix}-${name}`);
+        }
+    }
+
+    return patterns;
+}
+
+// ─── Webapp file scanning ──────────────────────────────────────────────────────
+
+const SCAN_EXTENSIONS = new Set(['tsx', 'ts', 'css', 'html']);
+const IGNORE_SEGMENTS = ['node_modules', 'dist'];
+
+/**
+ * Recursively list source files under `dir` that match SCAN_EXTENSIONS and
+ * don't live in an ignored sub-path.
+ */
+async function listSourceFiles(dir) {
+    const entries = await readdir(dir, { recursive: true, withFileTypes: true });
+    return entries
+        .filter((e) => {
+            if (!e.isFile()) return false;
+            const ext = path.extname(e.name).slice(1);
+            if (!SCAN_EXTENSIONS.has(ext)) return false;
+            if (e.name.endsWith('.d.ts')) return false;
+            // parentPath is Node 20+; path is the legacy field
+            const fullPath = path.join(e.parentPath ?? e.path, e.name);
+            return !IGNORE_SEGMENTS.some((seg) => fullPath.includes(`${path.sep}${seg}${path.sep}`));
+        })
+        .map((e) => path.join(e.parentPath ?? e.path, e.name));
+}
+
+/**
+ * Return the 1-based line numbers in `content` that contain `pattern`.
+ */
+export function getMatchingLines(content, pattern) {
+    const lines = content.split('\n');
+    const result = [];
+    for (let i = 0; i < lines.length; i++) {
+        if (lines[i].includes(pattern)) result.push(i + 1);
+    }
+    return result;
+}
+
+/**
+ * Scan `webappDir` for usages of every removed CSS variable.
+ *
+ * Returns a nested map keyed by var name → pattern → list of { file, lines }.
+ * File paths are relative to the monorepo root (two levels above webappDir).
+ *
+ * @param {string[]} removedVars
+ * @param {string} webappDir
+ * @returns {Promise<Record<string, Record<string, Array<{file: string, lines: number[]}>>>>}
+ */
+export async function findUsages(removedVars, webappDir) {
+    const files = await listSourceFiles(webappDir);
+    const repoRoot = path.resolve(webappDir, '..', '..');
+
+    // Pre-compute search patterns per variable.
+    const varPatterns = new Map(removedVars.map((v) => [v, getSearchPatterns(v)]));
+
+    /** @type {Record<string, Record<string, Array<{file: string, lines: number[]}>>>} */
+    const usages = {};
+
+    for (const filePath of files) {
+        const content = readFileSync(filePath, 'utf-8');
+        const relPath = path.relative(repoRoot, filePath);
+
+        for (const [varName, patterns] of varPatterns) {
+            for (const pattern of patterns) {
+                if (!content.includes(pattern)) continue;
+                const lines = getMatchingLines(content, pattern);
+                if (lines.length === 0) continue;
+
+                if (!usages[varName]) usages[varName] = {};
+                if (!usages[varName][pattern]) usages[varName][pattern] = [];
+                usages[varName][pattern].push({ file: relPath, lines });
+            }
+        }
+    }
+
+    return usages;
+}
+
+// ─── Reporting ─────────────────────────────────────────────────────────────────
+
+/**
+ * Pretty-print a usage report to `stream` (defaults to process.stderr).
+ * Returns `true` if at least one usage was found.
+ *
+ * @param {Record<string, Record<string, Array<{file: string, lines: number[]}>>>} usages
+ * @param {{ stream?: NodeJS.WritableStream }} options
+ */
+export function reportUsages(usages, { stream = process.stderr } = {}) {
+    const vars = Object.keys(usages);
+    if (vars.length === 0) return false;
+
+    stream.write('\n⚠ Removed tokens still in use:\n');
+
+    let totalHits = 0;
+    for (const [varName, patterns] of Object.entries(usages)) {
+        stream.write(`\n  ${varName}\n`);
+        for (const [pattern, hits] of Object.entries(patterns)) {
+            stream.write(`    as: ${pattern}\n`);
+            for (const { file, lines } of hits) {
+                for (const line of lines) {
+                    stream.write(`      ${file}:${line}\n`);
+                    totalHits++;
+                }
+            }
+        }
+    }
+
+    stream.write(`\n  ${vars.length} removed token(s) with ${totalHits} usage(s) in the webapp.\n`);
+    stream.write('  Update webapp references before merging.\n\n');
+
+    return true;
+}
+
+// ─── Orchestrator ──────────────────────────────────────────────────────────────
+
+/**
+ * Diff `oldCss` vs `newCss`, scan `webappDir`, report, and return results.
+ *
+ * @param {{ oldCss: string, newCss: string, webappDir?: string }}
+ * @returns {Promise<{ removed: string[], usages: object, hasUsages: boolean }>}
+ */
+export async function checkRemovedTokens({ oldCss, newCss, webappDir = WEBAPP_SRC_DIR }) {
+    const removed = findRemovedVars(oldCss, newCss);
+    if (removed.length === 0) {
+        return { removed, usages: {}, hasUsages: false };
+    }
+
+    const usages = await findUsages(removed, webappDir);
+    const hasUsages = reportUsages(usages);
+    return { removed, usages, hasUsages };
+}
+
+// ─── CI entry point ────────────────────────────────────────────────────────────
+
+async function runCi() {
+    // Use the merge-base of HEAD and origin/master as baseline so the check
+    // covers all commits on the branch, not just the last one.
+    // Falls back to HEAD~1 for repos without a remote (e.g. shallow clones).
+    let mergeBase;
+    try {
+        mergeBase = execFileSync('git', ['merge-base', 'HEAD', 'origin/master'], { encoding: 'utf-8' }).trim();
+    } catch {
+        try {
+            mergeBase = execFileSync('git', ['rev-parse', 'HEAD~1'], { encoding: 'utf-8' }).trim();
+        } catch {
+            process.stderr.write('⚠ Could not determine baseline commit; skipping removed-token check.\n');
+            process.exit(0);
+        }
+    }
+
+    const cssRepoPath = 'packages/design-system/tokens/tokens.generated.css';
+    let oldCss;
+    try {
+        oldCss = execFileSync('git', ['show', `${mergeBase}:${cssRepoPath}`], { encoding: 'utf-8' });
+    } catch {
+        // File didn't exist at the base commit — nothing to diff against.
+        console.log('No baseline tokens.generated.css at merge-base; skipping check.');
+        process.exit(0);
+    }
+
+    if (!existsSync(TOKENS_CSS_PATH)) {
+        process.stderr.write(`✗ tokens.generated.css not found at ${TOKENS_CSS_PATH}.\nRun: npm run tokens:build --workspace=@nangohq/design-system\n`);
+        process.exit(1);
+    }
+    const newCss = readFileSync(TOKENS_CSS_PATH, 'utf-8');
+
+    const { hasUsages } = await checkRemovedTokens({ oldCss, newCss });
+    process.exit(hasUsages ? 1 : 0);
+}
+
+if (process.argv[1] === fileURLToPath(import.meta.url)) {
+    runCi().catch((err) => {
+        process.stderr.write(`✗ ${err.message}\n`);
+        process.exit(1);
+    });
+}

--- a/packages/design-system/scripts/tokens-check-removed.mjs
+++ b/packages/design-system/scripts/tokens-check-removed.mjs
@@ -42,14 +42,16 @@ export function extractDefinedVars(css) {
 /**
  * Return CSS variable names present in `oldCss` but absent in `newCss`.
  *
- * `--color-*` variables are Tailwind @theme aliases always derived from a
- * semantic var — skipped here to avoid noise (the parent semantic var is
- * already in the removed set and generates the Tailwind utility patterns).
+ * Includes `--color-*` and `--shadow-*` @theme aliases: source can reference
+ * them directly (e.g. `var(--color-border-muted, currentcolor)` in index.css),
+ * so a removed alias must still be caught. getSearchPatterns only emits the
+ * direct `var()` reference for those — their utility classes are generated from
+ * the underlying semantic token, which is checked via its own entry.
  */
 export function findRemovedVars(oldCss, newCss) {
     const oldVars = extractDefinedVars(oldCss);
     const newVars = extractDefinedVars(newCss);
-    return [...oldVars].filter((v) => !newVars.has(v) && !v.startsWith('--color-'));
+    return [...oldVars].filter((v) => !newVars.has(v));
 }
 
 // ─── Tailwind pattern generation ───────────────────────────────────────────────
@@ -77,22 +79,55 @@ const TAILWIND_COLOR_PREFIXES = [
     'via'
 ];
 
+// Tailwind v4 @theme primitive namespaces (`--<ns>-ds-*`) → the utility family
+// each one generates, e.g. `--radius-ds-xs` registers `rounded-ds-xs` and
+// `--border-width-ds-hairline` registers `border-ds-hairline`. Unlike semantic
+// color tokens (which take every color prefix), each primitive namespace maps to
+// exactly one utility prefix. Keys are the full namespace before `-ds-`.
+const PRIMITIVE_THEME_UTILITY = {
+    radius: 'rounded',
+    'border-width': 'border',
+    text: 'text',
+    'font-weight': 'font',
+    tracking: 'tracking',
+    leading: 'leading'
+};
+
 /**
  * Return all literal strings to search for when a CSS variable is removed.
  *
- *  • `var(--token)` — direct CSS-variable reference (all tokens)
- *  • `prefix-token-name` — Tailwind utility class patterns for semantic tokens
- *    (i.e. tokens NOT prefixed with `--ds-`, which are primitives kept out of
- *    @theme and therefore have no Tailwind utilities)
+ * The pattern set depends on how the variable is registered with Tailwind:
+ *
+ *  • `var(--token)` — direct reference, always searched for every variable.
+ *  • Raw primitives (`--ds-*`) are kept out of @theme — no utilities.
+ *  • `--color-*` / `--shadow-*` are @theme aliases whose utilities come from the
+ *    underlying semantic token (searched via that token's own entry), so only the
+ *    direct `var()` reference matters here.
+ *  • `--<ns>-ds-*` primitive registrations map to one utility family, e.g.
+ *    `--radius-ds-xs` → `rounded-ds-xs`, `--border-width-ds-hairline` →
+ *    `border-ds-hairline`. The `-ds-` infix distinguishes these from semantic
+ *    color tokens that share the prefix (`--text-strong` → `text-text-strong`,
+ *    not a font-size utility).
+ *  • Everything else is a semantic color token and takes every color prefix.
  */
 export function getSearchPatterns(varName) {
     const name = varName.slice(2); // strip '--'
     const patterns = [`var(${varName})`];
 
-    if (!name.startsWith('ds-')) {
-        for (const prefix of TAILWIND_COLOR_PREFIXES) {
-            patterns.push(`${prefix}-${name}`);
-        }
+    if (name.startsWith('ds-') || name.startsWith('color-') || name.startsWith('shadow-')) {
+        return patterns;
+    }
+
+    // Capture the full namespace before the first `-ds-` (e.g. 'border-width').
+    const nsMatch = name.match(/^(.+?)-ds-/);
+    if (nsMatch && PRIMITIVE_THEME_UTILITY[nsMatch[1]]) {
+        // name.slice(ns.length) keeps the leading '-ds-…', e.g. 'radius-ds-xs' -> '-ds-xs'.
+        patterns.push(`${PRIMITIVE_THEME_UTILITY[nsMatch[1]]}${name.slice(nsMatch[1].length)}`);
+        return patterns;
+    }
+
+    for (const prefix of TAILWIND_COLOR_PREFIXES) {
+        patterns.push(`${prefix}-${name}`);
     }
 
     return patterns;

--- a/packages/design-system/scripts/tokens-check-removed.mjs
+++ b/packages/design-system/scripts/tokens-check-removed.mjs
@@ -12,7 +12,6 @@
  *      version of tokens.generated.css from git, compares it to the working-tree
  *      version, and exits 1 if any removed tokens are still referenced.
  */
-
 import { execFileSync } from 'child_process';
 import { existsSync, readFileSync } from 'fs';
 import { readdir } from 'fs/promises';
@@ -65,6 +64,8 @@ const TAILWIND_COLOR_PREFIXES = [
     'divide',
     'fill',
     'from',
+    'inset-ring',
+    'inset-shadow',
     'outline',
     'placeholder',
     'ring',
@@ -121,14 +122,26 @@ async function listSourceFiles(dir) {
         .map((e) => path.join(e.parentPath ?? e.path, e.name));
 }
 
+function escapeRegExp(str) {
+    return str.replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
+}
+
 /**
- * Return the 1-based line numbers in `content` that contain `pattern`.
+ * Return the 1-based line numbers in `content` where `pattern` appears at a
+ * token boundary.
+ *
+ * A plain substring match would flag a removed token inside a longer surviving
+ * one — e.g. removing `text-link` (utility `text-text-link`) would falsely match
+ * `text-text-link-hover`. We require the match to be bounded by a non-`[\w-]`
+ * character on each side, so trailing variants/opacity modifiers (`/50`, followed
+ * by a space or quote) still match but a longer token name does not.
  */
 export function getMatchingLines(content, pattern) {
+    const re = new RegExp(`(?<![\\w-])${escapeRegExp(pattern)}(?![\\w-])`);
     const lines = content.split('\n');
     const result = [];
     for (let i = 0; i < lines.length; i++) {
-        if (lines[i].includes(pattern)) result.push(i + 1);
+        if (re.test(lines[i])) result.push(i + 1);
     }
     return result;
 }

--- a/packages/design-system/scripts/tokens-check-removed.unit.test.mjs
+++ b/packages/design-system/scripts/tokens-check-removed.unit.test.mjs
@@ -1,0 +1,266 @@
+import { mkdirSync, rmSync, writeFileSync } from 'node:fs';
+import os from 'node:os';
+import path from 'node:path';
+import { afterEach, beforeEach, describe, expect, it } from 'vitest';
+
+import { checkRemovedTokens, extractDefinedVars, findRemovedVars, findUsages, getMatchingLines, getSearchPatterns, reportUsages } from './tokens-check-removed.mjs';
+
+// ─── extractDefinedVars ────────────────────────────────────────────────────────
+
+describe('extractDefinedVars', () => {
+    it('extracts simple variable definitions', () => {
+        const css = `:root {\n  --surface-canvas: #fff;\n  --text-strong: #000;\n}`;
+        const vars = extractDefinedVars(css);
+        expect(vars.has('--surface-canvas')).toBe(true);
+        expect(vars.has('--text-strong')).toBe(true);
+    });
+
+    it('does not match var() references', () => {
+        const css = `a { color: var(--text-strong); }`;
+        const vars = extractDefinedVars(css);
+        expect(vars.size).toBe(0);
+    });
+
+    it('handles whitespace before the colon', () => {
+        const css = `  --some-token  : value;`;
+        const vars = extractDefinedVars(css);
+        expect(vars.has('--some-token')).toBe(true);
+    });
+
+    it('returns an empty set for CSS with no definitions', () => {
+        expect(extractDefinedVars('body { color: red; }').size).toBe(0);
+    });
+});
+
+// ─── findRemovedVars ───────────────────────────────────────────────────────────
+
+describe('findRemovedVars', () => {
+    const makeCss = (...vars) => vars.map((v) => `${v}: value;`).join('\n');
+
+    it('returns vars present in old but absent in new', () => {
+        const old = makeCss('--surface-canvas', '--text-strong');
+        const next = makeCss('--surface-canvas');
+        expect(findRemovedVars(old, next)).toEqual(['--text-strong']);
+    });
+
+    it('returns empty array when no vars are removed', () => {
+        const css = makeCss('--surface-canvas', '--text-strong');
+        expect(findRemovedVars(css, css)).toEqual([]);
+    });
+
+    it('ignores --color-* vars (Tailwind @theme aliases)', () => {
+        const old = makeCss('--surface-canvas', '--color-surface-canvas');
+        const next = makeCss('--surface-canvas-new');
+        // --color-surface-canvas is removed but should be skipped
+        const removed = findRemovedVars(old, next);
+        expect(removed).not.toContain('--color-surface-canvas');
+        expect(removed).toContain('--surface-canvas');
+    });
+
+    it('handles completely empty new CSS', () => {
+        const old = makeCss('--surface-canvas');
+        expect(findRemovedVars(old, '')).toEqual(['--surface-canvas']);
+    });
+});
+
+// ─── getSearchPatterns ─────────────────────────────────────────────────────────
+
+describe('getSearchPatterns', () => {
+    it('always includes var() reference', () => {
+        const patterns = getSearchPatterns('--surface-canvas');
+        expect(patterns).toContain('var(--surface-canvas)');
+    });
+
+    it('includes Tailwind utility patterns for semantic tokens', () => {
+        const patterns = getSearchPatterns('--surface-canvas');
+        expect(patterns).toContain('bg-surface-canvas');
+        expect(patterns).toContain('text-surface-canvas');
+        expect(patterns).toContain('border-surface-canvas');
+        expect(patterns).toContain('fill-surface-canvas');
+        expect(patterns).toContain('stroke-surface-canvas');
+        expect(patterns).toContain('ring-surface-canvas');
+        expect(patterns).toContain('from-surface-canvas');
+        expect(patterns).toContain('via-surface-canvas');
+        expect(patterns).toContain('to-surface-canvas');
+    });
+
+    it('does NOT include Tailwind patterns for --ds-* primitive tokens', () => {
+        const patterns = getSearchPatterns('--ds-color-neutral-50');
+        expect(patterns).toEqual(['var(--ds-color-neutral-50)']);
+    });
+
+    it('includes exactly var() for a --ds-* token (no Tailwind patterns)', () => {
+        const patterns = getSearchPatterns('--ds-typography-font-size-md');
+        expect(patterns.length).toBe(1);
+        expect(patterns[0]).toBe('var(--ds-typography-font-size-md)');
+    });
+});
+
+// ─── getMatchingLines ──────────────────────────────────────────────────────────
+
+describe('getMatchingLines', () => {
+    it('returns 1-based line numbers for matching lines', () => {
+        const content = ['line one', 'bg-surface-canvas here', 'line three', 'bg-surface-canvas again'].join('\n');
+        expect(getMatchingLines(content, 'bg-surface-canvas')).toEqual([2, 4]);
+    });
+
+    it('returns empty array when pattern is not found', () => {
+        expect(getMatchingLines('nothing here', 'missing')).toEqual([]);
+    });
+});
+
+// ─── findUsages ────────────────────────────────────────────────────────────────
+
+describe('findUsages', () => {
+    let tmpDir;
+
+    beforeEach(() => {
+        tmpDir = mkdirSync(path.join(os.tmpdir(), `test-webapp-${Date.now()}`), { recursive: true }) ?? path.join(os.tmpdir(), `test-webapp-${Date.now()}`);
+        // mkdirSync with recursive returns the path only when newly created on some Node versions
+        // Re-derive it
+        tmpDir = path.join(os.tmpdir(), `test-webapp-${Date.now()}`);
+        mkdirSync(tmpDir, { recursive: true });
+    });
+
+    afterEach(() => {
+        rmSync(tmpDir, { recursive: true, force: true });
+    });
+
+    it('finds var() references in TSX files', async () => {
+        writeFileSync(path.join(tmpDir, 'Comp.tsx'), `const s = { color: 'var(--surface-canvas)' };`);
+        const usages = await findUsages(['--surface-canvas'], tmpDir);
+        expect(usages['--surface-canvas']).toBeDefined();
+        expect(usages['--surface-canvas']['var(--surface-canvas)']).toHaveLength(1);
+        expect(usages['--surface-canvas']['var(--surface-canvas)'][0].lines).toContain(1);
+    });
+
+    it('finds Tailwind utility class usages', async () => {
+        writeFileSync(path.join(tmpDir, 'Card.tsx'), `<div className="bg-surface-canvas text-text-strong" />`);
+        const usages = await findUsages(['--surface-canvas', '--text-strong'], tmpDir);
+        expect(usages['--surface-canvas']['bg-surface-canvas']).toBeDefined();
+        expect(usages['--text-strong']['text-text-strong']).toBeDefined();
+    });
+
+    it('finds usages in CSS files', async () => {
+        writeFileSync(path.join(tmpDir, 'styles.css'), `.foo { background: var(--surface-canvas); }`);
+        const usages = await findUsages(['--surface-canvas'], tmpDir);
+        expect(usages['--surface-canvas']['var(--surface-canvas)']).toBeDefined();
+    });
+
+    it('does not scan .d.ts files', async () => {
+        writeFileSync(path.join(tmpDir, 'types.d.ts'), `// var(--surface-canvas)`);
+        const usages = await findUsages(['--surface-canvas'], tmpDir);
+        expect(Object.keys(usages)).toHaveLength(0);
+    });
+
+    it('ignores node_modules', async () => {
+        const nmDir = path.join(tmpDir, 'node_modules', 'pkg');
+        mkdirSync(nmDir, { recursive: true });
+        writeFileSync(path.join(nmDir, 'index.tsx'), `var(--surface-canvas)`);
+        const usages = await findUsages(['--surface-canvas'], tmpDir);
+        expect(Object.keys(usages)).toHaveLength(0);
+    });
+
+    it('returns empty object when no usages found', async () => {
+        writeFileSync(path.join(tmpDir, 'Clean.tsx'), `<div className="bg-white" />`);
+        const usages = await findUsages(['--surface-canvas'], tmpDir);
+        expect(Object.keys(usages)).toHaveLength(0);
+    });
+
+    it('does not generate Tailwind patterns for --ds-* vars', async () => {
+        // bg-ds-color-neutral-50 should NOT be searched
+        writeFileSync(path.join(tmpDir, 'Prim.tsx'), `style={{ background: 'var(--ds-color-neutral-50)' }}`);
+        const usages = await findUsages(['--ds-color-neutral-50'], tmpDir);
+        // Only var() pattern was searched — Tailwind pattern would be "bg-ds-color-neutral-50" etc.
+        const patterns = Object.keys(usages['--ds-color-neutral-50'] ?? {});
+        expect(patterns.every((p) => p.startsWith('var('))).toBe(true);
+    });
+});
+
+// ─── reportUsages ──────────────────────────────────────────────────────────────
+
+describe('reportUsages', () => {
+    function captureStream() {
+        // Use a mutable container so we don't lose the reference after destructuring
+        const buf = { output: '' };
+        const stream = { write: (chunk) => { buf.output += String(chunk); } };
+        return { stream, buf };
+    }
+
+    it('returns false and writes nothing for empty usages', () => {
+        const { stream, buf } = captureStream();
+        const result = reportUsages({}, { stream });
+        expect(result).toBe(false);
+        expect(buf.output).toBe('');
+    });
+
+    it('returns true and writes a report when usages exist', () => {
+        const { stream, buf } = captureStream();
+        const usages = {
+            '--surface-canvas': {
+                'bg-surface-canvas': [{ file: 'packages/webapp/src/Card.tsx', lines: [12, 34] }],
+                'var(--surface-canvas)': [{ file: 'packages/webapp/src/index.css', lines: [5] }]
+            }
+        };
+        const result = reportUsages(usages, { stream });
+        expect(result).toBe(true);
+        expect(buf.output).toContain('--surface-canvas');
+        expect(buf.output).toContain('bg-surface-canvas');
+        expect(buf.output).toContain('Card.tsx:12');
+        expect(buf.output).toContain('Card.tsx:34');
+        expect(buf.output).toContain('index.css:5');
+        expect(buf.output).toContain('1 removed token(s)');
+        expect(buf.output).toContain('3 usage(s)');
+    });
+
+    it('counts hits across multiple tokens', () => {
+        const { stream, buf } = captureStream();
+        const usages = {
+            '--text-strong': { 'text-text-strong': [{ file: 'a.tsx', lines: [1] }] },
+            '--border-default': { 'border-border-default': [{ file: 'b.tsx', lines: [1] }] }
+        };
+        reportUsages(usages, { stream });
+        expect(buf.output).toContain('2 removed token(s)');
+        expect(buf.output).toContain('2 usage(s)');
+    });
+});
+
+// ─── checkRemovedTokens ────────────────────────────────────────────────────────
+
+describe('checkRemovedTokens', () => {
+    let tmpDir;
+
+    beforeEach(() => {
+        tmpDir = path.join(os.tmpdir(), `test-check-${Date.now()}`);
+        mkdirSync(tmpDir, { recursive: true });
+    });
+
+    afterEach(() => {
+        rmSync(tmpDir, { recursive: true, force: true });
+    });
+
+    it('returns hasUsages: false when no tokens are removed', async () => {
+        const css = `:root { --surface-canvas: #fff; }`;
+        const result = await checkRemovedTokens({ oldCss: css, newCss: css, webappDir: tmpDir });
+        expect(result.hasUsages).toBe(false);
+        expect(result.removed).toHaveLength(0);
+    });
+
+    it('returns hasUsages: false when removed token has no webapp usages', async () => {
+        const oldCss = `:root { --surface-canvas: #fff; --text-strong: #000; }`;
+        const newCss = `:root { --surface-canvas: #fff; }`;
+        writeFileSync(path.join(tmpDir, 'App.tsx'), `<div className="bg-white" />`);
+        const result = await checkRemovedTokens({ oldCss, newCss, webappDir: tmpDir });
+        expect(result.hasUsages).toBe(false);
+        expect(result.removed).toContain('--text-strong');
+    });
+
+    it('returns hasUsages: true when removed token is still referenced', async () => {
+        const oldCss = `:root { --surface-canvas: #fff; --text-strong: #000; }`;
+        const newCss = `:root { --surface-canvas: #fff; }`;
+        writeFileSync(path.join(tmpDir, 'App.tsx'), `<div className="text-text-strong" />`);
+        const result = await checkRemovedTokens({ oldCss, newCss, webappDir: tmpDir });
+        expect(result.hasUsages).toBe(true);
+        expect(result.usages['--text-strong']).toBeDefined();
+    });
+});

--- a/packages/design-system/scripts/tokens-check-removed.unit.test.mjs
+++ b/packages/design-system/scripts/tokens-check-removed.unit.test.mjs
@@ -1,9 +1,18 @@
 import { mkdirSync, rmSync, writeFileSync } from 'node:fs';
 import os from 'node:os';
 import path from 'node:path';
+
 import { afterEach, beforeEach, describe, expect, it } from 'vitest';
 
-import { checkRemovedTokens, extractDefinedVars, findRemovedVars, findUsages, getMatchingLines, getSearchPatterns, reportUsages } from './tokens-check-removed.mjs';
+import {
+    checkRemovedTokens,
+    extractDefinedVars,
+    findRemovedVars,
+    findUsages,
+    getMatchingLines,
+    getSearchPatterns,
+    reportUsages
+} from './tokens-check-removed.mjs';
 
 // ─── extractDefinedVars ────────────────────────────────────────────────────────
 
@@ -84,6 +93,12 @@ describe('getSearchPatterns', () => {
         expect(patterns).toContain('to-surface-canvas');
     });
 
+    it('includes Tailwind v4 inset-ring and inset-shadow color utilities', () => {
+        const patterns = getSearchPatterns('--surface-canvas');
+        expect(patterns).toContain('inset-ring-surface-canvas');
+        expect(patterns).toContain('inset-shadow-surface-canvas');
+    });
+
     it('does NOT include Tailwind patterns for --ds-* primitive tokens', () => {
         const patterns = getSearchPatterns('--ds-color-neutral-50');
         expect(patterns).toEqual(['var(--ds-color-neutral-50)']);
@@ -106,6 +121,21 @@ describe('getMatchingLines', () => {
 
     it('returns empty array when pattern is not found', () => {
         expect(getMatchingLines('nothing here', 'missing')).toEqual([]);
+    });
+
+    it('does not match a token name that is a prefix of a longer token', () => {
+        // Removing `text-link` must not flag code using the distinct `text-link-hover`.
+        expect(getMatchingLines('class="text-text-link-hover"', 'text-text-link')).toEqual([]);
+    });
+
+    it('matches the exact utility and its opacity/variant forms', () => {
+        expect(getMatchingLines('class="text-text-link"', 'text-text-link')).toEqual([1]);
+        expect(getMatchingLines('class="text-text-link/50"', 'text-text-link')).toEqual([1]);
+        expect(getMatchingLines('class="hover:text-text-link"', 'text-text-link')).toEqual([1]);
+    });
+
+    it('does not match a longer var() reference', () => {
+        expect(getMatchingLines('color: var(--text-link-hover)', 'var(--text-link)')).toEqual([]);
     });
 });
 
@@ -183,7 +213,11 @@ describe('reportUsages', () => {
     function captureStream() {
         // Use a mutable container so we don't lose the reference after destructuring
         const buf = { output: '' };
-        const stream = { write: (chunk) => { buf.output += String(chunk); } };
+        const stream = {
+            write: (chunk) => {
+                buf.output += String(chunk);
+            }
+        };
         return { stream, buf };
     }
 

--- a/packages/design-system/scripts/tokens-check-removed.unit.test.mjs
+++ b/packages/design-system/scripts/tokens-check-removed.unit.test.mjs
@@ -57,12 +57,11 @@ describe('findRemovedVars', () => {
         expect(findRemovedVars(css, css)).toEqual([]);
     });
 
-    it('ignores --color-* vars (Tailwind @theme aliases)', () => {
+    it('includes removed --color-* aliases so direct var() refs are caught', () => {
         const old = makeCss('--surface-canvas', '--color-surface-canvas');
         const next = makeCss('--surface-canvas-new');
-        // --color-surface-canvas is removed but should be skipped
         const removed = findRemovedVars(old, next);
-        expect(removed).not.toContain('--color-surface-canvas');
+        expect(removed).toContain('--color-surface-canvas');
         expect(removed).toContain('--surface-canvas');
     });
 
@@ -99,15 +98,39 @@ describe('getSearchPatterns', () => {
         expect(patterns).toContain('inset-shadow-surface-canvas');
     });
 
-    it('does NOT include Tailwind patterns for --ds-* primitive tokens', () => {
+    it('does NOT include Tailwind patterns for raw --ds-* primitive tokens', () => {
         const patterns = getSearchPatterns('--ds-color-neutral-50');
         expect(patterns).toEqual(['var(--ds-color-neutral-50)']);
     });
 
-    it('includes exactly var() for a --ds-* token (no Tailwind patterns)', () => {
+    it('includes exactly var() for a raw --ds-* token (no Tailwind patterns)', () => {
         const patterns = getSearchPatterns('--ds-typography-font-size-md');
         expect(patterns.length).toBe(1);
         expect(patterns[0]).toBe('var(--ds-typography-font-size-md)');
+    });
+
+    it('maps --<ns>-ds-* primitive registrations to their single utility', () => {
+        // These are registered in @theme and generate real utilities the webapp uses
+        // (rounded-ds-xs, border-ds-hairline, text-ds-md, font-ds-medium, ...).
+        expect(getSearchPatterns('--radius-ds-xs')).toEqual(['var(--radius-ds-xs)', 'rounded-ds-xs']);
+        expect(getSearchPatterns('--text-ds-md')).toEqual(['var(--text-ds-md)', 'text-ds-md']);
+        expect(getSearchPatterns('--border-width-ds-hairline')).toEqual(['var(--border-width-ds-hairline)', 'border-ds-hairline']);
+        expect(getSearchPatterns('--font-weight-ds-medium')).toEqual(['var(--font-weight-ds-medium)', 'font-ds-medium']);
+        expect(getSearchPatterns('--tracking-ds-tight')).toEqual(['var(--tracking-ds-tight)', 'tracking-ds-tight']);
+        expect(getSearchPatterns('--leading-ds-normal')).toEqual(['var(--leading-ds-normal)', 'leading-ds-normal']);
+    });
+
+    it('treats semantic tokens sharing a primitive prefix as color tokens', () => {
+        // --text-strong is a semantic text color, not a font-size primitive.
+        const patterns = getSearchPatterns('--text-strong');
+        expect(patterns).toContain('text-text-strong');
+        expect(patterns).toContain('bg-text-strong');
+        expect(patterns).not.toContain('text-strong');
+    });
+
+    it('emits only the direct var() reference for --color-*/--shadow-* aliases', () => {
+        expect(getSearchPatterns('--color-border-muted')).toEqual(['var(--color-border-muted)']);
+        expect(getSearchPatterns('--shadow-container-inset')).toEqual(['var(--shadow-container-inset)']);
     });
 });
 

--- a/packages/design-system/scripts/tokens-fetch.mjs
+++ b/packages/design-system/scripts/tokens-fetch.mjs
@@ -26,6 +26,7 @@ import StyleDictionary from 'style-dictionary';
 const __dirname = path.dirname(fileURLToPath(import.meta.url));
 const TOKENS_DIR = path.resolve(__dirname, '../tokens');
 const BUILD_ONLY = process.argv.includes('--build-only');
+const STRICT = process.argv.includes('--strict');
 
 const GITHUB_RAW_URL = 'https://raw.githubusercontent.com/NangoHQ/nango/design/tokens/packages/design-system/tokens/tokens.json';
 
@@ -97,7 +98,7 @@ export function formatTokenValue(token) {
  * Run one Style Dictionary build pass and return the resolved, transformed tokens.
  * SD handles alias resolution, color normalization, and naming.
  */
-async function resolveTokens({ sourceFiles, includeFiles = [] }) {
+export async function resolveTokens({ sourceFiles, includeFiles = [], strict = false }) {
     const sd = new StyleDictionary({
         include: includeFiles,
         source: sourceFiles,
@@ -110,6 +111,8 @@ async function resolveTokens({ sourceFiles, includeFiles = [] }) {
                 files: []
             }
         },
+        // Always 'warn' — SD leaves unresolved aliases as raw `{alias}` strings.
+        // We handle strict vs permissive behavior ourselves in the loop below.
         log: { verbosity: 'silent', errors: { brokenReferences: 'warn' } }
     });
 
@@ -129,9 +132,12 @@ async function resolveTokens({ sourceFiles, includeFiles = [] }) {
         if (!t.isSource) continue;
         if (t['$type'] === 'other' && t.path.some((s) => s.startsWith('$'))) continue;
         const value = t.$value ?? t.value;
-        // Skip tokens with unresolved aliases — SD couldn't find the referenced token.
-        // These would produce invalid CSS (e.g. `--foo: {text.muted}`) and crash prettier.
+        // Detect unresolved aliases — SD leaves them as raw `{alias}` strings when it can't
+        // find the referenced token. Including them would produce invalid CSS with no value.
         if (typeof value === 'string' && value.startsWith('{') && value.endsWith('}')) {
+            if (strict) {
+                throw new Error(`Unresolved token alias: ${t.path.join('.')} → ${value}`);
+            }
             console.warn(`⚠ Skipping ${t.path.join('.')} — unresolved alias: ${value}`);
             continue;
         }
@@ -294,7 +300,7 @@ async function buildWithFormat({ includeFiles = [], sourceFile, outPath, format 
 
 // ─── Main ─────────────────────────────────────────────────────────────────────
 
-export async function buildCss(tokensData) {
+export async function buildCss(tokensData, { strict = false } = {}) {
     const { Primitives, 'Semantic/Light': SemanticLight, 'Semantic/Dark': SemanticDark, Typography } = tokensData;
 
     if (!Primitives || !SemanticLight || !SemanticDark) {
@@ -326,9 +332,9 @@ export async function buildCss(tokensData) {
     let primTokens, lightTokens, darkTokens, typographyCss;
     try {
         [primTokens, lightTokens, darkTokens] = await Promise.all([
-            resolveTokens({ sourceFiles: [primFile] }),
-            resolveTokens({ includeFiles: [primFile], sourceFiles: [lightFile] }),
-            resolveTokens({ includeFiles: [primFile], sourceFiles: [darkFile] })
+            resolveTokens({ sourceFiles: [primFile], strict }),
+            resolveTokens({ includeFiles: [primFile], sourceFiles: [lightFile], strict }),
+            resolveTokens({ includeFiles: [primFile], sourceFiles: [darkFile], strict })
         ]);
         typographyCss = typFile
             ? await buildWithFormat({
@@ -409,7 +415,7 @@ async function main() {
 
     // Build CSS first — if SD throws, we leave the on-disk tokens.json untouched
     // so the working tree stays consistent (old tokens.json + old tokens.generated.css).
-    const css = await buildCss(tokensData);
+    const css = await buildCss(tokensData, { strict: STRICT });
 
     mkdirSync(TOKENS_DIR, { recursive: true });
     if (!BUILD_ONLY) {

--- a/packages/design-system/scripts/tokens-fetch.mjs
+++ b/packages/design-system/scripts/tokens-fetch.mjs
@@ -281,7 +281,7 @@ export function buildTypographyBlock(tokens) {
  * Run a Style Dictionary build pass using a named format and return the output as a string.
  * SD requires a real file destination — we write to `outPath` (inside tmpDir) and read it back.
  */
-async function buildWithFormat({ includeFiles = [], sourceFile, outPath, format }) {
+async function buildWithFormat({ includeFiles = [], sourceFile, outPath, format, strict = false }) {
     const sd = new StyleDictionary({
         include: includeFiles,
         source: [sourceFile],
@@ -292,7 +292,9 @@ async function buildWithFormat({ includeFiles = [], sourceFile, outPath, format 
                 files: [{ destination: path.basename(outPath), format }]
             }
         },
-        log: { verbosity: 'silent', errors: { brokenReferences: 'warn' } }
+        // In strict mode a broken alias in the typography set throws instead of
+        // silently emitting invalid type-* CSS, matching resolveTokens' behavior.
+        log: { verbosity: 'silent', errors: { brokenReferences: strict ? 'throw' : 'warn' } }
     });
     await sd.buildAllPlatforms();
     return readFileSync(outPath, 'utf8');
@@ -341,7 +343,8 @@ export async function buildCss(tokensData, { strict = false } = {}) {
                   includeFiles: [primFile],
                   sourceFile: typFile,
                   outPath: path.join(tmpDir, 'typography.css'),
-                  format: 'css/typography-classes'
+                  format: 'css/typography-classes',
+                  strict
               })
             : '';
     } finally {

--- a/packages/design-system/scripts/tokens-fetch.unit.test.mjs
+++ b/packages/design-system/scripts/tokens-fetch.unit.test.mjs
@@ -1,4 +1,8 @@
-import { describe, expect, it } from 'vitest';
+import { mkdirSync, rmSync, writeFileSync } from 'fs';
+import os from 'os';
+import path from 'path';
+
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 
 import {
     buildCss,
@@ -7,7 +11,8 @@ import {
     buildPrimitivesThemeBlock,
     buildTailwindThemeBlock,
     buildTypographyBlock,
-    formatTokenValue
+    formatTokenValue,
+    resolveTokens
 } from './tokens-fetch.mjs';
 
 // ─── formatTokenValue ──────────────────────────────────────────────────────────
@@ -270,5 +275,86 @@ describe('buildCss', () => {
 
     it('lists the sets it did find in the error message', async () => {
         await expect(buildCss({ Primitives: {}, 'Semantic/Light': {} })).rejects.toThrow(/Found: Primitives, Semantic\/Light/);
+    });
+});
+
+// ─── resolveTokens — strict flag ──────────────────────────────────────────────
+
+describe('resolveTokens — strict flag', () => {
+    let tmpDir;
+
+    // Token files used across tests:
+    //   valid.json   — one color token with a resolvable self-reference alias
+    //   broken.json  — one good token + one pointing to a non-existent alias
+
+    beforeEach(() => {
+        tmpDir = path.join(os.tmpdir(), `ds-test-${Date.now()}`);
+        mkdirSync(tmpDir, { recursive: true });
+
+        writeFileSync(
+            path.join(tmpDir, 'valid.json'),
+            JSON.stringify({
+                color: {
+                    blue: { $value: '#3b82f6', $type: 'color' }
+                },
+                text: {
+                    primary: { $value: '{color.blue}', $type: 'color' }
+                }
+            })
+        );
+
+        writeFileSync(
+            path.join(tmpDir, 'broken.json'),
+            JSON.stringify({
+                color: {
+                    blue: { $value: '#3b82f6', $type: 'color' }
+                },
+                text: {
+                    primary: { $value: '{color.blue}', $type: 'color' },
+                    muted: { $value: '{nonexistent.token}', $type: 'color' }
+                }
+            })
+        );
+    });
+
+    afterEach(() => {
+        rmSync(tmpDir, { recursive: true, force: true });
+    });
+
+    it('resolves valid aliases in non-strict mode', async () => {
+        const tokens = await resolveTokens({ sourceFiles: [path.join(tmpDir, 'valid.json')] });
+        const names = tokens.map((t) => t.path.join('.'));
+        expect(names).toContain('color.blue');
+        expect(names).toContain('text.primary');
+    });
+
+    it('skips unresolved aliases and warns in non-strict mode (default)', async () => {
+        const warnSpy = vi.spyOn(console, 'warn').mockImplementation(() => {});
+        try {
+            const tokens = await resolveTokens({ sourceFiles: [path.join(tmpDir, 'broken.json')] });
+            // The broken token should be silently dropped
+            const names = tokens.map((t) => t.path.join('.'));
+            expect(names).not.toContain('text.muted');
+            // Valid tokens still present
+            expect(names).toContain('color.blue');
+            expect(names).toContain('text.primary');
+            // A warning was emitted
+            expect(warnSpy).toHaveBeenCalledWith(expect.stringContaining('text.muted'));
+            expect(warnSpy).toHaveBeenCalledWith(expect.stringContaining('{nonexistent.token}'));
+        } finally {
+            warnSpy.mockRestore();
+        }
+    });
+
+    it('throws on unresolved aliases in strict mode', async () => {
+        await expect(
+            resolveTokens({ sourceFiles: [path.join(tmpDir, 'broken.json')], strict: true })
+        ).rejects.toThrow(/Unresolved token alias: text\.muted → \{nonexistent\.token\}/);
+    });
+
+    it('does not throw for a fully resolved token set in strict mode', async () => {
+        await expect(
+            resolveTokens({ sourceFiles: [path.join(tmpDir, 'valid.json')], strict: true })
+        ).resolves.not.toThrow();
     });
 });


### PR DESCRIPTION
## Problem

When design tokens are consolidated or renamed, CSS variables disappear from `tokens.generated.css` but webapp code can still reference them — directly via `var(--token)` or via Tailwind utilities (`bg-token`, `rounded-ds-*`, …). These orphaned references only surface when something visually breaks. We caught exactly this by hand in #6788; this PR automates that check.

## Solution

- **`tokens-check-removed.mjs`**: diffs merge-base vs current `tokens.generated.css` for removed CSS variables, then scans `packages/webapp/src` for each removed token's real references — direct `var()` (including fallback forms) and the exact Tailwind utilities it generates. Matches at token boundaries so `text-link` doesn't false-positive on `text-text-link-hover`.
- **`--strict` build flag**: unresolved token aliases warn-and-skip locally but throw in CI, so a broken alias can't silently produce incomplete CSS.
- **CI workflow** (`tokens-check.yaml`) on PRs/merge-queue touching tokens/scripts/webapp: build `--strict`, assert the committed CSS matches the rebuild (`git diff --exit-code`), then run the removed-token check. A `token-check` aggregation job provides a stable required-status-check name.

## Testing

- `npm test --workspace=@nangohq/design-system` passes.
- `tokens:build --strict` and `tokens:check` exit 0 on the current token set with no CSS drift.
- Verified the gates fire: removing `--radius-ds-xs`, `--color-border-muted`, and used semantic tokens each flag their webapp references.

## Follow-up

- `token-check` still needs to be added as a required status check in `master` branch protection (a repo setting) for the gate to block merges.

Fixes [NAN-5679](https://linear.app/nango/issue/NAN-5679)
