### PR TITLE
fix(mfa): enforce MFA on managed auth logins (NAN-6463)

### DIFF
--- a/packages/server/lib/controllers/v1/account/managed/auth.ts
+++ b/packages/server/lib/controllers/v1/account/managed/auth.ts
@@ -4,9 +4,10 @@ import { basePublicUrl, flagHasUsage, nanoid, normalizeEmail, report } from '@na
 
 import { envs } from '../../../../env.js';
 import { linkBillingCustomer, linkBillingFreeSubscription } from '../../../../utils/billing.js';
+import { loginOrStartPendingMfa } from '../mfa/login.js';
 
 import type { InviteAccountState } from './postSignup.js';
-import type { DBInvitation, DBTeam, DBUser } from '@nangohq/types';
+import type { DBInvitation, DBTeam } from '@nangohq/types';
 import type { User, WorkOS } from '@workos-inc/node';
 import type { Request, Response } from 'express';
 
@@ -89,19 +90,6 @@ export async function setManagedAuthEmailVerification(req: Request, verification
         state
     };
     await saveSession(req);
-}
-
-async function loginManagedAuthUser(req: Request, user: DBUser): Promise<void> {
-    await new Promise<void>((resolve, reject) => {
-        req.login(user, (err) => {
-            if (err) {
-                reject(err instanceof Error ? err : new Error(String(err)));
-                return;
-            }
-
-            resolve();
-        });
-    });
 }
 
 export function getManagedAuthRequestMetadata(req: Request) {
@@ -210,31 +198,35 @@ export async function finalizeManagedAuthentication({
 
     clearManagedAuthEmailVerification(req);
 
+    let destination = '/';
     try {
-        await loginManagedAuthUser(req, user);
+        if (invitation && isNewUser) {
+            // New user: created directly in the invited team, auto-accept and proceed
+            await acceptInvitation(invitation.token);
+        } else if (invitation) {
+            // Existing user: let them explicitly accept or decline on the invite page
+            destination = `/signup/${invitation.token}`;
+        } else if (isNewUser) {
+            destination = '/onboarding/hear-about-us';
+        }
+    } catch (err) {
+        report(err);
+        res.status(500).send({ error: { code: 'server_error', message: 'Failed to finalize login' } });
+        return;
+    }
+
+    try {
+        if (await loginOrStartPendingMfa(req, user, destination)) {
+            respondWithSuccess(res, `${basePublicUrl}/signin/mfa`, responseMode);
+            return;
+        }
     } catch (err) {
         report(err);
         res.status(500).send({ error: { code: 'server_error', message: 'Failed to login' } });
         return;
     }
 
-    try {
-        if (invitation && isNewUser) {
-            // New user: created directly in the invited team, auto-accept and proceed
-            await acceptInvitation(invitation.token);
-            respondWithSuccess(res, `${basePublicUrl}/`, responseMode);
-        } else if (invitation) {
-            // Existing user: log them in and let them explicitly accept or decline on the invite page
-            respondWithSuccess(res, `${basePublicUrl}/signup/${invitation.token}`, responseMode);
-        } else if (isNewUser) {
-            respondWithSuccess(res, `${basePublicUrl}/onboarding/hear-about-us`, responseMode);
-        } else {
-            respondWithSuccess(res, `${basePublicUrl}/`, responseMode);
-        }
-    } catch (err) {
-        report(err);
-        res.status(500).send({ error: { code: 'server_error', message: 'Failed to finalize login' } });
-    }
+    respondWithSuccess(res, `${basePublicUrl}${destination}`, responseMode);
 }
 
 function respondWithSuccess(res: Response, url: string, responseMode: 'json' | 'redirect') {

--- a/packages/server/lib/controllers/v1/account/managed/verification.integration.test.ts
+++ b/packages/server/lib/controllers/v1/account/managed/verification.integration.test.ts
@@ -1,9 +1,11 @@
+import * as OTPAuth from 'otpauth';
 import { afterAll, beforeAll, beforeEach, describe, expect, it, vi } from 'vitest';
 
-import { userService } from '@nangohq/shared';
+import { mfaService, seeders, userService } from '@nangohq/shared';
 import { nanoid, normalizeEmail } from '@nangohq/utils';
 
 import type { runServer as runServerType } from '../../../../utils/tests.js';
+import type * as featureFlagsType from '@nangohq/feature-flags';
 
 const workosMocks = vi.hoisted(() => {
     process.env['FLAG_MANAGED_AUTH_ENABLED'] = 'true';
@@ -38,16 +40,19 @@ type RunServer = typeof runServerType;
 
 let api: Awaited<ReturnType<RunServer>>;
 let runServer: RunServer;
+let featureFlags: typeof featureFlagsType;
 
 describe(`POST ${route}`, () => {
     beforeAll(async () => {
         vi.resetModules();
         ({ runServer } = await import('../../../../utils/tests.js'));
+        featureFlags = await import('@nangohq/feature-flags');
         api = await runServer();
     });
 
     afterAll(() => {
         api.server.close();
+        vi.restoreAllMocks();
     });
 
     beforeEach(() => {
@@ -196,5 +201,60 @@ describe(`POST ${route}`, () => {
                 code: 'generic_error_support'
             }
         });
+    });
+
+    it('should challenge MFA before completing a managed auth login', async () => {
+        vi.spyOn(featureFlags.getFlags(), 'isMFAEnabled').mockResolvedValue(true);
+
+        const { user } = await seeders.seedAccountEnvAndUser();
+        const enrollment = (await mfaService.startEnrollment(user.id, user.email)).unwrap();
+        const totp = OTPAuth.URI.parse(enrollment.otpauthUri) as OTPAuth.TOTP;
+        (await mfaService.activateEnrollment(user.id, totp.generate())).unwrap();
+
+        workosMocks.authenticateWithCode.mockResolvedValue({
+            user: { email: user.email, firstName: 'Managed', lastName: 'User' },
+            organizationId: undefined
+        });
+
+        const callbackRes = await fetch(`${api.url}/api/v1/login/callback?code=oauth_code_123`, {
+            redirect: 'manual'
+        });
+
+        expect(callbackRes.status).toBe(302);
+        expect(callbackRes.headers.get('location')).toBe('http://localhost:3003/signin/mfa');
+
+        const sessionCookie = callbackRes.headers.getSetCookie()[0]?.split(';')[0];
+        expect(sessionCookie).toBeTruthy();
+
+        const beforeVerification = await api.fetch('/api/v1/account/mfa', { method: 'GET', session: sessionCookie! });
+        expect(beforeVerification.res.status).toBe(401);
+
+        const verification = await api.fetch('/api/v1/account/mfa/login/verify', {
+            method: 'POST',
+            session: sessionCookie!,
+            // A fresh window, the activation code above is already consumed
+            body: { type: 'code', code: totp.generate({ timestamp: Date.now() + 30_000 }) }
+        });
+
+        expect(verification.res.status).toBe(200);
+        expect(verification.json).toMatchObject({ data: { url: '/', user: { email: user.email } } });
+    });
+
+    it('should not challenge MFA when the user has no active factor', async () => {
+        vi.spyOn(featureFlags.getFlags(), 'isMFAEnabled').mockResolvedValue(true);
+
+        const { user } = await seeders.seedAccountEnvAndUser();
+
+        workosMocks.authenticateWithCode.mockResolvedValue({
+            user: { email: user.email, firstName: 'Managed', lastName: 'User' },
+            organizationId: undefined
+        });
+
+        const callbackRes = await fetch(`${api.url}/api/v1/login/callback?code=oauth_code_123`, {
+            redirect: 'manual'
+        });
+
+        expect(callbackRes.status).toBe(302);
+        expect(callbackRes.headers.get('location')).toBe('http://localhost:3003/');
     });
 });


### PR DESCRIPTION
MFA is enforced in exactly one place, `loginOrStartPendingMfa`, and until now it had a single call site: the local password route.

The managed auth path had its own `loginManagedAuthUser` that called `req.login` directly, so none of the WorkOS flows (Google OAuth, SSO org callback, WorkOS email verification) ever saw the gate. Since `finalizeManagedAuthentication` resolves the user by email, it is the same DB row as the password login. A user who enrolled TOTP could skip it entirely by signing in with Google or SSO instead.

### What changed

- `finalizeManagedAuthentication` now goes through `loginOrStartPendingMfa` and redirects to `/signin/mfa` when a challenge is pending
- Destination is computed before login so it can be carried as the `returnTo`, invitation accept moved ahead of the gate
- Works for both response modes, the callback is a redirect and the WorkOS verification path is json
- No UI change. `MFALogin.tsx` is driven entirely by the server session, so a plain redirect lands on a working page

NAN-6463