### PR TITLE
test(scheduler): give each suite its own db schema (NAN-6500)

### DIFF
--- a/packages/orchestrator/lib/backpressure-monitor.integration.test.ts
+++ b/packages/orchestrator/lib/backpressure-monitor.integration.test.ts
@@ -17,7 +17,7 @@ const noopCallbacks = {
 };
 
 describe('BackpressureMonitor', () => {
-    const dbClient = getTestDbClient();
+    const dbClient = getTestDbClient('orchestrator_backpressure');
     let scheduler: Scheduler;
 
     beforeEach(async () => {

--- a/packages/orchestrator/lib/clients/client.integration.test.ts
+++ b/packages/orchestrator/lib/clients/client.integration.test.ts
@@ -12,7 +12,7 @@ import type { PostImmediate } from '../routes/v1/postImmediate.js';
 import type { Task } from '@nangohq/scheduler';
 import type { Result } from '@nangohq/utils';
 
-const dbClient = getTestDbClient();
+const dbClient = getTestDbClient('orchestrator_client');
 const eventsHandler = new TaskEventsHandler(dbClient.db);
 const scheduler = new Scheduler({
     db: dbClient.db,

--- a/packages/orchestrator/lib/clients/processor.integration.test.ts
+++ b/packages/orchestrator/lib/clients/processor.integration.test.ts
@@ -15,7 +15,7 @@ import type { OrchestratorTask } from './types.js';
 import type { Task } from '@nangohq/scheduler';
 import type { Result } from '@nangohq/utils';
 
-const dbClient = getTestDbClient();
+const dbClient = getTestDbClient('orchestrator_processor');
 const taskEventsHandler = new TaskEventsHandler(dbClient.db);
 const scheduler = new Scheduler({
     db: dbClient.db,

--- a/packages/orchestrator/lib/events.integration.test.ts
+++ b/packages/orchestrator/lib/events.integration.test.ts
@@ -7,7 +7,7 @@ import { taskEvents, TaskEventsHandler } from './events.js';
 
 import type { Task } from '@nangohq/scheduler';
 
-const dbClient = getTestDbClient();
+const dbClient = getTestDbClient('orchestrator_events');
 const mockActionTask: Task = {
     id: '00000000-0000-0000-0000-000000000000',
     name: 'task-name',

--- a/packages/orchestrator/lib/helpers.test.ts
+++ b/packages/orchestrator/lib/helpers.test.ts
@@ -14,8 +14,8 @@ export class TestOrchestratorService {
     private scheduler: Scheduler | null;
     private eventsHandler: TaskEventsHandler;
 
-    constructor({ port }: { port: number }) {
-        this.dbClient = getTestDbClient();
+    constructor({ port, schema }: { port: number; schema: string }) {
+        this.dbClient = getTestDbClient(schema);
         this.eventsHandler = new TaskEventsHandler(this.dbClient.db);
         this.port = port;
         this.scheduler = null;

--- a/packages/scheduler/lib/daemons/daemon.integration.test.ts
+++ b/packages/scheduler/lib/daemons/daemon.integration.test.ts
@@ -7,7 +7,7 @@ import { SchedulerDaemon } from './daemon.js';
 
 import type knex from 'knex';
 
-const db = getTestDbClient().db;
+const db = getTestDbClient('scheduler_daemon').db;
 
 describe('SchedulerDaemon', () => {
     it('should be abortable', async () => {

--- a/packages/scheduler/lib/daemons/scheduling/scheduling.integration.test.ts
+++ b/packages/scheduler/lib/daemons/scheduling/scheduling.integration.test.ts
@@ -16,7 +16,7 @@ import type { Schedule, ScheduleState, Task, TaskState } from '../../types.js';
 import type knex from 'knex';
 
 describe('dueSchedules', () => {
-    const dbClient = getTestDbClient();
+    const dbClient = getTestDbClient('scheduler_scheduling');
     const db = dbClient.db;
 
     beforeEach(async () => {

--- a/packages/scheduler/lib/db/helpers.test.ts
+++ b/packages/scheduler/lib/db/helpers.test.ts
@@ -1,8 +1,10 @@
 import { DatabaseClient, defaultDatabaseClientOptions } from './client.js';
 
-export const getTestDbClient = () =>
+// Every suite passes its own schema. `migrate()` creates it and `clearDatabase()` drops it,
+// so sharing one means a teardown in one file destroys the schema another file is still using.
+export const getTestDbClient = (schema: string) =>
     new DatabaseClient({
         ...defaultDatabaseClientOptions,
         url: `postgres://${process.env['NANGO_DB_USER']}:${process.env['NANGO_DB_PASSWORD']}@${process.env['NANGO_DB_HOST']}:${process.env['NANGO_DB_PORT']}/${process.env['NANGO_DB_NAME']}`,
-        schema: 'scheduler'
+        schema
     });

--- a/packages/scheduler/lib/models/schedules.integration.test.ts
+++ b/packages/scheduler/lib/models/schedules.integration.test.ts
@@ -10,7 +10,7 @@ import type { Schedule } from '../types.js';
 import type knex from 'knex';
 
 describe('Schedules', () => {
-    const dbClient = getTestDbClient();
+    const dbClient = getTestDbClient('scheduler_schedules');
     const db = dbClient.db;
     beforeEach(async () => {
         await dbClient.migrate();

--- a/packages/scheduler/lib/models/tasks.integration.test.ts
+++ b/packages/scheduler/lib/models/tasks.integration.test.ts
@@ -27,7 +27,7 @@ const props = {
 };
 
 describe('Task', () => {
-    const dbClient = getTestDbClient();
+    const dbClient = getTestDbClient('scheduler_tasks');
     const db = dbClient.db;
     beforeEach(async () => {
         await dbClient.migrate();

--- a/packages/scheduler/lib/scheduler.integration.test.ts
+++ b/packages/scheduler/lib/scheduler.integration.test.ts
@@ -12,7 +12,7 @@ import type { TaskProps } from './models/tasks.js';
 import type { Schedule, ScheduleState, Task } from './types.js';
 
 describe('Scheduler', () => {
-    const dbClient = getTestDbClient();
+    const dbClient = getTestDbClient('scheduler');
     const callbacks = {
         CREATED: vi.fn((task: Task) => expect(task.state).toBe('CREATED')),
         STARTED: vi.fn((task: Task) => expect(task.state).toBe('STARTED')),

--- a/vite.integration.config.ts
+++ b/vite.integration.config.ts
@@ -34,15 +34,13 @@ function findSuitesUsingViMock(root: string): string[] {
     return found;
 }
 
-const usesViMock = findSuitesUsingViMock('packages');
+// Each of these now owns its own db schema, but they still need their own process. They build a
+// `DatabaseClient` with its own knex pool and run live daemons, and neither is torn down reliably,
+// so in a shared process the pools and daemons accumulate until unrelated suites fail to get a
+// connection. The process boundary is what reclaims them.
+const runsDaemonsAndOwnsAPool = ['**/packages/scheduler/**/*.integration.test.ts', '**/packages/orchestrator/**/*.integration.test.ts'];
 
-// These all run live polling daemons against the fixed `scheduler` schema, so a daemon from
-// one file steals dequeues and transitions tasks in the next. Orchestrator counts because its
-// harness builds a Scheduler on `getTestDbClient` from @nangohq/scheduler, which pins that same
-// schema, and tears down with `clearDatabase()`:
-const ownsTheSchedulerSchema = ['**/packages/scheduler/**/*.integration.test.ts', '**/packages/orchestrator/**/*.integration.test.ts'];
-
-const needsOwnProcess = [...usesViMock, ...ownsTheSchedulerSchema];
+const needsOwnProcess = [...findSuitesUsingViMock('packages'), ...runsDaemonsAndOwnsAPool];
 
 const shared = {
     include: ['**/*.integration.{test,spec}.?(c|m)[jt]s?(x)'],


### PR DESCRIPTION
`getTestDbClient` in @nangohq/scheduler hardcoded `schema: 'scheduler'`. All 10 call sites shared it, 5 in packages/scheduler and 4 in packages/orchestrator plus the orchestrator harness.

`migrate()` runs `CREATE SCHEMA IF NOT EXISTS` and `clearDatabase()` runs `DROP SCHEMA CASCADE`, so a teardown in one file drops the schema another file is still using. That is the likely source of the `Invalid state transition from CREATED to FAILED` and `expected +0 to be 1` failures these suites produce.

Each suite now passes its own schema, the way fleet's helper already works. That is why no fleet suite needs isolation. Suggested by @TBonnin on #6970.

## Effect

Running the nine suites on their own:

| | result |
|---|---|
| master, shared schema | 6 failures, then 0, then 0 |
| this branch, per suite schemas | 0, 0, 0, 0 |

## They still keep their own process

Removing the quarantine was tried and does not work. Each of these files builds a `DatabaseClient` with its own knex pool and runs live daemons, and neither is torn down reliably. In a shared process the pools and daemons accumulate until unrelated suites fail with `Failed to authenticate user`, which is a connection problem rather than a logic one.

So this fixes the flakiness but does not recover the import cost. The isolated fileset stays at 14 files.

## What this does not fix

The integration suite is flaky on master independently of this. Running it unsharded 8 times on an unmodified checkout gave 5 clean and 3 failed, roughly 1 in 3, with `Invalid state transition`, `expected +0 to be 1` and timestamp assertions. This branch measured 3 clean out of 6, which is indistinguishable at that sample size.

Unsharded local runs are harsher than CI, which splits into 4 shards so each process carries about 40 files instead of 159. That is the likely reason CI stays green. Worth its own ticket.

## Test plan

- [ ] `tests-integration` green in CI
- [ ] re-run the workflow a few times, since a single green does not distinguish a 50% from a 62% clean rate
- [ ] scheduler suites specifically, watch for `Invalid state transition` and `expected +0 to be 1`


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/NangoHQ/nango/pull/6987?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

