### PR TITLE
fix(auth): require explicit email confirmation before sign-in

### DIFF
--- a/packages/server/lib/controllers/v1/account/confirmEmail.integration.test.ts
+++ b/packages/server/lib/controllers/v1/account/confirmEmail.integration.test.ts
@@ -1,0 +1,90 @@
+import { afterAll, beforeAll, describe, expect, it } from 'vitest';
+
+import { userService } from '@nangohq/shared';
+import { nanoid } from '@nangohq/utils';
+
+import { runServer } from '../../../utils/tests.js';
+
+const confirmEmailRoute = '/api/v1/account/verify/code';
+const signinRoute = '/api/v1/account/signin';
+
+let api: Awaited<ReturnType<typeof runServer>>;
+
+async function signupUser() {
+    const email = `${nanoid()}@example.com`;
+    const password = 'aZ1-foobar!?';
+    const signupRes = await api.fetch('/api/v1/account/signup', {
+        method: 'POST',
+        body: { email, name: 'Foobar', password, foundUs: 'tests' }
+    });
+
+    expect(signupRes.res.status).toBe(200);
+
+    const user = await userService.getUserByEmail(email);
+    expect(user).toBeTruthy();
+    expect(user!.email_verification_token).toBeTruthy();
+
+    return { email, password, user: user! };
+}
+
+describe(`POST ${confirmEmailRoute}`, () => {
+    beforeAll(async () => {
+        api = await runServer();
+    });
+
+    afterAll(() => {
+        api.server.close();
+    });
+
+    it('verifies the email without creating a session', async () => {
+        const { email, password, user } = await signupUser();
+
+        const { res, json } = await api.fetch(confirmEmailRoute, {
+            method: 'POST',
+            body: { token: user.email_verification_token! }
+        });
+
+        expect(res.status).toBe(200);
+        expect(res.headers.getSetCookie()).toHaveLength(0);
+        expect(json).toMatchObject({ email, userId: user.id, accountId: user.account_id });
+
+        const verifiedUser = await userService.getUserById(user.id, true);
+        expect(verifiedUser?.email_verified).toBe(true);
+        expect(verifiedUser?.email_verification_token).toBeNull();
+
+        const signinRes = await api.fetch(signinRoute, { method: 'POST', body: { email, password } });
+        expect(signinRes.res.status).toBe(200);
+        expect(signinRes.res.headers.getSetCookie()[0]).toMatch(/^nango_session=/);
+    });
+
+    it('does not verify an expired token', async () => {
+        const { user } = await signupUser();
+        await userService.update({ id: user.id, email_verification_token_expires_at: new Date(Date.now() - 1_000) });
+
+        const { res, json } = await api.fetch(confirmEmailRoute, {
+            method: 'POST',
+            body: { token: user.email_verification_token! }
+        });
+
+        expect(res.status).toBe(400);
+        expect(json).toMatchObject({ error: { code: 'token_expired' } });
+
+        const unverifiedUser = await userService.getUserById(user.id, true);
+        expect(unverifiedUser?.email_verified).toBe(false);
+    });
+
+    it('does not verify an invalid token', async () => {
+        const { user } = await signupUser();
+
+        const { res, json } = await api.fetch(confirmEmailRoute, {
+            method: 'POST',
+            body: { token: 'invalid-token' }
+        });
+
+        expect(res.status).toBe(400);
+        expect(json).toMatchObject({ error: { code: 'invalid_token' } });
+
+        const unverifiedUser = await userService.getUserById(user.id, true);
+        expect(unverifiedUser?.email_verified).toBe(false);
+    });
+});

