### PR TITLE
feat(types): enforce audit coverage via an endpoint opt-out policy (NAN-6269)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -18,6 +18,3 @@ temp
 CLAUDE.local.md
 .cursor/*.local.mdc
 
-# Vim swap files
-*.swp
-*.swo

--- a/.gitignore
+++ b/.gitignore
@@ -17,3 +17,7 @@ temp
 .claude/settings.local.json
 CLAUDE.local.md
 .cursor/*.local.mdc
+
+# Vim swap files
+*.swp
+*.swo

--- a/packages/types/lib/account/api.ts
+++ b/packages/types/lib/account/api.ts
@@ -1,7 +1,8 @@
-import type { ApiError, Endpoint } from '../api.js';
+import type { ApiEndpoint, ApiError } from '../api.js';
 import type { ApiUser } from '../user/api.js';
 
-export type PostSignup = Endpoint<{
+export type PostSignup = ApiEndpoint<{
+    Audit: { audit: false; reason: 'non-auditable' };
     Method: 'POST';
     Path: '/api/v1/account/signup';
     Body: {
@@ -26,7 +27,8 @@ export type PostSignup = Endpoint<{
     };
 }>;
 
-export type ValidateEmailAndLogin = Endpoint<{
+export type ValidateEmailAndLogin = ApiEndpoint<{
+    Audit: { audit: false; reason: 'non-auditable' };
     Method: 'POST';
     Path: '/api/v1/account/verify/code';
     Body: {
@@ -44,7 +46,8 @@ export type ValidateEmailAndLogin = Endpoint<{
     };
 }>;
 
-export type ResendVerificationEmailByUuid = Endpoint<{
+export type ResendVerificationEmailByUuid = ApiEndpoint<{
+    Audit: { audit: false; reason: 'non-auditable' };
     Method: 'POST';
     Path: '/api/v1/account/resend-verification-email/by-uuid';
     Body: { uuid: string };
@@ -54,7 +57,8 @@ export type ResendVerificationEmailByUuid = Endpoint<{
     };
 }>;
 
-export type ResendVerificationEmailByEmail = Endpoint<{
+export type ResendVerificationEmailByEmail = ApiEndpoint<{
+    Audit: { audit: false; reason: 'non-auditable' };
     Method: 'POST';
     Path: '/api/v1/account/resend-verification-email/by-email';
     Body: { email: string };
@@ -64,7 +68,8 @@ export type ResendVerificationEmailByEmail = Endpoint<{
     };
 }>;
 
-export type GetEmailByUuid = Endpoint<{
+export type GetEmailByUuid = ApiEndpoint<{
+    Audit: { audit: false; reason: 'non-auditable' };
     Method: 'GET';
     Path: '/api/v1/account/email/:uuid';
     Params: { uuid: string };
@@ -75,7 +80,8 @@ export type GetEmailByUuid = Endpoint<{
     };
 }>;
 
-export type GetEmailByExpiredToken = Endpoint<{
+export type GetEmailByExpiredToken = ApiEndpoint<{
+    Audit: { audit: false; reason: 'non-auditable' };
     Method: 'GET';
     Path: '/api/v1/account/email/expired-token/:token';
     Params: { token: string };
@@ -87,7 +93,8 @@ export type GetEmailByExpiredToken = Endpoint<{
     };
 }>;
 
-export type PostSignin = Endpoint<{
+export type PostSignin = ApiEndpoint<{
+    Audit: { audit: false; reason: 'non-auditable' };
     Method: 'POST';
     Path: '/api/v1/account/signin';
     Body: {
@@ -99,13 +106,15 @@ export type PostSignin = Endpoint<{
     Success: { user: ApiUser } | { data: { mfaRequired: true } };
 }>;
 
-export type PostLogout = Endpoint<{
+export type PostLogout = ApiEndpoint<{
+    Audit: { audit: false; reason: 'non-auditable' };
     Method: 'POST';
     Path: '/api/v1/account/logout';
     Success: never;
 }>;
 
-export type PostForgotPassword = Endpoint<{
+export type PostForgotPassword = ApiEndpoint<{
+    Audit: { audit: false; reason: 'non-auditable' };
     Method: 'POST';
     Path: '/api/v1/account/forgot-password';
     Body: {
@@ -116,7 +125,8 @@ export type PostForgotPassword = Endpoint<{
     };
 }>;
 
-export type PutResetPassword = Endpoint<{
+export type PutResetPassword = ApiEndpoint<{
+    Audit: { audit: false; reason: 'non-auditable' };
     Method: 'PUT';
     Path: '/api/v1/account/reset-password';
     Body: {
@@ -129,7 +139,8 @@ export type PutResetPassword = Endpoint<{
     };
 }>;
 
-export type PostManagedSignup = Endpoint<{
+export type PostManagedSignup = ApiEndpoint<{
+    Audit: { audit: false; reason: 'non-auditable' };
     Method: 'POST';
     Path: '/api/v1/account/managed/signup';
     Body: {
@@ -143,7 +154,8 @@ export type PostManagedSignup = Endpoint<{
     };
 }>;
 
-export type GetManagedEmailVerification = Endpoint<{
+export type GetManagedEmailVerification = ApiEndpoint<{
+    Audit: { audit: false; reason: 'non-auditable' };
     Method: 'GET';
     Path: '/api/v1/account/managed/verification';
     Error: ApiError<'not_found'>;
@@ -154,7 +166,8 @@ export type GetManagedEmailVerification = Endpoint<{
     };
 }>;
 
-export type PostManagedEmailVerification = Endpoint<{
+export type PostManagedEmailVerification = ApiEndpoint<{
+    Audit: { audit: false; reason: 'non-auditable' };
     Method: 'POST';
     Path: '/api/v1/account/managed/verification';
     Body: {
@@ -168,7 +181,8 @@ export type PostManagedEmailVerification = Endpoint<{
     };
 }>;
 
-export type GetManagedCallback = Endpoint<{
+export type GetManagedCallback = ApiEndpoint<{
+    Audit: { audit: false; reason: 'non-auditable' };
     Method: 'GET';
     Path: '/api/v1/login/callback';
     Querystring: {
@@ -183,7 +197,8 @@ export type GetManagedCallback = Endpoint<{
     };
 }>;
 
-export type GetOnboardingHearAboutUs = Endpoint<{
+export type GetOnboardingHearAboutUs = ApiEndpoint<{
+    Audit: { audit: false; reason: 'non-auditable' };
     Method: 'GET';
     Path: '/api/v1/account/onboarding/hear-about-us';
     Error: ApiError<'unauthorized'>;
@@ -194,7 +209,8 @@ export type GetOnboardingHearAboutUs = Endpoint<{
     };
 }>;
 
-export type PostOnboardingHearAboutUs = Endpoint<{
+export type PostOnboardingHearAboutUs = ApiEndpoint<{
+    Audit: { audit: false; reason: 'non-auditable' };
     Method: 'POST';
     Path: '/api/v1/account/onboarding/hear-about-us';
     Body: {

--- a/packages/types/lib/account/api.ts
+++ b/packages/types/lib/account/api.ts
@@ -2,7 +2,7 @@ import type { ApiEndpoint, ApiError } from '../api.js';
 import type { ApiUser } from '../user/api.js';
 
 export type PostSignup = ApiEndpoint<{
-    Audit: { audit: false; reason: 'non-auditable' };
+    Audit: { reason: 'non-auditable' };
     Method: 'POST';
     Path: '/api/v1/account/signup';
     Body: {
@@ -28,7 +28,7 @@ export type PostSignup = ApiEndpoint<{
 }>;
 
 export type ValidateEmailAndLogin = ApiEndpoint<{
-    Audit: { audit: false; reason: 'non-auditable' };
+    Audit: { reason: 'non-auditable' };
     Method: 'POST';
     Path: '/api/v1/account/verify/code';
     Body: {
@@ -47,7 +47,7 @@ export type ValidateEmailAndLogin = ApiEndpoint<{
 }>;
 
 export type ResendVerificationEmailByUuid = ApiEndpoint<{
-    Audit: { audit: false; reason: 'non-auditable' };
+    Audit: { reason: 'non-auditable' };
     Method: 'POST';
     Path: '/api/v1/account/resend-verification-email/by-uuid';
     Body: { uuid: string };
@@ -58,7 +58,7 @@ export type ResendVerificationEmailByUuid = ApiEndpoint<{
 }>;
 
 export type ResendVerificationEmailByEmail = ApiEndpoint<{
-    Audit: { audit: false; reason: 'non-auditable' };
+    Audit: { reason: 'non-auditable' };
     Method: 'POST';
     Path: '/api/v1/account/resend-verification-email/by-email';
     Body: { email: string };
@@ -69,7 +69,7 @@ export type ResendVerificationEmailByEmail = ApiEndpoint<{
 }>;
 
 export type GetEmailByUuid = ApiEndpoint<{
-    Audit: { audit: false; reason: 'non-auditable' };
+    Audit: { reason: 'non-auditable' };
     Method: 'GET';
     Path: '/api/v1/account/email/:uuid';
     Params: { uuid: string };
@@ -81,7 +81,7 @@ export type GetEmailByUuid = ApiEndpoint<{
 }>;
 
 export type GetEmailByExpiredToken = ApiEndpoint<{
-    Audit: { audit: false; reason: 'non-auditable' };
+    Audit: { reason: 'non-auditable' };
     Method: 'GET';
     Path: '/api/v1/account/email/expired-token/:token';
     Params: { token: string };
@@ -94,7 +94,7 @@ export type GetEmailByExpiredToken = ApiEndpoint<{
 }>;
 
 export type PostSignin = ApiEndpoint<{
-    Audit: { audit: false; reason: 'non-auditable' };
+    Audit: { reason: 'non-auditable' };
     Method: 'POST';
     Path: '/api/v1/account/signin';
     Body: {
@@ -107,14 +107,14 @@ export type PostSignin = ApiEndpoint<{
 }>;
 
 export type PostLogout = ApiEndpoint<{
-    Audit: { audit: false; reason: 'non-auditable' };
+    Audit: { reason: 'non-auditable' };
     Method: 'POST';
     Path: '/api/v1/account/logout';
     Success: never;
 }>;
 
 export type PostForgotPassword = ApiEndpoint<{
-    Audit: { audit: false; reason: 'non-auditable' };
+    Audit: { reason: 'non-auditable' };
     Method: 'POST';
     Path: '/api/v1/account/forgot-password';
     Body: {
@@ -126,7 +126,7 @@ export type PostForgotPassword = ApiEndpoint<{
 }>;
 
 export type PutResetPassword = ApiEndpoint<{
-    Audit: { audit: false; reason: 'non-auditable' };
+    Audit: { reason: 'non-auditable' };
     Method: 'PUT';
     Path: '/api/v1/account/reset-password';
     Body: {
@@ -140,7 +140,7 @@ export type PutResetPassword = ApiEndpoint<{
 }>;
 
 export type PostManagedSignup = ApiEndpoint<{
-    Audit: { audit: false; reason: 'non-auditable' };
+    Audit: { reason: 'non-auditable' };
     Method: 'POST';
     Path: '/api/v1/account/managed/signup';
     Body: {
@@ -155,7 +155,7 @@ export type PostManagedSignup = ApiEndpoint<{
 }>;
 
 export type GetManagedEmailVerification = ApiEndpoint<{
-    Audit: { audit: false; reason: 'non-auditable' };
+    Audit: { reason: 'non-auditable' };
     Method: 'GET';
     Path: '/api/v1/account/managed/verification';
     Error: ApiError<'not_found'>;
@@ -167,7 +167,7 @@ export type GetManagedEmailVerification = ApiEndpoint<{
 }>;
 
 export type PostManagedEmailVerification = ApiEndpoint<{
-    Audit: { audit: false; reason: 'non-auditable' };
+    Audit: { reason: 'non-auditable' };
     Method: 'POST';
     Path: '/api/v1/account/managed/verification';
     Body: {
@@ -182,7 +182,7 @@ export type PostManagedEmailVerification = ApiEndpoint<{
 }>;
 
 export type GetManagedCallback = ApiEndpoint<{
-    Audit: { audit: false; reason: 'non-auditable' };
+    Audit: { reason: 'non-auditable' };
     Method: 'GET';
     Path: '/api/v1/login/callback';
     Querystring: {
@@ -198,7 +198,7 @@ export type GetManagedCallback = ApiEndpoint<{
 }>;
 
 export type GetOnboardingHearAboutUs = ApiEndpoint<{
-    Audit: { audit: false; reason: 'non-auditable' };
+    Audit: { reason: 'non-auditable' };
     Method: 'GET';
     Path: '/api/v1/account/onboarding/hear-about-us';
     Error: ApiError<'unauthorized'>;
@@ -210,7 +210,7 @@ export type GetOnboardingHearAboutUs = ApiEndpoint<{
 }>;
 
 export type PostOnboardingHearAboutUs = ApiEndpoint<{
-    Audit: { audit: false; reason: 'non-auditable' };
+    Audit: { reason: 'non-auditable' };
     Method: 'POST';
     Path: '/api/v1/account/onboarding/hear-about-us';
     Body: {

--- a/packages/types/lib/account/api.ts
+++ b/packages/types/lib/account/api.ts
@@ -2,7 +2,7 @@ import type { ApiEndpoint, ApiError } from '../api.js';
 import type { ApiUser } from '../user/api.js';
 
 export type PostSignup = ApiEndpoint<{
-    Audit: { reason: 'non-auditable' };
+    Audit: { kind: 'no-audit'; reason: 'non-auditable' };
     Method: 'POST';
     Path: '/api/v1/account/signup';
     Body: {
@@ -28,7 +28,7 @@ export type PostSignup = ApiEndpoint<{
 }>;
 
 export type ValidateEmailAndLogin = ApiEndpoint<{
-    Audit: { reason: 'non-auditable' };
+    Audit: { kind: 'no-audit'; reason: 'non-auditable' };
     Method: 'POST';
     Path: '/api/v1/account/verify/code';
     Body: {
@@ -47,7 +47,7 @@ export type ValidateEmailAndLogin = ApiEndpoint<{
 }>;
 
 export type ResendVerificationEmailByUuid = ApiEndpoint<{
-    Audit: { reason: 'non-auditable' };
+    Audit: { kind: 'no-audit'; reason: 'non-auditable' };
     Method: 'POST';
     Path: '/api/v1/account/resend-verification-email/by-uuid';
     Body: { uuid: string };
@@ -58,7 +58,7 @@ export type ResendVerificationEmailByUuid = ApiEndpoint<{
 }>;
 
 export type ResendVerificationEmailByEmail = ApiEndpoint<{
-    Audit: { reason: 'non-auditable' };
+    Audit: { kind: 'no-audit'; reason: 'non-auditable' };
     Method: 'POST';
     Path: '/api/v1/account/resend-verification-email/by-email';
     Body: { email: string };
@@ -69,7 +69,7 @@ export type ResendVerificationEmailByEmail = ApiEndpoint<{
 }>;
 
 export type GetEmailByUuid = ApiEndpoint<{
-    Audit: { reason: 'non-auditable' };
+    Audit: { kind: 'no-audit'; reason: 'non-auditable' };
     Method: 'GET';
     Path: '/api/v1/account/email/:uuid';
     Params: { uuid: string };
@@ -81,7 +81,7 @@ export type GetEmailByUuid = ApiEndpoint<{
 }>;
 
 export type GetEmailByExpiredToken = ApiEndpoint<{
-    Audit: { reason: 'non-auditable' };
+    Audit: { kind: 'no-audit'; reason: 'non-auditable' };
     Method: 'GET';
     Path: '/api/v1/account/email/expired-token/:token';
     Params: { token: string };
@@ -94,7 +94,7 @@ export type GetEmailByExpiredToken = ApiEndpoint<{
 }>;
 
 export type PostSignin = ApiEndpoint<{
-    Audit: { reason: 'non-auditable' };
+    Audit: { kind: 'no-audit'; reason: 'non-auditable' };
     Method: 'POST';
     Path: '/api/v1/account/signin';
     Body: {
@@ -107,14 +107,14 @@ export type PostSignin = ApiEndpoint<{
 }>;
 
 export type PostLogout = ApiEndpoint<{
-    Audit: { reason: 'non-auditable' };
+    Audit: { kind: 'no-audit'; reason: 'non-auditable' };
     Method: 'POST';
     Path: '/api/v1/account/logout';
     Success: never;
 }>;
 
 export type PostForgotPassword = ApiEndpoint<{
-    Audit: { reason: 'non-auditable' };
+    Audit: { kind: 'no-audit'; reason: 'non-auditable' };
     Method: 'POST';
     Path: '/api/v1/account/forgot-password';
     Body: {
@@ -126,7 +126,7 @@ export type PostForgotPassword = ApiEndpoint<{
 }>;
 
 export type PutResetPassword = ApiEndpoint<{
-    Audit: { reason: 'non-auditable' };
+    Audit: { kind: 'no-audit'; reason: 'non-auditable' };
     Method: 'PUT';
     Path: '/api/v1/account/reset-password';
     Body: {
@@ -140,7 +140,7 @@ export type PutResetPassword = ApiEndpoint<{
 }>;
 
 export type PostManagedSignup = ApiEndpoint<{
-    Audit: { reason: 'non-auditable' };
+    Audit: { kind: 'no-audit'; reason: 'non-auditable' };
     Method: 'POST';
     Path: '/api/v1/account/managed/signup';
     Body: {
@@ -155,7 +155,7 @@ export type PostManagedSignup = ApiEndpoint<{
 }>;
 
 export type GetManagedEmailVerification = ApiEndpoint<{
-    Audit: { reason: 'non-auditable' };
+    Audit: { kind: 'no-audit'; reason: 'non-auditable' };
     Method: 'GET';
     Path: '/api/v1/account/managed/verification';
     Error: ApiError<'not_found'>;
@@ -167,7 +167,7 @@ export type GetManagedEmailVerification = ApiEndpoint<{
 }>;
 
 export type PostManagedEmailVerification = ApiEndpoint<{
-    Audit: { reason: 'non-auditable' };
+    Audit: { kind: 'no-audit'; reason: 'non-auditable' };
     Method: 'POST';
     Path: '/api/v1/account/managed/verification';
     Body: {
@@ -182,7 +182,7 @@ export type PostManagedEmailVerification = ApiEndpoint<{
 }>;
 
 export type GetManagedCallback = ApiEndpoint<{
-    Audit: { reason: 'non-auditable' };
+    Audit: { kind: 'no-audit'; reason: 'non-auditable' };
     Method: 'GET';
     Path: '/api/v1/login/callback';
     Querystring: {
@@ -198,7 +198,7 @@ export type GetManagedCallback = ApiEndpoint<{
 }>;
 
 export type GetOnboardingHearAboutUs = ApiEndpoint<{
-    Audit: { reason: 'non-auditable' };
+    Audit: { kind: 'no-audit'; reason: 'non-auditable' };
     Method: 'GET';
     Path: '/api/v1/account/onboarding/hear-about-us';
     Error: ApiError<'unauthorized'>;
@@ -210,7 +210,7 @@ export type GetOnboardingHearAboutUs = ApiEndpoint<{
 }>;
 
 export type PostOnboardingHearAboutUs = ApiEndpoint<{
-    Audit: { reason: 'non-auditable' };
+    Audit: { kind: 'no-audit'; reason: 'non-auditable' };
     Method: 'POST';
     Path: '/api/v1/account/onboarding/hear-about-us';
     Body: {

--- a/packages/types/lib/action/api.ts
+++ b/packages/types/lib/action/api.ts
@@ -6,7 +6,7 @@ export interface AsyncActionResponse {
 }
 
 export type GetAsyncActionResult = ApiEndpoint<{
-    Audit: { audit: false; reason: 'non-auditable' };
+    Audit: { reason: 'non-auditable' };
     Method: 'GET';
     Path: `/action/:id`;
     Params: {
@@ -19,7 +19,7 @@ export type GetAsyncActionResult = ApiEndpoint<{
 }>;
 
 export type PostPublicTriggerAction = ApiEndpoint<{
-    Audit: { audit: false; reason: 'non-auditable' };
+    Audit: { reason: 'non-auditable' };
     Method: 'POST';
     Path: '/action/trigger';
     Body: {
@@ -36,7 +36,7 @@ export type PostPublicTriggerAction = ApiEndpoint<{
 }>;
 
 export type PostInternalTriggerFunction = ApiEndpoint<{
-    Audit: { audit: false; reason: 'non-auditable' };
+    Audit: { reason: 'non-auditable' };
     Method: 'POST';
     Path: '/api/v1/trigger/function';
     Body: {
@@ -52,7 +52,7 @@ export type PostInternalTriggerFunction = ApiEndpoint<{
 
 /** @deprecated Use POST /action/trigger to trigger actions and GET /records to fetch sync records instead. */
 export type GetPublicV1 = ApiEndpoint<{
-    Audit: { audit: false; reason: 'non-auditable' };
+    Audit: { reason: 'non-auditable' };
     Method: 'GET';
     Path: `/v1/:path`;
     Params: any;

--- a/packages/types/lib/action/api.ts
+++ b/packages/types/lib/action/api.ts
@@ -1,23 +1,25 @@
-import type { Endpoint } from '../api.js';
+import type { ApiEndpoint } from '../api.js';
 
 export interface AsyncActionResponse {
     id: string;
     statusUrl: string;
 }
 
-export type GetAsyncActionResult = Endpoint<{
+export type GetAsyncActionResult = ApiEndpoint<{
+    Audit: { audit: false; reason: 'non-auditable' };
     Method: 'GET';
     Path: `/action/:id`;
     Params: {
         id: string;
     };
     // This endpoint can actually return any json value (not just object)
-    // but Endpoint definition is not flexible enough to support that.
-    // TODO: fix Endpoint definition to support any json value
+    // but ApiEndpoint definition is not flexible enough to support that.
+    // TODO: fix ApiEndpoint definition to support any json value
     Success: Record<string, any>;
 }>;
 
-export type PostPublicTriggerAction = Endpoint<{
+export type PostPublicTriggerAction = ApiEndpoint<{
+    Audit: { audit: false; reason: 'non-auditable' };
     Method: 'POST';
     Path: '/action/trigger';
     Body: {
@@ -33,7 +35,8 @@ export type PostPublicTriggerAction = Endpoint<{
     Success: any;
 }>;
 
-export type PostInternalTriggerFunction = Endpoint<{
+export type PostInternalTriggerFunction = ApiEndpoint<{
+    Audit: { audit: false; reason: 'non-auditable' };
     Method: 'POST';
     Path: '/api/v1/trigger/function';
     Body: {
@@ -48,7 +51,8 @@ export type PostInternalTriggerFunction = Endpoint<{
 }>;
 
 /** @deprecated Use POST /action/trigger to trigger actions and GET /records to fetch sync records instead. */
-export type GetPublicV1 = Endpoint<{
+export type GetPublicV1 = ApiEndpoint<{
+    Audit: { audit: false; reason: 'non-auditable' };
     Method: 'GET';
     Path: `/v1/:path`;
     Params: any;

--- a/packages/types/lib/action/api.ts
+++ b/packages/types/lib/action/api.ts
@@ -6,7 +6,7 @@ export interface AsyncActionResponse {
 }
 
 export type GetAsyncActionResult = ApiEndpoint<{
-    Audit: { reason: 'non-auditable' };
+    Audit: { kind: 'no-audit'; reason: 'non-auditable' };
     Method: 'GET';
     Path: `/action/:id`;
     Params: {
@@ -19,7 +19,7 @@ export type GetAsyncActionResult = ApiEndpoint<{
 }>;
 
 export type PostPublicTriggerAction = ApiEndpoint<{
-    Audit: { reason: 'non-auditable' };
+    Audit: { kind: 'no-audit'; reason: 'non-auditable' };
     Method: 'POST';
     Path: '/action/trigger';
     Body: {
@@ -36,7 +36,7 @@ export type PostPublicTriggerAction = ApiEndpoint<{
 }>;
 
 export type PostInternalTriggerFunction = ApiEndpoint<{
-    Audit: { reason: 'non-auditable' };
+    Audit: { kind: 'no-audit'; reason: 'non-auditable' };
     Method: 'POST';
     Path: '/api/v1/trigger/function';
     Body: {
@@ -52,7 +52,7 @@ export type PostInternalTriggerFunction = ApiEndpoint<{
 
 /** @deprecated Use POST /action/trigger to trigger actions and GET /records to fetch sync records instead. */
 export type GetPublicV1 = ApiEndpoint<{
-    Audit: { reason: 'non-auditable' };
+    Audit: { kind: 'no-audit'; reason: 'non-auditable' };
     Method: 'GET';
     Path: `/v1/:path`;
     Params: any;

--- a/packages/types/lib/admin/http.api.ts
+++ b/packages/types/lib/admin/http.api.ts
@@ -1,6 +1,7 @@
-import type { Endpoint } from '../index.js';
+import type { ApiEndpoint } from '../index.js';
 
-export type PostImpersonate = Endpoint<{
+export type PostImpersonate = ApiEndpoint<{
+    Audit: { audit: false; reason: 'TODO: audit coverage pending' };
     Method: 'POST';
     Path: `/api/v1/admin/impersonate`;
     Querystring: {

--- a/packages/types/lib/admin/http.api.ts
+++ b/packages/types/lib/admin/http.api.ts
@@ -1,7 +1,7 @@
 import type { ApiEndpoint } from '../index.js';
 
 export type PostImpersonate = ApiEndpoint<{
-    Audit: { reason: 'TODO: audit coverage pending' };
+    Audit: { kind: 'no-audit'; reason: 'TODO: audit coverage pending' };
     Method: 'POST';
     Path: `/api/v1/admin/impersonate`;
     Querystring: {

--- a/packages/types/lib/admin/http.api.ts
+++ b/packages/types/lib/admin/http.api.ts
@@ -1,7 +1,7 @@
 import type { ApiEndpoint } from '../index.js';
 
 export type PostImpersonate = ApiEndpoint<{
-    Audit: { audit: false; reason: 'TODO: audit coverage pending' };
+    Audit: { reason: 'TODO: audit coverage pending' };
     Method: 'POST';
     Path: `/api/v1/admin/impersonate`;
     Querystring: {

--- a/packages/types/lib/api.ts
+++ b/packages/types/lib/api.ts
@@ -1,4 +1,4 @@
-import type { EndpointAuditPolicy } from './audit-trail/event.js';
+import type { EndpointAudit } from './audit-trail/event.js';
 import type { RunnerOutputError } from './runner/index.js';
 
 export interface ApiError<TCode extends string, TErrors = Error[] | ValidationError[] | undefined, TPayload = unknown> {
@@ -104,10 +104,10 @@ export interface Endpoint<T extends EndpointDefinition> {
 }
 
 // Customer-facing API endpoints declare an audit policy: the audit event they record, or an explicit
-// `NoAuditEvent` opt-out. This makes audit coverage a compile-time decision — a customer endpoint cannot
+// `NoAudit` opt-out. This makes audit coverage a compile-time decision — a customer endpoint cannot
 // be added without consciously opting in or out. Internal service routes keep using `Endpoint`.
 export interface ApiEndpointDefinition extends EndpointDefinition {
-    Audit: EndpointAuditPolicy;
+    Audit: EndpointAudit;
 }
 export type ApiEndpoint<T extends ApiEndpointDefinition> = Endpoint<T> & { Audit: T['Audit'] };
 

--- a/packages/types/lib/api.ts
+++ b/packages/types/lib/api.ts
@@ -1,3 +1,4 @@
+import type { EndpointAuditPolicy } from './audit-trail/event.js';
 import type { RunnerOutputError } from './runner/index.js';
 
 export interface ApiError<TCode extends string, TErrors = Error[] | ValidationError[] | undefined, TPayload = unknown> {
@@ -101,6 +102,14 @@ export interface Endpoint<T extends EndpointDefinition> {
      */
     Reply: ResDefaultErrors | (T['Error'] extends ApiError<any> ? T['Error'] | T['Success'] : T['Success']);
 }
+
+// Customer-facing API endpoints declare an audit policy: the audit event they record, or an explicit
+// `NoAuditEvent` opt-out. This makes audit coverage a compile-time decision — a customer endpoint cannot
+// be added without consciously opting in or out. Internal service routes keep using `Endpoint`.
+export interface ApiEndpointDefinition extends EndpointDefinition {
+    Audit: EndpointAuditPolicy;
+}
+export type ApiEndpoint<T extends ApiEndpointDefinition> = Endpoint<T> & { Audit: T['Audit'] };
 
 export interface ErrorPayload {
     type: string;

--- a/packages/types/lib/audit-trail/api.ts
+++ b/packages/types/lib/audit-trail/api.ts
@@ -22,7 +22,7 @@ export interface ApiAuditTrailEvent {
 }
 
 export type GetAuditTrail = ApiEndpoint<{
-    Audit: { audit: false; reason: 'non-auditable' };
+    Audit: { reason: 'non-auditable' };
     Method: 'GET';
     Path: '/api/v1/audit-trail';
     Querystring: {

--- a/packages/types/lib/audit-trail/api.ts
+++ b/packages/types/lib/audit-trail/api.ts
@@ -1,4 +1,4 @@
-import type { Endpoint } from '../api.js';
+import type { ApiEndpoint } from '../api.js';
 import type { AuditAction, AuditActor, AuditContext, AuditOutcome, AuditResource, AuditTarget, AuditTrailVersion } from './event.js';
 
 // The audit event returned to the dashboard — the stored blob, parsed. Typed strictly for the current
@@ -21,7 +21,8 @@ export interface ApiAuditTrailEvent {
     metadata?: Record<string, unknown>;
 }
 
-export type GetAuditTrail = Endpoint<{
+export type GetAuditTrail = ApiEndpoint<{
+    Audit: { audit: false; reason: 'non-auditable' };
     Method: 'GET';
     Path: '/api/v1/audit-trail';
     Querystring: {

--- a/packages/types/lib/audit-trail/api.ts
+++ b/packages/types/lib/audit-trail/api.ts
@@ -22,7 +22,7 @@ export interface ApiAuditTrailEvent {
 }
 
 export type GetAuditTrail = ApiEndpoint<{
-    Audit: { reason: 'non-auditable' };
+    Audit: { kind: 'no-audit'; reason: 'non-auditable' };
     Method: 'GET';
     Path: '/api/v1/audit-trail';
     Querystring: {

--- a/packages/types/lib/audit-trail/event.ts
+++ b/packages/types/lib/audit-trail/event.ts
@@ -23,3 +23,17 @@ export interface AuditContext {
     ip?: string;
     userAgent?: string;
 }
+
+// Every endpoint must declare an audit policy on its `Endpoint` definition: either the audit event it
+// records, or an explicit `NoAuditEvent` opt-out. This makes audit coverage a compile-time decision —
+// a new endpoint cannot be added without consciously opting in or out.
+export interface AuditEndpointEvent {
+    resource: AuditResource;
+    action: AuditAction;
+    scope: 'account' | 'environment';
+}
+export interface NoAuditEvent {
+    audit: false;
+    reason: string;
+}
+export type EndpointAuditPolicy = AuditEndpointEvent | NoAuditEvent;

--- a/packages/types/lib/audit-trail/event.ts
+++ b/packages/types/lib/audit-trail/event.ts
@@ -25,15 +25,35 @@ export interface AuditContext {
     userAgent?: string;
 }
 
-// Every endpoint must declare an audit policy on its `Endpoint` definition: either the audit event it
-// records, or an explicit `NoAuditEvent` opt-out. This makes audit coverage a compile-time decision —
-// a new endpoint cannot be added without consciously opting in or out.
-export interface AuditEndpointEvent {
+// Every endpoint declares an audit policy on its `ApiEndpoint` definition: either the audit event it
+// records (`AuditEndpointPolicy`) or an explicit `NoAudit` opt-out. This makes audit coverage a
+// compile-time decision — a customer endpoint cannot be added without consciously opting in or out.
+export interface AuditEndpointPolicy {
+    kind: 'audit';
     resource: AuditResource;
     action: AuditAction;
     scope: AuditScope;
 }
-export interface NoAuditEvent {
-    reason: string;
+export interface NoAudit<Reason extends string = 'non-auditable'> {
+    kind: 'no-audit';
+    reason: Reason;
 }
-export type EndpointAuditPolicy = AuditEndpointEvent | NoAuditEvent;
+export type EndpointAudit = AuditEndpointPolicy | NoAudit<string>;
+
+// Constructors for the policies above — `auditable()` stamps `kind: 'audit'` so each identity is
+// authored once (in `auditPolicies`) and referenced from both the endpoint type and the middleware.
+export const Audit = {
+    auditable: <R extends AuditResource, A extends AuditAction, S extends AuditScope>(policy: {
+        resource: R;
+        action: A;
+        scope: S;
+    }): { kind: 'audit'; resource: R; action: A; scope: S } => ({ kind: 'audit', ...policy }),
+    notAuditable: <Reason extends string = 'non-auditable'>(reason: Reason = 'non-auditable' as Reason): NoAudit<Reason> => ({ kind: 'no-audit', reason })
+} as const;
+
+// The single source of truth for each audited endpoint's identity. Endpoint types reference an entry
+// via `typeof auditPolicies.x`; the audit middleware spreads the same entry — so the two cannot drift.
+export const auditPolicies = {
+    connectionDeleted: Audit.auditable({ resource: 'connection', action: 'deleted', scope: 'environment' }),
+    memberRoleChanged: Audit.auditable({ resource: 'member', action: 'role_changed', scope: 'account' })
+} as const;

--- a/packages/types/lib/audit-trail/event.ts
+++ b/packages/types/lib/audit-trail/event.ts
@@ -6,6 +6,7 @@ export type AuditTargetType = 'connection' | 'member';
 export type AuditOutcome = 'success' | 'failure' | 'denied';
 export type AuditResource = 'connection' | 'member';
 export type AuditAction = 'deleted' | 'role_changed';
+export type AuditScope = 'account' | 'environment';
 
 export interface AuditActor {
     type: AuditActorType;
@@ -30,10 +31,9 @@ export interface AuditContext {
 export interface AuditEndpointEvent {
     resource: AuditResource;
     action: AuditAction;
-    scope: 'account' | 'environment';
+    scope: AuditScope;
 }
 export interface NoAuditEvent {
-    audit: false;
     reason: string;
 }
 export type EndpointAuditPolicy = AuditEndpointEvent | NoAuditEvent;

--- a/packages/types/lib/auth/http.api.ts
+++ b/packages/types/lib/auth/http.api.ts
@@ -51,7 +51,7 @@ type AuthErrors =
     | ApiError<'connection_validation_failed'>;
 
 export type PostPublicApiKeyAuthorization = ApiEndpoint<{
-    Audit: { reason: 'TODO: audit coverage pending' };
+    Audit: { kind: 'no-audit'; reason: 'TODO: audit coverage pending' };
     Method: 'POST';
     Body: {
         apiKey: string;
@@ -66,7 +66,7 @@ export type PostPublicApiKeyAuthorization = ApiEndpoint<{
 }>;
 
 export type PostPublicAppStoreAuthorization = ApiEndpoint<{
-    Audit: { reason: 'TODO: audit coverage pending' };
+    Audit: { kind: 'no-audit'; reason: 'TODO: audit coverage pending' };
     Method: 'POST';
     Body: {
         privateKeyId: string;
@@ -84,7 +84,7 @@ export type PostPublicAppStoreAuthorization = ApiEndpoint<{
 }>;
 
 export type PostPublicBasicAuthorization = ApiEndpoint<{
-    Audit: { reason: 'TODO: audit coverage pending' };
+    Audit: { kind: 'no-audit'; reason: 'TODO: audit coverage pending' };
     Method: 'POST';
     Body: {
         username: string;
@@ -100,7 +100,7 @@ export type PostPublicBasicAuthorization = ApiEndpoint<{
 }>;
 
 export type PostPublicTbaAuthorization = ApiEndpoint<{
-    Audit: { reason: 'TODO: audit coverage pending' };
+    Audit: { kind: 'no-audit'; reason: 'TODO: audit coverage pending' };
     Method: 'POST';
     Body: {
         token_id: string;
@@ -119,7 +119,7 @@ export type PostPublicTbaAuthorization = ApiEndpoint<{
 }>;
 
 export type PostPublicJwtAuthorization = ApiEndpoint<{
-    Audit: { reason: 'TODO: audit coverage pending' };
+    Audit: { kind: 'no-audit'; reason: 'TODO: audit coverage pending' };
     Method: 'POST';
     Body: Record<string, any>;
     Querystring: ConnectionQueryString;
@@ -132,7 +132,7 @@ export type PostPublicJwtAuthorization = ApiEndpoint<{
 }>;
 
 export type PostPublicUnauthenticatedAuthorization = ApiEndpoint<{
-    Audit: { reason: 'TODO: audit coverage pending' };
+    Audit: { kind: 'no-audit'; reason: 'TODO: audit coverage pending' };
     Method: 'POST';
     Querystring: ConnectionQueryString;
     Params: {
@@ -144,7 +144,7 @@ export type PostPublicUnauthenticatedAuthorization = ApiEndpoint<{
 }>;
 
 export type PostPublicBillAuthorization = ApiEndpoint<{
-    Audit: { reason: 'TODO: audit coverage pending' };
+    Audit: { kind: 'no-audit'; reason: 'TODO: audit coverage pending' };
     Method: 'POST';
     Body: {
         username: string;
@@ -162,7 +162,7 @@ export type PostPublicBillAuthorization = ApiEndpoint<{
 }>;
 
 export type PostPublicTwoStepAuthorization = ApiEndpoint<{
-    Audit: { reason: 'TODO: audit coverage pending' };
+    Audit: { kind: 'no-audit'; reason: 'TODO: audit coverage pending' };
     Method: 'POST';
     Body: Record<string, any>;
     Querystring: ConnectionQueryString;
@@ -175,7 +175,7 @@ export type PostPublicTwoStepAuthorization = ApiEndpoint<{
 }>;
 
 export type PostPublicSignatureAuthorization = ApiEndpoint<{
-    Audit: { reason: 'TODO: audit coverage pending' };
+    Audit: { kind: 'no-audit'; reason: 'TODO: audit coverage pending' };
     Method: 'POST';
     Body: {
         username: string;
@@ -200,7 +200,7 @@ type AwsSigV4AuthErrors =
     | ApiError<'aws_sigv4_sts_request_failed'>;
 
 export type PostPublicAwsSigV4Authorization = ApiEndpoint<{
-    Audit: { reason: 'TODO: audit coverage pending' };
+    Audit: { kind: 'no-audit'; reason: 'TODO: audit coverage pending' };
     Method: 'POST';
     Body: {
         role_arn: string;
@@ -216,7 +216,7 @@ export type PostPublicAwsSigV4Authorization = ApiEndpoint<{
 }>;
 
 export type PostPublicOauthOutboundAuthorization = ApiEndpoint<{
-    Audit: { reason: 'TODO: audit coverage pending' };
+    Audit: { kind: 'no-audit'; reason: 'TODO: audit coverage pending' };
     Method: 'POST';
     Body: {
         username: string;

--- a/packages/types/lib/auth/http.api.ts
+++ b/packages/types/lib/auth/http.api.ts
@@ -1,4 +1,4 @@
-import type { ApiError, Endpoint } from '../api.js';
+import type { ApiEndpoint, ApiError } from '../api.js';
 
 export type ConnectionQueryString = {
     connection_id?: string | undefined;
@@ -50,7 +50,8 @@ type AuthErrors =
     | ApiError<'connection_test_failed'>
     | ApiError<'connection_validation_failed'>;
 
-export type PostPublicApiKeyAuthorization = Endpoint<{
+export type PostPublicApiKeyAuthorization = ApiEndpoint<{
+    Audit: { audit: false; reason: 'TODO: audit coverage pending' };
     Method: 'POST';
     Body: {
         apiKey: string;
@@ -64,7 +65,8 @@ export type PostPublicApiKeyAuthorization = Endpoint<{
     Success: ConnectionResponseSuccess;
 }>;
 
-export type PostPublicAppStoreAuthorization = Endpoint<{
+export type PostPublicAppStoreAuthorization = ApiEndpoint<{
+    Audit: { audit: false; reason: 'TODO: audit coverage pending' };
     Method: 'POST';
     Body: {
         privateKeyId: string;
@@ -81,7 +83,8 @@ export type PostPublicAppStoreAuthorization = Endpoint<{
     Success: ConnectionResponseSuccess;
 }>;
 
-export type PostPublicBasicAuthorization = Endpoint<{
+export type PostPublicBasicAuthorization = ApiEndpoint<{
+    Audit: { audit: false; reason: 'TODO: audit coverage pending' };
     Method: 'POST';
     Body: {
         username: string;
@@ -96,7 +99,8 @@ export type PostPublicBasicAuthorization = Endpoint<{
     Success: ConnectionResponseSuccess;
 }>;
 
-export type PostPublicTbaAuthorization = Endpoint<{
+export type PostPublicTbaAuthorization = ApiEndpoint<{
+    Audit: { audit: false; reason: 'TODO: audit coverage pending' };
     Method: 'POST';
     Body: {
         token_id: string;
@@ -114,7 +118,8 @@ export type PostPublicTbaAuthorization = Endpoint<{
     Success: ConnectionResponseSuccess;
 }>;
 
-export type PostPublicJwtAuthorization = Endpoint<{
+export type PostPublicJwtAuthorization = ApiEndpoint<{
+    Audit: { audit: false; reason: 'TODO: audit coverage pending' };
     Method: 'POST';
     Body: Record<string, any>;
     Querystring: ConnectionQueryString;
@@ -126,7 +131,8 @@ export type PostPublicJwtAuthorization = Endpoint<{
     Success: ConnectionResponseSuccess;
 }>;
 
-export type PostPublicUnauthenticatedAuthorization = Endpoint<{
+export type PostPublicUnauthenticatedAuthorization = ApiEndpoint<{
+    Audit: { audit: false; reason: 'TODO: audit coverage pending' };
     Method: 'POST';
     Querystring: ConnectionQueryString;
     Params: {
@@ -137,7 +143,8 @@ export type PostPublicUnauthenticatedAuthorization = Endpoint<{
     Success: ConnectionResponseSuccess;
 }>;
 
-export type PostPublicBillAuthorization = Endpoint<{
+export type PostPublicBillAuthorization = ApiEndpoint<{
+    Audit: { audit: false; reason: 'TODO: audit coverage pending' };
     Method: 'POST';
     Body: {
         username: string;
@@ -154,7 +161,8 @@ export type PostPublicBillAuthorization = Endpoint<{
     Success: ConnectionResponseSuccess;
 }>;
 
-export type PostPublicTwoStepAuthorization = Endpoint<{
+export type PostPublicTwoStepAuthorization = ApiEndpoint<{
+    Audit: { audit: false; reason: 'TODO: audit coverage pending' };
     Method: 'POST';
     Body: Record<string, any>;
     Querystring: ConnectionQueryString;
@@ -166,7 +174,8 @@ export type PostPublicTwoStepAuthorization = Endpoint<{
     Success: ConnectionResponseSuccess;
 }>;
 
-export type PostPublicSignatureAuthorization = Endpoint<{
+export type PostPublicSignatureAuthorization = ApiEndpoint<{
+    Audit: { audit: false; reason: 'TODO: audit coverage pending' };
     Method: 'POST';
     Body: {
         username: string;
@@ -190,7 +199,8 @@ type AwsSigV4AuthErrors =
     | ApiError<'missing_aws_sigv4_region'>
     | ApiError<'aws_sigv4_sts_request_failed'>;
 
-export type PostPublicAwsSigV4Authorization = Endpoint<{
+export type PostPublicAwsSigV4Authorization = ApiEndpoint<{
+    Audit: { audit: false; reason: 'TODO: audit coverage pending' };
     Method: 'POST';
     Body: {
         role_arn: string;
@@ -205,7 +215,8 @@ export type PostPublicAwsSigV4Authorization = Endpoint<{
     Success: ConnectionResponseSuccess;
 }>;
 
-export type PostPublicOauthOutboundAuthorization = Endpoint<{
+export type PostPublicOauthOutboundAuthorization = ApiEndpoint<{
+    Audit: { audit: false; reason: 'TODO: audit coverage pending' };
     Method: 'POST';
     Body: {
         username: string;

--- a/packages/types/lib/auth/http.api.ts
+++ b/packages/types/lib/auth/http.api.ts
@@ -51,7 +51,7 @@ type AuthErrors =
     | ApiError<'connection_validation_failed'>;
 
 export type PostPublicApiKeyAuthorization = ApiEndpoint<{
-    Audit: { audit: false; reason: 'TODO: audit coverage pending' };
+    Audit: { reason: 'TODO: audit coverage pending' };
     Method: 'POST';
     Body: {
         apiKey: string;
@@ -66,7 +66,7 @@ export type PostPublicApiKeyAuthorization = ApiEndpoint<{
 }>;
 
 export type PostPublicAppStoreAuthorization = ApiEndpoint<{
-    Audit: { audit: false; reason: 'TODO: audit coverage pending' };
+    Audit: { reason: 'TODO: audit coverage pending' };
     Method: 'POST';
     Body: {
         privateKeyId: string;
@@ -84,7 +84,7 @@ export type PostPublicAppStoreAuthorization = ApiEndpoint<{
 }>;
 
 export type PostPublicBasicAuthorization = ApiEndpoint<{
-    Audit: { audit: false; reason: 'TODO: audit coverage pending' };
+    Audit: { reason: 'TODO: audit coverage pending' };
     Method: 'POST';
     Body: {
         username: string;
@@ -100,7 +100,7 @@ export type PostPublicBasicAuthorization = ApiEndpoint<{
 }>;
 
 export type PostPublicTbaAuthorization = ApiEndpoint<{
-    Audit: { audit: false; reason: 'TODO: audit coverage pending' };
+    Audit: { reason: 'TODO: audit coverage pending' };
     Method: 'POST';
     Body: {
         token_id: string;
@@ -119,7 +119,7 @@ export type PostPublicTbaAuthorization = ApiEndpoint<{
 }>;
 
 export type PostPublicJwtAuthorization = ApiEndpoint<{
-    Audit: { audit: false; reason: 'TODO: audit coverage pending' };
+    Audit: { reason: 'TODO: audit coverage pending' };
     Method: 'POST';
     Body: Record<string, any>;
     Querystring: ConnectionQueryString;
@@ -132,7 +132,7 @@ export type PostPublicJwtAuthorization = ApiEndpoint<{
 }>;
 
 export type PostPublicUnauthenticatedAuthorization = ApiEndpoint<{
-    Audit: { audit: false; reason: 'TODO: audit coverage pending' };
+    Audit: { reason: 'TODO: audit coverage pending' };
     Method: 'POST';
     Querystring: ConnectionQueryString;
     Params: {
@@ -144,7 +144,7 @@ export type PostPublicUnauthenticatedAuthorization = ApiEndpoint<{
 }>;
 
 export type PostPublicBillAuthorization = ApiEndpoint<{
-    Audit: { audit: false; reason: 'TODO: audit coverage pending' };
+    Audit: { reason: 'TODO: audit coverage pending' };
     Method: 'POST';
     Body: {
         username: string;
@@ -162,7 +162,7 @@ export type PostPublicBillAuthorization = ApiEndpoint<{
 }>;
 
 export type PostPublicTwoStepAuthorization = ApiEndpoint<{
-    Audit: { audit: false; reason: 'TODO: audit coverage pending' };
+    Audit: { reason: 'TODO: audit coverage pending' };
     Method: 'POST';
     Body: Record<string, any>;
     Querystring: ConnectionQueryString;
@@ -175,7 +175,7 @@ export type PostPublicTwoStepAuthorization = ApiEndpoint<{
 }>;
 
 export type PostPublicSignatureAuthorization = ApiEndpoint<{
-    Audit: { audit: false; reason: 'TODO: audit coverage pending' };
+    Audit: { reason: 'TODO: audit coverage pending' };
     Method: 'POST';
     Body: {
         username: string;
@@ -200,7 +200,7 @@ type AwsSigV4AuthErrors =
     | ApiError<'aws_sigv4_sts_request_failed'>;
 
 export type PostPublicAwsSigV4Authorization = ApiEndpoint<{
-    Audit: { audit: false; reason: 'TODO: audit coverage pending' };
+    Audit: { reason: 'TODO: audit coverage pending' };
     Method: 'POST';
     Body: {
         role_arn: string;
@@ -216,7 +216,7 @@ export type PostPublicAwsSigV4Authorization = ApiEndpoint<{
 }>;
 
 export type PostPublicOauthOutboundAuthorization = ApiEndpoint<{
-    Audit: { audit: false; reason: 'TODO: audit coverage pending' };
+    Audit: { reason: 'TODO: audit coverage pending' };
     Method: 'POST';
     Body: {
         username: string;

--- a/packages/types/lib/billing/http.api.ts
+++ b/packages/types/lib/billing/http.api.ts
@@ -1,7 +1,7 @@
 import type { ApiEndpoint } from '../api.js';
 
 export type PostOrbWebhooks = ApiEndpoint<{
-    Audit: { audit: false; reason: 'non-auditable' };
+    Audit: { reason: 'non-auditable' };
     Method: 'POST';
     Path: '/api/v1/orb/webhooks';
     Body: any;

--- a/packages/types/lib/billing/http.api.ts
+++ b/packages/types/lib/billing/http.api.ts
@@ -1,6 +1,7 @@
-import type { Endpoint } from '../api.js';
+import type { ApiEndpoint } from '../api.js';
 
-export type PostOrbWebhooks = Endpoint<{
+export type PostOrbWebhooks = ApiEndpoint<{
+    Audit: { audit: false; reason: 'non-auditable' };
     Method: 'POST';
     Path: '/api/v1/orb/webhooks';
     Body: any;

--- a/packages/types/lib/billing/http.api.ts
+++ b/packages/types/lib/billing/http.api.ts
@@ -1,7 +1,7 @@
 import type { ApiEndpoint } from '../api.js';
 
 export type PostOrbWebhooks = ApiEndpoint<{
-    Audit: { reason: 'non-auditable' };
+    Audit: { kind: 'no-audit'; reason: 'non-auditable' };
     Method: 'POST';
     Path: '/api/v1/orb/webhooks';
     Body: any;

--- a/packages/types/lib/cli/api.ts
+++ b/packages/types/lib/cli/api.ts
@@ -1,4 +1,4 @@
-import type { Endpoint } from '../api.js';
+import type { ApiEndpoint } from '../api.js';
 
 export type CliTelemetryEvent =
     | 'cli:init'
@@ -13,7 +13,8 @@ export type CliTelemetryEvent =
     | 'cli:deploy'
     | 'cli:pull';
 
-export type PostCliTelemetry = Endpoint<{
+export type PostCliTelemetry = ApiEndpoint<{
+    Audit: { audit: false; reason: 'non-auditable' };
     Method: 'POST';
     Path: '/cli/telemetry';
     Body: {

--- a/packages/types/lib/cli/api.ts
+++ b/packages/types/lib/cli/api.ts
@@ -14,7 +14,7 @@ export type CliTelemetryEvent =
     | 'cli:pull';
 
 export type PostCliTelemetry = ApiEndpoint<{
-    Audit: { reason: 'non-auditable' };
+    Audit: { kind: 'no-audit'; reason: 'non-auditable' };
     Method: 'POST';
     Path: '/cli/telemetry';
     Body: {

--- a/packages/types/lib/cli/api.ts
+++ b/packages/types/lib/cli/api.ts
@@ -14,7 +14,7 @@ export type CliTelemetryEvent =
     | 'cli:pull';
 
 export type PostCliTelemetry = ApiEndpoint<{
-    Audit: { audit: false; reason: 'non-auditable' };
+    Audit: { reason: 'non-auditable' };
     Method: 'POST';
     Path: '/cli/telemetry';
     Body: {

--- a/packages/types/lib/clientMetadata/http.api.ts
+++ b/packages/types/lib/clientMetadata/http.api.ts
@@ -1,6 +1,7 @@
-import type { ApiError, Endpoint } from '../api.js';
+import type { ApiEndpoint, ApiError } from '../api.js';
 
-export type GetPublicClientMetadata = Endpoint<{
+export type GetPublicClientMetadata = ApiEndpoint<{
+    Audit: { audit: false; reason: 'non-auditable' };
     Method: 'GET';
     Path: '/oauth/client-metadata/:environmentUuid/:providerConfigKey';
     Params: {

--- a/packages/types/lib/clientMetadata/http.api.ts
+++ b/packages/types/lib/clientMetadata/http.api.ts
@@ -1,7 +1,7 @@
 import type { ApiEndpoint, ApiError } from '../api.js';
 
 export type GetPublicClientMetadata = ApiEndpoint<{
-    Audit: { audit: false; reason: 'non-auditable' };
+    Audit: { reason: 'non-auditable' };
     Method: 'GET';
     Path: '/oauth/client-metadata/:environmentUuid/:providerConfigKey';
     Params: {

--- a/packages/types/lib/clientMetadata/http.api.ts
+++ b/packages/types/lib/clientMetadata/http.api.ts
@@ -1,7 +1,7 @@
 import type { ApiEndpoint, ApiError } from '../api.js';
 
 export type GetPublicClientMetadata = ApiEndpoint<{
-    Audit: { reason: 'non-auditable' };
+    Audit: { kind: 'no-audit'; reason: 'non-auditable' };
     Method: 'GET';
     Path: '/oauth/client-metadata/:environmentUuid/:providerConfigKey';
     Params: {

--- a/packages/types/lib/connect/api.ts
+++ b/packages/types/lib/connect/api.ts
@@ -56,7 +56,7 @@ export type PostConnectSessionsBody =
       });
 
 export type PostConnectSessions = ApiEndpoint<{
-    Audit: { reason: 'non-auditable' };
+    Audit: { kind: 'no-audit'; reason: 'non-auditable' };
     Method: 'POST';
     Path: '/connect/sessions';
     Body: PostConnectSessionsBody;
@@ -70,7 +70,7 @@ export type PostConnectSessions = ApiEndpoint<{
 }>;
 
 export type PostPublicConnectSessionsReconnect = ApiEndpoint<{
-    Audit: { reason: 'non-auditable' };
+    Audit: { kind: 'no-audit'; reason: 'non-auditable' };
     Method: 'POST';
     Path: '/connect/sessions/reconnect';
     Body: {
@@ -93,7 +93,7 @@ export type PostPublicConnectSessionsReconnect = ApiEndpoint<{
 }>;
 
 export type GetConnectSession = ApiEndpoint<{
-    Audit: { reason: 'non-auditable' };
+    Audit: { kind: 'no-audit'; reason: 'non-auditable' };
     Method: 'GET';
     Path: '/connect/session';
     Success: {
@@ -102,14 +102,14 @@ export type GetConnectSession = ApiEndpoint<{
 }>;
 
 export type DeleteConnectSession = ApiEndpoint<{
-    Audit: { reason: 'non-auditable' };
+    Audit: { kind: 'no-audit'; reason: 'non-auditable' };
     Method: 'DELETE';
     Path: '/connect/session';
     Success: never;
 }>;
 
 export type PostInternalConnectSessions = ApiEndpoint<{
-    Audit: { reason: 'non-auditable' };
+    Audit: { kind: 'no-audit'; reason: 'non-auditable' };
     Method: 'POST';
     Path: '/api/v1/connect/sessions';
     Success: PostConnectSessions['Success'];
@@ -120,7 +120,7 @@ export type PostInternalConnectSessions = ApiEndpoint<{
 }>;
 
 export type PostPublicConnectTelemetry = ApiEndpoint<{
-    Audit: { reason: 'non-auditable' };
+    Audit: { kind: 'no-audit'; reason: 'non-auditable' };
     Method: 'POST';
     Path: '/connect/telemetry';
     Body: {

--- a/packages/types/lib/connect/api.ts
+++ b/packages/types/lib/connect/api.ts
@@ -1,4 +1,4 @@
-import type { Endpoint } from '../api.js';
+import type { ApiEndpoint } from '../api.js';
 import type { ConnectUISettings } from '../connectUISettings/dto.js';
 import type { ApiEndUser } from '../endUser/index.js';
 
@@ -55,7 +55,8 @@ export type PostConnectSessionsBody =
           end_user?: ConnectSessionInput['end_user'] | undefined;
       });
 
-export type PostConnectSessions = Endpoint<{
+export type PostConnectSessions = ApiEndpoint<{
+    Audit: { audit: false; reason: 'non-auditable' };
     Method: 'POST';
     Path: '/connect/sessions';
     Body: PostConnectSessionsBody;
@@ -68,7 +69,8 @@ export type PostConnectSessions = Endpoint<{
     };
 }>;
 
-export type PostPublicConnectSessionsReconnect = Endpoint<{
+export type PostPublicConnectSessionsReconnect = ApiEndpoint<{
+    Audit: { audit: false; reason: 'non-auditable' };
     Method: 'POST';
     Path: '/connect/sessions/reconnect';
     Body: {
@@ -90,7 +92,8 @@ export type PostPublicConnectSessionsReconnect = Endpoint<{
     };
 }>;
 
-export type GetConnectSession = Endpoint<{
+export type GetConnectSession = ApiEndpoint<{
+    Audit: { audit: false; reason: 'non-auditable' };
     Method: 'GET';
     Path: '/connect/session';
     Success: {
@@ -98,13 +101,15 @@ export type GetConnectSession = Endpoint<{
     };
 }>;
 
-export type DeleteConnectSession = Endpoint<{
+export type DeleteConnectSession = ApiEndpoint<{
+    Audit: { audit: false; reason: 'non-auditable' };
     Method: 'DELETE';
     Path: '/connect/session';
     Success: never;
 }>;
 
-export type PostInternalConnectSessions = Endpoint<{
+export type PostInternalConnectSessions = ApiEndpoint<{
+    Audit: { audit: false; reason: 'non-auditable' };
     Method: 'POST';
     Path: '/api/v1/connect/sessions';
     Success: PostConnectSessions['Success'];
@@ -114,7 +119,8 @@ export type PostInternalConnectSessions = Endpoint<{
     >;
 }>;
 
-export type PostPublicConnectTelemetry = Endpoint<{
+export type PostPublicConnectTelemetry = ApiEndpoint<{
+    Audit: { audit: false; reason: 'non-auditable' };
     Method: 'POST';
     Path: '/connect/telemetry';
     Body: {

--- a/packages/types/lib/connect/api.ts
+++ b/packages/types/lib/connect/api.ts
@@ -56,7 +56,7 @@ export type PostConnectSessionsBody =
       });
 
 export type PostConnectSessions = ApiEndpoint<{
-    Audit: { audit: false; reason: 'non-auditable' };
+    Audit: { reason: 'non-auditable' };
     Method: 'POST';
     Path: '/connect/sessions';
     Body: PostConnectSessionsBody;
@@ -70,7 +70,7 @@ export type PostConnectSessions = ApiEndpoint<{
 }>;
 
 export type PostPublicConnectSessionsReconnect = ApiEndpoint<{
-    Audit: { audit: false; reason: 'non-auditable' };
+    Audit: { reason: 'non-auditable' };
     Method: 'POST';
     Path: '/connect/sessions/reconnect';
     Body: {
@@ -93,7 +93,7 @@ export type PostPublicConnectSessionsReconnect = ApiEndpoint<{
 }>;
 
 export type GetConnectSession = ApiEndpoint<{
-    Audit: { audit: false; reason: 'non-auditable' };
+    Audit: { reason: 'non-auditable' };
     Method: 'GET';
     Path: '/connect/session';
     Success: {
@@ -102,14 +102,14 @@ export type GetConnectSession = ApiEndpoint<{
 }>;
 
 export type DeleteConnectSession = ApiEndpoint<{
-    Audit: { audit: false; reason: 'non-auditable' };
+    Audit: { reason: 'non-auditable' };
     Method: 'DELETE';
     Path: '/connect/session';
     Success: never;
 }>;
 
 export type PostInternalConnectSessions = ApiEndpoint<{
-    Audit: { audit: false; reason: 'non-auditable' };
+    Audit: { reason: 'non-auditable' };
     Method: 'POST';
     Path: '/api/v1/connect/sessions';
     Success: PostConnectSessions['Success'];
@@ -120,7 +120,7 @@ export type PostInternalConnectSessions = ApiEndpoint<{
 }>;
 
 export type PostPublicConnectTelemetry = ApiEndpoint<{
-    Audit: { audit: false; reason: 'non-auditable' };
+    Audit: { reason: 'non-auditable' };
     Method: 'POST';
     Path: '/connect/telemetry';
     Body: {

--- a/packages/types/lib/connectUISettings/api.ts
+++ b/packages/types/lib/connectUISettings/api.ts
@@ -1,7 +1,8 @@
-import type { ApiError, Endpoint } from '../api.js';
+import type { ApiEndpoint, ApiError } from '../api.js';
 import type { ConnectUISettings } from './dto.js';
 
-export type GetConnectUISettings = Endpoint<{
+export type GetConnectUISettings = ApiEndpoint<{
+    Audit: { audit: false; reason: 'non-auditable' };
     Method: 'GET';
     Path: '/api/v1/connect-ui-settings';
     Querystring: { env: string };
@@ -11,7 +12,8 @@ export type GetConnectUISettings = Endpoint<{
     Error: ApiError<'failed_to_get_connect_ui_settings'>;
 }>;
 
-export type PutConnectUISettings = Endpoint<{
+export type PutConnectUISettings = ApiEndpoint<{
+    Audit: { audit: false; reason: 'non-auditable' };
     Method: 'PUT';
     Path: '/api/v1/connect-ui-settings';
     Querystring: { env: string };

--- a/packages/types/lib/connectUISettings/api.ts
+++ b/packages/types/lib/connectUISettings/api.ts
@@ -2,7 +2,7 @@ import type { ApiEndpoint, ApiError } from '../api.js';
 import type { ConnectUISettings } from './dto.js';
 
 export type GetConnectUISettings = ApiEndpoint<{
-    Audit: { reason: 'non-auditable' };
+    Audit: { kind: 'no-audit'; reason: 'non-auditable' };
     Method: 'GET';
     Path: '/api/v1/connect-ui-settings';
     Querystring: { env: string };
@@ -13,7 +13,7 @@ export type GetConnectUISettings = ApiEndpoint<{
 }>;
 
 export type PutConnectUISettings = ApiEndpoint<{
-    Audit: { reason: 'non-auditable' };
+    Audit: { kind: 'no-audit'; reason: 'non-auditable' };
     Method: 'PUT';
     Path: '/api/v1/connect-ui-settings';
     Querystring: { env: string };

--- a/packages/types/lib/connectUISettings/api.ts
+++ b/packages/types/lib/connectUISettings/api.ts
@@ -2,7 +2,7 @@ import type { ApiEndpoint, ApiError } from '../api.js';
 import type { ConnectUISettings } from './dto.js';
 
 export type GetConnectUISettings = ApiEndpoint<{
-    Audit: { audit: false; reason: 'non-auditable' };
+    Audit: { reason: 'non-auditable' };
     Method: 'GET';
     Path: '/api/v1/connect-ui-settings';
     Querystring: { env: string };
@@ -13,7 +13,7 @@ export type GetConnectUISettings = ApiEndpoint<{
 }>;
 
 export type PutConnectUISettings = ApiEndpoint<{
-    Audit: { audit: false; reason: 'non-auditable' };
+    Audit: { reason: 'non-auditable' };
     Method: 'PUT';
     Path: '/api/v1/connect-ui-settings';
     Querystring: { env: string };

--- a/packages/types/lib/connection/api/get.ts
+++ b/packages/types/lib/connection/api/get.ts
@@ -1,4 +1,4 @@
-import { auditPolicies } from '../../audit-trail/event.js';
+import type { auditPolicies } from '../../audit-trail/event.js';
 
 import type { ApiEndpoint, ApiError, ApiTimestamps } from '../../api.js';
 import type {

--- a/packages/types/lib/connection/api/get.ts
+++ b/packages/types/lib/connection/api/get.ts
@@ -1,6 +1,5 @@
-import type { auditPolicies } from '../../audit-trail/event.js';
-
 import type { ApiEndpoint, ApiError, ApiTimestamps } from '../../api.js';
+import type { auditPolicies } from '../../audit-trail/event.js';
 import type {
     ApiKeyCredentials,
     ApiPublicAllAuthCredentials,

--- a/packages/types/lib/connection/api/get.ts
+++ b/packages/types/lib/connection/api/get.ts
@@ -27,7 +27,7 @@ export type ApiConnectionSimple = Pick<
     pausedSyncs: string[];
 };
 export type GetConnections = ApiEndpoint<{
-    Audit: { audit: false; reason: 'non-auditable' };
+    Audit: { reason: 'non-auditable' };
     Method: 'GET';
     Querystring: {
         env: string;
@@ -43,7 +43,7 @@ export type GetConnections = ApiEndpoint<{
 }>;
 
 export type GetConnectionsCount = ApiEndpoint<{
-    Audit: { audit: false; reason: 'non-auditable' };
+    Audit: { reason: 'non-auditable' };
     Method: 'GET';
     Querystring: {
         env: string;
@@ -64,7 +64,7 @@ export type ApiPublicConnection = Pick<DBConnection, 'id' | 'connection_id'> & {
     tags: Tags;
 };
 export type GetPublicConnections = ApiEndpoint<{
-    Audit: { audit: false; reason: 'non-auditable' };
+    Audit: { reason: 'non-auditable' };
     Method: 'GET';
     Querystring: {
         connectionId?: string | undefined;
@@ -83,7 +83,7 @@ export type GetPublicConnections = ApiEndpoint<{
 }>;
 
 export type PostPublicConnection = ApiEndpoint<{
-    Audit: { audit: false; reason: 'TODO: audit coverage pending' };
+    Audit: { reason: 'TODO: audit coverage pending' };
     Method: 'POST';
     Path: '/connections';
     Body: {
@@ -124,7 +124,7 @@ export type GetConnection = ApiEndpoint<{
     };
     Path: '/api/v1/connections/:connectionId';
     Error: ApiError<'unknown_provider_config'>;
-    Audit: { audit: false; reason: 'non-auditable' };
+    Audit: { reason: 'non-auditable' };
     Success: {
         data: {
             provider: string;
@@ -148,7 +148,7 @@ export type ApiPublicConnectionFull = Pick<DBConnection, 'id' | 'connection_id' 
     credentials: ApiPublicAllAuthCredentials;
 };
 export type GetPublicConnection = ApiEndpoint<{
-    Audit: { audit: false; reason: 'non-auditable' };
+    Audit: { reason: 'non-auditable' };
     Method: 'GET';
     Params: {
         connectionId: string;
@@ -165,7 +165,7 @@ export type GetPublicConnection = ApiEndpoint<{
 }>;
 
 export type PatchPublicConnection = ApiEndpoint<{
-    Audit: { audit: false; reason: 'TODO: audit coverage pending' };
+    Audit: { reason: 'TODO: audit coverage pending' };
     Method: 'PATCH';
     Path: '/connections/:connectionId';
     Params: {
@@ -184,7 +184,7 @@ export type PatchPublicConnection = ApiEndpoint<{
 }>;
 
 export type PatchConnection = ApiEndpoint<{
-    Audit: { audit: false; reason: 'TODO: audit coverage pending' };
+    Audit: { reason: 'TODO: audit coverage pending' };
     Method: 'PATCH';
     Path: '/api/v1/connections/:connectionId';
     Params: {
@@ -204,7 +204,7 @@ export type PatchConnection = ApiEndpoint<{
 }>;
 
 export type PostConnectionRefresh = ApiEndpoint<{
-    Audit: { audit: false; reason: 'TODO: audit coverage pending' };
+    Audit: { reason: 'TODO: audit coverage pending' };
     Method: 'POST';
     Params: {
         connectionId: string;

--- a/packages/types/lib/connection/api/get.ts
+++ b/packages/types/lib/connection/api/get.ts
@@ -1,3 +1,5 @@
+import { auditPolicies } from '../../audit-trail/event.js';
+
 import type { ApiEndpoint, ApiError, ApiTimestamps } from '../../api.js';
 import type {
     ApiKeyCredentials,
@@ -27,7 +29,7 @@ export type ApiConnectionSimple = Pick<
     pausedSyncs: string[];
 };
 export type GetConnections = ApiEndpoint<{
-    Audit: { reason: 'non-auditable' };
+    Audit: { kind: 'no-audit'; reason: 'non-auditable' };
     Method: 'GET';
     Querystring: {
         env: string;
@@ -43,7 +45,7 @@ export type GetConnections = ApiEndpoint<{
 }>;
 
 export type GetConnectionsCount = ApiEndpoint<{
-    Audit: { reason: 'non-auditable' };
+    Audit: { kind: 'no-audit'; reason: 'non-auditable' };
     Method: 'GET';
     Querystring: {
         env: string;
@@ -64,7 +66,7 @@ export type ApiPublicConnection = Pick<DBConnection, 'id' | 'connection_id'> & {
     tags: Tags;
 };
 export type GetPublicConnections = ApiEndpoint<{
-    Audit: { reason: 'non-auditable' };
+    Audit: { kind: 'no-audit'; reason: 'non-auditable' };
     Method: 'GET';
     Querystring: {
         connectionId?: string | undefined;
@@ -83,7 +85,7 @@ export type GetPublicConnections = ApiEndpoint<{
 }>;
 
 export type PostPublicConnection = ApiEndpoint<{
-    Audit: { reason: 'TODO: audit coverage pending' };
+    Audit: { kind: 'no-audit'; reason: 'TODO: audit coverage pending' };
     Method: 'POST';
     Path: '/connections';
     Body: {
@@ -124,7 +126,7 @@ export type GetConnection = ApiEndpoint<{
     };
     Path: '/api/v1/connections/:connectionId';
     Error: ApiError<'unknown_provider_config'>;
-    Audit: { reason: 'non-auditable' };
+    Audit: { kind: 'no-audit'; reason: 'non-auditable' };
     Success: {
         data: {
             provider: string;
@@ -148,7 +150,7 @@ export type ApiPublicConnectionFull = Pick<DBConnection, 'id' | 'connection_id' 
     credentials: ApiPublicAllAuthCredentials;
 };
 export type GetPublicConnection = ApiEndpoint<{
-    Audit: { reason: 'non-auditable' };
+    Audit: { kind: 'no-audit'; reason: 'non-auditable' };
     Method: 'GET';
     Params: {
         connectionId: string;
@@ -165,7 +167,7 @@ export type GetPublicConnection = ApiEndpoint<{
 }>;
 
 export type PatchPublicConnection = ApiEndpoint<{
-    Audit: { reason: 'TODO: audit coverage pending' };
+    Audit: { kind: 'no-audit'; reason: 'TODO: audit coverage pending' };
     Method: 'PATCH';
     Path: '/connections/:connectionId';
     Params: {
@@ -184,7 +186,7 @@ export type PatchPublicConnection = ApiEndpoint<{
 }>;
 
 export type PatchConnection = ApiEndpoint<{
-    Audit: { reason: 'TODO: audit coverage pending' };
+    Audit: { kind: 'no-audit'; reason: 'TODO: audit coverage pending' };
     Method: 'PATCH';
     Path: '/api/v1/connections/:connectionId';
     Params: {
@@ -204,7 +206,7 @@ export type PatchConnection = ApiEndpoint<{
 }>;
 
 export type PostConnectionRefresh = ApiEndpoint<{
-    Audit: { reason: 'TODO: audit coverage pending' };
+    Audit: { kind: 'no-audit'; reason: 'TODO: audit coverage pending' };
     Method: 'POST';
     Params: {
         connectionId: string;
@@ -223,7 +225,7 @@ export type PostConnectionRefresh = ApiEndpoint<{
 }>;
 
 export type DeletePublicConnection = ApiEndpoint<{
-    Audit: { resource: 'connection'; action: 'deleted'; scope: 'environment' };
+    Audit: typeof auditPolicies.connectionDeleted;
     Method: 'DELETE';
     Path: '/connection/:connectionId';
     Params: { connectionId: string };
@@ -239,5 +241,5 @@ export type DeleteConnection = ApiEndpoint<{
     Querystring: { provider_config_key: string; env: string };
     Error: ApiError<'unknown_connection'> | ApiError<'unknown_provider_config'>;
     Success: { success: boolean };
-    Audit: { resource: 'connection'; action: 'deleted'; scope: 'environment' };
+    Audit: typeof auditPolicies.connectionDeleted;
 }>;

--- a/packages/types/lib/connection/api/get.ts
+++ b/packages/types/lib/connection/api/get.ts
@@ -1,4 +1,4 @@
-import type { ApiError, ApiTimestamps, Endpoint } from '../../api.js';
+import type { ApiEndpoint, ApiError, ApiTimestamps } from '../../api.js';
 import type {
     ApiKeyCredentials,
     ApiPublicAllAuthCredentials,
@@ -26,7 +26,8 @@ export type ApiConnectionSimple = Pick<
     tags: Tags;
     pausedSyncs: string[];
 };
-export type GetConnections = Endpoint<{
+export type GetConnections = ApiEndpoint<{
+    Audit: { audit: false; reason: 'non-auditable' };
     Method: 'GET';
     Querystring: {
         env: string;
@@ -41,7 +42,8 @@ export type GetConnections = Endpoint<{
     };
 }>;
 
-export type GetConnectionsCount = Endpoint<{
+export type GetConnectionsCount = ApiEndpoint<{
+    Audit: { audit: false; reason: 'non-auditable' };
     Method: 'GET';
     Querystring: {
         env: string;
@@ -61,7 +63,8 @@ export type ApiPublicConnection = Pick<DBConnection, 'id' | 'connection_id'> & {
     end_user: ApiEndUser | null;
     tags: Tags;
 };
-export type GetPublicConnections = Endpoint<{
+export type GetPublicConnections = ApiEndpoint<{
+    Audit: { audit: false; reason: 'non-auditable' };
     Method: 'GET';
     Querystring: {
         connectionId?: string | undefined;
@@ -79,7 +82,8 @@ export type GetPublicConnections = Endpoint<{
     };
 }>;
 
-export type PostPublicConnection = Endpoint<{
+export type PostPublicConnection = ApiEndpoint<{
+    Audit: { audit: false; reason: 'TODO: audit coverage pending' };
     Method: 'POST';
     Path: '/connections';
     Body: {
@@ -109,7 +113,7 @@ export type ApiConnectionFull = Omit<
     ReplaceInObject<DBConnectionDecrypted, Date, string>,
     'credentials_iv' | 'end_user_id' | 'credentials_tag' | 'deleted' | 'deleted_at'
 >;
-export type GetConnection = Endpoint<{
+export type GetConnection = ApiEndpoint<{
     Method: 'GET';
     Params: {
         connectionId: string;
@@ -120,6 +124,7 @@ export type GetConnection = Endpoint<{
     };
     Path: '/api/v1/connections/:connectionId';
     Error: ApiError<'unknown_provider_config'>;
+    Audit: { audit: false; reason: 'non-auditable' };
     Success: {
         data: {
             provider: string;
@@ -142,7 +147,8 @@ export type ApiPublicConnectionFull = Pick<DBConnection, 'id' | 'connection_id' 
     tags: Tags;
     credentials: ApiPublicAllAuthCredentials;
 };
-export type GetPublicConnection = Endpoint<{
+export type GetPublicConnection = ApiEndpoint<{
+    Audit: { audit: false; reason: 'non-auditable' };
     Method: 'GET';
     Params: {
         connectionId: string;
@@ -158,7 +164,8 @@ export type GetPublicConnection = Endpoint<{
     Success: ApiPublicConnectionFull;
 }>;
 
-export type PatchPublicConnection = Endpoint<{
+export type PatchPublicConnection = ApiEndpoint<{
+    Audit: { audit: false; reason: 'TODO: audit coverage pending' };
     Method: 'PATCH';
     Path: '/connections/:connectionId';
     Params: {
@@ -176,7 +183,8 @@ export type PatchPublicConnection = Endpoint<{
     Error: ApiError<'unknown_provider_config' | 'not_found' | 'server_error' | 'invalid_body'>;
 }>;
 
-export type PatchConnection = Endpoint<{
+export type PatchConnection = ApiEndpoint<{
+    Audit: { audit: false; reason: 'TODO: audit coverage pending' };
     Method: 'PATCH';
     Path: '/api/v1/connections/:connectionId';
     Params: {
@@ -195,7 +203,8 @@ export type PatchConnection = Endpoint<{
     Error: ApiError<'unknown_provider_config' | 'not_found' | 'server_error' | 'invalid_body'>;
 }>;
 
-export type PostConnectionRefresh = Endpoint<{
+export type PostConnectionRefresh = ApiEndpoint<{
+    Audit: { audit: false; reason: 'TODO: audit coverage pending' };
     Method: 'POST';
     Params: {
         connectionId: string;
@@ -213,7 +222,8 @@ export type PostConnectionRefresh = Endpoint<{
     };
 }>;
 
-export type DeletePublicConnection = Endpoint<{
+export type DeletePublicConnection = ApiEndpoint<{
+    Audit: { resource: 'connection'; action: 'deleted'; scope: 'environment' };
     Method: 'DELETE';
     Path: '/connection/:connectionId';
     Params: { connectionId: string };
@@ -222,11 +232,12 @@ export type DeletePublicConnection = Endpoint<{
     Success: { success: boolean };
 }>;
 
-export type DeleteConnection = Endpoint<{
+export type DeleteConnection = ApiEndpoint<{
     Method: 'DELETE';
     Path: '/api/v1/connections/:connectionId';
     Params: { connectionId: string };
     Querystring: { provider_config_key: string; env: string };
     Error: ApiError<'unknown_connection'> | ApiError<'unknown_provider_config'>;
     Success: { success: boolean };
+    Audit: { resource: 'connection'; action: 'deleted'; scope: 'environment' };
 }>;

--- a/packages/types/lib/connection/api/metadata.ts
+++ b/packages/types/lib/connection/api/metadata.ts
@@ -10,7 +10,7 @@ export interface MetadataBody {
 type MetadataError = ApiError<'invalid_body'> | ApiError<'unknown_connection'>;
 
 export type SetMetadata = ApiEndpoint<{
-    Audit: { audit: false; reason: 'TODO: audit coverage pending' };
+    Audit: { reason: 'TODO: audit coverage pending' };
     Method: 'POST';
     Body: MetadataBody;
     Path: '/connection/metadata';
@@ -19,7 +19,7 @@ export type SetMetadata = ApiEndpoint<{
 }>;
 
 export type UpdateMetadata = ApiEndpoint<{
-    Audit: { audit: false; reason: 'TODO: audit coverage pending' };
+    Audit: { reason: 'TODO: audit coverage pending' };
     Method: 'PATCH';
     Path: '/connection/metadata';
     Body: MetadataBody;
@@ -28,7 +28,7 @@ export type UpdateMetadata = ApiEndpoint<{
 }>;
 
 export type PostConnectionMetadata = ApiEndpoint<{
-    Audit: { audit: false; reason: 'TODO: audit coverage pending' };
+    Audit: { reason: 'TODO: audit coverage pending' };
     Method: 'POST';
     Path: '/api/v1/connections/:connectionId/metadata';
     Params: {

--- a/packages/types/lib/connection/api/metadata.ts
+++ b/packages/types/lib/connection/api/metadata.ts
@@ -10,7 +10,7 @@ export interface MetadataBody {
 type MetadataError = ApiError<'invalid_body'> | ApiError<'unknown_connection'>;
 
 export type SetMetadata = ApiEndpoint<{
-    Audit: { reason: 'TODO: audit coverage pending' };
+    Audit: { kind: 'no-audit'; reason: 'TODO: audit coverage pending' };
     Method: 'POST';
     Body: MetadataBody;
     Path: '/connection/metadata';
@@ -19,7 +19,7 @@ export type SetMetadata = ApiEndpoint<{
 }>;
 
 export type UpdateMetadata = ApiEndpoint<{
-    Audit: { reason: 'TODO: audit coverage pending' };
+    Audit: { kind: 'no-audit'; reason: 'TODO: audit coverage pending' };
     Method: 'PATCH';
     Path: '/connection/metadata';
     Body: MetadataBody;
@@ -28,7 +28,7 @@ export type UpdateMetadata = ApiEndpoint<{
 }>;
 
 export type PostConnectionMetadata = ApiEndpoint<{
-    Audit: { reason: 'TODO: audit coverage pending' };
+    Audit: { kind: 'no-audit'; reason: 'TODO: audit coverage pending' };
     Method: 'POST';
     Path: '/api/v1/connections/:connectionId/metadata';
     Params: {

--- a/packages/types/lib/connection/api/metadata.ts
+++ b/packages/types/lib/connection/api/metadata.ts
@@ -1,4 +1,4 @@
-import type { ApiError, Endpoint } from '../../api.js';
+import type { ApiEndpoint, ApiError } from '../../api.js';
 import type { Metadata } from '../db.js';
 
 export interface MetadataBody {
@@ -9,7 +9,8 @@ export interface MetadataBody {
 
 type MetadataError = ApiError<'invalid_body'> | ApiError<'unknown_connection'>;
 
-export type SetMetadata = Endpoint<{
+export type SetMetadata = ApiEndpoint<{
+    Audit: { audit: false; reason: 'TODO: audit coverage pending' };
     Method: 'POST';
     Body: MetadataBody;
     Path: '/connection/metadata';
@@ -17,7 +18,8 @@ export type SetMetadata = Endpoint<{
     Success: MetadataBody;
 }>;
 
-export type UpdateMetadata = Endpoint<{
+export type UpdateMetadata = ApiEndpoint<{
+    Audit: { audit: false; reason: 'TODO: audit coverage pending' };
     Method: 'PATCH';
     Path: '/connection/metadata';
     Body: MetadataBody;
@@ -25,7 +27,8 @@ export type UpdateMetadata = Endpoint<{
     Success: MetadataBody;
 }>;
 
-export type PostConnectionMetadata = Endpoint<{
+export type PostConnectionMetadata = ApiEndpoint<{
+    Audit: { audit: false; reason: 'TODO: audit coverage pending' };
     Method: 'POST';
     Path: '/api/v1/connections/:connectionId/metadata';
     Params: {

--- a/packages/types/lib/deploy/api.ts
+++ b/packages/types/lib/deploy/api.ts
@@ -6,7 +6,7 @@ import type { SyncDeploymentResult } from './index.js';
 import type { JSONSchema7 } from 'json-schema';
 
 export type PostDeployConfirmation = ApiEndpoint<{
-    Audit: { reason: 'TODO: audit coverage pending' };
+    Audit: { kind: 'no-audit'; reason: 'TODO: audit coverage pending' };
     Method: 'POST';
     Path: '/sync/deploy/confirmation';
     Body: {
@@ -23,7 +23,7 @@ export type PostDeployConfirmation = ApiEndpoint<{
 }>;
 
 export type PostDeploy = ApiEndpoint<{
-    Audit: { reason: 'TODO: audit coverage pending' };
+    Audit: { kind: 'no-audit'; reason: 'TODO: audit coverage pending' };
     Method: 'POST';
     Path: '/sync/deploy';
     Body: {
@@ -42,7 +42,7 @@ export type PostDeploy = ApiEndpoint<{
 }>;
 
 export type PostDeployInternal = ApiEndpoint<{
-    Audit: { reason: 'TODO: audit coverage pending' };
+    Audit: { kind: 'no-audit'; reason: 'TODO: audit coverage pending' };
     Method: 'POST';
     Path: '/sync/deploy/internal';
     Querystring: {

--- a/packages/types/lib/deploy/api.ts
+++ b/packages/types/lib/deploy/api.ts
@@ -1,11 +1,12 @@
-import type { ApiError, Endpoint } from '../api.js';
+import type { ApiEndpoint, ApiError } from '../api.js';
 import type { OnEventType } from '../scripts/on-events/api.js';
 import type { FunctionSource } from '../syncConfigs/db.js';
 import type { CLIDeployFlowConfig, OnEventScriptsByProvider } from './incomingFlow.js';
 import type { SyncDeploymentResult } from './index.js';
 import type { JSONSchema7 } from 'json-schema';
 
-export type PostDeployConfirmation = Endpoint<{
+export type PostDeployConfirmation = ApiEndpoint<{
+    Audit: { audit: false; reason: 'TODO: audit coverage pending' };
     Method: 'POST';
     Path: '/sync/deploy/confirmation';
     Body: {
@@ -21,7 +22,8 @@ export type PostDeployConfirmation = Endpoint<{
     Success: ScriptDifferences;
 }>;
 
-export type PostDeploy = Endpoint<{
+export type PostDeploy = ApiEndpoint<{
+    Audit: { audit: false; reason: 'TODO: audit coverage pending' };
     Method: 'POST';
     Path: '/sync/deploy';
     Body: {
@@ -39,7 +41,8 @@ export type PostDeploy = Endpoint<{
     Success: SyncDeploymentResult[];
 }>;
 
-export type PostDeployInternal = Endpoint<{
+export type PostDeployInternal = ApiEndpoint<{
+    Audit: { audit: false; reason: 'TODO: audit coverage pending' };
     Method: 'POST';
     Path: '/sync/deploy/internal';
     Querystring: {

--- a/packages/types/lib/deploy/api.ts
+++ b/packages/types/lib/deploy/api.ts
@@ -6,7 +6,7 @@ import type { SyncDeploymentResult } from './index.js';
 import type { JSONSchema7 } from 'json-schema';
 
 export type PostDeployConfirmation = ApiEndpoint<{
-    Audit: { audit: false; reason: 'TODO: audit coverage pending' };
+    Audit: { reason: 'TODO: audit coverage pending' };
     Method: 'POST';
     Path: '/sync/deploy/confirmation';
     Body: {
@@ -23,7 +23,7 @@ export type PostDeployConfirmation = ApiEndpoint<{
 }>;
 
 export type PostDeploy = ApiEndpoint<{
-    Audit: { audit: false; reason: 'TODO: audit coverage pending' };
+    Audit: { reason: 'TODO: audit coverage pending' };
     Method: 'POST';
     Path: '/sync/deploy';
     Body: {
@@ -42,7 +42,7 @@ export type PostDeploy = ApiEndpoint<{
 }>;
 
 export type PostDeployInternal = ApiEndpoint<{
-    Audit: { audit: false; reason: 'TODO: audit coverage pending' };
+    Audit: { reason: 'TODO: audit coverage pending' };
     Method: 'POST';
     Path: '/sync/deploy/internal';
     Querystring: {

--- a/packages/types/lib/environment/api/index.ts
+++ b/packages/types/lib/environment/api/index.ts
@@ -10,7 +10,7 @@ export type ApiEnvironment = Merge<DBEnvironment, { callback_url: string } & Api
 export type ApiWebhooks = Omit<DBExternalWebhook, 'id' | 'environment_id' | 'created_at' | 'updated_at'>;
 
 export type GetEnvironments = ApiEndpoint<{
-    Audit: { reason: 'non-auditable' };
+    Audit: { kind: 'no-audit'; reason: 'non-auditable' };
     Method: 'GET';
     Path: '/api/v1/environments';
     Success: {
@@ -19,7 +19,7 @@ export type GetEnvironments = ApiEndpoint<{
 }>;
 
 export type PostEnvironment = ApiEndpoint<{
-    Audit: { reason: 'TODO: audit coverage pending' };
+    Audit: { kind: 'no-audit'; reason: 'TODO: audit coverage pending' };
     Method: 'POST';
     Path: '/api/v1/environments';
     Body: { name: string };
@@ -29,7 +29,7 @@ export type PostEnvironment = ApiEndpoint<{
 }>;
 
 export type GetEnvironment = ApiEndpoint<{
-    Audit: { reason: 'non-auditable' };
+    Audit: { kind: 'no-audit'; reason: 'non-auditable' };
     Method: 'GET';
     Path: '/api/v1/environments/current';
     Success: {
@@ -49,7 +49,7 @@ export type GetEnvironment = ApiEndpoint<{
 }>;
 
 export type PatchEnvironment = ApiEndpoint<{
-    Audit: { reason: 'TODO: audit coverage pending' };
+    Audit: { kind: 'no-audit'; reason: 'TODO: audit coverage pending' };
     Method: 'PATCH';
     Path: '/api/v1/environments';
     Body: {
@@ -69,7 +69,7 @@ export type PatchEnvironment = ApiEndpoint<{
 }>;
 
 export type DeleteEnvironment = ApiEndpoint<{
-    Audit: { reason: 'TODO: audit coverage pending' };
+    Audit: { kind: 'no-audit'; reason: 'TODO: audit coverage pending' };
     Method: 'DELETE';
     Path: '/api/v1/environments';
     Success: never;
@@ -77,14 +77,14 @@ export type DeleteEnvironment = ApiEndpoint<{
 }>;
 
 export type GetPublicEnvironmentVariables = ApiEndpoint<{
-    Audit: { reason: 'non-auditable' };
+    Audit: { kind: 'no-audit'; reason: 'non-auditable' };
     Method: 'GET';
     Path: '/api/v1/environment-variables';
     Success: { name: string; value: string }[];
 }>;
 
 export type ListApiKeys = ApiEndpoint<{
-    Audit: { reason: 'non-auditable' };
+    Audit: { kind: 'no-audit'; reason: 'non-auditable' };
     Method: 'GET';
     Path: '/api/v1/environment/api-keys';
     Success: {
@@ -100,7 +100,7 @@ export type ListApiKeys = ApiEndpoint<{
 }>;
 
 export type CreateApiKey = ApiEndpoint<{
-    Audit: { reason: 'TODO: audit coverage pending' };
+    Audit: { kind: 'no-audit'; reason: 'TODO: audit coverage pending' };
     Method: 'POST';
     Path: '/api/v1/environment/api-keys';
     Body: {
@@ -120,7 +120,7 @@ export type CreateApiKey = ApiEndpoint<{
 }>;
 
 export type DeleteApiKey = ApiEndpoint<{
-    Audit: { reason: 'TODO: audit coverage pending' };
+    Audit: { kind: 'no-audit'; reason: 'TODO: audit coverage pending' };
     Method: 'DELETE';
     Path: '/api/v1/environment/api-keys/:keyId';
     Params: { keyId: number };
@@ -128,7 +128,7 @@ export type DeleteApiKey = ApiEndpoint<{
 }>;
 
 export type PatchApiKey = ApiEndpoint<{
-    Audit: { reason: 'TODO: audit coverage pending' };
+    Audit: { kind: 'no-audit'; reason: 'TODO: audit coverage pending' };
     Method: 'PATCH';
     Path: '/api/v1/environment/api-keys/:keyId';
     Params: { keyId: number };

--- a/packages/types/lib/environment/api/index.ts
+++ b/packages/types/lib/environment/api/index.ts
@@ -10,7 +10,7 @@ export type ApiEnvironment = Merge<DBEnvironment, { callback_url: string } & Api
 export type ApiWebhooks = Omit<DBExternalWebhook, 'id' | 'environment_id' | 'created_at' | 'updated_at'>;
 
 export type GetEnvironments = ApiEndpoint<{
-    Audit: { audit: false; reason: 'non-auditable' };
+    Audit: { reason: 'non-auditable' };
     Method: 'GET';
     Path: '/api/v1/environments';
     Success: {
@@ -19,7 +19,7 @@ export type GetEnvironments = ApiEndpoint<{
 }>;
 
 export type PostEnvironment = ApiEndpoint<{
-    Audit: { audit: false; reason: 'TODO: audit coverage pending' };
+    Audit: { reason: 'TODO: audit coverage pending' };
     Method: 'POST';
     Path: '/api/v1/environments';
     Body: { name: string };
@@ -29,7 +29,7 @@ export type PostEnvironment = ApiEndpoint<{
 }>;
 
 export type GetEnvironment = ApiEndpoint<{
-    Audit: { audit: false; reason: 'non-auditable' };
+    Audit: { reason: 'non-auditable' };
     Method: 'GET';
     Path: '/api/v1/environments/current';
     Success: {
@@ -49,7 +49,7 @@ export type GetEnvironment = ApiEndpoint<{
 }>;
 
 export type PatchEnvironment = ApiEndpoint<{
-    Audit: { audit: false; reason: 'TODO: audit coverage pending' };
+    Audit: { reason: 'TODO: audit coverage pending' };
     Method: 'PATCH';
     Path: '/api/v1/environments';
     Body: {
@@ -69,7 +69,7 @@ export type PatchEnvironment = ApiEndpoint<{
 }>;
 
 export type DeleteEnvironment = ApiEndpoint<{
-    Audit: { audit: false; reason: 'TODO: audit coverage pending' };
+    Audit: { reason: 'TODO: audit coverage pending' };
     Method: 'DELETE';
     Path: '/api/v1/environments';
     Success: never;
@@ -77,14 +77,14 @@ export type DeleteEnvironment = ApiEndpoint<{
 }>;
 
 export type GetPublicEnvironmentVariables = ApiEndpoint<{
-    Audit: { audit: false; reason: 'non-auditable' };
+    Audit: { reason: 'non-auditable' };
     Method: 'GET';
     Path: '/api/v1/environment-variables';
     Success: { name: string; value: string }[];
 }>;
 
 export type ListApiKeys = ApiEndpoint<{
-    Audit: { audit: false; reason: 'non-auditable' };
+    Audit: { reason: 'non-auditable' };
     Method: 'GET';
     Path: '/api/v1/environment/api-keys';
     Success: {
@@ -100,7 +100,7 @@ export type ListApiKeys = ApiEndpoint<{
 }>;
 
 export type CreateApiKey = ApiEndpoint<{
-    Audit: { audit: false; reason: 'TODO: audit coverage pending' };
+    Audit: { reason: 'TODO: audit coverage pending' };
     Method: 'POST';
     Path: '/api/v1/environment/api-keys';
     Body: {
@@ -120,7 +120,7 @@ export type CreateApiKey = ApiEndpoint<{
 }>;
 
 export type DeleteApiKey = ApiEndpoint<{
-    Audit: { audit: false; reason: 'TODO: audit coverage pending' };
+    Audit: { reason: 'TODO: audit coverage pending' };
     Method: 'DELETE';
     Path: '/api/v1/environment/api-keys/:keyId';
     Params: { keyId: number };
@@ -128,7 +128,7 @@ export type DeleteApiKey = ApiEndpoint<{
 }>;
 
 export type PatchApiKey = ApiEndpoint<{
-    Audit: { audit: false; reason: 'TODO: audit coverage pending' };
+    Audit: { reason: 'TODO: audit coverage pending' };
     Method: 'PATCH';
     Path: '/api/v1/environment/api-keys/:keyId';
     Params: { keyId: number };

--- a/packages/types/lib/environment/api/index.ts
+++ b/packages/types/lib/environment/api/index.ts
@@ -1,5 +1,5 @@
 import type { ApiKeyScope } from '../../api-keys/scopes.js';
-import type { ApiError, ApiTimestamps, Endpoint } from '../../api.js';
+import type { ApiEndpoint, ApiError, ApiTimestamps } from '../../api.js';
 import type { ApiPlan } from '../../plans/http.api.js';
 import type { DBEnvironment, DBExternalWebhook } from '../db.js';
 import type { ApiEnvironmentVariable } from '../variable/api.js';
@@ -9,7 +9,8 @@ export type ApiEnvironment = Merge<DBEnvironment, { callback_url: string } & Api
 
 export type ApiWebhooks = Omit<DBExternalWebhook, 'id' | 'environment_id' | 'created_at' | 'updated_at'>;
 
-export type GetEnvironments = Endpoint<{
+export type GetEnvironments = ApiEndpoint<{
+    Audit: { audit: false; reason: 'non-auditable' };
     Method: 'GET';
     Path: '/api/v1/environments';
     Success: {
@@ -17,7 +18,8 @@ export type GetEnvironments = Endpoint<{
     };
 }>;
 
-export type PostEnvironment = Endpoint<{
+export type PostEnvironment = ApiEndpoint<{
+    Audit: { audit: false; reason: 'TODO: audit coverage pending' };
     Method: 'POST';
     Path: '/api/v1/environments';
     Body: { name: string };
@@ -26,7 +28,8 @@ export type PostEnvironment = Endpoint<{
     };
 }>;
 
-export type GetEnvironment = Endpoint<{
+export type GetEnvironment = ApiEndpoint<{
+    Audit: { audit: false; reason: 'non-auditable' };
     Method: 'GET';
     Path: '/api/v1/environments/current';
     Success: {
@@ -45,7 +48,8 @@ export type GetEnvironment = Endpoint<{
     };
 }>;
 
-export type PatchEnvironment = Endpoint<{
+export type PatchEnvironment = ApiEndpoint<{
+    Audit: { audit: false; reason: 'TODO: audit coverage pending' };
     Method: 'PATCH';
     Path: '/api/v1/environments';
     Body: {
@@ -64,20 +68,23 @@ export type PatchEnvironment = Endpoint<{
     Error: ApiError<'conflict' | 'cannot_toggle_prod_environment'>;
 }>;
 
-export type DeleteEnvironment = Endpoint<{
+export type DeleteEnvironment = ApiEndpoint<{
+    Audit: { audit: false; reason: 'TODO: audit coverage pending' };
     Method: 'DELETE';
     Path: '/api/v1/environments';
     Success: never;
     Error: ApiError<'cannot_delete_prod_environment'>;
 }>;
 
-export type GetPublicEnvironmentVariables = Endpoint<{
+export type GetPublicEnvironmentVariables = ApiEndpoint<{
+    Audit: { audit: false; reason: 'non-auditable' };
     Method: 'GET';
     Path: '/api/v1/environment-variables';
     Success: { name: string; value: string }[];
 }>;
 
-export type ListApiKeys = Endpoint<{
+export type ListApiKeys = ApiEndpoint<{
+    Audit: { audit: false; reason: 'non-auditable' };
     Method: 'GET';
     Path: '/api/v1/environment/api-keys';
     Success: {
@@ -92,7 +99,8 @@ export type ListApiKeys = Endpoint<{
     };
 }>;
 
-export type CreateApiKey = Endpoint<{
+export type CreateApiKey = ApiEndpoint<{
+    Audit: { audit: false; reason: 'TODO: audit coverage pending' };
     Method: 'POST';
     Path: '/api/v1/environment/api-keys';
     Body: {
@@ -111,14 +119,16 @@ export type CreateApiKey = Endpoint<{
     Error: ApiError<'conflict' | 'resource_capped'>;
 }>;
 
-export type DeleteApiKey = Endpoint<{
+export type DeleteApiKey = ApiEndpoint<{
+    Audit: { audit: false; reason: 'TODO: audit coverage pending' };
     Method: 'DELETE';
     Path: '/api/v1/environment/api-keys/:keyId';
     Params: { keyId: number };
     Success: { success: true };
 }>;
 
-export type PatchApiKey = Endpoint<{
+export type PatchApiKey = ApiEndpoint<{
+    Audit: { audit: false; reason: 'TODO: audit coverage pending' };
     Method: 'PATCH';
     Path: '/api/v1/environment/api-keys/:keyId';
     Params: { keyId: number };

--- a/packages/types/lib/environment/api/otlp.ts
+++ b/packages/types/lib/environment/api/otlp.ts
@@ -6,7 +6,7 @@ export interface OtlpSettings {
 }
 
 export type UpdateOtlpSettings = ApiEndpoint<{
-    Audit: { reason: 'TODO: audit coverage pending' };
+    Audit: { kind: 'no-audit'; reason: 'TODO: audit coverage pending' };
     Method: 'POST';
     Querystring: {
         env: string;

--- a/packages/types/lib/environment/api/otlp.ts
+++ b/packages/types/lib/environment/api/otlp.ts
@@ -1,11 +1,12 @@
-import type { ApiError, Endpoint } from '../../api.js';
+import type { ApiEndpoint, ApiError } from '../../api.js';
 
 export interface OtlpSettings {
     endpoint: string;
     headers: Record<string, string>;
 }
 
-export type UpdateOtlpSettings = Endpoint<{
+export type UpdateOtlpSettings = ApiEndpoint<{
+    Audit: { audit: false; reason: 'TODO: audit coverage pending' };
     Method: 'POST';
     Querystring: {
         env: string;

--- a/packages/types/lib/environment/api/otlp.ts
+++ b/packages/types/lib/environment/api/otlp.ts
@@ -6,7 +6,7 @@ export interface OtlpSettings {
 }
 
 export type UpdateOtlpSettings = ApiEndpoint<{
-    Audit: { audit: false; reason: 'TODO: audit coverage pending' };
+    Audit: { reason: 'TODO: audit coverage pending' };
     Method: 'POST';
     Querystring: {
         env: string;

--- a/packages/types/lib/environment/api/webhook.ts
+++ b/packages/types/lib/environment/api/webhook.ts
@@ -1,7 +1,7 @@
 import type { ApiEndpoint } from '../../api.js';
 
 export type PatchWebhook = ApiEndpoint<{
-    Audit: { reason: 'TODO: audit coverage pending' };
+    Audit: { kind: 'no-audit'; reason: 'TODO: audit coverage pending' };
     Method: 'PATCH';
     Querystring: {
         env: string;

--- a/packages/types/lib/environment/api/webhook.ts
+++ b/packages/types/lib/environment/api/webhook.ts
@@ -1,6 +1,7 @@
-import type { Endpoint } from '../../api.js';
+import type { ApiEndpoint } from '../../api.js';
 
-export type PatchWebhook = Endpoint<{
+export type PatchWebhook = ApiEndpoint<{
+    Audit: { audit: false; reason: 'TODO: audit coverage pending' };
     Method: 'PATCH';
     Querystring: {
         env: string;

--- a/packages/types/lib/environment/api/webhook.ts
+++ b/packages/types/lib/environment/api/webhook.ts
@@ -1,7 +1,7 @@
 import type { ApiEndpoint } from '../../api.js';
 
 export type PatchWebhook = ApiEndpoint<{
-    Audit: { audit: false; reason: 'TODO: audit coverage pending' };
+    Audit: { reason: 'TODO: audit coverage pending' };
     Method: 'PATCH';
     Querystring: {
         env: string;

--- a/packages/types/lib/environment/variable/api.ts
+++ b/packages/types/lib/environment/variable/api.ts
@@ -3,7 +3,7 @@ import type { DBEnvironmentVariable } from '../db.js';
 
 export type ApiEnvironmentVariable = Pick<DBEnvironmentVariable, 'name' | 'value'>;
 export type PostEnvironmentVariables = ApiEndpoint<{
-    Audit: { audit: false; reason: 'TODO: audit coverage pending' };
+    Audit: { reason: 'TODO: audit coverage pending' };
     Method: 'POST';
     Path: '/api/v1/environments/variables';
     Querystring: { env: string };

--- a/packages/types/lib/environment/variable/api.ts
+++ b/packages/types/lib/environment/variable/api.ts
@@ -1,8 +1,9 @@
-import type { Endpoint } from '../../api.js';
+import type { ApiEndpoint } from '../../api.js';
 import type { DBEnvironmentVariable } from '../db.js';
 
 export type ApiEnvironmentVariable = Pick<DBEnvironmentVariable, 'name' | 'value'>;
-export type PostEnvironmentVariables = Endpoint<{
+export type PostEnvironmentVariables = ApiEndpoint<{
+    Audit: { audit: false; reason: 'TODO: audit coverage pending' };
     Method: 'POST';
     Path: '/api/v1/environments/variables';
     Querystring: { env: string };

--- a/packages/types/lib/environment/variable/api.ts
+++ b/packages/types/lib/environment/variable/api.ts
@@ -3,7 +3,7 @@ import type { DBEnvironmentVariable } from '../db.js';
 
 export type ApiEnvironmentVariable = Pick<DBEnvironmentVariable, 'name' | 'value'>;
 export type PostEnvironmentVariables = ApiEndpoint<{
-    Audit: { reason: 'TODO: audit coverage pending' };
+    Audit: { kind: 'no-audit'; reason: 'TODO: audit coverage pending' };
     Method: 'POST';
     Path: '/api/v1/environments/variables';
     Querystring: { env: string };

--- a/packages/types/lib/fleet/api.ts
+++ b/packages/types/lib/fleet/api.ts
@@ -1,8 +1,7 @@
-import type { ApiEndpoint, ApiError } from '../api.js';
+import type { ApiError, Endpoint } from '../api.js';
 import type { Deployment, ImageType } from './index.js';
 
-export type PostRollout = ApiEndpoint<{
-    Audit: { audit: false; reason: 'non-auditable' };
+export type PostRollout = Endpoint<{
     Method: 'POST';
     Path: '/fleet/:fleetId/rollout';
     Body: {

--- a/packages/types/lib/fleet/api.ts
+++ b/packages/types/lib/fleet/api.ts
@@ -1,7 +1,8 @@
-import type { ApiError, Endpoint } from '../api.js';
+import type { ApiEndpoint, ApiError } from '../api.js';
 import type { Deployment, ImageType } from './index.js';
 
-export type PostRollout = Endpoint<{
+export type PostRollout = ApiEndpoint<{
+    Audit: { audit: false; reason: 'non-auditable' };
     Method: 'POST';
     Path: '/fleet/:fleetId/rollout';
     Body: {

--- a/packages/types/lib/flow/http.api.ts
+++ b/packages/types/lib/flow/http.api.ts
@@ -2,7 +2,7 @@ import type { ApiEndpoint, ApiError } from '../api.js';
 import type { ScriptTypeLiteral } from '../nangoYaml/index.js';
 
 export type PutUpgradePreBuiltFlow = ApiEndpoint<{
-    Audit: { audit: false; reason: 'TODO: audit coverage pending' };
+    Audit: { reason: 'TODO: audit coverage pending' };
     Method: 'PUT';
     Path: '/api/v1/flows/pre-built/upgrade';
     Querystring: { env: string };
@@ -22,7 +22,7 @@ export type PutUpgradePreBuiltFlow = ApiEndpoint<{
 }>;
 
 export type PostPreBuiltDeploy = ApiEndpoint<{
-    Audit: { audit: false; reason: 'TODO: audit coverage pending' };
+    Audit: { reason: 'TODO: audit coverage pending' };
     Method: 'POST';
     Path: '/api/v1/flows/pre-built/deploy';
     Querystring: { env: string };
@@ -40,7 +40,7 @@ export type PostPreBuiltDeploy = ApiEndpoint<{
 }>;
 
 export type PatchFlowEnable = ApiEndpoint<{
-    Audit: { audit: false; reason: 'TODO: audit coverage pending' };
+    Audit: { reason: 'TODO: audit coverage pending' };
     Method: 'PATCH';
     Path: '/api/v1/flows/:id/enable';
     Querystring: { env: string };
@@ -60,7 +60,7 @@ export type PatchFlowEnable = ApiEndpoint<{
 }>;
 
 export type PatchFlowDisable = ApiEndpoint<{
-    Audit: { audit: false; reason: 'TODO: audit coverage pending' };
+    Audit: { reason: 'TODO: audit coverage pending' };
     Method: 'PATCH';
     Path: '/api/v1/flows/:id/disable';
     Querystring: { env: string };
@@ -80,7 +80,7 @@ export type PatchFlowDisable = ApiEndpoint<{
 }>;
 
 export type PatchFlowFrequency = ApiEndpoint<{
-    Audit: { audit: false; reason: 'TODO: audit coverage pending' };
+    Audit: { reason: 'TODO: audit coverage pending' };
     Method: 'PATCH';
     Path: '/api/v1/flows/:id/frequency';
     Querystring: { env: string };
@@ -101,7 +101,7 @@ export type PatchFlowFrequency = ApiEndpoint<{
 }>;
 
 export type GetFlowDownload = ApiEndpoint<{
-    Audit: { audit: false; reason: 'non-auditable' };
+    Audit: { reason: 'non-auditable' };
     Method: 'GET';
     Path: '/api/v1/flows/:id/download';
     Querystring: { env: string };

--- a/packages/types/lib/flow/http.api.ts
+++ b/packages/types/lib/flow/http.api.ts
@@ -2,7 +2,7 @@ import type { ApiEndpoint, ApiError } from '../api.js';
 import type { ScriptTypeLiteral } from '../nangoYaml/index.js';
 
 export type PutUpgradePreBuiltFlow = ApiEndpoint<{
-    Audit: { reason: 'TODO: audit coverage pending' };
+    Audit: { kind: 'no-audit'; reason: 'TODO: audit coverage pending' };
     Method: 'PUT';
     Path: '/api/v1/flows/pre-built/upgrade';
     Querystring: { env: string };
@@ -22,7 +22,7 @@ export type PutUpgradePreBuiltFlow = ApiEndpoint<{
 }>;
 
 export type PostPreBuiltDeploy = ApiEndpoint<{
-    Audit: { reason: 'TODO: audit coverage pending' };
+    Audit: { kind: 'no-audit'; reason: 'TODO: audit coverage pending' };
     Method: 'POST';
     Path: '/api/v1/flows/pre-built/deploy';
     Querystring: { env: string };
@@ -40,7 +40,7 @@ export type PostPreBuiltDeploy = ApiEndpoint<{
 }>;
 
 export type PatchFlowEnable = ApiEndpoint<{
-    Audit: { reason: 'TODO: audit coverage pending' };
+    Audit: { kind: 'no-audit'; reason: 'TODO: audit coverage pending' };
     Method: 'PATCH';
     Path: '/api/v1/flows/:id/enable';
     Querystring: { env: string };
@@ -60,7 +60,7 @@ export type PatchFlowEnable = ApiEndpoint<{
 }>;
 
 export type PatchFlowDisable = ApiEndpoint<{
-    Audit: { reason: 'TODO: audit coverage pending' };
+    Audit: { kind: 'no-audit'; reason: 'TODO: audit coverage pending' };
     Method: 'PATCH';
     Path: '/api/v1/flows/:id/disable';
     Querystring: { env: string };
@@ -80,7 +80,7 @@ export type PatchFlowDisable = ApiEndpoint<{
 }>;
 
 export type PatchFlowFrequency = ApiEndpoint<{
-    Audit: { reason: 'TODO: audit coverage pending' };
+    Audit: { kind: 'no-audit'; reason: 'TODO: audit coverage pending' };
     Method: 'PATCH';
     Path: '/api/v1/flows/:id/frequency';
     Querystring: { env: string };
@@ -101,7 +101,7 @@ export type PatchFlowFrequency = ApiEndpoint<{
 }>;
 
 export type GetFlowDownload = ApiEndpoint<{
-    Audit: { reason: 'non-auditable' };
+    Audit: { kind: 'no-audit'; reason: 'non-auditable' };
     Method: 'GET';
     Path: '/api/v1/flows/:id/download';
     Querystring: { env: string };

--- a/packages/types/lib/flow/http.api.ts
+++ b/packages/types/lib/flow/http.api.ts
@@ -1,7 +1,8 @@
-import type { ApiError, Endpoint } from '../api.js';
+import type { ApiEndpoint, ApiError } from '../api.js';
 import type { ScriptTypeLiteral } from '../nangoYaml/index.js';
 
-export type PutUpgradePreBuiltFlow = Endpoint<{
+export type PutUpgradePreBuiltFlow = ApiEndpoint<{
+    Audit: { audit: false; reason: 'TODO: audit coverage pending' };
     Method: 'PUT';
     Path: '/api/v1/flows/pre-built/upgrade';
     Querystring: { env: string };
@@ -20,7 +21,8 @@ export type PutUpgradePreBuiltFlow = Endpoint<{
     };
 }>;
 
-export type PostPreBuiltDeploy = Endpoint<{
+export type PostPreBuiltDeploy = ApiEndpoint<{
+    Audit: { audit: false; reason: 'TODO: audit coverage pending' };
     Method: 'POST';
     Path: '/api/v1/flows/pre-built/deploy';
     Querystring: { env: string };
@@ -37,7 +39,8 @@ export type PostPreBuiltDeploy = Endpoint<{
     };
 }>;
 
-export type PatchFlowEnable = Endpoint<{
+export type PatchFlowEnable = ApiEndpoint<{
+    Audit: { audit: false; reason: 'TODO: audit coverage pending' };
     Method: 'PATCH';
     Path: '/api/v1/flows/:id/enable';
     Querystring: { env: string };
@@ -56,7 +59,8 @@ export type PatchFlowEnable = Endpoint<{
     };
 }>;
 
-export type PatchFlowDisable = Endpoint<{
+export type PatchFlowDisable = ApiEndpoint<{
+    Audit: { audit: false; reason: 'TODO: audit coverage pending' };
     Method: 'PATCH';
     Path: '/api/v1/flows/:id/disable';
     Querystring: { env: string };
@@ -75,7 +79,8 @@ export type PatchFlowDisable = Endpoint<{
     };
 }>;
 
-export type PatchFlowFrequency = Endpoint<{
+export type PatchFlowFrequency = ApiEndpoint<{
+    Audit: { audit: false; reason: 'TODO: audit coverage pending' };
     Method: 'PATCH';
     Path: '/api/v1/flows/:id/frequency';
     Querystring: { env: string };
@@ -95,7 +100,8 @@ export type PatchFlowFrequency = Endpoint<{
     };
 }>;
 
-export type GetFlowDownload = Endpoint<{
+export type GetFlowDownload = ApiEndpoint<{
+    Audit: { audit: false; reason: 'non-auditable' };
     Method: 'GET';
     Path: '/api/v1/flows/:id/download';
     Querystring: { env: string };

--- a/packages/types/lib/functions/api.ts
+++ b/packages/types/lib/functions/api.ts
@@ -164,7 +164,7 @@ export type FunctionDeploymentResultBody =
       };
 
 export type PostFunctionCompile = ApiEndpoint<{
-    Audit: { reason: 'TODO: audit coverage pending' };
+    Audit: { kind: 'no-audit'; reason: 'TODO: audit coverage pending' };
     Method: 'POST';
     Path: '/functions/compile';
     Body: FunctionCompileBody;
@@ -173,7 +173,7 @@ export type PostFunctionCompile = ApiEndpoint<{
 }>;
 
 export type PostFunctionDryrun = ApiEndpoint<{
-    Audit: { reason: 'TODO: audit coverage pending' };
+    Audit: { kind: 'no-audit'; reason: 'TODO: audit coverage pending' };
     Method: 'POST';
     Path: '/functions/dryruns';
     Body: FunctionDryrunBody;
@@ -182,7 +182,7 @@ export type PostFunctionDryrun = ApiEndpoint<{
 }>;
 
 export type GetFunctionDryrun = ApiEndpoint<{
-    Audit: { reason: 'non-auditable' };
+    Audit: { kind: 'no-audit'; reason: 'non-auditable' };
     Method: 'GET';
     Path: '/functions/dryruns/:id';
     Params: { id: string };
@@ -191,7 +191,7 @@ export type GetFunctionDryrun = ApiEndpoint<{
 }>;
 
 export type PostFunctionDryrunResult = ApiEndpoint<{
-    Audit: { reason: 'TODO: audit coverage pending' };
+    Audit: { kind: 'no-audit'; reason: 'TODO: audit coverage pending' };
     Method: 'POST';
     Path: '/functions/dryruns/:id/result';
     Params: { id: string };
@@ -201,7 +201,7 @@ export type PostFunctionDryrunResult = ApiEndpoint<{
 }>;
 
 export type PostFunctionDeployment = ApiEndpoint<{
-    Audit: { reason: 'TODO: audit coverage pending' };
+    Audit: { kind: 'no-audit'; reason: 'TODO: audit coverage pending' };
     Method: 'POST';
     Path: '/functions/deployments';
     Body: FunctionDeploymentBody;
@@ -212,7 +212,7 @@ export type PostFunctionDeployment = ApiEndpoint<{
 }>;
 
 export type GetFunctionDeployment = ApiEndpoint<{
-    Audit: { reason: 'non-auditable' };
+    Audit: { kind: 'no-audit'; reason: 'non-auditable' };
     Method: 'GET';
     Path: '/functions/deployments/:id';
     Params: { id: string };
@@ -221,7 +221,7 @@ export type GetFunctionDeployment = ApiEndpoint<{
 }>;
 
 export type PostFunctionDeploymentResult = ApiEndpoint<{
-    Audit: { reason: 'TODO: audit coverage pending' };
+    Audit: { kind: 'no-audit'; reason: 'TODO: audit coverage pending' };
     Method: 'POST';
     Path: '/functions/deployments/:id/result';
     Params: { id: string };
@@ -257,7 +257,7 @@ export interface ProviderTemplatesSuccess {
 }
 
 export type GetIntegrationFunctions = ApiEndpoint<{
-    Audit: { reason: 'non-auditable' };
+    Audit: { kind: 'no-audit'; reason: 'non-auditable' };
     Method: 'GET';
     Path: '/api/v1/integrations/:providerConfigKey/functions';
     Querystring: { env: string } & FunctionListFilters;
@@ -266,7 +266,7 @@ export type GetIntegrationFunctions = ApiEndpoint<{
 }>;
 
 export type GetIntegrationFunction = ApiEndpoint<{
-    Audit: { reason: 'non-auditable' };
+    Audit: { kind: 'no-audit'; reason: 'non-auditable' };
     Method: 'GET';
     Path: '/api/v1/integrations/:providerConfigKey/functions/:functionName';
     Querystring: { env: string; type?: FunctionType };
@@ -275,7 +275,7 @@ export type GetIntegrationFunction = ApiEndpoint<{
 }>;
 
 export type DeleteIntegrationFunction = ApiEndpoint<{
-    Audit: { reason: 'TODO: audit coverage pending' };
+    Audit: { kind: 'no-audit'; reason: 'TODO: audit coverage pending' };
     Method: 'DELETE';
     Path: '/api/v1/integrations/:providerConfigKey/functions/:functionName';
     /** TODO: support deleting on-event functions */
@@ -286,7 +286,7 @@ export type DeleteIntegrationFunction = ApiEndpoint<{
 }>;
 
 export type GetProviderTemplates = ApiEndpoint<{
-    Audit: { reason: 'non-auditable' };
+    Audit: { kind: 'no-audit'; reason: 'non-auditable' };
     Method: 'GET';
     Path: '/api/v1/providers/:providerConfigKey/templates';
     Querystring: { env: string };
@@ -295,7 +295,7 @@ export type GetProviderTemplates = ApiEndpoint<{
 }>;
 
 export type GetPublicIntegrationFunctions = ApiEndpoint<{
-    Audit: { reason: 'non-auditable' };
+    Audit: { kind: 'no-audit'; reason: 'non-auditable' };
     Method: 'GET';
     Path: '/integrations/:uniqueKey/functions';
     Querystring: FunctionListFilters;
@@ -304,7 +304,7 @@ export type GetPublicIntegrationFunctions = ApiEndpoint<{
 }>;
 
 export type GetPublicIntegrationFunction = ApiEndpoint<{
-    Audit: { reason: 'non-auditable' };
+    Audit: { kind: 'no-audit'; reason: 'non-auditable' };
     Method: 'GET';
     Path: '/integrations/:uniqueKey/functions/:name';
     Querystring: { type?: FunctionType };
@@ -313,7 +313,7 @@ export type GetPublicIntegrationFunction = ApiEndpoint<{
 }>;
 
 export type DeletePublicIntegrationFunction = ApiEndpoint<{
-    Audit: { reason: 'TODO: audit coverage pending' };
+    Audit: { kind: 'no-audit'; reason: 'TODO: audit coverage pending' };
     Method: 'DELETE';
     Path: '/integrations/:uniqueKey/functions/:name';
     /** TODO: support deleting on-event functions */
@@ -324,7 +324,7 @@ export type DeletePublicIntegrationFunction = ApiEndpoint<{
 }>;
 
 export type GetPublicProviderTemplates = ApiEndpoint<{
-    Audit: { reason: 'non-auditable' };
+    Audit: { kind: 'no-audit'; reason: 'non-auditable' };
     Method: 'GET';
     Path: '/providers/:provider/templates';
     Params: { provider: string };
@@ -332,7 +332,7 @@ export type GetPublicProviderTemplates = ApiEndpoint<{
 }>;
 
 export type GetIntegrationTemplates = ApiEndpoint<{
-    Audit: { reason: 'non-auditable' };
+    Audit: { kind: 'no-audit'; reason: 'non-auditable' };
     Method: 'GET';
     Path: '/api/v1/integrations/:providerConfigKey/templates';
     Querystring: { env: string };

--- a/packages/types/lib/functions/api.ts
+++ b/packages/types/lib/functions/api.ts
@@ -164,7 +164,7 @@ export type FunctionDeploymentResultBody =
       };
 
 export type PostFunctionCompile = ApiEndpoint<{
-    Audit: { audit: false; reason: 'TODO: audit coverage pending' };
+    Audit: { reason: 'TODO: audit coverage pending' };
     Method: 'POST';
     Path: '/functions/compile';
     Body: FunctionCompileBody;
@@ -173,7 +173,7 @@ export type PostFunctionCompile = ApiEndpoint<{
 }>;
 
 export type PostFunctionDryrun = ApiEndpoint<{
-    Audit: { audit: false; reason: 'TODO: audit coverage pending' };
+    Audit: { reason: 'TODO: audit coverage pending' };
     Method: 'POST';
     Path: '/functions/dryruns';
     Body: FunctionDryrunBody;
@@ -182,7 +182,7 @@ export type PostFunctionDryrun = ApiEndpoint<{
 }>;
 
 export type GetFunctionDryrun = ApiEndpoint<{
-    Audit: { audit: false; reason: 'non-auditable' };
+    Audit: { reason: 'non-auditable' };
     Method: 'GET';
     Path: '/functions/dryruns/:id';
     Params: { id: string };
@@ -191,7 +191,7 @@ export type GetFunctionDryrun = ApiEndpoint<{
 }>;
 
 export type PostFunctionDryrunResult = ApiEndpoint<{
-    Audit: { audit: false; reason: 'TODO: audit coverage pending' };
+    Audit: { reason: 'TODO: audit coverage pending' };
     Method: 'POST';
     Path: '/functions/dryruns/:id/result';
     Params: { id: string };
@@ -201,7 +201,7 @@ export type PostFunctionDryrunResult = ApiEndpoint<{
 }>;
 
 export type PostFunctionDeployment = ApiEndpoint<{
-    Audit: { audit: false; reason: 'TODO: audit coverage pending' };
+    Audit: { reason: 'TODO: audit coverage pending' };
     Method: 'POST';
     Path: '/functions/deployments';
     Body: FunctionDeploymentBody;
@@ -212,7 +212,7 @@ export type PostFunctionDeployment = ApiEndpoint<{
 }>;
 
 export type GetFunctionDeployment = ApiEndpoint<{
-    Audit: { audit: false; reason: 'non-auditable' };
+    Audit: { reason: 'non-auditable' };
     Method: 'GET';
     Path: '/functions/deployments/:id';
     Params: { id: string };
@@ -221,7 +221,7 @@ export type GetFunctionDeployment = ApiEndpoint<{
 }>;
 
 export type PostFunctionDeploymentResult = ApiEndpoint<{
-    Audit: { audit: false; reason: 'TODO: audit coverage pending' };
+    Audit: { reason: 'TODO: audit coverage pending' };
     Method: 'POST';
     Path: '/functions/deployments/:id/result';
     Params: { id: string };
@@ -257,7 +257,7 @@ export interface ProviderTemplatesSuccess {
 }
 
 export type GetIntegrationFunctions = ApiEndpoint<{
-    Audit: { audit: false; reason: 'non-auditable' };
+    Audit: { reason: 'non-auditable' };
     Method: 'GET';
     Path: '/api/v1/integrations/:providerConfigKey/functions';
     Querystring: { env: string } & FunctionListFilters;
@@ -266,7 +266,7 @@ export type GetIntegrationFunctions = ApiEndpoint<{
 }>;
 
 export type GetIntegrationFunction = ApiEndpoint<{
-    Audit: { audit: false; reason: 'non-auditable' };
+    Audit: { reason: 'non-auditable' };
     Method: 'GET';
     Path: '/api/v1/integrations/:providerConfigKey/functions/:functionName';
     Querystring: { env: string; type?: FunctionType };
@@ -275,7 +275,7 @@ export type GetIntegrationFunction = ApiEndpoint<{
 }>;
 
 export type DeleteIntegrationFunction = ApiEndpoint<{
-    Audit: { audit: false; reason: 'TODO: audit coverage pending' };
+    Audit: { reason: 'TODO: audit coverage pending' };
     Method: 'DELETE';
     Path: '/api/v1/integrations/:providerConfigKey/functions/:functionName';
     /** TODO: support deleting on-event functions */
@@ -286,7 +286,7 @@ export type DeleteIntegrationFunction = ApiEndpoint<{
 }>;
 
 export type GetProviderTemplates = ApiEndpoint<{
-    Audit: { audit: false; reason: 'non-auditable' };
+    Audit: { reason: 'non-auditable' };
     Method: 'GET';
     Path: '/api/v1/providers/:providerConfigKey/templates';
     Querystring: { env: string };
@@ -295,7 +295,7 @@ export type GetProviderTemplates = ApiEndpoint<{
 }>;
 
 export type GetPublicIntegrationFunctions = ApiEndpoint<{
-    Audit: { audit: false; reason: 'non-auditable' };
+    Audit: { reason: 'non-auditable' };
     Method: 'GET';
     Path: '/integrations/:uniqueKey/functions';
     Querystring: FunctionListFilters;
@@ -304,7 +304,7 @@ export type GetPublicIntegrationFunctions = ApiEndpoint<{
 }>;
 
 export type GetPublicIntegrationFunction = ApiEndpoint<{
-    Audit: { audit: false; reason: 'non-auditable' };
+    Audit: { reason: 'non-auditable' };
     Method: 'GET';
     Path: '/integrations/:uniqueKey/functions/:name';
     Querystring: { type?: FunctionType };
@@ -313,7 +313,7 @@ export type GetPublicIntegrationFunction = ApiEndpoint<{
 }>;
 
 export type DeletePublicIntegrationFunction = ApiEndpoint<{
-    Audit: { audit: false; reason: 'TODO: audit coverage pending' };
+    Audit: { reason: 'TODO: audit coverage pending' };
     Method: 'DELETE';
     Path: '/integrations/:uniqueKey/functions/:name';
     /** TODO: support deleting on-event functions */
@@ -324,7 +324,7 @@ export type DeletePublicIntegrationFunction = ApiEndpoint<{
 }>;
 
 export type GetPublicProviderTemplates = ApiEndpoint<{
-    Audit: { audit: false; reason: 'non-auditable' };
+    Audit: { reason: 'non-auditable' };
     Method: 'GET';
     Path: '/providers/:provider/templates';
     Params: { provider: string };
@@ -332,7 +332,7 @@ export type GetPublicProviderTemplates = ApiEndpoint<{
 }>;
 
 export type GetIntegrationTemplates = ApiEndpoint<{
-    Audit: { audit: false; reason: 'non-auditable' };
+    Audit: { reason: 'non-auditable' };
     Method: 'GET';
     Path: '/api/v1/integrations/:providerConfigKey/templates';
     Querystring: { env: string };

--- a/packages/types/lib/functions/api.ts
+++ b/packages/types/lib/functions/api.ts
@@ -1,4 +1,4 @@
-import type { ApiError, Endpoint } from '../api.js';
+import type { ApiEndpoint, ApiError } from '../api.js';
 import type { DeployedNangoFunction, FunctionType, NangoActionFunction, NangoFunctionTemplate, NangoSyncFunction } from './domain.js';
 
 export type RunnableFunctionType = Extract<FunctionType, 'action' | 'sync'>;
@@ -163,7 +163,8 @@ export type FunctionDeploymentResultBody =
           };
       };
 
-export type PostFunctionCompile = Endpoint<{
+export type PostFunctionCompile = ApiEndpoint<{
+    Audit: { audit: false; reason: 'TODO: audit coverage pending' };
     Method: 'POST';
     Path: '/functions/compile';
     Body: FunctionCompileBody;
@@ -171,7 +172,8 @@ export type PostFunctionCompile = Endpoint<{
     Success: FunctionCompileSuccess;
 }>;
 
-export type PostFunctionDryrun = Endpoint<{
+export type PostFunctionDryrun = ApiEndpoint<{
+    Audit: { audit: false; reason: 'TODO: audit coverage pending' };
     Method: 'POST';
     Path: '/functions/dryruns';
     Body: FunctionDryrunBody;
@@ -179,7 +181,8 @@ export type PostFunctionDryrun = Endpoint<{
     Success: FunctionDryrunCreateSuccess;
 }>;
 
-export type GetFunctionDryrun = Endpoint<{
+export type GetFunctionDryrun = ApiEndpoint<{
+    Audit: { audit: false; reason: 'non-auditable' };
     Method: 'GET';
     Path: '/functions/dryruns/:id';
     Params: { id: string };
@@ -187,7 +190,8 @@ export type GetFunctionDryrun = Endpoint<{
     Success: FunctionDryrunResultSuccess;
 }>;
 
-export type PostFunctionDryrunResult = Endpoint<{
+export type PostFunctionDryrunResult = ApiEndpoint<{
+    Audit: { audit: false; reason: 'TODO: audit coverage pending' };
     Method: 'POST';
     Path: '/functions/dryruns/:id/result';
     Params: { id: string };
@@ -196,7 +200,8 @@ export type PostFunctionDryrunResult = Endpoint<{
     Success: { ok: true };
 }>;
 
-export type PostFunctionDeployment = Endpoint<{
+export type PostFunctionDeployment = ApiEndpoint<{
+    Audit: { audit: false; reason: 'TODO: audit coverage pending' };
     Method: 'POST';
     Path: '/functions/deployments';
     Body: FunctionDeploymentBody;
@@ -206,7 +211,8 @@ export type PostFunctionDeployment = Endpoint<{
     Success: FunctionDeploymentCreateSuccess;
 }>;
 
-export type GetFunctionDeployment = Endpoint<{
+export type GetFunctionDeployment = ApiEndpoint<{
+    Audit: { audit: false; reason: 'non-auditable' };
     Method: 'GET';
     Path: '/functions/deployments/:id';
     Params: { id: string };
@@ -214,7 +220,8 @@ export type GetFunctionDeployment = Endpoint<{
     Success: FunctionDeploymentResultSuccess;
 }>;
 
-export type PostFunctionDeploymentResult = Endpoint<{
+export type PostFunctionDeploymentResult = ApiEndpoint<{
+    Audit: { audit: false; reason: 'TODO: audit coverage pending' };
     Method: 'POST';
     Path: '/functions/deployments/:id/result';
     Params: { id: string };
@@ -249,7 +256,8 @@ export interface ProviderTemplatesSuccess {
     data: (NangoSyncFunction | NangoActionFunction)[];
 }
 
-export type GetIntegrationFunctions = Endpoint<{
+export type GetIntegrationFunctions = ApiEndpoint<{
+    Audit: { audit: false; reason: 'non-auditable' };
     Method: 'GET';
     Path: '/api/v1/integrations/:providerConfigKey/functions';
     Querystring: { env: string } & FunctionListFilters;
@@ -257,7 +265,8 @@ export type GetIntegrationFunctions = Endpoint<{
     Success: FunctionListSuccess;
 }>;
 
-export type GetIntegrationFunction = Endpoint<{
+export type GetIntegrationFunction = ApiEndpoint<{
+    Audit: { audit: false; reason: 'non-auditable' };
     Method: 'GET';
     Path: '/api/v1/integrations/:providerConfigKey/functions/:functionName';
     Querystring: { env: string; type?: FunctionType };
@@ -265,7 +274,8 @@ export type GetIntegrationFunction = Endpoint<{
     Success: DeployedFunctionSuccess;
 }>;
 
-export type DeleteIntegrationFunction = Endpoint<{
+export type DeleteIntegrationFunction = ApiEndpoint<{
+    Audit: { audit: false; reason: 'TODO: audit coverage pending' };
     Method: 'DELETE';
     Path: '/api/v1/integrations/:providerConfigKey/functions/:functionName';
     /** TODO: support deleting on-event functions */
@@ -275,7 +285,8 @@ export type DeleteIntegrationFunction = Endpoint<{
     Success: FunctionDeletionSuccess;
 }>;
 
-export type GetProviderTemplates = Endpoint<{
+export type GetProviderTemplates = ApiEndpoint<{
+    Audit: { audit: false; reason: 'non-auditable' };
     Method: 'GET';
     Path: '/api/v1/providers/:providerConfigKey/templates';
     Querystring: { env: string };
@@ -283,7 +294,8 @@ export type GetProviderTemplates = Endpoint<{
     Success: ProviderTemplatesSuccess;
 }>;
 
-export type GetPublicIntegrationFunctions = Endpoint<{
+export type GetPublicIntegrationFunctions = ApiEndpoint<{
+    Audit: { audit: false; reason: 'non-auditable' };
     Method: 'GET';
     Path: '/integrations/:uniqueKey/functions';
     Querystring: FunctionListFilters;
@@ -291,7 +303,8 @@ export type GetPublicIntegrationFunctions = Endpoint<{
     Success: FunctionListSuccess;
 }>;
 
-export type GetPublicIntegrationFunction = Endpoint<{
+export type GetPublicIntegrationFunction = ApiEndpoint<{
+    Audit: { audit: false; reason: 'non-auditable' };
     Method: 'GET';
     Path: '/integrations/:uniqueKey/functions/:name';
     Querystring: { type?: FunctionType };
@@ -299,7 +312,8 @@ export type GetPublicIntegrationFunction = Endpoint<{
     Success: DeployedFunctionSuccess;
 }>;
 
-export type DeletePublicIntegrationFunction = Endpoint<{
+export type DeletePublicIntegrationFunction = ApiEndpoint<{
+    Audit: { audit: false; reason: 'TODO: audit coverage pending' };
     Method: 'DELETE';
     Path: '/integrations/:uniqueKey/functions/:name';
     /** TODO: support deleting on-event functions */
@@ -309,14 +323,16 @@ export type DeletePublicIntegrationFunction = Endpoint<{
     Success: FunctionDeletionSuccess;
 }>;
 
-export type GetPublicProviderTemplates = Endpoint<{
+export type GetPublicProviderTemplates = ApiEndpoint<{
+    Audit: { audit: false; reason: 'non-auditable' };
     Method: 'GET';
     Path: '/providers/:provider/templates';
     Params: { provider: string };
     Success: ProviderTemplatesSuccess;
 }>;
 
-export type GetIntegrationTemplates = Endpoint<{
+export type GetIntegrationTemplates = ApiEndpoint<{
+    Audit: { audit: false; reason: 'non-auditable' };
     Method: 'GET';
     Path: '/api/v1/integrations/:providerConfigKey/templates';
     Querystring: { env: string };

--- a/packages/types/lib/gettingStarted/api.ts
+++ b/packages/types/lib/gettingStarted/api.ts
@@ -2,7 +2,7 @@ import type { ApiEndpoint, ApiError } from '../api.js';
 import type { GettingStartedOutput as GettingStartedProgressOutput, PatchGettingStartedInput as PatchGettingStartedProgressInput } from './dto.js';
 
 export type GetGettingStarted = ApiEndpoint<{
-    Audit: { reason: 'non-auditable' };
+    Audit: { kind: 'no-audit'; reason: 'non-auditable' };
     Method: 'GET';
     Path: '/api/v1/getting-started';
     Querystring: { env: string };
@@ -13,7 +13,7 @@ export type GetGettingStarted = ApiEndpoint<{
 }>;
 
 export type PatchGettingStarted = ApiEndpoint<{
-    Audit: { reason: 'non-auditable' };
+    Audit: { kind: 'no-audit'; reason: 'non-auditable' };
     Method: 'PATCH';
     Path: '/api/v1/getting-started';
     Querystring: { env: string };

--- a/packages/types/lib/gettingStarted/api.ts
+++ b/packages/types/lib/gettingStarted/api.ts
@@ -1,7 +1,8 @@
-import type { ApiError, Endpoint } from '../api.js';
+import type { ApiEndpoint, ApiError } from '../api.js';
 import type { GettingStartedOutput as GettingStartedProgressOutput, PatchGettingStartedInput as PatchGettingStartedProgressInput } from './dto.js';
 
-export type GetGettingStarted = Endpoint<{
+export type GetGettingStarted = ApiEndpoint<{
+    Audit: { audit: false; reason: 'non-auditable' };
     Method: 'GET';
     Path: '/api/v1/getting-started';
     Querystring: { env: string };
@@ -11,7 +12,8 @@ export type GetGettingStarted = Endpoint<{
     Error: ApiError<'failed_to_get_or_create_getting_started_progress'>;
 }>;
 
-export type PatchGettingStarted = Endpoint<{
+export type PatchGettingStarted = ApiEndpoint<{
+    Audit: { audit: false; reason: 'non-auditable' };
     Method: 'PATCH';
     Path: '/api/v1/getting-started';
     Querystring: { env: string };

--- a/packages/types/lib/gettingStarted/api.ts
+++ b/packages/types/lib/gettingStarted/api.ts
@@ -2,7 +2,7 @@ import type { ApiEndpoint, ApiError } from '../api.js';
 import type { GettingStartedOutput as GettingStartedProgressOutput, PatchGettingStartedInput as PatchGettingStartedProgressInput } from './dto.js';
 
 export type GetGettingStarted = ApiEndpoint<{
-    Audit: { audit: false; reason: 'non-auditable' };
+    Audit: { reason: 'non-auditable' };
     Method: 'GET';
     Path: '/api/v1/getting-started';
     Querystring: { env: string };
@@ -13,7 +13,7 @@ export type GetGettingStarted = ApiEndpoint<{
 }>;
 
 export type PatchGettingStarted = ApiEndpoint<{
-    Audit: { audit: false; reason: 'non-auditable' };
+    Audit: { reason: 'non-auditable' };
     Method: 'PATCH';
     Path: '/api/v1/getting-started';
     Querystring: { env: string };

--- a/packages/types/lib/integration/api.ts
+++ b/packages/types/lib/integration/api.ts
@@ -41,7 +41,7 @@ export interface ApiPublicIntegrationInclude {
 }
 
 export type GetPublicListIntegrations = ApiEndpoint<{
-    Audit: { reason: 'non-auditable' };
+    Audit: { kind: 'no-audit'; reason: 'non-auditable' };
     Method: 'GET';
     Path: '/integrations';
     Querystring?: { connect_session_token: string };
@@ -51,7 +51,7 @@ export type GetPublicListIntegrations = ApiEndpoint<{
 }>;
 
 export type PostPublicIntegration = ApiEndpoint<{
-    Audit: { reason: 'TODO: audit coverage pending' };
+    Audit: { kind: 'no-audit'; reason: 'TODO: audit coverage pending' };
     Method: 'POST';
     Path: '/integrations';
     Body: {
@@ -68,7 +68,7 @@ export type PostPublicIntegration = ApiEndpoint<{
 }>;
 
 export type PostPublicQuickstartIntegration = ApiEndpoint<{
-    Audit: { reason: 'TODO: audit coverage pending' };
+    Audit: { kind: 'no-audit'; reason: 'TODO: audit coverage pending' };
     Method: 'POST';
     Path: '/integrations/quickstart';
     Body: {
@@ -83,7 +83,7 @@ export type PostPublicQuickstartIntegration = ApiEndpoint<{
 }>;
 
 export type GetPublicIntegration = ApiEndpoint<{
-    Audit: { reason: 'non-auditable' };
+    Audit: { kind: 'no-audit'; reason: 'non-auditable' };
     Method: 'GET';
     Path: '/integrations/:uniqueKey';
     Params: { uniqueKey: string };
@@ -92,7 +92,7 @@ export type GetPublicIntegration = ApiEndpoint<{
 }>;
 
 export type PatchPublicIntegration = ApiEndpoint<{
-    Audit: { reason: 'TODO: audit coverage pending' };
+    Audit: { kind: 'no-audit'; reason: 'TODO: audit coverage pending' };
     Method: 'PATCH';
     Path: '/integrations/:uniqueKey';
     Params: { uniqueKey: string };
@@ -113,7 +113,7 @@ export type PatchPublicIntegration = ApiEndpoint<{
 }>;
 
 export type DeletePublicIntegration = ApiEndpoint<{
-    Audit: { reason: 'TODO: audit coverage pending' };
+    Audit: { kind: 'no-audit'; reason: 'TODO: audit coverage pending' };
     Method: 'DELETE';
     Path: '/integrations/:uniqueKey';
     Params: { uniqueKey: string };
@@ -121,7 +121,7 @@ export type DeletePublicIntegration = ApiEndpoint<{
 }>;
 
 export type GetPublicFunctionCode = ApiEndpoint<{
-    Audit: { reason: 'non-auditable' };
+    Audit: { kind: 'no-audit'; reason: 'non-auditable' };
     Method: 'GET';
     Path: '/integrations/:uniqueKey/functions/:name/code';
     Params: {
@@ -139,7 +139,7 @@ export type GetPublicFunctionCode = ApiEndpoint<{
 }>;
 
 export type GetFunctionCode = ApiEndpoint<{
-    Audit: { reason: 'non-auditable' };
+    Audit: { kind: 'no-audit'; reason: 'non-auditable' };
     Method: 'GET';
     Path: '/api/v1/integrations/:providerConfigKey/functions/:functionName/code';
     Params: {
@@ -176,7 +176,7 @@ export type ApiIntegrationList = ApiIntegration & {
 };
 
 export type GetIntegrations = ApiEndpoint<{
-    Audit: { reason: 'non-auditable' };
+    Audit: { kind: 'no-audit'; reason: 'non-auditable' };
     Method: 'GET';
     Path: '/api/v1/integrations';
     Success: {
@@ -243,7 +243,7 @@ export type IntegrationAuthBody =
     | InstallPluginAuthBody;
 
 export type PostIntegration = ApiEndpoint<{
-    Audit: { reason: 'TODO: audit coverage pending' };
+    Audit: { kind: 'no-audit'; reason: 'TODO: audit coverage pending' };
     Method: 'POST';
     Path: '/api/v1/integrations';
     Querystring: { env: string };
@@ -265,7 +265,7 @@ export type PostIntegration = ApiEndpoint<{
 }>;
 
 export type GetIntegration = ApiEndpoint<{
-    Audit: { reason: 'non-auditable' };
+    Audit: { kind: 'no-audit'; reason: 'non-auditable' };
     Method: 'GET';
     Path: '/api/v1/integrations/:providerConfigKey';
     Querystring: { env: string };
@@ -286,7 +286,7 @@ export type GetIntegration = ApiEndpoint<{
 }>;
 
 export type PatchIntegration = ApiEndpoint<{
-    Audit: { reason: 'TODO: audit coverage pending' };
+    Audit: { kind: 'no-audit'; reason: 'TODO: audit coverage pending' };
     Method: 'PATCH';
     Path: '/api/v1/integrations/:providerConfigKey';
     Querystring: { env: string };
@@ -309,7 +309,7 @@ export type PatchIntegration = ApiEndpoint<{
 }>;
 
 export type DeleteIntegration = ApiEndpoint<{
-    Audit: { reason: 'TODO: audit coverage pending' };
+    Audit: { kind: 'no-audit'; reason: 'TODO: audit coverage pending' };
     Method: 'DELETE';
     Path: '/api/v1/integrations/:providerConfigKey';
     Querystring: { env: string };
@@ -320,7 +320,7 @@ export type DeleteIntegration = ApiEndpoint<{
 }>;
 
 export type GetIntegrationFlows = ApiEndpoint<{
-    Audit: { reason: 'non-auditable' };
+    Audit: { kind: 'no-audit'; reason: 'non-auditable' };
     Method: 'GET';
     Path: '/api/v1/integrations/:providerConfigKey/flows';
     Querystring: { env: string };

--- a/packages/types/lib/integration/api.ts
+++ b/packages/types/lib/integration/api.ts
@@ -1,4 +1,4 @@
-import type { ApiError, ApiTimestamps, Endpoint } from '../api.js';
+import type { ApiEndpoint, ApiError, ApiTimestamps } from '../api.js';
 import type { AuthModes, AuthModeType } from '../auth/api.js';
 import type { NangoSyncConfig } from '../flow/index.js';
 import type { ScriptTypeLiteral } from '../nangoYaml/index.js';
@@ -40,7 +40,8 @@ export interface ApiPublicIntegrationInclude {
         | null;
 }
 
-export type GetPublicListIntegrations = Endpoint<{
+export type GetPublicListIntegrations = ApiEndpoint<{
+    Audit: { audit: false; reason: 'non-auditable' };
     Method: 'GET';
     Path: '/integrations';
     Querystring?: { connect_session_token: string };
@@ -49,7 +50,8 @@ export type GetPublicListIntegrations = Endpoint<{
     };
 }>;
 
-export type PostPublicIntegration = Endpoint<{
+export type PostPublicIntegration = ApiEndpoint<{
+    Audit: { audit: false; reason: 'TODO: audit coverage pending' };
     Method: 'POST';
     Path: '/integrations';
     Body: {
@@ -65,7 +67,8 @@ export type PostPublicIntegration = Endpoint<{
     };
 }>;
 
-export type PostPublicQuickstartIntegration = Endpoint<{
+export type PostPublicQuickstartIntegration = ApiEndpoint<{
+    Audit: { audit: false; reason: 'TODO: audit coverage pending' };
     Method: 'POST';
     Path: '/integrations/quickstart';
     Body: {
@@ -79,7 +82,8 @@ export type PostPublicQuickstartIntegration = Endpoint<{
     };
 }>;
 
-export type GetPublicIntegration = Endpoint<{
+export type GetPublicIntegration = ApiEndpoint<{
+    Audit: { audit: false; reason: 'non-auditable' };
     Method: 'GET';
     Path: '/integrations/:uniqueKey';
     Params: { uniqueKey: string };
@@ -87,7 +91,8 @@ export type GetPublicIntegration = Endpoint<{
     Success: { data: ApiPublicIntegration };
 }>;
 
-export type PatchPublicIntegration = Endpoint<{
+export type PatchPublicIntegration = ApiEndpoint<{
+    Audit: { audit: false; reason: 'TODO: audit coverage pending' };
     Method: 'PATCH';
     Path: '/integrations/:uniqueKey';
     Params: { uniqueKey: string };
@@ -107,14 +112,16 @@ export type PatchPublicIntegration = Endpoint<{
     };
 }>;
 
-export type DeletePublicIntegration = Endpoint<{
+export type DeletePublicIntegration = ApiEndpoint<{
+    Audit: { audit: false; reason: 'TODO: audit coverage pending' };
     Method: 'DELETE';
     Path: '/integrations/:uniqueKey';
     Params: { uniqueKey: string };
     Success: { success: true };
 }>;
 
-export type GetPublicFunctionCode = Endpoint<{
+export type GetPublicFunctionCode = ApiEndpoint<{
+    Audit: { audit: false; reason: 'non-auditable' };
     Method: 'GET';
     Path: '/integrations/:uniqueKey/functions/:name/code';
     Params: {
@@ -131,7 +138,8 @@ export type GetPublicFunctionCode = Endpoint<{
     Error: ApiError<'not_found'> | ApiError<'ambiguous_function', undefined, { matches: { type: ScriptTypeLiteral; name: string }[] }>;
 }>;
 
-export type GetFunctionCode = Endpoint<{
+export type GetFunctionCode = ApiEndpoint<{
+    Audit: { audit: false; reason: 'non-auditable' };
     Method: 'GET';
     Path: '/api/v1/integrations/:providerConfigKey/functions/:functionName/code';
     Params: {
@@ -167,7 +175,8 @@ export type ApiIntegrationList = ApiIntegration & {
     };
 };
 
-export type GetIntegrations = Endpoint<{
+export type GetIntegrations = ApiEndpoint<{
+    Audit: { audit: false; reason: 'non-auditable' };
     Method: 'GET';
     Path: '/api/v1/integrations';
     Success: {
@@ -233,7 +242,8 @@ export type IntegrationAuthBody =
     | MCPOAuth2GenericAuthBody
     | InstallPluginAuthBody;
 
-export type PostIntegration = Endpoint<{
+export type PostIntegration = ApiEndpoint<{
+    Audit: { audit: false; reason: 'TODO: audit coverage pending' };
     Method: 'POST';
     Path: '/api/v1/integrations';
     Querystring: { env: string };
@@ -254,7 +264,8 @@ export type PostIntegration = Endpoint<{
     };
 }>;
 
-export type GetIntegration = Endpoint<{
+export type GetIntegration = ApiEndpoint<{
+    Audit: { audit: false; reason: 'non-auditable' };
     Method: 'GET';
     Path: '/api/v1/integrations/:providerConfigKey';
     Querystring: { env: string };
@@ -274,7 +285,8 @@ export type GetIntegration = Endpoint<{
     };
 }>;
 
-export type PatchIntegration = Endpoint<{
+export type PatchIntegration = ApiEndpoint<{
+    Audit: { audit: false; reason: 'TODO: audit coverage pending' };
     Method: 'PATCH';
     Path: '/api/v1/integrations/:providerConfigKey';
     Querystring: { env: string };
@@ -296,7 +308,8 @@ export type PatchIntegration = Endpoint<{
     };
 }>;
 
-export type DeleteIntegration = Endpoint<{
+export type DeleteIntegration = ApiEndpoint<{
+    Audit: { audit: false; reason: 'TODO: audit coverage pending' };
     Method: 'DELETE';
     Path: '/api/v1/integrations/:providerConfigKey';
     Querystring: { env: string };
@@ -306,7 +319,8 @@ export type DeleteIntegration = Endpoint<{
     };
 }>;
 
-export type GetIntegrationFlows = Endpoint<{
+export type GetIntegrationFlows = ApiEndpoint<{
+    Audit: { audit: false; reason: 'non-auditable' };
     Method: 'GET';
     Path: '/api/v1/integrations/:providerConfigKey/flows';
     Querystring: { env: string };

--- a/packages/types/lib/integration/api.ts
+++ b/packages/types/lib/integration/api.ts
@@ -41,7 +41,7 @@ export interface ApiPublicIntegrationInclude {
 }
 
 export type GetPublicListIntegrations = ApiEndpoint<{
-    Audit: { audit: false; reason: 'non-auditable' };
+    Audit: { reason: 'non-auditable' };
     Method: 'GET';
     Path: '/integrations';
     Querystring?: { connect_session_token: string };
@@ -51,7 +51,7 @@ export type GetPublicListIntegrations = ApiEndpoint<{
 }>;
 
 export type PostPublicIntegration = ApiEndpoint<{
-    Audit: { audit: false; reason: 'TODO: audit coverage pending' };
+    Audit: { reason: 'TODO: audit coverage pending' };
     Method: 'POST';
     Path: '/integrations';
     Body: {
@@ -68,7 +68,7 @@ export type PostPublicIntegration = ApiEndpoint<{
 }>;
 
 export type PostPublicQuickstartIntegration = ApiEndpoint<{
-    Audit: { audit: false; reason: 'TODO: audit coverage pending' };
+    Audit: { reason: 'TODO: audit coverage pending' };
     Method: 'POST';
     Path: '/integrations/quickstart';
     Body: {
@@ -83,7 +83,7 @@ export type PostPublicQuickstartIntegration = ApiEndpoint<{
 }>;
 
 export type GetPublicIntegration = ApiEndpoint<{
-    Audit: { audit: false; reason: 'non-auditable' };
+    Audit: { reason: 'non-auditable' };
     Method: 'GET';
     Path: '/integrations/:uniqueKey';
     Params: { uniqueKey: string };
@@ -92,7 +92,7 @@ export type GetPublicIntegration = ApiEndpoint<{
 }>;
 
 export type PatchPublicIntegration = ApiEndpoint<{
-    Audit: { audit: false; reason: 'TODO: audit coverage pending' };
+    Audit: { reason: 'TODO: audit coverage pending' };
     Method: 'PATCH';
     Path: '/integrations/:uniqueKey';
     Params: { uniqueKey: string };
@@ -113,7 +113,7 @@ export type PatchPublicIntegration = ApiEndpoint<{
 }>;
 
 export type DeletePublicIntegration = ApiEndpoint<{
-    Audit: { audit: false; reason: 'TODO: audit coverage pending' };
+    Audit: { reason: 'TODO: audit coverage pending' };
     Method: 'DELETE';
     Path: '/integrations/:uniqueKey';
     Params: { uniqueKey: string };
@@ -121,7 +121,7 @@ export type DeletePublicIntegration = ApiEndpoint<{
 }>;
 
 export type GetPublicFunctionCode = ApiEndpoint<{
-    Audit: { audit: false; reason: 'non-auditable' };
+    Audit: { reason: 'non-auditable' };
     Method: 'GET';
     Path: '/integrations/:uniqueKey/functions/:name/code';
     Params: {
@@ -139,7 +139,7 @@ export type GetPublicFunctionCode = ApiEndpoint<{
 }>;
 
 export type GetFunctionCode = ApiEndpoint<{
-    Audit: { audit: false; reason: 'non-auditable' };
+    Audit: { reason: 'non-auditable' };
     Method: 'GET';
     Path: '/api/v1/integrations/:providerConfigKey/functions/:functionName/code';
     Params: {
@@ -176,7 +176,7 @@ export type ApiIntegrationList = ApiIntegration & {
 };
 
 export type GetIntegrations = ApiEndpoint<{
-    Audit: { audit: false; reason: 'non-auditable' };
+    Audit: { reason: 'non-auditable' };
     Method: 'GET';
     Path: '/api/v1/integrations';
     Success: {
@@ -243,7 +243,7 @@ export type IntegrationAuthBody =
     | InstallPluginAuthBody;
 
 export type PostIntegration = ApiEndpoint<{
-    Audit: { audit: false; reason: 'TODO: audit coverage pending' };
+    Audit: { reason: 'TODO: audit coverage pending' };
     Method: 'POST';
     Path: '/api/v1/integrations';
     Querystring: { env: string };
@@ -265,7 +265,7 @@ export type PostIntegration = ApiEndpoint<{
 }>;
 
 export type GetIntegration = ApiEndpoint<{
-    Audit: { audit: false; reason: 'non-auditable' };
+    Audit: { reason: 'non-auditable' };
     Method: 'GET';
     Path: '/api/v1/integrations/:providerConfigKey';
     Querystring: { env: string };
@@ -286,7 +286,7 @@ export type GetIntegration = ApiEndpoint<{
 }>;
 
 export type PatchIntegration = ApiEndpoint<{
-    Audit: { audit: false; reason: 'TODO: audit coverage pending' };
+    Audit: { reason: 'TODO: audit coverage pending' };
     Method: 'PATCH';
     Path: '/api/v1/integrations/:providerConfigKey';
     Querystring: { env: string };
@@ -309,7 +309,7 @@ export type PatchIntegration = ApiEndpoint<{
 }>;
 
 export type DeleteIntegration = ApiEndpoint<{
-    Audit: { audit: false; reason: 'TODO: audit coverage pending' };
+    Audit: { reason: 'TODO: audit coverage pending' };
     Method: 'DELETE';
     Path: '/api/v1/integrations/:providerConfigKey';
     Querystring: { env: string };
@@ -320,7 +320,7 @@ export type DeleteIntegration = ApiEndpoint<{
 }>;
 
 export type GetIntegrationFlows = ApiEndpoint<{
-    Audit: { audit: false; reason: 'non-auditable' };
+    Audit: { reason: 'non-auditable' };
     Method: 'GET';
     Path: '/api/v1/integrations/:providerConfigKey/flows';
     Querystring: { env: string };

--- a/packages/types/lib/invitations/api.ts
+++ b/packages/types/lib/invitations/api.ts
@@ -4,7 +4,7 @@ import type { ApiUser } from '../user/api.js';
 import type { Role } from '../user/db.js';
 
 export type PostInvite = ApiEndpoint<{
-    Audit: { reason: 'TODO: audit coverage pending' };
+    Audit: { kind: 'no-audit'; reason: 'TODO: audit coverage pending' };
     Method: 'POST';
     Path: '/api/v1/invite';
     Querystring: { env: string };
@@ -15,7 +15,7 @@ export type PostInvite = ApiEndpoint<{
 }>;
 
 export type DeleteInvite = ApiEndpoint<{
-    Audit: { reason: 'TODO: audit coverage pending' };
+    Audit: { kind: 'no-audit'; reason: 'TODO: audit coverage pending' };
     Method: 'DELETE';
     Path: '/api/v1/invite';
     Querystring: { env: string };
@@ -26,7 +26,7 @@ export type DeleteInvite = ApiEndpoint<{
 }>;
 
 export type GetInvite = ApiEndpoint<{
-    Audit: { reason: 'non-auditable' };
+    Audit: { kind: 'no-audit'; reason: 'non-auditable' };
     Method: 'GET';
     Path: '/api/v1/invite/:id';
     Params: { id: string };
@@ -42,7 +42,7 @@ export type GetInvite = ApiEndpoint<{
 }>;
 
 export type AcceptInvite = ApiEndpoint<{
-    Audit: { reason: 'TODO: audit coverage pending' };
+    Audit: { kind: 'no-audit'; reason: 'TODO: audit coverage pending' };
     Method: 'POST';
     Path: '/api/v1/invite/:id';
     Params: { id: string };
@@ -52,7 +52,7 @@ export type AcceptInvite = ApiEndpoint<{
 }>;
 
 export type DeclineInvite = ApiEndpoint<{
-    Audit: { reason: 'TODO: audit coverage pending' };
+    Audit: { kind: 'no-audit'; reason: 'TODO: audit coverage pending' };
     Method: 'DELETE';
     Path: '/api/v1/invite/:id';
     Params: { id: string };

--- a/packages/types/lib/invitations/api.ts
+++ b/packages/types/lib/invitations/api.ts
@@ -4,7 +4,7 @@ import type { ApiUser } from '../user/api.js';
 import type { Role } from '../user/db.js';
 
 export type PostInvite = ApiEndpoint<{
-    Audit: { audit: false; reason: 'TODO: audit coverage pending' };
+    Audit: { reason: 'TODO: audit coverage pending' };
     Method: 'POST';
     Path: '/api/v1/invite';
     Querystring: { env: string };
@@ -15,7 +15,7 @@ export type PostInvite = ApiEndpoint<{
 }>;
 
 export type DeleteInvite = ApiEndpoint<{
-    Audit: { audit: false; reason: 'TODO: audit coverage pending' };
+    Audit: { reason: 'TODO: audit coverage pending' };
     Method: 'DELETE';
     Path: '/api/v1/invite';
     Querystring: { env: string };
@@ -26,7 +26,7 @@ export type DeleteInvite = ApiEndpoint<{
 }>;
 
 export type GetInvite = ApiEndpoint<{
-    Audit: { audit: false; reason: 'non-auditable' };
+    Audit: { reason: 'non-auditable' };
     Method: 'GET';
     Path: '/api/v1/invite/:id';
     Params: { id: string };
@@ -42,7 +42,7 @@ export type GetInvite = ApiEndpoint<{
 }>;
 
 export type AcceptInvite = ApiEndpoint<{
-    Audit: { audit: false; reason: 'TODO: audit coverage pending' };
+    Audit: { reason: 'TODO: audit coverage pending' };
     Method: 'POST';
     Path: '/api/v1/invite/:id';
     Params: { id: string };
@@ -52,7 +52,7 @@ export type AcceptInvite = ApiEndpoint<{
 }>;
 
 export type DeclineInvite = ApiEndpoint<{
-    Audit: { audit: false; reason: 'TODO: audit coverage pending' };
+    Audit: { reason: 'TODO: audit coverage pending' };
     Method: 'DELETE';
     Path: '/api/v1/invite/:id';
     Params: { id: string };

--- a/packages/types/lib/invitations/api.ts
+++ b/packages/types/lib/invitations/api.ts
@@ -1,9 +1,10 @@
-import type { ApiError, Endpoint } from '../api.js';
+import type { ApiEndpoint, ApiError } from '../api.js';
 import type { ApiInvitation, ApiTeam } from '../team/api.js';
 import type { ApiUser } from '../user/api.js';
 import type { Role } from '../user/db.js';
 
-export type PostInvite = Endpoint<{
+export type PostInvite = ApiEndpoint<{
+    Audit: { audit: false; reason: 'TODO: audit coverage pending' };
     Method: 'POST';
     Path: '/api/v1/invite';
     Querystring: { env: string };
@@ -13,7 +14,8 @@ export type PostInvite = Endpoint<{
     };
 }>;
 
-export type DeleteInvite = Endpoint<{
+export type DeleteInvite = ApiEndpoint<{
+    Audit: { audit: false; reason: 'TODO: audit coverage pending' };
     Method: 'DELETE';
     Path: '/api/v1/invite';
     Querystring: { env: string };
@@ -23,7 +25,8 @@ export type DeleteInvite = Endpoint<{
     };
 }>;
 
-export type GetInvite = Endpoint<{
+export type GetInvite = ApiEndpoint<{
+    Audit: { audit: false; reason: 'non-auditable' };
     Method: 'GET';
     Path: '/api/v1/invite/:id';
     Params: { id: string };
@@ -38,7 +41,8 @@ export type GetInvite = Endpoint<{
     Errors: ApiError<'not_found'>;
 }>;
 
-export type AcceptInvite = Endpoint<{
+export type AcceptInvite = ApiEndpoint<{
+    Audit: { audit: false; reason: 'TODO: audit coverage pending' };
     Method: 'POST';
     Path: '/api/v1/invite/:id';
     Params: { id: string };
@@ -47,7 +51,8 @@ export type AcceptInvite = Endpoint<{
     };
 }>;
 
-export type DeclineInvite = Endpoint<{
+export type DeclineInvite = ApiEndpoint<{
+    Audit: { audit: false; reason: 'TODO: audit coverage pending' };
     Method: 'DELETE';
     Path: '/api/v1/invite/:id';
     Params: { id: string };

--- a/packages/types/lib/logs/api.ts
+++ b/packages/types/lib/logs/api.ts
@@ -1,5 +1,5 @@
 /* eslint-disable @typescript-eslint/no-redundant-type-constituents */
-import type { Endpoint } from '../api.js';
+import type { ApiEndpoint } from '../api.js';
 import type { PickFromUnion } from '../utils.js';
 import type { MessageRow, OperationList, OperationRow, OperationState } from './messages.js';
 
@@ -7,7 +7,8 @@ type Concat<T extends OperationList> = T extends { action: string } ? `${T['type
 export type ConcatOperationList = Concat<OperationList>;
 export type ConcatOperationListWithGroup = OperationList['type'] | ConcatOperationList;
 
-export type SearchOperations = Endpoint<{
+export type SearchOperations = ApiEndpoint<{
+    Audit: { audit: false; reason: 'non-auditable' };
     Method: 'POST';
     Path: '/api/v1/logs/operations';
     Querystring: { env: string };
@@ -38,7 +39,8 @@ export interface SearchPeriod {
 }
 export type SearchOperationsData = SearchOperations['Success']['data'][0];
 
-export type GetOperation = Endpoint<{
+export type GetOperation = ApiEndpoint<{
+    Audit: { audit: false; reason: 'non-auditable' };
     Method: 'GET';
     Path: `/api/v1/logs/operations/:operationId`;
     Querystring: { env: string };
@@ -48,7 +50,8 @@ export type GetOperation = Endpoint<{
     };
 }>;
 
-export type SearchMessages = Endpoint<{
+export type SearchMessages = ApiEndpoint<{
+    Audit: { audit: false; reason: 'non-auditable' };
     Method: 'POST';
     Path: '/api/v1/logs/messages';
     Querystring: { env: string };
@@ -68,7 +71,8 @@ export type SearchMessages = Endpoint<{
 }>;
 export type SearchMessagesData = SearchMessages['Success']['data'][0];
 
-export type SearchFilters = Endpoint<{
+export type SearchFilters = ApiEndpoint<{
+    Audit: { audit: false; reason: 'non-auditable' };
     Method: 'POST';
     Path: '/api/v1/logs/filters';
     Querystring: { env: string };
@@ -79,7 +83,8 @@ export type SearchFilters = Endpoint<{
 }>;
 export type SearchFiltersData = SearchMessages['Success']['data'][0];
 
-export type PostInsights = Endpoint<{
+export type PostInsights = ApiEndpoint<{
+    Audit: { audit: false; reason: 'non-auditable' };
     Method: 'POST';
     Path: '/api/v1/logs/insights';
     Querystring: { env: string };

--- a/packages/types/lib/logs/api.ts
+++ b/packages/types/lib/logs/api.ts
@@ -8,7 +8,7 @@ export type ConcatOperationList = Concat<OperationList>;
 export type ConcatOperationListWithGroup = OperationList['type'] | ConcatOperationList;
 
 export type SearchOperations = ApiEndpoint<{
-    Audit: { reason: 'non-auditable' };
+    Audit: { kind: 'no-audit'; reason: 'non-auditable' };
     Method: 'POST';
     Path: '/api/v1/logs/operations';
     Querystring: { env: string };
@@ -40,7 +40,7 @@ export interface SearchPeriod {
 export type SearchOperationsData = SearchOperations['Success']['data'][0];
 
 export type GetOperation = ApiEndpoint<{
-    Audit: { reason: 'non-auditable' };
+    Audit: { kind: 'no-audit'; reason: 'non-auditable' };
     Method: 'GET';
     Path: `/api/v1/logs/operations/:operationId`;
     Querystring: { env: string };
@@ -51,7 +51,7 @@ export type GetOperation = ApiEndpoint<{
 }>;
 
 export type SearchMessages = ApiEndpoint<{
-    Audit: { reason: 'non-auditable' };
+    Audit: { kind: 'no-audit'; reason: 'non-auditable' };
     Method: 'POST';
     Path: '/api/v1/logs/messages';
     Querystring: { env: string };
@@ -72,7 +72,7 @@ export type SearchMessages = ApiEndpoint<{
 export type SearchMessagesData = SearchMessages['Success']['data'][0];
 
 export type SearchFilters = ApiEndpoint<{
-    Audit: { reason: 'non-auditable' };
+    Audit: { kind: 'no-audit'; reason: 'non-auditable' };
     Method: 'POST';
     Path: '/api/v1/logs/filters';
     Querystring: { env: string };
@@ -84,7 +84,7 @@ export type SearchFilters = ApiEndpoint<{
 export type SearchFiltersData = SearchMessages['Success']['data'][0];
 
 export type PostInsights = ApiEndpoint<{
-    Audit: { reason: 'non-auditable' };
+    Audit: { kind: 'no-audit'; reason: 'non-auditable' };
     Method: 'POST';
     Path: '/api/v1/logs/insights';
     Querystring: { env: string };

--- a/packages/types/lib/logs/api.ts
+++ b/packages/types/lib/logs/api.ts
@@ -8,7 +8,7 @@ export type ConcatOperationList = Concat<OperationList>;
 export type ConcatOperationListWithGroup = OperationList['type'] | ConcatOperationList;
 
 export type SearchOperations = ApiEndpoint<{
-    Audit: { audit: false; reason: 'non-auditable' };
+    Audit: { reason: 'non-auditable' };
     Method: 'POST';
     Path: '/api/v1/logs/operations';
     Querystring: { env: string };
@@ -40,7 +40,7 @@ export interface SearchPeriod {
 export type SearchOperationsData = SearchOperations['Success']['data'][0];
 
 export type GetOperation = ApiEndpoint<{
-    Audit: { audit: false; reason: 'non-auditable' };
+    Audit: { reason: 'non-auditable' };
     Method: 'GET';
     Path: `/api/v1/logs/operations/:operationId`;
     Querystring: { env: string };
@@ -51,7 +51,7 @@ export type GetOperation = ApiEndpoint<{
 }>;
 
 export type SearchMessages = ApiEndpoint<{
-    Audit: { audit: false; reason: 'non-auditable' };
+    Audit: { reason: 'non-auditable' };
     Method: 'POST';
     Path: '/api/v1/logs/messages';
     Querystring: { env: string };
@@ -72,7 +72,7 @@ export type SearchMessages = ApiEndpoint<{
 export type SearchMessagesData = SearchMessages['Success']['data'][0];
 
 export type SearchFilters = ApiEndpoint<{
-    Audit: { audit: false; reason: 'non-auditable' };
+    Audit: { reason: 'non-auditable' };
     Method: 'POST';
     Path: '/api/v1/logs/filters';
     Querystring: { env: string };
@@ -84,7 +84,7 @@ export type SearchFilters = ApiEndpoint<{
 export type SearchFiltersData = SearchMessages['Success']['data'][0];
 
 export type PostInsights = ApiEndpoint<{
-    Audit: { audit: false; reason: 'non-auditable' };
+    Audit: { reason: 'non-auditable' };
     Method: 'POST';
     Path: '/api/v1/logs/insights';
     Querystring: { env: string };

--- a/packages/types/lib/mcp/api.ts
+++ b/packages/types/lib/mcp/api.ts
@@ -1,7 +1,7 @@
 import type { ApiEndpoint, ApiError } from '../api.js';
 
 export type PostConnectionToolsMcp = ApiEndpoint<{
-    Audit: { reason: 'non-auditable' };
+    Audit: { kind: 'no-audit'; reason: 'non-auditable' };
     Method: 'POST';
     Path: '/mcp';
     Body: Record<string, unknown>;
@@ -14,14 +14,14 @@ export type PostConnectionToolsMcp = ApiEndpoint<{
 }>;
 
 export type GetConnectionToolsMcp = ApiEndpoint<{
-    Audit: { reason: 'non-auditable' };
+    Audit: { kind: 'no-audit'; reason: 'non-auditable' };
     Method: 'GET';
     Path: '/mcp';
     Success: Record<string, unknown>;
 }>;
 
 export type PostControlPlaneMcp = ApiEndpoint<{
-    Audit: { reason: 'non-auditable' };
+    Audit: { kind: 'no-audit'; reason: 'non-auditable' };
     Method: 'POST';
     Path: '/mcp';
     Body: Record<string, unknown>;
@@ -29,7 +29,7 @@ export type PostControlPlaneMcp = ApiEndpoint<{
 }>;
 
 export type GetControlPlaneMcp = ApiEndpoint<{
-    Audit: { reason: 'non-auditable' };
+    Audit: { kind: 'no-audit'; reason: 'non-auditable' };
     Method: 'GET';
     Path: '/mcp';
     Success: Record<string, unknown>;

--- a/packages/types/lib/mcp/api.ts
+++ b/packages/types/lib/mcp/api.ts
@@ -1,7 +1,7 @@
 import type { ApiEndpoint, ApiError } from '../api.js';
 
 export type PostConnectionToolsMcp = ApiEndpoint<{
-    Audit: { audit: false; reason: 'non-auditable' };
+    Audit: { reason: 'non-auditable' };
     Method: 'POST';
     Path: '/mcp';
     Body: Record<string, unknown>;
@@ -14,14 +14,14 @@ export type PostConnectionToolsMcp = ApiEndpoint<{
 }>;
 
 export type GetConnectionToolsMcp = ApiEndpoint<{
-    Audit: { audit: false; reason: 'non-auditable' };
+    Audit: { reason: 'non-auditable' };
     Method: 'GET';
     Path: '/mcp';
     Success: Record<string, unknown>;
 }>;
 
 export type PostControlPlaneMcp = ApiEndpoint<{
-    Audit: { audit: false; reason: 'non-auditable' };
+    Audit: { reason: 'non-auditable' };
     Method: 'POST';
     Path: '/mcp';
     Body: Record<string, unknown>;
@@ -29,7 +29,7 @@ export type PostControlPlaneMcp = ApiEndpoint<{
 }>;
 
 export type GetControlPlaneMcp = ApiEndpoint<{
-    Audit: { audit: false; reason: 'non-auditable' };
+    Audit: { reason: 'non-auditable' };
     Method: 'GET';
     Path: '/mcp';
     Success: Record<string, unknown>;

--- a/packages/types/lib/mcp/api.ts
+++ b/packages/types/lib/mcp/api.ts
@@ -1,6 +1,7 @@
-import type { ApiError, Endpoint } from '../api.js';
+import type { ApiEndpoint, ApiError } from '../api.js';
 
-export type PostConnectionToolsMcp = Endpoint<{
+export type PostConnectionToolsMcp = ApiEndpoint<{
+    Audit: { audit: false; reason: 'non-auditable' };
     Method: 'POST';
     Path: '/mcp';
     Body: Record<string, unknown>;
@@ -12,20 +13,23 @@ export type PostConnectionToolsMcp = Endpoint<{
     Error: ApiError<'missing_connection_id' | 'unknown_connection'>;
 }>;
 
-export type GetConnectionToolsMcp = Endpoint<{
+export type GetConnectionToolsMcp = ApiEndpoint<{
+    Audit: { audit: false; reason: 'non-auditable' };
     Method: 'GET';
     Path: '/mcp';
     Success: Record<string, unknown>;
 }>;
 
-export type PostControlPlaneMcp = Endpoint<{
+export type PostControlPlaneMcp = ApiEndpoint<{
+    Audit: { audit: false; reason: 'non-auditable' };
     Method: 'POST';
     Path: '/mcp';
     Body: Record<string, unknown>;
     Success: Record<string, unknown>;
 }>;
 
-export type GetControlPlaneMcp = Endpoint<{
+export type GetControlPlaneMcp = ApiEndpoint<{
+    Audit: { audit: false; reason: 'non-auditable' };
     Method: 'GET';
     Path: '/mcp';
     Success: Record<string, unknown>;

--- a/packages/types/lib/meta/api.ts
+++ b/packages/types/lib/meta/api.ts
@@ -2,7 +2,7 @@ import type { ApiEndpoint, ApiError } from '../api.js';
 import type { DBEnvironment } from '../environment/db.js';
 
 export type GetMeta = ApiEndpoint<{
-    Audit: { reason: 'non-auditable' };
+    Audit: { kind: 'no-audit'; reason: 'non-auditable' };
     Method: 'GET';
     Path: '/api/v1/meta';
     Querystring: { env: string };

--- a/packages/types/lib/meta/api.ts
+++ b/packages/types/lib/meta/api.ts
@@ -1,7 +1,8 @@
-import type { ApiError, Endpoint } from '../api.js';
+import type { ApiEndpoint, ApiError } from '../api.js';
 import type { DBEnvironment } from '../environment/db.js';
 
-export type GetMeta = Endpoint<{
+export type GetMeta = ApiEndpoint<{
+    Audit: { audit: false; reason: 'non-auditable' };
     Method: 'GET';
     Path: '/api/v1/meta';
     Querystring: { env: string };

--- a/packages/types/lib/meta/api.ts
+++ b/packages/types/lib/meta/api.ts
@@ -2,7 +2,7 @@ import type { ApiEndpoint, ApiError } from '../api.js';
 import type { DBEnvironment } from '../environment/db.js';
 
 export type GetMeta = ApiEndpoint<{
-    Audit: { audit: false; reason: 'non-auditable' };
+    Audit: { reason: 'non-auditable' };
     Method: 'GET';
     Path: '/api/v1/meta';
     Querystring: { env: string };

--- a/packages/types/lib/mfa/api.ts
+++ b/packages/types/lib/mfa/api.ts
@@ -4,14 +4,14 @@ import type { ApiUser } from '../user/api.js';
 type MFAError = ApiError<'invalid_mfa_code'> | ApiError<'mfa_already_enabled'> | ApiError<'mfa_enrollment_not_found'> | ApiError<'mfa_not_enabled'>;
 
 export type GetMFAStatus = ApiEndpoint<{
-    Audit: { audit: false; reason: 'non-auditable' };
+    Audit: { reason: 'non-auditable' };
     Method: 'GET';
     Path: '/api/v1/account/mfa';
     Success: { data: { enabled: boolean } };
 }>;
 
 export type PostMFAEnrollment = ApiEndpoint<{
-    Audit: { audit: false; reason: 'to be discussed' };
+    Audit: { reason: 'to be discussed' };
     Method: 'POST';
     Path: '/api/v1/account/mfa/enroll';
     Error: ApiError<'mfa_already_enabled'>;
@@ -19,7 +19,7 @@ export type PostMFAEnrollment = ApiEndpoint<{
 }>;
 
 export type PostMFAActivation = ApiEndpoint<{
-    Audit: { audit: false; reason: 'to be discussed' };
+    Audit: { reason: 'to be discussed' };
     Method: 'POST';
     Path: '/api/v1/account/mfa/activate';
     Body: { code: string };
@@ -28,7 +28,7 @@ export type PostMFAActivation = ApiEndpoint<{
 }>;
 
 export type PostMFARecoveryCodes = ApiEndpoint<{
-    Audit: { audit: false; reason: 'to be discussed' };
+    Audit: { reason: 'to be discussed' };
     Method: 'POST';
     Path: '/api/v1/account/mfa/recovery-codes';
     Body: { code: string };
@@ -37,7 +37,7 @@ export type PostMFARecoveryCodes = ApiEndpoint<{
 }>;
 
 export type DeleteMFA = ApiEndpoint<{
-    Audit: { audit: false; reason: 'to be discussed' };
+    Audit: { reason: 'to be discussed' };
     Method: 'DELETE';
     Path: '/api/v1/account/mfa';
     Body: { code: string };
@@ -48,7 +48,7 @@ export type DeleteMFA = ApiEndpoint<{
 export type MFAEndpointError = MFAError;
 
 export type PostMFALoginVerification = ApiEndpoint<{
-    Audit: { audit: false; reason: 'to be discussed' };
+    Audit: { reason: 'to be discussed' };
     Method: 'POST';
     Path: '/api/v1/account/mfa/login/verify';
     Body: { type: 'code'; code: string } | { type: 'recoveryCode'; recoveryCode: string };

--- a/packages/types/lib/mfa/api.ts
+++ b/packages/types/lib/mfa/api.ts
@@ -4,14 +4,14 @@ import type { ApiUser } from '../user/api.js';
 type MFAError = ApiError<'invalid_mfa_code'> | ApiError<'mfa_already_enabled'> | ApiError<'mfa_enrollment_not_found'> | ApiError<'mfa_not_enabled'>;
 
 export type GetMFAStatus = ApiEndpoint<{
-    Audit: { reason: 'non-auditable' };
+    Audit: { kind: 'no-audit'; reason: 'non-auditable' };
     Method: 'GET';
     Path: '/api/v1/account/mfa';
     Success: { data: { enabled: boolean } };
 }>;
 
 export type PostMFAEnrollment = ApiEndpoint<{
-    Audit: { reason: 'to be discussed' };
+    Audit: { kind: 'no-audit'; reason: 'to be discussed' };
     Method: 'POST';
     Path: '/api/v1/account/mfa/enroll';
     Error: ApiError<'mfa_already_enabled'>;
@@ -19,7 +19,7 @@ export type PostMFAEnrollment = ApiEndpoint<{
 }>;
 
 export type PostMFAActivation = ApiEndpoint<{
-    Audit: { reason: 'to be discussed' };
+    Audit: { kind: 'no-audit'; reason: 'to be discussed' };
     Method: 'POST';
     Path: '/api/v1/account/mfa/activate';
     Body: { code: string };
@@ -28,7 +28,7 @@ export type PostMFAActivation = ApiEndpoint<{
 }>;
 
 export type PostMFARecoveryCodes = ApiEndpoint<{
-    Audit: { reason: 'to be discussed' };
+    Audit: { kind: 'no-audit'; reason: 'to be discussed' };
     Method: 'POST';
     Path: '/api/v1/account/mfa/recovery-codes';
     Body: { code: string };
@@ -37,7 +37,7 @@ export type PostMFARecoveryCodes = ApiEndpoint<{
 }>;
 
 export type DeleteMFA = ApiEndpoint<{
-    Audit: { reason: 'to be discussed' };
+    Audit: { kind: 'no-audit'; reason: 'to be discussed' };
     Method: 'DELETE';
     Path: '/api/v1/account/mfa';
     Body: { code: string };
@@ -48,7 +48,7 @@ export type DeleteMFA = ApiEndpoint<{
 export type MFAEndpointError = MFAError;
 
 export type PostMFALoginVerification = ApiEndpoint<{
-    Audit: { reason: 'to be discussed' };
+    Audit: { kind: 'no-audit'; reason: 'to be discussed' };
     Method: 'POST';
     Path: '/api/v1/account/mfa/login/verify';
     Body: { type: 'code'; code: string } | { type: 'recoveryCode'; recoveryCode: string };

--- a/packages/types/lib/mfa/api.ts
+++ b/packages/types/lib/mfa/api.ts
@@ -1,22 +1,25 @@
-import type { ApiError, Endpoint } from '../api.js';
+import type { ApiEndpoint, ApiError } from '../api.js';
 import type { ApiUser } from '../user/api.js';
 
 type MFAError = ApiError<'invalid_mfa_code'> | ApiError<'mfa_already_enabled'> | ApiError<'mfa_enrollment_not_found'> | ApiError<'mfa_not_enabled'>;
 
-export type GetMFAStatus = Endpoint<{
+export type GetMFAStatus = ApiEndpoint<{
+    Audit: { audit: false; reason: 'non-auditable' };
     Method: 'GET';
     Path: '/api/v1/account/mfa';
     Success: { data: { enabled: boolean } };
 }>;
 
-export type PostMFAEnrollment = Endpoint<{
+export type PostMFAEnrollment = ApiEndpoint<{
+    Audit: { audit: false; reason: 'to be discussed' };
     Method: 'POST';
     Path: '/api/v1/account/mfa/enroll';
     Error: ApiError<'mfa_already_enabled'>;
     Success: { data: { otpauthUri: string } };
 }>;
 
-export type PostMFAActivation = Endpoint<{
+export type PostMFAActivation = ApiEndpoint<{
+    Audit: { audit: false; reason: 'to be discussed' };
     Method: 'POST';
     Path: '/api/v1/account/mfa/activate';
     Body: { code: string };
@@ -24,7 +27,8 @@ export type PostMFAActivation = Endpoint<{
     Success: { data: { recoveryCodes: string[] } };
 }>;
 
-export type PostMFARecoveryCodes = Endpoint<{
+export type PostMFARecoveryCodes = ApiEndpoint<{
+    Audit: { audit: false; reason: 'to be discussed' };
     Method: 'POST';
     Path: '/api/v1/account/mfa/recovery-codes';
     Body: { code: string };
@@ -32,7 +36,8 @@ export type PostMFARecoveryCodes = Endpoint<{
     Success: { data: { recoveryCodes: string[] } };
 }>;
 
-export type DeleteMFA = Endpoint<{
+export type DeleteMFA = ApiEndpoint<{
+    Audit: { audit: false; reason: 'to be discussed' };
     Method: 'DELETE';
     Path: '/api/v1/account/mfa';
     Body: { code: string };
@@ -42,7 +47,8 @@ export type DeleteMFA = Endpoint<{
 
 export type MFAEndpointError = MFAError;
 
-export type PostMFALoginVerification = Endpoint<{
+export type PostMFALoginVerification = ApiEndpoint<{
+    Audit: { audit: false; reason: 'to be discussed' };
     Method: 'POST';
     Path: '/api/v1/account/mfa/login/verify';
     Body: { type: 'code'; code: string } | { type: 'recoveryCode'; recoveryCode: string };

--- a/packages/types/lib/plain/api.ts
+++ b/packages/types/lib/plain/api.ts
@@ -1,6 +1,7 @@
-import type { ApiError, Endpoint } from '../api.js';
+import type { ApiEndpoint, ApiError } from '../api.js';
 
-export type GetPlainHmac = Endpoint<{
+export type GetPlainHmac = ApiEndpoint<{
+    Audit: { audit: false; reason: 'non-auditable' };
     Method: 'GET';
     Path: `/api/v1/plain`;
     Success: { data: { hash: string } };

--- a/packages/types/lib/plain/api.ts
+++ b/packages/types/lib/plain/api.ts
@@ -1,7 +1,7 @@
 import type { ApiEndpoint, ApiError } from '../api.js';
 
 export type GetPlainHmac = ApiEndpoint<{
-    Audit: { audit: false; reason: 'non-auditable' };
+    Audit: { reason: 'non-auditable' };
     Method: 'GET';
     Path: `/api/v1/plain`;
     Success: { data: { hash: string } };

--- a/packages/types/lib/plain/api.ts
+++ b/packages/types/lib/plain/api.ts
@@ -1,7 +1,7 @@
 import type { ApiEndpoint, ApiError } from '../api.js';
 
 export type GetPlainHmac = ApiEndpoint<{
-    Audit: { reason: 'non-auditable' };
+    Audit: { kind: 'no-audit'; reason: 'non-auditable' };
     Method: 'GET';
     Path: `/api/v1/plain`;
     Success: { data: { hash: string } };

--- a/packages/types/lib/plans/http.api.ts
+++ b/packages/types/lib/plans/http.api.ts
@@ -1,4 +1,4 @@
-import type { Endpoint } from '../api.js';
+import type { ApiEndpoint } from '../api.js';
 import type { ApiBillingUsageMetrics, BillingCustomer, BillingInvoicingDetails, BreakdownDimensions } from '../billing/types.js';
 import type { MetricUsageSummary, UsageMetric } from '../usage/index.js';
 import type { ReplaceInObject } from '../utils.js';
@@ -6,7 +6,8 @@ import type { DBPlan } from './db.js';
 
 export type ApiPlan = ReplaceInObject<DBPlan, Date, string>;
 
-export type PostPlanExtendTrial = Endpoint<{
+export type PostPlanExtendTrial = ApiEndpoint<{
+    Audit: { audit: false; reason: 'TODO: audit coverage pending' };
     Method: 'POST';
     Path: '/api/v1/plans/trial/extension';
     Querystring: { env: string };
@@ -32,7 +33,8 @@ export interface PlanDefinition {
     flags: Omit<Partial<DBPlan>, 'id' | 'account_id' | 'name'>;
 }
 
-export type GetPlans = Endpoint<{
+export type GetPlans = ApiEndpoint<{
+    Audit: { audit: false; reason: 'non-auditable' };
     Method: 'GET';
     Path: '/api/v1/plans';
     Querystring: { env: string };
@@ -41,7 +43,8 @@ export type GetPlans = Endpoint<{
     };
 }>;
 
-export type GetPlan = Endpoint<{
+export type GetPlan = ApiEndpoint<{
+    Audit: { audit: false; reason: 'non-auditable' };
     Method: 'GET';
     Path: '/api/v1/plans/current';
     Querystring: { env: string };
@@ -50,7 +53,8 @@ export type GetPlan = Endpoint<{
     };
 }>;
 
-export type GetUsage = Endpoint<{
+export type GetUsage = ApiEndpoint<{
+    Audit: { audit: false; reason: 'non-auditable' };
     Method: 'GET';
     Path: '/api/v1/plans/usage';
     Querystring: { env: string };
@@ -68,7 +72,8 @@ export type GetUsage = Endpoint<{
 // Querystring is a per-metric discriminated union so the `dimension` field is
 // constrained to the metric's whitelist at compile time; the controller's zod
 // schema enforces the same shape at runtime.
-export type GetBillingUsageTopDimensionValues = Endpoint<{
+export type GetBillingUsageTopDimensionValues = ApiEndpoint<{
+    Audit: { audit: false; reason: 'non-auditable' };
     Method: 'GET';
     Path: '/api/v1/plans/billing-usage/top-dimension-values';
     Querystring: {
@@ -100,7 +105,8 @@ export type GetBillingUsageTopDimensionValues = Endpoint<{
     };
 }>;
 
-export type GetBillingUsage = Endpoint<{
+export type GetBillingUsage = ApiEndpoint<{
+    Audit: { audit: false; reason: 'non-auditable' };
     Method: 'GET';
     Path: '/api/v1/plans/billing-usage';
     Querystring: {
@@ -139,7 +145,8 @@ export type GetBillingUsage = Endpoint<{
     };
 }>;
 
-export type PutBillingInvoicingDetails = Endpoint<{
+export type PutBillingInvoicingDetails = ApiEndpoint<{
+    Audit: { audit: false; reason: 'TODO: audit coverage pending' };
     Method: 'PUT';
     Path: '/api/v1/plans/billing/invoicing';
     Querystring: { env: string };
@@ -149,7 +156,8 @@ export type PutBillingInvoicingDetails = Endpoint<{
     };
 }>;
 
-export type PostPlanChange = Endpoint<{
+export type PostPlanChange = ApiEndpoint<{
+    Audit: { audit: false; reason: 'TODO: audit coverage pending' };
     Method: 'POST';
     Path: '/api/v1/plans/change';
     Querystring: { env: string };

--- a/packages/types/lib/plans/http.api.ts
+++ b/packages/types/lib/plans/http.api.ts
@@ -7,7 +7,7 @@ import type { DBPlan } from './db.js';
 export type ApiPlan = ReplaceInObject<DBPlan, Date, string>;
 
 export type PostPlanExtendTrial = ApiEndpoint<{
-    Audit: { reason: 'TODO: audit coverage pending' };
+    Audit: { kind: 'no-audit'; reason: 'TODO: audit coverage pending' };
     Method: 'POST';
     Path: '/api/v1/plans/trial/extension';
     Querystring: { env: string };
@@ -34,7 +34,7 @@ export interface PlanDefinition {
 }
 
 export type GetPlans = ApiEndpoint<{
-    Audit: { reason: 'non-auditable' };
+    Audit: { kind: 'no-audit'; reason: 'non-auditable' };
     Method: 'GET';
     Path: '/api/v1/plans';
     Querystring: { env: string };
@@ -44,7 +44,7 @@ export type GetPlans = ApiEndpoint<{
 }>;
 
 export type GetPlan = ApiEndpoint<{
-    Audit: { reason: 'non-auditable' };
+    Audit: { kind: 'no-audit'; reason: 'non-auditable' };
     Method: 'GET';
     Path: '/api/v1/plans/current';
     Querystring: { env: string };
@@ -54,7 +54,7 @@ export type GetPlan = ApiEndpoint<{
 }>;
 
 export type GetUsage = ApiEndpoint<{
-    Audit: { reason: 'non-auditable' };
+    Audit: { kind: 'no-audit'; reason: 'non-auditable' };
     Method: 'GET';
     Path: '/api/v1/plans/usage';
     Querystring: { env: string };
@@ -73,7 +73,7 @@ export type GetUsage = ApiEndpoint<{
 // constrained to the metric's whitelist at compile time; the controller's zod
 // schema enforces the same shape at runtime.
 export type GetBillingUsageTopDimensionValues = ApiEndpoint<{
-    Audit: { reason: 'non-auditable' };
+    Audit: { kind: 'no-audit'; reason: 'non-auditable' };
     Method: 'GET';
     Path: '/api/v1/plans/billing-usage/top-dimension-values';
     Querystring: {
@@ -106,7 +106,7 @@ export type GetBillingUsageTopDimensionValues = ApiEndpoint<{
 }>;
 
 export type GetBillingUsage = ApiEndpoint<{
-    Audit: { reason: 'non-auditable' };
+    Audit: { kind: 'no-audit'; reason: 'non-auditable' };
     Method: 'GET';
     Path: '/api/v1/plans/billing-usage';
     Querystring: {
@@ -146,7 +146,7 @@ export type GetBillingUsage = ApiEndpoint<{
 }>;
 
 export type PutBillingInvoicingDetails = ApiEndpoint<{
-    Audit: { reason: 'TODO: audit coverage pending' };
+    Audit: { kind: 'no-audit'; reason: 'TODO: audit coverage pending' };
     Method: 'PUT';
     Path: '/api/v1/plans/billing/invoicing';
     Querystring: { env: string };
@@ -157,7 +157,7 @@ export type PutBillingInvoicingDetails = ApiEndpoint<{
 }>;
 
 export type PostPlanChange = ApiEndpoint<{
-    Audit: { reason: 'TODO: audit coverage pending' };
+    Audit: { kind: 'no-audit'; reason: 'TODO: audit coverage pending' };
     Method: 'POST';
     Path: '/api/v1/plans/change';
     Querystring: { env: string };

--- a/packages/types/lib/plans/http.api.ts
+++ b/packages/types/lib/plans/http.api.ts
@@ -7,7 +7,7 @@ import type { DBPlan } from './db.js';
 export type ApiPlan = ReplaceInObject<DBPlan, Date, string>;
 
 export type PostPlanExtendTrial = ApiEndpoint<{
-    Audit: { audit: false; reason: 'TODO: audit coverage pending' };
+    Audit: { reason: 'TODO: audit coverage pending' };
     Method: 'POST';
     Path: '/api/v1/plans/trial/extension';
     Querystring: { env: string };
@@ -34,7 +34,7 @@ export interface PlanDefinition {
 }
 
 export type GetPlans = ApiEndpoint<{
-    Audit: { audit: false; reason: 'non-auditable' };
+    Audit: { reason: 'non-auditable' };
     Method: 'GET';
     Path: '/api/v1/plans';
     Querystring: { env: string };
@@ -44,7 +44,7 @@ export type GetPlans = ApiEndpoint<{
 }>;
 
 export type GetPlan = ApiEndpoint<{
-    Audit: { audit: false; reason: 'non-auditable' };
+    Audit: { reason: 'non-auditable' };
     Method: 'GET';
     Path: '/api/v1/plans/current';
     Querystring: { env: string };
@@ -54,7 +54,7 @@ export type GetPlan = ApiEndpoint<{
 }>;
 
 export type GetUsage = ApiEndpoint<{
-    Audit: { audit: false; reason: 'non-auditable' };
+    Audit: { reason: 'non-auditable' };
     Method: 'GET';
     Path: '/api/v1/plans/usage';
     Querystring: { env: string };
@@ -73,7 +73,7 @@ export type GetUsage = ApiEndpoint<{
 // constrained to the metric's whitelist at compile time; the controller's zod
 // schema enforces the same shape at runtime.
 export type GetBillingUsageTopDimensionValues = ApiEndpoint<{
-    Audit: { audit: false; reason: 'non-auditable' };
+    Audit: { reason: 'non-auditable' };
     Method: 'GET';
     Path: '/api/v1/plans/billing-usage/top-dimension-values';
     Querystring: {
@@ -106,7 +106,7 @@ export type GetBillingUsageTopDimensionValues = ApiEndpoint<{
 }>;
 
 export type GetBillingUsage = ApiEndpoint<{
-    Audit: { audit: false; reason: 'non-auditable' };
+    Audit: { reason: 'non-auditable' };
     Method: 'GET';
     Path: '/api/v1/plans/billing-usage';
     Querystring: {
@@ -146,7 +146,7 @@ export type GetBillingUsage = ApiEndpoint<{
 }>;
 
 export type PutBillingInvoicingDetails = ApiEndpoint<{
-    Audit: { audit: false; reason: 'TODO: audit coverage pending' };
+    Audit: { reason: 'TODO: audit coverage pending' };
     Method: 'PUT';
     Path: '/api/v1/plans/billing/invoicing';
     Querystring: { env: string };
@@ -157,7 +157,7 @@ export type PutBillingInvoicingDetails = ApiEndpoint<{
 }>;
 
 export type PostPlanChange = ApiEndpoint<{
-    Audit: { audit: false; reason: 'TODO: audit coverage pending' };
+    Audit: { reason: 'TODO: audit coverage pending' };
     Method: 'POST';
     Path: '/api/v1/plans/change';
     Querystring: { env: string };

--- a/packages/types/lib/providers/api.ts
+++ b/packages/types/lib/providers/api.ts
@@ -3,7 +3,7 @@ import type { AuthModeType } from '../auth/api.js';
 import type { McpOAuth2ClientRegistration, Provider, SimplifiedJSONSchema } from './provider.js';
 
 export type GetPublicProviders = ApiEndpoint<{
-    Audit: { reason: 'non-auditable' };
+    Audit: { kind: 'no-audit'; reason: 'non-auditable' };
     Method: 'GET';
     Path: `/providers`;
     Querystring: { search?: string | undefined; connect_session_token?: string };
@@ -14,7 +14,7 @@ export type GetPublicProviders = ApiEndpoint<{
 export type ApiProvider = Provider & { name: string; logo_url: string };
 
 export type GetPublicProvider = ApiEndpoint<{
-    Audit: { reason: 'non-auditable' };
+    Audit: { kind: 'no-audit'; reason: 'non-auditable' };
     Method: 'GET';
     Path: `/providers/:provider`;
     Params: { provider: string };
@@ -40,7 +40,7 @@ export interface ApiProviderListItem {
 }
 
 export type GetProviders = ApiEndpoint<{
-    Audit: { reason: 'non-auditable' };
+    Audit: { kind: 'no-audit'; reason: 'non-auditable' };
     Method: 'GET';
     Path: '/api/v1/providers';
     Success: {
@@ -49,7 +49,7 @@ export type GetProviders = ApiEndpoint<{
 }>;
 
 export type GetProvider = ApiEndpoint<{
-    Audit: { reason: 'non-auditable' };
+    Audit: { kind: 'no-audit'; reason: 'non-auditable' };
     Method: 'GET';
     Path: '/api/v1/providers/:providerConfigKey';
     Params: { providerConfigKey: string };

--- a/packages/types/lib/providers/api.ts
+++ b/packages/types/lib/providers/api.ts
@@ -1,8 +1,9 @@
-import type { Endpoint } from '../api.js';
+import type { ApiEndpoint } from '../api.js';
 import type { AuthModeType } from '../auth/api.js';
 import type { McpOAuth2ClientRegistration, Provider, SimplifiedJSONSchema } from './provider.js';
 
-export type GetPublicProviders = Endpoint<{
+export type GetPublicProviders = ApiEndpoint<{
+    Audit: { audit: false; reason: 'non-auditable' };
     Method: 'GET';
     Path: `/providers`;
     Querystring: { search?: string | undefined; connect_session_token?: string };
@@ -12,7 +13,8 @@ export type GetPublicProviders = Endpoint<{
 }>;
 export type ApiProvider = Provider & { name: string; logo_url: string };
 
-export type GetPublicProvider = Endpoint<{
+export type GetPublicProvider = ApiEndpoint<{
+    Audit: { audit: false; reason: 'non-auditable' };
     Method: 'GET';
     Path: `/providers/:provider`;
     Params: { provider: string };
@@ -37,7 +39,8 @@ export interface ApiProviderListItem {
     integration_config?: Record<string, SimplifiedJSONSchema> | undefined;
 }
 
-export type GetProviders = Endpoint<{
+export type GetProviders = ApiEndpoint<{
+    Audit: { audit: false; reason: 'non-auditable' };
     Method: 'GET';
     Path: '/api/v1/providers';
     Success: {
@@ -45,7 +48,8 @@ export type GetProviders = Endpoint<{
     };
 }>;
 
-export type GetProvider = Endpoint<{
+export type GetProvider = ApiEndpoint<{
+    Audit: { audit: false; reason: 'non-auditable' };
     Method: 'GET';
     Path: '/api/v1/providers/:providerConfigKey';
     Params: { providerConfigKey: string };

--- a/packages/types/lib/providers/api.ts
+++ b/packages/types/lib/providers/api.ts
@@ -3,7 +3,7 @@ import type { AuthModeType } from '../auth/api.js';
 import type { McpOAuth2ClientRegistration, Provider, SimplifiedJSONSchema } from './provider.js';
 
 export type GetPublicProviders = ApiEndpoint<{
-    Audit: { audit: false; reason: 'non-auditable' };
+    Audit: { reason: 'non-auditable' };
     Method: 'GET';
     Path: `/providers`;
     Querystring: { search?: string | undefined; connect_session_token?: string };
@@ -14,7 +14,7 @@ export type GetPublicProviders = ApiEndpoint<{
 export type ApiProvider = Provider & { name: string; logo_url: string };
 
 export type GetPublicProvider = ApiEndpoint<{
-    Audit: { audit: false; reason: 'non-auditable' };
+    Audit: { reason: 'non-auditable' };
     Method: 'GET';
     Path: `/providers/:provider`;
     Params: { provider: string };
@@ -40,7 +40,7 @@ export interface ApiProviderListItem {
 }
 
 export type GetProviders = ApiEndpoint<{
-    Audit: { audit: false; reason: 'non-auditable' };
+    Audit: { reason: 'non-auditable' };
     Method: 'GET';
     Path: '/api/v1/providers';
     Success: {
@@ -49,7 +49,7 @@ export type GetProviders = ApiEndpoint<{
 }>;
 
 export type GetProvider = ApiEndpoint<{
-    Audit: { audit: false; reason: 'non-auditable' };
+    Audit: { reason: 'non-auditable' };
     Method: 'GET';
     Path: '/api/v1/providers/:providerConfigKey';
     Params: { providerConfigKey: string };

--- a/packages/types/lib/proxy/http.api.ts
+++ b/packages/types/lib/proxy/http.api.ts
@@ -1,6 +1,7 @@
-import type { Endpoint } from '../api.js';
+import type { ApiEndpoint } from '../api.js';
 
-export type AllPublicProxy = Endpoint<{
+export type AllPublicProxy = ApiEndpoint<{
+    Audit: { audit: false; reason: 'non-auditable' };
     Method: 'GET';
     Path: `/proxy/:anyPath`;
     Params: any;

--- a/packages/types/lib/proxy/http.api.ts
+++ b/packages/types/lib/proxy/http.api.ts
@@ -1,7 +1,7 @@
 import type { ApiEndpoint } from '../api.js';
 
 export type AllPublicProxy = ApiEndpoint<{
-    Audit: { audit: false; reason: 'non-auditable' };
+    Audit: { reason: 'non-auditable' };
     Method: 'GET';
     Path: `/proxy/:anyPath`;
     Params: any;

--- a/packages/types/lib/proxy/http.api.ts
+++ b/packages/types/lib/proxy/http.api.ts
@@ -1,7 +1,7 @@
 import type { ApiEndpoint } from '../api.js';
 
 export type AllPublicProxy = ApiEndpoint<{
-    Audit: { reason: 'non-auditable' };
+    Audit: { kind: 'no-audit'; reason: 'non-auditable' };
     Method: 'GET';
     Path: `/proxy/:anyPath`;
     Params: any;

--- a/packages/types/lib/record/api.ts
+++ b/packages/types/lib/record/api.ts
@@ -23,7 +23,7 @@ export type MergingStrategy = { strategy: 'override' } | { strategy: 'ignore_if_
 export type CursorOffset = 'first' | 'last';
 
 export type GetPublicRecords = ApiEndpoint<{
-    Audit: { audit: false; reason: 'non-auditable' };
+    Audit: { reason: 'non-auditable' };
     Method: 'GET';
     Path: `/records`;
     Headers: {
@@ -48,7 +48,7 @@ export type GetPublicRecords = ApiEndpoint<{
 }>;
 
 export type PatchPublicPruneRecords = ApiEndpoint<{
-    Audit: { audit: false; reason: 'TODO: audit coverage pending' };
+    Audit: { reason: 'TODO: audit coverage pending' };
     Method: 'PATCH';
     Path: `/records/prune`;
     Headers: {
@@ -77,7 +77,7 @@ export interface ConnectionRecordModel {
 }
 
 export type GetConnectionRecordModels = ApiEndpoint<{
-    Audit: { audit: false; reason: 'non-auditable' };
+    Audit: { reason: 'non-auditable' };
     Method: 'GET';
     Path: '/api/v1/connections/:connectionId/records/models';
     Params: {
@@ -93,7 +93,7 @@ export type GetConnectionRecordModels = ApiEndpoint<{
 }>;
 
 export type GetConnectionRecords = ApiEndpoint<{
-    Audit: { audit: false; reason: 'non-auditable' };
+    Audit: { reason: 'non-auditable' };
     Method: 'GET';
     Path: '/api/v1/connections/:connectionId/records';
     Params: {

--- a/packages/types/lib/record/api.ts
+++ b/packages/types/lib/record/api.ts
@@ -23,7 +23,7 @@ export type MergingStrategy = { strategy: 'override' } | { strategy: 'ignore_if_
 export type CursorOffset = 'first' | 'last';
 
 export type GetPublicRecords = ApiEndpoint<{
-    Audit: { reason: 'non-auditable' };
+    Audit: { kind: 'no-audit'; reason: 'non-auditable' };
     Method: 'GET';
     Path: `/records`;
     Headers: {
@@ -48,7 +48,7 @@ export type GetPublicRecords = ApiEndpoint<{
 }>;
 
 export type PatchPublicPruneRecords = ApiEndpoint<{
-    Audit: { reason: 'TODO: audit coverage pending' };
+    Audit: { kind: 'no-audit'; reason: 'TODO: audit coverage pending' };
     Method: 'PATCH';
     Path: `/records/prune`;
     Headers: {
@@ -77,7 +77,7 @@ export interface ConnectionRecordModel {
 }
 
 export type GetConnectionRecordModels = ApiEndpoint<{
-    Audit: { reason: 'non-auditable' };
+    Audit: { kind: 'no-audit'; reason: 'non-auditable' };
     Method: 'GET';
     Path: '/api/v1/connections/:connectionId/records/models';
     Params: {
@@ -93,7 +93,7 @@ export type GetConnectionRecordModels = ApiEndpoint<{
 }>;
 
 export type GetConnectionRecords = ApiEndpoint<{
-    Audit: { reason: 'non-auditable' };
+    Audit: { kind: 'no-audit'; reason: 'non-auditable' };
     Method: 'GET';
     Path: '/api/v1/connections/:connectionId/records';
     Params: {

--- a/packages/types/lib/record/api.ts
+++ b/packages/types/lib/record/api.ts
@@ -1,4 +1,4 @@
-import type { ApiError, Endpoint } from '../api.js';
+import type { ApiEndpoint, ApiError } from '../api.js';
 
 export type RecordLastAction = 'ADDED' | 'UPDATED' | 'DELETED' | 'added' | 'updated' | 'deleted';
 export type CombinedFilterAction = `${RecordLastAction},${RecordLastAction}`;
@@ -22,7 +22,8 @@ export type MergingStrategy = { strategy: 'override' } | { strategy: 'ignore_if_
 
 export type CursorOffset = 'first' | 'last';
 
-export type GetPublicRecords = Endpoint<{
+export type GetPublicRecords = ApiEndpoint<{
+    Audit: { audit: false; reason: 'non-auditable' };
     Method: 'GET';
     Path: `/records`;
     Headers: {
@@ -46,7 +47,8 @@ export type GetPublicRecords = Endpoint<{
     };
 }>;
 
-export type PatchPublicPruneRecords = Endpoint<{
+export type PatchPublicPruneRecords = ApiEndpoint<{
+    Audit: { audit: false; reason: 'TODO: audit coverage pending' };
     Method: 'PATCH';
     Path: `/records/prune`;
     Headers: {
@@ -74,7 +76,8 @@ export interface ConnectionRecordModel {
     updated_at: string;
 }
 
-export type GetConnectionRecordModels = Endpoint<{
+export type GetConnectionRecordModels = ApiEndpoint<{
+    Audit: { audit: false; reason: 'non-auditable' };
     Method: 'GET';
     Path: '/api/v1/connections/:connectionId/records/models';
     Params: {
@@ -89,7 +92,8 @@ export type GetConnectionRecordModels = Endpoint<{
     };
 }>;
 
-export type GetConnectionRecords = Endpoint<{
+export type GetConnectionRecords = ApiEndpoint<{
+    Audit: { audit: false; reason: 'non-auditable' };
     Method: 'GET';
     Path: '/api/v1/connections/:connectionId/records';
     Params: {

--- a/packages/types/lib/scripts/http.api.ts
+++ b/packages/types/lib/scripts/http.api.ts
@@ -1,4 +1,4 @@
-import type { Endpoint } from '../api.js';
+import type { ApiEndpoint } from '../api.js';
 import type { StandardNangoConfig } from '../flow/index.js';
 
 export interface OpenAIFunction {
@@ -11,7 +11,8 @@ export interface OpenAIFunction {
     };
 }
 
-export type GetPublicScriptsConfig = Endpoint<{
+export type GetPublicScriptsConfig = ApiEndpoint<{
+    Audit: { audit: false; reason: 'non-auditable' };
     Method: 'GET';
     Path: `/scripts/config`;
     Query: {

--- a/packages/types/lib/scripts/http.api.ts
+++ b/packages/types/lib/scripts/http.api.ts
@@ -12,7 +12,7 @@ export interface OpenAIFunction {
 }
 
 export type GetPublicScriptsConfig = ApiEndpoint<{
-    Audit: { audit: false; reason: 'non-auditable' };
+    Audit: { reason: 'non-auditable' };
     Method: 'GET';
     Path: `/scripts/config`;
     Query: {

--- a/packages/types/lib/scripts/http.api.ts
+++ b/packages/types/lib/scripts/http.api.ts
@@ -12,7 +12,7 @@ export interface OpenAIFunction {
 }
 
 export type GetPublicScriptsConfig = ApiEndpoint<{
-    Audit: { reason: 'non-auditable' };
+    Audit: { kind: 'no-audit'; reason: 'non-auditable' };
     Method: 'GET';
     Path: `/scripts/config`;
     Query: {

--- a/packages/types/lib/sharedCredentials/api.ts
+++ b/packages/types/lib/sharedCredentials/api.ts
@@ -1,6 +1,7 @@
-import type { ApiError, Endpoint } from '../api.js';
+import type { ApiEndpoint, ApiError } from '../api.js';
 
-export type GetSharedCredentialsProviders = Endpoint<{
+export type GetSharedCredentialsProviders = ApiEndpoint<{
+    Audit: { audit: false; reason: 'non-auditable' };
     Method: 'GET';
     Path: '/internal/shared-credentials';
     Success: {
@@ -9,7 +10,8 @@ export type GetSharedCredentialsProviders = Endpoint<{
     };
 }>;
 
-export type GetSharedCredentialsProvider = Endpoint<{
+export type GetSharedCredentialsProvider = ApiEndpoint<{
+    Audit: { audit: false; reason: 'non-auditable' };
     Method: 'GET';
     Path: '/internal/shared-credentials/:id';
     Params: { id: number };
@@ -19,7 +21,8 @@ export type GetSharedCredentialsProvider = Endpoint<{
     };
 }>;
 
-export type PostSharedCredentialsProvider = Endpoint<{
+export type PostSharedCredentialsProvider = ApiEndpoint<{
+    Audit: { audit: false; reason: 'non-auditable' };
     Method: 'POST';
     Path: '/internal/shared-credentials';
     Body: SharedCredentialsBodyInput;
@@ -29,7 +32,8 @@ export type PostSharedCredentialsProvider = Endpoint<{
     Error: ApiError<'invalid_body' | 'shared_credentials_already_exists' | 'invalid_provider'>;
 }>;
 
-export type PatchSharedCredentialsProvider = Endpoint<{
+export type PatchSharedCredentialsProvider = ApiEndpoint<{
+    Audit: { audit: false; reason: 'non-auditable' };
     Method: 'PATCH';
     Path: '/internal/shared-credentials/:id';
     Params: { id: number };

--- a/packages/types/lib/sharedCredentials/api.ts
+++ b/packages/types/lib/sharedCredentials/api.ts
@@ -1,7 +1,6 @@
-import type { ApiEndpoint, ApiError } from '../api.js';
+import type { ApiError, Endpoint } from '../api.js';
 
-export type GetSharedCredentialsProviders = ApiEndpoint<{
-    Audit: { audit: false; reason: 'non-auditable' };
+export type GetSharedCredentialsProviders = Endpoint<{
     Method: 'GET';
     Path: '/internal/shared-credentials';
     Success: {
@@ -10,8 +9,7 @@ export type GetSharedCredentialsProviders = ApiEndpoint<{
     };
 }>;
 
-export type GetSharedCredentialsProvider = ApiEndpoint<{
-    Audit: { audit: false; reason: 'non-auditable' };
+export type GetSharedCredentialsProvider = Endpoint<{
     Method: 'GET';
     Path: '/internal/shared-credentials/:id';
     Params: { id: number };
@@ -21,8 +19,7 @@ export type GetSharedCredentialsProvider = ApiEndpoint<{
     };
 }>;
 
-export type PostSharedCredentialsProvider = ApiEndpoint<{
-    Audit: { audit: false; reason: 'non-auditable' };
+export type PostSharedCredentialsProvider = Endpoint<{
     Method: 'POST';
     Path: '/internal/shared-credentials';
     Body: SharedCredentialsBodyInput;
@@ -32,8 +29,7 @@ export type PostSharedCredentialsProvider = ApiEndpoint<{
     Error: ApiError<'invalid_body' | 'shared_credentials_already_exists' | 'invalid_provider'>;
 }>;
 
-export type PatchSharedCredentialsProvider = ApiEndpoint<{
-    Audit: { audit: false; reason: 'non-auditable' };
+export type PatchSharedCredentialsProvider = Endpoint<{
     Method: 'PATCH';
     Path: '/internal/shared-credentials/:id';
     Params: { id: number };

--- a/packages/types/lib/stripe/http.api.ts
+++ b/packages/types/lib/stripe/http.api.ts
@@ -1,6 +1,7 @@
-import type { Endpoint } from '../api.js';
+import type { ApiEndpoint } from '../api.js';
 
-export type PostStripeCollectPayment = Endpoint<{
+export type PostStripeCollectPayment = ApiEndpoint<{
+    Audit: { audit: false; reason: 'non-auditable' };
     Method: 'POST';
     Path: '/api/v1/stripe/payment_methods';
     Success: {
@@ -13,7 +14,8 @@ export interface StripePaymentMethod {
     last4: string;
 }
 
-export type GetStripePaymentMethods = Endpoint<{
+export type GetStripePaymentMethods = ApiEndpoint<{
+    Audit: { audit: false; reason: 'non-auditable' };
     Method: 'GET';
     Path: '/api/v1/stripe/payment_methods';
     Success: {
@@ -21,7 +23,8 @@ export type GetStripePaymentMethods = Endpoint<{
     };
 }>;
 
-export type DeleteStripePayment = Endpoint<{
+export type DeleteStripePayment = ApiEndpoint<{
+    Audit: { audit: false; reason: 'non-auditable' };
     Method: 'DELETE';
     Path: '/api/v1/stripe/payment_methods';
     Querystring: { payment_id: string };
@@ -30,7 +33,8 @@ export type DeleteStripePayment = Endpoint<{
     };
 }>;
 
-export type PostStripeWebhooks = Endpoint<{
+export type PostStripeWebhooks = ApiEndpoint<{
+    Audit: { audit: false; reason: 'non-auditable' };
     Method: 'POST';
     Path: '/api/v1/stripe/webhooks';
     Body: any;

--- a/packages/types/lib/stripe/http.api.ts
+++ b/packages/types/lib/stripe/http.api.ts
@@ -1,7 +1,7 @@
 import type { ApiEndpoint } from '../api.js';
 
 export type PostStripeCollectPayment = ApiEndpoint<{
-    Audit: { audit: false; reason: 'non-auditable' };
+    Audit: { reason: 'non-auditable' };
     Method: 'POST';
     Path: '/api/v1/stripe/payment_methods';
     Success: {
@@ -15,7 +15,7 @@ export interface StripePaymentMethod {
 }
 
 export type GetStripePaymentMethods = ApiEndpoint<{
-    Audit: { audit: false; reason: 'non-auditable' };
+    Audit: { reason: 'non-auditable' };
     Method: 'GET';
     Path: '/api/v1/stripe/payment_methods';
     Success: {
@@ -24,7 +24,7 @@ export type GetStripePaymentMethods = ApiEndpoint<{
 }>;
 
 export type DeleteStripePayment = ApiEndpoint<{
-    Audit: { audit: false; reason: 'non-auditable' };
+    Audit: { reason: 'non-auditable' };
     Method: 'DELETE';
     Path: '/api/v1/stripe/payment_methods';
     Querystring: { payment_id: string };
@@ -34,7 +34,7 @@ export type DeleteStripePayment = ApiEndpoint<{
 }>;
 
 export type PostStripeWebhooks = ApiEndpoint<{
-    Audit: { audit: false; reason: 'non-auditable' };
+    Audit: { reason: 'non-auditable' };
     Method: 'POST';
     Path: '/api/v1/stripe/webhooks';
     Body: any;

--- a/packages/types/lib/stripe/http.api.ts
+++ b/packages/types/lib/stripe/http.api.ts
@@ -1,7 +1,7 @@
 import type { ApiEndpoint } from '../api.js';
 
 export type PostStripeCollectPayment = ApiEndpoint<{
-    Audit: { reason: 'non-auditable' };
+    Audit: { kind: 'no-audit'; reason: 'non-auditable' };
     Method: 'POST';
     Path: '/api/v1/stripe/payment_methods';
     Success: {
@@ -15,7 +15,7 @@ export interface StripePaymentMethod {
 }
 
 export type GetStripePaymentMethods = ApiEndpoint<{
-    Audit: { reason: 'non-auditable' };
+    Audit: { kind: 'no-audit'; reason: 'non-auditable' };
     Method: 'GET';
     Path: '/api/v1/stripe/payment_methods';
     Success: {
@@ -24,7 +24,7 @@ export type GetStripePaymentMethods = ApiEndpoint<{
 }>;
 
 export type DeleteStripePayment = ApiEndpoint<{
-    Audit: { reason: 'non-auditable' };
+    Audit: { kind: 'no-audit'; reason: 'non-auditable' };
     Method: 'DELETE';
     Path: '/api/v1/stripe/payment_methods';
     Querystring: { payment_id: string };
@@ -34,7 +34,7 @@ export type DeleteStripePayment = ApiEndpoint<{
 }>;
 
 export type PostStripeWebhooks = ApiEndpoint<{
-    Audit: { reason: 'non-auditable' };
+    Audit: { kind: 'no-audit'; reason: 'non-auditable' };
     Method: 'POST';
     Path: '/api/v1/stripe/webhooks';
     Body: any;

--- a/packages/types/lib/sync/api.ts
+++ b/packages/types/lib/sync/api.ts
@@ -1,7 +1,8 @@
-import type { ApiError, Endpoint } from '../api.js';
+import type { ApiEndpoint, ApiError } from '../api.js';
 import type { ReportedSyncJobStatus } from './index.js';
 
-export type PostPublicTrigger = Endpoint<{
+export type PostPublicTrigger = ApiEndpoint<{
+    Audit: { audit: false; reason: 'TODO: audit coverage pending' };
     Method: 'POST';
     Path: '/sync/trigger';
     Body: {
@@ -22,7 +23,8 @@ export type PostPublicTrigger = Endpoint<{
     Error: ApiError<'missing_provider_config_key' | 'unknown_provider_config' | 'unknown_connection' | 'no_syncs_found'>;
 }>;
 
-export type PostSyncVariant = Endpoint<{
+export type PostSyncVariant = ApiEndpoint<{
+    Audit: { audit: false; reason: 'TODO: audit coverage pending' };
     Method: 'POST';
     Path: '/sync/:name/variant/:variant';
     Body: {
@@ -39,7 +41,8 @@ export type PostSyncVariant = Endpoint<{
     Success: { id: string; name: string; variant: string };
 }>;
 
-export type DeleteSyncVariant = Endpoint<{
+export type DeleteSyncVariant = ApiEndpoint<{
+    Audit: { audit: false; reason: 'TODO: audit coverage pending' };
     Method: 'DELETE';
     Path: '/sync/:name/variant/:variant';
     Body: {
@@ -54,7 +57,8 @@ export type DeleteSyncVariant = Endpoint<{
     Success: { success: boolean };
 }>;
 
-export type PutPublicSyncConnectionFrequency = Endpoint<{
+export type PutPublicSyncConnectionFrequency = ApiEndpoint<{
+    Audit: { audit: false; reason: 'TODO: audit coverage pending' };
     Method: 'PUT';
     Path: '/sync/update-connection-frequency';
     Body: {
@@ -68,7 +72,8 @@ export type PutPublicSyncConnectionFrequency = Endpoint<{
     Error: ApiError<'unknown_connection' | 'unknown_sync'>;
 }>;
 
-export type PostPublicSyncPause = Endpoint<{
+export type PostPublicSyncPause = ApiEndpoint<{
+    Audit: { audit: false; reason: 'TODO: audit coverage pending' };
     Method: 'POST';
     Path: '/sync/pause';
     Body: {
@@ -80,7 +85,8 @@ export type PostPublicSyncPause = Endpoint<{
     Error: ApiError<'no_syncs_found' | 'unknown_connection' | 'unknown_provider_config'>;
 }>;
 
-export type PostPublicSyncStart = Endpoint<{
+export type PostPublicSyncStart = ApiEndpoint<{
+    Audit: { audit: false; reason: 'TODO: audit coverage pending' };
     Method: 'POST';
     Path: '/sync/start';
     Body: {
@@ -92,7 +98,8 @@ export type PostPublicSyncStart = Endpoint<{
     Error: ApiError<'no_syncs_found' | 'unknown_connection' | 'unknown_provider_config'>;
 }>;
 
-export type GetPublicSyncStatus = Endpoint<{
+export type GetPublicSyncStatus = ApiEndpoint<{
+    Audit: { audit: false; reason: 'non-auditable' };
     Method: 'GET';
     Path: '/sync/status';
     Querystring: {

--- a/packages/types/lib/sync/api.ts
+++ b/packages/types/lib/sync/api.ts
@@ -2,7 +2,7 @@ import type { ApiEndpoint, ApiError } from '../api.js';
 import type { ReportedSyncJobStatus } from './index.js';
 
 export type PostPublicTrigger = ApiEndpoint<{
-    Audit: { reason: 'TODO: audit coverage pending' };
+    Audit: { kind: 'no-audit'; reason: 'TODO: audit coverage pending' };
     Method: 'POST';
     Path: '/sync/trigger';
     Body: {
@@ -24,7 +24,7 @@ export type PostPublicTrigger = ApiEndpoint<{
 }>;
 
 export type PostSyncVariant = ApiEndpoint<{
-    Audit: { reason: 'TODO: audit coverage pending' };
+    Audit: { kind: 'no-audit'; reason: 'TODO: audit coverage pending' };
     Method: 'POST';
     Path: '/sync/:name/variant/:variant';
     Body: {
@@ -42,7 +42,7 @@ export type PostSyncVariant = ApiEndpoint<{
 }>;
 
 export type DeleteSyncVariant = ApiEndpoint<{
-    Audit: { reason: 'TODO: audit coverage pending' };
+    Audit: { kind: 'no-audit'; reason: 'TODO: audit coverage pending' };
     Method: 'DELETE';
     Path: '/sync/:name/variant/:variant';
     Body: {
@@ -58,7 +58,7 @@ export type DeleteSyncVariant = ApiEndpoint<{
 }>;
 
 export type PutPublicSyncConnectionFrequency = ApiEndpoint<{
-    Audit: { reason: 'TODO: audit coverage pending' };
+    Audit: { kind: 'no-audit'; reason: 'TODO: audit coverage pending' };
     Method: 'PUT';
     Path: '/sync/update-connection-frequency';
     Body: {
@@ -73,7 +73,7 @@ export type PutPublicSyncConnectionFrequency = ApiEndpoint<{
 }>;
 
 export type PostPublicSyncPause = ApiEndpoint<{
-    Audit: { reason: 'TODO: audit coverage pending' };
+    Audit: { kind: 'no-audit'; reason: 'TODO: audit coverage pending' };
     Method: 'POST';
     Path: '/sync/pause';
     Body: {
@@ -86,7 +86,7 @@ export type PostPublicSyncPause = ApiEndpoint<{
 }>;
 
 export type PostPublicSyncStart = ApiEndpoint<{
-    Audit: { reason: 'TODO: audit coverage pending' };
+    Audit: { kind: 'no-audit'; reason: 'TODO: audit coverage pending' };
     Method: 'POST';
     Path: '/sync/start';
     Body: {
@@ -99,7 +99,7 @@ export type PostPublicSyncStart = ApiEndpoint<{
 }>;
 
 export type GetPublicSyncStatus = ApiEndpoint<{
-    Audit: { reason: 'non-auditable' };
+    Audit: { kind: 'no-audit'; reason: 'non-auditable' };
     Method: 'GET';
     Path: '/sync/status';
     Querystring: {

--- a/packages/types/lib/sync/api.ts
+++ b/packages/types/lib/sync/api.ts
@@ -2,7 +2,7 @@ import type { ApiEndpoint, ApiError } from '../api.js';
 import type { ReportedSyncJobStatus } from './index.js';
 
 export type PostPublicTrigger = ApiEndpoint<{
-    Audit: { audit: false; reason: 'TODO: audit coverage pending' };
+    Audit: { reason: 'TODO: audit coverage pending' };
     Method: 'POST';
     Path: '/sync/trigger';
     Body: {
@@ -24,7 +24,7 @@ export type PostPublicTrigger = ApiEndpoint<{
 }>;
 
 export type PostSyncVariant = ApiEndpoint<{
-    Audit: { audit: false; reason: 'TODO: audit coverage pending' };
+    Audit: { reason: 'TODO: audit coverage pending' };
     Method: 'POST';
     Path: '/sync/:name/variant/:variant';
     Body: {
@@ -42,7 +42,7 @@ export type PostSyncVariant = ApiEndpoint<{
 }>;
 
 export type DeleteSyncVariant = ApiEndpoint<{
-    Audit: { audit: false; reason: 'TODO: audit coverage pending' };
+    Audit: { reason: 'TODO: audit coverage pending' };
     Method: 'DELETE';
     Path: '/sync/:name/variant/:variant';
     Body: {
@@ -58,7 +58,7 @@ export type DeleteSyncVariant = ApiEndpoint<{
 }>;
 
 export type PutPublicSyncConnectionFrequency = ApiEndpoint<{
-    Audit: { audit: false; reason: 'TODO: audit coverage pending' };
+    Audit: { reason: 'TODO: audit coverage pending' };
     Method: 'PUT';
     Path: '/sync/update-connection-frequency';
     Body: {
@@ -73,7 +73,7 @@ export type PutPublicSyncConnectionFrequency = ApiEndpoint<{
 }>;
 
 export type PostPublicSyncPause = ApiEndpoint<{
-    Audit: { audit: false; reason: 'TODO: audit coverage pending' };
+    Audit: { reason: 'TODO: audit coverage pending' };
     Method: 'POST';
     Path: '/sync/pause';
     Body: {
@@ -86,7 +86,7 @@ export type PostPublicSyncPause = ApiEndpoint<{
 }>;
 
 export type PostPublicSyncStart = ApiEndpoint<{
-    Audit: { audit: false; reason: 'TODO: audit coverage pending' };
+    Audit: { reason: 'TODO: audit coverage pending' };
     Method: 'POST';
     Path: '/sync/start';
     Body: {
@@ -99,7 +99,7 @@ export type PostPublicSyncStart = ApiEndpoint<{
 }>;
 
 export type GetPublicSyncStatus = ApiEndpoint<{
-    Audit: { audit: false; reason: 'non-auditable' };
+    Audit: { reason: 'non-auditable' };
     Method: 'GET';
     Path: '/sync/status';
     Querystring: {

--- a/packages/types/lib/team/api.ts
+++ b/packages/types/lib/team/api.ts
@@ -6,7 +6,7 @@ import type { DBTeam } from './db.js';
 import type { Merge } from 'type-fest';
 
 export type GetTeam = ApiEndpoint<{
-    Audit: { audit: false; reason: 'non-auditable' };
+    Audit: { reason: 'non-auditable' };
     Method: 'GET';
     Path: '/api/v1/team';
     Querystring: { env: string };
@@ -24,7 +24,7 @@ export type ApiInvitation = Merge<Omit<DBInvitation, 'token'>, ApiTimestamps>;
 export type ApiTeam = Merge<DBTeam, ApiTimestamps>;
 
 export type PutTeam = ApiEndpoint<{
-    Audit: { audit: false; reason: 'TODO: audit coverage pending' };
+    Audit: { reason: 'TODO: audit coverage pending' };
     Method: 'PUT';
     Path: '/api/v1/team';
     Querystring: { env: string };
@@ -35,7 +35,7 @@ export type PutTeam = ApiEndpoint<{
 }>;
 
 export type DeleteTeamUser = ApiEndpoint<{
-    Audit: { audit: false; reason: 'TODO: audit coverage pending' };
+    Audit: { reason: 'TODO: audit coverage pending' };
     Method: 'DELETE';
     Path: '/api/v1/team/users/:id';
     Querystring: { env: string };

--- a/packages/types/lib/team/api.ts
+++ b/packages/types/lib/team/api.ts
@@ -1,11 +1,12 @@
-import type { ApiError, ApiTimestamps, Endpoint } from '../api.js';
+import type { ApiEndpoint, ApiError, ApiTimestamps } from '../api.js';
 import type { DBInvitation } from '../invitations/db.js';
 import type { ApiUser } from '../user/api.js';
 import type { Role } from '../user/db.js';
 import type { DBTeam } from './db.js';
 import type { Merge } from 'type-fest';
 
-export type GetTeam = Endpoint<{
+export type GetTeam = ApiEndpoint<{
+    Audit: { audit: false; reason: 'non-auditable' };
     Method: 'GET';
     Path: '/api/v1/team';
     Querystring: { env: string };
@@ -22,7 +23,8 @@ export type GetTeam = Endpoint<{
 export type ApiInvitation = Merge<Omit<DBInvitation, 'token'>, ApiTimestamps>;
 export type ApiTeam = Merge<DBTeam, ApiTimestamps>;
 
-export type PutTeam = Endpoint<{
+export type PutTeam = ApiEndpoint<{
+    Audit: { audit: false; reason: 'TODO: audit coverage pending' };
     Method: 'PUT';
     Path: '/api/v1/team';
     Querystring: { env: string };
@@ -32,7 +34,8 @@ export type PutTeam = Endpoint<{
     };
 }>;
 
-export type DeleteTeamUser = Endpoint<{
+export type DeleteTeamUser = ApiEndpoint<{
+    Audit: { audit: false; reason: 'TODO: audit coverage pending' };
     Method: 'DELETE';
     Path: '/api/v1/team/users/:id';
     Querystring: { env: string };
@@ -43,7 +46,8 @@ export type DeleteTeamUser = Endpoint<{
     };
 }>;
 
-export type PatchTeamUser = Endpoint<{
+export type PatchTeamUser = ApiEndpoint<{
+    Audit: { resource: 'member'; action: 'role_changed'; scope: 'account' };
     Method: 'PATCH';
     Path: '/api/v1/team/users/:id';
     Querystring: { env: string };

--- a/packages/types/lib/team/api.ts
+++ b/packages/types/lib/team/api.ts
@@ -1,3 +1,5 @@
+import { auditPolicies } from '../audit-trail/event.js';
+
 import type { ApiEndpoint, ApiError, ApiTimestamps } from '../api.js';
 import type { DBInvitation } from '../invitations/db.js';
 import type { ApiUser } from '../user/api.js';
@@ -6,7 +8,7 @@ import type { DBTeam } from './db.js';
 import type { Merge } from 'type-fest';
 
 export type GetTeam = ApiEndpoint<{
-    Audit: { reason: 'non-auditable' };
+    Audit: { kind: 'no-audit'; reason: 'non-auditable' };
     Method: 'GET';
     Path: '/api/v1/team';
     Querystring: { env: string };
@@ -24,7 +26,7 @@ export type ApiInvitation = Merge<Omit<DBInvitation, 'token'>, ApiTimestamps>;
 export type ApiTeam = Merge<DBTeam, ApiTimestamps>;
 
 export type PutTeam = ApiEndpoint<{
-    Audit: { reason: 'TODO: audit coverage pending' };
+    Audit: { kind: 'no-audit'; reason: 'TODO: audit coverage pending' };
     Method: 'PUT';
     Path: '/api/v1/team';
     Querystring: { env: string };
@@ -35,7 +37,7 @@ export type PutTeam = ApiEndpoint<{
 }>;
 
 export type DeleteTeamUser = ApiEndpoint<{
-    Audit: { reason: 'TODO: audit coverage pending' };
+    Audit: { kind: 'no-audit'; reason: 'TODO: audit coverage pending' };
     Method: 'DELETE';
     Path: '/api/v1/team/users/:id';
     Querystring: { env: string };
@@ -47,7 +49,7 @@ export type DeleteTeamUser = ApiEndpoint<{
 }>;
 
 export type PatchTeamUser = ApiEndpoint<{
-    Audit: { resource: 'member'; action: 'role_changed'; scope: 'account' };
+    Audit: typeof auditPolicies.memberRoleChanged;
     Method: 'PATCH';
     Path: '/api/v1/team/users/:id';
     Querystring: { env: string };

--- a/packages/types/lib/team/api.ts
+++ b/packages/types/lib/team/api.ts
@@ -1,6 +1,5 @@
-import type { auditPolicies } from '../audit-trail/event.js';
-
 import type { ApiEndpoint, ApiError, ApiTimestamps } from '../api.js';
+import type { auditPolicies } from '../audit-trail/event.js';
 import type { DBInvitation } from '../invitations/db.js';
 import type { ApiUser } from '../user/api.js';
 import type { Role } from '../user/db.js';

--- a/packages/types/lib/team/api.ts
+++ b/packages/types/lib/team/api.ts
@@ -1,4 +1,4 @@
-import { auditPolicies } from '../audit-trail/event.js';
+import type { auditPolicies } from '../audit-trail/event.js';
 
 import type { ApiEndpoint, ApiError, ApiTimestamps } from '../api.js';
 import type { DBInvitation } from '../invitations/db.js';

--- a/packages/types/lib/user/api.ts
+++ b/packages/types/lib/user/api.ts
@@ -1,4 +1,4 @@
-import type { ApiEndpoint } from '../api.js';
+import type { ApiEndpoint, Endpoint } from '../api.js';
 import type { Role } from './db.js';
 
 export type GetUser = ApiEndpoint<{
@@ -10,8 +10,7 @@ export type GetUser = ApiEndpoint<{
     };
 }>;
 
-export type InternalGetUsers = ApiEndpoint<{
-    Audit: { audit: false; reason: 'non-auditable' };
+export type InternalGetUsers = Endpoint<{
     Method: 'GET';
     Path: `/internal/users`;
     Querystring: { accountId: number };

--- a/packages/types/lib/user/api.ts
+++ b/packages/types/lib/user/api.ts
@@ -1,7 +1,8 @@
-import type { Endpoint } from '../api.js';
+import type { ApiEndpoint } from '../api.js';
 import type { Role } from './db.js';
 
-export type GetUser = Endpoint<{
+export type GetUser = ApiEndpoint<{
+    Audit: { audit: false; reason: 'non-auditable' };
     Method: 'GET';
     Path: `/api/v1/user`;
     Success: {
@@ -9,7 +10,8 @@ export type GetUser = Endpoint<{
     };
 }>;
 
-export type InternalGetUsers = Endpoint<{
+export type InternalGetUsers = ApiEndpoint<{
+    Audit: { audit: false; reason: 'non-auditable' };
     Method: 'GET';
     Path: `/internal/users`;
     Querystring: { accountId: number };
@@ -18,7 +20,8 @@ export type InternalGetUsers = Endpoint<{
     };
 }>;
 
-export type PatchUser = Endpoint<{
+export type PatchUser = ApiEndpoint<{
+    Audit: { audit: false; reason: 'TODO: audit coverage pending' };
     Method: 'PATCH';
     Path: `/api/v1/user`;
     Body: {
@@ -49,7 +52,8 @@ export type ApiUserWithPermissions = ApiUser & {
     permissions: AllowedPermissions;
 };
 
-export type PutUserPassword = Endpoint<{
+export type PutUserPassword = ApiEndpoint<{
+    Audit: { audit: false; reason: 'TODO: audit coverage pending' };
     Method: 'PUT';
     Path: `/api/v1/user/password`;
     Body: { oldPassword: string; newPassword: string };

--- a/packages/types/lib/user/api.ts
+++ b/packages/types/lib/user/api.ts
@@ -2,7 +2,7 @@ import type { ApiEndpoint, Endpoint } from '../api.js';
 import type { Role } from './db.js';
 
 export type GetUser = ApiEndpoint<{
-    Audit: { reason: 'non-auditable' };
+    Audit: { kind: 'no-audit'; reason: 'non-auditable' };
     Method: 'GET';
     Path: `/api/v1/user`;
     Success: {
@@ -20,7 +20,7 @@ export type InternalGetUsers = Endpoint<{
 }>;
 
 export type PatchUser = ApiEndpoint<{
-    Audit: { reason: 'TODO: audit coverage pending' };
+    Audit: { kind: 'no-audit'; reason: 'TODO: audit coverage pending' };
     Method: 'PATCH';
     Path: `/api/v1/user`;
     Body: {
@@ -52,7 +52,7 @@ export type ApiUserWithPermissions = ApiUser & {
 };
 
 export type PutUserPassword = ApiEndpoint<{
-    Audit: { reason: 'TODO: audit coverage pending' };
+    Audit: { kind: 'no-audit'; reason: 'TODO: audit coverage pending' };
     Method: 'PUT';
     Path: `/api/v1/user/password`;
     Body: { oldPassword: string; newPassword: string };

--- a/packages/types/lib/user/api.ts
+++ b/packages/types/lib/user/api.ts
@@ -2,7 +2,7 @@ import type { ApiEndpoint, Endpoint } from '../api.js';
 import type { Role } from './db.js';
 
 export type GetUser = ApiEndpoint<{
-    Audit: { audit: false; reason: 'non-auditable' };
+    Audit: { reason: 'non-auditable' };
     Method: 'GET';
     Path: `/api/v1/user`;
     Success: {
@@ -20,7 +20,7 @@ export type InternalGetUsers = Endpoint<{
 }>;
 
 export type PatchUser = ApiEndpoint<{
-    Audit: { audit: false; reason: 'TODO: audit coverage pending' };
+    Audit: { reason: 'TODO: audit coverage pending' };
     Method: 'PATCH';
     Path: `/api/v1/user`;
     Body: {
@@ -52,7 +52,7 @@ export type ApiUserWithPermissions = ApiUser & {
 };
 
 export type PutUserPassword = ApiEndpoint<{
-    Audit: { audit: false; reason: 'TODO: audit coverage pending' };
+    Audit: { reason: 'TODO: audit coverage pending' };
     Method: 'PUT';
     Path: `/api/v1/user/password`;
     Body: { oldPassword: string; newPassword: string };

--- a/packages/types/lib/webhooks/http.api.ts
+++ b/packages/types/lib/webhooks/http.api.ts
@@ -1,7 +1,7 @@
 import type { ApiEndpoint, ApiError } from '../api.js';
 
 export type PostPublicWebhook = ApiEndpoint<{
-    Audit: { audit: false; reason: 'non-auditable' };
+    Audit: { reason: 'non-auditable' };
     Method: 'POST';
     Path: '/webhook/:environmentUuid/:providerConfigKey';
     Params: {

--- a/packages/types/lib/webhooks/http.api.ts
+++ b/packages/types/lib/webhooks/http.api.ts
@@ -1,7 +1,7 @@
 import type { ApiEndpoint, ApiError } from '../api.js';
 
 export type PostPublicWebhook = ApiEndpoint<{
-    Audit: { reason: 'non-auditable' };
+    Audit: { kind: 'no-audit'; reason: 'non-auditable' };
     Method: 'POST';
     Path: '/webhook/:environmentUuid/:providerConfigKey';
     Params: {

--- a/packages/types/lib/webhooks/http.api.ts
+++ b/packages/types/lib/webhooks/http.api.ts
@@ -1,6 +1,7 @@
-import type { ApiError, Endpoint } from '../api.js';
+import type { ApiEndpoint, ApiError } from '../api.js';
 
-export type PostPublicWebhook = Endpoint<{
+export type PostPublicWebhook = ApiEndpoint<{
+    Audit: { audit: false; reason: 'non-auditable' };
     Method: 'POST';
     Path: '/webhook/:environmentUuid/:providerConfigKey';
     Params: {


### PR DESCRIPTION
- Introduces `ApiEndpoint<>`, a customer-facing endpoint type with a **required** `Audit` field, making audit coverage a compile-time decision: a private/public API endpoint no longer compiles until it declares either the audit event it records or an explicit `NoAuditEvent` opt-out with a reason. Internal-service endpoints (persist, jobs, orchestrator, …) keep the unchanged `Endpoint<>` type.
- Annotates all 177 customer endpoints: 3 opt-ins to the already-wired events (connection deleted ×2, member role changed), 68 `TODO: audit coverage pending` (the control-plane worklist), 101 `non-auditable`, and 5 MFA endpoints `to be discussed`.

### Notes
- This enforces the *declaration* of an audit policy per endpoint. Reconciling each declared policy against the `auditable()` middleware actually wired in the server is a planned follow-up.
- MFA state-changing endpoints are parked as `to be discussed` — decision tracked in NAN-6450.
- `UpdateOtlpSettings` appears unreferenced in the codebase; left annotated pending confirmation it isn't dead.

## Test plan
- [x] `tsc -b` clean: types, server, webapp, connect-ui, persist, jobs
- [x] Enforcement verified — removing an endpoint's `Audit` field fails to compile
- [x] prettier + oxlint clean (only pre-existing `any` warnings in `Endpoint`)
- [ ] Work through the `TODO: audit coverage pending` endpoints as part of audit coverage (NAN-6444)
- [ ] Decide MFA endpoints (NAN-6450)
- [ ] Confirm or remove `UpdateOtlpSettings`

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/NangoHQ/nango/pull/6916?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

