### PR TITLE
feat(event-script): gate hubspot pre-connection-deletion script with metadata

### DIFF
--- a/packages/server/lib/hooks/connection/providers/hubspot/pre-connection-deletion.ts
+++ b/packages/server/lib/hooks/connection/providers/hubspot/pre-connection-deletion.ts
@@ -8,6 +8,12 @@ export default async function execute(nango: InternalNango) {
         const connection = await nango.getConnection();
         const credentials = connection.credentials as OAuth2Credentials;
 
+        // Some customers share a single HubSpot portal (and refresh token) across multiple Nango connections.
+        // Revoking the token when one connection is deleted would break the others, so allow opting out via metadata.
+        if (connection.metadata?.['skipTokenRevocation'] === true) {
+            return;
+        }
+
         if (!credentials.refresh_token) {
             return;
         }


### PR DESCRIPTION
## Describe the problem and your solution

- gate hubspot pre-connection-deletion script with metadata as some users share a single HubSpot portal (and refresh token) across multiple Nango connections, revoking the token when one connection is deleted would break the others.

<!-- Issue ticket number and link (if applicable) -->

<!-- Testing instructions (skip if just adding/editing providers) -->



<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/NangoHQ/nango/pull/6817?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

