### PR TITLE
refactor(webapp): adopt Card / EmptyCard for inline panels

### DIFF
--- a/packages/webapp/src/pages/Homepage/Show.tsx
+++ b/packages/webapp/src/pages/Homepage/Show.tsx
@@ -1,6 +1,7 @@
 import { Helmet } from 'react-helmet';
 import { Link } from 'react-router-dom';
 
+import { EmptyCard } from '../../components/ui/EmptyCard';
 import { useMeta } from '../../hooks/useMeta';
 import { useUser } from '../../hooks/useUser';
 import DashboardLayout from '../../layout/DashboardLayout';
@@ -28,7 +29,7 @@ export const Homepage: React.FC = () => {
                     </div>
                 </div>
 
-                <div className="flex gap-2 flex-col border border-border-muted rounded-md items-center text-text-strong text-center p-10 py-20 mt-4">
+                <EmptyCard className="mt-4 text-center text-text-strong">
                     <h2 className="text-xl text-center">Logs not configured</h2>
                     <div className="text-sm text-text-muted">
                         Follow{' '}
@@ -37,7 +38,7 @@ export const Homepage: React.FC = () => {
                         </Link>{' '}
                         to configure logs and enable execution metrics in your dashboard.
                     </div>
-                </div>
+                </EmptyCard>
             </DashboardLayout>
         );
     }

--- a/packages/webapp/src/pages/Logs/Show.tsx
+++ b/packages/webapp/src/pages/Logs/Show.tsx
@@ -2,6 +2,7 @@ import { useQueryState } from 'nuqs';
 import { Helmet } from 'react-helmet';
 import { Link } from 'react-router-dom';
 
+import { EmptyCard } from '../../components/ui/EmptyCard';
 import DashboardLayout from '../../layout/DashboardLayout';
 import { useStore } from '../../store';
 import { globalEnv } from '../../utils/env';
@@ -23,7 +24,7 @@ export const LogsShow: React.FC = () => {
                 <Helmet>
                     <title>Logs - Nango</title>
                 </Helmet>
-                <div className="flex gap-2 flex-col border border-border-muted rounded-md items-center text-text-strong text-center p-10 py-20">
+                <EmptyCard className="text-center text-text-strong">
                     <h2 className="text-xl text-center">Logs not configured</h2>
                     <div className="text-sm text-text-muted">
                         Follow{' '}
@@ -32,7 +33,7 @@ export const LogsShow: React.FC = () => {
                         </Link>{' '}
                         to configure logs.
                     </div>
-                </div>
+                </EmptyCard>
             </DashboardLayout>
         );
     }

