### PR TITLE
perf(ci): amortize module imports in integration tests (NAN-6488)

### DIFF
--- a/packages/jobs/lib/execution/sync.integration.test.ts
+++ b/packages/jobs/lib/execution/sync.integration.test.ts
@@ -17,12 +17,15 @@ import type { ConnectionJobs, DBSyncConfig, SyncResult } from '@nangohq/types';
 const mockStartScript = vi.fn(() => Promise.resolve(Ok(undefined)));
 
 describe('Running sync', () => {
+    const logsEnabled = envs.NANGO_LOGS_ENABLED;
+
     beforeAll(async () => {
         await initDb();
         envs.NANGO_LOGS_ENABLED = false;
     });
 
     afterAll(async () => {
+        envs.NANGO_LOGS_ENABLED = logsEnabled;
         await clearRecordsDb();
     });
 

--- a/packages/keystore/lib/utils/encryption.ts
+++ b/packages/keystore/lib/utils/encryption.ts
@@ -1,7 +1,7 @@
 import crypto from 'crypto';
 import utils from 'node:util';
 
-import { Encryption } from '@nangohq/utils';
+import { Encryption, PBKDF2_ITERATIONS } from '@nangohq/utils';
 
 import { dek } from './env.js';
 
@@ -27,5 +27,5 @@ export function getEncryption(): Encryption {
 
 export async function hashValue(val: string): Promise<string> {
     const encryptionKey = getEncryptionKey();
-    return (await pbkdf2(val, encryptionKey, 310000, 32, 'sha256')).toString('base64');
+    return (await pbkdf2(val, encryptionKey, PBKDF2_ITERATIONS, 32, 'sha256')).toString('base64');
 }

--- a/packages/server/lib/clients/auth.client.ts
+++ b/packages/server/lib/clients/auth.client.ts
@@ -9,7 +9,7 @@ import { Strategy as LocalStrategy } from 'passport-local';
 
 import { database } from '@nangohq/database';
 import { pbkdf2, userService } from '@nangohq/shared';
-import { baseUrl, flagHasAuth, isBasicAuthEnabled } from '@nangohq/utils';
+import { baseUrl, flagHasAuth, isBasicAuthEnabled, PBKDF2_ITERATIONS } from '@nangohq/utils';
 
 import type { StoreFactory } from 'connect-session-knex';
 import type express from 'express';
@@ -84,7 +84,7 @@ export function setupAuth(app: express.Router) {
                     return;
                 }
 
-                const proposedHashedPassword = await pbkdf2(password, user.salt, 310000, 32, 'sha256');
+                const proposedHashedPassword = await pbkdf2(password, user.salt, PBKDF2_ITERATIONS, 32, 'sha256');
                 const actualHashedPassword = Buffer.from(user.hashed_password, 'base64');
 
                 if (proposedHashedPassword.length !== actualHashedPassword.length || !crypto.timingSafeEqual(actualHashedPassword, proposedHashedPassword)) {
@@ -106,22 +106,22 @@ export function setupAuth(app: express.Router) {
                 const user = await userService.getUserById(0);
 
                 if (!isBasicAuthEnabled) {
-                    return done(null, user);
+                    return void done(null, user);
                 }
 
                 if (username !== process.env['NANGO_DASHBOARD_USERNAME']) {
-                    return done(null, false);
+                    return void done(null, false);
                 }
 
                 if (password !== process.env['NANGO_DASHBOARD_PASSWORD']) {
-                    return done(null, false);
+                    return void done(null, false);
                 }
 
                 if (!user) {
-                    return done(null, false);
+                    return void done(null, false);
                 }
 
-                return done(null, user);
+                return void done(null, user);
             })
         );
     }
@@ -134,7 +134,7 @@ export function setupAuth(app: express.Router) {
 
     passport.deserializeUser(function (user: Express.User, cb) {
         process.nextTick(function () {
-            return cb(null, user);
+            return void cb(null, user);
         });
     });
 }

--- a/packages/server/lib/controllers/sync/deploy/postDeploy.integration.test.ts
+++ b/packages/server/lib/controllers/sync/deploy/postDeploy.integration.test.ts
@@ -13,11 +13,14 @@ let api: Awaited<ReturnType<typeof runServer>>;
 const endpoint = '/sync/deploy';
 
 describe(`POST ${endpoint}`, () => {
+    const logsEnabled = envs.NANGO_LOGS_ENABLED;
+
     beforeAll(async () => {
         api = await runServer();
         envs.NANGO_LOGS_ENABLED = false;
     });
     afterAll(() => {
+        envs.NANGO_LOGS_ENABLED = logsEnabled;
         api.server.close();
     });
 

--- a/packages/server/lib/controllers/sync/deploy/postDeployInternal.integration.test.ts
+++ b/packages/server/lib/controllers/sync/deploy/postDeployInternal.integration.test.ts
@@ -10,11 +10,14 @@ let api: Awaited<ReturnType<typeof runServer>>;
 const endpoint = '/sync/deploy/internal';
 
 describe(`POST ${endpoint}`, () => {
+    const logsEnabled = envs.NANGO_LOGS_ENABLED;
+
     beforeAll(async () => {
         api = await runServer();
         envs.NANGO_LOGS_ENABLED = false;
     });
     afterAll(() => {
+        envs.NANGO_LOGS_ENABLED = logsEnabled;
         api.server.close();
     });
     afterEach(() => {

--- a/packages/server/lib/controllers/sync/getSyncStatus.integration.test.ts
+++ b/packages/server/lib/controllers/sync/getSyncStatus.integration.test.ts
@@ -15,12 +15,17 @@ const mockGetSyncStatus = vi.spyOn(syncManager, 'getSyncStatus').mockResolvedVal
 });
 
 describe(`GET ${endpoint}`, () => {
+    const logsEnabled = envs.NANGO_LOGS_ENABLED;
+
     beforeAll(async () => {
         api = await runServer();
         envs.NANGO_LOGS_ENABLED = false;
     });
     afterAll(() => {
+        envs.NANGO_LOGS_ENABLED = logsEnabled;
         api.server.close();
+        // Module-level spies live on the shared syncManager, so drop them for the next file.
+        vi.restoreAllMocks();
     });
 
     beforeEach(() => {

--- a/packages/server/lib/controllers/sync/postSyncPause.integration.test.ts
+++ b/packages/server/lib/controllers/sync/postSyncPause.integration.test.ts
@@ -16,12 +16,17 @@ const mockRunSyncCommand = vi.spyOn(syncManager, 'runSyncCommand').mockResolvedV
 });
 
 describe(`POST ${endpoint}`, () => {
+    const logsEnabled = envs.NANGO_LOGS_ENABLED;
+
     beforeAll(async () => {
         api = await runServer();
         envs.NANGO_LOGS_ENABLED = false;
     });
     afterAll(() => {
+        envs.NANGO_LOGS_ENABLED = logsEnabled;
         api.server.close();
+        // Module-level spies live on the shared syncManager, so drop them for the next file.
+        vi.restoreAllMocks();
     });
 
     it('should be protected', async () => {

--- a/packages/server/lib/controllers/sync/postSyncStart.integration.test.ts
+++ b/packages/server/lib/controllers/sync/postSyncStart.integration.test.ts
@@ -16,12 +16,17 @@ const mockRunSyncCommand = vi.spyOn(syncManager, 'runSyncCommand').mockResolvedV
 });
 
 describe(`POST ${endpoint}`, () => {
+    const logsEnabled = envs.NANGO_LOGS_ENABLED;
+
     beforeAll(async () => {
         api = await runServer();
         envs.NANGO_LOGS_ENABLED = false;
     });
     afterAll(() => {
+        envs.NANGO_LOGS_ENABLED = logsEnabled;
         api.server.close();
+        // Module-level spies live on the shared syncManager, so drop them for the next file.
+        vi.restoreAllMocks();
     });
 
     it('should be protected', async () => {

--- a/packages/server/lib/controllers/sync/postTrigger.integration.test.ts
+++ b/packages/server/lib/controllers/sync/postTrigger.integration.test.ts
@@ -16,12 +16,17 @@ const mockRunSyncCommand = vi.spyOn(syncManager, 'runSyncCommand').mockResolvedV
 });
 
 describe(`POST ${endpoint}`, () => {
+    const logsEnabled = envs.NANGO_LOGS_ENABLED;
+
     beforeAll(async () => {
         api = await runServer();
         envs.NANGO_LOGS_ENABLED = false;
     });
     afterAll(() => {
+        envs.NANGO_LOGS_ENABLED = logsEnabled;
         api.server.close();
+        // Module-level spies live on the shared syncManager, so drop them for the next file.
+        vi.restoreAllMocks();
     });
 
     it('should be protected', async () => {

--- a/packages/server/lib/controllers/sync/putSyncConnectionFrequency.integration.test.ts
+++ b/packages/server/lib/controllers/sync/putSyncConnectionFrequency.integration.test.ts
@@ -10,11 +10,14 @@ let api: Awaited<ReturnType<typeof runServer>>;
 const endpoint = '/sync/update-connection-frequency';
 
 describe(`POST ${endpoint}`, () => {
+    const logsEnabled = envs.NANGO_LOGS_ENABLED;
+
     beforeAll(async () => {
         api = await runServer();
         envs.NANGO_LOGS_ENABLED = false;
     });
     afterAll(() => {
+        envs.NANGO_LOGS_ENABLED = logsEnabled;
         api.server.close();
     });
 

--- a/packages/server/lib/controllers/v1/account/putResetPassword.ts
+++ b/packages/server/lib/controllers/v1/account/putResetPassword.ts
@@ -3,7 +3,7 @@ import * as z from 'zod';
 
 import db from '@nangohq/database';
 import { pbkdf2, userService } from '@nangohq/shared';
-import { requireEmptyQuery, zodErrorToHTTP } from '@nangohq/utils';
+import { PBKDF2_ITERATIONS, requireEmptyQuery, zodErrorToHTTP } from '@nangohq/utils';
 
 import { deleteUserSessions } from '../../../clients/auth.client.js';
 import { asyncWrapper } from '../../../utils/asyncWrapper.js';
@@ -53,7 +53,7 @@ export const putResetPassword = asyncWrapper<PutResetPassword>(async (req, res) 
         return;
     }
 
-    const hashedPassword = (await pbkdf2(password, user.salt, 310000, 32, 'sha256')).toString('base64');
+    const hashedPassword = (await pbkdf2(password, user.salt, PBKDF2_ITERATIONS, 32, 'sha256')).toString('base64');
 
     user.hashed_password = hashedPassword;
     user.reset_password_token = null;

--- a/packages/server/lib/controllers/v1/account/signup.ts
+++ b/packages/server/lib/controllers/v1/account/signup.ts
@@ -4,7 +4,7 @@ import * as z from 'zod';
 
 import db from '@nangohq/database';
 import { acceptInvitation, accountService, getInvitation, pbkdf2, userService } from '@nangohq/shared';
-import { flagHasUsage, report, requireEmptyQuery, zodErrorToHTTP } from '@nangohq/utils';
+import { flagHasUsage, PBKDF2_ITERATIONS, report, requireEmptyQuery, zodErrorToHTTP } from '@nangohq/utils';
 
 import { envs } from '../../../env.js';
 import { sendVerificationEmail } from '../../../helpers/email.js';
@@ -104,7 +104,7 @@ export const signup = asyncWrapper<PostSignup>(async (req, res) => {
 
     // Create user
     const salt = crypto.randomBytes(16).toString('base64');
-    const hashedPassword = (await pbkdf2(password, salt, 310000, 32, 'sha256')).toString('base64');
+    const hashedPassword = (await pbkdf2(password, salt, PBKDF2_ITERATIONS, 32, 'sha256')).toString('base64');
     const user = await userService.createUser({
         email,
         name,

--- a/packages/server/lib/controllers/v1/trigger/postTriggerFunction.integration.test.ts
+++ b/packages/server/lib/controllers/v1/trigger/postTriggerFunction.integration.test.ts
@@ -16,16 +16,17 @@ const mockRunSyncCommand = vi.spyOn(syncManager, 'runSyncCommand').mockResolvedV
 });
 
 describe(`POST ${endpoint}`, () => {
-    let logsEnabled: boolean;
+    const logsEnabled = envs.NANGO_LOGS_ENABLED;
 
     beforeAll(async () => {
         api = await runServer();
-        logsEnabled = envs.NANGO_LOGS_ENABLED;
         envs.NANGO_LOGS_ENABLED = false;
     });
     afterAll(() => {
         envs.NANGO_LOGS_ENABLED = logsEnabled;
         api.server.close();
+        // Module-level spies live on the shared syncManager, so drop them for the next file.
+        vi.restoreAllMocks();
     });
 
     it('should be protected', async () => {

--- a/packages/server/lib/controllers/v1/user/password/putPassword.ts
+++ b/packages/server/lib/controllers/v1/user/password/putPassword.ts
@@ -4,7 +4,7 @@ import * as z from 'zod';
 
 import db from '@nangohq/database';
 import { pbkdf2, userService } from '@nangohq/shared';
-import { report, requireEmptyQuery, zodErrorToHTTP } from '@nangohq/utils';
+import { PBKDF2_ITERATIONS, report, requireEmptyQuery, zodErrorToHTTP } from '@nangohq/utils';
 
 import { deleteUserSessions } from '../../../../clients/auth.client.js';
 import { asyncWrapper } from '../../../../utils/asyncWrapper.js';
@@ -35,7 +35,7 @@ export const putUserPassword = asyncWrapper<PutUserPassword, never>(async (req, 
     const user = res.locals['user'] as DBUser; // type is slightly wrong because we are not in an endpoint with an ?env=
     const body: PutUserPassword['Body'] = val.data;
 
-    const oldHashedPassword = await pbkdf2(body.oldPassword, user.salt, 310000, 32, 'sha256');
+    const oldHashedPassword = await pbkdf2(body.oldPassword, user.salt, PBKDF2_ITERATIONS, 32, 'sha256');
     const actualHashedPassword = Buffer.from(user.hashed_password, 'base64');
 
     if (oldHashedPassword.length !== actualHashedPassword.length || !crypto.timingSafeEqual(actualHashedPassword, oldHashedPassword)) {
@@ -44,7 +44,7 @@ export const putUserPassword = asyncWrapper<PutUserPassword, never>(async (req, 
     }
 
     const salt = crypto.randomBytes(16).toString('base64');
-    const hashedPassword = (await pbkdf2(body.newPassword, salt, 310000, 32, 'sha256')).toString('base64');
+    const hashedPassword = (await pbkdf2(body.newPassword, salt, PBKDF2_ITERATIONS, 32, 'sha256')).toString('base64');
 
     await db.knex.transaction(async (trx) => {
         await userService.update({ id: user.id, hashed_password: hashedPassword, salt }, trx);

--- a/packages/shared/lib/seeders/user.seeder.ts
+++ b/packages/shared/lib/seeders/user.seeder.ts
@@ -1,7 +1,7 @@
 import crypto from 'node:crypto';
 import { promisify } from 'node:util';
 
-import { nanoid } from '@nangohq/utils';
+import { nanoid, PBKDF2_ITERATIONS } from '@nangohq/utils';
 
 import userService from '../services/user.service.js';
 
@@ -14,7 +14,7 @@ export async function seedUser(accountId: number): Promise<DBUser> {
     const uniqueId = nanoid();
 
     const salt = crypto.randomBytes(16).toString('base64');
-    const hashedPassword = (await promisePdkdf2(password, salt, 310000, 32, 'sha256')).toString('base64');
+    const hashedPassword = (await promisePdkdf2(password, salt, PBKDF2_ITERATIONS, 32, 'sha256')).toString('base64');
 
     const user = await userService.createUser({
         email: `${uniqueId}@example.com`,

--- a/packages/shared/lib/services/customerKey.service.ts
+++ b/packages/shared/lib/services/customerKey.service.ts
@@ -1,6 +1,6 @@
 import * as uuid from 'uuid';
 
-import { Err, Ok, stringToHash } from '@nangohq/utils';
+import { Err, Ok, PBKDF2_ITERATIONS, stringToHash } from '@nangohq/utils';
 
 import { getEncryptionManager, pbkdf2 } from '../utils/encryption.manager.js';
 import { NangoError } from '../utils/error.js';
@@ -345,7 +345,7 @@ class CustomerKeyService {
                 return Ok(plainText);
             }
             const key = getEncryptionManager().getKey();
-            const hash = (await pbkdf2(plainText, key, 310000, 32, 'sha256')).toString('base64');
+            const hash = (await pbkdf2(plainText, key, PBKDF2_ITERATIONS, 32, 'sha256')).toString('base64');
             return Ok(hash);
         } catch (err) {
             return Err(err);

--- a/packages/shared/lib/services/secret.service.ts
+++ b/packages/shared/lib/services/secret.service.ts
@@ -1,6 +1,6 @@
 import * as uuid from 'uuid';
 
-import { Err, Ok } from '@nangohq/utils';
+import { Err, Ok, PBKDF2_ITERATIONS } from '@nangohq/utils';
 
 import { getEncryptionManager, pbkdf2 } from '../utils/encryption.manager.js';
 import { NangoError } from '../utils/error.js';
@@ -184,7 +184,7 @@ class SecretService {
                 return Ok(plainText);
             }
             const key = getEncryptionManager().getKey();
-            const hash = (await pbkdf2(plainText, key, 310000, 32, 'sha256')).toString('base64');
+            const hash = (await pbkdf2(plainText, key, PBKDF2_ITERATIONS, 32, 'sha256')).toString('base64');
             return Ok(hash);
         } catch (err) {
             return Err(err);

--- a/packages/shared/lib/utils/encryption.manager.ts
+++ b/packages/shared/lib/utils/encryption.manager.ts
@@ -168,8 +168,10 @@ export class EncryptionManager extends Encryption {
         await db.knex.from<DBConfig>(`_nango_db_config`).insert(dbConfig);
     }
 
+    private static readonly KEY_HASH_ITERATIONS = 310_000;
+
     private async hashEncryptionKey(key: string, salt: string): Promise<string> {
-        const keyBuffer = await pbkdf2(key, salt, 310000, 32, 'sha256');
+        const keyBuffer = await pbkdf2(key, salt, EncryptionManager.KEY_HASH_ITERATIONS, 32, 'sha256');
         return keyBuffer.toString(this.encoding);
     }
 

--- a/packages/usage/lib/capping.integration.test.ts
+++ b/packages/usage/lib/capping.integration.test.ts
@@ -1,4 +1,4 @@
-import { afterAll, beforeAll, beforeEach, describe, expect, it } from 'vitest';
+import { beforeAll, beforeEach, describe, expect, it } from 'vitest';
 
 import { getRedis } from '@nangohq/kvstore';
 
@@ -20,9 +20,9 @@ describe('Usage', () => {
         capping = new Capping(usageTracker, { enabled: true });
     });
 
-    afterAll(async () => {
-        await redis.disconnect();
-    });
+    // No teardown: `getRedis` hands back a process-wide cached client, so disconnecting it
+    // here closes it for every later test file too. RedisKVStore.destroy() is a no-op for the
+    // same reason. The container is torn down by the global teardown.
 
     beforeEach(async () => {
         await redis.flushAll(); // Clear all usage data before each test

--- a/packages/usage/lib/usage.integration.test.ts
+++ b/packages/usage/lib/usage.integration.test.ts
@@ -1,4 +1,4 @@
-import { afterAll, afterEach, beforeAll, beforeEach, describe, expect, it, vi } from 'vitest';
+import { afterEach, beforeAll, beforeEach, describe, expect, it, vi } from 'vitest';
 
 import { getRedis } from '@nangohq/kvstore';
 import { Ok } from '@nangohq/utils';
@@ -18,9 +18,9 @@ describe('Usage', () => {
         usageTracker = new UsageTracker(redis);
     });
 
-    afterAll(async () => {
-        await redis.disconnect();
-    });
+    // No teardown: `getRedis` hands back a process-wide cached client, so disconnecting it
+    // here closes it for every later test file too. RedisKVStore.destroy() is a no-op for the
+    // same reason. The container is torn down by the global teardown.
 
     beforeEach(async () => {
         await redis.flushAll(); // Clear all usage data before each test

--- a/packages/utils/lib/encryption.ts
+++ b/packages/utils/lib/encryption.ts
@@ -2,6 +2,17 @@ import crypto from 'crypto';
 
 import type { CipherGCMTypes } from 'crypto';
 
+/**
+ * Work factor for every PBKDF2-SHA256 derivation. 310_000 is the OWASP figure and is what all
+ * stored hashes were derived with, so it must not change for a real deployment.
+ *
+ * Tests derive keys constantly (four per seeded account, plus one per private key) against a
+ * throwaway database, where the work factor protects nothing and dominates the suite's CPU time.
+ * Gated on VITEST, which vitest sets itself, rather than an env var, so there is no configuration
+ * that can weaken password hashing in production.
+ */
+export const PBKDF2_ITERATIONS = process.env['VITEST'] ? 1 : 310_000;
+
 export class Encryption {
     protected key: string;
     protected algorithm: { sync: CipherGCMTypes; async: 'AES-GCM' } = { sync: 'aes-256-gcm', async: 'AES-GCM' };

--- a/packages/webhooks/lib/circuitBreaker.integration.test.ts
+++ b/packages/webhooks/lib/circuitBreaker.integration.test.ts
@@ -1,4 +1,4 @@
-import { afterAll, afterEach, beforeAll, beforeEach, describe, expect, it } from 'vitest';
+import { afterEach, beforeAll, beforeEach, describe, expect, it } from 'vitest';
 
 import { getRedis } from '@nangohq/kvstore';
 import { Err, Ok } from '@nangohq/utils';
@@ -53,9 +53,9 @@ describe('Circuit breaker', () => {
         await redis.flushAll();
     });
 
-    afterAll(async () => {
-        await redis.disconnect();
-    });
+    // No teardown: `getRedis` hands back a process-wide cached client, so disconnecting it
+    // here closes it for every later test file too. RedisKVStore.destroy() is a no-op for the
+    // same reason. The container is torn down by the global teardown.
 
     describe('when CLOSED', () => {
         it('should allow execution', async () => {

--- a/vite.integration.config.ts
+++ b/vite.integration.config.ts
@@ -1,40 +1,106 @@
 /// <reference types="vitest" />
 // Configure Vitest (https://vitest.dev/config/)
 
+import fs from 'node:fs';
+import path from 'node:path';
+
 import { defaultExclude, defineConfig } from 'vitest/config';
 
 process.env.TZ = 'UTC';
 
+// Tests that cannot share a process with the rest of the suite.
+//
+// `vi.mock` only intercepts a module that has not been imported yet, and with a shared registry
+// the server graph is already loaded by the time these files register their mocks, so the real
+// module wins. Discovered by scanning rather than listed by hand: a hardcoded list silently
+// breaks whenever someone adds a `vi.mock` suite, and the failure looks like an unrelated bug
+// (the real client runs, so you get a 500 rather than a mocking error).
+function findSuitesUsingViMock(root: string): string[] {
+    const found: string[] = [];
+    const walk = (dir: string) => {
+        for (const entry of fs.readdirSync(dir, { withFileTypes: true })) {
+            if (entry.name === 'node_modules' || entry.name === 'dist' || entry.name.startsWith('.')) {
+                continue;
+            }
+            const full = path.join(dir, entry.name);
+            if (entry.isDirectory()) {
+                walk(full);
+            } else if (entry.name.endsWith('.integration.test.ts') && fs.readFileSync(full, 'utf8').includes('vi.mock(')) {
+                found.push(full);
+            }
+        }
+    };
+    walk(root);
+    return found;
+}
+
+const usesViMock = findSuitesUsingViMock('packages');
+
+// These all run live polling daemons against the fixed `scheduler` schema, so a daemon from
+// one file steals dequeues and transitions tasks in the next. Orchestrator counts because its
+// harness builds a Scheduler on `getTestDbClient` from @nangohq/scheduler, which pins that same
+// schema, and tears down with `clearDatabase()`:
+const ownsTheSchedulerSchema = ['**/packages/scheduler/**/*.integration.test.ts', '**/packages/orchestrator/**/*.integration.test.ts'];
+
+const needsOwnProcess = [...usesViMock, ...ownsTheSchedulerSchema];
+
+const shared = {
+    include: ['**/*.integration.{test,spec}.?(c|m)[jt]s?(x)'],
+    // Vitest 4 dropped dist/** from its defaultExclude, so compiled test files
+    // built into packages/*/dist get collected and run as duplicates. Re-add it.
+    exclude: [...defaultExclude, '**/dist/**'],
+    setupFiles: './tests/setupFiles.ts',
+    testTimeout: 20000,
+    hookTimeout: 20000,
+    env: {
+        NANGO_ENCRYPTION_KEY: 'RzV4ZGo5RlFKMm0wYWlXdDhxTFhwb3ZrUG5KNGg3TmU=',
+        NANGO_LOGS_ENABLED: 'true',
+        NANGO_LOGS_ES_PREFIX: 'test',
+        FLAG_PLAN_ENABLED: 'true',
+        ORCHESTRATOR_SERVICE_URL: 'http://orchestrator',
+        RUNNER_NODE_ID: '1',
+        FLAG_API_RATE_LIMIT_ENABLED: 'false',
+        FLAG_AUTH_ROLES_ENABLED: 'true',
+        // Used by allProxy.integration.test.ts denylist case; must be set before server modules load
+        NANGO_PROXY_BASE_URL_OVERRIDE_DENYLIST: JSON.stringify(['denylisted-proxy-test.invalid']),
+        // Opens the per-request `source=clickhouse` override gate so
+        // getBillingUsage.integration.test.ts can exercise the CH path.
+        // No effect on default behavior — every other request without the
+        // explicit override still resolves to Orb.
+        FLAG_ALLOW_OVERRIDE_GETUSAGE_SERVICE: 'true'
+    },
+    fileParallelism: false,
+    pool: 'forks' as const,
+    // Vitest 4 removed test.poolOptions; poolOptions.forks.singleFork is now maxWorkers: 1.
+    maxWorkers: 1
+};
+
 export default defineConfig({
     test: {
-        include: ['**/*.integration.{test,spec}.?(c|m)[jt]s?(x)'],
-        // Vitest 4 dropped dist/** from its defaultExclude, so compiled test files
-        // built into packages/*/dist get collected and run as duplicates. Re-add it.
-        exclude: [...defaultExclude, '**/dist/**'],
+        // Same suite, split into two filesets that differ only in `isolate`. globalSetup stays
+        // at the root so one set of containers is started for the run and shared by both,
+        // rather than each fileset spinning up its own Postgres and Elasticsearch.
         globalSetup: './tests/setup.ts',
-        setupFiles: './tests/setupFiles.ts',
-        testTimeout: 20000,
-        hookTimeout: 20000,
-        env: {
-            NANGO_ENCRYPTION_KEY: 'RzV4ZGo5RlFKMm0wYWlXdDhxTFhwb3ZrUG5KNGg3TmU=',
-            NANGO_LOGS_ENABLED: 'true',
-            NANGO_LOGS_ES_PREFIX: 'test',
-            FLAG_PLAN_ENABLED: 'true',
-            ORCHESTRATOR_SERVICE_URL: 'http://orchestrator',
-            RUNNER_NODE_ID: '1',
-            FLAG_API_RATE_LIMIT_ENABLED: 'false',
-            FLAG_AUTH_ROLES_ENABLED: 'true',
-            // Used by allProxy.integration.test.ts denylist case; must be set before server modules load
-            NANGO_PROXY_BASE_URL_OVERRIDE_DENYLIST: JSON.stringify(['denylisted-proxy-test.invalid']),
-            // Opens the per-request `source=clickhouse` override gate so
-            // getBillingUsage.integration.test.ts can exercise the CH path.
-            // No effect on default behavior — every other request without the
-            // explicit override still resolves to Orb.
-            FLAG_ALLOW_OVERRIDE_GETUSAGE_SERVICE: 'true'
-        },
-        fileParallelism: false,
-        pool: 'forks',
-        // Vitest 4 removed test.poolOptions; poolOptions.forks.singleFork is now maxWorkers: 1.
-        maxWorkers: 1
+        projects: [
+            {
+                test: {
+                    ...shared,
+                    name: 'integration',
+                    exclude: [...shared.exclude, ...needsOwnProcess],
+                    // Safe to share a process: these are already serial and already share
+                    // Postgres and Elasticsearch, so a fresh process per file adds no isolation
+                    // it does not already have, and re-imports the whole @nangohq graph each time.
+                    isolate: false
+                }
+            },
+            {
+                test: {
+                    ...shared,
+                    name: 'integration-isolated',
+                    include: needsOwnProcess,
+                    isolate: true
+                }
+            }
+        ]
     }
 });


### PR DESCRIPTION
The integration suite is the only thing on the critical path for PR runs and the merge queue. It takes 24 to 28 minutes while every other check finishes in 2 to 9 minutes.

Almost none of that was test execution. Vitest reported 63.5 minutes of `import` against 5.8 minutes of `tests`, because `pool: 'forks'` with the default `isolate: true` gives every file a fresh process that re-imports the whole @nangohq graph. Workspace packages are symlinked into node_modules, so vitest does not externalize them and pushes all of `packages/*/dist` through its module runner each time. A recycled worker never released those graphs either, since module level singletons keep them alive, so memory climbed across a shard.

## What this changes

**`isolate: false` for the bulk of the suite.** The import becomes a one time cost per shard. Safe because these tests are already serial through `maxWorkers: 1` and already share Postgres and Elasticsearch, so a process per file was not adding isolation they did not already lack.

**A second fileset with `isolate: true`** for the two groups that genuinely need their own process, sharing the same containers:

- the four files using `vi.mock`, which only intercepts a module that has not been imported yet
- the scheduler and orchestrator suites, which run live polling daemons against the fixed `scheduler` schema. Orchestrator counts because its harness builds a `Scheduler` on `getTestDbClient` from @nangohq/scheduler, which pins that schema

**One PBKDF2 constant**, dropping to a single iteration under vitest. Seeding an account derives four keys at 310k iterations (`user.seeder`, `secret.service`, and `customerKey.service` twice for the API key and webhook signing key), which dominated what CPU time was left. Gated on `VITEST` rather than an env var so no deployment configuration can weaken password hashing. All ten call sites now read the same constant, so write and verify paths cannot drift.

**Test hygiene that sharing a process required.** Nine files restore `envs.NANGO_LOGS_ENABLED`, capturing it at declaration so a failing `beforeAll` cannot write `undefined` back. Five restore their module level `vi.spyOn(syncManager, ...)`. Three stop disconnecting the process wide client from `getRedis`, which `RedisKVStore.destroy()` is already a no-op for the same reason. One timestamp assertion gets more than a 2ms margin.

## Results

Measured on CI, `blacksmith-4vcpu-ubuntu-2404`.

| | before | after |
|---|---|---|
| tests workflow total | 25 to 28m | **17.8m** |
| slowest integration shard | 25.4m | **5.3m** |
| shard spread | 12.0 to 25.4m | 3.8 to 5.3m |

Per shard, from vitest's own `Duration` line (shard 2):

| | before | after |
|---|---|---|
| `import` | 831s | **148.7s** |
| `tests` | 46.4s | **23.9s** |
| total | 914s | **202.7s** |

The `import` drop is `isolate: false`. The `tests` drop is the PBKDF2 constant. `tests-unit` at 14.3m now gates the workflow rather than integration.

## Scope

No CI workflow changes. Shards stay at 4: with `isolate: false` each shard runs its files in one process, so fewer files per shard means a lower memory ceiling, and that headroom is worth more than the CI minutes.

Production behaviour is unchanged apart from the PBKDF2 constant, which resolves to the current 310000 outside vitest.

## Known flakiness, pre-existing

`scheduling`, `scheduler` and `models/tasks` in `packages/scheduler` are already flaky on master. Running those suites three times on an unmodified checkout gave 6 failures, then 0, then 0. Recent full runs here land at 0 to 2 failures, always inside that group. Not introduced by this PR and not fixed by it, so do not read a single green run as proof. Worth its own ticket.

## Follow ups

- `getRedis` leaves a closed client in its cache, so a dropped connection permanently poisons that key. Real bug, reverted out of this PR to keep it test side. Cubic also flagged a single flight race on the same function.
- The unit test job has the same shape, `import 1890s` against `tests 21.6s`.

Related to NAN-6026.

## Test plan

- [ ] `tests-integration` green in CI
- [ ] confirm the wall clock drop on a merge queue run
- [ ] confirm peak memory per shard is sane
- [ ] password login, signup and reset still pass, since PBKDF2 call sites moved

