### PR TITLE
perf(scheduler): index soft-deleted schedules for the cleaning daemon

### DIFF
--- a/packages/scheduler/lib/db/migrations/20260728071506_schedules_soft_deleted_index.ts
+++ b/packages/scheduler/lib/db/migrations/20260728071506_schedules_soft_deleted_index.ts
@@ -1,0 +1,19 @@
+import { SCHEDULES_TABLE } from '../../models/schedules.js';
+
+import type { Knex } from 'knex';
+
+export const config = {
+    transaction: false
+};
+
+export async function up(knex: Knex): Promise<void> {
+    await knex.raw(
+        `CREATE INDEX CONCURRENTLY IF NOT EXISTS "idx_schedules_soft_deleted_id"
+        ON ${SCHEDULES_TABLE} USING BTREE (id)
+        WHERE deleted_at IS NOT NULL;`
+    );
+}
+
+export async function down(knex: Knex): Promise<void> {
+    await knex.raw(`DROP INDEX IF EXISTS "idx_schedules_soft_deleted_id";`);
+}

--- a/packages/scheduler/lib/db/migrations/20260728071506_schedules_soft_deleted_index.ts
+++ b/packages/scheduler/lib/db/migrations/20260728071506_schedules_soft_deleted_index.ts
@@ -14,6 +14,4 @@ export async function up(knex: Knex): Promise<void> {
     );
 }
 
-export async function down(knex: Knex): Promise<void> {
-    await knex.raw(`DROP INDEX IF EXISTS "idx_schedules_soft_deleted_id";`);
-}
+export async function down(): Promise<void> {}


### PR DESCRIPTION
## Why

The cleaning daemon's schedules hard-delete burns ~427 ms of CPU every ~8s to delete at most one row. Measured on cloud prod:

```
Limit  (actual time=427.549..427.551 rows=1 loops=1)
  Buffers: shared hit=253987
  ->  Index Scan using schedules_pkey on schedules
        Filter: (deleted_at < (now() - '5 days'::interval))
        Rows Removed by Filter: 256444
```

The query filters on `deleted_at` but orders by `id`, so the planner walks `schedules_pkey` in `id` order filtering as it goes. It estimated `rows=18` and gambled on hitting a match early; it stepped over 256,444 live schedules instead. That is ~1.94 GiB of buffer accesses to return a single row, entirely `shared hit`, so it is pure CPU on a fully cached table — roughly 6% of a core, permanently.

It also degrades over time: as older deleted schedules get cleaned, the front of the `id` ordering fills with live rows and the walk gets longer.

## How

- **Indexed on `id`, not `deleted_at`.** The query's `ORDER BY` is on `id`, so a `deleted_at` index would have to gather every eligible row and sort it to pick one. A partial index on `id` walks in `id` order over soft-deleted rows only and stops at the first eligible one.
- **The partial predicate bounds the work.** `schedules` currently holds 2,578 soft-deleted rows (111 of them eligible) against 256k+ live rows, so the walk is bounded by 2,577 in the worst case however the ids interleave — a 100x reduction even pathologically.
- **No cost on the hot path.** `scheduleNextExecution` updates `schedules` ~67/s. Neither `id` nor `deleted_at` changes on those updates, so HOT updates are preserved and this index is never touched by them. It is only written when a schedule is actually soft-deleted, which is rare.
- **Not a throughput problem.** 111 eligible rows at ~1 per 8s clears in ~15 minutes, so the `LIMIT 1` and its cascade-safety reasoning stay exactly as they are. This is wasted scanning, not a backlog.
- **Migrations:** cloud prod runs `CREATE INDEX CONCURRENTLY` **manually**, then inserts the migration row so the auto-runner skips it. The scheduler migration runs inline at orchestrator boot (`app.ts` calls `dbClient.migrate()` before the server starts) and knex's migration lock serializes every rolling pod behind it, so a slow build stalls the deploy. Worse, if a startup probe kills the pod mid-build, Postgres leaves an **invalid** index and the next boot's `IF NOT EXISTS` matches on name, silently skips, and marks the migration applied — a green deploy with no speedup and nothing pointing at why. Self-hosted auto-runs it on deploy, which is fine on their small tables.

### Commands

(Schema-qualified for the operator runbook — the migration file itself uses unqualified table names and relies on `search_path`.)

**1. Pre-flight** — confirm the recorded migration name format, and that nothing long-lived is open (`CONCURRENTLY` waits for every transaction older than each of its two phases):

