### PR TITLE
fix(mcp-generic): omit empty client_secret on token refresh

### DIFF
--- a/packages/shared/lib/clients/mcpGeneric.client.ts
+++ b/packages/shared/lib/clients/mcpGeneric.client.ts
@@ -1,14 +1,12 @@
-import { discoverAuthorizationServerMetadata, discoverOAuthProtectedResourceMetadata } from '@modelcontextprotocol/sdk/client/auth.js';
+import { discoverAuthorizationServerMetadata, discoverOAuthProtectedResourceMetadata, refreshAuthorization } from '@modelcontextprotocol/sdk/client/auth.js';
 import { OAuthClientInformationSchema, OAuthMetadataSchema } from '@modelcontextprotocol/sdk/shared/auth.js';
-import { AuthorizationCode } from 'simple-oauth2';
 
 import { NangoError } from '../utils/error.js';
 
 import type { ServiceResponse } from '../models/Generic.js';
-import type { OAuthClientInformation, OAuthMetadata, OAuthProtectedResourceMetadata } from '@modelcontextprotocol/sdk/shared/auth.js';
+import type { OAuthClientInformation, OAuthMetadata, OAuthProtectedResourceMetadata, OAuthTokens } from '@modelcontextprotocol/sdk/shared/auth.js';
 import type { LogContext, LogContextStateless } from '@nangohq/logs';
 import type { DBConnectionDecrypted, OAuth2Credentials } from '@nangohq/types';
