### PR TITLE
chore(jobs): log underlying cause of 'runner unable to execute' error

### DIFF
--- a/packages/jobs/lib/runtime/runner.adapter.ts
+++ b/packages/jobs/lib/runtime/runner.adapter.ts
@@ -42,7 +42,6 @@ export class RunnerRuntimeAdapter implements RuntimeAdapter {
 
             return Ok(res);
         } catch (err) {
-            // Surface the cause internally: the wrapper below carries it only as `cause`, which nothing downstream logs.
             logger.error('Nango runner was unable to execute the function', {
                 error: err,
                 taskId: params.taskId,

--- a/packages/jobs/lib/runtime/runner.adapter.ts
+++ b/packages/jobs/lib/runtime/runner.adapter.ts
@@ -1,10 +1,12 @@
-import { Err, Ok } from '@nangohq/utils';
+import { Err, getLogger, Ok } from '@nangohq/utils';
 
 import { getRunner, getRunners } from '../runner/runner.js';
 
 import type { RuntimeAdapter } from './adapter.js';
 import type { NangoProps } from '@nangohq/types';
 import type { Result } from '@nangohq/utils';
+
+const logger = getLogger('RunnerRuntimeAdapter');
 
 export class RunnerRuntimeAdapter implements RuntimeAdapter {
     async cancel(params: { taskId: string; nangoProps: NangoProps }): Promise<Result<boolean>> {
@@ -40,6 +42,14 @@ export class RunnerRuntimeAdapter implements RuntimeAdapter {
 
             return Ok(res);
         } catch (err) {
+            // Surface the cause internally: the wrapper below carries it only as `cause`, which nothing downstream logs.
+            logger.error('Nango runner was unable to execute the function', {
+                error: err,
+                taskId: params.taskId,
+                teamId: params.nangoProps.team.id,
+                runnerId: runner.value.id,
+                runnerUrl: runner.value.url
+            });
             return Err(new Error(`Nango runner was unable to execute the function`, { cause: err }));
         }
     }

--- a/packages/jobs/lib/runtime/runner.adapter.ts
+++ b/packages/jobs/lib/runtime/runner.adapter.ts
@@ -45,8 +45,6 @@ export class RunnerRuntimeAdapter implements RuntimeAdapter {
             logger.error('Nango runner was unable to execute the function', {
                 error: err,
                 taskId: params.taskId,
-                teamId: params.nangoProps.team.id,
-                runnerId: runner.value.id,
                 runnerUrl: runner.value.url
             });
             return Err(new Error(`Nango runner was unable to execute the function`, { cause: err }));


### PR DESCRIPTION
## Summary
- During INC-124 we couldn't tell *why* the runner failed to start functions. The jobs service wraps a failed runner `start` RPC as `Nango runner was unable to execute the function` and attaches the real error only as `cause`, which nothing downstream logs — so the reason (timeout, connection refused, runner rejecting at capacity, …) was lost. This adds an internal `logger.error` in `RunnerRuntimeAdapter.invoke` that logs the error (the error logger serializes the `cause` chain) plus `taskId`, `teamId`, `runnerId`, and `runnerUrl`.
- The customer-facing operation log (`logCtx`) and task output are intentionally left unchanged, so runner internals aren't exposed to the customer — the cause is captured internally (Datadog) only.

## Test plan
- [x] `oxlint` clean on the changed file
- [x] `prettier --check` clean
- [ ] After deploy: confirm a `RunnerRuntimeAdapter` error log appears in Datadog with the serialized `cause` + `taskId`/`teamId`/`runnerId`/`runnerUrl` when a runner `start` RPC fails

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/NangoHQ/nango/pull/6851?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

