### PR TITLE
ci(tests): enable fileParallelism for integration tests

### DIFF
--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -73,8 +73,7 @@ jobs:
             - run: npm run test:unit -- --exclude packages/cli/
               if: needs.should-run.outputs.should_skip != 'true'
 
-    # Each shard spins up its own Postgres/ES/etc. containers and runs its file set with
-    # fileParallelism (see vite.integration.config.ts), on top of sharding across runners.
+    # Each shard spins up its own Postgres/ES/etc. containers for its file set.
     tests-integration-shards:
         needs: should-run
         runs-on: blacksmith-4vcpu-ubuntu-2404

--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -73,9 +73,8 @@ jobs:
             - run: npm run test:unit -- --exclude packages/cli/
               if: needs.should-run.outputs.should_skip != 'true'
 
-    # Integration tests run fully serially within a process (shared Postgres/ES),
-    # so we shard the file set across parallel runners to cut wall-clock time.
-    # Each shard spins up its own containers and stays internally serial.
+    # Each shard spins up its own Postgres/ES/etc. containers and runs its file set with
+    # fileParallelism (see vite.integration.config.ts), on top of sharding across runners.
     tests-integration-shards:
         needs: should-run
         runs-on: blacksmith-4vcpu-ubuntu-2404

--- a/package-lock.json
+++ b/package-lock.json
@@ -31622,83 +31622,6 @@
                 "d3-timer": "^3.0.1"
             }
         },
-        "node_modules/vite": {
-            "version": "7.3.6",
-            "resolved": "https://registry.npmjs.org/vite/-/vite-7.3.6.tgz",
-            "integrity": "sha512-4XP60spRGjSZFf1qYH+dJIkK2znL3zQfl9KkOV9MkkRR/3Dls0dxaBsQPTloEc5BLXWPL9vsOxopxyKoMmDueg==",
-            "dev": true,
-            "license": "MIT",
-            "optional": true,
-            "peer": true,
-            "dependencies": {
-                "esbuild": "^0.27.0 || ^0.28.0",
-                "fdir": "^6.5.0",
-                "picomatch": "^4.0.3",
-                "postcss": "^8.5.6",
-                "rollup": "^4.43.0",
-                "tinyglobby": "^0.2.15"
-            },
-            "bin": {
-                "vite": "bin/vite.js"
-            },
-            "engines": {
-                "node": "^20.19.0 || >=22.12.0"
-            },
-            "funding": {
-                "url": "https://github.com/vitejs/vite?sponsor=1"
-            },
-            "optionalDependencies": {
-                "fsevents": "~2.3.3"
-            },
-            "peerDependencies": {
-                "@types/node": "^20.19.0 || >=22.12.0",
-                "jiti": ">=1.21.0",
-                "less": "^4.0.0",
-                "lightningcss": "^1.21.0",
-                "sass": "^1.70.0",
-                "sass-embedded": "^1.70.0",
-                "stylus": ">=0.54.8",
-                "sugarss": "^5.0.0",
-                "terser": "^5.16.0",
-                "tsx": "^4.8.1",
-                "yaml": "^2.4.2"
-            },
-            "peerDependenciesMeta": {
-                "@types/node": {
-                    "optional": true
-                },
-                "jiti": {
-                    "optional": true
-                },
-                "less": {
-                    "optional": true
-                },
-                "lightningcss": {
-                    "optional": true
-                },
-                "sass": {
-                    "optional": true
-                },
-                "sass-embedded": {
-                    "optional": true
-                },
-                "stylus": {
-                    "optional": true
-                },
-                "sugarss": {
-                    "optional": true
-                },
-                "terser": {
-                    "optional": true
-                },
-                "tsx": {
-                    "optional": true
-                },
-                "yaml": {
-                    "optional": true
-                }
-            }
-        },
         "node_modules/vitest": {
             "version": "4.1.9",
             "resolved": "https://registry.npmjs.org/vitest/-/vitest-4.1.9.tgz",
@@ -36331,7 +36254,6 @@
                 "@nangohq/utils": "file:../utils",
                 "dd-trace": "5.52.0",
                 "express": "5.1.0",
-                "get-port": "7.1.0",
                 "p-queue": "8.0.1",
                 "zod": "4.0.5"
             },
