### PR TITLE
feat(auth): cache the persist auth context in-process

### DIFF
--- a/packages/shared/lib/services/account.service.integration.test.ts
+++ b/packages/shared/lib/services/account.service.integration.test.ts
@@ -4,6 +4,7 @@ import { afterEach, beforeAll, describe, expect, it, vi } from 'vitest';
 import db, { multipleMigrations } from '@nangohq/database';
 import { metrics } from '@nangohq/utils';
 
+import { envs } from '../env.js';
 import { createAccount as createTestAccount } from '../seeders/account.seeder.js';
 import { seedAccountEnvAndUser } from '../seeders/global.seeder.js';
 import accountService from './account.service.js';
@@ -375,23 +376,43 @@ describe('Account service', () => {
             }
         });
 
-        it('should record a shadow-cache miss then hit without ever serving from the shadow cache', async () => {
-            const { env, secret } = await seedAccountEnvAndUser();
+        it('should serve from cache within the TTL when enabled', async () => {
+            const previous = envs.AUTH_PERSIST_CONTEXT_CACHE_ENABLED;
+            (envs as { AUTH_PERSIST_CONTEXT_CACHE_ENABLED: boolean }).AUTH_PERSIST_CONTEXT_CACHE_ENABLED = true;
             const incrementSpy = vi.spyOn(metrics, 'increment');
+            try {
+                const { env, secret } = await seedAccountEnvAndUser();
 
-            // First lookup: nothing seen yet -> miss
+                // First lookup: miss -> resolved from the DB and cached
+                const first = (await accountService.getPersistAuthContext(secret.secret)).unwrap();
+                expect(first?.environment.id).toBe(env.id);
+                expect(incrementSpy).toHaveBeenCalledWith(metrics.Types.AUTH_CONTEXT_CACHE, 1, { cache: 'persist_internal_secret', result: 'miss' });
+
+                // Break the DB row; a cache hit must still resolve, proving it is served from the cache
+                await db.knex('api_secrets').where({ environment_id: env.id }).update({ hashed: uuid() });
+                incrementSpy.mockClear();
+
+                const second = (await accountService.getPersistAuthContext(secret.secret)).unwrap();
+                expect(incrementSpy).toHaveBeenCalledWith(metrics.Types.AUTH_CONTEXT_CACHE, 1, { cache: 'persist_internal_secret', result: 'hit' });
+                expect(second).toStrictEqual(first);
+            } finally {
+                (envs as { AUTH_PERSIST_CONTEXT_CACHE_ENABLED: boolean }).AUTH_PERSIST_CONTEXT_CACHE_ENABLED = previous;
+            }
+        });
+
+        it('should not cache when disabled (default)', async () => {
+            expect(envs.AUTH_PERSIST_CONTEXT_CACHE_ENABLED).toBe(false);
+            const incrementSpy = vi.spyOn(metrics, 'increment');
+            const { env, secret } = await seedAccountEnvAndUser();
+
             const first = (await accountService.getPersistAuthContext(secret.secret)).unwrap();
             expect(first?.environment.id).toBe(env.id);
-            expect(incrementSpy).toHaveBeenCalledWith(metrics.Types.AUTH_SHADOW_CACHE, 1, { cache: 'persist_internal_secret', result: 'miss' });
 
-            // Break the DB row: a real cache would still serve the stale context, the shadow must not
+            // With caching off, the next lookup goes to the (now broken) DB and returns null
             await db.knex('api_secrets').where({ environment_id: env.id }).update({ hashed: uuid() });
-            incrementSpy.mockClear();
-
-            // Second lookup within the TTL: recorded as a hit, but the value comes from the DB (now broken) -> null
             const second = (await accountService.getPersistAuthContext(secret.secret)).unwrap();
-            expect(incrementSpy).toHaveBeenCalledWith(metrics.Types.AUTH_SHADOW_CACHE, 1, { cache: 'persist_internal_secret', result: 'hit' });
             expect(second).toBeNull();
+            expect(incrementSpy).not.toHaveBeenCalledWith(metrics.Types.AUTH_CONTEXT_CACHE, 1, expect.anything());
         });
     });
 

