### PR TITLE
feat(account): add same-domain-account search

### DIFF
--- a/packages/database/lib/migrations/20260720120000_nango_users_email_domain_index.cjs
+++ b/packages/database/lib/migrations/20260720120000_nango_users_email_domain_index.cjs
@@ -1,0 +1,15 @@
+exports.config = { transaction: false };
+
+/**
+ * @param {import('knex').Knex} knex
+ */
+exports.up = async function (knex) {
+    await knex.raw(`
+        CREATE INDEX CONCURRENTLY IF NOT EXISTS "nango_users_email_domain_active"
+        ON "_nango_users" (LOWER(SPLIT_PART(email, '@', 2)))
+        INCLUDE (account_id)
+        WHERE suspended = false
+    `);
+};
+
+exports.down = function () {};

--- a/packages/database/lib/migrations/20260721120000_nango_users_account_id_index.cjs
+++ b/packages/database/lib/migrations/20260721120000_nango_users_account_id_index.cjs
@@ -1,0 +1,14 @@
+exports.config = { transaction: false };
+
+/**
+ * @param {import('knex').Knex} knex
+ */
+exports.up = async function (knex) {
+    await knex.raw(`
+        CREATE INDEX CONCURRENTLY IF NOT EXISTS "nango_users_account_id_active"
+        ON "_nango_users" (account_id, role)
+        WHERE suspended = false
+    `);
+};
+
+exports.down = function () {};

--- a/packages/shared/lib/services/account.service.integration.test.ts
+++ b/packages/shared/lib/services/account.service.integration.test.ts
@@ -11,6 +11,9 @@ import environmentService, { defaultEnvironments } from './environment.service.j
 import * as plans from './plans/plans.js';
 import { createSandboxApiKeyToken, decryptSandboxSigningSecret } from './sandbox-api-key.js';
 import secretService from './secret.service.js';
