### PR TITLE
refactor(mcp): rename management server env var

### DIFF
--- a/packages/server/lib/controllers/mcp/controlPlane.integration.test.ts
+++ b/packages/server/lib/controllers/mcp/controlPlane.integration.test.ts
@@ -11,7 +11,7 @@ import type { ApiKeyScope } from '@nangohq/types';
 type AuthenticateUser = typeof authenticateUserType;
 type RunServer = typeof runServerType;
 
-let originalControlPlaneMcpServerUrl: string | undefined;
+let originalManagementMcpServerUrl: string | undefined;
 let authenticateUser: AuthenticateUser;
 let runServer: RunServer;
 let api: Awaited<ReturnType<RunServer>>;
@@ -136,8 +136,8 @@ function parseToolText(res: any) {
 
 describe('POST /mcp control-plane server', () => {
     beforeAll(async () => {
-        originalControlPlaneMcpServerUrl = process.env['NANGO_CONTROL_PLANE_MCP_SERVER_URL'];
-        process.env['NANGO_CONTROL_PLANE_MCP_SERVER_URL'] = 'https://mcp-development.nango.dev';
+        originalManagementMcpServerUrl = process.env['NANGO_MANAGEMENT_MCP_SERVER_URL'];
+        process.env['NANGO_MANAGEMENT_MCP_SERVER_URL'] = 'https://mcp-development.nango.dev';
 
         vi.resetModules();
         ({ authenticateUser, runServer } = await import('../../utils/tests.js'));
@@ -146,10 +146,10 @@ describe('POST /mcp control-plane server', () => {
 
     afterAll(() => {
         api.server.close();
-        if (originalControlPlaneMcpServerUrl === undefined) {
-            delete process.env['NANGO_CONTROL_PLANE_MCP_SERVER_URL'];
+        if (originalManagementMcpServerUrl === undefined) {
+            delete process.env['NANGO_MANAGEMENT_MCP_SERVER_URL'];
         } else {
-            process.env['NANGO_CONTROL_PLANE_MCP_SERVER_URL'] = originalControlPlaneMcpServerUrl;
+            process.env['NANGO_MANAGEMENT_MCP_SERVER_URL'] = originalManagementMcpServerUrl;
         }
     });
 

--- a/packages/server/lib/routes.control-plane-mcp.ts
+++ b/packages/server/lib/routes.control-plane-mcp.ts
@@ -39,7 +39,7 @@ export const controlPlaneMcpAPI: RequestHandler = (req, res, next) => {
 };
 
 function isControlPlaneMcpHost(host: string): boolean {
-    if (!envs.NANGO_CONTROL_PLANE_MCP_SERVER_URL) {
+    if (!envs.NANGO_MANAGEMENT_MCP_SERVER_URL) {
         return false;
     }
 
@@ -48,6 +48,6 @@ function isControlPlaneMcpHost(host: string): boolean {
         return false;
     }
 
-    const controlPlaneMcpHostname = new URL(envs.NANGO_CONTROL_PLANE_MCP_SERVER_URL).hostname.toLowerCase();
+    const controlPlaneMcpHostname = new URL(envs.NANGO_MANAGEMENT_MCP_SERVER_URL).hostname.toLowerCase();
     return hostname === controlPlaneMcpHostname;
 }

--- a/packages/utils/lib/environment/parse.ts
+++ b/packages/utils/lib/environment/parse.ts
@@ -63,7 +63,7 @@ export const ENVS = z.object({
     NANGO_PORT: z.coerce.number().optional().default(3003), // Sync those two ports?
     SERVER_PORT: z.coerce.number().optional().default(3003),
     NANGO_SERVER_URL: z.url().optional(),
-    NANGO_CONTROL_PLANE_MCP_SERVER_URL: z.url().optional(),
+    NANGO_MANAGEMENT_MCP_SERVER_URL: z.url().optional(),
     NANGO_SERVER_KEEP_ALIVE_TIMEOUT: z.coerce.number().optional().default(61_000),
     DEFAULT_RATE_LIMIT_PER_MIN: z.coerce.number().min(1).optional().default(200),
     NANGO_CACHE_ENV_KEYS: z.stringbool().optional().default(false),

--- a/packages/utils/lib/environment/parse.unit.test.ts
+++ b/packages/utils/lib/environment/parse.unit.test.ts
@@ -24,9 +24,9 @@ describe('parse', () => {
         expect(res.E2B_SANDBOX_COMPILER_TEMPLATE).toBe('blank-workspace:dev');
     });
 
-    it('should parse the control-plane MCP server URL', () => {
-        const res = parseEnvs(ENVS, { NANGO_CONTROL_PLANE_MCP_SERVER_URL: 'https://mcp-development.nango.dev' });
-        expect(res.NANGO_CONTROL_PLANE_MCP_SERVER_URL).toBe('https://mcp-development.nango.dev');
+    it('should parse the management MCP server URL', () => {
+        const res = parseEnvs(ENVS, { NANGO_MANAGEMENT_MCP_SERVER_URL: 'https://mcp-development.nango.dev' });
+        expect(res.NANGO_MANAGEMENT_MCP_SERVER_URL).toBe('https://mcp-development.nango.dev');
     });
 
     it('should parse E2B sandbox metric settings', () => {


### PR DESCRIPTION
Renames the Management MCP server URL environment variable from `NANGO_CONTROL_PLANE_MCP_SERVER_URL` to `NANGO_MANAGEMENT_MCP_SERVER_URL` so it matches the public terminology.

Updates environment parsing, hostname routing, and related test coverage to use the new variable.

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/NangoHQ/nango/pull/6935?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

