### PR TITLE
fix(server): invalidate sessions after team member removal

### DIFF
--- a/packages/server/lib/controllers/v1/team/users/deleteTeamUser.integration.test.ts
+++ b/packages/server/lib/controllers/v1/team/users/deleteTeamUser.integration.test.ts
@@ -1,8 +1,8 @@
 import { afterAll, beforeAll, describe, expect, it } from 'vitest';
 
-import { seeders } from '@nangohq/shared';
+import { seeders, userService } from '@nangohq/shared';
 
-import { runServer, shouldBeProtected, shouldRequireQueryEnv } from '../../../../utils/tests.js';
+import { authenticateUser, isSuccess, runServer, shouldBeProtected, shouldRequireQueryEnv } from '../../../../utils/tests.js';
 
 const route = '/api/v1/team/users/:id';
 let api: Awaited<ReturnType<typeof runServer>>;
@@ -52,32 +52,48 @@ describe(`DELETE ${route}`, () => {
         expect(res.res.status).toBe(400);
     });
 
-    // TODO: can't test stuff that needs `user` because we are using an anonymous secret_key
-    // it('should delete team user', async () => {
-    //     const { env } = await seeders.seedAccountEnvAndUser();
-    //     const user2 = await seeders.seedUser(env.account_id);
+    it('should delete team user and invalidate removed user sessions', async () => {
+        const { account, user: adminUser } = await seeders.seedAccountEnvAndUser();
+        const removedUser = await seeders.seedUser(account.id);
 
-    //     const listBefore = await api.fetch('/api/v1/team', { method: 'GET', query: { env: 'dev' }, token: env.secret_key });
-    //     isSuccess(listBefore.json);
-    //     expect(listBefore.json.data.users).toHaveLength(2);
+        const adminSession = await authenticateUser(api, adminUser);
+        const removedUserSession = await authenticateUser(api, removedUser);
 
-    //     const res = await api.fetch(route, {
-    //         method: 'DELETE',
-    //         query: { env: 'dev' },
-    //         token: env.secret_key,
-    //         params: { id: user2.id }
-    //     });
+        const listBefore = await api.fetch('/api/v1/team', {
+            method: 'GET',
+            query: { env: 'dev' },
+            session: adminSession
+        });
+        isSuccess(listBefore.json);
+        expect(listBefore.json.data.users).toHaveLength(2);
 
-    //     expect(res.res.status).toBe(200);
-    //     isSuccess(res.json);
-    //     expect(res.json).toMatchObject<typeof res.json>({
-    //         data: {
-    //             success: true
-    //         }
-    //     });
+        const removal = await api.fetch(route, {
+            method: 'DELETE',
+            query: { env: 'dev' },
+            session: adminSession,
+            params: { id: removedUser.id }
+        });
 
-    //     const listAfter = await api.fetch('/api/v1/team', { method: 'GET', query: { env: 'dev' }, token: env.secret_key });
-    //     isSuccess(listAfter.json);
-    //     expect(listAfter.json.data.users).toHaveLength(1);
-    // });
+        expect(removal.res.status).toBe(200);
+        isSuccess(removal.json);
+        expect(removal.json).toStrictEqual<typeof removal.json>({ data: { success: true } });
+
+        const movedUser = await userService.getUserById(removedUser.id);
+        expect(movedUser?.account_id).not.toBe(account.id);
+
+        const removedUserSelf = await api.fetch('/api/v1/user', {
+            method: 'GET',
+            session: removedUserSession
+        });
+        expect(removedUserSelf.res.status).toBe(401);
+
+        const listAfter = await api.fetch('/api/v1/team', {
+            method: 'GET',
+            query: { env: 'dev' },
+            session: adminSession
+        });
+        isSuccess(listAfter.json);
+        expect(listAfter.json.data.users).toHaveLength(1);
+        expect(listAfter.json.data.users.map((u) => u.id)).toStrictEqual([adminUser.id]);
+    });
 });

--- a/packages/server/lib/controllers/v1/team/users/deleteTeamUser.ts
+++ b/packages/server/lib/controllers/v1/team/users/deleteTeamUser.ts
@@ -1,8 +1,10 @@
 import * as z from 'zod';
 
+import db from '@nangohq/database';
 import { accountService, userService } from '@nangohq/shared';
