### PR TITLE
docs: add self-hosted Management MCP setup

### DIFF
--- a/docs/guides/platform/self-hosting.mdx
+++ b/docs/guides/platform/self-hosting.mdx
@@ -192,6 +192,18 @@ The resulting OAuth callback URL is `<INSTANCE-URL>/oauth/callback`.
 If you are using a custom domain, update `NANGO_SERVER_URL` to match it.
 </Note>
 
+### Management MCP server
+
+The [Management MCP server](/reference/backend/management-mcp) runs as part of the main Nango server. To enable it, configure a dedicated hostname and route traffic for that hostname to the Nango server:
+
+```sh
+NANGO_MANAGEMENT_MCP_SERVER_URL=https://mcp.example.com
+```
+
+The hostname must be different from the hostname in `NANGO_SERVER_URL`. Nango uses the request hostname to distinguish Management MCP traffic from the public API. Restart the Nango server after setting the environment variable; the Management MCP endpoint is then available at `https://mcp.example.com/mcp`.
+
+The currently available Management MCP tools query Nango logs. Follow the [Logs](#logs) setup below to enable log storage, then configure your MCP client with the self-hosted endpoint and a scoped Nango API key as described in the [Management MCP reference](/reference/backend/management-mcp#connect).
+
 ### Connect UI
 
 Nango Connect is available for self-hosted deployments in the main Docker image.

--- a/docs/guides/platform/self-hosting.mdx
+++ b/docs/guides/platform/self-hosting.mdx
@@ -202,8 +202,6 @@ NANGO_MANAGEMENT_MCP_SERVER_URL=https://mcp.example.com
 
 The hostname must be different from the hostname in `NANGO_SERVER_URL`. Nango uses the request hostname to distinguish Management MCP traffic from the public API. Restart the Nango server after setting the environment variable; the Management MCP endpoint is then available at `https://mcp.example.com/mcp`.
 
-The currently available Management MCP tools query Nango logs. Follow the [Logs](#logs) setup below to enable log storage, then configure your MCP client with the self-hosted endpoint and a scoped Nango API key as described in the [Management MCP reference](/reference/backend/management-mcp#connect).
-
 ### Connect UI
 
 Nango Connect is available for self-hosted deployments in the main Docker image.

--- a/docs/llms-full.txt
+++ b/docs/llms-full.txt
@@ -6867,8 +6867,6 @@ NANGO_MANAGEMENT_MCP_SERVER_URL=https://mcp.example.com
 
 The hostname must be different from the hostname in `NANGO_SERVER_URL`. Nango uses the request hostname to distinguish Management MCP traffic from the public API. Restart the Nango server after setting the environment variable; the Management MCP endpoint is then available at `https://mcp.example.com/mcp`.
 
-The currently available Management MCP tools query Nango logs. Follow the [Logs](#logs) setup below to enable log storage, then configure your MCP client with the self-hosted endpoint and a scoped Nango API key as described in the [Management MCP reference](/reference/backend/management-mcp#connect).
-
 ### Connect UI
 
 Nango Connect is available for self-hosted deployments in the main Docker image.

--- a/docs/llms-full.txt
+++ b/docs/llms-full.txt
@@ -6857,6 +6857,18 @@ The resulting OAuth callback URL is `<INSTANCE-URL>/oauth/callback`.
 If you are using a custom domain, update `NANGO_SERVER_URL` to match it.
 </Note>
 
+### Management MCP server
+
+The [Management MCP server](/reference/backend/management-mcp) runs as part of the main Nango server. To enable it, configure a dedicated hostname and route traffic for that hostname to the Nango server:
+
+```sh
+NANGO_MANAGEMENT_MCP_SERVER_URL=https://mcp.example.com
+```
+
+The hostname must be different from the hostname in `NANGO_SERVER_URL`. Nango uses the request hostname to distinguish Management MCP traffic from the public API. Restart the Nango server after setting the environment variable; the Management MCP endpoint is then available at `https://mcp.example.com/mcp`.
+
+The currently available Management MCP tools query Nango logs. Follow the [Logs](#logs) setup below to enable log storage, then configure your MCP client with the self-hosted endpoint and a scoped Nango API key as described in the [Management MCP reference](/reference/backend/management-mcp#connect).
+
 ### Connect UI
 
 Nango Connect is available for self-hosted deployments in the main Docker image.


### PR DESCRIPTION
Documents how self-hosted operators enable the Management MCP server with a dedicated hostname and NANGO_MANAGEMENT_MCP_SERVER_URL.

Explains hostname routing, the MCP endpoint, log storage, and scoped API key requirements. Uses the environment variable name introduced by #6935 and should merge after that PR.

NAN-6462: https://linear.app/nango/issue/NAN-6462/update-self-hosted-docs-with-management-mcp-setup

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/NangoHQ/nango/pull/6937?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

