### PR TITLE
feat(connect-ui): honor custom server websockets path

### DIFF
--- a/docs/guides/platform/self-hosting.mdx
+++ b/docs/guides/platform/self-hosting.mdx
@@ -405,7 +405,7 @@ import Nango from '@nangohq/frontend';
 let nango = new Nango({ host: 'https://<YOUR-NANGO-INSTANCE>', websocketsPath: '</YOUR-WEBSOCKETS-PATH>' });
 ```
 
-Connect UI discovers the custom path on its own (from the connect session), so `websocketsPath` only needs to be configured for direct `nango.auth()` calls. If Nango is served behind a reverse proxy under a sub-path, Connect UI opens the websocket on the public path composed of the `apiURL` base path and `NANGO_SERVER_WEBSOCKETS_PATH`, e.g. `wss://<HOST>/<API-BASE-PATH></YOUR-WEBSOCKETS-PATH>`.
+Connect UI discovers the custom path on its own (from the connect session), so `websocketsPath` only needs to be configured for direct `nango.auth()` calls. If Nango is served behind a reverse proxy under a sub-path, direct `nango.auth()` needs the full public path in `websocketsPath` (e.g. `/<API-BASE-PATH></YOUR-WEBSOCKETS-PATH>`) because the SDK resolves it from the origin, while Connect UI composes the public path automatically from the `apiURL` base path and `NANGO_SERVER_WEBSOCKETS_PATH`.
 
 ### Telemetry
 

--- a/docs/guides/platform/self-hosting.mdx
+++ b/docs/guides/platform/self-hosting.mdx
@@ -405,6 +405,8 @@ import Nango from '@nangohq/frontend';
 let nango = new Nango({ host: 'https://<YOUR-NANGO-INSTANCE>', websocketsPath: '</YOUR-WEBSOCKETS-PATH>' });
 ```
 
+Connect UI discovers the custom path on its own (from the connect session), so `websocketsPath` only needs to be configured for direct `nango.auth()` calls. If Nango is served behind a reverse proxy under a sub-path, Connect UI opens the websocket on the public path composed of the `apiURL` base path and `NANGO_SERVER_WEBSOCKETS_PATH`, e.g. `wss://<HOST>/<API-BASE-PATH></YOUR-WEBSOCKETS-PATH>`.
+
 ### Telemetry
 
 Self-hosted instances do not automatically send telemetry back to Nango. Operational metrics and logs stay within your own infrastructure and are only exported if you configure the OpenTelemetry Export add-on described above.

--- a/docs/llms-full.txt
+++ b/docs/llms-full.txt
@@ -7070,6 +7070,8 @@ import Nango from '@nangohq/frontend';
 let nango = new Nango({ host: 'https://<YOUR-NANGO-INSTANCE>', websocketsPath: '</YOUR-WEBSOCKETS-PATH>' });
 ```
 
+Connect UI discovers the custom path on its own (from the connect session), so `websocketsPath` only needs to be configured for direct `nango.auth()` calls. If Nango is served behind a reverse proxy under a sub-path, Connect UI opens the websocket on the public path composed of the `apiURL` base path and `NANGO_SERVER_WEBSOCKETS_PATH`, e.g. `wss://<HOST>/<API-BASE-PATH></YOUR-WEBSOCKETS-PATH>`.
+
 ### Telemetry
 
 Self-hosted instances do not automatically send telemetry back to Nango. Operational metrics and logs stay within your own infrastructure and are only exported if you configure the OpenTelemetry Export add-on described above.

--- a/docs/llms-full.txt
+++ b/docs/llms-full.txt
@@ -7070,7 +7070,7 @@ import Nango from '@nangohq/frontend';
 let nango = new Nango({ host: 'https://<YOUR-NANGO-INSTANCE>', websocketsPath: '</YOUR-WEBSOCKETS-PATH>' });
 ```
 
-Connect UI discovers the custom path on its own (from the connect session), so `websocketsPath` only needs to be configured for direct `nango.auth()` calls. If Nango is served behind a reverse proxy under a sub-path, Connect UI opens the websocket on the public path composed of the `apiURL` base path and `NANGO_SERVER_WEBSOCKETS_PATH`, e.g. `wss://<HOST>/<API-BASE-PATH></YOUR-WEBSOCKETS-PATH>`.
+Connect UI discovers the custom path on its own (from the connect session), so `websocketsPath` only needs to be configured for direct `nango.auth()` calls. If Nango is served behind a reverse proxy under a sub-path, direct `nango.auth()` needs the full public path in `websocketsPath` (e.g. `/<API-BASE-PATH></YOUR-WEBSOCKETS-PATH>`) because the SDK resolves it from the origin, while Connect UI composes the public path automatically from the `apiURL` base path and `NANGO_SERVER_WEBSOCKETS_PATH`.
 
 ### Telemetry
 

