### PR TITLE
fix(docs): raise Ask AI panel above the navbar

### DIFF
--- a/docs/custom.css
+++ b/docs/custom.css
@@ -592,3 +592,13 @@ html:not(.dark) li[data-active="true"] > a { border-radius: 4px !important; }
 #content-area div.rounded-2xl.pointer-events-auto[class*="bg-background-light"] {
   display: none !important;
 }
+
+/* ══ ASK AI ASSISTANT PANEL — above navbar ═══════════════════════ */
+/*
+ * Raise the panel (Mintlify z-22) above the fixed opaque NAVBAR (z-30)
+ * so its header/Close button and first message aren't hidden behind it.
+ * Stays below the z-200 search / Ask AI dialogs. See NAN-6370.
+ */
+.sticky:has(> #chat-assistant-sheet) {
+  z-index: 40 !important;
+}


### PR DESCRIPTION
## Problem

The docs' `custom.css` NAVBAR override forces `#navbar` to `position: fixed; width: 100%; z-index: 30` with an opaque background, while Mintlify renders the Ask AI assistant panel as a full-height sticky sheet at `z-22`. The navbar therefore paints over the panel's top ~113px, causing two user-visible bugs:

- **The panel header — including its only Close (✕) button — is hidden**, so the assistant can only be dismissed by clicking blindly where nothing is visible ([NAN-6370](https://linear.app/nango/issue/NAN-6370)).
- **The first message in a conversation renders at the top of the list, behind the navbar**, so users can't see their first question.

## Solution

- Raise the assistant panel to `z-40` — above the navbar, but below the `z-200` search / Ask AI dialog portals so those still overlay it.

Fixes [NAN-6370](https://linear.app/nango/issue/NAN-6370)

## Testing

- Verified on docs.nango.dev by injecting the exact rule live: the header + ✕ button are visible and clickable, and the first user message shows — in light mode, dark mode, and both docked and maximized panel states.
- Clicking ✕ collapses the panel as expected.
- The Mintlify preview deploy on this PR can be used to confirm against the built branch.
