### PR TITLE
chore(utils): Remove Sentry integration from Node services

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -5819,28 +5819,6 @@
                 "node": ">=8.0.0"
             }
         },
-        "node_modules/@opentelemetry/api-logs": {
-            "version": "0.57.2",
-            "resolved": "https://registry.npmjs.org/@opentelemetry/api-logs/-/api-logs-0.57.2.tgz",
-            "integrity": "sha512-uIX52NnTM0iBh84MShlpouI7UKqkZ7MrUszTmaypHBu4r7NofznSnQRfJ+uUeDtQDj6w8eFGg5KBLDAwAPz1+A==",
-            "dependencies": {
-                "@opentelemetry/api": "^1.3.0"
-            },
-            "engines": {
-                "node": ">=14"
-            }
-        },
-        "node_modules/@opentelemetry/context-async-hooks": {
-            "version": "1.30.1",
-            "resolved": "https://registry.npmjs.org/@opentelemetry/context-async-hooks/-/context-async-hooks-1.30.1.tgz",
-            "integrity": "sha512-s5vvxXPVdjqS3kTLKMeBMvop9hbWkwzBpu+mUO2M7sZtlkyDJGwFe33wRKnbaYDo8ExRVBIIdwIGrqpxHuKttA==",
-            "engines": {
-                "node": ">=14"
-            },
-            "peerDependencies": {
-                "@opentelemetry/api": ">=1.0.0 <1.10.0"
-            }
-        },
         "node_modules/@opentelemetry/core": {
             "version": "1.30.1",
             "resolved": "https://registry.npmjs.org/@opentelemetry/core/-/core-1.30.1.tgz",
@@ -5928,394 +5906,6 @@
             },
             "peerDependencies": {
                 "@opentelemetry/api": ">=1.0.0 <1.10.0"
-            }
-        },
-        "node_modules/@opentelemetry/instrumentation": {
-            "version": "0.57.2",
-            "resolved": "https://registry.npmjs.org/@opentelemetry/instrumentation/-/instrumentation-0.57.2.tgz",
-            "integrity": "sha512-BdBGhQBh8IjZ2oIIX6F2/Q3LKm/FDDKi6ccYKcBTeilh6SNdNKveDOLk73BkSJjQLJk6qe4Yh+hHw1UPhCDdrg==",
-            "dependencies": {
-                "@opentelemetry/api-logs": "0.57.2",
-                "@types/shimmer": "^1.2.0",
-                "import-in-the-middle": "^1.8.1",
-                "require-in-the-middle": "^7.1.1",
-                "semver": "^7.5.2",
-                "shimmer": "^1.2.1"
-            },
-            "engines": {
-                "node": ">=14"
-            },
-            "peerDependencies": {
-                "@opentelemetry/api": "^1.3.0"
-            }
-        },
-        "node_modules/@opentelemetry/instrumentation-amqplib": {
-            "version": "0.46.1",
-            "resolved": "https://registry.npmjs.org/@opentelemetry/instrumentation-amqplib/-/instrumentation-amqplib-0.46.1.tgz",
-            "integrity": "sha512-AyXVnlCf/xV3K/rNumzKxZqsULyITJH6OVLiW6730JPRqWA7Zc9bvYoVNpN6iOpTU8CasH34SU/ksVJmObFibQ==",
-            "dependencies": {
-                "@opentelemetry/core": "^1.8.0",
-                "@opentelemetry/instrumentation": "^0.57.1",
-                "@opentelemetry/semantic-conventions": "^1.27.0"
-            },
-            "engines": {
-                "node": ">=14"
-            },
-            "peerDependencies": {
-                "@opentelemetry/api": "^1.3.0"
-            }
-        },
-        "node_modules/@opentelemetry/instrumentation-connect": {
-            "version": "0.43.1",
-            "resolved": "https://registry.npmjs.org/@opentelemetry/instrumentation-connect/-/instrumentation-connect-0.43.1.tgz",
-            "integrity": "sha512-ht7YGWQuV5BopMcw5Q2hXn3I8eG8TH0J/kc/GMcW4CuNTgiP6wCu44BOnucJWL3CmFWaRHI//vWyAhaC8BwePw==",
-            "dependencies": {
-                "@opentelemetry/core": "^1.8.0",
-                "@opentelemetry/instrumentation": "^0.57.1",
-                "@opentelemetry/semantic-conventions": "^1.27.0",
-                "@types/connect": "3.4.38"
-            },
-            "engines": {
-                "node": ">=14"
-            },
-            "peerDependencies": {
-                "@opentelemetry/api": "^1.3.0"
-            }
-        },
-        "node_modules/@opentelemetry/instrumentation-dataloader": {
-            "version": "0.16.1",
-            "resolved": "https://registry.npmjs.org/@opentelemetry/instrumentation-dataloader/-/instrumentation-dataloader-0.16.1.tgz",
-            "integrity": "sha512-K/qU4CjnzOpNkkKO4DfCLSQshejRNAJtd4esgigo/50nxCB6XCyi1dhAblUHM9jG5dRm8eu0FB+t87nIo99LYQ==",
-            "dependencies": {
-                "@opentelemetry/instrumentation": "^0.57.1"
-            },
-            "engines": {
-                "node": ">=14"
-            },
-            "peerDependencies": {
-                "@opentelemetry/api": "^1.3.0"
-            }
-        },
-        "node_modules/@opentelemetry/instrumentation-express": {
-            "version": "0.47.1",
-            "resolved": "https://registry.npmjs.org/@opentelemetry/instrumentation-express/-/instrumentation-express-0.47.1.tgz",
-            "integrity": "sha512-QNXPTWteDclR2B4pDFpz0TNghgB33UMjUt14B+BZPmtH1MwUFAfLHBaP5If0Z5NZC+jaH8oF2glgYjrmhZWmSw==",
-            "dependencies": {
-                "@opentelemetry/core": "^1.8.0",
-                "@opentelemetry/instrumentation": "^0.57.1",
-                "@opentelemetry/semantic-conventions": "^1.27.0"
-            },
-            "engines": {
-                "node": ">=14"
-            },
-            "peerDependencies": {
-                "@opentelemetry/api": "^1.3.0"
-            }
-        },
-        "node_modules/@opentelemetry/instrumentation-fastify": {
-            "version": "0.44.2",
-            "resolved": "https://registry.npmjs.org/@opentelemetry/instrumentation-fastify/-/instrumentation-fastify-0.44.2.tgz",
-            "integrity": "sha512-arSp97Y4D2NWogoXRb8CzFK3W2ooVdvqRRtQDljFt9uC3zI6OuShgey6CVFC0JxT1iGjkAr1r4PDz23mWrFULQ==",
-            "dependencies": {
-                "@opentelemetry/core": "^1.8.0",
-                "@opentelemetry/instrumentation": "^0.57.1",
-                "@opentelemetry/semantic-conventions": "^1.27.0"
-            },
-            "engines": {
-                "node": ">=14"
-            },
-            "peerDependencies": {
-                "@opentelemetry/api": "^1.3.0"
-            }
-        },
-        "node_modules/@opentelemetry/instrumentation-fs": {
-            "version": "0.19.1",
-            "resolved": "https://registry.npmjs.org/@opentelemetry/instrumentation-fs/-/instrumentation-fs-0.19.1.tgz",
-            "integrity": "sha512-6g0FhB3B9UobAR60BGTcXg4IHZ6aaYJzp0Ki5FhnxyAPt8Ns+9SSvgcrnsN2eGmk3RWG5vYycUGOEApycQL24A==",
-            "dependencies": {
-                "@opentelemetry/core": "^1.8.0",
-                "@opentelemetry/instrumentation": "^0.57.1"
-            },
-            "engines": {
-                "node": ">=14"
-            },
-            "peerDependencies": {
-                "@opentelemetry/api": "^1.3.0"
-            }
-        },
-        "node_modules/@opentelemetry/instrumentation-generic-pool": {
-            "version": "0.43.1",
-            "resolved": "https://registry.npmjs.org/@opentelemetry/instrumentation-generic-pool/-/instrumentation-generic-pool-0.43.1.tgz",
-            "integrity": "sha512-M6qGYsp1cURtvVLGDrPPZemMFEbuMmCXgQYTReC/IbimV5sGrLBjB+/hANUpRZjX67nGLdKSVLZuQQAiNz+sww==",
-            "dependencies": {
-                "@opentelemetry/instrumentation": "^0.57.1"
-            },
-            "engines": {
-                "node": ">=14"
-            },
-            "peerDependencies": {
-                "@opentelemetry/api": "^1.3.0"
-            }
-        },
-        "node_modules/@opentelemetry/instrumentation-graphql": {
-            "version": "0.47.1",
-            "resolved": "https://registry.npmjs.org/@opentelemetry/instrumentation-graphql/-/instrumentation-graphql-0.47.1.tgz",
-            "integrity": "sha512-EGQRWMGqwiuVma8ZLAZnExQ7sBvbOx0N/AE/nlafISPs8S+QtXX+Viy6dcQwVWwYHQPAcuY3bFt3xgoAwb4ZNQ==",
-            "dependencies": {
-                "@opentelemetry/instrumentation": "^0.57.1"
-            },
-            "engines": {
-                "node": ">=14"
-            },
-            "peerDependencies": {
-                "@opentelemetry/api": "^1.3.0"
-            }
-        },
-        "node_modules/@opentelemetry/instrumentation-hapi": {
-            "version": "0.45.2",
-            "resolved": "https://registry.npmjs.org/@opentelemetry/instrumentation-hapi/-/instrumentation-hapi-0.45.2.tgz",
-            "integrity": "sha512-7Ehow/7Wp3aoyCrZwQpU7a2CnoMq0XhIcioFuKjBb0PLYfBfmTsFTUyatlHu0fRxhwcRsSQRTvEhmZu8CppBpQ==",
-            "dependencies": {
-                "@opentelemetry/core": "^1.8.0",
-                "@opentelemetry/instrumentation": "^0.57.1",
-                "@opentelemetry/semantic-conventions": "^1.27.0"
-            },
-            "engines": {
-                "node": ">=14"
-            },
-            "peerDependencies": {
-                "@opentelemetry/api": "^1.3.0"
-            }
-        },
-        "node_modules/@opentelemetry/instrumentation-http": {
-            "version": "0.57.2",
-            "resolved": "https://registry.npmjs.org/@opentelemetry/instrumentation-http/-/instrumentation-http-0.57.2.tgz",
-            "integrity": "sha512-1Uz5iJ9ZAlFOiPuwYg29Bf7bJJc/GeoeJIFKJYQf67nTVKFe8RHbEtxgkOmK4UGZNHKXcpW4P8cWBYzBn1USpg==",
-            "dependencies": {
-                "@opentelemetry/core": "1.30.1",
-                "@opentelemetry/instrumentation": "0.57.2",
-                "@opentelemetry/semantic-conventions": "1.28.0",
-                "forwarded-parse": "2.1.2",
-                "semver": "^7.5.2"
-            },
-            "engines": {
-                "node": ">=14"
-            },
-            "peerDependencies": {
-                "@opentelemetry/api": "^1.3.0"
-            }
-        },
-        "node_modules/@opentelemetry/instrumentation-http/node_modules/@opentelemetry/semantic-conventions": {
-            "version": "1.28.0",
-            "resolved": "https://registry.npmjs.org/@opentelemetry/semantic-conventions/-/semantic-conventions-1.28.0.tgz",
-            "integrity": "sha512-lp4qAiMTD4sNWW4DbKLBkfiMZ4jbAboJIGOQr5DvciMRI494OapieI9qiODpOt0XBr1LjIDy1xAGAnVs5supTA==",
-            "engines": {
-                "node": ">=14"
-            }
-        },
-        "node_modules/@opentelemetry/instrumentation-ioredis": {
-            "version": "0.47.1",
-            "resolved": "https://registry.npmjs.org/@opentelemetry/instrumentation-ioredis/-/instrumentation-ioredis-0.47.1.tgz",
-            "integrity": "sha512-OtFGSN+kgk/aoKgdkKQnBsQFDiG8WdCxu+UrHr0bXScdAmtSzLSraLo7wFIb25RVHfRWvzI5kZomqJYEg/l1iA==",
-            "dependencies": {
-                "@opentelemetry/instrumentation": "^0.57.1",
-                "@opentelemetry/redis-common": "^0.36.2",
-                "@opentelemetry/semantic-conventions": "^1.27.0"
-            },
-            "engines": {
-                "node": ">=14"
-            },
-            "peerDependencies": {
-                "@opentelemetry/api": "^1.3.0"
-            }
-        },
-        "node_modules/@opentelemetry/instrumentation-kafkajs": {
-            "version": "0.7.1",
-            "resolved": "https://registry.npmjs.org/@opentelemetry/instrumentation-kafkajs/-/instrumentation-kafkajs-0.7.1.tgz",
-            "integrity": "sha512-OtjaKs8H7oysfErajdYr1yuWSjMAectT7Dwr+axIoZqT9lmEOkD/H/3rgAs8h/NIuEi2imSXD+vL4MZtOuJfqQ==",
-            "dependencies": {
-                "@opentelemetry/instrumentation": "^0.57.1",
-                "@opentelemetry/semantic-conventions": "^1.27.0"
-            },
-            "engines": {
-                "node": ">=14"
-            },
-            "peerDependencies": {
-                "@opentelemetry/api": "^1.3.0"
-            }
-        },
-        "node_modules/@opentelemetry/instrumentation-knex": {
-            "version": "0.44.1",
-            "resolved": "https://registry.npmjs.org/@opentelemetry/instrumentation-knex/-/instrumentation-knex-0.44.1.tgz",
-            "integrity": "sha512-U4dQxkNhvPexffjEmGwCq68FuftFK15JgUF05y/HlK3M6W/G2iEaACIfXdSnwVNe9Qh0sPfw8LbOPxrWzGWGMQ==",
-            "dependencies": {
-                "@opentelemetry/instrumentation": "^0.57.1",
-                "@opentelemetry/semantic-conventions": "^1.27.0"
-            },
-            "engines": {
-                "node": ">=14"
-            },
-            "peerDependencies": {
-                "@opentelemetry/api": "^1.3.0"
-            }
-        },
-        "node_modules/@opentelemetry/instrumentation-koa": {
-            "version": "0.47.1",
-            "resolved": "https://registry.npmjs.org/@opentelemetry/instrumentation-koa/-/instrumentation-koa-0.47.1.tgz",
-            "integrity": "sha512-l/c+Z9F86cOiPJUllUCt09v+kICKvT+Vg1vOAJHtHPsJIzurGayucfCMq2acd/A/yxeNWunl9d9eqZ0G+XiI6A==",
-            "dependencies": {
-                "@opentelemetry/core": "^1.8.0",
-                "@opentelemetry/instrumentation": "^0.57.1",
-                "@opentelemetry/semantic-conventions": "^1.27.0"
-            },
-            "engines": {
-                "node": ">=14"
-            },
-            "peerDependencies": {
-                "@opentelemetry/api": "^1.3.0"
-            }
-        },
-        "node_modules/@opentelemetry/instrumentation-lru-memoizer": {
-            "version": "0.44.1",
-            "resolved": "https://registry.npmjs.org/@opentelemetry/instrumentation-lru-memoizer/-/instrumentation-lru-memoizer-0.44.1.tgz",
-            "integrity": "sha512-5MPkYCvG2yw7WONEjYj5lr5JFehTobW7wX+ZUFy81oF2lr9IPfZk9qO+FTaM0bGEiymwfLwKe6jE15nHn1nmHg==",
-            "dependencies": {
-                "@opentelemetry/instrumentation": "^0.57.1"
-            },
-            "engines": {
-                "node": ">=14"
-            },
-            "peerDependencies": {
-                "@opentelemetry/api": "^1.3.0"
-            }
-        },
-        "node_modules/@opentelemetry/instrumentation-mongodb": {
-            "version": "0.52.0",
-            "resolved": "https://registry.npmjs.org/@opentelemetry/instrumentation-mongodb/-/instrumentation-mongodb-0.52.0.tgz",
-            "integrity": "sha512-1xmAqOtRUQGR7QfJFfGV/M2kC7wmI2WgZdpru8hJl3S0r4hW0n3OQpEHlSGXJAaNFyvT+ilnwkT+g5L4ljHR6g==",
-            "dependencies": {
-                "@opentelemetry/instrumentation": "^0.57.1",
-                "@opentelemetry/semantic-conventions": "^1.27.0"
-            },
-            "engines": {
-                "node": ">=14"
-            },
-            "peerDependencies": {
-                "@opentelemetry/api": "^1.3.0"
-            }
-        },
-        "node_modules/@opentelemetry/instrumentation-mongoose": {
-            "version": "0.46.1",
-            "resolved": "https://registry.npmjs.org/@opentelemetry/instrumentation-mongoose/-/instrumentation-mongoose-0.46.1.tgz",
-            "integrity": "sha512-3kINtW1LUTPkiXFRSSBmva1SXzS/72we/jL22N+BnF3DFcoewkdkHPYOIdAAk9gSicJ4d5Ojtt1/HeibEc5OQg==",
-            "dependencies": {
-                "@opentelemetry/core": "^1.8.0",
-                "@opentelemetry/instrumentation": "^0.57.1",
-                "@opentelemetry/semantic-conventions": "^1.27.0"
-            },
-            "engines": {
-                "node": ">=14"
-            },
-            "peerDependencies": {
-                "@opentelemetry/api": "^1.3.0"
-            }
-        },
-        "node_modules/@opentelemetry/instrumentation-mysql": {
-            "version": "0.45.1",
-            "resolved": "https://registry.npmjs.org/@opentelemetry/instrumentation-mysql/-/instrumentation-mysql-0.45.1.tgz",
-            "integrity": "sha512-TKp4hQ8iKQsY7vnp/j0yJJ4ZsP109Ht6l4RHTj0lNEG1TfgTrIH5vJMbgmoYXWzNHAqBH2e7fncN12p3BP8LFg==",
-            "dependencies": {
-                "@opentelemetry/instrumentation": "^0.57.1",
-                "@opentelemetry/semantic-conventions": "^1.27.0",
-                "@types/mysql": "2.15.26"
-            },
-            "engines": {
-                "node": ">=14"
-            },
-            "peerDependencies": {
-                "@opentelemetry/api": "^1.3.0"
-            }
-        },
-        "node_modules/@opentelemetry/instrumentation-mysql2": {
-            "version": "0.45.2",
-            "resolved": "https://registry.npmjs.org/@opentelemetry/instrumentation-mysql2/-/instrumentation-mysql2-0.45.2.tgz",
-            "integrity": "sha512-h6Ad60FjCYdJZ5DTz1Lk2VmQsShiViKe0G7sYikb0GHI0NVvApp2XQNRHNjEMz87roFttGPLHOYVPlfy+yVIhQ==",
-            "dependencies": {
-                "@opentelemetry/instrumentation": "^0.57.1",
-                "@opentelemetry/semantic-conventions": "^1.27.0",
-                "@opentelemetry/sql-common": "^0.40.1"
-            },
-            "engines": {
-                "node": ">=14"
-            },
-            "peerDependencies": {
-                "@opentelemetry/api": "^1.3.0"
-            }
-        },
-        "node_modules/@opentelemetry/instrumentation-pg": {
-            "version": "0.51.1",
-            "resolved": "https://registry.npmjs.org/@opentelemetry/instrumentation-pg/-/instrumentation-pg-0.51.1.tgz",
-            "integrity": "sha512-QxgjSrxyWZc7Vk+qGSfsejPVFL1AgAJdSBMYZdDUbwg730D09ub3PXScB9d04vIqPriZ+0dqzjmQx0yWKiCi2Q==",
-            "dependencies": {
-                "@opentelemetry/core": "^1.26.0",
-                "@opentelemetry/instrumentation": "^0.57.1",
-                "@opentelemetry/semantic-conventions": "^1.27.0",
-                "@opentelemetry/sql-common": "^0.40.1",
-                "@types/pg": "8.6.1",
-                "@types/pg-pool": "2.0.6"
-            },
-            "engines": {
-                "node": ">=14"
-            },
-            "peerDependencies": {
-                "@opentelemetry/api": "^1.3.0"
-            }
-        },
-        "node_modules/@opentelemetry/instrumentation-redis-4": {
-            "version": "0.46.1",
-            "resolved": "https://registry.npmjs.org/@opentelemetry/instrumentation-redis-4/-/instrumentation-redis-4-0.46.1.tgz",
-            "integrity": "sha512-UMqleEoabYMsWoTkqyt9WAzXwZ4BlFZHO40wr3d5ZvtjKCHlD4YXLm+6OLCeIi/HkX7EXvQaz8gtAwkwwSEvcQ==",
-            "dependencies": {
-                "@opentelemetry/instrumentation": "^0.57.1",
-                "@opentelemetry/redis-common": "^0.36.2",
-                "@opentelemetry/semantic-conventions": "^1.27.0"
-            },
-            "engines": {
-                "node": ">=14"
-            },
-            "peerDependencies": {
-                "@opentelemetry/api": "^1.3.0"
-            }
-        },
-        "node_modules/@opentelemetry/instrumentation-tedious": {
-            "version": "0.18.1",
-            "resolved": "https://registry.npmjs.org/@opentelemetry/instrumentation-tedious/-/instrumentation-tedious-0.18.1.tgz",
-            "integrity": "sha512-5Cuy/nj0HBaH+ZJ4leuD7RjgvA844aY2WW+B5uLcWtxGjRZl3MNLuxnNg5DYWZNPO+NafSSnra0q49KWAHsKBg==",
-            "dependencies": {
-                "@opentelemetry/instrumentation": "^0.57.1",
-                "@opentelemetry/semantic-conventions": "^1.27.0",
-                "@types/tedious": "^4.0.14"
-            },
-            "engines": {
-                "node": ">=14"
-            },
-            "peerDependencies": {
-                "@opentelemetry/api": "^1.3.0"
-            }
-        },
-        "node_modules/@opentelemetry/instrumentation-undici": {
-            "version": "0.10.1",
-            "resolved": "https://registry.npmjs.org/@opentelemetry/instrumentation-undici/-/instrumentation-undici-0.10.1.tgz",
-            "integrity": "sha512-rkOGikPEyRpMCmNu9AQuV5dtRlDmJp2dK5sw8roVshAGoB6hH/3QjDtRhdwd75SsJwgynWUNRUYe0wAkTo16tQ==",
-            "dependencies": {
-                "@opentelemetry/core": "^1.8.0",
-                "@opentelemetry/instrumentation": "^0.57.1"
-            },
-            "engines": {
-                "node": ">=14"
-            },
-            "peerDependencies": {
-                "@opentelemetry/api": "^1.7.0"
             }
         },
         "node_modules/@opentelemetry/otlp-exporter-base": {
@@ -6490,37 +6080,6 @@
                 "@opentelemetry/api": ">=1.0.0 <1.10.0"
             }
         },
