### PR TITLE
fix(billing): log Orb ingest failure cause

### DIFF
--- a/packages/billing/lib/billing.ts
+++ b/packages/billing/lib/billing.ts
@@ -29,7 +29,7 @@ export class Billing {
                   process: async (events) => {
                       const res = await this.ingest(events);
                       if (res.isErr()) {
-                          logger.error(res.error.message);
+                          logger.error(res.error.message, res.error);
                           throw res.error;
                       }
                   },


### PR DESCRIPTION
## Summary
- Include the full error object when Orb event ingest fails so logs capture the underlying cause, not only `failed_to_ingest_events`
