### PR TITLE
feat(auth): gate sign-in behind MFA

### DIFF
--- a/packages/server/lib/controllers/v1/account/mfa/login.ts
+++ b/packages/server/lib/controllers/v1/account/mfa/login.ts
@@ -1,0 +1,101 @@
+import db from '@nangohq/database';
+import { getFlags } from '@nangohq/feature-flags';
+import { accountService, mfaService, userService } from '@nangohq/shared';
+
+import type { DBUser, PostMFALoginVerification } from '@nangohq/types';
+import type { Request } from 'express';
+
+const MFA_LOGIN_TTL_MS = 10 * 60 * 1000;
+// Reserved TLD (RFC 2606) used only to resolve relative paths; a returnTo that escapes this origin is rejected.
+const RETURN_TO_BASE_ORIGIN = 'https://internal.invalid';
+
+type PendingMFALoginResult = { user: DBUser; returnTo: string } | { error: 'expired' | 'invalid' };
+
+export async function loginOrStartPendingMfa(req: Request, user: DBUser, returnTo: string): Promise<boolean> {
+    if (!(await isMFAEnabled(user)) || !(await mfaService.hasActiveFactor(user.id))) {
+        await loginUser(req, user);
+        return false;
+    }
+
+    await regenerateSession(req);
+    req.session.pendingMfaLogin = { userId: user.id, returnTo: safeReturnTo(returnTo), createdAt: Date.now() };
+    await saveSession(req);
+    return true;
+}
+
+export async function verifyPendingMfaLogin(req: Request, credential: PostMFALoginVerification['Body']): Promise<PendingMFALoginResult> {
+    const pending = req.session.pendingMfaLogin;
+    if (!pending || Date.now() - pending.createdAt > MFA_LOGIN_TTL_MS) {
+        delete req.session.pendingMfaLogin;
+        await saveSession(req);
+        return { error: 'expired' };
+    }
+
+    const user = await loadEligibleUser(pending.userId);
+    if (!user) {
+        return { error: 'invalid' };
+    }
+    const verified = (
+        credential.type === 'recoveryCode'
+            ? await mfaService.consumeRecoveryCode(user.id, credential.recoveryCode)
+            : await mfaService.verifyTotp(user.id, credential.code)
+    ).unwrap();
+    if (!verified) {
+        return { error: 'invalid' };
+    }
+
+    // Account state can change while the user completes the MFA challenge.
+    const currentUser = await loadEligibleUser(pending.userId);
+    if (!currentUser) {
+        return { error: 'invalid' };
+    }
+
+    const returnTo = pending.returnTo;
+    delete req.session.pendingMfaLogin;
+    await loginUser(req, currentUser);
+    await saveSession(req);
+    return { user: currentUser, returnTo };
+}
+
+async function loadEligibleUser(userId: number): Promise<DBUser | null> {
+    const user = await userService.getUserById(userId, true);
+    if (!user || user.suspended || !(await isMFAEnabled(user))) {
+        return null;
+    }
+    return user;
+}
+
+async function isMFAEnabled(user: DBUser): Promise<boolean> {
+    const account = await accountService.getAccountById(db.knex, user.account_id);
+    return Boolean(account && (await getFlags().isMFAEnabled(account.uuid)));
+}
+
+async function loginUser(req: Request, user: DBUser): Promise<void> {
+    await new Promise<void>((resolve, reject) => {
+        req.login(user, (err) => (err ? reject(err instanceof Error ? err : new Error(String(err))) : resolve()));
+    });
+}
+
+async function regenerateSession(req: Request): Promise<void> {
+    await new Promise<void>((resolve, reject) => {
+        req.session.regenerate((err) => (err ? reject(err instanceof Error ? err : new Error(String(err))) : resolve()));
+    });
+}
+
+async function saveSession(req: Request): Promise<void> {
+    await new Promise<void>((resolve, reject) => {
+        req.session.save((err) => (err ? reject(err instanceof Error ? err : new Error(String(err))) : resolve()));
+    });
+}
+
+function safeReturnTo(returnTo: string): string {
+    try {
+        const url = new URL(returnTo, RETURN_TO_BASE_ORIGIN);
+        if (url.origin === RETURN_TO_BASE_ORIGIN) {
+            return url.pathname + url.search + url.hash;
+        }
+    } catch {
+        // Malformed value; fall through to the safe default.
+    }
+    return '/';
+}

