### PR TITLE
feat(webhooks): adapt dispatch polling locally (NAN-6407)

### DIFF
--- a/packages/jobs/lib/app.ts
+++ b/packages/jobs/lib/app.ts
@@ -60,7 +60,9 @@ try {
               maxAgeMs: envs.NANGO_TASK_DISPATCH_MAX_AGE_SECONDS * 1000,
               pollPacer: new LocalAdaptivePollPacer({
                   maxDelayMs: envs.NANGO_TASK_DISPATCH_ADAPTIVE_MAX_POLL_DELAY_MS,
-                  healthyLatencyMs: envs.NANGO_TASK_DISPATCH_ADAPTIVE_HEALTHY_LATENCY_MS
+                  healthyLatencyMs: envs.NANGO_TASK_DISPATCH_ADAPTIVE_HEALTHY_LATENCY_MS,
+                  decayWindowMs: envs.NANGO_TASK_DISPATCH_ADAPTIVE_DECAY_WINDOW_MS,
+                  jitterRatio: envs.NANGO_TASK_DISPATCH_ADAPTIVE_JITTER_RATIO
               })
           })
         : undefined;
@@ -146,7 +148,9 @@ try {
         logger.info('webhook dispatch queue consumer started', {
             consumerConcurrency: envs.NANGO_TASK_DISPATCH_CONSUMER_CONCURRENCY,
             adaptiveMaxPollDelayMs: envs.NANGO_TASK_DISPATCH_ADAPTIVE_MAX_POLL_DELAY_MS,
-            adaptiveHealthyLatencyMs: envs.NANGO_TASK_DISPATCH_ADAPTIVE_HEALTHY_LATENCY_MS
+            adaptiveHealthyLatencyMs: envs.NANGO_TASK_DISPATCH_ADAPTIVE_HEALTHY_LATENCY_MS,
+            adaptiveDecayWindowMs: envs.NANGO_TASK_DISPATCH_ADAPTIVE_DECAY_WINDOW_MS,
+            adaptiveJitterRatio: envs.NANGO_TASK_DISPATCH_ADAPTIVE_JITTER_RATIO
         });
     }
 

--- a/packages/jobs/lib/app.ts
+++ b/packages/jobs/lib/app.ts
@@ -61,7 +61,8 @@ try {
               pollPacer: new LocalAdaptivePollPacer({
                   maxDelayMs: envs.NANGO_TASK_DISPATCH_ADAPTIVE_MAX_POLL_DELAY_MS,
                   healthyLatencyMs: envs.NANGO_TASK_DISPATCH_ADAPTIVE_HEALTHY_LATENCY_MS,
-                  decayWindowMs: envs.NANGO_TASK_DISPATCH_ADAPTIVE_DECAY_WINDOW_MS,
+                  latencyTauMs: envs.NANGO_TASK_DISPATCH_ADAPTIVE_LATENCY_TAU_MS,
+                  failureBackoffMs: envs.NANGO_TASK_DISPATCH_FAILURE_BACKOFF_MS,
                   jitterRatio: envs.NANGO_TASK_DISPATCH_ADAPTIVE_JITTER_RATIO
               })
           })
@@ -149,7 +150,8 @@ try {
             consumerConcurrency: envs.NANGO_TASK_DISPATCH_CONSUMER_CONCURRENCY,
             adaptiveMaxPollDelayMs: envs.NANGO_TASK_DISPATCH_ADAPTIVE_MAX_POLL_DELAY_MS,
             adaptiveHealthyLatencyMs: envs.NANGO_TASK_DISPATCH_ADAPTIVE_HEALTHY_LATENCY_MS,
-            adaptiveDecayWindowMs: envs.NANGO_TASK_DISPATCH_ADAPTIVE_DECAY_WINDOW_MS,
+            adaptiveLatencyTauMs: envs.NANGO_TASK_DISPATCH_ADAPTIVE_LATENCY_TAU_MS,
+            failureBackoffMs: envs.NANGO_TASK_DISPATCH_FAILURE_BACKOFF_MS,
             adaptiveJitterRatio: envs.NANGO_TASK_DISPATCH_ADAPTIVE_JITTER_RATIO
         });
     }

--- a/packages/jobs/lib/app.ts
+++ b/packages/jobs/lib/app.ts
@@ -16,6 +16,7 @@ import { LambdaKeepWarmProcessor } from './processors/lambdaKeepWarm.processor.j
 import { getDefaultFleet, startFleets, stopFleets } from './runtime/runtimes.js';
 import { server } from './server.js';
 import { pubsub } from './utils/pubsub.js';
+import { LocalAdaptivePollPacer } from './webhook/dispatch-queue/adaptive-polling.js';
 import { DispatchQueueConsumer } from './webhook/dispatch-queue/consumer.js';
 
 const logger = getLogger('Jobs');
@@ -56,7 +57,11 @@ try {
               maxMessages: envs.NANGO_TASK_DISPATCH_MAX_MESSAGES,
               waitTimeSeconds: envs.NANGO_TASK_DISPATCH_WAIT_TIME_SECONDS,
               visibilityTimeoutSeconds: envs.NANGO_TASK_DISPATCH_VISIBILITY_TIMEOUT_SECONDS,
-              maxAgeMs: envs.NANGO_TASK_DISPATCH_MAX_AGE_SECONDS * 1000
+              maxAgeMs: envs.NANGO_TASK_DISPATCH_MAX_AGE_SECONDS * 1000,
+              pollPacer: new LocalAdaptivePollPacer({
+                  maxDelayMs: envs.NANGO_TASK_DISPATCH_ADAPTIVE_MAX_POLL_DELAY_MS,
+                  healthyLatencyMs: envs.NANGO_TASK_DISPATCH_ADAPTIVE_HEALTHY_LATENCY_MS
+              })
           })
         : undefined;
 