-        "node_modules/@opentelemetry/redis-common": {
-            "version": "0.36.2",
-            "resolved": "https://registry.npmjs.org/@opentelemetry/redis-common/-/redis-common-0.36.2.tgz",
-            "integrity": "sha512-faYX1N0gpLhej/6nyp6bgRjzAKXn5GOEMYY7YhciSfCoITAktLUtQ36d24QEWNA1/WA1y6qQunCe0OhHRkVl9g==",
-            "engines": {
-                "node": ">=14"
-            }
-        },
-        "node_modules/@opentelemetry/resources": {
-            "version": "1.30.1",
-            "resolved": "https://registry.npmjs.org/@opentelemetry/resources/-/resources-1.30.1.tgz",
-            "integrity": "sha512-5UxZqiAgLYGFjS4s9qm5mBVo433u+dSPUFWVWXmLAD4wB65oMCoXaJP1KJa9DIYYMeHu3z4BZcStG3LC593cWA==",
-            "dependencies": {
-                "@opentelemetry/core": "1.30.1",
-                "@opentelemetry/semantic-conventions": "1.28.0"
-            },
-            "engines": {
-                "node": ">=14"
-            },
-            "peerDependencies": {
-                "@opentelemetry/api": ">=1.0.0 <1.10.0"
-            }
-        },
-        "node_modules/@opentelemetry/resources/node_modules/@opentelemetry/semantic-conventions": {
-            "version": "1.28.0",
-            "resolved": "https://registry.npmjs.org/@opentelemetry/semantic-conventions/-/semantic-conventions-1.28.0.tgz",
-            "integrity": "sha512-lp4qAiMTD4sNWW4DbKLBkfiMZ4jbAboJIGOQr5DvciMRI494OapieI9qiODpOt0XBr1LjIDy1xAGAnVs5supTA==",
-            "engines": {
-                "node": ">=14"
-            }
-        },
         "node_modules/@opentelemetry/sdk-logs": {
             "version": "0.54.0",
             "resolved": "https://registry.npmjs.org/@opentelemetry/sdk-logs/-/sdk-logs-0.54.0.tgz",
@@ -6628,30 +6187,6 @@
                 "@opentelemetry/api": ">=1.0.0 <1.10.0"
             }
         },
