### PR TITLE
docs: wrap long endpoint URLs in the API playground

### DIFF
--- a/docs/custom.css
+++ b/docs/custom.css
@@ -450,6 +450,60 @@ svg.nav-logo,
   #content-side-layout { margin-top: 6rem !important; }
 }
 
+/* ══ API PLAYGROUND — wrap long endpoint URLs ═══════════════════ */
+/*
+ * Mintlify renders the endpoint URL as a non-wrapping flex row — base-URL
+ * <select>, then a wrapper holding one element per path segment — inside a
+ * scrollable viewport with a right-edge fade. Overflow is silently scrolled
+ * out of sight, and the bar shares the prose column with the sticky
+ * code-sample column, so anything past two slashes clips even on a wide
+ * screen: /integrations/{uniqueKey}/functions/{name} needs 622px and hides
+ * 408px of itself. No docs.json equivalent — api.playground only exposes
+ * display / proxy / credentials.
+ *
+ * Fix: wrap instead of scroll. min-width clears the inline
+ * `min-width: fit-content` that forces the overflow; segments keep their own
+ * `min-w-max`, so lines break between segments, never inside one.
+ *
+ * `display: contents` is what makes it read correctly. Left as a flex item,
+ * the wrapper is a second, narrower wrapping context beside the <select>, so
+ * the path breaks inside a ~200px column while the base URL floats centered
+ * against it. Dropping its box promotes the segments into the row itself:
+ * lines fill the full width and read in order. Its `gap-0.5` dies with the
+ * box, hence the explicit gaps. Its hover copy button is positioned against
+ * the bar, not the wrapper, so it is unaffected.
+ *
+ * !important throughout: Base UI sets overflow, mask-image, and min-width
+ * inline and recomputes them on resize.
+ *
+ * Scoped by child combinators, not a descendant `:has(select…)` — the
+ * playground modal body is itself a scroll area *containing* the bar, so a
+ * descendant match unwraps its vertical scrolling. Both elements we mean
+ * (page bar, modal header) hold the <select> exactly two levels down; the
+ * sidebar and TOC scroll areas share these attributes and stay untouched.
+ *
+ * Rejected: `width: auto` on the <select> to reclaim its 194px — Mintlify
+ * sets that width via JS, and freed of it the <select> stretches and
+ * squeezes the path into a one-segment-per-line column. Also a smaller
+ * segment font — ~7% width, rarely changes the line count, off-scale type.
+ */
+[data-component-part='scroll-area-viewport']:has(
+    > [data-component-part='scroll-area-content'] > div > select[aria-label='Select base URL']
+  ) {
+  overflow: visible !important;
+  mask-image: none !important;
+}
+[data-component-part='scroll-area-content']:has(> div > select[aria-label='Select base URL']) {
+  min-width: 0 !important;
+  flex-wrap: wrap !important;
+  column-gap: 2px !important;
+  row-gap: 2px !important;
+}
+[data-component-part='scroll-area-content']:has(> div > select[aria-label='Select base URL'])
+  > div:last-child {
+  display: contents !important;
+}
+
 /* ══ SIDEBAR ANCHORS ═════════════════════════════════════════════ */
 .dark #navigation-items > ul {
   padding-bottom: 20px !important;


### PR DESCRIPTION
docs: wrap long endpoint URLs in the API playground

Mintlify renders the endpoint URL as a non-wrapping flex row inside a
horizontally scrollable viewport with a fade mask, so anything wider
than the bar is silently scrolled out of sight. The bar shares the prose
column with the sticky code-sample column, so any path past two slashes
clips even on a wide screen: GET /integrations/{uniqueKey}/functions/{name}
measures 622px and hides 408px of itself.

Let the URL wrap instead. Clearing min-width lets the row shrink to the
viewport, flex-wrap moves what doesn't fit to a second line, and dropping
the wrapper's box promotes the path segments into the row itself so lines
fill the full bar width and read in order.

Scoped through explicit child combinators rather than a descendant
:has(select) — the interactive playground modal body is itself a scroll
area containing the endpoint bar, and a descendant match unwraps its
vertical scrolling too.

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/NangoHQ/nango/pull/6986?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

