### PR TITLE
feat(audit): meter audit events that go missing before the store write (NAN-6472)

### DIFF
--- a/packages/server/lib/middleware/audit.middleware.ts
+++ b/packages/server/lib/middleware/audit.middleware.ts
@@ -174,6 +174,7 @@ async function emit(policy: AuditPolicy, req: Request, res: Response, resolved: 
         }
     } catch (err) {
         logger.error(`failed to emit audit event`, err);
+        metrics.increment(metrics.Types.AUDIT_EMIT_DROPPED, 1, { source: 'auditable' });
     }
 }
 
@@ -187,6 +188,7 @@ interface ResolvedAudit {
 export function auditable<TEndpoint extends AuditableEndpoint>(spec: AuditSpec<TEndpoint>): RequestHandler {
     return (req, res, next) => {
         void (async () => {
+            let listening = false;
             try {
                 const locals = res.locals as RequestLocals;
                 if (locals.account && (await getFlags().isAuditTrailEnabled(locals.account.uuid))) {
@@ -197,6 +199,7 @@ export function auditable<TEndpoint extends AuditableEndpoint>(spec: AuditSpec<T
                     res.on('finish', () => {
                         void emit(spec.policy, req, res, resolved);
                     });
+                    listening = true;
                     // Resolve target and metadata before the handler runs — some handlers move or overwrite
                     // the pre-mutation state (a removed member, an old role).
                     resolved = {
@@ -206,6 +209,9 @@ export function auditable<TEndpoint extends AuditableEndpoint>(spec: AuditSpec<T
                 }
             } catch (err) {
                 logger.error(`failed to resolve audit target`, err);
+                // Throwing before the listener is registered loses the event outright; after it, the event
+                // still emits with whatever resolved.
+                metrics.increment(listening ? metrics.Types.AUDIT_RESOLVE_FAILED : metrics.Types.AUDIT_EMIT_DROPPED, 1, { source: 'auditable' });
             } finally {
                 next();
             }

--- a/packages/server/lib/middleware/auditable.unit.test.ts
+++ b/packages/server/lib/middleware/auditable.unit.test.ts
@@ -3,8 +3,10 @@ import { EventEmitter } from 'node:events';
 import { beforeEach, describe, expect, it, vi } from 'vitest';
 
 import * as featureFlags from '@nangohq/feature-flags';
+import { metrics } from '@nangohq/utils';
 
 import {
+    auditable,
     auditConnectionUpdated,
     auditEnvironmentVariablesChanged,
     auditEnvironmentWebhookUrlsChanged,
@@ -53,6 +55,9 @@ async function runAudit(handler: RequestHandler, req: any, res: any) {
 
 describe('auditable() middleware behavior (unit)', () => {
     beforeEach(() => {
+        // metrics.increment stays spied across tests, so its call history has to be cleared or the
+        // negative assertions below pass or fail depending on test order.
+        vi.clearAllMocks();
         recordMock.mockReset().mockResolvedValue({ isErr: () => false });
         // getFlags() returns the stable noop facade in tests; force the audit trail on.
         vi.spyOn(featureFlags.getFlags(), 'isAuditTrailEnabled').mockResolvedValue(true);
@@ -166,5 +171,64 @@ describe('auditable() middleware behavior (unit)', () => {
         await vi.waitFor(() => expect(recordMock).toHaveBeenCalled());
         // Target was captured pre-next, so it still points at the original environment.
         expect(recordMock.mock.calls[0]?.[0]?.targets).toEqual([{ type: 'environment', id: '9', display: 'dev' }]);
+    });
+
+    describe('an event we meant to record going missing is metered', () => {
+        it('counts a resolution failure as degraded, not dropped — the event is still recorded', async () => {
+            const inc = vi.spyOn(metrics, 'increment').mockImplementation(() => undefined);
+            const handler = auditable({
+                policy: { resource: 'environment', action: 'variables_changed', scope: 'environment' },
+                target: () => {
+                    throw new Error('resolver exploded');
+                }
+            } as any);
+            const res = fakeRes(locals);
+
+            await new Promise<void>((resolve) => handler(fakeReq(), res, () => resolve()));
+            res.emit('finish');
+
+            await vi.waitFor(() => expect(recordMock).toHaveBeenCalled());
+            expect(inc).toHaveBeenCalledWith(metrics.Types.AUDIT_RESOLVE_FAILED, 1, { source: 'auditable' });
+            expect(inc).not.toHaveBeenCalledWith(metrics.Types.AUDIT_EMIT_DROPPED, 1, { source: 'auditable' });
+            // Degraded, not lost: the event still carries the account and outcome, just no target.
+            expect(recordMock.mock.calls[0]?.[0]?.accountId).toBe(42);
+            expect(recordMock.mock.calls[0]?.[0]?.outcome).toBe('success');
+            expect(recordMock.mock.calls[0]?.[0]?.targets).toEqual([]);
+        });
+
+        it('counts a gate failure as dropped — no listener was registered, so nothing is recorded', async () => {
+            const inc = vi.spyOn(metrics, 'increment').mockImplementation(() => undefined);
+            vi.spyOn(featureFlags.getFlags(), 'isAuditTrailEnabled').mockRejectedValue(new Error('unleash unreachable'));
+            const req = fakeReq({ body: { variables: [{ name: 'X', value: 'y' }] } });
+            const res = fakeRes(locals);
+
+            await new Promise<void>((resolve) => auditEnvironmentVariablesChanged(req, res, () => resolve()));
+            res.emit('finish');
+            await new Promise((resolve) => setImmediate(resolve));
+
+            expect(inc).toHaveBeenCalledWith(metrics.Types.AUDIT_EMIT_DROPPED, 1, { source: 'auditable' });
+            expect(inc).not.toHaveBeenCalledWith(metrics.Types.AUDIT_RESOLVE_FAILED, 1, { source: 'auditable' });
+            expect(recordMock).not.toHaveBeenCalled();
+        });
+
+        it('counts an emit failure as dropped — the event never reaches the store', async () => {
+            const inc = vi.spyOn(metrics, 'increment').mockImplementation(() => undefined);
+            // Resolution reads the body; only the emit path reads headers, so this throws inside emit().
+            const req = fakeReq({
+                body: { variables: [{ name: 'X', value: 'y' }] },
+                get: () => {
+                    throw new Error('headers gone');
+                }
+            });
+            const res = fakeRes(locals);
+
+            await new Promise<void>((resolve) => auditEnvironmentVariablesChanged(req, res, () => resolve()));
+            res.emit('finish');
+            await new Promise((resolve) => setImmediate(resolve));
+
+            expect(inc).toHaveBeenCalledWith(metrics.Types.AUDIT_EMIT_DROPPED, 1, { source: 'auditable' });
+            expect(inc).not.toHaveBeenCalledWith(metrics.Types.AUDIT_RESOLVE_FAILED, 1, { source: 'auditable' });
+            expect(recordMock).not.toHaveBeenCalled();
+        });
     });
 });

--- a/packages/utils/lib/telemetry/metrics.ts
+++ b/packages/utils/lib/telemetry/metrics.ts
@@ -160,6 +160,8 @@ export enum Types {
     AUTH_CALLBACK_STATE_COOKIE = 'nango.server.auth.callback.state_cookie',
 
     AUDIT_TARGET_DISPLAY_RESOLUTION_FAILED = 'nango.audit.target.display_resolution_failed',
+    AUDIT_EMIT_DROPPED = 'nango.audit.emit.dropped',
+    AUDIT_RESOLVE_FAILED = 'nango.audit.resolve.failed',
     AUDIT_CLICKHOUSE_INGEST_RESULT = 'nango.audit.clickhouse.ingest.result',
     AUDIT_CONSUMER_BATCH_SIZE = 'nango.audit.consumer.batch.size',
     AUDIT_CONSUMER_REJECTED = 'nango.audit.consumer.rejected',


### PR DESCRIPTION
- **An audit event that vanishes upstream of the store is now countable.** `store.record()` already meters every ClickHouse write attempt, so a failed *write* is alertable — but the two `catch` blocks that fire before it, when event construction or target resolution throws, were log-only. An event we intended to record disappearing was invisible to metrics.
- **Dropped and degraded are separate counters, because they are different failures.** The finish listener is registered before target resolution runs, so throwing *before* registration loses the event outright, while throwing *during* resolution still emits it with no target. `nango.audit.emit.dropped` therefore stays the single number to alert on for events actually lost, and `nango.audit.resolve.failed` covers the recorded-but-incomplete case.

Both carry a `source` tag so the dedicated auth, sync-command and MFA middlewares report distinctly once they land, and so NAN-6471's shared emit tail can absorb both increments without changing the metric contract.

## Deliberately not metered

- `DropAuditStore.record()` returns `Ok` while discarding, so any deployment without `CLICKHOUSE_URL` drops every event silently. That is correct behaviour for self-hosting rather than a fault, and no counter here sees it.
- `emit()`'s early return when there is no account — unreachable in practice, since the listener is only registered when one exists.

## Test plan

- [x] `ts-build`, `npm run lint` (exit 0), prettier clean
- [x] 10/10 middleware unit tests, 5/5 audit middleware integration tests
- [x] One test per path: resolution failure (degraded — asserts the event is still recorded with its account and outcome), gate failure and emit failure (both dropped — assert nothing reaches the store). Each asserts the counter that should fire *and* the one that should not
- [x] Verified non-vacuous: removing both increments reds exactly the three new tests and leaves the other seven green
- [x] Verified the dropped/degraded split is load-bearing: flattening it to a single counter reds exactly the gate-failure test
- [ ] After deploy: confirm both counters report, and set a threshold on `nango.audit.emit.dropped` — audit volume is low enough that any non-zero value is worth looking at

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/NangoHQ/nango/pull/6963?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