--- a/packages/shared/lib/services/account.service.ts
+++ b/packages/shared/lib/services/account.service.ts
@@ -30,27 +30,18 @@ const logger = getLogger('AccountService');
  * from the auth context — the value is only a TTL timestamp.
  */
 class ShadowAuthCache {
-    private seenAtNs = new FixedSizeMap<string, bigint>(10_000);
-    private readonly ttlNs: bigint;
+    private seen: TTLFixedSizeMap<string, true>;
 
     constructor(
         private readonly name: string,
         ttlMs: number
     ) {
-        this.ttlNs = BigInt(ttlMs) * 1_000_000n;
+        this.seen = new TTLFixedSizeMap(10_000, ttlMs);
     }
 
-    /** Emits hit/miss for this hash, evicting the entry when its TTL has passed. */
+    /** Emits hit/miss for this hash. Expired entries are evicted on read by the underlying map. */
     wouldHit(hash: string): boolean {
-        const seenAt = this.seenAtNs.get(hash);
-        let hit = false;
-        if (seenAt !== undefined) {
-            if (process.hrtime.bigint() - seenAt < this.ttlNs) {
-                hit = true;
-            } else {
-                this.seenAtNs.delete(hash);
-            }
-        }
+        const hit = this.seen.get(hash) !== undefined;
         metrics.increment(metrics.Types.AUTH_SHADOW_CACHE, 1, { cache: this.name, result: hit ? 'hit' : 'miss' });
         return hit;
     }
@@ -58,7 +49,7 @@ class ShadowAuthCache {
     /** Marks a successful lookup as would-be-cached. Skips fresh entries so their TTL is not extended. */
     populate(hash: string, wasHit: boolean): void {
         if (!wasHit) {
-            this.seenAtNs.set(hash, process.hrtime.bigint());
+            this.seen.set(hash, true);
         }
     }
 }

--- a/packages/shared/lib/services/account.service.ts
+++ b/packages/shared/lib/services/account.service.ts
@@ -1,5 +1,5 @@
 import db from '@nangohq/database';
-import { Err, FixedSizeMap, flagHasPlan, getLogger, isCloud, metrics, Ok, report } from '@nangohq/utils';
+import { Err, FixedSizeMap, flagHasPlan, getLogger, isCloud, metrics, Ok, report, TTLFixedSizeMap } from '@nangohq/utils';
 
 import { envs } from '../env.js';
 import { LogActionEnum } from '../models/Telemetry.js';
@@ -63,8 +63,38 @@ class ShadowAuthCache {
     }
 }
 
-const persistAuthShadowCache = new ShadowAuthCache('persist_internal_secret', envs.AUTH_SHADOW_CACHE_TTL_MS);
 const customerKeyShadowCache = new ShadowAuthCache('customer_key', envs.AUTH_SHADOW_CACHE_TTL_MS);
