### PR TITLE
fix(records): stop autoPruningCandidate test flaking in CI

### DIFF
--- a/packages/records/lib/stores/postgres/postgres.integration.test.ts
+++ b/packages/records/lib/stores/postgres/postgres.integration.test.ts
@@ -1812,9 +1812,11 @@ describe('PostgresStore', () => {
             await db(RECORDS_TABLE).where({ external_id: '1', connection_id: connectionId, model }).update({ updated_at: oneDayAgo });
 
             // Try to find a stale record
-            // Since we're picking a random partition, we might need to try multiple times
+            // Since we're picking a random partition (1/256 chance per try), we need enough attempts to make
+            // the odds of never hitting it negligible: (255/256)^1000 ≈ 2%, which was flaky in CI;
+            // (255/256)^3000 ≈ 0.0008%.
             const staleAfterMs = 60 * 60 * 1000; // 1 hour
-            for (let i = 0; i < 1000; i++) {
+            for (let i = 0; i < 3000; i++) {
                 const candidate = (await store.autoPruningCandidate({ staleAfterMs })).unwrap();
                 if (candidate) {
                     expect(candidate.connectionId).toBe(connectionId);
@@ -1830,7 +1832,7 @@ describe('PostgresStore', () => {
                 }
             }
             throw new Error('No candidate found. Expecting one');
-        });
+        }, 30000);
 
         it('should return null when no stale records exist', async () => {
             const connectionId = rnd.number();


### PR DESCRIPTION
## Problem

`PostgresStore > autoPruningCandidate > should find a stale record candidate for pruning` flaked in CI ([failing run](https://github.com/NangoHQ/nango/actions/runs/29810791146/job/88571143682)) with `Error: No candidate found. Expecting one`. `autoPruningCandidate()` picks a uniformly random partition out of 256 on every call (by design, to spread pruning load), so the test's 1000-attempt retry loop had a `(255/256)^1000 ≈ 2%` chance of never landing on the partition holding the seeded stale record.

## Solution

- Raise the retry loop from 1000 to 3000 attempts, dropping the failure odds to `~0.0008%`
- Bump the test's timeout to 30s to keep headroom for the worst case (measured ~2ms per call locally, so 3000 attempts ≈ 6s)

## Testing

- Ran `postgres.integration.test.ts` locally against real Postgres/Elasticsearch/Redis/ClickHouse — 69/69 pass
