### PR TITLE
fix(in-app): fix the brand bg color to respect the app theme

### DIFF
--- a/packages/webapp/src/components/PlainChat.tsx
+++ b/packages/webapp/src/components/PlainChat.tsx
@@ -104,7 +104,7 @@ function buildConfig(appId: string, darkMode: boolean, user?: ApiUser, emailHash
         theme: darkMode ? 'dark' : 'light',
         style: {
             brandColor: { light: '#016886', dark: '#00B2E3' },
-            brandBackgroundColor: '#02485D',
+            brandBackgroundColor: { light: '#016886', dark: '#02485D' },
             launcherBackgroundColor: { light: '#016886', dark: '#00B2E3' },
             launcherIconColor: { light: '#FFFFFF', dark: '#18191B' }
         },


### PR DESCRIPTION
## Describe the problem and your solution

- fix the brand bg color to respect the app theme 

<!-- Issue ticket number and link (if applicable) -->

<!-- Testing instructions (skip if just adding/editing providers) -->



<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/NangoHQ/nango/pull/6837?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