--- a/packages/connect-ui/src/lib/nango.ts
+++ b/packages/connect-ui/src/lib/nango.ts
@@ -13,7 +13,7 @@ import { useGlobal } from './store';
 export function buildWebsocketsPath(apiURL: string, serverWebsocketsPath?: string): string {
     const basePath = new URL(apiURL).pathname.replace(/\/+$/, '');
     const wsPath = serverWebsocketsPath || '/';
-    return `${basePath}${wsPath.startsWith('/') ? wsPath : `/${wsPath}`}`;
+    return basePath + (wsPath.startsWith('/') ? wsPath : `/${wsPath}`);
 }
 
 export function useNango() {

--- a/packages/connect-ui/src/lib/nango.ts
+++ b/packages/connect-ui/src/lib/nango.ts
@@ -21,7 +21,7 @@ export function useNango() {
     const setNango = useGlobal((state) => state.setNango);
     const nango = useGlobal((state) => state.nango);
     const apiURL = useGlobal((state) => state.apiURL);
-    const serverWebsocketsPath = useGlobal((state) => state.session?.websockets_path);
+    const serverWebsocketsPath = useGlobal((state) => state.session?.websocketsPath);
 
     // Create a singleton
     useEffect(() => {

--- a/packages/connect-ui/src/lib/nango.ts
+++ b/packages/connect-ui/src/lib/nango.ts
@@ -4,11 +4,24 @@ import Nango from '@nangohq/frontend';
 
 import { useGlobal } from './store';
 
+/**
+ * `Nango` resolves `websocketsPath` as an absolute path from the origin, which would silently
+ * drop any base path configured in `apiURL` (e.g. a self-hosted reverse-proxy prefix). Compose
+ * apiURL's own path with the server's websockets path (NANGO_SERVER_WEBSOCKETS_PATH, `/` when
+ * unset) so both the proxy prefix and a custom server path are honored.
+ */
+export function buildWebsocketsPath(apiURL: string, serverWebsocketsPath?: string): string {
+    const basePath = new URL(apiURL).pathname.replace(/\/+$/, '');
+    const wsPath = serverWebsocketsPath || '/';
+    return `${basePath}${wsPath.startsWith('/') ? wsPath : `/${wsPath}`}`;
+}
+
 export function useNango() {
     const sessionToken = useGlobal((state) => state.sessionToken);
     const setNango = useGlobal((state) => state.setNango);
     const nango = useGlobal((state) => state.nango);
     const apiURL = useGlobal((state) => state.apiURL);
+    const serverWebsocketsPath = useGlobal((state) => state.session?.websockets_path);
 
     // Create a singleton
     useEffect(() => {
@@ -20,13 +33,10 @@ export function useNango() {
             new Nango({
                 connectSessionToken: sessionToken,
                 host: apiURL,
-                // `Nango` resolves `websocketsPath` as an absolute path from the origin, which would
-                // silently drop any base path configured in `apiURL` (e.g. a self-hosted reverse-proxy
-                // prefix). Deriving it from apiURL's own path here keeps that prefix intact.
-                websocketsPath: `${new URL(apiURL).pathname.replace(/\/+$/, '')}/`
+                websocketsPath: buildWebsocketsPath(apiURL, serverWebsocketsPath)
             })
         );
-    }, [sessionToken]);
+    }, [sessionToken, apiURL, serverWebsocketsPath, setNango]);
 
     return nango;
 }

--- a/packages/connect-ui/src/lib/nango.unit.test.ts
+++ b/packages/connect-ui/src/lib/nango.unit.test.ts
@@ -1,0 +1,33 @@
+import { describe, expect, it } from 'vitest';
+
+import { buildWebsocketsPath } from './nango.js';
+
+describe('buildWebsocketsPath', () => {
+    it('defaults to the root path on a bare-origin apiURL', () => {
+        expect(buildWebsocketsPath('https://api.nango.dev')).toBe('/');
+    });
+
+    it('preserves a base path configured in apiURL', () => {
+        expect(buildWebsocketsPath('https://example.com/base/path')).toBe('/base/path/');
+    });
+
+    it('ignores a trailing slash in apiURL', () => {
+        expect(buildWebsocketsPath('https://example.com/base/path/')).toBe('/base/path/');
+    });
+
+    it('appends a custom server websockets path to the apiURL base path', () => {
+        expect(buildWebsocketsPath('https://example.com/base/path', '/ws')).toBe('/base/path/ws');
+    });
+
+    it('applies a custom server websockets path on a bare-origin apiURL', () => {
+        expect(buildWebsocketsPath('https://api.nango.dev', '/ws')).toBe('/ws');
+    });
+
+    it('treats the default server path "/" like an unset value', () => {
+        expect(buildWebsocketsPath('https://example.com/base/path', '/')).toBe('/base/path/');
+    });
+
+    it('normalizes a server path missing its leading slash', () => {
+        expect(buildWebsocketsPath('https://example.com/base/path', 'ws')).toBe('/base/path/ws');
+    });
+});

--- a/packages/server/lib/controllers/connect/getSession.integration.test.ts
+++ b/packages/server/lib/controllers/connect/getSession.integration.test.ts
@@ -86,7 +86,8 @@ describe(`GET ${endpoint}`, () => {
             data: {
                 endUser: { id: endUserId, email: 'a@b.com', display_name: null, tags: null, organization: null },
                 allowed_integrations: ['github'],
-                connectUISettings: connectUISettingsService.getDefaultConnectUISettings()
+                connectUISettings: connectUISettingsService.getDefaultConnectUISettings(),
+                websockets_path: '/'
             }
         });
         expect(res.res.status).toBe(200);
@@ -115,7 +116,8 @@ describe(`GET ${endpoint}`, () => {
             data: {
                 endUser: null,
                 allowed_integrations: ['github'],
-                connectUISettings: connectUISettingsService.getDefaultConnectUISettings()
+                connectUISettings: connectUISettingsService.getDefaultConnectUISettings(),
+                websockets_path: '/'
             }
         });
         expect(res.res.status).toBe(200);
@@ -144,7 +146,8 @@ describe(`GET ${endpoint}`, () => {
             data: {
                 endUser: null,
                 allowed_integrations: ['github'],
-                connectUISettings: connectUISettingsService.getDefaultConnectUISettings()
+                connectUISettings: connectUISettingsService.getDefaultConnectUISettings(),
+                websockets_path: '/'
             }
         });
         expect(res.res.status).toBe(200);
@@ -191,7 +194,8 @@ describe(`GET ${endpoint}`, () => {
             data: {
                 endUser: { id: endUserId, email: 'a@b.com', display_name: null, tags: null, organization: null },
                 allowed_integrations: ['github'],
-                connectUISettings: customConnectUISettings
+                connectUISettings: customConnectUISettings,
+                websockets_path: '/'
             }
         });
         expect(res.res.status).toBe(200);
@@ -236,7 +240,8 @@ describe(`GET ${endpoint}`, () => {
             data: {
                 endUser: { id: endUserId, email: 'a@b.com', display_name: null, tags: null, organization: null },
                 allowed_integrations: ['github'],
-                connectUISettings: connectUISettingsService.getDefaultConnectUISettings()
+                connectUISettings: connectUISettingsService.getDefaultConnectUISettings(),
+                websockets_path: '/'
             }
         });
         expect(res.res.status).toBe(200);

--- a/packages/server/lib/controllers/connect/getSession.integration.test.ts
+++ b/packages/server/lib/controllers/connect/getSession.integration.test.ts
@@ -1,4 +1,4 @@
-import { afterAll, beforeAll, describe, expect, it } from 'vitest';
+import { afterAll, afterEach, beforeAll, describe, expect, it, vi } from 'vitest';
 
 import db from '@nangohq/database';
 import { connectUISettingsService, seeders, updatePlan } from '@nangohq/shared';
@@ -17,6 +17,9 @@ describe(`GET ${endpoint}`, () => {
     });
     afterAll(() => {
         api.server.close();
+    });
+    afterEach(() => {
+        vi.unstubAllEnvs();
     });
 
     it('should be protected', async () => {
@@ -88,6 +91,39 @@ describe(`GET ${endpoint}`, () => {
                 allowed_integrations: ['github'],
                 connectUISettings: connectUISettingsService.getDefaultConnectUISettings(),
                 websockets_path: '/'
+            }
+        });
+        expect(res.res.status).toBe(200);
+    });
+
+    it('should get a session with the custom server websockets path when NANGO_SERVER_WEBSOCKETS_PATH is set', async () => {
+        vi.stubEnv('NANGO_SERVER_WEBSOCKETS_PATH', '/ws');
+
+        const { env, apiKey } = await seeders.seedAccountEnvAndUser();
+        await seeders.createConfigSeed(env, 'github', 'github');
+
+        // Create session
+        const endUserId = 'knownId';
+        const resCreate = await api.fetch('/connect/sessions', {
+            method: 'POST',
+            token: apiKey.secret,
+            body: { end_user: { id: endUserId, email: 'a@b.com' }, allowed_integrations: ['github'] }
+        });
+        isSuccess(resCreate.json);
+
+        // Get session
+        const res = await api.fetch(endpoint, {
+            method: 'GET',
+            token: resCreate.json.data.token
+        });
+
+        isSuccess(res.json);
+        expect(res.json).toStrictEqual<typeof res.json>({
+            data: {
+                endUser: { id: endUserId, email: 'a@b.com', display_name: null, tags: null, organization: null },
+                allowed_integrations: ['github'],
+                connectUISettings: connectUISettingsService.getDefaultConnectUISettings(),
+                websockets_path: '/ws'
             }
         });
         expect(res.res.status).toBe(200);

--- a/packages/server/lib/controllers/connect/getSession.integration.test.ts
+++ b/packages/server/lib/controllers/connect/getSession.integration.test.ts
@@ -90,7 +90,7 @@ describe(`GET ${endpoint}`, () => {
                 endUser: { id: endUserId, email: 'a@b.com', display_name: null, tags: null, organization: null },
                 allowed_integrations: ['github'],
                 connectUISettings: connectUISettingsService.getDefaultConnectUISettings(),
-                websockets_path: '/'
+                websocketsPath: '/'
             }
         });
         expect(res.res.status).toBe(200);
@@ -123,7 +123,7 @@ describe(`GET ${endpoint}`, () => {
                 endUser: { id: endUserId, email: 'a@b.com', display_name: null, tags: null, organization: null },
                 allowed_integrations: ['github'],
                 connectUISettings: connectUISettingsService.getDefaultConnectUISettings(),
-                websockets_path: '/ws'
+                websocketsPath: '/ws'
             }
         });
         expect(res.res.status).toBe(200);
@@ -153,7 +153,7 @@ describe(`GET ${endpoint}`, () => {
                 endUser: null,
                 allowed_integrations: ['github'],
                 connectUISettings: connectUISettingsService.getDefaultConnectUISettings(),
-                websockets_path: '/'
+                websocketsPath: '/'
             }
         });
         expect(res.res.status).toBe(200);
