### PR TITLE
perf(orch): don't wait for locked schedule when scheduling immediate task

### DIFF
--- a/packages/orchestrator/lib/clients/client.ts
+++ b/packages/orchestrator/lib/clients/client.ts
@@ -67,7 +67,7 @@ export class OrchestratorClient {
     public async immediate(props: ImmediateProps): Promise<Result<PostImmediate['Success'], ClientError>> {
         const res = await this.routeFetch(postImmediateRoute)({ body: props });
         if ('error' in res) {
-            const duplicateMessage = getDuplicateTaskNameMessage(res.error.payload);
+            const duplicateMessage = getErrorMessageForCode(res.error.payload, 'duplicate_task_name');
             if (duplicateMessage !== null) {
                 return Err({
                     name: 'duplicate_task_name',
@@ -174,11 +174,14 @@ export class OrchestratorClient {
 
     public async executeSync(props: ExecuteSyncProps): Promise<VoidReturn> {
         const res = await this.routeFetch(postScheduleRunRoute, {
-            // A schedule that already has an active task is a terminal answer, not a transient failure
+            // A schedule that already has an active task or is being mutated is a terminal answer, not a transient failure
             retryConfig: {
                 maxAttempts: 3,
                 delayMs: 50,
-                retryIf: (res) => 'error' in res && getScheduleTaskAlreadyRunningMessage(res.error.payload) === null
+                retryIf: (res) =>
+                    'error' in res &&
+                    getErrorMessageForCode(res.error.payload, 'schedule_task_already_running') === null &&
+                    getErrorMessageForCode(res.error.payload, 'schedule_locked') === null
             }
         })({
             body: {
@@ -187,11 +190,20 @@ export class OrchestratorClient {
             }
         });
         if ('error' in res) {
-            const alreadyRunning = getScheduleTaskAlreadyRunningMessage(res.error.payload);
+            const alreadyRunning = getErrorMessageForCode(res.error.payload, 'schedule_task_already_running');
             if (alreadyRunning !== null) {
                 return Err({
                     name: 'schedule_task_already_running',
                     message: alreadyRunning || 'A task for this schedule is already running',
+                    payload: {}
+                });
+            }
+
+            const locked = getErrorMessageForCode(res.error.payload, 'schedule_locked');
+            if (locked !== null) {
+                return Err({
+                    name: 'schedule_locked',
+                    message: locked || 'Schedule is being mutated by another operation',
                     payload: {}
                 });
             }
@@ -613,7 +625,7 @@ export class OrchestratorClient {
     }
 }
 
-function getDuplicateTaskNameMessage(payload: unknown): string | null {
+function getErrorMessageForCode(payload: unknown, code: string): string | null {
     if (!payload || typeof payload !== 'object' || !('error' in payload)) {
         return null;
     }
@@ -625,26 +637,7 @@ function getDuplicateTaskNameMessage(payload: unknown): string | null {
         };
     };
 
-    if (response.error?.code !== 'duplicate_task_name') {
-        return null;
-    }
-
-    return response.error.message || '';
-}
-
-function getScheduleTaskAlreadyRunningMessage(payload: unknown): string | null {
-    if (!payload || typeof payload !== 'object' || !('error' in payload)) {
-        return null;
-    }
-
-    const response = payload as {
-        error?: {
-            code?: string;
-            message?: string;
-        };
-    };
-
-    if (response.error?.code !== 'schedule_task_already_running') {
+    if (response.error?.code !== code) {
         return null;
     }
 

--- a/packages/orchestrator/lib/clients/client.ts
+++ b/packages/orchestrator/lib/clients/client.ts
@@ -173,13 +173,29 @@ export class OrchestratorClient {
     }
 
     public async executeSync(props: ExecuteSyncProps): Promise<VoidReturn> {
-        const res = await this.routeFetch(postScheduleRunRoute)({
+        const res = await this.routeFetch(postScheduleRunRoute, {
+            // A schedule that already has an active task is a terminal answer, not a transient failure
+            retryConfig: {
+                maxAttempts: 3,
+                delayMs: 50,
+                retryIf: (res) => 'error' in res && getScheduleTaskAlreadyRunningMessage(res.error.payload) === null
+            }
+        })({
             body: {
                 scheduleName: props.scheduleName,
                 extra: props.extra
             }
         });
         if ('error' in res) {
+            const alreadyRunning = getScheduleTaskAlreadyRunningMessage(res.error.payload);
+            if (alreadyRunning !== null) {
+                return Err({
+                    name: 'schedule_task_already_running',
+                    message: alreadyRunning || 'A task for this schedule is already running',
+                    payload: {}
+                });
+            }
+
             return Err({
                 name: res.error.code,
                 message: res.error.message || `Error creating recurring schedule`,
@@ -610,6 +626,25 @@ function getDuplicateTaskNameMessage(payload: unknown): string | null {
     };
 
     if (response.error?.code !== 'duplicate_task_name') {
+        return null;
+    }
+
+    return response.error.message || '';
+}
+
+function getScheduleTaskAlreadyRunningMessage(payload: unknown): string | null {
+    if (!payload || typeof payload !== 'object' || !('error' in payload)) {
+        return null;
+    }
+
+    const response = payload as {
+        error?: {
+            code?: string;
+            message?: string;
+        };
+    };
+
+    if (response.error?.code !== 'schedule_task_already_running') {
         return null;
     }
 

--- a/packages/orchestrator/lib/routes/v1/schedules/postRun.ts
+++ b/packages/orchestrator/lib/routes/v1/schedules/postRun.ts
@@ -1,6 +1,6 @@
 import * as z from 'zod';
 
-import { isScheduleTaskAlreadyRunningError } from '@nangohq/scheduler';
+import { isScheduleLockedError, isScheduleTaskAlreadyRunningError } from '@nangohq/scheduler';
 import { validateRequest } from '@nangohq/utils';
 
 import type { Scheduler } from '@nangohq/scheduler';
@@ -18,7 +18,7 @@ export type PostScheduleRun = Endpoint<{
         scheduleName: string;
         extra: JsonObject;
     };
-    Error: ApiError<'recurring_run_failed' | 'schedule_task_already_running'>;
+    Error: ApiError<'recurring_run_failed' | 'schedule_task_already_running' | 'schedule_locked'>;
     Success: { scheduleId: string };
 }>;
 
@@ -37,6 +37,10 @@ const handler = (scheduler: Scheduler) => {
         if (schedule.isErr()) {
             if (isScheduleTaskAlreadyRunningError(schedule.error)) {
                 res.status(409).json({ error: { code: 'schedule_task_already_running', message: schedule.error.message } });
+                return;
+            }
+            if (isScheduleLockedError(schedule.error)) {
+                res.status(409).json({ error: { code: 'schedule_locked', message: schedule.error.message } });
                 return;
             }
             res.status(500).json({ error: { code: 'recurring_run_failed', message: schedule.error.message } });

--- a/packages/orchestrator/lib/routes/v1/schedules/postRun.ts
+++ b/packages/orchestrator/lib/routes/v1/schedules/postRun.ts
@@ -1,5 +1,6 @@
 import * as z from 'zod';
 
+import { isScheduleTaskAlreadyRunningError } from '@nangohq/scheduler';
 import { validateRequest } from '@nangohq/utils';
 
 import type { Scheduler } from '@nangohq/scheduler';
@@ -17,7 +18,7 @@ export type PostScheduleRun = Endpoint<{
         scheduleName: string;
         extra: JsonObject;
     };
-    Error: ApiError<'recurring_run_failed'>;
+    Error: ApiError<'recurring_run_failed' | 'schedule_task_already_running'>;
     Success: { scheduleId: string };
 }>;
 
@@ -34,6 +35,10 @@ const handler = (scheduler: Scheduler) => {
             extra: res.locals.parsedBody.extra
         });
         if (schedule.isErr()) {
+            if (isScheduleTaskAlreadyRunningError(schedule.error)) {
+                res.status(409).json({ error: { code: 'schedule_task_already_running', message: schedule.error.message } });
+                return;
+            }
             res.status(500).json({ error: { code: 'recurring_run_failed', message: schedule.error.message } });
             return;
         }

--- a/packages/scheduler/lib/errors.ts
+++ b/packages/scheduler/lib/errors.ts
@@ -8,3 +8,14 @@ export class DuplicateTaskNameError extends Error {
 export function isDuplicateTaskNameError(err: unknown): boolean {
     return err instanceof DuplicateTaskNameError;
 }
+
+export class ScheduleTaskAlreadyRunningError extends Error {
+    constructor() {
+        super('A task for this schedule is already running');
+        this.name = 'ScheduleTaskAlreadyRunningError';
+    }
+}
+
+export function isScheduleTaskAlreadyRunningError(err: unknown): boolean {
+    return err instanceof ScheduleTaskAlreadyRunningError;
+}

--- a/packages/scheduler/lib/errors.ts
+++ b/packages/scheduler/lib/errors.ts
@@ -19,3 +19,18 @@ export class ScheduleTaskAlreadyRunningError extends Error {
 export function isScheduleTaskAlreadyRunningError(err: unknown): boolean {
     return err instanceof ScheduleTaskAlreadyRunningError;
 }
+
+export class ScheduleLockedError extends Error {
+    constructor() {
+        super('Schedule is being mutated by another operation');
+        this.name = 'ScheduleLockedError';
+    }
+}
+
+export function isScheduleLockedError(err: unknown): boolean {
+    return err instanceof ScheduleLockedError;
+}
+
+export function isPgLockNotAvailableError(err: unknown): boolean {
+    return !!err && typeof err === 'object' && (err as { code?: string }).code === '55P03';
+}

--- a/packages/scheduler/lib/models/schedules.ts
+++ b/packages/scheduler/lib/models/schedules.ts
@@ -2,6 +2,8 @@ import { uuidv7 } from 'uuidv7';
 
 import { Err, Ok, stringifyError } from '@nangohq/utils';
 
+import { isPgLockNotAvailableError, ScheduleLockedError } from '../errors.js';
+
 import type { Schedule, ScheduleProps, ScheduleState, TaskState } from '../types.js';
 import type { Result } from '@nangohq/utils';
 import type knex from 'knex';
@@ -296,7 +298,7 @@ export async function remove(db: knex.Knex, id: string): Promise<Result<Schedule
 
 export async function search(
     db: knex.Knex,
-    params: { id?: string; names?: string[]; state?: ScheduleState; limit: number; forUpdate?: boolean }
+    params: { id?: string; names?: string[]; state?: ScheduleState; limit: number; forUpdate?: boolean; noWait?: boolean }
 ): Promise<Result<Schedule[]>> {
     try {
         const query = db.from<DbSchedule>(SCHEDULES_TABLE).limit(params.limit);
@@ -311,10 +313,16 @@ export async function search(
         }
         if (params.forUpdate) {
             query.forUpdate();
+            if (params.noWait) {
+                query.noWait();
+            }
         }
         const schedules = await query;
         return Ok(schedules.map(DbSchedule.from));
     } catch (err) {
+        if (isPgLockNotAvailableError(err)) {
+            return Err(new ScheduleLockedError());
+        }
         return Err(new Error(`Error searching schedules: ${stringifyError(err)}`));
     }
 }

--- a/packages/scheduler/lib/models/tasks.ts
+++ b/packages/scheduler/lib/models/tasks.ts
@@ -128,7 +128,7 @@ export interface CreateOpts {
     onConflict?: 'throw' | 'skip';
 }
 
-export type DiscardReason = 'capped' | 'duplicate';
+export type DiscardReason = 'capped' | 'duplicate' | 'conflict';
 export interface DiscardedTask {
     props: TaskProps;
     reason: DiscardReason;
@@ -179,16 +179,20 @@ export async function create(db: knex.Knex, taskProps: TaskProps[], opts: Create
         const candidates = Array.from(candidatesPerGroup.values()).flat();
         const created: Task[] = [];
         const insertedNameCounts = new Map<string, number>();
+        const insertedTaskIds = new Set<string>();
         for (let i = 0; i < candidates.length; i += TASKS_INSERT_BATCH_SIZE) {
             const chunk = candidates.slice(i, i + TASKS_INSERT_BATCH_SIZE);
             const query = db.from<DBTask>(TASKS_TABLE).insert(chunk.map((c) => DbTask.to(c.task)));
             if (onConflict === 'skip') {
                 query.onConflict('name').ignore();
+            } else {
+                query.onConflict(db.raw("(schedule_id) WHERE state IN ('CREATED', 'STARTED')")).ignore();
             }
             const batch = await query.returning('*');
             for (const dbTask of batch) {
                 const t = DbTask.from(dbTask);
                 created.push(t);
+                insertedTaskIds.add(t.id);
                 insertedNameCounts.set(t.name, (insertedNameCounts.get(t.name) ?? 0) + 1);
             }
         }
@@ -200,6 +204,13 @@ export async function create(db: knex.Knex, taskProps: TaskProps[], opts: Create
                     insertedNameCounts.set(props.name, remaining - 1);
                 } else {
                     discarded.push({ props, reason: 'duplicate' });
+                }
+            }
+        }
+        if (onConflict === 'throw') {
+            for (const { props, task } of candidates) {
+                if (!insertedTaskIds.has(task.id)) {
+                    discarded.push({ props, reason: 'conflict' });
                 }
             }
         }

--- a/packages/scheduler/lib/scheduler.integration.test.ts
+++ b/packages/scheduler/lib/scheduler.integration.test.ts
@@ -4,7 +4,7 @@ import { nanoid } from '@nangohq/utils';
 
 import { defaultSchedulerConfig } from './config.js';
 import { getTestDbClient } from './db/helpers.test.js';
-import { isDuplicateTaskNameError } from './errors.js';
+import { isDuplicateTaskNameError, isScheduleTaskAlreadyRunningError } from './errors.js';
 import { Scheduler } from './scheduler.js';
 
 import type { TaskProps } from './models/tasks.js';
@@ -218,7 +218,20 @@ describe('Scheduler', () => {
     it('should not run an immediate task for a schedule if another task is already running', async () => {
         const schedule = await recurring({ scheduler });
         await immediate(scheduler, { schedule }); // first task: OK
-        await expect(immediate(scheduler, { schedule })).rejects.toThrow();
+        await expect(immediate(scheduler, { schedule })).rejects.toSatisfy(isScheduleTaskAlreadyRunningError);
+    });
+    it('should create exactly one task for concurrent immediate calls on the same schedule', async () => {
+        const schedule = await recurring({ scheduler });
+
+        const results = await Promise.allSettled([immediate(scheduler, { schedule }), immediate(scheduler, { schedule })]);
+        const created = results.filter((result): result is PromiseFulfilledResult<Task> => result.status === 'fulfilled');
+        const rejected = results.filter((result): result is PromiseRejectedResult => result.status === 'rejected');
+
+        expect(created).toHaveLength(1);
+        expect(rejected).toHaveLength(1);
+        expect(isScheduleTaskAlreadyRunningError(rejected[0]?.reason)).toBe(true);
+        expect((await scheduler.searchTasks({ scheduleId: schedule.id, state: 'CREATED' })).unwrap()).toHaveLength(1);
+        expect(callbacks.CREATED).toHaveBeenCalledOnce();
     });
     it('should create an uncapped task when immediate is called for a schedule', async () => {
         const schedule = await recurring({ scheduler });

--- a/packages/scheduler/lib/scheduler.integration.test.ts
+++ b/packages/scheduler/lib/scheduler.integration.test.ts
@@ -4,7 +4,8 @@ import { nanoid } from '@nangohq/utils';
 
 import { defaultSchedulerConfig } from './config.js';
 import { getTestDbClient } from './db/helpers.test.js';
-import { isDuplicateTaskNameError, isScheduleTaskAlreadyRunningError } from './errors.js';
+import { isDuplicateTaskNameError, isScheduleLockedError, isScheduleTaskAlreadyRunningError } from './errors.js';
+import * as schedules from './models/schedules.js';
 import { Scheduler } from './scheduler.js';
 
 import type { TaskProps } from './models/tasks.js';
@@ -229,9 +230,20 @@ describe('Scheduler', () => {
 
         expect(created).toHaveLength(1);
         expect(rejected).toHaveLength(1);
-        expect(isScheduleTaskAlreadyRunningError(rejected[0]?.reason)).toBe(true);
+        // the loser either fails to acquire the schedule lock or, if it acquired it after the winner committed, conflicts on the task
+        expect(isScheduleLockedError(rejected[0]?.reason) || isScheduleTaskAlreadyRunningError(rejected[0]?.reason)).toBe(true);
         expect((await scheduler.searchTasks({ scheduleId: schedule.id, state: 'CREATED' })).unwrap()).toHaveLength(1);
         expect(callbacks.CREATED).toHaveBeenCalledOnce();
+    });
+    it('should not run an immediate task for a schedule locked by another transaction', async () => {
+        const schedule = await recurring({ scheduler });
+
+        await dbClient.db.transaction(async (trx) => {
+            (await schedules.search(trx, { id: schedule.id, limit: 1, forUpdate: true })).unwrap();
+            await expect(immediate(scheduler, { schedule })).rejects.toSatisfy(isScheduleLockedError);
+        });
+
+        expect((await scheduler.searchTasks({ scheduleId: schedule.id })).unwrap()).toHaveLength(0);
     });
     it('should create an uncapped task when immediate is called for a schedule', async () => {
         const schedule = await recurring({ scheduler });

--- a/packages/scheduler/lib/scheduler.ts
+++ b/packages/scheduler/lib/scheduler.ts
@@ -6,6 +6,7 @@ import { defaultSchedulerConfig, noopLogger } from './config.js';
 import { CleaningDaemon } from './daemons/cleaning/cleaning.daemon.js';
 import { ExpiringDaemon } from './daemons/expiring/expiring.daemon.js';
 import { SchedulingDaemon } from './daemons/scheduling/scheduling.daemon.js';
+import { ScheduleTaskAlreadyRunningError } from './errors.js';
 import * as schedules from './models/schedules.js';
 import * as tasks from './models/tasks.js';
 import { logger, setLogger } from './utils/logger.js';
@@ -216,26 +217,13 @@ export class Scheduler {
         }
         const events: SchedulerEvent[] = [];
         const result = await this.db.transaction<Result<Task>>(async (trx) => {
-            // forUpdate = true so that the schedule is locked to prevent any concurrent update or concurrent scheduling of tasks
-            const getSchedules = await schedules.search(trx, { names: [props.scheduleName], limit: 1, forUpdate: true });
+            const getSchedules = await schedules.search(trx, { names: [props.scheduleName], limit: 1 });
             if (getSchedules.isErr()) {
                 return Err(getSchedules.error);
             }
             const schedule = getSchedules.value[0];
             if (!schedule) {
                 return Err(new Error(`Schedule '${props.scheduleName}' not found`));
-            }
-            // Not scheduling a task if another task for the same schedule is already running
-            const running = await tasks.search(trx, {
-                scheduleId: schedule.id,
-                states: ['CREATED', 'STARTED']
-            });
-            if (running.isErr()) {
-                return Err(running.error);
-            }
-            if (running.value.length > 0) {
-                // TODO: identify this error so we can return something else than a 500
-                return Err(new Error(`Task for schedule '${props.scheduleName}' is already running: ${running.value[0]?.id}`));
             }
             const inserted = await this.insertTask(trx, {
                 name: `${schedule.name}:${uuidv7()}`,
@@ -286,6 +274,9 @@ export class Scheduler {
         }
         const task = createResult.value.created[0];
         if (!task) {
+            if (taskProps.scheduleId && createResult.value.discarded.some((discarded) => discarded.reason === 'conflict')) {
+                return { result: Err(new ScheduleTaskAlreadyRunningError()), events: [] };
+            }
             const events = createResult.value.discarded
                 .filter((d) => d.reason === 'capped')
                 .map((d): SchedulerEvent => ({ type: 'task_dropped', groupKey: d.props.groupKey, count: 1, reason: 'task_cap' }));

--- a/packages/scheduler/lib/scheduler.ts
+++ b/packages/scheduler/lib/scheduler.ts
@@ -217,7 +217,9 @@ export class Scheduler {
         }
         const events: SchedulerEvent[] = [];
         const result = await this.db.transaction<Result<Task>>(async (trx) => {
-            const getSchedules = await schedules.search(trx, { names: [props.scheduleName], limit: 1 });
+            // The schedule must be locked before inserting the task so that concurrent calls and/or scheduling daemon don't attempt to mutate the schedule while we're inserting the task.
+            // noWait so that concurrent runs for the same schedule fail immediately instead of piling up
+            const getSchedules = await schedules.search(trx, { names: [props.scheduleName], limit: 1, forUpdate: true, noWait: true });
             if (getSchedules.isErr()) {
                 return Err(getSchedules.error);
             }

--- a/packages/tasks/lib/types.ts
+++ b/packages/tasks/lib/types.ts
@@ -106,4 +106,4 @@ export type EnqueueBatchItem<Defs extends readonly AnyTaskDefinition[]> = {
     };
 }[Defs[number]['type']];
 
-export type EnqueueDiscardReason = 'capped' | 'duplicate';
+export type EnqueueDiscardReason = 'capped' | 'duplicate' | 'conflict';


### PR DESCRIPTION
Mass triggering of the same sync is causing `schedules.search()` queries to pile up and wait because of the `for update` condition used to ensure only one task is active per schedule. 
- An unique index is now in place, coupled with the `ON CONFLICT` statement added in this commit to make postgres take care of the unique active task requirement. 
- `immediate()` doesn't wait for schedule row to be available if already locked and fail fast instead.
- Ensures conflicting tasks and locked schedules aren't retried

<!-- Describe the problem and your solution --> 

<!-- Issue ticket number and link (if applicable) -->

<!-- Testing instructions (skip if just adding/editing providers) -->



<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/NangoHQ/nango/pull/6926?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

