### PR TITLE
feat(webapp): stack billing page sections, drop tabs

### DIFF
--- a/packages/webapp/src/layout/DashboardLayout.tsx
+++ b/packages/webapp/src/layout/DashboardLayout.tsx
@@ -28,7 +28,7 @@ const DashboardLayout = React.forwardRef<HTMLDivElement, DashboardLayoutProps>(
                         className={cn('relative w-full flex-1 min-h-0 overflow-auto bg-surface-page min-w-3xl', fullWidth ? 'p-0' : 'p-11')}
                         {...props}
                     >
-                        <div className={cn('grow h-auto mx-auto w-full', fullWidth ? 'p-11' : 'min-w-[968px] max-w-[1056px]', className)}>{children}</div>
+                        <div className={cn('grow h-auto mx-auto w-full', fullWidth ? 'p-6' : 'min-w-[968px] max-w-[1056px]', className)}>{children}</div>
                         <Playground />
                     </div>
                 </SidebarInset>

--- a/packages/webapp/src/pages/Team/Billing/Show.tsx
+++ b/packages/webapp/src/pages/Team/Billing/Show.tsx
@@ -57,24 +57,28 @@ export const TeamBilling: React.FC = () => {
             {/* max-w: the old 1280 cap plus the 228px (184px side panel + 44px gap) the tabbed
                 NavigationList side panel used to take up, now that the sections stack instead */}
             <div className="flex flex-col gap-8 max-w-[1508px]">
-                <header className="flex justify-end items-center">
-                    {!isFreePlan && (
+                {!isFreePlan && (
+                    <header className="flex justify-end items-center">
                         <div className="flex items-center gap-4">
                             <MonthSelector onMonthChange={setSelectedMonth} />
                         </div>
-                    )}
-                </header>
+                    </header>
+                )}
                 <div id="usage">
                     <Usage selectedMonth={selectedMonth} />
                 </div>
                 <Separator />
-                <div id="plans" className="w-full overflow-x-auto">
-                    <Plans />
+                <div id="plans" className="flex flex-col gap-4">
+                    <span className="text-text-strong text-body-medium-medium">Plans</span>
+                    <div className="w-full overflow-x-auto">
+                        <Plans />
+                    </div>
                 </div>
                 {canManageBilling && (
                     <>
                         <Separator />
-                        <div id="payment-and-invoices">
+                        <div id="payment-and-invoices" className="flex flex-col gap-4">
+                            <span className="text-text-strong text-body-medium-medium">Billing information</span>
                             <Payment />
                         </div>
                     </>

--- a/packages/webapp/src/pages/Team/Billing/Show.tsx
+++ b/packages/webapp/src/pages/Team/Billing/Show.tsx
@@ -4,10 +4,8 @@ import { useLocation } from 'react-router-dom';
 
 import { permissions } from '@nangohq/authz';
 
-import { PermissionGate } from '@/components/patterns/PermissionGate';
-import { Navigation, NavigationContent, NavigationList, NavigationTrigger } from '@/components/ui/Navigation';
+import { Separator } from '@/components/ui/Separator';
 import { useEnvironment } from '@/hooks/useEnvironment';
-import { useHashNavigation } from '@/hooks/useHashNavigation';
 import { usePermissions } from '@/hooks/usePermissions';
 import { useStore } from '@/store';
 import { track } from '@/utils/analytics';
@@ -18,8 +16,6 @@ import { Plans } from './components/Plans';
 import { Usage } from './components/Usage';
 
 export const TeamBilling: React.FC = () => {
-    const [activeTab, setActiveTab] = useHashNavigation('usage');
-    const isUsageTab = activeTab === 'usage';
     const [selectedMonth, setSelectedMonth] = useState<Date>(() => {
         const now = new Date();
         return new Date(now.getUTCFullYear(), now.getUTCMonth(), 1);
@@ -35,22 +31,20 @@ export const TeamBilling: React.FC = () => {
     const canManageBilling = can(permissions.canManageBilling);
 
     useEffect(() => {
-        if (!canManageBilling && activeTab === 'payment-and-invoices') {
-            setActiveTab('usage');
-        }
-    }, [canManageBilling, activeTab, setActiveTab]);
+        track('web:usage:viewed', {});
+    }, []);
 
-    // Read the tab from the URL hash directly: useHashNavigation defaults to 'usage' until it syncs
-    // after mount, so opening #plans would otherwise fire a usage view for one render.
+    // The 3 sections used to be separate tabs reachable via #usage/#plans/#payment-and-invoices
+    // (still linked from other pages). Now that they're stacked on one page, scroll to the matching
+    // section instead of switching tabs.
     const location = useLocation();
-    const onUsageTab = (location.hash ? location.hash.slice(1) : 'usage') === 'usage';
-
-    // Track a usage-page view when the tab becomes active (initial load or switching back to it).
     useEffect(() => {
-        if (onUsageTab) {
-            track('web:usage:viewed', {});
+        const hash = location.hash.slice(1);
+        if (!hash) {
+            return;
         }
-    }, [onUsageTab]);
+        document.getElementById(hash)?.scrollIntoView({ block: 'start' });
+    }, [location.hash]);
 
     // Full-width page shell keeps chrome consistent with the other dashboard pages, but the billing
     // content is capped and left-aligned: the usage charts have a fixed height, so unbounded width
@@ -60,38 +54,31 @@ export const TeamBilling: React.FC = () => {
             <Helmet>
                 <title>Billing & usage - Nango</title>
             </Helmet>
-            <div className="flex flex-col gap-8 max-w-[1280px]">
+            {/* max-w: the old 1280 cap plus the 228px (184px side panel + 44px gap) the tabbed
+                NavigationList side panel used to take up, now that the sections stack instead */}
+            <div className="flex flex-col gap-8 max-w-[1508px]">
                 <header className="flex justify-end items-center">
-                    {isUsageTab && !isFreePlan && (
+                    {!isFreePlan && (
                         <div className="flex items-center gap-4">
                             <MonthSelector onMonthChange={setSelectedMonth} />
                         </div>
                     )}
                 </header>
-                <Navigation value={activeTab} onValueChange={setActiveTab} className="max-w-full">
-                    <NavigationList>
-                        <NavigationTrigger value={'usage'}>Usage</NavigationTrigger>
-                        <NavigationTrigger value={'plans'}>Plans</NavigationTrigger>
-                        <PermissionGate condition={canManageBilling}>
-                            {(allowed) => (
-                                <NavigationTrigger value={'payment-and-invoices'} disabled={!allowed}>
-                                    Payment & Invoices
-                                </NavigationTrigger>
-                            )}
-                        </PermissionGate>
-                    </NavigationList>
-                    <NavigationContent value={'usage'} className="w-full flex flex-col gap-6">
-                        <Usage selectedMonth={selectedMonth} />
-                    </NavigationContent>
-                    <NavigationContent value={'plans'} className="w-full overflow-x-auto">
-                        <Plans />
-                    </NavigationContent>
-                    {canManageBilling && (
-                        <NavigationContent value={'payment-and-invoices'} className="w-full">
+                <div id="usage">
+                    <Usage selectedMonth={selectedMonth} />
+                </div>
+                <Separator />
+                <div id="plans" className="w-full overflow-x-auto">
+                    <Plans />
+                </div>
+                {canManageBilling && (
+                    <>
+                        <Separator />
+                        <div id="payment-and-invoices">
                             <Payment />
-                        </NavigationContent>
-                    )}
-                </Navigation>
+                        </div>
+                    </>
+                )}
             </div>
         </DashboardLayout>
     );


### PR DESCRIPTION
## Problem

The Billing & usage page used tabs (Usage / Plans / Payment & Invoices) to switch between sections. The approved redesign drops the nav-pattern decision (tabs vs. a drill-in side panel) in favor of stacking all three sections on one page.

## Solution

- Remove the tabbed `Navigation` UI; render Usage, Plans, and Payment stacked in a single column
- Add a `Separator` between each section, inside a 32px gap column, matching the approved Figma design
- Widen the content `max-w` from 1280px to 1508px — the old tab UI's vertical `NavigationList` side panel + its gap (228px) is now freed up for content
- Preserve `#usage` / `#plans` / `#payment-and-invoices` deep links (still used by several other pages) by scrolling to the matching section instead of switching tabs

Fixes [NAN-6219](https://linear.app/nango/issue/NAN-6219/build-the-billing-and-usage-page-shell-layout)

## Testing

- Verified locally in both light and dark mode: sections stack with separators in the right places, no tabs
- Verified `#payment-and-invoices` and other hash deep links correctly scroll to their section
- `npm run lint` and `npm run ts-build` pass
