### PR TITLE
fix(webapp): guard Stripe init against empty publishable key

### DIFF
--- a/packages/webapp/src/utils/stripe.ts
+++ b/packages/webapp/src/utils/stripe.ts
@@ -5,5 +5,5 @@ import { globalEnv } from './env';
 import type { StripeError } from '@stripe/stripe-js';
 
 const stripePublishableKey = globalEnv.publicStripeKey;
-export const stripePromise = loadStripe(stripePublishableKey);
+export const stripePromise = stripePublishableKey ? loadStripe(stripePublishableKey) : Promise.resolve(null);
 export type { StripeError };


### PR DESCRIPTION
loadStripe() was called unconditionally with globalEnv.publicStripeKey, which is an empty string on self-hosted/local instances with no Stripe key configured. Stripe.js throws for an empty string instead of resolving null, causing an uncaught promise rejection on every page load - including pre-auth pages like /signin - plus real network beacons fired to stripe.com before any login.

Guard the call so stripePromise resolves to null when unconfigured. Downstream consumers already handle this: Plans.tsx has an existing `if (!stripe)` guard, and Stripe's <Elements> accepts a null-resolving promise by design.

<!-- Describe the problem and your solution -->

Related to #5640, which reported this exact crash for self-hosted instances. That issue and its fix (#5641) were auto-closed by the stale bot without maintainer review - confirmed the bug is still live on current master.

<!-- Issue ticket number and link (if applicable) -->

Closes #5640

<!-- Testing instructions (skip if just adding/editing providers) -->

- Set publicStripeKey to an empty string (default on self-hosted/local dev)
- Load /signin or /signup before this fix: uncaught IntegrationError in console + real network calls to stripe.com, before any login
- After this fix: page loads clean, zero Stripe-related console errors, zero stripe.com network calls
- Typecheck clean, vitest run --dir=packages/webapp passes (240/240)

cc @macko911 for review, you've touched this file/area most recently, tagging in case you have context on why the empty-key guard was never added.

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/NangoHQ/nango/pull/6985?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

