### PR TITLE
feat(auth): add account invitation requests during onboarding

### DIFF
--- a/packages/database/lib/migrations/20260727120000_add_account_invitation_requested_at_to_users.cjs
+++ b/packages/database/lib/migrations/20260727120000_add_account_invitation_requested_at_to_users.cjs
@@ -1,0 +1,11 @@
+/**
+ * @param {import('knex').Knex} knex
+ */
+exports.up = async function (knex) {
+    await knex.raw(`ALTER TABLE "_nango_users" ADD COLUMN IF NOT EXISTS "account_invitation_requested_at" timestamptz NULL`);
+};
+
+/**
+ * @param {import('knex').Knex} knex
+ */
+exports.down = async function () {};

--- a/packages/server/lib/controllers/v1/account/index.ts
+++ b/packages/server/lib/controllers/v1/account/index.ts
@@ -8,3 +8,4 @@ export * from './confirmEmail.js';
 export * from './onboarding/getHearAboutUs.js';
 export * from './onboarding/postHearAboutUs.js';
 export * from './onboarding/getAccountDiscovery.js';
+export * from './onboarding/postRequestInvite.js';

--- a/packages/server/lib/controllers/v1/account/onboarding/postRequestInvite.integration.test.ts
+++ b/packages/server/lib/controllers/v1/account/onboarding/postRequestInvite.integration.test.ts
@@ -1,0 +1,113 @@
+import { afterAll, afterEach, beforeAll, describe, expect, it, vi } from 'vitest';
+
+import { accountService, userService } from '@nangohq/shared';
+import { nanoid } from '@nangohq/utils';
+
+import { sendAccountInvitationRequestEmail } from '../../../../helpers/email.js';
+import { runServer } from '../../../../utils/tests.js';
+
+import type * as emailHelpers from '../../../../helpers/email.js';
+
+vi.mock('../../../../helpers/email.js', async (importActual) => ({
+    ...(await importActual<typeof emailHelpers>()),
+    sendAccountInvitationRequestEmail: vi.fn(() => Promise.resolve())
+}));
+
+const signupRoute = '/api/v1/account/signup';
+const signinRoute = '/api/v1/account/signin';
+const accountDiscoveryRoute = '/api/v1/account/onboarding/account-discovery';
+const requestInviteRoute = '/api/v1/account/onboarding/request-invite';
+
+let api: Awaited<ReturnType<typeof runServer>>;
+
+async function createSuggestedAccountSession() {
+    const domain = `${nanoid()}.example.com`;
+    const suggestedAccount = await accountService.createAccount({ name: 'Suggested account', email: `admin@${domain}` });
+    expect(suggestedAccount).not.toBeNull();
+
+    const administrator = await userService.createUser({
+        email: `admin@${domain}`,
+        name: 'Existing administrator',
+        account_id: suggestedAccount!.id,
+        email_verified: true,
+        role: 'administrator'
+    });
+    expect(administrator).not.toBeNull();
+
+    const email = `new-user@${domain}`;
+    const signupRes = await api.fetch(signupRoute, {
+        method: 'POST',
+        body: { email, name: 'New user', password: 'aZ1-foobar!?', foundUs: 'tests' }
+    });
+    expect(signupRes.res.status).toBe(200);
+
+    const requester = await userService.getUserByEmail(email);
+    expect(requester).toBeTruthy();
+    await userService.verifyUserEmail(requester!.id, { markAccountDiscoveryPending: true });
+
+    const signinRes = await api.fetch(signinRoute, { method: 'POST', body: { email, password: 'aZ1-foobar!?' } });
+    expect(signinRes.res.status).toBe(200);
+    expect(signinRes.json).toMatchObject({ url: '/onboarding/account-discovery' });
+    const session = signinRes.res.headers.getSetCookie()[0]?.split(';')[0];
+    expect(session).toBeTruthy();
+
+    const discoveryRes = await api.fetch(accountDiscoveryRoute, { method: 'GET', session: session! });
+    expect(discoveryRes.res.status).toBe(200);
+
+    return { administrator: administrator!, requester: (await userService.getUserByEmail(email))!, session: session!, suggestedAccount: suggestedAccount! };
+}
+
+describe(`POST ${requestInviteRoute}`, () => {
+    beforeAll(async () => {
+        api = await runServer();
+    });
+
+    afterAll(() => {
+        api.server.close();
+    });
+
+    afterEach(() => {
+        vi.mocked(sendAccountInvitationRequestEmail).mockReset();
+        vi.mocked(sendAccountInvitationRequestEmail).mockResolvedValue(undefined);
+    });
+
+    it('emails verified active administrators once and permanently consumes the request', async () => {
+        const { administrator, requester, session, suggestedAccount } = await createSuggestedAccountSession();
+
+        const first = await api.fetch(requestInviteRoute, { method: 'POST', session });
+        const second = await api.fetch(requestInviteRoute, { method: 'POST', session });
+
+        expect(first.res.status).toBe(200);
+        expect(second.res.status).toBe(404);
+        expect(sendAccountInvitationRequestEmail).toHaveBeenCalledTimes(1);
+        expect(sendAccountInvitationRequestEmail).toHaveBeenCalledWith({
+            email: administrator.email,
+            account: expect.objectContaining({ id: suggestedAccount.id, name: suggestedAccount.name }),
+            requester: expect.objectContaining({ id: requester.id, name: requester.name, email: requester.email })
+        });
+
+        const updatedRequester = await userService.getUserById(requester.id);
+        expect(updatedRequester?.account_invitation_requested_at).not.toBeNull();
+    });
+
+    it('allows a retry when all invitation request emails fail', async () => {
+        const { requester, session } = await createSuggestedAccountSession();
+        vi.mocked(sendAccountInvitationRequestEmail).mockRejectedValueOnce(new Error('email provider down'));
+
+        const failed = await api.fetch(requestInviteRoute, { method: 'POST', session });
+
+        expect(failed.res.status).toBe(503);
+        expect(failed.json).toEqual({ error: { code: 'email_delivery_failed' } });
+        // Session marker should not be set when mail delivery fails completely.
+        expect((await userService.getUserById(requester.id))?.account_invitation_requested_at).toBeNull();
+
+        const retry = await api.fetch(requestInviteRoute, { method: 'POST', session });
+        expect(retry.res.status).toBe(200);
+
+        const duplicate = await api.fetch(requestInviteRoute, { method: 'POST', session });
+        expect(duplicate.res.status).toBe(404);
+
+        expect(sendAccountInvitationRequestEmail).toHaveBeenCalledTimes(2);
+        expect((await userService.getUserById(requester.id))?.account_invitation_requested_at).not.toBeNull();
+    });
+});