-        "node_modules/@opentelemetry/sdk-trace-base": {
-            "version": "1.30.1",
-            "resolved": "https://registry.npmjs.org/@opentelemetry/sdk-trace-base/-/sdk-trace-base-1.30.1.tgz",
-            "integrity": "sha512-jVPgBbH1gCy2Lb7X0AVQ8XAfgg0pJ4nvl8/IiQA6nxOsPvS+0zMJaFSs2ltXe0J6C8dqjcnpyqINDJmU30+uOg==",
-            "dependencies": {
-                "@opentelemetry/core": "1.30.1",
-                "@opentelemetry/resources": "1.30.1",
-                "@opentelemetry/semantic-conventions": "1.28.0"
-            },
-            "engines": {
-                "node": ">=14"
-            },
-            "peerDependencies": {
-                "@opentelemetry/api": ">=1.0.0 <1.10.0"
-            }
-        },
-        "node_modules/@opentelemetry/sdk-trace-base/node_modules/@opentelemetry/semantic-conventions": {
-            "version": "1.28.0",
-            "resolved": "https://registry.npmjs.org/@opentelemetry/semantic-conventions/-/semantic-conventions-1.28.0.tgz",
-            "integrity": "sha512-lp4qAiMTD4sNWW4DbKLBkfiMZ4jbAboJIGOQr5DvciMRI494OapieI9qiODpOt0XBr1LjIDy1xAGAnVs5supTA==",
-            "engines": {
-                "node": ">=14"
-            }
-        },
         "node_modules/@opentelemetry/sdk-trace-node": {
             "version": "1.27.0",
             "resolved": "https://registry.npmjs.org/@opentelemetry/sdk-trace-node/-/sdk-trace-node-1.27.0.tgz",
@@ -6738,20 +6273,6 @@
             "integrity": "sha512-sAay1RrB+ONOem0OZanAR1ZI/k7yDpnOQSQmTMuGImUQb2y8EbSaCJ94FQluM74xoU03vlb2d2U90hZluL6nQg==",
             "engines": {
                 "node": ">=14"
-            }
-        },
-        "node_modules/@opentelemetry/sql-common": {
-            "version": "0.40.1",
-            "resolved": "https://registry.npmjs.org/@opentelemetry/sql-common/-/sql-common-0.40.1.tgz",
-            "integrity": "sha512-nSDlnHSqzC3pXn/wZEZVLuAuJ1MYMXPBwtv2qAbCa3847SaHItdE7SzUq/Jtb0KZmh1zfAbNi3AAMjztTT4Ugg==",
-            "dependencies": {
-                "@opentelemetry/core": "^1.1.0"
-            },
-            "engines": {
-                "node": ">=14"
-            },
-            "peerDependencies": {
-                "@opentelemetry/api": "^1.1.0"
             }
         },
         "node_modules/@oxc-parser/binding-android-arm-eabi": {
@@ -7833,17 +7354,6 @@
             "resolved": "https://registry.npmjs.org/@posthog/types/-/types-1.386.4.tgz",
             "integrity": "sha512-UgE9+5+wkZg7yc2MpW5G32/6zYW8fAbXJkG8WGnrb4X8OKWzNa9cWeNCd82vKok+TSoRpM4qiYQFtBSpJS1dsw==",
             "license": "MIT"
-        },
-        "node_modules/@prisma/instrumentation": {
-            "version": "6.4.1",
-            "resolved": "https://registry.npmjs.org/@prisma/instrumentation/-/instrumentation-6.4.1.tgz",
-            "integrity": "sha512-1SeN0IvMp5zm3RLJnEr+Zn67WDqUIPP1lF/PkLbi/X64vsnFyItcXNRBrYr0/sI2qLcH9iNzJUhyd3emdGizaQ==",
-            "dependencies": {
-                "@opentelemetry/instrumentation": "^0.52.0 || ^0.53.0 || ^0.54.0 || ^0.55.0 || ^0.56.0 || ^0.57.0"
-            },
-            "peerDependencies": {
-                "@opentelemetry/api": "^1.8"
-            }
         },
         "node_modules/@protobufjs/aspromise": {
             "version": "1.1.2",
@@ -14584,86 +14094,6 @@
                 "node": ">=14.18"
             }
         },