+
+/**
+ * In-process cache of the persist auth context, keyed by the secret's hash. The cached
+ * PersistAuthContext holds no secret material (account/environment ids, environment name,
+ * and a few plan fields), so the only trade-off is staleness: a served entry can be up to
+ * the TTL old, delaying visibility of revoked keys, deleted environments, and plan changes.
+ * Enable/disable and TTL are configured via AUTH_PERSIST_CONTEXT_CACHE_* (see parse.ts).
+ */
+class PersistAuthContextCache {
+    // TTL is a startup config; the enabled flag is read per-call so it can be toggled at runtime.
+    private cache = new TTLFixedSizeMap<string, PersistAuthContext>(10_000, envs.AUTH_PERSIST_CONTEXT_CACHE_TTL_MS);
+
+    get(hash: string): PersistAuthContext | undefined {
+        if (!envs.AUTH_PERSIST_CONTEXT_CACHE_ENABLED) {
+            return undefined;
+        }
+        const cached = this.cache.get(hash);
+        metrics.increment(metrics.Types.AUTH_CONTEXT_CACHE, 1, { cache: 'persist_internal_secret', result: cached ? 'hit' : 'miss' });
+        return cached;
+    }
+
+    set(hash: string, context: PersistAuthContext): void {
+        if (!envs.AUTH_PERSIST_CONTEXT_CACHE_ENABLED) {
+            return;
+        }
+        // The cached instance is shared across requests; callers must not mutate it.
+        this.cache.set(hash, context);
+    }
+}
+
+const persistAuthContextCache = new PersistAuthContextCache();
 
 interface AccountContext {
     account: DBTeam;
@@ -741,7 +771,11 @@ class AccountService {
         }
 
         const hash = await this.hashSecretWithCache(secretKey);
-        const wouldHit = persistAuthShadowCache.wouldHit(hash);
+
+        const cached = persistAuthContextCache.get(hash);
+        if (cached) {
+            return cached;
+        }
 
         const row = await db.readOnly
             .select<{
@@ -774,8 +808,7 @@ class AccountService {
 
         // Store only successful lookups to avoid polluting the cache
         hashLocalCache.set(secretKey, hash);
-        persistAuthShadowCache.populate(hash, wouldHit);
-        return {
+        const context: PersistAuthContext = {
             account: { id: row.account_id },
             environment: { id: row.environment_id, name: row.environment_name },
             plan:
@@ -783,6 +816,8 @@ class AccountService {
                     ? { id: row.plan_id, name: row.plan_name, records_store: row.records_store }
                     : null
         };
+        persistAuthContextCache.set(hash, context);
+        return context;
     }
 
     /**

--- a/packages/utils/lib/environment/parse.ts
+++ b/packages/utils/lib/environment/parse.ts
@@ -27,7 +27,7 @@ export const ENVS = z.object({
     // Cached entries are served for up to this long, so revoked keys, deleted environments, and plan
     // changes stay visible until it elapses. Avoid raising it beyond 1 minute unless strictly
     // necessary — a larger TTL widens that eventual-consistency window. Read once at startup.
-    AUTH_PERSIST_CONTEXT_CACHE_TTL_MS: z.coerce.number().int().positive().optional().default(60_000), // 1 minute
+    AUTH_PERSIST_CONTEXT_CACHE_TTL_MS: z.coerce.number().int().positive().max(60_000).optional().default(60_000), // 1 minute
 
     // API
     NANGO_PORT: z.coerce.number().optional().default(3003), // Sync those two ports?

--- a/packages/utils/lib/environment/parse.ts
+++ b/packages/utils/lib/environment/parse.ts
@@ -22,6 +22,12 @@ export const ENVS = z.object({
     AUTH_ALLOW_SIGNUP: z.stringbool().optional().default(true),
     DEFAULT_USER_ROLE: z.enum(roles).optional().default('administrator'),
     AUTH_SHADOW_CACHE_TTL_MS: z.coerce.number().int().positive().optional().default(60_000), // 1 minute
+    // In-process cache of the persist auth context (persist internal-secret route).
+    AUTH_PERSIST_CONTEXT_CACHE_ENABLED: z.stringbool().optional().default(false),
+    // Cached entries are served for up to this long, so revoked keys, deleted environments, and plan
+    // changes stay visible until it elapses. Avoid raising it beyond 1 minute unless strictly
+    // necessary — a larger TTL widens that eventual-consistency window. Read once at startup.
+    AUTH_PERSIST_CONTEXT_CACHE_TTL_MS: z.coerce.number().int().positive().optional().default(60_000), // 1 minute
 
     // API
     NANGO_PORT: z.coerce.number().optional().default(3003), // Sync those two ports?

--- a/packages/utils/lib/map.ts
+++ b/packages/utils/lib/map.ts
@@ -69,3 +69,43 @@ export class FixedSizeMap<K, V> {
         return this.map.size;
     }
 }
+
+/**
+ * A FixedSizeMap whose entries also expire after a TTL.
+ *
+ * Expiry uses a monotonic clock, so wall-clock jumps cannot extend or shorten
+ * an entry's life. Expired entries are evicted on read.
+ */
+export class TTLFixedSizeMap<K, V> {
+    private map: FixedSizeMap<K, { value: V; setAtNs: bigint }>;
+    private ttlNs: bigint;
+
+    constructor(maxSize: number, ttlMs: number) {
+        if (!Number.isFinite(ttlMs) || ttlMs < 0) {
+            throw new Error('ttlMs must be a finite, non-negative number.');
+        }
+        this.map = new FixedSizeMap(maxSize);
+        // trunc: BigInt() throws on non-integers
+        this.ttlNs = BigInt(Math.trunc(ttlMs)) * 1_000_000n;
+    }
+
+    get(key: K): V | undefined {
+        const entry = this.map.get(key);
+        if (!entry) {
+            return undefined;
+        }
+        if (process.hrtime.bigint() - entry.setAtNs >= this.ttlNs) {
+            this.map.delete(key);
+            return undefined;
+        }
+        return entry.value;
+    }
+
+    set(key: K, value: V): void {
+        this.map.set(key, { value, setAtNs: process.hrtime.bigint() });
+    }
+
+    get size(): number {
+        return this.map.size;
+    }
+}

--- a/packages/utils/lib/map.ts
+++ b/packages/utils/lib/map.ts
@@ -84,6 +84,9 @@ export class TTLFixedSizeMap<K, V> {
         if (!Number.isFinite(ttlMs) || ttlMs < 0) {
             throw new Error('ttlMs must be a finite, non-negative number.');
         }
+        if (!Number.isInteger(maxSize) || maxSize <= 0) {
+            throw new Error('maxSize must be a positive integer.');
+        }
         this.map = new FixedSizeMap(maxSize);
         // trunc: BigInt() throws on non-integers
         this.ttlNs = BigInt(Math.trunc(ttlMs)) * 1_000_000n;

--- a/packages/utils/lib/map.unit.test.ts
+++ b/packages/utils/lib/map.unit.test.ts
@@ -1,6 +1,6 @@
-import { describe, expect, it } from 'vitest';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 
-import { FixedSizeMap } from './map.js';
+import { FixedSizeMap, TTLFixedSizeMap } from './map.js';
 
 describe('FixedSizeMap', () => {
     describe('basic operations', () => {
@@ -192,5 +192,61 @@ describe('FixedSizeMap', () => {
             expect(map.has('key3')).toBe(false); // evicted
             expect(map.has('key4')).toBe(true);
         });
+    });
+});
+
+describe('TTLFixedSizeMap', () => {
+    beforeEach(() => {
+        vi.useFakeTimers({ toFake: ['hrtime'] });
+    });
+
+    afterEach(() => {
+        vi.useRealTimers();
+    });
+
+    it('should throw on invalid TTL', () => {
+        expect(() => new TTLFixedSizeMap<string, number>(10, NaN)).toThrow('ttlMs must be a finite, non-negative number.');
+        expect(() => new TTLFixedSizeMap<string, number>(10, Infinity)).toThrow('ttlMs must be a finite, non-negative number.');
+        expect(() => new TTLFixedSizeMap<string, number>(10, -1)).toThrow('ttlMs must be a finite, non-negative number.');
+    });
+
+    it('should return entries younger than the TTL', () => {
+        const map = new TTLFixedSizeMap<string, number>(10, 60_000);
+        map.set('a', 1);
+        vi.advanceTimersByTime(59_999);
+        expect(map.get('a')).toBe(1);
+    });
+
+    it('should return undefined for missing keys', () => {
+        const map = new TTLFixedSizeMap<string, number>(10, 60_000);
+        expect(map.get('missing')).toBeUndefined();
+    });
+
+    it('should expire and evict entries once the TTL elapses', () => {
+        const map = new TTLFixedSizeMap<string, number>(10, 60_000);
+        map.set('a', 1);
+        vi.advanceTimersByTime(60_000);
+        expect(map.get('a')).toBeUndefined();
+        expect(map.size).toBe(0);
+    });
+
+    it('should reset the TTL when an entry is rewritten', () => {
+        const map = new TTLFixedSizeMap<string, number>(10, 60_000);
+        map.set('a', 1);
+        vi.advanceTimersByTime(50_000);
+        map.set('a', 2);
+        vi.advanceTimersByTime(30_000);
+        expect(map.get('a')).toBe(2);
+    });
+
+    it('should evict the least recently written entry at capacity', () => {
+        const map = new TTLFixedSizeMap<string, number>(2, 60_000);
+        map.set('a', 1);
+        map.set('b', 2);
+        map.set('c', 3);
+        expect(map.get('a')).toBeUndefined();
+        expect(map.get('b')).toBe(2);
+        expect(map.get('c')).toBe(3);
+        expect(map.size).toBe(2);
     });
 });

--- a/packages/utils/lib/telemetry/metrics.ts
+++ b/packages/utils/lib/telemetry/metrics.ts
@@ -7,6 +7,7 @@ export enum Types {
 
     AUTH_SECRET_KEY_HASH_CACHE = 'nango.auth.secretKeyHashCache',
     AUTH_SHADOW_CACHE = 'nango.auth.shadowCache',
+    AUTH_CONTEXT_CACHE = 'nango.auth.contextCache',
     AUTH_GET_ENV_BY_CONNECT_SESSION = 'nango.auth.getEnvByConnectSession',
     AUTH_GET_ENV_BY_SECRET_KEY = 'nango.auth.getEnvBySecretKey',
     AUTH_GET_ENV_BY_SECRET_KEY_SOURCE = 'nango.auth.getEnvBySecretKey.source',


### PR DESCRIPTION
- Promotes the persist internal-secret auth path from shadow measurement to a real in-process cache. `getPersistAuthContext` now serves the resolved `PersistAuthContext` from a per-process TTL cache keyed by the secret hash, eliminating the auth DB lookup on hits.
- **Off by default**, enable/disable via `AUTH_PERSIST_CONTEXT_CACHE_ENABLED`; TTL via `AUTH_PERSIST_CONTEXT_CACHE_TTL_MS` (default **1 minute**). The TTL comment warns against raising it beyond a minute unless strictly necessary, since a larger TTL widens the eventual-consistency window.
- Adds `TTLFixedSizeMap` to `@nangohq/utils` (size-bounded + monotonic-clock TTL, evict-on-read) with unit tests.
- **Customer-key auth is intentionally left shadow-only** (not cached) in this PR.

## Why this is safe

The measurement PR (#6858) recorded a **99.56%** hit ratio on this path over a representative window — nearly every persist auth lookup is a repeat within a minute — so the DB saving is large and real.

- **Security**: the cached `PersistAuthContext` is the pruned context — account id, environment id/name, and a few plan fields. **No secret material.** It is strictly less sensitive than the existing `hashLocalCache`, which already holds raw secret keys as map keys.
- **Staleness**: the only trade-off. A served entry can be up to the TTL old, so revoked keys, deleted environments, and plan changes take up to 1 minute to become visible on a given pod. At 1 minute this is a defensible posture; the config comment discourages widening it.

## Behaviour

Keyed on the secret hash; populated only on successful lookups (unknown keys are never cached and continue to fail fast); a fresh entry's TTL is not extended on a hit; entries are evicted on read once expired. Emits `nango.auth.contextCache{cache: persist_internal_secret, result}` so the live hit ratio is observable. When disabled, the path behaves exactly as today (DB lookup every request, no metric).

## Test plan

- [x] `TTLFixedSizeMap` unit tests (TTL expiry/eviction, reset-on-rewrite, capacity, invalid TTL)
- [x] Integration: enabled → second lookup within TTL is served from cache (proven by breaking the DB row between calls and still resolving); disabled → the broken DB row makes the second lookup return null (nothing cached)
- [x] Verified the enabled test goes red if the cache read is disabled
- [x] Build + account-service and persist integration suites green; lint/prettier clean
- [ ] Deploy off, then enable in prod and watch `nango.auth.contextCache` hit ratio + the `api_secrets` auth query rate drop, persist auth errors flat

## Follow-ups

- Customer-key path (heavy query, ~88% measured hit ratio) can get the same treatment in a separate PR — note it debounces `last_used_at`, so caching hits would refresh that ~once per TTL per key.
- The persist half of the shadow cache (#6858) is now redundant and can be removed once this lands.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/NangoHQ/nango/pull/6886?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

