### PR TITLE
feat(webapp): add connection reconnect flow (NAN-4537)

### DIFF
--- a/packages/server/lib/controllers/v1/connect/sessions/postConnectSessionsReconnect.ts
+++ b/packages/server/lib/controllers/v1/connect/sessions/postConnectSessionsReconnect.ts
@@ -1,0 +1,105 @@
+import * as z from 'zod';
+
+import db from '@nangohq/database';
+import * as keystore from '@nangohq/keystore';
+import { endUserToMeta, logContextGetter } from '@nangohq/logs';
+import { connectionService, getEndUser } from '@nangohq/shared';
+import { buildConnectUiSessionLink, requireEmptyQuery, zodErrorToHTTP } from '@nangohq/utils';
+
+import { connectionIdSchema, providerConfigKeySchema } from '../../../../helpers/validation.js';
+import * as connectSessionService from '../../../../services/connectSession.service.js';
+import { asyncWrapper } from '../../../../utils/asyncWrapper.js';
+
+import type { PostInternalConnectSessionsReconnect } from '@nangohq/types';
+
+const bodySchema = z
+    .object({
+        connection_id: connectionIdSchema,
+        provider_config_key: providerConfigKeySchema
+    })
+    .strict();
+
+interface Reply {
+    status: number;
+    response: PostInternalConnectSessionsReconnect['Reply'];
+}
+
+export const postInternalConnectSessionsReconnect = asyncWrapper<PostInternalConnectSessionsReconnect>(async (req, res) => {
+    const valQuery = requireEmptyQuery(req, { withEnv: true });
+    if (valQuery) {
+        res.status(400).send({ error: { code: 'invalid_query_params', errors: zodErrorToHTTP(valQuery.error) } });
+        return;
+    }
+
+    const valBody = bodySchema.safeParse(req.body);
+    if (!valBody.success) {
+        res.status(400).send({ error: { code: 'invalid_body', errors: zodErrorToHTTP(valBody.error) } });
+        return;
+    }
+
+    const { account, environment } = res.locals;
+    const body: PostInternalConnectSessionsReconnect['Body'] = valBody.data;
+
+    const { status, response }: Reply = await db.knex.transaction<Reply>(async (trx) => {
+        const connection = await connectionService.checkIfConnectionExists(trx, {
+            connectionId: body.connection_id,
+            providerConfigKey: body.provider_config_key,
+            environmentId: environment.id
+        });
+        if (!connection) {
+            return { status: 400, response: { error: { code: 'invalid_body', message: 'ConnectionID or IntegrationId does not exists' } } };
+        }
+
+        let endUser = null;
+        if (connection.end_user_id) {
+            const endUserRes = await getEndUser(trx, { id: connection.end_user_id, accountId: account.id, environmentId: environment.id }, { forUpdate: true });
+            if (endUserRes.isErr()) {
+                return { status: 500, response: { error: { code: 'server_error', message: endUserRes.error.message } } };
+            }
+            endUser = endUserRes.value;
+        }
+
+        const logCtx = await logContextGetter.create(
+            { operation: { type: 'auth', action: 'create_connection' }, meta: { authType: 'unauth', connectSession: endUserToMeta(endUser) } },
+            { account, environment }
+        );
+
+        // Reuse the connection's existing tags as-is: this is an existing connection being re-authenticated,
+        // not a new one, so its tags (e.g. `origin`) must not be overwritten by this dashboard-initiated session.
+        const createConnectSession = await connectSessionService.createConnectSession(trx, {
+            endUserId: endUser?.id ?? null,
+            endUser: null,
+            accountId: account.id,
+            environmentId: environment.id,
+            connectionId: connection.id,
+            allowedIntegrations: [body.provider_config_key],
+            integrationsConfigDefaults: null,
+            operationId: logCtx.id,
+            overrides: null,
+            webhookUrlOverride: null,
+            tags: connection.tags
+        });
+        if (createConnectSession.isErr()) {
+            return { status: 500, response: { error: { code: 'server_error', message: 'Failed to create connect session' } } };
+        }
+
+        // create a private key for the connect session
+        const createPrivateKey = await keystore.createPrivateKey(trx, {
+            displayName: '',
+            accountId: account.id,
+            environmentId: environment.id,
+            entityType: 'connect_session',
+            entityId: createConnectSession.value.id,
+            ttlInMs: 30 * 60 * 1000 // 30 minutes
+        });
+        if (createPrivateKey.isErr()) {
+            return { status: 500, response: { error: { code: 'server_error', message: 'Failed to create session token' } } };
+        }
+
+        const [token, privateKey] = createPrivateKey.value;
+        const connect_link = buildConnectUiSessionLink(token);
+        return { status: 201, response: { data: { token, connect_link, expires_at: privateKey.expiresAt!.toISOString() } } };
+    });
+
+    res.status(status).send(response);
+});