-import type { AccessToken } from 'simple-oauth2';
 
 /**
  * Validates MCP server URL to prevent SSRF attacks
@@ -245,37 +243,18 @@ export async function refreshMcpGenericCredentials({
         };
     }
 
-    // Use simple-oauth2 with the stored metadata (since MCP tokens are standard OAuth2)
-    const oauth2ClientConfig = {
-        client: {
-            id: clientInformation.client_id,
-            secret: '' // MCP uses PKCE, no client secret needed
-        },
-        auth: {
-            tokenHost: new URL(metadata.token_endpoint).origin,
-            tokenPath: new URL(metadata.token_endpoint).pathname
-        },
-        http: {
-            headers: { 'User-Agent': 'Nango' }
-        },
-        options: {
-            authorizationMethod: 'body' as const,
-            bodyFormat: 'form' as const
-        }
-    };
+    // Use the MCP SDK refresh path (same as the initial code exchange) so public clients
+    // omit client_secret entirely. simple-oauth2 always sends client_secret= when using
+    // body auth, which strict token endpoints (e.g. Resend) reject with 400.
+    const resource = resourceUrl ? new URL(resourceUrl) : undefined;
 
-    const client = new AuthorizationCode(oauth2ClientConfig);
-
-    const oldAccessToken = client.createToken({
-        access_token: currentCredentials.access_token,
-        refresh_token: currentCredentials.refresh_token,
-        expires_at: currentCredentials.expires_at
-    });
-
-    let rawNewAccessToken: AccessToken;
+    let tokens: OAuthTokens;
     try {
-        rawNewAccessToken = await oldAccessToken.refresh({
-            ...(resourceUrl && { resource: resourceUrl })
+        tokens = await refreshAuthorization(mcpServerUrl, {
+            metadata,
+            clientInformation,
+            refreshToken: currentCredentials.refresh_token,
+            ...(resource && { resource })
         });
     } catch (err) {
         const errorMessage = err instanceof Error ? err.message : String(err);
@@ -288,10 +267,10 @@ export async function refreshMcpGenericCredentials({
 
     const refreshedCredentials: OAuth2Credentials = {
         type: 'OAUTH2',
-        access_token: rawNewAccessToken.token['access_token'] as string,
-        refresh_token: (rawNewAccessToken.token['refresh_token'] as string) || currentCredentials.refresh_token,
-        expires_at: rawNewAccessToken.token['expires_at'] ? new Date(rawNewAccessToken.token['expires_at'] as string) : undefined,
-        raw: rawNewAccessToken.token
+        access_token: tokens.access_token,
+        refresh_token: tokens.refresh_token || currentCredentials.refresh_token,
+        expires_at: tokens.expires_in ? new Date(Date.now() + tokens.expires_in * 1000) : undefined,
+        raw: tokens
     };
 
     return { success: true, error: null, response: refreshedCredentials };

--- a/packages/shared/lib/clients/mcpGeneric.client.ts
+++ b/packages/shared/lib/clients/mcpGeneric.client.ts
@@ -243,10 +243,19 @@ export async function refreshMcpGenericCredentials({
         };
     }
 
-    // Use the MCP SDK refresh path (same as the initial code exchange) so public clients
-    // omit client_secret entirely. simple-oauth2 always sends client_secret= when using
-    // body auth, which strict token endpoints (e.g. Resend) reject with 400.
-    const resource = resourceUrl ? new URL(resourceUrl) : undefined;
+    let resource: URL | undefined;
+    if (resourceUrl) {
+        try {
+            resource = new URL(resourceUrl);
+        } catch (err) {
+            void logCtx.error('Failed to parse oauth_resource_url', { error: String(err), resourceUrl });
+            return {
+                success: false,
+                error: new NangoError('invalid_oauth_metadata', { error: String(err) }),
+                response: null
+            };
+        }
+    }
 
     let tokens: OAuthTokens;
     try {

--- a/packages/shared/lib/clients/mcpGeneric.client.unit.test.ts
+++ b/packages/shared/lib/clients/mcpGeneric.client.unit.test.ts
@@ -1,8 +1,72 @@
-import { describe, expect, it } from 'vitest';
+import { afterEach, describe, expect, it, vi } from 'vitest';
 
-import { chooseMcpClientIdMethod } from './mcpGeneric.client.js';
+import { chooseMcpClientIdMethod, refreshMcpGenericCredentials } from './mcpGeneric.client.js';
+
+import type { LogContextStateless } from '@nangohq/logs';
+import type { DBConnectionDecrypted, OAuth2Credentials } from '@nangohq/types';
 
 const cimdUrl = 'https://api.example.com/oauth/client-metadata/env-uuid/my-integration';
+
+const oauthMetadata = {
+    issuer: 'https://auth.example.com',
+    authorization_endpoint: 'https://auth.example.com/authorize',
+    token_endpoint: 'https://auth.example.com/oauth/token',
+    response_types_supported: ['code'],
+    token_endpoint_auth_methods_supported: ['none']
+};
+
+const publicClientInfo = {
+    client_id: 'public-client-id',
+    token_endpoint_auth_method: 'none'
+};
+
+function mockLogCtx(): LogContextStateless {
+    return { error: vi.fn(), info: vi.fn(), warn: vi.fn(), debug: vi.fn() } as unknown as LogContextStateless;
+}
+
+function mcpGenericConnection(overrides?: {
+    clientInfo?: Record<string, unknown>;
+    credentials?: Partial<OAuth2Credentials>;
+    resourceUrl?: string;
+}): DBConnectionDecrypted {
+    return {
+        connection_id: 'a',
+        created_at: new Date(),
+        end_user_id: null,
+        environment_id: 1,
+        provider_config_key: 'mcp-generic',
+        updated_at: new Date(),
+        webhook_url_override: null,
+        config_id: 1,
+        credentials_iv: null,
+        credentials_tag: null,
+        deleted: false,
+        deleted_at: null,
+        id: -1,
+        last_fetched_at: null,
+        metadata: null,
+        credentials_expires_at: null,
+        last_refresh_failure: null,
+        last_refresh_success: null,
+        refresh_attempts: null,
+        refresh_exhausted: false,
+        tags: {},
+        connection_config: {
+            oauth_metadata: JSON.stringify(oauthMetadata),
+            oauth_client_info: JSON.stringify(overrides?.clientInfo ?? publicClientInfo),
+            oauth_resource_url: overrides?.resourceUrl ?? 'https://mcp.example.com/',
+            mcp_server_url: 'https://mcp.example.com/mcp'
+        },
+        credentials: {
+            type: 'OAUTH2',
+            access_token: 'old-access',
+            refresh_token: 'refresh-token',
+            expires_at: new Date(Date.now() - 1000),
+            raw: {},
+            ...overrides?.credentials
+        }
+    };
+}
 
 describe('chooseMcpClientIdMethod', () => {
     it('prefers CIMD when the server advertises support and a document url is available', () => {
@@ -34,5 +98,83 @@ describe('chooseMcpClientIdMethod', () => {
     it('falls back to static when neither CIMD nor DCR is available', () => {
         expect(chooseMcpClientIdMethod({}, null)).toBe('static');
         expect(chooseMcpClientIdMethod({ client_id_metadata_document_supported: true }, null)).toBe('static');
+    });
+});
+
+describe('refreshMcpGenericCredentials', () => {
+    afterEach(() => {
+        vi.unstubAllGlobals();
+    });
+
+    it('refreshes without sending client_secret for public clients', async () => {
+        const fetchMock = vi.fn().mockResolvedValue(
+            new Response(JSON.stringify({ access_token: 'new-access', token_type: 'Bearer', expires_in: 3600, refresh_token: 'new-refresh' }), {
+                status: 200,
+                headers: { 'content-type': 'application/json' }
+            })
+        );
+        vi.stubGlobal('fetch', fetchMock);
+
+        const result = await refreshMcpGenericCredentials({
+            connection: mcpGenericConnection(),
+            logCtx: mockLogCtx()
+        });
+
+        expect(result.success).toBe(true);
+        expect(result.response?.access_token).toBe('new-access');
+        expect(result.response?.refresh_token).toBe('new-refresh');
+        expect(result.response?.expires_at).toBeInstanceOf(Date);
+
+        expect(fetchMock).toHaveBeenCalledOnce();
+        const [url, init] = fetchMock.mock.calls[0]!;
+        expect(String(url)).toBe('https://auth.example.com/oauth/token');
+        expect(init?.method).toBe('POST');
+
+        const body = new URLSearchParams(init?.body as string);
+        expect(body.get('grant_type')).toBe('refresh_token');
+        expect(body.get('refresh_token')).toBe('refresh-token');
+        expect(body.get('client_id')).toBe('public-client-id');
+        expect(body.get('resource')).toBe('https://mcp.example.com/');
+        expect(body.has('client_secret')).toBe(false);
+    });
+
+    it('preserves the existing refresh token when the server does not return a new one', async () => {
+        vi.stubGlobal(
+            'fetch',
+            vi.fn().mockResolvedValue(
+                new Response(JSON.stringify({ access_token: 'new-access', token_type: 'Bearer', expires_in: 3600 }), {
+                    status: 200,
+                    headers: { 'content-type': 'application/json' }
+                })
+            )
+        );
+
+        const result = await refreshMcpGenericCredentials({
+            connection: mcpGenericConnection(),
+            logCtx: mockLogCtx()
+        });
+
+        expect(result.success).toBe(true);
+        expect(result.response?.refresh_token).toBe('refresh-token');
+    });
+
+    it('returns refresh_token_external_error when the token endpoint rejects the request', async () => {
+        vi.stubGlobal(
+            'fetch',
+            vi.fn().mockResolvedValue(
+                new Response(JSON.stringify({ error: 'invalid_request', error_description: 'client_secret: missing_required_field' }), {
+                    status: 400,
+                    headers: { 'content-type': 'application/json' }
+                })
+            )
+        );
+
+        const result = await refreshMcpGenericCredentials({
+            connection: mcpGenericConnection(),
+            logCtx: mockLogCtx()
+        });
+
+        expect(result.success).toBe(false);
+        expect(result.error?.type).toBe('refresh_token_external_error');
     });
 });

--- a/packages/shared/lib/clients/mcpGeneric.client.unit.test.ts
+++ b/packages/shared/lib/clients/mcpGeneric.client.unit.test.ts
@@ -177,4 +177,18 @@ describe('refreshMcpGenericCredentials', () => {
         expect(result.success).toBe(false);
         expect(result.error?.type).toBe('refresh_token_external_error');
     });
+
+    it('returns invalid_oauth_metadata when oauth_resource_url is malformed', async () => {
+        const fetchMock = vi.fn();
+        vi.stubGlobal('fetch', fetchMock);
+
+        const result = await refreshMcpGenericCredentials({
+            connection: mcpGenericConnection({ resourceUrl: 'not a url' }),
+            logCtx: mockLogCtx()
+        });
+
+        expect(result.success).toBe(false);
+        expect(result.error?.type).toBe('unhandled_invalid_oauth_metadata');
+        expect(fetchMock).not.toHaveBeenCalled();
+    });
 });


### PR DESCRIPTION
Public MCP clients were refreshed via simple-oauth2, which always sent client_secret= and broke strict token endpoints like Resend. Use the MCP SDK refresh path instead so the secret is omitted entirely.


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/NangoHQ/nango/pull/6921?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