--- a/packages/server/lib/controllers/v1/account/onboarding/postRequestInvite.ts
+++ b/packages/server/lib/controllers/v1/account/onboarding/postRequestInvite.ts
@@ -1,0 +1,67 @@
+import { getLogger, requireEmptyBody, requireEmptyQuery, zodErrorToHTTP } from '@nangohq/utils';
+
+import { requestAccountInvitation } from '../../../../services/accountInvitationRequest.service.js';
+import { asyncWrapper } from '../../../../utils/asyncWrapper.js';
+import { clearPendingAccountDiscovery, getPendingAccountDiscovery } from './accountDiscoverySession.js';
+
+import type { AccountInvitationRequestError } from '../../../../services/accountInvitationRequest.service.js';
+import type { PostOnboardingRequestInvite } from '@nangohq/types';
+import type { Response } from 'express';
+
+const logger = getLogger('Server.PostOnboardingRequestInvite');
+
+const sendRequestInviteError = (res: Response<PostOnboardingRequestInvite['Reply']>, error: AccountInvitationRequestError) => {
+    logger.error(error.message, error.context);
+
+    switch (error.code) {
+        case 'email_delivery_failed':
+            res.status(503).send({ error: { code: 'email_delivery_failed' } });
+            break;
+
+        case 'account_not_found':
+        case 'no_administrators':
+            res.status(404).send({ error: { code: 'not_found' } });
+            break;
+
+        default:
+            ((exhaustiveCheck: never) => {
+                throw new Error(`Unhandled request account invitation error code: ${exhaustiveCheck}`);
+            })(error.code);
+    }
+};
+
+export const postOnboardingRequestInvite = asyncWrapper<PostOnboardingRequestInvite>(async (req, res) => {
+    const emptyQuery = requireEmptyQuery(req, { withEnv: false });
+    if (emptyQuery) {
+        res.status(400).send({ error: { code: 'invalid_query_params', errors: zodErrorToHTTP(emptyQuery.error) } });
+        return;
+    }
+
+    const emptyBody = requireEmptyBody(req);
+    if (emptyBody) {
+        res.status(400).send({ error: { code: 'invalid_body', errors: zodErrorToHTTP(emptyBody.error) } });
+        return;
+    }
+
+    const { user } = res.locals;
+    const discovery = await getPendingAccountDiscovery(req, user.id);
+    if (!discovery?.recommendation || !user.email_verified) {
+        logger.error("Pending account discovery marker not found in session or email not verified, can't send invite requests.", {
+            emailVerified: user.email_verified
+        });
+        res.status(404).send({ error: { code: 'not_found' } });
+        return;
+    }
+
+    const result = await requestAccountInvitation({ user, accountId: discovery.recommendation.accountId });
+    if (result.isErr()) {
+        sendRequestInviteError(res, result.error);
+        return;
+    }
+
+    await clearPendingAccountDiscovery(req).catch((err) =>
+        logger.warning('Failed to clear account discovery onboarding session', { error: err, userId: user.id })
+    );
+
+    res.status(200).send({ data: { success: true } });
+});

