### PR TITLE
feat(webapp): reach usage breakdown values and keep long legends readable

### DIFF
--- a/packages/webapp/AGENTS.md
+++ b/packages/webapp/AGENTS.md
@@ -59,6 +59,7 @@ Events are sent to PostHog. Use the **typed catalog** for anything new.
 
 ### Conventions
 
+- **Coverage**: when you add a new user-initiated, intentful interaction — navigation, create / apply / copy / export, plan or filter changes, and the like — add a tracked event for it in the same change. Skip incidental UI state (hover, focus, expand/collapse, transient toggles); tracking that drowns the useful signal and bloats the catalog.
 - **Event names**: `web:<area>:<action>`, colon-delimited (e.g. `web:usage:filtered`, `web:playground:run:clicked`).
 - **Property values** should be PostHog-serializable primitives (`string | number | boolean`). This is a convention, not enforced by the types — don't declare nested objects or arrays in the catalog; they don't map cleanly to PostHog properties.
 - **Privacy**: never send identifying free-form values (connection IDs, environment names, emails). Send low-cardinality slugs — e.g. a filter's *dimension*, not its value. PostHog init also sets `mask_personal_data_properties`, but keep events clean at the source.

--- a/packages/webapp/src/components/patterns/chart/ChartCard.tsx
+++ b/packages/webapp/src/components/patterns/chart/ChartCard.tsx
@@ -43,6 +43,14 @@ interface ChartCardProps {
     capLine?: number;
     /** 'cumulative' plots counter metrics as a running month-to-date total so the curve climbs to the cap. */
     chartMode?: 'daily' | 'cumulative';
+    /** In-app route for a breakdown series, when it points somewhere navigable — adds a "go to" link to its legend row. */
+    seriesHref?: (series: ChartSeries) => string | undefined;
+    /** The value to copy for a breakdown series, when it's worth copying — adds a copy button to its legend row. */
+    seriesCopyValue?: (series: ChartSeries) => string | undefined;
+    /** Fired when a series' value is copied from the legend. For analytics only. */
+    onSeriesCopy?: (series: ChartSeries) => void;
+    /** Fired when a series' "go to" link is followed from the legend. For analytics only. */
+    onSeriesGoTo?: (series: ChartSeries) => void;
 }
 
 /**
@@ -67,7 +75,11 @@ export const ChartCard: React.FC<ChartCardProps> = ({
     onSeriesToggle,
     hideHeader,
     capLine,
-    chartMode
+    chartMode,
+    seriesHref,
+    seriesCopyValue,
+    onSeriesCopy,
+    onSeriesGoTo
 }) => {
     const isBreakdown = breakdownSeries !== undefined;
     const isCumulative = data?.view_mode === 'cumulative';
@@ -206,7 +218,16 @@ export const ChartCard: React.FC<ChartCardProps> = ({
                             // monthly cap dwarfs the per-day values and would flatten the bars.
                             capLine={renderAsArea && !isSliced ? capLine : undefined}
                         />
-                        {breakdownSeries && breakdownSeries.length > 0 && <ChartLegend series={breakdownSeries} interactions={interactions} />}
+                        {breakdownSeries && breakdownSeries.length > 0 && (
+                            <ChartLegend
+                                series={breakdownSeries}
+                                interactions={interactions}
+                                seriesHref={seriesHref}
+                                seriesCopyValue={seriesCopyValue}
+                                onSeriesCopy={onSeriesCopy}
+                                onSeriesGoTo={onSeriesGoTo}
+                            />
+                        )}
                         {!isBreakdown && singleSeries && (
                             // Static, non-interactive: with one series there's nothing to isolate or hide.
                             <ChartStaticLegend series={[{ key: 'total', ...singleSeries }]} />

--- a/packages/webapp/src/components/patterns/chart/ChartCard.tsx
+++ b/packages/webapp/src/components/patterns/chart/ChartCard.tsx
@@ -6,7 +6,7 @@ import { InfoTooltip } from '../../ui/InfoTooltip';
 import { Skeleton } from '../../ui/Skeleton';
 import { BreakdownChart } from './BreakdownChart';
 import { formatExact, formatShare } from './chartFormat';
-import { ChartLegend } from './ChartLegend';
+import { ChartLegend, ChartStaticLegend } from './ChartLegend';
 import { useChartData, visibleBreakdownTotal } from './useChartData';
 import { useChartInteractions } from './useChartInteractions';
 
@@ -209,12 +209,7 @@ export const ChartCard: React.FC<ChartCardProps> = ({
                         {breakdownSeries && breakdownSeries.length > 0 && <ChartLegend series={breakdownSeries} interactions={interactions} />}
                         {!isBreakdown && singleSeries && (
                             // Static, non-interactive: with one series there's nothing to isolate or hide.
-                            <div className="flex items-center gap-1.5 pt-3 text-xs flex-shrink-0">
-                                <span className="block size-2.5 rounded-[2px]" aria-hidden style={{ backgroundColor: singleSeries.color }} />
-                                <span className="text-text-secondary truncate" title={singleSeries.label}>
-                                    {singleSeries.label}
-                                </span>
-                            </div>
+                            <ChartStaticLegend series={[{ key: 'total', ...singleSeries }]} />
                         )}
                     </>
                 )}

--- a/packages/webapp/src/components/patterns/chart/ChartLegend.tsx
+++ b/packages/webapp/src/components/patterns/chart/ChartLegend.tsx
@@ -112,7 +112,7 @@ export const ChartLegend: React.FC<ChartLegendProps> = ({ series, interactions, 
                                 // width is reserved at rest (they're laid out but transparent) so fading them in never
                                 // changes the row's width — otherwise, in this content-sized wrap layout, the row would
                                 // grow on hover and reflow the wrapped rows below it.
-                                <div className="flex shrink-0 items-center gap-0.5 text-text-secondary opacity-0 transition-opacity duration-150 group-hover/row:opacity-100 focus-within:opacity-100">
+                                <div className="flex shrink-0 items-center gap-0.5 text-text-secondary opacity-0 transition-opacity duration-150 group-hover/row:opacity-100 group-focus-within/row:opacity-100">
                                     {copyValue && <CopyButton text={copyValue} className="size-5 p-0" onCopy={() => onSeriesCopy?.(s)} />}
                                     {href && (
                                         <Link

--- a/packages/webapp/src/components/patterns/chart/ChartLegend.tsx
+++ b/packages/webapp/src/components/patterns/chart/ChartLegend.tsx
@@ -18,9 +18,11 @@ interface ChartStaticLegendProps {
 export const ChartLegend: React.FC<ChartLegendProps> = ({ series, interactions }) => {
     const { hidden, isSeriesHidden, toggleIsolate, toggleHidden, hoverSeries, unhoverSeries, hoveredKey } = interactions;
     return (
-        <div className="flex flex-wrap gap-x-2 gap-y-0.5 pt-3 pb-1 max-h-[96px] overflow-y-auto flex-shrink-0 text-[13px]">
+        <div className="flex flex-wrap gap-x-2 gap-y-0.5 pt-3 pb-1 flex-shrink-0 text-[13px]">
             {series.map((s) => {
                 const dimmed = isSeriesHidden(s.key);
+                // Render UUID values (connection ids, etc.) monospace so their equal-width rows line up as a grid.
+                const isUuid = Boolean(s.value) && /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/i.test(s.value ?? '');
                 // `active` = this series is the hovered one. It's set both by hovering the legend row and by
                 // hovering the series' chart band (BreakdownChart calls hoverSeries on band enter), so highlight
                 // stays in sync in both directions.
@@ -78,6 +80,7 @@ export const ChartLegend: React.FC<ChartLegendProps> = ({ series, interactions }
                                 onMouseLeave={onLeave}
                                 className={cn(
                                     'relative min-w-0 max-w-full overflow-x-auto whitespace-nowrap text-left transition-colors',
+                                    isUuid && 'font-mono text-[12px]',
                                     dimmed
                                         ? 'text-text-muted line-through hover:text-text-secondary'
                                         : cn('text-text-secondary group-hover/row:text-text-strong', active && 'text-text-strong')
@@ -97,7 +100,7 @@ export const ChartLegend: React.FC<ChartLegendProps> = ({ series, interactions }
 /** Static legend: same visual rhythm as ChartLegend, without hide/isolate interactions. */
 export const ChartStaticLegend: React.FC<ChartStaticLegendProps> = ({ series }) => {
     return (
-        <div className="flex flex-wrap gap-x-2 gap-y-0.5 pt-3 pb-1 max-h-[96px] overflow-y-auto flex-shrink-0 text-[13px]">
+        <div className="flex flex-wrap gap-x-2 gap-y-0.5 pt-3 pb-1 flex-shrink-0 text-[13px]">
             {series.map((s) => (
                 <div key={s.key} className="flex min-w-0 max-w-full">
                     <div className="inline-flex min-w-0 max-w-full items-center gap-1.5 rounded-md px-1 py-0.5">

--- a/packages/webapp/src/components/patterns/chart/ChartLegend.tsx
+++ b/packages/webapp/src/components/patterns/chart/ChartLegend.tsx
@@ -10,11 +10,15 @@ interface ChartLegendProps {
     interactions: ChartInteractions;
 }
 
+interface ChartStaticLegendProps {
+    series: Pick<ChartSeries, 'key' | 'label' | 'color'>[];
+}
+
 /** Interactive legend: hover a row to highlight its band, click the label to isolate, click the swatch to hide/show. */
 export const ChartLegend: React.FC<ChartLegendProps> = ({ series, interactions }) => {
     const { hidden, isSeriesHidden, toggleIsolate, toggleHidden, hoverSeries, unhoverSeries, hoveredKey } = interactions;
     return (
-        <div className="grid grid-cols-[repeat(auto-fill,minmax(150px,1fr))] gap-x-2 gap-y-0.5 pt-3 pb-1 max-h-[96px] overflow-y-auto flex-shrink-0 text-[13px]">
+        <div className="flex flex-wrap gap-x-2 gap-y-0.5 pt-3 pb-1 max-h-[96px] overflow-y-auto flex-shrink-0 text-[13px]">
             {series.map((s) => {
                 const dimmed = isSeriesHidden(s.key);
                 // `active` = this series is the hovered one. It's set both by hovering the legend row and by
@@ -36,13 +40,11 @@ export const ChartLegend: React.FC<ChartLegendProps> = ({ series, interactions }
                     title: `Toggle ${s.label}`
                 };
                 return (
-                    // The grid cell keeps column alignment; the inner pill hugs swatch + label so the
-                    // hover background only covers the content, not the empty space across the cell.
-                    <div key={s.key} className="flex min-w-0">
+                    <div key={s.key} className="flex min-w-0 max-w-full">
                         <div
                             className={cn(
-                                'group/row inline-flex min-w-0 max-w-full cursor-pointer items-center gap-1.5 rounded-md px-1 py-0.5 transition-colors hover:bg-state-selected-muted',
-                                active && 'bg-state-selected-muted'
+                                'group/row inline-flex min-w-0 max-w-full cursor-pointer items-center gap-1.5 rounded-md px-1 py-0.5 transition-colors hover:bg-state-hover',
+                                active && 'bg-state-hover'
                             )}
                         >
                             {/* Checkbox-style swatch: a color-filled square with a ring (a darker shade of its own color)
@@ -75,7 +77,7 @@ export const ChartLegend: React.FC<ChartLegendProps> = ({ series, interactions }
                                 onMouseEnter={onEnter}
                                 onMouseLeave={onLeave}
                                 className={cn(
-                                    'relative min-w-0 truncate transition-colors',
+                                    'relative min-w-0 max-w-full overflow-x-auto whitespace-nowrap text-left transition-colors',
                                     dimmed
                                         ? 'text-text-muted line-through hover:text-text-secondary'
                                         : cn('text-text-secondary group-hover/row:text-text-strong', active && 'text-text-strong')
@@ -88,6 +90,29 @@ export const ChartLegend: React.FC<ChartLegendProps> = ({ series, interactions }
                     </div>
                 );
             })}
+        </div>
+    );
+};
+
+/** Static legend: same visual rhythm as ChartLegend, without hide/isolate interactions. */
+export const ChartStaticLegend: React.FC<ChartStaticLegendProps> = ({ series }) => {
+    return (
+        <div className="flex flex-wrap gap-x-2 gap-y-0.5 pt-3 pb-1 max-h-[96px] overflow-y-auto flex-shrink-0 text-[13px]">
+            {series.map((s) => (
+                <div key={s.key} className="flex min-w-0 max-w-full">
+                    <div className="inline-flex min-w-0 max-w-full items-center gap-1.5 rounded-md px-1 py-0.5">
+                        <span className="relative flex size-[18px] shrink-0 items-center justify-center" aria-hidden>
+                            <span
+                                className="block size-3.5 rounded-[3px] border [border-color:color-mix(in_srgb,var(--swatch),#000_28%)]"
+                                style={{ backgroundColor: s.color, ['--swatch']: s.color } as React.CSSProperties}
+                            />
+                        </span>
+                        <span className="text-text-secondary min-w-0 max-w-full overflow-x-auto whitespace-nowrap" title={s.label}>
+                            {s.label}
+                        </span>
+                    </div>
+                </div>
+            ))}
         </div>
     );
 };

--- a/packages/webapp/src/components/patterns/chart/ChartLegend.tsx
+++ b/packages/webapp/src/components/patterns/chart/ChartLegend.tsx
@@ -1,5 +1,7 @@
-import { Check, X } from 'lucide-react';
+import { ArrowUpRight, Check, X } from 'lucide-react';
+import { Link } from 'react-router-dom';
 
+import { CopyButton } from '@/components/ui/CopyButton';
 import { cn } from '@/utils/utils';
 
 import type { ChartSeries } from './types';
@@ -8,19 +10,35 @@ import type { ChartInteractions } from './useChartInteractions';
 interface ChartLegendProps {
     series: ChartSeries[];
     interactions: ChartInteractions;
+    /** In-app route for a series, when it points somewhere navigable — adds a "go to" link to that row. */
+    seriesHref?: (series: ChartSeries) => string | undefined;
+    /** The value to copy for a series, when it's worth copying — adds a copy button to that row. */
+    seriesCopyValue?: (series: ChartSeries) => string | undefined;
+    /** Fired when a series' value is copied. For analytics only — keeps this pattern PostHog-free. */
+    onSeriesCopy?: (series: ChartSeries) => void;
+    /** Fired when a series' "go to" link is followed. For analytics only. */
+    onSeriesGoTo?: (series: ChartSeries) => void;
 }
 
 interface ChartStaticLegendProps {
     series: Pick<ChartSeries, 'key' | 'label' | 'color'>[];
 }
 
-/** Interactive legend: hover a row to highlight its band, click the label to isolate, click the swatch to hide/show. */
-export const ChartLegend: React.FC<ChartLegendProps> = ({ series, interactions }) => {
+/**
+ * Interactive legend: hover a row to highlight its band, click the label to isolate, click the
+ * swatch to hide/show. On hover (or keyboard focus) a row also reveals per-series actions the caller
+ * opts into: a copy button when {@link ChartLegendProps.seriesCopyValue} returns a value, and a "go
+ * to" link when {@link ChartLegendProps.seriesHref} resolves one.
+ */
+export const ChartLegend: React.FC<ChartLegendProps> = ({ series, interactions, seriesHref, seriesCopyValue, onSeriesCopy, onSeriesGoTo }) => {
     const { hidden, isSeriesHidden, toggleIsolate, toggleHidden, hoverSeries, unhoverSeries, hoveredKey } = interactions;
     return (
         <div className="flex flex-wrap gap-x-2 gap-y-0.5 pt-3 pb-1 flex-shrink-0 text-[13px]">
             {series.map((s) => {
                 const dimmed = isSeriesHidden(s.key);
+                // Per-row actions, both opt-in per series via the caller: a copy value and a "go to" route.
+                const href = seriesHref?.(s);
+                const copyValue = seriesCopyValue?.(s);
                 // Render UUID values (connection ids, etc.) monospace so their equal-width rows line up as a grid.
                 const isUuid = Boolean(s.value) && /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/i.test(s.value ?? '');
                 // `active` = this series is the hovered one. It's set both by hovering the legend row and by
@@ -89,6 +107,29 @@ export const ChartLegend: React.FC<ChartLegendProps> = ({ series, interactions }
                             >
                                 {s.label}
                             </button>
+                            {(copyValue || href) && (
+                                // Actions revealed on hover/focus, in clean space to the right of the label. Their
+                                // width is reserved at rest (they're laid out but transparent) so fading them in never
+                                // changes the row's width — otherwise, in this content-sized wrap layout, the row would
+                                // grow on hover and reflow the wrapped rows below it.
+                                <div className="flex shrink-0 items-center gap-0.5 text-text-secondary opacity-0 transition-opacity duration-150 group-hover/row:opacity-100 focus-within:opacity-100">
+                                    {copyValue && <CopyButton text={copyValue} className="size-5 p-0" onCopy={() => onSeriesCopy?.(s)} />}
+                                    {href && (
+                                        <Link
+                                            to={href}
+                                            onClick={(e) => {
+                                                e.stopPropagation();
+                                                onSeriesGoTo?.(s);
+                                            }}
+                                            aria-label={`Go to ${s.label}`}
+                                            title={`Go to ${s.label}`}
+                                            className="flex size-5 items-center justify-center rounded text-text-secondary transition-colors hover:text-text-strong focus-default"
+                                        >
+                                            <ArrowUpRight className="size-3.5" />
+                                        </Link>
+                                    )}
+                                </div>
+                            )}
                         </div>
                     </div>
                 );

--- a/packages/webapp/src/components/ui/CopyButton.tsx
+++ b/packages/webapp/src/components/ui/CopyButton.tsx
@@ -5,11 +5,12 @@ import { IconButton } from '@nangohq/design-system';
 
 import { cn } from '@/utils/utils';
 
-export const CopyButton: React.FC<{ text: string; disabled?: boolean; iconType?: 'clipboard' | 'link'; className?: string }> = ({
+export const CopyButton: React.FC<{ text: string; disabled?: boolean; iconType?: 'clipboard' | 'link'; className?: string; onCopy?: () => void }> = ({
     text,
     disabled,
     iconType = 'clipboard',
-    className
+    className,
+    onCopy
 }) => {
     const [copied, setCopied] = useState(false);
     const [hasInteracted, setHasInteracted] = useState(false);
@@ -19,6 +20,7 @@ export const CopyButton: React.FC<{ text: string; disabled?: boolean; iconType?:
         await navigator.clipboard.writeText(text);
         setCopied(true);
         setHasInteracted(true);
+        onCopy?.();
     };
 
     useEffect(() => {

--- a/packages/webapp/src/pages/Team/Billing/components/UsageChartCard.tsx
+++ b/packages/webapp/src/pages/Team/Billing/components/UsageChartCard.tsx
@@ -5,7 +5,15 @@ import { ChartCard } from '@/components/patterns/chart';
 import { colorsForValues } from '@/components/patterns/chart/usageChartColors';
 import { useApiGetBillingUsageDetail } from '@/hooks/usePlan';
 import { track } from '@/utils/analytics';
-import { BREAKDOWN_DIMENSIONS, DEFAULT_TOP_N, formatDimensionValue, parseFilterParam, resolveBreakdownDimension } from '../usageBreakdown';
+import {
+    BREAKDOWN_DIMENSIONS,
+    breakdownSeriesCopyValue,
+    breakdownSeriesHref,
+    DEFAULT_TOP_N,
+    formatDimensionValue,
+    parseFilterParam,
+    resolveBreakdownDimension
+} from '../usageBreakdown';
 import { toChartSeries } from '../usageChartSeries';
 import { useBreakdownEnabled } from '../useBreakdownEnabled';
 import { BreakdownFilterControl } from './BreakdownFilterControl';
@@ -192,6 +200,10 @@ export const UsageChartCard: React.FC<UsageChartCardProps> = ({
             onSeriesToggle={() => track('web:usage:series_toggled', { metric })}
             capLine={capLine}
             chartMode={chartModeState}
+            seriesHref={(s) => (dimension && s.value ? breakdownSeriesHref(env, dimension, s.value) : undefined)}
+            seriesCopyValue={(s) => (dimension && s.value ? breakdownSeriesCopyValue(dimension, s.value) : undefined)}
+            onSeriesCopy={() => dimension && track('web:usage:value_copied', { metric, dimension })}
+            onSeriesGoTo={() => dimension && track('web:usage:value_opened', { metric, dimension })}
         />
     );
 };

--- a/packages/webapp/src/pages/Team/Billing/usageBreakdown.ts
+++ b/packages/webapp/src/pages/Team/Billing/usageBreakdown.ts
@@ -86,6 +86,30 @@ export function isSearchableDimension(dimension: AnyBreakdownDimension): boolean
 }
 
 /**
+ * In-app route for a breakdown series that points to a navigable entity, or `undefined` when the
+ * series can't be linked. Only `integration_id` resolves today: its value is the provider config
+ * key, which is exactly what the integration page route keys on. `connection_id` is deliberately
+ * not linkable yet — the connection route also needs the integration, which the breakdown value
+ * doesn't carry (tracked in NAN-6252).
+ */
+export function breakdownSeriesHref(env: string, dimension: AnyBreakdownDimension, value: string): string | undefined {
+    if (dimension === 'integration_id') {
+        return `/${env}/integrations/${encodeURIComponent(value)}`;
+    }
+    return undefined;
+}
+
+/**
+ * The value to copy for a breakdown series, or `undefined` when the series offers no copy action.
+ * Only `connection_id` qualifies: its value is an opaque id you'd paste elsewhere (a lookup, the
+ * API, a filter). Other dimensions are either human-readable (model, function name) or tiny enums,
+ * where a copy button is clutter — and `integration_id` gets a "go to" link instead.
+ */
+export function breakdownSeriesCopyValue(dimension: AnyBreakdownDimension, value: string): string | undefined {
+    return dimension === 'connection_id' ? value : undefined;
+}
+
+/**
  * The breakdown dimension actually sent to the query. Group and filter may target the same
  * dimension — the backend rejects that degenerate split, so the filter wins and the grouping is
  * dropped from the query. (The grouping stays in the URL, so clearing the filter restores it.)

--- a/packages/webapp/src/pages/Team/Billing/usageBreakdown.unit.test.ts
+++ b/packages/webapp/src/pages/Team/Billing/usageBreakdown.unit.test.ts
@@ -2,6 +2,8 @@ import { describe, expect, it } from 'vitest';
 
 import {
     BREAKDOWN_DIMENSIONS,
+    breakdownSeriesCopyValue,
+    breakdownSeriesHref,
     DIMENSION_LABELS,
     formatDimensionValue,
     isSearchableDimension,
@@ -106,6 +108,34 @@ describe('isSearchableDimension', () => {
         for (const dim of referenced) {
             expect(open.has(dim) || closed.has(dim), `unclassified dimension "${dim}"`).toBe(true);
             expect(isSearchableDimension(dim)).toBe(open.has(dim));
+        }
+    });
+});
+
+describe('breakdownSeriesHref', () => {
+    it('links an integration_id series to its integration page', () => {
+        expect(breakdownSeriesHref('prod', 'integration_id', 'hubspot')).toBe('/prod/integrations/hubspot');
+    });
+
+    it('URL-encodes the provider config key', () => {
+        expect(breakdownSeriesHref('prod', 'integration_id', 'my integration/v2')).toBe('/prod/integrations/my%20integration%2Fv2');
+    });
+
+    it('returns undefined for every other dimension (not linkable yet)', () => {
+        for (const dim of ['connection_id', 'model', 'function_name', 'environment_id', 'success', 'package', 'callsite'] as const) {
+            expect(breakdownSeriesHref('prod', dim, 'anything'), `${dim} should not be linkable`).toBeUndefined();
+        }
+    });
+});
+
+describe('breakdownSeriesCopyValue', () => {
+    it('offers copy only for connection_id', () => {
+        expect(breakdownSeriesCopyValue('connection_id', '5c33f330-7f55-4cbd-a8cc-b091ee3ac15c')).toBe('5c33f330-7f55-4cbd-a8cc-b091ee3ac15c');
+    });
+
+    it('returns undefined for every other dimension (no copy button)', () => {
+        for (const dim of ['integration_id', 'model', 'function_name', 'function_type', 'success', 'environment_id', 'package', 'callsite'] as const) {
+            expect(breakdownSeriesCopyValue(dim, 'anything'), `${dim} should not be copyable`).toBeUndefined();
         }
     });
 });

--- a/packages/webapp/src/utils/analyticsEvents.ts
+++ b/packages/webapp/src/utils/analyticsEvents.ts
@@ -27,6 +27,8 @@ export interface AnalyticsEvents {
     };
     'web:usage:series_isolated': { metric: UsageMetric };
     'web:usage:series_toggled': { metric: UsageMetric };
+    'web:usage:value_copied': { metric: UsageMetric; dimension: AnyBreakdownDimension };
+    'web:usage:value_opened': { metric: UsageMetric; dimension: AnyBreakdownDimension };
     'web:usage:invoice_details_clicked': Record<string, never>;
     'web:usage:billing_portal_clicked': Record<string, never>;
 


### PR DESCRIPTION
## Problem

On Team → Billing, the usage-breakdown chart legend handled long values poorly and was a dead end. Long connection UUIDs wrapped raggedly and a fixed max-height clipped the last series row behind a scrollbar, and there was no way to act on a value — you couldn't copy a connection id to find it elsewhere, or jump to the integration behind a slice.

## Solution

Legend readability ([NAN-6261](https://linear.app/nango/issue/NAN-6261/make-chart-legends-readable-for-long-billing-values)):

* Render UUID values (connection ids) in 12px monospace so their equal-width rows line up as clean columns instead of a ragged wrap.
* Drop the legend's fixed max-height so every series row stays visible instead of the scroll area clipping the last one.

Reach a value ([NAN-6251](https://linear.app/nango/issue/NAN-6251/copy-a-usage-breakdown-value-or-open-its-integration-from-the-chart)):

* On hover/focus a legend row reveals per-series actions: **Copy** on connection rows (the opaque id you'd paste into a lookup, the API, or a filter) and a **Go to** link on integration rows (opens the integration page).
* Other dimensions (model, function name, status, environment, …) get no actions — they're human-readable or tiny enums where icons are just clutter.
* The action space is reserved so revealing icons on hover never reflows the wrapped rows.
* Actions are injected via `seriesHref` / `seriesCopyValue` props from the billing layer, so `ChartLegend` stays dimension-agnostic.
* Both new actions emit product-analytics events (`web:usage:value_copied` / `web:usage:value_opened`, with metric + dimension), following the existing legend-interaction tracking pattern.

Connection navigation ("go to this connection") is intentionally out of scope — the connection route also needs the integration, which the breakdown value doesn't carry (tracked in [NAN-6252](https://linear.app/nango/issue/NAN-6252)).

Fixes [NAN-6251](https://linear.app/nango/issue/NAN-6251)<br>Fixes [NAN-6261](https://linear.app/nango/issue/NAN-6261)

## Testing

* Unit: `breakdownSeriesHref` (integration → route, URL-encoded; others → none) and `breakdownSeriesCopyValue` (connection → copy; others → none).
* Live (local ClickHouse seed, Free-plan usage table): grouped a metric by Connection → copy-only rows, UUIDs monospace and aligned, all rows visible; by Integration → the Go-to link opens the correct integration page; by Model → no actions. Confirmed hovering doesn't shift the legend and Copy writes the raw id.
* webapp typecheck, oxlint, prettier, and unit tests pass.

https://github.com/user-attachments/assets/99c7e9f2-1eda-4d27-8310-0dc711822416