### PR TITLE
feat(authz): account-level api keys (service, auth query, scope split)

### DIFF
--- a/packages/server/lib/authz/middleware.ts
+++ b/packages/server/lib/authz/middleware.ts
@@ -6,9 +6,9 @@ import type { RequestLocals } from '../utils/express.js';
 import type { Permission, Scope } from '@nangohq/types';
 import type { RequestHandler } from 'express';
 
-export const envScope = (l: RequestLocals): Scope => (l.environment?.is_production ? 'production' : 'non-production');
+export const envScope = (l: Partial<RequestLocals>): Scope => (l.environment?.is_production ? 'production' : 'non-production');
 
-type ScopedPermission = Omit<Permission, 'scope'> & { scopedBy: (locals: RequestLocals) => Scope };
+type ScopedPermission = Omit<Permission, 'scope'> & { scopedBy: (locals: Partial<RequestLocals>) => Scope };
 
 export function can(permission: Permission | ScopedPermission): RequestHandler {
     return async (_req, res, next) => {
@@ -17,7 +17,7 @@ export function can(permission: Permission | ScopedPermission): RequestHandler {
             return;
         }
 
-        const { plan, user } = res.locals as RequestLocals;
+        const { plan, user } = res.locals as Partial<RequestLocals>;
 
         if (flagHasPlan && (!plan || !plan.has_rbac)) {
             next();
@@ -31,7 +31,7 @@ export function can(permission: Permission | ScopedPermission): RequestHandler {
 
         const perm: Permission =
             'scopedBy' in permission
-                ? { action: permission.action, resource: permission.resource, scope: permission.scopedBy(res.locals as RequestLocals) }
+                ? { action: permission.action, resource: permission.resource, scope: permission.scopedBy(res.locals as Partial<RequestLocals>) }
                 : permission;
         const allowed = await evaluator.evaluate(user.role, perm);
 

--- a/packages/server/lib/controllers/action/getAsyncActionResult.ts
+++ b/packages/server/lib/controllers/action/getAsyncActionResult.ts
@@ -3,7 +3,7 @@ import * as z from 'zod';
 import { errorManager } from '@nangohq/shared';
 import { zodErrorToHTTP } from '@nangohq/utils';
 
-import { asyncWrapper } from '../../utils/asyncWrapper.js';
+import { asyncWrapperWithEnvironment } from '../../utils/asyncWrapper.js';
 import { getOrchestrator } from '../../utils/utils.js';
 
 import type { GetAsyncActionResult } from '@nangohq/types';
@@ -16,7 +16,7 @@ const paramValidation = z
     })
     .strict();
 
-export const getAsyncActionResult = asyncWrapper<GetAsyncActionResult>(async (req, res) => {
+export const getAsyncActionResult = asyncWrapperWithEnvironment<GetAsyncActionResult>(async (req, res) => {
     const paramValue = paramValidation.safeParse(req.params);
     if (!paramValue.success) {
         res.status(400).send({ error: { code: 'invalid_uri_params', errors: zodErrorToHTTP(paramValue.error) } });

--- a/packages/server/lib/controllers/action/postTriggerAction.ts
+++ b/packages/server/lib/controllers/action/postTriggerAction.ts
@@ -4,7 +4,7 @@ import * as z from 'zod';
 import { getHeaders, metrics, redactHeaders, requireEmptyQuery, zodErrorToHTTP } from '@nangohq/utils';
 
 import { connectionIdSchema, providerConfigKeySchema, syncNameSchema } from '../../helpers/validation.js';
-import { asyncWrapper } from '../../utils/asyncWrapper.js';
+import { asyncWrapperWithEnvironment } from '../../utils/asyncWrapper.js';
 import { runAction } from './runAction.js';
 
 import type { PostPublicTriggerAction } from '@nangohq/types';
@@ -21,7 +21,7 @@ const schemaBody = z.object({
     input: z.unknown()
 });
 
-export const postPublicTriggerAction = asyncWrapper<PostPublicTriggerAction>(async (req, res) => {
+export const postPublicTriggerAction = asyncWrapperWithEnvironment<PostPublicTriggerAction>(async (req, res) => {
     const valHeaders = schemaHeaders.safeParse(req.headers);
     if (!valHeaders.success) {
         res.status(400).send({ error: { code: 'invalid_headers', errors: zodErrorToHTTP(valHeaders.error) } });

--- a/packages/server/lib/controllers/auth/postApiKey.ts
+++ b/packages/server/lib/controllers/auth/postApiKey.ts
@@ -18,7 +18,7 @@ import {
     connectionCreationFailed as connectionCreationFailedHook,
     testConnectionCredentials
 } from '../../hooks/hooks.js';
-import { asyncWrapper } from '../../utils/asyncWrapper.js';
+import { asyncWrapperWithEnvironment } from '../../utils/asyncWrapper.js';
 import { errorRestrictConnectionId, isIntegrationAllowed, resolveConnectionConfig, resolveOutboundWebhookUrlOverride } from '../../utils/auth.js';
 import { hmacCheck } from '../../utils/hmac.js';
 
@@ -42,7 +42,7 @@ const paramsValidation = z
     })
     .strict();
 
-export const postPublicApiKeyAuthorization = asyncWrapper<PostPublicApiKeyAuthorization>(async (req, res, next: NextFunction) => {
+export const postPublicApiKeyAuthorization = asyncWrapperWithEnvironment<PostPublicApiKeyAuthorization>(async (req, res, next: NextFunction) => {
     const val = bodyValidation.safeParse(req.body);
     if (!val.success) {
         res.status(400).send({

--- a/packages/server/lib/controllers/auth/postAppStore.ts
+++ b/packages/server/lib/controllers/auth/postAppStore.ts
@@ -17,7 +17,7 @@ import { metrics, report, stringifyError, zodErrorToHTTP } from '@nangohq/utils'
 import { connectionConfigParamsSchema, connectionCredential, connectionIdSchema, providerConfigKeySchema } from '../../helpers/validation.js';
 import { handleValidateConnectionFailure, validateConnection } from '../../hooks/connection/on/validate-connection.js';
 import { connectionCreated as connectionCreatedHook, connectionCreationFailed as connectionCreationFailedHook } from '../../hooks/hooks.js';
-import { asyncWrapper } from '../../utils/asyncWrapper.js';
+import { asyncWrapperWithEnvironment } from '../../utils/asyncWrapper.js';
 import { errorRestrictConnectionId, isIntegrationAllowed, resolveConnectionConfig, resolveOutboundWebhookUrlOverride } from '../../utils/auth.js';
 import { hmacCheck } from '../../utils/hmac.js';
 
@@ -48,7 +48,7 @@ const paramsValidation = z
     })
     .strict();
 
-export const postPublicAppStoreAuthorization = asyncWrapper<PostPublicAppStoreAuthorization>(async (req, res, next: NextFunction) => {
+export const postPublicAppStoreAuthorization = asyncWrapperWithEnvironment<PostPublicAppStoreAuthorization>(async (req, res, next: NextFunction) => {
     const val = bodyValidation.safeParse(req.body);
     if (!val.success) {
         res.status(400).send({

--- a/packages/server/lib/controllers/auth/postAwsSigV4.ts
+++ b/packages/server/lib/controllers/auth/postAwsSigV4.ts
@@ -22,7 +22,7 @@ import { metrics, zodErrorToHTTP } from '@nangohq/utils';
 import { connectionConfigParamsSchema, connectionCredential, connectionIdSchema, providerConfigKeySchema } from '../../helpers/validation.js';
 import { handleValidateConnectionFailure, validateConnection } from '../../hooks/connection/on/validate-connection.js';
 import { connectionCreated as connectionCreatedHook, connectionCreationFailed as connectionCreationFailedHook } from '../../hooks/hooks.js';
-import { asyncWrapper } from '../../utils/asyncWrapper.js';
+import { asyncWrapperWithEnvironment } from '../../utils/asyncWrapper.js';
 import { errorRestrictConnectionId, isIntegrationAllowed, resolveConnectionConfig, resolveOutboundWebhookUrlOverride } from '../../utils/auth.js';
 import { hmacCheck } from '../../utils/hmac.js';
 
@@ -59,7 +59,7 @@ const paramsValidation = z
     })
     .strict();
 
-export const postPublicAwsSigV4Authorization = asyncWrapper<PostPublicAwsSigV4Authorization>(async (req, res, next: NextFunction) => {
+export const postPublicAwsSigV4Authorization = asyncWrapperWithEnvironment<PostPublicAwsSigV4Authorization>(async (req, res, next: NextFunction) => {
     const valBody = bodyValidation.safeParse(req.body);
     if (!valBody.success) {
         res.status(400).send({ error: { code: 'invalid_body', errors: zodErrorToHTTP(valBody.error) } });

--- a/packages/server/lib/controllers/auth/postBasic.ts
+++ b/packages/server/lib/controllers/auth/postBasic.ts
@@ -18,7 +18,7 @@ import {
     connectionCreationFailed as connectionCreationFailedHook,
     testConnectionCredentials
 } from '../../hooks/hooks.js';
-import { asyncWrapper } from '../../utils/asyncWrapper.js';
+import { asyncWrapperWithEnvironment } from '../../utils/asyncWrapper.js';
 import { errorRestrictConnectionId, isIntegrationAllowed, resolveConnectionConfig, resolveOutboundWebhookUrlOverride } from '../../utils/auth.js';
 import { hmacCheck } from '../../utils/hmac.js';
 
@@ -40,7 +40,7 @@ const paramsValidation = z
     })
     .strict();
 
-export const postPublicBasicAuthorization = asyncWrapper<PostPublicBasicAuthorization>(async (req, res, next: NextFunction) => {
+export const postPublicBasicAuthorization = asyncWrapperWithEnvironment<PostPublicBasicAuthorization>(async (req, res, next: NextFunction) => {
     const val = connectionCredentialsBasicSchema.safeParse(req.body);
     if (!val.success) {
         res.status(400).send({

--- a/packages/server/lib/controllers/auth/postBill.ts
+++ b/packages/server/lib/controllers/auth/postBill.ts
@@ -17,7 +17,7 @@ import { metrics, report, stringifyError, zodErrorToHTTP } from '@nangohq/utils'
 import { connectionConfigParamsSchema, connectionCredential, connectionIdSchema, providerConfigKeySchema } from '../../helpers/validation.js';
 import { handleValidateConnectionFailure, validateConnection } from '../../hooks/connection/on/validate-connection.js';
 import { connectionCreated as connectionCreatedHook, connectionCreationFailed as connectionCreationFailedHook } from '../../hooks/hooks.js';
-import { asyncWrapper } from '../../utils/asyncWrapper.js';
+import { asyncWrapperWithEnvironment } from '../../utils/asyncWrapper.js';
 import { errorRestrictConnectionId, isIntegrationAllowed, resolveConnectionConfig, resolveOutboundWebhookUrlOverride } from '../../utils/auth.js';
 import { hmacCheck } from '../../utils/hmac.js';
 
@@ -49,7 +49,7 @@ const paramsValidation = z
     })
     .strict();
 
-export const postPublicBillAuthorization = asyncWrapper<PostPublicBillAuthorization>(async (req, res, next: NextFunction) => {
+export const postPublicBillAuthorization = asyncWrapperWithEnvironment<PostPublicBillAuthorization>(async (req, res, next: NextFunction) => {
     const val = bodyValidation.safeParse(req.body);
     if (!val.success) {
         res.status(400).send({

--- a/packages/server/lib/controllers/auth/postJwt.ts
+++ b/packages/server/lib/controllers/auth/postJwt.ts
@@ -21,7 +21,7 @@ import {
     connectionCreationFailed as connectionCreationFailedHook,
     testConnectionCredentials
 } from '../../hooks/hooks.js';
-import { asyncWrapper } from '../../utils/asyncWrapper.js';
+import { asyncWrapperWithEnvironment } from '../../utils/asyncWrapper.js';
 import { errorRestrictConnectionId, isIntegrationAllowed, resolveConnectionConfig, resolveOutboundWebhookUrlOverride } from '../../utils/auth.js';
 import { hmacCheck } from '../../utils/hmac.js';
 
@@ -45,7 +45,7 @@ const paramValidation = z
     })
     .strict();
 
-export const postPublicJwtAuthorization = asyncWrapper<PostPublicJwtAuthorization>(async (req, res, next: NextFunction) => {
+export const postPublicJwtAuthorization = asyncWrapperWithEnvironment<PostPublicJwtAuthorization>(async (req, res, next: NextFunction) => {
     const val = bodyValidation.safeParse(req.body);
     if (!val.success) {
         res.status(400).send({

--- a/packages/server/lib/controllers/auth/postOauthOutbound.ts
+++ b/packages/server/lib/controllers/auth/postOauthOutbound.ts
@@ -8,7 +8,7 @@ import { metrics, stringifyError, zodErrorToHTTP } from '@nangohq/utils';
 import { connectionConfigParamsSchema, connectionCredential, connectionIdSchema, providerConfigKeySchema } from '../../helpers/validation.js';
 import { handleValidateConnectionFailure, validateConnection } from '../../hooks/connection/on/validate-connection.js';
 import { connectionCreated as connectionCreatedHook, connectionCreationFailed as connectionCreationFailedHook } from '../../hooks/hooks.js';
-import { asyncWrapper } from '../../utils/asyncWrapper.js';
+import { asyncWrapperWithEnvironment } from '../../utils/asyncWrapper.js';
 import { errorRestrictConnectionId, isIntegrationAllowed, resolveConnectionConfig, resolveOutboundWebhookUrlOverride } from '../../utils/auth.js';
 import { hmacCheck } from '../../utils/hmac.js';
 
@@ -31,7 +31,7 @@ const paramsValidation = z
     })
     .strict();
 
-export const postPublicOauthOutboundAuthorization = asyncWrapper<PostPublicOauthOutboundAuthorization>(async (req, res, next: NextFunction) => {
+export const postPublicOauthOutboundAuthorization = asyncWrapperWithEnvironment<PostPublicOauthOutboundAuthorization>(async (req, res, next: NextFunction) => {
     const queryStringVal = queryStringValidation.safeParse(req.query);
     if (!queryStringVal.success) {
         res.status(400).send({

--- a/packages/server/lib/controllers/auth/postSignature.ts
+++ b/packages/server/lib/controllers/auth/postSignature.ts
@@ -21,7 +21,7 @@ import {
     connectionCreationFailed as connectionCreationFailedHook,
     testConnectionCredentials
 } from '../../hooks/hooks.js';
-import { asyncWrapper } from '../../utils/asyncWrapper.js';
+import { asyncWrapperWithEnvironment } from '../../utils/asyncWrapper.js';
 import { errorRestrictConnectionId, isIntegrationAllowed, resolveConnectionConfig, resolveOutboundWebhookUrlOverride } from '../../utils/auth.js';
 import { hmacCheck } from '../../utils/hmac.js';
 
@@ -52,7 +52,7 @@ const paramsValidation = z
     })
     .strict();
 
-export const postPublicSignatureAuthorization = asyncWrapper<PostPublicSignatureAuthorization>(async (req, res, next: NextFunction) => {
+export const postPublicSignatureAuthorization = asyncWrapperWithEnvironment<PostPublicSignatureAuthorization>(async (req, res, next: NextFunction) => {
     const val = bodyValidation.safeParse(req.body);
     if (!val.success) {
         res.status(400).send({

--- a/packages/server/lib/controllers/auth/postTba.ts
+++ b/packages/server/lib/controllers/auth/postTba.ts
@@ -12,7 +12,7 @@ import {
     connectionCreationFailed as connectionCreationFailedHook,
     testConnectionCredentials
 } from '../../hooks/hooks.js';
-import { asyncWrapper } from '../../utils/asyncWrapper.js';
+import { asyncWrapperWithEnvironment } from '../../utils/asyncWrapper.js';
 import { errorRestrictConnectionId, isIntegrationAllowed, resolveConnectionConfig, resolveOutboundWebhookUrlOverride } from '../../utils/auth.js';
 import { hmacCheck } from '../../utils/hmac.js';
 
@@ -42,7 +42,7 @@ const paramValidation = z
     })
     .strict();
 
-export const postPublicTbaAuthorization = asyncWrapper<PostPublicTbaAuthorization>(async (req, res, next) => {
+export const postPublicTbaAuthorization = asyncWrapperWithEnvironment<PostPublicTbaAuthorization>(async (req, res, next) => {
     const val = bodyValidation.safeParse(req.body);
     if (!val.success) {
         res.status(400).send({

--- a/packages/server/lib/controllers/auth/postTwoStep.ts
+++ b/packages/server/lib/controllers/auth/postTwoStep.ts
@@ -17,7 +17,7 @@ import { metrics, stringifyError, zodErrorToHTTP } from '@nangohq/utils';
 import { connectionConfigParamsSchema, connectionCredential, connectionIdSchema, providerConfigKeySchema } from '../../helpers/validation.js';
 import { handleValidateConnectionFailure, validateConnection } from '../../hooks/connection/on/validate-connection.js';
 import { connectionCreated as connectionCreatedHook, connectionCreationFailed as connectionCreationFailedHook } from '../../hooks/hooks.js';
-import { asyncWrapper } from '../../utils/asyncWrapper.js';
+import { asyncWrapperWithEnvironment } from '../../utils/asyncWrapper.js';
 import { errorRestrictConnectionId, isIntegrationAllowed, resolveConnectionConfig, resolveOutboundWebhookUrlOverride } from '../../utils/auth.js';
 import { hmacCheck } from '../../utils/hmac.js';
 
@@ -42,7 +42,7 @@ const paramsValidation = z
     })
     .strict();
 
-export const postPublicTwoStepAuthorization = asyncWrapper<PostPublicTwoStepAuthorization>(async (req, res, next: NextFunction) => {
+export const postPublicTwoStepAuthorization = asyncWrapperWithEnvironment<PostPublicTwoStepAuthorization>(async (req, res, next: NextFunction) => {
     const val = bodyValidation.safeParse(req.body);
     if (!val.success) {
         res.status(400).send({

--- a/packages/server/lib/controllers/auth/postUnauthenticated.ts
+++ b/packages/server/lib/controllers/auth/postUnauthenticated.ts
@@ -8,7 +8,7 @@ import { metrics, requireEmptyBody, stringifyError, zodErrorToHTTP } from '@nang
 import { connectionConfigParamsSchema, connectionCredential, connectionIdSchema, providerConfigKeySchema } from '../../helpers/validation.js';
 import { handleValidateConnectionFailure, validateConnection } from '../../hooks/connection/on/validate-connection.js';
 import { connectionCreated, connectionCreationFailed } from '../../hooks/hooks.js';
-import { asyncWrapper } from '../../utils/asyncWrapper.js';
+import { asyncWrapperWithEnvironment } from '../../utils/asyncWrapper.js';
 import { errorRestrictConnectionId, isIntegrationAllowed, resolveConnectionConfig, resolveOutboundWebhookUrlOverride } from '../../utils/auth.js';
 import { hmacCheck } from '../../utils/hmac.js';
 
@@ -29,7 +29,7 @@ const paramValidation = z
     })
     .strict();
 
-export const postPublicUnauthenticated = asyncWrapper<PostPublicUnauthenticatedAuthorization>(async (req, res) => {
+export const postPublicUnauthenticated = asyncWrapperWithEnvironment<PostPublicUnauthenticatedAuthorization>(async (req, res) => {
     const valBody = requireEmptyBody(req);
     if (valBody) {
         res.status(400).send({ error: { code: 'invalid_body', errors: zodErrorToHTTP(valBody.error) } });

--- a/packages/server/lib/controllers/config.controller.ts
+++ b/packages/server/lib/controllers/config.controller.ts
@@ -12,13 +12,14 @@ import {
 import { report } from '@nangohq/utils';
 
 import { hasScope } from '../middleware/scope.middleware.js';
+import { requireEnvironment } from '../utils/asyncWrapper.js';
 
 import type { RequestLocals } from '../utils/express.js';
 import type { IntegrationWithCreds, Integration as ProviderIntegration } from '@nangohq/shared';
 import type { NextFunction, Request, Response } from 'express';
 
 class ConfigController {
-    async listProvidersFromYaml(_: Request, res: Response<any, Required<RequestLocals>>) {
+    async listProvidersFromYaml(_: Request, res: Response<any, RequestLocals>) {
         const providers = getProviders();
         if (!providers) {
             res.status(500).send({ error: { code: 'server_error' } });
@@ -57,9 +58,12 @@ class ConfigController {
     /**
      * Public api
      */
-    async getProviderConfig(req: Request, res: Response<any, Required<RequestLocals>>, next: NextFunction) {
+    async getProviderConfig(req: Request, res: Response<any, RequestLocals>, next: NextFunction) {
         try {
-            const environment = res.locals['environment'];
+            const environment = requireEnvironment(req, res);
+            if (!environment) {
+                return;
+            }
             const environmentId = environment.id;
             const providerConfigKey = req.params['providerConfigKey'] as string | null;
             const includeCreds = req.query['include_creds'] === 'true';

--- a/packages/server/lib/controllers/connect/deleteSession.ts
+++ b/packages/server/lib/controllers/connect/deleteSession.ts
@@ -2,11 +2,11 @@ import db from '@nangohq/database';
 import { requireEmptyBody, requireEmptyQuery, zodErrorToHTTP } from '@nangohq/utils';
 
 import * as connectSessionService from '../../services/connectSession.service.js';
-import { asyncWrapper } from '../../utils/asyncWrapper.js';
+import { asyncWrapperWithEnvironment } from '../../utils/asyncWrapper.js';
 
 import type { DeleteConnectSession } from '@nangohq/types';
 
-export const deleteConnectSession = asyncWrapper<DeleteConnectSession>(async (req, res) => {
+export const deleteConnectSession = asyncWrapperWithEnvironment<DeleteConnectSession>(async (req, res) => {
     const emptyQuery = requireEmptyQuery(req);
     if (emptyQuery) {
         res.status(400).send({ error: { code: 'invalid_query_params', errors: zodErrorToHTTP(emptyQuery.error) } });

--- a/packages/server/lib/controllers/connect/getSession.ts
+++ b/packages/server/lib/controllers/connect/getSession.ts
@@ -3,11 +3,11 @@ import * as endUserService from '@nangohq/shared';
 import { connectUISettingsService, getWebsocketsPath } from '@nangohq/shared';
 import { isCloud, report, requireEmptyBody, requireEmptyQuery, zodErrorToHTTP } from '@nangohq/utils';
 
-import { asyncWrapper } from '../../utils/asyncWrapper.js';
+import { asyncWrapperWithEnvironment } from '../../utils/asyncWrapper.js';
 
 import type { GetConnectSession, InternalEndUser } from '@nangohq/types';
 
-export const getConnectSession = asyncWrapper<GetConnectSession>(async (req, res) => {
+export const getConnectSession = asyncWrapperWithEnvironment<GetConnectSession>(async (req, res) => {
     const emptyQuery = requireEmptyQuery(req);
     if (emptyQuery) {
         res.status(400).send({ error: { code: 'invalid_query_params', errors: zodErrorToHTTP(emptyQuery.error) } });

--- a/packages/server/lib/controllers/connect/postReconnect.ts
+++ b/packages/server/lib/controllers/connect/postReconnect.ts
@@ -8,7 +8,7 @@ import { buildConnectUiSessionLink, flagHasPlan, requireEmptyQuery, zodErrorToHT
 
 import { connectionIdSchema, providerConfigKeySchema } from '../../helpers/validation.js';
 import * as connectSessionService from '../../services/connectSession.service.js';
-import { asyncWrapper } from '../../utils/asyncWrapper.js';
+import { asyncWrapperWithEnvironment } from '../../utils/asyncWrapper.js';
 import { mapDeprecatedConnectionConfigWebhookUrl } from './mapDeprecatedConnectionConfigWebhookUrl.js';
 import { checkIntegrationsExist, bodySchema as originalBodySchema } from './postSessions.js';
 
@@ -32,7 +32,7 @@ interface Reply {
     response: PostPublicConnectSessionsReconnect['Reply'];
 }
 
-export const postConnectSessionsReconnect = asyncWrapper<PostPublicConnectSessionsReconnect>(async (req, res) => {
+export const postConnectSessionsReconnect = asyncWrapperWithEnvironment<PostPublicConnectSessionsReconnect>(async (req, res) => {
     const emptyQuery = requireEmptyQuery(req);
     if (emptyQuery) {
         res.status(400).send({ error: { code: 'invalid_query_params', errors: zodErrorToHTTP(emptyQuery.error) } });

--- a/packages/server/lib/controllers/connect/postSessions.ts
+++ b/packages/server/lib/controllers/connect/postSessions.ts
@@ -8,10 +8,10 @@ import { buildConnectUiSessionLink, requireEmptyQuery, zodErrorToHTTP } from '@n
 
 import { connectionTagsSchema, endUserSchema, providerConfigKeySchema, webhookUrlSchema } from '../../helpers/validation.js';
 import * as connectSessionService from '../../services/connectSession.service.js';
-import { asyncWrapper } from '../../utils/asyncWrapper.js';
+import { asyncWrapperWithEnvironment } from '../../utils/asyncWrapper.js';
 import { mapDeprecatedConnectionConfigWebhookUrl } from './mapDeprecatedConnectionConfigWebhookUrl.js';
 
-import type { RequestLocals } from '../../utils/express.js';
+import type { RequestLocalsWithEnvironment } from '../../utils/express.js';
 import type { Config } from '@nangohq/shared';
 import type { DBPlan, PostConnectSessions } from '@nangohq/types';
 import type { Response } from 'express';
@@ -68,7 +68,7 @@ interface Reply {
     response: PostConnectSessions['Reply'];
 }
 
-export const postConnectSessions = asyncWrapper<PostConnectSessions>(async (req, res) => {
+export const postConnectSessions = asyncWrapperWithEnvironment<PostConnectSessions>(async (req, res) => {
     const emptyQuery = requireEmptyQuery(req);
     if (emptyQuery) {
         res.status(400).send({ error: { code: 'invalid_query_params', errors: zodErrorToHTTP(emptyQuery.error) } });
@@ -130,7 +130,7 @@ export function checkIntegrationsExist(
     return errors.length > 0 ? errors : false;
 }
 
-export async function generateSession(res: Response<any, Required<RequestLocals>>, body: PostConnectSessions['Body'], plan?: DBPlan | null) {
+export async function generateSession(res: Response<any, RequestLocalsWithEnvironment>, body: PostConnectSessions['Body'], plan?: DBPlan | null) {
     const mapped = mapDeprecatedConnectionConfigWebhookUrl(body);
     if (!mapped.ok) {
         res.status(400).send({ error: { code: 'invalid_body', errors: zodErrorToHTTP({ issues: mapped.issues }) } });

--- a/packages/server/lib/controllers/connection.controller.ts
+++ b/packages/server/lib/controllers/connection.controller.ts
@@ -20,6 +20,7 @@ import {
     connectionRefreshSuccess
 } from '../hooks/hooks.js';
 import { slackService } from '../services/slack.js';
+import { requireEnvironment } from '../utils/asyncWrapper.js';
 import { getOrchestrator } from '../utils/utils.js';
 
 import type { RequestLocals } from '../utils/express.js';
@@ -40,14 +41,18 @@ import type { NextFunction, Request, Response } from 'express';
 const orchestrator = getOrchestrator();
 
 class ConnectionController {
-    async deleteAdminConnection(req: Request, res: Response<any, Required<RequestLocals>>, next: NextFunction) {
+    async deleteAdminConnection(req: Request, res: Response<any, RequestLocals>, next: NextFunction) {
         try {
             if (!flags.hasAdminCapabilities || !envs.NANGO_ADMIN_UUID) {
                 res.status(400).send({ error: { code: 'feature_disabled', message: 'Admin capabilities are not enabled' } });
                 return;
             }
 
-            const { environment, account } = res.locals;
+            const { account } = res.locals;
+            const environment = requireEnvironment(req, res);
+            if (!environment) {
+                return;
+            }
             const connectionId = req.params['connectionId'] as string;
             const expectedConnectionId = generateSlackConnectionId(account.uuid, environment.id);
 
@@ -107,9 +112,12 @@ class ConnectionController {
     /**
      * @deprecated
      */
-    async setMetadataLegacy(req: Request, res: Response<any, Required<RequestLocals>>, next: NextFunction) {
+    async setMetadataLegacy(req: Request, res: Response<any, RequestLocals>, next: NextFunction) {
         try {
-            const environment = res.locals['environment'];
+            const environment = requireEnvironment(req, res);
+            if (!environment) {
+                return;
+            }
             const connectionId = (req.params['connectionId'] as string) || (req.get('Connection-Id') as string);
             const providerConfigKey = (req.query['provider_config_key'] as string) || (req.get('Provider-Config-Key') as string);
 
@@ -141,9 +149,12 @@ class ConnectionController {
     /**
      * @deprecated
      */
-    async updateMetadataLegacy(req: Request, res: Response<any, Required<RequestLocals>>, next: NextFunction) {
+    async updateMetadataLegacy(req: Request, res: Response<any, RequestLocals>, next: NextFunction) {
         try {
-            const environment = res.locals['environment'];
+            const environment = requireEnvironment(req, res);
+            if (!environment) {
+                return;
+            }
             const connectionId = (req.params['connectionId'] as string) || (req.get('Connection-Id') as string);
             const providerConfigKey = (req.query['provider_config_key'] as string) || (req.get('Provider-Config-Key') as string);
 
@@ -170,9 +181,13 @@ class ConnectionController {
         }
     }
 
-    async createConnection(req: Request, res: Response<any, Required<RequestLocals>>, next: NextFunction) {
+    async createConnection(req: Request, res: Response<any, RequestLocals>, next: NextFunction) {
         try {
-            const { environment, account, plan } = res.locals;
+            const { account, plan } = res.locals;
+            const environment = requireEnvironment(req, res);
+            if (!environment) {
+                return;
+            }
             const { provider_config_key, metadata, connection_config } = req.body;
 
             const connectionId = (req.body['connection_id'] as string) || connectionService.generateConnectionId();

--- a/packages/server/lib/controllers/connection/connectionId/deleteConnection.ts
+++ b/packages/server/lib/controllers/connection/connectionId/deleteConnection.ts
@@ -7,7 +7,7 @@ import { zodErrorToHTTP } from '@nangohq/utils';
 import { connectionIdSchema, providerConfigKeySchema } from '../../../helpers/validation.js';
 import { preConnectionDeletion } from '../../../hooks/connection/on/pre-connection-deletion.js';
 import { slackService } from '../../../services/slack.js';
-import { asyncWrapper } from '../../../utils/asyncWrapper.js';
+import { asyncWrapperWithEnvironment } from '../../../utils/asyncWrapper.js';
 import { getOrchestrator } from '../../../utils/utils.js';
 
 import type { DeletePublicConnection } from '@nangohq/types';
@@ -25,7 +25,7 @@ const validationParams = z
 
 const orchestrator = getOrchestrator();
 
-export const deletePublicConnection = asyncWrapper<DeletePublicConnection>(async (req, res) => {
+export const deletePublicConnection = asyncWrapperWithEnvironment<DeletePublicConnection>(async (req, res) => {
     const valParams = validationParams.safeParse(req.params);
     if (!valParams.success) {
         res.status(400).send({ error: { code: 'invalid_uri_params', errors: zodErrorToHTTP(valParams.error) } });

--- a/packages/server/lib/controllers/connection/connectionId/getConnection.ts
+++ b/packages/server/lib/controllers/connection/connectionId/getConnection.ts
@@ -8,7 +8,7 @@ import { connectionFullToPublicApi } from '../../../formatters/connection.js';
 import { connectionIdSchema, providerConfigKeySchema } from '../../../helpers/validation.js';
 import { connectionRefreshFailed as connectionRefreshFailedHook, connectionRefreshSuccess as connectionRefreshSuccessHook } from '../../../hooks/hooks.js';
 import { hasScope } from '../../../middleware/scope.middleware.js';
-import { asyncWrapper } from '../../../utils/asyncWrapper.js';
+import { asyncWrapperWithEnvironment } from '../../../utils/asyncWrapper.js';
 
 import type { AllAuthCredentials, ApiPublicConnectionFull, GetPublicConnection, Result } from '@nangohq/types';
 
@@ -27,7 +27,7 @@ const paramValidation = z
     })
     .strict();
 
-export const getPublicConnection = asyncWrapper<GetPublicConnection>(async (req, res) => {
+export const getPublicConnection = asyncWrapperWithEnvironment<GetPublicConnection>(async (req, res) => {
     const queryParamValues = queryStringValidation.safeParse(req.query);
     if (!queryParamValues.success) {
         res.status(400).send({ error: { code: 'invalid_query_params', errors: zodErrorToHTTP(queryParamValues.error) } });

--- a/packages/server/lib/controllers/connection/connectionId/metadata/patchMetadata.ts
+++ b/packages/server/lib/controllers/connection/connectionId/metadata/patchMetadata.ts
@@ -4,7 +4,7 @@ import { connectionService } from '@nangohq/shared';
 import { requireEmptyQuery, zodErrorToHTTP } from '@nangohq/utils';
 
 import { connectionIdSchema, providerConfigKeySchema } from '../../../../helpers/validation.js';
-import { asyncWrapper } from '../../../../utils/asyncWrapper.js';
+import { asyncWrapperWithEnvironment } from '../../../../utils/asyncWrapper.js';
 
 import type { ApiError, DBConnectionDecrypted, MetadataBody, UpdateMetadata } from '@nangohq/types';
 
@@ -16,7 +16,7 @@ const validation = z
     })
     .strict();
 
-export const patchPublicMetadata = asyncWrapper<UpdateMetadata>(async (req, res) => {
+export const patchPublicMetadata = asyncWrapperWithEnvironment<UpdateMetadata>(async (req, res) => {
     const emptyQuery = requireEmptyQuery(req);
     if (emptyQuery) {
         res.status(400).send({ error: { code: 'invalid_query_params', errors: zodErrorToHTTP(emptyQuery.error) } });

--- a/packages/server/lib/controllers/connection/connectionId/metadata/postMetadata.ts
+++ b/packages/server/lib/controllers/connection/connectionId/metadata/postMetadata.ts
@@ -5,7 +5,7 @@ import { connectionService } from '@nangohq/shared';
 import { requireEmptyQuery, zodErrorToHTTP } from '@nangohq/utils';
 
 import { connectionIdSchema, providerConfigKeySchema } from '../../../../helpers/validation.js';
-import { asyncWrapper } from '../../../../utils/asyncWrapper.js';
+import { asyncWrapperWithEnvironment } from '../../../../utils/asyncWrapper.js';
 
 import type { ApiError, MetadataBody, SetMetadata } from '@nangohq/types';
 
@@ -17,7 +17,7 @@ const validation = z
     })
     .strict();
 
-export const postPublicMetadata = asyncWrapper<SetMetadata>(async (req, res) => {
+export const postPublicMetadata = asyncWrapperWithEnvironment<SetMetadata>(async (req, res) => {
     const emptyQuery = requireEmptyQuery(req);
     if (emptyQuery) {
         res.status(400).send({ error: { code: 'invalid_query_params', errors: zodErrorToHTTP(emptyQuery.error) } });

--- a/packages/server/lib/controllers/connection/connectionId/patchConnection.ts
+++ b/packages/server/lib/controllers/connection/connectionId/patchConnection.ts
@@ -3,7 +3,7 @@ import * as z from 'zod';
 import { zodErrorToHTTP } from '@nangohq/utils';
 
 import { connectionIdSchema, providerConfigKeySchema } from '../../../helpers/validation.js';
-import { asyncWrapper } from '../../../utils/asyncWrapper.js';
+import { asyncWrapperWithEnvironment } from '../../../utils/asyncWrapper.js';
 import { handlePatchConnection, patchConnectionBodySchema } from '../../shared/connections/patchConnection.js';
 
 import type { PatchPublicConnection } from '@nangohq/types';
@@ -16,7 +16,7 @@ const paramValidation = z.strictObject({
     connectionId: connectionIdSchema
 });
 
-export const patchPublicConnection = asyncWrapper<PatchPublicConnection>(async (req, res) => {
+export const patchPublicConnection = asyncWrapperWithEnvironment<PatchPublicConnection>(async (req, res) => {
     const queryParamValues = queryStringValidation.safeParse(req.query);
     if (!queryParamValues.success) {
         res.status(400).send({ error: { code: 'invalid_query_params', errors: zodErrorToHTTP(queryParamValues.error) } });

--- a/packages/server/lib/controllers/connection/getConnections.ts
+++ b/packages/server/lib/controllers/connection/getConnections.ts
@@ -4,7 +4,7 @@ import { connectionService, connectionTagsSchema } from '@nangohq/shared';
 import { zodErrorToHTTP } from '@nangohq/utils';
 
 import { connectionSimpleToPublicApi } from '../../formatters/connection.js';
-import { asyncWrapper } from '../../utils/asyncWrapper.js';
+import { asyncWrapperWithEnvironment } from '../../utils/asyncWrapper.js';
 import { bodySchema } from '../connect/postSessions.js';
 
 import type { GetPublicConnections } from '@nangohq/types';
@@ -22,7 +22,7 @@ const validationQuery = z
     })
     .strict();
 
-export const getPublicConnections = asyncWrapper<GetPublicConnections>(async (req, res) => {
+export const getPublicConnections = asyncWrapperWithEnvironment<GetPublicConnections>(async (req, res) => {
     const queryParamValues = validationQuery.safeParse(req.query);
     if (!queryParamValues.success) {
         res.status(400).send({

--- a/packages/server/lib/controllers/connection/postConnection.ts
+++ b/packages/server/lib/controllers/connection/postConnection.ts
@@ -30,7 +30,7 @@ import {
 } from '../../helpers/validation.js';
 import { handleValidateConnectionFailure, validateConnection } from '../../hooks/connection/on/validate-connection.js';
 import { connectionCreated, connectionCreationStartCapCheck, connectionRefreshSuccess, testConnectionCredentials } from '../../hooks/hooks.js';
-import { asyncWrapper } from '../../utils/asyncWrapper.js';
+import { asyncWrapperWithEnvironment } from '../../utils/asyncWrapper.js';
 
 import type { AuthOperationType, ConnectionConfig, ConnectionUpsertResponse, EndUser, PostPublicConnection, ProviderGithubApp } from '@nangohq/types';
 
@@ -95,7 +95,7 @@ const schemaBody = z.strictObject({
     tags: connectionTagsSchema.optional()
 });
 
-export const postPublicConnection = asyncWrapper<PostPublicConnection>(async (req, res) => {
+export const postPublicConnection = asyncWrapperWithEnvironment<PostPublicConnection>(async (req, res) => {
     const emptyQuery = requireEmptyQuery(req);
     if (emptyQuery) {
         res.status(400).send({ error: { code: 'invalid_query_params', errors: zodErrorToHTTP(emptyQuery.error) } });

--- a/packages/server/lib/controllers/environment.controller.ts
+++ b/packages/server/lib/controllers/environment.controller.ts
@@ -2,14 +2,18 @@ import { accountService, environmentService, errorManager, generateSlackConnecti
 import { flags } from '@nangohq/utils';
 
 import { envs } from '../env.js';
+import { requireEnvironment } from '../utils/asyncWrapper.js';
 
 import type { RequestLocals } from '../utils/express.js';
 import type { NextFunction, Request, Response } from 'express';
 
 class EnvironmentController {
-    getHmacDigest(req: Request, res: Response<any, Required<RequestLocals>>, next: NextFunction) {
+    getHmacDigest(req: Request, res: Response<any, RequestLocals>, next: NextFunction) {
         try {
-            const { environment } = res.locals;
+            const environment = requireEnvironment(req, res);
+            if (!environment) {
+                return;
+            }
             const { provider_config_key: providerConfigKey, connection_id: connectionId } = req.query;
 
             if (!providerConfigKey) {
@@ -33,14 +37,19 @@ class EnvironmentController {
         }
     }
 
-    async getAdminAuthInfo(req: Request, res: Response<any, Required<RequestLocals>>, next: NextFunction) {
+    async getAdminAuthInfo(req: Request, res: Response<any, RequestLocals>, next: NextFunction) {
         try {
             if (!flags.hasAdminCapabilities || !envs.NANGO_ADMIN_UUID) {
                 res.status(400).send({ error: { code: 'feature_disabled', message: 'Admin capabilities are not enabled' } });
                 return;
             }
 
-            const { account, environment: callerEnvironment } = res.locals;
+            const { account } = res.locals;
+            const callerEnvironment = requireEnvironment(req, res);
+            if (!callerEnvironment) {
+                return;
+            }
+
             const expectedConnectionId = generateSlackConnectionId(account.uuid, callerEnvironment.id);
             const { connection_id: connectionId } = req.query;
 

--- a/packages/server/lib/controllers/environment/getVariables.ts
+++ b/packages/server/lib/controllers/environment/getVariables.ts
@@ -1,11 +1,11 @@
 import { environmentService } from '@nangohq/shared';
 import { requireEmptyBody, requireEmptyQuery, zodErrorToHTTP } from '@nangohq/utils';
 
-import { asyncWrapper } from '../../utils/asyncWrapper.js';
+import { asyncWrapperWithEnvironment } from '../../utils/asyncWrapper.js';
 
 import type { GetPublicEnvironmentVariables } from '@nangohq/types';
 
-export const getPublicEnvironmentVariables = asyncWrapper<GetPublicEnvironmentVariables>(async (req, res) => {
+export const getPublicEnvironmentVariables = asyncWrapperWithEnvironment<GetPublicEnvironmentVariables>(async (req, res) => {
     const emptyQuery = requireEmptyQuery(req);
     if (emptyQuery) {
         res.status(400).send({ error: { code: 'invalid_query_params', errors: zodErrorToHTTP(emptyQuery.error) } });

--- a/packages/server/lib/controllers/flow.controller.ts
+++ b/packages/server/lib/controllers/flow.controller.ts
@@ -1,12 +1,17 @@
 import { configService, flowService, getSyncConfigsAsStandardConfig } from '@nangohq/shared';
 
+import { requireEnvironment } from '../utils/asyncWrapper.js';
+
 import type { RequestLocals } from '../utils/express.js';
 import type { NextFunction, Request, Response } from 'express';
 
 class FlowController {
-    public async getFlow(req: Request, res: Response<any, Required<RequestLocals>>, next: NextFunction) {
+    public async getFlow(req: Request, res: Response<any, RequestLocals>, next: NextFunction) {
         try {
-            const environment = res.locals['environment'];
+            const environment = requireEnvironment(req, res);
+            if (!environment) {
+                return;
+            }
             const providerConfigKey = req.query['provider_config_key'] as string;
             const { flowName } = req.params;
 

--- a/packages/server/lib/controllers/functions/deploy/getDeployment.ts
+++ b/packages/server/lib/controllers/functions/deploy/getDeployment.ts
@@ -1,12 +1,12 @@
 import { getFunctionDeployment as getStoredFunctionDeployment } from '@nangohq/sandbox';
 import { requireEmptyQuery, zodErrorToHTTP } from '@nangohq/utils';
 
-import { asyncWrapper } from '../../../utils/asyncWrapper.js';
+import { asyncWrapperWithEnvironment } from '../../../utils/asyncWrapper.js';
 import { functionDeploymentParamsSchema } from '../validation.js';
 
 import type { GetFunctionDeployment } from '@nangohq/types';
 
-export const getFunctionDeployment = asyncWrapper<GetFunctionDeployment>(async (req, res) => {
+export const getFunctionDeployment = asyncWrapperWithEnvironment<GetFunctionDeployment>(async (req, res) => {
     const emptyQuery = requireEmptyQuery(req);
     if (emptyQuery) {
         res.status(400).send({ error: { code: 'invalid_query_params', errors: zodErrorToHTTP(emptyQuery.error) } });

--- a/packages/server/lib/controllers/functions/deploy/helpers.ts
+++ b/packages/server/lib/controllers/functions/deploy/helpers.ts
@@ -18,7 +18,7 @@ export async function createDeploySandboxApiKey(parentApiKeyId: number, environm
     });
 }
 
-export function requireCustomerKeyId<T>(res: Response<T, Required<RequestLocals>>, message: string): number | null {
+export function requireCustomerKeyId<T>(res: Response<T, RequestLocals>, message: string): number | null {
     if (res.locals['apiKeyAuthSource'] !== 'customer_key' || !res.locals['apiKeyId']) {
         res.status(403).send({ error: { code: 'forbidden', message } } as T);
         return null;
@@ -27,7 +27,7 @@ export function requireCustomerKeyId<T>(res: Response<T, Required<RequestLocals>
     return res.locals['apiKeyId'];
 }
 
-export function verifyDeploymentResultSandboxToken<T>(res: Response<T, Required<RequestLocals>>, deploymentId: string): boolean {
+export function verifyDeploymentResultSandboxToken<T>(res: Response<T, RequestLocals>, deploymentId: string): boolean {
     if (res.locals['sandboxTokenPurpose'] !== 'deploy' || res.locals['sandboxTokenDeploymentId'] !== deploymentId) {
         res.status(403).send({ error: { code: 'forbidden', message: 'This sandbox token is not authorized for this deployment' } } as T);
         return false;

--- a/packages/server/lib/controllers/functions/deploy/postDeploy.ts
+++ b/packages/server/lib/controllers/functions/deploy/postDeploy.ts
@@ -10,18 +10,18 @@ import {
 import { configService, getSyncConfigRaw } from '@nangohq/shared';
 import { report, requireEmptyQuery, zodErrorToHTTP } from '@nangohq/utils';
 
-import { asyncWrapper } from '../../../utils/asyncWrapper.js';
+import { asyncWrapperWithEnvironment } from '../../../utils/asyncWrapper.js';
 import { deployIntegrationTemplate } from '../../v1/flows/preBuilt/helpers.js';
 import { sendStepError } from '../errors.js';
 import { getFunctionCallbackBaseUrl } from '../helpers.js';
 import { functionDeploymentBodySchema } from '../validation.js';
 import { createDeploySandboxApiKey, requireCustomerKeyId, toFunctionDeploymentError } from './helpers.js';
 
-import type { RequestLocals } from '../../../utils/express.js';
+import type { RequestLocalsWithEnvironment } from '../../../utils/express.js';
 import type { DBSyncConfig, FunctionDeploymentCodeBody, FunctionDeploymentTemplateBody, PostFunctionDeployment } from '@nangohq/types';
 import type { Response } from 'express';
 
-type DeploymentResponse = Response<PostFunctionDeployment['Reply'], Required<RequestLocals>>;
+type DeploymentResponse = Response<PostFunctionDeployment['Reply'], RequestLocalsWithEnvironment>;
 
 function isProtectedExistingFunction(existingSyncConfig: Pick<DBSyncConfig, 'source'> | null): boolean {
     return Boolean(existingSyncConfig && existingSyncConfig.source !== 'standalone');
@@ -214,7 +214,7 @@ async function handleDeployCode(res: DeploymentResponse, body: FunctionDeploymen
     }
 }
 
-export const postFunctionDeployment = asyncWrapper<PostFunctionDeployment>(async (req, res) => {
+export const postFunctionDeployment = asyncWrapperWithEnvironment<PostFunctionDeployment>(async (req, res) => {
     const emptyQuery = requireEmptyQuery(req);
     if (emptyQuery) {
         res.status(400).send({ error: { code: 'invalid_query_params', errors: zodErrorToHTTP(emptyQuery.error) } });

--- a/packages/server/lib/controllers/functions/deploy/postDeployResult.ts
+++ b/packages/server/lib/controllers/functions/deploy/postDeployResult.ts
@@ -7,14 +7,14 @@ import {
 } from '@nangohq/sandbox';
 import { requireEmptyQuery, zodErrorToHTTP } from '@nangohq/utils';
 
-import { asyncWrapper } from '../../../utils/asyncWrapper.js';
+import { asyncWrapperWithEnvironment } from '../../../utils/asyncWrapper.js';
 import { normalizeFunctionErrorCode } from '../errors.js';
 import { functionDeploymentParamsSchema, functionDeploymentResultBodySchema } from '../validation.js';
 import { toFunctionDeploymentError, verifyDeploymentResultSandboxToken } from './helpers.js';
 
 import type { PostFunctionDeploymentResult } from '@nangohq/types';
 
-export const postFunctionDeploymentResult = asyncWrapper<PostFunctionDeploymentResult>(async (req, res) => {
+export const postFunctionDeploymentResult = asyncWrapperWithEnvironment<PostFunctionDeploymentResult>(async (req, res) => {
     const emptyQuery = requireEmptyQuery(req);
     if (emptyQuery) {
         res.status(400).send({ error: { code: 'invalid_query_params', errors: zodErrorToHTTP(emptyQuery.error) } });

--- a/packages/server/lib/controllers/functions/dryrun/getDryrun.ts
+++ b/packages/server/lib/controllers/functions/dryrun/getDryrun.ts
@@ -1,12 +1,12 @@
 import { getFunctionDryrun as getStoredFunctionDryrun } from '@nangohq/sandbox';
 import { requireEmptyQuery, zodErrorToHTTP } from '@nangohq/utils';
 
-import { asyncWrapper } from '../../../utils/asyncWrapper.js';
+import { asyncWrapperWithEnvironment } from '../../../utils/asyncWrapper.js';
 import { functionDryrunParamsSchema } from '../validation.js';
 
 import type { GetFunctionDryrun } from '@nangohq/types';
 
-export const getFunctionDryrun = asyncWrapper<GetFunctionDryrun>(async (req, res) => {
+export const getFunctionDryrun = asyncWrapperWithEnvironment<GetFunctionDryrun>(async (req, res) => {
     const emptyQuery = requireEmptyQuery(req);
     if (emptyQuery) {
         res.status(400).send({ error: { code: 'invalid_query_params', errors: zodErrorToHTTP(emptyQuery.error) } });

--- a/packages/server/lib/controllers/functions/dryrun/helpers.ts
+++ b/packages/server/lib/controllers/functions/dryrun/helpers.ts
@@ -20,7 +20,7 @@ export async function createDryrunSandboxApiKey(parentApiKeyId: number, environm
     });
 }
 
-export function requireCustomerKeyId<T>(res: Response<T, Required<RequestLocals>>, message: string): number | null {
+export function requireCustomerKeyId<T>(res: Response<T, RequestLocals>, message: string): number | null {
     if (res.locals['apiKeyAuthSource'] !== 'customer_key' || !res.locals['apiKeyId']) {
         res.status(403).send({ error: { code: 'forbidden', message } } as T);
         return null;
@@ -29,7 +29,7 @@ export function requireCustomerKeyId<T>(res: Response<T, Required<RequestLocals>
     return res.locals['apiKeyId'];
 }
 
-export function verifyDryrunResultSandboxToken<T>(res: Response<T, Required<RequestLocals>>, dryrunId: string): boolean {
+export function verifyDryrunResultSandboxToken<T>(res: Response<T, RequestLocals>, dryrunId: string): boolean {
     if (res.locals['sandboxTokenPurpose'] !== 'dryrun' || res.locals['sandboxTokenDryrunId'] !== dryrunId) {
         res.status(403).send({ error: { code: 'forbidden', message: 'This sandbox token is not authorized for this dryrun' } } as T);
         return false;

--- a/packages/server/lib/controllers/functions/dryrun/postDryrun.ts
+++ b/packages/server/lib/controllers/functions/dryrun/postDryrun.ts
@@ -9,7 +9,7 @@ import {
 import { configService, connectionService } from '@nangohq/shared';
 import { requireEmptyQuery, zodErrorToHTTP } from '@nangohq/utils';
 
-import { asyncWrapper } from '../../../utils/asyncWrapper.js';
+import { asyncWrapperWithEnvironment } from '../../../utils/asyncWrapper.js';
 import { sendStepError } from '../errors.js';
 import { getFunctionCallbackBaseUrl } from '../helpers.js';
 import { functionDryrunBodySchema } from '../validation.js';
@@ -17,7 +17,7 @@ import { createDryrunSandboxApiKey, defaultFunctionName, requireCustomerKeyId, t
 
 import type { PostFunctionDryrun } from '@nangohq/types';
 
-export const postFunctionDryrun = asyncWrapper<PostFunctionDryrun>(async (req, res) => {
+export const postFunctionDryrun = asyncWrapperWithEnvironment<PostFunctionDryrun>(async (req, res) => {
     const emptyQuery = requireEmptyQuery(req);
     if (emptyQuery) {
         res.status(400).send({ error: { code: 'invalid_query_params', errors: zodErrorToHTTP(emptyQuery.error) } });

--- a/packages/server/lib/controllers/functions/dryrun/postDryrunResult.ts
+++ b/packages/server/lib/controllers/functions/dryrun/postDryrunResult.ts
@@ -1,14 +1,14 @@
 import { getFunctionDryrunRow, markFunctionDryrunFailed, markFunctionDryrunSuccess, parseDryrunSuccessOutput, sandboxService } from '@nangohq/sandbox';
 import { requireEmptyQuery, zodErrorToHTTP } from '@nangohq/utils';
 
-import { asyncWrapper } from '../../../utils/asyncWrapper.js';
+import { asyncWrapperWithEnvironment } from '../../../utils/asyncWrapper.js';
 import { normalizeFunctionErrorCode } from '../errors.js';
 import { functionDryrunParamsSchema, functionDryrunResultBodySchema } from '../validation.js';
 import { toFunctionDryrunError, verifyDryrunResultSandboxToken } from './helpers.js';
 
 import type { PostFunctionDryrunResult } from '@nangohq/types';
 
-export const postFunctionDryrunResult = asyncWrapper<PostFunctionDryrunResult>(async (req, res) => {
+export const postFunctionDryrunResult = asyncWrapperWithEnvironment<PostFunctionDryrunResult>(async (req, res) => {
     const emptyQuery = requireEmptyQuery(req);
     if (emptyQuery) {
         res.status(400).send({ error: { code: 'invalid_query_params', errors: zodErrorToHTTP(emptyQuery.error) } });

--- a/packages/server/lib/controllers/functions/functions.integration.test.ts
+++ b/packages/server/lib/controllers/functions/functions.integration.test.ts
@@ -25,9 +25,10 @@ async function seedAccount(scopes?: ApiKeyScope[]) {
 async function createApiKeyWithScopes(seed: Awaited<ReturnType<typeof seedAccount>>, scopes: string[]) {
     const key = await customerKeyService.createApiKey(db.knex, {
         accountId: seed.account.id,
-        environmentId: seed.env.id,
+        target: { type: 'environment', environmentId: seed.env.id },
         displayName: `test-${randomUUID()}`,
-        scopes
+        scopes,
+        withSandboxSigningSecret: true
     });
 
     return key.unwrap();

--- a/packages/server/lib/controllers/integrations/getListIntegrations.ts
+++ b/packages/server/lib/controllers/integrations/getListIntegrations.ts
@@ -3,11 +3,11 @@ import { configService, getProviders } from '@nangohq/shared';
 import { requireEmptyQuery, zodErrorToHTTP } from '@nangohq/utils';
 
 import { integrationToPublicApi } from '../../formatters/integration.js';
-import { asyncWrapper } from '../../utils/asyncWrapper.js';
+import { asyncWrapperWithEnvironment } from '../../utils/asyncWrapper.js';
 
 import type { GetPublicListIntegrations } from '@nangohq/types';
 
-export const getPublicListIntegrations = asyncWrapper<GetPublicListIntegrations>(async (req, res) => {
+export const getPublicListIntegrations = asyncWrapperWithEnvironment<GetPublicListIntegrations>(async (req, res) => {
     const emptyQuery = requireEmptyQuery(req);
     if (emptyQuery) {
         res.status(400).send({ error: { code: 'invalid_query_params', errors: zodErrorToHTTP(emptyQuery.error) } });

--- a/packages/server/lib/controllers/integrations/postIntegration.ts
+++ b/packages/server/lib/controllers/integrations/postIntegration.ts
@@ -11,7 +11,7 @@ import {
     providerConfigKeySchema,
     providerSchema
 } from '../../helpers/validation.js';
-import { asyncWrapper } from '../../utils/asyncWrapper.js';
+import { asyncWrapperWithEnvironment } from '../../utils/asyncWrapper.js';
 import { resolveIntegrationConfig } from '../v1/integrations/integrationConfig.js';
 
 import type { DBCreateIntegration, PostPublicIntegration, PostPublicQuickstartIntegration } from '@nangohq/types';
@@ -32,7 +32,7 @@ const validationBody = baseValidationBody.extend({
 
 const quickstartAuthModes = new Set(['OAUTH1', 'OAUTH2']);
 
-export const postPublicIntegration = asyncWrapper<PostPublicIntegration>(async (req, res) => {
+export const postPublicIntegration = asyncWrapperWithEnvironment<PostPublicIntegration>(async (req, res) => {
     const emptyQuery = requireEmptyQuery(req);
     if (emptyQuery) {
         res.status(400).send({ error: { code: 'invalid_query_params', errors: zodErrorToHTTP(emptyQuery.error) } });
@@ -142,7 +142,7 @@ export const postPublicIntegration = asyncWrapper<PostPublicIntegration>(async (
     });
 });
 
-export const postPublicQuickstartIntegration = asyncWrapper<PostPublicQuickstartIntegration>(async (req, res) => {
+export const postPublicQuickstartIntegration = asyncWrapperWithEnvironment<PostPublicQuickstartIntegration>(async (req, res) => {
     const emptyQuery = requireEmptyQuery(req);
     if (emptyQuery) {
         res.status(400).send({ error: { code: 'invalid_query_params', errors: zodErrorToHTTP(emptyQuery.error) } });

--- a/packages/server/lib/controllers/integrations/uniqueKey/deleteIntegration.ts
+++ b/packages/server/lib/controllers/integrations/uniqueKey/deleteIntegration.ts
@@ -1,7 +1,7 @@
 import { configService } from '@nangohq/shared';
 import { requireEmptyQuery, zodErrorToHTTP } from '@nangohq/utils';
 
-import { asyncWrapper } from '../../../utils/asyncWrapper.js';
+import { asyncWrapperWithEnvironment } from '../../../utils/asyncWrapper.js';
 import { getOrchestrator } from '../../../utils/utils.js';
 import { validationParams } from './getIntegration.js';
 
@@ -9,7 +9,7 @@ import type { DeletePublicIntegration } from '@nangohq/types';
 
 const orchestrator = getOrchestrator();
 
-export const deletePublicIntegration = asyncWrapper<DeletePublicIntegration>(async (req, res) => {
+export const deletePublicIntegration = asyncWrapperWithEnvironment<DeletePublicIntegration>(async (req, res) => {
     const emptyQuery = requireEmptyQuery(req);
     if (emptyQuery) {
         res.status(400).send({ error: { code: 'invalid_query_params', errors: zodErrorToHTTP(emptyQuery.error) } });

--- a/packages/server/lib/controllers/integrations/uniqueKey/functions/deleteFunction.ts
+++ b/packages/server/lib/controllers/integrations/uniqueKey/functions/deleteFunction.ts
@@ -3,7 +3,7 @@ import * as z from 'zod';
 import { zodErrorToHTTP } from '@nangohq/utils';
 
 import { deletableFunctionTypeSchema, providerConfigKeySchema, scriptNameSchema } from '../../../../helpers/validation.js';
-import { asyncWrapper } from '../../../../utils/asyncWrapper.js';
+import { asyncWrapperWithEnvironment } from '../../../../utils/asyncWrapper.js';
 import { handleDeleteIntegrationFunction } from '../../../shared/integrations/functions/deleteFunction.js';
 
 import type { DeletePublicIntegrationFunction } from '@nangohq/types';
@@ -22,7 +22,7 @@ const validationQuery = z
     })
     .strict();
 
-export const deletePublicIntegrationFunction = asyncWrapper<DeletePublicIntegrationFunction>(async (req, res) => {
+export const deletePublicIntegrationFunction = asyncWrapperWithEnvironment<DeletePublicIntegrationFunction>(async (req, res) => {
     const valQuery = validationQuery.safeParse(req.query);
     if (!valQuery.success) {
         res.status(400).send({ error: { code: 'invalid_query_params', errors: zodErrorToHTTP(valQuery.error) } });

--- a/packages/server/lib/controllers/integrations/uniqueKey/functions/getCode.ts
+++ b/packages/server/lib/controllers/integrations/uniqueKey/functions/getCode.ts
@@ -3,7 +3,7 @@ import * as z from 'zod';
 import { zodErrorToHTTP } from '@nangohq/utils';
 
 import { functionTypeSchema, providerConfigKeySchema, scriptNameSchema } from '../../../../helpers/validation.js';
-import { asyncWrapper } from '../../../../utils/asyncWrapper.js';
+import { asyncWrapperWithEnvironment } from '../../../../utils/asyncWrapper.js';
 import { handleGetFunctionCode } from '../../../shared/integrations/functions/getCode.js';
 
 import type { GetPublicFunctionCode } from '@nangohq/types';
@@ -21,7 +21,7 @@ const validationQuery = z
     })
     .strict();
 
-export const getFunctionCode = asyncWrapper<GetPublicFunctionCode>(async (req, res) => {
+export const getFunctionCode = asyncWrapperWithEnvironment<GetPublicFunctionCode>(async (req, res) => {
     const valParams = validationParams.safeParse(req.params);
     if (!valParams.success) {
         res.status(400).send({ error: { code: 'invalid_uri_params', errors: zodErrorToHTTP(valParams.error) } });

--- a/packages/server/lib/controllers/integrations/uniqueKey/functions/getFunction.ts
+++ b/packages/server/lib/controllers/integrations/uniqueKey/functions/getFunction.ts
@@ -3,7 +3,7 @@ import * as z from 'zod';
 import { zodErrorToHTTP } from '@nangohq/utils';
 
 import { functionTypeSchema, providerConfigKeySchema, scriptNameSchema } from '../../../../helpers/validation.js';
-import { asyncWrapper } from '../../../../utils/asyncWrapper.js';
+import { asyncWrapperWithEnvironment } from '../../../../utils/asyncWrapper.js';
 import { handleGetIntegrationFunction } from '../../../shared/integrations/functions/getFunction.js';
 
 import type { GetPublicIntegrationFunction } from '@nangohq/types';
@@ -21,7 +21,7 @@ const validationQuery = z
     })
     .strict();
 
-export const getPublicIntegrationFunction = asyncWrapper<GetPublicIntegrationFunction>(async (req, res) => {
+export const getPublicIntegrationFunction = asyncWrapperWithEnvironment<GetPublicIntegrationFunction>(async (req, res) => {
     const valQuery = validationQuery.safeParse(req.query);
     if (!valQuery.success) {
         res.status(400).send({ error: { code: 'invalid_query_params', errors: zodErrorToHTTP(valQuery.error) } });

--- a/packages/server/lib/controllers/integrations/uniqueKey/functions/getFunctions.ts
+++ b/packages/server/lib/controllers/integrations/uniqueKey/functions/getFunctions.ts
@@ -3,7 +3,7 @@ import * as z from 'zod';
 import { zodErrorToHTTP } from '@nangohq/utils';
 
 import { functionListQueryFields, providerConfigKeySchema } from '../../../../helpers/validation.js';
-import { asyncWrapper } from '../../../../utils/asyncWrapper.js';
+import { asyncWrapperWithEnvironment } from '../../../../utils/asyncWrapper.js';
 import { handleListIntegrationFunctions } from '../../../shared/integrations/functions/listFunctions.js';
 
 import type { GetPublicIntegrationFunctions } from '@nangohq/types';
@@ -16,7 +16,7 @@ const validationParams = z
 
 const validationQuery = z.object({ ...functionListQueryFields }).strict();
 
-export const getPublicIntegrationFunctions = asyncWrapper<GetPublicIntegrationFunctions>(async (req, res) => {
+export const getPublicIntegrationFunctions = asyncWrapperWithEnvironment<GetPublicIntegrationFunctions>(async (req, res) => {
     const valQuery = validationQuery.safeParse(req.query);
     if (!valQuery.success) {
         res.status(400).send({ error: { code: 'invalid_query_params', errors: zodErrorToHTTP(valQuery.error) } });

--- a/packages/server/lib/controllers/integrations/uniqueKey/getIntegration.ts
+++ b/packages/server/lib/controllers/integrations/uniqueKey/getIntegration.ts
@@ -6,7 +6,7 @@ import { zodErrorToHTTP } from '@nangohq/utils';
 import { integrationToPublicApi } from '../../../formatters/integration.js';
 import { providerConfigKeySchema } from '../../../helpers/validation.js';
 import { hasScope } from '../../../middleware/scope.middleware.js';
-import { asyncWrapper } from '../../../utils/asyncWrapper.js';
+import { asyncWrapperWithEnvironment } from '../../../utils/asyncWrapper.js';
 
 import type { ApiPublicIntegrationInclude, GetPublicIntegration } from '@nangohq/types';
 
@@ -26,7 +26,7 @@ const validationQuery = z
     })
     .strict();
 
-export const getPublicIntegration = asyncWrapper<GetPublicIntegration>(async (req, res) => {
+export const getPublicIntegration = asyncWrapperWithEnvironment<GetPublicIntegration>(async (req, res) => {
     const valQuery = validationQuery.safeParse(req.query);
     if (!valQuery.success) {
         res.status(400).send({ error: { code: 'invalid_query_params', errors: zodErrorToHTTP(valQuery.error) } });

--- a/packages/server/lib/controllers/integrations/uniqueKey/patchIntegration.ts
+++ b/packages/server/lib/controllers/integrations/uniqueKey/patchIntegration.ts
@@ -10,7 +10,7 @@ import {
     integrationForwardWebhooksSchema,
     providerConfigKeySchema
 } from '../../../helpers/validation.js';
-import { asyncWrapper } from '../../../utils/asyncWrapper.js';
+import { asyncWrapperWithEnvironment } from '../../../utils/asyncWrapper.js';
 import { resolveIntegrationConfig } from '../../v1/integrations/integrationConfig.js';
 import { validationParams } from './getIntegration.js';
 
@@ -27,7 +27,7 @@ const validationBody = z
     })
     .strict();
 
-export const patchPublicIntegration = asyncWrapper<PatchPublicIntegration>(async (req, res) => {
+export const patchPublicIntegration = asyncWrapperWithEnvironment<PatchPublicIntegration>(async (req, res) => {
     const emptyQuery = requireEmptyQuery(req);
     if (emptyQuery) {
         res.status(400).send({ error: { code: 'invalid_query_params', errors: zodErrorToHTTP(emptyQuery.error) } });

--- a/packages/server/lib/controllers/mcp/connectionTools.ts
+++ b/packages/server/lib/controllers/mcp/connectionTools.ts
@@ -5,7 +5,7 @@ import { connectionService } from '@nangohq/shared';
 import { zodErrorToHTTP } from '@nangohq/utils';
 
 import { connectionIdSchema, providerConfigKeySchema } from '../../helpers/validation.js';
-import { asyncWrapper } from '../../utils/asyncWrapper.js';
+import { asyncWrapperWithEnvironment } from '../../utils/asyncWrapper.js';
 import { createConnectionToolsMcpServer } from './connectionToolsServer.js';
 
 import type { Transport } from '@modelcontextprotocol/sdk/shared/transport.js';
@@ -18,7 +18,7 @@ export const validationHeaders = z
     })
     .strict();
 
-export const postConnectionToolsMcp = asyncWrapper<PostConnectionToolsMcp>(async (req, res) => {
+export const postConnectionToolsMcp = asyncWrapperWithEnvironment<PostConnectionToolsMcp>(async (req, res) => {
     const valHeaders = validationHeaders.safeParse({ 'connection-id': req.get('connection-id'), 'provider-config-key': req.get('provider-config-key') });
     if (!valHeaders.success) {
         res.status(400).send({ error: { code: 'invalid_headers', errors: zodErrorToHTTP(valHeaders.error) } });
@@ -60,7 +60,7 @@ export const postConnectionToolsMcp = asyncWrapper<PostConnectionToolsMcp>(async
 });
 
 // We have to be explicit about not supporting SSE
-export const getConnectionToolsMcp = asyncWrapper<GetConnectionToolsMcp>((_, res) => {
+export const getConnectionToolsMcp = asyncWrapperWithEnvironment<GetConnectionToolsMcp>((_, res) => {
     res.writeHead(405).end(
         JSON.stringify({
             jsonrpc: '2.0',

--- a/packages/server/lib/controllers/mcp/controlPlane.integration.test.ts
+++ b/packages/server/lib/controllers/mcp/controlPlane.integration.test.ts
@@ -6,7 +6,7 @@ import { logContextGetter } from '@nangohq/logs';
 import { seeders } from '@nangohq/shared';
 
 import type { authenticateUser as authenticateUserType, runServer as runServerType } from '../../utils/tests.js';
-import type { ApiKeyScope } from '@nangohq/types';
+import type { EnvironmentApiKeyScope } from '@nangohq/types';
 
 type AuthenticateUser = typeof authenticateUserType;
 type RunServer = typeof runServerType;
@@ -114,7 +114,7 @@ function parseServerSentEventJson(data: string): any {
     throw new Error('MCP SSE response did not contain a data payload');
 }
 
-async function createKeyWithScopes(scopes: ApiKeyScope[]) {
+async function createKeyWithScopes(scopes: EnvironmentApiKeyScope[]) {
     const { env, account, user } = await seeders.seedAccountEnvAndUser();
     const session = await authenticateUser(api, user);
     const res = await api.fetch('/api/v1/environment/api-keys', {

--- a/packages/server/lib/controllers/mcp/controlPlane.ts
+++ b/packages/server/lib/controllers/mcp/controlPlane.ts
@@ -1,12 +1,12 @@
 import { StreamableHTTPServerTransport } from '@modelcontextprotocol/sdk/server/streamableHttp.js';
 
-import { asyncWrapper } from '../../utils/asyncWrapper.js';
+import { asyncWrapperWithEnvironment } from '../../utils/asyncWrapper.js';
 import { createControlPlaneMcpServer } from './controlPlaneServer.js';
 
 import type { Transport } from '@modelcontextprotocol/sdk/shared/transport.js';
 import type { GetControlPlaneMcp, PostControlPlaneMcp } from '@nangohq/types';
 
-export const postControlPlaneMcp = asyncWrapper<PostControlPlaneMcp>(async (req, res) => {
+export const postControlPlaneMcp = asyncWrapperWithEnvironment<PostControlPlaneMcp>(async (req, res) => {
     const { account, environment } = res.locals;
     const server = createControlPlaneMcpServer(account, environment, res.locals['apiKeyScopes']);
     const transport: StreamableHTTPServerTransport = new StreamableHTTPServerTransport();
@@ -21,7 +21,7 @@ export const postControlPlaneMcp = asyncWrapper<PostControlPlaneMcp>(async (req,
 });
 
 // We have to be explicit about not supporting SSE
-export const getControlPlaneMcp = asyncWrapper<GetControlPlaneMcp>((_, res) => {
+export const getControlPlaneMcp = asyncWrapperWithEnvironment<GetControlPlaneMcp>((_, res) => {
     res.writeHead(405).end(
         JSON.stringify({
             jsonrpc: '2.0',

--- a/packages/server/lib/controllers/oauth.controller.ts
+++ b/packages/server/lib/controllers/oauth.controller.ts
@@ -43,6 +43,7 @@ import {
 } from '../hooks/hooks.js';
 import { getConnectSession } from '../services/connectSession.service.js';
 import oAuthSessionService from '../services/oauth-session.service.js';
+import { requireEnvironment } from '../utils/asyncWrapper.js';
 import { errorRestrictConnectionId, isIntegrationAllowed, resolveOutboundWebhookUrlOverride } from '../utils/auth.js';
 import { hmacCheck } from '../utils/hmac.js';
 import { authHtml } from '../utils/html.js';
@@ -94,8 +95,12 @@ function normalizeHeaderTag(value: string | undefined, allowed: Set<string>): st
 }
 
 class OAuthController {
-    public async oauthRequest(req: Request, res: Response<any, Required<RequestLocals>>, _next: NextFunction) {
-        const { account, environment, connectSession } = res.locals;
+    public async oauthRequest(req: Request, res: Response<any, RequestLocals>, _next: NextFunction) {
+        const { account, connectSession } = res.locals;
+        const environment = requireEnvironment(req, res);
+        if (!environment) {
+            return;
+        }
         const environmentId = environment.id;
         const { providerConfigKey } = req.params;
         const receivedConnectionId = req.query['connection_id'] as string | undefined;
@@ -360,8 +365,12 @@ class OAuthController {
         }
     }
 
-    public async oauth2RequestCC(req: Request, res: Response<any, Required<RequestLocals>>, next: NextFunction) {
-        const { environment, account, connectSession } = res.locals;
+    public async oauth2RequestCC(req: Request, res: Response<any, RequestLocals>, next: NextFunction) {
+        const { account, connectSession } = res.locals;
+        const environment = requireEnvironment(req, res);
+        if (!environment) {
+            return;
+        }
         const { providerConfigKey } = req.params;
         const receivedConnectionId = req.query['connection_id'] as string | undefined;
         let connectionId = receivedConnectionId || connectionService.generateConnectionId();

--- a/packages/server/lib/controllers/proxy/allProxy.ts
+++ b/packages/server/lib/controllers/proxy/allProxy.ts
@@ -28,7 +28,7 @@ import { getHeaders, getLogger, isBaseUrlOverrideDenied, metrics, normalizeDenyl
 import { envs } from '../../env.js';
 import { connectionIdSchema, providerConfigKeySchema } from '../../helpers/validation.js';
 import { connectionRefreshFailed, connectionRefreshSuccess } from '../../hooks/hooks.js';
-import { asyncWrapper } from '../../utils/asyncWrapper.js';
+import { asyncWrapperWithEnvironment } from '../../utils/asyncWrapper.js';
 import { egressTelemetryRecorder } from '../../utils/egressTelemetry.js';
 import { capping } from '../../utils/usage.js';
 
@@ -130,7 +130,7 @@ function applyFilteredResponseHeaders(res: Response, headers: Record<string, unk
     }
 }
 
-export const allPublicProxy = asyncWrapper<AllPublicProxy>(async (req, res, next) => {
+export const allPublicProxy = asyncWrapperWithEnvironment<AllPublicProxy>(async (req, res, next) => {
     const valHeaders = schemaHeaders.safeParse(req.headers);
     if (!valHeaders.success) {
         res.status(400).send({ error: { code: 'invalid_headers', errors: zodErrorToHTTP(valHeaders.error) } });

--- a/packages/server/lib/controllers/records/getRecords.ts
+++ b/packages/server/lib/controllers/records/getRecords.ts
@@ -6,7 +6,7 @@ import { connectionService } from '@nangohq/shared';
 import { ENVS, metrics, parseEnvs, zodErrorToHTTP } from '@nangohq/utils';
 
 import { connectionIdSchema, modelSchema, providerConfigKeySchema, variantSchema } from '../../helpers/validation.js';
-import { asyncWrapper } from '../../utils/asyncWrapper.js';
+import { asyncWrapperWithEnvironment } from '../../utils/asyncWrapper.js';
 import { egressTelemetryRecorder } from '../../utils/egressTelemetry.js';
 
 import type { GetPublicRecords } from '@nangohq/types';
@@ -51,7 +51,7 @@ export const validationHeaders = z
     })
     .strict();
 
-export const getPublicRecords = asyncWrapper<GetPublicRecords>(async (req, res) => {
+export const getPublicRecords = asyncWrapperWithEnvironment<GetPublicRecords>(async (req, res) => {
     const valQuery = validationQuery.safeParse(req.query);
     if (!valQuery.success) {
         res.status(400).send({ error: { code: 'invalid_query_params', errors: zodErrorToHTTP(valQuery.error) } });

--- a/packages/server/lib/controllers/records/patchPruneRecords.ts
+++ b/packages/server/lib/controllers/records/patchPruneRecords.ts
@@ -5,7 +5,7 @@ import { connectionService } from '@nangohq/shared';
 import { requireEmptyQuery, zodErrorToHTTP } from '@nangohq/utils';
 
 import { connectionIdSchema, modelSchema, providerConfigKeySchema, variantSchema } from '../../helpers/validation.js';
-import { asyncWrapper } from '../../utils/asyncWrapper.js';
+import { asyncWrapperWithEnvironment } from '../../utils/asyncWrapper.js';
 
 import type { PatchPublicPruneRecords } from '@nangohq/types';
 
@@ -24,7 +24,7 @@ export const validationHeaders = z
     })
     .strict();
 
-export const patchPublicPruneRecords = asyncWrapper<PatchPublicPruneRecords>(async (req, res) => {
+export const patchPublicPruneRecords = asyncWrapperWithEnvironment<PatchPublicPruneRecords>(async (req, res) => {
     const emptyQuery = requireEmptyQuery(req);
     if (emptyQuery) {
         res.status(400).send({ error: { code: 'invalid_query_params', errors: zodErrorToHTTP(emptyQuery.error) } });

--- a/packages/server/lib/controllers/scripts/config/getScriptsConfig.ts
+++ b/packages/server/lib/controllers/scripts/config/getScriptsConfig.ts
@@ -4,7 +4,7 @@ import { getSyncConfigsAsStandardConfig } from '@nangohq/shared';
 import { getDefinition } from '@nangohq/utils';
 
 import { providerNameSchema } from '../../../helpers/validation.js';
-import { asyncWrapper } from '../../../utils/asyncWrapper.js';
+import { asyncWrapperWithEnvironment } from '../../../utils/asyncWrapper.js';
 
 import type { GetPublicScriptsConfig, OpenAIFunction, StandardNangoConfig } from '@nangohq/types';
 import type { JSONSchema7 } from 'json-schema';
@@ -21,7 +21,7 @@ export const validationParams = z
     })
     .strict();
 
-export const getPublicScriptsConfig = asyncWrapper<GetPublicScriptsConfig>(async (req, res) => {
+export const getPublicScriptsConfig = asyncWrapperWithEnvironment<GetPublicScriptsConfig>(async (req, res) => {
     const { format = NANGO_FORMAT } = req.query as { format?: Format };
     const { environment } = res.locals;
 

--- a/packages/server/lib/controllers/shared/connections/patchConnection.ts
+++ b/packages/server/lib/controllers/shared/connections/patchConnection.ts
@@ -6,7 +6,7 @@ import { Err, Ok } from '@nangohq/utils';
 
 import { connectionTagsSchema, endUserSchema, webhookUrlSchema } from '../../../helpers/validation.js';
 
-import type { RequestLocals } from '../../../utils/express.js';
+import type { RequestLocalsWithEnvironment } from '../../../utils/express.js';
 import type { DBEnvironment, DBTeam, EndUserInput, PatchPublicConnection, Tags } from '@nangohq/types';
 import type { Response } from 'express';
 
@@ -24,7 +24,7 @@ export async function handlePatchConnection({
     providerConfigKey,
     body
 }: {
-    res: Response<PatchPublicConnection['Reply'], Required<RequestLocals>>;
+    res: Response<PatchPublicConnection['Reply'], RequestLocalsWithEnvironment>;
     account: DBTeam;
     environment: DBEnvironment;
     connectionId: string;

--- a/packages/server/lib/controllers/shared/connections/postConnectionMetadata.ts
+++ b/packages/server/lib/controllers/shared/connections/postConnectionMetadata.ts
@@ -1,7 +1,7 @@
 import db from '@nangohq/database';
 import { configService, connectionService } from '@nangohq/shared';
 
-import type { RequestLocals } from '../../../utils/express.js';
+import type { RequestLocalsWithEnvironment } from '../../../utils/express.js';
 import type { DBEnvironment, Metadata, PostConnectionMetadata } from '@nangohq/types';
 import type { Response } from 'express';
 
@@ -12,7 +12,7 @@ export async function handlePostConnectionMetadata({
     providerConfigKey,
     metadata
 }: {
-    res: Response<PostConnectionMetadata['Reply'], Required<RequestLocals>>;
+    res: Response<PostConnectionMetadata['Reply'], RequestLocalsWithEnvironment>;
     environment: DBEnvironment;
     connectionId: string;
     providerConfigKey: string;

--- a/packages/server/lib/controllers/shared/integrations/functions/deleteFunction.ts
+++ b/packages/server/lib/controllers/shared/integrations/functions/deleteFunction.ts
@@ -3,7 +3,7 @@ import { report } from '@nangohq/utils';
 
 import { startFunctionDeletion } from '../../../../tasks/startFunctionDeletion.js';
 
-import type { RequestLocals } from '../../../../utils/express.js';
+import type { RequestLocalsWithEnvironment } from '../../../../utils/express.js';
 import type { DBEnvironment, DeleteIntegrationFunction } from '@nangohq/types';
 import type { Response } from 'express';
 
@@ -14,7 +14,7 @@ export async function handleDeleteIntegrationFunction({
     name,
     type
 }: {
-    res: Response<DeleteIntegrationFunction['Reply'], Required<RequestLocals>>;
+    res: Response<DeleteIntegrationFunction['Reply'], RequestLocalsWithEnvironment>;
     environment: DBEnvironment;
     providerConfigKey: string;
     name: string;

--- a/packages/server/lib/controllers/shared/integrations/functions/getCode.ts
+++ b/packages/server/lib/controllers/shared/integrations/functions/getCode.ts
@@ -4,7 +4,7 @@ import path from 'node:path';
 import { configService, getSyncAndActionConfigsBySyncNameAndConfigId, localFileService, onEventScriptService, remoteFileService } from '@nangohq/shared';
 import { report, useS3 } from '@nangohq/utils';
 
-import type { RequestLocals } from '../../../../utils/express.js';
+import type { RequestLocalsWithEnvironment } from '../../../../utils/express.js';
 import type { DBEnvironment, GetFunctionCode, ScriptTypeLiteral } from '@nangohq/types';
 import type { Response } from 'express';
 
@@ -46,7 +46,7 @@ export async function handleGetFunctionCode({
     name,
     type
 }: {
-    res: Response<GetFunctionCode['Reply'], Required<RequestLocals>>;
+    res: Response<GetFunctionCode['Reply'], RequestLocalsWithEnvironment>;
     environment: DBEnvironment;
     providerConfigKey: string;
     name: string;

--- a/packages/server/lib/controllers/shared/integrations/functions/getFunction.ts
+++ b/packages/server/lib/controllers/shared/integrations/functions/getFunction.ts
@@ -1,7 +1,7 @@
 import { configService, getFunction } from '@nangohq/shared';
 import { report } from '@nangohq/utils';
 
-import type { RequestLocals } from '../../../../utils/express.js';
+import type { RequestLocalsWithEnvironment } from '../../../../utils/express.js';
 import type { DBEnvironment, FunctionType, GetIntegrationFunction } from '@nangohq/types';
 import type { Response } from 'express';
 
@@ -12,7 +12,7 @@ export async function handleGetIntegrationFunction({
     name,
     type
 }: {
-    res: Response<GetIntegrationFunction['Reply'], Required<RequestLocals>>;
+    res: Response<GetIntegrationFunction['Reply'], RequestLocalsWithEnvironment>;
     environment: DBEnvironment;
     providerConfigKey: string;
     name: string;

--- a/packages/server/lib/controllers/shared/integrations/functions/listFunctions.ts
+++ b/packages/server/lib/controllers/shared/integrations/functions/listFunctions.ts
@@ -1,7 +1,7 @@
 import { configService, listFunctions } from '@nangohq/shared';
 import { report } from '@nangohq/utils';
 
-import type { RequestLocals } from '../../../../utils/express.js';
+import type { RequestLocalsWithEnvironment } from '../../../../utils/express.js';
 import type { DBEnvironment, FunctionType, GetIntegrationFunctions } from '@nangohq/types';
 import type { Response } from 'express';
 
@@ -14,7 +14,7 @@ export async function handleListIntegrationFunctions({
     page,
     limit
 }: {
-    res: Response<GetIntegrationFunctions['Reply'], Required<RequestLocals>>;
+    res: Response<GetIntegrationFunctions['Reply'], RequestLocalsWithEnvironment>;
     environment: DBEnvironment;
     providerConfigKey: string;
     type: FunctionType | undefined;

--- a/packages/server/lib/controllers/sync.controller.ts
+++ b/packages/server/lib/controllers/sync.controller.ts
@@ -12,6 +12,7 @@ import {
 } from '@nangohq/shared';
 import { isHosted } from '@nangohq/utils';
 
+import { requireEnvironment } from '../utils/asyncWrapper.js';
 import { getOrchestrator } from '../utils/utils.js';
 
 import type { RequestLocals } from '../utils/express.js';
@@ -22,9 +23,12 @@ import type { NextFunction, Request, Response } from 'express';
 const orchestrator = getOrchestrator();
 
 class SyncController {
-    public async getSyncsByParams(req: Request, res: Response<any, Required<RequestLocals>>, next: NextFunction) {
+    public async getSyncsByParams(req: Request, res: Response<any, RequestLocals>, next: NextFunction) {
         try {
-            const { environment } = res.locals;
+            const environment = requireEnvironment(req, res);
+            if (!environment) {
+                return;
+            }
             const { connection_id, provider_config_key } = req.query;
 
             const {
@@ -76,11 +80,15 @@ class SyncController {
         }
     }
 
-    public async syncCommand(req: Request, res: Response<any, Required<RequestLocals>>, next: NextFunction) {
+    public async syncCommand(req: Request, res: Response<any, RequestLocals>, next: NextFunction) {
         let logCtx: LogContextOrigin | undefined;
 
         try {
-            const { account, environment } = res.locals;
+            const { account } = res.locals;
+            const environment = requireEnvironment(req, res);
+            if (!environment) {
+                return;
+            }
 
             const { command, nango_connection_id, sync_id, sync_name, sync_variant, delete_records } = req.body;
             const connection = await connectionService.getConnectionById(nango_connection_id);

--- a/packages/server/lib/controllers/sync/deleteSyncVariant.ts
+++ b/packages/server/lib/controllers/sync/deleteSyncVariant.ts
@@ -5,7 +5,7 @@ import { configService, connectionService, getSync, syncManager } from '@nangohq
 import { requireEmptyQuery, zodErrorToHTTP } from '@nangohq/utils';
 
 import { connectionIdSchema, providerConfigKeySchema, syncNameSchema, variantSchema } from '../../helpers/validation.js';
-import { asyncWrapper } from '../../utils/asyncWrapper.js';
+import { asyncWrapperWithEnvironment } from '../../utils/asyncWrapper.js';
 import { getOrchestrator } from '../../utils/utils.js';
 
 import type { DeleteSyncVariant } from '@nangohq/types';
@@ -26,7 +26,7 @@ const paramsValidation = z
     })
     .strict();
 
-export const deleteSyncVariant = asyncWrapper<DeleteSyncVariant>(async (req, res) => {
+export const deleteSyncVariant = asyncWrapperWithEnvironment<DeleteSyncVariant>(async (req, res) => {
     const { account, environment } = res.locals;
     const logCtx = await logContextGetter.create({ operation: { type: 'sync', action: 'delete_variant' } }, { account, environment });
 

--- a/packages/server/lib/controllers/sync/deploy/postConfirmation.ts
+++ b/packages/server/lib/controllers/sync/deploy/postConfirmation.ts
@@ -2,7 +2,7 @@ import { logContextGetter } from '@nangohq/logs';
 import { getAndReconcileDifferences, onEventScriptService } from '@nangohq/shared';
 import { metrics, requireEmptyQuery, zodErrorToHTTP } from '@nangohq/utils';
 
-import { asyncWrapper } from '../../../utils/asyncWrapper.js';
+import { asyncWrapperWithEnvironment } from '../../../utils/asyncWrapper.js';
 import { getOrchestrator } from '../../../utils/utils.js';
 import { validation } from './validation.js';
 
@@ -10,7 +10,7 @@ import type { PostDeployConfirmation, ScriptDifferences } from '@nangohq/types';
 
 const orchestrator = getOrchestrator();
 
-export const postDeployConfirmation = asyncWrapper<PostDeployConfirmation>(async (req, res) => {
+export const postDeployConfirmation = asyncWrapperWithEnvironment<PostDeployConfirmation>(async (req, res) => {
     const emptyQuery = requireEmptyQuery(req);
     if (emptyQuery) {
         res.status(400).send({ error: { code: 'invalid_query_params', errors: zodErrorToHTTP(emptyQuery.error) } });

--- a/packages/server/lib/controllers/sync/deploy/postDeploy.ts
+++ b/packages/server/lib/controllers/sync/deploy/postDeploy.ts
@@ -6,7 +6,7 @@ import { getLogger, requireEmptyQuery, zodErrorToHTTP } from '@nangohq/utils';
 
 import { getCliContext } from '../../../middleware/cliVersionCheck.js';
 import { startFunctionDeletion } from '../../../tasks/startFunctionDeletion.js';
-import { asyncWrapper } from '../../../utils/asyncWrapper.js';
+import { asyncWrapperWithEnvironment } from '../../../utils/asyncWrapper.js';
 import { getOrchestrator } from '../../../utils/utils.js';
 import { validationWithNangoYaml as validation } from './validation.js';
 
@@ -16,7 +16,7 @@ import type { PostDeploy } from '@nangohq/types';
 const logger = getLogger('Server.PostDeploy');
 const orchestrator = getOrchestrator();
 
-export const postDeploy = asyncWrapper<PostDeploy>(async (req, res) => {
+export const postDeploy = asyncWrapperWithEnvironment<PostDeploy>(async (req, res) => {
     const emptyQuery = requireEmptyQuery(req);
     if (emptyQuery) {
         res.status(400).send({ error: { code: 'invalid_query_params', errors: zodErrorToHTTP(emptyQuery.error) } });

--- a/packages/server/lib/controllers/sync/getSyncStatus.ts
+++ b/packages/server/lib/controllers/sync/getSyncStatus.ts
@@ -5,7 +5,7 @@ import { connectionService, getSyncsByConnectionId, getSyncsByProviderConfigKey,
 import { Ok, zodErrorToHTTP } from '@nangohq/utils';
 
 import { connectionIdSchema, providerConfigKeySchema } from '../../helpers/validation.js';
-import { asyncWrapper } from '../../utils/asyncWrapper.js';
+import { asyncWrapperWithEnvironment } from '../../utils/asyncWrapper.js';
 import { getOrchestrator } from '../../utils/utils.js';
 
 import type { DBConnectionDecrypted, GetPublicSyncStatus } from '@nangohq/types';
@@ -18,7 +18,7 @@ const querySchema = z.strictObject({
     connection_id: connectionIdSchema.optional()
 });
 
-export const getPublicSyncStatus = asyncWrapper<GetPublicSyncStatus>(async (req, res) => {
+export const getPublicSyncStatus = asyncWrapperWithEnvironment<GetPublicSyncStatus>(async (req, res) => {
     const parsedQuery = querySchema.safeParse(req.query);
     if (!parsedQuery.success) {
         res.status(400).send({ error: { code: 'invalid_query_params', errors: zodErrorToHTTP(parsedQuery.error) } });

--- a/packages/server/lib/controllers/sync/postSyncPause.ts
+++ b/packages/server/lib/controllers/sync/postSyncPause.ts
@@ -5,7 +5,7 @@ import { errorManager, normalizedSyncParams, SyncCommand, syncManager } from '@n
 import { zodErrorToHTTP } from '@nangohq/utils';
 
 import { connectionIdSchema, providerConfigKeySchema } from '../../helpers/validation.js';
-import { asyncWrapper } from '../../utils/asyncWrapper.js';
+import { asyncWrapperWithEnvironment } from '../../utils/asyncWrapper.js';
 import { getOrchestrator } from '../../utils/utils.js';
 
 import type { PostPublicSyncPause } from '@nangohq/types';
@@ -21,7 +21,7 @@ const bodySchema = z.strictObject({
     connection_id: connectionIdSchema.optional()
 });
 
-export const postPublicSyncPause = asyncWrapper<PostPublicSyncPause>(async (req, res) => {
+export const postPublicSyncPause = asyncWrapperWithEnvironment<PostPublicSyncPause>(async (req, res) => {
     const parsedBody = bodySchema.safeParse(req.body);
     if (!parsedBody.success) {
         res.status(400).send({ error: { code: 'invalid_body', errors: zodErrorToHTTP(parsedBody.error) } });

--- a/packages/server/lib/controllers/sync/postSyncStart.ts
+++ b/packages/server/lib/controllers/sync/postSyncStart.ts
@@ -5,7 +5,7 @@ import { errorManager, normalizedSyncParams, SyncCommand, syncManager } from '@n
 import { zodErrorToHTTP } from '@nangohq/utils';
 
 import { connectionIdSchema, providerConfigKeySchema } from '../../helpers/validation.js';
-import { asyncWrapper } from '../../utils/asyncWrapper.js';
+import { asyncWrapperWithEnvironment } from '../../utils/asyncWrapper.js';
 import { getOrchestrator } from '../../utils/utils.js';
 
 import type { PostPublicSyncStart } from '@nangohq/types';
@@ -21,7 +21,7 @@ const bodySchema = z.strictObject({
     connection_id: connectionIdSchema.optional()
 });
 
-export const postPublicSyncStart = asyncWrapper<PostPublicSyncStart>(async (req, res) => {
+export const postPublicSyncStart = asyncWrapperWithEnvironment<PostPublicSyncStart>(async (req, res) => {
     const parsedBody = bodySchema.safeParse(req.body);
     if (!parsedBody.success) {
         res.status(400).send({ error: { code: 'invalid_body', errors: zodErrorToHTTP(parsedBody.error) } });

--- a/packages/server/lib/controllers/sync/postSyncVariant.ts
+++ b/packages/server/lib/controllers/sync/postSyncVariant.ts
@@ -6,7 +6,7 @@ import { requireEmptyQuery, zodErrorToHTTP } from '@nangohq/utils';
 
 import { envs } from '../../env.js';
 import { connectionIdSchema, providerConfigKeySchema, syncNameSchema, variantSchema } from '../../helpers/validation.js';
-import { asyncWrapper } from '../../utils/asyncWrapper.js';
+import { asyncWrapperWithEnvironment } from '../../utils/asyncWrapper.js';
 import { getOrchestrator } from '../../utils/utils.js';
 
 import type { DBConnection, PostSyncVariant } from '@nangohq/types';
@@ -27,7 +27,7 @@ const paramsValidation = z
     })
     .strict();
 
-export const postSyncVariant = asyncWrapper<PostSyncVariant>(async (req, res) => {
+export const postSyncVariant = asyncWrapperWithEnvironment<PostSyncVariant>(async (req, res) => {
     const { account, environment, plan } = res.locals;
     const logCtx = await logContextGetter.create({ operation: { type: 'sync', action: 'create_variant' } }, { account, environment });
 

--- a/packages/server/lib/controllers/sync/postTrigger.ts
+++ b/packages/server/lib/controllers/sync/postTrigger.ts
@@ -4,7 +4,7 @@ import { logContextGetter } from '@nangohq/logs';
 import { errorManager, SyncCommand, syncManager } from '@nangohq/shared';
 import { requireEmptyQuery, zodErrorToHTTP } from '@nangohq/utils';
 
-import { asyncWrapper } from '../../utils/asyncWrapper.js';
+import { asyncWrapperWithEnvironment } from '../../utils/asyncWrapper.js';
 import { getOrchestrator } from '../../utils/utils.js';
 import { normalizeSyncParams } from './helpers.js';
 
@@ -37,7 +37,7 @@ const headersValidation = z.object({
 
 const orchestrator = getOrchestrator();
 
-export const postPublicTrigger = asyncWrapper<PostPublicTrigger>(async (req, res) => {
+export const postPublicTrigger = asyncWrapperWithEnvironment<PostPublicTrigger>(async (req, res) => {
     const emptyQuery = requireEmptyQuery(req);
     if (emptyQuery) {
         res.status(400).send({ error: { code: 'invalid_query_params', errors: zodErrorToHTTP(emptyQuery.error) } });

--- a/packages/server/lib/controllers/sync/putSyncConnectionFrequency.ts
+++ b/packages/server/lib/controllers/sync/putSyncConnectionFrequency.ts
@@ -5,7 +5,7 @@ import { configService, connectionService, getSyncAndActionConfigsBySyncNameAndC
 import { requireEmptyQuery, zodErrorToHTTP } from '@nangohq/utils';
 
 import { connectionIdSchema, frequencySchema, providerConfigKeySchema, syncNameSchema } from '../../helpers/validation.js';
-import { asyncWrapper } from '../../utils/asyncWrapper.js';
+import { asyncWrapperWithEnvironment } from '../../utils/asyncWrapper.js';
 import { getOrchestrator } from '../../utils/utils.js';
 
 import type { PutPublicSyncConnectionFrequency } from '@nangohq/types';
@@ -28,7 +28,7 @@ const orchestrator = getOrchestrator();
  * Allow users to change the default frequency value of a sync without losing the value.
  * The system will store the value inside `_nango_syncs.frequency` and update the relevant schedules.
  */
-export const putSyncConnectionFrequency = asyncWrapper<PutPublicSyncConnectionFrequency>(async (req, res, next) => {
+export const putSyncConnectionFrequency = asyncWrapperWithEnvironment<PutPublicSyncConnectionFrequency>(async (req, res, next) => {
     try {
         const emptyQuery = requireEmptyQuery(req);
         if (emptyQuery) {

--- a/packages/server/lib/controllers/v1/account/mfa/mfa.ts
+++ b/packages/server/lib/controllers/v1/account/mfa/mfa.ts
@@ -53,7 +53,7 @@ function validateCode(req: Request, res: Response): string | null {
     return null;
 }
 
-function getAuthenticatedUser<T>(res: Response<T, Required<RequestLocals>>) {
+function getAuthenticatedUser<T>(res: Response<T, RequestLocals>) {
     const user = res.locals['user'];
     if (!user) {
         throw new Error('MFA endpoint requires an authenticated user');
@@ -61,11 +61,11 @@ function getAuthenticatedUser<T>(res: Response<T, Required<RequestLocals>>) {
     return user;
 }
 
-async function isMFAEnabled<T>(res: Response<T, Required<RequestLocals>>): Promise<boolean> {
+async function isMFAEnabled<T>(res: Response<T, RequestLocals>): Promise<boolean> {
     return await getFlags().isMFAEnabled(res.locals['account'].uuid);
 }
 
-function rejectDisabledFeature<T>(res: Response<T, Required<RequestLocals>>) {
+function rejectDisabledFeature<T>(res: Response<T, RequestLocals>) {
     res.status(400).send({ error: { code: 'feature_disabled' } } as T);
 }
 

--- a/packages/server/lib/controllers/v1/connect/sessions/postConnectSessions.ts
+++ b/packages/server/lib/controllers/v1/connect/sessions/postConnectSessions.ts
@@ -3,7 +3,7 @@ import * as z from 'zod';
 import { buildTagsFromEndUser } from '@nangohq/shared';
 import { requireEmptyQuery, zodErrorToHTTP } from '@nangohq/utils';
 
-import { asyncWrapper } from '../../../../utils/asyncWrapper.js';
+import { asyncWrapperWithEnvironment } from '../../../../utils/asyncWrapper.js';
 import { generateSession, bodySchema as originalBodySchema } from '../../../connect/postSessions.js';
 
 import type { PostConnectSessions, PostInternalConnectSessions } from '@nangohq/types';
@@ -19,7 +19,7 @@ const bodySchema = z
     })
     .strict();
 
-export const postInternalConnectSessions = asyncWrapper<PostInternalConnectSessions>(async (req, res) => {
+export const postInternalConnectSessions = asyncWrapperWithEnvironment<PostInternalConnectSessions>(async (req, res) => {
     const valQuery = requireEmptyQuery(req, { withEnv: true });
     if (valQuery) {
         res.status(400).send({ error: { code: 'invalid_query_params', errors: zodErrorToHTTP(valQuery.error) } });

--- a/packages/server/lib/controllers/v1/connectUISettings/getConnectUISettings.ts
+++ b/packages/server/lib/controllers/v1/connectUISettings/getConnectUISettings.ts
@@ -2,11 +2,11 @@ import db from '@nangohq/database';
 import { connectUISettingsService } from '@nangohq/shared';
 import { report, requireEmptyQuery, zodErrorToHTTP } from '@nangohq/utils';
 
-import { asyncWrapper } from '../../../utils/asyncWrapper.js';
+import { asyncWrapperWithEnvironment } from '../../../utils/asyncWrapper.js';
 
 import type { GetConnectUISettings } from '@nangohq/types';
 
-export const getConnectUISettings = asyncWrapper<GetConnectUISettings>(async (req, res) => {
+export const getConnectUISettings = asyncWrapperWithEnvironment<GetConnectUISettings>(async (req, res) => {
     const emptyQuery = requireEmptyQuery(req, { withEnv: true });
     if (emptyQuery) {
         res.status(400).send({ error: { code: 'invalid_query_params', errors: zodErrorToHTTP(emptyQuery.error) } });

--- a/packages/server/lib/controllers/v1/connectUISettings/putConnectUISettings.ts
+++ b/packages/server/lib/controllers/v1/connectUISettings/putConnectUISettings.ts
@@ -4,7 +4,7 @@ import db from '@nangohq/database';
 import { connectUISettingsService } from '@nangohq/shared';
 import { report, requireEmptyQuery, zodErrorToHTTP } from '@nangohq/utils';
 
-import { asyncWrapper } from '../../../utils/asyncWrapper.js';
+import { asyncWrapperWithEnvironment } from '../../../utils/asyncWrapper.js';
 
 import type { ConnectUISettings, PutConnectUISettings } from '@nangohq/types';
 
@@ -21,7 +21,7 @@ const bodyValidation = z.strictObject({
     showWatermark: z.boolean()
 });
 
-export const putConnectUISettings = asyncWrapper<PutConnectUISettings>(async (req, res) => {
+export const putConnectUISettings = asyncWrapperWithEnvironment<PutConnectUISettings>(async (req, res) => {
     const emptyQuery = requireEmptyQuery(req, { withEnv: true });
     if (emptyQuery) {
         res.status(400).send({ error: { code: 'invalid_query_params', errors: zodErrorToHTTP(emptyQuery.error) } });

--- a/packages/server/lib/controllers/v1/connections/connectionId/deleteConnection.ts
+++ b/packages/server/lib/controllers/v1/connections/connectionId/deleteConnection.ts
@@ -7,7 +7,7 @@ import { zodErrorToHTTP } from '@nangohq/utils';
 import { connectionIdSchema, envSchema, providerConfigKeySchema } from '../../../../helpers/validation.js';
 import { preConnectionDeletion } from '../../../../hooks/connection/on/pre-connection-deletion.js';
 import { slackService } from '../../../../services/slack.js';
-import { asyncWrapper } from '../../../../utils/asyncWrapper.js';
+import { asyncWrapperWithEnvironment } from '../../../../utils/asyncWrapper.js';
 import { getOrchestrator } from '../../../../utils/utils.js';
 
 import type { DeleteConnection } from '@nangohq/types';
@@ -26,7 +26,7 @@ const validationParams = z
 
 const orchestrator = getOrchestrator();
 
-export const deleteConnection = asyncWrapper<DeleteConnection>(async (req, res) => {
+export const deleteConnection = asyncWrapperWithEnvironment<DeleteConnection>(async (req, res) => {
     const valParams = validationParams.safeParse(req.params);
     if (!valParams.success) {
         res.status(400).send({ error: { code: 'invalid_uri_params', errors: zodErrorToHTTP(valParams.error) } });

--- a/packages/server/lib/controllers/v1/connections/connectionId/getConnection.ts
+++ b/packages/server/lib/controllers/v1/connections/connectionId/getConnection.ts
@@ -10,7 +10,7 @@ import { connectionFullToApi } from '../../../../formatters/connection.js';
 import { endUserToApi } from '../../../../formatters/endUser.js';
 import { connectionIdSchema, envSchema, providerConfigKeySchema } from '../../../../helpers/validation.js';
 import { connectionRefreshFailed as connectionRefreshFailedHook, connectionRefreshSuccess as connectionRefreshSuccessHook } from '../../../../hooks/hooks.js';
-import { asyncWrapper } from '../../../../utils/asyncWrapper.js';
+import { asyncWrapperWithEnvironment } from '../../../../utils/asyncWrapper.js';
 
 import type { GetConnection } from '@nangohq/types';
 
@@ -27,7 +27,7 @@ const paramValidation = z
     })
     .strict();
 
-export const getConnection = asyncWrapper<GetConnection>(async (req, res) => {
+export const getConnection = asyncWrapperWithEnvironment<GetConnection>(async (req, res) => {
     const emptyBody = requireEmptyBody(req);
     if (emptyBody) {
         res.status(400).send({ error: { code: 'invalid_body', errors: zodErrorToHTTP(emptyBody.error) } });

--- a/packages/server/lib/controllers/v1/connections/connectionId/patchConnection.ts
+++ b/packages/server/lib/controllers/v1/connections/connectionId/patchConnection.ts
@@ -3,7 +3,7 @@ import * as z from 'zod';
 import { zodErrorToHTTP } from '@nangohq/utils';
 
 import { connectionIdSchema, envSchema, providerConfigKeySchema } from '../../../../helpers/validation.js';
-import { asyncWrapper } from '../../../../utils/asyncWrapper.js';
+import { asyncWrapperWithEnvironment } from '../../../../utils/asyncWrapper.js';
 import { handlePatchConnection, patchConnectionBodySchema } from '../../../shared/connections/patchConnection.js';
 
 import type { PatchConnection } from '@nangohq/types';
@@ -17,7 +17,7 @@ const paramValidation = z.strictObject({
     connectionId: connectionIdSchema
 });
 
-export const patchConnection = asyncWrapper<PatchConnection>(async (req, res) => {
+export const patchConnection = asyncWrapperWithEnvironment<PatchConnection>(async (req, res) => {
     const queryParamValues = queryStringValidation.safeParse(req.query);
     if (!queryParamValues.success) {
         res.status(400).send({ error: { code: 'invalid_query_params', errors: zodErrorToHTTP(queryParamValues.error) } });

--- a/packages/server/lib/controllers/v1/connections/connectionId/postConnectionMetadata.ts
+++ b/packages/server/lib/controllers/v1/connections/connectionId/postConnectionMetadata.ts
@@ -3,7 +3,7 @@ import * as z from 'zod';
 import { zodErrorToHTTP } from '@nangohq/utils';
 
 import { connectionIdSchema, envSchema, providerConfigKeySchema } from '../../../../helpers/validation.js';
-import { asyncWrapper } from '../../../../utils/asyncWrapper.js';
+import { asyncWrapperWithEnvironment } from '../../../../utils/asyncWrapper.js';
 import { handlePostConnectionMetadata } from '../../../shared/connections/postConnectionMetadata.js';
 
 import type { PostConnectionMetadata } from '@nangohq/types';
@@ -25,7 +25,7 @@ const validationParams = z
     })
     .strict();
 
-export const postConnectionMetadata = asyncWrapper<PostConnectionMetadata>(async (req, res) => {
+export const postConnectionMetadata = asyncWrapperWithEnvironment<PostConnectionMetadata>(async (req, res) => {
     const valQuery = validationQuery.safeParse(req.query);
     if (!valQuery.success) {
         res.status(400).send({ error: { code: 'invalid_query_params', errors: zodErrorToHTTP(valQuery.error) } });

--- a/packages/server/lib/controllers/v1/connections/connectionId/postRefresh.ts
+++ b/packages/server/lib/controllers/v1/connections/connectionId/postRefresh.ts
@@ -6,7 +6,7 @@ import { requireEmptyBody, zodErrorToHTTP } from '@nangohq/utils';
 
 import { connectionIdSchema, envSchema, providerConfigKeySchema } from '../../../../helpers/validation.js';
 import { connectionRefreshFailed as connectionRefreshFailedHook, connectionRefreshSuccess as connectionRefreshSuccessHook } from '../../../../hooks/hooks.js';
-import { asyncWrapper } from '../../../../utils/asyncWrapper.js';
+import { asyncWrapperWithEnvironment } from '../../../../utils/asyncWrapper.js';
 
 import type { PostConnectionRefresh } from '@nangohq/types';
 
@@ -23,7 +23,7 @@ const paramValidation = z
     })
     .strict();
 
-export const getConnectionRefresh = asyncWrapper<PostConnectionRefresh>(async (req, res) => {
+export const getConnectionRefresh = asyncWrapperWithEnvironment<PostConnectionRefresh>(async (req, res) => {
     const emptyBody = requireEmptyBody(req);
     if (emptyBody) {
         res.status(400).send({ error: { code: 'invalid_body', errors: zodErrorToHTTP(emptyBody.error) } });

--- a/packages/server/lib/controllers/v1/connections/connectionId/records/getModels.ts
+++ b/packages/server/lib/controllers/v1/connections/connectionId/records/getModels.ts
@@ -5,7 +5,7 @@ import { connectionService } from '@nangohq/shared';
 import { requireEmptyBody, zodErrorToHTTP } from '@nangohq/utils';
 
 import { connectionIdSchema, envSchema, providerConfigKeySchema } from '../../../../../helpers/validation.js';
-import { asyncWrapper } from '../../../../../utils/asyncWrapper.js';
+import { asyncWrapperWithEnvironment } from '../../../../../utils/asyncWrapper.js';
 
 import type { GetConnectionRecordModels } from '@nangohq/types';
 
@@ -22,7 +22,7 @@ const paramValidation = z
     })
     .strict();
 
-export const getConnectionRecordModels = asyncWrapper<GetConnectionRecordModels>(async (req, res) => {
+export const getConnectionRecordModels = asyncWrapperWithEnvironment<GetConnectionRecordModels>(async (req, res) => {
     const emptyBody = requireEmptyBody(req);
     if (emptyBody) {
         res.status(400).send({ error: { code: 'invalid_body', errors: zodErrorToHTTP(emptyBody.error) } });

--- a/packages/server/lib/controllers/v1/connections/connectionId/records/getRecords.ts
+++ b/packages/server/lib/controllers/v1/connections/connectionId/records/getRecords.ts
@@ -5,7 +5,7 @@ import { connectionService } from '@nangohq/shared';
 import { requireEmptyBody, zodErrorToHTTP } from '@nangohq/utils';
 
 import { connectionIdSchema, envSchema, providerConfigKeySchema, variantSchema } from '../../../../../helpers/validation.js';
-import { asyncWrapper } from '../../../../../utils/asyncWrapper.js';
+import { asyncWrapperWithEnvironment } from '../../../../../utils/asyncWrapper.js';
 
 import type { GetConnectionRecords } from '@nangohq/types';
 
@@ -42,7 +42,7 @@ const queryStringValidation = z
         path: ['cursor']
     });
 
-export const getConnectionRecords = asyncWrapper<GetConnectionRecords>(async (req, res) => {
+export const getConnectionRecords = asyncWrapperWithEnvironment<GetConnectionRecords>(async (req, res) => {
     const emptyBody = requireEmptyBody(req as any);
     if (emptyBody) {
         res.status(400).send({ error: { code: 'invalid_body', errors: zodErrorToHTTP(emptyBody.error) } });

--- a/packages/server/lib/controllers/v1/connections/getConnections.ts
+++ b/packages/server/lib/controllers/v1/connections/getConnections.ts
@@ -6,7 +6,7 @@ import { zodErrorToHTTP } from '@nangohq/utils';
 
 import { connectionSimpleToApi } from '../../../formatters/connection.js';
 import { envSchema, providerConfigKeySchema } from '../../../helpers/validation.js';
-import { asyncWrapper } from '../../../utils/asyncWrapper.js';
+import { asyncWrapperWithEnvironment } from '../../../utils/asyncWrapper.js';
 import { getOrchestrator } from '../../../utils/utils.js';
 
 import type { GetConnections } from '@nangohq/types';
@@ -28,7 +28,7 @@ const queryStringValidation = z
     })
     .strict();
 
-export const getConnections = asyncWrapper<GetConnections>(async (req, res) => {
+export const getConnections = asyncWrapperWithEnvironment<GetConnections>(async (req, res) => {
     const queryStringValues = queryStringValidation.safeParse(req.query);
     if (!queryStringValues.success) {
         res.status(400).send({

--- a/packages/server/lib/controllers/v1/connections/getConnectionsCount.ts
+++ b/packages/server/lib/controllers/v1/connections/getConnectionsCount.ts
@@ -4,7 +4,7 @@ import { connectionService } from '@nangohq/shared';
 import { zodErrorToHTTP } from '@nangohq/utils';
 
 import { envSchema } from '../../../helpers/validation.js';
-import { asyncWrapper } from '../../../utils/asyncWrapper.js';
+import { asyncWrapperWithEnvironment } from '../../../utils/asyncWrapper.js';
 
 import type { GetConnectionsCount } from '@nangohq/types';
 
@@ -14,7 +14,7 @@ const queryStringValidation = z
     })
     .strict();
 
-export const getConnectionsCount = asyncWrapper<GetConnectionsCount>(async (req, res) => {
+export const getConnectionsCount = asyncWrapperWithEnvironment<GetConnectionsCount>(async (req, res) => {
     const queryStringValues = queryStringValidation.safeParse(req.query);
     if (!queryStringValues.success) {
         res.status(400).send({

--- a/packages/server/lib/controllers/v1/environment/createApiKey.ts
+++ b/packages/server/lib/controllers/v1/environment/createApiKey.ts
@@ -4,7 +4,7 @@ import db from '@nangohq/database';
 import { customerKeyService } from '@nangohq/shared';
 import { apiKeyScopes, requireEmptyQuery, zodErrorToHTTP } from '@nangohq/utils';
 
-import { asyncWrapper } from '../../../utils/asyncWrapper.js';
+import { asyncWrapperWithEnvironment } from '../../../utils/asyncWrapper.js';
 
 import type { ApiKeyScope, CreateApiKey } from '@nangohq/types';
 
@@ -15,7 +15,7 @@ const validationBody = z
     })
     .strict();
 
-export const createApiKey = asyncWrapper<CreateApiKey>(async (req, res) => {
+export const createApiKey = asyncWrapperWithEnvironment<CreateApiKey>(async (req, res) => {
     const emptyQuery = requireEmptyQuery(req, { withEnv: true });
     if (emptyQuery) {
         res.status(400).send({ error: { code: 'invalid_query_params', errors: zodErrorToHTTP(emptyQuery.error) } });

--- a/packages/server/lib/controllers/v1/environment/createApiKey.ts
+++ b/packages/server/lib/controllers/v1/environment/createApiKey.ts
@@ -2,16 +2,16 @@ import * as z from 'zod';
 
 import db from '@nangohq/database';
 import { customerKeyService } from '@nangohq/shared';
-import { apiKeyScopes, requireEmptyQuery, zodErrorToHTTP } from '@nangohq/utils';
+import { environmentApiKeyScopes, requireEmptyQuery, zodErrorToHTTP } from '@nangohq/utils';
 
 import { asyncWrapperWithEnvironment } from '../../../utils/asyncWrapper.js';
 
-import type { ApiKeyScope, CreateApiKey } from '@nangohq/types';
+import type { CreateApiKey, EnvironmentApiKeyScope } from '@nangohq/types';
 
 const validationBody = z
     .object({
         display_name: z.string().min(1).max(255),
-        scopes: z.array(z.enum(apiKeyScopes)).nonempty('At least one scope is required when scopes are provided').optional()
+        scopes: z.array(z.enum(environmentApiKeyScopes)).nonempty('At least one scope is required when scopes are provided').optional()
     })
     .strict();
 
@@ -33,9 +33,10 @@ export const createApiKey = asyncWrapperWithEnvironment<CreateApiKey>(async (req
 
     const result = await customerKeyService.createApiKey(db.knex, {
         accountId: account.id,
-        environmentId: environment.id,
+        target: { type: 'environment', environmentId: environment.id },
         displayName,
-        scopes: scopes ?? ['environment:*']
+        scopes: scopes ?? ['environment:*'],
+        withSandboxSigningSecret: true
     });
 
     if (result.isErr()) {
@@ -55,7 +56,7 @@ export const createApiKey = asyncWrapperWithEnvironment<CreateApiKey>(async (req
         data: {
             id: key.id,
             display_name: key.display_name,
-            scopes: (key.scopes ?? []) as ApiKeyScope[],
+            scopes: (key.scopes ?? []) as EnvironmentApiKeyScope[],
             secret: key.secret,
             created_at: key.created_at.toISOString()
         }

--- a/packages/server/lib/controllers/v1/environment/deleteApiKey.ts
+++ b/packages/server/lib/controllers/v1/environment/deleteApiKey.ts
@@ -4,7 +4,7 @@ import db from '@nangohq/database';
 import { customerKeyService } from '@nangohq/shared';
 import { requireEmptyQuery, zodErrorToHTTP } from '@nangohq/utils';
 
-import { asyncWrapper } from '../../../utils/asyncWrapper.js';
+import { asyncWrapperWithEnvironment } from '../../../utils/asyncWrapper.js';
 
 import type { DeleteApiKey } from '@nangohq/types';
 
@@ -12,7 +12,7 @@ const validationParams = z.object({
     keyId: z.coerce.number().int().positive()
 });
 
-export const deleteApiKey = asyncWrapper<DeleteApiKey>(async (req, res) => {
+export const deleteApiKey = asyncWrapperWithEnvironment<DeleteApiKey>(async (req, res) => {
     const emptyQuery = requireEmptyQuery(req, { withEnv: true });
     if (emptyQuery) {
         res.status(400).send({ error: { code: 'invalid_query_params', errors: zodErrorToHTTP(emptyQuery.error) } });

--- a/packages/server/lib/controllers/v1/environment/deleteApiKey.ts
+++ b/packages/server/lib/controllers/v1/environment/deleteApiKey.ts
@@ -29,7 +29,7 @@ export const deleteApiKey = asyncWrapperWithEnvironment<DeleteApiKey>(async (req
 
     const { environment } = res.locals;
 
-    const result = await customerKeyService.deleteCustomerKey(db.knex, keyId, environment.id);
+    const result = await customerKeyService.deleteApiKey(db.knex, keyId, { type: 'environment', environmentId: environment.id });
     if (result.isErr()) {
         res.status(404).send({ error: { code: 'not_found', message: 'API key not found' } });
         return;

--- a/packages/server/lib/controllers/v1/environment/deleteEnvironment.integration.test.ts
+++ b/packages/server/lib/controllers/v1/environment/deleteEnvironment.integration.test.ts
@@ -38,7 +38,7 @@ describe(`DELETE ${endpoint}`, () => {
             throw new Error('Failed to create prod environment');
         }
 
-        const prodApiKeys = (await customerKeyService.getApiKeysByEnv(db.knex, prodEnv.id)).unwrap();
+        const prodApiKeys = (await customerKeyService.getApiKeys(db.knex, { type: 'environment', environmentId: prodEnv.id })).unwrap();
 
         const res = await api.fetch(endpoint, {
             method: 'DELETE',
@@ -64,7 +64,7 @@ describe(`DELETE ${endpoint}`, () => {
             throw new Error('Failed to create test environment');
         }
 
-        const testApiKeys = (await customerKeyService.getApiKeysByEnv(db.knex, testEnv.id)).unwrap();
+        const testApiKeys = (await customerKeyService.getApiKeys(db.knex, { type: 'environment', environmentId: testEnv.id })).unwrap();
 
         const res = await api.fetch(endpoint, {
             method: 'DELETE',
@@ -88,7 +88,7 @@ describe(`DELETE ${endpoint}`, () => {
             throw new Error('Failed to create test environment');
         }
 
-        const testApiKeys = (await customerKeyService.getApiKeysByEnv(db.knex, testEnv.id)).unwrap();
+        const testApiKeys = (await customerKeyService.getApiKeys(db.knex, { type: 'environment', environmentId: testEnv.id })).unwrap();
 
         // Create a provider config for this environment
         const providerName = 'github';

--- a/packages/server/lib/controllers/v1/environment/deleteEnvironment.ts
+++ b/packages/server/lib/controllers/v1/environment/deleteEnvironment.ts
@@ -1,12 +1,12 @@
 import { environmentService, PROD_ENVIRONMENT_NAME } from '@nangohq/shared';
 import { requireEmptyQuery, zodErrorToHTTP } from '@nangohq/utils';
 
-import { asyncWrapper } from '../../../utils/asyncWrapper.js';
+import { asyncWrapperWithEnvironment } from '../../../utils/asyncWrapper.js';
 import { getOrchestrator } from '../../../utils/utils.js';
 
 import type { DeleteEnvironment } from '@nangohq/types';
 
-export const deleteEnvironment = asyncWrapper<DeleteEnvironment>(async (req, res) => {
+export const deleteEnvironment = asyncWrapperWithEnvironment<DeleteEnvironment>(async (req, res) => {
     const emptyQuery = requireEmptyQuery(req, { withEnv: true });
     if (emptyQuery) {
         res.status(400).send({ error: { code: 'invalid_query_params', errors: zodErrorToHTTP(emptyQuery.error) } });

--- a/packages/server/lib/controllers/v1/environment/getEnvironment.ts
+++ b/packages/server/lib/controllers/v1/environment/getEnvironment.ts
@@ -16,11 +16,11 @@ import { envs } from '../../../env.js';
 import { environmentToApi } from '../../../formatters/environment.js';
 import { planToApi } from '../../../formatters/plan.js';
 import { webhooksToApi } from '../../../formatters/webhooks.js';
-import { asyncWrapper } from '../../../utils/asyncWrapper.js';
+import { asyncWrapperWithEnvironment } from '../../../utils/asyncWrapper.js';
 
 import type { GetEnvironment } from '@nangohq/types';
 
-export const getEnvironment = asyncWrapper<GetEnvironment>(async (req, res) => {
+export const getEnvironment = asyncWrapperWithEnvironment<GetEnvironment>(async (req, res) => {
     const emptyQuery = requireEmptyQuery(req, { withEnv: true });
     if (emptyQuery) {
         res.status(400).send({ error: { code: 'invalid_query_params', errors: zodErrorToHTTP(emptyQuery.error) } });

--- a/packages/server/lib/controllers/v1/environment/listApiKeys.ts
+++ b/packages/server/lib/controllers/v1/environment/listApiKeys.ts
@@ -3,11 +3,11 @@ import { customerKeyService } from '@nangohq/shared';
 import { requireEmptyQuery, zodErrorToHTTP } from '@nangohq/utils';
 
 import { canReadProdSecret } from '../../../authz/resolve.js';
-import { asyncWrapper } from '../../../utils/asyncWrapper.js';
+import { asyncWrapperWithEnvironment } from '../../../utils/asyncWrapper.js';
 
 import type { ApiKeyScope, ListApiKeys } from '@nangohq/types';
 
-export const listApiKeys = asyncWrapper<ListApiKeys>(async (req, res) => {
+export const listApiKeys = asyncWrapperWithEnvironment<ListApiKeys>(async (req, res) => {
     const emptyQuery = requireEmptyQuery(req, { withEnv: true });
     if (emptyQuery) {
         res.status(400).send({ error: { code: 'invalid_query_params', errors: zodErrorToHTTP(emptyQuery.error) } });

--- a/packages/server/lib/controllers/v1/environment/listApiKeys.ts
+++ b/packages/server/lib/controllers/v1/environment/listApiKeys.ts
@@ -5,7 +5,7 @@ import { requireEmptyQuery, zodErrorToHTTP } from '@nangohq/utils';
 import { canReadProdSecret } from '../../../authz/resolve.js';
 import { asyncWrapperWithEnvironment } from '../../../utils/asyncWrapper.js';
 
-import type { ApiKeyScope, ListApiKeys } from '@nangohq/types';
+import type { EnvironmentApiKeyScope, ListApiKeys } from '@nangohq/types';
 
 export const listApiKeys = asyncWrapperWithEnvironment<ListApiKeys>(async (req, res) => {
     const emptyQuery = requireEmptyQuery(req, { withEnv: true });
@@ -18,7 +18,7 @@ export const listApiKeys = asyncWrapperWithEnvironment<ListApiKeys>(async (req, 
 
     const canReadSecret = await canReadProdSecret(res.locals, environment);
 
-    const keysResult = await customerKeyService.getApiKeysByEnv(db.knex, environment.id);
+    const keysResult = await customerKeyService.getApiKeys(db.knex, { type: 'environment', environmentId: environment.id });
     if (keysResult.isErr()) {
         res.status(500).send({ error: { code: 'server_error', message: 'Failed to retrieve API keys' } });
         return;
@@ -29,7 +29,7 @@ export const listApiKeys = asyncWrapperWithEnvironment<ListApiKeys>(async (req, 
         return {
             id: key.id,
             display_name: key.display_name,
-            scopes: (key.scopes ?? []) as ApiKeyScope[],
+            scopes: (key.scopes ?? []) as EnvironmentApiKeyScope[],
             secret,
             last_used_at: key.last_used_at ? key.last_used_at.toISOString() : null,
             created_at: key.created_at.toISOString(),

--- a/packages/server/lib/controllers/v1/environment/patchApiKey.ts
+++ b/packages/server/lib/controllers/v1/environment/patchApiKey.ts
@@ -4,7 +4,7 @@ import db from '@nangohq/database';
 import { customerKeyService } from '@nangohq/shared';
 import { apiKeyScopes, zodErrorToHTTP } from '@nangohq/utils';
 
-import { asyncWrapper } from '../../../utils/asyncWrapper.js';
+import { asyncWrapperWithEnvironment } from '../../../utils/asyncWrapper.js';
 
 import type { PatchApiKey } from '@nangohq/types';
 
@@ -19,7 +19,7 @@ const validationBody = z
     })
     .refine((data) => data.scopes || data.display_name, { message: 'At least one of scopes or display_name is required' });
 
-export const patchApiKey = asyncWrapper<PatchApiKey>(async (req, res) => {
+export const patchApiKey = asyncWrapperWithEnvironment<PatchApiKey>(async (req, res) => {
     const valParams = validationParams.safeParse(req.params);
     if (!valParams.success) {
         res.status(400).send({ error: { code: 'invalid_body', errors: zodErrorToHTTP(valParams.error) } });

--- a/packages/server/lib/controllers/v1/environment/patchApiKey.ts
+++ b/packages/server/lib/controllers/v1/environment/patchApiKey.ts
@@ -2,7 +2,7 @@ import * as z from 'zod';
 
 import db from '@nangohq/database';
 import { customerKeyService } from '@nangohq/shared';
-import { apiKeyScopes, zodErrorToHTTP } from '@nangohq/utils';
+import { environmentApiKeyScopes, zodErrorToHTTP } from '@nangohq/utils';
 
 import { asyncWrapperWithEnvironment } from '../../../utils/asyncWrapper.js';
 
@@ -14,7 +14,7 @@ const validationParams = z.object({
 
 const validationBody = z
     .object({
-        scopes: z.array(z.enum(apiKeyScopes)).min(1).optional(),
+        scopes: z.array(z.enum(environmentApiKeyScopes)).min(1).optional(),
         display_name: z.string().min(1).max(255).optional()
     })
     .refine((data) => data.scopes || data.display_name, { message: 'At least one of scopes or display_name is required' });
@@ -36,7 +36,13 @@ export const patchApiKey = asyncWrapperWithEnvironment<PatchApiKey>(async (req, 
     }
 
     if (parsed.data.display_name) {
-        const result = await customerKeyService.renameApiKey(db.knex, keyId, parsed.data.display_name, environment.id, account.id);
+        const result = await customerKeyService.renameApiKey(
+            db.knex,
+            keyId,
+            parsed.data.display_name,
+            { type: 'environment', environmentId: environment.id },
+            account.id
+        );
         if (result.isErr()) {
             const { type: errType = '', message: errMsg = '' } = result.error as { type?: string; message?: string };
             if (errType === 'duplicate_api_key' || errMsg.includes('duplicate_api_key')) {
@@ -49,7 +55,10 @@ export const patchApiKey = asyncWrapperWithEnvironment<PatchApiKey>(async (req, 
     }
 
     if (parsed.data.scopes) {
-        const result = await customerKeyService.updateApiKeyScopes(db.knex, keyId, parsed.data.scopes, environment.id);
+        const result = await customerKeyService.updateApiKeyScopes(db.knex, keyId, parsed.data.scopes, {
+            type: 'environment',
+            environmentId: environment.id
+        });
         if (result.isErr()) {
             res.status(404).send({ error: { code: 'not_found', message: 'API key not found' } });
             return;

--- a/packages/server/lib/controllers/v1/environment/patchEnvironment.ts
+++ b/packages/server/lib/controllers/v1/environment/patchEnvironment.ts
@@ -7,7 +7,7 @@ import { flagHasPlan, requireEmptyQuery, zodErrorToHTTP } from '@nangohq/utils';
 import { resolve } from '../../../authz/resolve.js';
 import { environmentToApi } from '../../../formatters/environment.js';
 import { envSchema } from '../../../helpers/validation.js';
-import { asyncWrapper } from '../../../utils/asyncWrapper.js';
+import { asyncWrapperWithEnvironment } from '../../../utils/asyncWrapper.js';
 
 import type { DBEnvironment, PatchEnvironment } from '@nangohq/types';
 
@@ -27,7 +27,7 @@ const validationBody = z
     })
     .strict();
 
-export const patchEnvironment = asyncWrapper<PatchEnvironment>(async (req, res) => {
+export const patchEnvironment = asyncWrapperWithEnvironment<PatchEnvironment>(async (req, res) => {
     const emptyQuery = requireEmptyQuery(req, { withEnv: true });
     if (emptyQuery) {
         res.status(400).send({ error: { code: 'invalid_query_params', errors: zodErrorToHTTP(emptyQuery.error) } });

--- a/packages/server/lib/controllers/v1/environment/scopeEnforcement.integration.test.ts
+++ b/packages/server/lib/controllers/v1/environment/scopeEnforcement.integration.test.ts
@@ -4,7 +4,7 @@ import { seeders } from '@nangohq/shared';
 
 import { authenticateUser, isSuccess, runServer } from '../../../utils/tests.js';
 
-import type { ApiKeyScope } from '@nangohq/types';
+import type { EnvironmentApiKeyScope } from '@nangohq/types';
 
 let api: Awaited<ReturnType<typeof runServer>>;
 
@@ -23,12 +23,12 @@ let api: Awaited<ReturnType<typeof runServer>>;
 
 const WRONG_SCOPE = 'environment:mcp'; // unlikely to match any route except /mcp
 
-async function createKeyWithScopes(scopes: ApiKeyScope[]): Promise<string> {
+async function createKeyWithScopes(scopes: EnvironmentApiKeyScope[]): Promise<string> {
     const result = await createKeyWithScopesAndEnv(scopes);
     return result.secret;
 }
 
-async function createKeyWithScopesAndEnv(scopes: ApiKeyScope[]) {
+async function createKeyWithScopesAndEnv(scopes: EnvironmentApiKeyScope[]) {
     const { env, user } = await seeders.seedAccountEnvAndUser();
     const session = await authenticateUser(api, user);
     const res = await api.fetch('/api/v1/environment/api-keys', {

--- a/packages/server/lib/controllers/v1/environment/variables/postVariables.ts
+++ b/packages/server/lib/controllers/v1/environment/variables/postVariables.ts
@@ -3,7 +3,7 @@ import * as z from 'zod';
 import { environmentService } from '@nangohq/shared';
 import { requireEmptyQuery, zodErrorToHTTP } from '@nangohq/utils';
 
-import { asyncWrapper } from '../../../../utils/asyncWrapper.js';
+import { asyncWrapperWithEnvironment } from '../../../../utils/asyncWrapper.js';
 
 import type { PostEnvironmentVariables } from '@nangohq/types';
 
@@ -13,7 +13,7 @@ const validation = z
     })
     .strict();
 
-export const postEnvironmentVariables = asyncWrapper<PostEnvironmentVariables>(async (req, res) => {
+export const postEnvironmentVariables = asyncWrapperWithEnvironment<PostEnvironmentVariables>(async (req, res) => {
     const emptyQuery = requireEmptyQuery(req, { withEnv: true });
     if (emptyQuery) {
         res.status(400).send({ error: { code: 'invalid_query_params', errors: zodErrorToHTTP(emptyQuery.error) } });

--- a/packages/server/lib/controllers/v1/environment/webhook/patchWebhook.ts
+++ b/packages/server/lib/controllers/v1/environment/webhook/patchWebhook.ts
@@ -5,7 +5,7 @@ import { externalWebhookService } from '@nangohq/shared';
 import { requireEmptyQuery, zodErrorToHTTP } from '@nangohq/utils';
 
 import { webhookUrlSchema } from '../../../../helpers/validation.js';
-import { asyncWrapper } from '../../../../utils/asyncWrapper.js';
+import { asyncWrapperWithEnvironment } from '../../../../utils/asyncWrapper.js';
 
 import type { DBExternalWebhook, PatchWebhook } from '@nangohq/types';
 
@@ -21,7 +21,7 @@ const validation = z
     })
     .strict();
 
-export const patchWebhook = asyncWrapper<PatchWebhook>(async (req, res) => {
+export const patchWebhook = asyncWrapperWithEnvironment<PatchWebhook>(async (req, res) => {
     const emptyQuery = requireEmptyQuery(req, { withEnv: true });
     if (emptyQuery) {
         res.status(400).send({ error: { code: 'invalid_query_params', errors: zodErrorToHTTP(emptyQuery.error) } });

--- a/packages/server/lib/controllers/v1/flow/getDownload.ts
+++ b/packages/server/lib/controllers/v1/flow/getDownload.ts
@@ -3,7 +3,7 @@ import * as z from 'zod';
 import { configService, getSyncConfigById, remoteFileService } from '@nangohq/shared';
 import { requireEmptyQuery, zodErrorToHTTP } from '@nangohq/utils';
 
-import { asyncWrapper } from '../../../utils/asyncWrapper.js';
+import { asyncWrapperWithEnvironment } from '../../../utils/asyncWrapper.js';
 
 import type { GetFlowDownload } from '@nangohq/types';
 
@@ -13,7 +13,7 @@ export const validationParams = z
     })
     .strict();
 
-export const getFlowDownload = asyncWrapper<GetFlowDownload>(async (req, res) => {
+export const getFlowDownload = asyncWrapperWithEnvironment<GetFlowDownload>(async (req, res) => {
     const emptyQuery = requireEmptyQuery(req, { withEnv: true });
     if (emptyQuery) {
         res.status(400).send({ error: { code: 'invalid_query_params', errors: zodErrorToHTTP(emptyQuery.error) } });

--- a/packages/server/lib/controllers/v1/flows/id/patchDisable.ts
+++ b/packages/server/lib/controllers/v1/flows/id/patchDisable.ts
@@ -4,7 +4,7 @@ import { configService, disableScriptConfig, errorNotificationService, syncManag
 import { requireEmptyQuery, zodErrorToHTTP } from '@nangohq/utils';
 
 import { providerConfigKeySchema, providerSchema, scriptNameSchema } from '../../../../helpers/validation.js';
-import { asyncWrapper } from '../../../../utils/asyncWrapper.js';
+import { asyncWrapperWithEnvironment } from '../../../../utils/asyncWrapper.js';
 import { getOrchestrator } from '../../../../utils/utils.js';
 import { flowConfig } from '../../../sync/deploy/validation.js';
 
@@ -26,7 +26,7 @@ export const validationParams = z
     })
     .strict();
 
-export const patchFlowDisable = asyncWrapper<PatchFlowDisable>(async (req, res) => {
+export const patchFlowDisable = asyncWrapperWithEnvironment<PatchFlowDisable>(async (req, res) => {
     const emptyQuery = requireEmptyQuery(req, { withEnv: true });
     if (emptyQuery) {
         res.status(400).send({ error: { code: 'invalid_query_params', errors: zodErrorToHTTP(emptyQuery.error) } });

--- a/packages/server/lib/controllers/v1/flows/id/patchEnable.ts
+++ b/packages/server/lib/controllers/v1/flows/id/patchEnable.ts
@@ -3,14 +3,14 @@ import { logContextGetter } from '@nangohq/logs';
 import { configService, enableScriptConfig, getSyncConfigById, productTracking, startTrial, syncManager } from '@nangohq/shared';
 import { requireEmptyQuery, zodErrorToHTTP } from '@nangohq/utils';
 
-import { asyncWrapper } from '../../../../utils/asyncWrapper.js';
+import { asyncWrapperWithEnvironment } from '../../../../utils/asyncWrapper.js';
 import { getOrchestrator } from '../../../../utils/utils.js';
 import { validationBody, validationParams } from './patchDisable.js';
 
 import type { PatchFlowEnable } from '@nangohq/types';
 
 const orchestrator = getOrchestrator();
-export const patchFlowEnable = asyncWrapper<PatchFlowEnable>(async (req, res) => {
+export const patchFlowEnable = asyncWrapperWithEnvironment<PatchFlowEnable>(async (req, res) => {
     const emptyQuery = requireEmptyQuery(req, { withEnv: true });
     if (emptyQuery) {
         res.status(400).send({ error: { code: 'invalid_query_params', errors: zodErrorToHTTP(emptyQuery.error) } });

--- a/packages/server/lib/controllers/v1/flows/id/patchFrequency.ts
+++ b/packages/server/lib/controllers/v1/flows/id/patchFrequency.ts
@@ -2,7 +2,7 @@ import { configService, getSyncConfigById, getSyncsBySyncConfigId, updateFrequen
 import { requireEmptyQuery, zodErrorToHTTP } from '@nangohq/utils';
 
 import { frequencySchema } from '../../../../helpers/validation.js';
-import { asyncWrapper } from '../../../../utils/asyncWrapper.js';
+import { asyncWrapperWithEnvironment } from '../../../../utils/asyncWrapper.js';
 import { getOrchestrator } from '../../../../utils/utils.js';
 import { validationBody as validationBodyBase, validationParams } from './patchDisable.js';
 
@@ -15,7 +15,7 @@ export const validationBody = validationBodyBase.extend({
     frequency: frequencySchema
 });
 
-export const patchFlowFrequency = asyncWrapper<PatchFlowFrequency>(async (req, res) => {
+export const patchFlowFrequency = asyncWrapperWithEnvironment<PatchFlowFrequency>(async (req, res) => {
     const emptyQuery = requireEmptyQuery(req, { withEnv: true });
     if (emptyQuery) {
         res.status(400).send({ error: { code: 'invalid_query_params', errors: zodErrorToHTTP(emptyQuery.error) } });

--- a/packages/server/lib/controllers/v1/flows/preBuilt/postDeploy.ts
+++ b/packages/server/lib/controllers/v1/flows/preBuilt/postDeploy.ts
@@ -3,7 +3,7 @@ import * as z from 'zod';
 import { requireEmptyQuery, zodErrorToHTTP } from '@nangohq/utils';
 
 import { providerConfigKeySchema, scriptNameSchema } from '../../../../helpers/validation.js';
-import { asyncWrapper } from '../../../../utils/asyncWrapper.js';
+import { asyncWrapperWithEnvironment } from '../../../../utils/asyncWrapper.js';
 import { flowConfig } from '../../../sync/deploy/validation.js';
 import { deployIntegrationTemplate } from './helpers.js';
 
@@ -17,7 +17,7 @@ const validation = z
     })
     .strict();
 
-export const postPreBuiltDeploy = asyncWrapper<PostPreBuiltDeploy>(async (req, res) => {
+export const postPreBuiltDeploy = asyncWrapperWithEnvironment<PostPreBuiltDeploy>(async (req, res) => {
     const emptyQuery = requireEmptyQuery(req, { withEnv: true });
     if (emptyQuery) {
         res.status(400).send({ error: { code: 'invalid_query_params', errors: zodErrorToHTTP(emptyQuery.error) } });

--- a/packages/server/lib/controllers/v1/flows/preBuilt/putUpgrade.ts
+++ b/packages/server/lib/controllers/v1/flows/preBuilt/putUpgrade.ts
@@ -5,7 +5,7 @@ import { configService, flowService, getSyncConfigById, upgradeTemplate } from '
 import { requireEmptyQuery, zodErrorToHTTP } from '@nangohq/utils';
 
 import { providerConfigKeySchema, providerSchema, scriptNameSchema } from '../../../../helpers/validation.js';
-import { asyncWrapper } from '../../../../utils/asyncWrapper.js';
+import { asyncWrapperWithEnvironment } from '../../../../utils/asyncWrapper.js';
 import { flowConfig } from '../../../sync/deploy/validation.js';
 
 import type { PutUpgradePreBuiltFlow } from '@nangohq/types';
@@ -22,7 +22,7 @@ const validation = z
     })
     .strict();
 
-export const putUpgradePreBuilt = asyncWrapper<PutUpgradePreBuiltFlow>(async (req, res) => {
+export const putUpgradePreBuilt = asyncWrapperWithEnvironment<PutUpgradePreBuiltFlow>(async (req, res) => {
     const emptyQuery = requireEmptyQuery(req, { withEnv: true });
     if (emptyQuery) {
         res.status(400).send({ error: { code: 'invalid_query_params', errors: zodErrorToHTTP(emptyQuery.error) } });

--- a/packages/server/lib/controllers/v1/getV1.ts
+++ b/packages/server/lib/controllers/v1/getV1.ts
@@ -5,7 +5,7 @@ import { baseUrl, zodErrorToHTTP } from '@nangohq/utils';
 
 import { connectionIdSchema, providerConfigKeySchema } from '../../helpers/validation.js';
 import { hasScope } from '../../middleware/scope.middleware.js';
-import { asyncWrapper } from '../../utils/asyncWrapper.js';
+import { asyncWrapperWithEnvironment } from '../../utils/asyncWrapper.js';
 import { postPublicTriggerAction } from '../action/postTriggerAction.js';
 import { getPublicRecords } from '../records/getRecords.js';
 
@@ -17,7 +17,7 @@ const schemaHeaders = z.object({
 });
 
 /** @deprecated Use POST /action/trigger to trigger actions and GET /records to fetch sync records instead. */
-export const allPublicV1 = asyncWrapper<GetPublicV1>(async (req, res, next) => {
+export const allPublicV1 = asyncWrapperWithEnvironment<GetPublicV1>(async (req, res, next) => {
     const valHeaders = schemaHeaders.safeParse(req.headers);
     if (!valHeaders.success) {
         res.status(400).send({ error: { code: 'invalid_headers', errors: zodErrorToHTTP(valHeaders.error) } });

--- a/packages/server/lib/controllers/v1/gettingStarted/getGettingStarted.ts
+++ b/packages/server/lib/controllers/v1/gettingStarted/getGettingStarted.ts
@@ -2,7 +2,7 @@ import db from '@nangohq/database';
 import { gettingStartedService } from '@nangohq/shared';
 import { report, requireEmptyBody, requireEmptyQuery, zodErrorToHTTP } from '@nangohq/utils';
 
-import { asyncWrapper } from '../../../utils/asyncWrapper.js';
+import { asyncWrapperWithEnvironment } from '../../../utils/asyncWrapper.js';
 
 import type { GetGettingStarted } from '@nangohq/types';
 
@@ -10,7 +10,7 @@ import type { GetGettingStarted } from '@nangohq/types';
  * Getting started should always be available, so if it doesn't already exist, we create it,
  * including setting up a new github-getting-started integration using the preprovisioned provider if needed.
  */
-export const getGettingStarted = asyncWrapper<GetGettingStarted>(async (req, res) => {
+export const getGettingStarted = asyncWrapperWithEnvironment<GetGettingStarted>(async (req, res) => {
     const emptyQuery = requireEmptyQuery(req, { withEnv: true });
     if (emptyQuery) {
         res.status(400).send({ error: { code: 'invalid_query_params', errors: zodErrorToHTTP(emptyQuery.error) } });

--- a/packages/server/lib/controllers/v1/integrations/getIntegrations.ts
+++ b/packages/server/lib/controllers/v1/integrations/getIntegrations.ts
@@ -4,12 +4,12 @@ import { requireEmptyQuery, zodErrorToHTTP } from '@nangohq/utils';
 
 import { resolve } from '../../../authz/resolve.js';
 import { integrationToApi } from '../../../formatters/integration.js';
-import { asyncWrapper } from '../../../utils/asyncWrapper.js';
+import { asyncWrapperWithEnvironment } from '../../../utils/asyncWrapper.js';
 import { parseAssertionOptionParamsFromTemplate, parseConnectionConfigParamsFromTemplate, parseCredentialsParamsFromTemplate } from '../../../utils/utils.js';
 
 import type { ApiIntegrationList, GetIntegrations, ProviderTwoStep } from '@nangohq/types';
 
-export const getIntegrations = asyncWrapper<GetIntegrations>(async (req, res) => {
+export const getIntegrations = asyncWrapperWithEnvironment<GetIntegrations>(async (req, res) => {
     const emptyQuery = requireEmptyQuery(req, { withEnv: true });
     if (emptyQuery) {
         res.status(400).send({ error: { code: 'invalid_query_params', errors: zodErrorToHTTP(emptyQuery.error) } });

--- a/packages/server/lib/controllers/v1/integrations/postIntegration.ts
+++ b/packages/server/lib/controllers/v1/integrations/postIntegration.ts
@@ -2,14 +2,14 @@ import { configService, getGlobalClientMetadataDocumentUrl, getProvider, mcpClie
 import { requireEmptyQuery, zodErrorToHTTP } from '@nangohq/utils';
 
 import { integrationToApi } from '../../../formatters/integration.js';
-import { asyncWrapper } from '../../../utils/asyncWrapper.js';
+import { asyncWrapperWithEnvironment } from '../../../utils/asyncWrapper.js';
 import { buildIntegrationConfig } from './buildIntegrationConfig.js';
 import { resolveIntegrationConfig } from './integrationConfig.js';
 import { postIntegrationBodySchema } from './validation.js';
 
 import type { IntegrationConfig, PostIntegration, ProviderMcpOAUTH2 } from '@nangohq/types';
 
-export const postIntegration = asyncWrapper<PostIntegration>(async (req, res) => {
+export const postIntegration = asyncWrapperWithEnvironment<PostIntegration>(async (req, res) => {
     const emptyQuery = requireEmptyQuery(req, { withEnv: true });
     if (emptyQuery) {
         res.status(400).send({ error: { code: 'invalid_query_params', errors: zodErrorToHTTP(emptyQuery.error) } });

--- a/packages/server/lib/controllers/v1/integrations/providerConfigKey/deleteIntegration.ts
+++ b/packages/server/lib/controllers/v1/integrations/providerConfigKey/deleteIntegration.ts
@@ -1,7 +1,7 @@
 import { configService } from '@nangohq/shared';
 import { requireEmptyQuery, zodErrorToHTTP } from '@nangohq/utils';
 
-import { asyncWrapper } from '../../../../utils/asyncWrapper.js';
+import { asyncWrapperWithEnvironment } from '../../../../utils/asyncWrapper.js';
 import { getOrchestrator } from '../../../../utils/utils.js';
 import { validationParams } from './getIntegration.js';
 
@@ -9,7 +9,7 @@ import type { DeleteIntegration } from '@nangohq/types';
 
 const orchestrator = getOrchestrator();
 
-export const deleteIntegration = asyncWrapper<DeleteIntegration>(async (req, res) => {
+export const deleteIntegration = asyncWrapperWithEnvironment<DeleteIntegration>(async (req, res) => {
     const emptyQuery = requireEmptyQuery(req, { withEnv: true });
     if (emptyQuery) {
         res.status(400).send({ error: { code: 'invalid_query_params', errors: zodErrorToHTTP(emptyQuery.error) } });

--- a/packages/server/lib/controllers/v1/integrations/providerConfigKey/flows/getFlows.ts
+++ b/packages/server/lib/controllers/v1/integrations/providerConfigKey/flows/getFlows.ts
@@ -1,12 +1,12 @@
 import { configService, flowService, getSyncConfigsAsStandardConfig } from '@nangohq/shared';
 import { requireEmptyQuery, zodErrorToHTTP } from '@nangohq/utils';
 
-import { asyncWrapper } from '../../../../../utils/asyncWrapper.js';
+import { asyncWrapperWithEnvironment } from '../../../../../utils/asyncWrapper.js';
 import { validationParams } from '../getIntegration.js';
 
 import type { GetIntegration, GetIntegrationFlows, NangoSyncConfig } from '@nangohq/types';
 
-export const getIntegrationFlows = asyncWrapper<GetIntegrationFlows>(async (req, res) => {
+export const getIntegrationFlows = asyncWrapperWithEnvironment<GetIntegrationFlows>(async (req, res) => {
     const emptyQuery = requireEmptyQuery(req, { withEnv: true });
     if (emptyQuery) {
         res.status(400).send({ error: { code: 'invalid_query_params', errors: zodErrorToHTTP(emptyQuery.error) } });

--- a/packages/server/lib/controllers/v1/integrations/providerConfigKey/functions/deleteFunction.ts
+++ b/packages/server/lib/controllers/v1/integrations/providerConfigKey/functions/deleteFunction.ts
@@ -3,7 +3,7 @@ import * as z from 'zod';
 import { zodErrorToHTTP } from '@nangohq/utils';
 
 import { deletableFunctionTypeSchema, envSchema, providerConfigKeySchema } from '../../../../../helpers/validation.js';
-import { asyncWrapper } from '../../../../../utils/asyncWrapper.js';
+import { asyncWrapperWithEnvironment } from '../../../../../utils/asyncWrapper.js';
 import { handleDeleteIntegrationFunction } from '../../../../shared/integrations/functions/deleteFunction.js';
 
 import type { DeleteIntegrationFunction } from '@nangohq/types';
@@ -23,7 +23,7 @@ const paramsValidation = z
     })
     .strict();
 
-export const deleteIntegrationFunction = asyncWrapper<DeleteIntegrationFunction>(async (req, res) => {
+export const deleteIntegrationFunction = asyncWrapperWithEnvironment<DeleteIntegrationFunction>(async (req, res) => {
     const queryStringValues = querystringValidation.safeParse(req.query);
     if (!queryStringValues.success) {
         res.status(400).send({ error: { code: 'invalid_query_params', errors: zodErrorToHTTP(queryStringValues.error) } });

--- a/packages/server/lib/controllers/v1/integrations/providerConfigKey/functions/getCode.ts
+++ b/packages/server/lib/controllers/v1/integrations/providerConfigKey/functions/getCode.ts
@@ -3,7 +3,7 @@ import * as z from 'zod';
 import { zodErrorToHTTP } from '@nangohq/utils';
 
 import { envSchema, functionTypeSchema, providerConfigKeySchema } from '../../../../../helpers/validation.js';
-import { asyncWrapper } from '../../../../../utils/asyncWrapper.js';
+import { asyncWrapperWithEnvironment } from '../../../../../utils/asyncWrapper.js';
 import { handleGetFunctionCode } from '../../../../shared/integrations/functions/getCode.js';
 
 import type { GetFunctionCode } from '@nangohq/types';
@@ -22,7 +22,7 @@ const paramsValidation = z
     })
     .strict();
 
-export const getIntegrationFunctionCode = asyncWrapper<GetFunctionCode>(async (req, res) => {
+export const getIntegrationFunctionCode = asyncWrapperWithEnvironment<GetFunctionCode>(async (req, res) => {
     const queryStringValues = querystringValidation.safeParse(req.query);
     if (!queryStringValues.success) {
         res.status(400).send({ error: { code: 'invalid_query_params', errors: zodErrorToHTTP(queryStringValues.error) } });

--- a/packages/server/lib/controllers/v1/integrations/providerConfigKey/functions/getFunction.ts
+++ b/packages/server/lib/controllers/v1/integrations/providerConfigKey/functions/getFunction.ts
@@ -3,7 +3,7 @@ import * as z from 'zod';
 import { zodErrorToHTTP } from '@nangohq/utils';
 
 import { envSchema, functionTypeSchema, providerConfigKeySchema } from '../../../../../helpers/validation.js';
-import { asyncWrapper } from '../../../../../utils/asyncWrapper.js';
+import { asyncWrapperWithEnvironment } from '../../../../../utils/asyncWrapper.js';
 import { handleGetIntegrationFunction } from '../../../../shared/integrations/functions/getFunction.js';
 
 import type { GetIntegrationFunction } from '@nangohq/types';
@@ -22,7 +22,7 @@ const paramsValidation = z
     })
     .strict();
 
-export const getIntegrationFunction = asyncWrapper<GetIntegrationFunction>(async (req, res) => {
+export const getIntegrationFunction = asyncWrapperWithEnvironment<GetIntegrationFunction>(async (req, res) => {
     const queryStringValues = querystringValidation.safeParse(req.query);
     if (!queryStringValues.success) {
         res.status(400).send({ error: { code: 'invalid_query_params', errors: zodErrorToHTTP(queryStringValues.error) } });

--- a/packages/server/lib/controllers/v1/integrations/providerConfigKey/functions/getFunctions.ts
+++ b/packages/server/lib/controllers/v1/integrations/providerConfigKey/functions/getFunctions.ts
@@ -3,7 +3,7 @@ import * as z from 'zod';
 import { zodErrorToHTTP } from '@nangohq/utils';
 
 import { envSchema, functionListQueryFields } from '../../../../../helpers/validation.js';
-import { asyncWrapper } from '../../../../../utils/asyncWrapper.js';
+import { asyncWrapperWithEnvironment } from '../../../../../utils/asyncWrapper.js';
 import { handleListIntegrationFunctions } from '../../../../shared/integrations/functions/listFunctions.js';
 import { validationParams } from '../getIntegration.js';
 
@@ -16,7 +16,7 @@ const querystringValidation = z
     })
     .strict();
 
-export const getIntegrationFunctions = asyncWrapper<GetIntegrationFunctions>(async (req, res) => {
+export const getIntegrationFunctions = asyncWrapperWithEnvironment<GetIntegrationFunctions>(async (req, res) => {
     const queryStringValues = querystringValidation.safeParse(req.query);
     if (!queryStringValues.success) {
         res.status(400).send({ error: { code: 'invalid_query_params', errors: zodErrorToHTTP(queryStringValues.error) } });

--- a/packages/server/lib/controllers/v1/integrations/providerConfigKey/getIntegration.ts
+++ b/packages/server/lib/controllers/v1/integrations/providerConfigKey/getIntegration.ts
@@ -10,7 +10,7 @@ import { requireEmptyQuery, zodErrorToHTTP } from '@nangohq/utils';
 import { resolve } from '../../../../authz/resolve.js';
 import { integrationToApi } from '../../../../formatters/integration.js';
 import { providerConfigKeySchema } from '../../../../helpers/validation.js';
-import { asyncWrapper } from '../../../../utils/asyncWrapper.js';
+import { asyncWrapperWithEnvironment } from '../../../../utils/asyncWrapper.js';
 
 import type { GetIntegration } from '@nangohq/types';
 
@@ -20,7 +20,7 @@ export const validationParams = z
     })
     .strict();
 
-export const getIntegration = asyncWrapper<GetIntegration>(async (req, res) => {
+export const getIntegration = asyncWrapperWithEnvironment<GetIntegration>(async (req, res) => {
     const emptyQuery = requireEmptyQuery(req, { withEnv: true });
     if (emptyQuery) {
         res.status(400).send({ error: { code: 'invalid_query_params', errors: zodErrorToHTTP(emptyQuery.error) } });

--- a/packages/server/lib/controllers/v1/integrations/providerConfigKey/patchIntegration.ts
+++ b/packages/server/lib/controllers/v1/integrations/providerConfigKey/patchIntegration.ts
@@ -1,14 +1,14 @@
 import { configService, connectionService, getGlobalClientMetadataDocumentUrl, getProvider } from '@nangohq/shared';
 import { requireEmptyQuery, zodErrorToHTTP } from '@nangohq/utils';
 
-import { asyncWrapper } from '../../../../utils/asyncWrapper.js';
+import { asyncWrapperWithEnvironment } from '../../../../utils/asyncWrapper.js';
 import { resolveIntegrationConfig } from '../integrationConfig.js';
 import { patchIntegrationBodySchema } from '../validation.js';
 import { validationParams } from './getIntegration.js';
 
 import type { PatchIntegration, ProviderMcpOAUTH2 } from '@nangohq/types';
 
-export const patchIntegration = asyncWrapper<PatchIntegration>(async (req, res) => {
+export const patchIntegration = asyncWrapperWithEnvironment<PatchIntegration>(async (req, res) => {
     const emptyQuery = requireEmptyQuery(req, { withEnv: true });
     if (emptyQuery) {
         res.status(400).send({ error: { code: 'invalid_query_params', errors: zodErrorToHTTP(emptyQuery.error) } });

--- a/packages/server/lib/controllers/v1/integrations/providerConfigKey/templates/getTemplates.ts
+++ b/packages/server/lib/controllers/v1/integrations/providerConfigKey/templates/getTemplates.ts
@@ -2,12 +2,12 @@ import { configService, findActiveDeployedMeta, flowService } from '@nangohq/sha
 import { requireEmptyQuery, zodErrorToHTTP } from '@nangohq/utils';
 
 import { toNangoFunction } from '../../../../../formatters/function.js';
-import { asyncWrapper } from '../../../../../utils/asyncWrapper.js';
+import { asyncWrapperWithEnvironment } from '../../../../../utils/asyncWrapper.js';
 import { validationParams } from '../getIntegration.js';
 
 import type { DeployedMeta, GetIntegrationTemplates, NangoFunctionTemplate } from '@nangohq/types';
 
-export const getIntegrationTemplates = asyncWrapper<GetIntegrationTemplates>(async (req, res) => {
+export const getIntegrationTemplates = asyncWrapperWithEnvironment<GetIntegrationTemplates>(async (req, res) => {
     const emptyQuery = requireEmptyQuery(req, { withEnv: true });
     if (emptyQuery) {
         res.status(400).send({ error: { code: 'invalid_query_params', errors: zodErrorToHTTP(emptyQuery.error) } });

--- a/packages/server/lib/controllers/v1/logs/getOperation.ts
+++ b/packages/server/lib/controllers/v1/logs/getOperation.ts
@@ -3,7 +3,7 @@ import * as z from 'zod';
 import { envs, isLogsNotFoundError, modelOperations, operationIdRegex } from '@nangohq/logs';
 import { requireEmptyQuery, zodErrorToHTTP } from '@nangohq/utils';
 
-import { asyncWrapper } from '../../../utils/asyncWrapper.js';
+import { asyncWrapperWithEnvironment } from '../../../utils/asyncWrapper.js';
 
 import type { GetOperation } from '@nangohq/types';
 
@@ -13,7 +13,7 @@ const validation = z
     })
     .strict();
 
-export const getOperation = asyncWrapper<GetOperation>(async (req, res) => {
+export const getOperation = asyncWrapperWithEnvironment<GetOperation>(async (req, res) => {
     if (!envs.NANGO_LOGS_ENABLED) {
         res.status(404).send({ error: { code: 'feature_disabled' } });
         return;

--- a/packages/server/lib/controllers/v1/logs/postInsights.ts
+++ b/packages/server/lib/controllers/v1/logs/postInsights.ts
@@ -3,7 +3,7 @@ import * as z from 'zod';
 import { envs, modelInsights } from '@nangohq/logs';
 import { requireEmptyQuery, zodErrorToHTTP } from '@nangohq/utils';
 
-import { asyncWrapper } from '../../../utils/asyncWrapper.js';
+import { asyncWrapperWithEnvironment } from '../../../utils/asyncWrapper.js';
 
 import type { PostInsights } from '@nangohq/types';
 
@@ -13,7 +13,7 @@ const validation = z
     })
     .strict();
 
-export const postInsights = asyncWrapper<PostInsights>(async (req, res) => {
+export const postInsights = asyncWrapperWithEnvironment<PostInsights>(async (req, res) => {
     if (!envs.NANGO_LOGS_ENABLED) {
         res.status(404).send({ error: { code: 'feature_disabled' } });
         return;

--- a/packages/server/lib/controllers/v1/logs/searchFilters.ts
+++ b/packages/server/lib/controllers/v1/logs/searchFilters.ts
@@ -3,7 +3,7 @@ import * as z from 'zod';
 import { envs, modelOperations } from '@nangohq/logs';
 import { requireEmptyQuery, zodErrorToHTTP } from '@nangohq/utils';
 
-import { asyncWrapper } from '../../../utils/asyncWrapper.js';
+import { asyncWrapperWithEnvironment } from '../../../utils/asyncWrapper.js';
 
 import type { SearchFilters } from '@nangohq/types';
 
@@ -14,7 +14,7 @@ const validation = z
     })
     .strict();
 
-export const searchFilters = asyncWrapper<SearchFilters>(async (req, res) => {
+export const searchFilters = asyncWrapperWithEnvironment<SearchFilters>(async (req, res) => {
     if (!envs.NANGO_LOGS_ENABLED) {
         res.status(404).send({ error: { code: 'feature_disabled' } });
         return;

--- a/packages/server/lib/controllers/v1/logs/searchMessages.ts
+++ b/packages/server/lib/controllers/v1/logs/searchMessages.ts
@@ -3,7 +3,7 @@ import * as z from 'zod';
 import { envs, isLogsNotFoundError, modelMessages, modelOperations, operationIdRegex } from '@nangohq/logs';
 import { requireEmptyQuery, zodErrorToHTTP } from '@nangohq/utils';
 
-import { asyncWrapper } from '../../../utils/asyncWrapper.js';
+import { asyncWrapperWithEnvironment } from '../../../utils/asyncWrapper.js';
 
 import type { SearchMessages } from '@nangohq/types';
 
@@ -23,7 +23,7 @@ const validation = z
     })
     .strict();
 
-export const searchMessages = asyncWrapper<SearchMessages>(async (req, res) => {
+export const searchMessages = asyncWrapperWithEnvironment<SearchMessages>(async (req, res) => {
     if (!envs.NANGO_LOGS_ENABLED) {
         res.status(404).send({ error: { code: 'feature_disabled' } });
         return;

--- a/packages/server/lib/controllers/v1/logs/searchOperations.ts
+++ b/packages/server/lib/controllers/v1/logs/searchOperations.ts
@@ -3,7 +3,7 @@ import * as z from 'zod';
 import { envs, modelMessages, modelOperations } from '@nangohq/logs';
 import { requireEmptyQuery, zodErrorToHTTP } from '@nangohq/utils';
 
-import { asyncWrapper } from '../../../utils/asyncWrapper.js';
+import { asyncWrapperWithEnvironment } from '../../../utils/asyncWrapper.js';
 
 import type { SearchOperations } from '@nangohq/types';
 
@@ -57,7 +57,7 @@ const validation = z
     })
     .strict();
 
-export const searchOperations = asyncWrapper<SearchOperations>(async (req, res) => {
+export const searchOperations = asyncWrapperWithEnvironment<SearchOperations>(async (req, res) => {
     if (!envs.NANGO_LOGS_ENABLED) {
         res.status(404).send({ error: { code: 'feature_disabled' } });
         return;

--- a/packages/server/lib/controllers/v1/providers/providerConfigKey/templates/helpers.ts
+++ b/packages/server/lib/controllers/v1/providers/providerConfigKey/templates/helpers.ts
@@ -10,7 +10,7 @@ export function handleGetProviderTemplates({
     res,
     providerConfigKey
 }: {
-    res: Response<GetProviderTemplates['Reply'], Required<RequestLocals>>;
+    res: Response<GetProviderTemplates['Reply'], RequestLocals>;
     providerConfigKey: string;
 }): void {
     const all = flowService.getAllAvailableFlowsAsStandardConfig();

--- a/packages/server/lib/controllers/v1/trigger/postTriggerFunction.ts
+++ b/packages/server/lib/controllers/v1/trigger/postTriggerFunction.ts
@@ -6,7 +6,7 @@ import { errorManager, SyncCommand, syncManager } from '@nangohq/shared';
 import { getHeaders, metrics, redactHeaders, zodErrorToHTTP } from '@nangohq/utils';
 
 import { connectionIdSchema, providerConfigKeySchema, syncNameSchema } from '../../../helpers/validation.js';
-import { asyncWrapper } from '../../../utils/asyncWrapper.js';
+import { asyncWrapperWithEnvironment } from '../../../utils/asyncWrapper.js';
 import { getOrchestrator } from '../../../utils/utils.js';
 import { runAction } from '../../action/runAction.js';
 import { normalizeSyncParams } from '../../sync/helpers.js';
@@ -31,7 +31,7 @@ const bodySchema = z.discriminatedUnion('type', [
 
 const orchestrator = getOrchestrator();
 
-export const postTriggerFunction = asyncWrapper<PostInternalTriggerFunction>(async (req, res) => {
+export const postTriggerFunction = asyncWrapperWithEnvironment<PostInternalTriggerFunction>(async (req, res) => {
     const valBody = bodySchema.safeParse(req.body);
     if (!valBody.success) {
         res.status(400).send({ error: { code: 'invalid_body', errors: zodErrorToHTTP(valBody.error) } });

--- a/packages/server/lib/middleware/access.middleware.ts
+++ b/packages/server/lib/middleware/access.middleware.ts
@@ -54,8 +54,8 @@ export class AccessMiddleware {
     ): Promise<
         Result<{
             account: DBTeam;
-            environment: DBEnvironment;
-            secret: DBAPISecret;
+            environment?: DBEnvironment;
+            secret?: DBAPISecret;
             plan: DBPlan | null;
             auth?: {
                 source: 'customer_key' | 'sandbox_token' | 'api_secret' | 'env_var';
@@ -120,8 +120,11 @@ export class AccessMiddleware {
 
             res.locals['authType'] = 'secretKey';
             res.locals['account'] = result.value.account;
-            res.locals['environment'] = result.value.environment;
             res.locals['plan'] = result.value.plan;
+            // Absent for account-plane keys; environment routes are gated by their scope guards.
+            if (result.value.environment) {
+                res.locals['environment'] = result.value.environment;
+            }
             if (result.value.auth?.scopes) {
                 res.locals['apiKeyScopes'] = result.value.auth.scopes;
             }
@@ -412,8 +415,10 @@ export class AccessMiddleware {
                 }
                 res.locals['authType'] = 'secretKey';
                 res.locals['account'] = apiKeyResult.value.account;
-                res.locals['environment'] = apiKeyResult.value.environment;
                 res.locals['plan'] = apiKeyResult.value.plan;
+                if (apiKeyResult.value.environment) {
+                    res.locals['environment'] = apiKeyResult.value.environment;
+                }
                 if (apiKeyResult.value.auth?.scopes) {
                     res.locals['apiKeyScopes'] = apiKeyResult.value.auth.scopes;
                 }
@@ -575,8 +580,11 @@ export class AccessMiddleware {
 
             res.locals['authType'] = 'secretKey';
             res.locals['account'] = result.value.account;
-            res.locals['environment'] = result.value.environment;
             res.locals['plan'] = result.value.plan;
+            // Absent for account-plane keys; environment routes are gated by their scope guards.
+            if (result.value.environment) {
+                res.locals['environment'] = result.value.environment;
+            }
             tagTraceUser(result.value);
             next();
         } catch (err) {

--- a/packages/server/lib/middleware/access.middleware.ts
+++ b/packages/server/lib/middleware/access.middleware.ts
@@ -88,7 +88,7 @@ export class AccessMiddleware {
         return Ok({ ...accountContext });
     }
 
-    async secretKeyAuth(req: Request, res: Response<any, RequestLocals>, next: NextFunction) {
+    async secretKeyAuth(req: Request, res: Response<any, Partial<RequestLocals>>, next: NextFunction) {
         const active = tracer.scope().active();
         const span = tracer.startSpan('secretKeyAuth', {
             childOf: active!
@@ -184,7 +184,7 @@ export class AccessMiddleware {
         return Ok({ ...accountContext });
     }
 
-    async sessionAuth(req: Request, res: Response<any, RequestLocals>, next: NextFunction) {
+    async sessionAuth(req: Request, res: Response<any, Partial<RequestLocals>>, next: NextFunction) {
         const active = tracer.scope().active();
         const span = tracer.startSpan('sessionAuth', {
             childOf: active!
@@ -206,7 +206,7 @@ export class AccessMiddleware {
         }
     }
 
-    async noAuth(req: Request, res: Response<any, RequestLocals>, next: NextFunction) {
+    async noAuth(req: Request, res: Response<any, Partial<RequestLocals>>, next: NextFunction) {
         res.locals['authType'] = 'none';
         if (!req.isAuthenticated()) {
             const user = await userService.getUserById(process.env['LOCAL_NANGO_USER_ID'] ? parseInt(process.env['LOCAL_NANGO_USER_ID']) : 0);
@@ -230,7 +230,7 @@ export class AccessMiddleware {
         await fillLocalsFromSession(req, res, next);
     }
 
-    async basicAuth(req: Request, res: Response<any, RequestLocals>, next: NextFunction) {
+    async basicAuth(req: Request, res: Response<any, Partial<RequestLocals>>, next: NextFunction) {
         // Already signed in.
         if (req.isAuthenticated()) {
             await fillLocalsFromSession(req, res, next);
@@ -286,7 +286,7 @@ export class AccessMiddleware {
         });
     }
 
-    async connectSessionAuth(req: Request, res: Response<any, RequestLocals>, next: NextFunction) {
+    async connectSessionAuth(req: Request, res: Response<any, Partial<RequestLocals>>, next: NextFunction) {
         const active = tracer.scope().active();
         const span = tracer.startSpan('connectSessionAuth', {
             childOf: active!
@@ -335,7 +335,7 @@ export class AccessMiddleware {
      * This is the same as connectSessionAuth expect we check the body
      * Only used for /connect/telemetry because we use sendBeacon that does not accept headers
      */
-    async connectSessionAuthBody(req: Request, res: Response<any, RequestLocals>, next: NextFunction) {
+    async connectSessionAuthBody(req: Request, res: Response<any, Partial<RequestLocals>>, next: NextFunction) {
         const active = tracer.scope().active();
         const span = tracer.startSpan('connectSessionAuth', {
             childOf: active!
@@ -374,7 +374,7 @@ export class AccessMiddleware {
         }
     }
 
-    async connectSessionOrSecretKeyAuth(req: Request, res: Response<any, RequestLocals>, next: NextFunction) {
+    async connectSessionOrSecretKeyAuth(req: Request, res: Response<any, Partial<RequestLocals>>, next: NextFunction) {
         const active = tracer.scope().active();
         const span = tracer.startSpan('connectSessionOrSecretKeyAuth', {
             childOf: active!
@@ -461,7 +461,7 @@ export class AccessMiddleware {
         }
     }
 
-    async connectSessionOrPublicKeyAuth(req: Request, res: Response<any, RequestLocals>, next: NextFunction) {
+    async connectSessionOrPublicKeyAuth(req: Request, res: Response<any, Partial<RequestLocals>>, next: NextFunction) {
         const active = tracer.scope().active();
         const span = tracer.startSpan('connectSessionOrPublicKeyAuth', {
             childOf: active!
@@ -539,7 +539,7 @@ export class AccessMiddleware {
      * Test authentication that accepts both secret key and session authentication
      * This allows tests to use either authentication method
      */
-    async testAuth(req: Request, res: Response<any, RequestLocals>, next: NextFunction) {
+    async testAuth(req: Request, res: Response<any, Partial<RequestLocals>>, next: NextFunction) {
         if (!isTest) {
             res.status(401).send({ error: { code: 'unauthorized', message: 'testAuth is only available in test environment' } });
             return;
@@ -642,7 +642,7 @@ export class AccessMiddleware {
 /**
  * Fill res.locals with common information
  */
-async function fillLocalsFromSession(req: Request, res: Response<any, RequestLocals>, next: NextFunction) {
+async function fillLocalsFromSession(req: Request, res: Response<any, Partial<RequestLocals>>, next: NextFunction) {
     try {
         const user = await userService.getUserById(req.user!.id);
         if (!user) {

--- a/packages/server/lib/middleware/accountPlaneAuth.integration.test.ts
+++ b/packages/server/lib/middleware/accountPlaneAuth.integration.test.ts
@@ -1,6 +1,9 @@
+import { randomUUID } from 'crypto';
+
 import { afterAll, beforeAll, describe, expect, it } from 'vitest';
 
-import { seeders } from '@nangohq/shared';
+import db from '@nangohq/database';
+import { customerKeyService, seeders } from '@nangohq/shared';
 
 import { runServer } from '../utils/tests.js';
 
@@ -40,9 +43,8 @@ describe('account-plane key isolation', () => {
     });
 
     /**
-     * These two are environment surfaces with no `withScope` guard of their own — `/v1/*` is a catch-all
-     * and the control-plane MCP authorizes per tool — so `withEnvironment` is what makes them 403 rather
-     * than reaching the handler and hitting the 500 backstop.
+     * `/v1/*` is a catch-all with no `withScope` guard of its own, so nothing refuses the key before the
+     * handler. `asyncWrapperWithEnvironment` is what turns that into a 403 instead of a 500.
      */
     it('should refuse an account key on /v1/* with 403 rather than 500', async () => {
         const { accountApiKey } = await seeders.seedAccountEnvAndUser();
@@ -54,6 +56,31 @@ describe('account-plane key isolation', () => {
             headers: { 'provider-config-key': 'unused', 'connection-id': 'unused' },
             token: accountApiKey.secret
         });
+
+        expect(res.res.status).toBe(403);
+        expect(res.json).toMatchObject({ error: { code: 'forbidden' } });
+    });
+
+    /**
+     * A key naming no environment is the account plane by construction, so one carrying environment
+     * scopes is self-contradictory: its scopes satisfy the route guard, but there is no environment for
+     * the handler to act on. No service path produces this — the relation is deleted directly here — and
+     * the contract is that it is refused rather than surfacing as a 500.
+     */
+    it('should refuse an environment-scoped key bound to no environment', async () => {
+        const { account, env } = await seeders.seedAccountEnvAndUser();
+        const key = (
+            await customerKeyService.createApiKey(db.knex, {
+                accountId: account.id,
+                target: { type: 'environment', environmentId: env.id },
+                displayName: `orphan-${randomUUID()}`,
+                scopes: ['environment:*'],
+                withSandboxSigningSecret: false
+            })
+        ).unwrap();
+        await db.knex('customer_keys_relations').where({ customer_key_id: key.id }).delete();
+
+        const res = await api.fetch('/connection', { method: 'GET', query: {}, token: key.secret });
 
         expect(res.res.status).toBe(403);
         expect(res.json).toMatchObject({ error: { code: 'forbidden' } });

--- a/packages/server/lib/middleware/accountPlaneAuth.integration.test.ts
+++ b/packages/server/lib/middleware/accountPlaneAuth.integration.test.ts
@@ -1,0 +1,61 @@
+import { afterAll, beforeAll, describe, expect, it } from 'vitest';
+
+import { seeders } from '@nangohq/shared';
+
+import { runServer } from '../utils/tests.js';
+
+let api: Awaited<ReturnType<typeof runServer>>;
+
+/**
+ * One auth path resolves both key planes, so isolation is enforced by the route guards rather than by
+ * authentication: an account key presented to an environment route authenticates and is then refused
+ * with 403, not 401.
+ */
+describe('account-plane key isolation', () => {
+    beforeAll(async () => {
+        api = await runServer();
+    });
+
+    afterAll(() => {
+        api.server.close();
+    });
+
+    it('should refuse an account key on an environment-plane route', async () => {
+        const { accountApiKey } = await seeders.seedAccountEnvAndUser();
+
+        const res = await api.fetch('/connection', { method: 'GET', query: {}, token: accountApiKey.secret });
+
+        expect(res.res.status).toBe(403);
+        expect(res.json).toMatchObject({ error: { code: 'forbidden' } });
+    });
+
+    // Provider metadata is account-agnostic, so this route carries no scope guard and an account key
+    // is allowed through.
+    it('should allow an account key on the provider catalog, which is not environment data', async () => {
+        const { accountApiKey } = await seeders.seedAccountEnvAndUser();
+
+        const res = await api.fetch('/providers', { method: 'GET', query: {}, token: accountApiKey.secret });
+
+        expect(res.res.status).toBe(200);
+    });
+
+    /**
+     * These two are environment surfaces with no `withScope` guard of their own — `/v1/*` is a catch-all
+     * and the control-plane MCP authorizes per tool — so `withEnvironment` is what makes them 403 rather
+     * than reaching the handler and hitting the 500 backstop.
+     */
+    it('should refuse an account key on /v1/* with 403 rather than 500', async () => {
+        const { accountApiKey } = await seeders.seedAccountEnvAndUser();
+
+        const res = await api.fetch('/v1/:path', {
+            method: 'GET',
+            params: { path: 'anything' },
+            query: {},
+            headers: { 'provider-config-key': 'unused', 'connection-id': 'unused' },
+            token: accountApiKey.secret
+        });
+
+        expect(res.res.status).toBe(403);
+        expect(res.json).toMatchObject({ error: { code: 'forbidden' } });
+    });
+});

--- a/packages/server/lib/middleware/audit.middleware.ts
+++ b/packages/server/lib/middleware/audit.middleware.ts
@@ -68,9 +68,12 @@ type AuditSpec<TEndpoint extends AuditableEndpoint> = {
     policy: TEndpoint['Audit'];
     target?: (
         req: AuditRequest<TEndpoint>,
-        locals: RequestLocals
+        locals: Partial<RequestLocals>
     ) => AuditTarget | AuditTarget[] | undefined | Promise<AuditTarget | AuditTarget[] | undefined>;
-    metadata?: (req: AuditRequest<TEndpoint>, locals: RequestLocals) => Record<string, unknown> | undefined | Promise<Record<string, unknown> | undefined>;
+    metadata?: (
+        req: AuditRequest<TEndpoint>,
+        locals: Partial<RequestLocals>
+    ) => Record<string, unknown> | undefined | Promise<Record<string, unknown> | undefined>;
 };
 
 function toId(value: unknown): string | undefined {
@@ -95,7 +98,7 @@ function omitUndefined(obj: Record<string, unknown>): Record<string, unknown> | 
     return Object.keys(out).length > 0 ? out : undefined;
 }
 
-function resolveActor(locals: RequestLocals): AuditActor {
+function resolveActor(locals: Partial<RequestLocals>): AuditActor {
     if (locals.authType === 'session' && locals.user) {
         return { type: 'user', id: String(locals.user.id), display: locals.user.email };
     }
@@ -149,7 +152,7 @@ async function emit(policy: AuditPolicy, req: Request, res: Response, resolved: 
     // Stamp occurredAt now so it reflects the response time, not audit-write latency.
     const occurredAt = new Date().toISOString();
     try {
-        const locals = res.locals as RequestLocals;
+        const locals = res.locals as Partial<RequestLocals>;
         const { account, environment } = locals;
         if (!account) {
             return;
@@ -188,7 +191,7 @@ export function auditable<TEndpoint extends AuditableEndpoint>(spec: AuditSpec<T
     return (req, res, next) => {
         void (async () => {
             try {
-                const locals = res.locals as RequestLocals;
+                const locals = res.locals as Partial<RequestLocals>;
                 if (locals.account && (await getFlags().isAuditTrailEnabled(locals.account.uuid))) {
                     // Register the finish listener only once we know we should audit — a disabled account
                     // never installs a dead listener. It reads `resolved` lazily at finish, so it captures
@@ -288,7 +291,7 @@ async function dbTarget(type: AuditTargetType, value: unknown, lookup: (id: stri
     return { type, id, ...(display ? { display } : {}) };
 }
 
-function memberTarget(req: Request<{ id: number }>, locals: RequestLocals): Promise<AuditTarget | undefined> {
+function memberTarget(req: Request<{ id: number }>, locals: Partial<RequestLocals>): Promise<AuditTarget | undefined> {
     return dbTarget('member', req.params.id, async (id) => {
         if (!locals.account) {
             return undefined;
@@ -298,7 +301,7 @@ function memberTarget(req: Request<{ id: number }>, locals: RequestLocals): Prom
     });
 }
 
-function syncTarget(value: unknown, locals: RequestLocals): Promise<AuditTarget | undefined> {
+function syncTarget(value: unknown, locals: Partial<RequestLocals>): Promise<AuditTarget | undefined> {
     return dbTarget('sync', value, async (id) => {
         const numericId = Number(id);
         if (Number.isNaN(numericId) || !locals.environment) {
@@ -309,7 +312,7 @@ function syncTarget(value: unknown, locals: RequestLocals): Promise<AuditTarget 
     });
 }
 
-function apiKeyTarget(value: unknown, locals: RequestLocals): Promise<AuditTarget | undefined> {
+function apiKeyTarget(value: unknown, locals: Partial<RequestLocals>): Promise<AuditTarget | undefined> {
     return dbTarget('api_key', value, async (id) => {
         if (!locals.environment) {
             return undefined;

--- a/packages/server/lib/middleware/audit.middleware.ts
+++ b/packages/server/lib/middleware/audit.middleware.ts
@@ -317,7 +317,7 @@ function apiKeyTarget(value: unknown, locals: Partial<RequestLocals>): Promise<A
         if (!locals.environment) {
             return undefined;
         }
-        const result = await customerKeyService.getApiKeysByEnv(db.knex, locals.environment.id);
+        const result = await customerKeyService.getApiKeys(db.knex, { type: 'environment', environmentId: locals.environment.id });
         return result.isOk() ? result.value.find((key) => String(key.id) === id)?.display_name : undefined;
     });
 }

--- a/packages/server/lib/middleware/authenticateLocalSignin.middleware.ts
+++ b/packages/server/lib/middleware/authenticateLocalSignin.middleware.ts
@@ -17,7 +17,7 @@ interface LocalAuthInfo {
  * passes a full {@link DBUser}. We assert that here so downstream handlers see a
  * consistent type (see {@link RequestLocals.user}).
  */
-export function authenticateLocalSignin(req: Request, res: Response<any, RequestLocals>, next: NextFunction): void {
+export function authenticateLocalSignin(req: Request, res: Response<any, Partial<RequestLocals>>, next: NextFunction): void {
     passport.authenticate('local', { session: false }, (err: unknown, user: Express.User | false | null, info?: LocalAuthInfo) => {
         if (err) {
             next(err);

--- a/packages/server/lib/middleware/egress-meter.middleware.ts
+++ b/packages/server/lib/middleware/egress-meter.middleware.ts
@@ -9,7 +9,7 @@ function getCallsite(req: Request): string {
     return `${method}_${path}`;
 }
 
-export const egressMeterMiddleware = (req: Request, res: Response<any, RequestLocals>, next: NextFunction) => {
+export const egressMeterMiddleware = (req: Request, res: Response<any, Partial<RequestLocals>>, next: NextFunction) => {
     if (res.locals['apiKeyAuthSource'] !== 'customer_key') {
         next();
         return;

--- a/packages/server/lib/middleware/ratelimit.middleware.ts
+++ b/packages/server/lib/middleware/ratelimit.middleware.ts
@@ -69,7 +69,7 @@ async function getRateLimiter(size: DBPlan['api_rate_limit_size']) {
 /**
  * Rate limit api calls
  */
-export const rateLimiterMiddleware = async (req: Request, res: Response<any, RequestLocals>, next: NextFunction) => {
+export const rateLimiterMiddleware = async (req: Request, res: Response<any, Partial<RequestLocals>>, next: NextFunction) => {
     if (!flagHasAPIRateLimit) {
         next();
         return;
@@ -110,7 +110,7 @@ export const rateLimiterMiddleware = async (req: Request, res: Response<any, Req
     }
 };
 
-function getKey(req: Request, res: Response<any, RequestLocals>): string {
+function getKey(req: Request, res: Response<any, Partial<RequestLocals>>): string {
     if ('account' in res.locals) {
         let key = `account-${res.locals.authType === 'secretKey' ? 'secret' : 'global'}-${res.locals['account'].id}`;
         // customers requests and requests from scripts fall into different buckets
@@ -125,7 +125,7 @@ function getKey(req: Request, res: Response<any, RequestLocals>): string {
 }
 
 const specialPaths = ['/api/v1/account'];
-function getPointsToConsume(req: Request, res: Response<any, RequestLocals>, maxPoints: number): number {
+function getPointsToConsume(req: Request, res: Response<any, Partial<RequestLocals>>, maxPoints: number): number {
     const fullPath = path.join(req.baseUrl, req.route.path);
 
     if (specialPaths.some((p) => fullPath.startsWith(p))) {

--- a/packages/server/lib/middleware/scope.middleware.ts
+++ b/packages/server/lib/middleware/scope.middleware.ts
@@ -20,7 +20,7 @@ export function hasScope({ grantedScopes, requiredScope }: { grantedScopes: stri
 }
 
 export function withScope(requiredScope: ApiKeyScope) {
-    return function (_req: Request, res: Response<unknown, RequestLocals>, next: NextFunction): void {
+    return function (_req: Request, res: Response<unknown, Partial<RequestLocals>>, next: NextFunction): void {
         const scopes = res.locals['apiKeyScopes'];
 
         if (hasScope({ grantedScopes: scopes, requiredScope })) {
@@ -33,7 +33,7 @@ export function withScope(requiredScope: ApiKeyScope) {
 }
 
 export function withAnyScope(...requiredScopes: ApiKeyScope[]) {
-    return function (_req: Request, res: Response<unknown, RequestLocals>, next: NextFunction): void {
+    return function (_req: Request, res: Response<unknown, Partial<RequestLocals>>, next: NextFunction): void {
         const scopes = res.locals['apiKeyScopes'];
 
         for (const scope of requiredScopes) {

--- a/packages/server/lib/middleware/scope.middleware.ts
+++ b/packages/server/lib/middleware/scope.middleware.ts
@@ -19,20 +19,7 @@ export function hasScope({ grantedScopes, requiredScope }: { grantedScopes: stri
     return false;
 }
 
-export function withScope(requiredScope: ApiKeyScope) {
-    return function (_req: Request, res: Response<unknown, Partial<RequestLocals>>, next: NextFunction): void {
-        const scopes = res.locals['apiKeyScopes'];
-
-        if (hasScope({ grantedScopes: scopes, requiredScope })) {
-            next();
-            return;
-        }
-
-        res.status(403).json({ error: { code: 'forbidden', message: `Insufficient scope. Required: ${requiredScope}` } });
-    };
-}
-
-export function withAnyScope(...requiredScopes: ApiKeyScope[]) {
+function guard(requiredScopes: ApiKeyScope[]) {
     return function (_req: Request, res: Response<unknown, Partial<RequestLocals>>, next: NextFunction): void {
         const scopes = res.locals['apiKeyScopes'];
 
@@ -43,6 +30,28 @@ export function withAnyScope(...requiredScopes: ApiKeyScope[]) {
             }
         }
 
-        res.status(403).json({ error: { code: 'forbidden', message: `Insufficient scope. Required one of: ${requiredScopes.join(' or ')}` } });
+        const required = requiredScopes.length > 1 ? `one of: ${requiredScopes.join(' or ')}` : requiredScopes[0];
+        res.status(403).json({ error: { code: 'forbidden', message: `Insufficient scope. Required: ${required}` } });
     };
+}
+
+export function withScope(requiredScope: ApiKeyScope) {
+    return guard([requiredScope]);
+}
+
+export function withAnyScope(...requiredScopes: ApiKeyScope[]) {
+    return guard(requiredScopes);
+}
+
+/**
+ * For environment routes whose required scope isn't known at mount time — the `/v1/*splat` catch-all and
+ * the control-plane MCP endpoints resolve their own scopes inside the handler.
+ */
+export function withEnvironment(_req: Request, res: Response<unknown, Partial<RequestLocals>>, next: NextFunction): void {
+    if (!res.locals['environment']) {
+        res.status(403).json({ error: { code: 'forbidden', message: 'This endpoint requires an environment-scoped API key' } });
+        return;
+    }
+
+    next();
 }

--- a/packages/server/lib/middleware/scope.middleware.ts
+++ b/packages/server/lib/middleware/scope.middleware.ts
@@ -42,16 +42,3 @@ export function withScope(requiredScope: ApiKeyScope) {
 export function withAnyScope(...requiredScopes: ApiKeyScope[]) {
     return guard(requiredScopes);
 }
-
-/**
- * For environment routes whose required scope isn't known at mount time — the `/v1/*splat` catch-all and
- * the control-plane MCP endpoints resolve their own scopes inside the handler.
- */
-export function withEnvironment(_req: Request, res: Response<unknown, Partial<RequestLocals>>, next: NextFunction): void {
-    if (!res.locals['environment']) {
-        res.status(403).json({ error: { code: 'forbidden', message: 'This endpoint requires an environment-scoped API key' } });
-        return;
-    }
-
-    next();
-}

--- a/packages/server/lib/middleware/scope.middleware.unit.test.ts
+++ b/packages/server/lib/middleware/scope.middleware.unit.test.ts
@@ -43,13 +43,31 @@ describe('hasScope', () => {
         expect(hasScope({ grantedScopes: ['environment:deploy', 'environment:proxy'], requiredScope: 'environment:proxy' })).toBe(true);
     });
 
-    it('wildcard does not match across prefixes', () => {
-        // Cast to ApiKeyScope: account-level scopes are not yet supported, but we verify
-        // that environment:* doesn't accidentally match them
-        expect(hasScope({ grantedScopes: ['environment:*'], requiredScope: 'account:environments:create' as ApiKeyScope })).toBe(false);
-    });
-
     it('credential scope does not grant non-credential access', () => {
         expect(hasScope({ grantedScopes: ['environment:connections:read_credentials'], requiredScope: 'environment:connections:update' })).toBe(false);
+    });
+
+    // The prefix is the plane tag, and prefix matching is the only thing keeping the two planes
+    // apart. If this breaks, an environment key authorizes account operations.
+    describe('plane isolation', () => {
+        it('environment:* does not grant any account scope', () => {
+            expect(hasScope({ grantedScopes: ['environment:*'], requiredScope: 'account:*' })).toBe(false);
+            expect(hasScope({ grantedScopes: ['environment:*'], requiredScope: 'account:team:read' })).toBe(false);
+        });
+
+        it('account:* does not grant any environment scope', () => {
+            expect(hasScope({ grantedScopes: ['account:*'], requiredScope: 'environment:*' })).toBe(false);
+            expect(hasScope({ grantedScopes: ['account:*'], requiredScope: 'environment:connections:read' })).toBe(false);
+            expect(hasScope({ grantedScopes: ['account:*'], requiredScope: 'environment:deploy' })).toBe(false);
+        });
+
+        it('account:* grants account scopes', () => {
+            expect(hasScope({ grantedScopes: ['account:*'], requiredScope: 'account:team:read' })).toBe(true);
+        });
+
+        it('a specific account scope does not grant its siblings', () => {
+            expect(hasScope({ grantedScopes: ['account:team:read'], requiredScope: 'account:team:read' })).toBe(true);
+            expect(hasScope({ grantedScopes: ['account:team:read'], requiredScope: 'account:*' as ApiKeyScope })).toBe(false);
+        });
     });
 });

--- a/packages/server/lib/routes.control-plane-mcp.ts
+++ b/packages/server/lib/routes.control-plane-mcp.ts
@@ -6,6 +6,7 @@ import authMiddleware from './middleware/access.middleware.js';
 import { egressMeterMiddleware } from './middleware/egress-meter.middleware.js';
 import { jsonContentTypeMiddleware } from './middleware/json.middleware.js';
 import { rateLimiterMiddleware } from './middleware/ratelimit.middleware.js';
+import { withEnvironment } from './middleware/scope.middleware.js';
 
 import type { Request, RequestHandler } from 'express';
 
@@ -23,8 +24,8 @@ controlPlaneMcpRouter.use(
     }),
     jsonContentTypeMiddleware
 );
-controlPlaneMcpRouter.route('/mcp').post(apiAuth, postControlPlaneMcp);
-controlPlaneMcpRouter.route('/mcp').get(apiAuth, getControlPlaneMcp);
+controlPlaneMcpRouter.route('/mcp').post(apiAuth, withEnvironment, postControlPlaneMcp);
+controlPlaneMcpRouter.route('/mcp').get(apiAuth, withEnvironment, getControlPlaneMcp);
 controlPlaneMcpRouter.use((_, res) => {
     res.status(404).json({ error: { code: 'not_found', message: 'Not found' } });
 });

--- a/packages/server/lib/routes.control-plane-mcp.ts
+++ b/packages/server/lib/routes.control-plane-mcp.ts
@@ -6,7 +6,6 @@ import authMiddleware from './middleware/access.middleware.js';
 import { egressMeterMiddleware } from './middleware/egress-meter.middleware.js';
 import { jsonContentTypeMiddleware } from './middleware/json.middleware.js';
 import { rateLimiterMiddleware } from './middleware/ratelimit.middleware.js';
-import { withEnvironment } from './middleware/scope.middleware.js';
 
 import type { Request, RequestHandler } from 'express';
 
@@ -24,8 +23,8 @@ controlPlaneMcpRouter.use(
     }),
     jsonContentTypeMiddleware
 );
-controlPlaneMcpRouter.route('/mcp').post(apiAuth, withEnvironment, postControlPlaneMcp);
-controlPlaneMcpRouter.route('/mcp').get(apiAuth, withEnvironment, getControlPlaneMcp);
+controlPlaneMcpRouter.route('/mcp').post(apiAuth, postControlPlaneMcp);
+controlPlaneMcpRouter.route('/mcp').get(apiAuth, getControlPlaneMcp);
 controlPlaneMcpRouter.use((_, res) => {
     res.status(404).json({ error: { code: 'not_found', message: 'Not found' } });
 });

--- a/packages/server/lib/routes.public.ts
+++ b/packages/server/lib/routes.public.ts
@@ -94,7 +94,7 @@ import { connectionCapping } from './middleware/connection-capping.middleware.js
 import { egressMeterMiddleware } from './middleware/egress-meter.middleware.js';
 import { jsonContentTypeMiddleware } from './middleware/json.middleware.js';
 import { rateLimiterMiddleware } from './middleware/ratelimit.middleware.js';
-import { withAnyScope, withScope } from './middleware/scope.middleware.js';
+import { withAnyScope, withEnvironment, withScope } from './middleware/scope.middleware.js';
 import { webhookIngressRateLimit } from './middleware/webhook-ingress-ratelimit.middleware.js';
 import { isBinaryContentType } from './utils/utils.js';
 
@@ -355,7 +355,7 @@ publicAPI.route('/connect/telemetry').post(connectSessionAuthBody, postConnectTe
 
 // V1 passthrough (deprecated) — scope checks are inline in allPublicV1 after action/model resolution
 publicAPI.use('/v1', jsonContentTypeMiddleware);
-publicAPI.route('/v1/*splat').all(apiAuth, allPublicV1);
+publicAPI.route('/v1/*splat').all(apiAuth, withEnvironment, allPublicV1);
 
 // Proxy
 publicAPI.route('/proxy{/*splat}').all(apiAuth, withScope('environment:proxy'), upload.any(), allPublicProxy);

--- a/packages/server/lib/routes.public.ts
+++ b/packages/server/lib/routes.public.ts
@@ -94,7 +94,7 @@ import { connectionCapping } from './middleware/connection-capping.middleware.js
 import { egressMeterMiddleware } from './middleware/egress-meter.middleware.js';
 import { jsonContentTypeMiddleware } from './middleware/json.middleware.js';
 import { rateLimiterMiddleware } from './middleware/ratelimit.middleware.js';
-import { withAnyScope, withEnvironment, withScope } from './middleware/scope.middleware.js';
+import { withAnyScope, withScope } from './middleware/scope.middleware.js';
 import { webhookIngressRateLimit } from './middleware/webhook-ingress-ratelimit.middleware.js';
 import { isBinaryContentType } from './utils/utils.js';
 
@@ -355,7 +355,7 @@ publicAPI.route('/connect/telemetry').post(connectSessionAuthBody, postConnectTe
 
 // V1 passthrough (deprecated) — scope checks are inline in allPublicV1 after action/model resolution
 publicAPI.use('/v1', jsonContentTypeMiddleware);
-publicAPI.route('/v1/*splat').all(apiAuth, withEnvironment, allPublicV1);
+publicAPI.route('/v1/*splat').all(apiAuth, allPublicV1);
 
 // Proxy
 publicAPI.route('/proxy{/*splat}').all(apiAuth, withScope('environment:proxy'), upload.any(), allPublicProxy);

--- a/packages/server/lib/utils/asyncWrapper.ts
+++ b/packages/server/lib/utils/asyncWrapper.ts
@@ -2,13 +2,13 @@ import { isAsyncFunction } from 'util/types';
 
 import tracer from 'dd-trace';
 
-import { metrics } from '@nangohq/utils';
+import { metrics, report } from '@nangohq/utils';
 
-import type { RequestLocals } from './express.js';
-import type { Endpoint } from '@nangohq/types';
+import type { RequestLocals, RequestLocalsWithEnvironment } from './express.js';
+import type { DBEnvironment, Endpoint } from '@nangohq/types';
 import type { NextFunction, Request, RequestHandler, Response } from 'express';
 
-export function asyncWrapper<TEndpoint extends Endpoint<any>, Locals extends Record<string, any> = Required<RequestLocals>>(
+export function asyncWrapper<TEndpoint extends Endpoint<any>, Locals extends Record<string, any> = RequestLocals>(
     fn: (
         req: Request<TEndpoint['Params'], TEndpoint['Reply'], TEndpoint['Body'], TEndpoint['Querystring']>,
         res: Response<TEndpoint['Reply'], Locals>,
@@ -35,4 +35,42 @@ export function asyncWrapper<TEndpoint extends Endpoint<any>, Locals extends Rec
             return fn(req, res, next);
         }
     };
+}
+
+/**
+ * asyncWrapper for environment-scoped handlers: resolves the environment once and narrows it, so the
+ * handler can use `res.locals.environment` directly.
+ */
+export function asyncWrapperWithEnvironment<TEndpoint extends Endpoint<any>>(
+    fn: (
+        req: Request<TEndpoint['Params'], TEndpoint['Reply'], TEndpoint['Body'], TEndpoint['Querystring']>,
+        res: Response<TEndpoint['Reply'], RequestLocalsWithEnvironment>,
+        next: NextFunction
+    ) => Promise<void> | void
+): RequestHandler<any, TEndpoint['Reply'], any, any, any> {
+    // Must be async so asyncWrapper attaches its .catch(next).
+    return asyncWrapper<TEndpoint>(async (req, res, next) => {
+        if (!requireEnvironment(req, res)) {
+            return;
+        }
+
+        await fn(req, res as Response<TEndpoint['Reply'], RequestLocalsWithEnvironment>, next);
+    });
+}
+
+/**
+ * Returns the request's environment, or null *after having responded* 500 if it has none.
+ *
+ * No environment means an environment-scoped handler was wired to a route that resolves none, which
+ * is a wiring mistake rather than a client error.
+ */
+export function requireEnvironment(req: Request, res: Response<any, RequestLocals>): DBEnvironment | null {
+    const { environment } = res.locals;
+    if (!environment) {
+        report(new Error('handler_requires_environment'), { route: req.route?.path ?? req.originalUrl });
+        res.status(500).send({ error: { code: 'server_error' } });
+        return null;
+    }
+
+    return environment;
 }

--- a/packages/server/lib/utils/asyncWrapper.ts
+++ b/packages/server/lib/utils/asyncWrapper.ts
@@ -59,16 +59,18 @@ export function asyncWrapperWithEnvironment<TEndpoint extends Endpoint<any>>(
 }
 
 /**
- * Returns the request's environment, or null *after having responded* 500 if it has none.
+ * Returns the request's environment, or null *after having responded* 403 if it has none.
  *
- * No environment means an environment-scoped handler was wired to a route that resolves none, which
- * is a wiring mistake rather than a client error.
+ * 403 because the likely cause is a credential that is bound to no environment — an account-level API
+ * key aimed at an environment endpoint. Ideally that is refused by the route's scope guard before ever
+ * reaching a handler, so this still reports: it is either a route missing its guard, or a key whose
+ * scopes and reach disagree. Both are ours to fix, but neither is worth a 500 to the caller.
  */
 export function requireEnvironment(req: Request, res: Response<any, RequestLocals>): DBEnvironment | null {
     const { environment } = res.locals;
     if (!environment) {
         report(new Error('handler_requires_environment'), { route: req.route?.path ?? req.originalUrl });
-        res.status(500).send({ error: { code: 'server_error' } });
+        res.status(403).send({ error: { code: 'forbidden', message: 'This endpoint requires an environment-scoped API key' } });
         return null;
     }
 

--- a/packages/server/lib/utils/asyncWrapper.unit.test.ts
+++ b/packages/server/lib/utils/asyncWrapper.unit.test.ts
@@ -1,0 +1,71 @@
+import { describe, expect, it, vi } from 'vitest';
+
+import { asyncWrapperWithEnvironment, requireEnvironment } from './asyncWrapper.js';
+
+import type { RequestLocals } from './express.js';
+import type { DBEnvironment, Endpoint } from '@nangohq/types';
+import type { NextFunction, Request, Response } from 'express';
+
+type AnyEndpoint = Endpoint<{ Method: 'GET'; Path: '/test'; Success: { ok: true } }>;
+
+function mockReqRes(locals: Partial<RequestLocals>) {
+    const res = {
+        locals,
+        status: vi.fn().mockReturnThis(),
+        send: vi.fn().mockReturnThis()
+    };
+    const req = { route: { path: '/test' }, originalUrl: '/test', header: () => undefined };
+    return { req: req as unknown as Request, res: res as unknown as Response<any, RequestLocals>, spies: res };
+}
+
+describe('asyncWrapperWithEnvironment', () => {
+    it('runs the handler when an environment is present', async () => {
+        const environment = { id: 42 } as DBEnvironment;
+        const { req, res, spies } = mockReqRes({ environment });
+        const handler = vi.fn();
+
+        await asyncWrapperWithEnvironment<AnyEndpoint>(handler)(req, res, (() => undefined) as NextFunction);
+
+        expect(handler).toHaveBeenCalledOnce();
+        expect(handler.mock.calls[0]?.[1].locals.environment).toBe(environment);
+        expect(spies.status).not.toHaveBeenCalled();
+    });
+
+    it('does NOT run the handler and returns 500 when the environment is missing', async () => {
+        const { req, res, spies } = mockReqRes({});
+        const handler = vi.fn();
+
+        await asyncWrapperWithEnvironment<AnyEndpoint>(handler)(req, res, (() => undefined) as NextFunction);
+
+        expect(handler).not.toHaveBeenCalled();
+        expect(spies.status).toHaveBeenCalledWith(500);
+        expect(spies.send).toHaveBeenCalledWith({ error: { code: 'server_error' } });
+    });
+
+    it('routes a rejecting handler to next() rather than an unhandled rejection', async () => {
+        const { req, res } = mockReqRes({ environment: { id: 1 } as DBEnvironment });
+        const boom = new Error('boom');
+        const next = vi.fn();
+
+        await asyncWrapperWithEnvironment<AnyEndpoint>(() => Promise.reject(boom))(req, res, next as unknown as NextFunction);
+        await vi.waitFor(() => expect(next).toHaveBeenCalledWith(boom));
+    });
+});
+
+describe('requireEnvironment', () => {
+    it('returns the environment when present', () => {
+        const environment = { id: 7 } as DBEnvironment;
+        const { req, res, spies } = mockReqRes({ environment });
+
+        expect(requireEnvironment(req, res)).toBe(environment);
+        expect(spies.status).not.toHaveBeenCalled();
+    });
+
+    it('responds 500 and returns null when absent', () => {
+        const { req, res, spies } = mockReqRes({});
+
+        expect(requireEnvironment(req, res)).toBeNull();
+        expect(spies.status).toHaveBeenCalledWith(500);
+        expect(spies.send).toHaveBeenCalledWith({ error: { code: 'server_error' } });
+    });
+});

--- a/packages/server/lib/utils/asyncWrapper.unit.test.ts
+++ b/packages/server/lib/utils/asyncWrapper.unit.test.ts
@@ -31,15 +31,15 @@ describe('asyncWrapperWithEnvironment', () => {
         expect(spies.status).not.toHaveBeenCalled();
     });
 
-    it('does NOT run the handler and returns 500 when the environment is missing', async () => {
+    it('does NOT run the handler and returns 403 when the environment is missing', async () => {
         const { req, res, spies } = mockReqRes({});
         const handler = vi.fn();
 
         await asyncWrapperWithEnvironment<AnyEndpoint>(handler)(req, res, (() => undefined) as NextFunction);
 
         expect(handler).not.toHaveBeenCalled();
-        expect(spies.status).toHaveBeenCalledWith(500);
-        expect(spies.send).toHaveBeenCalledWith({ error: { code: 'server_error' } });
+        expect(spies.status).toHaveBeenCalledWith(403);
+        expect(spies.send).toHaveBeenCalledWith({ error: { code: 'forbidden', message: 'This endpoint requires an environment-scoped API key' } });
     });
 
     it('routes a rejecting handler to next() rather than an unhandled rejection', async () => {
@@ -61,11 +61,11 @@ describe('requireEnvironment', () => {
         expect(spies.status).not.toHaveBeenCalled();
     });
 
-    it('responds 500 and returns null when absent', () => {
+    it('responds 403 and returns null when absent', () => {
         const { req, res, spies } = mockReqRes({});
 
         expect(requireEnvironment(req, res)).toBeNull();
-        expect(spies.status).toHaveBeenCalledWith(500);
-        expect(spies.send).toHaveBeenCalledWith({ error: { code: 'server_error' } });
+        expect(spies.status).toHaveBeenCalledWith(403);
+        expect(spies.send).toHaveBeenCalledWith({ error: { code: 'forbidden', message: 'This endpoint requires an environment-scoped API key' } });
     });
 });

--- a/packages/server/lib/utils/auth.ts
+++ b/packages/server/lib/utils/auth.ts
@@ -43,7 +43,7 @@ export async function isIntegrationAllowed({
 }: {
     config: IntegrationConfig;
     logCtx: LogContext;
-    res: Response<ApiError<'integration_not_allowed'>, Required<RequestLocals>>;
+    res: Response<ApiError<'integration_not_allowed'>, RequestLocals>;
 }): Promise<boolean> {
     if (res.locals['authType'] !== 'connectSession') {
         return true;

--- a/packages/server/lib/utils/express.ts
+++ b/packages/server/lib/utils/express.ts
@@ -22,13 +22,19 @@ import type { ConnectSession, DBAPISecret, DBEnvironment, DBPlan, DBTeam, DBUser
 //       };
 
 export interface RequestLocals {
-    authType?: 'secretKey' | 'publicKey' | 'basic' | 'adminKey' | 'none' | 'session' | 'connectSession';
-    user?: DBUser;
-    account?: DBTeam;
+    // Set by every auth path.
+    authType: 'secretKey' | 'publicKey' | 'basic' | 'adminKey' | 'none' | 'session' | 'connectSession';
+    account: DBTeam;
+    plan: DBPlan | null;
+
+    // Asserted, not guaranteed: `connectSession` is only set by connect-session auth and `user` only
+    // by session auth. Enough handlers read them unguarded that narrowing them is its own change.
+    connectSession: ConnectSession;
+    user: DBUser;
+
+    // Set only by some auth paths, so a handler must check before use.
     environment?: DBEnvironment;
-    connectSession?: ConnectSession;
     endUser?: InternalEndUser | null;
-    plan?: DBPlan | null;
     lang?: string;
     secret?: DBAPISecret;
     apiKeyScopes?: string[];
@@ -39,3 +45,6 @@ export interface RequestLocals {
     sandboxTokenDryrunId?: string;
     sandboxTokenDeploymentId?: string;
 }
+
+/** RequestLocals with the environment confirmed present — see `asyncWrapperWithEnvironment` and `requireEnvironment`. */
+export type RequestLocalsWithEnvironment = RequestLocals & { environment: DBEnvironment };

--- a/packages/shared/lib/seeders/global.seeder.ts
+++ b/packages/shared/lib/seeders/global.seeder.ts
@@ -14,15 +14,25 @@ export async function seedAccountEnvAndUser({ plan: planOverride }: { plan?: Par
     env: DBEnvironment;
     secret: DBAPISecret;
     apiKey: DBCustomerKey;
+    accountApiKey: DBCustomerKey;
     user: DBUser;
     plan: DBPlan;
 }> {
     const account = await createAccount();
     const env = await createEnvironmentSeed(account.id, 'dev');
     const secret = (await secretService.getDefaultSecretForEnv(db.knex, env)).unwrap();
-    const apiKeys = (await customerKeyService.getApiKeysByEnv(db.knex, env.id)).unwrap();
+    const apiKeys = (await customerKeyService.getApiKeys(db.knex, { type: 'environment', environmentId: env.id })).unwrap();
     const apiKey = apiKeys[0]!;
+    const accountApiKey = (
+        await customerKeyService.createApiKey(db.knex, {
+            accountId: account.id,
+            target: { type: 'account', accountId: account.id },
+            displayName: 'Account key',
+            scopes: ['account:*'],
+            withSandboxSigningSecret: false
+        })
+    ).unwrap();
     const plan = (await createPlan(db.knex, { account_id: account.id, name: 'free', ...planOverride })).unwrap();
     const user = await seedUser(account.id);
-    return { account, env, secret, apiKey, user, plan };
+    return { account, env, secret, apiKey, accountApiKey, user, plan };
 }

--- a/packages/shared/lib/services/account.service.integration.test.ts
+++ b/packages/shared/lib/services/account.service.integration.test.ts
@@ -163,7 +163,7 @@ describe('Account service', () => {
         const environment = await environmentService.createEnvironment(db.knex, { accountId: account.id, name: uuid() });
         const plan = (await plans.createPlan(db.knex, { account_id: account.id, name: 'free' })).unwrap();
         const secret = (await secretService.getDefaultSecretForEnv(db.knex, environment!)).unwrap();
-        const apiKeys = (await customerKeyService.getApiKeysByEnv(db.knex, environment!.id)).unwrap();
+        const apiKeys = (await customerKeyService.getApiKeys(db.knex, { type: 'environment', environmentId: environment!.id })).unwrap();
 
         const bySecretKey = await accountService.getAccountContext({ secretKey: apiKeys[0]!.secret });
 
@@ -214,7 +214,7 @@ describe('Account service', () => {
         const account = await createTestAccount();
         const environment = await environmentService.createEnvironment(db.knex, { accountId: account.id, name: uuid() });
         await plans.createPlan(db.knex, { account_id: account.id, name: 'free' });
-        const apiKeys = (await customerKeyService.getApiKeysByEnv(db.knex, environment!.id)).unwrap();
+        const apiKeys = (await customerKeyService.getApiKeys(db.knex, { type: 'environment', environmentId: environment!.id })).unwrap();
 
         await db
             .knex('customer_keys')
@@ -244,25 +244,47 @@ describe('Account service', () => {
         expect(bySecretKey).toBeNull();
     });
 
-    it('should return null when matching customer key relation is not environment-scoped (no fallback to api_secrets)', async () => {
+    /**
+     * The plane is decided by whether the key names an environment, so an environment key whose
+     * environment is soft-deleted must fail rather than fall through to the account plane — otherwise
+     * it would authenticate as an account context while still carrying `environment:*` scopes, passing
+     * environment scope guards with no environment behind them.
+     */
+    it('should return null when the key environment is soft-deleted (no fallback to the account plane)', async () => {
         const account = await createTestAccount();
         const environment = await environmentService.createEnvironment(db.knex, { accountId: account.id, name: uuid() });
         await plans.createPlan(db.knex, { account_id: account.id, name: 'free' });
+        const apiKeys = (await customerKeyService.getApiKeys(db.knex, { type: 'environment', environmentId: environment!.id })).unwrap();
 
-        const apiKey = await db.knex('customer_keys').select('id').where({ account_id: account.id, key_type: 'api' }).whereNull('deleted_at').first();
+        await db.knex('_nango_environments').where({ id: environment!.id }).update({ deleted: true });
 
-        expect(apiKey).toBeDefined();
-
-        await db.knex('customer_keys_relations').where({ customer_key_id: apiKey!.id }).delete();
-        await db.knex('customer_keys_relations').insert({
-            customer_key_id: apiKey!.id,
-            entity_type: 'account',
-            entity_id: account.id
-        });
-
-        const bySecretKey = await accountService.getAccountContext({ secretKey: environment!.secret_key });
+        const bySecretKey = await accountService.getAccountContext({ secretKey: apiKeys[0]!.secret });
 
         expect(bySecretKey).toBeNull();
+    });
+
+    it('should resolve an account key with no environment or secret', async () => {
+        const account = await createTestAccount();
+        await environmentService.createEnvironment(db.knex, { accountId: account.id, name: uuid() });
+        await plans.createPlan(db.knex, { account_id: account.id, name: 'free' });
+
+        const accountKey = (
+            await customerKeyService.createApiKey(db.knex, {
+                accountId: account.id,
+                target: { type: 'account', accountId: account.id },
+                displayName: `account-${uuid()}`,
+                scopes: ['account:*'],
+                withSandboxSigningSecret: false
+            })
+        ).unwrap();
+
+        const context = await accountService.getAccountContext({ secretKey: accountKey.secret });
+
+        expect(context?.account.id).toBe(account.id);
+        expect(context?.plan).toBeDefined();
+        expect(context?.environment).toBeUndefined();
+        expect(context?.secret).toBeUndefined();
+        expect(context?.auth).toMatchObject({ scopes: ['account:*'], apiKeyId: accountKey.id });
     });
 
     it('should return null when secretKey does not match either table', async () => {
@@ -276,7 +298,7 @@ describe('Account service', () => {
         const environment = await environmentService.createEnvironment(db.knex, { accountId: account.id, name: uuid() });
         const plan = (await plans.createPlan(db.knex, { account_id: account.id, name: 'free' })).unwrap();
         const secret = (await secretService.getDefaultSecretForEnv(db.knex, environment!)).unwrap();
-        const apiKeys = (await customerKeyService.getApiKeysByEnv(db.knex, environment!.id)).unwrap();
+        const apiKeys = (await customerKeyService.getApiKeys(db.knex, { type: 'environment', environmentId: environment!.id })).unwrap();
         const apiKey = apiKeys[0]!;
         const signingSecret = decryptSandboxSigningSecret(apiKey)!;
         const dryrunId = '00000000-0000-4000-8000-000000000001';
@@ -327,7 +349,7 @@ describe('Account service', () => {
         const account = await createTestAccount();
         const environment = await environmentService.createEnvironment(db.knex, { accountId: account.id, name: uuid() });
         await plans.createPlan(db.knex, { account_id: account.id, name: 'free' });
-        const apiKeys = (await customerKeyService.getApiKeysByEnv(db.knex, environment!.id)).unwrap();
+        const apiKeys = (await customerKeyService.getApiKeys(db.knex, { type: 'environment', environmentId: environment!.id })).unwrap();
         const signingSecret = decryptSandboxSigningSecret(apiKeys[0]!)!;
         const now = Date.now();
         const sandboxToken = createSandboxApiKeyToken({
@@ -348,7 +370,7 @@ describe('Account service', () => {
         const account = await createTestAccount();
         const environment = await environmentService.createEnvironment(db.knex, { accountId: account.id, name: uuid() });
         await plans.createPlan(db.knex, { account_id: account.id, name: 'free' });
-        const apiKeys = (await customerKeyService.getApiKeysByEnv(db.knex, environment!.id)).unwrap();
+        const apiKeys = (await customerKeyService.getApiKeys(db.knex, { type: 'environment', environmentId: environment!.id })).unwrap();
         const apiKey = apiKeys[0]!;
         const signingSecret = decryptSandboxSigningSecret(apiKey)!;
 
@@ -375,9 +397,10 @@ describe('Account service', () => {
         const parentKey = (
             await customerKeyService.createApiKey(db.knex, {
                 accountId: account.id,
-                environmentId: environment!.id,
+                target: { type: 'environment', environmentId: environment!.id },
                 displayName: `sandbox-parent-${uuid()}`,
-                scopes: ['environment:functions:dryrun']
+                scopes: ['environment:functions:dryrun'],
+                withSandboxSigningSecret: true
             })
         ).unwrap();
         const signingSecret = decryptSandboxSigningSecret(parentKey)!;
@@ -391,7 +414,10 @@ describe('Account service', () => {
             expiresAt: new Date(Date.now() + 60 * 1000)
         });
 
-        await customerKeyService.updateApiKeyScopes(db.knex, parentKey.id, ['environment:records:read'], environment!.id);
+        await customerKeyService.updateApiKeyScopes(db.knex, parentKey.id, ['environment:records:read'], {
+            type: 'environment',
+            environmentId: environment!.id
+        });
 
         const bySecretKey = await accountService.getAccountContext({ secretKey: sandboxToken });
 
@@ -408,7 +434,7 @@ describe('Account service', () => {
         const account = await createTestAccount();
         const environment = await environmentService.createEnvironment(db.knex, { accountId: account.id, name: uuid() });
         await plans.createPlan(db.knex, { account_id: account.id, name: 'free' });
-        const apiKeys = (await customerKeyService.getApiKeysByEnv(db.knex, environment!.id)).unwrap();
+        const apiKeys = (await customerKeyService.getApiKeys(db.knex, { type: 'environment', environmentId: environment!.id })).unwrap();
         const customerKeySecret = apiKeys[0]!.secret;
 
         const initial = await accountService.getAccountContext({ secretKey: customerKeySecret });

--- a/packages/shared/lib/services/account.service.ts
+++ b/packages/shared/lib/services/account.service.ts
@@ -89,8 +89,8 @@ const persistAuthContextCache = new PersistAuthContextCache();
 
 interface AccountContext {
     account: DBTeam;
-    environment: DBEnvironment;
-    secret: DBAPISecret;
+    environment?: DBEnvironment;
+    secret?: DBAPISecret;
     plan: DBPlan | null;
     auth?: {
         source: 'customer_key' | 'sandbox_token' | 'api_secret' | 'env_var';
@@ -102,6 +102,8 @@ interface AccountContext {
         deploymentId?: string;
     };
 }
+
+type AccountContextWithEnvironment = AccountContext & { environment: DBEnvironment; secret: DBAPISecret };
 
 const freeEmailDomains = new Set([
     'gmail.com',
@@ -323,7 +325,7 @@ class AccountService {
      * exist in api_secrets. Returns null when no env var matches the key; when one
      * matches, resolution failures are terminal (context: null, no hashed lookup).
      */
-    private async getAccountContextFromEnvVar(key: string): Promise<{ context: AccountContext | null } | null> {
+    private async getAccountContextFromEnvVar(key: string): Promise<{ context: AccountContextWithEnvironment | null } | null> {
         const environmentVariables = Object.keys(process.env).filter((k) => k.startsWith('NANGO_SECRET_KEY_'));
         for (const environmentVariable of environmentVariables) {
             const envSecretKey = process.env[environmentVariable] as string;
@@ -356,7 +358,7 @@ class AccountService {
         return null;
     }
 
-    async getAccountContextByPublicKey(publicKey: string): Promise<AccountContext | null> {
+    async getAccountContextByPublicKey(publicKey: string): Promise<AccountContextWithEnvironment | null> {
         if (!isCloud) {
             const environmentVariables = Object.keys(process.env).filter((key) => key.startsWith('NANGO_PUBLIC_KEY_'));
             if (environmentVariables.length > 0) {
@@ -385,6 +387,16 @@ class AccountService {
         return this.getAccountContext({ publicKey });
     }
 
+    async getAccountContext(
+        opts:
+            | { publicKey: string }
+            | { internalSecretKey: string }
+            | { accountId: number; envName: string }
+            | { environmentId: number }
+            | { environmentUuid: string }
+            | { accountUuid: string; envName: string }
+    ): Promise<AccountContextWithEnvironment | null>;
+    async getAccountContext(opts: { secretKey: string } | { internalSecretKey: string }): Promise<AccountContext | null>;
     async getAccountContext(
         // TODO: fix this union type that is not discriminated
         opts:
@@ -491,7 +503,7 @@ class AccountService {
         };
     }
 
-    private async getAccountContextBySandboxApiKey(sandboxApiKey: string): Promise<Result<AccountContext | null>> {
+    private async getAccountContextBySandboxApiKey(sandboxApiKey: string): Promise<Result<AccountContextWithEnvironment | null>> {
         try {
             const parsed = parseSandboxApiKeyToken(sandboxApiKey);
             if (!parsed) {
@@ -663,9 +675,9 @@ class AccountService {
         } = await db.knex.raw<{
             rows: {
                 account: DBTeam;
-                environment: DBEnvironment;
+                environment: DBEnvironment | null;
                 plan: DBPlan | null;
-                default_secret: DBAPISecret;
+                default_secret: DBAPISecret | null;
                 pending_secret: DBAPISecret | null;
                 auth_scopes: string[] | null;
                 auth_api_key_id: number;
@@ -674,13 +686,14 @@ class AccountService {
         }>(
             `
                 WITH matched_customer_key AS (
-                    SELECT ck.id, ckr.entity_id AS environment_id, ck.scopes, ck.display_name
+                    SELECT ck.id, ck.account_id, ck.scopes, ck.display_name, ckr.entity_id AS environment_id
                     FROM customer_keys ck
-                    JOIN customer_keys_relations ckr ON ckr.customer_key_id = ck.id
+                    LEFT JOIN customer_keys_relations ckr
+                        ON ckr.customer_key_id = ck.id
+                       AND ckr.entity_type = 'environment'
                     WHERE ck.hashed = ?
                       AND ck.key_type = 'api'
                       AND ck.deleted_at IS NULL
-                      AND ckr.entity_type = 'environment'
                     LIMIT 1
                 ),
                 updated_customer_key AS (
@@ -701,16 +714,21 @@ class AccountService {
                     matched_customer_key.id AS auth_api_key_id,
                     matched_customer_key.display_name AS auth_display_name
                 FROM matched_customer_key
-                JOIN _nango_environments ON _nango_environments.id = matched_customer_key.environment_id
-                JOIN _nango_accounts ON _nango_accounts.id = _nango_environments.account_id
-                JOIN api_secrets AS default_secret
+                LEFT JOIN _nango_environments
+                    ON _nango_environments.id = matched_customer_key.environment_id
+                   AND _nango_environments.deleted = false
+                JOIN _nango_accounts ON _nango_accounts.id = COALESCE(_nango_environments.account_id, matched_customer_key.account_id)
+                LEFT JOIN api_secrets AS default_secret
                     ON default_secret.environment_id = _nango_environments.id
                    AND default_secret.is_default = true
                 LEFT JOIN api_secrets AS pending_secret
                     ON pending_secret.environment_id = _nango_environments.id
                    AND pending_secret.is_default = false
                 LEFT JOIN plans ON plans.account_id = _nango_accounts.id
-                WHERE _nango_environments.deleted = false
+                -- An environment-bound key whose environment is soft-deleted must fail auth: without this
+                -- the COALESCE above resolves it to its own account_id, so it would authenticate with no
+                -- environment while still carrying environment scopes.
+                WHERE matched_customer_key.environment_id IS NULL OR default_secret.id IS NOT NULL
                 LIMIT 1;
             `,
             [hash]
@@ -722,7 +740,8 @@ class AccountService {
         hashLocalCache.set(secretKey, hash);
         customerKeyShadowCache.populate(hash, wouldHit);
 
-        const defaultSecret = getEncryptionManager().decryptAPISecret(row.default_secret);
+        // Both absent for account-plane keys, which are bound to no environment.
+        const defaultSecret = row.default_secret ? getEncryptionManager().decryptAPISecret(row.default_secret) : null;
         const pendingKey = row.pending_secret ? getEncryptionManager().decryptAPISecret(row.pending_secret) : null;
 
         return {
@@ -731,14 +750,19 @@ class AccountService {
                 created_at: new Date(row.account.created_at),
                 updated_at: new Date(row.account.updated_at)
             },
-            environment: {
-                ...row.environment,
-                secret_key: defaultSecret.secret,
-                pending_secret_key: pendingKey?.secret || null,
-                created_at: new Date(row.environment.created_at),
-                updated_at: new Date(row.environment.updated_at),
-                deleted_at: row.environment.deleted_at ? new Date(row.environment.deleted_at) : row.environment.deleted_at
-            },
+            ...(row.environment && defaultSecret
+                ? {
+                      environment: {
+                          ...row.environment,
+                          secret_key: defaultSecret.secret,
+                          pending_secret_key: pendingKey?.secret || null,
+                          created_at: new Date(row.environment.created_at),
+                          updated_at: new Date(row.environment.updated_at),
+                          deleted_at: row.environment.deleted_at ? new Date(row.environment.deleted_at) : row.environment.deleted_at
+                      },
+                      secret: defaultSecret
+                  }
+                : {}),
             plan: row.plan
                 ? {
                       ...row.plan,
@@ -751,7 +775,6 @@ class AccountService {
                       orb_future_plan_at: row.plan.orb_future_plan_at ? new Date(row.plan.orb_future_plan_at) : row.plan.orb_future_plan_at
                   }
                 : null,
-            secret: defaultSecret,
             auth: {
                 source: 'customer_key' as const,
                 scopes: row.auth_scopes ?? [],
@@ -852,7 +875,7 @@ class AccountService {
      * Used by internal services (persist, runners) that authenticate with the
      * environment's internal secret key. Avoids polluting customer_keys.last_used_at.
      */
-    private async getAccountContextByInternalSecret(secretKey: string): Promise<AccountContext | null> {
+    private async getAccountContextByInternalSecret(secretKey: string): Promise<AccountContextWithEnvironment | null> {
         const hash = await this.hashSecretWithCache(secretKey);
 
         const row = await db.readOnly

--- a/packages/shared/lib/services/customerKey.service.ts
+++ b/packages/shared/lib/services/customerKey.service.ts
@@ -14,9 +14,11 @@ const CUSTOMER_KEYS_TABLE = 'customer_keys';
 const CUSTOMER_KEYS_RELATIONS_TABLE = 'customer_keys_relations';
 // Cache decrypted webhook signing key per environment. No eviction needed since rotation is not supported yet.
 const webhookSigningKeyCache = new Map<number, string>();
-// Internal safety limit — not a product constraint, just prevents unbounded key creation.
+// Internal safety limit per target — not a product constraint, just prevents unbounded key creation.
 // Can be raised without migration if needed.
-export const MAX_API_KEYS_PER_ENV = 50;
+export const MAX_API_KEYS_PER_TARGET = 50;
+
+export type KeyTarget = { type: 'environment'; environmentId: number } | { type: 'account'; accountId: number };
 
 class CustomerKeyService {
     private async acquireNameLock(trx: Knex, accountId: number, keyType: string): Promise<void> {
@@ -24,18 +26,42 @@ class CustomerKeyService {
         await trx.raw(`SELECT pg_advisory_xact_lock(?) as "lock_customer_key_name_${keyType}"`, [lockKey]);
     }
 
-    private async insertApiKeyForEnvironment(
+    /** Restricts a query to the keys applying to this target, so neither plane sees or mutates the other's. */
+    private scopedToTarget(trx: Knex, target: KeyTarget) {
+        // Correlated subquery rather than a join: these predicates also run inside UPDATE, and Postgres
+        // has no UPDATE ... LEFT JOIN.
+        const boundToEnvironment = trx(CUSTOMER_KEYS_RELATIONS_TABLE)
+            .select(trx.raw('1'))
+            .where('customer_key_id', trx.ref(`${CUSTOMER_KEYS_TABLE}.id`))
+            .where('entity_type', 'environment');
+
+        if (target.type === 'environment') {
+            const boundToThisEnvironment = boundToEnvironment.where('entity_id', target.environmentId);
+            return (qb: Knex.QueryBuilder): void => {
+                void qb.whereExists(boundToThisEnvironment);
+            };
+        }
+
+        // Account keys are this account's keys that are bound to no environment.
+        return (qb: Knex.QueryBuilder): void => {
+            void qb.where(`${CUSTOMER_KEYS_TABLE}.account_id`, target.accountId).whereNotExists(boundToEnvironment);
+        };
+    }
+
+    private async insertApiKey(
         trx: Knex,
         {
             accountId,
-            environmentId,
+            target,
             displayName,
-            scopes
+            scopes,
+            withSandboxSigningSecret
         }: {
             accountId: number;
-            environmentId: number;
+            target: KeyTarget;
             displayName: string;
             scopes: string[];
+            withSandboxSigningSecret: boolean;
         }
     ): Promise<Result<DBCustomerKey>> {
         try {
@@ -55,7 +81,7 @@ class CustomerKeyService {
                 iv: '',
                 tag: '',
                 hashed: hashed.value,
-                ...encryptSandboxSigningSecret(createSandboxSigningSecret()),
+                ...(withSandboxSigningSecret ? encryptSandboxSigningSecret(createSandboxSigningSecret()) : {}),
                 last_used_at: null,
                 deleted_at: null
             } satisfies Partial<DBCustomerKey>;
@@ -69,11 +95,13 @@ class CustomerKeyService {
                 return Err(new NangoError('impossible_condition'));
             }
 
-            await trx<DBCustomerKeyRelation>(CUSTOMER_KEYS_RELATIONS_TABLE).insert({
-                customer_key_id: row.id,
-                entity_type: 'environment',
-                entity_id: environmentId
-            });
+            if (target.type === 'environment') {
+                await trx<DBCustomerKeyRelation>(CUSTOMER_KEYS_RELATIONS_TABLE).insert({
+                    customer_key_id: row.id,
+                    entity_type: 'environment',
+                    entity_id: target.environmentId
+                });
+            }
 
             row.secret = plainText; // Callers expect unencrypted secret.
             return Ok(row);
@@ -86,54 +114,45 @@ class CustomerKeyService {
         trx: Knex,
         {
             accountId,
-            environmentId,
+            target,
             displayName,
-            scopes = ['environment:*']
+            scopes,
+            withSandboxSigningSecret
         }: {
             accountId: number;
-            environmentId: number;
+            target: KeyTarget;
             displayName: string;
-            scopes?: string[];
+            scopes: string[];
+            withSandboxSigningSecret: boolean;
         }
     ): Promise<Result<DBCustomerKey>> {
         try {
             const created = await trx.transaction(async (innerTrx) => {
                 await this.acquireNameLock(innerTrx, accountId, 'api');
 
-                // Check name uniqueness within the environment
                 const existing = await innerTrx<DBCustomerKey>(CUSTOMER_KEYS_TABLE)
                     .select(`${CUSTOMER_KEYS_TABLE}.id`)
-                    .join(CUSTOMER_KEYS_RELATIONS_TABLE, `${CUSTOMER_KEYS_RELATIONS_TABLE}.customer_key_id`, `${CUSTOMER_KEYS_TABLE}.id`)
                     .where(`${CUSTOMER_KEYS_TABLE}.key_type`, 'api')
                     .where(`${CUSTOMER_KEYS_TABLE}.display_name`, displayName)
-                    .where(`${CUSTOMER_KEYS_RELATIONS_TABLE}.entity_type`, 'environment')
-                    .where(`${CUSTOMER_KEYS_RELATIONS_TABLE}.entity_id`, environmentId)
                     .whereNull(`${CUSTOMER_KEYS_TABLE}.deleted_at`)
+                    .modify(this.scopedToTarget(innerTrx, target))
                     .first();
 
                 if (existing) {
                     throw new NangoError('duplicate_api_key', { display_name: displayName });
                 }
 
-                // Check max keys per environment
                 const count = await innerTrx<DBCustomerKey>(CUSTOMER_KEYS_TABLE)
-                    .join(CUSTOMER_KEYS_RELATIONS_TABLE, `${CUSTOMER_KEYS_RELATIONS_TABLE}.customer_key_id`, `${CUSTOMER_KEYS_TABLE}.id`)
                     .where(`${CUSTOMER_KEYS_TABLE}.key_type`, 'api')
-                    .where(`${CUSTOMER_KEYS_RELATIONS_TABLE}.entity_type`, 'environment')
-                    .where(`${CUSTOMER_KEYS_RELATIONS_TABLE}.entity_id`, environmentId)
                     .whereNull(`${CUSTOMER_KEYS_TABLE}.deleted_at`)
+                    .modify(this.scopedToTarget(innerTrx, target))
                     .count('* as total')
-                    .first();
-                if (count && Number(count['total']) >= MAX_API_KEYS_PER_ENV) {
-                    throw new NangoError('resource_capped', { max: MAX_API_KEYS_PER_ENV });
+                    .first<{ total: string | number } | undefined>();
+                if (count && Number(count.total) >= MAX_API_KEYS_PER_TARGET) {
+                    throw new NangoError('resource_capped', { max: MAX_API_KEYS_PER_TARGET });
                 }
 
-                const inserted = await this.insertApiKeyForEnvironment(innerTrx, {
-                    accountId,
-                    environmentId,
-                    displayName,
-                    scopes
-                });
+                const inserted = await this.insertApiKey(innerTrx, { accountId, target, displayName, scopes, withSandboxSigningSecret });
                 if (inserted.isErr()) {
                     throw inserted.error;
                 }
@@ -200,15 +219,13 @@ class CustomerKeyService {
         }
     }
 
-    public async getApiKeysByEnv(trx: Knex, envId: number): Promise<Result<DBCustomerKey[]>> {
+    public async getApiKeys(trx: Knex, target: KeyTarget): Promise<Result<DBCustomerKey[]>> {
         try {
-            const rows = await trx<DBCustomerKey>(CUSTOMER_KEYS_TABLE)
+            const rows: DBCustomerKey[] = await trx<DBCustomerKey>(CUSTOMER_KEYS_TABLE)
                 .select(`${CUSTOMER_KEYS_TABLE}.*`)
-                .join(CUSTOMER_KEYS_RELATIONS_TABLE, `${CUSTOMER_KEYS_RELATIONS_TABLE}.customer_key_id`, `${CUSTOMER_KEYS_TABLE}.id`)
-                .where(`${CUSTOMER_KEYS_RELATIONS_TABLE}.entity_type`, 'environment')
-                .where(`${CUSTOMER_KEYS_RELATIONS_TABLE}.entity_id`, envId)
                 .where(`${CUSTOMER_KEYS_TABLE}.key_type`, 'api')
                 .whereNull(`${CUSTOMER_KEYS_TABLE}.deleted_at`)
+                .modify(this.scopedToTarget(trx, target))
                 .orderBy(`${CUSTOMER_KEYS_TABLE}.display_name`, 'asc');
 
             const decrypted = rows.map(
@@ -248,21 +265,18 @@ class CustomerKeyService {
         }
     }
 
-    public async renameApiKey(trx: Knex, keyId: number, displayName: string, envId: number, accountId: number): Promise<Result<void>> {
+    public async renameApiKey(trx: Knex, keyId: number, displayName: string, target: KeyTarget, accountId: number): Promise<Result<void>> {
         try {
             await trx.transaction(async (innerTrx) => {
                 await this.acquireNameLock(innerTrx, accountId, 'api');
 
-                // Check uniqueness: no other API key in the same environment should have this name
                 const existing = await innerTrx<DBCustomerKey>(CUSTOMER_KEYS_TABLE)
                     .select(`${CUSTOMER_KEYS_TABLE}.id`)
-                    .join(CUSTOMER_KEYS_RELATIONS_TABLE, `${CUSTOMER_KEYS_RELATIONS_TABLE}.customer_key_id`, `${CUSTOMER_KEYS_TABLE}.id`)
                     .where(`${CUSTOMER_KEYS_TABLE}.key_type`, 'api')
                     .where(`${CUSTOMER_KEYS_TABLE}.display_name`, displayName)
-                    .where(`${CUSTOMER_KEYS_RELATIONS_TABLE}.entity_type`, 'environment')
-                    .where(`${CUSTOMER_KEYS_RELATIONS_TABLE}.entity_id`, envId)
                     .whereNull(`${CUSTOMER_KEYS_TABLE}.deleted_at`)
                     .whereNot(`${CUSTOMER_KEYS_TABLE}.id`, keyId)
+                    .modify(this.scopedToTarget(innerTrx, target))
                     .first();
 
                 if (existing) {
@@ -273,13 +287,7 @@ class CustomerKeyService {
                     .where(`${CUSTOMER_KEYS_TABLE}.id`, keyId)
                     .where(`${CUSTOMER_KEYS_TABLE}.key_type`, 'api')
                     .whereNull(`${CUSTOMER_KEYS_TABLE}.deleted_at`)
-                    .whereExists(function () {
-                        void this.select(innerTrx.raw('1'))
-                            .from(CUSTOMER_KEYS_RELATIONS_TABLE)
-                            .whereRaw(`${CUSTOMER_KEYS_RELATIONS_TABLE}.customer_key_id = ${CUSTOMER_KEYS_TABLE}.id`)
-                            .whereRaw(`${CUSTOMER_KEYS_RELATIONS_TABLE}.entity_type = ?`, ['environment'])
-                            .whereRaw(`${CUSTOMER_KEYS_RELATIONS_TABLE}.entity_id = ?`, [envId]);
-                    })
+                    .modify(this.scopedToTarget(innerTrx, target))
                     .update({ display_name: displayName, updated_at: innerTrx.fn.now() as unknown as Date });
                 if (updated === 0) {
                     throw new NangoError('no_such_api_secret', { id: keyId });
@@ -291,19 +299,13 @@ class CustomerKeyService {
         }
     }
 
-    public async updateApiKeyScopes(trx: Knex, keyId: number, scopes: string[], envId: number): Promise<Result<void>> {
+    public async updateApiKeyScopes(trx: Knex, keyId: number, scopes: string[], target: KeyTarget): Promise<Result<void>> {
         try {
             const updated = await trx<DBCustomerKey>(CUSTOMER_KEYS_TABLE)
                 .where(`${CUSTOMER_KEYS_TABLE}.id`, keyId)
                 .where(`${CUSTOMER_KEYS_TABLE}.key_type`, 'api')
                 .whereNull(`${CUSTOMER_KEYS_TABLE}.deleted_at`)
-                .whereExists(function () {
-                    void this.select(trx.raw('1'))
-                        .from(CUSTOMER_KEYS_RELATIONS_TABLE)
-                        .whereRaw(`${CUSTOMER_KEYS_RELATIONS_TABLE}.customer_key_id = ${CUSTOMER_KEYS_TABLE}.id`)
-                        .whereRaw(`${CUSTOMER_KEYS_RELATIONS_TABLE}.entity_type = ?`, ['environment'])
-                        .whereRaw(`${CUSTOMER_KEYS_RELATIONS_TABLE}.entity_id = ?`, [envId]);
-                })
+                .modify(this.scopedToTarget(trx, target))
                 .update({ scopes, updated_at: trx.fn.now() as unknown as Date });
             if (updated === 0) {
                 return Err(new NangoError('no_such_api_secret', { id: keyId }));
@@ -314,19 +316,13 @@ class CustomerKeyService {
         }
     }
 
-    public async deleteCustomerKey(trx: Knex, keyId: number, envId: number): Promise<Result<void>> {
+    public async deleteApiKey(trx: Knex, keyId: number, target: KeyTarget): Promise<Result<void>> {
         try {
             const updated = await trx<DBCustomerKey>(CUSTOMER_KEYS_TABLE)
                 .where(`${CUSTOMER_KEYS_TABLE}.id`, keyId)
                 .where(`${CUSTOMER_KEYS_TABLE}.key_type`, 'api')
                 .whereNull(`${CUSTOMER_KEYS_TABLE}.deleted_at`)
-                .whereExists(function () {
-                    void this.select(trx.raw('1'))
-                        .from(CUSTOMER_KEYS_RELATIONS_TABLE)
-                        .whereRaw(`${CUSTOMER_KEYS_RELATIONS_TABLE}.customer_key_id = ${CUSTOMER_KEYS_TABLE}.id`)
-                        .whereRaw(`${CUSTOMER_KEYS_RELATIONS_TABLE}.entity_type = ?`, ['environment'])
-                        .whereRaw(`${CUSTOMER_KEYS_RELATIONS_TABLE}.entity_id = ?`, [envId]);
-                })
+                .modify(this.scopedToTarget(trx, target))
                 .update({
                     deleted_at: trx.fn.now() as unknown as Date
                 });

--- a/packages/shared/lib/services/environment.service.ts
+++ b/packages/shared/lib/services/environment.service.ts
@@ -142,8 +142,10 @@ class EnvironmentService {
 
             const apiKey = await customerKeyService.createApiKey(innerTrx, {
                 accountId: accountId,
-                environmentId: env.id,
-                displayName: 'Default - Full access'
+                target: { type: 'environment', environmentId: env.id },
+                displayName: 'Default - Full access',
+                scopes: ['environment:*'],
+                withSandboxSigningSecret: true
             });
             if (apiKey.isErr()) {
                 throw apiKey.error;
@@ -166,7 +168,7 @@ class EnvironmentService {
         return environment;
     }
 
-    async createDefaultEnvironments(trx: Knex, { accountId: accountId }: { accountId: number }): Promise<void> {
+    async createDefaultEnvironments(trx: Knex, { accountId }: { accountId: number }): Promise<void> {
         for (const environment of defaultEnvironments) {
             const newEnv = await this.createEnvironment(trx, { accountId, name: environment });
             if (newEnv) {

--- a/packages/shared/lib/utils/encryption.manager.integration.test.ts
+++ b/packages/shared/lib/utils/encryption.manager.integration.test.ts
@@ -3,6 +3,7 @@ import { beforeAll, describe, expect, it } from 'vitest';
 import db, { multipleMigrations } from '@nangohq/database';
 
 import { seedAccountEnvAndUser } from '../seeders/index.js';
+import customerKeyService from '../services/customerKey.service.js';
 import environmentService from '../services/environment.service.js';
 import { decryptSandboxSigningSecret } from '../services/sandbox-api-key.js';
 import secretService from '../services/secret.service.js';
@@ -114,6 +115,29 @@ describe('encryption', () => {
             const decryptedSigningSecret = decryptSandboxSigningSecret(rawKey!);
             expect(decryptedSigningSecret).toBeTruthy();
             expect(rawKey!.sandbox_signing_secret).not.toEqual(decryptedSigningSecret);
+        });
+
+        // The re-encryption loop selects customer_keys unfiltered, so it must cover account-plane keys
+        // too — they are in the same table but carry no sandbox signing secret.
+        it('should encrypt account API keys and leave their sandbox columns null', async () => {
+            db.knex.client.config.searchPath = 'nango_encrypt_account_keys';
+            db.schema = () => 'nango_encrypt_account_keys';
+
+            await multipleMigrations();
+
+            // @ts-expect-error Modify the key on the fly
+            encryptionManager.key = testEncryptionKey;
+
+            const { accountApiKey } = await seedAccountEnvAndUser();
+            const rawKey = await db.knex<DBCustomerKey>('customer_keys').where({ id: accountApiKey.id }).first();
+            expect(rawKey).toBeDefined();
+            expect(rawKey!.secret).not.toEqual(accountApiKey.secret);
+            expect(rawKey!.iv).toBeTruthy();
+            expect(rawKey!.tag).toBeTruthy();
+            expect(rawKey!.sandbox_signing_secret).toBeNull();
+
+            const decrypted = (await customerKeyService.getApiKeys(db.knex, { type: 'account', accountId: accountApiKey.account_id })).unwrap();
+            expect(decrypted.find((k) => k.id === accountApiKey.id)?.secret).toEqual(accountApiKey.secret);
         });
     });
 });

--- a/packages/types/lib/api-keys/scopes.ts
+++ b/packages/types/lib/api-keys/scopes.ts
@@ -1,4 +1,7 @@
-export const API_KEY_SCOPES = [
+// Scopes are split by plane. The prefix is the plane tag, and `hasScope`'s prefix matching keeps the
+// two families isolated: `environment:*` never matches `account:...` and vice versa. Keep them apart
+// so an environment key can never be granted an account capability.
+export const ENVIRONMENT_API_KEY_SCOPES = [
     'environment:*',
     // Integrations
     'environment:integrations:list',
@@ -54,6 +57,14 @@ export const API_KEY_SCOPES = [
     'environment:mcp'
 ] as const;
 
-export type ApiKeyScope = (typeof API_KEY_SCOPES)[number];
+export type EnvironmentApiKeyScope = (typeof ENVIRONMENT_API_KEY_SCOPES)[number];
 
-export const ALL_SCOPES: string[] = [...API_KEY_SCOPES];
+export const ACCOUNT_API_KEY_SCOPES = [
+    'account:*',
+    // Team
+    'account:team:read'
+] as const;
+
+export type AccountApiKeyScope = (typeof ACCOUNT_API_KEY_SCOPES)[number];
+
+export type ApiKeyScope = EnvironmentApiKeyScope | AccountApiKeyScope;

--- a/packages/types/lib/environment/api/index.ts
+++ b/packages/types/lib/environment/api/index.ts
@@ -1,4 +1,4 @@
-import type { ApiKeyScope } from '../../api-keys/scopes.js';
+import type { EnvironmentApiKeyScope } from '../../api-keys/scopes.js';
 import type { ApiEndpoint, ApiError, ApiTimestamps } from '../../api.js';
 import type { AuditPolicy } from '../../audit-trail/event.js';
 import type { ApiPlan } from '../../plans/http.api.js';
@@ -92,7 +92,7 @@ export type ListApiKeys = ApiEndpoint<{
         data: {
             id: number;
             display_name: string;
-            scopes: ApiKeyScope[];
+            scopes: EnvironmentApiKeyScope[];
             secret: string;
             last_used_at: string | null;
             created_at: string;
@@ -106,13 +106,13 @@ export type CreateApiKey = ApiEndpoint<{
     Path: '/api/v1/environment/api-keys';
     Body: {
         display_name: string;
-        scopes?: ApiKeyScope[];
+        scopes?: EnvironmentApiKeyScope[];
     };
     Success: {
         data: {
             id: number;
             display_name: string;
-            scopes: ApiKeyScope[];
+            scopes: EnvironmentApiKeyScope[];
             secret: string;
             created_at: string;
         };
@@ -134,7 +134,7 @@ export type PatchApiKey = ApiEndpoint<{
     Path: '/api/v1/environment/api-keys/:keyId';
     Params: { keyId: number };
     Body: {
-        scopes?: ApiKeyScope[];
+        scopes?: EnvironmentApiKeyScope[];
         display_name?: string;
     };
     Success: { success: true };

--- a/packages/types/lib/index.ts
+++ b/packages/types/lib/index.ts
@@ -78,8 +78,7 @@ export type * from './dbConfig/db.js';
 export type * from './nangoYaml/index.js';
 
 export type * from './environment/db.js';
-export { ALL_SCOPES, API_KEY_SCOPES } from './api-keys/scopes.js';
-export type { ApiKeyScope } from './api-keys/scopes.js';
+export type { AccountApiKeyScope, ApiKeyScope, EnvironmentApiKeyScope } from './api-keys/scopes.js';
 export type * from './environment/api/index.js';
 export type * from './environment/api/webhook.js';
 export type * from './environment/api/otlp.js';

--- a/packages/utils/lib/api-key-scopes.ts
+++ b/packages/utils/lib/api-key-scopes.ts
@@ -1,6 +1,6 @@
-import type { ApiKeyScope } from '@nangohq/types';
+import type { AccountApiKeyScope, EnvironmentApiKeyScope } from '@nangohq/types';
 
-export const apiKeyScopes = [
+export const environmentApiKeyScopes = [
     'environment:*',
     // Integrations
     'environment:integrations:list',
@@ -54,9 +54,16 @@ export const apiKeyScopes = [
     'environment:variables:read',
     // MCP
     'environment:mcp'
-] as const satisfies readonly ApiKeyScope[];
+] as const satisfies readonly EnvironmentApiKeyScope[];
 
-// The `satisfies` above rejects entries that aren't valid `ApiKeyScope`s;
-// the assertion below rejects any `ApiKeyScope` missing from this array.
-// Together they keep the two lists in sync.
-true satisfies [Exclude<ApiKeyScope, (typeof apiKeyScopes)[number]>] extends [never] ? true : never;
+export const accountApiKeyScopes = [
+    'account:*',
+    // Team
+    'account:team:read'
+] as const satisfies readonly AccountApiKeyScope[];
+
+// Each `satisfies` above rejects entries that aren't valid scopes for that plane;
+// the assertions below reject any scope missing from its array.
+// Together they keep these lists in sync with @nangohq/types.
+true satisfies [Exclude<EnvironmentApiKeyScope, (typeof environmentApiKeyScopes)[number]>] extends [never] ? true : never;
+true satisfies [Exclude<AccountApiKeyScope, (typeof accountApiKeyScopes)[number]>] extends [never] ? true : never;

--- a/packages/utils/lib/telemetry/tracer.ts
+++ b/packages/utils/lib/telemetry/tracer.ts
@@ -8,12 +8,13 @@ export function tagTraceUser({
     plan
 }: {
     account: Pick<DBTeam, 'id'>;
-    environment: Pick<DBEnvironment, 'id'>;
+    // Absent for account-plane credentials, which are not bound to any environment.
+    environment?: Pick<DBEnvironment, 'id'> | undefined;
     plan?: Pick<DBPlan, 'name'> | null;
 }) {
     tracer.setUser({
         id: String(account.id),
-        environmentId: String(environment.id),
+        ...(environment ? { environmentId: String(environment.id) } : {}),
         paying: plan?.name !== 'free' ? 'paying' : 'free',
         plan: plan?.name
     });

--- a/packages/webapp/src/pages/Environment/Settings/scope-logic.ts
+++ b/packages/webapp/src/pages/Environment/Settings/scope-logic.ts
@@ -1,9 +1,9 @@
-import type { ApiKeyScope } from '@nangohq/types';
+import type { EnvironmentApiKeyScope } from '@nangohq/types';
 
 export interface ScopeItem {
-    value: ApiKeyScope;
+    value: EnvironmentApiKeyScope;
     label: string;
-    credentials?: ApiKeyScope;
+    credentials?: EnvironmentApiKeyScope;
 }
 
 export interface ScopeGroup {


### PR DESCRIPTION
"Adds" account-level API keys. This uses the existing middlewares and scope system, but some things needed to happen:

1. The way the environment was validated on api keys was by fetching the key that had the environment relation. No relation? Key not found -> 401 (this was previously unreachable, works when a key is 1:1 with an env). But now that we are adding API keys that don't relate to an environment, when the environment relation is not found we assume it's an account-level key, and the `res.locals.environment` is kept undefined. 
2. The scopes are split by plane: `AccountApiKeyScope` and `EnvironmentApiKeyScope`
3. The `CustomerKeyService` can now create keys for both targets.
4. Mixed-plane scopes are prevented at the endpoint level.
5. We don't define a relation in `customer_keys_relations` for account-level api keys because `customer_keys` already carry an `account_id`. Having both adds the chance for drift and complicates this v0 step.

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/NangoHQ/nango/pull/6989?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

