### PR TITLE
feat(webapp): redesign 2FA setup screens

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -23251,6 +23251,17 @@
                 "css-in-js-utils": "^3.1.0"
             }
         },
+        "node_modules/input-otp": {
+            "version": "1.4.2",
+            "resolved": "https://registry.npmjs.org/input-otp/-/input-otp-1.4.2.tgz",
+            "integrity": "sha512-l3jWwYNvrEa6NTCt7BECfCm48GvwuZzkoeG3gBL2w4CHeOXW3eKFmf9UNYkNfYc3mxMrthMnxjIE07MT0zLBQA==",
+            "dev": true,
+            "license": "MIT",
+            "peerDependencies": {
+                "react": "^16.8 || ^17.0 || ^18.0 || ^19.0.0 || ^19.0.0-rc",
+                "react-dom": "^16.8 || ^17.0 || ^18.0 || ^19.0.0 || ^19.0.0-rc"
+            }
+        },
         "node_modules/inquirer": {
             "version": "13.1.0",
             "resolved": "https://registry.npmjs.org/inquirer/-/inquirer-13.1.0.tgz",
@@ -37480,6 +37491,7 @@
                 "env-cmd": "10.1.0",
                 "fuse.js": "7.1.0",
                 "httpsnippet-lite": "3.0.5",
+                "input-otp": "1.4.2",
                 "json-schema": "0.4.0",
                 "lodash": "4.18.1",
                 "lucide-react": "0.542.0",

--- a/packages/webapp/package.json
+++ b/packages/webapp/package.json
@@ -71,6 +71,7 @@
         "env-cmd": "10.1.0",
         "fuse.js": "7.1.0",
         "httpsnippet-lite": "3.0.5",
+        "input-otp": "1.4.2",
         "json-schema": "0.4.0",
         "lodash": "4.18.1",
         "lucide-react": "0.542.0",

--- a/packages/webapp/src/app/router.tsx
+++ b/packages/webapp/src/app/router.tsx
@@ -37,6 +37,7 @@ import { HearAboutUs } from '@/pages/Onboarding/HearAboutUs';
 import { Root } from '@/pages/Root';
 import { TeamBilling } from '@/pages/Team/Billing/Show';
 import { TeamSettingsPage } from '@/pages/Team/Settings';
+import { Enable2FA } from '@/pages/User/Enable2FA';
 import { UserSettings } from '@/pages/User/Settings';
 import { useStore } from '@/store';
 import { globalEnv } from '@/utils/env';
@@ -167,8 +168,18 @@ export const router = sentryCreateBrowserRouter([
             },
             {
                 path: '/user-settings',
-                element: <UserSettings />,
-                handle: { breadcrumb: 'User settings' } as BreadcrumbHandle
+                handle: { breadcrumb: 'Profile settings' } as BreadcrumbHandle,
+                children: [
+                    {
+                        index: true,
+                        element: <UserSettings />
+                    },
+                    {
+                        path: 'enable-2fa',
+                        element: <Enable2FA />,
+                        handle: { breadcrumb: 'Enable 2FA' } as BreadcrumbHandle
+                    }
+                ]
             },
             {
                 path: '/team/billing',

--- a/packages/webapp/src/components-v2/ui/InputOTP.tsx
+++ b/packages/webapp/src/components-v2/ui/InputOTP.tsx
@@ -1,0 +1,55 @@
+import { OTPInput, OTPInputContext, REGEXP_ONLY_DIGITS } from 'input-otp';
+import * as React from 'react';
+
+import { cn } from '@/utils/utils';
+
+function InputOTP({
+    className,
+    containerClassName,
+    ...props
+}: React.ComponentProps<typeof OTPInput> & {
+    containerClassName?: string;
+}) {
+    return (
+        <OTPInput
+            data-slot="input-otp"
+            inputMode="numeric"
+            pattern={REGEXP_ONLY_DIGITS}
+            aria-label="One-time password"
+            containerClassName={cn('flex items-center gap-2 has-disabled:opacity-50', containerClassName)}
+            className={cn('disabled:cursor-not-allowed', className)}
+            {...props}
+        />
+    );
+}
+
+function InputOTPGroup({ className, ...props }: React.ComponentProps<'div'>) {
+    return <div data-slot="input-otp-group" className={cn('flex items-center gap-2', className)} {...props} />;
+}
+
+function InputOTPSlot({ index, className, ...props }: React.ComponentProps<'div'> & { index: number }) {
+    const inputOTPContext = React.useContext(OTPInputContext);
+    const { char, hasFakeCaret, isActive } = inputOTPContext?.slots[index] ?? {};
+
+    return (
+        <div
+            data-slot="input-otp-slot"
+            data-active={isActive}
+            className={cn(
+                'relative flex size-10 items-center justify-center rounded-ds-xs border-ds-hairline border-border-interactive bg-surface-input text-text-default text-ds-md font-ds-medium transition-[color,box-shadow]',
+                'data-[active=true]:border-[var(--focus-ring-default)] data-[active=true]:shadow-[0_0_0_0.5px_var(--focus-ring-default),inset_0_0_0_0.5px_var(--focus-ring-default)] data-[active=true]:z-10',
+                className
+            )}
+            {...props}
+        >
+            {char}
+            {hasFakeCaret && (
+                <div className="pointer-events-none absolute inset-0 flex items-center justify-center">
+                    <div className="h-4 w-px animate-pulse bg-text-default" />
+                </div>
+            )}
+        </div>
+    );
+}
+
+export { InputOTP, InputOTPGroup, InputOTPSlot };

--- a/packages/webapp/src/pages/Account/MFALogin.tsx
+++ b/packages/webapp/src/pages/Account/MFALogin.tsx
@@ -5,6 +5,7 @@ import { useNavigate } from 'react-router-dom';
 
 import { Button, InputGroup, InputGroupInput } from '@nangohq/design-system';
 
+import { InputOTP, InputOTPGroup, InputOTPSlot } from '@/components-v2/ui/InputOTP';
 import { Alert, AlertDescription } from '@/components/ui/Alert';
 import { StyledLink } from '@/components/ui/StyledLink';
 import { useMFALoginVerification } from '@/hooks/useAuth';
@@ -20,11 +21,10 @@ export const MFALogin: React.FC = () => {
     const [useRecoveryCode, setUseRecoveryCode] = useState(false);
     const [errorMessage, setErrorMessage] = useState('');
 
-    const submit = async (event: React.FormEvent<HTMLFormElement>) => {
-        event.preventDefault();
+    const verifyCode = async (value: string) => {
         setErrorMessage('');
         try {
-            const result = await verify(useRecoveryCode ? { type: 'recoveryCode', recoveryCode: code } : { type: 'code', code });
+            const result = await verify(useRecoveryCode ? { type: 'recoveryCode', recoveryCode: value } : { type: 'code', code: value });
             signin(result.data.user);
             navigate(result.data.url, { replace: true });
         } catch (err) {
@@ -35,6 +35,8 @@ export const MFALogin: React.FC = () => {
             }
         }
     };
+
+    const hasValidCode = useRecoveryCode ? code.length > 0 : /^\d{6}$/.test(code);
 
     return (
         <DefaultLayout className="gap-10">
@@ -53,19 +55,45 @@ export const MFALogin: React.FC = () => {
                     </Alert>
                 )}
             </div>
-            <form onSubmit={(event) => void submit(event)} className="flex flex-col gap-5 w-full">
-                <InputGroup>
-                    <InputGroupInput
-                        value={code}
-                        onChange={(event) => setCode(event.target.value)}
-                        placeholder={useRecoveryCode ? 'Recovery code' : '123456'}
-                        aria-label={useRecoveryCode ? 'Recovery code' : 'Authenticator code'}
-                        autoComplete="one-time-code"
-                        inputMode={useRecoveryCode ? 'text' : 'numeric'}
-                        disabled={isPending}
-                    />
-                </InputGroup>
-                <Button type="submit" size="lg" loading={isPending} disabled={useRecoveryCode ? code.length === 0 : !/^\d{6}$/.test(code)}>
+            <form
+                onSubmit={(event) => {
+                    event.preventDefault();
+                    void verifyCode(code);
+                }}
+                className="flex flex-col gap-5 w-full"
+            >
+                {useRecoveryCode ? (
+                    <InputGroup>
+                        <InputGroupInput
+                            value={code}
+                            onChange={(event) => setCode(event.target.value)}
+                            placeholder="Recovery code"
+                            aria-label="Recovery code"
+                            autoComplete="one-time-code"
+                            inputMode="text"
+                            disabled={isPending}
+                        />
+                    </InputGroup>
+                ) : (
+                    <div className="flex justify-center">
+                        <InputOTP
+                            maxLength={6}
+                            value={code}
+                            onChange={setCode}
+                            onComplete={(value: string) => void verifyCode(value)}
+                            disabled={isPending}
+                            aria-label="Authenticator code"
+                            autoFocus
+                        >
+                            <InputOTPGroup>
+                                {[0, 1, 2, 3, 4, 5].map((i) => (
+                                    <InputOTPSlot key={i} index={i} />
+                                ))}
+                            </InputOTPGroup>
+                        </InputOTP>
+                    </div>
+                )}
+                <Button type="submit" size="lg" loading={isPending} disabled={!hasValidCode}>
                     Verify and continue
                 </Button>
             </form>
@@ -76,6 +104,7 @@ export const MFALogin: React.FC = () => {
                     onClick={() => {
                         setUseRecoveryCode((value) => !value);
                         setCode('');
+                        setErrorMessage('');
                     }}
                 >
                     {useRecoveryCode ? 'Use an authenticator code' : 'Use a recovery code'}

--- a/packages/webapp/src/pages/Team/components/TeamMembers.tsx
+++ b/packages/webapp/src/pages/Team/components/TeamMembers.tsx
@@ -152,8 +152,8 @@ export const TeamMembers: React.FC = () => {
                                 </ButtonLink>
                             </div>
                         </TableHead>
-                        <TableHead>Status</TableHead>
                         {mfaFeatureEnabled && <TableHead>2FA</TableHead>}
+                        <TableHead>Status</TableHead>
                         <TableHead className="text-right">{/* Actions */}</TableHead>
                     </TableRow>
                 </TableHeader>
@@ -186,18 +186,6 @@ export const TeamMembers: React.FC = () => {
                                 </div>
                             </TableCell>
 
-                            <TableCell>
-                                {user.is_invitation ? (
-                                    <div className="inline-flex items-center gap-2 text-text-secondary">
-                                        <Dot className="bg-status-warning-icon" /> Invited
-                                    </div>
-                                ) : (
-                                    <div className="inline-flex items-center gap-2 text-text-strong">
-                                        <Dot className="bg-status-success-icon" /> Active
-                                    </div>
-                                )}
-                            </TableCell>
-
                             {mfaFeatureEnabled && (
                                 <TableCell>
                                     {user.is_invitation ? (
@@ -209,6 +197,18 @@ export const TeamMembers: React.FC = () => {
                                     )}
                                 </TableCell>
                             )}
+
+                            <TableCell>
+                                {user.is_invitation ? (
+                                    <div className="inline-flex items-center gap-2 text-text-secondary">
+                                        <Dot className="bg-status-warning-icon" /> Invited
+                                    </div>
+                                ) : (
+                                    <div className="inline-flex items-center gap-2 text-text-strong">
+                                        <Dot className="bg-status-success-icon" /> Active
+                                    </div>
+                                )}
+                            </TableCell>
 
                             <TableCell className="text-right">
                                 {me?.email === user.email ? null : (

--- a/packages/webapp/src/pages/User/Enable2FA.tsx
+++ b/packages/webapp/src/pages/User/Enable2FA.tsx
@@ -1,0 +1,193 @@
+import { QRCodeSVG } from 'qrcode.react';
+import { useEffect, useRef, useState } from 'react';
+import { Helmet } from 'react-helmet';
+import { useNavigate } from 'react-router-dom';
+
+import { Button } from '@nangohq/design-system';
+
+import { InputOTP, InputOTPGroup, InputOTPSlot } from '@/components-v2/ui/InputOTP';
+import { Checkbox } from '@/components/ui/Checkbox';
+import { CopyButton } from '@/components/ui/CopyButton';
+import { Skeleton } from '@/components/ui/Skeleton';
+import { useMFA } from '@/hooks/useMFA';
+import { useToast } from '@/hooks/useToast';
+import DashboardLayout from '@/layout/DashboardLayout';
+import { track } from '@/utils/analytics';
+import { MfaStepper } from './components/MfaStepper';
+import { RecoveryCodes } from './components/RecoveryCodes';
+import { getMFAErrorMessage } from './mfaErrors';
+
+import type { MfaStep } from './components/MfaStepper';
+
+function extractSecret(otpauthUri: string): string | null {
+    const query = otpauthUri.split('?')[1];
+    if (!query) {
+        return null;
+    }
+    const secret = new URLSearchParams(query).get('secret');
+    return secret ? secret.replace(/(.{4})/g, '$1 ').trim() : null;
+}
+
+export const Enable2FA: React.FC = () => {
+    const navigate = useNavigate();
+    const { toast } = useToast();
+    const { enroll, activate } = useMFA();
+
+    const [step, setStep] = useState<MfaStep>('scan');
+    const [otpauthUri, setOtpauthUri] = useState<string | null>(null);
+    const [code, setCode] = useState('');
+    const [recoveryCodes, setRecoveryCodes] = useState<string[]>([]);
+    const [savedConfirmed, setSavedConfirmed] = useState(false);
+
+    const enrollmentStarted = useRef(false);
+
+    const goToSettings = () => navigate('/user-settings');
+
+    const cancel = (fromStep: 'scan' | 'save') => {
+        track('web:2fa:enable_cancelled', { step: fromStep });
+        goToSettings();
+    };
+
+    useEffect(() => {
+        if (enrollmentStarted.current) {
+            return;
+        }
+        enrollmentStarted.current = true;
+
+        void (async () => {
+            try {
+                const result = await enroll.mutateAsync();
+                setOtpauthUri(result.data.otpauthUri);
+                track('web:2fa:enable_started', {});
+            } catch (err) {
+                toast({ title: getMFAErrorMessage(err), variant: 'error' });
+                goToSettings();
+            }
+        })();
+        // eslint-disable-next-line react-hooks/exhaustive-deps
+    }, []);
+
+    const verifyAndContinue = async () => {
+        try {
+            const result = await activate.mutateAsync({ code });
+            track('web:2fa:enabled', {});
+            setRecoveryCodes(result.data.recoveryCodes);
+            setStep('save');
+        } catch (err) {
+            setCode('');
+            toast({ title: getMFAErrorMessage(err), variant: 'error' });
+        }
+    };
+
+    const secret = otpauthUri ? extractSecret(otpauthUri) : null;
+    const hasValidCode = /^\d{6}$/.test(code);
+
+    return (
+        <DashboardLayout fullWidth>
+            <Helmet>
+                <title>Enable 2FA - Nango</title>
+            </Helmet>
+            <div className="mx-auto flex max-w-[640px] flex-col gap-8 py-4">
+                <MfaStepper current={step} />
+
+                <div className="rounded-ds-sm border-ds-hairline border-border-default bg-surface-panel">
+                    {step === 'scan' && (
+                        <>
+                            <div className="flex flex-col items-center gap-6 px-8 py-8">
+                                <div className="flex flex-col items-center gap-1 text-center">
+                                    <h2 className="text-heading-sm text-text-strong">Set up authenticator app</h2>
+                                    <p className="text-body-small-regular text-text-secondary">
+                                        Scan this with Google Authenticator, 1Password, or any TOTP app.
+                                    </p>
+                                </div>
+
+                                {otpauthUri ? (
+                                    <>
+                                        <div className="rounded-ds-xs border-ds-hairline border-border-default bg-white p-3">
+                                            <QRCodeSVG value={otpauthUri} size={160} bgColor="#ffffff" fgColor="#000000" />
+                                        </div>
+                                        <div className="flex flex-col items-center gap-2">
+                                            <span className="text-body-small-regular text-text-secondary">Can&apos;t scan? Enter this key manually:</span>
+                                            {secret && (
+                                                <div className="flex items-center gap-1 rounded-ds-xs bg-surface-input px-2 py-1 font-mono text-ds-sm text-text-default">
+                                                    <span>{secret}</span>
+                                                    <CopyButton text={secret.replace(/\s/g, '')} />
+                                                </div>
+                                            )}
+                                        </div>
+                                        <div className="flex flex-col items-center gap-3">
+                                            <span className="text-body-small-medium text-text-strong">Enter the 6-digit code from your app:</span>
+                                            <InputOTP maxLength={6} value={code} onChange={setCode} onComplete={() => void verifyAndContinue()} autoFocus>
+                                                <InputOTPGroup>
+                                                    {[0, 1, 2, 3, 4, 5].map((i) => (
+                                                        <InputOTPSlot key={i} index={i} />
+                                                    ))}
+                                                </InputOTPGroup>
+                                            </InputOTP>
+                                        </div>
+                                    </>
+                                ) : (
+                                    <div className="flex flex-col items-center gap-4">
+                                        <Skeleton className="size-[160px]" />
+                                        <Skeleton className="h-6 w-40" />
+                                    </div>
+                                )}
+                            </div>
+                            <div className="flex justify-end gap-2 border-t border-border-muted px-6 py-4">
+                                <Button variant="outline" onClick={() => cancel('scan')}>
+                                    Cancel
+                                </Button>
+                                <Button onClick={() => void verifyAndContinue()} loading={activate.isPending} disabled={!hasValidCode}>
+                                    Continue
+                                </Button>
+                            </div>
+                        </>
+                    )}
+
+                    {step === 'save' && (
+                        <>
+                            <div className="flex flex-col items-center gap-6 px-8 py-8">
+                                <div className="flex flex-col items-center gap-1 text-center">
+                                    <h2 className="text-heading-sm text-text-strong">Save your recovery codes</h2>
+                                    <p className="text-body-small-regular text-text-secondary">
+                                        Use one of these if you lose access to your authenticator app. Each code works once.
+                                    </p>
+                                </div>
+
+                                <RecoveryCodes codes={recoveryCodes} context="enroll" />
+
+                                <label className="flex items-center gap-2 text-body-small-regular text-text-default">
+                                    <Checkbox checked={savedConfirmed} onCheckedChange={(value) => setSavedConfirmed(value === true)} />
+                                    I&apos;ve saved these codes somewhere safe
+                                </label>
+                            </div>
+                            <div className="flex justify-end gap-2 border-t border-border-muted px-6 py-4">
+                                <Button variant="outline" onClick={() => cancel('save')}>
+                                    Cancel
+                                </Button>
+                                <Button onClick={() => setStep('done')} disabled={!savedConfirmed}>
+                                    Continue
+                                </Button>
+                            </div>
+                        </>
+                    )}
+
+                    {step === 'done' && (
+                        <div className="flex flex-col items-center gap-4 px-8 py-10 text-center">
+                            <div className="flex flex-col items-center gap-2">
+                                <h2 className="text-heading-sm text-text-strong">Two-factor authentication is enabled</h2>
+                                <p className="text-body-small-regular text-text-secondary">You&apos;ll be asked for a code at every sign-in.</p>
+                                <p className="text-body-small-regular text-text-secondary">
+                                    {recoveryCodes.length} of {recoveryCodes.length} recovery codes remaining
+                                </p>
+                            </div>
+                            <Button variant="outline" onClick={goToSettings}>
+                                Close
+                            </Button>
+                        </div>
+                    )}
+                </div>
+            </div>
+        </DashboardLayout>
+    );
+};

--- a/packages/webapp/src/pages/User/Settings.tsx
+++ b/packages/webapp/src/pages/User/Settings.tsx
@@ -1,6 +1,6 @@
-import { QRCodeSVG } from 'qrcode.react';
 import { useState } from 'react';
 import { Helmet } from 'react-helmet';
+import { useNavigate } from 'react-router-dom';
 
 import {
     Button,
@@ -15,17 +15,20 @@ import {
     Input
 } from '@nangohq/design-system';
 
+import { InputOTP, InputOTPGroup, InputOTPSlot } from '@/components-v2/ui/InputOTP';
 import { CriticalErrorAlert } from '@/components/patterns/CriticalErrorAlert';
 import { EditableInput } from '@/components/patterns/EditableInput';
-import { CopyButton } from '@/components/ui/CopyButton';
 import { Select, SelectContent, SelectItem, SelectTrigger, SelectValue } from '@/components/ui/Select';
 import { Skeleton } from '@/components/ui/Skeleton';
 import { useThemeStore } from '@/lib/theme';
+import { track } from '@/utils/analytics';
 import { useMFA } from '../../hooks/useMFA';
 import { useToast } from '../../hooks/useToast';
 import { apiPatchUser, useUser } from '../../hooks/useUser';
 import DashboardLayout from '../../layout/DashboardLayout';
 import { APIError } from '../../utils/api';
+import { RecoveryCodes } from './components/RecoveryCodes';
+import { getMFAErrorMessage } from './mfaErrors';
 
 import type { Theme } from '@/lib/theme';
 
@@ -115,50 +118,23 @@ export const UserSettings: React.FC = () => {
     );
 };
 
-type MFAAction = 'disable' | 'regenerate' | null;
-
-const mfaErrorMessages: Record<string, string> = {
-    invalid_mfa_code: 'Invalid verification code. Try again.',
-    mfa_already_enabled: 'Multi-factor authentication is already enabled.',
-    mfa_enrollment_not_found: 'Start MFA enrollment again before confirming.',
-    mfa_not_enabled: 'Multi-factor authentication is not enabled.'
-};
-
-function getMFAErrorMessage(error: unknown): string {
-    if (error instanceof APIError) {
-        const json: unknown = error.json;
-        if (typeof json === 'object' && json !== null && 'error' in json) {
-            const apiError = (json as { error: unknown }).error;
-            if (typeof apiError === 'object' && apiError !== null) {
-                const { code, message } = apiError as { code?: unknown; message?: unknown };
-                if (typeof code === 'string' && code in mfaErrorMessages) {
-                    return mfaErrorMessages[code]!;
-                }
-                if (typeof message === 'string') {
-                    return message;
-                }
-            }
-        }
-    }
-    return 'Something went wrong. Please try again.';
-}
-
 const MFASettings: React.FC = () => {
+    const navigate = useNavigate();
     const { toast } = useToast();
-    const { enabled, loading, error, enroll, activate, regenerateRecoveryCodes, disable } = useMFA();
-    const [enrollmentUri, setEnrollmentUri] = useState<string | null>(null);
-    const [recoveryCodes, setRecoveryCodes] = useState<string[] | null>(null);
+    const { enabled, loading, error, regenerateRecoveryCodes, disable } = useMFA();
+    const [disableOpen, setDisableOpen] = useState(false);
+    const [regenOpen, setRegenOpen] = useState(false);
+    const [newCodes, setNewCodes] = useState<string[] | null>(null);
     const [code, setCode] = useState('');
-    const [action, setAction] = useState<MFAAction>(null);
     const hasValidCode = /^\d{6}$/.test(code);
 
-    const closeEnrollment = () => {
-        setEnrollmentUri(null);
+    const closeDisable = () => {
+        setDisableOpen(false);
         setCode('');
     };
 
-    const closeAction = () => {
-        setAction(null);
+    const closeRegen = () => {
+        setRegenOpen(false);
         setCode('');
     };
 
@@ -169,186 +145,130 @@ const MFASettings: React.FC = () => {
         }
     }
 
-    const startEnrollment = async () => {
+    const confirmDisable = async () => {
         try {
-            const result = await enroll.mutateAsync();
+            await disable.mutateAsync({ code });
+            track('web:2fa:disabled', {});
+            toast({ title: 'Two-factor authentication is disabled', variant: 'success' });
+            closeDisable();
+        } catch (err) {
             setCode('');
-            setEnrollmentUri(result.data.otpauthUri);
-        } catch (err) {
             toast({ title: getMFAErrorMessage(err), variant: 'error' });
         }
     };
 
-    const activateEnrollment = async () => {
+    const confirmRegen = async () => {
         try {
-            const result = await activate.mutateAsync({ code });
-            closeEnrollment();
-            setRecoveryCodes(result.data.recoveryCodes);
-            toast({ title: 'Multi-factor authentication is enabled', variant: 'success' });
+            const result = await regenerateRecoveryCodes.mutateAsync({ code });
+            track('web:2fa:recovery_codes_regenerated', {});
+            closeRegen();
+            setNewCodes(result.data.recoveryCodes);
         } catch (err) {
+            setCode('');
             toast({ title: getMFAErrorMessage(err), variant: 'error' });
         }
     };
-
-    const confirmAction = async () => {
-        try {
-            if (action === 'regenerate') {
-                const result = await regenerateRecoveryCodes.mutateAsync({ code });
-                setRecoveryCodes(result.data.recoveryCodes);
-                toast({ title: 'New recovery codes generated', variant: 'success' });
-            } else if (action === 'disable') {
-                await disable.mutateAsync({ code });
-                toast({ title: 'Multi-factor authentication is disabled', variant: 'success' });
-            }
-            closeAction();
-        } catch (err) {
-            toast({ title: getMFAErrorMessage(err), variant: 'error' });
-        }
-    };
-
-    const actionTitle = action === 'disable' ? 'Disable multi-factor authentication' : 'Generate new recovery codes';
-    const actionDescription =
-        action === 'disable'
-            ? 'Enter a code from your authenticator app to disable multi-factor authentication.'
-            : 'Enter a code from your authenticator app to replace your existing recovery codes.';
 
     return (
         <>
             <div className="col-span-2 mt-2 border-t border-border-muted pt-8" />
             <div className="col-span-2 grid grid-cols-[237px_1fr] items-center gap-x-6">
-                <FieldLabel>Multi-factor authentication</FieldLabel>
+                <FieldLabel>Two-factor authentication</FieldLabel>
                 <div className="flex flex-col items-start gap-3">
                     {loading ? (
                         <Skeleton className="h-8 w-40" />
                     ) : error ? (
-                        <p className="text-text-danger text-ds-sm">Unable to load multi-factor authentication settings.</p>
+                        <p className="text-text-danger text-ds-sm">Unable to load two-factor authentication settings.</p>
                     ) : enabled ? (
-                        <>
-                            <p className="text-text-secondary text-ds-sm">Authenticator app protection is enabled.</p>
-                            <div className="flex flex-wrap gap-2">
-                                <Button variant="outline" onClick={() => setAction('regenerate')}>
-                                    Generate recovery codes
-                                </Button>
-                                <Button variant="danger" onClick={() => setAction('disable')}>
-                                    Disable MFA
-                                </Button>
-                            </div>
-                        </>
-                    ) : (
-                        <>
-                            <p className="text-text-secondary text-ds-sm">Use an authenticator app to add an extra layer of protection to your account.</p>
-                            <Button onClick={() => void startEnrollment()} loading={enroll.isPending}>
-                                Enable MFA
+                        <div className="flex flex-wrap gap-2">
+                            <Button variant="danger" onClick={() => setDisableOpen(true)}>
+                                Disable 2FA
                             </Button>
-                        </>
+                            <Button variant="outline" onClick={() => setRegenOpen(true)}>
+                                Generate recovery codes
+                            </Button>
+                        </div>
+                    ) : (
+                        <Button onClick={() => navigate('/user-settings/enable-2fa')}>Enable 2FA</Button>
                     )}
                 </div>
             </div>
 
-            <Dialog open={enrollmentUri !== null} onOpenChange={(open) => !open && closeEnrollment()}>
+            <Dialog open={disableOpen} onOpenChange={(open) => !open && closeDisable()}>
                 <DialogContent>
                     <DialogHeader>
-                        <DialogTitle>Set up your authenticator app</DialogTitle>
-                        <DialogDescription>Scan this QR code, then enter the six-digit code from your authenticator app.</DialogDescription>
+                        <DialogTitle>Disable two-factor authentication</DialogTitle>
+                        <DialogDescription>Enter the 6-digit code from your authenticator app to disable two-factor authentication</DialogDescription>
                     </DialogHeader>
                     <DialogBody>
-                        {enrollmentUri && (
-                            <div className="flex flex-col items-center gap-4">
-                                <div className="rounded-ds-sm border border-border-default bg-white p-4">
-                                    <QRCodeSVG value={enrollmentUri} size={180} bgColor="#ffffff" fgColor="#000000" />
-                                </div>
-                                <div className="flex items-center gap-1 text-text-secondary text-ds-xs">
-                                    <span>Cannot scan the code?</span>
-                                    <CopyButton text={enrollmentUri} />
-                                </div>
-                            </div>
-                        )}
-                        <label className="flex flex-col gap-2 text-text-default text-ds-sm">
-                            Verification code
-                            <Input
-                                value={code}
-                                onChange={(event) => setCode(event.target.value)}
-                                inputMode="numeric"
-                                autoComplete="one-time-code"
-                                maxLength={6}
-                                placeholder="123456"
-                            />
-                        </label>
+                        <div className="flex flex-col items-center gap-3">
+                            <span className="text-body-small-medium text-text-strong">Enter your verification code:</span>
+                            <InputOTP maxLength={6} value={code} onChange={setCode} autoFocus>
+                                <InputOTPGroup>
+                                    {[0, 1, 2, 3, 4, 5].map((i) => (
+                                        <InputOTPSlot key={i} index={i} />
+                                    ))}
+                                </InputOTPGroup>
+                            </InputOTP>
+                        </div>
                     </DialogBody>
                     <DialogFooter>
-                        <Button variant="outline" size="sm" onClick={closeEnrollment}>
+                        <Button variant="outline" size="sm" onClick={closeDisable}>
                             Cancel
                         </Button>
-                        <Button size="sm" onClick={() => void activateEnrollment()} loading={activate.isPending} disabled={!hasValidCode}>
-                            Confirm and continue
+                        <Button variant="danger" size="sm" onClick={() => void confirmDisable()} loading={disable.isPending} disabled={!hasValidCode}>
+                            Disable 2FA
                         </Button>
                     </DialogFooter>
                 </DialogContent>
             </Dialog>
 
-            <Dialog open={action !== null} onOpenChange={(open) => !open && closeAction()}>
+            <Dialog open={regenOpen} onOpenChange={(open) => !open && closeRegen()}>
                 <DialogContent>
                     <DialogHeader>
-                        <DialogTitle>{actionTitle}</DialogTitle>
-                        <DialogDescription>{actionDescription}</DialogDescription>
+                        <DialogTitle>Generate new recovery codes</DialogTitle>
+                        <DialogDescription>
+                            Enter the 6-digit code from your authenticator app. Your existing recovery codes will stop working.
+                        </DialogDescription>
                     </DialogHeader>
                     <DialogBody>
-                        <label className="flex flex-col gap-2 text-text-default text-ds-sm">
-                            Verification code
-                            <Input
-                                value={code}
-                                onChange={(event) => setCode(event.target.value)}
-                                inputMode="numeric"
-                                autoComplete="one-time-code"
-                                maxLength={6}
-                                placeholder="123456"
-                            />
-                        </label>
+                        <div className="flex flex-col items-center gap-3">
+                            <span className="text-body-small-medium text-text-strong">Enter your verification code:</span>
+                            <InputOTP maxLength={6} value={code} onChange={setCode} autoFocus>
+                                <InputOTPGroup>
+                                    {[0, 1, 2, 3, 4, 5].map((i) => (
+                                        <InputOTPSlot key={i} index={i} />
+                                    ))}
+                                </InputOTPGroup>
+                            </InputOTP>
+                        </div>
                     </DialogBody>
                     <DialogFooter>
-                        <Button variant="outline" size="sm" onClick={closeAction}>
+                        <Button variant="outline" size="sm" onClick={closeRegen}>
                             Cancel
                         </Button>
-                        <Button
-                            variant={action === 'disable' ? 'danger' : 'primary'}
-                            size="sm"
-                            onClick={() => void confirmAction()}
-                            loading={disable.isPending || regenerateRecoveryCodes.isPending}
-                            disabled={!hasValidCode}
-                        >
-                            {action === 'disable' ? 'Disable MFA' : 'Generate codes'}
+                        <Button size="sm" onClick={() => void confirmRegen()} loading={regenerateRecoveryCodes.isPending} disabled={!hasValidCode}>
+                            Generate codes
                         </Button>
                     </DialogFooter>
                 </DialogContent>
             </Dialog>
 
-            <Dialog open={recoveryCodes !== null} onOpenChange={() => undefined}>
+            <Dialog open={newCodes !== null}>
                 <DialogContent
                     showCloseButton={false}
                     onEscapeKeyDown={(event) => event.preventDefault()}
                     onPointerDownOutside={(event) => event.preventDefault()}
+                    onInteractOutside={(event) => event.preventDefault()}
                 >
                     <DialogHeader>
                         <DialogTitle>Save your recovery codes</DialogTitle>
-                        <DialogDescription>Keep these codes somewhere safe. Each code can only be used once and will not be shown again.</DialogDescription>
+                        <DialogDescription>Your previous codes no longer work. Each of these works once, so store them somewhere safe.</DialogDescription>
                     </DialogHeader>
-                    <DialogBody>
-                        {recoveryCodes && (
-                            <div className="flex flex-col gap-3">
-                                <div className="grid grid-cols-2 gap-2 rounded-ds-sm border border-border-default bg-surface-canvas p-4 font-mono text-ds-sm text-text-default">
-                                    {recoveryCodes.map((recoveryCode) => (
-                                        <code key={recoveryCode}>{recoveryCode}</code>
-                                    ))}
-                                </div>
-                                <div className="flex justify-end">
-                                    <CopyButton text={recoveryCodes.join('\n')} />
-                                </div>
-                            </div>
-                        )}
-                    </DialogBody>
+                    <DialogBody>{newCodes && <RecoveryCodes codes={newCodes} context="regenerate" />}</DialogBody>
                     <DialogFooter>
-                        <Button size="sm" onClick={() => setRecoveryCodes(null)}>
-                            I saved my codes
+                        <Button size="sm" onClick={() => setNewCodes(null)}>
+                            Done
                         </Button>
                     </DialogFooter>
                 </DialogContent>

--- a/packages/webapp/src/pages/User/components/MfaStepper.tsx
+++ b/packages/webapp/src/pages/User/components/MfaStepper.tsx
@@ -1,0 +1,66 @@
+import { Check } from 'lucide-react';
+import { Fragment } from 'react';
+
+import { cn } from '@/utils/utils';
+
+export type MfaStep = 'scan' | 'save' | 'done';
+
+const STEPS: { id: MfaStep; label: string }[] = [
+    { id: 'scan', label: 'Scan and verify' },
+    { id: 'save', label: 'Save codes' },
+    { id: 'done', label: 'Done' }
+];
+
+export const MfaStepper: React.FC<{ current: MfaStep }> = ({ current }) => {
+    const currentIndex = STEPS.findIndex((step) => step.id === current);
+
+    return (
+        <div role="list" aria-label="Two-factor setup progress" className="flex items-start justify-center">
+            {STEPS.map((step, index) => {
+                const isCompleted = index < currentIndex;
+                const isActive = index === currentIndex;
+                const isLast = index === STEPS.length - 1;
+
+                return (
+                    <Fragment key={step.id}>
+                        <div
+                            role="listitem"
+                            aria-current={isActive ? 'step' : undefined}
+                            aria-label={`${step.label}${isCompleted ? ' (completed)' : isActive ? ' (current)' : ''}`}
+                            className="flex flex-col items-center gap-2"
+                        >
+                            <div
+                                aria-hidden="true"
+                                className={cn(
+                                    'flex size-5 items-center justify-center rounded-full border transition-colors',
+                                    isCompleted && 'border-interactive-primary text-interactive-primary',
+                                    isActive && isLast && 'border-interactive-primary bg-interactive-primary text-text-on-brand',
+                                    isActive && !isLast && 'border-interactive-primary',
+                                    !isCompleted && !isActive && 'border-border-default'
+                                )}
+                            >
+                                {isCompleted || (isActive && isLast) ? (
+                                    <Check className="size-3" />
+                                ) : isActive ? (
+                                    <div className="size-2 rounded-full bg-interactive-primary" />
+                                ) : null}
+                            </div>
+                            <span
+                                aria-hidden="true"
+                                className={cn('whitespace-nowrap text-ds-xs', isActive || isCompleted ? 'text-text-default' : 'text-text-muted')}
+                            >
+                                {step.label}
+                            </span>
+                        </div>
+                        {!isLast && (
+                            <div
+                                aria-hidden="true"
+                                className={cn('mt-2.5 h-px min-w-12 flex-1', isCompleted ? 'bg-interactive-primary' : 'bg-border-default')}
+                            />
+                        )}
+                    </Fragment>
+                );
+            })}
+        </div>
+    );
+};

--- a/packages/webapp/src/pages/User/components/RecoveryCodes.tsx
+++ b/packages/webapp/src/pages/User/components/RecoveryCodes.tsx
@@ -1,0 +1,64 @@
+import { Check, Copy, Download } from 'lucide-react';
+import { useEffect, useState } from 'react';
+
+import { Button } from '@nangohq/design-system';
+
+import { useToast } from '@/hooks/useToast';
+import { track } from '@/utils/analytics';
+
+export const RecoveryCodes: React.FC<{ codes: string[]; context: 'enroll' | 'regenerate' }> = ({ codes, context }) => {
+    const { toast } = useToast();
+    const [copied, setCopied] = useState(false);
+
+    useEffect(() => {
+        if (!copied) {
+            return;
+        }
+        const timer = setTimeout(() => setCopied(false), 1500);
+        return () => clearTimeout(timer);
+    }, [copied]);
+
+    const copyAll = async () => {
+        try {
+            await navigator.clipboard.writeText(codes.join('\n'));
+            setCopied(true);
+            track('web:2fa:recovery_codes_copied', { context });
+        } catch {
+            toast({ title: 'Could not copy to clipboard. Copy the codes manually.', variant: 'error' });
+        }
+    };
+
+    const downloadAll = () => {
+        const blob = new Blob([codes.join('\n')], { type: 'text/plain' });
+        const url = URL.createObjectURL(blob);
+        const link = document.createElement('a');
+        link.href = url;
+        link.download = 'nango-recovery-codes.txt';
+        link.click();
+        URL.revokeObjectURL(url);
+        track('web:2fa:recovery_codes_downloaded', { context });
+    };
+
+    return (
+        <div className="flex flex-col items-center gap-4">
+            <div className="grid w-full grid-cols-2 gap-x-8 gap-y-1 rounded-ds-xs border-ds-hairline border-border-default bg-surface-input px-6 py-4 font-mono text-ds-sm text-text-default">
+                {codes.map((code, index) => (
+                    <code key={`${code}-${index}`}>{code}</code>
+                ))}
+            </div>
+            <div className="flex gap-2">
+                <Button variant="outline" onClick={downloadAll}>
+                    <Download className="size-4" />
+                    Download all
+                </Button>
+                <Button variant="outline" onClick={() => void copyAll()}>
+                    {copied ? <Check className="size-4" /> : <Copy className="size-4" />}
+                    {copied ? 'Copied' : 'Copy all'}
+                </Button>
+            </div>
+            <span className="sr-only" role="status" aria-live="polite">
+                {copied ? 'Recovery codes copied to clipboard' : ''}
+            </span>
+        </div>
+    );
+};

--- a/packages/webapp/src/pages/User/mfaErrors.ts
+++ b/packages/webapp/src/pages/User/mfaErrors.ts
@@ -1,0 +1,27 @@
+import { APIError } from '@/utils/api';
+
+const mfaErrorMessages: Record<string, string> = {
+    invalid_mfa_code: 'Invalid verification code. Try again.',
+    mfa_already_enabled: 'Two-factor authentication is already enabled.',
+    mfa_enrollment_not_found: 'Start setup again before confirming.',
+    mfa_not_enabled: 'Two-factor authentication is not enabled.'
+};
+
+export function getMFAErrorMessage(error: unknown): string {
+    if (error instanceof APIError) {
+        const json: unknown = error.json;
+        if (typeof json === 'object' && json !== null && 'error' in json) {
+            const apiError = (json as { error: unknown }).error;
+            if (typeof apiError === 'object' && apiError !== null) {
+                const { code, message } = apiError as { code?: unknown; message?: unknown };
+                if (typeof code === 'string' && Object.prototype.hasOwnProperty.call(mfaErrorMessages, code)) {
+                    return mfaErrorMessages[code]!;
+                }
+                if (typeof message === 'string') {
+                    return message;
+                }
+            }
+        }
+    }
+    return 'Something went wrong. Please try again.';
+}

--- a/packages/webapp/src/utils/analyticsEvents.ts
+++ b/packages/webapp/src/utils/analyticsEvents.ts
@@ -57,4 +57,13 @@ export interface AnalyticsEvents {
     // Account & onboarding
     'web:account_signup': { user_id: number; accountId: number };
     'web:signup:hear_about': { source: PostOnboardingHearAboutUs['Body']['source'] };
+
+    // Two-factor authentication
+    'web:2fa:enable_started': Record<string, never>;
+    'web:2fa:enabled': Record<string, never>;
+    'web:2fa:enable_cancelled': { step: 'scan' | 'save' };
+    'web:2fa:disabled': Record<string, never>;
+    'web:2fa:recovery_codes_regenerated': Record<string, never>;
+    'web:2fa:recovery_codes_copied': { context: 'enroll' | 'regenerate' };
+    'web:2fa:recovery_codes_downloaded': { context: 'enroll' | 'regenerate' };
 }


### PR DESCRIPTION
Redesigns the 2FA setup and management screens to match the new Figma designs.


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/NangoHQ/nango/pull/6878?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

