### PR TITLE
docs: flatten management mcp reference

### DIFF
--- a/docs/custom.css
+++ b/docs/custom.css
@@ -221,6 +221,13 @@ html:not(.dark) #navbar {
 html:not(.dark) :has(> #sidebar-content) { border-right: 1px solid rgba(0, 0, 0, 0.08) !important; }
 #sidebar-content .pointer-events-none.sticky { display: none !important; }
 #navigation-items { padding-top: 20px !important; }
+#navigation-items img[src$="/images/mcp.svg"] {
+  opacity: 0.38;
+}
+.dark #navigation-items img[src$="/images/mcp.svg"] {
+  filter: invert(1);
+  opacity: 0.58;
+}
 
 /* ══ TOC — hide scrollbar until hover ════════════════════════════ */
 /*

--- a/docs/docs.json
+++ b/docs/docs.json
@@ -80,11 +80,15 @@
   "redirects": [
     {
       "source": "/reference/backend/control-plane-mcp/overview",
-      "destination": "/reference/backend/management-mcp/overview"
+      "destination": "/reference/backend/management-mcp"
     },
     {
       "source": "/reference/backend/control-plane-mcp/logs",
-      "destination": "/reference/backend/management-mcp/overview"
+      "destination": "/reference/backend/management-mcp"
+    },
+    {
+      "source": "/reference/backend/management-mcp/overview",
+      "destination": "/reference/backend/management-mcp"
     },
     {
       "source": "/integrations/all/snowflake",
@@ -897,11 +901,7 @@
                       "reference/backend/backend-sdk/php"
                     ]
                   },
-                  {
-                    "group": "Management MCP (Beta)",
-                    "icon": "/images/mcp.svg",
-                    "pages": ["reference/backend/management-mcp/overview"]
-                  }
+                  "reference/backend/management-mcp"
                 ]
               },
               {

--- a/docs/getting-started/coding-agent-setup.mdx
+++ b/docs/getting-started/coding-agent-setup.mdx
@@ -25,7 +25,7 @@ It is public and does not require authentication.
 
 ## Management MCP server (Beta)
 
-Add Nango's Management MCP server to let your coding agent manage your Nango environment. The available tools are listed in the [Management MCP reference](/reference/backend/management-mcp/overview#tools).
+Add Nango's Management MCP server to let your coding agent manage your Nango environment. Today, it can explore logs, and we are progressively adding capabilities so that everything you can do in the Nango UI can also be done from an LLM interface. The available tools are listed in the [Management MCP reference](/reference/backend/management-mcp#tools).
 
 Create an API key in **Environment Settings > API Keys**, then replace `<NANGO_API_KEY>` in the relevant configuration below.
 

--- a/docs/guides/platform/observability.mdx
+++ b/docs/guides/platform/observability.mdx
@@ -34,7 +34,7 @@ We recommend exploring the logs in your own Nango account under **Logs**.
 
 ## Logs MCP tools (Beta)
 
-The [Management MCP server](/reference/backend/management-mcp/overview#logs) provides Beta tools for listing and filtering log operations and retrieving their messages from an MCP-compatible client.
+The [Management MCP server](/reference/backend/management-mcp#logs) provides Beta tools for listing and filtering log operations and retrieving their messages from an MCP-compatible client.
 
 ## OpenTelemetry export
 

--- a/docs/guides/platform/observability.mdx
+++ b/docs/guides/platform/observability.mdx
@@ -36,6 +36,8 @@ We recommend exploring the logs in your own Nango account under **Logs**.
 
 The [Management MCP server](/reference/backend/management-mcp#logs) provides Beta tools for listing and filtering log operations and retrieving their messages from an MCP-compatible client.
 
+This helps LLMs investigate and fix integration issues automatically.
+
 ## OpenTelemetry export
 
 Nango supports exporting OpenTelemetry traces so you can monitor and analyze integration activity in your own observability stack.

--- a/docs/llms-full.txt
+++ b/docs/llms-full.txt
@@ -255,7 +255,7 @@ It is public and does not require authentication.
 
 ## Management MCP server (Beta)
 
-Add Nango's Management MCP server to let your coding agent manage your Nango environment. The available tools are listed in the [Management MCP reference](/reference/backend/management-mcp/overview#tools).
+Add Nango's Management MCP server to let your coding agent manage your Nango environment. Today, it can explore logs, and we are progressively adding capabilities so that everything you can do in the Nango UI can also be done from an LLM interface. The available tools are listed in the [Management MCP reference](/reference/backend/management-mcp#tools).
 
 Create an API key in **Environment Settings > API Keys**, then replace `<NANGO_API_KEY>` in the relevant configuration below.
 
@@ -6068,7 +6068,7 @@ We recommend exploring the logs in your own Nango account under **Logs**.
 
 ## Logs MCP tools (Beta)
 
-The [Management MCP server](/reference/backend/management-mcp/overview#logs) provides Beta tools for listing and filtering log operations and retrieving their messages from an MCP-compatible client.
+The [Management MCP server](/reference/backend/management-mcp#logs) provides Beta tools for listing and filtering log operations and retrieving their messages from an MCP-compatible client.
 
 ## OpenTelemetry export
 
@@ -9118,7 +9118,7 @@ The **Default - Full access** key that comes with each environment already has a
 | `environment:logs:read` | Read log operations and messages |
 
 <Note>
-    The `environment:logs:read` scope is currently only used by the [Logs tools in the Management MCP server](/reference/backend/management-mcp/overview#logs).
+    The `environment:logs:read` scope is currently only used by the [Logs tools in the Management MCP server](/reference/backend/management-mcp#logs).
 </Note>
 
 ### Actions
@@ -12637,9 +12637,9 @@ Source: https://nango.dev/docs/reference/backend/backend-sdk/php.md
 
 <Note>Coming soon. Use the [REST API](/reference/backend/http-api/authentication) in the meantime.</Note>
 
-## Management MCP overview (Beta)
+## Management MCP (Beta)
 
-Source: https://nango.dev/docs/reference/backend/management-mcp/overview.md
+Source: https://nango.dev/docs/reference/backend/management-mcp.md
 Description: Manage a Nango environment from an MCP client.
 
 <Note>

--- a/docs/llms-full.txt
+++ b/docs/llms-full.txt
@@ -6070,6 +6070,8 @@ We recommend exploring the logs in your own Nango account under **Logs**.
 
 The [Management MCP server](/reference/backend/management-mcp#logs) provides Beta tools for listing and filtering log operations and retrieving their messages from an MCP-compatible client.
 
+This helps LLMs investigate and fix integration issues automatically.
+
 ## OpenTelemetry export
 
 Nango supports exporting OpenTelemetry traces so you can monitor and analyze integration activity in your own observability stack.

--- a/docs/llms.txt
+++ b/docs/llms.txt
@@ -129,7 +129,7 @@ Use provider URLs by replacing `{slug}` with a slug from the API catalog:
 - [Backend: Backend SDK: Go](https://nango.dev/docs/reference/backend/backend-sdk/go.md)
 - [Backend: Backend SDK: Rust](https://nango.dev/docs/reference/backend/backend-sdk/rust.md)
 - [Backend: Backend SDK: PHP](https://nango.dev/docs/reference/backend/backend-sdk/php.md)
-- [Backend: Management MCP (Beta): Management MCP overview (Beta)](https://nango.dev/docs/reference/backend/management-mcp/overview.md): Manage a Nango environment from an MCP client.
+- [Backend: Management MCP (Beta)](https://nango.dev/docs/reference/backend/management-mcp.md): Manage a Nango environment from an MCP client.
 - [Functions: Functions CLI](https://nango.dev/docs/reference/functions/functions-cli.md): Full reference of the CLI available to implement, test & deploy Nango Functions.
 - [Functions: Functions SDK](https://nango.dev/docs/reference/functions/functions-sdk.md): Full reference of the SDK available in Nango Functions.
 

--- a/docs/reference/backend/http-api/api-keys.mdx
+++ b/docs/reference/backend/http-api/api-keys.mdx
@@ -203,7 +203,7 @@ The **Default - Full access** key that comes with each environment already has a
 | `environment:logs:read` | Read log operations and messages |
 
 <Note>
-    The `environment:logs:read` scope is currently only used by the [Logs tools in the Management MCP server](/reference/backend/management-mcp/overview#logs).
+    The `environment:logs:read` scope is currently only used by the [Logs tools in the Management MCP server](/reference/backend/management-mcp#logs).
 </Note>
 
 ### Actions

--- a/docs/reference/backend/management-mcp.mdx
+++ b/docs/reference/backend/management-mcp.mdx
@@ -1,7 +1,8 @@
 ---
-title: 'Management MCP overview (Beta)'
-sidebarTitle: 'Overview'
+title: 'Management MCP (Beta)'
+sidebarTitle: 'Management MCP (Beta)'
 description: 'Manage a Nango environment from an MCP client.'
+icon: '/images/mcp.svg'
 ---
 
 <Note>

--- a/docs/updates/changelog.mdx
+++ b/docs/updates/changelog.mdx
@@ -14,7 +14,7 @@ description: "Important developer & product updates, including deprecations & br
 
   Authenticate with a Nango API key sent as a Bearer token. The logs tools require the `environment:logs:read` scope. More tools are on the way, with the goal of supporting the full public API.
 
-  Learn more in the [Management MCP reference](/reference/backend/management-mcp/overview) and the [coding agent setup page](/getting-started/coding-agent-setup#management-mcp-server-beta).
+  Learn more in the [Management MCP reference](/reference/backend/management-mcp) and the [coding agent setup page](/getting-started/coding-agent-setup#management-mcp-server-beta).
 
   ![Claude Code querying Nango logs through the Management MCP server](/images/changelog/nango-management-mcp-logs.png)
 </Update>


### PR DESCRIPTION
## Summary

- Flatten the Management MCP reference from `/reference/backend/management-mcp/overview` to `/reference/backend/management-mcp`.
- Add the MCP icon via page metadata and preserve a redirect from the old overview route.
- Mention in coding agent setup that Management MCP can explore logs and is expanding toward UI-equivalent LLM capabilities.
- Regenerate `llms.txt` and `llms-full.txt` for the updated route/content.

## Checks

- `npm run docs:generate:llms`
- `npx prettier --check docs/docs.json docs/getting-started/coding-agent-setup.mdx docs/guides/platform/observability.mdx docs/reference/backend/http-api/api-keys.mdx docs/reference/backend/management-mcp.mdx docs/updates/changelog.mdx`


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/NangoHQ/nango/pull/6843?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

