### PR TITLE
feat(audit): batch the consumer's writes and stop dropping events on failure

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -36125,6 +36125,7 @@
             "version": "1.0.0",
             "dependencies": {
                 "@aws-sdk/client-s3": "3.993.0",
+                "@aws-sdk/client-sqs": "3.993.0",
                 "@nangohq/audit": "file:../audit",
                 "@nangohq/billing": "file:../billing",
                 "@nangohq/database": "file:../database",

--- a/packages/audit/lib/clickhouse.ts
+++ b/packages/audit/lib/clickhouse.ts
@@ -2,10 +2,17 @@ import { createClient } from '@clickhouse/client';
 
 import type { ClickHouseClient } from '@clickhouse/client';
 
-export function auditClickhouseClient(clickhouseUrl: string): ClickHouseClient {
+// A dashboard query has nothing to retry, so reads wait out a suspended dev/staging instance waking up.
+// A write must instead finish inside the queue's visibility timeout, so its caller passes a shorter one.
+const READ_REQUEST_TIMEOUT_MS = 60_000;
+
+export function auditClickhouseClient(
+    clickhouseUrl: string,
+    { requestTimeoutMs = READ_REQUEST_TIMEOUT_MS }: { requestTimeoutMs?: number } = {}
+): ClickHouseClient {
     return createClient({
         url: clickhouseUrl,
         database: 'usage',
-        request_timeout: 60_000 // CH Cloud auto-suspend wake-up can exceed the 30s default
+        request_timeout: requestTimeoutMs
     });
 }

--- a/packages/audit/lib/error.ts
+++ b/packages/audit/lib/error.ts
@@ -1,0 +1,13 @@
+const MAX_LENGTH = 600;
+
+/**
+ * `VIOLATED_CONSTRAINT` and format-parse errors quote the offending row back, and the audit blob holds the
+ * actor's email and IP — logging one verbatim would copy that into logs with none of the audit store's
+ * controls. Everything diagnostic precedes the quoted row, so cutting from there keeps the error useful.
+ */
+export function sanitizeClickhouseError(err: unknown): string {
+    const message = err instanceof Error ? err.message : String(err);
+    const cut = message.search(/Column values:|Cannot parse input:/);
+    const sanitized = cut === -1 ? message : `${message.slice(0, cut).trimEnd()} [row omitted]`;
+    return sanitized.length > MAX_LENGTH ? `${sanitized.slice(0, MAX_LENGTH)}…` : sanitized;
+}

--- a/packages/audit/lib/error.unit.test.ts
+++ b/packages/audit/lib/error.unit.test.ts
@@ -1,0 +1,54 @@
+import { describe, expect, it } from 'vitest';
+
+import { sanitizeClickhouseError } from './error.js';
+
+// Verbatim shapes captured from ClickHouse 26.3.3 inserting into the real audit table.
+const EMAIL = 'secret.person@customer.example';
+
+describe('sanitizeClickhouseError', () => {
+    it('keeps a throwing-extractor error whole — it names the field and value, neither of which is PII', () => {
+        const err = new Error(
+            `Code: 376. DB::Exception: Cannot parse uuid NOT-A-UUID: Cannot parse UUID from String: while executing 'FUNCTION toUUID(JSONExtractString(event, 'id'_String) :: 1)': (CANNOT_PARSE_UUID)`
+        );
+        const out = sanitizeClickhouseError(err);
+        expect(out).toContain('CANNOT_PARSE_UUID');
+        expect(out).toContain('NOT-A-UUID');
+        expect(out).toContain("JSONExtractString(event, 'id'");
+    });
+
+    it('strips the row a constraint violation quotes back', () => {
+        const err = new Error(
+            `Code: 469. DB::Exception: Constraint \`account_id_valid\` for table audit.audit_trail_events is violated at row 1. ` +
+                `Expression: (JSONType(event, 'accountId') IN ('Int64', 'UInt64')). ` +
+                `Column values: event = '{"id": "2222", "actor": {"display": "${EMAIL}"}, "context": {"ip": "203.0.113.77"}}': (VIOLATED_CONSTRAINT)`
+        );
+        const out = sanitizeClickhouseError(err);
+
+        expect(out).not.toContain(EMAIL);
+        expect(out).not.toContain('203.0.113.77');
+        // Still diagnostic: the code, the constraint and the expression survive.
+        expect(out).toContain('account_id_valid');
+        expect(out).toContain("JSONType(event, 'accountId')");
+        expect(out).toContain('[row omitted]');
+    });
+
+    it('strips the payload a format-parse error echoes wholesale', () => {
+        const err = new Error(
+            `Code: 27. DB::Exception: Cannot parse input: expected ',' before: 'actor":{"display":"${EMAIL}"},"context":{"ip":"203.0.113.77"}}': (at row 1)`
+        );
+        const out = sanitizeClickhouseError(err);
+
+        expect(out).not.toContain(EMAIL);
+        expect(out).not.toContain('203.0.113.77');
+        expect(out).toContain('Code: 27');
+    });
+
+    it('bounds the length so an unrecognised shape cannot dump a payload either', () => {
+        const out = sanitizeClickhouseError(new Error(`DB::Exception: ${EMAIL.repeat(200)}`));
+        expect(out.length).toBeLessThanOrEqual(601);
+    });
+
+    it('accepts a non-Error', () => {
+        expect(sanitizeClickhouseError('plain string')).toBe('plain string');
+    });
+});

--- a/packages/audit/lib/index.ts
+++ b/packages/audit/lib/index.ts
@@ -3,5 +3,4 @@ export type { AuditBatchWriter, AuditReader, AuditWriter } from './store.js';
 export { ClickhouseAuditStore, DropAuditStore } from './store.js';
 export { PubSubAuditWriter } from './pubsub.js';
 export { auditClickhouseClient } from './clickhouse.js';
-export { sanitizeClickhouseError } from './error.js';
 export { AuditClient, InvalidAuditCursorError } from './audit.js';

--- a/packages/audit/lib/index.ts
+++ b/packages/audit/lib/index.ts
@@ -1,6 +1,7 @@
 export type * from './event.js';
-export type { AuditReader, AuditWriter } from './store.js';
+export type { AuditBatchWriter, AuditReader, AuditWriter } from './store.js';
 export { ClickhouseAuditStore, DropAuditStore } from './store.js';
 export { PubSubAuditWriter } from './pubsub.js';
 export { auditClickhouseClient } from './clickhouse.js';
+export { sanitizeClickhouseError } from './error.js';
 export { AuditClient, InvalidAuditCursorError } from './audit.js';

--- a/packages/audit/lib/store.integration.test.ts
+++ b/packages/audit/lib/store.integration.test.ts
@@ -136,3 +136,31 @@ describe('AuditClient.record through ClickhouseAuditStore', () => {
         expect(events[0]!.resource).toBe('connection');
     });
 });
+
+describe('ClickhouseAuditStore.list deduplication', () => {
+    it('returns one row for an event that was stored twice', async () => {
+        const id = '44444444-4444-4444-4444-444444444444';
+        // Merges are what eventually collapse a ReplacingMergeTree duplicate, and on a table this small one
+        // fires almost immediately — stopping them is what makes this test the read path rather than a merge.
+        await client.command({ query: `SYSTEM STOP MERGES ${database}.audit_trail_events` });
+        try {
+            // At-least-once delivery: the same event, same ORDER BY key, written by two separate attempts.
+            await insertEvent({ id, accountId: 9, occurredAt: at(3000) });
+            await insertEvent({ id, accountId: 9, occurredAt: at(3000) });
+
+            const raw = await client.query({
+                query: `SELECT count() AS c FROM ${database}.audit_trail_events WHERE account_id = 9`,
+                format: 'JSONEachRow'
+            });
+            expect(Number((await raw.json<{ c: string | number }>())[0]!.c)).toBe(2);
+
+            // Both rows are in storage, yet the read returns one — so a redelivered event never shows up
+            // twice in the dashboard while it waits for a merge.
+            const { events } = (await store.list({ accountId: 9, limit: 10 })).unwrap();
+            expect(events).toHaveLength(1);
+            expect(events[0]!.id).toBe(id);
+        } finally {
+            await client.command({ query: `SYSTEM START MERGES ${database}.audit_trail_events` });
+        }
+    });
+});

