### PR TITLE
perf(scheduler): add unique index to ensure one active task per schedule

### DIFF
--- a/packages/scheduler/lib/db/migrations/20260728085028_tasks_one_active_per_schedule.ts
+++ b/packages/scheduler/lib/db/migrations/20260728085028_tasks_one_active_per_schedule.ts
@@ -1,0 +1,19 @@
+import { TASKS_TABLE } from '../../models/tasks.js';
+
+import type { Knex } from 'knex';
+
+export const config = {
+    transaction: false
+};
+
+export async function up(knex: Knex): Promise<void> {
+    // Create a unique index on the tasks table to ensure that only one task can be in the 'CREATED' or 'STARTED' state for a given schedule_id at any time.
+    // This prevents multiple active tasks from being created for the same schedule.
+    await knex.raw(
+        `CREATE UNIQUE INDEX CONCURRENTLY IF NOT EXISTS tasks_one_active_per_schedule
+        ON ${TASKS_TABLE} (schedule_id)
+        WHERE state IN ('CREATED', 'STARTED');`
+    );
+}
+
+export async function down(_knex: Knex): Promise<void> {}


### PR DESCRIPTION
This is currently enforced via app logic. The goal is to push the enforcement to the database and remove the locking of the  schedule row and the fetching of the current active task in order to prevent mass sync triggering to pile up. 
The uniqueness will be enforced by the index and fail fast when attempting to add multiple tasks for the same schedule.


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/NangoHQ/nango/pull/6925?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

