### PR TITLE
refactor(env): centralize environment creation validation

### DIFF
--- a/packages/persist/lib/server.integration.test.ts
+++ b/packages/persist/lib/server.integration.test.ts
@@ -746,8 +746,7 @@ describe('Persist API', () => {
 
 const initDb = async () => {
     const now = new Date();
-    const env = await environmentService.createEnvironment(db.knex, { accountId: 0, name: 'testEnv' });
-    if (!env) throw new Error('Environment not created');
+    const env = (await environmentService.createEnvironment(db.knex, { accountId: 0, name: 'testEnv' })).unwrap();
     const secret = (await secretService.getDefaultSecretForEnv(db.knex, env)).unwrap();
 
     const plan = (await createPlan(db.knex, { account_id: 0, name: 'free' })).unwrap();

--- a/packages/server/lib/controllers/environment/sendCreateEnvironmentError.ts
+++ b/packages/server/lib/controllers/environment/sendCreateEnvironmentError.ts
@@ -1,0 +1,27 @@
+import { PROD_ENVIRONMENT_NAME } from '@nangohq/shared';
+
+import type { CreateEnvironmentError } from '@nangohq/shared';
+import type { Response } from 'express';
+
+export function sendCreateEnvironmentError(res: Response, error: CreateEnvironmentError): void {
+    switch (error.code) {
+        case 'invalid_is_prod_flag':
+            res.status(400).send({
+                error: { code: error.code, message: `The "${PROD_ENVIRONMENT_NAME}" environment must be marked as production.` }
+            });
+            return;
+        case 'conflict':
+            res.status(409).send({ error: { code: error.code, message: 'Environment already exists' } });
+            return;
+        case 'resource_capped':
+            res.status(400).send({ error: { code: error.code, message: 'Maximum number of environments reached' } });
+            return;
+        case 'creation_failed':
+            res.status(500).send({ error: { code: 'server_error', message: 'Failed to create environment' } });
+            return;
+        default:
+            ((exhaustiveCheck: never) => {
+                throw new Error(`Unhandled create environment error code: ${exhaustiveCheck}`);
+            })(error.code);
+    }
+}

--- a/packages/server/lib/controllers/sync/deploy/postDeployInternal.ts
+++ b/packages/server/lib/controllers/sync/deploy/postDeployInternal.ts
@@ -50,14 +50,15 @@ export const postDeployInternal = asyncWrapper<PostDeployInternal>(async (req, r
     let environment = await environmentService.getByEnvironmentName(account.id, environmentName);
 
     if (!environment) {
-        environment = await environmentService.createEnvironment(db.knex, { accountId: account.id, name: environmentName });
+        const created = await environmentService.createEnvironment(db.knex, { accountId: account.id, name: environmentName });
 
-        if (!environment) {
+        if (created.isErr()) {
             res.status(500).send({
                 error: { code: 'environment_creation_error', message: 'There was an error creating the environment, please try again' }
             });
             return;
         }
+        environment = created.value;
 
         // since we're making a new environment, we want to make sure the config creds and
         // connections are copied from the dev environment

--- a/packages/server/lib/controllers/v1/environment/deleteEnvironment.integration.test.ts
+++ b/packages/server/lib/controllers/v1/environment/deleteEnvironment.integration.test.ts
@@ -33,10 +33,7 @@ describe(`DELETE ${endpoint}`, () => {
 
     it('should not allow deleting prod environment', async () => {
         const { account } = await seeders.seedAccountEnvAndUser();
-        const prodEnv = await environmentService.createEnvironment(db.knex, { accountId: account.id, name: PROD_ENVIRONMENT_NAME });
-        if (!prodEnv) {
-            throw new Error('Failed to create prod environment');
-        }
+        const prodEnv = (await environmentService.createEnvironment(db.knex, { accountId: account.id, name: PROD_ENVIRONMENT_NAME })).unwrap();
 
         const prodApiKeys = (await customerKeyService.getApiKeysByEnv(db.knex, prodEnv.id)).unwrap();
 
@@ -59,10 +56,7 @@ describe(`DELETE ${endpoint}`, () => {
 
     it('should successfully delete a non-prod environment', async () => {
         const { account } = await seeders.seedAccountEnvAndUser();
-        const testEnv = await environmentService.createEnvironment(db.knex, { accountId: account.id, name: 'test-delete' });
-        if (!testEnv) {
-            throw new Error('Failed to create test environment');
-        }
+        const testEnv = (await environmentService.createEnvironment(db.knex, { accountId: account.id, name: 'test-delete' })).unwrap();
 
         const testApiKeys = (await customerKeyService.getApiKeysByEnv(db.knex, testEnv.id)).unwrap();
 
@@ -83,10 +77,7 @@ describe(`DELETE ${endpoint}`, () => {
     it('should soft delete configs, syncConfigs and syncs when environment is deleted', async () => {
         // Seed account, environment, and user
         const { account } = await seeders.seedAccountEnvAndUser();
-        const testEnv = await environmentService.createEnvironment(db.knex, { accountId: account.id, name: 'test-delete-related' });
-        if (!testEnv) {
-            throw new Error('Failed to create test environment');
-        }
+        const testEnv = (await environmentService.createEnvironment(db.knex, { accountId: account.id, name: 'test-delete-related' })).unwrap();
 
         const testApiKeys = (await customerKeyService.getApiKeysByEnv(db.knex, testEnv.id)).unwrap();
 

--- a/packages/server/lib/controllers/v1/environment/postEnvironment.ts
+++ b/packages/server/lib/controllers/v1/environment/postEnvironment.ts
@@ -1,11 +1,12 @@
 import * as z from 'zod';
 
 import db from '@nangohq/database';
-import { environmentService, externalWebhookService, getPlan } from '@nangohq/shared';
+import { environmentService, getPlan } from '@nangohq/shared';
 import { flagHasPlan, requireEmptyQuery, zodErrorToHTTP } from '@nangohq/utils';
 
 import { envSchema } from '../../../helpers/validation.js';
 import { asyncWrapper } from '../../../utils/asyncWrapper.js';
+import { sendCreateEnvironmentError } from '../../environment/sendCreateEnvironmentError.js';
 
 import type { PostEnvironment } from '@nangohq/types';
 
@@ -31,7 +32,7 @@ export const postEnvironment = asyncWrapper<PostEnvironment>(async (req, res) =>
     const body: PostEnvironment['Body'] = valBody.data;
 
     const accountId = res.locals.account.id;
-    const environments = await environmentService.getEnvironmentsByAccountId(accountId);
+    let plan;
 
     if (flagHasPlan) {
         const planRes = await getPlan(db.knex, { accountId });
@@ -40,39 +41,16 @@ export const postEnvironment = asyncWrapper<PostEnvironment>(async (req, res) =>
             return;
         }
 
-        const plan = planRes.value;
-        if (plan && environments.length >= plan.environments_max) {
-            res.status(400).send({
-                error: {
-                    code: 'resource_capped',
-                    message: 'Maximum number of environments reached'
-                }
-            });
-            return;
-        }
+        plan = planRes.value;
     }
 
-    const exists = environments.some((env) => env.name === body.name);
-    if (exists) {
-        res.status(409).send({ error: { code: 'conflict', message: 'Environment already exists' } });
+    const created = await environmentService.createEnvironment(db.knex, { accountId, name: body.name, ...(plan && { plan }) });
+    if (created.isErr()) {
+        sendCreateEnvironmentError(res, created.error);
         return;
     }
 
-    const created = await environmentService.createEnvironment(db.knex, { accountId: accountId, name: body.name });
-    if (!created) {
-        res.status(500).send({ error: { code: 'server_error', message: 'Failed to create environment' } });
-        return;
-    }
+    const environment = created.value;
 
-    await externalWebhookService.update(db.knex, {
-        environment_id: created.id,
-        data: {
-            on_auth_creation: true,
-            on_auth_refresh_error: true,
-            on_sync_completion_always: true,
-            on_sync_error: true
-        }
-    });
-
-    res.status(200).send({ data: { id: created.id, name: created.name } });
+    res.status(200).send({ data: { id: environment.id, name: environment.name } });
 });

--- a/packages/shared/lib/index.ts
+++ b/packages/shared/lib/index.ts
@@ -36,6 +36,7 @@ export * from './services/sync/config/config.service.js';
 export * from './services/sync/config/endpoint.service.js';
 export * from './services/sync/config/deploy.service.js';
 export * from './services/endUser.service.js';
+export type { CreateEnvironmentError } from './services/environment.service.js';
 export * from './services/tags.service.js';
 export * from './services/tags/schema.js';
 export * as gettingStartedService from './services/getting-started.service.js';

--- a/packages/shared/lib/seeders/environment.seeder.ts
+++ b/packages/shared/lib/seeders/environment.seeder.ts
@@ -1,15 +1,13 @@
+import { v4 as uuid } from 'uuid';
+
 import db from '@nangohq/database';
 
 import environmentService from '../services/environment.service.js';
 
 import type { DBEnvironment } from '@nangohq/types';
 
-export async function createEnvironmentSeed(accountId: number = 0, envName: string = 'test'): Promise<DBEnvironment> {
-    const env = await environmentService.createEnvironment(db.knex, { accountId: accountId, name: envName });
-    if (!env) {
-        throw new Error('Failed to create environment');
-    }
-    return env;
+export async function createEnvironmentSeed(accountId: number = 0, envName: string = uuid()): Promise<DBEnvironment> {
+    return (await environmentService.createEnvironment(db.knex, { accountId: accountId, name: envName })).unwrap();
 }
 
 export function getTestEnvironment(data?: Partial<DBEnvironment>): DBEnvironment {

--- a/packages/shared/lib/services/account.service.integration.test.ts
+++ b/packages/shared/lib/services/account.service.integration.test.ts
@@ -247,33 +247,33 @@ describe('Account service', () => {
 
     it('should not infer an environment when a key has multiple environment relations', async () => {
         const account = await createTestAccount();
-        const firstEnvironment = await environmentService.createEnvironment(db.knex, { accountId: account.id, name: uuid() });
-        const secondEnvironment = await environmentService.createEnvironment(db.knex, { accountId: account.id, name: uuid() });
+        const firstEnvironment = (await environmentService.createEnvironment(db.knex, { accountId: account.id, name: uuid() })).unwrap();
+        const secondEnvironment = (await environmentService.createEnvironment(db.knex, { accountId: account.id, name: uuid() })).unwrap();
         await plans.createPlan(db.knex, { account_id: account.id, name: 'free' });
-        const [apiKey] = (await customerKeyService.getApiKeysByEnv(db.knex, firstEnvironment!.id)).unwrap();
+        const [apiKey] = (await customerKeyService.getApiKeysByEnv(db.knex, firstEnvironment.id)).unwrap();
 
         await db.knex('customer_keys_relations').insert({
             customer_key_id: apiKey!.id,
             entity_type: 'environment',
-            entity_id: secondEnvironment!.id
+            entity_id: secondEnvironment.id
         });
 
         const context = await accountService.getAccountContextByApiKey({ secretKey: apiKey!.secret });
 
-        expect(context?.principal.environmentIds).toEqual([firstEnvironment!.id, secondEnvironment!.id].sort((a, b) => a - b));
+        expect(context?.principal.environmentIds).toEqual([firstEnvironment.id, secondEnvironment.id].sort((a, b) => a - b));
         expect(context?.environment).toBeUndefined();
         await expect(accountService.getAccountContext({ secretKey: apiKey!.secret })).resolves.toBeNull();
     });
 
     it('should ignore an environment relation owned by another account', async () => {
         const firstAccount = await createTestAccount();
-        const firstEnvironment = await environmentService.createEnvironment(db.knex, { accountId: firstAccount.id, name: uuid() });
+        const firstEnvironment = (await environmentService.createEnvironment(db.knex, { accountId: firstAccount.id, name: uuid() })).unwrap();
         await plans.createPlan(db.knex, { account_id: firstAccount.id, name: 'free' });
         const secondAccount = await createTestAccount();
-        const secondEnvironment = await environmentService.createEnvironment(db.knex, { accountId: secondAccount.id, name: uuid() });
-        const [apiKey] = (await customerKeyService.getApiKeysByEnv(db.knex, firstEnvironment!.id)).unwrap();
+        const secondEnvironment = (await environmentService.createEnvironment(db.knex, { accountId: secondAccount.id, name: uuid() })).unwrap();
+        const [apiKey] = (await customerKeyService.getApiKeysByEnv(db.knex, firstEnvironment.id)).unwrap();
 
-        await db.knex('customer_keys_relations').where({ customer_key_id: apiKey!.id }).update({ entity_id: secondEnvironment!.id });
+        await db.knex('customer_keys_relations').where({ customer_key_id: apiKey!.id }).update({ entity_id: secondEnvironment.id });
 
         const context = await accountService.getAccountContextByApiKey({ secretKey: apiKey!.secret });
 

--- a/packages/shared/lib/services/account.service.integration.test.ts
+++ b/packages/shared/lib/services/account.service.integration.test.ts
@@ -2,14 +2,14 @@ import { v4 as uuid } from 'uuid';
 import { afterEach, beforeAll, describe, expect, it, vi } from 'vitest';
 
 import db, { multipleMigrations } from '@nangohq/database';
-import { metrics } from '@nangohq/utils';
+import { Err, metrics } from '@nangohq/utils';
 
 import { envs } from '../env.js';
 import { createAccount as createTestAccount } from '../seeders/account.seeder.js';
 import { seedAccountEnvAndUser } from '../seeders/global.seeder.js';
 import accountService from './account.service.js';
 import customerKeyService from './customerKey.service.js';
-import environmentService, { defaultEnvironments } from './environment.service.js';
+import environmentService, { CreateEnvironmentError, defaultEnvironments } from './environment.service.js';
 import * as plans from './plans/plans.js';
 import { createSandboxApiKeyToken, decryptSandboxSigningSecret } from './sandbox-api-key.js';
 import secretService from './secret.service.js';
@@ -158,9 +158,21 @@ describe('Account service', () => {
         expect(account).toBeUndefined();
     });
 
+    it('should rollback the transaction if creating a default environment fails', async () => {
+        vi.spyOn(environmentService, 'createEnvironment').mockResolvedValueOnce(Err(new CreateEnvironmentError('creation_failed')));
+
+        const accountName = uuid();
+        const teamName = `${accountName}'s Team`;
+
+        await expect(accountService.createAccount({ name: accountName })).rejects.toThrow('creation_failed');
+
+        const account = await db.knex.select('*').from('_nango_accounts').where({ name: teamName }).first();
+        expect(account).toBeUndefined();
+    });
+
     it('should retrieve account context by secretKey', async () => {
         const account = await createTestAccount();
-        const environment = await environmentService.createEnvironment(db.knex, { accountId: account.id, name: uuid() });
+        const environment = (await environmentService.createEnvironment(db.knex, { accountId: account.id, name: uuid() })).unwrap();
         const plan = (await plans.createPlan(db.knex, { account_id: account.id, name: 'free' })).unwrap();
         const secret = (await secretService.getDefaultSecretForEnv(db.knex, environment!)).unwrap();
         const apiKeys = (await customerKeyService.getApiKeysByEnv(db.knex, environment!.id)).unwrap();
@@ -272,7 +284,7 @@ describe('Account service', () => {
 
     it('should return null when customer key is missing (no fallback to api_secrets)', async () => {
         const account = await createTestAccount();
-        const environment = await environmentService.createEnvironment(db.knex, { accountId: account.id, name: uuid() });
+        const environment = (await environmentService.createEnvironment(db.knex, { accountId: account.id, name: uuid() })).unwrap();
         await plans.createPlan(db.knex, { account_id: account.id, name: 'free' });
 
         await db.knex('customer_keys_relations').where({ entity_type: 'environment', entity_id: environment!.id }).delete();
@@ -285,7 +297,7 @@ describe('Account service', () => {
 
     it('should prefer customer key scopes when both tables match the same secret', async () => {
         const account = await createTestAccount();
-        const environment = await environmentService.createEnvironment(db.knex, { accountId: account.id, name: uuid() });
+        const environment = (await environmentService.createEnvironment(db.knex, { accountId: account.id, name: uuid() })).unwrap();
         await plans.createPlan(db.knex, { account_id: account.id, name: 'free' });
         const apiKeys = (await customerKeyService.getApiKeysByEnv(db.knex, environment!.id)).unwrap();
 
@@ -307,7 +319,7 @@ describe('Account service', () => {
 
     it('should return null when matching customer key is soft-deleted (no fallback to api_secrets)', async () => {
         const account = await createTestAccount();
-        const environment = await environmentService.createEnvironment(db.knex, { accountId: account.id, name: uuid() });
+        const environment = (await environmentService.createEnvironment(db.knex, { accountId: account.id, name: uuid() })).unwrap();
         await plans.createPlan(db.knex, { account_id: account.id, name: 'free' });
 
         await db.knex('customer_keys').update({ deleted_at: new Date() }).where({ account_id: account.id, key_type: 'api' });
@@ -319,7 +331,7 @@ describe('Account service', () => {
 
     it('should return null when matching customer key relation is not environment-scoped (no fallback to api_secrets)', async () => {
         const account = await createTestAccount();
-        const environment = await environmentService.createEnvironment(db.knex, { accountId: account.id, name: uuid() });
+        const environment = (await environmentService.createEnvironment(db.knex, { accountId: account.id, name: uuid() })).unwrap();
         await plans.createPlan(db.knex, { account_id: account.id, name: 'free' });
 
         const apiKey = await db.knex('customer_keys').select('id').where({ account_id: account.id, key_type: 'api' }).whereNull('deleted_at').first();
@@ -346,7 +358,7 @@ describe('Account service', () => {
 
     it('should retrieve account context by sandbox API key token', async () => {
         const account = await createTestAccount();
-        const environment = await environmentService.createEnvironment(db.knex, { accountId: account.id, name: uuid() });
+        const environment = (await environmentService.createEnvironment(db.knex, { accountId: account.id, name: uuid() })).unwrap();
         const plan = (await plans.createPlan(db.knex, { account_id: account.id, name: 'free' })).unwrap();
         const secret = (await secretService.getDefaultSecretForEnv(db.knex, environment!)).unwrap();
         const apiKeys = (await customerKeyService.getApiKeysByEnv(db.knex, environment!.id)).unwrap();
@@ -398,7 +410,7 @@ describe('Account service', () => {
 
     it('should return null when sandbox API key token is expired', async () => {
         const account = await createTestAccount();
-        const environment = await environmentService.createEnvironment(db.knex, { accountId: account.id, name: uuid() });
+        const environment = (await environmentService.createEnvironment(db.knex, { accountId: account.id, name: uuid() })).unwrap();
         await plans.createPlan(db.knex, { account_id: account.id, name: 'free' });
         const apiKeys = (await customerKeyService.getApiKeysByEnv(db.knex, environment!.id)).unwrap();
         const signingSecret = decryptSandboxSigningSecret(apiKeys[0]!)!;
@@ -419,7 +431,7 @@ describe('Account service', () => {
 
     it('should return null when sandbox API key token parent key is soft-deleted', async () => {
         const account = await createTestAccount();
-        const environment = await environmentService.createEnvironment(db.knex, { accountId: account.id, name: uuid() });
+        const environment = (await environmentService.createEnvironment(db.knex, { accountId: account.id, name: uuid() })).unwrap();
         await plans.createPlan(db.knex, { account_id: account.id, name: 'free' });
         const apiKeys = (await customerKeyService.getApiKeysByEnv(db.knex, environment!.id)).unwrap();
         const apiKey = apiKeys[0]!;
@@ -442,7 +454,7 @@ describe('Account service', () => {
 
     it('should apply current parent scopes when resolving sandbox API key token', async () => {
         const account = await createTestAccount();
-        const environment = await environmentService.createEnvironment(db.knex, { accountId: account.id, name: uuid() });
+        const environment = (await environmentService.createEnvironment(db.knex, { accountId: account.id, name: uuid() })).unwrap();
         await plans.createPlan(db.knex, { account_id: account.id, name: 'free' });
 
         const parentKey = (
@@ -479,7 +491,7 @@ describe('Account service', () => {
 
     it('should debounce customer key last_used_at updates when resolving by secretKey', async () => {
         const account = await createTestAccount();
-        const environment = await environmentService.createEnvironment(db.knex, { accountId: account.id, name: uuid() });
+        const environment = (await environmentService.createEnvironment(db.knex, { accountId: account.id, name: uuid() })).unwrap();
         await plans.createPlan(db.knex, { account_id: account.id, name: 'free' });
         const apiKeys = (await customerKeyService.getApiKeysByEnv(db.knex, environment!.id)).unwrap();
         const customerKeySecret = apiKeys[0]!.secret;
@@ -509,7 +521,7 @@ describe('Account service', () => {
 
     it('should return environment:* scopes for internalSecretKey (api_secret path)', async () => {
         const account = await createTestAccount();
-        const environment = await environmentService.createEnvironment(db.knex, { accountId: account.id, name: uuid() });
+        const environment = (await environmentService.createEnvironment(db.knex, { accountId: account.id, name: uuid() })).unwrap();
         await plans.createPlan(db.knex, { account_id: account.id, name: 'free' });
         const secret = (await secretService.getDefaultSecretForEnv(db.knex, environment!)).unwrap();
 
@@ -542,7 +554,7 @@ describe('Account service', () => {
         it('should resolve env-var keys before the DB lookup', async () => {
             const account = await createTestAccount();
             const envName = uuid();
-            const environment = await environmentService.createEnvironment(db.knex, { accountId: account.id, name: envName });
+            const environment = (await environmentService.createEnvironment(db.knex, { accountId: account.id, name: envName })).unwrap();
             await plans.createPlan(db.knex, { account_id: account.id, name: 'free' });
 
             const envVarName = `NANGO_SECRET_KEY_${envName.toUpperCase()}`;
@@ -622,7 +634,7 @@ describe('Account service', () => {
 
     it('should retrieve account context by publicKey', async () => {
         const account = await createTestAccount();
-        const environment = await environmentService.createEnvironment(db.knex, { accountId: account.id, name: uuid() });
+        const environment = (await environmentService.createEnvironment(db.knex, { accountId: account.id, name: uuid() })).unwrap();
         const plan = (await plans.createPlan(db.knex, { account_id: account.id, name: 'free' })).unwrap();
         const secret = (await secretService.getDefaultSecretForEnv(db.knex, environment!)).unwrap();
 
@@ -654,7 +666,7 @@ describe('Account service', () => {
 
     it('should retrieve account context by environment uuid', async () => {
         const account = await createTestAccount();
-        const environment = await environmentService.createEnvironment(db.knex, { accountId: account.id, name: uuid() });
+        const environment = (await environmentService.createEnvironment(db.knex, { accountId: account.id, name: uuid() })).unwrap();
         const plan = (await plans.createPlan(db.knex, { account_id: account.id, name: 'free' })).unwrap();
         const secret = (await secretService.getDefaultSecretForEnv(db.knex, environment!)).unwrap();
 
@@ -686,7 +698,7 @@ describe('Account service', () => {
 
     it('should retrieve account context by account uuid', async () => {
         const account = await createTestAccount();
-        const environment = await environmentService.createEnvironment(db.knex, { accountId: account.id, name: uuid() });
+        const environment = (await environmentService.createEnvironment(db.knex, { accountId: account.id, name: uuid() })).unwrap();
         const plan = (await plans.createPlan(db.knex, { account_id: account.id, name: 'free' })).unwrap();
         const secret = (await secretService.getDefaultSecretForEnv(db.knex, environment!)).unwrap();
 
@@ -718,7 +730,7 @@ describe('Account service', () => {
 
     it('should retrieve account context by accountId and envName', async () => {
         const account = await createTestAccount();
-        const environment = await environmentService.createEnvironment(db.knex, { accountId: account.id, name: uuid() });
+        const environment = (await environmentService.createEnvironment(db.knex, { accountId: account.id, name: uuid() })).unwrap();
         const plan = (await plans.createPlan(db.knex, { account_id: account.id, name: 'free' })).unwrap();
         const secret = (await secretService.getDefaultSecretForEnv(db.knex, environment!)).unwrap();
 
@@ -750,7 +762,7 @@ describe('Account service', () => {
 
     it('should retrieve account context by environmentId', async () => {
         const account = await createTestAccount();
-        const environment = await environmentService.createEnvironment(db.knex, { accountId: account.id, name: uuid() });
+        const environment = (await environmentService.createEnvironment(db.knex, { accountId: account.id, name: uuid() })).unwrap();
         const plan = (await plans.createPlan(db.knex, { account_id: account.id, name: 'free' })).unwrap();
         const secret = (await secretService.getDefaultSecretForEnv(db.knex, environment!)).unwrap();
 

--- a/packages/shared/lib/services/account.service.ts
+++ b/packages/shared/lib/services/account.service.ts
@@ -279,14 +279,20 @@ class AccountService {
 
             if (flagHasPlan) {
                 const freePlan = plansList.find((plan) => plan.code === 'free');
-                const res = await createPlan(trx, { account_id: result[0].id, name: 'free', ...freePlan?.flags });
-                if (res.isErr()) {
-                    report(res.error);
-                    // Rollback transaction
-                    throw res.error;
+                const createdPlan = await createPlan(trx, { account_id: result[0].id, name: 'free', ...freePlan?.flags });
+                if (createdPlan.isErr()) {
+                    // Report and rollback transaction
+                    report(createdPlan.error);
+                    throw createdPlan.error;
                 }
             }
-            await environmentService.createDefaultEnvironments(trx, { accountId: result[0].id });
+
+            const createdEnvs = await environmentService.createDefaultEnvironments(trx, { accountId: result[0].id });
+            if (createdEnvs.isErr()) {
+                // Rollback transaction; the service already reports on errors
+                throw createdEnvs.error;
+            }
+
             metrics.increment(metrics.Types.ACCOUNT_CREATED, 1, { accountId: result[0].id });
             return result[0];
         });

--- a/packages/shared/lib/services/environment.service.integration.test.ts
+++ b/packages/shared/lib/services/environment.service.integration.test.ts
@@ -3,6 +3,7 @@ import { beforeAll, describe, expect, it } from 'vitest';
 
 import db, { multipleMigrations } from '@nangohq/database';
 
+import { externalWebhookService } from '../index.js';
 import { createAccount } from '../seeders/account.seeder.js';
 import { createEnvironmentSeed } from '../seeders/environment.seeder.js';
 import environmentService from './environment.service.js';
@@ -15,10 +16,7 @@ describe('Environment service', () => {
     it('should create a service with secrets', async () => {
         const account = await createAccount();
         const envName = uuid();
-        const env = await environmentService.createEnvironment(db.knex, { accountId: account.id, name: envName });
-        if (!env) {
-            throw new Error('failed_to_create_env');
-        }
+        const env = (await environmentService.createEnvironment(db.knex, { accountId: account.id, name: envName })).unwrap();
 
         expect(env).toStrictEqual({
             account_id: account.id,
@@ -55,16 +53,68 @@ describe('Environment service', () => {
 
     it('should set is_production = true when name is prod', async () => {
         const account = await createAccount();
-        const env = await environmentService.createEnvironment(db.knex, { accountId: account.id, name: 'prod' });
-        expect(env).not.toBeNull();
-        expect(env!.is_production).toBe(true);
+        const env = (await environmentService.createEnvironment(db.knex, { accountId: account.id, name: 'prod' })).unwrap();
+        expect(env.is_production).toBe(true);
     });
 
-    it('should set is_production = false for non-prod environments', async () => {
+    it('should set is_production = false by default when name is not prod', async () => {
         const account = await createAccount();
-        const env = await environmentService.createEnvironment(db.knex, { accountId: account.id, name: 'dev' });
-        expect(env).not.toBeNull();
-        expect(env!.is_production).toBe(false);
+        const env = (await environmentService.createEnvironment(db.knex, { accountId: account.id, name: 'dev' })).unwrap();
+        expect(env.is_production).toBe(false);
+    });
+
+    it('should create default external webhook settings', async () => {
+        const account = await createAccount();
+        const env = (await environmentService.createEnvironment(db.knex, { accountId: account.id, name: uuid() })).unwrap();
+
+        await expect(externalWebhookService.get(env.id)).resolves.toMatchObject({
+            environment_id: env.id,
+            on_auth_creation: true,
+            on_auth_refresh_error: true,
+            on_sync_completion_always: true,
+            on_sync_error: true
+        });
+    });
+
+    it('should reject creating environment named prod as a non-production environment', async () => {
+        const account = await createAccount();
+        const result = await environmentService.createEnvironment(db.knex, { accountId: account.id, name: 'prod', isProduction: false });
+        expect(result).toSatisfy((value) => value.isErr() && value.error.code === 'invalid_is_prod_flag');
+    });
+
+    it('should reject duplicate environment names', async () => {
+        const account = await createAccount();
+        const name = uuid();
+        await environmentService.createEnvironment(db.knex, { accountId: account.id, name });
+
+        const result = await environmentService.createEnvironment(db.knex, { accountId: account.id, name });
+
+        expect(result).toSatisfy((value) => value.isErr() && value.error.code === 'conflict');
+    });
+
+    it('should persist optional environment settings during creation', async () => {
+        const account = await createAccount();
+        const env = (
+            await environmentService.createEnvironment(db.knex, {
+                accountId: account.id,
+                name: uuid(),
+                isProduction: true,
+                callbackUrl: 'https://example.com/callback',
+                hmacKey: 'hmac-key',
+                hmacEnabled: true,
+                slackNotifications: true,
+                otlpSettings: { endpoint: 'https://otel.example.com', headers: { Authorization: 'Bearer token' } }
+            })
+        ).unwrap();
+
+        expect(env).toMatchObject({
+            is_production: true,
+            callback_url: 'https://example.com/callback',
+            hmac_key: 'hmac-key',
+            hmac_enabled: true,
+            slack_notifications: true,
+            otlp_settings: { endpoint: 'https://otel.example.com', headers: { Authorization: 'Bearer token' } }
+        });
     });
 
     describe('environment variables', () => {

--- a/packages/shared/lib/services/environment.service.ts
+++ b/packages/shared/lib/services/environment.service.ts
@@ -1,7 +1,7 @@
 import * as z from 'zod';
 
 import db from '@nangohq/database';
-import { report, useLambdaKeepWarm } from '@nangohq/utils';
+import { Err, Ok, report, useLambdaKeepWarm } from '@nangohq/utils';
 
 import { PROD_ENVIRONMENT_NAME } from '../constants.js';
 import { configService, externalWebhookService, getGlobalOAuthCallbackUrl } from '../index.js';
@@ -15,11 +15,23 @@ import secretService from './secret.service.js';
 
 import type { Orchestrator } from '../index.js';
 import type { Knex } from '@nangohq/database';
-import type { DBEnvironment, DBEnvironmentVariable, SdkLogger } from '@nangohq/types';
+import type { DBEnvironment, DBEnvironmentVariable, DBPlan, SdkLogger } from '@nangohq/types';
+import type { Result } from '@nangohq/utils';
 
 const TABLE = '_nango_environments';
 
 export const defaultEnvironments = [PROD_ENVIRONMENT_NAME, 'dev'];
+
+export type CreateEnvironmentErrorCode = 'invalid_is_prod_flag' | 'conflict' | 'resource_capped' | 'creation_failed';
+
+export class CreateEnvironmentError extends Error {
+    constructor(
+        public readonly code: CreateEnvironmentErrorCode,
+        options?: { cause?: unknown }
+    ) {
+        super(code, options);
+    }
+}
 
 /** After an environment row exists (outer transaction may still be open). Publishes keep-warm when Lambda + plan tenant isolation are enabled. */
 async function onNewEnvironment(
@@ -56,6 +68,14 @@ async function onNewEnvironment(
 }
 
 class EnvironmentService {
+    private resolveIsProduction({ name, isProduction }: { name: string; isProduction?: boolean | undefined }): Result<boolean, CreateEnvironmentError> {
+        if (name === PROD_ENVIRONMENT_NAME && isProduction === false) {
+            return Err(new CreateEnvironmentError('invalid_is_prod_flag'));
+        }
+
+        return Ok(name === PROD_ENVIRONMENT_NAME ? true : (isProduction ?? false));
+    }
+
     async getEnvironmentsByAccountId(account_id: number): Promise<Pick<DBEnvironment, 'id' | 'name' | 'is_production'>[]> {
         try {
             const result = await db.knex
@@ -119,59 +139,96 @@ class EnvironmentService {
         });
     }
 
-    async createEnvironment(trx = db.knex, { accountId, name }: { accountId: number; name: string }): Promise<DBEnvironment | null> {
-        const isProduction = name === PROD_ENVIRONMENT_NAME;
-        const environment = await trx.transaction(async (innerTrx) => {
-            const [env] = await innerTrx<DBEnvironment>(TABLE).insert({ account_id: accountId, name, is_production: isProduction }).returning('*');
-            if (!env) {
-                innerTrx.rollback();
-                return null;
-            }
-            // Invariant: Every environment always has one default key (used by runners for persist auth).
-            const created = await secretService.createSecret(innerTrx, {
-                environmentId: env.id,
-                displayName: 'default',
-                isDefault: true
-            });
-            if (created.isErr()) {
-                throw created.error;
-            }
-            const secret = created.value;
-            env.secret_key = secret.secret;
-            env.pending_secret_key = null;
-
-            const apiKey = await customerKeyService.createApiKey(innerTrx, {
-                accountId: accountId,
-                environmentId: env.id,
-                displayName: 'Default - Full access'
-            });
-            if (apiKey.isErr()) {
-                throw apiKey.error;
-            }
-
-            const webhookKey = await customerKeyService.createWebhookSigningKey(innerTrx, {
-                accountId: accountId,
-                environmentId: env.id
-            });
-            if (webhookKey.isErr()) {
-                throw webhookKey.error;
-            }
-
-            return env;
-        });
-
-        if (environment) {
-            await onNewEnvironment(trx, { accountId, environmentId: environment.id, isProduction });
+    async createEnvironment(
+        trx = db.knex,
+        {
+            accountId,
+            name,
+            isProduction: isProductionSetting,
+            callbackUrl,
+            hmacKey,
+            hmacEnabled,
+            slackNotifications,
+            otlpSettings,
+            plan
+        }: {
+            accountId: number;
+            name: string;
+            isProduction?: boolean;
+            callbackUrl?: string;
+            hmacKey?: string;
+            hmacEnabled?: boolean;
+            slackNotifications?: boolean;
+            otlpSettings?: DBEnvironment['otlp_settings'];
+            plan?: DBPlan | null;
         }
-        return environment;
-    }
+    ): Promise<Result<DBEnvironment, CreateEnvironmentError>> {
+        const isProduction = this.resolveIsProduction({ name, isProduction: isProductionSetting });
+        if (isProduction.isErr()) {
+            return Err(isProduction.error);
+        }
 
-    async createDefaultEnvironments(trx: Knex, { accountId: accountId }: { accountId: number }): Promise<void> {
-        for (const environment of defaultEnvironments) {
-            const newEnv = await this.createEnvironment(trx, { accountId, name: environment });
-            if (newEnv) {
-                await externalWebhookService.update(trx, {
-                    environment_id: newEnv.id,
+        let environmentId: number | undefined;
+        try {
+            const environments = await trx<DBEnvironment>(TABLE).select('name').where({ account_id: accountId, deleted: false });
+            // NOTE: This preserves the pre-existing race condition in environment-cap enforcement: concurrent creations can each pass this check and exceed the cap.
+            // Environment caps are an upper limit rather than a strict boundary, so a small overflow is acceptable.
+            if (plan && environments.length >= plan.environments_max) {
+                return Err(new CreateEnvironmentError('resource_capped'));
+            }
+            if (environments.some((environment) => environment.name === name)) {
+                return Err(new CreateEnvironmentError('conflict'));
+            }
+
+            const environment = await trx.transaction(async (innerTrx): Promise<DBEnvironment> => {
+                const [env] = await innerTrx<DBEnvironment>(TABLE)
+                    .insert({
+                        account_id: accountId,
+                        name,
+                        is_production: isProduction.value,
+                        ...(callbackUrl !== undefined && { callback_url: callbackUrl }),
+                        ...(hmacKey !== undefined && { hmac_key: hmacKey }),
+                        ...(hmacEnabled !== undefined && { hmac_enabled: hmacEnabled }),
+                        ...(slackNotifications !== undefined && { slack_notifications: slackNotifications }),
+                        ...(otlpSettings !== undefined && { otlp_settings: otlpSettings })
+                    })
+                    .returning('*');
+                if (!env) {
+                    throw Error('failed_to_insert_environment');
+                }
+                environmentId = env.id;
+                // Invariant: Every environment always has one default key (used by runners for persist auth).
+                const createdSecret = await secretService.createSecret(innerTrx, {
+                    environmentId: env.id,
+                    displayName: 'default',
+                    isDefault: true
+                });
+                if (createdSecret.isErr()) {
+                    throw createdSecret.error;
+                }
+                const secret = createdSecret.value;
+                env.secret_key = secret.secret;
+                env.pending_secret_key = null;
+
+                const createdApiKey = await customerKeyService.createApiKey(innerTrx, {
+                    accountId: accountId,
+                    environmentId: env.id,
+                    displayName: 'Default - Full access'
+                });
+                if (createdApiKey.isErr()) {
+                    throw createdApiKey.error;
+                }
+
+                const createdWebhookKey = await customerKeyService.createWebhookSigningKey(innerTrx, {
+                    accountId: accountId,
+                    environmentId: env.id
+                });
+                if (createdWebhookKey.isErr()) {
+                    throw createdWebhookKey.error;
+                }
+
+                await externalWebhookService.update(innerTrx, {
+                    environment_id: env.id,
                     data: {
                         on_auth_creation: true,
                         on_auth_refresh_error: true,
@@ -179,8 +236,27 @@ class EnvironmentService {
                         on_sync_error: true
                     }
                 });
+
+                return env;
+            });
+
+            await onNewEnvironment(trx, { accountId, environmentId: environment.id, isProduction: isProduction.value });
+            return Ok(environment);
+        } catch (err) {
+            report(err, { accountId, environmentId, environmentName: name });
+            return Err(new CreateEnvironmentError('creation_failed', { cause: err }));
+        }
+    }
+
+    async createDefaultEnvironments(trx: Knex, { accountId }: { accountId: number }): Promise<Result<void, CreateEnvironmentError>> {
+        for (const environment of defaultEnvironments) {
+            const createdEnv = await this.createEnvironment(trx, { accountId, name: environment });
+            if (createdEnv.isErr()) {
+                return Err(createdEnv.error);
             }
         }
+
+        return Ok();
     }
 
     async getEnvironmentsWithOtlpSettings(): Promise<DBEnvironment[]> {

--- a/packages/shared/lib/services/secret.service.integration.test.ts
+++ b/packages/shared/lib/services/secret.service.integration.test.ts
@@ -20,7 +20,7 @@ describe('Secret service', () => {
 
     const newEnv = async (): Promise<DBEnvironment> => {
         const account = await createAccount();
-        const env = (await environmentService.createEnvironment(db.knex, { accountId: account.id, name: uuid() }))!;
+        const env = (await environmentService.createEnvironment(db.knex, { accountId: account.id, name: uuid() })).unwrap();
         return env;
     };
 


### PR DESCRIPTION
Absorbed domain validation that had leaked out of the environment service for the creation operation. Also change its API to return a Result of typed errors rather than throwing generic ones.

- Add typed errors for invalid production flags, name conflicts, capacity limits, and unexpected creation failures
- Enforce conflict and capacity checks only when a plan is supplied to retain compatibility with current behavior.
- Move HTTP error translation into a reusable server helper
- Migrate existing environment creation callers and test fixtures to unwrap or handle the Result


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/NangoHQ/nango/pull/6972?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

