### PR TITLE
feat(providers): add supabase-management (Supabase Management API, OAuth2)

### DIFF
--- a/docs/api-integrations/supabase-management.mdx
+++ b/docs/api-integrations/supabase-management.mdx
@@ -1,0 +1,83 @@
+---
+title: 'Supabase Management API'
+sidebarTitle: 'Supabase Management API'
+description: 'Integrate your application with the Supabase Management API'
+---
+
+<Note>
+This integration is for the **Supabase Management API** (`api.supabase.com`), which
+manages a user's Supabase organizations and projects via OAuth. To call a single
+Supabase project's own REST API with a service key, use the [Supabase](/api-integrations/supabase)
+integration instead.
+</Note>
+
+## 🚀 Quickstart
+
+<Steps>
+    <Step title="Register a Supabase OAuth application">
+    In the Supabase dashboard, go to your organization's **Settings** -> **OAuth Apps** -> _Add application_.
+
+    Set the redirect URI to the callback URL shown on your Nango integration page, and
+    select the permissions your integration needs.
+
+    <Warning>
+    Supabase fixes an application's scopes **when the application is registered**, not
+    per authorization request. The `scope` authorize parameter is documented as
+    deprecated and does not narrow the grant.
+
+    If you need both read-only and read-write access, register **two applications** with
+    different permissions and create two Nango integrations from this provider.
+    </Warning>
+    </Step>
+    <Step title="Create the integration">
+    In Nango ([free signup](https://app.nango.dev)), go to [Integrations](https://app.nango.dev/dev/integrations) -> _Configure New Integration_ -> _Supabase Management API_, and enter the client ID and client secret from the application you registered.
+    </Step>
+    <Step title="Authorize a user">
+    Go to [Connections](https://app.nango.dev/dev/connections) -> _Add Test Connection_ -> _Authorize_. The user chooses which of their Supabase **organizations** to grant; the resulting token can reach every project in that organization.
+    </Step>
+    <Step title="Call the Management API">
+    List the projects the connection can see. Replace the placeholders with your [secret key](https://app.nango.dev/dev/environment-settings), [integration ID](https://app.nango.dev/dev/integrations) and [connection ID](https://app.nango.dev/dev/connections).
+
+    ```bash
+    curl "https://api.nango.dev/proxy/v1/projects" \
+      -H "Authorization: Bearer <NANGO-SECRET-KEY>" \
+      -H "Provider-Config-Key: <INTEGRATION-ID>" \
+      -H "Connection-Id: <CONNECTION-ID>"
+    ```
+    </Step>
+</Steps>
+
+## Useful links
+
+| Topic | Links |
+| - | - |
+| General | [Supabase website](https://supabase.com/) |
+| | [Create a Supabase account](https://supabase.com/dashboard/sign-up) |
+| Developer | [API documentation](https://supabase.com/docs/reference/api/introduction) |
+| | [Build a Supabase integration (OAuth)](https://supabase.com/docs/guides/integrations/build-a-supabase-integration) |
+| | [OAuth scopes](https://supabase.com/docs/guides/integrations/build-a-supabase-integration) |
+| | [API base URL](https://api.supabase.com) |
+
+<Tip>Need help getting started? Get help in the [community](https://nango.dev/slack).</Tip>
+
+## API gotchas
+
+- **Scopes are fixed at application registration.** Passing `scope` to the authorize
+  endpoint does not narrow the grant; Supabase documents that parameter as deprecated.
+  Register a separate OAuth application for each permission set you need.
+- **Grants are organization-scoped, not project-scoped.** A user consents for one
+  organization, and the resulting token can reach every project in it. If your product
+  needs to act on a single project, record the chosen project reference yourself and
+  scope your own requests to it.
+- **Both tokens rotate on refresh, and refresh is single-use.** A refresh returns a new
+  access token *and* a new refresh token; the previous access token is rejected
+  immediately with no grace period, and the previous refresh token returns
+  `404 No such refresh token found`. Two concurrent refreshes will therefore invalidate
+  each other. Nango handles this for you.
+- **Access tokens are opaque**, prefixed `sbp_oauth_`, and last 24 hours
+  (`expires_in: 86400`). They are not JWTs; do not attempt to decode them.
+- **PKCE is supported** (`S256` and `plain`) and is recommended.
+
+<Card title="Contribute API gotchas" icon="wand-magic-sparkles" href="https://github.com/NangoHQ/nango/blob/master/docs/api-integrations/supabase-management.mdx">
+Add your gotchas to help others.
+</Card>

--- a/docs/api-integrations/supabase-management.mdx
+++ b/docs/api-integrations/supabase-management.mdx
@@ -14,7 +14,7 @@ integration instead.
 ## 🚀 Quickstart
 
 <Steps>
-    <Step title="Register a Supabase OAuth application">
+    <Step id="register-oauth-app" title="Register a Supabase OAuth application">
     In the Supabase dashboard, go to your organization's **Settings** -> **OAuth Apps** -> _Add application_.
 
     Set the redirect URI to the callback URL shown on your Nango integration page, and
@@ -29,13 +29,13 @@ integration instead.
     different permissions and create two Nango integrations from this provider.
     </Warning>
     </Step>
-    <Step title="Create the integration">
+    <Step id="create-integration" title="Create the integration">
     In Nango ([free signup](https://app.nango.dev)), go to [Integrations](https://app.nango.dev/dev/integrations) -> _Configure New Integration_ -> _Supabase Management API_, and enter the client ID and client secret from the application you registered.
     </Step>
-    <Step title="Authorize a user">
+    <Step id="authorize-user" title="Authorize a user">
     Go to [Connections](https://app.nango.dev/dev/connections) -> _Add Test Connection_ -> _Authorize_. The user chooses which of their Supabase **organizations** to grant; the resulting token can reach every project in that organization.
     </Step>
-    <Step title="Call the Management API">
+    <Step id="call-management-api" title="Call the Management API">
     List the projects the connection can see. Replace the placeholders with your [secret key](https://app.nango.dev/dev/environment-settings), [integration ID](https://app.nango.dev/dev/integrations) and [connection ID](https://app.nango.dev/dev/connections).
 
     ```bash

--- a/packages/providers/providers.scopes.yaml
+++ b/packages/providers/providers.scopes.yaml
@@ -11166,6 +11166,14 @@ stripe-express:
     - read_only
     - read_write
 
+# source: https://supabase.com/docs/guides/integrations/build-a-supabase-integration
+# Scopes are fixed when the Supabase OAuth application is REGISTERED, not narrowed
+# by the authorize request; the `scope` parameter is documented as deprecated.
+supabase-management:
+    - projects:read
+    - database:read
+    - database:write
+
 # source: providers.yaml (no official scopes page or discovery endpoint found)
 surecontact: []
 

--- a/packages/providers/providers.yaml
+++ b/packages/providers/providers.yaml
@@ -21375,6 +21375,25 @@ supabase:
             pattern: '^sb_secret_[A-Za-z0-9_]+$'
             doc_section: '#step-2-finding-your-secret-key'
 
+supabase-management:
+    display_name: Supabase Management API
+    categories:
+        - dev-tools
+    auth_mode: OAUTH2
+    authorization_url: https://api.supabase.com/v1/oauth/authorize
+    token_url: https://api.supabase.com/v1/oauth/token
+    authorization_params:
+        response_type: code
+    token_params:
+        grant_type: authorization_code
+    refresh_params:
+        grant_type: refresh_token
+    proxy:
+        base_url: https://api.supabase.com
+        headers:
+            authorization: Bearer ${accessToken}
+    docs: https://nango.dev/docs/api-integrations/supabase-management
+
 supabase-mcp:
     display_name: Supabase (MCP)
     categories:

--- a/packages/webapp/public/images/template-logos/supabase-management.svg
+++ b/packages/webapp/public/images/template-logos/supabase-management.svg
@@ -1,0 +1,15 @@
+<svg width="60" height="62" viewBox="0 0 109 113" fill="none" xmlns="http://www.w3.org/2000/svg">
+<path d="M63.7076 110.284C60.8481 113.885 55.0502 111.912 54.9813 107.314L53.9738 40.0627L99.1935 40.0627C107.384 40.0627 111.952 49.5228 106.859 55.9374L63.7076 110.284Z" fill="url(#paint0_linear)"/>
+<path d="M63.7076 110.284C60.8481 113.885 55.0502 111.912 54.9813 107.314L53.9738 40.0627L99.1935 40.0627C107.384 40.0627 111.952 49.5228 106.859 55.9374L63.7076 110.284Z" fill="url(#paint1_linear)" fill-opacity="0.2"/>
+<path d="M45.317 2.07103C48.1765 -1.53037 53.9745 0.442937 54.0434 5.041L54.4849 72.2922H9.83113C1.64038 72.2922 -2.92775 62.8321 2.1655 56.4175L45.317 2.07103Z" fill="#3ECF8E"/>
+<defs>
+<linearGradient id="paint0_linear" x1="53.9738" y1="54.974" x2="94.1635" y2="71.8295" gradientUnits="userSpaceOnUse">
+<stop stop-color="#249361"/>
+<stop offset="1" stop-color="#3ECF8E"/>
+</linearGradient>
+<linearGradient id="paint1_linear" x1="36.1558" y1="30.578" x2="54.4844" y2="65.0806" gradientUnits="userSpaceOnUse">
+<stop/>
+<stop offset="1" stop-opacity="0"/>
+</linearGradient>
+</defs>
+</svg>


### PR DESCRIPTION
## Describe your changes

Adds `supabase-management`, a plain `OAUTH2` provider for the [Supabase Management API](https://supabase.com/docs/reference/api/introduction) (`api.supabase.com`).

This is distinct from the three Supabase providers already present:

| Existing | Auth | Targets |
| --- | --- | --- |
| `supabase` | API_KEY | one project's own REST API |
| `supabase-mcp` | API_KEY | `mcp.supabase.com` |
| `supabase-mcp-oauth` | MCP_OAUTH2 | `mcp.supabase.com` |

None of them can call the Management API with a user-authorized OAuth token, which is what an integration managing a user's organizations and projects needs.

## Two things worth flagging for review

**1. Scopes are fixed at application registration, not per request.** Supabase documents the `scope` authorize parameter as deprecated: *"Scopes are configured when you create your OAuth app."* Passing a narrower `scope` does not narrow the grant. An integrator needing both read-only and read-write therefore registers **two Supabase OAuth applications** and creates two Nango integrations from this single provider. This is called out in the docs page and in `providers.scopes.yaml`.

**2. Refresh is single-use and rotates both tokens.** Verified against the live endpoints: a refresh returns a new access token *and* a new refresh token; the previous access token is rejected immediately with no grace period, and the previous refresh token returns `404 No such refresh token found`. Two concurrent refreshes invalidate each other. Documented under API gotchas since it materially affects anyone implementing this themselves, and is a good reason to let Nango own refresh.

Other verified details, all from testing against the live API rather than docs alone:

- Access tokens are opaque, prefixed `sbp_oauth_`, `expires_in: 86400`. Not JWTs.
- The token response carries no `resource` field, so there is no audience binding.
- PKCE is supported (`S256` and `plain`); the provider leaves PKCE enabled.
- Client credentials go in the request body, so `token_request_auth_method` is omitted.
- Grants are **organization**-scoped: one consent covers every project in the chosen organization.

## Files

- `packages/providers/providers.yaml` — the provider
- `packages/providers/providers.scopes.yaml` — scope list. Added by hand; happy to drop it or let `update:providers:scopes:new` regenerate it if you prefer.
- `docs/api-integrations/supabase-management.mdx` — quickstart, links, gotchas
- `packages/webapp/public/images/template-logos/supabase-management.svg` — logo, same mark as the existing Supabase providers

## Checklist before requesting a review

- [x] I added tests, otherwise the reason is: provider entries are covered by `scripts/validation/providers/validate.ts`, which passes with no errors and no warnings for this provider.


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/NangoHQ/nango/pull/6915?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

