### PR TITLE
feat(auth): show per-member 2FA status on team settings

### DIFF
--- a/packages/server/lib/controllers/v1/team/getTeam.integration.test.ts
+++ b/packages/server/lib/controllers/v1/team/getTeam.integration.test.ts
@@ -46,6 +46,7 @@ describe(`GET ${route}`, () => {
             data: {
                 invitedUsers: [],
                 isAdminTeam: false,
+                mfaFeatureEnabled: false,
                 account: {
                     id: account.id,
                     name: account.name,
@@ -62,7 +63,8 @@ describe(`GET ${route}`, () => {
                         name: user.name,
                         uuid: user.uuid,
                         role: 'administrator',
-                        gettingStartedClosed: user.getting_started_closed
+                        gettingStartedClosed: user.getting_started_closed,
+                        mfaEnabled: false
                     }
                 ]
             }

--- a/packages/server/lib/controllers/v1/team/getTeam.ts
+++ b/packages/server/lib/controllers/v1/team/getTeam.ts
@@ -1,4 +1,5 @@
-import { listInvitations, userService } from '@nangohq/shared';
+import { getFlags } from '@nangohq/feature-flags';
+import { listInvitations, mfaService, userService } from '@nangohq/shared';
 import { requireEmptyQuery, zodErrorToHTTP } from '@nangohq/utils';
 
 import { envs } from '../../../env.js';
@@ -21,14 +22,18 @@ export const getTeam = asyncWrapper<GetTeam>(async (req, res) => {
     const users = await userService.getUsersByAccountId(account.id);
     const invitedUsers = await listInvitations({ accountId: account.id });
 
-    const usersFormatted = users.map(userToAPI);
+    const mfaFeatureEnabled = await getFlags().isMFAEnabled(account.uuid);
+    const mfaEnabledUserIds = mfaFeatureEnabled ? await mfaService.getEnabledUserIds(users.map((user) => user.id)) : new Set<number>();
+
+    const usersFormatted = users.map((user) => ({ ...userToAPI(user), mfaEnabled: mfaEnabledUserIds.has(user.id) }));
 
     res.status(200).send({
         data: {
             account: teamToApi(account),
             users: usersFormatted,
             invitedUsers: invitedUsers.map(invitationToApi),
-            isAdminTeam: account.uuid === envs.NANGO_ADMIN_UUID
+            isAdminTeam: account.uuid === envs.NANGO_ADMIN_UUID,
+            mfaFeatureEnabled
         }
     });
 });

--- a/packages/shared/lib/services/mfa.service.integration.test.ts
+++ b/packages/shared/lib/services/mfa.service.integration.test.ts
@@ -61,6 +61,25 @@ describe('MFA service', () => {
         expect(await mfaService.hasActiveFactor(user.id)).toBe(false);
     });
 
+    it('returns only the user ids with an active factor', async () => {
+        const account = await createAccount();
+        const enabledUser = await seedUser(account.id);
+        const enrolledOnlyUser = await seedUser(account.id);
+        const noFactorUser = await seedUser(account.id);
+
+        const enrollment = (await mfaService.startEnrollment(enabledUser.id, enabledUser.email)).unwrap();
+        const totp = OTPAuth.URI.parse(enrollment.otpauthUri) as OTPAuth.TOTP;
+        (await mfaService.activateEnrollment(enabledUser.id, totp.generate())).unwrap();
+
+        // enrolled but never activated, so not counted as enabled
+        (await mfaService.startEnrollment(enrolledOnlyUser.id, enrolledOnlyUser.email)).unwrap();
+
+        const enabledIds = await mfaService.getEnabledUserIds([enabledUser.id, enrolledOnlyUser.id, noFactorUser.id]);
+        expect(enabledIds).toEqual(new Set([enabledUser.id]));
+
+        expect(await mfaService.getEnabledUserIds([])).toEqual(new Set());
+    });
+
     it('returns encryption setup failures instead of rejecting', async () => {
         const failure = new Error('invalid encryption key');
         vi.spyOn(encryptionManager, 'getEncryptionManager').mockImplementation(() => {

--- a/packages/shared/lib/services/mfa.service.ts
+++ b/packages/shared/lib/services/mfa.service.ts
@@ -113,6 +113,15 @@ class MFAService {
         return Boolean(await this.getActiveFactor(userId));
     }
 
+    public async getEnabledUserIds(userIds: number[]): Promise<Set<number>> {
+        if (userIds.length === 0) {
+            return new Set();
+        }
+
+        const rows = await db.knex<DBMFAFactor>(FACTORS_TABLE).select('user_id').whereIn('user_id', userIds).whereNotNull('enabled_at');
+        return new Set(rows.map((row) => row.user_id));
+    }
+
     public async verifyTotp(userId: number, token: string): Promise<Result<boolean>> {
         try {
             const verified = await db.knex.transaction(async (trx) => {

--- a/packages/types/lib/team/api.ts
+++ b/packages/types/lib/team/api.ts
@@ -12,12 +12,18 @@ export type GetTeam = Endpoint<{
     Success: {
         data: {
             account: ApiTeam;
-            users: ApiUser[];
+            users: ApiTeamUser[];
             invitedUsers: ApiInvitation[];
             isAdminTeam: boolean;
+            // Whether MFA is available for this account. When false the dashboard hides per-member 2FA state.
+            mfaFeatureEnabled: boolean;
         };
     };
 }>;
+
+export interface ApiTeamUser extends ApiUser {
+    mfaEnabled: boolean;
+}
 
 export type ApiInvitation = Merge<Omit<DBInvitation, 'token'>, ApiTimestamps>;
 export type ApiTeam = Merge<DBTeam, ApiTimestamps>;

--- a/packages/webapp/src/pages/Team/components/TeamMembers.tsx
+++ b/packages/webapp/src/pages/Team/components/TeamMembers.tsx
@@ -22,7 +22,7 @@ import { useDeleteTeamUser, usePatchTeamUser, useTeam } from '../../../hooks/use
 import { useStore } from '../../../store';
 import { RoleSelect } from './RoleSelect';
 
-import type { ApiInvitation, ApiUser, Role } from '@nangohq/types';
+import type { ApiInvitation, ApiTeamUser, ApiUser, Role } from '@nangohq/types';
 
 const EditRoleDialog: React.FC<{ user: ApiUser; onClose: () => void }> = ({ user, onClose }) => {
     const env = useStore((state) => state.env);
@@ -89,7 +89,9 @@ export const TeamMembers: React.FC = () => {
 
     const [editingUser, setEditingUser] = useState<ApiUser | null>(null);
 
-    const allUsers: ((ApiUser & { is_invitation: false }) | (ApiInvitation & { is_invitation: true }))[] = useMemo(
+    const mfaFeatureEnabled = data?.data.mfaFeatureEnabled ?? false;
+
+    const allUsers: ((ApiTeamUser & { is_invitation: false }) | (ApiInvitation & { is_invitation: true }))[] = useMemo(
         () =>
             [
                 ...(data?.data.users || []).map((u) => ({ ...u, is_invitation: false as const })),
@@ -136,6 +138,7 @@ export const TeamMembers: React.FC = () => {
                             </div>
                         </TableHead>
                         <TableHead>Status</TableHead>
+                        {mfaFeatureEnabled && <TableHead>2FA</TableHead>}
                         <TableHead className="text-right">{/* Actions */}</TableHead>
                     </TableRow>
                 </TableHeader>
@@ -179,6 +182,18 @@ export const TeamMembers: React.FC = () => {
                                     </div>
                                 )}
                             </TableCell>
+
+                            {mfaFeatureEnabled && (
+                                <TableCell>
+                                    {user.is_invitation ? (
+                                        <span className="text-text-secondary">—</span>
+                                    ) : user.mfaEnabled ? (
+                                        <Badge variant="success">Enabled</Badge>
+                                    ) : (
+                                        <Badge variant="ghost">Disabled</Badge>
+                                    )}
+                                </TableCell>
+                            )}
 
                             <TableCell className="text-right">
                                 {me?.email === user.email ? null : (


### PR DESCRIPTION
## What

Adds a 2FA column to the team members table on the team settings page so admins can see at a glance which members have MFA enabled.

The column only shows for accounts where the `mfa` feature flag is on, since members can only enable 2FA when the feature is available for their account.

## Changes

**Backend**
- `mfaService.getEnabledUserIds(userIds)`: bulk lookup returning the set of user ids with an active factor, so the team endpoint avoids one query per member.
- `GET /api/v1/team` now returns `mfaEnabled` per user (via a dedicated `ApiTeamUser` type, leaving `ApiUser` and its many `userToAPI` callers untouched) plus a top-level `mfaFeatureEnabled` flag from the feature flag. When the flag is off the MFA lookup is skipped.

**Frontend**
- `TeamMembers.tsx` renders a "2FA" column when `mfaFeatureEnabled`. Active members show Enabled/Disabled, invited members show a neutral placeholder.


NAN-6425

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/NangoHQ/nango/pull/6894?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

