### PR TITLE
fix(providers): disable PKCE for jobber token exchange

### DIFF
--- a/packages/providers/providers.yaml
+++ b/packages/providers/providers.yaml
@@ -11289,6 +11289,7 @@ jobber:
     auth_mode: OAUTH2
     authorization_url: https://api.getjobber.com/api/oauth/authorize
     token_url: https://api.getjobber.com/api/oauth/token
+    disable_pkce: true
     authorization_params:
         response_type: code
     proxy:


### PR DESCRIPTION
Jobber's OAuth is broken today: its custom token function (`createJobberToken`) never sends a `code_verifier`, but the `jobber` provider entry had no `disable_pkce`, so the generic authorize flow still added a PKCE `code_challenge`. Jobber then rejects every token exchange with HTTP 400 (`jobber_token_request_error`) and no connection can be created.

Setting `disable_pkce: true` keeps both sides consistent (no challenge, no verifier) so the plain authorization-code flow that `createJobberToken` implements succeeds - same as the 64 other providers that already set this flag. `refreshJobberToken` is already PKCE-free and unaffected.

Closes #6825. The reporter verified the no-PKCE flow works against a live Jobber app.

`npm run test:providers` passes (schema + interpolation validation).

Note: #6825 also mentions the deprecated default `x-jobber-graphql-version` (`2025-01-20`). I left that out to keep this PR focused on the auth bug, and since the replacement version should be confirmed against Jobber's changelog first - happy to follow up separately.


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/NangoHQ/nango/pull/6826?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

