### PR TITLE
fix(providers): allow dots in contentstack api domain

### DIFF
--- a/packages/providers/providers.yaml
+++ b/packages/providers/providers.yaml
@@ -5572,7 +5572,7 @@ contentstack:
             type: string
             title: API Domain
             description: The domain to where you will access your API
-            pattern: '^[a-z0-9_-]+$'
+            pattern: '^[a-z0-9.-]+$'
             example: eu-api.contentstack.com
             prefix: https://
             order: 3


### PR DESCRIPTION
### What

Allow dots in the Contentstack apiDomain pattern: ^[a-z0-9_-]+$ to ^[a-z0-9.-]+$.

### Why

apiDomain builds the base URL (https://${connectionConfig.apiDomain}), but the pattern forbids `.` , so it rejects its own example eu-api.contentstack.com and every Contentstack region host (https://www.contentstack.com/docs/developers/apis/content-management-api), all of which are dotted. Users can't connect.

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/NangoHQ/nango/pull/6913?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

