### PR TITLE
feat(mcp): add integrations list tool

### DIFF
--- a/docs/llms-full.txt
+++ b/docs/llms-full.txt
@@ -12724,6 +12724,14 @@ Keep the API key server-side and only configure it in MCP clients you trust. Do 
 
 ## Tools
 
+### Integrations
+
+Use the Integrations tools to inspect and manage integrations in the authenticated Nango environment.
+
+| Tool                | Description                                      | Required API key scope          |
+| ------------------- | ------------------------------------------------ | ------------------------------- |
+| `integrations_list` | List integrations configured in the environment. | `environment:integrations:list` |
+
 ### Logs
 
 Use the Logs tools to find activity in the authenticated Nango environment and inspect the messages for a specific operation.

--- a/docs/reference/backend/management-mcp.mdx
+++ b/docs/reference/backend/management-mcp.mdx
@@ -35,6 +35,14 @@ Keep the API key server-side and only configure it in MCP clients you trust. Do 
 
 ## Tools
 
+### Integrations
+
+Use the Integrations tools to inspect and manage integrations in the authenticated Nango environment.
+
+| Tool                | Description                                      | Required API key scope          |
+| ------------------- | ------------------------------------------------ | ------------------------------- |
+| `integrations_list` | List integrations configured in the environment. | `environment:integrations:list` |
+
 ### Logs
 
 Use the Logs tools to find activity in the authenticated Nango environment and inspect the messages for a specific operation.

--- a/packages/server/lib/controllers/integrations/getListIntegrations.ts
+++ b/packages/server/lib/controllers/integrations/getListIntegrations.ts
@@ -1,8 +1,6 @@
-import db from '@nangohq/database';
-import { configService, getProviders } from '@nangohq/shared';
-import { requireEmptyQuery, zodErrorToHTTP } from '@nangohq/utils';
+import { report, requireEmptyQuery, zodErrorToHTTP } from '@nangohq/utils';
 
-import { integrationToPublicApi } from '../../formatters/integration.js';
+import integrationService from '../../services/integration.service.js';
 import { asyncWrapper } from '../../utils/asyncWrapper.js';
 
 import type { GetPublicListIntegrations } from '@nangohq/types';
@@ -15,23 +13,15 @@ export const getPublicListIntegrations = asyncWrapper<GetPublicListIntegrations>
     }
 
     const { environment, connectSession } = res.locals;
-    let configs = await configService.listProviderConfigs(db.knex, environment.id);
-
-    const providers = getProviders();
-    if (!providers) {
-        res.status(500).send({ error: { code: 'server_error', message: `failed to load providers` } });
+    const result = await integrationService.list({
+        environmentId: environment.id,
+        allowedIntegrations: connectSession?.allowedIntegrations
+    });
+    if (result.isErr()) {
+        report(result.error);
+        res.status(500).send({ error: { code: 'server_error', message: result.error.message } });
         return;
     }
 
-    if (connectSession?.allowedIntegrations) {
-        configs = configs.filter((config) => {
-            return connectSession.allowedIntegrations?.includes(config.unique_key);
-        });
-    }
-
-    res.status(200).send({
-        data: configs.map((config) => {
-            return integrationToPublicApi({ integration: config, provider: providers[config.provider]! });
-        })
-    });
+    res.status(200).send(result.value);
 });

--- a/packages/server/lib/controllers/integrations/getListIntegrations.ts
+++ b/packages/server/lib/controllers/integrations/getListIntegrations.ts
@@ -1,5 +1,6 @@
-import { report, requireEmptyQuery, zodErrorToHTTP } from '@nangohq/utils';
+import { requireEmptyQuery, zodErrorToHTTP } from '@nangohq/utils';
 
+import { integrationToPublicApi } from '../../formatters/integration.js';
 import integrationService from '../../services/integration.service.js';
 import { asyncWrapper } from '../../utils/asyncWrapper.js';
 
@@ -18,10 +19,11 @@ export const getPublicListIntegrations = asyncWrapper<GetPublicListIntegrations>
         allowedIntegrations: connectSession?.allowedIntegrations
     });
     if (result.isErr()) {
-        report(result.error);
         res.status(500).send({ error: { code: 'server_error', message: result.error.message } });
         return;
     }
 
-    res.status(200).send(result.value);
+    res.status(200).send({
+        data: result.value.map(({ integration, provider }) => integrationToPublicApi({ integration, provider }))
+    });
 });

--- a/packages/server/lib/controllers/mcp/controlPlane.integration.test.ts
+++ b/packages/server/lib/controllers/mcp/controlPlane.integration.test.ts
@@ -153,6 +153,44 @@ describe('POST /mcp control-plane server', () => {
         }
     });
 