--- a/packages/server/lib/controllers/v1/account/mfa/mfa.ts
+++ b/packages/server/lib/controllers/v1/account/mfa/mfa.ts
@@ -4,10 +4,12 @@ import { getFlags } from '@nangohq/feature-flags';
 import { MFAError, mfaService } from '@nangohq/shared';
 import { requireEmptyQuery, zodErrorToHTTP } from '@nangohq/utils';
 
+import { userToAPI } from '../../../../formatters/user.js';
 import { asyncWrapper } from '../../../../utils/asyncWrapper.js';
+import { verifyPendingMfaLogin } from './login.js';
 
 import type { RequestLocals } from '../../../../utils/express.js';
-import type { DeleteMFA, GetMFAStatus, PostMFAActivation, PostMFAEnrollment, PostMFARecoveryCodes } from '@nangohq/types';
+import type { DeleteMFA, GetMFAStatus, PostMFAActivation, PostMFAEnrollment, PostMFALoginVerification, PostMFARecoveryCodes } from '@nangohq/types';
 import type { Request, Response } from 'express';
 
 const codeValidation = z
@@ -15,6 +17,21 @@ const codeValidation = z
         code: z.string().regex(/^\d{6}$/)
     })
     .strict();
+
+const loginValidation = z.discriminatedUnion('type', [
+    z
+        .object({
+            type: z.literal('code'),
+            code: z.string().regex(/^\d{6}$/)
+        })
+        .strict(),
+    z
+        .object({
+            type: z.literal('recoveryCode'),
+            recoveryCode: z.string().min(1).max(255)
+        })
+        .strict()
+]);
 
 function validateQuery(req: Request, res: Response): boolean {
     const emptyQuery = requireEmptyQuery(req, { withEnv: false });
@@ -184,4 +201,26 @@ export const deleteMFA = asyncWrapper<DeleteMFA>(async (req, res) => {
         throw disabled.error;
     }
     res.status(200).send({ success: true });
+});
+
+export const postMFALoginVerification = asyncWrapper<PostMFALoginVerification>(async (req, res) => {
+    if (!validateQuery(req, res)) {
+        return;
+    }
+    const val = loginValidation.safeParse(req.body);
+    if (!val.success) {
+        res.status(400).send({ error: { code: 'invalid_body', errors: zodErrorToHTTP(val.error) } });
+        return;
+    }
+
+    const verified = await verifyPendingMfaLogin(req, val.data);
+    if ('error' in verified) {
+        if (verified.error === 'expired') {
+            res.status(400).send({ error: { code: 'mfa_login_expired' } });
+            return;
+        }
+        res.status(400).send({ error: { code: 'invalid_mfa_code' } });
+        return;
+    }
+    res.status(200).send({ data: { user: userToAPI(verified.user), url: verified.returnTo } });
 });

--- a/packages/server/lib/controllers/v1/account/signin.integration.test.ts
+++ b/packages/server/lib/controllers/v1/account/signin.integration.test.ts
@@ -1,9 +1,13 @@
-import { afterAll, beforeAll, describe, expect, it } from 'vitest';
+import * as OTPAuth from 'otpauth';
+import { afterAll, beforeAll, describe, expect, it, vi } from 'vitest';
 
-import { userService } from '@nangohq/shared';
+import * as featureFlags from '@nangohq/feature-flags';
+import { mfaService, userService } from '@nangohq/shared';
 import { nanoid } from '@nangohq/utils';
 
 import { isError, isSuccess, runServer } from '../../../utils/tests.js';