+import userService from './user.service.js';
+
+import type { DBTeam, DBUser, Role } from '@nangohq/types';
 
 describe('Account service', () => {
     beforeAll(async () => {
@@ -19,6 +22,112 @@ describe('Account service', () => {
 
     afterEach(() => {
         vi.restoreAllMocks();
+    });
+
+    async function createAccountWithUser({
+        email,
+        role = 'administrator',
+        suspended = false
+    }: {
+        email: string;
+        role?: Role;
+        suspended?: boolean;
+    }): Promise<{ account: DBTeam; user: DBUser }> {
+        const account = await createTestAccount();
+        const user = await userService.createUser({
+            email,
+            name: email,
+            account_id: account.id,
+            email_verified: true,
+            role
+        });
+
+        if (!user) {
+            throw new Error('Failed to create test user');
+        }
+
+        if (suspended) {
+            const updated = await userService.update({ id: user.id, suspended: true, suspended_at: new Date() });
+            if (!updated) {
+                throw new Error('Failed to suspend test user');
+            }
+            return { account, user: updated };
+        }
+
+        return { account, user };
+    }
+
+    async function createPlan(accountId: number, name: 'free' | 'growth-v2') {
+        const result = await plans.createPlan(db.knex, { account_id: accountId, name });
+        return result.unwrap();
+    }
+
+    describe('findAccountWithSameDomain', () => {
+        it('does not suggest accounts for a free email domain', async () => {
+            const current = await createAccountWithUser({ email: `${uuid()}@gmail.com` });
+            await createAccountWithUser({ email: `${uuid()}@gmail.com` });
+
+            await expect(accountService.findAccountWithSameDomain({ email: current.user.email, currentAccountId: current.account.id })).resolves.toBeNull();
+        });
+
+        it('suggests the only eligible account with a matching custom domain', async () => {
+            const domain = `${uuid()}.example.com`;
+            const current = await createAccountWithUser({ email: `new@${domain}` });
+            const candidate = await createAccountWithUser({ email: `admin@${domain}` });
+            await createPlan(candidate.account.id, 'free');
+
+            await expect(accountService.findAccountWithSameDomain({ email: current.user.email, currentAccountId: current.account.id })).resolves.toEqual({
+                id: candidate.account.id,
+                name: candidate.account.name
+            });
+        });
+
+        it('prefers a paid matching account over a free account', async () => {
+            const domain = `${uuid()}.example.com`;
+            const current = await createAccountWithUser({ email: `new@${domain}` });
+            const freeCandidate = await createAccountWithUser({ email: `free@${domain}` });
+            const paidCandidate = await createAccountWithUser({ email: `paid@${domain}` });
+            await createPlan(freeCandidate.account.id, 'free');
+            await createPlan(paidCandidate.account.id, 'growth-v2');
+
+            await expect(accountService.findAccountWithSameDomain({ email: current.user.email, currentAccountId: current.account.id })).resolves.toEqual({
+                id: paidCandidate.account.id,
+                name: paidCandidate.account.name
+            });
+        });
+
+        it('uses active member count to rank matching accounts with the same plan', async () => {
+            const domain = `${uuid()}.example.com`;
+            const current = await createAccountWithUser({ email: `new@${domain}` });
+            const smallerCandidate = await createAccountWithUser({ email: `small@${domain}` });
+            const largerCandidate = await createAccountWithUser({ email: `large@${domain}` });
+            await createPlan(smallerCandidate.account.id, 'free');
+            await createPlan(largerCandidate.account.id, 'free');
+            const additionalMember = await userService.createUser({
+                email: `${uuid()}@another.example.com`,
+                name: 'Additional member',
+                account_id: largerCandidate.account.id,
+                email_verified: true,
+                role: 'development_full_access'
+            });
+            expect(additionalMember).not.toBeNull();
+
+            await expect(accountService.findAccountWithSameDomain({ email: current.user.email, currentAccountId: current.account.id })).resolves.toEqual({
+                id: largerCandidate.account.id,
+                name: largerCandidate.account.name
+            });
+        });
+
+        it('excludes the current account, suspended matching users, and accounts without an active administrator', async () => {
+            const domain = `${uuid()}.example.com`;
+            const current = await createAccountWithUser({ email: `new@${domain}` });
+            const suspendedCandidate = await createAccountWithUser({ email: `suspended@${domain}`, suspended: true });
+            const noAdministrator = await createAccountWithUser({ email: `member@${domain}`, role: 'development_full_access' });
+            await createPlan(suspendedCandidate.account.id, 'growth-v2');
+            await createPlan(noAdministrator.account.id, 'growth-v2');
+
+            await expect(accountService.findAccountWithSameDomain({ email: current.user.email, currentAccountId: current.account.id })).resolves.toBeNull();
+        });
     });
 
     it('should create an account with default environments and a free plan', async () => {

--- a/packages/shared/lib/services/account.service.ts
+++ b/packages/shared/lib/services/account.service.ts
@@ -18,7 +18,7 @@ import secretService from './secret.service.js';
 import userService from './user.service.js';
 
 import type { Knex } from '@nangohq/database';
-import type { DBAPISecret, DBEnvironment, DBPlan, DBTeam, PersistAuthContext, Result } from '@nangohq/types';
+import type { DBAPISecret, DBEnvironment, DBPlan, DBTeam, DBUser, PersistAuthContext, Result } from '@nangohq/types';
 
 const hashLocalCache = new FixedSizeMap<string, string>(10_000);
 const logger = getLogger('AccountService');
@@ -85,6 +85,42 @@ const freeEmailDomains = new Set([
 ]);
 
 class AccountService {
+    async findAccountWithSameDomain({ email, currentAccountId }: { email: string; currentAccountId: number }): Promise<Pick<DBTeam, 'id' | 'name'> | null> {
+        const emailDomain = getEmailDomain(email);
+        if (!emailDomain || freeEmailDomains.has(emailDomain)) {
+            return null;
+        }
+
+        // Find eligible accounts with an active user from the same domain and an active administrator,
+        // excluding the user's current team. Prefer paid accounts, then accounts with more active members,
+        // and finally the lowest account ID for a stable tie-breaker.
+        const account = await db.knex
+            .with('candidate_account', (qb) => {
+                qb.from<DBTeam>('_nango_accounts as account')
+                    .innerJoin<DBUser>('_nango_users as same_domain_user', 'same_domain_user.account_id', 'account.id')
+                    .distinct('account.id', 'account.name')
+                    .where('account.id', '!=', currentAccountId)
+                    .where('same_domain_user.suspended', false)
+                    .whereRaw("LOWER(SPLIT_PART(same_domain_user.email, '@', 2)) = ?", [emailDomain])
+                    .whereExists(function () {
+                        this.select(db.knex.raw('1'))
+                            .from<DBUser>('_nango_users as administrator')
+                            .whereRaw('administrator.account_id = account.id')
+                            .where('administrator.suspended', false)
+                            .where('administrator.role', 'administrator');
+                    });
+            })
+            .from('candidate_account')
+            .leftJoin<DBPlan>('plans', 'plans.account_id', 'candidate_account.id')
+            .select<Pick<DBTeam, 'id' | 'name'>>('candidate_account.id', 'candidate_account.name')
+            .orderByRaw("CASE WHEN plans.name IS NOT NULL AND plans.name NOT IN ('free', 'free-uncapped') THEN 1 ELSE 0 END DESC")
+            .orderByRaw(`(SELECT COUNT(*) FROM _nango_users AS member WHERE member.account_id = candidate_account.id AND member.suspended = false) DESC`)
+            .orderBy('candidate_account.id', 'asc')
+            .first<Pick<DBTeam, 'id' | 'name'>>();
+
+        return account || null;
+    }
+
     async getAccountById(trx: Knex, id: number): Promise<DBTeam | null> {
         try {
             const result = await trx.select('*').from<DBTeam>(`_nango_accounts`).where({ id: id }).first();
@@ -818,6 +854,17 @@ class AccountService {
             }
         };
     }
+}
+
+function getEmailDomain(email: string): string | null {
+    const atIndex = email.lastIndexOf('@');
+    const emailDomain = email.slice(atIndex + 1).toLowerCase();
+
+    if (atIndex <= 0 || !emailDomain.includes('.')) {
+        return null;
+    }
+
+    return emailDomain;
 }
 
 function emailToTeamName({ email }: { email?: string | undefined }): string | false {


### PR DESCRIPTION
Adds accountService.findAccountWithSameDomain to power a request-invitation feature: on signup, find an existing team sharing the new user's email domain so they can request to join it instead of creating a new team.

- Skips public/free email domains via the existing freeEmailDomains list.
- Finds eligible teams with an active user on the same domain and at least one active administrator, excluding the signing-up user's own team.
- Ranks multiple matches by paid status, then active member count, then account ID for a stable tie-break.
- Adds integration coverage: public-domain exclusion, unique matches, paid-team priority, member-count ranking, and ineligible teams.

The query's per-candidate checks (administrator lookup, active member count) and the domain match itself would otherwise scan all of _nango_users on every signup, growing with total user count instead of the number of domain matches:

- Add nango_users_email_domain_active: partial expression index on LOWER(SPLIT_PART(email, '@', 2)) WHERE suspended = false, so the domain match is a direct index seek.
- Add nango_users_account_id_active: partial index on (account_id, role) WHERE suspended = false, covering the administrator whereExists check and the active-member-count lookup below. Also covers existing user.service.ts reads (getUsersByAccountId, countUsers, getAnUserByAccountId).
- Compute active member count as a correlated per-candidate subquery instead of a join + group by CTE, so it can use the new index instead of scanning every active user.

Verified via EXPLAIN ANALYZE against ~10k accounts / ~30k users
(prod-comparable scale): 251ms -> 2ms.

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/NangoHQ/nango/pull/6827?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

