### PR TITLE
refactor(audit): one emit tail for every audit path, and count what it drops (NAN-6471)

### DIFF
--- a/packages/server/lib/middleware/audit.middleware.ts
+++ b/packages/server/lib/middleware/audit.middleware.ts
@@ -178,7 +178,30 @@ async function resolveDisplay(target: AuditTargetType, lookup: () => Promise<str
     }
 }
 
-async function emit(
+type AuditEmitSource = 'auditable' | 'auth' | 'mfa_verified' | 'sync_command';
+
+// Takes a builder rather than a built event so a failure while building counts as a drop too. A
+// caller's own catch covers only the lookups deciding whether to record at all, which are not drops.
+export async function recordEvent(build: () => AuditEvent, source: AuditEmitSource): Promise<void> {
+    let dropped = true;
+    try {
+        const event = build();
+        const result = await audit.record(event);
+        if (result.isErr()) {
+            logger.error(`failed to record ${event.resource}/${event.action} audit event (${source})`, result.error);
+            return;
+        }
+        dropped = false;
+    } catch (err) {
+        logger.error(`failed to emit audit event (${source})`, err);
+    } finally {
+        if (dropped) {
+            metrics.increment(metrics.Types.AUDIT_EMIT_DROPPED, 1, { source });
+        }
+    }
+}
+
+function emit(
     policy: AuditPolicy,
     req: Request,
     res: Response,
@@ -188,11 +211,11 @@ async function emit(
 ): Promise<void> {
     // Stamp occurredAt now so it reflects the response time, not audit-write latency.
     const occurredAt = new Date().toISOString();
-    try {
+    return recordEvent(() => {
         const locals = res.locals as RequestLocals;
         const target = resolved?.target;
         const metadata = resolved?.metadata;
-        const event = {
+        return {
             occurredAt,
             accountId: account.id,
             environment: policy.scope === 'account' || !environment ? null : { id: environment.id, display: environment.name },
@@ -204,13 +227,7 @@ async function emit(
             outcome: outcomeFromStatus(res.statusCode),
             ...(metadata ? { metadata } : {})
         } as AuditEvent;
-        const result = await audit.record(event);
-        if (result.isErr()) {
-            logger.error(`failed to record audit event`, result.error);
-        }
-    } catch (err) {
-        logger.error(`failed to emit audit event`, err);
-    }
+    }, 'auditable');
 }
 
 interface ResolvedAudit {
@@ -271,7 +288,9 @@ export function auditable<TEndpoint extends AuditableEndpoint>(spec: AuditSpec<T
                     };
                 }
             } catch (err) {
+                // spec.account reads the database before the gate, so a throw here loses the event outright.
                 logger.error(`failed to resolve audit target`, err);
+                metrics.increment(metrics.Types.AUDIT_EMIT_DROPPED, 1, { source: 'auditable' });
             } finally {
                 next();
             }
@@ -802,24 +821,23 @@ async function emitMfaVerified(req: Request, res: Response, pendingUserId: numbe
         if (!(await getFlags().isAuditTrailEnabled(account.uuid))) {
             return;
         }
-        const bodyType = (req.body as Partial<PostMFALoginVerification['Body']>)?.type;
-        const method: MfaVerifiedMetadata['method'] | undefined = bodyType && Object.hasOwn(METHOD_BY_TYPE, bodyType) ? METHOD_BY_TYPE[bodyType] : undefined;
-        const event: AuditEvent = {
-            occurredAt,
-            accountId: account.id,
-            environment: null,
-            actor: { type: 'user', id: String(user.id), display: user.email },
-            resource: mfaVerifiedPolicy.resource,
-            action: mfaVerifiedPolicy.action,
-            targets: [{ type: 'user', id: String(user.id), display: user.email }],
-            context: contextFromRequest(req),
-            outcome: outcomeFromStatus(res.statusCode),
-            ...(method ? { metadata: { method } } : {})
-        };
-        const result = await audit.record(event);
-        if (result.isErr()) {
-            logger.error(`failed to record audit event`, result.error);
-        }
+        await recordEvent(() => {
+            const bodyType = (req.body as Partial<PostMFALoginVerification['Body']>)?.type;
+            const method: MfaVerifiedMetadata['method'] | undefined =
+                bodyType && Object.hasOwn(METHOD_BY_TYPE, bodyType) ? METHOD_BY_TYPE[bodyType] : undefined;
+            return {
+                occurredAt,
+                accountId: account.id,
+                environment: null,
+                actor: { type: 'user', id: String(user.id), display: user.email },
+                resource: mfaVerifiedPolicy.resource,
+                action: mfaVerifiedPolicy.action,
+                targets: [{ type: 'user', id: String(user.id), display: user.email }],
+                context: contextFromRequest(req),
+                outcome: outcomeFromStatus(res.statusCode),
+                ...(method ? { metadata: { method } } : {})
+            };
+        }, 'mfa_verified');
     } catch (err) {
         logger.error(`failed to emit mfa verify audit event`, err);
     }

--- a/packages/server/lib/middleware/audit.middleware.ts
+++ b/packages/server/lib/middleware/audit.middleware.ts
@@ -180,8 +180,9 @@ async function resolveDisplay(target: AuditTargetType, lookup: () => Promise<str
 
 type AuditEmitSource = 'auditable' | 'auth' | 'mfa_verified' | 'sync_command';
 
-// Takes a builder rather than a built event so a failure while building counts as a drop too. A
-// caller's own catch covers only the lookups deciding whether to record at all, which are not drops.
+// emit() serves only auditable(); the auth, MFA-verify and sync-command middlewares build and record
+// their own events, so this is the single point they share and the only place a drop can be counted
+// once. Takes a builder rather than a built event so a failure while building counts as a drop too.
 export async function recordEvent(build: () => AuditEvent, source: AuditEmitSource): Promise<void> {
     let dropped = true;
     try {
@@ -240,6 +241,7 @@ interface ResolvedAudit {
 export function auditable<TEndpoint extends AuditableEndpoint>(spec: AuditSpec<TEndpoint>): RequestHandler {
     return (req, res, next) => {
         void (async () => {
+            let willEmit = false;
             try {
                 const locals = res.locals as RequestLocals;
                 // Resolve the audited account before the flag gate: a spec may attribute the event to an
@@ -262,6 +264,7 @@ export function auditable<TEndpoint extends AuditableEndpoint>(spec: AuditSpec<T
                     // never installs a dead listener. It reads `resolved` lazily at finish, so it captures
                     // whatever we managed to resolve (even nothing, if resolution threw).
                     let resolved: ResolvedAudit | undefined;
+                    willEmit = true;
                     res.on('finish', () => {
                         void (async () => {
                             if (
@@ -288,9 +291,12 @@ export function auditable<TEndpoint extends AuditableEndpoint>(spec: AuditSpec<T
                     };
                 }
             } catch (err) {
-                // spec.account reads the database before the gate, so a throw here loses the event outright.
                 logger.error(`failed to resolve audit target`, err);
-                metrics.increment(metrics.Types.AUDIT_EMIT_DROPPED, 1, { source: 'auditable' });
+                // Nothing emits until the finish listener is registered, so a throw before that loses the
+                // event; after it the event still emits, without whatever failed to resolve, which is not.
+                if (!willEmit) {
+                    metrics.increment(metrics.Types.AUDIT_EMIT_DROPPED, 1, { source: 'auditable' });
+                }
             } finally {
                 next();
             }

--- a/packages/server/lib/middleware/auditAuth.middleware.ts
+++ b/packages/server/lib/middleware/auditAuth.middleware.ts
@@ -5,10 +5,9 @@ import { getFlags } from '@nangohq/feature-flags';
 import { accountService, userService } from '@nangohq/shared';
 import { getLogger } from '@nangohq/utils';
 
-import { audit } from '../audit.js';
-import { contextFromRequest, outcomeFromStatus } from './audit.middleware.js';
+import { contextFromRequest, outcomeFromStatus, recordEvent } from './audit.middleware.js';
 
-import type { AppAuthLoginMethod, AuditActor, AuditEvent, AuditOutcome } from '@nangohq/audit';
+import type { AppAuthLoginMethod, AuditActor, AuditOutcome } from '@nangohq/audit';
 import type {
     DBTeam,
     DBUser,
@@ -117,23 +116,23 @@ async function recordAuthEvent<TEndpoint extends Endpoint<any>>(
         if (!(await getFlags().isAuditTrailEnabled(principal.account.uuid))) {
             return;
         }
-        const ref = { type: 'user' as const, id: String(principal.userId), display: principal.userEmail };
-        // A non-success attempt never authenticated as the claimed email — the actor is anonymous, and the
-        // (untrusted) email is only the target it was aimed at (never the actor).
-        const actor: AuditActor = outcome === 'success' ? ref : { type: 'anonymous', id: 'unknown', display: 'anonymous' };
-        const common = {
-            occurredAt,
-            accountId: principal.account.id,
-            environment: null,
-            actor,
-            targets: [ref],
-            context: contextFromRequest(req),
-            outcome
-        };
-        // Read MFA state from the session (not the response body) so we don't wrap res.json: a login
-        // that started an MFA challenge leaves req.session.pendingMfaLogin set at finish.
-        const event: AuditEvent =
-            action === 'login'
+        await recordEvent(() => {
+            const ref = { type: 'user' as const, id: String(principal.userId), display: principal.userEmail };
+            // A non-success attempt never authenticated as the claimed email — the actor is anonymous, and
+            // the (untrusted) email is only the target it was aimed at (never the actor).
+            const actor: AuditActor = outcome === 'success' ? ref : { type: 'anonymous', id: 'unknown', display: 'anonymous' };
+            const common = {
+                occurredAt,
+                accountId: principal.account.id,
+                environment: null,
+                actor,
+                targets: [ref],
+                context: contextFromRequest(req),
+                outcome
+            };
+            // Read MFA state from the session (not the response body) so we don't wrap res.json: a login
+            // that started an MFA challenge leaves req.session.pendingMfaLogin set at finish.
+            return action === 'login'
                 ? {
                       ...common,
                       resource: 'app_auth',
@@ -141,10 +140,7 @@ async function recordAuthEvent<TEndpoint extends Endpoint<any>>(
                       metadata: { mfaRequired: Boolean(req.session.pendingMfaLogin), ...(options.method ? { method: options.method } : {}) }
                   }
                 : { ...common, resource: 'app_auth', action };
-        const result = await audit.record(event);
-        if (result.isErr()) {
-            logger.error(`failed to record ${action} audit event`, result.error);
-        }
+        }, 'auth');
     } catch (err) {
         logger.error('failed to emit auth audit event', err);
     }

--- a/packages/server/lib/middleware/auditSyncCommand.middleware.ts
+++ b/packages/server/lib/middleware/auditSyncCommand.middleware.ts
@@ -2,8 +2,7 @@ import { getFlags } from '@nangohq/feature-flags';
 import { SyncCommand } from '@nangohq/shared';
 import { getLogger } from '@nangohq/utils';
 
-import { audit } from '../audit.js';
-import { contextFromRequest, outcomeFromStatus, resolveActor } from './audit.middleware.js';
+import { contextFromRequest, outcomeFromStatus, recordEvent, resolveActor } from './audit.middleware.js';
 
 import type { RequestLocals } from '../utils/express.js';
 import type { AuditEvent, AuditTarget, SyncTriggeredMetadata } from '@nangohq/audit';
@@ -83,23 +82,21 @@ async function emit(req: Request, res: Response): Promise<void> {
         if (!account || !(await getFlags().isAuditTrailEnabled(account.uuid))) {
             return;
         }
-        const target = syncTarget(body);
-        const event = {
-            occurredAt,
-            accountId: account.id,
-            environment: environment ? { id: environment.id, display: environment.name } : null,
-            actor: resolveActor(locals),
-            resource: 'sync',
-            action: mapped.action,
-            targets: target ? [target] : [],
-            context: contextFromRequest(req),
-            outcome: outcomeFromStatus(res.statusCode),
-            ...('metadata' in mapped ? { metadata: mapped.metadata } : {})
-        } as AuditEvent;
-        const result = await audit.record(event);
-        if (result.isErr()) {
-            logger.error(`failed to record audit event`, result.error);
-        }
+        await recordEvent(() => {
+            const target = syncTarget(body);
+            return {
+                occurredAt,
+                accountId: account.id,
+                environment: environment ? { id: environment.id, display: environment.name } : null,
+                actor: resolveActor(locals),
+                resource: 'sync',
+                action: mapped.action,
+                targets: target ? [target] : [],
+                context: contextFromRequest(req),
+                outcome: outcomeFromStatus(res.statusCode),
+                ...('metadata' in mapped ? { metadata: mapped.metadata } : {})
+            } as AuditEvent;
+        }, 'sync_command');
     } catch (err) {
         logger.error(`failed to emit audit event`, err);
     }

--- a/packages/server/lib/middleware/auditable.unit.test.ts
+++ b/packages/server/lib/middleware/auditable.unit.test.ts
@@ -3,8 +3,10 @@ import { EventEmitter } from 'node:events';
 import { beforeEach, describe, expect, it, vi } from 'vitest';
 
 import * as featureFlags from '@nangohq/feature-flags';
+import { metrics } from '@nangohq/utils';
 
 import {
+    auditable,
     auditConnectionCreated,
     auditConnectionUpdated,
     auditEnvironmentVariablesChanged,
@@ -86,6 +88,8 @@ async function runAudit(handler: RequestHandler, req: any, res: any) {
 
 describe('auditable() middleware behavior (unit)', () => {
     beforeEach(() => {
+        // The metrics spy persists across tests; without clearing, negative assertions depend on order.
+        vi.clearAllMocks();
         recordMock.mockReset().mockResolvedValue({ isErr: () => false });
         // getFlags() returns the stable noop facade in tests; force the audit trail on.
         vi.spyOn(featureFlags.getFlags(), 'isAuditTrailEnabled').mockResolvedValue(true);
@@ -457,6 +461,41 @@ describe('auditable() lifecycle specs (unit)', () => {
             environment: { id: 9, display: 'dev' },
             targets: [{ type: 'function', id: 'my-prebuilt-sync' }],
             metadata: { providerConfigKey: 'algolia', type: 'sync' }
+        });
+    });
+
+    describe('a failure before the event can be emitted', () => {
+        const dropped = [metrics.Types.AUDIT_EMIT_DROPPED, 1, { source: 'auditable' }] as const;
+
+        it('is not counted when resolution fails after the listener is registered — the event still emits', async () => {
+            const inc = vi.spyOn(metrics, 'increment').mockImplementation(() => undefined);
+            const handler = auditable({
+                policy: { resource: 'environment', action: 'variables_changed', scope: 'environment' },
+                target: () => {
+                    throw new Error('resolver exploded');
+                }
+            } as any);
+            const res = fakeRes(locals);
+
+            await new Promise<void>((resolve) => handler(fakeReq(), res, () => resolve()));
+            res.emit('finish');
+
+            await vi.waitFor(() => expect(recordMock).toHaveBeenCalled());
+            expect(inc).not.toHaveBeenCalledWith(...dropped);
+            expect(recordMock.mock.calls[0]?.[0]).toMatchObject({ accountId: 42, outcome: 'success', targets: [] });
+        });
+
+        it('is counted when the gate fails before the listener is registered — nothing emits', async () => {
+            const inc = vi.spyOn(metrics, 'increment').mockImplementation(() => undefined);
+            vi.spyOn(featureFlags.getFlags(), 'isAuditTrailEnabled').mockRejectedValue(new Error('unleash unreachable'));
+            const res = fakeRes(locals);
+
+            await new Promise<void>((resolve) => auditEnvironmentVariablesChanged(fakeReq(), res, () => resolve()));
+            res.emit('finish');
+            await new Promise((resolve) => setImmediate(resolve));
+
+            expect(inc).toHaveBeenCalledWith(...dropped);
+            expect(recordMock).not.toHaveBeenCalled();
         });
     });
 });

--- a/packages/server/lib/middleware/recordEvent.unit.test.ts
+++ b/packages/server/lib/middleware/recordEvent.unit.test.ts
@@ -1,0 +1,90 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+import { Err, metrics, Ok } from '@nangohq/utils';
+
+import { recordEvent } from './audit.middleware.js';
+
+import type { AuditEvent } from '@nangohq/audit';
+
+const recordMock = vi.hoisted(() => vi.fn());
+vi.mock('../audit.js', () => ({ audit: { record: recordMock } }));
+
+const event: AuditEvent = {
+    occurredAt: '2026-07-31T10:00:00.000Z',
+    accountId: 42,
+    environment: null,
+    actor: { type: 'user', id: '7', display: 'dev@example.com' },
+    resource: 'connection',
+    action: 'deleted',
+    targets: [{ type: 'connection', id: '10' }],
+    context: {},
+    outcome: 'success'
+};
+
+const dropped = (source: string) => [metrics.Types.AUDIT_EMIT_DROPPED, 1, { source }];
+
+describe('recordEvent — every way an event fails to reach the store is counted once', () => {
+    beforeEach(() => {
+        // The metrics spy persists across tests; without clearing, negative assertions depend on order.
+        vi.clearAllMocks();
+        recordMock.mockReset().mockResolvedValue(Ok(undefined));
+    });
+
+    it('does not count an event the writer accepted', async () => {
+        const inc = vi.spyOn(metrics, 'increment').mockImplementation(() => undefined);
+
+        await recordEvent(() => event, 'auditable');
+
+        expect(recordMock).toHaveBeenCalledWith(event);
+        expect(inc).not.toHaveBeenCalledWith(...dropped('auditable'));
+    });
+
+    it('counts a writer that returns an error — the write or publish failed, so the event is gone', async () => {
+        const inc = vi.spyOn(metrics, 'increment').mockImplementation(() => undefined);
+        recordMock.mockResolvedValue(Err(new Error('clickhouse down')));
+
+        await recordEvent(() => event, 'auditable');
+
+        expect(inc).toHaveBeenCalledWith(...dropped('auditable'));
+    });
+
+    it('counts a writer that throws', async () => {
+        const inc = vi.spyOn(metrics, 'increment').mockImplementation(() => undefined);
+        recordMock.mockRejectedValue(new Error('boom'));
+
+        await recordEvent(() => event, 'auditable');
+
+        expect(inc).toHaveBeenCalledWith(...dropped('auditable'));
+    });
+
+    it('counts a builder that throws, and never reaches the writer', async () => {
+        const inc = vi.spyOn(metrics, 'increment').mockImplementation(() => undefined);
+
+        await recordEvent(() => {
+            throw new Error('could not build the event');
+        }, 'auditable');
+
+        expect(inc).toHaveBeenCalledWith(...dropped('auditable'));
+        expect(recordMock).not.toHaveBeenCalled();
+    });
+
+    it('reports the calling path as the source', async () => {
+        const inc = vi.spyOn(metrics, 'increment').mockImplementation(() => undefined);
+        recordMock.mockResolvedValue(Err(new Error('clickhouse down')));
+
+        await recordEvent(() => event, 'auth');
+        await recordEvent(() => event, 'mfa_verified');
+        await recordEvent(() => event, 'sync_command');
+
+        expect(inc).toHaveBeenCalledWith(...dropped('auth'));
+        expect(inc).toHaveBeenCalledWith(...dropped('mfa_verified'));
+        expect(inc).toHaveBeenCalledWith(...dropped('sync_command'));
+    });
+
+    it('never throws, so a failure cannot escape into the response finish handler', async () => {
+        vi.spyOn(metrics, 'increment').mockImplementation(() => undefined);
+        recordMock.mockRejectedValue(new Error('boom'));
+
+        await expect(recordEvent(() => event, 'auditable')).resolves.toBeUndefined();
+    });
+});

--- a/packages/utils/lib/telemetry/metrics.ts
+++ b/packages/utils/lib/telemetry/metrics.ts
@@ -160,6 +160,7 @@ export enum Types {
     AUTH_CALLBACK_STATE_COOKIE = 'nango.server.auth.callback.state_cookie',
 
     AUDIT_TARGET_DISPLAY_RESOLUTION_FAILED = 'nango.audit.target.display_resolution_failed',
+    AUDIT_EMIT_DROPPED = 'nango.audit.emit.dropped',
     AUDIT_CLICKHOUSE_INGEST_RESULT = 'nango.audit.clickhouse.ingest.result',
     AUDIT_CONSUMER_BATCH_SIZE = 'nango.audit.consumer.batch.size',
     AUDIT_CONSUMER_REJECTED = 'nango.audit.consumer.rejected',


### PR DESCRIPTION
- **Every audit path now reaches the store through one function.** Four middlewares each carried their own copy of the same tail — record the event, log a failed write, swallow anything thrown. `recordEvent` replaces all four, so `audit.record` is called from exactly one place in the server.
- **`nango.audit.emit.dropped` counts every way the server fails to hand an event off**, tagged by which path lost it: `auditable`, `auth`, `mfa_verified`, `sync_command`. These failures were previously log-only, so an event we meant to record could vanish with no metric at all. It deliberately overlaps the writer's own metrics — `ingest.result{success:false}` and `pubsub.publish{success:false}` say *why* an event was lost, this one says *that* it was, and stays meaningful when an environment switches transport.

## Why it takes a builder

`recordEvent(build, source)` receives a function rather than a finished event, which puts construction inside the same guard as the write. That matters for where the boundary falls: a malformed event is a loss and gets counted, while each caller's own `catch` is left covering only the lookups that decide *whether* to record — a missing pending MFA challenge, an email that maps to no user, an unrecognised sync command, a non-audited account. Those are skips, and counting them would have fired the metric on ordinary traffic.

One exception sits outside that split: a throw in `auditable()`'s resolver block is counted, because `spec.account` reads the database before the flag gate and a throw there means the finish listener is never registered, so nothing is emitted at all.

## Test plan

- [x] `ts-build`, `npm run lint` (exit 0), prettier clean
- [x] New unit suite for the shared tail: a writer that errors, a writer that throws, a builder that throws, a successful write, all four sources, and that it never throws into the finish handler
- [x] Verified non-vacuous — never arming the flag reds four of the six
- [x] Existing audit suites unchanged and passing: 37 unit, 26 integration across the mutation, auth, MFA and sync-command paths
- [ ] After deploy: confirm the counter reports, and set a threshold — audit volume is low enough that any non-zero value is worth looking at

Draft until reviewed together with the parked #6963, which this supersedes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/NangoHQ/nango/pull/6980?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

