### PR TITLE
feat(auth): shadow cache to measure auth cache hit ratio

### DIFF
--- a/packages/shared/lib/services/account.service.integration.test.ts
+++ b/packages/shared/lib/services/account.service.integration.test.ts
@@ -2,6 +2,7 @@ import { v4 as uuid } from 'uuid';
 import { afterEach, beforeAll, describe, expect, it, vi } from 'vitest';
 
 import db, { multipleMigrations } from '@nangohq/database';
+import { metrics } from '@nangohq/utils';
 
 import { createAccount as createTestAccount } from '../seeders/account.seeder.js';
 import { seedAccountEnvAndUser } from '../seeders/global.seeder.js';
@@ -372,6 +373,25 @@ describe('Account service', () => {
                 // eslint-disable-next-line @typescript-eslint/no-dynamic-delete
                 delete process.env[envVarName];
             }
+        });
+
+        it('should record a shadow-cache miss then hit without ever serving from the shadow cache', async () => {
+            const { env, secret } = await seedAccountEnvAndUser();
+            const incrementSpy = vi.spyOn(metrics, 'increment');
+
+            // First lookup: nothing seen yet -> miss
+            const first = (await accountService.getPersistAuthContext(secret.secret)).unwrap();
+            expect(first?.environment.id).toBe(env.id);
+            expect(incrementSpy).toHaveBeenCalledWith(metrics.Types.AUTH_SHADOW_CACHE, 1, { cache: 'persist_internal_secret', result: 'miss' });
+
+            // Break the DB row: a real cache would still serve the stale context, the shadow must not
+            await db.knex('api_secrets').where({ environment_id: env.id }).update({ hashed: uuid() });
+            incrementSpy.mockClear();
+
+            // Second lookup within the TTL: recorded as a hit, but the value comes from the DB (now broken) -> null
+            const second = (await accountService.getPersistAuthContext(secret.secret)).unwrap();
+            expect(incrementSpy).toHaveBeenCalledWith(metrics.Types.AUTH_SHADOW_CACHE, 1, { cache: 'persist_internal_secret', result: 'hit' });
+            expect(second).toBeNull();
         });
     });
 

--- a/packages/shared/lib/services/account.service.ts
+++ b/packages/shared/lib/services/account.service.ts
@@ -1,6 +1,7 @@
 import db from '@nangohq/database';
 import { Err, FixedSizeMap, flagHasPlan, getLogger, isCloud, metrics, Ok, report } from '@nangohq/utils';
 
+import { envs } from '../env.js';
 import { LogActionEnum } from '../models/Telemetry.js';
 import { getEncryptionManager } from '../utils/encryption.manager.js';
 import errorManager, { ErrorSourceEnum } from '../utils/error.manager.js';