+
+import type { DBUser } from '@nangohq/types';
 
 const signupRoute = '/api/v1/account/signup';
 const signinRoute = '/api/v1/account/signin';
@@ -32,13 +36,25 @@ async function signupUser({ emailVerified }: { emailVerified: boolean }): Promis
     return { email, password };
 }
 
+async function enrollMfaUser(): Promise<{ email: string; password: string; user: DBUser; totp: OTPAuth.TOTP }> {
+    const { email, password } = await signupUser({ emailVerified: true });
+    const user = await userService.getUserByEmail(email);
+    expect(user).toBeTruthy();
+    const enrollment = (await mfaService.startEnrollment(user!.id, email)).unwrap();
+    const totp = OTPAuth.URI.parse(enrollment.otpauthUri) as OTPAuth.TOTP;
+    (await mfaService.activateEnrollment(user!.id, totp.generate())).unwrap();
+    return { email, password, user: user!, totp };
+}
+
 describe(`POST ${signinRoute}`, () => {
     beforeAll(async () => {
         api = await runServer();
+        vi.spyOn(featureFlags.getFlags(), 'isMFAEnabled').mockResolvedValue(true);
     });
 
     afterAll(() => {
         api.server.close();
+        vi.restoreAllMocks();
     });
 
     it('should not set a session cookie when the body is invalid (even if credentials are valid)', async () => {
@@ -84,5 +100,90 @@ describe(`POST ${signinRoute}`, () => {
         const cookies = res.headers.getSetCookie();
         expect(cookies.length).toBeGreaterThan(0);
         expect(cookies[0]).toMatch(/^nango_session=/);
+    });
+
+    it('requires MFA verification before issuing an authenticated session', async () => {
+        const { email, password, user, totp } = await enrollMfaUser();
+        expect(await mfaService.hasActiveFactor(user.id)).toBe(true);
+
+        const signinResponse = await api.fetch(signinRoute, { method: 'POST', body: { email, password } });
+        expect(signinResponse.res.status).toBe(200);
+        isSuccess(signinResponse.json);
+        expect(signinResponse.json).toEqual({ data: { mfaRequired: true } });
+        const pendingSession = signinResponse.res.headers.getSetCookie()[0]!.split(';')[0]!;
+
+        const userResponse = await api.fetch('/api/v1/user', { method: 'GET', session: pendingSession });
+        expect(userResponse.res.status).toBe(401);
+
+        const verification = await api.fetch('/api/v1/account/mfa/login/verify', {
+            method: 'POST',
+            session: pendingSession,
+            body: { type: 'code', code: totp.generate({ timestamp: Date.now() + 30_000 }) }
+        });
+        expect(verification.res.status).toBe(200);
+        isSuccess(verification.json);
+        expect(verification.json.data.user.email.toLowerCase()).toBe(email.toLowerCase());
+    });
+
+    it('returns the requested returnTo after MFA verification', async () => {
+        const { email, password, totp } = await enrollMfaUser();
+
+        const signinResponse = await api.fetch(signinRoute, { method: 'POST', body: { email, password, returnTo: '/integrations' } });
+        const pendingSession = signinResponse.res.headers.getSetCookie()[0]!.split(';')[0]!;
+
+        const verification = await api.fetch('/api/v1/account/mfa/login/verify', {
+            method: 'POST',
+            session: pendingSession,
+            body: { type: 'code', code: totp.generate({ timestamp: Date.now() + 30_000 }) }
+        });
+        expect(verification.res.status).toBe(200);
+        isSuccess(verification.json);
+        expect(verification.json.data.url).toBe('/integrations');
+    });
+
+    it('sanitizes unsafe returnTo values to root', async () => {
+        const unsafeReturnTos = ['//evil.com', '/\t//evil.com', '/\n//evil.com', '/\\evil.com', 'https://evil.com'];
+
+        for (const returnTo of unsafeReturnTos) {
+            const { email, password, totp } = await enrollMfaUser();
+
+            const signinResponse = await api.fetch(signinRoute, { method: 'POST', body: { email, password, returnTo } });
+            const pendingSession = signinResponse.res.headers.getSetCookie()[0]!.split(';')[0]!;
+
+            const verification = await api.fetch('/api/v1/account/mfa/login/verify', {
+                method: 'POST',
+                session: pendingSession,
+                body: { type: 'code', code: totp.generate({ timestamp: Date.now() + 30_000 }) }
+            });
+            expect(verification.res.status).toBe(200);
+            isSuccess(verification.json);
+            expect(verification.json.data.url, `returnTo=${JSON.stringify(returnTo)}`).toBe('/');
+        }
+    });
+
+    it('rejects an expired MFA challenge', async () => {
+        const verification = await api.fetch('/api/v1/account/mfa/login/verify', { method: 'POST', body: { type: 'code', code: '123456' } });
+
+        expect(verification.res.status).toBe(400);
+        isError(verification.json);
+        expect(verification.json.error.code).toBe('mfa_login_expired');
+    });
+
+    it('rejects MFA verification when the user is suspended during the challenge', async () => {
+        const { email, password, user, totp } = await enrollMfaUser();
+
+        const signinResponse = await api.fetch(signinRoute, { method: 'POST', body: { email, password } });
+        const pendingSession = signinResponse.res.headers.getSetCookie()[0]!.split(';')[0]!;
+        await userService.suspendUser(user.id);
+
+        const verification = await api.fetch('/api/v1/account/mfa/login/verify', {
+            method: 'POST',
+            session: pendingSession,
+            body: { type: 'code', code: totp.generate({ timestamp: Date.now() + 30_000 }) }
+        });
+
+        expect(verification.res.status).toBe(400);
+        isError(verification.json);
+        expect(verification.json.error.code).toBe('invalid_mfa_code');
     });
 });

--- a/packages/server/lib/controllers/v1/account/signin.ts
+++ b/packages/server/lib/controllers/v1/account/signin.ts
@@ -5,6 +5,7 @@ import { requireEmptyQuery, zodErrorToHTTP } from '@nangohq/utils';
 
 import { userToAPI } from '../../../formatters/user.js';
 import { asyncWrapper } from '../../../utils/asyncWrapper.js';
+import { loginOrStartPendingMfa } from './mfa/login.js';
 
 import type { RequestLocals } from '../../../utils/express.js';
 import type { PostSignin } from '@nangohq/types';
@@ -13,7 +14,8 @@ import type { RequestHandler, Response } from 'express';
 const validation = z
     .object({
         email: z.string().email(),
-        password: z.string().min(8).max(64)
+        password: z.string().min(8).max(64),
+        returnTo: z.string().max(1024).optional()
     })
     .strict();
 
@@ -59,15 +61,10 @@ export const signin = asyncWrapper<PostSignin>(async (req, res: Response<any, Re
         return;
     }
 
-    await new Promise<void>((resolve, reject) => {
-        req.logIn(user as Express.User, (err) => {
-            if (err) {
-                reject(err instanceof Error ? err : new Error(String(err)));
-            } else {
-                resolve();
-            }
-        });
-    });
+    if (await loginOrStartPendingMfa(req, user, req.body.returnTo ?? '/')) {
+        res.status(200).send({ data: { mfaRequired: true } });
+        return;
+    }
 
     res.status(200).send({ user: userToAPI(user) });
 });

--- a/packages/server/lib/express.d.ts
+++ b/packages/server/lib/express.d.ts
@@ -22,6 +22,11 @@ declare module 'express-session' {
             pendingAuthenticationToken: string;
             state?: string | undefined;
         };
+        pendingMfaLogin?: {
+            userId: number;
+            returnTo: string;
+            createdAt: number;
+        };
     }
 }
 