@@ -183,7 +183,7 @@ describe(`GET ${endpoint}`, () => {
                 endUser: null,
                 allowed_integrations: ['github'],
                 connectUISettings: connectUISettingsService.getDefaultConnectUISettings(),
-                websockets_path: '/'
+                websocketsPath: '/'
             }
         });
         expect(res.res.status).toBe(200);
@@ -231,7 +231,7 @@ describe(`GET ${endpoint}`, () => {
                 endUser: { id: endUserId, email: 'a@b.com', display_name: null, tags: null, organization: null },
                 allowed_integrations: ['github'],
                 connectUISettings: customConnectUISettings,
-                websockets_path: '/'
+                websocketsPath: '/'
             }
         });
         expect(res.res.status).toBe(200);
@@ -277,7 +277,7 @@ describe(`GET ${endpoint}`, () => {
                 endUser: { id: endUserId, email: 'a@b.com', display_name: null, tags: null, organization: null },
                 allowed_integrations: ['github'],
                 connectUISettings: connectUISettingsService.getDefaultConnectUISettings(),
-                websockets_path: '/'
+                websocketsPath: '/'
             }
         });
         expect(res.res.status).toBe(200);

--- a/packages/server/lib/controllers/connect/getSession.ts
+++ b/packages/server/lib/controllers/connect/getSession.ts
@@ -1,7 +1,7 @@
 import db from '@nangohq/database';
 import * as endUserService from '@nangohq/shared';
