### PR TITLE
fix(server): short circuit token refresh when refresh_exhausted is true

### DIFF
--- a/packages/shared/lib/services/connections/credentials/refresh.integration.test.ts
+++ b/packages/shared/lib/services/connections/credentials/refresh.integration.test.ts
@@ -336,6 +336,43 @@ describe('refreshOrTestCredentials', () => {
         expect(onTest).not.toHaveBeenCalled();
     });
 
+    it('should return early with connection_refresh_exhausted even when instantRefresh (force_refresh) is true', async () => {
+        const { env, account } = await seedAccountEnvAndUser();
+        const integration = await createConfigSeed(env, 'algolia', 'algolia');
+        const connection = await createConnectionSeed({ env, provider: 'algolia', rawCredentials: { type: 'API_KEY', apiKey: 'foobar' } });
+        const decryptedConnection = encryptionManager.decryptConnection(connection);
+        if (!decryptedConnection) {
+            throw new Error('Failed to decrypt connection');
+        }
+
+        const exhaustedConnection = await connectionService.updateConnection({ ...decryptedConnection, refresh_exhausted: true });
+
+        await wait(2);
+        const onFailed = vi.fn();
+        const onSuccess = vi.fn();
+        const onTest = vi.fn();
+        const res = await refreshOrTestCredentials({
+            account,
+            environment: env,
+            integration,
+            instantRefresh: true,
+            connection: exhaustedConnection,
+            onRefreshFailed: onFailed,
+            onRefreshSuccess: onSuccess,
+            connectionTestHook: onTest,
+            logContextGetter: logContextGetter
+        });
+
+        expect(res.isErr()).toBe(true);
+        if (res.isErr()) {
+            expect(res.error.type).toBe('connection_refresh_exhausted');
+        }
+
+        expect(onFailed).not.toHaveBeenCalled();
+        expect(onSuccess).not.toHaveBeenCalled();
+        expect(onTest).not.toHaveBeenCalled();
+    });
+
     it('should return early if refresh failed within the cooldown window (non-instant refresh)', async () => {
         const { env, account } = await seedAccountEnvAndUser();
         const integration = await createConfigSeed(env, 'algolia', 'algolia');

--- a/packages/shared/lib/services/connections/credentials/refresh.ts
+++ b/packages/shared/lib/services/connections/credentials/refresh.ts
@@ -90,11 +90,12 @@ export async function refreshOrTestCredentials(props: RefreshProps): Promise<Res
         props.connection = { ...props.connection, last_fetched_at: new Date() };
 
         // short-circuit if we know the refresh will fail
-        if (!props.instantRefresh) {
-            if (props.connection.refresh_exhausted) {
-                return Err(new NangoError('connection_refresh_exhausted'));
-            }
+        // this applies even to instantRefresh (force_refresh): once exhausted, only a reconnect can clear it
+        if (props.connection.refresh_exhausted) {
+            return Err(new NangoError('connection_refresh_exhausted'));
+        }
 
+        if (!props.instantRefresh) {
             // Fail early if the last refresh attempt failed within the cooldown window.
             // Manual refreshes (instantRefresh=true) always bypass this check.
             if (props.connection.last_refresh_failure && Date.now() - props.connection.last_refresh_failure.getTime() < REFRESH_FAILURE_COOLDOWN_MS) {


### PR DESCRIPTION
## Describe the problem and your solution

-  short circuit token refresh when refresh_exhausted is true

<!-- Issue ticket number and link (if applicable) -->

<!-- Testing instructions (skip if just adding/editing providers) -->



<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/NangoHQ/nango/pull/6850?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

