### PR TITLE
fix(webapp): match paid usage header to free plan

### DIFF
--- a/packages/webapp/src/pages/Team/Billing/Show.tsx
+++ b/packages/webapp/src/pages/Team/Billing/Show.tsx
@@ -1,32 +1,18 @@
-import { useEffect, useState } from 'react';
+import { useEffect } from 'react';
 import { Helmet } from 'react-helmet';
 import { useLocation } from 'react-router-dom';
 
 import { permissions } from '@nangohq/authz';
 
 import { Separator } from '@/components/ui/Separator';
-import { useEnvironment } from '@/hooks/useEnvironment';
 import { usePermissions } from '@/hooks/usePermissions';
-import { useStore } from '@/store';
 import { track } from '@/utils/analytics';
 import DashboardLayout from '../../../layout/DashboardLayout';
-import { MonthSelector } from './components/MonthSelector';
 import { Payment } from './components/Payment';
 import { Plans } from './components/Plans';
 import { Usage } from './components/Usage';
 
 export const TeamBilling: React.FC = () => {
-    const [selectedMonth, setSelectedMonth] = useState<Date>(() => {
-        const now = new Date();
-        return new Date(now.getUTCFullYear(), now.getUTCMonth(), 1);
-    });
-
-    const env = useStore((state) => state.env);
-    const { data: environmentData } = useEnvironment(env);
-    // Free renders its own month selector in the caps table header, so the shared page-header
-    // selector is hidden to avoid two competing pickers.
-    const isFreePlan = environmentData?.plan?.name === 'free';
-
     const { can } = usePermissions();
     const canManageBilling = can(permissions.canManageBilling);
 
@@ -57,15 +43,8 @@ export const TeamBilling: React.FC = () => {
             {/* max-w: the old 1280 cap plus the 228px (184px side panel + 44px gap) the tabbed
                 NavigationList side panel used to take up, now that the sections stack instead */}
             <div className="flex flex-col gap-8 max-w-[1508px]">
-                {!isFreePlan && (
-                    <header className="flex justify-end items-center">
-                        <div className="flex items-center gap-4">
-                            <MonthSelector onMonthChange={setSelectedMonth} />
-                        </div>
-                    </header>
-                )}
                 <div id="usage">
-                    <Usage selectedMonth={selectedMonth} />
+                    <Usage />
                 </div>
                 <Separator />
                 <div id="plans" className="flex flex-col gap-4">

--- a/packages/webapp/src/pages/Team/Billing/components/MonthSelector.tsx
+++ b/packages/webapp/src/pages/Team/Billing/components/MonthSelector.tsx
@@ -1,5 +1,5 @@
 import { ChevronLeft, ChevronRight } from 'lucide-react';
-import { useEffect, useMemo } from 'react';
+import { useMemo } from 'react';
 
 import { IconButton } from '@nangohq/design-system';
 
@@ -10,23 +10,14 @@ import { useSelectedMonth } from '../useSelectedMonth';
 
 const EARLIEST_USAGE_MONTH_LABEL = new Date(EARLIEST_USAGE_MONTH_MS).toLocaleDateString('en-US', { month: 'long', year: 'numeric', timeZone: 'UTC' });
 
-interface MonthSelectorProps {
-    /** Notified whenever the selected month changes (backed by the shared `?month` param). */
-    onMonthChange?: (month: Date) => void;
-}
-
 /**
  * Month selector backed by the shared `?month` param (`useSelectedMonth`): chevron buttons flanking
  * a fixed-width month label (so the arrows don't shift between months), with the disabled "previous"
- * button surfacing the earliest-month tooltip. Used in both the paid usage page header and the Free
- * caps table header.
+ * button surfacing the earliest-month tooltip. Used in the usage section header on both Free and
+ * paid plans.
  */
-export const MonthSelector: React.FC<MonthSelectorProps> = ({ onMonthChange }) => {
+export const MonthSelector: React.FC = () => {
     const { selectedMonth, setSelectedMonth, canGoNext, canGoPrevious } = useSelectedMonth();
-
-    useEffect(() => {
-        onMonthChange?.(selectedMonth);
-    }, [selectedMonth, onMonthChange]);
 
     const monthDisplay = useMemo(() => selectedMonth.toLocaleDateString('en-US', { month: 'long', year: 'numeric', timeZone: 'UTC' }), [selectedMonth]);
 

--- a/packages/webapp/src/pages/Team/Billing/components/Usage.tsx
+++ b/packages/webapp/src/pages/Team/Billing/components/Usage.tsx
@@ -8,7 +8,9 @@ import { useEnvironment } from '@/hooks/useEnvironment';
 import { useApiGetBillingUsage } from '@/hooks/usePlan';
 import { useStore } from '@/store';
 import { track } from '@/utils/analytics';
+import { useSelectedMonth } from '../useSelectedMonth';
 import { FreeUsage } from './FreeUsage';
+import { MonthSelector } from './MonthSelector';
 import { USAGE_METRIC_LABELS, USAGE_METRICS } from './usageMetrics';
 import { UsageTable } from './UsageTable';
 
@@ -18,12 +20,9 @@ import type { DBPlan } from '@nangohq/types';
 // Typed against `DBPlan['name']` so a renamed or removed plan fails to compile instead of silently drifting.
 const CURRENT_PLAN_NAMES: readonly DBPlan['name'][] = ['free', 'free-uncapped', 'startup-deal', 'enterprise-cloud-hosted', 'starter-v2', 'growth-v2'];
 
-interface UsageProps {
-    selectedMonth: Date;
-}
-
-export const Usage: React.FC<UsageProps> = ({ selectedMonth }) => {
+export const Usage: React.FC = () => {
     const env = useStore((state) => state.env);
+    const { selectedMonth } = useSelectedMonth();
     const { data: environmentData } = useEnvironment(env);
     const plan = environmentData?.plan;
     const isFree = plan?.name === 'free';
@@ -70,7 +69,7 @@ export const Usage: React.FC<UsageProps> = ({ selectedMonth }) => {
     }));
 
     return (
-        <div className="w-full flex flex-col gap-6">
+        <div className="w-full flex flex-col gap-4">
             {isLegacyPlan && (
                 <Alert variant="info">
                     <Info />
@@ -95,6 +94,11 @@ export const Usage: React.FC<UsageProps> = ({ selectedMonth }) => {
                     </AlertDescription>
                 </Alert>
             )}
+
+            <div className="flex justify-between items-center">
+                <span className="text-text-strong text-body-medium-medium">Usage</span>
+                <MonthSelector />
+            </div>
 
             <UsageTable rows={rows} isLoading={isLoading} env={env} timeframe={timeframe} chartMode="daily" showLimits={false} />
 


### PR DESCRIPTION
## Problem

Since the collapsible usage table landed for paid plans (#6861), the heading above it doesn't match the Free plan: no "Usage" title, and the month picker sits in a separate page-shell header with different spacing. There's no reason for the two plans to have different heading sections.

## Solution

- Paid/legacy plans now render the same header row as Free ("Usage" title left, month selector right, same `gap-4` spacing) inside the usage section.
- `Usage` reads the month from the shared URL-backed `useSelectedMonth` hook instead of a prop, so the page shell drops its paid-only header, `selectedMonth` state, and the `MonthSelector` `onMonthChange` prop.

## Testing

- `ts-build` and lint pass.
- Verified in the browser against the dev API with a paid (`startup-deal`) account: header matches the Free layout, and stepping months updates the table data. Free plan path (`FreeUsage`) is untouched.

<img width="1511" height="667" alt="image" src="https://github.com/user-attachments/assets/72c9c951-fb7b-4ece-86e4-6f335ce8812d" />

