### PR TITLE
chore(ratelimit): add 10xl and 12xl rate limit tiers

### DIFF
--- a/packages/server/lib/middleware/ratelimit.middleware.ts
+++ b/packages/server/lib/middleware/ratelimit.middleware.ts
@@ -26,6 +26,7 @@ const rateLimiterSize: Record<DBPlan['api_rate_limit_size'], number> = {
     '4xl': defaultLimit * 75,
     '5xl': defaultLimit * 100,
     '6xl': defaultLimit * 125,
+    '8xl': defaultLimit * 175,
     '10xl': defaultLimit * 225,
     '12xl': defaultLimit * 275
 };

--- a/packages/server/lib/middleware/ratelimit.middleware.ts
+++ b/packages/server/lib/middleware/ratelimit.middleware.ts
@@ -26,8 +26,11 @@ const rateLimiterSize: Record<DBPlan['api_rate_limit_size'], number> = {
     '4xl': defaultLimit * 75,
     '5xl': defaultLimit * 100,
     '6xl': defaultLimit * 125,
+    '7xl': defaultLimit * 150,
     '8xl': defaultLimit * 175,
+    '9xl': defaultLimit * 200,
     '10xl': defaultLimit * 225,
+    '11xl': defaultLimit * 250,
     '12xl': defaultLimit * 275
 };
 const limiters = new Map<DBPlan['api_rate_limit_size'], RateLimiterAbstract>();

--- a/packages/server/lib/middleware/ratelimit.middleware.ts
+++ b/packages/server/lib/middleware/ratelimit.middleware.ts
@@ -25,7 +25,9 @@ const rateLimiterSize: Record<DBPlan['api_rate_limit_size'], number> = {
     '3xl': defaultLimit * 50,
     '4xl': defaultLimit * 75,
     '5xl': defaultLimit * 100,
-    '6xl': defaultLimit * 125
+    '6xl': defaultLimit * 125,
+    '10xl': defaultLimit * 225,
+    '12xl': defaultLimit * 275
 };
 const limiters = new Map<DBPlan['api_rate_limit_size'], RateLimiterAbstract>();
 

--- a/packages/shared/lib/services/plans/plans.ts
+++ b/packages/shared/lib/services/plans/plans.ts
@@ -330,9 +330,12 @@ export function mergeFlags({ currentPlan, newPlanDefinition }: { currentPlan: DB
                     '4xl': 7,
                     '5xl': 8,
                     '6xl': 9,
-                    '8xl': 10,
-                    '10xl': 11,
-                    '12xl': 12
+                    '7xl': 10,
+                    '8xl': 11,
+                    '9xl': 12,
+                    '10xl': 13,
+                    '11xl': 14,
+                    '12xl': 15
                 };
                 const currentIndex = sizeIndex[currentPlan[key]];
                 const newIndex = sizeIndex[newPlanDefinition.flags[key]];

--- a/packages/shared/lib/services/plans/plans.ts
+++ b/packages/shared/lib/services/plans/plans.ts
@@ -329,7 +329,9 @@ export function mergeFlags({ currentPlan, newPlanDefinition }: { currentPlan: DB
                     '3xl': 6,
                     '4xl': 7,
                     '5xl': 8,
-                    '6xl': 9
+                    '6xl': 9,
+                    '10xl': 10,
+                    '12xl': 11
                 };
                 const currentIndex = sizeIndex[currentPlan[key]];
                 const newIndex = sizeIndex[newPlanDefinition.flags[key]];

--- a/packages/shared/lib/services/plans/plans.ts
+++ b/packages/shared/lib/services/plans/plans.ts
@@ -330,8 +330,9 @@ export function mergeFlags({ currentPlan, newPlanDefinition }: { currentPlan: DB
                     '4xl': 7,
                     '5xl': 8,
                     '6xl': 9,
-                    '10xl': 10,
-                    '12xl': 11
+                    '8xl': 10,
+                    '10xl': 11,
+                    '12xl': 12
                 };
                 const currentIndex = sizeIndex[currentPlan[key]];
                 const newIndex = sizeIndex[newPlanDefinition.flags[key]];

--- a/packages/types/lib/plans/db.ts
+++ b/packages/types/lib/plans/db.ts
@@ -124,7 +124,7 @@ export interface DBPlan extends Timestamps {
      * Change the applied rate limit for the public API
      * @default "m"
      */
-    api_rate_limit_size: 's' | 'm' | 'l' | 'xl' | '2xl' | '3xl' | '4xl' | '5xl' | '6xl' | '10xl' | '12xl';
+    api_rate_limit_size: 's' | 'm' | 'l' | 'xl' | '2xl' | '3xl' | '4xl' | '5xl' | '6xl' | '8xl' | '10xl' | '12xl';
 
     /**
      * Enable or disable machine auto idling

--- a/packages/types/lib/plans/db.ts
+++ b/packages/types/lib/plans/db.ts
@@ -124,7 +124,7 @@ export interface DBPlan extends Timestamps {
      * Change the applied rate limit for the public API
      * @default "m"
      */
-    api_rate_limit_size: 's' | 'm' | 'l' | 'xl' | '2xl' | '3xl' | '4xl' | '5xl' | '6xl';
+    api_rate_limit_size: 's' | 'm' | 'l' | 'xl' | '2xl' | '3xl' | '4xl' | '5xl' | '6xl' | '10xl' | '12xl';
 
     /**
      * Enable or disable machine auto idling

--- a/packages/types/lib/plans/db.ts
+++ b/packages/types/lib/plans/db.ts
@@ -124,7 +124,7 @@ export interface DBPlan extends Timestamps {
      * Change the applied rate limit for the public API
      * @default "m"
      */
-    api_rate_limit_size: 's' | 'm' | 'l' | 'xl' | '2xl' | '3xl' | '4xl' | '5xl' | '6xl' | '8xl' | '10xl' | '12xl';
+    api_rate_limit_size: 's' | 'm' | 'l' | 'xl' | '2xl' | '3xl' | '4xl' | '5xl' | '6xl' | '7xl' | '8xl' | '9xl' | '10xl' | '11xl' | '12xl';
 
     /**
      * Enable or disable machine auto idling


### PR DESCRIPTION
## Summary
- Add `10xl` (×225) and `12xl` (×275) API rate limit tiers for plan overrides
- Same surface area as the previous rate limit bump: middleware limits, plan type, and merge ordering

## Test plan
- [ ] Confirm plans can be set to `api_rate_limit_size: '10xl' | '12xl'`
- [ ] Confirm rate limit headers reflect the new caps under load

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/NangoHQ/nango/pull/6824?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