-        "node_modules/@sentry/node": {
-            "version": "9.3.0",
-            "resolved": "https://registry.npmjs.org/@sentry/node/-/node-9.3.0.tgz",
-            "integrity": "sha512-XzphoVImlKh+wjeKYSaZlH4aQVuw8I63RH6juCktMBKnjTfR9aZkHWeiFc4YghHU2jPXjKTKvGFRkU45xIGr1g==",
-            "dependencies": {
-                "@opentelemetry/api": "^1.9.0",
-                "@opentelemetry/context-async-hooks": "^1.30.1",
-                "@opentelemetry/core": "^1.30.1",
-                "@opentelemetry/instrumentation": "^0.57.2",
-                "@opentelemetry/instrumentation-amqplib": "^0.46.1",
-                "@opentelemetry/instrumentation-connect": "0.43.1",
-                "@opentelemetry/instrumentation-dataloader": "0.16.1",
-                "@opentelemetry/instrumentation-express": "0.47.1",
-                "@opentelemetry/instrumentation-fastify": "0.44.2",
-                "@opentelemetry/instrumentation-fs": "0.19.1",
-                "@opentelemetry/instrumentation-generic-pool": "0.43.1",
-                "@opentelemetry/instrumentation-graphql": "0.47.1",
-                "@opentelemetry/instrumentation-hapi": "0.45.2",
-                "@opentelemetry/instrumentation-http": "0.57.2",
-                "@opentelemetry/instrumentation-ioredis": "0.47.1",
-                "@opentelemetry/instrumentation-kafkajs": "0.7.1",
-                "@opentelemetry/instrumentation-knex": "0.44.1",
-                "@opentelemetry/instrumentation-koa": "0.47.1",
-                "@opentelemetry/instrumentation-lru-memoizer": "0.44.1",
-                "@opentelemetry/instrumentation-mongodb": "0.52.0",
-                "@opentelemetry/instrumentation-mongoose": "0.46.1",
-                "@opentelemetry/instrumentation-mysql": "0.45.1",
-                "@opentelemetry/instrumentation-mysql2": "0.45.2",
-                "@opentelemetry/instrumentation-pg": "0.51.1",
-                "@opentelemetry/instrumentation-redis-4": "0.46.1",
-                "@opentelemetry/instrumentation-tedious": "0.18.1",
-                "@opentelemetry/instrumentation-undici": "0.10.1",
-                "@opentelemetry/resources": "^1.30.1",
-                "@opentelemetry/sdk-trace-base": "^1.30.1",
-                "@opentelemetry/semantic-conventions": "^1.30.0",
-                "@prisma/instrumentation": "6.4.1",
-                "@sentry/core": "9.3.0",
-                "@sentry/opentelemetry": "9.3.0",
-                "import-in-the-middle": "^1.13.0"
-            },
-            "engines": {
-                "node": ">=18"
-            }
-        },
-        "node_modules/@sentry/node/node_modules/@opentelemetry/semantic-conventions": {
-            "version": "1.41.1",
-            "resolved": "https://registry.npmjs.org/@opentelemetry/semantic-conventions/-/semantic-conventions-1.41.1.tgz",
-            "integrity": "sha512-/UhIkaZgPutTFmQ7RnIJGgDXZmtEJ7Dvi86xNTFWcnRxVRNk/aotsqDJYeEvDP+FSMB2SdW+pQzNMcWP0rwuNA==",
-            "license": "Apache-2.0",
-            "engines": {
-                "node": ">=14"
-            }
-        },
-        "node_modules/@sentry/node/node_modules/@sentry/core": {
-            "version": "9.3.0",
-            "resolved": "https://registry.npmjs.org/@sentry/core/-/core-9.3.0.tgz",
-            "integrity": "sha512-SxQ4z7wTkfguvYb2ctNEMU9kVAbhl9ymfjhLnrvtygTwL5soLqAKdco/lX/4P9K9Osgb2Dl6urQWRl+AhzKVbQ==",
-            "engines": {
-                "node": ">=18"
-            }
-        },
-        "node_modules/@sentry/node/node_modules/@sentry/opentelemetry": {
-            "version": "9.3.0",
-            "resolved": "https://registry.npmjs.org/@sentry/opentelemetry/-/opentelemetry-9.3.0.tgz",
-            "integrity": "sha512-kvHj0n0Gk5H482dU6UH+UrccMBPqbjYadwNdb61kMNy5H/xkFcCDKZ8wm3TawlnuiPxzzf4orofiR6Pn/IW6uA==",
-            "dependencies": {
-                "@sentry/core": "9.3.0"
-            },
-            "engines": {
-                "node": ">=18"
-            },
-            "peerDependencies": {
-                "@opentelemetry/api": "^1.9.0",
-                "@opentelemetry/context-async-hooks": "^1.30.1",
-                "@opentelemetry/core": "^1.30.1",
-                "@opentelemetry/instrumentation": "^0.57.1",
-                "@opentelemetry/sdk-trace-base": "^1.30.1",
-                "@opentelemetry/semantic-conventions": "^1.28.0"
-            }
-        },
         "node_modules/@sentry/react": {
             "version": "8.52.1",
             "resolved": "https://registry.npmjs.org/@sentry/react/-/react-8.52.1.tgz",
@@ -16634,6 +16064,7 @@
             "version": "3.4.38",
             "resolved": "https://registry.npmjs.org/@types/connect/-/connect-3.4.38.tgz",
             "integrity": "sha512-K6uROf1LD88uDQqJCktA4yzL1YYAK6NgfsI0v/mTgyPKWsX1CnJ0XPSDhViejru1GcRkLWb8RlzFYJRqGUbaug==",
+            "dev": true,
             "dependencies": {
                 "@types/node": "*"
             }
@@ -16945,14 +16376,6 @@
             "integrity": "sha512-GsCCIZDE/p3i96vtEqx+7dBUGXrc7zeSK3wwPHIaRThS+9OhWIXRqzs4d6k1SVU8g91DrNRWxWUGhp5KXQb2VA==",
             "dev": true
         },