--- a/packages/server/lib/routes.private.ts
+++ b/packages/server/lib/routes.private.ts
@@ -28,7 +28,14 @@ import { getManagedCallback } from './controllers/v1/account/managed/getCallback
 import { getManagedEmailVerification } from './controllers/v1/account/managed/getVerification.js';
 import { postManagedSignup } from './controllers/v1/account/managed/postSignup.js';
 import { postManagedEmailVerification } from './controllers/v1/account/managed/postVerification.js';
-import { deleteMFA, getMFAStatus, postMFAActivation, postMFAEnrollment, postMFARecoveryCodes } from './controllers/v1/account/mfa/mfa.js';
+import {
+    deleteMFA,
+    getMFAStatus,
+    postMFAActivation,
+    postMFAEnrollment,
+    postMFALoginVerification,
+    postMFARecoveryCodes
+} from './controllers/v1/account/mfa/mfa.js';
 import { postForgotPassword } from './controllers/v1/account/postForgotPassword.js';
 import { postLogout } from './controllers/v1/account/postLogout.js';
 import { putResetPassword } from './controllers/v1/account/putResetPassword.js';
@@ -193,6 +200,7 @@ web.route('/account/mfa').get(webAuth, getMFAStatus).delete(webAuth, deleteMFA);
 web.route('/account/mfa/enroll').post(webAuth, postMFAEnrollment);
 web.route('/account/mfa/activate').post(webAuth, postMFAActivation);
 web.route('/account/mfa/recovery-codes').post(webAuth, postMFARecoveryCodes);