```sql
SELECT name FROM nango_scheduler.migrations ORDER BY id DESC LIMIT 5;
-- expect names ending in .js (prod loads compiled migrations from dist/db/migrations)

SELECT pid, state, now() - xact_start AS xact_age, left(query, 80)
FROM pg_stat_activity
WHERE xact_start IS NOT NULL AND now() - xact_start > interval '5 seconds'
ORDER BY xact_age DESC;
-- expect: empty, or nothing long-lived
```

**2. Build the index** — CONCURRENTLY, no transaction wrapper (CONCURRENTLY can't run inside a txn):

```sql
CREATE INDEX CONCURRENTLY IF NOT EXISTS idx_schedules_soft_deleted_id
ON nango_scheduler.schedules USING BTREE (id)
WHERE deleted_at IS NOT NULL;
```

**3. Monitor progress** (from a separate psql session while the build is running):

```sql
SELECT phase, blocks_done, blocks_total,
       round(100.0 * blocks_done / NULLIF(blocks_total, 0), 1) AS pct
FROM pg_stat_progress_create_index;
```

**4. Verify success** — `indisvalid` and `indisready` must both be `t`:

```sql
SELECT indisvalid, indisready
FROM pg_index
WHERE indexrelid = 'nango_scheduler.idx_schedules_soft_deleted_id'::regclass;
-- expect: t, t
```

**5. Mark migration applied** — skip the auto-runner on next deploy:

```sql
INSERT INTO nango_scheduler.migrations (name, batch, migration_time)
VALUES (
    '20260728071506_schedules_soft_deleted_index.js',
    (SELECT COALESCE(MAX(batch), 0) + 1 FROM nango_scheduler.migrations),
    NOW()
);
```

**6. Confirm the win** — re-run the cleanup query's plan:

```sql
EXPLAIN (ANALYZE, BUFFERS)
SELECT "id" FROM "nango_scheduler"."schedules"
WHERE "deleted_at" < NOW() - INTERVAL '5 days'
ORDER BY "id" ASC
LIMIT 1;
-- expect: Index Scan using idx_schedules_soft_deleted_id,
--         Rows Removed by Filter down from 256444 to ~0,
--         Buffers down from 253987 to a few thousand
```

### Emergency stop (if the build needs to be aborted mid-flight)

**1. Find the PID** (from a separate psql session):

```sql
SELECT pid, now() - query_start AS duration, state
FROM pg_stat_activity
WHERE query ILIKE '%CREATE INDEX CONCURRENTLY IF NOT EXISTS idx_schedules_soft_deleted_id%'
  AND pid <> pg_backend_pid();
```

**2. Cancel gracefully** (preferred):

```sql
SELECT pg_cancel_backend(<pid>);
```

If cancel doesn't take effect within ~30s (some CREATE INDEX phases ignore SIGINT), escalate to terminate (drops the connection):

```sql
SELECT pg_terminate_backend(<pid>);
```

**3. Clean up the invalid leftover** — cancelled/terminated builds leave an invalid index in the catalog:

```sql
-- Check what's left:
SELECT indisvalid
FROM pg_index
WHERE indexrelid = 'nango_scheduler.idx_schedules_soft_deleted_id'::regclass;
-- if 'f': there's an invalid index that must be dropped before retrying

-- Drop it (CONCURRENTLY so the DROP itself doesn't lock the table):
DROP INDEX CONCURRENTLY IF EXISTS nango_scheduler.idx_schedules_soft_deleted_id;
```

After the DROP the table is back to a clean state and the build can be retried. Note this also matters if step 5 is skipped: an invalid index plus an unrecorded migration means the next deploy's `IF NOT EXISTS` matches the invalid index by name and no-ops.

## What

- Add partial index `idx_schedules_soft_deleted_id` on `schedules (id) WHERE deleted_at IS NOT NULL`, serving the `hardDeleteOlderThanNDays` cleanup query in `packages/scheduler/lib/models/schedules.ts`.

## Test plan

- [x] `npm run test:integration --dir=packages/scheduler` — 85/85 pass, migration applies to the test database
- [x] Current plan measured on cloud prod via `EXPLAIN (ANALYZE, BUFFERS)`
- [x] Soft-deleted population measured (2,578 total / 111 eligible) to confirm the index bounds the walk
- [ ] Cloud prod: pre-flight checks (migration name format, no long-lived transactions)
- [ ] Cloud prod: `CREATE INDEX CONCURRENTLY` and confirm `indisvalid = t, indisready = t`
- [ ] Cloud prod: `INSERT INTO nango_scheduler.migrations` to mark applied
- [ ] Cloud prod: re-run the plan and confirm `Rows Removed by Filter` drops from 256,444 to ~0
- [ ] Self-hosted auto-runs the migration on next deploy

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/NangoHQ/nango/pull/6924?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