--- a/packages/webapp/src/pages/Logs/components/SearchAllOperations.tsx
+++ b/packages/webapp/src/pages/Logs/components/SearchAllOperations.tsx
@@ -10,6 +10,7 @@ import { Button, InputGroup, InputGroupAddon, InputGroupButton, InputGroupInput 
 
 import { FilterMultiSelect } from '@/components/patterns/FilterMultiSelect';
 import { PeriodSelector } from '@/components/patterns/PeriodSelector';
+import { EmptyCard } from '@/components/ui/EmptyCard';
 import { Skeleton } from '@/components/ui/Skeleton';
 import { queryClient, useStore } from '../../../store';
 import { apiFetch } from '../../../utils/api';
@@ -340,10 +341,10 @@ export const SearchAllOperations: React.FC<Props> = ({ onSelectOperation }) => {
                         <tbody>
                             <tr className="hover:bg-transparent flex absolute w-full">
                                 <td colSpan={columns.length} className="h-24 text-center p-0 pt-4 w-full">
-                                    <div className="flex gap-2 flex-col border border-border-muted rounded-md items-center text-text-strong text-center p-10 py-20">
+                                    <EmptyCard className="text-center text-text-strong">
                                         <div className="text-center">No logs found</div>
                                         <div className="text-text-muted">Note that logs older than 15 days are automatically cleared.</div>
-                                    </div>
+                                    </EmptyCard>
                                 </td>
                             </tr>
                         </tbody>

--- a/packages/webapp/src/pages/Team/components/ImpersonateForm.tsx
+++ b/packages/webapp/src/pages/Team/components/ImpersonateForm.tsx
@@ -3,7 +3,7 @@ import { TriangleAlert } from 'lucide-react';
 import { useForm } from 'react-hook-form';
 import z from 'zod';
 
-import { Button, FieldLabel, Input } from '@nangohq/design-system';
+import { Button, Card, CardContent, CardHeader, CardTitle, FieldLabel, Input } from '@nangohq/design-system';
 
 import { Alert, AlertDescription } from '@/components/ui/Alert';
 import { Form, FormControl, FormField, FormItem, FormMessage } from '../../../components/ui/Form';
@@ -38,56 +38,62 @@ export const ImpersonateForm: React.FC = () => {
     };
 
     return (
-        <div className="w-100 flex flex-col gap-3 p-6 border border-border-default rounded-md relative">
-            <h3 className="text-heading-sm text-text-strong absolute top-[-12px] left-3 bg-surface-canvas px-1">Nango admin</h3>
-            <h3 className="text-heading-sm text-text-strong">Impersonate account</h3>
-            <Form {...form}>
-                <form onSubmit={form.handleSubmit(onSubmit)} className="flex flex-col gap-3">
-                    <div className="flex flex-col gap-2">
-                        <FieldLabel htmlFor="account_uuid">Account UUID</FieldLabel>
-                        <FormField
-                            control={form.control}
-                            name="account_uuid"
-                            render={({ field }) => (
-                                <FormItem>
-                                    <FormControl>
-                                        <Input placeholder="Account UUID" {...field} />
-                                    </FormControl>
-                                    <FormMessage />
-                                </FormItem>
-                            )}
-                        />
-                    </div>
+        <div className="relative w-100">
+            <h3 className="text-heading-sm text-text-strong absolute top-[-12px] left-3 z-10 bg-surface-canvas px-1">Nango admin</h3>
+            <Card>
+                <CardHeader>
+                    <CardTitle>Impersonate account</CardTitle>
+                </CardHeader>
+                <CardContent>
+                    <Form {...form}>
+                        <form onSubmit={form.handleSubmit(onSubmit)} className="flex flex-col gap-3">
+                            <div className="flex flex-col gap-2">
+                                <FieldLabel htmlFor="account_uuid">Account UUID</FieldLabel>
+                                <FormField
+                                    control={form.control}
+                                    name="account_uuid"
+                                    render={({ field }) => (
+                                        <FormItem>
+                                            <FormControl>
+                                                <Input placeholder="Account UUID" {...field} />
+                                            </FormControl>
+                                            <FormMessage />
+                                        </FormItem>
+                                    )}
+                                />
+                            </div>
 
-                    <div className="flex flex-col gap-2">
-                        <FieldLabel htmlFor="login_reason">Login reason</FieldLabel>
-                        <FormField
-                            control={form.control}
-                            name="login_reason"
-                            render={({ field }) => (
-                                <FormItem>
-                                    <FormControl>
-                                        <Input placeholder="Login reason" {...field} />
-                                    </FormControl>
-                                    <FormMessage />
-                                </FormItem>
-                            )}
-                        />
-                    </div>
-                    <Alert variant="warning">
-                        <TriangleAlert />
-                        <AlertDescription>
-                            <span>Impersonating an account will allow you to login as that account and perform actions on their behalf.</span>
-                        </AlertDescription>
-                    </Alert>
-                    <div className="self-end">
-                        <Button type="submit" variant="danger">
-                            Impersonate
-                        </Button>
-                    </div>
-                    {form.formState.errors.root && <p className="mt-2 mx-4 text-sm text-status-danger-text">{form.formState.errors.root.message}</p>}
-                </form>
-            </Form>
+                            <div className="flex flex-col gap-2">
+                                <FieldLabel htmlFor="login_reason">Login reason</FieldLabel>
+                                <FormField
+                                    control={form.control}
+                                    name="login_reason"
+                                    render={({ field }) => (
+                                        <FormItem>
+                                            <FormControl>
+                                                <Input placeholder="Login reason" {...field} />
+                                            </FormControl>
+                                            <FormMessage />
+                                        </FormItem>
+                                    )}
+                                />
+                            </div>
+                            <Alert variant="warning">
+                                <TriangleAlert />
+                                <AlertDescription>
+                                    <span>Impersonating an account will allow you to login as that account and perform actions on their behalf.</span>
+                                </AlertDescription>
+                            </Alert>
+                            <div className="self-end">
+                                <Button type="submit" variant="danger">
+                                    Impersonate
+                                </Button>
+                            </div>
+                            {form.formState.errors.root && <p className="mt-2 mx-4 text-sm text-status-danger-text">{form.formState.errors.root.message}</p>}
+                        </form>
+                    </Form>
+                </CardContent>
+            </Card>
         </div>
     );
 };


### PR DESCRIPTION
## Problem

Following the Card lift ([NAN-6385](https://linear.app/nango/issue/NAN-6385)), several screens still hand-roll card-like and empty-state panels with inline `border/rounded/padding` divs instead of the shared components, keeping visual drift alive.

## Solution

- `Team/components/ImpersonateForm` — inline bordered panel → design-system `Card` (the floating "Nango admin" legend is preserved via a `relative` wrapper).
- Three inline empty-state panels → the shared `EmptyCard`: homepage "Logs not configured", logs "Logs not configured", and the log-search "No logs found" state.

Scoped out per triage (in the ticket): `Integrations/CardLayout` and `Connection/CreateLegacy` are left as-is, and `Homepage/InsightChart` is held for a Card **Hover** variant (it's a clickable hover card, which the `md` Card can't express yet).

Fixes [NAN-6388](https://linear.app/nango/issue/NAN-6388)

## Testing

- Visual QA checklist: [NAN-6388 — Adopt Card / EmptyCard for inline panels](https://app.notion.com/p/3a4ce298312181c9aed2c8703d302745) (Notion).
- `ts-build`, `lint`, and `format:check` pass.
- Visual QA (light + dark): impersonate panel (Nango-admin only), homepage "Logs not configured", logs "Logs not configured", and log-search empty state. Note the empty states now use `EmptyCard`'s `surface-panel` bg + `p-20` (was borderless `p-10 py-20`); the log-search one sits in a table cell — confirm its height reads fine.