--- a/packages/server/lib/controllers/v1/connect/sessions/postConnectSessionsReconnect.ts
+++ b/packages/server/lib/controllers/v1/connect/sessions/postConnectSessionsReconnect.ts
@@ -2,7 +2,7 @@ import * as z from 'zod';
 
 import db from '@nangohq/database';
 import * as keystore from '@nangohq/keystore';
-import { endUserToMeta, logContextGetter } from '@nangohq/logs';
+import { defaultOperationExpiration, endUserToMeta, logContextGetter } from '@nangohq/logs';
 import { connectionService, getEndUser } from '@nangohq/shared';
 import { buildConnectUiSessionLink, requireEmptyQuery, zodErrorToHTTP } from '@nangohq/utils';
 
@@ -60,7 +60,11 @@ export const postInternalConnectSessionsReconnect = asyncWrapper<PostInternalCon
         }
 
         const logCtx = await logContextGetter.create(
-            { operation: { type: 'auth', action: 'create_connection' }, meta: { authType: 'unauth', connectSession: endUserToMeta(endUser) } },
+            {
+                operation: { type: 'auth', action: 'create_connection' },
+                meta: { authType: 'unauth', connectSession: endUserToMeta(endUser) },
+                expiresAt: defaultOperationExpiration.auth()
+            },
             { account, environment }
         );
 

--- a/packages/server/lib/routes.private.ts
+++ b/packages/server/lib/routes.private.ts
@@ -34,6 +34,7 @@ import { postLogout } from './controllers/v1/account/postLogout.js';
 import { putResetPassword } from './controllers/v1/account/putResetPassword.js';
 import { postImpersonate } from './controllers/v1/admin/impersonate/postImpersonate.js';
 import { postInternalConnectSessions } from './controllers/v1/connect/sessions/postConnectSessions.js';
+import { postInternalConnectSessionsReconnect } from './controllers/v1/connect/sessions/postConnectSessionsReconnect.js';
 import { deleteConnection } from './controllers/v1/connections/connectionId/deleteConnection.js';
 import { getConnection as getConnectionWeb } from './controllers/v1/connections/connectionId/getConnection.js';
 import { patchConnection } from './controllers/v1/connections/connectionId/patchConnection.js';