-import { connectUISettingsService } from '@nangohq/shared';
-import { report, requireEmptyBody, requireEmptyQuery, zodErrorToHTTP } from '@nangohq/utils';
+import { connectUISettingsService, getWebsocketsPath } from '@nangohq/shared';
+import { isCloud, report, requireEmptyBody, requireEmptyQuery, zodErrorToHTTP } from '@nangohq/utils';
 
 import { asyncWrapper } from '../../utils/asyncWrapper.js';
 
@@ -98,6 +98,9 @@ export const getConnectSession = asyncWrapper<GetConnectSession>(async (req, res
     }
     if (connectSession.overrides) {
         data.overrides = connectSession.overrides;
+    }
+    if (!isCloud) {
+        data.websockets_path = getWebsocketsPath();
     }
 
     res.status(200).send({ data });

--- a/packages/server/lib/controllers/connect/getSession.ts
+++ b/packages/server/lib/controllers/connect/getSession.ts
@@ -100,7 +100,7 @@ export const getConnectSession = asyncWrapper<GetConnectSession>(async (req, res
         data.overrides = connectSession.overrides;
     }
     if (!isCloud) {
-        data.websockets_path = getWebsocketsPath();
+        data.websocketsPath = getWebsocketsPath();
     }
 
     res.status(200).send({ data });

--- a/packages/server/lib/controllers/connect/getSession.unit.test.ts
+++ b/packages/server/lib/controllers/connect/getSession.unit.test.ts
@@ -1,0 +1,89 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+import { Ok } from '@nangohq/utils';
+
+import { getConnectSession } from './getSession.js';
+
+import type * as NangoUtils from '@nangohq/utils';
+import type { Request, Response } from 'express';
+
+const { mockGetConnectUISettings, mockGetDefaultConnectUISettings, mockGetWebsocketsPath } = vi.hoisted(() => {
+    return {
+        mockGetConnectUISettings: vi.fn(),
+        mockGetDefaultConnectUISettings: vi.fn(),
+        mockGetWebsocketsPath: vi.fn()
+    };
+});
+
+vi.mock('@nangohq/database', () => ({
+    default: { knex: {} }
+}));
+
+vi.mock('@nangohq/shared', () => ({
+    connectUISettingsService: {
+        getConnectUISettings: mockGetConnectUISettings,
+        getDefaultConnectUISettings: mockGetDefaultConnectUISettings
+    },
+    getWebsocketsPath: mockGetWebsocketsPath
+}));
+
+// isCloud is a module-level constant computed from process.env at import time, so it can't be
+// flipped with vi.stubEnv once @nangohq/utils has loaded; override it directly here instead.
+vi.mock('@nangohq/utils', async () => {
+    const actual: typeof NangoUtils = await vi.importActual('@nangohq/utils');
+
+    return {
+        ...actual,
+        isCloud: true
+    };
+});
+
+function buildReqRes() {
+    const req = {
+        query: {},
+        body: {},
+        route: { path: '/connect/session' },
+        originalUrl: '/connect/session',
+        header: vi.fn()
+    } as unknown as Request;
+    const status = vi.fn().mockReturnThis();
+    const send = vi.fn().mockReturnThis();
+    const res = {
+        locals: {
+            connectSession: {
+                endUserId: null,
+                endUser: null,
+                tags: { projectId: '123' },
+                allowedIntegrations: null,
+                integrationsConfigDefaults: null,
+                connectionId: null,
+                overrides: null
+            },
+            account: { id: 1 },
+            environment: { id: 1 },
+            plan: null
+        },
+        status,
+        send
+    } as unknown as Response;
+    return { req, res, status, send };
+}
+
+describe('getConnectSession', () => {
+    beforeEach(() => {
+        vi.clearAllMocks();
+        mockGetConnectUISettings.mockResolvedValue(Ok({ showWatermark: true, defaultTheme: 'system' }));
+        mockGetDefaultConnectUISettings.mockReturnValue({ showWatermark: true, defaultTheme: 'system' });
+        mockGetWebsocketsPath.mockReturnValue('/ws');
+    });
+
+    it('omits websockets_path on cloud, even if the server has a custom path configured', async () => {
+        const { req, res, send } = buildReqRes();
+
+        await getConnectSession(req, res, vi.fn());
+
+        expect(mockGetWebsocketsPath).not.toHaveBeenCalled();
+        const sent = send.mock.calls[0]?.[0] as { data: Record<string, unknown> } | undefined;
+        expect(sent?.data.websockets_path).toBeUndefined();
+    });
+});

--- a/packages/server/lib/controllers/connect/getSession.unit.test.ts
+++ b/packages/server/lib/controllers/connect/getSession.unit.test.ts
@@ -77,13 +77,13 @@ describe('getConnectSession', () => {
         mockGetWebsocketsPath.mockReturnValue('/ws');
     });
 
-    it('omits websockets_path on cloud, even if the server has a custom path configured', async () => {
+    it('omits websocketsPath on cloud, even if the server has a custom path configured', async () => {
         const { req, res, send } = buildReqRes();
 
         await getConnectSession(req, res, vi.fn());
 
         expect(mockGetWebsocketsPath).not.toHaveBeenCalled();
         const sent = send.mock.calls[0]?.[0] as { data: Record<string, unknown> } | undefined;
-        expect(sent?.data['websockets_path']).toBeUndefined();
+        expect(sent?.data['websocketsPath']).toBeUndefined();
     });
 });

--- a/packages/server/lib/controllers/connect/getSession.unit.test.ts
+++ b/packages/server/lib/controllers/connect/getSession.unit.test.ts
@@ -84,6 +84,6 @@ describe('getConnectSession', () => {
 
         expect(mockGetWebsocketsPath).not.toHaveBeenCalled();
         const sent = send.mock.calls[0]?.[0] as { data: Record<string, unknown> } | undefined;
-        expect(sent?.data.websockets_path).toBeUndefined();
+        expect(sent?.data['websockets_path']).toBeUndefined();
     });
 });