+    it('lists all tools with environment:* scope', async () => {
+        const { secret } = await createKeyWithScopes(['environment:*']);
+        const res = await mcpPost({
+            token: secret,
+            body: { jsonrpc: '2.0', id: 1, method: 'tools/list', params: {} }
+        });
+
+        expect(res.status).toBe(200);
+        expect(res.json.result.tools.map((tool: { name: string }) => tool.name)).toStrictEqual([
+            'integrations_list',
+            'logs_list_operations',
+            'logs_get_operation'
+        ]);
+    });
+
+    it('rejects each management tool when its required scope is missing', async () => {
+        const { secret } = await createKeyWithScopes(['environment:mcp']);
+        const toolNames = ['integrations_list', 'logs_list_operations', 'logs_get_operation'];
+
+        for (const toolName of toolNames) {
+            const res = await mcpPost({
+                token: secret,
+                body: {
+                    jsonrpc: '2.0',
+                    id: 1,
+                    method: 'tools/call',
+                    params: { name: toolName, arguments: {} }
+                }
+            });
+
+            expect(res.status).toBe(200);
+            expect(res.json.result).toStrictEqual({
+                content: [{ type: 'text', text: `MCP error -32602: Tool ${toolName} disabled` }],
+                isError: true
+            });
+        }
+    });
+
     it('lists log tools with logs:read scope', async () => {
         const { secret } = await createKeyWithScopes(['environment:logs:read']);
         const res = await mcpPost({
@@ -162,6 +200,17 @@ describe('POST /mcp control-plane server', () => {
 
         expect(res.status).toBe(200);
         expect(res.json.result.tools.map((tool: { name: string }) => tool.name)).toStrictEqual(['logs_list_operations', 'logs_get_operation']);
+    });
+
+    it('lists integration tools with integrations:list scope', async () => {
+        const { secret } = await createKeyWithScopes(['environment:integrations:list']);
+        const res = await mcpPost({
+            token: secret,
+            body: { jsonrpc: '2.0', id: 1, method: 'tools/list', params: {} }
+        });
+
+        expect(res.status).toBe(200);
+        expect(res.json.result.tools.map((tool: { name: string }) => tool.name)).toStrictEqual(['integrations_list']);
     });
 
     it('returns the legacy MCP JSON-RPC error shape for GET requests', async () => {
@@ -179,7 +228,7 @@ describe('POST /mcp control-plane server', () => {
         });
     });
 
-    it('does not grant logs tools with only the legacy mcp scope', async () => {
+    it('does not grant management tools with only the legacy mcp scope', async () => {
         const { secret } = await createKeyWithScopes(['environment:mcp']);
         const res = await mcpPost({
             token: secret,
@@ -202,6 +251,34 @@ describe('POST /mcp control-plane server', () => {
         expect(res.json.error).toMatchObject({
             code: 'forbidden',
             message: 'Insufficient scope. Required: environment:mcp'
+        });
+    });
+
+    it('lists integrations for the authenticated environment', async () => {
+        const { secret, env } = await createKeyWithScopes(['environment:integrations:list']);
+        await seeders.createConfigSeed(env, 'github', 'github');
+
+        const res = await mcpPost({
+            token: secret,
+            body: {
+                jsonrpc: '2.0',
+                id: 1,
+                method: 'tools/call',
+                params: {
+                    name: 'integrations_list',
+                    arguments: {}
+                }
+            }
+        });
+
+        expect(res.status).toBe(200);
+        const payload = parseToolText(res);
+        expect(payload.data).toHaveLength(1);
+        expect(payload.data[0]).toMatchObject({
+            provider: 'github',
+            unique_key: 'github',
+            display_name: 'GitHub (User OAuth)',
+            forward_webhooks: true
         });
     });
 

--- a/packages/server/lib/controllers/mcp/controlPlaneServer.ts
+++ b/packages/server/lib/controllers/mcp/controlPlaneServer.ts
@@ -1,6 +1,7 @@
 import { McpServer } from '@modelcontextprotocol/sdk/server/mcp.js';
 
 import { hasScope } from '../../middleware/scope.middleware.js';
+import { integrationsListTool } from './integrations/list.js';
 import { logsGetOperationTool } from './logs/getOperation.js';
 import { logsListOperationsTool } from './logs/listOperations.js';
 import { handleMcpToolError, jsonStructuredContent } from './utils.js';
@@ -9,7 +10,7 @@ import type { ControlPlaneMcpTool } from './controlPlaneTool.js';
 import type { AnySchema } from '@modelcontextprotocol/sdk/server/zod-compat.js';
 import type { ApiKeyScope, DBEnvironment, DBTeam } from '@nangohq/types';
 
-const controlPlaneMcpTools: ControlPlaneMcpTool[] = [logsListOperationsTool, logsGetOperationTool];
+const controlPlaneMcpTools: ControlPlaneMcpTool[] = [integrationsListTool, logsListOperationsTool, logsGetOperationTool];
 
 export function createControlPlaneMcpServer(account: DBTeam, environment: DBEnvironment, grantedScopes: string[] | undefined): McpServer {
     const server = new McpServer(

--- a/packages/server/lib/controllers/mcp/controlPlaneServer.unit.test.ts
+++ b/packages/server/lib/controllers/mcp/controlPlaneServer.unit.test.ts
@@ -14,6 +14,19 @@ import type { McpServer } from '@modelcontextprotocol/sdk/server/mcp.js';
 import type { DBEnvironment, DBTeam } from '@nangohq/types';
 
 describe('createControlPlaneMcpServer', () => {
+    it('exposes the integrations list tool when its scope is granted', async () => {
+        const { client, server } = await createTestClient(['environment:integrations:list']);
+
+        try {
+            const result = await client.listTools();
+
+            expect(result.tools.map((tool) => tool.name)).toStrictEqual(['integrations_list']);
+        } finally {
+            await client.close();
+            await server.close();
+        }
+    });
+
     it('disables tools when required scopes are missing', async () => {
         const handlerSpy = vi.spyOn(logsListOperationsTool, 'handler');
         const { client, server } = await createTestClient(['environment:mcp']);

--- a/packages/server/lib/controllers/mcp/controlPlaneServer.unit.test.ts
+++ b/packages/server/lib/controllers/mcp/controlPlaneServer.unit.test.ts
@@ -6,7 +6,6 @@ import { envs as logsEnvs } from '@nangohq/logs';
 import { Err, Ok } from '@nangohq/utils';
 
 import { createControlPlaneMcpServer } from './controlPlaneServer.js';
-import { logsGetOperationTool } from './logs/getOperation.js';
 import { logsListOperationsTool } from './logs/listOperations.js';
 import { PublicMcpError } from './utils.js';
 
@@ -139,43 +138,21 @@ describe('createControlPlaneMcpServer', () => {
         }
     });
 
-    it('returns an explicit public error for invalid logs list arguments', async () => {
-        const previousLogsEnabled = logsEnvs.NANGO_LOGS_ENABLED;
-        logsEnvs.NANGO_LOGS_ENABLED = true;
-
-        try {
-            await expect(
-                logsListOperationsTool.handler(
-                    { limit: 0 },
-                    { account: fakeAccount(), environment: fakeEnvironment(), grantedScopes: ['environment:logs:read'] }
-                )
-            ).resolves.toSatisfy((result) => result.isErr() && result.error.message.includes('Invalid logs_list_operations arguments'));
-        } finally {
-            logsEnvs.NANGO_LOGS_ENABLED = previousLogsEnabled;
-        }
-    });
-
     it('returns an explicit public error when logs are disabled', async () => {
         const previousLogsEnabled = logsEnvs.NANGO_LOGS_ENABLED;
         logsEnvs.NANGO_LOGS_ENABLED = false;
 
         try {
-            await expect(
-                logsListOperationsTool.handler({}, { account: fakeAccount(), environment: fakeEnvironment(), grantedScopes: ['environment:logs:read'] })
-            ).resolves.toSatisfy((result) => result.isErr() && result.error instanceof PublicMcpError && result.error.message === 'Nango logs are disabled');
-        } finally {
-            logsEnvs.NANGO_LOGS_ENABLED = previousLogsEnabled;
-        }
-    });
+            const result = await logsListOperationsTool.handler(
+                {},
+                { account: fakeAccount(), environment: fakeEnvironment(), grantedScopes: ['environment:logs:read'] }
+            );
 
-    it('returns an explicit public error for invalid get operation arguments', async () => {
-        const previousLogsEnabled = logsEnvs.NANGO_LOGS_ENABLED;
-        logsEnvs.NANGO_LOGS_ENABLED = true;
-
-        try {
-            await expect(
-                logsGetOperationTool.handler({}, { account: fakeAccount(), environment: fakeEnvironment(), grantedScopes: ['environment:logs:read'] })
-            ).resolves.toSatisfy((result) => result.isErr() && result.error.message.includes('Invalid logs_get_operation arguments'));
+            expect(result.isErr()).toBe(true);
+            if (result.isErr()) {
+                expect(result.error).toBeInstanceOf(PublicMcpError);
+                expect(result.error.message).toBe('Nango logs are disabled');
+            }
         } finally {
             logsEnvs.NANGO_LOGS_ENABLED = previousLogsEnabled;
         }

--- a/packages/server/lib/controllers/mcp/controlPlaneTool.ts
+++ b/packages/server/lib/controllers/mcp/controlPlaneTool.ts
@@ -1,3 +1,7 @@
+import { Err } from '@nangohq/utils';
+
+import { PublicMcpError } from './utils.js';
+
 import type { AnySchema } from '@modelcontextprotocol/sdk/server/zod-compat.js';
 import type { ApiKeyScope, DBEnvironment, DBTeam } from '@nangohq/types';
 import type { Result } from '@nangohq/utils';
@@ -20,6 +24,37 @@ export interface ControlPlaneMcpTool<TResponse extends object = object> {
     handler: (args: unknown, context: ControlPlaneMcpContext) => Promise<Result<TResponse>>;
 }
 
-export function defineControlPlaneMcpTool<TResponse extends object>(tool: ControlPlaneMcpTool<TResponse>): ControlPlaneMcpTool<TResponse> {
-    return tool;
+type ControlPlaneMcpToolDefinition<TInputSchema extends z.ZodType, TResponse extends object> = Omit<
+    ControlPlaneMcpTool<TResponse>,
+    'handler' | 'inputSchema'
+> & {
+    inputSchema: TInputSchema;
+    handler: (context: ControlPlaneMcpContext & { args: z.output<TInputSchema> }) => Result<TResponse> | Promise<Result<TResponse>>;
+};
+
+export function defineControlPlaneMcpTool<TInputSchema extends z.ZodType, TResponse extends object>(
+    tool: ControlPlaneMcpToolDefinition<TInputSchema, TResponse>
+): ControlPlaneMcpTool<TResponse> {
+    return {
+        ...tool,
+        async handler(args, context) {
+            const parsedArgs = tool.inputSchema.safeParse(args ?? {});
+            if (!parsedArgs.success) {
+                return Err(new PublicMcpError(formatArgumentsError(tool.name, parsedArgs.error)));
+            }
+
+            return await tool.handler({ ...context, args: parsedArgs.data });
+        }
+    };
+}
+
+function formatArgumentsError(toolName: string, error: z.ZodError): string {
+    const details = error.issues
+        .map((issue) => {
+            const path = issue.path.length > 0 ? issue.path.map(String).join('.') : 'arguments';
+            return `${path}: ${issue.message}`;
+        })
+        .join('; ');
+
+    return details ? `Invalid ${toolName} arguments: ${details}` : `Invalid ${toolName} arguments`;
 }

--- a/packages/server/lib/controllers/mcp/controlPlaneTool.unit.test.ts
+++ b/packages/server/lib/controllers/mcp/controlPlaneTool.unit.test.ts
@@ -1,0 +1,56 @@
+import { describe, expect, it } from 'vitest';
+import * as z from 'zod/v4';
+
+import { Ok } from '@nangohq/utils';
+
+import { defineControlPlaneMcpTool } from './controlPlaneTool.js';
+import { PublicMcpError } from './utils.js';
+
+import type { ControlPlaneMcpContext } from './controlPlaneTool.js';
+
+const context = {
+    account: {},
+    environment: {},
+    grantedScopes: ['environment:mcp']
+} as ControlPlaneMcpContext;
+
+describe('defineControlPlaneMcpTool', () => {
+    it('passes parsed arguments to the tool handler', async () => {
+        const tool = defineControlPlaneMcpTool({
+            name: 'test_tool',
+            description: 'Test tool',
+            inputSchema: z.object({ limit: z.number().default(10) }).strict(),
+            requiredScopes: ['environment:mcp'],
+            handler({ args }) {
+                return Ok({ limit: args.limit });
+            }
+        });
+
+        const result = await tool.handler({}, context);
+
+        expect(result.isOk()).toBe(true);
+        if (result.isOk()) {
+            expect(result.value).toStrictEqual({ limit: 10 });
+        }
+    });
+
+    it('returns a public error for invalid arguments', async () => {
+        const tool = defineControlPlaneMcpTool({
+            name: 'test_tool',
+            description: 'Test tool',
+            inputSchema: z.object({ limit: z.number().min(1) }).strict(),
+            requiredScopes: ['environment:mcp'],
+            handler({ args }) {
+                return Ok({ limit: args.limit });
+            }
+        });
+
+        const result = await tool.handler({ limit: 0 }, context);
+
+        expect(result.isErr()).toBe(true);
+        if (result.isErr()) {
+            expect(result.error).toBeInstanceOf(PublicMcpError);
+            expect(result.error.message).toContain('Invalid test_tool arguments: limit:');
+        }
+    });
+});

--- a/packages/server/lib/controllers/mcp/integrations/formatter.ts
+++ b/packages/server/lib/controllers/mcp/integrations/formatter.ts
@@ -1,5 +1,7 @@
 import { basePublicUrl } from '@nangohq/utils';
 
+import { getPreconfiguredCredentials } from '../../../utils/integrations.js';
+
 import type { IntegrationConfig, Provider } from '@nangohq/types';
 
 export function integrationToMcp({ integration, provider }: { integration: IntegrationConfig; provider: Provider }) {
@@ -16,12 +18,4 @@ export function integrationToMcp({ integration, provider }: { integration: Integ
         created_at: integration.created_at.toISOString(),
         updated_at: integration.updated_at.toISOString()
     };
-}
-
-function getPreconfiguredCredentials(custom: IntegrationConfig['custom'], provider: Provider): string[] {
-    if (!custom || provider.auth_mode !== 'TWO_STEP' || !provider.integration_config) {
-        return [];
-    }
-
-    return Object.keys(provider.integration_config).filter((field) => Boolean(custom[field]));
 }

--- a/packages/server/lib/controllers/mcp/integrations/formatter.ts
+++ b/packages/server/lib/controllers/mcp/integrations/formatter.ts
@@ -1,0 +1,27 @@
+import { basePublicUrl } from '@nangohq/utils';
+
+import type { IntegrationConfig, Provider } from '@nangohq/types';
+
+export function integrationToMcp({ integration, provider }: { integration: IntegrationConfig; provider: Provider }) {
+    const preconfiguredCredentials = getPreconfiguredCredentials(integration.custom, provider);
+
+    return {
+        unique_key: integration.unique_key,
+        provider: integration.provider,
+        display_name: integration.display_name || provider.display_name,
+        logo: `${basePublicUrl}/images/template-logos/${integration.provider}.svg`,
+        ...(provider.integration_config && integration.custom?.['keyLabel'] ? { credentials_label: { apiKey: integration.custom['keyLabel'] } } : {}),
+        ...(preconfiguredCredentials.length > 0 ? { preconfigured_credentials: preconfiguredCredentials } : {}),
+        forward_webhooks: integration.forward_webhooks === undefined ? true : integration.forward_webhooks,
+        created_at: integration.created_at.toISOString(),
+        updated_at: integration.updated_at.toISOString()
+    };
+}
+
+function getPreconfiguredCredentials(custom: IntegrationConfig['custom'], provider: Provider): string[] {
+    if (!custom || provider.auth_mode !== 'TWO_STEP' || !provider.integration_config) {
+        return [];
+    }
+
+    return Object.keys(provider.integration_config).filter((field) => Boolean(custom[field]));
+}

--- a/packages/server/lib/controllers/mcp/integrations/formatter.unit.test.ts
+++ b/packages/server/lib/controllers/mcp/integrations/formatter.unit.test.ts
@@ -1,0 +1,56 @@
+import { describe, expect, it } from 'vitest';
+
+import { getProvider } from '@nangohq/shared';
+
+import { integrationToMcp } from './formatter.js';
+
+import type { IntegrationConfig } from '@nangohq/types';
+
+describe('integrationToMcp', () => {
+    it('lists credentials preconfigured on a two-step integration', () => {
+        const provider = getProvider('sage-intacct-cc');
+        if (!provider) {
+            throw new Error('Expected sage-intacct-cc provider');
+        }
+        const integration = integrationFixture({
+            provider: 'sage-intacct-cc',
+            custom: { clientId: 'client-id', clientSecret: 'client-secret' }
+        });
+
+        const result = integrationToMcp({ integration, provider });
+
+        expect(result.preconfigured_credentials).toStrictEqual(['clientId', 'clientSecret']);
+    });
+
+    it('uses an integration-specific API key label', () => {
+        const provider = getProvider('private-api-generic');
+        if (!provider) {
+            throw new Error('Expected private-api-generic provider');
+        }
+        const integration = integrationFixture({
+            provider: 'private-api-generic',
+            custom: { keyLabel: 'Workspace token' }
+        });
+
+        const result = integrationToMcp({ integration, provider });
+
+        expect(result.credentials_label).toStrictEqual({ apiKey: 'Workspace token' });
+    });
+});
+
+function integrationFixture({ provider, custom }: { provider: string; custom: IntegrationConfig['custom'] }): IntegrationConfig {
+    return {
+        unique_key: provider,
+        provider,
+        oauth_client_id: null,
+        oauth_client_secret: null,
+        environment_id: 1,
+        custom,
+        missing_fields: [],
+        display_name: null,
+        forward_webhooks: true,
+        shared_credentials_id: null,
+        created_at: new Date('2026-01-01T00:00:00.000Z'),
+        updated_at: new Date('2026-01-02T00:00:00.000Z')
+    };
+}

--- a/packages/server/lib/controllers/mcp/integrations/list.ts
+++ b/packages/server/lib/controllers/mcp/integrations/list.ts
@@ -1,0 +1,70 @@
+import * as z from 'zod/v4';
+
+import { Err, Ok } from '@nangohq/utils';
+
+import integrationService from '../../../services/integration.service.js';
+import { defineControlPlaneMcpTool } from '../controlPlaneTool.js';
+import { PublicMcpError } from '../utils.js';
+
+import type { GetPublicListIntegrations } from '@nangohq/types';
+import type { Result } from '@nangohq/utils';
+
+const listIntegrationsArgumentsSchema = z.object({}).strict();
+
+const listIntegrationsOutputSchema = z
+    .object({
+        data: z.array(
+            z
+                .object({
+                    unique_key: z.string(),
+                    provider: z.string(),
+                    display_name: z.string(),
+                    logo: z.string(),
+                    credentials_label: z.record(z.string(), z.string()).optional(),
+                    preconfigured_credentials: z.array(z.string()).optional(),
+                    forward_webhooks: z.boolean(),
+                    created_at: z.string(),
+                    updated_at: z.string()
+                })
+                .strict()
+        )
+    })
+    .strict();
+
+type ParsedListIntegrationsArguments = z.infer<typeof listIntegrationsArgumentsSchema>;
+
+export const integrationsListTool = defineControlPlaneMcpTool<GetPublicListIntegrations['Success']>({
+    name: 'integrations_list',
+    description: 'List integrations configured in the authenticated Nango environment.',
+    inputSchema: listIntegrationsArgumentsSchema,
+    outputSchema: listIntegrationsOutputSchema,
+    requiredScopes: ['environment:integrations:list'],
+    async handler(args, { environment }) {
+        const parsedArgs = parseListIntegrationsArguments(args);
+        if (parsedArgs.isErr()) {
+            return Err(parsedArgs.error);
+        }
+
+        return await integrationService.list({ environmentId: environment.id });
+    }
+});
+
+function parseListIntegrationsArguments(args: unknown): Result<ParsedListIntegrationsArguments> {
+    const parsedArgs = listIntegrationsArgumentsSchema.safeParse(args ?? {});
+    if (!parsedArgs.success) {
+        return Err(new PublicMcpError(formatListIntegrationsArgumentsError(parsedArgs.error)));
+    }
+
+    return Ok(parsedArgs.data);
+}
+
+function formatListIntegrationsArgumentsError(error: z.ZodError): string {
+    const details = error.issues
+        .map((issue) => {
+            const path = issue.path.length > 0 ? issue.path.map(String).join('.') : 'arguments';
+            return `${path}: ${issue.message}`;
+        })
+        .join('; ');
+
+    return details ? `Invalid integrations_list arguments: ${details}` : 'Invalid integrations_list arguments';
+}

--- a/packages/server/lib/controllers/mcp/integrations/list.ts
+++ b/packages/server/lib/controllers/mcp/integrations/list.ts
@@ -1,13 +1,8 @@
 import * as z from 'zod/v4';
 
-import { Err, Ok } from '@nangohq/utils';
-
 import integrationService from '../../../services/integration.service.js';
 import { defineControlPlaneMcpTool } from '../controlPlaneTool.js';
-import { PublicMcpError } from '../utils.js';
-
-import type { GetPublicListIntegrations } from '@nangohq/types';
-import type { Result } from '@nangohq/utils';
+import { integrationToMcp } from './formatter.js';
 
 const listIntegrationsArgumentsSchema = z.object({}).strict();
 
@@ -31,40 +26,18 @@ const listIntegrationsOutputSchema = z
     })
     .strict();
 
-type ParsedListIntegrationsArguments = z.infer<typeof listIntegrationsArgumentsSchema>;
+type ListIntegrationsOutput = z.infer<typeof listIntegrationsOutputSchema>;
 
-export const integrationsListTool = defineControlPlaneMcpTool<GetPublicListIntegrations['Success']>({
+export const integrationsListTool = defineControlPlaneMcpTool<typeof listIntegrationsArgumentsSchema, ListIntegrationsOutput>({
     name: 'integrations_list',
     description: 'List integrations configured in the authenticated Nango environment.',
     inputSchema: listIntegrationsArgumentsSchema,
     outputSchema: listIntegrationsOutputSchema,
     requiredScopes: ['environment:integrations:list'],
-    async handler(args, { environment }) {
-        const parsedArgs = parseListIntegrationsArguments(args);
-        if (parsedArgs.isErr()) {
-            return Err(parsedArgs.error);
-        }
-
-        return await integrationService.list({ environmentId: environment.id });
+    async handler({ environment }) {
+        const result = await integrationService.list({ environmentId: environment.id });
+        return result.map((integrations) => ({
+            data: integrations.map(({ integration, provider }) => integrationToMcp({ integration, provider }))
+        }));
     }
 });
-
-function parseListIntegrationsArguments(args: unknown): Result<ParsedListIntegrationsArguments> {
-    const parsedArgs = listIntegrationsArgumentsSchema.safeParse(args ?? {});
-    if (!parsedArgs.success) {
-        return Err(new PublicMcpError(formatListIntegrationsArgumentsError(parsedArgs.error)));
-    }
-
-    return Ok(parsedArgs.data);
-}
-
-function formatListIntegrationsArgumentsError(error: z.ZodError): string {
-    const details = error.issues
-        .map((issue) => {
-            const path = issue.path.length > 0 ? issue.path.map(String).join('.') : 'arguments';
-            return `${path}: ${issue.message}`;
-        })
-        .join('; ');
-
-    return details ? `Invalid integrations_list arguments: ${details}` : 'Invalid integrations_list arguments';
-}

--- a/packages/server/lib/controllers/mcp/integrations/list.unit.test.ts
+++ b/packages/server/lib/controllers/mcp/integrations/list.unit.test.ts
@@ -1,13 +1,13 @@
 import { afterEach, describe, expect, it, vi } from 'vitest';
 
-import { Ok } from '@nangohq/utils';
+import { basePublicUrl, Ok } from '@nangohq/utils';
 
 import integrationService from '../../../services/integration.service.js';
-import { PublicMcpError } from '../utils.js';
 import { integrationsListTool } from './list.js';
 
 import type { ControlPlaneMcpContext } from '../controlPlaneTool.js';
-import type { GetPublicListIntegrations } from '@nangohq/types';
+import type { Config } from '@nangohq/shared';
+import type { Provider } from '@nangohq/types';
 
 const context = {
     account: {},
@@ -15,19 +15,8 @@ const context = {
     grantedScopes: ['environment:integrations:list']
 } as ControlPlaneMcpContext;
 
-const integrationListResponse: GetPublicListIntegrations['Success'] = {
-    data: [
-        {
-            unique_key: 'github',
-            provider: 'github',
-            display_name: 'GitHub',
-            logo: 'https://example.com/github.svg',
-            forward_webhooks: true,
-            created_at: '2026-01-01T00:00:00.000Z',
-            updated_at: '2026-01-02T00:00:00.000Z'
-        }
-    ]
-};
+const createdAt = new Date('2026-01-01T00:00:00.000Z');
+const updatedAt = new Date('2026-01-02T00:00:00.000Z');
 
 describe('integrationsListTool', () => {
     afterEach(() => {
@@ -35,25 +24,56 @@ describe('integrationsListTool', () => {
     });
 
     it('returns the integration list', async () => {
-        vi.spyOn(integrationService, 'list').mockResolvedValue(Ok(integrationListResponse));
+        vi.spyOn(integrationService, 'list').mockResolvedValue(
+            Ok([
+                {
+                    integration: integrationFixture(),
+                    provider: providerFixture()
+                }
+            ])
+        );
 
         const result = await integrationsListTool.handler({}, context);
 
         expect(result.isOk()).toBe(true);
         if (result.isOk()) {
-            expect(result.value).toStrictEqual(integrationListResponse);
-        }
-    });
-
-    it('returns a public error for invalid arguments', async () => {
-        vi.spyOn(integrationService, 'list').mockResolvedValue(Ok(integrationListResponse));
-
-        const result = await integrationsListTool.handler({ unexpected: true }, context);
-
-        expect(result.isErr()).toBe(true);
-        if (result.isErr()) {
-            expect(result.error).toBeInstanceOf(PublicMcpError);
-            expect(result.error.message).toContain('Invalid integrations_list arguments');
+            expect(result.value).toStrictEqual({
+                data: [
+                    {
+                        unique_key: 'github',
+                        provider: 'github',
+                        display_name: 'GitHub',
+                        logo: `${basePublicUrl}/images/template-logos/github.svg`,
+                        forward_webhooks: true,
+                        created_at: createdAt.toISOString(),
+                        updated_at: updatedAt.toISOString()
+                    }
+                ]
+            });
         }
     });
 });
+
+function integrationFixture(): Config {
+    return {
+        unique_key: 'github',
+        provider: 'github',
+        oauth_client_id: '',
+        oauth_client_secret: '',
+        environment_id: 42,
+        missing_fields: [],
+        display_name: null,
+        forward_webhooks: true,
+        shared_credentials_id: null,
+        created_at: createdAt,
+        updated_at: updatedAt
+    };
+}
+
+function providerFixture(): Provider {
+    return {
+        display_name: 'GitHub',
+        auth_mode: 'OAUTH2',
+        docs: ''
+    };
+}

--- a/packages/server/lib/controllers/mcp/integrations/list.unit.test.ts
+++ b/packages/server/lib/controllers/mcp/integrations/list.unit.test.ts
@@ -1,0 +1,59 @@
+import { afterEach, describe, expect, it, vi } from 'vitest';
+
+import { Ok } from '@nangohq/utils';
+
+import integrationService from '../../../services/integration.service.js';
+import { PublicMcpError } from '../utils.js';
+import { integrationsListTool } from './list.js';
+
+import type { ControlPlaneMcpContext } from '../controlPlaneTool.js';
+import type { GetPublicListIntegrations } from '@nangohq/types';
+
+const context = {
+    account: {},
+    environment: { id: 42 },
+    grantedScopes: ['environment:integrations:list']
+} as ControlPlaneMcpContext;
+
+const integrationListResponse: GetPublicListIntegrations['Success'] = {
+    data: [
+        {
+            unique_key: 'github',
+            provider: 'github',
+            display_name: 'GitHub',
+            logo: 'https://example.com/github.svg',
+            forward_webhooks: true,
+            created_at: '2026-01-01T00:00:00.000Z',
+            updated_at: '2026-01-02T00:00:00.000Z'
+        }
+    ]
+};
+
+describe('integrationsListTool', () => {
+    afterEach(() => {
+        vi.restoreAllMocks();
+    });
+
+    it('returns the integration list', async () => {
+        vi.spyOn(integrationService, 'list').mockResolvedValue(Ok(integrationListResponse));
+
+        const result = await integrationsListTool.handler({}, context);
+
+        expect(result.isOk()).toBe(true);
+        if (result.isOk()) {
+            expect(result.value).toStrictEqual(integrationListResponse);
+        }
+    });
+
+    it('returns a public error for invalid arguments', async () => {
+        vi.spyOn(integrationService, 'list').mockResolvedValue(Ok(integrationListResponse));
+
+        const result = await integrationsListTool.handler({ unexpected: true }, context);
+
+        expect(result.isErr()).toBe(true);
+        if (result.isErr()) {
+            expect(result.error).toBeInstanceOf(PublicMcpError);
+            expect(result.error.message).toContain('Invalid integrations_list arguments');
+        }
+    });
+});

--- a/packages/server/lib/controllers/mcp/logs/getOperation.ts
+++ b/packages/server/lib/controllers/mcp/logs/getOperation.ts
@@ -1,14 +1,12 @@
 import * as z from 'zod/v4';
 
 import { isLogsNotFoundError, LogsDisabledError, logsOperationsService, operationIdRegex } from '@nangohq/logs';
-import { Err, Ok } from '@nangohq/utils';
 
 import { defineControlPlaneMcpTool } from '../controlPlaneTool.js';
 import { PublicMcpError } from '../utils.js';
 import { defaultLimit, logsReadScope, maxLimit, normalizePeriod, periodSchema } from './utils.js';
 
 import type { GetLogOperationParams, GetLogOperationResult } from '@nangohq/logs';
-import type { Result } from '@nangohq/utils';
 
 const getOperationArgumentsSchema = z
     .object({
@@ -40,22 +38,17 @@ const getOperationOutputSchema = z
 
 type ParsedGetOperationArguments = Omit<GetLogOperationParams, 'accountId' | 'environmentId'>;
 
-export const logsGetOperationTool = defineControlPlaneMcpTool<GetLogOperationResult>({
+export const logsGetOperationTool = defineControlPlaneMcpTool<typeof getOperationArgumentsSchema, GetLogOperationResult>({
     name: 'logs_get_operation',
     description: 'Get one Nango log operation and a page of its message rows for the authenticated environment. Messages are returned newest first.',
     inputSchema: getOperationArgumentsSchema,
     outputSchema: getOperationOutputSchema,
     requiredScopes: [logsReadScope],
-    async handler(args, { account, environment }) {
-        const parsedArgs = parseGetOperationArguments(args);
-        if (parsedArgs.isErr()) {
-            return Err(parsedArgs.error);
-        }
-
+    async handler({ args, account, environment }) {
         const result = await logsOperationsService.getOperation({
             accountId: account.id,
             environmentId: environment.id,
-            ...parsedArgs.value
+            ...normalizeGetOperationArguments(args)
         });
 
         return result.mapError((error) => {
@@ -72,31 +65,14 @@ export const logsGetOperationTool = defineControlPlaneMcpTool<GetLogOperationRes
     }
 });
 
-function parseGetOperationArguments(args: unknown): Result<ParsedGetOperationArguments> {
-    const parsedArgs = getOperationArgumentsSchema.safeParse(args ?? {});
-    if (!parsedArgs.success) {
-        return Err(new PublicMcpError(formatGetOperationArgumentsError(parsedArgs.error)));
-    }
-
-    const parsed = parsedArgs.data;
-    return Ok({
-        operationId: parsed.operationId,
+function normalizeGetOperationArguments(args: z.infer<typeof getOperationArgumentsSchema>): ParsedGetOperationArguments {
+    return {
+        operationId: args.operationId,
         messages: {
-            limit: parsed.messages?.limit ?? defaultLimit,
-            cursor: parsed.messages?.cursor,
-            search: parsed.messages?.search,
-            period: parsed.messages?.period ? normalizePeriod(parsed.messages.period) : undefined
+            limit: args.messages?.limit ?? defaultLimit,
+            cursor: args.messages?.cursor,
+            search: args.messages?.search,
+            period: args.messages?.period ? normalizePeriod(args.messages.period) : undefined
         }
-    });
-}
-
-function formatGetOperationArgumentsError(error: z.ZodError): string {
-    const details = error.issues
-        .map((issue) => {
-            const path = issue.path.length > 0 ? issue.path.map(String).join('.') : 'arguments';
-            return `${path}: ${issue.message}`;
-        })
-        .join('; ');
-
-    return details ? `Invalid logs_get_operation arguments: ${details}` : 'Invalid logs_get_operation arguments';
+    };
 }

--- a/packages/server/lib/controllers/mcp/logs/listOperations.ts
+++ b/packages/server/lib/controllers/mcp/logs/listOperations.ts
@@ -1,7 +1,6 @@
 import * as z from 'zod/v4';
 
 import { LogsDisabledError, logsOperationsService } from '@nangohq/logs';
-import { Err, Ok } from '@nangohq/utils';
 
 import { defineControlPlaneMcpTool } from '../controlPlaneTool.js';
 import { PublicMcpError } from '../utils.js';
@@ -21,7 +20,6 @@ import type {
     SearchOperationsType,
     SearchPeriod
 } from '@nangohq/types';
-import type { Result } from '@nangohq/utils';
 
 const defaultOperationsPeriodMs = 24 * 60 * 60 * 1000;
 
@@ -170,7 +168,7 @@ const listOperationsOutputSchema = z
 type ListOperationsArguments = z.infer<typeof listOperationsArgumentsSchema>;
 type ParsedListOperationsArguments = Omit<ListLogOperationsParams, 'accountId' | 'environmentId'>;
 
-export const logsListOperationsTool = defineControlPlaneMcpTool<ListLogOperationsResult>({
+export const logsListOperationsTool = defineControlPlaneMcpTool<typeof listOperationsArgumentsSchema, ListLogOperationsResult>({
     name: 'logs_list_operations',
     description: [
         'List Nango log operations.',
@@ -181,16 +179,11 @@ export const logsListOperationsTool = defineControlPlaneMcpTool<ListLogOperation
     inputSchema: listOperationsArgumentsSchema,
     outputSchema: listOperationsOutputSchema,
     requiredScopes: [logsReadScope],
-    async handler(args, { account, environment }) {
-        const parsedArgs = parseListOperationsArguments(args);
-        if (parsedArgs.isErr()) {
-            return Err(parsedArgs.error);
-        }
-
+    async handler({ args, account, environment }) {
         const result = await logsOperationsService.listOperations({
             accountId: account.id,
             environmentId: environment.id,
-            ...parsedArgs.value
+            ...normalizeListOperationsArguments(args)
         });
 
         return result.mapError((error) => {
@@ -233,35 +226,18 @@ function normalizeFilterArray<T>(values: T[] | undefined): T[] | undefined {
     return values && values.length > 0 ? values : undefined;
 }
 
-function parseListOperationsArguments(args: unknown): Result<ParsedListOperationsArguments> {
-    const parsedArgs = listOperationsArgumentsSchema.safeParse(args ?? {});
-    if (!parsedArgs.success) {
-        return Err(new PublicMcpError(formatListOperationsArgumentsError(parsedArgs.error)));
-    }
+function normalizeListOperationsArguments(args: ListOperationsArguments): ParsedListOperationsArguments {
+    const period = args.period ? normalizePeriod(args.period) : defaultOperationsPeriod();
 
-    const parsed = parsedArgs.data;
-    const period = parsed.period ? normalizePeriod(parsed.period) : defaultOperationsPeriod();
-
-    return Ok({
-        limit: parsed.limit,
-        cursor: parsed.cursor,
-        states: normalizeFilterArray(parsed.states),
-        types: normalizeOperations(parsed.operations),
-        integrations: normalizeFilterArray(parsed.integrations),
-        connections: normalizeFilterArray(parsed.connections),
-        syncs: normalizeFilterArray(parsed.syncs),
+    return {
+        limit: args.limit,
+        cursor: args.cursor,
+        states: normalizeFilterArray(args.states),
+        types: normalizeOperations(args.operations),
+        integrations: normalizeFilterArray(args.integrations),
+        connections: normalizeFilterArray(args.connections),
+        syncs: normalizeFilterArray(args.syncs),
         period,
-        search: parsed.search
-    });
-}
-
-function formatListOperationsArgumentsError(error: z.ZodError): string {
-    const details = error.issues
-        .map((issue) => {
-            const path = issue.path.length > 0 ? issue.path.map(String).join('.') : 'arguments';
-            return `${path}: ${issue.message}`;
-        })
-        .join('; ');
-
-    return details ? `Invalid logs_list_operations arguments: ${details}` : 'Invalid logs_list_operations arguments';
+        search: args.search
+    };
 }

--- a/packages/server/lib/formatters/integration.ts
+++ b/packages/server/lib/formatters/integration.ts
@@ -1,6 +1,8 @@
 import { getProvider } from '@nangohq/shared';
 import { basePublicUrl } from '@nangohq/utils';
 
+import { getPreconfiguredCredentials } from '../utils/integrations.js';
+
 import type { ApiIntegration, ApiPublicIntegration, ApiPublicIntegrationInclude, IntegrationConfig, Provider } from '@nangohq/types';
 
 export function integrationToApi(data: IntegrationConfig, options?: { includeCredentials?: boolean }): ApiIntegration {
@@ -45,14 +47,6 @@ function maskSecretConfigFields(custom: IntegrationConfig['custom'], provider: P
     }
 
     return masked ?? custom;
-}
-
-function getPreconfiguredCredentials(custom: IntegrationConfig['custom'], provider: Provider): string[] {
-    if (!custom || provider.auth_mode !== 'TWO_STEP' || !provider.integration_config) {
-        return [];
-    }
-
-    return Object.keys(provider.integration_config).filter((field) => Boolean(custom[field]));
 }
 
 export function integrationToPublicApi({

--- a/packages/server/lib/services/integration.service.ts
+++ b/packages/server/lib/services/integration.service.ts
@@ -2,9 +2,7 @@ import db from '@nangohq/database';
 import { configService, getProviders } from '@nangohq/shared';
 import { Err, Ok } from '@nangohq/utils';
 
-import { integrationToPublicApi } from '../formatters/integration.js';
-
-import type { ApiPublicIntegration, GetPublicListIntegrations } from '@nangohq/types';
+import type { IntegrationConfig, Provider } from '@nangohq/types';
 import type { Result } from '@nangohq/utils';
 
 type IntegrationServiceErrorCode = 'list_failed';
@@ -19,6 +17,11 @@ export class IntegrationServiceError extends Error {
     }
 }
 
+export interface ListedIntegration {
+    integration: IntegrationConfig;
+    provider: Provider;
+}
+
 class IntegrationService {
     async list({
         environmentId,
@@ -26,7 +29,7 @@ class IntegrationService {
     }: {
         environmentId: number;
         allowedIntegrations?: string[] | null;
-    }): Promise<Result<GetPublicListIntegrations['Success'], IntegrationServiceError>> {
+    }): Promise<Result<ListedIntegration[], IntegrationServiceError>> {
         try {
             let configs = await configService.listProviderConfigs(db.knex, environmentId);
 
@@ -44,7 +47,7 @@ class IntegrationService {
                 configs = configs.filter((config) => allowedIntegrations.includes(config.unique_key));
             }
 
-            const data: ApiPublicIntegration[] = [];
+            const integrations: ListedIntegration[] = [];
             for (const config of configs) {
                 const provider = providers[config.provider];
                 if (!provider) {
@@ -56,10 +59,10 @@ class IntegrationService {
                         })
                     );
                 }
-                data.push(integrationToPublicApi({ integration: config, provider }));
+                integrations.push({ integration: config, provider });
             }
 
-            return Ok({ data });
+            return Ok(integrations);
         } catch (err) {
             return Err(
                 new IntegrationServiceError({

--- a/packages/server/lib/services/integration.service.ts
+++ b/packages/server/lib/services/integration.service.ts
@@ -1,0 +1,75 @@
+import db from '@nangohq/database';
+import { configService, getProviders } from '@nangohq/shared';
+import { Err, Ok } from '@nangohq/utils';
+
+import { integrationToPublicApi } from '../formatters/integration.js';
+
+import type { ApiPublicIntegration, GetPublicListIntegrations } from '@nangohq/types';
+import type { Result } from '@nangohq/utils';
+
+type IntegrationServiceErrorCode = 'list_failed';
+
+export class IntegrationServiceError extends Error {
+    public code: IntegrationServiceErrorCode;
+
+    constructor({ code, message, cause }: { code: IntegrationServiceErrorCode; message: string; cause?: unknown }) {
+        super(message, { cause });
+        this.name = 'IntegrationServiceError';
+        this.code = code;
+    }
+}
+
+class IntegrationService {
+    async list({
+        environmentId,
+        allowedIntegrations
+    }: {
+        environmentId: number;
+        allowedIntegrations?: string[] | null;
+    }): Promise<Result<GetPublicListIntegrations['Success'], IntegrationServiceError>> {
+        try {
+            let configs = await configService.listProviderConfigs(db.knex, environmentId);
+
+            const providers = getProviders();
+            if (!providers) {
+                return Err(
+                    new IntegrationServiceError({
+                        code: 'list_failed',
+                        message: 'failed to load providers'
+                    })
+                );
+            }
+
+            if (allowedIntegrations) {
+                configs = configs.filter((config) => allowedIntegrations.includes(config.unique_key));
+            }
+
+            const data: ApiPublicIntegration[] = [];
+            for (const config of configs) {
+                const provider = providers[config.provider];
+                if (!provider) {
+                    return Err(
+                        new IntegrationServiceError({
+                            code: 'list_failed',
+                            message: 'Failed to list integrations',
+                            cause: new Error(`Provider '${config.provider}' does not exist`)
+                        })
+                    );
+                }
+                data.push(integrationToPublicApi({ integration: config, provider }));
+            }
+
+            return Ok({ data });
+        } catch (err) {
+            return Err(
+                new IntegrationServiceError({
+                    code: 'list_failed',
+                    message: 'Failed to list integrations',
+                    cause: err
+                })
+            );
+        }
+    }
+}
+
+export default new IntegrationService();

--- a/packages/server/lib/services/integration.service.unit.test.ts
+++ b/packages/server/lib/services/integration.service.unit.test.ts
@@ -1,7 +1,6 @@
 import { afterEach, describe, expect, it, vi } from 'vitest';
 
 import * as shared from '@nangohq/shared';
-import { basePublicUrl } from '@nangohq/utils';
 
 import integrationService from './integration.service.js';
 
@@ -16,46 +15,46 @@ describe('integrationService', () => {
         vi.restoreAllMocks();
     });
 
-    it('lists and formats integrations for an environment', async () => {
-        vi.spyOn(shared.configService, 'listProviderConfigs').mockResolvedValue([
-            integrationFixture({ uniqueKey: 'github', provider: 'github' }),
-            integrationFixture({ uniqueKey: 'slack', provider: 'slack' })
-        ]);
+    it('lists integrations with their providers for an environment', async () => {
+        const githubIntegration = integrationFixture({ uniqueKey: 'github', provider: 'github' });
+        const slackIntegration = integrationFixture({ uniqueKey: 'slack', provider: 'slack' });
+        const githubProvider = providerFixture('GitHub');
+        const slackProvider = providerFixture('Slack');
+
+        vi.spyOn(shared.configService, 'listProviderConfigs').mockResolvedValue([githubIntegration, slackIntegration]);
         vi.spyOn(shared, 'getProviders').mockReturnValue({
-            github: providerFixture('GitHub'),
-            slack: providerFixture('Slack')
+            github: githubProvider,
+            slack: slackProvider
         });
 
         const result = await integrationService.list({ environmentId: 42 });
 
         expect(result.isOk()).toBe(true);
         if (result.isOk()) {
-            expect(result.value).toStrictEqual({
-                data: [
-                    publicIntegrationFixture({ uniqueKey: 'github', provider: 'github', displayName: 'GitHub' }),
-                    publicIntegrationFixture({ uniqueKey: 'slack', provider: 'slack', displayName: 'Slack' })
-                ]
-            });
+            expect(result.value).toStrictEqual([
+                { integration: githubIntegration, provider: githubProvider },
+                { integration: slackIntegration, provider: slackProvider }
+            ]);
         }
     });
 
     it('filters integrations to those allowed by a Connect Session', async () => {
-        vi.spyOn(shared.configService, 'listProviderConfigs').mockResolvedValue([
-            integrationFixture({ uniqueKey: 'github', provider: 'github' }),
-            integrationFixture({ uniqueKey: 'slack', provider: 'slack' })
-        ]);
+        const githubIntegration = integrationFixture({ uniqueKey: 'github', provider: 'github' });
+        const slackIntegration = integrationFixture({ uniqueKey: 'slack', provider: 'slack' });
+        const githubProvider = providerFixture('GitHub');
+        const slackProvider = providerFixture('Slack');
+
+        vi.spyOn(shared.configService, 'listProviderConfigs').mockResolvedValue([githubIntegration, slackIntegration]);
         vi.spyOn(shared, 'getProviders').mockReturnValue({
-            github: providerFixture('GitHub'),
-            slack: providerFixture('Slack')
+            github: githubProvider,
+            slack: slackProvider
         });
 
         const result = await integrationService.list({ environmentId: 42, allowedIntegrations: ['slack'] });
 
         expect(result.isOk()).toBe(true);
         if (result.isOk()) {
-            expect(result.value).toStrictEqual({
-                data: [publicIntegrationFixture({ uniqueKey: 'slack', provider: 'slack', displayName: 'Slack' })]
-            });
+            expect(result.value).toStrictEqual([{ integration: slackIntegration, provider: slackProvider }]);
         }
     });
 
@@ -128,17 +127,5 @@ function providerFixture(displayName: string): Provider {
         display_name: displayName,
         auth_mode: 'OAUTH2',
         docs: ''
-    };
-}
-
-function publicIntegrationFixture({ uniqueKey, provider, displayName }: { uniqueKey: string; provider: string; displayName: string }) {
-    return {
-        unique_key: uniqueKey,
-        provider,
-        display_name: displayName,
-        logo: `${basePublicUrl}/images/template-logos/${provider}.svg`,
-        forward_webhooks: true,
-        created_at: createdAt.toISOString(),
-        updated_at: updatedAt.toISOString()
     };
 }

--- a/packages/server/lib/services/integration.service.unit.test.ts
+++ b/packages/server/lib/services/integration.service.unit.test.ts
@@ -1,0 +1,144 @@
+import { afterEach, describe, expect, it, vi } from 'vitest';
+
+import * as shared from '@nangohq/shared';
+import { basePublicUrl } from '@nangohq/utils';
+
+import integrationService from './integration.service.js';
+
+import type { Config } from '@nangohq/shared';
+import type { Provider } from '@nangohq/types';
+
+const createdAt = new Date('2026-01-01T00:00:00.000Z');
+const updatedAt = new Date('2026-01-02T00:00:00.000Z');
+
+describe('integrationService', () => {
+    afterEach(() => {
+        vi.restoreAllMocks();
+    });
+
+    it('lists and formats integrations for an environment', async () => {
+        vi.spyOn(shared.configService, 'listProviderConfigs').mockResolvedValue([
+            integrationFixture({ uniqueKey: 'github', provider: 'github' }),
+            integrationFixture({ uniqueKey: 'slack', provider: 'slack' })
+        ]);
+        vi.spyOn(shared, 'getProviders').mockReturnValue({
+            github: providerFixture('GitHub'),
+            slack: providerFixture('Slack')
+        });
+
+        const result = await integrationService.list({ environmentId: 42 });
+
+        expect(result.isOk()).toBe(true);
+        if (result.isOk()) {
+            expect(result.value).toStrictEqual({
+                data: [
+                    publicIntegrationFixture({ uniqueKey: 'github', provider: 'github', displayName: 'GitHub' }),
+                    publicIntegrationFixture({ uniqueKey: 'slack', provider: 'slack', displayName: 'Slack' })
+                ]
+            });
+        }
+    });
+
+    it('filters integrations to those allowed by a Connect Session', async () => {
+        vi.spyOn(shared.configService, 'listProviderConfigs').mockResolvedValue([
+            integrationFixture({ uniqueKey: 'github', provider: 'github' }),
+            integrationFixture({ uniqueKey: 'slack', provider: 'slack' })
+        ]);
+        vi.spyOn(shared, 'getProviders').mockReturnValue({
+            github: providerFixture('GitHub'),
+            slack: providerFixture('Slack')
+        });
+
+        const result = await integrationService.list({ environmentId: 42, allowedIntegrations: ['slack'] });
+
+        expect(result.isOk()).toBe(true);
+        if (result.isOk()) {
+            expect(result.value).toStrictEqual({
+                data: [publicIntegrationFixture({ uniqueKey: 'slack', provider: 'slack', displayName: 'Slack' })]
+            });
+        }
+    });
+
+    it('returns an error when providers cannot be loaded', async () => {
+        vi.spyOn(shared.configService, 'listProviderConfigs').mockResolvedValue([]);
+        vi.spyOn(shared, 'getProviders').mockReturnValue(undefined);
+
+        const result = await integrationService.list({ environmentId: 42 });
+
+        expect(result.isErr()).toBe(true);
+        if (result.isErr()) {
+            expect(result.error).toMatchObject({
+                code: 'list_failed',
+                message: 'failed to load providers'
+            });
+        }
+    });
+
+    it('returns an error when an integration references a missing provider', async () => {
+        vi.spyOn(shared.configService, 'listProviderConfigs').mockResolvedValue([integrationFixture({ uniqueKey: 'missing', provider: 'missing' })]);
+        vi.spyOn(shared, 'getProviders').mockReturnValue({});
+
+        const result = await integrationService.list({ environmentId: 42 });
+
+        expect(result.isErr()).toBe(true);
+        if (result.isErr()) {
+            expect(result.error).toMatchObject({
+                code: 'list_failed',
+                message: 'Failed to list integrations',
+                cause: new Error("Provider 'missing' does not exist")
+            });
+        }
+    });
+
+    it('wraps unexpected listing failures as service errors', async () => {
+        const cause = new Error('database failed');
+        vi.spyOn(shared.configService, 'listProviderConfigs').mockRejectedValue(cause);
+
+        const result = await integrationService.list({ environmentId: 42 });
+
+        expect(result.isErr()).toBe(true);
+        if (result.isErr()) {
+            expect(result.error).toMatchObject({
+                code: 'list_failed',
+                message: 'Failed to list integrations',
+                cause
+            });
+        }
+    });
+});
+
+function integrationFixture({ uniqueKey, provider }: { uniqueKey: string; provider: string }): Config {
+    return {
+        unique_key: uniqueKey,
+        provider,
+        oauth_client_id: '',
+        oauth_client_secret: '',
+        environment_id: 42,
+        missing_fields: [],
+        display_name: null,
+        forward_webhooks: true,
+        shared_credentials_id: null,
+        created_at: createdAt,
+        updated_at: updatedAt
+    };
+}
+
+function providerFixture(displayName: string): Provider {
+    return {
+        display_name: displayName,
+        auth_mode: 'OAUTH2',
+        docs: ''
+    };
+}
+
+function publicIntegrationFixture({ uniqueKey, provider, displayName }: { uniqueKey: string; provider: string; displayName: string }) {
+    return {
+        unique_key: uniqueKey,
+        provider,
+        display_name: displayName,
+        logo: `${basePublicUrl}/images/template-logos/${provider}.svg`,
+        forward_webhooks: true,
+        created_at: createdAt.toISOString(),
+        updated_at: updatedAt.toISOString()
+    };
+}

--- a/packages/server/lib/utils/integrations.ts
+++ b/packages/server/lib/utils/integrations.ts
@@ -1,0 +1,9 @@
+import type { IntegrationConfig, Provider } from '@nangohq/types';
+
+export function getPreconfiguredCredentials(custom: IntegrationConfig['custom'], provider: Provider): string[] {
+    if (!custom || provider.auth_mode !== 'TWO_STEP' || !provider.integration_config) {
+        return [];
+    }
+
+    return Object.keys(provider.integration_config).filter((field) => Boolean(custom[field]));
+}


### PR DESCRIPTION
Adds an `integrations_list` Management MCP tool scoped to `environment:integrations:list`.
Extracts the existing `GET /integrations` database lookup, Connect Session filtering, and response formatting into a shared `IntegrationService` used by both HTTP and MCP.
Documents the tool and adds response and scope-enforcement coverage.

NAN-6294: https://linear.app/nango/issue/NAN-6294/tool-for-get-integrations


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/NangoHQ/nango/pull/6977?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