--- a/packages/server/lib/controllers/v1/account/confirmEmail.integration.test.ts
+++ b/packages/server/lib/controllers/v1/account/confirmEmail.integration.test.ts
@@ -11,7 +11,7 @@ const signinRoute = '/api/v1/account/signin';
 let api: Awaited<ReturnType<typeof runServer>>;
 
 async function signupUser() {
-    const email = `${nanoid()}@example.com`;
+    const email = `${nanoid().toLowerCase()}@example.com`;
     const password = 'aZ1-foobar!?';
     const signupRes = await api.fetch('/api/v1/account/signup', {
         method: 'POST',
@@ -59,11 +59,12 @@ describe(`POST ${confirmEmailRoute}`, () => {
 
     it('does not verify an expired token', async () => {
         const { user } = await signupUser();
+        const expiredToken = user.email_verification_token!;
         await userService.update({ id: user.id, email_verification_token_expires_at: new Date(Date.now() - 1_000) });
 
         const { res, json } = await api.fetch(confirmEmailRoute, {
             method: 'POST',
-            body: { token: user.email_verification_token! }
+            body: { token: expiredToken }
         });
 
         expect(res.status).toBe(400);
@@ -71,9 +72,26 @@ describe(`POST ${confirmEmailRoute}`, () => {
 
         const unverifiedUser = await userService.getUserById(user.id, true);
         expect(unverifiedUser?.email_verified).toBe(false);
+        expect(unverifiedUser?.email_verification_token).toBe(expiredToken);
+        expect(unverifiedUser?.email_verification_token_expires_at?.getTime()).toBeLessThan(Date.now());
     });
 
     it('does not verify an invalid token', async () => {
+        const { user } = await signupUser();
+
+        const { res, json } = await api.fetch(confirmEmailRoute, {
+            method: 'POST',
+            body: { token: '00000000-0000-4000-8000-000000000000' }
+        });
+
+        expect(res.status).toBe(400);
+        expect(json).toMatchObject({ error: { code: 'invalid_token' } });
+
+        const unverifiedUser = await userService.getUserById(user.id, true);
+        expect(unverifiedUser?.email_verified).toBe(false);
+    });
+
+    it('rejects a malformed token', async () => {
         const { user } = await signupUser();
 
         const { res, json } = await api.fetch(confirmEmailRoute, {
@@ -82,7 +100,7 @@ describe(`POST ${confirmEmailRoute}`, () => {
         });
 
         expect(res.status).toBe(400);
-        expect(json).toMatchObject({ error: { code: 'invalid_token' } });
+        expect(json).toMatchObject({ error: { code: 'invalid_body' } });
 
         const unverifiedUser = await userService.getUserById(user.id, true);
         expect(unverifiedUser?.email_verified).toBe(false);

--- a/packages/server/lib/controllers/v1/account/confirmEmail.ts
+++ b/packages/server/lib/controllers/v1/account/confirmEmail.ts
@@ -4,12 +4,11 @@ import db from '@nangohq/database';
 import { accountService, userService } from '@nangohq/shared';
 import { getLogger, requireEmptyQuery, zodErrorToHTTP } from '@nangohq/utils';
 
-import { userToAPI } from '../../../formatters/user.js';
 import { asyncWrapper } from '../../../utils/asyncWrapper.js';
 
-import type { ValidateEmailAndLogin } from '@nangohq/types';
+import type { ConfirmEmail } from '@nangohq/types';
 
-const logger = getLogger('Server.ValidateEmailAndLogin');
+const logger = getLogger('Server.ConfirmEmail');
 
 const validation = z
     .object({
@@ -17,7 +16,7 @@ const validation = z
     })
     .strict();
 
-export const validateEmailAndLogin = asyncWrapper<ValidateEmailAndLogin>(async (req, res) => {
+export const confirmEmail = asyncWrapper<ConfirmEmail>(async (req, res) => {
     const emptyQuery = requireEmptyQuery(req);
     if (emptyQuery) {
         res.status(400).send({ error: { code: 'invalid_query_params', errors: zodErrorToHTTP(emptyQuery.error) } });
@@ -44,7 +43,7 @@ export const validateEmailAndLogin = asyncWrapper<ValidateEmailAndLogin>(async (
             res.status(400).send({
                 error: {
                     code: 'token_expired',
-                    message: 'The token has expired. An email has been sent with a new token.'
+                    message: 'The token has expired.'
                 }
             });
         } else if (error.message === 'user_not_found') {
@@ -74,13 +73,5 @@ export const validateEmailAndLogin = asyncWrapper<ValidateEmailAndLogin>(async (
         showHearAboutUs = await accountService.shouldShowHearAboutUs(account);
     }
 
-    req.login(user, function (err) {
-        if (err) {
-            logger.error('Error logging in user');
-            res.status(500).send({ error: { code: 'error_logging_in', message: 'There was a problem logging in the user. Please reach out to support.' } });
-            return;
-        }
-
-        res.status(200).send({ user: userToAPI(user), showHearAboutUs });
-    });
+    res.status(200).send({ email: user.email, userId: user.id, accountId: user.account_id, showHearAboutUs });
 });

--- a/packages/server/lib/controllers/v1/account/confirmEmail.ts
+++ b/packages/server/lib/controllers/v1/account/confirmEmail.ts
@@ -12,7 +12,7 @@ const logger = getLogger('Server.ConfirmEmail');
 
 const validation = z
     .object({
-        token: z.string().min(6)
+        token: z.uuidv4()
     })
     .strict();
 

--- a/packages/server/lib/controllers/v1/account/index.ts
+++ b/packages/server/lib/controllers/v1/account/index.ts
@@ -4,6 +4,6 @@ export * from './resendVerificationEmailByUuid.js';
 export * from './resendVerificationEmailByEmail.js';
 export * from './signin.js';
 export * from './signup.js';
-export * from './validateEmailAndLogin.js';
+export * from './confirmEmail.js';
 export * from './onboarding/getHearAboutUs.js';
 export * from './onboarding/postHearAboutUs.js';

--- a/packages/server/lib/routes.private.ts
+++ b/packages/server/lib/routes.private.ts
@@ -13,6 +13,7 @@ import environmentController from './controllers/environment.controller.js';
 import flowController from './controllers/flow.controller.js';
 import syncController from './controllers/sync.controller.js';
 import {
+    confirmEmail,
     getEmailByExpiredToken,
     getEmailByUuid,
     getOnboardingHearAboutUs,
@@ -21,7 +22,6 @@ import {
     resendVerificationEmailByUuid,
     signin,
     signup,
-    validateEmailAndLogin,
     validateSigninRequest
 } from './controllers/v1/account/index.js';
 import { getManagedCallback } from './controllers/v1/account/managed/getCallback.js';
@@ -206,7 +206,7 @@ if (flagHasAuth) {
     web.route('/account/resend-verification-email/by-email').post(rateLimiterMiddleware, resendVerificationEmailByEmail);
     web.route('/account/email/:uuid').get(rateLimiterMiddleware, getEmailByUuid);
     web.route('/account/email/expired-token/:token').get(rateLimiterMiddleware, getEmailByExpiredToken);
-    web.route('/account/verify/code').post(rateLimiterMiddleware, validateEmailAndLogin);
+    web.route('/account/verify/code').post(rateLimiterMiddleware, confirmEmail);
 }
 
 if (flagHasManagedAuth) {

--- a/packages/types/lib/account/api.ts
+++ b/packages/types/lib/account/api.ts
@@ -27,21 +27,18 @@ export type PostSignup = ApiEndpoint<{
     };
 }>;
 
-export type ValidateEmailAndLogin = ApiEndpoint<{
+export type ConfirmEmail = ApiEndpoint<{
     Audit: { kind: 'no-audit'; reason: 'non-auditable' };
     Method: 'POST';
     Path: '/api/v1/account/verify/code';
     Body: {
         token: string;
     };
-    Error:
-        | ApiError<'error_logging_in'>
-        | ApiError<'error_validating_user'>
-        | ApiError<'invalid_token'>
-        | ApiError<'token_expired'>
-        | ApiError<'error_refreshing_token'>;
+    Error: ApiError<'error_validating_user'> | ApiError<'invalid_token'> | ApiError<'token_expired'>;
     Success: {
-        user: ApiUser;
+        email: string;
+        userId: number;
+        accountId: number;
         showHearAboutUs?: boolean;
     };
 }>;

--- a/packages/types/lib/api.endpoints.ts
+++ b/packages/types/lib/api.endpoints.ts
@@ -1,4 +1,5 @@
 import type {
+    ConfirmEmail,
     GetEmailByExpiredToken,
     GetEmailByUuid,
     GetManagedCallback,
@@ -189,6 +190,7 @@ export type PublicApiEndpoints =
 
 export type PrivateApiEndpoints =
     | GetAuditTrail
+    | ConfirmEmail
     | PostSignup
     | PostSignin
     | PostLogout

--- a/packages/webapp/src/pages/Account/EmailVerified.tsx
+++ b/packages/webapp/src/pages/Account/EmailVerified.tsx
@@ -1,80 +1,87 @@
-import { Loader2 } from 'lucide-react';
+import { CircleX } from 'lucide-react';
 import { useState } from 'react';
 import { useNavigate, useParams } from 'react-router-dom';
-import { useEffectOnce } from 'react-use';
-import { useSWRConfig } from 'swr';
 
+import { Button } from '@nangohq/design-system';
+
+import { Alert, AlertDescription } from '@/components/ui/Alert';
 import { useToast } from '@/hooks/useToast';
 import DefaultLayout from '@/layout/DefaultLayout';
 import { useStore } from '../../store';
 import { track } from '../../utils/analytics';
 import { apiFetch } from '../../utils/api';
-import { useSignin } from '../../utils/user';
 
-import type { GetUser, ValidateEmailAndLogin } from '@nangohq/types';
+import type { ConfirmEmail } from '@nangohq/types';
 
 export const EmailVerified: React.FC = () => {
     const [errorMessage, setErrorMessage] = useState('');
+    const [isConfirming, setIsConfirming] = useState(false);
     const { token } = useParams<{ token: string }>();
-    const signin = useSignin();
     const navigate = useNavigate();
     const { toast } = useToast();
-    const { mutate } = useSWRConfig();
 
     const env = useStore((state) => state.env);
 
-    useEffectOnce(() => {
-        if (!token) return;
+    const confirmEmail = async () => {
+        if (!token) {
+            setErrorMessage('The verification link is invalid. Please request a new email.');
+            return;
+        }
 
-        const verifyEmail = async () => {
-            try {
-                const res = await apiFetch(`/api/v1/account/verify/code`, {
-                    method: 'POST',
-                    body: JSON.stringify({ token })
-                });
+        setErrorMessage('');
+        setIsConfirming(true);
 
-                const response = await res.json();
+        try {
+            const res = await apiFetch(`/api/v1/account/verify/code`, {
+                method: 'POST',
+                body: JSON.stringify({ token })
+            });
+            const response = await res.json();
 
-                if (res.status !== 200) {
-                    const errorResponse: ValidateEmailAndLogin['Errors'] = response;
+            if (res.status !== 200) {
+                const errorResponse: ConfirmEmail['Errors'] = response;
 
-                    if (errorResponse.error.code === 'token_expired') {
-                        toast({ title: errorResponse.error.message, variant: 'error' });
-                        navigate(`/verify-email/expired/${token}`);
-                        return;
-                    }
-
-                    setErrorMessage(errorResponse.error.message || 'Issue verifying email. Please try again.');
+                if (errorResponse.error.code === 'token_expired') {
+                    toast({ title: errorResponse.error.message, variant: 'error' });
+                    navigate(`/verify-email/expired/${token}`);
                     return;
                 }
 
-                const user: ValidateEmailAndLogin['Success']['user'] = response['user'];
-                const showHearAboutUs = response['showHearAboutUs'] === true;
-
-                track('web:account_signup', {
-                    user_id: user.id,
-                    accountId: user.accountId
-                });
-
-                signin(user);
-                await mutate<GetUser['Success']>('/api/v1/user', { data: user as GetUser['Success']['data'] }, { revalidate: false });
-                sessionStorage.setItem('show-email-verified-toast', 'true');
-
-                const redirectPath = showHearAboutUs ? '/onboarding/hear-about-us' : `/${env}/getting-started`;
-                navigate(redirectPath, { replace: true });
-            } catch {
-                setErrorMessage('An error occurred while verifying the email. Please try again.');
+                setErrorMessage(errorResponse.error.message || 'Issue verifying email. Please try again.');
+                return;
             }
-        };
 
-        void verifyEmail();
-    });
+            const confirmation: ConfirmEmail['Success'] = response;
+            track('web:account_signup', { user_id: confirmation.userId, accountId: confirmation.accountId });
+            sessionStorage.setItem('show-email-verified-toast', 'true');
+
+            const redirectPath = confirmation.showHearAboutUs ? '/onboarding/hear-about-us' : `/${env}/getting-started`;
+            navigate(`/signin?next=${encodeURIComponent(redirectPath)}`, { replace: true, state: { email: confirmation.email } });
+        } catch {
+            setErrorMessage('An error occurred while verifying the email. Please try again.');
+        } finally {
+            setIsConfirming(false);
+        }
+    };
 
     return (
-        <DefaultLayout>
-            <div className="mt-4 flex flex-col justify-center items-center gap-8">
-                <h2 className="text-text-strong text-title-group">{errorMessage ? 'Something went wrong' : 'Verifying your email'}</h2>
-                {errorMessage ? <p className="text-text-muted text-body-small">{errorMessage}</p> : <Loader2 className="w-10 h-10 animate-spin" />}
+        <DefaultLayout className="gap-10">
+            <div className="flex flex-col items-center gap-3">
+                <h2 className="text-text-strong text-title-group">Confirm your email</h2>
+                <p className="text-text-secondary text-body-medium-regular text-center">Confirm your email address to finish creating your account.</p>
+
+                {errorMessage && (
+                    <Alert variant="error">
+                        <CircleX />
+                        <AlertDescription>{errorMessage}</AlertDescription>
+                    </Alert>
+                )}
+            </div>
+
+            <div className="grid w-full">
+                <Button onClick={confirmEmail} size="lg" loading={isConfirming}>
+                    Confirm email
+                </Button>
             </div>
         </DefaultLayout>
     );

--- a/packages/webapp/src/pages/Account/EmailVerified.tsx
+++ b/packages/webapp/src/pages/Account/EmailVerified.tsx
@@ -47,16 +47,24 @@ export const EmailVerified: React.FC = () => {
                     return;
                 }
 
+                if (errorResponse.error.code == 'invalid_token') {
+                    setErrorMessage('This link is no longer valid. It may have already been used - try signing in.');
+                    return;
+                }
+
                 setErrorMessage(errorResponse.error.message || 'Issue verifying email. Please try again.');
                 return;
             }
 
             const confirmation: ConfirmEmail['Success'] = response;
             track('web:account_signup', { user_id: confirmation.userId, accountId: confirmation.accountId });
-            sessionStorage.setItem('show-email-verified-toast', 'true');
+            toast({ title: 'Email verified successfully!', variant: 'success' });
 
             const redirectPath = confirmation.showHearAboutUs ? '/onboarding/hear-about-us' : `/${env}/getting-started`;
-            navigate(`/signin?next=${encodeURIComponent(redirectPath)}`, { replace: true, state: { email: confirmation.email } });
+            navigate(`/signin?next=${encodeURIComponent(redirectPath)}`, {
+                replace: true,
+                state: { email: confirmation.email }
+            });
         } catch {
             setErrorMessage('An error occurred while verifying the email. Please try again.');
         } finally {

--- a/packages/webapp/src/pages/Account/Signin.tsx
+++ b/packages/webapp/src/pages/Account/Signin.tsx
@@ -3,7 +3,7 @@ import { CircleX, ExternalLink, Loader2, TriangleAlert } from 'lucide-react';
 import { useEffect, useState } from 'react';
 import { Helmet } from 'react-helmet';
 import { useForm } from 'react-hook-form';
-import { useNavigate, useSearchParams } from 'react-router-dom';
+import { useLocation, useNavigate, useSearchParams } from 'react-router-dom';
 import z from 'zod';
 
 import { Button, InputGroup, InputGroupInput } from '@nangohq/design-system';
@@ -51,6 +51,7 @@ export const Signin: React.FC = () => {
     const { mutateAsync: resendVerificationEmailMutation, isPending: isResendingEmail } = useResendVerificationEmail();
     const signin = useSignin();
     const navigate = useNavigate();
+    const location = useLocation();
     const { toast } = useToast();
 
     const [searchParams, setSearchParams] = useSearchParams();
@@ -77,7 +78,7 @@ export const Signin: React.FC = () => {
     const form = useForm<SigninFormData>({
         resolver: zodResolver(signinSchema),
         defaultValues: {
-            email: '',
+            email: typeof location.state?.email === 'string' ? location.state.email : '',
             password: ''
         },
         mode: 'onSubmit'

--- a/packages/webapp/src/pages/GettingStarted/ClassicGettingStarted.tsx
+++ b/packages/webapp/src/pages/GettingStarted/ClassicGettingStarted.tsx
@@ -6,7 +6,6 @@ import { Helmet } from 'react-helmet';
 import { Button } from '@nangohq/design-system';
 
 import { Tag } from '@/components/ui/Tag';
-import { useToast } from '../../hooks/useToast';
 import DashboardLayout from '../../layout/DashboardLayout';
 import { track } from '../../utils/analytics';
 import { globalEnv } from '../../utils/env';
@@ -14,17 +13,7 @@ import { cn } from '../../utils/utils';
 
 let ytLoaded = false;
 export const ClassicGettingStarted: React.FC = () => {
-    const { toast } = useToast();
     const [hasVideo, setHasVideo] = useState(false);
-
-    useEffect(() => {
-        if (sessionStorage.getItem('show-email-verified-toast') !== 'true') {
-            return;
-        }
-
-        sessionStorage.removeItem('show-email-verified-toast');
-        toast({ title: 'Email verified successfully!', variant: 'success' });
-    }, [toast]);
 
     useEffect(() => {
         // The API will call this function when page has finished downloading

--- a/packages/webapp/src/pages/GettingStarted/Show.tsx
+++ b/packages/webapp/src/pages/GettingStarted/Show.tsx
@@ -23,15 +23,6 @@ export const GettingStarted: React.FC = () => {
     const { toast } = useToast();
 
     useEffect(() => {
-        if (sessionStorage.getItem('show-email-verified-toast') !== 'true') {
-            return;
-        }
-
-        sessionStorage.removeItem('show-email-verified-toast');
-        toast({ title: 'Email verified successfully!', variant: 'success' });
-    }, [toast]);
-
-    useEffect(() => {
         if (error) {
             toast({ title: 'Failed to get getting started', variant: 'error' });
             navigate('/');


### PR DESCRIPTION
Email verification links now open a confirmation screen instead of automatically verifying and authenticating the user.

Clicking “Confirm email” validates and consumes the token, marks the email as verified, and redirects to normal sign-in. No session is created during confirmation.

The existing token expiry and resend flow is preserved: an expired token routes to the resend screen, which issues a new link requiring explicit confirmation.

Also adds integration coverage for valid, expired, and invalid verification tokens, including the no-session guarantee.



<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/NangoHQ/nango/pull/6899?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

