### PR TITLE
docs: update external contribution guidelines

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,11 +1,14 @@
 # Contribution guidelines
 
-Nango only reviews external pull requests for:
+Thanks for your interest in contributing to Nango. We keep our review capacity focused on two types of external contributions:
 
-- **Security fixes.** Report vulnerabilities privately by following our [security policy](SECURITY.md) before submitting a fix.
-- **New API support.** Follow the [new API contribution guide](https://nango.dev/docs/integrations/contribute-or-request-api).
+- **Security fixes.** Please don't open a public issue or pull request. Report the vulnerability privately through our [security policy](SECURITY.md), and share any proposed fix through that same private channel.
+- **New API support.** Please follow the [new API contribution guide](https://nango.dev/docs/integrations/contribute-or-request-api) and we'll take it from there.
 
-We do not review external pull requests for bug fixes, new features, or improvements to existing features and APIs. Please report bugs in [GitHub issues](https://github.com/NangoHQ/nango/issues) instead. For questions and feedback, join the [community Slack](https://nango.dev/slack).
+For everything else, including bug fixes, new features, and improvements to existing features and APIs, we don't review external pull requests. We'd still love to hear from you:
+
+- Found something broken? [Report it](https://github.com/NangoHQ/nango/issues) and we'll take a look.
+- Questions, ideas, or feedback? Join us in the [community Slack](https://nango.dev/slack).
 
 See the [development setup](DEVELOPMENT.md) to run Nango and integrations locally.
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,78 +1,12 @@
-# Contribution Guidelines
+# Contribution guidelines
 
-To support a new API, simply ask the Nango team to add it with fast turnaround (2-5 days) on the [community](https://nango.dev/slack).
+Nango only reviews external pull requests for:
 
-For contributions, please [submit an issue](https://github.com/NangoHQ/nango/issues) describing your intent to contribute with details about your problem & solution. We will get back to you within 24h. Once we aligned & your change is approved by a team member, you can start implementing the change and submit a PR.
+- **Security fixes.** Report vulnerabilities privately by following our [security policy](SECURITY.md) before submitting a fix.
+- **New API support.** Follow the [new API contribution guide](https://nango.dev/docs/integrations/contribute-or-request-api).
 
-# Contributing
+We do not review external pull requests for bug fixes, new features, or improvements to existing features and APIs. Please report bugs in [GitHub issues](https://github.com/NangoHQ/nango/issues) instead. For questions and feedback, join the [community Slack](https://nango.dev/slack).
 
-You can run Nango locally with Docker and contribute an API ([step-by-step guide](https://nango.dev/docs/integrations/contribute-or-request-api)).
+See the [development setup](DEVELOPMENT.md) to run Nango and integrations locally.
 
-## Develop locally
-
-To develop on the platform locally follow those steps:
-
-```sh
-git clone https://github.com/NangoHQ/nango.git
-```
-
-Install the project
-
-```sh
-npm i
-npm run prepare
-```
-
-Set your envs
-
-```sh
-cp .env.example .env
-```
-
-Launch the databases and queue
-
-```sh
-npm run dev:docker
-```
-
-Launch Nango
-
-```sh
-# In two different shell
-npm run dev:watch
-npm run dev:watch:apps
-```
-
-Go to [http://localhost:3000](http://localhost:3000)
-
-## Run integrations
-
-Start by creating a folder that will contains your integrations
-
-```sh
-mkdir nango-integrations
-cd nango-integrations
-```
-
-Install the CLI
-
-```sh
-npm i -g nango
-```
-
-```sh
-nango init
-```
-
-Change the .env file `NANGO_SECRET_KEY_DEV` and `NANGO_HOSTPORT`.
-And deploy your changes
-
-```sh
-nango deploy dev
-```
-
-To know more about the CLI, check the [documentation](https://nango.dev/docs/reference/functions/functions-cli).
-
-## Proposing pull requests
-
-Pull Request title should follow [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/)
+Pull request titles must follow [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/). For a new API, use `feat(integrations): add support for <api>`.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -2,7 +2,7 @@
 
 Thanks for your interest in contributing to Nango. We keep our review capacity focused on two types of external contributions:
 
-- **Security fixes.** Please don't open a public issue or pull request. Report the vulnerability privately through our [security policy](SECURITY.md), and share any proposed fix through that same private channel.
+- **Security fixes.** Please don't open a public issue or pull request. Report the vulnerability privately as described in our [security policy](SECURITY.md).
 - **New API support.** Please follow the [new API contribution guide](https://nango.dev/docs/integrations/contribute-or-request-api) and we'll take it from there.
 
 For everything else, including bug fixes, new features, and improvements to existing features and APIs, we don't review external pull requests. We'd still love to hear from you:

--- a/DEVELOPMENT.md
+++ b/DEVELOPMENT.md
@@ -1,0 +1,55 @@
+# Development setup
+
+## Develop locally
+
+Clone the repository and install dependencies:
+
+```sh
+git clone https://github.com/NangoHQ/nango.git
+cd nango
+npm install
+npm run prepare
+```
+
+Create your environment file:
+
+```sh
+cp .env.example .env
+```
+
+Start the databases and queue:
+
+```sh
+npm run dev:docker
+```
+
+Run Nango in two separate terminals:
+
+```sh
+npm run dev:watch
+```
+
+```sh
+npm run dev:watch:apps
+```
+
+Open [http://localhost:3000](http://localhost:3000).
+
+## Run integrations
+
+Create a directory for your integrations and install the CLI:
+
+```sh
+mkdir nango-integrations
+cd nango-integrations
+npm install --global nango
+nango init
+```
+
+Set `NANGO_SECRET_KEY_DEV` and `NANGO_HOSTPORT` in `.env`, then deploy:
+
+```sh
+nango deploy dev
+```
+
+See the [CLI documentation](https://nango.dev/docs/reference/functions/functions-cli) for more information.

--- a/docs/contributing.mdx
+++ b/docs/contributing.mdx
@@ -1,6 +1,6 @@
 ---
 title: 'Contributing to Nango'
-sidebarTitle: 'Contributing to Nango'
+sidebarTitle: 'Contributing'
 description: 'Learn which external contributions Nango reviews'
 ---
 

--- a/docs/contributing.mdx
+++ b/docs/contributing.mdx
@@ -1,6 +1,6 @@
 ---
 title: 'Contributing to Nango'
-sidebarTitle: 'Contributing'
+sidebarTitle: 'Contributing to Nango'
 description: 'Learn which external contributions Nango reviews'
 ---
 

--- a/docs/contributing.mdx
+++ b/docs/contributing.mdx
@@ -4,9 +4,12 @@ sidebarTitle: 'Contributing to Nango'
 description: 'Learn which external contributions Nango reviews'
 ---
 
-Nango only reviews external pull requests for:
+Thanks for your interest in contributing to Nango. We keep our review capacity focused on two types of external contributions:
 
-- **Security fixes.** Report vulnerabilities privately through our [security policy](https://github.com/NangoHQ/nango/security/policy) before submitting a fix.
-- **New API support.** Follow the [new API contribution guide](/integrations/contribute-or-request-api).
+- **Security fixes.** Please don't open a public issue or pull request. Report the vulnerability privately through our [security policy](https://github.com/NangoHQ/nango/security/policy), and share any proposed fix through that same private channel.
+- **New API support.** Please follow the [new API contribution guide](/integrations/contribute-or-request-api) and we'll take it from there.
 
-We do not review external pull requests for bug fixes, new features, or improvements to existing features and APIs. Please [report bugs](https://github.com/NangoHQ/nango/issues) instead. For questions and feedback, join the [community Slack](https://nango.dev/slack).
+For everything else, including bug fixes, new features, and improvements to existing features and APIs, we don't review external pull requests. We'd still love to hear from you:
+
+- Found something broken? [Report it](https://github.com/NangoHQ/nango/issues) and we'll take a look.
+- Questions, ideas, or feedback? Join us in the [community Slack](https://nango.dev/slack).

--- a/docs/contributing.mdx
+++ b/docs/contributing.mdx
@@ -6,7 +6,7 @@ description: 'Learn which external contributions Nango reviews'
 
 Thanks for your interest in contributing to Nango. We keep our review capacity focused on two types of external contributions:
 
-- **Security fixes.** Please don't open a public issue or pull request. Report the vulnerability privately through our [security policy](https://github.com/NangoHQ/nango/security/policy), and share any proposed fix through that same private channel.
+- **Security fixes.** Please don't open a public issue or pull request. Report the vulnerability privately as described in our [security policy](https://nango.dev/security).
 - **New API support.** Please follow the [new API contribution guide](/integrations/contribute-or-request-api) and we'll take it from there.
 
 For everything else, including bug fixes, new features, and improvements to existing features and APIs, we don't review external pull requests. We'd still love to hear from you:

--- a/docs/contributing.mdx
+++ b/docs/contributing.mdx
@@ -1,0 +1,12 @@
+---
+title: 'Contributing to Nango'
+sidebarTitle: 'Contributing'
+description: 'Learn which external contributions Nango reviews'
+---
+
+Nango only reviews external pull requests for:
+
+- **Security fixes.** Report vulnerabilities privately through our [security policy](https://github.com/NangoHQ/nango/security/policy) before submitting a fix.
+- **New API support.** Follow the [new API contribution guide](/integrations/contribute-or-request-api).
+
+We do not review external pull requests for bug fixes, new features, or improvements to existing features and APIs. Please [report bugs](https://github.com/NangoHQ/nango/issues) instead. For questions and feedback, join the [community Slack](https://nango.dev/slack).

--- a/docs/docs.json
+++ b/docs/docs.json
@@ -773,7 +773,8 @@
                       "guides/platform/migrations/migrate-from-public-key",
                       "guides/platform/migrations/migrate-to-zero-yaml"
                     ]
-                  }
+                  },
+                  "contributing"
                 ]
               }
             ]
@@ -919,12 +920,6 @@
                   "reference/functions/functions-sdk"
                 ]
               }
-            ]
-          },
-          {
-            "group": "Contributing",
-            "pages": [
-              "contributing"
             ]
           }
         ]

--- a/docs/docs.json
+++ b/docs/docs.json
@@ -920,6 +920,12 @@
                 ]
               }
             ]
+          },
+          {
+            "group": "Contributing",
+            "pages": [
+              "contributing"
+            ]
           }
         ]
       },

--- a/docs/llms-full.txt
+++ b/docs/llms-full.txt
@@ -8643,7 +8643,7 @@ Description: Learn which external contributions Nango reviews
 
 Thanks for your interest in contributing to Nango. We keep our review capacity focused on two types of external contributions:
 
-- **Security fixes.** Please don't open a public issue or pull request. Report the vulnerability privately through our [security policy](https://github.com/NangoHQ/nango/security/policy), and share any proposed fix through that same private channel.
+- **Security fixes.** Please don't open a public issue or pull request. Report the vulnerability privately as described in our [security policy](https://nango.dev/security).
 - **New API support.** Please follow the [new API contribution guide](/integrations/contribute-or-request-api) and we'll take it from there.
 
 For everything else, including bug fixes, new features, and improvements to existing features and APIs, we don't review external pull requests. We'd still love to hear from you:

--- a/docs/llms-full.txt
+++ b/docs/llms-full.txt
@@ -13946,6 +13946,18 @@ Please reach out in the [community](https://nango.dev/slack) if you would like t
   **Questions, problems, feedback?** Please reach out in the [Slack community](https://nango.dev/slack).
 </Tip>
 
+## Contributing to Nango
+
+Source: https://nango.dev/docs/contributing.md
+Description: Learn which external contributions Nango reviews
+
+Nango only reviews external pull requests for:
+
+- **Security fixes.** Report vulnerabilities privately through our [security policy](https://github.com/NangoHQ/nango/security/policy) before submitting a fix.
+- **New API support.** Follow the [new API contribution guide](/integrations/contribute-or-request-api).
+
+We do not review external pull requests for bug fixes, new features, or improvements to existing features and APIs. Please [report bugs](https://github.com/NangoHQ/nango/issues) instead. For questions and feedback, join the [community Slack](https://nango.dev/slack).
+
 ## Explore APIs & integrations
 
 Source: https://nango.dev/docs/integrations/overview.md

--- a/docs/llms-full.txt
+++ b/docs/llms-full.txt
@@ -8636,6 +8636,21 @@ If you encounter any issues during migration, our support team is ready to help.
 - [Functions CLI](/reference/functions/functions-cli) - deploy and dry-run migrated functions.
 - [Testing](/guides/functions/testing) - verify migrated integrations before rollout.
 
+## Contributing to Nango
+
+Source: https://nango.dev/docs/contributing.md
+Description: Learn which external contributions Nango reviews
+
+Thanks for your interest in contributing to Nango. We keep our review capacity focused on two types of external contributions:
+
+- **Security fixes.** Please don't open a public issue or pull request. Report the vulnerability privately through our [security policy](https://github.com/NangoHQ/nango/security/policy), and share any proposed fix through that same private channel.
+- **New API support.** Please follow the [new API contribution guide](/integrations/contribute-or-request-api) and we'll take it from there.
+
+For everything else, including bug fixes, new features, and improvements to existing features and APIs, we don't review external pull requests. We'd still love to hear from you:
+
+- Found something broken? [Report it](https://github.com/NangoHQ/nango/issues) and we'll take a look.
+- Questions, ideas, or feedback? Join us in the [community Slack](https://nango.dev/slack).
+
 ## Frontend SDK
 
 Source: https://nango.dev/docs/reference/frontend/frontend-sdk.md
@@ -13945,18 +13960,6 @@ Please reach out in the [community](https://nango.dev/slack) if you would like t
 <Tip>
   **Questions, problems, feedback?** Please reach out in the [Slack community](https://nango.dev/slack).
 </Tip>
-
-## Contributing to Nango
-
-Source: https://nango.dev/docs/contributing.md
-Description: Learn which external contributions Nango reviews
-
-Nango only reviews external pull requests for:
-
-- **Security fixes.** Report vulnerabilities privately through our [security policy](https://github.com/NangoHQ/nango/security/policy) before submitting a fix.
-- **New API support.** Follow the [new API contribution guide](/integrations/contribute-or-request-api).
-
-We do not review external pull requests for bug fixes, new features, or improvements to existing features and APIs. Please [report bugs](https://github.com/NangoHQ/nango/issues) instead. For questions and feedback, join the [community Slack](https://nango.dev/slack).
 
 ## Explore APIs & integrations
 

--- a/docs/llms.txt
+++ b/docs/llms.txt
@@ -133,6 +133,10 @@ Use provider URLs by replacing `{slug}` with a slug from the API catalog:
 - [Functions: Functions CLI](https://nango.dev/docs/reference/functions/functions-cli.md): Full reference of the CLI available to implement, test & deploy Nango Functions.
 - [Functions: Functions SDK](https://nango.dev/docs/reference/functions/functions-sdk.md): Full reference of the SDK available in Nango Functions.
 
+## Contributing
+
+- [Contributing to Nango](https://nango.dev/docs/contributing.md): Learn which external contributions Nango reviews
+
 ## Overview
 
 - [Explore APIs & integrations](https://nango.dev/docs/integrations/overview.md)

--- a/docs/llms.txt
+++ b/docs/llms.txt
@@ -63,6 +63,7 @@ Use provider URLs by replacing `{slug}` with a slug from the API catalog:
 - [Platform: Migrations: Migrate from end user](https://nango.dev/docs/guides/platform/migrations/migrate-from-end-user.md): Guide to migrate away from using end users in connections and connect sessions
 - [Platform: Migrations: Migrate from public key](https://nango.dev/docs/guides/platform/migrations/migrate-from-public-key.md): Guide to migrate from using the public key (and HMAC) to a Connect session.
 - [Platform: Migrations: Migrating to Zero YAML](https://nango.dev/docs/guides/platform/migrations/migrate-to-zero-yaml.md): Guide on how to migrate to Zero YAML in Nango.
+- [Platform: Contributing to Nango](https://nango.dev/docs/contributing.md): Learn which external contributions Nango reviews
 
 ## Reference
 
@@ -132,10 +133,6 @@ Use provider URLs by replacing `{slug}` with a slug from the API catalog:
 - [Backend: Management MCP (Beta)](https://nango.dev/docs/reference/backend/management-mcp.md): Manage a Nango environment from an MCP client.
 - [Functions: Functions CLI](https://nango.dev/docs/reference/functions/functions-cli.md): Full reference of the CLI available to implement, test & deploy Nango Functions.
 - [Functions: Functions SDK](https://nango.dev/docs/reference/functions/functions-sdk.md): Full reference of the SDK available in Nango Functions.
-
-## Contributing
-
-- [Contributing to Nango](https://nango.dev/docs/contributing.md): Learn which external contributions Nango reviews
 
 ## Overview
 


### PR DESCRIPTION
## Problem and solution

External contribution scope was too broad and we were being hit by PRs with improvements we didn't want to maintain, or completely new features. This PR updates the guidelines to limit accepted external pull requests to security fixes and new API support, routes other requests to GitHub issues or Slack.

## Issue

[EPW-6](https://linear.app/nango/issue/EPW-6/stop-accepting-external-contributions)

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/NangoHQ/nango/pull/6944?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