@@ -36885,7 +36807,6 @@
                 "@types/passport-local": "1.0.38",
                 "@types/simple-oauth2": "4.1.1",
                 "@types/ws": "8.18.1",
-                "get-port": "7.1.0",
                 "nodemon": "3.1.10",
                 "type-fest": "4.41.0",
                 "typescript": "5.8.3",

--- a/packages/jobs/lib/execution/sync.integration.test.ts
+++ b/packages/jobs/lib/execution/sync.integration.test.ts
@@ -1,8 +1,7 @@
-import { afterAll, beforeAll, describe, expect, it, vi } from 'vitest';
+import { beforeAll, describe, expect, it, vi } from 'vitest';
 
 import { multipleMigrations } from '@nangohq/database';
 import { format as recordsFormatter, records as recordsService } from '@nangohq/records';
-import { clearDb as clearRecordsDb } from '@nangohq/records/lib/stores/postgres/tests/helpers.js';
 import { getLatestSyncJob, isSyncJobRunning, seeders, updateSyncJobResult } from '@nangohq/shared';
 import { Ok, stringifyError } from '@nangohq/utils';
 
@@ -20,10 +19,6 @@ describe('Running sync', () => {
     beforeAll(async () => {
         await initDb();
         envs.NANGO_LOGS_ENABLED = false;
-    });
-
-    afterAll(async () => {
-        await clearRecordsDb();
     });
 
     describe(`with track_deletes=false`, () => {

--- a/packages/orchestrator/lib/clients/client.integration.test.ts
+++ b/packages/orchestrator/lib/clients/client.integration.test.ts
@@ -1,4 +1,3 @@
-import getPort from 'get-port';
 import { afterAll, beforeAll, describe, expect, it } from 'vitest';
 
 import { getTestDbClient, Scheduler } from '@nangohq/scheduler';
@@ -11,6 +10,8 @@ import { OrchestratorClient } from './client.js';
 import type { PostImmediate } from '../routes/v1/postImmediate.js';
 import type { Task } from '@nangohq/scheduler';
 import type { Result } from '@nangohq/utils';
+import type { Server } from 'node:http';
+import type { AddressInfo } from 'node:net';
 
 const dbClient = getTestDbClient();
 const eventsHandler = new TaskEventsHandler(dbClient.db);
@@ -20,18 +21,23 @@ const scheduler = new Scheduler({
     onError: () => {}
 });
 
-describe('OrchestratorClient', async () => {
+describe('OrchestratorClient', () => {
     const server = getServer(scheduler, eventsHandler);
-    const port = await getPort();
-    const client = new OrchestratorClient({ baseUrl: `http://localhost:${port}` });
+    let httpServer: Server;
+    let client: OrchestratorClient;
 
     beforeAll(async () => {
         await dbClient.migrate();
-        server.listen(port);
+        httpServer = server.listen(0);
+        const address = await new Promise<AddressInfo>((resolve) => {
+            httpServer.once('listening', () => resolve(httpServer.address() as AddressInfo));
+        });
+        client = new OrchestratorClient({ baseUrl: `http://localhost:${address.port}` });
     });
 
     afterAll(async () => {
         scheduler.stop();
+        httpServer?.close();
         await dbClient.clearDatabase();
     });
 

--- a/packages/orchestrator/lib/clients/processor.integration.test.ts
+++ b/packages/orchestrator/lib/clients/processor.integration.test.ts
@@ -1,6 +1,5 @@
 import { setTimeout } from 'timers/promises';
 
-import getPort from 'get-port';
 import { afterAll, beforeAll, describe, it, vi } from 'vitest';
 
 import { getTestDbClient, Scheduler } from '@nangohq/scheduler';
@@ -14,6 +13,8 @@ import { OrchestratorProcessor } from './processor.js';
 import type { OrchestratorTask } from './types.js';
 import type { Task } from '@nangohq/scheduler';
 import type { Result } from '@nangohq/utils';
+import type { Server } from 'node:http';
+import type { AddressInfo } from 'node:net';
 
 const dbClient = getTestDbClient();
 const taskEventsHandler = new TaskEventsHandler(dbClient.db);
@@ -22,20 +23,25 @@ const scheduler = new Scheduler({
     on: taskEventsHandler.onCallbacks,
     onError: () => {}
 });
-const port = await getPort();
-const orchestratorClient = new OrchestratorClient({ baseUrl: `http://localhost:${port}` });
+let orchestratorClient: OrchestratorClient;
 
 describe('OrchestratorProcessor', () => {
     const server = getServer(scheduler, taskEventsHandler);
+    let httpServer: Server;
 
     beforeAll(async () => {
         await dbClient.migrate();
-        server.listen(port);
+        httpServer = server.listen(0);
+        const address = await new Promise<AddressInfo>((resolve) => {
+            httpServer.once('listening', () => resolve(httpServer.address() as AddressInfo));
+        });
+        orchestratorClient = new OrchestratorClient({ baseUrl: `http://localhost:${address.port}` });
     });
 
     afterAll(async () => {
         scheduler.stop();
         await setTimeout(100); // wait for the scheduler to stop
+        httpServer?.close();
         await dbClient.clearDatabase();
     });
 

--- a/packages/orchestrator/package.json
+++ b/packages/orchestrator/package.json
@@ -20,7 +20,6 @@
         "@nangohq/kvstore": "file:../kvstore",
         "dd-trace": "5.52.0",
         "express": "5.1.0",
-        "get-port": "7.1.0",
         "p-queue": "8.0.1",
         "zod": "4.0.5"
     },

--- a/packages/persist/lib/server.integration.test.ts
+++ b/packages/persist/lib/server.integration.test.ts
@@ -26,6 +26,8 @@ import { server } from './server.js';
 import type { UnencryptedRecordData } from '@nangohq/records';
 import type { Sync, Job as SyncJob } from '@nangohq/shared';
 import type { AllAuthCredentials, DBAPISecret, DBEnvironment, DBPlan, DBSyncConfig, DBTeam } from '@nangohq/types';
+import type { Server } from 'node:http';
+import type { AddressInfo } from 'node:net';
 
 const mockSecretKey = 'secret-key';
 
@@ -41,16 +43,20 @@ interface testSeed {
 }
 
 describe('Persist API', () => {
-    const port = 3096;
-    const serverUrl = `http://localhost:${port}`;
+    let serverUrl: string;
     let seed: testSeed;
+    let httpServer: Server;
 
     beforeAll(async () => {
         await multipleMigrations();
         await records.migrate();
         await migrateLogsMapping();
         seed = await initDb();
-        server.listen(port);
+        httpServer = server.listen(0);
+        const address = await new Promise<AddressInfo>((resolve) => {
+            httpServer.once('listening', () => resolve(httpServer.address() as AddressInfo));
+        });
+        serverUrl = `http://localhost:${address.port}`;
 
         vi.spyOn(getFlags(), 'shouldUseLightPersistAuthContext').mockResolvedValue(true);
         vi.spyOn(accountService, 'getPersistAuthContext').mockImplementation((key) => {
@@ -67,8 +73,8 @@ describe('Persist API', () => {
         });
     });
 
-    afterAll(async () => {
-        await clearDb();
+    afterAll(() => {
+        httpServer?.close();
     });
 
     it('should server /health', async () => {
@@ -865,15 +871,6 @@ const initDb = async () => {
         sync,
         syncJob
     };
-};
-
-const clearDb = async () => {
-    await db.knex.raw(`DROP SCHEMA nango CASCADE`);
-    await db.knex.raw(`CREATE SCHEMA nango`);
-    // The keystore migration tracker is in the 'migrations' schema and survives the drop.
-    // Clear it so migrateKeystore re-runs and recreates private_keys in the new nango schema.
-    await db.knex.raw(`DELETE FROM migrations.migrations_keystore_lock`).catch(() => {});
-    await db.knex.raw(`DELETE FROM migrations.migrations_keystore`).catch(() => {});
 };
 
 const insertRecords = async (seed: testSeed, model: string, toInsert: UnencryptedRecordData[]) => {

--- a/packages/records/lib/stores/postgres/migrations/20251211175100_records_outdated_records_indexes.ts
+++ b/packages/records/lib/stores/postgres/migrations/20251211175100_records_outdated_records_indexes.ts
@@ -11,7 +11,7 @@ export async function up(knex: Knex): Promise<void> {
     for (let p = 0; p < 256; p++) {
         await knex.raw(
             `CREATE INDEX CONCURRENTLY IF NOT EXISTS records_p${p}_mark_previous_generation_as_deleted_v2
-                ON nango_records.records_p${p}(connection_id, model, sync_job_id)
+                ON records_p${p}(connection_id, model, sync_job_id)
                 INCLUDE (id)
                 WHERE deleted_at IS NULL;`
         );

--- a/packages/records/lib/stores/postgres/migrations/20260428152100_records_outdated_records_indexes_v3.ts
+++ b/packages/records/lib/stores/postgres/migrations/20260428152100_records_outdated_records_indexes_v3.ts
@@ -11,7 +11,7 @@ export async function up(knex: Knex): Promise<void> {
     for (let p = 0; p < 256; p++) {
         await knex.raw(
             `CREATE INDEX CONCURRENTLY IF NOT EXISTS records_p${p}_mark_previous_generation_as_deleted_v3
-                ON nango_records.records_p${p}(connection_id, model, sync_job_id)
+                ON records_p${p}(connection_id, model, sync_job_id)
                 WHERE deleted_at IS NULL;`
         );
     }

--- a/packages/records/lib/stores/postgres/postgres.integration.test.ts
+++ b/packages/records/lib/stores/postgres/postgres.integration.test.ts
@@ -2222,7 +2222,7 @@ describe('PostgresStore', () => {
             const date = new Date('2025-01-18T00:00:00Z');
             const next = new Date('2025-01-19T00:00:00Z');
             await db.raw(
-                `CREATE TABLE IF NOT EXISTS nango_records.records_seen_20250118 PARTITION OF nango_records.records_seen FOR VALUES FROM ('${date.toISOString()}') TO ('${next.toISOString()}')`
+                `CREATE TABLE IF NOT EXISTS records_seen_20250118 PARTITION OF records_seen FOR VALUES FROM ('${date.toISOString()}') TO ('${next.toISOString()}')`
             );
             const indexName = 'records_seen_20250118_connection_model_generation';
             const before = await db.raw<{ rows: { exists: boolean }[] }>(`SELECT EXISTS (SELECT 1 FROM pg_class WHERE relname = ?) AS exists`, [indexName]);
@@ -2266,10 +2266,10 @@ describe('PostgresStore', () => {
             const syncJobId = rnd.number();
             await upsertRecords({ records: [{ id: '1', name: 'a' }], connectionId, environmentId, model, syncId, syncJobId });
 
-            const { rows } = await db.raw<{ rows: { generation: string }[] }>(
-                `SELECT generation FROM nango_records.records_seen WHERE connection_id = ? AND model = ?`,
-                [connectionId, model]
-            );
+            const { rows } = await db.raw<{ rows: { generation: string }[] }>(`SELECT generation FROM records_seen WHERE connection_id = ? AND model = ?`, [
+                connectionId,
+                model
+            ]);
             expect(rows).toHaveLength(1);
             // node-pg returns bigint as string; coerce for the compare.
             expect(Number(rows[0]?.generation)).toBe(syncJobId);

--- a/packages/records/lib/stores/postgres/tests/helpers.ts
+++ b/packages/records/lib/stores/postgres/tests/helpers.ts
@@ -1,9 +1,10 @@
-import knex from 'knex';
-
 import { envs } from '../../../env.js';
 import { makePostgresConfig } from '../config.js';
 
-const schema = envs.RECORDS_DATABASE_SCHEMA;
+// Dedicated schema, distinct from envs.RECORDS_DATABASE_SCHEMA: this suite truncates its
+// tables between tests, which would corrupt other integration test files (e.g. sync.integration.test.ts
+// in packages/jobs) sharing the default schema if run concurrently (fileParallelism).
+const schema = 'nango_records_postgres_store_test';
 export const testConfig = makePostgresConfig({
     databaseUrl: envs.RECORDS_DATABASE_URL!,
     schema,
@@ -15,9 +16,3 @@ export const testConfig = makePostgresConfig({
         max: envs.RECORDS_DATABASE_POOL_MAX
     }
 });
-const db = knex(testConfig);
-
-// WARNING: to use only in tests
-export async function clearDb(): Promise<void> {
-    await db.raw(`DROP SCHEMA ${schema} CASCADE`);
-}

--- a/packages/scheduler/lib/db/helpers.test.ts
+++ b/packages/scheduler/lib/db/helpers.test.ts
@@ -1,8 +1,13 @@
+import { randomUUID } from 'node:crypto';
+
 import { DatabaseClient, defaultDatabaseClientOptions } from './client.js';
 
+// Unique schema per client: test files run concurrently (fileParallelism), and a shared schema
+// would let one file's migrate() race another's, or its clearDatabase() (DROP SCHEMA CASCADE)
+// tear the schema down while another file is still using it.
 export const getTestDbClient = () =>
     new DatabaseClient({
         ...defaultDatabaseClientOptions,
         url: `postgres://${process.env['NANGO_DB_USER']}:${process.env['NANGO_DB_PASSWORD']}@${process.env['NANGO_DB_HOST']}:${process.env['NANGO_DB_PORT']}/${process.env['NANGO_DB_NAME']}`,
-        schema: 'scheduler'
+        schema: `scheduler_test_${randomUUID().replace(/-/g, '')}`
     });

--- a/packages/server/lib/clients/auth.client.ts
+++ b/packages/server/lib/clients/auth.client.ts
@@ -20,6 +20,8 @@ const SESSION_TABLE = '_nango_sessions';
 // @ts-expect-error types are wrong
 const KnexSessionStore = connectSessionKnex(session) as StoreFactory;
 
+// tests/setup.ts pre-creates this table in globalSetup with the same knex/tablename/sidfieldname
+// so concurrent test forks don't race the store's check-then-create — keep them in sync.
 const sessionStore = new KnexSessionStore({
     knex: database.knex,
     tablename: SESSION_TABLE,
@@ -106,22 +108,22 @@ export function setupAuth(app: express.Router) {
                 const user = await userService.getUserById(0);
 
                 if (!isBasicAuthEnabled) {
-                    return done(null, user);
+                    return void done(null, user);
                 }
 
                 if (username !== process.env['NANGO_DASHBOARD_USERNAME']) {
-                    return done(null, false);
+                    return void done(null, false);
                 }
 
                 if (password !== process.env['NANGO_DASHBOARD_PASSWORD']) {
-                    return done(null, false);
+                    return void done(null, false);
                 }
 
                 if (!user) {
-                    return done(null, false);
+                    return void done(null, false);
                 }
 
-                return done(null, user);
+                return void done(null, user);
             })
         );
     }
@@ -134,7 +136,7 @@ export function setupAuth(app: express.Router) {
 
     passport.deserializeUser(function (user: Express.User, cb) {
         process.nextTick(function () {
-            return cb(null, user);
+            return void cb(null, user);
         });
     });
 }

--- a/packages/server/lib/tasks/index.ts
+++ b/packages/server/lib/tasks/index.ts
@@ -9,6 +9,8 @@ import { exampleTask } from './handlers/example.js';
 
 const logger = getLogger('Server.Tasks');
 
+// tests/setup.ts's tasks pre-migration duplicates this URL/schema wiring (it can't import this
+// module without constructing the whole Tasks instance) — keep them in sync.
 const databaseUrl =
     envs.NANGO_DATABASE_URL ||
     `postgres://${encodeURIComponent(envs.NANGO_DB_USER)}:${encodeURIComponent(envs.NANGO_DB_PASSWORD)}@${envs.NANGO_DB_HOST}:${envs.NANGO_DB_PORT}/${envs.NANGO_DB_NAME}`;

--- a/packages/server/lib/utils/tests.ts
+++ b/packages/server/lib/utils/tests.ts
@@ -2,7 +2,6 @@ import { createServer } from 'node:http';
 import { inspect } from 'node:util';
 
 import express from 'express';
-import getPort from 'get-port';
 import { expect } from 'vitest';
 
 import db, { multipleMigrations } from '@nangohq/database';
@@ -14,6 +13,7 @@ import { tasks } from '../tasks/index.js';
 
 import type { APIEndpoints, APIEndpointsPicker, APIEndpointsPickerWithPath, DBUser } from '@nangohq/types';
 import type { Server } from 'node:http';
+import type { AddressInfo } from 'node:net';
 
 function uriParamsReplacer(tpl: string, data: Record<string, any>) {
     let res = tpl;
@@ -163,9 +163,11 @@ export async function runServer(): Promise<{ server: Server; url: string; fetch:
     app.set('query parser', 'extended');
     app.use(router);
     const server = createServer(app);
-    const port = await getPort();
+    // listen(0) lets the OS pick the port atomically — get-port's check-then-listen window
+    // can race across concurrent test forks (fileParallelism).
     return new Promise((resolve) => {
-        server.listen(port, () => {
+        server.listen(0, () => {
+            const { port } = server.address() as AddressInfo;
             const url = `http://localhost:${port}`;
             resolve({ server, url, fetch: apiFetch(url) });
         });

--- a/packages/server/package.json
+++ b/packages/server/package.json
@@ -93,7 +93,6 @@
         "@types/passport-local": "1.0.38",
         "@types/simple-oauth2": "4.1.1",
         "@types/ws": "8.18.1",
-        "get-port": "7.1.0",
         "nodemon": "3.1.10",
         "type-fest": "4.41.0",
         "typescript": "5.8.3",

--- a/tests/setup.ts
+++ b/tests/setup.ts
@@ -160,6 +160,39 @@ async function runMigrationsOnce() {
         const { records } = await import('@nangohq/records');
         await records.migrate();
     });
+    await runMigrationOnce('tasks', async () => {
+        // packages/server/lib/tasks/index.ts constructs a full Tasks (Scheduler + TaskProcessor)
+        // just to get this schema migrated, which has side effects we don't want in globalSetup.
+        // DatabaseClient is the same underlying migration runner without any of that.
+        const [{ DatabaseClient, defaultDatabaseClientOptions }, { ENVS, parseEnvs }] = await Promise.all([
+            import('@nangohq/scheduler'),
+            import('@nangohq/utils')
+        ]);
+        const envs = parseEnvs(ENVS);
+        const databaseUrl =
+            envs.NANGO_DATABASE_URL ||
+            `postgres://${encodeURIComponent(envs.NANGO_DB_USER)}:${encodeURIComponent(envs.NANGO_DB_PASSWORD)}@${envs.NANGO_DB_HOST}:${envs.NANGO_DB_PORT}/${envs.NANGO_DB_NAME}`;
+        const client = new DatabaseClient({ ...defaultDatabaseClientOptions, url: databaseUrl, schema: envs.TASKS_DATABASE_SCHEMA });
+        try {
+            await client.migrate();
+        } finally {
+            await client.destroy();
+        }
+    });
+    await runMigrationOnce('sessions', async () => {
+        // packages/server/lib/clients/auth.client.ts constructs a module-level KnexSessionStore,
+        // which does its own check-then-create of this table (not a tracked knex migration) the
+        // first time any file imports it. Doing that once here, ahead of any test file, avoids
+        // every fork racing to CREATE TABLE the same table concurrently.
+        const [{ default: connectSessionKnex }, { default: session }, { default: db }] = await Promise.all([
+            import('connect-session-knex'),
+            import('express-session'),
+            import('@nangohq/database')
+        ]);
+        const KnexSessionStore = connectSessionKnex(session);
+        const store = new KnexSessionStore({ knex: db.knex, tablename: '_nango_sessions', sidfieldname: 'sid' });
+        await store.ready;
+    });
 }
 
 export async function setup() {

--- a/tests/setup.ts
+++ b/tests/setup.ts
@@ -184,13 +184,18 @@ async function runMigrationsOnce() {
         // which does its own check-then-create of this table (not a tracked knex migration) the
         // first time any file imports it. Doing that once here, ahead of any test file, avoids
         // every fork racing to CREATE TABLE the same table concurrently.
+        //
+        // knex/tablename/sidfieldname must stay identical to auth.client.ts's sessionStore, or
+        // this pre-creation stops covering it. disableDbCleanup is the one intentional difference:
+        // it stops the store from scheduling its recurring expired-session delete in this process
+        // (we only want the table created).
         const [{ default: connectSessionKnex }, { default: session }, { default: db }] = await Promise.all([
             import('connect-session-knex'),
             import('express-session'),
             import('@nangohq/database')
         ]);
         const KnexSessionStore = connectSessionKnex(session);
-        const store = new KnexSessionStore({ knex: db.knex, tablename: '_nango_sessions', sidfieldname: 'sid' });
+        const store = new KnexSessionStore({ knex: db.knex, tablename: '_nango_sessions', sidfieldname: 'sid', disableDbCleanup: true });
         await store.ready;
     });
 }

--- a/tests/setup.ts
+++ b/tests/setup.ts
@@ -127,8 +127,44 @@ export async function setupClickhouse() {
     console.log('Clickhouse running at', url);
 }
 
+// Every runServer()-based integration test (and a few others) calls these same migration
+// functions in its own beforeAll. With fileParallelism, many files' beforeAll hooks fire
+// concurrently and race for knex's migration lock on the same shared schema — whichever loses
+// throws `MigrationLocked: Migration table is already locked`. Running them once here, before any
+// test file starts, means every file's own call sees zero pending migrations and never reaches
+// the lock-acquiring code path.
+//
+// Each step is independent and best-effort: if one fails (e.g. to import), the others still run,
+// and any file's own migration call remains the real safety net, just as it was before
+// fileParallelism.
+async function runMigrationOnce(name: string, run: () => Promise<void>) {
+    try {
+        await run();
+    } catch (err) {
+        console.error(`Pre-migration "${name}" in globalSetup failed, falling back to per-file migration calls`, err);
+    }
+}
+
+async function runMigrationsOnce() {
+    const { multipleMigrations, default: db } = await import('@nangohq/database');
+    await runMigrationOnce('database', () => multipleMigrations());
+    await runMigrationOnce('keystore', async () => {
+        const { migrate: migrateKeystore } = await import('@nangohq/keystore');
+        await migrateKeystore(db.knex);
+    });
+    await runMigrationOnce('logs', async () => {
+        const { migrateLogsMapping } = await import('@nangohq/logs');
+        await migrateLogsMapping();
+    });
+    await runMigrationOnce('records', async () => {
+        const { records } = await import('@nangohq/records');
+        await records.migrate();
+    });
+}
+
 export async function setup() {
     await Promise.all([setupPostgres(), setupLogsStorage(), setupActiveMQ(), setupRedis(), setupClickhouse()]);
+    await runMigrationsOnce();
 }
 
 export const teardown = async () => {

--- a/vite.integration.config.ts
+++ b/vite.integration.config.ts
@@ -32,9 +32,11 @@ export default defineConfig({
             // explicit override still resolves to Orb.
             FLAG_ALLOW_OVERRIDE_GETUSAGE_SERVICE: 'true'
         },
-        fileParallelism: false,
-        pool: 'forks',
-        // Vitest 4 removed test.poolOptions; poolOptions.forks.singleFork is now maxWorkers: 1.
-        maxWorkers: 1
+        // Each file still gets its own isolated fork (default `isolate: true`), so this just lets
+        // multiple files' forks run concurrently instead of one at a time. Safe now that the tests
+        // that used to drop/truncate shared Postgres schemas (persist, jobs/sync, records/postgres)
+        // either stopped doing that or moved to a dedicated schema — see NAN-6026 history.
+        fileParallelism: true,
+        pool: 'forks'
     }
 });

--- a/vite.integration.config.ts
+++ b/vite.integration.config.ts
@@ -31,12 +31,6 @@ export default defineConfig({
             // No effect on default behavior — every other request without the
             // explicit override still resolves to Orb.
             FLAG_ALLOW_OVERRIDE_GETUSAGE_SERVICE: 'true'
-        },
-        // Each file still gets its own isolated fork (default `isolate: true`), so this just lets
-        // multiple files' forks run concurrently instead of one at a time. Safe now that the tests
-        // that used to drop/truncate shared Postgres schemas (persist, jobs/sync, records/postgres)
-        // either stopped doing that or moved to a dedicated schema — see NAN-6026 history.
-        fileParallelism: true,
-        pool: 'forks'
+        }
     }
 });


### PR DESCRIPTION
## Problem

Integration test shards have crept from ~6-8 min to 10-15+ min since sharding landed, on top of the original wild variance (`isolate: false` was tried in NAN-6026 to fix the vitest 3→4 module-reimport regression, but got reverted — it exposed cross-file module-state coupling). With `fileParallelism: false` and `maxWorkers: 1`, each shard runs its ~35-100 files serially on a single core of a 4-vCPU runner, even though most of a file's wall time is bootstrap overhead (migrations check, fresh DB/ES/Redis connections per file), not actual test execution.

## Solution

`fileParallelism` was disabled in 2024 because a few tests assumed exclusive access to shared Postgres schemas (dropping/truncating them in teardown). This fixes those and turns it back on:

- Two records migrations hardcoded the `nango_records` schema in raw SQL instead of relying on `search_path` like every other migration — harmless against the real schema, but broke running them against any other schema
- `postgres.integration.test.ts` truncates shared records tables throughout its run (not just at teardown) — moved it to a dedicated schema, matching the existing `nango_encrypt` pattern in `encryption.manager.integration.test.ts`
- `persist/server.integration.test.ts` and `jobs/sync.integration.test.ts` each dropped a shared schema entirely in `afterAll` as pure teardown hygiene that nothing depended on — removed both drops
- Pre-run all migrations once in `globalSetup`, since concurrent files' `beforeAll` hooks calling the same migration functions now race for knex's migration lock on shared schemas; running them once upfront means every file's own call sees zero pending migrations and skips the lock-acquiring path
- Flip `fileParallelism: false` → `true`; each file still gets its own isolated fork (`isolate: true`, unchanged), this just lets multiple files' forks run concurrently instead of one at a time

## Testing

- Ran the three previously-unsafe files together locally with `fileParallelism: true` (103/103 passing), including concurrently with each other to confirm no cross-file schema corruption
- CI's sharded run on this PR is the real-scale validation
