### PR TITLE
fix(function): align types between types package and runner-sdk

### DIFF
--- a/packages/cli/lib/sdkExperimental.ts
+++ b/packages/cli/lib/sdkExperimental.ts
@@ -2,4 +2,4 @@
 // Intentionally kept off the main `nango` barrel.
 
 export { createFunction, deriveFunctionCapabilities } from '@nangohq/runner-sdk';
-export type { CreateFunctionProps, CreateFunctionResponse, TriggerDefinition } from '@nangohq/runner-sdk';
+export type { CreateFunctionProps, CreateFunctionResponse, FunctionTriggerDefinition } from '@nangohq/runner-sdk';

--- a/packages/cli/lib/zeroYaml/compile.unit.cli-test.ts
+++ b/packages/cli/lib/zeroYaml/compile.unit.cli-test.ts
@@ -55,8 +55,15 @@ describe('compileAll', () => {
             name: 'fetchIssues',
             integrationId: 'github',
             description: 'Fetch a GitHub issue on demand',
-            trigger: null,
-            capabilities: { usesRecords: false, usesOutbound: true, usesCheckpoints: false, usesMetadata: false, usesInvoke: false }
+            trigger: { kind: 'none' },
+            requires: { connection: true, outbound: true, invoke: false },
+            capabilities: { usesRecords: false, usesOutbound: true, usesCheckpoints: false, usesMetadata: false, usesInvoke: false },
+            limits: { concurrency: { perConnection: 'max' } },
+            input_schema_ref: '#/definitions/FunctionInput_github_fetchIssues',
+            output_schema_ref: '#/definitions/FunctionOutput_github_fetchIssues',
+            model_schema_refs: [],
+            metadata_schema_ref: null,
+            checkpoint_schema_ref: null
         });
         expect(functionsJson[0].json_schema.definitions).toHaveProperty('FunctionInput_github_fetchIssues');
         expect(functionsJson[0].json_schema.definitions).toHaveProperty('FunctionOutput_github_fetchIssues');
