### PR TITLE
feat(audit): filter the audit log by resource, and by resource + action

### DIFF
--- a/packages/audit/lib/audit.ts
+++ b/packages/audit/lib/audit.ts
@@ -66,21 +66,25 @@ export class AuditClient {
 
     /**
      * Account-scoped, most-recent-first. `cursor` is the opaque `nextCursor` of a previous page;
-     * `from`/`to` optionally bound the window and combine with the cursor. Empty when audit isn't wired
-     * to a backend.
+     * `from`/`to` and the resource filters optionally narrow the set and combine with the cursor. Empty
+     * when audit isn't wired to a backend.
      */
     async listAuditTrailEvents({
         accountId,
         limit,
         cursor,
         from,
-        to
+        to,
+        resources,
+        actions
     }: {
         accountId: number;
         limit: number;
         cursor?: string | undefined;
         from?: string | undefined;
         to?: string | undefined;
+        resources?: string[] | undefined;
+        actions?: string[] | undefined;
     }): Promise<Result<{ events: ApiAuditTrailEvent[]; nextCursor: string | null }>> {
         let before: AuditTrailCursor | undefined;
         if (cursor) {
@@ -91,7 +95,7 @@ export class AuditClient {
             before = decoded;
         }
 
-        return (await this.reader.list({ accountId, limit, before, from, to })).map((page) => ({
+        return (await this.reader.list({ accountId, limit, before, from, to, resources, actions })).map((page) => ({
             events: page.events,
             nextCursor: page.nextCursor ? encodeCursor(page.nextCursor) : null
         }));

--- a/packages/audit/lib/migrate.integration.test.ts
+++ b/packages/audit/lib/migrate.integration.test.ts
@@ -41,7 +41,10 @@ describe('audit migrate', () => {
 
         // Exact match: audit runs its own migration set, so none of the usage tables may appear here.
         expect(await tables()).toEqual(['audit_trail_events', 'migrations']);
-        expect(await appliedMigrations()).toEqual([expect.stringMatching(/^20260729000001_create_audit_trail_events\.[jt]s$/)]);
+        expect(await appliedMigrations()).toEqual([
+            expect.stringMatching(/^20260729000001_create_audit_trail_events\.[jt]s$/),
+            expect.stringMatching(/^20260731000001_add_resource_action_search_columns\.[jt]s$/)
+        ]);
     });
 
     it('does not re-apply an already-applied migration', async () => {
@@ -49,7 +52,19 @@ describe('audit migrate', () => {
 
         // Deliberately no FINAL: re-applying inserts a second row for the same name, which FINAL would hide.
         const res = await admin.query({ query: `SELECT count() AS count FROM ${database}.migrations`, format: 'JSONEachRow' });
-        expect(Number((await res.json<{ count: string }>())[0]!.count)).toBe(1);
+        expect(Number((await res.json<{ count: string }>())[0]!.count)).toBe(2);
+    });
+
+    it('creates a set index for each of the resource search columns', async () => {
+        const res = await admin.query({
+            query: `SELECT name, type_full AS type FROM system.data_skipping_indices WHERE database = {db:String} AND table = 'audit_trail_events' ORDER BY name`,
+            format: 'JSONEachRow',
+            query_params: { db: database }
+        });
+        expect(await res.json<{ name: string; type: string }>()).toEqual([
+            { name: 'idx_resource', type: 'set(0)' },
+            { name: 'idx_resource_action', type: 'set(0)' }
+        ]);
     });
 
     it('rejects an event whose accountId is missing, malformed or not a real account id', async () => {

--- a/packages/audit/lib/migrations/20260731000001_add_resource_action_search_columns.ts
+++ b/packages/audit/lib/migrations/20260731000001_add_resource_action_search_columns.ts
@@ -1,0 +1,14 @@
+// Non-throwing extracts, unlike the ORDER BY keys: a blob these can't read is still a storable event.
+// `resource_action` is its own column because two `set` indexes AND-ed prune per column, not per pair.
+export const sql = [
+    `
+    ALTER TABLE {database:Identifier}.audit_trail_events
+        ADD COLUMN IF NOT EXISTS resource        LowCardinality(String) MATERIALIZED JSONExtractString(event, 'resource'),
+        ADD COLUMN IF NOT EXISTS resource_action LowCardinality(String) MATERIALIZED concat(JSONExtractString(event, 'resource'), '.', JSONExtractString(event, 'action'))
+    `,
+    `
+    ALTER TABLE {database:Identifier}.audit_trail_events
+        ADD INDEX IF NOT EXISTS idx_resource        resource        TYPE set(0) GRANULARITY 1,
+        ADD INDEX IF NOT EXISTS idx_resource_action resource_action TYPE set(0) GRANULARITY 1
+    `
+];

--- a/packages/audit/lib/store.integration.test.ts
+++ b/packages/audit/lib/store.integration.test.ts
@@ -18,7 +18,19 @@ let client: ClickHouseClient;
 let store: ClickhouseAuditStore;
 
 // Known ids so the read assertions below are deterministic.
-async function insertEvent({ id, accountId, occurredAt }: { id: string; accountId: number; occurredAt: string }) {
+async function insertEvent({
+    id,
+    accountId,
+    occurredAt,
+    resource = 'connection',
+    action = 'deleted'
+}: {
+    id: string;
+    accountId: number;
+    occurredAt: string;
+    resource?: string;
+    action?: string;
+}) {
     const event = {
         id,
         version: '2026-07-16',
@@ -26,8 +38,8 @@ async function insertEvent({ id, accountId, occurredAt }: { id: string; accountI
         accountId,
         environment: null,
         actor: { type: 'user', id: '5', display: 'a@b.co' },
-        resource: 'connection',
-        action: 'deleted',
+        resource,
+        action,
         targets: [{ type: 'connection', id: '10' }],
         context: {},
         outcome: 'success'
@@ -55,6 +67,12 @@ beforeAll(async () => {
     await insertEvent({ id: '22222222-2222-2222-2222-222222222222', accountId: 1, occurredAt: at(1000) });
     await insertEvent({ id: '33333333-3333-3333-3333-333333333333', accountId: 1, occurredAt: at(2000) });
     await insertEvent({ id: '99999999-9999-9999-9999-999999999999', accountId: 2, occurredAt: at(1500) });
+
+    // account 3: one event per resource/action pair the filter tests select on
+    await insertEvent({ id: 'aaaaaaaa-0000-0000-0000-000000000001', accountId: 3, occurredAt: at(0), resource: 'connection', action: 'deleted' });
+    await insertEvent({ id: 'aaaaaaaa-0000-0000-0000-000000000002', accountId: 3, occurredAt: at(1000), resource: 'connection', action: 'updated' });
+    await insertEvent({ id: 'aaaaaaaa-0000-0000-0000-000000000003', accountId: 3, occurredAt: at(2000), resource: 'api_key', action: 'deleted' });
+    await insertEvent({ id: 'aaaaaaaa-0000-0000-0000-000000000004', accountId: 3, occurredAt: at(3000), resource: 'sync', action: 'enabled' });
 });
 
 afterAll(async () => {
@@ -91,6 +109,56 @@ describe('ClickhouseAuditStore.list', () => {
     it('filters by from/to date', async () => {
         const { events } = (await store.list({ accountId: 1, limit: 10, from: at(1000), to: at(2000) })).unwrap();
         expect(events.map((e) => e.id)).toEqual(['33333333-3333-3333-3333-333333333333', '22222222-2222-2222-2222-222222222222']);
+    });
+});
+
+describe('ClickhouseAuditStore.list resource filters', () => {
+    const resourceActionOf = (events: { resource: string; action: string }[]) => events.map((e) => `${e.resource}.${e.action}`).sort();
+
+    it('filters by resource', async () => {
+        const { events } = (await store.list({ accountId: 3, limit: 10, resources: ['connection'] })).unwrap();
+        expect(resourceActionOf(events)).toEqual(['connection.deleted', 'connection.updated']);
+        expect(events.every((e) => e.accountId === 3)).toBe(true);
+    });
+
+    it('filters by several resources at once', async () => {
+        const { events } = (await store.list({ accountId: 3, limit: 10, resources: ['api_key', 'sync'] })).unwrap();
+        expect(resourceActionOf(events)).toEqual(['api_key.deleted', 'sync.enabled']);
+    });
+
+    it('narrows a resource to a single action', async () => {
+        const { events } = (await store.list({ accountId: 3, limit: 10, resources: ['connection'], actions: ['deleted'] })).unwrap();
+        expect(resourceActionOf(events)).toEqual(['connection.deleted']);
+    });
+
+    // The pairs are the cross product, so an action belonging to another resource must not widen the match.
+    it('matches actions against their own resource only', async () => {
+        const onSync = (await store.list({ accountId: 3, limit: 10, resources: ['sync'], actions: ['enabled'] })).unwrap();
+        expect(resourceActionOf(onSync.events)).toEqual(['sync.enabled']);
+
+        // Same action, a resource that never records it: the pair matches nothing rather than falling
+        // back to either half.
+        const onConnection = (await store.list({ accountId: 3, limit: 10, resources: ['connection'], actions: ['enabled'] })).unwrap();
+        expect(onConnection.events).toHaveLength(0);
+    });
+
+    it('ignores actions given without a resource, since a pair needs both halves', async () => {
+        const { events } = (await store.list({ accountId: 3, limit: 10, actions: ['deleted'] })).unwrap();
+        expect(resourceActionOf(events)).toEqual(['api_key.deleted', 'connection.deleted', 'connection.updated', 'sync.enabled']);
+    });
+
+    it('combines with the date window and paginates', async () => {
+        const page1 = (await store.list({ accountId: 3, limit: 1, resources: ['connection'], from: at(0), to: at(1000) })).unwrap();
+        expect(resourceActionOf(page1.events)).toEqual(['connection.updated']);
+        expect(page1.nextCursor).not.toBeNull();
+
+        const page2 = (await store.list({ accountId: 3, limit: 1, resources: ['connection'], from: at(0), to: at(1000), before: page1.nextCursor! })).unwrap();
+        expect(resourceActionOf(page2.events)).toEqual(['connection.deleted']);
+    });
+
+    it('returns nothing for a resource that was never recorded', async () => {
+        const { events } = (await store.list({ accountId: 3, limit: 10, resources: ['team'] })).unwrap();
+        expect(events).toHaveLength(0);
     });
 });
 

--- a/packages/audit/lib/store.ts
+++ b/packages/audit/lib/store.ts
@@ -24,6 +24,9 @@ export interface ListAuditTrailEventsParams {
     before?: AuditTrailCursor | undefined;
     from?: string | undefined;
     to?: string | undefined;
+    resources?: string[] | undefined;
+    /** Narrows `resources`; ignored on its own, since a match needs both halves of `resource.action`. */
+    actions?: string[] | undefined;
 }
 
 export interface AuditTrailPage {
@@ -94,9 +97,20 @@ export class ClickhouseAuditStore implements AuditWriter, AuditBatchWriter, Audi
         }
     }
 
-    async list({ accountId, limit, before, from, to }: ListAuditTrailEventsParams): Promise<Result<AuditTrailPage>> {
+    async list({ accountId, limit, before, from, to, resources, actions }: ListAuditTrailEventsParams): Promise<Result<AuditTrailPage>> {
         const params: Record<string, unknown> = { account_id: accountId, limit: limit + 1 };
         const conditions = ['account_id = {account_id:Int64}'];
+        if (resources?.length) {
+            if (actions?.length) {
+                // Every requested pair, matched against the materialized concatenation. Two separate
+                // conditions would prune per column and let a granule through on a pair it doesn't hold.
+                conditions.push('resource_action IN {resource_actions:Array(String)}');
+                params['resource_actions'] = resources.flatMap((resource) => actions.map((action) => `${resource}.${action}`));
+            } else {
+                conditions.push('resource IN {resources:Array(String)}');
+                params['resources'] = resources;
+            }
+        }
         if (from) {
             conditions.push('occurred_at >= parseDateTime64BestEffortOrNull({from:String}, 3)');
             params['from'] = from;

--- a/packages/server/lib/controllers/v1/audit-trail/getAuditTrail.integration.test.ts
+++ b/packages/server/lib/controllers/v1/audit-trail/getAuditTrail.integration.test.ts
@@ -5,7 +5,7 @@ import { seeders } from '@nangohq/shared';
 
 import { authenticateUser, isSuccess, runServer } from '../../../utils/tests.js';
 
-import type { AuditEvent } from '@nangohq/audit';
+import type { AuditEvent, AuditResourceAction } from '@nangohq/audit';
 
 let api: Awaited<ReturnType<typeof runServer>>;
 let auditClient: ReturnType<typeof auditClickhouseClient>;
@@ -18,17 +18,16 @@ async function authAdmin() {
     return { session, account, env };
 }
 
-function auditEvent(accountId: number, occurredAt: string): AuditEvent {
+function auditEvent(accountId: number, occurredAt: string, resourceAction: AuditResourceAction = { resource: 'connection', action: 'deleted' }): AuditEvent {
     return {
         occurredAt,
         accountId,
         environment: null,
         actor: { type: 'user', id: '5', display: 'a@b.co' },
-        resource: 'connection',
-        action: 'deleted',
         targets: [{ type: 'connection', id: '10' }],
         context: {},
-        outcome: 'success'
+        outcome: 'success',
+        ...resourceAction
     };
 }
 
@@ -109,6 +108,52 @@ describe('GET /api/v1/audit-trail', () => {
         expect(event.id).toMatch(/^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/);
         expect(event.resource).toBe('connection');
         expect(event.action).toBe('deleted');
+    });
+
+    it('caps how many values one filter param can carry', async () => {
+        const { session } = await authAdmin();
+        const values = (n: number) => Array.from({ length: n }, (_, i) => `resource_${i}`).join(',');
+
+        const atCap = await api.fetch('/api/v1/audit-trail', { method: 'GET', session, query: { resources: values(50) } });
+        expect(atCap.res.status).toBe(200);
+
+        const overCap = await api.fetch('/api/v1/audit-trail', { method: 'GET', session, query: { resources: values(51) } });
+        expect(overCap.res.status).toBe(400);
+    });
+
+    it('rejects `actions` sent without `resources` with 400', async () => {
+        const { session } = await authAdmin();
+        const res = await api.fetch('/api/v1/audit-trail', { method: 'GET', session, query: { actions: 'deleted' } });
+        expect(res.res.status).toBe(400);
+    });
+
+    it('filters by resource, and by a resource narrowed to an action', async () => {
+        const { session, account } = await authAdmin();
+        (await emitter.record(auditEvent(account.id, '2026-07-16T10:00:00.000Z', { resource: 'connection', action: 'deleted' }))).unwrap();
+        (await emitter.record(auditEvent(account.id, '2026-07-16T10:00:01.000Z', { resource: 'connection', action: 'updated' }))).unwrap();
+        (await emitter.record(auditEvent(account.id, '2026-07-16T10:00:02.000Z', { resource: 'api_key', action: 'deleted' }))).unwrap();
+
+        const byResource = await api.fetch('/api/v1/audit-trail', { method: 'GET', session, query: { resources: 'connection' } });
+        expect(byResource.res.status).toBe(200);
+        isSuccess(byResource.json);
+        expect(byResource.json.data.map((e) => `${e.resource}.${e.action}`).sort()).toEqual(['connection.deleted', 'connection.updated']);
+
+        const byPair = await api.fetch('/api/v1/audit-trail', { method: 'GET', session, query: { resources: 'connection', actions: 'deleted' } });
+        expect(byPair.res.status).toBe(200);
+        isSuccess(byPair.json);
+        expect(byPair.json.data.map((e) => `${e.resource}.${e.action}`)).toEqual(['connection.deleted']);
+    });
+
+    it('filters by several resources at once', async () => {
+        const { session, account } = await authAdmin();
+        (await emitter.record(auditEvent(account.id, '2026-07-16T10:00:00.000Z', { resource: 'connection', action: 'deleted' }))).unwrap();
+        (await emitter.record(auditEvent(account.id, '2026-07-16T10:00:01.000Z', { resource: 'api_key', action: 'deleted' }))).unwrap();
+        (await emitter.record(auditEvent(account.id, '2026-07-16T10:00:02.000Z', { resource: 'team', action: 'updated' }))).unwrap();
+
+        const res = await api.fetch('/api/v1/audit-trail', { method: 'GET', session, query: { resources: 'connection,api_key' } });
+        expect(res.res.status).toBe(200);
+        isSuccess(res.json);
+        expect(res.json.data.map((e) => e.resource).sort()).toEqual(['api_key', 'connection']);
     });
 
     it('paginates via the opaque cursor', async () => {

--- a/packages/server/lib/controllers/v1/audit-trail/getAuditTrail.ts
+++ b/packages/server/lib/controllers/v1/audit-trail/getAuditTrail.ts
@@ -10,15 +10,30 @@ import type { GetAuditTrail } from '@nangohq/types';
 
 const PAGE_SIZE = 25;
 
+const MAX_FILTER_VALUES = 50;
+
+// Comma-separated list (`?resources=a,b`). Safe to split on a comma because both vocabularies are
+// snake_case identifiers. Unlike the enum-valued query params elsewhere the values aren't checked
+// against a vocabulary — the audit one has no runtime form — so an unknown value matches nothing.
+const csvParam = z
+    .string()
+    .transform((value) => value.split(','))
+    .pipe(z.array(z.string().min(1)).max(MAX_FILTER_VALUES));
+
 const queryStringValidation = z
     .object({
         cursor: z.string().optional(),
         from: z.iso.datetime().optional(),
-        to: z.iso.datetime().optional()
+        to: z.iso.datetime().optional(),
+        resources: csvParam.optional(),
+        actions: csvParam.optional()
     })
     // Account-scoped endpoint (no `env`). Not strict: any stray query param is stripped rather than 400'd, so a read never fails over an extra key.
     // Surface an inverted range as a 400 rather than a silently empty result.
-    .refine((q) => !q.from || !q.to || new Date(q.from) <= new Date(q.to), { message: '`from` must be before or equal to `to`', path: ['from'] });
+    .refine((q) => !q.from || !q.to || new Date(q.from) <= new Date(q.to), { message: '`from` must be before or equal to `to`', path: ['from'] })
+    // An action is only meaningful attached to a resource, so reject the pairless form rather than
+    // dropping it and returning a wider result set than the caller asked for.
+    .refine((q) => !q.actions?.length || Boolean(q.resources?.length), { message: '`actions` requires `resources`', path: ['actions'] });
 
 export const getAuditTrail = asyncWrapper<GetAuditTrail>(async (req, res) => {
     const query = queryStringValidation.safeParse(req.query);
@@ -28,9 +43,9 @@ export const getAuditTrail = asyncWrapper<GetAuditTrail>(async (req, res) => {
     }
 
     const { account } = res.locals;
-    const { cursor, from, to } = query.data;
+    const { cursor, from, to, resources, actions } = query.data;
 
-    const result = await audit.listAuditTrailEvents({ accountId: account.id, limit: PAGE_SIZE, cursor, from, to });
+    const result = await audit.listAuditTrailEvents({ accountId: account.id, limit: PAGE_SIZE, cursor, from, to, resources, actions });
     if (result.isErr()) {
         if (result.error instanceof InvalidAuditCursorError) {
             res.status(400).send({ error: { code: 'invalid_query_params', message: 'Invalid cursor' } });

--- a/packages/types/lib/audit-trail/api.ts
+++ b/packages/types/lib/audit-trail/api.ts
@@ -26,11 +26,15 @@ export type GetAuditTrail = ApiEndpoint<{
     Method: 'GET';
     Path: '/api/v1/audit-trail';
     Querystring: {
-        // Account-scoped endpoint: no `env`. `cursor` encodes position only, not the filter window — resend the
-        // same `from`/`to` on every page or subsequent pages paginate the unfiltered set past the cursor.
+        // Account-scoped endpoint: no `env`. `cursor` encodes position only, not the filter window — resend
+        // every other param on each page or subsequent pages paginate the unfiltered set past the cursor.
         cursor?: string;
         from?: string;
         to?: string;
+        // Comma-separated `AuditResource` / `AuditAction` values (`?resources=connection,sync`).
+        // `actions` requires `resources`: the pair is matched as one `resource.action` value.
+        resources?: string;
+        actions?: string;
     };
     Success: {
         data: ApiAuditTrailEvent[];

--- a/packages/webapp/src/components/patterns/FilterMultiSelect.tsx
+++ b/packages/webapp/src/components/patterns/FilterMultiSelect.tsx
@@ -26,6 +26,7 @@ interface FilterMultiSelectProps<T extends string = string> {
     width?: string;
     open?: boolean;
     onOpenChange?: (open: boolean) => void;
+    disabled?: boolean;
 }
 
 export function FilterMultiSelect<T extends string = string>({
@@ -40,7 +41,8 @@ export function FilterMultiSelect<T extends string = string>({
     max,
     width = 'w-56',
     open: controlledOpen,
-    onOpenChange: controlledOnOpenChange
+    onOpenChange: controlledOnOpenChange,
+    disabled = false
 }: FilterMultiSelectProps<T>) {
     const [internalOpen, setInternalOpen] = useState(false);
     const [search, setSearch] = useState('');
@@ -48,7 +50,7 @@ export function FilterMultiSelect<T extends string = string>({
     const searchInputRef = useRef<HTMLInputElement>(null);
 
     const isControlled = controlledOpen !== undefined;
-    const open = isControlled ? controlledOpen : internalOpen;
+    const open = (isControlled ? controlledOpen : internalOpen) && !disabled;
 
     const setOpen = useCallback(
         (val: boolean) => {
@@ -179,7 +181,7 @@ export function FilterMultiSelect<T extends string = string>({
     return (
         <Popover open={open} onOpenChange={setOpen}>
             <PopoverTrigger asChild>
-                <Button variant="outline" size="md" className={cn('text-text-muted', isDirty && 'text-text-strong')}>
+                <Button variant="outline" size="md" disabled={disabled} className={cn('text-text-muted', isDirty && 'text-text-strong')}>
                     {label}
                     {isDirty && (
                         <span

--- a/packages/webapp/src/hooks/useAudit.tsx
+++ b/packages/webapp/src/hooks/useAudit.tsx
@@ -2,12 +2,19 @@ import { useInfiniteQuery } from '@tanstack/react-query';
 
 import { APIError, apiFetch } from '../utils/api';
 
-import type { GetAuditTrail } from '@nangohq/types';
+import type { AuditAction, AuditResource, GetAuditTrail } from '@nangohq/types';
 
-export function useApiGetAuditTrail(filters: { from?: string | undefined; to?: string | undefined }, options?: { enabled?: boolean }) {
+interface AuditTrailFilters {
+    from?: string | undefined;
+    to?: string | undefined;
+    resources?: AuditResource[] | undefined;
+    actions?: AuditAction[] | undefined;
+}
+
+export function useApiGetAuditTrail(filters: AuditTrailFilters, options?: { enabled?: boolean }) {
     return useInfiniteQuery<GetAuditTrail['Success'], APIError, { pages: GetAuditTrail['Success'][] }, unknown[], string | null>({
         enabled: options?.enabled ?? true,
-        queryKey: ['audit-trail:infinite', filters.from ?? null, filters.to ?? null],
+        queryKey: ['audit-trail:infinite', filters.from ?? null, filters.to ?? null, filters.resources ?? null, filters.actions ?? null],
         queryFn: async ({ pageParam, signal }) => {
             const params = new URLSearchParams();
             if (pageParam) {
@@ -18,6 +25,12 @@ export function useApiGetAuditTrail(filters: { from?: string | undefined; to?: s
             }
             if (filters.to) {
                 params.append('to', filters.to);
+            }
+            if (filters.resources?.length) {
+                params.append('resources', filters.resources.join(','));
+            }
+            if (filters.actions?.length) {
+                params.append('actions', filters.actions.join(','));
             }
 
             const qs = params.toString();

--- a/packages/webapp/src/pages/Audit/Show.tsx
+++ b/packages/webapp/src/pages/Audit/Show.tsx
@@ -5,6 +5,8 @@ import { Helmet } from 'react-helmet';
 import { permissions } from '@nangohq/authz';
 import { Button } from '@nangohq/design-system';
 
+import { ConditionalTooltip } from '@/components/patterns/ConditionalTooltip';
+import { FilterMultiSelect } from '@/components/patterns/FilterMultiSelect';
 import { PeriodSelector } from '@/components/patterns/PeriodSelector';
 import { Skeleton } from '@/components/ui/Skeleton';
 import { Tag } from '@/components/ui/Tag';
@@ -16,9 +18,11 @@ import DashboardLayout from '@/layout/DashboardLayout';
 import { last14dPreset, logsPresets } from '@/utils/logs';
 import { formatDateToLogFormat } from '@/utils/utils';
 import { AuditEventDrawer } from './components/AuditEventDrawer';
+import { actionOptionsFor, ALL, resourceOptions } from './constants';
 
+import type { ActionFilter, ResourceFilter } from './constants';
 import type { Period } from '@/utils/dates';
-import type { ApiAuditTrailEvent, AuditOutcome } from '@nangohq/types';
+import type { ApiAuditTrailEvent, AuditAction, AuditOutcome, AuditResource } from '@nangohq/types';
 
 const outcomeVariant: Record<AuditOutcome, React.ComponentProps<typeof Tag>['variant']> = {
     success: 'success',
@@ -33,14 +37,26 @@ export const AuditShow: React.FC = () => {
     const { can } = usePermissions();
     const canReadAuditTrail = can(permissions.canReadAuditTrail);
     const [period, setPeriod] = useState<Period | null>(() => last14dPreset.toPeriod());
+    const [resources, setResources] = useState<ResourceFilter[]>([ALL]);
+    const [actions, setActions] = useState<ActionFilter[]>([ALL]);
     const [selected, setSelected] = useState<ApiAuditTrailEvent | null>(null);
 
     const from = period?.from ? period.from.toISOString() : undefined;
     const to = period?.to ? period.to.toISOString() : undefined;
 
+    // Actions are matched as `resource.action` pairs, so they're only offered once the resource half is unambiguous.
+    const singleResource: AuditResource | null = resources.length === 1 && resources[0] !== ALL ? resources[0] : null;
+    const onResourcesChange = (next: ResourceFilter[]) => {
+        setResources(next);
+        setActions([ALL]);
+    };
+
+    const resourceFilter = useMemo(() => resources.filter((resource): resource is AuditResource => resource !== ALL), [resources]);
+    const actionFilter = useMemo(() => (singleResource ? actions.filter((action): action is AuditAction => action !== ALL) : []), [actions, singleResource]);
+
     // Only read audit data once the flag and the caller's permission are confirmed; stays idle otherwise.
     const { data, isLoading, isError, refetch, isFetchingNextPage, hasNextPage, fetchNextPage } = useApiGetAuditTrail(
-        { from, to },
+        { from, to, resources: resourceFilter, actions: actionFilter },
         { enabled: meta?.auditTrail === true && canReadAuditTrail }
     );
     const events = useMemo(() => data?.pages.flatMap((page) => page.data) ?? [], [data]);
@@ -83,9 +99,22 @@ export const AuditShow: React.FC = () => {
 
             <div className="flex flex-col gap-3">
                 <div className="flex gap-2 justify-between">
-                    {/* Left side is reserved for search + filters (status, actor, resource, …) added later. */}
+                    {/* Left side is reserved for search + filters (status, actor, …) added later. */}
                     <div className="flex-1 min-w-0" />
                     <div className="flex gap-2">
+                        <FilterMultiSelect label="Resource" options={resourceOptions} selected={resources} defaultSelect={[ALL]} onChange={onResourcesChange} />
+                        <ConditionalTooltip condition={!singleResource} content="Select a single resource to filter by action" asChild>
+                            <span>
+                                <FilterMultiSelect
+                                    label="Action"
+                                    options={singleResource ? actionOptionsFor(singleResource) : []}
+                                    selected={actions}
+                                    defaultSelect={[ALL]}
+                                    onChange={setActions}
+                                    disabled={!singleResource}
+                                />
+                            </span>
+                        </ConditionalTooltip>
                         <PeriodSelector
                             isLive={false}
                             period={period}

--- a/packages/webapp/src/pages/Audit/constants.ts
+++ b/packages/webapp/src/pages/Audit/constants.ts
@@ -1,0 +1,57 @@
+import { formatKeyToLabel } from '@/utils/utils';
+
+import type { FilterOption } from '@/components/patterns/FilterMultiSelect';
+import type { AuditAction, AuditActionOf, AuditEventKey, AuditResource } from '@nangohq/types';
+
+/**
+ * Runtime twin of the audit event vocabulary, which `@nangohq/types` can only hand over as types — it
+ * emits no JavaScript, so the table itself can't cross the package boundary. Same arrangement as
+ * `apiKeyScopes` in `@nangohq/utils`, kept in step the same way: the `satisfies` rejects an action its
+ * resource doesn't record, and the assertion below rejects a recorded event missing from here.
+ */
+const actionsByResource = {
+    connection: ['created', 'updated', 'metadata_updated', 'refreshed', 'deleted'],
+    sync: ['enabled', 'disabled', 'paused', 'started', 'triggered', 'cancelled', 'frequency_changed', 'variant_created', 'variant_deleted'],
+    function: ['deployed', 'upgraded', 'deleted'],
+    integration: ['created', 'updated', 'deleted'],
+    api_key: ['created', 'updated', 'deleted'],
+    member: ['invited', 'invite_accepted', 'invite_declined', 'invite_revoked', 'role_changed', 'removed'],
+    team: ['updated'],
+    user: ['updated'],
+    environment: ['created', 'updated', 'variables_changed', 'webhook_urls_changed', 'deleted'],
+    app_auth: ['login', 'logout', 'signup', 'password_changed', 'password_reset'],
+    mfa: ['enrolled', 'enabled', 'disabled', 'verified', 'recovery_regenerated'],
+    billing: ['plan_changed', 'trial_extended', 'details_changed', 'payment_method_added', 'payment_method_removed']
+} as const satisfies { [R in AuditResource]: readonly AuditActionOf<R>[] };
+
+type ListedEvent = { [R in AuditResource]: `${R}.${(typeof actionsByResource)[R][number]}` }[AuditResource];
+true satisfies [Exclude<AuditEventKey, ListedEvent>] extends [never] ? true : never;
+
+const resourceLabels: Record<AuditResource, string> = {
+    connection: 'Connection',
+    sync: 'Sync',
+    function: 'Function',
+    integration: 'Integration',
+    api_key: 'API key',
+    member: 'Member',
+    team: 'Team',
+    user: 'User',
+    environment: 'Environment',
+    app_auth: 'Authentication',
+    mfa: 'MFA',
+    billing: 'Billing'
+};
+
+export const ALL = 'all';
+
+export type ResourceFilter = AuditResource | typeof ALL;
+export type ActionFilter = AuditAction | typeof ALL;
+
+export const resourceOptions: FilterOption<ResourceFilter>[] = [
+    { value: ALL, label: 'All' },
+    ...(Object.keys(actionsByResource) as AuditResource[]).map((resource) => ({ value: resource, label: resourceLabels[resource] }))
+];
+
+export function actionOptionsFor(resource: AuditResource): FilterOption<ActionFilter>[] {
+    return [{ value: ALL, label: 'All' }, ...actionsByResource[resource].map((action) => ({ value: action, label: formatKeyToLabel(action) }))];
+}

--- a/packages/webapp/src/pages/Audit/constants.ts
+++ b/packages/webapp/src/pages/Audit/constants.ts
@@ -4,10 +4,9 @@ import type { FilterOption } from '@/components/patterns/FilterMultiSelect';
 import type { AuditAction, AuditActionOf, AuditEventKey, AuditResource } from '@nangohq/types';
 
 /**
- * Runtime twin of the audit event vocabulary, which `@nangohq/types` can only hand over as types — it
- * emits no JavaScript, so the table itself can't cross the package boundary. Same arrangement as
- * `apiKeyScopes` in `@nangohq/utils`, kept in step the same way: the `satisfies` rejects an action its
- * resource doesn't record, and the assertion below rejects a recorded event missing from here.
+ * Runtime twin of the audit event vocabulary: `@nangohq/types` emits no JavaScript, so the table can't
+ * cross the package boundary as a value. Kept in step by the checks below, as `apiKeyScopes` does in
+ * `@nangohq/utils`.
  */
 const actionsByResource = {
     connection: ['created', 'updated', 'metadata_updated', 'refreshed', 'deleted'],


### PR DESCRIPTION
> [!IMPORTANT]
> **#6983 must be merged first.** This PR is stacked on it: the base branch is `pau/audit-event-vocabulary`, not `master`, and the dashboard's filter list won't compile without the `AuditActionOf` and `AuditEventKey` types that PR introduces. Once #6983 lands, GitHub retargets this one to `master` automatically.

Supersedes #6979, which hand-maintained the list #6983 lets the compiler check.

Demo: https://www.loom.com/share/412ec2bf2dc94ccfb1e1c72dc350fa8e

- Adds `resource` and `resource_action` materialized search columns to `audit_trail_events`, each with a `set` skip index. `resource_action` is a column of its own rather than two conditions because two `set` indexes AND-ed prune per column, not per pair — a granule holding `connection.created` and `api_key.deleted` satisfies both `resource='connection'` and `action='deleted'` while containing no `connection.deleted`. Measured on 200k local rows, `resource_action='api_key.deleted'` prunes 25 granules to 2.
- Exposes the filters on `GET /api/v1/audit-trail` as comma-separated `resources` / `actions` query params. `actions` without `resources` is rejected with a 400 rather than silently widened, since a match is against a single `resource.action` value and needs both halves.
- Wires two selectors into the dashboard audit log. Action stays disabled until exactly one resource is selected — with a tooltip saying why — and resets whenever the resource selection changes. This is a deliberate middle ground rather than a limitation: the store can already match actions across several resources, but offering the union of every selected resource's actions makes for a long list full of pairs that can never match. Narrowing to one resource keeps the action list meaningful, and picking several resources is still supported on its own.

## The filter list is a checked twin, not a hand-kept copy

`@nangohq/types` emits no JavaScript, so the vocabulary table can't cross the package boundary as a value. The dashboard keeps a runtime twin in `packages/webapp/src/pages/Audit/constants.ts`, kept in step exactly as `apiKeyScopes` in `@nangohq/utils` is: `satisfies { [R in AuditResource]: readonly AuditActionOf<R>[] }` rejects an action its resource doesn't record, and an `Exclude<AuditEventKey, …> extends [never]` assertion rejects a recorded event missing from the list.

This is what #6983 unblocks and why this PR is stacked on it. On #6979 the same list was hand-maintained against a union the dashboard couldn't import, and it had already drifted — 14 of the 51 recorded pairs were missing, every lifecycle and authentication event from the coverage PRs that merged after that branch was cut. Adding an audited event now fails the build until the list is updated.

## Notes

There is no standalone `action` column: filtering by action alone isn't offered, so it would index nothing anyone queries.

Both encodings for multi-value query params exist in the tree; comma-separated wins 4 sites to 2, and the in-repo deciding factor is whether a value can contain a comma — `getRecords` uses both and says so for `ids`. Resources and actions are `snake_case` identifiers, so CSV. One deliberate difference from the existing CSV params: the querystring is typed as the string that goes on the wire, not the array it denotes. `GetConnections['Querystring']` declares `integrationIds?: string[]` while sending a joined string, which is untested and wrong.

## Test plan

- [x] Store-level integration tests for filtering by resource, by several resources, by a resource narrowed to an action, an action matched against a resource that never records it, actions passed without a resource, and combination with the date window and keyset pagination
- [x] Endpoint tests for the CSV encoding, the value cap, and the 400 on `actions` without `resources`
- [x] Migration test asserts both search columns get a `set` index
- [x] Both compile-time guards on the twin proven red: a recorded event dropped from the list fails the assertion, and an impossible pair fails at the entry
- [x] Every new runtime assertion proven red by deliberate break
- [x] Verified end to end in the browser against local ClickHouse with seeded events across eight resources
- [x] Granule pruning confirmed with `EXPLAIN indexes=1`
- [x] `ts-build`, oxlint and prettier clean; 33 integration + 25 audit unit tests pass
- [ ] After deploy: confirm the two columns and indexes exist in the `audit` database on dev

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/NangoHQ/nango/pull/6984?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->


