### PR TITLE
fix(docs): stop changelog Update blocks clipping off the left edge (NAN-6464)

### DIFF
--- a/docs/custom.css
+++ b/docs/custom.css
@@ -331,34 +331,67 @@ html:not(.dark) #table-of-contents:not(:has(.toc-item[data-active="true"])) .toc
   font-weight: 500;
 }
 
-/* ══ CHANGELOG PAGE — hide left sidebar, keep TOC ════════════════ */
+/* ══ CHANGELOG PAGE — collapse left sidebar into a gutter ════════ */
 /*
  * Mintlify sets data-page-href on the #content div. We use :has()
- * to scope sidebar-hiding to just the changelog page while leaving
- * the right-side "On this page" TOC intact. Substring match is used
+ * to scope this to just the changelog page while leaving the
+ * right-side "On this page" TOC intact. Substring match is used
  * because local dev and prod may format the path slightly differently.
  *
- * Both rules below are gated to lg+ (≥1024px). Below lg, Mintlify
- * shows a hamburger menu instead of the desktop sidebar, and the
- * Update component renders as a vertical stack (flex-col) where the
- * label is full-width on top of the content. Applying the desktop
- * shift on smaller viewports would push content off the left edge.
+ * We COLLAPSE the sidebar to an empty 184px spacer rather than
+ * display:none-ing it, because that reserved space is what makes the
+ * .update-container shift below safe at every viewport width.
+ *
+ * Mintlify used to render the sidebar `position: fixed` and bake its
+ * 288px reservation into #content-area's padding (lg:pl-[23.7rem]).
+ * Hiding an out-of-flow box frees no flow space, so that padding stayed
+ * and the shift had ~363px of room. In late July 2026 the sidebar
+ * became an in-flow flex item and the padding dropped to
+ * lg:pl-[5.7rem] — the 288px moved out of padding and into real flex
+ * flow. display:none then collapsed it for real, #content-area
+ * (flex-grow) slid left to fill the gap, and only ~75px was left
+ * between the prose and the viewport edge. The -184px shift ran ~109px
+ * off the left edge, where an ancestor's `overflow-x-clip` sheared the
+ * date pill instead of producing a scrollbar. It only looked correct
+ * above ~1690px, where max-w-8xl centering happened to supply the
+ * missing slack. Reserving the 184px makes the gutter real at every
+ * width — and stays correct if Mintlify reverts to a fixed sidebar,
+ * since forcing the width of an out-of-flow box is a no-op. NAN-6464.
+ *
+ * Gated to lg+ (≥1024px). Below lg, Mintlify shows a hamburger menu
+ * instead of the desktop sidebar, and the Update component renders as a
+ * vertical stack (flex-col) where the label is full-width on top of the
+ * content. Applying the desktop shift on smaller viewports would push
+ * content off the left edge.
  */
 @media (min-width: 1024px) {
-  body:has([data-page-href*="updates/changelog"]) #sidebar-content,
+  /*
+   * border-right: without this the spacer keeps the divider from the
+   * `:has(> #sidebar-content)` rule further up and paints an orphan
+   * vertical rule down the empty gutter.
+   * pointer-events: the sidebar box is z-20 and now overlaps the date
+   * pill, which lives in #content-area at z-1 — without this the empty
+   * spacer swallows clicks on the pill's anchor link.
+   */
   body:has([data-page-href*="updates/changelog"]) :has(> #sidebar-content) {
+    width: 184px !important;
+    border-right: 0 !important;
+    pointer-events: none !important;
+  }
+
+  body:has([data-page-href*="updates/changelog"]) #sidebar-content {
     display: none !important;
   }
 
   /*
-   * Push only the Update components leftward into the freed sidebar
-   * space. The page header (title, description, copy page button)
-   * stays at its original prose-constrained position because we don't
-   * touch #content-area or #content. The Update flex row has a fixed
-   * 160px label column + 24px gap = 184px on the left, so we shift
-   * the entire .update-container left by 184px AND grow its width by
-   * 184px. Net effect: the date pill sits in the freed sidebar area,
-   * the content column starts where the date used to be, and the
+   * Push only the Update components leftward into the reserved gutter.
+   * The page header (title, description, copy page button) stays at its
+   * original prose-constrained position because we don't touch
+   * #content-area or #content. The Update flex row has a fixed 160px
+   * label column + 24px gap = 184px on the left, so we shift the entire
+   * .update-container left by 184px AND grow its width by 184px. Net
+   * effect: the date pill sits in the gutter, the content column starts
+   * where the date used to be (aligned with the page title), and the
    * right edge stays aligned with the rest of the page content.
    */
   body:has([data-page-href*="updates/changelog"]) .update-container {


### PR DESCRIPTION
## Issue
The <Update> date pills on /docs/updates/changelog are sheared off at the left edge of the window. It hits every viewport below ~1690px (any laptop or non-maximised window) but looks fine on a wide maximised display.

## Cause
We hide the left sidebar on that page and shift .update-container left by 184px, which worked while Mintlify rendered the sidebar position: fixed with its 288px reservation kept in #content-area's padding (lg:pl-[23.7rem]), leaving ~363px of room. 

Last week, Mintlify made the sidebar an in-flow flex item and dropped that padding to lg:pl-[5.7rem], so hiding it now collapses real space — only ~75px is left, the shift overruns by 108.8px, and an ancestor's overflow-x-clip cuts it off with no scrollbar.

## Fix
Collapse the sidebar to an empty 184px spacer instead of display: none, so the gutter the shift moves into is real at every width. Added border-right: 0 (otherwise an orphan divider runs down the empty gutter) and pointer-events: none (otherwise the z-20 spacer swallows clicks on the z-1 date pill).

## Tests
Loaded the live changelog page in headless Chromium with this branch's custom.css swapped in place, and measured 14 widths from 375 to 3840px. All pass: nothing clipped, body column still aligned with the page title, date pill link hit-testable, no horizontal overflow, sub-1024px stacked layout unchanged, light and dark clean.