@@ -138,7 +143,11 @@ try {
 
     if (webhookDispatchConsumer) {
         webhookDispatchConsumer.start();
-        logger.info('webhook dispatch queue consumer started');
+        logger.info('webhook dispatch queue consumer started', {
+            consumerConcurrency: envs.NANGO_TASK_DISPATCH_CONSUMER_CONCURRENCY,
+            adaptiveMaxPollDelayMs: envs.NANGO_TASK_DISPATCH_ADAPTIVE_MAX_POLL_DELAY_MS,
+            adaptiveHealthyLatencyMs: envs.NANGO_TASK_DISPATCH_ADAPTIVE_HEALTHY_LATENCY_MS
+        });
     }
 
     void otlp.register(getOtlpRoutes);

--- a/packages/jobs/lib/webhook/dispatch-queue/adaptive-polling.ts
+++ b/packages/jobs/lib/webhook/dispatch-queue/adaptive-polling.ts
@@ -5,7 +5,7 @@ import { metrics } from '@nangohq/utils';
 
 export interface DispatchPollPacer {
     wait(signal: AbortSignal): Promise<void>;
-    waitForBackoff(signal: AbortSignal, prepareWait: (delayMs: number) => Promise<void>): Promise<void>;
+    waitForBackoff(signal: AbortSignal, prepareWait: (delayMs: number, signal: AbortSignal) => Promise<void>): Promise<void>;
     recordCongestion(retryAfterMs: number, durationMs: number): void;
     recordFailure(durationMs: number): void;
     recordSuccess(durationMs: number): void;
@@ -83,7 +83,7 @@ export class LocalAdaptivePollPacer implements DispatchPollPacer {
      * Gates an already-received batch before orchestrator dispatch.
      * 1. Ignore adaptive pressure. 2. Prepare message visibility for the exact delay. 3. Wait for backoff and peer-loop extensions.
      */
-    async waitForBackoff(signal: AbortSignal, prepareWait: (delayMs: number) => Promise<void>): Promise<void> {
+    async waitForBackoff(signal: AbortSignal, prepareWait: (delayMs: number, signal: AbortSignal) => Promise<void>): Promise<void> {
         await this.waitUntilAllowed(signal, false, prepareWait);
     }
 
@@ -137,10 +137,15 @@ export class LocalAdaptivePollPacer implements DispatchPollPacer {
 
     /**
      * Executes the shared wait algorithm.
-     * 1. Snapshot and decay state. 2. Calculate bounded jitter. 3. Sleep. 4. Repeat only for a live deadline extension.
+     * 1. Reject shutdown. 2. Snapshot and decay state. 3. Prepare and sleep with jitter. 4. Recheck live deadline extensions.
      */
-    private async waitUntilAllowed(signal: AbortSignal, includeAdaptiveDelay: boolean, prepareWait?: (delayMs: number) => Promise<void>): Promise<void> {
-        while (!signal.aborted) {
+    private async waitUntilAllowed(
+        signal: AbortSignal,
+        includeAdaptiveDelay: boolean,
+        prepareWait?: (delayMs: number, signal: AbortSignal) => Promise<void>
+    ): Promise<void> {
+        while (true) {
+            signal.throwIfAborted();
             const now = this.now();
             this.decay(now);
             const observedBackoffUntil = this.backoffUntil;
@@ -156,7 +161,8 @@ export class LocalAdaptivePollPacer implements DispatchPollPacer {
             if (delayMs === 0) {
                 return;
             }
-            await prepareWait?.(delayMs);
+            await prepareWait?.(delayMs, signal);
+            signal.throwIfAborted();
             await this.sleep(delayMs, signal);
             if (this.backoffUntil <= observedBackoffUntil || this.backoffUntil <= this.now()) {
                 return;

--- a/packages/jobs/lib/webhook/dispatch-queue/adaptive-polling.ts
+++ b/packages/jobs/lib/webhook/dispatch-queue/adaptive-polling.ts
@@ -5,7 +5,7 @@ import { metrics } from '@nangohq/utils';
 
 export interface DispatchPollPacer {
     wait(signal: AbortSignal): Promise<void>;
-    waitForBackoff(signal: AbortSignal): Promise<void>;
+    waitForBackoff(signal: AbortSignal, prepareWait: (delayMs: number) => Promise<void>): Promise<void>;
     recordCongestion(retryAfterMs: number, durationMs: number): void;
     recordFailure(durationMs: number): void;
     recordSuccess(durationMs: number): void;
@@ -81,10 +81,10 @@ export class LocalAdaptivePollPacer implements DispatchPollPacer {
 
     /**
      * Gates an already-received batch before orchestrator dispatch.
-     * 1. Ignore adaptive pressure to avoid double pacing. 2. Wait only for explicit admission backoff and peer-loop extensions.
+     * 1. Ignore adaptive pressure. 2. Prepare message visibility for the exact delay. 3. Wait for backoff and peer-loop extensions.
      */
-    async waitForBackoff(signal: AbortSignal): Promise<void> {
-        await this.waitUntilAllowed(signal, false);
+    async waitForBackoff(signal: AbortSignal, prepareWait: (delayMs: number) => Promise<void>): Promise<void> {
+        await this.waitUntilAllowed(signal, false, prepareWait);
     }
 
     /**
@@ -139,7 +139,7 @@ export class LocalAdaptivePollPacer implements DispatchPollPacer {
      * Executes the shared wait algorithm.
      * 1. Snapshot and decay state. 2. Calculate bounded jitter. 3. Sleep. 4. Repeat only for a live deadline extension.
      */
-    private async waitUntilAllowed(signal: AbortSignal, includeAdaptiveDelay: boolean): Promise<void> {
+    private async waitUntilAllowed(signal: AbortSignal, includeAdaptiveDelay: boolean, prepareWait?: (delayMs: number) => Promise<void>): Promise<void> {
         while (!signal.aborted) {
             const now = this.now();
             this.decay(now);
@@ -156,6 +156,7 @@ export class LocalAdaptivePollPacer implements DispatchPollPacer {
             if (delayMs === 0) {
                 return;
             }
+            await prepareWait?.(delayMs);
             await this.sleep(delayMs, signal);
             if (this.backoffUntil <= observedBackoffUntil || this.backoffUntil <= this.now()) {
                 return;

--- a/packages/jobs/lib/webhook/dispatch-queue/adaptive-polling.ts
+++ b/packages/jobs/lib/webhook/dispatch-queue/adaptive-polling.ts
@@ -14,7 +14,8 @@ export interface DispatchPollPacer {
 interface LocalAdaptivePollPacerOptions {
     maxDelayMs: number;
     healthyLatencyMs: number;
-    decayWindowMs: number;
+    latencyTauMs: number;
+    failureBackoffMs: number;
     jitterRatio: number;
     now?: () => number;
     random?: () => number;
@@ -23,25 +24,30 @@ interface LocalAdaptivePollPacerOptions {
 
 /**
  * Converts pod-local orchestrator outcomes into a shared delay for all SQS poll loops.
- * Pressure rises immediately on slow calls or failures, then decays toward zero while explicit admission backoff is enforced separately.
+ * Successful latency updates a smoothed pressure signal, while admission and failure backoffs are enforced separately.
  */
 export class LocalAdaptivePollPacer implements DispatchPollPacer {
     /** Maximum latency-driven delay applied before an SQS receive. */
     private readonly maxDelayMs: number;
     /** Orchestrator latency where the one-sided sigmoid starts producing pressure. */
     private readonly healthyLatencyMs: number;
-    /** Time after which a pressure signal retains only one percent of its original weight. */
-    private readonly decayWindowMs: number;
+    /** Time constant controlling how quickly successful latency samples change pressure. */
+    private readonly latencyTauMs: number;
+    /** Fixed pod-local pause applied after a generic orchestrator failure. */
+    private readonly failureBackoffMs: number;
     /** Fraction of each delay randomized to desynchronize loops and pods. */
     private readonly jitterRatio: number;
     private readonly now: () => number;
     private readonly random: () => number;
     private readonly sleep: (delayMs: number, signal: AbortSignal) => Promise<void>;
-    /** Current normalized load signal, from zero for healthy to one for fully paced. */
-    private pressure = 0;
-    private lastUpdatedAt: number;
+    /** Smoothed normalized latency signal, from zero for healthy to one for fully paced. */
+    private latencyPressure = 0;
+    /** Monotonic time of the previous successful latency sample. */
+    private lastLatencySampleAt: number;
     /** Monotonic deadline through which orchestrator admission asked this pod to stop dispatching. */
-    private backoffUntil = 0;
+    private admissionBackoffUntil = 0;
+    /** Monotonic deadline for the short pause applied after a generic failure. */
+    private failureBackoffUntil = 0;
 
     /**
      * Builds the pod-local controller.
@@ -54,8 +60,11 @@ export class LocalAdaptivePollPacer implements DispatchPollPacer {
         if (!Number.isFinite(options.healthyLatencyMs) || options.healthyLatencyMs <= 0) {
             throw new Error('Webhook dispatch healthy latency must be positive');
         }
-        if (!Number.isFinite(options.decayWindowMs) || options.decayWindowMs <= 0) {
-            throw new Error('Webhook dispatch poll delay decay window must be positive');
+        if (!Number.isFinite(options.latencyTauMs) || options.latencyTauMs <= 0) {
+            throw new Error('Webhook dispatch latency EWMA time constant must be positive');
+        }
+        if (!Number.isFinite(options.failureBackoffMs) || options.failureBackoffMs < 0) {
+            throw new Error('Webhook dispatch failure backoff must be non-negative');
         }
         if (!Number.isFinite(options.jitterRatio) || options.jitterRatio < 0 || options.jitterRatio > 1) {
             throw new Error('Webhook dispatch poll delay jitter ratio must be between zero and one');
@@ -63,12 +72,13 @@ export class LocalAdaptivePollPacer implements DispatchPollPacer {
 
         this.maxDelayMs = options.maxDelayMs;
         this.healthyLatencyMs = options.healthyLatencyMs;
-        this.decayWindowMs = options.decayWindowMs;
+        this.latencyTauMs = options.latencyTauMs;
+        this.failureBackoffMs = options.failureBackoffMs;
         this.jitterRatio = options.jitterRatio;
         this.now = options.now ?? (() => performance.now());
         this.random = options.random ?? Math.random;
         this.sleep = options.sleep ?? (async (delayMs, signal) => await setTimeout(delayMs, undefined, { signal }));
-        this.lastUpdatedAt = this.now();
+        this.lastLatencySampleAt = this.now();
     }
 
     /**
@@ -89,39 +99,36 @@ export class LocalAdaptivePollPacer implements DispatchPollPacer {
 
     /**
      * Applies orchestrator admission feedback.
-     * 1. Decay old pressure. 2. Force full pressure. 3. Extend Retry-After. 4. Record latency and backoff metrics.
+     * 1. Preserve latency pressure. 2. Extend Retry-After. 3. Record latency and admission-backoff metrics.
      */
     recordCongestion(retryAfterMs: number, durationMs: number): void {
         const now = this.now();
-        this.decay(now);
-        this.pressure = 1;
         const validRetryAfterMs = Number.isFinite(retryAfterMs) ? Math.max(0, retryAfterMs) : 0;
-        this.backoffUntil = Math.max(this.backoffUntil, now + validRetryAfterMs);
+        this.admissionBackoffUntil = Math.max(this.admissionBackoffUntil, now + validRetryAfterMs);
         if (Number.isFinite(durationMs) && durationMs >= 0) {
             metrics.duration(metrics.Types.WEBHOOK_DISPATCH_ORCHESTRATOR_LATENCY_MS, durationMs);
         }
         metrics.increment(metrics.Types.WEBHOOK_DISPATCH_POLL_BACKOFF, 1, { reason: 'admission' });
-        metrics.gauge(metrics.Types.WEBHOOK_DISPATCH_POLL_PRESSURE, this.pressure);
+        metrics.gauge(metrics.Types.WEBHOOK_DISPATCH_POLL_LATENCY_PRESSURE, this.latencyPressure);
     }
 
     /**
      * Applies generic orchestrator failure feedback.
-     * 1. Decay old pressure. 2. Force full pressure. 3. Record latency and failure backoff metrics.
+     * 1. Preserve latency pressure. 2. Extend the fixed failure deadline. 3. Record latency and failure-backoff metrics.
      */
     recordFailure(durationMs: number): void {
         const now = this.now();
-        this.decay(now);
-        this.pressure = 1;
+        this.failureBackoffUntil = Math.max(this.failureBackoffUntil, now + this.failureBackoffMs);
         if (Number.isFinite(durationMs) && durationMs >= 0) {
             metrics.duration(metrics.Types.WEBHOOK_DISPATCH_ORCHESTRATOR_LATENCY_MS, durationMs);
         }
         metrics.increment(metrics.Types.WEBHOOK_DISPATCH_POLL_BACKOFF, 1, { reason: 'failure' });
-        metrics.gauge(metrics.Types.WEBHOOK_DISPATCH_POLL_PRESSURE, this.pressure);
+        metrics.gauge(metrics.Types.WEBHOOK_DISPATCH_POLL_LATENCY_PRESSURE, this.latencyPressure);
     }
 
     /**
      * Applies a successful orchestrator latency sample.
-     * 1. Decay old pressure. 2. Map latency through the sigmoid. 3. Keep the stronger signal and record metrics.
+     * 1. Map latency through the sigmoid. 2. Blend it with a time-adaptive EWMA. 3. Record latency and pressure metrics.
      */
     recordSuccess(durationMs: number): void {
         if (!Number.isFinite(durationMs) || durationMs < 0) {
@@ -129,10 +136,16 @@ export class LocalAdaptivePollPacer implements DispatchPollPacer {
         }
 
         const now = this.now();
-        this.decay(now);
-        this.pressure = Math.max(this.pressure, this.pressureForLatency(durationMs));
+        const elapsedMs = Math.max(0, now - this.lastLatencySampleAt);
+        const alpha = 1 - Math.exp(-elapsedMs / this.latencyTauMs);
+        const samplePressure = this.pressureForLatency(durationMs);
+        this.latencyPressure += alpha * (samplePressure - this.latencyPressure);
+        if (this.latencyPressure * this.maxDelayMs < 1) {
+            this.latencyPressure = 0;
+        }
+        this.lastLatencySampleAt = now;
         metrics.duration(metrics.Types.WEBHOOK_DISPATCH_ORCHESTRATOR_LATENCY_MS, durationMs);
-        metrics.gauge(metrics.Types.WEBHOOK_DISPATCH_POLL_PRESSURE, this.pressure);
+        metrics.gauge(metrics.Types.WEBHOOK_DISPATCH_POLL_LATENCY_PRESSURE, this.latencyPressure);
     }
 
     /**
@@ -147,15 +160,16 @@ export class LocalAdaptivePollPacer implements DispatchPollPacer {
         while (true) {
             signal.throwIfAborted();
             const now = this.now();
-            this.decay(now);
-            const observedBackoffUntil = this.backoffUntil;
-            const adaptiveCeilingMs = includeAdaptiveDelay ? this.pressure * this.maxDelayMs : 0;
+            this.clearExpiredBackoffs(now);
+            const observedBackoffUntil = Math.max(this.admissionBackoffUntil, this.failureBackoffUntil);
+            const adaptiveCeilingMs = includeAdaptiveDelay ? this.latencyPressure * this.maxDelayMs : 0;
             const adaptiveDelayMs = adaptiveCeilingMs * (1 - this.jitterRatio + this.random() * this.jitterRatio);
-            const backoffRemainingMs = Math.max(0, observedBackoffUntil - now);
-            const backoffJitterMs = backoffRemainingMs > 0 ? this.random() * backoffRemainingMs * this.jitterRatio : 0;
-            const delayMs = Math.ceil(Math.max(adaptiveDelayMs, backoffRemainingMs + backoffJitterMs));
+            const admissionRemainingMs = Math.max(0, this.admissionBackoffUntil - now);
+            const admissionJitterMs = admissionRemainingMs > 0 ? this.random() * admissionRemainingMs * this.jitterRatio : 0;
+            const failureRemainingMs = Math.max(0, this.failureBackoffUntil - now);
+            const delayMs = Math.ceil(Math.max(adaptiveDelayMs, admissionRemainingMs + admissionJitterMs, failureRemainingMs));
 
-            if (includeAdaptiveDelay || backoffRemainingMs > 0) {
+            if (includeAdaptiveDelay || observedBackoffUntil > now) {
                 metrics.gauge(metrics.Types.WEBHOOK_DISPATCH_POLL_DELAY_MS, delayMs);
             }
             if (delayMs === 0) {
@@ -164,7 +178,8 @@ export class LocalAdaptivePollPacer implements DispatchPollPacer {
             await prepareWait?.(delayMs, signal);
             signal.throwIfAborted();
             await this.sleep(delayMs, signal);
-            if (this.backoffUntil <= observedBackoffUntil || this.backoffUntil <= this.now()) {
+            const currentBackoffUntil = Math.max(this.admissionBackoffUntil, this.failureBackoffUntil);
+            if (currentBackoffUntil <= observedBackoffUntil || currentBackoffUntil <= this.now()) {
                 return;
             }
         }
@@ -179,21 +194,13 @@ export class LocalAdaptivePollPacer implements DispatchPollPacer {
         return Math.max(0, 2 / (1 + Math.exp(-normalizedLatency)) - 1);
     }
 
-    /**
-     * Recovers local polling capacity over time.
-     * 1. Apply exponential decay for elapsed time. 2. Drop sub-millisecond pressure. 3. Clear expired admission backoff.
-     */
-    private decay(now: number): void {
-        const elapsedMs = Math.max(0, now - this.lastUpdatedAt);
-        if (elapsedMs > 0) {
-            this.pressure *= Math.exp((-Math.log(100) * elapsedMs) / this.decayWindowMs);
-            if (this.pressure * this.maxDelayMs < 1) {
-                this.pressure = 0;
-            }
-            this.lastUpdatedAt = now;
+    /** Clears completed admission and failure deadlines before calculating the next wait. */
+    private clearExpiredBackoffs(now: number): void {
+        if (this.admissionBackoffUntil <= now) {
+            this.admissionBackoffUntil = 0;
         }
-        if (this.backoffUntil <= now) {
-            this.backoffUntil = 0;
+        if (this.failureBackoffUntil <= now) {
+            this.failureBackoffUntil = 0;
         }
     }
 }

--- a/packages/jobs/lib/webhook/dispatch-queue/adaptive-polling.ts
+++ b/packages/jobs/lib/webhook/dispatch-queue/adaptive-polling.ts
@@ -3,36 +3,50 @@ import { setTimeout } from 'node:timers/promises';
 
 import { metrics } from '@nangohq/utils';
 
-const DEFAULT_DECAY_WINDOW_MS = 5 * 60 * 1000;
-const JITTER_RATIO = 0.2;
-
 export interface DispatchPollPacer {
     wait(signal: AbortSignal): Promise<void>;
-    recordSuccess(durationMs: number): void;
-    recordCongestion(retryAfterMs: number): void;
+    waitForBackoff(signal: AbortSignal): Promise<void>;
+    recordCongestion(retryAfterMs: number, durationMs: number): void;
     recordFailure(durationMs: number): void;
+    recordSuccess(durationMs: number): void;
 }
 
 interface LocalAdaptivePollPacerOptions {
     maxDelayMs: number;
     healthyLatencyMs: number;
-    decayWindowMs?: number;
+    decayWindowMs: number;
+    jitterRatio: number;
     now?: () => number;
     random?: () => number;
     sleep?: (delayMs: number, signal: AbortSignal) => Promise<void>;
 }
 
+/**
+ * Converts pod-local orchestrator outcomes into a shared delay for all SQS poll loops.
+ * Pressure rises immediately on slow calls or failures, then decays toward zero while explicit admission backoff is enforced separately.
+ */
 export class LocalAdaptivePollPacer implements DispatchPollPacer {
+    /** Maximum latency-driven delay applied before an SQS receive. */
     private readonly maxDelayMs: number;
+    /** Orchestrator latency where the one-sided sigmoid starts producing pressure. */
     private readonly healthyLatencyMs: number;
+    /** Time after which a pressure signal retains only one percent of its original weight. */
     private readonly decayWindowMs: number;
+    /** Fraction of each delay randomized to desynchronize loops and pods. */
+    private readonly jitterRatio: number;
     private readonly now: () => number;
     private readonly random: () => number;
     private readonly sleep: (delayMs: number, signal: AbortSignal) => Promise<void>;
+    /** Current normalized load signal, from zero for healthy to one for fully paced. */
     private pressure = 0;
     private lastUpdatedAt: number;
+    /** Monotonic deadline through which orchestrator admission asked this pod to stop dispatching. */
     private backoffUntil = 0;
 
+    /**
+     * Builds the pod-local controller.
+     * 1. Validate each tuning input. 2. Store its dependencies. 3. Anchor decay to the monotonic clock.
+     */
     constructor(options: LocalAdaptivePollPacerOptions) {
         if (!Number.isFinite(options.maxDelayMs) || options.maxDelayMs < 0) {
             throw new Error('Webhook dispatch maximum poll delay must be non-negative');
@@ -40,42 +54,75 @@ export class LocalAdaptivePollPacer implements DispatchPollPacer {
         if (!Number.isFinite(options.healthyLatencyMs) || options.healthyLatencyMs <= 0) {
             throw new Error('Webhook dispatch healthy latency must be positive');
         }
-        if (options.decayWindowMs !== undefined && (!Number.isFinite(options.decayWindowMs) || options.decayWindowMs <= 0)) {
+        if (!Number.isFinite(options.decayWindowMs) || options.decayWindowMs <= 0) {
             throw new Error('Webhook dispatch poll delay decay window must be positive');
+        }
+        if (!Number.isFinite(options.jitterRatio) || options.jitterRatio < 0 || options.jitterRatio > 1) {
+            throw new Error('Webhook dispatch poll delay jitter ratio must be between zero and one');
         }
 
         this.maxDelayMs = options.maxDelayMs;
         this.healthyLatencyMs = options.healthyLatencyMs;
-        this.decayWindowMs = options.decayWindowMs ?? DEFAULT_DECAY_WINDOW_MS;
+        this.decayWindowMs = options.decayWindowMs;
+        this.jitterRatio = options.jitterRatio;
         this.now = options.now ?? (() => performance.now());
         this.random = options.random ?? Math.random;
         this.sleep = options.sleep ?? (async (delayMs, signal) => await setTimeout(delayMs, undefined, { signal }));
         this.lastUpdatedAt = this.now();
     }
 
+    /**
+     * Paces the next SQS receive.
+     * 1. Include both latency pressure and admission backoff. 2. Sleep with jitter. 3. Recheck extensions from peer loops.
+     */
     async wait(signal: AbortSignal): Promise<void> {
-        while (!signal.aborted) {
-            const now = this.now();
-            this.decay(now);
-            const observedBackoffUntil = this.backoffUntil;
-            const adaptiveCeilingMs = this.pressure * this.maxDelayMs;
-            const adaptiveDelayMs = adaptiveCeilingMs * (1 - JITTER_RATIO + this.random() * JITTER_RATIO);
-            const backoffRemainingMs = Math.max(0, observedBackoffUntil - now);
-            const backoffJitterMs = backoffRemainingMs > 0 ? this.random() * backoffRemainingMs * JITTER_RATIO : 0;
-            const delayMs = Math.ceil(Math.max(adaptiveDelayMs, backoffRemainingMs + backoffJitterMs));
-
-            metrics.gauge(metrics.Types.WEBHOOK_DISPATCH_POLL_DELAY_MS, delayMs);
-            metrics.gauge(metrics.Types.WEBHOOK_DISPATCH_POLL_PRESSURE, this.pressure);
-            if (delayMs === 0) {
-                return;
-            }
-            await this.sleep(delayMs, signal);
-            if (this.backoffUntil <= observedBackoffUntil || this.backoffUntil <= this.now()) {
-                return;
-            }
-        }
+        await this.waitUntilAllowed(signal, true);
     }
 
+    /**
+     * Gates an already-received batch before orchestrator dispatch.
+     * 1. Ignore adaptive pressure to avoid double pacing. 2. Wait only for explicit admission backoff and peer-loop extensions.
+     */
+    async waitForBackoff(signal: AbortSignal): Promise<void> {
+        await this.waitUntilAllowed(signal, false);
+    }
+
+    /**
+     * Applies orchestrator admission feedback.
+     * 1. Decay old pressure. 2. Force full pressure. 3. Extend Retry-After. 4. Record latency and backoff metrics.
+     */
+    recordCongestion(retryAfterMs: number, durationMs: number): void {
+        const now = this.now();
+        this.decay(now);
+        this.pressure = 1;
+        const validRetryAfterMs = Number.isFinite(retryAfterMs) ? Math.max(0, retryAfterMs) : 0;
+        this.backoffUntil = Math.max(this.backoffUntil, now + validRetryAfterMs);
+        if (Number.isFinite(durationMs) && durationMs >= 0) {
+            metrics.duration(metrics.Types.WEBHOOK_DISPATCH_ORCHESTRATOR_LATENCY_MS, durationMs);
+        }
+        metrics.increment(metrics.Types.WEBHOOK_DISPATCH_POLL_BACKOFF, 1, { reason: 'admission' });
+        metrics.gauge(metrics.Types.WEBHOOK_DISPATCH_POLL_PRESSURE, this.pressure);
+    }
+
+    /**
+     * Applies generic orchestrator failure feedback.
+     * 1. Decay old pressure. 2. Force full pressure. 3. Record latency and failure backoff metrics.
+     */
+    recordFailure(durationMs: number): void {
+        const now = this.now();
+        this.decay(now);
+        this.pressure = 1;
+        if (Number.isFinite(durationMs) && durationMs >= 0) {
+            metrics.duration(metrics.Types.WEBHOOK_DISPATCH_ORCHESTRATOR_LATENCY_MS, durationMs);
+        }
+        metrics.increment(metrics.Types.WEBHOOK_DISPATCH_POLL_BACKOFF, 1, { reason: 'failure' });
+        metrics.gauge(metrics.Types.WEBHOOK_DISPATCH_POLL_PRESSURE, this.pressure);
+    }
+
+    /**
+     * Applies a successful orchestrator latency sample.
+     * 1. Decay old pressure. 2. Map latency through the sigmoid. 3. Keep the stronger signal and record metrics.
+     */
     recordSuccess(durationMs: number): void {
         if (!Number.isFinite(durationMs) || durationMs < 0) {
             return;
@@ -88,35 +135,50 @@ export class LocalAdaptivePollPacer implements DispatchPollPacer {
         metrics.gauge(metrics.Types.WEBHOOK_DISPATCH_POLL_PRESSURE, this.pressure);
     }
 
-    recordCongestion(retryAfterMs: number): void {
-        const now = this.now();
-        this.decay(now);
-        this.pressure = 1;
-        this.backoffUntil = Math.max(this.backoffUntil, now + Math.max(0, retryAfterMs));
-        metrics.increment(metrics.Types.WEBHOOK_DISPATCH_POLL_BACKOFF, 1, { reason: 'admission' });
-        metrics.gauge(metrics.Types.WEBHOOK_DISPATCH_POLL_PRESSURE, this.pressure);
-    }
+    /**
+     * Executes the shared wait algorithm.
+     * 1. Snapshot and decay state. 2. Calculate bounded jitter. 3. Sleep. 4. Repeat only for a live deadline extension.
+     */
+    private async waitUntilAllowed(signal: AbortSignal, includeAdaptiveDelay: boolean): Promise<void> {
+        while (!signal.aborted) {
+            const now = this.now();
+            this.decay(now);
+            const observedBackoffUntil = this.backoffUntil;
+            const adaptiveCeilingMs = includeAdaptiveDelay ? this.pressure * this.maxDelayMs : 0;
+            const adaptiveDelayMs = adaptiveCeilingMs * (1 - this.jitterRatio + this.random() * this.jitterRatio);
+            const backoffRemainingMs = Math.max(0, observedBackoffUntil - now);
+            const backoffJitterMs = backoffRemainingMs > 0 ? this.random() * backoffRemainingMs * this.jitterRatio : 0;
+            const delayMs = Math.ceil(Math.max(adaptiveDelayMs, backoffRemainingMs + backoffJitterMs));
 
-    recordFailure(durationMs: number): void {
-        const now = this.now();
-        this.decay(now);
-        this.pressure = 1;
-        if (Number.isFinite(durationMs) && durationMs >= 0) {
-            metrics.duration(metrics.Types.WEBHOOK_DISPATCH_ORCHESTRATOR_LATENCY_MS, durationMs);
+            if (includeAdaptiveDelay || backoffRemainingMs > 0) {
+                metrics.gauge(metrics.Types.WEBHOOK_DISPATCH_POLL_DELAY_MS, delayMs);
+            }
+            if (delayMs === 0) {
+                return;
+            }
+            await this.sleep(delayMs, signal);
+            if (this.backoffUntil <= observedBackoffUntil || this.backoffUntil <= this.now()) {
+                return;
+            }
         }
-        metrics.increment(metrics.Types.WEBHOOK_DISPATCH_POLL_BACKOFF, 1, { reason: 'failure' });
-        metrics.gauge(metrics.Types.WEBHOOK_DISPATCH_POLL_PRESSURE, this.pressure);
     }
 
+    /**
+     * Converts latency into normalized pressure.
+     * Values at or below the healthy threshold map to zero; slower calls approach one through a one-sided sigmoid.
+     */
     private pressureForLatency(durationMs: number): number {
         const normalizedLatency = durationMs / this.healthyLatencyMs - 1;
         return Math.max(0, 2 / (1 + Math.exp(-normalizedLatency)) - 1);
     }
 
+    /**
+     * Recovers local polling capacity over time.
+     * 1. Apply exponential decay for elapsed time. 2. Drop sub-millisecond pressure. 3. Clear expired admission backoff.
+     */
     private decay(now: number): void {
         const elapsedMs = Math.max(0, now - this.lastUpdatedAt);
         if (elapsedMs > 0) {
-            // A pressure signal retains only 1% of its weight after the five-minute window.
             this.pressure *= Math.exp((-Math.log(100) * elapsedMs) / this.decayWindowMs);
             if (this.pressure * this.maxDelayMs < 1) {
                 this.pressure = 0;

--- a/packages/jobs/lib/webhook/dispatch-queue/adaptive-polling.ts
+++ b/packages/jobs/lib/webhook/dispatch-queue/adaptive-polling.ts
@@ -1,0 +1,130 @@
+import { performance } from 'node:perf_hooks';
+import { setTimeout } from 'node:timers/promises';
+
+import { metrics } from '@nangohq/utils';
+
+const DEFAULT_DECAY_WINDOW_MS = 5 * 60 * 1000;
+const JITTER_RATIO = 0.2;
+
+export interface DispatchPollPacer {
+    wait(signal: AbortSignal): Promise<void>;
+    recordSuccess(durationMs: number): void;
+    recordCongestion(retryAfterMs: number): void;
+    recordFailure(durationMs: number): void;
+}
+
+interface LocalAdaptivePollPacerOptions {
+    maxDelayMs: number;
+    healthyLatencyMs: number;
+    decayWindowMs?: number;
+    now?: () => number;
+    random?: () => number;
+    sleep?: (delayMs: number, signal: AbortSignal) => Promise<void>;
+}
+
+export class LocalAdaptivePollPacer implements DispatchPollPacer {
+    private readonly maxDelayMs: number;
+    private readonly healthyLatencyMs: number;
+    private readonly decayWindowMs: number;
+    private readonly now: () => number;
+    private readonly random: () => number;
+    private readonly sleep: (delayMs: number, signal: AbortSignal) => Promise<void>;
+    private pressure = 0;
+    private lastUpdatedAt: number;
+    private backoffUntil = 0;
+
+    constructor(options: LocalAdaptivePollPacerOptions) {
+        if (!Number.isFinite(options.maxDelayMs) || options.maxDelayMs < 0) {
+            throw new Error('Webhook dispatch maximum poll delay must be non-negative');
+        }
+        if (!Number.isFinite(options.healthyLatencyMs) || options.healthyLatencyMs <= 0) {
+            throw new Error('Webhook dispatch healthy latency must be positive');
+        }
+        if (options.decayWindowMs !== undefined && (!Number.isFinite(options.decayWindowMs) || options.decayWindowMs <= 0)) {
+            throw new Error('Webhook dispatch poll delay decay window must be positive');
+        }
+
+        this.maxDelayMs = options.maxDelayMs;
+        this.healthyLatencyMs = options.healthyLatencyMs;
+        this.decayWindowMs = options.decayWindowMs ?? DEFAULT_DECAY_WINDOW_MS;
+        this.now = options.now ?? (() => performance.now());
+        this.random = options.random ?? Math.random;
+        this.sleep = options.sleep ?? (async (delayMs, signal) => await setTimeout(delayMs, undefined, { signal }));
+        this.lastUpdatedAt = this.now();
+    }
+
+    async wait(signal: AbortSignal): Promise<void> {
+        while (!signal.aborted) {
+            const now = this.now();
+            this.decay(now);
+            const observedBackoffUntil = this.backoffUntil;
+            const adaptiveCeilingMs = this.pressure * this.maxDelayMs;
+            const adaptiveDelayMs = adaptiveCeilingMs * (1 - JITTER_RATIO + this.random() * JITTER_RATIO);
+            const backoffRemainingMs = Math.max(0, observedBackoffUntil - now);
+            const backoffJitterMs = backoffRemainingMs > 0 ? this.random() * backoffRemainingMs * JITTER_RATIO : 0;
+            const delayMs = Math.ceil(Math.max(adaptiveDelayMs, backoffRemainingMs + backoffJitterMs));
+
+            metrics.gauge(metrics.Types.WEBHOOK_DISPATCH_POLL_DELAY_MS, delayMs);
+            metrics.gauge(metrics.Types.WEBHOOK_DISPATCH_POLL_PRESSURE, this.pressure);
+            if (delayMs === 0) {
+                return;
+            }
+            await this.sleep(delayMs, signal);
+            if (this.backoffUntil <= observedBackoffUntil || this.backoffUntil <= this.now()) {
+                return;
+            }
+        }
+    }
+
+    recordSuccess(durationMs: number): void {
+        if (!Number.isFinite(durationMs) || durationMs < 0) {
+            return;
+        }
+
+        const now = this.now();
+        this.decay(now);
+        this.pressure = Math.max(this.pressure, this.pressureForLatency(durationMs));
+        metrics.duration(metrics.Types.WEBHOOK_DISPATCH_ORCHESTRATOR_LATENCY_MS, durationMs);
+        metrics.gauge(metrics.Types.WEBHOOK_DISPATCH_POLL_PRESSURE, this.pressure);
+    }
+
+    recordCongestion(retryAfterMs: number): void {
+        const now = this.now();
+        this.decay(now);
+        this.pressure = 1;
+        this.backoffUntil = Math.max(this.backoffUntil, now + Math.max(0, retryAfterMs));
+        metrics.increment(metrics.Types.WEBHOOK_DISPATCH_POLL_BACKOFF, 1, { reason: 'admission' });
+        metrics.gauge(metrics.Types.WEBHOOK_DISPATCH_POLL_PRESSURE, this.pressure);
+    }
+
+    recordFailure(durationMs: number): void {
+        const now = this.now();
+        this.decay(now);
+        this.pressure = 1;
+        if (Number.isFinite(durationMs) && durationMs >= 0) {
+            metrics.duration(metrics.Types.WEBHOOK_DISPATCH_ORCHESTRATOR_LATENCY_MS, durationMs);
+        }
+        metrics.increment(metrics.Types.WEBHOOK_DISPATCH_POLL_BACKOFF, 1, { reason: 'failure' });
+        metrics.gauge(metrics.Types.WEBHOOK_DISPATCH_POLL_PRESSURE, this.pressure);
+    }
+
+    private pressureForLatency(durationMs: number): number {
+        const normalizedLatency = durationMs / this.healthyLatencyMs - 1;
+        return Math.max(0, 2 / (1 + Math.exp(-normalizedLatency)) - 1);
+    }
+
+    private decay(now: number): void {
+        const elapsedMs = Math.max(0, now - this.lastUpdatedAt);
+        if (elapsedMs > 0) {
+            // A pressure signal retains only 1% of its weight after the five-minute window.
+            this.pressure *= Math.exp((-Math.log(100) * elapsedMs) / this.decayWindowMs);
+            if (this.pressure * this.maxDelayMs < 1) {
+                this.pressure = 0;
+            }
+            this.lastUpdatedAt = now;
+        }
+        if (this.backoffUntil <= now) {
+            this.backoffUntil = 0;
+        }
+    }
+}

--- a/packages/jobs/lib/webhook/dispatch-queue/adaptive-polling.unit.test.ts
+++ b/packages/jobs/lib/webhook/dispatch-queue/adaptive-polling.unit.test.ts
@@ -2,12 +2,23 @@ import { describe, expect, it, vi } from 'vitest';
 
 import { LocalAdaptivePollPacer } from './adaptive-polling.js';
 
-describe('LocalAdaptivePollPacer', () => {
-    it('does not delay polling at or below the healthy latency', async () => {
-        const sleep = vi.fn(() => Promise.resolve());
-        const pacer = new LocalAdaptivePollPacer({ maxDelayMs: 500, healthyLatencyMs: 100, now: () => 0, random: () => 0.5, sleep });
+const defaultOptions = {
+    maxDelayMs: 500,
+    healthyLatencyMs: 100,
+    decayWindowMs: 5 * 60 * 1000,
+    jitterRatio: 0.2
+};
 
-        pacer.recordSuccess(100);
+function makePacer(options: Partial<ConstructorParameters<typeof LocalAdaptivePollPacer>[0]> = {}): LocalAdaptivePollPacer {
+    return new LocalAdaptivePollPacer({ ...defaultOptions, ...options });
+}
+
+describe('LocalAdaptivePollPacer', () => {
+    it.each([50, 100])('does not delay polling for latency at or below the healthy threshold: %dms', async (durationMs) => {
+        const sleep = vi.fn(() => Promise.resolve());
+        const pacer = makePacer({ now: () => 0, random: () => 0.5, sleep });
+
+        pacer.recordSuccess(durationMs);
         await pacer.wait(new AbortController().signal);
 
         expect(sleep).not.toHaveBeenCalled();
@@ -15,7 +26,7 @@ describe('LocalAdaptivePollPacer', () => {
 
     it('maps unhealthy latency to a sigmoid delay with bounded jitter', async () => {
         const sleep = vi.fn(() => Promise.resolve());
-        const pacer = new LocalAdaptivePollPacer({ maxDelayMs: 500, healthyLatencyMs: 100, now: () => 0, random: () => 0.5, sleep });
+        const pacer = makePacer({ now: () => 0, random: () => 0.5, sleep });
 
         pacer.recordSuccess(200);
         await pacer.wait(new AbortController().signal);
@@ -26,7 +37,7 @@ describe('LocalAdaptivePollPacer', () => {
     it('decays latency pressure to effectively zero over five minutes', async () => {
         let now = 0;
         const sleep = vi.fn(() => Promise.resolve());
-        const pacer = new LocalAdaptivePollPacer({ maxDelayMs: 500, healthyLatencyMs: 100, now: () => now, random: () => 0.5, sleep });
+        const pacer = makePacer({ now: () => now, random: () => 0.5, sleep });
         pacer.recordSuccess(200);
 
         now = 5 * 60 * 1000;
@@ -41,10 +52,20 @@ describe('LocalAdaptivePollPacer', () => {
 
     it('honors admission Retry-After even when it exceeds the adaptive maximum', async () => {
         const sleep = vi.fn(() => Promise.resolve());
-        const pacer = new LocalAdaptivePollPacer({ maxDelayMs: 500, healthyLatencyMs: 100, now: () => 0, random: () => 0.5, sleep });
+        const pacer = makePacer({ now: () => 0, random: () => 0.5, sleep });
 
-        pacer.recordCongestion(1200);
+        pacer.recordCongestion(1200, 20);
         await pacer.wait(new AbortController().signal);
+
+        expect(sleep).toHaveBeenCalledWith(1320, expect.any(AbortSignal));
+    });
+
+    it('honors admission Retry-After at the pre-dispatch gate', async () => {
+        const sleep = vi.fn(() => Promise.resolve());
+        const pacer = makePacer({ now: () => 0, random: () => 0.5, sleep });
+
+        pacer.recordCongestion(1200, 20);
+        await pacer.waitForBackoff(new AbortController().signal);
 
         expect(sleep).toHaveBeenCalledWith(1320, expect.any(AbortSignal));
     });
@@ -52,11 +73,11 @@ describe('LocalAdaptivePollPacer', () => {
     it('extends an existing admission backoff', async () => {
         let now = 0;
         const sleep = vi.fn(() => Promise.resolve());
-        const pacer = new LocalAdaptivePollPacer({ maxDelayMs: 500, healthyLatencyMs: 100, now: () => now, random: () => 0.5, sleep });
-        pacer.recordCongestion(1200);
+        const pacer = makePacer({ now: () => now, random: () => 0.5, sleep });
+        pacer.recordCongestion(1200, 20);
 
         now = 400;
-        pacer.recordCongestion(2000);
+        pacer.recordCongestion(2000, 20);
         await pacer.wait(new AbortController().signal);
 
         expect(sleep).toHaveBeenCalledWith(2200, expect.any(AbortSignal));
@@ -76,12 +97,12 @@ describe('LocalAdaptivePollPacer', () => {
                 await firstSleep;
             }
         });
-        const pacer = new LocalAdaptivePollPacer({ maxDelayMs: 500, healthyLatencyMs: 100, now: () => now, random: () => 0.5, sleep });
+        const pacer = makePacer({ now: () => now, random: () => 0.5, sleep });
         pacer.recordSuccess(200);
 
         const waitPromise = pacer.wait(new AbortController().signal);
         await vi.waitFor(() => expect(sleep).toHaveBeenCalledOnce());
-        pacer.recordCongestion(1200);
+        pacer.recordCongestion(1200, 20);
         releaseFirstSleep();
         await waitPromise;
 
@@ -99,12 +120,12 @@ describe('LocalAdaptivePollPacer', () => {
             now += delayMs;
             await sleeping;
         });
-        const pacer = new LocalAdaptivePollPacer({ maxDelayMs: 500, healthyLatencyMs: 100, now: () => now, random: () => 1, sleep });
+        const pacer = makePacer({ now: () => now, random: () => 1, sleep });
         pacer.recordFailure(20);
 
         const waitPromise = pacer.wait(new AbortController().signal);
         await vi.waitFor(() => expect(sleep).toHaveBeenCalledOnce());
-        pacer.recordCongestion(100);
+        pacer.recordCongestion(100, 20);
         now += 200;
         releaseSleep();
         await waitPromise;
@@ -114,7 +135,7 @@ describe('LocalAdaptivePollPacer', () => {
 
     it('paces polling after generic orchestrator failures', async () => {
         const sleep = vi.fn(() => Promise.resolve());
-        const pacer = new LocalAdaptivePollPacer({ maxDelayMs: 500, healthyLatencyMs: 100, now: () => 0, random: () => 1, sleep });
+        const pacer = makePacer({ now: () => 0, random: () => 1, sleep });
 
         pacer.recordFailure(20);
         await pacer.wait(new AbortController().signal);
@@ -124,7 +145,7 @@ describe('LocalAdaptivePollPacer', () => {
 
     it('never exceeds the configured adaptive delay for latency pressure', async () => {
         const sleep = vi.fn(() => Promise.resolve());
-        const pacer = new LocalAdaptivePollPacer({ maxDelayMs: 500, healthyLatencyMs: 100, now: () => 0, random: () => 1, sleep });
+        const pacer = makePacer({ now: () => 0, random: () => 1, sleep });
 
         pacer.recordSuccess(10_000);
         await pacer.wait(new AbortController().signal);
@@ -133,7 +154,7 @@ describe('LocalAdaptivePollPacer', () => {
     });
 
     it('aborts an in-progress polling delay during shutdown', async () => {
-        const pacer = new LocalAdaptivePollPacer({ maxDelayMs: 500, healthyLatencyMs: 100, random: () => 1 });
+        const pacer = makePacer({ random: () => 1 });
         pacer.recordFailure(20);
         const controller = new AbortController();
 
@@ -141,5 +162,15 @@ describe('LocalAdaptivePollPacer', () => {
         controller.abort();
 
         await expect(waiting).rejects.toMatchObject({ name: 'AbortError' });
+    });
+
+    it('does not apply latency pressure again at the pre-dispatch backoff gate', async () => {
+        const sleep = vi.fn(() => Promise.resolve());
+        const pacer = makePacer({ now: () => 0, random: () => 1, sleep });
+        pacer.recordFailure(20);
+
+        await pacer.waitForBackoff(new AbortController().signal);
+
+        expect(sleep).not.toHaveBeenCalled();
     });
 });

--- a/packages/jobs/lib/webhook/dispatch-queue/adaptive-polling.unit.test.ts
+++ b/packages/jobs/lib/webhook/dispatch-queue/adaptive-polling.unit.test.ts
@@ -1,0 +1,145 @@
+import { describe, expect, it, vi } from 'vitest';
+
+import { LocalAdaptivePollPacer } from './adaptive-polling.js';
+
+describe('LocalAdaptivePollPacer', () => {
+    it('does not delay polling at or below the healthy latency', async () => {
+        const sleep = vi.fn(() => Promise.resolve());
+        const pacer = new LocalAdaptivePollPacer({ maxDelayMs: 500, healthyLatencyMs: 100, now: () => 0, random: () => 0.5, sleep });
+
+        pacer.recordSuccess(100);
+        await pacer.wait(new AbortController().signal);
+
+        expect(sleep).not.toHaveBeenCalled();
+    });
+
+    it('maps unhealthy latency to a sigmoid delay with bounded jitter', async () => {
+        const sleep = vi.fn(() => Promise.resolve());
+        const pacer = new LocalAdaptivePollPacer({ maxDelayMs: 500, healthyLatencyMs: 100, now: () => 0, random: () => 0.5, sleep });
+
+        pacer.recordSuccess(200);
+        await pacer.wait(new AbortController().signal);
+
+        expect(sleep).toHaveBeenCalledWith(208, expect.any(AbortSignal));
+    });
+
+    it('decays latency pressure to effectively zero over five minutes', async () => {
+        let now = 0;
+        const sleep = vi.fn(() => Promise.resolve());
+        const pacer = new LocalAdaptivePollPacer({ maxDelayMs: 500, healthyLatencyMs: 100, now: () => now, random: () => 0.5, sleep });
+        pacer.recordSuccess(200);
+
+        now = 5 * 60 * 1000;
+        await pacer.wait(new AbortController().signal);
+        expect(sleep).toHaveBeenLastCalledWith(3, expect.any(AbortSignal));
+
+        now = 10 * 60 * 1000;
+        sleep.mockClear();
+        await pacer.wait(new AbortController().signal);
+        expect(sleep).not.toHaveBeenCalled();
+    });
+
+    it('honors admission Retry-After even when it exceeds the adaptive maximum', async () => {
+        const sleep = vi.fn(() => Promise.resolve());
+        const pacer = new LocalAdaptivePollPacer({ maxDelayMs: 500, healthyLatencyMs: 100, now: () => 0, random: () => 0.5, sleep });
+
+        pacer.recordCongestion(1200);
+        await pacer.wait(new AbortController().signal);
+
+        expect(sleep).toHaveBeenCalledWith(1320, expect.any(AbortSignal));
+    });
+
+    it('extends an existing admission backoff', async () => {
+        let now = 0;
+        const sleep = vi.fn(() => Promise.resolve());
+        const pacer = new LocalAdaptivePollPacer({ maxDelayMs: 500, healthyLatencyMs: 100, now: () => now, random: () => 0.5, sleep });
+        pacer.recordCongestion(1200);
+
+        now = 400;
+        pacer.recordCongestion(2000);
+        await pacer.wait(new AbortController().signal);
+
+        expect(sleep).toHaveBeenCalledWith(2200, expect.any(AbortSignal));
+    });
+
+    it('rechecks a Retry-After deadline extended by another poll loop', async () => {
+        let now = 0;
+        let sleepCount = 0;
+        let releaseFirstSleep!: () => void;
+        const firstSleep = new Promise<void>((resolve) => {
+            releaseFirstSleep = resolve;
+        });
+        const sleep = vi.fn(async (delayMs: number) => {
+            now += delayMs;
+            sleepCount += 1;
+            if (sleepCount === 1) {
+                await firstSleep;
+            }
+        });
+        const pacer = new LocalAdaptivePollPacer({ maxDelayMs: 500, healthyLatencyMs: 100, now: () => now, random: () => 0.5, sleep });
+        pacer.recordSuccess(200);
+
+        const waitPromise = pacer.wait(new AbortController().signal);
+        await vi.waitFor(() => expect(sleep).toHaveBeenCalledOnce());
+        pacer.recordCongestion(1200);
+        releaseFirstSleep();
+        await waitPromise;
+
+        expect(sleep).toHaveBeenCalledTimes(2);
+        expect(sleep.mock.calls[1]?.[0]).toBe(1320);
+    });
+
+    it('does not wait again when an extended deadline expires during the current sleep', async () => {
+        let now = 0;
+        let releaseSleep!: () => void;
+        const sleeping = new Promise<void>((resolve) => {
+            releaseSleep = resolve;
+        });
+        const sleep = vi.fn(async (delayMs: number) => {
+            now += delayMs;
+            await sleeping;
+        });
+        const pacer = new LocalAdaptivePollPacer({ maxDelayMs: 500, healthyLatencyMs: 100, now: () => now, random: () => 1, sleep });
+        pacer.recordFailure(20);
+
+        const waitPromise = pacer.wait(new AbortController().signal);
+        await vi.waitFor(() => expect(sleep).toHaveBeenCalledOnce());
+        pacer.recordCongestion(100);
+        now += 200;
+        releaseSleep();
+        await waitPromise;
+
+        expect(sleep).toHaveBeenCalledOnce();
+    });
+
+    it('paces polling after generic orchestrator failures', async () => {
+        const sleep = vi.fn(() => Promise.resolve());
+        const pacer = new LocalAdaptivePollPacer({ maxDelayMs: 500, healthyLatencyMs: 100, now: () => 0, random: () => 1, sleep });
+
+        pacer.recordFailure(20);
+        await pacer.wait(new AbortController().signal);
+
+        expect(sleep).toHaveBeenCalledWith(500, expect.any(AbortSignal));
+    });
+
+    it('never exceeds the configured adaptive delay for latency pressure', async () => {
+        const sleep = vi.fn(() => Promise.resolve());
+        const pacer = new LocalAdaptivePollPacer({ maxDelayMs: 500, healthyLatencyMs: 100, now: () => 0, random: () => 1, sleep });
+
+        pacer.recordSuccess(10_000);
+        await pacer.wait(new AbortController().signal);
+
+        expect(sleep).toHaveBeenCalledWith(500, expect.any(AbortSignal));
+    });
+
+    it('aborts an in-progress polling delay during shutdown', async () => {
+        const pacer = new LocalAdaptivePollPacer({ maxDelayMs: 500, healthyLatencyMs: 100, random: () => 1 });
+        pacer.recordFailure(20);
+        const controller = new AbortController();
+
+        const waiting = pacer.wait(controller.signal);
+        controller.abort();
+
+        await expect(waiting).rejects.toMatchObject({ name: 'AbortError' });
+    });
+});

--- a/packages/jobs/lib/webhook/dispatch-queue/adaptive-polling.unit.test.ts
+++ b/packages/jobs/lib/webhook/dispatch-queue/adaptive-polling.unit.test.ts
@@ -62,12 +62,20 @@ describe('LocalAdaptivePollPacer', () => {
 
     it('honors admission Retry-After at the pre-dispatch gate', async () => {
         const sleep = vi.fn(() => Promise.resolve());
+        const prepareWait = vi.fn(() => Promise.resolve());
         const pacer = makePacer({ now: () => 0, random: () => 0.5, sleep });
 
         pacer.recordCongestion(1200, 20);
-        await pacer.waitForBackoff(new AbortController().signal);
+        await pacer.waitForBackoff(new AbortController().signal, prepareWait);
 
+        expect(prepareWait).toHaveBeenCalledWith(1320);
         expect(sleep).toHaveBeenCalledWith(1320, expect.any(AbortSignal));
+        const prepareOrder = prepareWait.mock.invocationCallOrder[0];
+        const sleepOrder = sleep.mock.invocationCallOrder[0];
+        if (prepareOrder === undefined || sleepOrder === undefined) {
+            throw new Error('Expected visibility preparation and sleep to be called');
+        }
+        expect(prepareOrder).toBeLessThan(sleepOrder);
     });
 
     it('extends an existing admission backoff', async () => {
@@ -169,7 +177,7 @@ describe('LocalAdaptivePollPacer', () => {
         const pacer = makePacer({ now: () => 0, random: () => 1, sleep });
         pacer.recordFailure(20);
 
-        await pacer.waitForBackoff(new AbortController().signal);
+        await pacer.waitForBackoff(new AbortController().signal, () => Promise.resolve());
 
         expect(sleep).not.toHaveBeenCalled();
     });

--- a/packages/jobs/lib/webhook/dispatch-queue/adaptive-polling.unit.test.ts
+++ b/packages/jobs/lib/webhook/dispatch-queue/adaptive-polling.unit.test.ts
@@ -5,7 +5,8 @@ import { LocalAdaptivePollPacer } from './adaptive-polling.js';
 const defaultOptions = {
     maxDelayMs: 500,
     healthyLatencyMs: 100,
-    decayWindowMs: 5 * 60 * 1000,
+    latencyTauMs: 10_000,
+    failureBackoffMs: 500,
     jitterRatio: 0.2
 };
 
@@ -15,39 +16,103 @@ function makePacer(options: Partial<ConstructorParameters<typeof LocalAdaptivePo
 
 describe('LocalAdaptivePollPacer', () => {
     it.each([50, 100])('does not delay polling for latency at or below the healthy threshold: %dms', async (durationMs) => {
+        let now = 0;
         const sleep = vi.fn(() => Promise.resolve());
-        const pacer = makePacer({ now: () => 0, random: () => 0.5, sleep });
+        const pacer = makePacer({ now: () => now, random: () => 0.5, sleep });
 
+        now = 1000;
         pacer.recordSuccess(durationMs);
         await pacer.wait(new AbortController().signal);
 
         expect(sleep).not.toHaveBeenCalled();
     });
 
-    it('maps unhealthy latency to a sigmoid delay with bounded jitter', async () => {
-        const sleep = vi.fn(() => Promise.resolve());
-        const pacer = makePacer({ now: () => 0, random: () => 0.5, sleep });
-
-        pacer.recordSuccess(200);
-        await pacer.wait(new AbortController().signal);
-
-        expect(sleep).toHaveBeenCalledWith(208, expect.any(AbortSignal));
-    });
-
-    it('decays latency pressure to effectively zero over five minutes', async () => {
+    it('smooths a single transient latency spike', async () => {
         let now = 0;
         const sleep = vi.fn(() => Promise.resolve());
         const pacer = makePacer({ now: () => now, random: () => 0.5, sleep });
-        pacer.recordSuccess(200);
 
-        now = 5 * 60 * 1000;
+        now = 1000;
+        pacer.recordSuccess(1000);
         await pacer.wait(new AbortController().signal);
-        expect(sleep).toHaveBeenLastCalledWith(3, expect.any(AbortSignal));
 
-        now = 10 * 60 * 1000;
-        sleep.mockClear();
+        expect(sleep).toHaveBeenCalledWith(43, expect.any(AbortSignal));
+    });
+
+    it.each([
+        [5, 178],
+        [10, 285],
+        [30, 428]
+    ])('reacts to sustained unhealthy latency over %ds', async (durationSeconds, expectedDelayMs) => {
+        let now = 0;
+        const sleep = vi.fn(() => Promise.resolve());
+        const pacer = makePacer({ now: () => now, random: () => 0.5, sleep });
+
+        for (let second = 1; second <= durationSeconds; second++) {
+            now = second * 1000;
+            pacer.recordSuccess(1000);
+        }
         await pacer.wait(new AbortController().signal);
-        expect(sleep).not.toHaveBeenCalled();
+
+        expect(sleep).toHaveBeenCalledWith(expectedDelayMs, expect.any(AbortSignal));
+    });
+
+    it('recovers as healthy latency samples replace sustained pressure', async () => {
+        let now = 0;
+        const sleep = vi.fn(() => Promise.resolve());
+        const pacer = makePacer({ now: () => now, random: () => 0.5, sleep });
+
+        for (let second = 1; second <= 10; second++) {
+            now = second * 1000;
+            pacer.recordSuccess(1000);
+        }
+        for (let second = 11; second <= 20; second++) {
+            now = second * 1000;
+            pacer.recordSuccess(50);
+        }
+        await pacer.wait(new AbortController().signal);
+
+        expect(sleep).toHaveBeenCalledWith(105, expect.any(AbortSignal));
+    });
+
+    it('responds consistently over wall-clock time at different sample frequencies', async () => {
+        let slowNow = 0;
+        let fastNow = 0;
+        const slowSleep = vi.fn(() => Promise.resolve());
+        const fastSleep = vi.fn(() => Promise.resolve());
+        const slowPacer = makePacer({ now: () => slowNow, random: () => 0.5, sleep: slowSleep });
+        const fastPacer = makePacer({ now: () => fastNow, random: () => 0.5, sleep: fastSleep });
+
+        for (let sample = 1; sample <= 10; sample++) {
+            slowNow = sample * 1000;
+            slowPacer.recordSuccess(1000);
+        }
+        for (let sample = 1; sample <= 100; sample++) {
+            fastNow = sample * 100;
+            fastPacer.recordSuccess(1000);
+        }
+        await slowPacer.wait(new AbortController().signal);
+        await fastPacer.wait(new AbortController().signal);
+
+        expect(slowSleep).toHaveBeenCalledWith(285, expect.any(AbortSignal));
+        expect(fastSleep).toHaveBeenCalledWith(285, expect.any(AbortSignal));
+    });
+
+    it('isolates a transient spike to the jobs pod that observed it', async () => {
+        let now = 0;
+        const sleeps = Array.from({ length: 10 }, () => vi.fn(() => Promise.resolve()));
+        const pacers = sleeps.map((sleep) => makePacer({ now: () => now, random: () => 0.5, sleep }));
+
+        now = 1000;
+        const affectedPacer = pacers[0];
+        if (!affectedPacer) {
+            throw new Error('Expected an affected jobs pod');
+        }
+        affectedPacer.recordSuccess(1000);
+        await Promise.all(pacers.map(async (pacer) => await pacer.wait(new AbortController().signal)));
+
+        expect(sleeps[0]).toHaveBeenCalledWith(43, expect.any(AbortSignal));
+        expect(sleeps.slice(1).every((sleep) => sleep.mock.calls.length === 0)).toBe(true);
     });
 
     it('honors admission Retry-After even when it exceeds the adaptive maximum', async () => {
@@ -58,6 +123,20 @@ describe('LocalAdaptivePollPacer', () => {
         await pacer.wait(new AbortController().signal);
 
         expect(sleep).toHaveBeenCalledWith(1320, expect.any(AbortSignal));
+    });
+
+    it('does not replace latency pressure with admission congestion', async () => {
+        let now = 0;
+        const sleep = vi.fn(() => Promise.resolve());
+        const pacer = makePacer({ now: () => now, random: () => 1, sleep });
+
+        now = 1000;
+        pacer.recordSuccess(1000);
+        pacer.recordCongestion(100, 20);
+        now = 1101;
+        await pacer.wait(new AbortController().signal);
+
+        expect(sleep).toHaveBeenCalledWith(48, expect.any(AbortSignal));
     });
 
     it('honors admission Retry-After at the pre-dispatch gate', async () => {
@@ -98,15 +177,14 @@ describe('LocalAdaptivePollPacer', () => {
         const firstSleep = new Promise<void>((resolve) => {
             releaseFirstSleep = resolve;
         });
-        const sleep = vi.fn(async (delayMs: number) => {
-            now += delayMs;
+        const sleep = vi.fn(async (_delayMs: number) => {
             sleepCount += 1;
             if (sleepCount === 1) {
                 await firstSleep;
             }
         });
         const pacer = makePacer({ now: () => now, random: () => 0.5, sleep });
-        pacer.recordSuccess(200);
+        pacer.recordCongestion(500, 20);
 
         const waitPromise = pacer.wait(new AbortController().signal);
         await vi.waitFor(() => expect(sleep).toHaveBeenCalledOnce());
@@ -124,24 +202,23 @@ describe('LocalAdaptivePollPacer', () => {
         const sleeping = new Promise<void>((resolve) => {
             releaseSleep = resolve;
         });
-        const sleep = vi.fn(async (delayMs: number) => {
-            now += delayMs;
+        const sleep = vi.fn(async () => {
             await sleeping;
         });
         const pacer = makePacer({ now: () => now, random: () => 1, sleep });
-        pacer.recordFailure(20);
+        pacer.recordCongestion(100, 20);
 
         const waitPromise = pacer.wait(new AbortController().signal);
         await vi.waitFor(() => expect(sleep).toHaveBeenCalledOnce());
-        pacer.recordCongestion(100, 20);
-        now += 200;
+        pacer.recordCongestion(200, 20);
+        now = 300;
         releaseSleep();
         await waitPromise;
 
         expect(sleep).toHaveBeenCalledOnce();
     });
 
-    it('paces polling after generic orchestrator failures', async () => {
+    it('applies the configured fixed backoff after generic failures', async () => {
         const sleep = vi.fn(() => Promise.resolve());
         const pacer = makePacer({ now: () => 0, random: () => 1, sleep });
 
@@ -151,17 +228,40 @@ describe('LocalAdaptivePollPacer', () => {
         expect(sleep).toHaveBeenCalledWith(500, expect.any(AbortSignal));
     });
 
-    it('never exceeds the configured adaptive delay for latency pressure', async () => {
+    it('allows disabling generic failure backoff', async () => {
         const sleep = vi.fn(() => Promise.resolve());
-        const pacer = makePacer({ now: () => 0, random: () => 1, sleep });
+        const pacer = makePacer({ failureBackoffMs: 0, now: () => 0, random: () => 1, sleep });
 
+        pacer.recordFailure(20);
+        await pacer.wait(new AbortController().signal);
+
+        expect(sleep).not.toHaveBeenCalled();
+    });
+
+    it('uses the longer of admission and generic failure backoffs', async () => {
+        const sleep = vi.fn(() => Promise.resolve());
+        const pacer = makePacer({ now: () => 0, random: () => 0.5, sleep });
+
+        pacer.recordFailure(20);
+        pacer.recordCongestion(1200, 20);
+        await pacer.wait(new AbortController().signal);
+
+        expect(sleep).toHaveBeenCalledWith(1320, expect.any(AbortSignal));
+    });
+
+    it('never exceeds the configured adaptive delay for latency pressure', async () => {
+        let now = 0;
+        const sleep = vi.fn(() => Promise.resolve());
+        const pacer = makePacer({ now: () => now, random: () => 1, sleep });
+
+        now = 100_000;
         pacer.recordSuccess(10_000);
         await pacer.wait(new AbortController().signal);
 
         expect(sleep).toHaveBeenCalledWith(500, expect.any(AbortSignal));
     });
 
-    it('aborts an in-progress polling delay during shutdown', async () => {
+    it('aborts an in-progress failure backoff during shutdown', async () => {
         const pacer = makePacer({ random: () => 1 });
         pacer.recordFailure(20);
         const controller = new AbortController();
@@ -173,10 +273,12 @@ describe('LocalAdaptivePollPacer', () => {
     });
 
     it('does not apply latency pressure again at the pre-dispatch backoff gate', async () => {
+        let now = 0;
         const sleep = vi.fn(() => Promise.resolve());
-        const pacer = makePacer({ now: () => 0, random: () => 1, sleep });
-        pacer.recordFailure(20);
+        const pacer = makePacer({ now: () => now, random: () => 1, sleep });
 
+        now = 1000;
+        pacer.recordSuccess(1000);
         await pacer.waitForBackoff(new AbortController().signal, () => Promise.resolve());
 
         expect(sleep).not.toHaveBeenCalled();

--- a/packages/jobs/lib/webhook/dispatch-queue/adaptive-polling.unit.test.ts
+++ b/packages/jobs/lib/webhook/dispatch-queue/adaptive-polling.unit.test.ts
@@ -68,7 +68,7 @@ describe('LocalAdaptivePollPacer', () => {
         pacer.recordCongestion(1200, 20);
         await pacer.waitForBackoff(new AbortController().signal, prepareWait);
 
-        expect(prepareWait).toHaveBeenCalledWith(1320);
+        expect(prepareWait).toHaveBeenCalledWith(1320, expect.any(AbortSignal));
         expect(sleep).toHaveBeenCalledWith(1320, expect.any(AbortSignal));
         const prepareOrder = prepareWait.mock.invocationCallOrder[0];
         const sleepOrder = sleep.mock.invocationCallOrder[0];
@@ -180,5 +180,17 @@ describe('LocalAdaptivePollPacer', () => {
         await pacer.waitForBackoff(new AbortController().signal, () => Promise.resolve());
 
         expect(sleep).not.toHaveBeenCalled();
+    });
+
+    it('does not prepare a pre-dispatch wait after shutdown starts', async () => {
+        const prepareWait = vi.fn(() => Promise.resolve());
+        const pacer = makePacer({ now: () => 0, random: () => 1 });
+        const controller = new AbortController();
+        pacer.recordCongestion(1000, 20);
+        controller.abort();
+
+        await expect(pacer.waitForBackoff(controller.signal, prepareWait)).rejects.toMatchObject({ name: 'AbortError' });
+
+        expect(prepareWait).not.toHaveBeenCalled();
     });
 });

--- a/packages/jobs/lib/webhook/dispatch-queue/consumer.ts
+++ b/packages/jobs/lib/webhook/dispatch-queue/consumer.ts
@@ -113,6 +113,7 @@ export class DispatchQueueConsumer {
         while (!signal.aborted) {
             try {
                 await this.pollPacer?.wait(signal);
+                const receiveStartedAt = performance.now();
                 const result = await this.sqs.send(
                     new ReceiveMessageCommand({
                         QueueUrl: this.queueUrl,
@@ -128,7 +129,7 @@ export class DispatchQueueConsumer {
                 const messages = result.Messages ?? [];
                 if (messages.length === 0) continue;
 
-                const outcome = await this.processBatch(messages);
+                const outcome = await this.processBatch(messages, receiveStartedAt);
                 if (outcome.result === 'success') {
                     this.pollPacer?.recordSuccess(outcome.durationMs ?? 0);
                 } else if (outcome.result === 'congestion') {
@@ -144,7 +145,7 @@ export class DispatchQueueConsumer {
         }
     }
 
-    private async processBatch(messages: Message[]): Promise<BatchOutcome> {
+    private async processBatch(messages: Message[], receiveStartedAt: number): Promise<BatchOutcome> {
         const active = tracer.scope().active();
         const span = tracer.startSpan('jobs.webhook.dispatch_queue.process_batch', {
             ...(active ? { childOf: active } : {}),
@@ -189,8 +190,8 @@ export class DispatchQueueConsumer {
                     };
                 });
 
-                await this.pollPacer?.waitForBackoff(this.abortController.signal, async (delayMs) => {
-                    await this.extendVisibilityForBackoff(entries, delayMs);
+                await this.pollPacer?.waitForBackoff(this.abortController.signal, async (delayMs, signal) => {
+                    await this.extendVisibilityForBackoff(entries, delayMs, receiveStartedAt, signal);
                 });
                 const startedAt = performance.now();
                 const res = await this.orchestratorClient.executeWebhookBatch(propsList);
@@ -297,11 +298,15 @@ export class DispatchQueueConsumer {
         await Promise.all(group.map((entry) => this.tryDeleteMessage(entry.receiptHandle)));
     }
 
-    private async extendVisibilityForBackoff(entries: ParsedEntry[], delayMs: number): Promise<void> {
-        const visibilityTimeoutSeconds = this.visibilityTimeoutSeconds + Math.ceil(delayMs / 1000);
-        if (visibilityTimeoutSeconds > MAX_SQS_VISIBILITY_TIMEOUT_SECONDS) {
+    private async extendVisibilityForBackoff(entries: ParsedEntry[], delayMs: number, receiveStartedAt: number, signal: AbortSignal): Promise<void> {
+        signal.throwIfAborted();
+        const backoffSeconds = Math.ceil(delayMs / 1000);
+        const elapsedSeconds = Math.max(1, Math.ceil((performance.now() - receiveStartedAt) / 1000));
+        const maxVisibilityTimeoutSeconds = Math.max(0, MAX_SQS_VISIBILITY_TIMEOUT_SECONDS - elapsedSeconds);
+        if (backoffSeconds >= maxVisibilityTimeoutSeconds) {
             throw new Error('Webhook dispatch admission backoff exceeds the maximum SQS visibility timeout');
         }
+        const visibilityTimeoutSeconds = Math.min(this.visibilityTimeoutSeconds + backoffSeconds, maxVisibilityTimeoutSeconds);
 
         const result = await this.sqs.send(
             new ChangeMessageVisibilityBatchCommand({
@@ -311,10 +316,17 @@ export class DispatchQueueConsumer {
                     ReceiptHandle: entry.receiptHandle,
                     VisibilityTimeout: visibilityTimeoutSeconds
                 }))
-            })
+            }),
+            { abortSignal: signal }
         );
         if (result.Failed?.length) {
-            throw new Error('Failed to extend webhook dispatch message visibility before admission backoff');
+            const failures = result.Failed.slice(0, 10).map((failure) => ({
+                id: failure.Id,
+                code: failure.Code,
+                message: failure.Message?.slice(0, 500),
+                senderFault: failure.SenderFault
+            }));
+            throw new Error(`Failed to extend webhook dispatch message visibility before admission backoff: ${JSON.stringify(failures)}`);
         }
     }
 

--- a/packages/jobs/lib/webhook/dispatch-queue/consumer.ts
+++ b/packages/jobs/lib/webhook/dispatch-queue/consumer.ts
@@ -130,7 +130,7 @@ export class DispatchQueueConsumer {
                 if (outcome.result === 'success') {
                     this.pollPacer?.recordSuccess(outcome.durationMs ?? 0);
                 } else if (outcome.result === 'congestion') {
-                    this.pollPacer?.recordCongestion(outcome.retryAfterMs ?? 1000);
+                    this.pollPacer?.recordCongestion(outcome.retryAfterMs ?? 1000, outcome.durationMs ?? 0);
                 } else if (outcome.result === 'failure') {
                     this.pollPacer?.recordFailure(outcome.durationMs ?? 0);
                 }
@@ -187,6 +187,7 @@ export class DispatchQueueConsumer {
                     };
                 });
 
+                await this.pollPacer?.waitForBackoff(this.abortController.signal);
                 const startedAt = performance.now();
                 const res = await this.orchestratorClient.executeWebhookBatch(propsList);
                 const durationMs = performance.now() - startedAt;

--- a/packages/jobs/lib/webhook/dispatch-queue/consumer.ts
+++ b/packages/jobs/lib/webhook/dispatch-queue/consumer.ts
@@ -1,3 +1,5 @@
+import { performance } from 'node:perf_hooks';
+
 import { DeleteMessageCommand, ReceiveMessageCommand, SQSClient } from '@aws-sdk/client-sqs';
 import tracer from 'dd-trace';
 import * as z from 'zod';
@@ -8,6 +10,7 @@ import { Err, getLogger, metrics, Ok, report } from '@nangohq/utils';
 
 import { envs } from '../../env.js';
 
+import type { DispatchPollPacer } from './adaptive-polling.js';
 import type { Message } from '@aws-sdk/client-sqs';
 import type { ExecuteWebhookProps, OrchestratorClient } from '@nangohq/nango-orchestrator';
 import type { WebhookDispatchMessage } from '@nangohq/types';
@@ -44,7 +47,14 @@ export interface DispatchQueueConsumerProps {
     waitTimeSeconds: number;
     visibilityTimeoutSeconds: number;
     maxAgeMs: number;
+    pollPacer?: DispatchPollPacer;
     sqs?: SQSClient;
+}
+
+interface BatchOutcome {
+    result: 'success' | 'congestion' | 'failure' | 'noop';
+    durationMs?: number;
+    retryAfterMs?: number;
 }
 
 interface ParsedEntry {
@@ -62,6 +72,7 @@ export class DispatchQueueConsumer {
     private readonly waitTimeSeconds: number;
     private readonly visibilityTimeoutSeconds: number;
     private readonly maxAgeMs: number;
+    private readonly pollPacer: DispatchPollPacer | undefined;
     private readonly abortController = new AbortController();
     private loopPromises: Promise<void>[] = [];
 
@@ -74,6 +85,7 @@ export class DispatchQueueConsumer {
         this.waitTimeSeconds = props.waitTimeSeconds;
         this.visibilityTimeoutSeconds = props.visibilityTimeoutSeconds;
         this.maxAgeMs = props.maxAgeMs;
+        this.pollPacer = props.pollPacer;
         this.sqs = props.sqs ?? new SQSClient(envs.AWS_REGION ? { region: envs.AWS_REGION } : {});
     }
 
@@ -98,6 +110,7 @@ export class DispatchQueueConsumer {
         const signal = this.abortController.signal;
         while (!signal.aborted) {
             try {
+                await this.pollPacer?.wait(signal);
                 const result = await this.sqs.send(
                     new ReceiveMessageCommand({
                         QueueUrl: this.queueUrl,
@@ -113,7 +126,14 @@ export class DispatchQueueConsumer {
                 const messages = result.Messages ?? [];
                 if (messages.length === 0) continue;
 
-                await this.processBatch(messages);
+                const outcome = await this.processBatch(messages);
+                if (outcome.result === 'success') {
+                    this.pollPacer?.recordSuccess(outcome.durationMs ?? 0);
+                } else if (outcome.result === 'congestion') {
+                    this.pollPacer?.recordCongestion(outcome.retryAfterMs ?? 1000);
+                } else if (outcome.result === 'failure') {
+                    this.pollPacer?.recordFailure(outcome.durationMs ?? 0);
+                }
             } catch (err) {
                 if (err instanceof Error && err.name === 'AbortError') break;
                 report(new Error('webhook dispatch consumer receive failed', { cause: err }));
@@ -122,7 +142,7 @@ export class DispatchQueueConsumer {
         }
     }
 
-    private async processBatch(messages: Message[]): Promise<void> {
+    private async processBatch(messages: Message[]): Promise<BatchOutcome> {
         const active = tracer.scope().active();
         const span = tracer.startSpan('jobs.webhook.dispatch_queue.process_batch', {
             ...(active ? { childOf: active } : {}),
@@ -133,7 +153,7 @@ export class DispatchQueueConsumer {
             try {
                 const entries = await this.filterMessages(messages);
                 if (entries.length === 0) {
-                    return;
+                    return { result: 'noop' };
                 }
 
                 // SQS might deliver the same message multiple times, so we guard against duplicates
@@ -167,7 +187,9 @@ export class DispatchQueueConsumer {
                     };
                 });
 
+                const startedAt = performance.now();
                 const res = await this.orchestratorClient.executeWebhookBatch(propsList);
+                const durationMs = performance.now() - startedAt;
                 if (res.isErr()) {
                     span.setTag('error', true);
                     span.setTag('error.type', res.error.name);
@@ -177,11 +199,16 @@ export class DispatchQueueConsumer {
                         span.setTag('error.details', responsePayload);
                     }
                     metrics.increment(metrics.Types.WEBHOOK_DISPATCH_CONSUME, entries.length, { result: 'failure' });
+                    if (res.error.name === 'webhook_admission_exceeded') {
+                        const retryAfterMs = getRetryAfterMs(res.error.payload);
+                        return { result: 'congestion', durationMs, ...(retryAfterMs !== undefined ? { retryAfterMs } : {}) };
+                    }
                     report(new Error('webhook dispatch consumer batch failed', { cause: res.error }));
-                    return;
+                    return { result: 'failure', durationMs };
                 }
 
                 await this.handleBatchResult(groupedEntries, res.value);
+                return { result: 'success', durationMs };
             } finally {
                 span.finish();
             }
@@ -299,4 +326,12 @@ function getClientErrorResponsePayload(err: { payload?: unknown }): string | nul
     }
 
     return JSON.stringify(responsePayload);
+}
+
+function getRetryAfterMs(payload: unknown): number | undefined {
+    if (!payload || typeof payload !== 'object' || !('retryAfterMs' in payload)) {
+        return undefined;
+    }
+    const retryAfterMs = payload.retryAfterMs;
+    return typeof retryAfterMs === 'number' && Number.isFinite(retryAfterMs) && retryAfterMs >= 0 ? retryAfterMs : undefined;
 }

--- a/packages/jobs/lib/webhook/dispatch-queue/consumer.ts
+++ b/packages/jobs/lib/webhook/dispatch-queue/consumer.ts
@@ -1,6 +1,6 @@
 import { performance } from 'node:perf_hooks';
 
-import { DeleteMessageCommand, ReceiveMessageCommand, SQSClient } from '@aws-sdk/client-sqs';
+import { ChangeMessageVisibilityBatchCommand, DeleteMessageCommand, ReceiveMessageCommand, SQSClient } from '@aws-sdk/client-sqs';
 import tracer from 'dd-trace';
 import * as z from 'zod';
 
@@ -17,6 +17,7 @@ import type { WebhookDispatchMessage } from '@nangohq/types';
 import type { Result } from '@nangohq/utils';
 
 const logger = getLogger('jobs.webhook.dispatch-queue.consumer');
+const MAX_SQS_VISIBILITY_TIMEOUT_SECONDS = 12 * 60 * 60;
 
 const messageSchema: z.ZodType<WebhookDispatchMessage> = z.object({
     version: z.literal(1),
@@ -59,6 +60,7 @@ interface BatchOutcome {
 
 interface ParsedEntry {
     msg: Message;
+    receiptHandle: string;
     parsed: WebhookDispatchMessage;
 }
 
@@ -187,7 +189,9 @@ export class DispatchQueueConsumer {
                     };
                 });
 
-                await this.pollPacer?.waitForBackoff(this.abortController.signal);
+                await this.pollPacer?.waitForBackoff(this.abortController.signal, async (delayMs) => {
+                    await this.extendVisibilityForBackoff(entries, delayMs);
+                });
                 const startedAt = performance.now();
                 const res = await this.orchestratorClient.executeWebhookBatch(propsList);
                 const durationMs = performance.now() - startedAt;
@@ -245,7 +249,7 @@ export class DispatchQueueConsumer {
                 }
             }
 
-            entries.push({ msg, parsed: message });
+            entries.push({ msg, receiptHandle: msg.ReceiptHandle, parsed: message });
         }
         return entries;
     }
@@ -290,7 +294,28 @@ export class DispatchQueueConsumer {
     }
 
     private async deleteGroup(group: ParsedEntry[]): Promise<void> {
-        await Promise.all(group.map((entry) => this.tryDeleteMessage(entry.msg.ReceiptHandle!)));
+        await Promise.all(group.map((entry) => this.tryDeleteMessage(entry.receiptHandle)));
+    }
+
+    private async extendVisibilityForBackoff(entries: ParsedEntry[], delayMs: number): Promise<void> {
+        const visibilityTimeoutSeconds = this.visibilityTimeoutSeconds + Math.ceil(delayMs / 1000);
+        if (visibilityTimeoutSeconds > MAX_SQS_VISIBILITY_TIMEOUT_SECONDS) {
+            throw new Error('Webhook dispatch admission backoff exceeds the maximum SQS visibility timeout');
+        }
+
+        const result = await this.sqs.send(
+            new ChangeMessageVisibilityBatchCommand({
+                QueueUrl: this.queueUrl,
+                Entries: entries.map((entry, index) => ({
+                    Id: String(index),
+                    ReceiptHandle: entry.receiptHandle,
+                    VisibilityTimeout: visibilityTimeoutSeconds
+                }))
+            })
+        );
+        if (result.Failed?.length) {
+            throw new Error('Failed to extend webhook dispatch message visibility before admission backoff');
+        }
     }
 
     private parseMessage(body: string): Result<WebhookDispatchMessage> {

--- a/packages/jobs/lib/webhook/dispatch-queue/consumer.ts
+++ b/packages/jobs/lib/webhook/dispatch-queue/consumer.ts
@@ -113,7 +113,6 @@ export class DispatchQueueConsumer {
         while (!signal.aborted) {
             try {
                 await this.pollPacer?.wait(signal);
-                const receiveStartedAt = performance.now();
                 const result = await this.sqs.send(
                     new ReceiveMessageCommand({
                         QueueUrl: this.queueUrl,
@@ -125,11 +124,12 @@ export class DispatchQueueConsumer {
                     }),
                     { abortSignal: signal }
                 );
+                const receivedAt = performance.now();
 
                 const messages = result.Messages ?? [];
                 if (messages.length === 0) continue;
 
-                const outcome = await this.processBatch(messages, receiveStartedAt);
+                const outcome = await this.processBatch(messages, receivedAt);
                 if (outcome.result === 'success') {
                     this.pollPacer?.recordSuccess(outcome.durationMs ?? 0);
                 } else if (outcome.result === 'congestion') {
@@ -145,7 +145,7 @@ export class DispatchQueueConsumer {
         }
     }
 
-    private async processBatch(messages: Message[], receiveStartedAt: number): Promise<BatchOutcome> {
+    private async processBatch(messages: Message[], receivedAt: number): Promise<BatchOutcome> {
         const active = tracer.scope().active();
         const span = tracer.startSpan('jobs.webhook.dispatch_queue.process_batch', {
             ...(active ? { childOf: active } : {}),
@@ -191,7 +191,7 @@ export class DispatchQueueConsumer {
                 });
 
                 await this.pollPacer?.waitForBackoff(this.abortController.signal, async (delayMs, signal) => {
-                    await this.extendVisibilityForBackoff(entries, delayMs, receiveStartedAt, signal);
+                    await this.extendVisibilityForBackoff(entries, delayMs, receivedAt, signal, this.visibilityTimeoutSeconds);
                 });
                 const startedAt = performance.now();
                 const res = await this.orchestratorClient.executeWebhookBatch(propsList);
@@ -206,8 +206,16 @@ export class DispatchQueueConsumer {
                     }
                     metrics.increment(metrics.Types.WEBHOOK_DISPATCH_CONSUME, entries.length, { result: 'failure' });
                     if (res.error.status === 529) {
-                        const retryAfterMs = getRetryAfterMs(res.error.payload);
-                        return { result: 'congestion', durationMs, ...(retryAfterMs !== undefined ? { retryAfterMs } : {}) };
+                        const retryAfterMs = getRetryAfterMs(res.error.payload) ?? 1000;
+                        try {
+                            await this.extendVisibilityForBackoff(entries, retryAfterMs, receivedAt, this.abortController.signal, 0);
+                        } catch (err) {
+                            if (err instanceof Error && err.name === 'AbortError') {
+                                throw err;
+                            }
+                            report(new Error('Failed to extend rejected webhook dispatch message visibility', { cause: err }));
+                        }
+                        return { result: 'congestion', durationMs, retryAfterMs };
                     }
                     report(new Error('webhook dispatch consumer batch failed', { cause: res.error }));
                     return { result: 'failure', durationMs };
@@ -298,15 +306,24 @@ export class DispatchQueueConsumer {
         await Promise.all(group.map((entry) => this.tryDeleteMessage(entry.receiptHandle)));
     }
 
-    private async extendVisibilityForBackoff(entries: ParsedEntry[], delayMs: number, receiveStartedAt: number, signal: AbortSignal): Promise<void> {
+    private async extendVisibilityForBackoff(
+        entries: ParsedEntry[],
+        delayMs: number,
+        receivedAt: number,
+        signal: AbortSignal,
+        processingWindowSeconds: number
+    ): Promise<void> {
         signal.throwIfAborted();
         const backoffSeconds = Math.ceil(delayMs / 1000);
-        const elapsedSeconds = Math.max(1, Math.ceil((performance.now() - receiveStartedAt) / 1000));
+        const elapsedSeconds = Math.max(1, Math.ceil((performance.now() - receivedAt) / 1000));
         const maxVisibilityTimeoutSeconds = Math.max(0, MAX_SQS_VISIBILITY_TIMEOUT_SECONDS - elapsedSeconds);
         if (backoffSeconds >= maxVisibilityTimeoutSeconds) {
             throw new Error('Webhook dispatch admission backoff exceeds the maximum SQS visibility timeout');
         }
-        const visibilityTimeoutSeconds = Math.min(this.visibilityTimeoutSeconds + backoffSeconds, maxVisibilityTimeoutSeconds);
+        const visibilityTimeoutSeconds = Math.min(
+            Math.max(this.visibilityTimeoutSeconds, backoffSeconds + processingWindowSeconds),
+            maxVisibilityTimeoutSeconds
+        );
 
         const result = await this.sqs.send(
             new ChangeMessageVisibilityBatchCommand({

--- a/packages/jobs/lib/webhook/dispatch-queue/consumer.ts
+++ b/packages/jobs/lib/webhook/dispatch-queue/consumer.ts
@@ -205,7 +205,7 @@ export class DispatchQueueConsumer {
                         span.setTag('error.details', responsePayload);
                     }
                     metrics.increment(metrics.Types.WEBHOOK_DISPATCH_CONSUME, entries.length, { result: 'failure' });
-                    if (res.error.name === 'webhook_admission_exceeded') {
+                    if (res.error.status === 529) {
                         const retryAfterMs = getRetryAfterMs(res.error.payload);
                         return { result: 'congestion', durationMs, ...(retryAfterMs !== undefined ? { retryAfterMs } : {}) };
                     }

--- a/packages/jobs/lib/webhook/dispatch-queue/consumer.unit.test.ts
+++ b/packages/jobs/lib/webhook/dispatch-queue/consumer.unit.test.ts
@@ -5,6 +5,7 @@ import { Err, Ok } from '@nangohq/utils';
 
 import { DispatchQueueConsumer } from './consumer.js';
 
+import type { DispatchPollPacer } from './adaptive-polling.js';
 import type { SQSClient } from '@aws-sdk/client-sqs';
 import type { OrchestratorClient } from '@nangohq/nango-orchestrator';
 import type { WebhookDispatchMessage } from '@nangohq/types';
@@ -68,6 +69,7 @@ function makeHarness(
         consumerConcurrency?: number;
         maxAgeMs?: number;
         sqsSend?: Mock<SqsSendFn>;
+        pollPacer?: DispatchPollPacer;
     } = {}
 ): Harness {
     const messages = opts.messages ?? [];
@@ -111,7 +113,8 @@ function makeHarness(
         maxMessages: 10,
         waitTimeSeconds: 0,
         visibilityTimeoutSeconds: 30,
-        maxAgeMs: opts.maxAgeMs ?? 0
+        maxAgeMs: opts.maxAgeMs ?? 0,
+        ...(opts.pollPacer ? { pollPacer: opts.pollPacer } : {})
     });
 
     return { consumer, sqsSend, sqsDestroy, orchestratorExecuteWebhookBatch };
@@ -224,6 +227,57 @@ describe('DispatchQueueConsumer', () => {
             expect(h.orchestratorExecuteWebhookBatch).toHaveBeenCalledTimes(1);
         });
 
+        expect(getDeleteCalls(h)).toHaveLength(0);
+    });
+
+    it('waits for the shared pacer before receiving messages', async () => {
+        const gate = deferred<void>();
+        const wait = vi.fn(() => gate.promise);
+        const pollPacer: DispatchPollPacer = { wait, recordSuccess: vi.fn(), recordCongestion: vi.fn(), recordFailure: vi.fn() };
+        const h = makeHarness({ pollPacer });
+
+        h.consumer.start();
+        await vi.waitFor(() => expect(wait).toHaveBeenCalledOnce());
+        expect(h.sqsSend).not.toHaveBeenCalled();
+
+        gate.resolve();
+        await vi.waitFor(() => expect(h.sqsSend).toHaveBeenCalled());
+        await h.consumer.stop();
+    });
+
+    it('records successful orchestrator latency with the pod-local pacer', async () => {
+        const recordSuccess = vi.fn();
+        const pollPacer: DispatchPollPacer = { wait: vi.fn(), recordSuccess, recordCongestion: vi.fn(), recordFailure: vi.fn() };
+        const h = makeHarness({ messages: [buildMessage()], pollPacer });
+
+        await runOnce(h, () => expect(recordSuccess).toHaveBeenCalledOnce());
+
+        expect(recordSuccess).toHaveBeenCalledWith(expect.any(Number));
+        expect(getDeleteCalls(h)).toHaveLength(1);
+    });
+
+    it('backs off the pod without deleting messages when webhook admission is exhausted', async () => {
+        const recordCongestion = vi.fn();
+        const pollPacer: DispatchPollPacer = { wait: vi.fn(), recordSuccess: vi.fn(), recordCongestion, recordFailure: vi.fn() };
+        const h = makeHarness({ messages: [buildMessage()], pollPacer });
+        h.orchestratorExecuteWebhookBatch.mockResolvedValueOnce(
+            Err({ name: 'webhook_admission_exceeded', message: 'busy', payload: { reason: 'concurrency', retryAfterMs: 2000 } })
+        );
+
+        await runOnce(h, () => expect(recordCongestion).toHaveBeenCalledWith(2000));
+
+        expect(getDeleteCalls(h)).toHaveLength(0);
+    });
+
+    it('paces the next poll after a generic batch failure', async () => {
+        const recordFailure = vi.fn();
+        const pollPacer: DispatchPollPacer = { wait: vi.fn(), recordSuccess: vi.fn(), recordCongestion: vi.fn(), recordFailure };
+        const h = makeHarness({ messages: [buildMessage()], pollPacer });
+        h.orchestratorExecuteWebhookBatch.mockResolvedValueOnce(Err({ name: 'server_error', message: 'boom', payload: null }));
+
+        await runOnce(h, () => expect(recordFailure).toHaveBeenCalledOnce());
+
+        expect(recordFailure).toHaveBeenCalledWith(expect.any(Number));
         expect(getDeleteCalls(h)).toHaveLength(0);
     });
 

--- a/packages/jobs/lib/webhook/dispatch-queue/consumer.unit.test.ts
+++ b/packages/jobs/lib/webhook/dispatch-queue/consumer.unit.test.ts
@@ -287,7 +287,7 @@ describe('DispatchQueueConsumer', () => {
         };
         const h = makeHarness({ messages: [buildMessage()], pollPacer });
         h.orchestratorExecuteWebhookBatch.mockResolvedValueOnce(
-            Err({ name: 'webhook_admission_exceeded', message: 'busy', payload: { reason: 'concurrency', retryAfterMs: 2000 } })
+            Err({ name: 'fetch_failed', status: 529, message: 'busy', payload: { reason: 'concurrency', retryAfterMs: 2000 } })
         );
 
         await runOnce(h, () => expect(recordCongestion).toHaveBeenCalledWith(2000, expect.any(Number)));

--- a/packages/jobs/lib/webhook/dispatch-queue/consumer.unit.test.ts
+++ b/packages/jobs/lib/webhook/dispatch-queue/consumer.unit.test.ts
@@ -1,4 +1,4 @@
-import { DeleteMessageCommand, ReceiveMessageCommand } from '@aws-sdk/client-sqs';
+import { ChangeMessageVisibilityBatchCommand, DeleteMessageCommand, ReceiveMessageCommand } from '@aws-sdk/client-sqs';
 import { beforeEach, describe, expect, it, vi } from 'vitest';
 
 import { Err, Ok } from '@nangohq/utils';
@@ -68,6 +68,7 @@ function makeHarness(
         badBody?: string;
         consumerConcurrency?: number;
         maxAgeMs?: number;
+        visibilityTimeoutSeconds?: number;
         sqsSend?: Mock<SqsSendFn>;
         pollPacer?: DispatchPollPacer;
     } = {}
@@ -92,6 +93,9 @@ function makeHarness(
             if (command instanceof DeleteMessageCommand) {
                 return {};
             }
+            if (command instanceof ChangeMessageVisibilityBatchCommand) {
+                return { Successful: (command.input.Entries ?? []).map((entry) => ({ Id: entry.Id })), Failed: [] };
+            }
             throw new Error(`unexpected command ${String(command)}`);
         });
 
@@ -112,7 +116,7 @@ function makeHarness(
         consumerConcurrency: opts.consumerConcurrency ?? 1,
         maxMessages: 10,
         waitTimeSeconds: 0,
-        visibilityTimeoutSeconds: 30,
+        visibilityTimeoutSeconds: opts.visibilityTimeoutSeconds ?? 30,
         maxAgeMs: opts.maxAgeMs ?? 0,
         ...(opts.pollPacer ? { pollPacer: opts.pollPacer } : {})
     });
@@ -122,6 +126,10 @@ function makeHarness(
 
 function getDeleteCalls(h: Harness) {
     return h.sqsSend.mock.calls.filter((c) => c[0] instanceof DeleteMessageCommand);
+}
+
+function getChangeVisibilityCalls(h: Harness) {
+    return h.sqsSend.mock.calls.filter((c) => c[0] instanceof ChangeMessageVisibilityBatchCommand);
 }
 
 async function runOnce(h: Harness, waitFor: () => void | Promise<void>): Promise<void> {
@@ -324,6 +332,46 @@ describe('DispatchQueueConsumer', () => {
         gate.resolve();
         await vi.waitFor(() => expect(h.orchestratorExecuteWebhookBatch).toHaveBeenCalledOnce());
         await h.consumer.stop();
+    });
+
+    it('extends message visibility to cover admission backoff and the configured processing window', async () => {
+        const waitForBackoff = vi.fn(async (_signal: AbortSignal, prepareWait: (delayMs: number) => Promise<void>) => {
+            await prepareWait(2500);
+        });
+        const pollPacer: DispatchPollPacer = {
+            wait: vi.fn(),
+            waitForBackoff,
+            recordSuccess: vi.fn(),
+            recordCongestion: vi.fn(),
+            recordFailure: vi.fn()
+        };
+        const h = makeHarness({
+            messages: [buildMessage({ taskName: 'webhook:1' }), buildMessage({ taskName: 'webhook:2' })],
+            visibilityTimeoutSeconds: 30,
+            pollPacer
+        });
+
+        await runOnce(h, () => expect(h.orchestratorExecuteWebhookBatch).toHaveBeenCalledOnce());
+
+        const visibilityCalls = getChangeVisibilityCalls(h);
+        expect(visibilityCalls).toHaveLength(1);
+        const command = visibilityCalls[0]?.[0];
+        if (!(command instanceof ChangeMessageVisibilityBatchCommand)) {
+            throw new Error('Expected a visibility batch command');
+        }
+        expect(command.input).toEqual({
+            QueueUrl: 'http://queue',
+            Entries: [
+                { Id: '0', ReceiptHandle: 'rh-0', VisibilityTimeout: 33 },
+                { Id: '1', ReceiptHandle: 'rh-1', VisibilityTimeout: 33 }
+            ]
+        });
+        const visibilityOrder = h.sqsSend.mock.invocationCallOrder[1];
+        const dispatchOrder = h.orchestratorExecuteWebhookBatch.mock.invocationCallOrder[0];
+        if (visibilityOrder === undefined || dispatchOrder === undefined) {
+            throw new Error('Expected visibility extension and orchestrator dispatch to be called');
+        }
+        expect(visibilityOrder).toBeLessThan(dispatchOrder);
     });
 
     it('deletes a poison-pill message without calling orchestrator', async () => {

--- a/packages/jobs/lib/webhook/dispatch-queue/consumer.unit.test.ts
+++ b/packages/jobs/lib/webhook/dispatch-queue/consumer.unit.test.ts
@@ -233,7 +233,13 @@ describe('DispatchQueueConsumer', () => {
     it('waits for the shared pacer before receiving messages', async () => {
         const gate = deferred<void>();
         const wait = vi.fn(() => gate.promise);
-        const pollPacer: DispatchPollPacer = { wait, recordSuccess: vi.fn(), recordCongestion: vi.fn(), recordFailure: vi.fn() };
+        const pollPacer: DispatchPollPacer = {
+            wait,
+            waitForBackoff: vi.fn(),
+            recordSuccess: vi.fn(),
+            recordCongestion: vi.fn(),
+            recordFailure: vi.fn()
+        };
         const h = makeHarness({ pollPacer });
 
         h.consumer.start();
@@ -247,7 +253,13 @@ describe('DispatchQueueConsumer', () => {
 
     it('records successful orchestrator latency with the pod-local pacer', async () => {
         const recordSuccess = vi.fn();
-        const pollPacer: DispatchPollPacer = { wait: vi.fn(), recordSuccess, recordCongestion: vi.fn(), recordFailure: vi.fn() };
+        const pollPacer: DispatchPollPacer = {
+            wait: vi.fn(),
+            waitForBackoff: vi.fn(),
+            recordSuccess,
+            recordCongestion: vi.fn(),
+            recordFailure: vi.fn()
+        };
         const h = makeHarness({ messages: [buildMessage()], pollPacer });
 
         await runOnce(h, () => expect(recordSuccess).toHaveBeenCalledOnce());
@@ -258,20 +270,32 @@ describe('DispatchQueueConsumer', () => {
 
     it('backs off the pod without deleting messages when webhook admission is exhausted', async () => {
         const recordCongestion = vi.fn();
-        const pollPacer: DispatchPollPacer = { wait: vi.fn(), recordSuccess: vi.fn(), recordCongestion, recordFailure: vi.fn() };
+        const pollPacer: DispatchPollPacer = {
+            wait: vi.fn(),
+            waitForBackoff: vi.fn(),
+            recordSuccess: vi.fn(),
+            recordCongestion,
+            recordFailure: vi.fn()
+        };
         const h = makeHarness({ messages: [buildMessage()], pollPacer });
         h.orchestratorExecuteWebhookBatch.mockResolvedValueOnce(
             Err({ name: 'webhook_admission_exceeded', message: 'busy', payload: { reason: 'concurrency', retryAfterMs: 2000 } })
         );
 
-        await runOnce(h, () => expect(recordCongestion).toHaveBeenCalledWith(2000));
+        await runOnce(h, () => expect(recordCongestion).toHaveBeenCalledWith(2000, expect.any(Number)));
 
         expect(getDeleteCalls(h)).toHaveLength(0);
     });
 
     it('paces the next poll after a generic batch failure', async () => {
         const recordFailure = vi.fn();
-        const pollPacer: DispatchPollPacer = { wait: vi.fn(), recordSuccess: vi.fn(), recordCongestion: vi.fn(), recordFailure };
+        const pollPacer: DispatchPollPacer = {
+            wait: vi.fn(),
+            waitForBackoff: vi.fn(),
+            recordSuccess: vi.fn(),
+            recordCongestion: vi.fn(),
+            recordFailure
+        };
         const h = makeHarness({ messages: [buildMessage()], pollPacer });
         h.orchestratorExecuteWebhookBatch.mockResolvedValueOnce(Err({ name: 'server_error', message: 'boom', payload: null }));
 
@@ -279,6 +303,27 @@ describe('DispatchQueueConsumer', () => {
 
         expect(recordFailure).toHaveBeenCalledWith(expect.any(Number));
         expect(getDeleteCalls(h)).toHaveLength(0);
+    });
+
+    it('rechecks pod-wide admission backoff after receiving and before dispatching', async () => {
+        const gate = deferred<void>();
+        const waitForBackoff = vi.fn(() => gate.promise);
+        const pollPacer: DispatchPollPacer = {
+            wait: vi.fn(),
+            waitForBackoff,
+            recordSuccess: vi.fn(),
+            recordCongestion: vi.fn(),
+            recordFailure: vi.fn()
+        };
+        const h = makeHarness({ messages: [buildMessage()], pollPacer });
+
+        h.consumer.start();
+        await vi.waitFor(() => expect(waitForBackoff).toHaveBeenCalledOnce());
+        expect(h.orchestratorExecuteWebhookBatch).not.toHaveBeenCalled();
+
+        gate.resolve();
+        await vi.waitFor(() => expect(h.orchestratorExecuteWebhookBatch).toHaveBeenCalledOnce());
+        await h.consumer.stop();
     });
 
     it('deletes a poison-pill message without calling orchestrator', async () => {

--- a/packages/jobs/lib/webhook/dispatch-queue/consumer.unit.test.ts
+++ b/packages/jobs/lib/webhook/dispatch-queue/consumer.unit.test.ts
@@ -1,3 +1,5 @@
+import { performance } from 'node:perf_hooks';
+
 import { ChangeMessageVisibilityBatchCommand, DeleteMessageCommand, ReceiveMessageCommand } from '@aws-sdk/client-sqs';
 import { beforeEach, describe, expect, it, vi } from 'vitest';
 
@@ -69,6 +71,7 @@ function makeHarness(
         consumerConcurrency?: number;
         maxAgeMs?: number;
         visibilityTimeoutSeconds?: number;
+        onReceive?: () => void;
         sqsSend?: Mock<SqsSendFn>;
         pollPacer?: DispatchPollPacer;
     } = {}
@@ -87,6 +90,7 @@ function makeHarness(
         vi.fn<SqsSendFn>(async (command: unknown) => {
             await new Promise((resolve) => setImmediate(resolve));
             if (command instanceof ReceiveMessageCommand) {
+                opts.onReceive?.();
                 const messages = bodyQueue.splice(0, bodyQueue.length);
                 return { Messages: messages };
             }
@@ -287,12 +291,17 @@ describe('DispatchQueueConsumer', () => {
         };
         const h = makeHarness({ messages: [buildMessage()], pollPacer });
         h.orchestratorExecuteWebhookBatch.mockResolvedValueOnce(
-            Err({ name: 'fetch_failed', status: 529, message: 'busy', payload: { reason: 'concurrency', retryAfterMs: 2000 } })
+            Err({ name: 'fetch_failed', status: 529, message: 'busy', payload: { reason: 'concurrency', retryAfterMs: 60_000 } })
         );
 
-        await runOnce(h, () => expect(recordCongestion).toHaveBeenCalledWith(2000, expect.any(Number)));
+        await runOnce(h, () => expect(recordCongestion).toHaveBeenCalledWith(60_000, expect.any(Number)));
 
         expect(getDeleteCalls(h)).toHaveLength(0);
+        const command = getChangeVisibilityCalls(h)[0]?.[0];
+        if (!(command instanceof ChangeMessageVisibilityBatchCommand)) {
+            throw new Error('Expected a visibility batch command');
+        }
+        expect(command.input.Entries).toEqual([{ Id: '0', ReceiptHandle: 'rh-0', VisibilityTimeout: 60 }]);
     });
 
     it('paces the next poll after a generic batch failure', async () => {
@@ -376,6 +385,8 @@ describe('DispatchQueueConsumer', () => {
     });
 
     it('clamps visibility extension to the remaining SQS maximum', async () => {
+        let now = 0;
+        vi.spyOn(performance, 'now').mockImplementation(() => now);
         const waitForBackoff = vi.fn(async (signal: AbortSignal, prepareWait: (delayMs: number, signal: AbortSignal) => Promise<void>) => {
             await prepareWait(2500, signal);
         });
@@ -386,7 +397,14 @@ describe('DispatchQueueConsumer', () => {
             recordCongestion: vi.fn(),
             recordFailure: vi.fn()
         };
-        const h = makeHarness({ messages: [buildMessage()], visibilityTimeoutSeconds: 43_200, pollPacer });
+        const h = makeHarness({
+            messages: [buildMessage()],
+            visibilityTimeoutSeconds: 43_200,
+            onReceive: () => {
+                now = 20_000;
+            },
+            pollPacer
+        });
 
         await runOnce(h, () => expect(h.orchestratorExecuteWebhookBatch).toHaveBeenCalledOnce());
 

--- a/packages/jobs/lib/webhook/dispatch-queue/consumer.unit.test.ts
+++ b/packages/jobs/lib/webhook/dispatch-queue/consumer.unit.test.ts
@@ -51,7 +51,7 @@ function deferred<T>() {
     return { promise, resolve, reject };
 }
 
-type SqsSendFn = (command: unknown) => Promise<unknown>;
+type SqsSendFn = (command: unknown, options?: { abortSignal?: AbortSignal }) => Promise<unknown>;
 type SqsDestroyFn = () => void;
 type OrchestratorExecuteWebhookBatchFn = (props: unknown[]) => Promise<unknown>;
 
@@ -335,8 +335,8 @@ describe('DispatchQueueConsumer', () => {
     });
 
     it('extends message visibility to cover admission backoff and the configured processing window', async () => {
-        const waitForBackoff = vi.fn(async (_signal: AbortSignal, prepareWait: (delayMs: number) => Promise<void>) => {
-            await prepareWait(2500);
+        const waitForBackoff = vi.fn(async (signal: AbortSignal, prepareWait: (delayMs: number, signal: AbortSignal) => Promise<void>) => {
+            await prepareWait(2500, signal);
         });
         const pollPacer: DispatchPollPacer = {
             wait: vi.fn(),
@@ -366,12 +366,35 @@ describe('DispatchQueueConsumer', () => {
                 { Id: '1', ReceiptHandle: 'rh-1', VisibilityTimeout: 33 }
             ]
         });
+        expect(visibilityCalls[0]?.[1]?.abortSignal).toBeInstanceOf(AbortSignal);
         const visibilityOrder = h.sqsSend.mock.invocationCallOrder[1];
         const dispatchOrder = h.orchestratorExecuteWebhookBatch.mock.invocationCallOrder[0];
         if (visibilityOrder === undefined || dispatchOrder === undefined) {
             throw new Error('Expected visibility extension and orchestrator dispatch to be called');
         }
         expect(visibilityOrder).toBeLessThan(dispatchOrder);
+    });
+
+    it('clamps visibility extension to the remaining SQS maximum', async () => {
+        const waitForBackoff = vi.fn(async (signal: AbortSignal, prepareWait: (delayMs: number, signal: AbortSignal) => Promise<void>) => {
+            await prepareWait(2500, signal);
+        });
+        const pollPacer: DispatchPollPacer = {
+            wait: vi.fn(),
+            waitForBackoff,
+            recordSuccess: vi.fn(),
+            recordCongestion: vi.fn(),
+            recordFailure: vi.fn()
+        };
+        const h = makeHarness({ messages: [buildMessage()], visibilityTimeoutSeconds: 43_200, pollPacer });
+
+        await runOnce(h, () => expect(h.orchestratorExecuteWebhookBatch).toHaveBeenCalledOnce());
+
+        const command = getChangeVisibilityCalls(h)[0]?.[0];
+        if (!(command instanceof ChangeMessageVisibilityBatchCommand)) {
+            throw new Error('Expected a visibility batch command');
+        }
+        expect(command.input.Entries?.[0]?.VisibilityTimeout).toBe(43_199);
     });
 
     it('deletes a poison-pill message without calling orchestrator', async () => {

--- a/packages/orchestrator/lib/clients/client.ts
+++ b/packages/orchestrator/lib/clients/client.ts
@@ -344,11 +344,8 @@ export class OrchestratorClient {
         });
 
         const res = await this.routeFetch(postImmediateBatchRoute, {
-            retryConfig: {
-                maxAttempts: 3,
-                delayMs: 50,
-                retryIf: (res) => 'error' in res && getWebhookAdmissionError(getResponseStatus(res.error), res.error.payload) === null
-            }
+            timeoutMs: 10_000,
+            retryConfig: { maxAttempts: 1, delayMs: 0 }
         })({ body: { tasks: entries } });
 
         if ('error' in res) {

--- a/packages/orchestrator/lib/clients/client.unit.test.ts
+++ b/packages/orchestrator/lib/clients/client.unit.test.ts
@@ -210,35 +210,6 @@ describe('OrchestratorClient executeWebhookBatch', () => {
         expect(fetchMock).toHaveBeenCalledTimes(1);
     });
 
-    it('returns explicit webhook admission feedback', async () => {
-        const fetchMock = vi.fn().mockResolvedValue(
-            new Response(
-                JSON.stringify({
-                    error: {
-                        code: 'webhook_admission_exceeded',
-                        message: 'busy',
-                        payload: { acquired: false, reason: 'concurrency', retryAfterMs: 1200 }
-                    }
-                }),
-                { status: 429, headers: { 'content-type': 'application/json' } }
-            )
-        );
-        vi.stubGlobal('fetch', fetchMock);
-
-        const client = new OrchestratorClient({ baseUrl: 'http://orchestrator.test' });
-        const res = await client.executeWebhookBatch([buildWebhookProps('a')]);
-
-        expect(res.isErr()).toBe(true);
-        if (res.isErr()) {
-            expect(res.error).toMatchObject({
-                name: 'webhook_admission_exceeded',
-                message: 'busy',
-                payload: { reason: 'concurrency', retryAfterMs: 1200 }
-            });
-        }
-        expect(fetchMock).toHaveBeenCalledTimes(1);
-    });
-
     it('returns batch admission overload without retrying', async () => {
         const fetchMock = vi.fn().mockResolvedValue(
             new Response(

--- a/packages/orchestrator/lib/clients/client.unit.test.ts
+++ b/packages/orchestrator/lib/clients/client.unit.test.ts
@@ -194,34 +194,49 @@ describe('OrchestratorClient executeWebhookBatch', () => {
         }
     });
 
-    it('retries transient 5xx responses on the batch path', async () => {
-        const fetchMock = vi
-            .fn()
-            .mockResolvedValueOnce(
-                new Response(JSON.stringify({ error: { code: 'server_error', message: 'temporary failure' } }), {
-                    status: 500,
-                    headers: { 'content-type': 'application/json' }
-                })
-            )
-            .mockResolvedValueOnce(
-                new Response(JSON.stringify({ error: { code: 'server_error', message: 'temporary failure' } }), {
-                    status: 500,
-                    headers: { 'content-type': 'application/json' }
-                })
-            )
-            .mockResolvedValueOnce(
-                new Response(JSON.stringify({ results: [{ taskId: 't1', retryKey: 'r1' }] }), {
-                    status: 200,
-                    headers: { 'content-type': 'application/json' }
-                })
-            );
+    it('does not retry failed batches because SQS owns durable retries', async () => {
+        const fetchMock = vi.fn().mockResolvedValue(
+            new Response(JSON.stringify({ error: { code: 'server_error', message: 'temporary failure' } }), {
+                status: 500,
+                headers: { 'content-type': 'application/json' }
+            })
+        );
         vi.stubGlobal('fetch', fetchMock);
 
         const client = new OrchestratorClient({ baseUrl: 'http://orchestrator.test' });
         const res = await client.executeWebhookBatch([buildWebhookProps('a')]);
 
-        expect(res.isOk()).toBe(true);
-        expect(fetchMock).toHaveBeenCalledTimes(3);
+        expect(res.isErr()).toBe(true);
+        expect(fetchMock).toHaveBeenCalledTimes(1);
+    });
+
+    it('returns explicit webhook admission feedback', async () => {
+        const fetchMock = vi.fn().mockResolvedValue(
+            new Response(
+                JSON.stringify({
+                    error: {
+                        code: 'webhook_admission_exceeded',
+                        message: 'busy',
+                        payload: { acquired: false, reason: 'concurrency', retryAfterMs: 1200 }
+                    }
+                }),
+                { status: 429, headers: { 'content-type': 'application/json' } }
+            )
+        );
+        vi.stubGlobal('fetch', fetchMock);
+
+        const client = new OrchestratorClient({ baseUrl: 'http://orchestrator.test' });
+        const res = await client.executeWebhookBatch([buildWebhookProps('a')]);
+
+        expect(res.isErr()).toBe(true);
+        if (res.isErr()) {
+            expect(res.error).toMatchObject({
+                name: 'webhook_admission_exceeded',
+                message: 'busy',
+                payload: { reason: 'concurrency', retryAfterMs: 1200 }
+            });
+        }
+        expect(fetchMock).toHaveBeenCalledTimes(1);
     });
 
     it('returns batch admission overload without retrying', async () => {

--- a/packages/utils/lib/environment/parse.ts
+++ b/packages/utils/lib/environment/parse.ts
@@ -691,6 +691,10 @@ const envSchema = z.object({
     // so peak orchestrator connections from webhook dispatch ≈ jobs_replicas × this. Keep it well
     // under ORCHESTRATOR_DB_POOL_MAX so bulk webhook ingress can't starve the orchestrator's core work.
     NANGO_TASK_DISPATCH_CONSUMER_CONCURRENCY: z.coerce.number().min(1).optional().default(5),
+    // Per-pod pacing ceiling. Zero disables latency-based delay, but explicit admission backoff is still honored.
+    NANGO_TASK_DISPATCH_ADAPTIVE_MAX_POLL_DELAY_MS: z.coerce.number().int().nonnegative().optional().default(500),
+    // Start pacing above the normal postImmediateBatch tail latency.
+    NANGO_TASK_DISPATCH_ADAPTIVE_HEALTHY_LATENCY_MS: z.coerce.number().int().positive().optional().default(100),
     NANGO_TASK_DISPATCH_PUBLISH_BATCH_SIZE: z.coerce.number().min(1).max(10).optional().default(10),
     NANGO_TASK_DISPATCH_PUBLISH_CONCURRENCY: z.coerce.number().min(1).optional().default(10),
     NANGO_TASK_DISPATCH_MAX_AGE_SECONDS: z.coerce.number().min(0).optional().default(7200),

--- a/packages/utils/lib/environment/parse.ts
+++ b/packages/utils/lib/environment/parse.ts
@@ -686,7 +686,7 @@ const envSchema = z.object({
     NANGO_TASK_DISPATCH_DLQ_URL: z.url().optional(),
     NANGO_TASK_DISPATCH_MAX_MESSAGES: z.coerce.number().min(1).max(10).optional().default(10),
     NANGO_TASK_DISPATCH_WAIT_TIME_SECONDS: z.coerce.number().min(0).max(20).optional().default(20),
-    NANGO_TASK_DISPATCH_VISIBILITY_TIMEOUT_SECONDS: z.coerce.number().min(0).max(43200).optional().default(30),
+    NANGO_TASK_DISPATCH_VISIBILITY_TIMEOUT_SECONDS: z.coerce.number().int().positive().max(43200).optional().default(30),
     // Number of parallel SQS poll loops. Each in-flight batch holds one orchestrator DB session,
     // so peak orchestrator connections from webhook dispatch ≈ jobs_replicas × this. Keep it well
     // under ORCHESTRATOR_DB_POOL_MAX so bulk webhook ingress can't starve the orchestrator's core work.

--- a/packages/utils/lib/environment/parse.ts
+++ b/packages/utils/lib/environment/parse.ts
@@ -695,13 +695,9 @@ const envSchema = z.object({
     NANGO_TASK_DISPATCH_ADAPTIVE_MAX_POLL_DELAY_MS: z.coerce.number().int().nonnegative().optional().default(500),
     // Start pacing above the normal postImmediateBatch tail latency.
     NANGO_TASK_DISPATCH_ADAPTIVE_HEALTHY_LATENCY_MS: z.coerce.number().int().positive().optional().default(100),
-    NANGO_TASK_DISPATCH_ADAPTIVE_DECAY_WINDOW_MS: z.coerce
-        .number()
-        .int()
-        .positive()
-        .optional()
-        .default(5 * 60 * 1000),
+    NANGO_TASK_DISPATCH_ADAPTIVE_LATENCY_TAU_MS: z.coerce.number().int().positive().optional().default(10_000),
     NANGO_TASK_DISPATCH_ADAPTIVE_JITTER_RATIO: z.coerce.number().min(0).max(1).optional().default(0.2),
+    NANGO_TASK_DISPATCH_FAILURE_BACKOFF_MS: z.coerce.number().int().nonnegative().optional().default(500),
     NANGO_TASK_DISPATCH_PUBLISH_BATCH_SIZE: z.coerce.number().min(1).max(10).optional().default(10),
     NANGO_TASK_DISPATCH_PUBLISH_CONCURRENCY: z.coerce.number().min(1).optional().default(10),
     NANGO_TASK_DISPATCH_MAX_AGE_SECONDS: z.coerce.number().min(0).optional().default(7200),

--- a/packages/utils/lib/environment/parse.ts
+++ b/packages/utils/lib/environment/parse.ts
@@ -695,6 +695,13 @@ const envSchema = z.object({
     NANGO_TASK_DISPATCH_ADAPTIVE_MAX_POLL_DELAY_MS: z.coerce.number().int().nonnegative().optional().default(500),
     // Start pacing above the normal postImmediateBatch tail latency.
     NANGO_TASK_DISPATCH_ADAPTIVE_HEALTHY_LATENCY_MS: z.coerce.number().int().positive().optional().default(100),
+    NANGO_TASK_DISPATCH_ADAPTIVE_DECAY_WINDOW_MS: z.coerce
+        .number()
+        .int()
+        .positive()
+        .optional()
+        .default(5 * 60 * 1000),
+    NANGO_TASK_DISPATCH_ADAPTIVE_JITTER_RATIO: z.coerce.number().min(0).max(1).optional().default(0.2),
     NANGO_TASK_DISPATCH_PUBLISH_BATCH_SIZE: z.coerce.number().min(1).max(10).optional().default(10),
     NANGO_TASK_DISPATCH_PUBLISH_CONCURRENCY: z.coerce.number().min(1).optional().default(10),
     NANGO_TASK_DISPATCH_MAX_AGE_SECONDS: z.coerce.number().min(0).optional().default(7200),

--- a/packages/utils/lib/environment/parse.unit.test.ts
+++ b/packages/utils/lib/environment/parse.unit.test.ts
@@ -21,8 +21,9 @@ describe('parse', () => {
             NANGO_PERSIST_PORT: 3007,
             NANGO_TASK_DISPATCH_ADAPTIVE_MAX_POLL_DELAY_MS: 500,
             NANGO_TASK_DISPATCH_ADAPTIVE_HEALTHY_LATENCY_MS: 100,
-            NANGO_TASK_DISPATCH_ADAPTIVE_DECAY_WINDOW_MS: 5 * 60 * 1000,
-            NANGO_TASK_DISPATCH_ADAPTIVE_JITTER_RATIO: 0.2
+            NANGO_TASK_DISPATCH_ADAPTIVE_LATENCY_TAU_MS: 10_000,
+            NANGO_TASK_DISPATCH_ADAPTIVE_JITTER_RATIO: 0.2,
+            NANGO_TASK_DISPATCH_FAILURE_BACKOFF_MS: 500
         });
     });
 
@@ -33,6 +34,16 @@ describe('parse', () => {
 
     it('should reject an adaptive poll jitter ratio above one', () => {
         expect(() => parseEnvs(ENVS, { NANGO_TASK_DISPATCH_ADAPTIVE_JITTER_RATIO: '1.1' })).toThrow();
+    });
+
+    it('should allow disabling generic failure backoff', () => {
+        const res = parseEnvs(ENVS, { NANGO_TASK_DISPATCH_FAILURE_BACKOFF_MS: '0' });
+        expect(res.NANGO_TASK_DISPATCH_FAILURE_BACKOFF_MS).toBe(0);
+    });
+
+    it('should reject invalid adaptive polling timing', () => {
+        expect(() => parseEnvs(ENVS, { NANGO_TASK_DISPATCH_ADAPTIVE_LATENCY_TAU_MS: '0' })).toThrow();
+        expect(() => parseEnvs(ENVS, { NANGO_TASK_DISPATCH_FAILURE_BACKOFF_MS: '-1' })).toThrow();
     });
 
     it('should parse the sandbox compiler template', () => {

--- a/packages/utils/lib/environment/parse.unit.test.ts
+++ b/packages/utils/lib/environment/parse.unit.test.ts
@@ -16,7 +16,17 @@ describe('parse', () => {
 
     it('should have some default', () => {
         const res = parseEnvs(ENVS, {});
-        expect(res).toMatchObject({ NANGO_DB_SSL: false, NANGO_PERSIST_PORT: 3007 });
+        expect(res).toMatchObject({
+            NANGO_DB_SSL: false,
+            NANGO_PERSIST_PORT: 3007,
+            NANGO_TASK_DISPATCH_ADAPTIVE_MAX_POLL_DELAY_MS: 500,
+            NANGO_TASK_DISPATCH_ADAPTIVE_HEALTHY_LATENCY_MS: 100
+        });
+    });
+
+    it('should allow disabling latency-based poll delays while retaining admission backoff', () => {
+        const res = parseEnvs(ENVS, { NANGO_TASK_DISPATCH_ADAPTIVE_MAX_POLL_DELAY_MS: '0' });
+        expect(res.NANGO_TASK_DISPATCH_ADAPTIVE_MAX_POLL_DELAY_MS).toBe(0);
     });
 
     it('should parse the sandbox compiler template', () => {

--- a/packages/utils/lib/environment/parse.unit.test.ts
+++ b/packages/utils/lib/environment/parse.unit.test.ts
@@ -20,13 +20,19 @@ describe('parse', () => {
             NANGO_DB_SSL: false,
             NANGO_PERSIST_PORT: 3007,
             NANGO_TASK_DISPATCH_ADAPTIVE_MAX_POLL_DELAY_MS: 500,
-            NANGO_TASK_DISPATCH_ADAPTIVE_HEALTHY_LATENCY_MS: 100
+            NANGO_TASK_DISPATCH_ADAPTIVE_HEALTHY_LATENCY_MS: 100,
+            NANGO_TASK_DISPATCH_ADAPTIVE_DECAY_WINDOW_MS: 5 * 60 * 1000,
+            NANGO_TASK_DISPATCH_ADAPTIVE_JITTER_RATIO: 0.2
         });
     });
 
     it('should allow disabling latency-based poll delays while retaining admission backoff', () => {
         const res = parseEnvs(ENVS, { NANGO_TASK_DISPATCH_ADAPTIVE_MAX_POLL_DELAY_MS: '0' });
         expect(res.NANGO_TASK_DISPATCH_ADAPTIVE_MAX_POLL_DELAY_MS).toBe(0);
+    });
+
+    it('should reject an adaptive poll jitter ratio above one', () => {
+        expect(() => parseEnvs(ENVS, { NANGO_TASK_DISPATCH_ADAPTIVE_JITTER_RATIO: '1.1' })).toThrow();
     });
 
     it('should parse the sandbox compiler template', () => {

--- a/packages/utils/lib/environment/parse.unit.test.ts
+++ b/packages/utils/lib/environment/parse.unit.test.ts
@@ -388,8 +388,8 @@ describe('parse', () => {
             expect(() => parseEnvs(ENVS, { NANGO_TASK_DISPATCH_WAIT_TIME_SECONDS: '21' })).toThrow();
         });
 
-        it('should reject NANGO_TASK_DISPATCH_VISIBILITY_TIMEOUT_SECONDS outside [0,43200]', () => {
-            expect(() => parseEnvs(ENVS, { NANGO_TASK_DISPATCH_VISIBILITY_TIMEOUT_SECONDS: '-1' })).toThrow();
+        it('should reject NANGO_TASK_DISPATCH_VISIBILITY_TIMEOUT_SECONDS outside [1,43200]', () => {
+            expect(() => parseEnvs(ENVS, { NANGO_TASK_DISPATCH_VISIBILITY_TIMEOUT_SECONDS: '0' })).toThrow();
             expect(() => parseEnvs(ENVS, { NANGO_TASK_DISPATCH_VISIBILITY_TIMEOUT_SECONDS: '43201' })).toThrow();
         });
 

--- a/packages/utils/lib/telemetry/metrics.ts
+++ b/packages/utils/lib/telemetry/metrics.ts
@@ -85,7 +85,7 @@ export enum Types {
     WEBHOOK_DISPATCH_BATCH_SIZE = 'nango.webhook.dispatch_queue.batch_size',
     WEBHOOK_DISPATCH_ORCHESTRATOR_LATENCY_MS = 'nango.webhook.dispatch_queue.orchestrator_latency_ms',
     WEBHOOK_DISPATCH_POLL_DELAY_MS = 'nango.webhook.dispatch_queue.poll_delay_ms',
-    WEBHOOK_DISPATCH_POLL_PRESSURE = 'nango.webhook.dispatch_queue.poll_pressure',
+    WEBHOOK_DISPATCH_POLL_LATENCY_PRESSURE = 'nango.webhook.dispatch_queue.poll_latency_pressure',
     WEBHOOK_DISPATCH_POLL_BACKOFF = 'nango.webhook.dispatch_queue.poll_backoff',
 
     ORCH_TASKS_CREATED = 'nango.orch.tasks.created',

--- a/packages/utils/lib/telemetry/metrics.ts
+++ b/packages/utils/lib/telemetry/metrics.ts
@@ -83,6 +83,10 @@ export enum Types {
     WEBHOOK_DISPATCH_DROPPED = 'nango.webhook.dispatch_queue.dropped',
     WEBHOOK_DISPATCH_DWELL_MS = 'nango.webhook.dispatch_queue.dwell_ms',
     WEBHOOK_DISPATCH_BATCH_SIZE = 'nango.webhook.dispatch_queue.batch_size',
+    WEBHOOK_DISPATCH_ORCHESTRATOR_LATENCY_MS = 'nango.webhook.dispatch_queue.orchestrator_latency_ms',
+    WEBHOOK_DISPATCH_POLL_DELAY_MS = 'nango.webhook.dispatch_queue.poll_delay_ms',
+    WEBHOOK_DISPATCH_POLL_PRESSURE = 'nango.webhook.dispatch_queue.poll_pressure',
+    WEBHOOK_DISPATCH_POLL_BACKOFF = 'nango.webhook.dispatch_queue.poll_backoff',
 
     ORCH_TASKS_CREATED = 'nango.orch.tasks.created',
     ORCH_TASKS_DROPPED = 'nango.orch.tasks.dropped',


### PR DESCRIPTION
## Summary

- add one shared in-memory pacing controller per jobs pod for all webhook dispatch SQS poll loops
- map successful orchestrator batch latency above 100ms through a one-sided sigmoid, then smooth it with a time-adaptive EWMA using a 10s time constant
- convert latency pressure to a bounded, jittered polling delay capped at 500ms
- keep admission and generic failures independent from latency: admission honors `retryAfterMs` pod-wide, while generic failures apply a fixed 500ms pause
- use the longest active latency, admission, or failure delay without coordinating state across jobs pods
- extend SQS message visibility across post-receive admission backoff, bounded by the remaining SQS visibility limit
- use one bounded batch request because SQS owns durable retries

This is a simpler alternative to #6871 and is stacked directly on the webhook admission branch. It intentionally keeps `NANGO_TASK_DISPATCH_CONSUMER_CONCURRENCY` as the fixed per-pod hard cap.

## Controller behavior

- successful latency is the only input to `latencyPressure`; the EWMA coefficient is derived from elapsed wall-clock time so behavior is consistent across sample rates
- HTTP 529 admission feedback only extends the admission deadline and preserves the orchestrator-provided retry interval
- generic failures only extend the fixed failure deadline; the backoff can be disabled by setting it to `0`
- admission backoff retains bounded jitter to desynchronize loops and pods, while generic failure backoff is exact
- shutdown aborts active adaptive, admission, and failure waits

Configuration:

- `NANGO_TASK_DISPATCH_ADAPTIVE_HEALTHY_LATENCY_MS=100`
- `NANGO_TASK_DISPATCH_ADAPTIVE_LATENCY_TAU_MS=10000`
- `NANGO_TASK_DISPATCH_ADAPTIVE_MAX_POLL_DELAY_MS=500`
- `NANGO_TASK_DISPATCH_ADAPTIVE_JITTER_RATIO=0.2`
- `NANGO_TASK_DISPATCH_FAILURE_BACKOFF_MS=500`

## Thresholds

Datadog production spans for `nango-orchestrator` `POST /v1/immediate/batch` showed:

- 30d: p50 22ms, p90 49ms, p95 66ms, p99 192ms
- 24h: p50 22ms, p90 44ms, p95 59ms, p99 167ms
- degraded five-minute windows: 95-188ms average / 239-363ms p95, with severe windows above 1s

The 100ms healthy threshold starts pacing above the normal tail while reacting before degraded windows reach admission failure. The 10s EWMA smooths isolated spikes but responds quickly to sustained latency.

## Verification

- `npm run ts-build`
- 108 focused unit tests covering controller timelines, sample-rate invariance, pod isolation, admission and failure separation, SQS visibility, orchestrator client behavior, and environment validation
