### PR TITLE
fix(orchestrator): change NOTIFY to use parameterized pg_notify

### DIFF
--- a/packages/orchestrator/lib/events.ts
+++ b/packages/orchestrator/lib/events.ts
@@ -159,7 +159,7 @@ class PgEventEmitter extends EventEmitter {
         }
 
         try {
-            await this.client.query(`NOTIFY ${this.channel}, '${payload}'`);
+            await this.client.query('SELECT pg_notify($1, $2)', [this.channel, payload]);
         } catch (err: any) {
             if (err.code === 'ECONNRESET' || err.code === 'ENOTCONN') {
                 this.connected = false;


### PR DESCRIPTION
Harden Postgres pub/sub notify handling by using a parameterized query instead of building the command as a string.

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/NangoHQ/nango/pull/6867?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