-        "node_modules/@types/mysql": {
-            "version": "2.15.26",
-            "resolved": "https://registry.npmjs.org/@types/mysql/-/mysql-2.15.26.tgz",
-            "integrity": "sha512-DSLCOXhkvfS5WNNPbfn2KdICAmk8lLc+/PNvnPnF7gOdMZCxopXduqv0OQ13y/yA/zXTSikZZqVgybUxOEg6YQ==",
-            "dependencies": {
-                "@types/node": "*"
-            }
-        },
         "node_modules/@types/node": {
             "version": "22.15.29",
             "resolved": "https://registry.npmjs.org/@types/node/-/node-22.15.29.tgz",
@@ -17060,21 +16483,15 @@
             }
         },
         "node_modules/@types/pg": {
-            "version": "8.6.1",
-            "resolved": "https://registry.npmjs.org/@types/pg/-/pg-8.6.1.tgz",
-            "integrity": "sha512-1Kc4oAGzAl7uqUStZCDvaLFqZrW9qWSjXOmBfdgyBP5La7Us6Mg4GBvRlSoaZMhQF/zSj1C8CtKMBkoiT8eL8w==",
+            "version": "8.15.5",
+            "resolved": "https://registry.npmjs.org/@types/pg/-/pg-8.15.5.tgz",
+            "integrity": "sha512-LF7lF6zWEKxuT3/OR8wAZGzkg4ENGXFNyiV/JeOt9z5B+0ZVwbql9McqX5c/WStFq1GaGso7H1AzP/qSzmlCKQ==",
+            "dev": true,
+            "license": "MIT",
             "dependencies": {
                 "@types/node": "*",
                 "pg-protocol": "*",
                 "pg-types": "^2.2.0"
-            }
-        },
-        "node_modules/@types/pg-pool": {
-            "version": "2.0.6",
-            "resolved": "https://registry.npmjs.org/@types/pg-pool/-/pg-pool-2.0.6.tgz",
-            "integrity": "sha512-TaAUE5rq2VQYxab5Ts7WZhKNmuN78Q6PiFonTDdpbx8a1H0M1vhy3rhiMjl+e2iHmogyMw7jZF4FrE6eJUy5HQ==",
-            "dependencies": {
-                "@types/pg": "*"
             }
         },
         "node_modules/@types/promptly": {
@@ -17170,11 +16587,6 @@
                 "@types/node": "*"
             }
         },
