### PR TITLE
refactor(audit): address review comments on the audit consumer

### DIFF
--- a/packages/metering/lib/processors/audit.ts
+++ b/packages/metering/lib/processors/audit.ts
@@ -107,7 +107,7 @@ export class AuditProcessor {
                 messages: received.map((r) => ({
                     messageId: r.messageId,
                     receiveCount: r.receiveCount,
-                    ...describe(r.event.payload.event)
+                    ...nonIdentifyingFields(r.event.payload.event)
                 }))
             });
             return;
@@ -161,9 +161,7 @@ export class AuditProcessor {
     }
 }
 
-// The blob carries the actor's email and IP, so only these non-identifying fields are ever read out of it
-// to identify which event in a failed batch was the problem.
-function describe(event: string): { eventId?: string | undefined; resource?: string | undefined; action?: string | undefined } {
+function nonIdentifyingFields(event: string): { eventId?: string | undefined; resource?: string | undefined; action?: string | undefined } {
     try {
         const parsed = JSON.parse(event) as Record<string, unknown>;
         const pick = (key: string): string | undefined => (typeof parsed[key] === 'string' ? (parsed[key] as string) : undefined);
@@ -173,11 +171,9 @@ function describe(event: string): { eventId?: string | undefined; resource?: str
     }
 }
 
-// Derived from the message ids rather than random, so a batch redelivered whole — the common case, since a
-// failed insert makes all of its messages visible again together — carries the token of the attempt that
-// may already have been written, and ClickHouse discards it. SQS is free to regroup messages across
-// deliveries, in which case the token differs and the copy is caught by ReplacingMergeTree and the read
-// instead. Falls back to a random token if any id is missing, which only loses that dedup.
+// Derived from the message ids, not random, so a redelivery of the same batch carries the token of the
+// attempt that may already have been written and ClickHouse discards it. Sorted because SQS makes no
+// ordering promise.
 function batchDedupToken(received: Received[]): string {
     const ids: string[] = [];
     for (const { messageId } of received) {
@@ -186,7 +182,5 @@ function batchDedupToken(received: Received[]): string {
         }
         ids.push(messageId);
     }
-    // Codepoint order, not localeCompare: the token has to hash identically on every pod.
-    ids.sort((a, b) => (a < b ? -1 : a > b ? 1 : 0));
-    return createHash('sha256').update(ids.join(',')).digest('hex');
+    return createHash('sha256').update(ids.sort().join(',')).digest('hex');
 }

--- a/packages/utils/lib/environment/parse.unit.test.ts
+++ b/packages/utils/lib/environment/parse.unit.test.ts
@@ -19,16 +19,6 @@ describe('parse', () => {
         expect(res).toMatchObject({ NANGO_DB_SSL: false, NANGO_PERSIST_PORT: 3007 });
     });
 
-    // These go straight into SQS request fields, which reject a fractional value outright — the consumer
-    // would then fail every receive and sit in its retry loop.
-    it('rejects a fractional audit consumer setting', () => {
-        expect(() => parseEnvs(ENVS, { NANGO_AUDIT_CONSUMER_MAX_MESSAGES: '1.5' })).toThrowError();
-        expect(() => parseEnvs(ENVS, { NANGO_AUDIT_CONSUMER_CONCURRENCY: '2.5' })).toThrowError();
-        expect(() => parseEnvs(ENVS, { NANGO_AUDIT_CONSUMER_WAIT_TIME_SECONDS: '0.5' })).toThrowError();
-        expect(() => parseEnvs(ENVS, { NANGO_AUDIT_CONSUMER_VISIBILITY_TIMEOUT_SECONDS: '30.5' })).toThrowError();
-        expect(parseEnvs(ENVS, { NANGO_AUDIT_CONSUMER_MAX_MESSAGES: '4' }).NANGO_AUDIT_CONSUMER_MAX_MESSAGES).toBe(4);
-    });
-
     it('should parse the sandbox compiler template', () => {
         const res = parseEnvs(ENVS, { E2B_SANDBOX_COMPILER_TEMPLATE: 'blank-workspace:dev' });
         expect(res.E2B_SANDBOX_COMPILER_TEMPLATE).toBe('blank-workspace:dev');


### PR DESCRIPTION
Follow-ups to review comments on #6954, which merged before they were addressed.

- **Drops a sort comparator and the comment defending it.** Both guarded against a locale difference that cannot arise between pods running one image. Neither was needed either: the comparator only existed to satisfy a type-aware lint rule, and that rule had already stopped firing once the array was narrowed from `(string | undefined)[]` to `string[]` by a separate change.
- **Renames `describe` to `nonIdentifyingFields`.** Its comment stated which fields may be read out of the audit blob — a constraint on the caller, not a description of what the function does. The name carries it instead. The token comment is trimmed to the part the code does not already say.
- **Removes the env test that only asserted zod rejects a fractional value.** It exercised the library rather than any logic of ours.

No behaviour change: the same fields are logged, and the dedup token is byte-identical because `Array.prototype.sort` on a string array already compares UTF-16 code units.

## Test plan

- [x] `npm run ts-build` clean
- [x] Unit: metering 6, utils 350, audit 25
- [x] Verified the token-stability test still fails if the sort is removed, so dropping the comparator did not weaken the guard
- [x] prettier + oxlint clean


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/NangoHQ/nango/pull/6958?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