-import { requireEmptyBody, requireEmptyQuery, zodErrorToHTTP } from '@nangohq/utils';
+import { getLogger, requireEmptyBody, requireEmptyQuery, zodErrorToHTTP } from '@nangohq/utils';
 
+import { deleteUserSessions } from '../../../../clients/auth.client.js';
 import { asyncWrapper } from '../../../../utils/asyncWrapper.js';
 
 import type { DeleteTeamUser } from '@nangohq/types';
@@ -12,6 +14,8 @@ const validation = z
         id: z.coerce.number()
     })
     .strict();
+
+const logger = getLogger('DeleteTeamUser');
 
 export const deleteTeamUser = asyncWrapper<DeleteTeamUser>(async (req, res) => {
     const emptyQuery = requireEmptyQuery(req, { withEnv: true });
@@ -52,14 +56,29 @@ export const deleteTeamUser = asyncWrapper<DeleteTeamUser>(async (req, res) => {
         return;
     }
 
-    const updated = await userService.update({ id: user.id, account_id: newTeam.id });
+    const updated = await db.knex.transaction(async (trx) => {
+        const movedUser = await userService.update({ id: user.id, account_id: newTeam.id }, trx);
+        if (!movedUser) {
+            return null;
+        }
+
+        // Force re-authentication so the removed member does not keep using an old team-scoped session.
+        await deleteUserSessions(user.id, { trx });
+
+        return movedUser;
+    });
     if (!updated) {
         res.status(500).send({ error: { code: 'server_error', message: 'failed to update user team' } });
         return;
     }
 
-    // TODO: destroy this user session to avoid desync
-    // TODO: last user removed from a team should (soft) delete the team
+    const remainingUsers = await userService.countUsers(account.id);
+    if (remainingUsers === 0) {
+        logger.warning('team has no active users after member removal', {
+            accountId: account.id,
+            removedUserId: user.id
+        });
+    }
 
     res.status(200).send({
         data: { success: true }


### PR DESCRIPTION
# Summary
This PR fixes session desynchronization when removing a team member from a team.

Linked issue: Closes #6828 

# What was happening
After removing a user from a team, the user was reassigned to another team, but existing dashboard sessions were still valid. That could leave the removed user with stale team-scoped session state.

# What changed
Updated [deleteTeamUser.ts](vscode-file://vscode-app/Applications/Visual%20Studio%20Code.app/Contents/Resources/app/out/vs/code/electron-browser/workbench/workbench.html) to:
run user reassignment in a DB transaction
invalidate the removed user sessions using existing auth session deletion logic
log when the source team has zero active users after removal (for visibility)
Updated [deleteTeamUser.integration.test.ts](vscode-file://vscode-app/Applications/Visual%20Studio%20Code.app/Contents/Resources/app/out/vs/code/electron-browser/workbench/workbench.html) to add an end-to-end scenario that verifies:
removal succeeds
removed user is moved to a different team
removed user’s prior session is rejected (401)
team list reflects only remaining member(s)

# Why this approach
Reuses existing session invalidation helper used in other auth-sensitive flows.
Keeps user move + session invalidation atomic through a single transaction.
Adds integration coverage for the exact behavior expected by the issue.

# Testing
Lint:
npm run lint -- [deleteTeamUser.ts](vscode-file://vscode-app/Applications/Visual%20Studio%20Code.app/Contents/Resources/app/out/vs/code/electron-browser/workbench/workbench.html) [deleteTeamUser.integration.test.ts](vscode-file://vscode-app/Applications/Visual%20Studio%20Code.app/Contents/Resources/app/out/vs/code/electron-browser/workbench/workbench.html)
Integration test:
CI=1 NODE_OPTIONS='--max-old-space-size=6144' npx vitest --config [vite.integration.config.ts](vscode-file://vscode-app/Applications/Visual%20Studio%20Code.app/Contents/Resources/app/out/vs/code/electron-browser/workbench/workbench.html) --run [deleteTeamUser.integration.test.ts](vscode-file://vscode-app/Applications/Visual%20Studio%20Code.app/Contents/Resources/app/out/vs/code/electron-browser/workbench/workbench.html)

# Result:

1 test file passed
4 tests passed

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/NangoHQ/nango/pull/6829?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