-        "node_modules/@types/shimmer": {
-            "version": "1.2.0",
-            "resolved": "https://registry.npmjs.org/@types/shimmer/-/shimmer-1.2.0.tgz",
-            "integrity": "sha512-UE7oxhQLLd9gub6JKIAhDq06T0F6FnztwMNRvYgjeQSBeMc1ZG/tA47EwfduvkuQS8apbkM/lpLpWsaCeYsXVg=="
-        },
         "node_modules/@types/simple-oauth2": {
             "version": "4.1.1",
             "dev": true,
@@ -17224,14 +16636,6 @@
             "resolved": "https://registry.npmjs.org/@types/stringify-object/-/stringify-object-4.0.5.tgz",
             "integrity": "sha512-TzX5V+njkbJ8iJ0mrj+Vqveep/1JBH4SSA3J2wYrE1eUrOhdsjTBCb0kao4EquSQ8KgPpqY4zSVP2vCPWKBElg==",
             "dev": true
-        },
-        "node_modules/@types/tedious": {
-            "version": "4.0.14",
-            "resolved": "https://registry.npmjs.org/@types/tedious/-/tedious-4.0.14.tgz",
-            "integrity": "sha512-KHPsfX/FoVbUGbyYvk1q9MMQHLPeRZhRJZdO45Q4YjvFkv4hMNghCWTvy7rdKessBsmtz4euWCWAB6/tVpI1Iw==",
-            "dependencies": {
-                "@types/node": "*"
-            }
         },
         "node_modules/@types/through": {
             "version": "0.0.33",
@@ -22896,11 +22300,6 @@
             "engines": {
                 "node": ">= 0.6"
             }
-        },
-        "node_modules/forwarded-parse": {
-            "version": "2.1.2",
-            "resolved": "https://registry.npmjs.org/forwarded-parse/-/forwarded-parse-2.1.2.tgz",
-            "integrity": "sha512-alTFZZQDKMporBH77856pXgzhEzaUVmLCDk+egLgIgHst3Tpndzz8MnKe+GzRJRfvVdn69HhpW7cmXzvtLvJAw=="
         },
         "node_modules/fresh": {
             "version": "2.0.0",
@@ -29045,41 +28444,6 @@
             "engines": {
                 "node": ">=0.10.0"
             }
-        },
-        "node_modules/require-in-the-middle": {
-            "version": "7.5.2",
-            "resolved": "https://registry.npmjs.org/require-in-the-middle/-/require-in-the-middle-7.5.2.tgz",
-            "integrity": "sha512-gAZ+kLqBdHarXB64XpAe2VCjB7rIRv+mU8tfRWziHRJ5umKsIHN2tLLv6EtMw7WCdP19S0ERVMldNvxYCHnhSQ==",
-            "dependencies": {
-                "debug": "^4.3.5",
-                "module-details-from-path": "^1.0.3",
-                "resolve": "^1.22.8"
-            },
-            "engines": {
-                "node": ">=8.6.0"
-            }
-        },
-        "node_modules/require-in-the-middle/node_modules/debug": {
-            "version": "4.4.3",
-            "resolved": "https://registry.npmjs.org/debug/-/debug-4.4.3.tgz",
-            "integrity": "sha512-RGwwWnwQvkVfavKVt22FGLw+xYSdzARwm0ru6DhTVA3umU5hZc28V3kO4stgYryrTlLpuvgI9GiijltAjNbcqA==",
-            "license": "MIT",
-            "dependencies": {
-                "ms": "^2.1.3"
-            },
-            "engines": {
-                "node": ">=6.0"
-            },
-            "peerDependenciesMeta": {
-                "supports-color": {
-                    "optional": true
-                }
-            }
-        },
-        "node_modules/require-in-the-middle/node_modules/ms": {
-            "version": "2.1.3",
-            "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.3.tgz",
-            "integrity": "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA=="
         },
         "node_modules/require-main-filename": {
             "version": "2.0.0",
@@ -37358,6 +36722,7 @@
                 "uuidv7": "0.6.3"
             },
             "devDependencies": {
+                "@types/pg": "8.15.5",
                 "type-fest": "4.41.0",
                 "vitest": "4.1.9"
             }