--- a/packages/server/lib/helpers/email.ts
+++ b/packages/server/lib/helpers/email.ts
@@ -5,6 +5,10 @@ import { basePublicUrl } from '@nangohq/utils';
 
 import type { DBInvitation, DBTeam, DBUser } from '@nangohq/types';
 
+export function sanitizeEmailSubject(subject: string): string {
+    return subject.replace(/[\r\n]+/g, ' ');
+}
+
 export async function sendVerificationEmail(email: string, name: string, token: string) {
     const emailClient = EmailClient.getInstance();
     await emailClient.send(
@@ -61,7 +65,7 @@ export async function sendInviteEmail({
 
     await emailClient.send(
         email,
-        `You're Invited! Join "${account.name}" on Nango`,
+        sanitizeEmailSubject(`You're Invited! Join "${account.name}" on Nango`),
         `<p>Hi,</p>
 
 <p>${he.encode(user.name)} invites you to join "${he.encode(account.name)}" on Nango.</p>
@@ -69,6 +73,31 @@ export async function sendInviteEmail({
 <p>${callToAction}</p>
 
 <p>Questions or issues? We are happy to help on the <a href="https://nango.dev/slack">Slack community</a>!</p>
+
+<p>Best,<br>
+Team Nango</p>
+            `
+    );
+}
+
+export async function sendAccountInvitationRequestEmail({
+    email,
+    account,
+    requester
+}: {
+    email: string;
+    account: Pick<DBTeam, 'name'>;
+    requester: Pick<DBUser, 'name' | 'email'>;
+}) {
+    const emailClient = EmailClient.getInstance();
+    await emailClient.send(
+        email,
+        sanitizeEmailSubject(`${requester.name} wants to join "${account.name}" on Nango`),
+        `<p>Hi,</p>
+
+<p><strong>${he.encode(requester.name)}</strong> (${he.encode(requester.email)}) has requested to join <strong>${he.encode(account.name)}</strong> on Nango.</p>
+
+<p>Their email address has been verified. To invite them, go to <a href="${basePublicUrl}/team-settings">Team Settings</a>.</p>
 
 <p>Best,<br>
 Team Nango</p>

--- a/packages/server/lib/helpers/email.unit.test.ts
+++ b/packages/server/lib/helpers/email.unit.test.ts
@@ -1,0 +1,9 @@
+import { describe, expect, it } from 'vitest';
+
+import { sanitizeEmailSubject } from './email.js';
+
+describe('sanitizeEmailSubject', () => {
+    it('removes carriage returns and line feeds from email subject values', () => {
+        expect(sanitizeEmailSubject('Requester\r\nBcc: attacker@example.com\nAccount')).toBe('Requester Bcc: attacker@example.com Account');
+    });
+});

--- a/packages/server/lib/middleware/access.middleware.ts
+++ b/packages/server/lib/middleware/access.middleware.ts
@@ -41,6 +41,7 @@ const ignoreEnvPaths = [
     '/api/v1/invite/:id',
     '/api/v1/account/onboarding/hear-about-us',
     '/api/v1/account/onboarding/account-discovery',
+    '/api/v1/account/onboarding/request-invite',
     '/api/v1/account/mfa',
     '/api/v1/account/mfa/enroll',
     '/api/v1/account/mfa/activate',

--- a/packages/server/lib/routes.private.ts
+++ b/packages/server/lib/routes.private.ts
@@ -19,6 +19,7 @@ import {
     getOnboardingAccountDiscovery,
     getOnboardingHearAboutUs,
     postOnboardingHearAboutUs,
+    postOnboardingRequestInvite,
     resendVerificationEmailByEmail,
     resendVerificationEmailByUuid,
     signin,
@@ -249,6 +250,7 @@ web.route('/meta').get(webAuth, getMeta);
 web.route('/account/onboarding/hear-about-us').get(webAuth, getOnboardingHearAboutUs);
 web.route('/account/onboarding/hear-about-us').post(webAuth, postOnboardingHearAboutUs);
 web.route('/account/onboarding/account-discovery').get(webAuth, getOnboardingAccountDiscovery);
+web.route('/account/onboarding/request-invite').post(webAuth, postOnboardingRequestInvite);
 web.route('/account/mfa').get(webAuth, getMFAStatus).delete(webAuth, auditMfaDisabled, deleteMFA);
 web.route('/account/mfa/enroll').post(webAuth, auditMfaEnrolled, postMFAEnrollment);
 web.route('/account/mfa/activate').post(webAuth, auditMfaEnabled, postMFAActivation);

--- a/packages/server/lib/services/accountInvitationRequest.service.ts
+++ b/packages/server/lib/services/accountInvitationRequest.service.ts
@@ -1,0 +1,81 @@
+import db from '@nangohq/database';
+import { accountService, userService } from '@nangohq/shared';
+import { Err, getLogger, Ok } from '@nangohq/utils';
+
+import { sendAccountInvitationRequestEmail } from '../helpers/email.js';
+
+import type { DBUser } from '@nangohq/types';
+import type { Result } from '@nangohq/utils';
+
+const logger = getLogger('Server.AccountInvitationRequest');
+
+export type AccountInvitationRequestErrorCode = 'account_not_found' | 'no_administrators' | 'email_delivery_failed';
+
+export class AccountInvitationRequestError extends Error {
+    public code: AccountInvitationRequestErrorCode;
+    public context?: Record<string, unknown>;
+    constructor({ code, message, context }: { code: AccountInvitationRequestErrorCode; message: string; context?: Record<string, unknown> }) {
+        super(message);
+        this.code = code;
+        this.context = context || {};
+    }
+}
+
+/**
+ * Asks the administrators of an account to invite a user.
+ *
+ * At most one request is ever sent per user: the "invitation requested" slot is claimed with an atomic
+ * conditional update, so a repeat call is a no-op instead of a second round of emails.
+ */
+export async function requestAccountInvitation({ user, accountId }: { user: DBUser; accountId: number }): Promise<Result<void, AccountInvitationRequestError>> {
+    const account = await accountService.getAccountById(db.knex, accountId);
+    if (!account) {
+        return Err(new AccountInvitationRequestError({ code: 'account_not_found', message: 'Recommended account not found.', context: { accountId } }));
+    }
+
+    const administrators = await userService.getVerifiedActiveAdministratorsByAccountId(account.id);
+    if (administrators.length === 0) {
+        return Err(
+            new AccountInvitationRequestError({
+                code: 'no_administrators',
+                message: 'No administrators found for recommended account.',
+                context: { accountId }
+            })
+        );
+    }
+
+    const requestedAt = await userService.markAccountInvitationRequestSent(user.id);
+    if (!requestedAt) {
+        // Already requested previously, nothing to re-send.
+        logger.info('Account invitation already requested, skipping emails', { requesterId: user.id, accountId: account.id });
+        return Ok(undefined);
+    }
+
+    const emailResults = await Promise.allSettled(
+        administrators.map((administrator) => sendAccountInvitationRequestEmail({ email: administrator.email, account, requester: user }))
+    );
+
+    const failedEmailCount = emailResults.filter((result) => result.status === 'rejected').length;
+    if (failedEmailCount === emailResults.length) {
+        const unmarked = await userService.unmarkAccountInvitationRequest(user.id, requestedAt);
+        return Err(
+            new AccountInvitationRequestError({
+                code: 'email_delivery_failed',
+                message: 'Failed to send all account invitation request emails',
+                // `unmarked` tells whether the claim was released, i.e. whether the user can retry.
+                context: { accountId: account.id, requesterId: user.id, failedEmailCount, unmarked }
+            })
+        );
+    }
+
+    if (failedEmailCount > 0) {
+        logger.warning('Failed to send some account invitation request emails', {
+            totalEmailsCount: emailResults.length,
+            failedEmailCount,
+            requesterId: user.id,
+            accountId: account.id
+        });
+    }
+
+    return Ok(undefined);
+}

--- a/packages/shared/lib/services/user.service.ts
+++ b/packages/shared/lib/services/user.service.ts
@@ -77,6 +77,30 @@ class UserService {
         return result;
     }
 
+    async getVerifiedActiveAdministratorsByAccountId(accountId: number): Promise<DBUser[]> {
+        return db.knex.select('*').from<DBUser>('_nango_users').where({ account_id: accountId, suspended: false, email_verified: true, role: 'administrator' });
+    }
+
+    async markAccountInvitationRequestSent(userId: number): Promise<Date | null> {
+        const [user] = await db
+            .knex<DBUser>('_nango_users')
+            .where({ id: userId })
+            .whereNull('account_invitation_requested_at')
+            .update({ account_invitation_requested_at: new Date(), updated_at: new Date() })
+            .returning('account_invitation_requested_at');
+
+        return user?.account_invitation_requested_at ?? null;
+    }
+
+    async unmarkAccountInvitationRequest(userId: number, requestedAt: Date): Promise<boolean> {
+        const updated = await db
+            .knex<DBUser>('_nango_users')
+            .where({ id: userId, account_invitation_requested_at: requestedAt })
+            .update({ account_invitation_requested_at: null, updated_at: new Date() });
+
+        return updated === 1;
+    }
+
     async countUsers(accountId: number): Promise<number> {
         const result = await db.knex
             .select(db.knex.raw('COUNT(id) as total'))

--- a/packages/types/lib/account/api.ts
+++ b/packages/types/lib/account/api.ts
@@ -223,6 +223,18 @@ export type GetOnboardingAccountDiscovery = ApiEndpoint<{
     };
 }>;
 
+export type PostOnboardingRequestInvite = ApiEndpoint<{
+    Audit: { kind: 'no-audit'; reason: 'non-auditable' };
+    Method: 'POST';
+    Path: '/api/v1/account/onboarding/request-invite';
+    Body: never;
+    Error: ApiError<'not_found'> | ApiError<'email_delivery_failed'>;
+    Success: {
+        data: {
+            success: true;
+        };
+    };
+}>;
 export type PostOnboardingHearAboutUs = ApiEndpoint<{
     Audit: { kind: 'no-audit'; reason: 'non-auditable' };
     Method: 'POST';

--- a/packages/types/lib/api.endpoints.ts
+++ b/packages/types/lib/api.endpoints.ts
@@ -9,6 +9,7 @@ import type {
     PostLogout,
     PostManagedEmailVerification,
     PostManagedSignup,
+    PostOnboardingRequestInvite,
     PostSignin,
     PostSignup,
     PutResetPassword
@@ -240,6 +241,7 @@ export type PrivateApiEndpoints =
     | GetManagedCallback
     | GetManagedEmailVerification
     | GetOnboardingAccountDiscovery
+    | PostOnboardingRequestInvite
     | PatchFlowDisable
     | PatchFlowEnable
     | PatchFlowFrequency

--- a/packages/types/lib/user/db.ts
+++ b/packages/types/lib/user/db.ts
@@ -18,5 +18,6 @@ export interface DBUser extends Timestamps {
     uuid: string;
     getting_started_closed: boolean;
     account_discovery_pending: boolean;
+    account_invitation_requested_at: Date | null;
     role: Role;
 }

--- a/packages/webapp/src/hooks/useAuth.tsx
+++ b/packages/webapp/src/hooks/useAuth.tsx
@@ -11,6 +11,7 @@ import type {
     PostManagedEmailVerification,
     PostMFALoginVerification,
     PostOnboardingHearAboutUs,
+    PostOnboardingRequestInvite,
     PostSignin,
     PostSignup,
     PutResetPassword,
@@ -343,6 +344,21 @@ export function useOnboardingAccountDiscovery() {
 
             if (res.status === 200) {
                 return (await res.json()) as GetOnboardingAccountDiscovery['Success'];
+            }
+
+            const json = (await res.json()) as Record<string, unknown>;
+            throw new APIError({ res, json });
+        }
+    });
+}
+
+export function usePostOnboardingRequestInvite() {
+    return useMutation<PostOnboardingRequestInvite['Success'], APIError>({
+        mutationFn: async () => {
+            const res = await apiFetch('/api/v1/account/onboarding/request-invite', { method: 'POST' });
+
+            if (res.status === 200) {
+                return (await res.json()) as PostOnboardingRequestInvite['Success'];
             }
 
             const json = (await res.json()) as Record<string, unknown>;

--- a/packages/webapp/src/pages/Onboarding/AccountDiscovery.tsx
+++ b/packages/webapp/src/pages/Onboarding/AccountDiscovery.tsx
@@ -1,18 +1,35 @@
-import { useEffect } from 'react';
+import { useEffect, useState } from 'react';
 import { useNavigate } from 'react-router-dom';
 
 import { Button } from '@nangohq/design-system';
 
+import { Alert, AlertDescription } from '@/components/ui/Alert';
 import { Separator } from '@/components/ui/Separator';
 import { Skeleton } from '@/components/ui/Skeleton';
-import { useOnboardingAccountDiscovery } from '@/hooks/useAuth';
+import { useOnboardingAccountDiscovery, usePostOnboardingRequestInvite } from '@/hooks/useAuth';
 import DefaultLayout from '@/layout/DefaultLayout';
+import { track } from '@/utils/analytics';
+import { APIError } from '@/utils/api';
 
 const hearAboutUsRoute = '/onboarding/hear-about-us';
 
 export const AccountDiscovery: React.FC = () => {
     const navigate = useNavigate();
     const { data, isLoading, error } = useOnboardingAccountDiscovery();
+    const { mutateAsync: requestInvite, isPending: isRequestingInvite } = usePostOnboardingRequestInvite();
+    const [requestError, setRequestError] = useState<'retry' | 'contact_admin' | null>(null);
+    const [requestSent, setRequestSent] = useState(false);
+
+    const requestToJoin = async () => {
+        setRequestError(null);
+        try {
+            await requestInvite();
+            track('web:account_join_request:submitted', {});
+            setRequestSent(true);
+        } catch (err) {
+            setRequestError(err instanceof APIError && err.json.error?.code === 'email_delivery_failed' ? 'retry' : 'contact_admin');
+        }
+    };
 
     useEffect(() => {
         if (error) {
@@ -27,32 +44,80 @@ export const AccountDiscovery: React.FC = () => {
     }, [data, error, navigate]);
 
     if (isLoading || !data?.data.suggestedAccountName) {
-        return (
-            <DefaultLayout>
-                <div className="mx-auto mt-16 flex max-w-xl flex-col gap-4">
-                    <Skeleton className="h-8 w-3/4" />
-                    <Skeleton className="h-5 w-full" />
-                    <Skeleton className="h-10 w-64" />
-                </div>
-            </DefaultLayout>
-        );
+        return <AccountDiscoveryLoading />;
     }
 
     return (
         <DefaultLayout className="gap-10">
             <h1 className="text-center text-text-strong text-title-group">Your team is already on Nango!</h1>
-            <div className="flex flex-col items-center gap-5">
-                <p className="text-center text-text-muted text-body-base">
-                    <strong className="text-text-strong">{data.data.suggestedAccountName}</strong>
-                </p>
-                <Button variant="outline" size="lg">
-                    Request to join
-                </Button>
-            </div>
-            <Separator />
-            <span className="cursor-pointer text-center text-text-strong underline hover:text-text-secondary" onClick={() => navigate(hearAboutUsRoute)}>
-                Continue with my new account
-            </span>
+            {requestSent ? (
+                <InvitationRequestSent onExploreTemporaryAccount={() => navigate(hearAboutUsRoute)} />
+            ) : (
+                <InvitationRequestPrompt
+                    suggestedAccountName={data.data.suggestedAccountName}
+                    requestError={requestError}
+                    isRequestingInvite={isRequestingInvite}
+                    onRequest={requestToJoin}
+                    onContinueWithNewAccount={() => navigate(hearAboutUsRoute)}
+                />
+            )}
         </DefaultLayout>
     );
 };
+
+const AccountDiscoveryLoading: React.FC = () => (
+    <DefaultLayout>
+        <div className="mx-auto mt-16 flex max-w-xl flex-col gap-4">
+            <Skeleton className="h-8 w-3/4" />
+            <Skeleton className="h-5 w-full" />
+            <Skeleton className="h-10 w-64" />
+        </div>
+    </DefaultLayout>
+);
+
+const InvitationRequestPrompt: React.FC<{
+    suggestedAccountName: string;
+    requestError: 'retry' | 'contact_admin' | null;
+    isRequestingInvite: boolean;
+    onRequest: () => Promise<void>;
+    onContinueWithNewAccount: () => void;
+}> = ({ suggestedAccountName, requestError, isRequestingInvite, onRequest, onContinueWithNewAccount }) => (
+    <div className="flex flex-col items-center gap-5">
+        <p className="text-center text-text-muted text-body-base">
+            <strong className="text-text-strong">{suggestedAccountName}</strong>
+        </p>
+        {requestError === 'retry' && (
+            <Alert variant="error">
+                <AlertDescription>We couldn&apos;t send your request. Please try again.</AlertDescription>
+            </Alert>
+        )}
+        {requestError === 'contact_admin' && (
+            <Alert variant="error">
+                <AlertDescription>Please ask a team administrator to invite you directly.</AlertDescription>
+            </Alert>
+        )}
+        <Button variant="outline" size="lg" loading={isRequestingInvite} onClick={() => void onRequest()}>
+            Request to join
+        </Button>
+        <Separator />
+        <IntoAccountLink onClick={onContinueWithNewAccount}>Continue with my new account</IntoAccountLink>
+    </div>
+);
+
+const InvitationRequestSent: React.FC<{ onExploreTemporaryAccount: () => void }> = ({ onExploreTemporaryAccount }) => (
+    <div className="flex flex-col items-center gap-5">
+        <Alert variant="success">
+            <AlertDescription className="flex-col items-center gap-0 text-center">
+                <span>Your invitation request has been sent!</span>
+                <span>You can explore Nango on your temporary account in the meantime.</span>
+            </AlertDescription>
+        </Alert>
+        <IntoAccountLink onClick={onExploreTemporaryAccount}>Explore with my temporary account</IntoAccountLink>
+    </div>
+);
+
+const IntoAccountLink: React.FC<{ children: React.ReactNode; onClick: () => void }> = ({ children, onClick }) => (
+    <span className="cursor-pointer text-center text-text-strong underline hover:text-text-secondary" onClick={onClick}>
+        {children}
+    </span>
+);

--- a/packages/webapp/src/utils/analyticsEvents.ts
+++ b/packages/webapp/src/utils/analyticsEvents.ts
@@ -57,6 +57,7 @@ export interface AnalyticsEvents {
     // Account & onboarding
     'web:account_signup': { user_id: number; accountId: number };
     'web:signup:hear_about': { source: PostOnboardingHearAboutUs['Body']['source'] };
+    'web:account_join_request:submitted': Record<string, never>;
 
     // Two-factor authentication
     'web:2fa:enable_started': Record<string, never>;


### PR DESCRIPTION
Add a one-shot invitation-request flow for users shown a same-domain account recommendation. The server uses the short-lived discovery marker (embedded in the session) to retrieve the recommended account id, records the request atomically, and notifies active team administrators with the requester's verified details.

Clear the short-lived discovery marker once the request is consumed, while retaining the user-level marker to prevent retries. Surface request failures in onboarding so users can ask their team administrator for a direct invite.




<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/NangoHQ/nango/pull/6918?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

