### PR TITLE
fix(providers): cursor-admin api key description says Greenhouse

### DIFF
--- a/packages/providers/providers.yaml
+++ b/packages/providers/providers.yaml
@@ -5740,7 +5740,7 @@ cursor-admin:
         username:
             type: string
             title: API key
-            description: The API Key of your Greenhouse account
+            description: The Admin API key for your Cursor account
             example: key_9164000970ca2f15c999047a0e2b7e03127885be41198616a6975af08b28239b
             pattern: '^(key_[a-f0-9]{64}|crsr_[a-f0-9]{64})$'
             secret: true


### PR DESCRIPTION
## Describe your changes

The `cursor-admin` provider's `username` credential description reads "The API Key of your Greenhouse account" — a leftover from the Greenhouse credential block it was copied from. Updated to say Cursor.

## Issue ticket number and link

N/A — one-line copy fix, spotted while integrating `cursor-admin`.

## Checklist before requesting a review (skip if just adding/editing APIs)

- [x] I added tests, otherwise the reason is: copy-only change to a credential description, no behavior
- [x] External API requests have retries
- [x] Pagination is used where appropriate
- [x] The built in `nango.paginate` function is used instead of a while loop
- [x] Third party requests are NOT parallelized

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/NangoHQ/nango/pull/6911?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

