### PR TITLE
feat(auth): add account discovery during new-user onboarding

### DIFF
--- a/packages/database/lib/migrations/20260731120000_add_account_discovery_pending_to_users.cjs
+++ b/packages/database/lib/migrations/20260731120000_add_account_discovery_pending_to_users.cjs
@@ -1,0 +1,13 @@
+exports.config = { transaction: true };
+
+/**
+ * @param {import('knex').Knex} knex
+ */
+exports.up = async function (knex) {
+    await knex.raw(`ALTER TABLE "_nango_users" ADD COLUMN IF NOT EXISTS "account_discovery_pending" BOOLEAN NOT NULL DEFAULT FALSE`);
+};
+
+/**
+ * @param {import('knex').Knex} knex
+ */
+exports.down = async function () {};

--- a/packages/server/lib/controllers/v1/account/confirmEmail.integration.test.ts
+++ b/packages/server/lib/controllers/v1/account/confirmEmail.integration.test.ts
@@ -46,15 +46,20 @@ describe(`POST ${confirmEmailRoute}`, () => {
 
         expect(res.status).toBe(200);
         expect(res.headers.getSetCookie()).toHaveLength(0);
-        expect(json).toMatchObject({ email, userId: user.id, accountId: user.account_id });
+        expect(json).toMatchObject({ user: { email, id: user.id, accountId: user.account_id } });
 
         const verifiedUser = await userService.getUserById(user.id, true);
         expect(verifiedUser?.email_verified).toBe(true);
         expect(verifiedUser?.email_verification_token).toBeNull();
+        expect(verifiedUser?.account_discovery_pending).toBe(true);
 
         const signinRes = await api.fetch(signinRoute, { method: 'POST', body: { email, password } });
         expect(signinRes.res.status).toBe(200);
         expect(signinRes.res.headers.getSetCookie()[0]).toMatch(/^nango_session=/);
+        expect(signinRes.json).toMatchObject({ url: '/onboarding/account-discovery' });
+
+        const signedInUser = await userService.getUserById(user.id, true);
+        expect(signedInUser?.account_discovery_pending).toBe(true);
     });
 
     it('does not verify an expired token', async () => {

--- a/packages/server/lib/controllers/v1/account/confirmEmail.ts
+++ b/packages/server/lib/controllers/v1/account/confirmEmail.ts
@@ -1,9 +1,9 @@
 import * as z from 'zod';
 
-import db from '@nangohq/database';
-import { accountService, userService } from '@nangohq/shared';
+import { userService } from '@nangohq/shared';
 import { getLogger, requireEmptyQuery, zodErrorToHTTP } from '@nangohq/utils';
 
+import { userToAPI } from '../../../formatters/user.js';
 import { asyncWrapper } from '../../../utils/asyncWrapper.js';
 
 import type { ConfirmEmail } from '@nangohq/types';
@@ -64,14 +64,7 @@ export const confirmEmail = asyncWrapper<ConfirmEmail>(async (req, res) => {
     }
 
     const user = tokenResponse.value;
+    await userService.verifyUserEmail(user.id, { markAccountDiscoveryPending: true });
 
-    await userService.verifyUserEmail(user.id);
-
-    let showHearAboutUs = false;
-    const account = await accountService.getAccountById(db.knex, user.account_id);
-    if (account) {
-        showHearAboutUs = await accountService.shouldShowHearAboutUs(account);
-    }
-
-    res.status(200).send({ email: user.email, userId: user.id, accountId: user.account_id, showHearAboutUs });
+    res.status(200).send({ user: userToAPI(user) });
 });

--- a/packages/server/lib/controllers/v1/account/index.ts
+++ b/packages/server/lib/controllers/v1/account/index.ts
@@ -7,3 +7,4 @@ export * from './signup.js';
 export * from './confirmEmail.js';
 export * from './onboarding/getHearAboutUs.js';
 export * from './onboarding/postHearAboutUs.js';
+export * from './onboarding/getAccountDiscovery.js';

--- a/packages/server/lib/controllers/v1/account/managed/auth.ts
+++ b/packages/server/lib/controllers/v1/account/managed/auth.ts
@@ -171,11 +171,15 @@ export async function finalizeManagedAuthentication({
             account = resAccount;
         }
 
+        // Invited users do not go through account discovery:
+        const account_discovery_pending = !invitation;
+
         user = await userService.createUser({
             email: authorizedUser.email,
             name,
             account_id: account.id,
             email_verified: true,
+            account_discovery_pending,
             role: invitation ? invitation.role : envs.DEFAULT_USER_ROLE
         });
         if (!user) {
@@ -201,13 +205,14 @@ export async function finalizeManagedAuthentication({
     let destination = '/';
     try {
         if (invitation && isNewUser) {
-            // New user: created directly in the invited team, auto-accept and proceed
+            // New user with an invitation: created directly in the invited team, auto-accept and proceed
             await acceptInvitation(invitation.token);
         } else if (invitation) {
-            // Existing user: let them explicitly accept or decline on the invite page
+            // Existing user with an invitation: let them explicitly accept or decline on the invite page
             destination = `/signup/${invitation.token}`;
         } else if (isNewUser) {
-            destination = '/onboarding/hear-about-us';
+            // New user without an invitation: redirect to account discovery onboarding
+            destination = '/onboarding/account-discovery';
         }
     } catch (err) {
         report(err);
@@ -216,7 +221,8 @@ export async function finalizeManagedAuthentication({
     }
 
     try {
-        if (await loginOrStartPendingMfa(req, user, destination)) {
+        const pendingMfa = await loginOrStartPendingMfa(req, user, destination);
+        if (pendingMfa) {
             respondWithSuccess(res, `${basePublicUrl}/signin/mfa`, responseMode);
             return;
         }

--- a/packages/server/lib/controllers/v1/account/managed/verification.integration.test.ts
+++ b/packages/server/lib/controllers/v1/account/managed/verification.integration.test.ts
@@ -127,7 +127,7 @@ describe(`POST ${route}`, () => {
         expect(postVerificationRes.res.status).toBe(200);
         expect(postVerificationRes.json).toStrictEqual({
             data: {
-                url: 'http://localhost:3003/onboarding/hear-about-us'
+                url: 'http://localhost:3003/onboarding/account-discovery'
             }
         });
 

--- a/packages/server/lib/controllers/v1/account/mfa/login.ts
+++ b/packages/server/lib/controllers/v1/account/mfa/login.ts
@@ -2,12 +2,12 @@ import db from '@nangohq/database';
 import { getFlags } from '@nangohq/feature-flags';
 import { accountService, mfaService, userService } from '@nangohq/shared';
 
+import { safeReturnTo } from '../returnTo.js';
+
 import type { DBUser, PostMFALoginVerification } from '@nangohq/types';
 import type { Request } from 'express';
 
 const MFA_LOGIN_TTL_MS = 10 * 60 * 1000;
-// Reserved TLD (RFC 2606) used only to resolve relative paths; a returnTo that escapes this origin is rejected.
-const RETURN_TO_BASE_ORIGIN = 'https://internal.invalid';
 
 type PendingMFALoginResult = { user: DBUser; returnTo: string } | { error: 'expired' | 'invalid' };
 
@@ -93,16 +93,4 @@ async function saveSession(req: Request): Promise<void> {
     await new Promise<void>((resolve, reject) => {
         req.session.save((err) => (err ? reject(err instanceof Error ? err : new Error(String(err))) : resolve()));
     });
-}
-
-function safeReturnTo(returnTo: string): string {
-    try {
-        const url = new URL(returnTo, RETURN_TO_BASE_ORIGIN);
-        if (url.origin === RETURN_TO_BASE_ORIGIN) {
-            return url.pathname + url.search + url.hash;
-        }
-    } catch {
-        // Malformed value; fall through to the safe default.
-    }
-    return '/';
 }

--- a/packages/server/lib/controllers/v1/account/onboarding/accountDiscoverySession.ts
+++ b/packages/server/lib/controllers/v1/account/onboarding/accountDiscoverySession.ts
@@ -1,0 +1,48 @@
+import type { Request } from 'express';
+
+const ACCOUNT_DISCOVERY_ONBOARDING_TTL_MS = 60 * 60 * 1000;
+
+export async function setAccountDiscoveryRecommendation(
+    req: Request,
+    userId: number,
+    recommendation: { accountId: number; accountName: string }
+): Promise<void> {
+    req.session.pendingAccountDiscovery = {
+        userId,
+        expiresAt: Date.now() + ACCOUNT_DISCOVERY_ONBOARDING_TTL_MS,
+        recommendation
+    };
+    await saveSession(req);
+}
+
+export async function getPendingAccountDiscovery(req: Request, userId: number) {
+    const discovery = req.session.pendingAccountDiscovery;
+    if (!discovery || discovery.userId !== userId) {
+        return null;
+    }
+
+    if (discovery.expiresAt <= Date.now()) {
+        await clearPendingAccountDiscovery(req);
+        return null;
+    }
+
+    return discovery;
+}
+
+export async function clearPendingAccountDiscovery(req: Request): Promise<void> {
+    delete req.session.pendingAccountDiscovery;
+    await saveSession(req);
+}
+
+async function saveSession(req: Request): Promise<void> {
+    await new Promise<void>((resolve, reject) => {
+        req.session.save((err) => {
+            if (err) {
+                reject(err instanceof Error ? err : new Error(String(err)));
+                return;
+            }
+
+            resolve();
+        });
+    });
+}

--- a/packages/server/lib/controllers/v1/account/onboarding/accountDiscoverySession.unit.test.ts
+++ b/packages/server/lib/controllers/v1/account/onboarding/accountDiscoverySession.unit.test.ts
@@ -1,0 +1,56 @@
+import { describe, expect, it, vi } from 'vitest';
+
+import { clearPendingAccountDiscovery, getPendingAccountDiscovery, setAccountDiscoveryRecommendation } from './accountDiscoverySession.js';
+
+import type { Request } from 'express';
+
+const createRequest = (pendingAccountDiscovery?: {
+    userId: number;
+    expiresAt: number;
+    recommendation?: { accountId: number; accountName: string };
+}): Request => {
+    const session = {
+        pendingAccountDiscovery,
+        save: vi.fn((callback: (error?: Error) => void) => callback())
+    };
+
+    return { session } as unknown as Request;
+};
+
+describe('account discovery onboarding session', () => {
+    it('stores the user-bound account recommendation in the server session', async () => {
+        const req = createRequest();
+        const recommendation = { accountId: 123, accountName: 'Example account' };
+
+        await setAccountDiscoveryRecommendation(req, 42, recommendation);
+
+        expect(req.session.pendingAccountDiscovery).toMatchObject({ userId: 42 });
+        expect(req.session.pendingAccountDiscovery?.expiresAt).toBeGreaterThan(Date.now());
+        expect(req.session.pendingAccountDiscovery?.recommendation).toStrictEqual(recommendation);
+        expect(req.session.save).toHaveBeenCalledOnce();
+    });
+
+    it('rejects a marker associated with another user', async () => {
+        const req = createRequest({ userId: 42, expiresAt: Date.now() + 60_000 });
+
+        await expect(getPendingAccountDiscovery(req, 7)).resolves.toBeNull();
+        expect(req.session.save).not.toHaveBeenCalled();
+    });
+
+    it('removes and persists an expired marker', async () => {
+        const req = createRequest({ userId: 42, expiresAt: Date.now() - 1 });
+
+        await expect(getPendingAccountDiscovery(req, 42)).resolves.toBeNull();
+        expect(req.session.pendingAccountDiscovery).toBeUndefined();
+        expect(req.session.save).toHaveBeenCalledOnce();
+    });
+
+    it('clears the marker after a discovery without a recommendation', async () => {
+        const req = createRequest({ userId: 42, expiresAt: Date.now() + 60_000 });
+
+        await clearPendingAccountDiscovery(req);
+
+        expect(req.session.pendingAccountDiscovery).toBeUndefined();
+        expect(req.session.save).toHaveBeenCalledOnce();
+    });
+});

--- a/packages/server/lib/controllers/v1/account/onboarding/getAccountDiscovery.integration.test.ts
+++ b/packages/server/lib/controllers/v1/account/onboarding/getAccountDiscovery.integration.test.ts
@@ -1,0 +1,74 @@
+import { afterAll, beforeAll, describe, expect, it } from 'vitest';
+
+import { accountService, userService } from '@nangohq/shared';
+import { nanoid } from '@nangohq/utils';
+
+import { runServer } from '../../../../utils/tests.js';
+
+const signupRoute = '/api/v1/account/signup';
+const signinRoute = '/api/v1/account/signin';
+const accountDiscoveryRoute = '/api/v1/account/onboarding/account-discovery';
+
+let api: Awaited<ReturnType<typeof runServer>>;
+
+describe(`GET ${accountDiscoveryRoute}`, () => {
+    beforeAll(async () => {
+        api = await runServer();
+    });
+
+    afterAll(() => {
+        api.server.close();
+    });
+
+    it('suggests an eligible same-domain account on the first account-discovery request after sign-in', async () => {
+        const domain = `${nanoid()}.example.com`;
+        const existingAccount = await accountService.createAccount({ name: 'Existing account', email: `admin@${domain}` });
+        expect(existingAccount).not.toBeNull();
+        const existingAdmin = await userService.createUser({
+            email: `admin@${domain}`,
+            name: 'Existing administrator',
+            account_id: existingAccount!.id,
+            email_verified: true,
+            role: 'administrator'
+        });
+        expect(existingAdmin).not.toBeNull();
+
+        const email = `new-user@${domain}`;
+        const signupRes = await api.fetch(signupRoute, {
+            method: 'POST',
+            body: { email, name: 'New user', password: 'aZ1-foobar!?', foundUs: 'tests' }
+        });
+        expect(signupRes.res.status).toBe(200);
+
+        const newUser = await userService.getUserByEmail(email);
+        expect(newUser).toBeTruthy();
+        await userService.verifyUserEmail(newUser!.id, { markAccountDiscoveryPending: true });
+
+        const verifiedUser = await userService.getUserById(newUser!.id, true);
+        expect(verifiedUser?.account_discovery_pending).toBe(true);
+
+        const signinRes = await api.fetch(signinRoute, {
+            method: 'POST',
+            body: { email, password: 'aZ1-foobar!?' }
+        });
+        expect(signinRes.res.status).toBe(200);
+        expect(signinRes.json).toMatchObject({ url: '/onboarding/account-discovery' });
+        const session = signinRes.res.headers.getSetCookie()[0]?.split(';')[0];
+        expect(session).toBeTruthy();
+
+        const signedInUser = await userService.getUserById(newUser!.id, true);
+        expect(signedInUser?.account_discovery_pending).toBe(true);
+
+        const discoveryRes = await api.fetch(accountDiscoveryRoute, { method: 'GET', session: session! });
+
+        expect(discoveryRes.res.status).toBe(200);
+        expect(discoveryRes.json).toStrictEqual({
+            data: {
+                suggestedAccountName: existingAccount!.name
+            }
+        });
+
+        const discoveredUser = await userService.getUserById(newUser!.id, true);
+        expect(discoveredUser?.account_discovery_pending).toBe(false);
+    });
+});

--- a/packages/server/lib/controllers/v1/account/onboarding/getAccountDiscovery.ts
+++ b/packages/server/lib/controllers/v1/account/onboarding/getAccountDiscovery.ts
@@ -1,0 +1,44 @@
+import { accountService, userService } from '@nangohq/shared';
+import { requireEmptyQuery, zodErrorToHTTP } from '@nangohq/utils';
+
+import { asyncWrapper } from '../../../../utils/asyncWrapper.js';
+import { getPendingAccountDiscovery, setAccountDiscoveryRecommendation } from './accountDiscoverySession.js';
+
+import type { GetOnboardingAccountDiscovery } from '@nangohq/types';
+
+export const getOnboardingAccountDiscovery = asyncWrapper<GetOnboardingAccountDiscovery>(async (req, res) => {
+    const emptyQuery = requireEmptyQuery(req, { withEnv: false });
+    if (emptyQuery) {
+        res.status(400).send({ error: { code: 'invalid_query_params', errors: zodErrorToHTTP(emptyQuery.error) } });
+        return;
+    }
+
+    const { user, account } = res.locals;
+
+    const discovery = await getPendingAccountDiscovery(req, user.id);
+    if (discovery?.recommendation) {
+        res.status(200).send({ data: { suggestedAccountName: discovery.recommendation.accountName } });
+        return;
+    }
+
+    if (!(await userService.consumeAccountDiscoveryPendingMarker(user.id))) {
+        res.status(404).send({ error: { code: 'not_found', message: 'Account discovery is only available during onboarding.' } });
+        return;
+    }
+
+    const suggestedAccount = await accountService.findAccountWithSameDomain({ email: user.email, currentAccountId: account.id });
+    if (!suggestedAccount) {
+        res.status(200).send({ data: { suggestedAccountName: null } });
+        return;
+    }
+
+    await setAccountDiscoveryRecommendation(req, user.id, { accountId: suggestedAccount.id, accountName: suggestedAccount.name });
+
+    res.status(200).send({
+        data: {
+            // Return the account name to render the suggestion in the browser.
+            // The account ID remains server-side for the join-request flow.
+            suggestedAccountName: suggestedAccount.name ?? null
+        }
+    });
+});

--- a/packages/server/lib/controllers/v1/account/putResetPassword.integration.test.ts
+++ b/packages/server/lib/controllers/v1/account/putResetPassword.integration.test.ts
@@ -11,6 +11,7 @@ const signupRoute = '/api/v1/account/signup';
 const signinRoute = '/api/v1/account/signin';
 const resetPasswordRoute = '/api/v1/account/reset-password';
 const userRoute = '/api/v1/user';
+const accountDiscoveryRoute = '/api/v1/account/onboarding/account-discovery';
 
 let api: Awaited<ReturnType<typeof runServer>>;
 
@@ -70,5 +71,9 @@ describe(`PUT ${resetPasswordRoute}`, () => {
         // every session is forcibly logged out (the reset flow is anonymous, so none is spared)
         expect((await api.fetch(userRoute, { method: 'GET', session: sessionA })).res.status).toBe(401);
         expect((await api.fetch(userRoute, { method: 'GET', session: sessionB })).res.status).toBe(401);
+
+        const recoveredSession = await signin(email, 'aZ1-newpass!?');
+        // password recovery must not make an existing user eligible for new-user account discovery.
+        expect((await api.fetch(accountDiscoveryRoute, { method: 'GET', session: recoveredSession })).res.status).toBe(404);
     });
 });

--- a/packages/server/lib/controllers/v1/account/returnTo.ts
+++ b/packages/server/lib/controllers/v1/account/returnTo.ts
@@ -1,0 +1,14 @@
+// Reserved TLD (RFC 2606) used only to resolve relative paths; a returnTo that escapes this origin is rejected.
+const RETURN_TO_BASE_ORIGIN = 'https://internal.invalid';
+
+export function safeReturnTo(returnTo: string): string {
+    try {
+        const url = new URL(returnTo, RETURN_TO_BASE_ORIGIN);
+        if (url.origin === RETURN_TO_BASE_ORIGIN) {
+            return url.pathname + url.search + url.hash;
+        }
+    } catch {
+        // Malformed value; fall through to the safe default.
+    }
+    return '/';
+}

--- a/packages/server/lib/controllers/v1/account/signin.integration.test.ts
+++ b/packages/server/lib/controllers/v1/account/signin.integration.test.ts
@@ -11,6 +11,7 @@ import type { DBUser } from '@nangohq/types';
 
 const signupRoute = '/api/v1/account/signup';
 const signinRoute = '/api/v1/account/signin';
+const accountDiscoveryRoute = '/api/v1/account/onboarding/account-discovery';
 
 let api: Awaited<ReturnType<typeof runServer>>;
 
@@ -95,11 +96,27 @@ describe(`POST ${signinRoute}`, () => {
 
         expect(res.status).toBe(200);
         isSuccess(json);
-        expect(json).toHaveProperty('user');
+        expect(json).toMatchObject({ user: { email: email.toLowerCase() }, url: '/' });
 
         const cookies = res.headers.getSetCookie();
         expect(cookies.length).toBeGreaterThan(0);
         expect(cookies[0]).toMatch(/^nango_session=/);
+    });
+
+    it('returns the requested returnTo for a pending user', async () => {
+        const { email, password } = await signupUser({ emailVerified: true });
+        const user = await userService.getUserByEmail(email);
+        expect(user).toBeTruthy();
+        await userService.update({ id: user!.id, account_discovery_pending: true });
+
+        const { res, json } = await api.fetch(signinRoute, {
+            method: 'POST',
+            body: { email, password, returnTo: '/integrations' }
+        });
+
+        expect(res.status).toBe(200);
+        isSuccess(json);
+        expect(json).toMatchObject({ url: '/integrations' });
     });
 
     it('requires MFA verification before issuing an authenticated session', async () => {
@@ -125,7 +142,7 @@ describe(`POST ${signinRoute}`, () => {
         expect(verification.json.data.user.email.toLowerCase()).toBe(email.toLowerCase());
     });
 
-    it('returns the requested returnTo after MFA verification', async () => {
+    it('returned url points to returnTo after MFA verification', async () => {
         const { email, password, totp } = await enrollMfaUser();
 
         const signinResponse = await api.fetch(signinRoute, { method: 'POST', body: { email, password, returnTo: '/integrations' } });
@@ -139,6 +156,51 @@ describe(`POST ${signinRoute}`, () => {
         expect(verification.res.status).toBe(200);
         isSuccess(verification.json);
         expect(verification.json.data.url).toBe('/integrations');
+    });
+
+    it('returned url points to returnTo after MFA verification even when account-discovery is pending', async () => {
+        const { email, password, user, totp } = await enrollMfaUser();
+        await userService.update({ id: user.id, account_discovery_pending: true });
+
+        const signinResponse = await api.fetch(signinRoute, { method: 'POST', body: { email, password, returnTo: '/integrations' } });
+        const pendingSession = signinResponse.res.headers.getSetCookie()[0]!.split(';')[0]!;
+
+        const verification = await api.fetch('/api/v1/account/mfa/login/verify', {
+            method: 'POST',
+            session: pendingSession,
+            body: { type: 'code', code: totp.generate({ timestamp: Date.now() + 30_000 }) }
+        });
+        expect(verification.res.status).toBe(200);
+        isSuccess(verification.json);
+        expect(verification.json.data.url).toBe('/integrations');
+
+        const signedInUser = await userService.getUserById(user.id, true);
+        expect(signedInUser?.account_discovery_pending).toBe(true);
+    });
+
+    it('returned url points to account-discovery after MFA, but only when account-discovery is pending and returnTo is unspecified', async () => {
+        const { email, password, user, totp } = await enrollMfaUser();
+        await userService.update({ id: user.id, account_discovery_pending: true });
+
+        const signinResponse = await api.fetch(signinRoute, { method: 'POST', body: { email, password } });
+        const pendingSession = signinResponse.res.headers.getSetCookie()[0]!.split(';')[0]!;
+
+        const verification = await api.fetch('/api/v1/account/mfa/login/verify', {
+            method: 'POST',
+            session: pendingSession,
+            body: { type: 'code', code: totp.generate({ timestamp: Date.now() + 30_000 }) }
+        });
+        expect(verification.res.status).toBe(200);
+        isSuccess(verification.json);
+        expect(verification.json.data.url).toBe('/onboarding/account-discovery');
+
+        const session = verification.res.headers.getSetCookie()[0]?.split(';')[0];
+        expect(session).toBeTruthy();
+        const discoveryRes = await api.fetch(accountDiscoveryRoute, { method: 'GET', session: session! });
+        expect(discoveryRes.res.status).toBe(200);
+
+        const discoveredUser = await userService.getUserById(user.id, true);
+        expect(discoveredUser?.account_discovery_pending).toBe(false);
     });
 
     it('sanitizes unsafe returnTo values to root', async () => {

--- a/packages/server/lib/controllers/v1/account/signin.ts
+++ b/packages/server/lib/controllers/v1/account/signin.ts
@@ -6,9 +6,10 @@ import { requireEmptyQuery, zodErrorToHTTP } from '@nangohq/utils';
 import { userToAPI } from '../../../formatters/user.js';
 import { asyncWrapper } from '../../../utils/asyncWrapper.js';
 import { loginOrStartPendingMfa } from './mfa/login.js';
+import { safeReturnTo } from './returnTo.js';
 
 import type { RequestLocals } from '../../../utils/express.js';
-import type { PostSignin } from '@nangohq/types';
+import type { DBUser, PostSignin } from '@nangohq/types';
 import type { RequestHandler, Response } from 'express';
 
 const validation = z
@@ -18,6 +19,11 @@ const validation = z
         returnTo: z.string().max(1024).optional()
     })
     .strict();
+
+function resolvePostLoginDestination(user: DBUser, returnTo?: string): string {
+    const destination = safeReturnTo(returnTo ?? '/');
+    return destination === '/' && user.account_discovery_pending ? '/onboarding/account-discovery' : destination;
+}
 
 export const validateSigninRequest: RequestHandler = (req, res, next) => {
     const emptyQuery = requireEmptyQuery(req);
@@ -61,10 +67,12 @@ export const signin = asyncWrapper<PostSignin>(async (req, res: Response<any, Re
         return;
     }
 
-    if (await loginOrStartPendingMfa(req, user, req.body.returnTo ?? '/')) {
+    const destination = resolvePostLoginDestination(user, req.body.returnTo);
+    const pendingMfa = await loginOrStartPendingMfa(req, user, destination);
+    if (pendingMfa) {
         res.status(200).send({ data: { mfaRequired: true } });
         return;
     }
 
-    res.status(200).send({ user: userToAPI(user) });
+    res.status(200).send({ user: userToAPI(user), url: destination });
 });

--- a/packages/server/lib/express.d.ts
+++ b/packages/server/lib/express.d.ts
@@ -37,6 +37,14 @@ declare module 'express-session' {
             returnTo: string;
             createdAt: number;
         };
+        pendingAccountDiscovery?: {
+            userId: number;
+            expiresAt: number;
+            recommendation?: {
+                accountId: number;
+                accountName: string;
+            };
+        };
     }
 }
 

--- a/packages/server/lib/middleware/access.middleware.ts
+++ b/packages/server/lib/middleware/access.middleware.ts
@@ -40,6 +40,7 @@ const ignoreEnvPaths = [
     '/api/v1/signin',
     '/api/v1/invite/:id',
     '/api/v1/account/onboarding/hear-about-us',
+    '/api/v1/account/onboarding/account-discovery',
     '/api/v1/account/mfa',
     '/api/v1/account/mfa/enroll',
     '/api/v1/account/mfa/activate',

--- a/packages/server/lib/middleware/audit.auth.private.integration.test.ts
+++ b/packages/server/lib/middleware/audit.auth.private.integration.test.ts
@@ -329,7 +329,7 @@ describe('audit — auth flows', () => {
 
             const res = await fetch(`${api.url}/api/v1/login/callback?code=oauth_code_123`, { redirect: 'manual' });
             expect(res.status).toBe(302);
-            expect(res.headers.get('location')).toBe('http://localhost:3003/onboarding/hear-about-us');
+            expect(res.headers.get('location')).toBe('http://localhost:3003/onboarding/account-discovery');
 
             const user = await userService.getUserByEmail(email);
             expect(user).not.toBeNull();

--- a/packages/server/lib/routes.private.ts
+++ b/packages/server/lib/routes.private.ts
@@ -16,6 +16,7 @@ import {
     confirmEmail,
     getEmailByExpiredToken,
     getEmailByUuid,
+    getOnboardingAccountDiscovery,
     getOnboardingHearAboutUs,
     postOnboardingHearAboutUs,
     resendVerificationEmailByEmail,
@@ -247,6 +248,7 @@ if (flagHasManagedAuth) {
 web.route('/meta').get(webAuth, getMeta);
 web.route('/account/onboarding/hear-about-us').get(webAuth, getOnboardingHearAboutUs);
 web.route('/account/onboarding/hear-about-us').post(webAuth, postOnboardingHearAboutUs);
+web.route('/account/onboarding/account-discovery').get(webAuth, getOnboardingAccountDiscovery);
 web.route('/account/mfa').get(webAuth, getMFAStatus).delete(webAuth, auditMfaDisabled, deleteMFA);
 web.route('/account/mfa/enroll').post(webAuth, auditMfaEnrolled, postMFAEnrollment);
 web.route('/account/mfa/activate').post(webAuth, auditMfaEnabled, postMFAActivation);

--- a/packages/shared/lib/services/user.service.ts
+++ b/packages/shared/lib/services/user.service.ts
@@ -128,6 +128,7 @@ class UserService {
         salt = '',
         account_id,
         email_verified,
+        account_discovery_pending = false,
         role = envs.DEFAULT_USER_ROLE
     }: {
         email: string;
@@ -136,6 +137,7 @@ class UserService {
         salt?: string;
         account_id: number;
         email_verified: boolean;
+        account_discovery_pending?: boolean;
         role?: DBUser['role'];
     }): Promise<DBUser | null> {
         const expires_at = new Date(new Date().getTime() + VERIFICATION_EMAIL_EXPIRATION);
@@ -150,6 +152,7 @@ class UserService {
                 email_verified,
                 email_verification_token: email_verified ? null : uuid.v4(),
                 email_verification_token_expires_at: email_verified ? null : expires_at,
+                account_discovery_pending,
                 role
             })
             .returning('id');
@@ -175,8 +178,25 @@ class UserService {
         }
     }
 
-    async verifyUserEmail(id: number) {
-        return db.knex.from<DBUser>(`_nango_users`).where({ id }).update({ email_verified: true, email_verification_token: null });
+    async verifyUserEmail(id: number, { markAccountDiscoveryPending = false }: { markAccountDiscoveryPending?: boolean } = {}) {
+        return db.knex
+            .from<DBUser>(`_nango_users`)
+            .where({ id })
+            .update({
+                email_verified: true,
+                email_verification_token: null,
+                ...(markAccountDiscoveryPending && { account_discovery_pending: true })
+            });
+    }
+
+    async consumeAccountDiscoveryPendingMarker(id: number): Promise<boolean> {
+        const updated = await db.knex
+            .from<DBUser>(`_nango_users`)
+            .where({ id, account_discovery_pending: true })
+            .update({ account_discovery_pending: false, updated_at: new Date() })
+            .returning('id');
+
+        return updated.length === 1;
     }
 
     async update({ id, ...data }: { id: number } & Omit<Partial<DBUser>, 'id'>, trx: Knex = db.knex): Promise<DBUser | null> {

--- a/packages/types/lib/account/api.ts
+++ b/packages/types/lib/account/api.ts
@@ -37,10 +37,7 @@ export type ConfirmEmail = ApiEndpoint<{
     };
     Error: ApiError<'error_validating_user'> | ApiError<'invalid_token'> | ApiError<'token_expired'>;
     Success: {
-        email: string;
-        userId: number;
-        accountId: number;
-        showHearAboutUs?: boolean;
+        user: ApiUser;
     };
 }>;
 
@@ -101,7 +98,7 @@ export type PostSignin = ApiEndpoint<{
         returnTo?: string;
     };
     Error: ApiError<'email_not_verified'> | ApiError<'user_suspended'> | ApiError<'unauthorized'>;
-    Success: { user: ApiUser } | { data: { mfaRequired: true } };
+    Success: { user: ApiUser; url: string } | { data: { mfaRequired: true } };
 }>;
 
 export type PostLogout = ApiEndpoint<{
@@ -210,6 +207,18 @@ export type GetOnboardingHearAboutUs = ApiEndpoint<{
     Success: {
         data: {
             showHearAboutUs: boolean;
+        };
+    };
+}>;
+
+export type GetOnboardingAccountDiscovery = ApiEndpoint<{
+    Audit: { kind: 'no-audit'; reason: 'non-auditable' };
+    Method: 'GET';
+    Path: '/api/v1/account/onboarding/account-discovery';
+    Error: ApiError<'forbidden'>;
+    Success: {
+        data: {
+            suggestedAccountName: string | null;
         };
     };
 }>;

--- a/packages/types/lib/api.endpoints.ts
+++ b/packages/types/lib/api.endpoints.ts
@@ -4,6 +4,7 @@ import type {
     GetEmailByUuid,
     GetManagedCallback,
     GetManagedEmailVerification,
+    GetOnboardingAccountDiscovery,
     PostForgotPassword,
     PostLogout,
     PostManagedEmailVerification,
@@ -238,6 +239,7 @@ export type PrivateApiEndpoints =
     | GetEmailByUuid
     | GetManagedCallback
     | GetManagedEmailVerification
+    | GetOnboardingAccountDiscovery
     | PatchFlowDisable
     | PatchFlowEnable
     | PatchFlowFrequency

--- a/packages/types/lib/user/db.ts
+++ b/packages/types/lib/user/db.ts
@@ -17,5 +17,6 @@ export interface DBUser extends Timestamps {
     email_verification_token_expires_at: Date | null;
     uuid: string;
     getting_started_closed: boolean;
+    account_discovery_pending: boolean;
     role: Role;
 }

--- a/packages/webapp/src/app/router.tsx
+++ b/packages/webapp/src/app/router.tsx
@@ -33,6 +33,7 @@ import { Templates } from '@/pages/Integrations/providerConfigKey/Templates';
 import { IntegrationsList } from '@/pages/Integrations/Show';
 import { LogsShow } from '@/pages/Logs/Show';
 import { NotFound } from '@/pages/NotFound';
+import { AccountDiscovery } from '@/pages/Onboarding/AccountDiscovery';
 import { HearAboutUs } from '@/pages/Onboarding/HearAboutUs';
 import { Root } from '@/pages/Root';
 import { TeamBilling } from '@/pages/Team/Billing/Show';
@@ -160,6 +161,10 @@ export const router = sentryCreateBrowserRouter([
             {
                 path: '/onboarding/hear-about-us',
                 element: <HearAboutUs />
+            },
+            {
+                path: '/onboarding/account-discovery',
+                element: <AccountDiscovery />
             },
             {
                 path: '/team-settings',

--- a/packages/webapp/src/hooks/useAuth.tsx
+++ b/packages/webapp/src/hooks/useAuth.tsx
@@ -5,6 +5,7 @@ import { APIError, apiFetch } from '@/utils/api';
 import type {
     GetEmailByUuid,
     GetManagedEmailVerification,
+    GetOnboardingAccountDiscovery,
     GetOnboardingHearAboutUs,
     PostForgotPassword,
     PostManagedEmailVerification,
@@ -326,6 +327,22 @@ export function useOnboardingHearAboutUs() {
 
             if (res.status === 200) {
                 return (await res.json()) as GetOnboardingHearAboutUs['Success'];
+            }
+
+            const json = (await res.json()) as Record<string, unknown>;
+            throw new APIError({ res, json });
+        }
+    });
+}
+
+export function useOnboardingAccountDiscovery() {
+    return useQuery<GetOnboardingAccountDiscovery['Success'], APIError>({
+        queryKey: ['account', 'onboarding', 'account-discovery'],
+        queryFn: async () => {
+            const res = await apiFetch('/api/v1/account/onboarding/account-discovery');
+
+            if (res.status === 200) {
+                return (await res.json()) as GetOnboardingAccountDiscovery['Success'];
             }
 
             const json = (await res.json()) as Record<string, unknown>;

--- a/packages/webapp/src/pages/Account/EmailVerified.tsx
+++ b/packages/webapp/src/pages/Account/EmailVerified.tsx
@@ -7,7 +7,6 @@ import { Button } from '@nangohq/design-system';
 import { Alert, AlertDescription } from '@/components/ui/Alert';
 import { useToast } from '@/hooks/useToast';
 import DefaultLayout from '@/layout/DefaultLayout';
-import { useStore } from '../../store';
 import { track } from '../../utils/analytics';
 import { apiFetch } from '../../utils/api';
 
@@ -19,8 +18,6 @@ export const EmailVerified: React.FC = () => {
     const { token } = useParams<{ token: string }>();
     const navigate = useNavigate();
     const { toast } = useToast();
-
-    const env = useStore((state) => state.env);
 
     const confirmEmail = async () => {
         if (!token) {
@@ -57,13 +54,12 @@ export const EmailVerified: React.FC = () => {
             }
 
             const confirmation: ConfirmEmail['Success'] = response;
-            track('web:account_signup', { user_id: confirmation.userId, accountId: confirmation.accountId });
+            track('web:account_signup', { user_id: confirmation.user.id, accountId: confirmation.user.accountId });
             toast({ title: 'Email verified successfully!', variant: 'success' });
 
-            const redirectPath = confirmation.showHearAboutUs ? '/onboarding/hear-about-us' : `/${env}/getting-started`;
-            navigate(`/signin?next=${encodeURIComponent(redirectPath)}`, {
+            navigate(`/signin?next=${encodeURIComponent('/onboarding/account-discovery')}`, {
                 replace: true,
-                state: { email: confirmation.email }
+                state: { email: confirmation.user.email }
             });
         } catch {
             setErrorMessage('An error occurred while verifying the email. Please try again.');

--- a/packages/webapp/src/pages/Account/Signin.tsx
+++ b/packages/webapp/src/pages/Account/Signin.tsx
@@ -27,22 +27,6 @@ const signinSchema = z.object({
 
 type SigninFormData = z.infer<typeof signinSchema>;
 
-// Resolve against the current origin and reject anything that escapes it, so a crafted `next` can't become an open redirect.
-function safeInternalPath(path: string | null): string {
-    if (!path) {
-        return '/';
-    }
-    try {
-        const url = new URL(path, window.location.origin);
-        if (url.origin === window.location.origin) {
-            return url.pathname + url.search + url.hash;
-        }
-    } catch {
-        // Malformed value; fall through to the safe default.
-    }
-    return '/';
-}
-
 export const Signin: React.FC = () => {
     const hasLocalAuth = globalEnv.features.auth;
     const hasManagedAuth = globalEnv.features.managedAuth;
@@ -96,7 +80,7 @@ export const Signin: React.FC = () => {
                 }
                 const user: ApiUser = res.json.user;
                 signin(user);
-                navigate(safeInternalPath(next));
+                navigate(res.json.url);
             } else if (res.status === 401) {
                 setServerErrorMessage('Invalid email or password.');
                 form.resetField('password', { defaultValue: '' });

--- a/packages/webapp/src/pages/Onboarding/AccountDiscovery.tsx
+++ b/packages/webapp/src/pages/Onboarding/AccountDiscovery.tsx
@@ -1,0 +1,58 @@
+import { useEffect } from 'react';
+import { useNavigate } from 'react-router-dom';
+
+import { Button } from '@nangohq/design-system';
+
+import { Separator } from '@/components/ui/Separator';
+import { Skeleton } from '@/components/ui/Skeleton';
+import { useOnboardingAccountDiscovery } from '@/hooks/useAuth';
+import DefaultLayout from '@/layout/DefaultLayout';
+
+const hearAboutUsRoute = '/onboarding/hear-about-us';
+
+export const AccountDiscovery: React.FC = () => {
+    const navigate = useNavigate();
+    const { data, isLoading, error } = useOnboardingAccountDiscovery();
+
+    useEffect(() => {
+        if (error) {
+            navigate(hearAboutUsRoute, { replace: true });
+            return;
+        }
+
+        if (data && !data.data.suggestedAccountName) {
+            // If there are no recommendations, redirect the user to hear-about-us:
+            navigate(hearAboutUsRoute, { replace: true });
+        }
+    }, [data, error, navigate]);
+
+    if (isLoading || !data?.data.suggestedAccountName) {
+        return (
+            <DefaultLayout>
+                <div className="mx-auto mt-16 flex max-w-xl flex-col gap-4">
+                    <Skeleton className="h-8 w-3/4" />
+                    <Skeleton className="h-5 w-full" />
+                    <Skeleton className="h-10 w-64" />
+                </div>
+            </DefaultLayout>
+        );
+    }
+
+    return (
+        <DefaultLayout className="gap-10">
+            <h1 className="text-center text-text-strong text-title-group">Your team is already on Nango!</h1>
+            <div className="flex flex-col items-center gap-5">
+                <p className="text-center text-text-muted text-body-base">
+                    <strong className="text-text-strong">{data.data.suggestedAccountName}</strong>
+                </p>
+                <Button variant="outline" size="lg">
+                    Request to join
+                </Button>
+            </div>
+            <Separator />
+            <span className="cursor-pointer text-center text-text-strong underline hover:text-text-secondary" onClick={() => navigate(hearAboutUsRoute)}>
+                Continue with my new account
+            </span>
+        </DefaultLayout>
+    );
+};

--- a/packages/webapp/src/utils/routes.ts
+++ b/packages/webapp/src/utils/routes.ts
@@ -1,4 +1,12 @@
-export const NON_ENV_PATH_PREFIXES = ['/onboarding/hear-about-us', '/account-settings', '/team-settings', '/user-settings', '/team/billing', '/team/audit'];
+export const NON_ENV_PATH_PREFIXES = [
+    '/onboarding/hear-about-us',
+    '/onboarding/account-discovery',
+    '/account-settings',
+    '/team-settings',
+    '/user-settings',
+    '/team/billing',
+    '/team/audit'
+];
 
 export const isNonEnvPath = (pathname: string): boolean => {
     // Direct non-env path: /team-settings, /team/billing, etc.


### PR DESCRIPTION
Add a short-lived, server-side account-discovery marker for newly created password and managed-auth users. The discovery flow finds and caches the best same-domain account recommendation while exposing only its name to the client.

Keep marker persistence best-effort so discovery failures never block signup. No-match, rejection, and discovery-error paths fall back to the existing hear-about-us onboarding guard.

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/NangoHQ/nango/pull/6879?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

