### PR TITLE
fix(webapp): use state-hover token for table row hover

### DIFF
--- a/packages/webapp/src/components/ui/Table.tsx
+++ b/packages/webapp/src/components/ui/Table.tsx
@@ -27,7 +27,7 @@ function TableRow({ className, ...props }: React.ComponentProps<'tr'>) {
         <tr
             data-slot="table-row"
             className={cn(
-                'px-6 h-11 hover:bg-state-selected-muted [thead_&]:hover:bg-transparent data-[state=selected]:bg-state-selected border-b border-border-muted transition-colors',
+                'px-6 h-11 hover:bg-state-hover [thead_&]:hover:bg-transparent data-[state=selected]:bg-state-selected border-b border-border-muted transition-colors',
                 className
             )}
             {...props}

--- a/packages/webapp/src/pages/Connection/components/RecordsTab.tsx
+++ b/packages/webapp/src/pages/Connection/components/RecordsTab.tsx
@@ -301,7 +301,7 @@ const VirtualizedRecordRows = ({
                             data-index={vRow.index}
                             ref={(node) => rowVirtualizer.measureElement(node)}
                             className={cn(
-                                'absolute left-0 flex h-11 w-full cursor-pointer border-b border-border-muted hover:bg-state-selected-muted',
+                                'absolute left-0 flex h-11 w-full cursor-pointer border-b border-border-muted hover:bg-state-hover',
                                 'transition-colors'
                             )}
                             style={{

--- a/packages/webapp/src/pages/Team/Billing/components/UsageRow.tsx
+++ b/packages/webapp/src/pages/Team/Billing/components/UsageRow.tsx
@@ -64,7 +64,7 @@ export const UsageRow: React.FC<UsageRowProps> = ({
 
     return (
         <Collapsible open={open} onOpenChange={onOpenChange} className="border-b border-border-muted last:border-b-0 data-[state=open]:bg-surface-panel">
-            <CollapsibleTrigger className="group w-full text-left py-4 transition-colors data-[state=closed]:hover:bg-surface-panel data-[state=open]:border-b data-[state=open]:border-border-muted">
+            <CollapsibleTrigger className="group w-full text-left py-4 transition-colors data-[state=closed]:hover:bg-state-hover data-[state=open]:border-b data-[state=open]:border-border-muted">
                 <div className={USAGE_ROW_GRID}>
                     <div className="flex flex-col min-w-0">
                         <span className="text-text-default text-body-medium-regular truncate">{label}</span>


### PR DESCRIPTION
## Problem

Table rows and the billing usage table's collapsible rows each hovered with a different substitute token instead of `state-hover`: the shared `TableRow` and `RecordsTab` rows used `state-selected-muted`, and the billing `UsageRow` used `surface-panel`. This made row hover inconsistent across the app and out of sync with the design system.

## Solution

- Use `state-hover` for row hover in the shared `TableRow` (covers Integrations list, Connections list, Team members, API keys, Billing plans, Syncs tab)
- Use `state-hover` for row hover in the records tab's virtualized rows
- Use `state-hover` for the billing usage table's collapsible row hover

## Testing

- Verified against the dev environment in light mode: hovering a row on Connections, Integrations, and the Billing usage table all resolve to `background-color: rgba(0, 0, 0, 0.06)` (`state-hover`'s light value), confirming the shared `TableRow` and `UsageRow` fix