@@ -241,6 +242,11 @@ web.route('/environment/admin-auth').get(
 
 // Connect
 web.route('/connect/sessions').post(webAuth, can({ action: 'update', resource: 'connection', scopedBy: envScope }), postInternalConnectSessions);
+web.route('/connect/sessions/reconnect').post(
+    webAuth,
+    can({ action: 'update', resource: 'connection', scopedBy: envScope }),
+    postInternalConnectSessionsReconnect
+);
 
 // Connect UI settings
 web.route('/connect-ui-settings').get(webAuth, getConnectUISettings);

--- a/packages/types/lib/api.endpoints.ts
+++ b/packages/types/lib/api.endpoints.ts
@@ -34,6 +34,7 @@ import type {
     GetConnectSession,
     PostConnectSessions,
     PostInternalConnectSessions,
+    PostInternalConnectSessionsReconnect,
     PostPublicConnectSessionsReconnect,
     PostPublicConnectTelemetry
 } from './connect/api.js';
@@ -212,6 +213,7 @@ export type PrivateApiEndpoints =
     | SearchMessages
     | SearchFilters
     | PostInternalConnectSessions
+    | PostInternalConnectSessionsReconnect
     | GetIntegrationFlows
     | GetIntegrationFunction
     | GetIntegrationFunctions

--- a/packages/types/lib/connect/api.ts
+++ b/packages/types/lib/connect/api.ts
@@ -114,6 +114,16 @@ export type PostInternalConnectSessions = Endpoint<{
     >;
 }>;
 
+export type PostInternalConnectSessionsReconnect = Endpoint<{
+    Method: 'POST';
+    Path: '/api/v1/connect/sessions/reconnect';
+    Success: PostConnectSessions['Success'];
+    Body: {
+        connection_id: string;
+        provider_config_key: string;
+    };
+}>;
+
 export type PostPublicConnectTelemetry = Endpoint<{
     Method: 'POST';
     Path: '/connect/telemetry';

--- a/packages/webapp/src/components/patterns/ConfirmDialog.tsx
+++ b/packages/webapp/src/components/patterns/ConfirmDialog.tsx
@@ -7,7 +7,7 @@ import { StyledLink } from '../ui/StyledLink';
 
 export interface ConfirmDialogOptions {
     title: string;
-    description: string;
+    description: React.ReactNode;
     confirmButtonText?: string;
     cancelButtonText?: string;
     confirmVariant?: 'primary' | 'danger' | 'secondary' | 'outline';

--- a/packages/webapp/src/hooks/useConnect.tsx
+++ b/packages/webapp/src/hooks/useConnect.tsx
@@ -1,6 +1,6 @@
 import { apiFetch } from '../utils/api';
 
-import type { PostInternalConnectSessions } from '@nangohq/types';
+import type { PostInternalConnectSessions, PostInternalConnectSessionsReconnect } from '@nangohq/types';
 
 export async function apiConnectSessions(env: string, body: PostInternalConnectSessions['Body']) {
     const res = await apiFetch(`/api/v1/connect/sessions?env=${env}`, {
@@ -11,5 +11,17 @@ export async function apiConnectSessions(env: string, body: PostInternalConnectS
     return {
         res,
         json: (await res.json()) as PostInternalConnectSessions['Reply']
+    };
+}
+
+export async function apiConnectSessionsReconnect(env: string, body: PostInternalConnectSessionsReconnect['Body']) {
+    const res = await apiFetch(`/api/v1/connect/sessions/reconnect?env=${env}`, {
+        method: 'POST',
+        body: JSON.stringify(body)
+    });
+
+    return {
+        res,
+        json: (await res.json()) as PostInternalConnectSessionsReconnect['Reply']
     };
 }

--- a/packages/webapp/src/pages/Connection/components/AuthTab.tsx
+++ b/packages/webapp/src/pages/Connection/components/AuthTab.tsx
@@ -8,6 +8,7 @@ import { AuthCredentials } from './AuthCredentials/AuthCredentials';
 import { ConnectionExtras } from './ConnectionExtras';
 import { ConnectionTabLayout } from './ConnectionTabLayout';
 import { EditableConnectionTags } from './EditableConnectionTags';
+import { ReconnectPanel } from './ReconnectPanel';
 
 export const AuthTab = () => {
     const env = useStore((state) => state.env);
@@ -19,13 +20,15 @@ export const AuthTab = () => {
     return (
         <ConnectionTabLayout connectionData={connectionData}>
             <div className="flex flex-col gap-8 w-full max-w-2xl">
+                <ReconnectPanel />
+
                 {errorLog && (
                     <Alert variant="error">
                         <Info />
                         <AlertDescription>
                             {credentials.type === 'BASIC' || credentials.type === 'API_KEY'
-                                ? 'There was an error while testing credentials validity.'
-                                : 'There was an error refreshing the credentials.'}
+                                ? "Nango couldn't automatically verify these credentials. Reconnect above to restore this connection."
+                                : "Nango couldn't automatically refresh these credentials. Reconnect above to restore this connection."}
                         </AlertDescription>
                         <AlertActions>
                             <AlertButtonLink

--- a/packages/webapp/src/pages/Connection/components/ReconnectPanel.tsx
+++ b/packages/webapp/src/pages/Connection/components/ReconnectPanel.tsx
@@ -77,26 +77,37 @@ export const ReconnectPanel = () => {
             return;
         }
 
+        hasConnected.current = undefined;
+
         const nango = new Nango({
             host: globalEnv.apiUrl,
             websocketsPath: environmentAndAccount.environment.websockets_path || ''
         });
 
-        connectUI.current = nango.openConnectUI({
+        // Captured locally (not just via the connectUI ref) so a stale callback from a
+        // prior click can't apply its session token to a newer popup instance.
+        const ui = nango.openConnectUI({
             baseURL: globalEnv.connectUrl,
             apiURL: globalEnv.apiUrl,
             onEvent,
             themeOverride: isDarkMode ? 'dark' : 'light'
         });
+        connectUI.current = ui;
 
         // Defer session creation so the popup can open and show a loading state immediately.
         setTimeout(async () => {
-            const res = await createReconnectSession();
-            if ('error' in res.json) {
+            try {
+                const res = await createReconnectSession();
+                if ('error' in res.json) {
+                    toast.toast({ title: 'Failed to start reconnect', variant: 'error' });
+                    ui.close();
+                    return;
+                }
+                ui.setSessionToken(res.json.data.token);
+            } catch {
                 toast.toast({ title: 'Failed to start reconnect', variant: 'error' });
-                return;
+                ui.close();
             }
-            connectUI.current!.setSessionToken(res.json.data.token);
         }, 0);
     };
 
@@ -123,6 +134,8 @@ export const ReconnectPanel = () => {
             } catch (_) {
                 toast.toast({ title: 'Failed to copy link', variant: 'error' });
             }
+        } catch (_) {
+            toast.toast({ title: 'Failed to create shareable link', variant: 'error' });
         } finally {
             setIsShareLinkLoading(false);
         }

--- a/packages/webapp/src/pages/Connection/components/ReconnectPanel.tsx
+++ b/packages/webapp/src/pages/Connection/components/ReconnectPanel.tsx
@@ -9,8 +9,8 @@ import { Button } from '@nangohq/design-system';
 import Nango from '@nangohq/frontend';
 
 import { PermissionGate } from '@/components/patterns/PermissionGate';
-import { Alert, AlertDescription } from '@/components/ui/Alert';
 import { InfoTooltip } from '@/components/ui/InfoTooltip';
+import { useConfirmDialog } from '@/hooks/useConfirmDialog';
 import { apiConnectSessionsReconnect } from '@/hooks/useConnect';
 import { clearConnectionsCache } from '@/hooks/useConnections';
 import { useEnvironment } from '@/hooks/useEnvironment';
@@ -41,6 +41,8 @@ export const ReconnectPanel = () => {
     const canReconnect = can(permissions.canWriteProdConnections) || !environmentAndAccount?.environment.is_production;
 
     const isDashboardOrigin = connection.tags.origin === 'nango_dashboard';
+
+    const { confirm, DialogComponent } = useConfirmDialog();
 
     const connectUI = useRef<ConnectUI>();
     const hasConnected = useRef<AuthResult | undefined>();
@@ -73,7 +75,7 @@ export const ReconnectPanel = () => {
         [toast, invalidateConnectionQueries]
     );
 
-    const onClickReconnect = () => {
+    const startReconnect = () => {
         if (!environmentAndAccount) {
             return;
         }
@@ -110,6 +112,23 @@ export const ReconnectPanel = () => {
                 ui.close();
             }
         }, 0);
+    };
+
+    const onClickReconnect = () => {
+        if (isDashboardOrigin) {
+            startReconnect();
+            return;
+        }
+
+        void confirm({
+            title: 'Reconnect this connection?',
+            description:
+                "This connection wasn't created from this dashboard. Reconnecting here will authenticate as whoever completes the popup in this browser, which may not be the original account. If someone else needs to reconnect, use Share reconnect link instead.",
+            confirmButtonText: 'Reconnect anyway',
+            confirmVariant: 'primary',
+            icon: <TriangleAlert />,
+            onConfirm: startReconnect
+        });
     };
 
     const onClickShareReconnectLink = async () => {
@@ -150,6 +169,7 @@ export const ReconnectPanel = () => {
 
     return (
         <div className="flex flex-col gap-3">
+            {DialogComponent}
             <div className="flex flex-row items-center gap-2">
                 <PermissionGate condition={canReconnect}>
                     {(allowed) => (
@@ -169,16 +189,6 @@ export const ReconnectPanel = () => {
                 </PermissionGate>
                 <InfoTooltip side="top">Anyone with this link can open Connect UI and finish reconnecting. The link expires in 30 minutes.</InfoTooltip>
             </div>
-
-            {!isDashboardOrigin && (
-                <Alert variant="warning">
-                    <TriangleAlert />
-                    <AlertDescription>
-                        This connection was not created from this dashboard. Reconnecting here will authenticate as whoever completes the popup in this browser,
-                        which may not be the original account. If someone else needs to reconnect, use the Share reconnect link option instead.
-                    </AlertDescription>
-                </Alert>
-            )}
         </div>
     );
 };

--- a/packages/webapp/src/pages/Connection/components/ReconnectPanel.tsx
+++ b/packages/webapp/src/pages/Connection/components/ReconnectPanel.tsx
@@ -1,5 +1,5 @@
 import { useQueryClient } from '@tanstack/react-query';
-import { Link2, Plug, TriangleAlert } from 'lucide-react';
+import { Link2, Plug } from 'lucide-react';
 import { useCallback, useRef, useState } from 'react';
 import { useUnmount } from 'react-use';
 import { useSWRConfig } from 'swr';
@@ -122,11 +122,15 @@ export const ReconnectPanel = () => {
 
         void confirm({
             title: 'Reconnect this connection?',
-            description:
-                "This connection wasn't created from this dashboard. Reconnecting here will authenticate as whoever completes the popup in this browser, which may not be the original account. If someone else needs to reconnect, use Share reconnect link instead.",
-            confirmButtonText: 'Reconnect anyway',
+            description: (
+                <div className="flex flex-col gap-2">
+                    <p>This connection was not created from this dashboard.</p>
+                    <p>Reconnecting here will authenticate as whoever completes the popup in this browser, which may not be the original account.</p>
+                    <p>If someone else needs to reconnect, use Share reconnect link instead.</p>
+                </div>
+            ),
+            confirmButtonText: 'Reconnect',
             confirmVariant: 'primary',
-            icon: <TriangleAlert />,
             onConfirm: startReconnect
         });
     };

--- a/packages/webapp/src/pages/Connection/components/ReconnectPanel.tsx
+++ b/packages/webapp/src/pages/Connection/components/ReconnectPanel.tsx
@@ -1,0 +1,169 @@
+import { useQueryClient } from '@tanstack/react-query';
+import { Link2, Plug, TriangleAlert } from 'lucide-react';
+import { useCallback, useRef, useState } from 'react';
+import { useUnmount } from 'react-use';
+import { useSWRConfig } from 'swr';
+
+import { permissions } from '@nangohq/authz';
+import { Button } from '@nangohq/design-system';
+import Nango from '@nangohq/frontend';
+
+import { PermissionGate } from '@/components/patterns/PermissionGate';
+import { Alert, AlertDescription } from '@/components/ui/Alert';
+import { apiConnectSessionsReconnect } from '@/hooks/useConnect';
+import { clearConnectionsCache } from '@/hooks/useConnections';
+import { useEnvironment } from '@/hooks/useEnvironment';
+import { usePermissions } from '@/hooks/usePermissions';
+import { useToast } from '@/hooks/useToast';
+import { darkModeSelector, useThemeStore } from '@/lib/theme';
+import { useConnectionContext } from '@/pages/Connection/Show';
+import { useStore } from '@/store';
+import { globalEnv } from '@/utils/env';
+import { formatDateToPreciseUSFormat } from '@/utils/utils';
+
+import type { AuthResult, ConnectUI, OnConnectEvent } from '@nangohq/frontend';
+
+export const ReconnectPanel = () => {
+    const env = useStore((state) => state.env);
+    const toast = useToast();
+    const queryClient = useQueryClient();
+    const { cache, mutate } = useSWRConfig();
+
+    const { connectionData, providerConfigKey } = useConnectionContext();
+    const { connection } = connectionData;
+
+    const { data } = useEnvironment(env);
+    const environmentAndAccount = data?.environmentAndAccount;
+    const isDarkMode = useThemeStore(darkModeSelector);
+
+    const { can } = usePermissions();
+    const canReconnect = can(permissions.canWriteProdConnections) || !environmentAndAccount?.environment.is_production;
+
+    const isDashboardOrigin = connection.tags.origin === 'nango_dashboard';
+
+    const connectUI = useRef<ConnectUI>();
+    const hasConnected = useRef<AuthResult | undefined>();
+    const [isShareLinkLoading, setIsShareLinkLoading] = useState(false);
+
+    const invalidateConnectionQueries = useCallback(() => {
+        void queryClient.invalidateQueries({ queryKey: ['connection', connection.connection_id, env, providerConfigKey] });
+        void queryClient.invalidateQueries({ queryKey: ['connections'] });
+        clearConnectionsCache(cache, mutate);
+    }, [queryClient, connection.connection_id, env, providerConfigKey, cache, mutate]);
+
+    const createReconnectSession = useCallback(async () => {
+        return await apiConnectSessionsReconnect(env, {
+            connection_id: connection.connection_id,
+            provider_config_key: providerConfigKey
+        });
+    }, [env, connection.connection_id, providerConfigKey]);
+
+    const onEvent: OnConnectEvent = useCallback(
+        (event) => {
+            if (event.type === 'close') {
+                if (hasConnected.current) {
+                    toast.toast({ title: 'Connection reauthenticated', variant: 'success' });
+                }
+            } else if (event.type === 'connect') {
+                hasConnected.current = event.payload;
+                invalidateConnectionQueries();
+            }
+        },
+        [toast, invalidateConnectionQueries]
+    );
+
+    const onClickReconnect = () => {
+        if (!environmentAndAccount) {
+            return;
+        }
+
+        const nango = new Nango({
+            host: globalEnv.apiUrl,
+            websocketsPath: environmentAndAccount.environment.websockets_path || ''
+        });
+
+        connectUI.current = nango.openConnectUI({
+            baseURL: globalEnv.connectUrl,
+            apiURL: globalEnv.apiUrl,
+            onEvent,
+            themeOverride: isDarkMode ? 'dark' : 'light'
+        });
+
+        // Defer session creation so the popup can open and show a loading state immediately.
+        setTimeout(async () => {
+            const res = await createReconnectSession();
+            if ('error' in res.json) {
+                toast.toast({ title: 'Failed to start reconnect', variant: 'error' });
+                return;
+            }
+            connectUI.current!.setSessionToken(res.json.data.token);
+        }, 0);
+    };
+
+    const onClickShareReconnectLink = async () => {
+        setIsShareLinkLoading(true);
+        try {
+            const res = await createReconnectSession();
+            if (!res.res.ok || 'error' in res.json) {
+                toast.toast({ title: 'Failed to create shareable link', variant: 'error' });
+                return;
+            }
+
+            const { connect_link: connectLink, expires_at: expiresAt } = res.json.data;
+            const shareUrl = new URL(connectLink);
+            shareUrl.searchParams.set('apiURL', globalEnv.apiUrl);
+
+            try {
+                await navigator.clipboard.writeText(shareUrl.toString());
+                toast.toast({
+                    title: 'Shareable link copied',
+                    description: `Session expires in 30 mins (${formatDateToPreciseUSFormat(expiresAt)})`,
+                    variant: 'success'
+                });
+            } catch (_) {
+                toast.toast({ title: 'Failed to copy link', variant: 'error' });
+            }
+        } finally {
+            setIsShareLinkLoading(false);
+        }
+    };
+
+    useUnmount(() => {
+        if (connectUI.current) {
+            connectUI.current.close();
+        }
+    });
+
+    return (
+        <div className="flex flex-col gap-3">
+            <div className="flex flex-row items-center gap-2">
+                <PermissionGate condition={canReconnect}>
+                    {(allowed) => (
+                        <Button variant="outline" size="md" onClick={onClickReconnect} disabled={!allowed}>
+                            <Plug />
+                            Reconnect
+                        </Button>
+                    )}
+                </PermissionGate>
+                <PermissionGate condition={canReconnect}>
+                    {(allowed) => (
+                        <Button variant="ghost" size="md" onClick={onClickShareReconnectLink} loading={isShareLinkLoading} disabled={!allowed}>
+                            <Link2 />
+                            Share reconnect link
+                        </Button>
+                    )}
+                </PermissionGate>
+            </div>
+
+            {!isDashboardOrigin && (
+                <Alert variant="warning">
+                    <TriangleAlert />
+                    <AlertDescription>
+                        This connection was not created from this dashboard. Reconnecting here will authenticate as whoever completes the popup in this browser,
+                        which may not be the original account. If someone else needs to reconnect, use the Share reconnect link option instead.
+                    </AlertDescription>
+                </Alert>
+            )}
+        </div>
+    );
+};

--- a/packages/webapp/src/pages/Connection/components/ReconnectPanel.tsx
+++ b/packages/webapp/src/pages/Connection/components/ReconnectPanel.tsx
@@ -10,6 +10,7 @@ import Nango from '@nangohq/frontend';
 
 import { PermissionGate } from '@/components/patterns/PermissionGate';
 import { Alert, AlertDescription } from '@/components/ui/Alert';
+import { InfoTooltip } from '@/components/ui/InfoTooltip';
 import { apiConnectSessionsReconnect } from '@/hooks/useConnect';
 import { clearConnectionsCache } from '@/hooks/useConnections';
 import { useEnvironment } from '@/hooks/useEnvironment';
@@ -166,6 +167,7 @@ export const ReconnectPanel = () => {
                         </Button>
                     )}
                 </PermissionGate>
+                <InfoTooltip side="top">Anyone with this link can open Connect UI and finish reconnecting. The link expires in 30 minutes.</InfoTooltip>
             </div>
 
             {!isDashboardOrigin && (


### PR DESCRIPTION
## Problem

OAuth (and other) connections can lose valid credentials, and the dashboard has no way to fix this short of deleting and recreating the connection. The existing "Refresh" button only replays the stored refresh_token server-side — once that's dead (or for auth types with no refresh mechanism at all), there's no recovery path.

## Solution

- Add a dashboard-authenticated `POST /api/v1/connect/sessions/reconnect` endpoint that creates a Connect session scoped to an existing connection (mirroring the public `/connect/sessions/reconnect` endpoint), so completing the auth flow overwrites credentials in place instead of creating a new connection
- Add a "Reconnect" + "Share reconnect link" panel to the connection's Auth tab, always visible
- Show an inline warning when a connection wasn't created from this dashboard (no `origin: nango_dashboard` tag), since completing the popup authenticates as whoever is in the browser, not necessarily the original account — both actions stay enabled either way
- Reword the existing auth-error banner to point at Reconnect, since by the time it's shown an automatic refresh has already failed

Fixes [NAN-4537](https://linear.app/nango/issue/NAN-4537)

## Testing

Verified locally end-to-end: Reconnect opens the Connect UI popup scoped to the right integration, Share reconnect link copies a working link, the origin-tag warning correctly shows/hides, and the error banner + existing "Expired credentials" list badge render together. Confirmed in the DB that reconnecting preserves the connection's existing tags rather than overwriting them.
