### PR TITLE
feat(connect-ui): allow configuring frame-ancestors for self-hosted Connect UI

### DIFF
--- a/docs/guides/platform/self-hosting.mdx
+++ b/docs/guides/platform/self-hosting.mdx
@@ -218,6 +218,22 @@ Nango Connect is available by default at `http://localhost:3009`.
 If you are using a custom domain, update `NANGO_PUBLIC_CONNECT_URL` to match it.
 </Note>
 
+#### Allowing Connect UI to be framed
+
+`nango.openConnectUI()` loads Connect UI in an iframe, so the response must not carry a framing restriction. Nango does not set one, but a reverse proxy or CDN in front of your instance may add `X-Frame-Options` — Cloudflare's "Add security headers" managed transform sets `SAMEORIGIN` zone-wide, for example — which blocks the iframe.
+
+Set the origins allowed to embed Connect UI:
+
+```sh
+NANGO_CONNECT_UI_FRAME_ANCESTORS="'self' https://app.example.com"
+```
+
+The value is used verbatim as the CSP `frame-ancestors` source list. Browsers ignore `X-Frame-Options` whenever `frame-ancestors` is present, so this takes precedence over a header added upstream, without disabling that header for the rest of your domain.
+
+<Note>
+Prefer naming the exact origins that embed Connect UI. `frame-ancestors` can express an allowlist, which `X-Frame-Options` cannot, so this is a tighter policy than the header it overrides — not a relaxation of it.
+</Note>
+
 #### Hosting under a base path
 
 Connect UI works under any base path, for example behind a reverse proxy that routes services by path. Set `NANGO_PUBLIC_CONNECT_URL` to the full URL including the path:

--- a/packages/server/entrypoint.sh
+++ b/packages/server/entrypoint.sh
@@ -10,6 +10,26 @@ echo "$dir/packages/server/dist/server.js"
 
 # connect ui
 if [ "$FLAG_SERVE_CONNECT_UI" == "true" ]; then
+  # Connect UI is loaded in an iframe, so it must not be served with a framing restriction. `serve`
+  # sets none itself, but a reverse proxy or CDN in front may add `X-Frame-Options`, which then wins
+  # by default. Emitting `frame-ancestors` overrides it: per CSP, browsers ignore `X-Frame-Options`
+  # when that directive is present. `serve` reads this file automatically, and `--single` is applied
+  # on top of it, so the SPA fallback is unaffected.
+  if [ -n "$NANGO_CONNECT_UI_FRAME_ANCESTORS" ]; then
+    cat > "$dir/packages/connect-ui/dist/serve.json" <<JSON
+{
+  "headers": [
+    {
+      "source": "**/*",
+      "headers": [
+        { "key": "Content-Security-Policy", "value": "frame-ancestors $NANGO_CONNECT_UI_FRAME_ANCESTORS" }
+      ]
+    }
+  ]
+}
+JSON
+  fi
+
   node "$dir/packages/server/dist/server.js" &
 
   # This is not recommended, you should serve Connect UI from a dedicated static website hosting


### PR DESCRIPTION
I've read [CONTRIBUTING.md](https://github.com/NangoHQ/nango/blob/master/CONTRIBUTING.md) and know external PRs outside security fixes and new API support aren't normally reviewed — so treat this as a bug report with a patch attached rather than a request for your review time. Close it and I'll re-file as an issue if that's easier.

## The problem

`nango.openConnectUI()` loads Connect UI in an iframe, but the static server serving it has no way to set response headers, and there's no env var for a CSP:

```json
"serve:unsafe": "serve -s dist -p ${NANGO_CONNECT_UI_PORT:-3009}"
```

Nango sets no framing header itself, which means whatever sits in front of a self-hosted instance decides. Cloudflare's "Add security headers" managed transform sets `X-Frame-Options: SAMEORIGIN` **zone-wide** and cannot be scoped to a hostname, so on our deployment every Connect UI response arrived with `SAMEORIGIN` and the iframe was refused:

```
Refused to display 'https://nango-connect-dev.example.io/' in a frame
because it set 'X-Frame-Options' to 'sameorigin'.
```

We confirmed the origin was clean by fetching `serve` directly inside the pod — no framing header — so this is entirely down to what's in front. There's currently no in-app way for an operator to override it. We only had a workaround because we control the CDN; anyone behind a proxy they don't control is stuck.

## The change

Adds `NANGO_CONNECT_UI_FRAME_ANCESTORS`. When set, `packages/server/entrypoint.sh` writes a `serve.json` next to the built assets:

```json
{ "headers": [ { "source": "**/*", "headers": [
  { "key": "Content-Security-Policy", "value": "frame-ancestors <value>" } ] } ] }
```

`serve` reads that file automatically via `serve-handler`'s `headers` support, so there's no new dependency and no lockfile churn. When the variable is unset nothing is written and behaviour is unchanged.

Per the CSP spec, browsers ignore `X-Frame-Options` whenever `frame-ancestors` is present. So this lets an operator override a header added upstream **without** weakening that header for the rest of their domain — and it's a stricter control than the one it overrides, since `frame-ancestors` can name specific origins and `X-Frame-Options` cannot.

## Why this doesn't break the SPA fallback

That was my main concern, since a `serve.json` could plausibly replace the CLI-derived config and lose `-s`. It doesn't — `--single` is applied on top of the loaded configuration:

```ts
// source/main.ts
const [configError, config] = await resolve(loadConfiguration(presentDirectory, directoryToServe, args));
...
if (args['--single']) {
  const { rewrites } = config;
  const existingRewrites = Array.isArray(rewrites) ? rewrites : [];
  // Ensure this is the first rewrite rule so it gets priority.
  config.rewrites = [{ source: '**', destination: '/index.html' }, ...existingRewrites];
}
```

Verified empirically against `serve@14.2.6` with the generated config in place:

| Request | Result |
|---|---|
| `/` | `200` `text/html` + CSP header |
| `/some/client/route` | `200` `text/html` (fallback intact) + CSP header |
| `/assets/app.js` | `200` `application/javascript` (real asset, not the fallback) + CSP header |

`bash -n` passes on the entrypoint, and the generated JSON validates with a realistic multi-origin value.

## Notes

- Docs updated in `docs/guides/platform/self-hosting.mdx`, in the Connect UI section, as a purely additive block.
- The value is used verbatim as the `frame-ancestors` source list, so operators can pass `'self' https://app.example.com` or whatever suits them.
- If you'd rather this lived somewhere other than the entrypoint — a small static server in `packages/connect-ui`, or having the server serve the SPA so the existing helmet CSP config applies — I'm happy to redo it. The entrypoint felt like the smallest change that solves the problem for the image you actually publish.

Related: we hit several other self-hosting-on-Kubernetes gaps in the Helm chart, raised separately in [NangoHQ/nango-helm-charts#34](https://github.com/NangoHQ/nango-helm-charts/pull/34) (including a question about whether `RUNNER_TYPE=KUBERNETES` is the intended topology, given the published image is amd64-only).

Made with [Cursor](https://cursor.com)

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/NangoHQ/nango/pull/6956?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

