### PR TITLE
feat(audit): record control-plane mutation events, type-locked to endpoint policy (NAN-6444)

### DIFF
--- a/packages/audit/lib/event.ts
+++ b/packages/audit/lib/event.ts
@@ -2,8 +2,6 @@
 
 import type { AuditActor, AuditContext, AuditOutcome, AuditTarget } from '@nangohq/types';
 
-// Re-export the shared vocabulary so @nangohq/audit consumers (e.g. the server audit middleware) keep
-// importing these from here.
 export type {
     AuditActor,
     AuditActorType,
@@ -16,21 +14,59 @@ export type {
     AuditTrailVersion
 } from '@nangohq/types';
 
-export interface ConnectionDeletedMetadata {
-    // Qualifies the target: connection_id is unique only per (provider config key, environment).
-    providerConfigKey: string;
+export interface ConnectionMetadata {
+    providerConfigKey?: string;
 }
-
+export interface ConnectionUpdatedMetadata {
+    providerConfigKey?: string;
+    changedFields?: string[];
+}
+export interface IntegrationUpdatedMetadata {
+    changedFields?: string[];
+}
+export interface FunctionDeletedMetadata {
+    providerConfigKey?: string;
+    // Recorded as-is from the request; intentionally not narrowed so unexpected values still surface.
+    type?: string;
+}
+export interface ApiKeyUpdatedMetadata {
+    displayName?: string;
+    scopes?: string[];
+}
+export interface SyncFrequencyChangedMetadata {
+    providerConfigKey?: string;
+    frequency?: string;
+}
+export interface SyncVariantMetadata {
+    variant?: string;
+}
 export interface MemberRoleChangedMetadata {
-    // Optional: capturing it needs pre-update state a route-level emit may not have.
     fromRole?: string;
-    toRole: string;
+    toRole?: string;
+}
+export interface TeamUpdatedMetadata {
+    name?: string;
+}
+export interface EnvironmentUpdatedMetadata {
+    name?: string;
+    changedFields?: string[];
+}
+export interface EnvironmentVariablesChangedMetadata {
+    variableCount?: number;
+    variableNames?: string[];
+}
+export interface EnvironmentWebhookMetadata {
+    primaryUrl?: string;
+    secondaryUrl?: string;
+}
+export interface BillingPlanChangedMetadata {
+    fromPlan?: string;
+    toPlan?: string;
 }
 
 interface AuditEventCommon {
     occurredAt: string;
     accountId: number;
-    // null for account-scoped events (e.g. member changes) that aren't tied to an environment.
     environment: { id: number; display: string } | null;
     actor: AuditActor;
     via?: AuditActor[];
@@ -39,6 +75,27 @@ interface AuditEventCommon {
     outcome: AuditOutcome;
 }
 
-export type AuditEvent =
-    | (AuditEventCommon & { resource: 'connection'; action: 'deleted'; metadata?: ConnectionDeletedMetadata })
-    | (AuditEventCommon & { resource: 'member'; action: 'role_changed'; metadata?: MemberRoleChangedMetadata });
+export type AuditResourceAction =
+    | { resource: 'connection'; action: 'refreshed' | 'metadata_updated' | 'deleted'; metadata?: ConnectionMetadata }
+    | { resource: 'connection'; action: 'updated'; metadata?: ConnectionUpdatedMetadata }
+    | { resource: 'integration'; action: 'updated'; metadata?: IntegrationUpdatedMetadata }
+    | { resource: 'integration'; action: 'deleted' }
+    | { resource: 'function'; action: 'deleted'; metadata?: FunctionDeletedMetadata }
+    | { resource: 'api_key'; action: 'updated'; metadata?: ApiKeyUpdatedMetadata }
+    | { resource: 'api_key'; action: 'deleted' }
+    | { resource: 'sync'; action: 'enabled' | 'disabled' }
+    | { resource: 'sync'; action: 'frequency_changed'; metadata?: SyncFrequencyChangedMetadata }
+    | { resource: 'sync'; action: 'variant_created' | 'variant_deleted'; metadata?: SyncVariantMetadata }
+    | { resource: 'member'; action: 'removed' }
+    | { resource: 'member'; action: 'role_changed'; metadata?: MemberRoleChangedMetadata }
+    | { resource: 'team'; action: 'updated'; metadata?: TeamUpdatedMetadata }
+    | { resource: 'user'; action: 'updated' }
+    | { resource: 'environment'; action: 'deleted' }
+    | { resource: 'environment'; action: 'webhook_urls_changed'; metadata?: EnvironmentWebhookMetadata }
+    | { resource: 'environment'; action: 'updated'; metadata?: EnvironmentUpdatedMetadata }
+    | { resource: 'environment'; action: 'variables_changed'; metadata?: EnvironmentVariablesChangedMetadata }
+    | { resource: 'billing'; action: 'trial_extended' | 'details_changed' }
+    | { resource: 'billing'; action: 'plan_changed'; metadata?: BillingPlanChangedMetadata }
+    | { resource: 'app_auth'; action: 'password_changed' };
+
+export type AuditEvent = AuditEventCommon & AuditResourceAction;

--- a/packages/server/lib/middleware/audit.middleware.ts
+++ b/packages/server/lib/middleware/audit.middleware.ts
@@ -6,7 +6,7 @@ import { getLogger, metrics } from '@nangohq/utils';
 import { audit } from '../audit.js';
 
 import type { RequestLocals } from '../utils/express.js';
-import type { AuditActor, AuditContext, AuditEvent, AuditOutcome, AuditResourceAction, AuditTarget, AuditTargetType } from '@nangohq/audit';
+import type { AuditActor, AuditContext, AuditEvent, AuditOutcome, AuditTarget, AuditTargetType } from '@nangohq/audit';
 import type {
     AuditEndpointPolicy,
     DeleteApiKey,
@@ -53,29 +53,16 @@ type AuditRequest<TEndpoint extends Endpoint<any>> = Request<TEndpoint['Params']
 
 type AuditableEndpoint = Endpoint<any> & { Audit: AuditEndpointPolicy };
 
-// Matched by action membership, since a variant may group several actions under one metadata shape.
-type VariantFor<TAudit extends AuditEndpointPolicy> = AuditResourceAction extends infer V
-    ? V extends AuditResourceAction
-        ? V['resource'] extends TAudit['resource']
-            ? TAudit['action'] extends V['action']
-                ? V
-                : never
-            : never
-        : never
-    : never;
-type MetaOf<V> = V extends { metadata?: infer M } ? M : never;
-type SpecMetadata<TEndpoint extends Endpoint<any>, V> = 'metadata' extends keyof V
-    ? { metadata?: (req: AuditRequest<TEndpoint>, locals: RequestLocals) => MetaOf<V> | undefined | Promise<MetaOf<V> | undefined> }
-    : { metadata?: never };
-
 // The identity comes from the endpoint's own `Audit` declaration (so wiring can't disagree with it);
-// the spec only adds the runtime resolvers.
+// the spec only adds the runtime resolvers. Metadata is best-effort and loosely typed here — the
+// per-event shapes are documented on the emit model (@nangohq/audit's AuditEvent).
 export type AuditSpec<TEndpoint extends AuditableEndpoint> = Omit<TEndpoint['Audit'], 'kind'> & {
     target?: (
         req: AuditRequest<TEndpoint>,
         locals: RequestLocals
     ) => AuditTarget | AuditTarget[] | undefined | Promise<AuditTarget | AuditTarget[] | undefined>;
-} & SpecMetadata<TEndpoint, VariantFor<TEndpoint['Audit']>>;
+    metadata?: (req: AuditRequest<TEndpoint>, locals: RequestLocals) => Record<string, unknown> | undefined | Promise<Record<string, unknown> | undefined>;
+};
 
 function toId(value: unknown): string | undefined {
     if (typeof value === 'string') {

--- a/packages/server/lib/middleware/audit.middleware.ts
+++ b/packages/server/lib/middleware/audit.middleware.ts
@@ -1,46 +1,93 @@
+import db from '@nangohq/database';
 import { getFlags } from '@nangohq/feature-flags';
-import { userService } from '@nangohq/shared';
+import { customerKeyService, getSyncConfigById, userService } from '@nangohq/shared';
 import { getLogger, metrics } from '@nangohq/utils';
 
 import { audit } from '../audit.js';
 
 import type { RequestLocals } from '../utils/express.js';
+import type { AuditActor, AuditContext, AuditEvent, AuditOutcome, AuditResourceAction, AuditTarget, AuditTargetType } from '@nangohq/audit';
 import type {
-    AuditActor,
-    AuditContext,
-    AuditEvent,
-    AuditOutcome,
-    AuditTarget,
-    AuditTargetType,
-    ConnectionDeletedMetadata,
-    MemberRoleChangedMetadata
-} from '@nangohq/audit';
-import type { DeleteConnection, DeletePublicConnection, Endpoint, PatchTeamUser } from '@nangohq/types';
+    AuditEndpointPolicy,
+    DeleteApiKey,
+    DeleteConnection,
+    DeleteEnvironment,
+    DeleteIntegration,
+    DeleteIntegrationFunction,
+    DeletePublicConnection,
+    DeletePublicIntegration,
+    DeletePublicIntegrationFunction,
+    DeleteSyncVariant,
+    DeleteTeamUser,
+    Endpoint,
+    PatchApiKey,
+    PatchConnection,
+    PatchEnvironment,
+    PatchFlowDisable,
+    PatchFlowEnable,
+    PatchFlowFrequency,
+    PatchIntegration,
+    PatchPublicConnection,
+    PatchPublicIntegration,
+    PatchTeamUser,
+    PatchUser,
+    PatchWebhook,
+    PostConnectionMetadata,
+    PostConnectionRefresh,
+    PostEnvironmentVariables,
+    PostPlanChange,
+    PostPlanExtendTrial,
+    PostSyncVariant,
+    PutBillingInvoicingDetails,
+    PutPublicSyncConnectionFrequency,
+    PutTeam,
+    PutUserPassword,
+    SetMetadata,
+    UpdateMetadata
+} from '@nangohq/types';
 import type { Request, RequestHandler, Response } from 'express';
 
 const logger = getLogger('Audit');
 
 type AuditRequest<TEndpoint extends Endpoint<any>> = Request<TEndpoint['Params'], TEndpoint['Reply'], TEndpoint['Body'], TEndpoint['Querystring']>;
 
-// Everything is derived from the request so the event can be emitted for any outcome —
-// including permission denials, where the controller never runs.
-interface AuditSpecBase<TEndpoint extends Endpoint<any>> {
-    target?: (req: AuditRequest<TEndpoint>, locals: RequestLocals) => AuditTarget | undefined | Promise<AuditTarget | undefined>;
-    // `account`-scoped events emit a null environment; `environment`-scoped carry the request's env.
-    scope: 'account' | 'environment';
+type AuditableEndpoint = Endpoint<any> & { Audit: AuditEndpointPolicy };
+
+// Matched by action membership, since a variant may group several actions under one metadata shape.
+type VariantFor<TAudit extends AuditEndpointPolicy> = AuditResourceAction extends infer V
+    ? V extends AuditResourceAction
+        ? V['resource'] extends TAudit['resource']
+            ? TAudit['action'] extends V['action']
+                ? V
+                : never
+            : never
+        : never
+    : never;
+type MetaOf<V> = V extends { metadata?: infer M } ? M : never;
+type SpecMetadata<TEndpoint extends Endpoint<any>, V> = 'metadata' extends keyof V
+    ? { metadata?: (req: AuditRequest<TEndpoint>, locals: RequestLocals) => MetaOf<V> | undefined | Promise<MetaOf<V> | undefined> }
+    : { metadata?: never };
+
+// The identity comes from the endpoint's own `Audit` declaration (so wiring can't disagree with it);
+// the spec only adds the runtime resolvers.
+export type AuditSpec<TEndpoint extends AuditableEndpoint> = Omit<TEndpoint['Audit'], 'kind'> & {
+    target?: (
+        req: AuditRequest<TEndpoint>,
+        locals: RequestLocals
+    ) => AuditTarget | AuditTarget[] | undefined | Promise<AuditTarget | AuditTarget[] | undefined>;
+} & SpecMetadata<TEndpoint, VariantFor<TEndpoint['Audit']>>;
+
+function toId(value: unknown): string | undefined {
+    if (typeof value === 'string') {
+        return value.length > 0 ? value : undefined;
+    }
+    return typeof value === 'number' ? String(value) : undefined;
 }
 
-export type AuditSpec<TEndpoint extends Endpoint<any> = Endpoint<any>> =
-    | (AuditSpecBase<TEndpoint> & {
-          resource: 'connection';
-          action: 'deleted';
-          metadata?: (req: AuditRequest<TEndpoint>) => ConnectionDeletedMetadata | undefined;
-      })
-    | (AuditSpecBase<TEndpoint> & {
-          resource: 'member';
-          action: 'role_changed';
-          metadata?: (req: AuditRequest<TEndpoint>) => MemberRoleChangedMetadata | undefined;
-      });
+function makeTarget(type: AuditTargetType, value: unknown, display?: string): AuditTarget | undefined {
+    const id = toId(value);
+    return id ? { type, id, ...(display ? { display } : {}) } : undefined;
+}
 
 function resolveActor(locals: RequestLocals): AuditActor {
     if (locals.authType === 'session' && locals.user) {
@@ -92,22 +139,26 @@ async function resolveDisplay(target: AuditTargetType, lookup: () => Promise<str
     }
 }
 
-async function emit(spec: AuditSpec, req: Request, res: Response): Promise<void> {
-    // Stamp occurredAt now, before the async flag check, so it reflects the response — not flag latency.
+async function emit(
+    spec: Omit<AuditEndpointPolicy, 'kind'>,
+    req: Request,
+    res: Response,
+    enabled: boolean,
+    resolved: ResolvedAudit | undefined
+): Promise<void> {
+    // Stamp occurredAt now so it reflects the response time, not audit-write latency.
     const occurredAt = new Date().toISOString();
     try {
+        if (!enabled) {
+            return;
+        }
         const locals = res.locals as RequestLocals;
         const { account, environment } = locals;
         if (!account) {
             return;
         }
-        if (!(await getFlags().isAuditTrailEnabled(account.uuid))) {
-            return;
-        }
-        const target = await spec.target?.(req, locals);
-        const metadata = spec.metadata?.(req);
-        // Cast is plumbing: AuditSpec already type-checks against the AuditEvent variants, but TS
-        // can't narrow the spread back to one.
+        const target = resolved?.target;
+        const metadata = resolved?.metadata;
         const event = {
             occurredAt,
             accountId: account.id,
@@ -115,7 +166,7 @@ async function emit(spec: AuditSpec, req: Request, res: Response): Promise<void>
             actor: resolveActor(locals),
             resource: spec.resource,
             action: spec.action,
-            targets: target ? [target] : [],
+            targets: Array.isArray(target) ? target : target ? [target] : [],
             context: contextFromRequest(req),
             outcome: outcomeFromStatus(res.statusCode),
             ...(metadata ? { metadata } : {})
@@ -129,45 +180,417 @@ async function emit(spec: AuditSpec, req: Request, res: Response): Promise<void>
     }
 }
 
+interface ResolvedAudit {
+    target: AuditTarget | AuditTarget[] | undefined;
+    metadata: unknown;
+}
+
 // Place AFTER auth and BEFORE authorization so it captures every outcome — including 403 denials
 // that never reach the controller.
-export function auditable<TEndpoint extends Endpoint<any>>(spec: AuditSpec<TEndpoint>): RequestHandler {
+export function auditable<TEndpoint extends AuditableEndpoint>(spec: AuditSpec<TEndpoint>): RequestHandler {
     return (req, res, next) => {
+        // Resolve target and metadata before the handler runs — some handlers move or overwrite the
+        // pre-mutation state (a removed member, an old role) — then emit on finish. The audit-enabled
+        // flag is checked once here (not again in emit) so a single check drives both phases.
+        let enabled = false;
+        let resolved: ResolvedAudit | undefined;
         res.on('finish', () => {
-            void emit(spec, req, res);
+            void emit(spec, req, res, enabled, resolved);
         });
-        next();
+        void (async () => {
+            try {
+                const locals = res.locals as RequestLocals;
+                if (locals.account && (await getFlags().isAuditTrailEnabled(locals.account.uuid))) {
+                    enabled = true;
+                    resolved = {
+                        target: spec.target ? await spec.target(req, locals) : undefined,
+                        metadata: spec.metadata ? await spec.metadata(req, locals) : undefined
+                    };
+                }
+            } catch (err) {
+                logger.error(`failed to resolve audit target`, err);
+            } finally {
+                next();
+            }
+        })();
     };
 }
 
-// Per-route wiring is manual: new connection-delete routes (e.g. the admin delete) must opt in.
-export const auditConnectionDeleted = auditable<DeletePublicConnection | DeleteConnection>({
+function param(req: Request<any, any, any, any>, key: string): unknown {
+    return (req.params as Record<string, unknown>)[key];
+}
+function query(req: Request<any, any, any, any>, key: string): unknown {
+    return (req.query as Record<string, unknown>)[key];
+}
+function bodyField(req: Request<any, any, any, any>, key: string): unknown {
+    return req.body && typeof req.body === 'object' ? (req.body as Record<string, unknown>)[key] : undefined;
+}
+function providerConfigKeyMeta(value: unknown): { providerConfigKey: string } | undefined {
+    return typeof value === 'string' && value.length > 0 ? { providerConfigKey: value } : undefined;
+}
+// Keep only origin + path from a URL — a webhook URL can carry a secret token in its query string or
+// userinfo, and this goes into the immutable audit record.
+function safeUrl(value: unknown): string | undefined {
+    if (typeof value !== 'string' || value.length === 0) {
+        return undefined;
+    }
+    try {
+        const url = new URL(value);
+        return url.origin;
+    } catch {
+        return undefined;
+    }
+}
+const CHANGED_FIELDS_MAX = 30;
+const CHANGED_FIELD_KEY_MAX = 64;
+// Names of the fields present in the request body — never their values, so secrets never leak.
+function changedFields(req: Request<any, any, any, any>): string[] | undefined {
+    if (!req.body || typeof req.body !== 'object') {
+        return undefined;
+    }
+    const keys = Object.keys(req.body as Record<string, unknown>)
+        .filter((key) => key.length <= CHANGED_FIELD_KEY_MAX)
+        .slice(0, CHANGED_FIELDS_MAX);
+    return keys.length > 0 ? keys : undefined;
+}
+async function memberTarget(req: AuditRequest<Endpoint<any>>, locals: RequestLocals): Promise<AuditTarget | undefined> {
+    const id = toId(param(req, 'id'));
+    if (!id) {
+        return undefined;
+    }
+    const display = await resolveDisplay('member', async () => {
+        if (!locals.account) {
+            return undefined;
+        }
+        const user = await userService.getUserByIdAndAccountId(Number(id), locals.account.id);
+        return user?.email;
+    });
+    return { type: 'member', id, ...(display ? { display } : {}) };
+}
+
+async function syncTarget(value: unknown, locals: RequestLocals): Promise<AuditTarget | undefined> {
+    const id = toId(value);
+    if (!id) {
+        return undefined;
+    }
+    const numericId = Number(id);
+    const display = Number.isNaN(numericId)
+        ? undefined
+        : await resolveDisplay('sync', async () => {
+              if (!locals.environment) {
+                  return undefined;
+              }
+              const syncConfig = await getSyncConfigById(locals.environment.id, numericId);
+              return syncConfig?.sync_name;
+          });
+    return { type: 'sync', id, ...(display ? { display } : {}) };
+}
+
+async function apiKeyTarget(value: unknown, locals: RequestLocals): Promise<AuditTarget | undefined> {
+    const id = toId(value);
+    if (!id) {
+        return undefined;
+    }
+    const display = await resolveDisplay('api_key', async () => {
+        if (!locals.environment) {
+            return undefined;
+        }
+        const result = await customerKeyService.getApiKeysByEnv(db.knex, locals.environment.id);
+        return result.isOk() ? result.value.find((key) => String(key.id) === id)?.display_name : undefined;
+    });
+    return { type: 'api_key', id, ...(display ? { display } : {}) };
+}
+
+export const auditConnectionRefreshed = auditable<PostConnectionRefresh>({
+    resource: 'connection',
+    action: 'refreshed',
+    scope: 'environment',
+    target: (req) => makeTarget('connection', param(req, 'connectionId')),
+    metadata: (req) => providerConfigKeyMeta(query(req, 'provider_config_key'))
+});
+export const auditConnectionUpdated = auditable<PatchConnection | PatchPublicConnection>({
+    resource: 'connection',
+    action: 'updated',
+    scope: 'environment',
+    target: (req) => makeTarget('connection', param(req, 'connectionId')),
+    metadata: (req) => {
+        const meta: { providerConfigKey?: string; changedFields?: string[] } = {};
+        const providerConfigKey = query(req, 'provider_config_key');
+        if (typeof providerConfigKey === 'string' && providerConfigKey.length > 0) {
+            meta.providerConfigKey = providerConfigKey;
+        }
+        const fields = changedFields(req);
+        if (fields) {
+            meta.changedFields = fields;
+        }
+        return Object.keys(meta).length > 0 ? meta : undefined;
+    }
+});
+export const auditConnectionMetadataUpdated = auditable<PostConnectionMetadata | SetMetadata | UpdateMetadata>({
+    resource: 'connection',
+    action: 'metadata_updated',
+    scope: 'environment',
+    // The batch metadata endpoints accept connection_id as an array — record one target per connection.
+    target: (req) => {
+        const fromBody = bodyField(req, 'connection_id');
+        if (Array.isArray(fromBody)) {
+            return fromBody.map((id) => makeTarget('connection', id)).filter((t): t is AuditTarget => Boolean(t));
+        }
+        return makeTarget('connection', param(req, 'connectionId') ?? fromBody);
+    },
+    metadata: (req) => providerConfigKeyMeta(query(req, 'provider_config_key') ?? bodyField(req, 'provider_config_key'))
+});
+export const auditConnectionDeleted = auditable<DeleteConnection | DeletePublicConnection>({
     resource: 'connection',
     action: 'deleted',
     scope: 'environment',
-    target: (req) => ({ type: 'connection', id: req.params.connectionId }),
+    target: (req) => makeTarget('connection', param(req, 'connectionId')),
+    metadata: (req) => providerConfigKeyMeta(query(req, 'provider_config_key'))
+});
+
+export const auditIntegrationUpdated = auditable<PatchIntegration | PatchPublicIntegration>({
+    resource: 'integration',
+    action: 'updated',
+    scope: 'environment',
+    target: (req) => makeTarget('integration', param(req, 'providerConfigKey') ?? param(req, 'uniqueKey')),
     metadata: (req) => {
-        const key = req.query.provider_config_key;
-        return typeof key === 'string' ? { providerConfigKey: key } : undefined;
+        const fields = changedFields(req);
+        return fields ? { changedFields: fields } : undefined;
+    }
+});
+export const auditIntegrationDeleted = auditable<DeleteIntegration | DeletePublicIntegration>({
+    resource: 'integration',
+    action: 'deleted',
+    scope: 'environment',
+    target: (req) => makeTarget('integration', param(req, 'providerConfigKey') ?? param(req, 'uniqueKey'))
+});
+
+export const auditFunctionDeleted = auditable<DeleteIntegrationFunction | DeletePublicIntegrationFunction>({
+    resource: 'function',
+    action: 'deleted',
+    scope: 'environment',
+    target: (req) => makeTarget('function', param(req, 'functionName') ?? param(req, 'name')),
+    metadata: (req) => {
+        const meta: { providerConfigKey?: string; type?: string } = {};
+        const providerConfigKey = param(req, 'providerConfigKey') ?? param(req, 'uniqueKey');
+        if (typeof providerConfigKey === 'string' && providerConfigKey.length > 0) {
+            meta.providerConfigKey = providerConfigKey;
+        }
+        // A sync and an action can share a name; `type` disambiguates which function was deleted.
+        const type = query(req, 'type');
+        if (typeof type === 'string') {
+            meta.type = type;
+        }
+        return Object.keys(meta).length > 0 ? meta : undefined;
     }
 });
 
+export const auditApiKeyUpdated = auditable<PatchApiKey>({
+    resource: 'api_key',
+    action: 'updated',
+    scope: 'environment',
+    target: (req, locals) => apiKeyTarget(param(req, 'keyId'), locals),
+    metadata: (req) => {
+        const meta: { displayName?: string; scopes?: string[] } = {};
+        const displayName = bodyField(req, 'display_name');
+        if (typeof displayName === 'string') {
+            meta.displayName = displayName;
+        }
+        const scopes = bodyField(req, 'scopes');
+        if (Array.isArray(scopes)) {
+            meta.scopes = scopes.filter((s): s is string => typeof s === 'string');
+        }
+        return Object.keys(meta).length > 0 ? meta : undefined;
+    }
+});
+export const auditApiKeyDeleted = auditable<DeleteApiKey>({
+    resource: 'api_key',
+    action: 'deleted',
+    scope: 'environment',
+    target: (req, locals) => apiKeyTarget(param(req, 'keyId'), locals)
+});
+
+export const auditSyncEnabled = auditable<PatchFlowEnable>({
+    resource: 'sync',
+    action: 'enabled',
+    scope: 'environment',
+    target: (req, locals) => syncTarget(param(req, 'id'), locals)
+});
+export const auditSyncDisabled = auditable<PatchFlowDisable>({
+    resource: 'sync',
+    action: 'disabled',
+    scope: 'environment',
+    target: (req, locals) => syncTarget(param(req, 'id'), locals)
+});
+export const auditSyncFrequencyChanged = auditable<PatchFlowFrequency | PutPublicSyncConnectionFrequency>({
+    resource: 'sync',
+    action: 'frequency_changed',
+    scope: 'environment',
+    target: (req, locals) => syncTarget(param(req, 'id') ?? bodyField(req, 'sync_name'), locals),
+    metadata: (req) => {
+        const meta: { providerConfigKey?: string; frequency?: string } = {};
+        const frequency = bodyField(req, 'frequency');
+        if (typeof frequency === 'string') {
+            meta.frequency = frequency;
+        }
+        // Private route sends camelCase `providerConfigKey`; public route sends snake_case.
+        const providerConfigKey = bodyField(req, 'providerConfigKey') ?? bodyField(req, 'provider_config_key');
+        if (typeof providerConfigKey === 'string') {
+            meta.providerConfigKey = providerConfigKey;
+        }
+        return Object.keys(meta).length > 0 ? meta : undefined;
+    }
+});
+export const auditSyncVariantCreated = auditable<PostSyncVariant>({
+    resource: 'sync',
+    action: 'variant_created',
+    scope: 'environment',
+    target: (req) => makeTarget('sync', param(req, 'name')),
+    metadata: (req) => {
+        const variant = param(req, 'variant');
+        return typeof variant === 'string' ? { variant } : undefined;
+    }
+});
+export const auditSyncVariantDeleted = auditable<DeleteSyncVariant>({
+    resource: 'sync',
+    action: 'variant_deleted',
+    scope: 'environment',
+    target: (req) => makeTarget('sync', param(req, 'name')),
+    metadata: (req) => {
+        const variant = param(req, 'variant');
+        return typeof variant === 'string' ? { variant } : undefined;
+    }
+});
+
+export const auditMemberRemoved = auditable<DeleteTeamUser>({
+    resource: 'member',
+    action: 'removed',
+    scope: 'account',
+    target: memberTarget
+});
 export const auditMemberRoleChanged = auditable<PatchTeamUser>({
     resource: 'member',
     action: 'role_changed',
     scope: 'account',
-    target: async (req, locals) => {
-        const display = await resolveDisplay('member', async () => {
-            if (!locals.account) {
-                return undefined;
+    target: memberTarget,
+    metadata: async (req, locals) => {
+        const meta: { fromRole?: string; toRole?: string } = {};
+        const role = bodyField(req, 'role');
+        if (typeof role === 'string') {
+            meta.toRole = role;
+        }
+        const id = toId(param(req, 'id'));
+        if (id && locals.account) {
+            const accountId = locals.account.id;
+            const fromRole = await resolveDisplay('member', async () => {
+                const user = await userService.getUserByIdAndAccountId(Number(id), accountId);
+                return user?.role;
+            });
+            if (fromRole) {
+                meta.fromRole = fromRole;
             }
-            const user = await userService.getUserByIdAndAccountId(Number(req.params.id), locals.account.id);
-            return user?.email;
-        });
-        return { type: 'member', id: String(req.params.id), ...(display ? { display } : {}) };
-    },
-    metadata: (req) => {
-        const role = req.body?.role;
-        return typeof role === 'string' ? { toRole: role } : undefined;
+        }
+        return Object.keys(meta).length > 0 ? meta : undefined;
     }
+});
+export const auditTeamUpdated = auditable<PutTeam>({
+    resource: 'team',
+    action: 'updated',
+    scope: 'account',
+    target: (_req, locals) => makeTarget('team', locals.account?.id, locals.account?.name),
+    metadata: (req) => {
+        const name = bodyField(req, 'name');
+        return typeof name === 'string' ? { name } : undefined;
+    }
+});
+export const auditUserUpdated = auditable<PatchUser>({
+    resource: 'user',
+    action: 'updated',
+    scope: 'account',
+    target: (_req, locals) => makeTarget('user', locals.user?.id, locals.user?.email)
+});
+
+export const auditEnvironmentDeleted = auditable<DeleteEnvironment>({
+    resource: 'environment',
+    action: 'deleted',
+    scope: 'environment',
+    target: (_req, locals) => makeTarget('environment', locals.environment?.id, locals.environment?.name)
+});
+export const auditEnvironmentUpdated = auditable<PatchEnvironment>({
+    resource: 'environment',
+    action: 'updated',
+    scope: 'environment',
+    target: (_req, locals) => makeTarget('environment', locals.environment?.id, locals.environment?.name),
+    metadata: (req) => {
+        const meta: { name?: string; changedFields?: string[] } = {};
+        const name = bodyField(req, 'name');
+        if (typeof name === 'string') {
+            meta.name = name;
+        }
+        const fields = changedFields(req);
+        if (fields) {
+            meta.changedFields = fields;
+        }
+        return Object.keys(meta).length > 0 ? meta : undefined;
+    }
+});
+export const auditEnvironmentVariablesChanged = auditable<PostEnvironmentVariables>({
+    resource: 'environment',
+    action: 'variables_changed',
+    scope: 'environment',
+    target: (_req, locals) => makeTarget('environment', locals.environment?.id, locals.environment?.name),
+    metadata: (req) => {
+        const variables = bodyField(req, 'variables');
+        if (!Array.isArray(variables)) {
+            return undefined;
+        }
+        const variableNames = variables
+            .map((v) => (v && typeof v === 'object' ? (v as Record<string, unknown>)['name'] : undefined))
+            .filter((n): n is string => typeof n === 'string');
+        return { variableCount: variables.length, ...(variableNames.length > 0 ? { variableNames } : {}) };
+    }
+});
+export const auditEnvironmentWebhookUrlsChanged = auditable<PatchWebhook>({
+    resource: 'environment',
+    action: 'webhook_urls_changed',
+    scope: 'environment',
+    target: (_req, locals) => makeTarget('environment', locals.environment?.id, locals.environment?.name),
+    metadata: (req) => {
+        const meta: { primaryUrl?: string; secondaryUrl?: string } = {};
+        const primaryUrl = safeUrl(bodyField(req, 'primary_url'));
+        if (primaryUrl) {
+            meta.primaryUrl = primaryUrl;
+        }
+        const secondaryUrl = safeUrl(bodyField(req, 'secondary_url'));
+        if (secondaryUrl) {
+            meta.secondaryUrl = secondaryUrl;
+        }
+        return Object.keys(meta).length > 0 ? meta : undefined;
+    }
+});
+
+export const auditBillingPlanChanged = auditable<PostPlanChange>({
+    resource: 'billing',
+    action: 'plan_changed',
+    scope: 'account',
+    metadata: (req, locals) => {
+        const meta: { fromPlan?: string; toPlan?: string } = {};
+        const orbId = bodyField(req, 'orbId');
+        if (typeof orbId === 'string') {
+            meta.toPlan = orbId;
+        }
+        if (locals.plan?.name) {
+            meta.fromPlan = locals.plan.name;
+        }
+        return Object.keys(meta).length > 0 ? meta : undefined;
+    }
+});
+export const auditBillingTrialExtended = auditable<PostPlanExtendTrial>({ resource: 'billing', action: 'trial_extended', scope: 'account' });
+export const auditBillingDetailsChanged = auditable<PutBillingInvoicingDetails>({ resource: 'billing', action: 'details_changed', scope: 'account' });
+
+export const auditAppAuthPasswordChanged = auditable<PutUserPassword>({
+    resource: 'app_auth',
+    action: 'password_changed',
+    scope: 'account',
+    target: (_req, locals) => makeTarget('user', locals.user?.id, locals.user?.email)
 });

--- a/packages/server/lib/middleware/audit.middleware.ts
+++ b/packages/server/lib/middleware/audit.middleware.ts
@@ -203,17 +203,57 @@ export function auditable<TEndpoint extends AuditableEndpoint>(spec: AuditSpec<T
     };
 }
 
+// The deprecated single-connection metadata routes (POST/PATCH /connection/:connectionId/metadata)
+// reuse the batch SetMetadata/UpdateMetadata endpoints but carry the connection in the path/query
+// instead of the body. Those routes have no typed contract (their controllers take a raw Request), so
+// these two reads stay untyped — the batch body fields they fall back to ARE typed on the resolver.
 function param(req: Request<any, any, any, any>, key: string): unknown {
     return (req.params as Record<string, unknown>)[key];
 }
 function query(req: Request<any, any, any, any>, key: string): unknown {
     return (req.query as Record<string, unknown>)[key];
 }
-function bodyField(req: Request<any, any, any, any>, key: string): unknown {
-    return req.body && typeof req.body === 'object' ? (req.body as Record<string, unknown>)[key] : undefined;
-}
 function providerConfigKeyMeta(value: unknown): { providerConfigKey: string } | undefined {
     return typeof value === 'string' && value.length > 0 ? { providerConfigKey: value } : undefined;
+}
+// The batch metadata endpoints accept connection_id as an array (body) — record one target per
+// connection; the deprecated single-connection routes carry it in the path instead.
+function connectionTargets(paramId: unknown, bodyId: string | string[] | undefined): AuditTarget | AuditTarget[] | undefined {
+    if (Array.isArray(bodyId)) {
+        return bodyId.map((id) => makeTarget('connection', id)).filter((t): t is AuditTarget => Boolean(t));
+    }
+    return makeTarget('connection', paramId ?? bodyId);
+}
+function connectionUpdatedMeta(providerConfigKey: string | undefined, fields: string[] | undefined): Record<string, unknown> | undefined {
+    const meta: { providerConfigKey?: string; changedFields?: string[] } = {};
+    if (providerConfigKey && providerConfigKey.length > 0) {
+        meta.providerConfigKey = providerConfigKey;
+    }
+    if (fields) {
+        meta.changedFields = fields;
+    }
+    return Object.keys(meta).length > 0 ? meta : undefined;
+}
+function syncFrequencyMeta(frequency: string | null | undefined, providerConfigKey: string | undefined): Record<string, unknown> | undefined {
+    const meta: { providerConfigKey?: string; frequency?: string } = {};
+    if (typeof frequency === 'string') {
+        meta.frequency = frequency;
+    }
+    if (typeof providerConfigKey === 'string') {
+        meta.providerConfigKey = providerConfigKey;
+    }
+    return Object.keys(meta).length > 0 ? meta : undefined;
+}
+function functionDeletedMeta(providerConfigKey: string | undefined, type: string | undefined): Record<string, unknown> | undefined {
+    const meta: { providerConfigKey?: string; type?: string } = {};
+    if (providerConfigKey && providerConfigKey.length > 0) {
+        meta.providerConfigKey = providerConfigKey;
+    }
+    // A sync and an action can share a name; `type` disambiguates which function was deleted.
+    if (type) {
+        meta.type = type;
+    }
+    return Object.keys(meta).length > 0 ? meta : undefined;
 }
 // Keep only the origin (scheme + host) of a URL — a webhook URL can carry a secret token in its path,
 // query string, or userinfo, and this goes into the immutable audit record.
@@ -240,8 +280,8 @@ function changedFields(req: Request<any, any, any, any>): string[] | undefined {
         .slice(0, CHANGED_FIELDS_MAX);
     return keys.length > 0 ? keys : undefined;
 }
-async function memberTarget(req: AuditRequest<Endpoint<any>>, locals: RequestLocals): Promise<AuditTarget | undefined> {
-    const id = toId(param(req, 'id'));
+async function memberTarget(req: Request<{ id: number }>, locals: RequestLocals): Promise<AuditTarget | undefined> {
+    const id = toId(req.params.id);
     if (!id) {
         return undefined;
     }
@@ -292,100 +332,122 @@ export const auditConnectionRefreshed = auditable<PostConnectionRefresh>({
     resource: 'connection',
     action: 'refreshed',
     scope: 'environment',
-    target: (req) => makeTarget('connection', param(req, 'connectionId')),
-    metadata: (req) => providerConfigKeyMeta(query(req, 'provider_config_key'))
+    target: (req) => makeTarget('connection', req.params.connectionId),
+    metadata: (req) => providerConfigKeyMeta(req.query.provider_config_key)
 });
-export const auditConnectionUpdated = auditable<PatchConnection | PatchPublicConnection>({
+export const auditConnectionUpdated = auditable<PatchConnection>({
     resource: 'connection',
     action: 'updated',
     scope: 'environment',
-    target: (req) => makeTarget('connection', param(req, 'connectionId')),
-    metadata: (req) => {
-        const meta: { providerConfigKey?: string; changedFields?: string[] } = {};
-        const providerConfigKey = query(req, 'provider_config_key');
-        if (typeof providerConfigKey === 'string' && providerConfigKey.length > 0) {
-            meta.providerConfigKey = providerConfigKey;
-        }
-        const fields = changedFields(req);
-        if (fields) {
-            meta.changedFields = fields;
-        }
-        return Object.keys(meta).length > 0 ? meta : undefined;
-    }
+    target: (req) => makeTarget('connection', req.params.connectionId),
+    metadata: (req) => connectionUpdatedMeta(req.query.provider_config_key, changedFields(req))
 });
-export const auditConnectionMetadataUpdated = auditable<PostConnectionMetadata | SetMetadata | UpdateMetadata>({
+export const auditPublicConnectionUpdated = auditable<PatchPublicConnection>({
+    resource: 'connection',
+    action: 'updated',
+    scope: 'environment',
+    target: (req) => makeTarget('connection', req.params.connectionId),
+    metadata: (req) => connectionUpdatedMeta(req.query.provider_config_key, changedFields(req))
+});
+export const auditConnectionMetadataUpdated = auditable<PostConnectionMetadata>({
+    resource: 'connection',
+    action: 'metadata_updated',
+    scope: 'environment',
+    target: (req) => makeTarget('connection', req.params.connectionId),
+    metadata: (req) => providerConfigKeyMeta(req.query.provider_config_key)
+});
+export const auditPublicConnectionMetadataSet = auditable<SetMetadata>({
     resource: 'connection',
     action: 'metadata_updated',
     scope: 'environment',
     // The batch metadata endpoints accept connection_id as an array — record one target per connection.
-    target: (req) => {
-        const fromBody = bodyField(req, 'connection_id');
-        if (Array.isArray(fromBody)) {
-            return fromBody.map((id) => makeTarget('connection', id)).filter((t): t is AuditTarget => Boolean(t));
-        }
-        return makeTarget('connection', param(req, 'connectionId') ?? fromBody);
-    },
-    metadata: (req) => providerConfigKeyMeta(query(req, 'provider_config_key') ?? bodyField(req, 'provider_config_key'))
+    target: (req) => connectionTargets(param(req, 'connectionId'), req.body.connection_id),
+    metadata: (req) => providerConfigKeyMeta(query(req, 'provider_config_key') ?? req.body.provider_config_key)
 });
-export const auditConnectionDeleted = auditable<DeleteConnection | DeletePublicConnection>({
+export const auditPublicConnectionMetadataUpdated = auditable<UpdateMetadata>({
+    resource: 'connection',
+    action: 'metadata_updated',
+    scope: 'environment',
+    target: (req) => connectionTargets(param(req, 'connectionId'), req.body.connection_id),
+    metadata: (req) => providerConfigKeyMeta(query(req, 'provider_config_key') ?? req.body.provider_config_key)
+});
+export const auditConnectionDeleted = auditable<DeleteConnection>({
     resource: 'connection',
     action: 'deleted',
     scope: 'environment',
-    target: (req) => makeTarget('connection', param(req, 'connectionId')),
-    metadata: (req) => providerConfigKeyMeta(query(req, 'provider_config_key'))
+    target: (req) => makeTarget('connection', req.params.connectionId),
+    metadata: (req) => providerConfigKeyMeta(req.query.provider_config_key)
+});
+export const auditPublicConnectionDeleted = auditable<DeletePublicConnection>({
+    resource: 'connection',
+    action: 'deleted',
+    scope: 'environment',
+    target: (req) => makeTarget('connection', req.params.connectionId),
+    metadata: (req) => providerConfigKeyMeta(req.query.provider_config_key)
 });
 
-export const auditIntegrationUpdated = auditable<PatchIntegration | PatchPublicIntegration>({
+export const auditIntegrationUpdated = auditable<PatchIntegration>({
     resource: 'integration',
     action: 'updated',
     scope: 'environment',
-    target: (req) => makeTarget('integration', param(req, 'providerConfigKey') ?? param(req, 'uniqueKey')),
+    target: (req) => makeTarget('integration', req.params.providerConfigKey),
     metadata: (req) => {
         const fields = changedFields(req);
         return fields ? { changedFields: fields } : undefined;
     }
 });
-export const auditIntegrationDeleted = auditable<DeleteIntegration | DeletePublicIntegration>({
+export const auditPublicIntegrationUpdated = auditable<PatchPublicIntegration>({
+    resource: 'integration',
+    action: 'updated',
+    scope: 'environment',
+    target: (req) => makeTarget('integration', req.params.uniqueKey),
+    metadata: (req) => {
+        const fields = changedFields(req);
+        return fields ? { changedFields: fields } : undefined;
+    }
+});
+export const auditIntegrationDeleted = auditable<DeleteIntegration>({
     resource: 'integration',
     action: 'deleted',
     scope: 'environment',
-    target: (req) => makeTarget('integration', param(req, 'providerConfigKey') ?? param(req, 'uniqueKey'))
+    target: (req) => makeTarget('integration', req.params.providerConfigKey)
+});
+export const auditPublicIntegrationDeleted = auditable<DeletePublicIntegration>({
+    resource: 'integration',
+    action: 'deleted',
+    scope: 'environment',
+    target: (req) => makeTarget('integration', req.params.uniqueKey)
 });
 
-export const auditFunctionDeleted = auditable<DeleteIntegrationFunction | DeletePublicIntegrationFunction>({
+export const auditFunctionDeleted = auditable<DeleteIntegrationFunction>({
     resource: 'function',
     action: 'deleted',
     scope: 'environment',
-    target: (req) => makeTarget('function', param(req, 'functionName') ?? param(req, 'name')),
-    metadata: (req) => {
-        const meta: { providerConfigKey?: string; type?: string } = {};
-        const providerConfigKey = param(req, 'providerConfigKey') ?? param(req, 'uniqueKey');
-        if (typeof providerConfigKey === 'string' && providerConfigKey.length > 0) {
-            meta.providerConfigKey = providerConfigKey;
-        }
-        // A sync and an action can share a name; `type` disambiguates which function was deleted.
-        const type = query(req, 'type');
-        if (typeof type === 'string') {
-            meta.type = type;
-        }
-        return Object.keys(meta).length > 0 ? meta : undefined;
-    }
+    target: (req) => makeTarget('function', req.params.functionName),
+    metadata: (req) => functionDeletedMeta(req.params.providerConfigKey, req.query.type)
+});
+export const auditPublicFunctionDeleted = auditable<DeletePublicIntegrationFunction>({
+    resource: 'function',
+    action: 'deleted',
+    scope: 'environment',
+    target: (req) => makeTarget('function', req.params.name),
+    metadata: (req) => functionDeletedMeta(req.params.uniqueKey, req.query.type)
 });
 
 export const auditApiKeyUpdated = auditable<PatchApiKey>({
     resource: 'api_key',
     action: 'updated',
     scope: 'environment',
-    target: (req, locals) => apiKeyTarget(param(req, 'keyId'), locals),
+    target: (req, locals) => apiKeyTarget(req.params.keyId, locals),
     metadata: (req) => {
         const meta: { displayName?: string; scopes?: string[] } = {};
-        const displayName = bodyField(req, 'display_name');
+        const displayName = req.body.display_name;
         if (typeof displayName === 'string') {
             meta.displayName = displayName;
         }
-        const scopes = bodyField(req, 'scopes');
+        const scopes = req.body.scopes;
         if (Array.isArray(scopes)) {
-            meta.scopes = scopes.filter((s): s is string => typeof s === 'string');
+            meta.scopes = scopes.filter((s) => typeof s === 'string');
         }
         return Object.keys(meta).length > 0 ? meta : undefined;
     }
@@ -394,59 +456,50 @@ export const auditApiKeyDeleted = auditable<DeleteApiKey>({
     resource: 'api_key',
     action: 'deleted',
     scope: 'environment',
-    target: (req, locals) => apiKeyTarget(param(req, 'keyId'), locals)
+    target: (req, locals) => apiKeyTarget(req.params.keyId, locals)
 });
 
 export const auditSyncEnabled = auditable<PatchFlowEnable>({
     resource: 'sync',
     action: 'enabled',
     scope: 'environment',
-    target: (req, locals) => syncTarget(param(req, 'id'), locals)
+    target: (req, locals) => syncTarget(req.params.id, locals)
 });
 export const auditSyncDisabled = auditable<PatchFlowDisable>({
     resource: 'sync',
     action: 'disabled',
     scope: 'environment',
-    target: (req, locals) => syncTarget(param(req, 'id'), locals)
+    target: (req, locals) => syncTarget(req.params.id, locals)
 });
-export const auditSyncFrequencyChanged = auditable<PatchFlowFrequency | PutPublicSyncConnectionFrequency>({
+export const auditSyncFrequencyChanged = auditable<PatchFlowFrequency>({
     resource: 'sync',
     action: 'frequency_changed',
     scope: 'environment',
-    target: (req, locals) => syncTarget(param(req, 'id') ?? bodyField(req, 'sync_name'), locals),
-    metadata: (req) => {
-        const meta: { providerConfigKey?: string; frequency?: string } = {};
-        const frequency = bodyField(req, 'frequency');
-        if (typeof frequency === 'string') {
-            meta.frequency = frequency;
-        }
-        // Private route sends camelCase `providerConfigKey`; public route sends snake_case.
-        const providerConfigKey = bodyField(req, 'providerConfigKey') ?? bodyField(req, 'provider_config_key');
-        if (typeof providerConfigKey === 'string') {
-            meta.providerConfigKey = providerConfigKey;
-        }
-        return Object.keys(meta).length > 0 ? meta : undefined;
-    }
+    target: (req, locals) => syncTarget(req.params.id, locals),
+    // Private route sends camelCase `providerConfigKey`.
+    metadata: (req) => syncFrequencyMeta(req.body.frequency, req.body.providerConfigKey)
+});
+export const auditPublicSyncFrequencyChanged = auditable<PutPublicSyncConnectionFrequency>({
+    resource: 'sync',
+    action: 'frequency_changed',
+    scope: 'environment',
+    target: (req, locals) => syncTarget(req.body.sync_name, locals),
+    // Public route sends snake_case `provider_config_key`.
+    metadata: (req) => syncFrequencyMeta(req.body.frequency, req.body.provider_config_key)
 });
 export const auditSyncVariantCreated = auditable<PostSyncVariant>({
     resource: 'sync',
     action: 'variant_created',
     scope: 'environment',
-    target: (req) => makeTarget('sync', param(req, 'name')),
-    metadata: (req) => {
-        const variant = param(req, 'variant');
-        return typeof variant === 'string' ? { variant } : undefined;
-    }
+    target: (req) => makeTarget('sync', req.params.name),
+    metadata: (req) => ({ variant: req.params.variant })
 });
 export const auditSyncVariantDeleted = auditable<DeleteSyncVariant>({
     resource: 'sync',
     action: 'variant_deleted',
     scope: 'environment',
-    target: (req) => makeTarget('sync', param(req, 'name')),
-    metadata: (req) => {
-        const variant = param(req, 'variant');
-        return typeof variant === 'string' ? { variant } : undefined;
-    }
+    target: (req) => makeTarget('sync', req.params.name),
+    metadata: (req) => ({ variant: req.params.variant })
 });
 
 export const auditMemberRemoved = auditable<DeleteTeamUser>({
@@ -462,11 +515,11 @@ export const auditMemberRoleChanged = auditable<PatchTeamUser>({
     target: memberTarget,
     metadata: async (req, locals) => {
         const meta: { fromRole?: string; toRole?: string } = {};
-        const role = bodyField(req, 'role');
+        const role = req.body.role;
         if (typeof role === 'string') {
             meta.toRole = role;
         }
-        const id = toId(param(req, 'id'));
+        const id = toId(req.params.id);
         if (id && locals.account) {
             const accountId = locals.account.id;
             const fromRole = await resolveDisplay('member', async () => {
@@ -486,7 +539,7 @@ export const auditTeamUpdated = auditable<PutTeam>({
     scope: 'account',
     target: (_req, locals) => makeTarget('team', locals.account?.id, locals.account?.name),
     metadata: (req) => {
-        const name = bodyField(req, 'name');
+        const name = req.body.name;
         return typeof name === 'string' ? { name } : undefined;
     }
 });
@@ -510,7 +563,7 @@ export const auditEnvironmentUpdated = auditable<PatchEnvironment>({
     target: (_req, locals) => makeTarget('environment', locals.environment?.id, locals.environment?.name),
     metadata: (req) => {
         const meta: { name?: string; changedFields?: string[] } = {};
-        const name = bodyField(req, 'name');
+        const name = req.body.name;
         if (typeof name === 'string') {
             meta.name = name;
         }
@@ -527,7 +580,7 @@ export const auditEnvironmentVariablesChanged = auditable<PostEnvironmentVariabl
     scope: 'environment',
     target: (_req, locals) => makeTarget('environment', locals.environment?.id, locals.environment?.name),
     metadata: (req) => {
-        const variables = bodyField(req, 'variables');
+        const variables = req.body.variables;
         if (!Array.isArray(variables)) {
             return undefined;
         }
@@ -544,11 +597,11 @@ export const auditEnvironmentWebhookUrlsChanged = auditable<PatchWebhook>({
     target: (_req, locals) => makeTarget('environment', locals.environment?.id, locals.environment?.name),
     metadata: (req) => {
         const meta: { primaryUrl?: string; secondaryUrl?: string } = {};
-        const primaryUrl = safeUrl(bodyField(req, 'primary_url'));
+        const primaryUrl = safeUrl(req.body.primary_url);
         if (primaryUrl) {
             meta.primaryUrl = primaryUrl;
         }
-        const secondaryUrl = safeUrl(bodyField(req, 'secondary_url'));
+        const secondaryUrl = safeUrl(req.body.secondary_url);
         if (secondaryUrl) {
             meta.secondaryUrl = secondaryUrl;
         }
@@ -562,7 +615,7 @@ export const auditBillingPlanChanged = auditable<PostPlanChange>({
     scope: 'account',
     metadata: (req, locals) => {
         const meta: { fromPlan?: string; toPlan?: string } = {};
-        const orbId = bodyField(req, 'orbId');
+        const orbId = req.body.orbId;
         if (typeof orbId === 'string') {
             meta.toPlan = orbId;
         }

--- a/packages/server/lib/middleware/audit.middleware.ts
+++ b/packages/server/lib/middleware/audit.middleware.ts
@@ -76,6 +76,18 @@ function makeTarget(type: AuditTargetType, value: unknown, display?: string): Au
     return id ? { type, id, ...(display ? { display } : {}) } : undefined;
 }
 
+// Drop keys whose value is undefined, returning undefined when nothing is left. Callers map any
+// "absent" sentinel (empty string, non-string) to undefined themselves — compact only strips undefined.
+function compact(obj: Record<string, unknown>): Record<string, unknown> | undefined {
+    const out: Record<string, unknown> = {};
+    for (const [key, value] of Object.entries(obj)) {
+        if (value !== undefined) {
+            out[key] = value;
+        }
+    }
+    return Object.keys(out).length > 0 ? out : undefined;
+}
+
 function resolveActor(locals: RequestLocals): AuditActor {
     if (locals.authType === 'session' && locals.user) {
         return { type: 'user', id: String(locals.user.id), display: locals.user.email };
@@ -126,19 +138,10 @@ async function resolveDisplay(target: AuditTargetType, lookup: () => Promise<str
     }
 }
 
-async function emit(
-    spec: Omit<AuditEndpointPolicy, 'kind'>,
-    req: Request,
-    res: Response,
-    enabled: boolean,
-    resolved: ResolvedAudit | undefined
-): Promise<void> {
+async function emit(spec: Omit<AuditEndpointPolicy, 'kind'>, req: Request, res: Response, resolved: ResolvedAudit | undefined): Promise<void> {
     // Stamp occurredAt now so it reflects the response time, not audit-write latency.
     const occurredAt = new Date().toISOString();
     try {
-        if (!enabled) {
-            return;
-        }
         const locals = res.locals as RequestLocals;
         const { account, environment } = locals;
         if (!account) {
@@ -176,19 +179,19 @@ interface ResolvedAudit {
 // that never reach the controller.
 export function auditable<TEndpoint extends AuditableEndpoint>(spec: AuditSpec<TEndpoint>): RequestHandler {
     return (req, res, next) => {
-        // Resolve target and metadata before the handler runs — some handlers move or overwrite the
-        // pre-mutation state (a removed member, an old role) — then emit on finish. The audit-enabled
-        // flag is checked once here (not again in emit) so a single check drives both phases.
-        let enabled = false;
-        let resolved: ResolvedAudit | undefined;
-        res.on('finish', () => {
-            void emit(spec, req, res, enabled, resolved);
-        });
         void (async () => {
             try {
                 const locals = res.locals as RequestLocals;
                 if (locals.account && (await getFlags().isAuditTrailEnabled(locals.account.uuid))) {
-                    enabled = true;
+                    // Register the finish listener only once we know we should audit — a disabled account
+                    // never installs a dead listener. It reads `resolved` lazily at finish, so it captures
+                    // whatever we managed to resolve (even nothing, if resolution threw).
+                    let resolved: ResolvedAudit | undefined;
+                    res.on('finish', () => {
+                        void emit(spec, req, res, resolved);
+                    });
+                    // Resolve target and metadata before the handler runs — some handlers move or overwrite
+                    // the pre-mutation state (a removed member, an old role).
                     resolved = {
                         target: spec.target ? await spec.target(req, locals) : undefined,
                         metadata: spec.metadata ? await spec.metadata(req, locals) : undefined
@@ -225,35 +228,23 @@ function connectionTargets(paramId: unknown, bodyId: string | string[] | undefin
     return makeTarget('connection', paramId ?? bodyId);
 }
 function connectionUpdatedMeta(providerConfigKey: string | undefined, fields: string[] | undefined): Record<string, unknown> | undefined {
-    const meta: { providerConfigKey?: string; changedFields?: string[] } = {};
-    if (providerConfigKey && providerConfigKey.length > 0) {
-        meta.providerConfigKey = providerConfigKey;
-    }
-    if (fields) {
-        meta.changedFields = fields;
-    }
-    return Object.keys(meta).length > 0 ? meta : undefined;
+    return compact({
+        providerConfigKey: providerConfigKey && providerConfigKey.length > 0 ? providerConfigKey : undefined,
+        changedFields: fields
+    });
 }
 function syncFrequencyMeta(frequency: string | null | undefined, providerConfigKey: string | undefined): Record<string, unknown> | undefined {
-    const meta: { providerConfigKey?: string; frequency?: string } = {};
-    if (typeof frequency === 'string') {
-        meta.frequency = frequency;
-    }
-    if (typeof providerConfigKey === 'string') {
-        meta.providerConfigKey = providerConfigKey;
-    }
-    return Object.keys(meta).length > 0 ? meta : undefined;
+    return compact({
+        frequency: typeof frequency === 'string' ? frequency : undefined,
+        providerConfigKey: typeof providerConfigKey === 'string' ? providerConfigKey : undefined
+    });
 }
 function functionDeletedMeta(providerConfigKey: string | undefined, type: string | undefined): Record<string, unknown> | undefined {
-    const meta: { providerConfigKey?: string; type?: string } = {};
-    if (providerConfigKey && providerConfigKey.length > 0) {
-        meta.providerConfigKey = providerConfigKey;
-    }
-    // A sync and an action can share a name; `type` disambiguates which function was deleted.
-    if (type) {
-        meta.type = type;
-    }
-    return Object.keys(meta).length > 0 ? meta : undefined;
+    return compact({
+        providerConfigKey: providerConfigKey && providerConfigKey.length > 0 ? providerConfigKey : undefined,
+        // A sync and an action can share a name; `type` disambiguates which function was deleted.
+        type: type ? type : undefined
+    });
 }
 // Keep only the origin (scheme + host) of a URL — a webhook URL can carry a secret token in its path,
 // query string, or userinfo, and this goes into the immutable audit record.
@@ -280,52 +271,47 @@ function changedFields(req: Request<any, any, any, any>): string[] | undefined {
         .slice(0, CHANGED_FIELDS_MAX);
     return keys.length > 0 ? keys : undefined;
 }
-async function memberTarget(req: Request<{ id: number }>, locals: RequestLocals): Promise<AuditTarget | undefined> {
-    const id = toId(req.params.id);
+// Shared shape for targets whose display is looked up from the DB: normalize the id, bail if absent,
+// resolve the display best-effort (failures degrade to no display), and assemble the target. Each call
+// site supplies only its own lookup — the id is handed in already normalized.
+async function dbTarget(type: AuditTargetType, value: unknown, lookup: (id: string) => Promise<string | undefined>): Promise<AuditTarget | undefined> {
+    const id = toId(value);
     if (!id) {
         return undefined;
     }
-    const display = await resolveDisplay('member', async () => {
+    const display = await resolveDisplay(type, () => lookup(id));
+    return { type, id, ...(display ? { display } : {}) };
+}
+
+function memberTarget(req: Request<{ id: number }>, locals: RequestLocals): Promise<AuditTarget | undefined> {
+    return dbTarget('member', req.params.id, async (id) => {
         if (!locals.account) {
             return undefined;
         }
         const user = await userService.getUserByIdAndAccountId(Number(id), locals.account.id);
         return user?.email;
     });
-    return { type: 'member', id, ...(display ? { display } : {}) };
 }
 
-async function syncTarget(value: unknown, locals: RequestLocals): Promise<AuditTarget | undefined> {
-    const id = toId(value);
-    if (!id) {
-        return undefined;
-    }
-    const numericId = Number(id);
-    const display = Number.isNaN(numericId)
-        ? undefined
-        : await resolveDisplay('sync', async () => {
-              if (!locals.environment) {
-                  return undefined;
-              }
-              const syncConfig = await getSyncConfigById(locals.environment.id, numericId);
-              return syncConfig?.sync_name;
-          });
-    return { type: 'sync', id, ...(display ? { display } : {}) };
+function syncTarget(value: unknown, locals: RequestLocals): Promise<AuditTarget | undefined> {
+    return dbTarget('sync', value, async (id) => {
+        const numericId = Number(id);
+        if (Number.isNaN(numericId) || !locals.environment) {
+            return undefined;
+        }
+        const syncConfig = await getSyncConfigById(locals.environment.id, numericId);
+        return syncConfig?.sync_name;
+    });
 }
 
-async function apiKeyTarget(value: unknown, locals: RequestLocals): Promise<AuditTarget | undefined> {
-    const id = toId(value);
-    if (!id) {
-        return undefined;
-    }
-    const display = await resolveDisplay('api_key', async () => {
+function apiKeyTarget(value: unknown, locals: RequestLocals): Promise<AuditTarget | undefined> {
+    return dbTarget('api_key', value, async (id) => {
         if (!locals.environment) {
             return undefined;
         }
         const result = await customerKeyService.getApiKeysByEnv(db.knex, locals.environment.id);
         return result.isOk() ? result.value.find((key) => String(key.id) === id)?.display_name : undefined;
     });
-    return { type: 'api_key', id, ...(display ? { display } : {}) };
 }
 
 export const auditConnectionRefreshed = auditable<PostConnectionRefresh>({
@@ -439,18 +425,11 @@ export const auditApiKeyUpdated = auditable<PatchApiKey>({
     action: 'updated',
     scope: 'environment',
     target: (req, locals) => apiKeyTarget(req.params.keyId, locals),
-    metadata: (req) => {
-        const meta: { displayName?: string; scopes?: string[] } = {};
-        const displayName = req.body.display_name;
-        if (typeof displayName === 'string') {
-            meta.displayName = displayName;
-        }
-        const scopes = req.body.scopes;
-        if (Array.isArray(scopes)) {
-            meta.scopes = scopes.filter((s) => typeof s === 'string');
-        }
-        return Object.keys(meta).length > 0 ? meta : undefined;
-    }
+    metadata: (req) =>
+        compact({
+            displayName: typeof req.body.display_name === 'string' ? req.body.display_name : undefined,
+            scopes: Array.isArray(req.body.scopes) ? req.body.scopes.filter((s) => typeof s === 'string') : undefined
+        })
 });
 export const auditApiKeyDeleted = auditable<DeleteApiKey>({
     resource: 'api_key',
@@ -514,23 +493,20 @@ export const auditMemberRoleChanged = auditable<PatchTeamUser>({
     scope: 'account',
     target: memberTarget,
     metadata: async (req, locals) => {
-        const meta: { fromRole?: string; toRole?: string } = {};
         const role = req.body.role;
-        if (typeof role === 'string') {
-            meta.toRole = role;
-        }
+        let fromRole: string | undefined;
         const id = toId(req.params.id);
         if (id && locals.account) {
             const accountId = locals.account.id;
-            const fromRole = await resolveDisplay('member', async () => {
+            fromRole = await resolveDisplay('member', async () => {
                 const user = await userService.getUserByIdAndAccountId(Number(id), accountId);
                 return user?.role;
             });
-            if (fromRole) {
-                meta.fromRole = fromRole;
-            }
         }
-        return Object.keys(meta).length > 0 ? meta : undefined;
+        return compact({
+            toRole: typeof role === 'string' ? role : undefined,
+            fromRole: fromRole ? fromRole : undefined
+        });
     }
 });
 export const auditTeamUpdated = auditable<PutTeam>({
@@ -561,18 +537,11 @@ export const auditEnvironmentUpdated = auditable<PatchEnvironment>({
     action: 'updated',
     scope: 'environment',
     target: (_req, locals) => makeTarget('environment', locals.environment?.id, locals.environment?.name),
-    metadata: (req) => {
-        const meta: { name?: string; changedFields?: string[] } = {};
-        const name = req.body.name;
-        if (typeof name === 'string') {
-            meta.name = name;
-        }
-        const fields = changedFields(req);
-        if (fields) {
-            meta.changedFields = fields;
-        }
-        return Object.keys(meta).length > 0 ? meta : undefined;
-    }
+    metadata: (req) =>
+        compact({
+            name: typeof req.body.name === 'string' ? req.body.name : undefined,
+            changedFields: changedFields(req)
+        })
 });
 export const auditEnvironmentVariablesChanged = auditable<PostEnvironmentVariables>({
     resource: 'environment',
@@ -587,7 +556,7 @@ export const auditEnvironmentVariablesChanged = auditable<PostEnvironmentVariabl
         const variableNames = variables
             .map((v) => (v && typeof v === 'object' ? (v as Record<string, unknown>)['name'] : undefined))
             .filter((n): n is string => typeof n === 'string');
-        return { variableCount: variables.length, ...(variableNames.length > 0 ? { variableNames } : {}) };
+        return compact({ variableCount: variables.length, variableNames: variableNames.length > 0 ? variableNames : undefined });
     }
 });
 export const auditEnvironmentWebhookUrlsChanged = auditable<PatchWebhook>({
@@ -595,35 +564,22 @@ export const auditEnvironmentWebhookUrlsChanged = auditable<PatchWebhook>({
     action: 'webhook_urls_changed',
     scope: 'environment',
     target: (_req, locals) => makeTarget('environment', locals.environment?.id, locals.environment?.name),
-    metadata: (req) => {
-        const meta: { primaryUrl?: string; secondaryUrl?: string } = {};
-        const primaryUrl = safeUrl(req.body.primary_url);
-        if (primaryUrl) {
-            meta.primaryUrl = primaryUrl;
-        }
-        const secondaryUrl = safeUrl(req.body.secondary_url);
-        if (secondaryUrl) {
-            meta.secondaryUrl = secondaryUrl;
-        }
-        return Object.keys(meta).length > 0 ? meta : undefined;
-    }
+    metadata: (req) =>
+        compact({
+            primaryUrl: safeUrl(req.body.primary_url),
+            secondaryUrl: safeUrl(req.body.secondary_url)
+        })
 });
 
 export const auditBillingPlanChanged = auditable<PostPlanChange>({
     resource: 'billing',
     action: 'plan_changed',
     scope: 'account',
-    metadata: (req, locals) => {
-        const meta: { fromPlan?: string; toPlan?: string } = {};
-        const orbId = req.body.orbId;
-        if (typeof orbId === 'string') {
-            meta.toPlan = orbId;
-        }
-        if (locals.plan?.name) {
-            meta.fromPlan = locals.plan.name;
-        }
-        return Object.keys(meta).length > 0 ? meta : undefined;
-    }
+    metadata: (req, locals) =>
+        compact({
+            toPlan: typeof req.body.orbId === 'string' ? req.body.orbId : undefined,
+            fromPlan: locals.plan?.name || undefined
+        })
 });
 export const auditBillingTrialExtended = auditable<PostPlanExtendTrial>({ resource: 'billing', action: 'trial_extended', scope: 'account' });
 export const auditBillingDetailsChanged = auditable<PutBillingInvoicingDetails>({ resource: 'billing', action: 'details_changed', scope: 'account' });

--- a/packages/server/lib/middleware/audit.middleware.ts
+++ b/packages/server/lib/middleware/audit.middleware.ts
@@ -215,8 +215,8 @@ function bodyField(req: Request<any, any, any, any>, key: string): unknown {
 function providerConfigKeyMeta(value: unknown): { providerConfigKey: string } | undefined {
     return typeof value === 'string' && value.length > 0 ? { providerConfigKey: value } : undefined;
 }
-// Keep only origin + path from a URL — a webhook URL can carry a secret token in its query string or
-// userinfo, and this goes into the immutable audit record.
+// Keep only the origin (scheme + host) of a URL — a webhook URL can carry a secret token in its path,
+// query string, or userinfo, and this goes into the immutable audit record.
 function safeUrl(value: unknown): string | undefined {
     if (typeof value !== 'string' || value.length === 0) {
         return undefined;

--- a/packages/server/lib/middleware/audit.middleware.ts
+++ b/packages/server/lib/middleware/audit.middleware.ts
@@ -8,7 +8,10 @@ import { audit } from '../audit.js';
 import type { RequestLocals } from '../utils/express.js';
 import type { AuditActor, AuditContext, AuditEvent, AuditOutcome, AuditTarget, AuditTargetType } from '@nangohq/audit';
 import type {
-    AuditEndpointPolicy,
+    AuditAction,
+    AuditPolicy,
+    AuditResource,
+    AuditScope,
     DeleteApiKey,
     DeleteConnection,
     DeleteEnvironment,
@@ -51,12 +54,23 @@ const logger = getLogger('Audit');
 
 type AuditRequest<TEndpoint extends Endpoint<any>> = Request<TEndpoint['Params'], TEndpoint['Reply'], TEndpoint['Body'], TEndpoint['Querystring']>;
 
-type AuditableEndpoint = Endpoint<any> & { Audit: AuditEndpointPolicy };
+type AuditableEndpoint = Endpoint<any> & { Audit: AuditPolicy };
+
+// Build a concrete audit policy value inline at each spec. The resource/action/scope are captured as
+// literal types, so the value is checked against the endpoint's own `Audit: AuditPolicy<…>` declaration
+// (`policy: TEndpoint['Audit']`) — the wiring cannot disagree with the endpoint contract.
+const Audit = {
+    auditable: <R extends AuditResource, A extends AuditAction, S extends AuditScope>(policy: { resource: R; action: A; scope: S }): AuditPolicy<R, A, S> => ({
+        kind: 'audit',
+        ...policy
+    })
+};
 
 // The identity comes from the endpoint's own `Audit` declaration (so wiring can't disagree with it);
 // the spec only adds the runtime resolvers. Metadata is best-effort and loosely typed here — the
 // per-event shapes are documented on the emit model (@nangohq/audit's AuditEvent).
-export type AuditSpec<TEndpoint extends AuditableEndpoint> = Omit<TEndpoint['Audit'], 'kind'> & {
+type AuditSpec<TEndpoint extends AuditableEndpoint> = {
+    policy: TEndpoint['Audit'];
     target?: (
         req: AuditRequest<TEndpoint>,
         locals: RequestLocals
@@ -138,7 +152,7 @@ async function resolveDisplay(target: AuditTargetType, lookup: () => Promise<str
     }
 }
 
-async function emit(spec: Omit<AuditEndpointPolicy, 'kind'>, req: Request, res: Response, resolved: ResolvedAudit | undefined): Promise<void> {
+async function emit(policy: AuditPolicy, req: Request, res: Response, resolved: ResolvedAudit | undefined): Promise<void> {
     // Stamp occurredAt now so it reflects the response time, not audit-write latency.
     const occurredAt = new Date().toISOString();
     try {
@@ -152,10 +166,10 @@ async function emit(spec: Omit<AuditEndpointPolicy, 'kind'>, req: Request, res: 
         const event = {
             occurredAt,
             accountId: account.id,
-            environment: spec.scope === 'account' || !environment ? null : { id: environment.id, display: environment.name },
+            environment: policy.scope === 'account' || !environment ? null : { id: environment.id, display: environment.name },
             actor: resolveActor(locals),
-            resource: spec.resource,
-            action: spec.action,
+            resource: policy.resource,
+            action: policy.action,
             targets: Array.isArray(target) ? target : target ? [target] : [],
             context: contextFromRequest(req),
             outcome: outcomeFromStatus(res.statusCode),
@@ -188,7 +202,7 @@ export function auditable<TEndpoint extends AuditableEndpoint>(spec: AuditSpec<T
                     // whatever we managed to resolve (even nothing, if resolution threw).
                     let resolved: ResolvedAudit | undefined;
                     res.on('finish', () => {
-                        void emit(spec, req, res, resolved);
+                        void emit(spec.policy, req, res, resolved);
                     });
                     // Resolve target and metadata before the handler runs — some handlers move or overwrite
                     // the pre-mutation state (a removed member, an old role).
@@ -315,67 +329,49 @@ function apiKeyTarget(value: unknown, locals: RequestLocals): Promise<AuditTarge
 }
 
 export const auditConnectionRefreshed = auditable<PostConnectionRefresh>({
-    resource: 'connection',
-    action: 'refreshed',
-    scope: 'environment',
+    policy: Audit.auditable({ resource: 'connection', action: 'refreshed', scope: 'environment' }),
     target: (req) => makeTarget('connection', req.params.connectionId),
     metadata: (req) => providerConfigKeyMeta(req.query.provider_config_key)
 });
 export const auditConnectionUpdated = auditable<PatchConnection>({
-    resource: 'connection',
-    action: 'updated',
-    scope: 'environment',
+    policy: Audit.auditable({ resource: 'connection', action: 'updated', scope: 'environment' }),
     target: (req) => makeTarget('connection', req.params.connectionId),
     metadata: (req) => connectionUpdatedMeta(req.query.provider_config_key, changedFields(req))
 });
 export const auditPublicConnectionUpdated = auditable<PatchPublicConnection>({
-    resource: 'connection',
-    action: 'updated',
-    scope: 'environment',
+    policy: Audit.auditable({ resource: 'connection', action: 'updated', scope: 'environment' }),
     target: (req) => makeTarget('connection', req.params.connectionId),
     metadata: (req) => connectionUpdatedMeta(req.query.provider_config_key, changedFields(req))
 });
 export const auditConnectionMetadataUpdated = auditable<PostConnectionMetadata>({
-    resource: 'connection',
-    action: 'metadata_updated',
-    scope: 'environment',
+    policy: Audit.auditable({ resource: 'connection', action: 'metadata_updated', scope: 'environment' }),
     target: (req) => makeTarget('connection', req.params.connectionId),
     metadata: (req) => providerConfigKeyMeta(req.query.provider_config_key)
 });
 export const auditPublicConnectionMetadataSet = auditable<SetMetadata>({
-    resource: 'connection',
-    action: 'metadata_updated',
-    scope: 'environment',
+    policy: Audit.auditable({ resource: 'connection', action: 'metadata_updated', scope: 'environment' }),
     // The batch metadata endpoints accept connection_id as an array — record one target per connection.
     target: (req) => connectionTargets(param(req, 'connectionId'), req.body.connection_id),
     metadata: (req) => providerConfigKeyMeta(query(req, 'provider_config_key') ?? req.body.provider_config_key)
 });
 export const auditPublicConnectionMetadataUpdated = auditable<UpdateMetadata>({
-    resource: 'connection',
-    action: 'metadata_updated',
-    scope: 'environment',
+    policy: Audit.auditable({ resource: 'connection', action: 'metadata_updated', scope: 'environment' }),
     target: (req) => connectionTargets(param(req, 'connectionId'), req.body.connection_id),
     metadata: (req) => providerConfigKeyMeta(query(req, 'provider_config_key') ?? req.body.provider_config_key)
 });
 export const auditConnectionDeleted = auditable<DeleteConnection>({
-    resource: 'connection',
-    action: 'deleted',
-    scope: 'environment',
+    policy: Audit.auditable({ resource: 'connection', action: 'deleted', scope: 'environment' }),
     target: (req) => makeTarget('connection', req.params.connectionId),
     metadata: (req) => providerConfigKeyMeta(req.query.provider_config_key)
 });
 export const auditPublicConnectionDeleted = auditable<DeletePublicConnection>({
-    resource: 'connection',
-    action: 'deleted',
-    scope: 'environment',
+    policy: Audit.auditable({ resource: 'connection', action: 'deleted', scope: 'environment' }),
     target: (req) => makeTarget('connection', req.params.connectionId),
     metadata: (req) => providerConfigKeyMeta(req.query.provider_config_key)
 });
 
 export const auditIntegrationUpdated = auditable<PatchIntegration>({
-    resource: 'integration',
-    action: 'updated',
-    scope: 'environment',
+    policy: Audit.auditable({ resource: 'integration', action: 'updated', scope: 'environment' }),
     target: (req) => makeTarget('integration', req.params.providerConfigKey),
     metadata: (req) => {
         const fields = changedFields(req);
@@ -383,9 +379,7 @@ export const auditIntegrationUpdated = auditable<PatchIntegration>({
     }
 });
 export const auditPublicIntegrationUpdated = auditable<PatchPublicIntegration>({
-    resource: 'integration',
-    action: 'updated',
-    scope: 'environment',
+    policy: Audit.auditable({ resource: 'integration', action: 'updated', scope: 'environment' }),
     target: (req) => makeTarget('integration', req.params.uniqueKey),
     metadata: (req) => {
         const fields = changedFields(req);
@@ -393,37 +387,27 @@ export const auditPublicIntegrationUpdated = auditable<PatchPublicIntegration>({
     }
 });
 export const auditIntegrationDeleted = auditable<DeleteIntegration>({
-    resource: 'integration',
-    action: 'deleted',
-    scope: 'environment',
+    policy: Audit.auditable({ resource: 'integration', action: 'deleted', scope: 'environment' }),
     target: (req) => makeTarget('integration', req.params.providerConfigKey)
 });
 export const auditPublicIntegrationDeleted = auditable<DeletePublicIntegration>({
-    resource: 'integration',
-    action: 'deleted',
-    scope: 'environment',
+    policy: Audit.auditable({ resource: 'integration', action: 'deleted', scope: 'environment' }),
     target: (req) => makeTarget('integration', req.params.uniqueKey)
 });
 
 export const auditFunctionDeleted = auditable<DeleteIntegrationFunction>({
-    resource: 'function',
-    action: 'deleted',
-    scope: 'environment',
+    policy: Audit.auditable({ resource: 'function', action: 'deleted', scope: 'environment' }),
     target: (req) => makeTarget('function', req.params.functionName),
     metadata: (req) => functionDeletedMeta(req.params.providerConfigKey, req.query.type)
 });
 export const auditPublicFunctionDeleted = auditable<DeletePublicIntegrationFunction>({
-    resource: 'function',
-    action: 'deleted',
-    scope: 'environment',
+    policy: Audit.auditable({ resource: 'function', action: 'deleted', scope: 'environment' }),
     target: (req) => makeTarget('function', req.params.name),
     metadata: (req) => functionDeletedMeta(req.params.uniqueKey, req.query.type)
 });
 
 export const auditApiKeyUpdated = auditable<PatchApiKey>({
-    resource: 'api_key',
-    action: 'updated',
-    scope: 'environment',
+    policy: Audit.auditable({ resource: 'api_key', action: 'updated', scope: 'environment' }),
     target: (req, locals) => apiKeyTarget(req.params.keyId, locals),
     metadata: (req) =>
         compact({
@@ -432,65 +416,47 @@ export const auditApiKeyUpdated = auditable<PatchApiKey>({
         })
 });
 export const auditApiKeyDeleted = auditable<DeleteApiKey>({
-    resource: 'api_key',
-    action: 'deleted',
-    scope: 'environment',
+    policy: Audit.auditable({ resource: 'api_key', action: 'deleted', scope: 'environment' }),
     target: (req, locals) => apiKeyTarget(req.params.keyId, locals)
 });
 
 export const auditSyncEnabled = auditable<PatchFlowEnable>({
-    resource: 'sync',
-    action: 'enabled',
-    scope: 'environment',
+    policy: Audit.auditable({ resource: 'sync', action: 'enabled', scope: 'environment' }),
     target: (req, locals) => syncTarget(req.params.id, locals)
 });
 export const auditSyncDisabled = auditable<PatchFlowDisable>({
-    resource: 'sync',
-    action: 'disabled',
-    scope: 'environment',
+    policy: Audit.auditable({ resource: 'sync', action: 'disabled', scope: 'environment' }),
     target: (req, locals) => syncTarget(req.params.id, locals)
 });
 export const auditSyncFrequencyChanged = auditable<PatchFlowFrequency>({
-    resource: 'sync',
-    action: 'frequency_changed',
-    scope: 'environment',
+    policy: Audit.auditable({ resource: 'sync', action: 'frequency_changed', scope: 'environment' }),
     target: (req, locals) => syncTarget(req.params.id, locals),
     // Private route sends camelCase `providerConfigKey`.
     metadata: (req) => syncFrequencyMeta(req.body.frequency, req.body.providerConfigKey)
 });
 export const auditPublicSyncFrequencyChanged = auditable<PutPublicSyncConnectionFrequency>({
-    resource: 'sync',
-    action: 'frequency_changed',
-    scope: 'environment',
+    policy: Audit.auditable({ resource: 'sync', action: 'frequency_changed', scope: 'environment' }),
     target: (req, locals) => syncTarget(req.body.sync_name, locals),
     // Public route sends snake_case `provider_config_key`.
     metadata: (req) => syncFrequencyMeta(req.body.frequency, req.body.provider_config_key)
 });
 export const auditSyncVariantCreated = auditable<PostSyncVariant>({
-    resource: 'sync',
-    action: 'variant_created',
-    scope: 'environment',
+    policy: Audit.auditable({ resource: 'sync', action: 'variant_created', scope: 'environment' }),
     target: (req) => makeTarget('sync', req.params.name),
     metadata: (req) => ({ variant: req.params.variant })
 });
 export const auditSyncVariantDeleted = auditable<DeleteSyncVariant>({
-    resource: 'sync',
-    action: 'variant_deleted',
-    scope: 'environment',
+    policy: Audit.auditable({ resource: 'sync', action: 'variant_deleted', scope: 'environment' }),
     target: (req) => makeTarget('sync', req.params.name),
     metadata: (req) => ({ variant: req.params.variant })
 });
 
 export const auditMemberRemoved = auditable<DeleteTeamUser>({
-    resource: 'member',
-    action: 'removed',
-    scope: 'account',
+    policy: Audit.auditable({ resource: 'member', action: 'removed', scope: 'account' }),
     target: memberTarget
 });
 export const auditMemberRoleChanged = auditable<PatchTeamUser>({
-    resource: 'member',
-    action: 'role_changed',
-    scope: 'account',
+    policy: Audit.auditable({ resource: 'member', action: 'role_changed', scope: 'account' }),
     target: memberTarget,
     metadata: async (req, locals) => {
         const role = req.body.role;
@@ -510,9 +476,7 @@ export const auditMemberRoleChanged = auditable<PatchTeamUser>({
     }
 });
 export const auditTeamUpdated = auditable<PutTeam>({
-    resource: 'team',
-    action: 'updated',
-    scope: 'account',
+    policy: Audit.auditable({ resource: 'team', action: 'updated', scope: 'account' }),
     target: (_req, locals) => makeTarget('team', locals.account?.id, locals.account?.name),
     metadata: (req) => {
         const name = req.body.name;
@@ -520,22 +484,16 @@ export const auditTeamUpdated = auditable<PutTeam>({
     }
 });
 export const auditUserUpdated = auditable<PatchUser>({
-    resource: 'user',
-    action: 'updated',
-    scope: 'account',
+    policy: Audit.auditable({ resource: 'user', action: 'updated', scope: 'account' }),
     target: (_req, locals) => makeTarget('user', locals.user?.id, locals.user?.email)
 });
 
 export const auditEnvironmentDeleted = auditable<DeleteEnvironment>({
-    resource: 'environment',
-    action: 'deleted',
-    scope: 'environment',
+    policy: Audit.auditable({ resource: 'environment', action: 'deleted', scope: 'environment' }),
     target: (_req, locals) => makeTarget('environment', locals.environment?.id, locals.environment?.name)
 });
 export const auditEnvironmentUpdated = auditable<PatchEnvironment>({
-    resource: 'environment',
-    action: 'updated',
-    scope: 'environment',
+    policy: Audit.auditable({ resource: 'environment', action: 'updated', scope: 'environment' }),
     target: (_req, locals) => makeTarget('environment', locals.environment?.id, locals.environment?.name),
     metadata: (req) =>
         compact({
@@ -544,9 +502,7 @@ export const auditEnvironmentUpdated = auditable<PatchEnvironment>({
         })
 });
 export const auditEnvironmentVariablesChanged = auditable<PostEnvironmentVariables>({
-    resource: 'environment',
-    action: 'variables_changed',
-    scope: 'environment',
+    policy: Audit.auditable({ resource: 'environment', action: 'variables_changed', scope: 'environment' }),
     target: (_req, locals) => makeTarget('environment', locals.environment?.id, locals.environment?.name),
     metadata: (req) => {
         const variables = req.body.variables;
@@ -560,9 +516,7 @@ export const auditEnvironmentVariablesChanged = auditable<PostEnvironmentVariabl
     }
 });
 export const auditEnvironmentWebhookUrlsChanged = auditable<PatchWebhook>({
-    resource: 'environment',
-    action: 'webhook_urls_changed',
-    scope: 'environment',
+    policy: Audit.auditable({ resource: 'environment', action: 'webhook_urls_changed', scope: 'environment' }),
     target: (_req, locals) => makeTarget('environment', locals.environment?.id, locals.environment?.name),
     metadata: (req) =>
         compact({
@@ -572,21 +526,21 @@ export const auditEnvironmentWebhookUrlsChanged = auditable<PatchWebhook>({
 });
 
 export const auditBillingPlanChanged = auditable<PostPlanChange>({
-    resource: 'billing',
-    action: 'plan_changed',
-    scope: 'account',
+    policy: Audit.auditable({ resource: 'billing', action: 'plan_changed', scope: 'account' }),
     metadata: (req, locals) =>
         compact({
             toPlan: typeof req.body.orbId === 'string' ? req.body.orbId : undefined,
             fromPlan: locals.plan?.name || undefined
         })
 });
-export const auditBillingTrialExtended = auditable<PostPlanExtendTrial>({ resource: 'billing', action: 'trial_extended', scope: 'account' });
-export const auditBillingDetailsChanged = auditable<PutBillingInvoicingDetails>({ resource: 'billing', action: 'details_changed', scope: 'account' });
+export const auditBillingTrialExtended = auditable<PostPlanExtendTrial>({
+    policy: Audit.auditable({ resource: 'billing', action: 'trial_extended', scope: 'account' })
+});
+export const auditBillingDetailsChanged = auditable<PutBillingInvoicingDetails>({
+    policy: Audit.auditable({ resource: 'billing', action: 'details_changed', scope: 'account' })
+});
 
 export const auditAppAuthPasswordChanged = auditable<PutUserPassword>({
-    resource: 'app_auth',
-    action: 'password_changed',
-    scope: 'account',
+    policy: Audit.auditable({ resource: 'app_auth', action: 'password_changed', scope: 'account' }),
     target: (_req, locals) => makeTarget('user', locals.user?.id, locals.user?.email)
 });

--- a/packages/server/lib/middleware/audit.middleware.ts
+++ b/packages/server/lib/middleware/audit.middleware.ts
@@ -56,9 +56,6 @@ type AuditRequest<TEndpoint extends Endpoint<any>> = Request<TEndpoint['Params']
 
 type AuditableEndpoint = Endpoint<any> & { Audit: AuditPolicy };
 
-// Build a concrete audit policy value inline at each spec. The resource/action/scope are captured as
-// literal types, so the value is checked against the endpoint's own `Audit: AuditPolicy<…>` declaration
-// (`policy: TEndpoint['Audit']`) — the wiring cannot disagree with the endpoint contract.
 const Audit = {
     auditable: <R extends AuditResource, A extends AuditAction, S extends AuditScope>(policy: { resource: R; action: A; scope: S }): AuditPolicy<R, A, S> => ({
         kind: 'audit',
@@ -66,9 +63,7 @@ const Audit = {
     })
 };
 
-// The identity comes from the endpoint's own `Audit` declaration (so wiring can't disagree with it);
-// the spec only adds the runtime resolvers. Metadata is best-effort and loosely typed here — the
-// per-event shapes are documented on the emit model (@nangohq/audit's AuditEvent).
+// Metadata is loosely typed here; per-event shapes live on the emit model (@nangohq/audit's AuditEvent).
 type AuditSpec<TEndpoint extends AuditableEndpoint> = {
     policy: TEndpoint['Audit'];
     target?: (
@@ -90,9 +85,7 @@ function makeTarget(type: AuditTargetType, value: unknown, display?: string): Au
     return id ? { type, id, ...(display ? { display } : {}) } : undefined;
 }
 
-// Drop keys whose value is undefined, returning undefined when nothing is left. Callers map any
-// "absent" sentinel (empty string, non-string) to undefined themselves — compact only strips undefined.
-function compact(obj: Record<string, unknown>): Record<string, unknown> | undefined {
+function omitUndefined(obj: Record<string, unknown>): Record<string, unknown> | undefined {
     const out: Record<string, unknown> = {};
     for (const [key, value] of Object.entries(obj)) {
         if (value !== undefined) {
@@ -242,19 +235,19 @@ function connectionTargets(paramId: unknown, bodyId: string | string[] | undefin
     return makeTarget('connection', paramId ?? bodyId);
 }
 function connectionUpdatedMeta(providerConfigKey: string | undefined, fields: string[] | undefined): Record<string, unknown> | undefined {
-    return compact({
+    return omitUndefined({
         providerConfigKey: providerConfigKey && providerConfigKey.length > 0 ? providerConfigKey : undefined,
         changedFields: fields
     });
 }
 function syncFrequencyMeta(frequency: string | null | undefined, providerConfigKey: string | undefined): Record<string, unknown> | undefined {
-    return compact({
+    return omitUndefined({
         frequency: typeof frequency === 'string' ? frequency : undefined,
         providerConfigKey: typeof providerConfigKey === 'string' ? providerConfigKey : undefined
     });
 }
 function functionDeletedMeta(providerConfigKey: string | undefined, type: string | undefined): Record<string, unknown> | undefined {
-    return compact({
+    return omitUndefined({
         providerConfigKey: providerConfigKey && providerConfigKey.length > 0 ? providerConfigKey : undefined,
         // A sync and an action can share a name; `type` disambiguates which function was deleted.
         type: type ? type : undefined
@@ -285,9 +278,7 @@ function changedFields(req: Request<any, any, any, any>): string[] | undefined {
         .slice(0, CHANGED_FIELDS_MAX);
     return keys.length > 0 ? keys : undefined;
 }
-// Shared shape for targets whose display is looked up from the DB: normalize the id, bail if absent,
-// resolve the display best-effort (failures degrade to no display), and assemble the target. Each call
-// site supplies only its own lookup — the id is handed in already normalized.
+// Target whose display is looked up from the DB best-effort; failures degrade to no display.
 async function dbTarget(type: AuditTargetType, value: unknown, lookup: (id: string) => Promise<string | undefined>): Promise<AuditTarget | undefined> {
     const id = toId(value);
     if (!id) {
@@ -350,7 +341,6 @@ export const auditConnectionMetadataUpdated = auditable<PostConnectionMetadata>(
 });
 export const auditPublicConnectionMetadataSet = auditable<SetMetadata>({
     policy: Audit.auditable({ resource: 'connection', action: 'metadata_updated', scope: 'environment' }),
-    // The batch metadata endpoints accept connection_id as an array — record one target per connection.
     target: (req) => connectionTargets(param(req, 'connectionId'), req.body.connection_id),
     metadata: (req) => providerConfigKeyMeta(query(req, 'provider_config_key') ?? req.body.provider_config_key)
 });
@@ -410,7 +400,7 @@ export const auditApiKeyUpdated = auditable<PatchApiKey>({
     policy: Audit.auditable({ resource: 'api_key', action: 'updated', scope: 'environment' }),
     target: (req, locals) => apiKeyTarget(req.params.keyId, locals),
     metadata: (req) =>
-        compact({
+        omitUndefined({
             displayName: typeof req.body.display_name === 'string' ? req.body.display_name : undefined,
             scopes: Array.isArray(req.body.scopes) ? req.body.scopes.filter((s) => typeof s === 'string') : undefined
         })
@@ -469,7 +459,7 @@ export const auditMemberRoleChanged = auditable<PatchTeamUser>({
                 return user?.role;
             });
         }
-        return compact({
+        return omitUndefined({
             toRole: typeof role === 'string' ? role : undefined,
             fromRole: fromRole ? fromRole : undefined
         });
@@ -496,7 +486,7 @@ export const auditEnvironmentUpdated = auditable<PatchEnvironment>({
     policy: Audit.auditable({ resource: 'environment', action: 'updated', scope: 'environment' }),
     target: (_req, locals) => makeTarget('environment', locals.environment?.id, locals.environment?.name),
     metadata: (req) =>
-        compact({
+        omitUndefined({
             name: typeof req.body.name === 'string' ? req.body.name : undefined,
             changedFields: changedFields(req)
         })
@@ -512,14 +502,14 @@ export const auditEnvironmentVariablesChanged = auditable<PostEnvironmentVariabl
         const variableNames = variables
             .map((v) => (v && typeof v === 'object' ? (v as Record<string, unknown>)['name'] : undefined))
             .filter((n): n is string => typeof n === 'string');
-        return compact({ variableCount: variables.length, variableNames: variableNames.length > 0 ? variableNames : undefined });
+        return omitUndefined({ variableCount: variables.length, variableNames: variableNames.length > 0 ? variableNames : undefined });
     }
 });
 export const auditEnvironmentWebhookUrlsChanged = auditable<PatchWebhook>({
     policy: Audit.auditable({ resource: 'environment', action: 'webhook_urls_changed', scope: 'environment' }),
     target: (_req, locals) => makeTarget('environment', locals.environment?.id, locals.environment?.name),
     metadata: (req) =>
-        compact({
+        omitUndefined({
             primaryUrl: safeUrl(req.body.primary_url),
             secondaryUrl: safeUrl(req.body.secondary_url)
         })
@@ -528,7 +518,7 @@ export const auditEnvironmentWebhookUrlsChanged = auditable<PatchWebhook>({
 export const auditBillingPlanChanged = auditable<PostPlanChange>({
     policy: Audit.auditable({ resource: 'billing', action: 'plan_changed', scope: 'account' }),
     metadata: (req, locals) =>
-        compact({
+        omitUndefined({
             toPlan: typeof req.body.orbId === 'string' ? req.body.orbId : undefined,
             fromPlan: locals.plan?.name || undefined
         })

--- a/packages/server/lib/middleware/audit.private.integration.test.ts
+++ b/packages/server/lib/middleware/audit.private.integration.test.ts
@@ -67,10 +67,12 @@ describe('audit middleware (private API)', () => {
         });
     });
 
-    it('audit log for a member role change', async () => {
+    it('audit log for a member role change captures the pre-change role', async () => {
         const { account, user, plan } = await seeders.seedAccountEnvAndUser();
         await updatePlan(db.knex, { id: plan.id, has_rbac: true });
         const targetUser = await seeders.seedUser(account.id);
+        // Pin a known starting role; the controller overwrites it, so fromRole proves we resolved before it ran.
+        await userService.update({ id: targetUser.id, role: 'development_full_access' });
         const session = await authenticateUser(api, user);
 
         const res = await api.fetch('/api/v1/team/users/:id', {
@@ -93,7 +95,7 @@ describe('audit middleware (private API)', () => {
             environment: null,
             actor: { type: 'user', id: String(user.id), display: user.email },
             targets: [{ type: 'member', id: String(targetUser.id), display: targetUser.email }],
-            metadata: { toRole: 'production_support' }
+            metadata: { fromRole: 'development_full_access', toRole: 'production_support' }
         });
     });
 
@@ -153,5 +155,117 @@ describe('audit middleware (private API)', () => {
             targets: [{ type: 'member', id: String(other.user.id) }]
         });
         expect(event?.targets[0]).not.toHaveProperty('display');
+    });
+
+    it('records the changed field names (not values) for a connection update', async () => {
+        const { user, connection } = await seedConnection();
+        const session = await authenticateUser(api, user);
+
+        const res = await api.fetch('/api/v1/connections/:connectionId', {
+            method: 'PATCH',
+            session,
+            params: { connectionId: connection.connection_id },
+            query: { provider_config_key: 'algolia', env: 'dev' },
+            body: { webhook_url_override: 'https://leaked-value.test/hook' }
+        });
+
+        expect(res.res.status).toBe(200);
+        await vi.waitFor(() => {
+            expect(auditSpy).toHaveBeenCalled();
+        });
+        const event = auditSpy.mock.calls[0]?.[0];
+        expect(event).toMatchObject({
+            resource: 'connection',
+            action: 'updated',
+            outcome: 'success',
+            metadata: { providerConfigKey: 'algolia', changedFields: ['webhook_url_override'] }
+        });
+        // Only the field name is recorded — the submitted value must not reach the audit record.
+        expect(JSON.stringify(event)).not.toContain('leaked-value');
+    });
+
+    it('records variable names but never their values', async () => {
+        const { user } = await seeders.seedAccountEnvAndUser();
+        const session = await authenticateUser(api, user);
+
+        const res = await api.fetch('/api/v1/environments/variables', {
+            method: 'POST',
+            session,
+            query: { env: 'dev' },
+            body: {
+                variables: [
+                    { name: 'API_URL', value: 'https://secret.example' },
+                    { name: 'TOKEN', value: 'super-secret-value' }
+                ]
+            }
+        });
+
+        expect(res.res.status).toBe(200);
+        await vi.waitFor(() => {
+            expect(auditSpy).toHaveBeenCalled();
+        });
+        const event = auditSpy.mock.calls[0]?.[0];
+        expect(event).toMatchObject({
+            resource: 'environment',
+            action: 'variables_changed',
+            metadata: { variableCount: 2, variableNames: ['API_URL', 'TOKEN'] }
+        });
+        // The values must never reach the audit record.
+        const serialized = JSON.stringify(event);
+        expect(serialized).not.toContain('super-secret-value');
+        expect(serialized).not.toContain('secret.example');
+    });
+
+    it('records the new webhook URLs for a webhook settings change', async () => {
+        const { user } = await seeders.seedAccountEnvAndUser();
+        const session = await authenticateUser(api, user);
+
+        const res = await api.fetch('/api/v1/environments/webhook', {
+            method: 'PATCH',
+            session,
+            query: { env: 'dev' },
+            body: { primary_url: 'https://hooks.example/primary?token=shh-secret' }
+        });
+
+        expect(res.res.status).toBe(200);
+        await vi.waitFor(() => {
+            expect(auditSpy).toHaveBeenCalled();
+        });
+        const event = auditSpy.mock.calls[0]?.[0];
+        expect(event).toMatchObject({
+            resource: 'environment',
+            action: 'webhook_urls_changed',
+            // Only the origin is recorded — path and any secret query params are stripped.
+            metadata: { primaryUrl: 'https://hooks.example' }
+        });
+        expect(JSON.stringify(event)).not.toContain('shh-secret');
+    });
+
+    it('captures a removed member email resolved before the controller moves the row', async () => {
+        const { account, user, plan } = await seeders.seedAccountEnvAndUser();
+        await updatePlan(db.knex, { id: plan.id, has_rbac: true });
+        const targetUser = await seeders.seedUser(account.id);
+        const session = await authenticateUser(api, user);
+
+        const res = await api.fetch('/api/v1/team/users/:id', {
+            method: 'DELETE',
+            session,
+            query: { env: 'dev' },
+            params: { id: targetUser.id }
+        });
+
+        expect(res.res.status).toBe(200);
+        isSuccess(res.json);
+        await vi.waitFor(() => {
+            expect(auditSpy).toHaveBeenCalled();
+        });
+        // The controller moves the member out of the account, so the email is only knowable if the
+        // target was resolved before the handler ran — this guards the resolve-before-next() timing.
+        expect(auditSpy.mock.calls[0]?.[0]).toMatchObject({
+            resource: 'member',
+            action: 'removed',
+            outcome: 'success',
+            targets: [{ type: 'member', id: String(targetUser.id), display: targetUser.email }]
+        });
     });
 });

--- a/packages/server/lib/routes.private.ts
+++ b/packages/server/lib/routes.private.ts
@@ -120,7 +120,32 @@ import { getUser } from './controllers/v1/user/getUser.js';
 import { putUserPassword } from './controllers/v1/user/password/putPassword.js';
 import { patchUser } from './controllers/v1/user/patchUser.js';
 import authMiddleware from './middleware/access.middleware.js';
-import { auditConnectionDeleted, auditMemberRoleChanged } from './middleware/audit.middleware.js';
+import {
+    auditApiKeyDeleted,
+    auditApiKeyUpdated,
+    auditAppAuthPasswordChanged,
+    auditBillingDetailsChanged,
+    auditBillingPlanChanged,
+    auditBillingTrialExtended,
+    auditConnectionDeleted,
+    auditConnectionMetadataUpdated,
+    auditConnectionRefreshed,
+    auditConnectionUpdated,
+    auditEnvironmentDeleted,
+    auditEnvironmentUpdated,
+    auditEnvironmentVariablesChanged,
+    auditEnvironmentWebhookUrlsChanged,
+    auditFunctionDeleted,
+    auditIntegrationDeleted,
+    auditIntegrationUpdated,
+    auditMemberRemoved,
+    auditMemberRoleChanged,
+    auditSyncDisabled,
+    auditSyncEnabled,
+    auditSyncFrequencyChanged,
+    auditTeamUpdated,
+    auditUserUpdated
+} from './middleware/audit.middleware.js';
 import { authenticateLocalSignin } from './middleware/authenticateLocalSignin.middleware.js';
 import { jsonContentTypeMiddleware } from './middleware/json.middleware.js';
 import { rateLimiterMiddleware } from './middleware/ratelimit.middleware.js';
@@ -205,8 +230,8 @@ web.route('/account/mfa/login/verify').post(rateLimiterMiddleware, postMFALoginV
 
 // Team
 web.route('/team').get(webAuth, getTeam);
-web.route('/team').put(webAuth, can(p.canManageTeam), putTeam);
-web.route('/team/users/:id').delete(webAuth, can(p.canRemoveTeamMember), deleteTeamUser);
+web.route('/team').put(webAuth, auditTeamUpdated, can(p.canManageTeam), putTeam);
+web.route('/team/users/:id').delete(webAuth, auditMemberRemoved, can(p.canRemoveTeamMember), deleteTeamUser);
 web.route('/team/users/:id').patch(webAuth, auditMemberRoleChanged, can(p.canUpdateTeamMember), patchTeamUser);
 
 // Invitations
@@ -219,27 +244,47 @@ web.route('/invite/:id').delete(webAuth, declineInvite);
 // Plans
 web.route('/plans').get(webAuth, getPlans);
 web.route('/plans/current').get(webAuth, getCurrentPlan);
-web.route('/plans/trial/extension').post(webAuth, can(p.canChangePlan), postPlanExtendTrial);
+web.route('/plans/trial/extension').post(webAuth, auditBillingTrialExtended, can(p.canChangePlan), postPlanExtendTrial);
 web.route('/plans/usage').get(webAuth, getUsage);
 web.route('/plans/billing-usage').get(webAuth, getBillingUsage);
 web.route('/plans/billing-usage/top-dimension-values').get(webAuth, getBillingUsageTopDimensionValues);
-web.route('/plans/billing/invoicing').put(webAuth, can(p.canChangePlan), putInvoicingDetails);
-web.route('/plans/change').post(webAuth, can(p.canChangePlan), postPlanChange);
+web.route('/plans/billing/invoicing').put(webAuth, auditBillingDetailsChanged, can(p.canChangePlan), putInvoicingDetails);
+web.route('/plans/change').post(webAuth, auditBillingPlanChanged, can(p.canChangePlan), postPlanChange);
 
 // Environments
 web.route('/environments').get(webAuth, getEnvironments);
 web.route('/environments').post(webAuth, can(p.canCreateEnvironment), postEnvironment);
-web.route('/environments/').patch(webAuth, can({ action: 'update', resource: 'environment', scopedBy: envScope }), patchEnvironment);
-web.route('/environments/').delete(webAuth, can({ action: 'delete', resource: 'environment', scopedBy: envScope }), deleteEnvironment);
+web.route('/environments/').patch(webAuth, auditEnvironmentUpdated, can({ action: 'update', resource: 'environment', scopedBy: envScope }), patchEnvironment);
+web.route('/environments/').delete(webAuth, auditEnvironmentDeleted, can({ action: 'delete', resource: 'environment', scopedBy: envScope }), deleteEnvironment);
 web.route('/environments/current').get(webAuth, can({ action: 'read', resource: 'environment', scopedBy: envScope }), getEnvironment);
-web.route('/environments/webhook').patch(webAuth, can({ action: 'update', resource: 'webhook', scopedBy: envScope }), patchWebhook);
-web.route('/environments/variables').post(webAuth, can({ action: 'update', resource: 'environment_variable', scopedBy: envScope }), postEnvironmentVariables);
+web.route('/environments/webhook').patch(
+    webAuth,
+    auditEnvironmentWebhookUrlsChanged,
+    can({ action: 'update', resource: 'webhook', scopedBy: envScope }),
+    patchWebhook
+);
+web.route('/environments/variables').post(
+    webAuth,
+    auditEnvironmentVariablesChanged,
+    can({ action: 'update', resource: 'environment_variable', scopedBy: envScope }),
+    postEnvironmentVariables
+);
 
 // API Key management
 web.route('/environment/api-keys').get(webAuth, can({ action: 'read', resource: 'environment_key', scopedBy: envScope }), listApiKeys);
 web.route('/environment/api-keys').post(webAuth, can({ action: 'update', resource: 'environment_key', scopedBy: envScope }), createApiKey);
-web.route('/environment/api-keys/:keyId').patch(webAuth, can({ action: 'update', resource: 'environment_key', scopedBy: envScope }), patchApiKey);
-web.route('/environment/api-keys/:keyId').delete(webAuth, can({ action: 'update', resource: 'environment_key', scopedBy: envScope }), deleteApiKey);
+web.route('/environment/api-keys/:keyId').patch(
+    webAuth,
+    auditApiKeyUpdated,
+    can({ action: 'update', resource: 'environment_key', scopedBy: envScope }),
+    patchApiKey
+);
+web.route('/environment/api-keys/:keyId').delete(
+    webAuth,
+    auditApiKeyDeleted,
+    can({ action: 'update', resource: 'environment_key', scopedBy: envScope }),
+    deleteApiKey
+);
 
 web.route('/environment/hmac').get(webAuth, environmentController.getHmacDigest.bind(environmentController));
 web.route('/environment/admin-auth').get(
@@ -259,13 +304,23 @@ web.route('/connect-ui-settings').put(webAuth, can(p.canManageConnectUI), putCon
 web.route('/integrations').get(webAuth, can({ action: 'read', resource: 'integration', scopedBy: envScope }), getIntegrations);
 web.route('/integrations').post(webAuth, can({ action: 'update', resource: 'integration', scopedBy: envScope }), postIntegration);
 web.route('/integrations/:providerConfigKey').get(webAuth, can({ action: 'read', resource: 'integration', scopedBy: envScope }), getIntegration);
-web.route('/integrations/:providerConfigKey').patch(webAuth, can({ action: 'update', resource: 'integration', scopedBy: envScope }), patchIntegration);
-web.route('/integrations/:providerConfigKey').delete(webAuth, can({ action: 'delete', resource: 'integration', scopedBy: envScope }), deleteIntegration);
+web.route('/integrations/:providerConfigKey').patch(
+    webAuth,
+    auditIntegrationUpdated,
+    can({ action: 'update', resource: 'integration', scopedBy: envScope }),
+    patchIntegration
+);
+web.route('/integrations/:providerConfigKey').delete(
+    webAuth,
+    auditIntegrationDeleted,
+    can({ action: 'delete', resource: 'integration', scopedBy: envScope }),
+    deleteIntegration
+);
 web.route('/integrations/:providerConfigKey/flows').get(webAuth, can({ action: 'read', resource: 'flow', scopedBy: envScope }), getIntegrationFlows);
 web.route('/integrations/:providerConfigKey/functions').get(webAuth, can({ action: 'read', resource: 'flow', scopedBy: envScope }), getIntegrationFunctions);
 web.route('/integrations/:providerConfigKey/functions/:functionName')
     .get(webAuth, can({ action: 'read', resource: 'flow', scopedBy: envScope }), getIntegrationFunction)
-    .delete(webAuth, can({ action: 'delete', resource: 'flow', scopedBy: envScope }), deleteIntegrationFunction);
+    .delete(webAuth, auditFunctionDeleted, can({ action: 'delete', resource: 'flow', scopedBy: envScope }), deleteIntegrationFunction);
 web.route('/integrations/:providerConfigKey/functions/:functionName/code').get(
     webAuth,
     can({ action: 'read', resource: 'flow', scopedBy: envScope }),
@@ -288,9 +343,24 @@ web.route('/connections/:connectionId/records/models').get(
     getConnectionRecordModels
 );
 web.route('/connections/:connectionId/records').get(webAuth, can({ action: 'read', resource: 'connection', scopedBy: envScope }), getConnectionRecords);
-web.route('/connections/:connectionId/refresh').post(webAuth, can({ action: 'update', resource: 'connection', scopedBy: envScope }), getConnectionRefresh);
-web.route('/connections/:connectionId/metadata').post(webAuth, can({ action: 'update', resource: 'connection', scopedBy: envScope }), postConnectionMetadata);
-web.route('/connections/:connectionId').patch(webAuth, can({ action: 'update', resource: 'connection', scopedBy: envScope }), patchConnection);
+web.route('/connections/:connectionId/refresh').post(
+    webAuth,
+    auditConnectionRefreshed,
+    can({ action: 'update', resource: 'connection', scopedBy: envScope }),
+    getConnectionRefresh
+);
+web.route('/connections/:connectionId/metadata').post(
+    webAuth,
+    auditConnectionMetadataUpdated,
+    can({ action: 'update', resource: 'connection', scopedBy: envScope }),
+    postConnectionMetadata
+);
+web.route('/connections/:connectionId').patch(
+    webAuth,
+    auditConnectionUpdated,
+    can({ action: 'update', resource: 'connection', scopedBy: envScope }),
+    patchConnection
+);
 web.route('/connections/:connectionId').delete(
     webAuth,
     auditConnectionDeleted,
@@ -305,8 +375,8 @@ web.route('/connections/admin/:connectionId').delete(
 
 // User
 web.route('/user').get(webAuth, getUser);
-web.route('/user').patch(webAuth, patchUser);
-web.route('/user/password').put(webAuth, putUserPassword);
+web.route('/user').patch(webAuth, auditUserUpdated, patchUser);
+web.route('/user/password').put(webAuth, auditAppAuthPasswordChanged, putUserPassword);
 
 // Plain (in-app support chat)
 web.route('/plain').get(webAuth, getPlainHmac);
@@ -320,9 +390,14 @@ web.route('/sync/command').post(
 );
 web.route('/flows/pre-built/deploy').post(webAuth, can({ action: 'update', resource: 'flow', scopedBy: envScope }), postPreBuiltDeploy);
 web.route('/flows/pre-built/upgrade').put(webAuth, can({ action: 'update', resource: 'flow', scopedBy: envScope }), putUpgradePreBuilt);
-web.route('/flows/:id/disable').patch(webAuth, can({ action: 'update', resource: 'flow', scopedBy: envScope }), patchFlowDisable);
-web.route('/flows/:id/enable').patch(webAuth, can({ action: 'update', resource: 'flow', scopedBy: envScope }), patchFlowEnable);
-web.route('/flows/:id/frequency').patch(webAuth, can({ action: 'update', resource: 'flow', scopedBy: envScope }), patchFlowFrequency);
+web.route('/flows/:id/disable').patch(webAuth, auditSyncDisabled, can({ action: 'update', resource: 'flow', scopedBy: envScope }), patchFlowDisable);
+web.route('/flows/:id/enable').patch(webAuth, auditSyncEnabled, can({ action: 'update', resource: 'flow', scopedBy: envScope }), patchFlowEnable);
+web.route('/flows/:id/frequency').patch(
+    webAuth,
+    auditSyncFrequencyChanged,
+    can({ action: 'update', resource: 'flow', scopedBy: envScope }),
+    patchFlowFrequency
+);
 web.route('/flows/:id/download').get(webAuth, can({ action: 'read', resource: 'flow', scopedBy: envScope }), getFlowDownload);
 web.route('/flow/:flowName').get(webAuth, can({ action: 'read', resource: 'flow', scopedBy: envScope }), flowController.getFlow.bind(syncController));
 

--- a/packages/server/lib/routes.public.ts
+++ b/packages/server/lib/routes.public.ts
@@ -77,7 +77,17 @@ import { postWebhook } from './controllers/webhook/environmentUuid/postWebhook.j
 import { envs } from './env.js';
 import { acceptLanguageMiddleware } from './middleware/accept-language.middleware.js';
 import authMiddleware from './middleware/access.middleware.js';
-import { auditConnectionDeleted } from './middleware/audit.middleware.js';
+import {
+    auditConnectionDeleted,
+    auditConnectionMetadataUpdated,
+    auditConnectionUpdated,
+    auditFunctionDeleted,
+    auditIntegrationDeleted,
+    auditIntegrationUpdated,
+    auditSyncFrequencyChanged,
+    auditSyncVariantCreated,
+    auditSyncVariantDeleted
+} from './middleware/audit.middleware.js';
 import { cliMaxVersion, cliMinVersion } from './middleware/cliVersionCheck.js';
 import { connectionCapping } from './middleware/connection-capping.middleware.js';
 import { egressMeterMiddleware } from './middleware/egress-meter.middleware.js';
@@ -213,18 +223,18 @@ publicAPI
     .get(connectSessionOrApiAuth, withAnyScope('environment:integrations:list', 'environment:integrations:list_credentials'), getPublicListIntegrations);
 publicAPI.route('/integrations').post(apiAuth, withScope('environment:integrations:create'), postPublicIntegration);
 publicAPI.route('/integrations/quickstart').post(apiAuth, withScope('environment:integrations:create'), postPublicQuickstartIntegration);
-publicAPI.route('/integrations/:uniqueKey').patch(apiAuth, withScope('environment:integrations:update'), patchPublicIntegration);
+publicAPI.route('/integrations/:uniqueKey').patch(apiAuth, auditIntegrationUpdated, withScope('environment:integrations:update'), patchPublicIntegration);
 publicAPI
     .route('/integrations/:uniqueKey')
     .get(apiAuth, withAnyScope('environment:integrations:read', 'environment:integrations:read_credentials'), getPublicIntegration);
 
-publicAPI.route('/integrations/:uniqueKey').delete(apiAuth, withScope('environment:integrations:delete'), deletePublicIntegration);
+publicAPI.route('/integrations/:uniqueKey').delete(apiAuth, auditIntegrationDeleted, withScope('environment:integrations:delete'), deletePublicIntegration);
 publicAPI.route('/integrations/:uniqueKey/functions/:name/code').get(apiAuth, withScope('environment:functions:read'), getFunctionCode);
 publicAPI.route('/integrations/:uniqueKey/functions').get(apiAuth, withScope('environment:functions:list'), getPublicIntegrationFunctions);
 publicAPI
     .route('/integrations/:uniqueKey/functions/:name')
     .get(apiAuth, withScope('environment:functions:read'), getPublicIntegrationFunction)
-    .delete(apiAuth, withScope('environment:functions:delete'), deletePublicIntegrationFunction);
+    .delete(apiAuth, auditFunctionDeleted, withScope('environment:functions:delete'), deletePublicIntegrationFunction);
 
 // @deprecated connections
 publicAPI.use('/connection', jsonContentTypeMiddleware);
@@ -239,15 +249,25 @@ publicAPI.route('/connection/:connectionId').delete(apiAuth, auditConnectionDele
 // @deprecated
 publicAPI
     .route('/connection/:connectionId/metadata')
-    .post(apiAuth, withScope('environment:connections:update'), connectionController.setMetadataLegacy.bind(connectionController));
+    .post(
+        apiAuth,
+        auditConnectionMetadataUpdated,
+        withScope('environment:connections:update'),
+        connectionController.setMetadataLegacy.bind(connectionController)
+    );
 // @deprecated
 publicAPI
     .route('/connection/:connectionId/metadata')
-    .patch(apiAuth, withScope('environment:connections:update'), connectionController.updateMetadataLegacy.bind(connectionController));
+    .patch(
+        apiAuth,
+        auditConnectionMetadataUpdated,
+        withScope('environment:connections:update'),
+        connectionController.updateMetadataLegacy.bind(connectionController)
+    );
 // @deprecated
-publicAPI.route('/connection/metadata').post(apiAuth, withScope('environment:connections:update'), postPublicMetadata);
+publicAPI.route('/connection/metadata').post(apiAuth, auditConnectionMetadataUpdated, withScope('environment:connections:update'), postPublicMetadata);
 // @deprecated
-publicAPI.route('/connection/metadata').patch(apiAuth, withScope('environment:connections:update'), patchPublicMetadata);
+publicAPI.route('/connection/metadata').patch(apiAuth, auditConnectionMetadataUpdated, withScope('environment:connections:update'), patchPublicMetadata);
 // @deprecated
 publicAPI.route('/connection').post(apiAuth, withScope('environment:connections:create'), connectionController.createConnection.bind(connectionController));
 
@@ -255,12 +275,12 @@ publicAPI.route('/connection').post(apiAuth, withScope('environment:connections:
 publicAPI.use('/connections', jsonContentTypeMiddleware);
 publicAPI.route('/connections').post(apiAuth, withScope('environment:connections:create'), postPublicConnection);
 publicAPI.route('/connections').get(apiAuth, withAnyScope('environment:connections:list', 'environment:connections:list_credentials'), getPublicConnections);
-publicAPI.route('/connections/metadata').post(apiAuth, withScope('environment:connections:update'), postPublicMetadata);
-publicAPI.route('/connections/metadata').patch(apiAuth, withScope('environment:connections:update'), patchPublicMetadata);
+publicAPI.route('/connections/metadata').post(apiAuth, auditConnectionMetadataUpdated, withScope('environment:connections:update'), postPublicMetadata);
+publicAPI.route('/connections/metadata').patch(apiAuth, auditConnectionMetadataUpdated, withScope('environment:connections:update'), patchPublicMetadata);
 publicAPI
     .route('/connections/:connectionId')
     .get(apiAuth, withAnyScope('environment:connections:read', 'environment:connections:read_credentials'), getPublicConnection);
-publicAPI.route('/connections/:connectionId').patch(apiAuth, withScope('environment:connections:update'), patchPublicConnection);
+publicAPI.route('/connections/:connectionId').patch(apiAuth, auditConnectionUpdated, withScope('environment:connections:update'), patchPublicConnection);
 publicAPI.route('/connections/:connectionId').delete(apiAuth, auditConnectionDeleted, withScope('environment:connections:delete'), deletePublicConnection);
 
 // Config
@@ -278,7 +298,7 @@ publicAPI.use('/cli', jsonContentTypeMiddleware);
 publicAPI.route('/cli/telemetry').post(rateLimiterMiddleware, postCliTelemetry);
 
 // Syncs
-publicAPI.route('/sync/update-connection-frequency').put(apiAuth, withScope('environment:syncs:update'), putSyncConnectionFrequency);
+publicAPI.route('/sync/update-connection-frequency').put(apiAuth, auditSyncFrequencyChanged, withScope('environment:syncs:update'), putSyncConnectionFrequency);
 
 // Records
 publicAPI.use('/records', jsonContentTypeMiddleware);
@@ -291,8 +311,8 @@ publicAPI.route('/sync/trigger').post(apiAuth, withScope('environment:syncs:exec
 publicAPI.route('/sync/pause').post(apiAuth, withScope('environment:syncs:execute'), postPublicSyncPause);
 publicAPI.route('/sync/start').post(apiAuth, withScope('environment:syncs:execute'), postPublicSyncStart);
 publicAPI.route('/sync/status').get(apiAuth, withScope('environment:syncs:read'), getPublicSyncStatus);
-publicAPI.route('/sync/:name/variant/:variant').post(apiAuth, withScope('environment:syncs:variant:create'), postSyncVariant);
-publicAPI.route('/sync/:name/variant/:variant').delete(apiAuth, withScope('environment:syncs:variant:delete'), deleteSyncVariant);
+publicAPI.route('/sync/:name/variant/:variant').post(apiAuth, auditSyncVariantCreated, withScope('environment:syncs:variant:create'), postSyncVariant);
+publicAPI.route('/sync/:name/variant/:variant').delete(apiAuth, auditSyncVariantDeleted, withScope('environment:syncs:variant:delete'), deleteSyncVariant);
 
 // MCP
 publicAPI.use('/mcp', jsonContentTypeMiddleware);

--- a/packages/server/lib/routes.public.ts
+++ b/packages/server/lib/routes.public.ts
@@ -78,13 +78,14 @@ import { envs } from './env.js';
 import { acceptLanguageMiddleware } from './middleware/accept-language.middleware.js';
 import authMiddleware from './middleware/access.middleware.js';
 import {
-    auditConnectionDeleted,
-    auditConnectionMetadataUpdated,
-    auditConnectionUpdated,
-    auditFunctionDeleted,
-    auditIntegrationDeleted,
-    auditIntegrationUpdated,
-    auditSyncFrequencyChanged,
+    auditPublicConnectionDeleted,
+    auditPublicConnectionMetadataSet,
+    auditPublicConnectionMetadataUpdated,
+    auditPublicConnectionUpdated,
+    auditPublicFunctionDeleted,
+    auditPublicIntegrationDeleted,
+    auditPublicIntegrationUpdated,
+    auditPublicSyncFrequencyChanged,
     auditSyncVariantCreated,
     auditSyncVariantDeleted
 } from './middleware/audit.middleware.js';
@@ -223,18 +224,20 @@ publicAPI
     .get(connectSessionOrApiAuth, withAnyScope('environment:integrations:list', 'environment:integrations:list_credentials'), getPublicListIntegrations);
 publicAPI.route('/integrations').post(apiAuth, withScope('environment:integrations:create'), postPublicIntegration);
 publicAPI.route('/integrations/quickstart').post(apiAuth, withScope('environment:integrations:create'), postPublicQuickstartIntegration);
-publicAPI.route('/integrations/:uniqueKey').patch(apiAuth, auditIntegrationUpdated, withScope('environment:integrations:update'), patchPublicIntegration);
+publicAPI.route('/integrations/:uniqueKey').patch(apiAuth, auditPublicIntegrationUpdated, withScope('environment:integrations:update'), patchPublicIntegration);
 publicAPI
     .route('/integrations/:uniqueKey')
     .get(apiAuth, withAnyScope('environment:integrations:read', 'environment:integrations:read_credentials'), getPublicIntegration);
 
-publicAPI.route('/integrations/:uniqueKey').delete(apiAuth, auditIntegrationDeleted, withScope('environment:integrations:delete'), deletePublicIntegration);
+publicAPI
+    .route('/integrations/:uniqueKey')
+    .delete(apiAuth, auditPublicIntegrationDeleted, withScope('environment:integrations:delete'), deletePublicIntegration);
 publicAPI.route('/integrations/:uniqueKey/functions/:name/code').get(apiAuth, withScope('environment:functions:read'), getFunctionCode);
 publicAPI.route('/integrations/:uniqueKey/functions').get(apiAuth, withScope('environment:functions:list'), getPublicIntegrationFunctions);
 publicAPI
     .route('/integrations/:uniqueKey/functions/:name')
     .get(apiAuth, withScope('environment:functions:read'), getPublicIntegrationFunction)
-    .delete(apiAuth, auditFunctionDeleted, withScope('environment:functions:delete'), deletePublicIntegrationFunction);
+    .delete(apiAuth, auditPublicFunctionDeleted, withScope('environment:functions:delete'), deletePublicIntegrationFunction);
 
 // @deprecated connections
 publicAPI.use('/connection', jsonContentTypeMiddleware);
@@ -245,13 +248,13 @@ publicAPI
 // @deprecated
 publicAPI.route('/connection').get(apiAuth, withAnyScope('environment:connections:list', 'environment:connections:list_credentials'), getPublicConnections);
 // @deprecated
-publicAPI.route('/connection/:connectionId').delete(apiAuth, auditConnectionDeleted, withScope('environment:connections:delete'), deletePublicConnection);
+publicAPI.route('/connection/:connectionId').delete(apiAuth, auditPublicConnectionDeleted, withScope('environment:connections:delete'), deletePublicConnection);
 // @deprecated
 publicAPI
     .route('/connection/:connectionId/metadata')
     .post(
         apiAuth,
-        auditConnectionMetadataUpdated,
+        auditPublicConnectionMetadataSet,
         withScope('environment:connections:update'),
         connectionController.setMetadataLegacy.bind(connectionController)
     );
@@ -260,14 +263,14 @@ publicAPI
     .route('/connection/:connectionId/metadata')
     .patch(
         apiAuth,
-        auditConnectionMetadataUpdated,
+        auditPublicConnectionMetadataUpdated,
         withScope('environment:connections:update'),
         connectionController.updateMetadataLegacy.bind(connectionController)
     );
 // @deprecated
-publicAPI.route('/connection/metadata').post(apiAuth, auditConnectionMetadataUpdated, withScope('environment:connections:update'), postPublicMetadata);
+publicAPI.route('/connection/metadata').post(apiAuth, auditPublicConnectionMetadataSet, withScope('environment:connections:update'), postPublicMetadata);
 // @deprecated
-publicAPI.route('/connection/metadata').patch(apiAuth, auditConnectionMetadataUpdated, withScope('environment:connections:update'), patchPublicMetadata);
+publicAPI.route('/connection/metadata').patch(apiAuth, auditPublicConnectionMetadataUpdated, withScope('environment:connections:update'), patchPublicMetadata);
 // @deprecated
 publicAPI.route('/connection').post(apiAuth, withScope('environment:connections:create'), connectionController.createConnection.bind(connectionController));
 
@@ -275,13 +278,15 @@ publicAPI.route('/connection').post(apiAuth, withScope('environment:connections:
 publicAPI.use('/connections', jsonContentTypeMiddleware);
 publicAPI.route('/connections').post(apiAuth, withScope('environment:connections:create'), postPublicConnection);
 publicAPI.route('/connections').get(apiAuth, withAnyScope('environment:connections:list', 'environment:connections:list_credentials'), getPublicConnections);
-publicAPI.route('/connections/metadata').post(apiAuth, auditConnectionMetadataUpdated, withScope('environment:connections:update'), postPublicMetadata);
-publicAPI.route('/connections/metadata').patch(apiAuth, auditConnectionMetadataUpdated, withScope('environment:connections:update'), patchPublicMetadata);
+publicAPI.route('/connections/metadata').post(apiAuth, auditPublicConnectionMetadataSet, withScope('environment:connections:update'), postPublicMetadata);
+publicAPI.route('/connections/metadata').patch(apiAuth, auditPublicConnectionMetadataUpdated, withScope('environment:connections:update'), patchPublicMetadata);
 publicAPI
     .route('/connections/:connectionId')
     .get(apiAuth, withAnyScope('environment:connections:read', 'environment:connections:read_credentials'), getPublicConnection);
-publicAPI.route('/connections/:connectionId').patch(apiAuth, auditConnectionUpdated, withScope('environment:connections:update'), patchPublicConnection);
-publicAPI.route('/connections/:connectionId').delete(apiAuth, auditConnectionDeleted, withScope('environment:connections:delete'), deletePublicConnection);
+publicAPI.route('/connections/:connectionId').patch(apiAuth, auditPublicConnectionUpdated, withScope('environment:connections:update'), patchPublicConnection);
+publicAPI
+    .route('/connections/:connectionId')
+    .delete(apiAuth, auditPublicConnectionDeleted, withScope('environment:connections:delete'), deletePublicConnection);
 
 // Config
 publicAPI.use('/environment-variables', jsonContentTypeMiddleware);
@@ -298,7 +303,9 @@ publicAPI.use('/cli', jsonContentTypeMiddleware);
 publicAPI.route('/cli/telemetry').post(rateLimiterMiddleware, postCliTelemetry);
 
 // Syncs
-publicAPI.route('/sync/update-connection-frequency').put(apiAuth, auditSyncFrequencyChanged, withScope('environment:syncs:update'), putSyncConnectionFrequency);
+publicAPI
+    .route('/sync/update-connection-frequency')
+    .put(apiAuth, auditPublicSyncFrequencyChanged, withScope('environment:syncs:update'), putSyncConnectionFrequency);
 
 // Records
 publicAPI.use('/records', jsonContentTypeMiddleware);

--- a/packages/types/lib/audit-trail/event.ts
+++ b/packages/types/lib/audit-trail/event.ts
@@ -75,58 +75,18 @@ export interface AuditContext {
 }
 
 // Every endpoint declares an audit policy on its `ApiEndpoint` definition: either the audit event it
-// records (`AuditEndpointPolicy`) or an explicit `NoAudit` opt-out. This makes audit coverage a
-// compile-time decision — a customer endpoint cannot be added without consciously opting in or out.
-export interface AuditEndpointPolicy {
+// records (`AuditPolicy`) or an explicit `NoAudit` opt-out. This makes audit coverage a compile-time
+// decision — a customer endpoint cannot be added without consciously opting in or out. The policy's
+// resource/action/scope are captured as type parameters so the endpoint's declaration and the
+// middleware spec that services it are checked against each other by the compiler.
+export interface AuditPolicy<R extends AuditResource = AuditResource, A extends AuditAction = AuditAction, S extends AuditScope = AuditScope> {
     kind: 'audit';
-    resource: AuditResource;
-    action: AuditAction;
-    scope: AuditScope;
+    resource: R;
+    action: A;
+    scope: S;
 }
 export interface NoAudit<Reason extends string = 'non-auditable'> {
     kind: 'no-audit';
     reason: Reason;
 }
-export type EndpointAudit = AuditEndpointPolicy | NoAudit<string>;
-
-// Constructors for the policies above — `auditable()` stamps `kind: 'audit'` so each identity is
-// authored once (in `auditPolicies`) and referenced from both the endpoint type and the middleware.
-export const Audit = {
-    auditable: <R extends AuditResource, A extends AuditAction, S extends AuditScope>(policy: {
-        resource: R;
-        action: A;
-        scope: S;
-    }): { kind: 'audit'; resource: R; action: A; scope: S } => ({ kind: 'audit', ...policy }),
-    notAuditable: <Reason extends string = 'non-auditable'>(reason: Reason = 'non-auditable' as Reason): NoAudit<Reason> => ({ kind: 'no-audit', reason })
-} as const;
-
-// The single source of truth for each audited endpoint's identity. Endpoint types reference an entry
-// via `typeof auditPolicies.x`; the audit middleware spreads the same entry — so the two cannot drift.
-export const auditPolicies = {
-    connectionRefreshed: Audit.auditable({ resource: 'connection', action: 'refreshed', scope: 'environment' }),
-    connectionUpdated: Audit.auditable({ resource: 'connection', action: 'updated', scope: 'environment' }),
-    connectionMetadataUpdated: Audit.auditable({ resource: 'connection', action: 'metadata_updated', scope: 'environment' }),
-    connectionDeleted: Audit.auditable({ resource: 'connection', action: 'deleted', scope: 'environment' }),
-    integrationUpdated: Audit.auditable({ resource: 'integration', action: 'updated', scope: 'environment' }),
-    integrationDeleted: Audit.auditable({ resource: 'integration', action: 'deleted', scope: 'environment' }),
-    functionDeleted: Audit.auditable({ resource: 'function', action: 'deleted', scope: 'environment' }),
-    apiKeyUpdated: Audit.auditable({ resource: 'api_key', action: 'updated', scope: 'environment' }),
-    apiKeyDeleted: Audit.auditable({ resource: 'api_key', action: 'deleted', scope: 'environment' }),
-    syncEnabled: Audit.auditable({ resource: 'sync', action: 'enabled', scope: 'environment' }),
-    syncDisabled: Audit.auditable({ resource: 'sync', action: 'disabled', scope: 'environment' }),
-    syncFrequencyChanged: Audit.auditable({ resource: 'sync', action: 'frequency_changed', scope: 'environment' }),
-    syncVariantCreated: Audit.auditable({ resource: 'sync', action: 'variant_created', scope: 'environment' }),
-    syncVariantDeleted: Audit.auditable({ resource: 'sync', action: 'variant_deleted', scope: 'environment' }),
-    memberRemoved: Audit.auditable({ resource: 'member', action: 'removed', scope: 'account' }),
-    memberRoleChanged: Audit.auditable({ resource: 'member', action: 'role_changed', scope: 'account' }),
-    teamUpdated: Audit.auditable({ resource: 'team', action: 'updated', scope: 'account' }),
-    userUpdated: Audit.auditable({ resource: 'user', action: 'updated', scope: 'account' }),
-    environmentDeleted: Audit.auditable({ resource: 'environment', action: 'deleted', scope: 'environment' }),
-    environmentUpdated: Audit.auditable({ resource: 'environment', action: 'updated', scope: 'environment' }),
-    environmentVariablesChanged: Audit.auditable({ resource: 'environment', action: 'variables_changed', scope: 'environment' }),
-    environmentWebhookUrlsChanged: Audit.auditable({ resource: 'environment', action: 'webhook_urls_changed', scope: 'environment' }),
-    billingPlanChanged: Audit.auditable({ resource: 'billing', action: 'plan_changed', scope: 'account' }),
-    billingTrialExtended: Audit.auditable({ resource: 'billing', action: 'trial_extended', scope: 'account' }),
-    billingDetailsChanged: Audit.auditable({ resource: 'billing', action: 'details_changed', scope: 'account' }),
-    appAuthPasswordChanged: Audit.auditable({ resource: 'app_auth', action: 'password_changed', scope: 'account' })
-} as const;
+export type EndpointAudit = AuditPolicy | NoAudit<string>;

--- a/packages/types/lib/audit-trail/event.ts
+++ b/packages/types/lib/audit-trail/event.ts
@@ -2,11 +2,60 @@
 // (@nangohq/audit's AuditEvent) and the read/API side (ApiAuditTrailEvent).
 export type AuditTrailVersion = '2026-07-16';
 export type AuditActorType = 'user' | 'api_key' | 'system';
-export type AuditTargetType = 'connection' | 'member';
 export type AuditOutcome = 'success' | 'failure' | 'denied';
-export type AuditResource = 'connection' | 'member';
-export type AuditAction = 'deleted' | 'role_changed';
+
+export type AuditResource =
+    | 'connection'
+    | 'sync'
+    | 'function'
+    | 'integration'
+    | 'api_key'
+    | 'member'
+    | 'team'
+    | 'user'
+    | 'environment'
+    | 'app_auth'
+    | 'billing'
+    | 'audit_log';
+
+export type AuditAction =
+    | 'created'
+    | 'reauthorized'
+    | 'refreshed'
+    | 'updated'
+    | 'metadata_updated'
+    | 'deleted'
+    | 'paused'
+    | 'started'
+    | 'enabled'
+    | 'disabled'
+    | 'frequency_changed'
+    | 'triggered'
+    | 'variant_created'
+    | 'variant_deleted'
+    | 'upgraded'
+    | 'deployed'
+    | 'invited'
+    | 'invite_accepted'
+    | 'invite_revoked'
+    | 'removed'
+    | 'role_changed'
+    | 'variables_changed'
+    | 'webhook_urls_changed'
+    | 'login'
+    | 'login_failed'
+    | 'logout'
+    | 'signup'
+    | 'password_changed'
+    | 'password_reset'
+    | 'plan_changed'
+    | 'trial_extended'
+    | 'details_changed'
+    | 'exported';
+
 export type AuditScope = 'account' | 'environment';
+
+export type AuditTargetType = 'connection' | 'sync' | 'function' | 'integration' | 'api_key' | 'member' | 'team' | 'user' | 'environment';
 
 export interface AuditActor {
     type: AuditActorType;
@@ -54,6 +103,30 @@ export const Audit = {
 // The single source of truth for each audited endpoint's identity. Endpoint types reference an entry
 // via `typeof auditPolicies.x`; the audit middleware spreads the same entry — so the two cannot drift.
 export const auditPolicies = {
+    connectionRefreshed: Audit.auditable({ resource: 'connection', action: 'refreshed', scope: 'environment' }),
+    connectionUpdated: Audit.auditable({ resource: 'connection', action: 'updated', scope: 'environment' }),
+    connectionMetadataUpdated: Audit.auditable({ resource: 'connection', action: 'metadata_updated', scope: 'environment' }),
     connectionDeleted: Audit.auditable({ resource: 'connection', action: 'deleted', scope: 'environment' }),
-    memberRoleChanged: Audit.auditable({ resource: 'member', action: 'role_changed', scope: 'account' })
+    integrationUpdated: Audit.auditable({ resource: 'integration', action: 'updated', scope: 'environment' }),
+    integrationDeleted: Audit.auditable({ resource: 'integration', action: 'deleted', scope: 'environment' }),
+    functionDeleted: Audit.auditable({ resource: 'function', action: 'deleted', scope: 'environment' }),
+    apiKeyUpdated: Audit.auditable({ resource: 'api_key', action: 'updated', scope: 'environment' }),
+    apiKeyDeleted: Audit.auditable({ resource: 'api_key', action: 'deleted', scope: 'environment' }),
+    syncEnabled: Audit.auditable({ resource: 'sync', action: 'enabled', scope: 'environment' }),
+    syncDisabled: Audit.auditable({ resource: 'sync', action: 'disabled', scope: 'environment' }),
+    syncFrequencyChanged: Audit.auditable({ resource: 'sync', action: 'frequency_changed', scope: 'environment' }),
+    syncVariantCreated: Audit.auditable({ resource: 'sync', action: 'variant_created', scope: 'environment' }),
+    syncVariantDeleted: Audit.auditable({ resource: 'sync', action: 'variant_deleted', scope: 'environment' }),
+    memberRemoved: Audit.auditable({ resource: 'member', action: 'removed', scope: 'account' }),
+    memberRoleChanged: Audit.auditable({ resource: 'member', action: 'role_changed', scope: 'account' }),
+    teamUpdated: Audit.auditable({ resource: 'team', action: 'updated', scope: 'account' }),
+    userUpdated: Audit.auditable({ resource: 'user', action: 'updated', scope: 'account' }),
+    environmentDeleted: Audit.auditable({ resource: 'environment', action: 'deleted', scope: 'environment' }),
+    environmentUpdated: Audit.auditable({ resource: 'environment', action: 'updated', scope: 'environment' }),
+    environmentVariablesChanged: Audit.auditable({ resource: 'environment', action: 'variables_changed', scope: 'environment' }),
+    environmentWebhookUrlsChanged: Audit.auditable({ resource: 'environment', action: 'webhook_urls_changed', scope: 'environment' }),
+    billingPlanChanged: Audit.auditable({ resource: 'billing', action: 'plan_changed', scope: 'account' }),
+    billingTrialExtended: Audit.auditable({ resource: 'billing', action: 'trial_extended', scope: 'account' }),
+    billingDetailsChanged: Audit.auditable({ resource: 'billing', action: 'details_changed', scope: 'account' }),
+    appAuthPasswordChanged: Audit.auditable({ resource: 'app_auth', action: 'password_changed', scope: 'account' })
 } as const;

--- a/packages/types/lib/connection/api/get.ts
+++ b/packages/types/lib/connection/api/get.ts
@@ -166,7 +166,7 @@ export type GetPublicConnection = ApiEndpoint<{
 }>;
 
 export type PatchPublicConnection = ApiEndpoint<{
-    Audit: { kind: 'no-audit'; reason: 'TODO: audit coverage pending' };
+    Audit: typeof auditPolicies.connectionUpdated;
     Method: 'PATCH';
     Path: '/connections/:connectionId';
     Params: {
@@ -185,7 +185,7 @@ export type PatchPublicConnection = ApiEndpoint<{
 }>;
 
 export type PatchConnection = ApiEndpoint<{
-    Audit: { kind: 'no-audit'; reason: 'TODO: audit coverage pending' };
+    Audit: typeof auditPolicies.connectionUpdated;
     Method: 'PATCH';
     Path: '/api/v1/connections/:connectionId';
     Params: {
@@ -205,7 +205,7 @@ export type PatchConnection = ApiEndpoint<{
 }>;
 
 export type PostConnectionRefresh = ApiEndpoint<{
-    Audit: { kind: 'no-audit'; reason: 'TODO: audit coverage pending' };
+    Audit: typeof auditPolicies.connectionRefreshed;
     Method: 'POST';
     Params: {
         connectionId: string;

--- a/packages/types/lib/connection/api/get.ts
+++ b/packages/types/lib/connection/api/get.ts
@@ -1,5 +1,5 @@
 import type { ApiEndpoint, ApiError, ApiTimestamps } from '../../api.js';
-import type { auditPolicies } from '../../audit-trail/event.js';
+import type { AuditPolicy } from '../../audit-trail/event.js';
 import type {
     ApiKeyCredentials,
     ApiPublicAllAuthCredentials,
@@ -166,7 +166,7 @@ export type GetPublicConnection = ApiEndpoint<{
 }>;
 
 export type PatchPublicConnection = ApiEndpoint<{
-    Audit: typeof auditPolicies.connectionUpdated;
+    Audit: AuditPolicy<'connection', 'updated', 'environment'>;
     Method: 'PATCH';
     Path: '/connections/:connectionId';
     Params: {
@@ -185,7 +185,7 @@ export type PatchPublicConnection = ApiEndpoint<{
 }>;
 
 export type PatchConnection = ApiEndpoint<{
-    Audit: typeof auditPolicies.connectionUpdated;
+    Audit: AuditPolicy<'connection', 'updated', 'environment'>;
     Method: 'PATCH';
     Path: '/api/v1/connections/:connectionId';
     Params: {
@@ -205,7 +205,7 @@ export type PatchConnection = ApiEndpoint<{
 }>;
 
 export type PostConnectionRefresh = ApiEndpoint<{
-    Audit: typeof auditPolicies.connectionRefreshed;
+    Audit: AuditPolicy<'connection', 'refreshed', 'environment'>;
     Method: 'POST';
     Params: {
         connectionId: string;
@@ -224,7 +224,7 @@ export type PostConnectionRefresh = ApiEndpoint<{
 }>;
 
 export type DeletePublicConnection = ApiEndpoint<{
-    Audit: typeof auditPolicies.connectionDeleted;
+    Audit: AuditPolicy<'connection', 'deleted', 'environment'>;
     Method: 'DELETE';
     Path: '/connection/:connectionId';
     Params: { connectionId: string };
@@ -240,5 +240,5 @@ export type DeleteConnection = ApiEndpoint<{
     Querystring: { provider_config_key: string; env: string };
     Error: ApiError<'unknown_connection'> | ApiError<'unknown_provider_config'>;
     Success: { success: boolean };
-    Audit: typeof auditPolicies.connectionDeleted;
+    Audit: AuditPolicy<'connection', 'deleted', 'environment'>;
 }>;

--- a/packages/types/lib/connection/api/metadata.ts
+++ b/packages/types/lib/connection/api/metadata.ts
@@ -1,4 +1,5 @@
 import type { ApiEndpoint, ApiError } from '../../api.js';
+import type { auditPolicies } from '../../audit-trail/event.js';
 import type { Metadata } from '../db.js';
 
 export interface MetadataBody {
@@ -10,7 +11,7 @@ export interface MetadataBody {
 type MetadataError = ApiError<'invalid_body'> | ApiError<'unknown_connection'>;
 
 export type SetMetadata = ApiEndpoint<{
-    Audit: { kind: 'no-audit'; reason: 'TODO: audit coverage pending' };
+    Audit: typeof auditPolicies.connectionMetadataUpdated;
     Method: 'POST';
     Body: MetadataBody;
     Path: '/connection/metadata';
@@ -19,7 +20,7 @@ export type SetMetadata = ApiEndpoint<{
 }>;
 
 export type UpdateMetadata = ApiEndpoint<{
-    Audit: { kind: 'no-audit'; reason: 'TODO: audit coverage pending' };
+    Audit: typeof auditPolicies.connectionMetadataUpdated;
     Method: 'PATCH';
     Path: '/connection/metadata';
     Body: MetadataBody;
@@ -28,7 +29,7 @@ export type UpdateMetadata = ApiEndpoint<{
 }>;
 
 export type PostConnectionMetadata = ApiEndpoint<{
-    Audit: { kind: 'no-audit'; reason: 'TODO: audit coverage pending' };
+    Audit: typeof auditPolicies.connectionMetadataUpdated;
     Method: 'POST';
     Path: '/api/v1/connections/:connectionId/metadata';
     Params: {

--- a/packages/types/lib/connection/api/metadata.ts
+++ b/packages/types/lib/connection/api/metadata.ts
@@ -1,5 +1,5 @@
 import type { ApiEndpoint, ApiError } from '../../api.js';
-import type { auditPolicies } from '../../audit-trail/event.js';
+import type { AuditPolicy } from '../../audit-trail/event.js';
 import type { Metadata } from '../db.js';
 
 export interface MetadataBody {
@@ -11,7 +11,7 @@ export interface MetadataBody {
 type MetadataError = ApiError<'invalid_body'> | ApiError<'unknown_connection'>;
 
 export type SetMetadata = ApiEndpoint<{
-    Audit: typeof auditPolicies.connectionMetadataUpdated;
+    Audit: AuditPolicy<'connection', 'metadata_updated', 'environment'>;
     Method: 'POST';
     Body: MetadataBody;
     Path: '/connection/metadata';
@@ -20,7 +20,7 @@ export type SetMetadata = ApiEndpoint<{
 }>;
 
 export type UpdateMetadata = ApiEndpoint<{
-    Audit: typeof auditPolicies.connectionMetadataUpdated;
+    Audit: AuditPolicy<'connection', 'metadata_updated', 'environment'>;
     Method: 'PATCH';
     Path: '/connection/metadata';
     Body: MetadataBody;
@@ -29,7 +29,7 @@ export type UpdateMetadata = ApiEndpoint<{
 }>;
 
 export type PostConnectionMetadata = ApiEndpoint<{
-    Audit: typeof auditPolicies.connectionMetadataUpdated;
+    Audit: AuditPolicy<'connection', 'metadata_updated', 'environment'>;
     Method: 'POST';
     Path: '/api/v1/connections/:connectionId/metadata';
     Params: {

--- a/packages/types/lib/environment/api/index.ts
+++ b/packages/types/lib/environment/api/index.ts
@@ -1,6 +1,6 @@
 import type { ApiKeyScope } from '../../api-keys/scopes.js';
 import type { ApiEndpoint, ApiError, ApiTimestamps } from '../../api.js';
-import type { auditPolicies } from '../../audit-trail/event.js';
+import type { AuditPolicy } from '../../audit-trail/event.js';
 import type { ApiPlan } from '../../plans/http.api.js';
 import type { DBEnvironment, DBExternalWebhook } from '../db.js';
 import type { ApiEnvironmentVariable } from '../variable/api.js';
@@ -50,7 +50,7 @@ export type GetEnvironment = ApiEndpoint<{
 }>;
 
 export type PatchEnvironment = ApiEndpoint<{
-    Audit: typeof auditPolicies.environmentUpdated;
+    Audit: AuditPolicy<'environment', 'updated', 'environment'>;
     Method: 'PATCH';
     Path: '/api/v1/environments';
     Body: {
@@ -70,7 +70,7 @@ export type PatchEnvironment = ApiEndpoint<{
 }>;
 
 export type DeleteEnvironment = ApiEndpoint<{
-    Audit: typeof auditPolicies.environmentDeleted;
+    Audit: AuditPolicy<'environment', 'deleted', 'environment'>;
     Method: 'DELETE';
     Path: '/api/v1/environments';
     Success: never;
@@ -121,7 +121,7 @@ export type CreateApiKey = ApiEndpoint<{
 }>;
 
 export type DeleteApiKey = ApiEndpoint<{
-    Audit: typeof auditPolicies.apiKeyDeleted;
+    Audit: AuditPolicy<'api_key', 'deleted', 'environment'>;
     Method: 'DELETE';
     Path: '/api/v1/environment/api-keys/:keyId';
     Params: { keyId: number };
@@ -129,7 +129,7 @@ export type DeleteApiKey = ApiEndpoint<{
 }>;
 
 export type PatchApiKey = ApiEndpoint<{
-    Audit: typeof auditPolicies.apiKeyUpdated;
+    Audit: AuditPolicy<'api_key', 'updated', 'environment'>;
     Method: 'PATCH';
     Path: '/api/v1/environment/api-keys/:keyId';
     Params: { keyId: number };

--- a/packages/types/lib/environment/api/index.ts
+++ b/packages/types/lib/environment/api/index.ts
@@ -1,5 +1,6 @@
 import type { ApiKeyScope } from '../../api-keys/scopes.js';
 import type { ApiEndpoint, ApiError, ApiTimestamps } from '../../api.js';
+import type { auditPolicies } from '../../audit-trail/event.js';
 import type { ApiPlan } from '../../plans/http.api.js';
 import type { DBEnvironment, DBExternalWebhook } from '../db.js';
 import type { ApiEnvironmentVariable } from '../variable/api.js';
@@ -49,7 +50,7 @@ export type GetEnvironment = ApiEndpoint<{
 }>;
 
 export type PatchEnvironment = ApiEndpoint<{
-    Audit: { kind: 'no-audit'; reason: 'TODO: audit coverage pending' };
+    Audit: typeof auditPolicies.environmentUpdated;
     Method: 'PATCH';
     Path: '/api/v1/environments';
     Body: {
@@ -69,7 +70,7 @@ export type PatchEnvironment = ApiEndpoint<{
 }>;
 
 export type DeleteEnvironment = ApiEndpoint<{
-    Audit: { kind: 'no-audit'; reason: 'TODO: audit coverage pending' };
+    Audit: typeof auditPolicies.environmentDeleted;
     Method: 'DELETE';
     Path: '/api/v1/environments';
     Success: never;
@@ -120,7 +121,7 @@ export type CreateApiKey = ApiEndpoint<{
 }>;
 
 export type DeleteApiKey = ApiEndpoint<{
-    Audit: { kind: 'no-audit'; reason: 'TODO: audit coverage pending' };
+    Audit: typeof auditPolicies.apiKeyDeleted;
     Method: 'DELETE';
     Path: '/api/v1/environment/api-keys/:keyId';
     Params: { keyId: number };
@@ -128,7 +129,7 @@ export type DeleteApiKey = ApiEndpoint<{
 }>;
 
 export type PatchApiKey = ApiEndpoint<{
-    Audit: { kind: 'no-audit'; reason: 'TODO: audit coverage pending' };
+    Audit: typeof auditPolicies.apiKeyUpdated;
     Method: 'PATCH';
     Path: '/api/v1/environment/api-keys/:keyId';
     Params: { keyId: number };

--- a/packages/types/lib/environment/api/webhook.ts
+++ b/packages/types/lib/environment/api/webhook.ts
@@ -1,8 +1,8 @@
 import type { ApiEndpoint } from '../../api.js';
-import type { auditPolicies } from '../../audit-trail/event.js';
+import type { AuditPolicy } from '../../audit-trail/event.js';
 
 export type PatchWebhook = ApiEndpoint<{
-    Audit: typeof auditPolicies.environmentWebhookUrlsChanged;
+    Audit: AuditPolicy<'environment', 'webhook_urls_changed', 'environment'>;
     Method: 'PATCH';
     Querystring: {
         env: string;

--- a/packages/types/lib/environment/api/webhook.ts
+++ b/packages/types/lib/environment/api/webhook.ts
@@ -1,7 +1,8 @@
 import type { ApiEndpoint } from '../../api.js';
+import type { auditPolicies } from '../../audit-trail/event.js';
 
 export type PatchWebhook = ApiEndpoint<{
-    Audit: { kind: 'no-audit'; reason: 'TODO: audit coverage pending' };
+    Audit: typeof auditPolicies.environmentWebhookUrlsChanged;
     Method: 'PATCH';
     Querystring: {
         env: string;

--- a/packages/types/lib/environment/variable/api.ts
+++ b/packages/types/lib/environment/variable/api.ts
@@ -1,10 +1,10 @@
 import type { ApiEndpoint } from '../../api.js';
-import type { auditPolicies } from '../../audit-trail/event.js';
+import type { AuditPolicy } from '../../audit-trail/event.js';
 import type { DBEnvironmentVariable } from '../db.js';
 
 export type ApiEnvironmentVariable = Pick<DBEnvironmentVariable, 'name' | 'value'>;
 export type PostEnvironmentVariables = ApiEndpoint<{
-    Audit: typeof auditPolicies.environmentVariablesChanged;
+    Audit: AuditPolicy<'environment', 'variables_changed', 'environment'>;
     Method: 'POST';
     Path: '/api/v1/environments/variables';
     Querystring: { env: string };

--- a/packages/types/lib/environment/variable/api.ts
+++ b/packages/types/lib/environment/variable/api.ts
@@ -1,9 +1,10 @@
 import type { ApiEndpoint } from '../../api.js';
+import type { auditPolicies } from '../../audit-trail/event.js';
 import type { DBEnvironmentVariable } from '../db.js';
 
 export type ApiEnvironmentVariable = Pick<DBEnvironmentVariable, 'name' | 'value'>;
 export type PostEnvironmentVariables = ApiEndpoint<{
-    Audit: { kind: 'no-audit'; reason: 'TODO: audit coverage pending' };
+    Audit: typeof auditPolicies.environmentVariablesChanged;
     Method: 'POST';
     Path: '/api/v1/environments/variables';
     Querystring: { env: string };

--- a/packages/types/lib/flow/http.api.ts
+++ b/packages/types/lib/flow/http.api.ts
@@ -1,4 +1,5 @@
 import type { ApiEndpoint, ApiError } from '../api.js';
+import type { auditPolicies } from '../audit-trail/event.js';
 import type { ScriptTypeLiteral } from '../nangoYaml/index.js';
 
 export type PutUpgradePreBuiltFlow = ApiEndpoint<{
@@ -40,7 +41,7 @@ export type PostPreBuiltDeploy = ApiEndpoint<{
 }>;
 
 export type PatchFlowEnable = ApiEndpoint<{
-    Audit: { kind: 'no-audit'; reason: 'TODO: audit coverage pending' };
+    Audit: typeof auditPolicies.syncEnabled;
     Method: 'PATCH';
     Path: '/api/v1/flows/:id/enable';
     Querystring: { env: string };
@@ -60,7 +61,7 @@ export type PatchFlowEnable = ApiEndpoint<{
 }>;
 
 export type PatchFlowDisable = ApiEndpoint<{
-    Audit: { kind: 'no-audit'; reason: 'TODO: audit coverage pending' };
+    Audit: typeof auditPolicies.syncDisabled;
     Method: 'PATCH';
     Path: '/api/v1/flows/:id/disable';
     Querystring: { env: string };
@@ -80,7 +81,7 @@ export type PatchFlowDisable = ApiEndpoint<{
 }>;
 
 export type PatchFlowFrequency = ApiEndpoint<{
-    Audit: { kind: 'no-audit'; reason: 'TODO: audit coverage pending' };
+    Audit: typeof auditPolicies.syncFrequencyChanged;
     Method: 'PATCH';
     Path: '/api/v1/flows/:id/frequency';
     Querystring: { env: string };

--- a/packages/types/lib/flow/http.api.ts
+++ b/packages/types/lib/flow/http.api.ts
@@ -1,5 +1,5 @@
 import type { ApiEndpoint, ApiError } from '../api.js';
-import type { auditPolicies } from '../audit-trail/event.js';
+import type { AuditPolicy } from '../audit-trail/event.js';
 import type { ScriptTypeLiteral } from '../nangoYaml/index.js';
 
 export type PutUpgradePreBuiltFlow = ApiEndpoint<{
@@ -41,7 +41,7 @@ export type PostPreBuiltDeploy = ApiEndpoint<{
 }>;
 
 export type PatchFlowEnable = ApiEndpoint<{
-    Audit: typeof auditPolicies.syncEnabled;
+    Audit: AuditPolicy<'sync', 'enabled', 'environment'>;
     Method: 'PATCH';
     Path: '/api/v1/flows/:id/enable';
     Querystring: { env: string };
@@ -61,7 +61,7 @@ export type PatchFlowEnable = ApiEndpoint<{
 }>;
 
 export type PatchFlowDisable = ApiEndpoint<{
-    Audit: typeof auditPolicies.syncDisabled;
+    Audit: AuditPolicy<'sync', 'disabled', 'environment'>;
     Method: 'PATCH';
     Path: '/api/v1/flows/:id/disable';
     Querystring: { env: string };
@@ -81,7 +81,7 @@ export type PatchFlowDisable = ApiEndpoint<{
 }>;
 
 export type PatchFlowFrequency = ApiEndpoint<{
-    Audit: typeof auditPolicies.syncFrequencyChanged;
+    Audit: AuditPolicy<'sync', 'frequency_changed', 'environment'>;
     Method: 'PATCH';
     Path: '/api/v1/flows/:id/frequency';
     Querystring: { env: string };

--- a/packages/types/lib/functions/api.ts
+++ b/packages/types/lib/functions/api.ts
@@ -1,5 +1,5 @@
 import type { ApiEndpoint, ApiError } from '../api.js';
-import type { auditPolicies } from '../audit-trail/event.js';
+import type { AuditPolicy } from '../audit-trail/event.js';
 import type { DeployedNangoFunction, FunctionType, NangoActionFunction, NangoFunctionTemplate, NangoSyncFunction } from './domain.js';
 
 export type RunnableFunctionType = Extract<FunctionType, 'action' | 'sync'>;
@@ -276,7 +276,7 @@ export type GetIntegrationFunction = ApiEndpoint<{
 }>;
 
 export type DeleteIntegrationFunction = ApiEndpoint<{
-    Audit: typeof auditPolicies.functionDeleted;
+    Audit: AuditPolicy<'function', 'deleted', 'environment'>;
     Method: 'DELETE';
     Path: '/api/v1/integrations/:providerConfigKey/functions/:functionName';
     /** TODO: support deleting on-event functions */
@@ -314,7 +314,7 @@ export type GetPublicIntegrationFunction = ApiEndpoint<{
 }>;
 
 export type DeletePublicIntegrationFunction = ApiEndpoint<{
-    Audit: typeof auditPolicies.functionDeleted;
+    Audit: AuditPolicy<'function', 'deleted', 'environment'>;
     Method: 'DELETE';
     Path: '/integrations/:uniqueKey/functions/:name';
     /** TODO: support deleting on-event functions */

--- a/packages/types/lib/functions/api.ts
+++ b/packages/types/lib/functions/api.ts
@@ -1,4 +1,5 @@
 import type { ApiEndpoint, ApiError } from '../api.js';
+import type { auditPolicies } from '../audit-trail/event.js';
 import type { DeployedNangoFunction, FunctionType, NangoActionFunction, NangoFunctionTemplate, NangoSyncFunction } from './domain.js';
 
 export type RunnableFunctionType = Extract<FunctionType, 'action' | 'sync'>;
@@ -275,7 +276,7 @@ export type GetIntegrationFunction = ApiEndpoint<{
 }>;
 
 export type DeleteIntegrationFunction = ApiEndpoint<{
-    Audit: { kind: 'no-audit'; reason: 'TODO: audit coverage pending' };
+    Audit: typeof auditPolicies.functionDeleted;
     Method: 'DELETE';
     Path: '/api/v1/integrations/:providerConfigKey/functions/:functionName';
     /** TODO: support deleting on-event functions */
@@ -313,7 +314,7 @@ export type GetPublicIntegrationFunction = ApiEndpoint<{
 }>;
 
 export type DeletePublicIntegrationFunction = ApiEndpoint<{
-    Audit: { kind: 'no-audit'; reason: 'TODO: audit coverage pending' };
+    Audit: typeof auditPolicies.functionDeleted;
     Method: 'DELETE';
     Path: '/integrations/:uniqueKey/functions/:name';
     /** TODO: support deleting on-event functions */

--- a/packages/types/lib/integration/api.ts
+++ b/packages/types/lib/integration/api.ts
@@ -1,5 +1,5 @@
 import type { ApiEndpoint, ApiError, ApiTimestamps } from '../api.js';
-import type { auditPolicies } from '../audit-trail/event.js';
+import type { AuditPolicy } from '../audit-trail/event.js';
 import type { AuthModes, AuthModeType } from '../auth/api.js';
 import type { NangoSyncConfig } from '../flow/index.js';
 import type { ScriptTypeLiteral } from '../nangoYaml/index.js';
@@ -93,7 +93,7 @@ export type GetPublicIntegration = ApiEndpoint<{
 }>;
 
 export type PatchPublicIntegration = ApiEndpoint<{
-    Audit: typeof auditPolicies.integrationUpdated;
+    Audit: AuditPolicy<'integration', 'updated', 'environment'>;
     Method: 'PATCH';
     Path: '/integrations/:uniqueKey';
     Params: { uniqueKey: string };
@@ -114,7 +114,7 @@ export type PatchPublicIntegration = ApiEndpoint<{
 }>;
 
 export type DeletePublicIntegration = ApiEndpoint<{
-    Audit: typeof auditPolicies.integrationDeleted;
+    Audit: AuditPolicy<'integration', 'deleted', 'environment'>;
     Method: 'DELETE';
     Path: '/integrations/:uniqueKey';
     Params: { uniqueKey: string };
@@ -287,7 +287,7 @@ export type GetIntegration = ApiEndpoint<{
 }>;
 
 export type PatchIntegration = ApiEndpoint<{
-    Audit: typeof auditPolicies.integrationUpdated;
+    Audit: AuditPolicy<'integration', 'updated', 'environment'>;
     Method: 'PATCH';
     Path: '/api/v1/integrations/:providerConfigKey';
     Querystring: { env: string };
@@ -310,7 +310,7 @@ export type PatchIntegration = ApiEndpoint<{
 }>;
 
 export type DeleteIntegration = ApiEndpoint<{
-    Audit: typeof auditPolicies.integrationDeleted;
+    Audit: AuditPolicy<'integration', 'deleted', 'environment'>;
     Method: 'DELETE';
     Path: '/api/v1/integrations/:providerConfigKey';
     Querystring: { env: string };

--- a/packages/types/lib/integration/api.ts
+++ b/packages/types/lib/integration/api.ts
@@ -1,4 +1,5 @@
 import type { ApiEndpoint, ApiError, ApiTimestamps } from '../api.js';
+import type { auditPolicies } from '../audit-trail/event.js';
 import type { AuthModes, AuthModeType } from '../auth/api.js';
 import type { NangoSyncConfig } from '../flow/index.js';
 import type { ScriptTypeLiteral } from '../nangoYaml/index.js';
@@ -92,7 +93,7 @@ export type GetPublicIntegration = ApiEndpoint<{
 }>;
 
 export type PatchPublicIntegration = ApiEndpoint<{
-    Audit: { kind: 'no-audit'; reason: 'TODO: audit coverage pending' };
+    Audit: typeof auditPolicies.integrationUpdated;
     Method: 'PATCH';
     Path: '/integrations/:uniqueKey';
     Params: { uniqueKey: string };
@@ -113,7 +114,7 @@ export type PatchPublicIntegration = ApiEndpoint<{
 }>;
 
 export type DeletePublicIntegration = ApiEndpoint<{
-    Audit: { kind: 'no-audit'; reason: 'TODO: audit coverage pending' };
+    Audit: typeof auditPolicies.integrationDeleted;
     Method: 'DELETE';
     Path: '/integrations/:uniqueKey';
     Params: { uniqueKey: string };
@@ -286,7 +287,7 @@ export type GetIntegration = ApiEndpoint<{
 }>;
 
 export type PatchIntegration = ApiEndpoint<{
-    Audit: { kind: 'no-audit'; reason: 'TODO: audit coverage pending' };
+    Audit: typeof auditPolicies.integrationUpdated;
     Method: 'PATCH';
     Path: '/api/v1/integrations/:providerConfigKey';
     Querystring: { env: string };
@@ -309,7 +310,7 @@ export type PatchIntegration = ApiEndpoint<{
 }>;
 
 export type DeleteIntegration = ApiEndpoint<{
-    Audit: { kind: 'no-audit'; reason: 'TODO: audit coverage pending' };
+    Audit: typeof auditPolicies.integrationDeleted;
     Method: 'DELETE';
     Path: '/api/v1/integrations/:providerConfigKey';
     Querystring: { env: string };

--- a/packages/types/lib/plans/http.api.ts
+++ b/packages/types/lib/plans/http.api.ts
@@ -1,5 +1,5 @@
 import type { ApiEndpoint } from '../api.js';
-import type { auditPolicies } from '../audit-trail/event.js';
+import type { AuditPolicy } from '../audit-trail/event.js';
 import type { ApiBillingUsageMetrics, BillingCustomer, BillingInvoicingDetails, BreakdownDimensions } from '../billing/types.js';
 import type { MetricUsageSummary, UsageMetric } from '../usage/index.js';
 import type { ReplaceInObject } from '../utils.js';
@@ -8,7 +8,7 @@ import type { DBPlan } from './db.js';
 export type ApiPlan = ReplaceInObject<DBPlan, Date, string>;
 
 export type PostPlanExtendTrial = ApiEndpoint<{
-    Audit: typeof auditPolicies.billingTrialExtended;
+    Audit: AuditPolicy<'billing', 'trial_extended', 'account'>;
     Method: 'POST';
     Path: '/api/v1/plans/trial/extension';
     Querystring: { env: string };
@@ -147,7 +147,7 @@ export type GetBillingUsage = ApiEndpoint<{
 }>;
 
 export type PutBillingInvoicingDetails = ApiEndpoint<{
-    Audit: typeof auditPolicies.billingDetailsChanged;
+    Audit: AuditPolicy<'billing', 'details_changed', 'account'>;
     Method: 'PUT';
     Path: '/api/v1/plans/billing/invoicing';
     Querystring: { env: string };
@@ -158,7 +158,7 @@ export type PutBillingInvoicingDetails = ApiEndpoint<{
 }>;
 
 export type PostPlanChange = ApiEndpoint<{
-    Audit: typeof auditPolicies.billingPlanChanged;
+    Audit: AuditPolicy<'billing', 'plan_changed', 'account'>;
     Method: 'POST';
     Path: '/api/v1/plans/change';
     Querystring: { env: string };

--- a/packages/types/lib/plans/http.api.ts
+++ b/packages/types/lib/plans/http.api.ts
@@ -1,4 +1,5 @@
 import type { ApiEndpoint } from '../api.js';
+import type { auditPolicies } from '../audit-trail/event.js';
 import type { ApiBillingUsageMetrics, BillingCustomer, BillingInvoicingDetails, BreakdownDimensions } from '../billing/types.js';
 import type { MetricUsageSummary, UsageMetric } from '../usage/index.js';
 import type { ReplaceInObject } from '../utils.js';
@@ -7,7 +8,7 @@ import type { DBPlan } from './db.js';
 export type ApiPlan = ReplaceInObject<DBPlan, Date, string>;
 
 export type PostPlanExtendTrial = ApiEndpoint<{
-    Audit: { kind: 'no-audit'; reason: 'TODO: audit coverage pending' };
+    Audit: typeof auditPolicies.billingTrialExtended;
     Method: 'POST';
     Path: '/api/v1/plans/trial/extension';
     Querystring: { env: string };
@@ -146,7 +147,7 @@ export type GetBillingUsage = ApiEndpoint<{
 }>;
 
 export type PutBillingInvoicingDetails = ApiEndpoint<{
-    Audit: { kind: 'no-audit'; reason: 'TODO: audit coverage pending' };
+    Audit: typeof auditPolicies.billingDetailsChanged;
     Method: 'PUT';
     Path: '/api/v1/plans/billing/invoicing';
     Querystring: { env: string };
@@ -157,7 +158,7 @@ export type PutBillingInvoicingDetails = ApiEndpoint<{
 }>;
 
 export type PostPlanChange = ApiEndpoint<{
-    Audit: { kind: 'no-audit'; reason: 'TODO: audit coverage pending' };
+    Audit: typeof auditPolicies.billingPlanChanged;
     Method: 'POST';
     Path: '/api/v1/plans/change';
     Querystring: { env: string };

--- a/packages/types/lib/sync/api.ts
+++ b/packages/types/lib/sync/api.ts
@@ -1,5 +1,5 @@
 import type { ApiEndpoint, ApiError } from '../api.js';
-import type { auditPolicies } from '../audit-trail/event.js';
+import type { AuditPolicy } from '../audit-trail/event.js';
 import type { ReportedSyncJobStatus } from './index.js';
 
 export type PostPublicTrigger = ApiEndpoint<{
@@ -25,7 +25,7 @@ export type PostPublicTrigger = ApiEndpoint<{
 }>;
 
 export type PostSyncVariant = ApiEndpoint<{
-    Audit: typeof auditPolicies.syncVariantCreated;
+    Audit: AuditPolicy<'sync', 'variant_created', 'environment'>;
     Method: 'POST';
     Path: '/sync/:name/variant/:variant';
     Body: {
@@ -43,7 +43,7 @@ export type PostSyncVariant = ApiEndpoint<{
 }>;
 
 export type DeleteSyncVariant = ApiEndpoint<{
-    Audit: typeof auditPolicies.syncVariantDeleted;
+    Audit: AuditPolicy<'sync', 'variant_deleted', 'environment'>;
     Method: 'DELETE';
     Path: '/sync/:name/variant/:variant';
     Body: {
@@ -59,7 +59,7 @@ export type DeleteSyncVariant = ApiEndpoint<{
 }>;
 
 export type PutPublicSyncConnectionFrequency = ApiEndpoint<{
-    Audit: typeof auditPolicies.syncFrequencyChanged;
+    Audit: AuditPolicy<'sync', 'frequency_changed', 'environment'>;
     Method: 'PUT';
     Path: '/sync/update-connection-frequency';
     Body: {

--- a/packages/types/lib/sync/api.ts
+++ b/packages/types/lib/sync/api.ts
@@ -1,4 +1,5 @@
 import type { ApiEndpoint, ApiError } from '../api.js';
+import type { auditPolicies } from '../audit-trail/event.js';
 import type { ReportedSyncJobStatus } from './index.js';
 
 export type PostPublicTrigger = ApiEndpoint<{
@@ -24,7 +25,7 @@ export type PostPublicTrigger = ApiEndpoint<{
 }>;
 
 export type PostSyncVariant = ApiEndpoint<{
-    Audit: { kind: 'no-audit'; reason: 'TODO: audit coverage pending' };
+    Audit: typeof auditPolicies.syncVariantCreated;
     Method: 'POST';
     Path: '/sync/:name/variant/:variant';
     Body: {
@@ -42,7 +43,7 @@ export type PostSyncVariant = ApiEndpoint<{
 }>;
 
 export type DeleteSyncVariant = ApiEndpoint<{
-    Audit: { kind: 'no-audit'; reason: 'TODO: audit coverage pending' };
+    Audit: typeof auditPolicies.syncVariantDeleted;
     Method: 'DELETE';
     Path: '/sync/:name/variant/:variant';
     Body: {
@@ -58,7 +59,7 @@ export type DeleteSyncVariant = ApiEndpoint<{
 }>;
 
 export type PutPublicSyncConnectionFrequency = ApiEndpoint<{
-    Audit: { kind: 'no-audit'; reason: 'TODO: audit coverage pending' };
+    Audit: typeof auditPolicies.syncFrequencyChanged;
     Method: 'PUT';
     Path: '/sync/update-connection-frequency';
     Body: {

--- a/packages/types/lib/team/api.ts
+++ b/packages/types/lib/team/api.ts
@@ -31,7 +31,7 @@ export type ApiInvitation = Merge<Omit<DBInvitation, 'token'>, ApiTimestamps>;
 export type ApiTeam = Merge<DBTeam, ApiTimestamps>;
 
 export type PutTeam = ApiEndpoint<{
-    Audit: { kind: 'no-audit'; reason: 'TODO: audit coverage pending' };
+    Audit: typeof auditPolicies.teamUpdated;
     Method: 'PUT';
     Path: '/api/v1/team';
     Querystring: { env: string };
@@ -42,7 +42,7 @@ export type PutTeam = ApiEndpoint<{
 }>;
 
 export type DeleteTeamUser = ApiEndpoint<{
-    Audit: { kind: 'no-audit'; reason: 'TODO: audit coverage pending' };
+    Audit: typeof auditPolicies.memberRemoved;
     Method: 'DELETE';
     Path: '/api/v1/team/users/:id';
     Querystring: { env: string };

--- a/packages/types/lib/team/api.ts
+++ b/packages/types/lib/team/api.ts
@@ -1,5 +1,5 @@
 import type { ApiEndpoint, ApiError, ApiTimestamps } from '../api.js';
-import type { auditPolicies } from '../audit-trail/event.js';
+import type { AuditPolicy } from '../audit-trail/event.js';
 import type { DBInvitation } from '../invitations/db.js';
 import type { ApiUser } from '../user/api.js';
 import type { Role } from '../user/db.js';
@@ -31,7 +31,7 @@ export type ApiInvitation = Merge<Omit<DBInvitation, 'token'>, ApiTimestamps>;
 export type ApiTeam = Merge<DBTeam, ApiTimestamps>;
 
 export type PutTeam = ApiEndpoint<{
-    Audit: typeof auditPolicies.teamUpdated;
+    Audit: AuditPolicy<'team', 'updated', 'account'>;
     Method: 'PUT';
     Path: '/api/v1/team';
     Querystring: { env: string };
@@ -42,7 +42,7 @@ export type PutTeam = ApiEndpoint<{
 }>;
 
 export type DeleteTeamUser = ApiEndpoint<{
-    Audit: typeof auditPolicies.memberRemoved;
+    Audit: AuditPolicy<'member', 'removed', 'account'>;
     Method: 'DELETE';
     Path: '/api/v1/team/users/:id';
     Querystring: { env: string };
@@ -54,7 +54,7 @@ export type DeleteTeamUser = ApiEndpoint<{
 }>;
 
 export type PatchTeamUser = ApiEndpoint<{
-    Audit: typeof auditPolicies.memberRoleChanged;
+    Audit: AuditPolicy<'member', 'role_changed', 'account'>;
     Method: 'PATCH';
     Path: '/api/v1/team/users/:id';
     Querystring: { env: string };

--- a/packages/types/lib/user/api.ts
+++ b/packages/types/lib/user/api.ts
@@ -1,5 +1,5 @@
 import type { ApiEndpoint, Endpoint } from '../api.js';
-import type { auditPolicies } from '../audit-trail/event.js';
+import type { AuditPolicy } from '../audit-trail/event.js';
 import type { Role } from './db.js';
 
 export type GetUser = ApiEndpoint<{
@@ -21,7 +21,7 @@ export type InternalGetUsers = Endpoint<{
 }>;
 
 export type PatchUser = ApiEndpoint<{
-    Audit: typeof auditPolicies.userUpdated;
+    Audit: AuditPolicy<'user', 'updated', 'account'>;
     Method: 'PATCH';
     Path: `/api/v1/user`;
     Body: {
@@ -53,7 +53,7 @@ export type ApiUserWithPermissions = ApiUser & {
 };
 
 export type PutUserPassword = ApiEndpoint<{
-    Audit: typeof auditPolicies.appAuthPasswordChanged;
+    Audit: AuditPolicy<'app_auth', 'password_changed', 'account'>;
     Method: 'PUT';
     Path: `/api/v1/user/password`;
     Body: { oldPassword: string; newPassword: string };

--- a/packages/types/lib/user/api.ts
+++ b/packages/types/lib/user/api.ts
@@ -1,4 +1,5 @@
 import type { ApiEndpoint, Endpoint } from '../api.js';
+import type { auditPolicies } from '../audit-trail/event.js';
 import type { Role } from './db.js';
 
 export type GetUser = ApiEndpoint<{
@@ -20,7 +21,7 @@ export type InternalGetUsers = Endpoint<{
 }>;
 
 export type PatchUser = ApiEndpoint<{
-    Audit: { kind: 'no-audit'; reason: 'TODO: audit coverage pending' };
+    Audit: typeof auditPolicies.userUpdated;
     Method: 'PATCH';
     Path: `/api/v1/user`;
     Body: {
@@ -52,7 +53,7 @@ export type ApiUserWithPermissions = ApiUser & {
 };
 
 export type PutUserPassword = ApiEndpoint<{
-    Audit: { kind: 'no-audit'; reason: 'TODO: audit coverage pending' };
+    Audit: typeof auditPolicies.appAuthPasswordChanged;
     Method: 'PUT';
     Path: `/api/v1/user/password`;
     Body: { oldPassword: string; newPassword: string };


### PR DESCRIPTION
Builds on #6916 (NAN-6269). Base will move to `master` once #6916 merges.

- Wires `auditable()` on the control-plane **mutation** endpoints (connection, integration, function, sync, api_key, member, team, user, environment, billing, app_auth). Each records on response finish with the actor, target, outcome, and per-event metadata. Targets are resolved *before* the handler runs so pre-mutation state (a removed member, an old role) survives moves/soft-deletes.
- **Type-locks declaration to wiring:** `auditable<TEndpoint>()` now derives its audit identity from the endpoint's declared `Audit` policy (from NAN-6269). It is a compile error to wire audit on a `non-auditable` endpoint, or to declare a `resource`/`action` that disagrees with the endpoint type — so the endpoint's policy and the middleware can't drift.
- Flips the 31 covered endpoints from their opt-out placeholder to their real audit identity; the remaining `TODO: audit coverage pending` set shrinks accordingly.

### Metadata never carries secrets
Per-event metadata records field *names* and safe scalars (e.g. `changedFields`, `variableNames`, `fromRole`/`toRole`, `frequency`) — never values — so there is no secret-redaction surface to maintain.

## Test plan
- [x] `tsc -b` clean: types, audit, server, webapp, connect-ui
- [x] Reconciliation verified at type level: non-auditable endpoint / mismatched event fails to compile
- [x] prettier + oxlint clean (pre-existing `any` warnings only)
- [ ] Run `audit.*.integration.test.ts` in CI (Docker/testcontainers unavailable locally) — covers connection.deleted, member.role_changed (+fromRole), connection.updated changedFields, variables (names, no values), webhook URLs, flag-off, denied, cross-account
- [ ] Rebase onto `master` after #6916 merges

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/NangoHQ/nango/pull/6917?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

