### PR TITLE
refactor(audit): derive the audit event vocabulary from one table

### DIFF
--- a/packages/audit/lib/event.ts
+++ b/packages/audit/lib/event.ts
@@ -1,11 +1,12 @@
 // `id` and `version` are stamped at the emit boundary, not by the caller.
 
-import type { AuditActor, AuditContext, AuditOutcome, AuditTarget, AuditTrailVersion } from '@nangohq/types';
+import type { AuditActor, AuditContext, AuditEventKey, AuditOutcome, AuditTarget, AuditTrailVersion } from '@nangohq/types';
 
 export type {
     AuditActor,
     AuditActorType,
     AuditContext,
+    AuditEventKey,
     AuditOutcome,
     AuditTarget,
     AuditTargetType,
@@ -151,6 +152,14 @@ export type AuditResourceAction =
     | { resource: 'app_auth'; action: 'password_changed' | 'logout' | 'signup' | 'password_reset' }
     | { resource: 'mfa'; action: 'enrolled' | 'enabled' | 'disabled' | 'recovery_regenerated' }
     | { resource: 'mfa'; action: 'verified'; metadata?: MfaVerifiedMetadata };
+
+type EmittedKey<T extends { resource: string; action: string }> = T extends unknown ? `${T['resource']}.${T['action']}` : never;
+
+type EmittedButNotInVocabulary = Exclude<EmittedKey<AuditResourceAction>, AuditEventKey>;
+type InVocabularyButNotEmitted = Exclude<AuditEventKey, EmittedKey<AuditResourceAction>>;
+
+true satisfies [EmittedButNotInVocabulary] extends [never] ? true : never;
+true satisfies [InVocabularyButNotEmitted] extends [never] ? true : never;
 
 export type AuditEvent = AuditEventCommon & AuditResourceAction;
 

--- a/packages/audit/lib/event.ts
+++ b/packages/audit/lib/event.ts
@@ -158,8 +158,7 @@ type EmittedKey<T extends { resource: string; action: string }> = T extends unkn
 type EmittedButNotInVocabulary = Exclude<EmittedKey<AuditResourceAction>, AuditEventKey>;
 type InVocabularyButNotEmitted = Exclude<AuditEventKey, EmittedKey<AuditResourceAction>>;
 
-true satisfies [EmittedButNotInVocabulary] extends [never] ? true : never;
-true satisfies [InVocabularyButNotEmitted] extends [never] ? true : never;
+true satisfies [EmittedButNotInVocabulary, InVocabularyButNotEmitted] extends [never, never] ? true : never;
 
 export type AuditEvent = AuditEventCommon & AuditResourceAction;
 

--- a/packages/server/lib/middleware/audit.middleware.ts
+++ b/packages/server/lib/middleware/audit.middleware.ts
@@ -9,7 +9,7 @@ import type { RequestLocals } from '../utils/express.js';
 import type { AuditActor, AuditContext, AuditEvent, AuditOutcome, AuditTarget, AuditTargetType, MfaVerifiedMetadata } from '@nangohq/audit';
 import type {
     AcceptInvite,
-    AuditAction,
+    AuditActionOf,
     AuditPolicy,
     AuditResource,
     AuditScope,
@@ -80,7 +80,11 @@ type AuditRequest<TEndpoint extends Endpoint<any>> = Request<TEndpoint['Params']
 type AuditableEndpoint = Endpoint<any> & { Audit: AuditPolicy };
 
 const Audit = {
-    auditable: <R extends AuditResource, A extends AuditAction, S extends AuditScope>(policy: { resource: R; action: A; scope: S }): AuditPolicy<R, A, S> => ({
+    auditable: <R extends AuditResource, A extends AuditActionOf<R>, S extends AuditScope>(policy: {
+        resource: R;
+        action: A;
+        scope: S;
+    }): AuditPolicy<R, A, S> => ({
         kind: 'audit',
         ...policy
     })

--- a/packages/types/lib/audit-trail/event.ts
+++ b/packages/types/lib/audit-trail/event.ts
@@ -4,8 +4,8 @@ export type AuditTrailVersion = '2026-07-16';
 export type AuditActorType = 'user' | 'api_key' | 'system' | 'anonymous';
 export type AuditOutcome = 'success' | 'failure' | 'denied';
 
-// Not exported: this package emits no JavaScript, so a const here is unusable at runtime. Code needing
-// the list at runtime keeps a twin checked against `AuditEventKey`, as `apiKeyScopes` does for scopes.
+// Not exported: this package emits no JavaScript, so a const here is unusable at runtime — code needing
+// the list keeps a twin checked against `AuditEventKey`, as `apiKeyScopes` does for scopes.
 const AUDIT_EVENTS = {
     connection: ['created', 'updated', 'metadata_updated', 'refreshed', 'deleted'],
     sync: ['enabled', 'disabled', 'paused', 'started', 'triggered', 'cancelled', 'frequency_changed', 'variant_created', 'variant_deleted'],
@@ -22,10 +22,10 @@ const AUDIT_EVENTS = {
 } as const;
 
 export type AuditResource = keyof typeof AUDIT_EVENTS;
-export type AuditAction = (typeof AUDIT_EVENTS)[AuditResource][number];
 export type AuditActionOf<R extends AuditResource> = (typeof AUDIT_EVENTS)[R][number];
+export type AuditAction = AuditActionOf<AuditResource>;
 
-export type AuditEventKey = { [R in AuditResource]: `${R}.${(typeof AUDIT_EVENTS)[R][number]}` }[AuditResource];
+export type AuditEventKey = { [R in AuditResource]: `${R}.${AuditActionOf<R>}` }[AuditResource];
 
 export type AuditScope = 'account' | 'environment';
 

--- a/packages/types/lib/audit-trail/event.ts
+++ b/packages/types/lib/audit-trail/event.ts
@@ -4,28 +4,26 @@ export type AuditTrailVersion = '2026-07-16';
 export type AuditActorType = 'user' | 'api_key' | 'system' | 'anonymous';
 export type AuditOutcome = 'success' | 'failure' | 'denied';
 
-// Not exported: this package emits no JavaScript, so a const here is unusable at runtime — code needing
-// the list keeps a twin checked against `AuditEventKey`, as `apiKeyScopes` does for scopes.
-const AUDIT_EVENTS = {
-    connection: ['created', 'updated', 'metadata_updated', 'refreshed', 'deleted'],
-    sync: ['enabled', 'disabled', 'paused', 'started', 'triggered', 'cancelled', 'frequency_changed', 'variant_created', 'variant_deleted'],
-    function: ['deployed', 'upgraded', 'deleted'],
-    integration: ['created', 'updated', 'deleted'],
-    api_key: ['created', 'updated', 'deleted'],
-    member: ['invited', 'invite_accepted', 'invite_declined', 'invite_revoked', 'role_changed', 'removed'],
-    team: ['updated'],
-    user: ['updated'],
-    environment: ['created', 'updated', 'variables_changed', 'webhook_urls_changed', 'deleted'],
-    app_auth: ['login', 'logout', 'signup', 'password_changed', 'password_reset'],
-    mfa: ['enrolled', 'enabled', 'disabled', 'verified', 'recovery_regenerated'],
-    billing: ['plan_changed', 'trial_extended', 'details_changed', 'payment_method_added', 'payment_method_removed']
-} as const;
+interface AuditEventTable {
+    connection: 'created' | 'updated' | 'metadata_updated' | 'refreshed' | 'deleted';
+    sync: 'enabled' | 'disabled' | 'paused' | 'started' | 'triggered' | 'cancelled' | 'frequency_changed' | 'variant_created' | 'variant_deleted';
+    function: 'deployed' | 'upgraded' | 'deleted';
+    integration: 'created' | 'updated' | 'deleted';
+    api_key: 'created' | 'updated' | 'deleted';
+    member: 'invited' | 'invite_accepted' | 'invite_declined' | 'invite_revoked' | 'role_changed' | 'removed';
+    team: 'updated';
+    user: 'updated';
+    environment: 'created' | 'updated' | 'variables_changed' | 'webhook_urls_changed' | 'deleted';
+    app_auth: 'login' | 'logout' | 'signup' | 'password_changed' | 'password_reset';
+    mfa: 'enrolled' | 'enabled' | 'disabled' | 'verified' | 'recovery_regenerated';
+    billing: 'plan_changed' | 'trial_extended' | 'details_changed' | 'payment_method_added' | 'payment_method_removed';
+}
 
-export type AuditResource = keyof typeof AUDIT_EVENTS;
-export type AuditActionOf<R extends AuditResource> = (typeof AUDIT_EVENTS)[R][number];
+export type AuditResource = keyof AuditEventTable;
+export type AuditActionOf<R extends AuditResource> = AuditEventTable[R];
 export type AuditAction = AuditActionOf<AuditResource>;
 
-export type AuditEventKey = { [R in AuditResource]: `${R}.${AuditActionOf<R>}` }[AuditResource];
+export type AuditEventKey = { [R in AuditResource]: `${R}.${AuditEventTable[R]}` }[AuditResource];
 
 export type AuditScope = 'account' | 'environment';
 

--- a/packages/types/lib/audit-trail/event.ts
+++ b/packages/types/lib/audit-trail/event.ts
@@ -4,61 +4,28 @@ export type AuditTrailVersion = '2026-07-16';
 export type AuditActorType = 'user' | 'api_key' | 'system' | 'anonymous';
 export type AuditOutcome = 'success' | 'failure' | 'denied';
 
-export type AuditResource =
-    | 'connection'
-    | 'sync'
-    | 'function'
-    | 'integration'
-    | 'api_key'
-    | 'member'
-    | 'team'
-    | 'user'
-    | 'environment'
-    | 'app_auth'
-    | 'mfa'
-    | 'billing'
-    | 'audit_log';
+// Not exported: this package emits no JavaScript, so a const here is unusable at runtime. Code needing
+// the list at runtime keeps a twin checked against `AuditEventKey`, as `apiKeyScopes` does for scopes.
+const AUDIT_EVENTS = {
+    connection: ['created', 'updated', 'metadata_updated', 'refreshed', 'deleted'],
+    sync: ['enabled', 'disabled', 'paused', 'started', 'triggered', 'cancelled', 'frequency_changed', 'variant_created', 'variant_deleted'],
+    function: ['deployed', 'upgraded', 'deleted'],
+    integration: ['created', 'updated', 'deleted'],
+    api_key: ['created', 'updated', 'deleted'],
+    member: ['invited', 'invite_accepted', 'invite_declined', 'invite_revoked', 'role_changed', 'removed'],
+    team: ['updated'],
+    user: ['updated'],
+    environment: ['created', 'updated', 'variables_changed', 'webhook_urls_changed', 'deleted'],
+    app_auth: ['login', 'logout', 'signup', 'password_changed', 'password_reset'],
+    mfa: ['enrolled', 'enabled', 'disabled', 'verified', 'recovery_regenerated'],
+    billing: ['plan_changed', 'trial_extended', 'details_changed', 'payment_method_added', 'payment_method_removed']
+} as const;
 
-export type AuditAction =
-    | 'created'
-    | 'reauthorized'
-    | 'refreshed'
-    | 'updated'
-    | 'metadata_updated'
-    | 'deleted'
-    | 'paused'
-    | 'started'
-    | 'cancelled'
-    | 'enabled'
-    | 'disabled'
-    | 'frequency_changed'
-    | 'triggered'
-    | 'variant_created'
-    | 'variant_deleted'
-    | 'upgraded'
-    | 'deployed'
-    | 'invited'
-    | 'invite_accepted'
-    | 'invite_declined'
-    | 'invite_revoked'
-    | 'removed'
-    | 'role_changed'
-    | 'variables_changed'
-    | 'webhook_urls_changed'
-    | 'login'
-    | 'logout'
-    | 'signup'
-    | 'password_changed'
-    | 'password_reset'
-    | 'enrolled'
-    | 'recovery_regenerated'
-    | 'verified'
-    | 'plan_changed'
-    | 'trial_extended'
-    | 'details_changed'
-    | 'payment_method_added'
-    | 'payment_method_removed'
-    | 'exported';
+export type AuditResource = keyof typeof AUDIT_EVENTS;
+export type AuditAction = (typeof AUDIT_EVENTS)[AuditResource][number];
+export type AuditActionOf<R extends AuditResource> = (typeof AUDIT_EVENTS)[R][number];
+
+export type AuditEventKey = { [R in AuditResource]: `${R}.${(typeof AUDIT_EVENTS)[R][number]}` }[AuditResource];
 
 export type AuditScope = 'account' | 'environment';
 
@@ -86,7 +53,7 @@ export interface AuditContext {
 // decision — a customer endpoint cannot be added without consciously opting in or out. The policy's
 // resource/action/scope are captured as type parameters so the endpoint's declaration and the
 // middleware spec that services it are checked against each other by the compiler.
-export interface AuditPolicy<R extends AuditResource = AuditResource, A extends AuditAction = AuditAction, S extends AuditScope = AuditScope> {
+export interface AuditPolicy<R extends AuditResource = AuditResource, A extends AuditActionOf<R> = AuditActionOf<R>, S extends AuditScope = AuditScope> {
     kind: 'audit';
     resource: R;
     action: A;


### PR DESCRIPTION
- **The audit event vocabulary is one table instead of two independent unions.** `AuditResource` and `AuditAction` were hand-listed separately, so nothing tied a resource to the actions it records: `team` and `deleted` were each valid, which made `team.deleted` declarable even though no such event exists. Both now derive from a single table of recorded events, along with `AuditEventKey` (`resource.action`) for consumers that need to enumerate the vocabulary.
- **All three places that name an event are checked against that table.** An endpoint's audit policy and the middleware's policy builder each constrain their action by their resource, so an impossible pair fails where it is written. Two assertions tie the emit-side metadata union to the vocabulary in both directions — rejecting an event emitted with no vocabulary entry, and a vocabulary entry nothing emits.
- **Drops `audit_log`, `exported` and `reauthorized`**, none of which any event emits. The table can't express a resource with no actions or an action belonging to no resource, so they go by construction.

Type-only. No runtime behaviour changes.

### Why the table isn't exported

`@nangohq/types` is `emitDeclarationOnly` — it ships declarations and no JavaScript, so an exported const there is visible to the type checker and absent at runtime. The table stays module-local and only its type projections cross the package boundary.

Code that needs the list at runtime keeps a twin checked against `AuditEventKey`. That is what `apiKeyScopes` in `@nangohq/utils` already does for API key scopes: the canonical list lives in `@nangohq/types`, the runtime twin lives in a package that emits JavaScript, and two compile-time assertions keep them in step. This PR adds no twin, because nothing on master consumes the vocabulary at runtime yet.

Constraining the policy's action by its resource follows the correlated-parameter pattern already used by `APIEndpointsPicker` in `packages/types/lib/api.endpoints.ts`, `Extract<Event, { subject: TSubject }>` in `packages/pubsub/lib/publisher.ts`, and the task payload lookup in `packages/tasks/lib/types.ts`.

### The builder was the gap

Narrowing the policy type alone was not enough. `Audit.auditable` declared its action parameter independently of its resource, so it accepted an impossible pair and the mistake only surfaced downstream, where the middleware spec is checked against the endpoint's declaration — which reports an assignability mismatch between two policy types rather than the invalid pair. Constraining the builder makes it fail on the argument itself.

### What this unblocks

#6979 hand-maintains the dashboard's audit filter list against the emit union, which lives in a package the webapp cannot import. Measured against master, that list is missing 14 of the 51 emitted pairs — every lifecycle and authentication event from the coverage PRs that merged after the branch was cut, `app_auth.login` included. `AuditEventKey` lets the list be verified at compile time, so an omission fails the build instead of silently making those events unfilterable.

### Adding an audited event

Still four files: the vocabulary table, the emit union's metadata member, the middleware spec, and the endpoint's policy declaration. This PR doesn't reduce that count — it makes the four checked against each other rather than kept in step by hand.

## Test plan

- [x] `ts-build` clean, zero errors. `packages/webapp` is in `tsconfig.build.json`, so the dashboard is covered
- [x] 25 audit unit tests pass
- [x] prettier and oxlint clean
- [x] Every existing endpoint declaration and all 56 builder call sites already named a valid pair — both constraints compiled with no change to any of them, so the loose constraints were hiding no live bug
- [x] Five deliberate breaks proven red: an action removed from the vocabulary (fails at every endpoint declaration naming it), an event emitted with no vocabulary entry, a vocabulary entry nothing emits, an endpoint declaring `team.deleted`, and the builder called with `team.deleted`
- [ ] #6979 restacked onto this branch, with its filter list checked against `AuditEventKey`