+web.route('/account/mfa/login/verify').post(rateLimiterMiddleware, postMFALoginVerification);
 
 // Team
 web.route('/team').get(webAuth, getTeam);

--- a/packages/types/lib/account/api.ts
+++ b/packages/types/lib/account/api.ts
@@ -93,11 +93,10 @@ export type PostSignin = Endpoint<{
     Body: {
         email: string;
         password: string;
+        returnTo?: string;
     };
     Error: ApiError<'email_not_verified'> | ApiError<'user_suspended'> | ApiError<'unauthorized'>;
-    Success: {
-        user: ApiUser;
-    };
+    Success: { user: ApiUser } | { data: { mfaRequired: true } };
 }>;
 
 export type PostLogout = Endpoint<{

--- a/packages/types/lib/api.endpoints.ts
+++ b/packages/types/lib/api.endpoints.ts
@@ -104,7 +104,7 @@ import type {
 import type { DeleteInvite, GetInvite, PostInvite } from './invitations/api.js';
 import type { GetOperation, PostInsights, SearchFilters, SearchMessages, SearchOperations } from './logs/api.js';
 import type { GetMeta } from './meta/api.js';
-import type { DeleteMFA, GetMFAStatus, PostMFAActivation, PostMFAEnrollment, PostMFARecoveryCodes } from './mfa/api.js';
+import type { DeleteMFA, GetMFAStatus, PostMFAActivation, PostMFAEnrollment, PostMFALoginVerification, PostMFARecoveryCodes } from './mfa/api.js';
 import type { GetPlainHmac } from './plain/api.js';
 import type { GetBillingUsage, GetBillingUsageTopDimensionValues, PostPlanChange, PostPlanExtendTrial, PutBillingInvoicingDetails } from './plans/http.api.js';
 import type { GetProvider, GetProviders, GetPublicProvider, GetPublicProviders } from './providers/api.js';
@@ -271,6 +271,7 @@ export type PrivateApiEndpoints =
     | PostMFAEnrollment
     | PostMFAActivation
     | PostMFARecoveryCodes
+    | PostMFALoginVerification
     | DeleteMFA
     | GetPlainHmac;
 

--- a/packages/types/lib/mfa/api.ts
+++ b/packages/types/lib/mfa/api.ts
@@ -1,4 +1,5 @@
 import type { ApiError, Endpoint } from '../api.js';
+import type { ApiUser } from '../user/api.js';
 
 type MFAError = ApiError<'invalid_mfa_code'> | ApiError<'mfa_already_enabled'> | ApiError<'mfa_enrollment_not_found'> | ApiError<'mfa_not_enabled'>;
 
@@ -40,3 +41,11 @@ export type DeleteMFA = Endpoint<{
 }>;
 
 export type MFAEndpointError = MFAError;
+
+export type PostMFALoginVerification = Endpoint<{
+    Method: 'POST';
+    Path: '/api/v1/account/mfa/login/verify';
+    Body: { type: 'code'; code: string } | { type: 'recoveryCode'; recoveryCode: string };
+    Error: ApiError<'invalid_mfa_code'> | ApiError<'mfa_login_expired'>;
+    Success: { data: { user: ApiUser; url: string } };
+}>;

--- a/packages/webapp/src/hooks/useAuth.tsx
+++ b/packages/webapp/src/hooks/useAuth.tsx
@@ -30,12 +30,12 @@ export function useSigninAPI() {
               status: 401;
           },
         APIError,
-        { email: string; password: string }
+        PostSignin['Body']
     >({
-        mutationFn: async ({ email, password }) => {
+        mutationFn: async ({ email, password, returnTo }) => {
             const res = await apiFetch('/api/v1/account/signin', {
                 method: 'POST',
-                body: JSON.stringify({ email, password })
+                body: JSON.stringify({ email, password, returnTo })
             });
 
             if (res.status === 200) {

--- a/packages/webapp/src/pages/Account/Signin.tsx
+++ b/packages/webapp/src/pages/Account/Signin.tsx
@@ -27,6 +27,22 @@ const signinSchema = z.object({
 
 type SigninFormData = z.infer<typeof signinSchema>;
 
+// Resolve against the current origin and reject anything that escapes it, so a crafted `next` can't become an open redirect.
+function safeInternalPath(path: string | null): string {
+    if (!path) {
+        return '/';
+    }
+    try {
+        const url = new URL(path, window.location.origin);
+        if (url.origin === window.location.origin) {
+            return url.pathname + url.search + url.hash;
+        }
+    } catch {
+        // Malformed value; fall through to the safe default.
+    }
+    return '/';
+}
+
 export const Signin: React.FC = () => {
     const hasLocalAuth = globalEnv.features.auth;
     const hasManagedAuth = globalEnv.features.managedAuth;
@@ -70,12 +86,16 @@ export const Signin: React.FC = () => {
     const onSubmitForm = async (data: SigninFormData) => {
         setServerErrorMessage('');
         try {
-            const res = await signinMutation({ email: data.email, password: data.password });
+            const res = await signinMutation({ email: data.email, password: data.password, returnTo: next ?? undefined });
 
             if (res.status === 200) {
+                if (!('user' in res.json)) {
+                    navigate('/signin/mfa');
+                    return;
+                }
                 const user: ApiUser = res.json.user;
                 signin(user);
-                navigate(next && next.startsWith('/') && !next.startsWith('//') ? next : '/');
+                navigate(safeInternalPath(next));
             } else if (res.status === 401) {
                 setServerErrorMessage('Invalid email or password.');
                 form.resetField('password', { defaultValue: '' });


### PR DESCRIPTION
## Summary
- Gate password sign-in behind an active MFA factor for accounts with the mfa flag enabled.
- Create a short-lived pending MFA session without authenticating the user, require TOTP or a recovery code before completing login.
- Route the dashboard sign-in flow to the MFA challenge response and add the supporting endpoint, session, and API types.
- Add coverage confirming no authenticated session is issued until MFA verification succeeds and operational MFA failures propagate as server errors

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/NangoHQ/nango/pull/6822?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

