### PR TITLE
chore(auth): remove the persist-light-auth-context rollout flag

### DIFF
--- a/packages/feature-flags/lib/flags.ts
+++ b/packages/feature-flags/lib/flags.ts
@@ -30,15 +30,6 @@ export function buildFlags(client: FeatureFlagsClient) {
             return client.isEnabled('action-trace-manual-keep', { targetingKey: String(environmentId), environmentId }, false);
         },
         /**
-         * Whether persist auth resolves the minimal PersistAuthContext via the light
-         * lookup instead of the full account context query. No account is known before
-         * the lookup, so gradual rollout buckets per evaluation — use random stickiness.
-         * Default `false`.
-         */
-        shouldUseLightPersistAuthContext() {
-            return client.isEnabled('persist-light-auth-context', {}, false);
-        },
-        /**
          * Whether to send sync completion webhooks for this environment and provider.
          * Default `true`.
          */

--- a/packages/persist/lib/middleware/auth.middleware.ts
+++ b/packages/persist/lib/middleware/auth.middleware.ts
@@ -1,6 +1,5 @@
 import tracer from 'dd-trace';
 
-import { getFlags } from '@nangohq/feature-flags';
 import { accountService } from '@nangohq/shared';
 import { flagHasPlan, stringifyError, tagTraceUser } from '@nangohq/utils';
 
@@ -30,28 +29,19 @@ export const authMiddleware = async (req: Request, res: Response<any, AuthLocals
     }
 
     try {
-        // Rollout switch between two fully isolated auth paths: the legacy full
-        // account context lookup and the light PersistAuthContext one.
-        let accountContext: PersistAuthContext | null;
-        if (await getFlags().shouldUseLightPersistAuthContext()) {
-            const result = await tracer.trace('persist.middleware.auth.getPersistAuthContext', async (span) => {
-                const res = await accountService.getPersistAuthContext(secret);
-                if (res.isErr()) {
-                    // Err is returned, not thrown, so the span must be failed explicitly
-                    span?.setTag('error', res.error);
-                }
-                return res;
-            });
-            if (result.isErr()) {
-                res.status(401).json({ error: { code: 'unauthorized', message: `Unauthorized: ${stringifyError(result.error)}` } });
-                return;
+        const result = await tracer.trace('persist.middleware.auth.getPersistAuthContext', async (span) => {
+            const res = await accountService.getPersistAuthContext(secret);
+            if (res.isErr()) {
+                // Err is returned, not thrown, so the span must be failed explicitly
+                span?.setTag('error', res.error);
             }
-            accountContext = result.value;
-        } else {
-            accountContext = await tracer.trace('persist.middleware.auth.getAccountContextByApiKey', async () => {
-                return await accountService.getAccountContextByApiKey({ internalSecretKey: secret });
-            });
+            return res;
+        });
+        if (result.isErr()) {
+            res.status(401).json({ error: { code: 'unauthorized', message: `Unauthorized: ${stringifyError(result.error)}` } });
+            return;
         }
+        const accountContext = result.value;
         if (!accountContext) {
             res.status(401).json({ error: { code: 'unauthorized', message: `Unauthorized: Account not found` } });
             return;

--- a/packages/persist/lib/server.integration.test.ts
+++ b/packages/persist/lib/server.integration.test.ts
@@ -2,7 +2,6 @@ import fetch from 'node-fetch';
 import { afterAll, beforeAll, describe, expect, it, vi } from 'vitest';
 
 import db, { multipleMigrations } from '@nangohq/database';
-import { getFlags } from '@nangohq/feature-flags';
 import { logContextGetter, migrateLogsMapping } from '@nangohq/logs';
 import { records } from '@nangohq/records';
 import { formatRecords } from '@nangohq/records/lib/helpers/format.js';
@@ -52,7 +51,6 @@ describe('Persist API', () => {
         seed = await initDb();
         server.listen(port);
 
-        vi.spyOn(getFlags(), 'shouldUseLightPersistAuthContext').mockResolvedValue(true);
         vi.spyOn(accountService, 'getPersistAuthContext').mockImplementation((key) => {
             if (key === mockSecretKey) {
                 return Promise.resolve(
@@ -75,30 +73,6 @@ describe('Persist API', () => {
         const response = await fetch(`${serverUrl}/health`);
         expect(response.status).toEqual(200);
         expect(await response.json()).toEqual({ status: 'ok' });
-    });
-
-    it('should authenticate through the legacy lookup when the flag is off', async () => {
-        vi.mocked(getFlags().shouldUseLightPersistAuthContext).mockResolvedValueOnce(false);
-        const legacySpy = vi.spyOn(accountService, 'getAccountContextByApiKey').mockResolvedValueOnce({
-            account: seed.account,
-            environment: seed.env,
-            secret: seed.secret,
-            plan: seed.plan
-        });
-
-        const response = await fetch(`${serverUrl}/environment/${seed.env.id}/log`, {
-            method: 'POST',
-            body: JSON.stringify({
-                activityLogId: seed.activityLogId,
-                log: { type: 'log', level: 'info', message: 'Hello from the legacy path!', createdAt: new Date().toISOString() }
-            }),
-            headers: {
-                Authorization: `Bearer ${mockSecretKey}`,
-                'Content-Type': 'application/json'
-            }
-        });
-        expect(response.status).toEqual(204);
-        expect(legacySpy).toHaveBeenCalledOnce();
     });
 
     it('should log', async () => {


### PR DESCRIPTION
- The light `PersistAuthContext` lookup is fully rolled out (100%), so this removes the `persist-light-auth-context` feature flag and the now-dead legacy full-lookup branch in the persist auth middleware. Persist auth always resolves via `getPersistAuthContext`.
- Drops the `shouldUseLightPersistAuthContext` facade method from `@nangohq/feature-flags` and the flag mock + legacy-path test from the persist integration suite.

The `getPersistAuthContext` span is now always emitted (the conditional `getAccountContextByApiKey` span on this path is gone). `getAccountContextByApiKey` itself remains — it still serves the server's customer-key auth path.

## Test plan

- [x] Build + persist integration suite green (legacy-path test removed)
- [x] feature-flags unit suite green; no references to the flag remain in the codebase
- [ ] After merge: delete the `persist-light-auth-context` flag in Unleash

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/NangoHQ/nango/pull/6888?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

