### PR TITLE
feat(webapp): redesign billing details section

### DIFF
--- a/packages/billing/lib/clients/noop/client.ts
+++ b/packages/billing/lib/clients/noop/client.ts
@@ -20,12 +20,16 @@ import type { Result } from '@nangohq/utils';
  * still reads its actual numbers from ClickHouse) don't fail on the missing Orb
  * dependency. Deployed environments always set `ORB_API_KEY` and use OrbClient.
  */
-function stubCustomer(accountId: number, details?: Pick<BillingInvoicingDetails, 'legalEntityName' | 'email'>): BillingCustomer {
+function stubCustomer(
+    accountId: number,
+    details?: Pick<BillingInvoicingDetails, 'legalEntityName' | 'email'> & Partial<Pick<BillingInvoicingDetails, 'additionalEmails'>>
+): BillingCustomer {
     return {
         id: `local-customer-${accountId}`,
         invoicingDetails: {
             legalEntityName: details?.legalEntityName ?? `Local account ${accountId}`,
             email: details?.email ?? `account-${accountId}@local.nango.dev`,
+            additionalEmails: details?.additionalEmails ?? [],
             address: null,
             taxId: null
         },

--- a/packages/billing/lib/clients/orb/adapters.ts
+++ b/packages/billing/lib/clients/orb/adapters.ts
@@ -50,6 +50,7 @@ export function toOrbPutCustomerPayload(invoicingDetails: BillingInvoicingDetail
     const payload: Orb.CustomerUpdateByExternalIDParams = {
         name: invoicingDetails.legalEntityName,
         email: invoicingDetails.email,
+        additional_emails: val.data.additionalEmails,
         tax_id: val.data.taxId
     };
 
@@ -76,6 +77,7 @@ export function fromOrbCustomer(orbCustomer: Orb.Customer): BillingCustomer {
         invoicingDetails: {
             legalEntityName: orbCustomer.name,
             email: orbCustomer.email,
+            additionalEmails: orbCustomer.additional_emails,
             address: orbCustomer.billing_address ? fromOrbAddress(orbCustomer.billing_address) : null,
             taxId: orbCustomer.tax_id
         }

--- a/packages/billing/lib/clients/orb/adapters.ts
+++ b/packages/billing/lib/clients/orb/adapters.ts
@@ -77,7 +77,7 @@ export function fromOrbCustomer(orbCustomer: Orb.Customer): BillingCustomer {
         invoicingDetails: {
             legalEntityName: orbCustomer.name,
             email: orbCustomer.email,
-            additionalEmails: orbCustomer.additional_emails,
+            additionalEmails: orbCustomer.additional_emails ?? [],
             address: orbCustomer.billing_address ? fromOrbAddress(orbCustomer.billing_address) : null,
             taxId: orbCustomer.tax_id
         }

--- a/packages/billing/lib/clients/orb/adapters.unit.test.ts
+++ b/packages/billing/lib/clients/orb/adapters.unit.test.ts
@@ -118,6 +118,7 @@ describe('toOrbPutCustomerPayload', () => {
     const base: BillingInvoicingDetails = {
         legalEntityName: 'Acme Corp',
         email: 'billing@acme.com',
+        additionalEmails: [],
         address: null,
         taxId: null
     };
@@ -128,6 +129,13 @@ describe('toOrbPutCustomerPayload', () => {
         const value = result.unwrap();
         expect(value.name).toBe('Acme Corp');
         expect(value.email).toBe('billing@acme.com');
+    });
+
+    it('sets additional_emails', () => {
+        const result = toOrbPutCustomerPayload({ ...base, additionalEmails: ['ap@acme.com', 'finance@acme.com'] });
+        expect(result.isOk()).toBe(true);
+        const value = result.unwrap();
+        expect(value.additional_emails).toEqual(['ap@acme.com', 'finance@acme.com']);
     });
 
     it('sets billing_address to null when address is null', () => {
@@ -216,6 +224,7 @@ describe('fromOrbCustomer', () => {
         portal_url: 'https://portal.example.com',
         name: 'Acme Corp',
         email: 'billing@acme.com',
+        additional_emails: ['ap@acme.com'],
         billing_address: null,
         tax_id: null
     } as unknown as Orb.Customer;
@@ -226,6 +235,7 @@ describe('fromOrbCustomer', () => {
         expect(result.portalUrl).toBe('https://portal.example.com');
         expect(result.invoicingDetails.legalEntityName).toBe('Acme Corp');
         expect(result.invoicingDetails.email).toBe('billing@acme.com');
+        expect(result.invoicingDetails.additionalEmails).toEqual(['ap@acme.com']);
     });
 
     it('sets address to null when billing_address is null', () => {

--- a/packages/billing/lib/clients/orb/types.ts
+++ b/packages/billing/lib/clients/orb/types.ts
@@ -236,6 +236,7 @@ export type OrbTaxIdType = z.infer<typeof orbTaxIdTypeSchema>;
 export const putOrbCustomerSchema = z.object({
     legalEntityName: z.string(),
     email: z.email(),
+    additionalEmails: z.array(z.email()).max(49),
     address: z
         .object({
             line1: z.string().nullable(),

--- a/packages/server/lib/controllers/v1/plans/billing/putInvoicingDetails.integration.test.ts
+++ b/packages/server/lib/controllers/v1/plans/billing/putInvoicingDetails.integration.test.ts
@@ -124,6 +124,39 @@ describe(`PUT ${route}`, () => {
             expect(res.json.error.code).toBe('invalid_body');
         });
 
+        it('should reject more than 49 additional emails', async () => {
+            const { plan, apiKey } = await seeders.seedAccountEnvAndUser();
+            await updatePlan(db.knex, { id: plan.id, orb_customer_id: 'orb_cust_123' });
+
+            const res = await api.fetch(route, {
+                method: 'PUT',
+                query: { env: 'dev' },
+                token: apiKey.secret,
+                body: { ...validBody, additionalEmails: Array.from({ length: 50 }, (_, i) => `email${i}@acme.com`) }
+            });
+
+            isError(res.json);
+            expect(res.res.status).toBe(400);
+            expect(res.json.error.code).toBe('invalid_body');
+        });
+
+        it('should reject a duplicate email between email and additionalEmails', async () => {
+            const { plan, apiKey } = await seeders.seedAccountEnvAndUser();
+            await updatePlan(db.knex, { id: plan.id, orb_customer_id: 'orb_cust_123' });
+
+            const res = await api.fetch(route, {
+                method: 'PUT',
+                query: { env: 'dev' },
+                token: apiKey.secret,
+                // Case-only duplicate of the primary email.
+                body: { ...validBody, additionalEmails: ['BILLING@acme.com'] }
+            });
+
+            isError(res.json);
+            expect(res.res.status).toBe(400);
+            expect(res.json.error.code).toBe('invalid_body');
+        });
+
         it('should reject extra params in query', async () => {
             const { apiKey } = await seeders.seedAccountEnvAndUser();
             const res = await api.fetch(route, {
@@ -196,6 +229,26 @@ describe(`PUT ${route}`, () => {
             isSuccess(res.json);
             expect(res.res.status).toBe(200);
             expect(putCustomerSpy).toHaveBeenCalledWith(expect.any(Number), body);
+        });
+
+        it('should default additionalEmails to [] when omitted', async () => {
+            const { plan, apiKey } = await seeders.seedAccountEnvAndUser();
+            await updatePlan(db.knex, { id: plan.id, orb_customer_id: 'orb_cust_123' });
+
+            // Simulates a caller on the prior single-email payload shape (e.g. a stale
+            // webapp bundle mid-deploy) — must keep working rather than 400 invalid_body.
+            const { additionalEmails: _additionalEmails, ...bodyWithoutAdditionalEmails } = validBody;
+            const res = await api.fetch(route, {
+                method: 'PUT',
+                query: { env: 'dev' },
+                token: apiKey.secret,
+                // @ts-expect-error omitting additionalEmails on purpose
+                body: bodyWithoutAdditionalEmails
+            });
+
+            isSuccess(res.json);
+            expect(res.res.status).toBe(200);
+            expect(putCustomerSpy).toHaveBeenCalledWith(expect.any(Number), validBody);
         });
 
         it('should allow null address and taxId', async () => {

--- a/packages/server/lib/controllers/v1/plans/billing/putInvoicingDetails.integration.test.ts
+++ b/packages/server/lib/controllers/v1/plans/billing/putInvoicingDetails.integration.test.ts
@@ -19,6 +19,7 @@ const mockCustomer: BillingCustomer = {
     invoicingDetails: {
         legalEntityName: 'Acme Corp',
         email: 'billing@acme.com',
+        additionalEmails: [],
         address: null,
         taxId: null
     },
@@ -28,6 +29,7 @@ const mockCustomer: BillingCustomer = {
 const validBody: BillingInvoicingDetails = {
     legalEntityName: 'Acme Corp',
     email: 'billing@acme.com',
+    additionalEmails: [],
     address: null,
     taxId: null
 };
@@ -106,6 +108,22 @@ describe(`PUT ${route}`, () => {
             expect(res.json.error.code).toBe('invalid_body');
         });
 
+        it('should reject an invalid additional email', async () => {
+            const { plan, apiKey } = await seeders.seedAccountEnvAndUser();
+            await updatePlan(db.knex, { id: plan.id, orb_customer_id: 'orb_cust_123' });
+
+            const res = await api.fetch(route, {
+                method: 'PUT',
+                query: { env: 'dev' },
+                token: apiKey.secret,
+                body: { ...validBody, additionalEmails: ['ap@acme.com', 'not-an-email'] }
+            });
+
+            isError(res.json);
+            expect(res.res.status).toBe(400);
+            expect(res.json.error.code).toBe('invalid_body');
+        });
+
         it('should reject extra params in query', async () => {
             const { apiKey } = await seeders.seedAccountEnvAndUser();
             const res = await api.fetch(route, {
@@ -147,9 +165,27 @@ describe(`PUT ${route}`, () => {
             const body: BillingInvoicingDetails = {
                 legalEntityName: 'Acme Corp',
                 email: 'billing@acme.com',
+                additionalEmails: ['ap@acme.com', 'finance@acme.com'],
                 address: { line1: '123 Main St', line2: null, city: 'San Francisco', state: 'CA', postalCode: '94105', country: 'US' },
                 taxId: { country: 'US', type: 'us_ein', value: '12-3456789' }
             };
+            const res = await api.fetch(route, {
+                method: 'PUT',
+                query: { env: 'dev' },
+                token: apiKey.secret,
+                body
+            });
+
+            isSuccess(res.json);
+            expect(res.res.status).toBe(200);
+            expect(putCustomerSpy).toHaveBeenCalledWith(expect.any(Number), body);
+        });
+
+        it('should accept a populated additionalEmails list', async () => {
+            const { plan, apiKey } = await seeders.seedAccountEnvAndUser();
+            await updatePlan(db.knex, { id: plan.id, orb_customer_id: 'orb_cust_123' });
+
+            const body: BillingInvoicingDetails = { ...validBody, additionalEmails: ['ap@acme.com', 'finance@acme.com'] };
             const res = await api.fetch(route, {
                 method: 'PUT',
                 query: { env: 'dev' },

--- a/packages/server/lib/controllers/v1/plans/billing/putInvoicingDetails.integration.test.ts
+++ b/packages/server/lib/controllers/v1/plans/billing/putInvoicingDetails.integration.test.ts
@@ -235,8 +235,6 @@ describe(`PUT ${route}`, () => {
             const { plan, apiKey } = await seeders.seedAccountEnvAndUser();
             await updatePlan(db.knex, { id: plan.id, orb_customer_id: 'orb_cust_123' });
 
-            // Simulates a caller on the prior single-email payload shape (e.g. a stale
-            // webapp bundle mid-deploy) — must keep working rather than 400 invalid_body.
             const { additionalEmails: _additionalEmails, ...bodyWithoutAdditionalEmails } = validBody;
             const res = await api.fetch(route, {
                 method: 'PUT',

--- a/packages/server/lib/controllers/v1/plans/billing/putInvoicingDetails.ts
+++ b/packages/server/lib/controllers/v1/plans/billing/putInvoicingDetails.ts
@@ -30,6 +30,7 @@ const validation = z
     .object({
         legalEntityName: z.string(),
         email: z.email(),
+        additionalEmails: z.array(z.email()),
         address: addressSchema.nullable(),
         taxId: taxIdSchema.nullable()
     })

--- a/packages/server/lib/controllers/v1/plans/billing/putInvoicingDetails.ts
+++ b/packages/server/lib/controllers/v1/plans/billing/putInvoicingDetails.ts
@@ -30,11 +30,21 @@ const validation = z
     .object({
         legalEntityName: z.string(),
         email: z.email(),
-        additionalEmails: z.array(z.email()),
+        // Optional + defaulted so callers on the prior single-email payload shape (e.g. a
+        // stale webapp bundle mid-deploy) keep working instead of getting invalid_body.
+        // Capped at 49 to match Orb's 50-address limit (primary + additional).
+        additionalEmails: z.array(z.email()).max(49).optional().default([]),
         address: addressSchema.nullable(),
         taxId: taxIdSchema.nullable()
     })
-    .strict();
+    .strict()
+    .refine(
+        (data) => {
+            const all = [data.email, ...data.additionalEmails].map((e) => e.toLowerCase());
+            return new Set(all).size === all.length;
+        },
+        { message: 'Duplicate billing email address', path: ['additionalEmails'] }
+    );
 
 export const putInvoicingDetails = asyncWrapper<PutBillingInvoicingDetails>(async (req, res) => {
     const emptyQuery = requireEmptyQuery(req, { withEnv: true });

--- a/packages/server/lib/controllers/v1/plans/billing/putInvoicingDetails.ts
+++ b/packages/server/lib/controllers/v1/plans/billing/putInvoicingDetails.ts
@@ -30,9 +30,7 @@ const validation = z
     .object({
         legalEntityName: z.string(),
         email: z.email(),
-        // Optional + defaulted so callers on the prior single-email payload shape (e.g. a
-        // stale webapp bundle mid-deploy) keep working instead of getting invalid_body.
-        // Capped at 49 to match Orb's 50-address limit (primary + additional).
+        // Optional/defaulted for backward compat; capped at 49 to match Orb's 50-address limit.
         additionalEmails: z.array(z.email()).max(49).optional().default([]),
         address: addressSchema.nullable(),
         taxId: taxIdSchema.nullable()

--- a/packages/server/lib/controllers/v1/plans/usage/getBillingUsage.integration.test.ts
+++ b/packages/server/lib/controllers/v1/plans/usage/getBillingUsage.integration.test.ts
@@ -20,7 +20,7 @@ let getCustomerSpy: any;
 
 const mockCustomer: BillingCustomer = {
     id: 'orb_cust_123',
-    invoicingDetails: { legalEntityName: 'Acme', email: 'billing@acme.com', address: null, taxId: null },
+    invoicingDetails: { legalEntityName: 'Acme', email: 'billing@acme.com', additionalEmails: [], address: null, taxId: null },
     portalUrl: null
 };
 

--- a/packages/server/lib/controllers/v1/stripe/payment_methods/getPaymentMethods.ts
+++ b/packages/server/lib/controllers/v1/stripe/payment_methods/getPaymentMethods.ts
@@ -41,7 +41,10 @@ export const getStripePaymentMethods = asyncWrapper<GetStripePaymentMethods>(asy
         data: list.data.map((p) => {
             return {
                 id: p.id,
-                last4: p.card!.last4
+                brand: p.card!.brand,
+                last4: p.card!.last4,
+                expMonth: p.card!.exp_month,
+                expYear: p.card!.exp_year
             };
         })
     });

--- a/packages/types/lib/billing/types.ts
+++ b/packages/types/lib/billing/types.ts
@@ -41,6 +41,7 @@ export interface BillingCustomer {
 export interface BillingInvoicingDetails {
     legalEntityName: string;
     email: string;
+    additionalEmails: string[];
     address: BillingAddress | null;
     taxId: BillingTaxId | null;
 }

--- a/packages/types/lib/stripe/http.api.ts
+++ b/packages/types/lib/stripe/http.api.ts
@@ -12,7 +12,10 @@ export type PostStripeCollectPayment = ApiEndpoint<{
 
 export interface StripePaymentMethod {
     id: string;
+    brand: string;
     last4: string;
+    expMonth: number;
+    expYear: number;
 }
 
 export type GetStripePaymentMethods = ApiEndpoint<{

--- a/packages/webapp/src/components/ui/Combobox.tsx
+++ b/packages/webapp/src/components/ui/Combobox.tsx
@@ -559,12 +559,12 @@ function ComboboxChip({ className, children, showRemove = true, ...props }: Comb
         <ComboboxPrimitive.Chip
             data-slot="combobox-chip"
             className={cn(
-                'inline-flex h-[21px] w-fit items-center justify-center gap-[2px] rounded bg-surface-page border border-border-default px-[6px] text-sm font-normal whitespace-nowrap text-text-secondary has-disabled:pointer-events-none has-disabled:cursor-not-allowed has-disabled:opacity-50 has-data-[slot=combobox-chip-remove]:pr-0.5',
+                'inline-flex h-[21px] max-w-full min-w-0 items-center justify-center gap-[2px] rounded bg-surface-page border border-border-default px-[6px] text-sm font-normal text-text-secondary has-disabled:pointer-events-none has-disabled:cursor-not-allowed has-disabled:opacity-50 has-data-[slot=combobox-chip-remove]:pr-0.5',
                 className
             )}
             {...props}
         >
-            {children}
+            <span className="min-w-0 truncate">{children}</span>
             {showRemove && (
                 <ComboboxPrimitive.ChipRemove
                     render={<IconButton variant="ghost" size="2xs" label="Remove" />}

--- a/packages/webapp/src/components/ui/Combobox.tsx
+++ b/packages/webapp/src/components/ui/Combobox.tsx
@@ -559,7 +559,7 @@ function ComboboxChip({ className, children, showRemove = true, ...props }: Comb
         <ComboboxPrimitive.Chip
             data-slot="combobox-chip"
             className={cn(
-                'inline-flex h-[21px] max-w-full min-w-0 items-center justify-center gap-[2px] rounded bg-surface-page border border-border-default px-[6px] text-sm font-normal text-text-secondary has-disabled:pointer-events-none has-disabled:cursor-not-allowed has-disabled:opacity-50 has-data-[slot=combobox-chip-remove]:pr-0.5',
+                'focus-default inline-flex h-[21px] max-w-full min-w-0 items-center justify-center gap-[2px] rounded bg-surface-page border border-border-default px-[6px] text-sm font-normal text-text-secondary outline-none has-disabled:pointer-events-none has-disabled:cursor-not-allowed has-disabled:opacity-50 has-data-[slot=combobox-chip-remove]:pr-0.5',
                 className
             )}
             {...props}

--- a/packages/webapp/src/components/ui/Combobox.tsx
+++ b/packages/webapp/src/components/ui/Combobox.tsx
@@ -545,7 +545,7 @@ const ComboboxChips = React.forwardRef<HTMLDivElement, React.ComponentPropsWitho
                 ref={ref}
                 data-slot="combobox-chips"
                 className={cn(
-                    'flex flex-wrap items-center gap-1.5 rounded border border-border-muted bg-surface-canvas px-2 text-sm outline-none focus:outline-none focus-visible:outline-none focus-within:border-border-muted has-data-[slot=combobox-chip]:px-1.5',
+                    'flex flex-wrap items-center gap-1.5 rounded border border-border-muted bg-surface-canvas px-2 py-1.5 text-sm outline-none focus:outline-none focus-visible:outline-none focus-within:border-border-muted has-data-[slot=combobox-chip]:px-1.5',
                     className
                 )}
                 {...props}

--- a/packages/webapp/src/pages/Team/Billing/Show.tsx
+++ b/packages/webapp/src/pages/Team/Billing/Show.tsx
@@ -56,8 +56,7 @@ export const TeamBilling: React.FC = () => {
                 {canManageBilling && (
                     <>
                         <Separator />
-                        <div id="payment-and-invoices" className="flex flex-col gap-4">
-                            <span className="text-text-strong text-body-medium-medium">Billing information</span>
+                        <div id="payment-and-invoices">
                             <Payment />
                         </div>
                     </>

--- a/packages/webapp/src/pages/Team/Billing/components/InvoicingAddressFields.tsx
+++ b/packages/webapp/src/pages/Team/Billing/components/InvoicingAddressFields.tsx
@@ -1,7 +1,7 @@
 import { Plus, Trash2 } from 'lucide-react';
 import { useFormContext, useWatch } from 'react-hook-form';
 
-import { Card, CardAction, CardContent, CardHeader, CardTitle, IconButton, Input } from '@nangohq/design-system';
+import { IconButton, Input } from '@nangohq/design-system';
 
 import { FormControl, FormField, FormItem, FormLabel, FormMessage } from '@/components/ui/Form';
 import { Select, SelectContent, SelectItem, SelectTrigger, SelectValue } from '@/components/ui/Select';
@@ -24,28 +24,24 @@ export const InvoicingAddressFields: React.FC = () => {
     };
 
     return (
-        <Card>
-            <CardHeader>
-                <CardTitle>
-                    <span className="flex items-center gap-2">
-                        Billing address
-                        <OptionalTag />
-                    </span>
-                </CardTitle>
-                <CardAction>
-                    {address ? (
-                        <IconButton type="button" variant="ghost" size="2xs" onClick={handleRemove} label="Remove line">
-                            <Trash2 />
-                        </IconButton>
-                    ) : (
-                        <IconButton type="button" variant="ghost" size="2xs" onClick={handleAdd} label="Add line">
-                            <Plus />
-                        </IconButton>
-                    )}
-                </CardAction>
-            </CardHeader>
+        <div className="border-t border-border-muted">
+            <div className="p-4 flex items-center justify-between">
+                <span className="flex items-center gap-2 text-text-strong text-ds-lg font-ds-medium leading-ds-snug tracking-ds-tight">
+                    Billing address
+                    <OptionalTag />
+                </span>
+                {address ? (
+                    <IconButton type="button" variant="ghost" size="2xs" onClick={handleRemove} label="Remove line">
+                        <Trash2 />
+                    </IconButton>
+                ) : (
+                    <IconButton type="button" variant="ghost" size="2xs" onClick={handleAdd} label="Add line">
+                        <Plus />
+                    </IconButton>
+                )}
+            </div>
             {address && (
-                <CardContent>
+                <div className="px-4 pb-4">
                     <div className="grid grid-cols-2 items-start gap-3">
                         <FormField
                             control={control}
@@ -139,8 +135,8 @@ export const InvoicingAddressFields: React.FC = () => {
                             )}
                         />
                     </div>
-                </CardContent>
+                </div>
             )}
-        </Card>
+        </div>
     );
 };

--- a/packages/webapp/src/pages/Team/Billing/components/InvoicingAddressFields.tsx
+++ b/packages/webapp/src/pages/Team/Billing/components/InvoicingAddressFields.tsx
@@ -26,7 +26,7 @@ export const InvoicingAddressFields: React.FC = () => {
     return (
         <div className="border-t border-border-muted">
             <div className="p-4 flex items-center justify-between">
-                <span className="flex items-center gap-2 text-text-strong text-ds-lg font-ds-medium leading-ds-snug tracking-ds-tight">
+                <span className="flex items-center gap-2 text-text-strong text-body-medium-regular">
                     Billing address
                     <OptionalTag />
                 </span>

--- a/packages/webapp/src/pages/Team/Billing/components/InvoicingAddressFields.tsx
+++ b/packages/webapp/src/pages/Team/Billing/components/InvoicingAddressFields.tsx
@@ -1,12 +1,11 @@
-import { Plus, Trash2 } from 'lucide-react';
 import { useFormContext, useWatch } from 'react-hook-form';
 
-import { IconButton, Input } from '@nangohq/design-system';
+import { Input } from '@nangohq/design-system';
 
 import { FormControl, FormField, FormItem, FormLabel, FormMessage } from '@/components/ui/Form';
 import { Select, SelectContent, SelectItem, SelectTrigger, SelectValue } from '@/components/ui/Select';
 import { countryCodes } from '../invoicingConstants';
-import { OptionalTag } from './InvoicingDetailsForm';
+import { InvoicingOptionalSection } from './InvoicingOptionalSection';
 
 import type { InvoicingFormData } from './InvoicingDetailsForm';
 
@@ -25,119 +24,107 @@ export const InvoicingAddressFields: React.FC<{ onExpand: () => void }> = ({ onE
     };
 
     return (
-        <div className="border-t border-border-muted">
-            <div className="p-4 flex items-center justify-between">
-                <span className="flex items-center gap-2 text-text-strong text-body-medium-regular">
-                    Billing address
-                    <OptionalTag />
-                </span>
-                {address ? (
-                    <IconButton type="button" variant="ghost" size="2xs" onClick={handleRemove} label="Remove line">
-                        <Trash2 />
-                    </IconButton>
-                ) : (
-                    <IconButton type="button" variant="ghost" size="2xs" onClick={handleAdd} label="Add line">
-                        <Plus />
-                    </IconButton>
-                )}
+        <InvoicingOptionalSection
+            title="Billing address"
+            present={!!address}
+            onAdd={handleAdd}
+            onRemove={handleRemove}
+            addLabel="Add line"
+            removeLabel="Remove line"
+        >
+            <div className="grid grid-cols-2 items-start gap-3">
+                <FormField
+                    control={control}
+                    name="address.line1"
+                    render={({ field }) => (
+                        <FormItem>
+                            <FormLabel>Address line 1</FormLabel>
+                            <FormControl>
+                                <Input placeholder="123 Main St" {...field} value={field.value ?? ''} />
+                            </FormControl>
+                            <FormMessage />
+                        </FormItem>
+                    )}
+                />
+                <FormField
+                    control={control}
+                    name="address.line2"
+                    render={({ field }) => (
+                        <FormItem>
+                            <FormLabel>Address line 2</FormLabel>
+                            <FormControl>
+                                <Input placeholder="Suite 100" {...field} value={field.value ?? ''} />
+                            </FormControl>
+                            <FormMessage />
+                        </FormItem>
+                    )}
+                />
+                <FormField
+                    control={control}
+                    name="address.city"
+                    render={({ field }) => (
+                        <FormItem>
+                            <FormLabel>City</FormLabel>
+                            <FormControl>
+                                <Input placeholder="San Francisco" {...field} value={field.value ?? ''} />
+                            </FormControl>
+                            <FormMessage />
+                        </FormItem>
+                    )}
+                />
+                <FormField
+                    control={control}
+                    name="address.state"
+                    render={({ field }) => (
+                        <FormItem>
+                            <FormLabel>State</FormLabel>
+                            <FormControl>
+                                <Input placeholder="CA" {...field} value={field.value ?? ''} />
+                            </FormControl>
+                            <FormMessage />
+                        </FormItem>
+                    )}
+                />
+                <FormField
+                    control={control}
+                    name="address.postalCode"
+                    render={({ field }) => (
+                        <FormItem>
+                            <FormLabel>Postal code</FormLabel>
+                            <FormControl>
+                                <Input placeholder="94105" {...field} value={field.value ?? ''} />
+                            </FormControl>
+                            <FormMessage />
+                        </FormItem>
+                    )}
+                />
+                <FormField
+                    control={control}
+                    name="address.country"
+                    render={({ field }) => (
+                        <FormItem>
+                            <FormLabel className="flex gap-1 items-center">
+                                Country <span className="text-text-danger">*</span>
+                            </FormLabel>
+                            <Select value={field.value || undefined} onValueChange={field.onChange}>
+                                <FormControl>
+                                    <SelectTrigger className="w-full !bg-surface-canvas border-border-muted text-text-strong data-[placeholder]:text-text-muted hover:!bg-surface-canvas focus:border-border-default">
+                                        <SelectValue placeholder="Choose country" />
+                                    </SelectTrigger>
+                                </FormControl>
+                                <SelectContent>
+                                    {countryCodes.map(({ value, label }) => (
+                                        <SelectItem key={value} value={value}>
+                                            {label}
+                                        </SelectItem>
+                                    ))}
+                                </SelectContent>
+                            </Select>
+                            <FormMessage />
+                        </FormItem>
+                    )}
+                />
             </div>
-            {address && (
-                <div className="px-4 pb-4">
-                    <div className="grid grid-cols-2 items-start gap-3">
-                        <FormField
-                            control={control}
-                            name="address.line1"
-                            render={({ field }) => (
-                                <FormItem>
-                                    <FormLabel>Address line 1</FormLabel>
-                                    <FormControl>
-                                        <Input placeholder="123 Main St" {...field} value={field.value ?? ''} />
-                                    </FormControl>
-                                    <FormMessage />
-                                </FormItem>
-                            )}
-                        />
-                        <FormField
-                            control={control}
-                            name="address.line2"
-                            render={({ field }) => (
-                                <FormItem>
-                                    <FormLabel>Address line 2</FormLabel>
-                                    <FormControl>
-                                        <Input placeholder="Suite 100" {...field} value={field.value ?? ''} />
-                                    </FormControl>
-                                    <FormMessage />
-                                </FormItem>
-                            )}
-                        />
-                        <FormField
-                            control={control}
-                            name="address.city"
-                            render={({ field }) => (
-                                <FormItem>
-                                    <FormLabel>City</FormLabel>
-                                    <FormControl>
-                                        <Input placeholder="San Francisco" {...field} value={field.value ?? ''} />
-                                    </FormControl>
-                                    <FormMessage />
-                                </FormItem>
-                            )}
-                        />
-                        <FormField
-                            control={control}
-                            name="address.state"
-                            render={({ field }) => (
-                                <FormItem>
-                                    <FormLabel>State</FormLabel>
-                                    <FormControl>
-                                        <Input placeholder="CA" {...field} value={field.value ?? ''} />
-                                    </FormControl>
-                                    <FormMessage />
-                                </FormItem>
-                            )}
-                        />
-                        <FormField
-                            control={control}
-                            name="address.postalCode"
-                            render={({ field }) => (
-                                <FormItem>
-                                    <FormLabel>Postal code</FormLabel>
-                                    <FormControl>
-                                        <Input placeholder="94105" {...field} value={field.value ?? ''} />
-                                    </FormControl>
-                                    <FormMessage />
-                                </FormItem>
-                            )}
-                        />
-                        <FormField
-                            control={control}
-                            name="address.country"
-                            render={({ field }) => (
-                                <FormItem>
-                                    <FormLabel className="flex gap-1 items-center">
-                                        Country <span className="text-text-danger">*</span>
-                                    </FormLabel>
-                                    <Select value={field.value || undefined} onValueChange={field.onChange}>
-                                        <FormControl>
-                                            <SelectTrigger className="w-full !bg-surface-canvas border-border-muted text-text-strong data-[placeholder]:text-text-muted hover:!bg-surface-canvas focus:border-border-default">
-                                                <SelectValue placeholder="Choose country" />
-                                            </SelectTrigger>
-                                        </FormControl>
-                                        <SelectContent>
-                                            {countryCodes.map(({ value, label }) => (
-                                                <SelectItem key={value} value={value}>
-                                                    {label}
-                                                </SelectItem>
-                                            ))}
-                                        </SelectContent>
-                                    </Select>
-                                    <FormMessage />
-                                </FormItem>
-                            )}
-                        />
-                    </div>
-                </div>
-            )}
-        </div>
+        </InvoicingOptionalSection>
     );
 };

--- a/packages/webapp/src/pages/Team/Billing/components/InvoicingAddressFields.tsx
+++ b/packages/webapp/src/pages/Team/Billing/components/InvoicingAddressFields.tsx
@@ -108,7 +108,7 @@ export const InvoicingAddressFields: React.FC<{ onExpand: () => void }> = ({ onE
                             </FormLabel>
                             <Select value={field.value || undefined} onValueChange={field.onChange}>
                                 <FormControl>
-                                    <SelectTrigger className="w-full">
+                                    <SelectTrigger className="w-full bg-surface-input text-text-default">
                                         <SelectValue placeholder="Choose country" />
                                     </SelectTrigger>
                                 </FormControl>

--- a/packages/webapp/src/pages/Team/Billing/components/InvoicingAddressFields.tsx
+++ b/packages/webapp/src/pages/Team/Billing/components/InvoicingAddressFields.tsx
@@ -108,7 +108,7 @@ export const InvoicingAddressFields: React.FC<{ onExpand: () => void }> = ({ onE
                             </FormLabel>
                             <Select value={field.value || undefined} onValueChange={field.onChange}>
                                 <FormControl>
-                                    <SelectTrigger className="w-full !bg-surface-canvas border-border-muted text-text-strong data-[placeholder]:text-text-muted hover:!bg-surface-canvas focus:border-border-default">
+                                    <SelectTrigger className="w-full">
                                         <SelectValue placeholder="Choose country" />
                                     </SelectTrigger>
                                 </FormControl>

--- a/packages/webapp/src/pages/Team/Billing/components/InvoicingAddressFields.tsx
+++ b/packages/webapp/src/pages/Team/Billing/components/InvoicingAddressFields.tsx
@@ -1,4 +1,5 @@
 import { Plus, Trash2 } from 'lucide-react';
+import { useRef } from 'react';
 import { useFormContext, useWatch } from 'react-hook-form';
 
 import { IconButton, Input } from '@nangohq/design-system';
@@ -13,10 +14,13 @@ import type { InvoicingFormData } from './InvoicingDetailsForm';
 export const InvoicingAddressFields: React.FC = () => {
     const { control, setValue, clearErrors } = useFormContext<InvoicingFormData>();
     const address = useWatch({ control, name: 'address' });
+    const sectionRef = useRef<HTMLDivElement>(null);
 
     const handleAdd = () => {
         setValue('address', { line1: null, line2: null, city: null, state: null, postalCode: null, country: '' }, { shouldDirty: true });
         clearErrors('address');
+        // Scroll the newly-expanded fields into view once React has rendered them.
+        requestAnimationFrame(() => sectionRef.current?.scrollIntoView({ behavior: 'smooth', block: 'nearest' }));
     };
 
     const handleRemove = () => {
@@ -24,7 +28,7 @@ export const InvoicingAddressFields: React.FC = () => {
     };
 
     return (
-        <div className="border-t border-border-muted">
+        <div ref={sectionRef} className="border-t border-border-muted">
             <div className="p-4 flex items-center justify-between">
                 <span className="flex items-center gap-2 text-text-strong text-body-medium-regular">
                     Billing address

--- a/packages/webapp/src/pages/Team/Billing/components/InvoicingAddressFields.tsx
+++ b/packages/webapp/src/pages/Team/Billing/components/InvoicingAddressFields.tsx
@@ -1,5 +1,4 @@
 import { Plus, Trash2 } from 'lucide-react';
-import { useRef } from 'react';
 import { useFormContext, useWatch } from 'react-hook-form';
 
 import { IconButton, Input } from '@nangohq/design-system';
@@ -11,16 +10,14 @@ import { OptionalTag } from './InvoicingDetailsForm';
 
 import type { InvoicingFormData } from './InvoicingDetailsForm';
 
-export const InvoicingAddressFields: React.FC = () => {
+export const InvoicingAddressFields: React.FC<{ onExpand: () => void }> = ({ onExpand }) => {
     const { control, setValue, clearErrors } = useFormContext<InvoicingFormData>();
     const address = useWatch({ control, name: 'address' });
-    const sectionRef = useRef<HTMLDivElement>(null);
 
     const handleAdd = () => {
         setValue('address', { line1: null, line2: null, city: null, state: null, postalCode: null, country: '' }, { shouldDirty: true });
         clearErrors('address');
-        // Scroll the newly-expanded fields into view once React has rendered them.
-        requestAnimationFrame(() => sectionRef.current?.scrollIntoView({ behavior: 'smooth', block: 'nearest' }));
+        onExpand();
     };
 
     const handleRemove = () => {
@@ -28,7 +25,7 @@ export const InvoicingAddressFields: React.FC = () => {
     };
 
     return (
-        <div ref={sectionRef} className="border-t border-border-muted">
+        <div className="border-t border-border-muted">
             <div className="p-4 flex items-center justify-between">
                 <span className="flex items-center gap-2 text-text-strong text-body-medium-regular">
                     Billing address

--- a/packages/webapp/src/pages/Team/Billing/components/InvoicingDetailsForm.tsx
+++ b/packages/webapp/src/pages/Team/Billing/components/InvoicingDetailsForm.tsx
@@ -3,7 +3,7 @@ import { useEffect } from 'react';
 import { useForm } from 'react-hook-form';
 import { z } from 'zod';
 
-import { Button, Card, CardContent, CardHeader, CardTitle, Input } from '@nangohq/design-system';
+import { Button, Input } from '@nangohq/design-system';
 
 import { Form, FormControl, FormField, FormItem, FormLabel, FormMessage } from '@/components/ui/Form';
 import { Skeleton } from '@/components/ui/Skeleton';
@@ -12,6 +12,7 @@ import { useToast } from '@/hooks/useToast';
 import { useStore } from '@/store';
 import { countryCodes, taxIdTypes } from '../invoicingConstants';
 import { InvoicingAddressFields } from './InvoicingAddressFields';
+import { InvoicingEmailsField } from './InvoicingEmailsField';
 import { InvoicingTaxIdFields } from './InvoicingTaxIdFields';
 
 import type { BillingCustomer } from '@nangohq/types';
@@ -40,7 +41,7 @@ const taxIdSchema = z.object({
 
 const schema = z.object({
     legalEntityName: z.string().min(1, 'Required'),
-    email: z.string().email('Valid email required'),
+    emails: z.array(z.string().email('Invalid email address')).min(1, 'At least one billing email required'),
     address: addressSchema.nullable(),
     taxId: taxIdSchema.nullable()
 });
@@ -50,7 +51,7 @@ export type InvoicingFormData = z.infer<typeof schema>;
 function toFormData(customer: BillingCustomer): InvoicingFormData {
     return {
         legalEntityName: customer.invoicingDetails.legalEntityName,
-        email: customer.invoicingDetails.email,
+        emails: [customer.invoicingDetails.email, ...customer.invoicingDetails.additionalEmails],
         address: customer.invoicingDetails.address ? { ...customer.invoicingDetails.address, country: customer.invoicingDetails.address.country ?? '' } : null,
         taxId: customer.invoicingDetails.taxId
     };
@@ -74,7 +75,13 @@ export const InvoicingDetailsForm: React.FC<{ customer: BillingCustomer | undefi
 
     const onSubmit = async (data: InvoicingFormData) => {
         try {
-            await putAsync({ legalEntityName: data.legalEntityName, email: data.email, address: data.address, taxId: data.taxId });
+            await putAsync({
+                legalEntityName: data.legalEntityName,
+                email: data.emails[0]!,
+                additionalEmails: data.emails.slice(1),
+                address: data.address,
+                taxId: data.taxId
+            });
             toast({ title: 'Invoicing details updated', variant: 'success' });
         } catch {
             toast({ title: 'Failed to update invoicing details', variant: 'error' });
@@ -83,7 +90,7 @@ export const InvoicingDetailsForm: React.FC<{ customer: BillingCustomer | undefi
 
     if (!customer) {
         return (
-            <div className="flex flex-col gap-3">
+            <div className="border-t border-border-muted p-4 flex flex-col gap-3">
                 <Skeleton className="w-40 h-5" />
                 <Skeleton className="w-full h-9" />
                 <Skeleton className="w-full h-9" />
@@ -93,51 +100,30 @@ export const InvoicingDetailsForm: React.FC<{ customer: BillingCustomer | undefi
 
     return (
         <Form {...form}>
-            <form onSubmit={form.handleSubmit(onSubmit)} className="flex flex-col gap-6">
-                <Card>
-                    <CardHeader>
-                        <CardTitle>Billing information</CardTitle>
-                    </CardHeader>
-                    <CardContent>
-                        <div className="flex flex-row items-start gap-5 [&>*]:flex-1">
-                            <FormField
-                                control={form.control}
-                                name="legalEntityName"
-                                render={({ field }) => (
-                                    <FormItem>
-                                        <FormLabel className="flex gap-1 items-center">
-                                            Legal entity name <span className="text-text-danger">*</span>
-                                        </FormLabel>
-                                        <FormControl>
-                                            <Input placeholder="Acme Inc." {...field} />
-                                        </FormControl>
-                                        <FormMessage />
-                                    </FormItem>
-                                )}
-                            />
-                            <FormField
-                                control={form.control}
-                                name="email"
-                                render={({ field }) => (
-                                    <FormItem>
-                                        <FormLabel className="flex gap-1 items-center">
-                                            Billing email <span className="text-text-danger">*</span>
-                                        </FormLabel>
-                                        <FormControl>
-                                            <Input type="email" placeholder="billing@company.com" {...field} />
-                                        </FormControl>
-                                        <FormMessage />
-                                    </FormItem>
-                                )}
-                            />
-                        </div>
-                    </CardContent>
-                </Card>
+            <form onSubmit={form.handleSubmit(onSubmit)}>
+                <div className="border-t border-border-muted p-4 flex flex-row items-start gap-5 [&>*]:flex-1">
+                    <FormField
+                        control={form.control}
+                        name="legalEntityName"
+                        render={({ field }) => (
+                            <FormItem>
+                                <FormLabel className="flex gap-1 items-center">
+                                    Legal entity name <span className="text-text-danger">*</span>
+                                </FormLabel>
+                                <FormControl>
+                                    <Input placeholder="Acme Inc." {...field} />
+                                </FormControl>
+                                <FormMessage />
+                            </FormItem>
+                        )}
+                    />
+                    <InvoicingEmailsField />
+                </div>
 
                 <InvoicingAddressFields />
                 <InvoicingTaxIdFields />
 
-                <div className="flex justify-start">
+                <div className="border-t border-border-muted p-4">
                     <Button type="submit" variant="primary" size="md" loading={isPending}>
                         Save changes
                     </Button>

--- a/packages/webapp/src/pages/Team/Billing/components/InvoicingDetailsForm.tsx
+++ b/packages/webapp/src/pages/Team/Billing/components/InvoicingDetailsForm.tsx
@@ -13,6 +13,7 @@ import { useStore } from '@/store';
 import { countryCodes, taxIdTypes } from '../invoicingConstants';
 import { InvoicingAddressFields } from './InvoicingAddressFields';
 import { InvoicingEmailsField } from './InvoicingEmailsField';
+import { toFormData } from './invoicingFormData.js';
 import { InvoicingTaxIdFields } from './InvoicingTaxIdFields';
 
 import type { BillingCustomer } from '@nangohq/types';
@@ -62,19 +63,6 @@ const schema = z
     });
 
 export type InvoicingFormData = z.infer<typeof schema>;
-
-function toFormData(customer: BillingCustomer): InvoicingFormData {
-    return {
-        legalEntityName: customer.invoicingDetails.legalEntityName,
-        // Defensive: `additionalEmails` is typed as required, but a client can still hit an
-        // API version that predates the field (e.g. this webapp build outrunning the backend
-        // deploy), so a real response can omit it despite the type's guarantee.
-        emails: [customer.invoicingDetails.email, ...(customer.invoicingDetails.additionalEmails ?? [])],
-        emailsDraft: '',
-        address: customer.invoicingDetails.address ? { ...customer.invoicingDetails.address, country: customer.invoicingDetails.address.country ?? '' } : null,
-        taxId: customer.invoicingDetails.taxId
-    };
-}
 
 export const InvoicingDetailsForm: React.FC<{ customer: BillingCustomer | undefined }> = ({ customer }) => {
     const env = useStore((state) => state.env);

--- a/packages/webapp/src/pages/Team/Billing/components/InvoicingDetailsForm.tsx
+++ b/packages/webapp/src/pages/Team/Billing/components/InvoicingDetailsForm.tsx
@@ -66,7 +66,10 @@ export type InvoicingFormData = z.infer<typeof schema>;
 function toFormData(customer: BillingCustomer): InvoicingFormData {
     return {
         legalEntityName: customer.invoicingDetails.legalEntityName,
-        emails: [customer.invoicingDetails.email, ...customer.invoicingDetails.additionalEmails],
+        // Defensive: `additionalEmails` is typed as required, but a client can still hit an
+        // API version that predates the field (e.g. this webapp build outrunning the backend
+        // deploy), so a real response can omit it despite the type's guarantee.
+        emails: [customer.invoicingDetails.email, ...(customer.invoicingDetails.additionalEmails ?? [])],
         emailsDraft: '',
         address: customer.invoicingDetails.address ? { ...customer.invoicingDetails.address, country: customer.invoicingDetails.address.country ?? '' } : null,
         taxId: customer.invoicingDetails.taxId

--- a/packages/webapp/src/pages/Team/Billing/components/InvoicingDetailsForm.tsx
+++ b/packages/webapp/src/pages/Team/Billing/components/InvoicingDetailsForm.tsx
@@ -39,12 +39,27 @@ const taxIdSchema = z.object({
     value: z.string().min(1, 'Required')
 });
 
-const schema = z.object({
-    legalEntityName: z.string().min(1, 'Required'),
-    emails: z.array(z.string().email('Invalid email address')).min(1, 'At least one billing email required'),
-    address: addressSchema.nullable(),
-    taxId: taxIdSchema.nullable()
-});
+const schema = z
+    .object({
+        legalEntityName: z.string().min(1, 'Required'),
+        emails: z
+            .array(z.string().email('Invalid email address'))
+            .min(1, 'At least one billing email required')
+            .max(50, 'Maximum 50 billing email addresses')
+            .refine((emails) => new Set(emails.map((email) => email.toLowerCase())).size === emails.length, 'Duplicate billing email address'),
+        // Tracks text left in the chip input's textbox that hasn't been committed to `emails`
+        // yet (e.g. a typo the user hasn't fixed or cleared). Not sent to the API — its only
+        // job is to fail validation so Save can't silently drop it.
+        emailsDraft: z.string(),
+        address: addressSchema.nullable(),
+        taxId: taxIdSchema.nullable()
+    })
+    .superRefine((data, ctx) => {
+        const draft = data.emailsDraft.trim();
+        if (draft && !z.string().email().safeParse(draft).success) {
+            ctx.addIssue({ code: 'custom', path: ['emails'], message: `Invalid email address: ${draft}` });
+        }
+    });
 
 export type InvoicingFormData = z.infer<typeof schema>;
 
@@ -52,6 +67,7 @@ function toFormData(customer: BillingCustomer): InvoicingFormData {
     return {
         legalEntityName: customer.invoicingDetails.legalEntityName,
         emails: [customer.invoicingDetails.email, ...customer.invoicingDetails.additionalEmails],
+        emailsDraft: '',
         address: customer.invoicingDetails.address ? { ...customer.invoicingDetails.address, country: customer.invoicingDetails.address.country ?? '' } : null,
         taxId: customer.invoicingDetails.taxId
     };

--- a/packages/webapp/src/pages/Team/Billing/components/InvoicingDetailsForm.tsx
+++ b/packages/webapp/src/pages/Team/Billing/components/InvoicingDetailsForm.tsx
@@ -3,7 +3,7 @@ import { useEffect } from 'react';
 import { useForm } from 'react-hook-form';
 import { z } from 'zod';
 
-import { Button, Input } from '@nangohq/design-system';
+import { Badge, Button, Card, Input } from '@nangohq/design-system';
 
 import { Form, FormControl, FormField, FormItem, FormLabel, FormMessage } from '@/components/ui/Form';
 import { Skeleton } from '@/components/ui/Skeleton';
@@ -18,9 +18,7 @@ import { InvoicingTaxIdFields } from './InvoicingTaxIdFields';
 
 import type { BillingCustomer } from '@nangohq/types';
 
-export const OptionalTag = () => (
-    <span className="bg-surface-page border border-border-strong rounded px-2 py-0.5 text-body-small-regular text-text-muted">Optional</span>
-);
+export const OptionalTag = () => <Badge variant="secondary">Optional</Badge>;
 
 const countryValues = countryCodes.map((c) => c.value) as [string, ...string[]];
 const taxIdTypeValues = taxIdTypes.map((t) => t.value) as [string, ...string[]];
@@ -64,7 +62,10 @@ const schema = z
 
 export type InvoicingFormData = z.infer<typeof schema>;
 
-export const InvoicingDetailsForm: React.FC<{ customer: BillingCustomer | undefined }> = ({ customer }) => {
+export const InvoicingDetailsForm: React.FC<{ customer: BillingCustomer | undefined; paymentMethodSection: React.ReactNode }> = ({
+    customer,
+    paymentMethodSection
+}) => {
     const env = useStore((state) => state.env);
     const { toast } = useToast();
     const { mutateAsync: putAsync, isPending } = usePutBillingInvoicingDetails(env);
@@ -95,43 +96,48 @@ export const InvoicingDetailsForm: React.FC<{ customer: BillingCustomer | undefi
         }
     };
 
-    if (!customer) {
-        return (
-            <div className="border-t border-border-muted p-4 flex flex-col gap-3">
-                <Skeleton className="w-40 h-5" />
-                <Skeleton className="w-full h-9" />
-                <Skeleton className="w-full h-9" />
-            </div>
-        );
-    }
-
     return (
         <Form {...form}>
             <form onSubmit={form.handleSubmit(onSubmit)}>
-                <div className="border-t border-border-muted p-4 flex flex-row items-start gap-5 [&>*]:flex-1">
-                    <FormField
-                        control={form.control}
-                        name="legalEntityName"
-                        render={({ field }) => (
-                            <FormItem>
-                                <FormLabel className="flex gap-1 items-center">
-                                    Legal entity name <span className="text-text-danger">*</span>
-                                </FormLabel>
-                                <FormControl>
-                                    <Input placeholder="Acme Inc." {...field} />
-                                </FormControl>
-                                <FormMessage />
-                            </FormItem>
-                        )}
-                    />
-                    <InvoicingEmailsField />
-                </div>
+                <Card>
+                    {paymentMethodSection}
+                    {customer ? (
+                        <div className="border-t border-border-muted p-4 flex flex-row items-start gap-5 [&>*]:flex-1">
+                            <FormField
+                                control={form.control}
+                                name="legalEntityName"
+                                render={({ field }) => (
+                                    <FormItem>
+                                        <FormLabel className="flex gap-1 items-center">
+                                            Legal entity name <span className="text-text-danger">*</span>
+                                        </FormLabel>
+                                        <FormControl>
+                                            <Input placeholder="Acme Inc." {...field} />
+                                        </FormControl>
+                                        <FormMessage />
+                                    </FormItem>
+                                )}
+                            />
+                            <InvoicingEmailsField />
+                        </div>
+                    ) : (
+                        <div className="border-t border-border-muted p-4 flex flex-col gap-3">
+                            <Skeleton className="w-40 h-5" />
+                            <Skeleton className="w-full h-9" />
+                            <Skeleton className="w-full h-9" />
+                        </div>
+                    )}
 
-                <InvoicingAddressFields />
-                <InvoicingTaxIdFields />
+                    {customer && (
+                        <>
+                            <InvoicingAddressFields />
+                            <InvoicingTaxIdFields />
+                        </>
+                    )}
+                </Card>
 
-                <div className="border-t border-border-muted p-4">
-                    <Button type="submit" variant="primary" size="md" loading={isPending}>
+                <div className="pt-4">
+                    <Button type="submit" variant="primary" size="md" loading={isPending} disabled={!customer}>
                         Save changes
                     </Button>
                 </div>

--- a/packages/webapp/src/pages/Team/Billing/components/InvoicingDetailsForm.tsx
+++ b/packages/webapp/src/pages/Team/Billing/components/InvoicingDetailsForm.tsx
@@ -1,5 +1,5 @@
 import { zodResolver } from '@hookform/resolvers/zod';
-import { useEffect } from 'react';
+import { useEffect, useRef } from 'react';
 import { useForm } from 'react-hook-form';
 import { z } from 'zod';
 
@@ -68,6 +68,10 @@ export const InvoicingDetailsForm: React.FC<{
     const env = useStore((state) => state.env);
     const { toast } = useToast();
     const { mutateAsync: putAsync, isPending } = usePutBillingInvoicingDetails(env);
+    const formRef = useRef<HTMLFormElement>(null);
+    // Scrolls to the end of the whole form (past Save changes), not just the newly-expanded
+    // section, so there's no lingering "is there more below?" once a section is expanded.
+    const scrollFormIntoView = () => requestAnimationFrame(() => formRef.current?.scrollIntoView({ behavior: 'smooth', block: 'end' }));
 
     const form = useForm<InvoicingFormData>({
         resolver: zodResolver(schema),
@@ -97,7 +101,7 @@ export const InvoicingDetailsForm: React.FC<{
 
     return (
         <Form {...form}>
-            <form onSubmit={form.handleSubmit(onSubmit)}>
+            <form ref={formRef} onSubmit={form.handleSubmit(onSubmit)}>
                 <Card>
                     {paymentMethodSection}
                     {customer ? (
@@ -129,8 +133,8 @@ export const InvoicingDetailsForm: React.FC<{
 
                     {customer && (
                         <>
-                            <InvoicingAddressFields />
-                            <InvoicingTaxIdFields />
+                            <InvoicingAddressFields onExpand={scrollFormIntoView} />
+                            <InvoicingTaxIdFields onExpand={scrollFormIntoView} />
                         </>
                     )}
                 </Card>

--- a/packages/webapp/src/pages/Team/Billing/components/InvoicingDetailsForm.tsx
+++ b/packages/webapp/src/pages/Team/Billing/components/InvoicingDetailsForm.tsx
@@ -53,8 +53,12 @@ const schema = z
     })
     .superRefine((data, ctx) => {
         const draft = (data.emailsDraft ?? '').trim();
-        if (draft && !z.string().email().safeParse(draft).success) {
+        if (!draft) return;
+
+        if (!z.string().email().safeParse(draft).success) {
             ctx.addIssue({ code: 'custom', path: ['emails'], message: `Invalid email address: ${draft}` });
+        } else if (data.emails.some((email) => email.toLowerCase() === draft.toLowerCase())) {
+            ctx.addIssue({ code: 'custom', path: ['emails'], message: `Already added: ${draft}` });
         }
     });
 

--- a/packages/webapp/src/pages/Team/Billing/components/InvoicingDetailsForm.tsx
+++ b/packages/webapp/src/pages/Team/Billing/components/InvoicingDetailsForm.tsx
@@ -60,10 +60,11 @@ const schema = z
 
 export type InvoicingFormData = z.infer<typeof schema>;
 
-export const InvoicingDetailsForm: React.FC<{ customer: BillingCustomer | undefined; paymentMethodSection: React.ReactNode }> = ({
-    customer,
-    paymentMethodSection
-}) => {
+export const InvoicingDetailsForm: React.FC<{
+    customer: BillingCustomer | undefined;
+    paymentMethodSection: React.ReactNode;
+    isLoading: boolean;
+}> = ({ customer, paymentMethodSection, isLoading }) => {
     const env = useStore((state) => state.env);
     const { toast } = useToast();
     const { mutateAsync: putAsync, isPending } = usePutBillingInvoicingDetails(env);
@@ -118,13 +119,13 @@ export const InvoicingDetailsForm: React.FC<{ customer: BillingCustomer | undefi
                             />
                             <InvoicingEmailsField />
                         </div>
-                    ) : (
+                    ) : isLoading ? (
                         <div className="border-t border-border-muted p-4 flex flex-col gap-3">
                             <Skeleton className="w-40 h-5" />
                             <Skeleton className="w-full h-9" />
                             <Skeleton className="w-full h-9" />
                         </div>
-                    )}
+                    ) : null}
 
                     {customer && (
                         <>

--- a/packages/webapp/src/pages/Team/Billing/components/InvoicingDetailsForm.tsx
+++ b/packages/webapp/src/pages/Team/Billing/components/InvoicingDetailsForm.tsx
@@ -47,12 +47,12 @@ const schema = z
             .max(50, 'Maximum 50 billing email addresses')
             .refine((emails) => new Set(emails.map((email) => email.toLowerCase())).size === emails.length, 'Duplicate billing email address'),
         // Uncommitted chip-input text; not sent to the API, just fails validation so Save can't drop it.
-        emailsDraft: z.string(),
+        emailsDraft: z.string().optional(),
         address: addressSchema.nullable(),
         taxId: taxIdSchema.nullable()
     })
     .superRefine((data, ctx) => {
-        const draft = data.emailsDraft.trim();
+        const draft = (data.emailsDraft ?? '').trim();
         if (draft && !z.string().email().safeParse(draft).success) {
             ctx.addIssue({ code: 'custom', path: ['emails'], message: `Invalid email address: ${draft}` });
         }

--- a/packages/webapp/src/pages/Team/Billing/components/InvoicingDetailsForm.tsx
+++ b/packages/webapp/src/pages/Team/Billing/components/InvoicingDetailsForm.tsx
@@ -69,8 +69,7 @@ export const InvoicingDetailsForm: React.FC<{
     const { toast } = useToast();
     const { mutateAsync: putAsync, isPending } = usePutBillingInvoicingDetails(env);
     const formRef = useRef<HTMLFormElement>(null);
-    // Scrolls to the end of the whole form (past Save changes), not just the newly-expanded
-    // section, so there's no lingering "is there more below?" once a section is expanded.
+    // Scrolls to the form's end (past Save changes), not just the newly-expanded section.
     const scrollFormIntoView = () => requestAnimationFrame(() => formRef.current?.scrollIntoView({ behavior: 'smooth', block: 'end' }));
 
     const form = useForm<InvoicingFormData>({

--- a/packages/webapp/src/pages/Team/Billing/components/InvoicingDetailsForm.tsx
+++ b/packages/webapp/src/pages/Team/Billing/components/InvoicingDetailsForm.tsx
@@ -104,7 +104,7 @@ export const InvoicingDetailsForm: React.FC<{
                 <Card>
                     {paymentMethodSection}
                     {customer ? (
-                        <div className="border-t border-border-muted p-4 flex flex-row items-start gap-5 [&>*]:flex-1">
+                        <div className="border-t border-border-muted p-4 flex flex-row items-start gap-5 [&>*]:flex-1 [&>*]:min-w-0">
                             <FormField
                                 control={form.control}
                                 name="legalEntityName"

--- a/packages/webapp/src/pages/Team/Billing/components/InvoicingDetailsForm.tsx
+++ b/packages/webapp/src/pages/Team/Billing/components/InvoicingDetailsForm.tsx
@@ -46,9 +46,7 @@ const schema = z
             .min(1, 'At least one billing email required')
             .max(50, 'Maximum 50 billing email addresses')
             .refine((emails) => new Set(emails.map((email) => email.toLowerCase())).size === emails.length, 'Duplicate billing email address'),
-        // Tracks text left in the chip input's textbox that hasn't been committed to `emails`
-        // yet (e.g. a typo the user hasn't fixed or cleared). Not sent to the API — its only
-        // job is to fail validation so Save can't silently drop it.
+        // Uncommitted chip-input text; not sent to the API, just fails validation so Save can't drop it.
         emailsDraft: z.string(),
         address: addressSchema.nullable(),
         taxId: taxIdSchema.nullable()

--- a/packages/webapp/src/pages/Team/Billing/components/InvoicingEmailsField.tsx
+++ b/packages/webapp/src/pages/Team/Billing/components/InvoicingEmailsField.tsx
@@ -1,4 +1,3 @@
-import { useState } from 'react';
 import { useFormContext, useWatch } from 'react-hook-form';
 import { z } from 'zod';
 
@@ -11,10 +10,14 @@ const emailSchema = z.string().email();
 
 export const InvoicingEmailsField: React.FC = () => {
     const { control, setValue, setError, clearErrors } = useFormContext<InvoicingFormData>();
-    // Defaults to [] for the render between the parent's `customer` becoming truthy
-    // and the `form.reset(toFormData(customer))` effect actually populating the field.
+    // Both default to [] / '' for the render between the parent's `customer` becoming
+    // truthy and the `form.reset(toFormData(customer))` effect actually populating the field.
     const emails = useWatch({ control, name: 'emails' }) ?? [];
-    const [inputValue, setInputValue] = useState('');
+    // Backed by the form (not local state) so leftover, uncommitted text is part of
+    // `InvoicingFormData` and the schema's `superRefine` can block Save on it instead of
+    // it silently vanishing if a revalidation pass clears the field's manually-set error.
+    const inputValue = useWatch({ control, name: 'emailsDraft' }) ?? '';
+    const setInputValue = (value: string) => setValue('emailsDraft', value);
 
     const commit = (next: string[]) => {
         setValue('emails', next, { shouldDirty: true, shouldValidate: true });
@@ -29,11 +32,19 @@ export const InvoicingEmailsField: React.FC = () => {
             .filter(Boolean);
         if (candidates.length === 0) return;
 
+        const existingLower = new Set(emails.map((e) => e.toLowerCase()));
         const invalid = candidates.filter((c) => !emailSchema.safeParse(c).success);
-        const valid = candidates.filter((c) => emailSchema.safeParse(c).success && !emails.includes(c));
+        const valid: string[] = [];
+        for (const c of candidates) {
+            if (!emailSchema.safeParse(c).success) continue;
+            const lower = c.toLowerCase();
+            if (existingLower.has(lower)) continue;
+            existingLower.add(lower);
+            valid.push(c);
+        }
 
         if (valid.length > 0) {
-            commit(Array.from(new Set([...emails, ...valid])));
+            commit([...emails, ...valid]);
         }
 
         if (invalid.length > 0) {

--- a/packages/webapp/src/pages/Team/Billing/components/InvoicingEmailsField.tsx
+++ b/packages/webapp/src/pages/Team/Billing/components/InvoicingEmailsField.tsx
@@ -1,0 +1,105 @@
+import { useState } from 'react';
+import { useFormContext, useWatch } from 'react-hook-form';
+import { z } from 'zod';
+
+import { FormControl, FormField, FormItem, FormLabel, FormMessage } from '@/components/ui/Form';
+import { Combobox, ComboboxChip, ComboboxChips, ComboboxChipsInput, ComboboxValue } from '../../../../components/ui/Combobox';
+
+import type { InvoicingFormData } from './InvoicingDetailsForm';
+
+const emailSchema = z.string().email();
+
+export const InvoicingEmailsField: React.FC = () => {
+    const { control, setValue, setError, clearErrors } = useFormContext<InvoicingFormData>();
+    // Defaults to [] for the render between the parent's `customer` becoming truthy
+    // and the `form.reset(toFormData(customer))` effect actually populating the field.
+    const emails = useWatch({ control, name: 'emails' }) ?? [];
+    const [inputValue, setInputValue] = useState('');
+
+    const commit = (next: string[]) => {
+        setValue('emails', next, { shouldDirty: true, shouldValidate: true });
+    };
+
+    // Splits on commas so a paste of "a@x.com, b@x.com" (or Figma's comma-separated
+    // display format) adds every address at once instead of one long invalid chip.
+    const addEmailsFromText = (text: string) => {
+        const candidates = text
+            .split(',')
+            .map((e) => e.trim())
+            .filter(Boolean);
+        if (candidates.length === 0) return;
+
+        const invalid = candidates.filter((c) => !emailSchema.safeParse(c).success);
+        const valid = candidates.filter((c) => emailSchema.safeParse(c).success && !emails.includes(c));
+
+        if (valid.length > 0) {
+            commit(Array.from(new Set([...emails, ...valid])));
+        }
+
+        if (invalid.length > 0) {
+            setError('emails', { type: 'manual', message: `Invalid email address: ${invalid.join(', ')}` });
+            setInputValue(invalid.join(', '));
+        } else {
+            clearErrors('emails');
+            setInputValue('');
+        }
+    };
+
+    const handleKeyDown = (e: React.KeyboardEvent<HTMLInputElement>) => {
+        if (e.key === 'Enter' || e.key === ',') {
+            e.preventDefault();
+            const value = (e.target as HTMLInputElement).value.replace(/,$/, '').trim();
+            if (!value) return;
+            addEmailsFromText(value);
+        }
+    };
+
+    const handlePaste = (e: React.ClipboardEvent<HTMLInputElement>) => {
+        const text = e.clipboardData.getData('text');
+        if (!text.includes(',')) return;
+        e.preventDefault();
+        addEmailsFromText(text);
+    };
+
+    const handleBlur = () => {
+        if (inputValue.trim()) {
+            addEmailsFromText(inputValue);
+        }
+    };
+
+    return (
+        <FormField
+            control={control}
+            name="emails"
+            render={() => (
+                <FormItem>
+                    <FormLabel className="flex gap-1 items-center">
+                        Billing email addresses <span className="text-text-danger">*</span>
+                    </FormLabel>
+                    <FormControl>
+                        <Combobox items={[]} multiple value={emails} inputValue={inputValue} onValueChange={commit} open={false}>
+                            <ComboboxChips className="min-h-9">
+                                {emails.length > 0 && (
+                                    <ComboboxValue>
+                                        {emails.map((email) => (
+                                            <ComboboxChip key={email}>{email}</ComboboxChip>
+                                        ))}
+                                    </ComboboxValue>
+                                )}
+                                <ComboboxChipsInput
+                                    placeholder={emails.length === 0 ? 'billing@company.com' : ''}
+                                    value={inputValue}
+                                    onChange={(e) => setInputValue((e.target as HTMLInputElement).value)}
+                                    onKeyDown={handleKeyDown}
+                                    onPaste={handlePaste}
+                                    onBlur={handleBlur}
+                                />
+                            </ComboboxChips>
+                        </Combobox>
+                    </FormControl>
+                    <FormMessage />
+                </FormItem>
+            )}
+        />
+    );
+};

--- a/packages/webapp/src/pages/Team/Billing/components/InvoicingEmailsField.tsx
+++ b/packages/webapp/src/pages/Team/Billing/components/InvoicingEmailsField.tsx
@@ -1,3 +1,4 @@
+import { useState } from 'react';
 import { useFormContext, useWatch } from 'react-hook-form';
 import { z } from 'zod';
 
@@ -19,8 +20,24 @@ export const InvoicingEmailsField: React.FC = () => {
     const inputValue = useWatch({ control, name: 'emailsDraft' }) ?? '';
     const setInputValue = (value: string) => setValue('emailsDraft', value);
 
+    // Removing a chip (backspace or the chip's own × button) is a state update, not a native
+    // text edit, so the browser's built-in Cmd/Ctrl+Z has nothing to undo. Track removals here
+    // so we can restore the last one ourselves — see handleKeyDown.
+    const [removedStack, setRemovedStack] = useState<string[]>([]);
+
     const commit = (next: string[]) => {
+        const removed = emails.filter((e) => !next.includes(e));
+        if (removed.length > 0) {
+            setRemovedStack((prev) => [...prev, ...removed]);
+        }
         setValue('emails', next, { shouldDirty: true, shouldValidate: true });
+    };
+
+    const undoLastRemoval = () => {
+        if (removedStack.length === 0) return;
+        const last = removedStack[removedStack.length - 1]!;
+        setRemovedStack((prev) => prev.slice(0, -1));
+        setValue('emails', [...emails, last], { shouldDirty: true, shouldValidate: true });
     };
 
     // Splits on commas so a paste of "a@x.com, b@x.com" (or Figma's comma-separated
@@ -62,6 +79,15 @@ export const InvoicingEmailsField: React.FC = () => {
             const value = (e.target as HTMLInputElement).value.replace(/,$/, '').trim();
             if (!value) return;
             addEmailsFromText(value);
+            return;
+        }
+
+        // Only take over Cmd/Ctrl+Z when the input is empty — otherwise let the browser's
+        // native undo handle an in-progress text edit in the draft input as usual.
+        const isUndo = (e.metaKey || e.ctrlKey) && !e.shiftKey && e.key.toLowerCase() === 'z';
+        if (isUndo && !(e.target as HTMLInputElement).value) {
+            e.preventDefault();
+            undoLastRemoval();
         }
     };
 
@@ -89,7 +115,9 @@ export const InvoicingEmailsField: React.FC = () => {
                     </FormLabel>
                     <FormControl>
                         <Combobox items={[]} multiple value={emails} inputValue={inputValue} onValueChange={commit} open={false}>
-                            <ComboboxChips className="min-h-9">
+                            {/* ComboboxChips defaults to bg-surface-canvas/border-border-muted, which reads as a
+                                different (much darker) fill than a plain Input — match Input's own tokens instead. */}
+                            <ComboboxChips className="min-h-9 bg-surface-input border-border-interactive">
                                 {emails.length > 0 && (
                                     <ComboboxValue>
                                         {emails.map((email) => (

--- a/packages/webapp/src/pages/Team/Billing/components/InvoicingEmailsField.tsx
+++ b/packages/webapp/src/pages/Team/Billing/components/InvoicingEmailsField.tsx
@@ -63,10 +63,9 @@ export const InvoicingEmailsField: React.FC = () => {
             valid.push(c);
         }
 
-        if (valid.length > 0) {
-            commit([...emails, ...valid]);
-        }
-
+        // Update the draft before commit() triggers validation, otherwise it revalidates while
+        // emailsDraft still holds the just-typed text, which now also matches the freshly
+        // committed email and gets flagged as a duplicate of itself.
         const errors: string[] = [];
         if (invalid.length > 0) errors.push(`Invalid email address: ${invalid.join(', ')}`);
         if (duplicate.length > 0) errors.push(`Already added: ${duplicate.join(', ')}`);
@@ -77,6 +76,10 @@ export const InvoicingEmailsField: React.FC = () => {
         } else {
             clearErrors('emails');
             setInputValue('');
+        }
+
+        if (valid.length > 0) {
+            commit([...emails, ...valid]);
         }
     };
 

--- a/packages/webapp/src/pages/Team/Billing/components/InvoicingEmailsField.tsx
+++ b/packages/webapp/src/pages/Team/Billing/components/InvoicingEmailsField.tsx
@@ -11,18 +11,13 @@ const emailSchema = z.string().email();
 
 export const InvoicingEmailsField: React.FC = () => {
     const { control, setValue, setError, clearErrors } = useFormContext<InvoicingFormData>();
-    // Both default to [] / '' for the render between the parent's `customer` becoming
-    // truthy and the `form.reset(toFormData(customer))` effect actually populating the field.
+    // Falls back to [] before form.reset(toFormData(customer)) populates it.
     const emails = useWatch({ control, name: 'emails' }) ?? [];
-    // Backed by the form (not local state) so leftover, uncommitted text is part of
-    // `InvoicingFormData` and the schema's `superRefine` can block Save on it instead of
-    // it silently vanishing if a revalidation pass clears the field's manually-set error.
+    // Backed by the form, not local state, so superRefine can block Save on uncommitted text.
     const inputValue = useWatch({ control, name: 'emailsDraft' }) ?? '';
     const setInputValue = (value: string) => setValue('emailsDraft', value);
 
-    // Removing a chip (backspace or the chip's own × button) is a state update, not a native
-    // text edit, so the browser's built-in Cmd/Ctrl+Z has nothing to undo. Track removals here
-    // so we can restore the last one ourselves — see handleKeyDown.
+    // Chip removal isn't a native text edit, so the browser can't undo it — track it ourselves.
     const [removedStack, setRemovedStack] = useState<string[]>([]);
 
     const commit = (next: string[]) => {
@@ -40,8 +35,7 @@ export const InvoicingEmailsField: React.FC = () => {
         setValue('emails', [...emails, last], { shouldDirty: true, shouldValidate: true });
     };
 
-    // Splits on commas so a paste of "a@x.com, b@x.com" (or Figma's comma-separated
-    // display format) adds every address at once instead of one long invalid chip.
+    // Splits on commas so a multi-address paste adds each one instead of one long invalid chip.
     const addEmailsFromText = (text: string) => {
         const candidates = text
             .split(',')
@@ -82,8 +76,7 @@ export const InvoicingEmailsField: React.FC = () => {
             return;
         }
 
-        // Only take over Cmd/Ctrl+Z when the input is empty — otherwise let the browser's
-        // native undo handle an in-progress text edit in the draft input as usual.
+        // Only intercept Cmd/Ctrl+Z when the input is empty, else native text-undo should run.
         const isUndo = (e.metaKey || e.ctrlKey) && !e.shiftKey && e.key.toLowerCase() === 'z';
         if (isUndo && !(e.target as HTMLInputElement).value) {
             e.preventDefault();
@@ -115,12 +108,7 @@ export const InvoicingEmailsField: React.FC = () => {
                     </FormLabel>
                     <FormControl>
                         <Combobox items={[]} multiple value={emails} inputValue={inputValue} onValueChange={commit} open={false}>
-                            {/* ComboboxChips' defaults (bg-surface-canvas/border-border-muted, a 1px border, rounded,
-                                min-h-8, and a plain border-border-muted focus ring) all read differently from a plain
-                                Input (bg-surface-input/border-border-interactive, a hairline border, rounded-ds-xs, h-8,
-                                and the focus-ring-default border+shadow ring) — match Input's tokens, including its focus
-                                state, so the two fields look the same. min-h (not h) so the container can still grow when
-                                chips wrap. */}
+                            {/* Overrides ComboboxChips' defaults to match Input's tokens (bg, border, radius, height, focus ring). */}
                             <ComboboxChips
                                 className="min-h-8 rounded-ds-xs border-ds-hairline bg-surface-input border-border-interactive
                                 focus-within:border-[var(--focus-ring-default)]

--- a/packages/webapp/src/pages/Team/Billing/components/InvoicingEmailsField.tsx
+++ b/packages/webapp/src/pages/Team/Billing/components/InvoicingEmailsField.tsx
@@ -148,7 +148,12 @@ export const InvoicingEmailsField: React.FC = () => {
                                 <ComboboxChipsInput
                                     placeholder={emails.length === 0 ? 'billing@company.com' : ''}
                                     value={inputValue}
-                                    onChange={(e) => setInputValue((e.target as HTMLInputElement).value)}
+                                    onChange={(e) => {
+                                        setInputValue((e.target as HTMLInputElement).value);
+                                        // The user is actively editing, so the error is now stale — addEmailsFromText
+                                        // re-sets it if the edited text is still invalid/duplicate on the next commit attempt.
+                                        clearErrors('emails');
+                                    }}
                                     onKeyDown={handleKeyDown}
                                     onPaste={handlePaste}
                                     onBlur={handleBlur}

--- a/packages/webapp/src/pages/Team/Billing/components/InvoicingEmailsField.tsx
+++ b/packages/webapp/src/pages/Team/Billing/components/InvoicingEmailsField.tsx
@@ -46,12 +46,19 @@ export const InvoicingEmailsField: React.FC = () => {
         if (candidates.length === 0) return;
 
         const existingLower = new Set(emails.map((e) => e.toLowerCase()));
-        const invalid = candidates.filter((c) => !emailSchema.safeParse(c).success);
         const valid: string[] = [];
+        const invalid: string[] = [];
+        const duplicate: string[] = [];
         for (const c of candidates) {
-            if (!emailSchema.safeParse(c).success) continue;
+            if (!emailSchema.safeParse(c).success) {
+                invalid.push(c);
+                continue;
+            }
             const lower = c.toLowerCase();
-            if (existingLower.has(lower)) continue;
+            if (existingLower.has(lower)) {
+                duplicate.push(c);
+                continue;
+            }
             existingLower.add(lower);
             valid.push(c);
         }
@@ -60,8 +67,12 @@ export const InvoicingEmailsField: React.FC = () => {
             commit([...emails, ...valid]);
         }
 
-        if (invalid.length > 0) {
-            setError('emails', { type: 'manual', message: `Invalid email address: ${invalid.join(', ')}` });
+        const errors: string[] = [];
+        if (invalid.length > 0) errors.push(`Invalid email address: ${invalid.join(', ')}`);
+        if (duplicate.length > 0) errors.push(`Already added: ${duplicate.join(', ')}`);
+
+        if (errors.length > 0) {
+            setError('emails', { type: 'manual', message: errors.join('. ') });
             setInputValue(invalid.join(', '));
         } else {
             clearErrors('emails');

--- a/packages/webapp/src/pages/Team/Billing/components/InvoicingEmailsField.tsx
+++ b/packages/webapp/src/pages/Team/Billing/components/InvoicingEmailsField.tsx
@@ -73,7 +73,7 @@ export const InvoicingEmailsField: React.FC = () => {
 
         if (errors.length > 0) {
             setError('emails', { type: 'manual', message: errors.join('. ') });
-            setInputValue(invalid.join(', '));
+            setInputValue([...invalid, ...duplicate].join(', '));
         } else {
             clearErrors('emails');
             setInputValue('');

--- a/packages/webapp/src/pages/Team/Billing/components/InvoicingEmailsField.tsx
+++ b/packages/webapp/src/pages/Team/Billing/components/InvoicingEmailsField.tsx
@@ -32,6 +32,8 @@ export const InvoicingEmailsField: React.FC = () => {
         if (removedStack.length === 0) return;
         const last = removedStack[removedStack.length - 1]!;
         setRemovedStack((prev) => prev.slice(0, -1));
+        // Skip re-adding if it's already back in the list, otherwise this creates a duplicate.
+        if (emails.some((e) => e.toLowerCase() === last.toLowerCase())) return;
         setValue('emails', [...emails, last], { shouldDirty: true, shouldValidate: true });
     };
 

--- a/packages/webapp/src/pages/Team/Billing/components/InvoicingEmailsField.tsx
+++ b/packages/webapp/src/pages/Team/Billing/components/InvoicingEmailsField.tsx
@@ -116,10 +116,16 @@ export const InvoicingEmailsField: React.FC = () => {
                     <FormControl>
                         <Combobox items={[]} multiple value={emails} inputValue={inputValue} onValueChange={commit} open={false}>
                             {/* ComboboxChips' defaults (bg-surface-canvas/border-border-muted, a 1px border, rounded,
-                                min-h-8) all read differently from a plain Input (bg-surface-input/border-border-interactive,
-                                a hairline border, rounded-ds-xs, h-8) — match Input's tokens so the two fields look the same
-                                in the single-line case; min-h (not h) so the container can still grow when chips wrap. */}
-                            <ComboboxChips className="min-h-8 rounded-ds-xs border-ds-hairline bg-surface-input border-border-interactive">
+                                min-h-8, and a plain border-border-muted focus ring) all read differently from a plain
+                                Input (bg-surface-input/border-border-interactive, a hairline border, rounded-ds-xs, h-8,
+                                and the focus-ring-default border+shadow ring) — match Input's tokens, including its focus
+                                state, so the two fields look the same. min-h (not h) so the container can still grow when
+                                chips wrap. */}
+                            <ComboboxChips
+                                className="min-h-8 rounded-ds-xs border-ds-hairline bg-surface-input border-border-interactive
+                                focus-within:border-[var(--focus-ring-default)]
+                                focus-within:shadow-[0_0_0_0.5px_var(--focus-ring-default),inset_0_0_0_0.5px_var(--focus-ring-default)]"
+                            >
                                 {emails.length > 0 && (
                                     <ComboboxValue>
                                         {emails.map((email) => (

--- a/packages/webapp/src/pages/Team/Billing/components/InvoicingEmailsField.tsx
+++ b/packages/webapp/src/pages/Team/Billing/components/InvoicingEmailsField.tsx
@@ -115,9 +115,11 @@ export const InvoicingEmailsField: React.FC = () => {
                     </FormLabel>
                     <FormControl>
                         <Combobox items={[]} multiple value={emails} inputValue={inputValue} onValueChange={commit} open={false}>
-                            {/* ComboboxChips defaults to bg-surface-canvas/border-border-muted, which reads as a
-                                different (much darker) fill than a plain Input — match Input's own tokens instead. */}
-                            <ComboboxChips className="min-h-9 bg-surface-input border-border-interactive">
+                            {/* ComboboxChips' defaults (bg-surface-canvas/border-border-muted, a 1px border, rounded,
+                                min-h-8) all read differently from a plain Input (bg-surface-input/border-border-interactive,
+                                a hairline border, rounded-ds-xs, h-8) — match Input's tokens so the two fields look the same
+                                in the single-line case; min-h (not h) so the container can still grow when chips wrap. */}
+                            <ComboboxChips className="min-h-8 rounded-ds-xs border-ds-hairline bg-surface-input border-border-interactive">
                                 {emails.length > 0 && (
                                     <ComboboxValue>
                                         {emails.map((email) => (

--- a/packages/webapp/src/pages/Team/Billing/components/InvoicingEmailsField.tsx
+++ b/packages/webapp/src/pages/Team/Billing/components/InvoicingEmailsField.tsx
@@ -89,15 +89,19 @@ export const InvoicingEmailsField: React.FC = () => {
             const value = (e.target as HTMLInputElement).value.replace(/,$/, '').trim();
             if (!value) return;
             addEmailsFromText(value);
-            return;
         }
+    };
 
-        // Only intercept Cmd/Ctrl+Z when the input is empty and there's a removal to undo, else native text-undo should run.
+    // Bound to the chips container (not just the input) so Cmd/Ctrl+Z still works right after
+    // deleting a chip with the keyboard, when focus has moved to the next chip rather than back
+    // into the input.
+    const handleUndoShortcut = (e: React.KeyboardEvent<HTMLDivElement>) => {
         const isUndo = (e.metaKey || e.ctrlKey) && !e.shiftKey && e.key.toLowerCase() === 'z';
-        if (isUndo && !(e.target as HTMLInputElement).value && removedStack.length > 0) {
-            e.preventDefault();
-            undoLastRemoval();
-        }
+        if (!isUndo || removedStack.length === 0) return;
+        // Let native text-undo run if the user is actively editing draft text.
+        if (e.target instanceof HTMLInputElement && e.target.value) return;
+        e.preventDefault();
+        undoLastRemoval();
     };
 
     const handlePaste = (e: React.ClipboardEvent<HTMLInputElement>) => {
@@ -126,6 +130,7 @@ export const InvoicingEmailsField: React.FC = () => {
                         <Combobox items={[]} multiple value={emails} inputValue={inputValue} onValueChange={commit} open={false}>
                             {/* Overrides ComboboxChips' defaults to match Input's tokens (bg, border, radius, height, focus ring). */}
                             <ComboboxChips
+                                onKeyDown={handleUndoShortcut}
                                 className="min-h-8 rounded-ds-xs border-ds-hairline bg-surface-input border-border-interactive
                                 focus-within:border-[var(--focus-ring-default)]
                                 focus-within:shadow-[0_0_0_0.5px_var(--focus-ring-default),inset_0_0_0_0.5px_var(--focus-ring-default)]"

--- a/packages/webapp/src/pages/Team/Billing/components/InvoicingEmailsField.tsx
+++ b/packages/webapp/src/pages/Team/Billing/components/InvoicingEmailsField.tsx
@@ -37,10 +37,11 @@ export const InvoicingEmailsField: React.FC = () => {
         setValue('emails', [...emails, last], { shouldDirty: true, shouldValidate: true });
     };
 
-    // Splits on commas so a multi-address paste adds each one instead of one long invalid chip.
+    // Splits on commas and whitespace so a multi-address paste or a space-separated typed list
+    // adds each one instead of one long invalid chip.
     const addEmailsFromText = (text: string) => {
         const candidates = text
-            .split(',')
+            .split(/[,\s]+/)
             .map((e) => e.trim())
             .filter(Boolean);
         if (candidates.length === 0) return;
@@ -84,7 +85,7 @@ export const InvoicingEmailsField: React.FC = () => {
     };
 
     const handleKeyDown = (e: React.KeyboardEvent<HTMLInputElement>) => {
-        if (e.key === 'Enter' || e.key === ',') {
+        if (e.key === 'Enter' || e.key === ',' || e.key === ' ') {
             e.preventDefault();
             const value = (e.target as HTMLInputElement).value.replace(/,$/, '').trim();
             if (!value) return;
@@ -106,7 +107,7 @@ export const InvoicingEmailsField: React.FC = () => {
 
     const handlePaste = (e: React.ClipboardEvent<HTMLInputElement>) => {
         const text = e.clipboardData.getData('text');
-        if (!text.includes(',')) return;
+        if (!/[,\s]/.test(text.trim())) return;
         e.preventDefault();
         addEmailsFromText(text);
     };

--- a/packages/webapp/src/pages/Team/Billing/components/InvoicingEmailsField.tsx
+++ b/packages/webapp/src/pages/Team/Billing/components/InvoicingEmailsField.tsx
@@ -89,9 +89,9 @@ export const InvoicingEmailsField: React.FC = () => {
             return;
         }
 
-        // Only intercept Cmd/Ctrl+Z when the input is empty, else native text-undo should run.
+        // Only intercept Cmd/Ctrl+Z when the input is empty and there's a removal to undo, else native text-undo should run.
         const isUndo = (e.metaKey || e.ctrlKey) && !e.shiftKey && e.key.toLowerCase() === 'z';
-        if (isUndo && !(e.target as HTMLInputElement).value) {
+        if (isUndo && !(e.target as HTMLInputElement).value && removedStack.length > 0) {
             e.preventDefault();
             undoLastRemoval();
         }

--- a/packages/webapp/src/pages/Team/Billing/components/InvoicingEmailsField.tsx
+++ b/packages/webapp/src/pages/Team/Billing/components/InvoicingEmailsField.tsx
@@ -15,7 +15,7 @@ export const InvoicingEmailsField: React.FC = () => {
     const emails = useWatch({ control, name: 'emails' }) ?? [];
     // Backed by the form, not local state, so superRefine can block Save on uncommitted text.
     const inputValue = useWatch({ control, name: 'emailsDraft' }) ?? '';
-    const setInputValue = (value: string) => setValue('emailsDraft', value);
+    const setInputValue = (value: string) => setValue('emailsDraft', value, { shouldDirty: true });
 
     // Chip removal isn't a native text edit, so the browser can't undo it — track it ourselves.
     const [removedStack, setRemovedStack] = useState<string[]>([]);

--- a/packages/webapp/src/pages/Team/Billing/components/InvoicingEmailsField.tsx
+++ b/packages/webapp/src/pages/Team/Billing/components/InvoicingEmailsField.tsx
@@ -85,6 +85,10 @@ export const InvoicingEmailsField: React.FC = () => {
     };
 
     const handleKeyDown = (e: React.KeyboardEvent<HTMLInputElement>) => {
+        // Don't intercept while an IME composition is in progress, e.g. the space that finalizes
+        // a composed CJK character shouldn't be swallowed as a commit trigger.
+        if (e.nativeEvent.isComposing) return;
+
         if (e.key === 'Enter' || e.key === ',' || e.key === ' ') {
             e.preventDefault();
             const value = (e.target as HTMLInputElement).value.replace(/,$/, '').trim();

--- a/packages/webapp/src/pages/Team/Billing/components/InvoicingEmailsField.tsx
+++ b/packages/webapp/src/pages/Team/Billing/components/InvoicingEmailsField.tsx
@@ -129,12 +129,14 @@ export const InvoicingEmailsField: React.FC = () => {
                     </FormLabel>
                     <FormControl>
                         <Combobox items={[]} multiple value={emails} inputValue={inputValue} onValueChange={commit} open={false}>
-                            {/* Overrides ComboboxChips' defaults to match Input's tokens (bg, border, radius, height, focus ring). */}
+                            {/* Overrides ComboboxChips' defaults to match Input's tokens (bg, border, radius, height, focus ring).
+                            Scoped to the input specifically (not focus-within) so a keyboard-focused chip shows only its own
+                            ring, not this one too. */}
                             <ComboboxChips
                                 onKeyDown={handleUndoShortcut}
                                 className="min-h-8 rounded-ds-xs border-ds-hairline bg-surface-input border-border-interactive
-                                focus-within:border-[var(--focus-ring-default)]
-                                focus-within:shadow-[0_0_0_0.5px_var(--focus-ring-default),inset_0_0_0_0.5px_var(--focus-ring-default)]"
+                                has-[input:focus]:border-[var(--focus-ring-default)]
+                                has-[input:focus]:shadow-[0_0_0_0.5px_var(--focus-ring-default),inset_0_0_0_0.5px_var(--focus-ring-default)]"
                             >
                                 {emails.length > 0 && (
                                     <ComboboxValue>

--- a/packages/webapp/src/pages/Team/Billing/components/InvoicingOptionalSection.tsx
+++ b/packages/webapp/src/pages/Team/Billing/components/InvoicingOptionalSection.tsx
@@ -1,0 +1,36 @@
+import { Plus, Trash2 } from 'lucide-react';
+
+import { IconButton } from '@nangohq/design-system';
+
+import { OptionalTag } from './InvoicingDetailsForm';
+
+export const InvoicingOptionalSection: React.FC<{
+    title: string;
+    present: boolean;
+    onAdd: () => void;
+    onRemove: () => void;
+    addLabel: string;
+    removeLabel: string;
+    children: React.ReactNode;
+}> = ({ title, present, onAdd, onRemove, addLabel, removeLabel, children }) => {
+    return (
+        <div className="border-t border-border-muted">
+            <div className="p-4 flex items-center justify-between">
+                <span className="flex items-center gap-2 text-text-strong text-body-medium-regular">
+                    {title}
+                    <OptionalTag />
+                </span>
+                {present ? (
+                    <IconButton type="button" variant="ghost" size="2xs" onClick={onRemove} label={removeLabel}>
+                        <Trash2 />
+                    </IconButton>
+                ) : (
+                    <IconButton type="button" variant="ghost" size="2xs" onClick={onAdd} label={addLabel}>
+                        <Plus />
+                    </IconButton>
+                )}
+            </div>
+            {present && <div className="px-4 pb-4">{children}</div>}
+        </div>
+    );
+};

--- a/packages/webapp/src/pages/Team/Billing/components/InvoicingOptionalSection.tsx
+++ b/packages/webapp/src/pages/Team/Billing/components/InvoicingOptionalSection.tsx
@@ -1,4 +1,5 @@
 import { Plus, Trash2 } from 'lucide-react';
+import { useId } from 'react';
 
 import { IconButton } from '@nangohq/design-system';
 
@@ -13,6 +14,8 @@ export const InvoicingOptionalSection: React.FC<{
     removeLabel: string;
     children: React.ReactNode;
 }> = ({ title, present, onAdd, onRemove, addLabel, removeLabel, children }) => {
+    const contentId = useId();
+
     return (
         <div className="border-t border-border-muted">
             <div className="p-4 flex items-center justify-between">
@@ -21,16 +24,20 @@ export const InvoicingOptionalSection: React.FC<{
                     <OptionalTag />
                 </span>
                 {present ? (
-                    <IconButton type="button" variant="ghost" size="2xs" onClick={onRemove} label={removeLabel}>
+                    <IconButton type="button" variant="ghost" size="2xs" onClick={onRemove} label={removeLabel} aria-expanded={true} aria-controls={contentId}>
                         <Trash2 />
                     </IconButton>
                 ) : (
-                    <IconButton type="button" variant="ghost" size="2xs" onClick={onAdd} label={addLabel}>
+                    <IconButton type="button" variant="ghost" size="2xs" onClick={onAdd} label={addLabel} aria-expanded={false} aria-controls={contentId}>
                         <Plus />
                     </IconButton>
                 )}
             </div>
-            {present && <div className="px-4 pb-4">{children}</div>}
+            {present && (
+                <div id={contentId} className="px-4 pb-4">
+                    {children}
+                </div>
+            )}
         </div>
     );
 };

--- a/packages/webapp/src/pages/Team/Billing/components/InvoicingTaxIdFields.tsx
+++ b/packages/webapp/src/pages/Team/Billing/components/InvoicingTaxIdFields.tsx
@@ -55,7 +55,7 @@ export const InvoicingTaxIdFields: React.FC = () => {
     return (
         <div className="border-t border-border-muted">
             <div className="p-4 flex items-center justify-between">
-                <span className="flex items-center gap-2 text-text-strong text-ds-lg font-ds-medium leading-ds-snug tracking-ds-tight">
+                <span className="flex items-center gap-2 text-text-strong text-body-medium-regular">
                     Tax ID
                     <OptionalTag />
                 </span>

--- a/packages/webapp/src/pages/Team/Billing/components/InvoicingTaxIdFields.tsx
+++ b/packages/webapp/src/pages/Team/Billing/components/InvoicingTaxIdFields.tsx
@@ -2,7 +2,7 @@ import { Plus, Trash2 } from 'lucide-react';
 import { useEffect, useMemo } from 'react';
 import { useFormContext, useWatch } from 'react-hook-form';
 
-import { Card, CardAction, CardContent, CardHeader, CardTitle, IconButton, Input } from '@nangohq/design-system';
+import { IconButton, Input } from '@nangohq/design-system';
 
 import { FormControl, FormField, FormItem, FormLabel, FormMessage } from '@/components/ui/Form';
 import { Select, SelectContent, SelectItem, SelectTrigger, SelectValue } from '@/components/ui/Select';
@@ -53,28 +53,24 @@ export const InvoicingTaxIdFields: React.FC = () => {
     };
 
     return (
-        <Card>
-            <CardHeader>
-                <CardTitle>
-                    <span className="flex items-center gap-2">
-                        Tax ID
-                        <OptionalTag />
-                    </span>
-                </CardTitle>
-                <CardAction>
-                    {taxId ? (
-                        <IconButton type="button" variant="ghost" size="2xs" onClick={handleRemove} label="Remove tax ID">
-                            <Trash2 />
-                        </IconButton>
-                    ) : (
-                        <IconButton type="button" variant="ghost" size="2xs" onClick={handleAdd} label="Add tax ID">
-                            <Plus />
-                        </IconButton>
-                    )}
-                </CardAction>
-            </CardHeader>
+        <div className="border-t border-border-muted">
+            <div className="p-4 flex items-center justify-between">
+                <span className="flex items-center gap-2 text-text-strong text-ds-lg font-ds-medium leading-ds-snug tracking-ds-tight">
+                    Tax ID
+                    <OptionalTag />
+                </span>
+                {taxId ? (
+                    <IconButton type="button" variant="ghost" size="2xs" onClick={handleRemove} label="Remove tax ID">
+                        <Trash2 />
+                    </IconButton>
+                ) : (
+                    <IconButton type="button" variant="ghost" size="2xs" onClick={handleAdd} label="Add tax ID">
+                        <Plus />
+                    </IconButton>
+                )}
+            </div>
             {taxId && (
-                <CardContent>
+                <div className="px-4 pb-4">
                     <div className="grid grid-cols-2 items-start gap-3">
                         <FormField
                             control={control}
@@ -153,8 +149,8 @@ export const InvoicingTaxIdFields: React.FC = () => {
                             )}
                         />
                     </div>
-                </CardContent>
+                </div>
             )}
-        </Card>
+        </div>
     );
 };

--- a/packages/webapp/src/pages/Team/Billing/components/InvoicingTaxIdFields.tsx
+++ b/packages/webapp/src/pages/Team/Billing/components/InvoicingTaxIdFields.tsx
@@ -65,7 +65,7 @@ export const InvoicingTaxIdFields: React.FC<{ onExpand: () => void }> = ({ onExp
                             </FormLabel>
                             <Select value={field.value || undefined} onValueChange={field.onChange}>
                                 <FormControl>
-                                    <SelectTrigger className="w-full !bg-surface-canvas border-border-muted text-text-strong data-[placeholder]:text-text-muted hover:!bg-surface-canvas focus:border-border-default">
+                                    <SelectTrigger className="w-full">
                                         <SelectValue placeholder="Choose country" />
                                     </SelectTrigger>
                                 </FormControl>
@@ -91,7 +91,7 @@ export const InvoicingTaxIdFields: React.FC<{ onExpand: () => void }> = ({ onExp
                             </FormLabel>
                             <Select value={field.value} onValueChange={field.onChange}>
                                 <FormControl>
-                                    <SelectTrigger className="w-full !bg-surface-canvas border-border-muted text-text-strong data-[placeholder]:text-text-muted hover:!bg-surface-canvas focus:border-border-default">
+                                    <SelectTrigger className="w-full">
                                         <SelectValue placeholder="Select type" />
                                     </SelectTrigger>
                                 </FormControl>

--- a/packages/webapp/src/pages/Team/Billing/components/InvoicingTaxIdFields.tsx
+++ b/packages/webapp/src/pages/Team/Billing/components/InvoicingTaxIdFields.tsx
@@ -65,7 +65,7 @@ export const InvoicingTaxIdFields: React.FC<{ onExpand: () => void }> = ({ onExp
                             </FormLabel>
                             <Select value={field.value || undefined} onValueChange={field.onChange}>
                                 <FormControl>
-                                    <SelectTrigger className="w-full">
+                                    <SelectTrigger className="w-full bg-surface-input text-text-default">
                                         <SelectValue placeholder="Choose country" />
                                     </SelectTrigger>
                                 </FormControl>
@@ -91,7 +91,7 @@ export const InvoicingTaxIdFields: React.FC<{ onExpand: () => void }> = ({ onExp
                             </FormLabel>
                             <Select value={field.value} onValueChange={field.onChange}>
                                 <FormControl>
-                                    <SelectTrigger className="w-full">
+                                    <SelectTrigger className="w-full bg-surface-input text-text-default">
                                         <SelectValue placeholder="Select type" />
                                     </SelectTrigger>
                                 </FormControl>

--- a/packages/webapp/src/pages/Team/Billing/components/InvoicingTaxIdFields.tsx
+++ b/packages/webapp/src/pages/Team/Billing/components/InvoicingTaxIdFields.tsx
@@ -1,5 +1,5 @@
 import { Plus, Trash2 } from 'lucide-react';
-import { useEffect, useMemo, useRef } from 'react';
+import { useEffect, useMemo } from 'react';
 import { useFormContext, useWatch } from 'react-hook-form';
 
 import { IconButton, Input } from '@nangohq/design-system';
@@ -11,7 +11,7 @@ import { OptionalTag } from './InvoicingDetailsForm';
 
 import type { InvoicingFormData } from './InvoicingDetailsForm';
 
-export const InvoicingTaxIdFields: React.FC = () => {
+export const InvoicingTaxIdFields: React.FC<{ onExpand: () => void }> = ({ onExpand }) => {
     const { control, setValue, clearErrors } = useFormContext<InvoicingFormData>();
     const taxId = useWatch({ control, name: 'taxId' });
     const selectedCountry = useWatch({ control, name: 'taxId.country' });
@@ -42,13 +42,11 @@ export const InvoicingTaxIdFields: React.FC = () => {
     const docFormat = selectedTypeDef?.placeholder.replace(/\d/g, 'X') ?? null;
 
     const taxIdValue = useWatch({ control, name: 'taxId.value' });
-    const sectionRef = useRef<HTMLDivElement>(null);
 
     const handleAdd = () => {
         setValue('taxId', { country: '', type: '', value: '' }, { shouldDirty: true });
         clearErrors('taxId');
-        // Scroll the newly-expanded fields into view once React has rendered them.
-        requestAnimationFrame(() => sectionRef.current?.scrollIntoView({ behavior: 'smooth', block: 'nearest' }));
+        onExpand();
     };
 
     const handleRemove = () => {
@@ -56,7 +54,7 @@ export const InvoicingTaxIdFields: React.FC = () => {
     };
 
     return (
-        <div ref={sectionRef} className="border-t border-border-muted">
+        <div className="border-t border-border-muted">
             <div className="p-4 flex items-center justify-between">
                 <span className="flex items-center gap-2 text-text-strong text-body-medium-regular">
                     Tax ID

--- a/packages/webapp/src/pages/Team/Billing/components/InvoicingTaxIdFields.tsx
+++ b/packages/webapp/src/pages/Team/Billing/components/InvoicingTaxIdFields.tsx
@@ -1,5 +1,5 @@
 import { Plus, Trash2 } from 'lucide-react';
-import { useEffect, useMemo } from 'react';
+import { useEffect, useMemo, useRef } from 'react';
 import { useFormContext, useWatch } from 'react-hook-form';
 
 import { IconButton, Input } from '@nangohq/design-system';
@@ -42,10 +42,13 @@ export const InvoicingTaxIdFields: React.FC = () => {
     const docFormat = selectedTypeDef?.placeholder.replace(/\d/g, 'X') ?? null;
 
     const taxIdValue = useWatch({ control, name: 'taxId.value' });
+    const sectionRef = useRef<HTMLDivElement>(null);
 
     const handleAdd = () => {
         setValue('taxId', { country: '', type: '', value: '' }, { shouldDirty: true });
         clearErrors('taxId');
+        // Scroll the newly-expanded fields into view once React has rendered them.
+        requestAnimationFrame(() => sectionRef.current?.scrollIntoView({ behavior: 'smooth', block: 'nearest' }));
     };
 
     const handleRemove = () => {
@@ -53,7 +56,7 @@ export const InvoicingTaxIdFields: React.FC = () => {
     };
 
     return (
-        <div className="border-t border-border-muted">
+        <div ref={sectionRef} className="border-t border-border-muted">
             <div className="p-4 flex items-center justify-between">
                 <span className="flex items-center gap-2 text-text-strong text-body-medium-regular">
                     Tax ID

--- a/packages/webapp/src/pages/Team/Billing/components/InvoicingTaxIdFields.tsx
+++ b/packages/webapp/src/pages/Team/Billing/components/InvoicingTaxIdFields.tsx
@@ -1,13 +1,12 @@
-import { Plus, Trash2 } from 'lucide-react';
 import { useEffect, useMemo } from 'react';
 import { useFormContext, useWatch } from 'react-hook-form';
 
-import { IconButton, Input } from '@nangohq/design-system';
+import { Input } from '@nangohq/design-system';
 
 import { FormControl, FormField, FormItem, FormLabel, FormMessage } from '@/components/ui/Form';
 import { Select, SelectContent, SelectItem, SelectTrigger, SelectValue } from '@/components/ui/Select';
 import { countryCodes, countryToTaxIdTypes, taxIdTypes } from '../invoicingConstants';
-import { OptionalTag } from './InvoicingDetailsForm';
+import { InvoicingOptionalSection } from './InvoicingOptionalSection';
 
 import type { InvoicingFormData } from './InvoicingDetailsForm';
 
@@ -54,104 +53,85 @@ export const InvoicingTaxIdFields: React.FC<{ onExpand: () => void }> = ({ onExp
     };
 
     return (
-        <div className="border-t border-border-muted">
-            <div className="p-4 flex items-center justify-between">
-                <span className="flex items-center gap-2 text-text-strong text-body-medium-regular">
-                    Tax ID
-                    <OptionalTag />
-                </span>
-                {taxId ? (
-                    <IconButton type="button" variant="ghost" size="2xs" onClick={handleRemove} label="Remove tax ID">
-                        <Trash2 />
-                    </IconButton>
-                ) : (
-                    <IconButton type="button" variant="ghost" size="2xs" onClick={handleAdd} label="Add tax ID">
-                        <Plus />
-                    </IconButton>
-                )}
+        <InvoicingOptionalSection title="Tax ID" present={!!taxId} onAdd={handleAdd} onRemove={handleRemove} addLabel="Add tax ID" removeLabel="Remove tax ID">
+            <div className="grid grid-cols-2 items-start gap-3">
+                <FormField
+                    control={control}
+                    name="taxId.country"
+                    render={({ field }) => (
+                        <FormItem className="col-span-1">
+                            <FormLabel className="flex gap-1 items-center">
+                                Country <span className="text-text-danger">*</span>
+                            </FormLabel>
+                            <Select value={field.value || undefined} onValueChange={field.onChange}>
+                                <FormControl>
+                                    <SelectTrigger className="w-full !bg-surface-canvas border-border-muted text-text-strong data-[placeholder]:text-text-muted hover:!bg-surface-canvas focus:border-border-default">
+                                        <SelectValue placeholder="Choose country" />
+                                    </SelectTrigger>
+                                </FormControl>
+                                <SelectContent>
+                                    {countryCodes.map(({ value, label }) => (
+                                        <SelectItem key={value} value={value}>
+                                            {label}
+                                        </SelectItem>
+                                    ))}
+                                </SelectContent>
+                            </Select>
+                            <FormMessage />
+                        </FormItem>
+                    )}
+                />
+                <FormField
+                    control={control}
+                    name="taxId.type"
+                    render={({ field }) => (
+                        <FormItem className="col-span-1">
+                            <FormLabel className="flex gap-1 items-center">
+                                Type <span className="text-text-danger">*</span>
+                            </FormLabel>
+                            <Select value={field.value} onValueChange={field.onChange}>
+                                <FormControl>
+                                    <SelectTrigger className="w-full !bg-surface-canvas border-border-muted text-text-strong data-[placeholder]:text-text-muted hover:!bg-surface-canvas focus:border-border-default">
+                                        <SelectValue placeholder="Select type" />
+                                    </SelectTrigger>
+                                </FormControl>
+                                <SelectContent>
+                                    {filteredTypes.map(({ value, label }) => (
+                                        <SelectItem key={value} value={value}>
+                                            {label}
+                                        </SelectItem>
+                                    ))}
+                                </SelectContent>
+                            </Select>
+                            <FormMessage />
+                        </FormItem>
+                    )}
+                />
+                <FormField
+                    control={control}
+                    name="taxId.value"
+                    render={({ field, fieldState }) => (
+                        <FormItem>
+                            <FormLabel className="flex gap-1 items-center">
+                                Value <span className="text-text-danger">*</span>
+                            </FormLabel>
+                            <FormControl>
+                                <Input placeholder={`e.g. ${valuePlaceholder}`} {...field} />
+                            </FormControl>
+                            {fieldState.error ? (
+                                <FormMessage />
+                            ) : (
+                                docType &&
+                                docFormat && (
+                                    <p className={`text-body-small-regular ${taxIdValue ? 'text-text-muted' : 'text-text-danger'}`}>
+                                        Enter your {docType} in the format {docFormat}
+                                    </p>
+                                )
+                            )}
+                        </FormItem>
+                    )}
+                />
             </div>
-            {taxId && (
-                <div className="px-4 pb-4">
-                    <div className="grid grid-cols-2 items-start gap-3">
-                        <FormField
-                            control={control}
-                            name="taxId.country"
-                            render={({ field }) => (
-                                <FormItem className="col-span-1">
-                                    <FormLabel className="flex gap-1 items-center">
-                                        Country <span className="text-text-danger">*</span>
-                                    </FormLabel>
-                                    <Select value={field.value || undefined} onValueChange={field.onChange}>
-                                        <FormControl>
-                                            <SelectTrigger className="w-full !bg-surface-canvas border-border-muted text-text-strong data-[placeholder]:text-text-muted hover:!bg-surface-canvas focus:border-border-default">
-                                                <SelectValue placeholder="Choose country" />
-                                            </SelectTrigger>
-                                        </FormControl>
-                                        <SelectContent>
-                                            {countryCodes.map(({ value, label }) => (
-                                                <SelectItem key={value} value={value}>
-                                                    {label}
-                                                </SelectItem>
-                                            ))}
-                                        </SelectContent>
-                                    </Select>
-                                    <FormMessage />
-                                </FormItem>
-                            )}
-                        />
-                        <FormField
-                            control={control}
-                            name="taxId.type"
-                            render={({ field }) => (
-                                <FormItem className="col-span-1">
-                                    <FormLabel className="flex gap-1 items-center">
-                                        Type <span className="text-text-danger">*</span>
-                                    </FormLabel>
-                                    <Select value={field.value} onValueChange={field.onChange}>
-                                        <FormControl>
-                                            <SelectTrigger className="w-full !bg-surface-canvas border-border-muted text-text-strong data-[placeholder]:text-text-muted hover:!bg-surface-canvas focus:border-border-default">
-                                                <SelectValue placeholder="Select type" />
-                                            </SelectTrigger>
-                                        </FormControl>
-                                        <SelectContent>
-                                            {filteredTypes.map(({ value, label }) => (
-                                                <SelectItem key={value} value={value}>
-                                                    {label}
-                                                </SelectItem>
-                                            ))}
-                                        </SelectContent>
-                                    </Select>
-                                    <FormMessage />
-                                </FormItem>
-                            )}
-                        />
-                        <FormField
-                            control={control}
-                            name="taxId.value"
-                            render={({ field, fieldState }) => (
-                                <FormItem>
-                                    <FormLabel className="flex gap-1 items-center">
-                                        Value <span className="text-text-danger">*</span>
-                                    </FormLabel>
-                                    <FormControl>
-                                        <Input placeholder={`e.g. ${valuePlaceholder}`} {...field} />
-                                    </FormControl>
-                                    {fieldState.error ? (
-                                        <FormMessage />
-                                    ) : (
-                                        docType &&
-                                        docFormat && (
-                                            <p className={`text-body-small-regular ${taxIdValue ? 'text-text-muted' : 'text-text-danger'}`}>
-                                                Enter your {docType} in the format {docFormat}
-                                            </p>
-                                        )
-                                    )}
-                                </FormItem>
-                            )}
-                        />
-                    </div>
-                </div>
-            )}
-        </div>
+        </InvoicingOptionalSection>
     );
 };

--- a/packages/webapp/src/pages/Team/Billing/components/Payment.tsx
+++ b/packages/webapp/src/pages/Team/Billing/components/Payment.tsx
@@ -21,6 +21,49 @@ export const Payment: React.FC = () => {
         return paymentMethods?.data && paymentMethods.data.length > 0 ? paymentMethods.data[0] : null;
     }, [paymentMethods]);
 
+    const paymentMethodSection = (
+        <div className="p-4 flex items-center justify-between">
+            {isPaymentMethodsLoading ? (
+                <Skeleton className="w-full h-14" />
+            ) : paymentMethodsError ? (
+                <CriticalErrorAlert message="Error loading payment method" />
+            ) : (
+                <>
+                    <div className="flex flex-col gap-1">
+                        <span className="text-text-strong text-body-medium-regular">Payment method</span>
+                        {paymentMethod ? (
+                            <>
+                                <span className="text-text-secondary text-body-small-regular capitalize">
+                                    {paymentMethod.brand ?? 'Card'}···{paymentMethod.last4}
+                                </span>
+                                {/* Defensive: brand/last4 always exist on a Stripe card, but expMonth/expYear only exist once the
+                                    backend maps them — omit the line rather than render "Valid until undefined/ed" if it hasn't. */}
+                                {paymentMethod.expMonth && paymentMethod.expYear && (
+                                    <span className="text-text-secondary text-body-small-regular">
+                                        Valid until {String(paymentMethod.expMonth).padStart(2, '0')}/{String(paymentMethod.expYear).slice(-2)}
+                                    </span>
+                                )}
+                            </>
+                        ) : (
+                            <span className="text-text-secondary text-body-small-regular">No card added</span>
+                        )}
+                    </div>
+                    <PaymentMethodDialog replace={!!paymentMethod}>
+                        <Button size="sm" variant="secondary">
+                            {paymentMethod ? (
+                                <>
+                                    <Pencil /> Edit
+                                </>
+                            ) : (
+                                'Add payment method'
+                            )}
+                        </Button>
+                    </PaymentMethodDialog>
+                </>
+            )}
+        </div>
+    );
+
     return (
         <div className="flex-1 flex flex-col gap-4">
             <div className="flex items-center justify-between">
@@ -37,52 +80,16 @@ export const Payment: React.FC = () => {
                     ))}
             </div>
 
-            <Card>
-                <div className="p-4 flex items-start justify-between">
-                    {isPaymentMethodsLoading ? (
-                        <Skeleton className="w-full h-14" />
-                    ) : paymentMethodsError ? (
-                        <CriticalErrorAlert message="Error loading payment method" />
-                    ) : (
-                        <>
-                            <div className="flex flex-col gap-1">
-                                <span className="text-text-strong text-ds-lg font-ds-medium leading-ds-snug tracking-ds-tight">Payment method</span>
-                                {paymentMethod ? (
-                                    <>
-                                        <span className="text-text-secondary text-body-small-regular capitalize">
-                                            {paymentMethod.brand}···{paymentMethod.last4}
-                                        </span>
-                                        <span className="text-text-secondary text-body-small-regular">
-                                            Valid until {String(paymentMethod.expMonth).padStart(2, '0')}/{String(paymentMethod.expYear).slice(-2)}
-                                        </span>
-                                    </>
-                                ) : (
-                                    <span className="text-text-secondary text-body-small-regular">No card added</span>
-                                )}
-                            </div>
-                            <PaymentMethodDialog replace={!!paymentMethod}>
-                                <Button size="md">
-                                    {paymentMethod ? (
-                                        <>
-                                            <Pencil /> Edit
-                                        </>
-                                    ) : (
-                                        'Add payment method'
-                                    )}
-                                </Button>
-                            </PaymentMethodDialog>
-                        </>
-                    )}
-                </div>
-
-                {usageError ? (
+            {usageError ? (
+                <Card>
+                    {paymentMethodSection}
                     <div className="border-t border-border-muted p-4">
                         <CriticalErrorAlert message="Error loading invoicing details" />
                     </div>
-                ) : (
-                    <InvoicingDetailsForm customer={usage?.data.customer} />
-                )}
-            </Card>
+                </Card>
+            ) : (
+                <InvoicingDetailsForm customer={usage?.data.customer} paymentMethodSection={paymentMethodSection} />
+            )}
         </div>
     );
 };

--- a/packages/webapp/src/pages/Team/Billing/components/Payment.tsx
+++ b/packages/webapp/src/pages/Team/Billing/components/Payment.tsx
@@ -1,7 +1,7 @@
-import { CreditCard } from 'lucide-react';
+import { Pencil } from 'lucide-react';
 import { useMemo } from 'react';
 
-import { Button, Card, CardContent, CardHeader, CardTitle } from '@nangohq/design-system';
+import { Button, Card } from '@nangohq/design-system';
 
 import { CriticalErrorAlert } from '@/components/patterns/CriticalErrorAlert';
 import { Skeleton } from '@/components/ui/Skeleton';
@@ -9,7 +9,6 @@ import { StyledLink } from '@/components/ui/StyledLink';
 import { useApiGetBillingUsage } from '@/hooks/usePlan';
 import { useStripePaymentMethods } from '@/hooks/useStripe';
 import { useStore } from '@/store';
-import { Dot } from '../../../../components/ui/Dot';
 import { InvoicingDetailsForm } from './InvoicingDetailsForm';
 import { PaymentMethodDialog } from './PaymentMethodDialog';
 
@@ -23,62 +22,67 @@ export const Payment: React.FC = () => {
     }, [paymentMethods]);
 
     return (
-        <div className="flex-1 flex flex-col gap-8">
-            <div className="flex flex-col gap-5">
-                <h3 className="text-body-small-regular text-text-secondary">PAYMENT</h3>
-                <Card>
-                    <CardHeader>
-                        <CardTitle>Payment method</CardTitle>
-                    </CardHeader>
-                    <CardContent>
-                        {isPaymentMethodsLoading ? (
-                            <Skeleton className="w-full h-22.5" />
-                        ) : paymentMethodsError ? (
-                            <CriticalErrorAlert message="Error loading payment method" />
-                        ) : (
-                            <div className="w-full inline-flex items-center justify-between">
-                                <div className="inline-flex gap-3 items-center">
-                                    <div className="size-10 flex items-center justify-center border border-border-muted rounded">
-                                        <CreditCard className="size-4.5 text-icon-default" />
-                                    </div>
-                                    <div className="flex flex-col">
-                                        <div className="inline-flex gap-1.5 items-center">
-                                            <span className="text-text-strong text-sm leading-5 font-semibold">Credit Card</span>
-                                            <Dot variant={paymentMethod ? 'brand' : 'error'} />
-                                        </div>
-                                        <span className="text-text-muted text-s leading-5 font-medium">
-                                            {paymentMethod ? `Card ending in ${paymentMethod?.last4}` : 'No card added'}
-                                        </span>
-                                    </div>
-                                </div>
-                                <PaymentMethodDialog replace={!!paymentMethod}>
-                                    <Button size={'md'} className="min-w-27">
-                                        {paymentMethod ? 'Update' : 'Add payment method'}
-                                    </Button>
-                                </PaymentMethodDialog>
-                            </div>
-                        )}
-                    </CardContent>
-                </Card>
+        <div className="flex-1 flex flex-col gap-4">
+            <div className="flex items-center justify-between">
+                <span className="text-text-strong text-body-medium-medium">Billing information</span>
+                {!usageError &&
+                    (isUsageLoading ? (
+                        <Skeleton className="w-27 h-5" />
+                    ) : (
+                        usage?.data.customer.portalUrl && (
+                            <StyledLink to={usage.data.customer.portalUrl} icon type="external">
+                                View all invoices
+                            </StyledLink>
+                        )
+                    ))}
             </div>
 
-            <div className="flex flex-col gap-5">
-                <div className="flex items-center justify-between">
-                    <h3 className="text-body-small-regular text-text-secondary">INVOICING</h3>
-                    {!usageError &&
-                        (isUsageLoading ? (
-                            <Skeleton className="w-27 h-5" />
-                        ) : (
-                            usage?.data.customer.portalUrl && (
-                                <StyledLink to={usage.data.customer.portalUrl} icon type="external">
-                                    View invoices
-                                </StyledLink>
-                            )
-                        ))}
+            <Card>
+                <div className="p-4 flex items-start justify-between">
+                    {isPaymentMethodsLoading ? (
+                        <Skeleton className="w-full h-14" />
+                    ) : paymentMethodsError ? (
+                        <CriticalErrorAlert message="Error loading payment method" />
+                    ) : (
+                        <>
+                            <div className="flex flex-col gap-1">
+                                <span className="text-text-strong text-ds-lg font-ds-medium leading-ds-snug tracking-ds-tight">Payment method</span>
+                                {paymentMethod ? (
+                                    <>
+                                        <span className="text-text-secondary text-body-small-regular capitalize">
+                                            {paymentMethod.brand}···{paymentMethod.last4}
+                                        </span>
+                                        <span className="text-text-secondary text-body-small-regular">
+                                            Valid until {String(paymentMethod.expMonth).padStart(2, '0')}/{String(paymentMethod.expYear).slice(-2)}
+                                        </span>
+                                    </>
+                                ) : (
+                                    <span className="text-text-secondary text-body-small-regular">No card added</span>
+                                )}
+                            </div>
+                            <PaymentMethodDialog replace={!!paymentMethod}>
+                                <Button size="md">
+                                    {paymentMethod ? (
+                                        <>
+                                            <Pencil /> Edit
+                                        </>
+                                    ) : (
+                                        'Add payment method'
+                                    )}
+                                </Button>
+                            </PaymentMethodDialog>
+                        </>
+                    )}
                 </div>
 
-                {usageError ? <CriticalErrorAlert message="Error loading invoicing details" /> : <InvoicingDetailsForm customer={usage?.data.customer} />}
-            </div>
+                {usageError ? (
+                    <div className="border-t border-border-muted p-4">
+                        <CriticalErrorAlert message="Error loading invoicing details" />
+                    </div>
+                ) : (
+                    <InvoicingDetailsForm customer={usage?.data.customer} />
+                )}
+            </Card>
         </div>
     );
 };

--- a/packages/webapp/src/pages/Team/Billing/components/Payment.tsx
+++ b/packages/webapp/src/pages/Team/Billing/components/Payment.tsx
@@ -24,7 +24,7 @@ export const Payment: React.FC = () => {
     return (
         <div className="flex-1 flex flex-col gap-4">
             <div className="flex items-center justify-between">
-                <span className="text-text-strong text-body-medium-medium">Billing information</span>
+                <h3 className="text-text-strong text-body-medium-medium">Billing information</h3>
                 {!usageError &&
                     (isUsageLoading ? (
                         <Skeleton className="w-27 h-5" />

--- a/packages/webapp/src/pages/Team/Billing/components/Payment.tsx
+++ b/packages/webapp/src/pages/Team/Billing/components/Payment.tsx
@@ -36,8 +36,7 @@ export const Payment: React.FC = () => {
                                 <span className="text-text-secondary text-body-small-regular capitalize">
                                     {paymentMethod.brand ?? 'Card'}···{paymentMethod.last4}
                                 </span>
-                                {/* Defensive: brand/last4 always exist on a Stripe card, but expMonth/expYear only exist once the
-                                    backend maps them — omit the line rather than render "Valid until undefined/ed" if it hasn't. */}
+                                {/* expMonth/expYear can be absent from an older API response — omit rather than render undefined. */}
                                 {paymentMethod.expMonth && paymentMethod.expYear && (
                                     <span className="text-text-secondary text-body-small-regular">
                                         Valid until {String(paymentMethod.expMonth).padStart(2, '0')}/{String(paymentMethod.expYear).slice(-2)}

--- a/packages/webapp/src/pages/Team/Billing/components/Payment.tsx
+++ b/packages/webapp/src/pages/Team/Billing/components/Payment.tsx
@@ -63,32 +63,36 @@ export const Payment: React.FC = () => {
         </div>
     );
 
-    return (
-        <div className="flex-1 flex flex-col gap-4">
-            <div className="flex items-center justify-between">
+    if (usageError) {
+        return (
+            <div className="flex-1 flex flex-col gap-4">
                 <h3 className="text-text-strong text-body-medium-medium">Billing information</h3>
-                {!usageError &&
-                    (isUsageLoading ? (
-                        <Skeleton className="w-27 h-5" />
-                    ) : (
-                        usage?.data.customer.portalUrl && (
-                            <StyledLink to={usage.data.customer.portalUrl} icon type="external">
-                                View all invoices
-                            </StyledLink>
-                        )
-                    ))}
-            </div>
-
-            {usageError ? (
                 <Card>
                     {paymentMethodSection}
                     <div className="border-t border-border-muted p-4">
                         <CriticalErrorAlert message="Error loading invoicing details" />
                     </div>
                 </Card>
-            ) : (
-                <InvoicingDetailsForm customer={usage?.data.customer} paymentMethodSection={paymentMethodSection} />
-            )}
+            </div>
+        );
+    }
+
+    return (
+        <div className="flex-1 flex flex-col gap-4">
+            <div className="flex items-center justify-between">
+                <h3 className="text-text-strong text-body-medium-medium">Billing information</h3>
+                {isUsageLoading ? (
+                    <Skeleton className="w-27 h-5" />
+                ) : (
+                    usage?.data.customer.portalUrl && (
+                        <StyledLink to={usage.data.customer.portalUrl} icon type="external">
+                            View all invoices
+                        </StyledLink>
+                    )
+                )}
+            </div>
+
+            <InvoicingDetailsForm customer={usage?.data.customer} paymentMethodSection={paymentMethodSection} isLoading={isUsageLoading} />
         </div>
     );
 };

--- a/packages/webapp/src/pages/Team/Billing/components/invoicingFormData.ts
+++ b/packages/webapp/src/pages/Team/Billing/components/invoicingFormData.ts
@@ -1,0 +1,15 @@
+import type { InvoicingFormData } from './InvoicingDetailsForm.js';
+import type { BillingCustomer } from '@nangohq/types';
+
+export function toFormData(customer: BillingCustomer): InvoicingFormData {
+    return {
+        legalEntityName: customer.invoicingDetails.legalEntityName,
+        // Defensive: `additionalEmails` is typed as required, but a client can still hit an
+        // API version that predates the field (e.g. this webapp build outrunning the backend
+        // deploy), so a real response can omit it despite the type's guarantee.
+        emails: [customer.invoicingDetails.email, ...(customer.invoicingDetails.additionalEmails ?? [])],
+        emailsDraft: '',
+        address: customer.invoicingDetails.address ? { ...customer.invoicingDetails.address, country: customer.invoicingDetails.address.country ?? '' } : null,
+        taxId: customer.invoicingDetails.taxId
+    };
+}

--- a/packages/webapp/src/pages/Team/Billing/components/invoicingFormData.ts
+++ b/packages/webapp/src/pages/Team/Billing/components/invoicingFormData.ts
@@ -6,6 +6,9 @@ export function toFormData(customer: BillingCustomer): InvoicingFormData {
         legalEntityName: customer.invoicingDetails.legalEntityName,
         // additionalEmails is typed as required, but a real response can still omit it.
         emails: [customer.invoicingDetails.email, ...(customer.invoicingDetails.additionalEmails ?? [])],
+        // Match the input's cleared state so a draft edit that's later cleared back to '' isn't
+        // permanently dirty against an `undefined` default, which would block future resets.
+        emailsDraft: '',
         address: customer.invoicingDetails.address ? { ...customer.invoicingDetails.address, country: customer.invoicingDetails.address.country ?? '' } : null,
         taxId: customer.invoicingDetails.taxId
     };

--- a/packages/webapp/src/pages/Team/Billing/components/invoicingFormData.ts
+++ b/packages/webapp/src/pages/Team/Billing/components/invoicingFormData.ts
@@ -4,9 +4,7 @@ import type { BillingCustomer } from '@nangohq/types';
 export function toFormData(customer: BillingCustomer): InvoicingFormData {
     return {
         legalEntityName: customer.invoicingDetails.legalEntityName,
-        // Defensive: `additionalEmails` is typed as required, but a client can still hit an
-        // API version that predates the field (e.g. this webapp build outrunning the backend
-        // deploy), so a real response can omit it despite the type's guarantee.
+        // additionalEmails is typed as required, but a real response can still omit it.
         emails: [customer.invoicingDetails.email, ...(customer.invoicingDetails.additionalEmails ?? [])],
         emailsDraft: '',
         address: customer.invoicingDetails.address ? { ...customer.invoicingDetails.address, country: customer.invoicingDetails.address.country ?? '' } : null,

--- a/packages/webapp/src/pages/Team/Billing/components/invoicingFormData.ts
+++ b/packages/webapp/src/pages/Team/Billing/components/invoicingFormData.ts
@@ -6,7 +6,6 @@ export function toFormData(customer: BillingCustomer): InvoicingFormData {
         legalEntityName: customer.invoicingDetails.legalEntityName,
         // additionalEmails is typed as required, but a real response can still omit it.
         emails: [customer.invoicingDetails.email, ...(customer.invoicingDetails.additionalEmails ?? [])],
-        emailsDraft: '',
         address: customer.invoicingDetails.address ? { ...customer.invoicingDetails.address, country: customer.invoicingDetails.address.country ?? '' } : null,
         taxId: customer.invoicingDetails.taxId
     };

--- a/packages/webapp/src/pages/Team/Billing/components/invoicingFormData.unit.test.ts
+++ b/packages/webapp/src/pages/Team/Billing/components/invoicingFormData.unit.test.ts
@@ -1,0 +1,37 @@
+import { describe, expect, it } from 'vitest';
+
+import { toFormData } from './invoicingFormData.js';
+
+import type { BillingCustomer } from '@nangohq/types';
+
+function customerWith(invoicingDetails: Partial<BillingCustomer['invoicingDetails']>): BillingCustomer {
+    return {
+        id: 'orb_cust_123',
+        portalUrl: null,
+        invoicingDetails: {
+            legalEntityName: 'Acme Corp',
+            email: 'billing@acme.com',
+            additionalEmails: [],
+            address: null,
+            taxId: null,
+            ...invoicingDetails
+        }
+    };
+}
+
+describe('toFormData', () => {
+    it('includes the primary email followed by the additional ones', () => {
+        const form = toFormData(customerWith({ email: 'billing@acme.com', additionalEmails: ['ap@acme.com', 'finance@acme.com'] }));
+        expect(form.emails).toEqual(['billing@acme.com', 'ap@acme.com', 'finance@acme.com']);
+    });
+
+    it('falls back to just the primary email when additionalEmails is missing from the response', () => {
+        // A real client can hit an API version that predates the additionalEmails field
+        // (e.g. this webapp build outrunning the backend deploy) despite the type's guarantee.
+        const customer = customerWith({ email: 'billing@acme.com' });
+        // @ts-expect-error simulating a response shape older than the current type
+        delete customer.invoicingDetails.additionalEmails;
+
+        expect(toFormData(customer).emails).toEqual(['billing@acme.com']);
+    });
+});

--- a/packages/webapp/src/pages/Team/Billing/components/invoicingFormData.unit.test.ts
+++ b/packages/webapp/src/pages/Team/Billing/components/invoicingFormData.unit.test.ts
@@ -26,8 +26,6 @@ describe('toFormData', () => {
     });
 
     it('falls back to just the primary email when additionalEmails is missing from the response', () => {
-        // A real client can hit an API version that predates the additionalEmails field
-        // (e.g. this webapp build outrunning the backend deploy) despite the type's guarantee.
         const customer = customerWith({ email: 'billing@acme.com' });
         // @ts-expect-error simulating a response shape older than the current type
         delete customer.invoicingDetails.additionalEmails;


### PR DESCRIPTION
## Problem

Customers manage their payment method and billing details (legal entity name, billing email, address, tax ID) in-app, but the section didn't match the approved design — it rendered as four separately-bordered cards under two subheadings instead of one unified panel — and only supported a single billing email, even though Orb (and the ticket) support multiple.

## Solution

- Support multiple billing emails end to end: `additionalEmails` on `BillingInvoicingDetails`, the Orb adapter/schema, the local noop billing client, and server-side validation
- Add a chip input (`InvoicingEmailsField`) so a customer can add/remove multiple billing email addresses instead of typing one into a plain text field
- Collapse the "Billing information" section from four bordered cards into one panel with internal dividers, matching the approved design — title + "View all invoices" link, payment method, legal entity/email fields, collapsible billing address and tax ID rows, then save
- Expose Stripe's card brand and expiry (`brand`/`expMonth`/`expYear`) on `StripePaymentMethod` so the payment-method row can show a brand + last4 + expiry summary

Fixes [NAN-6224](https://linear.app/nango/issue/NAN-6224)

## Testing

- Added/updated backend unit and integration tests for `additionalEmails` (Orb adapters, `PUT /plans/billing/invoicing`)
- Verified locally in the browser: panel layout matches the Figma design, adding/removing email chips works, invalid addresses are rejected with an inline error, and billing address/tax ID expand-collapse still works within the single panel

<img width="1267" height="770" alt="image" src="https://github.com/user-attachments/assets/fb9c576d-55b8-4f8c-9383-21cf08fed2cf" />


https://github.com/user-attachments/assets/dd6f914c-3542-4bbf-a46c-05270e34988a

