### PR TITLE
fix(orchestrator): align workers and dispatch telemetry (NAN-6405)

### DIFF
--- a/packages/orchestrator/lib/clients/processor.ts
+++ b/packages/orchestrator/lib/clients/processor.ts
@@ -59,11 +59,12 @@ export class OrchestratorProcessor {
 
     private async processingLoop(): Promise<void> {
         while (this.status === 'running') {
-            // wait for the queue to have space before dequeuing more tasks
-            await this.queue.onSizeLessThan(this.queue.concurrency);
-            const available = this.queue.concurrency - this.queue.size;
-            const limit = available + this.queue.concurrency; // fetching more than available to keep the queue full
-            const tasks = await this.orchestratorClient.dequeue({ groupKeyPattern: this.groupKeyPattern, limit, longPolling: true });
+            const free = this.queue.concurrency - this.queue.pending - this.queue.size;
+            if (free <= 0) {
+                await this.waitForCapacity();
+                continue;
+            }
+            const tasks = await this.orchestratorClient.dequeue({ groupKeyPattern: this.groupKeyPattern, limit: free, longPolling: true });
             if (tasks.isErr()) {
                 logger.error(`failed to dequeue tasks: ${stringifyError(tasks.error)}`);
                 await setTimeout(1000); // wait for a bit before retrying to avoid hammering the server in case of repetitive errors
@@ -83,6 +84,26 @@ export class OrchestratorProcessor {
         }
         this.status = 'stopped';
         return;
+    }
+
+    private waitForCapacity(): Promise<void> {
+        return new Promise<void>((resolve) => {
+            let settled = false;
+            const onCapacity = () => {
+                if (settled) {
+                    return;
+                }
+                settled = true;
+                this.queue.off('completed', onCapacity);
+                this.queue.off('next', onCapacity);
+                resolve();
+            };
+            this.queue.on('completed', onCapacity);
+            this.queue.on('next', onCapacity);
+            if (this.queue.pending + this.queue.size < this.queue.concurrency) {
+                onCapacity();
+            }
+        });
     }
 
     private async processTask(task: OrchestratorTask, parentSpan: Span): Promise<void> {

--- a/packages/orchestrator/lib/clients/processor.unit.test.ts
+++ b/packages/orchestrator/lib/clients/processor.unit.test.ts
@@ -1,0 +1,53 @@
+import { describe, expect, it, vi } from 'vitest';
+
+import { Ok } from '@nangohq/utils';
+
+import { OrchestratorProcessor } from './processor.js';
+
+import type { OrchestratorClient } from './client.js';
+import type { OrchestratorTask } from './types.js';
+import type { Result } from '@nangohq/utils';
+
+function deferred<T>() {
+    let resolve!: (value: T | PromiseLike<T>) => void;
+    const promise = new Promise<T>((res) => {
+        resolve = res;
+    });
+    return { promise, resolve };
+}
+
+describe('OrchestratorProcessor', () => {
+    it('only dequeues as many tasks as there are free worker slots', async () => {
+        const firstHandler = deferred<undefined>();
+        const secondHandler = deferred<undefined>();
+        const secondDequeue = deferred<Result<OrchestratorTask[]>>();
+        const tasks = [{ id: 'task-1' }, { id: 'task-2' }] as OrchestratorTask[];
+        const dequeue = vi
+            .fn()
+            .mockResolvedValueOnce(Ok(tasks))
+            .mockImplementationOnce(() => secondDequeue.promise);
+        const handler = vi
+            .fn()
+            .mockImplementationOnce(() => firstHandler.promise.then(() => Ok(undefined)))
+            .mockImplementationOnce(() => secondHandler.promise.then(() => Ok(undefined)));
+        const processor = new OrchestratorProcessor({
+            orchestratorClient: { dequeue } as unknown as OrchestratorClient,
+            groupKeyPattern: 'webhook*',
+            maxConcurrency: 2,
+            handler
+        });
+
+        processor.start();
+        await vi.waitFor(() => expect(handler).toHaveBeenCalledTimes(2));
+        expect(dequeue).toHaveBeenCalledTimes(1);
+
+        firstHandler.resolve(undefined);
+        await vi.waitFor(() => expect(dequeue).toHaveBeenCalledTimes(2));
+        expect(dequeue).toHaveBeenNthCalledWith(2, { groupKeyPattern: 'webhook*', limit: 1, longPolling: true });
+
+        const stop = processor.stop();
+        secondHandler.resolve(undefined);
+        secondDequeue.resolve(Ok([]));
+        await stop;
+    });
+});

--- a/packages/orchestrator/lib/events.integration.test.ts
+++ b/packages/orchestrator/lib/events.integration.test.ts
@@ -1,6 +1,7 @@
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 
 import { getTestDbClient } from '@nangohq/scheduler';
+import { metrics } from '@nangohq/utils';
 
 import { envs } from './env.js';
 import { taskEvents, TaskEventsHandler } from './events.js';
@@ -162,6 +163,17 @@ describe('TaskEventsHandler', () => {
 
             expect(handler).toHaveBeenCalledTimes(2);
         });
+    });
+
+    it('clamps task start lag when clocks are skewed', () => {
+        const duration = vi.spyOn(metrics, 'duration').mockImplementation(() => {});
+        eventsHandler.onCallbacks['STARTED']({
+            ...mockActionTask,
+            createdAt: new Date('2026-07-22T12:00:01.000Z'),
+            lastStateTransitionAt: new Date('2026-07-22T12:00:00.000Z')
+        });
+
+        expect(duration).toHaveBeenCalledWith(metrics.Types.ORCH_TASKS_START_LAG_MS, 0, { primitive: 'taskGroup' });
     });
 });
 