@@ -38015,7 +37380,6 @@
             "dependencies": {
                 "@colors/colors": "1.6.0",
                 "@nangohq/egress": "file:../egress",
-                "@sentry/node": "9.3.0",
                 "axios": "1.18.0",
                 "dd-trace": "5.52.0",
                 "exponential-backoff": "3.1.1",

--- a/packages/jobs/lib/app.ts
+++ b/packages/jobs/lib/app.ts
@@ -6,7 +6,7 @@ import { generateImage } from '@nangohq/fleet';
 import { destroy as destroyKvstore } from '@nangohq/kvstore';
 import { destroy as destroyLogs, otlp } from '@nangohq/logs';
 import { getOtlpRoutes } from '@nangohq/shared';
-import { getLogger, initSentry, once, report, stringifyError } from '@nangohq/utils';
+import { getLogger, once, report, stringifyError } from '@nangohq/utils';
 
 import { orchestratorClient } from './clients.js';
 import { envs } from './env.js';
@@ -31,8 +31,6 @@ process.on('uncaughtException', (err) => {
     report(err);
     // not closing on purpose
 });
-
-initSentry({ dsn: envs.SENTRY_DSN, applicationName: envs.NANGO_DB_APPLICATION_NAME, hash: envs.GIT_HASH });
 
 try {
     await initializeFeatureFlags();

--- a/packages/metering/lib/app.ts
+++ b/packages/metering/lib/app.ts
@@ -6,7 +6,7 @@ import { billing } from '@nangohq/billing';
 import { destroy as destroyFeatureFlags, initialize as initializeFeatureFlags } from '@nangohq/feature-flags';
 import { DefaultTransport } from '@nangohq/pubsub';
 import { Clickhouse, getUsageTracker, migrate as migrateUsage } from '@nangohq/usage';
-import { initSentry, once, report } from '@nangohq/utils';
+import { once, report } from '@nangohq/utils';
 
 import { billingEventsS3DLQMonitorCron } from './crons/billingEventsS3DLQMonitor.js';
 import { billingEventsS3ExportCron } from './crons/billingEventsS3Export.js';
@@ -27,8 +27,6 @@ try {
         logger.error('Received uncaughtException...', err);
         report(err);
     });
-
-    initSentry({ dsn: envs.SENTRY_DSN, applicationName: envs.NANGO_DB_APPLICATION_NAME, hash: envs.GIT_HASH });
 
     await initializeFeatureFlags();
 

--- a/packages/orchestrator/lib/app.ts
+++ b/packages/orchestrator/lib/app.ts
@@ -2,7 +2,7 @@ import './tracer.js';
 
 import { destroy as destroyFeatureFlags, initialize as initializeFeatureFlags } from '@nangohq/feature-flags';
 import { DatabaseClient, defaultDatabaseClientOptions, Scheduler } from '@nangohq/scheduler';
-import { initSentry, once, report, stringifyError } from '@nangohq/utils';
+import { once, report, stringifyError } from '@nangohq/utils';
 
 import { BackpressureMonitor } from './backpressure-monitor.js';
 import { envs } from './env.js';
@@ -22,8 +22,6 @@ process.on('uncaughtException', (err) => {
     report(err);
     // not closing on purpose
 });
-
-initSentry({ dsn: envs.SENTRY_DSN, applicationName: envs.NANGO_DB_APPLICATION_NAME, hash: envs.GIT_HASH });
 
 const databaseSchema = envs.ORCHESTRATOR_DATABASE_SCHEMA;
 const databaseUrl =

--- a/packages/persist/lib/app.ts
+++ b/packages/persist/lib/app.ts
@@ -5,7 +5,7 @@ import { destroy as destroyFeatureFlags, initialize as initializeFeatureFlags } 
 import { destroy as destroyKvstore } from '@nangohq/kvstore';
 import { destroy as destroyLogs } from '@nangohq/logs';
 import { records } from '@nangohq/records';
-import { getLogger, initSentry, once, report } from '@nangohq/utils';
+import { getLogger, once, report } from '@nangohq/utils';
 
 import { autoDeletingDaemon } from './daemons/autodeleting.daemon.js';
 import { autoPruningDaemon } from './daemons/autopruning.daemon.js';
@@ -28,8 +28,6 @@ process.on('uncaughtException', (err) => {
     report(err);
     // not closing on purpose
 });
-
-initSentry({ dsn: envs.SENTRY_DSN, applicationName: envs.NANGO_DB_APPLICATION_NAME, hash: envs.GIT_HASH });
 
 let api: Server;
 const autoPruning = autoPruningDaemon();

--- a/packages/scheduler/package.json
+++ b/packages/scheduler/package.json
@@ -23,6 +23,7 @@
         "uuidv7": "0.6.3"
     },
     "devDependencies": {
+        "@types/pg": "8.15.5",
         "type-fest": "4.41.0",
         "vitest": "4.1.9"
     }