--- a/packages/audit/lib/store.ts
+++ b/packages/audit/lib/store.ts
@@ -1,3 +1,5 @@
+import { ClickHouseError } from '@clickhouse/client';
+
 import { Err, getLogger, metrics, Ok, stringifyError } from '@nangohq/utils';
 
 import type { ClickHouseClient } from '@clickhouse/client';
@@ -31,6 +33,11 @@ export interface AuditWriter {
     record(record: SerializedAuditEvent): Promise<Result<void>>;
 }
 
+export interface AuditBatchWriter {
+    /** `dedupToken` must be stable across retries of a batch, so a re-sent insert is discarded server-side. */
+    recordMany(records: SerializedAuditEvent[], opts: { dedupToken: string }): Promise<Result<void>>;
+}
+
 export interface AuditReader {
     list(params: ListAuditTrailEventsParams): Promise<Result<AuditTrailPage>>;
 }
@@ -45,7 +52,7 @@ export class DropAuditStore implements AuditWriter, AuditReader {
     }
 }
 
-export class ClickhouseAuditStore implements AuditWriter, AuditReader {
+export class ClickhouseAuditStore implements AuditWriter, AuditBatchWriter, AuditReader {
     constructor(
         private readonly client: ClickHouseClient,
         private readonly retentionDays = AUDIT_RETENTION_DAYS
@@ -54,16 +61,32 @@ export class ClickhouseAuditStore implements AuditWriter, AuditReader {
     // Never throws, so every call emits exactly one ingest-result metric — callers rely on that to
     // reconcile events published against events stored.
     async record(record: SerializedAuditEvent): Promise<Result<void>> {
+        return this.insert([record], {});
+    }
+
+    async recordMany(records: SerializedAuditEvent[], { dedupToken }: { dedupToken: string }): Promise<Result<void>> {
+        if (records.length === 0) {
+            return Ok(undefined);
+        }
+        return this.insert(records, { insert_deduplication_token: dedupToken });
+    }
+
+    private async insert(records: SerializedAuditEvent[], settings: { insert_deduplication_token?: string }): Promise<Result<void>> {
         try {
             await this.client.insert({
                 table: 'audit_trail_events',
-                values: [{ event: record.event, retention_days: this.retentionDays }],
-                format: 'JSONEachRow'
+                values: records.map((r) => ({ event: r.event, retention_days: this.retentionDays })),
+                format: 'JSONEachRow',
+                clickhouse_settings: settings
             });
-            metrics.increment(metrics.Types.AUDIT_CLICKHOUSE_INGEST_RESULT, 1, { success: 'true' });
+            metrics.increment(metrics.Types.AUDIT_CLICKHOUSE_INGEST_RESULT, records.length, { success: 'true' });
             return Ok(undefined);
         } catch (err) {
-            metrics.increment(metrics.Types.AUDIT_CLICKHOUSE_INGEST_RESULT, 1, { success: 'false' });
+            // ClickHouse's own code, so alerting can separate a rejected event (a bug in what we emit, e.g.
+            // 469 VIOLATED_CONSTRAINT or 376 CANNOT_PARSE_UUID) from an unavailable backend, without this
+            // having to enumerate codes or match on message text.
+            const code = err instanceof ClickHouseError ? err.code : 'unknown';
+            metrics.increment(metrics.Types.AUDIT_CLICKHOUSE_INGEST_RESULT, records.length, { success: 'false', code });
             return Err(err);
         }
     }
@@ -85,6 +108,9 @@ export class ClickhouseAuditStore implements AuditWriter, AuditReader {
             params['before_id'] = before.id;
         }
 
+        // No FINAL and no `LIMIT 1 BY id`: both dedup server-side but defeat the short-circuit ORDER BY gets
+        // from the primary key prefix. Unbounded on a 5M-row account, rows read: 99K as written, 1.1M with
+        // LIMIT 1 BY, 5M with FINAL. Copies are dropped from the result set instead.
         // Cursor columns aliased so `occurred_at`/`id` in WHERE/ORDER BY still resolve to the real columns.
         const sql = `
             SELECT event, toString(id) AS cursor_id, toString(occurred_at) AS cursor_occurred_at
@@ -103,9 +129,13 @@ export class ClickhouseAuditStore implements AuditWriter, AuditReader {
             });
             const rows = await res.json<{ event: string; cursor_id: string; cursor_occurred_at: string }>();
 
+            // Copies share (account_id, occurred_at, id), so they are adjacent in this ordering. `hasMore`
+            // stays keyed off the raw count: a page thinned by more than the spare row is short, not final.
+            const deduped = rows.filter((row, i) => i === 0 || row.cursor_id !== rows[i - 1]!.cursor_id);
+
             // Fetched limit+1: the extra row means there's another page — drop it and expose its cursor.
             const hasMore = rows.length > limit;
-            const page = hasMore ? rows.slice(0, limit) : rows;
+            const page = deduped.slice(0, limit);
             const last = page.at(-1);
             const nextCursor = hasMore && last ? { occurredAt: last.cursor_occurred_at, id: last.cursor_id } : null;
 

--- a/packages/audit/lib/store.ts
+++ b/packages/audit/lib/store.ts
@@ -2,6 +2,8 @@ import { ClickHouseError } from '@clickhouse/client';
 
 import { Err, getLogger, metrics, Ok, stringifyError } from '@nangohq/utils';
 
+import { sanitizeClickhouseError } from './error.js';
+
 import type { ClickHouseClient } from '@clickhouse/client';
 import type { ApiAuditTrailEvent, SerializedAuditEvent } from '@nangohq/types';
 import type { Result } from '@nangohq/utils';
@@ -82,12 +84,13 @@ export class ClickhouseAuditStore implements AuditWriter, AuditBatchWriter, Audi
             metrics.increment(metrics.Types.AUDIT_CLICKHOUSE_INGEST_RESULT, records.length, { success: 'true' });
             return Ok(undefined);
         } catch (err) {
-            // ClickHouse's own code, so alerting can separate a rejected event (a bug in what we emit, e.g.
-            // 469 VIOLATED_CONSTRAINT or 376 CANNOT_PARSE_UUID) from an unavailable backend, without this
-            // having to enumerate codes or match on message text.
-            const code = err instanceof ClickHouseError ? err.code : 'unknown';
-            metrics.increment(metrics.Types.AUDIT_CLICKHOUSE_INGEST_RESULT, records.length, { success: 'false', code });
-            return Err(err);
+            // A block insert is atomic, so a server error means nothing was written. No response means the
+            // opposite: the rows may be stored and a retry can duplicate them. The specific code is logged
+            // rather than tagged, to keep this dimension bounded.
+            const reason = err instanceof ClickHouseError ? 'server_error' : 'no_response';
+            metrics.increment(metrics.Types.AUDIT_CLICKHOUSE_INGEST_RESULT, records.length, { success: 'false', reason });
+            // Sanitised here so no caller can log the row ClickHouse quotes back.
+            return Err(new Error(sanitizeClickhouseError(err)));
         }
     }
 

--- a/packages/audit/lib/store.unit.test.ts
+++ b/packages/audit/lib/store.unit.test.ts
@@ -1,3 +1,4 @@
+import { ClickHouseError } from '@clickhouse/client';
 import { afterEach, describe, expect, it, vi } from 'vitest';
 
 import { metrics } from '@nangohq/utils';
@@ -52,7 +53,7 @@ describe('ClickhouseAuditStore.record', () => {
         const result = await store.record(record);
 
         expect(result.isErr()).toBe(true);
-        expect(inc).toHaveBeenCalledWith(metrics.Types.AUDIT_CLICKHOUSE_INGEST_RESULT, 1, { success: 'false' });
+        expect(inc).toHaveBeenCalledWith(metrics.Types.AUDIT_CLICKHOUSE_INGEST_RESULT, 1, { success: 'false', code: 'unknown' });
     });
 
     it('returns Err with a failure metric instead of throwing on a malformed record', async () => {
@@ -62,7 +63,7 @@ describe('ClickhouseAuditStore.record', () => {
         const result = await store.record(undefined as unknown as SerializedAuditEvent);
 
         expect(result.isErr()).toBe(true);
-        expect(inc).toHaveBeenCalledWith(metrics.Types.AUDIT_CLICKHOUSE_INGEST_RESULT, 1, { success: 'false' });
+        expect(inc).toHaveBeenCalledWith(metrics.Types.AUDIT_CLICKHOUSE_INGEST_RESULT, 1, { success: 'false', code: 'unknown' });
     });
 });
 
@@ -71,5 +72,60 @@ describe('DropAuditStore', () => {
         const store: AuditWriter & AuditReader = new DropAuditStore();
         expect((await store.record(record)).isOk()).toBe(true);
         expect((await store.list({ accountId: 1, limit: 25 })).unwrap()).toEqual({ events: [], nextCursor: null });
+    });
+});
+
+describe('ClickhouseAuditStore.recordMany', () => {
+    afterEach(() => vi.restoreAllMocks());
+
+    it('writes the whole batch in one insert, carrying the dedup token', async () => {
+        const inc = vi.spyOn(metrics, 'increment').mockImplementation(() => undefined);
+        const insert = vi.fn().mockResolvedValue({});
+        const store = new ClickhouseAuditStore({ insert } as unknown as ClickHouseClient, 90);
+
+        const result = await store.recordMany([record, { event: '{"id":"second"}' }], { dedupToken: 'token-1' });
+
+        expect(result.isOk()).toBe(true);
+        expect(insert).toHaveBeenCalledOnce();
+        const arg = insert.mock.calls[0]![0] as {
+            values: { event: string; retention_days: number }[];
+            clickhouse_settings: { insert_deduplication_token?: string };
+        };
+        expect(arg.values).toEqual([
+            { event: record.event, retention_days: 90 },
+            { event: '{"id":"second"}', retention_days: 90 }
+        ]);
+        expect(arg.clickhouse_settings.insert_deduplication_token).toBe('token-1');
+        expect(inc).toHaveBeenCalledWith(metrics.Types.AUDIT_CLICKHOUSE_INGEST_RESULT, 2, { success: 'true' });
+    });
+
+    it('counts every record in the batch as failed when the insert fails', async () => {
+        const inc = vi.spyOn(metrics, 'increment').mockImplementation(() => undefined);
+        const insert = vi.fn().mockRejectedValue(new Error('clickhouse unavailable'));
+        const store = new ClickhouseAuditStore({ insert } as unknown as ClickHouseClient, 90);
+
+        expect((await store.recordMany([record, record, record], { dedupToken: 't' })).isErr()).toBe(true);
+        expect(inc).toHaveBeenCalledWith(metrics.Types.AUDIT_CLICKHOUSE_INGEST_RESULT, 3, { success: 'false', code: 'unknown' });
+    });
+
+    it('does not insert an empty batch', async () => {
+        const insert = vi.fn();
+        const store = new ClickhouseAuditStore({ insert } as unknown as ClickHouseClient, 90);
+
+        expect((await store.recordMany([], { dedupToken: 't' })).isOk()).toBe(true);
+        expect(insert).not.toHaveBeenCalled();
+    });
+});
+
+describe('ClickhouseAuditStore ingest failure tagging', () => {
+    afterEach(() => vi.restoreAllMocks());
+
+    it("tags the failure with ClickHouse's own error code so alerting can tell a bad event from a bad backend", async () => {
+        const inc = vi.spyOn(metrics, 'increment').mockImplementation(() => undefined);
+        const insert = vi.fn().mockRejectedValue(new ClickHouseError({ message: 'constraint violated', code: '469', type: 'VIOLATED_CONSTRAINT' }));
+        const store = new ClickhouseAuditStore({ insert } as unknown as ClickHouseClient, 90);
+
+        expect((await store.recordMany([record], { dedupToken: 't' })).isErr()).toBe(true);
+        expect(inc).toHaveBeenCalledWith(metrics.Types.AUDIT_CLICKHOUSE_INGEST_RESULT, 1, { success: 'false', code: '469' });
     });
 });

--- a/packages/audit/lib/store.unit.test.ts
+++ b/packages/audit/lib/store.unit.test.ts
@@ -53,7 +53,7 @@ describe('ClickhouseAuditStore.record', () => {
         const result = await store.record(record);
 
         expect(result.isErr()).toBe(true);
-        expect(inc).toHaveBeenCalledWith(metrics.Types.AUDIT_CLICKHOUSE_INGEST_RESULT, 1, { success: 'false', code: 'unknown' });
+        expect(inc).toHaveBeenCalledWith(metrics.Types.AUDIT_CLICKHOUSE_INGEST_RESULT, 1, { success: 'false', reason: 'no_response' });
     });
 
     it('returns Err with a failure metric instead of throwing on a malformed record', async () => {
@@ -63,7 +63,7 @@ describe('ClickhouseAuditStore.record', () => {
         const result = await store.record(undefined as unknown as SerializedAuditEvent);
 
         expect(result.isErr()).toBe(true);
-        expect(inc).toHaveBeenCalledWith(metrics.Types.AUDIT_CLICKHOUSE_INGEST_RESULT, 1, { success: 'false', code: 'unknown' });
+        expect(inc).toHaveBeenCalledWith(metrics.Types.AUDIT_CLICKHOUSE_INGEST_RESULT, 1, { success: 'false', reason: 'no_response' });
     });
 });
 
@@ -105,7 +105,7 @@ describe('ClickhouseAuditStore.recordMany', () => {
         const store = new ClickhouseAuditStore({ insert } as unknown as ClickHouseClient, 90);
 
         expect((await store.recordMany([record, record, record], { dedupToken: 't' })).isErr()).toBe(true);
-        expect(inc).toHaveBeenCalledWith(metrics.Types.AUDIT_CLICKHOUSE_INGEST_RESULT, 3, { success: 'false', code: 'unknown' });
+        expect(inc).toHaveBeenCalledWith(metrics.Types.AUDIT_CLICKHOUSE_INGEST_RESULT, 3, { success: 'false', reason: 'no_response' });
     });
 
     it('does not insert an empty batch', async () => {
@@ -117,15 +117,39 @@ describe('ClickhouseAuditStore.recordMany', () => {
     });
 });
 
-describe('ClickhouseAuditStore ingest failure tagging', () => {
+describe('ClickhouseAuditStore ingest failures', () => {
     afterEach(() => vi.restoreAllMocks());
 
-    it("tags the failure with ClickHouse's own error code so alerting can tell a bad event from a bad backend", async () => {
+    it('separates a server error, where nothing was written, from no response, where it may have been', async () => {
         const inc = vi.spyOn(metrics, 'increment').mockImplementation(() => undefined);
-        const insert = vi.fn().mockRejectedValue(new ClickHouseError({ message: 'constraint violated', code: '469', type: 'VIOLATED_CONSTRAINT' }));
-        const store = new ClickhouseAuditStore({ insert } as unknown as ClickHouseClient, 90);
+        const served = new ClickhouseAuditStore(
+            { insert: vi.fn().mockRejectedValue(new ClickHouseError({ message: 'constraint violated', code: '469' })) } as unknown as ClickHouseClient,
+            90
+        );
+        const silent = new ClickhouseAuditStore({ insert: vi.fn().mockRejectedValue(new Error('socket hang up')) } as unknown as ClickHouseClient, 90);
 
-        expect((await store.recordMany([record], { dedupToken: 't' })).isErr()).toBe(true);
-        expect(inc).toHaveBeenCalledWith(metrics.Types.AUDIT_CLICKHOUSE_INGEST_RESULT, 1, { success: 'false', code: '469' });
+        await served.recordMany([record], { dedupToken: 't' });
+        expect(inc).toHaveBeenCalledWith(metrics.Types.AUDIT_CLICKHOUSE_INGEST_RESULT, 1, { success: 'false', reason: 'server_error' });
+
+        await silent.recordMany([record], { dedupToken: 't' });
+        expect(inc).toHaveBeenCalledWith(metrics.Types.AUDIT_CLICKHOUSE_INGEST_RESULT, 1, { success: 'false', reason: 'no_response' });
+    });
+
+    it('returns an error with the quoted row already stripped, so no caller can log it', async () => {
+        vi.spyOn(metrics, 'increment').mockImplementation(() => undefined);
+        const raw =
+            'Code: 469. DB::Exception: Constraint `account_id_valid` is violated at row 1. ' +
+            'Column values: event = \'{"actor":{"display":"leak@customer.example"}}\'';
+        const store = new ClickhouseAuditStore(
+            { insert: vi.fn().mockRejectedValue(new ClickHouseError({ message: raw, code: '469' })) } as unknown as ClickHouseClient,
+            90
+        );
+
+        const result = await store.recordMany([record], { dedupToken: 't' });
+        expect(result.isErr()).toBe(true);
+        if (result.isErr()) {
+            expect(result.error.message).not.toContain('leak@customer.example');
+            expect(result.error.message).toContain('account_id_valid');
+        }
     });
 });

--- a/packages/metering/lib/app.ts
+++ b/packages/metering/lib/app.ts
@@ -73,8 +73,10 @@ try {
     // rather than configured: an insert outliving a message's invisibility would be redelivered while the
     // first attempt is still running, and both would write the row.
     const auditQueueUrl = envs.NANGO_PUBSUB_SNS_SQS_CONFIG.queueUrls?.['audit:audit'];
+    // Audit events only reach SQS when the publisher targets SNS, which is the `sns-sqs` transport alone —
+    // under `activemq` or `migration` the producer publishes to ActiveMQ, so there would be nothing to poll.
     const auditProc =
-        envs.CLICKHOUSE_URL && auditQueueUrl
+        envs.NANGO_PUBSUB_TRANSPORT === 'sns-sqs' && envs.CLICKHOUSE_URL && auditQueueUrl
             ? new AuditProcessor({
                   queueUrl: auditQueueUrl,
                   store: new ClickhouseAuditStore(
@@ -91,7 +93,7 @@ try {
     if (auditProc) {
         auditProc.start();
     } else {
-        logger.info('Audit consumer not started: CLICKHOUSE_URL or the audit queue URL is not configured');
+        logger.info('Audit consumer not started: needs the sns-sqs transport, CLICKHOUSE_URL and the audit queue URL');
     }
 
     // Crons

--- a/packages/metering/lib/app.ts
+++ b/packages/metering/lib/app.ts
@@ -2,7 +2,7 @@ import './tracer.js';
 
 import * as cron from 'node-cron';
 
-import { auditClickhouseClient, ClickhouseAuditStore, DropAuditStore } from '@nangohq/audit';
+import { auditClickhouseClient, ClickhouseAuditStore } from '@nangohq/audit';
 import { billing } from '@nangohq/billing';
 import { destroy as destroyFeatureFlags, initialize as initializeFeatureFlags } from '@nangohq/feature-flags';
 import { DefaultTransport } from '@nangohq/pubsub';
@@ -18,6 +18,8 @@ import { AuditProcessor } from './processors/audit.js';
 import { TeamProcessor } from './processors/team.js';
 import { UsageProcessor } from './processors/usage.js';
 import { logger } from './utils.js';
+
+const WRITE_TIMEOUT_FRACTION_OF_VISIBILITY = 2 / 3;
 
 try {
     process.on('unhandledRejection', (reason) => {
@@ -59,10 +61,31 @@ try {
     const teamProc = new TeamProcessor({ transport: pubsubTransport });
     teamProc.start();
 
-    // Audit processor
-    const auditStore = envs.CLICKHOUSE_URL ? new ClickhouseAuditStore(auditClickhouseClient(envs.CLICKHOUSE_URL)) : new DropAuditStore();
-    const auditProc = new AuditProcessor({ transport: pubsubTransport, store: auditStore });
-    auditProc.start();
+    // Audit processor. The queue URL comes from the pub/sub config so it stays the single source of truth
+    // even though this consumer polls SQS itself. The write timeout is derived from the visibility timeout
+    // rather than configured: an insert outliving a message's invisibility would be redelivered while the
+    // first attempt is still running, and both would write the row.
+    const auditQueueUrl = envs.NANGO_PUBSUB_SNS_SQS_CONFIG.queueUrls?.['audit:audit'];
+    const auditProc =
+        envs.CLICKHOUSE_URL && auditQueueUrl
+            ? new AuditProcessor({
+                  queueUrl: auditQueueUrl,
+                  store: new ClickhouseAuditStore(
+                      auditClickhouseClient(envs.CLICKHOUSE_URL, {
+                          requestTimeoutMs: Math.floor(envs.NANGO_AUDIT_CONSUMER_VISIBILITY_TIMEOUT_SECONDS * 1000 * WRITE_TIMEOUT_FRACTION_OF_VISIBILITY)
+                      })
+                  ),
+                  concurrency: envs.NANGO_AUDIT_CONSUMER_CONCURRENCY,
+                  maxMessages: envs.NANGO_AUDIT_CONSUMER_MAX_MESSAGES,
+                  waitTimeSeconds: envs.NANGO_AUDIT_CONSUMER_WAIT_TIME_SECONDS,
+                  visibilityTimeoutSeconds: envs.NANGO_AUDIT_CONSUMER_VISIBILITY_TIMEOUT_SECONDS
+              })
+            : null;
+    if (auditProc) {
+        auditProc.start();
+    } else {
+        logger.info('Audit consumer not started: CLICKHOUSE_URL or the audit queue URL is not configured');
+    }
 
     // Crons
     exportUsageCron();
@@ -73,6 +96,7 @@ try {
     // Graceful shutdown
     const close = once(async () => {
         await e2bSandboxesDaemonHandle?.abort();
+        await auditProc?.stop();
         const disconnect = await pubsubTransport.disconnect();
         if (disconnect.isErr()) {
             logger.error('Error disconnecting from ActiveMQ', disconnect.error);

--- a/packages/metering/lib/processors/audit.ts
+++ b/packages/metering/lib/processors/audit.ts
@@ -1,41 +1,167 @@
-import { Subscriber } from '@nangohq/pubsub';
+import { randomUUID } from 'node:crypto';
+
+import { DeleteMessageCommand, ReceiveMessageCommand, SQSClient } from '@aws-sdk/client-sqs';
+
+import { sanitizeClickhouseError } from '@nangohq/audit';
+import { getSubjectMessageAttribute, serde, unwrapSqsBody } from '@nangohq/pubsub';
+import { metrics, report } from '@nangohq/utils';
 
 import { envs } from '../env.js';
 import { logger } from '../utils.js';
 
-import type { AuditWriter } from '@nangohq/audit';
-import type { Transport } from '@nangohq/pubsub';
+import type { Message } from '@aws-sdk/client-sqs';
+import type { AuditBatchWriter } from '@nangohq/audit';
+import type { AuditRecordedEvent } from '@nangohq/types';
 
+const SUBJECT = 'audit';
+
+interface Received {
+    receiptHandle: string;
+    event: AuditRecordedEvent;
+    messageId: string | undefined;
+    receiveCount: number | undefined;
+}
+
+export interface AuditProcessorProps {
+    queueUrl: string;
+    store: AuditBatchWriter;
+    concurrency: number;
+    maxMessages: number;
+    waitTimeSeconds: number;
+    visibilityTimeoutSeconds: number;
+    sqs?: SQSClient;
+}
+
+/**
+ * Polls SQS itself rather than through `@nangohq/pubsub`'s Subscriber, so a whole batch collapses into one
+ * insert and this consumer decides when messages are acknowledged.
+ */
 export class AuditProcessor {
-    private subscriber: Subscriber;
-    private store: AuditWriter;
+    private readonly sqs: SQSClient;
+    private readonly abortController = new AbortController();
+    private loops: Promise<void>[] = [];
 
-    constructor({ transport, store }: { transport: Transport; store: AuditWriter }) {
-        this.subscriber = new Subscriber(transport);
-        this.store = store;
+    constructor(private readonly props: AuditProcessorProps) {
+        this.sqs = props.sqs ?? new SQSClient(envs.AWS_REGION ? { region: envs.AWS_REGION } : {});
     }
 
     public start(): void {
-        logger.info('Starting audit subscriber...', { concurrency: envs.METERING_AUDIT_EVENTS_SUBSCRIBE_CONCURRENCY });
+        if (this.loops.length > 0) {
+            return;
+        }
+        logger.info(`Starting audit consumer on ${this.props.queueUrl}`, { concurrency: this.props.concurrency });
+        this.loops = Array.from({ length: this.props.concurrency }, () => this.pollLoop());
+    }
 
-        this.subscriber.subscribe({
-            consumerGroup: 'audit',
-            subject: 'audit',
-            concurrency: envs.METERING_AUDIT_EVENTS_SUBSCRIBE_CONCURRENCY,
-            // Deliberately never throws. The transport acks whenever this callback resolves, so a failed
-            // write drops the event instead of being retried and eventually sent to the DLQ. That keeps
-            // parity with the direct-write path this replaces; throw-to-retry lands with the hardened
-            // consumer, together with publish-side batching, in a subsequent PR.
-            callback: async (event) => {
-                try {
-                    const result = await this.store.record(event.payload);
-                    if (result.isErr()) {
-                        logger.error(`Failed to store audit event: ${result.error.message}`);
-                    }
-                } catch (err) {
-                    logger.error('Failed to store audit event', err);
+    public async stop(): Promise<void> {
+        this.abortController.abort();
+        await Promise.allSettled(this.loops);
+        this.loops = [];
+        this.sqs.destroy();
+    }
+
+    private async pollLoop(): Promise<void> {
+        const signal = this.abortController.signal;
+        while (!signal.aborted) {
+            try {
+                const res = await this.sqs.send(
+                    new ReceiveMessageCommand({
+                        QueueUrl: this.props.queueUrl,
+                        MaxNumberOfMessages: this.props.maxMessages,
+                        WaitTimeSeconds: this.props.waitTimeSeconds,
+                        VisibilityTimeout: this.props.visibilityTimeoutSeconds,
+                        MessageAttributeNames: ['All'],
+                        MessageSystemAttributeNames: ['ApproximateReceiveCount']
+                    }),
+                    { abortSignal: signal }
+                );
+                const messages = res.Messages ?? [];
+                if (messages.length > 0) {
+                    await this.processBatch(messages, signal);
                 }
+            } catch (err) {
+                if (err instanceof Error && err.name === 'AbortError') {
+                    break;
+                }
+                report(new Error('Audit consumer receive failed', { cause: err }));
+                await new Promise((resolve) => setTimeout(resolve, 1000));
             }
-        });
+        }
+    }
+
+    private async processBatch(messages: Message[], signal: AbortSignal): Promise<void> {
+        const received = messages.flatMap((msg) => this.decode(msg));
+        if (received.length === 0) {
+            return;
+        }
+        metrics.histogram(metrics.Types.AUDIT_CONSUMER_BATCH_SIZE, received.length);
+
+        const result = await this.props.store.recordMany(
+            received.map((r) => r.event.payload),
+            { dedupToken: randomUUID() }
+        );
+
+        if (result.isErr()) {
+            // Left undeleted on purpose: the messages redeliver and, past the queue's maxReceiveCount, reach
+            // the DLQ, where they can be redriven once the cause is fixed.
+            logger.error(`Failed to store audit events: ${sanitizeClickhouseError(result.error)}`, {
+                messages: received.map((r) => ({
+                    messageId: r.messageId,
+                    receiveCount: r.receiveCount,
+                    ...describe(r.event.payload.event)
+                }))
+            });
+            return;
+        }
+
+        await Promise.all(received.map(({ receiptHandle }) => this.deleteMessage(receiptHandle, signal)));
+    }
+
+    // Anything it drops is left undeleted, so it reaches the DLQ with its payload intact instead of being
+    // discarded here.
+    private decode(msg: Message): Received[] {
+        if (!msg.Body || !msg.ReceiptHandle) {
+            return [];
+        }
+        if (getSubjectMessageAttribute(msg.Body, msg.MessageAttributes) !== SUBJECT) {
+            metrics.increment(metrics.Types.AUDIT_CONSUMER_REJECTED, 1, { reason: 'subject_mismatch' });
+            report(new Error('Audit consumer: message subject mismatch'), { messageId: msg.MessageId });
+            return [];
+        }
+        const decoded = serde.deserialize<AuditRecordedEvent>(Buffer.from(unwrapSqsBody(msg.Body), 'base64'));
+        if (decoded.isErr()) {
+            metrics.increment(metrics.Types.AUDIT_CONSUMER_REJECTED, 1, { reason: 'invalid_schema' });
+            report(new Error('Audit consumer: failed to deserialize message'), { messageId: msg.MessageId });
+            return [];
+        }
+        const receiveCount = Number(msg.Attributes?.['ApproximateReceiveCount']);
+        return [
+            {
+                receiptHandle: msg.ReceiptHandle,
+                event: decoded.value,
+                messageId: msg.MessageId,
+                receiveCount: Number.isFinite(receiveCount) ? receiveCount : undefined
+            }
+        ];
+    }
+
+    private async deleteMessage(receiptHandle: string, signal: AbortSignal): Promise<void> {
+        try {
+            await this.sqs.send(new DeleteMessageCommand({ QueueUrl: this.props.queueUrl, ReceiptHandle: receiptHandle }), { abortSignal: signal });
+        } catch (err) {
+            report(new Error('Audit consumer delete failed', { cause: err }));
+        }
+    }
+}
+
+// The blob carries the actor's email and IP, so only these non-identifying fields are ever read out of it
+// to identify which event in a failed batch was the problem.
+function describe(event: string): { eventId?: string | undefined; resource?: string | undefined; action?: string | undefined } {
+    try {
+        const parsed = JSON.parse(event) as Record<string, unknown>;
+        const pick = (key: string): string | undefined => (typeof parsed[key] === 'string' ? (parsed[key] as string) : undefined);
+        return { eventId: pick('id'), resource: pick('resource'), action: pick('action') };
+    } catch {
+        return {};
     }
 }

--- a/packages/metering/lib/processors/audit.ts
+++ b/packages/metering/lib/processors/audit.ts
@@ -2,7 +2,6 @@ import { randomUUID } from 'node:crypto';
 
 import { DeleteMessageCommand, ReceiveMessageCommand, SQSClient } from '@aws-sdk/client-sqs';
 
-import { sanitizeClickhouseError } from '@nangohq/audit';
 import { getSubjectMessageAttribute, serde, unwrapSqsBody } from '@nangohq/pubsub';
 import { metrics, report } from '@nangohq/utils';
 
@@ -104,7 +103,7 @@ export class AuditProcessor {
         if (result.isErr()) {
             // Left undeleted on purpose: the messages redeliver and, past the queue's maxReceiveCount, reach
             // the DLQ, where they can be redriven once the cause is fixed.
-            logger.error(`Failed to store audit events: ${sanitizeClickhouseError(result.error)}`, {
+            logger.error(`Failed to store audit events: ${result.error.message}`, {
                 messages: received.map((r) => ({
                     messageId: r.messageId,
                     receiveCount: r.receiveCount,

--- a/packages/metering/lib/processors/audit.ts
+++ b/packages/metering/lib/processors/audit.ts
@@ -1,4 +1,4 @@
-import { randomUUID } from 'node:crypto';
+import { createHash, randomUUID } from 'node:crypto';
 
 import { DeleteMessageCommand, ReceiveMessageCommand, SQSClient } from '@aws-sdk/client-sqs';
 
@@ -97,7 +97,7 @@ export class AuditProcessor {
 
         const result = await this.props.store.recordMany(
             received.map((r) => r.event.payload),
-            { dedupToken: randomUUID() }
+            { dedupToken: batchDedupToken(received) }
         );
 
         if (result.isErr()) {
@@ -133,6 +133,14 @@ export class AuditProcessor {
             report(new Error('Audit consumer: failed to deserialize message'), { messageId: msg.MessageId });
             return [];
         }
+        // `deserialize` gives back whatever was serialised, so the type is an assertion rather than a check.
+        // Only the envelope this code owns is verified — whether the event itself is storable is the table's
+        // constraints to decide, and duplicating them here would give them a second place to drift from.
+        if (typeof decoded.value.payload?.event !== 'string') {
+            metrics.increment(metrics.Types.AUDIT_CONSUMER_REJECTED, 1, { reason: 'invalid_schema' });
+            report(new Error('Audit consumer: message is not an audit envelope'), { messageId: msg.MessageId });
+            return [];
+        }
         const receiveCount = Number(msg.Attributes?.['ApproximateReceiveCount']);
         return [
             {
@@ -163,4 +171,22 @@ function describe(event: string): { eventId?: string | undefined; resource?: str
     } catch {
         return {};
     }
+}
+
+// Derived from the message ids rather than random, so a batch redelivered whole — the common case, since a
+// failed insert makes all of its messages visible again together — carries the token of the attempt that
+// may already have been written, and ClickHouse discards it. SQS is free to regroup messages across
+// deliveries, in which case the token differs and the copy is caught by ReplacingMergeTree and the read
+// instead. Falls back to a random token if any id is missing, which only loses that dedup.
+function batchDedupToken(received: Received[]): string {
+    const ids: string[] = [];
+    for (const { messageId } of received) {
+        if (!messageId) {
+            return randomUUID();
+        }
+        ids.push(messageId);
+    }
+    // Codepoint order, not localeCompare: the token has to hash identically on every pod.
+    ids.sort((a, b) => (a < b ? -1 : a > b ? 1 : 0));
+    return createHash('sha256').update(ids.join(',')).digest('hex');
 }

--- a/packages/metering/lib/processors/audit.unit.test.ts
+++ b/packages/metering/lib/processors/audit.unit.test.ts
@@ -81,7 +81,7 @@ describe('AuditProcessor', () => {
         expect(recordMany).toHaveBeenCalledTimes(1);
         const [records, opts] = recordMany.mock.calls[0] as [{ event: string }[], { dedupToken: string }];
         expect(records.map((r) => (JSON.parse(r.event) as { id: string }).id)).toEqual(['a', 'b', 'c']);
-        expect(opts.dedupToken).toMatch(/^[0-9a-f-]{36}$/);
+        expect(opts.dedupToken).toMatch(/^[0-9a-f]{64}$/);
         expect(deleted.sort()).toEqual(['handle-a', 'handle-b', 'handle-c']);
     });
 
@@ -108,6 +108,33 @@ describe('AuditProcessor', () => {
         const recordMany = vi.fn().mockResolvedValue(Ok(undefined));
         const wrongSubject = { ...auditMessage('x'), MessageAttributes: { subject: { DataType: 'String', StringValue: 'usage' } } };
         const { deleted } = await run([wrongSubject], { recordMany });
+
+        expect(recordMany).not.toHaveBeenCalled();
+        expect(deleted).toEqual([]);
+    });
+
+    it('gives a batch the same dedup token every time it is delivered, so a re-sent insert is discarded', async () => {
+        const first = vi.fn().mockResolvedValue(Ok(undefined));
+        await run([auditMessage('a'), auditMessage('b')], { recordMany: first });
+
+        // Same messages, redelivered in a different order — SQS makes no ordering promise.
+        const second = vi.fn().mockResolvedValue(Ok(undefined));
+        await run([auditMessage('b'), auditMessage('a')], { recordMany: second });
+
+        const tokenOf = (m: ReturnType<typeof vi.fn>) => (m.mock.calls[0] as [unknown, { dedupToken: string }])[1].dedupToken;
+        expect(tokenOf(first)).toBe(tokenOf(second));
+    });
+
+    it('rejects an envelope whose payload carries no event blob', async () => {
+        const recordMany = vi.fn().mockResolvedValue(Ok(undefined));
+        const notAnEnvelope = {
+            ...auditMessage('x'),
+            Body: serde
+                .serialize({ idempotencyKey: 'k', subject: 'audit', type: 'audit.recorded', payload: {}, createdAt: new Date() })
+                .unwrap()
+                .toString('base64')
+        };
+        const { deleted } = await run([notAnEnvelope], { recordMany });
 
         expect(recordMany).not.toHaveBeenCalled();
         expect(deleted).toEqual([]);

--- a/packages/metering/lib/processors/audit.unit.test.ts
+++ b/packages/metering/lib/processors/audit.unit.test.ts
@@ -1,72 +1,115 @@
-import { describe, expect, it, vi } from 'vitest';
+import { DeleteMessageCommand, ReceiveMessageCommand } from '@aws-sdk/client-sqs';
+import { afterEach, describe, expect, it, vi } from 'vitest';
 
+import { serde } from '@nangohq/pubsub';
 import { Err, Ok } from '@nangohq/utils';
 
-import { logger } from '../utils.js';
 import { AuditProcessor } from './audit.js';
 
-import type { AuditWriter } from '@nangohq/audit';
-import type { SubscribeProps, Transport } from '@nangohq/pubsub';
+import type { SQSClient } from '@aws-sdk/client-sqs';
+import type { AuditBatchWriter } from '@nangohq/audit';
 import type { AuditRecordedEvent } from '@nangohq/types';
 
-const record = { event: '{"id":"11111111-1111-1111-1111-111111111111","accountId":42}' };
+const QUEUE_URL = 'https://sqs.us-west-2.amazonaws.com/1/audit-test-audit-test';
 
-const message = {
-    idempotencyKey: 'key-1',
-    subject: 'audit',
-    type: 'audit.recorded',
-    payload: record,
-    createdAt: new Date('2026-07-16T10:00:00.000Z')
-} satisfies AuditRecordedEvent;
+function auditMessage(eventId: string) {
+    const event = {
+        idempotencyKey: `key-${eventId}`,
+        subject: 'audit',
+        type: 'audit.recorded',
+        payload: { event: JSON.stringify({ id: eventId, resource: 'connection', action: 'deleted', accountId: 42 }) },
+        createdAt: new Date('2026-07-30T10:00:00.000Z')
+    } satisfies AuditRecordedEvent;
 
-function start(store: AuditWriter) {
-    let props: SubscribeProps<'audit'> | undefined;
-    const transport = {
-        subscribe: (p: SubscribeProps<'audit'>) => {
-            props = p;
+    return {
+        MessageId: `sqs-${eventId}`,
+        ReceiptHandle: `handle-${eventId}`,
+        Body: serde.serialize(event).unwrap().toString('base64'),
+        MessageAttributes: { subject: { DataType: 'String', StringValue: 'audit' } },
+        Attributes: { ApproximateReceiveCount: '2' }
+    };
+}
+
+// Serves one poll then nothing, so a loop makes exactly one pass over the messages under test.
+function sqsServing(messages: unknown[]) {
+    const deleted: string[] = [];
+    let served = false;
+    const send = vi.fn().mockImplementation((command: unknown) => {
+        if (command instanceof ReceiveMessageCommand) {
+            if (served) {
+                // Stands in for long polling: without a macrotask the loop would spin on microtasks and
+                // starve the test's timers.
+                return new Promise((resolve) => setTimeout(() => resolve({}), 5));
+            }
+            served = true;
+            return Promise.resolve({ Messages: messages });
         }
-    } as unknown as Transport;
+        if (command instanceof DeleteMessageCommand) {
+            deleted.push(String(command.input.ReceiptHandle));
+            return Promise.resolve({});
+        }
+        return Promise.resolve({});
+    });
+    return { sqs: { send, destroy: vi.fn() } as unknown as SQSClient, deleted, send };
+}
 
-    new AuditProcessor({ transport, store }).start();
-
-    return props!;
+async function run(messages: unknown[], store: AuditBatchWriter) {
+    const { sqs, deleted, send } = sqsServing(messages);
+    const proc = new AuditProcessor({
+        queueUrl: QUEUE_URL,
+        store,
+        concurrency: 1,
+        maxMessages: 10,
+        waitTimeSeconds: 0,
+        visibilityTimeoutSeconds: 30,
+        sqs
+    });
+    proc.start();
+    // The second receive only happens once the first batch has been handled.
+    await vi.waitFor(() => expect(send.mock.calls.filter((c) => c[0] instanceof ReceiveMessageCommand).length).toBeGreaterThan(1));
+    await proc.stop();
+    return { deleted };
 }
 
 describe('AuditProcessor', () => {
-    it('subscribes to the audit subject under the audit consumer group', () => {
-        const props = start({ record: () => Promise.resolve(Ok(undefined)) });
-        expect(props.subject).toBe('audit');
-        expect(props.consumerGroup).toBe('audit');
+    afterEach(() => vi.restoreAllMocks());
+
+    it('collapses a received batch into one write and deletes every message', async () => {
+        const recordMany = vi.fn().mockResolvedValue(Ok(undefined));
+        const { deleted } = await run([auditMessage('a'), auditMessage('b'), auditMessage('c')], { recordMany });
+
+        expect(recordMany).toHaveBeenCalledTimes(1);
+        const [records, opts] = recordMany.mock.calls[0] as [{ event: string }[], { dedupToken: string }];
+        expect(records.map((r) => (JSON.parse(r.event) as { id: string }).id)).toEqual(['a', 'b', 'c']);
+        expect(opts.dedupToken).toMatch(/^[0-9a-f-]{36}$/);
+        expect(deleted.sort()).toEqual(['handle-a', 'handle-b', 'handle-c']);
     });
 
-    it('stores the payload as received', async () => {
-        const write = vi.fn().mockResolvedValue(Ok(undefined));
-        const props = start({ record: write });
+    it('deletes nothing when the write fails, so the batch redelivers and reaches the DLQ', async () => {
+        const recordMany = vi.fn().mockResolvedValue(Err(new Error('clickhouse unavailable')));
+        const { deleted } = await run([auditMessage('a'), auditMessage('b')], { recordMany });
 
-        await props.callback(message);
-
-        expect(write).toHaveBeenCalledWith(record);
+        expect(recordMany).toHaveBeenCalledTimes(1);
+        expect(deleted).toEqual([]);
     });
 
-    it('logs and acknowledges when the write returns Err', async () => {
-        const error = vi.spyOn(logger, 'error');
-        const props = start({ record: () => Promise.resolve(Err(new Error('clickhouse unavailable'))) });
+    it('excludes an undecodable message from the batch and leaves it for the DLQ', async () => {
+        const recordMany = vi.fn().mockResolvedValue(Ok(undefined));
+        const undecodable = { ...auditMessage('bad'), Body: 'not-base64-v8' };
+        const { deleted } = await run([auditMessage('good'), undecodable], { recordMany });
 
-        await expect(props.callback(message)).resolves.toBeUndefined();
-        expect(error).toHaveBeenCalledWith(expect.stringContaining('clickhouse unavailable'));
+        const [records] = recordMany.mock.calls[0] as [{ event: string }[]];
+        expect(records).toHaveLength(1);
+        expect((JSON.parse(records[0]!.event) as { id: string }).id).toBe('good');
+        expect(deleted).toEqual(['handle-good']);
     });
 
-    // A throw and an Err must share one fate, or the same failure is dropped or retried depending on
-    // whether the writer happened to catch it.
-    it('logs and acknowledges when the write throws', async () => {
-        const error = vi.spyOn(logger, 'error');
-        const props = start({
-            record: () => {
-                throw new Error('unexpected');
-            }
-        });
+    it('skips a message published under another subject', async () => {
+        const recordMany = vi.fn().mockResolvedValue(Ok(undefined));
+        const wrongSubject = { ...auditMessage('x'), MessageAttributes: { subject: { DataType: 'String', StringValue: 'usage' } } };
+        const { deleted } = await run([wrongSubject], { recordMany });
 
-        await expect(props.callback(message)).resolves.toBeUndefined();
-        expect(error).toHaveBeenCalledWith('Failed to store audit event', expect.any(Error));
+        expect(recordMany).not.toHaveBeenCalled();
+        expect(deleted).toEqual([]);
     });
 });

--- a/packages/metering/package.json
+++ b/packages/metering/package.json
@@ -15,6 +15,7 @@
     },
     "dependencies": {
         "@aws-sdk/client-s3": "3.993.0",
+        "@aws-sdk/client-sqs": "3.993.0",
         "@nangohq/audit": "file:../audit",
         "@nangohq/billing": "file:../billing",
         "@nangohq/database": "file:../database",

--- a/packages/pubsub/lib/index.ts
+++ b/packages/pubsub/lib/index.ts
@@ -2,3 +2,7 @@ export type * from './transport/transport.js';
 export * from './publisher.js';
 export * from './subscriber.js';
 export * from './transport/default.js';
+// The SQS wire format, exposed so a consumer that owns its own polling loop (batching, ack timing)
+// decodes messages with the same code that produced them instead of reimplementing it.
+export { getSubjectMessageAttribute, unwrapSqsBody } from './transport/sns-sqs.js';
+export { serde } from './utils/serde.js';

--- a/packages/pubsub/lib/transport/sns-sqs.ts
+++ b/packages/pubsub/lib/transport/sns-sqs.ts
@@ -77,7 +77,7 @@ function subscribeConcurrency(concurrency: number | undefined): number {
     return Math.max(1, Math.min(10, Math.floor(n)));
 }
 
-function unwrapSqsBody(body: string): string {
+export function unwrapSqsBody(body: string): string {
     let parsed: unknown;
     try {
         parsed = JSON.parse(body);
@@ -91,7 +91,7 @@ function unwrapSqsBody(body: string): string {
     return body;
 }
 
-function getSubjectMessageAttribute(body: string, messageAttributes?: unknown): string | undefined {
+export function getSubjectMessageAttribute(body: string, messageAttributes?: unknown): string | undefined {
     const attrs = sqsMessageAttributesSchema.safeParse(messageAttributes);
     if (attrs.success) {
         const fromSqsAttr = attrs.data['subject']?.StringValue;
@@ -136,7 +136,7 @@ export class SnsSqs implements Transport {
         this.sns = props?.snsClient ?? new SNSClient({});
         this.sqs = props?.sqsClient ?? new SQSClient({});
         this.queueUrls = props?.queueUrls ?? {};
-        this.topicArns = { ...(props?.topicArns ?? {}) };
+        this.topicArns = { ...props?.topicArns };
     }
 
     public async connect(_props?: { timeoutMs: number }): Promise<Result<void>> {

--- a/packages/utils/lib/environment/parse.ts
+++ b/packages/utils/lib/environment/parse.ts
@@ -557,7 +557,10 @@ export const ENVS = z.object({
     // Audit
     NANGO_AUDIT_TRANSPORT: z.enum(['direct', 'pubsub']).optional().default('direct'),
     // .int() because these go straight into SQS request fields, which reject a fractional value outright.
-    NANGO_AUDIT_CONSUMER_CONCURRENCY: z.coerce.number().int().min(1).optional().default(5),
+    // One poll loop on purpose. Long polling returns as soon as a single message is available, so a batch
+    // only grows while an insert is in flight — extra loops would be parked in ReceiveMessage and take those
+    // arrivals one at a time, turning one insert into several. Raise it if queue depth starts building.
+    NANGO_AUDIT_CONSUMER_CONCURRENCY: z.coerce.number().int().min(1).optional().default(1),
     NANGO_AUDIT_CONSUMER_MAX_MESSAGES: z.coerce.number().int().min(1).max(10).optional().default(10),
     NANGO_AUDIT_CONSUMER_WAIT_TIME_SECONDS: z.coerce.number().int().min(0).max(20).optional().default(20),
     NANGO_AUDIT_CONSUMER_VISIBILITY_TIMEOUT_SECONDS: z.coerce.number().int().min(10).max(43200).optional().default(30),

--- a/packages/utils/lib/environment/parse.ts
+++ b/packages/utils/lib/environment/parse.ts
@@ -556,6 +556,10 @@ export const ENVS = z.object({
 
     // Audit
     NANGO_AUDIT_TRANSPORT: z.enum(['direct', 'pubsub']).optional().default('direct'),
+    NANGO_AUDIT_CONSUMER_CONCURRENCY: z.coerce.number().min(1).optional().default(5),
+    NANGO_AUDIT_CONSUMER_MAX_MESSAGES: z.coerce.number().min(1).max(10).optional().default(10),
+    NANGO_AUDIT_CONSUMER_WAIT_TIME_SECONDS: z.coerce.number().min(0).max(20).optional().default(20),
+    NANGO_AUDIT_CONSUMER_VISIBILITY_TIMEOUT_SECONDS: z.coerce.number().min(10).max(43200).optional().default(30),
 
     // PubSub
     NANGO_PUBSUB_TRANSPORT: z.enum(['activemq', 'sns-sqs', 'migration', 'none']).optional().default('none'),

--- a/packages/utils/lib/environment/parse.ts
+++ b/packages/utils/lib/environment/parse.ts
@@ -556,10 +556,11 @@ export const ENVS = z.object({
 
     // Audit
     NANGO_AUDIT_TRANSPORT: z.enum(['direct', 'pubsub']).optional().default('direct'),
-    NANGO_AUDIT_CONSUMER_CONCURRENCY: z.coerce.number().min(1).optional().default(5),
-    NANGO_AUDIT_CONSUMER_MAX_MESSAGES: z.coerce.number().min(1).max(10).optional().default(10),
-    NANGO_AUDIT_CONSUMER_WAIT_TIME_SECONDS: z.coerce.number().min(0).max(20).optional().default(20),
-    NANGO_AUDIT_CONSUMER_VISIBILITY_TIMEOUT_SECONDS: z.coerce.number().min(10).max(43200).optional().default(30),
+    // .int() because these go straight into SQS request fields, which reject a fractional value outright.
+    NANGO_AUDIT_CONSUMER_CONCURRENCY: z.coerce.number().int().min(1).optional().default(5),
+    NANGO_AUDIT_CONSUMER_MAX_MESSAGES: z.coerce.number().int().min(1).max(10).optional().default(10),
+    NANGO_AUDIT_CONSUMER_WAIT_TIME_SECONDS: z.coerce.number().int().min(0).max(20).optional().default(20),
+    NANGO_AUDIT_CONSUMER_VISIBILITY_TIMEOUT_SECONDS: z.coerce.number().int().min(10).max(43200).optional().default(30),
 
     // PubSub
     NANGO_PUBSUB_TRANSPORT: z.enum(['activemq', 'sns-sqs', 'migration', 'none']).optional().default('none'),

--- a/packages/utils/lib/environment/parse.unit.test.ts
+++ b/packages/utils/lib/environment/parse.unit.test.ts
@@ -19,6 +19,16 @@ describe('parse', () => {
         expect(res).toMatchObject({ NANGO_DB_SSL: false, NANGO_PERSIST_PORT: 3007 });
     });
 
+    // These go straight into SQS request fields, which reject a fractional value outright — the consumer
+    // would then fail every receive and sit in its retry loop.
+    it('rejects a fractional audit consumer setting', () => {
+        expect(() => parseEnvs(ENVS, { NANGO_AUDIT_CONSUMER_MAX_MESSAGES: '1.5' })).toThrowError();
+        expect(() => parseEnvs(ENVS, { NANGO_AUDIT_CONSUMER_CONCURRENCY: '2.5' })).toThrowError();
+        expect(() => parseEnvs(ENVS, { NANGO_AUDIT_CONSUMER_WAIT_TIME_SECONDS: '0.5' })).toThrowError();
+        expect(() => parseEnvs(ENVS, { NANGO_AUDIT_CONSUMER_VISIBILITY_TIMEOUT_SECONDS: '30.5' })).toThrowError();
+        expect(parseEnvs(ENVS, { NANGO_AUDIT_CONSUMER_MAX_MESSAGES: '4' }).NANGO_AUDIT_CONSUMER_MAX_MESSAGES).toBe(4);
+    });
+
     it('should parse the sandbox compiler template', () => {
         const res = parseEnvs(ENVS, { E2B_SANDBOX_COMPILER_TEMPLATE: 'blank-workspace:dev' });
         expect(res.E2B_SANDBOX_COMPILER_TEMPLATE).toBe('blank-workspace:dev');

--- a/packages/utils/lib/telemetry/metrics.ts
+++ b/packages/utils/lib/telemetry/metrics.ts
@@ -161,6 +161,8 @@ export enum Types {
 
     AUDIT_TARGET_DISPLAY_RESOLUTION_FAILED = 'nango.audit.target.display_resolution_failed',
     AUDIT_CLICKHOUSE_INGEST_RESULT = 'nango.audit.clickhouse.ingest.result',
+    AUDIT_CONSUMER_BATCH_SIZE = 'nango.audit.consumer.batch.size',
+    AUDIT_CONSUMER_REJECTED = 'nango.audit.consumer.rejected',
 
     FEATURE_FLAGS_CLIENT_UNAVAILABLE = 'nango.feature_flags.client.unavailable',
     FEATURE_FLAGS_CLIENT_RECONNECTED = 'nango.feature_flags.client.reconnected',


### PR DESCRIPTION
- **A failed write no longer discards the event.** The consumer reads up to ten messages per poll, writes them in one ClickHouse insert carrying a deduplication token, and deletes them only if that insert succeeded. A failure leaves them for redelivery and, past the queue's `maxReceiveCount`, the DLQ — where they can be redriven once the cause is fixed. Previously every failure was acknowledged, so a ClickHouse problem silently dropped audit events.
- **Reads collapse duplicate events.** At-least-once delivery can store an event twice, because a redelivered batch has a different composition and so a different deduplication token, and `ReplacingMergeTree` only merges the copy away eventually. The read path drops copies from the result set so the API and dashboard never show one.
- **Insert errors are sanitised before logging.** ClickHouse quotes the offending row back in `VIOLATED_CONSTRAINT` and format-parse errors, and the audit blob holds the actor's email and IP. The code, constraint name and failing expression are kept; the quoted payload is not — it stays in the DLQ message, under the same access controls as the audit store.

### Why the read doesn't deduplicate server-side

`FINAL` and `LIMIT 1 BY id` both defeat the short-circuit this query depends on: `ORDER BY` matches the primary key prefix, so ClickHouse stops as soon as the page is filled. Rows read for one unbounded page on a 5M-row account:

| | rows read |
|---|---|
| as written | 99K |
| `LIMIT 1 BY id` | 1.1M |
| `FINAL` | 5M — the entire account |

Extrapolated to the 300M-row account in the [performance benchmark](https://linear.app/nango/document/audit-logs-clickhouse-performancecost-benchmark-c54e4fd0a36d), `FINAL` would read 300M rows per page and its interactive latency conclusions would no longer hold. The benchmark stands as measured, with one constraint now attached to it: this query must not deduplicate server-side.

Copies share `(account_id, occurred_at, id)`, so they are adjacent in this ordering and a single pass catches them, and the keyset cursor's strict comparison excludes one straddling a page boundary. Because the query already fetches one spare row, a page containing a single copy is still full.

### Failure handling

Every failure is treated the same way — nothing is deleted — so there is no error classification in the control flow. Classification is a metric dimension instead: ingest failures are tagged with ClickHouse's own error code, so alerting can separate a rejected event (a bug in what we emit) from an unavailable backend without this code enumerating codes or matching message text. Undecodable messages and messages published under another subject are counted as rejections and also left undeleted, so they reach the DLQ with their payload intact.

Failure logs carry, per message, the SQS message id, the audit event id, its resource and action, and the delivery count — enough to identify which event in a batch was the problem and how close it is to the DLQ, without copying personal data into logs.

The write timeout is derived from the queue's visibility timeout rather than configured separately, so the two cannot be put out of step by a deploy: an insert outliving a message's invisibility would be redelivered while the first attempt was still running, and both would write the row.

### Behaviour changes

The consumer polls SQS directly instead of going through `@nangohq/pubsub`'s Subscriber, so it can batch and control acknowledgement. Consequences worth knowing:

- **It no longer starts on ActiveMQ deployments.** It needs an SQS queue URL, so on `NANGO_PUBSUB_TRANSPORT=activemq` tiers it logs and stays off rather than consuming. Audit is already gated on `CLICKHOUSE_URL`, so no environment loses a working path, but it is a capability removal for non-SQS tiers.
- The producer still publishes through `pubsub.publisher`, so the two halves of the pipeline now use different abstractions. Deliberate: batching and ack timing only exist at the consuming end.
- `nango.audit.clickhouse.ingest.result` gains a `code` tag on failures and now increments by the batch size rather than by one.

`@nangohq/pubsub` itself is behaviourally unchanged — only its wire-format helpers become exported, so the consumer decodes with the same code that produced the message instead of reimplementing a v8-serialised format outside the package that defines it.

### Notes for the reviewer

- The consumer's poll-loop, abort and shutdown scaffolding intentionally mirrors `packages/jobs/lib/webhook/dispatch-queue/consumer.ts`. This is the second use of that shape; a third should extract a shared SQS batch consumer.
- One line in `sns-sqs.ts` (`topicArns` spread) is an incidental `oxlint --fix` change applied by the pre-commit hook, not a deliberate edit. It cannot be reverted while the file is staged — the hook reapplies it.
- Conflicts with #6934 in three files (`clickhouse.ts`, `index.ts`, `metering/lib/app.ts`), all keep-both. Either can merge first.

## Test plan

- [x] `npm run ts-build` clean
- [x] Unit: audit 24, metering 4, pubsub 35, utils 350
- [x] Integration against real ClickHouse: audit store 6, including a duplicate stored with merges stopped, proving the read collapses it rather than a merge having done so
- [x] Read cost measured on a 5M-row account across 1-day, 14-day and unbounded windows
- [x] Verified by deliberate regression that the tests fail when the dedup, the delete-on-success rule, the sanitiser and the typed error code are each removed
- [x] prettier + oxlint clean
- [ ] Re-measure read cost on Cloud — the numbers above are a local single node at 5M rows, not SharedMergeTree at 300M
- [ ] DLQ alert and redrive runbook (NAN-6277), which this PR makes load-bearing and does not deliver
- [ ] Watch batch size, rejection count and DLQ depth on dev after the cutover


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/NangoHQ/nango/pull/6954?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

