### PR TITLE
fix(webhooks): skip HubSpot import events before dispatch

### DIFF
--- a/packages/server/lib/webhook/hubspot-webhook-routing.ts
+++ b/packages/server/lib/webhook/hubspot-webhook-routing.ts
@@ -1,12 +1,17 @@
 import crypto from 'node:crypto';
 
 import { NangoError } from '@nangohq/shared';
-import { Err, getLogger, Ok } from '@nangohq/utils';
+import { Err, getLogger, metrics, Ok } from '@nangohq/utils';
 
 import type { HubSpotWebhook, WebhookHandler } from './types.js';
 import type { IntegrationConfig } from '@nangohq/types';
 
 const logger = getLogger('Webhook.Hubspot');
+
+// Skip import events as they have the potential to overwhelm dispatch
+function isImportEvent(event: HubSpotWebhook): boolean {
+    return event.changeSource === 'IMPORT';
+}
 
 export function validate(integration: IntegrationConfig, headers: Record<string, any>, body: any): boolean {
     const signature = headers['x-hubspot-signature'];
@@ -30,7 +35,17 @@ const route: WebhookHandler<HubSpotWebhook | HubSpotWebhook[]> = async (nango, h
     }
 
     if (Array.isArray(body)) {
-        const groupedByObjectId = body.reduce<Record<string, HubSpotWebhook[]>>((acc, event) => {
+        const nonImportEvents = body.filter((event) => !isImportEvent(event));
+        const skipped = body.length - nonImportEvents.length;
+        if (skipped > 0) {
+            metrics.increment(metrics.Types.WEBHOOK_INCOMING_SKIPPED, skipped, {
+                provider: nango.integration.provider,
+                reason: 'hubspot_import',
+                environmentId: nango.environment.id
+            });
+        }
+
+        const groupedByObjectId = nonImportEvents.reduce<Record<string, HubSpotWebhook[]>>((acc, event) => {
             (acc[event.objectId] = acc[event.objectId] || []).push(event);
             return acc;
         }, {});
@@ -63,6 +78,15 @@ const route: WebhookHandler<HubSpotWebhook | HubSpotWebhook[]> = async (nango, h
         const uniqueConnectionIds = Array.from(new Set(connectionIds));
         return Ok({ content: { status: 'success' }, statusCode: 200, connectionIds: uniqueConnectionIds, toForward: body });
     } else {
+        if (isImportEvent(body)) {
+            metrics.increment(metrics.Types.WEBHOOK_INCOMING_SKIPPED, 1, {
+                provider: nango.integration.provider,
+                reason: 'hubspot_import',
+                environmentId: nango.environment.id
+            });
+            return Ok({ content: { status: 'success' }, statusCode: 200, connectionIds: [], toForward: body });
+        }
+
         const response = await nango.executeScriptForWebhooks({
             body,
             webhookType: 'subscriptionType',

--- a/packages/server/lib/webhook/hubspot-webhook-routing.unit.test.ts
+++ b/packages/server/lib/webhook/hubspot-webhook-routing.unit.test.ts
@@ -192,4 +192,85 @@ describe('Webhook route unit tests', () => {
             webhookType: 'subscriptionType'
         });
     });
+
+    it('Should skip events triggered by an import', async () => {
+        const integration = getTestConfig({ provider: 'hubspot', oauth_client_secret: 'abcdef' });
+
+        const mock = vi.fn();
+        const nangoMock = new InternalNango({
+            team: seeders.getTestTeam(),
+            environment: seeders.getTestEnvironment(),
+            plan: seeders.getTestPlan(),
+            integration,
+            logContextGetter
+        });
+        nangoMock.executeScriptForWebhooks = mock;
+
+        const body: HubSpotWebhook[] = [
+            {
+                eventId: 1,
+                subscriptionId: 2426762,
+                portalId: 143553137,
+                occurredAt: 1705422467780,
+                subscriptionType: 'contact.creation',
+                attemptNumber: 0,
+                objectId: 1801,
+                changeSource: 'CRM_UI'
+            },
+            {
+                eventId: 2,
+                subscriptionId: 2426762,
+                portalId: 143553137,
+                occurredAt: 1705422467780,
+                subscriptionType: 'contact.creation',
+                attemptNumber: 0,
+                objectId: 1802,
+                changeSource: 'IMPORT'
+            }
+        ];
+        const combinedSignature = `${integration.oauth_client_secret}${JSON.stringify(body)}`;
+        const createdHash = crypto.createHash('sha256').update(combinedSignature).digest('hex');
+        const headers = { 'x-hubspot-signature': createdHash };
+
+        await HubspotWebhookRouting.default(nangoMock as unknown as InternalNango, headers, body, '');
+
+        expect(mock).toHaveBeenCalledTimes(1);
+        expect(mock).toHaveBeenCalledWith({
+            body: body[0],
+            connectionIdentifier: 'portalId',
+            webhookType: 'subscriptionType'
+        });
+    });
+
+    it('Should skip a single import event', async () => {
+        const integration = getTestConfig({ provider: 'hubspot', oauth_client_secret: 'abcdef' });
+
+        const mock = vi.fn();
+        const nangoMock = new InternalNango({
+            team: seeders.getTestTeam(),
+            environment: seeders.getTestEnvironment(),
+            plan: seeders.getTestPlan(),
+            integration,
+            logContextGetter
+        });
+        nangoMock.executeScriptForWebhooks = mock;
+
+        const body: HubSpotWebhook = {
+            eventId: 1,
+            subscriptionId: 2426762,
+            portalId: 143553137,
+            occurredAt: 1705422467780,
+            subscriptionType: 'contact.creation',
+            attemptNumber: 0,
+            objectId: 1801,
+            changeSource: 'IMPORT'
+        };
+        const combinedSignature = `${integration.oauth_client_secret}${JSON.stringify(body)}`;
+        const createdHash = crypto.createHash('sha256').update(combinedSignature).digest('hex');
+        const headers = { 'x-hubspot-signature': createdHash };
+
+        await HubspotWebhookRouting.default(nangoMock as unknown as InternalNango, headers, body, '');
+
+        expect(mock).not.toHaveBeenCalled();
+    });
 });

--- a/packages/server/lib/webhook/internal-nango.ts
+++ b/packages/server/lib/webhook/internal-nango.ts
@@ -25,7 +25,7 @@ import type {
     WebhookDispatchMessage
 } from '@nangohq/types';
 
-const LARGE_FANOUT_THRESHOLD = 200;
+const LARGE_FANOUT_THRESHOLD = 10;
 const LOG_CONTEXT_CREATE_CONCURRENCY = 25;
 
 interface MatchedExecution {

--- a/packages/utils/lib/telemetry/metrics.ts
+++ b/packages/utils/lib/telemetry/metrics.ts
@@ -60,6 +60,7 @@ export enum Types {
 
     WEBHOOK_INCOMING_RECEIVED = 'nango.webhook.incoming.received',
     WEBHOOK_INCOMING_RATE_LIMITED = 'nango.webhook.incoming.rateLimited',
+    WEBHOOK_INCOMING_SKIPPED = 'nango.webhook.incoming.skipped',
     WEBHOOK_INCOMING_FORWARDED_SUCCESS = 'nango.webhook.incoming.forwarded.success',
     WEBHOOK_INCOMING_FORWARDED_FAILED = 'nango.webhook.incoming.forwarded.failed',
     WEBHOOK_OUTGOING_SUCCESS = 'nango.webhook.outgoing.success',


### PR DESCRIPTION
## What

Drop HubSpot webhook events triggered by an import (`changeSource === 'IMPORT'`) in the routing layer, before they reach dispatch.

A customer is continuously re-importing all their contacts. HubSpot fans out one webhook per record, which floods our dispatch/execution path and pressures our infra. Records changed by an import are still picked up by the periodic sync reading the webhook journal, so dropping the triggers here costs latency, not data.

## Changes

- `hubspot-webhook-routing.ts`: skip import events in both the array and single-event paths, before `executeScriptForWebhooks`.
- New `WEBHOOK_INCOMING_SKIPPED` metric (tagged `provider`, `reason=hubspot_import`, plus env) so we can see how much load this sheds.
- Lower `LARGE_FANOUT_THRESHOLD` from 200 to 10 to surface fanout earlier while we diagnose.
- Unit tests for mixed and single import payloads.

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/NangoHQ/nango/pull/6857?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