@@ -110,6 +117,11 @@ describe('validateFunction', () => {
 
     it('accepts an invoke-only function with no trigger', () => {
         const res = validateFunction({ ...base, params: {} });
+        expect(res.isOk()).toBe(true);
+    });
+
+    it("accepts an explicit 'none' trigger", () => {
+        const res = validateFunction({ ...base, params: { trigger: { kind: 'none' } } });
         expect(res.isOk()).toBe(true);
     });
 

--- a/packages/cli/lib/zeroYaml/definitions.ts
+++ b/packages/cli/lib/zeroYaml/definitions.ts
@@ -377,7 +377,8 @@ export function parseFunction({
         requires.connection === false
             ? {}
             : { concurrency: { perConnection: params.trigger?.kind === 'schedule' ? 1 : (params.limits?.concurrency?.perConnection ?? 'max') } };
-    const toSchemaRef = (name: string | null): string | null => (name ? `#/definitions/${name}` : null);
+    const toSchemaRef = (name: string): string => `#/definitions/${name}`;
+    const toSchemaRefNullable = (name: string | null): string | null => (name ? toSchemaRef(name) : null);
 
     return {
         name: basename,
@@ -387,11 +388,11 @@ export function parseFunction({
         requires,
         capabilities: deriveFunctionCapabilities(params),
         limits,
-        input_schema_ref: toSchemaRef(inputName),
-        output_schema_ref: toSchemaRef(outputName),
-        model_schema_refs: models ? Object.keys(models).map((name) => `#/definitions/${name}`) : [],
-        metadata_schema_ref: toSchemaRef(metadataName),
-        checkpoint_schema_ref: toSchemaRef(checkpointName),
+        input_schema_ref: toSchemaRefNullable(inputName),
+        output_schema_ref: toSchemaRefNullable(outputName),
+        model_schema_refs: Object.keys(models || {}).map(toSchemaRef),
+        metadata_schema_ref: toSchemaRefNullable(metadataName),
+        checkpoint_schema_ref: toSchemaRefNullable(checkpointName),
         json_schema: buildJsonSchemaDefinitionsFromZodModels(allZodModels)
     };
 }

--- a/packages/cli/lib/zeroYaml/definitions.ts
+++ b/packages/cli/lib/zeroYaml/definitions.ts
@@ -17,21 +17,53 @@ import {
     TrackDeletesDefinitionError
 } from './utils.js';
 
-import type { CreateActionResponse, CreateFunctionResponse, CreateOnEventResponse, CreateSyncResponse, Requires, TriggerDefinition } from '@nangohq/runner-sdk';
+import type {
+    CreateActionResponse,
+    CreateFunctionResponse,
+    CreateOnEventResponse,
+    CreateSyncResponse,
+    FunctionRequires,
+    FunctionTriggerDefinition
+} from '@nangohq/runner-sdk';
 import type { ZodCheckpoint, ZodMetadata, ZodModel } from '@nangohq/runner-sdk/lib/types.js';
-import type { FunctionCapabilities, NangoYamlParsed, NangoYamlParsedIntegration, ParsedNangoAction, ParsedNangoSync, Result } from '@nangohq/types';
-import type { JSONSchema7 } from 'json-schema';
+import type {
+    DBFunctionConfigVersion,
+    FunctionConcurrencyLimit,
+    NangoYamlParsed,
+    NangoYamlParsedIntegration,
+    ParsedNangoAction,
+    ParsedNangoSync,
+    Result
+} from '@nangohq/types';
 import type * as z from 'zod';
 
-export interface FunctionConfig {
+interface FunctionDefinition {
+    description: string;
+    trigger?: FunctionTriggerDefinition | undefined;
+    requires?: FunctionRequires | undefined;
+    limits?: { concurrency?: { perConnection?: FunctionConcurrencyLimit } } | undefined;
+    input?: z.ZodTypeAny | undefined;
+    output?: z.ZodTypeAny | undefined;
+    data?: { models?: Record<string, ZodModel>; metadata?: ZodMetadata; checkpoint?: ZodCheckpoint } | undefined;
+}
+
+export interface FunctionConfig
+    extends Pick<
+        DBFunctionConfigVersion,
+        | 'description'
+        | 'trigger'
+        | 'requires'
+        | 'capabilities'
+        | 'limits'
+        | 'input_schema_ref'
+        | 'output_schema_ref'
+        | 'model_schema_refs'
+        | 'metadata_schema_ref'
+        | 'checkpoint_schema_ref'
+        | 'json_schema'
+    > {
     name: string;
     integrationId: string;
-    description: string;
-    trigger: TriggerDefinition | null;
-    capabilities: FunctionCapabilities;
-    input: string | null;
-    output: string | null;
-    json_schema: JSONSchema7;
 }
 
 export interface ParsedIntegrationDefinitions extends NangoYamlParsed {
@@ -268,7 +300,7 @@ export function validateFunction({
     integrationId,
     basename
 }: {
-    params: { trigger?: TriggerDefinition | undefined; data?: unknown; requires?: Requires | undefined };
+    params: { trigger?: FunctionTriggerDefinition | undefined; data?: unknown; requires?: FunctionRequires | undefined };
     integrationId: string;
     basename: string;
 }): Result<void> {
@@ -276,7 +308,7 @@ export function validateFunction({
 
     // For now only trigger-less functions (triggered manually) are supported, with no data (records, checkpoints or metadata).
     // TODO: Add support for http, schedule and event triggers, and data
-    const supportedFunctionTriggerKinds: TriggerDefinition['kind'][] = [];
+    const supportedFunctionTriggerKinds: FunctionTriggerDefinition['kind'][] = ['none'];
 
     if (params.trigger && !supportedFunctionTriggerKinds.includes(params.trigger.kind)) {
         const supported = supportedFunctionTriggerKinds.map((kind) => `'${kind}'`).join(', ');
@@ -303,7 +335,7 @@ export function parseFunction({
     basename,
     basenameClean
 }: {
-    params: CreateFunctionResponse;
+    params: FunctionDefinition;
     integrationId: string;
     integrationIdClean: string;
     basename: string;
@@ -311,6 +343,10 @@ export function parseFunction({
 }): FunctionConfig {
     const inputName = params.input ? `FunctionInput_${integrationIdClean}_${basenameClean}` : null;
     const outputName = params.output ? `FunctionOutput_${integrationIdClean}_${basenameClean}` : null;
+    const metadata = params.data?.metadata;
+    const metadataName = metadata ? `FunctionMetadata_${integrationIdClean}_${basenameClean}` : null;
+    const checkpoint = params.data?.checkpoint;
+    const checkpointName = checkpoint ? `FunctionCheckpoint_${integrationIdClean}_${basenameClean}` : null;
 
     const allZodModels: Record<string, z.ZodType> = {};
     if (inputName) {
@@ -319,6 +355,12 @@ export function parseFunction({
     if (outputName) {
         allZodModels[outputName] = params.output as z.ZodType;
     }
+    if (metadataName && metadata) {
+        allZodModels[metadataName] = metadata;
+    }
+    if (checkpointName && checkpoint) {
+        allZodModels[checkpointName] = checkpoint;
+    }
     const models = params.data?.models;
     if (models) {
         for (const [name, model] of Object.entries(models)) {
@@ -326,14 +368,30 @@ export function parseFunction({
         }
     }
 
+    const requires: FunctionRequires =
+        params.requires?.connection === false
+            ? { connection: false, outbound: false, invoke: params.requires.invoke === true }
+            : { connection: true, outbound: params.requires?.outbound !== false, invoke: params.requires?.invoke === true };
+
+    const limits: DBFunctionConfigVersion['limits'] =
+        requires.connection === false
+            ? {}
+            : { concurrency: { perConnection: params.trigger?.kind === 'schedule' ? 1 : (params.limits?.concurrency?.perConnection ?? 'max') } };
+    const toSchemaRef = (name: string | null): string | null => (name ? `#/definitions/${name}` : null);
+
     return {
         name: basename,
         integrationId,
         description: params.description,
-        trigger: params.trigger ?? null,
+        trigger: params.trigger ?? { kind: 'none' },
+        requires,
         capabilities: deriveFunctionCapabilities(params),
-        input: inputName,
-        output: outputName,
+        limits,
+        input_schema_ref: toSchemaRef(inputName),
+        output_schema_ref: toSchemaRef(outputName),
+        model_schema_refs: models ? Object.keys(models).map((name) => `#/definitions/${name}`) : [],
+        metadata_schema_ref: toSchemaRef(metadataName),
+        checkpoint_schema_ref: toSchemaRef(checkpointName),
         json_schema: buildJsonSchemaDefinitionsFromZodModels(allZodModels)
     };
 }

--- a/packages/cli/lib/zeroYaml/definitions.unit.test.ts
+++ b/packages/cli/lib/zeroYaml/definitions.unit.test.ts
@@ -1,7 +1,7 @@
 import { describe, expect, it } from 'vitest';
 import * as z from 'zod';
 
-import { parseAction, parseSync } from './definitions.js';
+import { parseAction, parseFunction, parseSync } from './definitions.js';
 
 const syncParams = {
     type: 'sync' as const,
@@ -139,5 +139,89 @@ describe('parseAction', () => {
                 }
             }
         });
+    });
+});
+
+describe('parseFunction', () => {
+    const common = {
+        integrationId: 'github',
+        integrationIdClean: 'github',
+        basename: 'fetchIssues',
+        basenameClean: 'fetchIssues'
+    };
+    const params = {
+        description: 'A function'
+    };
+
+    it('normalizes an invoke-only connection-bound function', () => {
+        const fn = parseFunction({ ...common, params });
+
+        expect(fn).toMatchObject({
+            trigger: { kind: 'none' },
+            requires: { connection: true, outbound: true, invoke: false },
+            limits: { concurrency: { perConnection: 'max' } },
+            input_schema_ref: null,
+            output_schema_ref: null,
+            model_schema_refs: [],
+            metadata_schema_ref: null,
+            checkpoint_schema_ref: null
+        });
+    });
+
+    it('normalizes scheduled function concurrency to one', () => {
+        const fn = parseFunction({
+            ...common,
+            params: { ...params, trigger: { kind: 'schedule', frequency: 'every hour' } }
+        });
+
+        expect(fn.limits).toEqual({ concurrency: { perConnection: 1 } });
+    });
+
+    it('omits per-connection concurrency for connection-less functions', () => {
+        const fn = parseFunction({
+            ...common,
+            params: { ...params, requires: { connection: false } }
+        });
+
+        expect(fn.limits).toEqual({});
+        expect(fn.requires).toEqual({ connection: false, outbound: false, invoke: false });
+    });
+
+    it('normalizes explicitly selected requirements', () => {
+        const fn = parseFunction({
+            ...common,
+            params: { ...params, requires: { outbound: false, invoke: true } }
+        });
+
+        expect(fn.requires).toEqual({ connection: true, outbound: false, invoke: true });
+    });
+
+    it('emits references for every declared schema', () => {
+        const fn = parseFunction({
+            ...common,
+            params: {
+                ...params,
+                input: z.object({ query: z.string() }),
+                output: z.object({ count: z.number() }),
+                data: {
+                    models: { GithubIssue: z.object({ id: z.string() }) },
+                    metadata: z.object({ cursor: z.string() }),
+                    checkpoint: z.object({ page: z.number() })
+                }
+            }
+        });
+
+        expect(fn).toMatchObject({
+            input_schema_ref: '#/definitions/FunctionInput_github_fetchIssues',
+            output_schema_ref: '#/definitions/FunctionOutput_github_fetchIssues',
+            model_schema_refs: ['#/definitions/GithubIssue'],
+            metadata_schema_ref: '#/definitions/FunctionMetadata_github_fetchIssues',
+            checkpoint_schema_ref: '#/definitions/FunctionCheckpoint_github_fetchIssues'
+        });
+        expect(fn.json_schema.definitions).toHaveProperty('FunctionInput_github_fetchIssues');
+        expect(fn.json_schema.definitions).toHaveProperty('FunctionOutput_github_fetchIssues');
+        expect(fn.json_schema.definitions).toHaveProperty('GithubIssue');
+        expect(fn.json_schema.definitions).toHaveProperty('FunctionMetadata_github_fetchIssues');
+        expect(fn.json_schema.definitions).toHaveProperty('FunctionCheckpoint_github_fetchIssues');
     });
 });

--- a/packages/runner-sdk/lib/function.ts
+++ b/packages/runner-sdk/lib/function.ts
@@ -5,6 +5,9 @@ import type {
     AllAuthCredentials,
     EnvironmentVariable,
     FunctionCapabilities,
+    FunctionConcurrencyLimit,
+    FunctionRequires,
+    FunctionTriggerDefinition,
     GetPublicConnection,
     GetPublicIntegration,
     HTTP_METHOD,
@@ -15,46 +18,9 @@ import type {
 } from '@nangohq/types';
 import type * as z from 'zod';
 
+export type { DebounceKeySource, DebounceOptions, FunctionRequires, FunctionTriggerDefinition } from '@nangohq/types';
+
 type InferZod<T> = T extends z.ZodTypeAny ? z.infer<T> : never;
-
-// Limits
-
-// Max concurrent runs for a single connection: `1` serializes, `'max'` lets them overlap.
-export type ConcurrencyLimit = 1 | 'max';
-
-// Debounce
-
-/**
- * Declares where the debounce/coalescing key is extracted from:
- * - `{ body: '$.portalId' }`: dot notation path into the body
- * - `{ header: 'x-goog-resource-id' }`: flat, case-insensitive header lookup
- */
-export type DebounceKeySource = { body: string } | { header: string };
-
-// Coalesces a burst of inbound http requests into a single function run within a sliding window.
-export interface DebounceOptions {
-    // Events sharing the same resolved key coalesce together.
-    keyBy?: DebounceKeySource | DebounceKeySource[];
-    // Sliding window in milliseconds.
-    windowMs: number;
-    // When exceeded, the window stops sliding
-    maxEntities?: number;
-    // Which payload(s) from the coalesced window the handler receives: the first, the latest, or all of them.
-    take?: 'latest' | 'first' | 'all';
-}
-
-// Triggers
-
-/**
- * A trigger declares how a function is initiated FROM OUTSIDE; the `kind` discriminates what initiates execution.
- * - `schedule`: a periodic schedule
- * - `http`: an incoming http call or webhook request
- * - `event`: an internal Nango lifecycle event
- */
-export type TriggerDefinition =
-    | { kind: 'schedule'; frequency: string; autoStart?: boolean }
-    | { kind: 'http'; subscriptions?: string[]; debounce?: DebounceOptions }
-    | { kind: 'event'; events: OnEventType[] };
 
 // The inbound http request that initiated the run.
 export interface HttpRequest {
@@ -101,7 +67,7 @@ export type EventTrigger = TriggerBase & { kind: 'event'; input: { event: OnEven
  * synthesizes the envelope (e.g. an http `request`/`coalesced` derived from the invoked input).
  * A function with no declared trigger is invoke-only and receives `InvokeTrigger`.
  */
-export type Trigger<TT extends TriggerDefinition | undefined, TInput extends z.ZodTypeAny> = TT extends { kind: 'schedule' }
+export type Trigger<TT extends FunctionTriggerDefinition | undefined, TInput extends z.ZodTypeAny> = TT extends { kind: 'schedule' }
     ? ScheduleTrigger
     : TT extends { kind: 'http' }
       ? HttpTrigger<TT, TInput>
@@ -196,7 +162,7 @@ export type Nango<
     TModels extends Record<string, ZodModel>,
     TMetadata extends ZodMetadata,
     TCheckpoint extends ZodCheckpoint,
-    TRequires extends Requires
+    TRequires extends FunctionRequires
 > = TRequires extends { connection: false }
     ? NangoBase & ConnectionSearchCapability & (TRequires extends { invoke: true } ? InvokeCapability : unknown)
     : NangoBase &
@@ -209,21 +175,14 @@ export type Nango<
 
 // Function
 
-// What a function requires; shapes the capability-narrowed `nango` surface.
-export type Requires =
-    // Connection-bound (default): `getConnection` plus, by default, proxying and invoke capabilities.
-    | { connection?: true; outbound?: boolean; invoke?: boolean }
-    // Connection-less: no connection context, can only `searchConnections` and `invoke`.
-    | { connection: false; outbound?: false; invoke?: boolean };
-
 export interface CreateFunctionProps<
     TModels extends Record<string, ZodModel> = Record<never, ZodModel>,
     TInput extends z.ZodTypeAny = z.ZodVoid,
     TOutput extends z.ZodTypeAny = z.ZodVoid,
     TMetadata extends ZodMetadata = undefined,
     TCheckpoint extends ZodCheckpoint = undefined,
-    TTrigger extends TriggerDefinition | undefined = undefined,
-    TRequires extends Requires = { outbound: true; connection: true }
+    TTrigger extends FunctionTriggerDefinition | undefined = undefined,
+    TRequires extends FunctionRequires = { outbound: true; connection: true }
 > {
     description: string;
     // Optional input schema: the invoke call argument and/or the http request body. Omit when there is no input.
@@ -243,12 +202,12 @@ export interface CreateFunctionProps<
           };
     // How the function is initiated from outside. Omit for an invoke-only helper.
     trigger?: TTrigger;
-    // Opt in/out of capabilities (connection, outbound, invoke). See `Requires`.
+    // Opt in/out of capabilities (connection, outbound, invoke). See `FunctionRequires`.
     requires?: TRequires;
     limits?: {
         concurrency?: {
             // Max concurrent runs for a single connection. Pinned to `1` for schedule triggers.
-            perConnection?: TTrigger extends { kind: 'schedule' } ? 1 : ConcurrencyLimit;
+            perConnection?: TTrigger extends { kind: 'schedule' } ? 1 : FunctionConcurrencyLimit;
         };
     };
     // The handler. Runs on the runner with the capability-narrowed `nango` surface.
@@ -260,8 +219,8 @@ export interface CreateFunctionResponse<
     TOutput extends z.ZodTypeAny = z.ZodVoid,
     TMetadata extends ZodMetadata = undefined,
     TCheckpoint extends ZodCheckpoint = undefined,
-    TTrigger extends TriggerDefinition | undefined = undefined,
-    TRequires extends Requires = { outbound: true; connection: true }
+    TTrigger extends FunctionTriggerDefinition | undefined = undefined,
+    TRequires extends FunctionRequires = { outbound: true; connection: true }
 > extends CreateFunctionProps<TModels, TInput, TOutput, TMetadata, TCheckpoint, TTrigger, TRequires> {
     type: 'function';
     // The capabilities derived from the function definition.
@@ -293,8 +252,8 @@ export function createFunction<
     TOutput extends z.ZodTypeAny = z.ZodVoid,
     TMetadata extends ZodMetadata = undefined,
     TCheckpoint extends ZodCheckpoint = undefined,
-    TTrigger extends TriggerDefinition | undefined = undefined,
-    TRequires extends Requires = { outbound: true; connection: true }
+    TTrigger extends FunctionTriggerDefinition | undefined = undefined,
+    TRequires extends FunctionRequires = { outbound: true; connection: true }
 >(
     params: CreateFunctionProps<TModels, TInput, TOutput, TMetadata, TCheckpoint, TTrigger, TRequires>
 ): CreateFunctionResponse<TModels, TInput, TOutput, TMetadata, TCheckpoint, TTrigger, TRequires> {
@@ -304,7 +263,7 @@ export function createFunction<
 // Derives the runtime capabilities from function definition
 export function deriveFunctionCapabilities(params: {
     data?: { models?: Record<string, ZodModel>; metadata?: ZodMetadata; checkpoint?: ZodCheckpoint } | undefined;
-    requires?: Requires | undefined;
+    requires?: FunctionRequires | undefined;
 }): FunctionCapabilities {
     const models = params.data?.models;
     // A connection-less function has no connection to proxy through, so outbound is always off.

--- a/packages/runner-sdk/lib/function.unit.test.ts
+++ b/packages/runner-sdk/lib/function.unit.test.ts
@@ -246,6 +246,20 @@ describe('createFunction', () => {
         });
     });
 
+    describe('none trigger', () => {
+        it('uses the invoke-only execution shape', () => {
+            createFunction({
+                description: 'invoke-only helper',
+                // no trigger
+                input: z.object({ query: z.string() }),
+                exec: (_nango, trigger) => {
+                    expectTypeOf(trigger.kind).toEqualTypeOf<'invoke'>();
+                    expectTypeOf(trigger.input).toEqualTypeOf<{ query: string }>();
+                }
+            });
+        });
+    });
+
     describe('no models', () => {
         it('does not expose record/checkpoint/metadata methods', () => {
             createFunction({

--- a/packages/runner-sdk/lib/index.ts
+++ b/packages/runner-sdk/lib/index.ts
@@ -8,7 +8,7 @@ export * from './sync.js';
 export * from './scripts.js';
 export * from './checkpoint.js';
 export { createFunction, deriveFunctionCapabilities } from './function.js';
-export type { CreateFunctionProps, CreateFunctionResponse, Requires, TriggerDefinition } from './function.js';
+export type { CreateFunctionProps, CreateFunctionResponse, FunctionRequires, FunctionTriggerDefinition } from './function.js';
 export { executeUncontrolledFetch } from './uncontrolledFetch.js';
 export type { UncontrolledFetchOptions } from './uncontrolledFetch.js';
 export { isBaseUrlOverridePolicyEnabledFromEnv, resolveProxyBaseUrlOverrideDenylist } from './baseUrlOverrideDenylist.js';

--- a/packages/types/lib/function/config.ts
+++ b/packages/types/lib/function/config.ts
@@ -1,5 +1,13 @@
 import type { OnEventType } from '../scripts/on-events/api.js';
 
+export interface FunctionCapabilities {
+    usesRecords: boolean;
+    usesOutbound: boolean;
+    usesCheckpoints: boolean;
+    usesMetadata: boolean;
+    usesInvoke: boolean;
+}
+
 /**
  * Declares where the debounce/coalescing key is extracted from:
  * - `{ body: '$.portalId' }`: dot notation path into the body
@@ -40,4 +48,4 @@ export interface FunctionLimits {
     };
 }
 
-export type Requires = { connection?: true; outbound?: boolean; invoke?: boolean } | { connection: false; outbound?: false; invoke?: boolean };
+export type FunctionRequires = { connection?: true; outbound?: boolean; invoke?: boolean } | { connection: false; outbound?: false; invoke?: boolean };

--- a/packages/types/lib/function/db.ts
+++ b/packages/types/lib/function/db.ts
@@ -1,7 +1,6 @@
 import type { TimestampsAndDeletedAt } from '../db.js';
-import type { FunctionCapabilities } from '../functions/capabilities.js';
-import type { FunctionLimits, FunctionTriggerDefinition, Requires } from '../functions/config.js';
 import type { FunctionSource } from '../syncConfigs/db.js';
+import type { FunctionCapabilities, FunctionLimits, FunctionRequires, FunctionTriggerDefinition } from './config.js';
 import type { JSONSchema7 } from 'json-schema';
 
 export interface DBFunctionConfig extends TimestampsAndDeletedAt {
@@ -21,7 +20,7 @@ export interface DBFunctionConfigVersion extends TimestampsAndDeletedAt {
     version: string;
     source: FunctionSource;
     trigger: FunctionTriggerDefinition;
-    requires: Requires;
+    requires: FunctionRequires;
     capabilities: FunctionCapabilities;
     limits: FunctionLimits;
     input_schema_ref: string | null;

--- a/packages/types/lib/functions/capabilities.ts
+++ b/packages/types/lib/functions/capabilities.ts
@@ -1,7 +1,0 @@
-export interface FunctionCapabilities {
-    usesRecords: boolean;
-    usesCheckpoints: boolean;
-    usesMetadata: boolean;
-    usesOutbound: boolean;
-    usesInvoke: boolean;
-}

--- a/packages/types/lib/index.ts
+++ b/packages/types/lib/index.ts
@@ -107,10 +107,9 @@ export type * from './checkpoint/db.js';
 export type * from './mcp/api.js';
 export type * from './mfa/api.js';
 export type * from './mfa/db.js';
+export type * from './function/config.js';
 export type * from './function/db.js';
 export type * from './functions/api.js';
-export type * from './functions/capabilities.js';
-export type * from './functions/config.js';
 export type * from './functions/domain.js';
 
 export type * from './lambda/index.js';


### PR DESCRIPTION
This commit consolidates and align the types between `runner-sdk` and the `types` packages



<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/NangoHQ/nango/pull/6964?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