--- a/packages/server/lib/server.ts
+++ b/packages/server/lib/server.ts
@@ -16,7 +16,7 @@ import { destroy as destroyKvstore } from '@nangohq/kvstore';
 import { destroy as destroyLogs, start as migrateLogs, otlp } from '@nangohq/logs';
 import { records } from '@nangohq/records';
 import { getGlobalOAuthCallbackUrl, getOtlpRoutes, getProviders, getServerPort, getWebsocketsPath, pubsub } from '@nangohq/shared';
-import { flags, getLogger, initSentry, NANGO_VERSION, once, report } from '@nangohq/utils';
+import { flags, getLogger, NANGO_VERSION, once, report } from '@nangohq/utils';
 
 import publisher from './clients/publisher.client.js';
 import { deleteOldData } from './crons/deleteOldData.js';
@@ -37,8 +37,6 @@ import type { WebSocket } from 'ws';
 
 const { NANGO_MIGRATE_AT_START = 'true' } = process.env;
 const logger = getLogger('Server');
-
-initSentry({ dsn: envs.SENTRY_DSN, applicationName: envs.NANGO_DB_APPLICATION_NAME, hash: envs.GIT_HASH });
 
 process.on('unhandledRejection', (reason) => {
     logger.error('Received unhandledRejection...', reason);

--- a/packages/utils/lib/environment/parse.ts
+++ b/packages/utils/lib/environment/parse.ts
@@ -520,7 +520,6 @@ export const ENVS = z.object({
 
     // Sentry
     PUBLIC_SENTRY_KEY: z.string().optional(),
-    SENTRY_DSN: z.url().optional(),
 
     // Slack
     NANGO_SLACK_INTEGRATION_KEY: z.string().optional().default('slack'),

--- a/packages/utils/lib/errors.ts
+++ b/packages/utils/lib/errors.ts
@@ -1,9 +1,7 @@
-import * as Sentry from '@sentry/node';
 import { serializeError } from 'serialize-error';
 
 import { errorToObject } from './errorSerialize.js';
 import { getLogger } from './logger.js';
-import { NANGO_VERSION } from './version.js';
 
 export { errorToObject } from './errorSerialize.js';
 
@@ -72,37 +70,8 @@ export function stringifyError(err: unknown, opts?: { pretty?: boolean; stack?: 
     return JSON.stringify(filtered, null, opts?.pretty ? 2 : undefined);
 }
 
-let sentry = false;
-export function initSentry({ dsn, hash, applicationName }: { dsn: string | undefined; hash?: string | undefined; applicationName: string }) {
-    Sentry.init({
-        dsn: dsn || '',
-        sampleRate: 1,
-        skipOpenTelemetrySetup: true, // If false or not set, sentry is breaking our otel setup for logs export
-        enabled: dsn ? true : false,
-        release: `${NANGO_VERSION}@${hash || 'no_hash'}`,
-        serverName: applicationName,
-        maxBreadcrumbs: 10
-    });
-    if (dsn) {
-        sentry = true;
-        logger.info('Sentry configured');
-    }
-}
-
 const logger = getLogger('err');
 export function report(err: unknown, extra?: Record<string, unknown>) {
     const message = errorToObject(err).message || 'Unknown error';
     logger.error(message, { err, ...extra });
-
-    if (!sentry) {
-        return;
-    }
-
-    Sentry.withScope((scope) => {
-        if (extra) {
-            scope.setExtras(extra);
-        }
-
-        Sentry.captureException(err);
-    });
 }

--- a/packages/utils/package.json
+++ b/packages/utils/package.json
@@ -17,7 +17,6 @@
     "dependencies": {
         "@colors/colors": "1.6.0",
         "@nangohq/egress": "file:../egress",
-        "@sentry/node": "9.3.0",
         "axios": "1.18.0",
         "dd-trace": "5.52.0",
         "exponential-backoff": "3.1.1",


### PR DESCRIPTION
## Problem

Sentry was integrated in the Node backend services but nobody was using it — it just consumed quota and added noise.

## Solution

- Removed `initSentry()`/`Sentry.captureException` from `@nangohq/utils`'s `errors.ts`, the single centralized entry point
- Removed the `initSentry()` calls in the `server`, `jobs`, `persist`, `orchestrator`, and `metering` entrypoints
- Removed the `@sentry/node` dependency and the `SENTRY_DSN` env var
- Left the webapp's separate `@sentry/react` integration untouched (`PUBLIC_SENTRY_KEY`, CSP allowlist, CORS headers) — out of scope for this ticket
- Added `@types/pg` as an explicit dev dependency to `packages/scheduler`, since it was silently relying on it being hoisted transitively through `@sentry/node`'s OpenTelemetry pg instrumentation

Fixes [NAN-6240](https://linear.app/nango/issue/NAN-6240)

## Follow-ups (after merge)

- [ ] Confirm the `prod` and `staging` Sentry projects stop receiving events
- [ ] Delete the now-stale/disconnected `prod` and `staging` Sentry projects

## Testing

- `npm run ts-build` and `npm run lint` pass clean
- `packages/utils` unit tests pass (including `errors.unit.test.ts` and `environment/parse.unit.test.ts`)