--- a/packages/types/lib/connect/api.ts
+++ b/packages/types/lib/connect/api.ts
@@ -47,7 +47,7 @@ export type ConnectSessionOutput = Omit<ConnectSessionInput, 'end_user' | 'organ
      * Server-side WebSocket upgrade path (NANGO_SERVER_WEBSOCKETS_PATH), sent on self-hosted
      * deployments so Connect UI opens its OAuth-result socket on the matching path.
      */
-    websockets_path?: string;
+    websocketsPath?: string;
 };
 
 export type PostConnectSessionsBody =

--- a/packages/types/lib/connect/api.ts
+++ b/packages/types/lib/connect/api.ts
@@ -43,6 +43,11 @@ export type ConnectSessionOutput = Omit<ConnectSessionInput, 'end_user' | 'organ
     endUser: ApiEndUser | null;
     isReconnecting?: boolean;
     connectUISettings: ConnectUISettings;
+    /**
+     * Server-side WebSocket upgrade path (NANGO_SERVER_WEBSOCKETS_PATH), sent on self-hosted
+     * deployments so Connect UI opens its OAuth-result socket on the matching path.
+     */
+    websockets_path?: string;
 };
 
 export type PostConnectSessionsBody =


### PR DESCRIPTION
## Problem

Self-hosters can set `NANGO_SERVER_WEBSOCKETS_PATH` to serve the OAuth-popup WebSocket on a dedicated path (e.g. `/ws`) so they can firewall it separately from the REST API. The dashboard and headless `nango.auth()` honor it, but Connect UI derives its socket path solely from `apiURL`'s pathname — so any non-root value silently breaks all Connect UI OAuth flows.

## Solution

Connect UI discovers the path on its own; no new customer-facing config.

- Expose `websockets_path` on `GET /connect/session` on self-hosted deployments (mirrors how the environment endpoint feeds the dashboard).
- Connect UI composes the socket path from `apiURL`'s base path plus the server path instead of hardcoding the trailing `/` — the default composes to the current behavior, so cloud and existing setups are unaffected, and a prefix-stripping reverse proxy resolves to `<apiURL path>/ws`.
- Document that Connect UI picks the setting up automatically in the self-hosting guide.

Fixes [NAN-6422](https://linear.app/nango/issue/NAN-6422)

## Testing

- Unit tests for the path composition and updated `getSession` integration tests (field asserted on all success cases).
- Verified live with `NANGO_SERVER_WEBSOCKETS_PATH=/ws` locally: upgrade on `/` is rejected, `/ws` acks, and a full Connect UI GitHub OAuth flow opens the popup and reaches the provider's authorize page.