--- a/packages/orchestrator/lib/events.ts
+++ b/packages/orchestrator/lib/events.ts
@@ -239,6 +239,9 @@ export class TaskEventsHandler extends PgEventEmitter {
             STARTED: (task: Task) => {
                 logger.info(`Task started: ${stringifyTask(task)}`);
                 metrics.increment(metrics.Types.ORCH_TASKS_STARTED);
+                metrics.duration(metrics.Types.ORCH_TASKS_START_LAG_MS, task.lastStateTransitionAt.getTime() - task.createdAt.getTime(), {
+                    primitive: task.groupKey.split(GROUP_PREFIX_SEPARATOR)[0] || 'unknown'
+                });
                 // STARTED events are not listen to, so we don't emit them
             },
             SUCCEEDED: (task: Task) => {

--- a/packages/orchestrator/lib/events.ts
+++ b/packages/orchestrator/lib/events.ts
@@ -239,7 +239,7 @@ export class TaskEventsHandler extends PgEventEmitter {
             STARTED: (task: Task) => {
                 logger.info(`Task started: ${stringifyTask(task)}`);
                 metrics.increment(metrics.Types.ORCH_TASKS_STARTED);
-                metrics.duration(metrics.Types.ORCH_TASKS_START_LAG_MS, task.lastStateTransitionAt.getTime() - task.createdAt.getTime(), {
+                metrics.duration(metrics.Types.ORCH_TASKS_START_LAG_MS, Math.max(0, task.lastStateTransitionAt.getTime() - task.createdAt.getTime()), {
                     primitive: task.groupKey.split(GROUP_PREFIX_SEPARATOR)[0] || 'unknown'
                 });
                 // STARTED events are not listen to, so we don't emit them

--- a/packages/utils/lib/telemetry/metrics.ts
+++ b/packages/utils/lib/telemetry/metrics.ts
@@ -99,6 +99,7 @@ export enum Types {
     ORCH_TASKS_CANCELLED = 'nango.orch.tasks.cancelled',
     ORCH_QUEUE_BACKPRESSURE = 'nango.orch.queue.backpressure',
     ORCH_TASKS_DEQUEUED = 'nango.orch.tasks.dequeued',
+    ORCH_TASKS_START_LAG_MS = 'nango.orch.tasks.start_lag_ms',
     ORCH_WEBHOOK_ADMISSION = 'nango.orch.webhook_admission',
     ORCH_WEBHOOK_ADMISSION_INFLIGHT = 'nango.orch.webhook_admission.inflight',
 


### PR DESCRIPTION
## Summary

- dequeue only as many scheduler tasks as there are free local worker slots
- expose adaptive limit, active permit, admission, backlog, deferral, and task start-lag metrics
- propagate admission overload through the direct/oversized webhook path without retry amplification

## Stack

- stacked on #6872

Linear: NAN-6405

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/NangoHQ/nango/pull/6873?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->