@@ -22,6 +23,48 @@ import type { DBAPISecret, DBEnvironment, DBPlan, DBTeam, PersistAuthContext, Re
 
 const hashLocalCache = new FixedSizeMap<string, string>(10_000);
 const logger = getLogger('AccountService');
+
+/**
+ * Measurement-only auth cache: emits a hit/miss metric to estimate the hit ratio
+ * a real per-process cache would achieve. Serves nothing and stores nothing derived
+ * from the auth context — the value is only a TTL timestamp.
+ */
+class ShadowAuthCache {
+    private seenAtNs = new FixedSizeMap<string, bigint>(10_000);
+    private readonly ttlNs: bigint;
+
+    constructor(
+        private readonly name: string,
+        ttlMs: number
+    ) {
+        this.ttlNs = BigInt(ttlMs) * 1_000_000n;
+    }
+
+    /** Emits hit/miss for this hash, evicting the entry when its TTL has passed. */
+    wouldHit(hash: string): boolean {
+        const seenAt = this.seenAtNs.get(hash);
+        let hit = false;
+        if (seenAt !== undefined) {
+            if (process.hrtime.bigint() - seenAt < this.ttlNs) {
+                hit = true;
+            } else {
+                this.seenAtNs.delete(hash);
+            }
+        }
+        metrics.increment(metrics.Types.AUTH_SHADOW_CACHE, 1, { cache: this.name, result: hit ? 'hit' : 'miss' });
+        return hit;
+    }
+
+    /** Marks a successful lookup as would-be-cached. Skips fresh entries so their TTL is not extended. */
+    populate(hash: string, wasHit: boolean): void {
+        if (!wasHit) {
+            this.seenAtNs.set(hash, process.hrtime.bigint());
+        }
+    }
+}
+
+const persistAuthShadowCache = new ShadowAuthCache('persist_internal_secret', envs.AUTH_SHADOW_CACHE_TTL_MS);
+const customerKeyShadowCache = new ShadowAuthCache('customer_key', envs.AUTH_SHADOW_CACHE_TTL_MS);
 
 interface AccountContext {
     account: DBTeam;
@@ -553,6 +596,7 @@ class AccountService {
 
     private async getAccountContextByCustomerKey(secretKey: string): Promise<AccountContext | null> {
         const hash = await this.hashSecretWithCache(secretKey);
+        const wouldHit = customerKeyShadowCache.wouldHit(hash);
 
         // This query debounces last_used_at in the same statement, so it must run on the primary.
         // If we later introduce real read replicas for auth lookups, split this into:
@@ -619,6 +663,7 @@ class AccountService {
         }
 
         hashLocalCache.set(secretKey, hash);
+        customerKeyShadowCache.populate(hash, wouldHit);
 
         const defaultSecret = getEncryptionManager().decryptAPISecret(row.default_secret);
         const pendingKey = row.pending_secret ? getEncryptionManager().decryptAPISecret(row.pending_secret) : null;
@@ -696,6 +741,7 @@ class AccountService {
         }
 
         const hash = await this.hashSecretWithCache(secretKey);
+        const wouldHit = persistAuthShadowCache.wouldHit(hash);
 
         const row = await db.readOnly
             .select<{
@@ -728,6 +774,7 @@ class AccountService {
 
         // Store only successful lookups to avoid polluting the cache
         hashLocalCache.set(secretKey, hash);
+        persistAuthShadowCache.populate(hash, wouldHit);
         return {
             account: { id: row.account_id },
             environment: { id: row.environment_id, name: row.environment_name },

--- a/packages/utils/lib/environment/parse.ts
+++ b/packages/utils/lib/environment/parse.ts
@@ -21,6 +21,7 @@ export const ENVS = z.object({
     LOCAL_NANGO_USER_ID: z.coerce.number().optional(),
     AUTH_ALLOW_SIGNUP: z.stringbool().optional().default(true),
     DEFAULT_USER_ROLE: z.enum(roles).optional().default('administrator'),
+    AUTH_SHADOW_CACHE_TTL_MS: z.coerce.number().int().positive().optional().default(60_000), // 1 minute
 
     // API
     NANGO_PORT: z.coerce.number().optional().default(3003), // Sync those two ports?

--- a/packages/utils/lib/telemetry/metrics.ts
+++ b/packages/utils/lib/telemetry/metrics.ts
@@ -6,6 +6,7 @@ export enum Types {
     ACTION_INCOMING_PAYLOAD_SIZE_BYTES = 'nango.action.incoming.payloadSizeBytes',
 
     AUTH_SECRET_KEY_HASH_CACHE = 'nango.auth.secretKeyHashCache',
+    AUTH_SHADOW_CACHE = 'nango.auth.shadowCache',
     AUTH_GET_ENV_BY_CONNECT_SESSION = 'nango.auth.getEnvByConnectSession',
     AUTH_GET_ENV_BY_SECRET_KEY = 'nango.auth.getEnvBySecretKey',
     AUTH_GET_ENV_BY_SECRET_KEY_SOURCE = 'nango.auth.getEnvBySecretKey.source',


### PR DESCRIPTION
- Adds a measurement-only "shadow" cache to the two internal auth lookups — persist internal-secret (`getPersistAuthContext`) and the server's customer-key path (`getAccountContextByCustomerKey`). It emits `nango.auth.shadowCache{cache, result}` modelling what a real per-process auth cache would do, **but serves nothing and stores nothing derived from the auth context** — the map value is only a monotonic TTL timestamp.
- Purpose: quantify the DB-query reduction a real cache would deliver, per path, using the hit ratio as a proxy — before committing to a real cache, and with zero security or staleness risk to weigh. TTL configurable via `AUTH_SHADOW_CACHE_TTL_MS` (default 60s).

## Why this carries no risk

- **Security**: strictly less sensitive than the existing `hashLocalCache`, which already holds raw secret keys as map keys. The shadow holds only SHA hashes plus timestamps, bounded to 10k entries per path per pod.
- **Staleness/revocation**: it never serves, so there is nothing to go stale. The lookup remains the sole source of truth. The integration test encodes this: it breaks the DB row between two calls — a real cache would serve the stale context, but the shadow records a `hit` while the actual return is `null`.

It models a real cache faithfully so the ratio is trustworthy: keys are recorded only on successful lookups, a fresh entry's TTL is never extended on a hit (so hot keys still expire and the ratio isn't inflated), and expired entries are evicted on read.

## Reading the result

Once deployed, `sum:nango.auth.shadowCache{result:hit} by {cache} / sum:nango.auth.shadowCache{} by {cache}` gives the hit ratio per path. That ratio is the fraction of auth DB lookups a real cache at this TTL would eliminate.

## Test plan

- [x] Integration test: first call records a miss, second within TTL records a hit, and returns null after the DB row is broken (proving nothing is served)
- [x] Verified the test goes red if the shadow populate logic is broken
- [x] Build + full account-service integration suite green; lint/prettier clean
- [ ] After deploy: read the per-`cache` hit ratio over a representative window to size the real cache decision

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/NangoHQ/nango/pull/6858?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

